### PR TITLE
docs: document the default sandbox in install prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,25 @@ and capture.
 - **Rust**, via [rustup](https://rustup.rs). glass pins a nightly toolchain in
   `rust-toolchain.toml` (needed for the portable-SIMD hot paths); rustup installs it
   automatically on the first build, so there's no toolchain to choose.
-- **One OS dependency**, for the backend you'll run:
+- **A display dependency**, for the backend you'll run:
   - **Linux / X11 (default):** the headless X server — `sudo apt-get install -y xvfb`
     (Debian/Ubuntu; Fedora `xorg-x11-server-Xvfb`, Arch `xorg-server-xvfb`). glass spawns
     its own private display, so this binary is the only thing to install.
   - **Linux / Wayland:** a discoverable `sway ≥ 1.12` plus [Mesa](https://www.mesa3d.org/) software GL — see
     [Running on Wayland](#running-on-wayland-sway).
   - **Windows:** nothing extra; glass uses built-in Windows APIs.
+- **A containment runtime** — launched apps are **sandboxed by default**, and the `default`
+  level is *fail-closed*: with no sandbox available, `glass_start` errors rather than running
+  the app unconfined. So either install the runtime, or set `GLASS_SANDBOX=off` on the server
+  to launch apps unconfined:
+  - **Linux:** [bubblewrap](https://github.com/containers/bubblewrap) — `sudo apt-get install -y bubblewrap`
+    (Fedora/Arch: `bubblewrap`) — **and** unprivileged user namespaces enabled. Ubuntu 23.10+
+    restricts them via AppArmor; allow with
+    `sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0` (persist via `/etc/sysctl.d/`).
+  - **Windows:** [Sandboxie Classic](https://sandboxie-plus.com/downloads), installed with its service running.
+
+  See [Containment / sandboxing](#containment--sandboxing) for the levels; `glass-mcp doctor`
+  checks availability and prints the exact remedy for your system.
 
 ### Build from source
 

--- a/packaging/README-gnu.md
+++ b/packaging/README-gnu.md
@@ -27,10 +27,10 @@ is not yet built.) See the project README for the full picture:
   If that prints **2.38 or lower**, this prebuilt binary won't run (you'll get a
   `version 'GLIBC_2.39' not found` error) — use the static build instead.
 
-## 2. Install the prerequisite
+## 2. Install the prerequisites
 
-The default (X11) backend spawns its **own private, headless display** — the only
-thing to install is the headless X server:
+The default (X11) backend spawns its **own private, headless display** — install the
+headless X server:
 
 ```bash
 sudo apt-get update && sudo apt-get install -y xvfb
@@ -38,6 +38,19 @@ sudo apt-get update && sudo apt-get install -y xvfb
 
 (Equivalents: Fedora `sudo dnf install xorg-x11-server-Xvfb`; Arch
 `sudo pacman -S xorg-server-xvfb`.)
+
+glass also **sandboxes every launched app by default** (via bubblewrap), and that
+default is *fail-closed*: with no sandbox available it errors rather than running the
+app unconfined. So also install bubblewrap, or set `GLASS_SANDBOX=off` to run apps
+unconfined:
+
+```bash
+sudo apt-get install -y bubblewrap        # Fedora/Arch: bubblewrap
+```
+
+It also needs unprivileged user namespaces enabled; Ubuntu 23.10+ restricts them via
+AppArmor — allow with `sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0`.
+`glass-mcp doctor` checks this and prints the exact remedy.
 
 ## 3. Install the binary
 

--- a/packaging/README-musl.md
+++ b/packaging/README-musl.md
@@ -12,7 +12,7 @@ for the full picture: <https://github.com/fixed-width/glass>.
 
 ---
 
-## 1. Install the one prerequisite
+## 1. Install the prerequisites
 
 The default (X11) backend spawns its **own private, headless display** — you don't
 run or configure anything, but the headless X server itself must be installed:
@@ -23,6 +23,19 @@ sudo apt-get update && sudo apt-get install -y xvfb
 
 (Equivalents: Fedora `sudo dnf install xorg-x11-server-Xvfb`; Arch
 `sudo pacman -S xorg-server-xvfb`.)
+
+glass also **sandboxes every launched app by default** (via bubblewrap), and that
+default is *fail-closed*: with no sandbox available it errors rather than running the
+app unconfined. So also install bubblewrap, or set `GLASS_SANDBOX=off` to run apps
+unconfined:
+
+```bash
+sudo apt-get install -y bubblewrap        # Fedora/Arch: bubblewrap
+```
+
+It also needs unprivileged user namespaces enabled; Ubuntu 23.10+ restricts them via
+AppArmor — allow with `sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0`.
+`glass-mcp doctor` checks this and prints the exact remedy.
 
 That's the entire dependency list.
 

--- a/packaging/README-windows.md
+++ b/packaging/README-windows.md
@@ -20,6 +20,11 @@ This is the **Windows x86-64** build. See the project README for the full pictur
   the accessibility tree).
 - glass drives apps on the **interactive desktop**, so run it in a normal logged-in
   session (not a non-interactive service / Session 0).
+- **Containment:** glass **sandboxes every launched app by default**, and that default
+  is *fail-closed* — with no in-OS provider available, `glass_start` errors rather than
+  running the app unconfined. Install [Sandboxie Classic](https://sandboxie-plus.com/downloads)
+  (with its service running) for containment, or set `GLASS_SANDBOX=off` to launch apps
+  unconfined. `glass-mcp doctor`'s `sandbox` section reports this posture.
 
 ## 2. Install the binary
 


### PR DESCRIPTION
Launched apps are **sandboxed by default** (`SandboxLevel::Default`, fail-closed), but the install prerequisites listed only the display dependency (Xvfb/sway) and said Windows needs "nothing extra" — so a fresh user installs glass, runs it, and hits a `SandboxUnavailable` error with no forewarning.

Adds a **containment runtime** prerequisite to the main README and the three packaging READMEs:

- **Linux:** bubblewrap + unprivileged user namespaces enabled, including the Ubuntu 23.10+ AppArmor `sysctl` remedy (matches the `doctor` / `SandboxUnavailable` remedy strings).
- **Windows:** Sandboxie Classic with its service running.
- **Opt-out** is the `GLASS_SANDBOX=off` env var — there is no `--sandbox` CLI flag, and the per-call `sandbox:"off"` *tool argument* is the agent's, not install-facing.

Each points to the Containment section and `glass-mcp doctor` for the exact per-system remedy. **Docs only; no code change.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)