### PR TITLE
feat(windows): private clipboard for sandboxed apps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,27 @@ jobs:
       - run: cargo clippy --workspace --all-targets --locked -- -D warnings
       - run: cargo test --workspace --locked
 
+  miri:
+    name: Miri (UB check · pure crates)
+    runs-on: ubuntu-latest
+    # Miri interprets the MIR to catch undefined behaviour in the byte-level / unsafe-adjacent
+    # logic we own. Scoped to the crates whose tests are Miri-clean: glass-clip-hook (the private-
+    # clipboard wire protocol + store) and glass-windows (pure pixel/dpi/jobpids byte parsing).
+    # Miri cannot execute FFI / foreign functions, so the Win32 named-pipe server and the injected
+    # user32 detours (cfg(windows)) are out of Miri's reach — those are covered on-box + by review.
+    # The `miri` component is added here (not pinned in rust-toolchain.toml) so a future nightly
+    # bump that lacks it fails only this job, not every job's `rustup show`.
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install pinned toolchain
+        run: rustup show
+      - name: Add miri component
+        run: rustup component add miri
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: .
+      - run: cargo miri test -p glass-clip-hook -p glass-windows --locked
+
   x11:
     name: X11 integration (Xvfb)
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -88,7 +88,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -150,7 +150,7 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -208,7 +208,7 @@ dependencies = [
  "rustix",
  "signal-hook-registry",
  "slab",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -348,6 +348,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -726,7 +732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -898,6 +904,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "gethostname"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,6 +967,14 @@ version = "0.0.0"
 dependencies = [
  "glass-core",
  "uiautomation",
+]
+
+[[package]]
+name = "glass-clip-hook"
+version = "0.0.0"
+dependencies = [
+ "retour",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -1041,6 +1065,7 @@ name = "glass-windows"
 version = "0.0.0"
 dependencies = [
  "glass-a11y-windows",
+ "glass-clip-hook",
  "glass-core",
  "image",
  "windows 0.58.0",
@@ -1417,6 +1442,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libudis86-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139bbf9ddb1bfc90c1ac64dd2923d9c957cd433cee7315c018125d72ab08a6b0"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,6 +1477,15 @@ name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "matchit"
@@ -1497,7 +1541,17 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mmap-fixed-fixed"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0681853891801e4763dc252e843672faf32bcfee27a0aa3b19733902af450acc"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1655,7 +1709,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -1673,7 +1727,7 @@ dependencies = [
  "hermit-abi",
  "pin-project-lite",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1832,7 +1886,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1885,6 +1939,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "region"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "mach2",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1916,6 +1982,22 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "retour"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9af44d40e2400b44d491bfaf8eae111b09f23ac4de6e92728e79d93e699c527"
+dependencies = [
+ "cfg-if",
+ "generic-array",
+ "libc",
+ "libudis86-sys",
+ "mmap-fixed-fixed",
+ "once_cell",
+ "region",
+ "slice-pool2",
 ]
 
 [[package]]
@@ -1969,11 +2051,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2152,6 +2234,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slice-pool2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3d689654af89bdfeba29a914ab6ac0236d382eb3b764f7454dde052f2821f8"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2163,7 +2251,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cursor-icon",
  "libc",
  "log",
@@ -2189,7 +2277,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2270,7 +2358,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2348,7 +2436,7 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "tracing",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2438,7 +2526,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -2501,6 +2589,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "uds_windows"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2508,7 +2602,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2581,6 +2675,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -2721,7 +2821,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2746,7 +2846,7 @@ version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "rustix",
  "wayland-backend",
  "wayland-scanner",
@@ -2758,7 +2858,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cursor-icon",
  "wayland-backend",
 ]
@@ -2780,7 +2880,7 @@ version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -2792,7 +2892,7 @@ version = "20250721.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -2805,7 +2905,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -2818,7 +2918,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -2877,7 +2977,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3146,6 +3246,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -3308,7 +3417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -3425,7 +3534,7 @@ dependencies = [
  "tracing",
  "uds_windows",
  "uuid",
- "windows-sys",
+ "windows-sys 0.61.2",
  "winnow",
  "zbus_macros",
  "zbus_names",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/glass-core", "crates/glass-x11", "crates/glass-testapp", "crates/glass-mcp", "crates/glass-wayland", "crates/glass-a11y-linux", "crates/glass-windows", "crates/glass-a11y-windows", "crates/glass-sandbox-linux"]
+members = ["crates/glass-core", "crates/glass-x11", "crates/glass-testapp", "crates/glass-mcp", "crates/glass-wayland", "crates/glass-a11y-linux", "crates/glass-windows", "crates/glass-a11y-windows", "crates/glass-sandbox-linux", "crates/glass-clip-hook"]
 
 [workspace.package]
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -67,13 +67,15 @@ tree — for apps with no accessible UI (bare canvas / game UIs), so the agent f
 | | X11 | Wayland | Windows | macOS |
 |---|:--:|:--:|:--:|:--:|
 | Display isolation (app off your desktop) | ✓ private Xvfb | ✓ headless sway | – interactive desktop¹ | 🚧 |
-| Clipboard isolation | ✓ | ✓ | – shared OS clipboard | 🚧 |
+| Clipboard isolation | ✓ | ✓ | ✓ private (contained)³ | 🚧 |
 | Headless (no host desktop needed) | ✓ | ✓ | – needs a session² | 🚧 |
 
 ¹ A Windows VirtualDisplay / headless provider is a planned follow-on; stronger isolation today is
 the VM tier (the Windows Sandbox `.wsb` template under `packaging/windows-sandbox/`, or a managed
 VM running `glass-mcp serve --http`). ² Windows needs an interactive, logged-in session to render
-and capture.
+and capture. ³ When contained (`sandbox=default`/`strict`), the boxed app gets a private clipboard
+isolated from yours — an injected hook backs its clipboard with glass's own store; `sandbox=off`
+uses the real OS clipboard. Text only in v1 (classic apps; x64).
 
 **Transport:** MCP over **stdio** (default, all platforms) or **network HTTP** (`glass-mcp serve
 --http`, all platforms) — the network transport is behind the default-on `network` cargo feature
@@ -239,9 +241,11 @@ A few capabilities worth knowing:
   that part.
 - **Clipboard get/set.** `glass_clipboard_get` reads the clipboard as text
   (`""` when empty); `glass_clipboard_set` writes text so the app can paste it.
-  Both are isolated to the app's display on the private Xvfb/sway backends —
-  they never touch your real clipboard unless you set `GLASS_DISPLAY=:0` or use
-  the Windows backend. `glass_clipboard_get` is also the cheap text-extraction
+  Both are isolated to the app's display on the private Xvfb/sway backends, and
+  on Windows a sandboxed app gets a **private clipboard** too (an injected hook
+  backs the boxed app's clipboard with glass's own store) — so they never touch
+  your real clipboard unless you set `GLASS_DISPLAY=:0` or run the Windows
+  backend with `sandbox=off`. `glass_clipboard_get` is also the cheap text-extraction
   path: issue `ctrl+a` then `ctrl+c` via `glass_do`, then read here — faster and
   token-free compared to OCR for any app with selectable text.
 - **Real window managers.** On X11, window discovery uses `_NET_WM_PID`, a

--- a/crates/glass-clip-hook/Cargo.toml
+++ b/crates/glass-clip-hook/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "glass-clip-hook"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+# cdylib = the injected DLL (glass_clip_hook.dll); rlib = the pure proto/store
+# modules reused by glass-windows (host side).
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+# pure modules (proto/store) need nothing beyond std.
+
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.58", features = [
+  "Win32_Foundation",
+  "Win32_System_DataExchange", "Win32_System_Memory", "Win32_System_Ole",
+  "Win32_System_LibraryLoader",
+  "Win32_Storage_FileSystem", "Win32_System_Pipes",
+] }
+# Inline detours. License verified permissive in this task's Step 6 (MIT/BSD); IAT fallback documented.
+retour = "0.3"

--- a/crates/glass-clip-hook/Cargo.toml
+++ b/crates/glass-clip-hook/Cargo.toml
@@ -19,7 +19,11 @@ windows = { version = "0.58", features = [
   "Win32_Foundation",
   "Win32_System_DataExchange", "Win32_System_Memory", "Win32_System_Ole",
   "Win32_System_LibraryLoader",
-  "Win32_Storage_FileSystem", "Win32_System_Pipes",
+  # CreateFileW lives behind Win32_Security (SECURITY_ATTRIBUTES in its signature);
+  # ReadFile/WriteFile behind Win32_System_IO (OVERLAPPED) — both needed by the pipe client.
+  "Win32_Storage_FileSystem", "Win32_System_Pipes", "Win32_Security", "Win32_System_IO",
 ] }
 # Inline detours. License verified permissive in this task's Step 6 (MIT/BSD); IAT fallback documented.
-retour = "0.3"
+# `static-detour` enables the `static_detour!` macro (the type-safe detour table); it pulls in the
+# `nightly` feature — fine, the workspace is pinned to nightly (rust-toolchain.toml).
+retour = { version = "0.3", features = ["static-detour"] }

--- a/crates/glass-clip-hook/examples/clipprobe.rs
+++ b/crates/glass-clip-hook/examples/clipprobe.rs
@@ -1,0 +1,100 @@
+//! user32-only clipboard probe for on-box validation of the private-clipboard hook.
+//!
+//! `clipprobe roundtrip <text>` does a plain Win32 `SetClipboardData(CF_UNICODETEXT, <text>)`
+//! followed by `GetClipboardData(CF_UNICODETEXT)`, printing `READBACK=<value>`.
+//!
+//! Run UNBOXED it hits the real clipboard. Run inside a glass Sandboxie box (hook injected, the
+//! box also carrying `OpenClipboard=n`) the *only* way these calls can succeed is if the injected
+//! hook intercepts them and serves the private store — so a correct `READBACK` proves interception.
+//! Deliberately uses the raw user32 path (not OLE / .NET `Clipboard`), which is exactly what the
+//! v1 hook detours. Windows-only; a no-op elsewhere so the Linux dev box stays green.
+//!   cargo build -p glass-clip-hook --release --example clipprobe
+
+#[cfg(windows)]
+fn main() {
+    std::process::exit(run());
+}
+
+#[cfg(windows)]
+fn run() -> i32 {
+    use windows::Win32::Foundation::{HANDLE, HGLOBAL};
+    use windows::Win32::System::DataExchange::{
+        CloseClipboard, EmptyClipboard, GetClipboardData, OpenClipboard, SetClipboardData,
+    };
+    use windows::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
+    use windows::Win32::System::Ole::CF_UNICODETEXT;
+
+    let args: Vec<String> = std::env::args().collect();
+    if args.get(1).map(String::as_str) != Some("roundtrip") {
+        eprintln!("usage: clipprobe roundtrip <text>");
+        return 2;
+    }
+    let text = args.get(2).cloned().unwrap_or_default();
+    let cf = CF_UNICODETEXT.0 as u32;
+    let utf16: Vec<u16> = text.encode_utf16().chain(std::iter::once(0)).collect();
+    let bytes = std::mem::size_of_val(&utf16[..]);
+
+    unsafe {
+        // --- write ---
+        // SAFETY: standard user32 clipboard write of a CF_UNICODETEXT GMEM_MOVEABLE block; each
+        // call is checked and the clipboard is closed before returning. On success the system (or
+        // the hook) owns the handle, so we do not free it.
+        if OpenClipboard(None).is_err() {
+            eprintln!("FAIL: OpenClipboard(write)");
+            return 1;
+        }
+        let _ = EmptyClipboard();
+        let Ok(h) = GlobalAlloc(GMEM_MOVEABLE, bytes) else {
+            let _ = CloseClipboard();
+            eprintln!("FAIL: GlobalAlloc");
+            return 1;
+        };
+        let dst = GlobalLock(h);
+        if dst.is_null() {
+            let _ = CloseClipboard();
+            eprintln!("FAIL: GlobalLock(write)");
+            return 1;
+        }
+        std::ptr::copy_nonoverlapping(utf16.as_ptr() as *const u8, dst as *mut u8, bytes);
+        let _ = GlobalUnlock(h);
+        if SetClipboardData(cf, HANDLE(h.0)).is_err() {
+            let _ = CloseClipboard();
+            eprintln!("FAIL: SetClipboardData");
+            return 1;
+        }
+        let _ = CloseClipboard();
+
+        // --- read back ---
+        // SAFETY: standard user32 clipboard read; the returned handle is owned by the clipboard
+        // (we must not free it); we lock/copy/unlock and close.
+        if OpenClipboard(None).is_err() {
+            eprintln!("FAIL: OpenClipboard(read)");
+            return 1;
+        }
+        let read = match GetClipboardData(cf) {
+            Ok(hr) if !hr.is_invalid() => {
+                let g = HGLOBAL(hr.0);
+                let p = GlobalLock(g) as *const u16;
+                if p.is_null() {
+                    String::new()
+                } else {
+                    let mut len = 0usize;
+                    while *p.add(len) != 0 {
+                        len += 1;
+                    }
+                    let s = String::from_utf16_lossy(std::slice::from_raw_parts(p, len));
+                    let _ = GlobalUnlock(g);
+                    s
+                }
+            }
+            _ => String::new(),
+        };
+        let _ = CloseClipboard();
+
+        println!("READBACK={read}");
+    }
+    0
+}
+
+#[cfg(not(windows))]
+fn main() {}

--- a/crates/glass-clip-hook/src/hook.rs
+++ b/crates/glass-clip-hook/src/hook.rs
@@ -19,6 +19,7 @@ use windows::Win32::Storage::FileSystem::{
     CreateFileW, ReadFile, WriteFile, FILE_FLAGS_AND_ATTRIBUTES, FILE_SHARE_NONE, OPEN_EXISTING,
 };
 use windows::Win32::System::LibraryLoader::{GetModuleHandleW, GetProcAddress};
+use windows::Win32::System::Pipes::WaitNamedPipeW;
 use windows::Win32::System::Memory::{
     GlobalAlloc, GlobalLock, GlobalSize, GlobalUnlock, GMEM_MOVEABLE,
 };
@@ -79,23 +80,43 @@ fn rpc(req: Request) -> Option<Response> {
     resp
 }
 
-/// `CreateFileW` the named pipe for read+write. Returns `None` if it cannot be opened.
+/// `CreateFileW` the named pipe for read+write, retrying briefly. Returns `None` if it cannot be
+/// opened within the retry budget.
+///
+/// The host runs a single-instance accept loop: after it serves one connection there is a short gap
+/// before it re-creates the next pipe instance. A `Set` immediately followed by a `Get` (as a
+/// clipboard write→read does) races into that gap, so a single `CreateFile` would intermittently
+/// fail. We use the standard named-pipe client pattern: on failure, `WaitNamedPipe` for an instance
+/// (and back off briefly if the pipe is momentarily absent), then retry — bounded so a genuinely
+/// down server still fails soft rather than hanging.
 fn open_pipe(path: &str) -> Option<HANDLE> {
     let wide: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
-    // SAFETY: `wide` is a NUL-terminated UTF-16 buffer that outlives the call; all other args are
-    // plain values. CreateFileW returns a Result (Err on INVALID_HANDLE_VALUE), which we map to None.
-    unsafe {
-        CreateFileW(
-            PCWSTR::from_raw(wide.as_ptr()),
-            GENERIC_READ.0 | GENERIC_WRITE.0,
-            FILE_SHARE_NONE,
-            None,
-            OPEN_EXISTING,
-            FILE_FLAGS_AND_ATTRIBUTES(0),
-            HANDLE::default(),
-        )
-        .ok()
+    for _ in 0..40 {
+        // SAFETY: `wide` is a NUL-terminated UTF-16 buffer that outlives the call; all other args
+        // are plain values. CreateFileW returns Err on INVALID_HANDLE_VALUE, which we map to None.
+        let opened = unsafe {
+            CreateFileW(
+                PCWSTR::from_raw(wide.as_ptr()),
+                GENERIC_READ.0 | GENERIC_WRITE.0,
+                FILE_SHARE_NONE,
+                None,
+                OPEN_EXISTING,
+                FILE_FLAGS_AND_ATTRIBUTES(0),
+                HANDLE::default(),
+            )
+        };
+        if let Ok(h) = opened {
+            return Some(h);
+        }
+        // Instance busy → WaitNamedPipe blocks until one frees (up to 100ms). Instance momentarily
+        // absent → it returns Err fast, so back off ~10ms to avoid a tight spin, then retry.
+        // SAFETY: `wide` outlives the call; WaitNamedPipeW is a simple blocking wait by name.
+        let waited = unsafe { WaitNamedPipeW(PCWSTR::from_raw(wide.as_ptr()), 100) }.as_bool();
+        if !waited {
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
     }
+    None
 }
 
 /// Write the whole buffer, looping over partial writes. `Some(())` on success.

--- a/crates/glass-clip-hook/src/hook.rs
+++ b/crates/glass-clip-hook/src/hook.rs
@@ -1,0 +1,2 @@
+//! Injected hook DLL entry point — detours user32 clipboard APIs and proxies them to the
+//! host store over the named pipe set in `GLASS_CLIP_PIPE`. Implemented in Task 10.

--- a/crates/glass-clip-hook/src/hook.rs
+++ b/crates/glass-clip-hook/src/hook.rs
@@ -202,19 +202,15 @@ pub(crate) fn store_seq() -> u32 {
 /// Reads up to the first NUL (or the whole block if unterminated). `None` if lock fails / empty.
 pub(crate) fn read_utf16_from_hglobal(h: HGLOBAL) -> Option<String> {
     // SAFETY: `h` is the handle the app passed to SetClipboardData; GlobalLock pins it and returns
-    // a pointer valid until GlobalUnlock. GlobalSize gives the block's byte size so we never read
-    // out of bounds. We treat the bytes as UTF-16 code units (CF_UNICODETEXT contract).
+    // a pointer valid until GlobalUnlock. GlobalSize bounds the slice so we never read out of
+    // bounds; the NUL-terminated UTF-16 decode itself is pure + unit-tested (crate::text).
     unsafe {
         let ptr = GlobalLock(h) as *const u16;
         if ptr.is_null() {
             return None;
         }
-        let bytes = GlobalSize(h);
-        let units = bytes / 2;
-        let slice = std::slice::from_raw_parts(ptr, units);
-        // Stop at the first NUL terminator if present.
-        let end = slice.iter().position(|&c| c == 0).unwrap_or(units);
-        let text = String::from_utf16_lossy(&slice[..end]);
+        let units = GlobalSize(h) / 2;
+        let text = crate::text::utf16_nul_to_string(std::slice::from_raw_parts(ptr, units));
         let _ = GlobalUnlock(h);
         Some(text)
     }
@@ -224,19 +220,15 @@ pub(crate) fn read_utf16_from_hglobal(h: HGLOBAL) -> Option<String> {
 /// these as ANSI: each byte maps 1:1 to a `char` (Latin-1-ish), stopping at the first NUL.
 /// `None` if lock fails. Mirrors [`read_utf16_from_hglobal`].
 pub(crate) fn read_singlebyte_from_hglobal(h: HGLOBAL) -> Option<String> {
-    // SAFETY: `h` is the handle the app passed to SetClipboardData; GlobalLock pins it and returns a
-    // pointer valid until GlobalUnlock. GlobalSize bounds the read so we never go out of bounds.
+    // SAFETY: as read_utf16_from_hglobal, single-byte: GlobalLock pins `h`, GlobalSize bounds the
+    // slice; the Latin-1 NUL-terminated decode is pure + unit-tested (crate::text).
     unsafe {
         let ptr = GlobalLock(h) as *const u8;
         if ptr.is_null() {
             return None;
         }
-        let bytes = GlobalSize(h);
-        let slice = std::slice::from_raw_parts(ptr, bytes);
-        // Stop at the first NUL terminator if present.
-        let end = slice.iter().position(|&c| c == 0).unwrap_or(bytes);
-        // v1: interpret as ANSI/Latin-1 — each byte is one `char`.
-        let text: String = slice[..end].iter().map(|&b| b as char).collect();
+        let n = GlobalSize(h);
+        let text = crate::text::singlebyte_nul_to_string(std::slice::from_raw_parts(ptr, n));
         let _ = GlobalUnlock(h);
         Some(text)
     }
@@ -247,8 +239,7 @@ pub(crate) fn read_singlebyte_from_hglobal(h: HGLOBAL) -> Option<String> {
 /// the handle the caller must cache + eventually free; `None` on allocation failure.
 pub(crate) fn alloc_hglobal_for(fmt: u32, text: &str) -> Option<HGLOBAL> {
     if fmt == CF_UNICODETEXT_ID {
-        let mut units: Vec<u16> = text.encode_utf16().collect();
-        units.push(0); // NUL terminator
+        let units = crate::text::string_to_utf16_nul(text);
         let bytes = units.len() * 2;
         // SAFETY: GlobalAlloc(GMEM_MOVEABLE) returns a movable handle; GlobalLock pins it to a
         // writable pointer valid for `bytes`. We copy exactly `units.len()` u16s (== `bytes`) then
@@ -266,12 +257,8 @@ pub(crate) fn alloc_hglobal_for(fmt: u32, text: &str) -> Option<HGLOBAL> {
             Some(h)
         }
     } else {
-        // CF_TEXT / CF_OEMTEXT: down-convert to single-byte. Non-ASCII becomes '?' (lossy, v1).
-        let mut bytes: Vec<u8> = text
-            .chars()
-            .map(|c| if (c as u32) < 0x80 { c as u8 } else { b'?' })
-            .collect();
-        bytes.push(0); // NUL terminator
+        // CF_TEXT / CF_OEMTEXT: down-convert to single-byte (non-ASCII → '?', lossy v1).
+        let bytes = crate::text::string_to_singlebyte_nul(text);
         let n = bytes.len();
         // SAFETY: as above, sized to `n` bytes; we copy exactly `n` bytes then unlock.
         unsafe {

--- a/crates/glass-clip-hook/src/hook.rs
+++ b/crates/glass-clip-hook/src/hook.rs
@@ -12,7 +12,9 @@
 use std::sync::OnceLock;
 
 use windows::core::{PCSTR, PCWSTR};
-use windows::Win32::Foundation::{CloseHandle, GENERIC_READ, GENERIC_WRITE, HANDLE, HGLOBAL};
+use windows::Win32::Foundation::{
+    CloseHandle, GlobalFree, GENERIC_READ, GENERIC_WRITE, HANDLE, HGLOBAL,
+};
 use windows::Win32::Storage::FileSystem::{
     CreateFileW, ReadFile, WriteFile, FILE_FLAGS_AND_ATTRIBUTES, FILE_SHARE_NONE, OPEN_EXISTING,
 };
@@ -48,8 +50,11 @@ pub(crate) fn init() {
     if name.is_empty() {
         return;
     }
-    let _ = PIPE.set(format!(r"\\.\pipe\{name}"));
-    detour_impl::install();
+    // Only install detours when we newly set the pipe — a second `init()` (re-injection) must not
+    // re-patch already-enabled hooks.
+    if PIPE.set(format!(r"\\.\pipe\{name}")).is_ok() {
+        detour_impl::install();
+    }
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -161,6 +166,8 @@ pub(crate) fn store_empty() {
 
 pub(crate) fn store_seq() -> u32 {
     match rpc(Request::Seq) {
+        // u64→u32 truncation is fine: this feeds Win32 GetClipboardSequenceNumber (also u32) and
+        // only drives change-detection, so a wrap every 4 billion sets is harmless.
         Some(Response::Seq(n)) => n as u32,
         _ => 0,
     }
@@ -192,6 +199,28 @@ pub(crate) fn read_utf16_from_hglobal(h: HGLOBAL) -> Option<String> {
     }
 }
 
+/// Read a single-byte (`CF_TEXT`/`CF_OEMTEXT`) string out of an app-provided `HGLOBAL`. v1 treats
+/// these as ANSI: each byte maps 1:1 to a `char` (Latin-1-ish), stopping at the first NUL.
+/// `None` if lock fails. Mirrors [`read_utf16_from_hglobal`].
+pub(crate) fn read_singlebyte_from_hglobal(h: HGLOBAL) -> Option<String> {
+    // SAFETY: `h` is the handle the app passed to SetClipboardData; GlobalLock pins it and returns a
+    // pointer valid until GlobalUnlock. GlobalSize bounds the read so we never go out of bounds.
+    unsafe {
+        let ptr = GlobalLock(h) as *const u8;
+        if ptr.is_null() {
+            return None;
+        }
+        let bytes = GlobalSize(h);
+        let slice = std::slice::from_raw_parts(ptr, bytes);
+        // Stop at the first NUL terminator if present.
+        let end = slice.iter().position(|&c| c == 0).unwrap_or(bytes);
+        // v1: interpret as ANSI/Latin-1 — each byte is one `char`.
+        let text: String = slice[..end].iter().map(|&b| b as char).collect();
+        let _ = GlobalUnlock(h);
+        Some(text)
+    }
+}
+
 /// Allocate a `GMEM_MOVEABLE` `HGLOBAL` and write `text` into it in the encoding `fmt` requires:
 /// UTF-16 (+ NUL) for `CF_UNICODETEXT`, single-byte (lossy) for `CF_TEXT`/`CF_OEMTEXT`. Returns
 /// the handle the caller must cache + eventually free; `None` on allocation failure.
@@ -207,6 +236,8 @@ pub(crate) fn alloc_hglobal_for(fmt: u32, text: &str) -> Option<HGLOBAL> {
             let h = GlobalAlloc(GMEM_MOVEABLE, bytes).ok()?;
             let dst = GlobalLock(h) as *mut u16;
             if dst.is_null() {
+                // SAFETY: we own `h` (alloc succeeded, not yet handed to caller); free to avoid leak.
+                let _ = GlobalFree(h);
                 return None;
             }
             std::ptr::copy_nonoverlapping(units.as_ptr(), dst, units.len());
@@ -226,6 +257,8 @@ pub(crate) fn alloc_hglobal_for(fmt: u32, text: &str) -> Option<HGLOBAL> {
             let h = GlobalAlloc(GMEM_MOVEABLE, n).ok()?;
             let dst = GlobalLock(h) as *mut u8;
             if dst.is_null() {
+                // SAFETY: we own `h` (alloc succeeded, not yet handed to caller); free to avoid leak.
+                let _ = GlobalFree(h);
                 return None;
             }
             std::ptr::copy_nonoverlapping(bytes.as_ptr(), dst, n);

--- a/crates/glass-clip-hook/src/hook.rs
+++ b/crates/glass-clip-hook/src/hook.rs
@@ -1,2 +1,265 @@
-//! Injected hook DLL entry point — detours user32 clipboard APIs and proxies them to the
-//! host store over the named pipe set in `GLASS_CLIP_PIPE`. Implemented in Task 10.
+//! user32 clipboard detours + the pipe client (cfg windows; runtime-validated on LOTUS).
+//!
+//! Emulates a per-app clipboard backed by the host store. The detours NEVER call the real
+//! clipboard APIs (the box also has `OpenClipboard=n`), so the user's clipboard is untouched.
+//! v1: `CF_UNICODETEXT` (+ `CF_TEXT`/`CF_OEMTEXT` synthesized on read). Eager data only — delayed
+//! rendering (`SetClipboardData(_, NULL)`) and OLE are out of scope (documented limitation).
+//!
+//! Compile-time verified by cross-compiling to `x86_64-pc-windows-gnu`. Runtime interception is
+//! finalized on a real Windows box (LOTUS); the detour table is authored complete so that on-box
+//! work is debugging, not authoring.
+
+use std::sync::OnceLock;
+
+use windows::core::{PCSTR, PCWSTR};
+use windows::Win32::Foundation::{CloseHandle, GENERIC_READ, GENERIC_WRITE, HANDLE, HGLOBAL};
+use windows::Win32::Storage::FileSystem::{
+    CreateFileW, ReadFile, WriteFile, FILE_FLAGS_AND_ATTRIBUTES, FILE_SHARE_NONE, OPEN_EXISTING,
+};
+use windows::Win32::System::LibraryLoader::{GetModuleHandleW, GetProcAddress};
+use windows::Win32::System::Memory::{
+    GlobalAlloc, GlobalLock, GlobalSize, GlobalUnlock, GMEM_MOVEABLE,
+};
+
+use crate::proto::{self, Request, Response};
+
+mod detour_impl;
+
+// CF_UNICODETEXT = 13, CF_TEXT = 1, CF_OEMTEXT = 7 (stable Win32 ABI ids).
+pub(crate) const CF_UNICODETEXT_ID: u32 = 13;
+pub(crate) const CF_TEXT_ID: u32 = 1;
+pub(crate) const CF_OEMTEXT_ID: u32 = 7;
+
+/// Resolved pipe path (`\\.\pipe\<GLASS_CLIP_PIPE>`). `None` ⇒ the DLL is inert.
+static PIPE: OnceLock<String> = OnceLock::new();
+
+/// True iff a text clipboard format. The three synthesized text formats are interchangeable on
+/// read (we down/up-convert UTF-16); only `CF_UNICODETEXT` is stored.
+pub(crate) fn is_text_format(fmt: u32) -> bool {
+    fmt == CF_UNICODETEXT_ID || fmt == CF_TEXT_ID || fmt == CF_OEMTEXT_ID
+}
+
+/// Called from `InjectDllMain`. Inert if `GLASS_CLIP_PIPE` is unset (only the target app's
+/// process tree carries it; every other boxed process loads this DLL but stays dormant).
+pub(crate) fn init() {
+    let Ok(name) = std::env::var("GLASS_CLIP_PIPE") else {
+        return;
+    };
+    if name.is_empty() {
+        return;
+    }
+    let _ = PIPE.set(format!(r"\\.\pipe\{name}"));
+    detour_impl::install();
+}
+
+// ---------------------------------------------------------------------------------------------
+// Pipe client: one request → one response over a fresh connection. Clipboard ops are rare, so
+// there is no pooling. Every failure path returns `None` / does nothing (fail-soft): the detours
+// then behave as an empty clipboard rather than panicking or touching the real one.
+// ---------------------------------------------------------------------------------------------
+
+/// Open the pipe, write `frame(req.encode())`, read one framed `Response`. `None` on any failure.
+fn rpc(req: Request) -> Option<Response> {
+    let pipe = PIPE.get()?;
+    let h = open_pipe(pipe)?;
+    let resp = (|| {
+        let body = proto::frame(&req.encode());
+        write_all(h, &body)?;
+        read_response(h)
+    })();
+    // SAFETY: `h` is a valid handle returned by CreateFileW and not used after this call.
+    unsafe {
+        let _ = CloseHandle(h);
+    }
+    resp
+}
+
+/// `CreateFileW` the named pipe for read+write. Returns `None` if it cannot be opened.
+fn open_pipe(path: &str) -> Option<HANDLE> {
+    let wide: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
+    // SAFETY: `wide` is a NUL-terminated UTF-16 buffer that outlives the call; all other args are
+    // plain values. CreateFileW returns a Result (Err on INVALID_HANDLE_VALUE), which we map to None.
+    unsafe {
+        CreateFileW(
+            PCWSTR::from_raw(wide.as_ptr()),
+            GENERIC_READ.0 | GENERIC_WRITE.0,
+            FILE_SHARE_NONE,
+            None,
+            OPEN_EXISTING,
+            FILE_FLAGS_AND_ATTRIBUTES(0),
+            HANDLE::default(),
+        )
+        .ok()
+    }
+}
+
+/// Write the whole buffer, looping over partial writes. `Some(())` on success.
+fn write_all(h: HANDLE, buf: &[u8]) -> Option<()> {
+    let mut off = 0usize;
+    while off < buf.len() {
+        let mut written: u32 = 0;
+        // SAFETY: `h` is valid; the slice is in-bounds; `written` is a live out-param.
+        unsafe {
+            WriteFile(h, Some(&buf[off..]), Some(&mut written), None).ok()?;
+        }
+        if written == 0 {
+            return None; // pipe closed mid-write
+        }
+        off += written as usize;
+    }
+    Some(())
+}
+
+/// Read a 4-byte LE length prefix, then that many bytes, then `Response::decode`.
+fn read_response(h: HANDLE) -> Option<Response> {
+    let mut len_buf = [0u8; 4];
+    read_exact(h, &mut len_buf)?;
+    let len = u32::from_le_bytes(len_buf) as usize;
+    if len > proto::MAX_TEXT_BYTES + 16 {
+        return None; // refuse absurd frames (matches proto::parse_frame's cap)
+    }
+    let mut body = vec![0u8; len];
+    read_exact(h, &mut body)?;
+    Response::decode(&body).ok()
+}
+
+/// Loop `ReadFile` until `buf` is full. `None` on short read (EOF) or error.
+fn read_exact(h: HANDLE, buf: &mut [u8]) -> Option<()> {
+    let mut off = 0usize;
+    while off < buf.len() {
+        let mut read: u32 = 0;
+        // SAFETY: `h` is valid; the destination slice is in-bounds; `read` is a live out-param.
+        unsafe {
+            ReadFile(h, Some(&mut buf[off..]), Some(&mut read), None).ok()?;
+        }
+        if read == 0 {
+            return None; // EOF before the buffer was filled
+        }
+        off += read as usize;
+    }
+    Some(())
+}
+
+// ---------------------------------------------------------------------------------------------
+// Host-store view used by the detours. Each is fail-soft (None / no-op on a down pipe).
+// ---------------------------------------------------------------------------------------------
+
+pub(crate) fn store_get() -> Option<String> {
+    match rpc(Request::Get)? {
+        Response::Text(t) => t,
+        _ => None,
+    }
+}
+
+pub(crate) fn store_set(s: &str) {
+    let _ = rpc(Request::Set(s.to_string()));
+}
+
+pub(crate) fn store_empty() {
+    let _ = rpc(Request::Empty);
+}
+
+pub(crate) fn store_seq() -> u32 {
+    match rpc(Request::Seq) {
+        Some(Response::Seq(n)) => n as u32,
+        _ => 0,
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// HGLOBAL <-> text helpers used by SetClipboardData / GetClipboardData detours.
+// ---------------------------------------------------------------------------------------------
+
+/// Read a UTF-16 string out of an app-provided `HGLOBAL` (as handed to `SetClipboardData`).
+/// Reads up to the first NUL (or the whole block if unterminated). `None` if lock fails / empty.
+pub(crate) fn read_utf16_from_hglobal(h: HGLOBAL) -> Option<String> {
+    // SAFETY: `h` is the handle the app passed to SetClipboardData; GlobalLock pins it and returns
+    // a pointer valid until GlobalUnlock. GlobalSize gives the block's byte size so we never read
+    // out of bounds. We treat the bytes as UTF-16 code units (CF_UNICODETEXT contract).
+    unsafe {
+        let ptr = GlobalLock(h) as *const u16;
+        if ptr.is_null() {
+            return None;
+        }
+        let bytes = GlobalSize(h);
+        let units = bytes / 2;
+        let slice = std::slice::from_raw_parts(ptr, units);
+        // Stop at the first NUL terminator if present.
+        let end = slice.iter().position(|&c| c == 0).unwrap_or(units);
+        let text = String::from_utf16_lossy(&slice[..end]);
+        let _ = GlobalUnlock(h);
+        Some(text)
+    }
+}
+
+/// Allocate a `GMEM_MOVEABLE` `HGLOBAL` and write `text` into it in the encoding `fmt` requires:
+/// UTF-16 (+ NUL) for `CF_UNICODETEXT`, single-byte (lossy) for `CF_TEXT`/`CF_OEMTEXT`. Returns
+/// the handle the caller must cache + eventually free; `None` on allocation failure.
+pub(crate) fn alloc_hglobal_for(fmt: u32, text: &str) -> Option<HGLOBAL> {
+    if fmt == CF_UNICODETEXT_ID {
+        let mut units: Vec<u16> = text.encode_utf16().collect();
+        units.push(0); // NUL terminator
+        let bytes = units.len() * 2;
+        // SAFETY: GlobalAlloc(GMEM_MOVEABLE) returns a movable handle; GlobalLock pins it to a
+        // writable pointer valid for `bytes`. We copy exactly `units.len()` u16s (== `bytes`) then
+        // unlock. On any failure we return None without leaking (alloc failed ⇒ nothing to free).
+        unsafe {
+            let h = GlobalAlloc(GMEM_MOVEABLE, bytes).ok()?;
+            let dst = GlobalLock(h) as *mut u16;
+            if dst.is_null() {
+                return None;
+            }
+            std::ptr::copy_nonoverlapping(units.as_ptr(), dst, units.len());
+            let _ = GlobalUnlock(h);
+            Some(h)
+        }
+    } else {
+        // CF_TEXT / CF_OEMTEXT: down-convert to single-byte. Non-ASCII becomes '?' (lossy, v1).
+        let mut bytes: Vec<u8> = text
+            .chars()
+            .map(|c| if (c as u32) < 0x80 { c as u8 } else { b'?' })
+            .collect();
+        bytes.push(0); // NUL terminator
+        let n = bytes.len();
+        // SAFETY: as above, sized to `n` bytes; we copy exactly `n` bytes then unlock.
+        unsafe {
+            let h = GlobalAlloc(GMEM_MOVEABLE, n).ok()?;
+            let dst = GlobalLock(h) as *mut u8;
+            if dst.is_null() {
+                return None;
+            }
+            std::ptr::copy_nonoverlapping(bytes.as_ptr(), dst, n);
+            let _ = GlobalUnlock(h);
+            Some(h)
+        }
+    }
+}
+
+/// Resolve a user32 export's absolute address. Using an absolute address (rather than naming the
+/// import) detours *all* call sites in the process, not just this DLL's IAT slot.
+///
+/// # Safety
+/// Caller transmutes the returned address to the export's exact ABI signature.
+pub(crate) unsafe fn user32_proc(name: &[u8]) -> Option<*const ()> {
+    // `name` must be a NUL-terminated ASCII byte string (e.g. b"OpenClipboard\0").
+    // SAFETY: "user32.dll\0" is a valid module name literal; GetModuleHandleW returns the loaded
+    // module (user32 is always present in a GUI process). GetProcAddress returns the export or None.
+    let module = GetModuleHandleW(PCWSTR::from_raw(USER32_W.as_ptr())).ok()?;
+    let proc = GetProcAddress(module, PCSTR::from_raw(name.as_ptr()));
+    proc.map(|f| f as *const ())
+}
+
+/// `"user32.dll\0"` as UTF-16 (module name for `GetModuleHandleW`).
+static USER32_W: [u16; 11] = [
+    b'u' as u16,
+    b's' as u16,
+    b'e' as u16,
+    b'r' as u16,
+    b'3' as u16,
+    b'2' as u16,
+    b'.' as u16,
+    b'd' as u16,
+    b'l' as u16,
+    b'l' as u16,
+    0,
+];

--- a/crates/glass-clip-hook/src/hook/detour_impl.rs
+++ b/crates/glass-clip-hook/src/hook/detour_impl.rs
@@ -1,0 +1,255 @@
+//! The `retour` static-detour table for the user32 clipboard APIs.
+//!
+//! Each detour mirrors the exact Win32 ABI of its export (raw newtypes, `extern "system"`), is
+//! resolved to an absolute address via `GetProcAddress` (so *every* call site in the process is
+//! intercepted, not just this DLL's IAT slot), and emulates the operation against the host store.
+//! The detours NEVER call the real clipboard APIs — there is deliberately no `.call(...)` to the
+//! trampoline. That is the whole point: the box also runs `OpenClipboard=n`, so the real APIs are
+//! denied; we fully substitute them.
+//!
+//! Compile-time verified by cross-compiling to `x86_64-pc-windows-gnu`. Whether the detours
+//! actually intercept at runtime is finalized on a real Windows box (LOTUS).
+
+use std::cell::Cell;
+
+use retour::static_detour;
+use windows::Win32::Foundation::{GlobalFree, BOOL, HANDLE, HGLOBAL, HWND};
+
+use super::{
+    alloc_hglobal_for, is_text_format, read_utf16_from_hglobal, store_empty, store_get, store_seq,
+    store_set, user32_proc, CF_TEXT_ID, CF_UNICODETEXT_ID,
+};
+
+// Exact raw ABI signatures of the user32 exports (from windows-rs `link!` declarations).
+// `HANDLE` stands in for the clipboard `HGLOBAL`/`HANDLE` the ABI actually uses (same layout).
+type FnOpenClipboard = unsafe extern "system" fn(HWND) -> BOOL;
+type FnCloseClipboard = unsafe extern "system" fn() -> BOOL;
+type FnEmptyClipboard = unsafe extern "system" fn() -> BOOL;
+type FnSetClipboardData = unsafe extern "system" fn(u32, HANDLE) -> HANDLE;
+type FnGetClipboardData = unsafe extern "system" fn(u32) -> HANDLE;
+type FnIsClipboardFormatAvailable = unsafe extern "system" fn(u32) -> BOOL;
+type FnCountClipboardFormats = unsafe extern "system" fn() -> i32;
+type FnEnumClipboardFormats = unsafe extern "system" fn(u32) -> u32;
+type FnGetClipboardSequenceNumber = unsafe extern "system" fn() -> u32;
+
+static_detour! {
+    static OpenClipboardHook: unsafe extern "system" fn(HWND) -> BOOL;
+    static CloseClipboardHook: unsafe extern "system" fn() -> BOOL;
+    static EmptyClipboardHook: unsafe extern "system" fn() -> BOOL;
+    static SetClipboardDataHook: unsafe extern "system" fn(u32, HANDLE) -> HANDLE;
+    static GetClipboardDataHook: unsafe extern "system" fn(u32) -> HANDLE;
+    static IsClipboardFormatAvailableHook: unsafe extern "system" fn(u32) -> BOOL;
+    static CountClipboardFormatsHook: unsafe extern "system" fn() -> i32;
+    static EnumClipboardFormatsHook: unsafe extern "system" fn(u32) -> u32;
+    static GetClipboardSequenceNumberHook: unsafe extern "system" fn() -> u32;
+}
+
+thread_local! {
+    /// Whether *this thread* currently holds the (emulated) clipboard open. Win32 clipboard
+    /// ownership is thread-affine, so per-thread state matches the real semantics and avoids any
+    /// cross-thread locking. Purely advisory here — we never gate store access on it (the real
+    /// APIs would, but we stay permissive/fail-soft).
+    static CLIP_OPEN: Cell<bool> = const { Cell::new(false) };
+
+    /// The last `HGLOBAL` returned from `GetClipboardData`. The Win32 contract says the *clipboard*
+    /// owns that memory and the app must not free it; we own it instead and free it on the next
+    /// open/empty/close (whichever comes first). Stored as `isize` (the pointer bits) so the
+    /// `thread_local!` needs no `unsafe`-Sync dance. A thread-local (not a global Mutex) because
+    /// the handle is only ever produced + consumed on the clipboard-owning thread.
+    static LAST_HANDLE: Cell<isize> = const { Cell::new(0) };
+}
+
+/// Free + forget the cached `GetClipboardData` handle, if any. Called on open/empty/close.
+fn free_cached_handle() {
+    LAST_HANDLE.with(|c| {
+        let raw = c.replace(0);
+        if raw != 0 {
+            // SAFETY: `raw` is an HGLOBAL we allocated in `alloc_hglobal_for` (GMEM_MOVEABLE) and
+            // handed out exactly once; freeing it here is the agreed ownership transfer. We zero
+            // the cell first so a re-entrant call cannot double-free.
+            unsafe {
+                let _ = GlobalFree(HGLOBAL(raw as *mut _));
+            }
+        }
+    });
+}
+
+/// Cache a freshly-allocated handle to be freed on the next open/empty/close.
+fn cache_handle(h: HGLOBAL) {
+    free_cached_handle(); // never leak a prior one
+    LAST_HANDLE.with(|c| c.set(h.0 as isize));
+}
+
+// ---- detour bodies ---------------------------------------------------------------------------
+
+/// `OpenClipboard(hwnd)` → mark open; always succeed. Never touches the real clipboard.
+fn open_clipboard(_hwnd: HWND) -> BOOL {
+    free_cached_handle();
+    CLIP_OPEN.with(|c| c.set(true));
+    BOOL(1)
+}
+
+/// `CloseClipboard()` → mark closed; free the cached handle. Always succeed.
+fn close_clipboard() -> BOOL {
+    CLIP_OPEN.with(|c| c.set(false));
+    free_cached_handle();
+    BOOL(1)
+}
+
+/// `EmptyClipboard()` → clear the host store; free the cached handle. Always succeed.
+fn empty_clipboard() -> BOOL {
+    store_empty();
+    free_cached_handle();
+    BOOL(1)
+}
+
+/// `SetClipboardData(fmt, h)` → for text formats with a non-NULL handle, read the UTF-16 text and
+/// store it. Returns `h` (the contract: the clipboard now "owns" it; we keep the store as the
+/// source of truth). `h == NULL` is delayed rendering — out of scope in v1: return NULL, no change.
+/// Non-text formats are ignored (return the handle unchanged, no store change).
+fn set_clipboard_data(fmt: u32, h: HANDLE) -> HANDLE {
+    if h.0.is_null() {
+        return HANDLE::default(); // delayed rendering unsupported (v1)
+    }
+    if is_text_format(fmt) {
+        if let Some(text) = read_utf16_from_hglobal(HGLOBAL(h.0)) {
+            store_set(&text);
+        }
+    }
+    h
+}
+
+/// `GetClipboardData(fmt)` → for text formats, allocate a fresh `HGLOBAL` in the requested encoding
+/// from the host store, cache it (so the app needn't free it; we free on next open/empty/close),
+/// and return it. NULL if the store is empty, the format is non-text, or the pipe is down.
+fn get_clipboard_data(fmt: u32) -> HANDLE {
+    if !is_text_format(fmt) {
+        return HANDLE::default();
+    }
+    let Some(text) = store_get() else {
+        return HANDLE::default();
+    };
+    match alloc_hglobal_for(fmt, &text) {
+        Some(h) => {
+            cache_handle(h);
+            HANDLE(h.0)
+        }
+        None => HANDLE::default(),
+    }
+}
+
+/// `IsClipboardFormatAvailable(fmt)` → TRUE iff a text format and the store is non-empty.
+fn is_clipboard_format_available(fmt: u32) -> BOOL {
+    BOOL((is_text_format(fmt) && store_get().is_some()) as i32)
+}
+
+/// `CountClipboardFormats()` → 2 (CF_UNICODETEXT + CF_TEXT) when the store has text, else 0.
+fn count_clipboard_formats() -> i32 {
+    if store_get().is_some() {
+        2
+    } else {
+        0
+    }
+}
+
+/// `EnumClipboardFormats(prev)` → enumerate our synthesized text formats:
+/// 0 → CF_UNICODETEXT; CF_UNICODETEXT → CF_TEXT; anything else → 0 (end of list).
+fn enum_clipboard_formats(prev: u32) -> u32 {
+    match prev {
+        0 => CF_UNICODETEXT_ID,
+        CF_UNICODETEXT_ID => CF_TEXT_ID,
+        _ => 0,
+    }
+}
+
+/// `GetClipboardSequenceNumber()` → the host store's sequence number (bumps on every set/empty).
+fn get_clipboard_sequence_number() -> u32 {
+    store_seq()
+}
+
+// ---- installation ----------------------------------------------------------------------------
+
+/// Resolve every user32 clipboard export and enable its detour. Best-effort + fail-soft: a single
+/// unresolved/uninitialisable export is logged-by-omission and skipped, never panicking (a panic
+/// across the FFI boundary in `InjectDllMain` would take down the boxed app).
+pub(super) fn install() {
+    // SAFETY (whole block): each `user32_proc` returns the absolute address of the named export,
+    // which we transmute to that export's exact ABI signature (verified against windows-rs `link!`
+    // declarations). `retour`'s `initialize` then trampolines the target and routes calls to our
+    // hook; `enable` patches the prologue. Both are `unsafe` by contract. Every step is fallible
+    // and we `let _ =` / `if let` to stay fail-soft — we never unwrap across the FFI boundary.
+    unsafe {
+        if let Some(p) = user32_proc(b"OpenClipboard\0") {
+            let target: FnOpenClipboard = std::mem::transmute(p);
+            if OpenClipboardHook.initialize(target, open_clipboard).is_ok() {
+                let _ = OpenClipboardHook.enable();
+            }
+        }
+        if let Some(p) = user32_proc(b"CloseClipboard\0") {
+            let target: FnCloseClipboard = std::mem::transmute(p);
+            if CloseClipboardHook.initialize(target, close_clipboard).is_ok() {
+                let _ = CloseClipboardHook.enable();
+            }
+        }
+        if let Some(p) = user32_proc(b"EmptyClipboard\0") {
+            let target: FnEmptyClipboard = std::mem::transmute(p);
+            if EmptyClipboardHook.initialize(target, empty_clipboard).is_ok() {
+                let _ = EmptyClipboardHook.enable();
+            }
+        }
+        if let Some(p) = user32_proc(b"SetClipboardData\0") {
+            let target: FnSetClipboardData = std::mem::transmute(p);
+            if SetClipboardDataHook
+                .initialize(target, set_clipboard_data)
+                .is_ok()
+            {
+                let _ = SetClipboardDataHook.enable();
+            }
+        }
+        if let Some(p) = user32_proc(b"GetClipboardData\0") {
+            let target: FnGetClipboardData = std::mem::transmute(p);
+            if GetClipboardDataHook
+                .initialize(target, get_clipboard_data)
+                .is_ok()
+            {
+                let _ = GetClipboardDataHook.enable();
+            }
+        }
+        if let Some(p) = user32_proc(b"IsClipboardFormatAvailable\0") {
+            let target: FnIsClipboardFormatAvailable = std::mem::transmute(p);
+            if IsClipboardFormatAvailableHook
+                .initialize(target, is_clipboard_format_available)
+                .is_ok()
+            {
+                let _ = IsClipboardFormatAvailableHook.enable();
+            }
+        }
+        if let Some(p) = user32_proc(b"CountClipboardFormats\0") {
+            let target: FnCountClipboardFormats = std::mem::transmute(p);
+            if CountClipboardFormatsHook
+                .initialize(target, count_clipboard_formats)
+                .is_ok()
+            {
+                let _ = CountClipboardFormatsHook.enable();
+            }
+        }
+        if let Some(p) = user32_proc(b"EnumClipboardFormats\0") {
+            let target: FnEnumClipboardFormats = std::mem::transmute(p);
+            if EnumClipboardFormatsHook
+                .initialize(target, enum_clipboard_formats)
+                .is_ok()
+            {
+                let _ = EnumClipboardFormatsHook.enable();
+            }
+        }
+        if let Some(p) = user32_proc(b"GetClipboardSequenceNumber\0") {
+            let target: FnGetClipboardSequenceNumber = std::mem::transmute(p);
+            if GetClipboardSequenceNumberHook
+                .initialize(target, get_clipboard_sequence_number)
+                .is_ok()
+            {
+                let _ = GetClipboardSequenceNumberHook.enable();
+            }
+        }
+    }
+}

--- a/crates/glass-clip-hook/src/hook/detour_impl.rs
+++ b/crates/glass-clip-hook/src/hook/detour_impl.rs
@@ -16,8 +16,9 @@ use retour::static_detour;
 use windows::Win32::Foundation::{GlobalFree, BOOL, HANDLE, HGLOBAL, HWND};
 
 use super::{
-    alloc_hglobal_for, is_text_format, read_utf16_from_hglobal, store_empty, store_get, store_seq,
-    store_set, user32_proc, CF_TEXT_ID, CF_UNICODETEXT_ID,
+    alloc_hglobal_for, is_text_format, read_singlebyte_from_hglobal, read_utf16_from_hglobal,
+    store_empty, store_get, store_seq, store_set, user32_proc, CF_OEMTEXT_ID, CF_TEXT_ID,
+    CF_UNICODETEXT_ID,
 };
 
 // Exact raw ABI signatures of the user32 exports (from windows-rs `link!` declarations).
@@ -75,96 +76,137 @@ fn free_cached_handle() {
 }
 
 /// Cache a freshly-allocated handle to be freed on the next open/empty/close.
+///
+/// NOTE: we free the previous handle on the NEXT `GetClipboardData` (via `cache_handle` →
+/// `free_cached_handle`) as well as on open/empty/close — slightly narrower than the Win32
+/// "valid until CloseClipboard" contract, but fine for the lock-copy-unlock pattern apps use.
 fn cache_handle(h: HGLOBAL) {
     free_cached_handle(); // never leak a prior one
     LAST_HANDLE.with(|c| c.set(h.0 as isize));
 }
 
 // ---- detour bodies ---------------------------------------------------------------------------
+//
+// Every detour body is wrapped in `catch_unwind`: a Rust panic unwinding across an `extern
+// "system"` frame into the host app is UB. `catch_unwind` contains it and we return the same
+// fail-soft default the body uses for a down pipe. (A member-crate `panic = "abort"` would NOT
+// help — Cargo only honors `[profile]` at the workspace root, so it is silently ignored.)
+// `AssertUnwindSafe` is sound here: on panic we return a safe default and mutate no shared
+// invariant, even though the closures touch raw pointers / thread-local `Cell`s.
 
 /// `OpenClipboard(hwnd)` → mark open; always succeed. Never touches the real clipboard.
 fn open_clipboard(_hwnd: HWND) -> BOOL {
-    free_cached_handle();
-    CLIP_OPEN.with(|c| c.set(true));
-    BOOL(1)
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        free_cached_handle();
+        CLIP_OPEN.with(|c| c.set(true));
+        BOOL(1)
+    }))
+    .unwrap_or(BOOL(0))
 }
 
 /// `CloseClipboard()` → mark closed; free the cached handle. Always succeed.
 fn close_clipboard() -> BOOL {
-    CLIP_OPEN.with(|c| c.set(false));
-    free_cached_handle();
-    BOOL(1)
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        CLIP_OPEN.with(|c| c.set(false));
+        free_cached_handle();
+        BOOL(1)
+    }))
+    .unwrap_or(BOOL(0))
 }
 
 /// `EmptyClipboard()` → clear the host store; free the cached handle. Always succeed.
 fn empty_clipboard() -> BOOL {
-    store_empty();
-    free_cached_handle();
-    BOOL(1)
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        store_empty();
+        free_cached_handle();
+        BOOL(1)
+    }))
+    .unwrap_or(BOOL(0))
 }
 
-/// `SetClipboardData(fmt, h)` → for text formats with a non-NULL handle, read the UTF-16 text and
-/// store it. Returns `h` (the contract: the clipboard now "owns" it; we keep the store as the
-/// source of truth). `h == NULL` is delayed rendering — out of scope in v1: return NULL, no change.
-/// Non-text formats are ignored (return the handle unchanged, no store change).
+/// `SetClipboardData(fmt, h)` → for text formats with a non-NULL handle, read the text in the
+/// format's own encoding and store it. Returns `h` (the contract: the clipboard now "owns" it; we
+/// keep the store as the source of truth). `h == NULL` is delayed rendering — out of scope in v1:
+/// return NULL, no change. Non-text formats are ignored (return the handle unchanged).
+///
+/// v1 text-format handling: `CF_UNICODETEXT` reads as UTF-16; `CF_TEXT`/`CF_OEMTEXT` read as
+/// single-byte ANSI (the app's buffer is single-byte — reading it as UTF-16 would garble it).
 fn set_clipboard_data(fmt: u32, h: HANDLE) -> HANDLE {
-    if h.0.is_null() {
-        return HANDLE::default(); // delayed rendering unsupported (v1)
-    }
-    if is_text_format(fmt) {
-        if let Some(text) = read_utf16_from_hglobal(HGLOBAL(h.0)) {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        if h.0.is_null() {
+            return HANDLE::default(); // delayed rendering unsupported (v1)
+        }
+        let text = if fmt == CF_UNICODETEXT_ID {
+            read_utf16_from_hglobal(HGLOBAL(h.0))
+        } else if fmt == CF_TEXT_ID || fmt == CF_OEMTEXT_ID {
+            read_singlebyte_from_hglobal(HGLOBAL(h.0))
+        } else {
+            None // non-text format: ignore
+        };
+        if let Some(text) = text {
             store_set(&text);
         }
-    }
-    h
+        h
+    }))
+    .unwrap_or(HANDLE::default())
 }
 
 /// `GetClipboardData(fmt)` → for text formats, allocate a fresh `HGLOBAL` in the requested encoding
 /// from the host store, cache it (so the app needn't free it; we free on next open/empty/close),
 /// and return it. NULL if the store is empty, the format is non-text, or the pipe is down.
 fn get_clipboard_data(fmt: u32) -> HANDLE {
-    if !is_text_format(fmt) {
-        return HANDLE::default();
-    }
-    let Some(text) = store_get() else {
-        return HANDLE::default();
-    };
-    match alloc_hglobal_for(fmt, &text) {
-        Some(h) => {
-            cache_handle(h);
-            HANDLE(h.0)
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        if !is_text_format(fmt) {
+            return HANDLE::default();
         }
-        None => HANDLE::default(),
-    }
+        let Some(text) = store_get() else {
+            return HANDLE::default();
+        };
+        match alloc_hglobal_for(fmt, &text) {
+            Some(h) => {
+                cache_handle(h);
+                HANDLE(h.0)
+            }
+            None => HANDLE::default(),
+        }
+    }))
+    .unwrap_or(HANDLE::default())
 }
 
 /// `IsClipboardFormatAvailable(fmt)` → TRUE iff a text format and the store is non-empty.
 fn is_clipboard_format_available(fmt: u32) -> BOOL {
-    BOOL((is_text_format(fmt) && store_get().is_some()) as i32)
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        BOOL((is_text_format(fmt) && store_get().is_some()) as i32)
+    }))
+    .unwrap_or(BOOL(0))
 }
 
 /// `CountClipboardFormats()` → 2 (CF_UNICODETEXT + CF_TEXT) when the store has text, else 0.
 fn count_clipboard_formats() -> i32 {
-    if store_get().is_some() {
-        2
-    } else {
-        0
-    }
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        if store_get().is_some() {
+            2
+        } else {
+            0
+        }
+    }))
+    .unwrap_or(0)
 }
 
 /// `EnumClipboardFormats(prev)` → enumerate our synthesized text formats:
 /// 0 → CF_UNICODETEXT; CF_UNICODETEXT → CF_TEXT; anything else → 0 (end of list).
 fn enum_clipboard_formats(prev: u32) -> u32 {
-    match prev {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| match prev {
         0 => CF_UNICODETEXT_ID,
         CF_UNICODETEXT_ID => CF_TEXT_ID,
         _ => 0,
-    }
+    }))
+    .unwrap_or(0)
 }
 
 /// `GetClipboardSequenceNumber()` → the host store's sequence number (bumps on every set/empty).
 fn get_clipboard_sequence_number() -> u32 {
-    store_seq()
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(store_seq)).unwrap_or(0)
 }
 
 // ---- installation ----------------------------------------------------------------------------

--- a/crates/glass-clip-hook/src/lib.rs
+++ b/crates/glass-clip-hook/src/lib.rs
@@ -9,6 +9,12 @@
 pub mod proto;
 pub mod store;
 
+// Pure clipboard text codecs the windows hook defers to. Compiled for windows (the hook) and for
+// test (so the suite runs + Miri-checks on the Linux dev box); unused on a non-test non-windows
+// build, hence the cfg gate.
+#[cfg(any(windows, test))]
+mod text;
+
 #[cfg(windows)]
 mod hook;
 

--- a/crates/glass-clip-hook/src/lib.rs
+++ b/crates/glass-clip-hook/src/lib.rs
@@ -1,0 +1,13 @@
+//! glass private-clipboard shim.
+//!
+//! Two faces: (1) an injected **DLL** (`cdylib`) loaded into the Sandboxie-boxed app via
+//! `InjectDll64=`, which detours the user32 clipboard APIs and proxies them to a host store
+//! over a named pipe; (2) a pure **library** (`rlib`) exposing the wire [`proto`]col and the
+//! host-side [`store`], reused by `glass-windows`. Only [`hook`] is Win32 — the rest is pure
+//! and unit-tested on the Linux dev box.
+
+pub mod proto;
+pub mod store;
+
+#[cfg(windows)]
+mod hook;

--- a/crates/glass-clip-hook/src/lib.rs
+++ b/crates/glass-clip-hook/src/lib.rs
@@ -11,3 +11,11 @@ pub mod store;
 
 #[cfg(windows)]
 mod hook;
+
+/// Sandboxie InjectDll entry point (called after SbieDll, before the app's entry). Inert unless
+/// `GLASS_CLIP_PIPE` is set (only the target app's process tree carries it). See [`hook`].
+#[cfg(windows)]
+#[no_mangle]
+pub extern "system" fn InjectDllMain(_h_sbie_dll: isize, _unused: usize) {
+    hook::init();
+}

--- a/crates/glass-clip-hook/src/lib.rs
+++ b/crates/glass-clip-hook/src/lib.rs
@@ -17,5 +17,8 @@ mod hook;
 #[cfg(windows)]
 #[no_mangle]
 pub extern "system" fn InjectDllMain(_h_sbie_dll: isize, _unused: usize) {
-    hook::init();
+    // A panic unwinding across this `extern "system"` frame into the host app would be UB.
+    // `catch_unwind` contains it (member-crate `panic = "abort"` is ignored by Cargo — only the
+    // workspace-root `[profile]` is honored — so we cannot rely on it).
+    let _ = std::panic::catch_unwind(hook::init);
 }

--- a/crates/glass-clip-hook/src/proto.rs
+++ b/crates/glass-clip-hook/src/proto.rs
@@ -1,0 +1,1 @@
+//! Wire protocol between the injected hook DLL (client) and the host store server.

--- a/crates/glass-clip-hook/src/proto.rs
+++ b/crates/glass-clip-hook/src/proto.rs
@@ -1,1 +1,197 @@
 //! Wire protocol between the injected hook DLL (client) and the host store server.
+
+/// Protocol version. Bumped on any wire-format change; a mismatch is rejected (never guessed).
+pub const VERSION: u8 = 1;
+
+/// Hard cap on a single text payload (1 MiB of UTF-8). Larger `Set`s are rejected by the
+/// reader, not truncated — no silent loss.
+pub const MAX_TEXT_BYTES: usize = 1 << 20;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Request {
+    Get,
+    Set(String),
+    Empty,
+    Seq,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Response {
+    Text(Option<String>),
+    Ok,
+    Seq(u64),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ProtoError {
+    Version(u8),
+    Truncated,
+    BadTag(u8),
+    TooLarge(usize),
+    Utf8,
+}
+
+fn put_str(out: &mut Vec<u8>, s: &str) {
+    let b = s.as_bytes();
+    out.extend_from_slice(&(b.len() as u32).to_le_bytes());
+    out.extend_from_slice(b);
+}
+
+fn take_str(buf: &[u8]) -> Result<String, ProtoError> {
+    if buf.len() < 4 {
+        return Err(ProtoError::Truncated);
+    }
+    let n = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]) as usize;
+    if n > MAX_TEXT_BYTES {
+        return Err(ProtoError::TooLarge(n));
+    }
+    let body = &buf[4..];
+    if body.len() < n {
+        return Err(ProtoError::Truncated);
+    }
+    String::from_utf8(body[..n].to_vec()).map_err(|_| ProtoError::Utf8)
+}
+
+impl Request {
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = vec![VERSION];
+        match self {
+            Request::Get => out.push(1),
+            Request::Empty => out.push(2),
+            Request::Set(s) => {
+                out.push(3);
+                put_str(&mut out, s);
+            }
+            Request::Seq => out.push(4),
+        }
+        out
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Request, ProtoError> {
+        if bytes.len() < 2 {
+            return Err(ProtoError::Truncated);
+        }
+        if bytes[0] != VERSION {
+            return Err(ProtoError::Version(bytes[0]));
+        }
+        match bytes[1] {
+            1 => Ok(Request::Get),
+            2 => Ok(Request::Empty),
+            3 => Ok(Request::Set(take_str(&bytes[2..])?)),
+            4 => Ok(Request::Seq),
+            t => Err(ProtoError::BadTag(t)),
+        }
+    }
+}
+
+impl Response {
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = vec![VERSION];
+        match self {
+            Response::Text(None) => out.push(1),
+            Response::Text(Some(s)) => {
+                out.push(2);
+                put_str(&mut out, s);
+            }
+            Response::Ok => out.push(3),
+            Response::Seq(n) => {
+                out.push(4);
+                out.extend_from_slice(&n.to_le_bytes());
+            }
+        }
+        out
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Response, ProtoError> {
+        if bytes.len() < 2 {
+            return Err(ProtoError::Truncated);
+        }
+        if bytes[0] != VERSION {
+            return Err(ProtoError::Version(bytes[0]));
+        }
+        match bytes[1] {
+            1 => Ok(Response::Text(None)),
+            2 => Ok(Response::Text(Some(take_str(&bytes[2..])?))),
+            3 => Ok(Response::Ok),
+            4 => {
+                let b = bytes.get(2..10).ok_or(ProtoError::Truncated)?;
+                let mut a = [0u8; 8];
+                a.copy_from_slice(b);
+                Ok(Response::Seq(u64::from_le_bytes(a)))
+            }
+            t => Err(ProtoError::BadTag(t)),
+        }
+    }
+}
+
+/// Length-prefix a message body for the pipe (4-byte LE length + body).
+pub fn frame(body: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(4 + body.len());
+    out.extend_from_slice(&(body.len() as u32).to_le_bytes());
+    out.extend_from_slice(body);
+    out
+}
+
+/// Parse one length-prefixed frame, returning (body, remaining). Errors if incomplete.
+pub fn parse_frame(buf: &[u8]) -> Result<(Vec<u8>, &[u8]), ProtoError> {
+    if buf.len() < 4 {
+        return Err(ProtoError::Truncated);
+    }
+    let n = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]) as usize;
+    if n > MAX_TEXT_BYTES + 16 {
+        return Err(ProtoError::TooLarge(n));
+    }
+    let body = buf.get(4..4 + n).ok_or(ProtoError::Truncated)?;
+    Ok((body.to_vec(), &buf[4 + n..]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_round_trips() {
+        for r in [Request::Get, Request::Empty, Request::Seq, Request::Set("héllo 世界".into())] {
+            let bytes = r.encode();
+            assert_eq!(Request::decode(&bytes).unwrap(), r);
+        }
+    }
+
+    #[test]
+    fn response_round_trips() {
+        for r in [
+            Response::Text(None),
+            Response::Text(Some("abc".into())),
+            Response::Ok,
+            Response::Seq(42),
+        ] {
+            let bytes = r.encode();
+            assert_eq!(Response::decode(&bytes).unwrap(), r);
+        }
+    }
+
+    #[test]
+    fn rejects_version_skew() {
+        let mut bytes = Request::Get.encode();
+        bytes[0] = VERSION ^ 0xFF; // corrupt the version byte
+        assert!(matches!(Request::decode(&bytes), Err(ProtoError::Version(_))));
+    }
+
+    #[test]
+    fn rejects_truncated_and_bad_tag() {
+        assert!(Request::decode(&[]).is_err());
+        assert!(Request::decode(&[VERSION]).is_err()); // version only, no tag
+        assert!(Request::decode(&[VERSION, 0x7F]).is_err()); // unknown tag
+        // truncated Set: version+tag+len says 5 but no bytes follow
+        assert!(Request::decode(&[VERSION, 3, 5, 0, 0, 0]).is_err());
+    }
+
+    #[test]
+    fn frame_then_parse_round_trips() {
+        let payload = Request::Set("x".into()).encode();
+        let framed = frame(&payload);
+        let (got, rest) = parse_frame(&framed).unwrap();
+        assert_eq!(got, payload);
+        assert!(rest.is_empty());
+    }
+}

--- a/crates/glass-clip-hook/src/store.rs
+++ b/crates/glass-clip-hook/src/store.rs
@@ -1,0 +1,1 @@
+//! Host-owned private clipboard store (pure; no Win32).

--- a/crates/glass-clip-hook/src/store.rs
+++ b/crates/glass-clip-hook/src/store.rs
@@ -1,1 +1,102 @@
 //! Host-owned private clipboard store (pure; no Win32).
+
+use std::sync::{Arc, Mutex};
+
+use crate::proto::{Request, Response};
+
+#[derive(Default)]
+struct ClipboardState {
+    text: Option<String>,
+    seq: u64,
+}
+
+/// The single source of truth for a contained app's clipboard, shared (cloned `Arc`) between
+/// the pipe server thread and the platform's `get/set_clipboard`. Pure — no Win32.
+#[derive(Clone, Default)]
+pub struct PrivateClipboard(Arc<Mutex<ClipboardState>>);
+
+impl PrivateClipboard {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn get(&self) -> Option<String> {
+        self.0.lock().expect("clip mutex").text.clone()
+    }
+
+    pub fn set(&self, text: String) {
+        let mut g = self.0.lock().expect("clip mutex");
+        g.text = Some(text);
+        g.seq = g.seq.wrapping_add(1);
+    }
+
+    pub fn empty(&self) {
+        let mut g = self.0.lock().expect("clip mutex");
+        g.text = None;
+        g.seq = g.seq.wrapping_add(1);
+    }
+
+    pub fn seq(&self) -> u64 {
+        self.0.lock().expect("clip mutex").seq
+    }
+
+    /// Apply a wire request, returning the wire response. The single place the server maps
+    /// protocol → state, so the hook DLL and `glass_clipboard_*` stay consistent.
+    pub fn apply(&self, req: Request) -> Response {
+        match req {
+            Request::Get => Response::Text(self.get()),
+            Request::Set(s) => {
+                self.set(s);
+                Response::Ok
+            }
+            Request::Empty => {
+                self.empty();
+                Response::Ok
+            }
+            Request::Seq => Response::Seq(self.seq()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_get_round_trip_and_seq_bumps() {
+        let c = PrivateClipboard::new();
+        assert_eq!(c.get(), None);
+        let s0 = c.seq();
+        c.set("hi".into());
+        assert_eq!(c.get(), Some("hi".into()));
+        assert!(c.seq() > s0);
+    }
+
+    #[test]
+    fn empty_clears_and_bumps() {
+        let c = PrivateClipboard::new();
+        c.set("hi".into());
+        let s1 = c.seq();
+        c.empty();
+        assert_eq!(c.get(), None);
+        assert!(c.seq() > s1);
+    }
+
+    #[test]
+    fn apply_request_maps_to_responses() {
+        let c = PrivateClipboard::new();
+        assert_eq!(c.apply(super::super::proto::Request::Set("z".into())), super::super::proto::Response::Ok);
+        assert_eq!(c.apply(super::super::proto::Request::Get), super::super::proto::Response::Text(Some("z".into())));
+        assert_eq!(c.apply(super::super::proto::Request::Empty), super::super::proto::Response::Ok);
+        assert_eq!(c.apply(super::super::proto::Request::Get), super::super::proto::Response::Text(None));
+        assert!(matches!(c.apply(super::super::proto::Request::Seq), super::super::proto::Response::Seq(_)));
+    }
+
+    #[test]
+    fn clone_shares_state() {
+        let a = PrivateClipboard::new();
+        let b = a.clone();
+        a.set("shared".into());
+        assert_eq!(b.get(), Some("shared".into())); // same Arc
+    }
+}

--- a/crates/glass-clip-hook/src/text.rs
+++ b/crates/glass-clip-hook/src/text.rs
@@ -1,0 +1,89 @@
+//! Pure clipboard text codecs (no Win32), unit-tested + Miri-checked on the Linux dev box.
+//!
+//! The `cfg(windows)` hook does the `unsafe` FFI — locking an `HGLOBAL` into a slice *bounded by
+//! `GlobalSize`* — and defers the actual NUL-terminated parse/encode to these helpers. So the
+//! UB-prone slicing/decoding lives in safe, tested code; only the FFI lock itself stays `unsafe`.
+//!
+//! Compiled for `windows` (the hook uses it) and for `test` (so the suite runs on Linux + Miri).
+
+/// Decode a `CF_UNICODETEXT` block (the whole locked buffer, as UTF-16 code units) to a `String`,
+/// stopping at the first NUL terminator — or consuming the whole buffer if it is unterminated.
+/// Invalid UTF-16 (e.g. a lone surrogate) is replaced, never an error and never UB.
+pub(crate) fn utf16_nul_to_string(units: &[u16]) -> String {
+    let end = units.iter().position(|&c| c == 0).unwrap_or(units.len());
+    String::from_utf16_lossy(&units[..end])
+}
+
+/// Decode a `CF_TEXT`/`CF_OEMTEXT` block (the whole locked buffer, as bytes) to a `String`, stopping
+/// at the first NUL. v1 treats each byte as ANSI/Latin-1: every byte maps 1:1 to a `char`.
+pub(crate) fn singlebyte_nul_to_string(bytes: &[u8]) -> String {
+    let end = bytes.iter().position(|&b| b == 0).unwrap_or(bytes.len());
+    bytes[..end].iter().map(|&b| b as char).collect()
+}
+
+/// Encode `text` as a NUL-terminated UTF-16 buffer for `CF_UNICODETEXT`.
+pub(crate) fn string_to_utf16_nul(text: &str) -> Vec<u16> {
+    text.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+/// Encode `text` as a NUL-terminated single-byte buffer for `CF_TEXT`/`CF_OEMTEXT`. v1 is
+/// ASCII-only: any non-ASCII char becomes `'?'` (lossy). NB this is *lossier* than
+/// [`singlebyte_nul_to_string`], which round-trips full Latin-1 — encode and decode are asymmetric
+/// by design in v1 (we only ever populate the store from CF_UNICODETEXT in practice).
+pub(crate) fn string_to_singlebyte_nul(text: &str) -> Vec<u8> {
+    text.chars()
+        .map(|c| if (c as u32) < 0x80 { c as u8 } else { b'?' })
+        .chain(std::iter::once(0))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn utf16_decode_stops_at_nul_and_handles_edges() {
+        // stops at the terminator, ignoring anything past it
+        assert_eq!(
+            utf16_nul_to_string(&[b'H' as u16, b'i' as u16, 0, b'X' as u16]),
+            "Hi"
+        );
+        // unterminated → the whole buffer (no out-of-bounds walk past the end)
+        assert_eq!(utf16_nul_to_string(&[b'H' as u16, b'i' as u16]), "Hi");
+        // empty buffer and leading NUL → empty string
+        assert_eq!(utf16_nul_to_string(&[]), "");
+        assert_eq!(utf16_nul_to_string(&[0, b'H' as u16]), "");
+        // non-ASCII BMP
+        assert_eq!(utf16_nul_to_string(&[0x4e16, 0x754c, 0]), "世界");
+        // lone high surrogate is invalid UTF-16 → replacement char (lossy, never UB)
+        assert_eq!(utf16_nul_to_string(&[0xD800, 0]), "\u{FFFD}");
+    }
+
+    #[test]
+    fn singlebyte_decode_is_latin1_to_first_nul() {
+        assert_eq!(singlebyte_nul_to_string(b"AB\0C"), "AB");
+        assert_eq!(singlebyte_nul_to_string(b"AB"), "AB"); // unterminated
+        assert_eq!(singlebyte_nul_to_string(b""), "");
+        assert_eq!(singlebyte_nul_to_string(&[0, b'A']), "");
+        // high byte → Latin-1 char (0xE9 == 'é')
+        assert_eq!(singlebyte_nul_to_string(&[0xE9, 0]), "é");
+    }
+
+    #[test]
+    fn utf16_encode_appends_one_nul_and_round_trips() {
+        assert_eq!(string_to_utf16_nul("Hi"), vec![b'H' as u16, b'i' as u16, 0]);
+        assert_eq!(string_to_utf16_nul(""), vec![0]);
+        // encode → decode round-trips (decode drops the terminator)
+        for s in ["", "Hi", "世界", "tab\tnl\n"] {
+            assert_eq!(utf16_nul_to_string(&string_to_utf16_nul(s)), s);
+        }
+    }
+
+    #[test]
+    fn singlebyte_encode_is_ascii_only_lossy() {
+        assert_eq!(string_to_singlebyte_nul("AB"), vec![b'A', b'B', 0]);
+        assert_eq!(string_to_singlebyte_nul(""), vec![0]);
+        // non-ASCII → '?' — documents the encode/decode asymmetry
+        assert_eq!(string_to_singlebyte_nul("é世"), vec![b'?', b'?', 0]);
+    }
+}

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -134,20 +134,22 @@ impl GlassServer {
     }
 
     #[tool(
-        description = "Read the clipboard as text (\"\" if empty). Acts on the app's display — \
-                       isolated from your real clipboard on the private Xvfb/sway backends. Also \
-                       the cheap text-extraction path: glass_do ctrl+a then ctrl+c, then read \
-                       here (beats OCR for selectable text)."
+        description = "Read the clipboard as text (\"\" if empty). Acts on the app's clipboard — \
+                       isolated from your real clipboard on the private Xvfb/sway backends and on \
+                       a contained Windows app (a private boxed clipboard). Also the cheap \
+                       text-extraction path: glass_do ctrl+a then ctrl+c, then read here (beats \
+                       OCR for selectable text)."
     )]
     async fn glass_clipboard_get(&self) -> Result<CallToolResult, McpError> {
         self.run(tools::clipboard_get).await
     }
 
     #[tool(
-        description = "Write text to the clipboard so the app can paste it. Isolated to the \
-                       app's display on private backends; on shared-desktop modes \
-                       (GLASS_DISPLAY=:0, Windows) this writes your real clipboard — snapshot \
-                       with glass_clipboard_get first if needed."
+        description = "Write text to the clipboard so the app can paste it. Isolated from your \
+                       real clipboard on the private Xvfb/sway backends and on a contained Windows \
+                       app (a private boxed clipboard); only shared-desktop modes (GLASS_DISPLAY=:0, \
+                       or the Windows backend with sandbox=off) write your real clipboard — \
+                       snapshot with glass_clipboard_get first if needed."
     )]
     async fn glass_clipboard_set(
         &self,

--- a/crates/glass-windows/Cargo.toml
+++ b/crates/glass-windows/Cargo.toml
@@ -8,6 +8,7 @@ publish.workspace = true
 
 [dependencies]
 glass-core.workspace = true
+glass-clip-hook = { path = "../glass-clip-hook" }
 
 [target.'cfg(windows)'.dependencies]
 windows-capture = "1"
@@ -21,6 +22,9 @@ windows = { version = "0.58", features = [
   # doctor: session (RemoteDesktop), WGC support probe, true build via RtlGetVersion
   "Win32_System_RemoteDesktop", "Graphics_Capture",
   "Wdk_System_SystemServices", "Win32_System_SystemInformation",
+  # private clipboard: host named-pipe server + scoped security descriptor
+  "Win32_System_Pipes", "Win32_Storage_FileSystem", "Win32_System_IO",
+  "Win32_Security_Authorization",
 ] }
 
 # Only the on-box validation example (examples/onbox.rs) needs a PNG encoder to save captured

--- a/crates/glass-windows/src/containment/clip_onbox.rs
+++ b/crates/glass-windows/src/containment/clip_onbox.rs
@@ -93,9 +93,25 @@ fn private_clipboard_isolation() {
     // The probe writes then reads CF_UNICODETEXT. The box also carries OpenClipboard=n, so the ONLY
     // way the probe can read back what it wrote is via the injected hook → a correct READBACK proves
     // interception, not the real clipboard.
-    let line = wait_for_log(&sink, "READBACK=", Duration::from_secs(12));
+    let line = wait_for_log(&sink, "READBACK=", Duration::from_secs(20));
+    // Diagnostic: dump everything the boxed process emitted (stdout+stderr), so a missing READBACK
+    // tells us whether the probe failed (FAIL: ...), ran silently, or didn't run at all.
+    {
+        let g = sink.lock().unwrap();
+        eprintln!("--- boxed log sink: {} line(s) ---", g.len());
+        for (s, l) in g.iter() {
+            eprintln!("[{s:?}] {l}");
+        }
+        eprintln!("--- end sink ---");
+    }
     let store = app.private_clipboard();
     let ambient_after = crate::clipboard::get().unwrap_or_default();
+    eprintln!(
+        "DIAG host_store={:?} ambient_after={:?} sentinel={:?}",
+        store.as_ref().map(|s| s.get()),
+        ambient_after,
+        sentinel
+    );
     app.kill();
 
     let line = line.expect("probe produced no READBACK= line (hook not intercepting? check the log sink)");

--- a/crates/glass-windows/src/containment/clip_onbox.rs
+++ b/crates/glass-windows/src/containment/clip_onbox.rs
@@ -1,0 +1,116 @@
+//! On-box (LOTUS) deterministic validation of the private-clipboard hook. `#[ignore]`d — it needs
+//! Sandboxie running, the built `glass_clip_hook.dll` (path in `GLASS_CLIP_HOOK_DLL`), and the built
+//! `clipprobe` example. No GUI / interactive desktop is needed: the probe only calls user32
+//! clipboard APIs, so it runs over SSH. Run on the box with:
+//! ```text
+//!   set GLASS_CLIP_HOOK_DLL=C:\Users\mpd\glass\target\release\glass_clip_hook.dll
+//!   cargo test -p glass-windows --release private_clipboard_isolation -- --ignored --nocapture
+//! ```
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use glass_core::logbuf::Stream;
+use glass_core::{AppSpec, SandboxLevel};
+
+use super::sandboxie::{available, sandboxie_dir, Sandboxie};
+
+/// `<profile>` dir (release/debug) holding the built `glass_clip_hook.dll` and `examples/`.
+/// `current_exe` = `<profile>/deps/glass_windows-HASH.exe`.
+fn profile_dir() -> PathBuf {
+    let exe = std::env::current_exe().expect("current_exe");
+    exe.parent()
+        .and_then(|p| p.parent())
+        .expect("profile dir")
+        .to_path_buf()
+}
+
+/// Poll `sink` until a line contains `needle`, or `timeout` elapses.
+fn wait_for_log(
+    sink: &Arc<Mutex<Vec<(Stream, String)>>>,
+    needle: &str,
+    timeout: Duration,
+) -> Option<String> {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if let Ok(g) = sink.lock() {
+            if let Some((_, line)) = g.iter().find(|(_, l)| l.contains(needle)) {
+                return Some(line.clone());
+            }
+        }
+        std::thread::sleep(Duration::from_millis(150));
+    }
+    None
+}
+
+#[test]
+#[ignore = "on-box: needs Sandboxie + GLASS_CLIP_HOOK_DLL + the clipprobe example"]
+fn private_clipboard_isolation() {
+    let dir = sandboxie_dir();
+    assert!(available(&dir), "Sandboxie not available at {dir}");
+
+    let probe = profile_dir().join("examples").join("clipprobe.exe");
+    assert!(
+        probe.exists(),
+        "build the probe first: cargo build -p glass-clip-hook --release --example clipprobe (looked at {})",
+        probe.display()
+    );
+    let dll = std::env::var("GLASS_CLIP_HOOK_DLL")
+        .expect("set GLASS_CLIP_HOOK_DLL to the built glass_clip_hook.dll");
+    assert!(
+        PathBuf::from(&dll).exists(),
+        "GLASS_CLIP_HOOK_DLL points at a missing file: {dll}"
+    );
+
+    // A sentinel on the AMBIENT (real) clipboard of this session's window station — the boxed
+    // probe must never disturb it.
+    let sentinel = format!("SENTINEL-{}", std::process::id());
+    crate::clipboard::set(&sentinel).expect("set ambient clipboard");
+
+    let sb = Sandboxie {
+        dir: dir.clone(),
+        box_name: format!("glass_cliptest_{}", std::process::id()),
+    };
+    sb.configure(SandboxLevel::Default).expect("configure box");
+
+    let spec = AppSpec {
+        build: None,
+        run: vec![
+            probe.to_string_lossy().into_owned(),
+            "roundtrip".into(),
+            "FROM-BOX".into(),
+        ],
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        timeout_ms: 15000,
+        sandbox: SandboxLevel::Default,
+    };
+    let sink: Arc<Mutex<Vec<(Stream, String)>>> = Arc::new(Mutex::new(Vec::new()));
+    let app = sb.launch(&spec, sink.clone()).expect("launch boxed probe");
+
+    // The probe writes then reads CF_UNICODETEXT. The box also carries OpenClipboard=n, so the ONLY
+    // way the probe can read back what it wrote is via the injected hook → a correct READBACK proves
+    // interception, not the real clipboard.
+    let line = wait_for_log(&sink, "READBACK=", Duration::from_secs(12));
+    let store = app.private_clipboard();
+    let ambient_after = crate::clipboard::get().unwrap_or_default();
+    app.kill();
+
+    let line = line.expect("probe produced no READBACK= line (hook not intercepting? check the log sink)");
+    assert!(line.contains("READBACK=FROM-BOX"), "boxed read-back mismatch: {line:?}");
+
+    let store = store.expect("Layer 2 inactive — GLASS_CLIP_HOOK_DLL not resolved / pipe server failed");
+    assert_eq!(
+        store.get().as_deref(),
+        Some("FROM-BOX"),
+        "host store did not see the boxed write"
+    );
+
+    assert_eq!(
+        ambient_after, sentinel,
+        "AMBIENT CLIPBOARD WAS TOUCHED — isolation breach"
+    );
+    println!("PASS: boxed clipboard roundtrip served by the private store; ambient clipboard untouched");
+}

--- a/crates/glass-windows/src/containment/clip_server.rs
+++ b/crates/glass-windows/src/containment/clip_server.rs
@@ -9,6 +9,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
 
 use glass_clip_hook::proto::{self, Request, Response};
 use glass_clip_hook::store::PrivateClipboard;
@@ -18,19 +19,18 @@ use windows::core::PCWSTR;
 use windows::Win32::Foundation::{CloseHandle, BOOL, HANDLE, INVALID_HANDLE_VALUE};
 use windows::Win32::Security::Authorization::ConvertStringSecurityDescriptorToSecurityDescriptorW;
 use windows::Win32::Security::{PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES};
-use windows::Win32::Storage::FileSystem::{ReadFile, WriteFile};
+use windows::Win32::Storage::FileSystem::{FlushFileBuffers, ReadFile, WriteFile};
 use windows::Win32::System::Pipes::{
-    ConnectNamedPipe, CreateNamedPipeW, DisconnectNamedPipe, PIPE_READMODE_BYTE, PIPE_TYPE_BYTE,
-    PIPE_WAIT,
+    ConnectNamedPipe, CreateNamedPipeW, DisconnectNamedPipe, GetNamedPipeClientProcessId,
+    PIPE_READMODE_BYTE, PIPE_TYPE_BYTE, PIPE_WAIT,
 };
 
-/// SDDL for the pipe DACL: Everyone (WD) + SYSTEM generic-all. Everyone is required, not just the
-/// owner: the Sandboxie box runs the client under a **restricted** token (even with
-/// KeepTokenIntegrity=y), whose access check is satisfied only by a SID in its *restricting* set —
-/// an owner-only DACL is denied. The pipe name is per-box and ephemeral and only ever carries this
-/// box's own clipboard text on the local machine, so Everyone-on-a-named-pipe is acceptable for v1
-/// (a local process would also have to guess the per-box name). Tightening to the box SID is a
-/// follow-up.
+/// SDDL for the pipe DACL: Everyone (WD) + SYSTEM generic-all. Everyone is required merely so the
+/// box's client can *connect*: with `KeepTokenIntegrity=y` the Sandboxie token's access check is
+/// satisfied only by a SID in its restricting set, so an owner-only DACL is denied. The DACL is
+/// therefore NOT the authorization boundary — every connection is gated by [`client_in_box`], which
+/// verifies the client PID belongs to THIS Sandboxie box (`Start.exe /listpids`) before a request is
+/// honored. So an ordinary local process that guessed the per-box pipe name is rejected.
 const PIPE_SDDL: &str = "D:(A;;GA;;;WD)(A;;GA;;;SY)";
 
 fn to_wide(s: &str) -> Vec<u16> {
@@ -45,15 +45,21 @@ pub(crate) struct ClipServer {
 }
 
 impl ClipServer {
-    /// Start the accept loop for `pipe_name` (e.g. `glass-clip-glass_1234`), serving `store`.
-    pub(crate) fn start(pipe_name: &str, store: PrivateClipboard) -> Result<ClipServer> {
+    /// Start the accept loop for `pipe_name` (e.g. `glass-clip-glass_1234`), serving `store`. `dir`
+    /// + `box_name` identify the Sandboxie box so each connection can be gated to its members.
+    pub(crate) fn start(
+        pipe_name: &str,
+        store: PrivateClipboard,
+        dir: String,
+        box_name: String,
+    ) -> Result<ClipServer> {
         let pipe_path = format!(r"\\.\pipe\{pipe_name}");
         let stop = Arc::new(AtomicBool::new(false));
         let stop_t = stop.clone();
         let path_t = pipe_path.clone();
         let thread = std::thread::Builder::new()
             .name(format!("glass-clip:{pipe_name}"))
-            .spawn(move || accept_loop(&path_t, store, stop_t))
+            .spawn(move || accept_loop(&path_t, store, stop_t, dir, box_name))
             .map_err(|e| GlassError::Backend(format!("spawn clip server: {e}")))?;
         Ok(ClipServer { pipe_path, stop, thread: Some(thread) })
     }
@@ -119,12 +125,22 @@ fn make_security() -> Result<(SECURITY_ATTRIBUTES, PSECURITY_DESCRIPTOR)> {
     Ok((sa, psd))
 }
 
-fn accept_loop(pipe_path: &str, store: PrivateClipboard, stop: Arc<AtomicBool>) {
+fn accept_loop(
+    pipe_path: &str,
+    store: PrivateClipboard,
+    stop: Arc<AtomicBool>,
+    dir: String,
+    box_name: String,
+) {
     let wide = to_wide(pipe_path);
     let (sa, psd) = match make_security() {
         Ok(v) => v,
         Err(_) => return, // server unavailable → Layer-1-only (user still protected)
     };
+    // Cache the box's PID set briefly: the gate needs it per connection, but `Start.exe /listpids`
+    // is a subprocess, so refresh at most ~twice a second (clipboard ops are rare; the box's pids
+    // are stable within a session).
+    let mut pids: (Instant, Vec<u32>) = (Instant::now(), Vec::new());
     while !stop.load(Ordering::Relaxed) {
         use windows::Win32::Storage::FileSystem::PIPE_ACCESS_DUPLEX;
         // SAFETY: classic CreateNamedPipeW; `wide` is NUL-terminated; sa points at a live SD.
@@ -154,7 +170,10 @@ fn accept_loop(pipe_path: &str, store: PrivateClipboard, stop: Arc<AtomicBool>) 
             break;
         }
         if connected {
-            serve_one(pipe, &store);
+            if pids.1.is_empty() || pids.0.elapsed() > Duration::from_millis(500) {
+                pids = (Instant::now(), box_pids(&dir, &box_name));
+            }
+            serve_one(pipe, &store, &pids.1);
         }
         // SAFETY: done with this instance.
         unsafe {
@@ -170,18 +189,54 @@ fn accept_loop(pipe_path: &str, store: PrivateClipboard, stop: Arc<AtomicBool>) 
     }
 }
 
+/// The box's current PID set via `Start.exe /box:<box> /listpids` — the authoritative Sandboxie
+/// membership list (the same call the backend uses for discovery). Empty on any failure, so the
+/// gate fails closed.
+fn box_pids(dir: &str, box_name: &str) -> Vec<u32> {
+    match std::process::Command::new(format!(r"{dir}\Start.exe"))
+        .args([&format!("/box:{box_name}"), "/listpids"])
+        .output()
+    {
+        Ok(out) => super::config::parse_listpids(&String::from_utf8_lossy(&out.stdout)),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Authorization gate: is the connected pipe client a process inside THIS Sandboxie box?
+///
+/// The broad pipe DACL only lets the box connect at all (its `KeepTokenIntegrity` token fails an
+/// owner-only DACL); this membership check is the real boundary. We look up the client PID
+/// (`GetNamedPipeClientProcessId`) and require it to be in the box's `/listpids` set — so an
+/// ordinary local process that guessed the per-box pipe name is rejected. Fail closed on any error.
+fn client_in_box(pipe: HANDLE, box_pids: &[u32]) -> bool {
+    let mut pid = 0u32;
+    // SAFETY: writes the connected client's PID into `pid`; returns Err if there is no client.
+    if unsafe { GetNamedPipeClientProcessId(pipe, &mut pid) }.is_err() || pid == 0 {
+        return false;
+    }
+    box_pids.contains(&pid)
+}
+
 /// Read one length-prefixed request, apply it, write the length-prefixed response.
-fn serve_one(pipe: HANDLE, store: &PrivateClipboard) {
+fn serve_one(pipe: HANDLE, store: &PrivateClipboard, box_pids: &[u32]) {
     let Some(body) = read_frame(pipe) else { return };
+    // Authorization: only a process inside our Sandboxie box is served — the DACL merely lets the
+    // box connect; this is the boundary against any other local process (see [`client_in_box`]).
+    if !client_in_box(pipe, box_pids) {
+        return;
+    }
     let resp = match Request::decode(&body) {
         Ok(req) => store.apply(req),
         Err(_) => Response::Text(None), // skew/garbage → empty, never a crash
     };
     let out = proto::frame(&resp.encode());
     let mut written = 0u32;
-    // SAFETY: writing `out` to a connected pipe instance we own.
+    // SAFETY: write the response, then FlushFileBuffers — it blocks until the client has read all
+    // the bytes. Without it, the caller's DisconnectNamedPipe can fire first and DISCARD the unread
+    // response (the read-back then comes back empty), which is timing-dependent and flaky.
     unsafe {
         let _ = WriteFile(pipe, Some(&out), Some(&mut written as *mut u32), None);
+        let _ = FlushFileBuffers(pipe);
     }
 }
 

--- a/crates/glass-windows/src/containment/clip_server.rs
+++ b/crates/glass-windows/src/containment/clip_server.rs
@@ -6,9 +6,6 @@
 //! we [`PrivateClipboard::apply`] and answer. The boxed `glass_clip_hook` DLL is the client.
 //! Sandboxie's `OpenPipePath` lets the box reach this host pipe (always applied).
 
-// Task 8 wires ClipServer into SandboxieApp; until then suppress the dead-code lint.
-#![allow(dead_code)]
-
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread::JoinHandle;

--- a/crates/glass-windows/src/containment/clip_server.rs
+++ b/crates/glass-windows/src/containment/clip_server.rs
@@ -24,9 +24,14 @@ use windows::Win32::System::Pipes::{
     PIPE_WAIT,
 };
 
-/// SDDL: allow the current user (Owner) and SYSTEM generic-all; nothing wider. The box token is
-/// the same user (KeepTokenIntegrity=y) so it can connect; other users cannot.
-const PIPE_SDDL: &str = "D:(A;;GA;;;OW)(A;;GA;;;SY)";
+/// SDDL for the pipe DACL: Everyone (WD) + SYSTEM generic-all. Everyone is required, not just the
+/// owner: the Sandboxie box runs the client under a **restricted** token (even with
+/// KeepTokenIntegrity=y), whose access check is satisfied only by a SID in its *restricting* set —
+/// an owner-only DACL is denied. The pipe name is per-box and ephemeral and only ever carries this
+/// box's own clipboard text on the local machine, so Everyone-on-a-named-pipe is acceptable for v1
+/// (a local process would also have to guess the per-box name). Tightening to the box SID is a
+/// follow-up.
+const PIPE_SDDL: &str = "D:(A;;GA;;;WD)(A;;GA;;;SY)";
 
 fn to_wide(s: &str) -> Vec<u16> {
     s.encode_utf16().chain(std::iter::once(0)).collect()

--- a/crates/glass-windows/src/containment/clip_server.rs
+++ b/crates/glass-windows/src/containment/clip_server.rs
@@ -1,0 +1,217 @@
+//! Host-side named-pipe server backing a boxed app's private clipboard.
+//!
+//! One server per contained app: a thread runs an accept loop on `\\.\pipe\glass-clip-<box>`
+//! with a security descriptor scoped to the current user (the box runs at user integrity under
+//! `KeepTokenIntegrity=y`). Each connection carries one length-prefixed [`proto`] request, which
+//! we [`PrivateClipboard::apply`] and answer. The boxed `glass_clip_hook` DLL is the client.
+//! Sandboxie's `OpenPipePath` lets the box reach this host pipe (always applied).
+
+// Task 8 wires ClipServer into SandboxieApp; until then suppress the dead-code lint.
+#![allow(dead_code)]
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+
+use glass_clip_hook::proto::{self, Request, Response};
+use glass_clip_hook::store::PrivateClipboard;
+use glass_core::{GlassError, Result};
+
+use windows::core::PCWSTR;
+use windows::Win32::Foundation::{CloseHandle, BOOL, HANDLE, INVALID_HANDLE_VALUE};
+use windows::Win32::Security::Authorization::ConvertStringSecurityDescriptorToSecurityDescriptorW;
+use windows::Win32::Security::{PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES};
+use windows::Win32::Storage::FileSystem::{ReadFile, WriteFile};
+use windows::Win32::System::Pipes::{
+    ConnectNamedPipe, CreateNamedPipeW, DisconnectNamedPipe, PIPE_READMODE_BYTE, PIPE_TYPE_BYTE,
+    PIPE_WAIT,
+};
+
+/// SDDL: allow the current user (Owner) and SYSTEM generic-all; nothing wider. The box token is
+/// the same user (KeepTokenIntegrity=y) so it can connect; other users cannot.
+const PIPE_SDDL: &str = "D:(A;;GA;;;OW)(A;;GA;;;SY)";
+
+fn to_wide(s: &str) -> Vec<u16> {
+    s.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+/// A running clipboard pipe server. Dropping/`stop`ping it ends the accept loop and joins.
+pub(crate) struct ClipServer {
+    pipe_path: String,
+    stop: Arc<AtomicBool>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl ClipServer {
+    /// Start the accept loop for `pipe_name` (e.g. `glass-clip-glass_1234`), serving `store`.
+    pub(crate) fn start(pipe_name: &str, store: PrivateClipboard) -> Result<ClipServer> {
+        let pipe_path = format!(r"\\.\pipe\{pipe_name}");
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_t = stop.clone();
+        let path_t = pipe_path.clone();
+        let thread = std::thread::Builder::new()
+            .name(format!("glass-clip:{pipe_name}"))
+            .spawn(move || accept_loop(&path_t, store, stop_t))
+            .map_err(|e| GlassError::Backend(format!("spawn clip server: {e}")))?;
+        Ok(ClipServer { pipe_path, stop, thread: Some(thread) })
+    }
+
+    /// Stop the loop: flag, then poke the pipe (a self-connect) to break a blocking
+    /// `ConnectNamedPipe`, then join.
+    pub(crate) fn stop(mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        let wide = to_wide(&self.pipe_path);
+        // SAFETY: opening our own pipe by name to release the accept loop; handle closed immediately.
+        unsafe {
+            use windows::Win32::Foundation::GENERIC_READ;
+            use windows::Win32::Foundation::GENERIC_WRITE;
+            use windows::Win32::Storage::FileSystem::{
+                CreateFileW, FILE_FLAGS_AND_ATTRIBUTES, FILE_SHARE_NONE, OPEN_EXISTING,
+            };
+            if let Ok(h) = CreateFileW(
+                PCWSTR(wide.as_ptr()),
+                (GENERIC_READ | GENERIC_WRITE).0,
+                FILE_SHARE_NONE,
+                None,
+                OPEN_EXISTING,
+                FILE_FLAGS_AND_ATTRIBUTES(0),
+                None,
+            ) {
+                let _ = CloseHandle(h);
+            }
+        }
+        if let Some(t) = self.thread.take() {
+            let _ = t.join();
+        }
+    }
+}
+
+impl Drop for ClipServer {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+    }
+}
+
+/// Build a SECURITY_ATTRIBUTES from `PIPE_SDDL`. Returns the descriptor alongside so its memory
+/// outlives the SA (the SA holds a raw pointer into it).
+fn make_security() -> Result<(SECURITY_ATTRIBUTES, PSECURITY_DESCRIPTOR)> {
+    let wsddl = to_wide(PIPE_SDDL);
+    let mut psd = PSECURITY_DESCRIPTOR::default();
+    // SAFETY: wsddl is a NUL-terminated SDDL string; the call allocates a self-relative SD into
+    // psd which we free when the server stops (LocalFree). Single-threaded setup, no aliasing.
+    unsafe {
+        use windows::Win32::Security::Authorization::SDDL_REVISION_1;
+        ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            PCWSTR(wsddl.as_ptr()),
+            SDDL_REVISION_1,
+            &mut psd,
+            None,
+        )
+        .map_err(|e| GlassError::Backend(format!("clip pipe SDDL: {e}")))?;
+    }
+    let sa = SECURITY_ATTRIBUTES {
+        nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
+        lpSecurityDescriptor: psd.0,
+        bInheritHandle: BOOL(0),
+    };
+    Ok((sa, psd))
+}
+
+fn accept_loop(pipe_path: &str, store: PrivateClipboard, stop: Arc<AtomicBool>) {
+    let wide = to_wide(pipe_path);
+    let (sa, psd) = match make_security() {
+        Ok(v) => v,
+        Err(_) => return, // server unavailable → Layer-1-only (user still protected)
+    };
+    while !stop.load(Ordering::Relaxed) {
+        use windows::Win32::Storage::FileSystem::PIPE_ACCESS_DUPLEX;
+        // SAFETY: classic CreateNamedPipeW; `wide` is NUL-terminated; sa points at a live SD.
+        let pipe = unsafe {
+            CreateNamedPipeW(
+                PCWSTR(wide.as_ptr()),
+                PIPE_ACCESS_DUPLEX,
+                PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+                4,
+                proto::MAX_TEXT_BYTES as u32 + 64,
+                proto::MAX_TEXT_BYTES as u32 + 64,
+                0,
+                Some(&sa),
+            )
+        };
+        if pipe == INVALID_HANDLE_VALUE {
+            break;
+        }
+        // SAFETY: blocks until a client connects (or our self-poke in stop()).
+        let connected = unsafe { ConnectNamedPipe(pipe, None) }.is_ok();
+        if stop.load(Ordering::Relaxed) {
+            // SAFETY: closing the instance handle we own.
+            unsafe {
+                let _ = DisconnectNamedPipe(pipe);
+                let _ = CloseHandle(pipe);
+            }
+            break;
+        }
+        if connected {
+            serve_one(pipe, &store);
+        }
+        // SAFETY: done with this instance.
+        unsafe {
+            let _ = DisconnectNamedPipe(pipe);
+            let _ = CloseHandle(pipe);
+        }
+    }
+    // SAFETY: free the SD allocated by ConvertStringSecurityDescriptor…; psd.0 is the pointer
+    // returned by that API via LocalAlloc and must be freed with LocalFree.
+    unsafe {
+        use windows::Win32::Foundation::HLOCAL;
+        let _ = windows::Win32::Foundation::LocalFree(HLOCAL(psd.0));
+    }
+}
+
+/// Read one length-prefixed request, apply it, write the length-prefixed response.
+fn serve_one(pipe: HANDLE, store: &PrivateClipboard) {
+    let Some(body) = read_frame(pipe) else { return };
+    let resp = match Request::decode(&body) {
+        Ok(req) => store.apply(req),
+        Err(_) => Response::Text(None), // skew/garbage → empty, never a crash
+    };
+    let out = proto::frame(&resp.encode());
+    let mut written = 0u32;
+    // SAFETY: writing `out` to a connected pipe instance we own.
+    unsafe {
+        let _ = WriteFile(pipe, Some(&out), Some(&mut written as *mut u32), None);
+    }
+}
+
+/// Read a 4-byte LE length then exactly that many bytes. None on any short/failed read.
+fn read_frame(pipe: HANDLE) -> Option<Vec<u8>> {
+    let mut len_buf = [0u8; 4];
+    if !read_exact(pipe, &mut len_buf) {
+        return None;
+    }
+    let n = u32::from_le_bytes(len_buf) as usize;
+    if n > proto::MAX_TEXT_BYTES + 64 {
+        return None;
+    }
+    let mut body = vec![0u8; n];
+    if !read_exact(pipe, &mut body) {
+        return None;
+    }
+    Some(body)
+}
+
+fn read_exact(pipe: HANDLE, buf: &mut [u8]) -> bool {
+    let mut off = 0usize;
+    while off < buf.len() {
+        let mut read = 0u32;
+        // SAFETY: reading into buf[off..] on a connected pipe instance we own.
+        let ok =
+            unsafe { ReadFile(pipe, Some(&mut buf[off..]), Some(&mut read as *mut u32), None) }
+                .is_ok();
+        if !ok || read == 0 {
+            return false;
+        }
+        off += read as usize;
+    }
+    true
+}

--- a/crates/glass-windows/src/containment/config.rs
+++ b/crates/glass-windows/src/containment/config.rs
@@ -132,7 +132,6 @@ pub(crate) fn pick_path(
 
 /// Per-box pipe name (no namespace prefix; the host opens `\\.\pipe\<name>`, the box reaches it
 /// via `OpenPipePath=\Device\NamedPipe\<name>`). Derived from the box name so it's unique/session.
-#[allow(dead_code)] // consumed in Task 8
 pub(crate) fn clip_pipe_name(box_name: &str) -> String {
     format!("glass-clip-{box_name}")
 }
@@ -142,7 +141,6 @@ pub(crate) fn clip_pipe_name(box_name: &str) -> String {
 /// Precedence: explicit (`GLASS_CLIP_HOOK_DLL`) > `<exe_dir>/glass_clip_hook.dll` > `None`
 /// (Layer-2 unavailable — Layer-1-only). Mirrors `sandboxie_dir`'s precedence, but returns
 /// `Option`: a missing DLL must NOT fail the launch (clipboard isn't core to running the app).
-#[allow(dead_code)] // consumed in Task 8
 pub(crate) fn hook_dll_path(explicit: Option<&str>, exe_dir: Option<&str>) -> Option<String> {
     if let Some(e) = explicit {
         return Some(e.to_string());
@@ -152,7 +150,6 @@ pub(crate) fn hook_dll_path(explicit: Option<&str>, exe_dir: Option<&str>) -> Op
 
 /// The Layer-2 SbieIni `(key,value)` lines: inject the hook DLL into every boxed process and let
 /// the box reach the host's clipboard pipe. (`GLASS_CLIP_PIPE` is set separately, in launch.cmd.)
-#[allow(dead_code)] // consumed in Task 8
 pub(crate) fn clip_layer2_lines(box_name: &str, dll_path: &str) -> Vec<(String, String)> {
     vec![
         ("InjectDll64".to_string(), dll_path.to_string()),
@@ -183,10 +180,6 @@ fn reject_unsafe_launch_token(s: &str) -> Result<()> {
         )));
     }
     Ok(())
-}
-
-pub(crate) fn build_launch_cmd(spec: &AppSpec, out_log: &Path, err_log: &Path) -> Result<String> {
-    build_launch_cmd_env(spec, out_log, err_log, None)
 }
 
 /// Build the `launch.cmd` body: `@echo off`, an optional leading `set "GLASS_CLIP_PIPE=<name>"`
@@ -256,7 +249,7 @@ mod tests {
     #[test]
     fn launch_cmd_quotes_tokens_and_redirects() {
         let spec = launch_spec(vec!["C:\\Program Files\\app.exe".into(), "--flag".into()], None);
-        let script = build_launch_cmd(&spec, Path::new("out.log"), Path::new("err.log")).unwrap();
+        let script = build_launch_cmd_env(&spec, Path::new("out.log"), Path::new("err.log"), None).unwrap();
         assert!(script.starts_with("@echo off\r\n"), "script: {script:?}");
         assert!(script.contains("\"C:\\Program Files\\app.exe\" \"--flag\""), "script: {script:?}");
         assert!(script.contains("1>\"out.log\" 2>\"err.log\""), "script: {script:?}");
@@ -269,7 +262,7 @@ mod tests {
         for bad in ["a\"b", "a%PATH%b", "a\rb", "a\nb"] {
             let spec = launch_spec(vec!["app.exe".into(), bad.into()], None);
             assert!(
-                build_launch_cmd(&spec, Path::new("o"), Path::new("e")).is_err(),
+                build_launch_cmd_env(&spec, Path::new("o"), Path::new("e"), None).is_err(),
                 "run token {bad:?} must be rejected"
             );
         }
@@ -280,7 +273,7 @@ mod tests {
         for bad in ["C:\\a\"b", "C:\\%TEMP%", "C:\\a\rb", "C:\\a\nb"] {
             let spec = launch_spec(vec!["app.exe".into()], Some(bad));
             assert!(
-                build_launch_cmd(&spec, Path::new("o"), Path::new("e")).is_err(),
+                build_launch_cmd_env(&spec, Path::new("o"), Path::new("e"), None).is_err(),
                 "cwd {bad:?} must be rejected"
             );
         }

--- a/crates/glass-windows/src/containment/config.rs
+++ b/crates/glass-windows/src/containment/config.rs
@@ -130,6 +130,36 @@ pub(crate) fn pick_path(
         .unwrap_or_else(|| default.to_string())
 }
 
+/// Per-box pipe name (no namespace prefix; the host opens `\\.\pipe\<name>`, the box reaches it
+/// via `OpenPipePath=\Device\NamedPipe\<name>`). Derived from the box name so it's unique/session.
+pub(crate) fn clip_pipe_name(box_name: &str) -> String {
+    format!("glass-clip-{box_name}")
+}
+
+/// Resolve the injected hook DLL.
+///
+/// Precedence: explicit (`GLASS_CLIP_HOOK_DLL`) > `<exe_dir>/glass_clip_hook.dll` > `None`
+/// (Layer-2 unavailable — Layer-1-only). Mirrors `sandboxie_dir`'s precedence, but returns
+/// `Option`: a missing DLL must NOT fail the launch (clipboard isn't core to running the app).
+pub(crate) fn hook_dll_path(explicit: Option<&str>, exe_dir: Option<&str>) -> Option<String> {
+    if let Some(e) = explicit {
+        return Some(e.to_string());
+    }
+    exe_dir.map(|d| format!("{d}/glass_clip_hook.dll"))
+}
+
+/// The Layer-2 SbieIni `(key,value)` lines: inject the hook DLL into every boxed process and let
+/// the box reach the host's clipboard pipe. (`GLASS_CLIP_PIPE` is set separately, in launch.cmd.)
+pub(crate) fn clip_layer2_lines(box_name: &str, dll_path: &str) -> Vec<(String, String)> {
+    vec![
+        ("InjectDll64".to_string(), dll_path.to_string()),
+        (
+            "OpenPipePath".to_string(),
+            format!("\\Device\\NamedPipe\\{}", clip_pipe_name(box_name)),
+        ),
+    ]
+}
+
 /// Characters in a `spec.run` token or `spec.cwd` that cannot be safely emitted into the
 /// generated `launch.cmd`, so a token containing any of them is rejected (fail-closed) rather
 /// than producing a script cmd.exe would mis-parse or that could inject a second command:
@@ -306,5 +336,28 @@ mod tests {
         assert_eq!(pick_path(None, Some("Y"), Some("Z"), "D"), "Y");
         assert_eq!(pick_path(None, None, Some("Z"), "D"), "Z");
         assert_eq!(pick_path(None, None, None, "D"), "D");
+    }
+
+    #[test]
+    fn clip_pipe_name_is_per_box() {
+        assert_eq!(clip_pipe_name("glass_1234"), "glass-clip-glass_1234");
+    }
+
+    #[test]
+    fn hook_dll_path_precedence() {
+        // explicit env wins; else beside the exe; else None (Layer-2 unavailable).
+        assert_eq!(hook_dll_path(Some("X.dll"), Some("/exe/dir")), Some("X.dll".to_string()));
+        assert_eq!(hook_dll_path(None, Some("/exe/dir")), Some("/exe/dir/glass_clip_hook.dll".to_string()));
+        assert_eq!(hook_dll_path(None, None), None);
+    }
+
+    #[test]
+    fn layer2_box_lines_inject_and_open_pipe() {
+        let lines = clip_layer2_lines("glass_7", "C:\\g\\glass_clip_hook.dll");
+        assert!(lines.contains(&("InjectDll64".to_string(), "C:\\g\\glass_clip_hook.dll".to_string())));
+        assert!(lines.contains(&(
+            "OpenPipePath".to_string(),
+            "\\Device\\NamedPipe\\glass-clip-glass_7".to_string()
+        )));
     }
 }

--- a/crates/glass-windows/src/containment/config.rs
+++ b/crates/glass-windows/src/containment/config.rs
@@ -132,6 +132,7 @@ pub(crate) fn pick_path(
 
 /// Per-box pipe name (no namespace prefix; the host opens `\\.\pipe\<name>`, the box reaches it
 /// via `OpenPipePath=\Device\NamedPipe\<name>`). Derived from the box name so it's unique/session.
+#[allow(dead_code)] // consumed in Task 8
 pub(crate) fn clip_pipe_name(box_name: &str) -> String {
     format!("glass-clip-{box_name}")
 }
@@ -141,6 +142,7 @@ pub(crate) fn clip_pipe_name(box_name: &str) -> String {
 /// Precedence: explicit (`GLASS_CLIP_HOOK_DLL`) > `<exe_dir>/glass_clip_hook.dll` > `None`
 /// (Layer-2 unavailable — Layer-1-only). Mirrors `sandboxie_dir`'s precedence, but returns
 /// `Option`: a missing DLL must NOT fail the launch (clipboard isn't core to running the app).
+#[allow(dead_code)] // consumed in Task 8
 pub(crate) fn hook_dll_path(explicit: Option<&str>, exe_dir: Option<&str>) -> Option<String> {
     if let Some(e) = explicit {
         return Some(e.to_string());
@@ -150,6 +152,7 @@ pub(crate) fn hook_dll_path(explicit: Option<&str>, exe_dir: Option<&str>) -> Op
 
 /// The Layer-2 SbieIni `(key,value)` lines: inject the hook DLL into every boxed process and let
 /// the box reach the host's clipboard pipe. (`GLASS_CLIP_PIPE` is set separately, in launch.cmd.)
+#[allow(dead_code)] // consumed in Task 8
 pub(crate) fn clip_layer2_lines(box_name: &str, dll_path: &str) -> Vec<(String, String)> {
     vec![
         ("InjectDll64".to_string(), dll_path.to_string()),

--- a/crates/glass-windows/src/containment/config.rs
+++ b/crates/glass-windows/src/containment/config.rs
@@ -99,6 +99,10 @@ pub(crate) fn box_settings(level: SandboxLevel) -> Vec<(&'static str, &'static s
         ("NotifyInternetAccessDenied", "n"),
         ("NotifyStartRunAccessDenied", "n"),
         ("AllowNetworkAccess", if net.allow_network_access { "y" } else { "n" }),
+        // Layer 1 (unconditional): block the boxed app from the user's global clipboard.
+        // A private clipboard is layered back on top by the InjectDll64 hook (Layer 2);
+        // if the hook is unavailable the app simply has no clipboard — the user's is safe.
+        ("OpenClipboard", "n"),
     ]
 }
 
@@ -254,6 +258,17 @@ mod tests {
             decide(SandboxLevel::Strict, ProviderChoice::None, true),
             Decision::FailClosed(_)
         ));
+    }
+
+    #[test]
+    fn box_settings_always_blocks_user_clipboard() {
+        // Layer 1: the boxed app can never touch the user's clipboard, at any level.
+        for level in [SandboxLevel::Default, SandboxLevel::Strict] {
+            assert!(
+                box_settings(level).contains(&("OpenClipboard", "n")),
+                "OpenClipboard=n must be set at {level:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/glass-windows/src/containment/config.rs
+++ b/crates/glass-windows/src/containment/config.rs
@@ -182,14 +182,27 @@ fn reject_unsafe_launch_token(s: &str) -> Result<()> {
     Ok(())
 }
 
-/// Build the `launch.cmd` body: `@echo off`, an optional `cd /d "<cwd>"`, then the quoted
-/// exe + each quoted arg with stdout/stderr redirected to the log files.
+pub(crate) fn build_launch_cmd(spec: &AppSpec, out_log: &Path, err_log: &Path) -> Result<String> {
+    build_launch_cmd_env(spec, out_log, err_log, None)
+}
+
+/// Build the `launch.cmd` body: `@echo off`, an optional leading `set "GLASS_CLIP_PIPE=<name>"`
+/// (when `clip_pipe` is `Some`), an optional `cd /d "<cwd>"`, then the quoted exe + each quoted
+/// arg with stdout/stderr redirected to the log files.
 ///
 /// Every token is wrapped in `"..."`. CMD treats most of its metacharacters (`& | < > ^`)
 /// literally inside a quoted token, so quoting handles those — but `"`, `%`, and embedded
 /// newlines cannot be made safe in this context (see [`FORBIDDEN_LAUNCH_CHARS`]), so any
 /// `spec.run` element or `spec.cwd` containing one is rejected with an honest error.
-pub(crate) fn build_launch_cmd(spec: &AppSpec, out_log: &Path, err_log: &Path) -> Result<String> {
+///
+/// The pipe name is glass-generated (`glass-clip-<box>`), so it carries no injection risk and
+/// does not need token rejection. `build_launch_cmd` delegates here with `clip_pipe = None`.
+pub(crate) fn build_launch_cmd_env(
+    spec: &AppSpec,
+    out_log: &Path,
+    err_log: &Path,
+    clip_pipe: Option<&str>,
+) -> Result<String> {
     if let Some(cwd) = &spec.cwd {
         reject_unsafe_launch_token(&cwd.to_string_lossy())?;
     }
@@ -197,6 +210,9 @@ pub(crate) fn build_launch_cmd(spec: &AppSpec, out_log: &Path, err_log: &Path) -
         reject_unsafe_launch_token(part)?;
     }
     let mut s = String::from("@echo off\r\n");
+    if let Some(pipe) = clip_pipe {
+        s.push_str(&format!("set \"GLASS_CLIP_PIPE={pipe}\"\r\n"));
+    }
     if let Some(cwd) = &spec.cwd {
         s.push_str(&format!("cd /d \"{}\"\r\n", cwd.display()));
     }
@@ -359,5 +375,16 @@ mod tests {
             "OpenPipePath".to_string(),
             "\\Device\\NamedPipe\\glass-clip-glass_7".to_string()
         )));
+    }
+
+    #[test]
+    fn launch_cmd_sets_clip_pipe_env_when_present() {
+        let spec = launch_spec(vec!["app.exe".into()], None);
+        let with = build_launch_cmd_env(&spec, Path::new("o"), Path::new("e"), Some("glass-clip-glass_9")).unwrap();
+        assert!(with.contains("set \"GLASS_CLIP_PIPE=glass-clip-glass_9\"\r\n"), "got: {with:?}");
+        // None → no env line (Layer-1-only), and the exe still runs.
+        let without = build_launch_cmd_env(&spec, Path::new("o"), Path::new("e"), None).unwrap();
+        assert!(!without.contains("GLASS_CLIP_PIPE"), "got: {without:?}");
+        assert!(without.contains("\"app.exe\""));
     }
 }

--- a/crates/glass-windows/src/containment/mod.rs
+++ b/crates/glass-windows/src/containment/mod.rs
@@ -17,6 +17,12 @@ pub(crate) use imp::{resolve_containment, ClipboardRoute, Launched, LogSink};
 #[cfg(windows)]
 pub(crate) use sandboxie::{available, sandboxie_dir};
 
+/// Resolve the clip hook DLL path the way the launcher does (env > exe dir > None), for doctor.
+#[cfg(windows)]
+pub(crate) fn config_hook_dll_path(exe_dir: Option<&str>) -> Option<String> {
+    config::hook_dll_path(std::env::var("GLASS_CLIP_HOOK_DLL").ok().as_deref(), exe_dir)
+}
+
 #[cfg(windows)]
 mod imp {
     use std::io::{BufRead, BufReader};

--- a/crates/glass-windows/src/containment/mod.rs
+++ b/crates/glass-windows/src/containment/mod.rs
@@ -4,6 +4,9 @@
 pub(crate) mod config;
 
 #[cfg(windows)]
+mod clip_server;
+
+#[cfg(windows)]
 mod sandboxie;
 
 #[cfg(windows)]

--- a/crates/glass-windows/src/containment/mod.rs
+++ b/crates/glass-windows/src/containment/mod.rs
@@ -9,6 +9,11 @@ mod clip_server;
 #[cfg(windows)]
 mod sandboxie;
 
+// On-box (LOTUS) deterministic validation of the private-clipboard hook. Compiled only for the
+// Windows test profile; the single test inside is `#[ignore]`d (needs Sandboxie + the built DLL).
+#[cfg(all(test, windows))]
+mod clip_onbox;
+
 #[cfg(windows)]
 pub(crate) use imp::{resolve_containment, ClipboardRoute, Launched, LogSink};
 

--- a/crates/glass-windows/src/containment/mod.rs
+++ b/crates/glass-windows/src/containment/mod.rs
@@ -10,7 +10,7 @@ mod clip_server;
 mod sandboxie;
 
 #[cfg(windows)]
-pub(crate) use imp::{resolve_containment, Launched, LogSink};
+pub(crate) use imp::{resolve_containment, ClipboardRoute, Launched, LogSink};
 
 // Re-export the Sandboxie availability/dir probes so the doctor can report posture
 // without reaching into the private `sandboxie` module path.
@@ -149,6 +149,29 @@ mod imp {
             match self {
                 Launched::Unconfined(a) => a.kill(),
                 Launched::Sandboxie(a) => a.kill(),
+            }
+        }
+    }
+
+    /// How a launched app's clipboard is served. The platform turns this into behavior; a contained
+    /// app must never read/write the user's real clipboard.
+    pub(crate) enum ClipboardRoute {
+        /// Unconfined (`sandbox=off`): the real OS clipboard (today's behavior; the explicit escape hatch).
+        RealOs,
+        /// Sandboxie + hook active: glass's private store.
+        Private(glass_clip_hook::store::PrivateClipboard),
+        /// Sandboxie, hook unavailable (Layer-1-only): clipboard is disabled — error, never the real clipboard.
+        DisabledContained,
+    }
+
+    impl Launched {
+        pub(crate) fn clipboard_route(&self) -> ClipboardRoute {
+            match self {
+                Launched::Unconfined(_) => ClipboardRoute::RealOs,
+                Launched::Sandboxie(a) => match a.private_clipboard() {
+                    Some(store) => ClipboardRoute::Private(store),
+                    None => ClipboardRoute::DisabledContained,
+                },
             }
         }
     }

--- a/crates/glass-windows/src/containment/sandboxie.rs
+++ b/crates/glass-windows/src/containment/sandboxie.rs
@@ -414,7 +414,6 @@ impl SandboxieApp {
     /// The clipboard routing for this contained app: `Some(store)` when Layer 2 is active,
     /// `None` when Layer-1-only (the platform turns `None` into the "disabled" error — it must
     /// never fall back to the user's real clipboard for a contained app).
-    #[allow(dead_code)] // Task 9 wires this into the Platform get/set_clipboard route
     pub(crate) fn private_clipboard(&self) -> Option<PrivateClipboard> {
         self.clip.as_ref().map(|(store, _)| store.clone())
     }

--- a/crates/glass-windows/src/containment/sandboxie.rs
+++ b/crates/glass-windows/src/containment/sandboxie.rs
@@ -127,7 +127,8 @@ impl Sandboxie {
         }
         let pipe = config::clip_pipe_name(&self.box_name);
         let store = PrivateClipboard::new();
-        let server = ClipServer::start(&pipe, store.clone()).ok()?;
+        let server =
+            ClipServer::start(&pipe, store.clone(), self.dir.clone(), self.box_name.clone()).ok()?;
         let sbieini = sbieini(&self.dir);
         for (k, v) in config::clip_layer2_lines(&self.box_name, &dll) {
             if self.run_sbie(&sbieini, &["set", &self.box_name, &k, &v]).is_err() {

--- a/crates/glass-windows/src/containment/sandboxie.rs
+++ b/crates/glass-windows/src/containment/sandboxie.rs
@@ -26,9 +26,11 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use glass_clip_hook::store::PrivateClipboard;
 use glass_core::logbuf::Stream;
 use glass_core::{AppSpec, GlassError, Result, SandboxLevel};
 
+use super::clip_server::ClipServer;
 use super::config;
 use super::imp::LogSink;
 
@@ -107,6 +109,37 @@ pub(crate) struct Sandboxie {
 }
 
 impl Sandboxie {
+    /// Configure the private-clipboard hook for this box (Layer 2). Returns `Some((store, server,
+    /// pipe))` when the hook DLL is resolvable and the pipe server starts; `None` (Layer-1-only)
+    /// otherwise. Never fails the launch — a missing hook leaves the app clipboard-less but the
+    /// user's clipboard safe (Layer 1 already applied via box_settings).
+    fn setup_private_clipboard(&self) -> Option<(PrivateClipboard, ClipServer, String)> {
+        let exe_dir = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(|d| d.to_string_lossy().into_owned()));
+        let dll = config::hook_dll_path(
+            std::env::var("GLASS_CLIP_HOOK_DLL").ok().as_deref(),
+            exe_dir.as_deref(),
+        )?;
+        if !Path::new(&dll).exists() {
+            crate::disclose_clip_disabled(&dll);
+            return None;
+        }
+        let pipe = config::clip_pipe_name(&self.box_name);
+        let store = PrivateClipboard::new();
+        let server = ClipServer::start(&pipe, store.clone()).ok()?;
+        let sbieini = sbieini(&self.dir);
+        for (k, v) in config::clip_layer2_lines(&self.box_name, &dll) {
+            if self.run_sbie(&sbieini, &["set", &self.box_name, &k, &v]).is_err() {
+                return None;
+            }
+        }
+        if self.run_sbie(&start_exe(&self.dir), &["/reload"]).is_err() {
+            return None;
+        }
+        Some((store, server, pipe))
+    }
+
     /// Run a Sandboxie CLI tool, mapping a spawn failure or non-zero exit to `Backend`.
     fn run_sbie(&self, exe: &str, args: &[&str]) -> Result<()> {
         let status = Command::new(exe)
@@ -200,6 +233,12 @@ impl Sandboxie {
     /// Launch the app contained, redirecting its stdio to files in a per-session log dir and
     /// tailing those files into `logs`. Returns the live handle.
     pub(crate) fn launch(&self, spec: &AppSpec, logs: LogSink) -> Result<SandboxieApp> {
+        // Layer-2 clipboard: configure the hook DLL + pipe server (best-effort; None = Layer-1-only).
+        // This writes clipboard ini lines and does a /reload BEFORE the logdir reload below,
+        // so both sets of ini changes land before the app is ever spawned.
+        let clip = self.setup_private_clipboard();
+        let clip_pipe = clip.as_ref().map(|(_, _, p)| p.clone());
+
         let logdir = std::env::temp_dir().join(&self.box_name);
         std::fs::create_dir_all(&logdir).map_err(|e| {
             GlassError::AppNotStarted(format!("create log dir {}: {e}", logdir.display()))
@@ -217,8 +256,9 @@ impl Sandboxie {
         let err_log = logdir.join("err.log");
 
         // Generate launch.cmd: optional cd, then the quoted exe + args with stdio redirected.
+        // Passes the clipboard pipe name (if Layer 2 is active) as GLASS_CLIP_PIPE env.
         let cmd_path = logdir.join("launch.cmd");
-        let script = super::config::build_launch_cmd(spec, &out_log, &err_log)?;
+        let script = super::config::build_launch_cmd_env(spec, &out_log, &err_log, clip_pipe.as_deref())?;
         std::fs::write(&cmd_path, script).map_err(|e| {
             GlassError::AppNotStarted(format!("write {}: {e}", cmd_path.display()))
         })?;
@@ -251,6 +291,7 @@ impl Sandboxie {
             inner,
             stop,
             tailers,
+            clip: clip.map(|(store, server, _)| (store, server)),
         })
     }
 }
@@ -332,6 +373,9 @@ pub(crate) struct SandboxieApp {
     inner: crate::process::LaunchedApp,
     stop: Arc<AtomicBool>,
     tailers: Vec<std::thread::JoinHandle<()>>,
+    /// Layer-2 private clipboard: the host store + its pipe server. `None` = Layer-1-only
+    /// (app clipboard disabled, user protected).
+    clip: Option<(PrivateClipboard, ClipServer)>,
 }
 
 impl SandboxieApp {
@@ -367,13 +411,22 @@ impl SandboxieApp {
         Ok(None)
     }
 
+    /// The clipboard routing for this contained app: `Some(store)` when Layer 2 is active,
+    /// `None` when Layer-1-only (the platform turns `None` into the "disabled" error — it must
+    /// never fall back to the user's real clipboard for a contained app).
+    #[allow(dead_code)] // Task 9 wires this into the Platform get/set_clipboard route
+    pub(crate) fn private_clipboard(&self) -> Option<PrivateClipboard> {
+        self.clip.as_ref().map(|(store, _)| store.clone())
+    }
+
     /// Tear the box down, ordered so no log line is lost and no tailer outlives teardown:
     /// `/terminate` (stop the box producing output) → signal stop → **join** the tailers
-    /// (each does a final `drain()` of the real log files) → kill+reap the wrapper → remove
-    /// the log dir (only now that the tailers have exited and read everything) → clear the
-    /// box's config section so per-session `glass_<pid>` boxes don't accumulate in
-    /// `Sandboxie.ini` (`SbieIni set <box> * ""` — the maintainer's documented box-clear).
-    pub(crate) fn kill(self) {
+    /// (each does a final `drain()` of the real log files) → kill+reap the wrapper → stop
+    /// the clipboard pipe server → remove the log dir (only now that the tailers have exited
+    /// and read everything) → clear the box's config section so per-session `glass_<pid>`
+    /// boxes don't accumulate in `Sandboxie.ini` (`SbieIni set <box> * ""` — the
+    /// maintainer's documented box-clear).
+    pub(crate) fn kill(mut self) {
         let _ = Command::new(start_exe(&self.dir))
             .args([&format!("/box:{}", self.box_name), "/terminate"])
             .status();
@@ -382,6 +435,9 @@ impl SandboxieApp {
             let _ = h.join();
         }
         self.inner.kill();
+        if let Some((_, server)) = self.clip.take() {
+            server.stop();
+        }
         let _ = std::fs::remove_dir_all(&self.logdir);
         // Best-effort: remove the box's config section from Sandboxie.ini.
         let _ = Command::new(sbieini(&self.dir))

--- a/crates/glass-windows/src/doctor.rs
+++ b/crates/glass-windows/src/doctor.rs
@@ -168,6 +168,26 @@ pub(crate) fn build_sandbox_checks(
     v
 }
 
+/// Clipboard posture: with the hook DLL the contained app gets a PRIVATE clipboard isolated from
+/// the user's; without it, Layer 1 (`OpenClipboard=n`) still protects the user but the app has no
+/// clipboard. Pure mapping → Linux-tested.
+pub(crate) fn build_clipboard_check(hook_resolvable: bool, dll_path: &str) -> Check {
+    if hook_resolvable {
+        Check::new(
+            "clipboard isolation",
+            CheckStatus::Ok,
+            format!("private clipboard active (hook {dll_path}) — isolated from your clipboard"),
+        )
+    } else {
+        Check::new(
+            "clipboard isolation",
+            CheckStatus::Warn,
+            "contained app clipboard disabled (hook DLL not found); your clipboard is protected",
+        )
+        .with_remedy("set GLASS_CLIP_HOOK_DLL or reinstall so the boxed app gets a private clipboard")
+    }
+}
+
 // ---- Windows fact-gathering (cfg(windows), on-box validated) ----
 #[cfg(windows)]
 pub fn checks(_deep: bool) -> Vec<Check> {
@@ -181,7 +201,17 @@ pub fn sandbox_checks() -> Vec<Check> {
     let avail = crate::containment::available(&dir);
     let prompt = gather_prompt_global(&dir);
     let ws = gather_windows_sandbox();
-    build_sandbox_checks(avail, &dir, prompt, ws)
+    let mut v = build_sandbox_checks(avail, &dir, prompt, ws);
+    let exe_dir = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|d| d.to_string_lossy().into_owned()));
+    let dll = crate::containment::config_hook_dll_path(exe_dir.as_deref());
+    let resolvable = dll
+        .as_deref()
+        .map(|p| std::path::Path::new(p).exists())
+        .unwrap_or(false);
+    v.push(build_clipboard_check(resolvable, dll.as_deref().unwrap_or("<unset>")));
+    v
 }
 
 /// Read Sandboxie's global `PromptForInternetAccess` via `SbieIni.exe query GlobalSettings
@@ -412,5 +442,16 @@ mod tests {
         let v = build_sandbox_checks(true, r"C:\Program Files\Sandboxie", Some(false), true);
         let vm = v.iter().find(|c| c.name == "Windows Sandbox (VM tier)").unwrap();
         assert_eq!(vm.status, CheckStatus::Ok);
+    }
+
+    #[test]
+    fn clipboard_check_reports_layer() {
+        // hook resolvable → private clipboard active; else Layer-1-only (disabled-for-safety).
+        let ok = build_clipboard_check(true, "C:\\g\\glass_clip_hook.dll");
+        assert_eq!(ok.status, CheckStatus::Ok);
+        assert!(ok.detail.contains("private clipboard"));
+        let warn = build_clipboard_check(false, "C:\\g\\glass_clip_hook.dll");
+        assert_eq!(warn.status, CheckStatus::Warn);
+        assert!(warn.detail.contains("disabled"));
     }
 }

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -13,6 +13,21 @@ pub mod containment; // Windows containment provider seam (pure config is host-t
 pub mod pixels; // pure BGRA->RGBA swizzle — cross-platform, unit-tested on the Linux dev box
 pub mod vkmap; // pure named-keysym->VK map — cross-platform, unit-tested on the Linux dev box
 
+/// One-time stderr note when a contained app can't get a private clipboard (hook DLL missing):
+/// the app's clipboard is disabled to protect the user's — never a silent revert to sharing it.
+#[cfg(windows)]
+pub(crate) fn disclose_clip_disabled(dll: &str) {
+    use std::sync::Once;
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        eprintln!(
+            "glass: private clipboard unavailable (hook DLL not found at {dll}); the sandboxed \
+             app's clipboard is DISABLED to protect your clipboard. Set GLASS_CLIP_HOOK_DLL or \
+             reinstall to enable it."
+        );
+    });
+}
+
 #[cfg(windows)]
 mod capture;
 #[cfg(windows)]

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -193,11 +193,33 @@ mod backend {
         }
 
         fn get_clipboard(&mut self) -> Result<String> {
-            crate::clipboard::get()
+            use crate::containment::ClipboardRoute;
+            match self.app.as_ref().map(|a| a.clipboard_route()) {
+                // No app yet, or unconfined → today's real-OS clipboard.
+                None | Some(ClipboardRoute::RealOs) => crate::clipboard::get(),
+                Some(ClipboardRoute::Private(store)) => Ok(store.get().unwrap_or_default()),
+                Some(ClipboardRoute::DisabledContained) => Err(GlassError::Unsupported(
+                    "private clipboard for the contained app (hook DLL not active); the app's clipboard \
+                     is disabled to protect yours — set GLASS_CLIP_HOOK_DLL"
+                        .into(),
+                )),
+            }
         }
 
         fn set_clipboard(&mut self, text: &str) -> Result<()> {
-            crate::clipboard::set(text)
+            use crate::containment::ClipboardRoute;
+            match self.app.as_ref().map(|a| a.clipboard_route()) {
+                None | Some(ClipboardRoute::RealOs) => crate::clipboard::set(text),
+                Some(ClipboardRoute::Private(store)) => {
+                    store.set(text.to_string());
+                    Ok(())
+                }
+                Some(ClipboardRoute::DisabledContained) => Err(GlassError::Unsupported(
+                    "private clipboard for the contained app (hook DLL not active); the app's clipboard \
+                     is disabled to protect yours — set GLASS_CLIP_HOOK_DLL"
+                        .into(),
+                )),
+            }
         }
 
         fn window(&mut self, op: &WindowOp) -> Result<WindowGeometry> {


### PR DESCRIPTION
## Summary

On Windows a sandboxed target app shared the one global OS clipboard with you, so `glass_clipboard_get/set` (and the app's own copy/paste) contended with — and could clobber — your real clipboard. This gives a **contained** Windows app a private clipboard isolated from yours:

- An injected hook DLL (`glass-clip-hook`, loaded via Sandboxie `InjectDll64=`) detours the boxed app's user32 clipboard APIs to a glass-owned store reached over a per-box named pipe; `glass_clipboard_get/set` operate on that same store.
- `OpenClipboard=n` on the box is an unconditional floor: the boxed app can never reach your clipboard even if the hook is unavailable.
- The host pipe server authorizes every connection by verifying the client PID is in the box — the broad pipe DACL only lets the box's restricted token *connect*; it is not the boundary.
- `sandbox=off` keeps today's real-OS-clipboard behavior.

Text-only v1 (`CF_UNICODETEXT`, with `CF_TEXT`/`CF_OEMTEXT` synthesized), x64.

## Validation

- Pure wire protocol, store, and text codecs are TDD'd and **Miri-checked** on Linux; the Win32 closure cross-compiles (windows-gnu) and builds native MSVC.
- Validated on real hardware (Win11, interactive session): a boxed clipboard write→read roundtrips through the private store while the user's clipboard stays at its sentinel — reproducibly (multiple runs), with the authorization gate active.

## Test plan

- [ ] CI green (check · miri · windows · x11 · wayland)
- [x] On-box: contained clipboard roundtrip served by the private store, real clipboard untouched (reproduced 4×)