### PR TITLE
feat(windows): rich clipboard 2a-i — generic format store + user32 (text/HTML/RTF/images)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ the VM tier (the Windows Sandbox `.wsb` template under `packaging/windows-sandbo
 VM running `glass-mcp serve --http`). ² Windows needs an interactive, logged-in session to render
 and capture. ³ When contained (`sandbox=default`/`strict`), the boxed app gets a private clipboard
 isolated from yours — an injected hook backs its clipboard with glass's own store; `sandbox=off`
-uses the real OS clipboard. Text only in v1 (classic apps; x64).
+uses the real OS clipboard. Carries text, HTML, RTF, and images for apps using the Win32 clipboard
+(x64); rich apps that copy via OLE, and file copy, are in progress.
 
 **Transport:** MCP over **stdio** (default, all platforms) or **network HTTP** (`glass-mcp serve
 --http`, all platforms) — the network transport is behind the default-on `network` cargo feature

--- a/crates/glass-clip-hook/Cargo.toml
+++ b/crates/glass-clip-hook/Cargo.toml
@@ -22,6 +22,9 @@ windows = { version = "0.58", features = [
   # CreateFileW lives behind Win32_Security (SECURITY_ATTRIBUTES in its signature);
   # ReadFile/WriteFile behind Win32_System_IO (OVERLAPPED) — both needed by the pipe client.
   "Win32_Storage_FileSystem", "Win32_System_Pipes", "Win32_Security", "Win32_System_IO",
+  # Win32_Graphics_Gdi: CreateDIBitmap/DeleteObject for CF_BITMAP synthesis.
+  # Win32_Globalization: WideCharToMultiByte/GetUserDefaultLCID for CF_TEXT/CF_LOCALE synthesis.
+  "Win32_Graphics_Gdi", "Win32_Globalization",
 ] }
 # Inline detours. License verified permissive in this task's Step 6 (MIT/BSD); IAT fallback documented.
 # `static-detour` enables the `static_detour!` macro (the type-safe detour table); it pulls in the

--- a/crates/glass-clip-hook/examples/clipprobe.rs
+++ b/crates/glass-clip-hook/examples/clipprobe.rs
@@ -12,7 +12,16 @@
 
 #[cfg(windows)]
 fn main() {
-    std::process::exit(run());
+    let mode = std::env::args().nth(1).unwrap_or_default();
+    let code = match mode.as_str() {
+        "roundtrip" => run(),
+        "roundtrip-multi" => run_multi(),
+        _ => {
+            eprintln!("usage: clipprobe <roundtrip|roundtrip-multi> [text]");
+            2
+        }
+    };
+    std::process::exit(code);
 }
 
 #[cfg(windows)]
@@ -92,6 +101,150 @@ fn run() -> i32 {
         let _ = CloseClipboard();
 
         println!("READBACK={read}");
+    }
+    0
+}
+
+/// Allocate a `GMEM_MOVEABLE` `HGLOBAL` holding `data`; null handle on failure.
+///
+/// # Safety
+/// Standard `GlobalAlloc`/`GlobalLock`/copy/`GlobalUnlock`. The returned handle is handed to
+/// `SetClipboardData` (which takes ownership on success); the caller must not free it.
+#[cfg(windows)]
+unsafe fn alloc_global(data: &[u8]) -> windows::Win32::Foundation::HGLOBAL {
+    use windows::Win32::Foundation::HGLOBAL;
+    use windows::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
+    let Ok(h) = GlobalAlloc(GMEM_MOVEABLE, data.len()) else {
+        return HGLOBAL(std::ptr::null_mut());
+    };
+    let dst = GlobalLock(h);
+    if dst.is_null() {
+        return HGLOBAL(std::ptr::null_mut());
+    }
+    std::ptr::copy_nonoverlapping(data.as_ptr(), dst as *mut u8, data.len());
+    let _ = GlobalUnlock(h);
+    h
+}
+
+/// `GetClipboardData(fmt)` → the full `HGLOBAL` contents as bytes (bounded by `GlobalSize`). `None`
+/// if the format is absent or the handle is not a lockable HGLOBAL (e.g. a GDI `CF_BITMAP`).
+///
+/// # Safety
+/// The returned handle is owned by the clipboard; we lock/copy/unlock without freeing it.
+#[cfg(windows)]
+unsafe fn read_global_bytes(fmt: u32) -> Option<Vec<u8>> {
+    use windows::Win32::Foundation::HGLOBAL;
+    use windows::Win32::System::DataExchange::GetClipboardData;
+    use windows::Win32::System::Memory::{GlobalLock, GlobalSize, GlobalUnlock};
+    let hr = GetClipboardData(fmt).ok()?;
+    if hr.is_invalid() {
+        return None;
+    }
+    let g = HGLOBAL(hr.0);
+    let p = GlobalLock(g) as *const u8;
+    if p.is_null() {
+        return None;
+    }
+    let n = GlobalSize(g);
+    let v = std::slice::from_raw_parts(p, n).to_vec();
+    let _ = GlobalUnlock(g);
+    Some(v)
+}
+
+/// Multi-format probe: write `CF_UNICODETEXT` + the registered `"HTML Format"` (round-tripped by
+/// NAME) + a tiny valid `CF_DIB` in ONE clipboard session, then read each back — plus `CF_BITMAP`,
+/// which the hook must SYNTHESIZE from the stored DIB via GDI. Prints one `READBACK-*` line per
+/// format and a final `PROBE-MULTI-DONE`. Boxed (hook + `OpenClipboard=n`), every line proves the
+/// hook captured/served/synthesized that format from the private store.
+#[cfg(windows)]
+fn run_multi() -> i32 {
+    use windows::core::PCWSTR;
+    use windows::Win32::Foundation::HANDLE;
+    use windows::Win32::System::DataExchange::{
+        CloseClipboard, EmptyClipboard, GetClipboardData, OpenClipboard, RegisterClipboardFormatW,
+        SetClipboardData,
+    };
+    use windows::Win32::System::Ole::{CF_BITMAP, CF_DIB, CF_UNICODETEXT};
+
+    // Three payloads.
+    let utf16: Vec<u16> = "FROM-BOX-MULTI".encode_utf16().chain(std::iter::once(0)).collect();
+    let text_bytes: Vec<u8> = utf16.iter().flat_map(|u| u.to_le_bytes()).collect();
+    let html_bytes = b"<b>hi</b>".to_vec();
+    // A 2x2 32bpp BI_RGB DIB: 40-byte BITMAPINFOHEADER + 16 pixel bytes = 56 bytes.
+    let mut dib: Vec<u8> = Vec::with_capacity(56);
+    dib.extend_from_slice(&40u32.to_le_bytes()); // biSize
+    dib.extend_from_slice(&2i32.to_le_bytes()); // biWidth
+    dib.extend_from_slice(&2i32.to_le_bytes()); // biHeight
+    dib.extend_from_slice(&1u16.to_le_bytes()); // biPlanes
+    dib.extend_from_slice(&32u16.to_le_bytes()); // biBitCount
+    dib.extend_from_slice(&0u32.to_le_bytes()); // biCompression = BI_RGB
+    dib.extend_from_slice(&0u32.to_le_bytes()); // biSizeImage
+    dib.extend_from_slice(&0i32.to_le_bytes()); // xppm
+    dib.extend_from_slice(&0i32.to_le_bytes()); // yppm
+    dib.extend_from_slice(&0u32.to_le_bytes()); // biClrUsed
+    dib.extend_from_slice(&0u32.to_le_bytes()); // biClrImportant
+    dib.extend_from_slice(&[0u8; 16]); // 2x2 * 4 bytes
+
+    let cf_text = CF_UNICODETEXT.0 as u32;
+    let cf_dib = CF_DIB.0 as u32;
+    let cf_bmp = CF_BITMAP.0 as u32;
+
+    unsafe {
+        let html_w: Vec<u16> = "HTML Format".encode_utf16().chain(std::iter::once(0)).collect();
+        let html_fmt = RegisterClipboardFormatW(PCWSTR::from_raw(html_w.as_ptr()));
+        if html_fmt == 0 {
+            eprintln!("FAIL: RegisterClipboardFormatW");
+            return 1;
+        }
+
+        // --- write all three in one session ---
+        if OpenClipboard(None).is_err() {
+            eprintln!("FAIL: OpenClipboard(write)");
+            return 1;
+        }
+        let _ = EmptyClipboard();
+        for (fmt, data) in [(cf_text, &text_bytes), (html_fmt, &html_bytes), (cf_dib, &dib)] {
+            let h = alloc_global(data);
+            if h.0.is_null() {
+                let _ = CloseClipboard();
+                eprintln!("FAIL: alloc {fmt}");
+                return 1;
+            }
+            if SetClipboardData(fmt, HANDLE(h.0)).is_err() {
+                let _ = CloseClipboard();
+                eprintln!("FAIL: SetClipboardData {fmt}");
+                return 1;
+            }
+        }
+        let _ = CloseClipboard();
+
+        // --- read back ---
+        if OpenClipboard(None).is_err() {
+            eprintln!("FAIL: OpenClipboard(read)");
+            return 1;
+        }
+        let text_rb = read_global_bytes(cf_text)
+            .map(|b| {
+                let units: Vec<u16> =
+                    b.chunks_exact(2).map(|c| u16::from_le_bytes([c[0], c[1]])).collect();
+                let len = units.iter().position(|&u| u == 0).unwrap_or(units.len());
+                String::from_utf16_lossy(&units[..len])
+            })
+            .unwrap_or_default();
+        let html_rb = read_global_bytes(html_fmt)
+            .map(|b| String::from_utf8_lossy(&b).into_owned())
+            .unwrap_or_default();
+        let dib_len = read_global_bytes(cf_dib).map(|b| b.len()).unwrap_or(0);
+        // CF_BITMAP is a GDI HBITMAP (NOT an HGLOBAL) synthesized by the hook from the stored DIB —
+        // a valid handle proves the GDI synthesis path works on-box.
+        let bmp_ok = matches!(GetClipboardData(cf_bmp), Ok(hr) if !hr.is_invalid());
+        let _ = CloseClipboard();
+
+        println!("READBACK-TEXT={text_rb}");
+        println!("READBACK-HTML={html_rb}");
+        println!("READBACK-DIB-LEN={dib_len}");
+        println!("READBACK-BMP={}", if bmp_ok { "OK" } else { "NULL" });
+        println!("PROBE-MULTI-DONE");
     }
     0
 }

--- a/crates/glass-clip-hook/src/dib.rs
+++ b/crates/glass-clip-hook/src/dib.rs
@@ -1,0 +1,207 @@
+//! Pure DIB / DIBV5 byte-layout parsing + validation + header rewrite (no Win32, Miri-checked).
+//!
+//! `CF_DIB`/`CF_DIBV5` blobs are attacker-influenced (they come from a boxed app's clipboard), so
+//! every size is computed with checked arithmetic and validated against the actual buffer length —
+//! this is where an out-of-bounds read or integer overflow would otherwise hide. The `cfg(windows)`
+//! hook only hands GDI (`CreateDIBitmap`) a layout that parsed clean here.
+
+const BIH: usize = 40; // BITMAPINFOHEADER
+const BV5: usize = 124; // BITMAPV5HEADER
+
+/// Validated geometry of a DIB blob (header + optional color table + pixel bits).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DibInfo {
+    pub width: i32,
+    pub height: i32, // may be negative (top-down); magnitude used for size
+    pub bpp: u16,
+    pub header_bytes: usize,      // 40 or 124
+    pub color_table_bytes: usize, // palette size in bytes
+    pub stride: usize,            // DWORD-aligned bytes per scan line
+    pub image_bytes: usize,       // stride * |height|
+}
+
+fn rd_u16(b: &[u8], o: usize) -> Option<u16> {
+    Some(u16::from_le_bytes(b.get(o..o + 2)?.try_into().ok()?))
+}
+fn rd_u32(b: &[u8], o: usize) -> Option<u32> {
+    Some(u32::from_le_bytes(b.get(o..o + 4)?.try_into().ok()?))
+}
+fn rd_i32(b: &[u8], o: usize) -> Option<i32> {
+    Some(i32::from_le_bytes(b.get(o..o + 4)?.try_into().ok()?))
+}
+
+/// Parse a header of declared size `header_bytes` (40 or 124). Fields at offsets shared by BIH/BV5.
+fn parse_with_header(b: &[u8], header_bytes: usize) -> Option<DibInfo> {
+    if b.len() < header_bytes {
+        return None;
+    }
+    let size = rd_u32(b, 0)? as usize;
+    if size != header_bytes {
+        return None;
+    }
+    let width = rd_i32(b, 4)?;
+    let height = rd_i32(b, 8)?;
+    let bpp = rd_u16(b, 14)?;
+    let compression = rd_u32(b, 16)?;
+    let clr_used = rd_u32(b, 32)?;
+    if width <= 0 || bpp == 0 || compression != 0 {
+        return None; // top-down requires width>0; only BI_RGB (0) handled in v2a-i; reject others
+    }
+    let abs_h = (height as i64).unsigned_abs();
+    // color table: for <=8bpp, clr_used (or 2^bpp if 0) entries of 4 bytes.
+    let color_table_bytes = if bpp <= 8 {
+        let entries = if clr_used == 0 { 1u64 << bpp } else { clr_used as u64 };
+        if entries > 256 {
+            return None; // a palette can't exceed 2^8
+        }
+        (entries as usize) * 4
+    } else {
+        0
+    };
+    // stride = ((width*bpp + 31)/32)*4, all in u64 to avoid overflow.
+    let bits = (width as u64).checked_mul(bpp as u64)?;
+    let stride = ((bits.checked_add(31)?) / 32).checked_mul(4)?;
+    let image = stride.checked_mul(abs_h)?;
+    if image > (crate::proto::MAX_ITEM_BYTES as u64) {
+        return None;
+    }
+    let stride = stride as usize;
+    let image_bytes = image as usize;
+    let need = header_bytes
+        .checked_add(color_table_bytes)?
+        .checked_add(image_bytes)?;
+    if b.len() < need {
+        return None; // buffer shorter than the geometry declares
+    }
+    Some(DibInfo {
+        width,
+        height,
+        bpp,
+        header_bytes,
+        color_table_bytes,
+        stride,
+        image_bytes,
+    })
+}
+
+pub(crate) fn parse_dib(b: &[u8]) -> Option<DibInfo> {
+    parse_with_header(b, BIH)
+}
+pub(crate) fn parse_dibv5(b: &[u8]) -> Option<DibInfo> {
+    parse_with_header(b, BV5)
+}
+
+/// `CF_DIB` (BITMAPINFOHEADER) → `CF_DIBV5` (BITMAPV5HEADER): widen the header to 124 bytes (zero the
+/// new fields; the OS supplies sRGB defaults when color-space is absent), keep table + bits verbatim.
+pub(crate) fn dib_to_dibv5(b: &[u8]) -> Option<Vec<u8>> {
+    let d = parse_dib(b)?;
+    let mut out = vec![0u8; BV5];
+    out[..BIH].copy_from_slice(&b[..BIH]);
+    out[0..4].copy_from_slice(&(BV5 as u32).to_le_bytes()); // biSize = 124
+    out.extend_from_slice(&b[BIH..BIH + d.color_table_bytes + d.image_bytes]);
+    Some(out)
+}
+
+/// `CF_DIBV5` → `CF_DIB`: narrow the header back to 40 bytes; keep table + bits verbatim.
+pub(crate) fn dibv5_to_dib(b: &[u8]) -> Option<Vec<u8>> {
+    let d = parse_dibv5(b)?;
+    let mut out = vec![0u8; BIH];
+    out.copy_from_slice(&b[..BIH]);
+    out[0..4].copy_from_slice(&(BIH as u32).to_le_bytes());
+    out.extend_from_slice(&b[BV5..BV5 + d.color_table_bytes + d.image_bytes]);
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A minimal valid 40-byte BITMAPINFOHEADER for a 2x2 32bpp BI_RGB top-down image (no color table).
+    fn bih_2x2_32() -> Vec<u8> {
+        let mut v = Vec::new();
+        v.extend_from_slice(&40u32.to_le_bytes()); // biSize
+        v.extend_from_slice(&2i32.to_le_bytes()); // biWidth
+        v.extend_from_slice(&2i32.to_le_bytes()); // biHeight
+        v.extend_from_slice(&1u16.to_le_bytes()); // biPlanes
+        v.extend_from_slice(&32u16.to_le_bytes()); // biBitCount
+        v.extend_from_slice(&0u32.to_le_bytes()); // biCompression = BI_RGB
+        v.extend_from_slice(&0u32.to_le_bytes()); // biSizeImage
+        v.extend_from_slice(&0i32.to_le_bytes()); // xppm
+        v.extend_from_slice(&0i32.to_le_bytes()); // yppm
+        v.extend_from_slice(&0u32.to_le_bytes()); // biClrUsed
+        v.extend_from_slice(&0u32.to_le_bytes()); // biClrImportant
+        v
+    }
+    fn valid_dib() -> Vec<u8> {
+        let mut v = bih_2x2_32();
+        v.extend_from_slice(&[0u8; 2 * 2 * 4]); // 16 pixel bytes
+        v
+    }
+
+    #[test]
+    fn parses_a_valid_dib() {
+        let d = parse_dib(&valid_dib()).expect("valid");
+        assert_eq!(d.width, 2);
+        assert_eq!(d.height, 2);
+        assert_eq!(d.bpp, 32);
+        assert_eq!(d.color_table_bytes, 0);
+        assert_eq!(d.stride, 8); // 2px*4B = 8, already DWORD-aligned
+        assert_eq!(d.image_bytes, 16);
+        assert_eq!(d.header_bytes, 40);
+    }
+
+    #[test]
+    fn computes_dword_aligned_stride() {
+        // 3px wide, 24bpp → 9 bytes/row → padded to 12 (DWORD aligned)
+        let mut h = bih_2x2_32();
+        h[4..8].copy_from_slice(&3i32.to_le_bytes()); // width=3
+        h[8..12].copy_from_slice(&1i32.to_le_bytes()); // height=1
+        h[14..16].copy_from_slice(&24u16.to_le_bytes()); // 24bpp
+        h.extend_from_slice(&[0u8; 12]); // one padded row
+        let d = parse_dib(&h).expect("valid");
+        assert_eq!(d.stride, 12);
+        assert_eq!(d.image_bytes, 12);
+    }
+
+    #[test]
+    fn rejects_truncated_header() {
+        assert!(parse_dib(&[0u8; 10]).is_none());
+        assert!(parse_dib(&[]).is_none());
+    }
+
+    #[test]
+    fn rejects_absurd_geometry_without_overflow() {
+        let mut h = bih_2x2_32();
+        h[4..8].copy_from_slice(&i32::MAX.to_le_bytes()); // width = 2^31-1
+        h[8..12].copy_from_slice(&i32::MAX.to_le_bytes()); // height = 2^31-1
+        // stride*height overflows usize math if done naively; parse must reject, not panic/overflow.
+        assert!(parse_dib(&h).is_none());
+    }
+
+    #[test]
+    fn rejects_buffer_shorter_than_declared_image() {
+        let mut v = bih_2x2_32(); // declares a 2x2x32 image (16 bytes) but we append only 4
+        v.extend_from_slice(&[0u8; 4]);
+        assert!(parse_dib(&v).is_none());
+    }
+
+    #[test]
+    fn rejects_oversize_color_table() {
+        let mut h = bih_2x2_32();
+        h[14..16].copy_from_slice(&8u16.to_le_bytes()); // 8bpp
+        h[32..36].copy_from_slice(&u32::MAX.to_le_bytes()); // biClrUsed = 2^32-1 → absurd table
+        assert!(parse_dib(&h).is_none());
+    }
+
+    #[test]
+    fn dib_to_dibv5_and_back_preserve_geometry() {
+        let dib = valid_dib();
+        let v5 = dib_to_dibv5(&dib).expect("v5");
+        // V5 header is 124 bytes; total grows by (124-40).
+        assert_eq!(v5.len(), dib.len() + (124 - 40));
+        let info = parse_dibv5(&v5).expect("parse v5");
+        assert_eq!((info.width, info.height, info.bpp), (2, 2, 32));
+        let back = dibv5_to_dib(&v5).expect("back");
+        assert_eq!(parse_dib(&back).unwrap().width, 2);
+    }
+}

--- a/crates/glass-clip-hook/src/dib.rs
+++ b/crates/glass-clip-hook/src/dib.rs
@@ -87,6 +87,9 @@ fn parse_with_header(b: &[u8], header_bytes: usize) -> Option<DibInfo> {
 pub(crate) fn parse_dib(b: &[u8]) -> Option<DibInfo> {
     parse_with_header(b, BIH)
 }
+/// Used by the host-side server path (DIBV5→DIB narrowing) and the tests; the DLL hook only ever
+/// widens DIB→DIBV5, so this is dead on a non-test DLL-only build.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn parse_dibv5(b: &[u8]) -> Option<DibInfo> {
     parse_with_header(b, BV5)
 }
@@ -103,6 +106,9 @@ pub(crate) fn dib_to_dibv5(b: &[u8]) -> Option<Vec<u8>> {
 }
 
 /// `CF_DIBV5` → `CF_DIB`: narrow the header back to 40 bytes; keep table + bits verbatim.
+///
+/// Used by the host-side server path + the tests; the DLL hook only ever widens DIB→DIBV5.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn dibv5_to_dib(b: &[u8]) -> Option<Vec<u8>> {
     let d = parse_dibv5(b)?;
     let mut out = vec![0u8; BIH];

--- a/crates/glass-clip-hook/src/hook.rs
+++ b/crates/glass-clip-hook/src/hook.rs
@@ -2,8 +2,10 @@
 //!
 //! Emulates a per-app clipboard backed by the host store. The detours NEVER call the real
 //! clipboard APIs (the box also has `OpenClipboard=n`), so the user's clipboard is untouched.
-//! v1: `CF_UNICODETEXT` (+ `CF_TEXT`/`CF_OEMTEXT` synthesized on read). Eager data only — delayed
-//! rendering (`SetClipboardData(_, NULL)`) and OLE are out of scope (documented limitation).
+//! v2: arbitrary `format → bytes` items captured into a pending set and committed atomically on
+//! `CloseClipboard`; on read we serve any stored format verbatim, or synthesize a derivative from
+//! its canonical stored form (text triad/LOCALE ← CF_UNICODETEXT; CF_BITMAP/DIBV5 ← CF_DIB). Eager
+//! data only — delayed rendering (`SetClipboardData(_, NULL)`) and OLE are out of scope.
 //!
 //! Compile-time verified by cross-compiling to `x86_64-pc-windows-gnu`. Runtime interception is
 //! finalized on a real Windows box (LOTUS); the detour table is authored complete so that on-box
@@ -24,23 +26,12 @@ use windows::Win32::System::Memory::{
     GlobalAlloc, GlobalLock, GlobalSize, GlobalUnlock, GMEM_MOVEABLE,
 };
 
-use crate::proto::{self, Request, Response};
+use crate::proto::{self, FormatKey, Request, Response};
 
 mod detour_impl;
 
-// CF_UNICODETEXT = 13, CF_TEXT = 1, CF_OEMTEXT = 7 (stable Win32 ABI ids).
-pub(crate) const CF_UNICODETEXT_ID: u32 = 13;
-pub(crate) const CF_TEXT_ID: u32 = 1;
-pub(crate) const CF_OEMTEXT_ID: u32 = 7;
-
 /// Resolved pipe path (`\\.\pipe\<GLASS_CLIP_PIPE>`). `None` ⇒ the DLL is inert.
 static PIPE: OnceLock<String> = OnceLock::new();
-
-/// True iff a text clipboard format. The three synthesized text formats are interchangeable on
-/// read (we down/up-convert UTF-16); only `CF_UNICODETEXT` is stored.
-pub(crate) fn is_text_format(fmt: u32) -> bool {
-    fmt == CF_UNICODETEXT_ID || fmt == CF_TEXT_ID || fmt == CF_OEMTEXT_ID
-}
 
 /// Called from `InjectDllMain`. Inert if `GLASS_CLIP_PIPE` is unset (only the target app's
 /// process tree carries it; every other boxed process loads this DLL but stays dormant).
@@ -141,7 +132,7 @@ fn read_response(h: HANDLE) -> Option<Response> {
     let mut len_buf = [0u8; 4];
     read_exact(h, &mut len_buf)?;
     let len = u32::from_le_bytes(len_buf) as usize;
-    if len > proto::MAX_TEXT_BYTES + 16 {
+    if len > proto::MAX_TOTAL_BYTES + 4096 {
         return None; // refuse absurd frames (matches proto::parse_frame's cap)
     }
     let mut body = vec![0u8; len];
@@ -170,15 +161,25 @@ fn read_exact(h: HANDLE, buf: &mut [u8]) -> Option<()> {
 // Host-store view used by the detours. Each is fail-soft (None / no-op on a down pipe).
 // ---------------------------------------------------------------------------------------------
 
-pub(crate) fn store_get() -> Option<String> {
-    match rpc(Request::Get)? {
-        Response::Text(t) => t,
-        _ => None,
+/// Ship one atomic multi-format copy to the host.
+pub(crate) fn store_set_all(items: Vec<(FormatKey, Vec<u8>)>) {
+    let _ = rpc(Request::SetAll(items));
+}
+
+/// The host's stored format keys (canonical only; synthesis is computed locally via `synth`).
+pub(crate) fn store_list() -> Vec<FormatKey> {
+    match rpc(Request::List) {
+        Some(Response::Formats(k)) => k,
+        _ => Vec::new(),
     }
 }
 
-pub(crate) fn store_set(s: &str) {
-    let _ = rpc(Request::Set(s.to_string()));
+/// One stored format's bytes from the host (no synthesis).
+pub(crate) fn store_get_bytes(key: &FormatKey) -> Option<Vec<u8>> {
+    match rpc(Request::Get(key.clone()))? {
+        Response::Bytes(b) => b,
+        _ => None,
+    }
 }
 
 pub(crate) fn store_empty() {
@@ -195,84 +196,58 @@ pub(crate) fn store_seq() -> u32 {
 }
 
 // ---------------------------------------------------------------------------------------------
-// HGLOBAL <-> text helpers used by SetClipboardData / GetClipboardData detours.
+// Generic HGLOBAL byte helpers + the one text code-page conversion, used by the detours.
 // ---------------------------------------------------------------------------------------------
 
-/// Read a UTF-16 string out of an app-provided `HGLOBAL` (as handed to `SetClipboardData`).
-/// Reads up to the first NUL (or the whole block if unterminated). `None` if lock fails / empty.
-pub(crate) fn read_utf16_from_hglobal(h: HGLOBAL) -> Option<String> {
-    // SAFETY: `h` is the handle the app passed to SetClipboardData; GlobalLock pins it and returns
-    // a pointer valid until GlobalUnlock. GlobalSize bounds the slice so we never read out of
-    // bounds; the NUL-terminated UTF-16 decode itself is pure + unit-tested (crate::text).
-    unsafe {
-        let ptr = GlobalLock(h) as *const u16;
-        if ptr.is_null() {
-            return None;
-        }
-        let units = GlobalSize(h) / 2;
-        let text = crate::text::utf16_nul_to_string(std::slice::from_raw_parts(ptr, units));
-        let _ = GlobalUnlock(h);
-        Some(text)
-    }
-}
-
-/// Read a single-byte (`CF_TEXT`/`CF_OEMTEXT`) string out of an app-provided `HGLOBAL`. v1 treats
-/// these as ANSI: each byte maps 1:1 to a `char` (Latin-1-ish), stopping at the first NUL.
-/// `None` if lock fails. Mirrors [`read_utf16_from_hglobal`].
-pub(crate) fn read_singlebyte_from_hglobal(h: HGLOBAL) -> Option<String> {
-    // SAFETY: as read_utf16_from_hglobal, single-byte: GlobalLock pins `h`, GlobalSize bounds the
-    // slice; the Latin-1 NUL-terminated decode is pure + unit-tested (crate::text).
+/// Copy the full contents of an app-provided `HGLOBAL` to a `Vec<u8>` (bounded by `GlobalSize`).
+pub(crate) fn read_bytes_from_hglobal(h: HGLOBAL) -> Option<Vec<u8>> {
+    // SAFETY: GlobalLock pins `h`; GlobalSize bounds the slice so we never read OOB; slice→Vec is safe.
     unsafe {
         let ptr = GlobalLock(h) as *const u8;
         if ptr.is_null() {
             return None;
         }
         let n = GlobalSize(h);
-        let text = crate::text::singlebyte_nul_to_string(std::slice::from_raw_parts(ptr, n));
+        let v = std::slice::from_raw_parts(ptr, n).to_vec();
         let _ = GlobalUnlock(h);
-        Some(text)
+        Some(v)
     }
 }
 
-/// Allocate a `GMEM_MOVEABLE` `HGLOBAL` and write `text` into it in the encoding `fmt` requires:
-/// UTF-16 (+ NUL) for `CF_UNICODETEXT`, single-byte (lossy) for `CF_TEXT`/`CF_OEMTEXT`. Returns
-/// the handle the caller must cache + eventually free; `None` on allocation failure.
-pub(crate) fn alloc_hglobal_for(fmt: u32, text: &str) -> Option<HGLOBAL> {
-    if fmt == CF_UNICODETEXT_ID {
-        let units = crate::text::string_to_utf16_nul(text);
-        let bytes = units.len() * 2;
-        // SAFETY: GlobalAlloc(GMEM_MOVEABLE) returns a movable handle; GlobalLock pins it to a
-        // writable pointer valid for `bytes`. We copy exactly `units.len()` u16s (== `bytes`) then
-        // unlock. On any failure we return None without leaking (alloc failed ⇒ nothing to free).
-        unsafe {
-            let h = GlobalAlloc(GMEM_MOVEABLE, bytes).ok()?;
-            let dst = GlobalLock(h) as *mut u16;
-            if dst.is_null() {
-                // SAFETY: we own `h` (alloc succeeded, not yet handed to caller); free to avoid leak.
-                let _ = GlobalFree(h);
-                return None;
-            }
-            std::ptr::copy_nonoverlapping(units.as_ptr(), dst, units.len());
-            let _ = GlobalUnlock(h);
-            Some(h)
+/// Allocate a `GMEM_MOVEABLE` `HGLOBAL` holding exactly `bytes`. Caller caches + frees it.
+pub(crate) fn alloc_hglobal_bytes(bytes: &[u8]) -> Option<HGLOBAL> {
+    // SAFETY: GlobalAlloc(GMEM_MOVEABLE) then GlobalLock to a writable ptr valid for bytes.len();
+    // copy exactly bytes.len(); unlock. Free on lock failure to avoid a leak.
+    unsafe {
+        let h = GlobalAlloc(GMEM_MOVEABLE, bytes.len()).ok()?;
+        let dst = GlobalLock(h) as *mut u8;
+        if dst.is_null() {
+            let _ = GlobalFree(h);
+            return None;
         }
-    } else {
-        // CF_TEXT / CF_OEMTEXT: down-convert to single-byte (non-ASCII → '?', lossy v1).
-        let bytes = crate::text::string_to_singlebyte_nul(text);
-        let n = bytes.len();
-        // SAFETY: as above, sized to `n` bytes; we copy exactly `n` bytes then unlock.
-        unsafe {
-            let h = GlobalAlloc(GMEM_MOVEABLE, n).ok()?;
-            let dst = GlobalLock(h) as *mut u8;
-            if dst.is_null() {
-                // SAFETY: we own `h` (alloc succeeded, not yet handed to caller); free to avoid leak.
-                let _ = GlobalFree(h);
-                return None;
-            }
-            std::ptr::copy_nonoverlapping(bytes.as_ptr(), dst, n);
-            let _ = GlobalUnlock(h);
-            Some(h)
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), dst, bytes.len());
+        let _ = GlobalUnlock(h);
+        Some(h)
+    }
+}
+
+/// CF_UNICODETEXT bytes → CF_TEXT/CF_OEMTEXT bytes via the real code page (ANSI/OEM).
+pub(crate) fn unicode_to_codepage(utf16_bytes: &[u8], oem: bool) -> Vec<u8> {
+    use windows::Win32::Globalization::{WideCharToMultiByte, CP_ACP, CP_OEMCP};
+    let units: Vec<u16> = utf16_bytes
+        .chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .collect();
+    let cp = if oem { CP_OEMCP } else { CP_ACP };
+    // SAFETY: two-call WideCharToMultiByte (size, then fill); `units` outlives both; output sized exactly.
+    unsafe {
+        let len = WideCharToMultiByte(cp, 0, &units, None, PCSTR::null(), None);
+        if len <= 0 {
+            return vec![0];
         }
+        let mut out = vec![0u8; len as usize];
+        WideCharToMultiByte(cp, 0, &units, Some(&mut out), PCSTR::null(), None);
+        out
     }
 }
 

--- a/crates/glass-clip-hook/src/hook/detour_impl.rs
+++ b/crates/glass-clip-hook/src/hook/detour_impl.rs
@@ -159,6 +159,7 @@ fn available_ids() -> Vec<u32> {
     crate::synth::available(&store_list())
         .iter()
         .map(id_of)
+        .filter(|&id| id != 0)
         .collect()
 }
 
@@ -198,6 +199,11 @@ fn make_bitmap_handle(dib: &[u8]) -> Option<HANDLE> {
     // sized by `info`. GetDC/ReleaseDC are paired.
     unsafe {
         let hdc = GetDC(None);
+        if hdc.is_invalid() {
+            // SAFETY: ReleaseDC on a null/invalid HDC is a safe no-op; bail rather than hand GDI a null DC.
+            ReleaseDC(None, hdc);
+            return None;
+        }
         let bmih = dib.as_ptr() as *const BITMAPINFOHEADER;
         let bits =
             dib.as_ptr().add(info.header_bytes + info.color_table_bytes) as *const core::ffi::c_void;

--- a/crates/glass-clip-hook/src/hook/detour_impl.rs
+++ b/crates/glass-clip-hook/src/hook/detour_impl.rs
@@ -10,15 +10,18 @@
 //! Compile-time verified by cross-compiling to `x86_64-pc-windows-gnu`. Whether the detours
 //! actually intercept at runtime is finalized on a real Windows box (LOTUS).
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 
 use retour::static_detour;
 use windows::Win32::Foundation::{GlobalFree, BOOL, HANDLE, HGLOBAL, HWND};
+use windows::Win32::Graphics::Gdi::{DeleteObject, HBITMAP, HGDIOBJ};
+use windows::Win32::System::DataExchange::{GetClipboardFormatNameW, RegisterClipboardFormatW};
+
+use crate::proto::FormatKey;
 
 use super::{
-    alloc_hglobal_for, is_text_format, read_singlebyte_from_hglobal, read_utf16_from_hglobal,
-    store_empty, store_get, store_seq, store_set, user32_proc, CF_OEMTEXT_ID, CF_TEXT_ID,
-    CF_UNICODETEXT_ID,
+    alloc_hglobal_bytes, read_bytes_from_hglobal, store_empty, store_get_bytes, store_list,
+    store_set_all, store_seq, unicode_to_codepage, user32_proc,
 };
 
 // Exact raw ABI signatures of the user32 exports (from windows-rs `link!` declarations).
@@ -45,6 +48,14 @@ static_detour! {
     static GetClipboardSequenceNumberHook: unsafe extern "system" fn() -> u32;
 }
 
+/// What kind of resource the cached handle is, so it is freed via the right Win32 destructor.
+#[derive(Clone, Copy, PartialEq)]
+enum HandleKind {
+    None,
+    Global,
+    Gdi,
+}
+
 thread_local! {
     /// Whether *this thread* currently holds the (emulated) clipboard open. Win32 clipboard
     /// ownership is thread-affine, so per-thread state matches the real semantics and avoids any
@@ -52,37 +63,154 @@ thread_local! {
     /// APIs would, but we stay permissive/fail-soft).
     static CLIP_OPEN: Cell<bool> = const { Cell::new(false) };
 
-    /// The last `HGLOBAL` returned from `GetClipboardData`. The Win32 contract says the *clipboard*
+    /// Formats `SetClipboardData`'d since the last `EmptyClipboard`, shipped as one atomic `SetAll`
+    /// at `CloseClipboard` (a multi-format copy = one transaction / one seq bump).
+    static PENDING: RefCell<Vec<(FormatKey, Vec<u8>)>> = const { RefCell::new(Vec::new()) };
+
+    /// The last handle returned from `GetClipboardData`. The Win32 contract says the *clipboard*
     /// owns that memory and the app must not free it; we own it instead and free it on the next
-    /// open/empty/close (whichever comes first). Stored as `isize` (the pointer bits) so the
+    /// open/empty/close (whichever comes first). Tagged by kind so an HGLOBAL is freed via
+    /// `GlobalFree` and a GDI HBITMAP via `DeleteObject`. Stored as `isize` (the handle bits) so the
     /// `thread_local!` needs no `unsafe`-Sync dance. A thread-local (not a global Mutex) because
     /// the handle is only ever produced + consumed on the clipboard-owning thread.
-    static LAST_HANDLE: Cell<isize> = const { Cell::new(0) };
+    static LAST_HANDLE: Cell<(isize, HandleKind)> = const { Cell::new((0, HandleKind::None)) };
 }
 
 /// Free + forget the cached `GetClipboardData` handle, if any. Called on open/empty/close.
 fn free_cached_handle() {
     LAST_HANDLE.with(|c| {
-        let raw = c.replace(0);
-        if raw != 0 {
-            // SAFETY: `raw` is an HGLOBAL we allocated in `alloc_hglobal_for` (GMEM_MOVEABLE) and
-            // handed out exactly once; freeing it here is the agreed ownership transfer. We zero
-            // the cell first so a re-entrant call cannot double-free.
-            unsafe {
+        // Zero the cell first so a re-entrant call cannot double-free.
+        let (raw, kind) = c.replace((0, HandleKind::None));
+        if raw == 0 {
+            return;
+        }
+        match kind {
+            // SAFETY: `raw` is an HGLOBAL we allocated in `alloc_hglobal_bytes` (GMEM_MOVEABLE) and
+            // handed out exactly once; freeing it here is the agreed ownership transfer.
+            HandleKind::Global => unsafe {
                 let _ = GlobalFree(HGLOBAL(raw as *mut _));
-            }
+            },
+            // SAFETY: `raw` is a GDI HBITMAP we created in `make_bitmap_handle` and handed out once;
+            // DeleteObject is the matching destructor.
+            HandleKind::Gdi => unsafe {
+                let _ = DeleteObject(HGDIOBJ(raw as *mut _));
+            },
+            HandleKind::None => {}
         }
     });
 }
 
-/// Cache a freshly-allocated handle to be freed on the next open/empty/close.
+/// Cache a freshly-allocated HGLOBAL to be freed (via `GlobalFree`) on the next open/empty/close.
 ///
-/// NOTE: we free the previous handle on the NEXT `GetClipboardData` (via `cache_handle` →
+/// NOTE: we free the previous handle on the NEXT `GetClipboardData` (via `cache_*` →
 /// `free_cached_handle`) as well as on open/empty/close — slightly narrower than the Win32
 /// "valid until CloseClipboard" contract, but fine for the lock-copy-unlock pattern apps use.
-fn cache_handle(h: HGLOBAL) {
+fn cache_global(h: HGLOBAL) {
     free_cached_handle(); // never leak a prior one
-    LAST_HANDLE.with(|c| c.set(h.0 as isize));
+    LAST_HANDLE.with(|c| c.set((h.0 as isize, HandleKind::Global)));
+}
+
+/// Cache a freshly-created GDI HBITMAP to be freed (via `DeleteObject`) on the next open/empty/close.
+fn cache_bitmap(h: HBITMAP) {
+    free_cached_handle(); // never leak a prior one
+    LAST_HANDLE.with(|c| c.set((h.0 as isize, HandleKind::Gdi)));
+}
+
+// ---- format id <-> FormatKey + synthesis -----------------------------------------------------
+
+// Standard Win32 clipboard format ids (stable ABI).
+const CF_TEXT: u32 = 1;
+const CF_BITMAP: u32 = 2;
+const CF_OEMTEXT: u32 = 7;
+const CF_LOCALE: u32 = 16;
+const CF_DIBV5: u32 = 17;
+
+/// Raw clipboard id → `FormatKey`: a registered (>=0xC000) id resolves to its NAME (portable across
+/// processes), everything else stays a `Standard` id.
+fn key_of(id: u32) -> FormatKey {
+    if id >= 0xC000 {
+        let mut buf = [0u16; 256];
+        // SAFETY: GetClipboardFormatNameW writes up to buf.len() chars into `buf` and returns the
+        // count (0 on failure); the slice bounds the read.
+        let n = unsafe { GetClipboardFormatNameW(id, &mut buf) };
+        if n > 0 {
+            return FormatKey::Named(String::from_utf16_lossy(&buf[..n as usize]));
+        }
+    }
+    FormatKey::Standard(id)
+}
+
+/// `FormatKey` → this process's clipboard id (re-registering named formats so the id is valid here).
+fn id_of(key: &FormatKey) -> u32 {
+    match key {
+        FormatKey::Standard(id) => *id,
+        FormatKey::Named(name) => {
+            let w: Vec<u16> = name.encode_utf16().chain(std::iter::once(0)).collect();
+            // SAFETY: `w` is a NUL-terminated UTF-16 buffer that outlives the call;
+            // RegisterClipboardFormatW returns this session's id for that name.
+            unsafe { RegisterClipboardFormatW(windows::core::PCWSTR::from_raw(w.as_ptr())) }
+        }
+    }
+}
+
+/// The clipboard ids currently available to the app: the stored canonical set plus locally
+/// synthesizable derivatives (`synth::available`), each mapped to this process's id.
+fn available_ids() -> Vec<u32> {
+    crate::synth::available(&store_list())
+        .iter()
+        .map(id_of)
+        .collect()
+}
+
+/// Bytes for `fmt`: stored verbatim, or synthesized from the canonical stored format.
+fn resolve_bytes(fmt: u32, key: &FormatKey) -> Option<Vec<u8>> {
+    if let Some(b) = store_get_bytes(key) {
+        return Some(b);
+    }
+    let canon = crate::synth::canonical_for(key)?;
+    let src = store_get_bytes(&canon)?;
+    Some(match fmt {
+        CF_TEXT => unicode_to_codepage(&src, false),
+        CF_OEMTEXT => unicode_to_codepage(&src, true),
+        CF_LOCALE => locale_blob(),
+        CF_DIBV5 => crate::dib::dib_to_dibv5(&src)?,
+        CF_BITMAP => src, // handed to make_bitmap_handle by the caller
+        _ => return None,
+    })
+}
+
+/// The 4-byte `CF_LOCALE` blob: the user's default LCID (little-endian).
+fn locale_blob() -> Vec<u8> {
+    use windows::Win32::Globalization::GetUserDefaultLCID;
+    // SAFETY: GetUserDefaultLCID takes no args and returns the LCID.
+    let lcid = unsafe { GetUserDefaultLCID() };
+    lcid.to_le_bytes().to_vec()
+}
+
+/// Build a GDI `HBITMAP` from a validated `CF_DIB` blob. Cached + freed via `DeleteObject`.
+fn make_bitmap_handle(dib: &[u8]) -> Option<HANDLE> {
+    use windows::Win32::Graphics::Gdi::{
+        CreateDIBitmap, GetDC, ReleaseDC, BITMAPINFO, BITMAPINFOHEADER, CBM_INIT, DIB_RGB_COLORS,
+    };
+    let info = crate::dib::parse_dib(dib)?; // validated geometry → bounds-safe offsets
+    // SAFETY: `dib` parsed clean (header + table + bits within bounds). The header ptr is read as a
+    // BITMAPINFOHEADER/BITMAPINFO; `bits` = dib + header_bytes + color_table_bytes is in-bounds and
+    // sized by `info`. GetDC/ReleaseDC are paired.
+    unsafe {
+        let hdc = GetDC(None);
+        let bmih = dib.as_ptr() as *const BITMAPINFOHEADER;
+        let bits =
+            dib.as_ptr().add(info.header_bytes + info.color_table_bytes) as *const core::ffi::c_void;
+        let bmi = dib.as_ptr() as *const BITMAPINFO;
+        let hbm = CreateDIBitmap(hdc, Some(bmih), CBM_INIT as u32, Some(bits), Some(bmi), DIB_RGB_COLORS);
+        ReleaseDC(None, hdc);
+        if hbm.is_invalid() {
+            None
+        } else {
+            cache_bitmap(hbm);
+            Some(HANDLE(hbm.0))
+        }
+    }
 }
 
 // ---- detour bodies ---------------------------------------------------------------------------
@@ -104,19 +232,25 @@ fn open_clipboard(_hwnd: HWND) -> BOOL {
     .unwrap_or(BOOL(0))
 }
 
-/// `CloseClipboard()` → mark closed; free the cached handle. Always succeed.
+/// `CloseClipboard()` → mark closed; commit the pending multi-format copy as one atomic `SetAll`
+/// (one transaction / one seq bump); free the cached handle. Always succeed.
 fn close_clipboard() -> BOOL {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         CLIP_OPEN.with(|c| c.set(false));
+        let items = PENDING.with(|p| std::mem::take(&mut *p.borrow_mut()));
+        if !items.is_empty() {
+            store_set_all(items);
+        }
         free_cached_handle();
         BOOL(1)
     }))
     .unwrap_or(BOOL(0))
 }
 
-/// `EmptyClipboard()` → clear the host store; free the cached handle. Always succeed.
+/// `EmptyClipboard()` → drop any pending copy, clear the host store, free the cached handle.
 fn empty_clipboard() -> BOOL {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        PENDING.with(|p| p.borrow_mut().clear());
         store_empty();
         free_cached_handle();
         BOOL(1)
@@ -124,47 +258,43 @@ fn empty_clipboard() -> BOOL {
     .unwrap_or(BOOL(0))
 }
 
-/// `SetClipboardData(fmt, h)` → for text formats with a non-NULL handle, read the text in the
-/// format's own encoding and store it. Returns `h` (the contract: the clipboard now "owns" it; we
-/// keep the store as the source of truth). `h == NULL` is delayed rendering — out of scope in v1:
-/// return NULL, no change. Non-text formats are ignored (return the handle unchanged).
-///
-/// v1 text-format handling: `CF_UNICODETEXT` reads as UTF-16; `CF_TEXT`/`CF_OEMTEXT` read as
-/// single-byte ANSI (the app's buffer is single-byte — reading it as UTF-16 would garble it).
+/// `SetClipboardData(fmt, h)` → capture the format's bytes from the app's `HGLOBAL` into the pending
+/// set (committed atomically on `CloseClipboard`). Returns `h` (the contract: the clipboard now
+/// "owns" it; we keep the store as the source of truth). `h == NULL` is delayed rendering — out of
+/// scope (OLE apps covered separately in 2a-ii): skip, no change.
 fn set_clipboard_data(fmt: u32, h: HANDLE) -> HANDLE {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         if h.0.is_null() {
-            return HANDLE::default(); // delayed rendering unsupported (v1)
+            return HANDLE::default(); // delayed rendering unsupported
         }
-        let text = if fmt == CF_UNICODETEXT_ID {
-            read_utf16_from_hglobal(HGLOBAL(h.0))
-        } else if fmt == CF_TEXT_ID || fmt == CF_OEMTEXT_ID {
-            read_singlebyte_from_hglobal(HGLOBAL(h.0))
-        } else {
-            None // non-text format: ignore
-        };
-        if let Some(text) = text {
-            store_set(&text);
+        if let Some(bytes) = read_bytes_from_hglobal(HGLOBAL(h.0)) {
+            let key = key_of(fmt);
+            PENDING.with(|p| {
+                let mut v = p.borrow_mut();
+                v.retain(|(k, _)| *k != key); // last write wins per format
+                v.push((key, bytes));
+            });
         }
         h
     }))
     .unwrap_or(HANDLE::default())
 }
 
-/// `GetClipboardData(fmt)` → for text formats, allocate a fresh `HGLOBAL` in the requested encoding
-/// from the host store, cache it (so the app needn't free it; we free on next open/empty/close),
-/// and return it. NULL if the store is empty, the format is non-text, or the pipe is down.
+/// `GetClipboardData(fmt)` → resolve the format's bytes (stored verbatim or synthesized), then hand
+/// back a handle the app needn't free (we free on next open/empty/close): a GDI `HBITMAP` for
+/// `CF_BITMAP`, otherwise a fresh `HGLOBAL`. NULL if unavailable or the pipe is down.
 fn get_clipboard_data(fmt: u32) -> HANDLE {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        if !is_text_format(fmt) {
-            return HANDLE::default();
-        }
-        let Some(text) = store_get() else {
+        let key = key_of(fmt);
+        let Some(bytes) = resolve_bytes(fmt, &key) else {
             return HANDLE::default();
         };
-        match alloc_hglobal_for(fmt, &text) {
+        if fmt == CF_BITMAP {
+            return make_bitmap_handle(&bytes).unwrap_or_default();
+        }
+        match alloc_hglobal_bytes(&bytes) {
             Some(h) => {
-                cache_handle(h);
+                cache_global(h);
                 HANDLE(h.0)
             }
             None => HANDLE::default(),
@@ -173,33 +303,34 @@ fn get_clipboard_data(fmt: u32) -> HANDLE {
     .unwrap_or(HANDLE::default())
 }
 
-/// `IsClipboardFormatAvailable(fmt)` → TRUE iff a text format and the store is non-empty.
+/// `IsClipboardFormatAvailable(fmt)` → TRUE iff `fmt` is among the stored/synthesizable formats.
 fn is_clipboard_format_available(fmt: u32) -> BOOL {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        BOOL((is_text_format(fmt) && store_get().is_some()) as i32)
+        BOOL(available_ids().contains(&fmt) as i32)
     }))
     .unwrap_or(BOOL(0))
 }
 
-/// `CountClipboardFormats()` → 2 (CF_UNICODETEXT + CF_TEXT) when the store has text, else 0.
+/// `CountClipboardFormats()` → the number of stored/synthesizable formats.
 fn count_clipboard_formats() -> i32 {
-    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        if store_get().is_some() {
-            2
-        } else {
-            0
-        }
-    }))
-    .unwrap_or(0)
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| available_ids().len() as i32))
+        .unwrap_or(0)
 }
 
-/// `EnumClipboardFormats(prev)` → enumerate our synthesized text formats:
-/// 0 → CF_UNICODETEXT; CF_UNICODETEXT → CF_TEXT; anything else → 0 (end of list).
+/// `EnumClipboardFormats(prev)` → walk the stored/synthesizable formats in order: `0` yields the
+/// first; otherwise the one after `prev`; `0` again at the end of the list.
 fn enum_clipboard_formats(prev: u32) -> u32 {
-    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| match prev {
-        0 => CF_UNICODETEXT_ID,
-        CF_UNICODETEXT_ID => CF_TEXT_ID,
-        _ => 0,
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let ids = available_ids();
+        match prev {
+            0 => ids.first().copied().unwrap_or(0),
+            _ => ids
+                .iter()
+                .position(|&x| x == prev)
+                .and_then(|i| ids.get(i + 1))
+                .copied()
+                .unwrap_or(0),
+        }
     }))
     .unwrap_or(0)
 }

--- a/crates/glass-clip-hook/src/lib.rs
+++ b/crates/glass-clip-hook/src/lib.rs
@@ -18,6 +18,9 @@ mod text;
 #[cfg(any(windows, test))]
 mod dib;
 
+#[cfg(any(windows, test))]
+mod synth;
+
 #[cfg(windows)]
 mod hook;
 

--- a/crates/glass-clip-hook/src/lib.rs
+++ b/crates/glass-clip-hook/src/lib.rs
@@ -15,6 +15,9 @@ pub mod store;
 #[cfg(any(windows, test))]
 mod text;
 
+#[cfg(any(windows, test))]
+mod dib;
+
 #[cfg(windows)]
 mod hook;
 

--- a/crates/glass-clip-hook/src/proto.rs
+++ b/crates/glass-clip-hook/src/proto.rs
@@ -310,6 +310,42 @@ mod tests {
     }
 
     #[test]
+    fn rejects_oversize_item_count() {
+        // count > 4096 is rejected BEFORE any per-item allocation (no pre-alloc amplification).
+        let mut b = vec![VERSION, 1 /*SetAll*/];
+        b.extend_from_slice(&5000u32.to_le_bytes()); // huge count, no item bytes follow
+        assert!(matches!(Request::decode(&b), Err(ProtoError::TooLarge(_))));
+        // same guard on the Formats response.
+        let mut f = vec![VERSION, 1 /*Formats*/];
+        f.extend_from_slice(&5000u32.to_le_bytes());
+        assert!(matches!(Response::decode(&f), Err(ProtoError::TooLarge(_))));
+    }
+
+    #[test]
+    fn rejects_oversize_name() {
+        // a Named key length over MAX_NAME_BYTES is rejected before the name bytes are read.
+        let mut b = vec![VERSION, 3 /*Get*/, 1 /*Named*/];
+        b.extend_from_slice(&((MAX_NAME_BYTES + 1) as u32).to_le_bytes());
+        assert!(matches!(Request::decode(&b), Err(ProtoError::TooLarge(_))));
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // ~96 MiB buffer — too slow under the Miri interpreter
+    fn rejects_oversize_total() {
+        // 3 items each just under MAX_ITEM_BYTES → aggregate exceeds MAX_TOTAL_BYTES.
+        let chunk = MAX_ITEM_BYTES - 1;
+        let mut b = vec![VERSION, 1 /*SetAll*/];
+        b.extend_from_slice(&3u32.to_le_bytes());
+        for _ in 0..3 {
+            b.push(0); // Standard
+            b.extend_from_slice(&1u32.to_le_bytes()); // id
+            b.extend_from_slice(&(chunk as u32).to_le_bytes());
+            b.resize(b.len() + chunk, 0u8);
+        }
+        assert!(matches!(Request::decode(&b), Err(ProtoError::TooLarge(_))));
+    }
+
+    #[test]
     fn frame_then_parse_round_trips() {
         let payload = Request::SetAll(sample()).encode();
         let framed = frame(&payload);

--- a/crates/glass-clip-hook/src/proto.rs
+++ b/crates/glass-clip-hook/src/proto.rs
@@ -1,23 +1,38 @@
-//! Wire protocol between the injected hook DLL (client) and the host store server.
+//! Wire protocol between the injected hook DLL (client) and the host store server. v2 carries
+//! arbitrary clipboard formats as `(FormatKey, bytes)` items; registered formats are keyed by NAME
+//! (the per-session 0xC000+ ids aren't portable across processes).
 
-/// Protocol version. Bumped on any wire-format change; a mismatch is rejected (never guessed).
-pub const VERSION: u8 = 1;
+/// Bumped on any wire-format change; a mismatch is rejected (never guessed).
+pub const VERSION: u8 = 2;
 
-/// Hard cap on a single text payload (1 MiB of UTF-8). Larger `Set`s are rejected by the
-/// reader, not truncated — no silent loss.
-pub const MAX_TEXT_BYTES: usize = 1 << 20;
+/// Per-item byte cap (32 MiB — large enough for images). Oversize is rejected, never truncated.
+pub const MAX_ITEM_BYTES: usize = 32 << 20;
+/// Aggregate cap across one SetAll/Items message.
+pub const MAX_TOTAL_BYTES: usize = 64 << 20;
+/// Cap on a registered-format NAME (UTF-8 bytes).
+pub const MAX_NAME_BYTES: usize = 256;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FormatKey {
+    Standard(u32),
+    Named(String),
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Request {
-    Get,
-    Set(String),
+    SetAll(Vec<(FormatKey, Vec<u8>)>),
+    List,
+    Get(FormatKey),
+    GetAll,
     Empty,
     Seq,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Response {
-    Text(Option<String>),
+    Formats(Vec<FormatKey>),
+    Bytes(Option<Vec<u8>>),
+    Items(Vec<(FormatKey, Vec<u8>)>),
     Ok,
     Seq(u64),
 }
@@ -31,96 +46,185 @@ pub enum ProtoError {
     Utf8,
 }
 
-fn put_str(out: &mut Vec<u8>, s: &str) {
-    let b = s.as_bytes();
-    out.extend_from_slice(&(b.len() as u32).to_le_bytes());
-    out.extend_from_slice(b);
+struct Reader<'a> {
+    b: &'a [u8],
+    i: usize,
+}
+impl<'a> Reader<'a> {
+    fn new(b: &'a [u8]) -> Self {
+        Self { b, i: 0 }
+    }
+    fn u8(&mut self) -> Result<u8, ProtoError> {
+        let v = *self.b.get(self.i).ok_or(ProtoError::Truncated)?;
+        self.i += 1;
+        Ok(v)
+    }
+    fn u32(&mut self) -> Result<u32, ProtoError> {
+        let s = self.b.get(self.i..self.i + 4).ok_or(ProtoError::Truncated)?;
+        self.i += 4;
+        Ok(u32::from_le_bytes([s[0], s[1], s[2], s[3]]))
+    }
+    fn u64(&mut self) -> Result<u64, ProtoError> {
+        let s = self.b.get(self.i..self.i + 8).ok_or(ProtoError::Truncated)?;
+        self.i += 8;
+        let mut a = [0u8; 8];
+        a.copy_from_slice(s);
+        Ok(u64::from_le_bytes(a))
+    }
+    fn bytes(&mut self, cap: usize) -> Result<Vec<u8>, ProtoError> {
+        let n = self.u32()? as usize;
+        if n > cap {
+            return Err(ProtoError::TooLarge(n));
+        }
+        let s = self.b.get(self.i..self.i + n).ok_or(ProtoError::Truncated)?;
+        self.i += n;
+        Ok(s.to_vec())
+    }
+    fn key(&mut self) -> Result<FormatKey, ProtoError> {
+        match self.u8()? {
+            0 => Ok(FormatKey::Standard(self.u32()?)),
+            1 => {
+                let b = self.bytes(MAX_NAME_BYTES)?;
+                Ok(FormatKey::Named(String::from_utf8(b).map_err(|_| ProtoError::Utf8)?))
+            }
+            t => Err(ProtoError::BadTag(t)),
+        }
+    }
+    fn items(&mut self) -> Result<Vec<(FormatKey, Vec<u8>)>, ProtoError> {
+        let count = self.u32()? as usize;
+        if count > 4096 {
+            return Err(ProtoError::TooLarge(count));
+        }
+        let mut out = Vec::new();
+        let mut total = 0usize;
+        for _ in 0..count {
+            let k = self.key()?;
+            let v = self.bytes(MAX_ITEM_BYTES)?;
+            total = total.saturating_add(v.len());
+            if total > MAX_TOTAL_BYTES {
+                return Err(ProtoError::TooLarge(total));
+            }
+            out.push((k, v));
+        }
+        Ok(out)
+    }
 }
 
-fn take_str(buf: &[u8]) -> Result<String, ProtoError> {
-    if buf.len() < 4 {
-        return Err(ProtoError::Truncated);
+fn put_u32(o: &mut Vec<u8>, v: u32) {
+    o.extend_from_slice(&v.to_le_bytes());
+}
+fn put_bytes(o: &mut Vec<u8>, b: &[u8]) {
+    put_u32(o, b.len() as u32);
+    o.extend_from_slice(b);
+}
+fn put_key(o: &mut Vec<u8>, k: &FormatKey) {
+    match k {
+        FormatKey::Standard(id) => {
+            o.push(0);
+            put_u32(o, *id);
+        }
+        FormatKey::Named(s) => {
+            o.push(1);
+            put_bytes(o, s.as_bytes());
+        }
     }
-    let n = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]) as usize;
-    if n > MAX_TEXT_BYTES {
-        return Err(ProtoError::TooLarge(n));
+}
+fn put_items(o: &mut Vec<u8>, items: &[(FormatKey, Vec<u8>)]) {
+    put_u32(o, items.len() as u32);
+    for (k, v) in items {
+        put_key(o, k);
+        put_bytes(o, v);
     }
-    let body = &buf[4..];
-    if body.len() < n {
-        return Err(ProtoError::Truncated);
-    }
-    String::from_utf8(body[..n].to_vec()).map_err(|_| ProtoError::Utf8)
 }
 
 impl Request {
     pub fn encode(&self) -> Vec<u8> {
-        let mut out = vec![VERSION];
+        let mut o = vec![VERSION];
         match self {
-            Request::Get => out.push(1),
-            Request::Empty => out.push(2),
-            Request::Set(s) => {
-                out.push(3);
-                put_str(&mut out, s);
+            Request::SetAll(items) => {
+                o.push(1);
+                put_items(&mut o, items);
             }
-            Request::Seq => out.push(4),
+            Request::List => o.push(2),
+            Request::Get(k) => {
+                o.push(3);
+                put_key(&mut o, k);
+            }
+            Request::GetAll => o.push(4),
+            Request::Empty => o.push(5),
+            Request::Seq => o.push(6),
         }
-        out
+        o
     }
-
-    pub fn decode(bytes: &[u8]) -> Result<Request, ProtoError> {
-        if bytes.len() < 2 {
-            return Err(ProtoError::Truncated);
+    pub fn decode(b: &[u8]) -> Result<Request, ProtoError> {
+        let mut r = Reader::new(b);
+        if r.u8()? != VERSION {
+            return Err(ProtoError::Version(b[0]));
         }
-        if bytes[0] != VERSION {
-            return Err(ProtoError::Version(bytes[0]));
-        }
-        match bytes[1] {
-            1 => Ok(Request::Get),
-            2 => Ok(Request::Empty),
-            3 => Ok(Request::Set(take_str(&bytes[2..])?)),
-            4 => Ok(Request::Seq),
-            t => Err(ProtoError::BadTag(t)),
-        }
+        Ok(match r.u8()? {
+            1 => Request::SetAll(r.items()?),
+            2 => Request::List,
+            3 => Request::Get(r.key()?),
+            4 => Request::GetAll,
+            5 => Request::Empty,
+            6 => Request::Seq,
+            t => return Err(ProtoError::BadTag(t)),
+        })
     }
 }
 
 impl Response {
     pub fn encode(&self) -> Vec<u8> {
-        let mut out = vec![VERSION];
+        let mut o = vec![VERSION];
         match self {
-            Response::Text(None) => out.push(1),
-            Response::Text(Some(s)) => {
-                out.push(2);
-                put_str(&mut out, s);
+            Response::Formats(keys) => {
+                o.push(1);
+                put_u32(&mut o, keys.len() as u32);
+                for k in keys {
+                    put_key(&mut o, k);
+                }
             }
-            Response::Ok => out.push(3),
+            Response::Bytes(None) => o.push(2),
+            Response::Bytes(Some(v)) => {
+                o.push(3);
+                put_bytes(&mut o, v);
+            }
+            Response::Items(items) => {
+                o.push(4);
+                put_items(&mut o, items);
+            }
+            Response::Ok => o.push(5),
             Response::Seq(n) => {
-                out.push(4);
-                out.extend_from_slice(&n.to_le_bytes());
+                o.push(6);
+                o.extend_from_slice(&n.to_le_bytes());
             }
         }
-        out
+        o
     }
-
-    pub fn decode(bytes: &[u8]) -> Result<Response, ProtoError> {
-        if bytes.len() < 2 {
-            return Err(ProtoError::Truncated);
+    pub fn decode(b: &[u8]) -> Result<Response, ProtoError> {
+        let mut r = Reader::new(b);
+        if r.u8()? != VERSION {
+            return Err(ProtoError::Version(b[0]));
         }
-        if bytes[0] != VERSION {
-            return Err(ProtoError::Version(bytes[0]));
-        }
-        match bytes[1] {
-            1 => Ok(Response::Text(None)),
-            2 => Ok(Response::Text(Some(take_str(&bytes[2..])?))),
-            3 => Ok(Response::Ok),
-            4 => {
-                let b = bytes.get(2..10).ok_or(ProtoError::Truncated)?;
-                let mut a = [0u8; 8];
-                a.copy_from_slice(b);
-                Ok(Response::Seq(u64::from_le_bytes(a)))
+        Ok(match r.u8()? {
+            1 => {
+                let n = r.u32()? as usize;
+                if n > 4096 {
+                    return Err(ProtoError::TooLarge(n));
+                }
+                let mut keys = Vec::new();
+                for _ in 0..n {
+                    keys.push(r.key()?);
+                }
+                Response::Formats(keys)
             }
-            t => Err(ProtoError::BadTag(t)),
-        }
+            2 => Response::Bytes(None),
+            3 => Response::Bytes(Some(r.bytes(MAX_ITEM_BYTES)?)),
+            4 => Response::Items(r.items()?),
+            5 => Response::Ok,
+            6 => Response::Seq(r.u64()?),
+            t => return Err(ProtoError::BadTag(t)),
+        })
     }
 }
 
@@ -132,13 +236,13 @@ pub fn frame(body: &[u8]) -> Vec<u8> {
     out
 }
 
-/// Parse one length-prefixed frame, returning (body, remaining). Errors if incomplete.
+/// Parse one length-prefixed frame, returning (body, remaining). Errors if incomplete/oversize.
 pub fn parse_frame(buf: &[u8]) -> Result<(Vec<u8>, &[u8]), ProtoError> {
     if buf.len() < 4 {
         return Err(ProtoError::Truncated);
     }
     let n = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]) as usize;
-    if n > MAX_TEXT_BYTES + 16 {
+    if n > MAX_TOTAL_BYTES + 4096 {
         return Err(ProtoError::TooLarge(n));
     }
     let body = buf.get(4..4 + n).ok_or(ProtoError::Truncated)?;
@@ -149,46 +253,65 @@ pub fn parse_frame(buf: &[u8]) -> Result<(Vec<u8>, &[u8]), ProtoError> {
 mod tests {
     use super::*;
 
+    fn sample() -> Vec<(FormatKey, Vec<u8>)> {
+        vec![
+            (FormatKey::Standard(13), b"\x68\x00\x69\x00\x00\x00".to_vec()), // CF_UNICODETEXT "hi"
+            (FormatKey::Named("HTML Format".into()), b"<b>hi</b>".to_vec()),
+        ]
+    }
+
     #[test]
     fn request_round_trips() {
-        for r in [Request::Get, Request::Empty, Request::Seq, Request::Set("héllo 世界".into())] {
-            let bytes = r.encode();
-            assert_eq!(Request::decode(&bytes).unwrap(), r);
+        for r in [
+            Request::List,
+            Request::GetAll,
+            Request::Empty,
+            Request::Seq,
+            Request::Get(FormatKey::Standard(13)),
+            Request::Get(FormatKey::Named("PNG".into())),
+            Request::SetAll(sample()),
+        ] {
+            assert_eq!(Request::decode(&r.encode()).unwrap(), r);
         }
     }
 
     #[test]
     fn response_round_trips() {
         for r in [
-            Response::Text(None),
-            Response::Text(Some("abc".into())),
             Response::Ok,
             Response::Seq(42),
+            Response::Bytes(None),
+            Response::Bytes(Some(b"abc".to_vec())),
+            Response::Formats(vec![FormatKey::Standard(13), FormatKey::Named("HTML Format".into())]),
+            Response::Items(sample()),
         ] {
-            let bytes = r.encode();
-            assert_eq!(Response::decode(&bytes).unwrap(), r);
+            assert_eq!(Response::decode(&r.encode()).unwrap(), r);
         }
     }
 
     #[test]
-    fn rejects_version_skew() {
-        let mut bytes = Request::Get.encode();
-        bytes[0] = VERSION ^ 0xFF; // corrupt the version byte
-        assert!(matches!(Request::decode(&bytes), Err(ProtoError::Version(_))));
+    fn rejects_version_skew_truncation_bad_tag() {
+        let mut b = Request::List.encode();
+        b[0] = VERSION ^ 0xFF;
+        assert!(matches!(Request::decode(&b), Err(ProtoError::Version(_))));
+        assert!(Request::decode(&[]).is_err());
+        assert!(Request::decode(&[VERSION]).is_err());
+        assert!(Request::decode(&[VERSION, 0x7F]).is_err());
     }
 
     #[test]
-    fn rejects_truncated_and_bad_tag() {
-        assert!(Request::decode(&[]).is_err());
-        assert!(Request::decode(&[VERSION]).is_err()); // version only, no tag
-        assert!(Request::decode(&[VERSION, 0x7F]).is_err()); // unknown tag
-        // truncated Set: version+tag+len says 5 but no bytes follow
-        assert!(Request::decode(&[VERSION, 3, 5, 0, 0, 0]).is_err());
+    fn rejects_oversize_item() {
+        let mut b = vec![VERSION, 1 /*SetAll*/];
+        b.extend_from_slice(&1u32.to_le_bytes()); // 1 item
+        b.push(0); // FormatKey tag Standard
+        b.extend_from_slice(&13u32.to_le_bytes());
+        b.extend_from_slice(&((MAX_ITEM_BYTES + 1) as u32).to_le_bytes()); // bytes len too big
+        assert!(matches!(Request::decode(&b), Err(ProtoError::TooLarge(_))));
     }
 
     #[test]
     fn frame_then_parse_round_trips() {
-        let payload = Request::Set("x".into()).encode();
+        let payload = Request::SetAll(sample()).encode();
         let framed = frame(&payload);
         let (got, rest) = parse_frame(&framed).unwrap();
         assert_eq!(got, payload);

--- a/crates/glass-clip-hook/src/store.rs
+++ b/crates/glass-clip-hook/src/store.rs
@@ -1,17 +1,21 @@
-//! Host-owned private clipboard store (pure; no Win32).
+//! Host-owned private clipboard store (pure; no Win32). Holds an ordered set of
+//! `(FormatKey, bytes)` items (source priority order: most-descriptive first) + a sequence number.
 
 use std::sync::{Arc, Mutex};
 
-use crate::proto::{Request, Response};
+use crate::proto::{FormatKey, Request, Response};
+
+#[cfg(any(windows, test))]
+const CF_UNICODETEXT: u32 = 13;
 
 #[derive(Default)]
 struct ClipboardState {
-    text: Option<String>,
+    items: Vec<(FormatKey, Vec<u8>)>,
     seq: u64,
 }
 
-/// The single source of truth for a contained app's clipboard, shared (cloned `Arc`) between
-/// the pipe server thread and the platform's `get/set_clipboard`. Pure — no Win32.
+/// The single source of truth for a contained app's clipboard, shared (cloned `Arc`) between the
+/// pipe server thread and the platform's `get/set_clipboard`. Pure — no Win32.
 #[derive(Clone, Default)]
 pub struct PrivateClipboard(Arc<Mutex<ClipboardState>>);
 
@@ -20,19 +24,28 @@ impl PrivateClipboard {
         Self::default()
     }
 
-    pub fn get(&self) -> Option<String> {
-        self.0.lock().expect("clip mutex").text.clone()
+    pub fn set_all(&self, items: Vec<(FormatKey, Vec<u8>)>) {
+        let mut g = self.0.lock().expect("clip mutex");
+        g.items = items;
+        g.seq = g.seq.wrapping_add(1);
     }
 
-    pub fn set(&self, text: String) {
-        let mut g = self.0.lock().expect("clip mutex");
-        g.text = Some(text);
-        g.seq = g.seq.wrapping_add(1);
+    pub fn list(&self) -> Vec<FormatKey> {
+        self.0.lock().expect("clip mutex").items.iter().map(|(k, _)| k.clone()).collect()
+    }
+
+    pub fn get(&self, key: &FormatKey) -> Option<Vec<u8>> {
+        let g = self.0.lock().expect("clip mutex");
+        g.items.iter().find(|(k, _)| k == key).map(|(_, v)| v.clone())
+    }
+
+    pub fn get_all(&self) -> Vec<(FormatKey, Vec<u8>)> {
+        self.0.lock().expect("clip mutex").items.clone()
     }
 
     pub fn empty(&self) {
         let mut g = self.0.lock().expect("clip mutex");
-        g.text = None;
+        g.items.clear();
         g.seq = g.seq.wrapping_add(1);
     }
 
@@ -40,15 +53,38 @@ impl PrivateClipboard {
         self.0.lock().expect("clip mutex").seq
     }
 
-    /// Apply a wire request, returning the wire response. The single place the server maps
-    /// protocol → state, so the hook DLL and `glass_clipboard_*` stay consistent.
+    /// Convenience for the agent's text path: write a single `CF_UNICODETEXT` item (UTF-16 + NUL).
+    #[cfg(any(windows, test))]
+    pub fn set_text(&self, text: &str) {
+        let bytes: Vec<u8> = crate::text::string_to_utf16_nul(text)
+            .iter()
+            .flat_map(|u| u.to_le_bytes())
+            .collect();
+        self.set_all(vec![(FormatKey::Standard(CF_UNICODETEXT), bytes)]);
+    }
+
+    /// Convenience: read the `CF_UNICODETEXT` item as a `String` (NUL-terminated UTF-16), if present.
+    #[cfg(any(windows, test))]
+    pub fn get_text(&self) -> Option<String> {
+        let bytes = self.get(&FormatKey::Standard(CF_UNICODETEXT))?;
+        let units: Vec<u16> = bytes
+            .chunks_exact(2)
+            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .collect();
+        Some(crate::text::utf16_nul_to_string(&units))
+    }
+
+    /// The single place the server maps protocol → state, so the hook DLL and `glass_clipboard_*`
+    /// stay consistent.
     pub fn apply(&self, req: Request) -> Response {
         match req {
-            Request::Get => Response::Text(self.get()),
-            Request::Set(s) => {
-                self.set(s);
+            Request::SetAll(items) => {
+                self.set_all(items);
                 Response::Ok
             }
+            Request::List => Response::Formats(self.list()),
+            Request::Get(k) => Response::Bytes(self.get(&k)),
+            Request::GetAll => Response::Items(self.get_all()),
             Request::Empty => {
                 self.empty();
                 Response::Ok
@@ -61,42 +97,67 @@ impl PrivateClipboard {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::proto::{FormatKey, Request, Response};
+
+    fn items() -> Vec<(FormatKey, Vec<u8>)> {
+        vec![
+            (FormatKey::Standard(13), b"u".to_vec()),
+            (FormatKey::Named("HTML Format".into()), b"<b/>".to_vec()),
+        ]
+    }
 
     #[test]
-    fn set_get_round_trip_and_seq_bumps() {
+    fn set_all_get_list_seq() {
         let c = PrivateClipboard::new();
-        assert_eq!(c.get(), None);
+        assert!(c.list().is_empty());
         let s0 = c.seq();
-        c.set("hi".into());
-        assert_eq!(c.get(), Some("hi".into()));
+        c.set_all(items());
         assert!(c.seq() > s0);
+        assert_eq!(c.list(), vec![FormatKey::Standard(13), FormatKey::Named("HTML Format".into())]);
+        assert_eq!(c.get(&FormatKey::Standard(13)), Some(b"u".to_vec()));
+        assert_eq!(c.get(&FormatKey::Named("HTML Format".into())), Some(b"<b/>".to_vec()));
+        assert_eq!(c.get(&FormatKey::Standard(999)), None);
+        assert_eq!(c.get_all(), items());
     }
 
     #[test]
     fn empty_clears_and_bumps() {
         let c = PrivateClipboard::new();
-        c.set("hi".into());
-        let s1 = c.seq();
+        c.set_all(items());
+        let s = c.seq();
         c.empty();
-        assert_eq!(c.get(), None);
-        assert!(c.seq() > s1);
+        assert!(c.list().is_empty());
+        assert!(c.seq() > s);
     }
 
     #[test]
-    fn apply_request_maps_to_responses() {
+    fn apply_dispatches_v2() {
         let c = PrivateClipboard::new();
-        assert_eq!(c.apply(super::super::proto::Request::Set("z".into())), super::super::proto::Response::Ok);
-        assert_eq!(c.apply(super::super::proto::Request::Get), super::super::proto::Response::Text(Some("z".into())));
-        assert_eq!(c.apply(super::super::proto::Request::Empty), super::super::proto::Response::Ok);
-        assert_eq!(c.apply(super::super::proto::Request::Get), super::super::proto::Response::Text(None));
-        assert!(matches!(c.apply(super::super::proto::Request::Seq), super::super::proto::Response::Seq(_)));
+        assert_eq!(c.apply(Request::SetAll(items())), Response::Ok);
+        assert_eq!(c.apply(Request::List), Response::Formats(vec![FormatKey::Standard(13), FormatKey::Named("HTML Format".into())]));
+        assert_eq!(c.apply(Request::Get(FormatKey::Standard(13))), Response::Bytes(Some(b"u".to_vec())));
+        assert_eq!(c.apply(Request::Get(FormatKey::Standard(1))), Response::Bytes(None));
+        assert_eq!(c.apply(Request::GetAll), Response::Items(items()));
+        assert!(matches!(c.apply(Request::Seq), Response::Seq(_)));
+        assert_eq!(c.apply(Request::Empty), Response::Ok);
+        assert_eq!(c.apply(Request::List), Response::Formats(vec![]));
     }
 
     #[test]
     fn clone_shares_state() {
         let a = PrivateClipboard::new();
         let b = a.clone();
-        a.set("shared".into());
-        assert_eq!(b.get(), Some("shared".into())); // same Arc
+        a.set_all(items());
+        assert_eq!(b.list().len(), 2);
+    }
+
+    #[test]
+    fn text_helpers_round_trip_via_cf_unicodetext() {
+        let c = PrivateClipboard::new();
+        assert_eq!(c.get_text(), None);
+        c.set_text("héllo");
+        assert_eq!(c.get_text().as_deref(), Some("héllo"));
+        // set_text stores exactly CF_UNICODETEXT (id 13)
+        assert_eq!(c.list(), vec![FormatKey::Standard(13)]);
     }
 }

--- a/crates/glass-clip-hook/src/synth.rs
+++ b/crates/glass-clip-hook/src/synth.rs
@@ -1,0 +1,92 @@
+//! Pure synthesis *decisions* (no Win32, Miri-checked): which formats are available given the
+//! stored set (canonical + synthesizable, canonical-first), and which stored format synthesizes a
+//! requested one. The actual byte conversions live in the `cfg(windows)` hook (code page via
+//! `WideCharToMultiByte`; `CF_BITMAP` via GDI; `CF_DIBV5` via `dib.rs`).
+
+use crate::proto::FormatKey::{self, Standard};
+
+const CF_TEXT: u32 = 1;
+const CF_BITMAP: u32 = 2;
+const CF_OEMTEXT: u32 = 7;
+const CF_DIB: u32 = 8;
+const CF_UNICODETEXT: u32 = 13;
+const CF_LOCALE: u32 = 16;
+const CF_DIBV5: u32 = 17;
+
+/// Formats this canonical id can synthesize (excluding itself).
+fn derivatives(id: u32) -> &'static [u32] {
+    match id {
+        CF_UNICODETEXT => &[CF_TEXT, CF_OEMTEXT, CF_LOCALE],
+        CF_DIB => &[CF_BITMAP, CF_DIBV5],
+        _ => &[],
+    }
+}
+
+/// The full available-format set for `stored`: each stored key (in order), then any derivatives not
+/// already stored. Mirrors the OS enumeration order (canonical-first, then synthesized).
+pub(crate) fn available(stored: &[FormatKey]) -> Vec<FormatKey> {
+    let mut out: Vec<FormatKey> = stored.to_vec();
+    for k in stored {
+        if let Standard(id) = k {
+            for &d in derivatives(*id) {
+                if !out.contains(&Standard(d)) {
+                    out.push(Standard(d));
+                }
+            }
+        }
+    }
+    out
+}
+
+/// If `requested` is a synthesizable derivative, the stored canonical key it derives from.
+pub(crate) fn canonical_for(requested: &FormatKey) -> Option<FormatKey> {
+    let Standard(id) = requested else { return None };
+    let canon = match *id {
+        CF_TEXT | CF_OEMTEXT | CF_LOCALE => CF_UNICODETEXT,
+        CF_BITMAP | CF_DIBV5 => CF_DIB,
+        _ => return None,
+    };
+    Some(Standard(canon))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::FormatKey::{Named, Standard};
+
+    #[test]
+    fn unicodetext_yields_text_triad_and_locale() {
+        let avail = available(&[Standard(13)]); // CF_UNICODETEXT
+        // canonical first, then synthesized, in a stable order
+        assert_eq!(avail[0], Standard(13));
+        for k in [Standard(1), Standard(7), Standard(16)] {
+            assert!(avail.contains(&k), "missing {k:?}");
+        }
+        assert_eq!(canonical_for(&Standard(1)), Some(Standard(13))); // CF_TEXT  ← CF_UNICODETEXT
+        assert_eq!(canonical_for(&Standard(7)), Some(Standard(13))); // CF_OEMTEXT
+    }
+
+    #[test]
+    fn dib_yields_bitmap_and_dibv5() {
+        let avail = available(&[Standard(8)]); // CF_DIB
+        assert_eq!(avail[0], Standard(8));
+        for k in [Standard(2), Standard(17)] {
+            assert!(avail.contains(&k)); // CF_BITMAP, CF_DIBV5
+        }
+        assert_eq!(canonical_for(&Standard(2)), Some(Standard(8))); // CF_BITMAP ← CF_DIB
+        assert_eq!(canonical_for(&Standard(17)), Some(Standard(8))); // CF_DIBV5  ← CF_DIB
+    }
+
+    #[test]
+    fn named_formats_pass_through_no_synthesis() {
+        let avail = available(&[Named("HTML Format".into())]);
+        assert_eq!(avail, vec![Named("HTML Format".into())]);
+        assert_eq!(canonical_for(&Named("HTML Format".into())), None);
+    }
+
+    #[test]
+    fn already_stored_is_not_duplicated() {
+        let avail = available(&[Standard(13), Standard(1)]); // both stored
+        assert_eq!(avail.iter().filter(|k| **k == Standard(1)).count(), 1);
+    }
+}

--- a/crates/glass-clip-hook/src/text.rs
+++ b/crates/glass-clip-hook/src/text.rs
@@ -16,6 +16,10 @@ pub(crate) fn utf16_nul_to_string(units: &[u16]) -> String {
 
 /// Decode a `CF_TEXT`/`CF_OEMTEXT` block (the whole locked buffer, as bytes) to a `String`, stopping
 /// at the first NUL. v1 treats each byte as ANSI/Latin-1: every byte maps 1:1 to a `char`.
+///
+/// The v2 hook no longer down/up-converts single-byte text in Rust (it defers to the OS code page
+/// via `WideCharToMultiByte`); kept for the tests that pin the pure decode behavior.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn singlebyte_nul_to_string(bytes: &[u8]) -> String {
     let end = bytes.iter().position(|&b| b == 0).unwrap_or(bytes.len());
     bytes[..end].iter().map(|&b| b as char).collect()
@@ -30,6 +34,7 @@ pub(crate) fn string_to_utf16_nul(text: &str) -> Vec<u16> {
 /// ASCII-only: any non-ASCII char becomes `'?'` (lossy). NB this is *lossier* than
 /// [`singlebyte_nul_to_string`], which round-trips full Latin-1 — encode and decode are asymmetric
 /// by design in v1 (we only ever populate the store from CF_UNICODETEXT in practice).
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn string_to_singlebyte_nul(text: &str) -> Vec<u8> {
     text.chars()
         .map(|c| if (c as u32) < 0x80 { c as u8 } else { b'?' })

--- a/crates/glass-windows/src/containment/clip_onbox.rs
+++ b/crates/glass-windows/src/containment/clip_onbox.rs
@@ -108,7 +108,7 @@ fn private_clipboard_isolation() {
     let ambient_after = crate::clipboard::get().unwrap_or_default();
     eprintln!(
         "DIAG host_store={:?} ambient_after={:?} sentinel={:?}",
-        store.as_ref().map(|s| s.get()),
+        store.as_ref().map(|s| s.get_text()),
         ambient_after,
         sentinel
     );
@@ -119,7 +119,7 @@ fn private_clipboard_isolation() {
 
     let store = store.expect("Layer 2 inactive — GLASS_CLIP_HOOK_DLL not resolved / pipe server failed");
     assert_eq!(
-        store.get().as_deref(),
+        store.get_text().as_deref(),
         Some("FROM-BOX"),
         "host store did not see the boxed write"
     );

--- a/crates/glass-windows/src/containment/clip_onbox.rs
+++ b/crates/glass-windows/src/containment/clip_onbox.rs
@@ -130,3 +130,109 @@ fn private_clipboard_isolation() {
     );
     println!("PASS: boxed clipboard roundtrip served by the private store; ambient clipboard untouched");
 }
+
+#[test]
+#[ignore = "on-box: needs Sandboxie + GLASS_CLIP_HOOK_DLL + the clipprobe example"]
+fn private_clipboard_multiformat() {
+    let dir = sandboxie_dir();
+    assert!(available(&dir), "Sandboxie not available at {dir}");
+
+    let probe = profile_dir().join("examples").join("clipprobe.exe");
+    assert!(
+        probe.exists(),
+        "build the probe first: cargo build -p glass-clip-hook --release --example clipprobe (looked at {})",
+        probe.display()
+    );
+    let dll = std::env::var("GLASS_CLIP_HOOK_DLL")
+        .expect("set GLASS_CLIP_HOOK_DLL to the built glass_clip_hook.dll");
+    assert!(
+        PathBuf::from(&dll).exists(),
+        "GLASS_CLIP_HOOK_DLL points at a missing file: {dll}"
+    );
+
+    let sentinel = format!("SENTINEL-{}", std::process::id());
+    crate::clipboard::set(&sentinel).expect("set ambient clipboard");
+
+    let sb = Sandboxie {
+        dir: dir.clone(),
+        box_name: format!("glass_clipmulti_{}", std::process::id()),
+    };
+    sb.configure(SandboxLevel::Default).expect("configure box");
+
+    let spec = AppSpec {
+        build: None,
+        run: vec![
+            probe.to_string_lossy().into_owned(),
+            "roundtrip-multi".into(),
+        ],
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        timeout_ms: 15000,
+        sandbox: SandboxLevel::Default,
+    };
+    let sink: Arc<Mutex<Vec<(Stream, String)>>> = Arc::new(Mutex::new(Vec::new()));
+    let app = sb.launch(&spec, sink.clone()).expect("launch boxed probe");
+
+    // The probe writes text + HTML (named) + DIB in one session, then reads each back plus a
+    // synthesized CF_BITMAP, ending with `PROBE-MULTI-DONE`. Boxed (OpenClipboard=n), every
+    // READBACK is served by the hook from the private store.
+    let done = wait_for_log(&sink, "PROBE-MULTI-DONE", Duration::from_secs(20));
+    let lines: Vec<String> = sink.lock().unwrap().iter().map(|(_, l)| l.clone()).collect();
+    eprintln!("--- boxed log sink: {} line(s) ---", lines.len());
+    for l in &lines {
+        eprintln!("  {l}");
+    }
+    eprintln!("--- end sink ---");
+
+    let store = app.private_clipboard();
+    let ambient_after = crate::clipboard::get().unwrap_or_default();
+    eprintln!(
+        "DIAG host_store_text={:?} keys={:?} ambient_after={:?} sentinel={:?}",
+        store.as_ref().map(|s| s.get_text()),
+        store.as_ref().map(|s| s.list()),
+        ambient_after,
+        sentinel
+    );
+    app.kill();
+
+    done.expect("probe produced no PROBE-MULTI-DONE line (hook not intercepting? check the sink)");
+
+    let readback = |prefix: &str| -> String {
+        lines
+            .iter()
+            .find_map(|l| l.strip_prefix(prefix).map(str::to_string))
+            .unwrap_or_default()
+    };
+    assert_eq!(readback("READBACK-TEXT="), "FROM-BOX-MULTI", "text round-trip");
+    assert_eq!(readback("READBACK-HTML="), "<b>hi</b>", "HTML (named format) round-trip by name");
+    let dib_len: usize = readback("READBACK-DIB-LEN=").parse().unwrap_or(0);
+    assert!(dib_len >= 56, "DIB round-trip too short: {dib_len}");
+    assert_eq!(readback("READBACK-BMP="), "OK", "CF_BITMAP GDI-synthesized from the stored DIB");
+
+    let store = store.expect("Layer 2 inactive — GLASS_CLIP_HOOK_DLL not resolved / pipe server failed");
+    assert_eq!(
+        store.get_text().as_deref(),
+        Some("FROM-BOX-MULTI"),
+        "host store text"
+    );
+    let keys = store.list();
+    assert!(
+        keys.contains(&glass_clip_hook::proto::FormatKey::Named("HTML Format".into())),
+        "host store missing HTML Format: {keys:?}"
+    );
+    assert!(
+        keys.contains(&glass_clip_hook::proto::FormatKey::Standard(8)),
+        "host store missing CF_DIB: {keys:?}"
+    );
+    assert!(
+        keys.contains(&glass_clip_hook::proto::FormatKey::Standard(13)),
+        "host store missing CF_UNICODETEXT: {keys:?}"
+    );
+
+    assert_eq!(
+        ambient_after, sentinel,
+        "AMBIENT CLIPBOARD WAS TOUCHED — isolation breach"
+    );
+    println!("PASS: boxed multi-format (text + HTML + DIB + synthesized CF_BITMAP) served by the private store; ambient untouched");
+}

--- a/crates/glass-windows/src/containment/clip_server.rs
+++ b/crates/glass-windows/src/containment/clip_server.rs
@@ -150,8 +150,8 @@ fn accept_loop(
                 PIPE_ACCESS_DUPLEX,
                 PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
                 4,
-                proto::MAX_TEXT_BYTES as u32 + 64,
-                proto::MAX_TEXT_BYTES as u32 + 64,
+                64 * 1024,
+                64 * 1024,
                 0,
                 Some(&sa),
             )
@@ -227,7 +227,7 @@ fn serve_one(pipe: HANDLE, store: &PrivateClipboard, box_pids: &[u32]) {
     }
     let resp = match Request::decode(&body) {
         Ok(req) => store.apply(req),
-        Err(_) => Response::Text(None), // skew/garbage → empty, never a crash
+        Err(_) => Response::Bytes(None), // skew/garbage → benign empty, never a crash
     };
     let out = proto::frame(&resp.encode());
     let mut written = 0u32;
@@ -247,7 +247,7 @@ fn read_frame(pipe: HANDLE) -> Option<Vec<u8>> {
         return None;
     }
     let n = u32::from_le_bytes(len_buf) as usize;
-    if n > proto::MAX_TEXT_BYTES + 64 {
+    if n > proto::MAX_TOTAL_BYTES + 4096 {
         return None;
     }
     let mut body = vec![0u8; n];

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -197,7 +197,7 @@ mod backend {
             match self.app.as_ref().map(|a| a.clipboard_route()) {
                 // No app yet, or unconfined → today's real-OS clipboard.
                 None | Some(ClipboardRoute::RealOs) => crate::clipboard::get(),
-                Some(ClipboardRoute::Private(store)) => Ok(store.get().unwrap_or_default()),
+                Some(ClipboardRoute::Private(store)) => Ok(store.get_text().unwrap_or_default()),
                 Some(ClipboardRoute::DisabledContained) => Err(GlassError::Unsupported(
                     "private clipboard for the contained app (hook DLL not active); the app's clipboard \
                      is disabled to protect yours — set GLASS_CLIP_HOOK_DLL"
@@ -211,7 +211,7 @@ mod backend {
             match self.app.as_ref().map(|a| a.clipboard_route()) {
                 None | Some(ClipboardRoute::RealOs) => crate::clipboard::set(text),
                 Some(ClipboardRoute::Private(store)) => {
-                    store.set(text.to_string());
+                    store.set_text(text);
                     Ok(())
                 }
                 Some(ClipboardRoute::DisabledContained) => Err(GlassError::Unsupported(


### PR DESCRIPTION
## Summary

Extends the Windows private clipboard (#3, text-only) to carry **arbitrary formats** on the user32 surface — text, HTML, RTF, and images — so a sandboxed app's copy/paste of rich content works and stays isolated from your clipboard. This is **phase 2a-i**; the OLE hook that makes rich apps (Word/Chrome) engage is 2a-ii, and file copy is 2b.

- **Generic `format → bytes` store + v2 wire protocol** — `FormatKey = Standard(u32) | Named(String)`; registered formats keyed by *name* (their per-session ids aren't portable). One copy = one atomic `SetAll` = one seq bump.
- **The 9 user32 detours generalized** — capture any eager `SetClipboardData` format into a per-copy pending set committed on `CloseClipboard`; serve any stored **or synthesized** format: the text triad (`CF_TEXT`/`CF_OEMTEXT`/`CF_LOCALE`) via the code page, `CF_BITMAP` via GDI `CreateDIBitmap` from the stored DIB, `CF_DIBV5` via a header rewrite. Handle cache is kind-tagged (HGLOBAL→`GlobalFree`, GDI→`DeleteObject`).
- **UB-defense is structural** — all attacker-influenced byte logic (DIB geometry parsing, wire framing, synthesis decisions) lives in pure, **Miri-checked** modules (`dib`, `proto`, `store`, `synth`); `unsafe` is confined to irreducible Win32/GDI FFI, each `// SAFETY:`-commented and `catch_unwind`-guarded at every `extern "system"` boundary.

## Validation

- 28 pure tests + **Miri** (incl. an adversarial DIB corpus and proto hostile-input rejection); a whole-branch integration review confirmed the seam contract round-trips and the format-id constants are identical across modules.
- Full windows-gnu closure cross-compiles clean; native MSVC builds on Win11.
- **On-box (Win11), reproduced 4×:** a boxed app sets `CF_UNICODETEXT` + `"HTML Format"` (round-tripped by name) + `CF_DIB` in one copy and reads each back, plus a `CF_BITMAP` GDI-synthesized from the stored DIB — all served by the private store while the user's real clipboard stays at its sentinel (isolation held every run).

## Test plan

- [ ] CI green (check · miri · windows · x11 · wayland)
- [x] On-box: multi-format roundtrip + isolation, reproduced 4×