### PR TITLE
chore: update windows-rs 0.58 → 0.62 (+ windows-capture 2); dedup to one version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -920,7 +920,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -974,7 +974,7 @@ name = "glass-clip-hook"
 version = "0.0.0"
 dependencies = [
  "retour",
- "windows 0.58.0",
+ "windows",
 ]
 
 [[package]]
@@ -1068,7 +1068,7 @@ dependencies = [
  "glass-clip-hook",
  "glass-core",
  "image",
- "windows 0.58.0",
+ "windows",
  "windows-capture",
 ]
 
@@ -1227,7 +1227,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -1637,7 +1637,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2613,8 +2613,8 @@ checksum = "c68495a701b9f2f21f29353ac446f0d27dd0d7ce97aa9ccf9061bca0446cd744"
 dependencies = [
  "chrono",
  "uiautomation_derive",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -2988,59 +2988,27 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets",
-]
-
-[[package]]
-name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections 0.2.0",
- "windows-core 0.61.2",
- "windows-future 0.2.1",
- "windows-link 0.1.3",
- "windows-numerics 0.2.0",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections 0.3.2",
- "windows-core 0.62.2",
- "windows-future 0.3.2",
- "windows-numerics 0.3.1",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
 ]
 
 [[package]]
 name = "windows-capture"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a4df73e95feddb9ec1a7e9c2ca6323b8c97d5eeeff78d28f1eccdf19c882b24"
+checksum = "0f9460c7b82f6b7d314d85b45610481f26a1159a42dadf1e13a329041553e060"
 dependencies = [
  "parking_lot",
  "rayon",
  "thiserror 2.0.18",
- "windows 0.61.3",
- "windows-future 0.2.1",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core 0.61.2",
+ "windows",
+ "windows-future",
 ]
 
 [[package]]
@@ -3049,33 +3017,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -3084,22 +3026,11 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
- "windows-threading 0.1.0",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -3108,20 +3039,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
- "windows-threading 0.2.1",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3129,17 +3049,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3159,25 +3068,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "windows-numerics"
@@ -3185,26 +3078,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -3213,26 +3088,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -3241,7 +3097,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3259,7 +3115,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3280,20 +3136,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]

--- a/crates/glass-clip-hook/Cargo.toml
+++ b/crates/glass-clip-hook/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "rlib"]
 # pure modules (proto/store) need nothing beyond std.
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.58", features = [
+windows = { version = "0.62", features = [
   "Win32_Foundation",
   "Win32_System_DataExchange", "Win32_System_Memory", "Win32_System_Ole",
   "Win32_System_LibraryLoader",

--- a/crates/glass-clip-hook/examples/clipprobe.rs
+++ b/crates/glass-clip-hook/examples/clipprobe.rs
@@ -66,7 +66,7 @@ fn run() -> i32 {
         }
         std::ptr::copy_nonoverlapping(utf16.as_ptr() as *const u8, dst as *mut u8, bytes);
         let _ = GlobalUnlock(h);
-        if SetClipboardData(cf, HANDLE(h.0)).is_err() {
+        if SetClipboardData(cf, Some(HANDLE(h.0))).is_err() {
             let _ = CloseClipboard();
             eprintln!("FAIL: SetClipboardData");
             return 1;
@@ -210,7 +210,7 @@ fn run_multi() -> i32 {
                 eprintln!("FAIL: alloc {fmt}");
                 return 1;
             }
-            if SetClipboardData(fmt, HANDLE(h.0)).is_err() {
+            if SetClipboardData(fmt, Some(HANDLE(h.0))).is_err() {
                 let _ = CloseClipboard();
                 eprintln!("FAIL: SetClipboardData {fmt}");
                 return 1;

--- a/crates/glass-clip-hook/src/hook.rs
+++ b/crates/glass-clip-hook/src/hook.rs
@@ -93,7 +93,7 @@ fn open_pipe(path: &str) -> Option<HANDLE> {
                 None,
                 OPEN_EXISTING,
                 FILE_FLAGS_AND_ATTRIBUTES(0),
-                HANDLE::default(),
+                None,
             )
         };
         if let Ok(h) = opened {
@@ -222,7 +222,7 @@ pub(crate) fn alloc_hglobal_bytes(bytes: &[u8]) -> Option<HGLOBAL> {
         let h = GlobalAlloc(GMEM_MOVEABLE, bytes.len()).ok()?;
         let dst = GlobalLock(h) as *mut u8;
         if dst.is_null() {
-            let _ = GlobalFree(h);
+            let _ = GlobalFree(Some(h));
             return None;
         }
         std::ptr::copy_nonoverlapping(bytes.as_ptr(), dst, bytes.len());

--- a/crates/glass-clip-hook/src/hook/detour_impl.rs
+++ b/crates/glass-clip-hook/src/hook/detour_impl.rs
@@ -13,7 +13,8 @@
 use std::cell::{Cell, RefCell};
 
 use retour::static_detour;
-use windows::Win32::Foundation::{GlobalFree, BOOL, HANDLE, HGLOBAL, HWND};
+use windows::core::BOOL;
+use windows::Win32::Foundation::{GlobalFree, HANDLE, HGLOBAL, HWND};
 use windows::Win32::Graphics::Gdi::{DeleteObject, HBITMAP, HGDIOBJ};
 use windows::Win32::System::DataExchange::{GetClipboardFormatNameW, RegisterClipboardFormatW};
 
@@ -88,7 +89,7 @@ fn free_cached_handle() {
             // SAFETY: `raw` is an HGLOBAL we allocated in `alloc_hglobal_bytes` (GMEM_MOVEABLE) and
             // handed out exactly once; freeing it here is the agreed ownership transfer.
             HandleKind::Global => unsafe {
-                let _ = GlobalFree(HGLOBAL(raw as *mut _));
+                let _ = GlobalFree(Some(HGLOBAL(raw as *mut _)));
             },
             // SAFETY: `raw` is a GDI HBITMAP we created in `make_bitmap_handle` and handed out once;
             // DeleteObject is the matching destructor.

--- a/crates/glass-windows/Cargo.toml
+++ b/crates/glass-windows/Cargo.toml
@@ -11,8 +11,8 @@ glass-core.workspace = true
 glass-clip-hook = { path = "../glass-clip-hook" }
 
 [target.'cfg(windows)'.dependencies]
-windows-capture = "1"
-windows = { version = "0.58", features = [
+windows-capture = "2"
+windows = { version = "0.62", features = [
   "Win32_Foundation", "Win32_Security", "Win32_UI_WindowsAndMessaging",
   "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_HiDpi", "Win32_Graphics_Dwm",
   "Win32_System_Threading",
@@ -36,5 +36,5 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 # The onbox examples set Per-Monitor-V2 awareness at runtime (they carry no manifest); the
 # onbox_a11y example also drives the UIA reader to validate the accessibility path on the box.
 [target.'cfg(windows)'.dev-dependencies]
-windows = { version = "0.58", features = ["Win32_Foundation", "Win32_UI_HiDpi", "Win32_UI_WindowsAndMessaging"] }
+windows = { version = "0.62", features = ["Win32_Foundation", "Win32_UI_HiDpi", "Win32_UI_WindowsAndMessaging"] }
 glass-a11y-windows = { path = "../glass-a11y-windows" }

--- a/crates/glass-windows/src/capture.rs
+++ b/crates/glass-windows/src/capture.rs
@@ -57,10 +57,11 @@ impl GraphicsCaptureApiHandler for OneShot {
         capture_control: InternalCaptureControl,
     ) -> std::result::Result<(), Self::Error> {
         let (w, h) = (frame.width(), frame.height());
-        let mut fb = frame.buffer()?;
-        // Tightly-packed (RowPitch padding removed): width*height*4 BGRA bytes.
-        let bytes = fb.as_nopadding_buffer()?;
-        let owned = bytes.to_vec();
+        let fb = frame.buffer()?;
+        // Tightly-packed (RowPitch padding removed): width*height*4 BGRA bytes. windows-capture 2
+        // writes the de-padded bytes into a caller-provided buffer and returns a borrowed slice.
+        let mut packed = Vec::new();
+        let owned = fb.as_nopadding_buffer(&mut packed).to_vec();
         // If the receiver is gone the caller already bailed; just stop cleanly.
         let _ = self.tx.send((owned, w, h));
         capture_control.stop();

--- a/crates/glass-windows/src/clipboard.rs
+++ b/crates/glass-windows/src/clipboard.rs
@@ -113,7 +113,7 @@ pub fn set(text: &str) -> Result<()> {
             // Free on this error path — we still own the memory.
             // SAFETY: We own hglobal (GlobalAlloc succeeded, SetClipboardData has
             // not been called yet), so GlobalFree is safe.
-            let _ = unsafe { GlobalFree(hglobal) };
+            let _ = unsafe { GlobalFree(Some(hglobal)) };
             return Err(GlassError::Backend("GlobalLock failed on new clipboard handle".into()));
         }
         // SAFETY: `ptr` points to `byte_len` bytes of writable memory; `utf16`
@@ -130,7 +130,7 @@ pub fn set(text: &str) -> Result<()> {
         .map_err(|e| {
             // We still own hglobal — free it before returning.
             // SAFETY: SetClipboardData has not been called, so we still own hglobal.
-            let _ = unsafe { GlobalFree(hglobal) };
+            let _ = unsafe { GlobalFree(Some(hglobal)) };
             GlassError::Backend(format!("OpenClipboard failed: {e}"))
         })?;
 
@@ -139,7 +139,7 @@ pub fn set(text: &str) -> Result<()> {
     let empty_result = unsafe { EmptyClipboard() };
     if let Err(e) = empty_result {
         // SAFETY: We still own hglobal; free it before closing.
-        let _ = unsafe { GlobalFree(hglobal) };
+        let _ = unsafe { GlobalFree(Some(hglobal)) };
         // SAFETY: We successfully opened the clipboard.
         let _ = unsafe { CloseClipboard() };
         return Err(GlassError::Backend(format!("EmptyClipboard failed: {e}")));
@@ -152,7 +152,7 @@ pub fn set(text: &str) -> Result<()> {
     // SAFETY: The clipboard is open and empty.  SetClipboardData transfers ownership
     // of `hmem`/`hglobal` to the system on success — we must NOT free it afterwards.
     // On failure the allocation is still ours and we free it below.
-    let set_result = unsafe { SetClipboardData(CF_UNICODETEXT.0 as u32, hmem) };
+    let set_result = unsafe { SetClipboardData(CF_UNICODETEXT.0 as u32, Some(hmem)) };
 
     // SAFETY: The clipboard was successfully opened; close it regardless of whether
     // SetClipboardData succeeded.
@@ -164,7 +164,7 @@ pub fn set(text: &str) -> Result<()> {
             // SetClipboardData failed — we still own hglobal; free it.
             // SAFETY: SetClipboardData failed, so ownership did not transfer; we must
             // free to avoid a leak.
-            let _ = unsafe { GlobalFree(hglobal) };
+            let _ = unsafe { GlobalFree(Some(hglobal)) };
             Err(GlassError::Backend(format!("SetClipboardData failed: {e}")))
         }
     }

--- a/crates/glass-windows/src/containment/clip_server.rs
+++ b/crates/glass-windows/src/containment/clip_server.rs
@@ -16,7 +16,8 @@ use glass_clip_hook::store::PrivateClipboard;
 use glass_core::{GlassError, Result};
 
 use windows::core::PCWSTR;
-use windows::Win32::Foundation::{CloseHandle, BOOL, HANDLE, INVALID_HANDLE_VALUE};
+use windows::core::BOOL;
+use windows::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};
 use windows::Win32::Security::Authorization::ConvertStringSecurityDescriptorToSecurityDescriptorW;
 use windows::Win32::Security::{PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES};
 use windows::Win32::Storage::FileSystem::{FlushFileBuffers, ReadFile, WriteFile};
@@ -185,7 +186,7 @@ fn accept_loop(
     // returned by that API via LocalAlloc and must be freed with LocalFree.
     unsafe {
         use windows::Win32::Foundation::HLOCAL;
-        let _ = windows::Win32::Foundation::LocalFree(HLOCAL(psd.0));
+        let _ = windows::Win32::Foundation::LocalFree(Some(HLOCAL(psd.0)));
     }
 }
 

--- a/crates/glass-windows/src/process.rs
+++ b/crates/glass-windows/src/process.rs
@@ -297,7 +297,7 @@ pub(crate) fn job_pids(job: HANDLE) -> Vec<u32> {
         // formed over `buf`, so its (byte) alignment is irrelevant.
         let ok = unsafe {
             QueryInformationJobObject(
-                job,
+                Some(job),
                 JobObjectBasicProcessIdList,
                 buf.as_mut_ptr() as *mut c_void,
                 bytes as u32,

--- a/crates/glass-windows/src/util.rs
+++ b/crates/glass-windows/src/util.rs
@@ -2,7 +2,8 @@
 //! DWM frame bounds / cloaked detection, and the "is this a real app window" filter.
 
 use std::ffi::c_void;
-use windows::Win32::Foundation::{BOOL, HWND, LPARAM, RECT, TRUE};
+use windows::core::BOOL;
+use windows::Win32::Foundation::{HWND, LPARAM, RECT, TRUE};
 use windows::Win32::Graphics::Dwm::{
     DwmGetWindowAttribute, DWMWA_CLOAKED, DWMWA_EXTENDED_FRAME_BOUNDS,
 };

--- a/crates/glass-windows/src/windows.rs
+++ b/crates/glass-windows/src/windows.rs
@@ -122,7 +122,7 @@ pub(crate) fn move_window(hwnd: HWND, x: i32, y: i32) -> Result<()> {
     unsafe {
         SetWindowPos(
             hwnd,
-            HWND::default(),
+            None,
             x + dx,
             y + dy,
             0,
@@ -146,7 +146,7 @@ pub(crate) fn resize_window(hwnd: HWND, width: u32, height: u32) -> Result<()> {
     unsafe {
         SetWindowPos(
             hwnd,
-            HWND::default(),
+            None,
             0,
             0,
             width as i32 + extra_w,


### PR DESCRIPTION
## Summary

Updates the `windows` crate from `0.58` to `0.62.2` across the workspace and `windows-capture` `1` → `2`. The tree was carrying **three** windows versions (`0.58` direct, `0.61` via `uiautomation`, `0.62` via `windows-capture`); this **collapses them to a single `0.62.2`** — `uiautomation 0.25` and `windows-capture 2.0` both accept it.

The churn is small and mechanical (the big windows-rs API changes were in the COM/`#[implement]` area, which the current code doesn't use):
- `BOOL` moved from `Win32::Foundation` to `windows::core`.
- Several functions' params became `Option<>` for metadata-optional handles: `GlobalFree`, `LocalFree`, `SetClipboardData` (`hMem`), `SetWindowPos` (`hWndInsertAfter`), `QueryInformationJobObject`, `CreateFileW` (`hTemplateFile`).
- `windows-capture 2`'s `Frame::as_nopadding_buffer` now writes into a caller-provided buffer and returns a borrowed slice.

`glass-a11y-windows` (via `uiautomation`) needed no changes. `tools/windows-validation` is a separate throwaway workspace and is left as-is.

## Validation

- Full windows-gnu closure (`glass-clip-hook` + `glass-windows` + `glass-a11y-windows` + `glass-mcp`) cross-compiles clean; native MSVC builds on Win11.
- Linux workspace tests + clippy + Miri green.
- **On-box (Win11):** the 2a-i clipboard tests (isolation + multi-format) PASS, and the full backend smoke PASS — **WGC capture returns non-blank pixels via the new `windows-capture 2` path** (reproduced 3×), plus input, window move/resize (±2px), kill-tree, and doctor.

## Test plan

- [ ] CI green (check · miri · windows · x11 · wayland)
- [x] On-box: clipboard + backend smoke (capture/input/window/kill/doctor), capture keystone reproduced 3×