### PR TITLE
feat(windows): rich clipboard 2a-ii — OLE clipboard hook (Word/Excel/Chrome)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,6 +975,7 @@ version = "0.0.0"
 dependencies = [
  "retour",
  "windows",
+ "windows-core",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ the VM tier (the Windows Sandbox `.wsb` template under `packaging/windows-sandbo
 VM running `glass-mcp serve --http`). ² Windows needs an interactive, logged-in session to render
 and capture. ³ When contained (`sandbox=default`/`strict`), the boxed app gets a private clipboard
 isolated from yours — an injected hook backs its clipboard with glass's own store; `sandbox=off`
-uses the real OS clipboard. Carries text, HTML, RTF, and images for apps using the Win32 clipboard
-(x64); rich apps that copy via OLE, and file copy, are in progress.
+uses the real OS clipboard. Carries text, HTML, RTF, and images for apps using either the Win32 or
+the OLE clipboard (so rich apps like Word, Excel, and Chrome work too; x64); file copy is in progress.
 
 **Transport:** MCP over **stdio** (default, all platforms) or **network HTTP** (`glass-mcp serve
 --http`, all platforms) — the network transport is behind the default-on `network` cargo feature

--- a/crates/glass-clip-hook/Cargo.toml
+++ b/crates/glass-clip-hook/Cargo.toml
@@ -25,6 +25,9 @@ windows = { version = "0.62", features = [
   # Win32_Graphics_Gdi: CreateDIBitmap/DeleteObject for CF_BITMAP synthesis.
   # Win32_Globalization: WideCharToMultiByte/GetUserDefaultLCID for CF_TEXT/CF_LOCALE synthesis.
   "Win32_Graphics_Gdi", "Win32_Globalization",
+  # OLE clipboard hook (2a-ii): Com/StructuredStorage for IDataObject/IEnumFORMATETC/STGMEDIUM/IStream;
+  # Note: #[implement] is re-exported by windows-core (windows::core::implement) without a feature gate.
+  "Win32_System_Com", "Win32_System_Com_StructuredStorage",
 ] }
 # Inline detours. License verified permissive in this task's Step 6 (MIT/BSD); IAT fallback documented.
 # `static-detour` enables the `static_detour!` macro (the type-safe detour table); it pulls in the

--- a/crates/glass-clip-hook/Cargo.toml
+++ b/crates/glass-clip-hook/Cargo.toml
@@ -29,6 +29,11 @@ windows = { version = "0.62", features = [
   # Note: #[implement] is re-exported by windows-core (windows::core::implement) without a feature gate.
   "Win32_System_Com", "Win32_System_Com_StructuredStorage",
 ] }
+# `#[implement]`'s generated code refers to the crate by its absolute path `::windows_core`, so the
+# macro requires a crate named `windows_core` in scope at the crate root (the umbrella re-export
+# `windows::core` is only an alias, not that crate name). Depend on `windows-core` directly — same
+# 0.62.2 the umbrella `windows` pins, so the COM/IUnknown types unify with the ones above.
+windows-core = "0.62"
 # Inline detours. License verified permissive in this task's Step 6 (MIT/BSD); IAT fallback documented.
 # `static-detour` enables the `static_detour!` macro (the type-safe detour table); it pulls in the
 # `nightly` feature — fine, the workspace is pinned to nightly (rust-toolchain.toml).

--- a/crates/glass-clip-hook/examples/clipprobe.rs
+++ b/crates/glass-clip-hook/examples/clipprobe.rs
@@ -16,8 +16,9 @@ fn main() {
     let code = match mode.as_str() {
         "roundtrip" => run(),
         "roundtrip-multi" => run_multi(),
+        "roundtrip-ole" => run_ole(),
         _ => {
-            eprintln!("usage: clipprobe <roundtrip|roundtrip-multi> [text]");
+            eprintln!("usage: clipprobe <roundtrip|roundtrip-multi|roundtrip-ole> [text]");
             2
         }
     };
@@ -245,6 +246,408 @@ fn run_multi() -> i32 {
         println!("READBACK-DIB-LEN={dib_len}");
         println!("READBACK-BMP={}", if bmp_ok { "OK" } else { "NULL" });
         println!("PROBE-MULTI-DONE");
+    }
+    0
+}
+
+// ---------------------------------------------------------------------------
+// OLE round-trip probe (2a-ii).
+//
+// `clipprobe roundtrip-ole` exercises the OLE clipboard surface (`OleSetClipboard` /
+// `OleGetClipboard`), which the hook detours separately from the user32 path. It builds a tiny
+// in-process `IDataObject` offering CF_UNICODETEXT + a named "HTML Format" over `TYMED_HGLOBAL`,
+// pushes it with `OleSetClipboard` (→ glass marshals it into the private store), then reads it back
+// two ways: via `OleGetClipboard` (→ glass's proxy IDataObject) AND via raw user32
+// `GetClipboardData` (cross-surface coherence — the OLE copy must also be visible to the user32
+// serve path). Prints `OLE-TEXT=` / `OLE-HTML=` / `U32-TEXT=` and a final `PROBE-OLE-DONE`.
+// ---------------------------------------------------------------------------
+
+/// Run a vtable-method body, converting a panic (UB across the `extern "system"` COM boundary) into
+/// an error HRESULT. The `#[implement]` thunks have no panic guard, so every `_Impl` method guards
+/// itself (mirrors `hook/dataobject.rs`).
+#[cfg(windows)]
+fn guard_hr(f: impl FnOnce() -> windows::core::HRESULT) -> windows::core::HRESULT {
+    use windows::Win32::Foundation::E_UNEXPECTED;
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)).unwrap_or(E_UNEXPECTED)
+}
+
+#[cfg(windows)]
+fn guard_res<T>(f: impl FnOnce() -> windows::core::Result<T>) -> windows::core::Result<T> {
+    use windows::Win32::Foundation::E_UNEXPECTED;
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f))
+        .unwrap_or_else(|_| Err(E_UNEXPECTED.into()))
+}
+
+/// Build a fresh HGLOBAL/content `FORMATETC` for `cf` (rebuilt per id, never stored/cloned).
+#[cfg(windows)]
+fn probe_formatetc(cf: u16) -> windows::Win32::System::Com::FORMATETC {
+    use windows::Win32::System::Com::{FORMATETC, DVASPECT_CONTENT, TYMED_HGLOBAL};
+    FORMATETC {
+        cfFormat: cf,
+        ptd: std::ptr::null_mut(),
+        dwAspect: DVASPECT_CONTENT.0,
+        lindex: -1,
+        tymed: TYMED_HGLOBAL.0 as u32,
+    }
+}
+
+/// Enumerator over the probe object's two format ids — `AtomicUsize` cursor, `FORMATETC` built on
+/// demand (mirrors `StoreEnum` in `hook/dataobject.rs`).
+#[cfg(windows)]
+#[windows::core::implement(windows::Win32::System::Com::IEnumFORMATETC)]
+struct ProbeEnum {
+    ids: Vec<u16>,
+    idx: std::sync::atomic::AtomicUsize,
+}
+
+#[cfg(windows)]
+#[allow(non_snake_case)]
+impl windows::Win32::System::Com::IEnumFORMATETC_Impl for ProbeEnum_Impl {
+    fn Next(
+        &self,
+        celt: u32,
+        rgelt: *mut windows::Win32::System::Com::FORMATETC,
+        pceltfetched: *mut u32,
+    ) -> windows::core::HRESULT {
+        use std::sync::atomic::Ordering;
+        use windows::Win32::Foundation::{S_FALSE, S_OK};
+        guard_hr(|| {
+            let mut n = 0u32;
+            let mut i = self.idx.load(Ordering::Relaxed);
+            while n < celt && i < self.ids.len() {
+                // SAFETY: the caller guarantees rgelt has >= celt slots; write a freshly-built FORMATETC.
+                unsafe { rgelt.add(n as usize).write(probe_formatetc(self.ids[i])) };
+                i += 1;
+                n += 1;
+            }
+            self.idx.store(i, Ordering::Relaxed);
+            if !pceltfetched.is_null() {
+                // SAFETY: caller out-param; may be null (then ignored).
+                unsafe { *pceltfetched = n };
+            }
+            if n == celt {
+                S_OK
+            } else {
+                S_FALSE
+            }
+        })
+    }
+    fn Skip(&self, celt: u32) -> windows::core::Result<()> {
+        use std::sync::atomic::Ordering;
+        guard_res(|| {
+            let i = (self.idx.load(Ordering::Relaxed) + celt as usize).min(self.ids.len());
+            self.idx.store(i, Ordering::Relaxed);
+            Ok(())
+        })
+    }
+    fn Reset(&self) -> windows::core::Result<()> {
+        use std::sync::atomic::Ordering;
+        guard_res(|| {
+            self.idx.store(0, Ordering::Relaxed);
+            Ok(())
+        })
+    }
+    fn Clone(&self) -> windows::core::Result<windows::Win32::System::Com::IEnumFORMATETC> {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        guard_res(|| {
+            Ok(ProbeEnum {
+                ids: self.ids.clone(),
+                idx: AtomicUsize::new(self.idx.load(Ordering::Relaxed)),
+            }
+            .into())
+        })
+    }
+}
+
+/// A minimal source `IDataObject` for the OLE probe: two byte formats over `TYMED_HGLOBAL`, each
+/// `GetData` handing back a FRESH HGLOBAL the caller frees (mirrors `StoreDataObject`).
+#[cfg(windows)]
+#[windows::core::implement(windows::Win32::System::Com::IDataObject)]
+struct ProbeData {
+    /// `(cf, bytes)` pairs in served order.
+    formats: Vec<(u16, Vec<u8>)>,
+}
+
+#[cfg(windows)]
+#[allow(non_snake_case)]
+impl windows::Win32::System::Com::IDataObject_Impl for ProbeData_Impl {
+    fn GetData(
+        &self,
+        pformatetcin: *const windows::Win32::System::Com::FORMATETC,
+    ) -> windows::core::Result<windows::Win32::System::Com::STGMEDIUM> {
+        use std::mem::ManuallyDrop;
+        use windows::core::Error;
+        use windows::Win32::Foundation::{DV_E_FORMATETC, E_OUTOFMEMORY};
+        use windows::Win32::System::Com::{STGMEDIUM, STGMEDIUM_0, TYMED_HGLOBAL};
+        guard_res(|| {
+            // SAFETY: OLE guarantees a valid FORMATETC pointer for the call.
+            let req = unsafe { &*pformatetcin };
+            if (req.tymed & TYMED_HGLOBAL.0 as u32) == 0 {
+                return Err(Error::from_hresult(DV_E_FORMATETC));
+            }
+            let Some((_, bytes)) = self.formats.iter().find(|(cf, _)| *cf == req.cfFormat) else {
+                return Err(Error::from_hresult(DV_E_FORMATETC));
+            };
+            // Hand back a FRESH HGLOBAL — the caller frees it (pUnkForRelease = None).
+            // SAFETY: `alloc_global` is a standard GlobalAlloc/Lock/copy/Unlock; the handle is then
+            // owned by the returned STGMEDIUM (ReleaseStgMedium frees it).
+            let h = unsafe { alloc_global(bytes) };
+            if h.0.is_null() {
+                return Err(Error::from_hresult(E_OUTOFMEMORY));
+            }
+            Ok(STGMEDIUM {
+                tymed: TYMED_HGLOBAL.0 as u32,
+                u: STGMEDIUM_0 { hGlobal: h },
+                pUnkForRelease: ManuallyDrop::new(None),
+            })
+        })
+    }
+    fn GetDataHere(
+        &self,
+        _: *const windows::Win32::System::Com::FORMATETC,
+        _: *mut windows::Win32::System::Com::STGMEDIUM,
+    ) -> windows::core::Result<()> {
+        use windows::core::Error;
+        use windows::Win32::Foundation::DV_E_FORMATETC;
+        guard_res(|| Err(Error::from_hresult(DV_E_FORMATETC)))
+    }
+    fn QueryGetData(
+        &self,
+        pformatetc: *const windows::Win32::System::Com::FORMATETC,
+    ) -> windows::core::HRESULT {
+        use windows::Win32::Foundation::{DV_E_FORMATETC, S_OK};
+        use windows::Win32::System::Com::TYMED_HGLOBAL;
+        guard_hr(|| {
+            // SAFETY: valid for the call.
+            let req = unsafe { &*pformatetc };
+            if (req.tymed & TYMED_HGLOBAL.0 as u32) != 0
+                && self.formats.iter().any(|(cf, _)| *cf == req.cfFormat)
+            {
+                S_OK
+            } else {
+                DV_E_FORMATETC
+            }
+        })
+    }
+    fn GetCanonicalFormatEtc(
+        &self,
+        _: *const windows::Win32::System::Com::FORMATETC,
+        pout: *mut windows::Win32::System::Com::FORMATETC,
+    ) -> windows::core::HRESULT {
+        use windows::Win32::Foundation::E_NOTIMPL;
+        guard_hr(|| {
+            if !pout.is_null() {
+                // SAFETY: caller out-param; ptd=null signals "use the input formatetc".
+                unsafe { (*pout).ptd = std::ptr::null_mut() };
+            }
+            E_NOTIMPL
+        })
+    }
+    fn SetData(
+        &self,
+        _: *const windows::Win32::System::Com::FORMATETC,
+        _: *const windows::Win32::System::Com::STGMEDIUM,
+        _: windows::core::BOOL,
+    ) -> windows::core::Result<()> {
+        use windows::core::Error;
+        use windows::Win32::Foundation::E_NOTIMPL;
+        guard_res(|| Err(Error::from_hresult(E_NOTIMPL)))
+    }
+    fn EnumFormatEtc(
+        &self,
+        dwdirection: u32,
+    ) -> windows::core::Result<windows::Win32::System::Com::IEnumFORMATETC> {
+        use std::sync::atomic::AtomicUsize;
+        use windows::core::Error;
+        use windows::Win32::Foundation::E_NOTIMPL;
+        use windows::Win32::System::Com::DATADIR_GET;
+        guard_res(|| {
+            if dwdirection != DATADIR_GET.0 as u32 {
+                return Err(Error::from_hresult(E_NOTIMPL));
+            }
+            Ok(ProbeEnum {
+                ids: self.formats.iter().map(|(cf, _)| *cf).collect(),
+                idx: AtomicUsize::new(0),
+            }
+            .into())
+        })
+    }
+    fn DAdvise(
+        &self,
+        _: *const windows::Win32::System::Com::FORMATETC,
+        _: u32,
+        _: windows::core::Ref<windows::Win32::System::Com::IAdviseSink>,
+    ) -> windows::core::Result<u32> {
+        use windows::core::Error;
+        use windows::Win32::Foundation::OLE_E_ADVISENOTSUPPORTED;
+        guard_res(|| Err(Error::from_hresult(OLE_E_ADVISENOTSUPPORTED)))
+    }
+    fn DUnadvise(&self, _: u32) -> windows::core::Result<()> {
+        use windows::core::Error;
+        use windows::Win32::Foundation::OLE_E_ADVISENOTSUPPORTED;
+        guard_res(|| Err(Error::from_hresult(OLE_E_ADVISENOTSUPPORTED)))
+    }
+    fn EnumDAdvise(&self) -> windows::core::Result<windows::Win32::System::Com::IEnumSTATDATA> {
+        use windows::core::Error;
+        use windows::Win32::Foundation::OLE_E_ADVISENOTSUPPORTED;
+        guard_res(|| Err(Error::from_hresult(OLE_E_ADVISENOTSUPPORTED)))
+    }
+}
+
+/// Decode `bytes` as a NUL-terminated UTF-16LE string (CF_UNICODETEXT payload).
+#[cfg(windows)]
+fn utf16_to_string(bytes: &[u8]) -> String {
+    let units: Vec<u16> =
+        bytes.chunks_exact(2).map(|c| u16::from_le_bytes([c[0], c[1]])).collect();
+    let len = units.iter().position(|&u| u == 0).unwrap_or(units.len());
+    String::from_utf16_lossy(&units[..len])
+}
+
+/// Read the bytes of an HGLOBAL held in `medium` (bounded by `GlobalSize`), then `ReleaseStgMedium`.
+///
+/// # Safety
+/// `medium` must be a valid `TYMED_HGLOBAL` STGMEDIUM returned by `GetData`; we lock/copy/unlock its
+/// HGLOBAL and then release the medium (freeing the handle).
+#[cfg(windows)]
+unsafe fn take_stgmedium_bytes(
+    medium: &mut windows::Win32::System::Com::STGMEDIUM,
+) -> Option<Vec<u8>> {
+    use windows::Win32::System::Memory::{GlobalLock, GlobalSize, GlobalUnlock};
+    use windows::Win32::System::Ole::ReleaseStgMedium;
+    let h = medium.u.hGlobal;
+    let out = if h.0.is_null() {
+        None
+    } else {
+        let p = GlobalLock(h) as *const u8;
+        if p.is_null() {
+            None
+        } else {
+            let n = GlobalSize(h);
+            let v = std::slice::from_raw_parts(p, n).to_vec();
+            let _ = GlobalUnlock(h);
+            Some(v)
+        }
+    };
+    ReleaseStgMedium(medium as *mut _);
+    out
+}
+
+/// OLE round-trip probe — see the module-level comment above.
+#[cfg(windows)]
+fn run_ole() -> i32 {
+    use windows::core::PCWSTR;
+    use windows::Win32::System::Com::{
+        CoInitializeEx, IDataObject, FORMATETC, COINIT_APARTMENTTHREADED, DVASPECT_CONTENT,
+        TYMED_HGLOBAL,
+    };
+    use windows::Win32::System::DataExchange::{
+        CloseClipboard, GetClipboardData, OpenClipboard, RegisterClipboardFormatW,
+    };
+    use windows::Win32::System::Memory::{GlobalLock, GlobalUnlock};
+    use windows::Win32::System::Ole::{OleGetClipboard, OleSetClipboard, CF_UNICODETEXT};
+
+    let cf_text = CF_UNICODETEXT.0;
+    let text = "OLE-FROM-BOX";
+    let utf16: Vec<u16> = text.encode_utf16().chain(std::iter::once(0)).collect();
+    let text_bytes: Vec<u8> = utf16.iter().flat_map(|u| u.to_le_bytes()).collect();
+    let html_bytes = b"<i>ole</i>".to_vec();
+
+    unsafe {
+        // OLE requires COM init on this STA thread.
+        // SAFETY: standard COM init; we tolerate S_FALSE (already initialized).
+        let hr = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
+        if hr.is_err() {
+            eprintln!("FAIL: CoInitializeEx hr={hr:?}");
+            return 1;
+        }
+
+        let html_w: Vec<u16> = "HTML Format".encode_utf16().chain(std::iter::once(0)).collect();
+        // SAFETY: a NUL-terminated wide string we own for the duration of the call.
+        let html_fmt = RegisterClipboardFormatW(PCWSTR::from_raw(html_w.as_ptr()));
+        if html_fmt == 0 || html_fmt > u16::MAX as u32 {
+            eprintln!("FAIL: RegisterClipboardFormatW ({html_fmt})");
+            return 1;
+        }
+        let cf_html = html_fmt as u16;
+
+        // --- write via OLE: glass's OleSetClipboard detour marshals the source IDataObject into the
+        //     private store. ---
+        let obj: IDataObject = ProbeData {
+            formats: vec![(cf_text, text_bytes), (cf_html, html_bytes)],
+        }
+        .into();
+        // SAFETY: a boxed in-process IDataObject; OleSetClipboard takes a borrowed reference.
+        if let Err(e) = OleSetClipboard(&obj) {
+            eprintln!("FAIL: OleSetClipboard {e:?}");
+            return 1;
+        }
+
+        // --- read back via OLE: glass's OleGetClipboard detour hands back its proxy IDataObject. ---
+        // SAFETY: returns a marshaled proxy; we drive GetData per format.
+        let got = match OleGetClipboard() {
+            Ok(o) => o,
+            Err(e) => {
+                eprintln!("FAIL: OleGetClipboard {e:?}");
+                return 1;
+            }
+        };
+        let mut ole_text = String::new();
+        let mut ole_html = String::new();
+        for (cf, is_text, slot) in [
+            (cf_text, true, &mut ole_text),
+            (cf_html, false, &mut ole_html),
+        ] {
+            let fe = FORMATETC {
+                cfFormat: cf,
+                ptd: std::ptr::null_mut(),
+                dwAspect: DVASPECT_CONTENT.0,
+                lindex: -1,
+                tymed: TYMED_HGLOBAL.0 as u32,
+            };
+            // SAFETY: valid FORMATETC; GetData returns a TYMED_HGLOBAL medium we own + must release.
+            let mut medium = match got.GetData(&fe) {
+                Ok(m) => m,
+                Err(e) => {
+                    eprintln!("FAIL: OLE GetData cf={cf} {e:?}");
+                    return 1;
+                }
+            };
+            // SAFETY: medium is a fresh TYMED_HGLOBAL from GetData; take_stgmedium_bytes releases it.
+            let bytes = take_stgmedium_bytes(&mut medium).unwrap_or_default();
+            *slot = if is_text {
+                utf16_to_string(&bytes)
+            } else {
+                String::from_utf8_lossy(&bytes).into_owned()
+            };
+        }
+
+        // --- read back via raw user32 (cross-surface coherence: the OLE copy must also be visible to
+        //     the user32 serve path). ---
+        // SAFETY: standard user32 read; the returned handle is owned by the clipboard (not freed).
+        let mut u32_text = String::new();
+        if OpenClipboard(None).is_ok() {
+            if let Ok(hr) = GetClipboardData(cf_text as u32) {
+                if !hr.is_invalid() {
+                    let g = windows::Win32::Foundation::HGLOBAL(hr.0);
+                    let p = GlobalLock(g) as *const u16;
+                    if !p.is_null() {
+                        let mut len = 0usize;
+                        while *p.add(len) != 0 {
+                            len += 1;
+                        }
+                        u32_text =
+                            String::from_utf16_lossy(std::slice::from_raw_parts(p, len));
+                        let _ = GlobalUnlock(g);
+                    }
+                }
+            }
+            let _ = CloseClipboard();
+        }
+
+        println!("OLE-TEXT={ole_text}");
+        println!("OLE-HTML={ole_html}");
+        println!("U32-TEXT={u32_text}");
+        println!("PROBE-OLE-DONE");
     }
     0
 }

--- a/crates/glass-clip-hook/src/hook.rs
+++ b/crates/glass-clip-hook/src/hook.rs
@@ -249,8 +249,6 @@ pub(crate) fn store_seq() -> u32 {
 }
 
 /// The whole stored snapshot (for the OLE serve path's one-shot bake).
-// Used by the OLE dataobject proxy (Task 3); suppress dead-code until that module is filled in.
-#[allow(dead_code)]
 pub(crate) fn store_get_all() -> Vec<(FormatKey, Vec<u8>)> {
     match rpc(Request::GetAll) {
         Some(Response::Items(items)) => items,
@@ -347,8 +345,6 @@ static USER32_W: [u16; 11] = [
 ///
 /// # Safety
 /// Caller transmutes the returned address to the export's exact ABI signature.
-// Used by the OLE detours (Task 4); suppress dead-code until that module is filled in.
-#[allow(dead_code)]
 pub(crate) unsafe fn ole32_proc(name: &[u8]) -> Option<*const ()> {
     // SAFETY: "ole32.dll\0" is a valid module name; an OLE-using app has it loaded. We do NOT
     // LoadLibrary it — if it isn't loaded, the app isn't using OLE and there's nothing to hook.
@@ -358,7 +354,6 @@ pub(crate) unsafe fn ole32_proc(name: &[u8]) -> Option<*const ()> {
 }
 
 /// `"ole32.dll\0"` as UTF-16.
-#[allow(dead_code)]
 static OLE32_W: [u16; 10] = [
     b'o' as u16, b'l' as u16, b'e' as u16, b'3' as u16, b'2' as u16, b'.' as u16, b'd' as u16,
     b'l' as u16, b'l' as u16, 0,

--- a/crates/glass-clip-hook/src/hook.rs
+++ b/crates/glass-clip-hook/src/hook.rs
@@ -38,12 +38,6 @@ mod ole;
 pub(crate) const CF_TEXT: u32 = 1;
 pub(crate) const CF_BITMAP: u32 = 2;
 pub(crate) const CF_OEMTEXT: u32 = 7;
-// CF_DIB and CF_UNICODETEXT are referenced by the OLE serve path (Tasks 3/4) but not yet used;
-// suppress dead-code warnings until those modules are filled in.
-#[allow(dead_code)]
-pub(crate) const CF_DIB: u32 = 8;
-#[allow(dead_code)]
-pub(crate) const CF_UNICODETEXT: u32 = 13;
 pub(crate) const CF_LOCALE: u32 = 16;
 pub(crate) const CF_DIBV5: u32 = 17;
 

--- a/crates/glass-clip-hook/src/hook.rs
+++ b/crates/glass-clip-hook/src/hook.rs
@@ -26,9 +26,62 @@ use windows::Win32::System::Memory::{
     GlobalAlloc, GlobalLock, GlobalSize, GlobalUnlock, GMEM_MOVEABLE,
 };
 
+use windows::Win32::System::DataExchange::{GetClipboardFormatNameW, RegisterClipboardFormatW};
+
 use crate::proto::{self, FormatKey, Request, Response};
 
 mod detour_impl;
+mod dataobject;
+mod ole;
+
+// Standard Win32 clipboard format ids (stable ABI).
+pub(crate) const CF_TEXT: u32 = 1;
+pub(crate) const CF_BITMAP: u32 = 2;
+pub(crate) const CF_OEMTEXT: u32 = 7;
+// CF_DIB and CF_UNICODETEXT are referenced by the OLE serve path (Tasks 3/4) but not yet used;
+// suppress dead-code warnings until those modules are filled in.
+#[allow(dead_code)]
+pub(crate) const CF_DIB: u32 = 8;
+#[allow(dead_code)]
+pub(crate) const CF_UNICODETEXT: u32 = 13;
+pub(crate) const CF_LOCALE: u32 = 16;
+pub(crate) const CF_DIBV5: u32 = 17;
+
+/// Raw clipboard id → `FormatKey`: a registered (>=0xC000) id resolves to its NAME (portable across
+/// processes), everything else stays a `Standard` id.
+pub(crate) fn key_of(id: u32) -> FormatKey {
+    if id >= 0xC000 {
+        let mut buf = [0u16; 256];
+        // SAFETY: GetClipboardFormatNameW writes up to buf.len() chars and returns the count (0 on
+        // failure); the slice bounds the read.
+        let n = unsafe { GetClipboardFormatNameW(id, &mut buf) };
+        if n > 0 {
+            return FormatKey::Named(String::from_utf16_lossy(&buf[..n as usize]));
+        }
+    }
+    FormatKey::Standard(id)
+}
+
+/// `FormatKey` → this process's clipboard id (re-registering named formats so the id is valid here).
+pub(crate) fn id_of(key: &FormatKey) -> u32 {
+    match key {
+        FormatKey::Standard(id) => *id,
+        FormatKey::Named(name) => {
+            let w: Vec<u16> = name.encode_utf16().chain(std::iter::once(0)).collect();
+            // SAFETY: `w` is NUL-terminated and outlives the call; RegisterClipboardFormatW returns
+            // this session's id for that name.
+            unsafe { RegisterClipboardFormatW(windows::core::PCWSTR::from_raw(w.as_ptr())) }
+        }
+    }
+}
+
+/// 4-byte `CF_LOCALE` blob = the current input-language LCID.
+pub(crate) fn locale_blob() -> Vec<u8> {
+    use windows::Win32::Globalization::GetUserDefaultLCID;
+    // SAFETY: GetUserDefaultLCID takes no args and returns the LCID.
+    let lcid = unsafe { GetUserDefaultLCID() };
+    lcid.to_le_bytes().to_vec()
+}
 
 /// Resolved pipe path (`\\.\pipe\<GLASS_CLIP_PIPE>`). `None` ⇒ the DLL is inert.
 static PIPE: OnceLock<String> = OnceLock::new();
@@ -195,6 +248,16 @@ pub(crate) fn store_seq() -> u32 {
     }
 }
 
+/// The whole stored snapshot (for the OLE serve path's one-shot bake).
+// Used by the OLE dataobject proxy (Task 3); suppress dead-code until that module is filled in.
+#[allow(dead_code)]
+pub(crate) fn store_get_all() -> Vec<(FormatKey, Vec<u8>)> {
+    match rpc(Request::GetAll) {
+        Some(Response::Items(items)) => items,
+        _ => Vec::new(),
+    }
+}
+
 // ---------------------------------------------------------------------------------------------
 // Generic HGLOBAL byte helpers + the one text code-page conversion, used by the detours.
 // ---------------------------------------------------------------------------------------------
@@ -278,4 +341,25 @@ static USER32_W: [u16; 11] = [
     b'l' as u16,
     b'l' as u16,
     0,
+];
+
+/// Resolve an `ole32` export's absolute address (so all call sites are detoured). See `user32_proc`.
+///
+/// # Safety
+/// Caller transmutes the returned address to the export's exact ABI signature.
+// Used by the OLE detours (Task 4); suppress dead-code until that module is filled in.
+#[allow(dead_code)]
+pub(crate) unsafe fn ole32_proc(name: &[u8]) -> Option<*const ()> {
+    // SAFETY: "ole32.dll\0" is a valid module name; an OLE-using app has it loaded. We do NOT
+    // LoadLibrary it — if it isn't loaded, the app isn't using OLE and there's nothing to hook.
+    let module = GetModuleHandleW(PCWSTR::from_raw(OLE32_W.as_ptr())).ok()?;
+    let proc = GetProcAddress(module, PCSTR::from_raw(name.as_ptr()));
+    proc.map(|f| f as *const ())
+}
+
+/// `"ole32.dll\0"` as UTF-16.
+#[allow(dead_code)]
+static OLE32_W: [u16; 10] = [
+    b'o' as u16, b'l' as u16, b'e' as u16, b'3' as u16, b'2' as u16, b'.' as u16, b'd' as u16,
+    b'l' as u16, b'l' as u16, 0,
 ];

--- a/crates/glass-clip-hook/src/hook/dataobject.rs
+++ b/crates/glass-clip-hook/src/hook/dataobject.rs
@@ -1,0 +1,1 @@
+//! #[implement] IDataObject proxy (2a-ii). Filled in Task 3.

--- a/crates/glass-clip-hook/src/hook/dataobject.rs
+++ b/crates/glass-clip-hook/src/hook/dataobject.rs
@@ -123,15 +123,13 @@ impl IEnumFORMATETC_Impl for StoreEnum_Impl {
 }
 
 /// The proxy data object. Holds the baked snapshot + its precomputed served format ids.
-// Constructed by the OLE detour path (Task 4, `ole.rs`); suppress dead-code until that lands.
-#[allow(dead_code)]
+/// Constructed by the OLE detour path (`ole.rs`'s `OleGetClipboard`).
 #[implement(IDataObject)]
 pub(super) struct StoreDataObject {
     entries: Vec<(FormatKey, Vec<u8>)>,
     ids: Vec<u16>,
 }
 
-#[allow(dead_code)] // removed in Task 4 (ole.rs calls it)
 impl StoreDataObject {
     /// Build from a store snapshot: served ids = `synth::serve_keys` mapped to this session's ids.
     pub(super) fn new(entries: Vec<(FormatKey, Vec<u8>)>) -> Self {

--- a/crates/glass-clip-hook/src/hook/dataobject.rs
+++ b/crates/glass-clip-hook/src/hook/dataobject.rs
@@ -13,7 +13,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use windows::core::{implement, Error, Ref, Result, BOOL, HRESULT};
 use windows::Win32::Foundation::{
-    DV_E_FORMATETC, E_NOTIMPL, OLE_E_ADVISENOTSUPPORTED, S_FALSE, S_OK,
+    DV_E_FORMATETC, E_NOTIMPL, E_OUTOFMEMORY, E_UNEXPECTED, OLE_E_ADVISENOTSUPPORTED, S_FALSE,
+    S_OK,
 };
 use windows::Win32::System::Com::{
     IAdviseSink, IDataObject, IDataObject_Impl, IEnumFORMATETC, IEnumFORMATETC_Impl, IEnumSTATDATA,
@@ -26,6 +27,17 @@ use super::{
     alloc_hglobal_bytes, id_of, key_of, locale_blob, unicode_to_codepage, CF_DIBV5, CF_LOCALE,
     CF_OEMTEXT, CF_TEXT,
 };
+
+/// Run a vtable-method body, converting a panic (UB across the `extern "system"` COM boundary) into
+/// an error HRESULT. The macro's thunks have no panic guard and member-crate `panic=abort` is
+/// ignored by Cargo, so every `_Impl` method must guard itself (design D7).
+fn guard_hr(f: impl FnOnce() -> HRESULT) -> HRESULT {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)).unwrap_or(E_UNEXPECTED)
+}
+fn guard_res<T>(f: impl FnOnce() -> Result<T>) -> Result<T> {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f))
+        .unwrap_or_else(|_| Err(E_UNEXPECTED.into()))
+}
 
 /// Bytes for `cf` from the baked `entries`: stored verbatim, or byte-synthesized from its canonical.
 fn bytes_for(entries: &[(FormatKey, Vec<u8>)], cf: u16) -> Option<Vec<u8>> {
@@ -65,40 +77,48 @@ struct StoreEnum {
 
 impl IEnumFORMATETC_Impl for StoreEnum_Impl {
     fn Next(&self, celt: u32, rgelt: *mut FORMATETC, pceltfetched: *mut u32) -> HRESULT {
-        let mut n = 0u32;
-        let mut i = self.idx.load(Ordering::Relaxed);
-        while n < celt && i < self.ids.len() {
-            // SAFETY: the caller guarantees rgelt has >= celt slots; write a freshly-built FORMATETC.
-            unsafe { rgelt.add(n as usize).write(formatetc(self.ids[i])) };
-            i += 1;
-            n += 1;
-        }
-        self.idx.store(i, Ordering::Relaxed);
-        if !pceltfetched.is_null() {
-            // SAFETY: caller out-param; may be null (then ignored).
-            unsafe { *pceltfetched = n };
-        }
-        if n == celt {
-            S_OK
-        } else {
-            S_FALSE
-        }
+        guard_hr(|| {
+            let mut n = 0u32;
+            let mut i = self.idx.load(Ordering::Relaxed);
+            while n < celt && i < self.ids.len() {
+                // SAFETY: the caller guarantees rgelt has >= celt slots; write a freshly-built FORMATETC.
+                unsafe { rgelt.add(n as usize).write(formatetc(self.ids[i])) };
+                i += 1;
+                n += 1;
+            }
+            self.idx.store(i, Ordering::Relaxed);
+            if !pceltfetched.is_null() {
+                // SAFETY: caller out-param; may be null (then ignored).
+                unsafe { *pceltfetched = n };
+            }
+            if n == celt {
+                S_OK
+            } else {
+                S_FALSE
+            }
+        })
     }
     fn Skip(&self, celt: u32) -> Result<()> {
-        let i = (self.idx.load(Ordering::Relaxed) + celt as usize).min(self.ids.len());
-        self.idx.store(i, Ordering::Relaxed);
-        Ok(())
+        guard_res(|| {
+            let i = (self.idx.load(Ordering::Relaxed) + celt as usize).min(self.ids.len());
+            self.idx.store(i, Ordering::Relaxed);
+            Ok(())
+        })
     }
     fn Reset(&self) -> Result<()> {
-        self.idx.store(0, Ordering::Relaxed);
-        Ok(())
+        guard_res(|| {
+            self.idx.store(0, Ordering::Relaxed);
+            Ok(())
+        })
     }
     fn Clone(&self) -> Result<IEnumFORMATETC> {
-        Ok(StoreEnum {
-            ids: self.ids.clone(),
-            idx: AtomicUsize::new(self.idx.load(Ordering::Relaxed)),
-        }
-        .into())
+        guard_res(|| {
+            Ok(StoreEnum {
+                ids: self.ids.clone(),
+                idx: AtomicUsize::new(self.idx.load(Ordering::Relaxed)),
+            }
+            .into())
+        })
     }
 }
 
@@ -128,65 +148,73 @@ impl StoreDataObject {
 
 impl IDataObject_Impl for StoreDataObject_Impl {
     fn GetData(&self, pformatetcin: *const FORMATETC) -> Result<STGMEDIUM> {
-        // SAFETY: OLE guarantees a valid FORMATETC pointer for the call.
-        let req = unsafe { &*pformatetcin };
-        if (req.tymed & TYMED_HGLOBAL.0 as u32) == 0 {
-            return Err(Error::from_hresult(DV_E_FORMATETC));
-        }
-        let Some(bytes) = bytes_for(&self.entries, req.cfFormat) else {
-            return Err(Error::from_hresult(DV_E_FORMATETC));
-        };
-        // Hand back a FRESH HGLOBAL — the caller frees it (pUnkForRelease = None).
-        let Some(h) = alloc_hglobal_bytes(&bytes) else {
-            return Err(Error::from_hresult(DV_E_FORMATETC));
-        };
-        Ok(STGMEDIUM {
-            tymed: TYMED_HGLOBAL.0 as u32,
-            u: STGMEDIUM_0 { hGlobal: h },
-            pUnkForRelease: ManuallyDrop::new(None),
+        guard_res(|| {
+            // SAFETY: OLE guarantees a valid FORMATETC pointer for the call.
+            let req = unsafe { &*pformatetcin };
+            if (req.tymed & TYMED_HGLOBAL.0 as u32) == 0 {
+                return Err(Error::from_hresult(DV_E_FORMATETC));
+            }
+            let Some(bytes) = bytes_for(&self.entries, req.cfFormat) else {
+                return Err(Error::from_hresult(DV_E_FORMATETC));
+            };
+            // Hand back a FRESH HGLOBAL — the caller frees it (pUnkForRelease = None).
+            let Some(h) = alloc_hglobal_bytes(&bytes) else {
+                return Err(Error::from_hresult(E_OUTOFMEMORY));
+            };
+            Ok(STGMEDIUM {
+                tymed: TYMED_HGLOBAL.0 as u32,
+                u: STGMEDIUM_0 { hGlobal: h },
+                pUnkForRelease: ManuallyDrop::new(None),
+            })
         })
     }
     fn GetDataHere(&self, _: *const FORMATETC, _: *mut STGMEDIUM) -> Result<()> {
-        Err(Error::from_hresult(DV_E_FORMATETC))
+        guard_res(|| Err(Error::from_hresult(DV_E_FORMATETC)))
     }
     fn QueryGetData(&self, pformatetc: *const FORMATETC) -> HRESULT {
-        // SAFETY: valid for the call.
-        let req = unsafe { &*pformatetc };
-        if (req.tymed & TYMED_HGLOBAL.0 as u32) != 0
-            && bytes_for(&self.entries, req.cfFormat).is_some()
-        {
-            S_OK
-        } else {
-            DV_E_FORMATETC
-        }
+        guard_hr(|| {
+            // SAFETY: valid for the call.
+            let req = unsafe { &*pformatetc };
+            if (req.tymed & TYMED_HGLOBAL.0 as u32) != 0
+                && bytes_for(&self.entries, req.cfFormat).is_some()
+            {
+                S_OK
+            } else {
+                DV_E_FORMATETC
+            }
+        })
     }
     fn GetCanonicalFormatEtc(&self, _: *const FORMATETC, pout: *mut FORMATETC) -> HRESULT {
-        if !pout.is_null() {
-            // SAFETY: caller out-param; ptd=null signals "use the input formatetc".
-            unsafe { (*pout).ptd = std::ptr::null_mut() };
-        }
-        E_NOTIMPL
+        guard_hr(|| {
+            if !pout.is_null() {
+                // SAFETY: caller out-param; ptd=null signals "use the input formatetc".
+                unsafe { (*pout).ptd = std::ptr::null_mut() };
+            }
+            E_NOTIMPL
+        })
     }
     fn SetData(&self, _: *const FORMATETC, _: *const STGMEDIUM, _: BOOL) -> Result<()> {
-        Err(Error::from_hresult(E_NOTIMPL))
+        guard_res(|| Err(Error::from_hresult(E_NOTIMPL)))
     }
     fn EnumFormatEtc(&self, dwdirection: u32) -> Result<IEnumFORMATETC> {
-        if dwdirection != DATADIR_GET.0 as u32 {
-            return Err(Error::from_hresult(E_NOTIMPL));
-        }
-        Ok(StoreEnum {
-            ids: self.ids.clone(),
-            idx: AtomicUsize::new(0),
-        }
-        .into())
+        guard_res(|| {
+            if dwdirection != DATADIR_GET.0 as u32 {
+                return Err(Error::from_hresult(E_NOTIMPL));
+            }
+            Ok(StoreEnum {
+                ids: self.ids.clone(),
+                idx: AtomicUsize::new(0),
+            }
+            .into())
+        })
     }
     fn DAdvise(&self, _: *const FORMATETC, _: u32, _: Ref<IAdviseSink>) -> Result<u32> {
-        Err(Error::from_hresult(OLE_E_ADVISENOTSUPPORTED))
+        guard_res(|| Err(Error::from_hresult(OLE_E_ADVISENOTSUPPORTED)))
     }
     fn DUnadvise(&self, _: u32) -> Result<()> {
-        Err(Error::from_hresult(OLE_E_ADVISENOTSUPPORTED))
+        guard_res(|| Err(Error::from_hresult(OLE_E_ADVISENOTSUPPORTED)))
     }
     fn EnumDAdvise(&self) -> Result<IEnumSTATDATA> {
-        Err(Error::from_hresult(OLE_E_ADVISENOTSUPPORTED))
+        guard_res(|| Err(Error::from_hresult(OLE_E_ADVISENOTSUPPORTED)))
     }
 }

--- a/crates/glass-clip-hook/src/hook/dataobject.rs
+++ b/crates/glass-clip-hook/src/hook/dataobject.rs
@@ -1,1 +1,192 @@
-//! #[implement] IDataObject proxy (2a-ii). Filled in Task 3.
+//! A hand-rolled COM `IDataObject` (+ `IEnumFORMATETC`) that serves a baked clipboard snapshot.
+//!
+//! Built by `OleGetClipboard` from a one-shot `store_get_all()` so its `GetData` does ZERO pipe I/O
+//! (no COM reentrancy on paste). Serves byte formats over `TYMED_HGLOBAL`: stored verbatim, or a
+//! byte-synthesized derivative (text triad via code page, `CF_DIBV5` via `dib`). GDI `CF_BITMAP` is
+//! NOT served here (the user32 path handles that). Each `GetData` returns a FRESH HGLOBAL the caller
+//! frees — never our owned bytes.
+
+#![allow(non_snake_case)]
+
+use std::mem::ManuallyDrop;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use windows::core::{implement, Error, Ref, Result, BOOL, HRESULT};
+use windows::Win32::Foundation::{
+    DV_E_FORMATETC, E_NOTIMPL, OLE_E_ADVISENOTSUPPORTED, S_FALSE, S_OK,
+};
+use windows::Win32::System::Com::{
+    IAdviseSink, IDataObject, IDataObject_Impl, IEnumFORMATETC, IEnumFORMATETC_Impl, IEnumSTATDATA,
+    FORMATETC, STGMEDIUM, STGMEDIUM_0, DATADIR_GET, DVASPECT_CONTENT, TYMED_HGLOBAL,
+};
+
+use crate::proto::FormatKey;
+
+use super::{
+    alloc_hglobal_bytes, id_of, key_of, locale_blob, unicode_to_codepage, CF_DIBV5, CF_LOCALE,
+    CF_OEMTEXT, CF_TEXT,
+};
+
+/// Bytes for `cf` from the baked `entries`: stored verbatim, or byte-synthesized from its canonical.
+fn bytes_for(entries: &[(FormatKey, Vec<u8>)], cf: u16) -> Option<Vec<u8>> {
+    let key = key_of(cf as u32);
+    if let Some((_, b)) = entries.iter().find(|(k, _)| *k == key) {
+        return Some(b.clone());
+    }
+    let canon = crate::synth::canonical_for(&key)?;
+    let (_, src) = entries.iter().find(|(k, _)| *k == canon)?;
+    Some(match cf as u32 {
+        CF_TEXT => unicode_to_codepage(src, false),
+        CF_OEMTEXT => unicode_to_codepage(src, true),
+        CF_LOCALE => locale_blob(),
+        CF_DIBV5 => crate::dib::dib_to_dibv5(src)?,
+        _ => return None,
+    })
+}
+
+/// Build a fresh HGLOBAL/content `FORMATETC` for `cf` (rebuilt per-id rather than stored/cloned).
+fn formatetc(cf: u16) -> FORMATETC {
+    FORMATETC {
+        cfFormat: cf,
+        ptd: std::ptr::null_mut(),
+        dwAspect: DVASPECT_CONTENT.0,
+        lindex: -1,
+        tymed: TYMED_HGLOBAL.0 as u32,
+    }
+}
+
+/// The enumerator over the proxy's served format ids. `AtomicUsize` cursor (the macro is Agile →
+/// Send+Sync); ids (`u16`) stored, `FORMATETC` built on demand.
+#[implement(IEnumFORMATETC)]
+struct StoreEnum {
+    ids: Vec<u16>,
+    idx: AtomicUsize,
+}
+
+impl IEnumFORMATETC_Impl for StoreEnum_Impl {
+    fn Next(&self, celt: u32, rgelt: *mut FORMATETC, pceltfetched: *mut u32) -> HRESULT {
+        let mut n = 0u32;
+        let mut i = self.idx.load(Ordering::Relaxed);
+        while n < celt && i < self.ids.len() {
+            // SAFETY: the caller guarantees rgelt has >= celt slots; write a freshly-built FORMATETC.
+            unsafe { rgelt.add(n as usize).write(formatetc(self.ids[i])) };
+            i += 1;
+            n += 1;
+        }
+        self.idx.store(i, Ordering::Relaxed);
+        if !pceltfetched.is_null() {
+            // SAFETY: caller out-param; may be null (then ignored).
+            unsafe { *pceltfetched = n };
+        }
+        if n == celt {
+            S_OK
+        } else {
+            S_FALSE
+        }
+    }
+    fn Skip(&self, celt: u32) -> Result<()> {
+        let i = (self.idx.load(Ordering::Relaxed) + celt as usize).min(self.ids.len());
+        self.idx.store(i, Ordering::Relaxed);
+        Ok(())
+    }
+    fn Reset(&self) -> Result<()> {
+        self.idx.store(0, Ordering::Relaxed);
+        Ok(())
+    }
+    fn Clone(&self) -> Result<IEnumFORMATETC> {
+        Ok(StoreEnum {
+            ids: self.ids.clone(),
+            idx: AtomicUsize::new(self.idx.load(Ordering::Relaxed)),
+        }
+        .into())
+    }
+}
+
+/// The proxy data object. Holds the baked snapshot + its precomputed served format ids.
+// Constructed by the OLE detour path (Task 4, `ole.rs`); suppress dead-code until that lands.
+#[allow(dead_code)]
+#[implement(IDataObject)]
+pub(super) struct StoreDataObject {
+    entries: Vec<(FormatKey, Vec<u8>)>,
+    ids: Vec<u16>,
+}
+
+#[allow(dead_code)] // removed in Task 4 (ole.rs calls it)
+impl StoreDataObject {
+    /// Build from a store snapshot: served ids = `synth::serve_keys` mapped to this session's ids.
+    pub(super) fn new(entries: Vec<(FormatKey, Vec<u8>)>) -> Self {
+        let keys: Vec<FormatKey> = entries.iter().map(|(k, _)| k.clone()).collect();
+        let ids = crate::synth::serve_keys(&keys)
+            .iter()
+            .map(id_of)
+            .filter(|&id| id != 0 && id <= u16::MAX as u32)
+            .map(|id| id as u16)
+            .collect();
+        Self { entries, ids }
+    }
+}
+
+impl IDataObject_Impl for StoreDataObject_Impl {
+    fn GetData(&self, pformatetcin: *const FORMATETC) -> Result<STGMEDIUM> {
+        // SAFETY: OLE guarantees a valid FORMATETC pointer for the call.
+        let req = unsafe { &*pformatetcin };
+        if (req.tymed & TYMED_HGLOBAL.0 as u32) == 0 {
+            return Err(Error::from_hresult(DV_E_FORMATETC));
+        }
+        let Some(bytes) = bytes_for(&self.entries, req.cfFormat) else {
+            return Err(Error::from_hresult(DV_E_FORMATETC));
+        };
+        // Hand back a FRESH HGLOBAL — the caller frees it (pUnkForRelease = None).
+        let Some(h) = alloc_hglobal_bytes(&bytes) else {
+            return Err(Error::from_hresult(DV_E_FORMATETC));
+        };
+        Ok(STGMEDIUM {
+            tymed: TYMED_HGLOBAL.0 as u32,
+            u: STGMEDIUM_0 { hGlobal: h },
+            pUnkForRelease: ManuallyDrop::new(None),
+        })
+    }
+    fn GetDataHere(&self, _: *const FORMATETC, _: *mut STGMEDIUM) -> Result<()> {
+        Err(Error::from_hresult(DV_E_FORMATETC))
+    }
+    fn QueryGetData(&self, pformatetc: *const FORMATETC) -> HRESULT {
+        // SAFETY: valid for the call.
+        let req = unsafe { &*pformatetc };
+        if (req.tymed & TYMED_HGLOBAL.0 as u32) != 0
+            && bytes_for(&self.entries, req.cfFormat).is_some()
+        {
+            S_OK
+        } else {
+            DV_E_FORMATETC
+        }
+    }
+    fn GetCanonicalFormatEtc(&self, _: *const FORMATETC, pout: *mut FORMATETC) -> HRESULT {
+        if !pout.is_null() {
+            // SAFETY: caller out-param; ptd=null signals "use the input formatetc".
+            unsafe { (*pout).ptd = std::ptr::null_mut() };
+        }
+        E_NOTIMPL
+    }
+    fn SetData(&self, _: *const FORMATETC, _: *const STGMEDIUM, _: BOOL) -> Result<()> {
+        Err(Error::from_hresult(E_NOTIMPL))
+    }
+    fn EnumFormatEtc(&self, dwdirection: u32) -> Result<IEnumFORMATETC> {
+        if dwdirection != DATADIR_GET.0 as u32 {
+            return Err(Error::from_hresult(E_NOTIMPL));
+        }
+        Ok(StoreEnum {
+            ids: self.ids.clone(),
+            idx: AtomicUsize::new(0),
+        }
+        .into())
+    }
+    fn DAdvise(&self, _: *const FORMATETC, _: u32, _: Ref<IAdviseSink>) -> Result<u32> {
+        Err(Error::from_hresult(OLE_E_ADVISENOTSUPPORTED))
+    }
+    fn DUnadvise(&self, _: u32) -> Result<()> {
+        Err(Error::from_hresult(OLE_E_ADVISENOTSUPPORTED))
+    }
+    fn EnumDAdvise(&self) -> Result<IEnumSTATDATA> {
+        Err(Error::from_hresult(OLE_E_ADVISENOTSUPPORTED))
+    }
+}

--- a/crates/glass-clip-hook/src/hook/detour_impl.rs
+++ b/crates/glass-clip-hook/src/hook/detour_impl.rs
@@ -16,13 +16,13 @@ use retour::static_detour;
 use windows::core::BOOL;
 use windows::Win32::Foundation::{GlobalFree, HANDLE, HGLOBAL, HWND};
 use windows::Win32::Graphics::Gdi::{DeleteObject, HBITMAP, HGDIOBJ};
-use windows::Win32::System::DataExchange::{GetClipboardFormatNameW, RegisterClipboardFormatW};
 
 use crate::proto::FormatKey;
 
 use super::{
-    alloc_hglobal_bytes, read_bytes_from_hglobal, store_empty, store_get_bytes, store_list,
-    store_set_all, store_seq, unicode_to_codepage, user32_proc,
+    alloc_hglobal_bytes, id_of, key_of, locale_blob, read_bytes_from_hglobal, store_empty,
+    store_get_bytes, store_list, store_set_all, store_seq, unicode_to_codepage, user32_proc,
+    CF_BITMAP, CF_DIBV5, CF_LOCALE, CF_OEMTEXT, CF_TEXT,
 };
 
 // Exact raw ABI signatures of the user32 exports (from windows-rs `link!` declarations).
@@ -119,41 +119,6 @@ fn cache_bitmap(h: HBITMAP) {
 
 // ---- format id <-> FormatKey + synthesis -----------------------------------------------------
 
-// Standard Win32 clipboard format ids (stable ABI).
-const CF_TEXT: u32 = 1;
-const CF_BITMAP: u32 = 2;
-const CF_OEMTEXT: u32 = 7;
-const CF_LOCALE: u32 = 16;
-const CF_DIBV5: u32 = 17;
-
-/// Raw clipboard id → `FormatKey`: a registered (>=0xC000) id resolves to its NAME (portable across
-/// processes), everything else stays a `Standard` id.
-fn key_of(id: u32) -> FormatKey {
-    if id >= 0xC000 {
-        let mut buf = [0u16; 256];
-        // SAFETY: GetClipboardFormatNameW writes up to buf.len() chars into `buf` and returns the
-        // count (0 on failure); the slice bounds the read.
-        let n = unsafe { GetClipboardFormatNameW(id, &mut buf) };
-        if n > 0 {
-            return FormatKey::Named(String::from_utf16_lossy(&buf[..n as usize]));
-        }
-    }
-    FormatKey::Standard(id)
-}
-
-/// `FormatKey` → this process's clipboard id (re-registering named formats so the id is valid here).
-fn id_of(key: &FormatKey) -> u32 {
-    match key {
-        FormatKey::Standard(id) => *id,
-        FormatKey::Named(name) => {
-            let w: Vec<u16> = name.encode_utf16().chain(std::iter::once(0)).collect();
-            // SAFETY: `w` is a NUL-terminated UTF-16 buffer that outlives the call;
-            // RegisterClipboardFormatW returns this session's id for that name.
-            unsafe { RegisterClipboardFormatW(windows::core::PCWSTR::from_raw(w.as_ptr())) }
-        }
-    }
-}
-
 /// The clipboard ids currently available to the app: the stored canonical set plus locally
 /// synthesizable derivatives (`synth::available`), each mapped to this process's id.
 fn available_ids() -> Vec<u32> {
@@ -179,14 +144,6 @@ fn resolve_bytes(fmt: u32, key: &FormatKey) -> Option<Vec<u8>> {
         CF_BITMAP => src, // handed to make_bitmap_handle by the caller
         _ => return None,
     })
-}
-
-/// The 4-byte `CF_LOCALE` blob: the user's default LCID (little-endian).
-fn locale_blob() -> Vec<u8> {
-    use windows::Win32::Globalization::GetUserDefaultLCID;
-    // SAFETY: GetUserDefaultLCID takes no args and returns the LCID.
-    let lcid = unsafe { GetUserDefaultLCID() };
-    lcid.to_le_bytes().to_vec()
 }
 
 /// Build a GDI `HBITMAP` from a validated `CF_DIB` blob. Cached + freed via `DeleteObject`.
@@ -432,4 +389,5 @@ pub(super) fn install() {
             }
         }
     }
+    super::ole::install_ole();
 }

--- a/crates/glass-clip-hook/src/hook/ole.rs
+++ b/crates/glass-clip-hook/src/hook/ole.rs
@@ -1,0 +1,2 @@
+//! OLE clipboard detours (2a-ii). Filled in Task 4.
+pub(super) fn install_ole() {}

--- a/crates/glass-clip-hook/src/hook/ole.rs
+++ b/crates/glass-clip-hook/src/hook/ole.rs
@@ -100,6 +100,13 @@ unsafe fn marshal(data: &IDataObject) -> Vec<(FormatKey, Vec<u8>)> {
             let Ok(mut stg) = data.GetData(&req) else {
                 continue;
             };
+            // A non-conformant GetData may return a different medium than requested; reading the
+            // union by the requested tymed would then read the wrong member (UB). Validate first,
+            // releasing the medium so there is no leak before we skip.
+            if stg.tymed != tymed.0 as u32 {
+                ReleaseStgMedium(&mut stg);
+                continue;
+            }
             let bytes = if tymed == TYMED_HGLOBAL {
                 read_bytes_from_hglobal(stg.u.hGlobal)
             } else {

--- a/crates/glass-clip-hook/src/hook/ole.rs
+++ b/crates/glass-clip-hook/src/hook/ole.rs
@@ -1,2 +1,204 @@
-//! OLE clipboard detours (2a-ii). Filled in Task 4.
-pub(super) fn install_ole() {}
+//! The 4 `ole32` clipboard detours (2a-ii). Capture marshals the app's `IDataObject` eagerly into
+//! the store; serve hands back the baked-snapshot proxy (`dataobject::StoreDataObject`). Like the
+//! user32 detours, fully substituted (no trampoline) — so OLE's own internal user32 calls don't
+//! double-fire. Every body `catch_unwind`-guarded (a panic across a COM/HRESULT FFI boundary is UB).
+
+use std::cell::Cell;
+use std::ffi::c_void;
+use std::mem::ManuallyDrop;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+use retour::static_detour;
+use windows::core::{Interface, HRESULT};
+use windows::Win32::Foundation::{S_FALSE, S_OK};
+use windows::Win32::System::Com::{
+    IDataObject, IStream, DATADIR_GET, FORMATETC, STREAM_SEEK_SET, TYMED_HGLOBAL, TYMED_ISTREAM,
+};
+use windows::Win32::System::Ole::ReleaseStgMedium;
+
+use crate::proto::{FormatKey, MAX_ITEM_BYTES, MAX_TOTAL_BYTES};
+
+use super::dataobject::StoreDataObject;
+use super::{
+    key_of, ole32_proc, read_bytes_from_hglobal, store_empty, store_get_all, store_seq,
+    store_set_all,
+};
+
+type FnOleSet = unsafe extern "system" fn(*mut c_void) -> HRESULT;
+type FnOleGet = unsafe extern "system" fn(*mut *mut c_void) -> HRESULT;
+type FnOleFlush = unsafe extern "system" fn() -> HRESULT;
+type FnOleIsCurrent = unsafe extern "system" fn(*mut c_void) -> HRESULT;
+
+static_detour! {
+    static OleSetClipboardHook: unsafe extern "system" fn(*mut c_void) -> HRESULT;
+    static OleGetClipboardHook: unsafe extern "system" fn(*mut *mut c_void) -> HRESULT;
+    static OleFlushClipboardHook: unsafe extern "system" fn() -> HRESULT;
+    static OleIsCurrentClipboardHook: unsafe extern "system" fn(*mut c_void) -> HRESULT;
+}
+
+thread_local! {
+    /// (last `OleSetClipboard` object pointer, store seq right after that SetAll) — for
+    /// `OleIsCurrentClipboard`'s owner check.
+    static LAST_SET: Cell<(isize, u32)> = const { Cell::new((0, 0)) };
+}
+
+/// Read a `TYMED_ISTREAM` medium's bytes (Seek(0)+Read loop), capped at `MAX_ITEM_BYTES`.
+///
+/// # Safety
+/// `stream` is a live `IStream` from a `GetData` STGMEDIUM we own until `ReleaseStgMedium`.
+unsafe fn read_stream_bytes(stream: &IStream) -> Option<Vec<u8>> {
+    stream.Seek(0, STREAM_SEEK_SET, None).ok()?;
+    let mut out: Vec<u8> = Vec::new();
+    let mut chunk = [0u8; 64 * 1024];
+    loop {
+        let mut got = 0u32;
+        let hr = stream.Read(
+            chunk.as_mut_ptr() as *mut c_void,
+            chunk.len() as u32,
+            Some(&mut got),
+        );
+        if hr.is_err() || got == 0 {
+            break;
+        }
+        if out.len() + got as usize > MAX_ITEM_BYTES {
+            return None; // oversize: reject, never truncate
+        }
+        out.extend_from_slice(&chunk[..got as usize]);
+    }
+    Some(out)
+}
+
+/// Marshal every HGLOBAL/ISTREAM format of `data` to `(FormatKey, bytes)`, size-capped.
+///
+/// # Safety
+/// `data` is the app's live `IDataObject` (borrowed; we don't Release it).
+unsafe fn marshal(data: &IDataObject) -> Vec<(FormatKey, Vec<u8>)> {
+    let mut out: Vec<(FormatKey, Vec<u8>)> = Vec::new();
+    let mut total = 0usize;
+    let Ok(en) = data.EnumFormatEtc(DATADIR_GET.0 as u32) else {
+        return out;
+    };
+    loop {
+        let mut fe = [FORMATETC::default()];
+        let mut fetched = 0u32;
+        // The consuming `IEnumFORMATETC::Next` wrapper takes (&mut [FORMATETC], Option<*mut u32>).
+        if en.Next(&mut fe, Some(&mut fetched)).is_err() || fetched == 0 {
+            break;
+        }
+        let base = &fe[0];
+        for tymed in [TYMED_HGLOBAL, TYMED_ISTREAM] {
+            let req = FORMATETC {
+                cfFormat: base.cfFormat,
+                ptd: base.ptd,
+                dwAspect: base.dwAspect,
+                lindex: base.lindex,
+                tymed: tymed.0 as u32,
+            };
+            if data.QueryGetData(&req) != S_OK {
+                continue;
+            }
+            let Ok(mut stg) = data.GetData(&req) else {
+                continue;
+            };
+            let bytes = if tymed == TYMED_HGLOBAL {
+                read_bytes_from_hglobal(stg.u.hGlobal)
+            } else {
+                (*stg.u.pstm).as_ref().and_then(|s| read_stream_bytes(s))
+            };
+            ReleaseStgMedium(&mut stg);
+            if let Some(b) = bytes {
+                if b.len() <= MAX_ITEM_BYTES && total + b.len() <= MAX_TOTAL_BYTES {
+                    total += b.len();
+                    out.push((key_of(base.cfFormat as u32), b));
+                }
+                break; // captured this format; don't also try ISTREAM
+            }
+        }
+    }
+    out
+}
+
+fn ole_set_clipboard(p: *mut c_void) -> HRESULT {
+    catch_unwind(AssertUnwindSafe(|| {
+        if p.is_null() {
+            store_empty();
+            LAST_SET.with(|c| c.set((0, store_seq())));
+            return S_OK;
+        }
+        // Borrow the app's IDataObject without taking ownership (don't Release it).
+        // SAFETY: `p` is a valid IDataObject* the app passed to OleSetClipboard. `ManuallyDrop`
+        // prevents the final Release that `from_raw`'s owned interface would otherwise do.
+        let data = ManuallyDrop::new(unsafe { IDataObject::from_raw(p) });
+        let items = unsafe { marshal(&data) };
+        store_set_all(items);
+        LAST_SET.with(|c| c.set((p as isize, store_seq())));
+        S_OK
+    }))
+    .unwrap_or(S_OK)
+}
+
+fn ole_get_clipboard(pp: *mut *mut c_void) -> HRESULT {
+    catch_unwind(AssertUnwindSafe(|| {
+        if pp.is_null() {
+            return S_OK;
+        }
+        let obj: IDataObject = StoreDataObject::new(store_get_all()).into();
+        // Transfer one ref to the caller (who Releases it).
+        // SAFETY: `pp` is a valid out-param; into_raw hands over ownership.
+        unsafe { *pp = obj.into_raw() };
+        S_OK
+    }))
+    .unwrap_or(S_OK)
+}
+
+fn ole_flush_clipboard() -> HRESULT {
+    // We've eagerly stored; flush is a no-op. (Do not call the real OLE — we substitute it.)
+    S_OK
+}
+
+fn ole_is_current_clipboard(p: *mut c_void) -> HRESULT {
+    catch_unwind(AssertUnwindSafe(|| {
+        let (last_p, last_seq) = LAST_SET.with(|c| c.get());
+        if !p.is_null() && p as isize == last_p && store_seq() == last_seq {
+            S_OK
+        } else {
+            S_FALSE
+        }
+    }))
+    .unwrap_or(S_FALSE)
+}
+
+/// Resolve + enable the 4 ole32 detours. Fail-soft (a missing export is skipped).
+pub(super) fn install_ole() {
+    // SAFETY: each `ole32_proc` returns the export's absolute address, transmuted to its exact ABI;
+    // retour initialize/enable are unsafe by contract; every step is fallible and stays fail-soft.
+    unsafe {
+        if let Some(p) = ole32_proc(b"OleSetClipboard\0") {
+            let t: FnOleSet = std::mem::transmute(p);
+            if OleSetClipboardHook.initialize(t, ole_set_clipboard).is_ok() {
+                let _ = OleSetClipboardHook.enable();
+            }
+        }
+        if let Some(p) = ole32_proc(b"OleGetClipboard\0") {
+            let t: FnOleGet = std::mem::transmute(p);
+            if OleGetClipboardHook.initialize(t, ole_get_clipboard).is_ok() {
+                let _ = OleGetClipboardHook.enable();
+            }
+        }
+        if let Some(p) = ole32_proc(b"OleFlushClipboard\0") {
+            let t: FnOleFlush = std::mem::transmute(p);
+            if OleFlushClipboardHook.initialize(t, ole_flush_clipboard).is_ok() {
+                let _ = OleFlushClipboardHook.enable();
+            }
+        }
+        if let Some(p) = ole32_proc(b"OleIsCurrentClipboard\0") {
+            let t: FnOleIsCurrent = std::mem::transmute(p);
+            if OleIsCurrentClipboardHook
+                .initialize(t, ole_is_current_clipboard)
+                .is_ok()
+            {
+                let _ = OleIsCurrentClipboardHook.enable();
+            }
+        }
+    }
+}

--- a/crates/glass-clip-hook/src/hook/ole.rs
+++ b/crates/glass-clip-hook/src/hook/ole.rs
@@ -78,7 +78,10 @@ unsafe fn marshal(data: &IDataObject) -> Vec<(FormatKey, Vec<u8>)> {
     let Ok(en) = data.EnumFormatEtc(DATADIR_GET.0 as u32) else {
         return out;
     };
-    loop {
+    // Bound the enumeration: a non-conformant boxed `IDataObject` whose enumerator never reports
+    // exhaustion would otherwise spin this detour forever (capture must never hang). A real
+    // clipboard offers a few dozen formats; 256 is generous.
+    for _ in 0..256 {
         let mut fe = [FORMATETC::default()];
         let mut fetched = 0u32;
         // The consuming `IEnumFORMATETC::Next` wrapper takes (&mut [FORMATETC], Option<*mut u32>).

--- a/crates/glass-clip-hook/src/synth.rs
+++ b/crates/glass-clip-hook/src/synth.rs
@@ -38,6 +38,12 @@ pub(crate) fn available(stored: &[FormatKey]) -> Vec<FormatKey> {
     out
 }
 
+/// The formats the OLE proxy advertises: `available` minus GDI `CF_BITMAP` (the byte-serving proxy
+/// only produces HGLOBAL media; `CF_BITMAP` is a GDI handle served only by the user32 path).
+pub(crate) fn serve_keys(stored: &[FormatKey]) -> Vec<FormatKey> {
+    available(stored).into_iter().filter(|k| *k != Standard(CF_BITMAP)).collect()
+}
+
 /// If `requested` is a synthesizable derivative, the stored canonical key it derives from.
 pub(crate) fn canonical_for(requested: &FormatKey) -> Option<FormatKey> {
     let Standard(id) = requested else { return None };
@@ -88,5 +94,21 @@ mod tests {
     fn already_stored_is_not_duplicated() {
         let avail = available(&[Standard(13), Standard(1)]); // both stored
         assert_eq!(avail.iter().filter(|k| **k == Standard(1)).count(), 1);
+    }
+
+    #[test]
+    fn serve_keys_excludes_cf_bitmap_but_keeps_byte_derivatives() {
+        // CF_DIB stored → serve DIB + DIBV5 (byte) but NOT CF_BITMAP (GDI handle).
+        let keys = serve_keys(&[Standard(8)]);
+        assert!(keys.contains(&Standard(8))); // CF_DIB
+        assert!(keys.contains(&Standard(17))); // CF_DIBV5 (byte rewrite)
+        assert!(!keys.contains(&Standard(2)), "CF_BITMAP must be excluded: {keys:?}");
+        // CF_UNICODETEXT stored → text triad (all byte) kept.
+        let t = serve_keys(&[Standard(13)]);
+        for k in [Standard(13), Standard(1), Standard(7), Standard(16)] {
+            assert!(t.contains(&k), "missing {k:?}");
+        }
+        // Named formats pass through.
+        assert_eq!(serve_keys(&[Named("HTML Format".into())]), vec![Named("HTML Format".into())]);
     }
 }

--- a/crates/glass-windows/src/containment/clip_onbox.rs
+++ b/crates/glass-windows/src/containment/clip_onbox.rs
@@ -236,3 +236,108 @@ fn private_clipboard_multiformat() {
     );
     println!("PASS: boxed multi-format (text + HTML + DIB + synthesized CF_BITMAP) served by the private store; ambient untouched");
 }
+
+#[test]
+#[ignore = "on-box: needs Sandboxie + GLASS_CLIP_HOOK_DLL + the clipprobe example"]
+fn private_clipboard_ole() {
+    let dir = sandboxie_dir();
+    assert!(available(&dir), "Sandboxie not available at {dir}");
+
+    let probe = profile_dir().join("examples").join("clipprobe.exe");
+    assert!(
+        probe.exists(),
+        "build the probe first: cargo build -p glass-clip-hook --release --example clipprobe (looked at {})",
+        probe.display()
+    );
+    let dll = std::env::var("GLASS_CLIP_HOOK_DLL")
+        .expect("set GLASS_CLIP_HOOK_DLL to the built glass_clip_hook.dll");
+    assert!(
+        PathBuf::from(&dll).exists(),
+        "GLASS_CLIP_HOOK_DLL points at a missing file: {dll}"
+    );
+
+    let sentinel = format!("SENTINEL-{}", std::process::id());
+    crate::clipboard::set(&sentinel).expect("set ambient clipboard");
+
+    let sb = Sandboxie {
+        dir: dir.clone(),
+        box_name: format!("glass_clipole_{}", std::process::id()),
+    };
+    sb.configure(SandboxLevel::Default).expect("configure box");
+
+    let spec = AppSpec {
+        build: None,
+        run: vec![
+            probe.to_string_lossy().into_owned(),
+            "roundtrip-ole".into(),
+        ],
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        timeout_ms: 15000,
+        sandbox: SandboxLevel::Default,
+    };
+    let sink: Arc<Mutex<Vec<(Stream, String)>>> = Arc::new(Mutex::new(Vec::new()));
+    let app = sb.launch(&spec, sink.clone()).expect("launch boxed probe");
+
+    // The probe pushes a source IDataObject (text + named HTML) via OleSetClipboard, then reads it
+    // back via OleGetClipboard (glass's proxy) AND via raw user32 GetClipboardData (cross-surface
+    // coherence), ending with `PROBE-OLE-DONE`. Boxed (OpenClipboard=n), every readback is served by
+    // the hook from the private store.
+    let done = wait_for_log(&sink, "PROBE-OLE-DONE", Duration::from_secs(20));
+    let lines: Vec<String> = sink.lock().unwrap().iter().map(|(_, l)| l.clone()).collect();
+    eprintln!("--- boxed log sink: {} line(s) ---", lines.len());
+    for l in &lines {
+        eprintln!("  {l}");
+    }
+    eprintln!("--- end sink ---");
+
+    let store = app.private_clipboard();
+    let ambient_after = crate::clipboard::get().unwrap_or_default();
+    eprintln!(
+        "DIAG host_store_text={:?} keys={:?} ambient_after={:?} sentinel={:?}",
+        store.as_ref().map(|s| s.get_text()),
+        store.as_ref().map(|s| s.list()),
+        ambient_after,
+        sentinel
+    );
+    app.kill();
+
+    done.expect("probe produced no PROBE-OLE-DONE line (OLE detour not intercepting? check the sink)");
+
+    let readback = |prefix: &str| -> String {
+        lines
+            .iter()
+            .find_map(|l| l.strip_prefix(prefix).map(str::to_string))
+            .unwrap_or_default()
+    };
+    assert_eq!(readback("OLE-TEXT="), "OLE-FROM-BOX", "OLE text round-trip (OleGet → proxy)");
+    assert_eq!(readback("OLE-HTML="), "<i>ole</i>", "OLE HTML (named format) round-trip by name");
+    assert_eq!(
+        readback("U32-TEXT="),
+        "OLE-FROM-BOX",
+        "cross-surface coherence — OLE copy visible to user32 GetClipboardData"
+    );
+
+    let store = store.expect("Layer 2 inactive — GLASS_CLIP_HOOK_DLL not resolved / pipe server failed");
+    assert_eq!(
+        store.get_text().as_deref(),
+        Some("OLE-FROM-BOX"),
+        "host store text"
+    );
+    let keys = store.list();
+    assert!(
+        keys.contains(&glass_clip_hook::proto::FormatKey::Named("HTML Format".into())),
+        "host store missing HTML Format: {keys:?}"
+    );
+    assert!(
+        keys.contains(&glass_clip_hook::proto::FormatKey::Standard(13)),
+        "host store missing CF_UNICODETEXT: {keys:?}"
+    );
+
+    assert_eq!(
+        ambient_after, sentinel,
+        "AMBIENT CLIPBOARD WAS TOUCHED — isolation breach"
+    );
+    println!("PASS: boxed OLE copy served by the private store + visible to user32 (coherence); ambient untouched");
+}

--- a/crates/glass-windows/src/containment/mod.rs
+++ b/crates/glass-windows/src/containment/mod.rs
@@ -10,7 +10,7 @@ mod clip_server;
 mod sandboxie;
 
 // On-box (LOTUS) deterministic validation of the private-clipboard hook. Compiled only for the
-// Windows test profile; the single test inside is `#[ignore]`d (needs Sandboxie + the built DLL).
+// Windows test profile; the tests inside are `#[ignore]`d (need Sandboxie + the built DLL).
 #[cfg(all(test, windows))]
 mod clip_onbox;
 


### PR DESCRIPTION
## Summary

Adds an **OLE clipboard hook** so Windows apps that copy via the OLE clipboard (`OleSetClipboard` with an `IDataObject` — Word, Excel, PowerPoint, Chrome/Edge/Electron, Explorer, WPF/WinForms/Qt/Java) engage the sandboxed app's private clipboard, not just user32 apps. Builds on 2a-i (#4); rich apps were the gap, because they copy through OLE and delay-render the user32 formats.

- **Capture** — the `OleSetClipboard` detour marshals the app's `IDataObject` eagerly (`EnumFormatEtc`/`GetData` over `TYMED_HGLOBAL`+`TYMED_ISTREAM`) → the **same** 2a-i store (`store_set_all`). No store/proto/host changes.
- **Serve** — the `OleGetClipboard` detour returns a hand-rolled `#[implement(IDataObject)]` + `IEnumFORMATETC` proxy built from a one-shot store snapshot (zero pipe I/O inside `GetData`, so no COM reentrancy on paste). `OleFlushClipboard`→`S_OK`; `OleIsCurrentClipboard`→seq/ptr check.
- Both detour sets are fully substituted (no trampoline), so OLE's internal user32 calls don't double-fire. One store, two coherent surfaces.
- Reuses every pure 2a-i helper (`key_of`/`id_of`, `synth`, `dib`, `alloc_hglobal_bytes`); the only new pure logic (`serve_keys`) is Miri-tested.

## UB defense

The COM FFI is the riskiest surface, so each piece got an adversarial review and a fix:
- **`catch_unwind` on every one of the 13 `IDataObject`/`IEnumFORMATETC` methods** — the `windows` 0.62 `#[implement]` thunks have no panic guard and member-crate `panic=abort` is ignored by Cargo, so a panic across a COM vtable call would be UB.
- **STGMEDIUM `tymed` validated against the request before union access** — a hostile/non-conformant `IDataObject` returning a different medium than asked can't make us read the wrong union member.
- **The marshal enumeration is bounded** (256 formats) so a non-conformant boxed enumerator can't hang the detour (capture must never hang).
- The app's `IDataObject` is borrowed (`from_raw`+`ManuallyDrop`, refcount untouched); the proxy out-param transfers exactly one ref (`into_raw`); `ReleaseStgMedium` exactly once per successful `GetData`; fresh HGLOBAL per `GetData`.

## Validation

- Full windows-gnu closure cross-compiles clean; native MSVC builds on Win11; Linux tests + clippy + Miri green.
- **On-box (Win11), reproduced 4×:** a boxed app `OleSetClipboard`s an `IDataObject` (text + a named `"HTML Format"`), then reads it back via **both** `OleGetClipboard` (our proxy) **and** user32 `GetClipboardData` — proving cross-surface coherence (one store) — while the user's real clipboard stays at its sentinel (isolation).

Text/HTML/RTF/images; x64. Files (`CF_HDROP`, virtual `FileContents`) are the next phase (2b).

## Test plan

- [ ] CI green (check · miri · windows · x11 · wayland)
- [x] On-box: OLE round-trip + user32 coherence + isolation, reproduced 4×