### PR TITLE
Fix code-review findings: coords, silent failures, leaks, hangs, clipboard correctness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,6 +1021,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "glass-proc-linux"
+version = "0.0.0"
+
+[[package]]
 name = "glass-sandbox-linux"
 version = "0.0.0"
 dependencies = [
@@ -1050,6 +1054,7 @@ name = "glass-wayland"
 version = "0.0.0"
 dependencies = [
  "glass-core",
+ "glass-proc-linux",
  "glass-sandbox-linux",
  "rustix",
  "serde",
@@ -1079,6 +1084,7 @@ version = "0.0.0"
 dependencies = [
  "criterion",
  "glass-core",
+ "glass-proc-linux",
  "glass-sandbox-linux",
  "x11rb",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/glass-core", "crates/glass-x11", "crates/glass-testapp", "crates/glass-mcp", "crates/glass-wayland", "crates/glass-a11y-linux", "crates/glass-windows", "crates/glass-a11y-windows", "crates/glass-sandbox-linux", "crates/glass-clip-hook"]
+members = ["crates/glass-core", "crates/glass-x11", "crates/glass-testapp", "crates/glass-mcp", "crates/glass-wayland", "crates/glass-a11y-linux", "crates/glass-windows", "crates/glass-a11y-windows", "crates/glass-sandbox-linux", "crates/glass-proc-linux", "crates/glass-clip-hook"]
 
 [workspace.package]
 edition = "2021"
@@ -19,6 +19,7 @@ tempfile = "3"
 x11rb = { version = "0.13", features = ["xtest"] }
 glass-core = { path = "crates/glass-core" }
 glass-sandbox-linux = { path = "crates/glass-sandbox-linux" }
+glass-proc-linux = { path = "crates/glass-proc-linux" }
 glass-wayland = { path = "crates/glass-wayland" }
 glass-a11y-linux = { path = "crates/glass-a11y-linux" }
 atspi = { version = "0.30", features = ["tokio"] }

--- a/crates/glass-clip-hook/src/dib.rs
+++ b/crates/glass-clip-hook/src/dib.rs
@@ -14,10 +14,14 @@ pub(crate) struct DibInfo {
     pub width: i32,
     pub height: i32, // may be negative (top-down); magnitude used for size
     pub bpp: u16,
-    pub header_bytes: usize,      // 40 or 124
-    pub color_table_bytes: usize, // palette size in bytes
-    pub stride: usize,            // DWORD-aligned bytes per scan line
-    pub image_bytes: usize,       // stride * |height|
+    pub compression: u32, // biCompression: 0 = BI_RGB, 3 = BI_BITFIELDS (only these are accepted)
+    pub header_bytes: usize, // 40 or 124
+    // Bytes of the `bmiColors[]` area between header and pixels: an RGBQUAD palette
+    // (BI_RGB), or the 3 DWORD color masks (BI_BITFIELDS on a 40-byte header; on a
+    // 124-byte BITMAPV5HEADER the masks are header fields, so this is 0).
+    pub color_table_bytes: usize,
+    pub stride: usize,      // DWORD-aligned bytes per scan line
+    pub image_bytes: usize, // stride * |height|
 }
 
 fn rd_u16(b: &[u8], o: usize) -> Option<u16> {
@@ -44,23 +48,44 @@ fn parse_with_header(b: &[u8], header_bytes: usize) -> Option<DibInfo> {
     let bpp = rd_u16(b, 14)?;
     let compression = rd_u32(b, 16)?;
     let clr_used = rd_u32(b, 32)?;
-    if width <= 0 || bpp == 0 || compression != 0 {
-        return None; // top-down requires width>0; only BI_RGB (0) handled in v2a-i; reject others
+    if width <= 0 || bpp == 0 {
+        return None; // top-down requires width>0 (negative *height* is fine)
     }
     let abs_h = (height as i64).unsigned_abs();
-    // color table: for <=8bpp, clr_used (or 2^bpp if 0) entries of 4 bytes.
-    let color_table_bytes: usize = if bpp <= 8 {
-        let entries = if clr_used == 0 { 1u64 << bpp } else { clr_used as u64 };
-        if entries > 256 {
-            return None; // a palette can't exceed 2^8
+    // The bmiColors[] area between header and pixels. We accept BI_RGB (0) and
+    // BI_BITFIELDS (3); RLE/JPEG/PNG/ALPHABITFIELDS are rejected.
+    const BI_RGB: u32 = 0;
+    const BI_BITFIELDS: u32 = 3;
+    let color_table_bytes: usize = match compression {
+        BI_RGB if bpp <= 8 => {
+            // Palette: clr_used (or 2^bpp if 0) entries of 4 bytes.
+            let entries = if clr_used == 0 { 1u64 << bpp } else { clr_used as u64 };
+            if entries > 256 {
+                return None; // a palette can't exceed 2^8
+            }
+            (entries as usize) * 4
         }
-        (entries as usize) * 4
-    } else {
-        // High-bpp packed DIBs may carry a biClrUsed optimization palette
-        // (4 bytes/entry) between header and pixels; count it so the pixel
-        // offset stays correct. biClrUsed==0 (the common case) yields 0. Any
-        // absurd value is caught by the buffer-length check below, not here.
-        (clr_used as u64).checked_mul(4)?.try_into().ok()?
+        BI_RGB => {
+            // High-bpp packed DIBs may carry a biClrUsed optimization palette
+            // (4 bytes/entry); count it so the pixel offset stays correct.
+            // biClrUsed==0 (the common case) yields 0; absurd values are caught
+            // by the buffer-length check below, not here.
+            (clr_used as u64).checked_mul(4)?.try_into().ok()?
+        }
+        BI_BITFIELDS => {
+            // 16/32bpp only; the bmiColors[] area holds 3 DWORD color masks. On a
+            // 40-byte BITMAPINFOHEADER they're a 12-byte block before the pixels;
+            // on a 124-byte BITMAPV5HEADER they're header fields, so none follow.
+            if bpp != 16 && bpp != 32 {
+                return None;
+            }
+            if header_bytes == BIH {
+                12
+            } else {
+                0
+            }
+        }
+        _ => return None, // BI_RLE8/4, BI_JPEG, BI_PNG, BI_ALPHABITFIELDS
     };
     // stride = ((width*bpp + 31)/32)*4, all in u64 to avoid overflow.
     let bits = (width as u64).checked_mul(bpp as u64)?;
@@ -81,6 +106,7 @@ fn parse_with_header(b: &[u8], header_bytes: usize) -> Option<DibInfo> {
         width,
         height,
         bpp,
+        compression,
         header_bytes,
         color_table_bytes,
         stride,
@@ -98,18 +124,36 @@ pub(crate) fn parse_dibv5(b: &[u8]) -> Option<DibInfo> {
     parse_with_header(b, BV5)
 }
 
+/// Offsets of the three color-mask fields within a `BITMAPV5HEADER`
+/// (`bV5RedMask`, `bV5GreenMask`, `bV5BlueMask`); the 4th is `bV5AlphaMask` at 52.
+const BV5_MASKS: usize = 40;
+
 /// `CF_DIB` (BITMAPINFOHEADER) → `CF_DIBV5` (BITMAPV5HEADER): widen the header to 124 bytes (zero the
-/// new fields; the OS supplies sRGB defaults when color-space is absent), keep table + bits verbatim.
+/// new fields; the OS supplies sRGB defaults when color-space is absent), keep the pixel bits.
+///
+/// For BI_BITFIELDS the 3 masks that follow a 40-byte header move INTO the V5 header's mask fields
+/// (a verbatim copy would leave them after the header — an invalid V5); BI_RGB palette + bits are
+/// copied verbatim.
 pub(crate) fn dib_to_dibv5(b: &[u8]) -> Option<Vec<u8>> {
     let d = parse_dib(b)?;
     let mut out = vec![0u8; BV5];
     out[..BIH].copy_from_slice(&b[..BIH]);
     out[0..4].copy_from_slice(&(BV5 as u32).to_le_bytes()); // biSize = 124
-    out.extend_from_slice(&b[BIH..BIH + d.color_table_bytes + d.image_bytes]);
+    if d.compression == 3 {
+        // Relocate the 3 RGB masks (b[40..52]) into bV5Red/Green/BlueMask; the
+        // pixels follow the masks in the source, so skip them when copying bits.
+        out[BV5_MASKS..BV5_MASKS + 12].copy_from_slice(&b[BIH..BIH + 12]);
+        out.extend_from_slice(&b[BIH + 12..BIH + 12 + d.image_bytes]);
+    } else {
+        out.extend_from_slice(&b[BIH..BIH + d.color_table_bytes + d.image_bytes]);
+    }
     Some(out)
 }
 
-/// `CF_DIBV5` → `CF_DIB`: narrow the header back to 40 bytes; keep table + bits verbatim.
+/// `CF_DIBV5` → `CF_DIB`: narrow the header back to 40 bytes; keep the pixel bits.
+///
+/// For BI_BITFIELDS the V5 header's mask fields become a 12-byte block after the 40-byte header
+/// (the BITMAPINFOHEADER layout); BI_RGB palette + bits are copied verbatim.
 ///
 /// Used by the host-side server path + the tests; the DLL hook only ever widens DIB→DIBV5.
 #[cfg_attr(not(test), allow(dead_code))]
@@ -118,7 +162,14 @@ pub(crate) fn dibv5_to_dib(b: &[u8]) -> Option<Vec<u8>> {
     let mut out = vec![0u8; BIH];
     out.copy_from_slice(&b[..BIH]);
     out[0..4].copy_from_slice(&(BIH as u32).to_le_bytes());
-    out.extend_from_slice(&b[BV5..BV5 + d.color_table_bytes + d.image_bytes]);
+    if d.compression == 3 {
+        // Masks are header fields in the V5; emit them as the 12-byte block a
+        // BITMAPINFOHEADER expects between header and pixels.
+        out.extend_from_slice(&b[BV5_MASKS..BV5_MASKS + 12]);
+        out.extend_from_slice(&b[BV5..BV5 + d.image_bytes]);
+    } else {
+        out.extend_from_slice(&b[BV5..BV5 + d.color_table_bytes + d.image_bytes]);
+    }
     Some(out)
 }
 
@@ -223,6 +274,77 @@ mod tests {
         h[14..16].copy_from_slice(&8u16.to_le_bytes()); // 8bpp
         h[32..36].copy_from_slice(&u32::MAX.to_le_bytes()); // biClrUsed = 2^32-1 → absurd table
         assert!(parse_dib(&h).is_none());
+    }
+
+    // A 1x1 32bpp BI_BITFIELDS BITMAPINFOHEADER with the 3 RGB DWORD masks that
+    // follow it (no pixels appended).
+    fn bih_bitfields_1x1_32() -> Vec<u8> {
+        let mut v = bih_2x2_32();
+        v[4..8].copy_from_slice(&1i32.to_le_bytes()); // width=1
+        v[8..12].copy_from_slice(&1i32.to_le_bytes()); // height=1
+        v[16..20].copy_from_slice(&3u32.to_le_bytes()); // biCompression = BI_BITFIELDS
+        v.extend_from_slice(&0x00FF_0000u32.to_le_bytes()); // red mask
+        v.extend_from_slice(&0x0000_FF00u32.to_le_bytes()); // green mask
+        v.extend_from_slice(&0x0000_00FFu32.to_le_bytes()); // blue mask
+        v
+    }
+
+    #[test]
+    fn parses_bi_bitfields_with_mask_block() {
+        let mut v = bih_bitfields_1x1_32();
+        v.extend_from_slice(&[0xCC; 4]); // 1px * 4B pixels (stride 4)
+        let d = parse_dib(&v).expect("BITFIELDS DIB");
+        assert_eq!(d.compression, 3);
+        assert_eq!(d.color_table_bytes, 12, "3 DWORD masks sit between header and pixels");
+        assert_eq!(d.image_bytes, 4);
+        assert_eq!(
+            &v[d.header_bytes + d.color_table_bytes..][..4],
+            &[0xCC; 4],
+            "pixels start after the mask block"
+        );
+    }
+
+    #[test]
+    fn rejects_rle_jpeg_png_and_alphabitfields() {
+        for comp in [1u32, 2, 4, 5, 6] {
+            let mut v = bih_2x2_32();
+            v[16..20].copy_from_slice(&comp.to_le_bytes());
+            v.extend_from_slice(&[0u8; 16]);
+            assert!(parse_dib(&v).is_none(), "compression {comp} must be rejected");
+        }
+    }
+
+    #[test]
+    fn rejects_bitfields_at_unsupported_bpp() {
+        let mut v = bih_bitfields_1x1_32();
+        v[14..16].copy_from_slice(&8u16.to_le_bytes()); // 8bpp + BITFIELDS is invalid
+        v.extend_from_slice(&[0u8; 4]);
+        assert!(parse_dib(&v).is_none(), "BITFIELDS is only valid for 16/32bpp");
+    }
+
+    #[test]
+    fn bitfields_round_trips_dib_v5_dib() {
+        let mut dib = bih_bitfields_1x1_32();
+        dib.extend_from_slice(&[0xCC; 4]);
+
+        // Widen: the masks must move INTO the V5 header (offsets 40/44/48), not
+        // be appended after it (which would be an invalid V5).
+        let v5 = dib_to_dibv5(&dib).expect("widen");
+        assert_eq!(&v5[40..44], &0x00FF_0000u32.to_le_bytes(), "bV5RedMask");
+        assert_eq!(&v5[44..48], &0x0000_FF00u32.to_le_bytes(), "bV5GreenMask");
+        assert_eq!(&v5[48..52], &0x0000_00FFu32.to_le_bytes(), "bV5BlueMask");
+        let pv5 = parse_dibv5(&v5).expect("parse v5");
+        assert_eq!(pv5.compression, 3);
+        assert_eq!(pv5.color_table_bytes, 0, "V5 carries the masks in-header");
+        assert_eq!(pv5.image_bytes, 4);
+
+        // Narrow back: masks return to a 12-byte block after the 40-byte header.
+        let back = dibv5_to_dib(&v5).expect("narrow");
+        let pback = parse_dib(&back).expect("parse back");
+        assert_eq!(pback.compression, 3);
+        assert_eq!(pback.color_table_bytes, 12);
+        assert_eq!(&back[40..52], &dib[40..52], "masks survive the round-trip");
+        assert_eq!(pback.image_bytes, 4);
     }
 
     #[test]

--- a/crates/glass-clip-hook/src/dib.rs
+++ b/crates/glass-clip-hook/src/dib.rs
@@ -49,14 +49,18 @@ fn parse_with_header(b: &[u8], header_bytes: usize) -> Option<DibInfo> {
     }
     let abs_h = (height as i64).unsigned_abs();
     // color table: for <=8bpp, clr_used (or 2^bpp if 0) entries of 4 bytes.
-    let color_table_bytes = if bpp <= 8 {
+    let color_table_bytes: usize = if bpp <= 8 {
         let entries = if clr_used == 0 { 1u64 << bpp } else { clr_used as u64 };
         if entries > 256 {
             return None; // a palette can't exceed 2^8
         }
         (entries as usize) * 4
     } else {
-        0
+        // High-bpp packed DIBs may carry a biClrUsed optimization palette
+        // (4 bytes/entry) between header and pixels; count it so the pixel
+        // offset stays correct. biClrUsed==0 (the common case) yields 0. Any
+        // absurd value is caught by the buffer-length check below, not here.
+        (clr_used as u64).checked_mul(4)?.try_into().ok()?
     };
     // stride = ((width*bpp + 31)/32)*4, all in u64 to avoid overflow.
     let bits = (width as u64).checked_mul(bpp as u64)?;
@@ -189,6 +193,28 @@ mod tests {
         let mut v = bih_2x2_32(); // declares a 2x2x32 image (16 bytes) but we append only 4
         v.extend_from_slice(&[0u8; 4]);
         assert!(parse_dib(&v).is_none());
+    }
+
+    #[test]
+    fn honors_high_bpp_optimization_palette() {
+        // A 32bpp BI_RGB DIB may legally carry a biClrUsed optimization palette
+        // (4 bytes/entry) between the header and the pixels. It must be counted,
+        // or every consumer mislocates the pixel bits (silent corruption).
+        let mut v = bih_2x2_32();
+        v[8..12].copy_from_slice(&1i32.to_le_bytes()); // height=1 (keep it small)
+        v[4..8].copy_from_slice(&1i32.to_le_bytes()); // width=1 → stride 4, image 4
+        v[32..36].copy_from_slice(&2u32.to_le_bytes()); // biClrUsed = 2 → 8 palette bytes
+        v.extend_from_slice(&[0xAA; 8]); // palette
+        v.extend_from_slice(&[0xBB; 4]); // 1px * 4B pixels
+        let d = parse_dib(&v).expect("valid high-bpp DIB with palette");
+        assert_eq!(d.color_table_bytes, 8, "biClrUsed palette must be counted for bpp>8");
+        assert_eq!(d.image_bytes, 4);
+        // Pixels must be located after header + palette (40 + 8 = 48), not at 40.
+        assert_eq!(
+            &v[d.header_bytes + d.color_table_bytes..][..d.image_bytes],
+            &[0xBB; 4],
+            "pixel offset must skip the palette"
+        );
     }
 
     #[test]

--- a/crates/glass-mcp/src/tools/wait.rs
+++ b/crates/glass-mcp/src/tools/wait.rs
@@ -71,9 +71,14 @@ pub fn wait_for_region(glass: &mut Glass, a: &WaitForRegionArgs) -> ToolResult {
         timeout_ms: a.timeout_ms.unwrap_or(10_000),
     };
     let o = glass.wait_for_region(&params).map_err(|e| e.to_string())?;
+    // `wait_for_region` diffs region-cropped frames, so its bbox originates at
+    // the crop's (0,0). Translate back to window coordinates before returning
+    // (coordinates are window-relative at the tool boundary; this also keeps it
+    // consistent with glass_diff, whose bbox is already window-relative).
+    let (ox, oy) = a.region.as_ref().map_or((0, 0), |r| (r.x, r.y));
     let bbox = o
         .bbox
-        .map(|b| json!({ "x": b.x, "y": b.y, "width": b.width, "height": b.height }));
+        .map(|b| json!({ "x": b.x + ox, "y": b.y + oy, "width": b.width, "height": b.height }));
     let meta = json!({
         "matched": o.matched,
         "changed_pct": o.changed_pct,
@@ -254,6 +259,43 @@ mod tests {
         assert_eq!(out.0.len(), 1, "no include_image -> text only");
         match out.0.last().unwrap() {
             OutContent::Text(t) => assert!(t.contains("\"matched\":true"), "got: {t}"),
+            _ => panic!("expected text"),
+        }
+    }
+
+    #[test]
+    fn region_bbox_is_window_relative_not_crop_relative() {
+        // A non-zero-origin region must report its change bbox in WINDOW
+        // coordinates, not relative to the crop (the window-relative-at-the-
+        // tool-boundary invariant; also keeps it consistent with glass_diff).
+        // Window 4x4, region {2,2,2,2}; the whole region flips black->white so
+        // the bbox covers the full crop: crop-relative would be (0,0), but
+        // window-relative must be (2,2).
+        let black = Frame::solid(4, 4, [0, 0, 0, 255]);
+        let white = Frame::solid(4, 4, [255, 255, 255, 255]);
+        let mut g = glass_with(FakePlatform::new(4, 4).with_frames(vec![black, white]));
+        g.start(&AppSpec {
+            build: None,
+            run: vec!["x".into()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 1,
+            sandbox: glass_core::SandboxLevel::Off,
+        })
+        .unwrap();
+        let mut a = region_args();
+        a.region = Some(RegionArgs { x: 2, y: 2, width: 2, height: 2 });
+        let out = wait_for_region(&mut g, &a).unwrap();
+        match out.0.last().unwrap() {
+            OutContent::Text(t) => {
+                let v: serde_json::Value = serde_json::from_str(t).unwrap();
+                assert_eq!(v["matched"], true, "got: {t}");
+                assert_eq!(v["bbox"]["x"], 2, "bbox x must be window-relative; got: {t}");
+                assert_eq!(v["bbox"]["y"], 2, "bbox y must be window-relative; got: {t}");
+                assert_eq!(v["bbox"]["width"], 2, "got: {t}");
+                assert_eq!(v["bbox"]["height"], 2, "got: {t}");
+            }
             _ => panic!("expected text"),
         }
     }

--- a/crates/glass-proc-linux/Cargo.toml
+++ b/crates/glass-proc-linux/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "glass-proc-linux"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[dependencies]

--- a/crates/glass-proc-linux/src/lib.rs
+++ b/crates/glass-proc-linux/src/lib.rs
@@ -1,0 +1,131 @@
+//! Linux process-tree introspection via `/proc`.
+//!
+//! A small, backend-agnostic utility shared by the Linux display backends
+//! (`glass-x11`, `glass-wayland`): given the pid glass spawned, enumerate that
+//! process **and all its descendants**. Both backends need this because the
+//! process they spawn is frequently *not* the app — it's a wrapper (a `bwrap`
+//! sandbox, sway's `exec`, a shell launcher), and the real app is a descendant
+//! with a different pid. The full set is used to correlate windows
+//! (`_NET_WM_PID`) and the accessibility tree (the AT-SPI connection pid) back
+//! to the launch.
+//!
+//! This is deliberately *not* in `glass-core` (it is OS-specific `/proc` I/O,
+//! which belongs behind the `Platform` seam, not in the portable core) nor in
+//! the sandbox crate (it is generic process introspection, unrelated to
+//! bubblewrap). The Windows peer (`descendant_pids`, Toolhelp-based) lives with
+//! the Windows backend for the same reason — the OS APIs can't share an impl.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+/// The pid `root_pid` plus every descendant process, read from `/proc`.
+///
+/// Returns `[root_pid]` if `/proc` is unavailable, and just `[root_pid]` if it
+/// has no children yet (callers poll in a loop, so an empty subtree simply
+/// means "retry"). Cycle-safe even if PID reuse mid-scan produces a bogus
+/// parent cycle (see [`collect_descendants`]).
+pub fn proc_tree_pids(root_pid: u32) -> Vec<u32> {
+    // Read all (pid → ppid) pairs from /proc.
+    let proc = match std::fs::read_dir("/proc") {
+        Ok(d) => d,
+        Err(_) => return vec![root_pid],
+    };
+    let mut parent_of: HashMap<u32, u32> = HashMap::new();
+    for entry in proc.flatten() {
+        let name = entry.file_name();
+        let pid_str = name.to_string_lossy();
+        let Ok(pid) = pid_str.parse::<u32>() else { continue };
+        let status_path = format!("/proc/{pid}/status");
+        let Ok(content) = std::fs::read_to_string(&status_path) else { continue };
+        for line in content.lines() {
+            if let Some(rest) = line.strip_prefix("PPid:") {
+                if let Ok(ppid) = rest.trim().parse::<u32>() {
+                    parent_of.insert(pid, ppid);
+                }
+                break;
+            }
+        }
+    }
+    collect_descendants(root_pid, &parent_of)
+}
+
+/// Collect `root` and all its descendants given a child→parent-pid map.
+/// Cycle-safe (a `seen` set guarantees termination even if the map contains a
+/// cycle, e.g. from PID reuse mid-scan).
+fn collect_descendants(root: u32, parent_of: &HashMap<u32, u32>) -> Vec<u32> {
+    let mut seen: HashSet<u32> = HashSet::new();
+    let mut out = Vec::new();
+    let mut q = VecDeque::from([root]);
+    while let Some(pid) = q.pop_front() {
+        if !seen.insert(pid) {
+            continue;
+        }
+        out.push(pid);
+        for (&child, &ppid) in parent_of {
+            if ppid == pid && !seen.contains(&child) {
+                q.push_back(child);
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{collect_descendants, proc_tree_pids};
+    use std::collections::HashMap;
+
+    #[test]
+    fn descendants_normal_tree() {
+        // root 100 → children 200, 201; 200 → child 300
+        let mut parent_of = HashMap::new();
+        parent_of.insert(200u32, 100u32);
+        parent_of.insert(201u32, 100u32);
+        parent_of.insert(300u32, 200u32);
+        let mut result = collect_descendants(100, &parent_of);
+        result.sort();
+        assert_eq!(result, vec![100, 200, 201, 300]);
+    }
+
+    #[test]
+    fn descendants_cycle_terminates() {
+        // Cycle: parent_of[100] = 200, parent_of[200] = 100
+        // (simulates PID-reuse creating a bogus cycle in the map mid-scan)
+        let mut parent_of = HashMap::new();
+        parent_of.insert(100u32, 200u32);
+        parent_of.insert(200u32, 100u32);
+        // Must terminate and include the root.
+        let result = collect_descendants(100, &parent_of);
+        assert!(result.contains(&100), "root must be present even with a cycle");
+        assert!(result.len() <= 2, "cycle must not cause unbounded growth");
+    }
+
+    #[test]
+    fn descendants_root_only() {
+        let parent_of: HashMap<u32, u32> = HashMap::new();
+        assert_eq!(collect_descendants(42, &parent_of), vec![42]);
+    }
+
+    #[test]
+    fn proc_tree_pids_includes_a_real_descendant() {
+        // For a wrapped launch (bwrap / sway exec / shell) the spawned child is
+        // the wrapper and the real app is a *descendant* with a different pid;
+        // proc_tree_pids must walk down to it (a plain `[child_pid]` would not).
+        use std::process::{Command, Stdio};
+        let mut child = Command::new("sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn sleep");
+        let child_pid = child.id();
+        let pids = proc_tree_pids(std::process::id());
+        let _ = child.kill();
+        let _ = child.wait();
+        assert!(pids.contains(&std::process::id()), "must include the root pid");
+        assert!(
+            pids.contains(&child_pid),
+            "must include the spawned descendant pid {child_pid}; got {pids:?}"
+        );
+    }
+}

--- a/crates/glass-wayland/Cargo.toml
+++ b/crates/glass-wayland/Cargo.toml
@@ -9,6 +9,7 @@ publish.workspace = true
 [dependencies]
 glass-core.workspace = true
 glass-sandbox-linux.workspace = true
+glass-proc-linux.workspace = true
 wayland-client.workspace = true
 wayland-protocols-wlr.workspace = true
 wayland-protocols-misc.workspace = true

--- a/crates/glass-wayland/src/clipboard.rs
+++ b/crates/glass-wayland/src/clipboard.rs
@@ -7,12 +7,17 @@
 //! the X11 owner-thread pattern.
 
 use std::io::{Read, Write};
-use std::os::fd::AsFd;
+use std::os::fd::{AsFd, OwnedFd};
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Condvar, Mutex};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
+
+/// Cap on how long `get()` waits for the selection owner to finish writing the
+/// transfer pipe. The owner is an arbitrary external app, so a stuck/slow one
+/// must not hang the server (the X11 backend guards the analogous read with 1s).
+const CLIP_READ_TIMEOUT: Duration = Duration::from_secs(2);
 
 use wayland_client::globals::registry_queue_init;
 use wayland_client::protocol::wl_seat;
@@ -401,15 +406,56 @@ pub fn get(socket: &Path) -> Result<String> {
         .roundtrip(&mut state)
         .map_err(|e| GlassError::Backend(format!("clipboard get: roundtrip3: {e}")))?;
 
-    // Read to EOF from the read end.
-    let mut buf = Vec::new();
-    let mut file = std::fs::File::from(read_end);
-    file.read_to_end(&mut buf)
-        .map_err(|e| GlassError::Backend(format!("clipboard get: read pipe: {e}")))?;
+    // Read to EOF from the read end, bounded by a deadline so a misbehaving
+    // selection owner can't hang us forever (see CLIP_READ_TIMEOUT).
+    let buf = read_to_eof_bounded(read_end, CLIP_READ_TIMEOUT)?;
 
     offer.destroy();
 
     Ok(String::from_utf8_lossy(&buf).into_owned())
+}
+
+/// Read `fd` to EOF, but give up after `timeout`. The selection owner is an
+/// arbitrary external app; one that opens the transfer but never finishes
+/// writing (or never closes its write end) would otherwise block this read —
+/// and, via the session-wide Glass lock, every other tool call. Poll the fd
+/// with the remaining deadline and read when ready; we are the pipe's sole
+/// reader, so a poll-ready read never blocks. Returns `Timeout` on expiry.
+fn read_to_eof_bounded(fd: OwnedFd, timeout: Duration) -> Result<Vec<u8>> {
+    let deadline = Instant::now() + timeout;
+    let mut file = std::fs::File::from(fd);
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 8192];
+    loop {
+        let now = Instant::now();
+        if now >= deadline {
+            return Err(GlassError::Timeout(timeout.as_millis() as u64));
+        }
+        let remaining = deadline - now;
+        let ts = rustix::event::Timespec {
+            tv_sec: remaining.as_secs() as i64,
+            tv_nsec: remaining.subsec_nanos() as i64,
+        };
+        // The PollFd borrows `file` only for this statement, freeing it before
+        // the read below.
+        let ready = rustix::event::poll(
+            &mut [rustix::event::PollFd::new(&file, rustix::event::PollFlags::IN)],
+            Some(&ts),
+        );
+        match ready {
+            Ok(0) => return Err(GlassError::Timeout(timeout.as_millis() as u64)),
+            Ok(_) => match file.read(&mut chunk) {
+                Ok(0) => return Ok(buf), // EOF
+                Ok(n) => buf.extend_from_slice(&chunk[..n]),
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(e) => {
+                    return Err(GlassError::Backend(format!("clipboard get: read pipe: {e}")))
+                }
+            },
+            Err(rustix::io::Errno::INTR) => continue,
+            Err(e) => return Err(GlassError::Backend(format!("clipboard get: poll: {e}"))),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -671,4 +717,32 @@ fn serve_loop(
     // Signal that this owner has stopped so the platform can re-spawn if needed.
     stop.store(true, Ordering::Relaxed);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{read_to_eof_bounded, CLIP_READ_TIMEOUT};
+    use glass_core::GlassError;
+    use std::io::Write;
+    use std::time::Duration;
+
+    #[test]
+    fn bounded_read_times_out_when_writer_stalls() {
+        // Writer end open but silent — a stuck/slow selection owner that opened
+        // the transfer but never finishes writing. Must NOT hang forever.
+        let (read_end, _write_end) = rustix::pipe::pipe().expect("pipe");
+        let r = read_to_eof_bounded(read_end, Duration::from_millis(200));
+        assert!(matches!(r, Err(GlassError::Timeout(_))), "expected Timeout, got {r:?}");
+        // _write_end stays alive above so no EOF is signalled during the read.
+    }
+
+    #[test]
+    fn bounded_read_collects_until_eof() {
+        let (read_end, write_end) = rustix::pipe::pipe().expect("pipe");
+        let mut w = std::fs::File::from(write_end);
+        w.write_all(b"clip!").expect("write");
+        drop(w); // close the write end → EOF
+        let got = read_to_eof_bounded(read_end, CLIP_READ_TIMEOUT).expect("read ok");
+        assert_eq!(got, b"clip!");
+    }
 }

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -500,7 +500,11 @@ fn bring_up_session(
             break s;
         }
         if let Ok(Some(status)) = child.try_wait() {
-            let _ = child.wait();
+            // sway exited — but on an *unclean* exit its group children
+            // (Xwayland + the exec'd app) can outlive it. Reap the whole
+            // group, not just the leader, or a leaked Xwayland holds the X
+            // display in the global namespace and breaks the next session.
+            reap_group(&mut child);
             return Err(GlassError::AppExited(status.code()));
         }
         if Instant::now() >= deadline {
@@ -534,7 +538,9 @@ fn bring_up_session(
                 break (Some(w.identifier.clone()), rect_to_geom(&w.rect));
             }
             if let Ok(Some(status)) = child.try_wait() {
-                let _ = child.wait();
+                // Reap the whole group (see the socket-wait loop above): an
+                // unclean sway exit can orphan Xwayland + the app otherwise.
+                reap_group(&mut child);
                 return Err(GlassError::AppExited(status.code()));
             }
             if Instant::now() >= deadline {

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -195,6 +195,19 @@ fn parse_sway_version(s: &str) -> Option<(u32, u32)> {
     Some((major, minor))
 }
 
+/// Pick an output-x one pixel away from `axx` for the focus-reassert nudge.
+/// sway only re-evaluates pointer focus on motion, so the intermediate point
+/// must be a genuine delta. Nudging left (`axx - 1`) is a no-op at the left
+/// edge (`axx == 0`), which silently lost the first click/scroll there — so
+/// nudge right instead, clamped to stay on a `w`-wide output.
+fn nudge_x(axx: u32, w: u32) -> u32 {
+    if axx > 0 {
+        axx - 1
+    } else {
+        (axx + 1).min(w.saturating_sub(1))
+    }
+}
+
 /// Find sway's `wayland-N` socket in the private runtime dir (sway uses
 /// `wayland-1`, not cage's `wayland-0`). Ignores `wayland-N.lock` and `sway-ipc.*`.
 fn find_wayland_socket(dir: &Path) -> Option<PathBuf> {
@@ -780,7 +793,7 @@ impl Platform for WaylandPlatform {
             vp.motion_absolute(t, ax(x), ay(y), w, h);
             vp.frame();
             settle(q, s)?;
-            vp.motion_absolute(t, ax(x).saturating_sub(1), ay(y), w, h);
+            vp.motion_absolute(t, nudge_x(ax(x), w), ay(y), w, h);
             vp.frame();
             vp.motion_absolute(t, ax(x), ay(y), w, h);
             vp.frame();
@@ -991,7 +1004,7 @@ impl Platform for WaylandPlatform {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_sway_version;
+    use super::{nudge_x, parse_sway_version};
 
     #[test]
     fn parse_sway_version_handles_real_and_garbage() {
@@ -999,5 +1012,24 @@ mod tests {
         assert_eq!(parse_sway_version("sway version 1.9"), Some((1, 9)));
         assert_eq!(parse_sway_version("not a version"), None);
         assert!((1u32, 12u32) >= (1, 12) && (1u32, 9u32) < (1, 12));
+    }
+
+    #[test]
+    fn nudge_x_always_differs_from_target() {
+        // Interior: nudge one pixel left.
+        assert_eq!(nudge_x(5, 100), 4);
+        assert_eq!(nudge_x(1, 100), 0);
+        // Right edge stays on-output and still differs.
+        assert_eq!(nudge_x(99, 100), 98);
+        // Left edge (output x==0): must NOT be a no-op — nudge right instead.
+        assert_eq!(nudge_x(0, 100), 1);
+        // The core regression property: on any real (>=2px wide) output the
+        // nudge is always a genuine motion delta, so sway re-evaluates focus.
+        for w in 2..=64u32 {
+            for x in 0..w {
+                assert_ne!(nudge_x(x, w), x, "no-op nudge at x={x}, w={w}");
+                assert!(nudge_x(x, w) < w, "nudge off-output at x={x}, w={w}");
+            }
+        }
     }
 }

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -1006,6 +1006,21 @@ impl Platform for WaylandPlatform {
     fn drain_logs(&mut self) -> Vec<(Stream, String)> {
         std::mem::take(&mut *self.logs.lock().unwrap())
     }
+
+    /// The app's process subtree. The child we spawn is **sway**, which launches
+    /// the app as an `exec` descendant (under a shell, and `bwrap` when
+    /// sandboxed), so the real app has a different pid. The a11y reader
+    /// correlates the AT-SPI connection pid against this set, so it must include
+    /// the descendants — the inherited single-pid default leaves it empty and the
+    /// reader can't tell apps apart. Mirrors the X11 backend's `app_pids()`.
+    /// (We intentionally don't override `app_pid()`: there is no single
+    /// authoritative app pid here — sway's pid isn't the app's.)
+    fn app_pids(&self) -> Vec<u32> {
+        match &self.active {
+            Some(s) => glass_proc_linux::proc_tree_pids(s.child.id()),
+            None => Vec::new(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/glass-windows/src/clipboard.rs
+++ b/crates/glass-windows/src/clipboard.rs
@@ -10,7 +10,9 @@ use windows::Win32::Foundation::{GlobalFree, HANDLE, HGLOBAL};
 use windows::Win32::System::DataExchange::{
     CloseClipboard, EmptyClipboard, GetClipboardData, OpenClipboard, SetClipboardData,
 };
-use windows::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
+use windows::Win32::System::Memory::{
+    GlobalAlloc, GlobalLock, GlobalSize, GlobalUnlock, GMEM_MOVEABLE,
+};
 use windows::Win32::System::Ole::CF_UNICODETEXT;
 
 use glass_core::{GlassError, Result};
@@ -65,14 +67,20 @@ fn read_clipboard_text() -> Result<String> {
         return Err(GlassError::Backend("GlobalLock failed on clipboard handle".into()));
     }
 
-    // Read the NUL-terminated UTF-16 string.
+    // The clipboard owner is an arbitrary (possibly malicious/buggy) app, so we
+    // can't trust the CF_UNICODETEXT block to actually be NUL-terminated. Bound
+    // the scan by the block's real size (GlobalSize) so a non-terminated buffer
+    // can't read past the allocation (UB) — stop at the first NUL or the cap.
+    // SAFETY: hglobal is the locked clipboard handle; GlobalSize reports its
+    // allocated byte length (0 on error → empty read, still safe).
+    let max_wchars = unsafe { GlobalSize(hglobal) } / std::mem::size_of::<u16>();
     let text = {
-        // SAFETY: `ptr` is valid UTF-16 data locked from the clipboard handle.
-        // We walk until the NUL terminator, which CF_UNICODETEXT data must have.
+        // SAFETY: `ptr` points at the locked block; the loop indexes strictly
+        // less than `max_wchars` u16s, all within the GlobalSize-reported bytes.
         let wchars: *const u16 = ptr as *const u16;
         let mut len = 0usize;
         unsafe {
-            while *wchars.add(len) != 0 {
+            while len < max_wchars && *wchars.add(len) != 0 {
                 len += 1;
             }
             let slice = std::slice::from_raw_parts(wchars, len);

--- a/crates/glass-windows/src/containment/clip_onbox.rs
+++ b/crates/glass-windows/src/containment/clip_onbox.rs
@@ -68,10 +68,7 @@ fn private_clipboard_isolation() {
     let sentinel = format!("SENTINEL-{}", std::process::id());
     crate::clipboard::set(&sentinel).expect("set ambient clipboard");
 
-    let sb = Sandboxie {
-        dir: dir.clone(),
-        box_name: format!("glass_cliptest_{}", std::process::id()),
-    };
+    let sb = Sandboxie::new(dir.clone(), format!("glass_cliptest_{}", std::process::id()));
     sb.configure(SandboxLevel::Default).expect("configure box");
 
     let spec = AppSpec {
@@ -153,10 +150,7 @@ fn private_clipboard_multiformat() {
     let sentinel = format!("SENTINEL-{}", std::process::id());
     crate::clipboard::set(&sentinel).expect("set ambient clipboard");
 
-    let sb = Sandboxie {
-        dir: dir.clone(),
-        box_name: format!("glass_clipmulti_{}", std::process::id()),
-    };
+    let sb = Sandboxie::new(dir.clone(), format!("glass_clipmulti_{}", std::process::id()));
     sb.configure(SandboxLevel::Default).expect("configure box");
 
     let spec = AppSpec {
@@ -259,10 +253,7 @@ fn private_clipboard_ole() {
     let sentinel = format!("SENTINEL-{}", std::process::id());
     crate::clipboard::set(&sentinel).expect("set ambient clipboard");
 
-    let sb = Sandboxie {
-        dir: dir.clone(),
-        box_name: format!("glass_clipole_{}", std::process::id()),
-    };
+    let sb = Sandboxie::new(dir.clone(), format!("glass_clipole_{}", std::process::id()));
     sb.configure(SandboxLevel::Default).expect("configure box");
 
     let spec = AppSpec {
@@ -364,10 +355,7 @@ fn private_clipboard_hdrop() {
     let sentinel = format!("SENTINEL-{}", std::process::id());
     crate::clipboard::set(&sentinel).expect("set ambient clipboard");
 
-    let sb = Sandboxie {
-        dir: dir.clone(),
-        box_name: format!("glass_cliphdrop_{}", std::process::id()),
-    };
+    let sb = Sandboxie::new(dir.clone(), format!("glass_cliphdrop_{}", std::process::id()));
     sb.configure(SandboxLevel::Default).expect("configure box");
 
     let spec = AppSpec {

--- a/crates/glass-windows/src/containment/clip_server.rs
+++ b/crates/glass-windows/src/containment/clip_server.rs
@@ -65,15 +65,23 @@ impl ClipServer {
         Ok(ClipServer { pipe_path, stop, thread: Some(thread) })
     }
 
-    /// Stop the loop: flag, then poke the pipe (a self-connect) to break a blocking
-    /// `ConnectNamedPipe`, then join.
+    /// Stop the loop and join its accept thread. Thin consuming wrapper over
+    /// [`Self::shutdown`]; `Drop` also calls `shutdown`, so a `ClipServer`
+    /// dropped without an explicit `stop()` is reclaimed just the same.
     pub(crate) fn stop(mut self) {
+        self.shutdown();
+    }
+
+    /// Flag the loop, poke the pipe (a self-connect) to break a blocking
+    /// `ConnectNamedPipe`, then join the accept thread. Idempotent: the thread
+    /// handle is taken via the `Option`, so calling this twice (e.g. `stop()`
+    /// then `Drop`) joins exactly once.
+    fn shutdown(&mut self) {
         self.stop.store(true, Ordering::Relaxed);
         let wide = to_wide(&self.pipe_path);
         // SAFETY: opening our own pipe by name to release the accept loop; handle closed immediately.
         unsafe {
-            use windows::Win32::Foundation::GENERIC_READ;
-            use windows::Win32::Foundation::GENERIC_WRITE;
+            use windows::Win32::Foundation::{GENERIC_READ, GENERIC_WRITE};
             use windows::Win32::Storage::FileSystem::{
                 CreateFileW, FILE_FLAGS_AND_ATTRIBUTES, FILE_SHARE_NONE, OPEN_EXISTING,
             };
@@ -97,7 +105,12 @@ impl ClipServer {
 
 impl Drop for ClipServer {
     fn drop(&mut self) {
-        self.stop.store(true, Ordering::Relaxed);
+        // Full teardown even when stop() was never called — e.g. an early
+        // return in setup_private_clipboard, or a launch() that fails after the
+        // server started — so the accept thread + pipe instance + security
+        // descriptor are never leaked (previously Drop only set the flag, which
+        // a thread parked in ConnectNamedPipe never observes).
+        self.shutdown();
     }
 }
 

--- a/crates/glass-windows/src/containment/clip_server.rs
+++ b/crates/glass-windows/src/containment/clip_server.rs
@@ -17,7 +17,9 @@ use glass_core::{GlassError, Result};
 
 use windows::core::PCWSTR;
 use windows::core::BOOL;
-use windows::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};
+use windows::Win32::Foundation::{
+    CloseHandle, ERROR_PIPE_CONNECTED, HANDLE, INVALID_HANDLE_VALUE,
+};
 use windows::Win32::Security::Authorization::ConvertStringSecurityDescriptorToSecurityDescriptorW;
 use windows::Win32::Security::{PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES};
 use windows::Win32::Storage::FileSystem::{FlushFileBuffers, ReadFile, WriteFile};
@@ -174,7 +176,16 @@ fn accept_loop(
             break;
         }
         // SAFETY: blocks until a client connects (or our self-poke in stop()).
-        let connected = unsafe { ConnectNamedPipe(pipe, None) }.is_ok();
+        // A client that connects in the gap between CreateNamedPipeW and
+        // ConnectNamedPipe makes the call return FALSE + ERROR_PIPE_CONNECTED —
+        // which IS a connected client. windows-rs maps that FALSE to Err, so
+        // `.is_ok()` alone would silently drop the client (its read-back then
+        // comes back empty — the flaky-empty-readback class). Treat it as
+        // connected.
+        let connected = match unsafe { ConnectNamedPipe(pipe, None) } {
+            Ok(()) => true,
+            Err(e) => e.code() == windows::core::HRESULT::from_win32(ERROR_PIPE_CONNECTED.0),
+        };
         if stop.load(Ordering::Relaxed) {
             // SAFETY: closing the instance handle we own.
             unsafe {

--- a/crates/glass-windows/src/containment/mod.rs
+++ b/crates/glass-windows/src/containment/mod.rs
@@ -75,10 +75,10 @@ mod imp {
         match decide(spec.sandbox, choice, super::sandboxie::available(&dir)) {
             Decision::Unconfined => Ok(Containment::Unconfined),
             Decision::Sandboxie => {
-                let s = super::sandboxie::Sandboxie {
+                let s = super::sandboxie::Sandboxie::new(
                     dir,
-                    box_name: format!("glass_{}", std::process::id()),
-                };
+                    format!("glass_{}", std::process::id()),
+                );
                 s.configure(spec.sandbox)?;
                 Ok(Containment::Sandboxie(s))
             }

--- a/crates/glass-windows/src/containment/sandboxie.rs
+++ b/crates/glass-windows/src/containment/sandboxie.rs
@@ -106,9 +106,37 @@ fn service_running(name: &str) -> bool {
 pub(crate) struct Sandboxie {
     pub dir: String,
     pub box_name: String,
+    /// Armed by `configure()` once it begins writing this box's `Sandboxie.ini`
+    /// section; disarmed by a successful `launch()` (which hands the clear to
+    /// [`SandboxieApp::kill`]). While armed, dropping `Sandboxie` clears the
+    /// section, so a failure anywhere between `configure()` and a successful
+    /// `launch()` never orphans a per-session `glass_<pid>` section in the
+    /// shared `Sandboxie.ini`.
+    section_armed: AtomicBool,
+}
+
+/// Remove a box's entire config section from `Sandboxie.ini`
+/// (`SbieIni set <box> * ""` — the maintainer's documented box-clear), so
+/// per-session `glass_<pid>` boxes don't accumulate. Best-effort.
+fn clear_box_section(dir: &str, box_name: &str) {
+    let _ = Command::new(sbieini(dir)).args(["set", box_name, "*", ""]).status();
+}
+
+impl Drop for Sandboxie {
+    fn drop(&mut self) {
+        if self.section_armed.load(Ordering::Relaxed) {
+            clear_box_section(&self.dir, &self.box_name);
+        }
+    }
 }
 
 impl Sandboxie {
+    /// A box handle for `box_name` under install `dir`. The section guard starts
+    /// disarmed; `configure()` arms it.
+    pub(crate) fn new(dir: String, box_name: String) -> Self {
+        Self { dir, box_name, section_armed: AtomicBool::new(false) }
+    }
+
     /// Configure the private-clipboard hook for this box (Layer 2). Returns `Some((store, server,
     /// pipe))` when the hook DLL is resolvable and the pipe server starts; `None` (Layer-1-only)
     /// otherwise. Never fails the launch — a missing hook leaves the app clipboard-less but the
@@ -158,6 +186,9 @@ impl Sandboxie {
     /// Configure the box for `level`: strict global gate first, then the policy `set` pairs,
     /// the compat templates, the strict AFD device close, and a `/reload`.
     pub(crate) fn configure(&self, level: SandboxLevel) -> Result<()> {
+        // This box's persistent ini section is about to exist; arm the guard so
+        // any failure before a successful launch() clears it (see the struct doc).
+        self.section_armed.store(true, Ordering::Relaxed);
         let dir = self.dir.clone();
         let sbieini = sbieini(&dir);
 
@@ -285,6 +316,9 @@ impl Sandboxie {
             spawn_tailer(err_log, Stream::Stderr, logs.clone(), stop.clone()),
         ];
 
+        // Launch succeeded: the box now belongs to SandboxieApp, whose kill()
+        // clears the section. Disarm so our Drop doesn't wipe a live box.
+        self.section_armed.store(false, Ordering::Relaxed);
         Ok(SandboxieApp {
             dir: self.dir.clone(),
             box_name: self.box_name.clone(),
@@ -439,9 +473,6 @@ impl SandboxieApp {
             server.stop();
         }
         let _ = std::fs::remove_dir_all(&self.logdir);
-        // Best-effort: remove the box's config section from Sandboxie.ini.
-        let _ = Command::new(sbieini(&self.dir))
-            .args(["set", self.box_name.as_str(), "*", ""])
-            .status();
+        clear_box_section(&self.dir, &self.box_name);
     }
 }

--- a/crates/glass-windows/src/input.rs
+++ b/crates/glass-windows/src/input.rs
@@ -97,18 +97,36 @@ fn key_vk(vk: VIRTUAL_KEY, up: bool) -> INPUT {
     }
 }
 
-/// Submit a batch of `INPUT`s. A short send (UIPI / foreground-lock blocking some
-/// events) is an environmental best-effort condition, not a hard error — warn like
-/// the probe and return `Ok` (the box-validation step verifies events actually land).
-fn send(inputs: &[INPUT]) {
+/// Submit a batch of `INPUT`s.
+///
+/// A *partial* short send (some events injected, some dropped by UIPI /
+/// foreground-lock) is an environmental best-effort condition, not a hard
+/// error — warn like the probe and return `Ok`. A *total* failure, however —
+/// zero events injected from a non-empty batch (locked input desktop, UIPI,
+/// foreground lock blocking everything) — is indistinguishable from a
+/// successful click/keystroke to the agent, which would then proceed on a
+/// false premise. The no-silent-fallbacks invariant requires that be a
+/// structured error, matching the X11 backend (every XTEST failure → Backend).
+fn send(inputs: &[INPUT]) -> Result<()> {
+    if inputs.is_empty() {
+        return Ok(());
+    }
     // SAFETY: `inputs` is a valid slice and the stride is the real `INPUT` size.
-    let n = unsafe { SendInput(inputs, std::mem::size_of::<INPUT>() as i32) };
-    if n as usize != inputs.len() {
+    let n = unsafe { SendInput(inputs, std::mem::size_of::<INPUT>() as i32) } as usize;
+    if n == 0 {
+        return Err(GlassError::Backend(format!(
+            "SendInput injected 0/{} events — input blocked (UIPI / foreground lock / \
+             locked input desktop); try running elevated",
+            inputs.len()
+        )));
+    }
+    if n != inputs.len() {
         eprintln!(
             "glass: SendInput sent {n}/{} events (UIPI/foreground block? run elevated)",
             inputs.len()
         );
     }
+    Ok(())
 }
 
 /// The `MOUSEEVENTF_*DOWN`/`*UP` flag pair for a button.
@@ -147,7 +165,7 @@ pub(crate) fn send_pointer(active_hwnd: isize, event: &PointerEvent) -> Result<(
     match *event {
         PointerEvent::Move { x, y } => {
             let (nx, ny) = to_norm(x, y);
-            send(&[mouse(nx, ny, MOUSEEVENTF_MOVE | ABS)]);
+            send(&[mouse(nx, ny, MOUSEEVENTF_MOVE | ABS)])?;
         }
         PointerEvent::Click { x, y, button, count, ref modifiers } => {
             let (nx, ny) = to_norm(x, y);
@@ -164,7 +182,7 @@ pub(crate) fn send_pointer(active_hwnd: isize, event: &PointerEvent) -> Result<(
             for m in modifiers.iter().rev() {
                 inputs.push(key_vk(modifier_vk(*m), true));
             }
-            send(&inputs);
+            send(&inputs)?;
         }
         PointerEvent::Drag { from_x, from_y, to_x, to_y, button, ref modifiers } => {
             let path = glass_core::drag_path((from_x, from_y), (to_x, to_y));
@@ -190,7 +208,7 @@ pub(crate) fn send_pointer(active_hwnd: isize, event: &PointerEvent) -> Result<(
             for m in modifiers.iter().rev() {
                 inputs.push(key_vk(modifier_vk(*m), true));
             }
-            send(&inputs);
+            send(&inputs)?;
         }
         PointerEvent::Scroll { x, y, dx, dy, ref modifiers } => {
             let (nx, ny) = to_norm(x, y);
@@ -208,7 +226,7 @@ pub(crate) fn send_pointer(active_hwnd: isize, event: &PointerEvent) -> Result<(
             for m in modifiers.iter().rev() {
                 inputs.push(key_vk(modifier_vk(*m), true));
             }
-            send(&inputs);
+            send(&inputs)?;
         }
     }
     Ok(())
@@ -226,9 +244,8 @@ pub(crate) fn send_key(active_hwnd: isize, event: &KeyEvent) -> Result<()> {
                 inputs.push(key_unicode(unit, false));
                 inputs.push(key_unicode(unit, true));
             }
-            if !inputs.is_empty() {
-                send(&inputs);
-            }
+            // `send` no-ops an empty batch, so empty text is a clean Ok.
+            send(&inputs)?;
         }
         KeyEvent::Chord(s) => {
             let (mods, keysym) = glass_core::keys::parse_chord(s)?;
@@ -244,7 +261,7 @@ pub(crate) fn send_key(active_hwnd: isize, event: &KeyEvent) -> Result<()> {
             for &mvk in mod_vks.iter().rev() {
                 inputs.push(key_vk(mvk, true));
             }
-            send(&inputs);
+            send(&inputs)?;
         }
     }
     Ok(())

--- a/crates/glass-x11/Cargo.toml
+++ b/crates/glass-x11/Cargo.toml
@@ -14,6 +14,7 @@ bench = false
 [dependencies]
 glass-core.workspace = true
 glass-sandbox-linux.workspace = true
+glass-proc-linux.workspace = true
 x11rb.workspace = true
 
 [dev-dependencies]

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -771,6 +771,19 @@ impl Platform for X11Platform {
     fn app_pid(&self) -> Option<u32> {
         self.child.as_ref().map(|c| c.id())
     }
+
+    /// The app's full process subtree, not just the spawned child. For a
+    /// sandboxed launch the spawned child is `bwrap` and the real app is a
+    /// descendant with a different pid; the a11y reader correlates the AT-SPI
+    /// connection pid against this set, so it must include descendants — the
+    /// inherited `[app_pid()]` default breaks a11y for every `sandbox != off`
+    /// launch. Mirrors the `proc_tree_pids` set used by window discovery.
+    fn app_pids(&self) -> Vec<u32> {
+        match &self.child {
+            Some(c) => proc_tree_pids(c.id()),
+            None => Vec::new(),
+        }
+    }
 }
 
 /// Decide whether a window's fetched `WM_NAME` and `WM_CLASS` satisfy a hint.
@@ -821,9 +834,37 @@ fn button_number(button: glass_core::MouseButton) -> u8 {
 
 #[cfg(test)]
 mod tests {
-    use super::{collect_descendants, hint_matches};
+    use super::{collect_descendants, hint_matches, proc_tree_pids};
     use glass_core::WindowHint;
     use std::collections::HashMap;
+
+    // --- proc_tree_pids (the mechanism app_pids() relies on) ---
+
+    #[test]
+    fn proc_tree_pids_includes_a_real_descendant() {
+        // For a sandboxed launch the spawned child is `bwrap` and the real app
+        // is a *descendant* with a different pid. app_pids() must surface that
+        // descendant (so a11y pid-correlation works) — the plain `[app_pid()]`
+        // default never would. Spawn a real child and assert proc_tree_pids
+        // walks down to it.
+        use std::process::{Command, Stdio};
+        let mut child = Command::new("sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn sleep");
+        let child_pid = child.id();
+        let pids = proc_tree_pids(std::process::id());
+        let _ = child.kill();
+        let _ = child.wait();
+        assert!(pids.contains(&std::process::id()), "must include the root pid");
+        assert!(
+            pids.contains(&child_pid),
+            "must include the spawned descendant pid {child_pid}; got {pids:?}"
+        );
+    }
 
     // --- collect_descendants ---
 

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -7,6 +7,7 @@ use glass_core::{
     AppSpec, Frame, GlassError, KeyEvent, Platform, PointerEvent, Region, Result, Stream,
     WindowGeometry, WindowHint, WindowId, WindowInfo, WindowOp,
 };
+use glass_proc_linux::proc_tree_pids;
 use x11rb::connection::Connection;
 use x11rb::protocol::xproto::*;
 use x11rb::protocol::xtest::ConnectionExt as _;
@@ -502,64 +503,9 @@ fn spawn_reader<R: std::io::Read + Send + 'static>(reader: R, stream: Stream, si
     });
 }
 
-/// Collect the full set of host PIDs in the process tree rooted at `root_pid`
-/// (inclusive). Reads `/proc/<pid>/status` for each process in `/proc` and
-/// follows `PPid:` links upward to root_pid.
-///
-/// This is needed for sandboxed launches: when `bwrap` is the direct child (and
-/// thus the recorded child PID), the actual app is bwrap's child with a
-/// different PID. `_NET_WM_PID` is set to the app's real host PID, so window
-/// discovery must check all descendants of the spawned process, not just its
-/// own PID.
-///
-/// Returns an empty vec if `/proc` is not available or `root_pid` has no
-/// children yet (the caller polls in a loop so an empty set just means "retry").
-fn proc_tree_pids(root_pid: u32) -> Vec<u32> {
-    // Read all (ppid, pid) pairs from /proc.
-    let proc = match std::fs::read_dir("/proc") {
-        Ok(d) => d,
-        Err(_) => return vec![root_pid],
-    };
-    let mut parent_of: std::collections::HashMap<u32, u32> = std::collections::HashMap::new();
-    for entry in proc.flatten() {
-        let name = entry.file_name();
-        let pid_str = name.to_string_lossy();
-        let Ok(pid) = pid_str.parse::<u32>() else { continue };
-        let status_path = format!("/proc/{pid}/status");
-        let Ok(content) = std::fs::read_to_string(&status_path) else { continue };
-        for line in content.lines() {
-            if let Some(rest) = line.strip_prefix("PPid:") {
-                if let Ok(ppid) = rest.trim().parse::<u32>() {
-                    parent_of.insert(pid, ppid);
-                }
-                break;
-            }
-        }
-    }
-    collect_descendants(root_pid, &parent_of)
-}
-
-/// Collect `root` and all its descendants given a child→parent-pid map.
-/// Cycle-safe (a `seen` set guarantees termination even if the map contains a cycle,
-/// e.g. from PID reuse mid-scan).
-fn collect_descendants(root: u32, parent_of: &std::collections::HashMap<u32, u32>) -> Vec<u32> {
-    use std::collections::{HashSet, VecDeque};
-    let mut seen: HashSet<u32> = HashSet::new();
-    let mut out = Vec::new();
-    let mut q = VecDeque::from([root]);
-    while let Some(pid) = q.pop_front() {
-        if !seen.insert(pid) {
-            continue;
-        }
-        out.push(pid);
-        for (&child, &ppid) in parent_of {
-            if ppid == pid && !seen.contains(&child) {
-                q.push_back(child);
-            }
-        }
-    }
-    out
-}
+// The process-tree walk (`/proc`-based) that maps the spawned child to the
+// real app's descendants now lives in the shared `glass-proc-linux` crate
+// (`proc_tree_pids`), used by both the X11 and Wayland backends.
 
 impl Platform for X11Platform {
     fn start_app(&mut self, spec: &AppSpec) -> Result<WindowGeometry> {
@@ -834,70 +780,11 @@ fn button_number(button: glass_core::MouseButton) -> u8 {
 
 #[cfg(test)]
 mod tests {
-    use super::{collect_descendants, hint_matches, proc_tree_pids};
+    use super::hint_matches;
     use glass_core::WindowHint;
-    use std::collections::HashMap;
 
-    // --- proc_tree_pids (the mechanism app_pids() relies on) ---
-
-    #[test]
-    fn proc_tree_pids_includes_a_real_descendant() {
-        // For a sandboxed launch the spawned child is `bwrap` and the real app
-        // is a *descendant* with a different pid. app_pids() must surface that
-        // descendant (so a11y pid-correlation works) — the plain `[app_pid()]`
-        // default never would. Spawn a real child and assert proc_tree_pids
-        // walks down to it.
-        use std::process::{Command, Stdio};
-        let mut child = Command::new("sleep")
-            .arg("30")
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-            .expect("spawn sleep");
-        let child_pid = child.id();
-        let pids = proc_tree_pids(std::process::id());
-        let _ = child.kill();
-        let _ = child.wait();
-        assert!(pids.contains(&std::process::id()), "must include the root pid");
-        assert!(
-            pids.contains(&child_pid),
-            "must include the spawned descendant pid {child_pid}; got {pids:?}"
-        );
-    }
-
-    // --- collect_descendants ---
-
-    #[test]
-    fn descendants_normal_tree() {
-        // root 100 → children 200, 201; 200 → child 300
-        let mut parent_of = HashMap::new();
-        parent_of.insert(200u32, 100u32);
-        parent_of.insert(201u32, 100u32);
-        parent_of.insert(300u32, 200u32);
-        let mut result = collect_descendants(100, &parent_of);
-        result.sort();
-        assert_eq!(result, vec![100, 200, 201, 300]);
-    }
-
-    #[test]
-    fn descendants_cycle_terminates() {
-        // Cycle: parent_of[100] = 200, parent_of[200] = 100
-        // (simulates PID-reuse creating a bogus cycle in the map mid-scan)
-        let mut parent_of = HashMap::new();
-        parent_of.insert(100u32, 200u32);
-        parent_of.insert(200u32, 100u32);
-        // Must terminate and include the root.
-        let result = collect_descendants(100, &parent_of);
-        assert!(result.contains(&100), "root must be present even with a cycle");
-        assert!(result.len() <= 2, "cycle must not cause unbounded growth");
-    }
-
-    #[test]
-    fn descendants_root_only() {
-        let parent_of: HashMap<u32, u32> = HashMap::new();
-        assert_eq!(collect_descendants(42, &parent_of), vec![42]);
-    }
+    // proc_tree_pids / collect_descendants moved to the `glass-proc-linux` crate
+    // (tested there).
 
     fn hint(title: Option<&str>, class: Option<&str>) -> WindowHint {
         WindowHint { title: title.map(Into::into), class: class.map(Into::into) }

--- a/crates/glass-x11/src/xvfb.rs
+++ b/crates/glass-x11/src/xvfb.rs
@@ -5,8 +5,15 @@
 
 use std::io::{BufRead, BufReader};
 use std::process::{Child, ChildStdout, Command, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
 
 use glass_core::{GlassError, Result};
+
+/// How long to wait for Xvfb to report its display before treating it as wedged.
+/// Readiness is normally well under a second; this ceiling is generous so a
+/// slow/loaded host isn't falsely failed, while a hung Xvfb can't block start-up.
+const READY_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub struct Xvfb {
     child: Child,
@@ -36,27 +43,66 @@ impl Xvfb {
             })?;
 
         let stdout = child.stdout.take().expect("piped stdout");
-        let mut reader = BufReader::new(stdout);
-        let mut line = String::new();
-        if reader.read_line(&mut line).unwrap_or(0) == 0 {
-            let _ = child.kill();
-            let _ = child.wait();
-            return Err(GlassError::Backend(
-                "Xvfb exited without reporting a display (failed to start)".into(),
-            ));
-        }
-        let num: u32 = match line.trim().parse() {
-            Ok(n) => n,
-            Err(_) => {
+        match read_displayfd(stdout, READY_TIMEOUT) {
+            Ok((num, displayfd)) => Ok(Xvfb { child, display: format!(":{num}"), displayfd }),
+            Err(e) => {
                 let _ = child.kill();
                 let _ = child.wait();
-                return Err(GlassError::Backend(format!(
-                    "unexpected Xvfb -displayfd output: {line:?}"
-                )));
+                Err(GlassError::Backend(match e {
+                    ReadErr::Closed => {
+                        "Xvfb exited without reporting a display (failed to start)".into()
+                    }
+                    ReadErr::Garbage(line) => {
+                        format!("unexpected Xvfb -displayfd output: {line:?}")
+                    }
+                    ReadErr::TimedOut => format!(
+                        "Xvfb spawned but did not report a display within {}s (wedged); \
+                         not blocking start-up",
+                        READY_TIMEOUT.as_secs()
+                    ),
+                }))
             }
-        };
+        }
+    }
+}
 
-        Ok(Xvfb { child, display: format!(":{num}"), displayfd: reader.into_inner() })
+/// Why reading the `-displayfd` line failed.
+#[derive(Debug)]
+enum ReadErr {
+    /// The pipe closed before a line arrived — Xvfb exited (failed to start).
+    Closed,
+    /// A line arrived but wasn't a display number.
+    Garbage(String),
+    /// No line within the timeout — Xvfb spawned but never became ready.
+    TimedOut,
+}
+
+/// Read the display number Xvfb writes to its `-displayfd` pipe, bounded by
+/// `timeout`. The blocking `read_line` runs on a helper thread so a wedged Xvfb
+/// (alive, stdout open, but never reporting) can't block the caller forever —
+/// the original hang. On success the `ChildStdout` is handed back so the caller
+/// can hold it open for Xvfb's lifetime (closing it would SIGPIPE the server).
+fn read_displayfd(
+    stdout: ChildStdout,
+    timeout: Duration,
+) -> std::result::Result<(u32, ChildStdout), ReadErr> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        let n = reader.read_line(&mut line).unwrap_or(0);
+        // Hand the fd back so the caller keeps it open; ignore a send failure —
+        // the caller timed out and dropped the receiver, the child will be
+        // killed, and this read unblocks and drops the fd here.
+        let _ = tx.send((n, line, reader.into_inner()));
+    });
+    match rx.recv_timeout(timeout) {
+        Ok((0, _, _)) => Err(ReadErr::Closed),
+        Ok((_, line, fd)) => match line.trim().parse::<u32>() {
+            Ok(num) => Ok((num, fd)),
+            Err(_) => Err(ReadErr::Garbage(line.trim().to_string())),
+        },
+        Err(_) => Err(ReadErr::TimedOut),
     }
 }
 
@@ -69,5 +115,54 @@ impl Drop for Xvfb {
             let _ = std::fs::remove_file(format!("/tmp/.X{num}-lock"));
             let _ = std::fs::remove_file(format!("/tmp/.X11-unix/X{num}"));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{read_displayfd, ReadErr};
+    use std::process::{Command, Stdio};
+    use std::time::Duration;
+
+    #[test]
+    fn read_displayfd_times_out_on_a_silent_child() {
+        // A child that stays alive and never writes its display (the wedged-Xvfb
+        // case) must NOT block forever — read_displayfd returns TimedOut.
+        let mut child =
+            Command::new("sleep").arg("30").stdout(Stdio::piped()).spawn().expect("spawn sleep");
+        let stdout = child.stdout.take().expect("piped");
+        let r = read_displayfd(stdout, Duration::from_millis(200));
+        let _ = child.kill();
+        let _ = child.wait();
+        assert!(matches!(r, Err(ReadErr::TimedOut)), "expected TimedOut");
+    }
+
+    #[test]
+    fn read_displayfd_parses_a_reported_display() {
+        // Writes "7" then stays alive (Xvfb keeps fd 1 open after reporting).
+        // `exec sleep` keeps the same pid so child.kill() reaps it (no orphan).
+        let mut child = Command::new("sh")
+            .args(["-c", "echo 7; exec sleep 30"])
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn sh");
+        let stdout = child.stdout.take().expect("piped");
+        let r = read_displayfd(stdout, Duration::from_secs(5));
+        let _ = child.kill();
+        let _ = child.wait();
+        match r {
+            Ok((num, _fd)) => assert_eq!(num, 7),
+            Err(e) => panic!("expected display 7, got {e:?}"),
+        }
+    }
+
+    #[test]
+    fn read_displayfd_reports_closed_on_immediate_exit() {
+        // Exits without writing — the pipe closes (EOF) → Closed, not a hang.
+        let mut child = Command::new("true").stdout(Stdio::piped()).spawn().expect("spawn true");
+        let stdout = child.stdout.take().expect("piped");
+        let r = read_displayfd(stdout, Duration::from_secs(5));
+        let _ = child.wait();
+        assert!(matches!(r, Err(ReadErr::Closed)), "expected Closed");
     }
 }


### PR DESCRIPTION
Addresses findings from a full review of the workspace (the post-initial-release Windows clipboard/FFI burst plus a cross-backend sweep). 16 items: 10 of the 12 mediums plus several lows, grouped by theme.

## Fixes

**Coordinates / tool boundary**
- **M7** `glass_wait_for_region` now returns a **window-relative** bbox (was crop-relative for non-zero-origin regions, so agents clicked the wrong spot; also inconsistent with `glass_diff`).

**No-silent-fallback invariant**
- **M5** Windows `SendInput` returning **0 injected events** (UIPI/foreground-lock/locked desktop) is now a structured error instead of a silent `Ok` — matches the X11 backend.

**Accessibility pid correlation (sandboxed launches)**
- **M11** X11 `app_pids()` returns the full process subtree, so the AT-SPI reader matches the real app (a `bwrap` descendant) instead of failing for every sandboxed launch.
- **M11b** Wayland gets the same fix (the app is a `sway exec` descendant). The shared `/proc` tree walk is factored into a new focused `glass-proc-linux` crate used by both backends.

**Resource cleanup on error paths (RAII)**
- **M3** `ClipServer::Drop` now joins the accept loop (was only setting a flag a blocked thread never observes), reclaiming the thread + pipe + security descriptor — also fixes the `setup_private_clipboard` early-return leak (**L8**).
- **M4** A failed launch no longer orphans the per-session box section in the shared Sandboxie config (armed-on-configure / disarmed-on-success guard).
- **M9** Wayland reaps the whole `sway` process group on `AppExited` bring-up failures (was leaking Xwayland + the app on an unclean exit).

**Hangs (unbounded blocking reads)**
- **M12** `Xvfb` startup is bounded by a timeout, so a server that spawns but never reports a display can't hang session start (it also stops `probe_xvfb` leaking a thread + child).
- **M10** Wayland clipboard `get()` bounds the selection-transfer read with a deadline, so a misbehaving selection owner can't hang the server (and the session-wide lock).

**Clipboard / DIB correctness**
- **M1** High-bpp DIBs carrying a `biClrUsed` optimization palette are no longer silently corrupted (the palette is counted so the pixel offset is right).
- **M2** The clip-server accept loop treats `ERROR_PIPE_CONNECTED` as a connected client (a connect landing in the create/connect gap was dropped → empty read-back).
- **L9** The `CF_UNICODETEXT` scan is bounded by `GlobalSize` (an untrusted, non-NUL-terminated block could read out of bounds — UB).
- **L3** Full `BI_BITFIELDS` support (the dominant 32bpp clipboard DIB): parsing accounts for the mask block, and DIB↔DIBV5 conversions relocate the masks between the post-header block and the V5 header fields.

**Wayland input flake (follow-up)**
- **L17** The focus-reassert nudge is no longer a no-op at the left output edge (it was `saturating_sub(1)` → 0 at x==0, silently dropping the first left-edge click/scroll).

## Verification
- `cargo test --workspace`: **427 passed, 0 failed** (49 `#[ignore]`d integration tests run via the platform scripts).
- `cargo clippy --workspace --all-targets -- -D warnings`: clean on Linux **and** `x86_64-pc-windows-gnu`.
- New pure DIB parsing/relocation paths are **Miri-clean**.
- Linux-testable fixes are test-driven (failing test first); each new helper has unit tests.

## Pending on-box Windows validation
These compile + lint clean against the Windows target but change `cfg(windows)` **runtime** behavior that can't be exercised on Linux — to validate on a Windows host before relying on them: **M5** (blocked-input error), **M3** (Drop join), **M4** (config cleanup), **M2** (pipe race), **L9** (NUL bound), and **L3's GDI render paths** (`CreateDIBitmap` with BI_BITFIELDS + widened CF_DIBV5).

## Not included (follow-up)
Two mediums — **M6** (`discover_window` checks process-exit before window, breaking launcher-handoff apps) and **M8** (single-session gate released on any close-id) — plus the accessibility-robustness lows and the remaining nit-level items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)