### PR TITLE
docs(readme): order isolation table rows to match footnote sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ tree — for apps with no accessible UI (bare canvas / game UIs), so the agent f
 | | X11 | Wayland | Windows | macOS |
 |---|:--:|:--:|:--:|:--:|
 | Display isolation (app off your desktop) | ✓ private Xvfb | ✓ headless sway | – interactive desktop¹ | 🚧 |
-| Clipboard isolation | ✓ | ✓ | ✓ private (contained)³ | 🚧 |
 | Headless (no host desktop needed) | ✓ | ✓ | – needs a session² | 🚧 |
+| Clipboard isolation | ✓ | ✓ | ✓ private (contained)³ | 🚧 |
 
 ¹ A Windows VirtualDisplay / headless provider is a planned follow-on; stronger isolation today is
 the VM tier (the Windows Sandbox `.wsb` template under `packaging/windows-sandbox/`, or a managed


### PR DESCRIPTION
The **Isolation & runtime (per backend)** table listed *Clipboard isolation* before *Headless*, but their footnotes run in the opposite order (Headless is footnote ², Clipboard is footnote ³). Swapping the two rows makes the Windows-column superscripts read ¹ ² ³ top-to-bottom, matching the footnote prose.

Pure row reorder — no content change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)