### PR TITLE
Fix remaining review mediums: window discovery order (M6) + session-gate id match (M8)

### DIFF
--- a/crates/glass-mcp/src/serve/session_gate.rs
+++ b/crates/glass-mcp/src/serve/session_gate.rs
@@ -5,13 +5,16 @@
 //! client while one is live); `close_session` releases it. Every other
 //! [`SessionManager`] method is pure delegation to the inner manager.
 //!
-//! Releasing the slot in `close_session` correctly handles client disconnect:
-//! rmcp's `spawn_session_worker` calls `close_session` both on an explicit HTTP
-//! DELETE *and* when the per-session worker ends (i.e. the client drops), so the
-//! slot is freed in both cases.
+//! The slot is released in `close_session`, but ONLY for the admitted session's
+//! id. rmcp's `handle_delete` forwards the client's `Mcp-Session-Id` header
+//! without validating it (and `LocalSessionManager::close_session` returns `Ok`
+//! for an unknown id), and `spawn_session_worker` calls `close_session` on every
+//! worker end — including a superseded session's. Matching the id ensures a
+//! stale/bogus close can't free a live session's slot (which would let a second
+//! client in alongside the first).
 
 use std::io;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
 
 use futures::Stream;
 use rmcp::model::{ClientJsonRpcMessage, ServerJsonRpcMessage};
@@ -23,6 +26,20 @@ use rmcp::transport::streamable_http_server::session::{SessionId, SessionManager
 // `transport::common::server_side_http`), not from `tower`.
 use rmcp::transport::streamable_http_server::session::ServerSseMessage;
 
+/// The single admission slot.
+#[derive(Debug, Default)]
+enum Slot {
+    /// No session — a `create_session` is admitted.
+    #[default]
+    Empty,
+    /// A `create_session` has claimed the slot but its id isn't known yet (the
+    /// inner `create_session().await` is in flight). A concurrent create is
+    /// rejected; a close (which carries some other id) can't match.
+    Reserving,
+    /// Held by the admitted session; only a close for this id releases it.
+    Active(SessionId),
+}
+
 /// Wraps [`LocalSessionManager`], enforcing at most one concurrent session.
 ///
 /// A second `create_session` while one is live returns an error (surfaced to the
@@ -30,9 +47,11 @@ use rmcp::transport::streamable_http_server::session::ServerSseMessage;
 #[derive(Debug, Default)]
 pub struct SingleSessionManager {
     inner: LocalSessionManager,
-    // Plain `AtomicBool` (not `Arc`): the manager is owned by the HTTP service (the
-    // caller wraps it in an `Arc`); it is never cloned, so no internal sharing is needed.
-    occupied: AtomicBool,
+    // Plain `Mutex` (not `Arc`): the manager is owned by the HTTP service (the
+    // caller wraps it in an `Arc`); it is never cloned, so no internal sharing is
+    // needed. The lock is only ever held for synchronous state transitions, never
+    // across an `.await`.
+    slot: Mutex<Slot>,
 }
 
 /// The error returned when a second client tries to attach while one is live.
@@ -51,15 +70,22 @@ impl SessionManager for SingleSessionManager {
     type Transport = <LocalSessionManager as SessionManager>::Transport;
 
     async fn create_session(&self) -> Result<(SessionId, Self::Transport), Self::Error> {
-        // Claim the single slot; reject if already taken.
-        if self.occupied.swap(true, Ordering::AcqRel) {
-            return Err(busy_error());
+        // Claim the single slot before the await; reject if already taken.
+        {
+            let mut slot = self.slot.lock().unwrap();
+            if !matches!(*slot, Slot::Empty) {
+                return Err(busy_error());
+            }
+            *slot = Slot::Reserving;
         }
         match self.inner.create_session().await {
-            Ok(v) => Ok(v),
+            Ok((id, transport)) => {
+                *self.slot.lock().unwrap() = Slot::Active(id.clone());
+                Ok((id, transport))
+            }
             Err(e) => {
                 // Release the slot if the inner manager failed to create.
-                self.occupied.store(false, Ordering::Release);
+                *self.slot.lock().unwrap() = Slot::Empty;
                 Err(e)
             }
         }
@@ -67,9 +93,14 @@ impl SessionManager for SingleSessionManager {
 
     async fn close_session(&self, id: &SessionId) -> Result<(), Self::Error> {
         let r = self.inner.close_session(id).await;
-        // Always release the slot: a close is final whether or not the inner
-        // teardown reported an error.
-        self.occupied.store(false, Ordering::Release);
+        // Release the slot ONLY for the admitted session. A close for a
+        // stale/bogus id (an unvalidated DELETE header, or a superseded session's
+        // late worker-end) must not free a live session's slot — see the module
+        // docs.
+        let mut slot = self.slot.lock().unwrap();
+        if matches!(&*slot, Slot::Active(active) if active == id) {
+            *slot = Slot::Empty;
+        }
         r
     }
 
@@ -134,5 +165,26 @@ mod tests {
             .create_session()
             .await
             .expect("slot reusable after close");
+    }
+
+    #[tokio::test]
+    async fn close_with_foreign_id_does_not_release_the_slot() {
+        use std::sync::Arc;
+        let m = SingleSessionManager::default();
+        let (id, _t) = m.create_session().await.expect("first session admitted");
+        // rmcp's handle_delete forwards the client's Mcp-Session-Id header without
+        // validating it, and LocalSessionManager::close_session returns Ok for an
+        // unknown id — so a DELETE carrying a bogus/stale id (or a superseded
+        // session's late worker-end) must NOT free the live slot.
+        let bogus: SessionId = Arc::from("not-the-active-session");
+        let _ = m.close_session(&bogus).await;
+        assert!(
+            m.create_session().await.is_err(),
+            "slot must stay claimed after a close for a non-active id"
+        );
+        // The admitted session's own close still releases it.
+        m.close_session(&id).await.expect("closing the active session releases");
+        let (_id2, _t2) =
+            m.create_session().await.expect("slot reusable after the real close");
     }
 }

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -105,15 +105,13 @@ mod backend {
         ) -> Result<WindowGeometry> {
             let deadline = Instant::now() + Duration::from_millis(timeout_ms);
             loop {
-                // Fail fast if the app died on launch (crash/instant exit), rather than
-                // busy-polling the full timeout and reporting a misleading Timeout.
-                if let Some(app) = self.app.as_mut() {
-                    if let Ok(Some(status)) = app.try_wait() {
-                        return Err(GlassError::AppExited(status.code()));
-                    }
-                }
-                // Recompute the union each iteration: a launcher-handoff child may only
-                // appear (and own the window) several polls in.
+                // Look for the app's window FIRST, then check for exit. A launcher
+                // that hands its UI to a Job-captured child and exits 0 (Chromium/
+                // Electron-style) must not be reported as AppExited while the child's
+                // window is already up — so a window that exists wins even if the root
+                // has exited. (The X11 backend scans first, exit-checks second, for the
+                // same reason.) Recompute the pid union each iteration: a handoff child
+                // may only appear (and own the window) several polls in.
                 let pids = self.app_pids();
                 if let Some(w) = find_app_window(&pids, hint) {
                     // A window passed the filter but has no DWM frame bounds yet (a transient
@@ -121,6 +119,15 @@ mod backend {
                     if let Some(r) = crate::util::extended_frame_bounds(w.hwnd()) {
                         self.active_hwnd = Some(w.raw);
                         return Ok(crate::windows::rect_to_geometry(r));
+                    }
+                }
+                // No window yet — fail fast if the app died on launch (crash/instant
+                // exit), rather than busy-polling the full timeout and reporting a
+                // misleading Timeout. AppExited only when the root died AND no window
+                // exists.
+                if let Some(app) = self.app.as_mut() {
+                    if let Ok(Some(status)) = app.try_wait() {
+                        return Err(GlassError::AppExited(status.code()));
                     }
                 }
                 if Instant::now() >= deadline {


### PR DESCRIPTION
The two mediums not covered by #8 — completing all 12 from the review.

- **M8 — single-session gate released on any close-id** (`serve/session_gate.rs`). The gate held a bare `AtomicBool` and `close_session` freed it for *any* id. But rmcp's `handle_delete` forwards the client's `Mcp-Session-Id` header unvalidated (and `LocalSessionManager::close_session` returns `Ok` for unknown ids), and `spawn_session_worker` calls `close_session` on every worker end — so a DELETE with a bogus/stale id, or a superseded session's late worker-end, freed the live slot and let a second client in. Now tracks the admitted `SessionId` (`Empty`/`Reserving`/`Active(id)`) and releases only on an id match. **Regression test added** (admit A → close a foreign id → second create still rejected).

- **M6 — `discover_window` checked exit before the window** (`lib.rs`). It returned `AppExited` from the root's `try_wait()` before ever calling `find_app_window`, so a launcher that hands its UI to a Job-captured child and exits 0 (Chromium/Electron-style) was reported as exited while its window was up. Reordered to scan-first / exit-second (matching the X11 backend); `AppExited` now fires only when the root died **and** no window exists.

## Verification
- `cargo test --workspace`: **428 passed, 0 failed** (incl. the new M8 regression test).
- `cargo clippy --workspace --all-targets -- -D warnings`: clean on Linux **and** `x86_64-pc-windows-gnu`.
- M8 is fully unit-tested on Linux. M6 is `cfg(windows)`, compile-validated against the Windows target + reasoned from source (the launcher-handoff case is hard to force on-box — the validated Chromium case keeps its root alive); it mirrors the X11 backend's existing, proven ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)