### PR TITLE
Fix a11y-robustness lows: bounded UIA walk, COM isolation, editable state, set_value fingerprint (L12–L15)

### DIFF
--- a/crates/glass-a11y-windows/src/doctor.rs
+++ b/crates/glass-a11y-windows/src/doctor.rs
@@ -31,10 +31,16 @@ fn a11y_checks(uia: std::result::Result<(), String>) -> Vec<Check> {
 
 #[cfg(windows)]
 fn probe_uia() -> std::result::Result<(), String> {
-    match uiautomation::UIAutomation::new() {
+    // UIAutomation::new() initializes COM (MTA) on the calling thread and the
+    // uiautomation crate never uninitializes it — leaving the doctor's own thread
+    // permanently marked MTA. Run the probe on a throwaway thread so that apartment
+    // init is reclaimed at thread exit (mirrors the reader's per-call isolation).
+    std::thread::spawn(|| match uiautomation::UIAutomation::new() {
         Ok(_) => Ok(()),
         Err(e) => Err(e.to_string()),
-    }
+    })
+    .join()
+    .unwrap_or_else(|_| Err("UI Automation probe thread panicked".into()))
 }
 #[cfg(not(windows))]
 fn probe_uia() -> std::result::Result<(), String> {

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -27,6 +27,11 @@ const MAX_NODES: usize = 1500;
 /// per-level scan so the walk is genuinely bounded regardless of offscreen breadth.
 /// Generous enough not to truncate real UIs; with `MAX_DEPTH` it bounds total work.
 const MAX_SIBLINGS: usize = 4096;
+/// Per-edge tolerance (px) for the set_value bounds-fingerprint check. Window-relative
+/// bounds are stable for a static element across snapshot→set_value (window moves cancel),
+/// so this only absorbs sub-pixel/timing jitter; a different element that drift landed on
+/// the id sits far enough away to be rejected. Generous to avoid false-rejects.
+const SET_VALUE_BOUNDS_TOL: i64 = 12;
 
 #[derive(Default)]
 pub struct WindowsA11y;
@@ -269,10 +274,17 @@ fn run_set_value(ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
     let el = find_nth(&walker, &window, 0, &mut count, target.id.0)
         .ok_or(GlassError::AxElementChanged(target.id.0))?;
 
-    // Verify role + name (guards a stale id / mirror drift).
+    // Verify role + name + bounds (guards a stale id / tree drift). role+name
+    // alone isn't unique (many controls share a role and an empty name), so if
+    // drift lands a different same-role+name element on this pre-order id, the
+    // bounds fingerprint — the element sits elsewhere — rejects it. A target
+    // without captured bounds falls back to role+name only.
     let role = crate::mapping::map_role(el.get_control_type().map_err(uia_err)? as i32 as u32);
     let name = nonempty(el.get_name().unwrap_or_default());
-    if !target.matches(role, name.as_deref()) {
+    let bounds = window_relative_bounds(&el, (ctx.window.x, ctx.window.y));
+    if !target.matches(role, name.as_deref())
+        || !target.bounds_consistent(bounds, SET_VALUE_BOUNDS_TOL)
+    {
         return Err(GlassError::AxElementChanged(target.id.0));
     }
     let pat = el

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -20,6 +20,13 @@ const SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(10);
 /// Bounds so a pathological tree can't make a snapshot unbounded (tunable; sized on the box).
 const MAX_DEPTH: usize = 30;
 const MAX_NODES: usize = 1500;
+/// Per-level cap on siblings *examined* (on- or off-screen). `MAX_NODES` only counts
+/// nodes entered, and offscreen siblings are skipped without entering — so an
+/// all-offscreen run (a virtualized list of thousands) or a cyclic `get_next_sibling`
+/// would iterate without ever tripping `MAX_NODES`, spinning the worker thread. Cap the
+/// per-level scan so the walk is genuinely bounded regardless of offscreen breadth.
+/// Generous enough not to truncate real UIs; with `MAX_DEPTH` it bounds total work.
+const MAX_SIBLINGS: usize = 4096;
 
 #[derive(Default)]
 pub struct WindowsA11y;
@@ -158,7 +165,12 @@ fn walk(
     let mut children = Vec::new();
     if depth < MAX_DEPTH && *count < MAX_NODES {
         let mut child = walker.get_first_child(el).ok();
+        let mut siblings = 0usize;
         while let Some(c) = child {
+            siblings += 1;
+            if siblings > MAX_SIBLINGS {
+                break; // bound the per-level scan (offscreen breadth / cyclic sibling chain)
+            }
             if !c.is_offscreen().unwrap_or(false) {
                 children.push(walk(walker, &c, origin, depth + 1, count)?);
             }
@@ -205,7 +217,12 @@ fn gather(el: &UIElement, ct_id: u32) -> (crate::mapping::StateFacts, Option<Str
     } else {
         (None, None)
     };
-    let editable = ct_id == 50004 && readonly.map(|ro| !ro).unwrap_or(false);
+    // Editable iff a writable ValuePattern is present — for ANY value-bearing
+    // control (Edit/ComboBox/Document), not just Edit; otherwise a writable
+    // ComboBox/Document reports editable=false while set_value would succeed on
+    // it. `readonly` is only `Some` for those three types (gated above), so the
+    // match keeps non-value controls non-editable.
+    let editable = matches!(ct_id, 50003 | 50004 | 50030) && readonly.map(|ro| !ro).unwrap_or(false);
     let facts = crate::mapping::StateFacts {
         enabled: el.is_enabled().unwrap_or(false),
         offscreen: el.is_offscreen().unwrap_or(false),
@@ -283,7 +300,12 @@ fn find_nth(
     }
     if depth < MAX_DEPTH && *count < MAX_NODES {
         let mut child = walker.get_first_child(el).ok();
+        let mut siblings = 0usize;
         while let Some(c) = child {
+            siblings += 1;
+            if siblings > MAX_SIBLINGS {
+                break; // same per-level bound as walk(), so find_nth can't spin either
+            }
             if !c.is_offscreen().unwrap_or(false) {
                 if let Some(found) = find_nth(walker, &c, depth + 1, count, target) {
                     return Some(found);

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -287,20 +287,45 @@ pub struct AxContext {
 }
 
 /// A fingerprint identifying the element a value-set targets: its synthetic id
-/// (pre-order index) plus the role/name the caller saw in the snapshot. The
-/// backend verifies role+name after re-walking to the id, so a stale id errors
+/// (pre-order index), the role/name the caller saw in the snapshot, and the
+/// element's window-relative bounds when known. The backend re-walks to the id
+/// and verifies role+name (and bounds, when present) so a stale id — or tree
+/// drift that lands a *different* same-role+name element on the id — errors
 /// rather than overwriting the wrong element.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AxTarget {
     pub id: AxNodeId,
     pub role: AxRole,
     pub name: Option<String>,
+    /// The element's window-relative bounds at snapshot time, when known. An
+    /// extra fingerprint: re-walking to a pre-order id can land on a different
+    /// same-role+name element if the tree drifted, and that element sits
+    /// elsewhere — see [`Self::bounds_consistent`].
+    pub bounds: Option<AxRect>,
 }
 
 impl AxTarget {
     /// Whether a reached node's role + name match this target.
     pub fn matches(&self, role: AxRole, name: Option<&str>) -> bool {
         self.role == role && self.name.as_deref() == name
+    }
+
+    /// Whether a reached element's bounds `got` are consistent with the bounds
+    /// captured for this target, within `tol` px on every edge. `true` when no
+    /// bounds were captured (nothing to verify — role+name still gate). A
+    /// genuinely different element that drift moved onto this id sits elsewhere
+    /// and is rejected; sub-pixel / DWM-border jitter is tolerated.
+    pub fn bounds_consistent(&self, got: Option<AxRect>, tol: i64) -> bool {
+        match (self.bounds, got) {
+            (None, _) => true,
+            (Some(_), None) => false,
+            (Some(a), Some(b)) => {
+                (i64::from(a.x) - i64::from(b.x)).abs() <= tol
+                    && (i64::from(a.y) - i64::from(b.y)).abs() <= tol
+                    && (i64::from(a.width) - i64::from(b.width)).abs() <= tol
+                    && (i64::from(a.height) - i64::from(b.height)).abs() <= tol
+            }
+        }
     }
 }
 
@@ -476,15 +501,35 @@ mod tests {
 
     #[test]
     fn ax_target_matches_on_role_and_name() {
-        let t = AxTarget { id: AxNodeId(3), role: AxRole::TextField, name: Some("Email".into()) };
+        let t = AxTarget { id: AxNodeId(3), role: AxRole::TextField, name: Some("Email".into()), bounds: None };
         assert!(t.matches(AxRole::TextField, Some("Email")));
         assert!(!t.matches(AxRole::Button, Some("Email")), "role must match");
         assert!(!t.matches(AxRole::TextField, Some("Name")), "name must match");
         assert!(!t.matches(AxRole::TextField, None), "missing name must not match a named target");
 
-        let t_unnamed = AxTarget { id: AxNodeId(5), role: AxRole::TextField, name: None };
+        let t_unnamed = AxTarget { id: AxNodeId(5), role: AxRole::TextField, name: None, bounds: None };
         assert!(t_unnamed.matches(AxRole::TextField, None), "unnamed target matches unnamed live node");
         assert!(!t_unnamed.matches(AxRole::TextField, Some("X")), "unnamed target must not match a named live node");
+    }
+
+    #[test]
+    fn ax_target_bounds_consistent_rejects_a_moved_element() {
+        let r = AxRect { x: 100, y: 50, width: 80, height: 20 };
+        let t = AxTarget { id: AxNodeId(3), role: AxRole::TextField, name: None, bounds: Some(r) };
+        // Exact and within-tolerance bounds pass.
+        assert!(t.bounds_consistent(Some(r), 8));
+        assert!(
+            t.bounds_consistent(Some(AxRect { x: 104, y: 53, width: 80, height: 20 }), 8),
+            "minor jitter within tolerance is accepted"
+        );
+        // A different element that drift landed on this id sits elsewhere → rejected.
+        assert!(!t.bounds_consistent(Some(AxRect { x: 300, y: 400, width: 120, height: 30 }), 8));
+        // Expected a positioned element but the reached one has none → reject.
+        assert!(!t.bounds_consistent(None, 8));
+        // No fingerprint captured → nothing to verify, accept (role+name still gates).
+        let t_nofp = AxTarget { id: AxNodeId(3), role: AxRole::TextField, name: None, bounds: None };
+        assert!(t_nofp.bounds_consistent(Some(r), 8));
+        assert!(t_nofp.bounds_consistent(None, 8));
     }
 
     #[test]

--- a/crates/glass-core/src/session.rs
+++ b/crates/glass-core/src/session.rs
@@ -367,7 +367,8 @@ impl Glass {
             }
             let tree = s.last_ax.as_ref().ok_or(GlassError::NoAxSnapshot)?;
             let node = tree.find(id).ok_or(GlassError::AxElementNotFound(id.0))?;
-            let target = AxTarget { id, role: node.role, name: node.name.clone() };
+            let target =
+                AxTarget { id, role: node.role, name: node.name.clone(), bounds: node.bounds };
             let ctx = AxContext { pids: s.platform.app_pids(), window: s.geometry.clone() };
             (target, ctx)
         };
@@ -1537,7 +1538,15 @@ mod tests {
         g.set_value(AxNodeId(1), "hello").unwrap();
         let calls = log.lock().unwrap();
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].0, AxTarget { id: AxNodeId(1), role: AxRole::Button, name: Some("Save".into()) });
+        assert_eq!(
+            calls[0].0,
+            AxTarget {
+                id: AxNodeId(1),
+                role: AxRole::Button,
+                name: Some("Save".into()),
+                bounds: Some(AxRect { x: 10, y: 10, width: 20, height: 20 }),
+            }
+        );
         assert_eq!(calls[0].1, "hello");
     }
 

--- a/crates/glass-windows/examples/onbox_a11y_setvalue.rs
+++ b/crates/glass-windows/examples/onbox_a11y_setvalue.rs
@@ -97,7 +97,8 @@ mod imp {
             let _ = p.stop_app();
             return;
         };
-        let target = AxTarget { id: field.id, role: field.role, name: field.name.clone() };
+        let target =
+            AxTarget { id: field.id, role: field.role, name: field.name.clone(), bounds: field.bounds };
         println!(
             "\n[set_value]  field #{} {:?} {:?}  value-before = {:?}",
             field.id.0, field.role, field.name, field.value
@@ -137,7 +138,7 @@ mod imp {
         first_role(&tree.root, AxRole::Button, &mut button);
         match button {
             Some(b) => {
-                let bt = AxTarget { id: b.id, role: b.role, name: b.name.clone() };
+                let bt = AxTarget { id: b.id, role: b.role, name: b.name.clone(), bounds: b.bounds };
                 match a11y.set_value(&ctx, &bt, "x") {
                     Err(GlassError::AxElementNotEditable(_)) => {
                         println!("  PASS  button #{} -> AxElementNotEditable", b.id.0)


### PR DESCRIPTION
The accessibility-robustness lows from the review (all in `glass-a11y-windows`, plus a shared `AxTarget` field for L15).

- **L12 — bounded UIA walk.** `walk`/`find_nth` only counted *entered* nodes toward `MAX_NODES`, and offscreen siblings are skipped without entering — so an all-offscreen run (a virtualized list of thousands) or a cyclic `get_next_sibling` iterated without ever tripping the bound, spinning the detached worker thread (which outlives the caller's `SNAPSHOT_TIMEOUT`) indefinitely. Added a per-level `MAX_SIBLINGS` cap on siblings *examined*, so the walk is bounded regardless of offscreen breadth.
- **L13 — doctor COM isolation.** `probe_uia` called `UIAutomation::new()` directly on the doctor's thread; the crate inits COM (MTA) and never uninitializes, leaving the thread permanently MTA. Run the probe on a throwaway thread (joined for the result) so the apartment init is reclaimed at thread exit — mirroring the reader's per-call isolation.
- **L14 — editable state.** `editable` was derived only for Edit (ct 50004), but `set_value` writes any value-bearing control — a writable ComboBox/Document reported `editable=false` while `set_value` would succeed. Derive it for 50003/50004/50030.
- **L15 — set_value bounds fingerprint.** Re-walking to a pre-order id verified role+name only (not unique), so tree drift could land a different same-role+name element on the id and the write hit the wrong element. `AxTarget` gains a `bounds` field (populated from the cached snapshot node), and the reader rejects (`AxElementChanged`) when the reached element's window-relative bounds don't match within a generous tolerance; targets without captured bounds fall back to role+name. The Linux backend ignores the new field (additive).

## Verification
- `cargo test --workspace`: **429 passed, 0 failed**. The pure `AxTarget::bounds_consistent` comparison (L15) is unit-tested on the host.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean on Linux **and** `x86_64-pc-windows-gnu`.
- L12–L14 and L15's reader integration are `cfg(windows)` — compile-validated against the Windows target + reasoned; runtime (and L15's tolerance) pending on-box validation alongside M6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)