### PR TITLE
fix(windows): grace period for broker/handoff windows in discover_window

### DIFF
--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -27,7 +27,13 @@ pub struct ScreenshotArgs {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct WindowHintArgs {
+    /// Case-insensitive substring matched against window titles. Used to pick the
+    /// right window when several appear, and — since it ignores the process tree —
+    /// to locate a window the launched process hands off to an unrelated process
+    /// (e.g. some packaged Windows apps).
     pub title: Option<String>,
+    /// Exact window-class match. Same purpose as `title` but more stable, since
+    /// class names rarely carry the dynamic prefixes/suffixes that titles do.
     pub class: Option<String>,
 }
 
@@ -48,6 +54,10 @@ pub struct StartArgs {
     pub cwd: Option<String>,
     #[serde(default)]
     pub env: Vec<(String, String)>,
+    /// Optional `{ title?, class? }` to disambiguate which window is the app's when
+    /// more than one appears, or to find a window the launched process hands off to
+    /// an unrelated process (some packaged Windows apps). Omit to take the first
+    /// window owned by the launched process or a descendant it can follow.
     pub window_hint: Option<WindowHintArgs>,
     pub timeout_ms: Option<u64>,
 }

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -67,7 +67,7 @@ impl GlassServer {
     }
 
     #[tool(
-        description = "Build, launch, and locate a native GUI app; returns its window geometry. Optional `backend`: \"x11\" (headless Xvfb) or \"wayland\" (headless sway) on Linux, or \"windows\" on a Windows host; defaults to the host backend (windows on Windows, else x11)."
+        description = "Build, launch, and locate a native GUI app; returns its window geometry. Optional `backend`: \"x11\" (headless Xvfb) or \"wayland\" (headless sway) on Linux, or \"windows\" on a Windows host; defaults to the host backend (windows on Windows, else x11). Optional `window_hint` ({ title?, class? }) picks the right window when several appear, or locates one the launched process hands off to an unrelated process (some packaged Windows apps)."
     )]
     async fn glass_start(&self, Parameters(a): Parameters<StartArgs>) -> Result<CallToolResult, McpError> {
         self.run(move |g| tools::start(g, &a)).await

--- a/crates/glass-windows/examples/onbox_handoff.rs
+++ b/crates/glass-windows/examples/onbox_handoff.rs
@@ -1,0 +1,134 @@
+//! On-box validation for the broker/handoff grace period in `discover_window` (Windows-only).
+//!
+//! Win11's packaged Notepad launches `notepad.exe`, which hands its UI to a broker-spawned
+//! process and exits — so the real window is owned by neither the launcher nor a Job/Toolhelp
+//! descendant. This exercises both branches of `discovery::poll_decision`:
+//!   [A] WITH a title hint  -> should ADOPT the handoff window (the fix), polling past root-exit.
+//!   [B] WITHOUT a hint      -> should FAST-FAIL `AppExited` (crash detection, unchanged).
+//!
+//! Must run in the interactive desktop session (session 1) — over SSH (session 0) drive it via
+//! the scheduled-task bridge:
+//!   cargo run -p glass-windows --example onbox_handoff
+
+fn main() {
+    #[cfg(windows)]
+    imp::run();
+    #[cfg(not(windows))]
+    eprintln!("glass-windows `onbox_handoff` example is Windows-only; no-op on this host.");
+}
+
+#[cfg(windows)]
+mod imp {
+    use glass_core::{AppSpec, GlassError, Platform, WindowHint};
+    use glass_windows::WindowsPlatform;
+    use std::time::{Duration, Instant};
+
+    fn kill_notepad() {
+        let _ = std::process::Command::new("taskkill")
+            .args(["/F", "/IM", "notepad.exe", "/T"])
+            .output();
+        std::thread::sleep(Duration::from_millis(800));
+    }
+
+    fn spec(hint: Option<WindowHint>, timeout_ms: u64) -> AppSpec {
+        AppSpec {
+            build: None,
+            run: vec!["notepad.exe".to_string()],
+            cwd: None,
+            env: vec![],
+            window_hint: hint,
+            timeout_ms,
+            sandbox: glass_core::SandboxLevel::Off,
+        }
+    }
+
+    fn is_blank(px: &[u8]) -> bool {
+        match px.chunks_exact(4).next() {
+            Some(first) => px.chunks_exact(4).all(|c| c == first),
+            None => true,
+        }
+    }
+
+    pub fn run() {
+        println!("== glass-windows handoff/grace on-box validation ==");
+        // Standalone example (no embedded manifest): opt into Per-Monitor-V2 before any capture.
+        // SAFETY: process-global, no preconditions; harmless if already set.
+        unsafe {
+            let _ = windows::Win32::UI::HiDpi::SetProcessDpiAwarenessContext(
+                windows::Win32::UI::HiDpi::DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2,
+            );
+        }
+
+        // ---- [A] WITH a title hint -> expect ADOPT (the fix) ----
+        println!("\n[A] start_app notepad.exe WITH title hint \"Notepad\" (timeout 8s)");
+        kill_notepad();
+        let mut pa = WindowsPlatform::new().expect("new");
+        let t = Instant::now();
+        let res_a =
+            pa.start_app(&spec(Some(WindowHint { title: Some("Notepad".into()), class: None }), 8_000));
+        let el = t.elapsed().as_millis();
+        match &res_a {
+            Ok(g) => println!("  PASS  adopted handoff window in {el} ms  geometry = {g:?}"),
+            Err(e) => println!("  FAIL  {e}  (after {el} ms)"),
+        }
+        if res_a.is_ok() {
+            match pa.list_windows() {
+                Ok(ws) => {
+                    println!("  list_windows: {} window(s)", ws.len());
+                    for w in &ws {
+                        println!(
+                            "    active={} title={:?} class={:?} geo={:?}",
+                            w.active, w.title, w.class, w.geometry
+                        );
+                    }
+                }
+                Err(e) => println!("  list_windows FAIL {e}"),
+            }
+            match pa.capture_frame(None) {
+                Ok(f) => {
+                    let blank = is_blank(&f.pixels);
+                    println!(
+                        "  capture: {}x{} blank={} ({})",
+                        f.width,
+                        f.height,
+                        blank,
+                        if blank { "FAIL blank" } else { "PASS non-blank" }
+                    );
+                }
+                Err(e) => println!("  capture FAIL {e}"),
+            }
+        }
+        let _ = pa.stop_app();
+        kill_notepad();
+
+        // ---- [B] WITHOUT a hint -> expect fast-fail AppExited (unchanged) ----
+        println!("\n[B] start_app notepad.exe WITHOUT hint (timeout 8s) -> expect fast AppExited");
+        let mut pb = WindowsPlatform::new().expect("new");
+        let t = Instant::now();
+        let res_b = pb.start_app(&spec(None, 8_000));
+        let el = t.elapsed().as_millis();
+        match &res_b {
+            Ok(g) => println!(
+                "  UNEXPECTED Ok in {el} ms  geometry = {g:?}  (a stray notepad window owned by our \
+                 pid-set? — check)"
+            ),
+            Err(GlassError::AppExited(code)) => {
+                let fast = el < 4_000;
+                println!(
+                    "  {}  AppExited({code:?}) in {el} ms  ({})",
+                    if fast { "PASS" } else { "CHECK" },
+                    if fast {
+                        "fast-fail preserved"
+                    } else {
+                        "slower than expected — did it wait the timeout?"
+                    }
+                );
+            }
+            Err(e) => println!("  CHECK  unexpected error {e}  (after {el} ms)"),
+        }
+        let _ = pb.stop_app();
+        kill_notepad();
+
+        println!("\n== done ==");
+    }
+}

--- a/crates/glass-windows/src/discovery.rs
+++ b/crates/glass-windows/src/discovery.rs
@@ -1,0 +1,96 @@
+//! Pure decision logic for the window-discovery poll loop, factored out of the
+//! (Windows-only) `backend` so it compiles and is unit-tested on any host — like
+//! [`crate::dpi`] and friends. The backend owns the Win32 side of each poll
+//! (enumerate windows, `try_wait` the root, read DWM frame bounds) and consults
+//! [`poll_decision`] once per iteration to decide whether to wait or give up.
+
+/// What the discovery loop should do after a poll that found no adoptable window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PollStep {
+    /// No window yet, but it's still worth waiting — sleep and poll again.
+    KeepPolling,
+    /// Give up: the launched (root) process exited and nothing took over its UI.
+    /// Carries the root's exit code (`None` if it exited without one).
+    FailExited(Option<i32>),
+    /// Give up: the timeout elapsed while the root process was still alive.
+    FailTimeout,
+}
+
+/// Decide the next step when a poll iteration found no window to adopt.
+///
+/// - `root_exit`: `Some(code)` once the launched process has been observed exited,
+///   `None` while it is still alive.
+/// - `has_hint`: whether the caller supplied a title/class [`WindowHint`].
+/// - `past_deadline`: whether the timeout has elapsed.
+///
+/// The subtlety this encodes: a launcher can exit `0` the instant it hands its UI
+/// to an *unrelated* process — some packaged Windows apps activate through a system
+/// broker, so the real window is owned by neither the launcher nor a descendant the
+/// Job/Toolhelp set can follow. Failing the moment the root exits reports
+/// `AppExited` a beat before that handoff window maps. So when a hint is present —
+/// the caller's explicit signal that a specific window is expected, possibly from
+/// another process — keep polling for it until the deadline, then report the exit
+/// (more actionable than a bare `Timeout`). With no hint there is nothing an
+/// unrelated process could satisfy, so fail fast on root exit rather than burning
+/// the whole timeout on what is almost certainly a crash.
+///
+/// [`WindowHint`]: glass_core::platform::WindowHint
+pub fn poll_decision(root_exit: Option<Option<i32>>, has_hint: bool, past_deadline: bool) -> PollStep {
+    match root_exit {
+        // Root exited: fail now if there's no hint to wait on, or if we've already
+        // given a hinted handoff window until the deadline to appear.
+        Some(code) if !has_hint || past_deadline => PollStep::FailExited(code),
+        // Root exited, a hint is set, and there's still time: a broker/handoff
+        // window may yet map — keep polling for it.
+        Some(_) => PollStep::KeepPolling,
+        // Root still alive but out of time: report the timeout.
+        None if past_deadline => PollStep::FailTimeout,
+        // Root still alive and time remaining: keep polling.
+        None => PollStep::KeepPolling,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn root_alive_keeps_polling_until_deadline() {
+        assert_eq!(poll_decision(None, false, false), PollStep::KeepPolling);
+        assert_eq!(poll_decision(None, true, false), PollStep::KeepPolling);
+    }
+
+    #[test]
+    fn root_alive_past_deadline_times_out() {
+        assert_eq!(poll_decision(None, false, true), PollStep::FailTimeout);
+        assert_eq!(poll_decision(None, true, true), PollStep::FailTimeout);
+    }
+
+    #[test]
+    fn root_exited_without_hint_fails_fast() {
+        // The original fast-fail: a launcher that exits with no hint to wait on has
+        // (almost certainly) crashed — don't burn the whole timeout.
+        assert_eq!(poll_decision(Some(Some(1)), false, false), PollStep::FailExited(Some(1)));
+        assert_eq!(poll_decision(Some(None), false, false), PollStep::FailExited(None));
+    }
+
+    #[test]
+    fn root_exited_with_hint_keeps_polling_for_handoff() {
+        // The grace period: with a hint, a handoff/broker window may still appear,
+        // so keep polling rather than reporting AppExited the instant the root dies.
+        assert_eq!(poll_decision(Some(Some(0)), true, false), PollStep::KeepPolling);
+    }
+
+    #[test]
+    fn root_exited_with_hint_reports_exit_at_deadline() {
+        // If the hinted window never showed, report the exit (more actionable than a
+        // bare Timeout), preserving the exit code.
+        assert_eq!(poll_decision(Some(Some(0)), true, true), PollStep::FailExited(Some(0)));
+        assert_eq!(poll_decision(Some(Some(3)), true, true), PollStep::FailExited(Some(3)));
+    }
+
+    #[test]
+    fn root_exited_without_hint_at_deadline_still_reports_exit() {
+        assert_eq!(poll_decision(Some(Some(2)), false, true), PollStep::FailExited(Some(2)));
+    }
+}

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -10,6 +10,7 @@ pub mod doctor; // pure check-mapping cross-platform; Windows fact-gathering is 
 pub mod jobpids; // pure JOBOBJECT_BASIC_PROCESS_ID_LIST byte parser — Miri'd on the host
 pub mod jobcfg; // pure SandboxLevel -> job-limit descriptor — unit-tested on the Linux dev box
 pub mod containment; // Windows containment provider seam (pure config is host-tested)
+pub mod discovery; // pure window-discovery poll-loop decision — cross-platform, host-tested
 pub mod pixels; // pure BGRA->RGBA swizzle — cross-platform, unit-tested on the Linux dev box
 pub mod vkmap; // pure named-keysym->VK map — cross-platform, unit-tested on the Linux dev box
 
@@ -103,7 +104,13 @@ mod backend {
             hint: Option<&WindowHint>,
             timeout_ms: u64,
         ) -> Result<WindowGeometry> {
+            use crate::discovery::{poll_decision, PollStep};
+
             let deadline = Instant::now() + Duration::from_millis(timeout_ms);
+            // Latched once the root process is observed exited (its code preserved). A
+            // launcher can exit the instant it hands its UI off, so root-exit is not on
+            // its own fatal — see `poll_decision` for the hint-vs-no-hint policy.
+            let mut root_exit: Option<Option<i32>> = None;
             loop {
                 // Look for the app's window FIRST, then check for exit. A launcher
                 // that hands its UI to a Job-captured child and exits 0 (Chromium/
@@ -121,17 +128,22 @@ mod backend {
                         return Ok(crate::windows::rect_to_geometry(r));
                     }
                 }
-                // No window yet — fail fast if the app died on launch (crash/instant
-                // exit), rather than busy-polling the full timeout and reporting a
-                // misleading Timeout. AppExited only when the root died AND no window
-                // exists.
-                if let Some(app) = self.app.as_mut() {
-                    if let Ok(Some(status)) = app.try_wait() {
-                        return Err(GlassError::AppExited(status.code()));
+                // No window yet. Observe the root's exit once (latched). It's not
+                // necessarily fatal: an app can hand its UI to an *unrelated* process
+                // (some packaged apps activate via a system broker) the pid-set can't
+                // follow, so a title/class hint may still locate that window after the
+                // launcher exits. `poll_decision` encodes the policy.
+                if root_exit.is_none() {
+                    if let Some(app) = self.app.as_mut() {
+                        if let Ok(Some(status)) = app.try_wait() {
+                            root_exit = Some(status.code());
+                        }
                     }
                 }
-                if Instant::now() >= deadline {
-                    return Err(GlassError::Timeout(timeout_ms));
+                match poll_decision(root_exit, hint.is_some(), Instant::now() >= deadline) {
+                    PollStep::FailExited(code) => return Err(GlassError::AppExited(code)),
+                    PollStep::FailTimeout => return Err(GlassError::Timeout(timeout_ms)),
+                    PollStep::KeepPolling => {}
                 }
                 std::thread::sleep(Duration::from_millis(50));
             }


### PR DESCRIPTION
## Problem

A launcher can exit the instant it hands its UI to an **unrelated** process. Some packaged Windows apps (Win11 Notepad, Calculator, Store apps) activate through a system broker, so the real window is owned by neither the launcher nor a Job/Toolhelp descendant `discover_window` can follow. The loop returned `AppExited` the moment `try_wait` saw the root exit — a beat *before* the handoff window maps — so even the pid-independent title/class hint never got a chance to match. Net effect: glass couldn't drive these apps even when the caller knew the window's title/class.

## Change

Extract the per-iteration decision into a pure, host-tested `discovery::poll_decision` (cross-platform module, unit-tested on the Linux dev box per the crate's `dpi`/`jobcfg` convention). Policy:

| root state | hint? | before deadline | at deadline |
|---|---|---|---|
| alive | — | keep polling | `Timeout` |
| **exited** | **no** | `AppExited` (fast-fail, unchanged) | `AppExited` |
| **exited** | **yes** | **keep polling (NEW grace)** | `AppExited(code)` |

- **No hint → fast-fail preserved.** Crash detection unchanged; a launcher that exits with nothing to wait on still fails immediately rather than burning the timeout.
- **Hint present → root-exit is no longer fatal.** A broker/handoff window gets until the caller's own `timeout_ms` to appear; if it never does, report `AppExited(code)` (more actionable than a bare `Timeout`).

Also documents the `window_hint` MCP params (`title`/`class`) in the schema and the `glass_start` tool description — they existed but were undocumented, so an agent had no way to know the mechanism was available.

## Verification

- `cargo test -p glass-windows discovery` — 6 new unit tests (the full decision matrix), green on Linux.
- `cargo check` + `clippy --all-targets -D warnings` clean on both the Linux and `x86_64-pc-windows-gnu` targets.
- **On-box (LOTUS, Win11 25H2)** via `examples/onbox_handoff` in the interactive session:
  - `[A]` `notepad.exe` **with** title hint `"Notepad"` → **adopted** the broker window in **459 ms**, valid geometry, non-blank WGC capture.
  - `[B]` identical launch **without** hint → **`AppExited(Some(0))` in 118 ms** (fast-fail preserved, nowhere near the 8s timeout).
  - The A-vs-B contrast (same launch, only the hint differs) is the proof the fix flips `AppExited` → adopt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)