### PR TITLE
feat(windows): one-command on-box test harness (scripts/test-windows.sh)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ perf.data.old
 # Editor / OS cruft
 *.swp
 .DS_Store
+
+# Pulled-back artifacts from scripts/test-windows.sh on-box runs
+/.windows-artifacts/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,15 +537,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,29 +748,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
-name = "fdeflate"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
-dependencies = [
- "simd-adler32",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "foldhash"
@@ -1073,7 +1039,6 @@ dependencies = [
  "glass-a11y-windows",
  "glass-clip-hook",
  "glass-core",
- "image",
  "windows",
  "windows-capture",
 ]
@@ -1372,7 +1337,6 @@ dependencies = [
  "image-webp",
  "moxcms",
  "num-traits",
- "png",
 ]
 
 [[package]]
@@ -1529,16 +1493,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
 
 [[package]]
 name = "mio"
@@ -1708,19 +1662,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "png"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
-dependencies = [
- "bitflags 2.11.1",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
 ]
 
 [[package]]
@@ -2227,12 +2168,6 @@ dependencies = [
  "errno",
  "libc",
 ]
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"

--- a/crates/glass-windows/Cargo.toml
+++ b/crates/glass-windows/Cargo.toml
@@ -27,12 +27,6 @@ windows = { version = "0.62", features = [
   "Win32_Security_Authorization",
 ] }
 
-# Only the on-box validation example (examples/onbox.rs) needs a PNG encoder to save captured
-# frames; the library itself has no image dependency. glass-core's `image` is webp-only, so the
-# example pulls the png feature for itself.
-[dev-dependencies]
-image = { version = "0.25", default-features = false, features = ["png"] }
-
 # The onbox examples set Per-Monitor-V2 awareness at runtime (they carry no manifest); the
 # onbox_a11y example also drives the UIA reader to validate the accessibility path on the box.
 [target.'cfg(windows)'.dev-dependencies]

--- a/crates/glass-windows/examples/onbox.rs
+++ b/crates/glass-windows/examples/onbox.rs
@@ -1,7 +1,7 @@
 //! On-box validation harness for the glass-windows backend (Windows-only).
 //!
 //! Drives [`glass_windows::WindowsPlatform`] through the build → see → interact → debug loop on
-//! Notepad and writes PNGs + a text report to `C:\Users\mpd`. It MUST run in an interactive
+//! charmap.exe and writes WebP frames + a text report to `C:\Users\mpd`. It MUST run in an interactive
 //! desktop session (session 1) — WGC capture and `SendInput` need the active input desktop, so
 //! over SSH (session 0) it is driven via the scheduled-task bridge:
 //!   cargo run -p glass-windows --example onbox
@@ -18,7 +18,10 @@ fn main() {
 
 #[cfg(windows)]
 mod imp {
-    use glass_core::{AppSpec, KeyEvent, MouseButton, Platform, PointerEvent, WindowHint, WindowOp};
+    use glass_core::{
+        frame_to_webp, AppSpec, Frame, KeyEvent, MouseButton, Platform, PointerEvent, WindowHint,
+        WindowOp,
+    };
     use glass_windows::WindowsPlatform;
     use std::time::Duration;
 
@@ -35,11 +38,16 @@ mod imp {
     fn changed(a: &[u8], b: &[u8]) -> usize {
         a.chunks_exact(4).zip(b.chunks_exact(4)).filter(|(x, y)| x != y).count()
     }
-    fn save(name: &str, w: u32, h: u32, rgba: &[u8]) {
+    /// Encode a captured frame as lossless WebP (glass's production format, via
+    /// `frame_to_webp`) and write it next to the other artifacts.
+    fn save(name: &str, frame: &Frame) {
         let path = format!("{OUT}\\{name}");
-        match image::save_buffer(&path, rgba, w, h, image::ColorType::Rgba8) {
-            Ok(()) => println!("    saved {path}"),
-            Err(e) => println!("    save {path} FAILED: {e}"),
+        match frame_to_webp(frame) {
+            Ok(bytes) => match std::fs::write(&path, bytes) {
+                Ok(()) => println!("    saved {path}"),
+                Err(e) => println!("    save {path} FAILED: {e}"),
+            },
+            Err(e) => println!("    encode {path} FAILED: {e}"),
         }
     }
 
@@ -111,7 +119,7 @@ mod imp {
                     f.height,
                     blank
                 );
-                save("onbox_1_capture.png", f.width, f.height, &f.pixels);
+                save("onbox_1_capture.webp", &f);
                 Some(f)
             }
             Err(e) => {
@@ -133,7 +141,7 @@ mod imp {
                 "  after-type changed_px = {ch}  ({})",
                 if ch > 0 { "PASS text rendered" } else { "FAIL no change" }
             );
-            save("onbox_2_typed.png", f2.width, f2.height, &f2.pixels);
+            save("onbox_2_typed.webp", &f2);
         }
 
         println!("\n[list_windows]");
@@ -168,7 +176,7 @@ mod imp {
         }
         std::thread::sleep(Duration::from_millis(600));
         if let Ok(f) = p.capture_frame(None) {
-            save("onbox_3_moved_resized.png", f.width, f.height, &f.pixels);
+            save("onbox_3_moved_resized.webp", &f);
         }
 
         println!("\n[send_pointer Click (50,50)]");

--- a/crates/glass-windows/examples/onbox.rs
+++ b/crates/glass-windows/examples/onbox.rs
@@ -25,7 +25,12 @@ mod imp {
     use glass_windows::WindowsPlatform;
     use std::time::Duration;
 
-    const OUT: &str = "C:\\Users\\mpd";
+    /// Where captured-frame artifacts are written: the running user's profile dir, which is also
+    /// where scripts/test-windows.sh sweeps `*.webp` from. Resolved at runtime (not a hardcoded
+    /// user) so the harness finds the artifacts on any box.
+    fn out_dir() -> String {
+        std::env::var("USERPROFILE").unwrap_or_else(|_| ".".to_string())
+    }
 
     /// True if every pixel is identical (a uniform/blank frame — WGC didn't return real pixels).
     fn is_blank(px: &[u8]) -> bool {
@@ -41,7 +46,7 @@ mod imp {
     /// Encode a captured frame as lossless WebP (glass's production format, via
     /// `frame_to_webp`) and write it next to the other artifacts.
     fn save(name: &str, frame: &Frame) {
-        let path = format!("{OUT}\\{name}");
+        let path = format!("{}\\{}", out_dir(), name);
         match frame_to_webp(frame) {
             Ok(bytes) => match std::fs::write(&path, bytes) {
                 Ok(()) => println!("    saved {path}"),
@@ -187,7 +192,7 @@ mod imp {
 
         println!("\n[drain_logs]");
         let logs = p.drain_logs();
-        println!("  {} line(s) (Notepad is a GUI app → 0 expected)", logs.len());
+        println!("  {} line(s) (charmap is a GUI app — 0 expected)", logs.len());
 
         println!("\n[stop_app — Job kill-tree]");
         let pid = p.app_pid();

--- a/scripts/test-windows.sh
+++ b/scripts/test-windows.sh
@@ -87,35 +87,48 @@ if ! sshx "cmd /c echo ok" >/dev/null 2>&1; then
   exit 1
 fi
 
-# --- sync: push base commit, ship working-tree delta ---
+# Scratch we ship to the box (the bridge + working-tree deltas) must live OUTSIDE the repo: the
+# bridge git-resets and `git clean -fd`s the repo, which would otherwise wipe these before use.
+HOME_REMOTE="C:/Users/${RUSER}"
+BRIDGE_REMOTE="$HOME_REMOTE/.glass-run-onbox.ps1"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+# --- sync: push base commit, ship the bridge + any working-tree delta ---
 echo "== push base commit ($BRANCH @ ${SHA:0:8}) =="
 git push -q origin "HEAD:$BRANCH"
 
-DIFF_REMOTE=""; UNTAR_REMOTE=""
-TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+# The bridge can't run from inside the repo it is about to reset, and the target branch may not be
+# checked out on the box yet -- ship the local copy to a stable path and run it from there.
+# shellcheck disable=SC2086
+scp $SSH_OPTS -q tools/windows-validation/run-onbox.ps1 "$HOST:$BRIDGE_REMOTE"
+
 if [ "$DIRTY" -eq 1 ]; then
   echo "== ship working-tree delta =="
   git diff HEAD --binary > "$TMP/wip.diff"
   git ls-files --others --exclude-standard -z | tar --null -cf "$TMP/untracked.tar" --files-from=- 2>/dev/null || : > "$TMP/untracked.tar"
   # shellcheck disable=SC2086
-  scp $SSH_OPTS -q "$TMP/wip.diff" "$HOST:$REPO/.glass-wip.diff"
+  scp $SSH_OPTS -q "$TMP/wip.diff" "$HOST:$HOME_REMOTE/.glass-wip.diff"
   # shellcheck disable=SC2086
-  scp $SSH_OPTS -q "$TMP/untracked.tar" "$HOST:$REPO/.glass-untracked.tar"
-  DIFF_REMOTE="$REPO/.glass-wip.diff"; UNTAR_REMOTE="$REPO/.glass-untracked.tar"
-  PS_ARGS+=( -DiffPath "$DIFF_REMOTE" -UntarPath "$UNTAR_REMOTE" )
+  scp $SSH_OPTS -q "$TMP/untracked.tar" "$HOST:$HOME_REMOTE/.glass-untracked.tar"
+  PS_ARGS+=( -DiffPath "$HOME_REMOTE/.glass-wip.diff" -UntarPath "$HOME_REMOTE/.glass-untracked.tar" )
 fi
 
-# --- invoke the bridge ---
+# --- invoke the bridge. Require its completion marker: PowerShell can exit 0 even when -File
+# fails to load, so a clean exit code alone is not proof the bridge ran (no silent success). ---
 echo "== run on box =="
 set +e
 # shellcheck disable=SC2086
-sshx "powershell -NoProfile -ExecutionPolicy Bypass -File \"$REPO/tools/windows-validation/run-onbox.ps1\" ${PS_ARGS[*]}"
-RC=$?
+sshx "powershell -NoProfile -ExecutionPolicy Bypass -File \"$BRIDGE_REMOTE\" ${PS_ARGS[*]}" 2>&1 | tee "$TMP/out.log"
+RC=${PIPESTATUS[0]}
 set -e
+if ! grep -q '== aggregate:' "$TMP/out.log"; then
+  echo "error: bridge did not complete on the box (no aggregate line); treating as failure" >&2
+  [ "$RC" -eq 0 ] && RC=1
+fi
 
 # --- pull artifacts (best-effort) ---
 mkdir -p ./.windows-artifacts
 # shellcheck disable=SC2086
 scp $SSH_OPTS -q -r "$HOST:$REPO/.windows-artifacts/." ./.windows-artifacts/ 2>/dev/null || true
 echo "artifacts -> ./.windows-artifacts/ (rc=$RC)"
-exit $RC
+exit "$RC"

--- a/scripts/test-windows.sh
+++ b/scripts/test-windows.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Run glass-windows on-box validation on a REMOTE Windows box from Linux. Unlike the local
+# test-x11.sh / test-wayland.sh suites, the Windows box is remote and WGC/SendInput need its
+# interactive console session, so this orchestrates over SSH: push the base commit, ship any
+# uncommitted working-tree delta, then invoke tools/windows-validation/run-onbox.ps1 on the box
+# (which does the session-1 bounce). Skips cleanly when no box is configured.
+#
+# Config (env; nothing box-specific is committed to this public repo):
+#   GLASS_WIN_HOST       user@host for SSH (required; unset => skip)
+#   GLASS_WIN_REPO       remote checkout path (default C:/Users/<user>/glass)
+#   GLASS_WIN_SSH_OPTS   extra ssh/scp options (optional)
+#
+# Usage:
+#   ./scripts/test-windows.sh                 # all onbox_* examples
+#   ./scripts/test-windows.sh onbox_handoff   # one (or several) named examples
+#   ./scripts/test-windows.sh --all           # explicit all
+#   ./scripts/test-windows.sh --tests clip    # cargo test -- --ignored clip
+#   ./scripts/test-windows.sh --release ...    # release profile
+#   ./scripts/test-windows.sh --dry-run ...    # print the plan, no SSH
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+HOST="${GLASS_WIN_HOST:-}"
+REPO="${GLASS_WIN_REPO:-}"
+SSH_OPTS="${GLASS_WIN_SSH_OPTS:-}"
+
+DRY_RUN=0; RELEASE=0; TESTS=""
+declare -a TARGETS=()
+ALL=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --all) ALL=1 ;;
+    --tests) TESTS="${2:-}"; shift ;;
+    --release) RELEASE=1 ;;
+    --dry-run) DRY_RUN=1 ;;
+    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    --*) echo "unknown flag: $1" >&2; exit 2 ;;
+    *) TARGETS+=("$1") ;;
+  esac
+  shift
+done
+
+if [ -z "$HOST" ]; then
+  echo "windows box not configured (set GLASS_WIN_HOST=user@host [GLASS_WIN_REPO=C:/path]); skipping."
+  exit 0
+fi
+RUSER="${HOST%@*}"
+[ -n "$REPO" ] || REPO="C:/Users/${RUSER}/glass"
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+SHA="$(git rev-parse HEAD)"
+DIRTY=0
+if ! git diff --quiet HEAD || [ -n "$(git ls-files --others --exclude-standard)" ]; then DIRTY=1; fi
+
+# Assemble the bridge invocation args.
+PS_ARGS=( -RepoDir "$REPO" -Branch "$BRANCH" -Sha "$SHA" )
+[ "$ALL" -eq 1 ] && PS_ARGS+=( -All )
+[ ${#TARGETS[@]} -gt 0 ] && PS_ARGS+=( -Targets "$(IFS=,; echo "${TARGETS[*]}")" )
+[ -n "$TESTS" ] && PS_ARGS+=( -Tests "$TESTS" )
+[ "$RELEASE" -eq 1 ] && PS_ARGS+=( -Release )
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "[dry-run] host=$HOST repo=$REPO branch=$BRANCH sha=${SHA:0:8} dirty=$DIRTY"
+  if [ "$DIRTY" -eq 1 ]; then
+    echo "[dry-run] sync: git push origin HEAD:$BRANCH; scp diff+untracked; box resets to $SHA then applies delta"
+  else
+    echo "[dry-run] sync: git push origin HEAD:$BRANCH; box checks out $BRANCH and resets to $SHA"
+  fi
+  echo "[dry-run] invoke: run-onbox.ps1 ${PS_ARGS[*]}"
+  echo "[dry-run] then: scp $REPO/.windows-artifacts -> ./.windows-artifacts/"
+  exit 0
+fi
+
+# shellcheck disable=SC2086
+sshx() { ssh $SSH_OPTS -o ConnectTimeout=8 "$HOST" "$@"; }
+
+# --- preflight ---
+if ! sshx "cmd /c echo ok" >/dev/null 2>&1; then
+  echo "error: $HOST unreachable -- powered up with sshd running?" >&2
+  exit 1
+fi
+
+# --- sync: push base commit, ship working-tree delta ---
+echo "== push base commit ($BRANCH @ ${SHA:0:8}) =="
+git push -q origin "HEAD:$BRANCH"
+
+DIFF_REMOTE=""; UNTAR_REMOTE=""
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+if [ "$DIRTY" -eq 1 ]; then
+  echo "== ship working-tree delta =="
+  git diff HEAD --binary > "$TMP/wip.diff"
+  git ls-files --others --exclude-standard -z | tar --null -cf "$TMP/untracked.tar" --files-from=- 2>/dev/null || : > "$TMP/untracked.tar"
+  # shellcheck disable=SC2086
+  scp $SSH_OPTS -q "$TMP/wip.diff" "$HOST:$REPO/.glass-wip.diff"
+  # shellcheck disable=SC2086
+  scp $SSH_OPTS -q "$TMP/untracked.tar" "$HOST:$REPO/.glass-untracked.tar"
+  DIFF_REMOTE="$REPO/.glass-wip.diff"; UNTAR_REMOTE="$REPO/.glass-untracked.tar"
+  PS_ARGS+=( -DiffPath "$DIFF_REMOTE" -UntarPath "$UNTAR_REMOTE" )
+fi
+
+# --- invoke the bridge ---
+echo "== run on box =="
+set +e
+# shellcheck disable=SC2086
+sshx "powershell -NoProfile -ExecutionPolicy Bypass -File $REPO/tools/windows-validation/run-onbox.ps1 ${PS_ARGS[*]}"
+RC=$?
+set -e
+
+# --- pull artifacts (best-effort) ---
+mkdir -p ./.windows-artifacts
+# shellcheck disable=SC2086
+scp $SSH_OPTS -q -r "$HOST:$REPO/.windows-artifacts/." ./.windows-artifacts/ 2>/dev/null || true
+echo "artifacts -> ./.windows-artifacts/ (rc=$RC)"
+exit $RC

--- a/scripts/test-windows.sh
+++ b/scripts/test-windows.sh
@@ -46,8 +46,15 @@ if [ -z "$HOST" ]; then
 fi
 RUSER="${HOST%@*}"
 [ -n "$REPO" ] || REPO="C:/Users/${RUSER}/glass"
+case "$HOST$REPO" in
+  *[[:space:]]*) echo "error: GLASS_WIN_HOST/GLASS_WIN_REPO must not contain spaces" >&2; exit 2 ;;
+esac
 
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$BRANCH" = "HEAD" ]; then
+  echo "error: detached HEAD; check out a branch before running test-windows.sh" >&2
+  exit 1
+fi
 SHA="$(git rev-parse HEAD)"
 DIRTY=0
 if ! git diff --quiet HEAD || [ -n "$(git ls-files --others --exclude-standard)" ]; then DIRTY=1; fi
@@ -102,7 +109,7 @@ fi
 echo "== run on box =="
 set +e
 # shellcheck disable=SC2086
-sshx "powershell -NoProfile -ExecutionPolicy Bypass -File $REPO/tools/windows-validation/run-onbox.ps1 ${PS_ARGS[*]}"
+sshx "powershell -NoProfile -ExecutionPolicy Bypass -File \"$REPO/tools/windows-validation/run-onbox.ps1\" ${PS_ARGS[*]}"
 RC=$?
 set -e
 

--- a/tools/windows-validation/REMOTE.md
+++ b/tools/windows-validation/REMOTE.md
@@ -62,13 +62,27 @@ nowhere. This is the Windows equivalent of "a bare SSH shell isn't the GUI sessi
 
 ## The dev loop
 
+```bash
+# One command from Linux (set the env once, see below):
+./scripts/test-windows.sh onbox_handoff     # one example
+./scripts/test-windows.sh                    # all onbox_* examples
+./scripts/test-windows.sh --tests clip       # ignored tests matching "clip"
+
+# It pushes your branch (and ships any uncommitted changes), syncs the box, builds, runs each
+# target in the interactive session via the schtasks /it bridge, prints "N PASS / M FAIL", and
+# pulls WebP captures into ./.windows-artifacts/. Exit code is the verdict.
 ```
-edit on Linux ──► git push          (or edit directly via VS Code Remote-SSH)
-              ──► on box: git pull
-              ──► ssh: cargo build --release          # build over SSH is fine
-              ──► Moonlight session: winval <item>     # run where the desktop composes
-              ──► read PASS/FAIL ──► record in the validation plan's results table
+
+Configure the box once (nothing box-specific is committed):
+
+```bash
+export GLASS_WIN_HOST=user@box-ip          # required; unset => the script skips cleanly
+export GLASS_WIN_REPO=C:/Users/user/glass  # optional; defaults to C:/Users/<user>/glass
 ```
+
+Under the hood it still obeys the session rule below — `run-onbox.ps1` uses a `schtasks /it`
+scheduled task to execute in the interactive console session (the manual `winval`-in-Moonlight
+step is only needed for live watching).
 
 Once the make-or-break gate passes, the same box becomes the dev + integration-test machine
 for the real `glass-windows` crate (its `#[ignore]`d E2E suite runs in this mirrored session,

--- a/tools/windows-validation/run-onbox.ps1
+++ b/tools/windows-validation/run-onbox.ps1
@@ -127,7 +127,7 @@ foreach ($t in $Targets) {
 # --- 6. run ignored tests (optional) ---
 if ($Tests -ne "") {
   Write-Host "`n===== tests: --ignored $Tests ====="
-  cmd /c "cargo test -p glass-windows $relArg -- --ignored $Tests 2>&1" | Tee-Object -Variable tout | Out-Host
+  cmd /c "cargo test -p glass-windows $relArg -- --ignored $Tests 2>&1" | Out-Host
   if ($LASTEXITCODE -ne 0) { Write-Host "tests($Tests): FAIL"; $failures++ } else { Write-Host "tests($Tests): PASS" }
 }
 

--- a/tools/windows-validation/run-onbox.ps1
+++ b/tools/windows-validation/run-onbox.ps1
@@ -1,0 +1,132 @@
+# glass-windows on-box bridge. Invoked over SSH by scripts/test-windows.sh. Does ALL box-side work:
+# git sync (to a known base + optional working-tree overlay), cargo build, and the scheduled-task
+# bounce into the interactive desktop session (session 1) where WGC capture + SendInput work --
+# unlike the SSH session (session 0). Prints "<target>: PASS|FAIL", an aggregate, and exits non-zero
+# on any failure. ASCII-only (non-ASCII corrupts over the transfer). ErrorActionPreference=Continue
+# because native tools (cargo/git/schtasks) write progress to stderr, which under Stop aborts us.
+param(
+  [Parameter(Mandatory = $true)][string]$RepoDir,
+  [string]$Branch = "",
+  [string]$Sha = "",
+  [string]$DiffPath = "",
+  [string]$UntarPath = "",
+  [string[]]$Targets = @(),
+  [switch]$All,
+  [string]$Tests = "",
+  [int]$TimeoutSec = 300,
+  [switch]$Release
+)
+$ErrorActionPreference = "Continue"
+$failures = 0
+$artifacts = Join-Path $RepoDir ".windows-artifacts"
+
+function Fail($msg) { Write-Host "ERROR: $msg"; exit 1 }
+
+Set-Location $RepoDir
+
+# --- 1. sync to the requested base commit, then overlay any working-tree delta ---
+if ($Sha -ne "") {
+  Write-Host "== sync: fetch + reset to $Sha ($Branch) =="
+  cmd /c "git fetch -q origin $Branch 2>&1" | Out-Null
+  if ($LASTEXITCODE -ne 0) { Fail "git fetch failed" }
+  cmd /c "git checkout -q -f $Branch 2>&1" | Out-Null
+  if ($LASTEXITCODE -ne 0) { Fail "git checkout failed" }
+  cmd /c "git reset -q --hard $Sha 2>&1" | Out-Null
+  if ($LASTEXITCODE -ne 0) { Fail "git reset failed" }
+  cmd /c "git clean -q -fd 2>&1" | Out-Null
+  if ($LASTEXITCODE -ne 0) { Fail "git clean failed" }
+}
+if ($DiffPath -ne "" -and (Test-Path $DiffPath)) {
+  Write-Host "== sync: apply working-tree diff =="
+  cmd /c "git apply --whitespace=nowarn `"$DiffPath`" 2>&1"
+  if ($LASTEXITCODE -ne 0) { Fail "git apply failed" }
+}
+if ($UntarPath -ne "" -and (Test-Path $UntarPath)) {
+  Write-Host "== sync: extract untracked files =="
+  cmd /c "tar -xf `"$UntarPath`" -C `"$RepoDir`" 2>&1"
+  if ($LASTEXITCODE -ne 0) { Fail "untar failed" }
+}
+
+# --- 2. resolve target list ---
+$exDir = Join-Path $RepoDir "crates\glass-windows\examples"
+if ($All -or ($Targets.Count -eq 0 -and $Tests -eq "")) {
+  $Targets = Get-ChildItem (Join-Path $exDir "onbox_*.rs") | ForEach-Object { $_.BaseName }
+}
+if ($Targets.Count -eq 0 -and $Tests -eq "") { Fail "no onbox_* examples found and no -Tests specified" }
+$profile = if ($Release) { "release" } else { "debug" }
+$relArg = if ($Release) { "--release" } else { "" }
+
+# Fresh artifacts dir each run.
+if (Test-Path $artifacts) { Remove-Item $artifacts -Recurse -Force }
+New-Item -ItemType Directory -Path $artifacts | Out-Null
+
+# --- 3. helper: run one built exe in the interactive session, return its log text ---
+function Invoke-Interactive($exe, $tag) {
+  $log = Join-Path $env:TEMP "glassval-$tag.log"
+  if (Test-Path $log) { Remove-Item $log -Force }
+  $cmd = "cmd.exe /c `"`"$exe`" > `"$log`" 2>&1`""
+  schtasks /delete /tn glassval /f 2>$null | Out-Null
+  # /tr $cmd (with $cmd's embedded quotes) is validated on PowerShell 5.1 on the box -- PowerShell
+  # passes $cmd as one argv element; do NOT "fix" this quoting (it produced correct interactive runs).
+  schtasks /create /tn glassval /tr $cmd /sc ONCE /st 00:00 /rl HIGHEST /it /f | Out-Null
+  schtasks /run /tn glassval | Out-Null
+  $deadline = (Get-Date).AddSeconds($TimeoutSec)
+  do {
+    Start-Sleep -Milliseconds 700
+    $q = schtasks /query /tn glassval /fo LIST /v 2>$null
+    $sl = ($q | Select-String "^Status:" | Select-Object -First 1)
+    $running = $sl -and ($sl.ToString() -match "Running")
+  } while ($running -and (Get-Date) -lt $deadline)
+  # Loop exits when the task finished OR the deadline passed; still Running => we timed out.
+  if ($running) {
+    schtasks /end /tn glassval 2>$null | Out-Null
+    schtasks /delete /tn glassval /f 2>$null | Out-Null
+    return @{ text = ""; result = "timeout"; ran = $false }
+  }
+  Start-Sleep -Milliseconds 500
+  $q = schtasks /query /tn glassval /fo LIST /v 2>$null   # fresh query so Last Result is final
+  $lr = ($q | Select-String "Last Result:" | Select-Object -First 1)
+  $lastResult = if ($lr) { ($lr.ToString() -replace '.*:\s*', '').Trim() } else { "unknown" }
+  schtasks /delete /tn glassval /f 2>$null | Out-Null
+  if (-not (Test-Path $log)) { return @{ text = ""; result = $lastResult; ran = $false } }
+  return @{ text = (Get-Content $log -Raw); result = $lastResult; ran = $true }
+}
+
+# --- 4. verdict from a target's captured output ---
+function Test-Verdict($r) {
+  if (-not $r.ran) {
+    $why = if ($r.result -eq "timeout") { "timed out" } else { "no log (interactive bounce failed?)" }
+    return @{ ok = $false; why = $why }
+  }
+  if ($r.result -ne "0" -and $r.result -ne "unknown") { return @{ ok = $false; why = "exit $($r.result)" } }
+  if ($r.text -match "(?m)\bFAIL\b") { return @{ ok = $false; why = "FAIL token" } }
+  if ($r.text -notmatch "(?m)\bPASS\b") { return @{ ok = $false; why = "no PASS token" } }
+  return @{ ok = $true; why = "ok" }
+}
+
+# --- 5. run examples ---
+foreach ($t in $Targets) {
+  Write-Host "`n===== example: $t ====="
+  cmd /c "cargo build -p glass-windows --example $t $relArg 2>&1" | Select-Object -Last 20
+  if ($LASTEXITCODE -ne 0) { Write-Host "${t}: FAIL (build)"; $failures++; continue }
+  $exe = Join-Path $RepoDir "target\$profile\examples\$t.exe"
+  $r = Invoke-Interactive $exe $t
+  Write-Host $r.text
+  $v = Test-Verdict $r
+  if ($v.ok) { Write-Host "${t}: PASS" } else { Write-Host "${t}: FAIL ($($v.why))"; $failures++ }
+  Get-ChildItem (Join-Path $env:USERPROFILE "*.webp") -ErrorAction SilentlyContinue |
+    Copy-Item -Destination $artifacts -Force -ErrorAction SilentlyContinue
+}
+
+# --- 6. run ignored tests (optional) ---
+if ($Tests -ne "") {
+  Write-Host "`n===== tests: --ignored $Tests ====="
+  cmd /c "cargo test -p glass-windows $relArg -- --ignored $Tests 2>&1" | Tee-Object -Variable tout | Out-Host
+  if ($LASTEXITCODE -ne 0) { Write-Host "tests($Tests): FAIL"; $failures++ } else { Write-Host "tests($Tests): PASS" }
+}
+
+# --- 7. aggregate verdict ---
+$total = $Targets.Count + ($(if ($Tests -ne "") { 1 } else { 0 }))
+$passed = $total - $failures
+Write-Host "`n== aggregate: $passed PASS / $failures FAIL =="
+if ($failures -gt 0) { exit 1 } else { exit 0 }

--- a/tools/windows-validation/run-onbox.ps1
+++ b/tools/windows-validation/run-onbox.ps1
@@ -46,6 +46,8 @@ if ($UntarPath -ne "" -and (Test-Path $UntarPath)) {
   cmd /c "tar -xf `"$UntarPath`" -C `"$RepoDir`" 2>&1"
   if ($LASTEXITCODE -ne 0) { Fail "untar failed" }
 }
+# Remove the scratch delta files shipped by test-windows.sh so they don't linger in the repo.
+Remove-Item -Force -ErrorAction SilentlyContinue (Join-Path $RepoDir ".glass-wip.diff"), (Join-Path $RepoDir ".glass-untracked.tar")
 
 # --- 2. resolve target list ---
 $exDir = Join-Path $RepoDir "crates\glass-windows\examples"

--- a/tools/windows-validation/run-onbox.ps1
+++ b/tools/windows-validation/run-onbox.ps1
@@ -53,9 +53,10 @@ if ($UntarPath -ne "") { Remove-Item -Force -ErrorAction SilentlyContinue $Untar
 # --- 2. resolve target list ---
 $exDir = Join-Path $RepoDir "crates\glass-windows\examples"
 if ($All -or ($Targets.Count -eq 0 -and $Tests -eq "")) {
-  $Targets = Get-ChildItem (Join-Path $exDir "onbox_*.rs") | ForEach-Object { $_.BaseName }
+  # onbox*.rs (not onbox_*.rs): also include the plain `onbox` example, which produces the WebP artifacts.
+  $Targets = Get-ChildItem (Join-Path $exDir "onbox*.rs") | ForEach-Object { $_.BaseName }
 }
-if ($Targets.Count -eq 0 -and $Tests -eq "") { Fail "no onbox_* examples found and no -Tests specified" }
+if ($Targets.Count -eq 0 -and $Tests -eq "") { Fail "no onbox examples found and no -Tests specified" }
 $profile = if ($Release) { "release" } else { "debug" }
 $relArg = if ($Release) { "--release" } else { "" }
 

--- a/tools/windows-validation/run-onbox.ps1
+++ b/tools/windows-validation/run-onbox.ps1
@@ -46,8 +46,9 @@ if ($UntarPath -ne "" -and (Test-Path $UntarPath)) {
   cmd /c "tar -xf `"$UntarPath`" -C `"$RepoDir`" 2>&1"
   if ($LASTEXITCODE -ne 0) { Fail "untar failed" }
 }
-# Remove the scratch delta files shipped by test-windows.sh so they don't linger in the repo.
-Remove-Item -Force -ErrorAction SilentlyContinue (Join-Path $RepoDir ".glass-wip.diff"), (Join-Path $RepoDir ".glass-untracked.tar")
+# Remove the scratch delta files shipped by test-windows.sh (they live outside the repo) after use.
+if ($DiffPath -ne "") { Remove-Item -Force -ErrorAction SilentlyContinue $DiffPath }
+if ($UntarPath -ne "") { Remove-Item -Force -ErrorAction SilentlyContinue $UntarPath }
 
 # --- 2. resolve target list ---
 $exDir = Join-Path $RepoDir "crates\glass-windows\examples"

--- a/tools/windows-validation/run-onbox.ps1
+++ b/tools/windows-validation/run-onbox.ps1
@@ -102,8 +102,10 @@ function Test-Verdict($r) {
     return @{ ok = $false; why = $why }
   }
   if ($r.result -ne "0" -and $r.result -ne "unknown") { return @{ ok = $false; why = "exit $($r.result)" } }
-  if ($r.text -match "(?m)\bFAIL\b") { return @{ ok = $false; why = "FAIL token" } }
-  if ($r.text -notmatch "(?m)\bPASS\b") { return @{ ok = $false; why = "no PASS token" } }
+  # Case-SENSITIVE (-cmatch): only the uppercase PASS/FAIL status tokens count, so prose like
+  # "fast-fail preserved" does not trip the verdict (-match is case-insensitive by default).
+  if ($r.text -cmatch "(?m)\bFAIL\b") { return @{ ok = $false; why = "FAIL token" } }
+  if ($r.text -cnotmatch "(?m)\bPASS\b") { return @{ ok = $false; why = "no PASS token" } }
   return @{ ok = $true; why = "ok" }
 }
 


### PR DESCRIPTION
## Summary

Turns remote on-box Windows validation from a hand-driven SSH + scheduled-task dance into a single Linux command. Unlike the local `test-x11.sh` / `test-wayland.sh` suites, the Windows box (e.g. LOTUS) is remote and WGC/SendInput need its interactive console session, so this orchestrates over SSH.

- **`scripts/test-windows.sh`** — Linux entry point. Reads box config from env (`GLASS_WIN_HOST` / `GLASS_WIN_REPO` / `GLASS_WIN_SSH_OPTS`); **skips cleanly** when unset (nothing box-specific is committed — public repo). Preflights SSH, pushes the base commit + ships any **uncommitted** working-tree delta (`git diff --binary` + tar of untracked), invokes the bridge, then pulls WebP artifacts into `./.windows-artifacts/` (gitignored). Exit code is the verdict. `--all`, named examples, `--tests <filter>`, `--release`, `--dry-run`.
- **`tools/windows-validation/run-onbox.ps1`** — box-side bridge. git-syncs the repo to the requested commit (+ overlays the working-tree delta), builds, and runs each `onbox*` example in the **interactive session (session 1)** via a `schtasks /it` scheduled task, parses a case-sensitive PASS/FAIL verdict, copies artifacts, exits non-zero on any failure.
- **`onbox.rs`** now saves captures as **lossless WebP via `glass_core::frame_to_webp`** (the production encoder) instead of PNG, and the `image` dev-dep is dropped.
- **REMOTE.md** leads with the one-command flow.

Design/plan live in the private repo (`docs/superpowers/{specs,plans}/2026-06-10-windows-test-harness*`).

## Validated on-box (LOTUS, Win11 25H2)

- Clean-sync single example → `onbox_handoff: PASS`, exit 0.
- `--all` (9 examples) → **7 PASS / 2 FAIL**, exit 1. The 2 failures (`onbox_a11y_edge`, `onbox_killtree`) are the **known no-hint Edge-handoff limitation** (both use `window_hint: None` by design; documented in PR #12), faithfully reported by the harness — not a harness fault.
- WebP artifacts pulled back and verified valid (`RIFF…WEBP`).
- Dirty-tree fast loop: an uncommitted edit reached the box, compiled, and ran.

Hardening surfaced during on-box acceptance and folded in: bridge + scratch shipped **outside** the repo (it git-resets/cleans the repo), `== aggregate:` completion-marker required (PowerShell can exit 0 on a failed `-File`), case-sensitive verdict tokens (prose "fail" no longer trips it), `onbox*.rs` glob (so the artifact-producing `onbox` is included), detached-HEAD + space guards.

## Test plan

- [x] `cargo test --workspace` green; `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `shellcheck scripts/test-windows.sh` clean; bridge ASCII-only
- [x] On-box: clean-sync, `--all`, dirty-tree, artifact pull (see above)
- [ ] CI matrix (check / x11 / wayland / windows-native / miri / coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)