### PR TITLE
fix(windows): discover Job-child windows after a no-hint launcher exits

### DIFF
--- a/crates/glass-windows/src/discovery.rs
+++ b/crates/glass-windows/src/discovery.rs
@@ -1,10 +1,11 @@
 //! Pure decision logic for the window-discovery poll loop, factored out of the
 //! (Windows-only) `backend` so it compiles and is unit-tested on any host — like
 //! [`crate::dpi`] and friends. The backend owns the Win32 side of each poll
-//! (enumerate windows, `try_wait` the root, read DWM frame bounds) and consults
-//! [`poll_decision`] once per iteration to decide whether to wait or give up.
+//! (enumerate windows, `try_wait` the root, read DWM frame bounds, query the Job
+//! pid-set) and consults [`poll_decision`] once per iteration to decide whether to
+//! wait or give up.
 
-/// What the discovery loop should do after a poll that found no adoptable window.
+/// What the discovery loop should do after one poll found no usable window yet.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PollStep {
     /// No window yet, but it's still worth waiting — sleep and poll again.
@@ -21,27 +22,41 @@ pub enum PollStep {
 /// - `root_exit`: `Some(code)` once the launched process has been observed exited,
 ///   `None` while it is still alive.
 /// - `has_hint`: whether the caller supplied a title/class [`WindowHint`].
+/// - `has_live_descendants`: whether the app's process set still contains a live
+///   process other than the (now-exited) root — i.e. a Job-captured child.
 /// - `past_deadline`: whether the timeout has elapsed.
 ///
 /// The subtlety this encodes: a launcher can exit `0` the instant it hands its UI
-/// to an *unrelated* process — some packaged Windows apps activate through a system
-/// broker, so the real window is owned by neither the launcher nor a descendant the
-/// Job/Toolhelp set can follow. Failing the moment the root exits reports
-/// `AppExited` a beat before that handoff window maps. So when a hint is present —
-/// the caller's explicit signal that a specific window is expected, possibly from
-/// another process — keep polling for it until the deadline, then report the exit
-/// (more actionable than a bare `Timeout`). With no hint there is nothing an
-/// unrelated process could satisfy, so fail fast on root exit rather than burning
-/// the whole timeout on what is almost certainly a crash.
+/// off, before that UI's window maps. There are two legitimate hand-off shapes, and
+/// failing on root-exit alone breaks both:
+///
+/// 1. **To a Job-captured child** — the common multi-process case (Chromium/Edge/
+///    Electron/Java): the real browser/UI runs in child processes the Job retains
+///    after the root dies, so `job_pids()` still lists them (`has_live_descendants`).
+///    Their window appears a beat later. Validated on-box: Edge's root exits ~1s in
+///    while 5 live children remain in the Job and a window then maps.
+/// 2. **To an *unrelated* process** — some packaged apps activate through a system
+///    broker, so the window is owned by neither the launcher nor a descendant the
+///    pid-set can follow; only a `has_hint` title/class match can locate it.
+///
+/// So on root-exit keep polling until the deadline whenever a hint *or* a live
+/// descendant could still produce the window, then report the exit (more actionable
+/// than a bare `Timeout`). Fast-fail only when neither holds — a launcher that exits
+/// leaving no descendant and no hint to wait on is a genuine crash, and we shouldn't
+/// burn the whole timeout on it.
 ///
 /// [`WindowHint`]: glass_core::platform::WindowHint
-pub fn poll_decision(root_exit: Option<Option<i32>>, has_hint: bool, past_deadline: bool) -> PollStep {
+pub fn poll_decision(
+    root_exit: Option<Option<i32>>,
+    has_hint: bool,
+    has_live_descendants: bool,
+    past_deadline: bool,
+) -> PollStep {
     match root_exit {
-        // Root exited: fail now if there's no hint to wait on, or if we've already
-        // given a hinted handoff window until the deadline to appear.
-        Some(code) if !has_hint || past_deadline => PollStep::FailExited(code),
-        // Root exited, a hint is set, and there's still time: a broker/handoff
-        // window may yet map — keep polling for it.
+        // Root exited. Give up only when nothing more could appear: the deadline passed, OR there
+        // is neither a hint to wait on nor a live descendant that might still open a window.
+        Some(code) if past_deadline || (!has_hint && !has_live_descendants) => PollStep::FailExited(code),
+        // Root exited, but a hint or a live (Job-child) descendant may yet produce the window.
         Some(_) => PollStep::KeepPolling,
         // Root still alive but out of time: report the timeout.
         None if past_deadline => PollStep::FailTimeout,
@@ -56,41 +71,44 @@ mod tests {
 
     #[test]
     fn root_alive_keeps_polling_until_deadline() {
-        assert_eq!(poll_decision(None, false, false), PollStep::KeepPolling);
-        assert_eq!(poll_decision(None, true, false), PollStep::KeepPolling);
+        assert_eq!(poll_decision(None, false, false, false), PollStep::KeepPolling);
+        assert_eq!(poll_decision(None, true, false, false), PollStep::KeepPolling);
     }
 
     #[test]
     fn root_alive_past_deadline_times_out() {
-        assert_eq!(poll_decision(None, false, true), PollStep::FailTimeout);
-        assert_eq!(poll_decision(None, true, true), PollStep::FailTimeout);
+        assert_eq!(poll_decision(None, false, false, true), PollStep::FailTimeout);
+        assert_eq!(poll_decision(None, true, true, true), PollStep::FailTimeout);
     }
 
     #[test]
-    fn root_exited_without_hint_fails_fast() {
-        // The original fast-fail: a launcher that exits with no hint to wait on has
-        // (almost certainly) crashed — don't burn the whole timeout.
-        assert_eq!(poll_decision(Some(Some(1)), false, false), PollStep::FailExited(Some(1)));
-        assert_eq!(poll_decision(Some(None), false, false), PollStep::FailExited(None));
+    fn root_exited_crash_fast_fails() {
+        // No hint AND no live descendant: a launcher that exited leaving nothing behind has
+        // (almost certainly) crashed — fail fast rather than burning the whole timeout.
+        assert_eq!(poll_decision(Some(Some(1)), false, false, false), PollStep::FailExited(Some(1)));
+        assert_eq!(poll_decision(Some(None), false, false, false), PollStep::FailExited(None));
+    }
+
+    #[test]
+    fn root_exited_with_live_descendant_keeps_polling() {
+        // The fix: a Chromium/Edge/Electron launcher exits 0 but the Job retains live children
+        // whose window maps a beat later — keep polling even without a hint.
+        assert_eq!(poll_decision(Some(Some(0)), false, true, false), PollStep::KeepPolling);
     }
 
     #[test]
     fn root_exited_with_hint_keeps_polling_for_handoff() {
-        // The grace period: with a hint, a handoff/broker window may still appear,
-        // so keep polling rather than reporting AppExited the instant the root dies.
-        assert_eq!(poll_decision(Some(Some(0)), true, false), PollStep::KeepPolling);
+        // A broker/unrelated-process hand-off (no descendant in the set) — a title/class hint may
+        // still locate the window, so keep polling.
+        assert_eq!(poll_decision(Some(Some(0)), true, false, false), PollStep::KeepPolling);
     }
 
     #[test]
-    fn root_exited_with_hint_reports_exit_at_deadline() {
-        // If the hinted window never showed, report the exit (more actionable than a
-        // bare Timeout), preserving the exit code.
-        assert_eq!(poll_decision(Some(Some(0)), true, true), PollStep::FailExited(Some(0)));
-        assert_eq!(poll_decision(Some(Some(3)), true, true), PollStep::FailExited(Some(3)));
-    }
-
-    #[test]
-    fn root_exited_without_hint_at_deadline_still_reports_exit() {
-        assert_eq!(poll_decision(Some(Some(2)), false, true), PollStep::FailExited(Some(2)));
+    fn root_exited_reports_exit_at_deadline() {
+        // If the hinted/descendant window never showed, report the exit (more actionable than a
+        // bare Timeout), preserving the exit code — whichever kept us polling.
+        assert_eq!(poll_decision(Some(Some(0)), true, false, true), PollStep::FailExited(Some(0)));
+        assert_eq!(poll_decision(Some(Some(3)), false, true, true), PollStep::FailExited(Some(3)));
+        assert_eq!(poll_decision(Some(Some(2)), false, false, true), PollStep::FailExited(Some(2)));
     }
 }

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -111,6 +111,9 @@ mod backend {
             // launcher can exit the instant it hands its UI off, so root-exit is not on
             // its own fatal — see `poll_decision` for the hint-vs-no-hint policy.
             let mut root_exit: Option<Option<i32>> = None;
+            // The root's own pid — lets us tell a live Job-captured descendant (keep polling: its
+            // window may still map) from a bare crash (fast-fail) once the root exits.
+            let root_pid = self.app.as_ref().map(|a| a.root_pid());
             loop {
                 // Look for the app's window FIRST, then check for exit. A launcher
                 // that hands its UI to a Job-captured child and exits 0 (Chromium/
@@ -140,7 +143,15 @@ mod backend {
                         }
                     }
                 }
-                match poll_decision(root_exit, hint.is_some(), Instant::now() >= deadline) {
+                // A live process in the set other than the (now-exited) root means a Job-captured
+                // child is up that may still own a window (Chromium/Edge/Electron) — keep polling.
+                let has_live_descendants = root_pid.is_some_and(|rp| pids.iter().any(|&p| p != rp));
+                match poll_decision(
+                    root_exit,
+                    hint.is_some(),
+                    has_live_descendants,
+                    Instant::now() >= deadline,
+                ) {
                     PollStep::FailExited(code) => return Err(GlassError::AppExited(code)),
                     PollStep::FailTimeout => return Err(GlassError::Timeout(timeout_ms)),
                     PollStep::KeepPolling => {}


### PR DESCRIPTION
## Problem

`onbox_killtree` and `onbox_a11y_edge` failed on-box with `app exited (code Some(0))`: launching an isolated Edge returned `AppExited` instead of discovering its window. (Surfaced by the new `./scripts/test-windows.sh --all` — 7/9.)

## Root cause (confirmed on-box, not guessed)

Instrumented `discover_window` to trace the pid-set + windows past root-exit:

```
t=4ms    root_exit=None         pids=[22576]
t=975ms  root_exit=Some(Some(0)) pids=[23064,23052,23004,23080,23188,22576]  (5 live children + dead root)
→ a window maps a beat later; discovery succeeds once polling continues
```

A Chromium/Edge/Electron launcher exits `0` the instant it hands its UI to **child** processes — but the Job retains those children (`job_pids()` returns them after the root dies), and their window maps ~1s later. `discover_window`'s no-hint path fast-failed `AppExited` on root-exit *before* that window appeared — contradicting its own comment that Chromium/Electron hand-off "must not be reported as AppExited". (The children do **not** escape the Job; this is distinct from the broker case in #12.)

## Fix

`poll_decision` gains `has_live_descendants`. On root-exit with no hint, keep polling when the pid-set still holds a live process beyond the dead root (a Job child may yet own a window); fast-fail only when nothing live remains — a genuine crash. This generalizes #12's hint-grace to the no-hint multi-process case.

- **Preserved:** the no-hint broker case (notepad: launcher exits, leaves *no* Job descendant) still fast-fails immediately — verified `onbox_handoff` [B] stays under its 4s fast-fail threshold.
- **Preserved:** single-process crash detection (root exits, empty Job → fast-fail).

## Verification

- `discovery::poll_decision` unit tests extended (crash fast-fail vs live-descendant keep-polling vs hint-grace vs deadline) — green on Linux.
- `cargo clippy --workspace --all-targets -D warnings` clean; Windows-target build clean.
- **On-box (LOTUS):** `./scripts/test-windows.sh --all` → **9/9 PASS** (was 7/9). `onbox_killtree` / `onbox_a11y_edge` now discover + kill-tree correctly; `onbox_handoff` regression intact.

Follow-up (separate, noted): the harness's multiple-named-targets path comma-joins into one string that PowerShell `-File` doesn't split (single-target and `--all` are unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)