### PR TITLE
Keep internal framing out of the public repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,11 @@
 
 Guidance for Claude Code working in the **glass** open-core Rust workspace.
 
+> **This repository is PUBLIC.** Keep internal business/strategy, licensing-strategy
+> framing, planning and design specs, and the internal security threat model out of this
+> repo — that material lives in the private `fixed-width` repo. Document *what the product
+> does*, never *why it helps the business*.
+
 ## What glass is
 
 A Rust **MCP server** giving an AI agent a closed **build → see → interact → debug** loop

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,7 @@ members = ["crates/glass-core", "crates/glass-x11", "crates/glass-testapp", "cra
 
 [workspace.package]
 edition = "2021"
-# Open core: Apache-2.0 (the patent grant matters for OS-level input/capture).
-# Future moat crates carry FSL-1.1-Apache-2.0; none exist yet.
+# Apache-2.0 (the patent grant matters for OS-level input/capture).
 # Third-party deps stay permissive (MIT/Apache, no copyleft) per CLAUDE.md.
 # publish = false: open-source but not (yet) pushed to crates.io.
 license = "Apache-2.0"


### PR DESCRIPTION
## What

- Remove a speculative internal licensing-strategy comment from the workspace `Cargo.toml`. The `license = "Apache-2.0"` and `repository` fields remain the source of truth.
- Add a short note to `CLAUDE.md`: this repository is **public**, so internal business/strategy, planning and design specs, and the internal security threat model belong in the private repo — not here. Document *what the product does*, not *why it helps the business*.

## Why

Keeps internal material out of the public manifest and sets an explicit, discoverable expectation for contributors (human and agent) working in this repo.

No code or behavior changes — comments and docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)