### PR TITLE
chore(lint): enforce lint gate in-tree; prefer expect over allow/unwrap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,16 @@ license = "Apache-2.0"
 repository = "https://github.com/fixed-width/glass"
 publish = false
 
+# Lint gate, in-tree so `cargo clippy --workspace` enforces it without extra flags
+# (CI still adds `-D warnings` to also catch rustc warnings). The `all` group sits at
+# priority -1 so any specific lint override below it wins on conflict.
+[workspace.lints.rust]
+future_incompatible = "warn"
+nonstandard_style = "deny"
+
+[workspace.lints.clippy]
+all = { level = "deny", priority = -1 }
+
 [workspace.dependencies]
 thiserror = "1"
 image = { version = "0.25", default-features = false, features = ["webp"] }

--- a/crates/glass-a11y-linux/Cargo.toml
+++ b/crates/glass-a11y-linux/Cargo.toml
@@ -16,3 +16,6 @@ tokio.workspace = true
 [dev-dependencies]
 glass-x11 = { path = "../glass-x11" }
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/glass-a11y-windows/Cargo.toml
+++ b/crates/glass-a11y-windows/Cargo.toml
@@ -11,3 +11,6 @@ glass-core.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 uiautomation = { version = "0.25", features = ["process"] }
+
+[lints]
+workspace = true

--- a/crates/glass-clip-hook/Cargo.toml
+++ b/crates/glass-clip-hook/Cargo.toml
@@ -38,3 +38,6 @@ windows-core = "0.62"
 # `static-detour` enables the `static_detour!` macro (the type-safe detour table); it pulls in the
 # `nightly` feature — fine, the workspace is pinned to nightly (rust-toolchain.toml).
 retour = { version = "0.3", features = ["static-detour"] }
+
+[lints]
+workspace = true

--- a/crates/glass-core/Cargo.toml
+++ b/crates/glass-core/Cargo.toml
@@ -28,3 +28,6 @@ harness = false
 [[bench]]
 name = "image_io"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/glass-core/src/diff.rs
+++ b/crates/glass-core/src/diff.rs
@@ -139,19 +139,28 @@ pub fn diff(a: &Frame, b: &Frame, tolerance: u8) -> Result<DiffResult> {
 const MAX_YIQ_DELTA: f32 = 35215.0;
 
 // The canonical pixelmatch YIQ coefficients (kept at full precision for
-// traceability; f32 rounds them, hence the allow).
+// traceability; f32 rounds them, hence the expect).
 #[inline]
-#[allow(clippy::excessive_precision)]
+#[expect(
+    clippy::excessive_precision,
+    reason = "canonical pixelmatch YIQ coefficients kept at full precision for traceability; f32 narrows them"
+)]
 fn rgb2y(r: f32, g: f32, b: f32) -> f32 {
     r * 0.29889531 + g * 0.58662247 + b * 0.11448223
 }
 #[inline]
-#[allow(clippy::excessive_precision)]
+#[expect(
+    clippy::excessive_precision,
+    reason = "canonical pixelmatch YIQ coefficients kept at full precision for traceability; f32 narrows them"
+)]
 fn rgb2i(r: f32, g: f32, b: f32) -> f32 {
     r * 0.59597799 - g * 0.27417610 - b * 0.32180189
 }
 #[inline]
-#[allow(clippy::excessive_precision)]
+#[expect(
+    clippy::excessive_precision,
+    reason = "canonical pixelmatch YIQ coefficients kept at full precision for traceability; f32 narrows them"
+)]
 fn rgb2q(r: f32, g: f32, b: f32) -> f32 {
     r * 0.21147017 - g * 0.52261711 + b * 0.31114694
 }
@@ -345,7 +354,10 @@ pub fn diff_perceptual(a: &Frame, b: &Frame, threshold: f32) -> Result<DiffResul
 
 /// Classify the pixel at (x,y) and fold it into the running counters/bbox.
 #[inline]
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "hot per-pixel classifier; threads counters/bbox by &mut to avoid per-pixel allocation"
+)]
 fn classify_into(
     a: &Frame, b: &Frame, x: u32, y: u32, w: u32, h: u32, max_delta: f32, changed: &mut u64,
     aa_ignored: &mut u64, min_x: &mut u32, min_y: &mut u32, max_x: &mut u32, max_y: &mut u32,

--- a/crates/glass-mcp/Cargo.toml
+++ b/crates/glass-mcp/Cargo.toml
@@ -61,3 +61,6 @@ tokio = { version = "1", features = ["full"] }
 # the HTTP client). Pinned to rmcp's reqwest line so cargo unifies on one copy; plain
 # loopback HTTP needs no TLS provider, so keep default-features off.
 reqwest = { version = "0.13", default-features = false }
+
+[lints]
+workspace = true

--- a/crates/glass-mcp/src/serve/session_gate.rs
+++ b/crates/glass-mcp/src/serve/session_gate.rs
@@ -72,7 +72,7 @@ impl SessionManager for SingleSessionManager {
     async fn create_session(&self) -> Result<(SessionId, Self::Transport), Self::Error> {
         // Claim the single slot before the await; reject if already taken.
         {
-            let mut slot = self.slot.lock().unwrap();
+            let mut slot = self.slot.lock().expect("session slot mutex");
             if !matches!(*slot, Slot::Empty) {
                 return Err(busy_error());
             }
@@ -80,12 +80,12 @@ impl SessionManager for SingleSessionManager {
         }
         match self.inner.create_session().await {
             Ok((id, transport)) => {
-                *self.slot.lock().unwrap() = Slot::Active(id.clone());
+                *self.slot.lock().expect("session slot mutex") = Slot::Active(id.clone());
                 Ok((id, transport))
             }
             Err(e) => {
                 // Release the slot if the inner manager failed to create.
-                *self.slot.lock().unwrap() = Slot::Empty;
+                *self.slot.lock().expect("session slot mutex") = Slot::Empty;
                 Err(e)
             }
         }
@@ -97,7 +97,7 @@ impl SessionManager for SingleSessionManager {
         // stale/bogus id (an unvalidated DELETE header, or a superseded session's
         // late worker-end) must not free a live session's slot — see the module
         // docs.
-        let mut slot = self.slot.lock().unwrap();
+        let mut slot = self.slot.lock().expect("session slot mutex");
         if matches!(&*slot, Slot::Active(active) if active == id) {
             *slot = Slot::Empty;
         }

--- a/crates/glass-proc-linux/Cargo.toml
+++ b/crates/glass-proc-linux/Cargo.toml
@@ -7,3 +7,6 @@ repository.workspace = true
 publish.workspace = true
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/glass-sandbox-linux/Cargo.toml
+++ b/crates/glass-sandbox-linux/Cargo.toml
@@ -8,3 +8,6 @@ publish.workspace = true
 
 [dependencies]
 glass-core.workspace = true
+
+[lints]
+workspace = true

--- a/crates/glass-testapp/Cargo.toml
+++ b/crates/glass-testapp/Cargo.toml
@@ -26,3 +26,6 @@ tokio = { version = "1", features = ["full"] }
 base64 = "0.22"
 image = { version = "0.25", default-features = false, features = ["webp"] }
 serde_json = "1"
+
+[lints]
+workspace = true

--- a/crates/glass-wayland/Cargo.toml
+++ b/crates/glass-wayland/Cargo.toml
@@ -18,3 +18,6 @@ serde = { workspace = true }
 serde_json.workspace = true
 tempfile.workspace = true
 rustix.workspace = true
+
+[lints]
+workspace = true

--- a/crates/glass-wayland/src/clipboard.rs
+++ b/crates/glass-wayland/src/clipboard.rs
@@ -313,7 +313,7 @@ impl Dispatch<ZwlrDataControlSourceV1, ()> for ServeState {
         match event {
             zwlr_data_control_source_v1::Event::Send { mime_type: _, fd } => {
                 // Write the current text to the fd and close it.
-                let text = state.text.lock().unwrap().clone();
+                let text = state.text.lock().expect("clipboard text mutex").clone();
                 // fd is OwnedFd; wrap in File and write (file closes on drop).
                 let mut file = std::fs::File::from(fd);
                 let _ = file.write_all(text.as_bytes());
@@ -511,7 +511,7 @@ impl ClipboardOwner {
         let (lock, cvar) = &*ready;
         let result = cvar
             .wait_timeout_while(
-                lock.lock().unwrap(),
+                lock.lock().expect("clipboard ready mutex"),
                 Duration::from_secs(2),
                 |s| matches!(s, ReadyState::Pending),
             )
@@ -541,7 +541,7 @@ impl ClipboardOwner {
     /// Update the text being served. If the thread already lost ownership
     /// (`Cancelled`), this is a no-op (caller should re-spawn).
     pub fn set_text(&self, text: &str) {
-        *self.text.lock().unwrap() = text.to_string();
+        *self.text.lock().expect("clipboard text mutex") = text.to_string();
     }
 
     /// True if the serving thread is still running (hasn't stopped itself due
@@ -571,7 +571,7 @@ impl Drop for ClipboardOwner {
 /// Signal the ready condvar. Helper to reduce repetition.
 fn signal_ready(ready: &Arc<(Mutex<ReadyState>, Condvar)>, state: ReadyState) {
     let (lock, cvar) = &**ready;
-    *lock.lock().unwrap() = state;
+    *lock.lock().expect("clipboard ready mutex") = state;
     cvar.notify_one();
 }
 

--- a/crates/glass-wayland/src/command.rs
+++ b/crates/glass-wayland/src/command.rs
@@ -100,7 +100,7 @@ pub fn spawn_reader<R: std::io::Read + Send + 'static>(reader: R, stream: Stream
     std::thread::spawn(move || {
         for line in BufReader::new(reader).lines() {
             match line {
-                Ok(text) => sink.lock().unwrap().push((stream, text)),
+                Ok(text) => sink.lock().expect("log sink mutex").push((stream, text)),
                 Err(_) => break,
             }
         }

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -384,7 +384,10 @@ impl Dispatch<ZwpVirtualKeyboardV1, ()> for State {
 
 /// Connect to `socket`, verify globals, bind screencopy + virtual-input managers,
 /// read the output extent, and connect sway IPC. Returns everything for a session.
-#[allow(clippy::type_complexity)]
+#[expect(
+    clippy::type_complexity,
+    reason = "one-shot session-setup tuple, destructured immediately by the sole caller"
+)]
 fn open_session(
     socket: &Path,
     runtime_dir: &Path,
@@ -1004,7 +1007,7 @@ impl Platform for WaylandPlatform {
     }
 
     fn drain_logs(&mut self) -> Vec<(Stream, String)> {
-        std::mem::take(&mut *self.logs.lock().unwrap())
+        std::mem::take(&mut *self.logs.lock().expect("log buffer mutex"))
     }
 
     /// The app's process subtree. The child we spawn is **sway**, which launches

--- a/crates/glass-windows/Cargo.toml
+++ b/crates/glass-windows/Cargo.toml
@@ -32,3 +32,6 @@ windows = { version = "0.62", features = [
 [target.'cfg(windows)'.dev-dependencies]
 windows = { version = "0.62", features = ["Win32_Foundation", "Win32_UI_HiDpi", "Win32_UI_WindowsAndMessaging"] }
 glass-a11y-windows = { path = "../glass-a11y-windows" }
+
+[lints]
+workspace = true

--- a/crates/glass-windows/src/containment/mod.rs
+++ b/crates/glass-windows/src/containment/mod.rs
@@ -47,7 +47,7 @@ mod imp {
             let buf = BufReader::new(reader);
             for line in buf.lines() {
                 match line {
-                    Ok(text) => sink.lock().unwrap().push((stream, text)),
+                    Ok(text) => sink.lock().expect("log sink mutex").push((stream, text)),
                     Err(_) => break,
                 }
             }

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -303,7 +303,7 @@ mod backend {
         }
 
         fn drain_logs(&mut self) -> Vec<(Stream, String)> {
-            std::mem::take(&mut *self.logs.lock().unwrap())
+            std::mem::take(&mut *self.logs.lock().expect("log buffer mutex"))
         }
 
         fn app_pid(&self) -> Option<u32> {

--- a/crates/glass-x11/Cargo.toml
+++ b/crates/glass-x11/Cargo.toml
@@ -23,3 +23,6 @@ criterion = { workspace = true }
 [[bench]]
 name = "pixels"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/glass-x11/src/clipboard.rs
+++ b/crates/glass-x11/src/clipboard.rs
@@ -214,7 +214,7 @@ impl ClipboardOwner {
         let (lock, cvar) = &*ready;
         let result = cvar
             .wait_timeout_while(
-                lock.lock().unwrap(),
+                lock.lock().expect("clipboard ready mutex"),
                 Duration::from_secs(2),
                 |s| matches!(s, ReadyState::Pending),
             )
@@ -243,7 +243,7 @@ impl ClipboardOwner {
 
     /// Update the text that will be served on the next paste.
     pub fn set_text(&self, text: &str) {
-        *self.text.lock().unwrap() = text.to_string();
+        *self.text.lock().expect("clipboard text mutex") = text.to_string();
     }
 
     /// Returns `true` if the owner thread is still running (i.e. still owns the
@@ -277,7 +277,7 @@ impl Drop for ClipboardOwner {
 /// Signal the ready condvar from the owner thread. Helper to reduce repetition.
 fn signal_ready(ready: &Arc<(Mutex<ReadyState>, Condvar)>, state: ReadyState) {
     let (lock, cvar) = &**ready;
-    *lock.lock().unwrap() = state;
+    *lock.lock().expect("clipboard ready mutex") = state;
     cvar.notify_one();
 }
 
@@ -438,7 +438,7 @@ fn handle_selection_request(
         )?.check()?;
         reply_prop
     } else if req.target == utf8_string {
-        let data = text.lock().unwrap().clone();
+        let data = text.lock().expect("clipboard text mutex").clone();
         conn.change_property8(
             PropMode::REPLACE,
             req.requestor,

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -28,7 +28,7 @@ type LogSink = Arc<Mutex<Vec<(Stream, String)>>>;
 /// target app's top-level window, and drives it via X requests + XTEST.
 pub struct X11Platform {
     conn: RustConnection,
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "captured from the X setup for completeness; not currently read")]
     screen_num: usize,
     root: Window,
     display: String,
@@ -36,7 +36,6 @@ pub struct X11Platform {
     window: Option<Window>,
     logs: LogSink,
     // A private Xvfb we spawned (default path); kept alive so Drop tears it down.
-    #[allow(dead_code)]
     xvfb: Option<crate::xvfb::Xvfb>,
     // Background thread that owns the CLIPBOARD selection and serves pastes.
     clipboard_owner: Option<crate::clipboard::ClipboardOwner>,
@@ -496,7 +495,7 @@ fn spawn_reader<R: std::io::Read + Send + 'static>(reader: R, stream: Stream, si
         let buf = BufReader::new(reader);
         for line in buf.lines() {
             match line {
-                Ok(text) => sink.lock().unwrap().push((stream, text)),
+                Ok(text) => sink.lock().expect("log sink mutex").push((stream, text)),
                 Err(_) => break,
             }
         }
@@ -711,7 +710,7 @@ impl Platform for X11Platform {
     }
 
     fn drain_logs(&mut self) -> Vec<(Stream, String)> {
-        std::mem::take(&mut *self.logs.lock().unwrap())
+        std::mem::take(&mut *self.logs.lock().expect("log buffer mutex"))
     }
 
     fn app_pid(&self) -> Option<u32> {

--- a/crates/glass-x11/src/xvfb.rs
+++ b/crates/glass-x11/src/xvfb.rs
@@ -20,7 +20,7 @@ pub struct Xvfb {
     /// The chosen display, formatted `:N`.
     pub display: String,
     // Held open for the server's lifetime so Xvfb never gets SIGPIPE on the fd.
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "RAII: held open for the server's lifetime so the fd never SIGPIPEs")]
     displayfd: ChildStdout,
 }
 


### PR DESCRIPTION
Three Rust best-practices improvements (Apollo handbook ch.2 linting, ch.4 error handling). **No behavior change** — all `.unwrap()`→`.expect()` swaps and attribute changes are semantics-preserving.

## 1 — In-tree lint gate
- Added `[workspace.lints]` to the root manifest: `clippy::all = deny` (at `priority = -1` so specific lints can override), `future_incompatible = warn`, `nonstandard_style = deny`.
- Opted all 11 crates in with `[lints] workspace = true`.
- `cargo clippy --workspace` now enforces the gate without `-- -D warnings`; CI keeps that flag to also catch rustc warnings.

## 2 — `#[allow]` → `#[expect(…, reason = "…")]` (all 8 sites)
`excessive_precision` (YIQ coefficients), `too_many_arguments` (hot pixel classifier), `type_complexity` (session tuple), and 2 RAII `dead_code` fields — each now documents *why*.

`#[expect]` immediately caught a **stale** `#[allow(dead_code)]` on `X11Platform::xvfb` (the field is actually used), so that attribute was removed outright.

## 3 — Mutex locks standardized on `.expect()`
Converted the 18 **production** `.lock().unwrap()` sites to `.lock().expect("<lock>")` with lock-identifying messages (`clipboard text` / `clipboard ready` / `log sink` / `log buffer` / `session slot`). Test-module locks keep `.unwrap()` — the handbook blesses unwrap in tests.

## Verification
Local (Linux): `cargo build` ✅ · `cargo clippy --workspace --all-targets -- -D warnings` ✅ · `cargo test --workspace` ✅ (142 glass-core, 129 glass-mcp, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)