### PR TITLE
Wayland accessibility: opt-in a11y under headless sway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,6 +921,7 @@ dependencies = [
  "atspi",
  "atspi-common",
  "glass-core",
+ "glass-wayland",
  "glass-x11",
  "tempfile",
  "tokio",
@@ -1035,6 +1036,7 @@ name = "glass-wayland"
 version = "0.0.0"
 dependencies = [
  "glass-core",
+ "glass-dbus-linux",
  "glass-proc-linux",
  "glass-sandbox-linux",
  "rustix",

--- a/crates/glass-a11y-linux/Cargo.toml
+++ b/crates/glass-a11y-linux/Cargo.toml
@@ -15,6 +15,7 @@ tokio.workspace = true
 
 [dev-dependencies]
 glass-x11 = { path = "../glass-x11" }
+glass-wayland = { path = "../glass-wayland" }
 tempfile.workspace = true
 
 [lints]

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -220,3 +220,62 @@ fn a11y_works_under_default_sandbox() {
 fn a11y_works_under_strict_sandbox() {
     sandboxed_a11y_finds_widgets(glass_core::SandboxLevel::Strict);
 }
+
+// ---- Wayland a11y (#1 Phase 3 / #6): same reader, app launched under headless sway ----
+
+fn glass_wayland_with_a11y() -> Glass {
+    let factory: PlatformFactory = Box::new(|_backend| {
+        Ok(Backend {
+            platform: Box::new(glass_wayland::WaylandPlatform::new()?),
+            accessibility: Some(Box::new(glass_a11y_linux::LinuxA11y::new())),
+        })
+    });
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().join("baselines");
+    std::mem::forget(dir);
+    Glass::new(factory, "wayland".into(), BaselineStore::new(root), 100)
+}
+
+fn wayland_a11y_finds_widgets(level: glass_core::SandboxLevel) {
+    // GTK4's GL renderer fails under headless sway → cairo (software) renderer. Run the script
+    // relative to cwd=fixtures so it's reachable inside the sandbox (its $HOME is tmpfs'd).
+    let fixtures = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+    let mut glass = glass_wayland_with_a11y();
+    glass
+        .start(&AppSpec {
+            build: None,
+            run: vec!["python3".into(), "a11y_fixture.py".into()],
+            cwd: Some(fixtures.into()),
+            env: vec![
+                ("GSK_RENDERER".into(), "cairo".into()),
+                ("GDK_BACKEND".into(), "wayland".into()),
+            ],
+            window_hint: Some(WindowHint { title: Some("Glass A11y Fixture".into()), class: None }),
+            timeout_ms: 35_000,
+            sandbox: level,
+            a11y: true,
+        })
+        .unwrap_or_else(|e| panic!("wayland a11y launch ({level:?}): {e}"));
+    std::thread::sleep(std::time::Duration::from_millis(3_000));
+    let outline = glass.a11y_snapshot().expect("a11y snapshot (wayland)").to_outline();
+    assert!(outline.contains("Button \"Save\""), "no Save button (wayland {level:?}):\n{outline}");
+    glass.stop().expect("stop");
+}
+
+#[test]
+#[ignore = "needs sway + dbus + at-spi + GTK4 fixture; run via scripts/test-a11y.sh"]
+fn wayland_a11y_off() {
+    wayland_a11y_finds_widgets(glass_core::SandboxLevel::Off);
+}
+
+#[test]
+#[ignore = "needs sway + dbus + at-spi + GTK4 fixture + bwrap; run via scripts/test-a11y.sh"]
+fn wayland_a11y_default_sandbox() {
+    wayland_a11y_finds_widgets(glass_core::SandboxLevel::Default);
+}
+
+#[test]
+#[ignore = "needs sway + dbus + at-spi + GTK4 fixture + bwrap; run via scripts/test-a11y.sh"]
+fn wayland_a11y_strict_sandbox() {
+    wayland_a11y_finds_widgets(glass_core::SandboxLevel::Strict);
+}

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -43,7 +43,7 @@ pub use logbuf::{LogBuffer, LogLine, Stream};
 
 pub mod platform;
 pub use platform::{
-    AppSpec, KeyEvent, MouseButton, Platform, PointerEvent, SandboxLevel, WindowGeometry,
+    A11yBind, AppSpec, KeyEvent, MouseButton, Platform, PointerEvent, SandboxLevel, WindowGeometry,
     WindowHint, WindowId, WindowInfo, WindowOp,
 };
 

--- a/crates/glass-core/src/platform.rs
+++ b/crates/glass-core/src/platform.rs
@@ -95,6 +95,16 @@ pub struct WindowHint {
     pub class: Option<String>,
 }
 
+/// The private a11y bus details a sandboxed/launched app needs, kept together so a caller can't
+/// pass the bus address without also binding its socket dir into the sandbox. `addr` is the private
+/// **session** bus address (for `DBUS_SESSION_BUS_ADDRESS`); `dir` is the per-launch runtime dir
+/// holding the session + at-spi sockets (bound into the sandbox).
+#[derive(Clone, Copy, Debug)]
+pub struct A11yBind<'a> {
+    pub addr: &'a str,
+    pub dir: &'a std::path::Path,
+}
+
 /// Everything a backend needs to build, launch, and locate an app's window.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AppSpec {

--- a/crates/glass-wayland/Cargo.toml
+++ b/crates/glass-wayland/Cargo.toml
@@ -8,6 +8,7 @@ publish.workspace = true
 
 [dependencies]
 glass-core.workspace = true
+glass-dbus-linux = { path = "../glass-dbus-linux" }
 glass-sandbox-linux.workspace = true
 glass-proc-linux.workspace = true
 wayland-client.workspace = true

--- a/crates/glass-wayland/src/command.rs
+++ b/crates/glass-wayland/src/command.rs
@@ -25,7 +25,7 @@ pub const OUTPUT_HEIGHT: u32 = 720;
 /// invocation so the launched process runs in a sandboxed user namespace. The
 /// Wayland socket dir (`runtime_dir`) is re-exposed read-write inside the
 /// namespace so the app can still connect to sway.
-pub fn sway_config(spec: &AppSpec, runtime_dir: &Path) -> String {
+pub fn sway_config(spec: &AppSpec, runtime_dir: &Path, a11y_bind_dir: Option<&Path>) -> String {
     let argv: Vec<String> = match spec.sandbox {
         SandboxLevel::Off => spec.run.to_vec(),
         level => {
@@ -34,11 +34,15 @@ pub fn sway_config(spec: &AppSpec, runtime_dir: &Path) -> String {
             // Re-expose the program binary when it is absolute (it may live under
             // $HOME, which the ephemeral tmpfs shadows). PATH-resolved bare names
             // are covered by `--ro-bind / /` and need no extra bind.
+            let mut ro_binds = glass_sandbox_linux::program_ro_binds(&prog);
+            if let Some(dir) = a11y_bind_dir {
+                ro_binds.push(dir.to_path_buf());
+            }
             let opts = WrapOpts {
                 level,
                 home: ephemeral_home(),
                 cwd: spec.cwd.clone(),
-                ro_binds: glass_sandbox_linux::program_ro_binds(&prog),
+                ro_binds,
                 rw_binds: vec![runtime_dir.to_path_buf()],
             };
             let wrapped = wrap_argv(&prog, &args, &opts);
@@ -69,7 +73,13 @@ fn shell_quote(s: &str) -> String {
 /// `XDG_RUNTIME_DIR`. `--unsupported-gpu` is required because sway refuses to
 /// start on proprietary-Nvidia hosts; it is harmless under the headless backend.
 /// `spec.env` is applied last so a caller can still override anything.
-pub fn build_sway_command(sway: &Path, config: &Path, spec: &AppSpec, runtime_dir: &Path) -> Command {
+pub fn build_sway_command(
+    sway: &Path,
+    config: &Path,
+    spec: &AppSpec,
+    runtime_dir: &Path,
+    dbus_addr: Option<&str>,
+) -> Command {
     let mut cmd = Command::new(sway);
     // Run sway as its own process-group leader so the whole compositor subtree
     // it spawns (Xwayland + the exec'd app) can be torn down as a group on stop;
@@ -86,6 +96,11 @@ pub fn build_sway_command(sway: &Path, config: &Path, spec: &AppSpec, runtime_di
     cmd.env_remove("WAYLAND_DISPLAY");
     cmd.env_remove("DISPLAY");
     cmd.env_remove("WAYLAND_SOCKET");
+    if let Some(addr) = dbus_addr {
+        // sway passes its env to the exec'd app (like XDG_RUNTIME_DIR); under a sandbox the
+        // exec's bwrap inherits it too (no --clearenv). spec.env below still overrides.
+        cmd.env("DBUS_SESSION_BUS_ADDRESS", addr);
+    }
     for (k, v) in &spec.env {
         cmd.env(k, v);
     }
@@ -128,7 +143,7 @@ mod tests {
     #[test]
     fn sway_config_has_output_border_and_quoted_exec() {
         // sandbox: Off — exec must be the bare app argv, not wrapped in bwrap.
-        let cfg = sway_config(&spec(&["glass-testapp", "--windows", "2"]), std::path::Path::new("/run/glass-rt"));
+        let cfg = sway_config(&spec(&["glass-testapp", "--windows", "2"]), std::path::Path::new("/run/glass-rt"), None);
         assert!(cfg.contains("output HEADLESS-1 resolution 1280x720"), "{cfg}");
         assert!(cfg.contains("default_border none"), "{cfg}");
         assert!(cfg.contains("floating enable"), "{cfg}");
@@ -140,7 +155,7 @@ mod tests {
         use glass_core::SandboxLevel;
         let mut s = spec(&["glass-testapp", "--windows", "2"]);
         s.sandbox = SandboxLevel::Default;
-        let cfg = sway_config(&s, std::path::Path::new("/run/glass-rt"));
+        let cfg = sway_config(&s, std::path::Path::new("/run/glass-rt"), None);
         assert!(cfg.contains("exec 'bwrap'"), "{cfg}");
         assert!(cfg.contains("'--bind-try' '/run/glass-rt' '/run/glass-rt'"), "{cfg}");
         assert!(cfg.contains("'--' 'glass-testapp' '--windows' '2'"), "{cfg}");
@@ -148,7 +163,7 @@ mod tests {
 
     #[test]
     fn sway_config_exec_unwrapped_when_off() {
-        let cfg = sway_config(&spec(&["app"]), std::path::Path::new("/run/glass-rt"));
+        let cfg = sway_config(&spec(&["app"]), std::path::Path::new("/run/glass-rt"), None);
         assert!(cfg.contains("exec 'app'"), "{cfg}");
         assert!(!cfg.contains("bwrap"), "{cfg}");
     }
@@ -160,6 +175,7 @@ mod tests {
             Path::new("/run/x/sway.cfg"),
             &spec(&["app"]),
             Path::new("/run/x"),
+            None,
         );
         assert_eq!(cmd.get_program(), OsStr::new("/opt/glass/sway/bin/sway"));
         let args: Vec<_> = cmd.get_args().collect();
@@ -180,5 +196,35 @@ mod tests {
         for removed in ["WAYLAND_DISPLAY", "DISPLAY", "WAYLAND_SOCKET"] {
             assert_eq!(envs.get(OsStr::new(removed)), Some(&None), "{removed} must be removed");
         }
+    }
+
+    #[test]
+    fn build_sway_command_injects_dbus_addr() {
+        let s = spec(&["app"]);
+        let cmd = build_sway_command(
+            std::path::Path::new("/usr/bin/sway"),
+            std::path::Path::new("/tmp/cfg"),
+            &s,
+            std::path::Path::new("/run/glass-rt"),
+            Some("unix:path=/tmp/glass-a11y/session-bus"),
+        );
+        let dbus = cmd
+            .get_envs()
+            .find(|(k, _)| *k == std::ffi::OsStr::new("DBUS_SESSION_BUS_ADDRESS"))
+            .and_then(|(_, v)| v)
+            .map(|v| v.to_string_lossy().into_owned());
+        assert_eq!(dbus.as_deref(), Some("unix:path=/tmp/glass-a11y/session-bus"));
+    }
+
+    #[test]
+    fn sway_config_binds_a11y_dir_when_sandboxed() {
+        let mut s = spec(&["app"]);
+        s.sandbox = glass_core::SandboxLevel::Default;
+        let cfg = sway_config(
+            &s,
+            std::path::Path::new("/run/glass-rt"),
+            Some(std::path::Path::new("/tmp/glass-a11y-xyz")),
+        );
+        assert!(cfg.contains("/tmp/glass-a11y-xyz"), "a11y dir not bound into the exec bwrap:\n{cfg}");
     }
 }

--- a/crates/glass-wayland/src/doctor.rs
+++ b/crates/glass-wayland/src/doctor.rs
@@ -119,8 +119,8 @@ fn probe_sway(sway: &Path) -> Result<(), String> {
         sandbox: glass_core::SandboxLevel::Off,
         a11y: false,
     };
-    std::fs::write(&config, sway_config(&spec, rt.path())).map_err(|e| e.to_string())?;
-    let mut child = build_sway_command(sway, &config, &spec, rt.path())
+    std::fs::write(&config, sway_config(&spec, rt.path(), None)).map_err(|e| e.to_string())?;
+    let mut child = build_sway_command(sway, &config, &spec, rt.path(), None)
         .spawn()
         .map_err(|e| format!("spawn sway: {e}"))?;
 

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -65,12 +65,19 @@ pub struct WaylandPlatform {
     logs: LogSink,
     active: Option<ActiveSession>,
     clipboard_owner: Option<crate::clipboard::ClipboardOwner>,
+    dbus: Option<glass_dbus_linux::PrivateBus>,
 }
 
 impl WaylandPlatform {
     pub fn new() -> Result<Self> {
         let sway = resolve_sway()?;
-        Ok(Self { sway, logs: Arc::new(Mutex::new(Vec::new())), active: None, clipboard_owner: None })
+        Ok(Self {
+            sway,
+            logs: Arc::new(Mutex::new(Vec::new())),
+            active: None,
+            clipboard_owner: None,
+            dbus: None,
+        })
     }
 
     fn kill_session(&mut self) {
@@ -81,6 +88,7 @@ impl WaylandPlatform {
         if let Some(mut s) = self.active.take() {
             glass_proc_linux::reap_group(&mut s.child, glass_proc_linux::REAP_GRACE);
         }
+        self.dbus = None;
     }
 }
 
@@ -448,14 +456,15 @@ fn bring_up_session(
     sway: &Path,
     logs: &LogSink,
     spec: &AppSpec,
+    a11y: Option<glass_core::A11yBind>,
 ) -> Result<(ActiveSession, WindowGeometry)> {
     let runtime_dir =
         tempfile::Builder::new().prefix("glass-wl.").tempdir().map_err(GlassError::Io)?;
 
     let config = runtime_dir.path().join("sway.cfg");
-    std::fs::write(&config, sway_config(spec, runtime_dir.path())).map_err(GlassError::Io)?;
-
-    let mut cmd = build_sway_command(sway, &config, spec, runtime_dir.path());
+    std::fs::write(&config, sway_config(spec, runtime_dir.path(), a11y.map(|a| a.dir)))
+        .map_err(GlassError::Io)?;
+    let mut cmd = build_sway_command(sway, &config, spec, runtime_dir.path(), a11y.map(|a| a.addr));
     cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
     let mut child = cmd.spawn().map_err(|e| GlassError::AppNotStarted(format!("spawn sway: {e}")))?;
     if let Some(out) = child.stdout.take() {
@@ -611,10 +620,24 @@ impl Platform for WaylandPlatform {
         // genuine app exit or a config/sandbox error fails immediately. `bring_up`
         // reaps its own sway+Xwayland process group on failure, so a retry never
         // races a leftover compositor.
+        self.dbus = if spec.a11y {
+            Some(glass_dbus_linux::PrivateBus::start().map_err(|e| {
+                GlassError::AccessibilityUnavailable(format!(
+                    "a11y:true was requested but the private a11y bus could not start: {e}"
+                ))
+            })?)
+        } else {
+            None
+        };
+
         const ATTEMPTS: u32 = 2;
         let mut last_err = GlassError::Timeout(spec.timeout_ms);
         for attempt in 0..ATTEMPTS {
-            match bring_up_session(&self.sway, &self.logs, spec) {
+            let a11y = self.dbus.as_ref().map(|b| glass_core::A11yBind {
+                addr: b.session_bus_address(),
+                dir: b.runtime_dir(),
+            });
+            match bring_up_session(&self.sway, &self.logs, spec, a11y) {
                 Ok((session, geometry)) => {
                     self.active = Some(session);
                     return Ok(geometry);
@@ -624,9 +647,13 @@ impl Platform for WaylandPlatform {
                 {
                     last_err = e;
                 }
-                Err(e) => return Err(e),
+                Err(e) => {
+                    self.dbus = None; // reap the private bus on a hard failure
+                    return Err(e);
+                }
             }
         }
+        self.dbus = None; // reap the private bus after exhausted retries
         Err(last_err)
     }
 
@@ -993,6 +1020,10 @@ impl Platform for WaylandPlatform {
             Some(s) => glass_proc_linux::proc_tree_pids(s.child.id()),
             None => Vec::new(),
         }
+    }
+
+    fn a11y_bus_addr(&self) -> Option<String> {
+        self.dbus.as_ref().map(|b| b.a11y_bus_address().to_string())
     }
 }
 

--- a/crates/glass-x11/src/command.rs
+++ b/crates/glass-x11/src/command.rs
@@ -6,22 +6,23 @@ use glass_core::{AppSpec, SandboxLevel};
 use glass_sandbox_linux::{ephemeral_home, wrap_argv, WrapOpts};
 
 /// Build the launch command for `spec.run`, forcing `DISPLAY=<display>` (and, when
-/// `dbus_addr` is given, `DBUS_SESSION_BUS_ADDRESS=<addr>` so the child talks to the
+/// `a11y.addr` is given, `DBUS_SESSION_BUS_ADDRESS=<addr>` so the child talks to the
 /// private a11y bus) so the child renders on the backend's X server. Entries in
 /// `spec.env` are applied after, so the caller can still override either deliberately.
 ///
 /// When `spec.sandbox` is not `Off`, the command is wrapped in a `bwrap`
 /// invocation so the launched process runs in a sandboxed user namespace.
 /// The X11 socket dir (`/tmp/.X11-unix`) is re-exposed read-only inside the
-/// namespace so the app can still connect to the display. When `a11y_bind_dir`
+/// namespace so the app can still connect to the display. When `a11y.dir`
 /// is given, that directory (which holds the private session-bus and at-spi
 /// sockets) is also re-exposed so a sandboxed app can reach the a11y bus.
 pub fn build_command(
     spec: &AppSpec,
     display: &str,
-    dbus_addr: Option<&str>,
-    a11y_bind_dir: Option<&std::path::Path>,
+    a11y: Option<glass_core::A11yBind>,
 ) -> Command {
+    let dbus_addr = a11y.map(|a| a.addr);
+    let a11y_bind_dir = a11y.map(|a| a.dir);
     let mut cmd = match spec.sandbox {
         SandboxLevel::Off => {
             let mut c = Command::new(&spec.run[0]);
@@ -97,7 +98,7 @@ mod tests {
 
     #[test]
     fn sets_program_args_and_display() {
-        let cmd = build_command(&spec(&["/bin/app", "--flag", "x"]), ":99", None, None);
+        let cmd = build_command(&spec(&["/bin/app", "--flag", "x"]), ":99", None);
         assert_eq!(cmd.get_program(), OsStr::new("/bin/app"));
         let args: Vec<_> = cmd.get_args().collect();
         assert_eq!(args, vec![OsStr::new("--flag"), OsStr::new("x")]);
@@ -113,7 +114,7 @@ mod tests {
         let mut s = spec(&["app"]);
         s.env = vec![("DISPLAY".into(), ":7".into())];
         s.cwd = Some(PathBuf::from("/tmp"));
-        let cmd = build_command(&s, ":99", None, None);
+        let cmd = build_command(&s, ":99", None);
         // last DISPLAY env wins (spec.env applied after the forced default)
         let display = cmd
             .get_envs()
@@ -126,7 +127,7 @@ mod tests {
 
     #[test]
     fn dbus_addr_sets_session_bus_env() {
-        let cmd = build_command(&spec(&["app"]), ":99", Some("unix:path=/tmp/bus"), None);
+        let cmd = build_command(&spec(&["app"]), ":99", Some(glass_core::A11yBind { addr: "unix:path=/tmp/bus", dir: std::path::Path::new("/tmp/bus-dir") }));
         let addr = cmd
             .get_envs()
             .find(|(k, _)| *k == OsStr::new("DBUS_SESSION_BUS_ADDRESS"))
@@ -138,7 +139,7 @@ mod tests {
     fn spec_env_overrides_injected_dbus_addr() {
         let mut s = spec(&["app"]);
         s.env = vec![("DBUS_SESSION_BUS_ADDRESS".into(), "unix:path=/tmp/override".into())];
-        let cmd = build_command(&s, ":99", Some("unix:path=/tmp/bus"), None);
+        let cmd = build_command(&s, ":99", Some(glass_core::A11yBind { addr: "unix:path=/tmp/bus", dir: std::path::Path::new("/tmp/bus-dir") }));
         // Command stores env as a map: a later .env() for the same key replaces the earlier
         // one, so a spec.env entry overrides the injected default.
         let addr = cmd
@@ -151,7 +152,7 @@ mod tests {
 
     #[test]
     fn none_dbus_addr_leaves_session_bus_unset() {
-        let cmd = build_command(&spec(&["app"]), ":9", None, None);
+        let cmd = build_command(&spec(&["app"]), ":9", None);
         assert!(
             !cmd.get_envs().any(|(k, _)| k == OsStr::new("DBUS_SESSION_BUS_ADDRESS")),
             "DBUS_SESSION_BUS_ADDRESS must not be set when dbus_addr is None"
@@ -163,7 +164,7 @@ mod tests {
         use glass_core::SandboxLevel;
         let mut s = spec(&["/bin/app", "--flag"]);
         s.sandbox = SandboxLevel::Default;
-        let cmd = build_command(&s, ":99", None, None);
+        let cmd = build_command(&s, ":99", None);
         assert_eq!(cmd.get_program(), std::ffi::OsStr::new("bwrap"));
         let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy().into_owned()).collect();
         assert!(args.contains(&"--unshare-user".to_string()));
@@ -179,7 +180,7 @@ mod tests {
         let mut s = spec(&["app"]);
         s.sandbox = glass_core::SandboxLevel::Default;
         let dir = std::path::Path::new("/tmp/glass-a11y-xyz");
-        let cmd = build_command(&s, ":9", Some("unix:path=/tmp/glass-a11y-xyz/session-bus"), Some(dir));
+        let cmd = build_command(&s, ":9", Some(glass_core::A11yBind { addr: "unix:path=/tmp/glass-a11y-xyz/session-bus", dir }));
         let joined: String = std::iter::once(cmd.get_program())
             .chain(cmd.get_args())
             .map(|a| a.to_string_lossy().into_owned())

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -250,9 +250,11 @@ impl X11Platform {
         // injects the private session-bus address into the launched app's env.
         // For sandboxed launches, also bind the private bus dir into bwrap so the
         // sandboxed app can reach the advertised unix:path= sockets.
-        let dbus_addr = self.dbus.as_ref().map(|b| b.session_bus_address());
-        let a11y_dir = self.dbus.as_ref().map(|b| b.runtime_dir().to_path_buf());
-        let mut cmd = build_command(spec, &self.display, dbus_addr, a11y_dir.as_deref());
+        let a11y = self.dbus.as_ref().map(|b| glass_core::A11yBind {
+            addr: b.session_bus_address(),
+            dir: b.runtime_dir(),
+        });
+        let mut cmd = build_command(spec, &self.display, a11y);
         cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
         let mut child = cmd
             .spawn()

--- a/scripts/test-a11y.sh
+++ b/scripts/test-a11y.sh
@@ -28,6 +28,17 @@ if ! command -v dbus-daemon >/dev/null 2>&1 \
 fi
 
 TEST_FILTER="${1:-}"
+
+# Hermetic isolation: run the whole suite under a throwaway XDG_RUNTIME_DIR. AT-SPI derives its
+# socket dir from XDG_RUNTIME_DIR, so any at-spi-bus-launcher these tests spawn — through glass's
+# PrivateBus (which already overrides it) OR any other path — writes to this throwaway, NEVER the
+# operator's real /run/user/UID/at-spi. Unconditional belt-and-suspenders: the desktop's own
+# accessibility bus (md-viewer, etc.) cannot be wedged by a test run, regardless of code paths.
+A11Y_TEST_RUNTIME="$(mktemp -d "${TMPDIR:-/tmp}/glass-a11y-test-rt.XXXXXX")"
+chmod 700 "$A11Y_TEST_RUNTIME"
+trap 'rm -rf "$A11Y_TEST_RUNTIME"' EXIT
+export XDG_RUNTIME_DIR="$A11Y_TEST_RUNTIME"
+
 # --test-threads=1: tests share glass's AT-SPI bus per process; parallel launches
 # cause bus instability (fixtures disconnecting race with new connections).
-exec cargo test -p glass-a11y-linux --test integration -- --ignored --test-threads=1 "$TEST_FILTER"
+cargo test -p glass-a11y-linux --test integration -- --ignored --test-threads=1 "$TEST_FILTER"


### PR DESCRIPTION
## Summary

Brings opt-in accessibility (`a11y: true`) to the **Wayland (sway)** backend at sandbox levels `off`/`default`/`strict`, mirroring the X11 a11y wiring. Also hardens the a11y test harness so a test run can never disturb the operator's own desktop accessibility bus.

## Changes
- **Wayland a11y:** `WaylandPlatform` spawns glass's private, isolated a11y bus (fail-fast if `a11y:true` but the bus can't start — no silent degrade), injects `DBUS_SESSION_BUS_ADDRESS` into the sway command so the launched app uses it, exposes `a11y_bus_addr()`, and binds the private socket dir into the sandboxed `exec`'s bwrap. The AT-SPI reader and PID correlation are shared with X11 (no new mechanism). Closes the "Wayland returns an unrelated app" gap — the target is correlated by PID against sway's descendants.
- **`A11yBind`:** a small `glass-core` type coupling the a11y bus address with its bind dir so they can't be passed apart; X11's `build_command` adopts it.
- **Test harness:** `scripts/test-a11y.sh` runs the suite under a throwaway `XDG_RUNTIME_DIR`, so any `at-spi-bus-launcher` a test spawns writes there — never the real `/run/user/UID/at-spi`.

## Test plan
- `cargo test --workspace` + `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `./scripts/test-a11y.sh` — 10 pass, including Wayland a11y at `off`/`default`/`strict` (GTK4 fixture under headless sway, software `cairo` renderer). `./scripts/test-wayland.sh` (15) and `./scripts/test-x11.sh` (28): pass.
- Verified the host AT-SPI bus (`/run/user/UID/at-spi`) is left untouched across the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)