### PR TITLE
fix(a11y): don't nest a tokio runtime in a11y bring-up; run tools off the executor

### DIFF
--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -19,6 +19,42 @@ fn glass_x11_with_a11y() -> Glass {
     Glass::new(factory, "x11".into(), BaselineStore::new(root), 100)
 }
 
+/// Regression: the real MCP runs the (blocking) `glass_start` from *inside* its
+/// multi-thread tokio runtime. `PrivateBus::start` must bring up the a11y bus without
+/// nesting a runtime — nesting panics ("Cannot start a runtime from within a runtime"),
+/// which leaves the MCP request unanswered (the app appears to hang forever) and leaks the
+/// bus children. Launch the fixture from inside a multi-thread runtime and require success.
+/// Host-safe under test-a11y.sh's throwaway XDG_RUNTIME_DIR.
+#[test]
+#[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
+fn a11y_launch_succeeds_from_within_a_tokio_runtime() {
+    let fixture = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/a11y_fixture.py");
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let mut glass = glass_x11_with_a11y();
+        glass
+            .start(&AppSpec {
+                build: None,
+                run: vec!["python3".into(), fixture.into()],
+                cwd: None,
+                env: vec![
+                    ("LIBGL_ALWAYS_SOFTWARE".into(), "1".into()),
+                    ("GDK_BACKEND".into(), "x11".into()),
+                ],
+                window_hint: Some(WindowHint { title: Some("Glass A11y Fixture".into()), class: None }),
+                timeout_ms: 35_000,
+                sandbox: glass_core::SandboxLevel::Off,
+                a11y: true,
+            })
+            .expect("a11y launch from within a tokio runtime must not panic/hang");
+        glass.stop().expect("stop");
+    });
+}
+
 #[test]
 #[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
 fn snapshot_finds_gtk_widgets() {

--- a/crates/glass-dbus-linux/src/lib.rs
+++ b/crates/glass-dbus-linux/src/lib.rs
@@ -193,44 +193,56 @@ trait A11yBus {
 }
 
 fn resolve_a11y_address(session_addr: &str) -> Result<String> {
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|e| GlassError::Backend(format!("runtime: {e}")))?;
-    rt.block_on(async {
-        let resolve = async {
-            let addr: zbus::Address = session_addr
-                .try_into()
-                .map_err(|e| GlassError::Backend(format!("bad session address: {e}")))?;
-            let conn = zbus::connection::Builder::address(addr)
-                .map_err(|e| GlassError::Backend(format!("session conn builder: {e}")))?
-                .build()
-                .await
-                .map_err(|e| GlassError::Backend(format!("connect session bus: {e}")))?;
-            let proxy = A11yBusProxy::new(&conn)
-                .await
-                .map_err(|e| GlassError::Backend(format!("org.a11y.Bus proxy: {e}")))?;
-            let mut last = String::new();
-            let mut last_err: Option<String> = None;
-            for _ in 0..50 {
-                match proxy.get_address().await {
-                    Ok(a) if !a.is_empty() => return Ok(a),
-                    Ok(a) => last = a,
-                    Err(e) => last_err = Some(e.to_string()),
+    // Run on a dedicated OS thread. `PrivateBus::start` is synchronous but is reached (via
+    // `start_app`) from inside the MCP's multi-thread runtime. Building a runtime there
+    // panics ("Cannot start a runtime from within a runtime"), and a `current_thread`
+    // runtime nested in another runtime has a timer that never advances — so the bounds
+    // below would never fire. A fresh thread has no ambient runtime, so `block_on` and its
+    // timer work in every caller context (sync test, async worker, or spawn_blocking task).
+    let session_addr = session_addr.to_string();
+    std::thread::spawn(move || -> Result<String> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| GlassError::Backend(format!("runtime: {e}")))?;
+        rt.block_on(async move {
+            let resolve = async {
+                let addr: zbus::Address = session_addr
+                    .as_str()
+                    .try_into()
+                    .map_err(|e| GlassError::Backend(format!("bad session address: {e}")))?;
+                let conn = zbus::connection::Builder::address(addr)
+                    .map_err(|e| GlassError::Backend(format!("session conn builder: {e}")))?
+                    .build()
+                    .await
+                    .map_err(|e| GlassError::Backend(format!("connect session bus: {e}")))?;
+                let proxy = A11yBusProxy::new(&conn)
+                    .await
+                    .map_err(|e| GlassError::Backend(format!("org.a11y.Bus proxy: {e}")))?;
+                let mut last = String::new();
+                let mut last_err: Option<String> = None;
+                for _ in 0..50 {
+                    match proxy.get_address().await {
+                        Ok(a) if !a.is_empty() => return Ok(a),
+                        Ok(a) => last = a,
+                        Err(e) => last_err = Some(e.to_string()),
+                    }
+                    tokio::time::sleep(Duration::from_millis(100)).await;
                 }
-                tokio::time::sleep(Duration::from_millis(100)).await;
+                Err(GlassError::Backend(format!(
+                    "org.a11y.Bus.GetAddress did not yield an address after 5s (last ok: {last:?}, last err: {last_err:?})"
+                )))
+            };
+            match tokio::time::timeout(A11Y_RESOLVE_TIMEOUT, resolve).await {
+                Ok(result) => result,
+                Err(_) => Err(GlassError::Backend(format!(
+                    "a11y bus bring-up did not complete within {A11Y_RESOLVE_TIMEOUT:?} (at-spi-bus-launcher unresponsive)"
+                ))),
             }
-            Err(GlassError::Backend(format!(
-                "org.a11y.Bus.GetAddress did not yield an address after 5s (last ok: {last:?}, last err: {last_err:?})"
-            )))
-        };
-        match tokio::time::timeout(A11Y_RESOLVE_TIMEOUT, resolve).await {
-            Ok(result) => result,
-            Err(_) => Err(GlassError::Backend(format!(
-                "a11y bus bring-up did not complete within {A11Y_RESOLVE_TIMEOUT:?} (at-spi-bus-launcher unresponsive)"
-            ))),
-        }
+        })
     })
+    .join()
+    .map_err(|_| GlassError::Backend("a11y resolver thread panicked".into()))?
 }
 
 #[cfg(test)]

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -60,10 +60,22 @@ impl GlassServer {
 
     async fn run<F>(&self, f: F) -> Result<CallToolResult, McpError>
     where
-        F: FnOnce(&mut Glass) -> ToolResult,
+        F: FnOnce(&mut Glass) -> ToolResult + Send + 'static,
     {
-        let mut g = self.glass.lock().await;
-        Ok(map_tool_result(f(&mut g)))
+        // Run the synchronous tool body on a blocking thread, not on the async executor:
+        // build/launch/window-wait can block for a while and must not stall a runtime
+        // worker, and a tool's own use of `block_on` (e.g. the a11y bus bring-up) must not
+        // nest inside this runtime. A panic in the body becomes a loud error rather than an
+        // unanswered request that hangs the caller forever.
+        let glass = self.glass.clone();
+        let outcome = tokio::task::spawn_blocking(move || {
+            // `blocking_lock` is correct here (it would panic on an async worker); this is a
+            // blocking thread. Holding it serializes tools — glass has one active session.
+            let mut g = glass.blocking_lock();
+            f(&mut g)
+        })
+        .await;
+        Ok(map_tool_result(outcome.unwrap_or_else(|e| Err(format!("tool handler panicked: {e}")))))
     }
 
     #[tool(


### PR DESCRIPTION
## Summary

A `glass_start(a11y:true)` issued through the MCP server hung forever with no error.

**Root cause:** the MCP runs the synchronous tool body (`start_app`) *inside* its multi-thread tokio runtime. `PrivateBus::start` resolved the a11y bus address via a nested `current_thread` runtime + `block_on`, which from within a runtime panics (`Cannot start a runtime from within a runtime`). The panic left the MCP request **unanswered** (the client waits forever) and leaked the bus's `dbus-daemon` + `at-spi-bus-launcher`. a11y via the real MCP never actually worked — the a11y integration tests call `start()` *outside* any runtime, so they never hit this.

- **glass-dbus-linux:** resolve the a11y address on a dedicated OS thread, so `block_on` and its timer work in every caller context. (A nested runtime's timer never advances, so the existing 10s bring-up ceiling could never fire — now it does.)
- **glass-mcp:** run the synchronous tool body via `spawn_blocking` instead of inline on the async executor (matching `doctor`/`shutdown`), and turn a handler panic into a loud error instead of an unanswered request. Blocking build/launch/window-wait no longer stall a runtime worker.
- **Regression test:** launch the GTK fixture with a11y from inside a multi-thread runtime; must succeed (it panicked before). Host-safe under a throwaway `XDG_RUNTIME_DIR`.

Found by dogfooding.

## Test Plan
- [x] New `a11y_launch_succeeds_from_within_a_tokio_runtime` — panicked before, passes now
- [x] `./scripts/test-a11y.sh` — 11/11 a11y integration tests pass (X11 + sandboxed + Wayland), 37s
- [x] `cargo build -p glass-mcp` — every tool-handler closure satisfies the new `Send + 'static` bound
- [x] `cargo test --workspace` + `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] host `org.a11y.Bus` reachable throughout — isolation intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)