### PR TITLE
fix(dogfood round-2): wait_for_log pre-buffer hint (G1) + pin a11y XDG_RUNTIME_DIR on X11 (G2)

### DIFF
--- a/crates/glass-core/src/session.rs
+++ b/crates/glass-core/src/session.rs
@@ -108,6 +108,10 @@ pub struct WaitLogOutcome {
     /// Cursor to resume from: just past the matched line, or the buffer end on timeout.
     pub cursor: u64,
     pub elapsed_ms: u64,
+    /// Set on a timeout when the substring was already in the buffer *before* this call's
+    /// start cursor (the default-cursor footgun: a fast-boot line is otherwise skipped).
+    /// Points the caller at `cursor:0` instead of failing silently.
+    pub note: Option<String>,
 }
 
 struct ActiveSession {
@@ -518,8 +522,31 @@ impl Glass {
                 line: Some(line),
                 matched: true,
                 elapsed_ms: outcome.elapsed_ms,
+                note: None,
             },
-            None => WaitLogOutcome { matched: false, line: None, cursor: end, elapsed_ms: outcome.elapsed_ms },
+            None => {
+                // The default cursor is the buffer end at call start, so a line emitted
+                // *before* this call (e.g. a fast-boot "ready") is skipped and we time out.
+                // If the substring is already in the buffer before our start cursor, say so
+                // rather than failing silently — point the caller at cursor:0.
+                let note = if params.cursor.is_none() {
+                    let (earlier, _) = s.logs.read(0, 1, stream, Some(&contains));
+                    earlier
+                        .into_iter()
+                        .next()
+                        .filter(|l| l.seq < start_cursor)
+                        .map(|l| {
+                            format!(
+                                "{contains:?} was already in the log at seq {} (before this call); \
+                                 pass cursor:0 to match already-buffered lines",
+                                l.seq
+                            )
+                        })
+                } else {
+                    None
+                };
+                WaitLogOutcome { matched: false, line: None, cursor: end, elapsed_ms: outcome.elapsed_ms, note }
+            }
         })
     }
 
@@ -1471,6 +1498,11 @@ mod tests {
             .unwrap();
         assert!(!o.matched);
         assert!(o.line.is_none());
+        // Footgun guard: the line WAS in the buffer (seq 0) before the default start
+        // cursor, so the timeout must say so and point at cursor:0 — not fail silently.
+        let note = o.note.expect("timeout note when the substring was already buffered");
+        assert!(note.contains("cursor:0"), "note should point at cursor:0, got: {note}");
+        assert!(note.contains("seq 0"), "note should cite the buffered seq, got: {note}");
     }
 
     #[test]

--- a/crates/glass-mcp/src/tools/wait.rs
+++ b/crates/glass-mcp/src/tools/wait.rs
@@ -123,9 +123,11 @@ pub fn wait_for_log(glass: &mut Glass, a: &WaitForLogArgs) -> ToolResult {
             "text": l.text,
         })
     });
-    let body = json!({ "matched": o.matched, "line": line, "cursor": o.cursor, "elapsed_ms": o.elapsed_ms })
-        .to_string();
-    Ok(ToolOutput::text(crate::untrusted::wrap_untrusted(&body)))
+    let mut body = json!({ "matched": o.matched, "line": line, "cursor": o.cursor, "elapsed_ms": o.elapsed_ms });
+    if let Some(note) = &o.note {
+        body["note"] = json!(note);
+    }
+    Ok(ToolOutput::text(crate::untrusted::wrap_untrusted(&body.to_string())))
 }
 
 #[cfg(test)]

--- a/crates/glass-x11/src/command.rs
+++ b/crates/glass-x11/src/command.rs
@@ -5,9 +5,10 @@ use std::process::Command;
 use glass_core::{AppSpec, SandboxLevel};
 use glass_sandbox_linux::{ephemeral_home, wrap_argv, WrapOpts};
 
-/// Build the launch command for `spec.run`, forcing `DISPLAY=<display>` (and, when
-/// `a11y.addr` is given, `DBUS_SESSION_BUS_ADDRESS=<addr>` so the child talks to the
-/// private a11y bus) so the child renders on the backend's X server. Entries in
+/// Build the launch command for `spec.run`, forcing `DISPLAY=<display>` (and, when `a11y`
+/// is given, `DBUS_SESSION_BUS_ADDRESS=<addr>` + `XDG_RUNTIME_DIR=<dir>` so the child both
+/// talks to, and resolves its AT-SPI bus within, the private a11y dir — never the host's
+/// `/run/user/UID/at-spi/`) so the child renders on the backend's X server. Entries in
 /// `spec.env` are applied after, so the caller can still override either deliberately.
 ///
 /// When `spec.sandbox` is not `Off`, the command is wrapped in a `bwrap`
@@ -66,6 +67,15 @@ pub fn build_command(
     cmd.env("DISPLAY", display);
     if let Some(addr) = dbus_addr {
         cmd.env("DBUS_SESSION_BUS_ADDRESS", addr);
+    }
+    if let Some(dir) = a11y_bind_dir {
+        // Point the app's AT-SPI resolution at the private runtime dir (mirroring the
+        // Wayland path). Without this the app inherits the host XDG_RUNTIME_DIR, so
+        // accesskit/at-spi can fall back to the host's /run/user/UID/at-spi/bus_0 — which
+        // may be wedged/unlinked — and accesskit_unix panics on the missing socket. The
+        // private dir is re-exposed read-only into the sandbox above, so the same absolute
+        // path resolves inside bwrap too. Keeps a11y resolution isolated AND on a live bus.
+        cmd.env("XDG_RUNTIME_DIR", dir);
     }
     // Applied last so an explicit spec.env entry wins over the forced defaults.
     for (k, v) in &spec.env {
@@ -156,6 +166,34 @@ mod tests {
         assert!(
             !cmd.get_envs().any(|(k, _)| k == OsStr::new("DBUS_SESSION_BUS_ADDRESS")),
             "DBUS_SESSION_BUS_ADDRESS must not be set when dbus_addr is None"
+        );
+    }
+
+    #[test]
+    fn a11y_pins_private_xdg_runtime_dir() {
+        // The app must resolve AT-SPI within the private dir, not the host's /run/user/UID
+        // (whose at-spi bus may be wedged → accesskit_unix panic). Mirrors the Wayland path.
+        let cmd = build_command(
+            &spec(&["app"]),
+            ":9",
+            Some(glass_core::A11yBind {
+                addr: "unix:path=/tmp/glass-a11y-xyz/session-bus",
+                dir: std::path::Path::new("/tmp/glass-a11y-xyz"),
+            }),
+        );
+        let xrd = cmd
+            .get_envs()
+            .find(|(k, _)| *k == OsStr::new("XDG_RUNTIME_DIR"))
+            .and_then(|(_, v)| v);
+        assert_eq!(xrd, Some(OsStr::new("/tmp/glass-a11y-xyz")));
+    }
+
+    #[test]
+    fn no_a11y_leaves_xdg_runtime_dir_unset() {
+        let cmd = build_command(&spec(&["app"]), ":9", None);
+        assert!(
+            !cmd.get_envs().any(|(k, _)| k == OsStr::new("XDG_RUNTIME_DIR")),
+            "without a11y, XDG_RUNTIME_DIR must be left untouched"
         );
     }
 


### PR DESCRIPTION
Two findings from the round-2 clean-room dogfood (the loop itself passed; these are the glass-owned follow-ups).

## G1 — `glass_wait_for_log` silent pre-buffer footgun
The default cursor is the buffer *end* at call start, so the most natural pattern — `glass_start` → `wait_for_log "ready"` — silently times out when the line was already emitted (the agent hit this 3×). Fix keeps the deliberate future-only semantics but, on a timeout, detects that the substring was already in the buffer *before* the call and returns a `note` pointing at `cursor:0` — no more silent failure.

## G2 — intermittent `accesskit_unix` NotFound panic (X11)
With `a11y:true`, the app's `accesskit_unix` intermittently panicked (`context.rs:54`, "No such file or directory"), killing the a11y session after ~2 calls. Root cause: the X11 launch set `DBUS_SESSION_BUS_ADDRESS` but **not** `XDG_RUNTIME_DIR`, so the app inherited the *host* runtime dir and its AT-SPI resolution could fall back to the host `/run/user/UID/at-spi/bus_0` — which was wedged during the run — and `accesskit_unix` unwrap-panics on the missing socket. The **Wayland** path already pins `XDG_RUNTIME_DIR` (which is why a11y was stable there). X11 now mirrors it: pin `XDG_RUNTIME_DIR=<private dir>` when a11y is on, so AT-SPI resolution stays isolated **and** on a live bus. (The unwrap-panic is an upstream `accesskit_unix` robustness bug; this removes the trigger.)

## Test Plan
- [x] `wait_for_log` buffered-line timeout now carries a `cursor:0` hint (assertion added)
- [x] `build_command` pins `XDG_RUNTIME_DIR` to the private dir when a11y is on, leaves it unset otherwise (2 tests)
- [x] `./scripts/test-a11y.sh` — 11/11 a11y integration tests pass with the pinning
- [x] `cargo test --workspace` + `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] host `org.a11y.Bus` reachable throughout

Deferred (need a dedicated repro, no clear glass fix yet): G3 window-vanish-after-launch (intermittent; its trigger — a long silent `wait_for_log` — is reduced by G1) and G4 two mid-run subagent stalls (likely orchestration, not glass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)