### PR TITLE
fix: G3 sandboxed-app SIGKILL (dedicated dispatch thread) + wait_stable saw_motion

### DIFF
--- a/crates/glass-core/src/session.rs
+++ b/crates/glass-core/src/session.rs
@@ -32,6 +32,14 @@ pub struct WaitStableParams {
 pub struct WaitStableOutcome {
     pub frame: Frame,
     pub settled: bool,
+    /// Whether any frame-to-frame change was seen while watching. `settled:true` with
+    /// `saw_motion:false` over a short `observed_ms` is a *brief* quiet window — a slow
+    /// animation can still hide under it, so use `wait_for_region {until:"changes"}` to
+    /// positively assert motion. `settled:true` with `saw_motion:true` means it was moving
+    /// and then quieted.
+    pub saw_motion: bool,
+    /// How long (ms) frames were observed before settling or timing out.
+    pub observed_ms: u64,
 }
 
 /// Parameters for [`Glass::wait_for_element`].
@@ -412,7 +420,7 @@ impl Glass {
             Some(_) => self.active_mut()?.platform.capture_frame(None)?,
             None => tracker.last().cloned().expect("a frame was just observed"),
         };
-        Ok(WaitStableOutcome { frame, settled })
+        Ok(WaitStableOutcome { frame, settled, saw_motion: tracker.saw_change(), observed_ms: outcome.elapsed_ms })
     }
 
     /// Block until a precise accessibility-element condition holds, re-snapshotting

--- a/crates/glass-core/src/stability.rs
+++ b/crates/glass-core/src/stability.rs
@@ -4,25 +4,36 @@ use crate::frame::Frame;
 
 /// Decides when a stream of captured frames has "settled": `settle_frames`
 /// consecutive frames each unchanged (within `tolerance`) from the one before.
+///
+/// Settling means "the last N sampled frames were identical" — NOT "nothing will ever
+/// change." A slow or sub-sampling-rate animation can hold one phase across the sampled
+/// window and read as settled; [`saw_change`](Self::saw_change) records whether any change
+/// was observed during this watch so callers can tell a quiet-the-whole-time settle from
+/// one that simply caught a still moment.
 pub struct StabilityTracker {
     settle_frames: u32,
     tolerance: u8,
     last: Option<Frame>,
     stable_count: u32,
+    saw_change: bool,
 }
 
 impl StabilityTracker {
     pub fn new(settle_frames: u32, tolerance: u8) -> Self {
-        Self { settle_frames: settle_frames.max(1), tolerance, last: None, stable_count: 0 }
+        Self { settle_frames: settle_frames.max(1), tolerance, last: None, stable_count: 0, saw_change: false }
     }
 
     /// Feed the next frame. Returns `true` once the frame stream has settled.
     /// Errors only if frame sizes change mid-stream.
     pub fn observe(&mut self, frame: Frame) -> Result<bool> {
+        let had_prev = self.last.is_some();
         let unchanged = match &self.last {
             None => false,
             Some(prev) => diff(prev, &frame, self.tolerance)?.changed_pixels == 0,
         };
+        if had_prev && !unchanged {
+            self.saw_change = true;
+        }
         self.stable_count = if unchanged { self.stable_count + 1 } else { 0 };
         self.last = Some(frame);
         Ok(self.stable_count >= self.settle_frames)
@@ -31,6 +42,13 @@ impl StabilityTracker {
     /// The most recently observed frame.
     pub fn last(&self) -> Option<&Frame> {
         self.last.as_ref()
+    }
+
+    /// Whether any frame-to-frame change was observed during this watch. `false` after a
+    /// settle means the window was quiet throughout — but a watch shorter than an
+    /// animation's period can still miss it, so this is a hint, not a guarantee of idleness.
+    pub fn saw_change(&self) -> bool {
+        self.saw_change
     }
 }
 
@@ -67,5 +85,24 @@ mod tests {
         t.observe(a).unwrap();
         t.observe(b.clone()).unwrap();
         assert_eq!(t.last(), Some(&b));
+    }
+
+    #[test]
+    fn saw_change_distinguishes_quiet_from_animated_settles() {
+        let a = Frame::solid(2, 2, [0, 0, 0, 255]);
+        let b = Frame::solid(2, 2, [255, 255, 255, 255]);
+        // Quiet throughout: settles with saw_change == false.
+        let mut quiet = StabilityTracker::new(2, 0);
+        quiet.observe(a.clone()).unwrap();
+        quiet.observe(a.clone()).unwrap();
+        assert!(quiet.observe(a.clone()).unwrap());
+        assert!(!quiet.saw_change(), "no change seen -> saw_change is false");
+        // Moved, then quieted: still settles, but saw_change == true.
+        let mut moved = StabilityTracker::new(2, 0);
+        moved.observe(a.clone()).unwrap();
+        moved.observe(b.clone()).unwrap(); // a change
+        moved.observe(b.clone()).unwrap();
+        assert!(moved.observe(b.clone()).unwrap());
+        assert!(moved.saw_change(), "a change occurred -> saw_change is true");
     }
 }

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -13,9 +13,18 @@ use tokio::sync::Mutex;
 use crate::params::*;
 use crate::tools::{self, OutContent, ToolOutput, ToolResult};
 
+/// A synchronous tool body plus where to send its result — run on the dedicated
+/// `glass-platform` thread (see [`GlassServer::new`]).
+type Job = (
+    Box<dyn FnOnce(&mut Glass) -> ToolResult + Send>,
+    tokio::sync::oneshot::Sender<ToolResult>,
+);
+
 #[derive(Clone)]
 pub struct GlassServer {
     glass: Arc<Mutex<Glass>>,
+    /// Hands tool bodies to the long-lived `glass-platform` thread.
+    jobs: std::sync::mpsc::Sender<Job>,
     tool_router: ToolRouter<GlassServer>,
 }
 
@@ -49,7 +58,31 @@ fn map_tool_result(result: ToolResult) -> CallToolResult {
 #[tool_router]
 impl GlassServer {
     pub fn new(glass: Glass) -> Self {
-        Self { glass: Arc::new(Mutex::new(glass)), tool_router: Self::tool_router() }
+        let glass = Arc::new(Mutex::new(glass));
+        let (jobs, rx) = std::sync::mpsc::channel::<Job>();
+        // One long-lived OS thread runs EVERY tool body. Tool bodies that spawn a
+        // long-lived child — a sandboxed app under `bwrap --die-with-parent`, which SIGKILLs
+        // the sandbox on the death of its parent *thread* (PR_SET_PDEATHSIG is thread-scoped
+        // on Linux) — must be parented to a thread that lives for the whole process, NOT an
+        // ephemeral tokio blocking-pool thread. A pool thread, recycled after the launch
+        // call returns, would trigger that kill and the app would vanish right after launch.
+        // Running here also keeps blocking build/launch/wait work off the async executor and
+        // serializes tools (glass has one active session).
+        let worker_glass = glass.clone();
+        std::thread::Builder::new()
+            .name("glass-platform".into())
+            .spawn(move || {
+                while let Ok((job, reply)) = rx.recv() {
+                    let mut g = worker_glass.blocking_lock();
+                    // A panicking tool becomes a loud error AND the thread survives — so it
+                    // keeps serving calls and keeps parenting any still-running sandbox.
+                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| job(&mut g)))
+                        .unwrap_or_else(|_| Err("tool handler panicked".to_string()));
+                    let _ = reply.send(result);
+                }
+            })
+            .expect("spawn glass-platform thread");
+        Self { glass, jobs, tool_router: Self::tool_router() }
     }
 
     /// A clone of the shared session registry, for the process-exit teardown path in
@@ -62,20 +95,20 @@ impl GlassServer {
     where
         F: FnOnce(&mut Glass) -> ToolResult + Send + 'static,
     {
-        // Run the synchronous tool body on a blocking thread, not on the async executor:
-        // build/launch/window-wait can block for a while and must not stall a runtime
-        // worker, and a tool's own use of `block_on` (e.g. the a11y bus bring-up) must not
-        // nest inside this runtime. A panic in the body becomes a loud error rather than an
-        // unanswered request that hangs the caller forever.
-        let glass = self.glass.clone();
-        let outcome = tokio::task::spawn_blocking(move || {
-            // `blocking_lock` is correct here (it would panic on an async worker); this is a
-            // blocking thread. Holding it serializes tools — glass has one active session.
-            let mut g = glass.blocking_lock();
-            f(&mut g)
-        })
-        .await;
-        Ok(map_tool_result(outcome.unwrap_or_else(|e| Err(format!("tool handler panicked: {e}")))))
+        // Hand the (synchronous, possibly slow) tool body to the dedicated glass-platform
+        // thread and await its result. That thread — not an ephemeral blocking-pool thread —
+        // is the parent of any process the body spawns, so a sandboxed app's
+        // `--die-with-parent` only fires when glass itself exits. It also keeps blocking work
+        // off the async executor and serializes tools (glass has one session). A handler
+        // panic comes back as a loud error, never an unanswered request.
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        if self.jobs.send((Box::new(f), reply_tx)).is_err() {
+            return Ok(map_tool_result(Err("glass-platform thread is gone".to_string())));
+        }
+        let outcome = reply_rx
+            .await
+            .unwrap_or_else(|_| Err("glass-platform thread dropped the job".to_string()));
+        Ok(map_tool_result(outcome))
     }
 
     #[tool(

--- a/crates/glass-mcp/src/tools/capture.rs
+++ b/crates/glass-mcp/src/tools/capture.rs
@@ -41,12 +41,18 @@ pub fn wait_stable(glass: &mut Glass, a: &WaitStableArgs) -> ToolResult {
     };
     let outcome = glass.wait_stable(&params).map_err(|e| e.to_string())?;
     let settled = outcome.settled;
+    // `saw_motion`/`observed_ms` make `settled` non-opaque: settled with saw_motion:false
+    // over a short observed_ms is only a brief quiet window (a slow animation can hide).
+    let saw_motion = outcome.saw_motion;
+    let observed_ms = outcome.observed_ms;
 
     // Text-only: report the settle status + full-frame dims, no WebP. `region`
     // (which only crops the returned image) is intentionally ignored here.
     if !a.include_image.unwrap_or(true) {
         let meta = json!({
             "settled": settled,
+            "saw_motion": saw_motion,
+            "observed_ms": observed_ms,
             "width": outcome.frame.width,
             "height": outcome.frame.height,
         });
@@ -55,7 +61,7 @@ pub fn wait_stable(glass: &mut Glass, a: &WaitStableArgs) -> ToolResult {
 
     let frame = crop_frame(outcome.frame, a.region.as_ref())?;
     let img = frame_to_webp(&frame).map_err(|e| e.to_string())?;
-    let mut meta = json!({ "settled": settled, "width": frame.width, "height": frame.height });
+    let mut meta = json!({ "settled": settled, "saw_motion": saw_motion, "observed_ms": observed_ms, "width": frame.width, "height": frame.height });
     if let Some(r) = a.region.as_ref() {
         meta["x"] = json!(r.x);
         meta["y"] = json!(r.y);


### PR DESCRIPTION
Two round-3 dogfood follow-ups.

## G3 — sandboxed app vanishes right after launch (the priority)
A `glass_start` with a sandbox launched an app that **intermittently disappeared** seconds later (`window not found`), across multiple dogfood runs.

**Root cause (bisected):** bwrap `--die-with-parent` uses `PR_SET_PDEATHSIG`, which on Linux fires on the death of the parent **thread**. Since #24, tool bodies ran on tokio `spawn_blocking` *pool* threads — so the sandbox was parented to an ephemeral thread and got SIGKILL'd when that thread was recycled (intermittent: survived whenever the pool reused the thread). Proof:
- sandbox `off` → survives; sandbox `default` → dies.
- the **same bwrap flags from a stable shell parent** → survives.
- only glass's ephemeral-thread parent kills it.

**Fix:** dispatch every tool body on a single long-lived `glass-platform` thread, so any process a body spawns is parented to a thread that lives for the whole process — `--die-with-parent` now only fires when glass itself exits. Preserves #24's properties (blocking work off the async executor; serialized one-session access; handler panic → loud error via `catch_unwind`).

**Verified end-to-end** via an MCP-stdio client driving the release binary: a sandboxed window is present immediately **and** after 8s (the old binary returned `[]`).

## Settle-floor — `wait_stable {settled:true}` was opaque
Round 3 read `settled:true` as "idle" for a slow ~1s-blink dot that just held one phase across the sampled window (there is no fractional "floor" — settle is `changed_pixels==0` over `settle_frames`). Now `wait_stable` returns `saw_motion` (any frame-to-frame change seen during the watch) + `observed_ms` (how long it watched), so `settled:true` with `saw_motion:false` over a short `observed_ms` reads as a brief quiet window, not a guarantee of idleness. (`wait_for_region {until:"changes"}` remains the way to positively assert animation.)

## Test Plan
- [x] `cargo test --workspace` + `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] new `StabilityTracker::saw_change` unit test; existing wait_stable/stability tests pass
- [x] G3 reproduced (sandbox default dies; sandbox off + stable-parent survive) and the fix **verified end-to-end** on the release binary (window survives immediate + 8s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)