### PR TITLE
feat(audit): opt-in actuation audit log via a core seam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,6 +356,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,7 +430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
@@ -529,6 +538,15 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -603,6 +621,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,6 +668,16 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -976,6 +1014,7 @@ dependencies = [
  "anyhow",
  "axum",
  "base64",
+ "chrono",
  "clap",
  "embed-manifest",
  "futures",
@@ -992,6 +1031,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "sha2",
  "static_vcruntime",
  "tempfile",
  "tokio",
@@ -2169,6 +2209,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -323,6 +323,12 @@ prefix, so the log is not a secret sink. `GLASS_AUDIT_CONTENT=full` stores verba
 `none` stores no content, and `GLASS_AUDIT_PREFIX_LEN=<n>` sizes the prefix (`0` disables
 it). `glass-mcp doctor` reports whether auditing is on, the path, and the content mode.
 
+Two things are recorded in plaintext regardless of `GLASS_AUDIT_CONTENT`: the short
+content **prefix** (default 8 chars — set `GLASS_AUDIT_PREFIX_LEN=0` to drop it), and
+**target metadata** (the active window's title and an element's role/name) which is
+attribution, not actuation content. A window title or field label can itself be sensitive,
+so treat the log as confidential. Launch records intentionally omit `env` and `cwd`.
+
 ## External tool paths
 
 glass shells out to a few third-party programs. Each resolves from a `GLASS_*`

--- a/README.md
+++ b/README.md
@@ -308,6 +308,21 @@ checked-in Windows Sandbox template under `packaging/windows-sandbox/`, or a man
 glass-mcp doctor   # checks sandbox availability alongside display/compositor deps
 ```
 
+## Audit log (opt-in)
+
+Pass `--audit-log <path>` (or set `GLASS_AUDIT_LOG=<path>`) to append a JSONL record of
+every actuation glass performs — launch/stop, type, key, click, drag, scroll, set_value,
+clipboard writes, element clicks, window focus/resize/move, and each `glass_do`
+sub-action. Reads (screenshots, diffs, accessibility snapshots, log/clipboard reads) are
+not logged. The hook lives in the core actuation path, so no actuation can bypass it. One
+JSON object per line: `seq`, `ts`, `action`, `target`, `args`, `result`, and for
+content-bearing actions a `content` descriptor.
+
+Typed/clipboard/launch content is **redacted by default** to a length + SHA-256 + short
+prefix, so the log is not a secret sink. `GLASS_AUDIT_CONTENT=full` stores verbatim text,
+`none` stores no content, and `GLASS_AUDIT_PREFIX_LEN=<n>` sizes the prefix (`0` disables
+it). `glass-mcp doctor` reports whether auditing is on, the path, and the content mode.
+
 ## External tool paths
 
 glass shells out to a few third-party programs. Each resolves from a `GLASS_*`

--- a/crates/glass-core/src/audit.rs
+++ b/crates/glass-core/src/audit.rs
@@ -1,0 +1,94 @@
+//! Actuation audit seam (platform-agnostic). `glass-core` *invokes* an injected
+//! [`AuditSink`] after every actuation so the log is complete by construction; the
+//! concrete JSONL writer + redaction policy live in `glass-mcp`. Data + trait only —
+//! no serde/JSON/OS types, so the platform-agnostic invariant holds.
+
+use std::time::Duration;
+
+use crate::error::Result;
+use crate::platform::{AppSpec, KeyEvent, PointerEvent, WindowOp};
+
+/// The active window an actuation was directed at (best-effort).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WindowRef {
+    pub id: u64,
+    pub title: Option<String>,
+}
+
+/// An accessibility element an actuation targeted.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ElementRef {
+    pub id: u32,
+    pub role: Option<String>,
+    pub name: Option<String>,
+}
+
+/// Ambient context for an actuation.
+#[derive(Clone, Debug, Default)]
+pub struct ActuationContext {
+    pub window: Option<WindowRef>,
+}
+
+/// Whether an actuation succeeded, and the error message if not.
+#[derive(Clone, Debug)]
+pub struct AuditOutcome {
+    pub ok: bool,
+    pub error: Option<String>,
+}
+
+impl AuditOutcome {
+    /// Derive an outcome from a `glass-core` result (the error is stringified).
+    pub fn from_result<T>(r: &Result<T>) -> Self {
+        match r {
+            Ok(_) => AuditOutcome { ok: true, error: None },
+            Err(e) => AuditOutcome { ok: false, error: Some(e.to_string()) },
+        }
+    }
+}
+
+/// One actuation as seen at the core choke-point. Borrows the originating typed
+/// event so the sink can format without `glass-core` depending on serde/JSON.
+#[derive(Debug)]
+pub enum Actuation<'a> {
+    Launch { spec: &'a AppSpec, backend: &'a str },
+    Stop,
+    Pointer { event: &'a PointerEvent },
+    Key { event: &'a KeyEvent },
+    ClipboardSet { text: &'a str },
+    Window { op: &'a WindowOp },
+    ClickElement { element: ElementRef },
+    SetValue { element: ElementRef, text: &'a str },
+}
+
+/// Receives every actuation. Implemented in `glass-mcp` (`JsonlSink`). `Send` so it
+/// can live on `Glass`, which moves across the runtime's worker thread.
+pub trait AuditSink: Send {
+    /// Record one actuation. Implementations **must not panic** and must not
+    /// propagate errors: a sink-internal failure (e.g. I/O) is handled internally
+    /// (logged/counted/fail-closed), never surfaced into the actuation path.
+    fn record(
+        &self,
+        act: &Actuation,
+        ctx: &ActuationContext,
+        outcome: &AuditOutcome,
+        dur: Duration,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::GlassError;
+
+    #[test]
+    fn outcome_from_result_captures_ok_and_error() {
+        let ok: Result<()> = Ok(());
+        let o = AuditOutcome::from_result(&ok);
+        assert!(o.ok && o.error.is_none());
+
+        let err: Result<()> = Err(GlassError::NoActiveSession);
+        let e = AuditOutcome::from_result(&err);
+        assert!(!e.ok);
+        assert!(e.error.unwrap().to_lowercase().contains("session"));
+    }
+}

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -56,6 +56,9 @@ pub use accessibility::{
 pub mod marks;
 pub use marks::Mark;
 
+pub mod audit;
+pub use audit::{Actuation, ActuationContext, AuditOutcome, AuditSink, ElementRef, WindowRef};
+
 pub mod session;
 pub use session::{
     Backend, Glass, PlatformFactory, WaitElementOutcome, WaitElementParams, WaitLogOutcome,

--- a/crates/glass-core/src/session.rs
+++ b/crates/glass-core/src/session.rs
@@ -130,6 +130,8 @@ struct ActiveSession {
     last_ax: Option<AxTree>,
     geometry: WindowGeometry,
     logs: LogBuffer,
+    /// Best-effort active window for audit attribution (id from list_windows/select_window).
+    active_window: Option<crate::audit::WindowRef>,
 }
 
 impl ActiveSession {
@@ -171,6 +173,7 @@ pub struct Glass {
     baselines: BaselineStore,
     log_capacity: usize,
     active: Option<ActiveSession>,
+    audit: Option<Box<dyn crate::audit::AuditSink>>,
 }
 
 impl Glass {
@@ -180,7 +183,30 @@ impl Glass {
         baselines: BaselineStore,
         log_capacity: usize,
     ) -> Self {
-        Self { factory, default_backend, baselines, log_capacity: log_capacity.max(1), active: None }
+        Self { factory, default_backend, baselines, log_capacity: log_capacity.max(1), active: None, audit: None }
+    }
+
+    /// Install the audit sink. Every subsequent actuation is recorded through it.
+    pub fn set_audit_sink(&mut self, sink: Box<dyn crate::audit::AuditSink>) {
+        self.audit = Some(sink);
+    }
+
+    fn emit_audit(&self, act: &crate::audit::Actuation, outcome: crate::audit::AuditOutcome, dur: std::time::Duration) {
+        if let Some(sink) = &self.audit {
+            let window = self.active.as_ref().and_then(|s| s.active_window.clone());
+            sink.record(act, &crate::audit::ActuationContext { window }, &outcome, dur);
+        }
+    }
+
+    fn element_ref(&self, id: AxNodeId) -> crate::audit::ElementRef {
+        let (role, name) = self
+            .active
+            .as_ref()
+            .and_then(|s| s.last_ax.as_ref())
+            .and_then(|t| t.find(id))
+            .map(|n| (Some(format!("{:?}", n.role)), n.name.clone()))
+            .unwrap_or((None, None));
+        crate::audit::ElementRef { id: id.0, role, name }
     }
 
     fn require_active(&self) -> Result<&ActiveSession> {
@@ -227,6 +253,17 @@ impl Glass {
 
     /// Start with an explicit backend, constructing it via the factory.
     pub fn start_on(&mut self, backend: &str, spec: &AppSpec) -> Result<WindowGeometry> {
+        let t = std::time::Instant::now();
+        let result = self.start_on_inner(backend, spec);
+        self.emit_audit(
+            &crate::audit::Actuation::Launch { spec, backend },
+            crate::audit::AuditOutcome::from_result(&result),
+            t.elapsed(),
+        );
+        result
+    }
+
+    fn start_on_inner(&mut self, backend: &str, spec: &AppSpec) -> Result<WindowGeometry> {
         // One active session: tear down any current one first.
         if let Some(mut s) = self.active.take() {
             let _ = s.platform.stop_app();
@@ -239,13 +276,38 @@ impl Glass {
             last_ax: None,
             geometry: geometry.clone(),
             logs: LogBuffer::new(self.log_capacity),
+            active_window: None,
         };
         session.pump();
+        session.active_window = session
+            .platform
+            .list_windows()
+            .ok()
+            .and_then(|ws| ws.iter().find(|w| w.active).or_else(|| ws.first()).cloned())
+            .map(|w| crate::audit::WindowRef { id: w.id.0, title: w.title });
         self.active = Some(session);
         Ok(geometry)
     }
 
     pub fn stop(&mut self) -> Result<()> {
+        let t = std::time::Instant::now();
+        // Snapshot the window BEFORE stop_inner, which drops self.active — so this
+        // records on the dedicated path rather than emit_audit (which would see None
+        // after teardown). Keep this ordering if refactoring, or window attribution breaks.
+        let window = self.active.as_ref().and_then(|s| s.active_window.clone());
+        let result = self.stop_inner();
+        if let Some(sink) = &self.audit {
+            sink.record(
+                &crate::audit::Actuation::Stop,
+                &crate::audit::ActuationContext { window },
+                &crate::audit::AuditOutcome::from_result(&result),
+                t.elapsed(),
+            );
+        }
+        result
+    }
+
+    fn stop_inner(&mut self) -> Result<()> {
         let mut s = self.active.take().ok_or(GlassError::NoActiveSession)?;
         s.platform.stop_app()
         // `s` drops here, tearing down the spawned backend (Xvfb/sway).
@@ -281,6 +343,17 @@ impl Glass {
     }
 
     pub fn pointer(&mut self, event: &PointerEvent) -> Result<()> {
+        let t = std::time::Instant::now();
+        let result = self.pointer_inner(event);
+        self.emit_audit(
+            &crate::audit::Actuation::Pointer { event },
+            crate::audit::AuditOutcome::from_result(&result),
+            t.elapsed(),
+        );
+        result
+    }
+
+    fn pointer_inner(&mut self, event: &PointerEvent) -> Result<()> {
         self.check_bounds(event)?;
         let s = self.active_mut()?;
         s.platform.send_pointer(event)?;
@@ -289,6 +362,17 @@ impl Glass {
     }
 
     pub fn key(&mut self, event: &KeyEvent) -> Result<()> {
+        let t = std::time::Instant::now();
+        let result = self.key_inner(event);
+        self.emit_audit(
+            &crate::audit::Actuation::Key { event },
+            crate::audit::AuditOutcome::from_result(&result),
+            t.elapsed(),
+        );
+        result
+    }
+
+    fn key_inner(&mut self, event: &KeyEvent) -> Result<()> {
         let s = self.active_mut()?;
         s.platform.send_key(event)?;
         s.pump();
@@ -300,10 +384,34 @@ impl Glass {
     }
 
     pub fn set_clipboard(&mut self, text: &str) -> Result<()> {
+        let t = std::time::Instant::now();
+        let result = self.set_clipboard_inner(text);
+        self.emit_audit(
+            &crate::audit::Actuation::ClipboardSet { text },
+            crate::audit::AuditOutcome::from_result(&result),
+            t.elapsed(),
+        );
+        result
+    }
+
+    fn set_clipboard_inner(&mut self, text: &str) -> Result<()> {
         self.active_mut()?.platform.set_clipboard(text)
     }
 
     pub fn window(&mut self, op: &WindowOp) -> Result<WindowGeometry> {
+        let t = std::time::Instant::now();
+        let result = self.window_inner(op);
+        if !matches!(op, WindowOp::Geometry) {
+            self.emit_audit(
+                &crate::audit::Actuation::Window { op },
+                crate::audit::AuditOutcome::from_result(&result),
+                t.elapsed(),
+            );
+        }
+        result
+    }
+
+    fn window_inner(&mut self, op: &WindowOp) -> Result<WindowGeometry> {
         let s = self.active_mut()?;
         let geometry = s.platform.window(op)?;
         s.geometry = geometry.clone();
@@ -322,6 +430,7 @@ impl Glass {
         let s = self.active_mut()?;
         let geometry = s.platform.select_window(id)?;
         s.geometry = geometry.clone();
+        s.active_window = Some(crate::audit::WindowRef { id: id.0, title: None });
         s.pump();
         Ok(geometry)
     }
@@ -354,6 +463,18 @@ impl Glass {
     /// Click the element with id `id` from the most recent `a11y_snapshot`
     /// (clicks the center of its bounds, via the normal pointer path).
     pub fn click_element(&mut self, id: AxNodeId) -> Result<()> {
+        let t = std::time::Instant::now();
+        let element = self.element_ref(id);
+        let result = self.click_element_inner(id);
+        self.emit_audit(
+            &crate::audit::Actuation::ClickElement { element },
+            crate::audit::AuditOutcome::from_result(&result),
+            t.elapsed(),
+        );
+        result
+    }
+
+    fn click_element_inner(&mut self, id: AxNodeId) -> Result<()> {
         let (x, y) = {
             let s = self.require_active()?;
             let tree = s.last_ax.as_ref().ok_or(GlassError::NoAxSnapshot)?;
@@ -363,7 +484,7 @@ impl Glass {
                 .clamped_center(s.geometry.width, s.geometry.height)
                 .ok_or(GlassError::AxElementNotClickable(id.0))?
         };
-        self.pointer(&PointerEvent::Click { x, y, button: MouseButton::Left, count: 1, modifiers: vec![] })
+        self.pointer_inner(&PointerEvent::Click { x, y, button: MouseButton::Left, count: 1, modifiers: vec![] })
     }
 
     /// Set the value/text of element `id` (from the latest `a11y_snapshot`) via the
@@ -371,6 +492,18 @@ impl Glass {
     /// cached snapshot), `AxUnsupported` (no reader), or — from the backend —
     /// `AxElementNotEditable`/`AxElementChanged`.
     pub fn set_value(&mut self, id: AxNodeId, text: &str) -> Result<()> {
+        let t = std::time::Instant::now();
+        let element = self.element_ref(id);
+        let result = self.set_value_inner(id, text);
+        self.emit_audit(
+            &crate::audit::Actuation::SetValue { element, text },
+            crate::audit::AuditOutcome::from_result(&result),
+            t.elapsed(),
+        );
+        result
+    }
+
+    fn set_value_inner(&mut self, id: AxNodeId, text: &str) -> Result<()> {
         let (target, ctx) = {
             let s = self.require_active()?;
             // Check for reader availability before consulting the snapshot, so that
@@ -631,9 +764,11 @@ impl Glass {
 mod tests {
     use super::*;
     use crate::accessibility::{AxNode, AxRect, AxRole, AxStates, AxTarget, ElementCondition};
+    use crate::audit::{Actuation, ActuationContext, AuditOutcome, AuditSink};
     use crate::platform::SandboxLevel;
     use std::collections::VecDeque;
     use std::sync::{Arc, Mutex};
+    use std::time::Duration;
 
     /// Scriptable in-memory backend for testing the session manager.
     #[derive(Default)]
@@ -1684,5 +1819,87 @@ mod tests {
         // No session started — both ops should return NoActiveSession.
         assert!(matches!(g.get_clipboard().unwrap_err(), GlassError::NoActiveSession));
         assert!(matches!(g.set_clipboard("x").unwrap_err(), GlassError::NoActiveSession));
+    }
+
+    /// Records `"action:ok"` for each actuation the seam reports.
+    #[derive(Clone, Default)]
+    struct RecordingSink(Arc<Mutex<Vec<String>>>);
+    impl AuditSink for RecordingSink {
+        fn record(&self, act: &Actuation, _ctx: &ActuationContext, o: &AuditOutcome, _d: Duration) {
+            let action = match act {
+                Actuation::Launch { .. } => "launch",
+                Actuation::Stop => "stop",
+                Actuation::Pointer { event } => match event {
+                    PointerEvent::Move { .. } => "move",
+                    PointerEvent::Click { .. } => "click",
+                    PointerEvent::Drag { .. } => "drag",
+                    PointerEvent::Scroll { .. } => "scroll",
+                },
+                Actuation::Key { event } => match event {
+                    KeyEvent::Text(_) => "type",
+                    KeyEvent::Chord(_) => "key",
+                },
+                Actuation::ClipboardSet { .. } => "clipboard_set",
+                Actuation::Window { .. } => "window",
+                Actuation::ClickElement { .. } => "click_element",
+                Actuation::SetValue { .. } => "set_value",
+            };
+            self.0.lock().unwrap().push(format!("{action}:{}", o.ok));
+        }
+    }
+
+    fn first_button(t: &AxTree) -> AxNodeId {
+        fn walk(n: &AxNode) -> Option<AxNodeId> {
+            if n.role == AxRole::Button { return Some(n.id); }
+            n.children.iter().find_map(walk)
+        }
+        walk(&t.root).expect("fake_tree has a Button")
+    }
+
+    #[test]
+    fn seam_records_actuations_skips_reads_and_geometry() {
+        let sink = RecordingSink::default();
+        let frame = Frame::solid(100, 100, [0, 0, 0, 255]);
+        let mut g = glass_with_a11y(
+            FakePlatform::new(100, 100).with_frames(vec![frame.clone(), frame]),
+            fake_tree(),
+        );
+        g.set_audit_sink(Box::new(sink.clone()));
+
+        g.start(&spec()).unwrap();
+        let _ = g.screenshot(None).unwrap();          // read
+        let tree = g.a11y_snapshot().unwrap();        // read (populates last_ax)
+        g.pointer(&PointerEvent::Click { x: 1, y: 2, button: MouseButton::Left, count: 1, modifiers: vec![] }).unwrap();
+        g.key(&KeyEvent::Text("hi".into())).unwrap();
+        let _ = g.window(&WindowOp::Geometry).unwrap(); // read → no record
+        g.window(&WindowOp::Focus).unwrap();            // actuation
+        g.click_element(first_button(&tree)).unwrap();
+        g.stop().unwrap();
+
+        let got = sink.0.lock().unwrap().clone();
+        assert_eq!(
+            got,
+            vec!["launch:true", "click:true", "type:true", "window:true", "click_element:true", "stop:true"],
+            "reads (screenshot, a11y_snapshot, window-geometry) produce no records; click_element records ONCE (not also as click)"
+        );
+    }
+
+    #[test]
+    fn seam_records_failed_actuation_ok_false() {
+        let sink = RecordingSink::default();
+        let mut g = glass_with(FakePlatform::new(50, 50).with_frames(vec![Frame::solid(50, 50, [0; 4])]));
+        g.set_audit_sink(Box::new(sink.clone()));
+        g.start(&spec()).unwrap();
+        // Out-of-bounds click fails check_bounds → still recorded as ok:false.
+        let _ = g.pointer(&PointerEvent::Click { x: 999, y: 0, button: MouseButton::Left, count: 1, modifiers: vec![] });
+        let got = sink.0.lock().unwrap().clone();
+        assert_eq!(got, vec!["launch:true", "click:false"]);
+    }
+
+    #[test]
+    fn no_sink_means_no_behavior_change() {
+        let mut g = glass_with(FakePlatform::new(10, 10).with_frames(vec![Frame::solid(10, 10, [0; 4])]));
+        g.start(&spec()).unwrap();
+        g.pointer(&PointerEvent::Click { x: 0, y: 0, button: MouseButton::Left, count: 1, modifiers: vec![] }).unwrap();
     }
 }

--- a/crates/glass-mcp/Cargo.toml
+++ b/crates/glass-mcp/Cargo.toml
@@ -32,6 +32,9 @@ tokio-util = { version = "0.7", optional = true }
 # Non-optional: the untrusted-conduit nonce (untrusted.rs, compiled in every build,
 # incl. --no-default-features) needs a CSPRNG, as does network token generation.
 rand = { version = "0.8" }
+# Audit log: SHA-256 content digests (redacted by default) + RFC3339 timestamps.
+sha2 = "0.10"
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 futures = { version = "0.3", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/crates/glass-mcp/src/audit.rs
+++ b/crates/glass-mcp/src/audit.rs
@@ -2,6 +2,7 @@
 //! file, redacting content by default. The seam (when/what/completeness) lives in
 //! glass-core; this owns the wire format + redaction policy.
 
+use std::fs::OpenOptions;
 use std::io::Write;
 use std::sync::Mutex;
 use std::time::Duration;
@@ -219,6 +220,20 @@ impl JsonlSink {
             cfg,
         }
     }
+
+    /// Open (create-or-append). Fail-closed: an I/O error is returned to the caller.
+    pub fn open(path: &str, cfg: AuditConfig) -> std::io::Result<Self> {
+        let file = OpenOptions::new().create(true).append(true).open(path)?;
+        Ok(JsonlSink {
+            state: Mutex::new(SinkState { writer: Box::new(file), seq: 0, session: None, dropped: 0 }),
+            cfg,
+        })
+    }
+
+    #[cfg(test)]
+    fn dropped(&self) -> u64 {
+        self.state.lock().unwrap().dropped
+    }
 }
 
 impl AuditSink for JsonlSink {
@@ -268,6 +283,43 @@ fn mint_session() -> String {
     let mut b = [0u8; 8];
     rand::rngs::OsRng.fill_bytes(&mut b);
     format!("s-{}", b.iter().map(|x| format!("{x:02x}")).collect::<String>())
+}
+
+/// Audit posture (for `doctor`/`env`).
+#[derive(Debug, Clone)]
+pub struct AuditReport {
+    pub enabled: bool,
+    pub path: Option<String>,
+    pub content: ContentMode,
+    pub prefix_len: usize,
+}
+
+fn config_from(cli_path: Option<&str>, env: &dyn Fn(&str) -> Option<String>) -> (Option<String>, AuditConfig) {
+    let path = cli_path.map(String::from).or_else(|| env("GLASS_AUDIT_LOG").filter(|p| !p.is_empty()));
+    let content = env("GLASS_AUDIT_CONTENT").map(|s| ContentMode::parse(&s)).unwrap_or(ContentMode::Redacted);
+    let prefix_len = env("GLASS_AUDIT_PREFIX_LEN").and_then(|s| s.trim().parse().ok()).unwrap_or(8);
+    (path, AuditConfig { content, prefix_len })
+}
+
+/// Posture only — used by the `doctor` subcommand (does NOT open the file).
+pub fn report_from_config(cli_path: Option<&str>, env: impl Fn(&str) -> Option<String>) -> AuditReport {
+    let (path, cfg) = config_from(cli_path, &env);
+    AuditReport { enabled: path.is_some(), path, content: cfg.content, prefix_len: cfg.prefix_len }
+}
+
+/// Resolve the sink (opening the file, fail-closed) and the report. `None` sink when
+/// no path is configured.
+pub fn resolve(
+    cli_path: Option<&str>,
+    env: impl Fn(&str) -> Option<String>,
+) -> anyhow::Result<(Option<Box<dyn AuditSink>>, AuditReport)> {
+    let (path, cfg) = config_from(cli_path, &env);
+    let report = AuditReport { enabled: path.is_some(), path: path.clone(), content: cfg.content, prefix_len: cfg.prefix_len };
+    let sink: Option<Box<dyn AuditSink>> = match path {
+        None => None,
+        Some(p) => Some(Box::new(JsonlSink::open(&p, cfg).map_err(|e| anyhow::anyhow!("cannot open audit log {p:?}: {e}"))?)),
+    };
+    Ok((sink, report))
 }
 
 #[cfg(test)]
@@ -420,5 +472,77 @@ mod tests {
         assert_eq!(r["target"]["element"]["id"], 5);
         assert_eq!(r["target"]["element"]["role"], "PasswordField");
         assert_eq!(r["content"]["len"], 1);
+    }
+
+    #[test]
+    fn seq_monotonic_session_minted_on_launch_cleared_on_stop() {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let s = JsonlSink::with_writer(Box::new(Buf(buf.clone())), AuditConfig::default());
+        let spec = glass_core::AppSpec { build: None, run: vec!["app".into()], cwd: None, env: vec![], window_hint: None, timeout_ms: 1, sandbox: glass_core::SandboxLevel::Off, a11y: false };
+        s.record(&Actuation::Launch { spec: &spec, backend: "x11" }, &ActuationContext::default(), &ok(), Duration::from_millis(1));
+        s.record(&Actuation::Stop, &ActuationContext::default(), &ok(), Duration::from_millis(1));
+        s.record(&Actuation::Stop, &ActuationContext::default(), &ok(), Duration::from_millis(1)); // after stop
+        let r = lines(&buf);
+        assert_eq!(r.iter().map(|x| x["seq"].as_u64().unwrap()).collect::<Vec<_>>(), vec![1, 2, 3]);
+        let sess = r[0]["session"].as_str().unwrap().to_string();
+        assert!(sess.starts_with("s-"));
+        assert_eq!(r[1]["session"], sess, "stop stamps the ending session");
+        assert!(r[2]["session"].is_null(), "no session after stop");
+    }
+
+    #[test]
+    fn errored_actuation_records_ok_false_with_message() {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let s = JsonlSink::with_writer(Box::new(Buf(buf.clone())), AuditConfig::default());
+        let out = AuditOutcome { ok: false, error: Some("coords out of bounds".into()) };
+        s.record(&Actuation::Pointer { event: &PointerEvent::Click { x: 9, y: 9, button: MouseButton::Left, count: 1, modifiers: vec![] } }, &ActuationContext::default(), &out, Duration::from_millis(1));
+        let r = &lines(&buf)[0];
+        assert_eq!(r["result"]["ok"], false);
+        assert_eq!(r["result"]["error"], "coords out of bounds");
+    }
+
+    #[test]
+    fn write_failure_counts_not_panics() {
+        struct Fail;
+        impl Write for Fail {
+            fn write(&mut self, _: &[u8]) -> std::io::Result<usize> { Err(std::io::Error::other("full")) }
+            fn flush(&mut self) -> std::io::Result<()> { Ok(()) }
+        }
+        let s = JsonlSink::with_writer(Box::new(Fail), AuditConfig::default());
+        s.record(&Actuation::Stop, &ActuationContext::default(), &ok(), Duration::from_millis(1));
+        assert_eq!(s.dropped(), 1);
+    }
+
+    #[test]
+    fn open_fail_closed_and_append_semantics() {
+        assert!(JsonlSink::open("/nonexistent-xyz/a.jsonl", AuditConfig::default()).is_err());
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("a.jsonl");
+        std::fs::write(&p, "PRE\n").unwrap();
+        let s = JsonlSink::open(p.to_str().unwrap(), AuditConfig::default()).unwrap();
+        s.record(&Actuation::Stop, &ActuationContext::default(), &ok(), Duration::from_millis(1));
+        let body = std::fs::read_to_string(&p).unwrap();
+        assert!(body.starts_with("PRE\n") && body.lines().count() == 2);
+    }
+
+    #[test]
+    fn resolve_cli_over_env_disabled_when_unset_modes_from_env() {
+        let (sink, rep) = resolve(None, |_| None).unwrap();
+        assert!(sink.is_none() && !rep.enabled);
+
+        let dir = tempfile::tempdir().unwrap();
+        let envp = dir.path().join("e.jsonl");
+        let clip = dir.path().join("c.jsonl");
+        let env = |k: &str| match k {
+            "GLASS_AUDIT_LOG" => Some(envp.to_str().unwrap().to_string()),
+            "GLASS_AUDIT_CONTENT" => Some("full".into()),
+            "GLASS_AUDIT_PREFIX_LEN" => Some("4".into()),
+            _ => None,
+        };
+        let (sink, rep) = resolve(Some(clip.to_str().unwrap()), env).unwrap();
+        assert!(sink.is_some());
+        assert_eq!(rep.path.as_deref(), Some(clip.to_str().unwrap()), "CLI path wins");
+        assert_eq!(rep.content, ContentMode::Full);
+        assert_eq!(rep.prefix_len, 4);
     }
 }

--- a/crates/glass-mcp/src/audit.rs
+++ b/crates/glass-mcp/src/audit.rs
@@ -242,7 +242,9 @@ impl AuditSink for JsonlSink {
     fn record(&self, act: &Actuation, ctx: &ActuationContext, outcome: &AuditOutcome, dur: Duration) {
         let Some((action, args, raw)) = describe(act) else { return };
         let mut st = self.state.lock().unwrap_or_else(|p| p.into_inner());
-        st.seq += 1;
+        // Monotonic event counter. `saturating_add` so an (unreachable) overflow can't
+        // panic while the lock is held — `record` must never panic (trait contract).
+        st.seq = st.seq.saturating_add(1);
         if action == "launch" {
             st.session = Some(mint_session());
         }
@@ -258,6 +260,9 @@ impl AuditSink for JsonlSink {
             content: raw.as_deref().and_then(|r| render_content(r, &self.cfg)),
             result: ResultRecord {
                 ok: outcome.ok,
+                // `error` is recorded verbatim and is NOT run through content redaction.
+                // Invariant: backend error messages must never embed actuation content
+                // (e.g. the typed text), or it would leak here regardless of content mode.
                 error: outcome.error.clone(),
                 duration_ms: u64::try_from(dur.as_millis()).unwrap_or(u64::MAX),
             },
@@ -265,6 +270,9 @@ impl AuditSink for JsonlSink {
         if action == "stop" {
             st.session = None;
         }
+        // On write/serialize failure: count it, emit loudly, and continue — `seq` has
+        // already advanced, so a GAP in the persisted seq sequence is the intended
+        // signal that a record was lost. Do NOT renumber to hide a drop.
         match serde_json::to_string(&rec) {
             Ok(mut line) => {
                 line.push('\n');
@@ -283,7 +291,12 @@ impl AuditSink for JsonlSink {
 
 fn mint_session() -> String {
     let mut b = [0u8; 8];
-    rand::rngs::OsRng.fill_bytes(&mut b);
+    // `try_fill_bytes`, not `fill_bytes`: `record` must never panic, and `OsRng` can
+    // fail. A session id only distinguishes start→stop cycles (it need not be
+    // unpredictable), so on the astronomically-rare RNG error use a fixed fallback tag.
+    if rand::rngs::OsRng.try_fill_bytes(&mut b).is_err() {
+        return "s-norand".to_string();
+    }
     format!("s-{}", b.iter().map(|x| format!("{x:02x}")).collect::<String>())
 }
 

--- a/crates/glass-mcp/src/audit.rs
+++ b/crates/glass-mcp/src/audit.rs
@@ -526,6 +526,93 @@ mod tests {
     }
 
     #[test]
+    fn end_to_end_actuations_logged_reads_not() {
+        use crate::params::*;
+        use crate::tools;
+        use crate::tools::testutil::{glass_with, FakePlatform};
+        use glass_core::Frame;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("audit.jsonl");
+        let (sink, report) = resolve(Some(path.to_str().unwrap()), |k| {
+            // Disable the prefix so the redacted record never contains the plaintext.
+            if k == "GLASS_AUDIT_PREFIX_LEN" { Some("0".into()) } else { None }
+        })
+        .unwrap();
+        assert!(report.enabled);
+
+        // A FakePlatform with several frames so screenshot / settle work.
+        let frame = Frame::solid(100, 100, [0, 0, 0, 255]);
+        let mut g = glass_with(
+            FakePlatform::new(100, 100)
+                .with_frames(vec![frame.clone(), frame.clone(), frame.clone(), frame]),
+        );
+        g.set_audit_sink(sink.unwrap());
+
+        tools::start(
+            &mut g,
+            &StartArgs {
+                build: None,
+                run: vec!["app".into()],
+                backend: None,
+                sandbox: Some("off".into()),
+                cwd: None,
+                env: vec![],
+                window_hint: None,
+                timeout_ms: None,
+                a11y: None,
+            },
+        )
+        .unwrap();
+        tools::screenshot(&mut g, &ScreenshotArgs { region: None }).unwrap(); // read — not logged
+        tools::type_text(&mut g, &TypeArgs { text: "secret".into() }).unwrap(); // "type"
+        tools::do_actions(
+            &mut g,
+            &DoArgs {
+                actions: vec![
+                    Action::Click(ClickArgs {
+                        x: 1,
+                        y: 2,
+                        button: None,
+                        count: None,
+                        modifiers: None,
+                    }),
+                    Action::Settle(SettleArgs {
+                        interval_ms: Some(0),
+                        settle_frames: Some(1),
+                        tolerance: None,
+                        timeout_ms: Some(500),
+                        stability_region: None,
+                    }),
+                ],
+                then: None,
+            },
+        )
+        .unwrap(); // click (logged) + settle (read — not logged)
+        tools::window(&mut g, &WindowArgs { op: "geometry".into(), x: None, y: None, width: None, height: None }).unwrap(); // read — not logged
+        tools::window(&mut g, &WindowArgs { op: "focus".into(), x: None, y: None, width: None, height: None }).unwrap(); // "window"
+        tools::stop(&mut g).unwrap();
+
+        let body = std::fs::read_to_string(&path).unwrap();
+        let recs: Vec<serde_json::Value> =
+            body.lines().map(|l| serde_json::from_str(l).unwrap()).collect();
+        let actions: Vec<&str> =
+            recs.iter().map(|r| r["action"].as_str().unwrap()).collect();
+        assert_eq!(
+            actions,
+            vec!["launch", "type", "click", "window", "stop"],
+            "reads (screenshot, settle, window-geometry) are not logged; glass_do click IS"
+        );
+        let typ = recs.iter().find(|r| r["action"] == "type").unwrap();
+        assert!(typ["content"].get("text").is_none(), "redacted: no plaintext");
+        assert_eq!(typ["content"]["len"], 6);
+        assert!(!body.contains("secret"), "plaintext must not appear in redacted mode");
+        // launch program is recorded verbatim (structural, not content)
+        let launch = recs.iter().find(|r| r["action"] == "launch").unwrap();
+        assert_eq!(launch["args"]["program"], "app");
+    }
+
+    #[test]
     fn resolve_cli_over_env_disabled_when_unset_modes_from_env() {
         let (sink, rep) = resolve(None, |_| None).unwrap();
         assert!(sink.is_none() && !rep.enabled);

--- a/crates/glass-mcp/src/audit.rs
+++ b/crates/glass-mcp/src/audit.rs
@@ -92,6 +92,8 @@ fn describe(act: &Actuation) -> Option<(&'static str, Value, Option<String>)> {
     Some(match act {
         Actuation::Launch { spec, backend } => {
             let tail: Vec<&String> = spec.run.iter().skip(1).collect();
+            // Deliberately omit spec.env and spec.cwd: env vars commonly carry secrets
+            // (tokens, keys) and must not land in the log. Keep them out if extended.
             (
                 "launch",
                 json!({

--- a/crates/glass-mcp/src/audit.rs
+++ b/crates/glass-mcp/src/audit.rs
@@ -1,0 +1,424 @@
+//! Concrete audit sink: implements `glass_core::AuditSink` by appending JSONL to a
+//! file, redacting content by default. The seam (when/what/completeness) lives in
+//! glass-core; this owns the wire format + redaction policy.
+
+use std::io::Write;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use glass_core::{
+    Actuation, ActuationContext, AuditOutcome, AuditSink, KeyEvent, Modifier, MouseButton,
+    PointerEvent, WindowOp,
+};
+use rand::RngCore;
+use serde::Serialize;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContentMode {
+    None,
+    Redacted,
+    Full,
+}
+
+impl ContentMode {
+    pub fn parse(s: &str) -> Self {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "none" => ContentMode::None,
+            "full" => ContentMode::Full,
+            _ => ContentMode::Redacted,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct AuditConfig {
+    pub content: ContentMode,
+    pub prefix_len: usize,
+}
+
+impl Default for AuditConfig {
+    fn default() -> Self {
+        AuditConfig { content: ContentMode::Redacted, prefix_len: 8 }
+    }
+}
+
+fn sha256_hex(raw: &str) -> String {
+    Sha256::digest(raw.as_bytes()).iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn char_prefix(raw: &str, n: usize) -> &str {
+    match raw.char_indices().nth(n) {
+        Some((i, _)) => &raw[..i],
+        None => raw,
+    }
+}
+
+/// Content descriptor for one content-bearing actuation (`None` when mode is `None`).
+/// `len` is the UTF-8 **byte** length of the content (not the char count).
+pub fn render_content(raw: &str, cfg: &AuditConfig) -> Option<Value> {
+    match cfg.content {
+        ContentMode::None => None,
+        ContentMode::Redacted => {
+            let mut o = json!({ "len": raw.len(), "sha256": sha256_hex(raw) });
+            if cfg.prefix_len > 0 {
+                o["prefix"] = Value::String(char_prefix(raw, cfg.prefix_len).into());
+            }
+            Some(o)
+        }
+        ContentMode::Full => {
+            Some(json!({ "len": raw.len(), "sha256": sha256_hex(raw), "text": raw }))
+        }
+    }
+}
+
+fn fmt_button(b: &MouseButton) -> &'static str {
+    match b {
+        MouseButton::Left => "left",
+        MouseButton::Right => "right",
+        MouseButton::Middle => "middle",
+    }
+}
+
+fn fmt_mods(m: &[Modifier]) -> Vec<String> {
+    m.iter().map(|x| format!("{x:?}").to_lowercase()).collect()
+}
+
+/// Map an `Actuation` to `(action, args, raw_content)`. `None` = do not record
+/// (v1 excludes `Move`; `Geometry` never reaches here because `window` skips it).
+fn describe(act: &Actuation) -> Option<(&'static str, Value, Option<String>)> {
+    Some(match act {
+        Actuation::Launch { spec, backend } => {
+            let tail: Vec<&String> = spec.run.iter().skip(1).collect();
+            (
+                "launch",
+                json!({
+                    "program": spec.run.first(),
+                    "backend": backend,
+                    "argc": spec.run.len(),
+                    "has_build": spec.build.is_some()
+                }),
+                Some(json!({ "args": tail, "build": spec.build }).to_string()),
+            )
+        }
+        Actuation::Stop => ("stop", json!({}), None),
+        Actuation::Pointer { event } => match event {
+            PointerEvent::Move { .. } => return None,
+            PointerEvent::Click { x, y, button, count, modifiers } => (
+                "click",
+                json!({
+                    "x": x,
+                    "y": y,
+                    "button": fmt_button(button),
+                    "count": count,
+                    "modifiers": fmt_mods(modifiers)
+                }),
+                None,
+            ),
+            PointerEvent::Drag { from_x, from_y, to_x, to_y, button, modifiers, duration_ms } => (
+                "drag",
+                json!({
+                    "from_x": from_x,
+                    "from_y": from_y,
+                    "to_x": to_x,
+                    "to_y": to_y,
+                    "button": fmt_button(button),
+                    "modifiers": fmt_mods(modifiers),
+                    "duration_ms": duration_ms
+                }),
+                None,
+            ),
+            PointerEvent::Scroll { x, y, dx, dy, modifiers } => (
+                "scroll",
+                json!({
+                    "x": x,
+                    "y": y,
+                    "dx": dx,
+                    "dy": dy,
+                    "modifiers": fmt_mods(modifiers)
+                }),
+                None,
+            ),
+        },
+        Actuation::Key { event } => match event {
+            KeyEvent::Text(s) => ("type", json!({}), Some(s.clone())),
+            KeyEvent::Chord(c) => ("key", json!({ "chord": c }), None),
+        },
+        Actuation::ClipboardSet { text } => {
+            ("clipboard_set", json!({}), Some((*text).to_string()))
+        }
+        Actuation::Window { op } => {
+            let args = match op {
+                WindowOp::Focus => json!({ "op": "focus" }),
+                WindowOp::Resize { width, height } => {
+                    json!({ "op": "resize", "width": width, "height": height })
+                }
+                WindowOp::Move { x, y } => json!({ "op": "move", "x": x, "y": y }),
+                WindowOp::Geometry => return None,
+            };
+            ("window", args, None)
+        }
+        Actuation::ClickElement { .. } => ("click_element", json!({}), None),
+        Actuation::SetValue { text, .. } => ("set_value", json!({}), Some((*text).to_string())),
+    })
+}
+
+fn target_json(act: &Actuation, ctx: &ActuationContext) -> Value {
+    match act {
+        Actuation::ClickElement { element } | Actuation::SetValue { element, .. } => {
+            json!({ "element": { "id": element.id, "role": element.role, "name": element.name } })
+        }
+        _ => match &ctx.window {
+            Some(w) => json!({ "window": { "id": w.id, "title": w.title } }),
+            None => Value::Null,
+        },
+    }
+}
+
+#[derive(Serialize)]
+struct ResultRecord {
+    ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    duration_ms: u64,
+}
+
+#[derive(Serialize)]
+struct AuditRecord<'a> {
+    v: u32,
+    seq: u64,
+    ts: String,
+    session: Option<String>,
+    action: &'a str,
+    target: Value,
+    args: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content: Option<Value>,
+    result: ResultRecord,
+}
+
+struct SinkState {
+    writer: Box<dyn Write + Send>,
+    seq: u64,
+    session: Option<String>,
+    dropped: u64,
+}
+
+/// Append-only JSONL audit sink. Only constructed when auditing is enabled.
+pub struct JsonlSink {
+    state: Mutex<SinkState>,
+    cfg: AuditConfig,
+}
+
+impl JsonlSink {
+    #[cfg(test)]
+    pub fn with_writer(writer: Box<dyn Write + Send>, cfg: AuditConfig) -> Self {
+        JsonlSink {
+            state: Mutex::new(SinkState { writer, seq: 0, session: None, dropped: 0 }),
+            cfg,
+        }
+    }
+}
+
+impl AuditSink for JsonlSink {
+    fn record(&self, act: &Actuation, ctx: &ActuationContext, outcome: &AuditOutcome, dur: Duration) {
+        let Some((action, args, raw)) = describe(act) else { return };
+        let mut st = self.state.lock().unwrap_or_else(|p| p.into_inner());
+        st.seq += 1;
+        if action == "launch" {
+            st.session = Some(mint_session());
+        }
+        let session = st.session.clone();
+        let rec = AuditRecord {
+            v: 1,
+            seq: st.seq,
+            ts: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+            session,
+            action,
+            target: target_json(act, ctx),
+            args,
+            content: raw.as_deref().and_then(|r| render_content(r, &self.cfg)),
+            result: ResultRecord {
+                ok: outcome.ok,
+                error: outcome.error.clone(),
+                duration_ms: u64::try_from(dur.as_millis()).unwrap_or(u64::MAX),
+            },
+        };
+        if action == "stop" {
+            st.session = None;
+        }
+        match serde_json::to_string(&rec) {
+            Ok(mut line) => {
+                line.push('\n');
+                if let Err(e) = st.writer.write_all(line.as_bytes()).and_then(|_| st.writer.flush()) {
+                    st.dropped += 1;
+                    eprintln!("glass: AUDIT WRITE FAILED (seq {}): {e} — record dropped", st.seq);
+                }
+            }
+            Err(e) => {
+                st.dropped += 1;
+                eprintln!("glass: AUDIT SERIALIZE FAILED (seq {}): {e}", st.seq);
+            }
+        }
+    }
+}
+
+fn mint_session() -> String {
+    let mut b = [0u8; 8];
+    rand::rngs::OsRng.fill_bytes(&mut b);
+    format!("s-{}", b.iter().map(|x| format!("{x:02x}")).collect::<String>())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use glass_core::{
+        Actuation, ActuationContext, AuditOutcome, ElementRef, KeyEvent, MouseButton, PointerEvent,
+        WindowRef,
+    };
+    use std::io::Write;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    #[derive(Clone)]
+    struct Buf(Arc<Mutex<Vec<u8>>>);
+    impl Write for Buf {
+        fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(b);
+            Ok(b.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    fn ok() -> AuditOutcome {
+        AuditOutcome { ok: true, error: None }
+    }
+    fn lines(b: &Arc<Mutex<Vec<u8>>>) -> Vec<serde_json::Value> {
+        String::from_utf8(b.lock().unwrap().clone())
+            .unwrap()
+            .lines()
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect()
+    }
+    fn win_ctx() -> ActuationContext {
+        ActuationContext { window: Some(WindowRef { id: 7, title: Some("W".into()) }) }
+    }
+
+    #[test]
+    fn redacted_content_has_len_sha256_prefix_no_text() {
+        let cfg = AuditConfig { content: ContentMode::Redacted, prefix_len: 8 };
+        let v = render_content("hunter2!!", &cfg).unwrap();
+        assert_eq!(v["len"], 9);
+        assert_eq!(v["prefix"], "hunter2!");
+        assert!(v["sha256"].is_string());
+        assert!(v.get("text").is_none());
+    }
+
+    #[test]
+    fn prefix_utf8_safe_and_zero_len_omits() {
+        let v =
+            render_content("éà-x", &AuditConfig { content: ContentMode::Redacted, prefix_len: 2 })
+                .unwrap();
+        assert_eq!(v["prefix"], "éà");
+        let v0 = render_content(
+            "x",
+            &AuditConfig { content: ContentMode::Redacted, prefix_len: 0 },
+        )
+        .unwrap();
+        assert!(v0.get("prefix").is_none());
+    }
+
+    #[test]
+    fn full_mode_has_text_none_mode_omits() {
+        let f =
+            render_content("s", &AuditConfig { content: ContentMode::Full, prefix_len: 8 }).unwrap();
+        assert_eq!(f["text"], "s");
+        assert!(render_content("s", &AuditConfig { content: ContentMode::None, prefix_len: 8 })
+            .is_none());
+    }
+
+    #[test]
+    fn type_maps_to_action_with_redacted_content_and_window_target() {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let s = JsonlSink::with_writer(Box::new(Buf(buf.clone())), AuditConfig::default());
+        s.record(
+            &Actuation::Key { event: &KeyEvent::Text("pw".into()) },
+            &win_ctx(),
+            &ok(),
+            Duration::from_millis(3),
+        );
+        let r = &lines(&buf)[0];
+        assert_eq!(r["action"], "type");
+        assert_eq!(r["target"]["window"]["id"], 7);
+        assert_eq!(r["content"]["len"], 2);
+        assert!(r["content"].get("text").is_none());
+        assert_eq!(r["result"]["ok"], true);
+    }
+
+    #[test]
+    fn click_maps_args_key_chord_in_args() {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let s = JsonlSink::with_writer(Box::new(Buf(buf.clone())), AuditConfig::default());
+        s.record(
+            &Actuation::Pointer {
+                event: &PointerEvent::Click {
+                    x: 4,
+                    y: 5,
+                    button: MouseButton::Right,
+                    count: 2,
+                    modifiers: vec![],
+                },
+            },
+            &win_ctx(),
+            &ok(),
+            Duration::from_millis(1),
+        );
+        s.record(
+            &Actuation::Key { event: &KeyEvent::Chord("ctrl+s".into()) },
+            &win_ctx(),
+            &ok(),
+            Duration::from_millis(1),
+        );
+        let r = lines(&buf);
+        assert_eq!(r[0]["action"], "click");
+        assert_eq!(r[0]["args"]["x"], 4);
+        assert_eq!(r[0]["args"]["button"], "right");
+        assert_eq!(r[0]["args"]["count"], 2);
+        assert_eq!(r[1]["action"], "key");
+        assert_eq!(r[1]["args"]["chord"], "ctrl+s");
+        assert!(r[1].get("content").is_none());
+    }
+
+    #[test]
+    fn move_is_not_written() {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let s = JsonlSink::with_writer(Box::new(Buf(buf.clone())), AuditConfig::default());
+        s.record(
+            &Actuation::Pointer { event: &PointerEvent::Move { x: 1, y: 1 } },
+            &win_ctx(),
+            &ok(),
+            Duration::from_millis(1),
+        );
+        assert!(buf.lock().unwrap().is_empty(), "Move is excluded in v1");
+    }
+
+    #[test]
+    fn set_value_targets_element() {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let s = JsonlSink::with_writer(Box::new(Buf(buf.clone())), AuditConfig::default());
+        let el = ElementRef { id: 5, role: Some("PasswordField".into()), name: Some("Password".into()) };
+        s.record(
+            &Actuation::SetValue { element: el, text: "v" },
+            &ActuationContext::default(),
+            &ok(),
+            Duration::from_millis(1),
+        );
+        let r = &lines(&buf)[0];
+        assert_eq!(r["action"], "set_value");
+        assert_eq!(r["target"]["element"]["id"], 5);
+        assert_eq!(r["target"]["element"]["role"], "PasswordField");
+        assert_eq!(r["content"]["len"], 1);
+    }
+}

--- a/crates/glass-mcp/src/cli.rs
+++ b/crates/glass-mcp/src/cli.rs
@@ -17,6 +17,12 @@ use clap::{Parser, Subcommand};
 pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Command>,
+
+    /// Append a JSONL audit log of every actuation to PATH (also GLASS_AUDIT_LOG).
+    /// Opt-in; off when unset. Content redacted by default
+    /// (GLASS_AUDIT_CONTENT=none|redacted|full, GLASS_AUDIT_PREFIX_LEN=N).
+    #[arg(long, global = true, value_name = "PATH")]
+    pub audit_log: Option<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -101,6 +107,16 @@ mod tests {
     fn gen_token_subcommand_is_kebab_case() {
         let cli = Cli::try_parse_from(["glass-mcp", "gen-token", "--out", "/p"]).unwrap();
         assert!(matches!(cli.command, Some(Command::GenToken { out: Some(_) })));
+    }
+
+    #[test]
+    fn audit_log_is_global_and_optional() {
+        let c = Cli::try_parse_from(["glass-mcp", "--audit-log", "/p"]).unwrap();
+        assert!(c.command.is_none());
+        assert_eq!(c.audit_log.as_deref(), Some("/p"));
+        let c = Cli::try_parse_from(["glass-mcp", "serve", "--http", "--audit-log", "/q"]).unwrap();
+        assert_eq!(c.audit_log.as_deref(), Some("/q"));
+        assert!(Cli::try_parse_from(["glass-mcp"]).unwrap().audit_log.is_none());
     }
 
     #[test]

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -8,6 +8,15 @@ use glass_core::{Check, CheckStatus, Diagnosis, Section};
 /// Build the full environment report. `deep` spawns and tears down the default
 /// backend's headless display to verify it actually starts.
 pub fn diagnose(deep: bool) -> Diagnosis {
+    diagnose_inner(deep, None)
+}
+
+/// Like `diagnose`, plus an "audit" section describing the audit-log posture.
+pub fn diagnose_with_audit(deep: bool, report: &crate::audit::AuditReport) -> Diagnosis {
+    diagnose_inner(deep, Some(report))
+}
+
+fn diagnose_inner(deep: bool, audit: Option<&crate::audit::AuditReport>) -> Diagnosis {
     let backend = crate::default_backend(std::env::var("GLASS_BACKEND").ok().as_deref());
 
     let backend_detail = match std::env::var("GLASS_BACKEND") {
@@ -80,7 +89,25 @@ pub fn diagnose(deep: bool) -> Diagnosis {
         ));
     }
 
+    if let Some(report) = audit {
+        sections.push(audit_section(report));
+    }
+
     Diagnosis::new(sections)
+}
+
+fn audit_section(report: &crate::audit::AuditReport) -> Section {
+    let (status, detail) = if report.enabled {
+        let mode = match report.content {
+            crate::audit::ContentMode::None => "none",
+            crate::audit::ContentMode::Redacted => "redacted",
+            crate::audit::ContentMode::Full => "full",
+        };
+        (CheckStatus::Ok, format!("on → {} (content: {mode})", report.path.as_deref().unwrap_or("?")))
+    } else {
+        (CheckStatus::Skip, "off (set --audit-log/GLASS_AUDIT_LOG to enable)".to_string())
+    };
+    Section::new("audit", None, vec![Check::new("audit log", status, detail)])
 }
 
 #[cfg(test)]
@@ -124,5 +151,15 @@ mod tests {
         assert!(!placeholder, "no 'not built into this binary' placeholders when network is compiled in");
         #[cfg(not(feature = "network"))]
         let _ = placeholder; // network shows its own Skip line in the stdio-only build
+    }
+
+    #[test]
+    fn diagnose_with_audit_reports_posture() {
+        let on = crate::audit::AuditReport { enabled: true, path: Some("/v/g.jsonl".into()), content: crate::audit::ContentMode::Redacted, prefix_len: 8 };
+        let t = diagnose_with_audit(false, &on).render_text("x11");
+        assert!(t.contains("audit") && t.contains("/v/g.jsonl") && t.contains("redacted"), "{t}");
+        let off = crate::audit::AuditReport { enabled: false, path: None, content: crate::audit::ContentMode::Redacted, prefix_len: 8 };
+        let t = diagnose_with_audit(false, &off).render_text("x11").to_lowercase();
+        assert!(t.contains("audit") && t.contains("off"), "{t}");
     }
 }

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -12,6 +12,7 @@ pub fn diagnose(deep: bool) -> Diagnosis {
 }
 
 /// Like `diagnose`, plus an "audit" section describing the audit-log posture.
+/// Used by the `doctor` CLI subcommand and the `glass_doctor` MCP tool.
 pub fn diagnose_with_audit(deep: bool, report: &crate::audit::AuditReport) -> Diagnosis {
     diagnose_inner(deep, Some(report))
 }
@@ -103,7 +104,9 @@ fn audit_section(report: &crate::audit::AuditReport) -> Section {
             crate::audit::ContentMode::Redacted => "redacted",
             crate::audit::ContentMode::Full => "full",
         };
-        (CheckStatus::Ok, format!("on → {} (content: {mode})", report.path.as_deref().unwrap_or("?")))
+        // Invariant (set by audit::resolve/report_from_config): enabled ⇒ path is Some.
+        let path = report.path.as_deref().expect("AuditReport: enabled implies a path");
+        (CheckStatus::Ok, format!("on → {path} (content: {mode})"))
     } else {
         (CheckStatus::Skip, "off (set --audit-log/GLASS_AUDIT_LOG to enable)".to_string())
     };

--- a/crates/glass-mcp/src/env.rs
+++ b/crates/glass-mcp/src/env.rs
@@ -84,6 +84,15 @@ pub(crate) const GLASS_ENV: &[EnvVarDoc] = &[
     EnvVarDoc { name: "GLASS_TOKEN", scope: EnvScope::Network,
         purpose: "Bearer token for the serve --http transport",
         default: "(none)", secret: true },
+    EnvVarDoc { name: "GLASS_AUDIT_LOG", scope: EnvScope::All,
+        purpose: "Append a JSONL audit log of every actuation to this path (opt-in)",
+        default: "(off)", secret: false },
+    EnvVarDoc { name: "GLASS_AUDIT_CONTENT", scope: EnvScope::All,
+        purpose: "Audit content detail: none | redacted | full",
+        default: "redacted", secret: false },
+    EnvVarDoc { name: "GLASS_AUDIT_PREFIX_LEN", scope: EnvScope::All,
+        purpose: "Chars of plaintext prefix kept in redacted audit content (0 = none)",
+        default: "8", secret: false },
 ];
 
 /// Standard (non-`GLASS_*`) env glass reads at runtime — reference only.
@@ -214,6 +223,7 @@ mod tests {
             "GLASS_BACKEND", "GLASS_SANDBOX", "GLASS_DISPLAY", "GLASS_XVFB_SCREEN",
             "GLASS_XVFB", "GLASS_SWAY", "GLASS_BWRAP", "GLASS_SH",
             "GLASS_WIN_SANDBOX_PROVIDER", "GLASS_SANDBOXIE_DIR", "GLASS_TOKEN",
+            "GLASS_AUDIT_LOG", "GLASS_AUDIT_CONTENT", "GLASS_AUDIT_PREFIX_LEN",
         ];
         for name in expected {
             let n = GLASS_ENV.iter().filter(|d| d.name == name).count();

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -84,9 +84,10 @@ pub fn run_env(json: bool) -> ! {
 }
 
 /// Run the `doctor` subcommand and exit.
-pub fn run_doctor(deep: bool, json: bool) -> ! {
+pub fn run_doctor(deep: bool, json: bool, audit_log: Option<&str>) -> ! {
     let backend = default_backend(std::env::var("GLASS_BACKEND").ok().as_deref());
-    let diag = doctor::diagnose(deep);
+    let report = audit::report_from_config(audit_log, |k| std::env::var(k).ok());
+    let diag = doctor::diagnose_with_audit(deep, &report);
     if json {
         println!("{}", serde_json::to_string_pretty(&diag).expect("serialize diagnosis"));
     } else {
@@ -95,16 +96,18 @@ pub fn run_doctor(deep: bool, json: bool) -> ! {
     std::process::exit(diag.exit_code(backend));
 }
 
-/// Build the `Glass` session manager (backend built lazily per `glass_start`).
-pub fn boot() -> Glass {
+/// Build the `Glass` session manager, installing the audit sink if one is configured.
+pub fn boot(audit: Option<Box<dyn glass_core::AuditSink>>) -> Glass {
     let default = default_backend(std::env::var("GLASS_BACKEND").ok().as_deref()).to_string();
     let baselines = BaselineStore::new(".glass/baselines");
-    Glass::new(Box::new(make_platform), default, baselines, 10_000)
+    let mut glass = Glass::new(Box::new(make_platform), default, baselines, 10_000);
+    if let Some(sink) = audit { glass.set_audit_sink(sink); }
+    glass
 }
 
 /// Serve MCP over stdio (the default transport) and tear down on EOF or signal.
-pub async fn run_stdio(glass: Glass) -> anyhow::Result<()> {
-    let server = GlassServer::new(glass);
+pub async fn run_stdio(glass: Glass, report: crate::audit::AuditReport) -> anyhow::Result<()> {
+    let server = GlassServer::new(glass, report);
     let sessions = server.sessions();
     let service = server.serve(stdio()).await.context("starting the MCP stdio service")?;
 

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -1,6 +1,7 @@
 //! glass-mcp library root. `main.rs` is a thin binary over this so the serve
 //! path is reachable from integration tests.
 
+pub mod audit;
 pub mod cli;
 pub mod doctor;
 mod env;

--- a/crates/glass-mcp/src/main.rs
+++ b/crates/glass-mcp/src/main.rs
@@ -4,19 +4,27 @@ use glass_mcp::{boot, run_doctor, run_env, run_stdio};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    match Cli::parse().command {
+    let cli = Cli::parse();
+    let audit_log = cli.audit_log;
+    match cli.command {
         // No subcommand: serve MCP over stdio (the default).
-        None => run_stdio(boot()).await,
-        Some(Command::Doctor { deep, json }) => run_doctor(deep, json),
+        None => {
+            let (sink, report) =
+                glass_mcp::audit::resolve(audit_log.as_deref(), |k| std::env::var(k).ok())?;
+            run_stdio(boot(sink), report).await
+        }
+        Some(Command::Doctor { deep, json }) => run_doctor(deep, json, audit_log.as_deref()),
         Some(Command::Env { json }) => run_env(json),
         Some(Command::Serve { http, addr, token_file }) => {
             #[cfg(feature = "network")]
             {
-                glass_mcp::serve::run(http, addr, token_file).await
+                let (sink, report) =
+                    glass_mcp::audit::resolve(audit_log.as_deref(), |k| std::env::var(k).ok())?;
+                glass_mcp::serve::run(http, addr, token_file, sink, report).await
             }
             #[cfg(not(feature = "network"))]
             {
-                let _ = (http, addr, token_file);
+                let _ = (http, addr, token_file, &audit_log);
                 anyhow::bail!(
                     "`serve` (the network transport) is not included in this build; it \
                      requires the default-on `network` feature, which a \

--- a/crates/glass-mcp/src/main.rs
+++ b/crates/glass-mcp/src/main.rs
@@ -6,6 +6,8 @@ use glass_mcp::{boot, run_doctor, run_env, run_stdio};
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     let audit_log = cli.audit_log;
+    // Resolve (and OPEN, fail-closed) the audit sink only in the serving arms below —
+    // never for doctor/env/gen-token, so those never create the audit file as a side effect.
     match cli.command {
         // No subcommand: serve MCP over stdio (the default).
         None => {

--- a/crates/glass-mcp/src/serve/mod.rs
+++ b/crates/glass-mcp/src/serve/mod.rs
@@ -42,6 +42,8 @@ pub async fn run(
     http: bool,
     addr: Option<String>,
     token_file: Option<String>,
+    sink: Option<Box<dyn glass_core::AuditSink>>,
+    report: crate::audit::AuditReport,
 ) -> anyhow::Result<()> {
     // Delegate to the audited resolver (token precedence + exposure rules + its tests stay
     // the single source of truth); just reconstruct its flag form from clap's typed args.
@@ -84,7 +86,7 @@ pub async fn run(
     let listener = tokio::net::TcpListener::bind(cfg.addr)
         .await
         .with_context(|| format!("binding {}", cfg.addr))?;
-    run_on(listener, cfg, crate::boot()).await
+    run_on(listener, cfg, crate::boot(sink), report).await
 }
 
 /// Serve on an already-bound listener (so tests can bind `127.0.0.1:0`).
@@ -92,8 +94,9 @@ pub async fn run_on(
     listener: tokio::net::TcpListener,
     cfg: ServeConfig,
     glass: glass_core::Glass,
+    report: crate::audit::AuditReport,
 ) -> anyhow::Result<()> {
-    let server = GlassServer::new(glass);
+    let server = GlassServer::new(glass, report);
     let sessions = server.sessions();
 
     let cancel = CancellationToken::new();

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -10,6 +10,7 @@ use rmcp::model::{CallToolResult, Content, ServerCapabilities, ServerInfo};
 use rmcp::{ErrorData as McpError, ServerHandler, tool, tool_handler, tool_router};
 use tokio::sync::Mutex;
 
+use crate::audit::AuditReport;
 use crate::params::*;
 use crate::tools::{self, OutContent, ToolOutput, ToolResult};
 
@@ -25,6 +26,8 @@ pub struct GlassServer {
     glass: Arc<Mutex<Glass>>,
     /// Hands tool bodies to the long-lived `glass-platform` thread.
     jobs: std::sync::mpsc::Sender<Job>,
+    /// Audit-log posture, carried for `glass_doctor` display.
+    report: AuditReport,
     tool_router: ToolRouter<GlassServer>,
 }
 
@@ -57,7 +60,7 @@ fn map_tool_result(result: ToolResult) -> CallToolResult {
 
 #[tool_router]
 impl GlassServer {
-    pub fn new(glass: Glass) -> Self {
+    pub fn new(glass: Glass, report: AuditReport) -> Self {
         let glass = Arc::new(Mutex::new(glass));
         let (jobs, rx) = std::sync::mpsc::channel::<Job>();
         // One long-lived OS thread runs EVERY tool body. Tool bodies that spawn a
@@ -82,7 +85,7 @@ impl GlassServer {
                 }
             })
             .expect("spawn glass-platform thread");
-        Self { glass, jobs, tool_router: Self::tool_router() }
+        Self { glass, jobs, report, tool_router: Self::tool_router() }
     }
 
     /// A clone of the shared session registry, for the process-exit teardown path in
@@ -227,7 +230,8 @@ impl GlassServer {
         let deep = a.deep.unwrap_or(false);
         // The probes are blocking (and `deep` spawns a display), so keep them off the
         // stdio reactor thread.
-        let diag = tokio::task::spawn_blocking(move || crate::doctor::diagnose(deep))
+        let report = self.report.clone();
+        let diag = tokio::task::spawn_blocking(move || crate::doctor::diagnose_with_audit(deep, &report))
             .await
             .expect("doctor task panicked");
         Ok(to_call_result(ToolOutput::text(diag.render_text(backend))))

--- a/crates/glass-mcp/src/shutdown.rs
+++ b/crates/glass-mcp/src/shutdown.rs
@@ -80,7 +80,9 @@ mod tests {
         fn send_pointer(&mut self, _e: &PointerEvent) -> Result<()> { unimplemented!() }
         fn send_key(&mut self, _e: &KeyEvent) -> Result<()> { unimplemented!() }
         fn window(&mut self, _o: &WindowOp) -> Result<WindowGeometry> { unimplemented!() }
-        fn list_windows(&mut self) -> Result<Vec<WindowInfo>> { unimplemented!() }
+        // start_on() lists windows (best-effort) to attribute audit records, so this
+        // must answer rather than panic; no windows is fine for the shutdown test.
+        fn list_windows(&mut self) -> Result<Vec<WindowInfo>> { Ok(vec![]) }
         fn select_window(&mut self, _id: WindowId) -> Result<WindowGeometry> { unimplemented!() }
         fn drain_logs(&mut self) -> Vec<(Stream, String)> { vec![] }
     }

--- a/crates/glass-mcp/tests/network_roundtrip.rs
+++ b/crates/glass-mcp/tests/network_roundtrip.rs
@@ -16,9 +16,10 @@ async fn start_server(token: Option<&str>) -> String {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let cfg = ServeConfig { addr, token: token.map(String::from) };
-    let glass = glass_mcp::boot();
+    let glass = glass_mcp::boot(None);
+    let report = glass_mcp::audit::report_from_config(None, |_| None);
     tokio::spawn(async move {
-        let _ = glass_mcp::serve::run_on(listener, cfg, glass).await;
+        let _ = glass_mcp::serve::run_on(listener, cfg, glass, report).await;
     });
     // Give the listener a beat to start accepting.
     tokio::time::sleep(Duration::from_millis(50)).await;

--- a/crates/glass-testapp/tests/network.rs
+++ b/crates/glass-testapp/tests/network.rs
@@ -26,10 +26,11 @@ async fn network_screenshot_over_http() {
     // Start serve on an ephemeral loopback port.
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
-    let glass = glass_mcp::boot();
+    let glass = glass_mcp::boot(None);
+    let report = glass_mcp::audit::report_from_config(None, |_| None);
     tokio::spawn(async move {
         let cfg = ServeConfig { addr, token: Some("e2e".into()) };
-        let _ = glass_mcp::serve::run_on(listener, cfg, glass).await;
+        let _ = glass_mcp::serve::run_on(listener, cfg, glass, report).await;
     });
     // Give the listener a beat to start accepting.
     tokio::time::sleep(Duration::from_millis(50)).await;

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -780,9 +780,14 @@ impl Platform for X11Platform {
     fn send_key(&mut self, event: &KeyEvent) -> Result<()> {
         match event {
             KeyEvent::Text(text) => {
-                for c in text.chars() {
-                    let keysym = glass_core::keys::keysym_for_char(c)
-                        .ok_or_else(|| GlassError::InvalidKey(format!("untypable char {c:?}")))?;
+                // Identify an untypable char by its POSITION, never its value: this error
+                // is recorded verbatim in the audit log's `result.error`, which is not
+                // run through content redaction, so embedding the char would leak typed
+                // content. The caller can recover the char from its own input + the index.
+                for (i, c) in text.chars().enumerate() {
+                    let keysym = glass_core::keys::keysym_for_char(c).ok_or_else(|| {
+                        GlassError::InvalidKey(format!("char at index {i} has no X11 keysym"))
+                    })?;
                     self.key_with_mods(keysym, false, &[])?;
                 }
             }


### PR DESCRIPTION
## Summary

- Adds an **opt-in, append-only JSONL audit log** of every actuation glass performs — launch/stop, type, key, click, drag, scroll, set_value, clipboard writes, element clicks, window focus/resize/move, and each `glass_do` sub-action. Reads (screenshots, diffs, a11y snapshots, log/clipboard reads) are **not** logged.
- Hooked at a **core actuation seam** in `glass-core`: an `AuditSink` trait that `Glass` invokes after every actuation choke-point, so no actuation — current or future, tool or not — can bypass the log. `glass-mcp` supplies the concrete `JsonlSink` (mapping + redaction + JSONL I/O); `glass-core` stays platform-agnostic (data + trait only, no new deps).
- **Opt-in** via `--audit-log <path>` / `GLASS_AUDIT_LOG`; disabled installs no sink (zero cost). Content (typed text, clipboard, set_value, launch command) is **redacted by default** to `{len, sha256, prefix}`. Tunable: `GLASS_AUDIT_CONTENT=none|redacted|full`, `GLASS_AUDIT_PREFIX_LEN=<n>`.
- **Robust:** open failure is fail-closed (refuses to start); write failure is loud-to-stderr + counted + non-fatal (a `seq` gap marks the loss). `glass-mcp doctor` reports whether auditing is on, the path, and the content mode.
- One new permissively-licensed dependency: `sha2`.

Record shape (one JSON object per line):
```json
{"v":1,"seq":42,"ts":"…Z","session":"s-…","action":"type",
 "target":{"window":{"id":…,"title":…}},"content":{"len":19,"sha256":"…","prefix":"…"},
 "result":{"ok":true,"duration_ms":48}}
```

## Security notes

- Typed/clipboard/launch **content** is redacted by default; `full` mode is strictly opt-in.
- **Plaintext by design** (attribution, not content, and so outside `GLASS_AUDIT_CONTENT`): the active window `title`, an element's `role`/`name`, and the short content `prefix` (default 8 chars; `GLASS_AUDIT_PREFIX_LEN=0` drops it). Treat the log as confidential. Launch records intentionally omit `env`/`cwd`.
- A focused security + concurrency review of this branch found and fixed a narrow typed-content leak (an X11 `send_key` error embedded a char of the typed text, which `result.error` records unredacted — now identified by index); no concurrency bugs were found.

## Test Plan

- [ ] `cargo test --workspace` — unit (core-seam recording, JsonlSink mapping/redaction/I-O, fail-closed) + an end-to-end record-through-the-tool-layer test
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] Manual: `glass-mcp --audit-log /tmp/a.jsonl` driving an app → one JSONL line per actuation, reads absent, content redacted, no plaintext secret in the file
- [ ] `glass-mcp doctor` reports audit on/off + path + content mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)