### PR TITLE
fix(windows): adopt the boxed app window, not glass's launcher console, under Sandboxie

### DIFF
--- a/crates/glass-windows/src/containment/mod.rs
+++ b/crates/glass-windows/src/containment/mod.rs
@@ -150,6 +150,15 @@ mod imp {
                 Launched::Sandboxie(a) => a.pids(),
             }
         }
+        /// The window-class prefix that positively identifies this launch's app windows, when the
+        /// containment renames them. `None` for unconfined launches (no renaming); for Sandboxie,
+        /// `Sandbox:<box>:` — so discovery skips glass's own launcher console (left unrenamed).
+        pub(crate) fn adoption_class_prefix(&self) -> Option<String> {
+            match self {
+                Launched::Unconfined(_) => None,
+                Launched::Sandboxie(a) => Some(a.adoption_class_prefix()),
+            }
+        }
         pub(crate) fn try_wait(&mut self) -> std::io::Result<Option<std::process::ExitStatus>> {
             match self {
                 Launched::Unconfined(a) => a.try_wait(),

--- a/crates/glass-windows/src/containment/sandboxie.rs
+++ b/crates/glass-windows/src/containment/sandboxie.rs
@@ -439,6 +439,13 @@ impl SandboxieApp {
         pids
     }
 
+    /// The class prefix Sandboxie stamps on this box's app windows (`Sandbox:<box>:`). Window
+    /// discovery requires it under containment so it adopts the real boxed app window and skips
+    /// glass's own interposed launcher console (which Sandboxie leaves as `ConsoleWindowClass`).
+    pub(crate) fn adoption_class_prefix(&self) -> String {
+        format!("Sandbox:{}:", self.box_name)
+    }
+
     /// Always `Ok(None)`: the `Start.exe` wrapper exits right after handing off to the box, so
     /// its exit does not signal the app's; and a `std::process::ExitStatus` for the contained
     /// app cannot be synthesized here. Discovery relies on `pids()` / the start timeout instead.

--- a/crates/glass-windows/src/discovery.rs
+++ b/crates/glass-windows/src/discovery.rs
@@ -65,6 +65,18 @@ pub fn poll_decision(
     }
 }
 
+/// Whether a candidate window's class is adoptable, given the optional containment class prefix.
+///
+/// Sandboxie renames a boxed app's top-level window class to `Sandbox:<box>:<orig>`, but leaves
+/// glass's own interposed launcher console as `ConsoleWindowClass` (Sandboxie does not rename
+/// console windows). So under Sandboxie discovery requires the box prefix — that positively
+/// identifies the real app window and skips the launcher console, regardless of process topology
+/// (the boxed shell is reparented to `SbieSvc`, so a wrapper-parent walk can't find it). `None`
+/// (unconfined) accepts any class, since nothing renames windows there.
+pub fn class_adoptable(class: &str, class_prefix: Option<&str>) -> bool {
+    class_prefix.is_none_or(|p| class.starts_with(p))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -110,5 +122,21 @@ mod tests {
         assert_eq!(poll_decision(Some(Some(0)), true, false, true), PollStep::FailExited(Some(0)));
         assert_eq!(poll_decision(Some(Some(3)), false, true, true), PollStep::FailExited(Some(3)));
         assert_eq!(poll_decision(Some(Some(2)), false, false, true), PollStep::FailExited(Some(2)));
+    }
+
+    #[test]
+    fn class_adoptable_requires_box_prefix_under_sandboxie() {
+        let prefix = Some("Sandbox:glass_11128:");
+        assert!(class_adoptable("Sandbox:glass_11128:Notepad", prefix));
+        // glass's interposed launcher console keeps ConsoleWindowClass — not adoptable.
+        assert!(!class_adoptable("ConsoleWindowClass", prefix));
+        // a window from a different Sandboxie box is not ours.
+        assert!(!class_adoptable("Sandbox:other_box:Foo", prefix));
+    }
+
+    #[test]
+    fn class_adoptable_accepts_any_class_when_unconfined() {
+        assert!(class_adoptable("ConsoleWindowClass", None));
+        assert!(class_adoptable("Chrome_WidgetWin_1", None));
     }
 }

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -125,7 +125,8 @@ mod backend {
                 // same reason.) Recompute the pid union each iteration: a handoff child
                 // may only appear (and own the window) several polls in.
                 let pids = self.app_pids();
-                if let Some(w) = find_app_window(&pids, hint) {
+                let class_prefix = self.adoption_class_prefix();
+                if let Some(w) = find_app_window(&pids, hint, class_prefix.as_deref()) {
                     // A window passed the filter but has no DWM frame bounds yet (a transient
                     // splash destroyed mid-startup): don't fail — keep polling for the real one.
                     if let Some(r) = crate::util::extended_frame_bounds(w.hwnd()) {
@@ -160,6 +161,13 @@ mod backend {
                 }
                 std::thread::sleep(Duration::from_millis(50));
             }
+        }
+
+        /// The window-class prefix that positively identifies this launch's app windows (e.g.
+        /// `Sandbox:<box>:` under Sandboxie), or `None` when the launch doesn't rename windows.
+        /// Discovery requires it so it adopts the boxed app, not glass's own launcher console.
+        fn adoption_class_prefix(&self) -> Option<String> {
+            self.app.as_ref().and_then(|a| a.adoption_class_prefix())
         }
     }
 

--- a/crates/glass-windows/src/windows.rs
+++ b/crates/glass-windows/src/windows.rs
@@ -48,15 +48,25 @@ pub(crate) fn app_window_infos(pids: &[u32]) -> Vec<WinInfo> {
 }
 
 /// One scan implementing the discovery ladder:
-/// 1. the app's own process-set windows (the common case) — first match;
+/// 1. the app's own process-set windows (the common case) — first match whose class is adoptable
+///    (`class_prefix`: under Sandboxie only the boxed app's `Sandbox:<box>:`-renamed windows
+///    qualify, so glass's own launcher console — which Sandboxie leaves as `ConsoleWindowClass` —
+///    is skipped; `None` accepts any class);
 /// 2. else, if `hint` has a title, an app-like window whose title contains it
 ///    (handles an app that hands its UI to an unrelated process the pid-set misses);
 /// 3. else, if `hint` has a class, an app-like window whose class equals it.
 ///
 /// `pids` is the app's process set (Job list ∪ Toolhelp walk); rungs 2/3 don't use it.
 /// Returns the first match or `None`.
-pub(crate) fn find_app_window(pids: &[u32], hint: Option<&WindowHint>) -> Option<WinInfo> {
-    if let Some(w) = app_window_infos(pids).into_iter().next() {
+pub(crate) fn find_app_window(
+    pids: &[u32],
+    hint: Option<&WindowHint>,
+    class_prefix: Option<&str>,
+) -> Option<WinInfo> {
+    if let Some(w) = app_window_infos(pids)
+        .into_iter()
+        .find(|w| crate::discovery::class_adoptable(&w.class, class_prefix))
+    {
         return Some(w);
     }
     // Hint fallbacks (only reached when the pid-set rung misses — e.g. the app handed its UI

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -407,3 +407,34 @@ fn onbox_a11y_edge_geometry_fallback() {
     std::thread::sleep(Duration::from_secs(2));
     let _ = std::fs::remove_dir_all(&udd);
 }
+
+#[test]
+#[ignore = "on-box only: needs the interactive desktop session + Sandboxie"]
+fn onbox_contained_launch_adopts_app_not_console() {
+    dpi_aware_once();
+    let mut p = WindowsPlatform::new().expect("WindowsPlatform::new");
+    let spec = AppSpec {
+        build: None,
+        run: vec!["notepad.exe".to_string()],
+        cwd: None,
+        env: vec![],
+        window_hint: None, // the whole point: no hint needed once scaffolding is excluded
+        timeout_ms: 15_000,
+        sandbox: glass_core::SandboxLevel::Default,
+        a11y: false,
+    };
+    // Before the fix this "succeeds" by adopting the boxed `cmd /c launch.cmd` launcher console;
+    // the assertions below fail. After the fix, discovery adopts the boxed Notepad window.
+    let _geo = p
+        .start_app(&spec)
+        .expect("contained Notepad must adopt the app window, not the launcher console");
+    let windows = p.list_windows().expect("list_windows");
+    let active = windows.iter().find(|w| w.active).expect("an active adopted window");
+    let class = active.class.clone().unwrap_or_default();
+    assert_ne!(class, "ConsoleWindowClass", "glass_start adopted the Sandboxie launcher console");
+    assert!(
+        class.starts_with("Sandbox:"),
+        "expected a boxed app window class (Sandbox:<box>:...), got {class:?}"
+    );
+    p.stop_app().expect("stop_app");
+}


### PR DESCRIPTION
## Summary
- Under Sandboxie, `glass_start` adopted glass's own interposed `cmd /c launch.cmd` launcher console (`ConsoleWindowClass`) instead of the boxed app window, and `window_hint` couldn't correct it (rung 1 matched the console, so the hint rungs never ran).
- **Root cause** (from an on-box process/window dump): Sandboxie reparents boxed processes to its service (`SbieSvc`), so the cmd shell is *not* a child of glass's `Start.exe` wrapper — a pid/parent-link walk can't identify it. The reliable discriminator is the **window class**: Sandboxie renames a boxed app's top-level window to `Sandbox:<box>:<orig>` but leaves the launcher console as `ConsoleWindowClass`.
- **Fix:** discovery requires the box class prefix under containment (`discovery::class_adoptable`), threaded from `SandboxieApp::adoption_class_prefix` → `Launched` → `WindowsPlatform` into `find_app_window`'s rung 1. This positively identifies the boxed app window and skips the console, independent of process topology. Unconfined launches are unaffected (no prefix → any class); `looks_like_app_window` is untouched. All changes confined to `glass-windows`.

## Test Plan
- [x] `cargo test -p glass-windows discovery` (Linux host) — `class_adoptable` unit tests green
- [x] `cargo clippy -p glass-windows --all-targets -- -D warnings` on Windows — clean
- [x] On-box E2E `onbox_contained_launch_adopts_app_not_console` — a contained Notepad launch adopts `Sandbox:<box>:Notepad`, not the launcher console
- [x] Full `onbox` ignored suite (handoff / Edge / capture / a11y) — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)