### PR TITLE
fix(windows): run the build step unconfined under Sandboxie

### DIFF
--- a/crates/glass-windows/src/containment/build_onbox.rs
+++ b/crates/glass-windows/src/containment/build_onbox.rs
@@ -1,0 +1,53 @@
+//! On-box (LOTUS) validation that the build step runs UNCONFINED even under Sandboxie
+//! containment — only the launched *run* is the security boundary. Completes the Windows
+//! follow-on of `2026-06-11-unsandbox-build-design`. `#[ignore]`d: needs Sandboxie. No window is
+//! launched, so this runs over SSH (no interactive desktop required).
+
+use glass_core::{AppSpec, SandboxLevel};
+
+use super::imp::Containment;
+use super::sandboxie::{available, sandboxie_dir, Sandboxie};
+
+fn spec_with_build(build: String) -> AppSpec {
+    AppSpec {
+        build: Some(build),
+        run: vec!["notepad.exe".into()], // unused by run_build (it never launches)
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        timeout_ms: 1,
+        sandbox: SandboxLevel::Default,
+        a11y: false,
+    }
+}
+
+#[test]
+#[ignore = "on-box: needs Sandboxie"]
+fn build_runs_on_host_not_in_the_box() {
+    let dir = sandboxie_dir();
+    assert!(available(&dir), "Sandboxie not available at {dir}");
+
+    // A host path the build writes to. If the build runs CONTAINED, Sandboxie redirects the write
+    // into the box's copy-on-write store and this real path stays absent; if it runs UNCONFINED
+    // (correct — only the run is contained), the file lands on the real filesystem.
+    let marker =
+        std::env::temp_dir().join(format!("glass_build_marker_{}.txt", std::process::id()));
+    let _ = std::fs::remove_file(&marker);
+
+    let sb = Sandboxie::new(dir.clone(), format!("glass_buildtest_{}", std::process::id()));
+    sb.configure(SandboxLevel::Default).expect("configure box");
+    let containment = Containment::Sandboxie(sb);
+
+    // No quotes around the path (temp dir is space-free) — quoting it forces Rust's Command to
+    // backslash-escape the quotes through `cmd /C`, which mangles the redirect target.
+    let spec = spec_with_build(format!("echo built>{}", marker.display()));
+    containment.run_build(&spec).expect("run_build");
+
+    let landed = marker.exists();
+    let _ = std::fs::remove_file(&marker);
+    assert!(
+        landed,
+        "build must run on the HOST (marker on the real FS at {}), not inside the Sandboxie box",
+        marker.display()
+    );
+}

--- a/crates/glass-windows/src/containment/mod.rs
+++ b/crates/glass-windows/src/containment/mod.rs
@@ -14,6 +14,11 @@ mod sandboxie;
 #[cfg(all(test, windows))]
 mod clip_onbox;
 
+// On-box (LOTUS) validation that the build step runs unconfined even under Sandboxie. `#[ignore]`d
+// (needs Sandboxie); launches no window, so it runs over SSH.
+#[cfg(all(test, windows))]
+mod build_onbox;
+
 #[cfg(windows)]
 pub(crate) use imp::{resolve_containment, ClipboardRoute, Launched, LogSink};
 
@@ -87,11 +92,12 @@ mod imp {
     }
 
     impl Containment {
+        /// The optional build step runs UNCONFINED at every containment level — only the launched
+        /// *run* is the security boundary (`2026-06-11-unsandbox-build-design`; this completes the
+        /// deferred Windows follow-on). Containing the build bought nothing real and made even a
+        /// trivial build stall/fail under Sandboxie (the box isolates the toolchain/cache/network).
         pub(crate) fn run_build(&self, spec: &AppSpec) -> Result<()> {
-            match self {
-                Containment::Unconfined => crate::process::run_build_unconfined(spec),
-                Containment::Sandboxie(s) => s.run_build(spec),
-            }
+            crate::process::run_build_unconfined(spec)
         }
         /// Launch the app and wire its log readers into `logs`; returns the handle.
         pub(crate) fn launch(&self, spec: &AppSpec, logs: LogSink) -> Result<Launched> {

--- a/crates/glass-windows/src/containment/sandboxie.rs
+++ b/crates/glass-windows/src/containment/sandboxie.rs
@@ -10,7 +10,7 @@
 //! - `strict` additionally gates on the **global** `PromptForInternetAccess`: a `y` there
 //!   would deadlock a no-network box on a UI prompt, so we detect it and fail closed. We
 //!   never write `[GlobalSettings]`.
-//! - Build runs contained (`Start.exe /box:<box> /wait cmd /c <build>`).
+//! - The build step runs UNCONFINED (host) at every level — only the launched run is contained.
 //! - **Logs use a file fallback**: stdio pipes do NOT forward through `Start.exe`
 //!   (gate-proven), so the app is launched via a generated `launch.cmd` that redirects its
 //!   stdout/stderr to files in a per-session log dir glass owns, and reader threads tail
@@ -232,33 +232,6 @@ impl Sandboxie {
 
         // 5. reload so the service picks up the new box config.
         self.run_sbie(&start_exe(&dir), &["/reload"])?;
-        Ok(())
-    }
-
-    /// Run the optional build step contained: `Start.exe /box:<box> /wait cmd /c <build>`.
-    pub(crate) fn run_build(&self, spec: &AppSpec) -> Result<()> {
-        let Some(build) = &spec.build else {
-            return Ok(());
-        };
-        let mut cmd = Command::new(start_exe(&self.dir));
-        cmd.args([
-            &format!("/box:{}", self.box_name),
-            "/wait",
-            "cmd",
-            "/c",
-            build,
-        ]);
-        if let Some(dir) = &spec.cwd {
-            cmd.current_dir(dir);
-        }
-        let status = cmd
-            .status()
-            .map_err(|e| GlassError::AppNotStarted(format!("contained build: {e}")))?;
-        if !status.success() {
-            return Err(GlassError::AppNotStarted(format!(
-                "contained build failed with status {status}"
-            )));
-        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- The Windows Sandboxie path ran the optional `build` step **inside the box** (`Start.exe /box /wait cmd /c <build>`), so even a trivial build stalled + failed (60s+, exit 1) and `cargo build` never reached the host toolchain/cache/network — the **G1 operator-blocker** from the 2026-06-13 Windows dogfood (it stops a new operator cold with no real error).
- Completes the **deferred Windows follow-on** of `2026-06-11-unsandbox-build-design` (the Linux half shipped then): the build now runs on the host with the full dev env at **every** sandbox level; only the launched *run* is the security boundary. `Containment::run_build` always delegates to `run_build_unconfined`; the dead `Sandboxie::run_build` is removed. All changes confined to `glass-windows`.

## Test Plan
- [x] New on-box test `build_runs_on_host_not_in_the_box` — constructs a Sandboxie box, runs the build via `Containment::run_build`, asserts the marker lands on the **host** FS (not redirected into the box). RED before the fix (contained build failed, 60s+); GREEN after (0.19s).
- [x] `cargo clippy -p glass-windows --all-targets -- -D warnings` clean on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)