### PR TITLE
Drop a11y-windows unsafe: bind UIA via the adopted window handle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,6 @@ version = "0.0.0"
 dependencies = [
  "glass-core",
  "uiautomation",
- "windows",
 ]
 
 [[package]]

--- a/crates/glass-a11y-windows/Cargo.toml
+++ b/crates/glass-a11y-windows/Cargo.toml
@@ -11,7 +11,6 @@ glass-core.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 uiautomation = { version = "0.25", features = ["process"] }
-windows = { version = "0.62", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging"] }
 
 [lints]
 workspace = true

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -14,11 +14,6 @@ use uiautomation::patterns::{
 };
 use uiautomation::types::{ExpandCollapseState, Handle, Rect, ToggleState};
 use uiautomation::{UIAutomation, UIElement, UITreeWalker};
-use windows::core::BOOL;
-use windows::Win32::Foundation::{HWND, LPARAM, RECT};
-use windows::Win32::UI::WindowsAndMessaging::{
-    EnumWindows, GetWindowRect, GetWindowThreadProcessId, IsWindowVisible,
-};
 
 /// Hard cap so a hung UIA provider can't block the calling tool forever.
 const SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(10);
@@ -104,100 +99,20 @@ fn run_snapshot(ctx: &AxContext) -> Result<AxTree> {
     Ok(tree)
 }
 
-/// Find the launched app's top-level window and bind a UIA element to it.
-///
-/// Enumerates top-level windows with **Win32** (`EnumWindows` + `GetWindowThreadProcessId`) — pure
-/// HWND/kernel calls — then binds the chosen window with `element_from_handle`. The old approach
-/// walked the *desktop's UIA tree*, calling `get_process_id`/`get_bounding_rectangle` on **every**
-/// top-level window, including other apps'. A single foreign window whose UIA provider blocks
-/// cross-process calls on a worker thread (observed on a real desktop) wedged the entire snapshot.
-/// Touching only Win32 here, and the target window's own provider via `element_from_handle`, means
-/// no other app's provider is ever queried — the snapshot can't be held hostage by a misbehaving
-/// peer window.
-///
-/// Prefers a PID match against `ctx.pids` — the launched app's process *set* (root + the descendants
-/// the backend's Job enumerates), so a multi-process app (Electron/Edge) whose top-level window is
-/// owned by a DESCENDANT process still matches by pid. Disambiguates multiple matches, and falls back
-/// when no pid matches, by the rect closest to `ctx.window`. `AccessibilityUnavailable` if nothing
-/// matches.
+/// Bind a UIA element to glass's adopted window via its handle (`AxContext::window_handle`, set by
+/// the backend from its active `HWND`). a11y reads the *exact* window glass drives — the same handle
+/// `send_pointer`/`window` operate on — so it never enumerates the desktop or queries a peer app's
+/// UIA provider (a foreign provider that blocks cross-process calls on the worker thread could
+/// otherwise wedge the whole snapshot). `element_from_handle` touches only the target's provider.
 fn find_app_window(automation: &UIAutomation, ctx: &AxContext) -> Result<UIElement> {
-    let hwnd = find_app_window_handle(ctx)?;
-    automation
-        .element_from_handle(Handle::from(hwnd))
-        .map_err(uia_err)
-}
-
-/// The Win32 half of [`find_app_window`]: pick the best top-level window's `HWND` (as an `isize`).
-fn find_app_window_handle(ctx: &AxContext) -> Result<isize> {
-    let mut hwnds: Vec<HWND> = Vec::new();
-    // SAFETY: `collect_top_level` receives `&mut hwnds` via the LPARAM and only runs during this
-    // synchronous call, while `hwnds` is live on this stack frame.
-    unsafe {
-        let _ = EnumWindows(
-            Some(collect_top_level),
-            LPARAM(&mut hwnds as *mut Vec<HWND> as isize),
-        );
-    }
-
-    // rect distance to ctx.window (top-left + size), generous because the DWM extended-frame-bounds
-    // glass reports differs from the Win32 window rect by the invisible resize border (~7px/side).
-    let dist_to = |hwnd: HWND| -> Option<i64> {
-        let mut r = RECT::default();
-        // SAFETY: `hwnd` is a live top-level window from EnumWindows; `r` is written by the call.
-        unsafe { GetWindowRect(hwnd, &mut r) }.ok()?;
-        let (w, h) = (r.right - r.left, r.bottom - r.top);
-        if w <= 0 || h <= 0 {
-            return None; // zero-area / off-screen helper window
-        }
-        Some(
-            (r.left - ctx.window.x).abs() as i64
-                + (r.top - ctx.window.y).abs() as i64
-                + (w - ctx.window.width as i32).abs() as i64
-                + (h - ctx.window.height as i32).abs() as i64,
+    let handle = ctx.window_handle.ok_or_else(|| {
+        GlassError::AccessibilityUnavailable(
+            "no active window handle in the a11y context (the backend adopted no window)".into(),
         )
-    };
-
-    let mut by_pid: Option<(isize, i64)> = None; // closest among pid-matches
-    let mut by_geom: Option<(isize, i64)> = None; // closest visible overall (fallback)
-    for hwnd in hwnds {
-        // SAFETY: `hwnd` is a live top-level window from EnumWindows.
-        if !unsafe { IsWindowVisible(hwnd) }.as_bool() {
-            continue; // skip hidden message-only / helper windows
-        }
-        let Some(dist) = dist_to(hwnd) else { continue };
-        if by_geom.as_ref().map(|(_, d)| dist < *d).unwrap_or(true) {
-            by_geom = Some((hwnd.0 as isize, dist));
-        }
-        let mut got = 0u32;
-        // SAFETY: `hwnd` is live; `got` receives the owning pid.
-        unsafe { GetWindowThreadProcessId(hwnd, Some(&mut got)) };
-        let pid_ok = ctx.pids.is_empty() || ctx.pids.contains(&got);
-        if pid_ok && by_pid.as_ref().map(|(_, d)| dist < *d).unwrap_or(true) {
-            by_pid = Some((hwnd.0 as isize, dist));
-        }
-    }
-    if let Some((h, _)) = by_pid {
-        return Ok(h);
-    }
-    // No pid match: accept the geometry-closest window only if it's genuinely close (reject a wrong
-    // window). Tolerance is generous for the border delta; tuned on the box (Task 5).
-    const GEOM_TOLERANCE: i64 = 120;
-    if let Some((h, d)) = by_geom {
-        if d <= GEOM_TOLERANCE {
-            return Ok(h);
-        }
-    }
-    Err(GlassError::AccessibilityUnavailable(
-        "the app exposes no top-level window matching its pid or geometry (custom-drawn? fall back to screenshots)".into(),
-    ))
-}
-
-/// `EnumWindows` callback: append each top-level `HWND` to the `Vec<HWND>` carried in `lparam`.
-unsafe extern "system" fn collect_top_level(hwnd: HWND, lparam: LPARAM) -> BOOL {
-    // SAFETY: `lparam` is the `&mut Vec<HWND>` find_app_window_handle passed for this enumeration.
-    let hwnds = unsafe { &mut *(lparam.0 as *mut Vec<HWND>) };
-    hwnds.push(hwnd);
-    BOOL(1) // keep enumerating
+    })?;
+    automation
+        .element_from_handle(Handle::from(handle as isize))
+        .map_err(uia_err)
 }
 
 /// Recursively build a normalized node, bounded by depth + global node count.

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -284,6 +284,11 @@ pub struct AxContext {
     /// backend has a process-tree view (Windows' Job set); 1-element on X11/Wayland.
     pub pids: Vec<u32>,
     pub window: WindowGeometry,
+    /// Raw native handle of glass's active (adopted) window — a Windows `HWND` as `i64`. `Some`
+    /// whenever the backend tracks one; the Windows reader binds UI Automation directly to it (no
+    /// desktop re-discovery), so a11y reads the *exact* window glass is driving. `None` on backends
+    /// that address accessibility another way (Linux uses `a11y_bus_addr`); those ignore this field.
+    pub window_handle: Option<i64>,
     /// Address of the private a11y bus glass spawned for this launch, if any. `Some` only when the
     /// caller passed `a11y: true` and the bus started. When `None`, the Linux reader returns
     /// `AccessibilityUnavailable` (instructing the caller to relaunch with `a11y:true`) — it does

--- a/crates/glass-core/src/platform.rs
+++ b/crates/glass-core/src/platform.rs
@@ -190,6 +190,13 @@ pub trait Platform {
     fn a11y_bus_addr(&self) -> Option<String> {
         None
     }
+
+    /// Raw native handle of the active (adopted) window — a Windows `HWND` as `i64` — for the
+    /// accessibility reader to bind to directly (`AxContext::window_handle`). Default `None`;
+    /// backends that address a11y by bus (Linux) leave it unset.
+    fn active_window_handle(&self) -> Option<i64> {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/crates/glass-core/src/session.rs
+++ b/crates/glass-core/src/session.rs
@@ -442,9 +442,10 @@ impl Glass {
         let s = self.active_mut()?;
         let pids = s.platform.app_pids();
         let window = s.geometry.clone();
+        let window_handle = s.platform.active_window_handle();
         let a11y_bus_addr = s.platform.a11y_bus_addr();
         let acc = s.accessibility.as_mut().ok_or(GlassError::AxUnsupported)?;
-        let mut tree = acc.snapshot(&AxContext { pids, window, a11y_bus_addr })?;
+        let mut tree = acc.snapshot(&AxContext { pids, window, window_handle, a11y_bus_addr })?;
         tree.assign_ids();
         s.last_ax = Some(tree.clone());
         s.pump();
@@ -518,6 +519,7 @@ impl Glass {
             let ctx = AxContext {
                 pids: s.platform.app_pids(),
                 window: s.geometry.clone(),
+                window_handle: s.platform.active_window_handle(),
                 a11y_bus_addr: s.platform.a11y_bus_addr(),
             };
             (target, ctx)

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -324,6 +324,12 @@ mod backend {
         fn app_pids(&self) -> Vec<u32> {
             self.app.as_ref().map(|a| a.pids()).unwrap_or_default()
         }
+
+        /// The adopted window's `HWND` (as `i64`), so the a11y reader binds UI Automation straight
+        /// to the exact window glass drives — same handle `send_pointer`/`window` use.
+        fn active_window_handle(&self) -> Option<i64> {
+            self.active_hwnd.map(|h| h as i64)
+        }
     }
 
     impl Drop for WindowsPlatform {

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -231,7 +231,12 @@ fn onbox_a11y_snapshot_and_click() {
     std::thread::sleep(Duration::from_millis(1500));
 
     let mut a11y = WindowsA11y::new();
-    let ctx = AxContext { pids: p.app_pids(), window: geo.clone(), a11y_bus_addr: None };
+    let ctx = AxContext {
+        pids: p.app_pids(),
+        window: geo.clone(),
+        window_handle: p.active_window_handle(),
+        a11y_bus_addr: None,
+    };
     let tree = a11y.snapshot(&ctx).expect("a11y snapshot");
     assert!(tree.count > 0, "snapshot must have nodes");
     let (mut total, mut inter) = (0usize, 0usize);
@@ -315,7 +320,12 @@ fn onbox_modifier_click() {
     std::thread::sleep(Duration::from_millis(1200));
 
     let mut a11y = WindowsA11y::new();
-    let ctx = AxContext { pids: p.app_pids(), window: geo.clone(), a11y_bus_addr: None };
+    let ctx = AxContext {
+        pids: p.app_pids(),
+        window: geo.clone(),
+        window_handle: p.active_window_handle(),
+        a11y_bus_addr: None,
+    };
     let tree = a11y.snapshot(&ctx).expect("a11y snapshot");
     let mut hit = None;
     first_clickable(&tree.root, &mut hit);
@@ -381,7 +391,12 @@ fn onbox_a11y_set_value() {
     std::thread::sleep(Duration::from_millis(1500));
 
     let mut a11y = WindowsA11y::new();
-    let ctx = AxContext { pids: p.app_pids(), window: geo.clone(), a11y_bus_addr: None };
+    let ctx = AxContext {
+        pids: p.app_pids(),
+        window: geo.clone(),
+        window_handle: p.active_window_handle(),
+        a11y_bus_addr: None,
+    };
     let tree = a11y.snapshot(&ctx).expect("a11y snapshot");
 
     let mut field = None;
@@ -426,7 +441,12 @@ fn onbox_egui_set_value_honesty() {
     std::thread::sleep(Duration::from_millis(2000));
 
     let mut a11y = WindowsA11y::new();
-    let ctx = AxContext { pids: p.app_pids(), window: geo.clone(), a11y_bus_addr: None };
+    let ctx = AxContext {
+        pids: p.app_pids(),
+        window: geo.clone(),
+        window_handle: p.active_window_handle(),
+        a11y_bus_addr: None,
+    };
     let tree = a11y.snapshot(&ctx).expect("a11y snapshot of the egui fixture");
 
     // G2: egui exposes TextEdit as a read-only AccessKit projection — UIA SetValue is accepted
@@ -501,7 +521,7 @@ fn onbox_scroll_modifier_delivery_sandboxed() {
 
 #[test]
 #[ignore = "on-box only: needs the interactive desktop session + Edge"]
-fn onbox_a11y_edge_geometry_fallback() {
+fn onbox_a11y_edge_multiprocess() {
     let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     dpi_aware_once();
     let edge = glass_windows::onbox_support::locate_edge()
@@ -527,13 +547,19 @@ fn onbox_a11y_edge_geometry_fallback() {
         sandbox: glass_core::SandboxLevel::Off,
         a11y: false,
     };
-    // Edge's top-level window is owned by a DESCENDANT process, so the a11y reader's exact-pid match
-    // misses and the geometry fallback must recover it — the path charmap can't exercise.
+    // Edge's top-level window is owned by a DESCENDANT process. glass adopts it as the active window;
+    // the a11y reader reads it via that adopted handle (ctx.window_handle) — verifying a11y on a
+    // multi-process app whose window a single-process target like charmap can't exercise.
     let geo = p.start_app(&spec).expect("isolated Edge discovery (Job-child window)");
     std::thread::sleep(Duration::from_secs(6));
 
     let mut a11y = WindowsA11y::new();
-    let ctx = AxContext { pids: p.app_pids(), window: geo.clone(), a11y_bus_addr: None };
+    let ctx = AxContext {
+        pids: p.app_pids(),
+        window: geo.clone(),
+        window_handle: p.active_window_handle(),
+        a11y_bus_addr: None,
+    };
     let tree = a11y.snapshot(&ctx).expect("a11y snapshot on multi-process Edge");
     let (mut total, mut inter) = (0usize, 0usize);
     counts(&tree.root, &mut total, &mut inter);


### PR DESCRIPTION
Unsafe audit of the Windows dogfood series. Inventory: #29/#30/#32 added **no** unsafe; the only new unsafe was the **6 sites in `glass-a11y-windows/reader.rs`** (#31) — Win32 `EnumWindows` + `GetWindowRect` + `GetWindowThreadProcessId` re-discovering the app window on the worker thread, in a crate that previously had zero unsafe and no `windows` dep.

## Extraction
`WindowsPlatform` already tracks the adopted window's `HWND` (`active_hwnd` — exactly what `send_pointer`/`window` drive). Plumb it to the reader instead of re-discovering:

- `AxContext` gains `window_handle: Option<i64>` (raw native handle; a Windows `HWND`).
- `Platform` gains `active_window_handle()` (default `None`; Windows returns `active_hwnd`).
- The session fills it for `a11y_snapshot` and `set_value`.
- The reader binds UIA with `element_from_handle(window_handle)` — no desktop enumeration.

## Net
- **glass-a11y-windows: back to 0 unsafe, and the `windows` dependency dropped** (its only use was the enumeration).
- a11y reads the **exact** window glass drives, instead of re-guessing by pid+geometry — strictly more correct, and still never queries a peer app's UIA provider (the property that fixed the #31 hang).
- `onbox_a11y_edge_geometry_fallback` → `onbox_a11y_edge_multiprocess`: it reads the adopted descendant-owned window via its handle now (the geometry-fallback path it exercised is gone with the re-discovery).

## Test plan
- Linux: `cargo test --workspace` (excl. windows crates) compiles + green.
- On-box (3×-DPI host): `onbox_a11y_snapshot_and_click` (native UIA) and `onbox_egui_set_value_honesty` (accesskit) — both green via the handle path. build + clippy `--all-targets` clean on lotus.