### PR TITLE
Hold the modifier across the key's frame for synthetic chords

### DIFF
--- a/crates/glass-core/src/chord.rs
+++ b/crates/glass-core/src/chord.rs
@@ -1,0 +1,90 @@
+//! Platform-agnostic key-chord model: the `run_chord` driver that sequences a modifier+key chord
+//! against any backend's `ChordSink`, with the inter-phase dwell that makes a frame-based client
+//! register the modifier as *held across the key's frame*.
+
+use std::time::Duration;
+
+/// Dwell between a chord's phases (modifier-down → key → modifier-up). A synthetic chord injected as
+/// one burst is drained by a frame-based GUI (egui/winit) into a SINGLE frame, so the frame-aggregate
+/// modifier reads as already-released and the universal `key_pressed(K) && i.modifiers` hotkey idiom
+/// never fires. Holding the modifier across separate frames — like hardware, which holds it across
+/// many — fixes it. ~3 frames at 60Hz; ≥1 at 20Hz.
+pub const CHORD_DWELL: Duration = Duration::from_millis(50);
+
+/// The per-backend primitives that [`run_chord`] sequences. Each emitting method is **self-committed**
+/// (it performs the backend's commit barrier before returning — X11 `XFlush`, Wayland frame+settle,
+/// Windows one `SendInput` per call), so `run_chord` owns only ordering and the wall-clock dwell.
+/// `modifiers` presses/releases ALL the chord's modifiers at once; `key` presses/releases its single
+/// key.
+pub trait ChordSink {
+    /// Press (`down == true`) or release all the chord's modifier keys.
+    fn modifiers(&mut self, down: bool) -> crate::Result<()>;
+    /// Press (`down == true`) or release the chord's key.
+    fn key(&mut self, down: bool) -> crate::Result<()>;
+}
+
+/// Drive a chord against a backend `sink` — the single shared definition of the timing fix: hold the
+/// modifier(s) → **dwell** so the GUI registers them → tap the key → **dwell** so the key-press frame
+/// (modifier still held) is processed → release the modifier(s). Releasing the modifier strictly
+/// after the key's frame is what lets `key_pressed(K) && i.modifiers` hold.
+pub fn run_chord<S: ChordSink>(sink: &mut S) -> crate::Result<()> {
+    sink.modifiers(true)?;
+    std::thread::sleep(CHORD_DWELL);
+    sink.key(true)?;
+    sink.key(false)?;
+    std::thread::sleep(CHORD_DWELL);
+    sink.modifiers(false)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{run_chord, ChordSink, CHORD_DWELL};
+    use crate::Result;
+
+    #[derive(Debug, PartialEq)]
+    enum Call {
+        Mods(bool),
+        Key(bool),
+    }
+
+    #[derive(Default)]
+    struct RecordingSink {
+        calls: Vec<Call>,
+    }
+    impl ChordSink for RecordingSink {
+        fn modifiers(&mut self, down: bool) -> Result<()> {
+            self.calls.push(Call::Mods(down));
+            Ok(())
+        }
+        fn key(&mut self, down: bool) -> Result<()> {
+            self.calls.push(Call::Key(down));
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn holds_modifier_across_the_key_then_releases() {
+        use Call::*;
+        let mut sink = RecordingSink::default();
+        run_chord(&mut sink).unwrap();
+        // The order is the fix: the modifier is pressed before, and released strictly AFTER, the key
+        // — so a frame-based client sees `key_pressed && modifiers` hold in the key's frame.
+        assert_eq!(sink.calls, vec![Mods(true), Key(true), Key(false), Mods(false)]);
+    }
+
+    #[test]
+    fn run_chord_sleeps_both_dwells() {
+        // The two inter-phase dwells are the only wall-clock cost, so elapsed >= 2*CHORD_DWELL proves
+        // both holds happen (thread::sleep never returns early, so this can't flake on the >= side).
+        use std::time::Instant;
+        let mut sink = RecordingSink::default();
+        let started = Instant::now();
+        run_chord(&mut sink).unwrap();
+        assert!(
+            started.elapsed() >= CHORD_DWELL * 2,
+            "run_chord must sleep both phase dwells (only {:?} elapsed)",
+            started.elapsed()
+        );
+    }
+}

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -18,6 +18,9 @@ pub use frame::{Frame, Region};
 pub mod drag;
 pub use drag::{run_drag, DragGesture, DragSink};
 
+pub mod chord;
+pub use chord::{run_chord, ChordSink, CHORD_DWELL};
+
 pub mod keys;
 pub use keys::Modifier;
 

--- a/crates/glass-fixture-egui/src/main.rs
+++ b/crates/glass-fixture-egui/src/main.rs
@@ -28,19 +28,34 @@ impl eframe::App for Fixture {
             self.announced = true;
         }
         // Report each wheel event with the modifiers egui received ON the event, so on-box tests
-        // can verify wheel + modifier delivery (G3). The event's own modifiers are ground truth.
+        // can verify wheel + modifier delivery. The event's own modifiers are ground truth.
         ui.input(|i| {
             for ev in &i.raw.events {
-                if let egui::Event::MouseWheel { delta, modifiers, .. } = ev {
-                    // Also report how egui *routed* the wheel: ctrl+wheel becomes a zoom gesture
-                    // (zoom_delta != 1) and leaves smooth_scroll_delta at 0, so a handler that reads
-                    // the scroll delta under a `ctrl &&` gate (as glass-paint did) never sees it.
-                    log(&format!(
+                match ev {
+                    // ctrl+wheel becomes a zoom gesture (zoom_delta != 1) and leaves
+                    // smooth_scroll_delta at 0 — a handler reading the scroll delta under a `ctrl &&`
+                    // gate (as glass-paint did) never sees it.
+                    egui::Event::MouseWheel { delta, modifiers, .. } => log(&format!(
                         "[fixture] wheel delta=({:.1},{:.1}) ctrl={} shift={} | smooth_scroll_y={:.2} zoom_delta={:.4}",
                         delta.x, delta.y, modifiers.ctrl, modifiers.shift,
                         i.smooth_scroll_delta.y, i.zoom_delta()
-                    ));
+                    )),
+                    // Each key event carries its own (event-level) modifiers.
+                    egui::Event::Key { key, pressed, modifiers, .. } => log(&format!(
+                        "[fixture] key {key:?} pressed={pressed} ev_ctrl={} ev_cmd={}",
+                        modifiers.ctrl, modifiers.command
+                    )),
+                    _ => {}
                 }
+            }
+            // The standard egui hotkey idiom reads the FRAME-AGGREGATE modifier alongside
+            // key_pressed. glass_key "ctrl+z" must let `key_pressed(Z) && modifiers.command` hold in
+            // one frame — it can't if glass releases ctrl in the same frame the key arrives.
+            if i.key_pressed(egui::Key::Z) {
+                log(&format!(
+                    "[fixture] chord Z: frame_ctrl={} frame_cmd={} undo_idiom={}",
+                    i.modifiers.ctrl, i.modifiers.command, i.modifiers.command
+                ));
             }
         });
         egui::CentralPanel::default().show_inside(ui, |ui| {

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -676,6 +676,48 @@ impl glass_core::DragSink for WaylandDragSink<'_> {
     }
 }
 
+/// Lets `glass_core::run_chord` drive a Wayland key chord through the virtual keyboard. The keymap
+/// (with the chord's key as keycode 1) is uploaded and the modifier mask set in `modifiers(true)`;
+/// each method self-commits (roundtrip + 8ms settle) so the modifier is held across the key's frame.
+struct WaylandChordSink<'a> {
+    s: &'a mut ActiveSession,
+    mask: u32,
+    keysym: u32,
+}
+
+impl WaylandChordSink<'_> {
+    fn settle(&mut self) -> Result<()> {
+        self.s
+            .queue
+            .roundtrip(&mut self.s.state)
+            .map_err(|e| GlassError::Backend(format!("roundtrip: {e}")))?;
+        std::thread::sleep(Duration::from_millis(8));
+        Ok(())
+    }
+}
+
+impl glass_core::ChordSink for WaylandChordSink<'_> {
+    fn modifiers(&mut self, down: bool) -> Result<()> {
+        let kb = self.s.keyboard.clone();
+        if down {
+            // Upload the keymap (chord key = keycode 1) regardless of mask, then set the modifiers.
+            upload_keymap(&mut *self.s, &kb, &crate::keyboard::build_keymap(&[self.keysym]))?;
+            if self.mask != 0 {
+                kb.modifiers(self.mask, 0, 0, 0);
+            }
+        } else if self.mask != 0 {
+            kb.modifiers(0, 0, 0, 0);
+        }
+        self.settle()
+    }
+    fn key(&mut self, down: bool) -> Result<()> {
+        let kb = self.s.keyboard.clone();
+        self.s.time = self.s.time.wrapping_add(1);
+        kb.key(self.s.time, 1, u32::from(down)); // keycode 1 = the chord's key; 1=pressed, 0=released
+        self.settle()
+    }
+}
+
 impl Platform for WaylandPlatform {
     fn start_app(&mut self, spec: &AppSpec) -> Result<WindowGeometry> {
         // Fail-closed: if a sandbox was requested but bwrap is unavailable, error
@@ -977,15 +1019,9 @@ impl Platform for WaylandPlatform {
             }
             KeyEvent::Chord(c) => {
                 let (mods, keysym) = parse_chord(c)?; // validates before any traffic
-                upload_keymap(session, &kb, &build_keymap(&[keysym]))?;
-                let mask = modifier_mask(&mods);
-                if mask != 0 {
-                    kb.modifiers(mask, 0, 0, 0);
-                }
-                tap(session, &kb, 1);
-                if mask != 0 {
-                    kb.modifiers(0, 0, 0, 0);
-                }
+                let mut sink =
+                    WaylandChordSink { s: &mut *session, mask: modifier_mask(&mods), keysym };
+                glass_core::run_chord(&mut sink)?;
             }
         }
         session.conn.flush().map_err(|e| GlassError::Backend(format!("flush: {e}")))?;

--- a/crates/glass-windows/src/input.rs
+++ b/crates/glass-windows/src/input.rs
@@ -201,6 +201,27 @@ impl glass_core::DragSink for WindowsDragSink<'_> {
     }
 }
 
+/// `ChordSink` for Windows: one `SendInput` per call (its own commit), so `run_chord`'s dwell lands
+/// between phases the app actually processes as separate frames. `key_vk(_, true)` is the release.
+struct WindowsChordSink {
+    mod_vks: Vec<VIRTUAL_KEY>,
+    vk: VIRTUAL_KEY,
+}
+
+impl glass_core::ChordSink for WindowsChordSink {
+    fn modifiers(&mut self, down: bool) -> Result<()> {
+        let inputs: Vec<_> = if down {
+            self.mod_vks.iter().map(|&m| key_vk(m, false)).collect()
+        } else {
+            self.mod_vks.iter().rev().map(|&m| key_vk(m, true)).collect()
+        };
+        send(&inputs)
+    }
+    fn key(&mut self, down: bool) -> Result<()> {
+        send(&[key_vk(self.vk, !down)])
+    }
+}
+
 /// Inject a pointer event into the active window. Coordinates are window-relative.
 pub(crate) fn send_pointer(active_hwnd: isize, event: &PointerEvent) -> Result<()> {
     let hwnd = raw_to_hwnd(active_hwnd);
@@ -294,16 +315,10 @@ pub(crate) fn send_key(active_hwnd: isize, event: &KeyEvent) -> Result<()> {
             let vk = keysym_to_vk(keysym)
                 .ok_or_else(|| GlassError::InvalidKey(format!("key in chord {s:?} has no Windows mapping")))?;
             let mod_vks: Vec<VIRTUAL_KEY> = mods.iter().map(|&m| modifier_vk(m)).collect();
-            let mut inputs = Vec::with_capacity(mod_vks.len() * 2 + 2);
-            for &mvk in &mod_vks {
-                inputs.push(key_vk(mvk, false));
-            }
-            inputs.push(key_vk(vk, false));
-            inputs.push(key_vk(vk, true));
-            for &mvk in mod_vks.iter().rev() {
-                inputs.push(key_vk(mvk, true));
-            }
-            send(&inputs)?;
+            // Shared, frame-aware sequencing: hold the modifier across the key's frame instead of
+            // bursting the whole chord into one — see glass_core::run_chord.
+            let mut sink = WindowsChordSink { mod_vks, vk };
+            glass_core::run_chord(&mut sink)?;
         }
     }
     Ok(())

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -74,7 +74,7 @@ fn egui_fixture_spec(sandbox: glass_core::SandboxLevel) -> AppSpec {
 
 /// Drive a plain wheel then a ctrl+wheel at the window center; return the fixture's "wheel" log lines
 /// for each (the fixture logs every MouseWheel event with the modifiers egui received on it). Used to
-/// verify wheel + modifier delivery across containment levels (G3).
+/// verify wheel + modifier delivery across containment levels.
 fn scroll_evidence(p: &mut WindowsPlatform, geo: &WindowGeometry) -> (Vec<String>, Vec<String>) {
     fn wheel_lines(p: &mut WindowsPlatform) -> Vec<String> {
         p.drain_logs().into_iter().map(|(_, l)| l).filter(|l| l.contains("wheel")).collect()
@@ -449,7 +449,7 @@ fn onbox_egui_set_value_honesty() {
     };
     let tree = a11y.snapshot(&ctx).expect("a11y snapshot of the egui fixture");
 
-    // G2: egui exposes TextEdit as a read-only AccessKit projection — UIA SetValue is accepted
+    // egui exposes TextEdit as a read-only AccessKit projection — UIA SetValue is accepted
     // but never applied. set_value must report that honestly (AxValueNotApplied), not false success.
     let mut field = None;
     first_role(&tree.root, AxRole::TextField, &mut field);
@@ -469,7 +469,7 @@ fn onbox_egui_set_value_honesty() {
 
 // Uncontained: the first end-to-end verification that Windows scroll AND its ctrl modifier reach the
 // app (the existing onbox_modifier_click only checks SendInput submits, never delivery). Proven on
-// the 3x-DPI dogfood host, so this is the working baseline that G3's Sandboxie repro is measured
+// the 3x-DPI dogfood host, so this is the working baseline that the Sandboxie repro is measured
 // against.
 #[test]
 #[ignore = "on-box only: needs the interactive desktop session + builds the egui fixture"]
@@ -493,7 +493,7 @@ fn onbox_scroll_modifier_delivery() {
     );
 }
 
-// G3: the dogfood ran glass-paint UNDER SANDBOXIE and concluded ctrl+scroll "delivered nothing to
+// The dogfood ran glass-paint UNDER SANDBOXIE and concluded ctrl+scroll "delivered nothing to
 // egui". Measured directly here with the fixture as ground truth, the synthesized wheel AND its ctrl
 // modifier DO cross the Sandboxie boundary into the contained app — refuting that conclusion (the
 // dogfood had inferred "no wheel" from the app not visibly zooming, conflating delivery with effect).
@@ -516,6 +516,38 @@ fn onbox_scroll_modifier_delivery_sandboxed() {
     assert!(
         ctrl.iter().any(|l| l.contains("ctrl=true")),
         "ctrl+scroll must cross the Sandboxie boundary with ctrl=true, got {ctrl:?}"
+    );
+}
+
+// A synthetic key chord must hold the modifier across the frame the key lands in, so the
+// standard egui hotkey idiom (`key_pressed(K) && i.modifiers.command`) fires — as it does for real
+// hardware that holds the modifier across many frames. If glass injects ctrl-down/Z/ctrl-up in one
+// burst, egui drains them into a single frame and the frame-aggregate modifier is already false.
+#[test]
+#[ignore = "on-box only: needs the interactive desktop session + builds the egui fixture"]
+fn onbox_chord_modifier_frame() {
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    dpi_aware_once();
+    let mut p = WindowsPlatform::new().expect("WindowsPlatform::new");
+    let _geo = p
+        .start_app(&egui_fixture_spec(glass_core::SandboxLevel::Off))
+        .expect("build + launch the egui fixture");
+    std::thread::sleep(Duration::from_millis(2000));
+    let _ = p.drain_logs(); // discard startup logs
+
+    p.send_key(&KeyEvent::Chord("ctrl+z".to_string())).expect("ctrl+z chord submits");
+    std::thread::sleep(Duration::from_millis(600));
+    let logs: Vec<String> = p.drain_logs().into_iter().map(|(_, l)| l).collect();
+    for l in logs.iter().filter(|l| l.contains("key ") || l.contains("chord Z")) {
+        eprintln!("  {l}");
+    }
+    let _ = p.stop_app();
+
+    let chord = logs.iter().filter(|l| l.contains("chord Z")).cloned().collect::<Vec<_>>();
+    assert!(!chord.is_empty(), "ctrl+z must reach egui as a Z key press, got none");
+    assert!(
+        chord.iter().any(|l| l.contains("undo_idiom=true")),
+        "ctrl+z must let `key_pressed(Z) && modifiers.command` hold in one frame, got {chord:?}"
     );
 }
 

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -646,6 +646,41 @@ impl glass_core::DragSink for X11DragSink<'_> {
     }
 }
 
+/// Lets `glass_core::run_chord` drive an X11 key chord through the existing XTEST primitives. Each
+/// method self-commits with `XFlush`; the modifier keycodes are held between `modifiers(true)` and
+/// `modifiers(false)`, so a frame-based client sees the modifier held across the key's frame.
+struct X11ChordSink<'a> {
+    p: &'a X11Platform,
+    mods: &'a [glass_core::keys::Modifier],
+    keycode: u8,
+    kcs: Vec<u8>,
+}
+
+impl X11ChordSink<'_> {
+    fn flush(&self) -> Result<()> {
+        self.p.conn.flush().map_err(|e| GlassError::Backend(format!("flush: {e}")))
+    }
+}
+
+impl glass_core::ChordSink for X11ChordSink<'_> {
+    fn modifiers(&mut self, down: bool) -> Result<()> {
+        if down {
+            self.kcs = self.p.press_mods(self.mods)?;
+        } else {
+            self.p.release_mods(&self.kcs)?;
+        }
+        self.flush()
+    }
+    fn key(&mut self, down: bool) -> Result<()> {
+        let kind = if down { XT_KEY_PRESS } else { XT_KEY_RELEASE };
+        self.p
+            .conn
+            .xtest_fake_input(kind, self.keycode, x11rb::CURRENT_TIME, self.p.root, 0, 0, 0)
+            .map_err(|e| GlassError::Backend(format!("xtest key: {e}")))?;
+        self.flush()
+    }
+}
+
 impl Platform for X11Platform {
     fn start_app(&mut self, spec: &AppSpec) -> Result<WindowGeometry> {
         if spec.sandbox != glass_core::SandboxLevel::Off {
@@ -793,7 +828,13 @@ impl Platform for X11Platform {
             }
             KeyEvent::Chord(chord) => {
                 let (mods, keysym) = glass_core::keys::parse_chord(chord)?;
-                self.key_with_mods(keysym, false, &mods)?;
+                let (keycode, needs_shift) = self.keycode_for(keysym)?;
+                let mut mods = mods;
+                if needs_shift && !mods.contains(&glass_core::keys::Modifier::Shift) {
+                    mods.push(glass_core::keys::Modifier::Shift);
+                }
+                let mut sink = X11ChordSink { p: &*self, mods: &mods, keycode, kcs: Vec::new() };
+                glass_core::run_chord(&mut sink)?;
             }
         }
         self.conn.flush().map_err(|e| GlassError::Backend(format!("flush: {e}")))?;


### PR DESCRIPTION
## The bug
A synthetic key chord injected as one burst (modifier-down → key → modifier-up) is drained by a frame-based GUI (egui/winit) into a **single frame**. The frame-aggregate modifier then reads as already-released while the key is `key_pressed` that frame, so the universal hotkey idiom

```rust
if i.key_pressed(Key::Z) && i.modifiers.command { /* undo */ }
```

**never fires** — even though each key event carries the correct *event-level* modifiers (so egui's built-in shortcuts work). Real hardware holds the modifier across many frames; glass didn't.

## The fix (shared, all backends)
`glass_core::run_chord` + `ChordSink`, mirroring `run_drag`/`DragSink`:

> hold the modifier(s) → **dwell** → tap the key → **dwell** → release the modifier(s)

The modifier is held across the key's frame and released only *after* it, so a frame-based client sees the idiom hold. Windows, X11, and Wayland each supply a thin sink; the timing/ordering live once in core.

## Coverage
- **`glass-core` unit test** (CI): `run_chord` emits `Mods↓, Key↓, Key↑, Mods↓` in order and both inter-phase dwells actually sleep.
- **On-box egui (Windows):** `onbox_chord_modifier_frame` sends `ctrl+z` and asserts `key_pressed(Z) && modifiers.command` holds in one frame — RED before, GREEN after. Measured: `frame_ctrl=false→true`, `undo_idiom=false→true`. The fixture logs per-event vs per-frame modifier state.
- glass-testapp is event-based (reads each `KeyPress`'s own modifiers), so it can't exhibit the frame collapse — the Linux end-to-end case is inherently covered by the unit test + the Windows egui on-box test.

## Test plan
- Linux: `cargo test -p glass-core chord` ✓; `clippy --workspace --all-targets -D warnings` ✓; X11/Wayland compile ✓.
- On-box (3×-DPI host): `onbox_chord_modifier_frame` GREEN; build + clippy clean.