### PR TITLE
Fix contained-app clipboard writes (boxed clipboard anonymous-token denial)

### DIFF
--- a/crates/glass-clip-hook/src/hook.rs
+++ b/crates/glass-clip-hook/src/hook.rs
@@ -20,6 +20,7 @@ use windows::Win32::Foundation::{
 use windows::Win32::Storage::FileSystem::{
     CreateFileW, ReadFile, WriteFile, FILE_FLAGS_AND_ATTRIBUTES, FILE_SHARE_NONE, OPEN_EXISTING,
 };
+use windows::Win32::Security::RevertToSelf;
 use windows::Win32::System::LibraryLoader::{GetModuleHandleW, GetProcAddress};
 use windows::Win32::System::Pipes::WaitNamedPipeW;
 use windows::Win32::System::Memory::{
@@ -128,6 +129,17 @@ fn rpc(req: Request) -> Option<Response> {
 /// (and back off briefly if the pipe is momentarily absent), then retry — bounded so a genuinely
 /// down server still fails soft rather than hanging.
 fn open_pipe(path: &str) -> Option<HANDLE> {
+    // Connect to the host as THIS PROCESS, not a thread impersonation. clipboard-win (arboard) wraps
+    // the app's `CloseClipboard` in `ImpersonateAnonymousToken`/`RevertToSelf` (a crbug/441834
+    // mitigation), and our `CloseClipboard` detour — which ships the copy via this pipe — runs inside
+    // it. Without reverting, the connect uses the ANONYMOUS token, which the pipe DACL (grants
+    // `Everyone`, which by Windows default excludes Anonymous) denies (`ERROR_ACCESS_DENIED`) — so an
+    // app's own clipboard write would silently never reach the store. `RevertToSelf` is a harmless
+    // no-op when the thread isn't impersonating (the common case for reads).
+    // SAFETY: drops the calling thread's impersonation token; always sound.
+    unsafe {
+        let _ = RevertToSelf();
+    }
     let wide: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
     for _ in 0..40 {
         // SAFETY: `wide` is a NUL-terminated UTF-16 buffer that outlives the call; all other args

--- a/crates/glass-fixture-egui/src/main.rs
+++ b/crates/glass-fixture-egui/src/main.rs
@@ -16,6 +16,8 @@ struct Fixture {
     text: String,
     value: f32,
     announced: bool,
+    frames: u32,
+    copied: bool,
 }
 
 impl eframe::App for Fixture {
@@ -26,6 +28,15 @@ impl eframe::App for Fixture {
         if !self.announced {
             log("[fixture] ready");
             self.announced = true;
+        }
+        // Write the clipboard once via egui (-> arboard -> user32 SetClipboardData), a few frames in
+        // so the host's private-clipboard store/pipe is up. Tests whether a contained app's own
+        // clipboard write is readable by glass.
+        self.frames += 1;
+        if !self.copied && self.frames >= 60 {
+            self.copied = true;
+            ui.ctx().copy_text("GLASS-CLIP-SENTINEL".to_string());
+            log("[fixture] copied sentinel");
         }
         // Report each wheel event with the modifiers egui received ON the event, so on-box tests
         // can verify wheel + modifier delivery. The event's own modifiers are ground truth.

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -381,6 +381,42 @@ fn onbox_clipboard_roundtrip() {
     assert!(p.get_clipboard().expect("get empty clipboard").is_empty(), "empty round-trip");
 }
 
+// The dogfood found that a CONTAINED app's own clipboard write was invisible to glass: glass set/get
+// round-tripped and glass->app paste worked, but the app's ctx.copy_text (-> arboard -> user32
+// SetClipboardData, detoured into the private store) read back empty. This reproduces it with the
+// fixture auto-copying a sentinel under Sandboxie, and isolates the app-write path from the store
+// itself (glass's own set/get is checked after, on the same private store).
+#[test]
+#[ignore = "on-box only: needs the interactive desktop session + Sandboxie + the clip hook + builds the egui fixture"]
+fn onbox_contained_clipboard_app_write() {
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    dpi_aware_once();
+    let mut p = WindowsPlatform::new().expect("WindowsPlatform::new");
+    let _geo = p
+        .start_app(&egui_fixture_spec(glass_core::SandboxLevel::Default))
+        .expect("build + launch the egui fixture under Sandboxie");
+    std::thread::sleep(Duration::from_millis(3000)); // let it start AND auto-copy (frame >= 60)
+
+    let logs: Vec<String> = p.drain_logs().into_iter().map(|(_, l)| l).collect();
+    let copied = logs.iter().any(|l| l.contains("copied sentinel"));
+    let after_app = p.get_clipboard().unwrap_or_default();
+    // Isolate: does glass's own set/get work on this private store? (Run after, so it can't mask the
+    // app-write result.) after_glass tells real-app-write-lost from store/route-broken.
+    let after_glass = match p.set_clipboard("GLASS-SEEDED") {
+        Ok(()) => p.get_clipboard().unwrap_or_default(),
+        Err(e) => format!("<set_clipboard err: {e}>"),
+    };
+    eprintln!("copied-log={copied} after_app={after_app:?} after_glass={after_glass:?}");
+    let _ = p.stop_app();
+
+    assert!(copied, "the contained app must have run its copy (frame counter reached)");
+    assert_eq!(
+        after_app, "GLASS-CLIP-SENTINEL",
+        "glass must read the contained app's own clipboard write (glass's own set/get on the same \
+         private store = {after_glass:?})"
+    );
+}
+
 #[test]
 #[ignore = "on-box only: needs the interactive desktop session"]
 fn onbox_a11y_set_value() {


### PR DESCRIPTION
## The bug
Under Sandboxie's private boxed clipboard, a contained app's **own** clipboard write was silently lost. `glass_clipboard_set`→`get` round-tripped, and glass→app paste worked, but when the contained egui app wrote the clipboard (`ctx.copy_text` → arboard → user32 `SetClipboardData`, detoured into the host store), `glass_clipboard_get` returned empty.

## Root cause
**clipboard-win** (arboard's Windows backend) wraps the app's `CloseClipboard` in `ImpersonateAnonymousToken`/`RevertToSelf` — a Chromium [crbug/441834](https://crbug.com/441834) mitigation. glass's `CloseClipboard` detour ships the captured copy to the host store **over a named pipe, inside that impersonation**, so the connect ran under the **ANONYMOUS** token. The pipe DACL grants `Everyone` (`WD`), which by Windows default **excludes Anonymous** → `ERROR_ACCESS_DENIED` → the `SetAll` RPC failed fail-soft → the write never reached the store.

The asymmetry is fully explained: the preceding `EmptyClipboard` (issued *before* the Drop's impersonation) and the paste's `GetClipboardData` (outside it) connect under the normal token and work — only the app's *writes* were invisible.

Localized on-box by tracing each detour, each pipe RPC, the box-gate, and the accept loop, down to `open_pipe`'s `CreateFileW` returning `hr=0x80070005` (`ACCESS_DENIED`).

## Fix
`RevertToSelf()` before the pipe `CreateFileW`, so the hook always connects to the host as **the process** (the identity the box-membership gate checks anyway), not a thread impersonation. It's a no-op when the thread isn't impersonating (reads/paste), so nothing else changes.

## Test
`onbox_contained_clipboard_app_write`: the egui fixture writes a sentinel to the clipboard under Sandboxie; the test asserts glass reads it back, and (for isolation) that glass's own set/get round-trips on the same private store. RED before the fix (`after_app=""`), GREEN after (`after_app="GLASS-CLIP-SENTINEL"`), verified on-box.

## Test plan
- Linux: `cargo test -p glass-clip-hook` (34 pure proto/store/codec tests) green; clippy `--all-targets` clean.
- On-box (Sandboxie + hook): `onbox_contained_clipboard_app_write` green. DLL build + clippy clean.