### PR TITLE
fix(input): hold the modifier across the wheel's frame for synthetic scrolls

### DIFF
--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -21,6 +21,9 @@ pub use drag::{run_drag, DragGesture, DragSink};
 pub mod chord;
 pub use chord::{run_chord, ChordSink, CHORD_DWELL};
 
+pub mod scroll;
+pub use scroll::{run_scroll, ScrollSink, SCROLL_DWELL};
+
 pub mod keys;
 pub use keys::Modifier;
 

--- a/crates/glass-core/src/scroll.rs
+++ b/crates/glass-core/src/scroll.rs
@@ -1,0 +1,104 @@
+//! Platform-agnostic scroll model: the `run_scroll` driver that sequences a wheel scroll — with an
+//! optional held modifier — against any backend's `ScrollSink`. A modified scroll holds the modifier
+//! across the wheel's frame (the same dwell fix as `run_chord`) so a frame-based client reads
+//! `i.modifiers` as held when the wheel arrives.
+
+use std::time::Duration;
+
+/// Dwell between a modified scroll's phases (modifier-down → wheel → modifier-up). A modifier+wheel
+/// injected as one burst is drained by a frame-based GUI (egui/winit) into a SINGLE frame, so the
+/// frame-aggregate modifier reads as already-released and a `ctrl/shift + wheel` gesture (zoom,
+/// shift-to-scroll-horizontally) never sees the modifier held. Holding it across separate frames —
+/// like hardware — fixes it. Mirrors [`crate::chord::CHORD_DWELL`]: ~3 frames at 60Hz; ≥1 at 20Hz.
+pub const SCROLL_DWELL: Duration = Duration::from_millis(50);
+
+/// The per-backend primitives that [`run_scroll`] sequences. Each emitting method is **self-committed**
+/// (it performs the backend's commit barrier before returning — X11 `XFlush`, Wayland frame+settle,
+/// Windows one `SendInput` per call), so `run_scroll` owns only ordering and the wall-clock dwell.
+pub trait ScrollSink {
+    /// Press (`down == true`) or release the scroll's held modifier keys. Called by [`run_scroll`]
+    /// only for a modified scroll (the plain path emits the wheel directly).
+    fn modifiers(&mut self, down: bool) -> crate::Result<()>;
+    /// Position the pointer and emit the wheel (vertical then horizontal) at that point.
+    fn wheel(&mut self) -> crate::Result<()>;
+}
+
+/// Drive a scroll against a backend `sink`. A *plain* scroll (`has_modifiers == false`) emits the
+/// wheel directly — the hot, latency-sensitive path takes no dwell. A *modified* scroll holds the
+/// modifier → **dwell** so the GUI registers it → emit the wheel (modifier still held) → **dwell** →
+/// release: the same frame-aware sequencing as [`crate::run_chord`], so `i.modifiers` reads held in
+/// the wheel's frame. Releasing the modifier strictly after the wheel's frame is what lets a handler
+/// gating on `i.modifiers.ctrl` see it.
+pub fn run_scroll<S: ScrollSink>(sink: &mut S, has_modifiers: bool) -> crate::Result<()> {
+    if !has_modifiers {
+        return sink.wheel();
+    }
+    sink.modifiers(true)?;
+    std::thread::sleep(SCROLL_DWELL);
+    sink.wheel()?;
+    std::thread::sleep(SCROLL_DWELL);
+    sink.modifiers(false)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{run_scroll, ScrollSink, SCROLL_DWELL};
+    use crate::Result;
+
+    #[derive(Debug, PartialEq)]
+    enum Call {
+        Mods(bool),
+        Wheel,
+    }
+
+    #[derive(Default)]
+    struct RecordingSink {
+        calls: Vec<Call>,
+    }
+    impl ScrollSink for RecordingSink {
+        fn modifiers(&mut self, down: bool) -> Result<()> {
+            self.calls.push(Call::Mods(down));
+            Ok(())
+        }
+        fn wheel(&mut self) -> Result<()> {
+            self.calls.push(Call::Wheel);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn modified_scroll_holds_modifier_across_the_wheel_then_releases() {
+        use Call::*;
+        let mut sink = RecordingSink::default();
+        run_scroll(&mut sink, true).unwrap();
+        // The order is the fix: the modifier is pressed before, and released strictly AFTER, the
+        // wheel — so a frame-based client sees `i.modifiers` held in the wheel's frame.
+        assert_eq!(sink.calls, vec![Mods(true), Wheel, Mods(false)]);
+    }
+
+    #[test]
+    fn plain_scroll_emits_the_wheel_with_no_modifier_traffic() {
+        use Call::*;
+        let mut sink = RecordingSink::default();
+        run_scroll(&mut sink, false).unwrap();
+        // No modifier to hold: just the wheel via the early-return branch (which has no dwell).
+        assert_eq!(sink.calls, vec![Wheel]);
+    }
+
+    #[test]
+    fn modified_scroll_sleeps_both_dwells() {
+        // The two inter-phase dwells are the only wall-clock cost, so elapsed >= 2*SCROLL_DWELL
+        // proves both holds happen (thread::sleep never returns early, so this can't flake on the
+        // >= side). The plain path's no-dwell is pinned by the call-sequence test above.
+        use std::time::Instant;
+        let mut sink = RecordingSink::default();
+        let started = Instant::now();
+        run_scroll(&mut sink, true).unwrap();
+        assert!(
+            started.elapsed() >= SCROLL_DWELL * 2,
+            "a modified scroll must sleep both phase dwells (only {:?} elapsed)",
+            started.elapsed()
+        );
+    }
+}

--- a/crates/glass-fixture-egui/src/main.rs
+++ b/crates/glass-fixture-egui/src/main.rs
@@ -38,17 +38,22 @@ impl eframe::App for Fixture {
             ui.ctx().copy_text("GLASS-CLIP-SENTINEL".to_string());
             log("[fixture] copied sentinel");
         }
-        // Report each wheel event with the modifiers egui received ON the event, so on-box tests
-        // can verify wheel + modifier delivery. The event's own modifiers are ground truth.
+        // Report each wheel event with BOTH the event-level modifiers and the frame-aggregate
+        // modifiers, so on-box tests can verify wheel + modifier delivery AND that the modifier is
+        // held across the wheel's frame (the layer the egui `i.modifiers` handler idiom reads).
         ui.input(|i| {
             for ev in &i.raw.events {
                 match ev {
-                    // ctrl+wheel becomes a zoom gesture (zoom_delta != 1) and leaves
-                    // smooth_scroll_delta at 0 — a handler reading the scroll delta under a `ctrl &&`
-                    // gate (as glass-paint did) never sees it.
+                    // `ev_*` are the modifiers carried ON the wheel event; `frame_*` are the
+                    // frame-aggregate `i.modifiers` a handler actually gates on. They diverge when a
+                    // synthetic ctrl+wheel is injected as one burst: the event carries ctrl, but the
+                    // frame-aggregate reads released because the modifier is pressed and released
+                    // within a single frame — so `i.modifiers.ctrl` is false. (ctrl+wheel also routes
+                    // to a zoom gesture, zeroing smooth_scroll_delta.)
                     egui::Event::MouseWheel { delta, modifiers, .. } => log(&format!(
-                        "[fixture] wheel delta=({:.1},{:.1}) ctrl={} shift={} | smooth_scroll_y={:.2} zoom_delta={:.4}",
+                        "[fixture] wheel delta=({:.1},{:.1}) ev_ctrl={} ev_shift={} frame_ctrl={} frame_shift={} smooth_scroll_y={:.2} zoom_delta={:.4}",
                         delta.x, delta.y, modifiers.ctrl, modifiers.shift,
+                        i.modifiers.ctrl, i.modifiers.shift,
                         i.smooth_scroll_delta.y, i.zoom_delta()
                     )),
                     // Each key event carries its own (event-level) modifiers.

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -718,6 +718,89 @@ impl glass_core::ChordSink for WaylandChordSink<'_> {
     }
 }
 
+/// Lets `glass_core::run_scroll` drive a Wayland scroll through the virtual pointer + keyboard. The
+/// modifier mask is set in `modifiers(true)` and cleared in `modifiers(false)`; `wheel` positions the
+/// pointer (with the focus-reassert nudge, like the drag sink) then emits the vertical and horizontal
+/// axis. Each method self-commits (frame + roundtrip + 8ms settle) so the modifier is held across the
+/// wheel's frame.
+struct WaylandScrollSink<'a> {
+    s: &'a mut ActiveSession,
+    w: u32,
+    h: u32,
+    ox: i32,
+    oy: i32,
+    x: i32,
+    y: i32,
+    dx: i32,
+    dy: i32,
+    mask: u32,
+}
+
+impl WaylandScrollSink<'_> {
+    fn tick(&mut self) -> u32 {
+        self.s.time = self.s.time.wrapping_add(1);
+        self.s.time
+    }
+    fn ax(&self, x: i32) -> u32 {
+        (self.ox + x).max(0) as u32
+    }
+    fn ay(&self, y: i32) -> u32 {
+        (self.oy + y).max(0) as u32
+    }
+    fn settle(&mut self) -> Result<()> {
+        self.s
+            .queue
+            .roundtrip(&mut self.s.state)
+            .map_err(|e| GlassError::Backend(format!("roundtrip: {e}")))?;
+        std::thread::sleep(Duration::from_millis(8));
+        Ok(())
+    }
+}
+
+impl glass_core::ScrollSink for WaylandScrollSink<'_> {
+    fn modifiers(&mut self, down: bool) -> Result<()> {
+        if self.mask == 0 {
+            return Ok(());
+        }
+        let kb = self.s.keyboard.clone();
+        if down {
+            upload_keymap(&mut *self.s, &kb, &crate::keyboard::build_keymap(&[]))?;
+            kb.modifiers(self.mask, 0, 0, 0);
+        } else {
+            kb.modifiers(0, 0, 0, 0);
+        }
+        self.settle()
+    }
+    fn wheel(&mut self) -> Result<()> {
+        let vp = self.s.pointer.clone();
+        let (w, h) = (self.w, self.h);
+        let (axx, ayy) = (self.ax(self.x), self.ay(self.y));
+        // Position with the focus-reassert nudge (sway re-evaluates pointer focus only on motion).
+        let t = self.tick();
+        vp.motion_absolute(t, axx, ayy, w, h);
+        vp.frame();
+        self.settle()?;
+        let t = self.tick();
+        vp.motion_absolute(t, nudge_x(axx, w), ayy, w, h);
+        vp.frame();
+        vp.motion_absolute(t, axx, ayy, w, h);
+        vp.frame();
+        self.settle()?;
+        // Emit the wheel (vertical then horizontal) at that point.
+        if self.dy != 0 {
+            let t = self.tick();
+            vp.axis_discrete(t, Axis::VerticalScroll, self.dy as f64 * 15.0, self.dy);
+            vp.frame();
+        }
+        if self.dx != 0 {
+            let t = self.tick();
+            vp.axis_discrete(t, Axis::HorizontalScroll, self.dx as f64 * 15.0, self.dx);
+            vp.frame();
+        }
+        self.settle()
+    }
+}
+
 impl Platform for WaylandPlatform {
     fn start_app(&mut self, spec: &AppSpec) -> Result<WindowGeometry> {
         // Fail-closed: if a sandbox was requested but bwrap is unavailable, error
@@ -968,24 +1051,21 @@ impl Platform for WaylandPlatform {
                 glass_core::run_drag(&mut sink, &gesture)?;
             }
             PointerEvent::Scroll { x, y, dx, dy, ref modifiers } => {
-                position(&mut session.queue, &mut session.state, x, y)?;
-                let mask = modifier_mask(modifiers);
-                if mask != 0 {
-                    upload_keymap(session, &kb, &crate::keyboard::build_keymap(&[]))?;
-                    kb.modifiers(mask, 0, 0, 0);
-                }
-                if dy != 0 {
-                    vp.axis_discrete(t, Axis::VerticalScroll, dy as f64 * 15.0, dy);
-                    vp.frame();
-                }
-                if dx != 0 {
-                    vp.axis_discrete(t, Axis::HorizontalScroll, dx as f64 * 15.0, dx);
-                    vp.frame();
-                }
-                if mask != 0 {
-                    settle(&mut session.queue, &mut session.state)?;
-                    kb.modifiers(0, 0, 0, 0);
-                }
+                // Shared, frame-aware sequencing: hold the modifier across the wheel's frame instead
+                // of bursting modifier+wheel+release into one — see glass_core::run_scroll.
+                let mut sink = WaylandScrollSink {
+                    s: &mut *session,
+                    w,
+                    h,
+                    ox,
+                    oy,
+                    x,
+                    y,
+                    dx,
+                    dy,
+                    mask: modifier_mask(modifiers),
+                };
+                glass_core::run_scroll(&mut sink, !modifiers.is_empty())?;
             }
         }
         session.conn.flush().map_err(|e| GlassError::Backend(format!("flush: {e}")))?;

--- a/crates/glass-windows/src/input.rs
+++ b/crates/glass-windows/src/input.rs
@@ -222,6 +222,39 @@ impl glass_core::ChordSink for WindowsChordSink {
     }
 }
 
+/// `ScrollSink` for Windows: one `SendInput` per call (its own commit). `wheel` positions the cursor
+/// then emits the vertical and horizontal wheel in a single batch; `modifiers` presses/releases the
+/// held modifier keys around it, so with `run_scroll`'s dwell the wheel lands in a frame the app reads
+/// the modifier as held (instead of released by a same-frame modifier-up).
+struct WindowsScrollSink {
+    nx: i32,
+    ny: i32,
+    dx: i32,
+    dy: i32,
+    mod_vks: Vec<VIRTUAL_KEY>,
+}
+
+impl glass_core::ScrollSink for WindowsScrollSink {
+    fn modifiers(&mut self, down: bool) -> Result<()> {
+        let inputs: Vec<_> = if down {
+            self.mod_vks.iter().map(|&m| key_vk(m, false)).collect()
+        } else {
+            self.mod_vks.iter().rev().map(|&m| key_vk(m, true)).collect()
+        };
+        send(&inputs)
+    }
+    fn wheel(&mut self) -> Result<()> {
+        // Scroll sign matches x11 (`scroll_button(5=down,4=up, dy)`): there positive `dy` clicks
+        // button 5 = scroll DOWN. Windows WHEEL is positive=forward/up, so negate `dy`. Horizontal:
+        // positive `dx` = right, and Windows HWHEEL positive = right, so `dx` is used as-is.
+        send(&[
+            mouse(self.nx, self.ny, MOUSEEVENTF_MOVE | ABS),
+            mouse_wheel(-self.dy * WHEEL_DELTA, MOUSEEVENTF_WHEEL),
+            mouse_wheel(self.dx * WHEEL_DELTA, MOUSEEVENTF_HWHEEL),
+        ])
+    }
+}
+
 /// Inject a pointer event into the active window. Coordinates are window-relative.
 pub(crate) fn send_pointer(active_hwnd: isize, event: &PointerEvent) -> Result<()> {
     let hwnd = raw_to_hwnd(active_hwnd);
@@ -275,21 +308,11 @@ pub(crate) fn send_pointer(active_hwnd: isize, event: &PointerEvent) -> Result<(
         }
         PointerEvent::Scroll { x, y, dx, dy, ref modifiers } => {
             let (nx, ny) = to_norm(x, y);
-            // Scroll sign matches x11 (`scroll_button(5=down,4=up, dy)`): there positive
-            // `dy` clicks button 5 = scroll DOWN. Windows WHEEL is positive=forward/up, so
-            // negate `dy`. Horizontal: x11 `scroll_button(7=right,6=left, dx)` => positive
-            // `dx` = right, and Windows HWHEEL positive = right, so `dx` is used as-is.
-            let mut inputs = Vec::new();
-            for m in modifiers {
-                inputs.push(key_vk(modifier_vk(*m), false));
-            }
-            inputs.push(mouse(nx, ny, MOUSEEVENTF_MOVE | ABS));
-            inputs.push(mouse_wheel(-dy * WHEEL_DELTA, MOUSEEVENTF_WHEEL));
-            inputs.push(mouse_wheel(dx * WHEEL_DELTA, MOUSEEVENTF_HWHEEL));
-            for m in modifiers.iter().rev() {
-                inputs.push(key_vk(modifier_vk(*m), true));
-            }
-            send(&inputs)?;
+            let mod_vks: Vec<VIRTUAL_KEY> = modifiers.iter().map(|&m| modifier_vk(m)).collect();
+            // Shared, frame-aware sequencing: hold the modifier across the wheel's frame instead of
+            // bursting modifier+wheel+release into one — see glass_core::run_scroll.
+            let mut sink = WindowsScrollSink { nx, ny, dx, dy, mod_vks };
+            glass_core::run_scroll(&mut sink, !modifiers.is_empty())?;
         }
     }
     Ok(())

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -73,8 +73,9 @@ fn egui_fixture_spec(sandbox: glass_core::SandboxLevel) -> AppSpec {
 }
 
 /// Drive a plain wheel then a ctrl+wheel at the window center; return the fixture's "wheel" log lines
-/// for each (the fixture logs every MouseWheel event with the modifiers egui received on it). Used to
-/// verify wheel + modifier delivery across containment levels.
+/// for each. Each line carries both `ev_ctrl` (the modifier on the wheel event — delivery) and
+/// `frame_ctrl` (the frame-aggregate `i.modifiers.ctrl` a handler gates on — held across the frame).
+/// Used to verify wheel + modifier delivery AND modifier-hold across containment levels.
 fn scroll_evidence(p: &mut WindowsPlatform, geo: &WindowGeometry) -> (Vec<String>, Vec<String>) {
     fn wheel_lines(p: &mut WindowsPlatform) -> Vec<String> {
         p.drain_logs().into_iter().map(|(_, l)| l).filter(|l| l.contains("wheel")).collect()
@@ -503,10 +504,13 @@ fn onbox_egui_set_value_honesty() {
     let _ = p.stop_app();
 }
 
-// Uncontained: the first end-to-end verification that Windows scroll AND its ctrl modifier reach the
-// app (the existing onbox_modifier_click only checks SendInput submits, never delivery). Proven on
-// the 3x-DPI dogfood host, so this is the working baseline that the Sandboxie repro is measured
-// against.
+// Uncontained: end-to-end verification that a Windows ctrl+scroll both DELIVERS the wheel with its
+// modifier on the event (`ev_ctrl`) AND holds the modifier across the wheel's frame so the
+// frame-aggregate `i.modifiers.ctrl` (`frame_ctrl`) — the layer a real handler gates on — reads it.
+// The event reaching egui was never the gap; the gap is the frame-aggregate modifier, which a
+// one-burst modifier+wheel+release drops (the modifier is released in the same frame the wheel
+// lands). run_scroll's hold-dwell-release fixes it. This is the working baseline the Sandboxie repro
+// is measured against.
 #[test]
 #[ignore = "on-box only: needs the interactive desktop session + builds the egui fixture"]
 fn onbox_scroll_modifier_delivery() {
@@ -524,15 +528,19 @@ fn onbox_scroll_modifier_delivery() {
 
     assert!(!plain.is_empty(), "plain scroll must deliver a wheel event to egui");
     assert!(
-        ctrl.iter().any(|l| l.contains("ctrl=true")),
-        "ctrl+scroll must deliver a wheel event with ctrl=true to egui, got {ctrl:?}"
+        ctrl.iter().any(|l| l.contains("ev_ctrl=true")),
+        "ctrl+scroll must deliver a wheel event carrying ctrl to egui, got {ctrl:?}"
+    );
+    assert!(
+        ctrl.iter().any(|l| l.contains("frame_ctrl=true")),
+        "ctrl+scroll must hold ctrl across the wheel's frame (frame-aggregate i.modifiers.ctrl), \
+         got {ctrl:?}"
     );
 }
 
-// The dogfood ran glass-paint UNDER SANDBOXIE and concluded ctrl+scroll "delivered nothing to
-// egui". Measured directly here with the fixture as ground truth, the synthesized wheel AND its ctrl
-// modifier DO cross the Sandboxie boundary into the contained app — refuting that conclusion (the
-// dogfood had inferred "no wheel" from the app not visibly zooming, conflating delivery with effect).
+// The same two assertions across the Sandboxie boundary: the wheel + its event modifier cross into
+// the contained app (never the gap), and the modifier is held across the wheel's frame so a contained
+// handler reading `i.modifiers.ctrl` sees it.
 #[test]
 #[ignore = "on-box only: needs the interactive desktop session + Sandboxie + builds the egui fixture"]
 fn onbox_scroll_modifier_delivery_sandboxed() {
@@ -550,8 +558,12 @@ fn onbox_scroll_modifier_delivery_sandboxed() {
 
     assert!(!plain.is_empty(), "plain scroll must cross the Sandboxie boundary to egui");
     assert!(
-        ctrl.iter().any(|l| l.contains("ctrl=true")),
-        "ctrl+scroll must cross the Sandboxie boundary with ctrl=true, got {ctrl:?}"
+        ctrl.iter().any(|l| l.contains("ev_ctrl=true")),
+        "ctrl+scroll must cross the Sandboxie boundary carrying ctrl on the event, got {ctrl:?}"
+    );
+    assert!(
+        ctrl.iter().any(|l| l.contains("frame_ctrl=true")),
+        "ctrl+scroll must hold ctrl across the wheel's frame inside the sandbox, got {ctrl:?}"
     );
 }
 

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -681,6 +681,45 @@ impl glass_core::ChordSink for X11ChordSink<'_> {
     }
 }
 
+/// Lets `glass_core::run_scroll` drive an X11 scroll through the existing XTEST primitives. The
+/// modifier keycodes are held between `modifiers(true)` and `modifiers(false)`, so a frame-based
+/// client sees the modifier held across the wheel's frame; each method self-commits with `XFlush`.
+struct X11ScrollSink<'a> {
+    p: &'a X11Platform,
+    ox: i32,
+    oy: i32,
+    x: i32,
+    y: i32,
+    dx: i32,
+    dy: i32,
+    mods: &'a [glass_core::keys::Modifier],
+    kcs: Vec<u8>,
+}
+
+impl X11ScrollSink<'_> {
+    fn flush(&self) -> Result<()> {
+        self.p.conn.flush().map_err(|e| GlassError::Backend(format!("flush: {e}")))
+    }
+}
+
+impl glass_core::ScrollSink for X11ScrollSink<'_> {
+    fn modifiers(&mut self, down: bool) -> Result<()> {
+        if down {
+            self.kcs = self.p.press_mods(self.mods)?;
+        } else {
+            self.p.release_mods(&self.kcs)?;
+        }
+        self.flush()
+    }
+    fn wheel(&mut self) -> Result<()> {
+        self.p.warp(self.ox, self.oy, self.x, self.y)?;
+        // 4=up,5=down,6=left,7=right; click |delta| times.
+        self.p.scroll_button(5, 4, self.dy)?;
+        self.p.scroll_button(7, 6, self.dx)?;
+        self.flush()
+    }
+}
+
 impl Platform for X11Platform {
     fn start_app(&mut self, spec: &AppSpec) -> Result<WindowGeometry> {
         if spec.sandbox != glass_core::SandboxLevel::Off {
@@ -777,12 +816,20 @@ impl Platform for X11Platform {
         match *event {
             PointerEvent::Move { x, y } => self.warp(ox, oy, x, y)?,
             PointerEvent::Scroll { x, y, dx, dy, ref modifiers } => {
-                self.warp(ox, oy, x, y)?;
-                let kcs = self.press_mods(modifiers)?;
-                // 4=up,5=down,6=left,7=right; click |delta| times.
-                self.scroll_button(5, 4, dy)?;
-                self.scroll_button(7, 6, dx)?;
-                self.release_mods(&kcs)?;
+                // Shared, frame-aware sequencing: hold the modifier across the wheel's frame instead
+                // of bursting modifier+wheel+release into one — see glass_core::run_scroll.
+                let mut sink = X11ScrollSink {
+                    p: &*self,
+                    ox,
+                    oy,
+                    x,
+                    y,
+                    dx,
+                    dy,
+                    mods: modifiers.as_slice(),
+                    kcs: Vec::new(),
+                };
+                glass_core::run_scroll(&mut sink, !modifiers.is_empty())?;
             }
             PointerEvent::Click { x, y, button, count, ref modifiers } => {
                 self.warp(ox, oy, x, y)?;


### PR DESCRIPTION
## Summary

A scroll injected as one burst — modifier-down + wheel + modifier-up in a single
`SendInput`/XTEST/Wayland batch — is drained by a frame-based GUI (egui/winit) into a
single frame. The frame-aggregate `i.modifiers` then reads already-released, so a
ctrl/shift+wheel gesture (zoom, shift-to-scroll-horizontally) never sees the modifier
**held** — even though it correctly rides the wheel event. This is the same frame-collapse
the chord path already fixes.

Adds `glass_core::run_scroll` + `ScrollSink` — the single shared definition of the timing
fix: hold the modifier → dwell so the GUI registers it → emit the wheel (modifier still
held) → dwell → release. A plain scroll (no modifier) takes a no-dwell hot path. Wired into
the Windows, X11, and Wayland backends, each replacing a one-burst `Scroll` arm, mirroring
`run_chord`/`run_drag`.

The existing on-box scroll tests asserted only that the modifier *rode the wheel event*;
they're extended here to also assert the frame-aggregate modifier — the layer a real handler
reads — which is what exposed this gap.

## Test plan

- `glass-core`: three `run_scroll` unit tests (phase ordering, plain-path emits no modifier
  traffic, a modified scroll sleeps both dwells).
- On-box (Windows, egui fixture): `onbox_scroll_modifier_delivery` and `…_sandboxed` now
  assert both `ev_ctrl=true` (rides the event) and `frame_ctrl=true` (held across the wheel's
  frame, i.e. the frame-aggregate `i.modifiers.ctrl`). Both green uncontained and under
  Sandboxie; `frame_ctrl` was `false` before this change, `true` after.
- `cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` clean;
  `glass-windows` (incl. tests) clean on `x86_64-pc-windows-gnu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)