### PR TITLE
docs(test): describe behaviour instead of internal gap-tracking numbers

### DIFF
--- a/crates/glass-testapp/tests/integration.rs
+++ b/crates/glass-testapp/tests/integration.rs
@@ -622,7 +622,7 @@ fn sandbox_off_build_step_writes_to_real_home() {
     assert!(exists, "Off sandbox: sentinel {sentinel_path:?} must exist (unconfined write)");
 }
 
-/// The build step is UNSANDBOXED (only the launched run is contained — gap #5), so even at the
+/// The build step is UNSANDBOXED (only the launched run is contained), so even at the
 /// `Default` sandbox level the build runs with the full developer environment and writes the real
 /// `$HOME`. (Network access in the build is likewise the host's — no separate test; the run's
 /// containment is covered by the run-step sandbox tests.)
@@ -735,7 +735,7 @@ fn start_app_focuses_window_so_keys_reach_it() {
     let mut p = X11Platform::connect(Some(&xvfb.display)).unwrap();
     // --no-self-focus: the fixture does NOT focus itself, so a key reaches it
     // only if start_app focused it. (The default fixture self-focuses, which
-    // masks this gap — see the spec.)
+    // would mask whether start_app does the focusing.)
     let spec = AppSpec {
         build: None,
         run: vec![TESTAPP.to_string(), "--no-self-focus".to_string()],

--- a/crates/glass-testapp/tests/wayland.rs
+++ b/crates/glass-testapp/tests/wayland.rs
@@ -437,4 +437,4 @@ fn wayland_build_step_runs_before_launch() {
 }
 
 // (Build-step network containment tests removed: the build step is unsandboxed by design —
-// only the launched run is contained. See the unsandbox-build change / gap #5.)
+// only the launched run is contained.)

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -507,7 +507,7 @@ fn onbox_egui_set_value_honesty() {
 // Uncontained: end-to-end verification that a Windows ctrl+scroll both DELIVERS the wheel with its
 // modifier on the event (`ev_ctrl`) AND holds the modifier across the wheel's frame so the
 // frame-aggregate `i.modifiers.ctrl` (`frame_ctrl`) — the layer a real handler gates on — reads it.
-// The event reaching egui was never the gap; the gap is the frame-aggregate modifier, which a
+// The event reaching egui was never the bug; the bug is the frame-aggregate modifier, which a
 // one-burst modifier+wheel+release drops (the modifier is released in the same frame the wheel
 // lands). run_scroll's hold-dwell-release fixes it. This is the working baseline the Sandboxie repro
 // is measured against.
@@ -539,7 +539,7 @@ fn onbox_scroll_modifier_delivery() {
 }
 
 // The same two assertions across the Sandboxie boundary: the wheel + its event modifier cross into
-// the contained app (never the gap), and the modifier is held across the wheel's frame so a contained
+// the contained app (never the bug), and the modifier is held across the wheel's frame so a contained
 // handler reading `i.modifiers.ctrl` sees it.
 #[test]
 #[ignore = "on-box only: needs the interactive desktop session + Sandboxie + builds the egui fixture"]


### PR DESCRIPTION
## What

A few public test comments referenced internal dogfood **gap numbers** (`gap #5`) and a private planning spec. Per the repo guideline (public glass code describes *what the behaviour is*, not internal tracking), these are reworded to describe the behaviour under test.

## Changes (comment-only, no behaviour change)

- `glass-testapp/tests/integration.rs` — drop the `gap #5` tag from the unsandboxed-build comment; drop the `see the spec` pointer from the focus-on-start comment.
- `glass-testapp/tests/wayland.rs` — drop the `gap #5` tag from the removed-build-network-test note.
- `glass-windows/tests/onbox.rs` — "the gap" → "the bug" in the ctrl+scroll comments (it meant the bug under test).

Remaining uses of the word "gap" in the tree are legitimate common-noun usages (timing gaps, digit spacing, sequence gaps), left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)