### PR TITLE
docs(readme): scope the X11 "only thing to install" to the display

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ between screenshots cost no vision tokens.
 - **A display dependency**, for the backend you'll run:
   - **Linux / X11 (default):** the headless X server — `sudo apt-get install -y xvfb`
     (Debian/Ubuntu; Fedora `xorg-x11-server-Xvfb`, Arch `xorg-server-xvfb`). glass spawns
-    its own private display, so this binary is the only thing to install.
+    its own private display, so Xvfb is all you need for the display — no desktop or
+    window manager. (You'll still need a containment runtime by default — see below.)
   - **Linux / Wayland:** a discoverable `sway ≥ 1.12` plus [Mesa](https://www.mesa3d.org/) software GL — see
     [Running on Wayland](#running-on-wayland-sway).
   - **Windows:** nothing extra; glass uses built-in Windows APIs.


### PR DESCRIPTION
## What

The X11 prerequisite read:

> glass spawns its own private display, so **this binary is the only thing to install**.

Technically true *for the display dependency* — but it reads as the only install for glass overall. In the default configuration you also need a **containment runtime** (bubblewrap on Linux), which is fail-closed: without it, `glass_start` errors. That requirement is the very next prerequisite bullet, so the absolute phrasing here is misleading.

## Change

Rescope the claim to what it actually means — glass spawns its own headless Xvfb, so no desktop or window manager is needed — and add a one-line pointer to the containment prerequisite:

> glass spawns its own private display, so Xvfb is all you need for the display — no desktop or window manager. (You'll still need a containment runtime by default — see below.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)