### PR TITLE
fix(input): self-commit each keystroke when typing on X11 and Wayland

### DIFF
--- a/crates/glass-core/src/typing.rs
+++ b/crates/glass-core/src/typing.rs
@@ -1,44 +1,39 @@
 //! Platform-agnostic text-typing model: the `run_type` driver that types a string one
-//! character at a time against any backend's `TypeSink`, pacing each keystroke with a dwell
-//! so a target that processes input asynchronously drains one before the next arrives.
+//! character at a time against any backend's `TypeSink`, committing each keystroke before
+//! the next so a client that processes input asynchronously doesn't miss keys.
 
 use std::time::Duration;
 
-/// Default dwell between consecutive typed characters. On Windows, injecting
-/// `KEYEVENTF_UNICODE` keystrokes faster than the target drains its input queue triggers a
-/// race *downstream* of glass: the OS resolves queued `VK_PACKET` events from a shared slot,
-/// so a backed-up run of characters all collapse to the *last* value written (`"aaa bbb ccc"`
-/// typed as `"aaa ccccccc"`; identical-character runs are unaffected). glass injects the
-/// correct keystrokes with zero drops — the corruption is in the OS/target, and a
-/// per-character dwell long enough for it to keep up avoids it. Tunable per host on Windows
-/// via `GLASS_TYPE_DWELL_MS` (raise on a slow/loaded box, lower for speed). 60ms is the
-/// measured-reliable floor on a Win11 interactive desktop (30ms still dropped a character
-/// ~1/3 of the time on strings with adjacent identical characters).
+/// Default dwell between consecutive typed characters. Used by the Windows backend (tunable
+/// via `GLASS_TYPE_DWELL_MS`): injecting `KEYEVENTF_UNICODE` keystrokes faster than the
+/// target drains its queue races a downstream OS bug that collapses a run of characters to
+/// the last one (`"aaa bbb ccc"` → `"aaa ccccccc"`). 60ms is the measured-reliable floor on
+/// a Win11 desktop. The Linux backends pace by committing each keystroke (X11 `XFlush` /
+/// Wayland roundtrip) rather than by sleeping, so they pass a shorter dwell.
 pub const TYPE_DWELL: Duration = Duration::from_millis(60);
 
-/// The per-backend primitive that [`run_type`] sequences. `character` is **self-committed**
-/// (it performs the backend's commit barrier before returning — Windows one `SendInput` per
-/// call), so `run_type` owns only the per-character ordering and the inter-character dwell.
+/// The per-backend primitive that [`run_type`] sequences. `character` must be
+/// **self-committed**: it performs the backend's commit barrier before returning — Windows
+/// one `SendInput`, X11 `XFlush`, Wayland a compositor roundtrip — so each keystroke is
+/// delivered before the next. A picky or heavy client (e.g. a browser) silently drops
+/// keystrokes that are merely queued and committed once at the end.
 pub trait TypeSink {
-    /// Press and release one character — `code_units` is its UTF-16 encoding (one unit for a
-    /// BMP char, two for a surrogate pair). The pair is committed together so a non-BMP
-    /// character is never split across the dwell.
-    fn character(&mut self, code_units: &[u16]) -> crate::Result<()>;
+    /// Press and release one character, committing before returning.
+    fn character(&mut self, c: char) -> crate::Result<()>;
 }
 
 /// Type `text` against a backend `sink`, one character at a time, sleeping `dwell` *between*
 /// characters (so there are `n-1` dwells — none before the first or after the last). Each
-/// character is emitted as its own committed injection; the dwell is what keeps a string from
-/// being delivered faster than the target can drain it.
+/// character is its own committed keystroke; together with the dwell this keeps a string
+/// from being delivered faster than the target can drain it.
 pub fn run_type<S: TypeSink>(sink: &mut S, text: &str, dwell: Duration) -> crate::Result<()> {
-    let mut buf = [0u16; 2];
     let mut first = true;
     for c in text.chars() {
         if !first {
             std::thread::sleep(dwell);
         }
         first = false;
-        sink.character(c.encode_utf16(&mut buf))?;
+        sink.character(c)?;
     }
     Ok(())
 }
@@ -51,31 +46,31 @@ mod tests {
 
     #[derive(Default)]
     struct RecordingSink {
-        chars: Vec<Vec<u16>>,
+        chars: Vec<char>,
     }
     impl TypeSink for RecordingSink {
-        fn character(&mut self, code_units: &[u16]) -> Result<()> {
-            self.chars.push(code_units.to_vec());
+        fn character(&mut self, c: char) -> Result<()> {
+            self.chars.push(c);
             Ok(())
         }
     }
 
     #[test]
-    fn emits_each_character_individually_including_adjacent_duplicates() {
-        // The bug class: adjacent identical characters. Each must be emitted as its own
-        // character, in order — never collapsed or batched.
+    fn emits_each_character_in_order_including_adjacent_duplicates() {
+        // The bug class: runs of adjacent identical characters (and spaces). Each must be
+        // emitted as its own keystroke, in order — never collapsed or batched.
         let mut sink = RecordingSink::default();
-        run_type(&mut sink, "aab", Duration::ZERO).unwrap();
-        assert_eq!(sink.chars, vec![vec![b'a' as u16], vec![b'a' as u16], vec![b'b' as u16]]);
+        run_type(&mut sink, "aab c", Duration::ZERO).unwrap();
+        assert_eq!(sink.chars, vec!['a', 'a', 'b', ' ', 'c']);
     }
 
     #[test]
-    fn keeps_a_surrogate_pair_in_one_commit() {
-        // U+1D11E (𝄞) is a non-BMP char: two UTF-16 units that must stay in one committed
-        // injection, not be split across the inter-character dwell.
+    fn passes_each_char_whole_including_non_bmp() {
+        // run_type splits on `char`, never bytes/code units — a non-BMP character (U+1D11E)
+        // reaches the sink as a single `char`, so a backend can't split it mid-keystroke.
         let mut sink = RecordingSink::default();
-        run_type(&mut sink, "𝄞", Duration::ZERO).unwrap();
-        assert_eq!(sink.chars, vec![vec![0xD834, 0xDD1E]]);
+        run_type(&mut sink, "a𝄞b", Duration::ZERO).unwrap();
+        assert_eq!(sink.chars, vec!['a', '𝄞', 'b']);
     }
 
     #[test]

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -570,12 +570,37 @@ fn upload_keymap(s: &mut ActiveSession, kb: &ZwpVirtualKeyboardV1, keymap: &str)
     Ok(())
 }
 
-/// Press then release evdev keycode `kc`, bumping the session clock per event.
-fn tap(s: &mut ActiveSession, kb: &ZwpVirtualKeyboardV1, kc: u32) {
-    s.time = s.time.wrapping_add(1);
-    kb.key(s.time, kc, 1); // 1 = pressed
-    s.time = s.time.wrapping_add(1);
-    kb.key(s.time, kc, 0); // 0 = released
+/// Press then release evdev keycode `kc`, bumping the session clock per event and
+/// self-committing (roundtrip + settle) after each — so the compositor processes the
+/// press/release individually, like the chord sink. A heavy client (e.g. a browser) ignores
+/// taps that are merely queued and flushed once at the end.
+fn tap(s: &mut ActiveSession, kb: &ZwpVirtualKeyboardV1, kc: u32) -> Result<()> {
+    for state in [1u32, 0] {
+        s.time = s.time.wrapping_add(1);
+        kb.key(s.time, kc, state);
+        s.queue
+            .roundtrip(&mut s.state)
+            .map_err(|e| GlassError::Backend(format!("roundtrip: {e}")))?;
+        std::thread::sleep(Duration::from_millis(8));
+    }
+    Ok(())
+}
+
+/// `TypeSink` for Wayland: types each character by uploading a one-key keymap (the char's
+/// keysym at keycode 1) and tapping it, self-committed per key — exactly the chord sink's
+/// shape. A heavy client (e.g. a browser) ignores keys tapped under a multi-key keymap it
+/// hasn't adopted, or flushed only once at the end. See glass_core::run_type.
+struct WaylandTypeSink<'a> {
+    s: &'a mut ActiveSession,
+    kb: ZwpVirtualKeyboardV1,
+}
+
+impl glass_core::TypeSink for WaylandTypeSink<'_> {
+    fn character(&mut self, c: char) -> Result<()> {
+        let ks = glass_core::keys::keysym_for_text(c);
+        upload_keymap(&mut *self.s, &self.kb, &crate::keyboard::build_keymap(&[ks]))?;
+        tap(&mut *self.s, &self.kb, 1)
+    }
 }
 
 /// XKB real-modifier mask for a chord's modifiers (standard `include "complete"`
@@ -1072,30 +1097,17 @@ impl Platform for WaylandPlatform {
         Ok(())
     }
     fn send_key(&mut self, event: &KeyEvent) -> Result<()> {
-        use crate::keyboard::build_keymap;
-        use glass_core::keys::{keysym_for_text, parse_chord};
+        use glass_core::keys::parse_chord;
         let session = self.active.as_mut().ok_or(GlassError::NoActiveSession)?;
         let kb = session.keyboard.clone();
         match event {
-            KeyEvent::Text(s) => {
-                let chars: Vec<char> = s.chars().collect();
-                if chars.is_empty() {
-                    return Ok(());
-                }
-                // One keycode per distinct keysym (first-occurrence order).
-                let mut syms: Vec<u32> = Vec::new();
-                for &c in &chars {
-                    let ks = keysym_for_text(c);
-                    if !syms.contains(&ks) {
-                        syms.push(ks);
-                    }
-                }
-                upload_keymap(session, &kb, &build_keymap(&syms))?;
-                for &c in &chars {
-                    let ks = keysym_for_text(c);
-                    let kc = syms.iter().position(|&k| k == ks).unwrap() as u32 + 1;
-                    tap(session, &kb, kc);
-                }
+            KeyEvent::Text(text) => {
+                // Per-character, self-committed typing (a 1-key keymap + tap, roundtripped
+                // per key) so a heavy client receives a long string instead of dropping a
+                // batch — see glass_core::run_type and WaylandTypeSink. The per-key roundtrip
+                // is the pacing, so no extra inter-character dwell is needed.
+                let mut sink = WaylandTypeSink { s: &mut *session, kb };
+                glass_core::run_type(&mut sink, text, std::time::Duration::ZERO)?;
             }
             KeyEvent::Chord(c) => {
                 let (mods, keysym) = parse_chord(c)?; // validates before any traffic

--- a/crates/glass-windows/src/input.rs
+++ b/crates/glass-windows/src/input.rs
@@ -272,9 +272,12 @@ fn type_dwell() -> std::time::Duration {
 }
 
 impl glass_core::TypeSink for WindowsTypeSink {
-    fn character(&mut self, code_units: &[u16]) -> Result<()> {
-        let mut inputs = Vec::with_capacity(code_units.len() * 2);
-        for &unit in code_units {
+    fn character(&mut self, c: char) -> Result<()> {
+        // All of the char's UTF-16 units (1 for BMP, 2 for a surrogate pair) go in one
+        // SendInput so a non-BMP char is committed as a unit.
+        let mut buf = [0u16; 2];
+        let mut inputs = Vec::with_capacity(4);
+        for unit in c.encode_utf16(&mut buf).iter().copied() {
             inputs.push(key_unicode(unit, false));
             inputs.push(key_unicode(unit, true));
         }

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -646,6 +646,27 @@ impl glass_core::DragSink for X11DragSink<'_> {
     }
 }
 
+/// `TypeSink` for X11: each character is typed via XTEST and committed with its own `XFlush`
+/// (like the chord sink), so `run_type`'s per-character commit reaches the server before the
+/// next. A heavy client (e.g. a browser) drops a string whose key events are all flushed once
+/// at the end. `idx` tracks position for the untypable-char error, which must never embed the
+/// char value (it would leak typed content into the unredacted audit log).
+struct X11TypeSink<'a> {
+    p: &'a X11Platform,
+    idx: usize,
+}
+
+impl glass_core::TypeSink for X11TypeSink<'_> {
+    fn character(&mut self, c: char) -> Result<()> {
+        let keysym = glass_core::keys::keysym_for_char(c).ok_or_else(|| {
+            GlassError::InvalidKey(format!("char at index {} has no X11 keysym", self.idx))
+        })?;
+        self.idx += 1;
+        self.p.key_with_mods(keysym, false, &[])?;
+        self.p.conn.flush().map_err(|e| GlassError::Backend(format!("flush: {e}")))
+    }
+}
+
 /// Lets `glass_core::run_chord` drive an X11 key chord through the existing XTEST primitives. Each
 /// method self-commits with `XFlush`; the modifier keycodes are held between `modifiers(true)` and
 /// `modifiers(false)`, so a frame-based client sees the modifier held across the key's frame.
@@ -862,16 +883,12 @@ impl Platform for X11Platform {
     fn send_key(&mut self, event: &KeyEvent) -> Result<()> {
         match event {
             KeyEvent::Text(text) => {
-                // Identify an untypable char by its POSITION, never its value: this error
-                // is recorded verbatim in the audit log's `result.error`, which is not
-                // run through content redaction, so embedding the char would leak typed
-                // content. The caller can recover the char from its own input + the index.
-                for (i, c) in text.chars().enumerate() {
-                    let keysym = glass_core::keys::keysym_for_char(c).ok_or_else(|| {
-                        GlassError::InvalidKey(format!("char at index {i} has no X11 keysym"))
-                    })?;
-                    self.key_with_mods(keysym, false, &[])?;
-                }
+                // Per-character, self-committed typing (an XFlush per char) so a heavy client
+                // (e.g. a browser) receives a long string instead of dropping events flushed
+                // once at the end — see glass_core::run_type and X11TypeSink. The 8ms dwell
+                // paces between characters (XFlush sends but does not wait).
+                let mut sink = X11TypeSink { p: &*self, idx: 0 };
+                glass_core::run_type(&mut sink, text, std::time::Duration::from_millis(8))?;
             }
             KeyEvent::Chord(chord) => {
                 let (mods, keysym) = glass_core::keys::parse_chord(chord)?;


### PR DESCRIPTION
## Problem

glass could not type into **firefox** on Linux — on *both* X11 and Wayland. Chords (`glass_key`) landed, but `glass_type` produced nothing. Lightweight apps (glass-testapp, `xed`) typed fine, which masked it.

## Root cause (same class as #42)

The typing path emits every key event then **commits once at the end** — X11 a single `XFlush`, Wayland a single flush — whereas the **chord/scroll/drag sinks self-commit per primitive** (per-`XFlush` / per-roundtrip). A heavy or picky client (firefox) silently drops a batch it's handed all at once. This is the same bug the Windows `run_type` fix (#42) addressed; typing was simply the one input path on Linux that never got the per-key-commit treatment.

Confirmed live on both backends: `glass_key "a"` (chord, self-committed) typed into firefox's URL bar, but batched `glass_type` did not — and a longer keymap-adoption settle didn't help, ruling out latency and pointing squarely at the missing per-key commit.

## Fix

Route X11 and Wayland `KeyEvent::Text` through `glass_core::run_type` (already used by Windows) with self-committing `TypeSink`s:
- **X11TypeSink** — an `XFlush` per character, paced by a short dwell (`XFlush` sends but doesn't wait).
- **WaylandTypeSink** — a one-key keymap + tap, **roundtripped per key** (firefox also ignores a multi-key keymap it hasn't adopted before the taps arrive).

`TypeSink::character` now takes a `char` (the Windows sink encodes UTF-16 internally), so all three backends share one driver — consistent with how `run_chord`/`run_scroll`/`run_drag` already work.

## Verification

- **firefox now receives typed text on both backends** — `x11 fix aaa bbb ccc` (X11) and `wayland fix aaa bbb ccc` (sway), where before the fix nothing landed.
- `glass-testapp`/`xed` and the **X11 + Wayland integration suites stay green**; full `cargo test --workspace` passes; Windows cross-compiles + clippy clean on all backends.

## Caveats

- Verified via firefox's **URL bar (chrome)**. The web-content `<textarea>` wouldn't take focus from a click under headless Xvfb/sway — a separate focus matter, **not** the typing path (likely fine on a real desktop with a WM).
- **Perf:** typing is now per-character. Wayland re-uploads a 1-key keymap + roundtrips per key (~tens of ms/char); X11 ~8ms/char. Correctness over speed here; a single-keymap optimization is possible but unverified (it'd need another firefox cycle).
- The testapp integration tests pass with or without this fix (light consumer), so they don't guard the heavy-client behavior — that's verified live, consistent with how the chord/scroll/drag sinks are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)