### PR TITLE
Android a11y-service: ServiceA11y reader (Compose-rich tree + high-fidelity set_value)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,9 +24,10 @@ Cargo workspace at the repo root. Crates: `glass-core` (platform-agnostic heart 
 backends (`glass-x11`, `glass-wayland`, `glass-windows`, `glass-android`), the a11y readers
 (`glass-a11y-linux`, `glass-a11y-windows`; the Android `uiautomator` reader lives in
 `glass-android`), `glass-sandbox-linux`, the `glass-mcp` server binary, and the
-`glass-testapp` fixture. `glass-android` also holds the host-side client + lifecycle for the
-optional on-device agent; the agent itself is a separate repo
-(`github.com/fixed-width/glass-android-agent`), driven over `adb forward`.
+`glass-testapp` fixture. `glass-android` also holds the host-side client + lifecycle for two
+optional on-device companions — an `app_process` agent (clipboard + high-fidelity input) and an
+`AccessibilityService` (Compose-rich a11y tree + high-fidelity `set_value`); both live in the
+separate repo `github.com/fixed-width/glass-android-agent`, driven over `adb forward`.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -308,8 +308,9 @@ across backends — only the setup differs:
   sandbox, so there's no separate containment step. The app is built (`spec.build`, e.g.
   `./gradlew assembleDebug`) on the host, installed, and launched; `glass_start`'s `run` is the
   launch component `package/.Activity` (plus an optional `.apk`). Capture, input, logs,
-  multi-window, and a `uiautomator` accessibility tree work over `adb`; clipboard and
-  high-fidelity input come from an optional on-device agent. Window
+  multi-window, and a `uiautomator` accessibility tree work over `adb`; two optional on-device
+  companions add more — an agent for clipboard + high-fidelity input, and an AccessibilityService
+  for a Compose-rich a11y tree + high-fidelity `set_value`. Window
   resize/move (apps are full-screen) and physical devices are non-goals. See the Android section
   of your host guide: [Linux](docs/running-on-linux.md) · [Windows](docs/running-on-windows.md) · [macOS](docs/running-on-macos.md).
 
@@ -347,7 +348,7 @@ Where glass stands by OS. **✓** supported · **◑** partial · **–** not su
 | Containment / sandboxing | ✓ bubblewrap | ✓ Sandboxie Classic | ✓ the emulator VM | 🚧 |
 | Display isolation (app off your desktop) | ✓ headless Xvfb / sway | – interactive desktop | ✓ headless emulator | 🚧 |
 
-† **Android** is emulator-only. Capture, multi-window, input, and logs work over `adb`, and glass manages the AVD (attach a running one, or boot a headless one). **Clipboard and high-fidelity input** use the optional on-device agent (see the Android section of your host guide: [Linux](docs/running-on-linux.md) · [Windows](docs/running-on-windows.md) · [macOS](docs/running-on-macos.md)) — without it, input falls back to adb's `input` and clipboard is unavailable. Window resize/move (apps are full-screen) and physical devices are non-goals.
+† **Android** is emulator-only. Capture, multi-window, input, and logs work over `adb`, and glass manages the AVD (attach a running one, or boot a headless one). **Clipboard and high-fidelity input** use the optional on-device agent, and an optional on-device **AccessibilityService** sharpens the a11y tree (Compose) + `set_value` (both in the Android section of your host guide: [Linux](docs/running-on-linux.md) · [Windows](docs/running-on-windows.md) · [macOS](docs/running-on-macos.md)) — without the agent, input falls back to adb's `input` and clipboard is unavailable; without the service, a11y falls back to `uiautomator`. Window resize/move (apps are full-screen) and physical devices are non-goals.
 
 The per-platform detail — sandboxing levels, display isolation, the accessibility tree —
 lives in the [Containment](#containment--sandboxing), [Backends](#backends), and
@@ -363,9 +364,11 @@ The Linux feature set is implemented and tested across **both** Linux backends
 (X11 and Wayland/wlroots), and the **Windows** backend (WGC capture, SendInput, UI
 Automation) is built and CI-tested. An **Android** backend drives native apps in an AVD
 emulator over `adb` — capture, input, logcat, multi-window, a `uiautomator` accessibility
-tree, a managed AVD (attach-or-boot), and — via an optional
-[on-device agent](docs/running-on-linux.md#optional-on-device-agent-clipboard--high-fidelity-input) (Linux) / [on-device agent](docs/running-on-windows.md#optional-on-device-agent-clipboard--high-fidelity-input) (Windows) — clipboard and high-fidelity input; it's built and
-unit-tested in CI and validated on-device. **macOS is the one OS backend not yet built.**
+tree, a managed AVD (attach-or-boot), and two optional on-device companions — an agent
+(clipboard + high-fidelity input) and an AccessibilityService (Compose-rich a11y tree +
+high-fidelity `set_value`), both set up in the [Linux](docs/running-on-linux.md) /
+[Windows](docs/running-on-windows.md) Android guides; it's built and unit-tested in CI and
+validated on-device. **macOS is the one OS backend not yet built.**
 
 ## License
 

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -14,8 +14,15 @@ use crate::axmap::class_to_role;
 use crate::conn::Conn;
 
 /// Map one device `tree` JSON node (+descendants) into an `AxNode`, converting screen bounds to
-/// window-relative. Ids are left at `AxNodeId(0)`; the core assigns them (same pre-order order
-/// as the device's `ref`, so `AxNodeId(n)` == device `ref` n).
+/// window-relative. Ids are left `AxNodeId(0)`; the core's `AxTree::assign_ids` numbers them
+/// pre-order (root = 0).
+///
+/// INVARIANT: `AxNodeId(n)` equals the device's `ref` n. Both sides number the *same* node set in
+/// the *same* pre-order: the device assigns `ref` while walking its adapted tree, sends that tree
+/// as JSON `children` (in order), and this mapper recurses `children` in order without skipping or
+/// reordering — a node with malformed/missing bounds errors the whole snapshot rather than being
+/// dropped (which would shift every later id). So `set_value` can send `target.id.0` as the device
+/// `ref` and hit the right node. Keep both walks pre-order if either side changes.
 fn json_to_node(v: &Value, win: &WindowGeometry) -> Result<AxNode> {
     let cls = v.get("class").and_then(Value::as_str).unwrap_or("");
     let text = v.get("text").and_then(Value::as_str);
@@ -23,13 +30,17 @@ fn json_to_node(v: &Value, win: &WindowGeometry) -> Result<AxNode> {
     let b = v
         .get("bounds")
         .ok_or_else(|| GlassError::AccessibilityUnavailable("node missing bounds".into()))?;
-    let (x, y, w, h) = (
-        b.get("x").and_then(Value::as_i64).unwrap_or(0) as i32,
-        b.get("y").and_then(Value::as_i64).unwrap_or(0) as i32,
-        b.get("w").and_then(Value::as_i64).unwrap_or(0) as u32,
-        b.get("h").and_then(Value::as_i64).unwrap_or(0) as u32,
-    );
+    let b_i32 = |k: &str| -> Result<i32> {
+        b.get(k).and_then(Value::as_i64).and_then(|v| i32::try_from(v).ok())
+            .ok_or_else(|| GlassError::AccessibilityUnavailable(format!("node bounds.{k} missing or out of range")))
+    };
+    let b_u32 = |k: &str| -> Result<u32> {
+        b.get(k).and_then(Value::as_i64).and_then(|v| u32::try_from(v).ok())
+            .ok_or_else(|| GlassError::AccessibilityUnavailable(format!("node bounds.{k} missing or out of range")))
+    };
+    let (x, y, w, h) = (b_i32("x")?, b_i32("y")?, b_u32("w")?, b_u32("h")?);
     let flag = |k: &str| v.get(k).and_then(Value::as_bool).unwrap_or(false);
+    // Recursion depth = a11y tree depth (shallow in practice; not hardened against adversarial nesting).
     let children = match v.get("children").and_then(Value::as_array) {
         Some(arr) => arr.iter().map(|c| json_to_node(c, win)).collect::<Result<Vec<_>>>()?,
         None => vec![],
@@ -38,11 +49,14 @@ fn json_to_node(v: &Value, win: &WindowGeometry) -> Result<AxNode> {
         id: AxNodeId(0),
         role: class_to_role(cls),
         raw_role: cls.to_string(),
+        // name: the element's own text label, falling back to content-description.
+        // value: editable text content only (content-description is not user-entered text).
         name: text.or(desc).map(str::to_string),
         value: text.map(str::to_string),
         states: AxStates {
             enabled: flag("enabled"),
             editable: flag("editable"),
+            // Android "focusable" is keyboard-only; map isClickable -> focusable as the actability proxy.
             focusable: flag("clickable"),
             visible: true,
             ..Default::default()
@@ -54,6 +68,7 @@ fn json_to_node(v: &Value, win: &WindowGeometry) -> Result<AxNode> {
 
 /// Build the `AxTree` from a device `tree` response value (the `"tree"` object).
 pub(crate) fn tree_from_json(tree: &Value, win: &WindowGeometry) -> Result<AxTree> {
+    // count stays 0 until the caller runs AxTree::assign_ids (per the Accessibility trait contract).
     Ok(AxTree { root: json_to_node(tree, win)?, count: 0 })
 }
 

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -168,7 +168,8 @@ impl Accessibility for ServiceA11y {
             let mut after = self.snapshot(ctx)?;
             after.assign_ids();
             let got = after.find(target.id).and_then(|n| n.value.clone());
-            if got.as_deref() == Some(text) {
+            // An empty field reports no value (None), not Some(""), so compare against "".
+            if got.as_deref().unwrap_or("") == text {
                 return Ok(());
             }
             if std::time::Instant::now() >= deadline {
@@ -198,7 +199,7 @@ pub fn a11y_apk(get: &dyn Fn(&str) -> Option<String>) -> Option<String> {
     get("GLASS_ANDROID_A11Y_APK").filter(|s| !s.is_empty())
 }
 
-struct Active { serial: Option<String>, port: u16, prior_enabled: String }
+struct Active { serial: Option<String>, port: u16, prior_enabled: String, prior_a11y_enabled: String }
 
 /// Owns the installed+enabled state so the shutdown hook can restore it. Cloneable (shared
 /// `Arc<Mutex<Option<Active>>>`) like `AgentRegistry`.
@@ -212,10 +213,14 @@ impl A11yServiceRegistry {
     /// connected `ServiceClient`. The apk path is resolved from env by the caller.
     pub fn ensure(&self, adb: &Adb, apk: &str) -> Result<ServiceClient> {
         adb.run(["install", "-r", apk])?;
-        let prior = adb.run(["shell", "settings", "get", "secure", "enabled_accessibility_services"])
-            .unwrap_or_default();
+        let get = |k: &str| adb.run(["shell", "settings", "get", "secure", k]).unwrap_or_default();
+        let prior = get("enabled_accessibility_services");
         let prior = prior.trim();
         let prior = if prior == "null" { "" } else { prior };
+        // Save the global flag too, so teardown restores the device's prior a11y state exactly.
+        let prior_a11y = get("accessibility_enabled");
+        let prior_a11y = prior_a11y.trim();
+        let prior_a11y = if prior_a11y == "null" || prior_a11y.is_empty() { "0" } else { prior_a11y };
         let want = if prior.is_empty() { SERVICE_COMPONENT.to_string() }
                    else if prior.split(':').any(|s| s == SERVICE_COMPONENT) { prior.to_string() }
                    else { format!("{prior}:{SERVICE_COMPONENT}") };
@@ -224,14 +229,25 @@ impl A11yServiceRegistry {
         let out = adb.run(["forward", "tcp:0", &format!("localabstract:{SOCKET}")])?;
         let port = crate::agent::parse_forward_port(&out)
             .ok_or_else(|| GlassError::Backend(format!("adb forward gave no port: {out:?}")))?;
-        let client = wait_for_service(port)?; // connect + ping, retry briefly
+        // From here, a failure must roll back the settings + forward, else a failed `ensure` leaks
+        // an enabled service and a forward slot.
+        let client = match wait_for_service(port) {
+            Ok(c) => c,
+            Err(e) => {
+                restore_a11y(adb, prior, prior_a11y, port);
+                return Err(e);
+            }
+        };
         *self.state.lock().unwrap() = Some(Active {
-            serial: adb.serial().map(str::to_string), port, prior_enabled: prior.to_string(),
+            serial: adb.serial().map(str::to_string),
+            port,
+            prior_enabled: prior.to_string(),
+            prior_a11y_enabled: prior_a11y.to_string(),
         });
         Ok(client)
     }
 
-    /// Restore the prior accessibility-services setting and remove the forward. Best-effort,
+    /// Restore the device's prior accessibility state and remove the forward. Best-effort,
     /// idempotent. No process to kill (disabling unbinds the service).
     pub fn shutdown(&self) {
         if let Ok(mut g) = self.state.lock() {
@@ -240,19 +256,23 @@ impl A11yServiceRegistry {
                     Some(s) => Adb::from_env().with_serial(s.clone()),
                     None => Adb::from_env(),
                 };
-                if a.prior_enabled.is_empty() {
-                    // `settings put ... ""` errors ("Bad arguments"); delete to clear the list and
-                    // turn a11y off (we enabled it; with no prior service nothing else needs it).
-                    let _ = adb.run(["shell", "settings", "delete", "secure", "enabled_accessibility_services"]);
-                    let _ = adb.run(["shell", "settings", "put", "secure", "accessibility_enabled", "0"]);
-                } else {
-                    let _ = adb.run(["shell", "settings", "put", "secure",
-                        "enabled_accessibility_services", &a.prior_enabled]);
-                }
-                let _ = adb.run(["forward", "--remove", &format!("tcp:{}", a.port)]);
+                restore_a11y(&adb, &a.prior_enabled, &a.prior_a11y_enabled, a.port);
             }
         }
     }
+}
+
+/// Restore `enabled_accessibility_services` + `accessibility_enabled` to their prior values and
+/// remove the forwarded port. Shared by `shutdown` and the failed-`ensure` rollback. Best-effort.
+fn restore_a11y(adb: &Adb, prior_enabled: &str, prior_a11y_enabled: &str, port: u16) {
+    if prior_enabled.is_empty() {
+        // `settings put ... ""` errors ("Bad arguments"); delete to clear the list instead.
+        let _ = adb.run(["shell", "settings", "delete", "secure", "enabled_accessibility_services"]);
+    } else {
+        let _ = adb.run(["shell", "settings", "put", "secure", "enabled_accessibility_services", prior_enabled]);
+    }
+    let _ = adb.run(["shell", "settings", "put", "secure", "accessibility_enabled", prior_a11y_enabled]);
+    let _ = adb.run(["forward", "--remove", &format!("tcp:{port}")]);
 }
 
 /// Connect to the forwarded service port, retrying briefly while the service binds + listens.

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -73,15 +73,12 @@ pub(crate) fn tree_from_json(tree: &Value, win: &WindowGeometry) -> Result<AxTre
 }
 
 /// Line-JSON client to the on-device a11y service (mirrors `AgentClient`).
-pub(crate) struct ServiceClient {
+pub struct ServiceClient {
     conn: Mutex<Conn>,
     port: u16,
 }
 
 impl ServiceClient {
-    // NOTE: connect/ping are not yet called outside this module; will be consumed by Task 5
-    // (A11yServiceRegistry). The allows are temporary and will be removed when that task wires them.
-    #[allow(dead_code)]
     pub fn connect(port: u16) -> Result<ServiceClient> {
         let conn = Conn::open(port)?;
         Ok(ServiceClient { conn: Mutex::new(conn), port })
@@ -120,7 +117,6 @@ impl ServiceClient {
         self.call(req).map(|_| ())
     }
 
-    #[allow(dead_code)]
     pub fn ping(&self) -> Result<()> {
         self.call(json!({"op": "ping"})).map(|_| ())
     }
@@ -165,6 +161,82 @@ impl Accessibility for ServiceA11y {
             return Err(GlassError::AxElementNotEditable(target.id.0));
         }
         self.client.action(target.id.0, "set_text", Some(text))
+    }
+}
+
+use std::sync::Arc;
+use crate::adb::Adb;
+
+const SERVICE_COMPONENT: &str = "com.fixedwidth.glassa11y/com.fixedwidth.glassa11y.GlassA11yService";
+const SOCKET: &str = "glass-a11y";
+
+/// `GLASS_ANDROID_A11Y_APK` (path to the APK) when configured + not disabled.
+pub fn a11y_apk(get: &dyn Fn(&str) -> Option<String>) -> Option<String> {
+    if get("GLASS_ANDROID_A11Y").map(|v| v.eq_ignore_ascii_case("off")).unwrap_or(false) {
+        return None;
+    }
+    get("GLASS_ANDROID_A11Y_APK").filter(|s| !s.is_empty())
+}
+
+struct Active { serial: Option<String>, port: u16, prior_enabled: String }
+
+/// Owns the installed+enabled state so the shutdown hook can restore it. Cloneable (shared
+/// `Arc<Mutex<Option<Active>>>`) like `AgentRegistry`.
+#[derive(Clone, Default)]
+pub struct A11yServiceRegistry { state: Arc<std::sync::Mutex<Option<Active>>> }
+
+impl A11yServiceRegistry {
+    pub fn new() -> Self { Self::default() }
+
+    /// Install + enable the service on `adb`'s device, forward a port, connect, ping. Returns a
+    /// connected `ServiceClient`. The apk path is resolved from env by the caller.
+    pub fn ensure(&self, adb: &Adb, apk: &str) -> Result<ServiceClient> {
+        adb.run(["install", "-r", apk])?;
+        let prior = adb.run(["shell", "settings", "get", "secure", "enabled_accessibility_services"])
+            .unwrap_or_default();
+        let prior = prior.trim();
+        let prior = if prior == "null" { "" } else { prior };
+        let want = if prior.is_empty() { SERVICE_COMPONENT.to_string() }
+                   else if prior.split(':').any(|s| s == SERVICE_COMPONENT) { prior.to_string() }
+                   else { format!("{prior}:{SERVICE_COMPONENT}") };
+        adb.run(["shell", "settings", "put", "secure", "enabled_accessibility_services", &want])?;
+        adb.run(["shell", "settings", "put", "secure", "accessibility_enabled", "1"])?;
+        let out = adb.run(["forward", "tcp:0", &format!("localabstract:{SOCKET}")])?;
+        let port = crate::agent::parse_forward_port(&out)
+            .ok_or_else(|| GlassError::Backend(format!("adb forward gave no port: {out:?}")))?;
+        let client = wait_for_service(port)?; // connect + ping, retry briefly
+        *self.state.lock().unwrap() = Some(Active {
+            serial: adb.serial().map(str::to_string), port, prior_enabled: prior.to_string(),
+        });
+        Ok(client)
+    }
+
+    /// Restore the prior accessibility-services setting and remove the forward. Best-effort,
+    /// idempotent. No process to kill (disabling unbinds the service).
+    pub fn shutdown(&self) {
+        if let Ok(mut g) = self.state.lock() {
+            if let Some(a) = g.take() {
+                let adb = match &a.serial {
+                    Some(s) => Adb::from_env().with_serial(s.clone()),
+                    None => Adb::from_env(),
+                };
+                let _ = adb.run(["shell", "settings", "put", "secure",
+                    "enabled_accessibility_services", &a.prior_enabled]);
+                let _ = adb.run(["forward", "--remove", &format!("tcp:{}", a.port)]);
+            }
+        }
+    }
+}
+
+/// Connect to the forwarded service port, retrying briefly while the service binds + listens.
+pub(crate) fn wait_for_service(port: u16) -> Result<ServiceClient> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        match ServiceClient::connect(port).and_then(|c| c.ping().map(|_| c)) {
+            Ok(c) => return Ok(c),
+            Err(e) if std::time::Instant::now() >= deadline => return Err(e),
+            Err(_) => std::thread::sleep(std::time::Duration::from_millis(150)),
+        }
     }
 }
 

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -1,0 +1,193 @@
+//! `ServiceA11y` — the on-device-AccessibilityService a11y reader. Talks the `tree`/`action`
+//! line-JSON protocol to `glass-a11y.apk` over an `adb forward`ed socket, and maps the live
+//! `AccessibilityNodeInfo` tree (sent as JSON) into glass's `AxTree`.
+
+use std::sync::Mutex;
+
+use serde_json::{json, Value};
+
+use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxStates, AxTarget, AxTree};
+use glass_core::platform::WindowGeometry;
+use glass_core::{GlassError, Result};
+
+use crate::axmap::class_to_role;
+use crate::conn::Conn;
+
+/// Map one device `tree` JSON node (+descendants) into an `AxNode`, converting screen bounds to
+/// window-relative. Ids are left at `AxNodeId(0)`; the core assigns them (same pre-order order
+/// as the device's `ref`, so `AxNodeId(n)` == device `ref` n).
+fn json_to_node(v: &Value, win: &WindowGeometry) -> Result<AxNode> {
+    let cls = v.get("class").and_then(Value::as_str).unwrap_or("");
+    let text = v.get("text").and_then(Value::as_str);
+    let desc = v.get("desc").and_then(Value::as_str);
+    let b = v
+        .get("bounds")
+        .ok_or_else(|| GlassError::AccessibilityUnavailable("node missing bounds".into()))?;
+    let (x, y, w, h) = (
+        b.get("x").and_then(Value::as_i64).unwrap_or(0) as i32,
+        b.get("y").and_then(Value::as_i64).unwrap_or(0) as i32,
+        b.get("w").and_then(Value::as_i64).unwrap_or(0) as u32,
+        b.get("h").and_then(Value::as_i64).unwrap_or(0) as u32,
+    );
+    let flag = |k: &str| v.get(k).and_then(Value::as_bool).unwrap_or(false);
+    let children = match v.get("children").and_then(Value::as_array) {
+        Some(arr) => arr.iter().map(|c| json_to_node(c, win)).collect::<Result<Vec<_>>>()?,
+        None => vec![],
+    };
+    Ok(AxNode {
+        id: AxNodeId(0),
+        role: class_to_role(cls),
+        raw_role: cls.to_string(),
+        name: text.or(desc).map(str::to_string),
+        value: text.map(str::to_string),
+        states: AxStates {
+            enabled: flag("enabled"),
+            editable: flag("editable"),
+            focusable: flag("clickable"),
+            visible: true,
+            ..Default::default()
+        },
+        bounds: Some(AxRect { x: x - win.x, y: y - win.y, width: w, height: h }),
+        children,
+    })
+}
+
+/// Build the `AxTree` from a device `tree` response value (the `"tree"` object).
+pub(crate) fn tree_from_json(tree: &Value, win: &WindowGeometry) -> Result<AxTree> {
+    Ok(AxTree { root: json_to_node(tree, win)?, count: 0 })
+}
+
+/// Line-JSON client to the on-device a11y service (mirrors `AgentClient`).
+pub(crate) struct ServiceClient {
+    conn: Mutex<Conn>,
+    port: u16,
+}
+
+impl ServiceClient {
+    // NOTE: connect/ping are not yet called outside this module; will be consumed by Task 5
+    // (A11yServiceRegistry). The allows are temporary and will be removed when that task wires them.
+    #[allow(dead_code)]
+    pub fn connect(port: u16) -> Result<ServiceClient> {
+        let conn = Conn::open(port)?;
+        Ok(ServiceClient { conn: Mutex::new(conn), port })
+    }
+
+    /// Run a request, transparently reconnecting once if the socket dropped.
+    /// Mirrors `AgentClient::call`: lock, try, reconnect on `(e, true)`, retry.
+    fn call(&self, req: Value) -> Result<Value> {
+        let mut conn = self
+            .conn
+            .lock()
+            .map_err(|_| GlassError::Backend("a11y service client lock poisoned".into()))?;
+        match conn.call(req.clone()) {
+            Ok(v) => Ok(v),
+            Err((e, false)) => Err(e),
+            Err((_, true)) => {
+                // The service's accept loop accepts a fresh connection after a drop.
+                *conn = Conn::open(self.port)?;
+                conn.call(req).map_err(|(e, _)| e)
+            }
+        }
+    }
+
+    fn tree(&self, package: &str) -> Result<Value> {
+        let r = self.call(json!({"op": "tree", "package": package}))?;
+        r.get("tree")
+            .cloned()
+            .ok_or_else(|| GlassError::AccessibilityUnavailable("no tree in response".into()))
+    }
+
+    fn action(&self, ref_id: u32, action: &str, text: Option<&str>) -> Result<()> {
+        let mut req = json!({"op": "action", "ref": ref_id, "action": action});
+        if let Some(t) = text {
+            req["text"] = json!(t);
+        }
+        self.call(req).map(|_| ())
+    }
+
+    #[allow(dead_code)]
+    pub fn ping(&self) -> Result<()> {
+        self.call(json!({"op": "ping"})).map(|_| ())
+    }
+}
+
+/// The Accessibility reader backed by the on-device service. `package` is the target app.
+pub struct ServiceA11y {
+    client: ServiceClient,
+    package: String,
+}
+
+impl ServiceA11y {
+    // NOTE: new is not yet called outside this module; will be consumed by Task 5
+    // (A11yServiceRegistry). The allow is temporary.
+    #[allow(dead_code)]
+    pub(crate) fn new(client: ServiceClient, package: String) -> Self {
+        Self { client, package }
+    }
+}
+
+impl Accessibility for ServiceA11y {
+    fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
+        let tree = self.client.tree(&self.package)?;
+        tree_from_json(&tree, &ctx.window)
+    }
+
+    fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
+        // Guard: re-snapshot and verify the ref still points at the same editable element
+        // (role+name+bounds) before acting — the same drift protection as AndroidA11y::set_value.
+        let tree = {
+            let mut t = self.snapshot(ctx)?;
+            t.assign_ids();
+            t
+        };
+        let node = tree.find(target.id).ok_or(GlassError::AxElementNotFound(target.id.0))?;
+        if !target.matches(node.role, node.name.as_deref())
+            || !target.bounds_consistent(node.bounds, 8)
+        {
+            return Err(GlassError::AxElementChanged(target.id.0));
+        }
+        if !node.states.editable {
+            return Err(GlassError::AxElementNotEditable(target.id.0));
+        }
+        self.client.action(target.id.0, "set_text", Some(text))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use glass_core::accessibility::AxRole;
+    use serde_json::json;
+
+    fn win() -> WindowGeometry {
+        WindowGeometry { x: 0, y: 100, width: 1080, height: 2300 }
+    }
+
+    #[test]
+    fn maps_json_tree_to_window_relative_axtree() {
+        let v = json!({
+            "ref": 0, "class": "android.widget.FrameLayout",
+            "bounds": {"x": 0, "y": 100, "w": 1080, "h": 2300},
+            "editable": false, "clickable": false, "enabled": true, "scrollable": false,
+            "children": [
+                {"ref": 1, "class": "android.widget.EditText", "text": "Email",
+                 "bounds": {"x": 40, "y": 200, "w": 600, "h": 120},
+                 "editable": true, "clickable": true, "enabled": true, "scrollable": false},
+                {"ref": 2, "class": "android.widget.Button", "desc": "Save",
+                 "bounds": {"x": 40, "y": 360, "w": 200, "h": 100},
+                 "editable": false, "clickable": true, "enabled": true, "scrollable": false}
+            ]
+        });
+        let mut t = tree_from_json(&v, &win()).unwrap();
+        t.assign_ids();
+        assert_eq!(t.count, 3);
+        let email = t.find(AxNodeId(1)).unwrap();
+        assert_eq!(email.role, AxRole::TextField);
+        assert_eq!(email.name.as_deref(), Some("Email"));
+        assert!(email.states.editable);
+        assert_eq!(email.bounds.unwrap().y, 100); // window-relative: 200 - win.y 100
+        let save = t.find(AxNodeId(2)).unwrap();
+        assert_eq!(save.role, AxRole::Button);
+        assert_eq!(save.name.as_deref(), Some("Save"));
+    }
+}

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -129,10 +129,7 @@ pub struct ServiceA11y {
 }
 
 impl ServiceA11y {
-    // NOTE: new is not yet called outside this module; will be consumed by Task 5
-    // (A11yServiceRegistry). The allow is temporary.
-    #[allow(dead_code)]
-    pub(crate) fn new(client: ServiceClient, package: String) -> Self {
+    pub fn new(client: ServiceClient, package: String) -> Self {
         Self { client, package }
     }
 }

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -158,7 +158,29 @@ impl Accessibility for ServiceA11y {
         if !node.states.editable {
             return Err(GlassError::AxElementNotEditable(target.id.0));
         }
-        self.client.action(target.id.0, "set_text", Some(text))
+        self.client.action(target.id.0, "set_text", Some(text))?;
+        // Verify the value actually took. ACTION_SET_TEXT returns success but silently no-ops when
+        // *replacing* existing text in a Compose field, so a bare Ok could lie (glass forbids silent
+        // fallbacks). The set is async (Compose recompose → a11y update), so poll briefly for the
+        // value to land; error honestly only on timeout.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            let mut after = self.snapshot(ctx)?;
+            after.assign_ids();
+            let got = after.find(target.id).and_then(|n| n.value.clone());
+            if got.as_deref() == Some(text) {
+                return Ok(());
+            }
+            if std::time::Instant::now() >= deadline {
+                return Err(GlassError::Backend(format!(
+                    "set_value on element {} did not take (field is {got:?}, wanted {text:?}); a \
+                     Compose field that already holds text can't be replaced via ACTION_SET_TEXT — \
+                     clear it first or unset GLASS_ANDROID_A11Y_APK to use the uiautomator backend",
+                    target.id.0
+                )));
+            }
+            std::thread::sleep(std::time::Duration::from_millis(150));
+        }
     }
 }
 

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -30,15 +30,16 @@ fn json_to_node(v: &Value, win: &WindowGeometry) -> Result<AxNode> {
     let b = v
         .get("bounds")
         .ok_or_else(|| GlassError::AccessibilityUnavailable("node missing bounds".into()))?;
-    let b_i32 = |k: &str| -> Result<i32> {
-        b.get(k).and_then(Value::as_i64).and_then(|v| i32::try_from(v).ok())
-            .ok_or_else(|| GlassError::AccessibilityUnavailable(format!("node bounds.{k} missing or out of range")))
+    // Clamp rather than error: a live a11y tree legitimately contains degenerate/off-screen rects
+    // (zero or inverted w/h out of `getBoundsInScreen`), so erroring would fail the whole snapshot
+    // on one odd node. Negative w/h clamp to 0; values outside the int range clamp to its bounds.
+    let bi = |k: &str| -> i32 {
+        b.get(k).and_then(Value::as_i64).unwrap_or(0).clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32
     };
-    let b_u32 = |k: &str| -> Result<u32> {
-        b.get(k).and_then(Value::as_i64).and_then(|v| u32::try_from(v).ok())
-            .ok_or_else(|| GlassError::AccessibilityUnavailable(format!("node bounds.{k} missing or out of range")))
+    let bu = |k: &str| -> u32 {
+        b.get(k).and_then(Value::as_i64).unwrap_or(0).clamp(0, i64::from(u32::MAX)) as u32
     };
-    let (x, y, w, h) = (b_i32("x")?, b_i32("y")?, b_u32("w")?, b_u32("h")?);
+    let (x, y, w, h) = (bi("x"), bi("y"), bu("w"), bu("h"));
     let flag = |k: &str| v.get(k).and_then(Value::as_bool).unwrap_or(false);
     // Recursion depth = a11y tree depth (shallow in practice; not hardened against adversarial nesting).
     let children = match v.get("children").and_then(Value::as_array) {
@@ -217,8 +218,15 @@ impl A11yServiceRegistry {
                     Some(s) => Adb::from_env().with_serial(s.clone()),
                     None => Adb::from_env(),
                 };
-                let _ = adb.run(["shell", "settings", "put", "secure",
-                    "enabled_accessibility_services", &a.prior_enabled]);
+                if a.prior_enabled.is_empty() {
+                    // `settings put ... ""` errors ("Bad arguments"); delete to clear the list and
+                    // turn a11y off (we enabled it; with no prior service nothing else needs it).
+                    let _ = adb.run(["shell", "settings", "delete", "secure", "enabled_accessibility_services"]);
+                    let _ = adb.run(["shell", "settings", "put", "secure", "accessibility_enabled", "0"]);
+                } else {
+                    let _ = adb.run(["shell", "settings", "put", "secure",
+                        "enabled_accessibility_services", &a.prior_enabled]);
+                }
                 let _ = adb.run(["forward", "--remove", &format!("tcp:{}", a.port)]);
             }
         }
@@ -273,5 +281,19 @@ mod tests {
         let save = t.find(AxNodeId(2)).unwrap();
         assert_eq!(save.role, AxRole::Button);
         assert_eq!(save.name.as_deref(), Some("Save"));
+    }
+
+    #[test]
+    fn degenerate_bounds_clamp_instead_of_erroring() {
+        // A live a11y tree legitimately has zero/inverted rects; the mapper must clamp, not fail.
+        let v = json!({
+            "ref": 0, "class": "android.view.View",
+            "bounds": {"x": -5, "y": 10, "w": -3, "h": 0},
+            "editable": false, "clickable": false, "enabled": true, "scrollable": false
+        });
+        let t = tree_from_json(&v, &win()).expect("degenerate bounds must not error the snapshot");
+        let b = t.root.bounds.unwrap();
+        assert_eq!((b.width, b.height), (0, 0)); // negative/zero w/h clamp to 0
+        assert_eq!((b.x, b.y), (-5, -90)); // window-relative: x -5-0, y 10-100
     }
 }

--- a/crates/glass-android/src/agent.rs
+++ b/crates/glass-android/src/agent.rs
@@ -3,8 +3,6 @@
 //! `localabstract:glass-agent`. `AgentClient` is the request/response client; `AgentRegistry`
 //! owns the device server's lifecycle. Everything degrades to the adb paths on failure.
 
-use std::io::{BufRead, BufReader, Write};
-use std::net::TcpStream;
 use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex};
 
@@ -12,6 +10,7 @@ use glass_core::{GlassError, Result};
 use serde_json::{json, Value};
 
 use crate::adb::Adb;
+use crate::conn::Conn;
 
 /// One absolute-display point in a pointer path (the agent's gesture element).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -19,87 +18,6 @@ pub struct Pt {
     pub x: i32,
     pub y: i32,
     pub t_ms: u64,
-}
-
-/// The protocol version this client speaks (must match the agent's hello `proto`).
-const PROTO: i64 = 1;
-
-/// A live connection to the agent: a framed line reader/writer + a monotonic id.
-struct Conn {
-    writer: TcpStream,
-    reader: BufReader<TcpStream>,
-    next_id: i64,
-}
-
-impl Conn {
-    /// Connect to `127.0.0.1:port`, read + version-check the hello banner.
-    fn open(port: u16) -> Result<Conn> {
-        let stream = TcpStream::connect(("127.0.0.1", port))
-            .map_err(|e| GlassError::Backend(format!("agent connect :{port}: {e}")))?;
-        // Set read/write timeouts so a stalled agent surfaces as a transport error (which
-        // the existing reconnect path handles) rather than hanging the MCP thread forever.
-        let to = std::time::Duration::from_secs(30);
-        stream.set_read_timeout(Some(to)).ok();
-        stream.set_write_timeout(Some(to)).ok();
-        let reader = BufReader::new(
-            stream.try_clone().map_err(|e| GlassError::Backend(format!("agent clone: {e}")))?,
-        );
-        let mut c = Conn { writer: stream, reader, next_id: 1 };
-        let hello = c.read_line()?;
-        let v: Value = serde_json::from_str(&hello)
-            .map_err(|e| GlassError::Backend(format!("agent hello parse: {e}")))?;
-        let proto = v.get("hello").and_then(|h| h.get("proto")).and_then(Value::as_i64);
-        if proto != Some(PROTO) {
-            return Err(GlassError::Backend(format!(
-                "agent protocol mismatch: got {proto:?}, want {PROTO}"
-            )));
-        }
-        Ok(c)
-    }
-
-    fn read_line(&mut self) -> Result<String> {
-        let mut line = String::new();
-        let n = self
-            .reader
-            .read_line(&mut line)
-            .map_err(|e| GlassError::Backend(format!("agent read: {e}")))?;
-        if n == 0 {
-            return Err(GlassError::Backend("agent closed the connection".into()));
-        }
-        Ok(line.trim_end().to_string())
-    }
-
-    /// Send one request object (an `id` is injected) and return the response `Value`.
-    /// Returns `(result, io_error)` — `io_error` is true when the failure was a
-    /// transport I/O error (dropped connection) rather than a protocol-level error.
-    fn call(&mut self, mut req: Value) -> std::result::Result<Value, (GlassError, bool)> {
-        let id = self.next_id;
-        self.next_id += 1;
-        req["id"] = json!(id);
-        let mut line = serde_json::to_string(&req).expect("serialize request");
-        line.push('\n');
-        self.writer
-            .write_all(line.as_bytes())
-            .and_then(|_| self.writer.flush())
-            .map_err(|e| (GlassError::Backend(format!("agent write: {e}")), true))?;
-        let resp_line = self.read_line().map_err(|e| (e, true))?;
-        let resp: Value = serde_json::from_str(&resp_line)
-            .map_err(|e| (GlassError::Backend(format!("agent resp parse: {e}")), false))?;
-        if resp.get("id").and_then(Value::as_i64) != Some(id) {
-            return Err((
-                GlassError::Backend(format!(
-                    "agent response id mismatch (got {:?}, want {id})",
-                    resp.get("id")
-                )),
-                false,
-            ));
-        }
-        if resp.get("ok").and_then(Value::as_bool) != Some(true) {
-            let err = resp.get("error").and_then(Value::as_str).unwrap_or("agent error");
-            return Err((GlassError::Backend(format!("agent: {err}")), false));
-        }
-        Ok(resp)
-    }
 }
 
 /// Request/response client to the agent. `connect` reconnects on a dropped socket once.

--- a/crates/glass-android/src/agent.rs
+++ b/crates/glass-android/src/agent.rs
@@ -89,7 +89,7 @@ pub fn agent_enabled(get: &dyn Fn(&str) -> Option<String>) -> bool {
 
 /// Parse the local port `adb forward tcp:0 …` prints on stdout.
 /// Skips blank lines and `* daemon …` noise that adb emits on a cold start.
-fn parse_forward_port(out: &str) -> Option<u16> {
+pub(crate) fn parse_forward_port(out: &str) -> Option<u16> {
     out.lines()
         .map(str::trim)
         .filter(|l| !l.is_empty() && !l.starts_with('*'))

--- a/crates/glass-android/src/conn.rs
+++ b/crates/glass-android/src/conn.rs
@@ -1,0 +1,95 @@
+//! Shared line-delimited-JSON TCP connection used by the agent client and the
+//! a11y-service client. `Conn` opens a TCP socket, wraps it in a `BufReader` for
+//! line reads, and exposes a `call` method that writes one JSON request line and
+//! reads one JSON response line.
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpStream;
+use std::time::Duration;
+
+use glass_core::GlassError;
+use serde_json::{json, Value};
+
+/// The protocol version this client speaks (must match the agent's hello `proto`).
+pub(crate) const PROTO: i64 = 1;
+
+/// A live connection to the agent: a framed line reader/writer + a monotonic id.
+pub(crate) struct Conn {
+    pub(crate) writer: TcpStream,
+    pub(crate) reader: BufReader<TcpStream>,
+    pub(crate) next_id: i64,
+}
+
+impl Conn {
+    /// Connect to `127.0.0.1:port`, read + version-check the hello banner.
+    pub(crate) fn open(port: u16) -> glass_core::Result<Conn> {
+        let stream = TcpStream::connect(("127.0.0.1", port))
+            .map_err(|e| GlassError::Backend(format!("agent connect :{port}: {e}")))?;
+        // Set read/write timeouts so a stalled agent surfaces as a transport error (which
+        // the existing reconnect path handles) rather than hanging the MCP thread forever.
+        let to = Duration::from_secs(30);
+        stream.set_read_timeout(Some(to)).ok();
+        stream.set_write_timeout(Some(to)).ok();
+        let reader = BufReader::new(
+            stream.try_clone().map_err(|e| GlassError::Backend(format!("agent clone: {e}")))?,
+        );
+        let mut c = Conn { writer: stream, reader, next_id: 1 };
+        let hello = c.read_line()?;
+        let v: Value = serde_json::from_str(&hello)
+            .map_err(|e| GlassError::Backend(format!("agent hello parse: {e}")))?;
+        let proto = v.get("hello").and_then(|h| h.get("proto")).and_then(Value::as_i64);
+        if proto != Some(PROTO) {
+            return Err(GlassError::Backend(format!(
+                "agent protocol mismatch: got {proto:?}, want {PROTO}"
+            )));
+        }
+        Ok(c)
+    }
+
+    pub(crate) fn read_line(&mut self) -> glass_core::Result<String> {
+        let mut line = String::new();
+        let n = self
+            .reader
+            .read_line(&mut line)
+            .map_err(|e| GlassError::Backend(format!("agent read: {e}")))?;
+        if n == 0 {
+            return Err(GlassError::Backend("agent closed the connection".into()));
+        }
+        Ok(line.trim_end().to_string())
+    }
+
+    /// Send one request object (an `id` is injected) and return the response `Value`.
+    /// Returns `(result, io_error)` — `io_error` is true when the failure was a
+    /// transport I/O error (dropped connection) rather than a protocol-level error.
+    pub(crate) fn call(
+        &mut self,
+        mut req: Value,
+    ) -> std::result::Result<Value, (GlassError, bool)> {
+        let id = self.next_id;
+        self.next_id += 1;
+        req["id"] = json!(id);
+        let mut line = serde_json::to_string(&req).expect("serialize request");
+        line.push('\n');
+        self.writer
+            .write_all(line.as_bytes())
+            .and_then(|_| self.writer.flush())
+            .map_err(|e| (GlassError::Backend(format!("agent write: {e}")), true))?;
+        let resp_line = self.read_line().map_err(|e| (e, true))?;
+        let resp: Value = serde_json::from_str(&resp_line)
+            .map_err(|e| (GlassError::Backend(format!("agent resp parse: {e}")), false))?;
+        if resp.get("id").and_then(Value::as_i64) != Some(id) {
+            return Err((
+                GlassError::Backend(format!(
+                    "agent response id mismatch (got {:?}, want {id})",
+                    resp.get("id")
+                )),
+                false,
+            ));
+        }
+        if resp.get("ok").and_then(Value::as_bool) != Some(true) {
+            let err = resp.get("error").and_then(Value::as_str).unwrap_or("agent error");
+            return Err((GlassError::Backend(format!("agent: {err}")), false));
+        }
+        Ok(resp)
+    }
+}

--- a/crates/glass-android/src/doctor.rs
+++ b/crates/glass-android/src/doctor.rs
@@ -41,6 +41,14 @@ struct Probe {
     agent_jar_exists: bool,
     /// Deep launch+ping result; `Some` only when deep && configured && a device is attachable.
     agent_deep: Option<Result<(), String>>,
+    /// `GLASS_ANDROID_A11Y` is explicitly `off`.
+    a11y_off: bool,
+    /// Resolved `GLASS_ANDROID_A11Y_APK` (non-empty), else `None`.
+    a11y_apk: Option<String>,
+    /// The `a11y_apk` path is an existing file (false when `a11y_apk` is `None`).
+    a11y_apk_exists: bool,
+    /// Deep install+enable+ping result; `Some` only when deep && configured && a device is attachable.
+    a11y_deep: Option<Result<(), String>>,
 }
 
 /// Result of the deep probes against one online device. `Ok` carries a human detail,
@@ -101,6 +109,23 @@ fn probe(deep_requested: bool) -> Probe {
         _ => None,
     };
 
+    let a11y_off = get("GLASS_ANDROID_A11Y").map(|v| v.eq_ignore_ascii_case("off")).unwrap_or(false);
+    let a11y_apk = crate::a11y_service::a11y_apk(&get);
+    let a11y_apk_exists =
+        a11y_apk.as_deref().map(|p| std::path::Path::new(p).is_file()).unwrap_or(false);
+    // Deep a11y probe: install + enable the service on the device glass would attach to,
+    // ping it, then tear it down (reuses the production lifecycle; idempotent + clean).
+    let a11y_deep = match &selection {
+        Action::Attach(serial) if deep_requested && !a11y_off && a11y_apk_exists => {
+            let apk = a11y_apk.as_deref().unwrap();
+            let reg = crate::a11y_service::A11yServiceRegistry::new();
+            let r = reg.ensure(&adb.with_serial(serial.clone()), apk).map(|_| ()).map_err(|e| e.to_string());
+            reg.shutdown();
+            Some(r)
+        }
+        _ => None,
+    };
+
     Probe {
         adb_bin,
         adb_version,
@@ -114,6 +139,10 @@ fn probe(deep_requested: bool) -> Probe {
         agent_jar,
         agent_jar_exists,
         agent_deep,
+        a11y_off,
+        a11y_apk,
+        a11y_apk_exists,
+        a11y_deep,
     }
 }
 
@@ -165,7 +194,7 @@ fn deep_probe(adb: &Adb, serial: &str) -> DeepProbe {
 /// Build the Android doctor section's checks from observed state. Pure.
 fn build_checks(p: &Probe) -> Vec<Check> {
     let (screencap, uiautomator) = deep_checks(p);
-    vec![adb_check(p), emulator_check(p), device_check(p), agent_check(p), screencap, uiautomator]
+    vec![adb_check(p), emulator_check(p), device_check(p), agent_check(p), a11y_check(p), screencap, uiautomator]
 }
 
 fn agent_check(p: &Probe) -> Check {
@@ -207,6 +236,40 @@ fn agent_check(p: &Probe) -> Check {
             };
             Check::new("agent", CheckStatus::Skip, reason)
         }
+    }
+}
+
+fn a11y_check(p: &Probe) -> Check {
+    if p.a11y_off {
+        return Check::new("a11y-service", CheckStatus::Skip, "disabled (GLASS_ANDROID_A11Y=off)");
+    }
+    let Some(apk) = &p.a11y_apk else {
+        return Check::new(
+            "a11y-service",
+            CheckStatus::Skip,
+            "not configured (optional — set GLASS_ANDROID_A11Y_APK for a Compose-rich tree + high-fidelity set_value)",
+        );
+    };
+    if !p.a11y_apk_exists {
+        return Check::new(
+            "a11y-service",
+            CheckStatus::Warn,
+            format!("GLASS_ANDROID_A11Y_APK={apk} but no file there"),
+        )
+        .with_remedy("build the APK (`./gradlew :a11y:assembleDebug` in glass-android-agent), or fix the path");
+    }
+    // a11y_deep is Some only when deep was requested (see probe); so None means
+    // either not-deep (Ok configured) or deep-but-no-attachable-device (Skip).
+    match (&p.a11y_deep, p.deep_requested) {
+        (Some(Ok(())), _) => {
+            Check::new("a11y-service", CheckStatus::Ok, format!("reachable (installed + enabled + ping ok): {apk}"))
+        }
+        (Some(Err(e)), _) => {
+            Check::new("a11y-service", CheckStatus::Fail, format!("service did not come up: {e}"))
+                .with_remedy("ensure the device allows enabling an AccessibilityService and the APK is a valid debug build")
+        }
+        (None, false) => Check::new("a11y-service", CheckStatus::Ok, format!("configured: {apk}")),
+        (None, true) => Check::new("a11y-service", CheckStatus::Skip, "no online device to probe"),
     }
 }
 
@@ -323,6 +386,10 @@ mod tests {
             agent_jar: Some("/sdk/glass-agent.jar".into()),
             agent_jar_exists: true,
             agent_deep: None,
+            a11y_off: false,
+            a11y_apk: Some("/sdk/glass-a11y.apk".into()),
+            a11y_apk_exists: true,
+            a11y_deep: None,
         }
     }
 
@@ -546,11 +613,11 @@ mod tests {
     }
 
     #[test]
-    fn checks_always_emits_the_six_named_checks() {
+    fn checks_always_emits_the_seven_named_checks() {
         // Spawns adb/emulator; both fail-fast when absent, so this is host-independent.
         let c = checks(false);
         let names: Vec<&str> = c.iter().map(|c| c.name.as_str()).collect();
-        assert_eq!(names, ["adb", "emulator", "device", "agent", "screencap", "uiautomator"]);
+        assert_eq!(names, ["adb", "emulator", "device", "agent", "a11y-service", "screencap", "uiautomator"]);
     }
 
     #[test]
@@ -619,5 +686,73 @@ mod tests {
         p.selection = Action::Boot; // deep but nothing attachable → agent not probed
         p.agent_deep = None;
         assert_eq!(find(&build_checks(&p), "agent").status, CheckStatus::Skip);
+    }
+
+    #[test]
+    fn a11y_configured_passive_is_ok() {
+        let c = build_checks(&base_probe());
+        let a = find(&c, "a11y-service");
+        assert_eq!(a.status, CheckStatus::Ok);
+        assert!(a.detail.contains("configured"));
+    }
+
+    #[test]
+    fn a11y_off_is_skip() {
+        let mut p = base_probe();
+        p.a11y_off = true;
+        assert_eq!(find(&build_checks(&p), "a11y-service").status, CheckStatus::Skip);
+    }
+
+    #[test]
+    fn a11y_unset_is_skip() {
+        let mut p = base_probe();
+        p.a11y_apk = None;
+        p.a11y_apk_exists = false;
+        let a = build_checks(&p);
+        let a = find(&a, "a11y-service");
+        assert_eq!(a.status, CheckStatus::Skip);
+        assert!(a.detail.contains("GLASS_ANDROID_A11Y_APK"));
+    }
+
+    #[test]
+    fn a11y_apk_missing_is_warn() {
+        let mut p = base_probe();
+        p.a11y_apk = Some("/nope.apk".into());
+        p.a11y_apk_exists = false;
+        let a = build_checks(&p);
+        let a = find(&a, "a11y-service");
+        assert_eq!(a.status, CheckStatus::Warn);
+        assert!(a.remedy.as_deref().unwrap().contains("gradlew"));
+    }
+
+    #[test]
+    fn a11y_deep_ok_is_ok() {
+        let mut p = base_probe();
+        p.deep_requested = true;
+        p.a11y_deep = Some(Ok(()));
+        let a = build_checks(&p);
+        let a = find(&a, "a11y-service");
+        assert_eq!(a.status, CheckStatus::Ok);
+        assert!(a.detail.contains("reachable"));
+    }
+
+    #[test]
+    fn a11y_deep_fail_is_fail() {
+        let mut p = base_probe();
+        p.deep_requested = true;
+        p.a11y_deep = Some(Err("connect refused".into()));
+        let a = build_checks(&p);
+        let a = find(&a, "a11y-service");
+        assert_eq!(a.status, CheckStatus::Fail);
+        assert!(a.detail.contains("connect refused"));
+    }
+
+    #[test]
+    fn a11y_deep_no_device_is_skip() {
+        let mut p = base_probe();
+        p.deep_requested = true;
+        p.selection = Action::Boot; // deep but nothing attachable → service not probed
+        p.a11y_deep = None;
+        assert_eq!(find(&build_checks(&p), "a11y-service").status, CheckStatus::Skip);
     }
 }

--- a/crates/glass-android/src/lib.rs
+++ b/crates/glass-android/src/lib.rs
@@ -22,7 +22,7 @@ mod screencap;
 mod target;
 
 pub use a11y::AndroidA11y;
-pub use a11y_service::ServiceA11y;
+pub use a11y_service::{ServiceA11y, A11yServiceRegistry, a11y_apk};
 pub use agent::{AgentClient, AgentRegistry};
 pub use avd::EmulatorRegistry;
 pub use platform::AndroidPlatform;

--- a/crates/glass-android/src/lib.rs
+++ b/crates/glass-android/src/lib.rs
@@ -6,6 +6,7 @@
 
 mod adb;
 mod a11y;
+mod a11y_service;
 mod agent;
 mod avd;
 mod axmap;
@@ -21,6 +22,7 @@ mod screencap;
 mod target;
 
 pub use a11y::AndroidA11y;
+pub use a11y_service::ServiceA11y;
 pub use agent::{AgentClient, AgentRegistry};
 pub use avd::EmulatorRegistry;
 pub use platform::AndroidPlatform;

--- a/crates/glass-android/src/lib.rs
+++ b/crates/glass-android/src/lib.rs
@@ -7,10 +7,11 @@
 mod adb;
 mod a11y;
 mod agent;
-mod axmap;
 mod avd;
+mod axmap;
 mod build;
 mod cmd;
+mod conn;
 pub mod doctor;
 mod input;
 mod logs;

--- a/crates/glass-android/tests/a11y_service_loop.rs
+++ b/crates/glass-android/tests/a11y_service_loop.rs
@@ -1,0 +1,66 @@
+//! Live a11y-service round-trip. Ignored; run with a booted AVD + the built APK:
+//!   GLASS_ADB=$HOME/android-sdk/platform-tools/adb \
+//!   GLASS_ANDROID_A11Y_APK=$HOME/git-sources/fw/glass-android-agent/a11y/build/outputs/apk/debug/a11y-debug.apk \
+//!     cargo test -p glass-android --test a11y_service_loop -- --ignored --nocapture
+
+use glass_android::{A11yServiceRegistry, AgentRegistry, AndroidPlatform, EmulatorRegistry, ServiceA11y};
+use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget};
+use glass_core::{AppSpec, Platform, SandboxLevel, WindowGeometry};
+
+#[test]
+#[ignore = "requires a booted AVD + GLASS_ADB + GLASS_ANDROID_A11Y_APK"]
+fn a11y_service_snapshot_and_actions() {
+    let apk = std::env::var("GLASS_ANDROID_A11Y_APK").expect("set GLASS_ANDROID_A11Y_APK");
+    // Resolve the device the same way production does, and reuse its serial-bound adb (the
+    // `resolved_adb()` accessor) — no bespoke test helper. Launch Settings for an active window.
+    let agents = AgentRegistry::new();
+    let mut p = AndroidPlatform::from_env(&EmulatorRegistry::new(), &agents).expect("attach");
+    let spec = AppSpec {
+        build: None,
+        run: vec!["com.android.settings/.Settings".into()],
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        timeout_ms: 10_000,
+        sandbox: SandboxLevel::Off,
+        a11y: false,
+    };
+    p.start_app(&spec).expect("launch settings");
+    let adb = p.resolved_adb();
+
+    let reg = A11yServiceRegistry::new();
+    let client = reg.ensure(&adb, &apk).expect("install + enable + connect");
+    let mut a11y = ServiceA11y::new(client, String::new());
+    let ctx = AxContext {
+        pids: vec![],
+        window: WindowGeometry { x: 0, y: 0, width: 1080, height: 2400 },
+        window_handle: None,
+        a11y_bus_addr: None,
+    };
+
+    let mut tree = a11y.snapshot(&ctx).expect("snapshot");
+    tree.assign_ids();
+    assert!(tree.count > 1, "expected a non-trivial a11y tree, got {}", tree.count);
+
+    // If the active window has an editable field, set it via the service (ACTION_SET_TEXT — the
+    // reliable high-fidelity action). Settings' top screen has none, so this is best-effort; point
+    // the test at the :fixture-compose app (which has a Name EditText) to exercise it for real.
+    fn first_editable(n: &AxNode) -> Option<&AxNode> {
+        if n.states.editable {
+            return Some(n);
+        }
+        n.children.iter().find_map(first_editable)
+    }
+    if let Some(node) = first_editable(&tree.root) {
+        let target = AxTarget { id: node.id, role: node.role, name: node.name.clone(), bounds: node.bounds };
+        a11y.set_value(&ctx, &target, "viaA11y").expect("set_value via ACTION_SET_TEXT");
+    }
+
+    reg.shutdown(); // restores enabled_accessibility_services + removes the forward
+    p.stop_app().ok();
+    drop(p);
+    agents.shutdown(); // tear down any agent the platform launched (no leaks)
+
+    // Then the controller condition-polls the device to confirm teardown left no enabled service
+    // and no forward (don't snapshot immediately — the unbind is async, ~1s; mirror the agent_loop leak check).
+}

--- a/crates/glass-mcp/src/env.rs
+++ b/crates/glass-mcp/src/env.rs
@@ -120,6 +120,12 @@ pub(crate) const GLASS_ENV: &[EnvVarDoc] = &[
     EnvVarDoc { name: "GLASS_ANDROID_AGENT", scope: EnvScope::Android,
         purpose: "auto|off; default auto when the jar resolves; off forces the pure-adb paths",
         default: "auto", secret: false },
+    EnvVarDoc { name: "GLASS_ANDROID_A11Y_APK", scope: EnvScope::Android,
+        purpose: "path to glass-a11y.apk; enables the on-device AccessibilityService reader (Compose-rich tree + high-fidelity set_value); unset \u{21d2} uiautomator",
+        default: "(none; uiautomator used)", secret: false },
+    EnvVarDoc { name: "GLASS_ANDROID_A11Y", scope: EnvScope::Android,
+        purpose: "auto|off \u{2014} disable the a11y service even when the APK is set",
+        default: "auto", secret: false },
     EnvVarDoc { name: "GLASS_TOKEN", scope: EnvScope::Network,
         purpose: "Bearer token for the serve --http transport",
         default: "(none)", secret: true },
@@ -266,6 +272,7 @@ mod tests {
             "GLASS_EMULATOR", "GLASS_AVD", "GLASS_EMULATOR_ARGS",
             "GLASS_EMULATOR_BOOT_TIMEOUT_MS", "GLASS_EMULATOR_KEEP",
             "GLASS_ANDROID_AGENT_JAR", "GLASS_ANDROID_AGENT",
+            "GLASS_ANDROID_A11Y_APK", "GLASS_ANDROID_A11Y",
             "GLASS_TOKEN",
             "GLASS_AUDIT_LOG", "GLASS_AUDIT_CONTENT", "GLASS_AUDIT_PREFIX_LEN",
         ];
@@ -299,7 +306,10 @@ mod tests {
         assert!(idx("GLASS_SWAY") < idx("GLASS_BWRAP"));
         assert!(idx("GLASS_BWRAP") < idx("GLASS_WIN_SANDBOX_PROVIDER"));
         assert!(idx("GLASS_WIN_SANDBOX_PROVIDER") < idx("GLASS_ANDROID_AGENT_JAR"));
-        assert!(idx("GLASS_ANDROID_AGENT_JAR") < idx("GLASS_TOKEN"));
+        assert!(idx("GLASS_ANDROID_AGENT_JAR") < idx("GLASS_ANDROID_A11Y_APK"));
+        // Use unique purpose snippets to distinguish A11Y_APK from A11Y (prefix-match hazard).
+        assert!(idx("glass-a11y.apk") < idx("disable the a11y service"));
+        assert!(idx("disable the a11y service") < idx("GLASS_TOKEN"));
         // adjacency within the windows group
         assert!(idx("GLASS_WIN_SANDBOX_PROVIDER") < idx("GLASS_SANDBOXIE_DIR"));
     }

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -38,11 +38,24 @@ pub fn make_platform(
     backend: &str,
     registry: &glass_android::EmulatorRegistry,
     agents: &glass_android::AgentRegistry,
+    a11y: &glass_android::A11yServiceRegistry,
 ) -> Result<Backend> {
     if backend == "android" {
         let platform = glass_android::AndroidPlatform::from_env(registry, agents)?;
+        let get = |k: &str| std::env::var(k).ok();
         let accessibility: Option<Box<dyn glass_core::Accessibility + Send>> =
-            Some(Box::new(glass_android::AndroidA11y::for_adb(platform.resolved_adb())));
+            match glass_android::a11y_apk(&get) {
+                Some(apk) => match a11y.ensure(&platform.resolved_adb(), &apk) {
+                    // The package isn't known until start_app; the device service serves the
+                    // ACTIVE window regardless, so an empty package is correct for the MVP.
+                    Ok(client) => Some(Box::new(glass_android::ServiceA11y::new(client, String::new()))),
+                    Err(e) => {
+                        eprintln!("glass-android: a11y service unavailable, using uiautomator: {e}");
+                        Some(Box::new(glass_android::AndroidA11y::for_adb(platform.resolved_adb())))
+                    }
+                },
+                None => Some(Box::new(glass_android::AndroidA11y::for_adb(platform.resolved_adb()))),
+            };
         let platform: Box<dyn Platform + Send> = Box::new(platform);
         return Ok(Backend { platform, accessibility });
     }
@@ -114,15 +127,18 @@ pub fn boot(audit: Option<Box<dyn glass_core::AuditSink>>) -> Glass {
     let baselines = BaselineStore::new(".glass/baselines");
     let registry = glass_android::EmulatorRegistry::new();
     let agents = glass_android::AgentRegistry::new();
+    let a11y = glass_android::A11yServiceRegistry::new();
     let reg_factory = registry.clone();
     let agents_factory = agents.clone();
+    let a11y_factory = a11y.clone();
     let mut glass = Glass::new(
-        Box::new(move |b| make_platform(b, &reg_factory, &agents_factory)),
+        Box::new(move |b| make_platform(b, &reg_factory, &agents_factory, &a11y_factory)),
         default,
         baselines,
         10_000,
     );
     glass.set_shutdown_hook(Box::new(move || {
+        a11y.shutdown();
         agents.shutdown();
         registry.kill_all();
     }));

--- a/docs/running-on-linux.md
+++ b/docs/running-on-linux.md
@@ -233,6 +233,28 @@ glass pushes, launches, and tears the agent down for you. Without it, glass uses
 `adb` input path and `glass_clipboard_*` report unsupported. Set
 **`GLASS_ANDROID_AGENT=off`** to force the `adb` paths even when the jar is present.
 
+### Optional on-device a11y service (Compose-rich tree + high-fidelity `set_value`)
+
+A second optional companion — also from **[glass-android-agent](https://github.com/fixed-width/glass-android-agent)** —
+sharpens semantic addressing. `glass_a11y_snapshot` works over plain `adb` via `uiautomator`,
+but `uiautomator` tends to flatten Jetpack Compose UIs, and `glass_set_value` falls back to
+keystroke simulation. The on-device **AccessibilityService** reads the live
+`AccessibilityNodeInfo` tree (so Compose semantics come through) and sets editable fields via
+the real `ACTION_SET_TEXT`.
+
+Point **`GLASS_ANDROID_A11Y_APK`** at its `glass-a11y.apk`:
+
+- Download the prebuilt APK from the agent repo's [Releases](https://github.com/fixed-width/glass-android-agent/releases).
+- Or build it yourself: `./gradlew :a11y:assembleDebug` in the agent repo.
+
+glass installs the APK, enables the service, connects, and restores the device's prior
+accessibility state on teardown — all automatically. Without it, glass uses the `uiautomator`
+reader. Set **`GLASS_ANDROID_A11Y=off`** to force `uiautomator` even when the APK is present.
+
+Scope: the service backs the **accessibility tree + `glass_set_value`**. Element *clicks* stay
+coordinate taps (precise, using the service's bounds) — Android's `ACTION_CLICK` is unreliable
+on Compose, so glass doesn't route clicks through it.
+
 ### Check the setup
 
 ```bash
@@ -241,4 +263,4 @@ GLASS_BACKEND=android glass-mcp doctor
 GLASS_BACKEND=android glass-mcp doctor --deep
 ```
 
-Reports `adb`, the emulator + AVDs, the online/attachable device, and the agent status.
+Reports `adb`, the emulator + AVDs, the online/attachable device, and the agent + a11y-service status.

--- a/docs/running-on-linux.md
+++ b/docs/running-on-linux.md
@@ -197,6 +197,16 @@ Point glass at `adb` with **`GLASS_ADB`** (or put it on `PATH`):
 export GLASS_ADB=~/android-sdk/platform-tools/adb
 ```
 
+### Create an AVD
+
+If you don't have an emulator image yet, install a system image and create one (named `glass`
+here, which `GLASS_AVD=glass` then selects):
+
+```bash
+sdkmanager "system-images;android-34;google_apis;x86_64"
+avdmanager create avd -n glass -k "system-images;android-34;google_apis;x86_64" --device pixel_6
+```
+
 ### Managed AVD (attach-or-boot)
 
 Like Android Studio, glass prefers to attach: if an emulator is already online it uses

--- a/docs/running-on-windows.md
+++ b/docs/running-on-windows.md
@@ -188,6 +188,16 @@ Set `ANDROID_SDK_ROOT` so glass can find the emulator alongside `adb`:
 $env:ANDROID_SDK_ROOT = "$env:LOCALAPPDATA\Android\Sdk"
 ```
 
+### Create an AVD
+
+If you don't have an emulator image yet, install a system image and create one (named `glass`
+here, which `GLASS_AVD=glass` then selects):
+
+```powershell
+sdkmanager "system-images;android-34;google_apis;x86_64"
+avdmanager create avd -n glass -k "system-images;android-34;google_apis;x86_64" --device pixel_6
+```
+
 ### Managed AVD (attach-or-boot)
 
 Like Android Studio, glass prefers to attach: if an emulator is already online it uses

--- a/docs/running-on-windows.md
+++ b/docs/running-on-windows.md
@@ -217,6 +217,28 @@ glass pushes, launches, and tears the agent down for you. Without it, glass uses
 `adb` input path and `glass_clipboard_*` report unsupported. Set
 **`GLASS_ANDROID_AGENT=off`** to force the `adb` paths even when the jar is present.
 
+### Optional on-device a11y service (Compose-rich tree + high-fidelity `set_value`)
+
+A second optional companion — also from **[glass-android-agent](https://github.com/fixed-width/glass-android-agent)** —
+sharpens semantic addressing. `glass_a11y_snapshot` works over plain `adb` via `uiautomator`,
+but `uiautomator` tends to flatten Jetpack Compose UIs, and `glass_set_value` falls back to
+keystroke simulation. The on-device **AccessibilityService** reads the live
+`AccessibilityNodeInfo` tree (so Compose semantics come through) and sets editable fields via
+the real `ACTION_SET_TEXT`.
+
+Point **`GLASS_ANDROID_A11Y_APK`** at its `glass-a11y.apk`:
+
+- Download the prebuilt APK from the agent repo's [Releases](https://github.com/fixed-width/glass-android-agent/releases).
+- Or build it yourself: `./gradlew :a11y:assembleDebug` in the agent repo.
+
+glass installs the APK, enables the service, connects, and restores the device's prior
+accessibility state on teardown — all automatically. Without it, glass uses the `uiautomator`
+reader. Set **`GLASS_ANDROID_A11Y=off`** to force `uiautomator` even when the APK is present.
+
+Scope: the service backs the **accessibility tree + `glass_set_value`**. Element *clicks* stay
+coordinate taps (precise, using the service's bounds) — Android's `ACTION_CLICK` is unreliable
+on Compose, so glass doesn't route clicks through it.
+
 ### Check the setup
 
 ```powershell
@@ -226,7 +248,7 @@ glass-mcp doctor
 glass-mcp doctor --deep
 ```
 
-Reports `adb`, the emulator + AVDs, the online/attachable device, and the agent status.
+Reports `adb`, the emulator + AVDs, the online/attachable device, and the agent + a11y-service status.
 
 ---
 


### PR DESCRIPTION
Host-side integration for the on-device AccessibilityService companion ([glass-android-agent](https://github.com/fixed-width/glass-android-agent)). When `GLASS_ANDROID_A11Y_APK` is set, glass installs+enables the service and reads a **Compose-rich a11y tree** + does **high-fidelity `set_value`** (`ACTION_SET_TEXT`) over an `adb forward`ed socket; otherwise it falls back to the existing `uiautomator` reader. **No `glass-core` change.**

## What's here (10 commits)
- `conn.rs` — shared line-JSON `Conn` (extracted from `agent.rs`).
- `a11y_service.rs` — `ServiceClient` (mirrors `AgentClient`), `ServiceA11y` (`Accessibility`: `snapshot` + `set_value`), JSON→`AxTree` mapper, `A11yServiceRegistry` (install→enable→forward→connect; teardown restores the device's prior a11y state exactly).
- `make_platform` selects `ServiceA11y` when configured (else uiautomator); `A11yServiceRegistry` threaded through `boot()` + the shutdown hook (a11y → agent → emulator).
- `env.rs` — `GLASS_ANDROID_A11Y_APK` + `GLASS_ANDROID_A11Y`. `doctor.rs` — an `a11y-service` check. A live `#[ignore]` `a11y_service_loop`.

## Key design decision (validated on-device)
`ACTION_CLICK` is **unreliable on Compose** (returns true but no-ops/flaky across every dispatch strategy), so clicks are **not** routed through the service — `glass_click_element` stays a coordinate tap (now precise on the service's accurate bounds). The reliable high-fidelity action is `ACTION_SET_TEXT`, which `set_value` covers. `set_value` **poll-verifies** the value actually landed and errors honestly otherwise (no silent no-op — `ACTION_SET_TEXT` is async and silently no-ops some replaces; verifying makes it reliable + honest).

## Verification
- Workspace gates clean (`test --workspace`, `clippy --all-targets -D warnings`, `build --locked`).
- Live on the android-34 AVD: snapshot a real Settings tree + the Compose fixture; `set_value` round-trips (set + clear); teardown leak-free (no enabled service, no forward, `accessibility_enabled` restored). Subagent-driven (impl + spec + quality review per task) + a final holistic review; every Critical/Important finding fixed (ensure-rollback, empty-field set_value, flag restore, bounds clamp).

Opt-in + falls back to uiautomator, so this is safe to merge ahead of tagging the agent APK release.