### PR TITLE
Android: discover the SDK (adb/emulator) with zero config; honest doctor

### DIFF
--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -189,7 +189,29 @@ use std::sync::Arc;
 use crate::adb::Adb;
 
 const SERVICE_COMPONENT: &str = "com.fixedwidth.glassa11y/com.fixedwidth.glassa11y.GlassA11yService";
+const SERVICE_PACKAGE: &str = "com.fixedwidth.glassa11y";
 const SOCKET: &str = "glass-a11y";
+
+/// True when an `adb install` failure is the "existing package signed differently" case
+/// that only an uninstall can clear (e.g. a release APK over a local debug build).
+fn is_signature_mismatch(err: &str) -> bool {
+    err.contains("INSTALL_FAILED_UPDATE_INCOMPATIBLE") || err.contains("signatures do not match")
+}
+
+/// Install the service APK, recovering from a signature mismatch. glass owns this package
+/// (install → enable → teardown, no meaningful user state), so when a differently-signed
+/// build is already present it removes the stale copy and installs fresh rather than failing.
+fn install_service(adb: &Adb, apk: &str) -> Result<()> {
+    match adb.run(["install", "-r", apk]) {
+        Ok(_) => Ok(()),
+        Err(e) if is_signature_mismatch(&e.to_string()) => {
+            eprintln!("glass-a11y: replacing a differently-signed existing install of {SERVICE_PACKAGE}");
+            adb.run(["uninstall", SERVICE_PACKAGE])?;
+            adb.run(["install", "-r", apk]).map(|_| ())
+        }
+        Err(e) => Err(e),
+    }
+}
 
 /// `GLASS_ANDROID_A11Y_APK`, else `glass-a11y.apk` dropped in the glass data dir or next
 /// to the `glass-mcp` binary; `None` when disabled via `GLASS_ANDROID_A11Y=off`.
@@ -217,7 +239,7 @@ impl A11yServiceRegistry {
     /// Install + enable the service on `adb`'s device, forward a port, connect, ping. Returns a
     /// connected `ServiceClient`. The apk path is resolved from env by the caller.
     pub fn ensure(&self, adb: &Adb, apk: &str) -> Result<ServiceClient> {
-        adb.run(["install", "-r", apk])?;
+        install_service(adb, apk)?;
         let get = |k: &str| adb.run(["shell", "settings", "get", "secure", k]).unwrap_or_default();
         let prior = get("enabled_accessibility_services");
         let prior = prior.trim();
@@ -300,6 +322,16 @@ mod tests {
 
     fn win() -> WindowGeometry {
         WindowGeometry { x: 0, y: 100, width: 1080, height: 2300 }
+    }
+
+    #[test]
+    fn signature_mismatch_detected() {
+        assert!(is_signature_mismatch(
+            "Failure [INSTALL_FAILED_UPDATE_INCOMPATIBLE: Existing package signatures do not match newer version; ignoring!]"
+        ));
+        assert!(is_signature_mismatch("signatures do not match newer version"));
+        assert!(!is_signature_mismatch("Failure [INSTALL_FAILED_INSUFFICIENT_STORAGE]"));
+        assert!(!is_signature_mismatch("error: device offline"));
     }
 
     #[test]

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -191,12 +191,17 @@ use crate::adb::Adb;
 const SERVICE_COMPONENT: &str = "com.fixedwidth.glassa11y/com.fixedwidth.glassa11y.GlassA11yService";
 const SOCKET: &str = "glass-a11y";
 
-/// `GLASS_ANDROID_A11Y_APK` (path to the APK) when configured + not disabled.
+/// `GLASS_ANDROID_A11Y_APK`, else `glass-a11y.apk` dropped in the glass data dir or next
+/// to the `glass-mcp` binary; `None` when disabled via `GLASS_ANDROID_A11Y=off`.
 pub fn a11y_apk(get: &dyn Fn(&str) -> Option<String>) -> Option<String> {
     if get("GLASS_ANDROID_A11Y").map(|v| v.eq_ignore_ascii_case("off")).unwrap_or(false) {
         return None;
     }
-    get("GLASS_ANDROID_A11Y_APK").filter(|s| !s.is_empty())
+    let mut dirs = crate::sdk::artifact_data_dirs(get);
+    dirs.extend(crate::sdk::exe_dir());
+    crate::sdk::resolve_artifact("GLASS_ANDROID_A11Y_APK", "glass-a11y.apk", &dirs, get, &|p| {
+        p.is_file()
+    })
 }
 
 struct Active { serial: Option<String>, port: u16, prior_enabled: String, prior_a11y_enabled: String }

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -10,13 +10,12 @@ pub struct Adb {
 }
 
 impl Adb {
-    /// Resolve the `adb` binary from `GLASS_ADB`, else `"adb"` on `PATH`.
+    /// Resolve the `adb` binary: `GLASS_ADB`, else `$SDK/platform-tools/adb` from a
+    /// discovered SDK root (env or a common install location), else `"adb"` on `PATH`.
     /// Serial is unset until a target resolves it.
     pub fn from_env() -> Self {
-        let bin = std::env::var("GLASS_ADB")
-            .ok()
-            .filter(|s| !s.is_empty())
-            .unwrap_or_else(|| "adb".to_string());
+        let get = |k: &str| std::env::var(k).ok();
+        let bin = crate::sdk::resolve_adb(&get, &|p| p.exists()).bin();
         Self { bin, serial: None }
     }
 

--- a/crates/glass-android/src/agent.rs
+++ b/crates/glass-android/src/agent.rs
@@ -76,9 +76,14 @@ impl AgentClient {
     }
 }
 
-/// `GLASS_ANDROID_AGENT_JAR`, if set + non-empty.
+/// `GLASS_ANDROID_AGENT_JAR`, else `glass-agent.jar` dropped in the glass data dir or
+/// next to the `glass-mcp` binary.
 pub fn agent_jar(get: &dyn Fn(&str) -> Option<String>) -> Option<String> {
-    get("GLASS_ANDROID_AGENT_JAR").filter(|s| !s.is_empty())
+    let mut dirs = crate::sdk::artifact_data_dirs(get);
+    dirs.extend(crate::sdk::exe_dir());
+    crate::sdk::resolve_artifact("GLASS_ANDROID_AGENT_JAR", "glass-agent.jar", &dirs, get, &|p| {
+        p.is_file()
+    })
 }
 
 /// The agent is used when not explicitly `off` and a jar is resolvable.

--- a/crates/glass-android/src/avd.rs
+++ b/crates/glass-android/src/avd.rs
@@ -38,18 +38,30 @@ pub enum Action {
     Error(String),
 }
 
-/// Resolve the `emulator` binary: `GLASS_EMULATOR`, else `$ANDROID_SDK_ROOT/emulator/emulator`,
-/// else `$ANDROID_HOME/emulator/emulator`, else `emulator` (on `PATH`). `get` reads an env var.
-pub fn resolve_emulator_bin(get: &dyn Fn(&str) -> Option<String>) -> String {
+/// Resolve the `emulator` binary: `GLASS_EMULATOR`, else `$SDK/emulator/emulator` from a
+/// discovered SDK root (env or a common install location), else `"emulator"` (on `PATH`).
+pub fn resolve_emulator_bin(
+    get: &dyn Fn(&str) -> Option<String>,
+    exists: &dyn Fn(&std::path::Path) -> bool,
+) -> String {
     if let Some(bin) = get("GLASS_EMULATOR").filter(|s| !s.is_empty()) {
         return bin;
     }
-    for root in ["ANDROID_SDK_ROOT", "ANDROID_HOME"] {
-        if let Some(sdk) = get(root).filter(|s| !s.is_empty()) {
-            return format!("{sdk}/emulator/emulator");
-        }
+    if let Some(root) = crate::sdk::resolve_sdk_root(get, exists) {
+        return root.path.join("emulator").join(emulator_exe()).to_string_lossy().into_owned();
     }
     "emulator".to_string()
+}
+
+fn emulator_exe() -> &'static str {
+    #[cfg(windows)]
+    {
+        "emulator.exe"
+    }
+    #[cfg(not(windows))]
+    {
+        "emulator"
+    }
 }
 
 /// Parse `emulator -list-avds` (AVD names, one per line; skip INFO/WARNING noise).
@@ -176,7 +188,7 @@ impl EmulatorRegistry {
 /// Spawns the emulator detached, waits for a new device + `sys.boot_completed`, and
 /// errors (after killing the half-booted emulator) on timeout or spawn failure.
 pub fn boot_avd(base: &Adb, get: &dyn Fn(&str) -> Option<String>) -> Result<String> {
-    let bin = resolve_emulator_bin(get);
+    let bin = resolve_emulator_bin(get, &|p| p.exists());
     let avds = parse_list_avds(&run_emulator_list(&bin)?);
     let avd = choose_avd(get("GLASS_AVD").as_deref(), &avds)?;
     let args = emulator_args(&avd, get("GLASS_EMULATOR_ARGS").as_deref());
@@ -257,22 +269,33 @@ mod tests {
             "GLASS_EMULATOR" => Some("/custom/emulator".to_string()),
             _ => None,
         };
-        assert_eq!(resolve_emulator_bin(&env), "/custom/emulator");
+        assert_eq!(resolve_emulator_bin(&env, &|_| true), "/custom/emulator");
 
         let env = |k: &str| match k {
             "ANDROID_SDK_ROOT" => Some("/sdk".to_string()),
             _ => None,
         };
-        assert_eq!(resolve_emulator_bin(&env), "/sdk/emulator/emulator");
+        assert_eq!(resolve_emulator_bin(&env, &|_| true), "/sdk/emulator/emulator");
 
         let env = |k: &str| match k {
             "ANDROID_HOME" => Some("/home/sdk".to_string()),
             _ => None,
         };
-        assert_eq!(resolve_emulator_bin(&env), "/home/sdk/emulator/emulator");
+        assert_eq!(resolve_emulator_bin(&env, &|_| true), "/home/sdk/emulator/emulator");
 
         let env = |_: &str| None;
-        assert_eq!(resolve_emulator_bin(&env), "emulator");
+        assert_eq!(resolve_emulator_bin(&env, &|_| false), "emulator");
+    }
+
+    #[test]
+    fn emulator_from_discovered_default_sdk() {
+        // No env at all, but a default SDK location exists on disk.
+        let env = |k: &str| match k {
+            "HOME" => Some("/home/u".to_string()),
+            _ => None,
+        };
+        let exists = |p: &std::path::Path| p == std::path::Path::new("/home/u/android-sdk");
+        assert_eq!(resolve_emulator_bin(&env, &exists), "/home/u/android-sdk/emulator/emulator");
     }
 
     #[test]

--- a/crates/glass-android/src/avd.rs
+++ b/crates/glass-android/src/avd.rs
@@ -287,6 +287,9 @@ mod tests {
         assert_eq!(resolve_emulator_bin(&env, &|_| false), "emulator");
     }
 
+    // Default install locations are OS-specific (Linux paths here); gate so the
+    // cross-platform CI (incl. the Windows job) doesn't run this assertion.
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     #[test]
     fn emulator_from_discovered_default_sdk() {
         // No env at all, but a default SDK location exists on disk.

--- a/crates/glass-android/src/doctor.rs
+++ b/crates/glass-android/src/doctor.rs
@@ -215,7 +215,7 @@ fn agent_check(p: &Probe) -> Check {
         return Check::new(
             "agent",
             CheckStatus::Skip,
-            "not configured (optional — set GLASS_ANDROID_AGENT_JAR for clipboard + high-fidelity input)",
+            "not configured (optional — set GLASS_ANDROID_AGENT_JAR, or drop glass-agent.jar in the glass data dir, for clipboard + high-fidelity input)",
         );
     };
     if !p.agent_jar_exists {
@@ -257,7 +257,7 @@ fn a11y_check(p: &Probe) -> Check {
         return Check::new(
             "a11y-service",
             CheckStatus::Skip,
-            "not configured (optional — set GLASS_ANDROID_A11Y_APK for a Compose-rich tree + high-fidelity set_value)",
+            "not configured (optional — set GLASS_ANDROID_A11Y_APK, or drop glass-a11y.apk in the glass data dir, for a Compose-rich tree + high-fidelity set_value)",
         );
     };
     if !p.a11y_apk_exists {

--- a/crates/glass-android/src/doctor.rs
+++ b/crates/glass-android/src/doctor.rs
@@ -70,7 +70,7 @@ fn probe(deep_requested: bool) -> Probe {
     let adb = Adb::from_env();
     let adb_bin = adb.bin().to_string();
     let adb_version = adb.run(["version"]).ok().map(|s| first_line(&s)).filter(|s| !s.is_empty());
-    let emulator_bin = resolve_emulator_bin(&get);
+    let emulator_bin = resolve_emulator_bin(&get, &|p| p.exists());
     let avds = list_avds(&emulator_bin);
 
     let online_devices: Vec<Device> = if adb_version.is_some() {

--- a/crates/glass-android/src/doctor.rs
+++ b/crates/glass-android/src/doctor.rs
@@ -14,8 +14,13 @@ use crate::target::{parse_devices, Device};
 /// Observed host state for the Android doctor checks. Captured by `probe`, consumed
 /// by the pure `build_checks` so all branch logic is unit-testable without subprocesses.
 struct Probe {
-    /// Resolved adb path (`GLASS_ADB`, else `"adb"`).
+    /// Resolved adb path (`GLASS_ADB` / discovered SDK / `"adb"` on PATH).
     adb_bin: String,
+    /// Human description of how adb was resolved (path + source), for the OK detail.
+    adb_detail: String,
+    /// Ordered candidates discovery considered (env vars + default locations), for the
+    /// Fail trail.
+    adb_trail: Vec<String>,
     /// First line of `adb version`; `None` when adb is absent/unrunnable.
     adb_version: Option<String>,
     /// Resolved emulator path (`GLASS_EMULATOR`/SDK root/`"emulator"`).
@@ -67,6 +72,9 @@ pub fn checks(deep: bool) -> Vec<Check> {
 
 fn probe(deep_requested: bool) -> Probe {
     let get = |k: &str| std::env::var(k).ok();
+    let adb_resolution = crate::sdk::resolve_adb(&get, &|p| p.exists());
+    let adb_detail = adb_resolution.describe();
+    let adb_trail = crate::sdk::sdk_search_trail(&get);
     let adb = Adb::from_env();
     let adb_bin = adb.bin().to_string();
     let adb_version = adb.run(["version"]).ok().map(|s| first_line(&s)).filter(|s| !s.is_empty());
@@ -128,6 +136,8 @@ fn probe(deep_requested: bool) -> Probe {
 
     Probe {
         adb_bin,
+        adb_detail,
+        adb_trail,
         adb_version,
         emulator_bin,
         avds,
@@ -339,7 +349,7 @@ fn emulator_check(p: &Probe) -> Check {
                 p.emulator_bin
             ),
         )
-        .with_remedy("install the Android emulator package, or set GLASS_EMULATOR / ANDROID_SDK_ROOT"),
+        .with_remedy("install the Android emulator at a standard SDK location (auto-found), or set GLASS_EMULATOR / ANDROID_SDK_ROOT"),
         Some(avds) if avds.is_empty() => Check::new(
             "emulator",
             CheckStatus::Warn,
@@ -358,13 +368,19 @@ fn emulator_check(p: &Probe) -> Check {
 
 fn adb_check(p: &Probe) -> Check {
     match &p.adb_version {
-        Some(v) => Check::new("adb", CheckStatus::Ok, format!("{} ({v})", p.adb_bin)),
+        Some(v) => Check::new("adb", CheckStatus::Ok, format!("{} ({v})", p.adb_detail)),
         None => Check::new(
             "adb",
             CheckStatus::Fail,
-            format!("`adb` not found or not runnable ({})", p.adb_bin),
+            format!(
+                "`adb` not found — looked in: {}; resolved `{}`",
+                p.adb_trail.join(", "),
+                p.adb_bin
+            ),
         )
-        .with_remedy("install Android platform-tools, or set GLASS_ADB to the adb binary"),
+        .with_remedy(
+            "install Android platform-tools at any standard SDK location (auto-found), or set GLASS_ADB",
+        ),
     }
 }
 
@@ -375,6 +391,12 @@ mod tests {
     fn base_probe() -> Probe {
         Probe {
             adb_bin: "/sdk/platform-tools/adb".into(),
+            adb_detail: "/sdk/platform-tools/adb (via discovered SDK /home/u/android-sdk)".into(),
+            adb_trail: vec![
+                "ANDROID_SDK_ROOT".into(),
+                "ANDROID_HOME".into(),
+                "/home/u/android-sdk".into(),
+            ],
             adb_version: Some("Android Debug Bridge version 1.0.41".into()),
             emulator_bin: "/sdk/emulator/emulator".into(),
             avds: Some(vec!["glass".into()]),
@@ -427,6 +449,28 @@ mod tests {
         let adb = find(&c, "adb");
         assert_eq!(adb.status, CheckStatus::Fail);
         assert!(adb.remedy.as_deref().unwrap().contains("GLASS_ADB"));
+    }
+
+    #[test]
+    fn adb_ok_detail_shows_resolution_source() {
+        let c = build_checks(&base_probe());
+        let adb = find(&c, "adb");
+        assert_eq!(adb.status, CheckStatus::Ok);
+        assert!(adb.detail.contains("via discovered SDK"), "got {}", adb.detail);
+    }
+
+    #[test]
+    fn adb_fail_detail_shows_search_trail() {
+        let mut p = base_probe();
+        p.adb_version = None;
+        let c = build_checks(&p);
+        let adb = find(&c, "adb");
+        assert_eq!(adb.status, CheckStatus::Fail);
+        assert!(
+            adb.detail.contains("looked in: ANDROID_SDK_ROOT, ANDROID_HOME"),
+            "got {}",
+            adb.detail
+        );
     }
 
     #[test]

--- a/crates/glass-android/src/lib.rs
+++ b/crates/glass-android/src/lib.rs
@@ -19,6 +19,7 @@ mod logs;
 mod parse;
 mod platform;
 mod screencap;
+mod sdk;
 mod target;
 
 pub use a11y::AndroidA11y;

--- a/crates/glass-android/src/sdk.rs
+++ b/crates/glass-android/src/sdk.rs
@@ -141,6 +141,57 @@ pub fn sdk_search_trail(get: &dyn Fn(&str) -> Option<String>) -> Vec<String> {
     t
 }
 
+/// The glass per-user data dir(s) where optional on-device artifacts (the agent jar,
+/// the a11y APK) can be dropped so they're found with no env configuration.
+pub fn artifact_data_dirs(get: &dyn Fn(&str) -> Option<String>) -> Vec<PathBuf> {
+    let mut v = Vec::new();
+    #[cfg(target_os = "windows")]
+    for var in ["APPDATA", "LOCALAPPDATA"] {
+        if let Some(d) = get(var).filter(|s| !s.is_empty()) {
+            v.push(PathBuf::from(d).join("glass"));
+        }
+    }
+    #[cfg(target_os = "macos")]
+    if let Some(h) = get("HOME").filter(|s| !s.is_empty()) {
+        v.push(PathBuf::from(format!("{h}/Library/Application Support/glass")));
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    {
+        if let Some(x) = get("XDG_DATA_HOME").filter(|s| !s.is_empty()) {
+            v.push(PathBuf::from(x).join("glass"));
+        } else if let Some(h) = get("HOME").filter(|s| !s.is_empty()) {
+            v.push(PathBuf::from(format!("{h}/.local/share/glass")));
+        }
+    }
+    v
+}
+
+/// The directory holding the running executable, for finding artifacts shipped next to
+/// the `glass-mcp` binary. `None` if it can't be determined.
+pub fn exe_dir() -> Option<PathBuf> {
+    std::env::current_exe().ok().and_then(|p| p.parent().map(PathBuf::from))
+}
+
+/// Resolve an optional artifact (e.g. the agent jar) by `env_var` → the first `dirs`
+/// entry that holds `filename` on disk → `None`. The env path is returned even when it
+/// does not exist, so the caller can still warn "set but missing" rather than silently
+/// discovering a different copy.
+pub fn resolve_artifact(
+    env_var: &str,
+    filename: &str,
+    dirs: &[PathBuf],
+    get: &dyn Fn(&str) -> Option<String>,
+    exists: &dyn Fn(&Path) -> bool,
+) -> Option<String> {
+    if let Some(p) = get(env_var).filter(|s| !s.is_empty()) {
+        return Some(p);
+    }
+    dirs.iter()
+        .map(|d| d.join(filename))
+        .find(|cand| exists(cand))
+        .map(|p| p.to_string_lossy().into_owned())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -196,6 +247,50 @@ mod tests {
         assert!(t.iter().any(|s| s.contains("android-sdk")), "trail: {t:?}");
     }
 
+    // Artifact resolution tests pass `dirs` explicitly, so they're OS-agnostic.
+    #[test]
+    fn artifact_env_override_wins() {
+        let get = getter(&[("GLASS_ANDROID_AGENT_JAR", "/explicit/glass-agent.jar")]);
+        let dirs = [PathBuf::from("/data/glass")];
+        let r = resolve_artifact("GLASS_ANDROID_AGENT_JAR", "glass-agent.jar", &dirs, &get, &|_| true);
+        assert_eq!(r.as_deref(), Some("/explicit/glass-agent.jar"));
+    }
+
+    #[test]
+    fn artifact_found_in_data_dir_when_env_unset() {
+        let get = getter(&[]);
+        let dirs = [PathBuf::from("/data/glass")];
+        let exists = |p: &Path| p == Path::new("/data/glass/glass-agent.jar");
+        let r = resolve_artifact("GLASS_ANDROID_AGENT_JAR", "glass-agent.jar", &dirs, &get, &exists);
+        assert_eq!(r.as_deref(), Some("/data/glass/glass-agent.jar"));
+    }
+
+    #[test]
+    fn artifact_none_when_unset_and_absent() {
+        let get = getter(&[]);
+        let dirs = [PathBuf::from("/data/glass")];
+        let r = resolve_artifact("GLASS_ANDROID_AGENT_JAR", "glass-agent.jar", &dirs, &get, &|_| false);
+        assert_eq!(r, None);
+    }
+
+    #[test]
+    fn artifact_env_set_but_missing_still_returns_the_path() {
+        // So doctor can warn "set but no file there" instead of silently using another copy.
+        let get = getter(&[("GLASS_ANDROID_AGENT_JAR", "/explicit/missing.jar")]);
+        let dirs = [PathBuf::from("/data/glass")];
+        let r = resolve_artifact("GLASS_ANDROID_AGENT_JAR", "glass-agent.jar", &dirs, &get, &|_| false);
+        assert_eq!(r.as_deref(), Some("/explicit/missing.jar"));
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    #[test]
+    fn data_dirs_prefer_xdg_then_home() {
+        let get = getter(&[("XDG_DATA_HOME", "/xdg"), ("HOME", "/home/u")]);
+        assert_eq!(artifact_data_dirs(&get)[0], PathBuf::from("/xdg/glass"));
+        let get2 = getter(&[("HOME", "/home/u")]);
+        assert_eq!(artifact_data_dirs(&get2)[0], PathBuf::from("/home/u/.local/share/glass"));
+    }
+
     #[test]
     fn env_root_wins_when_it_exists() {
         let get = getter(&[("ANDROID_SDK_ROOT", "/sdk"), ("HOME", "/home/u")]);
@@ -212,6 +307,9 @@ mod tests {
         assert_eq!(r.source, SdkSource::Env("ANDROID_HOME"));
     }
 
+    // Default install locations are OS-specific (Linux paths here); gate so the
+    // cross-platform CI (incl. the Windows job) doesn't run this assertion.
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     #[test]
     fn discovers_default_location_with_no_env() {
         let get = getter(&[("HOME", "/home/u")]);

--- a/crates/glass-android/src/sdk.rs
+++ b/crates/glass-android/src/sdk.rs
@@ -65,12 +65,89 @@ pub fn resolve_sdk_root(
         .map(|path| SdkRoot { path, source: SdkSource::Default })
 }
 
+/// How `adb` was resolved, for honest diagnostics.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AdbResolution {
+    /// From `GLASS_ADB`.
+    GlassAdb(String),
+    /// `$SDK/platform-tools/adb` under a discovered root.
+    Sdk { bin: String, root: SdkRoot },
+    /// Fell back to `"adb"` on `PATH`.
+    Path,
+}
+
+impl AdbResolution {
+    /// The adb binary to invoke.
+    pub fn bin(&self) -> String {
+        match self {
+            AdbResolution::GlassAdb(p) => p.clone(),
+            AdbResolution::Sdk { bin, .. } => bin.clone(),
+            AdbResolution::Path => "adb".to_string(),
+        }
+    }
+}
+
+fn adb_exe() -> &'static str {
+    #[cfg(windows)]
+    {
+        "adb.exe"
+    }
+    #[cfg(not(windows))]
+    {
+        "adb"
+    }
+}
+
+/// Resolve adb: `GLASS_ADB` → `$SDK/platform-tools/adb` (when found + exists) → `"adb"`.
+pub fn resolve_adb(
+    get: &dyn Fn(&str) -> Option<String>,
+    exists: &dyn Fn(&Path) -> bool,
+) -> AdbResolution {
+    if let Some(p) = get("GLASS_ADB").filter(|s| !s.is_empty()) {
+        return AdbResolution::GlassAdb(p);
+    }
+    if let Some(root) = resolve_sdk_root(get, exists) {
+        let bin = root.path.join("platform-tools").join(adb_exe());
+        if exists(&bin) {
+            return AdbResolution::Sdk { bin: bin.to_string_lossy().into_owned(), root };
+        }
+    }
+    AdbResolution::Path
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn getter(pairs: &'static [(&'static str, &'static str)]) -> impl Fn(&str) -> Option<String> {
         move |k| pairs.iter().find(|(n, _)| *n == k).map(|(_, v)| v.to_string())
+    }
+
+    #[test]
+    fn adb_glass_override_wins() {
+        let get = getter(&[("GLASS_ADB", "/custom/adb"), ("ANDROID_SDK_ROOT", "/sdk")]);
+        assert_eq!(resolve_adb(&get, &|_| true).bin(), "/custom/adb");
+    }
+
+    #[test]
+    fn adb_from_discovered_sdk() {
+        let get = getter(&[("HOME", "/home/u")]);
+        let exists = |p: &Path| {
+            p == Path::new("/home/u/android-sdk")
+                || p == Path::new("/home/u/android-sdk/platform-tools/adb")
+        };
+        match resolve_adb(&get, &exists) {
+            AdbResolution::Sdk { bin, .. } => {
+                assert_eq!(bin, "/home/u/android-sdk/platform-tools/adb")
+            }
+            other => panic!("expected Sdk, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn adb_falls_back_to_path() {
+        let get = getter(&[("HOME", "/home/u")]);
+        assert_eq!(resolve_adb(&get, &|_| false).bin(), "adb");
     }
 
     #[test]

--- a/crates/glass-android/src/sdk.rs
+++ b/crates/glass-android/src/sdk.rs
@@ -85,6 +85,24 @@ impl AdbResolution {
             AdbResolution::Path => "adb".to_string(),
         }
     }
+
+    /// A short human description of how adb was found, for `glass doctor`.
+    pub fn describe(&self) -> String {
+        match self {
+            AdbResolution::GlassAdb(p) => format!("{p} (via GLASS_ADB)"),
+            AdbResolution::Sdk { bin, root } => {
+                format!("{bin} (via {} SDK {})", source_word(&root.source), root.path.display())
+            }
+            AdbResolution::Path => "adb (on PATH)".to_string(),
+        }
+    }
+}
+
+fn source_word(s: &SdkSource) -> &'static str {
+    match s {
+        SdkSource::Env(_) => "configured",
+        SdkSource::Default => "discovered",
+    }
 }
 
 fn adb_exe() -> &'static str {
@@ -113,6 +131,14 @@ pub fn resolve_adb(
         }
     }
     AdbResolution::Path
+}
+
+/// Human labels for the ordered candidates discovery considers — env vars then default
+/// locations — so `glass doctor` can render the search trail on failure.
+pub fn sdk_search_trail(get: &dyn Fn(&str) -> Option<String>) -> Vec<String> {
+    let mut t = vec!["ANDROID_SDK_ROOT".to_string(), "ANDROID_HOME".to_string()];
+    t.extend(default_locations(get).into_iter().map(|p| p.display().to_string()));
+    t
 }
 
 #[cfg(test)]
@@ -148,6 +174,26 @@ mod tests {
     fn adb_falls_back_to_path() {
         let get = getter(&[("HOME", "/home/u")]);
         assert_eq!(resolve_adb(&get, &|_| false).bin(), "adb");
+    }
+
+    #[test]
+    fn describe_names_the_discovered_sdk() {
+        let r = AdbResolution::Sdk {
+            bin: "/home/u/android-sdk/platform-tools/adb".into(),
+            root: SdkRoot { path: "/home/u/android-sdk".into(), source: SdkSource::Default },
+        };
+        let d = r.describe();
+        assert!(d.contains("/home/u/android-sdk/platform-tools/adb"), "got {d}");
+        assert!(d.contains("discovered"), "got {d}");
+    }
+
+    #[test]
+    fn trail_lists_env_then_defaults() {
+        let get = getter(&[("HOME", "/home/u")]);
+        let t = sdk_search_trail(&get);
+        assert_eq!(&t[0], "ANDROID_SDK_ROOT");
+        assert_eq!(&t[1], "ANDROID_HOME");
+        assert!(t.iter().any(|s| s.contains("android-sdk")), "trail: {t:?}");
     }
 
     #[test]

--- a/crates/glass-android/src/sdk.rs
+++ b/crates/glass-android/src/sdk.rs
@@ -1,0 +1,105 @@
+//! Android SDK discovery: locate the SDK root — and from it `adb`/`emulator` — so the
+//! backend works with zero configuration, falling back through env overrides and common
+//! install locations. Pure resolution: the only impurities are injected (`get` for env,
+//! `exists` for filesystem presence), so every branch is unit-tested without I/O.
+
+use std::path::{Path, PathBuf};
+
+/// How the SDK root was located, for honest diagnostics.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SdkSource {
+    /// Named by an environment variable.
+    Env(&'static str),
+    /// Found at a default install location on disk.
+    Default,
+}
+
+/// A resolved SDK root and how it was found.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SdkRoot {
+    pub path: PathBuf,
+    pub source: SdkSource,
+}
+
+/// Default SDK install locations to probe for the current OS, given `$HOME`
+/// (and `%LOCALAPPDATA%` on Windows) read via `get`.
+fn default_locations(get: &dyn Fn(&str) -> Option<String>) -> Vec<PathBuf> {
+    let mut v = Vec::new();
+    #[cfg(target_os = "windows")]
+    if let Some(la) = get("LOCALAPPDATA").filter(|s| !s.is_empty()) {
+        v.push(PathBuf::from(format!(r"{la}\Android\Sdk")));
+    }
+    #[cfg(target_os = "macos")]
+    if let Some(h) = get("HOME").filter(|s| !s.is_empty()) {
+        v.push(PathBuf::from(format!("{h}/Library/Android/sdk")));
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    {
+        if let Some(h) = get("HOME").filter(|s| !s.is_empty()) {
+            v.push(PathBuf::from(format!("{h}/Android/Sdk")));
+            v.push(PathBuf::from(format!("{h}/android-sdk")));
+        }
+        v.push(PathBuf::from("/opt/android-sdk"));
+        v.push(PathBuf::from("/usr/lib/android-sdk"));
+    }
+    v
+}
+
+/// Resolve the SDK root: `ANDROID_SDK_ROOT`, else `ANDROID_HOME` (each only if the dir
+/// exists), else the first existing default install location. `None` when nothing is found.
+pub fn resolve_sdk_root(
+    get: &dyn Fn(&str) -> Option<String>,
+    exists: &dyn Fn(&Path) -> bool,
+) -> Option<SdkRoot> {
+    for var in ["ANDROID_SDK_ROOT", "ANDROID_HOME"] {
+        if let Some(p) = get(var).filter(|s| !s.is_empty()) {
+            let path = PathBuf::from(p);
+            if exists(&path) {
+                return Some(SdkRoot { path, source: SdkSource::Env(var) });
+            }
+        }
+    }
+    default_locations(get)
+        .into_iter()
+        .find(|p| exists(p))
+        .map(|path| SdkRoot { path, source: SdkSource::Default })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn getter(pairs: &'static [(&'static str, &'static str)]) -> impl Fn(&str) -> Option<String> {
+        move |k| pairs.iter().find(|(n, _)| *n == k).map(|(_, v)| v.to_string())
+    }
+
+    #[test]
+    fn env_root_wins_when_it_exists() {
+        let get = getter(&[("ANDROID_SDK_ROOT", "/sdk"), ("HOME", "/home/u")]);
+        let r = resolve_sdk_root(&get, &|p| p == Path::new("/sdk")).unwrap();
+        assert_eq!(r.path, PathBuf::from("/sdk"));
+        assert_eq!(r.source, SdkSource::Env("ANDROID_SDK_ROOT"));
+    }
+
+    #[test]
+    fn falls_through_env_root_that_is_missing() {
+        // ANDROID_SDK_ROOT set but absent; ANDROID_HOME present and exists.
+        let get = getter(&[("ANDROID_SDK_ROOT", "/nope"), ("ANDROID_HOME", "/home/u/android-sdk")]);
+        let r = resolve_sdk_root(&get, &|p| p == Path::new("/home/u/android-sdk")).unwrap();
+        assert_eq!(r.source, SdkSource::Env("ANDROID_HOME"));
+    }
+
+    #[test]
+    fn discovers_default_location_with_no_env() {
+        let get = getter(&[("HOME", "/home/u")]);
+        let r = resolve_sdk_root(&get, &|p| p == Path::new("/home/u/android-sdk")).unwrap();
+        assert_eq!(r.path, PathBuf::from("/home/u/android-sdk"));
+        assert_eq!(r.source, SdkSource::Default);
+    }
+
+    #[test]
+    fn none_when_nothing_exists() {
+        let get = getter(&[("HOME", "/home/u")]);
+        assert!(resolve_sdk_root(&get, &|_| false).is_none());
+    }
+}


### PR DESCRIPTION
Makes glass's Android backend work with **zero env configuration**, and hardens two install paths it exposed.

## Problem

Android resolution (`adb`, `emulator`, the optional agent jar / a11y APK) depended on the **glass-mcp server process** inheriting the operator's shell environment — which it frequently doesn't (an MCP client launches the server without the SDK vars; or they live in shell-specific config like fish universal variables). Result: `glass_doctor` reports "adb unavailable" even though adb works fine in the user's shell, and the optional companions require env paths.

## Changes (all backward-compatible — env vars remain explicit overrides)

1. **SDK discovery** — new pure `sdk.rs`: find the SDK via `ANDROID_SDK_ROOT` → `ANDROID_HOME` → common install locations (`~/Android/Sdk`, `~/android-sdk`, `/opt/...`; macOS `~/Library/Android/sdk`; Windows `%LOCALAPPDATA%\Android\Sdk`). adb (`$SDK/platform-tools/adb`) and emulator (`$SDK/emulator/emulator`) derive from it.
2. **Agent jar / a11y APK discovery** — `agent_jar`/`a11y_apk` resolve env var → glass data dir (`$XDG_DATA_HOME/glass`, `%APPDATA%\glass`, `~/Library/Application Support/glass`) → next to the `glass-mcp` binary. Flows through the real load paths (`AgentRegistry::ensure`, `make_platform`), not just diagnostics.
3. **Honest doctor** — adb/emulator checks report how they resolved + the search trail on failure; the agent/a11y "not configured" hints name the drop-in dir.
4. **a11y-service install self-heals** on signature mismatch — when a differently-signed build of glass's own `com.fixedwidth.glassa11y` is already installed (e.g. release APK over a local debug build), uninstall the stale copy + reinstall instead of failing with `INSTALL_FAILED_UPDATE_INCOMPATIBLE`.

No `glass_start`/`AppSpec` changes; no auto-download (no hardcoded URLs — glass only looks in well-known on-disk locations).

## Verification

- 130 `glass-android` unit tests (pure, injected env + `exists`); full `cargo test --workspace`; `clippy --workspace --all-targets -D warnings` clean.
- OS-specific default-location tests are `#[cfg]`-gated so the Windows CI job doesn't run Linux-path assertions.
- Manual smokes (no env set): doctor's adb/emulator go green via discovered SDK; agent + a11y-service go green from a dropped-in data dir; and the signature-mismatch uninstall+reinstall recovers a real stuck AVD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)