### PR TITLE
Android dogfood fixes: real drag samples + unconditional doctor pre-flight

### DIFF
--- a/crates/glass-android/src/input.rs
+++ b/crates/glass-android/src/input.rs
@@ -139,10 +139,32 @@ fn meta_keycode(m: Modifier) -> u32 {
     }
 }
 
+/// Pixels between interpolated samples along an agent drag path. Small enough that the first
+/// samples clear Android touch-slop near the start, so a drag is recognized at its true origin
+/// rather than its end (a 2-point path injects DOWN+UP only, which touch-slop swallows).
+const AGENT_STEP_PX: i32 = 16;
+
+/// Interpolate a drag path `from`→`to` over `ms` into evenly spaced samples (≥8) so the
+/// on-device agent injects real `ACTION_MOVE` events. First sample `t=0`, last `t=ms`.
+fn agent_path(fx: i32, fy: i32, tx: i32, ty: i32, ms: u64) -> Vec<Pt> {
+    let dist = (tx - fx).abs().max((ty - fy).abs());
+    let steps = (dist / AGENT_STEP_PX).clamp(8, 64) as u64;
+    (0..=steps)
+        .map(|i| {
+            let f = i as f64 / steps as f64;
+            Pt {
+                x: fx + ((tx - fx) as f64 * f).round() as i32,
+                y: fy + ((ty - fy) as f64 * f).round() as i32,
+                t_ms: (ms as f64 * f).round() as u64,
+            }
+        })
+        .collect()
+}
+
 /// Map a pointer event to the agent's gesture(s): a list of absolute-display pointer paths
 /// (one path per tap/swipe), mirroring `pointer_commands`' window→display mapping. `Click`
-/// with count N yields N single-point tap paths; `Drag`/`Scroll` yield one 2-point path;
-/// `Move` yields nothing.
+/// with count N yields N single-point tap paths; `Drag` yields one interpolated multi-point
+/// path; `Scroll` yields one 2-point swipe; `Move` yields nothing.
 pub(crate) fn agent_pointer(origin: &WindowGeometry, event: &PointerEvent) -> Vec<Vec<Pt>> {
     let abs = |x: i32, y: i32| (origin.x + x, origin.y + y);
     match *event {
@@ -155,7 +177,7 @@ pub(crate) fn agent_pointer(origin: &WindowGeometry, event: &PointerEvent) -> Ve
             let (fx, fy) = abs(from_x, from_y);
             let (tx, ty) = abs(to_x, to_y);
             let ms = if duration_ms == 0 { SWIPE_MS } else { duration_ms };
-            vec![vec![Pt { x: fx, y: fy, t_ms: 0 }, Pt { x: tx, y: ty, t_ms: ms }]]
+            vec![agent_path(fx, fy, tx, ty, ms)]
         }
         PointerEvent::Scroll { x, y, dx, dy, .. } => {
             let (cx, cy) = abs(x, y);
@@ -235,11 +257,23 @@ mod agent_inject_tests {
     }
 
     #[test]
-    fn drag_maps_to_two_point_path_with_duration() {
+    fn drag_interpolates_intermediate_samples() {
         let ev = PointerEvent::Drag { from_x: 0, from_y: 0, to_x: 50, to_y: 60, duration_ms: 250, button: MouseButton::Left, modifiers: vec![] };
         let g = agent_pointer(&origin(), &ev);
         assert_eq!(g.len(), 1);
-        assert_eq!(g[0], vec![Pt { x: 100, y: 200, t_ms: 0 }, Pt { x: 150, y: 260, t_ms: 250 }]);
+        let path = &g[0];
+        // Endpoints exact: DOWN at abs(from) @ t0, UP at abs(to) @ t=ms.
+        assert_eq!(path.first().copied().unwrap(), Pt { x: 100, y: 200, t_ms: 0 });
+        assert_eq!(path.last().copied().unwrap(), Pt { x: 150, y: 260, t_ms: 250 });
+        // Real ACTION_MOVE samples between DOWN and UP — a 2-point path is swallowed by
+        // Android touch-slop (onDragStart fires at the end coordinate). See dogfood F8.
+        assert!(path.len() >= 8, "expected interpolated samples, got {}", path.len());
+        // Monotonic in time and along the (down-right) path.
+        assert!(path.windows(2).all(|w| w[0].t_ms <= w[1].t_ms), "t_ms not monotonic: {path:?}");
+        assert!(
+            path.windows(2).all(|w| w[0].x <= w[1].x && w[0].y <= w[1].y),
+            "not monotonic along path: {path:?}"
+        );
     }
 
     #[test]

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -92,18 +92,17 @@ fn diagnose_inner(deep: bool, audit: Option<&crate::audit::AuditReport>) -> Diag
         ));
     }
 
-    // Android is host-OS-agnostic (drives an AVD over adb), so the crate is always
-    // compiled in. Its checks spawn adb/emulator probes, so run them only when android is
-    // the selected backend; otherwise emit a single note on how to enable them.
-    let android_checks = if backend == "android" {
-        glass_android::doctor::checks(deep)
-    } else {
-        vec![Check::new(
-            "android backend",
-            CheckStatus::Skip,
-            "not selected — set GLASS_BACKEND=android to run adb/emulator checks",
-        )]
-    };
+    // Android is host-OS-agnostic (drives an AVD over adb), so the crate is always compiled
+    // in. Run its basic presence checks unconditionally — like the desktop backends — so the
+    // doctor gives android pre-flight regardless of the (launch-frozen) GLASS_BACKEND. Only
+    // the expensive/mutating deep probes (boot AVD, install agent) stay gated to the selected
+    // backend. When android isn't active, soften any Fail to Warn so an irrelevant missing
+    // adb/emulator doesn't fail the overall verdict for a desktop user.
+    let android_selected = backend == "android";
+    let mut android_checks = glass_android::doctor::checks(deep && android_selected);
+    if !android_selected {
+        soften_inactive_android(&mut android_checks);
+    }
     sections.push(Section::new("android", Some("android".into()), android_checks));
 
     if let Some(report) = audit {
@@ -129,9 +128,38 @@ fn audit_section(report: &crate::audit::AuditReport) -> Section {
     Section::new("audit", None, vec![Check::new("audit log", status, detail)])
 }
 
+/// When android isn't the active backend, its presence checks are advisory: downgrade any
+/// `Fail` to `Warn` (noting why) so a missing adb/emulator — irrelevant to the current
+/// backend — doesn't fail the overall diagnosis. The actual status is still reported.
+fn soften_inactive_android(checks: &mut [Check]) {
+    for c in checks {
+        if c.status == CheckStatus::Fail {
+            c.status = CheckStatus::Warn;
+            c.detail = format!("{} (only required when the android backend is selected)", c.detail);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn inactive_android_fails_soften_to_warn() {
+        let mut checks = vec![
+            Check::new("adb", CheckStatus::Fail, "`adb` not found").with_remedy("install platform-tools"),
+            Check::new("emulator", CheckStatus::Warn, "no AVDs listed"),
+            Check::new("agent", CheckStatus::Skip, "not configured"),
+            Check::new("device", CheckStatus::Ok, "1 online"),
+        ];
+        soften_inactive_android(&mut checks);
+        assert_eq!(checks[0].status, CheckStatus::Warn); // Fail → Warn
+        assert!(checks[0].detail.contains("only required when the android backend is selected"));
+        assert_eq!(checks[0].remedy.as_deref(), Some("install platform-tools")); // remedy preserved
+        assert_eq!(checks[1].status, CheckStatus::Warn); // Warn untouched
+        assert_eq!(checks[2].status, CheckStatus::Skip); // Skip untouched
+        assert_eq!(checks[3].status, CheckStatus::Ok); // Ok untouched
+    }
 
     #[test]
     fn diagnose_lists_only_compiled_in_backends() {
@@ -147,10 +175,10 @@ mod tests {
         assert_eq!(titles, ["general", "network", "x11", "wayland", "sandbox", "accessibility (linux)", "android"]);
         #[cfg(windows)]
         assert_eq!(titles, ["general", "network", "windows", "sandbox", "accessibility (windows)", "android"]);
-        // Android's section is always present and non-empty (real checks when it's the
-        // selected backend, else a single "set GLASS_BACKEND=android" Skip note). Asserting
-        // non-empty catches accidental removal of the section or its else-branch, without
-        // depending on which backend the ambient env resolves to.
+        // Android's section is always present and non-empty — its basic presence checks now
+        // run unconditionally (deep probes gated to the selected backend; Fails softened to
+        // Warn when android isn't active). Asserting non-empty catches accidental removal of
+        // the section, without depending on which backend the ambient env resolves to.
         let android = d.sections.iter().find(|s| s.title == "android").expect("android section");
         assert_eq!(android.backend.as_deref(), Some("android"));
         assert!(!android.checks.is_empty());


### PR DESCRIPTION
Two P1 fixes surfaced by the Android paint-app dogfood run.

## 1. `glass_drag` injects interpolated move samples (not just DOWN+UP)

The on-device agent's drag path was 2 points `[from, to]` → DOWN + UP with no `ACTION_MOVE` between. Compose `detectDragGestures` touch-slop swallows that (onDragStart fires at the *end* coordinate), so a real drag renders as a degenerate zero-length stroke — which the dogfood hit immediately (finding F8). Now the path is interpolated into ≥8 evenly-spaced, time-stamped samples, so a genuine drag is delivered and standard touch-slop drag detection works. The `adb shell input swipe` path already interpolates natively, so this was agent-path-only.

## 2. `glass_doctor` runs android pre-flight unconditionally

The android section ran **zero** checks unless `GLASS_BACKEND=android` — which is frozen at server launch, so you couldn't check android readiness from a session that didn't set it (the one time you most want to). Inconsistent with the desktop backends, which run their basic checks unconditionally and gate only the *deep* probes by selection. Now android matches: basic presence checks (adb/emulator/AVD/agent) always run; deep probes (boot/install/launch) stay gated to the selected backend. When android isn't the active backend, a `Fail` softens to `Warn` so an irrelevant missing adb/emulator doesn't fail a desktop user's overall verdict — the status is still shown. Dogfood finding #1.

Before (GLASS_BACKEND unset): `– android backend: not selected — set GLASS_BACKEND=android …`
After: full `✓ adb / ✓ emulator / ✓ device …` pre-flight.

## Verification
- New unit tests: drag interpolation (endpoints exact, ≥8 monotonic samples) and the inactive-android Fail→Warn softening (both pure/hermetic).
- Full `cargo test --workspace` + `clippy --workspace --all-targets -D warnings` clean.
- Live: `glass-mcp doctor` with `GLASS_BACKEND` unset now shows the android section running real checks.

Independent of #48 (touches `input.rs` + `glass-mcp/doctor.rs`; #48 touches `glass-android/{sdk,adb,avd,doctor}.rs`). Merge order doesn't matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)