### PR TITLE
Android dogfood P2s: scroll fling + actability-aware role matching

### DIFF
--- a/crates/glass-android/src/input.rs
+++ b/crates/glass-android/src/input.rs
@@ -163,8 +163,8 @@ fn agent_path(fx: i32, fy: i32, tx: i32, ty: i32, ms: u64) -> Vec<Pt> {
 
 /// Map a pointer event to the agent's gesture(s): a list of absolute-display pointer paths
 /// (one path per tap/swipe), mirroring `pointer_commands`' window→display mapping. `Click`
-/// with count N yields N single-point tap paths; `Drag` yields one interpolated multi-point
-/// path; `Scroll` yields one 2-point swipe; `Move` yields nothing.
+/// with count N yields N single-point tap paths; `Drag` and `Scroll` each yield one
+/// interpolated multi-point path (so the swipe has real velocity); `Move` yields nothing.
 pub(crate) fn agent_pointer(origin: &WindowGeometry, event: &PointerEvent) -> Vec<Vec<Pt>> {
     let abs = |x: i32, y: i32| (origin.x + x, origin.y + y);
     match *event {
@@ -185,7 +185,9 @@ pub(crate) fn agent_pointer(origin: &WindowGeometry, event: &PointerEvent) -> Ve
             let hi_y = (origin.y + origin.height as i32 - 1).max(origin.y);
             let ex = cx.saturating_sub(dx.saturating_mul(SCROLL_STEP_PX)).clamp(origin.x, hi_x);
             let ey = cy.saturating_sub(dy.saturating_mul(SCROLL_STEP_PX)).clamp(origin.y, hi_y);
-            vec![vec![Pt { x: cx, y: cy, t_ms: 0 }, Pt { x: ex, y: ey, t_ms: SWIPE_MS }]]
+            // Interpolate so the swipe carries real velocity (a fling), not a single jump —
+            // a 2-point swipe under-scrolls and stalls on long lists (dogfood #17).
+            vec![agent_path(cx, cy, ex, ey, SWIPE_MS)]
         }
     }
 }
@@ -283,13 +285,16 @@ mod agent_inject_tests {
     }
 
     #[test]
-    fn scroll_maps_to_one_swipe() {
+    fn scroll_interpolates_one_swipe() {
         let ev = PointerEvent::Scroll { x: 250, y: 400, dx: 0, dy: 1, modifiers: vec![] };
         let g = agent_pointer(&origin(), &ev);
         assert_eq!(g.len(), 1);
-        assert_eq!(g[0].len(), 2);
-        assert_eq!(g[0][0], Pt { x: 350, y: 600, t_ms: 0 });
-        assert_eq!(g[0][1], Pt { x: 350, y: 480, t_ms: SWIPE_MS });
+        let path = &g[0];
+        assert_eq!(path.first().copied().unwrap(), Pt { x: 350, y: 600, t_ms: 0 });
+        assert_eq!(path.last().copied().unwrap(), Pt { x: 350, y: 480, t_ms: SWIPE_MS });
+        // Interpolated samples give the swipe real velocity → a fling, so deep scrolls
+        // don't stall. Dogfood finding #17.
+        assert!(path.len() >= 8, "scroll should fling with interpolated samples, got {}", path.len());
     }
 
     /// Drift guard: `pointer_commands` and `agent_pointer` must agree on absolute
@@ -311,7 +316,8 @@ mod agent_inject_tests {
         assert_eq!((sargv[0][3].as_str(), sargv[0][4].as_str()), ("350", "600"));
         assert_eq!(spath[0][0], Pt { x: 350, y: 600, t_ms: 0 });
         assert_eq!((sargv[0][5].as_str(), sargv[0][6].as_str()), ("350", "480"));
-        assert_eq!((spath[0][1].x, spath[0][1].y), (350, 480));
+        let end = spath[0].last().unwrap();
+        assert_eq!((end.x, end.y), (350, 480));
     }
 }
 

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -481,9 +481,19 @@ pub fn element_match<'a>(
     value_contains: Option<&str>,
     condition: ElementCondition,
 ) -> ElementMatch<'a> {
+    // Role filter: exact match, OR — when an interactable role is requested — an actable
+    // node that the backend left generically classified. Toolkits like Jetpack Compose
+    // surface a real button as a clickable `Group`/`Other` (the role is lost), so an exact
+    // filter would miss it; matching by name + actability finds it anyway.
+    let role_match = |n: &AxNode, r: AxRole| {
+        n.role == r
+            || (r.is_interactable()
+                && n.states.focusable
+                && matches!(n.role, AxRole::Group | AxRole::Other))
+    };
     let selector_match = |n: &AxNode| -> bool {
         name.is_none_or(|q| n.name.as_deref().is_some_and(|nm| nm.contains(q)))
-            && role.is_none_or(|r| n.role == r)
+            && role.is_none_or(|r| role_match(n, r))
             && value_contains.is_none_or(|v| n.value.as_deref().is_some_and(|val| val.contains(v)))
     };
     if condition == ElementCondition::Disappears {
@@ -694,6 +704,40 @@ mod tests {
             ElementMatch::Satisfied(Some(n)) => assert_eq!(n.name.as_deref(), Some("Save")),
             other => panic!("expected the Button, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn role_button_matches_unclassified_actable_node() {
+        // A Compose button often surfaces as a clickable (focusable) Group with the role
+        // lost — `role:"Button"` should still find it by name + actability.
+        let mut clickable = leaf(AxRole::Group, "Submit");
+        clickable.states = AxStates { focusable: true, enabled: true, ..Default::default() };
+        let inert = leaf(AxRole::Group, "Panel"); // a non-actable Group must NOT match Button
+        let root = AxNode {
+            id: AxNodeId(0),
+            role: AxRole::Window,
+            raw_role: "frame".into(),
+            name: Some("App".into()),
+            value: None,
+            states: AxStates::default(),
+            bounds: None,
+            children: vec![clickable, inert],
+        };
+        let t = AxTree { root, count: 0 };
+        assert!(
+            matches!(
+                element_match(&t, Some("Submit"), Some(AxRole::Button), None, ElementCondition::Appears),
+                ElementMatch::Satisfied(Some(n)) if n.name.as_deref() == Some("Submit")
+            ),
+            "clickable Group should satisfy role:Button"
+        );
+        assert!(
+            matches!(
+                element_match(&t, Some("Panel"), Some(AxRole::Button), None, ElementCondition::Appears),
+                ElementMatch::Pending
+            ),
+            "a non-actable Group must not satisfy role:Button"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two more dogfood-found fixes (P2).

## `glass_scroll` flings instead of stalling (#17)
The agent scroll path was a 2-point swipe (single jump), which under-scrolls and stalls on long lists. Interpolate it via `agent_path` (same helper PR #49 added for drag) so the swipe carries real velocity and flings.

## `glass_wait_for_element {role:"Button"}` matches Compose buttons (#20)
Toolkits like Jetpack Compose surface a real button as a clickable `Group` (the role is lost). An exact role filter missed it. Now an *interactable* role request also matches a **focusable/clickable** node that the backend left generically classified (`Group`/`Other`) — found by name + actionability. Non-actable Groups still don't match.

Pairs with glass-android-agent PR #3, which makes the agent report `clickable` from `ACTION_CLICK` (Compose buttons report `isClickable()==false`) — so the focusable signal this relies on is actually set. Each is independently correct; together they close finding #20.

(Multi-touch / pinch, #13, is deferred — it's a feature needing its own design.)

## Verification
New unit tests for both (scroll interpolation; role matching an actable Group but not an inert one). Full `cargo test --workspace` + `clippy --workspace --all-targets -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)