### PR TITLE
Android multi-touch: glass_gesture

### DIFF
--- a/crates/glass-android/src/agent.rs
+++ b/crates/glass-android/src/agent.rs
@@ -68,6 +68,19 @@ impl AgentClient {
             .collect();
         self.call(json!({"op": "pointer", "gesture": g, "button": button})).map(|_| ())
     }
+    pub fn gesture(&self, paths: &[Vec<Pt>]) -> Result<()> {
+        let pointers: Vec<Value> = paths
+            .iter()
+            .map(|path| {
+                Value::Array(
+                    path.iter()
+                        .map(|p| json!({ "x": p.x, "y": p.y, "t_ms": p.t_ms }))
+                        .collect(),
+                )
+            })
+            .collect();
+        self.call(json!({ "op": "gesture", "pointers": pointers })).map(|_| ())
+    }
     pub fn key(&self, chord: &str) -> Result<()> {
         self.call(json!({"op": "key", "chord": chord})).map(|_| ())
     }

--- a/crates/glass-android/src/input.rs
+++ b/crates/glass-android/src/input.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use crate::adb::Adb;
 use crate::agent::{AgentClient, Pt};
 use glass_core::keys::parse_chord;
-use glass_core::{GlassError, KeyEvent, Modifier, PointerEvent, Result, WindowGeometry};
+use glass_core::{GlassError, KeyEvent, Modifier, PointerEvent, Result, Segment, WindowGeometry};
 
 /// Pixels of swipe travel per scroll "click" (`Scroll.dx/dy` are wheel clicks —
 /// X11 clicks the wheel `|delta|` times). Tunable.
@@ -162,6 +162,37 @@ fn agent_path(fx: i32, fy: i32, tx: i32, ty: i32, ms: u64) -> Vec<Pt> {
         .collect()
 }
 
+/// Build N time-aligned absolute-coord pointer paths from window-relative segments. All paths
+/// share one sample count (from the longest segment, clamped like a drag) and the same `t_ms`
+/// timeline, so the device can emit aligned multi-pointer frames. `from==to` → a constant path.
+fn agent_gesture_paths(origin: &WindowGeometry, segments: &[Segment], duration_ms: u64) -> Vec<Vec<Pt>> {
+    let ms = if duration_ms == 0 { SWIPE_MS } else { duration_ms };
+    let abs = |x: i32, y: i32| (origin.x + x, origin.y + y);
+    let longest = segments
+        .iter()
+        .map(|s| (s.to_x - s.from_x).abs().max((s.to_y - s.from_y).abs()))
+        .max()
+        .unwrap_or(0);
+    let steps = (longest / AGENT_STEP_PX).clamp(8, 64) as u64;
+    segments
+        .iter()
+        .map(|s| {
+            let (fx, fy) = abs(s.from_x, s.from_y);
+            let (tx, ty) = abs(s.to_x, s.to_y);
+            (0..=steps)
+                .map(|i| {
+                    let f = i as f64 / steps as f64;
+                    Pt {
+                        x: fx + ((tx - fx) as f64 * f).round() as i32,
+                        y: fy + ((ty - fy) as f64 * f).round() as i32,
+                        t_ms: (ms as f64 * f).round() as u64,
+                    }
+                })
+                .collect()
+        })
+        .collect()
+}
+
 /// Map a pointer event to the agent's gesture(s): a list of absolute-display pointer paths
 /// (one path per tap/swipe), mirroring `pointer_commands`' window→display mapping. `Click`
 /// with count N yields N single-point tap paths; `Drag` and `Scroll` each yield one
@@ -202,10 +233,9 @@ pub(crate) struct AgentInjector {
 
 impl Injector for AgentInjector {
     fn pointer(&self, _adb: &Adb, origin: &WindowGeometry, event: &PointerEvent) -> Result<()> {
-        if let PointerEvent::Gesture { .. } = event {
-            return Err(GlassError::Unsupported(
-                "multi-touch requires the on-device agent (not yet wired)".into(),
-            ));
+        if let PointerEvent::Gesture { pointers, duration_ms } = event {
+            let paths = agent_gesture_paths(origin, pointers, *duration_ms);
+            return self.agent.gesture(&paths);
         }
         // One agent request per gesture: a Click{count:N} sends N sequential taps.
         for gesture in agent_pointer(origin, event) {
@@ -257,7 +287,7 @@ impl Injector for ShellInjector {
 mod agent_inject_tests {
     use super::*;
     use crate::agent::Pt;
-    use glass_core::{MouseButton, PointerEvent, WindowGeometry};
+    use glass_core::{MouseButton, PointerEvent, Segment, WindowGeometry};
 
     fn origin() -> WindowGeometry { WindowGeometry { x: 100, y: 200, width: 500, height: 800 } }
 
@@ -307,6 +337,23 @@ mod agent_inject_tests {
         // Interpolated samples give the swipe real velocity → a fling, so deep scrolls
         // don't stall. Dogfood finding #17.
         assert!(path.len() >= 8, "scroll should fling with interpolated samples, got {}", path.len());
+    }
+
+    #[test]
+    fn gesture_builds_time_aligned_absolute_paths() {
+        let segments = vec![
+            Segment { from_x: 0, from_y: 0, to_x: 80, to_y: 0 },   // moves right 80px
+            Segment { from_x: 40, from_y: 40, to_x: 40, to_y: 40 }, // held
+        ];
+        let paths = agent_gesture_paths(&origin(), &segments, 250);
+        assert_eq!(paths.len(), 2);
+        assert_eq!(paths[0].len(), paths[1].len());
+        assert!(paths[0].len() >= 8);
+        assert_eq!(paths[0].iter().map(|p| p.t_ms).collect::<Vec<_>>(),
+                   paths[1].iter().map(|p| p.t_ms).collect::<Vec<_>>());
+        assert_eq!(paths[0].first().copied().unwrap(), Pt { x: 100, y: 200, t_ms: 0 });
+        assert_eq!(paths[0].last().copied().unwrap(), Pt { x: 180, y: 200, t_ms: 250 });
+        assert!(paths[1].iter().all(|p| p.x == 140 && p.y == 240));
     }
 
     /// Drift guard: `pointer_commands` and `agent_pointer` must agree on absolute

--- a/crates/glass-android/src/input.rs
+++ b/crates/glass-android/src/input.rs
@@ -47,6 +47,7 @@ pub fn pointer_commands(origin: &WindowGeometry, event: &PointerEvent) -> Vec<Ve
             let ey = cy.saturating_sub(dy.saturating_mul(SCROLL_STEP_PX)).clamp(origin.y, hi_y);
             vec![swipe(cx, cy, ex, ey, SWIPE_MS)]
         }
+        PointerEvent::Gesture { .. } => vec![], // adb has no multi-touch; ShellInjector refuses
     }
 }
 
@@ -189,6 +190,7 @@ pub(crate) fn agent_pointer(origin: &WindowGeometry, event: &PointerEvent) -> Ve
             // a 2-point swipe under-scrolls and stalls on long lists (dogfood #17).
             vec![agent_path(cx, cy, ex, ey, SWIPE_MS)]
         }
+        PointerEvent::Gesture { .. } => vec![], // handled by AgentInjector::pointer directly
     }
 }
 
@@ -200,6 +202,11 @@ pub(crate) struct AgentInjector {
 
 impl Injector for AgentInjector {
     fn pointer(&self, _adb: &Adb, origin: &WindowGeometry, event: &PointerEvent) -> Result<()> {
+        if let PointerEvent::Gesture { .. } = event {
+            return Err(GlassError::Unsupported(
+                "multi-touch requires the on-device agent (not yet wired)".into(),
+            ));
+        }
         // One agent request per gesture: a Click{count:N} sends N sequential taps.
         for gesture in agent_pointer(origin, event) {
             self.agent.pointer(&gesture, "left")?;
@@ -227,6 +234,11 @@ pub struct ShellInjector;
 
 impl Injector for ShellInjector {
     fn pointer(&self, adb: &Adb, origin: &WindowGeometry, event: &PointerEvent) -> Result<()> {
+        if let PointerEvent::Gesture { .. } = event {
+            return Err(GlassError::Unsupported(
+                "multi-touch requires the on-device agent (not yet wired)".into(),
+            ));
+        }
         for argv in pointer_commands(origin, event) {
             adb.run(argv.iter().map(String::as_str))?;
         }

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -53,7 +53,7 @@ pub use logbuf::{LogBuffer, LogLine, Stream};
 pub mod platform;
 pub use platform::{
     A11yBind, AppSpec, KeyEvent, MouseButton, Platform, PointerEvent, SandboxLevel, Segment,
-    WindowGeometry, WindowHint, WindowId, WindowInfo, WindowOp,
+    WindowGeometry, WindowHint, WindowId, WindowInfo, WindowOp, MAX_GESTURE_POINTERS,
 };
 
 pub mod accessibility;

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -52,8 +52,8 @@ pub use logbuf::{LogBuffer, LogLine, Stream};
 
 pub mod platform;
 pub use platform::{
-    A11yBind, AppSpec, KeyEvent, MouseButton, Platform, PointerEvent, SandboxLevel, WindowGeometry,
-    WindowHint, WindowId, WindowInfo, WindowOp,
+    A11yBind, AppSpec, KeyEvent, MouseButton, Platform, PointerEvent, SandboxLevel, Segment,
+    WindowGeometry, WindowHint, WindowId, WindowInfo, WindowOp,
 };
 
 pub mod accessibility;

--- a/crates/glass-core/src/platform.rs
+++ b/crates/glass-core/src/platform.rs
@@ -48,6 +48,19 @@ pub enum MouseButton {
     Middle,
 }
 
+/// One pointer's straight path within a multi-touch gesture, in **window-relative** px.
+/// `from == to` is a finger held stationary for the gesture's duration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Segment {
+    pub from_x: i32,
+    pub from_y: i32,
+    pub to_x: i32,
+    pub to_y: i32,
+}
+
+/// Max simultaneous pointers a `Gesture` may carry (Android tops out around this).
+pub const MAX_GESTURE_POINTERS: usize = 10;
+
 /// A pointer action in **window-relative** coordinates (0,0 = top-left).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PointerEvent {
@@ -55,6 +68,9 @@ pub enum PointerEvent {
     Click { x: i32, y: i32, button: MouseButton, count: u32, modifiers: Vec<Modifier> },
     Drag { from_x: i32, from_y: i32, to_x: i32, to_y: i32, button: MouseButton, modifiers: Vec<Modifier>, duration_ms: u64 },
     Scroll { x: i32, y: i32, dx: i32, dy: i32, modifiers: Vec<Modifier> },
+    /// N simultaneous straight pointer segments, all down at t=0 and up at t=duration_ms.
+    /// Android-only (needs the on-device agent); other paths return `Unsupported`.
+    Gesture { pointers: Vec<Segment>, duration_ms: u64 },
 }
 
 /// A keyboard action: either literal text to type or a chord like `ctrl+s`.

--- a/crates/glass-core/src/session.rs
+++ b/crates/glass-core/src/session.rs
@@ -249,6 +249,13 @@ impl Glass {
                 check(from_x, from_y)?;
                 check(to_x, to_y)
             }
+            PointerEvent::Gesture { ref pointers, .. } => {
+                for p in pointers {
+                    check(p.from_x, p.from_y)?;
+                    check(p.to_x, p.to_y)?;
+                }
+                Ok(())
+            }
         }
     }
 
@@ -777,7 +784,7 @@ mod tests {
     use super::*;
     use crate::accessibility::{AxNode, AxRect, AxRole, AxStates, AxTarget, ElementCondition};
     use crate::audit::{Actuation, ActuationContext, AuditOutcome, AuditSink};
-    use crate::platform::SandboxLevel;
+    use crate::platform::{Segment, SandboxLevel};
     use std::collections::VecDeque;
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
@@ -1070,6 +1077,20 @@ mod tests {
             modifiers: vec![],
         });
         assert!(matches!(err.unwrap_err(), GlassError::CoordOutOfBounds { .. }));
+    }
+
+    #[test]
+    fn gesture_out_of_bounds_segment_is_rejected() {
+        let mut g = glass_with(FakePlatform::new(100, 80));
+        g.start(&spec()).unwrap();
+        let ev = PointerEvent::Gesture {
+            pointers: vec![
+                Segment { from_x: 10, from_y: 10, to_x: 20, to_y: 20 },
+                Segment { from_x: 10, from_y: 10, to_x: 200, to_y: 20 }, // to_x out of 100-wide window
+            ],
+            duration_ms: 100,
+        };
+        assert!(matches!(g.pointer(&ev), Err(GlassError::CoordOutOfBounds { .. })));
     }
 
     #[test]
@@ -1858,6 +1879,7 @@ mod tests {
                     PointerEvent::Click { .. } => "click",
                     PointerEvent::Drag { .. } => "drag",
                     PointerEvent::Scroll { .. } => "scroll",
+                    PointerEvent::Gesture { .. } => "gesture",
                 },
                 Actuation::Key { event } => match event {
                     KeyEvent::Text(_) => "type",

--- a/crates/glass-mcp/src/audit.rs
+++ b/crates/glass-mcp/src/audit.rs
@@ -8,8 +8,8 @@ use std::sync::Mutex;
 use std::time::Duration;
 
 use glass_core::{
-    Actuation, ActuationContext, AuditOutcome, AuditSink, KeyEvent, Modifier, MouseButton,
-    PointerEvent, WindowOp,
+    platform::Segment, Actuation, ActuationContext, AuditOutcome, AuditSink, KeyEvent, Modifier,
+    MouseButton, PointerEvent, WindowOp,
 };
 use rand::RngCore;
 use serde::Serialize;
@@ -140,6 +140,16 @@ fn describe(act: &Actuation) -> Option<(&'static str, Value, Option<String>)> {
                     "dx": dx,
                     "dy": dy,
                     "modifiers": fmt_mods(modifiers)
+                }),
+                None,
+            ),
+            PointerEvent::Gesture { pointers, duration_ms } => (
+                "gesture",
+                json!({
+                    "pointers": pointers.iter().map(|s: &Segment| json!({
+                        "from_x": s.from_x, "from_y": s.from_y, "to_x": s.to_x, "to_y": s.to_y
+                    })).collect::<Vec<_>>(),
+                    "duration_ms": duration_ms
                 }),
                 None,
             ),

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -143,6 +143,26 @@ pub struct DragArgs {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct PointerArgs {
+    /// Window-relative start point.
+    pub from: PointArg,
+    /// Window-relative end point. Equal to `from` = a finger held in place.
+    pub to: PointArg,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct PointArg { pub x: i32, pub y: i32 }
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GestureArgs {
+    /// 2–10 simultaneous pointers; each a straight from→to segment. Pinch = two pointers
+    /// moving toward/apart; rotate = two on an arc; two-finger swipe = two parallel segments.
+    pub pointers: Vec<PointerArgs>,
+    /// Span the gesture over this many ms (all pointers down at 0, up at duration). Default 250.
+    pub duration_ms: Option<u64>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct ScrollArgs {
     pub x: i32,
     pub y: i32,

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -171,6 +171,17 @@ impl GlassServer {
         self.run(move |g| tools::scroll(g, &a)).await
     }
 
+    #[tool(
+        description = "Perform a multi-touch gesture: 2–10 pointers, each a straight from→to \
+                       segment in window-relative px, all down together at t=0 and up at \
+                       duration_ms. Pinch = two pointers toward/apart; rotate = two on an arc; \
+                       two-finger swipe = two parallel segments; a from==to pointer is held. \
+                       Android backend only (needs the on-device agent)."
+    )]
+    async fn glass_gesture(&self, Parameters(a): Parameters<GestureArgs>) -> Result<CallToolResult, McpError> {
+        self.run(move |g| tools::gesture(g, &a)).await
+    }
+
     #[tool(description = "Type a string of text into the focused window.")]
     async fn glass_type(&self, Parameters(a): Parameters<TypeArgs>) -> Result<CallToolResult, McpError> {
         self.run(move |g| tools::type_text(g, &a)).await

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -282,6 +282,11 @@ pub(crate) mod testutil {
             }
         }
         fn send_pointer(&mut self, e: &PointerEvent) -> Result<()> {
+            if let PointerEvent::Gesture { .. } = e {
+                return Err(GlassError::Unsupported(
+                    "multi-touch gestures are only supported on the android backend".into(),
+                ));
+            }
             self.events.lock().unwrap().push(match e {
                 PointerEvent::Click { x, y, .. } => format!("click({x},{y})"),
                 PointerEvent::Move { x, y } => format!("move({x},{y})"),
@@ -289,6 +294,7 @@ pub(crate) mod testutil {
                     format!("drag({from_x},{from_y}->{to_x},{to_y})")
                 }
                 PointerEvent::Scroll { x, y, dx, dy, .. } => format!("scroll({x},{y},{dx},{dy})"),
+                PointerEvent::Gesture { .. } => unreachable!(),
             });
             self.pointer_events.push(e.clone());
             Ok(())

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -282,11 +282,6 @@ pub(crate) mod testutil {
             }
         }
         fn send_pointer(&mut self, e: &PointerEvent) -> Result<()> {
-            if let PointerEvent::Gesture { .. } = e {
-                return Err(GlassError::Unsupported(
-                    "multi-touch gestures are only supported on the android backend".into(),
-                ));
-            }
             self.events.lock().unwrap().push(match e {
                 PointerEvent::Click { x, y, .. } => format!("click({x},{y})"),
                 PointerEvent::Move { x, y } => format!("move({x},{y})"),
@@ -294,7 +289,7 @@ pub(crate) mod testutil {
                     format!("drag({from_x},{from_y}->{to_x},{to_y})")
                 }
                 PointerEvent::Scroll { x, y, dx, dy, .. } => format!("scroll({x},{y},{dx},{dy})"),
-                PointerEvent::Gesture { .. } => unreachable!(),
+                PointerEvent::Gesture { pointers, .. } => format!("gesture({})", pointers.len()),
             });
             self.pointer_events.push(e.clone());
             Ok(())

--- a/crates/glass-mcp/src/tools/input.rs
+++ b/crates/glass-mcp/src/tools/input.rs
@@ -49,6 +49,25 @@ pub fn drag(glass: &mut Glass, a: &DragArgs) -> ToolResult {
     Ok(ToolOutput::text("ok"))
 }
 
+pub fn gesture(glass: &mut Glass, a: &GestureArgs) -> ToolResult {
+    let n = a.pointers.len();
+    if n < 2 {
+        return Err("glass_gesture needs 2+ pointers; use glass_drag for a single pointer".into());
+    }
+    if n > glass_core::MAX_GESTURE_POINTERS {
+        return Err(format!("too many pointers ({n}); max is {}", glass_core::MAX_GESTURE_POINTERS));
+    }
+    let pointers = a
+        .pointers
+        .iter()
+        .map(|p| glass_core::Segment { from_x: p.from.x, from_y: p.from.y, to_x: p.to.x, to_y: p.to.y })
+        .collect();
+    glass
+        .pointer(&PointerEvent::Gesture { pointers, duration_ms: a.duration_ms.unwrap_or(250).min(10_000) })
+        .map_err(|e| e.to_string())?;
+    Ok(ToolOutput::text("ok"))
+}
+
 pub fn scroll(glass: &mut Glass, a: &ScrollArgs) -> ToolResult {
     let modifiers = parse_modifiers(a.modifiers.as_deref())?;
     glass
@@ -142,6 +161,29 @@ mod tests {
         assert_eq!(text(&drag(&mut g, &d).unwrap()), "ok");
         let s = ScrollArgs { x: 5, y: 6, dx: None, dy: Some(2), modifiers: None };
         assert_eq!(text(&scroll(&mut g, &s).unwrap()), "ok");
+    }
+
+    #[test]
+    fn gesture_two_pointers_ok() {
+        let mut g = started();
+        let a = GestureArgs {
+            pointers: vec![
+                PointerArgs { from: PointArg { x: 30, y: 40 }, to: PointArg { x: 10, y: 40 } },
+                PointerArgs { from: PointArg { x: 50, y: 40 }, to: PointArg { x: 70, y: 40 } },
+            ],
+            duration_ms: Some(120),
+        };
+        assert_eq!(text(&gesture(&mut g, &a).unwrap()), "ok");
+    }
+
+    #[test]
+    fn gesture_one_pointer_errors() {
+        let mut g = started();
+        let a = GestureArgs {
+            pointers: vec![PointerArgs { from: PointArg { x: 1, y: 1 }, to: PointArg { x: 2, y: 2 } }],
+            duration_ms: None,
+        };
+        assert!(gesture(&mut g, &a).is_err());
     }
 
     #[test]

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -1092,6 +1092,11 @@ impl Platform for WaylandPlatform {
                 };
                 glass_core::run_scroll(&mut sink, !modifiers.is_empty())?;
             }
+            PointerEvent::Gesture { .. } => {
+                return Err(GlassError::Unsupported(
+                    "multi-touch gestures are only supported on the android backend".into(),
+                ));
+            }
         }
         session.conn.flush().map_err(|e| GlassError::Backend(format!("flush: {e}")))?;
         Ok(())

--- a/crates/glass-windows/src/input.rs
+++ b/crates/glass-windows/src/input.rs
@@ -344,6 +344,11 @@ pub(crate) fn send_pointer(active_hwnd: isize, event: &PointerEvent) -> Result<(
             let mut sink = WindowsScrollSink { nx, ny, dx, dy, mod_vks };
             glass_core::run_scroll(&mut sink, !modifiers.is_empty())?;
         }
+        PointerEvent::Gesture { .. } => {
+            return Err(GlassError::Unsupported(
+                "multi-touch gestures are only supported on the android backend".into(),
+            ));
+        }
     }
     Ok(())
 }

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -875,6 +875,11 @@ impl Platform for X11Platform {
                 };
                 glass_core::run_drag(&mut sink, &gesture)?;
             }
+            PointerEvent::Gesture { .. } => {
+                return Err(GlassError::Unsupported(
+                    "multi-touch gestures are only supported on the android backend".into(),
+                ));
+            }
         }
         self.conn.flush().map_err(|e| GlassError::Backend(format!("flush: {e}")))?;
         Ok(())


### PR DESCRIPTION
`glass_gesture`: N (2–10) simultaneous start→end pointer segments over a shared duration — pinch, rotate, two-finger swipe, hold-and-drag.

- **glass-core:** `PointerEvent::Gesture { pointers: Vec<Segment>, duration_ms }` + bounds-check; adding the variant forces every backend to handle it (completeness by construction).
- **glass-android (agent on):** builds N **time-aligned** absolute pointer paths (one shared sample count, same `t_ms` timeline) and sends a new `gesture` op to the on-device agent.
- **Refused cleanly everywhere else:** the adb fallback (`adb input` has no multi-touch) and the x11/wayland/windows backends return `Unsupported`. A 1-pointer or >10-pointer call is a tool error.

Pairs with **glass-android-agent `gesture-op`** PR, which replays the aligned paths as one multi-pointer `MotionEvent` stream and adds a pinch fixture. Needs the agent (v0.4.0) for the device side.

Unit-tested: aligned path building (equal length + timestamps; held pointer constant), the 2–10 validation. Full `cargo test --workspace` + `clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)