### PR TITLE
docs: document glass_gesture multi-touch

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ specific knobs are host-specific — see your host guide:
 **[Linux](docs/running-on-linux.md)** · **[Windows](docs/running-on-windows.md)** · **[macOS](docs/running-on-macos.md)**.
 
 The agent then gets tools like `glass_start`, `glass_screenshot`, `glass_click`,
-`glass_drag`, `glass_scroll`, `glass_type`, `glass_key`, `glass_wait_stable`,
+`glass_drag`, `glass_scroll`, `glass_gesture`, `glass_type`, `glass_key`, `glass_wait_stable`,
 `glass_baseline_save`, `glass_diff`, `glass_logs`, `glass_list_windows`,
 `glass_select_window`, `glass_a11y_snapshot`, `glass_click_element`, `glass_set_value`,
 `glass_a11y_marks`, `glass_wait_for_element`, `glass_wait_for_region`,
@@ -171,6 +171,11 @@ A few capabilities worth knowing:
   `glass_scroll` accept an optional `modifiers` array (e.g. `["ctrl"]`,
   `["ctrl","shift"]`) that holds Ctrl/Shift/Alt/Super during the action —
   enabling shift/ctrl-click multi-select, modified drags, and Ctrl+scroll.
+- **Multi-touch gestures (`glass_gesture`, Android only).** Drive 2–10 simultaneous
+  pointers — each a straight `from→to` segment over a shared duration — for pinch-zoom,
+  two-finger rotate, and two-finger swipes. Android-only and requires the on-device
+  agent (`adb`'s `input` has no multi-touch command); the `adb` fallback and the
+  desktop backends refuse with a clear error rather than degrade to a single pointer.
 - **Batched input (`glass_do`).** Run an ordered sequence of input actions
   (click/type/key/move/drag/scroll/settle) in one call with an optional text-first
   `then` observe (settle/diff/screenshot), collapsing per-action round-trips and
@@ -348,7 +353,7 @@ Where glass stands by OS. **✓** supported · **◑** partial · **–** not su
 | Containment / sandboxing | ✓ bubblewrap | ✓ Sandboxie Classic | ✓ the emulator VM | 🚧 |
 | Display isolation (app off your desktop) | ✓ headless Xvfb / sway | – interactive desktop | ✓ headless emulator | 🚧 |
 
-† **Android** is emulator-only. Capture, multi-window, input, and logs work over `adb`, and glass manages the AVD (attach a running one, or boot a headless one). **Clipboard and high-fidelity input** use the optional on-device agent, and an optional on-device **AccessibilityService** sharpens the a11y tree (Compose) + `set_value` (both in the Android section of your host guide: [Linux](docs/running-on-linux.md) · [Windows](docs/running-on-windows.md) · [macOS](docs/running-on-macos.md)) — without the agent, input falls back to adb's `input` and clipboard is unavailable; without the service, a11y falls back to `uiautomator`. Window resize/move (apps are full-screen) and physical devices are non-goals.
+† **Android** is emulator-only. Capture, multi-window, input, and logs work over `adb`, and glass manages the AVD (attach a running one, or boot a headless one). **Clipboard, high-fidelity input, and multi-touch gestures (`glass_gesture`)** use the optional on-device agent, and an optional on-device **AccessibilityService** sharpens the a11y tree (Compose) + `set_value` (both in the Android section of your host guide: [Linux](docs/running-on-linux.md) · [Windows](docs/running-on-windows.md) · [macOS](docs/running-on-macos.md)) — without the agent, input falls back to adb's `input` (single-pointer only — no multi-touch) and clipboard is unavailable; without the service, a11y falls back to `uiautomator`. Window resize/move (apps are full-screen) and physical devices are non-goals.
 
 The per-platform detail — sandboxing levels, display isolation, the accessibility tree —
 lives in the [Containment](#containment--sandboxing), [Backends](#backends), and

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -394,7 +394,8 @@ impl ServerHandler for GlassServer {
                  app — no app integration needed. One active session; tools target it implicitly; \
                  choose a backend (x11 or wayland) at glass_start.\n\n\
                  Loop: glass_start launches the app and captures its logs; glass_screenshot to see \
-                 it; glass_click / glass_type / glass_key / glass_scroll / glass_drag to interact \
+                 it; glass_click / glass_type / glass_key / glass_scroll / glass_drag (and \
+                 glass_gesture for android multi-touch) to interact \
                  (coordinates are WINDOW-RELATIVE — 0,0 is the app window's top-left); \
                  glass_wait_stable to let a render settle before you look or compare; glass_logs \
                  for the app's stdout/stderr.\n\n\

--- a/docs/running-on-linux.md
+++ b/docs/running-on-linux.md
@@ -232,7 +232,7 @@ Over plain `adb`, glass types with `input text`/`keyevent` and can't reach the s
 clipboard. A small companion — **[glass-android-agent](https://github.com/fixed-width/glass-android-agent)**,
 a separate Apache-2.0 repo — closes both gaps: it runs on the device as a shell-uid
 `app_process` server and gives glass real `MotionEvent`/`KeyEvent` injection (faithful
-Unicode) and clipboard get/set.
+Unicode, plus multi-touch gestures via `glass_gesture`) and clipboard get/set.
 
 Point **`GLASS_ANDROID_AGENT_JAR`** at its `glass-agent.jar`:
 

--- a/docs/running-on-windows.md
+++ b/docs/running-on-windows.md
@@ -216,7 +216,7 @@ Over plain `adb`, glass types with `input text`/`keyevent` and can't reach the s
 clipboard. A small companion — **[glass-android-agent](https://github.com/fixed-width/glass-android-agent)**,
 a separate Apache-2.0 repo — closes both gaps: it runs on the device as a shell-uid
 `app_process` server and gives glass real `MotionEvent`/`KeyEvent` injection (faithful
-Unicode) and clipboard get/set.
+Unicode, plus multi-touch gestures via `glass_gesture`) and clipboard get/set.
 
 Point **`GLASS_ANDROID_AGENT_JAR`** at its `glass-agent.jar`:
 


### PR DESCRIPTION
`glass_gesture` (multi-touch — glass #51, agent v0.4.0) shipped with only its in-protocol tool description. This adds the prose docs:

- **README** — `glass_gesture` in the tool list, a feature bullet (2–10 pointers, Android-only, agent-required; `adb` fallback and desktop backends refuse rather than degrade), and the Android capability summary.
- **MCP server instructions** — list `glass_gesture` among the interact tools.
- **Linux/Windows host guides** — note the on-device agent enables multi-touch gestures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)