### PR TITLE
refactor(clip): RAII guards for HGLOBAL clipboard memory

### DIFF
--- a/crates/glass-clip-hook/examples/clipprobe.rs
+++ b/crates/glass-clip-hook/examples/clipprobe.rs
@@ -11,6 +11,9 @@
 //!   cargo build -p glass-clip-hook --release --example clipprobe
 
 #[cfg(windows)]
+use glass_clip_hook::{HGlobalLock, OwnedHGlobal};
+
+#[cfg(windows)]
 fn main() {
     let mode = std::env::args().nth(1).unwrap_or_default();
     let code = match mode.as_str() {
@@ -34,7 +37,6 @@ fn run() -> i32 {
     use windows::Win32::System::DataExchange::{
         CloseClipboard, EmptyClipboard, GetClipboardData, OpenClipboard, SetClipboardData,
     };
-    use windows::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
     use windows::Win32::System::Ole::CF_UNICODETEXT;
 
     let args: Vec<String> = std::env::args().collect();
@@ -57,24 +59,21 @@ fn run() -> i32 {
             return 1;
         }
         let _ = EmptyClipboard();
-        let Ok(h) = GlobalAlloc(GMEM_MOVEABLE, bytes) else {
+        let mut buf = Vec::with_capacity(bytes);
+        for unit in &utf16 {
+            buf.extend_from_slice(&unit.to_le_bytes());
+        }
+        let Some(mem) = OwnedHGlobal::from_bytes(&buf) else {
             let _ = CloseClipboard();
             eprintln!("FAIL: GlobalAlloc");
             return 1;
         };
-        let dst = GlobalLock(h);
-        if dst.is_null() {
+        if SetClipboardData(cf, Some(HANDLE(mem.handle().0))).is_err() {
             let _ = CloseClipboard();
-            eprintln!("FAIL: GlobalLock(write)");
+            eprintln!("FAIL: SetClipboardData"); // `mem` drops here -> GlobalFree
             return 1;
         }
-        std::ptr::copy_nonoverlapping(utf16.as_ptr() as *const u8, dst as *mut u8, bytes);
-        let _ = GlobalUnlock(h);
-        if SetClipboardData(cf, Some(HANDLE(h.0))).is_err() {
-            let _ = CloseClipboard();
-            eprintln!("FAIL: SetClipboardData");
-            return 1;
-        }
+        mem.into_raw(); // success: the system (or the hook) owns the handle now
         let _ = CloseClipboard();
 
         // --- read back ---
@@ -85,21 +84,11 @@ fn run() -> i32 {
             return 1;
         }
         let read = match GetClipboardData(cf) {
-            Ok(hr) if !hr.is_invalid() => {
-                let g = HGLOBAL(hr.0);
-                let p = GlobalLock(g) as *const u16;
-                if p.is_null() {
-                    String::new()
-                } else {
-                    let mut len = 0usize;
-                    while *p.add(len) != 0 {
-                        len += 1;
-                    }
-                    let s = String::from_utf16_lossy(std::slice::from_raw_parts(p, len));
-                    let _ = GlobalUnlock(g);
-                    s
-                }
-            }
+            // SAFETY: clipboard-owned handle, valid while the clipboard is open.
+            Ok(hr) if !hr.is_invalid() => match HGlobalLock::new(HGLOBAL(hr.0)) {
+                Some(lock) => utf16_to_string(lock.as_bytes()),
+                None => String::new(),
+            },
             _ => String::new(),
         };
         let _ = CloseClipboard();
@@ -112,22 +101,14 @@ fn run() -> i32 {
 /// Allocate a `GMEM_MOVEABLE` `HGLOBAL` holding `data`; null handle on failure.
 ///
 /// # Safety
-/// Standard `GlobalAlloc`/`GlobalLock`/copy/`GlobalUnlock`. The returned handle is handed to
+/// Allocates via [`OwnedHGlobal`] and relinquishes ownership. The returned handle is handed to
 /// `SetClipboardData` (which takes ownership on success); the caller must not free it.
 #[cfg(windows)]
 unsafe fn alloc_global(data: &[u8]) -> windows::Win32::Foundation::HGLOBAL {
     use windows::Win32::Foundation::HGLOBAL;
-    use windows::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
-    let Ok(h) = GlobalAlloc(GMEM_MOVEABLE, data.len()) else {
-        return HGLOBAL(std::ptr::null_mut());
-    };
-    let dst = GlobalLock(h);
-    if dst.is_null() {
-        return HGLOBAL(std::ptr::null_mut());
-    }
-    std::ptr::copy_nonoverlapping(data.as_ptr(), dst as *mut u8, data.len());
-    let _ = GlobalUnlock(h);
-    h
+    OwnedHGlobal::from_bytes(data)
+        .map(|m| m.into_raw()) // caller (STGMEDIUM / SetClipboardData) owns + frees it
+        .unwrap_or(HGLOBAL(std::ptr::null_mut()))
 }
 
 /// `GetClipboardData(fmt)` → the full `HGLOBAL` contents as bytes (bounded by `GlobalSize`). `None`
@@ -139,20 +120,12 @@ unsafe fn alloc_global(data: &[u8]) -> windows::Win32::Foundation::HGLOBAL {
 unsafe fn read_global_bytes(fmt: u32) -> Option<Vec<u8>> {
     use windows::Win32::Foundation::HGLOBAL;
     use windows::Win32::System::DataExchange::GetClipboardData;
-    use windows::Win32::System::Memory::{GlobalLock, GlobalSize, GlobalUnlock};
     let hr = GetClipboardData(fmt).ok()?;
     if hr.is_invalid() {
         return None;
     }
-    let g = HGLOBAL(hr.0);
-    let p = GlobalLock(g) as *const u8;
-    if p.is_null() {
-        return None;
-    }
-    let n = GlobalSize(g);
-    let v = std::slice::from_raw_parts(p, n).to_vec();
-    let _ = GlobalUnlock(g);
-    Some(v)
+    let lock = HGlobalLock::new(HGLOBAL(hr.0))?;
+    Some(lock.as_bytes().to_vec())
 }
 
 /// Multi-format probe: write `CF_UNICODETEXT` + the registered `"HTML Format"` (round-tripped by
@@ -392,8 +365,8 @@ impl windows::Win32::System::Com::IDataObject_Impl for ProbeData_Impl {
                 return Err(Error::from_hresult(DV_E_FORMATETC));
             };
             // Hand back a FRESH HGLOBAL — the caller frees it (pUnkForRelease = None).
-            // SAFETY: `alloc_global` is a standard GlobalAlloc/Lock/copy/Unlock; the handle is then
-            // owned by the returned STGMEDIUM (ReleaseStgMedium frees it).
+            // SAFETY: `alloc_global` allocates an owned HGLOBAL and relinquishes it; the handle is
+            // then owned by the returned STGMEDIUM (ReleaseStgMedium frees it).
             let h = unsafe { alloc_global(bytes) };
             if h.0.is_null() {
                 return Err(Error::from_hresult(E_OUTOFMEMORY));
@@ -515,21 +488,12 @@ fn utf16_to_string(bytes: &[u8]) -> String {
 unsafe fn take_stgmedium_bytes(
     medium: &mut windows::Win32::System::Com::STGMEDIUM,
 ) -> Option<Vec<u8>> {
-    use windows::Win32::System::Memory::{GlobalLock, GlobalSize, GlobalUnlock};
     use windows::Win32::System::Ole::ReleaseStgMedium;
     let h = medium.u.hGlobal;
     let out = if h.0.is_null() {
         None
     } else {
-        let p = GlobalLock(h) as *const u8;
-        if p.is_null() {
-            None
-        } else {
-            let n = GlobalSize(h);
-            let v = std::slice::from_raw_parts(p, n).to_vec();
-            let _ = GlobalUnlock(h);
-            Some(v)
-        }
+        HGlobalLock::new(h).map(|lock| lock.as_bytes().to_vec())
     };
     ReleaseStgMedium(medium as *mut _);
     out
@@ -578,7 +542,6 @@ fn run_hdrop() -> i32 {
         CloseClipboard, EmptyClipboard, OpenClipboard, SetClipboardData,
     };
     use windows::Win32::Foundation::HANDLE;
-    use windows::Win32::System::Memory::{GlobalLock, GlobalSize, GlobalUnlock};
     use windows::Win32::System::Ole::{OleGetClipboard, OleSetClipboard, ReleaseStgMedium};
 
     const CF_HDROP: u32 = 15;
@@ -662,15 +625,7 @@ fn run_hdrop() -> i32 {
                 let out = if h.0.is_null() {
                     None
                 } else {
-                    let p = GlobalLock(h) as *const u8;
-                    if p.is_null() {
-                        None
-                    } else {
-                        let n = GlobalSize(h);
-                        let v = std::slice::from_raw_parts(p, n).to_vec();
-                        let _ = GlobalUnlock(h);
-                        Some(v)
-                    }
+                    HGlobalLock::new(h).map(|lock| lock.as_bytes().to_vec())
                 };
                 ReleaseStgMedium(&mut medium as *mut _);
                 out.unwrap_or_default()
@@ -699,7 +654,6 @@ fn run_ole() -> i32 {
     use windows::Win32::System::DataExchange::{
         CloseClipboard, GetClipboardData, OpenClipboard, RegisterClipboardFormatW,
     };
-    use windows::Win32::System::Memory::{GlobalLock, GlobalUnlock};
     use windows::Win32::System::Ole::{OleGetClipboard, OleSetClipboard, CF_UNICODETEXT};
 
     let cf_text = CF_UNICODETEXT.0;
@@ -785,15 +739,8 @@ fn run_ole() -> i32 {
             if let Ok(hr) = GetClipboardData(cf_text as u32) {
                 if !hr.is_invalid() {
                     let g = windows::Win32::Foundation::HGLOBAL(hr.0);
-                    let p = GlobalLock(g) as *const u16;
-                    if !p.is_null() {
-                        let mut len = 0usize;
-                        while *p.add(len) != 0 {
-                            len += 1;
-                        }
-                        u32_text =
-                            String::from_utf16_lossy(std::slice::from_raw_parts(p, len));
-                        let _ = GlobalUnlock(g);
+                    if let Some(lock) = HGlobalLock::new(g) {
+                        u32_text = utf16_to_string(lock.as_bytes());
                     }
                 }
             }

--- a/crates/glass-clip-hook/src/hglobal.rs
+++ b/crates/glass-clip-hook/src/hglobal.rs
@@ -1,0 +1,109 @@
+//! RAII guards over Win32 `HGLOBAL` moveable memory, shared by the clipboard read/write paths
+//! (`glass-windows` clipboard + the injected `hook`). All `GlobalLock`/`GlobalUnlock`/`GlobalAlloc`/
+//! `GlobalFree`/`from_raw_parts` `unsafe` lives here once, behind safe APIs. Windows-only; the crate
+//! cross-compiles to `x86_64-pc-windows-gnu` so this is compile-checked on the Linux dev box.
+
+use core::ffi::c_void;
+
+use windows::Win32::Foundation::{GlobalFree, HGLOBAL};
+use windows::Win32::System::Memory::{
+    GlobalAlloc, GlobalLock, GlobalSize, GlobalUnlock, GMEM_MOVEABLE,
+};
+
+/// RAII lock over a moveable `HGLOBAL`: `GlobalLock` on construction, `GlobalUnlock` on drop. The
+/// byte view is bounded by `GlobalSize`, so reads cannot run past the allocation.
+///
+/// Borrows — does not own — the handle; freeing is a separate concern (see [`OwnedHGlobal`], or the
+/// system taking ownership after `SetClipboardData`).
+pub struct HGlobalLock {
+    h: HGLOBAL,
+    ptr: *mut c_void,
+    len: usize,
+}
+
+impl HGlobalLock {
+    /// Lock `h`, returning `None` if `GlobalLock` fails (null).
+    ///
+    /// # Safety
+    /// `h` must be a valid `HGLOBAL` (from `GlobalAlloc`, or a clipboard data handle for a global
+    /// format) that stays valid for the lifetime of the returned guard.
+    pub unsafe fn new(h: HGLOBAL) -> Option<Self> {
+        // SAFETY: caller guarantees `h` is valid. GlobalLock pins the moveable block, returning a
+        // pointer to it or null on failure.
+        let ptr = unsafe { GlobalLock(h) };
+        if ptr.is_null() {
+            return None;
+        }
+        // SAFETY: `h` is locked; GlobalSize reports its allocated byte length (0 on error).
+        let len = unsafe { GlobalSize(h) };
+        Some(Self { h, ptr, len })
+    }
+
+    /// The locked block as a byte slice, bounded by `GlobalSize`.
+    pub fn as_bytes(&self) -> &[u8] {
+        // SAFETY: `ptr` is the locked, non-null base; `len` is the GlobalSize byte length. The slice
+        // borrows `self`, so it cannot outlive the lock that keeps the block pinned.
+        unsafe { std::slice::from_raw_parts(self.ptr as *const u8, self.len) }
+    }
+
+    /// The locked block as a mutable byte slice. Internal: only [`OwnedHGlobal::from_bytes`] writes.
+    pub(crate) fn as_mut_bytes(&mut self) -> &mut [u8] {
+        // SAFETY: as `as_bytes`; `&mut self` proves we hold the only reference to the block.
+        unsafe { std::slice::from_raw_parts_mut(self.ptr as *mut u8, self.len) }
+    }
+}
+
+impl Drop for HGlobalLock {
+    fn drop(&mut self) {
+        // SAFETY: we took the matching lock in `new`. For a GMEM_MOVEABLE block the result is
+        // informational (Err only when the lock count reaches 0), so we ignore it.
+        let _ = unsafe { GlobalUnlock(self.h) };
+    }
+}
+
+/// Owns a `GMEM_MOVEABLE` `HGLOBAL` from `GlobalAlloc`. Frees it in `Drop` unless ownership is
+/// relinquished via [`into_raw`](Self::into_raw) (e.g. after `SetClipboardData` takes it).
+pub struct OwnedHGlobal {
+    h: HGLOBAL,
+}
+
+impl OwnedHGlobal {
+    /// Allocate a `GMEM_MOVEABLE` block holding exactly `bytes`. `None` on alloc/lock failure (any
+    /// partial allocation is freed before returning).
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        // SAFETY: GlobalAlloc(GMEM_MOVEABLE, n) is the canonical moveable allocation; Err on failure.
+        let h = unsafe { GlobalAlloc(GMEM_MOVEABLE, bytes.len()) }.ok()?;
+        let owned = Self { h };
+        {
+            // SAFETY: `h` was just returned by GlobalAlloc, so it is valid.
+            let mut lock = unsafe { HGlobalLock::new(owned.h) }?; // on None, `owned` drops -> free
+            // GlobalAlloc may round the block UP, so the locked slice can be longer than requested;
+            // copy into the exact prefix (a whole-slice copy_from_slice would panic on a mismatch).
+            lock.as_mut_bytes()[..bytes.len()].copy_from_slice(bytes);
+            // `lock` drops here -> GlobalUnlock.
+        }
+        Some(owned)
+    }
+
+    /// The raw handle, for APIs that need it (e.g. `HANDLE(h.0)` for `SetClipboardData`).
+    pub fn handle(&self) -> HGLOBAL {
+        self.h
+    }
+
+    /// Relinquish ownership: return the raw handle and suppress the `Drop` free. Call after the
+    /// system takes the block (e.g. `SetClipboardData` succeeded) or to hand it to a caller that
+    /// will free it.
+    pub fn into_raw(self) -> HGLOBAL {
+        let h = self.h;
+        std::mem::forget(self);
+        h
+    }
+}
+
+impl Drop for OwnedHGlobal {
+    fn drop(&mut self) {
+        // SAFETY: we own `self.h` (from GlobalAlloc, not relinquished via into_raw), so GlobalFree
+        // is the correct release. Result is informational.
+        let _ = unsafe { GlobalFree(Some(self.h)) };
+    }
+}

--- a/crates/glass-clip-hook/src/hook.rs
+++ b/crates/glass-clip-hook/src/hook.rs
@@ -15,7 +15,7 @@ use std::sync::OnceLock;
 
 use windows::core::{PCSTR, PCWSTR};
 use windows::Win32::Foundation::{
-    CloseHandle, GlobalFree, GENERIC_READ, GENERIC_WRITE, HANDLE, HGLOBAL,
+    CloseHandle, GENERIC_READ, GENERIC_WRITE, HANDLE, HGLOBAL,
 };
 use windows::Win32::Storage::FileSystem::{
     CreateFileW, ReadFile, WriteFile, FILE_FLAGS_AND_ATTRIBUTES, FILE_SHARE_NONE, OPEN_EXISTING,
@@ -23,9 +23,8 @@ use windows::Win32::Storage::FileSystem::{
 use windows::Win32::Security::RevertToSelf;
 use windows::Win32::System::LibraryLoader::{GetModuleHandleW, GetProcAddress};
 use windows::Win32::System::Pipes::WaitNamedPipeW;
-use windows::Win32::System::Memory::{
-    GlobalAlloc, GlobalLock, GlobalSize, GlobalUnlock, GMEM_MOVEABLE,
-};
+
+use crate::hglobal::{HGlobalLock, OwnedHGlobal};
 
 use windows::Win32::System::DataExchange::{GetClipboardFormatNameW, RegisterClipboardFormatW};
 
@@ -268,34 +267,15 @@ pub(crate) fn store_get_all() -> Vec<(FormatKey, Vec<u8>)> {
 
 /// Copy the full contents of an app-provided `HGLOBAL` to a `Vec<u8>` (bounded by `GlobalSize`).
 pub(crate) fn read_bytes_from_hglobal(h: HGLOBAL) -> Option<Vec<u8>> {
-    // SAFETY: GlobalLock pins `h`; GlobalSize bounds the slice so we never read OOB; slice→Vec is safe.
-    unsafe {
-        let ptr = GlobalLock(h) as *const u8;
-        if ptr.is_null() {
-            return None;
-        }
-        let n = GlobalSize(h);
-        let v = std::slice::from_raw_parts(ptr, n).to_vec();
-        let _ = GlobalUnlock(h);
-        Some(v)
-    }
+    // SAFETY: `h` is an app-provided clipboard data handle, valid for this call.
+    let lock = unsafe { HGlobalLock::new(h) }?;
+    Some(lock.as_bytes().to_vec())
 }
 
 /// Allocate a `GMEM_MOVEABLE` `HGLOBAL` holding exactly `bytes`. Caller caches + frees it.
 pub(crate) fn alloc_hglobal_bytes(bytes: &[u8]) -> Option<HGLOBAL> {
-    // SAFETY: GlobalAlloc(GMEM_MOVEABLE) then GlobalLock to a writable ptr valid for bytes.len();
-    // copy exactly bytes.len(); unlock. Free on lock failure to avoid a leak.
-    unsafe {
-        let h = GlobalAlloc(GMEM_MOVEABLE, bytes.len()).ok()?;
-        let dst = GlobalLock(h) as *mut u8;
-        if dst.is_null() {
-            let _ = GlobalFree(Some(h));
-            return None;
-        }
-        std::ptr::copy_nonoverlapping(bytes.as_ptr(), dst, bytes.len());
-        let _ = GlobalUnlock(h);
-        Some(h)
-    }
+    // Caller owns + frees the returned handle, so relinquish ownership with `into_raw`.
+    Some(OwnedHGlobal::from_bytes(bytes)?.into_raw())
 }
 
 /// CF_UNICODETEXT bytes → CF_TEXT/CF_OEMTEXT bytes via the real code page (ANSI/OEM).

--- a/crates/glass-clip-hook/src/lib.rs
+++ b/crates/glass-clip-hook/src/lib.rs
@@ -24,6 +24,12 @@ mod synth;
 #[cfg(windows)]
 mod hook;
 
+#[cfg(windows)]
+mod hglobal;
+#[cfg(windows)]
+#[doc(hidden)] // intended public API is `proto`/`store`; these are a Win32 util for glass-windows
+pub use hglobal::{HGlobalLock, OwnedHGlobal};
+
 /// Sandboxie InjectDll entry point (called after SbieDll, before the app's entry). Inert unless
 /// `GLASS_CLIP_PIPE` is set (only the target app's process tree carries it). See [`hook`].
 #[cfg(windows)]

--- a/crates/glass-windows/src/clipboard.rs
+++ b/crates/glass-windows/src/clipboard.rs
@@ -4,17 +4,13 @@
 //! to tear down. Both functions are safe wrappers around `unsafe` Win32 calls; every
 //! `unsafe` block is guarded by a `// SAFETY:` comment per the repo policy.
 
-use std::ptr;
-
-use windows::Win32::Foundation::{GlobalFree, HANDLE, HGLOBAL};
+use windows::Win32::Foundation::{HANDLE, HGLOBAL};
 use windows::Win32::System::DataExchange::{
     CloseClipboard, EmptyClipboard, GetClipboardData, OpenClipboard, SetClipboardData,
 };
-use windows::Win32::System::Memory::{
-    GlobalAlloc, GlobalLock, GlobalSize, GlobalUnlock, GMEM_MOVEABLE,
-};
 use windows::Win32::System::Ole::CF_UNICODETEXT;
 
+use glass_clip_hook::{HGlobalLock, OwnedHGlobal};
 use glass_core::{GlassError, Result};
 
 /// Read the clipboard as UTF-8 text.
@@ -55,125 +51,70 @@ fn read_clipboard_text() -> Result<String> {
         _ => return Ok(String::new()),
     };
 
-    // Reinterpret the clipboard HANDLE as an HGLOBAL (both are `*mut c_void`
-    // wrappers; Win32 GetClipboardData returns an HGLOBAL for `CF_UNICODETEXT`).
+    // Reinterpret the clipboard HANDLE as an HGLOBAL (both wrap `*mut c_void`;
+    // GetClipboardData returns an HGLOBAL for CF_UNICODETEXT).
     let hglobal = HGLOBAL(handle.0);
 
-    // SAFETY: `hglobal` is a valid HGLOBAL returned by GetClipboardData for
-    // CF_UNICODETEXT while the clipboard is open.  GlobalLock returns a pointer
-    // to the moveable memory; we hold no other references to this block.
-    let ptr = unsafe { GlobalLock(hglobal) };
-    if ptr.is_null() {
-        return Err(GlassError::Backend("GlobalLock failed on clipboard handle".into()));
-    }
+    // SAFETY: `hglobal` is the HGLOBAL GetClipboardData returned for CF_UNICODETEXT;
+    // it stays valid until the caller closes the clipboard, which outlives this `lock`.
+    let lock = unsafe { HGlobalLock::new(hglobal) }
+        .ok_or_else(|| GlassError::Backend("GlobalLock failed on clipboard handle".into()))?;
 
-    // The clipboard owner is an arbitrary (possibly malicious/buggy) app, so we
-    // can't trust the CF_UNICODETEXT block to actually be NUL-terminated. Bound
-    // the scan by the block's real size (GlobalSize) so a non-terminated buffer
-    // can't read past the allocation (UB) — stop at the first NUL or the cap.
-    // SAFETY: hglobal is the locked clipboard handle; GlobalSize reports its
-    // allocated byte length (0 on error → empty read, still safe).
-    let max_wchars = unsafe { GlobalSize(hglobal) } / std::mem::size_of::<u16>();
-    let text = {
-        // SAFETY: `ptr` points at the locked block; the loop indexes strictly
-        // less than `max_wchars` u16s, all within the GlobalSize-reported bytes.
-        let wchars: *const u16 = ptr as *const u16;
-        let mut len = 0usize;
-        unsafe {
-            while len < max_wchars && *wchars.add(len) != 0 {
-                len += 1;
-            }
-            let slice = std::slice::from_raw_parts(wchars, len);
-            String::from_utf16_lossy(slice)
-        }
-    };
-
-    // SAFETY: We locked hglobal above; we must unlock it before the clipboard is
-    // closed.  GlobalUnlock returns an error only when the lock count hits 0 for a
-    // GMEM_MOVEABLE block — for our read path the result is informational only, so
-    // we ignore it.
-    let _ = unsafe { GlobalUnlock(hglobal) };
-
-    Ok(text)
+    // The clipboard owner is an arbitrary (possibly buggy/malicious) app, so CF_UNICODETEXT
+    // may not be NUL-terminated. Bound the scan by the locked block size; `chunks_exact` drops
+    // any stray trailing odd byte (valid UTF-16 is even-length). `lock` unlocks on drop.
+    let units: Vec<u16> = lock
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|c| u16::from_ne_bytes([c[0], c[1]]))
+        .take_while(|&u| u != 0)
+        .collect();
+    Ok(String::from_utf16_lossy(&units))
 }
 
 /// Write UTF-8 text to the clipboard (encoded as NUL-terminated UTF-16).
 ///
-/// On success the system owns the allocated global memory — we must NOT free it.
-/// On failure we free the allocation and return [`GlassError::Backend`].
+/// On success the system owns the allocated global memory — we must NOT free it. On any failure the
+/// `OwnedHGlobal` frees the allocation as it drops.
 pub fn set(text: &str) -> Result<()> {
-    // Encode as UTF-16 + NUL terminator.
+    // Encode as native-endian (Windows = little-endian) UTF-16 + NUL terminator, as raw bytes.
     let utf16: Vec<u16> = text.encode_utf16().chain(std::iter::once(0u16)).collect();
-    let byte_len = utf16.len() * std::mem::size_of::<u16>();
-
-    // SAFETY: GlobalAlloc with GMEM_MOVEABLE is the canonical way to allocate a
-    // moveable block for the clipboard.  `byte_len` is always >0 (at minimum the
-    // NUL terminator).
-    let hglobal = unsafe { GlobalAlloc(GMEM_MOVEABLE, byte_len) }
-        .map_err(|e| GlassError::Backend(format!("GlobalAlloc failed: {e}")))?;
-
-    // Copy the UTF-16 data into the locked block.
-    {
-        // SAFETY: `hglobal` is a valid GMEM_MOVEABLE handle just returned by
-        // GlobalAlloc.  GlobalLock returns a writable pointer to the block.
-        let ptr = unsafe { GlobalLock(hglobal) };
-        if ptr.is_null() {
-            // Free on this error path — we still own the memory.
-            // SAFETY: We own hglobal (GlobalAlloc succeeded, SetClipboardData has
-            // not been called yet), so GlobalFree is safe.
-            let _ = unsafe { GlobalFree(Some(hglobal)) };
-            return Err(GlassError::Backend("GlobalLock failed on new clipboard handle".into()));
-        }
-        // SAFETY: `ptr` points to `byte_len` bytes of writable memory; `utf16`
-        // has exactly `byte_len` bytes.  No aliasing — we hold the only reference.
-        unsafe {
-            ptr::copy_nonoverlapping(utf16.as_ptr() as *const u8, ptr as *mut u8, byte_len);
-        }
-        // SAFETY: We locked hglobal above; unlock before SetClipboardData.
-        let _ = unsafe { GlobalUnlock(hglobal) };
+    let mut bytes = Vec::with_capacity(utf16.len() * 2);
+    for unit in utf16 {
+        bytes.extend_from_slice(&unit.to_le_bytes());
     }
 
-    // SAFETY: OpenClipboard(None) is safe from any thread (no owner window needed).
-    unsafe { OpenClipboard(None) }
-        .map_err(|e| {
-            // We still own hglobal — free it before returning.
-            // SAFETY: SetClipboardData has not been called, so we still own hglobal.
-            let _ = unsafe { GlobalFree(Some(hglobal)) };
-            GlassError::Backend(format!("OpenClipboard failed: {e}"))
-        })?;
+    // `mem` frees itself on drop until we relinquish it to the system via `into_raw` below.
+    let mem = OwnedHGlobal::from_bytes(&bytes)
+        .ok_or_else(|| GlassError::Backend("GlobalAlloc/GlobalLock failed for clipboard".into()))?;
 
-    // SAFETY: The clipboard is now open.  EmptyClipboard clears existing data and
-    // transfers clipboard ownership to us.
-    let empty_result = unsafe { EmptyClipboard() };
-    if let Err(e) = empty_result {
-        // SAFETY: We still own hglobal; free it before closing.
-        let _ = unsafe { GlobalFree(Some(hglobal)) };
-        // SAFETY: We successfully opened the clipboard.
+    // SAFETY: OpenClipboard(None) is safe from any thread. On the `?` early-return `mem` drops -> free.
+    unsafe { OpenClipboard(None) }
+        .map_err(|e| GlassError::Backend(format!("OpenClipboard failed: {e}")))?;
+
+    // SAFETY: the clipboard is open; EmptyClipboard clears it and transfers ownership to us.
+    if let Err(e) = unsafe { EmptyClipboard() } {
+        // SAFETY: we opened the clipboard above. `mem` drops after this -> GlobalFree.
         let _ = unsafe { CloseClipboard() };
         return Err(GlassError::Backend(format!("EmptyClipboard failed: {e}")));
     }
 
-    // Convert HGLOBAL to HANDLE for SetClipboardData (both are `*mut c_void`
-    // wrappers; SetClipboardData's second parameter is typed as HANDLE).
-    let hmem = HANDLE(hglobal.0);
+    // HGLOBAL -> HANDLE for SetClipboardData (both wrap `*mut c_void`).
+    let hmem = HANDLE(mem.handle().0);
 
-    // SAFETY: The clipboard is open and empty.  SetClipboardData transfers ownership
-    // of `hmem`/`hglobal` to the system on success — we must NOT free it afterwards.
-    // On failure the allocation is still ours and we free it below.
+    // SAFETY: the clipboard is open and empty. On success SetClipboardData transfers ownership of the
+    // block to the system (so we must NOT free it — `into_raw`); on failure it stays ours.
     let set_result = unsafe { SetClipboardData(CF_UNICODETEXT.0 as u32, Some(hmem)) };
 
-    // SAFETY: The clipboard was successfully opened; close it regardless of whether
-    // SetClipboardData succeeded.
+    // SAFETY: the clipboard was opened; close it regardless of the set result.
     let _ = unsafe { CloseClipboard() };
 
     match set_result {
-        Ok(_) => Ok(()),
-        Err(e) => {
-            // SetClipboardData failed — we still own hglobal; free it.
-            // SAFETY: SetClipboardData failed, so ownership did not transfer; we must
-            // free to avoid a leak.
-            let _ = unsafe { GlobalFree(Some(hglobal)) };
-            Err(GlassError::Backend(format!("SetClipboardData failed: {e}")))
+        Ok(_) => {
+            mem.into_raw(); // system owns the block now — suppress the Drop free
+            Ok(())
         }
+        // `mem` drops here -> GlobalFree (ownership never transferred).
+        Err(e) => Err(GlassError::Backend(format!("SetClipboardData failed: {e}"))),
     }
 }


### PR DESCRIPTION
## What

Introduce two RAII guards in `glass-clip-hook` and route all the Windows clipboard
`GlobalLock`/`GlobalUnlock`/`GlobalAlloc`/`GlobalFree` plumbing through them:

- **`HGlobalLock`** — borrows an `HGLOBAL`, `GlobalLock` on construction and `GlobalUnlock` on
  drop, exposing a byte slice bounded by `GlobalSize`.
- **`OwnedHGlobal`** — owns a `GlobalAlloc` block, `GlobalFree` on drop unless `into_raw()`
  relinquishes ownership (e.g. after `SetClipboardData` takes it). `from_bytes()` is the
  alloc+fill convenience shared by every write site.

This satisfies the repo's *"Avoid `unsafe` — prefer safe abstractions; isolate + document any
required `unsafe`"* invariant: all the `Global*` + `from_raw_parts` `unsafe` now lives in one
audited module (`hglobal.rs`) instead of being re-spelled at each call site.

## Why

The lock/unlock and alloc/free obligations were maintained by hand across multiple call sites. In
`clipboard.rs::set` alone, four scattered `GlobalFree` error paths existed to avoid leaking on each
early return. Moving these into `Drop` makes leak-on-error-path **structurally impossible**, and the
`get()` read loses its hand-rolled `*wchars.add(len)` pointer scan in favor of a safe
`chunks_exact(2)` decode over the bounded slice.

## Changes

- `glass-clip-hook/src/hglobal.rs` (new) — the two guards.
- `glass-clip-hook/src/hook.rs` — `read_bytes_from_hglobal` / `alloc_hglobal_bytes` via guards.
- `glass-windows/src/clipboard.rs` — `get` (safe NUL-scan) / `set` (Drop-based frees) via guards.
- `glass-clip-hook/examples/clipprobe.rs` — all 7 read/write sites via guards.

After this, the only `Global*` calls outside `hglobal.rs` are the six guard internals and one
intentionally out-of-scope site (`detour_impl.rs:92`, a different ownership flow).

## Verification

- Cross-compile (`--target x86_64-pc-windows-gnu`) + `clippy -D warnings` clean for both crates,
  all targets.
- Native Linux build + host unit tests green (34 passed).
- On real Windows (lotus): `onbox_clipboard_roundtrip` **PASS** (non-ASCII + empty-string get/set
  round-trip) and `onbox_contained_clipboard_app_write` **PASS** (the Sandboxie detour-proxy path
  through the injected hook). Behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)