### PR TITLE
docs(windows): document mttvdd virtual display for headless capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ Where glass stands by OS. **✓** supported · **◑** partial · **–** not su
 | Capture · input · windows · clipboard · logs | ✓ | ✓ | ✓ † | 🚧 |
 | Accessibility (semantic addressing) | ✓ AT-SPI | ✓ UI Automation | ✓ UIAutomator | 🚧 AX |
 | Containment / sandboxing | ✓ bubblewrap | ✓ Sandboxie Classic | ✓ the emulator VM | 🚧 |
-| Display isolation (app off your desktop) | ✓ headless Xvfb / sway | – interactive desktop | ✓ headless emulator | 🚧 |
+| Display isolation (app off your desktop) | ✓ headless Xvfb / sway | ◑ virtual display · VM tier | ✓ headless emulator | 🚧 |
 
 † **Android** is emulator-only. Capture, multi-window, input, and logs work over `adb`, and glass manages the AVD (attach a running one, or boot a headless one). **Clipboard, high-fidelity input, and multi-touch gestures (`glass_gesture`)** use the optional on-device agent, and an optional on-device **AccessibilityService** sharpens the a11y tree (Compose) + `set_value` (both in the Android section of your host guide: [Linux](docs/running-on-linux.md) · [Windows](docs/running-on-windows.md) · [macOS](docs/running-on-macos.md)) — without the agent, input falls back to adb's `input` (single-pointer only — no multi-touch) and clipboard is unavailable; without the service, a11y falls back to `uiautomator`. glass is developed and tested against **Android 14 (API 34)**; the `adb` backend assumes no particular version and the optional companions declare an Android 7.0 (API 24) floor (details in your host guide). Window resize/move (apps are full-screen) and physical devices are non-goals.
 

--- a/crates/glass-windows/src/display/existing.rs
+++ b/crates/glass-windows/src/display/existing.rs
@@ -4,8 +4,9 @@ use windows::Win32::UI::WindowsAndMessaging::{
     GetSystemMetrics, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN,
 };
 
-/// Use whatever display the logged-in interactive session already presents (real monitor,
-/// dummy plug, or — in a later plan — a pre-provisioned virtual display). No provisioning.
+/// Use whatever display the logged-in interactive session already presents — a real monitor,
+/// a dummy plug, or a virtual monitor from an indirect-display driver (e.g. mttvdd) on a
+/// headless box. No provisioning. See docs/running-on-windows.md.
 pub(crate) struct ExistingDesktop;
 
 impl DisplayProvider for ExistingDesktop {

--- a/crates/glass-windows/src/display/mod.rs
+++ b/crates/glass-windows/src/display/mod.rs
@@ -1,10 +1,11 @@
-// The display-provisioning seam. v1 ships only ExistingDesktop; the headless
-// VirtualDisplay provider is a deferred follow-on plan. `WindowsPlatform::start_app`
-// consumes it (Task 5).
+// The display-provisioning seam: where the target app renders for a session.
+// `ExistingDesktop` uses the display the interactive session already presents — a real
+// monitor, a dummy plug, or a virtual monitor from an indirect-display driver (e.g. mttvdd)
+// on a headless box. See docs/running-on-windows.md.
 
 use glass_core::Result;
 
-/// Where the target app renders for a session. v1 = ExistingDesktop; VirtualDisplay is a later plan.
+/// Where the target app renders for a session.
 pub(crate) trait DisplayProvider {
     /// Ensure a usable composited display exists; return its logical size in physical pixels.
     fn ensure(&mut self) -> Result<ProvisionedDisplay>;

--- a/docs/running-on-windows.md
+++ b/docs/running-on-windows.md
@@ -11,7 +11,9 @@ Running glass on a Windows host.
   (Windows.Graphics.Capture for screenshots, SendInput for input, UI Automation for
   the accessibility tree).
 - glass drives apps on the **interactive desktop**, so run it in a normal logged-in
-  session (not a non-interactive service / Session 0).
+  session (not a non-interactive service / Session 0). On a box with **no monitor
+  attached**, add a virtual display driver so that session has a display to capture —
+  see [Headless capture](#headless-capture--a-virtual-display-driver) below.
 
 ## Containment runtime
 
@@ -131,6 +133,38 @@ glass-mcp serve --http
 
 Then point the client at `http://127.0.0.1:7300`. The connection is encrypted by SSH;
 glass itself does not own TLS.
+
+## Headless capture — a virtual display driver
+
+glass captures the **interactive console session** the GPU composes (see above). On a box
+with a physical monitor (or a dummy/headless display plug), that session already has a
+display to capture. A box with **no monitor attached** — a CI runner, a server, a remote
+VM — may have no composited display in that session, so WGC has nothing to grab.
+
+An **indirect-display (IddCx) driver** fixes this by adding a *virtual monitor* to the
+interactive session. The recommended one is the community
+**[Virtual-Display-Driver](https://github.com/VirtualDrivers/Virtual-Display-Driver)**
+(often called **MttVDD**; MIT, signed): it auto-provisions a monitor from
+`C:\VirtualDisplayDriver\vdd_settings.xml` (`<monitors><count>`) with no holder process to
+keep running.
+
+Install (elevated PowerShell, after trusting the driver's signing certificate per its
+README):
+
+```powershell
+pnputil /add-driver C:\path\to\MttVDD.inf /install
+```
+
+Once installed, the virtual monitor is part of the interactive session, so **glass picks it
+up automatically** — no glass configuration. The app renders on it and WGC captures it like
+any other display; if a real monitor is also attached, place the app on the virtual
+monitor's (off-screen) coordinates.
+
+> **Headless ≠ isolated.** A virtual display driver makes Windows *headless-capable* — it
+> does **not** wall the app off your interactive session the way Linux's private `Xvfb` /
+> `sway` server does. There is still **one** interactive desktop, and the virtual monitor is
+> part of it. For the app fully off your session, use the
+> [VM / strong-isolation tier](#vm--strong-isolation-tier) below.
 
 ## VM / strong-isolation tier
 

--- a/tools/windows-validation/REMOTE.md
+++ b/tools/windows-validation/REMOTE.md
@@ -20,7 +20,7 @@ That splits remote access into two camps:
 |---|---|---|
 | Edit + build + git | **OpenSSH server** (+ optional VS Code **Remote-SSH**) | enabled by `setup-box.ps1`; build with `cargo build` over SSH |
 | **Run + watch tests** | **Sunshine** (host) + **Moonlight** (Linux client) | open-source, low-latency, mirrors the console, survives client disconnect |
-| Headless capture | **Parsec VDD** virtual display | no need to unplug the monitor — capture a window placed on the virtual display |
+| Headless capture | **MttVDD** virtual display | a window placed on the virtual monitor is capturable without unplugging the real one (Parsec VDD also works) |
 
 ## One-time setup
 
@@ -45,8 +45,12 @@ That splits remote access into two camps:
      or your package manager); add the box, enter the PIN from Sunshine's web UI, then launch
      the **Desktop** entry. You're now looking at the real console session.
 
-4. **Virtual display driver** for headless capture: install **Parsec VDD**
-   (<https://github.com/nomi-san/parsec-vdd>, MIT/signed).
+4. **Virtual display driver** for headless capture: install the community
+   **[Virtual-Display-Driver / MttVDD](https://github.com/VirtualDrivers/Virtual-Display-Driver)**
+   (MIT, signed) — it auto-provisions a virtual monitor from
+   `C:\VirtualDisplayDriver\vdd_settings.xml` with no holder process. **Parsec VDD**
+   (<https://github.com/nomi-san/parsec-vdd>, MIT/signed) also works, but needs a
+   ping-holder process kept running.
 
 ## The one gotcha: SSH is session 0, capture/input need session 1
 


### PR DESCRIPTION
## What

Documents how to run glass headless on a Windows box with **no physical monitor**, using an indirect-display (IddCx) virtual display driver — recommended: the community **Virtual-Display-Driver / MttVDD**.

## Why this needed clarifying

glass captures the interactive console session. A monitorless box (CI runner, server, remote VM) may have no composited display in that session, so a virtual display driver gives it a surface to capture. Validated on-box (a window placed on the virtual monitor captures non-blank).

The subtle point: a virtual monitor is added to the **one** interactive session, so it makes Windows *headless-capable* but does **not** isolate the app off your session the way Linux's private `Xvfb`/`sway` server does. The docs now make that distinction explicit and point at the VM tier for true isolation.

## Changes
- `docs/running-on-windows.md` — new "Headless capture — a virtual display driver" section (install + auto-pickup + "headless ≠ isolated" callout); requirements bullet points monitorless boxes at it
- `README.md` — Windows display-isolation cell: `– interactive desktop` → `◑ virtual display · VM tier`
- `crates/glass-windows/src/display/{mod.rs,existing.rs}` — comments describe `ExistingDesktop` consuming a VDD's virtual monitor (dropped stale "deferred plan" wording)
- `tools/windows-validation/REMOTE.md` — MttVDD promoted to the recommended headless-capture driver; Parsec VDD kept as the alternative

Docs + comments only; no behavior change. Local gate green (build · clippy -D warnings · test).