### PR TITLE
feat(macos): glass-macos backend — Plan 1 skeleton (crate + TCC preflight + CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,28 @@ jobs:
           ~/.local/share/glass/sway/bin/sway --version
       - run: ./scripts/test-wayland.sh
 
+  macos:
+    name: macOS (build · clippy · test)
+    runs-on: macos-14   # arm64 hosted runner
+    # Only the glass-macos crate is Mac-specific; the rest of the workspace already
+    # builds/tests on the Linux `check` job. This is the only place the
+    # cfg(target_os = "macos") code gets built + linted + tested — the Linux job can't
+    # compile it. Capture/input integration tests are #[ignore]d (need a granted,
+    # WindowServer-connected TCC context) and run on-box; the runner covers pure +
+    # macOS unit tests.
+    steps:
+      - uses: actions/checkout@v6
+      # rustup auto-installs the pinned toolchain + components from
+      # rust-toolchain.toml (single source of truth for the nightly).
+      - name: Install pinned toolchain
+        run: rustup show
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: .
+      - run: cargo build  -p glass-macos --locked
+      - run: cargo clippy -p glass-macos --all-targets --locked -- -D warnings
+      - run: ./scripts/test-macos.sh
+
   windows:
     name: Windows (build · clippy · test)
     runs-on: windows-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,6 +1017,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "glass-macos"
+version = "0.0.0"
+dependencies = [
+ "glass-core",
+]
+
+[[package]]
 name = "glass-mcp"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/glass-core", "crates/glass-x11", "crates/glass-testapp", "crates/glass-mcp", "crates/glass-wayland", "crates/glass-a11y-linux", "crates/glass-windows", "crates/glass-a11y-windows", "crates/glass-sandbox-linux", "crates/glass-proc-linux", "crates/glass-clip-hook", "crates/glass-dbus-linux", "crates/glass-android"]
+members = ["crates/glass-core", "crates/glass-x11", "crates/glass-testapp", "crates/glass-mcp", "crates/glass-wayland", "crates/glass-a11y-linux", "crates/glass-windows", "crates/glass-a11y-windows", "crates/glass-sandbox-linux", "crates/glass-proc-linux", "crates/glass-clip-hook", "crates/glass-dbus-linux", "crates/glass-android", "crates/glass-macos"]
 # glass-fixture-egui is intentionally excluded: heavy egui deps, only exercised by #[ignore]d
 # on-box a11y tests CI can't run. Built on-demand on the box.
 exclude = ["crates/glass-fixture-egui"]

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -77,6 +77,12 @@ pub enum GlassError {
     #[error("{0} is not supported by this backend")]
     Unsupported(String),
 
+    /// A required OS permission is not granted. Carries which permission and how to
+    /// grant it, so the MCP layer can tell the agent exactly what to do. Never paper
+    /// over this with a blank frame (no-silent-fallback invariant).
+    #[error("{which} permission denied: {remedy}")]
+    PermissionDenied { which: String, remedy: String },
+
     #[error("backend error: {0}")]
     Backend(String),
 
@@ -153,5 +159,21 @@ mod tests {
             GlassError::AccessibilityUnavailable("no a11y bus".into()).to_string(),
             "accessibility unavailable: no a11y bus"
         );
+    }
+}
+
+#[cfg(test)]
+mod permission_error_tests {
+    use super::GlassError;
+
+    #[test]
+    fn permission_denied_renders_which_and_remedy() {
+        let e = GlassError::PermissionDenied {
+            which: "Screen Recording".into(),
+            remedy: "grant GlassProbe in System Settings > Privacy & Security".into(),
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("Screen Recording"), "{msg}");
+        assert!(msg.contains("System Settings"), "{msg}");
     }
 }

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -160,11 +160,6 @@ mod tests {
             "accessibility unavailable: no a11y bus"
         );
     }
-}
-
-#[cfg(test)]
-mod permission_error_tests {
-    use super::GlassError;
 
     #[test]
     fn permission_denied_renders_which_and_remedy() {

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "glass-macos"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[lib]
+bench = false
+
+[dependencies]
+glass-core.workspace = true
+
+# macOS-only FFI deps land in Plan 2 (objc2 family). Kept empty here so the
+# crate's pure modules build on the Linux dev box with zero macOS deps.
+[target.'cfg(target_os = "macos")'.dependencies]
+
+[lints]
+workspace = true

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -7,7 +7,7 @@ use glass_core::logbuf::Stream;
 use glass_core::platform::{
     AppSpec, KeyEvent, Platform, PointerEvent, WindowGeometry, WindowId, WindowInfo, WindowOp,
 };
-use glass_core::{GlassError, Result};
+use glass_core::Result;
 
 use crate::permissions;
 

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -67,12 +67,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn drain_logs_is_empty_then_drains() {
+    fn drain_logs_takes_then_empties() {
         // Build without preflight (which would require grants) by constructing the struct
         // directly — `new()` is exercised in the Mac-gated suite.
         let mut p = MacosPlatform { logs: vec![(Stream::Stdout, "hi".into())], app_pid: Some(42) };
-        assert_eq!(p.app_pid(), Some(42));
         assert_eq!(p.drain_logs().len(), 1);
         assert!(p.drain_logs().is_empty());
+    }
+
+    #[test]
+    fn app_pid_returns_the_constructed_value() {
+        let p = MacosPlatform { logs: Vec::new(), app_pid: Some(42) };
+        assert_eq!(p.app_pid(), Some(42));
+    }
+
+    #[test]
+    fn new_agrees_with_preflight() {
+        // The central invariant: new() must error iff preflight() errors. Guards against a
+        // future edit that swallows the missing-grant propagation. On an ungranted CI runner
+        // both are Err; on a granted box both are Ok.
+        assert_eq!(crate::permissions::preflight().is_err(), MacosPlatform::new().is_err());
     }
 }

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -1,0 +1,78 @@
+//! The macOS `Platform` backend. Plan 1 lands the struct + trait surface with the
+//! window-server methods stubbed; Plan 2 fills capture + display provisioning, Plan 3
+//! input, Plan 4 windows. `new()` runs the TCC preflight so a missing grant fails fast.
+
+use glass_core::frame::{Frame, Region};
+use glass_core::logbuf::Stream;
+use glass_core::platform::{
+    AppSpec, KeyEvent, Platform, PointerEvent, WindowGeometry, WindowId, WindowInfo, WindowOp,
+};
+use glass_core::{GlassError, Result};
+
+use crate::permissions;
+
+/// macOS backend. v1 renders the target app onto a `CGVirtualDisplay` (Plan 2) and
+/// drives it with ScreenCaptureKit + CGEvent + AXUIElement.
+pub struct MacosPlatform {
+    /// Logs drained by `drain_logs`, filled by the per-stream readers once `start_app`
+    /// exists (Plan 2). Empty until then.
+    logs: Vec<(Stream, String)>,
+    /// The launched app's root pid; `None` until `start_app`.
+    app_pid: Option<u32>,
+}
+
+impl MacosPlatform {
+    /// Construct the backend, failing fast if a required TCC grant is missing.
+    pub fn new() -> Result<Self> {
+        permissions::preflight()?;
+        Ok(Self { logs: Vec::new(), app_pid: None })
+    }
+}
+
+impl Platform for MacosPlatform {
+    fn start_app(&mut self, _spec: &AppSpec) -> Result<WindowGeometry> {
+        unimplemented!("Plan 2: spawn + CGVirtualDisplay + window discovery")
+    }
+    fn stop_app(&mut self) -> Result<()> {
+        unimplemented!("Plan 2: terminate child + tear down provisioning")
+    }
+    fn capture_frame(&mut self, _region: Option<&Region>) -> Result<Frame> {
+        unimplemented!("Plan 2: ScreenCaptureKit per-window capture")
+    }
+    fn send_pointer(&mut self, _event: &PointerEvent) -> Result<()> {
+        unimplemented!("Plan 3: CGEvent pointer")
+    }
+    fn send_key(&mut self, _event: &KeyEvent) -> Result<()> {
+        unimplemented!("Plan 3: CGEvent keyboard")
+    }
+    fn window(&mut self, _op: &WindowOp) -> Result<WindowGeometry> {
+        unimplemented!("Plan 4: AXUIElement window ops")
+    }
+    fn list_windows(&mut self) -> Result<Vec<WindowInfo>> {
+        unimplemented!("Plan 4: CGWindowList/SCShareableContent by pid")
+    }
+    fn select_window(&mut self, _id: WindowId) -> Result<WindowGeometry> {
+        unimplemented!("Plan 4: raise + focus + activate")
+    }
+    fn drain_logs(&mut self) -> Vec<(Stream, String)> {
+        std::mem::take(&mut self.logs)
+    }
+    fn app_pid(&self) -> Option<u32> {
+        self.app_pid
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drain_logs_is_empty_then_drains() {
+        // Build without preflight (which would require grants) by constructing the struct
+        // directly — `new()` is exercised in the Mac-gated suite.
+        let mut p = MacosPlatform { logs: vec![(Stream::Stdout, "hi".into())], app_pid: Some(42) };
+        assert_eq!(p.app_pid(), Some(42));
+        assert_eq!(p.drain_logs().len(), 1);
+        assert!(p.drain_logs().is_empty());
+    }
+}

--- a/crates/glass-macos/src/coords.rs
+++ b/crates/glass-macos/src/coords.rs
@@ -1,0 +1,1 @@
+// filled in Task 3

--- a/crates/glass-macos/src/coords.rs
+++ b/crates/glass-macos/src/coords.rs
@@ -2,7 +2,8 @@
 //! Linux dev box. The macOS backend (Plans 2–4) maps window-relative tool coordinates to
 //! global screen coordinates here before posting CGEvents or capturing a sub-region.
 
-use glass_core::GlassError;
+use glass_core::frame::Region;
+use glass_core::{GlassError, Result};
 
 /// Translate a window-relative point to a global screen point given the window origin.
 pub fn to_global(origin: (i32, i32), rel: (i32, i32)) -> (i32, i32) {
@@ -10,23 +11,23 @@ pub fn to_global(origin: (i32, i32), rel: (i32, i32)) -> (i32, i32) {
 }
 
 /// Reject a window-relative point outside the window (the no-out-of-bounds invariant).
-pub fn check_in_bounds(x: i32, y: i32, width: u32, height: u32) -> Result<(), GlassError> {
+pub fn check_in_bounds(x: i32, y: i32, width: u32, height: u32) -> Result<()> {
     if x < 0 || y < 0 || x as i64 >= width as i64 || y as i64 >= height as i64 {
         return Err(GlassError::CoordOutOfBounds { x, y, width, height });
     }
     Ok(())
 }
 
-/// Clamp a window-relative region to the window rect, returning `(x, y, w, h)` = the
-/// intersection of the region with the window. A region fully outside clamps to zero
-/// size at the nearest edge. Computed in `i64` so no cast can wrap for any input.
-pub fn clamp_region(rx: i32, ry: i32, rw: u32, rh: u32, width: u32, height: u32) -> (u32, u32, u32, u32) {
+/// Clamp a window-relative region to the window rect, returning the intersection of the
+/// region with the window as a [`Region`]. A region fully outside clamps to zero size at
+/// the nearest edge. Computed in `i64` so no cast can wrap for any input.
+pub fn clamp_region(rx: i32, ry: i32, rw: u32, rh: u32, width: u32, height: u32) -> Region {
     let (w_i, h_i) = (width as i64, height as i64);
     let left = (rx as i64).clamp(0, w_i);
     let top = (ry as i64).clamp(0, h_i);
     let right = (rx as i64 + rw as i64).clamp(0, w_i);
     let bottom = (ry as i64 + rh as i64).clamp(0, h_i);
-    (left as u32, top as u32, (right - left) as u32, (bottom - top) as u32)
+    Region { x: left as u32, y: top as u32, width: (right - left) as u32, height: (bottom - top) as u32 }
 }
 
 #[cfg(test)]
@@ -49,18 +50,20 @@ mod tests {
 
     #[test]
     fn clamp_region_trims_to_window() {
-        assert_eq!(clamp_region(10, 10, 100, 100, 640, 480), (10, 10, 100, 100));
-        assert_eq!(clamp_region(600, 0, 100, 50, 640, 480), (600, 0, 40, 50)); // width trimmed
-        assert_eq!(clamp_region(700, 0, 100, 50, 640, 480), (640, 0, 0, 50)); // fully outside → 0 width
+        assert_eq!(clamp_region(10, 10, 100, 100, 640, 480), Region { x: 10, y: 10, width: 100, height: 100 });
+        // width trimmed
+        assert_eq!(clamp_region(600, 0, 100, 50, 640, 480), Region { x: 600, y: 0, width: 40, height: 50 });
+        // fully outside → 0 width
+        assert_eq!(clamp_region(700, 0, 100, 50, 640, 480), Region { x: 640, y: 0, width: 0, height: 50 });
     }
 
     #[test]
     fn clamp_region_trims_left_top_overhang() {
         // fully outside on the left → zero width (mirror of the right-edge case)
-        assert_eq!(clamp_region(-100, 0, 50, 50, 640, 480), (0, 0, 0, 50));
+        assert_eq!(clamp_region(-100, 0, 50, 50, 640, 480), Region { x: 0, y: 0, width: 0, height: 50 });
         // partial left overhang → only the in-window portion's width
-        assert_eq!(clamp_region(-50, 0, 100, 50, 640, 480), (0, 0, 50, 50));
+        assert_eq!(clamp_region(-50, 0, 100, 50, 640, 480), Region { x: 0, y: 0, width: 50, height: 50 });
         // fully outside on the top → zero height
-        assert_eq!(clamp_region(0, -100, 50, 50, 640, 480), (0, 0, 50, 0));
+        assert_eq!(clamp_region(0, -100, 50, 50, 640, 480), Region { x: 0, y: 0, width: 50, height: 0 });
     }
 }

--- a/crates/glass-macos/src/coords.rs
+++ b/crates/glass-macos/src/coords.rs
@@ -1,1 +1,55 @@
-// filled in Task 3
+//! Pure window-relative ↔ global coordinate math. Cross-platform → unit-tested on the
+//! Linux dev box. The macOS backend (Plans 2–4) maps window-relative tool coordinates to
+//! global screen coordinates here before posting CGEvents or capturing a sub-region.
+
+use glass_core::GlassError;
+
+/// Translate a window-relative point to a global screen point given the window origin.
+pub fn to_global(origin: (i32, i32), rel: (i32, i32)) -> (i32, i32) {
+    (origin.0 + rel.0, origin.1 + rel.1)
+}
+
+/// Reject a window-relative point outside the window (the no-out-of-bounds invariant).
+pub fn check_in_bounds(x: i32, y: i32, width: u32, height: u32) -> Result<(), GlassError> {
+    if x < 0 || y < 0 || x as i64 >= width as i64 || y as i64 >= height as i64 {
+        return Err(GlassError::CoordOutOfBounds { x, y, width, height });
+    }
+    Ok(())
+}
+
+/// Clamp a window-relative region to the window rect, returning `(x, y, w, h)` with the
+/// width/height trimmed so the region never exceeds the window. A region fully outside
+/// clamps to zero size at the nearest edge.
+pub fn clamp_region(rx: i32, ry: i32, rw: u32, rh: u32, width: u32, height: u32) -> (u32, u32, u32, u32) {
+    let x = rx.clamp(0, width as i32) as u32;
+    let y = ry.clamp(0, height as i32) as u32;
+    let w = rw.min(width.saturating_sub(x));
+    let h = rh.min(height.saturating_sub(y));
+    (x, y, w, h)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_global_adds_origin() {
+        assert_eq!(to_global((100, 200), (40, 80)), (140, 280));
+        assert_eq!(to_global((-5, 0), (10, 10)), (5, 10));
+    }
+
+    #[test]
+    fn in_bounds_accepts_inside_rejects_outside() {
+        assert!(check_in_bounds(0, 0, 640, 480).is_ok());
+        assert!(check_in_bounds(639, 479, 640, 480).is_ok());
+        assert!(matches!(check_in_bounds(640, 0, 640, 480), Err(GlassError::CoordOutOfBounds { .. })));
+        assert!(matches!(check_in_bounds(-1, 0, 640, 480), Err(GlassError::CoordOutOfBounds { .. })));
+    }
+
+    #[test]
+    fn clamp_region_trims_to_window() {
+        assert_eq!(clamp_region(10, 10, 100, 100, 640, 480), (10, 10, 100, 100));
+        assert_eq!(clamp_region(600, 0, 100, 50, 640, 480), (600, 0, 40, 50)); // width trimmed
+        assert_eq!(clamp_region(700, 0, 100, 50, 640, 480), (640, 0, 0, 50)); // fully outside → 0 width
+    }
+}

--- a/crates/glass-macos/src/coords.rs
+++ b/crates/glass-macos/src/coords.rs
@@ -17,15 +17,16 @@ pub fn check_in_bounds(x: i32, y: i32, width: u32, height: u32) -> Result<(), Gl
     Ok(())
 }
 
-/// Clamp a window-relative region to the window rect, returning `(x, y, w, h)` with the
-/// width/height trimmed so the region never exceeds the window. A region fully outside
-/// clamps to zero size at the nearest edge.
+/// Clamp a window-relative region to the window rect, returning `(x, y, w, h)` = the
+/// intersection of the region with the window. A region fully outside clamps to zero
+/// size at the nearest edge. Computed in `i64` so no cast can wrap for any input.
 pub fn clamp_region(rx: i32, ry: i32, rw: u32, rh: u32, width: u32, height: u32) -> (u32, u32, u32, u32) {
-    let x = rx.clamp(0, width as i32) as u32;
-    let y = ry.clamp(0, height as i32) as u32;
-    let w = rw.min(width.saturating_sub(x));
-    let h = rh.min(height.saturating_sub(y));
-    (x, y, w, h)
+    let (w_i, h_i) = (width as i64, height as i64);
+    let left = (rx as i64).clamp(0, w_i);
+    let top = (ry as i64).clamp(0, h_i);
+    let right = (rx as i64 + rw as i64).clamp(0, w_i);
+    let bottom = (ry as i64 + rh as i64).clamp(0, h_i);
+    (left as u32, top as u32, (right - left) as u32, (bottom - top) as u32)
 }
 
 #[cfg(test)]
@@ -51,5 +52,15 @@ mod tests {
         assert_eq!(clamp_region(10, 10, 100, 100, 640, 480), (10, 10, 100, 100));
         assert_eq!(clamp_region(600, 0, 100, 50, 640, 480), (600, 0, 40, 50)); // width trimmed
         assert_eq!(clamp_region(700, 0, 100, 50, 640, 480), (640, 0, 0, 50)); // fully outside → 0 width
+    }
+
+    #[test]
+    fn clamp_region_trims_left_top_overhang() {
+        // fully outside on the left → zero width (mirror of the right-edge case)
+        assert_eq!(clamp_region(-100, 0, 50, 50, 640, 480), (0, 0, 0, 50));
+        // partial left overhang → only the in-window portion's width
+        assert_eq!(clamp_region(-50, 0, 100, 50, 640, 480), (0, 0, 50, 50));
+        // fully outside on the top → zero height
+        assert_eq!(clamp_region(0, -100, 50, 50, 640, 480), (0, 0, 50, 0));
     }
 }

--- a/crates/glass-macos/src/keymap.rs
+++ b/crates/glass-macos/src/keymap.rs
@@ -1,0 +1,1 @@
+// filled in Task 2

--- a/crates/glass-macos/src/keymap.rs
+++ b/crates/glass-macos/src/keymap.rs
@@ -1,1 +1,69 @@
-// filled in Task 2
+//! Pure US-layout ASCII → (virtual keycode, needs-shift). Cross-platform so it is
+//! unit-tested on the Linux dev box; Plan 3's CGEvent input casts `u16 as CGKeyCode`.
+//! Keycodes are the documented Carbon `kVK_ANSI_*` values (validated in inject_input.swift).
+
+/// Map an ASCII character to its US-layout virtual keycode and whether Shift is held.
+/// Returns `None` for characters with no single-key US mapping (caller skips/handles).
+pub fn key_for(ch: char) -> Option<(u16, bool)> {
+    // Base (unshifted) keys: lowercase letters, digits, and the unshifted punctuation.
+    const BASE: &[(char, u16)] = &[
+        ('a', 0), ('s', 1), ('d', 2), ('f', 3), ('h', 4), ('g', 5), ('z', 6), ('x', 7),
+        ('c', 8), ('v', 9), ('b', 11), ('q', 12), ('w', 13), ('e', 14), ('r', 15), ('y', 16),
+        ('t', 17), ('1', 18), ('2', 19), ('3', 20), ('4', 21), ('6', 22), ('5', 23), ('=', 24),
+        ('9', 25), ('7', 26), ('-', 27), ('8', 28), ('0', 29), (']', 30), ('o', 31), ('u', 32),
+        ('[', 33), ('i', 34), ('p', 35), ('l', 37), ('j', 38), ('k', 40), ('n', 45), ('m', 46),
+        ('.', 47), (' ', 49), ('/', 44), (';', 41), ('\'', 39), (',', 43), ('`', 50), ('\\', 42),
+    ];
+    if let Some(&(_, code)) = BASE.iter().find(|&&(c, _)| c == ch) {
+        return Some((code, false));
+    }
+    // Uppercase letters → same key with Shift.
+    if ch.is_ascii_uppercase() {
+        let lower = ch.to_ascii_lowercase();
+        if let Some(&(_, code)) = BASE.iter().find(|&&(c, _)| c == lower) {
+            return Some((code, true));
+        }
+    }
+    // Shifted symbols → the base key for the symbol on that physical key, with Shift.
+    const SHIFTED: &[(char, char)] = &[
+        ('!', '1'), ('@', '2'), ('#', '3'), ('$', '4'), ('%', '5'), ('^', '6'), ('&', '7'),
+        ('*', '8'), ('(', '9'), (')', '0'), ('_', '-'), ('+', '='), ('{', '['), ('}', ']'),
+        ('|', '\\'), (':', ';'), ('"', '\''), ('<', ','), ('>', '.'), ('?', '/'), ('~', '`'),
+    ];
+    if let Some(&(_, base)) = SHIFTED.iter().find(|&&(c, _)| c == ch) {
+        if let Some(&(_, code)) = BASE.iter().find(|&&(c, _)| c == base) {
+            return Some((code, true));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::key_for;
+
+    #[test]
+    fn lowercase_letters_unshifted() {
+        assert_eq!(key_for('a'), Some((0, false)));
+        assert_eq!(key_for('m'), Some((46, false)));
+    }
+
+    #[test]
+    fn uppercase_letters_shifted_same_key() {
+        assert_eq!(key_for('A'), Some((0, true)));
+        assert_eq!(key_for('Z'), Some((6, true)));
+    }
+
+    #[test]
+    fn digits_unshifted_and_their_symbols_shifted() {
+        assert_eq!(key_for('1'), Some((18, false)));
+        assert_eq!(key_for('!'), Some((18, true))); // same physical key as '1', shifted
+        assert_eq!(key_for(')'), Some((29, true))); // same key as '0'
+    }
+
+    #[test]
+    fn space_and_unmapped() {
+        assert_eq!(key_for(' '), Some((49, false)));
+        assert_eq!(key_for('€'), None);
+    }
+}

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -1,0 +1,17 @@
+//! The macOS `Platform` backend for glass (ScreenCaptureKit + CGEvent + AXUIElement,
+//! rendered onto a `CGVirtualDisplay`).
+//!
+//! Like `glass-windows`, the pure logic ([`keymap`], [`coords`]) is crate-level and
+//! unit-tested on the Linux dev box; the OS-touching modules and the `MacosPlatform`
+//! impl are gated `#[cfg(target_os = "macos")]`. Off macOS the crate exposes only the
+//! pure modules.
+
+pub mod coords; // pure window-relative <-> global math — cross-platform, host-tested
+pub mod keymap; // pure ASCII -> (keycode, shift) US map — cross-platform, host-tested
+
+#[cfg(target_os = "macos")]
+mod permissions;
+#[cfg(target_os = "macos")]
+mod backend;
+#[cfg(target_os = "macos")]
+pub use backend::MacosPlatform;

--- a/crates/glass-macos/src/permissions.rs
+++ b/crates/glass-macos/src/permissions.rs
@@ -1,14 +1,44 @@
 //! TCC preflight. glass needs two grants on macOS: **Screen Recording** (capture +
 //! window titles) and **Accessibility** (window move/resize/focus + CGEvent input).
 //! Neither can be force-granted (SIP/MDM can't allow Screen Recording); the product
-//! holds them via a stable code-signed identity (see the validation plan). Here we only
-//! *detect* a missing grant and return an actionable error — never a blank frame.
+//! holds them via a stable code-signed identity. Here we only *detect* a missing grant
+//! and return an actionable error — never a blank frame.
 
-use glass_core::{GlassError, Result};
+use glass_core::Result;
+
+/// The two macOS TCC grants glass needs. A local enum keeps the permission names in
+/// one place (no stringly-typed drift) and lets the preflight test assert the specific
+/// missing grant. Converted to a `String` only at the `GlassError` boundary — the shared
+/// `glass-core` error stays platform-agnostic.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Permission {
+    ScreenRecording,
+    Accessibility,
+}
+
+impl Permission {
+    fn label(self) -> &'static str {
+        match self {
+            Permission::ScreenRecording => "Screen Recording",
+            Permission::Accessibility => "Accessibility",
+        }
+    }
+    fn remedy(self) -> &'static str {
+        match self {
+            Permission::ScreenRecording => "enable glass in System Settings > Privacy & Security > Screen Recording (run inside a logged-in session; grant persists for the signed binary)",
+            Permission::Accessibility => "enable glass in System Settings > Privacy & Security > Accessibility",
+        }
+    }
+    fn denied(self) -> glass_core::GlassError {
+        glass_core::GlassError::PermissionDenied { which: self.label().into(), remedy: self.remedy().into() }
+    }
+}
 
 // Both are plain C functions; no objc2 needed for preflight.
 #[link(name = "CoreGraphics", kind = "framework")]
 extern "C" {
+    // Apple declares this post-10.15 API with C99 `bool`, guaranteed to be 0/1 — unlike
+    // the legacy `Boolean`/`u8` ABI on `AXIsProcessTrusted` below.
     fn CGPreflightScreenCaptureAccess() -> bool;
 }
 #[link(name = "ApplicationServices", kind = "framework")]
@@ -20,14 +50,14 @@ extern "C" {
 }
 
 /// True if this process holds the Screen Recording grant.
-pub fn screen_recording_ok() -> bool {
+pub(crate) fn screen_recording_ok() -> bool {
     // SAFETY: `CGPreflightScreenCaptureAccess` is a no-argument C predicate that only
     // reads this process's TCC state; it has no preconditions and no side effects.
     unsafe { CGPreflightScreenCaptureAccess() }
 }
 
 /// True if this process is trusted for Accessibility (AX APIs + CGEvent posting).
-pub fn accessibility_ok() -> bool {
+pub(crate) fn accessibility_ok() -> bool {
     // SAFETY: `AXIsProcessTrusted` is a no-argument C predicate over this process's
     // trust state; no preconditions, no side effects. It returns `Boolean` (u8); any
     // nonzero value means trusted.
@@ -36,20 +66,12 @@ pub fn accessibility_ok() -> bool {
 
 /// Fail fast with an actionable error if either grant is missing. Called at session
 /// start before any capture/input is attempted.
-pub fn preflight() -> Result<()> {
+pub(crate) fn preflight() -> Result<()> {
     if !screen_recording_ok() {
-        return Err(GlassError::PermissionDenied {
-            which: "Screen Recording".into(),
-            remedy: "enable glass in System Settings > Privacy & Security > Screen Recording \
-                     (run inside a logged-in session; grant persists for the signed binary)"
-                .into(),
-        });
+        return Err(Permission::ScreenRecording.denied());
     }
     if !accessibility_ok() {
-        return Err(GlassError::PermissionDenied {
-            which: "Accessibility".into(),
-            remedy: "enable glass in System Settings > Privacy & Security > Accessibility".into(),
-        });
+        return Err(Permission::Accessibility.denied());
     }
     Ok(())
 }
@@ -57,6 +79,7 @@ pub fn preflight() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use glass_core::GlassError;
 
     #[test]
     fn preflight_matches_the_two_predicates() {
@@ -68,7 +91,10 @@ mod tests {
             Ok(()) => assert!(sr && ax, "preflight Ok but a predicate was false"),
             Err(GlassError::PermissionDenied { which, .. }) => {
                 assert!(!sr || !ax, "preflight denied but both predicates true");
-                assert!(which == "Screen Recording" || which == "Accessibility", "{which}");
+                // preflight checks Screen Recording first, so the specific predicate
+                // that failed pins which grant the error must name.
+                let expected = if !sr { Permission::ScreenRecording } else { Permission::Accessibility };
+                assert_eq!(which, expected.label());
             }
             Err(e) => panic!("unexpected error: {e}"),
         }

--- a/crates/glass-macos/src/permissions.rs
+++ b/crates/glass-macos/src/permissions.rs
@@ -1,0 +1,72 @@
+//! TCC preflight. glass needs two grants on macOS: **Screen Recording** (capture +
+//! window titles) and **Accessibility** (window move/resize/focus + CGEvent input).
+//! Neither can be force-granted (SIP/MDM can't allow Screen Recording); the product
+//! holds them via a stable code-signed identity (see the validation plan). Here we only
+//! *detect* a missing grant and return an actionable error — never a blank frame.
+
+use glass_core::{GlassError, Result};
+
+// Both are plain C functions; no objc2 needed for preflight.
+#[link(name = "CoreGraphics", kind = "framework")]
+extern "C" {
+    fn CGPreflightScreenCaptureAccess() -> bool;
+}
+#[link(name = "ApplicationServices", kind = "framework")]
+extern "C" {
+    fn AXIsProcessTrusted() -> bool;
+}
+
+/// True if this process holds the Screen Recording grant.
+pub fn screen_recording_ok() -> bool {
+    // SAFETY: `CGPreflightScreenCaptureAccess` is a no-argument C predicate that only
+    // reads this process's TCC state; it has no preconditions and no side effects.
+    unsafe { CGPreflightScreenCaptureAccess() }
+}
+
+/// True if this process is trusted for Accessibility (AX APIs + CGEvent posting).
+pub fn accessibility_ok() -> bool {
+    // SAFETY: `AXIsProcessTrusted` is a no-argument C predicate over this process's
+    // trust state; no preconditions, no side effects.
+    unsafe { AXIsProcessTrusted() }
+}
+
+/// Fail fast with an actionable error if either grant is missing. Called at session
+/// start before any capture/input is attempted.
+pub fn preflight() -> Result<()> {
+    if !screen_recording_ok() {
+        return Err(GlassError::PermissionDenied {
+            which: "Screen Recording".into(),
+            remedy: "enable glass in System Settings > Privacy & Security > Screen Recording \
+                     (run inside a logged-in session; grant persists for the signed binary)"
+                .into(),
+        });
+    }
+    if !accessibility_ok() {
+        return Err(GlassError::PermissionDenied {
+            which: "Accessibility".into(),
+            remedy: "enable glass in System Settings > Privacy & Security > Accessibility".into(),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preflight_matches_the_two_predicates() {
+        // On a box where grants are present, preflight is Ok; where absent, it errors with
+        // the missing permission named. Either way the predicates and preflight agree.
+        let sr = screen_recording_ok();
+        let ax = accessibility_ok();
+        match preflight() {
+            Ok(()) => assert!(sr && ax, "preflight Ok but a predicate was false"),
+            Err(GlassError::PermissionDenied { which, .. }) => {
+                assert!(!sr || !ax, "preflight denied but both predicates true");
+                assert!(which == "Screen Recording" || which == "Accessibility", "{which}");
+            }
+            Err(e) => panic!("unexpected error: {e}"),
+        }
+    }
+}

--- a/crates/glass-macos/src/permissions.rs
+++ b/crates/glass-macos/src/permissions.rs
@@ -13,7 +13,10 @@ extern "C" {
 }
 #[link(name = "ApplicationServices", kind = "framework")]
 extern "C" {
-    fn AXIsProcessTrusted() -> bool;
+    // Apple declares this `Boolean` (= `unsigned char`), NOT C99 `_Bool`. Binding it as
+    // `u8` and comparing `!= 0` avoids the Rust-`bool` validity invariant (only 0/1 are
+    // legal bit patterns; any other byte would be instant UB), matching `accessibility-sys`.
+    fn AXIsProcessTrusted() -> u8;
 }
 
 /// True if this process holds the Screen Recording grant.
@@ -26,8 +29,9 @@ pub fn screen_recording_ok() -> bool {
 /// True if this process is trusted for Accessibility (AX APIs + CGEvent posting).
 pub fn accessibility_ok() -> bool {
     // SAFETY: `AXIsProcessTrusted` is a no-argument C predicate over this process's
-    // trust state; no preconditions, no side effects.
-    unsafe { AXIsProcessTrusted() }
+    // trust state; no preconditions, no side effects. It returns `Boolean` (u8); any
+    // nonzero value means trusted.
+    unsafe { AXIsProcessTrusted() != 0 }
 }
 
 /// Fail fast with an actionable error if either grant is missing. Called at session

--- a/scripts/test-macos.sh
+++ b/scripts/test-macos.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Run the glass-macos suite. Skips (exit 0) when not on macOS, so it is safe to call
+# from any CI matrix leg — mirroring scripts/test-x11.sh / test-wayland.sh.
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "test-macos.sh: not macOS (uname=$(uname -s)) — skipping."
+  exit 0
+fi
+
+# Pure + macOS unit tests. (Capture/input integration tests are #[ignore]d and added in
+# later plans; they need a granted, WindowServer-connected context — a gui/501 LaunchAgent.)
+cargo test -p glass-macos "${1:-}"

--- a/scripts/test-macos.sh
+++ b/scripts/test-macos.sh
@@ -8,6 +8,10 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
   exit 0
 fi
 
+# Run from the repo root so `cargo -p` resolves regardless of the caller's cwd
+# (mirrors scripts/test-x11.sh / test-wayland.sh / test-windows.sh).
+cd "$(dirname "$0")/.."
+
 # Pure + macOS unit tests. (Capture/input integration tests are #[ignore]d and added in
 # later plans; they need a granted, WindowServer-connected context — a gui/501 LaunchAgent.)
 cargo test -p glass-macos "${1:-}"


### PR DESCRIPTION
First increment of the macOS `Platform` backend: the crate skeleton and its foundations. Follow-on PRs add capture, input, and window management.

## What's here
- **`glass-macos` crate** implementing `glass_core::Platform`, mirroring the `glass-windows` layout — pure cross-platform modules at crate level, OS-touching code behind `#[cfg(target_os = "macos")]`:
  - `keymap` — pure US-layout ASCII → (keycode, shift); host-tested.
  - `coords` — pure window-relative ↔ global mapping + region clamping (returns `glass_core::frame::Region`); host-tested.
  - `permissions` — TCC preflight (Screen Recording + Accessibility) via CoreGraphics/ApplicationServices FFI; returns a structured, actionable error when a grant is missing (no silent fallback).
  - `MacosPlatform` — the `Platform` impl. The window-server methods (`capture_frame`, `send_pointer`/`send_key`, `window`/`list_windows`/`select_window`, `start_app`/`stop_app`) are `unimplemented!()` stubs filled by the follow-on PRs; `drain_logs`/`app_pid` are real, and `new()` runs the TCC preflight so a missing grant fails fast.
- **`glass_core::GlassError::PermissionDenied { which, remedy }`** — a structured, platform-agnostic permission error (plain strings; no OS types in core).
- **macOS CI** — a `macos-14` job that builds, lints (`clippy -D warnings`), and tests `glass-macos` (the Linux jobs can't compile the `cfg(macos)` code); plus `scripts/test-macos.sh` (skips cleanly off macOS).

## Notes
- Minimum target macOS 14; developed and verified on macOS 26.5 (Apple Silicon).
- `AXIsProcessTrusted` is bound as `u8` (Apple's legacy `Boolean` = `unsigned char` ABI), not Rust `bool`, to avoid a `bool`-validity-invariant UB hazard; `CGPreflightScreenCaptureAccess` is genuinely C99 `bool`. Each `unsafe` FFI block carries a `// SAFETY:` comment.
- No new dependencies — `objc2` bindings arrive with the capture PR.

## Verification
- Linux: `cargo build/clippy/test --workspace --locked` green.
- macOS 26.5 (Apple Silicon): `cargo clippy -p glass-macos --all-targets --locked -- -D warnings` clean; `cargo test -p glass-macos` 12/12 passing (incl. the FFI-linking preflight test and a `new()`-propagation guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
