### PR TITLE
feat(macos): glass-macos capture — launch + ScreenCaptureKit window capture (Plan 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,6 +1051,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-image-io",
  "objc2-screen-capture-kit",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,6 +687,18 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -1020,7 +1041,16 @@ dependencies = [
 name = "glass-macos"
 version = "0.0.0"
 dependencies = [
+ "block2",
+ "dispatch2",
  "glass-core",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "objc2-image-io",
+ "objc2-screen-capture-kit",
 ]
 
 [[package]]
@@ -1609,6 +1639,262 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-av-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478ae33fcac9df0a18db8302387c666b8ef08a3e2d62b510ca4fc278a384b6c0"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "dispatch2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "dispatch2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-media"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec576860167a15dd9fce7fbee7512beb4e31f532159d3482d1f9c6caedf31d"
+dependencies = [
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-video",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-image-io"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b0446e98cf4a784cc7a0177715ff317eeaa8463841c616cfc78aa4f953c4ea"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-screen-capture-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74b7c5390f477482f001bc354d6571a70db7e4f8d5288e860c45521fbce11394"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "dispatch2",
+ "libc",
+ "objc2",
+ "objc2-av-foundation",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-media",
+ "objc2-foundation",
+ "objc2-uniform-type-identifiers",
+]
+
+[[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7902ac02859fc1f7045f8b598c63f1ae0cc7efeaa06a9bc9f3d9a3c955974fa4"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,8 +696,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
- "libc",
  "objc2",
 ]
 
@@ -1042,7 +1040,6 @@ name = "glass-macos"
 version = "0.0.0"
 dependencies = [
  "block2",
- "dispatch2",
  "glass-core",
  "objc2",
  "objc2-app-kit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,7 +1049,6 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-foundation",
- "objc2-image-io",
  "objc2-screen-capture-kit",
  "rustix",
 ]
@@ -1658,70 +1657,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
- "libc",
- "objc2",
- "objc2-cloud-kit",
- "objc2-core-data",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-core-image",
- "objc2-core-text",
- "objc2-core-video",
- "objc2-foundation",
- "objc2-quartz-core",
-]
-
-[[package]]
-name = "objc2-av-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478ae33fcac9df0a18db8302387c666b8ef08a3e2d62b510ca4fc278a384b6c0"
-dependencies = [
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-cloud-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
-dependencies = [
- "bitflags 2.11.1",
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-audio"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
-dependencies = [
- "dispatch2",
- "objc2",
- "objc2-core-audio-types",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-core-audio-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
-dependencies = [
- "bitflags 2.11.1",
- "objc2",
-]
-
-[[package]]
-name = "objc2-core-data"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
-dependencies = [
- "bitflags 2.11.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -1733,9 +1668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
  "dispatch2",
- "libc",
  "objc2",
 ]
 
@@ -1746,62 +1679,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
- "dispatch2",
- "libc",
- "objc2",
- "objc2-core-foundation",
- "objc2-io-surface",
- "objc2-metal",
-]
-
-[[package]]
-name = "objc2-core-image"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
-dependencies = [
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-media"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ec576860167a15dd9fce7fbee7512beb4e31f532159d3482d1f9c6caedf31d"
-dependencies = [
- "bitflags 2.11.1",
  "dispatch2",
  "objc2",
- "objc2-core-audio",
- "objc2-core-audio-types",
  "objc2-core-foundation",
- "objc2-core-video",
-]
-
-[[package]]
-name = "objc2-core-text"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
-dependencies = [
- "bitflags 2.11.1",
- "objc2",
- "objc2-core-foundation",
- "objc2-core-graphics",
-]
-
-[[package]]
-name = "objc2-core-video"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
-dependencies = [
- "bitflags 2.11.1",
- "objc2",
- "objc2-core-foundation",
- "objc2-core-graphics",
  "objc2-io-surface",
 ]
 
@@ -1818,22 +1698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
- "libc",
  "objc2",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-image-io"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b0446e98cf4a784cc7a0177715ff317eeaa8463841c616cfc78aa4f953c4ea"
-dependencies = [
- "block2",
- "objc2",
- "objc2-core-foundation",
- "objc2-core-graphics",
 ]
 
 [[package]]
@@ -1848,53 +1713,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-metal"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
-dependencies = [
- "bitflags 2.11.1",
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-quartz-core"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
-dependencies = [
- "bitflags 2.11.1",
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
 name = "objc2-screen-capture-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74b7c5390f477482f001bc354d6571a70db7e4f8d5288e860c45521fbce11394"
 dependencies = [
- "bitflags 2.11.1",
  "block2",
- "dispatch2",
  "libc",
  "objc2",
- "objc2-av-foundation",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-core-media",
- "objc2-foundation",
- "objc2-uniform-type-identifiers",
-]
-
-[[package]]
-name = "objc2-uniform-type-identifiers"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7902ac02859fc1f7045f8b598c63f1ae0cc7efeaa06a9bc9f3d9a3c955974fa4"
-dependencies = [
- "objc2",
  "objc2-foundation",
 ]
 

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -23,18 +23,43 @@ glass-core.workspace = true
 # macOS-only FFI deps (objc2 family). Kept in this target table so the crate's pure
 # modules still build on the Linux dev box with zero macOS deps. Versions pinned to
 # exactly what `.superpowers/sdd/objc2-spike-report.md` proved compiles + runs cleanly
-# (zero warnings) against the real frameworks on mini; default features are used
-# throughout because each crate's default set already covers every type the spike (and
-# this crate's planned Plan 2 call sequences) touch — see the report's "Crate versions
-# used" table.
+# (zero warnings) against the real frameworks on mini. Each `objc2-*` framework crate
+# gates its ObjC types behind per-type Cargo features; `default-features = false` +
+# an explicit minimal `features` list keeps unused framework bindings (AVFoundation,
+# Metal, CoreData, CloudKit, etc. — pulled in wholesale by each crate's `default`
+# feature set) out of the build entirely. See `.superpowers/sdd/feature-trim-report.md`
+# for how each list was derived and verified empirically on mini.
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.4"
-objc2-foundation = "0.3.2"
-objc2-app-kit = "0.3.2"
-objc2-screen-capture-kit = "0.3.2"
-objc2-core-graphics = "0.3.2"
-objc2-core-foundation = "0.3.2"
-objc2-image-io = "0.3.2"
+objc2-foundation = { version = "0.3.2", default-features = false, features = [
+    "NSArray",
+    "NSEnumerator",
+    "NSError",
+    "NSString",
+] }
+objc2-app-kit = { version = "0.3.2", default-features = false, features = [
+    "NSApplication",
+    "NSResponder",
+] }
+objc2-screen-capture-kit = { version = "0.3.2", default-features = false, features = [
+    "SCShareableContent",
+    "SCScreenshotManager",
+    "SCStream",
+    "block2",
+    "libc",
+    "objc2-core-foundation",
+    "objc2-core-graphics",
+] }
+objc2-core-graphics = { version = "0.3.2", default-features = false, features = [
+    "CGImage",
+    "CGColorSpace",
+    "CGContext",
+    "CGBitmapContext",
+    "objc2",
+] }
+objc2-core-foundation = { version = "0.3.2", default-features = false, features = [
+    "CFCGTypes",
+] }
 block2 = "0.6.2"
 dispatch2 = "0.3.1"
 # SIGTERM/SIGKILL for `process::terminate` — already a workspace dep (glass-wayland,

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -29,6 +29,10 @@ objc2-core-foundation = "0.3.2"
 objc2-image-io = "0.3.2"
 block2 = "0.6.2"
 dispatch2 = "0.3.1"
+# SIGTERM/SIGKILL for `process::terminate` — already a workspace dep (glass-wayland,
+# glass-proc-linux use it on Linux); its `kill_process`/`Pid`/`Signal` are plain POSIX
+# and available on macOS too.
+rustix.workspace = true
 
 [lints]
 workspace = true

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -12,9 +12,23 @@ bench = false
 [dependencies]
 glass-core.workspace = true
 
-# macOS-only FFI deps land in Plan 2 (objc2 family). Kept empty here so the
-# crate's pure modules build on the Linux dev box with zero macOS deps.
+# macOS-only FFI deps (objc2 family). Kept in this target table so the crate's pure
+# modules still build on the Linux dev box with zero macOS deps. Versions pinned to
+# exactly what `.superpowers/sdd/objc2-spike-report.md` proved compiles + runs cleanly
+# (zero warnings) against the real frameworks on mini; default features are used
+# throughout because each crate's default set already covers every type the spike (and
+# this crate's planned Plan 2 call sequences) touch — see the report's "Crate versions
+# used" table.
 [target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6.4"
+objc2-foundation = "0.3.2"
+objc2-app-kit = "0.3.2"
+objc2-screen-capture-kit = "0.3.2"
+objc2-core-graphics = "0.3.2"
+objc2-core-foundation = "0.3.2"
+objc2-image-io = "0.3.2"
+block2 = "0.6.2"
+dispatch2 = "0.3.1"
 
 [lints]
 workspace = true

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -61,7 +61,6 @@ objc2-core-foundation = { version = "0.3.2", default-features = false, features 
     "CFCGTypes",
 ] }
 block2 = "0.6.2"
-dispatch2 = "0.3.1"
 # SIGTERM/SIGKILL for `process::terminate` — already a workspace dep (glass-wayland,
 # glass-proc-linux use it on Linux); its `kill_process`/`Pid`/`Signal` are plain POSIX
 # and available on macOS too.

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -9,6 +9,14 @@ publish.workspace = true
 [lib]
 bench = false
 
+# Mac-gated capture integration test (crates/glass-macos/tests/capture.rs): harness =
+# false because it defines its own `fn main()` that must run on the process's true main
+# thread (AppKit's `MainThreadMarker` requirement — see the file's module doc), which
+# libtest's per-test worker threads can't provide.
+[[test]]
+name = "capture"
+harness = false
+
 [dependencies]
 glass-core.workspace = true
 

--- a/crates/glass-macos/fixture/quadrants.swift
+++ b/crates/glass-macos/fixture/quadrants.swift
@@ -1,0 +1,113 @@
+// quadrants.swift — glass-macos capture fixture (Plan 2, Task 6).
+//
+// A minimal Cocoa app: a single 400x400 window whose entire content view paints 4 known
+// solid colors into the window's four VISUAL quadrants — i.e. the quadrants as they
+// appear on screen, not raw view-local coordinates. `NSView` is bottom-left-origin,
+// y-up when unflipped (the default, and what this view uses): a rect drawn at view
+// y:[200,400) appears at the TOP of the window on screen, and y:[0,200) at the BOTTOM.
+// So:
+//
+//   visual top-left     (screen upper-left)  = red   #FF0000
+//   visual top-right    (screen upper-right) = green #00FF00
+//   visual bottom-left  (screen lower-left)  = blue  #0000FF
+//   visual bottom-right (screen lower-right) = white #FFFFFF
+//
+// Colors are set via `NSColor(deviceRed:green:blue:alpha:)` (device RGB, no ColorSync
+// matching) so the captured framebuffer bytes land as close as possible to the exact
+// values above.
+//
+// The window is deliberately BORDERLESS (no title bar chrome): a titled window's full
+// frame (what ScreenCaptureKit's per-window capture returns) would include a title-bar
+// strip of a height that varies by macOS version, which would break exact-quadrant
+// pixel math in the capture test. A borderless window's frame equals its content view
+// exactly, so the captured frame is exactly this view's 400x400 (at whatever backing
+// scale) with no chrome to account for. `window.title` is still set for identification
+// in logs/debugging even though it isn't drawn as chrome.
+//
+// Also spawns a background thread that reads stdin lines and echoes `got: <line>` to
+// stdout, flushing after each — unused by this task's capture test, but exercised by the
+// future input plan (Plan 3) so the same fixture serves both.
+//
+// Build: swiftc -O -parse-as-library quadrants.swift -o quadrants
+//   (`-parse-as-library` is required because this file uses a top-level `@main` type
+//   rather than unadorned top-level statements — the same gotcha as
+//   glass/tools/macos-validation/capture_window.swift.)
+
+import Cocoa
+
+let windowSize = NSSize(width: 400, height: 400)
+
+/// A borderless window that can still become key/main — not needed for this task's pure
+/// capture test, but keeps the fixture usable for Plan 3's input work without surprises.
+final class FixtureWindow: NSWindow {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { true }
+}
+
+final class QuadrantView: NSView {
+    override func draw(_ dirtyRect: NSRect) {
+        let half = bounds.width / 2 // == bounds.height / 2 for a 400x400 view
+        let quadrants: [(NSRect, NSColor)] = [
+            // view-local rect                                            color   visual quadrant
+            (NSRect(x: 0, y: half, width: half, height: half), red), // top-left
+            (NSRect(x: half, y: half, width: half, height: half), green), // top-right
+            (NSRect(x: 0, y: 0, width: half, height: half), blue), // bottom-left
+            (NSRect(x: half, y: 0, width: half, height: half), white), // bottom-right
+        ]
+        for (rect, color) in quadrants {
+            color.setFill()
+            NSBezierPath(rect: rect).fill()
+        }
+    }
+
+    private let red = NSColor(deviceRed: 1, green: 0, blue: 0, alpha: 1)
+    private let green = NSColor(deviceRed: 0, green: 1, blue: 0, alpha: 1)
+    private let blue = NSColor(deviceRed: 0, green: 0, blue: 1, alpha: 1)
+    private let white = NSColor(deviceRed: 1, green: 1, blue: 1, alpha: 1)
+}
+
+/// Reads stdin lines on a background thread and echoes `got: <line>` to stdout — for
+/// Plan 3's input-driving test, unused by Task 6's capture test.
+enum StdinEcho {
+    static func start() {
+        Thread.detachNewThread {
+            while let line = readLine(strippingNewline: true) {
+                print("got: \(line)")
+                fflush(stdout)
+            }
+        }
+    }
+}
+
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    var window: FixtureWindow!
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        let rect = NSRect(origin: .zero, size: windowSize)
+        window = FixtureWindow(
+            contentRect: rect,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "glass-fixture"
+        window.isOpaque = true
+        window.hasShadow = false
+        window.level = .normal
+        window.contentView = QuadrantView(frame: rect)
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+}
+
+@main
+struct Main {
+    static func main() {
+        let app = NSApplication.shared
+        app.setActivationPolicy(.regular)
+        let delegate = AppDelegate()
+        app.delegate = delegate
+        StdinEcho.start()
+        app.run()
+    }
+}

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -2,17 +2,19 @@
 //! window-server methods stubbed; Plan 2 fills capture + display provisioning, Plan 3
 //! input, Plan 4 windows. `new()` runs the TCC preflight so a missing grant fails fast.
 
+use std::process::Child;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use glass_core::frame::{Frame, Region};
 use glass_core::logbuf::Stream;
 use glass_core::platform::{
     AppSpec, KeyEvent, Platform, PointerEvent, WindowGeometry, WindowId, WindowInfo, WindowOp,
 };
-use glass_core::Result;
+use glass_core::{GlassError, Result};
 
 use crate::permissions;
-use crate::process::LogSink;
+use crate::process::{self, LogSink};
 
 /// macOS backend. v1 renders the target app onto a `CGVirtualDisplay` (Plan 2) and
 /// drives it with ScreenCaptureKit + CGEvent + AXUIElement.
@@ -24,25 +26,92 @@ pub struct MacosPlatform {
     logs: LogSink,
     /// The launched app's root pid; `None` until `start_app`.
     app_pid: Option<u32>,
+    /// The launched child process, kept so `stop_app`/`Drop` can `process::terminate`
+    /// it. `None` until `start_app` and after `stop_app` (idempotent).
+    child: Option<Child>,
 }
 
 impl MacosPlatform {
     /// Construct the backend, failing fast if a required TCC grant is missing.
     pub fn new() -> Result<Self> {
         permissions::preflight()?;
-        Ok(Self { logs: Arc::new(Mutex::new(Vec::new())), app_pid: None })
+        Ok(Self { logs: Arc::new(Mutex::new(Vec::new())), app_pid: None, child: None })
+    }
+
+    /// Run the optional `spec.build` shell step in `spec.cwd`, mirroring the X11/Windows
+    /// backends' `sh -c`/`cmd /C` build step. A nonzero exit maps to
+    /// `GlassError::AppNotStarted` — no launch is attempted if the build failed.
+    fn run_build(spec: &AppSpec) -> Result<()> {
+        let Some(build) = &spec.build else {
+            return Ok(());
+        };
+        let mut cmd = std::process::Command::new("/bin/sh");
+        cmd.arg("-c").arg(build);
+        if let Some(dir) = &spec.cwd {
+            cmd.current_dir(dir);
+        }
+        let status = cmd
+            .status()
+            .map_err(|e| GlassError::AppNotStarted(format!("build command: {e}")))?;
+        if !status.success() {
+            return Err(GlassError::AppNotStarted(format!(
+                "build command failed with status {status}"
+            )));
+        }
+        Ok(())
     }
 }
 
 impl Platform for MacosPlatform {
-    fn start_app(&mut self, _spec: &AppSpec) -> Result<WindowGeometry> {
-        unimplemented!("Plan 2: spawn + CGVirtualDisplay + window discovery")
+    /// Run the optional build step, spawn the app, then confirm a window appears for its
+    /// pid within `spec.timeout_ms` via ScreenCaptureKit's `SCShareableContent`
+    /// enumeration.
+    ///
+    /// **Main-thread affinity:** `scwindow::find_window_for_pids` calls
+    /// `ffi::app_kit_init()`, which requires the true main thread (`MainThreadMarker`
+    /// panics off it). In Plan 2 this is exercised only by Task 6's `harness=false`
+    /// main-thread test; wiring it under glass-mcp's worker-thread dispatcher
+    /// (main-thread marshaling) is deferred to Plan 5.
+    fn start_app(&mut self, spec: &AppSpec) -> Result<WindowGeometry> {
+        Self::run_build(spec)?;
+        let mut child = process::spawn(spec, self.logs.clone())?;
+        let pid = child.id();
+        match crate::scwindow::find_window_for_pids(&[pid as i32], Duration::from_millis(spec.timeout_ms)) {
+            Ok(m) => {
+                self.child = Some(child);
+                self.app_pid = Some(pid);
+                Ok(m.geometry)
+            }
+            Err(e) => {
+                // The window never appeared (or discovery otherwise failed): don't leak
+                // the spawned child.
+                process::terminate(&mut child);
+                Err(e)
+            }
+        }
     }
+
+    /// Terminate the launched child (if any) and clear the active pid. Idempotent — a
+    /// call with nothing running is `Ok(())`.
     fn stop_app(&mut self) -> Result<()> {
-        unimplemented!("Plan 2: terminate child + tear down provisioning")
+        if let Some(mut child) = self.child.take() {
+            process::terminate(&mut child);
+        }
+        self.app_pid = None;
+        Ok(())
     }
-    fn capture_frame(&mut self, _region: Option<&Region>) -> Result<Frame> {
-        unimplemented!("Plan 2: ScreenCaptureKit per-window capture")
+
+    /// Capture the active app's window as an RGBA8 frame, re-resolving it by pid on
+    /// every call (see `scwindow.rs`'s module doc — a `Retained<SCWindow>` can't be
+    /// cached across calls).
+    ///
+    /// **Main-thread affinity:** like `start_app`, this reaches `ffi::app_kit_init()`
+    /// (via `capture::capture_window`) and must run on the true main thread; see the
+    /// note on `start_app`.
+    fn capture_frame(&mut self, region: Option<&Region>) -> Result<Frame> {
+        permissions::preflight()?;
+        let pid = self.app_pid.ok_or(GlassError::NoActiveSession)?;
+        crate::capture::capture_window(&[pid as i32], region)
     }
     fn send_pointer(&mut self, _event: &PointerEvent) -> Result<()> {
         unimplemented!("Plan 3: CGEvent pointer")
@@ -67,6 +136,19 @@ impl Platform for MacosPlatform {
     }
 }
 
+impl Drop for MacosPlatform {
+    /// Reap a still-running launched app on drop — parity with the X11/Wayland/Windows
+    /// backends, so a backend dropped without an explicit `stop_app()` (panic-unwind, or
+    /// the process-exit backstop path) does not orphan its child. `process::terminate`
+    /// is idempotent, and `child.take()` in `stop_app` means this is a no-op if
+    /// `stop_app` already ran.
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            process::terminate(&mut child);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -78,6 +160,7 @@ mod tests {
         let mut p = MacosPlatform {
             logs: Arc::new(Mutex::new(vec![(Stream::Stdout, "hi".into())])),
             app_pid: Some(42),
+            child: None,
         };
         assert_eq!(p.drain_logs().len(), 1);
         assert!(p.drain_logs().is_empty());
@@ -85,8 +168,20 @@ mod tests {
 
     #[test]
     fn app_pid_returns_the_constructed_value() {
-        let p = MacosPlatform { logs: Arc::new(Mutex::new(Vec::new())), app_pid: Some(42) };
+        let p =
+            MacosPlatform { logs: Arc::new(Mutex::new(Vec::new())), app_pid: Some(42), child: None };
         assert_eq!(p.app_pid(), Some(42));
+    }
+
+    #[test]
+    fn stop_app_on_a_fresh_platform_is_idempotent() {
+        // No child stored: stop_app must not panic (e.g. on an unwrap of a live process
+        // handle) and must succeed — this path never touches AppKit, so it's exercisable
+        // off the Mac-gated suite's main-thread test.
+        let mut p = MacosPlatform { logs: Arc::new(Mutex::new(Vec::new())), app_pid: None, child: None };
+        assert!(p.stop_app().is_ok());
+        assert!(p.stop_app().is_ok(), "a second call must also be Ok");
+        assert_eq!(p.app_pid(), None);
     }
 
     #[test]

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -4,7 +4,7 @@
 
 use std::process::Child;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use glass_core::frame::{Frame, Region};
 use glass_core::logbuf::Stream;
@@ -15,6 +15,12 @@ use glass_core::{GlassError, Result};
 
 use crate::permissions;
 use crate::process::{self, LogSink};
+
+/// Poll interval between discovery attempts in [`MacosPlatform::discover_window`] —
+/// matches `scwindow::find_window_for_pids`'s own poll cadence
+/// (`poll_until(100, ..)`), which that loop takes over here so it can also race
+/// against `child.try_wait()`.
+const DISCOVERY_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 /// macOS backend. v1 renders the target app onto a `CGVirtualDisplay` (Plan 2) and
 /// drives it with ScreenCaptureKit + CGEvent + AXUIElement.
@@ -60,27 +66,52 @@ impl MacosPlatform {
         }
         Ok(())
     }
+
+    /// Poll for `child`'s window, alternating a single [`crate::scwindow::query_once`]
+    /// discovery attempt with `child.try_wait()` so a crashed launch fails fast with
+    /// [`GlassError::AppExited`] instead of riding out the whole `timeout_ms` budget
+    /// waiting for a window that will never appear — mirrors
+    /// `glass-x11/src/platform.rs`'s `discover_window`. Can't delegate this to
+    /// `scwindow::find_window_for_pids`: that helper owns its *entire* poll loop
+    /// internally, with no child handle to race against.
+    fn discover_window(child: &mut Child, pid: u32, timeout_ms: u64) -> Result<WindowGeometry> {
+        crate::ffi::app_kit_init();
+        let deadline = Instant::now() + Duration::from_millis(timeout_ms.max(1));
+        loop {
+            if let Some(m) = crate::scwindow::query_once(&[pid as i32])? {
+                return Ok(m.geometry);
+            }
+            if let Ok(Some(status)) = child.try_wait() {
+                return Err(GlassError::AppExited(status.code()));
+            }
+            if Instant::now() >= deadline {
+                return Err(GlassError::Timeout(timeout_ms));
+            }
+            std::thread::sleep(DISCOVERY_POLL_INTERVAL);
+        }
+    }
 }
 
 impl Platform for MacosPlatform {
     /// Run the optional build step, spawn the app, then confirm a window appears for its
     /// pid within `spec.timeout_ms` via ScreenCaptureKit's `SCShareableContent`
-    /// enumeration.
+    /// enumeration — alternated with `child.try_wait()` so a crashed launch fails fast
+    /// with `GlassError::AppExited` instead of riding out the whole timeout (see
+    /// `discover_window`).
     ///
-    /// **Main-thread affinity:** `scwindow::find_window_for_pids` calls
-    /// `ffi::app_kit_init()`, which requires the true main thread (`MainThreadMarker`
-    /// panics off it). In Plan 2 this is exercised only by Task 6's `harness=false`
-    /// main-thread test; wiring it under glass-mcp's worker-thread dispatcher
-    /// (main-thread marshaling) is deferred to Plan 5.
+    /// **Main-thread affinity:** `discover_window` calls `ffi::app_kit_init()`, which
+    /// requires the true main thread (`MainThreadMarker` panics off it). In Plan 2 this is
+    /// exercised only by Task 6's `harness=false` main-thread test; wiring it under
+    /// glass-mcp's worker-thread dispatcher (main-thread marshaling) is deferred to Plan 5.
     fn start_app(&mut self, spec: &AppSpec) -> Result<WindowGeometry> {
         Self::run_build(spec)?;
         let mut child = process::spawn(spec, self.logs.clone())?;
         let pid = child.id();
-        match crate::scwindow::find_window_for_pids(&[pid as i32], Duration::from_millis(spec.timeout_ms)) {
-            Ok(m) => {
+        match Self::discover_window(&mut child, pid, spec.timeout_ms) {
+            Ok(geometry) => {
                 self.child = Some(child);
                 self.app_pid = Some(pid);
-                Ok(m.geometry)
+                Ok(geometry)
             }
             Err(e) => {
                 // The window never appeared (or discovery otherwise failed): don't leak

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -2,6 +2,8 @@
 //! window-server methods stubbed; Plan 2 fills capture + display provisioning, Plan 3
 //! input, Plan 4 windows. `new()` runs the TCC preflight so a missing grant fails fast.
 
+use std::sync::{Arc, Mutex};
+
 use glass_core::frame::{Frame, Region};
 use glass_core::logbuf::Stream;
 use glass_core::platform::{
@@ -10,13 +12,16 @@ use glass_core::platform::{
 use glass_core::Result;
 
 use crate::permissions;
+use crate::process::LogSink;
 
 /// macOS backend. v1 renders the target app onto a `CGVirtualDisplay` (Plan 2) and
 /// drives it with ScreenCaptureKit + CGEvent + AXUIElement.
 pub struct MacosPlatform {
-    /// Logs drained by `drain_logs`, filled by the per-stream readers once `start_app`
-    /// exists (Plan 2). Empty until then.
-    logs: Vec<(Stream, String)>,
+    /// Logs drained by `drain_logs`, filled by `process::spawn`'s per-stream reader
+    /// threads once `start_app` exists (Plan 2). `Arc<Mutex<_>>` because those threads
+    /// push into it concurrently with `drain_logs` reading it here. Empty until
+    /// `start_app` launches a child.
+    logs: LogSink,
     /// The launched app's root pid; `None` until `start_app`.
     app_pid: Option<u32>,
 }
@@ -25,7 +30,7 @@ impl MacosPlatform {
     /// Construct the backend, failing fast if a required TCC grant is missing.
     pub fn new() -> Result<Self> {
         permissions::preflight()?;
-        Ok(Self { logs: Vec::new(), app_pid: None })
+        Ok(Self { logs: Arc::new(Mutex::new(Vec::new())), app_pid: None })
     }
 }
 
@@ -55,7 +60,7 @@ impl Platform for MacosPlatform {
         unimplemented!("Plan 4: raise + focus + activate")
     }
     fn drain_logs(&mut self) -> Vec<(Stream, String)> {
-        std::mem::take(&mut self.logs)
+        std::mem::take(&mut *self.logs.lock().expect("log buffer mutex"))
     }
     fn app_pid(&self) -> Option<u32> {
         self.app_pid
@@ -70,14 +75,17 @@ mod tests {
     fn drain_logs_takes_then_empties() {
         // Build without preflight (which would require grants) by constructing the struct
         // directly — `new()` is exercised in the Mac-gated suite.
-        let mut p = MacosPlatform { logs: vec![(Stream::Stdout, "hi".into())], app_pid: Some(42) };
+        let mut p = MacosPlatform {
+            logs: Arc::new(Mutex::new(vec![(Stream::Stdout, "hi".into())])),
+            app_pid: Some(42),
+        };
         assert_eq!(p.drain_logs().len(), 1);
         assert!(p.drain_logs().is_empty());
     }
 
     #[test]
     fn app_pid_returns_the_constructed_value() {
-        let p = MacosPlatform { logs: Vec::new(), app_pid: Some(42) };
+        let p = MacosPlatform { logs: Arc::new(Mutex::new(Vec::new())), app_pid: Some(42) };
         assert_eq!(p.app_pid(), Some(42));
     }
 

--- a/crates/glass-macos/src/capture.rs
+++ b/crates/glass-macos/src/capture.rs
@@ -1,0 +1,268 @@
+//! ScreenCaptureKit per-window capture → RGBA8 `Frame`.
+//!
+//! Re-resolves the target window fresh on every call — a `Retained<SCWindow>` can't be
+//! held across calls or across the completion-handler's thread boundary (see
+//! `scwindow.rs`'s module doc) — via the nested async flow proven end-to-end in the objc2
+//! spike (`.superpowers/sdd/objc2-spike-report.md` Part A):
+//! `SCShareableContent` → [`crate::scwindow::find_on_screen_window`] →
+//! `SCContentFilter::initWithDesktopIndependentWindow` → `SCStreamConfiguration` →
+//! `SCScreenshotManager::captureImageWithFilter_configuration_completionHandler` →
+//! `CGImage`, drawn into a tightly-packed RGBA8 bitmap context inside the innermost
+//! completion block. Per `ffi.rs`'s async-bridge convention, only plain owned/`Send` data
+//! (the finished [`Frame`]) ever crosses back out of a completion handler — never a
+//! `Retained<_>`/`CGImage` pointer.
+
+use std::sync::mpsc;
+use std::time::Duration;
+
+use block2::RcBlock;
+use objc2::AnyThread;
+use objc2_core_foundation::{CGPoint, CGRect, CGSize};
+use objc2_core_graphics::{
+    CGBitmapContextCreate, CGColorSpace, CGContext, CGImage, CGImageAlphaInfo,
+};
+use objc2_foundation::NSError;
+use objc2_screen_capture_kit::{
+    SCContentFilter, SCScreenshotManager, SCShareableContent, SCStreamConfiguration,
+};
+
+use glass_core::frame::{Frame, Region};
+use glass_core::{GlassError, Result};
+
+use crate::permissions::Permission;
+use crate::scwindow::find_on_screen_window;
+
+/// Max wait for one capture round trip (`SCShareableContent` + `SCScreenshotManager`
+/// both completing). Generous relative to the spike's sub-second observations — this
+/// covers a wedged completion handler, not normal latency.
+const CAPTURE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// `SCStreamErrorDomain`'s code for a declined Screen Recording TCC grant — observed
+/// verbatim in the spike's TCC-declined run (`.superpowers/sdd/objc2-spike-report.md`).
+const TCC_DECLINE_CODE: isize = -3801;
+
+/// Capture the first on-screen window owned by one of `pids` as an RGBA8 [`Frame`],
+/// optionally cropped to a window-relative `region`. Returns
+/// [`GlassError::WindowNotFound`] if no on-screen window is owned by `pids`,
+/// [`GlassError::PermissionDenied`] on a Screen Recording TCC decline, or
+/// [`GlassError::CaptureFailed`] for any other ScreenCaptureKit failure.
+// Not yet called: `MacosPlatform::capture_frame` still `unimplemented!()` until a later
+// task wires `start_app`/`capture_frame` to `process::spawn` + this function. Kept
+// `pub(crate)` + allowed here rather than deleted, mirroring `ffi.rs`'s `app_kit_init`
+// and `scwindow.rs`'s `find_window_for_pids` convention, so the capture logic lands in
+// one place instead of being reintroduced per call site.
+#[allow(dead_code)]
+pub(crate) fn capture_window(pids: &[i32], region: Option<&Region>) -> Result<Frame> {
+    crate::ffi::app_kit_init();
+
+    let (tx, rx) = mpsc::channel::<CaptureReply>();
+    let pids_owned: Vec<i32> = pids.to_vec();
+    let region_owned = region.copied();
+
+    let content_block = RcBlock::new(
+        move |content_ptr: *mut SCShareableContent, err_ptr: *mut NSError| {
+            if content_ptr.is_null() {
+                let err = classify_null_result(
+                    err_ptr,
+                    "SCShareableContent completion handler returned null content and null error",
+                );
+                let _ = tx.send(CaptureReply::Err(err));
+                return;
+            }
+            // SAFETY: `content_ptr` was just checked non-null; the framework guarantees
+            // it points to a live `SCShareableContent` for the duration of this callback.
+            let content: &SCShareableContent = unsafe { &*content_ptr };
+
+            let Some((window, _pid)) = find_on_screen_window(content, &pids_owned) else {
+                let _ = tx.send(CaptureReply::Err(GlassError::WindowNotFound));
+                return;
+            };
+
+            // SAFETY: `window` is a live `SCWindow` just resolved above;
+            // `initWithDesktopIndependentWindow:` has no other preconditions.
+            let filter = unsafe {
+                SCContentFilter::initWithDesktopIndependentWindow(
+                    SCContentFilter::alloc(),
+                    &window,
+                )
+            };
+            // SAFETY: plain no-arg initializer; no preconditions.
+            let config = unsafe { SCStreamConfiguration::new() };
+            // SAFETY: plain property getters on the freshly constructed `filter`.
+            let (scale, content_rect) =
+                unsafe { (filter.pointPixelScale() as f64, filter.contentRect()) };
+            let width = ((content_rect.size.width * scale) as usize).max(1);
+            let height = ((content_rect.size.height * scale) as usize).max(1);
+            // SAFETY: plain property setters on the freshly constructed, uniquely-owned
+            // `config`; no other preconditions.
+            unsafe {
+                config.setWidth(width);
+                config.setHeight(height);
+                config.setShowsCursor(false);
+            }
+
+            let tx_img = tx.clone();
+            let image_block =
+                RcBlock::new(move |image_ptr: *mut CGImage, err_ptr: *mut NSError| {
+                    if image_ptr.is_null() {
+                        let err = classify_null_result(
+                            err_ptr,
+                            "SCScreenshotManager.captureImage returned null image and null error",
+                        );
+                        let _ = tx_img.send(CaptureReply::Err(err));
+                        return;
+                    }
+                    // SAFETY: `image_ptr` was just checked non-null; the framework
+                    // guarantees it points to a live `CGImage` for the duration of this
+                    // callback. All work on it happens synchronously right here — the
+                    // `CGImage` itself never leaves this block.
+                    let image: &CGImage = unsafe { &*image_ptr };
+                    let result = rgba_frame_from_cgimage(image)
+                        .and_then(|frame| crop_to_region(frame, region_owned.as_ref()));
+                    let _ = tx_img.send(match result {
+                        Ok(frame) => CaptureReply::Ok(frame),
+                        Err(e) => CaptureReply::Err(e),
+                    });
+                });
+
+            // SAFETY: `image_block` matches
+            // `captureImageWithFilter:configuration:completionHandler:`'s documented
+            // signature (`*mut CGImage, *mut NSError`, per the generated binding) — the
+            // exact sequence the spike proved end-to-end. The call itself has no other
+            // preconditions.
+            unsafe {
+                SCScreenshotManager::captureImageWithFilter_configuration_completionHandler(
+                    &filter,
+                    &config,
+                    Some(&image_block),
+                );
+            }
+        },
+    );
+
+    // SAFETY: `content_block` matches
+    // `getShareableContentExcludingDesktopWindows:onScreenWindowsOnly:completionHandler:`'s
+    // documented signature (`*mut SCShareableContent, *mut NSError`) — the same call
+    // `scwindow.rs`'s `query_once` proved. The call itself has no other preconditions.
+    unsafe {
+        SCShareableContent::getShareableContentExcludingDesktopWindows_onScreenWindowsOnly_completionHandler(
+            true, true, &content_block,
+        );
+    }
+
+    match rx.recv_timeout(CAPTURE_TIMEOUT) {
+        Ok(CaptureReply::Ok(frame)) => Ok(frame),
+        Ok(CaptureReply::Err(e)) => Err(e),
+        Err(mpsc::RecvTimeoutError::Timeout) => Err(GlassError::CaptureFailed(
+            "ScreenCaptureKit capture timed out waiting for the completion handler".into(),
+        )),
+        Err(mpsc::RecvTimeoutError::Disconnected) => Err(GlassError::Backend(
+            "ScreenCaptureKit completion handler was dropped without replying".into(),
+        )),
+    }
+}
+
+/// A capture round trip's outcome, funneled out of the innermost completion block as
+/// plain owned data (per `ffi.rs`'s async-bridge convention: never a `Retained<T>`/raw
+/// objc2 object — the finished `Frame`'s bytes are built entirely inside the callback).
+enum CaptureReply {
+    Ok(Frame),
+    Err(GlassError),
+}
+
+/// Crop `frame` to `region` (window-relative), clamping the region to the captured frame
+/// first via [`crate::coords::clamp_region`] (defense in depth — the session layer should
+/// already validate the region against the window before it reaches the backend, per
+/// `glass_core::frame::Region::check_fits`'s doc). `None` returns `frame` unchanged.
+fn crop_to_region(frame: Frame, region: Option<&Region>) -> Result<Frame> {
+    let Some(r) = region else { return Ok(frame) };
+    let clamped = crate::coords::clamp_region(
+        r.x as i32,
+        r.y as i32,
+        r.width,
+        r.height,
+        frame.width,
+        frame.height,
+    );
+    frame.crop(&clamped)
+}
+
+/// Draw a captured `CGImage` into a tightly-packed RGBA8 (premultiplied-last, host byte
+/// order) bitmap context and hand back the raw bytes as a [`Frame`] — the spike's
+/// `analyze_and_write` bitmap path, minus the luma-sampling/PNG-writing (capture only
+/// needs the pixels). `CGContextDrawImage`'s internal colorspace conversion means this
+/// yields tightly-packed RGBA bytes directly regardless of the source image's own pixel
+/// format (BGRA for SDR captures, per `SCScreenshotManager`'s docs) — no separate swizzle
+/// needed.
+fn rgba_frame_from_cgimage(image: &CGImage) -> Result<Frame> {
+    let w = CGImage::width(Some(image));
+    let h = CGImage::height(Some(image));
+    if w == 0 || h == 0 {
+        return Err(GlassError::CaptureFailed(format!(
+            "captured image has zero dimensions ({w}x{h})"
+        )));
+    }
+
+    let bytes_per_row = w * 4;
+    let mut buf = vec![0u8; bytes_per_row * h];
+    let color_space = CGColorSpace::new_device_rgb()
+        .ok_or_else(|| GlassError::CaptureFailed("CGColorSpaceCreateDeviceRGB failed".into()))?;
+    // kCGImageAlphaPremultipliedLast, host byte order (0) — matches the spike's proven
+    // config (glass never depends on the alpha channel; opaque windows read back 255).
+    let bitmap_info = CGImageAlphaInfo::PremultipliedLast.0;
+    // SAFETY: `buf` is a valid, uniquely-owned `bytes_per_row * h`-byte buffer, sized
+    // exactly for `w`/`h`/`bytes_per_row`; `CGBitmapContextCreate` writes directly into
+    // it rather than copying, so `buf` holds the drawn pixels once `draw_image` returns
+    // below. `buf` is Rust-owned heap memory, not freed by `ctx`'s `CFRelease` — its
+    // validity doesn't depend on `ctx`'s lifetime. `color_space` is a live `CGColorSpace`.
+    let ctx = unsafe {
+        CGBitmapContextCreate(
+            buf.as_mut_ptr() as *mut _,
+            w,
+            h,
+            8,
+            bytes_per_row,
+            Some(&color_space),
+            bitmap_info,
+        )
+    }
+    .ok_or_else(|| GlassError::CaptureFailed("CGBitmapContextCreate failed".into()))?;
+
+    let rect = CGRect {
+        origin: CGPoint { x: 0.0, y: 0.0 },
+        size: CGSize { width: w as f64, height: h as f64 },
+    };
+    CGContext::draw_image(Some(&ctx), rect, Some(image));
+
+    Frame::new(w as u32, h as u32, buf)
+}
+
+/// Classify a `null` ScreenCaptureKit result's paired `NSError`: [`GlassError::PermissionDenied`]
+/// for a Screen Recording TCC decline (domain `SCStreamErrorDomain`, code `-3801`, and/or
+/// a "declined" description — the spike observed all three together, but any one is
+/// treated as authoritative since Apple doesn't document which fields are stable across
+/// OS versions), [`GlassError::CaptureFailed`] otherwise. `fallback_msg` covers the
+/// (framework-contract-violating, but defensively handled) case where both the result and
+/// the error came back null.
+fn classify_null_result(err_ptr: *mut NSError, fallback_msg: &str) -> GlassError {
+    if err_ptr.is_null() {
+        return GlassError::CaptureFailed(fallback_msg.to_string());
+    }
+    // SAFETY: the framework guarantees a non-null, valid `NSError` whenever it hands back
+    // a null content/image — proven in the spike's TCC-declined run (see `scwindow.rs`'s
+    // identical precondition).
+    let err: &NSError = unsafe { &*err_ptr };
+    let domain = err.domain().to_string();
+    let code = err.code();
+    let description = err.localizedDescription().to_string();
+    let detail = format!("{domain} (code {code}): {description}");
+
+    let is_tcc_decline = domain.contains("SCStreamErrorDomain")
+        || code == TCC_DECLINE_CODE
+        || description.to_lowercase().contains("declined");
+    if is_tcc_decline {
+        Permission::ScreenRecording.denied_with_detail(detail)
+    } else {
+        GlassError::CaptureFailed(detail)
+    }
+}

--- a/crates/glass-macos/src/capture.rs
+++ b/crates/glass-macos/src/capture.rs
@@ -29,7 +29,6 @@ use objc2_screen_capture_kit::{
 use glass_core::frame::{Frame, Region};
 use glass_core::{GlassError, Result};
 
-use crate::permissions::Permission;
 use crate::scwindow::find_on_screen_window;
 
 /// Max wait for one capture round trip (`SCShareableContent` + `SCScreenshotManager`
@@ -37,21 +36,11 @@ use crate::scwindow::find_on_screen_window;
 /// covers a wedged completion handler, not normal latency.
 const CAPTURE_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// `SCStreamErrorDomain`'s code for a declined Screen Recording TCC grant — observed
-/// verbatim in the spike's TCC-declined run (`.superpowers/sdd/objc2-spike-report.md`).
-const TCC_DECLINE_CODE: isize = -3801;
-
 /// Capture the first on-screen window owned by one of `pids` as an RGBA8 [`Frame`],
 /// optionally cropped to a window-relative `region`. Returns
 /// [`GlassError::WindowNotFound`] if no on-screen window is owned by `pids`,
 /// [`GlassError::PermissionDenied`] on a Screen Recording TCC decline, or
 /// [`GlassError::CaptureFailed`] for any other ScreenCaptureKit failure.
-// Not yet called: `MacosPlatform::capture_frame` still `unimplemented!()` until a later
-// task wires `start_app`/`capture_frame` to `process::spawn` + this function. Kept
-// `pub(crate)` + allowed here rather than deleted, mirroring `ffi.rs`'s `app_kit_init`
-// and `scwindow.rs`'s `find_window_for_pids` convention, so the capture logic lands in
-// one place instead of being reintroduced per call site.
-#[allow(dead_code)]
 pub(crate) fn capture_window(pids: &[i32], region: Option<&Region>) -> Result<Frame> {
     crate::ffi::app_kit_init();
 
@@ -62,7 +51,7 @@ pub(crate) fn capture_window(pids: &[i32], region: Option<&Region>) -> Result<Fr
     let content_block = RcBlock::new(
         move |content_ptr: *mut SCShareableContent, err_ptr: *mut NSError| {
             if content_ptr.is_null() {
-                let err = classify_null_result(
+                let err = crate::ffi::classify_null_result(
                     err_ptr,
                     "SCShareableContent completion handler returned null content and null error",
                 );
@@ -91,8 +80,15 @@ pub(crate) fn capture_window(pids: &[i32], region: Option<&Region>) -> Result<Fr
             // SAFETY: plain property getters on the freshly constructed `filter`.
             let (scale, content_rect) =
                 unsafe { (filter.pointPixelScale() as f64, filter.contentRect()) };
-            let width = ((content_rect.size.width * scale) as usize).max(1);
-            let height = ((content_rect.size.height * scale) as usize).max(1);
+            if content_rect.size.width <= 0.0 || content_rect.size.height <= 0.0 {
+                let _ = tx.send(CaptureReply::Err(GlassError::CaptureFailed(format!(
+                    "window content rect is degenerate ({}x{} pts)",
+                    content_rect.size.width, content_rect.size.height
+                ))));
+                return;
+            }
+            let width = (content_rect.size.width * scale) as usize;
+            let height = (content_rect.size.height * scale) as usize;
             // SAFETY: plain property setters on the freshly constructed, uniquely-owned
             // `config`; no other preconditions.
             unsafe {
@@ -105,7 +101,7 @@ pub(crate) fn capture_window(pids: &[i32], region: Option<&Region>) -> Result<Fr
             let image_block =
                 RcBlock::new(move |image_ptr: *mut CGImage, err_ptr: *mut NSError| {
                     if image_ptr.is_null() {
-                        let err = classify_null_result(
+                        let err = crate::ffi::classify_null_result(
                             err_ptr,
                             "SCScreenshotManager.captureImage returned null image and null error",
                         );
@@ -117,8 +113,16 @@ pub(crate) fn capture_window(pids: &[i32], region: Option<&Region>) -> Result<Fr
                     // callback. All work on it happens synchronously right here — the
                     // `CGImage` itself never leaves this block.
                     let image: &CGImage = unsafe { &*image_ptr };
+                    // NOTE: `Frame` is captured in backing PIXELS (`contentRect.size *
+                    // pointPixelScale`, this same `scale`), while `region` is
+                    // window-relative POINTS — the unit the session layer validates it in
+                    // (`WindowGeometry`, from `SCWindow.frame()`; see `scwindow.rs`).
+                    // `crop_to_region` converts it to pixels via `scale` before cropping
+                    // the pixel-space `Frame`. The wider points-vs-pixels reconciliation
+                    // across geometry/frame/click (the other backends use physical pixels
+                    // throughout) is a later coordinate-design item, not solved here.
                     let result = rgba_frame_from_cgimage(image)
-                        .and_then(|frame| crop_to_region(frame, region_owned.as_ref()));
+                        .and_then(|frame| crop_to_region(frame, region_owned.as_ref(), scale));
                     let _ = tx_img.send(match result {
                         Ok(frame) => CaptureReply::Ok(frame),
                         Err(e) => CaptureReply::Err(e),
@@ -170,17 +174,21 @@ enum CaptureReply {
     Err(GlassError),
 }
 
-/// Crop `frame` to `region` (window-relative), clamping the region to the captured frame
-/// first via [`crate::coords::clamp_region`] (defense in depth — the session layer should
-/// already validate the region against the window before it reaches the backend, per
-/// `glass_core::frame::Region::check_fits`'s doc). `None` returns `frame` unchanged.
-fn crop_to_region(frame: Frame, region: Option<&Region>) -> Result<Frame> {
+/// Crop `frame` to `region`, clamping to the captured frame first via
+/// [`crate::coords::clamp_region`] (defense in depth — the session layer should already
+/// validate the region against the window before it reaches the backend, per
+/// `glass_core::frame::Region::check_fits`'s doc). `region` is window-relative POINTS (see
+/// the NOTE at the call site above); `scale` (`pointPixelScale`) converts it to the PIXELS
+/// `frame` itself is in, via [`crate::coords::scale_region`], before clamping/cropping.
+/// `None` returns `frame` unchanged (no scaling needed for a no-op).
+fn crop_to_region(frame: Frame, region: Option<&Region>, scale: f64) -> Result<Frame> {
     let Some(r) = region else { return Ok(frame) };
+    let pixel_region = crate::coords::scale_region(r, scale);
     let clamped = crate::coords::clamp_region(
-        r.x as i32,
-        r.y as i32,
-        r.width,
-        r.height,
+        pixel_region.x as i32,
+        pixel_region.y as i32,
+        pixel_region.width,
+        pixel_region.height,
         frame.width,
         frame.height,
     );
@@ -235,36 +243,6 @@ fn rgba_frame_from_cgimage(image: &CGImage) -> Result<Frame> {
     CGContext::draw_image(Some(&ctx), rect, Some(image));
 
     Frame::new(w as u32, h as u32, buf)
-}
-
-/// Classify a `null` ScreenCaptureKit result's paired `NSError`: [`GlassError::PermissionDenied`]
-/// for a Screen Recording TCC decline (domain `SCStreamErrorDomain`, code `-3801`, and/or
-/// a "declined" description — the spike observed all three together, but any one is
-/// treated as authoritative since Apple doesn't document which fields are stable across
-/// OS versions), [`GlassError::CaptureFailed`] otherwise. `fallback_msg` covers the
-/// (framework-contract-violating, but defensively handled) case where both the result and
-/// the error came back null.
-fn classify_null_result(err_ptr: *mut NSError, fallback_msg: &str) -> GlassError {
-    if err_ptr.is_null() {
-        return GlassError::CaptureFailed(fallback_msg.to_string());
-    }
-    // SAFETY: the framework guarantees a non-null, valid `NSError` whenever it hands back
-    // a null content/image — proven in the spike's TCC-declined run (see `scwindow.rs`'s
-    // identical precondition).
-    let err: &NSError = unsafe { &*err_ptr };
-    let domain = err.domain().to_string();
-    let code = err.code();
-    let description = err.localizedDescription().to_string();
-    let detail = format!("{domain} (code {code}): {description}");
-
-    let is_tcc_decline = domain.contains("SCStreamErrorDomain")
-        || code == TCC_DECLINE_CODE
-        || description.to_lowercase().contains("declined");
-    if is_tcc_decline {
-        Permission::ScreenRecording.denied_with_detail(detail)
-    } else {
-        GlassError::CaptureFailed(detail)
-    }
 }
 
 #[cfg(test)]

--- a/crates/glass-macos/src/capture.rs
+++ b/crates/glass-macos/src/capture.rs
@@ -266,3 +266,14 @@ fn classify_null_result(err_ptr: *mut NSError, fallback_msg: &str) -> GlassError
         GlassError::CaptureFailed(detail)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capture_reply_is_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<CaptureReply>();
+    }
+}

--- a/crates/glass-macos/src/coords.rs
+++ b/crates/glass-macos/src/coords.rs
@@ -30,6 +30,33 @@ pub fn clamp_region(rx: i32, ry: i32, rw: u32, rh: u32, width: u32, height: u32)
     Region { x: left as u32, y: top as u32, width: (right - left) as u32, height: (bottom - top) as u32 }
 }
 
+/// Convert a window-relative `region` from POINTS to backing PIXELS by scaling every field
+/// by `scale` (macOS's `pointPixelScale`: `1.0` on a 1x display, `2.0` on 2x Retina).
+///
+/// The macOS capture backend needs this because its two coordinate sources disagree:
+/// `capture::capture_window`'s `Frame` is sized in backing pixels
+/// (`contentRect.size * pointPixelScale`), but the `region` passed to it is window-relative
+/// points — the unit `WindowGeometry` (from `SCWindow.frame()`) and the session layer's
+/// region validation both use. Cropping a points-sized region straight against a
+/// pixels-sized `Frame` silently reads the wrong (quarter-sized, on 2x) sub-image. Pure and
+/// cross-platform so the Retina (2x) math is unit-tested here even on a 1x dev box; the
+/// wider points-vs-pixels reconciliation across geometry/frame/click (the other backends
+/// use physical pixels throughout) is a later coordinate-design item, not solved by this
+/// one conversion.
+///
+/// Each field rounds to the nearest pixel independently (`f64::round`, ties away from
+/// zero) rather than truncating, so a fractional point value doesn't consistently lose a
+/// pixel versus the frame it's cropped against.
+pub fn scale_region(region: &Region, scale: f64) -> Region {
+    let scaled = |v: u32| (v as f64 * scale).round() as u32;
+    Region {
+        x: scaled(region.x),
+        y: scaled(region.y),
+        width: scaled(region.width),
+        height: scaled(region.height),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -65,5 +92,25 @@ mod tests {
         assert_eq!(clamp_region(-50, 0, 100, 50, 640, 480), Region { x: 0, y: 0, width: 50, height: 50 });
         // fully outside on the top → zero height
         assert_eq!(clamp_region(0, -100, 50, 50, 640, 480), Region { x: 0, y: 0, width: 50, height: 0 });
+    }
+
+    #[test]
+    fn scale_region_is_identity_at_1x() {
+        let region = Region { x: 10, y: 20, width: 300, height: 200 };
+        assert_eq!(scale_region(&region, 1.0), region);
+    }
+
+    #[test]
+    fn scale_region_doubles_at_2x_retina() {
+        let region = Region { x: 10, y: 20, width: 300, height: 200 };
+        assert_eq!(scale_region(&region, 2.0), Region { x: 20, y: 40, width: 600, height: 400 });
+    }
+
+    #[test]
+    fn scale_region_rounds_to_nearest_pixel() {
+        // 1*1.5=1.5 -> 2, 3*1.5=4.5 -> 5 (round-half-away-from-zero, per f64::round):
+        // fields round independently rather than truncating.
+        let region = Region { x: 1, y: 1, width: 3, height: 3 };
+        assert_eq!(scale_region(&region, 1.5), Region { x: 2, y: 2, width: 5, height: 5 });
     }
 }

--- a/crates/glass-macos/src/ffi.rs
+++ b/crates/glass-macos/src/ffi.rs
@@ -55,8 +55,17 @@ use std::sync::Once;
 
 use objc2::MainThreadMarker;
 use objc2_app_kit::NSApplication;
+use objc2_foundation::NSError;
+
+use glass_core::GlassError;
+
+use crate::permissions::Permission;
 
 static APP_KIT_INIT: Once = Once::new();
+
+/// `SCStreamErrorDomain`'s code for a declined Screen Recording TCC grant — observed
+/// verbatim in the spike's TCC-declined run (`.superpowers/sdd/objc2-spike-report.md`).
+const TCC_DECLINE_CODE: isize = -3801;
 
 /// Touch `NSApplication.shared` exactly once to establish this process's connection to
 /// the window server. Without it, ScreenCaptureKit/CoreGraphics calls from a bare CLI
@@ -69,19 +78,48 @@ static APP_KIT_INIT: Once = Once::new();
 /// correct one, from the real main thread — would then panic too with "Once instance
 /// has previously been poisoned"). Checking first means a single off-thread misuse
 /// can't permanently wedge the one-time init for the rest of the process.
-// Called by `scwindow::find_window_for_pids` before the first `SCShareableContent`
-// query; later capture/provisioning call sites (Plan 2's remaining steps) will call it
-// too — safe and cheap to call redundantly, since only the first call does anything.
-// `find_window_for_pids` itself isn't wired into `MacosPlatform::start_app` yet (a later
-// task's job), so this function isn't reachable from any true crate root either; kept
-// `#[allow(dead_code)]` (harmless now that it has a real caller) rather than deleted so
-// the Once and its doc stay in one place instead of being reintroduced per call site.
-#[allow(dead_code)]
+/// Called by `backend.rs`'s `discover_window` (before `start_app`'s window-discovery poll
+/// loop) and by `capture::capture_window` (before every capture) — safe and cheap to call
+/// redundantly, since only the first call does anything.
 pub(crate) fn app_kit_init() {
     let mtm = MainThreadMarker::new().expect("app_kit_init must run on the main thread");
     APP_KIT_INIT.call_once(|| {
         let _app = NSApplication::sharedApplication(mtm);
     });
+}
+
+/// Classify a `null` async ScreenCaptureKit result's paired `NSError`:
+/// [`GlassError::PermissionDenied`] for a Screen Recording TCC decline (domain
+/// `SCStreamErrorDomain`, code `-3801`, and/or a "declined" description — the spike
+/// observed all three together, but any one is treated as authoritative since Apple
+/// doesn't document which fields are stable across OS versions), [`GlassError::CaptureFailed`]
+/// otherwise. `fallback_msg` covers the (framework-contract-violating, but defensively
+/// handled) case where both the result and the error came back null.
+///
+/// Shared by every completion handler in this crate that can hand back a null result —
+/// `scwindow.rs`'s discovery query and `capture.rs`'s content/image queries — per this
+/// module's async-bridge convention, so a TCC decline is classified identically everywhere
+/// instead of each call site rolling its own (partial) version of this check.
+pub(crate) fn classify_null_result(err_ptr: *mut NSError, fallback_msg: &str) -> GlassError {
+    if err_ptr.is_null() {
+        return GlassError::CaptureFailed(fallback_msg.to_string());
+    }
+    // SAFETY: the framework guarantees a non-null, valid `NSError` whenever it hands back
+    // a null content/image — proven in the spike's TCC-declined run.
+    let err: &NSError = unsafe { &*err_ptr };
+    let domain = err.domain().to_string();
+    let code = err.code();
+    let description = err.localizedDescription().to_string();
+    let detail = format!("{domain} (code {code}): {description}");
+
+    let is_tcc_decline = domain.contains("SCStreamErrorDomain")
+        || code == TCC_DECLINE_CODE
+        || description.to_lowercase().contains("declined");
+    if is_tcc_decline {
+        Permission::ScreenRecording.denied_with_detail(detail)
+    } else {
+        GlassError::CaptureFailed(detail)
+    }
 }
 
 #[cfg(test)]

--- a/crates/glass-macos/src/ffi.rs
+++ b/crates/glass-macos/src/ffi.rs
@@ -1,0 +1,97 @@
+//! objc2 FFI helpers shared across the macOS backend: one-time AppKit init, plus the
+//! documented convention every later call site follows for bridging an async ObjC
+//! completion-handler back into synchronous Rust.
+//!
+//! ## The reusable pattern: async completion-handler → channel bridge
+//!
+//! Proven end-to-end in `.superpowers/sdd/objc2-spike-report.md` against
+//! ScreenCaptureKit's nested `SCShareableContent` → `SCScreenshotManager` completion
+//! handlers. The concrete `block2::RcBlock`s live at each call site (capture, display
+//! provisioning, etc. — Plan 2 tasks 2+), not here; this is the recipe they all follow:
+//!
+//! 1. Build the block with `block2::RcBlock::new(move |raw_ptr_args...| { ... })`, typed
+//!    exactly to match the generated binding's completion-handler signature (check each
+//!    API individually — some use raw `*mut T` args, others `Option<NonNull<T>>`; they
+//!    are not consistent, so read the generated source rather than assume).
+//! 2. Pass `&the_rc_block` directly where a `&block2::DynBlock<dyn Fn(...)>` parameter is
+//!    expected — `RcBlock<F>` `Deref`s to `Block<F>` (aka `DynBlock<F>`), no cast needed.
+//! 3. Inside the closure, do all the ObjC-object work synchronously (dereference the raw
+//!    pointer via `unsafe { &*ptr }`, call further async APIs and nest another block if
+//!    needed) and only cross back out of the callback with **plain owned/`Send` data**
+//!    (primitives, `String`, an enum of them) over a `std::sync::mpsc::channel`. Never
+//!    send a `Retained<T>`/raw objc2 object across the channel — build the final answer
+//!    entirely inside the last nested callback instead.
+//! 4. Block on `rx.recv_timeout(...)` on the calling thread. The completion handler runs
+//!    on whatever queue the framework was told to use (or a GCD default) — it does not
+//!    require the caller to be pumping a run loop.
+//!
+//! ## Gotchas carried forward from the spike (keep in mind at every call site)
+//!
+//! - `use objc2::AnyThread;` must be in scope for `ClassType::alloc()` on
+//!   any-thread-usable classes — otherwise the compiler reports "no associated function
+//!   `alloc`" even though the trait method is right there (it's a trait method, and the
+//!   trait isn't imported by default).
+//! - `NSArray<T>::iter()` yields owned `Retained<T>`, not `&T` — each element is a fresh
+//!   strong reference, safe to move out of the loop; calling `.retain()` on the item is a
+//!   type error (that's `objc2::Message`'s associated fn, not a `Retained<T>` method).
+//! - Several `objc2-core-graphics` free functions are deprecated in favor of associated
+//!   functions taking `Option<&Self>` as an explicit first argument, not true `&self`
+//!   methods: `CGColorSpaceCreateDeviceRGB()` → `CGColorSpace::new_device_rgb()`,
+//!   `CGContextDrawImage(ctx, rect, img)` → `CGContext::draw_image(ctx, rect, img)`,
+//!   `CGImageGetWidth(img)` → `CGImage::width(Some(img))`.
+//! - `CGBitmapContextCreate` (the classic, non-"Adaptive" constructor) is hand-written at
+//!   the `objc2-core-graphics` crate root, not under its `src/generated/` tree — easy to
+//!   miss if you only grep `generated/`.
+//! - `MainThreadMarker::new()` returns `Option<Self>` (`None` off the main thread) — the
+//!   static-checked idiom `objc2-app-kit`'s main-thread-only APIs expect
+//!   (`NSApplication::sharedApplication(mtm)` takes it directly); prefer it over an ad
+//!   hoc runtime assertion.
+//! - `msg_send!`'s return-type inference is automatic from the `let` binding's annotated
+//!   type (`Retained<T>` / `Option<Retained<T>>` / `bool` / a primitive) and the
+//!   selector's method family (`new`/`alloc`/`init`/`copy`) — no `msg_send_id!` needed
+//!   (deprecated in objc2 0.6).
+
+use std::sync::Once;
+
+use objc2::MainThreadMarker;
+use objc2_app_kit::NSApplication;
+
+static APP_KIT_INIT: Once = Once::new();
+
+/// Touch `NSApplication.shared` exactly once to establish this process's connection to
+/// the window server. Without it, ScreenCaptureKit/CoreGraphics calls from a bare CLI
+/// binary abort with `CGS_REQUIRE_INIT` (proven in the objc2 spike; see the module doc
+/// above). Must be called from the main thread; safe to call repeatedly — only the
+/// first call does anything.
+///
+/// The main-thread check runs *before* `call_once`, not inside its closure: a panic
+/// inside `Once::call_once` poisons the `Once` forever (every later call — even a
+/// correct one, from the real main thread — would then panic too with "Once instance
+/// has previously been poisoned"). Checking first means a single off-thread misuse
+/// can't permanently wedge the one-time init for the rest of the process.
+// Not yet called: Task 2 wires this into `MacosPlatform::start_app` before the first
+// capture/provisioning call. Kept `pub(crate)` + allowed here rather than deleted so the
+// Once and its doc land in one place instead of being reintroduced per call site.
+#[allow(dead_code)]
+pub(crate) fn app_kit_init() {
+    let mtm = MainThreadMarker::new().expect("app_kit_init must run on the main thread");
+    APP_KIT_INIT.call_once(|| {
+        let _app = NSApplication::sharedApplication(mtm);
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "must run on the main thread")]
+    fn app_kit_init_panics_off_the_main_thread() {
+        // libtest always runs each #[test] on a freshly spawned worker thread, never the
+        // process's real main thread, so `MainThreadMarker::new()` is `None` here — this
+        // exercises the off-main-thread guard rather than the real NSApplication touch.
+        // The real call only happens from Task 2's `MacosPlatform::start_app`, which
+        // glass always drives from the main thread.
+        app_kit_init();
+    }
+}

--- a/crates/glass-macos/src/ffi.rs
+++ b/crates/glass-macos/src/ffi.rs
@@ -69,9 +69,13 @@ static APP_KIT_INIT: Once = Once::new();
 /// correct one, from the real main thread — would then panic too with "Once instance
 /// has previously been poisoned"). Checking first means a single off-thread misuse
 /// can't permanently wedge the one-time init for the rest of the process.
-// Not yet called: Task 2 wires this into `MacosPlatform::start_app` before the first
-// capture/provisioning call. Kept `pub(crate)` + allowed here rather than deleted so the
-// Once and its doc land in one place instead of being reintroduced per call site.
+// Called by `scwindow::find_window_for_pids` before the first `SCShareableContent`
+// query; later capture/provisioning call sites (Plan 2's remaining steps) will call it
+// too — safe and cheap to call redundantly, since only the first call does anything.
+// `find_window_for_pids` itself isn't wired into `MacosPlatform::start_app` yet (a later
+// task's job), so this function isn't reachable from any true crate root either; kept
+// `#[allow(dead_code)]` (harmless now that it has a real caller) rather than deleted so
+// the Once and its doc stay in one place instead of being reintroduced per call site.
 #[allow(dead_code)]
 pub(crate) fn app_kit_init() {
     let mtm = MainThreadMarker::new().expect("app_kit_init must run on the main thread");

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -14,6 +14,8 @@ mod ffi;
 #[cfg(target_os = "macos")]
 mod permissions;
 #[cfg(target_os = "macos")]
+mod scwindow;
+#[cfg(target_os = "macos")]
 mod backend;
 #[cfg(target_os = "macos")]
 pub use backend::MacosPlatform;

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -18,6 +18,8 @@ mod scwindow;
 #[cfg(target_os = "macos")]
 mod capture;
 #[cfg(target_os = "macos")]
+mod process;
+#[cfg(target_os = "macos")]
 mod backend;
 #[cfg(target_os = "macos")]
 pub use backend::MacosPlatform;

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -10,6 +10,8 @@ pub mod coords; // pure window-relative <-> global math — cross-platform, host
 pub mod keymap; // pure ASCII -> (keycode, shift) US map — cross-platform, host-tested
 
 #[cfg(target_os = "macos")]
+mod ffi;
+#[cfg(target_os = "macos")]
 mod permissions;
 #[cfg(target_os = "macos")]
 mod backend;

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -16,6 +16,8 @@ mod permissions;
 #[cfg(target_os = "macos")]
 mod scwindow;
 #[cfg(target_os = "macos")]
+mod capture;
+#[cfg(target_os = "macos")]
 mod backend;
 #[cfg(target_os = "macos")]
 pub use backend::MacosPlatform;

--- a/crates/glass-macos/src/permissions.rs
+++ b/crates/glass-macos/src/permissions.rs
@@ -32,6 +32,19 @@ impl Permission {
     fn denied(self) -> glass_core::GlassError {
         glass_core::GlassError::PermissionDenied { which: self.label().into(), remedy: self.remedy().into() }
     }
+
+    /// Like [`Permission::denied`], but appends a caller-supplied diagnostic (e.g. the
+    /// raw `NSError` ScreenCaptureKit reported for a TCC decline) to the remedy text, so
+    /// the agent sees both the actionable fix and the underlying OS-reported reason.
+    /// `pub(crate)` (unlike `denied`) so other modules — e.g. `scwindow`'s
+    /// `SCShareableContent` preflight — can reuse this wording instead of hand-rolling
+    /// their own remedy string.
+    pub(crate) fn denied_with_detail(self, detail: impl std::fmt::Display) -> glass_core::GlassError {
+        glass_core::GlassError::PermissionDenied {
+            which: self.label().into(),
+            remedy: format!("{} (underlying error: {detail})", self.remedy()),
+        }
+    }
 }
 
 // Both are plain C functions; no objc2 needed for preflight.

--- a/crates/glass-macos/src/process.rs
+++ b/crates/glass-macos/src/process.rs
@@ -1,0 +1,200 @@
+//! App spawn, background log-piping, and terminate for the macOS backend.
+//!
+//! Mirrors `glass-x11`/`glass-wayland`'s `spawn`+`spawn_reader`+`LogSink` shape: a plain
+//! `std::process::Command` built from [`AppSpec`], stdout/stderr piped into a shared,
+//! `Arc<Mutex<_>>`-guarded log buffer via one reader thread per stream, so
+//! `MacosPlatform::drain_logs` can read it without blocking the readers. `terminate`
+//! mirrors `glass-proc-linux::reap`'s SIGTERM -> brief wait -> SIGKILL -> reap sequence,
+//! reimplemented here (rather than depending on that crate) because it is `/proc`-based
+//! and therefore Linux-only.
+//!
+//! Window discovery is a separate concern ([`crate::scwindow::find_window_for_pids`]);
+//! this module only owns the process lifecycle.
+
+use std::io::{BufRead, BufReader};
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use rustix::process::{kill_process, Pid, Signal};
+
+use glass_core::platform::{AppSpec, SandboxLevel};
+use glass_core::{GlassError, Result, Stream};
+
+/// Log lines captured by the per-stream reader threads spawned in [`spawn`], drained by
+/// `MacosPlatform::drain_logs`. `Arc<Mutex<_>>` (not a bare `Vec`) because the reader
+/// threads outlive `spawn`'s call and push into it concurrently with `drain_logs` reading
+/// it from the main thread — the same shape `glass-x11`/`glass-wayland` use.
+pub(crate) type LogSink = Arc<Mutex<Vec<(Stream, String)>>>;
+
+/// How long [`terminate`] waits after SIGTERM before escalating to SIGKILL. Short: a
+/// terminate call is already the "shut it down" path (`stop_app` or a failed launch's
+/// cleanup), not a place to make the caller wait for a slow shutdown handler.
+const TERMINATE_GRACE: Duration = Duration::from_millis(500);
+
+/// Spawn `spec.run` (with `spec.cwd`/`spec.env` applied) with stdout/stderr piped into
+/// `logs` via one reader thread per stream. Returns [`GlassError::AppNotStarted`] if the
+/// program can't be launched (e.g. not found, not executable).
+///
+/// macOS process containment (sandboxing) is not implemented yet: only
+/// [`SandboxLevel::Off`] is honored. `Default`/`Strict` return
+/// [`GlassError::Unsupported`] *before* launching anything — no silent downgrade to an
+/// unsandboxed run (the no-silent-fallback invariant).
+// Not yet called outside this module's tests: `MacosPlatform::start_app` wires this in
+// (Task 5). Kept `pub(crate)` + allowed here rather than deleted, mirroring
+// `scwindow.rs`'s `find_window_for_pids` and `capture.rs`'s `capture_window` convention,
+// so the spawn logic lands in one place instead of being reintroduced per call site.
+#[allow(dead_code)]
+pub(crate) fn spawn(spec: &AppSpec, logs: LogSink) -> Result<Child> {
+    if spec.sandbox != SandboxLevel::Off {
+        return Err(GlassError::Unsupported(
+            "macOS process containment is not implemented yet; use sandbox: off".into(),
+        ));
+    }
+
+    let mut cmd = Command::new(&spec.run[0]);
+    cmd.args(&spec.run[1..]);
+    if let Some(cwd) = &spec.cwd {
+        cmd.current_dir(cwd);
+    }
+    for (k, v) in &spec.env {
+        cmd.env(k, v);
+    }
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| GlassError::AppNotStarted(format!("spawn {:?}: {e}", spec.run)))?;
+
+    // `Stdio::piped()` guarantees these are `Some` immediately after a successful spawn.
+    let stdout = child.stdout.take().expect("stdout was piped");
+    let stderr = child.stderr.take().expect("stderr was piped");
+    spawn_reader(stdout, Stream::Stdout, logs.clone());
+    spawn_reader(stderr, Stream::Stderr, logs);
+
+    Ok(child)
+}
+
+/// Pipe a child stream's lines into the shared log sink on a background thread. Exits
+/// quietly (no error surfaced — this is a best-effort log tap, not the app's lifecycle)
+/// once the stream hits EOF (the child closed it, typically by exiting) or a read fails.
+fn spawn_reader<R: std::io::Read + Send + 'static>(reader: R, stream: Stream, sink: LogSink) {
+    std::thread::spawn(move || {
+        for line in BufReader::new(reader).lines() {
+            match line {
+                Ok(text) => sink.lock().expect("log sink mutex").push((stream, text)),
+                Err(_) => break,
+            }
+        }
+    });
+}
+
+/// Idempotently terminate `child`: SIGTERM, wait up to [`TERMINATE_GRACE`] for exit, then
+/// SIGKILL, then reap. Safe to call on an already-exited (or already-terminated) child —
+/// `try_wait` is checked first so a second call never re-signals a pid the kernel may have
+/// since recycled.
+// Not yet called outside this module's tests — `MacosPlatform::stop_app` (and
+// `start_app`'s failure-cleanup path) wire this in (Task 5). See `spawn`'s comment above.
+#[allow(dead_code)]
+pub(crate) fn terminate(child: &mut Child) {
+    if matches!(child.try_wait(), Ok(Some(_))) {
+        return;
+    }
+
+    let pid = Pid::from_child(child);
+    let _ = kill_process(pid, Signal::TERM);
+
+    let deadline = Instant::now() + TERMINATE_GRACE;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return,
+            Ok(None) if Instant::now() >= deadline => break,
+            Ok(None) => std::thread::sleep(Duration::from_millis(20)),
+            // `try_wait` failing is unexpected (the pid is ours) but not a reason to spin
+            // forever — fall through to the SIGKILL/reap below.
+            Err(_) => break,
+        }
+    }
+
+    let _ = child.kill(); // SIGKILL, tolerates an already-exited child.
+    let _ = child.wait(); // Reap so the child doesn't linger as a zombie.
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec(run: &[&str]) -> AppSpec {
+        AppSpec {
+            build: None,
+            run: run.iter().map(|s| s.to_string()).collect(),
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 1000,
+            sandbox: SandboxLevel::Off,
+            a11y: false,
+        }
+    }
+
+    fn empty_sink() -> LogSink {
+        Arc::new(Mutex::new(Vec::new()))
+    }
+
+    #[test]
+    fn non_off_sandbox_is_rejected_before_launch() {
+        for level in [SandboxLevel::Default, SandboxLevel::Strict] {
+            let mut s = spec(&["/bin/echo", "hi"]);
+            s.sandbox = level;
+            let err = spawn(&s, empty_sink()).expect_err("non-Off sandbox must be rejected");
+            assert!(
+                matches!(err, GlassError::Unsupported(_)),
+                "expected Unsupported, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn spawn_pipes_stdout_and_stderr_lines() {
+        let logs = empty_sink();
+        let mut child = spawn(&spec(&["/bin/sh", "-c", "echo out; echo err 1>&2"]), logs.clone())
+            .expect("spawn /bin/sh");
+        child.wait().expect("wait for /bin/sh to exit");
+        // The reader threads finish shortly after the child's fds close on exit; give them
+        // a moment rather than racing the drain against them.
+        std::thread::sleep(Duration::from_millis(100));
+
+        let lines = logs.lock().expect("log sink mutex").clone();
+        assert!(lines.contains(&(Stream::Stdout, "out".to_string())), "{lines:?}");
+        assert!(lines.contains(&(Stream::Stderr, "err".to_string())), "{lines:?}");
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn spawn_missing_program_returns_app_not_started() {
+        let err = spawn(&spec(&["/no/such/glass-test-binary"]), empty_sink())
+            .expect_err("missing program must fail to spawn");
+        assert!(matches!(err, GlassError::AppNotStarted(_)), "expected AppNotStarted, got {err:?}");
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn terminate_kills_a_long_running_child() {
+        let mut child = spawn(&spec(&["/bin/sleep", "100"]), empty_sink()).expect("spawn /bin/sleep");
+        terminate(&mut child);
+        let status = child.try_wait().expect("try_wait after terminate");
+        assert!(status.is_some(), "child should have exited after terminate");
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn terminate_is_idempotent_on_an_already_exited_child() {
+        let mut child = spawn(&spec(&["/bin/echo", "hi"]), empty_sink()).expect("spawn /bin/echo");
+        child.wait().expect("wait for /bin/echo to exit");
+        // Already reaped; terminate must not panic or hang.
+        terminate(&mut child);
+        terminate(&mut child);
+    }
+}

--- a/crates/glass-macos/src/process.rs
+++ b/crates/glass-macos/src/process.rs
@@ -40,11 +40,6 @@ const TERMINATE_GRACE: Duration = Duration::from_millis(500);
 /// [`SandboxLevel::Off`] is honored. `Default`/`Strict` return
 /// [`GlassError::Unsupported`] *before* launching anything — no silent downgrade to an
 /// unsandboxed run (the no-silent-fallback invariant).
-// Not yet called outside this module's tests: `MacosPlatform::start_app` wires this in
-// (Task 5). Kept `pub(crate)` + allowed here rather than deleted, mirroring
-// `scwindow.rs`'s `find_window_for_pids` and `capture.rs`'s `capture_window` convention,
-// so the spawn logic lands in one place instead of being reintroduced per call site.
-#[allow(dead_code)]
 pub(crate) fn spawn(spec: &AppSpec, logs: LogSink) -> Result<Child> {
     if spec.sandbox != SandboxLevel::Off {
         return Err(GlassError::Unsupported(
@@ -94,9 +89,6 @@ fn spawn_reader<R: std::io::Read + Send + 'static>(reader: R, stream: Stream, si
 /// SIGKILL, then reap. Safe to call on an already-exited (or already-terminated) child —
 /// `try_wait` is checked first so a second call never re-signals a pid the kernel may have
 /// since recycled.
-// Not yet called outside this module's tests — `MacosPlatform::stop_app` (and
-// `start_app`'s failure-cleanup path) wire this in (Task 5). See `spawn`'s comment above.
-#[allow(dead_code)]
 pub(crate) fn terminate(child: &mut Child) {
     if matches!(child.try_wait(), Ok(Some(_))) {
         return;

--- a/crates/glass-macos/src/scwindow.rs
+++ b/crates/glass-macos/src/scwindow.rs
@@ -242,4 +242,10 @@ mod tests {
             WindowGeometry { x: -50, y: -10, width: 100, height: 80 }
         );
     }
+
+    #[test]
+    fn query_reply_is_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<QueryReply>();
+    }
 }

--- a/crates/glass-macos/src/scwindow.rs
+++ b/crates/glass-macos/src/scwindow.rs
@@ -84,6 +84,42 @@ pub(crate) fn find_window_for_pids(pids: &[i32], timeout: Duration) -> Result<Wi
     outcome.value.ok_or(GlassError::Timeout(timeout_ms))
 }
 
+/// Find the first on-screen `SCWindow` in `content.windows()` owned by one of `pids`,
+/// returning it alongside its owning pid. Shared by [`query_once`] (which extracts a
+/// [`WindowMatch`] snapshot from the match, since the window itself can't survive the
+/// completion handler's thread boundary — see the module doc) and
+/// `capture::capture_window` (which needs the live `SCWindow` itself, still inside the
+/// same completion-handler callback, to build an `SCContentFilter` from it). Keeping the
+/// filter loop here means the two call sites can't drift apart on what "the target
+/// window" means.
+pub(crate) fn find_on_screen_window(
+    content: &SCShareableContent,
+    pids: &[i32],
+) -> Option<(Retained<SCWindow>, i32)> {
+    // SAFETY: `windows` is a plain getter on a live `SCShareableContent`; no other
+    // preconditions.
+    let windows: Retained<NSArray<SCWindow>> = unsafe { content.windows() };
+
+    for w in windows.iter() {
+        // SAFETY: `w` is a live `SCWindow` yielded by the array (`NSArray::iter` hands
+        // out a fresh, owned `Retained<SCWindow>` per element — see `ffi.rs`'s gotcha
+        // notes); this and the getters below have no preconditions beyond a valid
+        // receiver.
+        if !unsafe { w.isOnScreen() } {
+            continue;
+        }
+        // SAFETY: same as above — a plain property getter.
+        let owning_application = unsafe { w.owningApplication() };
+        let Some(app) = owning_application else { continue };
+        // SAFETY: same as above — a plain property getter.
+        let pid = unsafe { app.processID() };
+        if pids.contains(&pid) {
+            return Some((w, pid));
+        }
+    }
+    None
+}
+
 /// One `SCShareableContent` round trip via the `RcBlock` -> `mpsc` bridge (`ffi.rs`'s
 /// documented pattern): `Ok(Some(_))` on a match, `Ok(None)` if no matching on-screen
 /// window exists yet (the outer poll should retry), `Err` if `SCShareableContent` itself
@@ -113,38 +149,21 @@ fn query_once(pids: &[i32]) -> Result<Option<WindowMatch>> {
         // SAFETY: `content_ptr` was just checked non-null; the framework guarantees it
         // points to a live `SCShareableContent` for the duration of this callback.
         let content: &SCShareableContent = unsafe { &*content_ptr };
-        // SAFETY: `windows` is a plain getter on a live `SCShareableContent`; no other
-        // preconditions.
-        let windows: Retained<NSArray<SCWindow>> = unsafe { content.windows() };
 
-        for w in windows.iter() {
-            // SAFETY: `w` is a live `SCWindow` yielded by the array (`NSArray::iter`
-            // hands out a fresh, owned `Retained<SCWindow>` per element — see `ffi.rs`'s
-            // gotcha notes); this and the getters below have no preconditions beyond a
-            // valid receiver.
-            if !unsafe { w.isOnScreen() } {
-                continue;
-            }
-            // SAFETY: same as above — a plain property getter.
-            let owning_application = unsafe { w.owningApplication() };
-            let Some(app) = owning_application else { continue };
-            // SAFETY: same as above — a plain property getter.
-            let pid = unsafe { app.processID() };
-            if !pids_owned.contains(&pid) {
-                continue;
-            }
-            // SAFETY: same as above — plain property getters.
-            let (window_id, frame) = unsafe { (w.windowID(), w.frame()) };
-            let geometry = geometry_from_rect(
-                frame.origin.x,
-                frame.origin.y,
-                frame.size.width,
-                frame.size.height,
-            );
-            let _ = tx.send(QueryReply::Found(WindowMatch { pid, window_id, geometry }));
+        let Some((w, pid)) = find_on_screen_window(content, &pids_owned) else {
+            let _ = tx.send(QueryReply::NotFound);
             return;
-        }
-        let _ = tx.send(QueryReply::NotFound);
+        };
+        // SAFETY: `w` was just resolved live from `content.windows()` above; these are
+        // plain property getters with no other preconditions.
+        let (window_id, frame) = unsafe { (w.windowID(), w.frame()) };
+        let geometry = geometry_from_rect(
+            frame.origin.x,
+            frame.origin.y,
+            frame.size.width,
+            frame.size.height,
+        );
+        let _ = tx.send(QueryReply::Found(WindowMatch { pid, window_id, geometry }));
     });
 
     // SAFETY: `block` matches `getShareableContentExcludingDesktopWindows_onScreenWindowsOnly_completionHandler`'s

--- a/crates/glass-macos/src/scwindow.rs
+++ b/crates/glass-macos/src/scwindow.rs
@@ -39,15 +39,11 @@ use objc2_screen_capture_kit::{SCShareableContent, SCWindow};
 use glass_core::platform::WindowGeometry;
 use glass_core::{poll_until, GlassError, Result};
 
-use crate::permissions::Permission;
-
 /// A discovered on-screen window: enough to re-find or capture it later without holding
 /// a live `Retained<SCWindow>` across the completion handler's thread boundary (see
 /// module doc).
-// Fields aren't read yet: no call site consumes `find_window_for_pids`'s result until a
-// later task wires it into `MacosPlatform` (capture / `start_app`). Allowed here rather
-// than deleted so the type and its fields land in one place instead of being
-// reintroduced per call site — same convention as `ffi.rs`'s `app_kit_init`.
+// `geometry` is read by `start_app` (via `backend.rs::discover_window` ->
+// `query_once`); `pid`/`window_id` stay unread until Plan 4's list/select_window.
 #[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct WindowMatch {
@@ -67,14 +63,18 @@ pub(crate) struct WindowMatch {
 ///
 /// Calls [`crate::ffi::app_kit_init`] first to establish the window-server connection —
 /// required before any ScreenCaptureKit call from a bare CLI process (see `ffi.rs`).
-/// Returns [`GlassError::PermissionDenied`] immediately (no point polling — the grant
-/// isn't going to appear mid-poll) if `SCShareableContent` itself reports a TCC decline,
-/// or [`GlassError::Timeout`] if no matching window appears before `timeout` elapses.
-// Not yet called: a later task wires this into `MacosPlatform::start_app`/capture (per
-// the task brief, Task 3/5 re-discovers the window per capture). Kept `pub(crate)` +
-// allowed here rather than deleted, mirroring `ffi.rs`'s `app_kit_init` convention, so
-// the discovery logic and its tests land in one place instead of being reintroduced per
-// call site.
+/// Returns a classified error immediately (no point polling on a genuine
+/// `SCShareableContent` failure — see [`crate::ffi::classify_null_result`]:
+/// [`GlassError::PermissionDenied`] for a Screen Recording TCC decline,
+/// [`GlassError::CaptureFailed`] for anything else) or [`GlassError::Timeout`] if no
+/// matching window appears before `timeout` elapses.
+// No production caller: `MacosPlatform::start_app` runs its own poll loop
+// (`backend.rs::discover_window`) that alternates a single `query_once` attempt with
+// `child.try_wait()` so a crashed launch fails fast with `AppExited` — this function's
+// self-contained `poll_until` has no child handle to race against, so `start_app` can't
+// delegate its whole timeout budget to it. Kept `pub(crate)` + allowed here (not
+// deleted) as a plain "poll until found or timeout" primitive for a future call site
+// with no child to check (e.g. Plan 4 window rediscovery).
 #[allow(dead_code)]
 pub(crate) fn find_window_for_pids(pids: &[i32], timeout: Duration) -> Result<WindowMatch> {
     crate::ffi::app_kit_init();
@@ -120,11 +120,22 @@ pub(crate) fn find_on_screen_window(
     None
 }
 
+/// Cap on a single [`query_once`] attempt's wait for its `SCShareableContent` completion
+/// handler. A query resolves in well under a second in the spike's observations, so this
+/// is a wedged-handler backstop, not normal latency; kept small (rather than the old 5s)
+/// so it can't itself eat much of the outer poll loop's `timeout_ms`/deadline budget on a
+/// single bad tick — that budget is owned by the caller (`find_window_for_pids`'s
+/// `poll_until`, or `backend.rs::discover_window`'s own loop), which retries (or times
+/// out) regardless of this cap.
+const QUERY_TIMEOUT: Duration = Duration::from_secs(1);
+
 /// One `SCShareableContent` round trip via the `RcBlock` -> `mpsc` bridge (`ffi.rs`'s
 /// documented pattern): `Ok(Some(_))` on a match, `Ok(None)` if no matching on-screen
 /// window exists yet (the outer poll should retry), `Err` if `SCShareableContent` itself
-/// failed (e.g. a TCC decline — not worth retrying).
-fn query_once(pids: &[i32]) -> Result<Option<WindowMatch>> {
+/// failed — classified via [`crate::ffi::classify_null_result`] (TCC decline ->
+/// `PermissionDenied`, anything else -> `CaptureFailed`) rather than assumed to always be
+/// a permission decline; not worth retrying either way.
+pub(crate) fn query_once(pids: &[i32]) -> Result<Option<WindowMatch>> {
     let (tx, rx) = mpsc::channel::<QueryReply>();
     let pids_owned: Vec<i32> = pids.to_vec();
 
@@ -134,16 +145,11 @@ fn query_once(pids: &[i32]) -> Result<Option<WindowMatch>> {
     // it — never a `Retained<SCWindow>` (see module doc).
     let block = RcBlock::new(move |content_ptr: *mut SCShareableContent, err_ptr: *mut NSError| {
         if content_ptr.is_null() {
-            let msg = if err_ptr.is_null() {
-                "SCShareableContent completion handler returned null content and null error"
-                    .to_string()
-            } else {
-                // SAFETY: the framework guarantees a non-null, valid `NSError` whenever
-                // it hands back null content (proven in the spike's TCC-declined run).
-                let err: &NSError = unsafe { &*err_ptr };
-                format!("{err:?}")
-            };
-            let _ = tx.send(QueryReply::Failed(msg));
+            let err = crate::ffi::classify_null_result(
+                err_ptr,
+                "SCShareableContent completion handler returned null content and null error",
+            );
+            let _ = tx.send(QueryReply::Failed(err));
             return;
         }
         // SAFETY: `content_ptr` was just checked non-null; the framework guarantees it
@@ -176,14 +182,10 @@ fn query_once(pids: &[i32]) -> Result<Option<WindowMatch>> {
         );
     }
 
-    // A single query resolves in well under a second in the spike's observations; cap it
-    // generously so a wedged completion handler can't block this attempt forever. The
-    // outer `poll_until` in `find_window_for_pids` owns the real timeout budget and will
-    // retry (or surface `GlassError::Timeout`) regardless of this cap.
-    match rx.recv_timeout(Duration::from_secs(5)) {
+    match rx.recv_timeout(QUERY_TIMEOUT) {
         Ok(QueryReply::Found(m)) => Ok(Some(m)),
         Ok(QueryReply::NotFound) => Ok(None),
-        Ok(QueryReply::Failed(msg)) => Err(Permission::ScreenRecording.denied_with_detail(msg)),
+        Ok(QueryReply::Failed(e)) => Err(e),
         Err(mpsc::RecvTimeoutError::Timeout) => Ok(None),
         Err(mpsc::RecvTimeoutError::Disconnected) => Err(GlassError::Backend(
             "SCShareableContent completion handler was dropped without replying".into(),
@@ -196,7 +198,7 @@ fn query_once(pids: &[i32]) -> Result<Option<WindowMatch>> {
 enum QueryReply {
     Found(WindowMatch),
     NotFound,
-    Failed(String),
+    Failed(GlassError),
 }
 
 /// Convert a window frame (points, from `SCWindow.frame()`) to the platform-agnostic

--- a/crates/glass-macos/src/scwindow.rs
+++ b/crates/glass-macos/src/scwindow.rs
@@ -1,0 +1,226 @@
+//! `SCShareableContent` window discovery by pid.
+//!
+//! Polls ScreenCaptureKit's `SCShareableContent` enumeration — the same async
+//! completion-handler API proven end-to-end in
+//! `.superpowers/sdd/objc2-spike-report.md` Part A — for the first on-screen window
+//! owned by one of a set of pids (the launched app's process set), following `ffi.rs`'s
+//! documented async-bridge convention.
+//!
+//! ## Why this returns [`WindowMatch`], not `Retained<SCWindow>`
+//!
+//! The natural signature would return `(Retained<SCWindow>, WindowGeometry)`. That isn't
+//! achievable safely: `SCShareableContent`'s completion handler fires on an internal
+//! ScreenCaptureKit queue, not this function's calling thread, and `objc2`'s
+//! `Retained<T>` is only `Send`/`Sync` when `T: Send + Sync`
+//! (`unsafe impl<T: ?Sized + Sync + Send> Send for Retained<T> {}` in `objc2`'s
+//! `rc::retained` module) — `SCWindow` (an `extern_class!`-declared binding with no such
+//! bound, confirmed by reading the generated source: no `unsafe impl Send`/`Sync` for it
+//! anywhere in `objc2-screen-capture-kit`) is neither. Apple never documents `SCWindow`'s
+//! methods as safe to call concurrently from multiple threads, so `objc2` doesn't assert
+//! it either. Smuggling a `Retained<SCWindow>` out of the completion block via a raw
+//! pointer + `unsafe impl Send` wrapper would compile, but there'd be no real safety
+//! argument backing it — exactly the gotcha `ffi.rs`'s module doc warns against ("never
+//! send a `Retained<T>`/raw objc2 object across the channel").
+//!
+//! Instead, [`find_window_for_pids`] returns [`WindowMatch`]: the owning pid, the
+//! `CGWindowID` (a plain `u32`, stable for the window's lifetime and re-findable via a
+//! fresh query), and the geometry. That's everything a later capture call needs to
+//! re-resolve the exact window — which it must do per-call anyway, since a
+//! `Retained<SCWindow>` can't be cached across the same thread-crossing boundary.
+
+use std::sync::mpsc;
+use std::time::Duration;
+
+use block2::RcBlock;
+use objc2::rc::Retained;
+use objc2_foundation::{NSArray, NSError};
+use objc2_screen_capture_kit::{SCShareableContent, SCWindow};
+
+use glass_core::platform::WindowGeometry;
+use glass_core::{poll_until, GlassError, Result};
+
+use crate::permissions::Permission;
+
+/// A discovered on-screen window: enough to re-find or capture it later without holding
+/// a live `Retained<SCWindow>` across the completion handler's thread boundary (see
+/// module doc).
+// Fields aren't read yet: no call site consumes `find_window_for_pids`'s result until a
+// later task wires it into `MacosPlatform` (capture / `start_app`). Allowed here rather
+// than deleted so the type and its fields land in one place instead of being
+// reintroduced per call site — same convention as `ffi.rs`'s `app_kit_init`.
+#[allow(dead_code)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct WindowMatch {
+    /// The owning process's pid — one of the `pids` passed to `find_window_for_pids`.
+    pub(crate) pid: i32,
+    /// `SCWindow.windowID()` (`CGWindowID`, a `u32`) — stable for the window's lifetime;
+    /// re-findable via a fresh `SCShareableContent` query
+    /// (`content.windows().iter().find(|w| w.windowID() == id)`).
+    pub(crate) window_id: u32,
+    pub(crate) geometry: WindowGeometry,
+}
+
+/// Poll `SCShareableContent` roughly every 100ms for the first on-screen window whose
+/// `owningApplication().processID()` is in `pids`, until found or `timeout` elapses.
+/// Multi-window selection (picking among several matches for the same app) is Plan 4;
+/// this returns the first on-screen match.
+///
+/// Calls [`crate::ffi::app_kit_init`] first to establish the window-server connection —
+/// required before any ScreenCaptureKit call from a bare CLI process (see `ffi.rs`).
+/// Returns [`GlassError::PermissionDenied`] immediately (no point polling — the grant
+/// isn't going to appear mid-poll) if `SCShareableContent` itself reports a TCC decline,
+/// or [`GlassError::Timeout`] if no matching window appears before `timeout` elapses.
+// Not yet called: a later task wires this into `MacosPlatform::start_app`/capture (per
+// the task brief, Task 3/5 re-discovers the window per capture). Kept `pub(crate)` +
+// allowed here rather than deleted, mirroring `ffi.rs`'s `app_kit_init` convention, so
+// the discovery logic and its tests land in one place instead of being reintroduced per
+// call site.
+#[allow(dead_code)]
+pub(crate) fn find_window_for_pids(pids: &[i32], timeout: Duration) -> Result<WindowMatch> {
+    crate::ffi::app_kit_init();
+
+    let timeout_ms = timeout.as_millis() as u64;
+    let outcome = poll_until(100, timeout_ms, || query_once(pids))?;
+    outcome.value.ok_or(GlassError::Timeout(timeout_ms))
+}
+
+/// One `SCShareableContent` round trip via the `RcBlock` -> `mpsc` bridge (`ffi.rs`'s
+/// documented pattern): `Ok(Some(_))` on a match, `Ok(None)` if no matching on-screen
+/// window exists yet (the outer poll should retry), `Err` if `SCShareableContent` itself
+/// failed (e.g. a TCC decline — not worth retrying).
+fn query_once(pids: &[i32]) -> Result<Option<WindowMatch>> {
+    let (tx, rx) = mpsc::channel::<QueryReply>();
+    let pids_owned: Vec<i32> = pids.to_vec();
+
+    // The completion handler does the whole match-or-not decision synchronously inside
+    // the callback (per ffi.rs's async-bridge pattern) and only ever sends `QueryReply`
+    // — plain owned data, `Send` regardless of what ObjC objects were touched to build
+    // it — never a `Retained<SCWindow>` (see module doc).
+    let block = RcBlock::new(move |content_ptr: *mut SCShareableContent, err_ptr: *mut NSError| {
+        if content_ptr.is_null() {
+            let msg = if err_ptr.is_null() {
+                "SCShareableContent completion handler returned null content and null error"
+                    .to_string()
+            } else {
+                // SAFETY: the framework guarantees a non-null, valid `NSError` whenever
+                // it hands back null content (proven in the spike's TCC-declined run).
+                let err: &NSError = unsafe { &*err_ptr };
+                format!("{err:?}")
+            };
+            let _ = tx.send(QueryReply::Failed(msg));
+            return;
+        }
+        // SAFETY: `content_ptr` was just checked non-null; the framework guarantees it
+        // points to a live `SCShareableContent` for the duration of this callback.
+        let content: &SCShareableContent = unsafe { &*content_ptr };
+        // SAFETY: `windows` is a plain getter on a live `SCShareableContent`; no other
+        // preconditions.
+        let windows: Retained<NSArray<SCWindow>> = unsafe { content.windows() };
+
+        for w in windows.iter() {
+            // SAFETY: `w` is a live `SCWindow` yielded by the array (`NSArray::iter`
+            // hands out a fresh, owned `Retained<SCWindow>` per element — see `ffi.rs`'s
+            // gotcha notes); this and the getters below have no preconditions beyond a
+            // valid receiver.
+            if !unsafe { w.isOnScreen() } {
+                continue;
+            }
+            // SAFETY: same as above — a plain property getter.
+            let owning_application = unsafe { w.owningApplication() };
+            let Some(app) = owning_application else { continue };
+            // SAFETY: same as above — a plain property getter.
+            let pid = unsafe { app.processID() };
+            if !pids_owned.contains(&pid) {
+                continue;
+            }
+            // SAFETY: same as above — plain property getters.
+            let (window_id, frame) = unsafe { (w.windowID(), w.frame()) };
+            let geometry = geometry_from_rect(
+                frame.origin.x,
+                frame.origin.y,
+                frame.size.width,
+                frame.size.height,
+            );
+            let _ = tx.send(QueryReply::Found(WindowMatch { pid, window_id, geometry }));
+            return;
+        }
+        let _ = tx.send(QueryReply::NotFound);
+    });
+
+    // SAFETY: `block` matches `getShareableContentExcludingDesktopWindows_onScreenWindowsOnly_completionHandler`'s
+    // documented signature (`*mut SCShareableContent, *mut NSError`, per the generated
+    // binding) — the exact sequence the spike proved end-to-end. The call itself has no
+    // other preconditions.
+    unsafe {
+        SCShareableContent::getShareableContentExcludingDesktopWindows_onScreenWindowsOnly_completionHandler(
+            true, true, &block,
+        );
+    }
+
+    // A single query resolves in well under a second in the spike's observations; cap it
+    // generously so a wedged completion handler can't block this attempt forever. The
+    // outer `poll_until` in `find_window_for_pids` owns the real timeout budget and will
+    // retry (or surface `GlassError::Timeout`) regardless of this cap.
+    match rx.recv_timeout(Duration::from_secs(5)) {
+        Ok(QueryReply::Found(m)) => Ok(Some(m)),
+        Ok(QueryReply::NotFound) => Ok(None),
+        Ok(QueryReply::Failed(msg)) => Err(Permission::ScreenRecording.denied_with_detail(msg)),
+        Err(mpsc::RecvTimeoutError::Timeout) => Ok(None),
+        Err(mpsc::RecvTimeoutError::Disconnected) => Err(GlassError::Backend(
+            "SCShareableContent completion handler was dropped without replying".into(),
+        )),
+    }
+}
+
+/// One `SCShareableContent` query's outcome, funneled out of the completion block as
+/// plain owned data (see module doc: never a `Retained<SCWindow>`).
+enum QueryReply {
+    Found(WindowMatch),
+    NotFound,
+    Failed(String),
+}
+
+/// Convert a window frame (points, from `SCWindow.frame()`) to the platform-agnostic
+/// `WindowGeometry`. Pulled out as pure `f64` math (no `CGRect` dependency) so it can
+/// carry its own unit test without needing a live window.
+fn geometry_from_rect(x: f64, y: f64, width: f64, height: f64) -> WindowGeometry {
+    WindowGeometry {
+        x: x.round() as i32,
+        y: y.round() as i32,
+        width: width.round().max(0.0) as u32,
+        height: height.round().max(0.0) as u32,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn geometry_from_rect_rounds_to_nearest() {
+        assert_eq!(
+            geometry_from_rect(10.4, 20.6, 300.49, 200.5),
+            WindowGeometry { x: 10, y: 21, width: 300, height: 201 }
+        );
+    }
+
+    #[test]
+    fn geometry_from_rect_clamps_negative_size_to_zero() {
+        // A real CGRect from SCWindow.frame() never has a negative size, but the
+        // conversion must not panic or wrap on malformed input.
+        assert_eq!(
+            geometry_from_rect(0.0, 0.0, -1.0, -1.0),
+            WindowGeometry { x: 0, y: 0, width: 0, height: 0 }
+        );
+    }
+
+    #[test]
+    fn geometry_from_rect_preserves_negative_origin() {
+        // A window can sit left-of/above the primary display's origin in a multi-monitor
+        // layout; x/y must stay signed rather than clamping like width/height do.
+        assert_eq!(
+            geometry_from_rect(-50.0, -10.0, 100.0, 80.0),
+            WindowGeometry { x: -50, y: -10, width: 100, height: 80 }
+        );
+    }
+}

--- a/crates/glass-macos/tests/capture.rs
+++ b/crates/glass-macos/tests/capture.rs
@@ -59,7 +59,10 @@ mod macos_main {
     }
 
     /// Unwrap a `Result`, failing the whole test process with `context` prefixed to the
-    /// error on `Err`.
+    /// error on `Err`. Only safe to use before a fixture process has been spawned (or
+    /// once all spawn-time cleanup is already done) — it exits immediately, skipping
+    /// destructors, so anything that still needs `MacosPlatform::stop_app()` run against
+    /// it must go through `try_expect`/`run_checks` below instead.
     fn expect<T, E: std::fmt::Display>(result: Result<T, E>, context: &str) -> T {
         match result {
             Ok(v) => v,
@@ -67,13 +70,24 @@ mod macos_main {
         }
     }
 
+    /// Like `expect`, but returns the error as a `String` instead of exiting the
+    /// process. Used inside `run_checks`, where a failure must still flow back to
+    /// `run()` so it can `stop_app()` the spawned fixture (and clean up the fixture
+    /// build dir) before the process exits — `std::process::exit` skips Rust
+    /// destructors, so `MacosPlatform::Drop` would never reap the child if we exited
+    /// straight from in here.
+    fn try_expect<T, E: std::fmt::Display>(result: Result<T, E>, context: &str) -> Result<T, String> {
+        result.map_err(|e| format!("{context}: {e}"))
+    }
+
     fn swiftc_available() -> bool {
         Command::new("swiftc").arg("--version").output().is_ok_and(|o| o.status.success())
     }
 
     /// Build `fixture/quadrants.swift` to a fresh temp path. Returns the built binary's
-    /// path.
-    fn build_fixture() -> PathBuf {
+    /// path and the temp build dir it lives in (the caller is responsible for removing
+    /// the dir once done with it — see `run()`).
+    fn build_fixture() -> (PathBuf, PathBuf) {
         let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let source = manifest_dir.join("fixture").join("quadrants.swift");
         if !source.is_file() {
@@ -96,7 +110,7 @@ mod macos_main {
             Ok(s) => fail(format!("swiftc exited with {s} building {}", source.display())),
             Err(e) => fail(format!("failed to run swiftc: {e}")),
         }
-        out_bin
+        (out_bin, out_dir)
     }
 
     /// Fetch pixel `(x, y)` from a tightly-packed RGBA8 `Frame` buffer.
@@ -109,8 +123,11 @@ mod macos_main {
         a.iter().zip(b.iter()).all(|(x, y)| (*x as i32 - *y as i32).abs() <= TOLERANCE)
     }
 
-    /// Assert the pixel at `(x, y)` in `frame` is within tolerance of `expected`, failing
-    /// the process with a detailed message (including the actual bytes) otherwise.
+    /// Assert the pixel at `(x, y)` in `frame` is within tolerance of `expected`,
+    /// returning a detailed `Err` message (including the actual bytes) otherwise. Returns
+    /// `Result` rather than failing the process directly so a mismatch, raised from
+    /// inside `run_checks` with a fixture process already spawned, still flows back to
+    /// `run()`'s cleanup (`stop_app` + temp dir removal) before the process exits.
     fn assert_pixel(
         pixels: &[u8],
         frame_width: u32,
@@ -118,45 +135,40 @@ mod macos_main {
         y: u32,
         expected: [u8; 4],
         label: &str,
-    ) {
+    ) -> Result<(), String> {
         let got = pixel_at(pixels, frame_width, x, y);
         if !close(got, expected) {
-            fail(format!(
+            return Err(format!(
                 "{label} pixel at ({x},{y}) = {got:?}, expected ~{expected:?} (tolerance {TOLERANCE})"
             ));
         }
+        Ok(())
     }
 
     /// Assert every pixel in a tightly-packed RGBA8 buffer of `w`x`h` is within tolerance
-    /// of `expected`.
-    fn assert_uniform(pixels: &[u8], w: u32, h: u32, expected: [u8; 4], label: &str) {
+    /// of `expected`. Returns `Result` for the same reason as `assert_pixel`.
+    fn assert_uniform(pixels: &[u8], w: u32, h: u32, expected: [u8; 4], label: &str) -> Result<(), String> {
         for y in 0..h {
             for x in 0..w {
                 let got = pixel_at(pixels, w, x, y);
                 if !close(got, expected) {
-                    fail(format!(
+                    return Err(format!(
                         "{label}: non-uniform pixel at ({x},{y}) = {got:?}, expected ~{expected:?} \
                          (tolerance {TOLERANCE}) within a {w}x{h} region"
                     ));
                 }
             }
         }
+        Ok(())
     }
 
-    pub(super) fn run() {
-        if !swiftc_available() {
-            println!("skipped (no swiftc)");
-            return;
-        }
-
-        let fixture_bin = build_fixture();
-        println!("built fixture at {}", fixture_bin.display());
-
-        let mut platform = expect(
-            MacosPlatform::new(),
-            "MacosPlatform::new() (Screen Recording / Accessibility grant missing?)",
-        );
-
+    /// The whole capture-and-assert flow, from launching the fixture through the last
+    /// pixel assertion. Returns `Err` instead of exiting the process on any failure, so
+    /// `run()` can always reach `platform.stop_app()` first — a bare `std::process::exit`
+    /// from in here would skip `MacosPlatform::Drop` (Rust destructors don't run across
+    /// `exit`) and leak the spawned `quadrants` fixture process (reparented to launchd,
+    /// accumulating stray windows across repeated failed runs).
+    fn run_checks(platform: &mut MacosPlatform, fixture_bin: &std::path::Path) -> Result<(), String> {
         let spec = AppSpec {
             build: None,
             run: vec![fixture_bin.to_string_lossy().into_owned()],
@@ -168,19 +180,25 @@ mod macos_main {
             a11y: false,
         };
 
-        let geometry = expect(platform.start_app(&spec), "start_app");
+        let geometry = try_expect(platform.start_app(&spec), "start_app")?;
         println!("started fixture window: {geometry:?}");
 
         // start_app only waits for the window to *exist* (SCShareableContent
         // enumeration), not for its first paint to land — give the initial draw() a
-        // moment to complete before capturing.
+        // moment to complete before capturing. This fixture draws once, synchronously,
+        // immediately on launch, so a fixed sleep is sufficient here; it is NOT a
+        // wait-for-first-paint pattern to reuse for apps with slower or async first
+        // paints.
         std::thread::sleep(Duration::from_millis(500));
 
-        let frame = expect(platform.capture_frame(None), "capture_frame(None)");
+        let frame = try_expect(platform.capture_frame(None), "capture_frame(None)")?;
         println!("captured {}x{} frame", frame.width, frame.height);
 
         if frame.width < 2 || frame.height < 2 {
-            fail(format!("captured frame too small to sample quadrants: {}x{}", frame.width, frame.height));
+            return Err(format!(
+                "captured frame too small to sample quadrants: {}x{}",
+                frame.width, frame.height
+            ));
         }
 
         // Quadrant centers, in the captured Frame's own coordinate system (row-major,
@@ -191,10 +209,10 @@ mod macos_main {
         let (fw, fh) = (frame.width, frame.height);
         let (qx0, qx1) = (fw / 4, fw * 3 / 4);
         let (qy0, qy1) = (fh / 4, fh * 3 / 4);
-        assert_pixel(&frame.pixels, fw, qx0, qy0, RED, "top-left");
-        assert_pixel(&frame.pixels, fw, qx1, qy0, GREEN, "top-right");
-        assert_pixel(&frame.pixels, fw, qx0, qy1, BLUE, "bottom-left");
-        assert_pixel(&frame.pixels, fw, qx1, qy1, WHITE, "bottom-right");
+        assert_pixel(&frame.pixels, fw, qx0, qy0, RED, "top-left")?;
+        assert_pixel(&frame.pixels, fw, qx1, qy0, GREEN, "top-right")?;
+        assert_pixel(&frame.pixels, fw, qx0, qy1, BLUE, "bottom-left")?;
+        assert_pixel(&frame.pixels, fw, qx1, qy1, WHITE, "bottom-right")?;
         println!("full-frame quadrant colors OK");
 
         // Crop to the top-left quadrant (frame-relative Region) and assert it's uniformly
@@ -202,19 +220,56 @@ mod macos_main {
         let half_w = fw / 2;
         let half_h = fh / 2;
         let region = Region { x: 0, y: 0, width: half_w, height: half_h };
-        let cropped = expect(platform.capture_frame(Some(&region)), "capture_frame(Some(top-left region))");
+        let cropped =
+            try_expect(platform.capture_frame(Some(&region)), "capture_frame(Some(top-left region))")?;
         if cropped.width != half_w || cropped.height != half_h {
-            fail(format!(
+            return Err(format!(
                 "cropped frame is {}x{}, expected {half_w}x{half_h}",
                 cropped.width, cropped.height
             ));
         }
-        assert_uniform(&cropped.pixels, cropped.width, cropped.height, RED, "cropped top-left region");
+        assert_uniform(&cropped.pixels, cropped.width, cropped.height, RED, "cropped top-left region")?;
         println!("region-crop OK: {}x{} uniformly red", cropped.width, cropped.height);
 
-        expect(platform.stop_app(), "stop_app");
+        Ok(())
+    }
 
-        println!("CAPTURE_INTEGRATION_PASS");
-        std::process::exit(0);
+    pub(super) fn run() {
+        if !swiftc_available() {
+            println!("skipped (no swiftc)");
+            return;
+        }
+
+        let (fixture_bin, fixture_dir) = build_fixture();
+        println!("built fixture at {}", fixture_bin.display());
+
+        let mut platform = match MacosPlatform::new() {
+            Ok(p) => p,
+            Err(e) => {
+                let _ = std::fs::remove_dir_all(&fixture_dir);
+                fail(format!(
+                    "MacosPlatform::new() (Screen Recording / Accessibility grant missing?): {e}"
+                ));
+            }
+        };
+
+        let result = run_checks(&mut platform, &fixture_bin);
+
+        // Reached regardless of outcome, and BEFORE any process::exit below: stop_app is
+        // documented idempotent (a no-op if start_app never got far enough to spawn a
+        // child), so this is always safe and is what guarantees the fixture's `quadrants`
+        // process never survives a failed run. Best-effort temp dir cleanup rides along
+        // here too, on both the success and failure paths.
+        let stop_result = platform.stop_app();
+        let _ = std::fs::remove_dir_all(&fixture_dir);
+
+        match result {
+            Ok(()) => {
+                expect(stop_result, "stop_app");
+                println!("CAPTURE_INTEGRATION_PASS");
+                std::process::exit(0);
+            }
+            Err(msg) => fail(msg),
+        }
     }
 }

--- a/crates/glass-macos/tests/capture.rs
+++ b/crates/glass-macos/tests/capture.rs
@@ -269,7 +269,15 @@ mod macos_main {
                 println!("CAPTURE_INTEGRATION_PASS");
                 std::process::exit(0);
             }
-            Err(msg) => fail(msg),
+            Err(msg) => {
+                // stop_app is infallible today (always Ok), but surface a future failure
+                // here too rather than silently dropping it — this is the last point
+                // before the process exits, so it's the only chance to report it.
+                if let Err(e) = stop_result {
+                    eprintln!("(additionally) stop_app failed: {e}");
+                }
+                fail(msg);
+            }
         }
     }
 }

--- a/crates/glass-macos/tests/capture.rs
+++ b/crates/glass-macos/tests/capture.rs
@@ -1,0 +1,220 @@
+//! Mac-gated capture integration test — the first real-pixels proof through the whole
+//! `MacosPlatform` capture path (`MacosPlatform::new` -> `start_app` -> `capture_frame`
+//! -> ScreenCaptureKit -> `Frame`).
+//!
+//! **`harness = false`** (see `Cargo.toml`'s `[[test]] name = "capture"` entry): `Platform`
+//! calls that touch AppKit (`capture_frame`, `start_app`'s window discovery) reach
+//! `ffi::app_kit_init()` -> `NSApplication::sharedApplication(mtm)`, which requires the
+//! process's TRUE main thread (`objc2::MainThreadMarker`). libtest runs every `#[test]` on
+//! a spawned worker thread, so a normal harness test would panic on
+//! `MainThreadMarker::new().expect(...)`. This file defines its own `fn main()` instead,
+//! which — when this binary is executed directly rather than through libtest — runs on the
+//! real main thread.
+//!
+//! Needs the Screen Recording TCC grant, which only a signed, granted app bundle holds on
+//! this project's dev Mac (`mini`). A plain `cargo test --test capture` build (this file
+//! compiles and can run) will still fail at the grant check unless run in that granted
+//! context — the actual granted run copies this test binary into the granted
+//! `GlassProbe.app` bundle, re-signs it, and launches it via a `gui/501` LaunchAgent so it
+//! inherits the bundle's grants. See `.superpowers/sdd/objc2-spike-report.md` and
+//! `.superpowers/sdd/task-6-brief.md` for the exact procedure, and
+//! `scripts/test-macos.sh`'s `GLASS_MACOS_ONBOX` gate for how this fits the test scripts.
+
+#[cfg(not(target_os = "macos"))]
+fn main() {
+    println!("skipped (not macOS)");
+}
+
+#[cfg(target_os = "macos")]
+fn main() {
+    macos_main::run();
+}
+
+#[cfg(target_os = "macos")]
+mod macos_main {
+    use std::path::PathBuf;
+    use std::process::Command;
+    use std::time::Duration;
+
+    use glass_core::{AppSpec, Platform, Region, SandboxLevel};
+    use glass_macos::MacosPlatform;
+
+    /// Per-channel RGBA tolerance for a sampled pixel vs. its expected known color.
+    /// Generous relative to `deviceRGB` fills (which should land very close to exact),
+    /// but wide enough to absorb any residual compositor/backing-scale blending at a
+    /// sampled point (sample points are quadrant *centers*, away from color boundaries,
+    /// so this is a safety margin, not a load-bearing tolerance).
+    const TOLERANCE: i32 = 40;
+
+    const RED: [u8; 4] = [255, 0, 0, 255];
+    const GREEN: [u8; 4] = [0, 255, 0, 255];
+    const BLUE: [u8; 4] = [0, 0, 255, 255];
+    const WHITE: [u8; 4] = [255, 255, 255, 255];
+
+    /// Print a clear failure message and exit non-zero — the `harness = false` contract
+    /// (no libtest to format a panic for us).
+    fn fail(msg: impl AsRef<str>) -> ! {
+        eprintln!("FAIL: {}", msg.as_ref());
+        std::process::exit(1);
+    }
+
+    /// Unwrap a `Result`, failing the whole test process with `context` prefixed to the
+    /// error on `Err`.
+    fn expect<T, E: std::fmt::Display>(result: Result<T, E>, context: &str) -> T {
+        match result {
+            Ok(v) => v,
+            Err(e) => fail(format!("{context}: {e}")),
+        }
+    }
+
+    fn swiftc_available() -> bool {
+        Command::new("swiftc").arg("--version").output().is_ok_and(|o| o.status.success())
+    }
+
+    /// Build `fixture/quadrants.swift` to a fresh temp path. Returns the built binary's
+    /// path.
+    fn build_fixture() -> PathBuf {
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let source = manifest_dir.join("fixture").join("quadrants.swift");
+        if !source.is_file() {
+            fail(format!("fixture source not found at {}", source.display()));
+        }
+
+        let out_dir = std::env::temp_dir().join(format!("glass-macos-capture-test-{}", std::process::id()));
+        expect(std::fs::create_dir_all(&out_dir), "creating fixture build dir");
+        let out_bin = out_dir.join("quadrants");
+
+        let status = Command::new("swiftc")
+            .arg("-O")
+            .arg("-parse-as-library")
+            .arg(&source)
+            .arg("-o")
+            .arg(&out_bin)
+            .status();
+        match status {
+            Ok(s) if s.success() => {}
+            Ok(s) => fail(format!("swiftc exited with {s} building {}", source.display())),
+            Err(e) => fail(format!("failed to run swiftc: {e}")),
+        }
+        out_bin
+    }
+
+    /// Fetch pixel `(x, y)` from a tightly-packed RGBA8 `Frame` buffer.
+    fn pixel_at(pixels: &[u8], frame_width: u32, x: u32, y: u32) -> [u8; 4] {
+        let idx = (y as usize * frame_width as usize + x as usize) * 4;
+        [pixels[idx], pixels[idx + 1], pixels[idx + 2], pixels[idx + 3]]
+    }
+
+    fn close(a: [u8; 4], b: [u8; 4]) -> bool {
+        a.iter().zip(b.iter()).all(|(x, y)| (*x as i32 - *y as i32).abs() <= TOLERANCE)
+    }
+
+    /// Assert the pixel at `(x, y)` in `frame` is within tolerance of `expected`, failing
+    /// the process with a detailed message (including the actual bytes) otherwise.
+    fn assert_pixel(
+        pixels: &[u8],
+        frame_width: u32,
+        x: u32,
+        y: u32,
+        expected: [u8; 4],
+        label: &str,
+    ) {
+        let got = pixel_at(pixels, frame_width, x, y);
+        if !close(got, expected) {
+            fail(format!(
+                "{label} pixel at ({x},{y}) = {got:?}, expected ~{expected:?} (tolerance {TOLERANCE})"
+            ));
+        }
+    }
+
+    /// Assert every pixel in a tightly-packed RGBA8 buffer of `w`x`h` is within tolerance
+    /// of `expected`.
+    fn assert_uniform(pixels: &[u8], w: u32, h: u32, expected: [u8; 4], label: &str) {
+        for y in 0..h {
+            for x in 0..w {
+                let got = pixel_at(pixels, w, x, y);
+                if !close(got, expected) {
+                    fail(format!(
+                        "{label}: non-uniform pixel at ({x},{y}) = {got:?}, expected ~{expected:?} \
+                         (tolerance {TOLERANCE}) within a {w}x{h} region"
+                    ));
+                }
+            }
+        }
+    }
+
+    pub(super) fn run() {
+        if !swiftc_available() {
+            println!("skipped (no swiftc)");
+            return;
+        }
+
+        let fixture_bin = build_fixture();
+        println!("built fixture at {}", fixture_bin.display());
+
+        let mut platform = expect(
+            MacosPlatform::new(),
+            "MacosPlatform::new() (Screen Recording / Accessibility grant missing?)",
+        );
+
+        let spec = AppSpec {
+            build: None,
+            run: vec![fixture_bin.to_string_lossy().into_owned()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 8000,
+            sandbox: SandboxLevel::Off,
+            a11y: false,
+        };
+
+        let geometry = expect(platform.start_app(&spec), "start_app");
+        println!("started fixture window: {geometry:?}");
+
+        // start_app only waits for the window to *exist* (SCShareableContent
+        // enumeration), not for its first paint to land — give the initial draw() a
+        // moment to complete before capturing.
+        std::thread::sleep(Duration::from_millis(500));
+
+        let frame = expect(platform.capture_frame(None), "capture_frame(None)");
+        println!("captured {}x{} frame", frame.width, frame.height);
+
+        if frame.width < 2 || frame.height < 2 {
+            fail(format!("captured frame too small to sample quadrants: {}x{}", frame.width, frame.height));
+        }
+
+        // Quadrant centers, in the captured Frame's own coordinate system (row-major,
+        // top-left origin per glass_core::frame::Frame's contract). The fixture draws its
+        // four *visual* quadrants (as seen on screen) directly at these same corners —
+        // see quadrants.swift's header — so top-left/top-right/bottom-left/bottom-right
+        // below name the same corners on both sides.
+        let (fw, fh) = (frame.width, frame.height);
+        let (qx0, qx1) = (fw / 4, fw * 3 / 4);
+        let (qy0, qy1) = (fh / 4, fh * 3 / 4);
+        assert_pixel(&frame.pixels, fw, qx0, qy0, RED, "top-left");
+        assert_pixel(&frame.pixels, fw, qx1, qy0, GREEN, "top-right");
+        assert_pixel(&frame.pixels, fw, qx0, qy1, BLUE, "bottom-left");
+        assert_pixel(&frame.pixels, fw, qx1, qy1, WHITE, "bottom-right");
+        println!("full-frame quadrant colors OK");
+
+        // Crop to the top-left quadrant (frame-relative Region) and assert it's uniformly
+        // red and exactly half-sized.
+        let half_w = fw / 2;
+        let half_h = fh / 2;
+        let region = Region { x: 0, y: 0, width: half_w, height: half_h };
+        let cropped = expect(platform.capture_frame(Some(&region)), "capture_frame(Some(top-left region))");
+        if cropped.width != half_w || cropped.height != half_h {
+            fail(format!(
+                "cropped frame is {}x{}, expected {half_w}x{half_h}",
+                cropped.width, cropped.height
+            ));
+        }
+        assert_uniform(&cropped.pixels, cropped.width, cropped.height, RED, "cropped top-left region");
+        println!("region-crop OK: {}x{} uniformly red", cropped.width, cropped.height);
+
+        expect(platform.stop_app(), "stop_app");
+
+        println!("CAPTURE_INTEGRATION_PASS");
+        std::process::exit(0);
+    }
+}

--- a/scripts/test-macos.sh
+++ b/scripts/test-macos.sh
@@ -12,6 +12,25 @@ fi
 # (mirrors scripts/test-x11.sh / test-wayland.sh / test-windows.sh).
 cd "$(dirname "$0")/.."
 
-# Pure + macOS unit tests. (Capture/input integration tests are #[ignore]d and added in
-# later plans; they need a granted, WindowServer-connected context — a gui/501 LaunchAgent.)
-cargo test -p glass-macos "${1:-}"
+# Pure + macOS unit tests only (`--lib`). `crates/glass-macos/tests/capture.rs` is now a
+# real `[[test]]` target (see Cargo.toml), so a plain `cargo test -p glass-macos` with no
+# `--lib` filter would also try to build+run it — and it needs a granted, WindowServer
+# -connected context (a gui/501 LaunchAgent) that a plain on-box or CI run doesn't have,
+# so it would fail every ungranted run. `--lib` keeps this default invocation to exactly
+# the unit tests; see GLASS_MACOS_ONBOX below for the capture test.
+cargo test -p glass-macos --lib "${1:-}"
+
+# GLASS_MACOS_ONBOX=1: also build the harness=false capture integration test
+# (crates/glass-macos/tests/capture.rs) — the first-real-pixels proof of the whole
+# MacosPlatform::start_app -> capture_frame path via ScreenCaptureKit, using the native
+# fixture/quadrants.swift known-color window. Building it here just confirms it compiles
+# and links; it needs the Screen Recording TCC grant to actually PASS, which only a
+# signed, granted app bundle holds — so the real run happens out-of-band, copying this
+# built binary into the granted GlassProbe.app bundle, re-signing, and launching via a
+# gui/501 LaunchAgent so it inherits the grant (see
+# .superpowers/sdd/objc2-spike-report.md and .superpowers/sdd/task-6-brief.md for the
+# exact procedure). Plain `./scripts/test-macos.sh` (no env set) never touches this.
+if [[ "${GLASS_MACOS_ONBOX:-0}" == "1" ]]; then
+  echo "GLASS_MACOS_ONBOX=1: building the capture integration test binary..."
+  cargo test -p glass-macos --test capture --no-run
+fi


### PR DESCRIPTION
Second increment of the macOS `Platform` backend: the "see" half of the loop — launch an app, find its window, and capture it. (Plan 1 landed the crate skeleton + TCC preflight.)

## What's here
- **Launch + lifecycle** (`process.rs`, `backend.rs`): `start_app` runs the optional build step, spawns the app (piped stdout/stderr → the log ring buffer via an `Arc<Mutex>` sink), and discovers its window by pid; `stop_app`/`Drop` terminate the child (SIGTERM→SIGKILL→reap, idempotent). A crashed child fast-fails with `AppExited`. Sandbox levels other than `off` return a structured `Unsupported` (no silent downgrade — macOS containment is a later increment).
- **Window discovery** (`scwindow.rs`): `SCShareableContent` enumeration filtered by owning pid, with a timeout.
- **Capture** (`capture.rs`): ScreenCaptureKit per-window `SCScreenshotManager` capture → RGBA `Frame`, with window-relative region cropping. Runs on the existing display (a `CGVirtualDisplay` provider is a later increment). Missing grants / capture failures return structured errors, never a blank/stale frame.
- **objc2 FFI**: the async completion-handler bindings via `block2` (only `Send` data crosses the internal channel, guarded by static assertions); every `unsafe` block is documented with `// SAFETY:`. `AXIsProcessTrusted` bound as `u8` (Apple's `Boolean` ABI). objc2 crate features are trimmed to the minimal per-type set.
- **Test fixture + integration test**: a native Cocoa fixture drawing known-color quadrants + a `harness = false` (main-thread) capture test that asserts the captured quadrant colors and a region crop.

## Notes
- `capture_frame`'s `region` is window-relative and converted to backing pixels before cropping (HiDPI-correct). Reconciling geometry/frame/click units into a single physical-pixel space (as the other backends do) is a follow-up with the input increment.
- `capture_frame` reaches AppKit, which requires the process main thread; the integration test is `harness = false` for that reason. Driving the backend from a worker thread (main-thread marshaling) is a follow-up.
- Window management (`window`/`list_windows`/`select_window`) and input remain `unimplemented!()` for follow-up increments.

## Verification
- Linux: `cargo build/clippy/test --workspace --locked` green (the macOS modules are `cfg`-gated; pure modules + core run here).
- macOS 26.5 (Apple Silicon): `cargo clippy -p glass-macos --all-targets --locked -- -D warnings` clean; `cargo test -p glass-macos --lib` 27/27; the granted capture integration test captures a real window and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
