### PR TITLE
feat(macos): glass-macos input + physical-pixel coordinate model (Plan 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,6 +1654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.1",
+ "libc",
  "objc2",
  "objc2-foundation",
 ]

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -40,6 +40,10 @@ objc2-foundation = { version = "0.3.2", default-features = false, features = [
 objc2-app-kit = { version = "0.3.2", default-features = false, features = [
     "NSApplication",
     "NSResponder",
+    # `NSRunningApplication` — focus-before-inject (`input.rs::focus`); `libc` unlocks its
+    # `runningApplicationWithProcessIdentifier(pid: libc::pid_t)` class method.
+    "NSRunningApplication",
+    "libc",
 ] }
 objc2-screen-capture-kit = { version = "0.3.2", default-features = false, features = [
     "SCShareableContent",
@@ -56,6 +60,14 @@ objc2-core-graphics = { version = "0.3.2", default-features = false, features = 
     "CGContext",
     "CGBitmapContext",
     "objc2",
+    # CGEvent mouse injection (`input.rs`): `CGEvent` unlocks the `CGEvent` module (types +
+    # constructors/`post`/`set_flags`/etc.); `CGEventSource` the event-source constructor;
+    # `CGEventTypes` the `CGEventType`/`CGMouseButton`/`CGEventFlags`/`CGEventField`/
+    # `CGScrollEventUnit`/`CGEventTapLocation`/`CGEventSourceStateID` enums every call site
+    # here needs.
+    "CGEvent",
+    "CGEventSource",
+    "CGEventTypes",
 ] }
 objc2-core-foundation = { version = "0.3.2", default-features = false, features = [
     "CFCGTypes",

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -60,14 +60,17 @@ objc2-core-graphics = { version = "0.3.2", default-features = false, features = 
     "CGContext",
     "CGBitmapContext",
     "objc2",
-    # CGEvent mouse injection (`input.rs`): `CGEvent` unlocks the `CGEvent` module (types +
-    # constructors/`post`/`set_flags`/etc.); `CGEventSource` the event-source constructor;
-    # `CGEventTypes` the `CGEventType`/`CGMouseButton`/`CGEventFlags`/`CGEventField`/
-    # `CGScrollEventUnit`/`CGEventTapLocation`/`CGEventSourceStateID` enums every call site
-    # here needs.
+    # CGEvent mouse + keyboard injection (`input.rs`): `CGEvent` unlocks the `CGEvent`
+    # module (types + constructors/`post`/`set_flags`/etc.); `CGEventSource` the
+    # event-source constructor; `CGEventTypes` the `CGEventType`/`CGMouseButton`/
+    # `CGEventFlags`/`CGEventField`/`CGScrollEventUnit`/`CGEventTapLocation`/
+    # `CGEventSourceStateID` enums every call site here needs; `CGRemoteOperation` gates
+    # `CGEvent::new_keyboard_event` (`CGEventCreateKeyboardEvent`) and its `CGKeyCode`
+    # parameter type — `send_key`'s only addition over Task 2's mouse-only feature set.
     "CGEvent",
     "CGEventSource",
     "CGEventTypes",
+    "CGRemoteOperation",
 ] }
 objc2-core-foundation = { version = "0.3.2", default-features = false, features = [
     "CFCGTypes",

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -17,6 +17,13 @@ bench = false
 name = "capture"
 harness = false
 
+# Mac-gated input integration test (crates/glass-macos/tests/input.rs) — same harness=false
+# main-thread requirement as `capture` above (send_key/send_pointer reach AppKit's
+# NSRunningApplication::activate); see that file's module doc.
+[[test]]
+name = "input"
+harness = false
+
 [dependencies]
 glass-core.workspace = true
 

--- a/crates/glass-macos/fixture/quadrants.swift
+++ b/crates/glass-macos/fixture/quadrants.swift
@@ -1,4 +1,5 @@
-// quadrants.swift — glass-macos capture fixture (Plan 2, Task 6).
+// quadrants.swift — glass-macos capture + input fixture (Plan 2 Task 6, extended by Plan 3
+// Task 5).
 //
 // A minimal Cocoa app: a single 400x400 window whose entire content view paints 4 known
 // solid colors into the window's four VISUAL quadrants — i.e. the quadrants as they
@@ -25,8 +26,24 @@
 // in logs/debugging even though it isn't drawn as chrome.
 //
 // Also spawns a background thread that reads stdin lines and echoes `got: <line>` to
-// stdout, flushing after each — unused by this task's capture test, but exercised by the
-// future input plan (Plan 3) so the same fixture serves both.
+// stdout, flushing after each — used by the capture test only to confirm the process is
+// alive, but not for pixel assertions.
+//
+// This fixture is shared by TWO integration tests: the Plan 2 capture test (relies on the
+// 4-quadrant colors + exact 400x400 borderless window size) and the Plan 3 input test
+// (relies on the event reporting below). `QuadrantView` is made key/first-responder so it
+// actually receives keyboard and mouse events, and reports each one to stdout as a single
+// flushed line so the driving test can assert on injected input landing correctly:
+//
+//   key: <characters>      — one line per keyDown, the event's `characters` string.
+//   click: <x>,<y>         — one line per (left) mouseDown, in the content view's
+//                             coordinate space converted to TOP-LEFT-origin pixels (the
+//                             tool boundary's convention) — see `mouseDown` below for the
+//                             flip. For a borderless 1x-backing-scale window, view points
+//                             == window pixels.
+//   scroll: <dx>,<dy>      — one line per scrollWheel, `scrollingDeltaX`/`scrollingDeltaY`
+//                             verbatim (sign as macOS reports it), for verifying the
+//                             scroll-wheel sign convention against the tool boundary.
 //
 // Build: swiftc -O -parse-as-library quadrants.swift -o quadrants
 //   (`-parse-as-library` is required because this file uses a top-level `@main` type
@@ -45,6 +62,9 @@ final class FixtureWindow: NSWindow {
 }
 
 final class QuadrantView: NSView {
+    // Required to become first responder at all — NSView defaults to false.
+    override var acceptsFirstResponder: Bool { true }
+
     override func draw(_ dirtyRect: NSRect) {
         let half = bounds.width / 2 // == bounds.height / 2 for a 400x400 view
         let quadrants: [(NSRect, NSColor)] = [
@@ -64,6 +84,33 @@ final class QuadrantView: NSView {
     private let green = NSColor(deviceRed: 0, green: 1, blue: 0, alpha: 1)
     private let blue = NSColor(deviceRed: 0, green: 0, blue: 1, alpha: 1)
     private let white = NSColor(deviceRed: 1, green: 1, blue: 1, alpha: 1)
+
+    // MARK: - Input reporting (Plan 3)
+
+    override func keyDown(with event: NSEvent) {
+        print("key: \(event.characters ?? "")")
+        fflush(stdout)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        // `locationInWindow` is in the window's coordinate space (bottom-left origin);
+        // convert into this view's coordinate space (also bottom-left origin, since the
+        // view is unflipped — see the quadrant-color comment above), then flip y to match
+        // the tool boundary's top-left-origin pixel convention. For a borderless window at
+        // 1x backing scale, view points == window pixels, so no further scaling is needed.
+        let locationInView = convert(event.locationInWindow, from: nil)
+        let x = Int(locationInView.x.rounded())
+        let y = Int((bounds.height - locationInView.y).rounded())
+        print("click: \(x),\(y)")
+        fflush(stdout)
+    }
+
+    override func scrollWheel(with event: NSEvent) {
+        // Reported verbatim (sign as macOS delivers it) so the driving test can check the
+        // scroll-wheel sign convention against what the tool boundary sends.
+        print("scroll: \(event.scrollingDeltaX),\(event.scrollingDeltaY)")
+        fflush(stdout)
+    }
 }
 
 /// Reads stdin lines on a background thread and echoes `got: <line>` to stdout — for
@@ -96,6 +143,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         window.level = .normal
         window.contentView = QuadrantView(frame: rect)
         window.makeKeyAndOrderFront(nil)
+        window.makeFirstResponder(window.contentView)
         NSApp.activate(ignoringOtherApps: true)
     }
 }

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -13,6 +13,7 @@ use glass_core::platform::{
 };
 use glass_core::{GlassError, Result};
 
+use crate::coords;
 use crate::permissions;
 use crate::process::{self, LogSink};
 
@@ -46,6 +47,13 @@ pub struct MacosPlatform {
     /// screen space), from the last `start_app`'s `WindowMatch`. Defaults to `(0.0, 0.0)`
     /// before any session starts. See `scale`'s doc.
     origin_pt: (f64, f64),
+    /// The active session's window geometry in PIXELS (`WindowMatch::geometry`), from the
+    /// last `start_app`. Defaults to a zero-sized geometry before any session starts.
+    /// `send_pointer` bounds-checks each window-relative coordinate against this before
+    /// mapping it to a global point — see `check_pointer_bounds`'s doc for why the backend
+    /// enforces this itself rather than relying solely on `glass_core::session`'s own
+    /// (session-layer) bounds check.
+    geom: WindowGeometry,
 }
 
 impl MacosPlatform {
@@ -58,6 +66,7 @@ impl MacosPlatform {
             child: None,
             scale: 1.0,
             origin_pt: (0.0, 0.0),
+            geom: WindowGeometry::default(),
         })
     }
 
@@ -116,6 +125,37 @@ impl MacosPlatform {
     }
 }
 
+/// Bounds-check every window-relative coordinate `event` carries against `geom` via
+/// `coords::check_in_bounds`, failing with `GlassError::CoordOutOfBounds` before
+/// `input::send_pointer` ever maps a coordinate to a global point — the "no
+/// silently-wrong click" invariant. `glass_core::session` already runs an equivalent check
+/// (`Session::check_bounds`) above every backend, but that's not a substitute here: this
+/// crate's mac-gated integration tests (Task 6) call `MacosPlatform::send_pointer`
+/// directly, bypassing the session layer entirely, so the backend must not depend on a
+/// caller it can't guarantee sits in front of it. Mirrors `Session::check_bounds`'s own
+/// per-variant coverage (both endpoints of a `Drag`, every pointer of a `Gesture`) even
+/// though `Gesture` itself is `Unsupported` on macOS — bounds-checking still runs first so
+/// an out-of-bounds `Gesture` reports `CoordOutOfBounds`, not `Unsupported`.
+fn check_pointer_bounds(event: &PointerEvent, geom: &WindowGeometry) -> Result<()> {
+    let check = |x: i32, y: i32| coords::check_in_bounds(x, y, geom.width, geom.height);
+    match *event {
+        PointerEvent::Move { x, y } => check(x, y),
+        PointerEvent::Click { x, y, .. } => check(x, y),
+        PointerEvent::Scroll { x, y, .. } => check(x, y),
+        PointerEvent::Drag { from_x, from_y, to_x, to_y, .. } => {
+            check(from_x, from_y)?;
+            check(to_x, to_y)
+        }
+        PointerEvent::Gesture { ref pointers, .. } => {
+            for p in pointers {
+                check(p.from_x, p.from_y)?;
+                check(p.to_x, p.to_y)?;
+            }
+            Ok(())
+        }
+    }
+}
+
 impl Platform for MacosPlatform {
     /// Run the optional build step, spawn the app, then confirm a window appears for its
     /// pid within `spec.timeout_ms` via ScreenCaptureKit's `SCShareableContent`
@@ -137,6 +177,7 @@ impl Platform for MacosPlatform {
                 self.app_pid = Some(pid);
                 self.scale = m.scale;
                 self.origin_pt = m.origin_pt;
+                self.geom = m.geometry.clone();
                 Ok(m.geometry)
             }
             Err(e) => {
@@ -172,14 +213,20 @@ impl Platform for MacosPlatform {
     }
     /// Map the active session's pid/`scale`/`origin_pt` into `input::send_pointer` — see
     /// `input.rs`'s module doc for the CGEvent details and its main-thread-affinity note
-    /// (shared with `start_app`/`capture_frame` above).
+    /// (shared with `start_app`/`capture_frame` above). Bounds-checked against `self.geom`
+    /// first — see `check_pointer_bounds`'s doc.
     fn send_pointer(&mut self, event: &PointerEvent) -> Result<()> {
         permissions::preflight()?;
         let pid = self.app_pid.ok_or(GlassError::NoActiveSession)?;
+        check_pointer_bounds(event, &self.geom)?;
         crate::input::send_pointer(event, pid as i32, self.scale, self.origin_pt)
     }
-    fn send_key(&mut self, _event: &KeyEvent) -> Result<()> {
-        unimplemented!("Plan 3: CGEvent keyboard")
+    /// Map the active session's pid into `input::send_key` — see `input.rs`'s module doc
+    /// for the CGEvent keyboard details.
+    fn send_key(&mut self, event: &KeyEvent) -> Result<()> {
+        permissions::preflight()?;
+        let pid = self.app_pid.ok_or(GlassError::NoActiveSession)?;
+        crate::input::send_key(event, pid as i32)
     }
     fn window(&mut self, _op: &WindowOp) -> Result<WindowGeometry> {
         unimplemented!("Plan 4: AXUIElement window ops")
@@ -225,6 +272,7 @@ mod tests {
             child: None,
             scale: 1.0,
             origin_pt: (0.0, 0.0),
+            geom: WindowGeometry::default(),
         };
         assert_eq!(p.drain_logs().len(), 1);
         assert!(p.drain_logs().is_empty());
@@ -238,6 +286,7 @@ mod tests {
             child: None,
             scale: 1.0,
             origin_pt: (0.0, 0.0),
+            geom: WindowGeometry::default(),
         };
         assert_eq!(p.app_pid(), Some(42));
     }
@@ -253,6 +302,7 @@ mod tests {
             child: None,
             scale: 1.0,
             origin_pt: (0.0, 0.0),
+            geom: WindowGeometry::default(),
         };
         assert!(p.stop_app().is_ok());
         assert!(p.stop_app().is_ok(), "a second call must also be Ok");
@@ -265,5 +315,37 @@ mod tests {
         // future edit that swallows the missing-grant propagation. On an ungranted CI runner
         // both are Err; on a granted box both are Ok.
         assert_eq!(crate::permissions::preflight().is_err(), MacosPlatform::new().is_err());
+    }
+
+    #[test]
+    fn check_pointer_bounds_accepts_inside_rejects_outside() {
+        let geom = WindowGeometry { x: 0, y: 0, width: 640, height: 480 };
+        assert!(check_pointer_bounds(&PointerEvent::Move { x: 0, y: 0 }, &geom).is_ok());
+        assert!(check_pointer_bounds(&PointerEvent::Move { x: 639, y: 479 }, &geom).is_ok());
+        assert!(matches!(
+            check_pointer_bounds(&PointerEvent::Move { x: 640, y: 0 }, &geom),
+            Err(GlassError::CoordOutOfBounds { .. })
+        ));
+        assert!(matches!(
+            check_pointer_bounds(&PointerEvent::Move { x: -1, y: 0 }, &geom),
+            Err(GlassError::CoordOutOfBounds { .. })
+        ));
+    }
+
+    #[test]
+    fn check_pointer_bounds_checks_both_drag_endpoints() {
+        use glass_core::platform::MouseButton;
+        let geom = WindowGeometry { x: 0, y: 0, width: 640, height: 480 };
+        // In-bounds `from`, out-of-bounds `to`: must still reject.
+        let ev = PointerEvent::Drag {
+            from_x: 0,
+            from_y: 0,
+            to_x: 700,
+            to_y: 0,
+            button: MouseButton::Left,
+            modifiers: vec![],
+            duration_ms: 100,
+        };
+        assert!(matches!(check_pointer_bounds(&ev, &geom), Err(GlassError::CoordOutOfBounds { .. })));
     }
 }

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -35,13 +35,31 @@ pub struct MacosPlatform {
     /// The launched child process, kept so `stop_app`/`Drop` can `process::terminate`
     /// it. `None` until `start_app` and after `stop_app` (idempotent).
     child: Option<Child>,
+    /// The active session's `pointPixelScale` (`1.0` on a 1x display, `2.0` on 2x
+    /// Retina), from the last `start_app`'s `WindowMatch`. Defaults to `1.0` before any
+    /// session starts. Stored for `send_pointer`/`send_key` (Plan 3) to map a
+    /// window-relative PIXEL coordinate (the tool boundary's unit) to a global POINT via
+    /// `coords::pixel_to_global_point` before posting a CGEvent — not yet read here.
+    #[allow(dead_code)]
+    scale: f64,
+    /// The active session's window `contentRect.origin`, in POINTS (Quartz's global
+    /// screen space), from the last `start_app`'s `WindowMatch`. Defaults to `(0.0, 0.0)`
+    /// before any session starts. See `scale`'s doc — not yet read here.
+    #[allow(dead_code)]
+    origin_pt: (f64, f64),
 }
 
 impl MacosPlatform {
     /// Construct the backend, failing fast if a required TCC grant is missing.
     pub fn new() -> Result<Self> {
         permissions::preflight()?;
-        Ok(Self { logs: Arc::new(Mutex::new(Vec::new())), app_pid: None, child: None })
+        Ok(Self {
+            logs: Arc::new(Mutex::new(Vec::new())),
+            app_pid: None,
+            child: None,
+            scale: 1.0,
+            origin_pt: (0.0, 0.0),
+        })
     }
 
     /// Run the optional `spec.build` shell step in `spec.cwd`, mirroring the X11/Windows
@@ -74,12 +92,19 @@ impl MacosPlatform {
     /// `glass-x11/src/platform.rs`'s `discover_window`. Can't delegate this to
     /// `scwindow::find_window_for_pids`: that helper owns its *entire* poll loop
     /// internally, with no child handle to race against.
-    fn discover_window(child: &mut Child, pid: u32, timeout_ms: u64) -> Result<WindowGeometry> {
+    ///
+    /// Returns the whole [`crate::scwindow::WindowMatch`] (not just its `geometry`) so
+    /// `start_app` can also stash `scale`/`origin_pt` for the session.
+    fn discover_window(
+        child: &mut Child,
+        pid: u32,
+        timeout_ms: u64,
+    ) -> Result<crate::scwindow::WindowMatch> {
         crate::ffi::app_kit_init();
         let deadline = Instant::now() + Duration::from_millis(timeout_ms.max(1));
         loop {
             if let Some(m) = crate::scwindow::query_once(&[pid as i32])? {
-                return Ok(m.geometry);
+                return Ok(m);
             }
             if let Ok(Some(status)) = child.try_wait() {
                 return Err(GlassError::AppExited(status.code()));
@@ -108,10 +133,12 @@ impl Platform for MacosPlatform {
         let mut child = process::spawn(spec, self.logs.clone())?;
         let pid = child.id();
         match Self::discover_window(&mut child, pid, spec.timeout_ms) {
-            Ok(geometry) => {
+            Ok(m) => {
                 self.child = Some(child);
                 self.app_pid = Some(pid);
-                Ok(geometry)
+                self.scale = m.scale;
+                self.origin_pt = m.origin_pt;
+                Ok(m.geometry)
             }
             Err(e) => {
                 // The window never appeared (or discovery otherwise failed): don't leak
@@ -192,6 +219,8 @@ mod tests {
             logs: Arc::new(Mutex::new(vec![(Stream::Stdout, "hi".into())])),
             app_pid: Some(42),
             child: None,
+            scale: 1.0,
+            origin_pt: (0.0, 0.0),
         };
         assert_eq!(p.drain_logs().len(), 1);
         assert!(p.drain_logs().is_empty());
@@ -199,8 +228,13 @@ mod tests {
 
     #[test]
     fn app_pid_returns_the_constructed_value() {
-        let p =
-            MacosPlatform { logs: Arc::new(Mutex::new(Vec::new())), app_pid: Some(42), child: None };
+        let p = MacosPlatform {
+            logs: Arc::new(Mutex::new(Vec::new())),
+            app_pid: Some(42),
+            child: None,
+            scale: 1.0,
+            origin_pt: (0.0, 0.0),
+        };
         assert_eq!(p.app_pid(), Some(42));
     }
 
@@ -209,7 +243,13 @@ mod tests {
         // No child stored: stop_app must not panic (e.g. on an unwrap of a live process
         // handle) and must succeed — this path never touches AppKit, so it's exercisable
         // off the Mac-gated suite's main-thread test.
-        let mut p = MacosPlatform { logs: Arc::new(Mutex::new(Vec::new())), app_pid: None, child: None };
+        let mut p = MacosPlatform {
+            logs: Arc::new(Mutex::new(Vec::new())),
+            app_pid: None,
+            child: None,
+            scale: 1.0,
+            origin_pt: (0.0, 0.0),
+        };
         assert!(p.stop_app().is_ok());
         assert!(p.stop_app().is_ok(), "a second call must also be Ok");
         assert_eq!(p.app_pid(), None);

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -174,6 +174,7 @@ impl Platform for MacosPlatform {
     /// `input.rs`'s module doc for the CGEvent details and its main-thread-affinity note
     /// (shared with `start_app`/`capture_frame` above).
     fn send_pointer(&mut self, event: &PointerEvent) -> Result<()> {
+        permissions::preflight()?;
         let pid = self.app_pid.ok_or(GlassError::NoActiveSession)?;
         crate::input::send_pointer(event, pid as i32, self.scale, self.origin_pt)
     }

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -37,15 +37,14 @@ pub struct MacosPlatform {
     child: Option<Child>,
     /// The active session's `pointPixelScale` (`1.0` on a 1x display, `2.0` on 2x
     /// Retina), from the last `start_app`'s `WindowMatch`. Defaults to `1.0` before any
-    /// session starts. Stored for `send_pointer`/`send_key` (Plan 3) to map a
-    /// window-relative PIXEL coordinate (the tool boundary's unit) to a global POINT via
-    /// `coords::pixel_to_global_point` before posting a CGEvent — not yet read here.
-    #[allow(dead_code)]
+    /// session starts. Read by `send_pointer` (Plan 3 Task 2) to map a window-relative
+    /// PIXEL coordinate (the tool boundary's unit) to a global POINT via
+    /// `coords::pixel_to_global_point` before posting a CGEvent; `send_key` (Plan 3 Task 3)
+    /// doesn't need it.
     scale: f64,
     /// The active session's window `contentRect.origin`, in POINTS (Quartz's global
     /// screen space), from the last `start_app`'s `WindowMatch`. Defaults to `(0.0, 0.0)`
-    /// before any session starts. See `scale`'s doc — not yet read here.
-    #[allow(dead_code)]
+    /// before any session starts. See `scale`'s doc.
     origin_pt: (f64, f64),
 }
 
@@ -171,8 +170,12 @@ impl Platform for MacosPlatform {
         let pid = self.app_pid.ok_or(GlassError::NoActiveSession)?;
         crate::capture::capture_window(&[pid as i32], region)
     }
-    fn send_pointer(&mut self, _event: &PointerEvent) -> Result<()> {
-        unimplemented!("Plan 3: CGEvent pointer")
+    /// Map the active session's pid/`scale`/`origin_pt` into `input::send_pointer` — see
+    /// `input.rs`'s module doc for the CGEvent details and its main-thread-affinity note
+    /// (shared with `start_app`/`capture_frame` above).
+    fn send_pointer(&mut self, event: &PointerEvent) -> Result<()> {
+        let pid = self.app_pid.ok_or(GlassError::NoActiveSession)?;
+        crate::input::send_pointer(event, pid as i32, self.scale, self.origin_pt)
     }
     fn send_key(&mut self, _event: &KeyEvent) -> Result<()> {
         unimplemented!("Plan 3: CGEvent keyboard")

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -23,6 +23,13 @@ use crate::process::{self, LogSink};
 /// against `child.try_wait()`.
 const DISCOVERY_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
+/// Timeout for the fresh window re-resolution [`MacosPlatform::send_pointer`] does on every
+/// call via `scwindow::find_window_for_pids`. Short (unlike `start_app`'s `spec.timeout_ms`,
+/// which waits for a brand-new window to first appear): the window is already known to have
+/// existed as of the last successful call, so this only needs to cover the ordinary
+/// query-round-trip latency, not a real "is the app even launching" wait.
+const POINTER_RESOLVE_TIMEOUT: Duration = Duration::from_millis(2000);
+
 /// macOS backend. v1 renders the target app onto a `CGVirtualDisplay` (Plan 2) and
 /// drives it with ScreenCaptureKit + CGEvent + AXUIElement.
 pub struct MacosPlatform {
@@ -36,38 +43,13 @@ pub struct MacosPlatform {
     /// The launched child process, kept so `stop_app`/`Drop` can `process::terminate`
     /// it. `None` until `start_app` and after `stop_app` (idempotent).
     child: Option<Child>,
-    /// The active session's `pointPixelScale` (`1.0` on a 1x display, `2.0` on 2x
-    /// Retina), from the last `start_app`'s `WindowMatch`. Defaults to `1.0` before any
-    /// session starts. Read by `send_pointer` (Plan 3 Task 2) to map a window-relative
-    /// PIXEL coordinate (the tool boundary's unit) to a global POINT via
-    /// `coords::pixel_to_global_point` before posting a CGEvent; `send_key` (Plan 3 Task 3)
-    /// doesn't need it.
-    scale: f64,
-    /// The active session's window `contentRect.origin`, in POINTS (Quartz's global
-    /// screen space), from the last `start_app`'s `WindowMatch`. Defaults to `(0.0, 0.0)`
-    /// before any session starts. See `scale`'s doc.
-    origin_pt: (f64, f64),
-    /// The active session's window geometry in PIXELS (`WindowMatch::geometry`), from the
-    /// last `start_app`. Defaults to a zero-sized geometry before any session starts.
-    /// `send_pointer` bounds-checks each window-relative coordinate against this before
-    /// mapping it to a global point — see `check_pointer_bounds`'s doc for why the backend
-    /// enforces this itself rather than relying solely on `glass_core::session`'s own
-    /// (session-layer) bounds check.
-    geom: WindowGeometry,
 }
 
 impl MacosPlatform {
     /// Construct the backend, failing fast if a required TCC grant is missing.
     pub fn new() -> Result<Self> {
         permissions::preflight()?;
-        Ok(Self {
-            logs: Arc::new(Mutex::new(Vec::new())),
-            app_pid: None,
-            child: None,
-            scale: 1.0,
-            origin_pt: (0.0, 0.0),
-            geom: WindowGeometry::default(),
-        })
+        Ok(Self { logs: Arc::new(Mutex::new(Vec::new())), app_pid: None, child: None })
     }
 
     /// Run the optional `spec.build` shell step in `spec.cwd`, mirroring the X11/Windows
@@ -101,8 +83,11 @@ impl MacosPlatform {
     /// `scwindow::find_window_for_pids`: that helper owns its *entire* poll loop
     /// internally, with no child handle to race against.
     ///
-    /// Returns the whole [`crate::scwindow::WindowMatch`] (not just its `geometry`) so
-    /// `start_app` can also stash `scale`/`origin_pt` for the session.
+    /// Returns the whole [`crate::scwindow::WindowMatch`] (not just its `geometry`), even
+    /// though `start_app` only reads `geometry` from it today — `send_pointer` does its own
+    /// independent, fresh `scwindow::find_window_for_pids` resolution per call rather than
+    /// reusing anything cached here (see its doc), so this return type is just the natural
+    /// shape of a `query_once` result, not evidence of caching elsewhere.
     fn discover_window(
         child: &mut Child,
         pid: u32,
@@ -175,9 +160,10 @@ impl Platform for MacosPlatform {
             Ok(m) => {
                 self.child = Some(child);
                 self.app_pid = Some(pid);
-                self.scale = m.scale;
-                self.origin_pt = m.origin_pt;
-                self.geom = m.geometry.clone();
+                // Scale/origin/geometry are NOT cached here: `send_pointer` re-resolves the
+                // window fresh on every call instead (see its doc) since it may move/resize
+                // after this initial discovery. Only the initial geometry is returned to the
+                // caller, matching every other backend's `start_app` contract.
                 Ok(m.geometry)
             }
             Err(e) => {
@@ -211,15 +197,22 @@ impl Platform for MacosPlatform {
         let pid = self.app_pid.ok_or(GlassError::NoActiveSession)?;
         crate::capture::capture_window(&[pid as i32], region)
     }
-    /// Map the active session's pid/`scale`/`origin_pt` into `input::send_pointer` — see
-    /// `input.rs`'s module doc for the CGEvent details and its main-thread-affinity note
-    /// (shared with `start_app`/`capture_frame` above). Bounds-checked against `self.geom`
-    /// first — see `check_pointer_bounds`'s doc.
+    /// Map the active session's pid into `input::send_pointer` — see `input.rs`'s module
+    /// doc for the CGEvent details and its main-thread-affinity note (shared with
+    /// `start_app`/`capture_frame` above).
+    ///
+    /// NOTE: re-resolves the window fresh via `scwindow::find_window_for_pids` on every
+    /// call, mirroring `capture_frame`'s per-call resolution above — the window may have
+    /// moved or resized since `start_app` (or any earlier `send_pointer` call), so a
+    /// `scale`/`origin_pt`/geometry cached once at `start_app` would go stale. Both the
+    /// bounds check (`check_pointer_bounds`, see its doc) and the coordinate mapping use
+    /// this freshly-resolved geometry/scale/origin.
     fn send_pointer(&mut self, event: &PointerEvent) -> Result<()> {
         permissions::preflight()?;
         let pid = self.app_pid.ok_or(GlassError::NoActiveSession)?;
-        check_pointer_bounds(event, &self.geom)?;
-        crate::input::send_pointer(event, pid as i32, self.scale, self.origin_pt)
+        let m = crate::scwindow::find_window_for_pids(&[pid as i32], POINTER_RESOLVE_TIMEOUT)?;
+        check_pointer_bounds(event, &m.geometry)?;
+        crate::input::send_pointer(event, pid as i32, m.scale, m.origin_pt)
     }
     /// Map the active session's pid into `input::send_key` — see `input.rs`'s module doc
     /// for the CGEvent keyboard details.
@@ -270,9 +263,6 @@ mod tests {
             logs: Arc::new(Mutex::new(vec![(Stream::Stdout, "hi".into())])),
             app_pid: Some(42),
             child: None,
-            scale: 1.0,
-            origin_pt: (0.0, 0.0),
-            geom: WindowGeometry::default(),
         };
         assert_eq!(p.drain_logs().len(), 1);
         assert!(p.drain_logs().is_empty());
@@ -280,14 +270,7 @@ mod tests {
 
     #[test]
     fn app_pid_returns_the_constructed_value() {
-        let p = MacosPlatform {
-            logs: Arc::new(Mutex::new(Vec::new())),
-            app_pid: Some(42),
-            child: None,
-            scale: 1.0,
-            origin_pt: (0.0, 0.0),
-            geom: WindowGeometry::default(),
-        };
+        let p = MacosPlatform { logs: Arc::new(Mutex::new(Vec::new())), app_pid: Some(42), child: None };
         assert_eq!(p.app_pid(), Some(42));
     }
 
@@ -296,14 +279,7 @@ mod tests {
         // No child stored: stop_app must not panic (e.g. on an unwrap of a live process
         // handle) and must succeed — this path never touches AppKit, so it's exercisable
         // off the Mac-gated suite's main-thread test.
-        let mut p = MacosPlatform {
-            logs: Arc::new(Mutex::new(Vec::new())),
-            app_pid: None,
-            child: None,
-            scale: 1.0,
-            origin_pt: (0.0, 0.0),
-            geom: WindowGeometry::default(),
-        };
+        let mut p = MacosPlatform { logs: Arc::new(Mutex::new(Vec::new())), app_pid: None, child: None };
         assert!(p.stop_app().is_ok());
         assert!(p.stop_app().is_ok(), "a second call must also be Ok");
         assert_eq!(p.app_pid(), None);

--- a/crates/glass-macos/src/capture.rs
+++ b/crates/glass-macos/src/capture.rs
@@ -113,16 +113,13 @@ pub(crate) fn capture_window(pids: &[i32], region: Option<&Region>) -> Result<Fr
                     // callback. All work on it happens synchronously right here — the
                     // `CGImage` itself never leaves this block.
                     let image: &CGImage = unsafe { &*image_ptr };
-                    // NOTE: `Frame` is captured in backing PIXELS (`contentRect.size *
-                    // pointPixelScale`, this same `scale`), while `region` is
-                    // window-relative POINTS — the unit the session layer validates it in
-                    // (`WindowGeometry`, from `SCWindow.frame()`; see `scwindow.rs`).
-                    // `crop_to_region` converts it to pixels via `scale` before cropping
-                    // the pixel-space `Frame`. The wider points-vs-pixels reconciliation
-                    // across geometry/frame/click (the other backends use physical pixels
-                    // throughout) is a later coordinate-design item, not solved here.
+                    // `Frame` is captured in backing PIXELS (`contentRect.size *
+                    // pointPixelScale`), and `region` is already window-relative PIXELS
+                    // too — the tool boundary's unit throughout (see `coords.rs`'s module
+                    // doc and `scwindow.rs`'s `WindowMatch::geometry`) — so `crop_to_region`
+                    // crops directly, no unit conversion needed.
                     let result = rgba_frame_from_cgimage(image)
-                        .and_then(|frame| crop_to_region(frame, region_owned.as_ref(), scale));
+                        .and_then(|frame| crop_to_region(frame, region_owned.as_ref()));
                     let _ = tx_img.send(match result {
                         Ok(frame) => CaptureReply::Ok(frame),
                         Err(e) => CaptureReply::Err(e),
@@ -177,18 +174,16 @@ enum CaptureReply {
 /// Crop `frame` to `region`, clamping to the captured frame first via
 /// [`crate::coords::clamp_region`] (defense in depth — the session layer should already
 /// validate the region against the window before it reaches the backend, per
-/// `glass_core::frame::Region::check_fits`'s doc). `region` is window-relative POINTS (see
-/// the NOTE at the call site above); `scale` (`pointPixelScale`) converts it to the PIXELS
-/// `frame` itself is in, via [`crate::coords::scale_region`], before clamping/cropping.
-/// `None` returns `frame` unchanged (no scaling needed for a no-op).
-fn crop_to_region(frame: Frame, region: Option<&Region>, scale: f64) -> Result<Frame> {
+/// `glass_core::frame::Region::check_fits`'s doc). `region` is already window-relative
+/// PIXELS, the same unit `frame` itself is in — no scaling needed. `None` returns `frame`
+/// unchanged.
+fn crop_to_region(frame: Frame, region: Option<&Region>) -> Result<Frame> {
     let Some(r) = region else { return Ok(frame) };
-    let pixel_region = crate::coords::scale_region(r, scale);
     let clamped = crate::coords::clamp_region(
-        pixel_region.x as i32,
-        pixel_region.y as i32,
-        pixel_region.width,
-        pixel_region.height,
+        r.x as i32,
+        r.y as i32,
+        r.width,
+        r.height,
         frame.width,
         frame.height,
     );

--- a/crates/glass-macos/src/coords.rs
+++ b/crates/glass-macos/src/coords.rs
@@ -1,8 +1,17 @@
 //! Pure window-relative ↔ global coordinate math. Cross-platform → unit-tested on the
-//! Linux dev box. The macOS backend (Plans 2–4) maps window-relative tool coordinates to
-//! global screen coordinates here before posting CGEvents or capturing a sub-region.
+//! Linux dev box.
+//!
+//! The whole glass tool boundary — `WindowGeometry`, the captured `Frame`, and
+//! click/region coordinates — is backing PIXELS on macOS, matching `glass-x11` and
+//! `glass-windows`. Quartz's `CGEvent` APIs, though, address the *global* screen in
+//! POINTS, not pixels — so the macOS backend (Plan 3) uses [`pixel_to_global_point`] to
+//! map a window-relative PIXEL coordinate to a global POINT before posting a CGEvent.
+//! [`pixel_geometry_from_content_rect`] is the mirror-image conversion `scwindow.rs` uses
+//! to turn `SCContentFilter`'s `contentRect` (POINTS) + `pointPixelScale` into the PIXEL
+//! `WindowGeometry` the tool boundary reports.
 
 use glass_core::frame::Region;
+use glass_core::platform::WindowGeometry;
 use glass_core::{GlassError, Result};
 
 /// Translate a window-relative point to a global screen point given the window origin.
@@ -30,30 +39,42 @@ pub fn clamp_region(rx: i32, ry: i32, rw: u32, rh: u32, width: u32, height: u32)
     Region { x: left as u32, y: top as u32, width: (right - left) as u32, height: (bottom - top) as u32 }
 }
 
-/// Convert a window-relative `region` from POINTS to backing PIXELS by scaling every field
-/// by `scale` (macOS's `pointPixelScale`: `1.0` on a 1x display, `2.0` on 2x Retina).
+/// Map a window-relative PIXEL coordinate to a global POINT in Quartz's screen space:
+/// `origin_pt + rel_px / scale`. `scale` is the window's `pointPixelScale` (`1.0` on a 1x
+/// display, `2.0` on 2x Retina) and `origin_pt` is the window's `contentRect.origin` in
+/// POINTS (see [`pixel_geometry_from_content_rect`]'s doc for where both come from).
 ///
-/// The macOS capture backend needs this because its two coordinate sources disagree:
-/// `capture::capture_window`'s `Frame` is sized in backing pixels
-/// (`contentRect.size * pointPixelScale`), but the `region` passed to it is window-relative
-/// points — the unit `WindowGeometry` (from `SCWindow.frame()`) and the session layer's
-/// region validation both use. Cropping a points-sized region straight against a
-/// pixels-sized `Frame` silently reads the wrong (quarter-sized, on 2x) sub-image. Pure and
-/// cross-platform so the Retina (2x) math is unit-tested here even on a 1x dev box; the
-/// wider points-vs-pixels reconciliation across geometry/frame/click (the other backends
-/// use physical pixels throughout) is a later coordinate-design item, not solved by this
-/// one conversion.
+/// The macOS backend needs this because CGEvents post into a POINTS-addressed global
+/// space, while every tool-boundary coordinate (click/region, `WindowGeometry`, the
+/// captured `Frame`) is backing PIXELS — matching `glass-x11`/`glass-windows`. This is the
+/// one place a pixel value crosses back into points, right before posting a CGEvent.
+pub fn pixel_to_global_point(rel_px: (i32, i32), scale: f64, origin_pt: (f64, f64)) -> (f64, f64) {
+    (origin_pt.0 + rel_px.0 as f64 / scale, origin_pt.1 + rel_px.1 as f64 / scale)
+}
+
+/// Convert a window's `contentRect` (POINTS, from `SCContentFilter.contentRect()`) plus
+/// its `pointPixelScale` into a `WindowGeometry` in backing PIXELS — the unit the whole
+/// tool boundary uses. `x`/`y` is `contentRect.origin`, `width`/`height` is
+/// `contentRect.size`; each field is independently scaled by `scale` and rounded to the
+/// nearest pixel, matching how `capture::capture_window` sizes the captured `Frame`
+/// (`contentRect.size * pointPixelScale`) — so `scwindow.rs`'s reported geometry and
+/// `capture.rs`'s captured frame always agree on width/height in pixels.
 ///
-/// Each field rounds to the nearest pixel independently (`f64::round`, ties away from
-/// zero) rather than truncating, so a fractional point value doesn't consistently lose a
-/// pixel versus the frame it's cropped against.
-pub fn scale_region(region: &Region, scale: f64) -> Region {
-    let scaled = |v: u32| (v as f64 * scale).round() as u32;
-    Region {
-        x: scaled(region.x),
-        y: scaled(region.y),
-        width: scaled(region.width),
-        height: scaled(region.height),
+/// Pure `f64` math (no `CGRect` dependency) so the Retina (2x) scaling is unit-tested here
+/// even on a 1x dev box — `scwindow.rs` itself only compiles on macOS.
+///
+/// Each field rounds independently (`f64::round`, ties away from zero) rather than
+/// truncating, so a fractional point value doesn't consistently lose a pixel. Width/height
+/// clamp to `0` on a degenerate (negative) input rather than wrapping; `x`/`y` stay signed
+/// (a window can sit left-of/above the primary display's origin in a multi-monitor
+/// layout).
+pub fn pixel_geometry_from_content_rect(x: f64, y: f64, width: f64, height: f64, scale: f64) -> WindowGeometry {
+    let px = |v: f64| (v * scale).round();
+    WindowGeometry {
+        x: px(x) as i32,
+        y: px(y) as i32,
+        width: px(width).max(0.0) as u32,
+        height: px(height).max(0.0) as u32,
     }
 }
 
@@ -95,22 +116,62 @@ mod tests {
     }
 
     #[test]
-    fn scale_region_is_identity_at_1x() {
-        let region = Region { x: 10, y: 20, width: 300, height: 200 };
-        assert_eq!(scale_region(&region, 1.0), region);
+    fn pixel_to_global_point_at_1x() {
+        assert_eq!(pixel_to_global_point((100, 200), 1.0, (10.0, 20.0)), (110.0, 220.0));
     }
 
     #[test]
-    fn scale_region_doubles_at_2x_retina() {
-        let region = Region { x: 10, y: 20, width: 300, height: 200 };
-        assert_eq!(scale_region(&region, 2.0), Region { x: 20, y: 40, width: 600, height: 400 });
+    fn pixel_to_global_point_at_2x_retina() {
+        // pixel 200 / 2 = 100pt + origin 10 = 110; pixel 400 / 2 = 200pt + origin 20 = 220.
+        assert_eq!(pixel_to_global_point((200, 400), 2.0, (10.0, 20.0)), (110.0, 220.0));
     }
 
     #[test]
-    fn scale_region_rounds_to_nearest_pixel() {
+    fn pixel_to_global_point_handles_negative_rel_and_origin() {
+        assert_eq!(pixel_to_global_point((-40, -10), 2.0, (-5.0, 0.0)), (-25.0, -5.0));
+    }
+
+    #[test]
+    fn pixel_geometry_from_content_rect_is_identity_at_1x() {
+        assert_eq!(
+            pixel_geometry_from_content_rect(10.0, 20.0, 300.0, 200.0, 1.0),
+            WindowGeometry { x: 10, y: 20, width: 300, height: 200 }
+        );
+    }
+
+    #[test]
+    fn pixel_geometry_from_content_rect_scales_at_2x_retina() {
+        assert_eq!(
+            pixel_geometry_from_content_rect(10.0, 20.0, 300.0, 200.0, 2.0),
+            WindowGeometry { x: 20, y: 40, width: 600, height: 400 }
+        );
+    }
+
+    #[test]
+    fn pixel_geometry_from_content_rect_rounds_to_nearest_pixel() {
         // 1*1.5=1.5 -> 2, 3*1.5=4.5 -> 5 (round-half-away-from-zero, per f64::round):
         // fields round independently rather than truncating.
-        let region = Region { x: 1, y: 1, width: 3, height: 3 };
-        assert_eq!(scale_region(&region, 1.5), Region { x: 2, y: 2, width: 5, height: 5 });
+        assert_eq!(
+            pixel_geometry_from_content_rect(1.0, 1.0, 3.0, 3.0, 1.5),
+            WindowGeometry { x: 2, y: 2, width: 5, height: 5 }
+        );
+    }
+
+    #[test]
+    fn pixel_geometry_from_content_rect_clamps_negative_size_to_zero() {
+        // A real contentRect from SCContentFilter never has a negative size, but the
+        // conversion must not panic or wrap on malformed input.
+        assert_eq!(
+            pixel_geometry_from_content_rect(0.0, 0.0, -1.0, -1.0, 2.0),
+            WindowGeometry { x: 0, y: 0, width: 0, height: 0 }
+        );
+    }
+
+    #[test]
+    fn pixel_geometry_from_content_rect_preserves_negative_origin() {
+        assert_eq!(
+            pixel_geometry_from_content_rect(-50.0, -10.0, 100.0, 80.0, 2.0),
+            WindowGeometry { x: -100, y: -20, width: 200, height: 160 }
+        );
     }
 }

--- a/crates/glass-macos/src/input.rs
+++ b/crates/glass-macos/src/input.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 //! CGEvent mouse + keyboard injection: `send_pointer` maps each window-relative PIXEL
 //! coordinate to a global Quartz POINT via `coords::pixel_to_global_point`, raises the
 //! target app (focus-before-inject), then posts `Move`/`Click`/`Drag`/`Scroll` as CGEvents
@@ -210,15 +211,18 @@ impl TypeSink for MacTypeSink<'_> {
 fn send_chord(chord: &str, source: Option<&CGEventSource>) -> Result<()> {
     let parts: Vec<&str> = chord.split('+').map(str::trim).filter(|p| !p.is_empty()).collect();
     let Some((key_token, mod_tokens)) = parts.split_last() else {
-        return Err(GlassError::InvalidKey(chord.to_string()));
+        return Err(GlassError::InvalidKey(format!("empty chord (no key token): '{chord}'")));
     };
 
     let mut modifiers = Vec::with_capacity(mod_tokens.len());
     for m in mod_tokens {
-        modifiers.push(Modifier::from_name(m).ok_or_else(|| GlassError::InvalidKey(chord.to_string()))?);
+        modifiers.push(
+            Modifier::from_name(m)
+                .ok_or_else(|| GlassError::InvalidKey(format!("unknown modifier '{m}' in '{chord}'")))?,
+        );
     }
-    let (keycode, needs_shift) =
-        resolve_chord_key(key_token).ok_or_else(|| GlassError::InvalidKey(chord.to_string()))?;
+    let (keycode, needs_shift) = resolve_chord_key(key_token)
+        .ok_or_else(|| GlassError::InvalidKey(format!("unknown key '{key_token}' in '{chord}'")))?;
 
     let mut flags = to_flags(&modifiers);
     if needs_shift {
@@ -490,9 +494,26 @@ mod tests {
     #[test]
     fn send_chord_rejects_empty_unknown_modifier_and_unknown_key() {
         // None of these reach `tap_key` (they error before posting anything), so a `None`
-        // event source is safe to pass here.
-        assert!(matches!(send_chord("", None), Err(GlassError::InvalidKey(_))));
-        assert!(matches!(send_chord("hyper+x", None), Err(GlassError::InvalidKey(_))));
-        assert!(matches!(send_chord("ctrl+nope", None), Err(GlassError::InvalidKey(_))));
+        // event source is safe to pass here. Each also asserts the message names the
+        // specific bad token — mirroring `glass_core::keys::parse_chord`'s specificity —
+        // so a regression that flattens these back to a bare `chord.to_string()` is caught.
+        match send_chord("", None) {
+            Err(GlassError::InvalidKey(msg)) => {
+                assert!(msg.contains("empty"), "expected an 'empty chord' message, got {msg:?}");
+            }
+            other => panic!("expected InvalidKey, got {other:?}"),
+        }
+        match send_chord("hyper+x", None) {
+            Err(GlassError::InvalidKey(msg)) => {
+                assert!(msg.contains("hyper"), "message should name the bad modifier, got {msg:?}");
+            }
+            other => panic!("expected InvalidKey, got {other:?}"),
+        }
+        match send_chord("ctrl+nope", None) {
+            Err(GlassError::InvalidKey(msg)) => {
+                assert!(msg.contains("nope"), "message should name the bad key, got {msg:?}");
+            }
+            other => panic!("expected InvalidKey, got {other:?}"),
+        }
     }
 }

--- a/crates/glass-macos/src/input.rs
+++ b/crates/glass-macos/src/input.rs
@@ -1,0 +1,338 @@
+//! CGEvent mouse injection: `send_pointer` maps each window-relative PIXEL coordinate to a
+//! global Quartz POINT via `coords::pixel_to_global_point`, raises the target app
+//! (focus-before-inject), then posts `Move`/`Click`/`Drag`/`Scroll` as CGEvents through the
+//! HID event tap. `Gesture` (Android multi-touch) is `Unsupported` — see
+//! `glass_core::platform::PointerEvent`'s doc.
+//!
+//! Ported from the proven reference `tools/macos-validation/inject_input.swift`'s
+//! `clickGlobal` (mouse down/up via `CGEvent(mouseEventSource:mouseType:...)` +
+//! `.post(tap: .cghidEventTap)`) and its focus-before-inject
+//! (`NSRunningApplication(processIdentifier:).activate()`), onto `objc2-core-graphics`'s
+//! generated bindings — which expose `CGEvent`'s constructors/accessors as **associated**
+//! functions taking `Option<&CGEvent>` (e.g. `CGEvent::post(tap, event)`,
+//! `CGEvent::set_flags(event, flags)`), not Swift's `self`-methods. header-translator marks
+//! all of them (and `NSRunningApplication::activateWithOptions`) as plain safe Rust
+//! functions — their only precondition, a live `CGEvent`/`CGEventSource`/`NSRunningApplication`
+//! reference, is already enforced by the type system — so no `unsafe` block is needed
+//! anywhere in this file.
+//!
+//! Drag/scroll reuse glass_core's shared, already-unit-tested drivers
+//! ([`glass_core::run_drag`]/[`glass_core::DragGesture`], [`glass_core::run_scroll`]) — the
+//! same ones `glass-windows`/`glass-x11` sequence through their own `DragSink`/`ScrollSink` —
+//! so the waypoint interpolation/pacing/dwell math isn't reimplemented here.
+//!
+//! **Main-thread affinity:** like `backend.rs`'s `start_app`/`capture_frame`, this is called
+//! from `MacosPlatform::send_pointer`, which glass always drives from the main thread; wiring
+//! that under glass-mcp's worker-thread dispatcher is deferred to Plan 5 (see `backend.rs`'s
+//! module doc).
+
+use std::thread;
+use std::time::Duration;
+
+use objc2_app_kit::{NSApplicationActivationOptions, NSRunningApplication};
+use objc2_core_foundation::{CFRetained, CGPoint};
+use objc2_core_graphics::{
+    CGEvent, CGEventField, CGEventFlags, CGEventSource, CGEventSourceStateID, CGEventTapLocation,
+    CGEventType, CGMouseButton, CGScrollEventUnit,
+};
+
+use glass_core::keys::Modifier;
+use glass_core::platform::{MouseButton, PointerEvent};
+use glass_core::{run_drag, run_scroll, DragGesture, DragSink, GlassError, Result, ScrollSink};
+
+use crate::coords::pixel_to_global_point;
+
+/// Settle after raising the target app before the first event, so the window server has
+/// finished the activation before input lands. The validated probe (`inject_input.swift`)
+/// used 300ms after `activate()`; glass's own activation call is otherwise identical, so this
+/// clears the same race with margin.
+const FOCUS_SETTLE: Duration = Duration::from_millis(150);
+
+/// Inject `event` (already window-relative PIXELS) as CGEvents targeting the app at `pid`,
+/// mapping coordinates through `scale`/`origin_pt` (the active session's `pointPixelScale`
+/// and window `contentRect.origin`, carried by `MacosPlatform` since the last `start_app` —
+/// see `coords.rs`'s module doc).
+pub(crate) fn send_pointer(event: &PointerEvent, pid: i32, scale: f64, origin_pt: (f64, f64)) -> Result<()> {
+    focus(pid);
+
+    // Passing `None` here is a documented-valid `CGEventCreateMouseEvent`/
+    // `CGEventCreateScrollWheelEvent2` argument (falls back to the combined session state),
+    // so a `None` source (state-allocation failure — not observed in practice) degrades
+    // gracefully rather than erroring the whole call.
+    let source = CGEventSource::new(CGEventSourceStateID::HIDSystemState);
+    let to_point = |x: i32, y: i32| -> CGPoint {
+        let (gx, gy) = pixel_to_global_point((x, y), scale, origin_pt);
+        CGPoint { x: gx, y: gy }
+    };
+
+    match *event {
+        PointerEvent::Move { x, y } => {
+            let ev = mouse_event(
+                source.as_deref(),
+                CGEventType::MouseMoved,
+                to_point(x, y),
+                CGMouseButton::Left,
+                CGEventFlags::empty(),
+            )?;
+            post(&ev);
+        }
+        PointerEvent::Click { x, y, button, count, ref modifiers } => {
+            let point = to_point(x, y);
+            let flags = to_flags(modifiers);
+            let cg_button = to_cg_button(button);
+            let (down_ty, up_ty) = click_types(button);
+            // One down/up pair stamped with `clicks` in `kCGMouseEventClickState`, rather
+            // than `clicks` separate down/up pairs — the documented CGEvent technique for
+            // synthesizing a double/triple click (see Task 2's brief).
+            let clicks = i64::from(count.max(1));
+            let down = mouse_event(source.as_deref(), down_ty, point, cg_button, flags)?;
+            CGEvent::set_integer_value_field(Some(&down), CGEventField::MouseEventClickState, clicks);
+            post(&down);
+            let up = mouse_event(source.as_deref(), up_ty, point, cg_button, flags)?;
+            CGEvent::set_integer_value_field(Some(&up), CGEventField::MouseEventClickState, clicks);
+            post(&up);
+        }
+        PointerEvent::Drag { from_x, from_y, to_x, to_y, button, ref modifiers, duration_ms } => {
+            let gesture = DragGesture::plan((from_x, from_y), (to_x, to_y), duration_ms);
+            let mut sink = MacDragSink {
+                source: source.as_deref(),
+                scale,
+                origin_pt,
+                button,
+                flags: to_flags(modifiers),
+                last: CGPoint { x: 0.0, y: 0.0 },
+            };
+            run_drag(&mut sink, &gesture)?;
+        }
+        PointerEvent::Scroll { x, y, dx, dy, ref modifiers } => {
+            let mut sink =
+                MacScrollSink { source: source.as_deref(), point: to_point(x, y), dx, dy, flags: to_flags(modifiers) };
+            run_scroll(&mut sink, !modifiers.is_empty())?;
+        }
+        PointerEvent::Gesture { .. } => {
+            return Err(GlassError::Unsupported("multi-touch gesture is not supported on macOS".into()));
+        }
+    }
+    Ok(())
+}
+
+/// Raise `pid`'s app before injecting input — macOS delivers CGEvents posted at the HID tap
+/// to whatever the window server currently has focused, unlike X11/Windows where glass warps
+/// the pointer into an app it already knows the geometry of. Best-effort: a missing/exited
+/// app (`runningApplicationWithProcessIdentifier` returns `None`) or a declined activation
+/// (`activateWithOptions` returns `false`) doesn't fail the call — the event still posts to
+/// whatever currently has focus, matching `glass-windows::input::send_pointer`'s own
+/// best-effort `focus_window` nudge.
+fn focus(pid: i32) {
+    let Some(app) = NSRunningApplication::runningApplicationWithProcessIdentifier(pid) else {
+        return;
+    };
+    app.activateWithOptions(NSApplicationActivationOptions::empty());
+    thread::sleep(FOCUS_SETTLE);
+}
+
+/// Build a mouse CGEvent of `ty` at global `point`, tagged with `button`/`flags`. Does not
+/// post it — callers that also need to stamp `kCGMouseEventClickState` (`Click`) do so
+/// before posting.
+fn mouse_event(
+    source: Option<&CGEventSource>,
+    ty: CGEventType,
+    point: CGPoint,
+    button: CGMouseButton,
+    flags: CGEventFlags,
+) -> Result<CFRetained<CGEvent>> {
+    let ev = CGEvent::new_mouse_event(source, ty, point, button)
+        .ok_or_else(|| GlassError::Backend("CGEventCreateMouseEvent failed".into()))?;
+    CGEvent::set_flags(Some(&ev), flags);
+    Ok(ev)
+}
+
+/// Post `ev` at the HID event tap — every posted event in this module goes through here.
+fn post(ev: &CGEvent) {
+    CGEvent::post(CGEventTapLocation::HIDEventTap, Some(ev));
+}
+
+/// Map `button` to the `CGMouseButton` `CGEventCreateMouseEvent` expects.
+fn to_cg_button(button: MouseButton) -> CGMouseButton {
+    match button {
+        MouseButton::Left => CGMouseButton::Left,
+        MouseButton::Right => CGMouseButton::Right,
+        MouseButton::Middle => CGMouseButton::Center,
+    }
+}
+
+/// The (down, up) `CGEventType` pair for `button`.
+fn click_types(button: MouseButton) -> (CGEventType, CGEventType) {
+    match button {
+        MouseButton::Left => (CGEventType::LeftMouseDown, CGEventType::LeftMouseUp),
+        MouseButton::Right => (CGEventType::RightMouseDown, CGEventType::RightMouseUp),
+        MouseButton::Middle => (CGEventType::OtherMouseDown, CGEventType::OtherMouseUp),
+    }
+}
+
+/// The `*MouseDragged` `CGEventType` for `button` — the motion type Apple expects while the
+/// button is held (distinct from `MouseMoved`), so the target app's `mouseDragged:` handler
+/// (not just `mouseMoved:`) fires during a drag.
+fn dragged_type(button: MouseButton) -> CGEventType {
+    match button {
+        MouseButton::Left => CGEventType::LeftMouseDragged,
+        MouseButton::Right => CGEventType::RightMouseDragged,
+        MouseButton::Middle => CGEventType::OtherMouseDragged,
+    }
+}
+
+/// Map glass's OS-agnostic modifiers to `CGEventFlags`. macOS conveys a held modifier via
+/// flags set directly on each posted event, not a separate modifier-key down/up pair, so this
+/// is the only modifier handling `send_pointer` needs — see [`MacDragSink::modifiers`]/
+/// [`MacScrollSink::modifiers`]'s docs for why their trait hooks no-op.
+fn to_flags(modifiers: &[Modifier]) -> CGEventFlags {
+    modifiers.iter().fold(CGEventFlags::empty(), |acc, m| {
+        acc | match m {
+            Modifier::Shift => CGEventFlags::MaskShift,
+            Modifier::Control => CGEventFlags::MaskControl,
+            Modifier::Alt => CGEventFlags::MaskAlternate,
+            Modifier::Super => CGEventFlags::MaskCommand,
+        }
+    })
+}
+
+/// Lets `glass_core::run_drag` drive a macOS drag through CGEvent. Unlike Windows'
+/// `SendInput` (no per-event flags field, so held modifiers are real key down/up events) or
+/// X11 (XTEST key press/release), a CGEvent's `CGEventFlags` are stamped directly on every
+/// posted event — so `flags` is computed once from the gesture's modifiers and applied to
+/// every `place`/`move_to`/`button` call; `modifiers()` itself has nothing to emit.
+struct MacDragSink<'a> {
+    source: Option<&'a CGEventSource>,
+    scale: f64,
+    origin_pt: (f64, f64),
+    button: MouseButton,
+    flags: CGEventFlags,
+    /// Last point placed/moved to — `button()` posts here, since a mouse-button CGEvent's
+    /// own `mouseCursorPosition` argument is authoritative (mirrors `glass-windows`'
+    /// `WindowsDragSink::last`). `run_drag` always calls `place` before any `button`, so the
+    /// `(0, 0)` seed is overwritten before it's ever read.
+    last: CGPoint,
+}
+
+impl MacDragSink<'_> {
+    fn to_point(&self, x: i32, y: i32) -> CGPoint {
+        let (gx, gy) = pixel_to_global_point((x, y), self.scale, self.origin_pt);
+        CGPoint { x: gx, y: gy }
+    }
+}
+
+impl DragSink for MacDragSink<'_> {
+    fn place(&mut self, x: i32, y: i32) -> Result<()> {
+        self.last = self.to_point(x, y);
+        let ev = mouse_event(self.source, CGEventType::MouseMoved, self.last, to_cg_button(self.button), self.flags)?;
+        post(&ev);
+        Ok(())
+    }
+    fn move_to(&mut self, x: i32, y: i32) -> Result<()> {
+        self.last = self.to_point(x, y);
+        let ev =
+            mouse_event(self.source, dragged_type(self.button), self.last, to_cg_button(self.button), self.flags)?;
+        post(&ev);
+        Ok(())
+    }
+    fn button(&mut self, down: bool) -> Result<()> {
+        let (down_ty, up_ty) = click_types(self.button);
+        let ev = mouse_event(
+            self.source,
+            if down { down_ty } else { up_ty },
+            self.last,
+            to_cg_button(self.button),
+            self.flags,
+        )?;
+        CGEvent::set_integer_value_field(Some(&ev), CGEventField::MouseEventClickState, 1);
+        post(&ev);
+        Ok(())
+    }
+    fn modifiers(&mut self, _down: bool) -> Result<()> {
+        // No-op: see this module's `to_flags` doc — the held modifiers are already baked
+        // into every `place`/`move_to`/`button` event via `self.flags`.
+        Ok(())
+    }
+}
+
+/// Lets `glass_core::run_scroll` drive a macOS scroll through CGEvent — see
+/// [`MacDragSink`]'s doc for why `modifiers()` no-ops here too.
+struct MacScrollSink<'a> {
+    source: Option<&'a CGEventSource>,
+    point: CGPoint,
+    dx: i32,
+    dy: i32,
+    flags: CGEventFlags,
+}
+
+impl ScrollSink for MacScrollSink<'_> {
+    fn modifiers(&mut self, _down: bool) -> Result<()> {
+        Ok(())
+    }
+    fn wheel(&mut self) -> Result<()> {
+        // `CGEventCreateScrollWheelEvent2` carries no target point of its own — the window
+        // server delivers it to whatever's under the cursor (or the key window) — so
+        // position the cursor first (Task 2's brief).
+        let mv = mouse_event(self.source, CGEventType::MouseMoved, self.point, CGMouseButton::Left, self.flags)?;
+        post(&mv);
+
+        // Sign: verified against WebKit's macOS WebDriver wheel-action → CGEvent conversion
+        // (`PlatformMac`'s `CGEventCreateScrollWheelEvent(..., -delta.height(),
+        // -delta.width())`), which negates both axes converting a standard
+        // positive-Y-is-down/positive-X-is-right delta into `wheel1`/`wheel2` — i.e. a
+        // positive `wheel1`/`wheel2` scrolls up/left on macOS. That's the same
+        // positive-Y-is-down/positive-X-is-right contract glass's own `dx`/`dy` already use
+        // (see `glass-x11`'s `scroll_button(5=down,4=up, dy)`/`(7=right,6=left, dx)`), so the
+        // same negation applies here: `wheel1 = -dy`, `wheel2 = -dx`.
+        let ev = CGEvent::new_scroll_wheel_event2(self.source, CGScrollEventUnit::Line, 2, -self.dy, -self.dx, 0)
+            .ok_or_else(|| GlassError::Backend("CGEventCreateScrollWheelEvent2 failed".into()))?;
+        CGEvent::set_flags(Some(&ev), self.flags);
+        post(&ev);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_flags_maps_each_modifier_and_combines() {
+        assert_eq!(to_flags(&[]), CGEventFlags::empty());
+        assert_eq!(to_flags(&[Modifier::Shift]), CGEventFlags::MaskShift);
+        assert_eq!(to_flags(&[Modifier::Control]), CGEventFlags::MaskControl);
+        assert_eq!(to_flags(&[Modifier::Alt]), CGEventFlags::MaskAlternate);
+        assert_eq!(to_flags(&[Modifier::Super]), CGEventFlags::MaskCommand);
+        assert_eq!(
+            to_flags(&[Modifier::Control, Modifier::Super]),
+            CGEventFlags::MaskControl | CGEventFlags::MaskCommand
+        );
+    }
+
+    #[test]
+    fn button_type_mappings_cover_all_three_buttons() {
+        for button in [MouseButton::Left, MouseButton::Right, MouseButton::Middle] {
+            let (down, up) = click_types(button);
+            // Every button's down/up/dragged types are pairwise distinct — catches a
+            // copy-paste that mapped two buttons to the same CGEventType.
+            assert_ne!(down, up);
+            assert_ne!(dragged_type(button), down);
+            assert_ne!(dragged_type(button), up);
+        }
+        assert_eq!(to_cg_button(MouseButton::Left), CGMouseButton::Left);
+        assert_eq!(to_cg_button(MouseButton::Right), CGMouseButton::Right);
+        assert_eq!(to_cg_button(MouseButton::Middle), CGMouseButton::Center);
+        assert_eq!(click_types(MouseButton::Left), (CGEventType::LeftMouseDown, CGEventType::LeftMouseUp));
+        assert_eq!(click_types(MouseButton::Right), (CGEventType::RightMouseDown, CGEventType::RightMouseUp));
+        assert_eq!(click_types(MouseButton::Middle), (CGEventType::OtherMouseDown, CGEventType::OtherMouseUp));
+        assert_eq!(dragged_type(MouseButton::Left), CGEventType::LeftMouseDragged);
+        assert_eq!(dragged_type(MouseButton::Right), CGEventType::RightMouseDragged);
+        assert_eq!(dragged_type(MouseButton::Middle), CGEventType::OtherMouseDragged);
+    }
+
+    #[test]
+    fn gesture_is_unsupported() {
+        let err = send_pointer(&PointerEvent::Gesture { pointers: vec![], duration_ms: 0 }, 1, 1.0, (0.0, 0.0));
+        assert!(matches!(&err, Err(GlassError::Unsupported(_))), "expected Unsupported, got {err:?}");
+    }
+}

--- a/crates/glass-macos/src/input.rs
+++ b/crates/glass-macos/src/input.rs
@@ -1,30 +1,38 @@
-//! CGEvent mouse injection: `send_pointer` maps each window-relative PIXEL coordinate to a
-//! global Quartz POINT via `coords::pixel_to_global_point`, raises the target app
-//! (focus-before-inject), then posts `Move`/`Click`/`Drag`/`Scroll` as CGEvents through the
-//! HID event tap. `Gesture` (Android multi-touch) is `Unsupported` — see
-//! `glass_core::platform::PointerEvent`'s doc.
+//! CGEvent mouse + keyboard injection: `send_pointer` maps each window-relative PIXEL
+//! coordinate to a global Quartz POINT via `coords::pixel_to_global_point`, raises the
+//! target app (focus-before-inject), then posts `Move`/`Click`/`Drag`/`Scroll` as CGEvents
+//! through the HID event tap. `Gesture` (Android multi-touch) is `Unsupported` — see
+//! `glass_core::platform::PointerEvent`'s doc. `send_key` does the same focus-before-inject,
+//! then posts `KeyEvent::Text`/`Chord` as keyboard CGEvents.
 //!
 //! Ported from the proven reference `tools/macos-validation/inject_input.swift`'s
-//! `clickGlobal` (mouse down/up via `CGEvent(mouseEventSource:mouseType:...)` +
-//! `.post(tap: .cghidEventTap)`) and its focus-before-inject
-//! (`NSRunningApplication(processIdentifier:).activate()`), onto `objc2-core-graphics`'s
-//! generated bindings — which expose `CGEvent`'s constructors/accessors as **associated**
-//! functions taking `Option<&CGEvent>` (e.g. `CGEvent::post(tap, event)`,
-//! `CGEvent::set_flags(event, flags)`), not Swift's `self`-methods. header-translator marks
-//! all of them (and `NSRunningApplication::activateWithOptions`) as plain safe Rust
-//! functions — their only precondition, a live `CGEvent`/`CGEventSource`/`NSRunningApplication`
-//! reference, is already enforced by the type system — so no `unsafe` block is needed
-//! anywhere in this file.
+//! `clickGlobal`/`postKey`/`typeString` (down/up via `CGEvent(mouseEventSource:...)`/
+//! `CGEvent(keyboardEventSource:virtualKey:keyDown:)` + `.post(tap: .cghidEventTap)`) and its
+//! focus-before-inject (`NSRunningApplication(processIdentifier:).activate()`), onto
+//! `objc2-core-graphics`'s generated bindings — which expose `CGEvent`'s
+//! constructors/accessors as **associated** functions taking `Option<&CGEvent>` (e.g.
+//! `CGEvent::post(tap, event)`, `CGEvent::set_flags(event, flags)`), not Swift's
+//! `self`-methods. header-translator marks all of them (and
+//! `NSRunningApplication::activateWithOptions`) as plain safe Rust functions — their only
+//! precondition, a live `CGEvent`/`CGEventSource`/`NSRunningApplication` reference, is
+//! already enforced by the type system — so no `unsafe` block is needed anywhere in this
+//! file.
 //!
-//! Drag/scroll reuse glass_core's shared, already-unit-tested drivers
-//! ([`glass_core::run_drag`]/[`glass_core::DragGesture`], [`glass_core::run_scroll`]) — the
-//! same ones `glass-windows`/`glass-x11` sequence through their own `DragSink`/`ScrollSink` —
-//! so the waypoint interpolation/pacing/dwell math isn't reimplemented here.
+//! Drag/scroll/text reuse glass_core's shared, already-unit-tested drivers
+//! ([`glass_core::run_drag`]/[`glass_core::DragGesture`], [`glass_core::run_scroll`],
+//! [`glass_core::run_type`]) — the same ones `glass-windows`/`glass-x11` sequence through
+//! their own `DragSink`/`ScrollSink`/`TypeSink` — so the waypoint interpolation/pacing/dwell
+//! math isn't reimplemented here. `KeyEvent::Chord` does not: unlike Windows/X11 (where a
+//! held modifier is a real separate key down/up event, needing `glass_core::run_chord`'s
+//! cross-frame hold-then-release ordering), macOS conveys a held modifier via
+//! `CGEventFlags` stamped directly on the key's own down/up events — the same technique
+//! `to_flags`/`MacDragSink`/`MacScrollSink` already use for pointer modifiers below — so
+//! there is no separate modifier event to sequence.
 //!
 //! **Main-thread affinity:** like `backend.rs`'s `start_app`/`capture_frame`, this is called
-//! from `MacosPlatform::send_pointer`, which glass always drives from the main thread; wiring
-//! that under glass-mcp's worker-thread dispatcher is deferred to Plan 5 (see `backend.rs`'s
-//! module doc).
+//! from `MacosPlatform::send_pointer`/`send_key`, which glass always drives from the main
+//! thread; wiring that under glass-mcp's worker-thread dispatcher is deferred to Plan 5 (see
+//! `backend.rs`'s module doc).
 
 use std::thread;
 use std::time::Duration;
@@ -37,10 +45,13 @@ use objc2_core_graphics::{
 };
 
 use glass_core::keys::Modifier;
-use glass_core::platform::{MouseButton, PointerEvent};
-use glass_core::{run_drag, run_scroll, DragGesture, DragSink, GlassError, Result, ScrollSink};
+use glass_core::platform::{KeyEvent, MouseButton, PointerEvent};
+use glass_core::{
+    run_drag, run_scroll, run_type, DragGesture, DragSink, GlassError, Result, ScrollSink, TypeSink,
+};
 
 use crate::coords::pixel_to_global_point;
+use crate::keymap;
 
 /// Map a window-relative pixel coordinate to a global Quartz point, accounting for the
 /// session's display scale and window origin.
@@ -118,6 +129,117 @@ pub(crate) fn send_pointer(event: &PointerEvent, pid: i32, scale: f64, origin_pt
         }
     }
     Ok(())
+}
+
+/// Inter-keystroke delay for `KeyEvent::Text` typing — matches the proven reference
+/// (`inject_input.swift`'s `typeString`'s `usleep(12_000)`), so each keystroke is its own
+/// committed HID post before the next one lands (the same self-committing-per-keystroke
+/// discipline `glass-windows`/`glass-x11`/`glass-wayland` already need — see
+/// `glass_core::run_type`'s doc).
+const KEY_TYPE_DWELL: Duration = Duration::from_millis(12);
+
+/// Inject `event` as keyboard CGEvents targeting the app at `pid`, focusing it first (same
+/// best-effort `focus` helper/settle `send_pointer` uses above).
+pub(crate) fn send_key(event: &KeyEvent, pid: i32) -> Result<()> {
+    focus(pid);
+
+    // See `send_pointer`'s doc for why a `None` source is a documented-valid, gracefully
+    // degrading `CGEventCreateKeyboardEvent` argument rather than an error.
+    let source = CGEventSource::new(CGEventSourceStateID::HIDSystemState);
+
+    match event {
+        KeyEvent::Text(s) => {
+            let mut sink = MacTypeSink { source: source.as_deref() };
+            run_type(&mut sink, s, KEY_TYPE_DWELL)
+        }
+        KeyEvent::Chord(s) => send_chord(s, source.as_deref()),
+    }
+}
+
+/// Build a keyboard CGEvent for `keycode` (down or up), tagged with `flags`. Mirrors
+/// `mouse_event`'s shape — `CGEventCreateKeyboardEvent` failing (no observed cause; Apple
+/// documents no failure mode beyond resource exhaustion) maps to the same
+/// `GlassError::Backend` rather than a silent no-op post.
+fn keyboard_event(
+    source: Option<&CGEventSource>,
+    keycode: u16,
+    down: bool,
+    flags: CGEventFlags,
+) -> Result<CFRetained<CGEvent>> {
+    let ev = CGEvent::new_keyboard_event(source, keycode, down)
+        .ok_or_else(|| GlassError::Backend("CGEventCreateKeyboardEvent failed".into()))?;
+    CGEvent::set_flags(Some(&ev), flags);
+    Ok(ev)
+}
+
+/// Post one committed keystroke: a keyDown immediately followed by a keyUp, both carrying
+/// `flags` (e.g. Shift for an uppercase char or a chord's held modifiers).
+fn tap_key(source: Option<&CGEventSource>, keycode: u16, flags: CGEventFlags) -> Result<()> {
+    let down = keyboard_event(source, keycode, true, flags)?;
+    post(&down);
+    let up = keyboard_event(source, keycode, false, flags)?;
+    post(&up);
+    Ok(())
+}
+
+/// `TypeSink` for macOS: one keyDown+keyUp CGEvent pair per character — already a
+/// self-committed HID post (`CGEventPost` delivers synchronously) — so `run_type`'s
+/// inter-character dwell (`KEY_TYPE_DWELL`) lands between keystrokes exactly like the
+/// validated `inject_input.swift` probe. An unmappable char (no US-layout key —
+/// `keymap::key_for` returns `None`) fails the whole call rather than silently skipping it,
+/// per the no-silent-fallback invariant (`inject_input.swift`'s probe skips-and-warns; this
+/// backend does not).
+struct MacTypeSink<'a> {
+    source: Option<&'a CGEventSource>,
+}
+
+impl TypeSink for MacTypeSink<'_> {
+    fn character(&mut self, c: char) -> Result<()> {
+        let (keycode, shift) = keymap::key_for(c).ok_or_else(|| GlassError::InvalidKey(c.to_string()))?;
+        let flags = if shift { CGEventFlags::MaskShift } else { CGEventFlags::empty() };
+        tap_key(self.source, keycode, flags)
+    }
+}
+
+/// Parse and post a chord like `"ctrl+shift+a"` or `"F4"`: every token but the last must be
+/// a modifier `glass_core::keys::Modifier::from_name` recognizes (accumulated into
+/// `CGEventFlags` via the same `to_flags` `send_pointer` uses); the last token is the key,
+/// resolved via `resolve_chord_key`. The whole chord posts as a single keyDown+keyUp pair
+/// with the accumulated flags — see the module doc for why macOS needs no separate
+/// modifier-hold event (unlike `glass_core::run_chord`'s Windows/X11 use).
+fn send_chord(chord: &str, source: Option<&CGEventSource>) -> Result<()> {
+    let parts: Vec<&str> = chord.split('+').map(str::trim).filter(|p| !p.is_empty()).collect();
+    let Some((key_token, mod_tokens)) = parts.split_last() else {
+        return Err(GlassError::InvalidKey(chord.to_string()));
+    };
+
+    let mut modifiers = Vec::with_capacity(mod_tokens.len());
+    for m in mod_tokens {
+        modifiers.push(Modifier::from_name(m).ok_or_else(|| GlassError::InvalidKey(chord.to_string()))?);
+    }
+    let (keycode, needs_shift) =
+        resolve_chord_key(key_token).ok_or_else(|| GlassError::InvalidKey(chord.to_string()))?;
+
+    let mut flags = to_flags(&modifiers);
+    if needs_shift {
+        flags |= CGEventFlags::MaskShift;
+    }
+    tap_key(source, keycode, flags)
+}
+
+/// Resolve a chord's final token to `(keycode, needs_shift)`: a single char goes through
+/// [`keymap::key_for`] (which also reports whether that char needs Shift, e.g. `"ctrl+A"`);
+/// anything else goes through [`keymap::keycode_for_keyname`] (a named key has no inherent
+/// shift requirement of its own — any Shift comes from an explicit `shift` token in the
+/// chord instead).
+fn resolve_chord_key(token: &str) -> Option<(u16, bool)> {
+    let mut chars = token.chars();
+    if let (Some(c), None) = (chars.next(), chars.next()) {
+        if let Some(mapped) = keymap::key_for(c) {
+            return Some(mapped);
+        }
+    }
+    keymap::keycode_for_keyname(token).map(|code| (code, false))
 }
 
 /// Raise `pid`'s app before injecting input — macOS delivers CGEvents posted at the HID tap
@@ -337,5 +459,40 @@ mod tests {
     fn gesture_is_unsupported() {
         let err = send_pointer(&PointerEvent::Gesture { pointers: vec![], duration_ms: 0 }, 1, 1.0, (0.0, 0.0));
         assert!(matches!(&err, Err(GlassError::Unsupported(_))), "expected Unsupported, got {err:?}");
+    }
+
+    #[test]
+    fn resolve_chord_key_single_char_uses_key_for_and_reports_shift() {
+        // Lowercase needs no Shift; uppercase does — same physical key either way, matching
+        // `keymap::key_for`'s own contract.
+        assert_eq!(resolve_chord_key("a"), Some((0, false)));
+        assert_eq!(resolve_chord_key("A"), Some((0, true)));
+    }
+
+    #[test]
+    fn resolve_chord_key_named_key_has_no_inherent_shift() {
+        assert_eq!(resolve_chord_key("Return"), Some((36, false)));
+        assert_eq!(resolve_chord_key("F4"), Some((118, false)));
+    }
+
+    #[test]
+    fn resolve_chord_key_unknown_is_none() {
+        assert_eq!(resolve_chord_key("nope"), None);
+    }
+
+    #[test]
+    fn mac_type_sink_rejects_unmappable_char() {
+        // Errors before posting anything, so a `None` source is safe here too.
+        let mut sink = MacTypeSink { source: None };
+        assert!(matches!(sink.character('€'), Err(GlassError::InvalidKey(_))));
+    }
+
+    #[test]
+    fn send_chord_rejects_empty_unknown_modifier_and_unknown_key() {
+        // None of these reach `tap_key` (they error before posting anything), so a `None`
+        // event source is safe to pass here.
+        assert!(matches!(send_chord("", None), Err(GlassError::InvalidKey(_))));
+        assert!(matches!(send_chord("hyper+x", None), Err(GlassError::InvalidKey(_))));
+        assert!(matches!(send_chord("ctrl+nope", None), Err(GlassError::InvalidKey(_))));
     }
 }

--- a/crates/glass-macos/src/input.rs
+++ b/crates/glass-macos/src/input.rs
@@ -42,11 +42,18 @@ use glass_core::{run_drag, run_scroll, DragGesture, DragSink, GlassError, Result
 
 use crate::coords::pixel_to_global_point;
 
+/// Map a window-relative pixel coordinate to a global Quartz point, accounting for the
+/// session's display scale and window origin.
+fn to_cgpoint(x: i32, y: i32, scale: f64, origin_pt: (f64, f64)) -> CGPoint {
+    let (gx, gy) = pixel_to_global_point((x, y), scale, origin_pt);
+    CGPoint { x: gx, y: gy }
+}
+
 /// Settle after raising the target app before the first event, so the window server has
 /// finished the activation before input lands. The validated probe (`inject_input.swift`)
 /// used 300ms after `activate()`; glass's own activation call is otherwise identical, so this
-/// clears the same race with margin.
-const FOCUS_SETTLE: Duration = Duration::from_millis(150);
+/// uses the same 300ms settle time to clear the focus-before-inject race.
+const FOCUS_SETTLE: Duration = Duration::from_millis(300);
 
 /// Inject `event` (already window-relative PIXELS) as CGEvents targeting the app at `pid`,
 /// mapping coordinates through `scale`/`origin_pt` (the active session's `pointPixelScale`
@@ -60,10 +67,7 @@ pub(crate) fn send_pointer(event: &PointerEvent, pid: i32, scale: f64, origin_pt
     // so a `None` source (state-allocation failure — not observed in practice) degrades
     // gracefully rather than erroring the whole call.
     let source = CGEventSource::new(CGEventSourceStateID::HIDSystemState);
-    let to_point = |x: i32, y: i32| -> CGPoint {
-        let (gx, gy) = pixel_to_global_point((x, y), scale, origin_pt);
-        CGPoint { x: gx, y: gy }
-    };
+    let to_point = |x: i32, y: i32| to_cgpoint(x, y, scale, origin_pt);
 
     match *event {
         PointerEvent::Move { x, y } => {
@@ -216,8 +220,7 @@ struct MacDragSink<'a> {
 
 impl MacDragSink<'_> {
     fn to_point(&self, x: i32, y: i32) -> CGPoint {
-        let (gx, gy) = pixel_to_global_point((x, y), self.scale, self.origin_pt);
-        CGPoint { x: gx, y: gy }
+        to_cgpoint(x, y, self.scale, self.origin_pt)
     }
 }
 

--- a/crates/glass-macos/src/keymap.rs
+++ b/crates/glass-macos/src/keymap.rs
@@ -38,9 +38,55 @@ pub fn key_for(ch: char) -> Option<(u16, bool)> {
     None
 }
 
+/// Map a named key (as used in a chord's final token, e.g. `"Return"`, `"F4"`) to its
+/// US-layout virtual keycode. Matched case-insensitively against the documented Carbon
+/// `kVK_*` values (validated in `inject_input.swift`'s reference). Falls back to
+/// [`key_for`] for a single ASCII char (dropping the shift bit — callers that need it use
+/// `key_for` directly), so a chord's key token doesn't need two different lookups
+/// depending on whether it's named or literal. Returns `None` for anything else.
+pub fn keycode_for_keyname(name: &str) -> Option<u16> {
+    const NAMED: &[(&str, u16)] = &[
+        ("return", 36),
+        ("tab", 48),
+        ("space", 49),
+        ("delete", 51),
+        ("escape", 53),
+        ("left", 123),
+        ("right", 124),
+        ("down", 125),
+        ("up", 126),
+        ("home", 115),
+        ("end", 119),
+        ("pageup", 116),
+        ("pagedown", 121),
+        ("forwarddelete", 117),
+        ("f1", 122),
+        ("f2", 120),
+        ("f3", 99),
+        ("f4", 118),
+        ("f5", 96),
+        ("f6", 97),
+        ("f7", 98),
+        ("f8", 100),
+        ("f9", 101),
+        ("f10", 109),
+        ("f11", 103),
+        ("f12", 111),
+    ];
+    let lower = name.to_ascii_lowercase();
+    if let Some(&(_, code)) = NAMED.iter().find(|&&(n, _)| n == lower) {
+        return Some(code);
+    }
+    let mut chars = name.chars();
+    match (chars.next(), chars.next()) {
+        (Some(c), None) => key_for(c).map(|(code, _)| code),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::key_for;
+    use super::{key_for, keycode_for_keyname};
 
     #[test]
     fn lowercase_letters_unshifted() {
@@ -65,5 +111,48 @@ mod tests {
     fn space_and_unmapped() {
         assert_eq!(key_for(' '), Some((49, false)));
         assert_eq!(key_for('€'), None);
+    }
+
+    #[test]
+    fn named_keys_map_to_their_kvk_codes() {
+        assert_eq!(keycode_for_keyname("Return"), Some(36));
+        assert_eq!(keycode_for_keyname("Escape"), Some(53));
+        assert_eq!(keycode_for_keyname("Tab"), Some(48));
+        assert_eq!(keycode_for_keyname("Delete"), Some(51));
+    }
+
+    #[test]
+    fn named_keys_are_case_insensitive() {
+        assert_eq!(keycode_for_keyname("return"), Some(36));
+        assert_eq!(keycode_for_keyname("ESCAPE"), Some(53));
+        assert_eq!(keycode_for_keyname("EsCaPe"), Some(53));
+    }
+
+    #[test]
+    fn arrow_keys() {
+        assert_eq!(keycode_for_keyname("Left"), Some(123));
+        assert_eq!(keycode_for_keyname("Right"), Some(124));
+        assert_eq!(keycode_for_keyname("Down"), Some(125));
+        assert_eq!(keycode_for_keyname("Up"), Some(126));
+    }
+
+    #[test]
+    fn function_keys() {
+        assert_eq!(keycode_for_keyname("F1"), Some(122));
+        assert_eq!(keycode_for_keyname("F5"), Some(96));
+        assert_eq!(keycode_for_keyname("F12"), Some(111));
+    }
+
+    #[test]
+    fn single_char_falls_back_to_key_for() {
+        assert_eq!(keycode_for_keyname("a"), Some(0));
+        assert_eq!(keycode_for_keyname("A"), Some(0)); // shift bit dropped, same physical key
+    }
+
+    #[test]
+    fn unknown_name_is_none() {
+        assert_eq!(keycode_for_keyname("nope"), None);
+        assert_eq!(keycode_for_keyname("F13"), None);
+        assert_eq!(keycode_for_keyname(""), None);
     }
 }

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -20,6 +20,8 @@ mod capture;
 #[cfg(target_os = "macos")]
 mod process;
 #[cfg(target_os = "macos")]
+mod input;
+#[cfg(target_os = "macos")]
 mod backend;
 #[cfg(target_os = "macos")]
 pub use backend::MacosPlatform;

--- a/crates/glass-macos/src/scwindow.rs
+++ b/crates/glass-macos/src/scwindow.rs
@@ -44,7 +44,9 @@ use glass_core::{poll_until, GlassError, Result};
 /// a live `Retained<SCWindow>` across the completion handler's thread boundary (see
 /// module doc).
 // `geometry`/`scale`/`origin_pt` are read by `start_app` (via `backend.rs::discover_window`
-// -> `query_once`); `pid`/`window_id` stay unread until Plan 4's list/select_window.
+// -> `query_once`) and by `send_pointer` (via `backend.rs`'s direct
+// `find_window_for_pids` call on every pointer event); `pid`/`window_id` stay unread until
+// Plan 4's list/select_window.
 #[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct WindowMatch {
@@ -79,14 +81,16 @@ pub(crate) struct WindowMatch {
 /// [`GlassError::PermissionDenied`] for a Screen Recording TCC decline,
 /// [`GlassError::CaptureFailed`] for anything else) or [`GlassError::Timeout`] if no
 /// matching window appears before `timeout` elapses.
-// No production caller: `MacosPlatform::start_app` runs its own poll loop
-// (`backend.rs::discover_window`) that alternates a single `query_once` attempt with
-// `child.try_wait()` so a crashed launch fails fast with `AppExited` — this function's
-// self-contained `poll_until` has no child handle to race against, so `start_app` can't
-// delegate its whole timeout budget to it. Kept `pub(crate)` + allowed here (not
-// deleted) as a plain "poll until found or timeout" primitive for a future call site
-// with no child to check (e.g. Plan 4 window rediscovery).
-#[allow(dead_code)]
+///
+/// `MacosPlatform::start_app` still can't use this directly: it runs its own poll loop
+/// (`backend.rs::discover_window`) that alternates a single `query_once` attempt with
+/// `child.try_wait()` so a crashed launch fails fast with `AppExited`, and this function's
+/// self-contained `poll_until` has no child handle to race against. But
+/// `MacosPlatform::send_pointer` does call this directly on every invocation, to
+/// re-resolve the window's current geometry/scale/origin fresh (the window may have moved
+/// or resized since `start_app`, or since the previous `send_pointer` call) — there's no
+/// child handle to race there either (the session is already established), so this
+/// self-contained poll-until-found-or-timeout is exactly what it needs.
 pub(crate) fn find_window_for_pids(pids: &[i32], timeout: Duration) -> Result<WindowMatch> {
     crate::ffi::app_kit_init();
 

--- a/crates/glass-macos/src/scwindow.rs
+++ b/crates/glass-macos/src/scwindow.rs
@@ -33,8 +33,9 @@ use std::time::Duration;
 
 use block2::RcBlock;
 use objc2::rc::Retained;
+use objc2::AnyThread;
 use objc2_foundation::{NSArray, NSError};
-use objc2_screen_capture_kit::{SCShareableContent, SCWindow};
+use objc2_screen_capture_kit::{SCContentFilter, SCShareableContent, SCWindow};
 
 use glass_core::platform::WindowGeometry;
 use glass_core::{poll_until, GlassError, Result};
@@ -42,10 +43,10 @@ use glass_core::{poll_until, GlassError, Result};
 /// A discovered on-screen window: enough to re-find or capture it later without holding
 /// a live `Retained<SCWindow>` across the completion handler's thread boundary (see
 /// module doc).
-// `geometry` is read by `start_app` (via `backend.rs::discover_window` ->
-// `query_once`); `pid`/`window_id` stay unread until Plan 4's list/select_window.
+// `geometry`/`scale`/`origin_pt` are read by `start_app` (via `backend.rs::discover_window`
+// -> `query_once`); `pid`/`window_id` stay unread until Plan 4's list/select_window.
 #[allow(dead_code)]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) struct WindowMatch {
     /// The owning process's pid — one of the `pids` passed to `find_window_for_pids`.
     pub(crate) pid: i32,
@@ -53,7 +54,17 @@ pub(crate) struct WindowMatch {
     /// re-findable via a fresh `SCShareableContent` query
     /// (`content.windows().iter().find(|w| w.windowID() == id)`).
     pub(crate) window_id: u32,
+    /// Window geometry in backing PIXELS (`contentRect.size * scale`, matching the frame
+    /// `capture::capture_window` produces for this window) — the tool boundary's unit;
+    /// see `coords.rs`'s module doc.
     pub(crate) geometry: WindowGeometry,
+    /// `SCContentFilter.pointPixelScale()` for this window (`1.0` on a 1x display, `2.0`
+    /// on 2x Retina) — carried alongside `geometry` so the backend can later map a PIXEL
+    /// click coordinate back to a global POINT via `coords::pixel_to_global_point`.
+    pub(crate) scale: f64,
+    /// `contentRect.origin`, in POINTS (Quartz's global screen space) — the window origin
+    /// `coords::pixel_to_global_point` adds a scaled pixel offset to.
+    pub(crate) origin_pt: (f64, f64),
 }
 
 /// Poll `SCShareableContent` roughly every 100ms for the first on-screen window whose
@@ -160,16 +171,24 @@ pub(crate) fn query_once(pids: &[i32]) -> Result<Option<WindowMatch>> {
             let _ = tx.send(QueryReply::NotFound);
             return;
         };
-        // SAFETY: `w` was just resolved live from `content.windows()` above; these are
-        // plain property getters with no other preconditions.
-        let (window_id, frame) = unsafe { (w.windowID(), w.frame()) };
-        let geometry = geometry_from_rect(
-            frame.origin.x,
-            frame.origin.y,
-            frame.size.width,
-            frame.size.height,
+        // SAFETY: `w` is a live `SCWindow` just resolved above; `capture.rs` uses this
+        // same initializer on the same kind of live `SCWindow` — no other preconditions.
+        let filter = unsafe {
+            SCContentFilter::initWithDesktopIndependentWindow(SCContentFilter::alloc(), &w)
+        };
+        // SAFETY: `w`/`filter` are live; these are plain property getters with no other
+        // preconditions.
+        let (window_id, scale, content_rect) =
+            unsafe { (w.windowID(), filter.pointPixelScale() as f64, filter.contentRect()) };
+        let geometry = crate::coords::pixel_geometry_from_content_rect(
+            content_rect.origin.x,
+            content_rect.origin.y,
+            content_rect.size.width,
+            content_rect.size.height,
+            scale,
         );
-        let _ = tx.send(QueryReply::Found(WindowMatch { pid, window_id, geometry }));
+        let origin_pt = (content_rect.origin.x, content_rect.origin.y);
+        let _ = tx.send(QueryReply::Found(WindowMatch { pid, window_id, geometry, scale, origin_pt }));
     });
 
     // SAFETY: `block` matches `getShareableContentExcludingDesktopWindows_onScreenWindowsOnly_completionHandler`'s
@@ -201,49 +220,9 @@ enum QueryReply {
     Failed(GlassError),
 }
 
-/// Convert a window frame (points, from `SCWindow.frame()`) to the platform-agnostic
-/// `WindowGeometry`. Pulled out as pure `f64` math (no `CGRect` dependency) so it can
-/// carry its own unit test without needing a live window.
-fn geometry_from_rect(x: f64, y: f64, width: f64, height: f64) -> WindowGeometry {
-    WindowGeometry {
-        x: x.round() as i32,
-        y: y.round() as i32,
-        width: width.round().max(0.0) as u32,
-        height: height.round().max(0.0) as u32,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn geometry_from_rect_rounds_to_nearest() {
-        assert_eq!(
-            geometry_from_rect(10.4, 20.6, 300.49, 200.5),
-            WindowGeometry { x: 10, y: 21, width: 300, height: 201 }
-        );
-    }
-
-    #[test]
-    fn geometry_from_rect_clamps_negative_size_to_zero() {
-        // A real CGRect from SCWindow.frame() never has a negative size, but the
-        // conversion must not panic or wrap on malformed input.
-        assert_eq!(
-            geometry_from_rect(0.0, 0.0, -1.0, -1.0),
-            WindowGeometry { x: 0, y: 0, width: 0, height: 0 }
-        );
-    }
-
-    #[test]
-    fn geometry_from_rect_preserves_negative_origin() {
-        // A window can sit left-of/above the primary display's origin in a multi-monitor
-        // layout; x/y must stay signed rather than clamping like width/height do.
-        assert_eq!(
-            geometry_from_rect(-50.0, -10.0, 100.0, 80.0),
-            WindowGeometry { x: -50, y: -10, width: 100, height: 80 }
-        );
-    }
 
     #[test]
     fn query_reply_is_send() {

--- a/crates/glass-macos/tests/input.rs
+++ b/crates/glass-macos/tests/input.rs
@@ -1,0 +1,325 @@
+//! Mac-gated input integration test — the end-to-end proof that `MacosPlatform::send_key`/
+//! `send_pointer` land at the right place: a real `NSView` reports back the characters it
+//! received and the pixel it was clicked at, closing the loop on the whole
+//! pixel -> point -> global -> CGEvent -> AppKit -> app round trip. It also records the
+//! scroll-wheel sign question `input.rs`'s `MacScrollSink::wheel` left UNVERIFIED (see that
+//! file's module doc): a positive `dy` is sent and the fixture's raw, verbatim
+//! `NSEvent.scrollingDeltaY` is printed so a real granted run can confirm which sign macOS
+//! actually delivers — see the scroll leg's comment in `run_checks` below for why that sign
+//! is only recorded, not yet hard-asserted (no granted run has reached it for real yet).
+//!
+//! **`harness = false`** (see `Cargo.toml`'s `[[test]] name = "input"` entry) for the exact
+//! same reason as `tests/capture.rs`: `send_key`/`send_pointer` reach AppKit
+//! (`NSRunningApplication::activateWithOptions`, `ffi::app_kit_init()` via `start_app`'s
+//! window discovery), which requires the process's TRUE main thread
+//! (`objc2::MainThreadMarker`) — libtest's per-`#[test]` worker threads can't provide that,
+//! so this file defines its own `fn main()` instead.
+//!
+//! Needs the Accessibility TCC grant (CGEvent posting) in addition to Screen Recording
+//! (window discovery via ScreenCaptureKit), both held by the signed, granted `GlassProbe.app`
+//! bundle on this project's dev Mac (`mini`) — same granted-run procedure as
+//! `tests/capture.rs`: copy this built test binary into the bundle, re-sign, run via a
+//! `gui/501` LaunchAgent so it inherits the bundle's grants. See
+//! `.superpowers/sdd/objc2-spike-report.md`, `.superpowers/sdd/task-6-fix-report.md`, and
+//! `.superpowers/sdd/task-6-brief.md` for the exact procedure, and `scripts/test-macos.sh`'s
+//! `GLASS_MACOS_ONBOX` gate for how this fits the test scripts.
+//!
+//! **Additional runtime precondition beyond the two TCC grants: `mini`'s screen session
+//! must not be locked.** Task 6 debugging (see `.superpowers/sdd/task-6-report.md`)
+//! empirically proved that while the console session is locked
+//! (`CGSSessionScreenIsLocked=1`), macOS's secure-input protection pins
+//! `NSWorkspace.frontmostApplication` to `loginwindow` and silently drops every synthetic
+//! CGEvent aimed at a background app — `NSRunningApplication.activate`/
+//! `AXUIElementSetAttributeValue(kAXFrontmostAttribute)` both report success with zero
+//! effect, cursor *position* HID state updates but clicks never reach the target window,
+//! and keyDown events never arrive at all. This is a session-state precondition of the
+//! granted run, not a `glass-macos` bug — `capture.rs`'s read-only ScreenCaptureKit path is
+//! unaffected by it (compositor output is readable regardless of lock state), which is why
+//! this gap wasn't visible until this file's first real input-posting run.
+
+#[cfg(not(target_os = "macos"))]
+fn main() {
+    println!("skipped (not macOS)");
+}
+
+#[cfg(target_os = "macos")]
+fn main() {
+    macos_main::run();
+}
+
+#[cfg(target_os = "macos")]
+mod macos_main {
+    use std::path::PathBuf;
+    use std::process::Command;
+    use std::time::Duration;
+
+    use glass_core::platform::{KeyEvent, MouseButton, PointerEvent};
+    use glass_core::{AppSpec, Platform, SandboxLevel, Stream};
+    use glass_macos::MacosPlatform;
+
+    /// Settle after each injected action before draining logs — generous relative to
+    /// `input.rs`'s own internal `FOCUS_SETTLE` (300ms, already paid once per `send_key`/
+    /// `send_pointer` call via `focus()`), so the fixture's `fflush`ed stdout line has
+    /// definitely been read by `process.rs`'s background reader thread before we drain.
+    const ACTION_SETTLE: Duration = Duration::from_millis(400);
+
+    /// Window-relative pixel the click is sent to — the center of the fixture's top-left
+    /// (red) quadrant in its 400x400 window, comfortably away from any quadrant boundary.
+    const CLICK_TARGET: (i32, i32) = (100, 100);
+    /// `assert_click_near`'s tolerance: how far the fixture-reported click coordinate may
+    /// drift from `CLICK_TARGET` and still count as a correct round trip (rounding in the
+    /// pixel<->point conversion, not a loose "close enough").
+    const CLICK_TOLERANCE: i32 = 5;
+
+    /// Print a clear failure message and exit non-zero — the `harness = false` contract
+    /// (no libtest to format a panic for us).
+    fn fail(msg: impl AsRef<str>) -> ! {
+        eprintln!("FAIL: {}", msg.as_ref());
+        std::process::exit(1);
+    }
+
+    /// Unwrap a `Result`, failing the whole test process with `context` prefixed to the
+    /// error on `Err`. Only safe to use before a fixture process has been spawned (or once
+    /// all spawn-time cleanup is already done) — see `capture.rs`'s identical helper for why
+    /// anything after that must go through `try_expect`/`run_checks` instead.
+    fn expect<T, E: std::fmt::Display>(result: Result<T, E>, context: &str) -> T {
+        match result {
+            Ok(v) => v,
+            Err(e) => fail(format!("{context}: {e}")),
+        }
+    }
+
+    /// Like `expect`, but returns the error as a `String` instead of exiting the process —
+    /// see `capture.rs`'s identical helper's doc for why: a failure raised inside
+    /// `run_checks` (fixture already spawned) must flow back to `run()` so it can
+    /// `stop_app()` before the process exits, which a direct `std::process::exit` would skip
+    /// (Rust destructors don't run across `exit`).
+    fn try_expect<T, E: std::fmt::Display>(result: Result<T, E>, context: &str) -> Result<T, String> {
+        result.map_err(|e| format!("{context}: {e}"))
+    }
+
+    fn swiftc_available() -> bool {
+        Command::new("swiftc").arg("--version").output().is_ok_and(|o| o.status.success())
+    }
+
+    /// Build `fixture/quadrants.swift` to a fresh temp path — identical to `capture.rs`'s
+    /// `build_fixture`, just a distinct temp-dir name so a parallel run of both tests never
+    /// collides. Returns the built binary's path and the temp build dir it lives in (the
+    /// caller removes the dir once done — see `run()`).
+    fn build_fixture() -> (PathBuf, PathBuf) {
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let source = manifest_dir.join("fixture").join("quadrants.swift");
+        if !source.is_file() {
+            fail(format!("fixture source not found at {}", source.display()));
+        }
+
+        let out_dir = std::env::temp_dir().join(format!("glass-macos-input-test-{}", std::process::id()));
+        expect(std::fs::create_dir_all(&out_dir), "creating fixture build dir");
+        let out_bin = out_dir.join("quadrants");
+
+        let status = Command::new("swiftc")
+            .arg("-O")
+            .arg("-parse-as-library")
+            .arg(&source)
+            .arg("-o")
+            .arg(&out_bin)
+            .status();
+        match status {
+            Ok(s) if s.success() => {}
+            Ok(s) => fail(format!("swiftc exited with {s} building {}", source.display())),
+            Err(e) => fail(format!("failed to run swiftc: {e}")),
+        }
+        (out_bin, out_dir)
+    }
+
+    /// Every stdout line from `lines` that starts with `prefix`, with the prefix stripped —
+    /// e.g. `find_reported(lines, "key: ")` yields `["h", "e", ...]` from `quadrants.swift`'s
+    /// `key: <characters>` reporting. Stderr lines are ignored (the fixture never writes
+    /// there).
+    fn find_reported<'a>(lines: &'a [(Stream, String)], prefix: &str) -> Vec<&'a str> {
+        lines
+            .iter()
+            .filter(|(stream, _)| *stream == Stream::Stdout)
+            .filter_map(|(_, line)| line.strip_prefix(prefix))
+            .collect()
+    }
+
+    /// Parse a fixture-reported `"A,B"` pair (as printed by `quadrants.swift`'s `click:`/
+    /// `scroll:` lines) into `(A, B)`. Generic over `T` so callers can parse either the
+    /// integer `click:` pair or the floating-point `scroll:` pair (`NSEvent.scrollingDeltaX`/
+    /// `Y` are `CGFloat`).
+    fn parse_pair<T: std::str::FromStr>(raw: &str) -> Option<(T, T)> {
+        let (a, b) = raw.split_once(',')?;
+        Some((a.trim().parse().ok()?, b.trim().parse().ok()?))
+    }
+
+    /// Assert the fixture's `key:` lines, concatenated in report order, spell out `expected`
+    /// — each keyDown reports one character, so typing `"hello"` should produce exactly the
+    /// 5 lines `key: h`/`key: e`/`key: l`/`key: l`/`key: o`.
+    fn assert_typed(lines: &[(Stream, String)], expected: &str) -> Result<(), String> {
+        let reported = find_reported(lines, "key: ");
+        let got: String = reported.iter().copied().collect();
+        if got != expected {
+            return Err(format!(
+                "typed text mismatch: fixture reported {reported:?} (joined: {got:?}), expected {expected:?}"
+            ));
+        }
+        Ok(())
+    }
+
+    /// Assert the fixture's last `click:` line is within `tolerance` px of `expected` —
+    /// validates the whole pixel -> point -> global -> CGEvent -> back-to-window-pixel round
+    /// trip (`coords::pixel_to_global_point` on the way out, `quadrants.swift`'s
+    /// `mouseDown` view-space conversion on the way back).
+    fn assert_click_near(lines: &[(Stream, String)], expected: (i32, i32), tolerance: i32) -> Result<(), String> {
+        let reported = find_reported(lines, "click: ");
+        let Some(raw) = reported.last() else {
+            return Err(format!("no click: line in fixture output (stdout lines: {lines:?})"));
+        };
+        let Some((x, y)) = parse_pair::<i32>(raw) else {
+            return Err(format!("could not parse click coordinates from {raw:?}"));
+        };
+        if (x - expected.0).abs() > tolerance || (y - expected.1).abs() > tolerance {
+            return Err(format!(
+                "click landed at ({x},{y}), expected ~{expected:?} (tolerance {tolerance}px)"
+            ));
+        }
+        println!("click landed at ({x},{y}), expected ~{expected:?} — within {tolerance}px tolerance");
+        Ok(())
+    }
+
+    /// Read the fixture's last `scroll:` line, asserting it exists and reports a non-zero
+    /// vertical delta, and return `(reported_dx, reported_dy)` verbatim (`NSEvent`'s own
+    /// `scrollingDeltaX`/`Y`, unmodified) for the caller to interpret against glass's own
+    /// `dy`-sent convention.
+    fn read_scroll(lines: &[(Stream, String)]) -> Result<(f64, f64), String> {
+        let reported = find_reported(lines, "scroll: ");
+        let Some(raw) = reported.last() else {
+            return Err(format!("no scroll: line in fixture output (stdout lines: {lines:?})"));
+        };
+        let Some((dx, dy)) = parse_pair::<f64>(raw) else {
+            return Err(format!("could not parse scroll delta from {raw:?}"));
+        };
+        if dy == 0.0 {
+            return Err(format!("scroll dy reported as zero (raw scroll line: {raw:?})"));
+        }
+        Ok((dx, dy))
+    }
+
+    /// The whole `start_app` -> input-injection -> assertion flow, from launching the
+    /// fixture through the last assertion. Returns `Err` instead of exiting the process on
+    /// any failure, so `run()` can always reach `platform.stop_app()` first — see
+    /// `capture.rs`'s identical-shaped `run_checks` for why a bare `std::process::exit` from
+    /// in here would leak the spawned fixture process.
+    fn run_checks(platform: &mut MacosPlatform, fixture_bin: &std::path::Path) -> Result<(), String> {
+        let spec = AppSpec {
+            build: None,
+            run: vec![fixture_bin.to_string_lossy().into_owned()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 8000,
+            sandbox: SandboxLevel::Off,
+            a11y: false,
+        };
+
+        let geometry = try_expect(platform.start_app(&spec), "start_app")?;
+        println!("started fixture window: {geometry:?}");
+
+        // Give the fixture's window a moment to finish appearing/painting before the first
+        // injected event — mirrors capture.rs's identical settle (this fixture draws once,
+        // synchronously, immediately on launch; see that file's comment for why a fixed
+        // sleep is fine here specifically).
+        std::thread::sleep(Duration::from_millis(500));
+
+        // --- send_key: type "hello", assert the fixture reported exactly those chars. ---
+        try_expect(platform.send_key(&KeyEvent::Text("hello".into())), "send_key(Text(\"hello\"))")?;
+        std::thread::sleep(ACTION_SETTLE);
+        let key_logs = platform.drain_logs();
+        assert_typed(&key_logs, "hello")?;
+        println!("send_key OK: fixture reported the typed characters in order");
+
+        // --- send_pointer(Click): click a known pixel, assert the fixture reported that
+        // pixel back (within tolerance) — the pixel -> point -> global -> CGEvent -> back
+        // round trip. ---
+        let click_event = PointerEvent::Click {
+            x: CLICK_TARGET.0,
+            y: CLICK_TARGET.1,
+            button: MouseButton::Left,
+            count: 1,
+            modifiers: vec![],
+        };
+        try_expect(platform.send_pointer(&click_event), "send_pointer(Click)")?;
+        std::thread::sleep(ACTION_SETTLE);
+        let click_logs = platform.drain_logs();
+        assert_click_near(&click_logs, CLICK_TARGET, CLICK_TOLERANCE)?;
+        println!("send_pointer(Click) OK");
+
+        // --- send_pointer(Scroll): settle the scroll-wheel sign question. dy=5 is glass's
+        // "scroll the content DOWN" convention (see input.rs's module doc / glass-x11's
+        // `scroll_button(5=down,4=up, dy)`). `MacScrollSink::wheel` currently posts
+        // `wheel1 = -dy`; this call is what proves whether that's the right sign on real
+        // hardware, since `wheel1`'s effect on `NSEvent.scrollingDeltaY` was UNVERIFIED
+        // (input.rs's own doc comment) until a real granted run gets this far. Only
+        // `read_scroll`'s non-zero check is asserted here — the SIGN itself is recorded via
+        // `println!` rather than hard-asserted, because no run has yet reached this point
+        // for real (see this file's module doc: every granted run so far was blocked earlier,
+        // by `mini`'s screen being locked, before reaching the scroll leg at all). Once a
+        // real run reports the observed sign here, replace this comment + the println with a
+        // real assertion (flipping `input.rs`'s `wheel1 = -dy` first if the recorded sign
+        // shows glass's dy>0 does NOT produce the intended "scroll down" effect). ---
+        let scroll_event = PointerEvent::Scroll { x: 200, y: 200, dx: 0, dy: 5, modifiers: vec![] };
+        try_expect(platform.send_pointer(&scroll_event), "send_pointer(Scroll)")?;
+        std::thread::sleep(ACTION_SETTLE);
+        let scroll_logs = platform.drain_logs();
+        let (reported_dx, reported_dy) = read_scroll(&scroll_logs)?;
+        println!(
+            "send_pointer(Scroll) OK: sent dx=0,dy=5 (glass 'scroll down') -> fixture reported \
+             scrollingDeltaX={reported_dx},scrollingDeltaY={reported_dy} (SIGN NOT YET ASSERTED — \
+             see this file's module doc)"
+        );
+
+        Ok(())
+    }
+
+    pub(super) fn run() {
+        if !swiftc_available() {
+            println!("skipped (no swiftc)");
+            return;
+        }
+
+        let (fixture_bin, fixture_dir) = build_fixture();
+        println!("built fixture at {}", fixture_bin.display());
+
+        let mut platform = match MacosPlatform::new() {
+            Ok(p) => p,
+            Err(e) => {
+                let _ = std::fs::remove_dir_all(&fixture_dir);
+                fail(format!(
+                    "MacosPlatform::new() (Screen Recording / Accessibility grant missing?): {e}"
+                ));
+            }
+        };
+
+        let result = run_checks(&mut platform, &fixture_bin);
+
+        // Reached regardless of outcome, and BEFORE any process::exit below — see
+        // capture.rs's identical cleanup ordering for why this must run before any exit.
+        let stop_result = platform.stop_app();
+        let _ = std::fs::remove_dir_all(&fixture_dir);
+
+        match result {
+            Ok(()) => {
+                expect(stop_result, "stop_app");
+                println!("INPUT_INTEGRATION_PASS");
+                std::process::exit(0);
+            }
+            Err(msg) => {
+                if let Err(e) = stop_result {
+                    eprintln!("(additionally) stop_app failed: {e}");
+                }
+                fail(msg);
+            }
+        }
+    }
+}

--- a/crates/glass-macos/tests/input.rs
+++ b/crates/glass-macos/tests/input.rs
@@ -2,11 +2,14 @@
 //! `send_pointer` land at the right place: a real `NSView` reports back the characters it
 //! received and the pixel it was clicked at, closing the loop on the whole
 //! pixel -> point -> global -> CGEvent -> AppKit -> app round trip. It also records the
-//! scroll-wheel sign question `input.rs`'s `MacScrollSink::wheel` left UNVERIFIED (see that
-//! file's module doc): a positive `dy` is sent and the fixture's raw, verbatim
-//! `NSEvent.scrollingDeltaY` is printed so a real granted run can confirm which sign macOS
-//! actually delivers — see the scroll leg's comment in `run_checks` below for why that sign
-//! is only recorded, not yet hard-asserted (no granted run has reached it for real yet).
+//! scroll-wheel sign `input.rs`'s `MacScrollSink::wheel` produces: a positive `dy` is sent
+//! and the fixture's raw, verbatim `NSEvent.scrollingDeltaY` is printed. A granted run has
+//! confirmed this leg passes end-to-end, but the observed sign is intentionally left
+//! unasserted here — see the scroll leg's comment in `run_checks` below — because it
+//! depends on the target Mac's **natural-scrolling** system setting
+//! (`com.apple.swipescrolldirection`), not just `input.rs`'s own `wheel1 = -dy` mapping, so
+//! hard-asserting one fixed sign here would be machine-specific rather than a real
+//! regression check.
 //!
 //! **`harness = false`** (see `Cargo.toml`'s `[[test]] name = "input"` entry) for the exact
 //! same reason as `tests/capture.rs`: `send_key`/`send_pointer` reach AppKit
@@ -255,19 +258,19 @@ mod macos_main {
         assert_click_near(&click_logs, CLICK_TARGET, CLICK_TOLERANCE)?;
         println!("send_pointer(Click) OK");
 
-        // --- send_pointer(Scroll): settle the scroll-wheel sign question. dy=5 is glass's
-        // "scroll the content DOWN" convention (see input.rs's module doc / glass-x11's
-        // `scroll_button(5=down,4=up, dy)`). `MacScrollSink::wheel` currently posts
-        // `wheel1 = -dy`; this call is what proves whether that's the right sign on real
-        // hardware, since `wheel1`'s effect on `NSEvent.scrollingDeltaY` was UNVERIFIED
-        // (input.rs's own doc comment) until a real granted run gets this far. Only
-        // `read_scroll`'s non-zero check is asserted here — the SIGN itself is recorded via
-        // `println!` rather than hard-asserted, because no run has yet reached this point
-        // for real (see this file's module doc: every granted run so far was blocked earlier,
-        // by `mini`'s screen being locked, before reaching the scroll leg at all). Once a
-        // real run reports the observed sign here, replace this comment + the println with a
-        // real assertion (flipping `input.rs`'s `wheel1 = -dy` first if the recorded sign
-        // shows glass's dy>0 does NOT produce the intended "scroll down" effect). ---
+        // --- send_pointer(Scroll): record the scroll-wheel sign. dy=5 is glass's "scroll
+        // the content DOWN" convention (see input.rs's module doc / glass-x11's
+        // `scroll_button(5=down,4=up, dy)`). `MacScrollSink::wheel` posts `wheel1 = -dy`, but
+        // what `NSEvent.scrollingDeltaY` the window server ultimately delivers to the fixture
+        // also depends on `mini`'s **natural-scrolling** system setting
+        // (`com.apple.swipescrolldirection`), which inverts the effective on-screen direction
+        // independent of anything `input.rs` controls. So only `read_scroll`'s non-zero check
+        // is hard-asserted here — the SIGN itself is recorded via `println!` rather than
+        // asserted against one fixed expectation, since a fixed expectation would be
+        // machine-specific rather than a portable regression check. Follow-up: read
+        // `com.apple.swipescrolldirection` (e.g. via `defaults read -g
+        // com.apple.swipescrolldirection`) and fold it into the expectation so this can
+        // become a real, machine-independent assertion. ---
         let scroll_event = PointerEvent::Scroll { x: 200, y: 200, dx: 0, dy: 5, modifiers: vec![] };
         try_expect(platform.send_pointer(&scroll_event), "send_pointer(Scroll)")?;
         std::thread::sleep(ACTION_SETTLE);
@@ -275,8 +278,8 @@ mod macos_main {
         let (reported_dx, reported_dy) = read_scroll(&scroll_logs)?;
         println!(
             "send_pointer(Scroll) OK: sent dx=0,dy=5 (glass 'scroll down') -> fixture reported \
-             scrollingDeltaX={reported_dx},scrollingDeltaY={reported_dy} (SIGN NOT YET ASSERTED — \
-             see this file's module doc)"
+             scrollingDeltaX={reported_dx},scrollingDeltaY={reported_dy} (sign depends on \
+             mini's natural-scrolling setting — see this file's module doc)"
         );
 
         Ok(())

--- a/scripts/test-macos.sh
+++ b/scripts/test-macos.sh
@@ -33,4 +33,12 @@ cargo test -p glass-macos --lib "${1:-}"
 if [[ "${GLASS_MACOS_ONBOX:-0}" == "1" ]]; then
   echo "GLASS_MACOS_ONBOX=1: building the capture integration test binary..."
   cargo test -p glass-macos --test capture --no-run
+
+  # Same story as `capture` above, for crates/glass-macos/tests/input.rs (the send_key/
+  # send_pointer end-to-end proof) — building here just confirms it compiles and links; the
+  # granted run needs both Screen Recording and Accessibility TCC grants, so it happens
+  # out-of-band via the same GlassProbe.app LaunchAgent procedure (see
+  # .superpowers/sdd/task-6-brief.md).
+  echo "GLASS_MACOS_ONBOX=1: building the input integration test binary..."
+  cargo test -p glass-macos --test input --no-run
 fi


### PR DESCRIPTION
Third increment of the macOS `Platform` backend: the "interact" half — inject mouse and keyboard, and reconcile the coordinate units. Completes **build → see → interact** on macOS. (Plans 1 & 2 landed the crate skeleton + capture.)

## What's here
- **Physical-pixel coordinate model** (`coords`/`scwindow`/`capture`/`backend`): `WindowGeometry`, the captured `Frame`, and click/region coordinates are all in backing pixels (matching the X11/Windows backends). The backend maps a window-relative pixel coordinate to a global point (÷ `pointPixelScale`) for CGEvent. Geometry is re-resolved **fresh per capture/input call**, so it tracks a window that moves or resizes.
- **`send_pointer`** (`input.rs`): CGEvent mouse — move / click (button, count, modifiers) / drag / scroll, focus-before-inject, reusing `glass-core`'s shared Drag/Scroll drivers. `Gesture` → `Unsupported`. Coordinates bounds-checked (`CoordOutOfBounds`); Accessibility preflighted.
- **`send_key`** (`input.rs`): CGEvent keyboard — text (per-char, self-committing) + chords (modifiers as `CGEventFlags`). Named-key keymap (Return/Tab/arrows/F-keys/…).
- **objc2 FFI**: the CGEvent bindings are safe fns, so `input.rs` is `#![forbid(unsafe_code)]`. Minimal CGEvent Cargo features.
- **Test fixture + integration test**: the Cocoa fixture now reports received key/mouse/scroll events; a `harness = false` (main-thread) input test types text and clicks at a known pixel and asserts the fixture receives them at the right coordinate.

## Notes
- Scroll *direction* currently tracks the target Mac's "natural scrolling" system setting; normalizing it (so `dy` is setting-independent) is a follow-up.
- Input requires an unlocked, active GUI session (macOS suppresses synthetic input to background apps while the screen is locked); capture does not.
- Window management (`window`/`list_windows`/`select_window`) remains `unimplemented!()` for a follow-up; worker-thread main-thread marshaling is deferred.

## Verification
- Linux: `cargo build/clippy/test --workspace --locked` green.
- macOS 26.5 (Apple Silicon): `clippy -D warnings` clean; 45 unit tests; the granted input integration test types "hello" and clicks at pixel (100,100) — the fixture receives the keys in order and reports the click at exactly (100,100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
