### PR TITLE
feat(macos): glass-macos window management — list/select/window ops via AXUIElement (Plan 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,7 @@ dependencies = [
  "glass-core",
  "objc2",
  "objc2-app-kit",
+ "objc2-application-services",
  "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-foundation",
@@ -1657,6 +1658,17 @@ dependencies = [
  "libc",
  "objc2",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-application-services"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69282c2b5bc58fba07cb9de2113619532eb551e98efe3d8d695509ef45fbd53b"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -24,6 +24,14 @@ harness = false
 name = "input"
 harness = false
 
+# Mac-gated window-management integration test (crates/glass-macos/tests/windows.rs) — same
+# harness=false main-thread requirement as `capture`/`input` above (list_windows/
+# select_window/window/capture_frame all reach AppKit's ffi::app_kit_init()); see that
+# file's module doc.
+[[test]]
+name = "windows"
+harness = false
+
 [dependencies]
 glass-core.workspace = true
 

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -81,6 +81,34 @@ objc2-core-graphics = { version = "0.3.2", default-features = false, features = 
 ] }
 objc2-core-foundation = { version = "0.3.2", default-features = false, features = [
     "CFCGTypes",
+    # axwindow.rs: CFArray for kAXWindowsAttribute's element array (CFArray<AXUIElement>);
+    # CFString for AX attribute/action name literals (CFString::from_str — see
+    # axwindow.rs's module doc for why these aren't sourced from
+    # objc2-application-services's own constants features); CFNumber for
+    # CFBoolean/kCFBooleanTrue (kAXMainAttribute's set value).
+    "CFArray",
+    "CFString",
+    "CFNumber",
+] }
+# axwindow.rs: AXUIElement (window enumeration/attribute get+set/actions), AXValue
+# (position/size as CGPoint/CGSize), AXError (the shared failure type every AX call
+# returns). `HIServices` is the umbrella feature gating the whole generated module tree
+# those three live under (crates.io's per-type features only pick which files *inside*
+# HIServices compile in — the module itself doesn't exist without it; found by reading
+# `src/generated/mod.rs`'s `#[cfg(feature = "HIServices")] pub use self::__HIServices::*;`
+# after `AXUIElement`/`AXValue`/`AXError` alone failed to resolve). `libc` unlocks
+# AXUIElement::new_application(pid: libc::pid_t) — our own `i32` pid coerces to it directly
+# via the type alias, same as objc2-app-kit's `libc` feature above; no direct `libc`
+# dependency needed here. Deliberately NOT AXAttributeConstants/AXActionConstants/
+# AXRoleConstants: reading the generated source shows header-translator produced EMPTY
+# files for all three (no kAX*Attribute/kAX*Action symbols at all) — axwindow.rs declares
+# those attribute/action name strings itself instead (see its module doc).
+objc2-application-services = { version = "0.3.2", default-features = false, features = [
+    "HIServices",
+    "AXUIElement",
+    "AXValue",
+    "AXError",
+    "libc",
 ] }
 block2 = "0.6.2"
 # SIGTERM/SIGKILL for `process::terminate` — already a workspace dep (glass-wayland,

--- a/crates/glass-macos/fixture/quadrants.swift
+++ b/crates/glass-macos/fixture/quadrants.swift
@@ -1,12 +1,12 @@
 // quadrants.swift — glass-macos capture + input fixture (Plan 2 Task 6, extended by Plan 3
-// Task 5).
+// Task 5, extended again by Plan 4 Task 6).
 //
 // A minimal Cocoa app: a single 400x400 window whose entire content view paints 4 known
 // solid colors into the window's four VISUAL quadrants — i.e. the quadrants as they
 // appear on screen, not raw view-local coordinates. `NSView` is bottom-left-origin,
 // y-up when unflipped (the default, and what this view uses): a rect drawn at view
 // y:[200,400) appears at the TOP of the window on screen, and y:[0,200) at the BOTTOM.
-// So:
+// So, for the default (primary) window:
 //
 //   visual top-left     (screen upper-left)  = red   #FF0000
 //   visual top-right    (screen upper-right) = green #00FF00
@@ -29,11 +29,13 @@
 // stdout, flushing after each — used by the capture test only to confirm the process is
 // alive, but not for pixel assertions.
 //
-// This fixture is shared by TWO integration tests: the Plan 2 capture test (relies on the
-// 4-quadrant colors + exact 400x400 borderless window size) and the Plan 3 input test
-// (relies on the event reporting below). `QuadrantView` is made key/first-responder so it
-// actually receives keyboard and mouse events, and reports each one to stdout as a single
-// flushed line so the driving test can assert on injected input landing correctly:
+// This fixture is shared by THREE integration tests: the Plan 2 capture test (relies on
+// the 4-quadrant colors + exact 400x400 borderless window size), the Plan 3 input test
+// (relies on the event reporting below), and the Plan 4 window test (relies on the
+// SECOND window described next). `QuadrantView` is made key/first-responder so it
+// actually receives keyboard and mouse events, and reports each one to stdout as a
+// single flushed line so the driving test can assert on injected input landing
+// correctly:
 //
 //   key: <characters>      — one line per keyDown, the event's `characters` string.
 //   click: <x>,<y>         — one line per (left) mouseDown, in the content view's
@@ -45,6 +47,29 @@
 //                             verbatim (sign as macOS reports it), for verifying the
 //                             scroll-wheel sign convention against the tool boundary.
 //
+// Both windows report through these same three prefixes (they're separate instances of
+// the same `QuadrantView` class) — a deliberate simplification: only Plan 4 Task 6's
+// window test opens a second window, and it never sends key/click/scroll input to
+// either window, so there is no ambiguity to resolve today. A future multi-window input
+// test would need per-window prefixes; out of scope here.
+//
+// ## Plan 4 Task 6: a second, optional window
+//
+// Pass `--windows 2` (an argv pair) or set `GLASS_FIXTURE_WINDOWS=2` (an env var) to
+// additionally open a SECOND window, titled "glass-fixture-2", offset from the first by
+// (120, 120) points, painted with a DIFFERENT, easily-distinguished 4-color palette
+// (cyan/magenta/yellow/black instead of red/green/blue/white) — so a captured frame can
+// be identified as "the second window" by its pixel colors alone, the same way the
+// capture test identifies the first window's colors. The DEFAULT (no flag/env set)
+// still opens exactly one window, titled "glass-fixture", identical in every respect to
+// the pre-Plan-4 fixture — the capture/input tests never pass this flag, so they see no
+// behavior change.
+//
+// The primary window is always created (or re-ordered) last and made key/main, so it is
+// the frontmost window and therefore the one `SCShareableContent`'s window enumeration
+// finds first for this app's pid — preserving `start_app`'s pre-Plan-4 "first window
+// discovered becomes the active window" behavior even when a second window exists.
+//
 // Build: swiftc -O -parse-as-library quadrants.swift -o quadrants
 //   (`-parse-as-library` is required because this file uses a top-level `@main` type
 //   rather than unadorned top-level statements — the same gotcha as
@@ -54,6 +79,28 @@ import Cocoa
 
 let windowSize = NSSize(width: 400, height: 400)
 
+/// Where the second window (if any) is placed, relative to the primary window's `.zero`
+/// origin — see the module doc's Plan 4 Task 6 section.
+let secondWindowOffset = NSPoint(x: 120, y: 120)
+
+/// How many fixture windows to open this run: 1 (the pre-Plan-4 default, unaffected) or
+/// 2 (Plan 4 Task 6's window-integration test). Checks `--windows <n>` in argv first,
+/// then `GLASS_FIXTURE_WINDOWS` in the environment; any other/missing value means 1.
+/// `n < 1` is treated as 1 (a fixture with zero windows would never appear on-screen at
+/// all, defeating every test that uses it).
+func requestedWindowCount() -> Int {
+    let args = CommandLine.arguments
+    if let flagIndex = args.firstIndex(of: "--windows"), flagIndex + 1 < args.count,
+        let n = Int(args[flagIndex + 1])
+    {
+        return max(1, n)
+    }
+    if let raw = ProcessInfo.processInfo.environment["GLASS_FIXTURE_WINDOWS"], let n = Int(raw) {
+        return max(1, n)
+    }
+    return 1
+}
+
 /// A borderless window that can still become key/main — not needed for this task's pure
 /// capture test, but keeps the fixture usable for Plan 3's input work without surprises.
 final class FixtureWindow: NSWindow {
@@ -61,29 +108,74 @@ final class FixtureWindow: NSWindow {
     override var canBecomeMain: Bool { true }
 }
 
+/// One window's 4-color quadrant palette, keyed the same way the class doc above lists
+/// them (visual, on-screen corners).
+struct QuadrantPalette {
+    let topLeft: NSColor
+    let topRight: NSColor
+    let bottomLeft: NSColor
+    let bottomRight: NSColor
+}
+
+/// The primary ("glass-fixture") window's palette — unchanged from the pre-Plan-4
+/// fixture's hardcoded red/green/blue/white.
+let primaryPalette = QuadrantPalette(
+    topLeft: NSColor(deviceRed: 1, green: 0, blue: 0, alpha: 1), // red
+    topRight: NSColor(deviceRed: 0, green: 1, blue: 0, alpha: 1), // green
+    bottomLeft: NSColor(deviceRed: 0, green: 0, blue: 1, alpha: 1), // blue
+    bottomRight: NSColor(deviceRed: 1, green: 1, blue: 1, alpha: 1) // white
+)
+
+/// The secondary ("glass-fixture-2") window's palette — deliberately a DIFFERENT set of
+/// 4 colors (cyan/magenta/yellow/black) so a captured frame can be told apart from the
+/// primary window's red/green/blue/white by pixel color alone (see the module doc).
+let secondaryPalette = QuadrantPalette(
+    topLeft: NSColor(deviceRed: 0, green: 1, blue: 1, alpha: 1), // cyan
+    topRight: NSColor(deviceRed: 1, green: 0, blue: 1, alpha: 1), // magenta
+    bottomLeft: NSColor(deviceRed: 1, green: 1, blue: 0, alpha: 1), // yellow
+    bottomRight: NSColor(deviceRed: 0, green: 0, blue: 0, alpha: 1) // black
+)
+
 final class QuadrantView: NSView {
+    private let palette: QuadrantPalette
+
+    init(frame: NSRect, palette: QuadrantPalette) {
+        self.palette = palette
+        super.init(frame: frame)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("QuadrantView does not support NSCoder-based initialization")
+    }
+
     // Required to become first responder at all — NSView defaults to false.
     override var acceptsFirstResponder: Bool { true }
 
     override func draw(_ dirtyRect: NSRect) {
-        let half = bounds.width / 2 // == bounds.height / 2 for a 400x400 view
+        // Width and height halves are computed SEPARATELY (not one shared `half`, as the
+        // pre-Plan-4 version of this method assumed): the original 400x400 window made
+        // `bounds.width/2 == bounds.height/2` true by construction, but Plan 4 Task 6's
+        // `WindowOp::Resize` can leave the view non-square (e.g. 550x300) — a single shared
+        // `half` would draw the "top"/"bottom" pair too tall or too short by the width/height
+        // mismatch, corrupting the quadrant boundaries the capture test's pixel sampling
+        // relies on. Recomputed on every `draw(_:)` call (not cached) since `bounds` changes
+        // whenever the window is resized (`NSWindow` keeps its `contentView`'s frame equal to
+        // the window's content area on every resize — see the class doc above).
+        let halfW = bounds.width / 2
+        let halfH = bounds.height / 2
         let quadrants: [(NSRect, NSColor)] = [
-            // view-local rect                                            color   visual quadrant
-            (NSRect(x: 0, y: half, width: half, height: half), red), // top-left
-            (NSRect(x: half, y: half, width: half, height: half), green), // top-right
-            (NSRect(x: 0, y: 0, width: half, height: half), blue), // bottom-left
-            (NSRect(x: half, y: 0, width: half, height: half), white), // bottom-right
+            // view-local rect                                                color   visual quadrant
+            (NSRect(x: 0, y: halfH, width: halfW, height: halfH), palette.topLeft), // top-left
+            (NSRect(x: halfW, y: halfH, width: halfW, height: halfH), palette.topRight), // top-right
+            (NSRect(x: 0, y: 0, width: halfW, height: halfH), palette.bottomLeft), // bottom-left
+            (NSRect(x: halfW, y: 0, width: halfW, height: halfH), palette.bottomRight), // bottom-right
         ]
         for (rect, color) in quadrants {
             color.setFill()
             NSBezierPath(rect: rect).fill()
         }
     }
-
-    private let red = NSColor(deviceRed: 1, green: 0, blue: 0, alpha: 1)
-    private let green = NSColor(deviceRed: 0, green: 1, blue: 0, alpha: 1)
-    private let blue = NSColor(deviceRed: 0, green: 0, blue: 1, alpha: 1)
-    private let white = NSColor(deviceRed: 1, green: 1, blue: 1, alpha: 1)
 
     // MARK: - Input reporting (Plan 3)
 
@@ -97,7 +189,7 @@ final class QuadrantView: NSView {
         // convert into this view's coordinate space (also bottom-left origin, since the
         // view is unflipped — see the quadrant-color comment above), then flip y to match
         // the tool boundary's top-left-origin pixel convention. For a borderless window at
-        // 1x backing scale, view points == window pixels, so no further scaling is needed.
+        // 1x backing scale, view points == window pixels.
         let locationInView = convert(event.locationInWindow, from: nil)
         let x = Int(locationInView.x.rounded())
         let y = Int((bounds.height - locationInView.y).rounded())
@@ -127,24 +219,57 @@ enum StdinEcho {
 }
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
-    var window: FixtureWindow!
+    /// Strong refs to every open window — `NSWindow` does not otherwise keep itself alive,
+    /// and Plan 4 Task 6 needs a second instance to survive alongside the first.
+    var windows: [FixtureWindow] = []
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        let rect = NSRect(origin: .zero, size: windowSize)
-        window = FixtureWindow(
+        let count = requestedWindowCount()
+
+        // Secondary window (if requested) is created/ordered FIRST, so the primary window
+        // — created/ordered last, below — ends up frontmost. See the module doc's Plan 4
+        // Task 6 section for why this ordering matters (SCShareableContent enumeration
+        // order / start_app's "first window discovered becomes active" contract).
+        if count >= 2 {
+            let secondary = makeWindow(
+                origin: secondWindowOffset,
+                title: "glass-fixture-2",
+                palette: secondaryPalette
+            )
+            windows.append(secondary)
+            secondary.orderFront(nil)
+            secondary.makeFirstResponder(secondary.contentView)
+        }
+
+        let primary = makeWindow(origin: .zero, title: "glass-fixture", palette: primaryPalette)
+        windows.append(primary)
+        primary.makeKeyAndOrderFront(nil)
+        primary.makeFirstResponder(primary.contentView)
+
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    private func makeWindow(origin: NSPoint, title: String, palette: QuadrantPalette) -> FixtureWindow {
+        let rect = NSRect(origin: origin, size: windowSize)
+        let window = FixtureWindow(
             contentRect: rect,
-            styleMask: [.borderless],
+            // `.resizable` (alongside `.borderless`) is required for `AXUIElementSetAttributeValue`
+            // to accept `AXSize` at all — a non-resizable window rejects it with a generic
+            // `kAXErrorFailure` (-25200), discovered running Plan 4 Task 6's granted window
+            // test against a `[.borderless]`-only window. `.resizable` adds no visible chrome
+            // to a borderless window (no title bar, so no extra frame reserved for it — see
+            // the module doc's exact-400x400 rationale), so this doesn't affect the capture
+            // test's pixel-exact quadrant math; it only permits AX/programmatic resize.
+            styleMask: [.borderless, .resizable],
             backing: .buffered,
             defer: false
         )
-        window.title = "glass-fixture"
+        window.title = title
         window.isOpaque = true
         window.hasShadow = false
         window.level = .normal
-        window.contentView = QuadrantView(frame: rect)
-        window.makeKeyAndOrderFront(nil)
-        window.makeFirstResponder(window.contentView)
-        NSApp.activate(ignoringOtherApps: true)
+        window.contentView = QuadrantView(frame: NSRect(origin: .zero, size: windowSize), palette: palette)
+        return window
     }
 }
 

--- a/crates/glass-macos/src/axwindow.rs
+++ b/crates/glass-macos/src/axwindow.rs
@@ -76,13 +76,24 @@ extern "C" {
 }
 
 /// Per-field pixel tolerance for the geometry-match fallback (each of x/y/width/height).
-/// More generous than the proven `window_ops.swift` reference's 4px `close()` (which
-/// compares a before/after read of the *same* AX API): this compares an `AXUIElement`'s
-/// frame against `SCWindow`'s independently-reported geometry, where small window-manager
-/// framing differences are more plausible. Unverified at runtime — this task is
-/// compile-only; Task 6's granted multi-window test is the first real exercise of this
-/// path and may need to retune this constant.
+/// More generous than the brief-specified reference's 4px `close()` (which compares a
+/// before/after read of the *same* AX API): this compares an `AXUIElement`'s frame against
+/// `SCWindow`'s independently-reported geometry, where small window-manager framing
+/// differences are more plausible. Verified at runtime by the Task 6 window integration
+/// test's forced-fallback run (`GLASS_MACOS_FORCE_AX_GEOMETRY_FALLBACK`, see
+/// [`FORCE_AX_GEOMETRY_FALLBACK_ENV`]), which exercises this path against a real two-window
+/// layout and confirms it resolves the correct (non-first) window.
 const FALLBACK_TOLERANCE_PX: i32 = 8;
+
+/// Test-only diagnostic: when this environment variable is set (to any value), the private
+/// `_AXUIElementGetWindow` correlation is skipped entirely and [`ax_window_for_cgwindowid`]
+/// goes straight to [`geometry_fallback`] — final-review fix 5. Without this hook, the
+/// geometry fallback has zero live coverage on any Mac where the private symbol still works
+/// (which is every Mac observed so far): the fallback only ever engages if Apple breaks or
+/// renames `_AXUIElementGetWindow`, so there is no way to exercise it against a real
+/// multi-window layout without deliberately forcing it. Not read anywhere outside this
+/// module; not a supported way to configure glass in normal use.
+const FORCE_AX_GEOMETRY_FALLBACK_ENV: &str = "GLASS_MACOS_FORCE_AX_GEOMETRY_FALLBACK";
 
 /// Resolve the `AXUIElement` window for `pid` whose `CGWindowID` is `window_id`.
 ///
@@ -93,6 +104,10 @@ const FALLBACK_TOLERANCE_PX: i32 = 8;
 /// are the target window's already-known `SCShareableContent` pixel geometry and
 /// point-per-pixel scale (from `scwindow::WindowMatch`), compared against each AX window's
 /// own position/size. [`GlassError::WindowNotFound`] if neither path finds a match.
+///
+/// If [`FORCE_AX_GEOMETRY_FALLBACK_ENV`] is set, the private call is skipped entirely and
+/// this goes straight to the geometry fallback (test-only diagnostic — see that constant's
+/// doc).
 pub(crate) fn ax_window_for_cgwindowid(
     pid: i32,
     window_id: u32,
@@ -104,6 +119,14 @@ pub(crate) fn ax_window_for_cgwindowid(
     // no aliasing/lifetime preconditions.
     let app = unsafe { AXUIElement::new_application(pid) };
     let windows = ax_windows(&app)?;
+
+    if std::env::var_os(FORCE_AX_GEOMETRY_FALLBACK_ENV).is_some() {
+        eprintln!(
+            "glass-macos: {FORCE_AX_GEOMETRY_FALLBACK_ENV} set; skipping _AXUIElementGetWindow \
+             and forcing the geometry fallback for CGWindowID {window_id} (test-only diagnostic)"
+        );
+        return geometry_fallback(&windows, &geometry_px, scale).ok_or(GlassError::WindowNotFound);
+    }
 
     let mut any_private_call_succeeded = false;
     for w in windows.iter() {
@@ -304,21 +327,26 @@ fn ax_geometry_px(el: &AXUIElement, scale: f64) -> Result<WindowGeometry> {
     Ok(WindowGeometry { x, y, width: w.max(0) as u32, height: h.max(0) as u32 })
 }
 
-/// True if every field of `a`/`b` is within [`FALLBACK_TOLERANCE_PX`] of the other.
+/// True if every field of `a`/`b` is within [`FALLBACK_TOLERANCE_PX`] of the other. Computed
+/// in `i64` before `.abs()` so no cast can wrap for any input (matches `coords.rs`'s
+/// no-overflow house rule).
 fn within_tolerance(a: &WindowGeometry, b: &WindowGeometry) -> bool {
-    (a.x - b.x).abs() <= FALLBACK_TOLERANCE_PX
-        && (a.y - b.y).abs() <= FALLBACK_TOLERANCE_PX
-        && (a.width as i32 - b.width as i32).abs() <= FALLBACK_TOLERANCE_PX
-        && (a.height as i32 - b.height as i32).abs() <= FALLBACK_TOLERANCE_PX
+    let tolerance = i64::from(FALLBACK_TOLERANCE_PX);
+    (i64::from(a.x) - i64::from(b.x)).abs() <= tolerance
+        && (i64::from(a.y) - i64::from(b.y)).abs() <= tolerance
+        && (i64::from(a.width) - i64::from(b.width)).abs() <= tolerance
+        && (i64::from(a.height) - i64::from(b.height)).abs() <= tolerance
 }
 
 /// Sum of per-field absolute pixel differences between `a`/`b` — used only to rank
-/// candidates that already passed [`within_tolerance`], smallest-first.
+/// candidates that already passed [`within_tolerance`], smallest-first. Computed in `i64`
+/// before `.abs()` so no cast can wrap for any input (matches `coords.rs`'s no-overflow
+/// house rule).
 fn geometry_distance(a: &WindowGeometry, b: &WindowGeometry) -> i64 {
-    i64::from((a.x - b.x).abs())
-        + i64::from((a.y - b.y).abs())
-        + i64::from((a.width as i32 - b.width as i32).abs())
-        + i64::from((a.height as i32 - b.height as i32).abs())
+    (i64::from(a.x) - i64::from(b.x)).abs()
+        + (i64::from(a.y) - i64::from(b.y)).abs()
+        + (i64::from(a.width) - i64::from(b.width)).abs()
+        + (i64::from(a.height) - i64::from(b.height)).abs()
 }
 
 #[cfg(test)]

--- a/crates/glass-macos/src/axwindow.rs
+++ b/crates/glass-macos/src/axwindow.rs
@@ -1,0 +1,366 @@
+//! `AXUIElement` window operations (position/size get+set, raise, main) and the
+//! `CGWindowID` <-> `AXUIElement` correlation this crate needs to bridge two separate
+//! window-identity worlds: ScreenCaptureKit/`SCShareableContent` (`scwindow.rs`) addresses
+//! a window by its `CGWindowID` — the id `list_windows`/`select_window` hand back to an
+//! agent — while every window *operation* (move, resize, raise, focus) only exists on the
+//! Accessibility side, as an `AXUIElement`. There is no public API that maps one to the
+//! other in either direction.
+//!
+//! ## The correlation: private `_AXUIElementGetWindow`, contained + geometry fallback
+//!
+//! [`_AXUIElementGetWindow`] is the well-known private symbol every AX-based window
+//! manager (Rectangle, yabai, BetterDisplay, Hammerspoon) uses for exactly this: given an
+//! `AXUIElementRef`, it writes out the `CGWindowID` that window belongs to. It is
+//! undocumented, unversioned, and Apple could remove or rename it in any macOS release —
+//! the same posture this codebase takes with other private APIs (e.g. the planned
+//! `CGVirtualDisplay` provider): contained in one module, never the *only* path, and
+//! flagged here so a later maintainer knows to re-validate it against each new macOS
+//! major. [`ax_window_for_cgwindowid`] never trusts it exclusively: if the private call
+//! errors on *every* enumerated window (the "symbol looks broken" signal — distinct from
+//! "this particular window just isn't among them"), it falls back to matching the
+//! `AXUIElement`'s own position/size (converted points -> pixels via
+//! `coords::point_to_global_pixel`) against the target `CGWindowID`'s already-known
+//! `SCShareableContent` geometry, within a small pixel tolerance, picking the closest match.
+//!
+//! ## CFType memory: every AX "Copy"/"Create" call returns a +1 ref
+//!
+//! `AXUIElementCopyAttributeValue`/`AXValueCreate` follow Core Foundation's ordinary
+//! Copy/Create ownership rule — the caller owns the returned ref and must release it.
+//! [`copy_attribute`] wraps every such raw `*const CFType` in a `CFRetained<CFType>` via
+//! `CFRetained::from_raw` (no extra retain — matches `input.rs`'s `mouse_event`/
+//! `keyboard_event` wrapping `CGEvent::new_*`'s already-owned results), so the ref is
+//! dropped (released) automatically once it goes out of scope; nothing in this module
+//! manually calls `CFRelease`.
+//!
+//! ## `objc2-application-services` gotcha: the `kAX*` string constants are NOT generated
+//!
+//! The crate ships `AXAttributeConstants`/`AXActionConstants`/`AXRoleConstants` Cargo
+//! features, but they produce **empty** generated files — `header-translator` did not pick
+//! up `AXAttributeConstants.h`/`AXActionConstants.h`'s plain `extern const CFStringRef`
+//! declarations (confirmed by reading the generated source directly: each file is a
+//! two-line stub with no symbols). This module does not depend on those features at all;
+//! instead it builds each attribute/action name as a `CFString::from_str` literal
+//! (`"AXWindows"`, `"AXPosition"`, `"AXRaise"`, ...) — the same fixed values the (separate,
+//! unused-here) `accessibility-sys` crate hardcodes for the same reason, and the values
+//! Apple documents as stable strings, not just opaque symbol names.
+//!
+//! Every fn here is `pub(crate)` per Plan 4 Task 3's interface list, but Task 4
+//! (`window(op)`) and Task 5 (`select_window`) are what wire them into `backend.rs`; until
+//! then nothing in this crate calls the entry points, hence the module-wide
+//! `#![allow(dead_code)]` below (mirrors `process.rs`'s per-fn `#[allow(dead_code)]` on
+//! `spawn`/`terminate` from Plan 2, applied once for the whole file here since virtually
+//! everything in it is only reachable from those still-unwired entry points).
+
+#![allow(dead_code)]
+
+use std::ptr::NonNull;
+
+use objc2_application_services::{AXError, AXUIElement, AXValue, AXValueType};
+use objc2_core_foundation::{kCFBooleanTrue, CFArray, CFRetained, CFString, CFType, CGPoint, CGSize};
+
+use glass_core::platform::WindowGeometry;
+use glass_core::{GlassError, Result};
+
+use crate::coords::point_to_global_pixel;
+
+// The private CGWindowID<->AXUIElement bridge (see module doc). Declared here, not
+// available from `objc2-application-services` (it's undocumented and intentionally absent
+// from Apple's public headers, so no binding crate exposes it) — the same contained
+// `extern "C"` pattern `permissions.rs` uses for `AXIsProcessTrusted`/
+// `CGPreflightScreenCaptureAccess`.
+//
+// VERSION FRAGILITY: undocumented and unversioned; Apple could rename or remove it in any
+// macOS release without notice. Re-validate (does it still link? does it still return
+// `.Success` for real windows?) whenever this crate bumps its minimum-supported macOS
+// major. `ax_window_for_cgwindowid`'s geometry fallback exists specifically so a broken
+// symbol degrades this crate's window ops rather than making them entirely non-functional.
+#[link(name = "ApplicationServices", kind = "framework")]
+extern "C" {
+    fn _AXUIElementGetWindow(element: &AXUIElement, out_wid: *mut u32) -> AXError;
+}
+
+/// Per-field pixel tolerance for the geometry-match fallback (each of x/y/width/height).
+/// More generous than the proven `window_ops.swift` reference's 4px `close()` (which
+/// compares a before/after read of the *same* AX API): this compares an `AXUIElement`'s
+/// frame against `SCWindow`'s independently-reported geometry, where small window-manager
+/// framing differences are more plausible. Unverified at runtime — this task is
+/// compile-only; Task 6's granted multi-window test is the first real exercise of this
+/// path and may need to retune this constant.
+const FALLBACK_TOLERANCE_PX: i32 = 8;
+
+/// Resolve the `AXUIElement` window for `pid` whose `CGWindowID` is `window_id`.
+///
+/// Enumerates `AXUIElementCreateApplication(pid)`'s `kAXWindows`, and for each candidate
+/// calls the private [`_AXUIElementGetWindow`] to read its `CGWindowID`, returning the
+/// first exact match. If that private call errors on *every* candidate (a broken/renamed
+/// symbol — see the module doc), falls back to matching by geometry: `geometry_px`/`scale`
+/// are the target window's already-known `SCShareableContent` pixel geometry and
+/// point-per-pixel scale (from `scwindow::WindowMatch`), compared against each AX window's
+/// own position/size. [`GlassError::WindowNotFound`] if neither path finds a match.
+pub(crate) fn ax_window_for_cgwindowid(
+    pid: i32,
+    window_id: u32,
+    geometry_px: WindowGeometry,
+    scale: f64,
+) -> Result<CFRetained<AXUIElement>> {
+    // SAFETY: `AXUIElementCreateApplication` never returns NULL per Apple's documented
+    // contract (the binding itself `.expect()`s on this); `pid` is a plain process id with
+    // no aliasing/lifetime preconditions.
+    let app = unsafe { AXUIElement::new_application(pid) };
+    let windows = ax_windows(&app)?;
+
+    let mut any_private_call_succeeded = false;
+    for w in windows.iter() {
+        let mut wid: u32 = 0;
+        // SAFETY: `w` is a live `AXUIElement` window just yielded by `kAXWindows`; `wid`
+        // is a valid local out-param. See the symbol's declaration above for the broader
+        // private-API contract this call relies on.
+        let err = unsafe { _AXUIElementGetWindow(&w, &mut wid) };
+        if err == AXError::Success {
+            any_private_call_succeeded = true;
+            if wid == window_id {
+                return Ok(w);
+            }
+        }
+    }
+
+    if !any_private_call_succeeded {
+        eprintln!(
+            "glass-macos: _AXUIElementGetWindow errored on every AX window for pid {pid}; \
+             falling back to geometry match for CGWindowID {window_id}"
+        );
+        if let Some(w) = geometry_fallback(&windows, &geometry_px, scale) {
+            return Ok(w);
+        }
+    }
+    Err(GlassError::WindowNotFound)
+}
+
+/// Read `el`'s `AXPosition` (top-left, in points — Quartz's global screen space, same unit
+/// `coords.rs`'s `global_pixel_to_point`/`point_to_global_pixel` convert to/from).
+pub(crate) fn ax_position(el: &AXUIElement) -> Result<(f64, f64)> {
+    let value = attribute_axvalue(el, "AXPosition")?;
+    let mut point = CGPoint { x: 0.0, y: 0.0 };
+    // SAFETY: `value` was just verified (via `downcast`) to be a real `AXValue`; `point`
+    // is a valid local out-param whose type matches the requested `AXValueType::CGPoint` —
+    // mirrors the proven reference's `AXValueGetValue(v, .cgPoint, &p)`.
+    let ok = unsafe { value.value(AXValueType::CGPoint, NonNull::from(&mut point).cast()) };
+    if !ok {
+        return Err(GlassError::Backend("AXValueGetValue(AXPosition, .cgPoint) returned false".into()));
+    }
+    Ok((point.x, point.y))
+}
+
+/// Read `el`'s `AXSize` (width/height, in points).
+pub(crate) fn ax_size(el: &AXUIElement) -> Result<(f64, f64)> {
+    let value = attribute_axvalue(el, "AXSize")?;
+    let mut size = CGSize { width: 0.0, height: 0.0 };
+    // SAFETY: same as `ax_position` above, with `AXValueType::CGSize`/`CGSize`.
+    let ok = unsafe { value.value(AXValueType::CGSize, NonNull::from(&mut size).cast()) };
+    if !ok {
+        return Err(GlassError::Backend("AXValueGetValue(AXSize, .cgSize) returned false".into()));
+    }
+    Ok((size.width, size.height))
+}
+
+/// Set `el`'s `AXPosition` to `pos` (points). Errors if the AX call itself does not report
+/// success; does not read back to verify the value actually took — that's `backend.rs`'s
+/// `window(op)` (Task 4), which reads back every mutating op through `ax_position`/
+/// `ax_size` and returns a structured error if the change didn't land.
+pub(crate) fn ax_set_position(el: &AXUIElement, pos: (f64, f64)) -> Result<()> {
+    set_axvalue(el, "AXPosition", AXValueType::CGPoint, &mut CGPoint { x: pos.0, y: pos.1 })
+}
+
+/// Set `el`'s `AXSize` to `size` (points). Same no-read-back-verify contract as
+/// [`ax_set_position`].
+pub(crate) fn ax_set_size(el: &AXUIElement, size: (f64, f64)) -> Result<()> {
+    set_axvalue(el, "AXSize", AXValueType::CGSize, &mut CGSize { width: size.0, height: size.1 })
+}
+
+/// Raise `el` to the front of its application's window list (`kAXRaiseAction`).
+pub(crate) fn ax_raise(el: &AXUIElement) -> Result<()> {
+    let action = CFString::from_str("AXRaise");
+    // SAFETY: `el` is a live `AXUIElement`; matches `AXUIElementPerformAction`'s
+    // documented contract (element + action name, no other preconditions).
+    let err = unsafe { el.perform_action(&action) };
+    if err != AXError::Success {
+        return Err(ax_backend_err("AXRaise", err));
+    }
+    Ok(())
+}
+
+/// Mark `el` as its application's main window (`kAXMainAttribute` = true).
+pub(crate) fn ax_set_main(el: &AXUIElement) -> Result<()> {
+    let attr = CFString::from_str("AXMain");
+    // SAFETY: `kCFBooleanTrue` is a framework-owned singleton that is always live for the
+    // process's lifetime; reading the extern static is a plain global read.
+    let value = unsafe { kCFBooleanTrue }.ok_or_else(|| GlassError::Backend("kCFBooleanTrue unavailable".into()))?;
+    // SAFETY: `el` is live; `value` derefs to `&CFType` (see the module doc's CFType-memory
+    // section); matches `AXUIElementSetAttributeValue`'s documented contract.
+    let err = unsafe { el.set_attribute_value(&attr, value) };
+    if err != AXError::Success {
+        return Err(ax_backend_err("AXMain", err));
+    }
+    Ok(())
+}
+
+/// Copy `app`'s `kAXWindows` attribute and reinterpret it as a typed `CFArray<AXUIElement>`.
+fn ax_windows(app: &AXUIElement) -> Result<CFRetained<CFArray<AXUIElement>>> {
+    let cftype = copy_attribute(app, "AXWindows")?;
+    let arr = cftype
+        .downcast::<CFArray>()
+        .map_err(|_| GlassError::Backend("kAXWindowsAttribute did not return a CFArray".into()))?;
+    // SAFETY: `kAXWindowsAttribute` is documented by Apple to hold `AXUIElementRef`s; this
+    // only attaches compile-time element-type information (no runtime effect) — the same
+    // technique this crate's own `CFArray::from_objects`/`from_retained_objects`
+    // constructors use internally (`CFRetained::cast_unchecked::<Self>(array)`).
+    Ok(unsafe { CFRetained::cast_unchecked(arr) })
+}
+
+/// Copy `el`'s `attr_name` attribute value, downcast-checked to a concrete `AXValue`
+/// (position/size are always `AXValue`-wrapped `CGPoint`/`CGSize`, never a bare `CFType`).
+fn attribute_axvalue(el: &AXUIElement, attr_name: &str) -> Result<CFRetained<AXValue>> {
+    let cftype = copy_attribute(el, attr_name)?;
+    cftype.downcast::<AXValue>().map_err(|_| GlassError::Backend(format!("{attr_name} did not return an AXValue")))
+}
+
+/// `AXUIElementCopyAttributeValue(el, attr_name, ...)`, wrapping the already-retained (+1,
+/// per Core Foundation's Copy/Create rule — see the module doc) raw result in a
+/// `CFRetained<CFType>` so it's released automatically when dropped.
+fn copy_attribute(el: &AXUIElement, attr_name: &str) -> Result<CFRetained<CFType>> {
+    let attr = CFString::from_str(attr_name);
+    let mut raw: *const CFType = std::ptr::null();
+    // SAFETY: `el` is a live `AXUIElement`; `raw` is a valid local out-param slot matching
+    // `AXUIElementCopyAttributeValue`'s documented signature. No other preconditions.
+    let err = unsafe { el.copy_attribute_value(&attr, NonNull::from(&mut raw)) };
+    if err != AXError::Success {
+        return Err(ax_backend_err(attr_name, err));
+    }
+    let nn = NonNull::new(raw.cast_mut())
+        .ok_or_else(|| GlassError::Backend(format!("{attr_name}: AX reported success but returned a null value")))?;
+    // SAFETY: `AXUIElementCopyAttributeValue` follows Core Foundation's Copy/Create
+    // ownership rule — an already-retained (+1) `CFTypeRef` on success — so
+    // `CFRetained::from_raw` takes ownership without an extra retain (see the module doc).
+    Ok(unsafe { CFRetained::from_raw(nn) })
+}
+
+/// `AXValueCreate(value_type, value)` + `AXUIElementSetAttributeValue(el, attr_name, ...)`
+/// — the shared body of [`ax_set_position`]/[`ax_set_size`].
+fn set_axvalue<T>(el: &AXUIElement, attr_name: &str, value_type: AXValueType, value: &mut T) -> Result<()> {
+    // SAFETY: `AXValueCreate` copies the bytes pointed to by `value` internally (the
+    // pointer only needs to be valid for the duration of this call); `T`'s layout matches
+    // `value_type` for every caller of this private helper (`ax_set_position`/
+    // `ax_set_size` always pair `CGPoint`/`AXValueType::CGPoint` and
+    // `CGSize`/`AXValueType::CGSize`).
+    let ax_value = unsafe { AXValue::new(value_type, NonNull::from(value).cast()) }
+        .ok_or_else(|| GlassError::Backend(format!("AXValueCreate({attr_name}) failed")))?;
+    let attr = CFString::from_str(attr_name);
+    // SAFETY: `el` is live; `ax_value` derefs to `&CFType` (see the module doc); matches
+    // `AXUIElementSetAttributeValue`'s documented contract.
+    let err = unsafe { el.set_attribute_value(&attr, &ax_value) };
+    if err != AXError::Success {
+        return Err(ax_backend_err(attr_name, err));
+    }
+    Ok(())
+}
+
+/// Build a [`GlassError::Backend`] naming both the failing AX attribute/action and the raw
+/// `AXError` code, so a diagnostic doesn't collapse every AX failure into one opaque
+/// message.
+fn ax_backend_err(context: &str, err: AXError) -> GlassError {
+    GlassError::Backend(format!("{context}: AX call failed (AXError {})", err.0))
+}
+
+/// The geometry-match fallback for [`ax_window_for_cgwindowid`]: find the `AXUIElement` in
+/// `windows` whose pixel geometry (position/size converted via `scale`, same conversion
+/// `coords::point_to_global_pixel` performs for window ops) is closest to `target_px`,
+/// among those within [`FALLBACK_TOLERANCE_PX`] on every field. `None` if no candidate is
+/// within tolerance (including if reading any candidate's geometry itself fails — a window
+/// this fallback can't measure is not a usable match).
+fn geometry_fallback(
+    windows: &CFArray<AXUIElement>,
+    target_px: &WindowGeometry,
+    scale: f64,
+) -> Option<CFRetained<AXUIElement>> {
+    let mut best: Option<(i64, CFRetained<AXUIElement>)> = None;
+    for w in windows.iter() {
+        let Ok(geom) = ax_geometry_px(&w, scale) else { continue };
+        if !within_tolerance(&geom, target_px) {
+            continue;
+        }
+        let score = geometry_distance(&geom, target_px);
+        let better = match &best {
+            Some((best_score, _)) => score < *best_score,
+            None => true,
+        };
+        if better {
+            best = Some((score, w));
+        }
+    }
+    best.map(|(_, w)| w)
+}
+
+/// Read `el`'s position/size (points) and convert to pixel `WindowGeometry` via `scale` —
+/// the same `point_to_global_pixel` conversion `coords.rs` documents for window ops.
+fn ax_geometry_px(el: &AXUIElement, scale: f64) -> Result<WindowGeometry> {
+    let (x, y) = point_to_global_pixel(ax_position(el)?, scale);
+    let (w, h) = point_to_global_pixel(ax_size(el)?, scale);
+    Ok(WindowGeometry { x, y, width: w.max(0) as u32, height: h.max(0) as u32 })
+}
+
+/// True if every field of `a`/`b` is within [`FALLBACK_TOLERANCE_PX`] of the other.
+fn within_tolerance(a: &WindowGeometry, b: &WindowGeometry) -> bool {
+    (a.x - b.x).abs() <= FALLBACK_TOLERANCE_PX
+        && (a.y - b.y).abs() <= FALLBACK_TOLERANCE_PX
+        && (a.width as i32 - b.width as i32).abs() <= FALLBACK_TOLERANCE_PX
+        && (a.height as i32 - b.height as i32).abs() <= FALLBACK_TOLERANCE_PX
+}
+
+/// Sum of per-field absolute pixel differences between `a`/`b` — used only to rank
+/// candidates that already passed [`within_tolerance`], smallest-first.
+fn geometry_distance(a: &WindowGeometry, b: &WindowGeometry) -> i64 {
+    i64::from((a.x - b.x).abs())
+        + i64::from((a.y - b.y).abs())
+        + i64::from((a.width as i32 - b.width as i32).abs())
+        + i64::from((a.height as i32 - b.height as i32).abs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn geom(x: i32, y: i32, width: u32, height: u32) -> WindowGeometry {
+        WindowGeometry { x, y, width, height }
+    }
+
+    #[test]
+    fn within_tolerance_accepts_exact_and_small_diffs_rejects_large() {
+        let target = geom(100, 200, 640, 480);
+        assert!(within_tolerance(&target, &target));
+        assert!(within_tolerance(&geom(104, 196, 636, 484), &target));
+        assert!(!within_tolerance(&geom(120, 200, 640, 480), &target));
+        assert!(!within_tolerance(&geom(100, 200, 700, 480), &target));
+    }
+
+    #[test]
+    fn geometry_distance_sums_per_field_abs_diffs() {
+        let a = geom(100, 200, 640, 480);
+        let b = geom(103, 197, 645, 475);
+        // |100-103| + |200-197| + |640-645| + |480-475| = 3+3+5+5 = 16
+        assert_eq!(geometry_distance(&a, &b), 16);
+        assert_eq!(geometry_distance(&a, &a), 0);
+    }
+
+    #[test]
+    fn geometry_fallback_picks_the_closest_candidate() {
+        // Two windows within tolerance of the target — the closer one must win, not the
+        // first one enumerated. Exercised directly against `within_tolerance`/
+        // `geometry_distance` rather than `geometry_fallback` itself, which needs a live
+        // `CFArray<AXUIElement>` only obtainable on a granted macOS run (Task 6).
+        let target = geom(100, 200, 640, 480);
+        let near = geom(102, 199, 641, 481);
+        let far = geom(106, 194, 645, 475);
+        assert!(within_tolerance(&near, &target) && within_tolerance(&far, &target));
+        assert!(geometry_distance(&near, &target) < geometry_distance(&far, &target));
+    }
+}

--- a/crates/glass-macos/src/axwindow.rs
+++ b/crates/glass-macos/src/axwindow.rs
@@ -44,14 +44,10 @@
 //! unused-here) `accessibility-sys` crate hardcodes for the same reason, and the values
 //! Apple documents as stable strings, not just opaque symbol names.
 //!
-//! Every fn here is `pub(crate)` per Plan 4 Task 3's interface list, but Task 4
-//! (`window(op)`) and Task 5 (`select_window`) are what wire them into `backend.rs`; until
-//! then nothing in this crate calls the entry points, hence the module-wide
-//! `#![allow(dead_code)]` below (mirrors `process.rs`'s per-fn `#[allow(dead_code)]` on
-//! `spawn`/`terminate` from Plan 2, applied once for the whole file here since virtually
-//! everything in it is only reachable from those still-unwired entry points).
-
-#![allow(dead_code)]
+//! Every fn here is `pub(crate)` per Plan 4 Task 3's interface list; `backend.rs`'s
+//! `MacosPlatform::window` (Task 4) is what wires them in, calling
+//! [`ax_window_for_cgwindowid`] plus every getter/setter/action below. Task 5
+//! (`select_window`) reuses the same entry points rather than adding new ones.
 
 use std::ptr::NonNull;
 

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -6,6 +6,8 @@ use std::process::Child;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use objc2_application_services::AXUIElement;
+
 use glass_core::frame::{Frame, Region};
 use glass_core::logbuf::Stream;
 use glass_core::platform::{
@@ -13,6 +15,7 @@ use glass_core::platform::{
 };
 use glass_core::{GlassError, Result};
 
+use crate::axwindow;
 use crate::coords;
 use crate::permissions;
 use crate::process::{self, LogSink};
@@ -31,6 +34,14 @@ const DISCOVERY_POLL_INTERVAL: Duration = Duration::from_millis(100);
 /// existed as of the last successful call, so this only needs to cover the ordinary
 /// query-round-trip latency, not a real "is the app even launching" wait.
 const WINDOW_RESOLVE_TIMEOUT: Duration = Duration::from_millis(2000);
+
+/// Read-back tolerance (pixels) [`MacosPlatform::window`]'s mutating ops use to decide
+/// whether a `Move`/`Resize` actually took: `Move`'s final vs. requested position, and
+/// `Resize`'s did-anything-happen-at-all check (see [`resize_was_refused`]'s doc — a
+/// legitimate min/max-size clamp is not a refusal). `8`px mirrors `axwindow.rs`'s own
+/// `FALLBACK_TOLERANCE_PX` — generous enough to absorb point<->pixel rounding across a
+/// position/size round trip without masking a real refusal.
+const WINDOW_OP_TOLERANCE_PX: i32 = 8;
 
 /// macOS backend. v1 renders the target app onto a `CGVirtualDisplay` (Plan 2) and
 /// drives it with ScreenCaptureKit + CGEvent + AXUIElement.
@@ -185,6 +196,44 @@ fn window_info_from(w: crate::scwindow::AppWindow, active_window: Option<u32>) -
     }
 }
 
+/// Read `el`'s current `AXPosition`/`AXSize` (points) and convert to the pixel
+/// `WindowGeometry` [`MacosPlatform::window`] returns for every op — the shared read-back
+/// step after `Focus`/`Move`/`Resize`'s mutation, and the sole step for `Geometry`. Reuses
+/// `coords::pixel_geometry_from_content_rect`'s point->pixel scaling rather than
+/// reimplementing it: an AX position+size pair is exactly that function's `x`/`y`/`width`/
+/// `height` args (see `coords.rs`'s module doc), so this crate keeps one scaling
+/// implementation, not two.
+fn read_ax_geometry(el: &AXUIElement, scale: f64) -> Result<WindowGeometry> {
+    let (x, y) = axwindow::ax_position(el)?;
+    let (width, height) = axwindow::ax_size(el)?;
+    Ok(coords::pixel_geometry_from_content_rect(x, y, width, height, scale))
+}
+
+/// True if `geom`'s position is within [`WINDOW_OP_TOLERANCE_PX`] of a `Move { x, y }`
+/// target — the signal `window(op)`'s `Move` branch uses to catch a macOS window that
+/// silently ignores `AXPosition` (the no-silent-no-op contract `window(op)`'s doc
+/// describes). Pure so it's unit-testable without a live `AXUIElement`.
+fn move_took_effect(geom: &WindowGeometry, x: i32, y: i32) -> bool {
+    (geom.x - x).abs() <= WINDOW_OP_TOLERANCE_PX && (geom.y - y).abs() <= WINDOW_OP_TOLERANCE_PX
+}
+
+/// True if a `Resize { width, height }` had no visible effect at all: `after` is (within
+/// tolerance) the same size as `before`, even though `width`/`height` was a genuinely
+/// different size than `before`'s own. This is deliberately narrower than "does `after`
+/// exactly match the request": macOS may legitimately clamp to an intermediate size (a
+/// window's min/max content-size constraint), which is expected behavior, not a bug — the
+/// resulting `after` geometry is still returned to the caller in that case (see
+/// `window(op)`'s `Resize` doc). Only a total no-op (the size never moved, despite a real
+/// change being requested) is treated as the "macOS refused the resize" failure. Pure so
+/// it's unit-testable without a live `AXUIElement`.
+fn resize_was_refused(before: &WindowGeometry, after: &WindowGeometry, width: u32, height: u32) -> bool {
+    let requested_a_change = (width as i32 - before.width as i32).abs() > WINDOW_OP_TOLERANCE_PX
+        || (height as i32 - before.height as i32).abs() > WINDOW_OP_TOLERANCE_PX;
+    let nothing_moved = (after.width as i32 - before.width as i32).abs() <= WINDOW_OP_TOLERANCE_PX
+        && (after.height as i32 - before.height as i32).abs() <= WINDOW_OP_TOLERANCE_PX;
+    requested_a_change && nothing_moved
+}
+
 impl Platform for MacosPlatform {
     /// Run the optional build step, spawn the app, then confirm a window appears for its
     /// pid within `spec.timeout_ms` via ScreenCaptureKit's `SCShareableContent`
@@ -303,8 +352,73 @@ impl Platform for MacosPlatform {
         let m = self.resolve_active_window(pid as i32)?;
         crate::input::send_key(event, m.pid)
     }
-    fn window(&mut self, _op: &WindowOp) -> Result<WindowGeometry> {
-        unimplemented!("Plan 4: AXUIElement window ops")
+    /// Resolve the active window's `AXUIElement` (fresh every call, same rationale as
+    /// `resolve_active_window`: the window may have moved/resized/closed since the last
+    /// call) and dispatch `op` onto it:
+    ///
+    /// - `Focus` activates the owning app (`input::focus`, the same
+    ///   `NSRunningApplication::activate` call `send_pointer`/`send_key` already make),
+    ///   then `AXRaise`s and marks the window `AXMain` — CGEvents alone can't target a
+    ///   specific window (see `send_key`'s doc), this is what actually does.
+    /// - `Move { x, y }` converts the target from global-screen PIXELS to Quartz POINTS
+    ///   (`coords::global_pixel_to_point`) and sets `AXPosition`.
+    /// - `Resize { width, height }` sets `AXSize`, then re-sets `AXPosition` to its
+    ///   just-read current value, then sets `AXSize` again — the proven
+    ///   `window_ops.swift` workaround for a window that won't grow past its current
+    ///   on-screen bounds via a single `AXSize` set alone.
+    /// - `Geometry` performs no mutation.
+    ///
+    /// Every branch reads back the window's position/size afterward
+    /// ([`read_ax_geometry`]) and returns it in pixels — the tool boundary's unit. `Move`/
+    /// `Resize` additionally check the read-back actually reflects the request
+    /// ([`move_took_effect`]/[`resize_was_refused`]), returning `GlassError::Backend`
+    /// naming what didn't take rather than silently reporting success on a macOS window
+    /// that refused the change; `Focus`/`Geometry` have no such check since they assert
+    /// nothing about position/size.
+    fn window(&mut self, op: &WindowOp) -> Result<WindowGeometry> {
+        permissions::preflight()?;
+        let id = self.active_window.ok_or(GlassError::NoActiveSession)?;
+        let pid = self.app_pid.ok_or(GlassError::NoActiveSession)?;
+
+        let m = crate::scwindow::find_window_by_id(id, WINDOW_RESOLVE_TIMEOUT)?;
+        let el = axwindow::ax_window_for_cgwindowid(pid as i32, id, m.geometry.clone(), m.scale)?;
+
+        match *op {
+            WindowOp::Focus => {
+                crate::input::focus(pid as i32);
+                axwindow::ax_raise(&el)?;
+                axwindow::ax_set_main(&el)?;
+                read_ax_geometry(&el, m.scale)
+            }
+            WindowOp::Move { x, y } => {
+                let target_pt = coords::global_pixel_to_point((x, y), m.scale);
+                axwindow::ax_set_position(&el, target_pt)?;
+                let geom = read_ax_geometry(&el, m.scale)?;
+                if !move_took_effect(&geom, x, y) {
+                    return Err(GlassError::Backend(format!(
+                        "window move to ({x},{y}) px did not take; window is at ({},{})",
+                        geom.x, geom.y
+                    )));
+                }
+                Ok(geom)
+            }
+            WindowOp::Resize { width, height } => {
+                let target_size_pt = (width as f64 / m.scale, height as f64 / m.scale);
+                axwindow::ax_set_size(&el, target_size_pt)?;
+                let pos = axwindow::ax_position(&el)?;
+                axwindow::ax_set_position(&el, pos)?;
+                axwindow::ax_set_size(&el, target_size_pt)?;
+                let geom = read_ax_geometry(&el, m.scale)?;
+                if resize_was_refused(&m.geometry, &geom, width, height) {
+                    return Err(GlassError::Backend(format!(
+                        "window resize to {width}x{height} px was refused; window remains {}x{}",
+                        geom.width, geom.height
+                    )));
+                }
+                Ok(geom)
+            }
+            WindowOp::Geometry => read_ax_geometry(&el, m.scale),
+        }
     }
     /// Enumerate every on-screen window owned by the launched app's pid via
     /// `scwindow::list_app_windows` (one `SCShareableContent` query, all matches — not just
@@ -474,5 +588,57 @@ mod tests {
         assert!(!info.active);
         assert_eq!(info.title, None);
         assert_eq!(info.class, None);
+    }
+
+    #[test]
+    fn move_took_effect_accepts_exact_and_within_tolerance() {
+        let geom = WindowGeometry { x: 100, y: 200, width: 640, height: 480 };
+        assert!(move_took_effect(&geom, 100, 200), "exact match");
+        assert!(move_took_effect(&geom, 104, 196), "within tolerance");
+        assert!(move_took_effect(&geom, 92, 208), "within tolerance, other direction");
+    }
+
+    #[test]
+    fn move_took_effect_rejects_a_window_that_did_not_move() {
+        // The refusal case: AXSetAttributeValue(AXPosition) reported success but the
+        // window is still sitting wherever it started.
+        let geom = WindowGeometry { x: 100, y: 200, width: 640, height: 480 };
+        assert!(!move_took_effect(&geom, 500, 200), "x off by more than tolerance");
+        assert!(!move_took_effect(&geom, 100, 600), "y off by more than tolerance");
+    }
+
+    #[test]
+    fn resize_was_refused_when_size_never_moves() {
+        let before = WindowGeometry { x: 0, y: 0, width: 640, height: 480 };
+        let after = WindowGeometry { x: 0, y: 0, width: 640, height: 480 };
+        // Requested a real size change (800x600) but the window is still exactly where it
+        // started — the silent-no-op case `window(op)`'s Resize branch must catch.
+        assert!(resize_was_refused(&before, &after, 800, 600));
+    }
+
+    #[test]
+    fn resize_was_refused_is_false_when_nothing_was_requested() {
+        // width/height happen to equal `before`'s own size (e.g. a Resize to the current
+        // size) — no change was requested, so an unchanged `after` is not a refusal.
+        let before = WindowGeometry { x: 0, y: 0, width: 640, height: 480 };
+        let after = WindowGeometry { x: 0, y: 0, width: 640, height: 480 };
+        assert!(!resize_was_refused(&before, &after, 640, 480));
+    }
+
+    #[test]
+    fn resize_was_refused_is_false_on_a_legitimate_clamp() {
+        // macOS clamped to an intermediate size short of the request (e.g. a min-size
+        // constraint) rather than ignoring the resize outright — expected behavior, not a
+        // refusal; `window(op)` returns this actual geometry rather than erroring.
+        let before = WindowGeometry { x: 0, y: 0, width: 640, height: 480 };
+        let after = WindowGeometry { x: 0, y: 0, width: 700, height: 480 };
+        assert!(!resize_was_refused(&before, &after, 1200, 480));
+    }
+
+    #[test]
+    fn resize_was_refused_is_false_when_the_read_back_matches_the_request() {
+        let before = WindowGeometry { x: 0, y: 0, width: 640, height: 480 };
+        let after = WindowGeometry { x: 0, y: 0, width: 800, height: 600 };
+        assert!(!resize_was_refused(&before, &after, 800, 600));
     }
 }

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -36,12 +36,30 @@ const DISCOVERY_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const WINDOW_RESOLVE_TIMEOUT: Duration = Duration::from_millis(2000);
 
 /// Read-back tolerance (pixels) [`MacosPlatform::window`]'s mutating ops use to decide
-/// whether a `Move`/`Resize` actually took: `Move`'s final vs. requested position, and
-/// `Resize`'s did-anything-happen-at-all check (see [`resize_was_refused`]'s doc — a
-/// legitimate min/max-size clamp is not a refusal). `8`px mirrors `axwindow.rs`'s own
-/// `FALLBACK_TOLERANCE_PX` — generous enough to absorb point<->pixel rounding across a
-/// position/size round trip without masking a real refusal.
+/// whether a `Move`/`Resize`'s read-back position/size actually matches what was requested
+/// (see [`move_took_effect`]/[`resize_was_refused`]'s docs — a legitimate min/max-size clamp
+/// is not a refusal). `8`px mirrors `axwindow.rs`'s own `FALLBACK_TOLERANCE_PX` — generous
+/// enough to absorb point<->pixel rounding across a position/size round trip without masking
+/// a real refusal.
+///
+/// This is deliberately a *separate* constant from [`REQUEST_EPSILON_PX`] (final-review fix
+/// 3): using this same 8px value to also decide "was a change requested at all" let a
+/// fully-refused Move/Resize whose target happened to be within 8px of the window's starting
+/// position report success — the read-back (unchanged, since it was refused) was
+/// coincidentally within 8px of a target that was itself only a few pixels away. Splitting
+/// "was a change requested" (tight, `REQUEST_EPSILON_PX`) from "does the read-back match"
+/// (loose, this constant) closes that hole.
 const WINDOW_OP_TOLERANCE_PX: i32 = 8;
+
+/// Threshold (pixels) [`move_took_effect`]/[`resize_was_refused`] use to decide whether a
+/// `Move`/`Resize` request asked for a genuinely different position/size than the window
+/// already had — as opposed to [`WINDOW_OP_TOLERANCE_PX`], which judges whether the
+/// *read-back* matches the *request*. Kept tight (well under `WINDOW_OP_TOLERANCE_PX`) so a
+/// real (if small) requested change that's totally refused — the read-back stays at the
+/// window's original position/size — is still caught as a refusal rather than waved through
+/// because the unmoved position happens to already sit within `WINDOW_OP_TOLERANCE_PX` of
+/// the target. See both functions' docs for the exact logic.
+const REQUEST_EPSILON_PX: i32 = 2;
 
 /// macOS backend. v1 renders the target app onto a `CGVirtualDisplay` (Plan 2) and
 /// drives it with ScreenCaptureKit + CGEvent + AXUIElement.
@@ -137,15 +155,22 @@ impl MacosPlatform {
     }
 
     /// Resolve the window `capture_frame`/`send_pointer`/`send_key` should target *this*
-    /// call: `scwindow::find_window_by_id(active_window, ..)` once `select_window` (or
-    /// `start_app`'s initial discovery) has set an active `CGWindowID` — the retargeting the
-    /// `Platform` contract requires (see the `active_window` field's doc) — falling back to
-    /// the pre-Plan-4 "first on-screen window for this pid" lookup when nothing is selected
-    /// yet. Always fresh (never cached): mirrors `find_window_for_pids`'s own per-call
-    /// re-resolution, since the window may have moved/resized/closed since the last call.
+    /// call: `scwindow::find_window_by_id(active_window, [pid], ..)` once `select_window`
+    /// (or `start_app`'s initial discovery) has set an active `CGWindowID` — the retargeting
+    /// the `Platform` contract requires (see the `active_window` field's doc) — falling back
+    /// to the pre-Plan-4 "first on-screen window for this pid" lookup when nothing is
+    /// selected yet. Always fresh (never cached): mirrors `find_window_for_pids`'s own
+    /// per-call re-resolution, since the window may have moved/resized/closed since the last
+    /// call.
+    ///
+    /// Passes `&[pid]` to `find_window_by_id` (final-review fix 1): `active_window` is only
+    /// ever set to an id this backend itself resolved for `pid`, but scoping the lookup here
+    /// too means a stale/foreign id can never silently resolve to another app's window — it
+    /// surfaces `GlassError::WindowNotFound` instead, exactly like every other resolution
+    /// path in this module.
     fn resolve_active_window(&self, pid: i32) -> Result<crate::scwindow::WindowMatch> {
         match self.active_window {
-            Some(id) => crate::scwindow::find_window_by_id(id, WINDOW_RESOLVE_TIMEOUT),
+            Some(id) => crate::scwindow::find_window_by_id(id, &[pid], WINDOW_RESOLVE_TIMEOUT),
             None => crate::scwindow::find_window_for_pids(&[pid], WINDOW_RESOLVE_TIMEOUT),
         }
     }
@@ -209,28 +234,47 @@ fn read_ax_geometry(el: &AXUIElement, scale: f64) -> Result<WindowGeometry> {
     Ok(coords::pixel_geometry_from_content_rect(x, y, width, height, scale))
 }
 
-/// True if `geom`'s position is within [`WINDOW_OP_TOLERANCE_PX`] of a `Move { x, y }`
-/// target — the signal `window(op)`'s `Move` branch uses to catch a macOS window that
-/// silently ignores `AXPosition` (the no-silent-no-op contract `window(op)`'s doc
-/// describes). Pure so it's unit-testable without a live `AXUIElement`.
-fn move_took_effect(geom: &WindowGeometry, x: i32, y: i32) -> bool {
-    (geom.x - x).abs() <= WINDOW_OP_TOLERANCE_PX && (geom.y - y).abs() <= WINDOW_OP_TOLERANCE_PX
+/// True if a `Move { x, y }` request succeeded: either `x`/`y` was already (within
+/// [`REQUEST_EPSILON_PX`]) `before`'s own position — no real change was requested, so
+/// whatever `after` reads back as is fine — or `after` is within [`WINDOW_OP_TOLERANCE_PX`]
+/// of the target AND the window actually moved away from `before` (not just coincidentally
+/// unmoved-but-within-tolerance-of-a-nearby-target — see [`WINDOW_OP_TOLERANCE_PX`]/
+/// [`REQUEST_EPSILON_PX`]'s docs for why both checks are needed). The signal `window(op)`'s
+/// `Move` branch uses to catch a macOS window that silently ignores `AXPosition` (the
+/// no-silent-no-op contract `window(op)`'s doc describes). Computed in `i64` before `.abs()`
+/// so no cast can wrap for any input (matches `coords.rs`'s house rule). Pure so it's
+/// unit-testable without a live `AXUIElement`.
+fn move_took_effect(before: &WindowGeometry, after: &WindowGeometry, x: i32, y: i32) -> bool {
+    let requested_a_change = (i64::from(x) - i64::from(before.x)).abs() > i64::from(REQUEST_EPSILON_PX)
+        || (i64::from(y) - i64::from(before.y)).abs() > i64::from(REQUEST_EPSILON_PX);
+    if !requested_a_change {
+        return true;
+    }
+    let reached_target = (i64::from(after.x) - i64::from(x)).abs() <= i64::from(WINDOW_OP_TOLERANCE_PX)
+        && (i64::from(after.y) - i64::from(y)).abs() <= i64::from(WINDOW_OP_TOLERANCE_PX);
+    let stayed_put = (i64::from(after.x) - i64::from(before.x)).abs() <= i64::from(REQUEST_EPSILON_PX)
+        && (i64::from(after.y) - i64::from(before.y)).abs() <= i64::from(REQUEST_EPSILON_PX);
+    reached_target && !stayed_put
 }
 
 /// True if a `Resize { width, height }` had no visible effect at all: `after` is (within
-/// tolerance) the same size as `before`, even though `width`/`height` was a genuinely
-/// different size than `before`'s own. This is deliberately narrower than "does `after`
-/// exactly match the request": macOS may legitimately clamp to an intermediate size (a
-/// window's min/max content-size constraint), which is expected behavior, not a bug — the
-/// resulting `after` geometry is still returned to the caller in that case (see
-/// `window(op)`'s `Resize` doc). Only a total no-op (the size never moved, despite a real
-/// change being requested) is treated as the "macOS refused the resize" failure. Pure so
-/// it's unit-testable without a live `AXUIElement`.
+/// [`WINDOW_OP_TOLERANCE_PX`]) the same size as `before`, even though `width`/`height` asked
+/// for a genuinely different size than `before`'s own (more than [`REQUEST_EPSILON_PX`]
+/// different — see that constant's doc for why this must be tighter than
+/// `WINDOW_OP_TOLERANCE_PX`, otherwise a small-but-real requested resize that's totally
+/// refused would not even count as "a change was requested"). This is deliberately narrower
+/// than "does `after` exactly match the request": macOS may legitimately clamp to an
+/// intermediate size (a window's min/max content-size constraint), which is expected
+/// behavior, not a bug — the resulting `after` geometry is still returned to the caller in
+/// that case (see `window(op)`'s `Resize` doc). Only a total no-op (the size never moved,
+/// despite a real change being requested) is treated as the "macOS refused the resize"
+/// failure. Computed in `i64` before `.abs()` so no cast can wrap for any input (matches
+/// `coords.rs`'s house rule). Pure so it's unit-testable without a live `AXUIElement`.
 fn resize_was_refused(before: &WindowGeometry, after: &WindowGeometry, width: u32, height: u32) -> bool {
-    let requested_a_change = (width as i32 - before.width as i32).abs() > WINDOW_OP_TOLERANCE_PX
-        || (height as i32 - before.height as i32).abs() > WINDOW_OP_TOLERANCE_PX;
-    let nothing_moved = (after.width as i32 - before.width as i32).abs() <= WINDOW_OP_TOLERANCE_PX
-        && (after.height as i32 - before.height as i32).abs() <= WINDOW_OP_TOLERANCE_PX;
+    let requested_a_change = (i64::from(width) - i64::from(before.width)).abs() > i64::from(REQUEST_EPSILON_PX)
+        || (i64::from(height) - i64::from(before.height)).abs() > i64::from(REQUEST_EPSILON_PX);
+    let nothing_moved = (i64::from(after.width) - i64::from(before.width)).abs() <= i64::from(WINDOW_OP_TOLERANCE_PX)
+        && (i64::from(after.height) - i64::from(before.height)).abs() <= i64::from(WINDOW_OP_TOLERANCE_PX);
     requested_a_change && nothing_moved
 }
 
@@ -291,14 +335,16 @@ impl Platform for MacosPlatform {
     /// calls).
     ///
     /// NOTE: targets `active_window` when set (`capture::capture_window_by_id`, exact
-    /// `CGWindowID` match) — the retargeting `select_window` (a later task) drives, per the
-    /// `Platform` contract's "implicit target of capture/input" — else falls back to the
-    /// pre-Plan-4 first-on-screen-window-for-this-pid path (`capture::capture_window`).
-    /// `resolve_active_window`'s doc covers the shared decision; capture takes its own
-    /// `capture_window`/`capture_window_by_id` branch (rather than calling
-    /// `resolve_active_window` itself) because capture needs the live `SCWindow` inside a
-    /// single completion-handler callback to build its `SCContentFilter`, not just the
-    /// `WindowMatch` snapshot `resolve_active_window` returns.
+    /// `CGWindowID` match scoped to `&[pid]` — final-review fix 1, same rationale as
+    /// `resolve_active_window`'s doc) — the retargeting `select_window` (a later task)
+    /// drives, per the `Platform` contract's "implicit target of capture/input" — else falls
+    /// back to the pre-Plan-4 first-on-screen-window-for-this-pid path
+    /// (`capture::capture_window`). `resolve_active_window`'s doc covers the shared
+    /// decision; capture takes its own `capture_window`/`capture_window_by_id` branch
+    /// (rather than calling `resolve_active_window` itself) because capture needs the live
+    /// `SCWindow` inside a single completion-handler callback to build its
+    /// `SCContentFilter`, not just the `WindowMatch` snapshot `resolve_active_window`
+    /// returns.
     ///
     /// **Main-thread affinity:** like `start_app`, this reaches `ffi::app_kit_init()`
     /// (via `capture::capture_window`/`capture_window_by_id`) and must run on the true main
@@ -307,7 +353,7 @@ impl Platform for MacosPlatform {
         permissions::preflight()?;
         let pid = self.app_pid.ok_or(GlassError::NoActiveSession)?;
         match self.active_window {
-            Some(id) => crate::capture::capture_window_by_id(id, region),
+            Some(id) => crate::capture::capture_window_by_id(id, &[pid as i32], region),
             None => crate::capture::capture_window(&[pid as i32], region),
         }
     }
@@ -359,13 +405,15 @@ impl Platform for MacosPlatform {
     /// - `Focus` activates the owning app (`input::focus`, the same
     ///   `NSRunningApplication::activate` call `send_pointer`/`send_key` already make),
     ///   then `AXRaise`s and marks the window `AXMain` — CGEvents alone can't target a
-    ///   specific window (see `send_key`'s doc), this is what actually does.
+    ///   specific window (see `send_key`'s doc), this is what actually does. Propagates
+    ///   `input::focus`'s error (final-review fix 4) if the owning app is no longer running
+    ///   rather than silently raising/main-ing an `AXUIElement` for a process that's gone.
     /// - `Move { x, y }` converts the target from global-screen PIXELS to Quartz POINTS
     ///   (`coords::global_pixel_to_point`) and sets `AXPosition`.
     /// - `Resize { width, height }` sets `AXSize`, then re-sets `AXPosition` to its
-    ///   just-read current value, then sets `AXSize` again — the proven
-    ///   `window_ops.swift` workaround for a window that won't grow past its current
-    ///   on-screen bounds via a single `AXSize` set alone.
+    ///   just-read current value, then sets `AXSize` again — the brief-specified workaround
+    ///   (verified by the Task 6 window integration test) for a window that won't grow past
+    ///   its current on-screen bounds via a single `AXSize` set alone.
     /// - `Geometry` performs no mutation.
     ///
     /// Every branch reads back the window's position/size afterward
@@ -380,12 +428,15 @@ impl Platform for MacosPlatform {
         let id = self.active_window.ok_or(GlassError::NoActiveSession)?;
         let pid = self.app_pid.ok_or(GlassError::NoActiveSession)?;
 
-        let m = crate::scwindow::find_window_by_id(id, WINDOW_RESOLVE_TIMEOUT)?;
+        // `&[pid as i32]`-scoped (final-review fix 1): `id` came from this backend's own
+        // `active_window`, but scoping the lookup here too means a stale/foreign id can
+        // never resolve to another app's window.
+        let m = crate::scwindow::find_window_by_id(id, &[pid as i32], WINDOW_RESOLVE_TIMEOUT)?;
         let el = axwindow::ax_window_for_cgwindowid(pid as i32, id, m.geometry.clone(), m.scale)?;
 
         match *op {
             WindowOp::Focus => {
-                crate::input::focus(pid as i32);
+                crate::input::focus(pid as i32)?;
                 axwindow::ax_raise(&el)?;
                 axwindow::ax_set_main(&el)?;
                 read_ax_geometry(&el, m.scale)
@@ -394,7 +445,7 @@ impl Platform for MacosPlatform {
                 let target_pt = coords::global_pixel_to_point((x, y), m.scale);
                 axwindow::ax_set_position(&el, target_pt)?;
                 let geom = read_ax_geometry(&el, m.scale)?;
-                if !move_took_effect(&geom, x, y) {
+                if !move_took_effect(&m.geometry, &geom, x, y) {
                     return Err(GlassError::Backend(format!(
                         "window move to ({x},{y}) px did not take; window is at ({},{})",
                         geom.x, geom.y
@@ -437,32 +488,41 @@ impl Platform for MacosPlatform {
     /// active window, the implicit target of capture/input/window ops" (see
     /// `glass_core::platform`'s doc on this method).
     ///
-    /// First confirms `id` is currently on-screen via `scwindow::find_window_by_id`,
-    /// which already maps a lookup that never turns up `id` before
-    /// `WINDOW_RESOLVE_TIMEOUT` elapses to `GlassError::WindowNotFound` (see that
-    /// function's own doc) — exactly this method's "not currently one of the app's
-    /// windows" contract, so no extra `Timeout` -> `WindowNotFound` mapping is needed
-    /// here. Only after that check succeeds does `active_window` actually change — a
-    /// failed `select_window` must leave the previous target in place, not (say) clear
-    /// it.
+    /// First confirms `id` is currently on-screen AND owned by `self.app_pid` via
+    /// `scwindow::find_window_by_id(id, &[app_pid], ..)` (final-review fix 1 — pid-scoped,
+    /// unlike the pre-fix version which matched any on-screen `CGWindowID` system-wide),
+    /// which already maps a lookup that never turns up `id` before `WINDOW_RESOLVE_TIMEOUT`
+    /// elapses to `GlassError::WindowNotFound` (see that function's own doc) — exactly this
+    /// method's "not currently one of the app's windows" contract, so no extra `Timeout` ->
+    /// `WindowNotFound` mapping is needed here. Only after that check succeeds does
+    /// `active_window` actually change — a failed `select_window` must leave the previous
+    /// target in place, not (say) clear it.
     ///
     /// Then raises and focuses the newly-selected window by delegating to
-    /// `self.window(&WindowOp::Focus)` rather than duplicating its AXUIElement logic:
-    /// that path re-resolves `id`'s `AXUIElement` scoped to `self.app_pid`
-    /// (`axwindow::ax_window_for_cgwindowid`), which doubles as a second, stronger
-    /// validation that `id` genuinely belongs to *this* app (`find_window_by_id` alone
-    /// matches any on-screen `CGWindowID`, not just ones owned by `app_pid`) — a window
-    /// belonging to some other running app would fail here with `WindowNotFound` even
-    /// though the first check passed. `window(Focus)`'s own read-back
-    /// ([`read_ax_geometry`]) supplies the pixel `WindowGeometry` this method returns,
-    /// so the window is queried fresh exactly once more (mirroring every other op's
-    /// no-caching discipline) rather than reusing the first lookup's now-slightly-stale
-    /// geometry.
+    /// `self.window(&WindowOp::Focus)` rather than duplicating its AXUIElement logic: that
+    /// path re-resolves `id`'s `AXUIElement` scoped to `self.app_pid`
+    /// (`axwindow::ax_window_for_cgwindowid`) too, via a completely independent lookup path
+    /// (`SCShareableContent` above vs. `AXUIElementCreateApplication` here) — belt-and-
+    /// suspenders with the pid-scoped check above, not a second layer this method actually
+    /// depends on. `window(Focus)`'s own read-back ([`read_ax_geometry`]) supplies the pixel
+    /// `WindowGeometry` this method returns, so the window is queried fresh exactly once
+    /// more (mirroring every other op's no-caching discipline) rather than reusing the first
+    /// lookup's now-slightly-stale geometry.
+    ///
+    /// If `self.window(&WindowOp::Focus)` fails after `active_window` has already been
+    /// retargeted — e.g. the window closed in the gap between the check above and the
+    /// `AXRaise`/`AXMain` calls — `active_window` is rolled back to its prior value
+    /// (final-review fix 2) rather than left pointing at a window this call never actually
+    /// confirmed glass can operate on. Belt-and-suspenders with the pid-scoped check above:
+    /// that check already rejects a foreign/stale `id` before any mutation, so this rollback
+    /// only matters for the narrower window-closed-mid-call race.
     fn select_window(&mut self, id: WindowId) -> Result<WindowGeometry> {
         permissions::preflight()?;
-        crate::scwindow::find_window_by_id(id.0 as u32, WINDOW_RESOLVE_TIMEOUT)?;
+        let pid = self.app_pid.ok_or(GlassError::NoActiveSession)?;
+        let previous = self.active_window;
+        crate::scwindow::find_window_by_id(id.0 as u32, &[pid as i32], WINDOW_RESOLVE_TIMEOUT)?;
         self.active_window = Some(id.0 as u32);
-        self.window(&WindowOp::Focus)
+        self.window(&WindowOp::Focus).inspect_err(|_| self.active_window = previous)
     }
     fn drain_logs(&mut self) -> Vec<(Stream, String)> {
         std::mem::take(&mut *self.logs.lock().expect("log buffer mutex"))
@@ -619,20 +679,44 @@ mod tests {
     }
 
     #[test]
-    fn move_took_effect_accepts_exact_and_within_tolerance() {
-        let geom = WindowGeometry { x: 100, y: 200, width: 640, height: 480 };
-        assert!(move_took_effect(&geom, 100, 200), "exact match");
-        assert!(move_took_effect(&geom, 104, 196), "within tolerance");
-        assert!(move_took_effect(&geom, 92, 208), "within tolerance, other direction");
+    fn move_took_effect_accepts_a_genuine_move_that_reached_target() {
+        let before = WindowGeometry { x: 100, y: 200, width: 640, height: 480 };
+        let after_exact = WindowGeometry { x: 300, y: 200, width: 640, height: 480 };
+        assert!(move_took_effect(&before, &after_exact, 300, 200), "exact match");
+        let after_tolerance = WindowGeometry { x: 304, y: 196, width: 640, height: 480 };
+        assert!(move_took_effect(&before, &after_tolerance, 300, 200), "within tolerance");
     }
 
     #[test]
-    fn move_took_effect_rejects_a_window_that_did_not_move() {
+    fn move_took_effect_rejects_when_read_back_is_far_from_target() {
         // The refusal case: AXSetAttributeValue(AXPosition) reported success but the
         // window is still sitting wherever it started.
-        let geom = WindowGeometry { x: 100, y: 200, width: 640, height: 480 };
-        assert!(!move_took_effect(&geom, 500, 200), "x off by more than tolerance");
-        assert!(!move_took_effect(&geom, 100, 600), "y off by more than tolerance");
+        let before = WindowGeometry { x: 100, y: 200, width: 640, height: 480 };
+        let unmoved = WindowGeometry { x: 100, y: 200, width: 640, height: 480 };
+        assert!(!move_took_effect(&before, &unmoved, 500, 200), "x off by more than tolerance");
+        assert!(!move_took_effect(&before, &unmoved, 100, 600), "y off by more than tolerance");
+    }
+
+    #[test]
+    fn move_took_effect_rejects_a_total_refusal_even_for_a_small_requested_delta() {
+        // Regression test for final-review fix 3: a small (but genuine, > REQUEST_EPSILON_PX)
+        // requested delta that's fully refused must not be reported as success just because
+        // the unmoved position happens to still land within WINDOW_OP_TOLERANCE_PX of the
+        // target — the exact bug this fix closes.
+        let before = WindowGeometry { x: 100, y: 200, width: 640, height: 480 };
+        let unmoved = WindowGeometry { x: 100, y: 200, width: 640, height: 480 };
+        // Requested delta is 5px (> REQUEST_EPSILON_PX's 2px) but <= WINDOW_OP_TOLERANCE_PX's
+        // 8px, so the old single-tolerance logic silently accepted this as success.
+        assert!(!move_took_effect(&before, &unmoved, 105, 200));
+    }
+
+    #[test]
+    fn move_took_effect_is_true_when_no_real_change_was_requested() {
+        // Target is within REQUEST_EPSILON_PX of `before` -- essentially a no-op move, so
+        // whatever `after` reads back as is not a refusal to report.
+        let before = WindowGeometry { x: 100, y: 200, width: 640, height: 480 };
+        let after = WindowGeometry { x: 100, y: 200, width: 640, height: 480 };
+        assert!(move_took_effect(&before, &after, 101, 201));
     }
 
     #[test]
@@ -668,5 +752,17 @@ mod tests {
         let before = WindowGeometry { x: 0, y: 0, width: 640, height: 480 };
         let after = WindowGeometry { x: 0, y: 0, width: 800, height: 600 };
         assert!(!resize_was_refused(&before, &after, 800, 600));
+    }
+
+    #[test]
+    fn resize_was_refused_catches_a_total_refusal_of_a_small_requested_delta() {
+        // Regression test for final-review fix 3: a small (> REQUEST_EPSILON_PX, but within
+        // the old WINDOW_OP_TOLERANCE_PX-based "was a change requested" threshold) resize
+        // request that's fully refused must now be caught. Before this fix, a 5px delta
+        // wasn't even considered "a change was requested" (5 <= the old 8px threshold), so a
+        // total no-op silently reported success.
+        let before = WindowGeometry { x: 0, y: 0, width: 640, height: 480 };
+        let after = WindowGeometry { x: 0, y: 0, width: 640, height: 480 }; // unmoved
+        assert!(resize_was_refused(&before, &after, 645, 480));
     }
 }

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -433,8 +433,36 @@ impl Platform for MacosPlatform {
         let windows = crate::scwindow::list_app_windows(&[pid as i32])?;
         Ok(windows.into_iter().map(|w| window_info_from(w, self.active_window)).collect())
     }
-    fn select_window(&mut self, _id: WindowId) -> Result<WindowGeometry> {
-        unimplemented!("Plan 4: raise + focus + activate")
+    /// Retarget `active_window` to `id` — the `Platform` contract's "make `id` the
+    /// active window, the implicit target of capture/input/window ops" (see
+    /// `glass_core::platform`'s doc on this method).
+    ///
+    /// First confirms `id` is currently on-screen via `scwindow::find_window_by_id`,
+    /// which already maps a lookup that never turns up `id` before
+    /// `WINDOW_RESOLVE_TIMEOUT` elapses to `GlassError::WindowNotFound` (see that
+    /// function's own doc) — exactly this method's "not currently one of the app's
+    /// windows" contract, so no extra `Timeout` -> `WindowNotFound` mapping is needed
+    /// here. Only after that check succeeds does `active_window` actually change — a
+    /// failed `select_window` must leave the previous target in place, not (say) clear
+    /// it.
+    ///
+    /// Then raises and focuses the newly-selected window by delegating to
+    /// `self.window(&WindowOp::Focus)` rather than duplicating its AXUIElement logic:
+    /// that path re-resolves `id`'s `AXUIElement` scoped to `self.app_pid`
+    /// (`axwindow::ax_window_for_cgwindowid`), which doubles as a second, stronger
+    /// validation that `id` genuinely belongs to *this* app (`find_window_by_id` alone
+    /// matches any on-screen `CGWindowID`, not just ones owned by `app_pid`) — a window
+    /// belonging to some other running app would fail here with `WindowNotFound` even
+    /// though the first check passed. `window(Focus)`'s own read-back
+    /// ([`read_ax_geometry`]) supplies the pixel `WindowGeometry` this method returns,
+    /// so the window is queried fresh exactly once more (mirroring every other op's
+    /// no-caching discipline) rather than reusing the first lookup's now-slightly-stale
+    /// geometry.
+    fn select_window(&mut self, id: WindowId) -> Result<WindowGeometry> {
+        permissions::preflight()?;
+        crate::scwindow::find_window_by_id(id.0 as u32, WINDOW_RESOLVE_TIMEOUT)?;
+        self.active_window = Some(id.0 as u32);
+        self.window(&WindowOp::Focus)
     }
     fn drain_logs(&mut self) -> Vec<(Stream, String)> {
         std::mem::take(&mut *self.logs.lock().expect("log buffer mutex"))

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -23,12 +23,14 @@ use crate::process::{self, LogSink};
 /// against `child.try_wait()`.
 const DISCOVERY_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
-/// Timeout for the fresh window re-resolution [`MacosPlatform::send_pointer`] does on every
-/// call via `scwindow::find_window_for_pids`. Short (unlike `start_app`'s `spec.timeout_ms`,
-/// which waits for a brand-new window to first appear): the window is already known to have
+/// Timeout for the fresh per-call window re-resolution [`MacosPlatform::capture_frame`],
+/// [`MacosPlatform::send_pointer`], and [`MacosPlatform::send_key`] each do on every call
+/// (via `scwindow::find_window_by_id` when `active_window` is set, else
+/// `scwindow::find_window_for_pids`). Short (unlike `start_app`'s `spec.timeout_ms`, which
+/// waits for a brand-new window to first appear): the window is already known to have
 /// existed as of the last successful call, so this only needs to cover the ordinary
 /// query-round-trip latency, not a real "is the app even launching" wait.
-const POINTER_RESOLVE_TIMEOUT: Duration = Duration::from_millis(2000);
+const WINDOW_RESOLVE_TIMEOUT: Duration = Duration::from_millis(2000);
 
 /// macOS backend. v1 renders the target app onto a `CGVirtualDisplay` (Plan 2) and
 /// drives it with ScreenCaptureKit + CGEvent + AXUIElement.
@@ -43,13 +45,27 @@ pub struct MacosPlatform {
     /// The launched child process, kept so `stop_app`/`Drop` can `process::terminate`
     /// it. `None` until `start_app` and after `stop_app` (idempotent).
     child: Option<Child>,
+    /// The active window's `CGWindowID` — the implicit target of `capture_frame`/
+    /// `send_pointer`/`send_key`, per the `Platform` contract. `start_app` sets it to the
+    /// first window discovered for the launched app; `select_window` (Plan 4 Task 5) is
+    /// the only other place that changes it, and is exactly the "retargeting" the
+    /// `Platform` contract describes — once an agent picks a different window, capture and
+    /// input follow it. `None` only before any `start_app` call (or after `stop_app`),
+    /// meaning "no window chosen yet"; every per-call resolver below falls back to the
+    /// original first-on-screen-by-pid lookup in that case.
+    active_window: Option<u32>,
 }
 
 impl MacosPlatform {
     /// Construct the backend, failing fast if a required TCC grant is missing.
     pub fn new() -> Result<Self> {
         permissions::preflight()?;
-        Ok(Self { logs: Arc::new(Mutex::new(Vec::new())), app_pid: None, child: None })
+        Ok(Self {
+            logs: Arc::new(Mutex::new(Vec::new())),
+            app_pid: None,
+            child: None,
+            active_window: None,
+        })
     }
 
     /// Run the optional `spec.build` shell step in `spec.cwd`, mirroring the X11/Windows
@@ -108,6 +124,20 @@ impl MacosPlatform {
             std::thread::sleep(DISCOVERY_POLL_INTERVAL);
         }
     }
+
+    /// Resolve the window `capture_frame`/`send_pointer`/`send_key` should target *this*
+    /// call: `scwindow::find_window_by_id(active_window, ..)` once `select_window` (or
+    /// `start_app`'s initial discovery) has set an active `CGWindowID` — the retargeting the
+    /// `Platform` contract requires (see the `active_window` field's doc) — falling back to
+    /// the pre-Plan-4 "first on-screen window for this pid" lookup when nothing is selected
+    /// yet. Always fresh (never cached): mirrors `find_window_for_pids`'s own per-call
+    /// re-resolution, since the window may have moved/resized/closed since the last call.
+    fn resolve_active_window(&self, pid: i32) -> Result<crate::scwindow::WindowMatch> {
+        match self.active_window {
+            Some(id) => crate::scwindow::find_window_by_id(id, WINDOW_RESOLVE_TIMEOUT),
+            None => crate::scwindow::find_window_for_pids(&[pid], WINDOW_RESOLVE_TIMEOUT),
+        }
+    }
 }
 
 /// Bounds-check every window-relative coordinate `event` carries against `geom` via
@@ -160,6 +190,13 @@ impl Platform for MacosPlatform {
             Ok(m) => {
                 self.child = Some(child);
                 self.app_pid = Some(pid);
+                // NOTE: this seeds the active-window model (Plan 4 design decision 2): the
+                // first window discovered for the launched app becomes the implicit target
+                // of capture/input, exactly as `select_window` (a later task) will retarget
+                // it to a different window later. `resolve_active_window` (used by
+                // `capture_frame`/`send_pointer`/`send_key` below) is what actually honors
+                // this field on every call.
+                self.active_window = Some(m.window_id);
                 // Scale/origin/geometry are NOT cached here: `send_pointer` re-resolves the
                 // window fresh on every call instead (see its doc) since it may move/resize
                 // after this initial discovery. Only the initial geometry is returned to the
@@ -175,51 +212,82 @@ impl Platform for MacosPlatform {
         }
     }
 
-    /// Terminate the launched child (if any) and clear the active pid. Idempotent — a
-    /// call with nothing running is `Ok(())`.
+    /// Terminate the launched child (if any) and clear the active pid/window. Idempotent —
+    /// a call with nothing running is `Ok(())`.
     fn stop_app(&mut self) -> Result<()> {
         if let Some(mut child) = self.child.take() {
             process::terminate(&mut child);
         }
         self.app_pid = None;
+        self.active_window = None;
         Ok(())
     }
 
-    /// Capture the active app's window as an RGBA8 frame, re-resolving it by pid on
-    /// every call (see `scwindow.rs`'s module doc — a `Retained<SCWindow>` can't be
-    /// cached across calls).
+    /// Capture the active window as an RGBA8 frame, re-resolving it fresh on every call
+    /// (see `scwindow.rs`'s module doc — a `Retained<SCWindow>` can't be cached across
+    /// calls).
+    ///
+    /// NOTE: targets `active_window` when set (`capture::capture_window_by_id`, exact
+    /// `CGWindowID` match) — the retargeting `select_window` (a later task) drives, per the
+    /// `Platform` contract's "implicit target of capture/input" — else falls back to the
+    /// pre-Plan-4 first-on-screen-window-for-this-pid path (`capture::capture_window`).
+    /// `resolve_active_window`'s doc covers the shared decision; capture takes its own
+    /// `capture_window`/`capture_window_by_id` branch (rather than calling
+    /// `resolve_active_window` itself) because capture needs the live `SCWindow` inside a
+    /// single completion-handler callback to build its `SCContentFilter`, not just the
+    /// `WindowMatch` snapshot `resolve_active_window` returns.
     ///
     /// **Main-thread affinity:** like `start_app`, this reaches `ffi::app_kit_init()`
-    /// (via `capture::capture_window`) and must run on the true main thread; see the
-    /// note on `start_app`.
+    /// (via `capture::capture_window`/`capture_window_by_id`) and must run on the true main
+    /// thread; see the note on `start_app`.
     fn capture_frame(&mut self, region: Option<&Region>) -> Result<Frame> {
         permissions::preflight()?;
         let pid = self.app_pid.ok_or(GlassError::NoActiveSession)?;
-        crate::capture::capture_window(&[pid as i32], region)
+        match self.active_window {
+            Some(id) => crate::capture::capture_window_by_id(id, region),
+            None => crate::capture::capture_window(&[pid as i32], region),
+        }
     }
-    /// Map the active session's pid into `input::send_pointer` — see `input.rs`'s module
-    /// doc for the CGEvent details and its main-thread-affinity note (shared with
+    /// Map the active window into `input::send_pointer` — see `input.rs`'s module doc for
+    /// the CGEvent details and its main-thread-affinity note (shared with
     /// `start_app`/`capture_frame` above).
     ///
-    /// NOTE: re-resolves the window fresh via `scwindow::find_window_for_pids` on every
-    /// call, mirroring `capture_frame`'s per-call resolution above — the window may have
+    /// NOTE: re-resolves the window fresh via `resolve_active_window` on every call —
+    /// targeting `active_window` when set (the retargeting `select_window`, a later task,
+    /// drives), else falling back to the pre-Plan-4 first-on-screen-window-for-this-pid
+    /// path — mirroring `capture_frame`'s per-call resolution above. The window may have
     /// moved or resized since `start_app` (or any earlier `send_pointer` call), so a
     /// `scale`/`origin_pt`/geometry cached once at `start_app` would go stale. Both the
     /// bounds check (`check_pointer_bounds`, see its doc) and the coordinate mapping use
-    /// this freshly-resolved geometry/scale/origin.
+    /// this freshly-resolved geometry/scale/origin; the CGEvent focus target is the
+    /// resolved window's own owning pid (`m.pid`, from the fresh `SCShareableContent`
+    /// lookup), not necessarily `self.app_pid` — today they're always the same pid (glass
+    /// launches one app per session), but `m.pid` is the one actually tied to the window
+    /// being clicked.
     fn send_pointer(&mut self, event: &PointerEvent) -> Result<()> {
         permissions::preflight()?;
         let pid = self.app_pid.ok_or(GlassError::NoActiveSession)?;
-        let m = crate::scwindow::find_window_for_pids(&[pid as i32], POINTER_RESOLVE_TIMEOUT)?;
+        let m = self.resolve_active_window(pid as i32)?;
         check_pointer_bounds(event, &m.geometry)?;
-        crate::input::send_pointer(event, pid as i32, m.scale, m.origin_pt)
+        crate::input::send_pointer(event, m.pid, m.scale, m.origin_pt)
     }
-    /// Map the active session's pid into `input::send_key` — see `input.rs`'s module doc
-    /// for the CGEvent keyboard details.
+    /// Map the active window into `input::send_key` — see `input.rs`'s module doc for the
+    /// CGEvent keyboard details.
+    ///
+    /// NOTE: re-resolves the active window via `resolve_active_window` first, same as
+    /// `send_pointer`, even though keyboard CGEvents target a *process* (`focus(pid)`
+    /// activates the app, and the posted event then goes to whatever window that app
+    /// currently has key/main — there is no per-window keyboard targeting yet; that needs
+    /// AXUIElement raise/main, Plan 4 Task 4). The resolution here still matters: if
+    /// `active_window` is set but that window has closed, this surfaces
+    /// `GlassError::WindowNotFound` instead of silently posting keys to whatever else
+    /// happens to be focused — the same no-silent-wrong-target discipline `send_pointer`'s
+    /// bounds check enforces for clicks.
     fn send_key(&mut self, event: &KeyEvent) -> Result<()> {
         permissions::preflight()?;
         let pid = self.app_pid.ok_or(GlassError::NoActiveSession)?;
-        crate::input::send_key(event, pid as i32)
+        let m = self.resolve_active_window(pid as i32)?;
+        crate::input::send_key(event, m.pid)
     }
     fn window(&mut self, _op: &WindowOp) -> Result<WindowGeometry> {
         unimplemented!("Plan 4: AXUIElement window ops")
@@ -263,6 +331,7 @@ mod tests {
             logs: Arc::new(Mutex::new(vec![(Stream::Stdout, "hi".into())])),
             app_pid: Some(42),
             child: None,
+            active_window: None,
         };
         assert_eq!(p.drain_logs().len(), 1);
         assert!(p.drain_logs().is_empty());
@@ -270,7 +339,12 @@ mod tests {
 
     #[test]
     fn app_pid_returns_the_constructed_value() {
-        let p = MacosPlatform { logs: Arc::new(Mutex::new(Vec::new())), app_pid: Some(42), child: None };
+        let p = MacosPlatform {
+            logs: Arc::new(Mutex::new(Vec::new())),
+            app_pid: Some(42),
+            child: None,
+            active_window: None,
+        };
         assert_eq!(p.app_pid(), Some(42));
     }
 
@@ -279,10 +353,30 @@ mod tests {
         // No child stored: stop_app must not panic (e.g. on an unwrap of a live process
         // handle) and must succeed — this path never touches AppKit, so it's exercisable
         // off the Mac-gated suite's main-thread test.
-        let mut p = MacosPlatform { logs: Arc::new(Mutex::new(Vec::new())), app_pid: None, child: None };
+        let mut p = MacosPlatform {
+            logs: Arc::new(Mutex::new(Vec::new())),
+            app_pid: None,
+            child: None,
+            active_window: None,
+        };
         assert!(p.stop_app().is_ok());
         assert!(p.stop_app().is_ok(), "a second call must also be Ok");
         assert_eq!(p.app_pid(), None);
+    }
+
+    #[test]
+    fn stop_app_clears_active_window() {
+        // start_app seeds active_window (Plan 4 Task 1); stop_app must clear it too, so a
+        // later start_app on the same MacosPlatform never leaks a stale CGWindowID from a
+        // previous session into resolve_active_window.
+        let mut p = MacosPlatform {
+            logs: Arc::new(Mutex::new(Vec::new())),
+            app_pid: Some(42),
+            child: None,
+            active_window: Some(7),
+        };
+        assert!(p.stop_app().is_ok());
+        assert_eq!(p.active_window, None);
     }
 
     #[test]

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -171,6 +171,20 @@ fn check_pointer_bounds(event: &PointerEvent, geom: &WindowGeometry) -> Result<(
     }
 }
 
+/// Map one `scwindow::AppWindow` into the `WindowInfo` [`MacosPlatform::list_windows`]
+/// returns, given the backend's current `active_window`. Factored out of `list_windows` as
+/// a pure step so it's unit-testable without a live `SCShareableContent` query — runtime
+/// enumeration coverage is Task 6's.
+fn window_info_from(w: crate::scwindow::AppWindow, active_window: Option<u32>) -> WindowInfo {
+    WindowInfo {
+        id: WindowId(w.window_id as u64),
+        title: w.title,
+        class: w.application_name,
+        geometry: w.geometry,
+        active: Some(w.window_id) == active_window,
+    }
+}
+
 impl Platform for MacosPlatform {
     /// Run the optional build step, spawn the app, then confirm a window appears for its
     /// pid within `spec.timeout_ms` via ScreenCaptureKit's `SCShareableContent`
@@ -292,8 +306,18 @@ impl Platform for MacosPlatform {
     fn window(&mut self, _op: &WindowOp) -> Result<WindowGeometry> {
         unimplemented!("Plan 4: AXUIElement window ops")
     }
+    /// Enumerate every on-screen window owned by the launched app's pid via
+    /// `scwindow::list_app_windows` (one `SCShareableContent` query, all matches — not just
+    /// the active one), mapping each into a `WindowInfo` via [`window_info_from`].
+    ///
+    /// **Main-thread affinity:** like `start_app`/`capture_frame`, reaches
+    /// `ffi::app_kit_init()` (via `scwindow::list_app_windows`) and must run on the true
+    /// main thread; see the note on `start_app`.
     fn list_windows(&mut self) -> Result<Vec<WindowInfo>> {
-        unimplemented!("Plan 4: CGWindowList/SCShareableContent by pid")
+        permissions::preflight()?;
+        let pid = self.app_pid.ok_or(GlassError::NoActiveSession)?;
+        let windows = crate::scwindow::list_app_windows(&[pid as i32])?;
+        Ok(windows.into_iter().map(|w| window_info_from(w, self.active_window)).collect())
     }
     fn select_window(&mut self, _id: WindowId) -> Result<WindowGeometry> {
         unimplemented!("Plan 4: raise + focus + activate")
@@ -417,5 +441,38 @@ mod tests {
             duration_ms: 100,
         };
         assert!(matches!(check_pointer_bounds(&ev, &geom), Err(GlassError::CoordOutOfBounds { .. })));
+    }
+
+    #[test]
+    fn window_info_from_marks_the_active_window() {
+        let w = crate::scwindow::AppWindow {
+            window_id: 7,
+            geometry: WindowGeometry { x: 1, y: 2, width: 640, height: 480 },
+            title: Some("Untitled".into()),
+            application_name: Some("TestApp".into()),
+        };
+        let info = window_info_from(w.clone(), Some(7));
+        assert_eq!(info.id, WindowId(7));
+        assert_eq!(info.title, Some("Untitled".into()));
+        assert_eq!(info.class, Some("TestApp".into()));
+        assert_eq!(info.geometry, WindowGeometry { x: 1, y: 2, width: 640, height: 480 });
+        assert!(info.active, "window_id matches active_window");
+
+        let not_active = window_info_from(w, Some(8));
+        assert!(!not_active.active, "window_id does not match a different active_window");
+    }
+
+    #[test]
+    fn window_info_from_is_not_active_when_no_window_is_selected() {
+        let w = crate::scwindow::AppWindow {
+            window_id: 7,
+            geometry: WindowGeometry { x: 0, y: 0, width: 100, height: 100 },
+            title: None,
+            application_name: None,
+        };
+        let info = window_info_from(w, None);
+        assert!(!info.active);
+        assert_eq!(info.title, None);
+        assert_eq!(info.class, None);
     }
 }

--- a/crates/glass-macos/src/capture.rs
+++ b/crates/glass-macos/src/capture.rs
@@ -4,7 +4,9 @@
 //! held across calls or across the completion-handler's thread boundary (see
 //! `scwindow.rs`'s module doc) — via the nested async flow proven end-to-end in the objc2
 //! spike (`.superpowers/sdd/objc2-spike-report.md` Part A):
-//! `SCShareableContent` → [`crate::scwindow::find_on_screen_window`] →
+//! `SCShareableContent` → [`crate::scwindow::find_on_screen_window`]/
+//! [`crate::scwindow::find_on_screen_window_by_id`] (pid-set lookup for `capture_window`,
+//! exact-`CGWindowID` lookup for `capture_window_by_id` — see [`capture_resolved`]) →
 //! `SCContentFilter::initWithDesktopIndependentWindow` → `SCStreamConfiguration` →
 //! `SCScreenshotManager::captureImageWithFilter_configuration_completionHandler` →
 //! `CGImage`, drawn into a tightly-packed RGBA8 bitmap context inside the innermost
@@ -16,6 +18,7 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 use block2::RcBlock;
+use objc2::rc::Retained;
 use objc2::AnyThread;
 use objc2_core_foundation::{CGPoint, CGRect, CGSize};
 use objc2_core_graphics::{
@@ -23,13 +26,13 @@ use objc2_core_graphics::{
 };
 use objc2_foundation::NSError;
 use objc2_screen_capture_kit::{
-    SCContentFilter, SCScreenshotManager, SCShareableContent, SCStreamConfiguration,
+    SCContentFilter, SCScreenshotManager, SCShareableContent, SCStreamConfiguration, SCWindow,
 };
 
 use glass_core::frame::{Frame, Region};
 use glass_core::{GlassError, Result};
 
-use crate::scwindow::find_on_screen_window;
+use crate::scwindow::{find_on_screen_window, find_on_screen_window_by_id};
 
 /// Max wait for one capture round trip (`SCShareableContent` + `SCScreenshotManager`
 /// both completing). Generous relative to the spike's sub-second observations — this
@@ -41,11 +44,40 @@ const CAPTURE_TIMEOUT: Duration = Duration::from_secs(10);
 /// [`GlassError::WindowNotFound`] if no on-screen window is owned by `pids`,
 /// [`GlassError::PermissionDenied`] on a Screen Recording TCC decline, or
 /// [`GlassError::CaptureFailed`] for any other ScreenCaptureKit failure.
+///
+/// `backend.rs::capture_frame`'s fallback path for when `MacosPlatform::active_window` is
+/// unset — see [`capture_window_by_id`] for its active-window (retargeted) counterpart.
 pub(crate) fn capture_window(pids: &[i32], region: Option<&Region>) -> Result<Frame> {
+    let pids_owned: Vec<i32> = pids.to_vec();
+    capture_resolved(region, move |content| find_on_screen_window(content, &pids_owned))
+}
+
+/// Capture the specific on-screen window whose `CGWindowID == window_id` as an RGBA8
+/// [`Frame`], optionally cropped to a window-relative `region`. Same error mapping as
+/// [`capture_window`]. This is `backend.rs::capture_frame`'s active-window (retargeted)
+/// path: once `MacosPlatform::active_window` is set (by `start_app`, later by
+/// `select_window`), capture must target that *exact* window rather than "first on-screen
+/// window for this pid" — a multi-window app would otherwise silently capture the wrong
+/// window (Plan 4's design decision 2).
+pub(crate) fn capture_window_by_id(window_id: u32, region: Option<&Region>) -> Result<Frame> {
+    capture_resolved(region, move |content| find_on_screen_window_by_id(content, window_id))
+}
+
+/// Shared nested-async capture body for [`capture_window`]/[`capture_window_by_id`]: resolve
+/// the target `SCWindow` via `resolve` (the only thing that differs between a pid-set lookup
+/// and an exact-`CGWindowID` lookup), then build the `SCContentFilter`/`SCStreamConfiguration`
+/// and run `SCScreenshotManager`'s capture — identical for both callers, so this is the one
+/// place that logic lives (no risk of the two paths drifting on filter/config/crop
+/// handling). `resolve` runs inside the `SCShareableContent` completion block, so it must be
+/// `Send` (queue-hopped, like every other closure this module posts across the FFI
+/// boundary — see `ffi.rs`'s async-bridge doc) but does not need to be `Sync` (called once).
+fn capture_resolved(
+    region: Option<&Region>,
+    resolve: impl Fn(&SCShareableContent) -> Option<(Retained<SCWindow>, i32)> + Send + 'static,
+) -> Result<Frame> {
     crate::ffi::app_kit_init();
 
     let (tx, rx) = mpsc::channel::<CaptureReply>();
-    let pids_owned: Vec<i32> = pids.to_vec();
     let region_owned = region.copied();
 
     let content_block = RcBlock::new(
@@ -62,7 +94,7 @@ pub(crate) fn capture_window(pids: &[i32], region: Option<&Region>) -> Result<Fr
             // it points to a live `SCShareableContent` for the duration of this callback.
             let content: &SCShareableContent = unsafe { &*content_ptr };
 
-            let Some((window, _pid)) = find_on_screen_window(content, &pids_owned) else {
+            let Some((window, _pid)) = resolve(content) else {
                 let _ = tx.send(CaptureReply::Err(GlassError::WindowNotFound));
                 return;
             };

--- a/crates/glass-macos/src/capture.rs
+++ b/crates/glass-macos/src/capture.rs
@@ -52,15 +52,19 @@ pub(crate) fn capture_window(pids: &[i32], region: Option<&Region>) -> Result<Fr
     capture_resolved(region, move |content| find_on_screen_window(content, &pids_owned))
 }
 
-/// Capture the specific on-screen window whose `CGWindowID == window_id` as an RGBA8
-/// [`Frame`], optionally cropped to a window-relative `region`. Same error mapping as
-/// [`capture_window`]. This is `backend.rs::capture_frame`'s active-window (retargeted)
-/// path: once `MacosPlatform::active_window` is set (by `start_app`, later by
-/// `select_window`), capture must target that *exact* window rather than "first on-screen
-/// window for this pid" — a multi-window app would otherwise silently capture the wrong
-/// window (Plan 4's design decision 2).
-pub(crate) fn capture_window_by_id(window_id: u32, region: Option<&Region>) -> Result<Frame> {
-    capture_resolved(region, move |content| find_on_screen_window_by_id(content, window_id))
+/// Capture the specific on-screen window whose `CGWindowID == window_id` AND
+/// `owningApplication().processID() ∈ pids` as an RGBA8 [`Frame`], optionally cropped to a
+/// window-relative `region`. Same error mapping as [`capture_window`]. This is
+/// `backend.rs::capture_frame`'s active-window (retargeted) path: once
+/// `MacosPlatform::active_window` is set (by `start_app`, later by `select_window`), capture
+/// must target that *exact* window rather than "first on-screen window for this pid" — a
+/// multi-window app would otherwise silently capture the wrong window (Plan 4's design
+/// decision 2). The `pids` scoping (final-review fix 1) additionally guards against a
+/// stale/foreign `active_window` id: without it, `window_id` alone could match a window
+/// owned by a completely different app, silently capturing its pixels instead of erroring.
+pub(crate) fn capture_window_by_id(window_id: u32, pids: &[i32], region: Option<&Region>) -> Result<Frame> {
+    let pids_owned: Vec<i32> = pids.to_vec();
+    capture_resolved(region, move |content| find_on_screen_window_by_id(content, window_id, &pids_owned))
 }
 
 /// Shared nested-async capture body for [`capture_window`]/[`capture_window_by_id`]: resolve

--- a/crates/glass-macos/src/coords.rs
+++ b/crates/glass-macos/src/coords.rs
@@ -9,6 +9,11 @@
 //! [`pixel_geometry_from_content_rect`] is the mirror-image conversion `scwindow.rs` uses
 //! to turn `SCContentFilter`'s `contentRect` (POINTS) + `pointPixelScale` into the PIXEL
 //! `WindowGeometry` the tool boundary reports.
+//!
+//! [`global_pixel_to_point`]/[`point_to_global_pixel`] are Plan 4's ABSOLUTE (no
+//! window-origin offset) counterparts, for window `Move`/`Resize`/`Geometry` ops that
+//! address the global screen directly via `AXUIElement` rather than a window-relative
+//! click.
 
 use glass_core::frame::Region;
 use glass_core::platform::WindowGeometry;
@@ -50,6 +55,24 @@ pub fn clamp_region(rx: i32, ry: i32, rw: u32, rh: u32, width: u32, height: u32)
 /// one place a pixel value crosses back into points, right before posting a CGEvent.
 pub fn pixel_to_global_point(rel_px: (i32, i32), scale: f64, origin_pt: (f64, f64)) -> (f64, f64) {
     (origin_pt.0 + rel_px.0 as f64 / scale, origin_pt.1 + rel_px.1 as f64 / scale)
+}
+
+/// Map an ABSOLUTE global-screen PIXEL coordinate to Quartz's global POINT space:
+/// `px / scale`. Unlike [`pixel_to_global_point`] (which is window-RELATIVE and adds a
+/// window's `origin_pt`), this has no origin term — it's for Plan 4's window
+/// Move/Resize/Geometry ops, which address the global screen directly (a `WindowOp::Move`
+/// target, or an `AXUIElement` position/size already in global points), not a click
+/// relative to a window's top-left.
+pub fn global_pixel_to_point(px: (i32, i32), scale: f64) -> (f64, f64) {
+    (px.0 as f64 / scale, px.1 as f64 / scale)
+}
+
+/// The inverse of [`global_pixel_to_point`]: map an ABSOLUTE global POINT (e.g. read back
+/// from `AXUIElement`'s position/size) to a global PIXEL coordinate: `pt * scale`, rounded
+/// to the nearest pixel (ties away from zero, matching
+/// [`pixel_geometry_from_content_rect`]'s rounding).
+pub fn point_to_global_pixel(pt: (f64, f64), scale: f64) -> (i32, i32) {
+    ((pt.0 * scale).round() as i32, (pt.1 * scale).round() as i32)
 }
 
 /// Convert a window's `contentRect` (POINTS, from `SCContentFilter.contentRect()`) plus
@@ -129,6 +152,46 @@ mod tests {
     #[test]
     fn pixel_to_global_point_handles_negative_rel_and_origin() {
         assert_eq!(pixel_to_global_point((-40, -10), 2.0, (-5.0, 0.0)), (-25.0, -5.0));
+    }
+
+    #[test]
+    fn global_pixel_to_point_is_identity_at_1x() {
+        assert_eq!(global_pixel_to_point((100, 200), 1.0), (100.0, 200.0));
+    }
+
+    #[test]
+    fn global_pixel_to_point_halves_at_2x_retina() {
+        assert_eq!(global_pixel_to_point((200, 400), 2.0), (100.0, 200.0));
+    }
+
+    #[test]
+    fn global_pixel_to_point_handles_negative_pixels() {
+        assert_eq!(global_pixel_to_point((-200, -3), 2.0), (-100.0, -1.5));
+    }
+
+    #[test]
+    fn point_to_global_pixel_is_identity_at_1x() {
+        assert_eq!(point_to_global_pixel((100.0, 200.0), 1.0), (100, 200));
+    }
+
+    #[test]
+    fn point_to_global_pixel_doubles_at_2x_retina() {
+        assert_eq!(point_to_global_pixel((100.0, 200.0), 2.0), (200, 400));
+    }
+
+    #[test]
+    fn point_to_global_pixel_rounds_to_nearest_pixel() {
+        // 1.25 * 2 = 2.5 -> 3 (round-half-away-from-zero, per f64::round).
+        assert_eq!(point_to_global_pixel((1.25, 1.25), 2.0), (3, 3));
+    }
+
+    #[test]
+    fn global_pixel_point_round_trip_at_1x_and_2x() {
+        for scale in [1.0, 2.0] {
+            let px = (137, -42);
+            let pt = global_pixel_to_point(px, scale);
+            assert_eq!(point_to_global_pixel(pt, scale), px);
+        }
     }
 
     #[test]

--- a/crates/glass-macos/src/input.rs
+++ b/crates/glass-macos/src/input.rs
@@ -253,7 +253,11 @@ fn resolve_chord_key(token: &str) -> Option<(u16, bool)> {
 /// (`activateWithOptions` returns `false`) doesn't fail the call — the event still posts to
 /// whatever currently has focus, matching `glass-windows::input::send_pointer`'s own
 /// best-effort `focus_window` nudge.
-fn focus(pid: i32) {
+///
+/// `pub(crate)`: also the `NSRunningApplication(pid).activate()` step of
+/// `backend::MacosPlatform::window`'s `WindowOp::Focus` branch (Plan 4 Task 4), ahead of that
+/// branch's `axwindow::ax_raise`/`ax_set_main` — one activation call site rather than two.
+pub(crate) fn focus(pid: i32) {
     let Some(app) = NSRunningApplication::runningApplicationWithProcessIdentifier(pid) else {
         return;
     };

--- a/crates/glass-macos/src/input.rs
+++ b/crates/glass-macos/src/input.rs
@@ -72,7 +72,15 @@ const FOCUS_SETTLE: Duration = Duration::from_millis(300);
 /// and window `contentRect.origin`, carried by `MacosPlatform` since the last `start_app` —
 /// see `coords.rs`'s module doc).
 pub(crate) fn send_pointer(event: &PointerEvent, pid: i32, scale: f64, origin_pt: (f64, f64)) -> Result<()> {
-    focus(pid);
+    // `Gesture` is unconditionally unsupported on macOS regardless of `pid`'s validity (see
+    // the `PointerEvent::Gesture` arm below) — checked first, ahead of `focus`, so this
+    // fails fast without the side effect of raising/activating `pid`'s app for an operation
+    // that can never succeed (also keeps `focus`'s now-fallible missing-process check, fix
+    // 4, from masking this call-shape error behind an unrelated `AppExited`).
+    if matches!(event, PointerEvent::Gesture { .. }) {
+        return Err(GlassError::Unsupported("multi-touch gesture is not supported on macOS".into()));
+    }
+    focus(pid)?;
 
     // Passing `None` here is a documented-valid `CGEventCreateMouseEvent`/
     // `CGEventCreateScrollWheelEvent2` argument (falls back to the combined session state),
@@ -125,6 +133,9 @@ pub(crate) fn send_pointer(event: &PointerEvent, pid: i32, scale: f64, origin_pt
                 MacScrollSink { source: source.as_deref(), point: to_point(x, y), dx, dy, flags: to_flags(modifiers) };
             run_scroll(&mut sink, !modifiers.is_empty())?;
         }
+        // Already rejected by the early check above (before `focus`); kept here so this
+        // match stays exhaustive over `PointerEvent`'s variants and a future variant added
+        // to the enum still forces an explicit decision at this call site.
         PointerEvent::Gesture { .. } => {
             return Err(GlassError::Unsupported("multi-touch gesture is not supported on macOS".into()));
         }
@@ -142,7 +153,7 @@ const KEY_TYPE_DWELL: Duration = Duration::from_millis(12);
 /// Inject `event` as keyboard CGEvents targeting the app at `pid`, focusing it first (same
 /// best-effort `focus` helper/settle `send_pointer` uses above).
 pub(crate) fn send_key(event: &KeyEvent, pid: i32) -> Result<()> {
-    focus(pid);
+    focus(pid)?;
 
     // See `send_pointer`'s doc for why a `None` source is a documented-valid, gracefully
     // degrading `CGEventCreateKeyboardEvent` argument rather than an error.
@@ -248,21 +259,29 @@ fn resolve_chord_key(token: &str) -> Option<(u16, bool)> {
 
 /// Raise `pid`'s app before injecting input — macOS delivers CGEvents posted at the HID tap
 /// to whatever the window server currently has focused, unlike X11/Windows where glass warps
-/// the pointer into an app it already knows the geometry of. Best-effort: a missing/exited
-/// app (`runningApplicationWithProcessIdentifier` returns `None`) or a declined activation
-/// (`activateWithOptions` returns `false`) doesn't fail the call — the event still posts to
-/// whatever currently has focus, matching `glass-windows::input::send_pointer`'s own
-/// best-effort `focus_window` nudge.
+/// the pointer into an app it already knows the geometry of.
+///
+/// A missing/exited process (`runningApplicationWithProcessIdentifier` returns `None`) is a
+/// hard error (final-review fix 4), not best-effort: silently posting input to "whatever
+/// currently has focus" when the target app is actually gone is exactly the kind of
+/// silent-wrong-target failure the rest of this crate's pid-scoping goes out of its way to
+/// avoid (see `scwindow.rs`'s `find_window_by_id` doc) — an agent driving a dead app should
+/// see `GlassError::AppExited`, not a keystroke/click that silently landed somewhere else. A
+/// *declined* activation (`activateWithOptions` returns `false`, e.g. the OS deprioritizes a
+/// background-app activation request) still doesn't fail the call: the process is
+/// confirmed alive, and the event still posts to whatever currently has focus, matching
+/// `glass-windows::input::send_pointer`'s own best-effort `focus_window` nudge for that
+/// narrower case.
 ///
 /// `pub(crate)`: also the `NSRunningApplication(pid).activate()` step of
 /// `backend::MacosPlatform::window`'s `WindowOp::Focus` branch (Plan 4 Task 4), ahead of that
 /// branch's `axwindow::ax_raise`/`ax_set_main` — one activation call site rather than two.
-pub(crate) fn focus(pid: i32) {
-    let Some(app) = NSRunningApplication::runningApplicationWithProcessIdentifier(pid) else {
-        return;
-    };
+pub(crate) fn focus(pid: i32) -> Result<()> {
+    let app = NSRunningApplication::runningApplicationWithProcessIdentifier(pid)
+        .ok_or(GlassError::AppExited(None))?;
     app.activateWithOptions(NSApplicationActivationOptions::empty());
     thread::sleep(FOCUS_SETTLE);
+    Ok(())
 }
 
 /// Build a mouse CGEvent of `ty` at global `point`, tagged with `button`/`flags`. Does not

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -16,6 +16,8 @@ mod permissions;
 #[cfg(target_os = "macos")]
 mod scwindow;
 #[cfg(target_os = "macos")]
+mod axwindow;
+#[cfg(target_os = "macos")]
 mod capture;
 #[cfg(target_os = "macos")]
 mod process;

--- a/crates/glass-macos/src/scwindow.rs
+++ b/crates/glass-macos/src/scwindow.rs
@@ -1,10 +1,13 @@
-//! `SCShareableContent` window discovery by pid.
+//! `SCShareableContent` window discovery by pid, and by `CGWindowID` (Plan 4's
+//! active-window retargeting).
 //!
 //! Polls ScreenCaptureKit's `SCShareableContent` enumeration — the same async
 //! completion-handler API proven end-to-end in
 //! `.superpowers/sdd/objc2-spike-report.md` Part A — for the first on-screen window
-//! owned by one of a set of pids (the launched app's process set), following `ffi.rs`'s
-//! documented async-bridge convention.
+//! owned by one of a set of pids ([`find_window_for_pids`], the launched app's process
+//! set) or for the specific on-screen window with a given `CGWindowID`
+//! ([`find_window_by_id`], `MacosPlatform`'s active window once `select_window` has run),
+//! following `ffi.rs`'s documented async-bridge convention.
 //!
 //! ## Why this returns [`WindowMatch`], not `Retained<SCWindow>`
 //!
@@ -44,9 +47,10 @@ use glass_core::{poll_until, GlassError, Result};
 /// a live `Retained<SCWindow>` across the completion handler's thread boundary (see
 /// module doc).
 // `geometry`/`scale`/`origin_pt` are read by `start_app` (via `backend.rs::discover_window`
-// -> `query_once`) and by `send_pointer` (via `backend.rs`'s direct
-// `find_window_for_pids` call on every pointer event); `pid`/`window_id` stay unread until
-// Plan 4's list/select_window.
+// -> `query_once`) and by `send_pointer`/`capture_frame`/`send_key` (via `backend.rs`'s
+// per-call `find_window_for_pids`/`find_window_by_id` resolution); `window_id` is read by
+// `start_app` too (to seed `MacosPlatform::active_window`, Plan 4 Task 1). `pid` stays
+// unread outside construction until Plan 4's `list_windows`.
 #[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct WindowMatch {
@@ -99,6 +103,30 @@ pub(crate) fn find_window_for_pids(pids: &[i32], timeout: Duration) -> Result<Wi
     outcome.value.ok_or(GlassError::Timeout(timeout_ms))
 }
 
+/// Poll `SCShareableContent` roughly every 100ms for the on-screen window whose
+/// `windowID() == window_id`, until found or `timeout` elapses. This is Plan 4's
+/// active-window retargeting lookup: `backend.rs` calls it on every `capture_frame`/
+/// `send_pointer`/`send_key` once `select_window` has set an active `CGWindowID`, in place
+/// of [`find_window_for_pids`]'s first-on-screen-by-pid resolution — see its module doc for
+/// why re-resolving fresh per call (rather than caching a `Retained<SCWindow>`) is the only
+/// safe option.
+///
+/// Unlike `find_window_for_pids`'s [`GlassError::Timeout`] (appropriate while waiting for a
+/// brand-new window to first appear at launch), a `window_id` that never turns up here means
+/// a *previously known* window is gone — closed, or the id was never valid — so this returns
+/// [`GlassError::WindowNotFound`] instead, matching the `Platform` contract's
+/// `select_window`/window-op error (`glass_core::platform`'s doc) for exactly that case.
+///
+/// Returns a classified [`GlassError::PermissionDenied`]/[`GlassError::CaptureFailed`]
+/// immediately on a genuine `SCShareableContent` failure, same as `find_window_for_pids`.
+pub(crate) fn find_window_by_id(window_id: u32, timeout: Duration) -> Result<WindowMatch> {
+    crate::ffi::app_kit_init();
+
+    let timeout_ms = timeout.as_millis() as u64;
+    let outcome = poll_until(100, timeout_ms, || query_once_by_id(window_id))?;
+    outcome.value.ok_or(GlassError::WindowNotFound)
+}
+
 /// Find the first on-screen `SCWindow` in `content.windows()` owned by one of `pids`,
 /// returning it alongside its owning pid. Shared by [`query_once`] (which extracts a
 /// [`WindowMatch`] snapshot from the match, since the window itself can't survive the
@@ -133,6 +161,69 @@ pub(crate) fn find_on_screen_window(
         }
     }
     None
+}
+
+/// Find the on-screen `SCWindow` in `content.windows()` whose `windowID() == window_id`,
+/// returning it alongside its owning pid. The `find_window_by_id`-side counterpart of
+/// [`find_on_screen_window`] (which filters by owning pid instead of a specific window):
+/// same on-screen filter, same iteration, so the two lookups can't drift on what "on-screen"
+/// means. Used by [`query_once_by_id`] (which then builds a [`WindowMatch`] snapshot via
+/// [`window_match_from`], the same builder [`query_once`] uses) and by
+/// `capture::capture_window_by_id` (which, like `capture_window`, needs the live `SCWindow`
+/// itself, still inside the same completion-handler callback, to build an
+/// `SCContentFilter` — see [`find_on_screen_window`]'s doc).
+pub(crate) fn find_on_screen_window_by_id(
+    content: &SCShareableContent,
+    window_id: u32,
+) -> Option<(Retained<SCWindow>, i32)> {
+    // SAFETY: `windows` is a plain getter on a live `SCShareableContent`; no other
+    // preconditions.
+    let windows: Retained<NSArray<SCWindow>> = unsafe { content.windows() };
+
+    for w in windows.iter() {
+        // SAFETY: `w` is a live `SCWindow` yielded by the array; these are plain property
+        // getters with no other preconditions — see `find_on_screen_window`'s identical
+        // SAFETY notes.
+        if !unsafe { w.isOnScreen() } {
+            continue;
+        }
+        if unsafe { w.windowID() } != window_id {
+            continue;
+        }
+        // SAFETY: same as above — a plain property getter.
+        let owning_application = unsafe { w.owningApplication() };
+        let Some(app) = owning_application else { continue };
+        // SAFETY: same as above — a plain property getter.
+        let pid = unsafe { app.processID() };
+        return Some((w, pid));
+    }
+    None
+}
+
+/// Build a [`WindowMatch`] snapshot from a live `SCWindow` + its owning `pid` — the same
+/// `SCContentFilter`/`pointPixelScale`/`contentRect` -> pixel-`WindowGeometry` conversion
+/// [`query_once`]'s completion handler and `capture::capture_window` both need. Factored out
+/// so [`query_once`] and [`query_once_by_id`] can't drift on how a match becomes a
+/// `WindowMatch`.
+fn window_match_from(w: &SCWindow, pid: i32) -> WindowMatch {
+    // SAFETY: `w` is a live `SCWindow` passed in by a caller that just resolved it from a
+    // live `SCShareableContent.windows()` array (see `find_on_screen_window`/
+    // `find_on_screen_window_by_id`); `capture.rs` uses this same initializer on the same
+    // kind of live `SCWindow` — no other preconditions.
+    let filter = unsafe { SCContentFilter::initWithDesktopIndependentWindow(SCContentFilter::alloc(), w) };
+    // SAFETY: `w`/`filter` are live; these are plain property getters with no other
+    // preconditions.
+    let (window_id, scale, content_rect) =
+        unsafe { (w.windowID(), filter.pointPixelScale() as f64, filter.contentRect()) };
+    let geometry = crate::coords::pixel_geometry_from_content_rect(
+        content_rect.origin.x,
+        content_rect.origin.y,
+        content_rect.size.width,
+        content_rect.size.height,
+        scale,
+    );
+    let origin_pt = (content_rect.origin.x, content_rect.origin.y);
+    WindowMatch { pid, window_id, geometry, scale, origin_pt }
 }
 
 /// Cap on a single [`query_once`] attempt's wait for its `SCShareableContent` completion
@@ -175,30 +266,61 @@ pub(crate) fn query_once(pids: &[i32]) -> Result<Option<WindowMatch>> {
             let _ = tx.send(QueryReply::NotFound);
             return;
         };
-        // SAFETY: `w` is a live `SCWindow` just resolved above; `capture.rs` uses this
-        // same initializer on the same kind of live `SCWindow` — no other preconditions.
-        let filter = unsafe {
-            SCContentFilter::initWithDesktopIndependentWindow(SCContentFilter::alloc(), &w)
-        };
-        // SAFETY: `w`/`filter` are live; these are plain property getters with no other
-        // preconditions.
-        let (window_id, scale, content_rect) =
-            unsafe { (w.windowID(), filter.pointPixelScale() as f64, filter.contentRect()) };
-        let geometry = crate::coords::pixel_geometry_from_content_rect(
-            content_rect.origin.x,
-            content_rect.origin.y,
-            content_rect.size.width,
-            content_rect.size.height,
-            scale,
-        );
-        let origin_pt = (content_rect.origin.x, content_rect.origin.y);
-        let _ = tx.send(QueryReply::Found(WindowMatch { pid, window_id, geometry, scale, origin_pt }));
+        let _ = tx.send(QueryReply::Found(window_match_from(&w, pid)));
     });
 
     // SAFETY: `block` matches `getShareableContentExcludingDesktopWindows_onScreenWindowsOnly_completionHandler`'s
     // documented signature (`*mut SCShareableContent, *mut NSError`, per the generated
     // binding) — the exact sequence the spike proved end-to-end. The call itself has no
     // other preconditions.
+    unsafe {
+        SCShareableContent::getShareableContentExcludingDesktopWindows_onScreenWindowsOnly_completionHandler(
+            true, true, &block,
+        );
+    }
+
+    match rx.recv_timeout(QUERY_TIMEOUT) {
+        Ok(QueryReply::Found(m)) => Ok(Some(m)),
+        Ok(QueryReply::NotFound) => Ok(None),
+        Ok(QueryReply::Failed(e)) => Err(e),
+        Err(mpsc::RecvTimeoutError::Timeout) => Ok(None),
+        Err(mpsc::RecvTimeoutError::Disconnected) => Err(GlassError::Backend(
+            "SCShareableContent completion handler was dropped without replying".into(),
+        )),
+    }
+}
+
+/// [`find_window_by_id`]'s per-attempt round trip — identical shape to [`query_once`] (same
+/// `RcBlock` -> `mpsc` bridge, same `QUERY_TIMEOUT` cap, same error classification) but
+/// matching on a specific `window_id` via [`find_on_screen_window_by_id`] instead of an
+/// owning-pid set.
+fn query_once_by_id(window_id: u32) -> Result<Option<WindowMatch>> {
+    let (tx, rx) = mpsc::channel::<QueryReply>();
+
+    // Same completion-handler contract as `query_once`'s block: only ever sends the plain
+    // owned `QueryReply`, never a `Retained<SCWindow>` (see module doc).
+    let block = RcBlock::new(move |content_ptr: *mut SCShareableContent, err_ptr: *mut NSError| {
+        if content_ptr.is_null() {
+            let err = crate::ffi::classify_null_result(
+                err_ptr,
+                "SCShareableContent completion handler returned null content and null error",
+            );
+            let _ = tx.send(QueryReply::Failed(err));
+            return;
+        }
+        // SAFETY: `content_ptr` was just checked non-null; the framework guarantees it
+        // points to a live `SCShareableContent` for the duration of this callback.
+        let content: &SCShareableContent = unsafe { &*content_ptr };
+
+        let Some((w, pid)) = find_on_screen_window_by_id(content, window_id) else {
+            let _ = tx.send(QueryReply::NotFound);
+            return;
+        };
+        let _ = tx.send(QueryReply::Found(window_match_from(&w, pid)));
+    });
+
+    // SAFETY: same as `query_once`'s identical call — the documented signature, no other
+    // preconditions.
     unsafe {
         SCShareableContent::getShareableContentExcludingDesktopWindows_onScreenWindowsOnly_completionHandler(
             true, true, &block,

--- a/crates/glass-macos/src/scwindow.rs
+++ b/crates/glass-macos/src/scwindow.rs
@@ -73,6 +73,28 @@ pub(crate) struct WindowMatch {
     pub(crate) origin_pt: (f64, f64),
 }
 
+/// A discovered on-screen window, as returned by [`list_app_windows`] (Plan 4's
+/// `list_windows`): the `CGWindowID`, pixel geometry, title, and owning application name —
+/// everything `backend::list_windows` needs to build a `WindowInfo` per window. Same
+/// can't-hold-a-live-`SCWindow`-across-the-completion-boundary rationale as [`WindowMatch`]
+/// (see the module doc); `title`/`application_name` are read out as owned `String`s inside
+/// the completion block for the same reason `WindowMatch`'s fields are plain owned data.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct AppWindow {
+    /// `SCWindow.windowID()` (`CGWindowID`) — becomes `WindowInfo.id`.
+    pub(crate) window_id: u32,
+    /// Window geometry in backing PIXELS, same derivation as [`WindowMatch::geometry`].
+    pub(crate) geometry: WindowGeometry,
+    /// `SCWindow.title()` — `None` when the window has no title (e.g. a borderless
+    /// utility window) or the title wasn't retrievable.
+    pub(crate) title: Option<String>,
+    /// `SCWindow.owningApplication().applicationName()` — becomes `WindowInfo.class`.
+    /// `None` only if the window has no owning application by the time this is read
+    /// (defensive; `list_app_windows` already filters to windows with an owning
+    /// application, since that's how it matches on pid).
+    pub(crate) application_name: Option<String>,
+}
+
 /// Poll `SCShareableContent` roughly every 100ms for the first on-screen window whose
 /// `owningApplication().processID()` is in `pids`, until found or `timeout` elapses.
 /// Multi-window selection (picking among several matches for the same app) is Plan 4;
@@ -200,21 +222,20 @@ pub(crate) fn find_on_screen_window_by_id(
     None
 }
 
-/// Build a [`WindowMatch`] snapshot from a live `SCWindow` + its owning `pid` — the same
-/// `SCContentFilter`/`pointPixelScale`/`contentRect` -> pixel-`WindowGeometry` conversion
-/// [`query_once`]'s completion handler and `capture::capture_window` both need. Factored out
-/// so [`query_once`] and [`query_once_by_id`] can't drift on how a match becomes a
-/// `WindowMatch`.
-fn window_match_from(w: &SCWindow, pid: i32) -> WindowMatch {
+/// Derive a window's pixel geometry, `SCContentFilter` point-to-pixel scale, and POINT
+/// origin from a live `SCWindow` — the `SCContentFilter`/`pointPixelScale`/`contentRect` ->
+/// pixel-`WindowGeometry` conversion `capture::capture_window` also performs for the frame
+/// it produces. Factored out so [`window_match_from`] and [`app_window_from`] can't drift
+/// on how a window becomes a pixel geometry.
+fn window_geometry_and_scale(w: &SCWindow) -> (WindowGeometry, f64, (f64, f64)) {
     // SAFETY: `w` is a live `SCWindow` passed in by a caller that just resolved it from a
     // live `SCShareableContent.windows()` array (see `find_on_screen_window`/
-    // `find_on_screen_window_by_id`); `capture.rs` uses this same initializer on the same
-    // kind of live `SCWindow` — no other preconditions.
+    // `find_on_screen_window_by_id`/[`list_app_windows`]); `capture.rs` uses this same
+    // initializer on the same kind of live `SCWindow` — no other preconditions.
     let filter = unsafe { SCContentFilter::initWithDesktopIndependentWindow(SCContentFilter::alloc(), w) };
-    // SAFETY: `w`/`filter` are live; these are plain property getters with no other
+    // SAFETY: `filter` is live; these are plain property getters with no other
     // preconditions.
-    let (window_id, scale, content_rect) =
-        unsafe { (w.windowID(), filter.pointPixelScale() as f64, filter.contentRect()) };
+    let (scale, content_rect) = unsafe { (filter.pointPixelScale() as f64, filter.contentRect()) };
     let geometry = crate::coords::pixel_geometry_from_content_rect(
         content_rect.origin.x,
         content_rect.origin.y,
@@ -223,7 +244,119 @@ fn window_match_from(w: &SCWindow, pid: i32) -> WindowMatch {
         scale,
     );
     let origin_pt = (content_rect.origin.x, content_rect.origin.y);
+    (geometry, scale, origin_pt)
+}
+
+/// Build a [`WindowMatch`] snapshot from a live `SCWindow` + its owning `pid`. Factored out
+/// so [`query_once`] and [`query_once_by_id`] can't drift on how a match becomes a
+/// `WindowMatch`.
+fn window_match_from(w: &SCWindow, pid: i32) -> WindowMatch {
+    // SAFETY: `w` is live (see `window_geometry_and_scale`'s identical note); a plain
+    // property getter with no other preconditions.
+    let window_id = unsafe { w.windowID() };
+    let (geometry, scale, origin_pt) = window_geometry_and_scale(w);
     WindowMatch { pid, window_id, geometry, scale, origin_pt }
+}
+
+/// Build an [`AppWindow`] snapshot from a live `SCWindow` — [`list_app_windows`]'s
+/// per-window counterpart of [`window_match_from`], reading out title and owning
+/// application name as owned `String`s alongside the same pixel geometry derivation.
+fn app_window_from(w: &SCWindow) -> AppWindow {
+    // SAFETY: `w` is live (see `window_geometry_and_scale`'s identical note); these are
+    // plain property getters with no other preconditions.
+    let window_id = unsafe { w.windowID() };
+    // SAFETY: same as above.
+    let title = unsafe { w.title() }.map(|t| t.to_string());
+    // SAFETY: same as above.
+    let owning_application = unsafe { w.owningApplication() };
+    // SAFETY: `app` is a live `SCRunningApplication` just handed out by `w.owningApplication()`
+    // above; `applicationName` is a plain property getter with no other preconditions.
+    let application_name = owning_application.map(|app| unsafe { app.applicationName() }.to_string());
+    let (geometry, _scale, _origin_pt) = window_geometry_and_scale(w);
+    AppWindow { window_id, geometry, title, application_name }
+}
+
+/// Enumerate every on-screen window owned by one of `pids`, via a single `SCShareableContent`
+/// query (the multi-window counterpart of [`find_window_for_pids`]'s first-match lookup —
+/// Plan 4's `list_windows`). Unlike [`find_window_for_pids`]/[`find_window_by_id`], this does
+/// not `poll_until` retry: it's a one-shot snapshot, and an app legitimately having zero
+/// on-screen windows at some moment is a normal `Ok(vec![])`, not a `Timeout`/`WindowNotFound`
+/// condition worth retrying.
+///
+/// Calls [`crate::ffi::app_kit_init`] first, same as `find_window_for_pids`. Returns a
+/// classified error immediately on a genuine `SCShareableContent` failure (same
+/// `PermissionDenied`/`CaptureFailed` classification as `query_once` — see
+/// [`crate::ffi::classify_null_result`]). A completion handler that never replies within
+/// [`QUERY_TIMEOUT`] is treated as a backend error here (unlike `query_once`'s
+/// poll-loop-friendly `Ok(None)`): this function has no outer retry loop, so silently
+/// returning an empty `Vec` on a wedged handler would be indistinguishable from "the app
+/// really has no windows right now".
+pub(crate) fn list_app_windows(pids: &[i32]) -> Result<Vec<AppWindow>> {
+    crate::ffi::app_kit_init();
+
+    let (tx, rx) = mpsc::channel::<ListReply>();
+    let pids_owned: Vec<i32> = pids.to_vec();
+
+    // The completion handler collects every matching window into owned `AppWindow`s
+    // (plain data, `Send` regardless of what ObjC objects were touched to build it) and
+    // sends the whole `Vec` at once — never a `Retained<SCWindow>` (see module doc).
+    let block = RcBlock::new(move |content_ptr: *mut SCShareableContent, err_ptr: *mut NSError| {
+        if content_ptr.is_null() {
+            let err = crate::ffi::classify_null_result(
+                err_ptr,
+                "SCShareableContent completion handler returned null content and null error",
+            );
+            let _ = tx.send(ListReply::Failed(err));
+            return;
+        }
+        // SAFETY: `content_ptr` was just checked non-null; the framework guarantees it
+        // points to a live `SCShareableContent` for the duration of this callback.
+        let content: &SCShareableContent = unsafe { &*content_ptr };
+        // SAFETY: `windows` is a plain getter on a live `SCShareableContent`; no other
+        // preconditions.
+        let windows: Retained<NSArray<SCWindow>> = unsafe { content.windows() };
+
+        let mut found = Vec::new();
+        for w in windows.iter() {
+            // SAFETY: `w` is a live `SCWindow` yielded by the array; plain property
+            // getters with no other preconditions — see `find_on_screen_window`'s
+            // identical notes.
+            if !unsafe { w.isOnScreen() } {
+                continue;
+            }
+            // SAFETY: same as above.
+            let owning_application = unsafe { w.owningApplication() };
+            let Some(app) = owning_application else { continue };
+            // SAFETY: same as above.
+            let pid = unsafe { app.processID() };
+            if !pids_owned.contains(&pid) {
+                continue;
+            }
+            found.push(app_window_from(&w));
+        }
+        let _ = tx.send(ListReply::Found(found));
+    });
+
+    // SAFETY: `block` matches `getShareableContentExcludingDesktopWindows_onScreenWindowsOnly_completionHandler`'s
+    // documented signature (`*mut SCShareableContent, *mut NSError`, per the generated
+    // binding) — same call `query_once` makes. The call itself has no other
+    // preconditions.
+    unsafe {
+        SCShareableContent::getShareableContentExcludingDesktopWindows_onScreenWindowsOnly_completionHandler(
+            true, true, &block,
+        );
+    }
+
+    match rx.recv_timeout(QUERY_TIMEOUT) {
+        Ok(ListReply::Found(v)) => Ok(v),
+        Ok(ListReply::Failed(e)) => Err(e),
+        Err(mpsc::RecvTimeoutError::Timeout) => Err(GlassError::Backend(
+            "SCShareableContent completion handler did not reply within the query timeout".into(),
+        )),
+        Err(mpsc::RecvTimeoutError::Disconnected) => Err(GlassError::Backend(
+            "SCShareableContent completion handler was dropped without replying".into(),
+        )),
+    }
 }
 
 /// Cap on a single [`query_once`] attempt's wait for its `SCShareableContent` completion
@@ -346,6 +479,14 @@ enum QueryReply {
     Failed(GlassError),
 }
 
+/// [`list_app_windows`]'s completion-block outcome — the multi-window counterpart of
+/// [`QueryReply`], funneled out as the same kind of plain owned data (never a
+/// `Retained<SCWindow>`).
+enum ListReply {
+    Found(Vec<AppWindow>),
+    Failed(GlassError),
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -354,5 +495,11 @@ mod tests {
     fn query_reply_is_send() {
         fn assert_send<T: Send>() {}
         assert_send::<QueryReply>();
+    }
+
+    #[test]
+    fn list_reply_is_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<ListReply>();
     }
 }

--- a/crates/glass-macos/src/scwindow.rs
+++ b/crates/glass-macos/src/scwindow.rs
@@ -5,8 +5,10 @@
 //! completion-handler API proven end-to-end in
 //! `.superpowers/sdd/objc2-spike-report.md` Part A — for the first on-screen window
 //! owned by one of a set of pids ([`find_window_for_pids`], the launched app's process
-//! set) or for the specific on-screen window with a given `CGWindowID`
-//! ([`find_window_by_id`], `MacosPlatform`'s active window once `select_window` has run),
+//! set) or for the specific on-screen window with a given `CGWindowID` that is *also* owned
+//! by one of that same pid set ([`find_window_by_id`], `MacosPlatform`'s active window once
+//! `select_window` has run — the pid scoping closes a silent-wrong-target hole a bare
+//! `CGWindowID` match would otherwise open, since window ids are not namespaced per app),
 //! following `ffi.rs`'s documented async-bridge convention.
 //!
 //! ## Why this returns [`WindowMatch`], not `Retained<SCWindow>`
@@ -38,7 +40,7 @@ use block2::RcBlock;
 use objc2::rc::Retained;
 use objc2::AnyThread;
 use objc2_foundation::{NSArray, NSError};
-use objc2_screen_capture_kit::{SCContentFilter, SCShareableContent, SCWindow};
+use objc2_screen_capture_kit::{SCContentFilter, SCRunningApplication, SCShareableContent, SCWindow};
 
 use glass_core::platform::WindowGeometry;
 use glass_core::{poll_until, GlassError, Result};
@@ -49,9 +51,10 @@ use glass_core::{poll_until, GlassError, Result};
 // `geometry`/`scale`/`origin_pt` are read by `start_app` (via `backend.rs::discover_window`
 // -> `query_once`) and by `send_pointer`/`capture_frame`/`send_key` (via `backend.rs`'s
 // per-call `find_window_for_pids`/`find_window_by_id` resolution); `window_id` is read by
-// `start_app` too (to seed `MacosPlatform::active_window`, Plan 4 Task 1). `pid` stays
-// unread outside construction until Plan 4's `list_windows`.
-#[allow(dead_code)]
+// `start_app` too (to seed `MacosPlatform::active_window`, Plan 4 Task 1). `pid` is read by
+// `send_pointer`/`send_key` (via `resolve_active_window`'s per-call resolution) as the
+// CGEvent focus/AX-scoping target, and by every `find_window_by_id` call site's
+// pid-scoping check (Plan 4 final-review fix 1) — every field is read somewhere.
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct WindowMatch {
     /// The owning process's pid — one of the `pids` passed to `find_window_for_pids`.
@@ -126,26 +129,35 @@ pub(crate) fn find_window_for_pids(pids: &[i32], timeout: Duration) -> Result<Wi
 }
 
 /// Poll `SCShareableContent` roughly every 100ms for the on-screen window whose
-/// `windowID() == window_id`, until found or `timeout` elapses. This is Plan 4's
-/// active-window retargeting lookup: `backend.rs` calls it on every `capture_frame`/
-/// `send_pointer`/`send_key` once `select_window` has set an active `CGWindowID`, in place
-/// of [`find_window_for_pids`]'s first-on-screen-by-pid resolution — see its module doc for
-/// why re-resolving fresh per call (rather than caching a `Retained<SCWindow>`) is the only
-/// safe option.
+/// `windowID() == window_id` AND `owningApplication().processID() ∈ pids`, until found or
+/// `timeout` elapses. This is Plan 4's active-window retargeting lookup: `backend.rs` calls
+/// it on every `capture_frame`/`send_pointer`/`send_key` once `select_window` has set an
+/// active `CGWindowID`, in place of [`find_window_for_pids`]'s first-on-screen-by-pid
+/// resolution — see its module doc for why re-resolving fresh per call (rather than caching
+/// a `Retained<SCWindow>`) is the only safe option.
+///
+/// The `pids` filter (final-review fix 1) closes a silent-wrong-target hole: without it, a
+/// stale/foreign `CGWindowID` — e.g. left over in `MacosPlatform::active_window` after the
+/// windowing system recycles an id, or a bug that stores an id from a window that was never
+/// actually confirmed to belong to this app — would happily match *any* on-screen window
+/// system-wide, and every caller would silently capture/click/type into someone else's
+/// window. Scoping the match to `pids` turns that into a loud [`GlassError::WindowNotFound`]
+/// instead.
 ///
 /// Unlike `find_window_for_pids`'s [`GlassError::Timeout`] (appropriate while waiting for a
 /// brand-new window to first appear at launch), a `window_id` that never turns up here means
-/// a *previously known* window is gone — closed, or the id was never valid — so this returns
-/// [`GlassError::WindowNotFound`] instead, matching the `Platform` contract's
-/// `select_window`/window-op error (`glass_core::platform`'s doc) for exactly that case.
+/// a *previously known* window is gone — closed, no longer owned by `pids`, or the id was
+/// never valid — so this returns [`GlassError::WindowNotFound`] instead, matching the
+/// `Platform` contract's `select_window`/window-op error (`glass_core::platform`'s doc) for
+/// exactly that case.
 ///
 /// Returns a classified [`GlassError::PermissionDenied`]/[`GlassError::CaptureFailed`]
 /// immediately on a genuine `SCShareableContent` failure, same as `find_window_for_pids`.
-pub(crate) fn find_window_by_id(window_id: u32, timeout: Duration) -> Result<WindowMatch> {
+pub(crate) fn find_window_by_id(window_id: u32, pids: &[i32], timeout: Duration) -> Result<WindowMatch> {
     crate::ffi::app_kit_init();
 
     let timeout_ms = timeout.as_millis() as u64;
-    let outcome = poll_until(100, timeout_ms, || query_once_by_id(window_id))?;
+    let outcome = poll_until(100, timeout_ms, || query_once_by_id(window_id, pids))?;
     outcome.value.ok_or(GlassError::WindowNotFound)
 }
 
@@ -185,18 +197,23 @@ pub(crate) fn find_on_screen_window(
     None
 }
 
-/// Find the on-screen `SCWindow` in `content.windows()` whose `windowID() == window_id`,
-/// returning it alongside its owning pid. The `find_window_by_id`-side counterpart of
-/// [`find_on_screen_window`] (which filters by owning pid instead of a specific window):
-/// same on-screen filter, same iteration, so the two lookups can't drift on what "on-screen"
-/// means. Used by [`query_once_by_id`] (which then builds a [`WindowMatch`] snapshot via
-/// [`window_match_from`], the same builder [`query_once`] uses) and by
-/// `capture::capture_window_by_id` (which, like `capture_window`, needs the live `SCWindow`
-/// itself, still inside the same completion-handler callback, to build an
+/// Find the on-screen `SCWindow` in `content.windows()` whose `windowID() == window_id` AND
+/// `owningApplication().processID() ∈ pids`, returning it alongside its owning pid. The
+/// `find_window_by_id`-side counterpart of [`find_on_screen_window`] (which filters by
+/// owning pid alone instead of a specific window + pid set): same on-screen filter, same
+/// iteration, so the two lookups can't drift on what "on-screen" means. The `pids` check
+/// (final-review fix 1) is load-bearing, not defensive: `windowID` alone is not scoped to
+/// any particular app, so without it this would match *any* on-screen window system-wide,
+/// letting a stale/foreign `CGWindowID` silently resolve to someone else's window — see
+/// [`find_window_by_id`]'s doc. Used by [`query_once_by_id`] (which then builds a
+/// [`WindowMatch`] snapshot via [`window_match_from`], the same builder [`query_once`] uses)
+/// and by `capture::capture_window_by_id` (which, like `capture_window`, needs the live
+/// `SCWindow` itself, still inside the same completion-handler callback, to build an
 /// `SCContentFilter` — see [`find_on_screen_window`]'s doc).
 pub(crate) fn find_on_screen_window_by_id(
     content: &SCShareableContent,
     window_id: u32,
+    pids: &[i32],
 ) -> Option<(Retained<SCWindow>, i32)> {
     // SAFETY: `windows` is a plain getter on a live `SCShareableContent`; no other
     // preconditions.
@@ -217,6 +234,9 @@ pub(crate) fn find_on_screen_window_by_id(
         let Some(app) = owning_application else { continue };
         // SAFETY: same as above — a plain property getter.
         let pid = unsafe { app.processID() };
+        if !pids.contains(&pid) {
+            continue;
+        }
         return Some((w, pid));
     }
     None
@@ -258,20 +278,25 @@ fn window_match_from(w: &SCWindow, pid: i32) -> WindowMatch {
     WindowMatch { pid, window_id, geometry, scale, origin_pt }
 }
 
-/// Build an [`AppWindow`] snapshot from a live `SCWindow` — [`list_app_windows`]'s
-/// per-window counterpart of [`window_match_from`], reading out title and owning
-/// application name as owned `String`s alongside the same pixel geometry derivation.
-fn app_window_from(w: &SCWindow) -> AppWindow {
+/// Build an [`AppWindow`] snapshot from a live `SCWindow` + its already-resolved owning
+/// `app` — [`list_app_windows`]'s per-window counterpart of [`window_match_from`], reading
+/// out title and owning application name as owned `String`s alongside the same pixel
+/// geometry derivation. Takes `app` rather than re-deriving it via `w.owningApplication()`
+/// (final-review fix M3): `list_app_windows`'s loop has already called that getter once to
+/// filter by pid, so a second call here would be redundant — and since that filter already
+/// guarantees every `w` passed here has an owning application, `application_name` is always
+/// `Some` (the field stays `Option<String>` to match `AppWindow`'s general shape, matching
+/// `WindowInfo::class`'s own `Option<String>`).
+fn app_window_from(w: &SCWindow, app: &SCRunningApplication) -> AppWindow {
     // SAFETY: `w` is live (see `window_geometry_and_scale`'s identical note); these are
     // plain property getters with no other preconditions.
     let window_id = unsafe { w.windowID() };
     // SAFETY: same as above.
     let title = unsafe { w.title() }.map(|t| t.to_string());
-    // SAFETY: same as above.
-    let owning_application = unsafe { w.owningApplication() };
-    // SAFETY: `app` is a live `SCRunningApplication` just handed out by `w.owningApplication()`
-    // above; `applicationName` is a plain property getter with no other preconditions.
-    let application_name = owning_application.map(|app| unsafe { app.applicationName() }.to_string());
+    // SAFETY: `app` is the live `SCRunningApplication` the caller already resolved via
+    // `w.owningApplication()`; `applicationName` is a plain property getter with no other
+    // preconditions.
+    let application_name = Some(unsafe { app.applicationName() }.to_string());
     let (geometry, _scale, _origin_pt) = window_geometry_and_scale(w);
     AppWindow { window_id, geometry, title, application_name }
 }
@@ -332,7 +357,7 @@ pub(crate) fn list_app_windows(pids: &[i32]) -> Result<Vec<AppWindow>> {
             if !pids_owned.contains(&pid) {
                 continue;
             }
-            found.push(app_window_from(&w));
+            found.push(app_window_from(&w, &app));
         }
         let _ = tx.send(ListReply::Found(found));
     });
@@ -425,10 +450,11 @@ pub(crate) fn query_once(pids: &[i32]) -> Result<Option<WindowMatch>> {
 
 /// [`find_window_by_id`]'s per-attempt round trip — identical shape to [`query_once`] (same
 /// `RcBlock` -> `mpsc` bridge, same `QUERY_TIMEOUT` cap, same error classification) but
-/// matching on a specific `window_id` via [`find_on_screen_window_by_id`] instead of an
-/// owning-pid set.
-fn query_once_by_id(window_id: u32) -> Result<Option<WindowMatch>> {
+/// matching on a specific `window_id` (scoped to `pids`, final-review fix 1) via
+/// [`find_on_screen_window_by_id`] instead of an owning-pid set alone.
+fn query_once_by_id(window_id: u32, pids: &[i32]) -> Result<Option<WindowMatch>> {
     let (tx, rx) = mpsc::channel::<QueryReply>();
+    let pids_owned: Vec<i32> = pids.to_vec();
 
     // Same completion-handler contract as `query_once`'s block: only ever sends the plain
     // owned `QueryReply`, never a `Retained<SCWindow>` (see module doc).
@@ -445,7 +471,7 @@ fn query_once_by_id(window_id: u32) -> Result<Option<WindowMatch>> {
         // points to a live `SCShareableContent` for the duration of this callback.
         let content: &SCShareableContent = unsafe { &*content_ptr };
 
-        let Some((w, pid)) = find_on_screen_window_by_id(content, window_id) else {
+        let Some((w, pid)) = find_on_screen_window_by_id(content, window_id, &pids_owned) else {
             let _ = tx.send(QueryReply::NotFound);
             return;
         };

--- a/crates/glass-macos/tests/windows.rs
+++ b/crates/glass-macos/tests/windows.rs
@@ -1,0 +1,446 @@
+//! Mac-gated window-management integration test — the first real-window proof of
+//! `list_windows`/`select_window`/`window(op)` end-to-end, and in particular of the private
+//! `CGWindowID` <-> `AXUIElement` correlation (`axwindow::ax_window_for_cgwindowid`'s private
+//! `_AXUIElementGetWindow` call, contained + geometry-fallback — see `axwindow.rs`'s module
+//! doc). Every earlier Plan 4 task exercised this only against a *single* on-screen window,
+//! where "the app's only window" and "the correlated window" happen to be the same thing
+//! even if the correlation itself were silently broken. This test launches the extended
+//! `fixture/quadrants.swift` with TWO windows and drives ops against the *non-default* one
+//! (`select_window` to a specific `CGWindowID`, then `Move`/`Resize`/`Geometry`/
+//! `capture_frame` against it) — a wrong correlation would move/resize/capture the WRONG
+//! window, which the assertions below would catch (the moved/resized window's own geometry
+//! reads back wrong, or the captured pixels show the other window's palette).
+//!
+//! **`harness = false`** (see `Cargo.toml`'s `[[test]] name = "windows"` entry) for the exact
+//! same reason as `tests/capture.rs`/`tests/input.rs`: `start_app`/`list_windows`/`window`/
+//! `capture_frame` all reach `ffi::app_kit_init()`, which requires the process's TRUE main
+//! thread (`objc2::MainThreadMarker`) — libtest's per-`#[test]` worker threads can't provide
+//! that, so this file defines its own `fn main()` instead.
+//!
+//! Needs the same two TCC grants as `tests/input.rs` (Screen Recording for window discovery/
+//! capture, Accessibility for the AX window ops), held by the signed, granted `GlassProbe.app`
+//! bundle on this project's dev Mac (`mini`) — same granted-run procedure as `capture.rs`/
+//! `input.rs`: copy this built test binary into the bundle, re-sign, run via a `gui/501`
+//! LaunchAgent so it inherits the bundle's grants. See `.superpowers/sdd/objc2-spike-report.md`
+//! and `.superpowers/sdd/task-6-brief.md` for the exact procedure, and `scripts/test-macos.sh`'s
+//! `GLASS_MACOS_ONBOX` gate for how this fits the test scripts.
+//!
+//! **Additional runtime precondition beyond the two TCC grants: `mini`'s screen session must
+//! not be locked** — same secure-input restriction `tests/input.rs`'s module doc documents in
+//! detail (a locked screen silently drops synthetic input and pins frontmost-app queries to
+//! `loginwindow`). `select_window`/`window(op)` both activate/raise the target window, so this
+//! test needs an unlocked screen exactly like `input.rs` does.
+//!
+//! If a window op below fails, the failure message names which op and what geometry it read
+//! back; additionally, watch this run's stderr for `axwindow.rs`'s own diagnostic
+//! (`"_AXUIElementGetWindow errored on every AX window for pid ...; falling back to geometry
+//! match..."`) — its PRESENCE means the private symbol failed and the geometry fallback
+//! engaged for this run; its ABSENCE means the private correlation itself succeeded.
+
+#[cfg(not(target_os = "macos"))]
+fn main() {
+    println!("skipped (not macOS)");
+}
+
+#[cfg(target_os = "macos")]
+fn main() {
+    macos_main::run();
+}
+
+#[cfg(target_os = "macos")]
+mod macos_main {
+    use std::collections::HashSet;
+    use std::path::PathBuf;
+    use std::process::Command;
+    use std::time::Duration;
+
+    use glass_core::platform::{WindowGeometry, WindowInfo, WindowOp};
+    use glass_core::{AppSpec, Platform, SandboxLevel};
+    use glass_macos::MacosPlatform;
+
+    /// Settle after `start_app` before the first `list_windows` — both fixture windows need
+    /// a moment to finish appearing/painting (mirrors `capture.rs`/`input.rs`'s identical
+    /// fixed sleep for the single-window case).
+    const STARTUP_SETTLE: Duration = Duration::from_millis(500);
+
+    /// Settle after `window(Resize)` before `capture_frame(None)`. Discovered empirically:
+    /// `window(Resize)`'s own read-back goes through `AXUIElement` (synchronous, and already
+    /// reflects the new size immediately), but `capture_frame`'s `SCShareableContent`/
+    /// ScreenCaptureKit path lags slightly behind the on-screen compositor catching up to a
+    /// just-resized window — capturing with zero delay observed a captured `Frame` still
+    /// reporting the PRE-resize dimensions, with pixels beyond the window's actual new bounds
+    /// reading back as transparent black. Generous relative to `input.rs`'s 400ms
+    /// `ACTION_SETTLE` for the same class of "let the window system catch up" reason.
+    const RESIZE_SETTLE: Duration = Duration::from_millis(500);
+
+    /// `WindowOp::Move` target, in global screen PIXELS — comfortably away from (0,0) and
+    /// from the fixture's own default window positions (primary at `.zero`, secondary offset
+    /// by (120,120) points — see `quadrants.swift`'s module doc), so a successful move is an
+    /// unambiguous, large positional change rather than a coincidental near-match.
+    const MOVE_TARGET: (i32, i32) = (300, 200);
+    /// Tolerance (px) for comparing a read-back position against [`MOVE_TARGET`]. Wider than
+    /// `backend.rs`'s own internal `WINDOW_OP_TOLERANCE_PX` (8px, already enforced inside
+    /// `window(Move)` itself — a `window(Move)` call that returns `Ok` already passed that
+    /// check) to also absorb the independent `SCShareableContent`-vs-`AXUIElement` geometry
+    /// discrepancy `axwindow.rs`'s own `FALLBACK_TOLERANCE_PX` (8px) documents, since
+    /// `select_window`'s pre-move geometry check below compares across exactly that boundary.
+    const MOVE_TOLERANCE_PX: i32 = 10;
+    /// Tolerance (px) for [`geometry_close`]'s comparison of `select_window`'s returned
+    /// geometry (from a fresh `AXUIElement` read) against `list_windows`'s own geometry (from
+    /// `SCShareableContent`) for the same window — the same two-source discrepancy
+    /// `MOVE_TOLERANCE_PX` absorbs, at rest (no move/resize involved).
+    const SELECT_TOLERANCE_PX: i32 = 10;
+    /// `WindowOp::Resize` target, in PIXELS — both dimensions genuinely different from the
+    /// fixture's 400x400 default (width grows, height shrinks), so a successful resize is an
+    /// unambiguous change in both axes.
+    const RESIZE_TARGET: (u32, u32) = (550, 300);
+    /// Minimum per-axis change (px) for [`size_moved_toward`] to count a `Resize` as having
+    /// done anything at all — well above `backend.rs`'s own 8px no-op tolerance, so this only
+    /// rejects a resize that visibly did nothing, not rounding noise.
+    const RESIZE_CHANGE_THRESHOLD_PX: i64 = 20;
+
+    /// Per-channel RGBA tolerance for a sampled pixel vs. its expected known color — same
+    /// value and rationale as `capture.rs`'s identical constant.
+    const PIXEL_TOLERANCE: i32 = 40;
+    /// `quadrants.swift`'s `secondaryPalette` ("glass-fixture-2"'s quadrant colors) — see that
+    /// file's module doc. Used to confirm `capture_frame(None)` captured the SELECTED
+    /// (secondary) window, not the primary one, by pixel color alone.
+    const SECONDARY_TOP_LEFT: [u8; 4] = [0, 255, 255, 255]; // cyan
+    const SECONDARY_TOP_RIGHT: [u8; 4] = [255, 0, 255, 255]; // magenta
+    const SECONDARY_BOTTOM_LEFT: [u8; 4] = [255, 255, 0, 255]; // yellow
+    const SECONDARY_BOTTOM_RIGHT: [u8; 4] = [0, 0, 0, 255]; // black
+
+    /// Print a clear failure message and exit non-zero — the `harness = false` contract (no
+    /// libtest to format a panic for us).
+    fn fail(msg: impl AsRef<str>) -> ! {
+        eprintln!("FAIL: {}", msg.as_ref());
+        std::process::exit(1);
+    }
+
+    /// Unwrap a `Result`, failing the whole test process with `context` prefixed to the error
+    /// on `Err`. Only safe to use before a fixture process has been spawned — see
+    /// `capture.rs`'s identical helper for why anything after that must go through
+    /// `try_expect`/`run_checks` instead.
+    fn expect<T, E: std::fmt::Display>(result: Result<T, E>, context: &str) -> T {
+        match result {
+            Ok(v) => v,
+            Err(e) => fail(format!("{context}: {e}")),
+        }
+    }
+
+    /// Like `expect`, but returns the error as a `String` instead of exiting the process — so
+    /// a failure raised inside `run_checks` (fixture already spawned) still flows back to
+    /// `run()`, which reaches `stop_app()` before the process exits.
+    fn try_expect<T, E: std::fmt::Display>(result: Result<T, E>, context: &str) -> Result<T, String> {
+        result.map_err(|e| format!("{context}: {e}"))
+    }
+
+    fn swiftc_available() -> bool {
+        Command::new("swiftc").arg("--version").output().is_ok_and(|o| o.status.success())
+    }
+
+    /// Build `fixture/quadrants.swift` to a fresh temp path — identical to `capture.rs`'s/
+    /// `input.rs`'s `build_fixture`, just a distinct temp-dir name so a parallel run of all
+    /// three tests never collides.
+    fn build_fixture() -> (PathBuf, PathBuf) {
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let source = manifest_dir.join("fixture").join("quadrants.swift");
+        if !source.is_file() {
+            fail(format!("fixture source not found at {}", source.display()));
+        }
+
+        let out_dir = std::env::temp_dir().join(format!("glass-macos-windows-test-{}", std::process::id()));
+        expect(std::fs::create_dir_all(&out_dir), "creating fixture build dir");
+        let out_bin = out_dir.join("quadrants");
+
+        let status = Command::new("swiftc")
+            .arg("-O")
+            .arg("-parse-as-library")
+            .arg(&source)
+            .arg("-o")
+            .arg(&out_bin)
+            .status();
+        match status {
+            Ok(s) if s.success() => {}
+            Ok(s) => fail(format!("swiftc exited with {s} building {}", source.display())),
+            Err(e) => fail(format!("failed to run swiftc: {e}")),
+        }
+        (out_bin, out_dir)
+    }
+
+    /// Number of `windows` entries with `active == true`.
+    fn count_active(windows: &[WindowInfo]) -> usize {
+        windows.iter().filter(|w| w.active).count()
+    }
+
+    /// True if every field of `a`/`b` is within `tolerance` px of the other — the same shape
+    /// as `axwindow.rs`'s internal `within_tolerance`, reimplemented here (rather than
+    /// depending on that `pub(crate)` helper from a separate test binary) for comparing a
+    /// `list_windows`-reported geometry against a `select_window`/`window(op)`-reported one.
+    fn geometry_close(a: &WindowGeometry, b: &WindowGeometry, tolerance: i32) -> bool {
+        (a.x - b.x).abs() <= tolerance
+            && (a.y - b.y).abs() <= tolerance
+            && (a.width as i32 - b.width as i32).abs() <= tolerance
+            && (a.height as i32 - b.height as i32).abs() <= tolerance
+    }
+
+    /// True if `pos` is within `tolerance` px of `target` on both axes.
+    fn position_close(pos: (i32, i32), target: (i32, i32), tolerance: i32) -> bool {
+        (pos.0 - target.0).abs() <= tolerance && (pos.1 - target.1).abs() <= tolerance
+    }
+
+    /// True if a `Resize` visibly changed the window's size ([`RESIZE_CHANGE_THRESHOLD_PX`]
+    /// on at least one axis) AND the change moved the size closer to (or exactly to)
+    /// `target`, rather than further away — tolerant of macOS clamping to an intermediate
+    /// size (see `backend.rs`'s `resize_was_refused` doc for the same "clamped, not exact"
+    /// contract), while still catching a resize that did nothing or moved the wrong way.
+    fn size_moved_toward(before: &WindowGeometry, after: &WindowGeometry, target: (u32, u32)) -> bool {
+        let changed = (after.width as i64 - before.width as i64).abs() > RESIZE_CHANGE_THRESHOLD_PX
+            || (after.height as i64 - before.height as i64).abs() > RESIZE_CHANGE_THRESHOLD_PX;
+        if !changed {
+            return false;
+        }
+        let dist_before =
+            (before.width as i64 - target.0 as i64).abs() + (before.height as i64 - target.1 as i64).abs();
+        let dist_after =
+            (after.width as i64 - target.0 as i64).abs() + (after.height as i64 - target.1 as i64).abs();
+        dist_after <= dist_before
+    }
+
+    /// Fetch pixel `(x, y)` from a tightly-packed RGBA8 `Frame` buffer — identical to
+    /// `capture.rs`'s helper of the same name.
+    fn pixel_at(pixels: &[u8], frame_width: u32, x: u32, y: u32) -> [u8; 4] {
+        let idx = (y as usize * frame_width as usize + x as usize) * 4;
+        [pixels[idx], pixels[idx + 1], pixels[idx + 2], pixels[idx + 3]]
+    }
+
+    fn close(a: [u8; 4], b: [u8; 4]) -> bool {
+        a.iter().zip(b.iter()).all(|(x, y)| (*x as i32 - *y as i32).abs() <= PIXEL_TOLERANCE)
+    }
+
+    /// Assert the pixel at `(x, y)` in a tightly-packed RGBA8 buffer is within tolerance of
+    /// `expected` — identical shape to `capture.rs`'s helper of the same name.
+    fn assert_pixel(
+        pixels: &[u8],
+        frame_width: u32,
+        x: u32,
+        y: u32,
+        expected: [u8; 4],
+        label: &str,
+    ) -> Result<(), String> {
+        let got = pixel_at(pixels, frame_width, x, y);
+        if !close(got, expected) {
+            return Err(format!(
+                "{label} pixel at ({x},{y}) = {got:?}, expected ~{expected:?} (tolerance {PIXEL_TOLERANCE})"
+            ));
+        }
+        Ok(())
+    }
+
+    /// The whole `start_app` -> list/select/move/resize/capture -> assertion flow. Returns
+    /// `Err` instead of exiting the process on any failure, so `run()` can always reach
+    /// `platform.stop_app()` first — see `capture.rs`'s identically-shaped `run_checks` for
+    /// why a bare `std::process::exit` from in here would leak the spawned fixture process.
+    fn run_checks(platform: &mut MacosPlatform, fixture_bin: &std::path::Path) -> Result<(), String> {
+        let spec = AppSpec {
+            build: None,
+            run: vec![fixture_bin.to_string_lossy().into_owned(), "--windows".into(), "2".into()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 8000,
+            sandbox: SandboxLevel::Off,
+            a11y: false,
+        };
+
+        let geometry = try_expect(platform.start_app(&spec), "start_app")?;
+        println!("started 2-window fixture; initial active-window geometry: {geometry:?}");
+        std::thread::sleep(STARTUP_SETTLE);
+
+        // --- list_windows: both windows present, distinct ids, exactly one active. ---
+        let windows = try_expect(platform.list_windows(), "list_windows (initial)")?;
+        println!("list_windows (initial): {windows:?}");
+        if windows.len() < 2 {
+            return Err(format!("expected >=2 windows, got {}: {windows:?}", windows.len()));
+        }
+        let ids: HashSet<_> = windows.iter().map(|w| w.id).collect();
+        if ids.len() != windows.len() {
+            return Err(format!("window ids are not all distinct: {windows:?}"));
+        }
+        if count_active(&windows) != 1 {
+            return Err(format!(
+                "expected exactly one active window, got {}: {windows:?}",
+                count_active(&windows)
+            ));
+        }
+        let primary = windows
+            .iter()
+            .find(|w| w.title.as_deref() == Some("glass-fixture"))
+            .ok_or_else(|| format!("no window titled 'glass-fixture' in {windows:?}"))?;
+        let secondary = windows
+            .iter()
+            .find(|w| w.title.as_deref() == Some("glass-fixture-2"))
+            .ok_or_else(|| format!("no window titled 'glass-fixture-2' in {windows:?}"))?;
+        println!("found both fixture windows: primary={primary:?} secondary={secondary:?}");
+        if secondary.active {
+            return Err(format!(
+                "expected 'glass-fixture-2' to NOT be the initially active window (test needs to \
+                 select a non-active window to exercise retargeting): {secondary:?}"
+            ));
+        }
+        if !primary.active {
+            return Err(format!(
+                "expected 'glass-fixture' to be the initially active window (start_app's \
+                 first-window-discovered contract): {primary:?}"
+            ));
+        }
+        let secondary_id = secondary.id;
+        let secondary_geometry = secondary.geometry.clone();
+
+        // --- select_window(secondary.id): becomes active, geometry matches the listed
+        // window's own geometry (via a completely different lookup path — SCShareableContent
+        // for the list, AXUIElement for the select — so agreement here already exercises the
+        // CGWindowID<->AXUIElement correlation once). ---
+        let selected_geom =
+            try_expect(platform.select_window(secondary_id), "select_window(glass-fixture-2)")?;
+        println!("select_window(glass-fixture-2) -> {selected_geom:?}");
+        if !geometry_close(&selected_geom, &secondary_geometry, SELECT_TOLERANCE_PX) {
+            return Err(format!(
+                "select_window returned geometry {selected_geom:?}, expected within \
+                 {SELECT_TOLERANCE_PX}px of the listed window's own geometry {secondary_geometry:?} -- \
+                 check stderr above for _AXUIElementGetWindow/geometry-fallback diagnostics \
+                 (a wrong correlation would resolve to the WRONG AXUIElement here)"
+            ));
+        }
+
+        let windows_after_select = try_expect(platform.list_windows(), "list_windows (after select)")?;
+        println!("list_windows (after select): {windows_after_select:?}");
+        let now_selected = windows_after_select
+            .iter()
+            .find(|w| w.id == secondary_id)
+            .ok_or_else(|| {
+                format!("selected window {secondary_id:?} missing from list_windows: {windows_after_select:?}")
+            })?;
+        if !now_selected.active {
+            return Err(format!(
+                "expected glass-fixture-2 to be active after select_window: {windows_after_select:?}"
+            ));
+        }
+        if count_active(&windows_after_select) != 1 {
+            return Err(format!(
+                "expected exactly one active window after select, got {}: {windows_after_select:?}",
+                count_active(&windows_after_select)
+            ));
+        }
+        println!("select_window OK: glass-fixture-2 is now the sole active window");
+
+        // --- window(Move) on the selected (non-first) window. ---
+        let move_op = WindowOp::Move { x: MOVE_TARGET.0, y: MOVE_TARGET.1 };
+        let moved = try_expect(platform.window(&move_op), "window(Move)")?;
+        println!("window(Move{{{},{}}}) -> {moved:?}", MOVE_TARGET.0, MOVE_TARGET.1);
+        if !position_close((moved.x, moved.y), MOVE_TARGET, MOVE_TOLERANCE_PX) {
+            return Err(format!(
+                "window did not move to ~{MOVE_TARGET:?} (within {MOVE_TOLERANCE_PX}px); backend \
+                 reports ({},{}) -- check stderr above for _AXUIElementGetWindow/geometry-fallback \
+                 diagnostics",
+                moved.x, moved.y
+            ));
+        }
+        let geom_after_move = try_expect(platform.window(&WindowOp::Geometry), "window(Geometry) after Move")?;
+        println!("window(Geometry) after Move -> {geom_after_move:?}");
+        if !position_close((geom_after_move.x, geom_after_move.y), MOVE_TARGET, MOVE_TOLERANCE_PX) {
+            return Err(format!(
+                "window(Geometry) after Move disagrees with the Move op's own return: \
+                 {geom_after_move:?} vs target {MOVE_TARGET:?}"
+            ));
+        }
+        println!(
+            "window(Move) OK: window is at ({},{}), target was {MOVE_TARGET:?}",
+            geom_after_move.x, geom_after_move.y
+        );
+
+        // --- window(Resize) on the selected window: tolerant of macOS clamping — assert it
+        // changed toward the target, not exactly reached it. ---
+        let before_resize = geom_after_move;
+        let resize_op = WindowOp::Resize { width: RESIZE_TARGET.0, height: RESIZE_TARGET.1 };
+        let resized = try_expect(platform.window(&resize_op), "window(Resize)")?;
+        println!("window(Resize{{{},{}}}) -> {resized:?}", RESIZE_TARGET.0, RESIZE_TARGET.1);
+        if !size_moved_toward(&before_resize, &resized, RESIZE_TARGET) {
+            return Err(format!(
+                "resize did not move toward {RESIZE_TARGET:?}: before={before_resize:?}, \
+                 after={resized:?} -- check stderr above for _AXUIElementGetWindow/geometry-fallback \
+                 diagnostics"
+            ));
+        }
+        println!(
+            "window(Resize) OK: {}x{} -> {}x{} (target {}x{})",
+            before_resize.width, before_resize.height, resized.width, resized.height, RESIZE_TARGET.0, RESIZE_TARGET.1
+        );
+        std::thread::sleep(RESIZE_SETTLE);
+
+        // --- capture_frame(None): must capture the SELECTED (secondary) window — confirmed
+        // by its distinct quadrant palette, not the primary window's. ---
+        let frame = try_expect(platform.capture_frame(None), "capture_frame(None)")?;
+        println!("captured {}x{} frame of the selected window", frame.width, frame.height);
+        if frame.width < 2 || frame.height < 2 {
+            return Err(format!("captured frame too small to sample quadrants: {}x{}", frame.width, frame.height));
+        }
+        let (fw, fh) = (frame.width, frame.height);
+        let (qx0, qx1) = (fw / 4, fw * 3 / 4);
+        let (qy0, qy1) = (fh / 4, fh * 3 / 4);
+        assert_pixel(&frame.pixels, fw, qx0, qy0, SECONDARY_TOP_LEFT, "selected-window top-left")?;
+        assert_pixel(&frame.pixels, fw, qx1, qy0, SECONDARY_TOP_RIGHT, "selected-window top-right")?;
+        assert_pixel(&frame.pixels, fw, qx0, qy1, SECONDARY_BOTTOM_LEFT, "selected-window bottom-left")?;
+        assert_pixel(&frame.pixels, fw, qx1, qy1, SECONDARY_BOTTOM_RIGHT, "selected-window bottom-right")?;
+        println!(
+            "capture_frame OK: captured frame matches glass-fixture-2's distinct palette, not \
+             glass-fixture's -- confirms capture followed the select_window retarget"
+        );
+
+        Ok(())
+    }
+
+    pub(super) fn run() {
+        if !swiftc_available() {
+            println!("skipped (no swiftc)");
+            return;
+        }
+
+        let (fixture_bin, fixture_dir) = build_fixture();
+        println!("built fixture at {}", fixture_bin.display());
+
+        let mut platform = match MacosPlatform::new() {
+            Ok(p) => p,
+            Err(e) => {
+                let _ = std::fs::remove_dir_all(&fixture_dir);
+                fail(format!(
+                    "MacosPlatform::new() (Screen Recording / Accessibility grant missing?): {e}"
+                ));
+            }
+        };
+
+        let result = run_checks(&mut platform, &fixture_bin);
+
+        // Reached regardless of outcome, and BEFORE any process::exit below — see
+        // capture.rs's/input.rs's identical cleanup ordering for why this must run before
+        // any exit (stop_app is idempotent/infallible-today, and this is what guarantees the
+        // fixture's `quadrants` process — now potentially TWO windows' worth of it, still one
+        // process — never survives a failed run).
+        let stop_result = platform.stop_app();
+        let _ = std::fs::remove_dir_all(&fixture_dir);
+
+        match result {
+            Ok(()) => {
+                expect(stop_result, "stop_app");
+                println!("WINDOW_INTEGRATION_PASS");
+                std::process::exit(0);
+            }
+            Err(msg) => {
+                if let Err(e) = stop_result {
+                    eprintln!("(additionally) stop_app failed: {e}");
+                }
+                fail(msg);
+            }
+        }
+    }
+}

--- a/scripts/test-macos.sh
+++ b/scripts/test-macos.sh
@@ -41,4 +41,13 @@ if [[ "${GLASS_MACOS_ONBOX:-0}" == "1" ]]; then
   # .superpowers/sdd/task-6-brief.md).
   echo "GLASS_MACOS_ONBOX=1: building the input integration test binary..."
   cargo test -p glass-macos --test input --no-run
+
+  # Same story again, for crates/glass-macos/tests/windows.rs (the list_windows/
+  # select_window/window(op) end-to-end proof, incl. the private CGWindowID<->AXUIElement
+  # correlation) — building here just confirms it compiles and links; the granted run needs
+  # both TCC grants (same as `input` above) plus an unlocked screen session, so it happens
+  # out-of-band via the same GlassProbe.app LaunchAgent procedure (see
+  # .superpowers/sdd/task-6-brief.md).
+  echo "GLASS_MACOS_ONBOX=1: building the window integration test binary..."
+  cargo test -p glass-macos --test windows --no-run
 fi


### PR DESCRIPTION
Fourth increment of the macOS `Platform` backend: **window management** — enumerate, select, and focus/move/resize/measure windows. Completes **build → see → interact → manage**. (Plans 1–3 landed the crate, capture, and input.)

## What's here
- **`list_windows`** (`scwindow.rs`): enumerate the app's on-screen windows via `SCShareableContent` by pid → `WindowInfo` (id, title, class, geometry in pixels, active).
- **`select_window`** (`backend.rs`): sets the active window (a `CGWindowID`) that capture *and* input retarget to — **pid-scoped**, so a stale/foreign id fails closed with `WindowNotFound` rather than silently operating on another app's window.
- **`window(op)`** (`axwindow.rs` + `backend.rs`): Focus / Move / Resize / Geometry via `AXUIElement`. Coordinates are physical pixels at the boundary, converted to AX points via the display scale. Move/Resize read back and error on refusal (tolerating legitimate macOS size clamping).
- **`CGWindowID` ↔ `AXUIElement` correlation**: the private `_AXUIElementGetWindow` (contained in one module, version-fragility noted, with a geometry-match fallback so a private-symbol break degrades rather than bricks). CF memory via `CFRetained`; every `unsafe` block is `// SAFETY:`-documented.
- **Multi-window fixture + integration test**: the Cocoa fixture opens a 2nd window; a `harness = false` test lists ≥2 windows, selects the non-first one, moves/resizes it, and captures it — exercising the correlation (and, under a test env var, the fallback) for real.

## Notes
- Window management requires Accessibility (preflighted) + an unlocked, awake session (macOS suppresses AX/synthetic input while the display is asleep/locked).
- An `SCShareableContent` geometry-cache lag after an AX resize is handled with a settle in the test; worker-thread main-thread marshaling + glass-mcp wiring remain a follow-up.

## Verification
- Linux: `cargo build/clippy/test --workspace --locked` green.
- macOS 26.5 (Apple Silicon): `clippy -D warnings` clean; 68 unit tests; granted integration tests pass — window (list/select/move/resize on a non-first window), the geometry fallback (forced), and capture+input regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
