### PR TITLE
feat(macos): drive macOS apps through glass-mcp — backend wiring, signed-app run model, CI (Plan 5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,27 @@ jobs:
       - run: cargo build  -p glass-macos --locked
       - run: cargo clippy -p glass-macos --all-targets --locked -- -D warnings
       - run: ./scripts/test-macos.sh
+      # glass-mcp is the shipped binary; only this job can build/lint/run its
+      # cfg(target_os = "macos") wiring (Cargo.toml's macos dep, lib.rs's "macos" backend
+      # arm + default_backend). Capture/input tools need a granted, WindowServer-connected
+      # session the runner doesn't have, so this stays at build/lint/headless-boot — the
+      # granted checks run on-box (see docs/running-on-macos.md).
+      - run: cargo build  -p glass-mcp --locked
+      - run: cargo clippy -p glass-mcp --all-targets --locked -- -D warnings
+      - name: glass-mcp doctor sees the macos backend (TCC grants are absent on the runner)
+        # `doctor` exits non-zero without the Screen Recording/Accessibility grants, which
+        # the runner never has — expected, and NOT gated here (a hard exit-code gate would
+        # permanently red this job). What IS gated: the default backend must still resolve
+        # to "macos", proving the glass-macos wiring actually links and runs.
+        run: |
+          out="$(cargo run -p glass-mcp --locked -- doctor || true)"
+          echo "$out"
+          echo "$out" | grep -q "default backend: macos" || {
+            echo "::error::glass-mcp doctor did not resolve the default backend to macos"
+            exit 1
+          }
+      - name: glass-mcp headless stdio smoke (initialize + tools/list; no grants needed)
+        run: ./scripts/test-macos-mcp.sh
 
   windows:
     name: Windows (build · clippy · test)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,13 +126,18 @@ jobs:
       - run: cargo build  -p glass-macos --locked
       - run: cargo clippy -p glass-macos --all-targets --locked -- -D warnings
       - run: ./scripts/test-macos.sh
-      # glass-mcp is the shipped binary; only this job can build/lint/run its
+      # glass-mcp is the shipped binary; only this job can build/lint/test/run its
       # cfg(target_os = "macos") wiring (Cargo.toml's macos dep, lib.rs's "macos" backend
-      # arm + default_backend). Capture/input tools need a granted, WindowServer-connected
-      # session the runner doesn't have, so this stays at build/lint/headless-boot — the
-      # granted checks run on-box (see docs/running-on-macos.md).
+      # arm + default_backend). `cargo test` here is what actually executes the grants-free
+      # unit tests behind #[cfg(target_os = "macos")] (e.g. doctor's session-state /
+      # backend-resolution tests) — Linux/Windows compile that code out entirely, so this is
+      # the only job that runs it. Capture/input tools still need a granted,
+      # WindowServer-connected session the runner doesn't have, so those stay at
+      # build/lint/headless-boot — the granted checks run on-box (see
+      # docs/running-on-macos.md).
       - run: cargo build  -p glass-mcp --locked
       - run: cargo clippy -p glass-mcp --all-targets --locked -- -D warnings
+      - run: cargo test   -p glass-mcp --locked
       - name: glass-mcp doctor sees the macos backend (TCC grants are absent on the runner)
         # `doctor` exits non-zero without the Screen Recording/Accessibility grants, which
         # the runner never has — expected, and NOT gated here (a hard exit-code gate would

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,8 @@ read logs, diff against baselines, wait-until-stable, and read/drive the accessi
 tree — served over MCP (stdio, or `serve --http`). Backends behind a `Platform` seam: X11
 and Wayland (headless sway) on Linux, Windows (WGC/SendInput), Android (native apps in an AVD
 emulator over `adb`, host-OS-agnostic; clipboard + high-fidelity input via an optional
-on-device companion agent); macOS planned.
+on-device companion agent), macOS (ScreenCaptureKit capture, CGEvent input, AXUIElement
+windows/logs; accessibility reader + sandboxing still to come).
 
 ## Layout
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,6 +1066,7 @@ dependencies = [
  "glass-a11y-windows",
  "glass-android",
  "glass-core",
+ "glass-macos",
  "glass-sandbox-linux",
  "glass-wayland",
  "glass-windows",

--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ user "does this look right?".
 glass drives apps as an external black box, so it works with any native GUI app
 regardless of toolkit or language. It currently has two Linux backends — **X11** and
 **Wayland** ([wlroots](https://gitlab.freedesktop.org/wlroots/wlroots)) — a **Windows** backend ([Windows.Graphics.Capture](https://learn.microsoft.com/en-us/uwp/api/windows.graphics.capture),
-SendInput, UI Automation) — and an **Android** backend (drives native apps in an AVD emulator over `adb`), behind a platform-agnostic core; a **macOS** backend is
-planned. See the per-host setup guides: [Linux](docs/running-on-linux.md) · [Windows](docs/running-on-windows.md) · [macOS](docs/running-on-macos.md).
+SendInput, UI Automation) — an **Android** backend (drives native apps in an AVD emulator over `adb`) — and a
+**macOS** backend (ScreenCaptureKit capture, CGEvent input, AXUIElement windows), behind a platform-agnostic
+core; on macOS, accessibility (semantic addressing) and sandboxing are still planned. See the per-host setup
+guides: [Linux](docs/running-on-linux.md) · [Windows](docs/running-on-windows.md) · [macOS](docs/running-on-macos.md).
 
 ## The loop in practice
 
@@ -324,7 +326,7 @@ across backends — only the setup differs:
   the OS input pipeline — raise it on a slow/loaded host, lower it for speed. See
   [docs/running-on-windows.md](docs/running-on-windows.md).
 - **Android (AVD)** — drives a native Android app in an emulator over `adb`; **host-OS-agnostic**
-  (it shells out to `adb`, so it runs from a Linux or Windows host — macOS is planned). glass manages the
+  (it shells out to `adb`, so it runs from a Linux, Windows, or macOS host). glass manages the
   AVD — attaching to a running emulator or booting a headless one itself — and the VM *is* the
   sandbox, so there's no separate containment step. The app is built (`spec.build`, e.g.
   `./gradlew assembleDebug`) on the host, installed, and launched; `glass_start`'s `run` is the
@@ -367,12 +369,14 @@ Where glass stands by OS. **✓** supported · **◑** partial · **–** not su
 
 | Capability | Linux (X11 + Wayland) | Windows | Android (AVD) | macOS |
 |---|:--:|:--:|:--:|:--:|
-| Capture · input · windows · clipboard · logs | ✓ | ✓ | ✓ † | 🚧 |
+| Capture · input · windows · clipboard · logs | ✓ | ✓ | ✓ † | ◑ ‡ |
 | Accessibility (semantic addressing) | ✓ AT-SPI | ✓ UI Automation | ✓ UIAutomator | 🚧 AX |
 | Containment / sandboxing | ✓ bubblewrap | ✓ Sandboxie Classic | ✓ the emulator VM | 🚧 |
 | Display isolation (app off your desktop) | ✓ headless Xvfb / sway | ◑ virtual display · VM tier | ✓ headless emulator | 🚧 |
 
 † **Android** is emulator-only. Capture, multi-window, input, and logs work over `adb`, and glass manages the AVD (attach a running one, or boot a headless one). **Clipboard, high-fidelity input, and multi-touch gestures (`glass_gesture`)** use the optional on-device agent, and an optional on-device **AccessibilityService** sharpens the a11y tree (Compose) + `set_value` (both in the Android section of your host guide: [Linux](docs/running-on-linux.md) · [Windows](docs/running-on-windows.md) · [macOS](docs/running-on-macos.md)) — without the agent, input falls back to adb's `input` (single-pointer only — no multi-touch) and clipboard is unavailable; without the service, a11y falls back to `uiautomator`. glass is developed and tested against **Android 14 (API 34)**; the `adb` backend assumes no particular version and the optional companions declare an Android 7.0 (API 24) floor (details in your host guide). Window resize/move (apps are full-screen) and physical devices are non-goals.
+
+‡ **macOS** capture, input, windows, and logs are built and CI-tested (ScreenCaptureKit capture, CGEvent input, AXUIElement windows). Clipboard get/set is not yet wired up on macOS.
 
 The per-platform detail — sandboxing levels, display isolation, the accessibility tree —
 lives in the [Containment](#containment--sandboxing), [Backends](#backends), and
@@ -392,7 +396,9 @@ tree, a managed AVD (attach-or-boot), and two optional on-device companions — 
 (clipboard + high-fidelity input) and an AccessibilityService (Compose-rich a11y tree +
 high-fidelity `set_value`), both set up in the [Linux](docs/running-on-linux.md) /
 [Windows](docs/running-on-windows.md) Android guides; it's built and unit-tested in CI and
-validated on-device. **macOS is the one OS backend not yet built.**
+validated on-device. The **macOS** backend (ScreenCaptureKit capture, CGEvent input,
+AXUIElement windows/logs) is built and CI-tested; accessibility (AX) and sandboxing are
+not yet implemented — see [docs/running-on-macos.md](docs/running-on-macos.md).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,8 @@ The application glass launches is sandboxed by default, per OS:
   desktop** (display isolation is in progress); for full isolation, run glass inside a VM
   and reach it over the network transport — see
   [`packaging/windows-sandbox/`](packaging/windows-sandbox).
-- **macOS** — planned; the `sandbox` argument is accepted but not yet enforced.
+- **macOS** — the `sandbox` argument is accepted but not yet enforced; glass-macos ships
+  no containment yet.
 
 Choose the level per launch with `glass_start`'s `sandbox` argument, or globally with
 `GLASS_SANDBOX` (`off` / `default` / `strict`). `glass_doctor` reports what's available.

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -93,10 +93,13 @@ objc2-core-foundation = { version = "0.3.2", default-features = false, features 
     # CFString for AX attribute/action name literals (CFString::from_str — see
     # axwindow.rs's module doc for why these aren't sourced from
     # objc2-application-services's own constants features); CFNumber for
-    # CFBoolean/kCFBooleanTrue (kAXMainAttribute's set value).
+    # CFBoolean/kCFBooleanTrue (kAXMainAttribute's set value; also session.rs's
+    # CGSSessionScreenIsLocked reader). CFDictionary: session.rs reads
+    # CGSessionCopyCurrentDictionary's CFDictionary<CFString, CFType>.
     "CFArray",
     "CFString",
     "CFNumber",
+    "CFDictionary",
 ] }
 # axwindow.rs: AXUIElement (window enumeration/attribute get+set/actions), AXValue
 # (position/size as CGPoint/CGSize), AXError (the shared failure type every AX call

--- a/crates/glass-macos/src/ffi.rs
+++ b/crates/glass-macos/src/ffi.rs
@@ -70,22 +70,46 @@ const TCC_DECLINE_CODE: isize = -3801;
 /// Touch `NSApplication.shared` exactly once to establish this process's connection to
 /// the window server. Without it, ScreenCaptureKit/CoreGraphics calls from a bare CLI
 /// binary abort with `CGS_REQUIRE_INIT` (proven in the objc2 spike; see the module doc
-/// above). Must be called from the main thread; safe to call repeatedly — only the
-/// first call does anything.
+/// above). The *first* call must happen on the main thread; safe to call repeatedly
+/// (including from any other thread) afterward — only the first call does anything.
 ///
-/// The main-thread check runs *before* `call_once`, not inside its closure: a panic
-/// inside `Once::call_once` poisons the `Once` forever (every later call — even a
-/// correct one, from the real main thread — would then panic too with "Once instance
-/// has previously been poisoned"). Checking first means a single off-thread misuse
-/// can't permanently wedge the one-time init for the rest of the process.
+/// The completed-check runs *before* touching `MainThreadMarker` at all: once the
+/// one-time init has actually happened, this becomes a cheap, thread-agnostic no-op, so
+/// every call site that only cares "has `app_kit_init` run yet" (all of them — see below)
+/// can be reached from a non-main worker thread once startup has called
+/// [`init_main_thread`] once. See `.superpowers/sdd/thread0-research.md` and
+/// `.superpowers/sdd/thread0-spike-report.md` for why this is sound: the WindowServer
+/// connection `NSApplication.sharedApplication` establishes is a process-wide, one-time
+/// resource, not a per-thread one.
+///
+/// The main-thread check (for the first, real call) runs *before* `call_once`, not
+/// inside its closure: a panic inside `Once::call_once` poisons the `Once` forever
+/// (every later call — even a correct one, from the real main thread — would then panic
+/// too with "Once instance has previously been poisoned"). Checking first means a single
+/// off-thread misuse can't permanently wedge the one-time init for the rest of the
+/// process.
+///
 /// Called by `backend.rs`'s `discover_window` (before `start_app`'s window-discovery poll
 /// loop) and by `capture::capture_window` (before every capture) — safe and cheap to call
 /// redundantly, since only the first call does anything.
 pub(crate) fn app_kit_init() {
+    if APP_KIT_INIT.is_completed() {
+        return;
+    }
     let mtm = MainThreadMarker::new().expect("app_kit_init must run on the main thread");
     APP_KIT_INIT.call_once(|| {
         let _app = NSApplication::sharedApplication(mtm);
     });
+}
+
+/// Public entry point for a host process (e.g. `glass-mcp`'s `main()`) to perform the
+/// one-time AppKit/WindowServer init from the process's real main thread at startup,
+/// before spawning any worker thread that will later call into `MacosPlatform`. Thin
+/// wrapper over [`app_kit_init`] — see its doc for the full contract. After this returns,
+/// every subsequent `app_kit_init()` call (transitively, every `MacosPlatform` operation)
+/// is a cheap no-op safe to call from any thread.
+pub fn init_main_thread() {
+    app_kit_init();
 }
 
 /// Classify a `null` async ScreenCaptureKit result's paired `NSError`:

--- a/crates/glass-macos/src/ffi.rs
+++ b/crates/glass-macos/src/ffi.rs
@@ -96,6 +96,13 @@ pub(crate) fn app_kit_init() {
     if APP_KIT_INIT.is_completed() {
         return;
     }
+    // TOCTOU between the check above and `MainThreadMarker::new()` below is
+    // theoretical-only under the current call graph: every call site reaches this after
+    // `init_main_thread()` has already run on the process's real main thread before any
+    // worker thread is spawned (see this fn's and `init_main_thread`'s docs), so by the
+    // time a second/concurrent call could race the check, `is_completed()` is already
+    // `true`. A future call site that violated "init before spawning workers" would
+    // surface as a loud panic here (below), not silent UB.
     let mtm = MainThreadMarker::new().expect("app_kit_init must run on the main thread");
     APP_KIT_INIT.call_once(|| {
         let _app = NSApplication::sharedApplication(mtm);

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -27,3 +27,5 @@ mod input;
 mod backend;
 #[cfg(target_os = "macos")]
 pub use backend::MacosPlatform;
+#[cfg(target_os = "macos")]
+pub use ffi::init_main_thread;

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -33,8 +33,8 @@ pub use backend::MacosPlatform;
 pub use ffi::init_main_thread;
 // `doctor`-facing predicates (glass-mcp's doctor.rs): the two TCC grants (+ the exact
 // remedy text `preflight`'s `PermissionDenied` error also uses, so the two can't drift)
-// and whether the console session's display is locked/asleep.
+// and the console session's three-way state (unlocked/locked/no-session-attached).
 #[cfg(target_os = "macos")]
 pub use permissions::{accessibility_granted, accessibility_remedy, screen_recording_granted, screen_recording_remedy};
 #[cfg(target_os = "macos")]
-pub use session::session_locked;
+pub use session::{session_locked, session_state, SessionState};

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -24,8 +24,17 @@ mod process;
 #[cfg(target_os = "macos")]
 mod input;
 #[cfg(target_os = "macos")]
+mod session;
+#[cfg(target_os = "macos")]
 mod backend;
 #[cfg(target_os = "macos")]
 pub use backend::MacosPlatform;
 #[cfg(target_os = "macos")]
 pub use ffi::init_main_thread;
+// `doctor`-facing predicates (glass-mcp's doctor.rs): the two TCC grants (+ the exact
+// remedy text `preflight`'s `PermissionDenied` error also uses, so the two can't drift)
+// and whether the console session's display is locked/asleep.
+#[cfg(target_os = "macos")]
+pub use permissions::{accessibility_granted, accessibility_remedy, screen_recording_granted, screen_recording_remedy};
+#[cfg(target_os = "macos")]
+pub use session::session_locked;

--- a/crates/glass-macos/src/permissions.rs
+++ b/crates/glass-macos/src/permissions.rs
@@ -62,28 +62,44 @@ extern "C" {
     fn AXIsProcessTrusted() -> u8;
 }
 
-/// True if this process holds the Screen Recording grant.
-pub(crate) fn screen_recording_ok() -> bool {
+/// True if this process holds the Screen Recording grant. `pub` (not just
+/// `pub(crate)`) so `glass-mcp`'s `doctor` can report the grant without duplicating
+/// this FFI call.
+pub fn screen_recording_granted() -> bool {
     // SAFETY: `CGPreflightScreenCaptureAccess` is a no-argument C predicate that only
     // reads this process's TCC state; it has no preconditions and no side effects.
     unsafe { CGPreflightScreenCaptureAccess() }
 }
 
 /// True if this process is trusted for Accessibility (AX APIs + CGEvent posting).
-pub(crate) fn accessibility_ok() -> bool {
+/// `pub` for the same reason as [`screen_recording_granted`].
+pub fn accessibility_granted() -> bool {
     // SAFETY: `AXIsProcessTrusted` is a no-argument C predicate over this process's
     // trust state; no preconditions, no side effects. It returns `Boolean` (u8); any
     // nonzero value means trusted.
     unsafe { AXIsProcessTrusted() != 0 }
 }
 
+/// The exact remedy text for a missing Screen Recording grant — shared by
+/// [`preflight`]'s `PermissionDenied` error and `glass-mcp`'s `doctor`, so the two
+/// never drift apart.
+pub fn screen_recording_remedy() -> &'static str {
+    Permission::ScreenRecording.remedy()
+}
+
+/// The exact remedy text for a missing Accessibility grant — see
+/// [`screen_recording_remedy`].
+pub fn accessibility_remedy() -> &'static str {
+    Permission::Accessibility.remedy()
+}
+
 /// Fail fast with an actionable error if either grant is missing. Called at session
 /// start before any capture/input is attempted.
 pub(crate) fn preflight() -> Result<()> {
-    if !screen_recording_ok() {
+    if !screen_recording_granted() {
         return Err(Permission::ScreenRecording.denied());
     }
-    if !accessibility_ok() {
+    if !accessibility_granted() {
         return Err(Permission::Accessibility.denied());
     }
     Ok(())
@@ -98,8 +114,8 @@ mod tests {
     fn preflight_matches_the_two_predicates() {
         // On a box where grants are present, preflight is Ok; where absent, it errors with
         // the missing permission named. Either way the predicates and preflight agree.
-        let sr = screen_recording_ok();
-        let ax = accessibility_ok();
+        let sr = screen_recording_granted();
+        let ax = accessibility_granted();
         match preflight() {
             Ok(()) => assert!(sr && ax, "preflight Ok but a predicate was false"),
             Err(GlassError::PermissionDenied { which, .. }) => {

--- a/crates/glass-macos/src/session.rs
+++ b/crates/glass-macos/src/session.rs
@@ -102,7 +102,11 @@ fn copy_session_dictionary() -> Option<CFRetained<CFDictionary<CFString, CFType>
 /// docs) — everything else means *some* window-server session is attached, so it's
 /// `Locked`/`Unlocked` depending on the key. Apple's documented type for the key is
 /// `CFBoolean`; a `CFNumber` fallback costs nothing and keeps this robust if that ever
-/// changes.
+/// changes. A value of neither type is indeterminate — fail safe as `Locked` rather than
+/// silently reporting `Unlocked`, since `doctor` treats `Unlocked` as "capture/input
+/// should work" and a false-negative there just means a redundant "recover with
+/// `caffeinate -d`" hint, while a false-positive `Unlocked` would hide a real capture/
+/// input failure behind a clean bill of health.
 fn dict_reports_state(dict: Option<&CFDictionary<CFString, CFType>>) -> SessionState {
     let Some(dict) = dict else { return SessionState::NoSession };
     let key = CFString::from_str(SCREEN_IS_LOCKED_KEY);
@@ -112,7 +116,7 @@ fn dict_reports_state(dict: Option<&CFDictionary<CFString, CFType>>) -> SessionS
     } else if let Some(n) = value.downcast_ref::<CFNumber>() {
         n.as_i64().unwrap_or(0) != 0
     } else {
-        false
+        true
     };
     if locked { SessionState::Locked } else { SessionState::Unlocked }
 }
@@ -161,6 +165,20 @@ mod tests {
         let v: &CFType = unsafe { kCFBooleanTrue }.expect("kCFBooleanTrue");
         let d = dict_with("SomeOtherSessionKey", v);
         assert_eq!(dict_reports_state(Some(&d)), SessionState::Unlocked);
+    }
+
+    #[test]
+    fn unrecognized_value_type_fails_safe_as_locked() {
+        // If the key's value is ever neither `CFBoolean` nor `CFNumber` (Apple's
+        // documented type, plus our defensive fallback), that's an indeterminate read —
+        // not evidence the session is unlocked. Fail safe as `Locked` rather than
+        // silently reporting `Unlocked`, which would tell `doctor` capture/input should
+        // work when it's genuinely unknown whether they will. A `CFString` stands in for
+        // "some type we don't recognize" (`CFString` derefs to `CFType`, same as every
+        // other CF type here).
+        let v = CFString::from_str("not a bool or a number");
+        let d = dict_with(SCREEN_IS_LOCKED_KEY, &v);
+        assert_eq!(dict_reports_state(Some(&d)), SessionState::Locked);
     }
 
     #[test]

--- a/crates/glass-macos/src/session.rs
+++ b/crates/glass-macos/src/session.rs
@@ -1,0 +1,116 @@
+//! Session lock / display-sleep detection for `glass doctor` (and any future
+//! capture-time diagnostic). An asleep or locked console display sets the window
+//! server session's `CGSSessionScreenIsLocked` key; ScreenCaptureKit capture and
+//! CGEvent input silently degrade while it's set — with no blank-frame-shaped error of
+//! their own to catch — so `doctor` surfaces it directly rather than leaving an agent
+//! to debug a mysterious capture failure. `caffeinate -d`, run in the console session,
+//! keeps the display awake without needing sudo.
+
+use objc2_core_foundation::{CFBoolean, CFDictionary, CFNumber, CFRetained, CFString, CFType};
+
+const SCREEN_IS_LOCKED_KEY: &str = "CGSSessionScreenIsLocked";
+
+// `CGSessionCopyCurrentDictionary` is a long-standing (if formally undocumented)
+// CoreGraphics entry point — the standard way idle-time/lock-state tools read the
+// window server's session dictionary. `objc2-core-graphics` doesn't bind it, so it's
+// declared manually here, the same way `permissions.rs` declares
+// `CGPreflightScreenCaptureAccess`/`AXIsProcessTrusted`.
+#[link(name = "CoreGraphics", kind = "framework")]
+extern "C" {
+    fn CGSessionCopyCurrentDictionary() -> *mut CFDictionary<CFString, CFType>;
+}
+
+/// True if the console session's display is asleep/locked. This predicate can only
+/// prove "locked" — no session dictionary (no window-server session attached) or a
+/// dictionary missing the key is reported as unlocked (`false`), matching
+/// `CGSSessionScreenIsLocked`'s own convention of only appearing when the screen
+/// actually is locked.
+pub fn session_locked() -> bool {
+    dict_reports_locked(copy_session_dictionary().as_deref())
+}
+
+/// `CGSessionCopyCurrentDictionary`, wrapped in a `CFRetained` so it's released
+/// automatically. The call follows Core Foundation's Copy/Create ownership rule (an
+/// already-retained ref on success), and returns NULL when no window-server session is
+/// attached.
+fn copy_session_dictionary() -> Option<CFRetained<CFDictionary<CFString, CFType>>> {
+    // SAFETY: `CGSessionCopyCurrentDictionary` takes no arguments and only reads
+    // window-server session state; a NULL return is documented behavior (no attached
+    // session), not a precondition violation.
+    let raw = unsafe { CGSessionCopyCurrentDictionary() };
+    let nn = std::ptr::NonNull::new(raw)?;
+    // SAFETY: the "Copy" naming convention means the caller already owns a +1
+    // reference; `CFRetained::from_raw` takes ownership without an extra retain
+    // (matches `axwindow.rs`'s `copy_attribute`).
+    Some(unsafe { CFRetained::from_raw(nn) })
+}
+
+/// Pure: does this session dictionary report the screen as locked? Fully safe (no OS
+/// calls), so it's unit-tested directly against synthetic dictionaries. Apple's
+/// documented type for this key is `CFBoolean`; a `CFNumber` fallback costs nothing and
+/// keeps this robust if that ever changes.
+fn dict_reports_locked(dict: Option<&CFDictionary<CFString, CFType>>) -> bool {
+    let Some(dict) = dict else { return false };
+    let key = CFString::from_str(SCREEN_IS_LOCKED_KEY);
+    let Some(value) = dict.get(&key) else { return false };
+    if let Some(b) = value.downcast_ref::<CFBoolean>() {
+        return b.as_bool();
+    }
+    if let Some(n) = value.downcast_ref::<CFNumber>() {
+        return n.as_i64().unwrap_or(0) != 0;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use objc2_core_foundation::{kCFBooleanFalse, kCFBooleanTrue};
+
+    use super::*;
+
+    fn dict_with(key: &str, value: &CFType) -> CFRetained<CFDictionary<CFString, CFType>> {
+        let k = CFString::from_str(key);
+        CFDictionary::from_slices(&[&k], &[value])
+    }
+
+    #[test]
+    fn no_session_dictionary_is_unlocked() {
+        assert!(!dict_reports_locked(None));
+    }
+
+    #[test]
+    fn missing_key_is_unlocked() {
+        let d = CFDictionary::<CFString, CFType>::empty();
+        assert!(!dict_reports_locked(Some(&d)));
+    }
+
+    #[test]
+    fn true_boolean_value_is_locked() {
+        let v: &CFType = unsafe { kCFBooleanTrue }.expect("kCFBooleanTrue");
+        let d = dict_with(SCREEN_IS_LOCKED_KEY, v);
+        assert!(dict_reports_locked(Some(&d)));
+    }
+
+    #[test]
+    fn false_boolean_value_is_unlocked() {
+        let v: &CFType = unsafe { kCFBooleanFalse }.expect("kCFBooleanFalse");
+        let d = dict_with(SCREEN_IS_LOCKED_KEY, v);
+        assert!(!dict_reports_locked(Some(&d)));
+    }
+
+    #[test]
+    fn an_unrelated_key_does_not_count_as_locked() {
+        let v: &CFType = unsafe { kCFBooleanTrue }.expect("kCFBooleanTrue");
+        let d = dict_with("SomeOtherSessionKey", v);
+        assert!(!dict_reports_locked(Some(&d)));
+    }
+
+    #[test]
+    fn session_locked_runs_the_real_ffi_path_without_panicking() {
+        // Environment-gated like `permissions::preflight_matches_the_two_predicates` —
+        // there's no independent oracle for the live lock state on whatever box this
+        // runs on, so this just proves the real FFI path (framework call + CFRetained +
+        // dict lookup) completes without panicking or leaking a null deref.
+        let _ = session_locked();
+    }
+}

--- a/crates/glass-macos/src/session.rs
+++ b/crates/glass-macos/src/session.rs
@@ -1,10 +1,24 @@
-//! Session lock / display-sleep detection for `glass doctor` (and any future
-//! capture-time diagnostic). An asleep or locked console display sets the window
-//! server session's `CGSSessionScreenIsLocked` key; ScreenCaptureKit capture and
-//! CGEvent input silently degrade while it's set — with no blank-frame-shaped error of
-//! their own to catch — so `doctor` surfaces it directly rather than leaving an agent
-//! to debug a mysterious capture failure. `caffeinate -d`, run in the console session,
-//! keeps the display awake without needing sudo.
+//! Session lock / display-sleep / no-session detection for `glass doctor` (and any
+//! future capture-time diagnostic). An asleep or locked console display sets the
+//! window server session's `CGSSessionScreenIsLocked` key; ScreenCaptureKit capture
+//! and CGEvent input silently degrade while it's set — with no blank-frame-shaped
+//! error of their own to catch — so `doctor` surfaces it directly rather than leaving
+//! an agent to debug a mysterious capture failure. `caffeinate -d`, run in the console
+//! session, keeps the display awake without needing sudo.
+//!
+//! There's a second, distinct failure mode: `CGSessionCopyCurrentDictionary` returns
+//! NULL when there's no active graphical (Aqua) login session on the *console* at
+//! all — before anyone has logged in, after everyone has logged out, or on a headless
+//! boot with auto-login off. Note this is a console-wide fact, not one scoped to the
+//! calling process: it isn't "returns NULL whenever you're on a bare SSH shell" — a
+//! bare-SSH `doctor` run on a box where an account IS logged in at the console still
+//! sees that account's real (locked/unlocked) session dict, same as a GUI-launched
+//! process would (verified by hand: `doctor` run over plain SSH against the `mini`
+//! host, logged-in-but-unattended, reported the true unlocked state, not NoSession).
+//! What NULL actually signals is "capture/input have nothing to attach to *regardless
+//! of who calls this*" — which is not "a present, unlocked session" and so
+//! [`SessionState`] keeps it as its own variant rather than folding it into
+//! `Unlocked` the way an early version of this predicate did.
 
 use objc2_core_foundation::{CFBoolean, CFDictionary, CFNumber, CFRetained, CFString, CFType};
 
@@ -15,18 +29,55 @@ const SCREEN_IS_LOCKED_KEY: &str = "CGSSessionScreenIsLocked";
 // window server's session dictionary. `objc2-core-graphics` doesn't bind it, so it's
 // declared manually here, the same way `permissions.rs` declares
 // `CGPreflightScreenCaptureAccess`/`AXIsProcessTrusted`.
+//
+// The return type is written as the parameterized `*mut CFDictionary<CFString,
+// CFType>` rather than an untyped `*mut c_void` (this is the first FFI declaration in
+// the crate to do so). That's sound: `CFDictionary<K, V>` is a zero-cost phantom
+// wrapper around the same `CFDictionaryRef` C ABI regardless of `K`/`V` — the type
+// parameters only narrow what `objc2-core-foundation`'s safe accessors (`get`,
+// `from_slices`, ...) let Rust assume about the *values*, they don't change the
+// pointer's layout or the call's ABI. `CFType` is `objc2-core-foundation`'s top type
+// (every CF object downcasts to it), so `CFType` values are always a safe upper bound
+// for "whatever this dictionary actually holds" — declaring the precise
+// `CFDictionary<CFString, CFType>` here (instead of a bare pointer + a manual cast at
+// every call site) pushes the unsafety to one declaration instead of many.
 #[link(name = "CoreGraphics", kind = "framework")]
 extern "C" {
     fn CGSessionCopyCurrentDictionary() -> *mut CFDictionary<CFString, CFType>;
 }
 
-/// True if the console session's display is asleep/locked. This predicate can only
-/// prove "locked" — no session dictionary (no window-server session attached) or a
-/// dictionary missing the key is reported as unlocked (`false`), matching
-/// `CGSSessionScreenIsLocked`'s own convention of only appearing when the screen
-/// actually is locked.
+/// The three states the console session can be in. Collapsing all of these to a
+/// single `bool` (as an earlier version of this predicate did) hides
+/// [`SessionState::NoSession`] behind "unlocked", which would let a box with nobody
+/// logged in at the console sail through `doctor` with a clean bill of health while
+/// capture/input silently fail. Keeping the three states distinct lets callers —
+/// [`session_state`]'s only consumer today is `glass-mcp`'s doctor — report each
+/// honestly.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SessionState {
+    /// A console session is logged in and its display is unlocked/awake.
+    Unlocked,
+    /// A console session is logged in but its display is locked/asleep
+    /// (`CGSSessionScreenIsLocked` is set) — recoverable in place with `caffeinate -d`.
+    Locked,
+    /// No account is logged in at the console at all (before first login, after
+    /// logging out, or a headless boot with auto-login off) — capture/input need an
+    /// actual GUI login, not just an unlocked one.
+    NoSession,
+}
+
+/// True if the console session's display is locked/asleep. Convenience wrapper over
+/// [`session_state`] for callers that only care about the locked/not-locked
+/// distinction; note it reports [`SessionState::NoSession`] as "not locked" — callers
+/// that need to tell "nobody's logged in at the console" apart from "logged in and
+/// unlocked" (e.g. `doctor`) should match on [`session_state`] directly instead.
 pub fn session_locked() -> bool {
-    dict_reports_locked(copy_session_dictionary().as_deref())
+    matches!(session_state(), SessionState::Locked)
+}
+
+/// The full three-way session state (see [`SessionState`]).
+pub fn session_state() -> SessionState {
+    dict_reports_state(copy_session_dictionary().as_deref())
 }
 
 /// `CGSessionCopyCurrentDictionary`, wrapped in a `CFRetained` so it's released
@@ -45,21 +96,25 @@ fn copy_session_dictionary() -> Option<CFRetained<CFDictionary<CFString, CFType>
     Some(unsafe { CFRetained::from_raw(nn) })
 }
 
-/// Pure: does this session dictionary report the screen as locked? Fully safe (no OS
-/// calls), so it's unit-tested directly against synthetic dictionaries. Apple's
-/// documented type for this key is `CFBoolean`; a `CFNumber` fallback costs nothing and
-/// keeps this robust if that ever changes.
-fn dict_reports_locked(dict: Option<&CFDictionary<CFString, CFType>>) -> bool {
-    let Some(dict) = dict else { return false };
+/// Pure: map a session dictionary (or its absence) to a [`SessionState`]. Fully safe
+/// (no OS calls), so it's unit-tested directly against synthetic dictionaries and a
+/// missing one. A `None` dictionary is [`SessionState::NoSession`] (see the module
+/// docs) — everything else means *some* window-server session is attached, so it's
+/// `Locked`/`Unlocked` depending on the key. Apple's documented type for the key is
+/// `CFBoolean`; a `CFNumber` fallback costs nothing and keeps this robust if that ever
+/// changes.
+fn dict_reports_state(dict: Option<&CFDictionary<CFString, CFType>>) -> SessionState {
+    let Some(dict) = dict else { return SessionState::NoSession };
     let key = CFString::from_str(SCREEN_IS_LOCKED_KEY);
-    let Some(value) = dict.get(&key) else { return false };
-    if let Some(b) = value.downcast_ref::<CFBoolean>() {
-        return b.as_bool();
-    }
-    if let Some(n) = value.downcast_ref::<CFNumber>() {
-        return n.as_i64().unwrap_or(0) != 0;
-    }
-    false
+    let Some(value) = dict.get(&key) else { return SessionState::Unlocked };
+    let locked = if let Some(b) = value.downcast_ref::<CFBoolean>() {
+        b.as_bool()
+    } else if let Some(n) = value.downcast_ref::<CFNumber>() {
+        n.as_i64().unwrap_or(0) != 0
+    } else {
+        false
+    };
+    if locked { SessionState::Locked } else { SessionState::Unlocked }
 }
 
 #[cfg(test)]
@@ -74,43 +129,53 @@ mod tests {
     }
 
     #[test]
-    fn no_session_dictionary_is_unlocked() {
-        assert!(!dict_reports_locked(None));
+    fn null_dict_is_no_session() {
+        // The NULL-dict case: nobody logged in at the console at all — distinct from
+        // a present-but-unlocked session (see the module docs for why this is a
+        // console-wide fact, not a "ran over SSH" one).
+        assert_eq!(dict_reports_state(None), SessionState::NoSession);
     }
 
     #[test]
     fn missing_key_is_unlocked() {
         let d = CFDictionary::<CFString, CFType>::empty();
-        assert!(!dict_reports_locked(Some(&d)));
+        assert_eq!(dict_reports_state(Some(&d)), SessionState::Unlocked);
     }
 
     #[test]
     fn true_boolean_value_is_locked() {
         let v: &CFType = unsafe { kCFBooleanTrue }.expect("kCFBooleanTrue");
         let d = dict_with(SCREEN_IS_LOCKED_KEY, v);
-        assert!(dict_reports_locked(Some(&d)));
+        assert_eq!(dict_reports_state(Some(&d)), SessionState::Locked);
     }
 
     #[test]
     fn false_boolean_value_is_unlocked() {
         let v: &CFType = unsafe { kCFBooleanFalse }.expect("kCFBooleanFalse");
         let d = dict_with(SCREEN_IS_LOCKED_KEY, v);
-        assert!(!dict_reports_locked(Some(&d)));
+        assert_eq!(dict_reports_state(Some(&d)), SessionState::Unlocked);
     }
 
     #[test]
     fn an_unrelated_key_does_not_count_as_locked() {
         let v: &CFType = unsafe { kCFBooleanTrue }.expect("kCFBooleanTrue");
         let d = dict_with("SomeOtherSessionKey", v);
-        assert!(!dict_reports_locked(Some(&d)));
+        assert_eq!(dict_reports_state(Some(&d)), SessionState::Unlocked);
     }
 
     #[test]
-    fn session_locked_runs_the_real_ffi_path_without_panicking() {
+    fn session_locked_matches_session_state() {
+        // Thin-wrapper invariant: `session_locked()` is exactly `session_state() ==
+        // Locked`, for whatever state this box happens to be in.
+        assert_eq!(session_locked(), session_state() == SessionState::Locked);
+    }
+
+    #[test]
+    fn session_state_runs_the_real_ffi_path_without_panicking() {
         // Environment-gated like `permissions::preflight_matches_the_two_predicates` —
-        // there's no independent oracle for the live lock state on whatever box this
+        // there's no independent oracle for the live session state on whatever box this
         // runs on, so this just proves the real FFI path (framework call + CFRetained +
         // dict lookup) completes without panicking or leaking a null deref.
-        let _ = session_locked();
+        let _ = session_state();
     }
 }

--- a/crates/glass-mcp/Cargo.toml
+++ b/crates/glass-mcp/Cargo.toml
@@ -48,6 +48,9 @@ glass-sandbox-linux.workspace = true
 glass-windows = { path = "../glass-windows" }
 glass-a11y-windows = { path = "../glass-a11y-windows" }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+glass-macos = { path = "../glass-macos" }
+
 [build-dependencies]
 embed-manifest = "1"
 

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -146,63 +146,84 @@ fn soften_inactive_android(checks: &mut [Check]) {
 }
 
 /// macOS checks: the two TCC grants (Screen Recording, Accessibility), the console
-/// session's lock/display-sleep state, and the resolved backend. Pure — takes
-/// already-gathered facts, makes no OS calls itself — so it's unit-tested without
-/// needing real grants or a locked/awake session; [`macos_checks`] gathers the real
-/// facts via `glass_macos`. An asleep/locked session is a `Warn`, not a `Fail`: it's
-/// recoverable in-place (`caffeinate -d`) and shouldn't fail the whole doctor run the
-/// way a genuinely missing grant does.
+/// session's three-way state (unlocked/locked/nobody-logged-in), and the resolved
+/// backend. Pure — takes already-gathered facts, makes no OS calls itself — so it's
+/// unit-tested without needing real grants or a particular session state;
+/// [`macos_checks`] gathers the real facts via `glass_macos`. A locked/asleep session
+/// is a `Warn`, not a `Fail`: it's recoverable in-place (`caffeinate -d`), unlike a
+/// genuinely missing grant. No account being logged in at the console at all
+/// (`SessionState::NoSession` — see `glass_macos::session`, verified to be a
+/// console-wide fact, not merely "called over SSH") is also a `Warn`: distinct from
+/// both, not fixable by unlocking, but still surfaced without failing the whole
+/// doctor run over what's usually a launch-configuration issue rather than a broken
+/// install.
 #[cfg(target_os = "macos")]
 fn macos_checks_from(
     resolved_backend: &str,
     screen_recording: bool,
     accessibility: bool,
-    session_locked: bool,
+    session_state: glass_macos::SessionState,
 ) -> Vec<Check> {
-    let mut v = Vec::new();
-    v.push(if screen_recording {
-        Check::new("Screen Recording", CheckStatus::Ok, "granted")
-    } else {
-        Check::new(
-            "Screen Recording",
-            CheckStatus::Fail,
-            "not granted — capture will fail with a permission error",
-        )
-        .with_remedy(glass_macos::screen_recording_remedy())
-    });
-    v.push(if accessibility {
-        Check::new("Accessibility", CheckStatus::Ok, "granted")
-    } else {
-        Check::new(
-            "Accessibility",
-            CheckStatus::Fail,
-            "not granted — window management and input injection will fail",
-        )
-        .with_remedy(glass_macos::accessibility_remedy())
-    });
-    v.push(if session_locked {
-        Check::new(
-            "display awake",
-            CheckStatus::Warn,
-            "console session is locked/asleep — capture and input are silently suppressed while it is",
-        )
-        .with_remedy("run `caffeinate -d` in the console session to keep the display awake (no sudo needed)")
-    } else {
-        Check::new("display awake", CheckStatus::Ok, "session unlocked")
-    });
-    v.push(if resolved_backend == "macos" {
-        Check::new("backend", CheckStatus::Ok, "resolved to macos")
-    } else {
-        Check::new(
-            "backend",
-            CheckStatus::Warn,
-            format!("resolved backend is {resolved_backend}, not macos (GLASS_BACKEND override?)"),
-        )
-    });
-    v
+    vec![
+        if screen_recording {
+            Check::new("Screen Recording", CheckStatus::Ok, "granted")
+        } else {
+            Check::new(
+                "Screen Recording",
+                CheckStatus::Fail,
+                "not granted — capture will fail with a permission error",
+            )
+            .with_remedy(glass_macos::screen_recording_remedy())
+        },
+        if accessibility {
+            Check::new("Accessibility", CheckStatus::Ok, "granted")
+        } else {
+            Check::new(
+                "Accessibility",
+                CheckStatus::Fail,
+                "not granted — window management and input injection will fail",
+            )
+            .with_remedy(glass_macos::accessibility_remedy())
+        },
+        match session_state {
+            glass_macos::SessionState::Unlocked => Check::new("display awake", CheckStatus::Ok, "session unlocked"),
+            glass_macos::SessionState::Locked => Check::new(
+                "display awake",
+                CheckStatus::Warn,
+                "console session is locked/asleep — capture and input are silently suppressed while it is",
+            )
+            .with_remedy("run `caffeinate -d` in the console session to keep the display awake (no sudo needed)"),
+            glass_macos::SessionState::NoSession => Check::new(
+                "display awake",
+                CheckStatus::Warn,
+                "no account is logged in at the console (or it's sitting at the login window) — capture and \
+                 input need an actual GUI login, not just an unlocked screen; this is NOT about how glass-mcp \
+                 itself was launched (a bare-SSH process still sees a real logged-in console's state fine)",
+            )
+            .with_remedy(
+                "log in at the console for this account, then run glass-mcp as a gui/$(id -u) LaunchAgent: \
+                 `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/tech.fixedwidth.glass.plist` \
+                 (see docs/running-on-macos.md)",
+            ),
+        },
+        // The `general` section already prints the resolved default backend
+        // (`default backend`, above); this doesn't re-discover that fact, it just
+        // views it through a macOS-specific lens — is the backend this *macOS*
+        // binary resolved to actually macOS, e.g. flagging a `GLASS_BACKEND`
+        // override that names a backend not even compiled into this build.
+        if resolved_backend == "macos" {
+            Check::new("backend", CheckStatus::Ok, "resolved to macos")
+        } else {
+            Check::new(
+                "backend",
+                CheckStatus::Warn,
+                format!("resolved backend is {resolved_backend}, not macos (GLASS_BACKEND override?)"),
+            )
+        },
+    ]
 }
 
-/// Gather the real macOS facts (TCC grants, session lock state) and map them via
+/// Gather the real macOS facts (TCC grants, session state) and map them via
 /// [`macos_checks_from`].
 #[cfg(target_os = "macos")]
 fn macos_checks(resolved_backend: &str) -> Vec<Check> {
@@ -210,7 +231,7 @@ fn macos_checks(resolved_backend: &str) -> Vec<Check> {
         resolved_backend,
         glass_macos::screen_recording_granted(),
         glass_macos::accessibility_granted(),
-        glass_macos::session_locked(),
+        glass_macos::session_state(),
     )
 }
 
@@ -306,15 +327,17 @@ mod tests {
     mod macos {
         use super::*;
 
+        use glass_macos::SessionState;
+
         #[test]
         fn all_granted_awake_and_resolved_is_all_ok() {
-            let checks = macos_checks_from("macos", true, true, false);
+            let checks = macos_checks_from("macos", true, true, SessionState::Unlocked);
             assert!(checks.iter().all(|c| c.status == CheckStatus::Ok), "{checks:?}");
         }
 
         #[test]
         fn missing_screen_recording_fails_with_the_shared_remedy() {
-            let checks = macos_checks_from("macos", false, true, false);
+            let checks = macos_checks_from("macos", false, true, SessionState::Unlocked);
             let c = checks.iter().find(|c| c.name == "Screen Recording").unwrap();
             assert_eq!(c.status, CheckStatus::Fail);
             // Same wording `preflight`'s `PermissionDenied` error uses — no separate,
@@ -324,7 +347,7 @@ mod tests {
 
         #[test]
         fn missing_accessibility_fails_with_the_shared_remedy() {
-            let checks = macos_checks_from("macos", true, false, false);
+            let checks = macos_checks_from("macos", true, false, SessionState::Unlocked);
             let c = checks.iter().find(|c| c.name == "Accessibility").unwrap();
             assert_eq!(c.status, CheckStatus::Fail);
             assert_eq!(c.remedy.as_deref(), Some(glass_macos::accessibility_remedy()));
@@ -332,7 +355,7 @@ mod tests {
 
         #[test]
         fn locked_session_warns_and_names_caffeinate() {
-            let checks = macos_checks_from("macos", true, true, true);
+            let checks = macos_checks_from("macos", true, true, SessionState::Locked);
             let c = checks.iter().find(|c| c.name == "display awake").unwrap();
             assert_eq!(c.status, CheckStatus::Warn);
             assert!(c.remedy.as_deref().unwrap().contains("caffeinate -d"), "{c:?}");
@@ -342,7 +365,30 @@ mod tests {
         fn locked_session_does_not_fail_the_whole_doctor_run() {
             // The display-awake WARN must not escalate `Diagnosis::overall` to FAIL —
             // it's recoverable in place, unlike a genuinely missing grant.
-            let checks = macos_checks_from("macos", true, true, true);
+            let checks = macos_checks_from("macos", true, true, SessionState::Locked);
+            let d = Diagnosis::new(vec![Section::new("macos", Some("macos".into()), checks)]);
+            assert_eq!(d.overall("macos"), CheckStatus::Warn);
+            assert_eq!(d.exit_code("macos"), 0);
+        }
+
+        #[test]
+        fn no_session_warns_and_names_launchctl_bootstrap() {
+            // The distinct NULL-dict case — nobody logged in at the console at all
+            // (verified to be a console-wide fact, not "this process happens to be
+            // over SSH" — see `glass_macos::session`'s module docs), not a present-
+            // but-unlocked one. Must not collapse into the `Unlocked` Ok case.
+            let checks = macos_checks_from("macos", true, true, SessionState::NoSession);
+            let c = checks.iter().find(|c| c.name == "display awake").unwrap();
+            assert_eq!(c.status, CheckStatus::Warn);
+            assert!(c.detail.contains("no account is logged in at the console"), "{c:?}");
+            assert!(c.remedy.as_deref().unwrap().contains("launchctl bootstrap gui/"), "{c:?}");
+        }
+
+        #[test]
+        fn no_session_does_not_fail_the_whole_doctor_run() {
+            // Also recoverable (relaunch as a LaunchAgent) rather than a broken
+            // install, so it's a Warn like `Locked`, not escalated to Fail.
+            let checks = macos_checks_from("macos", true, true, SessionState::NoSession);
             let d = Diagnosis::new(vec![Section::new("macos", Some("macos".into()), checks)]);
             assert_eq!(d.overall("macos"), CheckStatus::Warn);
             assert_eq!(d.exit_code("macos"), 0);
@@ -350,7 +396,7 @@ mod tests {
 
         #[test]
         fn missing_grant_fails_the_whole_doctor_run_when_macos_is_the_default_backend() {
-            let checks = macos_checks_from("macos", false, true, false);
+            let checks = macos_checks_from("macos", false, true, SessionState::Unlocked);
             let d = Diagnosis::new(vec![Section::new("macos", Some("macos".into()), checks)]);
             assert_eq!(d.overall("macos"), CheckStatus::Fail);
             assert_eq!(d.exit_code("macos"), 1);
@@ -358,7 +404,7 @@ mod tests {
 
         #[test]
         fn backend_mismatch_warns_without_naming_it_a_failure() {
-            let checks = macos_checks_from("android", true, true, false);
+            let checks = macos_checks_from("android", true, true, SessionState::Unlocked);
             let c = checks.iter().find(|c| c.name == "backend").unwrap();
             assert_eq!(c.status, CheckStatus::Warn);
         }

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -51,11 +51,12 @@ fn diagnose_inner(deep: bool, audit: Option<&crate::audit::AuditReport>) -> Diag
     );
 
     // Only show sections for backends actually compiled into THIS binary — absent
-    // backends (e.g. windows on a Linux build, or macos anywhere today) are omitted
-    // rather than listed as "not built into this binary" placeholders. Accessibility is
-    // per-OS (AT-SPI on Linux, UIA on Windows), so it ships with whichever OS is built.
-    // Android is the exception: its crate is host-OS-agnostic and always compiled in, so
-    // its section is always emitted, gated at runtime (see below) rather than by cfg.
+    // backends (e.g. windows on a Linux build, or macos on a non-macOS build) are
+    // omitted rather than listed as "not built into this binary" placeholders.
+    // Accessibility is per-OS (AT-SPI on Linux, UIA on Windows); macOS's grants live in
+    // its own "macos" section instead. Android is the exception: its crate is
+    // host-OS-agnostic and always compiled in, so its section is always emitted, gated
+    // at runtime (see below) rather than by cfg.
     let mut sections = vec![general, network];
 
     #[cfg(target_os = "linux")]
@@ -90,6 +91,10 @@ fn diagnose_inner(deep: bool, audit: Option<&crate::audit::AuditReport>) -> Diag
             None,
             glass_a11y_windows::doctor::checks(deep),
         ));
+    }
+    #[cfg(target_os = "macos")]
+    {
+        sections.push(Section::new("macos", Some("macos".into()), macos_checks(backend)));
     }
 
     // Android is host-OS-agnostic (drives an AVD over adb), so the crate is always compiled
@@ -140,6 +145,75 @@ fn soften_inactive_android(checks: &mut [Check]) {
     }
 }
 
+/// macOS checks: the two TCC grants (Screen Recording, Accessibility), the console
+/// session's lock/display-sleep state, and the resolved backend. Pure — takes
+/// already-gathered facts, makes no OS calls itself — so it's unit-tested without
+/// needing real grants or a locked/awake session; [`macos_checks`] gathers the real
+/// facts via `glass_macos`. An asleep/locked session is a `Warn`, not a `Fail`: it's
+/// recoverable in-place (`caffeinate -d`) and shouldn't fail the whole doctor run the
+/// way a genuinely missing grant does.
+#[cfg(target_os = "macos")]
+fn macos_checks_from(
+    resolved_backend: &str,
+    screen_recording: bool,
+    accessibility: bool,
+    session_locked: bool,
+) -> Vec<Check> {
+    let mut v = Vec::new();
+    v.push(if screen_recording {
+        Check::new("Screen Recording", CheckStatus::Ok, "granted")
+    } else {
+        Check::new(
+            "Screen Recording",
+            CheckStatus::Fail,
+            "not granted — capture will fail with a permission error",
+        )
+        .with_remedy(glass_macos::screen_recording_remedy())
+    });
+    v.push(if accessibility {
+        Check::new("Accessibility", CheckStatus::Ok, "granted")
+    } else {
+        Check::new(
+            "Accessibility",
+            CheckStatus::Fail,
+            "not granted — window management and input injection will fail",
+        )
+        .with_remedy(glass_macos::accessibility_remedy())
+    });
+    v.push(if session_locked {
+        Check::new(
+            "display awake",
+            CheckStatus::Warn,
+            "console session is locked/asleep — capture and input are silently suppressed while it is",
+        )
+        .with_remedy("run `caffeinate -d` in the console session to keep the display awake (no sudo needed)")
+    } else {
+        Check::new("display awake", CheckStatus::Ok, "session unlocked")
+    });
+    v.push(if resolved_backend == "macos" {
+        Check::new("backend", CheckStatus::Ok, "resolved to macos")
+    } else {
+        Check::new(
+            "backend",
+            CheckStatus::Warn,
+            format!("resolved backend is {resolved_backend}, not macos (GLASS_BACKEND override?)"),
+        )
+    });
+    v
+}
+
+/// Gather the real macOS facts (TCC grants, session lock state) and map them via
+/// [`macos_checks_from`].
+#[cfg(target_os = "macos")]
+fn macos_checks(resolved_backend: &str) -> Vec<Check> {
+    macos_checks_from(
+        resolved_backend,
+        glass_macos::screen_recording_granted(),
+        glass_macos::accessibility_granted(),
+        glass_macos::session_locked(),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -170,11 +244,14 @@ mod tests {
         // Platform-gated backends compiled into THIS binary get a section; android is
         // always present (host-OS-agnostic crate) via a runtime gate. No "not built into
         // this binary" placeholders. Accessibility is per-OS (AT-SPI on Linux, UIA on
-        // Windows). macos has no backend yet, so it never appears.
+        // Windows); macOS's grants (Screen Recording, Accessibility) live inside its own
+        // "macos" section rather than a separate accessibility section.
         #[cfg(target_os = "linux")]
         assert_eq!(titles, ["general", "network", "x11", "wayland", "sandbox", "accessibility (linux)", "android"]);
         #[cfg(windows)]
         assert_eq!(titles, ["general", "network", "windows", "sandbox", "accessibility (windows)", "android"]);
+        #[cfg(target_os = "macos")]
+        assert_eq!(titles, ["general", "network", "macos", "android"]);
         // Android's section is always present and non-empty — its basic presence checks now
         // run unconditionally (deep probes gated to the selected backend; Fails softened to
         // Warn when android isn't active). Asserting non-empty catches accidental removal of
@@ -187,6 +264,7 @@ mod tests {
         assert_eq!(net.checks.len(), 1);
         // No section is a "not built into this binary" placeholder, and absent backends
         // are omitted entirely.
+        #[cfg(not(target_os = "macos"))]
         assert!(!titles.contains(&"macos"));
         #[cfg(target_os = "linux")]
         assert!(!titles.contains(&"windows"));
@@ -194,6 +272,12 @@ mod tests {
         {
             assert!(!titles.contains(&"x11"));
             assert!(!titles.contains(&"wayland"));
+        }
+        #[cfg(target_os = "macos")]
+        {
+            assert!(!titles.contains(&"x11"));
+            assert!(!titles.contains(&"wayland"));
+            assert!(!titles.contains(&"windows"));
         }
         let placeholder = d
             .sections
@@ -216,5 +300,67 @@ mod tests {
         let off = crate::audit::AuditReport { enabled: false, path: None, content: crate::audit::ContentMode::Redacted, prefix_len: 8 };
         let t = diagnose_with_audit(false, &off).render_text("x11").to_lowercase();
         assert!(t.contains("audit") && t.contains("off"), "{t}");
+    }
+
+    #[cfg(target_os = "macos")]
+    mod macos {
+        use super::*;
+
+        #[test]
+        fn all_granted_awake_and_resolved_is_all_ok() {
+            let checks = macos_checks_from("macos", true, true, false);
+            assert!(checks.iter().all(|c| c.status == CheckStatus::Ok), "{checks:?}");
+        }
+
+        #[test]
+        fn missing_screen_recording_fails_with_the_shared_remedy() {
+            let checks = macos_checks_from("macos", false, true, false);
+            let c = checks.iter().find(|c| c.name == "Screen Recording").unwrap();
+            assert_eq!(c.status, CheckStatus::Fail);
+            // Same wording `preflight`'s `PermissionDenied` error uses — no separate,
+            // driftable copy in glass-mcp.
+            assert_eq!(c.remedy.as_deref(), Some(glass_macos::screen_recording_remedy()));
+        }
+
+        #[test]
+        fn missing_accessibility_fails_with_the_shared_remedy() {
+            let checks = macos_checks_from("macos", true, false, false);
+            let c = checks.iter().find(|c| c.name == "Accessibility").unwrap();
+            assert_eq!(c.status, CheckStatus::Fail);
+            assert_eq!(c.remedy.as_deref(), Some(glass_macos::accessibility_remedy()));
+        }
+
+        #[test]
+        fn locked_session_warns_and_names_caffeinate() {
+            let checks = macos_checks_from("macos", true, true, true);
+            let c = checks.iter().find(|c| c.name == "display awake").unwrap();
+            assert_eq!(c.status, CheckStatus::Warn);
+            assert!(c.remedy.as_deref().unwrap().contains("caffeinate -d"), "{c:?}");
+        }
+
+        #[test]
+        fn locked_session_does_not_fail_the_whole_doctor_run() {
+            // The display-awake WARN must not escalate `Diagnosis::overall` to FAIL —
+            // it's recoverable in place, unlike a genuinely missing grant.
+            let checks = macos_checks_from("macos", true, true, true);
+            let d = Diagnosis::new(vec![Section::new("macos", Some("macos".into()), checks)]);
+            assert_eq!(d.overall("macos"), CheckStatus::Warn);
+            assert_eq!(d.exit_code("macos"), 0);
+        }
+
+        #[test]
+        fn missing_grant_fails_the_whole_doctor_run_when_macos_is_the_default_backend() {
+            let checks = macos_checks_from("macos", false, true, false);
+            let d = Diagnosis::new(vec![Section::new("macos", Some("macos".into()), checks)]);
+            assert_eq!(d.overall("macos"), CheckStatus::Fail);
+            assert_eq!(d.exit_code("macos"), 1);
+        }
+
+        #[test]
+        fn backend_mismatch_warns_without_naming_it_a_failure() {
+            let checks = macos_checks_from("android", true, true, false);
+            let c = checks.iter().find(|c| c.name == "backend").unwrap();
+            assert_eq!(c.status, CheckStatus::Warn);
+        }
     }
 }

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -82,9 +82,12 @@ pub fn make_platform(
     // to each. It connects lazily on first snapshot; an absent a11y bus surfaces as
     // AccessibilityUnavailable at call time, not here.
     // Accessibility is per-OS: AT-SPI on Linux, UI Automation on Windows. macOS has no
-    // a11y reader yet (AXUIElement tree reading is its own later plan) — no silent
-    // fallback: glass_a11y_snapshot/click_element/set_value surface
-    // AccessibilityUnavailable rather than pretending a tree exists.
+    // a11y reader yet (AXUIElement tree reading is its own later plan), so
+    // `accessibility` is `None` below — no silent fallback: glass-core's session layer
+    // surfaces `AxUnsupported` for a missing reader (see `glass-core::session`) rather
+    // than pretending a tree exists. That's a different variant from
+    // `AccessibilityUnavailable` above, which is for a *present* reader that fails at
+    // call time (e.g. Linux's AT-SPI bus being unreachable).
     #[cfg(windows)]
     let accessibility: Option<Box<dyn glass_core::Accessibility + Send>> =
         Some(Box::new(glass_a11y_windows::WindowsA11y::new()));

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -26,10 +26,10 @@ use rmcp::ServiceExt;
 
 use crate::server::GlassServer;
 
-#[cfg(not(any(target_os = "linux", windows)))]
+#[cfg(not(any(target_os = "linux", windows, target_os = "macos")))]
 compile_error!(
-    "glass-mcp has no display backend for this target OS; add one (e.g. a macOS backend) \
-     plus its make_platform + doctor arms"
+    "glass-mcp has no display backend for this target OS; add one (a Platform impl \
+     mirroring the linux/windows/macos backends) plus its make_platform + doctor arms"
 );
 
 /// Construct a backend by name. The only place that knows the concrete backends;
@@ -66,36 +66,48 @@ pub fn make_platform(
         "x11" => Box::new(X11Platform::from_env()?),
         #[cfg(windows)]
         "windows" => Box::new(glass_windows::WindowsPlatform::new()?),
+        #[cfg(target_os = "macos")]
+        "macos" => Box::new(glass_macos::MacosPlatform::new()?),
         other => {
             #[cfg(target_os = "linux")]
             let valid = "\"x11\", \"wayland\", or \"android\"";
             #[cfg(windows)]
             let valid = "\"windows\" or \"android\"";
+            #[cfg(target_os = "macos")]
+            let valid = "\"macos\" or \"android\"";
             return Err(GlassError::Backend(format!("unknown backend {other:?}; use {valid}")));
         }
     };
     // On Linux, AT-SPI serves both display backends, so the same reader is attached
     // to each. It connects lazily on first snapshot; an absent a11y bus surfaces as
     // AccessibilityUnavailable at call time, not here.
-    // Accessibility is per-OS: AT-SPI on Linux, UI Automation on Windows.
+    // Accessibility is per-OS: AT-SPI on Linux, UI Automation on Windows. macOS has no
+    // a11y reader yet (AXUIElement tree reading is its own later plan) — no silent
+    // fallback: glass_a11y_snapshot/click_element/set_value surface
+    // AccessibilityUnavailable rather than pretending a tree exists.
     #[cfg(windows)]
     let accessibility: Option<Box<dyn glass_core::Accessibility + Send>> =
         Some(Box::new(glass_a11y_windows::WindowsA11y::new()));
     #[cfg(target_os = "linux")]
     let accessibility: Option<Box<dyn glass_core::Accessibility + Send>> =
         Some(Box::new(glass_a11y_linux::LinuxA11y::new()));
+    #[cfg(target_os = "macos")]
+    let accessibility: Option<Box<dyn glass_core::Accessibility + Send>> = None;
     Ok(Backend { platform, accessibility })
 }
 
-/// Default backend name from `GLASS_BACKEND` (case-insensitive `wayland`/`windows`/`x11`/`android`).
-/// Unset defaults to the windows backend on a Windows host, else X11.
+/// Default backend name from `GLASS_BACKEND` (case-insensitive
+/// `wayland`/`windows`/`macos`/`x11`/`android`). Unset defaults to the windows backend on
+/// a Windows host, the macos backend on a macOS host, else X11.
 pub fn default_backend(env: Option<&str>) -> &'static str {
     match env {
         Some(v) if v.eq_ignore_ascii_case("android") => "android",
         Some(v) if v.eq_ignore_ascii_case("wayland") => "wayland",
         Some(v) if v.eq_ignore_ascii_case("windows") => "windows",
+        Some(v) if v.eq_ignore_ascii_case("macos") => "macos",
         Some(v) if v.eq_ignore_ascii_case("x11") => "x11",
         None if cfg!(windows) => "windows",
+        None if cfg!(target_os = "macos") => "macos",
         _ => "x11",
     }
 }
@@ -184,11 +196,15 @@ mod tests {
         assert_eq!(default_backend(Some("WAYLAND")), "wayland");
         assert_eq!(default_backend(Some("windows")), "windows");
         assert_eq!(default_backend(Some("WINDOWS")), "windows");
+        assert_eq!(default_backend(Some("macos")), "macos");
+        assert_eq!(default_backend(Some("MACOS")), "macos");
         assert_eq!(default_backend(Some("x11")), "x11");
         assert_eq!(default_backend(Some("nonsense")), "x11");
-        #[cfg(not(windows))]
-        assert_eq!(default_backend(None), "x11");
         #[cfg(windows)]
         assert_eq!(default_backend(None), "windows");
+        #[cfg(target_os = "macos")]
+        assert_eq!(default_backend(None), "macos");
+        #[cfg(not(any(windows, target_os = "macos")))]
+        assert_eq!(default_backend(None), "x11");
     }
 }

--- a/crates/glass-mcp/src/main.rs
+++ b/crates/glass-mcp/src/main.rs
@@ -4,6 +4,20 @@ use glass_mcp::{boot, run_doctor, run_env, run_stdio};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // One-time AppKit/WindowServer init (`NSApplication.sharedApplication`) — must run on
+    // the process's real main thread ("thread 0"), exactly once, before anything spawns the
+    // `glass-platform` worker thread that `GlassServer::new` (server.rs) parents every
+    // `MacosPlatform` call to. This is the FIRST statement of `main()`, with no `.await`
+    // above it: `#[tokio::main]`'s expansion builds the runtime and calls `Runtime::block_on`
+    // on the thread that invoked `main()` (thread 0), and `block_on` polls the async body
+    // itself on that same calling thread — so this line runs synchronously on thread 0
+    // during that first poll, strictly before `boot()`/`run_stdio()` below ever construct a
+    // `GlassServer` and spawn its worker thread. See glass-macos's `ffi::app_kit_init` doc
+    // and `.superpowers/sdd/thread0-spike-report.md` for why one call here is sufficient —
+    // every later `MacosPlatform` call, from any thread, is a cheap no-op after this.
+    #[cfg(target_os = "macos")]
+    glass_macos::init_main_thread();
+
     let cli = Cli::parse();
     let audit_log = cli.audit_log;
     // Resolve (and OPEN, fail-closed) the audit sink only in the serving arms below —

--- a/docs/running-on-linux.md
+++ b/docs/running-on-linux.md
@@ -166,9 +166,8 @@ interactive consent dialog, unsuited to unattended use.
 ## Android on Linux
 
 The Android backend is **host-OS-agnostic** — it shells out to `adb`, so it runs from
-a Linux host as well as Windows (macOS is planned — glass-mcp doesn't build on macOS
-yet; see [running-on-macos.md](running-on-macos.md)). This section covers what's
-Linux-specific about the setup.
+a Linux host as well as Windows and macOS (see [running-on-macos.md](running-on-macos.md)
+for the macOS host guide). This section covers what's Linux-specific about the setup.
 
 ### Supported Android versions
 

--- a/docs/running-on-macos.md
+++ b/docs/running-on-macos.md
@@ -1,20 +1,167 @@
-Running glass on a macOS host — *planned*.
+Running glass on a macOS host.
 
 ← [Back to README](../README.md)
 
-## Current status
+## System requirements
 
-glass-mcp does **not** build on macOS yet. `crates/glass-mcp/src/lib.rs` contains a
-`#[cfg(not(any(target_os = "linux", windows)))] compile_error!(...)`, so `cargo build`
-fails on macOS today.
+- **macOS 14 or later**, developed and tested on **Apple Silicon**. Nothing in the
+  backend is Apple-Silicon-specific, but Intel Macs aren't yet verified.
+- glass drives apps in the **logged-in Aqua session** (the real desktop, not a
+  headless framebuffer) and captures via ScreenCaptureKit / injects input via
+  CGEvent — both gated by **macOS's privacy permissions (TCC)**, covered below.
 
-macOS support — a native macOS backend plus a macOS build — is **planned** (arriving
-when hardware is available for development and testing).
+## The permission model, in short
 
-## Android from macOS
+macOS requires two one-time grants — **Screen Recording** (capture) and
+**Accessibility** (window management + input injection) — before glass can drive
+anything. Each grant is recorded against the *responsible process*, keyed to its
+**Designated Requirement**: the combination of its bundle identifier and its
+code-signing certificate. That has two consequences that shape everything below:
 
-Once glass-mcp builds on macOS, the **Android** backend will work from a Mac too — it
-is host-OS-agnostic and simply shells out to `adb`. No macOS-native display backend is
-required for Android.
+- **Rebuilding doesn't lose the grant.** Sign every build with the same identity
+  and bundle id, and a rebuilt binary inherits the grant automatically — no
+  re-click needed. Change either one and macOS treats it as a new app, needing a
+  fresh grant.
+- **Who launches the process matters.** A bare `ssh user@mac 'glass-mcp ...'`
+  shell is attributed to `sshd`, which can't hold a grant. Running glass-mcp as a
+  **LaunchAgent** in your own login session makes `launchd` its parent instead —
+  its own, grantable, responsible process. This is why macOS glass ships as a
+  signed app + LaunchAgent rather than a plain binary you `ssh` in and run.
 
-Check back here for setup instructions once the macOS build ships.
+So the setup is: create a stable signing identity once, build+sign the app with
+it, grant it Screen Recording + Accessibility once via System Settings, then run
+it as a LaunchAgent from then on — rebuilds and restarts never need the dialog
+again.
+
+## 1. Create a signing identity
+
+Any code-signing identity works — it doesn't need to be trusted by Apple or tied
+to an Apple Developer account (Developer ID / notarization only matter for
+Gatekeeper-distributing an app to *other* people, not for TCC grants on your own
+machine). The simplest way to make one:
+
+1. Open **Keychain Access**.
+2. Menu bar → **Keychain Access → Certificate Assistant → Create a Certificate…**
+3. Name it whatever you like (e.g. `glass-mcp signing`); **Identity Type: Self
+   Signed Root**; **Certificate Type: Code Signing**.
+4. Click **Create**. It lands in your login keychain, ready for `codesign -s`.
+
+(For a headless box with no one at the keyboard, the same identity can be created
+entirely from the command line into a dedicated keychain with `security
+create-keychain` + `security import`; the interactive Keychain Access flow above
+is simpler when you have a GUI session to run it in.)
+
+## 2. Build and sign the app
+
+```bash
+./packaging/macos/build-app.sh --identity "glass-mcp signing"
+# -> target/macos-app/GlassMcp.app
+```
+
+`--identity` is required — see [packaging/macos/README.md](../packaging/macos/README.md)
+for the rest of the flags (custom bundle id, a non-default keychain, version
+overrides). Confirm the signature:
+
+```bash
+codesign -dv target/macos-app/GlassMcp.app
+```
+
+## 3. Grant Screen Recording + Accessibility
+
+`glass-mcp doctor` only *checks* grant status — it never triggers the OS consent
+dialogs (that's deliberate: a diagnostic shouldn't pop dialogs). The dialogs
+appear the first time glass actually **drives** something, so register the
+signed binary with your agent and ask it to do something:
+
+```bash
+claude mcp add glass --scope user -- \
+  "$(pwd)/target/macos-app/GlassMcp.app/Contents/MacOS/glass-mcp"
+```
+
+Then, from your agent: *"Use glass to launch TextEdit and take a screenshot."*
+The first capture attempt prompts for **Screen Recording**; the first click or
+keystroke prompts for **Accessibility**. Grant both in **System Settings →
+Privacy & Security → Screen Recording** and **→ Accessibility** (add `GlassMcp`
+if it isn't listed yet, or toggle it on if it is), then ask your agent to try
+again. Confirm both stuck:
+
+```bash
+target/macos-app/GlassMcp.app/Contents/MacOS/glass-mcp doctor
+```
+
+You want the `[macos]` section all `✓`.
+
+As long as you keep signing with this same identity and bundle id, this is a
+**one-time step**: rebuilding, moving the app, or restarting the LaunchAgent
+below never re-prompts.
+
+## 4. Keep the Mac awake
+
+glass captures and drives the real desktop, so a sleeping or locked display has
+nothing to grab. On a box you're not actively using, hold it awake and unlocked:
+
+```bash
+caffeinate -d -i -s &
+```
+
+`glass-mcp doctor` checks this (the `display awake` line) and names this exact
+command if the session is locked.
+
+## 5. Run it
+
+The interactive setup above (stdio, your agent spawns the signed binary
+directly) is fine for driving apps from a Terminal you're sitting at. For a box
+no one is watching, run it as a LaunchAgent instead — that's what keeps
+glass-mcp launchd-parented so its grant stays attached to a stable process
+rather than to whatever spawns it that day.
+
+### Unattended (LaunchAgent + network transport) — the recommended model
+
+```bash
+mkdir -p ~/Library/LaunchAgents ~/Library/Logs/GlassMcp
+cp packaging/macos/tech.fixedwidth.glass.plist ~/Library/LaunchAgents/
+# Edit the copy: replace /Users/YOU with your home directory (and the app path
+# if you didn't install GlassMcp.app to /Applications).
+
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/tech.fixedwidth.glass.plist
+launchctl print gui/$(id -u)/tech.fixedwidth.glass   # confirm it's running
+```
+
+This starts `glass-mcp serve --http --addr 127.0.0.1:7300` — see
+[packaging/macos/README.md](../packaging/macos/README.md) for the load/unload
+commands. No `sudo` is needed anywhere in this flow.
+
+Point a client at it:
+
+```bash
+# Same machine: connect straight to loopback — no token needed.
+# From another machine, tunnel it first:
+ssh -L 7300:127.0.0.1:7300 you@themac
+```
+
+Then point your MCP client at `http://127.0.0.1:7300`. Binding beyond loopback
+follows the same fail-closed token rule as the other platforms — see the "Network
+transport" section of [running-on-windows.md](running-on-windows.md) for the
+`gen-token` / `--token-file` flow, which works identically here.
+
+Stop it with:
+
+```bash
+launchctl bootout gui/$(id -u)/tech.fixedwidth.glass
+```
+
+## Tools available on macOS
+
+Once granted (step 3), the agent has `glass_start`, `glass_screenshot`,
+`glass_click`, `glass_type`, `glass_wait_stable`, `glass_diff`, `glass_logs`,
+`glass_list_windows`, `glass_select_window`, and `glass_doctor`. The
+accessibility-tree tools — `glass_a11y_snapshot`, `glass_click_element` — aren't
+available on macOS yet.
+
+---
+
+## Problems?
+
+`glass-mcp doctor` diagnoses most setup issues and prints a remedy for each
+failed check. Bug reports and questions:
+<https://github.com/fixed-width/glass/issues>.

--- a/docs/running-on-macos.md
+++ b/docs/running-on-macos.md
@@ -158,6 +158,24 @@ Once granted (step 3), the agent has `glass_start`, `glass_screenshot`,
 accessibility-tree tools — `glass_a11y_snapshot`, `glass_click_element` — aren't
 available on macOS yet.
 
+## Troubleshooting: headless / SSH setup
+
+Two gotchas that only show up when you're driving a box over SSH (no one at the
+keyboard), e.g. re-signing after a code change or building the Swift capture-test
+fixture:
+
+- **Non-interactive `codesign` needs the keychain unlocked first.** A keychain
+  created (or last unlocked) in an earlier login session is locked again by the time
+  a bare SSH shell runs `codesign` — you'll see `errSecInternalComponent` rather
+  than an obviously-keychain-shaped error. Unlock it explicitly before signing:
+  `security unlock-keychain -p <password> <keychain>` (the login keychain if you
+  didn't pass `--keychain` to `build-app.sh`). This has nothing to do with TCC/AX
+  grants — it's the code-signing step itself failing to reach the private key.
+- **Any `@main` Swift source (including the `glass-macos` capture-test fixture,
+  `crates/glass-macos/fixture/quadrants.swift`) needs `swiftc -parse-as-library`.**
+  Without it, `swiftc` assumes top-level statements (the `main.swift` convention) and
+  errors on an explicit `@main` entry point.
+
 ---
 
 ## Problems?

--- a/docs/running-on-windows.md
+++ b/docs/running-on-windows.md
@@ -192,8 +192,8 @@ Both reuse glass's network transport — no glass code changes required.
 ## Android on Windows
 
 The Android backend is **host-OS-agnostic** — it shells out to `adb.exe`, so it runs
-from a Windows host just as from Linux (macOS is planned — glass-mcp doesn't build on
-macOS yet; see [running-on-macos.md](running-on-macos.md)).
+from a Windows host just as from Linux and macOS (see
+[running-on-macos.md](running-on-macos.md) for the macOS host guide).
 
 ### Supported Android versions
 

--- a/packaging/README-gnu.md
+++ b/packaging/README-gnu.md
@@ -5,8 +5,8 @@ launches an app, screenshots what's on screen, clicks and types into it, reads i
 logs, and detects visual changes — so the agent can build and debug a GUI on its own
 instead of asking you "does this look right?".
 
-This is the **Linux x86-64 (glibc)** build. (A Windows build is also available; macOS
-is not yet built.) See the project README for the full picture:
+This is the **Linux x86-64 (glibc)** build. (Windows and macOS builds are also available
+— see [docs/running-on-macos.md](../docs/running-on-macos.md).) See the project README for the full picture:
 <https://github.com/fixed-width/glass>.
 For Linux-specific display/compositor and containment setup, see
 [docs/running-on-linux.md](../docs/running-on-linux.md).

--- a/packaging/README-musl.md
+++ b/packaging/README-musl.md
@@ -7,7 +7,8 @@ instead of asking you "does this look right?".
 
 This is the **statically-linked Linux x86-64** build: **no glibc version requirement**
 and **no shared-library prerequisites** — it runs on essentially any x86-64 Linux.
-(A Windows build is also available; macOS is not yet built.) See the project README
+(Windows and macOS builds are also available — see
+[docs/running-on-macos.md](../docs/running-on-macos.md).) See the project README
 for the full picture: <https://github.com/fixed-width/glass>.
 For Linux-specific display/compositor and containment setup, see
 [docs/running-on-linux.md](../docs/running-on-linux.md).

--- a/packaging/macos/Info.plist
+++ b/packaging/macos/Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Template Info.plist for GlassMcp.app. build-app.sh copies this file in and can
+  override CFBundleIdentifier / CFBundleShortVersionString / CFBundleVersion (see
+  packaging/macos/README.md); the values below are the production defaults.
+
+  LSBackgroundOnly is set because glass-mcp is a headless agent: it has no windows,
+  no menu bar, and nothing to show in the Dock or the Force Quit list.
+-->
+<plist version="1.0">
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>tech.fixedwidth.glass</string>
+	<key>CFBundleExecutable</key>
+	<string>glass-mcp</string>
+	<key>CFBundleName</key>
+	<string>GlassMcp</string>
+	<key>CFBundleDisplayName</key>
+	<string>glass</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.1.2</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSBackgroundOnly</key>
+	<true/>
+	<key>LSMinimumSystemVersion</key>
+	<string>14.0</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Apache-2.0. https://github.com/fixed-width/glass</string>
+</dict>
+</plist>

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -1,0 +1,50 @@
+# packaging/macos
+
+Assembles `glass-mcp` into a signed macOS app bundle and runs it as a per-user
+LaunchAgent. This is a quick reference for the files here; see
+[docs/running-on-macos.md](../../docs/running-on-macos.md) for the full setup
+guide (creating a signing identity, granting Screen Recording / Accessibility,
+connecting a client).
+
+## Files
+
+- **`Info.plist`** — the app bundle's `Info.plist` template. Ships with the
+  production bundle id (`tech.fixedwidth.glass`) and `LSBackgroundOnly` set —
+  glass-mcp is a headless agent with no windows, no menu bar, and nothing to show
+  in the Dock. `build-app.sh` copies this in and can override the identifier and
+  version.
+- **`build-app.sh`** — builds `glass-mcp --release`, assembles `GlassMcp.app`
+  around it, and codesigns the bundle. Run `./build-app.sh --help` for flags;
+  `--identity` is required (there's deliberately no ad-hoc-signing default — an
+  ad-hoc signature's Designated Requirement isn't stable, so TCC grants wouldn't
+  survive a rebuild).
+- **`tech.fixedwidth.glass.plist`** — a `gui/<uid>` LaunchAgent template that runs
+  the bundled binary as `glass-mcp serve --http`. Copy it, fill in the
+  placeholders (your home directory, and the app path if you didn't install to
+  `/Applications`), then load it.
+
+## Build + sign
+
+```bash
+./packaging/macos/build-app.sh --identity "your signing identity"
+# -> target/macos-app/GlassMcp.app
+```
+
+## Load / unload the LaunchAgent
+
+```bash
+mkdir -p ~/Library/LaunchAgents ~/Library/Logs/GlassMcp
+cp packaging/macos/tech.fixedwidth.glass.plist ~/Library/LaunchAgents/
+# edit ~/Library/LaunchAgents/tech.fixedwidth.glass.plist: replace /Users/YOU
+# with your home directory (and the app path if not /Applications).
+
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/tech.fixedwidth.glass.plist
+launchctl print gui/$(id -u)/tech.fixedwidth.glass    # confirm it's running
+
+launchctl bootout gui/$(id -u)/tech.fixedwidth.glass   # stop + unload
+```
+
+No `sudo` is needed anywhere here — a LaunchAgent bootstrapped into your own
+`gui/<uid>` domain is entirely user-scoped, and it's what keeps glass-mcp's
+process launchd-parented (not SSH- or Terminal-parented), which is what makes its
+TCC grants attach reliably to the signed binary itself.

--- a/packaging/macos/build-app.sh
+++ b/packaging/macos/build-app.sh
@@ -109,6 +109,10 @@ if [ -n "$build_num" ]; then
 fi
 
 echo "==> codesigning (identity: $sign_identity, bundle id: $bundle_id)"
+# Non-interactive (SSH/CI) runs: if the keychain holding $sign_identity is locked,
+# codesign fails with errSecInternalComponent rather than an obviously-keychain-shaped
+# error — unlock it first with `security unlock-keychain -p <password> <keychain>`
+# (see docs/running-on-macos.md).
 codesign_args=(--force --options runtime -s "$sign_identity")
 if [ -n "$sign_keychain" ]; then
   codesign_args+=(--keychain "$sign_keychain")

--- a/packaging/macos/build-app.sh
+++ b/packaging/macos/build-app.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Assemble and codesign GlassMcp.app: a macOS app bundle wrapping the release
+# `glass-mcp` binary, so it can be granted Screen Recording / Accessibility once
+# and run as a `gui/<uid>` LaunchAgent (see docs/running-on-macos.md and
+# packaging/macos/README.md for the full setup).
+#
+#   ./packaging/macos/build-app.sh --identity "<signing identity>" [options]
+#
+# Required:
+#   --identity NAME     codesign identity (a Keychain "Common Name") to sign with.
+#                        (env: GLASS_SIGN_IDENTITY)
+#
+# Optional:
+#   --bundle-id ID       CFBundleIdentifier (default: tech.fixedwidth.glass — the
+#                        production identifier). (env: GLASS_BUNDLE_ID)
+#   --keychain PATH      keychain to resolve --identity from, passed straight to
+#                        `codesign --keychain` (default: the keychain search list).
+#                        (env: GLASS_SIGN_KEYCHAIN)
+#   --out DIR            output directory for GlassMcp.app (default:
+#                        target/macos-app under the repo root).
+#   --version X.Y.Z      CFBundleShortVersionString (default: the template's).
+#   --build N            CFBundleVersion (default: the template's).
+#   --skip-build         reuse the existing target/release/glass-mcp binary
+#                        instead of rebuilding — for iterating on packaging only.
+#
+# TCC (Screen Recording / Accessibility) grants key on the bundle's Designated
+# Requirement — bundle id + signing certificate — not on the binary's cdhash. So
+# re-running this script with the SAME --identity/--bundle-id after a code change
+# re-signs a new binary WITHOUT losing a previously-granted permission; changing
+# either the bundle id or the identity produces a new Designated Requirement and
+# starts the grant over.
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+usage: build-app.sh --identity NAME [--bundle-id ID] [--keychain PATH]
+                     [--out DIR] [--version X.Y.Z] [--build N] [--skip-build]
+EOF
+  exit 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+bundle_id="${GLASS_BUNDLE_ID:-tech.fixedwidth.glass}"
+sign_identity="${GLASS_SIGN_IDENTITY:-}"
+sign_keychain="${GLASS_SIGN_KEYCHAIN:-}"
+out_dir="$REPO_ROOT/target/macos-app"
+version=""
+build_num=""
+skip_build=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --identity)   sign_identity="$2"; shift 2 ;;
+    --bundle-id)  bundle_id="$2"; shift 2 ;;
+    --keychain)   sign_keychain="$2"; shift 2 ;;
+    --out)        out_dir="$2"; shift 2 ;;
+    --version)    version="$2"; shift 2 ;;
+    --build)      build_num="$2"; shift 2 ;;
+    --skip-build) skip_build=1; shift ;;
+    -h|--help)    usage ;;
+    *) echo "error: unknown argument: $1" >&2; usage ;;
+  esac
+done
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "error: build-app.sh must run on macOS (codesign is macOS-only)" >&2
+  exit 1
+fi
+
+if [ -z "$sign_identity" ]; then
+  echo "error: --identity (or GLASS_SIGN_IDENTITY) is required." >&2
+  echo "       There is no default, so a build never lands ad-hoc-signed by accident:" >&2
+  echo "       an ad-hoc signature (-s -) has no stable Designated Requirement, so" >&2
+  echo "       Screen Recording / Accessibility grants would NOT survive a rebuild." >&2
+  echo "       See docs/running-on-macos.md for how to create a signing identity." >&2
+  exit 1
+fi
+
+if ! command -v /usr/libexec/PlistBuddy >/dev/null 2>&1; then
+  echo "error: /usr/libexec/PlistBuddy not found (expected on every macOS install)" >&2
+  exit 1
+fi
+
+echo "==> building glass-mcp (release)"
+bin="$REPO_ROOT/target/release/glass-mcp"
+if [ "$skip_build" -eq 0 ]; then
+  ( cd "$REPO_ROOT" && cargo build --release -p glass-mcp )
+fi
+if [ ! -x "$bin" ]; then
+  echo "error: $bin not found or not executable (run without --skip-build first)" >&2
+  exit 1
+fi
+
+app="$out_dir/GlassMcp.app"
+echo "==> assembling $app"
+rm -rf "$app"
+mkdir -p "$app/Contents/MacOS"
+install -m 0755 "$bin" "$app/Contents/MacOS/glass-mcp"
+cp "$SCRIPT_DIR/Info.plist" "$app/Contents/Info.plist"
+
+/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier $bundle_id" "$app/Contents/Info.plist"
+if [ -n "$version" ]; then
+  /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $version" "$app/Contents/Info.plist"
+fi
+if [ -n "$build_num" ]; then
+  /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $build_num" "$app/Contents/Info.plist"
+fi
+
+echo "==> codesigning (identity: $sign_identity, bundle id: $bundle_id)"
+codesign_args=(--force --options runtime -s "$sign_identity")
+if [ -n "$sign_keychain" ]; then
+  codesign_args+=(--keychain "$sign_keychain")
+fi
+codesign "${codesign_args[@]}" "$app"
+
+echo "==> verifying"
+codesign --verify --strict "$app"
+codesign -dv "$app"
+
+echo "==> done: $app"

--- a/packaging/macos/tech.fixedwidth.glass.plist
+++ b/packaging/macos/tech.fixedwidth.glass.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  gui/<uid> LaunchAgent template that runs the signed GlassMcp.app as
+  `glass-mcp serve --http` — the unattended run model (see
+  docs/running-on-macos.md and packaging/macos/README.md).
+
+  Before loading this, edit the two placeholders below:
+    - /Users/YOU  -> your home directory (also fix the app path if you didn't
+                     install GlassMcp.app to /Applications).
+  The bind address (127.0.0.1:7300) is loopback-only, so no bearer token is
+  required; see docs/running-on-macos.md for reaching it from another machine.
+-->
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>tech.fixedwidth.glass</string>
+
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Applications/GlassMcp.app/Contents/MacOS/glass-mcp</string>
+		<string>serve</string>
+		<string>--http</string>
+		<string>--addr</string>
+		<string>127.0.0.1:7300</string>
+	</array>
+
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>GLASS_BACKEND</key>
+		<string>macos</string>
+	</dict>
+
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+	<key>ProcessType</key>
+	<string>Background</string>
+
+	<key>StandardOutPath</key>
+	<string>/Users/YOU/Library/Logs/GlassMcp/stdout.log</string>
+	<key>StandardErrorPath</key>
+	<string>/Users/YOU/Library/Logs/GlassMcp/stderr.log</string>
+</dict>
+</plist>

--- a/scripts/test-macos-mcp.sh
+++ b/scripts/test-macos-mcp.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Headless glass-mcp smoke: proves the stdio MCP server boots and lists its tools with
+# NEITHER a TCC grant NOR a WindowServer session — the macos-14 CI runner has neither, and
+# tools are registered before any backend is constructed, so `initialize` + `tools/list`
+# alone proves the macOS build links and the server starts, without touching capture/input
+# (glass_start, which builds a live MacosPlatform, is deliberately not called here).
+#
+# Skips (exit 0) when not on macOS, mirroring scripts/test-macos.sh, so it's safe to call
+# from any CI matrix leg.
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "test-macos-mcp.sh: not macOS (uname=$(uname -s)) — skipping."
+  exit 0
+fi
+
+# Run from the repo root so `cargo -p` resolves regardless of the caller's cwd (mirrors
+# scripts/test-macos.sh / test-x11.sh / test-wayland.sh / test-windows.sh).
+cd "$(dirname "$0")/.."
+
+# The JSON-RPC round trip needs a real request/response exchange over stdin/stdout, which
+# is awkward in portable bash (no `coproc`/GNU `timeout` guarantee on macOS's default
+# bash/coreutils) — python3 ships on every GitHub-hosted macOS runner, so do it there. A
+# SIGALRM bounds the whole exchange so a wedged server fails the job instead of hanging it.
+python3 - <<'PY'
+import json
+import signal
+import subprocess
+import sys
+
+
+def send(proc, obj):
+    proc.stdin.write((json.dumps(obj) + "\n").encode())
+    proc.stdin.flush()
+
+
+def recv(proc):
+    line = proc.stdout.readline()
+    if not line:
+        raise RuntimeError("glass-mcp closed stdout unexpectedly")
+    return json.loads(line)
+
+
+def alarm(signum, frame):
+    raise TimeoutError("glass-mcp smoke timed out after 30s")
+
+
+signal.signal(signal.SIGALRM, alarm)
+signal.alarm(30)
+
+proc = subprocess.Popen(
+    ["cargo", "run", "-p", "glass-mcp", "--locked", "--"],
+    stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+)
+try:
+    send(proc, {
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "ci-macos-smoke", "version": "0"},
+        },
+    })
+    init = recv(proc)
+    assert "result" in init, f"initialize failed: {init}"
+
+    send(proc, {"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+    send(proc, {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
+    tools = recv(proc)
+    names = [t["name"] for t in tools["result"]["tools"]]
+    assert "glass_start" in names, f"glass_start missing from tools/list: {names}"
+    print(f"OK: glass-mcp stdio server listed {len(names)} tools incl. glass_start")
+finally:
+    signal.alarm(0)
+    proc.stdin.close()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+    stderr = proc.stderr.read().decode(errors="replace")
+    if stderr.strip():
+        print("---- glass-mcp stderr ----", file=sys.stderr)
+        print(stderr, file=sys.stderr)
+PY


### PR DESCRIPTION
Fifth and final macOS increment: wire the macOS `Platform` backend into the `glass-mcp` server so an agent drives a Mac app end-to-end over MCP — completing **build → see → interact → manage → drivable over MCP**. (Plans 1–4 landed the crate, capture, input, and window management.)

## What's here
- **Backend wiring** (`glass-mcp`): `backend: "macos"` dispatch, `default_backend` → macos on a macOS host, and a one-time `init_main_thread()` at startup. The AppKit "main thread" requirement turned out to be self-imposed — only `NSApplication.sharedApplication`'s one-time CGS init needs thread 0; ScreenCaptureKit/CGEvent/AXUIElement are thread-agnostic. So `init_main_thread()` runs once on thread 0 at startup and the whole backend then runs on glass-mcp's existing worker thread — no threading restructure, no marshaling.
- **doctor** (`glass-mcp doctor`): Screen Recording + Accessibility grants (with remedies), display-awake / session state (distinguishes locked, and "no GUI session"), and backend resolution.
- **Signed-app run model** (`packaging/macos/`): `build-app.sh` assembles + codesigns `GlassMcp.app` (refuses ad-hoc signing so the TCC Designated Requirement — bundle id + cert — stays stable across rebuilds), a `gui/501` LaunchAgent template running `serve --http`, and `running-on-macos.md`.
- **CI**: the `macos-14` job now builds + clippy's + tests `glass-mcp` and runs a grants-free stdio + doctor smoke.

## Verification
- Linux: `cargo build/clippy/test --workspace --locked` green.
- macOS 26.5 (Apple Silicon): clippy `-D warnings` clean; glass-macos 76 + glass-mcp 157 lib tests (incl. the macOS doctor tests). **Granted end-to-end drive through `serve --http` under the gui/501 LaunchAgent**: glass_start → glass_screenshot (real non-blank WebP) → glass_click → glass_stop, with grant-persistence re-proven (re-sign → identical Designated Requirement).

## Notes
- The accessibility-tree reader (`glass_a11y_*`) and sandbox/containment for macOS remain follow-ups (the a11y seam returns `AxUnsupported` on macOS — no silent fallback). Clipboard get/set is not yet implemented (marked in the support table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
