### PR TITLE
macOS accessibility-tree reader (glass-a11y-macos)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,22 @@ jobs:
       - run: cargo build  -p glass-macos --locked
       - run: cargo clippy -p glass-macos --all-targets --locked -- -D warnings
       - run: ./scripts/test-macos.sh
+      # glass-a11y-macos is the standalone AXUIElement accessibility reader glass-mcp wires
+      # into the macOS backend (make_platform, doctor's "accessibility (macos)" section).
+      # Its pure `mapping` module has no cfg(macos) gate and already builds + unit-tests on
+      # the Linux `check` job's `cargo build/test --workspace` legs; this is the only job
+      # that can build/lint/test the cfg(target_os = "macos") `ffi`/`reader` modules
+      # underneath it (the AXUIElement snapshot/set_value implementation, incl. `reader`'s
+      # `set_value_took` unit tests, which are compiled out everywhere else).
+      - run: cargo build  -p glass-a11y-macos --locked
+      - run: cargo clippy -p glass-a11y-macos --all-targets --locked -- -D warnings
+      - run: cargo test   -p glass-a11y-macos --locked
+      # Compile/link gate for the harness=false `a11y` on-box integration test
+      # (crates/glass-macos/tests/a11y.rs) and its Swift fixture — proves both build against
+      # this runner's SDK without attempting the granted run (needs the Accessibility/Screen
+      # Recording TCC grants and a WindowServer session the runner doesn't have; that
+      # happens out-of-band — see the script's own comments and docs/running-on-macos.md).
+      - run: ./scripts/test-macos-a11y.sh
       # glass-mcp is the shipped binary; only this job can build/lint/test/run its
       # cfg(target_os = "macos") wiring (Cargo.toml's macos dep, lib.rs's "macos" backend
       # arm + default_backend). `cargo test` here is what actually executes the grants-free

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,15 +16,15 @@ tree — served over MCP (stdio, or `serve --http`). Backends behind a `Platform
 and Wayland (headless sway) on Linux, Windows (WGC/SendInput), Android (native apps in an AVD
 emulator over `adb`, host-OS-agnostic; clipboard + high-fidelity input via an optional
 on-device companion agent), macOS (ScreenCaptureKit capture, CGEvent input, AXUIElement
-windows/logs; accessibility reader + sandboxing still to come).
+windows/logs, accessibility tree; sandboxing still to come).
 
 ## Layout
 
 Cargo workspace at the repo root. Crates: `glass-core` (platform-agnostic heart — the
 `Platform`/`Accessibility` seams, session, `Frame`, diff, stability, log buffer), the
 backends (`glass-x11`, `glass-wayland`, `glass-windows`, `glass-android`), the a11y readers
-(`glass-a11y-linux`, `glass-a11y-windows`; the Android `uiautomator` reader lives in
-`glass-android`), `glass-sandbox-linux`, the `glass-mcp` server binary, and the
+(`glass-a11y-linux`, `glass-a11y-windows`, `glass-a11y-macos`; the Android `uiautomator`
+reader lives in `glass-android`), `glass-sandbox-linux`, the `glass-mcp` server binary, and the
 `glass-testapp` fixture. `glass-android` also holds the host-side client + lifecycle for two
 optional on-device companions — an `app_process` agent (clipboard + high-fidelity input) and an
 `AccessibilityService` (Compose-rich a11y tree + high-fidelity `set_value`); both live in the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,6 +1074,7 @@ dependencies = [
  "embed-manifest",
  "futures",
  "glass-a11y-linux",
+ "glass-a11y-macos",
  "glass-a11y-windows",
  "glass-android",
  "glass-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,6 +1050,7 @@ name = "glass-macos"
 version = "0.0.0"
 dependencies = [
  "block2",
+ "glass-a11y-macos",
  "glass-core",
  "objc2",
  "objc2-app-kit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,6 +986,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "glass-a11y-macos"
+version = "0.0.0"
+dependencies = [
+ "glass-core",
+ "objc2",
+ "objc2-application-services",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "glass-a11y-windows"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/glass-core", "crates/glass-x11", "crates/glass-testapp", "crates/glass-mcp", "crates/glass-wayland", "crates/glass-a11y-linux", "crates/glass-windows", "crates/glass-a11y-windows", "crates/glass-sandbox-linux", "crates/glass-proc-linux", "crates/glass-clip-hook", "crates/glass-dbus-linux", "crates/glass-android", "crates/glass-macos"]
+members = ["crates/glass-core", "crates/glass-x11", "crates/glass-testapp", "crates/glass-mcp", "crates/glass-wayland", "crates/glass-a11y-linux", "crates/glass-windows", "crates/glass-a11y-windows", "crates/glass-sandbox-linux", "crates/glass-proc-linux", "crates/glass-clip-hook", "crates/glass-dbus-linux", "crates/glass-android", "crates/glass-macos", "crates/glass-a11y-macos"]
 # glass-fixture-egui is intentionally excluded: heavy egui deps, only exercised by #[ignore]d
 # on-box a11y tests CI can't run. Built on-demand on the box.
 exclude = ["crates/glass-fixture-egui"]
@@ -35,6 +35,7 @@ glass-sandbox-linux = { path = "crates/glass-sandbox-linux" }
 glass-proc-linux = { path = "crates/glass-proc-linux" }
 glass-wayland = { path = "crates/glass-wayland" }
 glass-a11y-linux = { path = "crates/glass-a11y-linux" }
+glass-a11y-macos = { path = "crates/glass-a11y-macos" }
 glass-dbus-linux = { path = "crates/glass-dbus-linux" }
 atspi = { version = "0.30", features = ["tokio"] }
 atspi-common = "0.14"

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ glass drives apps as an external black box, so it works with any native GUI app
 regardless of toolkit or language. It currently has two Linux backends — **X11** and
 **Wayland** ([wlroots](https://gitlab.freedesktop.org/wlroots/wlroots)) — a **Windows** backend ([Windows.Graphics.Capture](https://learn.microsoft.com/en-us/uwp/api/windows.graphics.capture),
 SendInput, UI Automation) — an **Android** backend (drives native apps in an AVD emulator over `adb`) — and a
-**macOS** backend (ScreenCaptureKit capture, CGEvent input, AXUIElement windows), behind a platform-agnostic
-core; on macOS, accessibility (semantic addressing) and sandboxing are still planned. See the per-host setup
-guides: [Linux](docs/running-on-linux.md) · [Windows](docs/running-on-windows.md) · [macOS](docs/running-on-macos.md).
+**macOS** backend (ScreenCaptureKit capture, CGEvent input, AXUIElement windows and accessibility tree), behind
+a platform-agnostic core; on macOS, sandboxing is still planned. See the per-host setup guides:
+[Linux](docs/running-on-linux.md) · [Windows](docs/running-on-windows.md) · [macOS](docs/running-on-macos.md).
 
 ## The loop in practice
 
@@ -370,7 +370,7 @@ Where glass stands by OS. **✓** supported · **◑** partial · **–** not su
 | Capability | Linux (X11 + Wayland) | Windows | Android (AVD) | macOS |
 |---|:--:|:--:|:--:|:--:|
 | Capture · input · windows · clipboard · logs | ✓ | ✓ | ✓ † | ◑ ‡ |
-| Accessibility (semantic addressing) | ✓ AT-SPI | ✓ UI Automation | ✓ UIAutomator | 🚧 AX |
+| Accessibility (semantic addressing) | ✓ AT-SPI | ✓ UI Automation | ✓ UIAutomator | ✓ AX |
 | Containment / sandboxing | ✓ bubblewrap | ✓ Sandboxie Classic | ✓ the emulator VM | 🚧 |
 | Display isolation (app off your desktop) | ✓ headless Xvfb / sway | ◑ virtual display · VM tier | ✓ headless emulator | 🚧 |
 
@@ -397,8 +397,8 @@ tree, a managed AVD (attach-or-boot), and two optional on-device companions — 
 high-fidelity `set_value`), both set up in the [Linux](docs/running-on-linux.md) /
 [Windows](docs/running-on-windows.md) Android guides; it's built and unit-tested in CI and
 validated on-device. The **macOS** backend (ScreenCaptureKit capture, CGEvent input,
-AXUIElement windows/logs) is built and CI-tested; accessibility (AX) and sandboxing are
-not yet implemented — see [docs/running-on-macos.md](docs/running-on-macos.md).
+AXUIElement windows/logs, and an AXUIElement accessibility tree) is built and CI-tested;
+sandboxing is not yet implemented — see [docs/running-on-macos.md](docs/running-on-macos.md).
 
 ## License
 

--- a/crates/glass-a11y-macos/Cargo.toml
+++ b/crates/glass-a11y-macos/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "glass-a11y-macos"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[dependencies]
+glass-core.workspace = true
+
+# macOS-only FFI deps (objc2 family), used by Task 4's cfg-gated reader/ffi modules. Kept
+# in this target table so `mapping.rs` still builds on the Linux dev box with zero macOS
+# deps. Versions/features copied verbatim from `crates/glass-macos/Cargo.toml` so
+# `--locked` stays satisfiable against the already-resolved lockfile.
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6.4"
+objc2-application-services = { version = "0.3.2", default-features = false, features = [
+    "HIServices",
+    "AXUIElement",
+    "AXValue",
+    "AXError",
+    "libc",
+] }
+objc2-core-foundation = { version = "0.3.2", default-features = false, features = [
+    "CFArray",
+    "CFString",
+    "CFNumber",
+    "CFCGTypes",
+] }
+
+[lints]
+workspace = true

--- a/crates/glass-a11y-macos/Cargo.toml
+++ b/crates/glass-a11y-macos/Cargo.toml
@@ -9,7 +9,7 @@ publish.workspace = true
 [dependencies]
 glass-core.workspace = true
 
-# macOS-only FFI deps (objc2 family), used by Task 4's cfg-gated reader/ffi modules. Kept
+# macOS-only FFI deps (objc2 family), used by the cfg-gated reader/ffi modules. Kept
 # in this target table so `mapping.rs` still builds on the Linux dev box with zero macOS
 # deps. Versions/features copied verbatim from `crates/glass-macos/Cargo.toml` so
 # `--locked` stays satisfiable against the already-resolved lockfile.

--- a/crates/glass-a11y-macos/src/ffi.rs
+++ b/crates/glass-a11y-macos/src/ffi.rs
@@ -53,6 +53,17 @@ extern "C" {
         attribute: &CFString,
         settable: *mut u8,
     ) -> AXError;
+    // `AXError AXUIElementSetAttributeValue(AXUIElementRef, CFStringRef, CFTypeRef)` — the
+    // documented way to write an attribute. [`set_string_value`] uses it directly with a
+    // `CFString` value for `AXValue`: a plain string write, unlike `AXPosition`/`AXSize`
+    // (which wrap a `CGPoint`/`CGSize` in an `AXValueCreate`-built `AXValue` — see
+    // `axwindow::set_axvalue` — a step that only applies to those geometry types, not
+    // strings).
+    fn AXUIElementSetAttributeValue(
+        element: &AXUIElement,
+        attribute: &CFString,
+        value: &CFType,
+    ) -> AXError;
 }
 
 /// True if this process holds the Accessibility (AX) TCC grant. The snapshot gate calls
@@ -123,6 +134,24 @@ pub(crate) fn is_settable(el: &AXUIElement, attr_name: &str) -> bool {
     // `Boolean *` parameter.
     let err = unsafe { AXUIElementIsAttributeSettable(el, &attr, &mut settable) };
     err == AXError::Success && settable != 0
+}
+
+/// Write `text` as `el`'s `AXValue` (`AXUIElementSetAttributeValue`). The caller
+/// (`reader::set_value`) gates this on [`is_settable`] first; this only performs the write —
+/// it does not read back to verify the value actually took (that honesty check is the
+/// caller's read-back poll, mirroring the Windows reader's `set_value` contract).
+pub(crate) fn set_string_value(el: &AXUIElement, text: &str) -> Result<()> {
+    let attr = CFString::from_str("AXValue");
+    let value = CFString::from_str(text);
+    // SAFETY: `el` is a live `AXUIElement`; `attr`/`value` are valid `CFString`s. `value`
+    // deref-coerces `CFRetained<CFString>` -> `CFString` -> `CFType` (the same two-hop
+    // coercion `axwindow::set_axvalue` already relies on for its `CFRetained<AXValue>`
+    // argument), matching `AXUIElementSetAttributeValue`'s documented `CFTypeRef` parameter.
+    let err = unsafe { AXUIElementSetAttributeValue(el, &attr, &value) };
+    if err != AXError::Success {
+        return Err(ax_err("AXValue", err));
+    }
+    Ok(())
 }
 
 /// Read `el`'s `AXPosition` (top-left, in points — Quartz's top-left-origin global screen

--- a/crates/glass-a11y-macos/src/ffi.rs
+++ b/crates/glass-a11y-macos/src/ffi.rs
@@ -33,6 +33,25 @@ use objc2_core_foundation::{CFArray, CFBoolean, CFRetained, CFString, CFType, CG
 
 use glass_core::{GlassError, Result};
 
+/// The stable, Apple-documented `kAX*Attribute` name strings, hoisted into one place so a
+/// typo is a *compile* error rather than a silent "attribute absent" at runtime (a misspelled
+/// bare string literal type-checks and just reads back as a missing attribute). They are
+/// spelled out because `objc2-application-services`'s generated `kAX*` symbol constants are
+/// empty stubs — see the module doc.
+pub(crate) mod attr {
+    pub(crate) const VALUE: &str = "AXValue";
+    pub(crate) const ROLE: &str = "AXRole";
+    pub(crate) const ROLE_DESCRIPTION: &str = "AXRoleDescription";
+    pub(crate) const TITLE: &str = "AXTitle";
+    pub(crate) const DESCRIPTION: &str = "AXDescription";
+    pub(crate) const CHILDREN: &str = "AXChildren";
+    pub(crate) const WINDOWS: &str = "AXWindows";
+    pub(crate) const POSITION: &str = "AXPosition";
+    pub(crate) const SIZE: &str = "AXSize";
+    pub(crate) const ENABLED: &str = "AXEnabled";
+    pub(crate) const FOCUSED: &str = "AXFocused";
+}
+
 // `AXIsProcessTrusted` is a plain C predicate not surfaced by the objc2 bindings, declared
 // with the same contained `extern "C"` pattern `permissions.rs` uses. It is a public,
 // documented, stable AX API (unlike `axwindow.rs`'s `_AXUIElementGetWindow`, a private
@@ -67,13 +86,33 @@ pub(crate) fn app_element(pid: i32) -> CFRetained<AXUIElement> {
     unsafe { AXUIElement::new_application(pid) }
 }
 
-/// `AXUIElementCopyAttributeValue(el, attr_name, ...)`, wrapping the already-retained (+1,
-/// per Core Foundation's Copy/Create rule) raw result in a `CFRetained<CFType>` so it is
-/// released automatically when dropped. Errors (`AXError` != `Success`) become a structured
-/// [`GlassError::Backend`] naming the attribute — an absent attribute is one such error, so
-/// the value accessors below (`attribute_string`/`attribute_bool`) treat that as "no value"
-/// rather than a hard failure.
+/// `AXUIElementCopyAttributeValue(el, attr_name, ...)` in its "any non-`Success` is an error"
+/// form: it collapses *every* non-`Success` `AXError` — an absent attribute included — into a
+/// structured [`GlassError::Backend`]. The value accessors that treat "absent" as "no value"
+/// (`attribute_string`/`attribute_bool`) reach it through `.ok()`, so the distinction doesn't
+/// matter to them; callers that must tell "absent" from "real failure" apart use
+/// [`copy_attribute_checked`] directly.
 pub(crate) fn copy_attribute(el: &AXUIElement, attr_name: &str) -> Result<CFRetained<CFType>> {
+    copy_attribute_checked(el, attr_name)?
+        .ok_or_else(|| GlassError::Backend(format!("{attr_name}: attribute not present")))
+}
+
+/// Whether an `AXError` from an attribute *copy* means the element simply doesn't carry the
+/// attribute — a normal, non-failure state (most nodes lack most attributes). Only
+/// `AttributeUnsupported` (`kAXErrorAttributeUnsupported`, -25205) and `NoValue`
+/// (`kAXErrorNoValue`, -25212) qualify; every other non-`Success` code
+/// (`CannotComplete`/`InvalidUIElement`/`Failure`/...) is a genuine failure a caller must not
+/// silently read as "no value".
+fn is_absent_error(err: AXError) -> bool {
+    err == AXError::AttributeUnsupported || err == AXError::NoValue
+}
+
+/// `AXUIElementCopyAttributeValue`, distinguishing the three outcomes a no-silent-fallback
+/// caller needs: `Ok(Some(value))` on `Success`, `Ok(None)` when the attribute is
+/// *legitimately absent* ([`is_absent_error`]), and `Err` for any *real* AX failure. Wraps the
+/// already-retained (+1, per Core Foundation's Copy/Create rule) raw result in a
+/// `CFRetained<CFType>` so it is released automatically when dropped.
+fn copy_attribute_checked(el: &AXUIElement, attr_name: &str) -> Result<Option<CFRetained<CFType>>> {
     let attr = CFString::from_str(attr_name);
     let mut raw: *const CFType = std::ptr::null();
     // SAFETY: `el` is a live `AXUIElement`; `raw` is a valid local out-param slot matching
@@ -81,14 +120,15 @@ pub(crate) fn copy_attribute(el: &AXUIElement, attr_name: &str) -> Result<CFReta
     // `axwindow::copy_attribute`).
     let err = unsafe { el.copy_attribute_value(&attr, NonNull::from(&mut raw)) };
     if err != AXError::Success {
-        return Err(ax_err(attr_name, err));
+        return if is_absent_error(err) { Ok(None) } else { Err(ax_err(attr_name, err)) };
     }
-    let nn = NonNull::new(raw.cast_mut())
-        .ok_or_else(|| GlassError::Backend(format!("{attr_name}: AX reported success but returned a null value")))?;
+    let nn = NonNull::new(raw.cast_mut()).ok_or_else(|| {
+        GlassError::Backend(format!("{attr_name}: AX reported success but returned a null value"))
+    })?;
     // SAFETY: `AXUIElementCopyAttributeValue` follows Core Foundation's Copy/Create
     // ownership rule — an already-retained (+1) `CFTypeRef` on success — so
     // `CFRetained::from_raw` takes ownership without an extra retain (mirrors `axwindow`).
-    Ok(unsafe { CFRetained::from_raw(nn) })
+    Ok(Some(unsafe { CFRetained::from_raw(nn) }))
 }
 
 /// Read `el`'s `attr_name` as a `String`, or `None` when the attribute is absent, isn't a
@@ -98,6 +138,22 @@ pub(crate) fn attribute_string(el: &AXUIElement, attr_name: &str) -> Option<Stri
     let value = copy_attribute(el, attr_name).ok()?;
     let text = value.downcast::<CFString>().ok()?.to_string();
     (!text.is_empty()).then_some(text)
+}
+
+/// Error-aware sibling of [`attribute_string`]: `Ok(Some(s))` for a present `CFString` value
+/// (the empty string included — unlike [`attribute_string`], which folds `""` to `None`),
+/// `Ok(None)` when the attribute is absent or present-but-not-a-`CFString`, and `Err` for a
+/// *real* read failure. `set_value`'s post-write read-back polls through this so a failed
+/// *read* after the write can never be mistaken for the value having changed (a silent
+/// false-success).
+pub(crate) fn attribute_string_checked(
+    el: &AXUIElement,
+    attr_name: &str,
+) -> Result<Option<String>> {
+    match copy_attribute_checked(el, attr_name)? {
+        Some(value) => Ok(value.downcast::<CFString>().ok().map(|s| s.to_string())),
+        None => Ok(None),
+    }
 }
 
 /// Read `el`'s `attr_name` as a `bool` (`CFBoolean`), or `None` when the attribute is absent
@@ -125,7 +181,7 @@ pub(crate) fn is_settable(el: &AXUIElement, attr_name: &str) -> bool {
 /// it does not read back to verify the value actually took (that honesty check is the
 /// caller's read-back poll, mirroring the Windows reader's `set_value` contract).
 pub(crate) fn set_string_value(el: &AXUIElement, text: &str) -> Result<()> {
-    let attr = CFString::from_str("AXValue");
+    let attr = CFString::from_str(attr::VALUE);
     let value = CFString::from_str(text);
     // SAFETY: `el` is a live `AXUIElement`; `attr`/`value` are valid `CFString`s. `value`
     // deref-coerces `CFRetained<CFString>` -> `CFString` -> `CFType` (the same two-hop
@@ -133,7 +189,7 @@ pub(crate) fn set_string_value(el: &AXUIElement, text: &str) -> Result<()> {
     // argument), matching `set_attribute_value`'s documented `CFTypeRef` parameter.
     let err = unsafe { el.set_attribute_value(&attr, &value) };
     if err != AXError::Success {
-        return Err(ax_err("AXValue", err));
+        return Err(ax_err(attr::VALUE, err));
     }
     Ok(())
 }
@@ -141,7 +197,7 @@ pub(crate) fn set_string_value(el: &AXUIElement, text: &str) -> Result<()> {
 /// Read `el`'s `AXPosition` (top-left, in points — Quartz's top-left-origin global screen
 /// space, the same unit `AXSize` and `glass_core::coords` convert to/from pixels).
 pub(crate) fn ax_position(el: &AXUIElement) -> Result<(f64, f64)> {
-    let value = axvalue(el, "AXPosition")?;
+    let value = axvalue(el, attr::POSITION)?;
     let mut point = CGPoint { x: 0.0, y: 0.0 };
     // SAFETY: `value` was just verified (via `downcast`) to be a real `AXValue`; `point` is
     // a valid local out-param whose type matches the requested `AXValueType::CGPoint`
@@ -155,7 +211,7 @@ pub(crate) fn ax_position(el: &AXUIElement) -> Result<(f64, f64)> {
 
 /// Read `el`'s `AXSize` (width/height, in points).
 pub(crate) fn ax_size(el: &AXUIElement) -> Result<(f64, f64)> {
-    let value = axvalue(el, "AXSize")?;
+    let value = axvalue(el, attr::SIZE)?;
     let mut size = CGSize { width: 0.0, height: 0.0 };
     // SAFETY: same as `ax_position` above, with `AXValueType::CGSize`/`CGSize`.
     let ok = unsafe { value.value(AXValueType::CGSize, NonNull::from(&mut size).cast()) };
@@ -165,21 +221,30 @@ pub(crate) fn ax_size(el: &AXUIElement) -> Result<(f64, f64)> {
     Ok((size.width, size.height))
 }
 
-/// `el`'s `AXChildren` as a `Vec` of typed element refs (array order preserved). Errors if
-/// the attribute copy fails; the reader treats that as "no children" (a leaf).
+/// `el`'s `AXChildren` as a `Vec` of typed element refs (array order preserved). A
+/// legitimately-absent `AXChildren` (or an empty array) is `Ok(vec![])`; only a *real* AX read
+/// failure is `Err`, which `walk` surfaces (as a diagnostic + graceful degrade) rather than
+/// silently dropping the subtree.
 pub(crate) fn children(el: &AXUIElement) -> Result<Vec<CFRetained<AXUIElement>>> {
-    array_of_elements(el, "AXChildren")
+    array_of_elements(el, attr::CHILDREN)
 }
 
-/// `app`'s `AXWindows` as a `Vec` of typed element refs.
+/// `app`'s `AXWindows` as a `Vec` of typed element refs. Same absent-vs-failure contract as
+/// [`children`].
 pub(crate) fn app_windows(app: &AXUIElement) -> Result<Vec<CFRetained<AXUIElement>>> {
-    array_of_elements(app, "AXWindows")
+    array_of_elements(app, attr::WINDOWS)
 }
 
 /// Shared body of [`children`]/[`app_windows`]: copy an element-array attribute, reinterpret
 /// it as a typed `CFArray<AXUIElement>`, and collect its entries.
 fn array_of_elements(el: &AXUIElement, attr_name: &str) -> Result<Vec<CFRetained<AXUIElement>>> {
-    let value = copy_attribute(el, attr_name)?;
+    // A *legitimately absent* array attribute (`AttributeUnsupported`/`NoValue`) means "no
+    // children/windows" → an empty `Vec`; only a *real* AX failure propagates as `Err`, so the
+    // caller (the walk) can tell a genuinely-childless node from an `AXChildren` read that
+    // actually broke instead of silently dropping a subtree.
+    let Some(value) = copy_attribute_checked(el, attr_name)? else {
+        return Ok(Vec::new());
+    };
     let arr = value
         .downcast::<CFArray>()
         .map_err(|_| GlassError::Backend(format!("{attr_name} did not return a CFArray")))?;
@@ -204,4 +269,34 @@ fn axvalue(el: &AXUIElement, attr_name: &str) -> Result<CFRetained<AXValue>> {
 /// message (mirrors `axwindow::ax_backend_err`).
 fn ax_err(context: &str, err: AXError) -> GlassError {
     GlassError::Backend(format!("{context}: AX call failed (AXError {})", err.0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_absent_error;
+    use objc2_application_services::AXError;
+
+    #[test]
+    fn absent_ax_errors_classified_as_absent() {
+        // The only two AX codes that mean "the element simply doesn't carry this attribute".
+        assert!(is_absent_error(AXError::AttributeUnsupported));
+        assert!(is_absent_error(AXError::NoValue));
+    }
+
+    #[test]
+    fn success_and_real_failures_are_not_absent() {
+        // A real read failure must never be classified as "no value" — that misclassification
+        // is exactly the C1 silent-fallback this guards against.
+        for err in [
+            AXError::Success,
+            AXError::Failure,
+            AXError::IllegalArgument,
+            AXError::InvalidUIElement,
+            AXError::CannotComplete,
+            AXError::APIDisabled,
+            AXError::NotImplemented,
+        ] {
+            assert!(!is_absent_error(err), "{err:?} must not be treated as absent");
+        }
+    }
 }

--- a/crates/glass-a11y-macos/src/ffi.rs
+++ b/crates/glass-a11y-macos/src/ffi.rs
@@ -33,37 +33,21 @@ use objc2_core_foundation::{CFArray, CFBoolean, CFRetained, CFString, CFType, CG
 
 use glass_core::{GlassError, Result};
 
-// Plain C predicates/queries not surfaced (or not surfaced in the shape we want) by the
-// objc2 bindings, declared with the same contained `extern "C"` pattern `permissions.rs`
-// (`AXIsProcessTrusted`) and `axwindow.rs` (`_AXUIElementGetWindow`) use. Both are public,
-// documented, stable AX APIs (unlike `axwindow`'s private symbol), so no version-fragility
-// caveat applies.
+// `AXIsProcessTrusted` is a plain C predicate not surfaced by the objc2 bindings, declared
+// with the same contained `extern "C"` pattern `permissions.rs` uses. It is a public,
+// documented, stable AX API (unlike `axwindow.rs`'s `_AXUIElementGetWindow`, a private
+// symbol that carries its own version-fragility caveat, which doesn't apply here).
+// `AXUIElementIsAttributeSettable`/`AXUIElementSetAttributeValue` are *not* declared this
+// way — `AXUIElement` already exposes them as safe-shaped methods
+// (`is_attribute_settable`/`set_attribute_value`, both gated behind the `AXError` feature
+// this crate already enables), so [`is_settable`]/[`set_string_value`] call those directly
+// instead of duplicating the raw externs.
 #[link(name = "ApplicationServices", kind = "framework")]
 extern "C" {
     // Apple declares this `Boolean` (= `unsigned char`), NOT C99 `_Bool`. Binding it as
     // `u8` and comparing `!= 0` avoids Rust-`bool`'s validity invariant (only 0/1 are legal
     // bit patterns), matching `permissions.rs`.
     fn AXIsProcessTrusted() -> u8;
-    // `AXError AXUIElementIsAttributeSettable(AXUIElementRef, CFStringRef, Boolean*)` — the
-    // documented way to tell whether an attribute (e.g. `AXValue`) can be written, which is
-    // how the reader derives `editable`/`focusable`. `Boolean` out-param is `u8` for the
-    // same reason as above.
-    fn AXUIElementIsAttributeSettable(
-        element: &AXUIElement,
-        attribute: &CFString,
-        settable: *mut u8,
-    ) -> AXError;
-    // `AXError AXUIElementSetAttributeValue(AXUIElementRef, CFStringRef, CFTypeRef)` — the
-    // documented way to write an attribute. [`set_string_value`] uses it directly with a
-    // `CFString` value for `AXValue`: a plain string write, unlike `AXPosition`/`AXSize`
-    // (which wrap a `CGPoint`/`CGSize` in an `AXValueCreate`-built `AXValue` — see
-    // `axwindow::set_axvalue` — a step that only applies to those geometry types, not
-    // strings).
-    fn AXUIElementSetAttributeValue(
-        element: &AXUIElement,
-        attribute: &CFString,
-        value: &CFType,
-    ) -> AXError;
 }
 
 /// True if this process holds the Accessibility (AX) TCC grant. The snapshot gate calls
@@ -123,20 +107,20 @@ pub(crate) fn attribute_bool(el: &AXUIElement, attr_name: &str) -> Option<bool> 
     value.downcast_ref::<CFBoolean>().map(CFBoolean::as_bool)
 }
 
-/// Whether `attr_name` is writable on `el` (`AXUIElementIsAttributeSettable`). `false` on
-/// any AX error, including the attribute being absent — the reader uses this for `editable`
-/// (settable `AXValue`) and `focusable` (settable `AXFocused`).
+/// Whether `attr_name` is writable on `el` (`AXUIElement::is_attribute_settable`). `false`
+/// on any AX error, including the attribute being absent — the reader uses this for
+/// `editable` (settable `AXValue`) and `focusable` (settable `AXFocused`).
 pub(crate) fn is_settable(el: &AXUIElement, attr_name: &str) -> bool {
     let attr = CFString::from_str(attr_name);
     let mut settable: u8 = 0;
     // SAFETY: `el` is a live `AXUIElement`; `attr` is a valid `CFString`; `settable` is a
-    // valid local out-param matching `AXUIElementIsAttributeSettable`'s documented
-    // `Boolean *` parameter.
-    let err = unsafe { AXUIElementIsAttributeSettable(el, &attr, &mut settable) };
+    // valid local out-param matching `is_attribute_settable`'s documented `Boolean *`
+    // parameter (mirrors `copy_attribute`'s `NonNull`-out-param pattern above).
+    let err = unsafe { el.is_attribute_settable(&attr, NonNull::from(&mut settable)) };
     err == AXError::Success && settable != 0
 }
 
-/// Write `text` as `el`'s `AXValue` (`AXUIElementSetAttributeValue`). The caller
+/// Write `text` as `el`'s `AXValue` (`AXUIElement::set_attribute_value`). The caller
 /// (`reader::set_value`) gates this on [`is_settable`] first; this only performs the write —
 /// it does not read back to verify the value actually took (that honesty check is the
 /// caller's read-back poll, mirroring the Windows reader's `set_value` contract).
@@ -146,8 +130,8 @@ pub(crate) fn set_string_value(el: &AXUIElement, text: &str) -> Result<()> {
     // SAFETY: `el` is a live `AXUIElement`; `attr`/`value` are valid `CFString`s. `value`
     // deref-coerces `CFRetained<CFString>` -> `CFString` -> `CFType` (the same two-hop
     // coercion `axwindow::set_axvalue` already relies on for its `CFRetained<AXValue>`
-    // argument), matching `AXUIElementSetAttributeValue`'s documented `CFTypeRef` parameter.
-    let err = unsafe { AXUIElementSetAttributeValue(el, &attr, &value) };
+    // argument), matching `set_attribute_value`'s documented `CFTypeRef` parameter.
+    let err = unsafe { el.set_attribute_value(&attr, &value) };
     if err != AXError::Success {
         return Err(ax_err("AXValue", err));
     }

--- a/crates/glass-a11y-macos/src/ffi.rs
+++ b/crates/glass-a11y-macos/src/ffi.rs
@@ -1,0 +1,194 @@
+//! The macOS `AXUIElement` read primitives the accessibility snapshot needs, and the
+//! Accessibility-grant predicate that gates it.
+//!
+//! This crate is deliberately standalone — it does **not** depend on `glass-macos` — so the
+//! small subset of AX read wrappers it needs are re-implemented here rather than imported.
+//! Every objc2 call shape is ported verbatim from `glass-macos/src/axwindow.rs`
+//! (window position/size/children reads) and `glass-macos/src/permissions.rs` (the
+//! `AXIsProcessTrusted` grant gate); see those modules' docs for the fuller rationale behind
+//! each idiom. All of this crate's `unsafe` lives in this module, each block carrying the
+//! same `// SAFETY:` justification its `axwindow.rs`/`permissions.rs` counterpart does;
+//! `reader.rs` stays `unsafe`-free.
+//!
+//! ## CFType memory: every AX "Copy" call returns a +1 ref
+//!
+//! `AXUIElementCopyAttributeValue` follows Core Foundation's Copy/Create ownership rule —
+//! the caller owns the returned ref. [`copy_attribute`] wraps the raw `*const CFType` in a
+//! `CFRetained<CFType>` via `CFRetained::from_raw` (no extra retain), so it is released
+//! automatically on drop; nothing here calls `CFRelease` manually. Mirrors
+//! `axwindow::copy_attribute`.
+//!
+//! ## `objc2-application-services`: the `kAX*` name constants are empty stubs
+//!
+//! `header-translator` produced empty generated files for the `AXAttributeConstants`/
+//! `AXRoleConstants` features, so the `kAXRoleAttribute`/`kAXTitleAttribute`/... symbols do
+//! not exist. Every attribute name here is built as a `CFString::from_str` literal
+//! (`"AXRole"`, `"AXTitle"`, ...) — the stable documented strings — exactly as `axwindow.rs`
+//! does.
+
+use std::ptr::NonNull;
+
+use objc2_application_services::{AXError, AXUIElement, AXValue, AXValueType};
+use objc2_core_foundation::{CFArray, CFBoolean, CFRetained, CFString, CFType, CGPoint, CGSize};
+
+use glass_core::{GlassError, Result};
+
+// Plain C predicates/queries not surfaced (or not surfaced in the shape we want) by the
+// objc2 bindings, declared with the same contained `extern "C"` pattern `permissions.rs`
+// (`AXIsProcessTrusted`) and `axwindow.rs` (`_AXUIElementGetWindow`) use. Both are public,
+// documented, stable AX APIs (unlike `axwindow`'s private symbol), so no version-fragility
+// caveat applies.
+#[link(name = "ApplicationServices", kind = "framework")]
+extern "C" {
+    // Apple declares this `Boolean` (= `unsigned char`), NOT C99 `_Bool`. Binding it as
+    // `u8` and comparing `!= 0` avoids Rust-`bool`'s validity invariant (only 0/1 are legal
+    // bit patterns), matching `permissions.rs`.
+    fn AXIsProcessTrusted() -> u8;
+    // `AXError AXUIElementIsAttributeSettable(AXUIElementRef, CFStringRef, Boolean*)` — the
+    // documented way to tell whether an attribute (e.g. `AXValue`) can be written, which is
+    // how the reader derives `editable`/`focusable`. `Boolean` out-param is `u8` for the
+    // same reason as above.
+    fn AXUIElementIsAttributeSettable(
+        element: &AXUIElement,
+        attribute: &CFString,
+        settable: *mut u8,
+    ) -> AXError;
+}
+
+/// True if this process holds the Accessibility (AX) TCC grant. The snapshot gate calls
+/// this first and fails closed (never returns a stub tree) when it is false.
+pub(crate) fn accessibility_is_trusted() -> bool {
+    // SAFETY: `AXIsProcessTrusted` is a no-argument C predicate over this process's trust
+    // state; no preconditions, no side effects. Returns `Boolean` (u8); any nonzero value
+    // means trusted (mirrors `permissions.rs::accessibility_granted`).
+    unsafe { AXIsProcessTrusted() != 0 }
+}
+
+/// The application-level `AXUIElement` for `pid` — the root the window search starts from.
+pub(crate) fn app_element(pid: i32) -> CFRetained<AXUIElement> {
+    // SAFETY: `AXUIElementCreateApplication` never returns NULL per Apple's documented
+    // contract (the binding itself `.expect()`s on this); `pid` is a plain process id with
+    // no aliasing/lifetime preconditions (mirrors `axwindow::ax_window_for_cgwindowid`).
+    unsafe { AXUIElement::new_application(pid) }
+}
+
+/// `AXUIElementCopyAttributeValue(el, attr_name, ...)`, wrapping the already-retained (+1,
+/// per Core Foundation's Copy/Create rule) raw result in a `CFRetained<CFType>` so it is
+/// released automatically when dropped. Errors (`AXError` != `Success`) become a structured
+/// [`GlassError::Backend`] naming the attribute — an absent attribute is one such error, so
+/// the value accessors below (`attribute_string`/`attribute_bool`) treat that as "no value"
+/// rather than a hard failure.
+pub(crate) fn copy_attribute(el: &AXUIElement, attr_name: &str) -> Result<CFRetained<CFType>> {
+    let attr = CFString::from_str(attr_name);
+    let mut raw: *const CFType = std::ptr::null();
+    // SAFETY: `el` is a live `AXUIElement`; `raw` is a valid local out-param slot matching
+    // `AXUIElementCopyAttributeValue`'s documented signature (mirrors
+    // `axwindow::copy_attribute`).
+    let err = unsafe { el.copy_attribute_value(&attr, NonNull::from(&mut raw)) };
+    if err != AXError::Success {
+        return Err(ax_err(attr_name, err));
+    }
+    let nn = NonNull::new(raw.cast_mut())
+        .ok_or_else(|| GlassError::Backend(format!("{attr_name}: AX reported success but returned a null value")))?;
+    // SAFETY: `AXUIElementCopyAttributeValue` follows Core Foundation's Copy/Create
+    // ownership rule — an already-retained (+1) `CFTypeRef` on success — so
+    // `CFRetained::from_raw` takes ownership without an extra retain (mirrors `axwindow`).
+    Ok(unsafe { CFRetained::from_raw(nn) })
+}
+
+/// Read `el`'s `attr_name` as a `String`, or `None` when the attribute is absent, isn't a
+/// `CFString`, or is the empty string. A missing attribute is a normal state (most nodes
+/// lack most attributes), so this collapses to `None` rather than surfacing an error.
+pub(crate) fn attribute_string(el: &AXUIElement, attr_name: &str) -> Option<String> {
+    let value = copy_attribute(el, attr_name).ok()?;
+    let text = value.downcast::<CFString>().ok()?.to_string();
+    (!text.is_empty()).then_some(text)
+}
+
+/// Read `el`'s `attr_name` as a `bool` (`CFBoolean`), or `None` when the attribute is absent
+/// or isn't a boolean.
+pub(crate) fn attribute_bool(el: &AXUIElement, attr_name: &str) -> Option<bool> {
+    let value = copy_attribute(el, attr_name).ok()?;
+    value.downcast_ref::<CFBoolean>().map(CFBoolean::as_bool)
+}
+
+/// Whether `attr_name` is writable on `el` (`AXUIElementIsAttributeSettable`). `false` on
+/// any AX error, including the attribute being absent — the reader uses this for `editable`
+/// (settable `AXValue`) and `focusable` (settable `AXFocused`).
+pub(crate) fn is_settable(el: &AXUIElement, attr_name: &str) -> bool {
+    let attr = CFString::from_str(attr_name);
+    let mut settable: u8 = 0;
+    // SAFETY: `el` is a live `AXUIElement`; `attr` is a valid `CFString`; `settable` is a
+    // valid local out-param matching `AXUIElementIsAttributeSettable`'s documented
+    // `Boolean *` parameter.
+    let err = unsafe { AXUIElementIsAttributeSettable(el, &attr, &mut settable) };
+    err == AXError::Success && settable != 0
+}
+
+/// Read `el`'s `AXPosition` (top-left, in points — Quartz's top-left-origin global screen
+/// space, the same unit `AXSize` and `glass_core::coords` convert to/from pixels).
+pub(crate) fn ax_position(el: &AXUIElement) -> Result<(f64, f64)> {
+    let value = axvalue(el, "AXPosition")?;
+    let mut point = CGPoint { x: 0.0, y: 0.0 };
+    // SAFETY: `value` was just verified (via `downcast`) to be a real `AXValue`; `point` is
+    // a valid local out-param whose type matches the requested `AXValueType::CGPoint`
+    // (mirrors `axwindow::ax_position`).
+    let ok = unsafe { value.value(AXValueType::CGPoint, NonNull::from(&mut point).cast()) };
+    if !ok {
+        return Err(GlassError::Backend("AXValueGetValue(AXPosition, .cgPoint) returned false".into()));
+    }
+    Ok((point.x, point.y))
+}
+
+/// Read `el`'s `AXSize` (width/height, in points).
+pub(crate) fn ax_size(el: &AXUIElement) -> Result<(f64, f64)> {
+    let value = axvalue(el, "AXSize")?;
+    let mut size = CGSize { width: 0.0, height: 0.0 };
+    // SAFETY: same as `ax_position` above, with `AXValueType::CGSize`/`CGSize`.
+    let ok = unsafe { value.value(AXValueType::CGSize, NonNull::from(&mut size).cast()) };
+    if !ok {
+        return Err(GlassError::Backend("AXValueGetValue(AXSize, .cgSize) returned false".into()));
+    }
+    Ok((size.width, size.height))
+}
+
+/// `el`'s `AXChildren` as a `Vec` of typed element refs (array order preserved). Errors if
+/// the attribute copy fails; the reader treats that as "no children" (a leaf).
+pub(crate) fn children(el: &AXUIElement) -> Result<Vec<CFRetained<AXUIElement>>> {
+    array_of_elements(el, "AXChildren")
+}
+
+/// `app`'s `AXWindows` as a `Vec` of typed element refs.
+pub(crate) fn app_windows(app: &AXUIElement) -> Result<Vec<CFRetained<AXUIElement>>> {
+    array_of_elements(app, "AXWindows")
+}
+
+/// Shared body of [`children`]/[`app_windows`]: copy an element-array attribute, reinterpret
+/// it as a typed `CFArray<AXUIElement>`, and collect its entries.
+fn array_of_elements(el: &AXUIElement, attr_name: &str) -> Result<Vec<CFRetained<AXUIElement>>> {
+    let value = copy_attribute(el, attr_name)?;
+    let arr = value
+        .downcast::<CFArray>()
+        .map_err(|_| GlassError::Backend(format!("{attr_name} did not return a CFArray")))?;
+    // SAFETY: `AXChildren`/`AXWindows` are documented by Apple to hold `AXUIElementRef`s;
+    // this only attaches compile-time element-type information (no runtime effect) — the
+    // same technique `axwindow::ax_windows` uses (`CFRetained::cast_unchecked`).
+    let typed: CFRetained<CFArray<AXUIElement>> = unsafe { CFRetained::cast_unchecked(arr) };
+    Ok(typed.iter().collect())
+}
+
+/// Copy `el`'s `attr_name` value, downcast-checked to a concrete `AXValue` (position/size
+/// are always `AXValue`-wrapped `CGPoint`/`CGSize`, never a bare `CFType`).
+fn axvalue(el: &AXUIElement, attr_name: &str) -> Result<CFRetained<AXValue>> {
+    let value = copy_attribute(el, attr_name)?;
+    value
+        .downcast::<AXValue>()
+        .map_err(|_| GlassError::Backend(format!("{attr_name} did not return an AXValue")))
+}
+
+/// Build a [`GlassError::Backend`] naming both the failing AX attribute and the raw
+/// `AXError` code, so a diagnostic doesn't collapse every AX failure into one opaque
+/// message (mirrors `axwindow::ax_backend_err`).
+fn ax_err(context: &str, err: AXError) -> GlassError {
+    GlassError::Backend(format!("{context}: AX call failed (AXError {})", err.0))
+}

--- a/crates/glass-a11y-macos/src/lib.rs
+++ b/crates/glass-a11y-macos/src/lib.rs
@@ -1,0 +1,12 @@
+//! macOS accessibility-tree reader for glass (AXUIElement behind glass-core's Accessibility seam).
+
+pub mod mapping; // pure AX->normalized mapping — cross-platform, unit-tested on the Linux dev box
+
+// `ffi`/`reader` are added in Task 4 (the cfg(macos) AXUIElement reader itself); until then
+// this crate only ships the pure mapping module above, which builds on every OS.
+// #[cfg(target_os = "macos")]
+// mod ffi;
+// #[cfg(target_os = "macos")]
+// mod reader;
+// #[cfg(target_os = "macos")]
+// pub use reader::MacosA11y;

--- a/crates/glass-a11y-macos/src/lib.rs
+++ b/crates/glass-a11y-macos/src/lib.rs
@@ -2,11 +2,12 @@
 
 pub mod mapping; // pure AX->normalized mapping — cross-platform, unit-tested on the Linux dev box
 
-// `ffi`/`reader` are added in Task 4 (the cfg(macos) AXUIElement reader itself); until then
-// this crate only ships the pure mapping module above, which builds on every OS.
-// #[cfg(target_os = "macos")]
-// mod ffi;
-// #[cfg(target_os = "macos")]
-// mod reader;
-// #[cfg(target_os = "macos")]
-// pub use reader::MacosA11y;
+// The cfg(macos) AXUIElement reader: `ffi` holds every `unsafe` AX read primitive, `reader`
+// the `unsafe`-free root selection + pre-order walk behind glass-core's `Accessibility`
+// seam. Both are gated off non-macOS, where only the pure `mapping` module above compiles.
+#[cfg(target_os = "macos")]
+mod ffi;
+#[cfg(target_os = "macos")]
+mod reader;
+#[cfg(target_os = "macos")]
+pub use reader::MacosA11y;

--- a/crates/glass-a11y-macos/src/mapping.rs
+++ b/crates/glass-a11y-macos/src/mapping.rs
@@ -1,0 +1,139 @@
+//! Pure mapping from AXUIElement role strings + gathered state facts into glass's
+//! normalized `AxRole`/`AxStates`. No AXUIElement/objc2 calls — unit-tested directly on
+//! the Linux dev box. AX role strings (`kAXRoleAttribute`'s value) are the stable
+//! `"AXButton"`/`"AXTextField"`/... constants; the reader passes the string so this
+//! module needs no macOS-only dependency.
+
+use glass_core::{AxRole, AxStates};
+
+/// Map an AX role string to the normalized `AxRole`; unmapped roles become
+/// `AxRole::Other` (the reader keeps the original string in `raw_role`). AX role
+/// strings are canonical, so the match is case-sensitive.
+pub fn map_role(ax_role: &str) -> AxRole {
+    match ax_role {
+        "AXButton" => AxRole::Button,
+        "AXCheckBox" => AxRole::CheckBox,
+        "AXRadioButton" => AxRole::RadioButton,
+        "AXRadioGroup" => AxRole::Group,
+        "AXTextField" => AxRole::TextField,
+        "AXTextArea" => AxRole::TextArea,
+        "AXStaticText" => AxRole::Label,
+        "AXWindow" => AxRole::Window,
+        "AXGroup" => AxRole::Group,
+        "AXMenu" => AxRole::Menu,
+        "AXMenuItem" => AxRole::MenuItem,
+        "AXMenuBar" => AxRole::MenuBar,
+        "AXImage" => AxRole::Image,
+        "AXLink" => AxRole::Link,
+        "AXSlider" => AxRole::Slider,
+        "AXComboBox" => AxRole::ComboBox,
+        "AXPopUpButton" => AxRole::ComboBox,
+        "AXList" => AxRole::List,
+        "AXRow" => AxRole::ListItem,
+        "AXCell" => AxRole::Cell,
+        "AXToolbar" => AxRole::Toolbar,
+        "AXTabGroup" => AxRole::TabList,
+        "AXProgressIndicator" => AxRole::ProgressBar,
+        "AXScrollBar" => AxRole::ScrollBar,
+        _ => AxRole::Other,
+    }
+}
+
+/// Plain state facts the reader gathers from an AXUIElement (no objc2/AX types here, so
+/// this stays unit-testable on Linux). Field names mirror `glass_core::AxStates` 1:1.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct AxStateFacts {
+    pub enabled: bool,
+    pub focused: bool,
+    pub focusable: bool,
+    pub selected: bool,
+    pub checked: bool,
+    pub expanded: bool,
+    pub editable: bool,
+    pub visible: bool,
+}
+
+/// Map gathered facts to the normalized `AxStates`.
+pub fn map_states(f: &AxStateFacts) -> AxStates {
+    AxStates {
+        focused: f.focused,
+        focusable: f.focusable,
+        enabled: f.enabled,
+        visible: f.visible,
+        selected: f.selected,
+        checked: f.checked,
+        expanded: f.expanded,
+        editable: f.editable,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use glass_core::AxRole;
+
+    #[test]
+    fn maps_common_ax_roles() {
+        assert_eq!(map_role("AXButton"), AxRole::Button);
+        assert_eq!(map_role("AXCheckBox"), AxRole::CheckBox);
+        assert_eq!(map_role("AXTextField"), AxRole::TextField);
+        assert_eq!(map_role("AXTextArea"), AxRole::TextArea);
+        assert_eq!(map_role("AXStaticText"), AxRole::Label);
+        assert_eq!(map_role("AXWindow"), AxRole::Window);
+    }
+
+    #[test]
+    fn unmapped_role_is_other() {
+        assert_eq!(map_role("AXRuler"), AxRole::Other);
+        assert_eq!(map_role(""), AxRole::Other);
+    }
+
+    #[test]
+    fn maps_states() {
+        let f = AxStateFacts {
+            enabled: true,
+            focused: true,
+            editable: true,
+            ..Default::default()
+        };
+        let s = map_states(&f);
+        assert!(s.enabled && s.focused && s.editable);
+        assert!(!s.checked);
+    }
+
+    #[test]
+    fn maps_additional_ax_roles() {
+        assert_eq!(map_role("AXRadioButton"), AxRole::RadioButton);
+        assert_eq!(map_role("AXGroup"), AxRole::Group);
+        assert_eq!(map_role("AXMenu"), AxRole::Menu);
+        assert_eq!(map_role("AXMenuItem"), AxRole::MenuItem);
+        assert_eq!(map_role("AXMenuBar"), AxRole::MenuBar);
+        assert_eq!(map_role("AXImage"), AxRole::Image);
+        assert_eq!(map_role("AXLink"), AxRole::Link);
+        assert_eq!(map_role("AXSlider"), AxRole::Slider);
+        assert_eq!(map_role("AXComboBox"), AxRole::ComboBox);
+        assert_eq!(map_role("AXPopUpButton"), AxRole::ComboBox);
+        assert_eq!(map_role("AXList"), AxRole::List);
+        assert_eq!(map_role("AXRow"), AxRole::ListItem);
+        assert_eq!(map_role("AXCell"), AxRole::Cell);
+        assert_eq!(map_role("AXToolbar"), AxRole::Toolbar);
+        assert_eq!(map_role("AXTabGroup"), AxRole::TabList);
+        assert_eq!(map_role("AXRadioGroup"), AxRole::Group);
+        assert_eq!(map_role("AXProgressIndicator"), AxRole::ProgressBar);
+        assert_eq!(map_role("AXScrollBar"), AxRole::ScrollBar);
+    }
+
+    #[test]
+    fn visible_and_selected_and_checked_map() {
+        let f = AxStateFacts {
+            visible: true,
+            selected: true,
+            checked: true,
+            expanded: true,
+            ..Default::default()
+        };
+        let s = map_states(&f);
+        assert!(s.visible && s.selected && s.checked && s.expanded);
+        assert!(!s.enabled && !s.focused && !s.focusable && !s.editable);
+    }
+}

--- a/crates/glass-a11y-macos/src/mapping.rs
+++ b/crates/glass-a11y-macos/src/mapping.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 //! Pure mapping from AXUIElement role strings + gathered state facts into glass's
 //! normalized `AxRole`/`AxStates`. No AXUIElement/objc2 calls — unit-tested directly on
 //! the Linux dev box. AX role strings (`kAXRoleAttribute`'s value) are the stable

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -139,12 +139,11 @@ fn walk(
     // `AXRoleDescription` is the human-readable role ("button", "text field"); fall back to
     // the raw AX role string so `raw_role` is never empty.
     let raw_role = ffi::attribute_string(el, "AXRoleDescription").unwrap_or(ax_role);
+    // Name = title, else description — both stable labels (e.g. `setAccessibilityLabel`
+    // surfaces as `AXDescription`). Never fold in `AXValue`: it's volatile content, and a
+    // node's name must stay stable for the `AxTarget` fingerprint `set_value` relies on.
+    let name = ffi::attribute_string(el, "AXTitle").or_else(|| ffi::attribute_string(el, "AXDescription"));
     let value = ffi::attribute_string(el, "AXValue");
-    // Name = title, else the current value (a titleless text field surfaces its content as
-    // its name — the only string `AxTree::to_outline` renders), else the description.
-    let name = ffi::attribute_string(el, "AXTitle")
-        .or_else(|| value.clone())
-        .or_else(|| ffi::attribute_string(el, "AXDescription"));
     let bounds = window_relative_rect(el, scale, win);
     let states = mapping::map_states(&gather_states(el));
 

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -13,9 +13,13 @@
 //! [`GlassError::PermissionDenied`]; no matching window (including an empty pid set) is a
 //! [`GlassError::WindowNotFound`]. It never returns an empty/placeholder tree.
 
+use std::time::{Duration, Instant};
+
 use glass_core::coords::pixel_geometry_from_content_rect;
 use glass_core::platform::WindowGeometry;
-use glass_core::{Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTree, GlassError, Result};
+use glass_core::{
+    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget, AxTree, GlassError, Result,
+};
 use objc2_application_services::AXUIElement;
 use objc2_core_foundation::CFRetained;
 
@@ -45,6 +49,16 @@ const POSITION_TOLERANCE_PX: i32 = 8;
 /// scale. Position + width already pin the single-window case; this is a secondary guard.
 const HEIGHT_CONSISTENCY_SLACK_PX: f64 = 96.0;
 
+/// Per-edge pixel tolerance for `set_value`'s bounds fingerprint (guards a stale id after
+/// tree drift landing a same-role+name element elsewhere) — same basis as the Windows
+/// reader's `SET_VALUE_BOUNDS_TOL`.
+const SET_VALUE_BOUNDS_TOL: i64 = 12;
+/// How long `set_value` polls the `AXValue` read-back for the write to take before declaring
+/// it a no-op. Mirrors the Windows reader's `SET_VALUE_VERIFY_MS`.
+const SET_VALUE_VERIFY_MS: u64 = 800;
+/// Interval between read-back poll attempts.
+const SET_VALUE_POLL_MS: u64 = 20;
+
 /// Remedy text for a missing Accessibility grant. Kept in sync with `glass-macos`'s
 /// `permissions.rs` wording (this crate can't depend on that private module).
 const ACCESSIBILITY_REMEDY: &str =
@@ -62,20 +76,7 @@ impl MacosA11y {
 
 impl Accessibility for MacosA11y {
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
-        // Grant gate first — fail closed with an actionable error, never a stub tree.
-        if !ffi::accessibility_is_trusted() {
-            return Err(GlassError::PermissionDenied {
-                which: "Accessibility".into(),
-                remedy: ACCESSIBILITY_REMEDY.into(),
-            });
-        }
-
-        let &pid = ctx.pids.first().ok_or(GlassError::WindowNotFound)?;
-        let app = ffi::app_element(pid as i32);
-        // A failed `AXWindows` read is "no windows" → fall through to `WindowNotFound`.
-        let windows = ffi::app_windows(&app).unwrap_or_default();
-        let (window_el, scale) =
-            select_window(&windows, &ctx.window).ok_or(GlassError::WindowNotFound)?;
+        let (window_el, scale) = resolve_window(ctx)?;
 
         let mut count = 0usize;
         let root = walk(&window_el, &ctx.window, scale, 0, &mut count);
@@ -83,6 +84,72 @@ impl Accessibility for MacosA11y {
         // identical across OS backends.
         Ok(AxTree { root, count: 0 })
     }
+
+    fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
+        let (window_el, scale) = resolve_window(ctx)?;
+
+        // Start at 0 so `find_nth`'s pre-order numbering matches `snapshot`'s `walk` +
+        // `AxTree::assign_ids` (root id = 0); the role+name+bounds fingerprint below
+        // backstops any residual drift between the snapshot and this re-walk.
+        let mut count = 0usize;
+        let el = find_nth(window_el, 0, &mut count, target.id.0)
+            .ok_or(GlassError::AxElementNotFound(target.id.0))?;
+
+        // Verify role + name + bounds (guards a stale id / tree drift): if drift landed a
+        // different same-role+name element on this pre-order id, its bounds sit elsewhere
+        // and it is rejected here rather than silently overwritten.
+        let ax_role = ffi::attribute_string(&el, "AXRole").unwrap_or_default();
+        let role = mapping::map_role(&ax_role);
+        let name =
+            ffi::attribute_string(&el, "AXTitle").or_else(|| ffi::attribute_string(&el, "AXDescription"));
+        let bounds = window_relative_rect(&el, scale, &ctx.window);
+        if !target.matches(role, name.as_deref())
+            || !target.bounds_consistent(bounds, SET_VALUE_BOUNDS_TOL)
+        {
+            return Err(GlassError::AxElementChanged(target.id.0));
+        }
+
+        if !ffi::is_settable(&el, "AXValue") {
+            return Err(GlassError::AxElementNotEditable(target.id.0));
+        }
+
+        let before = ffi::attribute_string(&el, "AXValue").unwrap_or_default();
+        ffi::set_string_value(&el, text)?;
+
+        // Read-back poll: some editables accept the AX write without an `AXError` but never
+        // actually change `AXValue` (a misleading success) — require the read-back to show
+        // the change before reporting success, never a silent false-success.
+        let deadline = Instant::now() + Duration::from_millis(SET_VALUE_VERIFY_MS);
+        loop {
+            let after = ffi::attribute_string(&el, "AXValue").unwrap_or_default();
+            if set_value_took(&before, &after, text) {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err(GlassError::AxValueNotApplied(target.id.0));
+            }
+            std::thread::sleep(Duration::from_millis(SET_VALUE_POLL_MS));
+        }
+    }
+}
+
+/// Resolve the `AXWindow` + point→pixel `scale` for `ctx`: the grant gate, pid, app element,
+/// and window selection `snapshot` and `set_value` both need — shared so both address the
+/// identical window.
+fn resolve_window(ctx: &AxContext) -> Result<(CFRetained<AXUIElement>, f64)> {
+    // Grant gate first — fail closed with an actionable error, never a stub tree.
+    if !ffi::accessibility_is_trusted() {
+        return Err(GlassError::PermissionDenied {
+            which: "Accessibility".into(),
+            remedy: ACCESSIBILITY_REMEDY.into(),
+        });
+    }
+
+    let &pid = ctx.pids.first().ok_or(GlassError::WindowNotFound)?;
+    let app = ffi::app_element(pid as i32);
+    // A failed `AXWindows` read is "no windows" → fall through to `WindowNotFound`.
+    let windows = ffi::app_windows(&app).unwrap_or_default();
+    select_window(&windows, &ctx.window).ok_or(GlassError::WindowNotFound)
 }
 
 /// Select the `AXWindow` matching the backend's reported `win` and recover its point→pixel
@@ -178,12 +245,51 @@ fn walk(
 
 /// Whether to prune `el` from the walk: it has no positive-area geometry (zero-size /
 /// collapsed / offscreen), so it is neither clickable nor useful in the outline. A named,
-/// reusable predicate so Task 5's `find_nth` prunes identically and its pre-order ids line
-/// up with this walk's. A node whose size can't be read is *kept* (its `bounds` become
-/// `None`) rather than pruned, so an unreadable-geometry container never silently drops its
-/// subtree.
+/// reusable predicate so [`find_nth`] prunes identically and its pre-order ids line up with
+/// this walk's. A node whose size can't be read is *kept* (its `bounds` become `None`)
+/// rather than pruned, so an unreadable-geometry container never silently drops its subtree.
 pub(crate) fn should_skip(el: &AXUIElement) -> bool {
     matches!(ffi::ax_size(el), Ok((w, h)) if w <= 0.0 || h <= 0.0)
+}
+
+/// Pre-order walk mirroring [`walk`]'s traversal — same `should_skip` predicate, same
+/// `AXChildren` order, same `MAX_DEPTH`/`MAX_NODES`/`MAX_SIBLINGS` bounds — to locate the
+/// element at pre-order index `target`. That is the same numbering
+/// `glass_core::AxTree::assign_ids` gives the tree `snapshot` returns (root = 0), so a
+/// `target.id` captured from a snapshot lands on the same element here. `count` doubles as
+/// the running id (a node's id is `count`'s value on arrival, before it increments) and the
+/// `MAX_NODES` bound, identically to `walk`. Takes (and, on a mismatch, drops) ownership of
+/// each candidate rather than borrowing, since a matched child must outlive the `Vec` of
+/// siblings `ffi::children` returns.
+fn find_nth(
+    el: CFRetained<AXUIElement>,
+    depth: usize,
+    count: &mut usize,
+    target: u32,
+) -> Option<CFRetained<AXUIElement>> {
+    let my_id = *count as u32;
+    *count += 1;
+    if my_id == target {
+        return Some(el);
+    }
+    if depth < MAX_DEPTH && *count < MAX_NODES {
+        let mut siblings = 0usize;
+        for child in ffi::children(&el).unwrap_or_default() {
+            siblings += 1;
+            if siblings > MAX_SIBLINGS {
+                break; // same per-level bound as walk(), so find_nth can't spin either
+            }
+            if !should_skip(&child) {
+                if let Some(found) = find_nth(child, depth + 1, count, target) {
+                    return Some(found);
+                }
+            }
+            if *count >= MAX_NODES {
+                break;
+            }
+        }
+    }
+    None
 }
 
 /// `el`'s window-relative bounds in pixels, or `None` when position/size can't be read or
@@ -210,5 +316,42 @@ fn gather_states(el: &AXUIElement) -> AxStateFacts {
         focusable: ffi::is_settable(el, "AXFocused"),
         editable: ffi::is_settable(el, "AXValue"),
         ..Default::default()
+    }
+}
+
+/// Whether a `set_value` write actually took, judged from the value read back. Some
+/// read-only-in-practice editables accept the AX write without an `AXError` but never change
+/// `AXValue` (a misleading success); a real set changes the value, possibly to a reformatted
+/// string. So it took iff the read-back equals the request OR differs from the pre-set
+/// value. Mirrors the Windows reader's `set_value_took`.
+fn set_value_took(before: &str, after: &str, requested: &str) -> bool {
+    after == requested || after != before
+}
+
+#[cfg(test)]
+mod tests {
+    use super::set_value_took;
+
+    #[test]
+    fn noop_is_not_taken() {
+        // A read-only editable: value unchanged AND not the requested text.
+        assert!(!set_value_took("hello", "hello", "world"));
+    }
+
+    #[test]
+    fn exact_match_took() {
+        assert!(set_value_took("hello", "world", "world"));
+    }
+
+    #[test]
+    fn reformatted_change_took() {
+        // The AX field may normalize the written text — changed from before, so it took.
+        assert!(set_value_took("0", "0.0", "0"));
+    }
+
+    #[test]
+    fn setting_current_value_is_taken() {
+        // Edge case: requesting the value it already holds → equals request → taken.
+        assert!(set_value_took("world", "world", "world"));
     }
 }

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -1,0 +1,215 @@
+//! `MacosA11y`: the `AXUIElement` accessibility reader behind `glass-core`'s
+//! [`Accessibility`] seam. Given the launched app's pid and the active window's pixel
+//! geometry (from the display backend), it selects the matching `AXWindow`, recovers the
+//! point→pixel scale, and walks the element subtree pre-order into a normalized [`AxTree`]
+//! in window-relative pixels.
+//!
+//! **Runs inline on the caller's thread** — unlike the Linux (AT-SPI) and Windows (UIA)
+//! readers, AX has no thread-affinity requirement that forces a worker thread, and the
+//! on-box test binary already drives this from the process's true main thread. All `unsafe`
+//! FFI lives in [`crate::ffi`]; this module is `unsafe`-free.
+//!
+//! **Fails closed, never stubs.** A missing Accessibility grant is a
+//! [`GlassError::PermissionDenied`]; no matching window (including an empty pid set) is a
+//! [`GlassError::WindowNotFound`]. It never returns an empty/placeholder tree.
+
+use glass_core::coords::pixel_geometry_from_content_rect;
+use glass_core::platform::WindowGeometry;
+use glass_core::{Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTree, GlassError, Result};
+use objc2_application_services::AXUIElement;
+use objc2_core_foundation::CFRetained;
+
+use crate::ffi;
+use crate::mapping::{self, AxStateFacts};
+
+/// Deepest subtree level walked. Bounds work on a pathological/cyclic tree together with
+/// [`MAX_NODES`]; sized generously so it never truncates a real macOS UI.
+const MAX_DEPTH: usize = 30;
+/// Global cap on nodes *entered* — the hard ceiling on snapshot size.
+const MAX_NODES: usize = 1500;
+/// Per-level cap on siblings *examined* (on- or off-screen). [`MAX_NODES`] only counts
+/// entered nodes and [`should_skip`] siblings are skipped without entering, so an
+/// all-skipped level (a virtualized list of thousands) could iterate without ever tripping
+/// `MAX_NODES`. Cap the per-level scan so the walk is genuinely bounded regardless of
+/// breadth (mirrors the Windows reader).
+const MAX_SIBLINGS: usize = 4096;
+
+/// Per-axis pixel tolerance when matching an `AXWindow`'s origin against the backend's
+/// reported window origin. Same basis as `axwindow.rs`'s geometry-match fallback.
+const POSITION_TOLERANCE_PX: i32 = 8;
+/// Slack (pixels) allowed between the backend's reported window height and the height the
+/// width-derived `scale` predicts for the `AXWindow`. The scale is taken from *width*
+/// because a title bar makes the AX frame height exceed the captured content height; this
+/// slack absorbs that difference (generous enough to cover a title bar + toolbar even at 2x
+/// Retina) while still rejecting a window whose height is wildly inconsistent with the
+/// scale. Position + width already pin the single-window case; this is a secondary guard.
+const HEIGHT_CONSISTENCY_SLACK_PX: f64 = 96.0;
+
+/// Remedy text for a missing Accessibility grant. Kept in sync with `glass-macos`'s
+/// `permissions.rs` wording (this crate can't depend on that private module).
+const ACCESSIBILITY_REMEDY: &str =
+    "enable glass in System Settings > Privacy & Security > Accessibility";
+
+/// The macOS accessibility reader. Zero-sized; a fresh AX read is performed per `snapshot`.
+#[derive(Debug, Default)]
+pub struct MacosA11y;
+
+impl MacosA11y {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Accessibility for MacosA11y {
+    fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
+        // Grant gate first — fail closed with an actionable error, never a stub tree.
+        if !ffi::accessibility_is_trusted() {
+            return Err(GlassError::PermissionDenied {
+                which: "Accessibility".into(),
+                remedy: ACCESSIBILITY_REMEDY.into(),
+            });
+        }
+
+        let &pid = ctx.pids.first().ok_or(GlassError::WindowNotFound)?;
+        let app = ffi::app_element(pid as i32);
+        // A failed `AXWindows` read is "no windows" → fall through to `WindowNotFound`.
+        let windows = ffi::app_windows(&app).unwrap_or_default();
+        let (window_el, scale) =
+            select_window(&windows, &ctx.window).ok_or(GlassError::WindowNotFound)?;
+
+        let mut count = 0usize;
+        let root = walk(&window_el, &ctx.window, scale, 0, &mut count);
+        // Ids/count are assigned by `glass-core` (`AxTree::assign_ids`) so numbering is
+        // identical across OS backends.
+        Ok(AxTree { root, count: 0 })
+    }
+}
+
+/// Select the `AXWindow` matching the backend's reported `win` and recover its point→pixel
+/// `scale`. The scale comes from *width* (`win.width / ax_width_pts`); the window matches
+/// when its `AXPosition` (scaled to pixels) lands within [`POSITION_TOLERANCE_PX`] of
+/// `win`'s origin AND its height is consistent with that scale (within
+/// [`HEIGHT_CONSISTENCY_SLACK_PX`]). Among candidates, the closest origin wins. `None` when
+/// nothing matches (fail closed).
+fn select_window(
+    windows: &[CFRetained<AXUIElement>],
+    win: &WindowGeometry,
+) -> Option<(CFRetained<AXUIElement>, f64)> {
+    let mut best: Option<(i32, CFRetained<AXUIElement>, f64)> = None;
+    for w in windows {
+        let Ok((ax_w, ax_h)) = ffi::ax_size(w) else { continue };
+        if ax_w <= 0.0 || ax_h <= 0.0 {
+            continue;
+        }
+        let scale = win.width as f64 / ax_w;
+        if !scale.is_finite() || scale <= 0.0 {
+            continue;
+        }
+        let Ok((ax_x, ax_y)) = ffi::ax_position(w) else { continue };
+        let dx = ((ax_x * scale).round() as i32 - win.x).abs();
+        let dy = ((ax_y * scale).round() as i32 - win.y).abs();
+        if dx > POSITION_TOLERANCE_PX || dy > POSITION_TOLERANCE_PX {
+            continue;
+        }
+        if (win.height as f64 - ax_h * scale).abs() > HEIGHT_CONSISTENCY_SLACK_PX {
+            continue;
+        }
+        let dist = dx + dy;
+        if best.as_ref().is_none_or(|(best_dist, _, _)| dist < *best_dist) {
+            best = Some((dist, w.clone(), scale));
+        }
+    }
+    best.map(|(_, w, scale)| (w, scale))
+}
+
+/// Pre-order walk: build this element's [`AxNode`], then recurse into its (non-skipped)
+/// children in array order. `count` is the running node total, incremented on entry and
+/// shared across the whole walk so [`MAX_NODES`] bounds the entire tree.
+fn walk(
+    el: &AXUIElement,
+    win: &WindowGeometry,
+    scale: f64,
+    depth: usize,
+    count: &mut usize,
+) -> AxNode {
+    *count += 1;
+
+    let ax_role = ffi::attribute_string(el, "AXRole").unwrap_or_default();
+    let role = mapping::map_role(&ax_role);
+    // `AXRoleDescription` is the human-readable role ("button", "text field"); fall back to
+    // the raw AX role string so `raw_role` is never empty.
+    let raw_role = ffi::attribute_string(el, "AXRoleDescription").unwrap_or(ax_role);
+    let value = ffi::attribute_string(el, "AXValue");
+    // Name = title, else the current value (a titleless text field surfaces its content as
+    // its name — the only string `AxTree::to_outline` renders), else the description.
+    let name = ffi::attribute_string(el, "AXTitle")
+        .or_else(|| value.clone())
+        .or_else(|| ffi::attribute_string(el, "AXDescription"));
+    let bounds = window_relative_rect(el, scale, win);
+    let states = mapping::map_states(&gather_states(el));
+
+    let mut children = Vec::new();
+    if depth < MAX_DEPTH && *count < MAX_NODES {
+        let mut siblings = 0usize;
+        for child in ffi::children(el).unwrap_or_default() {
+            siblings += 1;
+            if siblings > MAX_SIBLINGS {
+                break;
+            }
+            if !should_skip(&child) {
+                children.push(walk(&child, win, scale, depth + 1, count));
+            }
+            if *count >= MAX_NODES {
+                break;
+            }
+        }
+    }
+
+    AxNode {
+        id: AxNodeId(0), // assigned by glass_core::AxTree::assign_ids
+        role,
+        raw_role,
+        name,
+        value,
+        states,
+        bounds,
+        children,
+    }
+}
+
+/// Whether to prune `el` from the walk: it has no positive-area geometry (zero-size /
+/// collapsed / offscreen), so it is neither clickable nor useful in the outline. A named,
+/// reusable predicate so Task 5's `find_nth` prunes identically and its pre-order ids line
+/// up with this walk's. A node whose size can't be read is *kept* (its `bounds` become
+/// `None`) rather than pruned, so an unreadable-geometry container never silently drops its
+/// subtree.
+pub(crate) fn should_skip(el: &AXUIElement) -> bool {
+    matches!(ffi::ax_size(el), Ok((w, h)) if w <= 0.0 || h <= 0.0)
+}
+
+/// `el`'s window-relative bounds in pixels, or `None` when position/size can't be read or
+/// the element has zero area. Shares `glass_core::coords`'s point→pixel conversion with the
+/// capture/input path so a11y bounds and click geometry can't drift.
+fn window_relative_rect(el: &AXUIElement, scale: f64, win: &WindowGeometry) -> Option<AxRect> {
+    let (pos_x, pos_y) = ffi::ax_position(el).ok()?;
+    let (size_w, size_h) = ffi::ax_size(el).ok()?;
+    let g = pixel_geometry_from_content_rect(pos_x, pos_y, size_w, size_h, scale);
+    if g.width == 0 || g.height == 0 {
+        return None;
+    }
+    Some(AxRect { x: g.x - win.x, y: g.y - win.y, width: g.width, height: g.height })
+}
+
+/// Gather the plain state facts `mapping::map_states` normalizes: `AXEnabled`/`AXFocused`
+/// (boolean attributes) and `editable`/`focusable` (whether `AXValue`/`AXFocused` are
+/// writable). The remaining facts stay at their defaults — macOS doesn't expose them as
+/// simple universal attributes, and the reader never over-claims a state it didn't read.
+fn gather_states(el: &AXUIElement) -> AxStateFacts {
+    AxStateFacts {
+        enabled: ffi::attribute_bool(el, "AXEnabled").unwrap_or(false),
+        focused: ffi::attribute_bool(el, "AXFocused").unwrap_or(false),
+        focusable: ffi::is_settable(el, "AXFocused"),
+        editable: ffi::is_settable(el, "AXValue"),
+        ..Default::default()
+    }
+}

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 //! `MacosA11y`: the `AXUIElement` accessibility reader behind `glass-core`'s
 //! [`Accessibility`] seam. Given the launched app's pid and the active window's pixel
 //! geometry (from the display backend), it selects the matching `AXWindow`, recovers the
@@ -23,7 +24,7 @@ use glass_core::{
 use objc2_application_services::AXUIElement;
 use objc2_core_foundation::CFRetained;
 
-use crate::ffi;
+use crate::ffi::{self, attr};
 use crate::mapping::{self, AxStateFacts};
 
 /// Deepest subtree level walked. Bounds work on a pathological/cyclic tree together with
@@ -43,7 +44,9 @@ const MAX_SIBLINGS: usize = 4096;
 /// an already-snapped-to-integer `scale` (see [`select_window`]); the raw width ratio can be
 /// off by a few points from border/content-vs-frame insets, which is why the scale is
 /// snapped before this tolerance is applied rather than folded into a larger tolerance here.
-const POSITION_TOLERANCE_PX: i32 = 8;
+/// Typed `i64` so the pixel-offset comparison in [`select_window`] stays in `i64` end-to-end
+/// (no `.abs()` on an `i32` that could wrap — see there).
+const POSITION_TOLERANCE_PX: i64 = 8;
 /// Slack (pixels) allowed between the backend's reported window height and the height the
 /// width-derived `scale` predicts for the `AXWindow`. The scale is taken from *width*
 /// because a title bar makes the AX frame height exceed the captured content height; this
@@ -101,10 +104,10 @@ impl Accessibility for MacosA11y {
         // Verify role + name + bounds (guards a stale id / tree drift): if drift landed a
         // different same-role+name element on this pre-order id, its bounds sit elsewhere
         // and it is rejected here rather than silently overwritten.
-        let ax_role = ffi::attribute_string(&el, "AXRole").unwrap_or_default();
+        let ax_role = ffi::attribute_string(&el, attr::ROLE).unwrap_or_default();
         let role = mapping::map_role(&ax_role);
-        let name =
-            ffi::attribute_string(&el, "AXTitle").or_else(|| ffi::attribute_string(&el, "AXDescription"));
+        let name = ffi::attribute_string(&el, attr::TITLE)
+            .or_else(|| ffi::attribute_string(&el, attr::DESCRIPTION));
         let bounds = window_relative_rect(&el, scale, &ctx.window);
         if !target.matches(role, name.as_deref())
             || !target.bounds_consistent(bounds, SET_VALUE_BOUNDS_TOL)
@@ -112,21 +115,27 @@ impl Accessibility for MacosA11y {
             return Err(GlassError::AxElementChanged(target.id.0));
         }
 
-        if !ffi::is_settable(&el, "AXValue") {
+        if !ffi::is_settable(&el, attr::VALUE) {
             return Err(GlassError::AxElementNotEditable(target.id.0));
         }
 
-        let before = ffi::attribute_string(&el, "AXValue").unwrap_or_default();
+        // Best-effort pre-write value (an unreadable `AXValue` here is fine — the *post*-write
+        // confirmation below is the honesty check, and it is error-aware).
+        let before = ffi::attribute_string(&el, attr::VALUE).unwrap_or_default();
         ffi::set_string_value(&el, text)?;
 
         // Read-back poll: some editables accept the AX write without an `AXError` but never
-        // actually change `AXValue` (a misleading success) — require the read-back to show
-        // the change before reporting success, never a silent false-success.
+        // actually change `AXValue` (a misleading success) — require the read-back to show the
+        // change before reporting success, never a silent false-success. The read-back is
+        // *error-aware*: only `Ok(Some(v))` (a real value) can confirm the write; an `Err` (a
+        // genuine read failure) or `Ok(None)` (absent value) is inconclusive, so we keep
+        // polling to the deadline rather than mistaking a failed read for a change.
         let deadline = Instant::now() + Duration::from_millis(SET_VALUE_VERIFY_MS);
         loop {
-            let after = ffi::attribute_string(&el, "AXValue").unwrap_or_default();
-            if set_value_took(&before, &after, text) {
-                return Ok(());
+            if let Ok(Some(after)) = ffi::attribute_string_checked(&el, attr::VALUE) {
+                if set_value_took(&before, &after, text) {
+                    return Ok(());
+                }
             }
             if Instant::now() >= deadline {
                 return Err(GlassError::AxValueNotApplied(target.id.0));
@@ -170,7 +179,7 @@ fn select_window(
     windows: &[CFRetained<AXUIElement>],
     win: &WindowGeometry,
 ) -> Option<(CFRetained<AXUIElement>, f64)> {
-    let mut best: Option<(i32, CFRetained<AXUIElement>, f64)> = None;
+    let mut best: Option<(i64, CFRetained<AXUIElement>, f64)> = None;
     let mut diagnostics: Vec<String> = Vec::new();
     for w in windows {
         let Ok((ax_w, ax_h)) = ffi::ax_size(w) else {
@@ -192,8 +201,10 @@ fn select_window(
             diagnostics.push(format!("ax_w={ax_w} ax_h={ax_h} scale={scale} <AXPosition unreadable>"));
             continue;
         };
-        let dx = ((ax_x * scale).round() as i32 - win.x).abs();
-        let dy = ((ax_y * scale).round() as i32 - win.y).abs();
+        // Cast to `i64` before subtracting so `.abs()` can never wrap (`i32::MIN.abs()`
+        // panics) — the same no-overflow discipline `axwindow::within_tolerance` follows.
+        let dx = ((ax_x * scale).round() as i64 - i64::from(win.x)).abs();
+        let dy = ((ax_y * scale).round() as i64 - i64::from(win.y)).abs();
         diagnostics.push(format!("ax=({ax_x}, {ax_y}, {ax_w}, {ax_h}) scale={scale} dx={dx} dy={dy}"));
         if dx > POSITION_TOLERANCE_PX || dy > POSITION_TOLERANCE_PX {
             continue;
@@ -230,23 +241,38 @@ fn walk(
 ) -> AxNode {
     *count += 1;
 
-    let ax_role = ffi::attribute_string(el, "AXRole").unwrap_or_default();
+    let ax_role = ffi::attribute_string(el, attr::ROLE).unwrap_or_default();
     let role = mapping::map_role(&ax_role);
-    // `AXRoleDescription` is the human-readable role ("button", "text field"); fall back to
-    // the raw AX role string so `raw_role` is never empty.
-    let raw_role = ffi::attribute_string(el, "AXRoleDescription").unwrap_or(ax_role);
+    // `AXRoleDescription` is the human-readable role ("button", "text field"); fall back to the
+    // raw AX role string when it's absent. If both are absent (an element exposing neither)
+    // `raw_role` is the empty string — a "role unknown" signal, not a guaranteed-populated
+    // field.
+    let raw_role = ffi::attribute_string(el, attr::ROLE_DESCRIPTION).unwrap_or(ax_role);
     // Name = title, else description — both stable labels (e.g. `setAccessibilityLabel`
     // surfaces as `AXDescription`). Never fold in `AXValue`: it's volatile content, and a
     // node's name must stay stable for the `AxTarget` fingerprint `set_value` relies on.
-    let name = ffi::attribute_string(el, "AXTitle").or_else(|| ffi::attribute_string(el, "AXDescription"));
-    let value = ffi::attribute_string(el, "AXValue");
+    let name = ffi::attribute_string(el, attr::TITLE)
+        .or_else(|| ffi::attribute_string(el, attr::DESCRIPTION));
+    let value = ffi::attribute_string(el, attr::VALUE);
     let bounds = window_relative_rect(el, scale, win);
     let states = mapping::map_states(&gather_states(el));
 
     let mut children = Vec::new();
     if depth < MAX_DEPTH && *count < MAX_NODES {
+        // `ffi::children` returns `Ok(vec![])` for a legitimately-childless (or absent-
+        // `AXChildren`) node and only `Err` for a *real* AX read failure. Degrade a real
+        // failure to "no children" so one broken node can't fail the whole snapshot — but log
+        // it (mirroring `select_window`'s no-match diagnostic) so the dropped subtree is
+        // observable, never silent.
+        let child_els = ffi::children(el).unwrap_or_else(|err| {
+            eprintln!(
+                "glass-a11y-macos: walk: AXChildren read failed for role={raw_role:?} \
+                 bounds={bounds:?}: {err}; treating as no children"
+            );
+            Vec::new()
+        });
         let mut siblings = 0usize;
-        for child in ffi::children(el).unwrap_or_default() {
+        for child in child_els {
             siblings += 1;
             if siblings > MAX_SIBLINGS {
                 break;
@@ -277,7 +303,7 @@ fn walk(
 /// reusable predicate so [`find_nth`] prunes identically and its pre-order ids line up with
 /// this walk's. A node whose size can't be read is *kept* (its `bounds` become `None`)
 /// rather than pruned, so an unreadable-geometry container never silently drops its subtree.
-pub(crate) fn should_skip(el: &AXUIElement) -> bool {
+fn should_skip(el: &AXUIElement) -> bool {
     matches!(ffi::ax_size(el), Ok((w, h)) if w <= 0.0 || h <= 0.0)
 }
 
@@ -340,10 +366,10 @@ fn window_relative_rect(el: &AXUIElement, scale: f64, win: &WindowGeometry) -> O
 /// simple universal attributes, and the reader never over-claims a state it didn't read.
 fn gather_states(el: &AXUIElement) -> AxStateFacts {
     AxStateFacts {
-        enabled: ffi::attribute_bool(el, "AXEnabled").unwrap_or(false),
-        focused: ffi::attribute_bool(el, "AXFocused").unwrap_or(false),
-        focusable: ffi::is_settable(el, "AXFocused"),
-        editable: ffi::is_settable(el, "AXValue"),
+        enabled: ffi::attribute_bool(el, attr::ENABLED).unwrap_or(false),
+        focused: ffi::attribute_bool(el, attr::FOCUSED).unwrap_or(false),
+        focusable: ffi::is_settable(el, attr::FOCUSED),
+        editable: ffi::is_settable(el, attr::VALUE),
         ..Default::default()
     }
 }

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -39,7 +39,10 @@ const MAX_NODES: usize = 1500;
 const MAX_SIBLINGS: usize = 4096;
 
 /// Per-axis pixel tolerance when matching an `AXWindow`'s origin against the backend's
-/// reported window origin. Same basis as `axwindow.rs`'s geometry-match fallback.
+/// reported window origin. Same basis as `axwindow.rs`'s geometry-match fallback. Sized for
+/// an already-snapped-to-integer `scale` (see [`select_window`]); the raw width ratio can be
+/// off by a few points from border/content-vs-frame insets, which is why the scale is
+/// snapped before this tolerance is applied rather than folded into a larger tolerance here.
 const POSITION_TOLERANCE_PX: i32 = 8;
 /// Slack (pixels) allowed between the backend's reported window height and the height the
 /// width-derived `scale` predicts for the `AXWindow`. The scale is taken from *width*
@@ -153,28 +156,45 @@ fn resolve_window(ctx: &AxContext) -> Result<(CFRetained<AXUIElement>, f64)> {
 }
 
 /// Select the `AXWindow` matching the backend's reported `win` and recover its point→pixel
-/// `scale`. The scale comes from *width* (`win.width / ax_width_pts`); the window matches
-/// when its `AXPosition` (scaled to pixels) lands within [`POSITION_TOLERANCE_PX`] of
-/// `win`'s origin AND its height is consistent with that scale (within
-/// [`HEIGHT_CONSISTENCY_SLACK_PX`]). Among candidates, the closest origin wins. `None` when
-/// nothing matches (fail closed).
+/// `scale`. The scale is derived from *width* (`win.width / ax_width_pts`) then snapped to
+/// the nearest integer, floored at `1.0`: macOS backing scale is always an integer (1x or
+/// 2x Retina), so a fractional raw ratio (e.g. `396 / 400 = 0.99`, from a `win` that is the
+/// window's *content* rect vs. the `AXWindow`'s *frame* rect) is border/inset noise, not a
+/// real scale — snapping it removes that noise before the position gate below runs. The
+/// window matches when its `AXPosition` (scaled to pixels) lands within
+/// [`POSITION_TOLERANCE_PX`] of `win`'s origin AND its height is consistent with that scale
+/// (within [`HEIGHT_CONSISTENCY_SLACK_PX`]). Among candidates, the closest origin wins.
+/// `None` when nothing matches (fail closed); logs each candidate's geometry to stderr in
+/// that case so a `WindowNotFound` is diagnosable without re-instrumenting.
 fn select_window(
     windows: &[CFRetained<AXUIElement>],
     win: &WindowGeometry,
 ) -> Option<(CFRetained<AXUIElement>, f64)> {
     let mut best: Option<(i32, CFRetained<AXUIElement>, f64)> = None;
+    let mut diagnostics: Vec<String> = Vec::new();
     for w in windows {
-        let Ok((ax_w, ax_h)) = ffi::ax_size(w) else { continue };
+        let Ok((ax_w, ax_h)) = ffi::ax_size(w) else {
+            diagnostics.push("<AXSize unreadable>".into());
+            continue;
+        };
         if ax_w <= 0.0 || ax_h <= 0.0 {
+            diagnostics.push(format!("ax_w={ax_w} ax_h={ax_h} <non-positive size>"));
             continue;
         }
-        let scale = win.width as f64 / ax_w;
+        // macOS backing scale is always an integer; snap out the border/content-vs-frame
+        // inset noise in the raw width ratio (see doc comment above).
+        let scale = (win.width as f64 / ax_w).round().max(1.0);
         if !scale.is_finite() || scale <= 0.0 {
+            diagnostics.push(format!("ax_w={ax_w} ax_h={ax_h} scale={scale} <invalid scale>"));
             continue;
         }
-        let Ok((ax_x, ax_y)) = ffi::ax_position(w) else { continue };
+        let Ok((ax_x, ax_y)) = ffi::ax_position(w) else {
+            diagnostics.push(format!("ax_w={ax_w} ax_h={ax_h} scale={scale} <AXPosition unreadable>"));
+            continue;
+        };
         let dx = ((ax_x * scale).round() as i32 - win.x).abs();
         let dy = ((ax_y * scale).round() as i32 - win.y).abs();
+        diagnostics.push(format!("ax=({ax_x}, {ax_y}, {ax_w}, {ax_h}) scale={scale} dx={dx} dy={dy}"));
         if dx > POSITION_TOLERANCE_PX || dy > POSITION_TOLERANCE_PX {
             continue;
         }
@@ -185,6 +205,15 @@ fn select_window(
         if best.as_ref().is_none_or(|(best_dist, _, _)| dist < *best_dist) {
             best = Some((dist, w.clone(), scale));
         }
+    }
+    if best.is_none() {
+        // Fail-closed dev-tool diagnostic (stderr only, no new error variant): a
+        // `WindowNotFound` with no clue why is much harder to debug than one that shows
+        // exactly how close (or not) each candidate came.
+        eprintln!(
+            "glass-a11y-macos: select_window found no match for ctx.window={win:?}; candidates: [{}]",
+            diagnostics.join(", ")
+        );
     }
     best.map(|(_, w, scale)| (w, scale))
 }

--- a/crates/glass-core/src/coords.rs
+++ b/crates/glass-core/src/coords.rs
@@ -1,0 +1,183 @@
+//! Pure window-relative / global ↔ point/pixel coordinate scale math. Cross-platform →
+//! unit-tested on the Linux dev box.
+//!
+//! This is the single source of truth for point↔pixel conversion on macOS, shared by
+//! `glass-macos` (capture/window ops) and `glass-a11y-macos` (the accessibility reader) so
+//! a11y bounds and capture/input geometry can never drift apart.
+//!
+//! The whole glass tool boundary — `WindowGeometry`, the captured `Frame`, and
+//! click/region coordinates — is backing PIXELS on macOS, matching `glass-x11` and
+//! `glass-windows`. Quartz's `CGEvent` APIs, though, address the *global* screen in
+//! POINTS, not pixels — so the macOS backend uses [`pixel_to_global_point`] to map a
+//! window-relative PIXEL coordinate to a global POINT before posting a CGEvent.
+//! [`pixel_geometry_from_content_rect`] is the mirror-image conversion `scwindow.rs` uses
+//! to turn `SCContentFilter`'s `contentRect` (POINTS) + `pointPixelScale` into the PIXEL
+//! `WindowGeometry` the tool boundary reports.
+//!
+//! [`global_pixel_to_point`]/[`point_to_global_pixel`] are the ABSOLUTE (no window-origin
+//! offset) counterparts, for window `Move`/`Resize`/`Geometry` ops that address the global
+//! screen directly via `AXUIElement` rather than a window-relative click.
+
+use crate::platform::WindowGeometry;
+
+/// Map a window-relative PIXEL coordinate to a global POINT in Quartz's screen space:
+/// `origin_pt + rel_px / scale`. `scale` is the window's `pointPixelScale` (`1.0` on a 1x
+/// display, `2.0` on 2x Retina) and `origin_pt` is the window's `contentRect.origin` in
+/// POINTS (see [`pixel_geometry_from_content_rect`]'s doc for where both come from).
+///
+/// The macOS backend needs this because CGEvents post into a POINTS-addressed global
+/// space, while every tool-boundary coordinate (click/region, `WindowGeometry`, the
+/// captured `Frame`) is backing PIXELS — matching `glass-x11`/`glass-windows`. This is the
+/// one place a pixel value crosses back into points, right before posting a CGEvent.
+pub fn pixel_to_global_point(rel_px: (i32, i32), scale: f64, origin_pt: (f64, f64)) -> (f64, f64) {
+    (origin_pt.0 + rel_px.0 as f64 / scale, origin_pt.1 + rel_px.1 as f64 / scale)
+}
+
+/// Map an ABSOLUTE global-screen PIXEL coordinate to Quartz's global POINT space:
+/// `px / scale`. Unlike [`pixel_to_global_point`] (which is window-RELATIVE and adds a
+/// window's `origin_pt`), this has no origin term — it's for window Move/Resize/Geometry
+/// ops, which address the global screen directly (a `WindowOp::Move` target, or an
+/// `AXUIElement` position/size already in global points), not a click relative to a
+/// window's top-left.
+pub fn global_pixel_to_point(px: (i32, i32), scale: f64) -> (f64, f64) {
+    (px.0 as f64 / scale, px.1 as f64 / scale)
+}
+
+/// The inverse of [`global_pixel_to_point`]: map an ABSOLUTE global POINT (e.g. read back
+/// from `AXUIElement`'s position/size) to a global PIXEL coordinate: `pt * scale`, rounded
+/// to the nearest pixel (ties away from zero, matching
+/// [`pixel_geometry_from_content_rect`]'s rounding).
+pub fn point_to_global_pixel(pt: (f64, f64), scale: f64) -> (i32, i32) {
+    ((pt.0 * scale).round() as i32, (pt.1 * scale).round() as i32)
+}
+
+/// Convert a window's `contentRect` (POINTS, from `SCContentFilter.contentRect()`) plus
+/// its `pointPixelScale` into a `WindowGeometry` in backing PIXELS — the unit the whole
+/// tool boundary uses. `x`/`y` is `contentRect.origin`, `width`/`height` is
+/// `contentRect.size`; each field is independently scaled by `scale` and rounded to the
+/// nearest pixel, matching how `capture::capture_window` sizes the captured `Frame`
+/// (`contentRect.size * pointPixelScale`) — so `scwindow.rs`'s reported geometry and
+/// `capture.rs`'s captured frame always agree on width/height in pixels.
+///
+/// Pure `f64` math (no `CGRect` dependency) so the Retina (2x) scaling is unit-tested here
+/// even on a 1x dev box — `scwindow.rs` itself only compiles on macOS.
+///
+/// Each field rounds independently (`f64::round`, ties away from zero) rather than
+/// truncating, so a fractional point value doesn't consistently lose a pixel. Width/height
+/// clamp to `0` on a degenerate (negative) input rather than wrapping; `x`/`y` stay signed
+/// (a window can sit left-of/above the primary display's origin in a multi-monitor
+/// layout).
+pub fn pixel_geometry_from_content_rect(x: f64, y: f64, width: f64, height: f64, scale: f64) -> WindowGeometry {
+    let px = |v: f64| (v * scale).round();
+    WindowGeometry {
+        x: px(x) as i32,
+        y: px(y) as i32,
+        width: px(width).max(0.0) as u32,
+        height: px(height).max(0.0) as u32,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pixel_to_global_point_at_1x() {
+        assert_eq!(pixel_to_global_point((100, 200), 1.0, (10.0, 20.0)), (110.0, 220.0));
+    }
+
+    #[test]
+    fn pixel_to_global_point_at_2x_retina() {
+        // pixel 200 / 2 = 100pt + origin 10 = 110; pixel 400 / 2 = 200pt + origin 20 = 220.
+        assert_eq!(pixel_to_global_point((200, 400), 2.0, (10.0, 20.0)), (110.0, 220.0));
+    }
+
+    #[test]
+    fn pixel_to_global_point_handles_negative_rel_and_origin() {
+        assert_eq!(pixel_to_global_point((-40, -10), 2.0, (-5.0, 0.0)), (-25.0, -5.0));
+    }
+
+    #[test]
+    fn global_pixel_to_point_is_identity_at_1x() {
+        assert_eq!(global_pixel_to_point((100, 200), 1.0), (100.0, 200.0));
+    }
+
+    #[test]
+    fn global_pixel_to_point_halves_at_2x_retina() {
+        assert_eq!(global_pixel_to_point((200, 400), 2.0), (100.0, 200.0));
+    }
+
+    #[test]
+    fn global_pixel_to_point_handles_negative_pixels() {
+        assert_eq!(global_pixel_to_point((-200, -3), 2.0), (-100.0, -1.5));
+    }
+
+    #[test]
+    fn point_to_global_pixel_is_identity_at_1x() {
+        assert_eq!(point_to_global_pixel((100.0, 200.0), 1.0), (100, 200));
+    }
+
+    #[test]
+    fn point_to_global_pixel_doubles_at_2x_retina() {
+        assert_eq!(point_to_global_pixel((100.0, 200.0), 2.0), (200, 400));
+    }
+
+    #[test]
+    fn point_to_global_pixel_rounds_to_nearest_pixel() {
+        // 1.25 * 2 = 2.5 -> 3 (round-half-away-from-zero, per f64::round).
+        assert_eq!(point_to_global_pixel((1.25, 1.25), 2.0), (3, 3));
+    }
+
+    #[test]
+    fn global_pixel_point_round_trip_at_1x_and_2x() {
+        for scale in [1.0, 2.0] {
+            let px = (137, -42);
+            let pt = global_pixel_to_point(px, scale);
+            assert_eq!(point_to_global_pixel(pt, scale), px);
+        }
+    }
+
+    #[test]
+    fn pixel_geometry_from_content_rect_is_identity_at_1x() {
+        assert_eq!(
+            pixel_geometry_from_content_rect(10.0, 20.0, 300.0, 200.0, 1.0),
+            WindowGeometry { x: 10, y: 20, width: 300, height: 200 }
+        );
+    }
+
+    #[test]
+    fn pixel_geometry_from_content_rect_scales_at_2x_retina() {
+        assert_eq!(
+            pixel_geometry_from_content_rect(10.0, 20.0, 300.0, 200.0, 2.0),
+            WindowGeometry { x: 20, y: 40, width: 600, height: 400 }
+        );
+    }
+
+    #[test]
+    fn pixel_geometry_from_content_rect_rounds_to_nearest_pixel() {
+        // 1*1.5=1.5 -> 2, 3*1.5=4.5 -> 5 (round-half-away-from-zero, per f64::round):
+        // fields round independently rather than truncating.
+        assert_eq!(
+            pixel_geometry_from_content_rect(1.0, 1.0, 3.0, 3.0, 1.5),
+            WindowGeometry { x: 2, y: 2, width: 5, height: 5 }
+        );
+    }
+
+    #[test]
+    fn pixel_geometry_from_content_rect_clamps_negative_size_to_zero() {
+        // A real contentRect from SCContentFilter never has a negative size, but the
+        // conversion must not panic or wrap on malformed input.
+        assert_eq!(
+            pixel_geometry_from_content_rect(0.0, 0.0, -1.0, -1.0, 2.0),
+            WindowGeometry { x: 0, y: 0, width: 0, height: 0 }
+        );
+    }
+
+    #[test]
+    fn pixel_geometry_from_content_rect_preserves_negative_origin() {
+        assert_eq!(
+            pixel_geometry_from_content_rect(-50.0, -10.0, 100.0, 80.0, 2.0),
+            WindowGeometry { x: -100, y: -20, width: 200, height: 160 }
+        );
+    }
+}

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -24,6 +24,8 @@ pub use drag::{run_drag, DragGesture, DragSink};
 pub mod chord;
 pub use chord::{run_chord, ChordSink, CHORD_DWELL};
 
+pub mod coords;
+
 pub mod scroll;
 pub use scroll::{run_scroll, ScrollSink, SCROLL_DWELL};
 

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -32,6 +32,14 @@ harness = false
 name = "windows"
 harness = false
 
+# Mac-gated accessibility-reader integration test (crates/glass-macos/tests/a11y.rs) — same
+# harness=false main-thread requirement as `capture`/`input`/`windows` above (start_app
+# reaches AppKit's ffi::app_kit_init()); drives `glass-a11y-macos`'s AXUIElement snapshot
+# against the `a11y_fixture` app. See that file's module doc.
+[[test]]
+name = "a11y"
+harness = false
+
 [dependencies]
 glass-core.workspace = true
 
@@ -126,6 +134,12 @@ block2 = "0.6.2"
 # glass-proc-linux use it on Linux); its `kill_process`/`Pid`/`Signal` are plain POSIX
 # and available on macOS too.
 rustix.workspace = true
+
+# Mac-only: the accessibility-reader integration test (tests/a11y.rs) drives the standalone
+# `glass-a11y-macos` snapshot. Kept in the cfg(macos) dev-dep table so the crate still
+# builds/tests on the Linux dev box (where the cfg(macos) test is a bare skip `main`).
+[target.'cfg(target_os = "macos")'.dev-dependencies]
+glass-a11y-macos.workspace = true
 
 [lints]
 workspace = true

--- a/crates/glass-macos/fixture/a11y_fixture.swift
+++ b/crates/glass-macos/fixture/a11y_fixture.swift
@@ -1,0 +1,74 @@
+// a11y_fixture.swift — glass-macos accessibility-tree test fixture (Plan 6 Task 3).
+//
+// A minimal Cocoa app whose window exposes a real NSAccessibility tree with three named
+// controls, for the macOS a11y reader's later on-box tests (Plan 6) to drive by name:
+//
+//   - an NSButton titled "Save" — prints `SAVE_CLICKED` to stdout (flushed) when clicked,
+//     so a later bounds-agreement test can grep the app's captured stdout for the marker.
+//   - an NSButton checkbox labelled "Enable".
+//   - an editable NSTextField labelled "Note", initial value "hello".
+//
+// Each control sets an explicit `accessibilityLabel` so the reader can find it by name
+// regardless of its visible title/string value. Sibling to `quadrants.swift` (the
+// capture/input fixture) in this same directory; kept separate because it exercises a
+// different concern (accessibility-tree contents, not pixels or raw input events).
+//
+// Build: swiftc -parse-as-library a11y_fixture.swift -o a11y_fixture
+//   (`-parse-as-library` is required because this file uses a top-level `@main` type
+//   rather than unadorned top-level statements — the same gotcha documented in
+//   quadrants.swift's build comment.)
+
+import AppKit
+
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    let window = NSWindow(
+        contentRect: NSRect(x: 0, y: 0, width: 400, height: 200),
+        styleMask: [.titled], backing: .buffered, defer: false)
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        let save = NSButton(title: "Save", target: self, action: #selector(onSave))
+        save.frame = NSRect(x: 20, y: 140, width: 80, height: 32)
+        save.setAccessibilityLabel("Save")
+
+        let enable = NSButton(checkboxWithTitle: "Enable", target: nil, action: nil)
+        enable.frame = NSRect(x: 20, y: 100, width: 120, height: 24)
+        enable.setAccessibilityLabel("Enable")
+
+        let note = NSTextField(string: "hello")
+        note.frame = NSRect(x: 20, y: 60, width: 200, height: 24)
+        note.setAccessibilityLabel("Note")
+
+        let contentView = NSView(frame: window.contentView!.bounds)
+        contentView.addSubview(save)
+        contentView.addSubview(enable)
+        contentView.addSubview(note)
+        window.contentView = contentView
+        window.title = "glass a11y fixture"
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    // `print` is fully buffered (not line-buffered) once stdout is a pipe rather than a
+    // TTY — and a later task's bounds-agreement test captures this app's stdout through a
+    // pipe and greps it for the marker, so the write must be flushed explicitly or it may
+    // never arrive before the test gives up. The brief's original
+    // `FileHandle.standardOutput.synchronizeFile()` calls `fsync(2)` under the hood,
+    // which fails — and raises an uncatchable Objective-C exception, crashing the
+    // process — on a non-seekable fd such as a pipe. `fflush(stdout)`, the convention
+    // already used throughout `quadrants.swift`, is the safe equivalent here.
+    @objc func onSave() {
+        print("SAVE_CLICKED")
+        fflush(stdout)
+    }
+}
+
+@main
+struct Main {
+    static func main() {
+        let app = NSApplication.shared
+        app.setActivationPolicy(.regular)
+        let delegate = AppDelegate()
+        app.delegate = delegate
+        app.run()
+    }
+}

--- a/crates/glass-macos/fixture/a11y_fixture.swift
+++ b/crates/glass-macos/fixture/a11y_fixture.swift
@@ -1,7 +1,7 @@
-// a11y_fixture.swift — glass-macos accessibility-tree test fixture (Plan 6 Task 3).
+// a11y_fixture.swift — glass-macos accessibility-tree test fixture.
 //
 // A minimal Cocoa app whose window exposes a real NSAccessibility tree with three named
-// controls, for the macOS a11y reader's later on-box tests (Plan 6) to drive by name:
+// controls, for the macOS a11y reader's on-box tests to drive by name:
 //
 //   - an NSButton titled "Save" — prints `SAVE_CLICKED` to stdout (flushed) when clicked,
 //     so a later bounds-agreement test can grep the app's captured stdout for the marker.

--- a/crates/glass-macos/src/coords.rs
+++ b/crates/glass-macos/src/coords.rs
@@ -1,23 +1,23 @@
 //! Pure window-relative ↔ global coordinate math. Cross-platform → unit-tested on the
 //! Linux dev box.
 //!
-//! The whole glass tool boundary — `WindowGeometry`, the captured `Frame`, and
-//! click/region coordinates — is backing PIXELS on macOS, matching `glass-x11` and
-//! `glass-windows`. Quartz's `CGEvent` APIs, though, address the *global* screen in
-//! POINTS, not pixels — so the macOS backend (Plan 3) uses [`pixel_to_global_point`] to
-//! map a window-relative PIXEL coordinate to a global POINT before posting a CGEvent.
-//! [`pixel_geometry_from_content_rect`] is the mirror-image conversion `scwindow.rs` uses
-//! to turn `SCContentFilter`'s `contentRect` (POINTS) + `pointPixelScale` into the PIXEL
-//! `WindowGeometry` the tool boundary reports.
-//!
-//! [`global_pixel_to_point`]/[`point_to_global_pixel`] are Plan 4's ABSOLUTE (no
-//! window-origin offset) counterparts, for window `Move`/`Resize`/`Geometry` ops that
-//! address the global screen directly via `AXUIElement` rather than a window-relative
-//! click.
+//! The point↔pixel scale kernel itself lives in [`glass_core::coords`] so glass-macos
+//! (capture/window ops) and glass-a11y-macos (the a11y reader) share ONE implementation —
+//! a11y bounds and capture/input geometry can never drift apart. This module keeps the
+//! window-relative helpers (`to_global`, `check_in_bounds`, `clamp_region`) that only
+//! glass-macos needs.
 
 use glass_core::frame::Region;
-use glass_core::platform::WindowGeometry;
 use glass_core::{GlassError, Result};
+
+// The scale kernel lives in glass-core so glass-macos (capture/window ops) and
+// glass-a11y-macos (the a11y reader) share ONE implementation — a11y bounds and
+// capture/input geometry can never drift apart. See the a11y-reader design's
+// "anti-drift guard" section.
+pub use glass_core::coords::{
+    global_pixel_to_point, pixel_geometry_from_content_rect, pixel_to_global_point,
+    point_to_global_pixel,
+};
 
 /// Translate a window-relative point to a global screen point given the window origin.
 pub fn to_global(origin: (i32, i32), rel: (i32, i32)) -> (i32, i32) {
@@ -42,63 +42,6 @@ pub fn clamp_region(rx: i32, ry: i32, rw: u32, rh: u32, width: u32, height: u32)
     let right = (rx as i64 + rw as i64).clamp(0, w_i);
     let bottom = (ry as i64 + rh as i64).clamp(0, h_i);
     Region { x: left as u32, y: top as u32, width: (right - left) as u32, height: (bottom - top) as u32 }
-}
-
-/// Map a window-relative PIXEL coordinate to a global POINT in Quartz's screen space:
-/// `origin_pt + rel_px / scale`. `scale` is the window's `pointPixelScale` (`1.0` on a 1x
-/// display, `2.0` on 2x Retina) and `origin_pt` is the window's `contentRect.origin` in
-/// POINTS (see [`pixel_geometry_from_content_rect`]'s doc for where both come from).
-///
-/// The macOS backend needs this because CGEvents post into a POINTS-addressed global
-/// space, while every tool-boundary coordinate (click/region, `WindowGeometry`, the
-/// captured `Frame`) is backing PIXELS — matching `glass-x11`/`glass-windows`. This is the
-/// one place a pixel value crosses back into points, right before posting a CGEvent.
-pub fn pixel_to_global_point(rel_px: (i32, i32), scale: f64, origin_pt: (f64, f64)) -> (f64, f64) {
-    (origin_pt.0 + rel_px.0 as f64 / scale, origin_pt.1 + rel_px.1 as f64 / scale)
-}
-
-/// Map an ABSOLUTE global-screen PIXEL coordinate to Quartz's global POINT space:
-/// `px / scale`. Unlike [`pixel_to_global_point`] (which is window-RELATIVE and adds a
-/// window's `origin_pt`), this has no origin term — it's for Plan 4's window
-/// Move/Resize/Geometry ops, which address the global screen directly (a `WindowOp::Move`
-/// target, or an `AXUIElement` position/size already in global points), not a click
-/// relative to a window's top-left.
-pub fn global_pixel_to_point(px: (i32, i32), scale: f64) -> (f64, f64) {
-    (px.0 as f64 / scale, px.1 as f64 / scale)
-}
-
-/// The inverse of [`global_pixel_to_point`]: map an ABSOLUTE global POINT (e.g. read back
-/// from `AXUIElement`'s position/size) to a global PIXEL coordinate: `pt * scale`, rounded
-/// to the nearest pixel (ties away from zero, matching
-/// [`pixel_geometry_from_content_rect`]'s rounding).
-pub fn point_to_global_pixel(pt: (f64, f64), scale: f64) -> (i32, i32) {
-    ((pt.0 * scale).round() as i32, (pt.1 * scale).round() as i32)
-}
-
-/// Convert a window's `contentRect` (POINTS, from `SCContentFilter.contentRect()`) plus
-/// its `pointPixelScale` into a `WindowGeometry` in backing PIXELS — the unit the whole
-/// tool boundary uses. `x`/`y` is `contentRect.origin`, `width`/`height` is
-/// `contentRect.size`; each field is independently scaled by `scale` and rounded to the
-/// nearest pixel, matching how `capture::capture_window` sizes the captured `Frame`
-/// (`contentRect.size * pointPixelScale`) — so `scwindow.rs`'s reported geometry and
-/// `capture.rs`'s captured frame always agree on width/height in pixels.
-///
-/// Pure `f64` math (no `CGRect` dependency) so the Retina (2x) scaling is unit-tested here
-/// even on a 1x dev box — `scwindow.rs` itself only compiles on macOS.
-///
-/// Each field rounds independently (`f64::round`, ties away from zero) rather than
-/// truncating, so a fractional point value doesn't consistently lose a pixel. Width/height
-/// clamp to `0` on a degenerate (negative) input rather than wrapping; `x`/`y` stay signed
-/// (a window can sit left-of/above the primary display's origin in a multi-monitor
-/// layout).
-pub fn pixel_geometry_from_content_rect(x: f64, y: f64, width: f64, height: f64, scale: f64) -> WindowGeometry {
-    let px = |v: f64| (v * scale).round();
-    WindowGeometry {
-        x: px(x) as i32,
-        y: px(y) as i32,
-        width: px(width).max(0.0) as u32,
-        height: px(height).max(0.0) as u32,
-    }
 }
 
 #[cfg(test)]
@@ -136,105 +79,5 @@ mod tests {
         assert_eq!(clamp_region(-50, 0, 100, 50, 640, 480), Region { x: 0, y: 0, width: 50, height: 50 });
         // fully outside on the top → zero height
         assert_eq!(clamp_region(0, -100, 50, 50, 640, 480), Region { x: 0, y: 0, width: 50, height: 0 });
-    }
-
-    #[test]
-    fn pixel_to_global_point_at_1x() {
-        assert_eq!(pixel_to_global_point((100, 200), 1.0, (10.0, 20.0)), (110.0, 220.0));
-    }
-
-    #[test]
-    fn pixel_to_global_point_at_2x_retina() {
-        // pixel 200 / 2 = 100pt + origin 10 = 110; pixel 400 / 2 = 200pt + origin 20 = 220.
-        assert_eq!(pixel_to_global_point((200, 400), 2.0, (10.0, 20.0)), (110.0, 220.0));
-    }
-
-    #[test]
-    fn pixel_to_global_point_handles_negative_rel_and_origin() {
-        assert_eq!(pixel_to_global_point((-40, -10), 2.0, (-5.0, 0.0)), (-25.0, -5.0));
-    }
-
-    #[test]
-    fn global_pixel_to_point_is_identity_at_1x() {
-        assert_eq!(global_pixel_to_point((100, 200), 1.0), (100.0, 200.0));
-    }
-
-    #[test]
-    fn global_pixel_to_point_halves_at_2x_retina() {
-        assert_eq!(global_pixel_to_point((200, 400), 2.0), (100.0, 200.0));
-    }
-
-    #[test]
-    fn global_pixel_to_point_handles_negative_pixels() {
-        assert_eq!(global_pixel_to_point((-200, -3), 2.0), (-100.0, -1.5));
-    }
-
-    #[test]
-    fn point_to_global_pixel_is_identity_at_1x() {
-        assert_eq!(point_to_global_pixel((100.0, 200.0), 1.0), (100, 200));
-    }
-
-    #[test]
-    fn point_to_global_pixel_doubles_at_2x_retina() {
-        assert_eq!(point_to_global_pixel((100.0, 200.0), 2.0), (200, 400));
-    }
-
-    #[test]
-    fn point_to_global_pixel_rounds_to_nearest_pixel() {
-        // 1.25 * 2 = 2.5 -> 3 (round-half-away-from-zero, per f64::round).
-        assert_eq!(point_to_global_pixel((1.25, 1.25), 2.0), (3, 3));
-    }
-
-    #[test]
-    fn global_pixel_point_round_trip_at_1x_and_2x() {
-        for scale in [1.0, 2.0] {
-            let px = (137, -42);
-            let pt = global_pixel_to_point(px, scale);
-            assert_eq!(point_to_global_pixel(pt, scale), px);
-        }
-    }
-
-    #[test]
-    fn pixel_geometry_from_content_rect_is_identity_at_1x() {
-        assert_eq!(
-            pixel_geometry_from_content_rect(10.0, 20.0, 300.0, 200.0, 1.0),
-            WindowGeometry { x: 10, y: 20, width: 300, height: 200 }
-        );
-    }
-
-    #[test]
-    fn pixel_geometry_from_content_rect_scales_at_2x_retina() {
-        assert_eq!(
-            pixel_geometry_from_content_rect(10.0, 20.0, 300.0, 200.0, 2.0),
-            WindowGeometry { x: 20, y: 40, width: 600, height: 400 }
-        );
-    }
-
-    #[test]
-    fn pixel_geometry_from_content_rect_rounds_to_nearest_pixel() {
-        // 1*1.5=1.5 -> 2, 3*1.5=4.5 -> 5 (round-half-away-from-zero, per f64::round):
-        // fields round independently rather than truncating.
-        assert_eq!(
-            pixel_geometry_from_content_rect(1.0, 1.0, 3.0, 3.0, 1.5),
-            WindowGeometry { x: 2, y: 2, width: 5, height: 5 }
-        );
-    }
-
-    #[test]
-    fn pixel_geometry_from_content_rect_clamps_negative_size_to_zero() {
-        // A real contentRect from SCContentFilter never has a negative size, but the
-        // conversion must not panic or wrap on malformed input.
-        assert_eq!(
-            pixel_geometry_from_content_rect(0.0, 0.0, -1.0, -1.0, 2.0),
-            WindowGeometry { x: 0, y: 0, width: 0, height: 0 }
-        );
-    }
-
-    #[test]
-    fn pixel_geometry_from_content_rect_preserves_negative_origin() {
-        assert_eq!(
-            pixel_geometry_from_content_rect(-50.0, -10.0, 100.0, 80.0, 2.0),
-            WindowGeometry { x: -100, y: -20, width: 200, height: 160 }
-        );
     }
 }

--- a/crates/glass-macos/tests/a11y.rs
+++ b/crates/glass-macos/tests/a11y.rs
@@ -7,6 +7,16 @@
 //! ("hello" -> "world") and confirms the non-editable "Save" button rejects a write with
 //! `AxElementNotEditable`.
 //!
+//! Finally, a **bounds-agreement drift guard**: it clamped-centers the "Save" node's
+//! a11y-reported `bounds` into window-relative pixels and dispatches a real
+//! `MacosPlatform::send_pointer(Click)` there (the exact same input path `tests/input.rs`
+//! exercises), then confirms the fixture's *own* button handler — not the a11y layer —
+//! printed `SAVE_CLICKED`. `MacosA11y::snapshot`'s bounds (AXUIElement's `kAXPositionAttribute`/
+//! `kAXSizeAttribute`, converted to window-relative pixels) and `MacosPlatform::send_pointer`'s
+//! injection (window-relative pixel -> global point -> `CGEvent`) are two independent
+//! coordinate pipelines; this is the end-to-end proof they agree, closing the loop the unit
+//! tests around each side can only assert in isolation.
+//!
 //! **`harness = false`** (see `Cargo.toml`'s `[[test]] name = "a11y"` entry): like
 //! `capture.rs`/`input.rs`/`windows.rs`, `MacosPlatform::start_app` reaches
 //! `ffi::app_kit_init()` -> `NSApplication::sharedApplication(mtm)`, which requires the
@@ -38,11 +48,18 @@ mod macos_main {
     use std::process::Command;
     use std::time::Duration;
 
+    use glass_core::platform::{MouseButton, PointerEvent};
     use glass_core::{
         Accessibility, AppSpec, AxContext, AxNode, AxRole, AxTarget, GlassError, Platform,
-        SandboxLevel,
+        SandboxLevel, Stream,
     };
     use glass_macos::MacosPlatform;
+
+    /// Settle after the a11y-bounds click before draining logs, mirroring `input.rs`'s
+    /// `ACTION_SETTLE` — generous relative to `send_pointer`'s own internal focus-settle so
+    /// the fixture's `fflush`ed `SAVE_CLICKED` line has definitely been read by the
+    /// platform's background log reader before we drain.
+    const CLICK_SETTLE: Duration = Duration::from_millis(400);
 
     /// The three elements the fixture exposes, asserted as substrings of the tree outline.
     /// `to_outline` renders each node as `#<id> <Role> "<name>" ...`, using only `name` (never
@@ -69,6 +86,14 @@ mod macos_main {
             return Some(node);
         }
         node.children.iter().find_map(|c| find_by_name(c, name))
+    }
+
+    /// True if any captured stdout line in `lines` contains `needle` — used by the
+    /// bounds-agreement check to confirm the fixture's own `onSave` handler (not the a11y
+    /// layer) observed the click. Mirrors `input.rs`'s `find_reported`, simplified to a
+    /// substring test since the fixture's marker line has no variable payload to parse out.
+    fn logs_contain(lines: &[(Stream, String)], needle: &str) -> bool {
+        lines.iter().any(|(stream, line)| *stream == Stream::Stdout && line.contains(needle))
     }
 
     /// Print a clear failure message and exit non-zero — the `harness = false` contract (no
@@ -216,6 +241,37 @@ mod macos_main {
         }
 
         println!("A11Y_SETVALUE_PASS");
+
+        // --- Bounds-agreement drift guard: clamped-center Save's a11y bounds into
+        // window-relative pixels, click there through the real input path, and confirm
+        // the fixture's OWN click handler (not the a11y layer) saw it. This proves
+        // `MacosA11y::snapshot`'s bounds and `MacosPlatform::send_pointer`'s coordinate
+        // system agree end-to-end, not just that each is internally self-consistent. ---
+        let save_bounds = match save.bounds {
+            Some(b) => b,
+            None => return Err(format!("\"Save\" node has no bounds in re-snapshot:\n{outline2}")),
+        };
+        let (cx, cy) = match save_bounds.clamped_center(ctx.window.width, ctx.window.height) {
+            Some(p) => p,
+            None => {
+                return Err(format!(
+                    "\"Save\" bounds {save_bounds:?} have zero area against window {:?}",
+                    ctx.window
+                ))
+            }
+        };
+        let click_event =
+            PointerEvent::Click { x: cx, y: cy, button: MouseButton::Left, count: 1, modifiers: vec![] };
+        try_expect(platform.send_pointer(&click_event), "send_pointer(Click) on Save's a11y bounds")?;
+        std::thread::sleep(CLICK_SETTLE);
+        let click_logs = platform.drain_logs();
+        if !logs_contain(&click_logs, "SAVE_CLICKED") {
+            return Err(format!(
+                "click via a11y bounds ({cx},{cy}) did not hit Save (fixture stdout: {click_logs:?})"
+            ));
+        }
+        println!("A11Y_BOUNDS_PASS");
+
         Ok(())
     }
 

--- a/crates/glass-macos/tests/a11y.rs
+++ b/crates/glass-macos/tests/a11y.rs
@@ -1,8 +1,8 @@
 //! Mac-gated accessibility-reader integration test — the first real-AX-tree proof through
 //! the whole `glass-a11y-macos` snapshot path (`MacosPlatform::start_app` -> `AxContext` ->
 //! `MacosA11y::snapshot` -> AXUIElement walk -> `AxTree`), driven against the `a11y_fixture`
-//! Cocoa app (a "Save" button, an "Enable" checkbox, and an editable "Note" field holding
-//! "hello").
+//! Cocoa app (a "Save" button, an "Enable" checkbox, and an editable "Note" field — labeled
+//! "Note" via `setAccessibilityLabel`, holding the content "hello").
 //!
 //! **`harness = false`** (see `Cargo.toml`'s `[[test]] name = "a11y"` entry): like
 //! `capture.rs`/`input.rs`/`windows.rs`, `MacosPlatform::start_app` reaches
@@ -35,14 +35,26 @@ mod macos_main {
     use std::process::Command;
     use std::time::Duration;
 
-    use glass_core::{Accessibility, AppSpec, AxContext, Platform, SandboxLevel};
+    use glass_core::{Accessibility, AppSpec, AxContext, AxNode, AxRole, Platform, SandboxLevel};
     use glass_macos::MacosPlatform;
 
     /// The three elements the fixture exposes, asserted as substrings of the tree outline.
-    /// `to_outline` renders each node as `#<id> <Role> "<name>" ...`, so the button and
-    /// checkbox match `Role "name"` and the editable field matches its value surfaced as the
-    /// node name (`"hello"`).
-    const NEEDLES: [&str; 3] = ["Button \"Save\"", "CheckBox \"Enable\"", "\"hello\""];
+    /// `to_outline` renders each node as `#<id> <Role> "<name>" ...`, using only `name` (never
+    /// `value`) — so the editable field's stable label (`setAccessibilityLabel("Note")`,
+    /// surfaced as `AXDescription`) is what appears here, not its volatile content ("hello").
+    /// The content is checked separately, via [`find_text_field`], against `AxNode::value`.
+    const NEEDLES: [&str; 3] = ["Button \"Save\"", "CheckBox \"Enable\"", "TextField \"Note\""];
+
+    /// Pre-order search for the first `TextField` node — the fixture's editable "Note" field.
+    /// Separate from the [`NEEDLES`] outline check because `to_outline` only ever renders
+    /// `name`; this reaches `AxNode::value` directly to prove content is read independently of
+    /// the (stable) label.
+    fn find_text_field(node: &AxNode) -> Option<&AxNode> {
+        if node.role == AxRole::TextField {
+            return Some(node);
+        }
+        node.children.iter().find_map(find_text_field)
+    }
 
     /// Print a clear failure message and exit non-zero — the `harness = false` contract (no
     /// libtest to format a panic for us). Mirrors `capture.rs`.
@@ -140,6 +152,16 @@ mod macos_main {
             if !outline.contains(needle) {
                 return Err(format!("missing {needle} in outline:\n{outline}"));
             }
+        }
+
+        // The outline only proves `name`; confirm `value` is read separately, straight off
+        // the field's content — not folded into `name` (that was the bug this test guards).
+        let field = match find_text_field(&tree.root) {
+            Some(n) => n,
+            None => return Err(format!("no TextField node in tree:\n{outline}")),
+        };
+        if field.value != Some("hello".to_string()) {
+            return Err(format!("TextField value = {:?}, want Some(\"hello\"):\n{outline}", field.value));
         }
         Ok(())
     }

--- a/crates/glass-macos/tests/a11y.rs
+++ b/crates/glass-macos/tests/a11y.rs
@@ -1,8 +1,11 @@
 //! Mac-gated accessibility-reader integration test — the first real-AX-tree proof through
-//! the whole `glass-a11y-macos` snapshot path (`MacosPlatform::start_app` -> `AxContext` ->
-//! `MacosA11y::snapshot` -> AXUIElement walk -> `AxTree`), driven against the `a11y_fixture`
-//! Cocoa app (a "Save" button, an "Enable" checkbox, and an editable "Note" field — labeled
-//! "Note" via `setAccessibilityLabel`, holding the content "hello").
+//! the whole `glass-a11y-macos` snapshot + set_value path (`MacosPlatform::start_app` ->
+//! `AxContext` -> `MacosA11y::snapshot`/`set_value` -> AXUIElement walk -> `AxTree`), driven
+//! against the `a11y_fixture` Cocoa app (a "Save" button, an "Enable" checkbox, and an
+//! editable "Note" field — labeled "Note" via `setAccessibilityLabel`, holding the content
+//! "hello"). After the snapshot checks, it round-trips `set_value` on the "Note" field
+//! ("hello" -> "world") and confirms the non-editable "Save" button rejects a write with
+//! `AxElementNotEditable`.
 //!
 //! **`harness = false`** (see `Cargo.toml`'s `[[test]] name = "a11y"` entry): like
 //! `capture.rs`/`input.rs`/`windows.rs`, `MacosPlatform::start_app` reaches
@@ -35,7 +38,10 @@ mod macos_main {
     use std::process::Command;
     use std::time::Duration;
 
-    use glass_core::{Accessibility, AppSpec, AxContext, AxNode, AxRole, Platform, SandboxLevel};
+    use glass_core::{
+        Accessibility, AppSpec, AxContext, AxNode, AxRole, AxTarget, GlassError, Platform,
+        SandboxLevel,
+    };
     use glass_macos::MacosPlatform;
 
     /// The three elements the fixture exposes, asserted as substrings of the tree outline.
@@ -54,6 +60,15 @@ mod macos_main {
             return Some(node);
         }
         node.children.iter().find_map(find_text_field)
+    }
+
+    /// Pre-order search for the first node whose `name` is exactly `name` — used to build an
+    /// `AxTarget` (id/role/name/bounds) for `set_value`'s round-trip and non-editable checks.
+    fn find_by_name<'a>(node: &'a AxNode, name: &str) -> Option<&'a AxNode> {
+        if node.name.as_deref() == Some(name) {
+            return Some(node);
+        }
+        node.children.iter().find_map(|c| find_by_name(c, name))
     }
 
     /// Print a clear failure message and exit non-zero — the `harness = false` contract (no
@@ -163,6 +178,44 @@ mod macos_main {
         if field.value != Some("hello".to_string()) {
             return Err(format!("TextField value = {:?}, want Some(\"hello\"):\n{outline}", field.value));
         }
+
+        // Round-trip an editable field: "hello" -> "world" via set_value, then re-snapshot
+        // and confirm the field's value actually changed (not a silent no-op).
+        let note = match find_by_name(&tree.root, "Note") {
+            Some(n) => n,
+            None => return Err(format!("no \"Note\" field in tree:\n{outline}")),
+        };
+        let note_tgt =
+            AxTarget { id: note.id, role: note.role, name: note.name.clone(), bounds: note.bounds };
+        try_expect(a11y.set_value(&ctx, &note_tgt, "world"), "set_value(Note, \"world\")")?;
+
+        let mut tree2 = try_expect(a11y.snapshot(&ctx), "re-snapshot after set_value")?;
+        tree2.assign_ids();
+        let outline2 = tree2.to_outline();
+        let field2 = match find_text_field(&tree2.root) {
+            Some(n) => n,
+            None => return Err(format!("no TextField node in re-snapshot:\n{outline2}")),
+        };
+        if field2.value != Some("world".to_string()) {
+            return Err(format!(
+                "TextField value after set_value = {:?}, want Some(\"world\"):\n{outline2}",
+                field2.value
+            ));
+        }
+
+        // A button is not editable: set_value must reject it, not silently no-op.
+        let save = match find_by_name(&tree2.root, "Save") {
+            Some(n) => n,
+            None => return Err(format!("no \"Save\" button in re-snapshot:\n{outline2}")),
+        };
+        let save_tgt =
+            AxTarget { id: save.id, role: save.role, name: save.name.clone(), bounds: save.bounds };
+        match a11y.set_value(&ctx, &save_tgt, "x") {
+            Err(GlassError::AxElementNotEditable(_)) => {}
+            other => return Err(format!("expected AxElementNotEditable for Save, got {other:?}")),
+        }
+
+        println!("A11Y_SETVALUE_PASS");
         Ok(())
     }
 

--- a/crates/glass-macos/tests/a11y.rs
+++ b/crates/glass-macos/tests/a11y.rs
@@ -1,0 +1,204 @@
+//! Mac-gated accessibility-reader integration test — the first real-AX-tree proof through
+//! the whole `glass-a11y-macos` snapshot path (`MacosPlatform::start_app` -> `AxContext` ->
+//! `MacosA11y::snapshot` -> AXUIElement walk -> `AxTree`), driven against the `a11y_fixture`
+//! Cocoa app (a "Save" button, an "Enable" checkbox, and an editable "Note" field holding
+//! "hello").
+//!
+//! **`harness = false`** (see `Cargo.toml`'s `[[test]] name = "a11y"` entry): like
+//! `capture.rs`/`input.rs`/`windows.rs`, `MacosPlatform::start_app` reaches
+//! `ffi::app_kit_init()` -> `NSApplication::sharedApplication(mtm)`, which requires the
+//! process's TRUE main thread. libtest runs every `#[test]` on a worker thread, so this file
+//! defines its own `fn main()` that — run directly rather than through libtest — is on the
+//! real main thread. `MacosA11y::snapshot` itself runs inline on that same thread (AX has no
+//! separate thread-affinity requirement).
+//!
+//! Needs the Accessibility (and Screen Recording, for `MacosPlatform::new`'s preflight) TCC
+//! grants, which only the signed, granted `GlassProbe.app` bundle holds on this project's
+//! dev Mac (`mini`) — see `capture.rs`'s module doc and `scripts/test-macos.sh` for how the
+//! granted run copies this binary into that bundle. The fixture binary path is taken from
+//! `GLASS_A11Y_FIXTURE_BIN` when set (the granted run pre-builds it); otherwise this builds
+//! `fixture/a11y_fixture.swift` with `swiftc`, or skips if neither is available.
+
+#[cfg(not(target_os = "macos"))]
+fn main() {
+    println!("skipped (not macOS)");
+}
+
+#[cfg(target_os = "macos")]
+fn main() {
+    macos_main::run();
+}
+
+#[cfg(target_os = "macos")]
+mod macos_main {
+    use std::path::PathBuf;
+    use std::process::Command;
+    use std::time::Duration;
+
+    use glass_core::{Accessibility, AppSpec, AxContext, Platform, SandboxLevel};
+    use glass_macos::MacosPlatform;
+
+    /// The three elements the fixture exposes, asserted as substrings of the tree outline.
+    /// `to_outline` renders each node as `#<id> <Role> "<name>" ...`, so the button and
+    /// checkbox match `Role "name"` and the editable field matches its value surfaced as the
+    /// node name (`"hello"`).
+    const NEEDLES: [&str; 3] = ["Button \"Save\"", "CheckBox \"Enable\"", "\"hello\""];
+
+    /// Print a clear failure message and exit non-zero — the `harness = false` contract (no
+    /// libtest to format a panic for us). Mirrors `capture.rs`.
+    fn fail(msg: impl AsRef<str>) -> ! {
+        eprintln!("FAIL: {}", msg.as_ref());
+        std::process::exit(1);
+    }
+
+    /// Unwrap a `Result`, failing the process with `context` prefixed on `Err`. Only safe
+    /// before a fixture process is spawned (it skips destructors) — post-spawn failures go
+    /// through `try_expect`/`run_checks` so `stop_app` still runs. Mirrors `capture.rs`.
+    fn expect<T, E: std::fmt::Display>(result: Result<T, E>, context: &str) -> T {
+        match result {
+            Ok(v) => v,
+            Err(e) => fail(format!("{context}: {e}")),
+        }
+    }
+
+    /// Like `expect`, but returns the error as a `String` so a failure flows back to `run()`
+    /// for `stop_app` + temp-dir cleanup before the process exits. Mirrors `capture.rs`.
+    fn try_expect<T, E: std::fmt::Display>(result: Result<T, E>, context: &str) -> Result<T, String> {
+        result.map_err(|e| format!("{context}: {e}"))
+    }
+
+    fn swiftc_available() -> bool {
+        Command::new("swiftc").arg("--version").output().is_ok_and(|o| o.status.success())
+    }
+
+    /// Build `fixture/a11y_fixture.swift` to a fresh temp path. Returns the built binary's
+    /// path and the temp build dir it lives in (the caller removes the dir when done).
+    /// Mirrors `capture.rs::build_fixture` (`@main` type -> `-parse-as-library`).
+    fn build_fixture() -> (PathBuf, PathBuf) {
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let source = manifest_dir.join("fixture").join("a11y_fixture.swift");
+        if !source.is_file() {
+            fail(format!("fixture source not found at {}", source.display()));
+        }
+
+        let out_dir = std::env::temp_dir().join(format!("glass-macos-a11y-test-{}", std::process::id()));
+        expect(std::fs::create_dir_all(&out_dir), "creating fixture build dir");
+        let out_bin = out_dir.join("a11y_fixture");
+
+        let status = Command::new("swiftc")
+            .arg("-O")
+            .arg("-parse-as-library")
+            .arg(&source)
+            .arg("-o")
+            .arg(&out_bin)
+            .status();
+        match status {
+            Ok(s) if s.success() => {}
+            Ok(s) => fail(format!("swiftc exited with {s} building {}", source.display())),
+            Err(e) => fail(format!("failed to run swiftc: {e}")),
+        }
+        (out_bin, out_dir)
+    }
+
+    /// Launch the fixture, snapshot its accessibility tree, and assert the outline contains
+    /// each of [`NEEDLES`]. Returns `Err` instead of exiting so `run()` can always reach
+    /// `stop_app` first (a bare `process::exit` here would skip `MacosPlatform::Drop` and
+    /// leak the spawned fixture — same rationale as `capture.rs::run_checks`).
+    fn run_checks(platform: &mut MacosPlatform, fixture_bin: &std::path::Path) -> Result<(), String> {
+        let spec = AppSpec {
+            build: None,
+            run: vec![fixture_bin.to_string_lossy().into_owned()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 8000,
+            sandbox: SandboxLevel::Off,
+            a11y: false,
+        };
+
+        let geometry = try_expect(platform.start_app(&spec), "start_app")?;
+        println!("started fixture window: {geometry:?}");
+
+        // start_app only waits for the window to exist, not for AppKit to finish building
+        // the accessibility tree behind it — give it a moment to settle before snapshotting.
+        std::thread::sleep(Duration::from_millis(800));
+
+        let ctx = AxContext {
+            pids: platform.app_pids(),
+            window: geometry.clone(),
+            window_handle: None,
+            a11y_bus_addr: None,
+        };
+
+        let mut a11y = glass_a11y_macos::MacosA11y::new();
+        let mut tree = try_expect(a11y.snapshot(&ctx), "snapshot")?;
+        tree.assign_ids(); // number nodes so the diagnostic outline reads naturally
+        let outline = tree.to_outline();
+        println!("a11y snapshot ({} nodes):\n{outline}", tree.count);
+
+        for needle in NEEDLES {
+            if !outline.contains(needle) {
+                return Err(format!("missing {needle} in outline:\n{outline}"));
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn run() {
+        // Prefer a pre-built fixture (the granted run supplies `GLASS_A11Y_FIXTURE_BIN`);
+        // otherwise build it here, skipping cleanly if `swiftc` is unavailable.
+        let (fixture_bin, fixture_dir) = match std::env::var_os("GLASS_A11Y_FIXTURE_BIN") {
+            Some(p) => {
+                let path = PathBuf::from(p);
+                if !path.is_file() {
+                    fail(format!("GLASS_A11Y_FIXTURE_BIN set but not a file: {}", path.display()));
+                }
+                (path, None)
+            }
+            None => {
+                if !swiftc_available() {
+                    println!("skipped (GLASS_A11Y_FIXTURE_BIN unset and no swiftc)");
+                    return;
+                }
+                let (bin, dir) = build_fixture();
+                (bin, Some(dir))
+            }
+        };
+        println!("using a11y fixture at {}", fixture_bin.display());
+
+        let cleanup_dir = |dir: &Option<PathBuf>| {
+            if let Some(d) = dir {
+                let _ = std::fs::remove_dir_all(d);
+            }
+        };
+
+        let mut platform = match MacosPlatform::new() {
+            Ok(p) => p,
+            Err(e) => {
+                cleanup_dir(&fixture_dir);
+                fail(format!("MacosPlatform::new() (Screen Recording / Accessibility grant missing?): {e}"));
+            }
+        };
+
+        let result = run_checks(&mut platform, &fixture_bin);
+
+        // Reached on every path and BEFORE any process::exit below: stop_app is idempotent,
+        // so this guarantees the fixture process never survives a failed run.
+        let stop_result = platform.stop_app();
+        cleanup_dir(&fixture_dir);
+
+        match result {
+            Ok(()) => {
+                expect(stop_result, "stop_app");
+                println!("A11Y_SNAPSHOT_PASS");
+                std::process::exit(0);
+            }
+            Err(msg) => {
+                if let Err(e) = stop_result {
+                    eprintln!("(additionally) stop_app failed: {e}");
+                }
+                fail(msg);
+            }
+        }
+    }
+}

--- a/crates/glass-mcp/Cargo.toml
+++ b/crates/glass-mcp/Cargo.toml
@@ -50,6 +50,7 @@ glass-a11y-windows = { path = "../glass-a11y-windows" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 glass-macos = { path = "../glass-macos" }
+glass-a11y-macos = { path = "../glass-a11y-macos" }
 
 [build-dependencies]
 embed-manifest = "1"

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -53,8 +53,10 @@ fn diagnose_inner(deep: bool, audit: Option<&crate::audit::AuditReport>) -> Diag
     // Only show sections for backends actually compiled into THIS binary — absent
     // backends (e.g. windows on a Linux build, or macos on a non-macOS build) are
     // omitted rather than listed as "not built into this binary" placeholders.
-    // Accessibility is per-OS (AT-SPI on Linux, UIA on Windows); macOS's grants live in
-    // its own "macos" section instead. Android is the exception: its crate is
+    // Accessibility is per-OS (AT-SPI on Linux, UIA on Windows); macOS instead gets two
+    // sections below — "macos" (the platform backend's own TCC posture) and
+    // "accessibility (macos)" (the a11y-tool reader's readiness) — see the comment there
+    // for why the two aren't merged. Android is the exception: its crate is
     // host-OS-agnostic and always compiled in, so its section is always emitted, gated
     // at runtime (see below) rather than by cfg.
     let mut sections = vec![general, network];

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -95,6 +95,19 @@ fn diagnose_inner(deep: bool, audit: Option<&crate::audit::AuditReport>) -> Diag
     #[cfg(target_os = "macos")]
     {
         sections.push(Section::new("macos", Some("macos".into()), macos_checks(backend)));
+        // Mirrors "accessibility (linux)"/"accessibility (windows)": a dedicated section
+        // for the a11y-tool reader itself (glass_a11y_snapshot/marks/click_element/
+        // set_value), distinct from the "macos" section above which covers the platform
+        // backend's own TCC posture (Screen Recording, session state, ...). The
+        // Accessibility grant check is intentionally duplicated between the two sections
+        // — here it answers "will the a11y tools work", there it answers "is this Mac
+        // set up at all" — both reuse the same `glass_macos::accessibility_granted()`
+        // fact and remedy string, so there's no risk of the two drifting apart.
+        sections.push(Section::new(
+            "accessibility (macos)",
+            None,
+            macos_a11y_checks(glass_macos::accessibility_granted()),
+        ));
     }
 
     // Android is host-OS-agnostic (drives an AVD over adb), so the crate is always compiled
@@ -235,6 +248,36 @@ fn macos_checks(resolved_backend: &str) -> Vec<Check> {
     )
 }
 
+/// The "accessibility (macos)" section: the `glass-a11y-macos` reader (AXUIElement) is a
+/// system framework, not an optional install like Linux's AT-SPI daemon or a service that
+/// needs spinning up — so it's always present in a macOS build, and the only real
+/// precondition left to report is the Accessibility TCC grant itself. Pure — takes the
+/// already-gathered grant fact, makes no OS calls — so it's unit-tested without needing a
+/// real grant, mirroring `glass_a11y_linux::doctor::a11y_checks`/
+/// `glass_a11y_windows::doctor::a11y_checks`.
+#[cfg(target_os = "macos")]
+fn macos_a11y_checks(accessibility_granted: bool) -> Vec<Check> {
+    vec![
+        Check::new(
+            "a11y reader",
+            CheckStatus::Ok,
+            "AXUIElement reader available — glass_a11y_snapshot / glass_a11y_marks / \
+             glass_click_element / glass_set_value will work once Accessibility is granted (see below)",
+        ),
+        if accessibility_granted {
+            Check::new("Accessibility", CheckStatus::Ok, "granted")
+        } else {
+            Check::new(
+                "Accessibility",
+                CheckStatus::Fail,
+                "not granted — glass_a11y_snapshot / glass_a11y_marks / glass_click_element / \
+                 glass_set_value will fail with a permission error",
+            )
+            .with_remedy(glass_macos::accessibility_remedy())
+        },
+    ]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -272,7 +315,7 @@ mod tests {
         #[cfg(windows)]
         assert_eq!(titles, ["general", "network", "windows", "sandbox", "accessibility (windows)", "android"]);
         #[cfg(target_os = "macos")]
-        assert_eq!(titles, ["general", "network", "macos", "android"]);
+        assert_eq!(titles, ["general", "network", "macos", "accessibility (macos)", "android"]);
         // Android's section is always present and non-empty — its basic presence checks now
         // run unconditionally (deep probes gated to the selected backend; Fails softened to
         // Warn when android isn't active). Asserting non-empty catches accidental removal of
@@ -407,6 +450,32 @@ mod tests {
             let checks = macos_checks_from("android", true, true, SessionState::Unlocked);
             let c = checks.iter().find(|c| c.name == "backend").unwrap();
             assert_eq!(c.status, CheckStatus::Warn);
+        }
+
+        #[test]
+        fn a11y_reader_is_always_reported_present() {
+            // The AXUIElement reader is a system framework compiled unconditionally into
+            // a macOS build — unlike Linux's AT-SPI daemon, there's no "not installed"
+            // state to detect, so this line is always Ok regardless of the grant.
+            let checks = macos_a11y_checks(false);
+            let reader = checks.iter().find(|c| c.name == "a11y reader").unwrap();
+            assert_eq!(reader.status, CheckStatus::Ok);
+        }
+
+        #[test]
+        fn a11y_granted_is_all_ok() {
+            let checks = macos_a11y_checks(true);
+            assert!(checks.iter().all(|c| c.status == CheckStatus::Ok), "{checks:?}");
+        }
+
+        #[test]
+        fn a11y_not_granted_fails_with_the_shared_remedy() {
+            let checks = macos_a11y_checks(false);
+            let c = checks.iter().find(|c| c.name == "Accessibility").unwrap();
+            assert_eq!(c.status, CheckStatus::Fail);
+            // Same remedy string as the "macos" section's own Accessibility check — no
+            // separate, driftable copy here either.
+            assert_eq!(c.remedy.as_deref(), Some(glass_macos::accessibility_remedy()));
         }
     }
 }

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -81,13 +81,11 @@ pub fn make_platform(
     // On Linux, AT-SPI serves both display backends, so the same reader is attached
     // to each. It connects lazily on first snapshot; an absent a11y bus surfaces as
     // AccessibilityUnavailable at call time, not here.
-    // Accessibility is per-OS: AT-SPI on Linux, UI Automation on Windows. macOS has no
-    // a11y reader yet (AXUIElement tree reading is its own later plan), so
-    // `accessibility` is `None` below — no silent fallback: glass-core's session layer
-    // surfaces `AxUnsupported` for a missing reader (see `glass-core::session`) rather
-    // than pretending a tree exists. That's a different variant from
-    // `AccessibilityUnavailable` above, which is for a *present* reader that fails at
-    // call time (e.g. Linux's AT-SPI bus being unreachable).
+    // Accessibility is per-OS: AT-SPI on Linux, UI Automation on Windows, AXUIElement on
+    // macOS. Each reader is attached unconditionally here — no silent fallback: a
+    // reader-specific failure (e.g. Linux's AT-SPI bus being unreachable, or macOS's
+    // Accessibility TCC grant being missing) surfaces as `AccessibilityUnavailable` at
+    // call time, not here.
     #[cfg(windows)]
     let accessibility: Option<Box<dyn glass_core::Accessibility + Send>> =
         Some(Box::new(glass_a11y_windows::WindowsA11y::new()));
@@ -95,7 +93,8 @@ pub fn make_platform(
     let accessibility: Option<Box<dyn glass_core::Accessibility + Send>> =
         Some(Box::new(glass_a11y_linux::LinuxA11y::new()));
     #[cfg(target_os = "macos")]
-    let accessibility: Option<Box<dyn glass_core::Accessibility + Send>> = None;
+    let accessibility: Option<Box<dyn glass_core::Accessibility + Send>> =
+        Some(Box::new(glass_a11y_macos::MacosA11y::new()));
     Ok(Backend { platform, accessibility })
 }
 

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -84,8 +84,8 @@ pub fn make_platform(
     // Accessibility is per-OS: AT-SPI on Linux, UI Automation on Windows, AXUIElement on
     // macOS. Each reader is attached unconditionally here — no silent fallback: a
     // reader-specific failure (e.g. Linux's AT-SPI bus being unreachable, or macOS's
-    // Accessibility TCC grant being missing) surfaces as `AccessibilityUnavailable` at
-    // call time, not here.
+    // Accessibility TCC grant being missing) surfaces as `AccessibilityUnavailable`
+    // (Linux/Windows) or `PermissionDenied` (macOS) at call time, not here.
     #[cfg(windows)]
     let accessibility: Option<Box<dyn glass_core::Accessibility + Send>> =
         Some(Box::new(glass_a11y_windows::WindowsA11y::new()));

--- a/docs/running-on-macos.md
+++ b/docs/running-on-macos.md
@@ -155,8 +155,10 @@ launchctl bootout gui/$(id -u)/tech.fixedwidth.glass
 Once granted (step 3), the agent has `glass_start`, `glass_screenshot`,
 `glass_click`, `glass_type`, `glass_wait_stable`, `glass_diff`, `glass_logs`,
 `glass_list_windows`, `glass_select_window`, and `glass_doctor`. The
-accessibility-tree tools — `glass_a11y_snapshot`, `glass_click_element` — aren't
-available on macOS yet.
+accessibility-tree tools — `glass_a11y_snapshot`, `glass_a11y_marks`,
+`glass_click_element`, and `glass_set_value` — also work on macOS, reading and
+driving the AXUIElement tree; they need the same Accessibility grant from step 3
+above (no separate permission).
 
 ## Troubleshooting: headless / SSH setup
 

--- a/scripts/test-macos-a11y.sh
+++ b/scripts/test-macos-a11y.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Compile/link gate for the macOS accessibility-reader integration test
+# (crates/glass-macos/tests/a11y.rs, the `a11y` [[test]] target) and its Swift fixture
+# (crates/glass-macos/fixture/a11y_fixture.swift). Skips (exit 0) when not on macOS,
+# mirroring scripts/test-macos.sh / test-macos-mcp.sh, so it's safe to call from any CI
+# matrix leg.
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "test-macos-a11y.sh: not macOS (uname=$(uname -s)) — skipping."
+  exit 0
+fi
+
+# Run from the repo root so `cargo -p` resolves regardless of the caller's cwd (mirrors
+# scripts/test-macos.sh / test-x11.sh / test-wayland.sh / test-windows.sh).
+cd "$(dirname "$0")/.."
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# `a11y_fixture.swift` uses a top-level `@main` type rather than unadorned top-level
+# statements, so it needs `-parse-as-library` — same gotcha `quadrants.swift` has, covered
+# in docs/running-on-macos.md's "headless / SSH setup" troubleshooting section. Building it
+# here only proves the fixture source is valid Swift; it is never executed by this script.
+echo "test-macos-a11y.sh: building a11y_fixture.swift..."
+swiftc -parse-as-library -o "$TMP/a11y_fixture" crates/glass-macos/fixture/a11y_fixture.swift
+
+# Build (never run) the harness=false `a11y` integration test binary — confirms it compiles
+# and links against `glass-a11y-macos`'s AXUIElement reader, the same `--no-run` compile/
+# link gate scripts/test-macos.sh's GLASS_MACOS_ONBOX block applies to `capture`/`input`/
+# `windows`.
+echo "test-macos-a11y.sh: building the a11y test binary..."
+cargo test -p glass-macos --test a11y --no-run
+
+# The GRANTED run — actually exercising the AXUIElement snapshot/set_value/click path
+# against the fixture built above — needs the Accessibility (and Screen Recording, for
+# MacosPlatform::new's preflight) TCC grants, which only the signed, granted GlassProbe.app
+# bundle holds on this project's dev Mac. That happens out-of-band from this script: copy
+# the `a11y` test binary this script just built into the GlassProbe.app bundle, re-sign,
+# and launch it via a `gui/501` LaunchAgent so it inherits the grant — the same recipe
+# test-macos.sh's GLASS_MACOS_ONBOX block documents for `capture`/`input`/`windows` (see
+# .superpowers/sdd/objc2-spike-report.md and .superpowers/sdd/task-6-brief.md for the exact
+# procedure). Point the launched binary at a fixture built the same way as above via
+# `GLASS_A11Y_FIXTURE_BIN=/path/to/a11y_fixture` — crates/glass-macos/tests/a11y.rs falls
+# back to building its own copy with `swiftc` when the var is unset, but the granted run
+# pre-builds one so the granted process doesn't need a writable `$TMPDIR` / working
+# `swiftc` invocation in that context. No machine-specific paths are hardcoded here; the
+# out-of-band recipe supplies them at run time.
+echo "test-macos-a11y.sh: OK (compile/link only — the granted run happens out-of-band; see comments above)."

--- a/scripts/test-macos-a11y.sh
+++ b/scripts/test-macos-a11y.sh
@@ -38,9 +38,8 @@ cargo test -p glass-macos --test a11y --no-run
 # bundle holds on this project's dev Mac. That happens out-of-band from this script: copy
 # the `a11y` test binary this script just built into the GlassProbe.app bundle, re-sign,
 # and launch it via a `gui/501` LaunchAgent so it inherits the grant — the same recipe
-# test-macos.sh's GLASS_MACOS_ONBOX block documents for `capture`/`input`/`windows` (see
-# .superpowers/sdd/objc2-spike-report.md and .superpowers/sdd/task-6-brief.md for the exact
-# procedure). Point the launched binary at a fixture built the same way as above via
+# test-macos.sh's GLASS_MACOS_ONBOX block documents for `capture`/`input`/`windows`. Point
+# the launched binary at a fixture built the same way as above via
 # `GLASS_A11Y_FIXTURE_BIN=/path/to/a11y_fixture` — crates/glass-macos/tests/a11y.rs falls
 # back to building its own copy with `swiftc` when the var is unset, but the granted run
 # pre-builds one so the granted process doesn't need a writable `$TMPDIR` / working


### PR DESCRIPTION
Adds a macOS accessibility-tree reader so an agent can drive Mac apps by semantic addressing instead of pixel-hunting. `glass_a11y_snapshot`, `glass_a11y_marks`, `glass_click_element`, and `glass_set_value` now work on macOS, at parity with the Linux (AT-SPI) and Windows (UIA) readers.

## What's in it

- **New `glass-a11y-macos` crate** — reads the AXUIElement tree behind glass-core's `Accessibility` seam. Standalone (depends only on the objc2 stack + glass-core), mirroring the Linux/Windows readers' `reader.rs` + pure `mapping.rs` split. All `unsafe` FFI is contained in `ffi.rs` (`#![forbid(unsafe_code)]` on the rest); AX reads use objc2 methods, with `AXIsProcessTrusted` the only raw extern.
- **Shared coordinate kernel** — the pure point↔pixel math moved from `glass-macos` into `glass-core`, so the reader and the capture/input backend compute window-relative pixels from one implementation (a11y bounds and input coordinates can't drift apart).
- **Root selection** — picks the app's active window by geometry-matching the backend's window rect, snapping the recovered scale to the integer backing scale (robust to content-vs-frame insets). Runs inline on the server's worker thread.
- **`set_value`** — writes via `AXValue` with a read-back poll that reports success only on a confirmed change; error-aware reads distinguish a real AX failure from a legitimately-absent attribute.
- Wired into `glass-mcp` (with a `doctor` section), plus a native AppKit test fixture, CI, and docs.

## Verification

Built and exercised on macOS 26.5 hardware under a granted app bundle:
- snapshot returns the correct tree; `set_value` round-trips an editable field and rejects a non-editable one;
- clicking at a11y-derived bounds lands on the target (coordinate agreement);
- a full `glass-mcp serve --http` end-to-end run drives all four tools over MCP.

Reviewed with a multi-lens whole-branch pass (code review, silent-failure, rust-best-practices, type design).

Sandboxing on macOS remains the one planned capability still to come.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
