### PR TITLE
macOS: clipboard isolation under containment (injection shim)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,14 @@ jobs:
       - run: cargo build  -p glass-sandbox-macos --locked
       - run: cargo clippy -p glass-sandbox-macos --all-targets --locked -- -D warnings
       - run: cargo test   -p glass-sandbox-macos --locked
+      # glass-clip-shim-macos is the DYLD_INSERT_LIBRARIES cdylib that swizzles
+      # +[NSPasteboard generalPasteboard] inside a contained app process. It's cdylib-only
+      # (crate-type = ["cdylib"], no rlib), so there's nothing for `cargo test` to run here —
+      # the pure routing logic it's driven by lives in glass-macos::clipboard_route, which
+      # has no cfg(macos) gate and already unit-tests on the Linux `check` job's `cargo test
+      # --workspace` leg. This is the only job that can build/lint the swizzle itself.
+      - run: cargo build  -p glass-clip-shim-macos --all-targets --locked
+      - run: cargo clippy -p glass-clip-shim-macos --all-targets --locked -- -D warnings
       # Compile/link gate for the harness=false `a11y` on-box integration test
       # (crates/glass-macos/tests/a11y.rs) and its Swift fixture — proves both build against
       # this runner's SDK without attempting the granted run (needs the Accessibility/Screen

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,9 @@ tree — served over MCP (stdio, or `serve --http`). Backends behind a `Platform
 and Wayland (headless sway) on Linux, Windows (WGC/SendInput), Android (native apps in an AVD
 emulator over `adb`, host-OS-agnostic; clipboard + high-fidelity input via an optional
 on-device companion agent), macOS (ScreenCaptureKit capture, CGEvent input, AXUIElement
-windows/logs, accessibility tree, clipboard, sandboxing (Seatbelt)).
+windows/logs, accessibility tree, clipboard (isolated + working for injectable apps under
+containment via a `DYLD_INSERT_LIBRARIES` swizzle shim; hardened-runtime apps fall back to
+unsupported), sandboxing (Seatbelt)).
 
 ## Layout
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -219,7 +219,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -515,7 +515,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -640,6 +640,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,7 +675,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -676,7 +686,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -707,7 +717,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -758,7 +768,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -894,7 +904,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1019,6 +1029,16 @@ dependencies = [
  "retour",
  "windows",
  "windows-core",
+]
+
+[[package]]
+name = "glass-clip-shim-macos"
+version = "0.0.0"
+dependencies = [
+ "ctor",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -1927,7 +1947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2078,7 +2098,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2214,7 +2234,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2280,7 +2300,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2322,7 +2342,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2333,7 +2353,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2368,7 +2388,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2502,6 +2522,17 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -2528,7 +2559,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2570,7 +2601,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2581,7 +2612,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2630,7 +2661,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2753,7 +2784,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2808,7 +2839,7 @@ checksum = "ffcc4d404aa1c03a848f95cf5feadc3e63946d7f095bf388770b85550093d388"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2950,7 +2981,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3235,7 +3266,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3246,7 +3277,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3419,7 +3450,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3435,7 +3466,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3531,7 +3562,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3589,7 +3620,7 @@ checksum = "10da05367f3a7b7553c8cdf8fa91aee6b64afebe32b51c95177957efc47ca3a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "zbus-lockstep",
  "zbus_xml",
  "zvariant",
@@ -3604,7 +3635,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -3650,7 +3681,7 @@ checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3670,7 +3701,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3704,7 +3735,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3736,7 +3767,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "zvariant_utils",
 ]
 
@@ -3749,6 +3780,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 2.0.117",
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/glass-core", "crates/glass-x11", "crates/glass-testapp", "crates/glass-mcp", "crates/glass-wayland", "crates/glass-a11y-linux", "crates/glass-windows", "crates/glass-a11y-windows", "crates/glass-sandbox-linux", "crates/glass-proc-linux", "crates/glass-clip-hook", "crates/glass-dbus-linux", "crates/glass-android", "crates/glass-macos", "crates/glass-a11y-macos", "crates/glass-sandbox-macos"]
+members = ["crates/glass-core", "crates/glass-x11", "crates/glass-testapp", "crates/glass-mcp", "crates/glass-wayland", "crates/glass-a11y-linux", "crates/glass-windows", "crates/glass-a11y-windows", "crates/glass-sandbox-linux", "crates/glass-proc-linux", "crates/glass-clip-hook", "crates/glass-dbus-linux", "crates/glass-android", "crates/glass-macos", "crates/glass-a11y-macos", "crates/glass-sandbox-macos", "crates/glass-clip-shim-macos"]
 # glass-fixture-egui is intentionally excluded: heavy egui deps, only exercised by #[ignore]d
 # on-box a11y tests CI can't run. Built on-demand on the box.
 exclude = ["crates/glass-fixture-egui"]

--- a/README.md
+++ b/README.md
@@ -209,7 +209,12 @@ A few capabilities worth knowing:
   and Chrome work too; x64) and real-file copy via `CF_HDROP` (virtual-file drag-out
   — shell extensions, zip attachments — is deferred). So they never touch
   your real clipboard unless you set `GLASS_DISPLAY=:0` or run the Windows
-  backend with `sandbox=off`. On **Android**, clipboard get/set works through the
+  backend with `sandbox=off`. On **macOS**, a contained **injectable** app gets an
+  isolated-but-working clipboard too: a `DYLD_INSERT_LIBRARIES` shim redirects it to a
+  private named pasteboard glass shares, so the app can copy/paste normally while your
+  real clipboard is never touched; a **hardened-runtime** app can't be redirected, so
+  these tools return `Unsupported` for it (see
+  [running-on-macos.md](docs/running-on-macos.md)). On **Android**, clipboard get/set works through the
   optional on-device agent (set `GLASS_ANDROID_AGENT_JAR`) —
   the system clipboard isn't reachable over plain `adb`, so without the agent these
   tools report unsupported. `glass_clipboard_get` is also the cheap text-extraction
@@ -378,7 +383,7 @@ Where glass stands by OS. **✓** supported · **◑** partial · **–** not su
 
 † **Android** is emulator-only. Capture, multi-window, input, and logs work over `adb`, and glass manages the AVD (attach a running one, or boot a headless one). **Clipboard, high-fidelity input, and multi-touch gestures (`glass_gesture`)** use the optional on-device agent, and an optional on-device **AccessibilityService** sharpens the a11y tree (Compose) + `set_value` (both in the Android section of your host guide: [Linux](docs/running-on-linux.md) · [Windows](docs/running-on-windows.md) · [macOS](docs/running-on-macos.md)) — without the agent, input falls back to adb's `input` (single-pointer only — no multi-touch) and clipboard is unavailable; without the service, a11y falls back to `uiautomator`. glass is developed and tested against **Android 14 (API 34)**; the `adb` backend assumes no particular version and the optional companions declare an Android 7.0 (API 24) floor (details in your host guide). Window resize/move (apps are full-screen) and physical devices are non-goals.
 
-‡ **macOS** capture, input, windows, clipboard, and logs are built and CI-tested (ScreenCaptureKit capture, CGEvent input, AXUIElement windows). Containment is Seatbelt (`sandbox_init`): filesystem + process are contained at `default`/`strict`, and `strict` additionally blocks outbound network. The filesystem model is whole-filesystem read (read-only) except your home directory (`/Users`), which is denied so secrets stay hidden, with the working directory re-allowed for reads even when it lives inside your home; writes are limited to the working directory plus scratch/cache dirs (`/tmp`, `/private/var/folders`, `/dev`). The clipboard is isolated under containment — `glass_clipboard_get`/`set` return `Unsupported` when `sandbox != off`; at `sandbox: off` it acts on the real system pasteboard. Known limits: the mach allow-list is broad (a hardening follow-up); Electron apps may be able to escape their own sandbox.
+‡ **macOS** capture, input, windows, clipboard, and logs are built and CI-tested (ScreenCaptureKit capture, CGEvent input, AXUIElement windows). Containment is Seatbelt (`sandbox_init`): filesystem + process are contained at `default`/`strict`, and `strict` additionally blocks outbound network. The filesystem model is whole-filesystem read (read-only) except your home directory (`/Users`), which is denied so secrets stay hidden, with the working directory re-allowed for reads even when it lives inside your home; writes are limited to the working directory plus scratch/cache dirs (`/tmp`, `/private/var/folders`, `/dev`). Under containment, the clipboard is isolated **and working** for an **injectable** app — a swizzle shim redirects it to a private named pasteboard glass shares; a **hardened-runtime** app can't be redirected, so `glass_clipboard_get`/`set` return `Unsupported` for it. At `sandbox: off` it acts on the real system pasteboard. Known limits: the mach allow-list is broad (a hardening follow-up); Electron apps may be able to escape their own sandbox.
 
 The per-platform detail — sandboxing levels, display isolation, the accessibility tree —
 lives in the [Containment](#containment--sandboxing), [Backends](#backends), and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,8 +26,12 @@ The application glass launches is sandboxed by default, per OS:
   and reach it over the network transport — see
   [`packaging/windows-sandbox/`](packaging/windows-sandbox).
 - **macOS** — Seatbelt (`sandbox_init`): filesystem + process containment at `default`, plus no
-  network at `strict`, applied to the launched app and **fail-closed**. The clipboard is
-  **isolated** under containment (a contained app cannot reach your real pasteboard). The app
+  network at `strict`, applied to the launched app and **fail-closed**. Under containment the
+  clipboard is **isolated and working** for an **injectable** app: an injected shim
+  (`DYLD_INSERT_LIBRARIES`) redirects the app's clipboard calls to a private named pasteboard
+  glass shares, so it can copy/paste normally while your real pasteboard stays untouched. An
+  app running under Apple's **hardened runtime** can't be redirected and falls back to
+  `Unsupported` (fail-closed) rather than reaching the real pasteboard. The app
   still **renders on the real desktop** (display isolation is not yet implemented on macOS).
   Known limits: the Mach-service allowlist is currently broad (hardening in progress), Electron
   apps may escape their own sandbox, and `sandbox_init` is deprecated-but-shipping.

--- a/crates/glass-clip-shim-macos/Cargo.toml
+++ b/crates/glass-clip-shim-macos/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "glass-clip-shim-macos"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[lib]
+# cdylib = the injected shim (libglass_clip_shim_macos.dylib). No rlib: the pure routing
+# logic lives in glass-macos::clipboard_route, not here.
+crate-type = ["cdylib"]
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6.4"
+objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSString"] }
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSPasteboard"] }
+ctor = "0.1"
+
+[lints]
+workspace = true

--- a/crates/glass-clip-shim-macos/src/lib.rs
+++ b/crates/glass-clip-shim-macos/src/lib.rs
@@ -1,0 +1,102 @@
+//! glass macOS clipboard shim — injected via `DYLD_INSERT_LIBRARIES` into a contained app
+//! process. On load it reads `GLASS_CLIP_PASTEBOARD`; if set, it swizzles
+//! `+[NSPasteboard generalPasteboard]` to return a private, named pasteboard instead of the
+//! real system one, then writes a sentinel item so glass can confirm the injection took.
+//! Inert if the env var is unset — a copy of this shim loaded into an unrelated (or
+//! uncontained) process is a no-op.
+//!
+//! Isolation: the contained app's ordinary `NSPasteboard.generalPasteboard` calls are
+//! transparently redirected to the private named pasteboard; glass reads/writes the same
+//! name from the host side; the real general pasteboard — and anything else on the desktop
+//! — is never touched.
+#![cfg_attr(not(target_os = "macos"), allow(unused_crate_dependencies))]
+
+#[cfg(target_os = "macos")]
+mod imp {
+    use std::sync::OnceLock;
+
+    use objc2::rc::Retained;
+    use objc2::runtime::{AnyClass, Imp, Sel};
+    use objc2::{sel, ClassType};
+    use objc2_app_kit::NSPasteboard;
+    use objc2_foundation::NSString;
+
+    /// The sentinel pasteboard-item type glass looks for to confirm the swizzle took.
+    const SENTINEL_TYPE: &str = "tech.fixedwidth.glass.clip-shim";
+
+    /// The private pasteboard name, read once from `GLASS_CLIP_PASTEBOARD` and cached for
+    /// the replacement IMP — which, as a bare Objective-C method implementation, has no
+    /// other way to reach this process's environment context each time it's invoked.
+    fn name() -> &'static NSString {
+        static NAME: OnceLock<Retained<NSString>> = OnceLock::new();
+        NAME.get_or_init(|| {
+            let raw = std::env::var("GLASS_CLIP_PASTEBOARD").unwrap_or_default();
+            NSString::from_str(&raw)
+        })
+    }
+
+    /// Replacement implementation for `+[NSPasteboard generalPasteboard]`: returns the
+    /// private named pasteboard instead of the real one.
+    ///
+    /// Signature and calling convention match what the Objective-C runtime expects for a
+    /// zero-argument class method IMP (`id (*)(Class, SEL)`); the return follows the same
+    /// "autoreleased, not owned by the caller" convention the real `generalPasteboard`
+    /// uses (its selector carries no `new`/`alloc`/`copy` prefix), via
+    /// [`Retained::autorelease_return`] — the pattern `objc2` itself documents for
+    /// returning an object from a hand-written method implementation.
+    extern "C-unwind" fn glass_general_pasteboard(_cls: &AnyClass, _cmd: Sel) -> *mut NSPasteboard {
+        let pb = NSPasteboard::pasteboardWithName(name());
+        Retained::autorelease_return(pb)
+    }
+
+    /// Swizzle `+[NSPasteboard generalPasteboard]` and write the sentinel. Called once from
+    /// the load-time ctor; inert unless `GLASS_CLIP_PASTEBOARD` is set.
+    pub(super) fn install() {
+        if std::env::var_os("GLASS_CLIP_PASTEBOARD").is_none() {
+            return; // no name set: not a process glass is containing, stay inert
+        }
+
+        let method = NSPasteboard::class()
+            .class_method(sel!(generalPasteboard))
+            .expect("NSPasteboard always declares +generalPasteboard");
+
+        // SAFETY: `glass_general_pasteboard` has the exact `extern "C-unwind" fn(&AnyClass,
+        // Sel) -> *mut NSPasteboard` shape the Objective-C runtime expects for this
+        // zero-argument class method's IMP. `Imp` is itself defined as a same-ABI, pointer-
+        // sized `unsafe extern "C-unwind" fn()` used purely as an opaque carrier type —
+        // transmuting our concretely-typed function pointer into it is the same technique
+        // objc2's own `MethodImplementation` impls use internally to produce an `Imp` from a
+        // typed method fn (see e.g. `objc2::runtime::ClassBuilder::add_class_method`), just
+        // applied here to swizzle an existing method instead of defining a new class.
+        let imp: Imp = unsafe {
+            std::mem::transmute::<extern "C-unwind" fn(&AnyClass, Sel) -> *mut NSPasteboard, Imp>(
+                glass_general_pasteboard,
+            )
+        };
+        // SAFETY: `imp` matches the signature the runtime expects for this method (see
+        // above). Overriding `generalPasteboard`'s implementation with one that returns a
+        // different, equally-valid `NSPasteboard` cannot introduce UB the original method
+        // didn't already permit — callers only ever see a normal, live `NSPasteboard`.
+        unsafe {
+            method.set_implementation(imp);
+        }
+
+        // Prove the injection took: write a sentinel item to the private pasteboard so
+        // glass can read it back from the host side and confirm the swizzle is live before
+        // trusting anything the contained app writes to "the clipboard".
+        let pb = NSPasteboard::pasteboardWithName(name());
+        pb.clearContents();
+        let sentinel_type = NSString::from_str(SENTINEL_TYPE);
+        let sentinel_value = NSString::from_str("1");
+        pb.setString_forType(&sentinel_value, &sentinel_type);
+    }
+}
+
+/// Runs once when the dylib is loaded (via `DYLD_INSERT_LIBRARIES`), before the host
+/// process's `main`. See the module doc for what it does and why it's inert unless glass
+/// opted this specific process in.
+#[cfg(target_os = "macos")]
+#[ctor::ctor]
+fn glass_clip_shim_load() {
+    imp::install();
+}

--- a/crates/glass-clip-shim-macos/src/lib.rs
+++ b/crates/glass-clip-shim-macos/src/lib.rs
@@ -24,15 +24,14 @@ mod imp {
     /// The sentinel pasteboard-item type glass looks for to confirm the swizzle took.
     const SENTINEL_TYPE: &str = "tech.fixedwidth.glass.clip-shim";
 
-    /// The private pasteboard name, read once from `GLASS_CLIP_PASTEBOARD` and cached for
-    /// the replacement IMP — which, as a bare Objective-C method implementation, has no
-    /// other way to reach this process's environment context each time it's invoked.
-    fn name() -> &'static NSString {
-        static NAME: OnceLock<Retained<NSString>> = OnceLock::new();
-        NAME.get_or_init(|| {
-            let raw = std::env::var("GLASS_CLIP_PASTEBOARD").unwrap_or_default();
-            NSString::from_str(&raw)
-        })
+    /// The private pasteboard name, read once from `GLASS_CLIP_PASTEBOARD` and cached as a
+    /// plain `String` — the replacement IMP, as a bare Objective-C method implementation, has
+    /// no other way to reach this process's environment each time it's invoked. Cached as a
+    /// `String` (not a `Retained<NSString>`) because an `NSString` is not `Sync` and so cannot
+    /// live in a `static OnceLock`; the cheap `NSString` is rebuilt at each use site.
+    fn name() -> &'static str {
+        static NAME: OnceLock<String> = OnceLock::new();
+        NAME.get_or_init(|| std::env::var("GLASS_CLIP_PASTEBOARD").unwrap_or_default())
     }
 
     /// Replacement implementation for `+[NSPasteboard generalPasteboard]`: returns the
@@ -45,7 +44,8 @@ mod imp {
     /// [`Retained::autorelease_return`] — the pattern `objc2` itself documents for
     /// returning an object from a hand-written method implementation.
     extern "C-unwind" fn glass_general_pasteboard(_cls: &AnyClass, _cmd: Sel) -> *mut NSPasteboard {
-        let pb = NSPasteboard::pasteboardWithName(name());
+        let pb_name = NSString::from_str(name());
+        let pb = NSPasteboard::pasteboardWithName(&pb_name);
         Retained::autorelease_return(pb)
     }
 
@@ -84,7 +84,8 @@ mod imp {
         // Prove the injection took: write a sentinel item to the private pasteboard so
         // glass can read it back from the host side and confirm the swizzle is live before
         // trusting anything the contained app writes to "the clipboard".
-        let pb = NSPasteboard::pasteboardWithName(name());
+        let pb_name = NSString::from_str(name());
+        let pb = NSPasteboard::pasteboardWithName(&pb_name);
         pb.clearContents();
         let sentinel_type = NSString::from_str(SENTINEL_TYPE);
         let sentinel_value = NSString::from_str("1");

--- a/crates/glass-clip-shim-macos/src/lib.rs
+++ b/crates/glass-clip-shim-macos/src/lib.rs
@@ -1,9 +1,10 @@
 //! glass macOS clipboard shim — injected via `DYLD_INSERT_LIBRARIES` into a contained app
 //! process. On load it reads `GLASS_CLIP_PASTEBOARD`; if set, it swizzles
 //! `+[NSPasteboard generalPasteboard]` to return a private, named pasteboard instead of the
-//! real system one, then writes a sentinel item so glass can confirm the injection took.
-//! Inert if the env var is unset — a copy of this shim loaded into an unrelated (or
-//! uncontained) process is a no-op.
+//! real system one, then writes a sentinel item to a dedicated `<name>.ready` pasteboard so
+//! glass can confirm the injection took (a separate board so the app's own `clearContents` on
+//! the content board can never wipe the sentinel). Inert if the env var is unset — a copy of
+//! this shim loaded into an unrelated (or uncontained) process is a no-op.
 //!
 //! Isolation: the contained app's ordinary `NSPasteboard.generalPasteboard` calls are
 //! transparently redirected to the private named pasteboard; glass reads/writes the same
@@ -81,15 +82,21 @@ mod imp {
             method.set_implementation(imp);
         }
 
-        // Prove the injection took: write a sentinel item to the private pasteboard so
-        // glass can read it back from the host side and confirm the swizzle is live before
-        // trusting anything the contained app writes to "the clipboard".
-        let pb_name = NSString::from_str(name());
-        let pb = NSPasteboard::pasteboardWithName(&pb_name);
-        pb.clearContents();
+        // Prove the injection took: write a sentinel item to a DEDICATED `<name>.ready`
+        // pasteboard (never the content board the app itself uses — its own `clearContents`
+        // on a write would wipe a same-board sentinel) so glass can read it back from the host
+        // side and confirm the swizzle is live before trusting a `Private` clipboard route.
+        let ready_name = NSString::from_str(&format!("{}.ready", name()));
+        let ready = NSPasteboard::pasteboardWithName(&ready_name);
+        ready.clearContents();
         let sentinel_type = NSString::from_str(SENTINEL_TYPE);
         let sentinel_value = NSString::from_str("1");
-        pb.setString_forType(&sentinel_value, &sentinel_type);
+        // Diagnostic only: the swizzle above already took effect regardless of this write. A
+        // `false` here means the sentinel write was refused, which would leave glass on the
+        // fail-closed `Unsupported` route — surface why rather than failing silently.
+        if !ready.setString_forType(&sentinel_value, &sentinel_type) {
+            eprintln!("glass-clip-shim: failed to write injection sentinel to {}.ready", name());
+        }
     }
 }
 

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -344,6 +344,13 @@ impl Platform for MacosPlatform {
                 // The window never appeared (or discovery otherwise failed): don't leak
                 // the spawned child.
                 process::terminate(&mut child);
+                // Nor the named pasteboards the shim may already have created — the app (and
+                // its ctor) ran before discovery. `self.clip` is never set on this path, so
+                // `stop_app` wouldn't release them; do it here.
+                if let Some(c) = &clip {
+                    crate::clipboard::release_named(&c.name);
+                    crate::clipboard::release_named(&format!("{}.ready", c.name));
+                }
                 Err(e)
             }
         }
@@ -612,6 +619,13 @@ impl Drop for MacosPlatform {
     fn drop(&mut self) {
         if let Some(mut child) = self.child.take() {
             process::terminate(&mut child);
+        }
+        // Release this session's named pasteboards too if `stop_app` didn't run (panic-unwind
+        // or the process-exit backstop). `stop_app` sets `self.clip = None`, so this is a no-op
+        // when it already ran; otherwise the boards would leak system-wide.
+        if let Some(clip) = &self.clip {
+            crate::clipboard::release_named(&clip.name);
+            crate::clipboard::release_named(&format!("{}.ready", clip.name));
         }
     }
 }

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -86,7 +86,7 @@ pub struct MacosPlatform {
     active_window: Option<u32>,
     /// How `get_clipboard`/`set_clipboard` route the active session's clipboard. Decided in
     /// `start_app` (success path, from `clip` below plus a live `clipboard::shim_present`
-    /// check), reset to the default (`RealGeneral`) in `stop_app` — see
+    /// check), reset to the fail-closed default (`Unsupported`) in `stop_app` — see
     /// `crate::clipboard_route`'s module doc for the full decision and the three routes.
     clipboard_route: ClipboardRoute,
     /// The clip-shim launch facts `process::spawn` produced for the current session's app —
@@ -320,17 +320,18 @@ impl Platform for MacosPlatform {
                 // this field on every call.
                 self.active_window = Some(m.window_id);
                 // Decide the session's clipboard route now that the launched window is
-                // confirmed: `clip` only carries the shim's launch-time facts
-                // (name/injectable), so a live `clipboard::shim_present` check confirms the
-                // swizzle actually took before a `Private` route is trusted (an injectable
-                // target whose injection silently failed must still land on `Unsupported`,
-                // not a `Private` route to a pasteboard the app was never redirected to).
+                // confirmed: `clip` only carries the shim's launch-time name (its presence
+                // means the launch was injectable), so a live `clipboard::shim_present` check
+                // confirms the swizzle actually took before a `Private` route is trusted (an
+                // injectable target whose injection silently failed must still land on
+                // `Unsupported`, not a `Private` route to a pasteboard the app was never
+                // redirected to).
                 self.clipboard_route = match &clip {
                     Some(c) => {
                         let confirmed = crate::clipboard::shim_present(&c.name);
-                        crate::clipboard_route::decide_route(spec.sandbox, &c.name, c.injectable, confirmed)
+                        crate::clipboard_route::decide_route(spec.sandbox, Some((&c.name, confirmed)))
                     }
-                    None => crate::clipboard_route::decide_route(spec.sandbox, "", false, false),
+                    None => crate::clipboard_route::decide_route(spec.sandbox, None),
                 };
                 self.clip = clip;
                 // Scale/origin/geometry are NOT cached here: `send_pointer` re-resolves the
@@ -353,6 +354,15 @@ impl Platform for MacosPlatform {
     fn stop_app(&mut self) -> Result<()> {
         if let Some(mut child) = self.child.take() {
             process::terminate(&mut child);
+        }
+        // Release this session's named pasteboards (the content board + its `.ready` sentinel
+        // board) before dropping the shim facts. Named pasteboards persist system-wide until
+        // released, and a leftover sentinel could otherwise mask a failed injection in a later
+        // session (see `crate::clipboard_route`). Only released when a shim launch name is
+        // known (an injectable, contained launch); uncontained/hardened launches have none.
+        if let Some(clip) = &self.clip {
+            crate::clipboard::release_named(&clip.name);
+            crate::clipboard::release_named(&format!("{}.ready", clip.name));
         }
         self.app_pid = None;
         self.active_window = None;
@@ -677,16 +687,17 @@ mod tests {
     #[test]
     fn stop_app_clears_clipboard_route() {
         // start_app decides clipboard_route for the session; stop_app must reset it to the
-        // default (RealGeneral) too, so a later start_app on the same MacosPlatform never
-        // inherits a stale contained-session route (which would wrongly route
-        // get_clipboard/set_clipboard to a private pasteboard, or Unsupported, that no
-        // longer applies) before the next start_app decides fresh.
+        // fail-closed default (Unsupported) too, so a later start_app on the same
+        // MacosPlatform never inherits a stale contained-session route (here a
+        // `Private(name)`, which would wrongly route get_clipboard/set_clipboard to a private
+        // pasteboard that no longer applies) before the next start_app decides fresh. `clip`
+        // is None so stop_app touches no pasteboard here.
         let mut p = MacosPlatform {
             logs: Arc::new(Mutex::new(Vec::new())),
             app_pid: Some(42),
             child: None,
             active_window: Some(7),
-            clipboard_route: ClipboardRoute::Unsupported,
+            clipboard_route: ClipboardRoute::Private("tech.fixedwidth.glass.clip.42.1.1".into()),
             clip: None,
         };
         assert!(p.stop_app().is_ok());
@@ -698,14 +709,16 @@ mod tests {
         // start_app stores process::spawn's ClipLaunch facts for a later clipboard-routing
         // decision; stop_app must clear them too, so a later start_app on the same
         // MacosPlatform never leaks a previous session's shim facts (e.g. a stale private
-        // pasteboard name) into a new one.
+        // pasteboard name) into a new one. With `clip` set, stop_app also exercises the
+        // `release_named` path for the content + `.ready` boards (harmless on names no live
+        // shim ever wrote).
         let mut p = MacosPlatform {
             logs: Arc::new(Mutex::new(Vec::new())),
             app_pid: Some(42),
             child: None,
             active_window: Some(7),
-            clipboard_route: ClipboardRoute::Private("tech.fixedwidth.glass.clip.1".into()),
-            clip: Some(ClipLaunch { name: "tech.fixedwidth.glass.clip.1".into(), injectable: true }),
+            clipboard_route: ClipboardRoute::Private("tech.fixedwidth.glass.clip.42.1.1".into()),
+            clip: Some(ClipLaunch { name: "tech.fixedwidth.glass.clip.42.1.1".into() }),
         };
         assert!(p.stop_app().is_ok());
         assert!(p.clip.is_none());

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -19,7 +19,7 @@ use glass_core::{GlassError, Result};
 use crate::axwindow;
 use crate::coords;
 use crate::permissions;
-use crate::process::{self, LogSink};
+use crate::process::{self, ClipLaunch, LogSink};
 
 /// Poll interval between discovery attempts in [`MacosPlatform::discover_window`] —
 /// matches `scwindow::find_window_for_pids`'s own poll cadence
@@ -88,6 +88,13 @@ pub struct MacosPlatform {
     /// routing: contained apps get no real-pasteboard bridge (fail-closed). Cached per-session
     /// (reset in `stop_app`), unlike Windows' derived `ClipboardRoute`.
     sandbox: SandboxLevel,
+    /// The clip-shim launch facts `process::spawn` produced for the current session's app —
+    /// `Some` only for a contained, injectable launch (see `process::ClipLaunch`'s doc).
+    /// `None` until `start_app`, and whenever the launch was uncontained or non-injectable.
+    /// Held here (rather than consumed inside `start_app`) so the clipboard-routing decision
+    /// that depends on it can run after the launched window is confirmed; reset in
+    /// `stop_app`.
+    clip: Option<ClipLaunch>,
 }
 
 impl MacosPlatform {
@@ -100,6 +107,7 @@ impl MacosPlatform {
             child: None,
             active_window: None,
             sandbox: SandboxLevel::Off,
+            clip: None,
         })
     }
 
@@ -297,7 +305,7 @@ impl Platform for MacosPlatform {
     /// glass-mcp's worker-thread dispatcher (main-thread marshaling) is deferred to Plan 5.
     fn start_app(&mut self, spec: &AppSpec) -> Result<WindowGeometry> {
         Self::run_build(spec)?;
-        let mut child = process::spawn(spec, self.logs.clone())?;
+        let (mut child, clip) = process::spawn(spec, self.logs.clone())?;
         let pid = child.id();
         match Self::discover_window(&mut child, pid, spec.timeout_ms) {
             Ok(m) => {
@@ -311,6 +319,10 @@ impl Platform for MacosPlatform {
                 // this field on every call.
                 self.active_window = Some(m.window_id);
                 self.sandbox = spec.sandbox;
+                // `clip` (the clip-shim facts from `process::spawn`) is stored, not yet
+                // consumed here: the clipboard-routing decision it feeds needs the launched
+                // window confirmed first (this arm), and belongs to a later, separate step.
+                self.clip = clip;
                 // Scale/origin/geometry are NOT cached here: `send_pointer` re-resolves the
                 // window fresh on every call instead (see its doc) since it may move/resize
                 // after this initial discovery. Only the initial geometry is returned to the
@@ -338,6 +350,9 @@ impl Platform for MacosPlatform {
         // stale sandbox level leak into clipboard routing (get_clipboard/set_clipboard) before
         // the next start_app sets it fresh.
         self.sandbox = SandboxLevel::Off;
+        // Same reasoning for the clip-shim facts: a stale `Some` from a previous session must
+        // not leak into a later one's clipboard routing.
+        self.clip = None;
         Ok(())
     }
 
@@ -591,6 +606,7 @@ mod tests {
             child: None,
             active_window: None,
             sandbox: SandboxLevel::Off,
+            clip: None,
         };
         assert_eq!(p.drain_logs().len(), 1);
         assert!(p.drain_logs().is_empty());
@@ -604,6 +620,7 @@ mod tests {
             child: None,
             active_window: None,
             sandbox: SandboxLevel::Off,
+            clip: None,
         };
         assert_eq!(p.app_pid(), Some(42));
     }
@@ -619,6 +636,7 @@ mod tests {
             child: None,
             active_window: None,
             sandbox: SandboxLevel::Off,
+            clip: None,
         };
         assert!(p.stop_app().is_ok());
         assert!(p.stop_app().is_ok(), "a second call must also be Ok");
@@ -636,6 +654,7 @@ mod tests {
             child: None,
             active_window: Some(7),
             sandbox: SandboxLevel::Off,
+            clip: None,
         };
         assert!(p.stop_app().is_ok());
         assert_eq!(p.active_window, None);
@@ -652,9 +671,28 @@ mod tests {
             child: None,
             active_window: Some(7),
             sandbox: SandboxLevel::Strict,
+            clip: None,
         };
         assert!(p.stop_app().is_ok());
         assert_eq!(p.sandbox, SandboxLevel::Off);
+    }
+
+    #[test]
+    fn stop_app_clears_clip() {
+        // start_app stores process::spawn's ClipLaunch facts for a later clipboard-routing
+        // decision; stop_app must clear them too, so a later start_app on the same
+        // MacosPlatform never leaks a previous session's shim facts (e.g. a stale private
+        // pasteboard name) into a new one.
+        let mut p = MacosPlatform {
+            logs: Arc::new(Mutex::new(Vec::new())),
+            app_pid: Some(42),
+            child: None,
+            active_window: Some(7),
+            sandbox: SandboxLevel::Default,
+            clip: Some(ClipLaunch { name: "tech.fixedwidth.glass.clip.1".into(), injectable: true }),
+        };
+        assert!(p.stop_app().is_ok());
+        assert!(p.clip.is_none());
     }
 
     #[test]
@@ -669,6 +707,7 @@ mod tests {
             child: None,
             active_window: None,
             sandbox: SandboxLevel::Strict,
+            clip: None,
         };
         assert!(matches!(p.get_clipboard(), Err(GlassError::Unsupported(_))));
         assert!(matches!(p.set_clipboard("x"), Err(GlassError::Unsupported(_))));

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -11,12 +11,12 @@ use objc2_application_services::AXUIElement;
 use glass_core::frame::{Frame, Region};
 use glass_core::logbuf::Stream;
 use glass_core::platform::{
-    AppSpec, KeyEvent, Platform, PointerEvent, SandboxLevel, WindowGeometry, WindowId, WindowInfo,
-    WindowOp,
+    AppSpec, KeyEvent, Platform, PointerEvent, WindowGeometry, WindowId, WindowInfo, WindowOp,
 };
 use glass_core::{GlassError, Result};
 
 use crate::axwindow;
+use crate::clipboard_route::ClipboardRoute;
 use crate::coords;
 use crate::permissions;
 use crate::process::{self, ClipLaunch, LogSink};
@@ -84,10 +84,11 @@ pub struct MacosPlatform {
     /// meaning "no window chosen yet"; every per-call resolver below falls back to the
     /// original first-on-screen-by-pid lookup in that case.
     active_window: Option<u32>,
-    /// The launched app's containment level. `Off` until `start_app`. Governs clipboard
-    /// routing: contained apps get no real-pasteboard bridge (fail-closed). Cached per-session
-    /// (reset in `stop_app`), unlike Windows' derived `ClipboardRoute`.
-    sandbox: SandboxLevel,
+    /// How `get_clipboard`/`set_clipboard` route the active session's clipboard. Decided in
+    /// `start_app` (success path, from `clip` below plus a live `clipboard::shim_present`
+    /// check), reset to the default (`RealGeneral`) in `stop_app` — see
+    /// `crate::clipboard_route`'s module doc for the full decision and the three routes.
+    clipboard_route: ClipboardRoute,
     /// The clip-shim launch facts `process::spawn` produced for the current session's app —
     /// `Some` only for a contained, injectable launch (see `process::ClipLaunch`'s doc).
     /// `None` until `start_app`, and whenever the launch was uncontained or non-injectable.
@@ -106,7 +107,7 @@ impl MacosPlatform {
             app_pid: None,
             child: None,
             active_window: None,
-            sandbox: SandboxLevel::Off,
+            clipboard_route: ClipboardRoute::default(),
             clip: None,
         })
     }
@@ -318,10 +319,19 @@ impl Platform for MacosPlatform {
                 // `capture_frame`/`send_pointer`/`send_key` below) is what actually honors
                 // this field on every call.
                 self.active_window = Some(m.window_id);
-                self.sandbox = spec.sandbox;
-                // `clip` (the clip-shim facts from `process::spawn`) is stored, not yet
-                // consumed here: the clipboard-routing decision it feeds needs the launched
-                // window confirmed first (this arm), and belongs to a later, separate step.
+                // Decide the session's clipboard route now that the launched window is
+                // confirmed: `clip` only carries the shim's launch-time facts
+                // (name/injectable), so a live `clipboard::shim_present` check confirms the
+                // swizzle actually took before a `Private` route is trusted (an injectable
+                // target whose injection silently failed must still land on `Unsupported`,
+                // not a `Private` route to a pasteboard the app was never redirected to).
+                self.clipboard_route = match &clip {
+                    Some(c) => {
+                        let confirmed = crate::clipboard::shim_present(&c.name);
+                        crate::clipboard_route::decide_route(spec.sandbox, &c.name, c.injectable, confirmed)
+                    }
+                    None => crate::clipboard_route::decide_route(spec.sandbox, "", false, false),
+                };
                 self.clip = clip;
                 // Scale/origin/geometry are NOT cached here: `send_pointer` re-resolves the
                 // window fresh on every call instead (see its doc) since it may move/resize
@@ -346,10 +356,10 @@ impl Platform for MacosPlatform {
         }
         self.app_pid = None;
         self.active_window = None;
-        // Reset containment too, so a later start_app on the same MacosPlatform can't have a
-        // stale sandbox level leak into clipboard routing (get_clipboard/set_clipboard) before
-        // the next start_app sets it fresh.
-        self.sandbox = SandboxLevel::Off;
+        // Reset the clipboard route too, so a later start_app on the same MacosPlatform can't
+        // have a stale route (e.g. a previous session's Private(name)) leak into
+        // get_clipboard/set_clipboard before the next start_app decides fresh.
+        self.clipboard_route = ClipboardRoute::default();
         // Same reasoning for the clip-shim facts: a stale `Some` from a previous session must
         // not leak into a later one's clipboard routing.
         self.clip = None;
@@ -556,26 +566,30 @@ impl Platform for MacosPlatform {
     fn app_pid(&self) -> Option<u32> {
         self.app_pid
     }
-    /// Read the clipboard. Uncontained (`sandbox: off`) → the real system pasteboard.
-    /// Contained (`Default`/`Strict`) → `Unsupported`: the app is denied the real pasteboard,
-    /// and glass does not bridge one (fail-closed, mirroring the Windows contained route).
+    /// Read the clipboard, routed per `clipboard_route` (decided in `start_app`; see
+    /// `crate::clipboard_route`'s module doc): `RealGeneral` (uncontained) reads the real
+    /// system pasteboard; `Private(name)` (contained + injectable + shim-confirmed) reads the
+    /// shim-redirected named pasteboard; `Unsupported` (contained, non-injectable, or
+    /// injection unconfirmed) fails closed — glass does not bridge one.
     fn get_clipboard(&mut self) -> Result<String> {
-        if self.sandbox != SandboxLevel::Off {
-            return Err(GlassError::Unsupported(
-                "clipboard is isolated under macOS containment (sandbox != off)".into(),
-            ));
+        match &self.clipboard_route {
+            ClipboardRoute::RealGeneral => crate::clipboard::get(),
+            ClipboardRoute::Private(name) => crate::clipboard::get_named(name),
+            ClipboardRoute::Unsupported => Err(GlassError::Unsupported(
+                "clipboard is isolated under macOS containment (target not injectable)".into(),
+            )),
         }
-        crate::clipboard::get()
     }
 
     /// Write the clipboard. Same routing as `get_clipboard`.
     fn set_clipboard(&mut self, text: &str) -> Result<()> {
-        if self.sandbox != SandboxLevel::Off {
-            return Err(GlassError::Unsupported(
-                "clipboard is isolated under macOS containment (sandbox != off)".into(),
-            ));
+        match &self.clipboard_route {
+            ClipboardRoute::RealGeneral => crate::clipboard::set(text),
+            ClipboardRoute::Private(name) => crate::clipboard::set_named(name, text),
+            ClipboardRoute::Unsupported => Err(GlassError::Unsupported(
+                "clipboard is isolated under macOS containment (target not injectable)".into(),
+            )),
         }
-        crate::clipboard::set(text)
     }
 }
 
@@ -605,7 +619,7 @@ mod tests {
             app_pid: Some(42),
             child: None,
             active_window: None,
-            sandbox: SandboxLevel::Off,
+            clipboard_route: ClipboardRoute::default(),
             clip: None,
         };
         assert_eq!(p.drain_logs().len(), 1);
@@ -619,7 +633,7 @@ mod tests {
             app_pid: Some(42),
             child: None,
             active_window: None,
-            sandbox: SandboxLevel::Off,
+            clipboard_route: ClipboardRoute::default(),
             clip: None,
         };
         assert_eq!(p.app_pid(), Some(42));
@@ -635,7 +649,7 @@ mod tests {
             app_pid: None,
             child: None,
             active_window: None,
-            sandbox: SandboxLevel::Off,
+            clipboard_route: ClipboardRoute::default(),
             clip: None,
         };
         assert!(p.stop_app().is_ok());
@@ -653,7 +667,7 @@ mod tests {
             app_pid: Some(42),
             child: None,
             active_window: Some(7),
-            sandbox: SandboxLevel::Off,
+            clipboard_route: ClipboardRoute::default(),
             clip: None,
         };
         assert!(p.stop_app().is_ok());
@@ -661,20 +675,22 @@ mod tests {
     }
 
     #[test]
-    fn stop_app_clears_sandbox_level() {
-        // start_app caches spec.sandbox for clipboard routing; stop_app must reset it to Off
-        // too, so a later start_app that launches uncontained never inherits a stale contained
-        // sandbox level (which would wrongly deny get_clipboard/set_clipboard).
+    fn stop_app_clears_clipboard_route() {
+        // start_app decides clipboard_route for the session; stop_app must reset it to the
+        // default (RealGeneral) too, so a later start_app on the same MacosPlatform never
+        // inherits a stale contained-session route (which would wrongly route
+        // get_clipboard/set_clipboard to a private pasteboard, or Unsupported, that no
+        // longer applies) before the next start_app decides fresh.
         let mut p = MacosPlatform {
             logs: Arc::new(Mutex::new(Vec::new())),
             app_pid: Some(42),
             child: None,
             active_window: Some(7),
-            sandbox: SandboxLevel::Strict,
+            clipboard_route: ClipboardRoute::Unsupported,
             clip: None,
         };
         assert!(p.stop_app().is_ok());
-        assert_eq!(p.sandbox, SandboxLevel::Off);
+        assert_eq!(p.clipboard_route, ClipboardRoute::default());
     }
 
     #[test]
@@ -688,7 +704,7 @@ mod tests {
             app_pid: Some(42),
             child: None,
             active_window: Some(7),
-            sandbox: SandboxLevel::Default,
+            clipboard_route: ClipboardRoute::Private("tech.fixedwidth.glass.clip.1".into()),
             clip: Some(ClipLaunch { name: "tech.fixedwidth.glass.clip.1".into(), injectable: true }),
         };
         assert!(p.stop_app().is_ok());
@@ -699,18 +715,35 @@ mod tests {
     fn clipboard_is_unsupported_under_containment() {
         // Construct the struct directly (not `MacosPlatform::new()`, which runs a
         // Screen-Recording TCC preflight that the ungranted CI runner can't pass) — the
-        // `!= Off` branch below returns before either clipboard method touches the real
+        // `Unsupported` route below returns before either clipboard method touches any
         // pasteboard, so this exercises the routing grant-free.
         let mut p = MacosPlatform {
             logs: Arc::new(Mutex::new(Vec::new())),
             app_pid: None,
             child: None,
             active_window: None,
-            sandbox: SandboxLevel::Strict,
+            clipboard_route: ClipboardRoute::Unsupported,
             clip: None,
         };
         assert!(matches!(p.get_clipboard(), Err(GlassError::Unsupported(_))));
         assert!(matches!(p.set_clipboard("x"), Err(GlassError::Unsupported(_))));
+    }
+
+    #[test]
+    fn clipboard_real_general_route_reaches_the_real_pasteboard() {
+        // RealGeneral must route to `crate::clipboard::get` rather than short-circuiting to
+        // `Unsupported`. Read-only (never calls `set_clipboard`), matching `clipboard.rs`'s
+        // own test-module discipline of never mutating the shared system pasteboard from an
+        // automated test — this only proves the route reaches the real implementation.
+        let mut p = MacosPlatform {
+            logs: Arc::new(Mutex::new(Vec::new())),
+            app_pid: None,
+            child: None,
+            active_window: None,
+            clipboard_route: ClipboardRoute::RealGeneral,
+            clip: None,
+        };
+        assert!(!matches!(p.get_clipboard(), Err(GlassError::Unsupported(_))));
     }
 
     #[test]

--- a/crates/glass-macos/src/clipboard.rs
+++ b/crates/glass-macos/src/clipboard.rs
@@ -1,12 +1,20 @@
-//! macOS clipboard (the general `NSPasteboard`) read/write behind the `Platform` seam.
+//! macOS clipboard (`NSPasteboard`) read/write behind the `Platform` seam.
 //!
-//! Text only, matching `Platform::get_clipboard`/`set_clipboard`. This module implements the
-//! **uncontained** (`sandbox: off`) path only: it acts on the user's **real system
-//! pasteboard** — the same shared-desktop behaviour the other backends have under
-//! `GLASS_DISPLAY=:0` / the Windows backend's `sandbox=off`. Under `Default`/`Strict`
-//! containment the Seatbelt profile denies the app the real pasteboard, so
-//! `MacosPlatform::get_clipboard`/`set_clipboard` route those levels to `Unsupported`
-//! before ever reaching this module — the clipboard is isolated, not bridged.
+//! Text only, matching `Platform::get_clipboard`/`set_clipboard`. Two pasteboards, chosen by
+//! `MacosPlatform`'s `clipboard_route` (`crate::clipboard_route::ClipboardRoute`):
+//!
+//! - **`RealGeneral`** (`sandbox: off`): [`get`]/[`set`] act on the user's **real system
+//!   pasteboard** — the same shared-desktop behaviour the other backends have under
+//!   `GLASS_DISPLAY=:0` / the Windows backend's `sandbox=off`.
+//! - **`Private(name)`** (contained + injectable + the clip shim confirmed): [`get_named`]/
+//!   [`set_named`] act on the private named pasteboard the shim redirected the contained
+//!   app's `NSPasteboard.generalPasteboard` to — the real general pasteboard is never
+//!   touched. [`shim_present`] confirms the shim's sentinel item landed there before
+//!   `start_app` trusts this route.
+//!
+//! `Unsupported` (contained, non-injectable/unconfirmed) never reaches this module at all —
+//! `MacosPlatform::get_clipboard`/`set_clipboard` short-circuit to `GlassError::Unsupported`
+//! first, fail-closed with no pasteboard bridge.
 //!
 //! The only `unsafe` here is reading AppKit's `NSPasteboardTypeString` extern static (Rust
 //! requires `unsafe` to read any extern static — see the `// SAFETY:` note); the `NSPasteboard`
@@ -16,6 +24,12 @@
 use glass_core::{GlassError, Result};
 use objc2_app_kit::{NSPasteboard, NSPasteboardType, NSPasteboardTypeString};
 use objc2_foundation::NSString;
+
+/// The clip shim's sentinel pasteboard-item type (`glass-clip-shim-macos`'s
+/// `SENTINEL_TYPE`) — written to the private named pasteboard once the shim's swizzle is
+/// live, so [`shim_present`] can confirm injection actually took rather than trusting
+/// `injectable` (codesign-derived) alone.
+const SHIM_SENTINEL_TYPE: &str = "tech.fixedwidth.glass.clip-shim";
 
 /// The plain-text pasteboard type constant.
 fn text_type() -> &'static NSPasteboardType {
@@ -35,6 +49,29 @@ pub(crate) fn get() -> Result<String> {
 /// no-op — if the pasteboard refuses the write.
 pub(crate) fn set(text: &str) -> Result<()> {
     write(&NSPasteboard::generalPasteboard(), text)
+}
+
+/// Read a named pasteboard's plain-text value; `""` when it holds no text. Used for the
+/// `ClipboardRoute::Private(name)` route — `name` is the per-session private pasteboard the
+/// clip shim redirected the contained app to.
+pub(crate) fn get_named(name: &str) -> Result<String> {
+    read(&NSPasteboard::pasteboardWithName(&NSString::from_str(name)))
+}
+
+/// Replace a named pasteboard's contents with `text` (plain text). Same routing as
+/// [`get_named`].
+pub(crate) fn set_named(name: &str, text: &str) -> Result<()> {
+    write(&NSPasteboard::pasteboardWithName(&NSString::from_str(name)), text)
+}
+
+/// Whether the clip shim's sentinel item ([`SHIM_SENTINEL_TYPE`]) is present on the named
+/// pasteboard `name` — confirms the shim's swizzle-and-write actually took, not merely that
+/// the target was injectable. `start_app` calls this to decide whether a `Private(name)`
+/// route is trustworthy.
+pub(crate) fn shim_present(name: &str) -> bool {
+    let pb = NSPasteboard::pasteboardWithName(&NSString::from_str(name));
+    let sentinel_type = NSString::from_str(SHIM_SENTINEL_TYPE);
+    pb.stringForType(&sentinel_type).is_some()
 }
 
 /// Read `pb`'s plain-text value; `""` when it holds no string of that type. Split from [`get`]
@@ -65,9 +102,10 @@ fn write(pb: &NSPasteboard, text: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{read, write};
+    use super::{get_named, read, set_named, shim_present, write, SHIM_SENTINEL_TYPE};
     use objc2::rc::Retained;
     use objc2_app_kit::NSPasteboard;
+    use objc2_foundation::NSString;
 
     // Drive a PRIVATE scratch pasteboard (`pasteboardWithUniqueName`), never the shared system
     // one, so the suite never reads — let alone clears — a developer's real clipboard.
@@ -76,6 +114,15 @@ mod tests {
     // released at process exit; a short test process needn't free them explicitly.)
     fn scratch() -> Retained<NSPasteboard> {
         NSPasteboard::pasteboardWithUniqueName()
+    }
+
+    /// A private *named* pasteboard for the `get_named`/`set_named`/`shim_present` tests
+    /// below, scoped by this test process's pid and `tag` so parallel tests in the same
+    /// process, and repeated CI runs, never collide on the same name. Unlike `scratch()`, this
+    /// exercises `NSPasteboard::pasteboardWithName` — the exact lookup `get_named`/
+    /// `set_named`/`shim_present` themselves perform — rather than `pasteboardWithUniqueName`.
+    fn named(tag: &str) -> String {
+        format!("tech.fixedwidth.glass.clip-shim-test.{}.{tag}", std::process::id())
     }
 
     #[test]
@@ -90,5 +137,37 @@ mod tests {
         // A fresh unique pasteboard holds no string type → `stringForType` is `None` → "".
         let pb = scratch();
         assert_eq!(read(&pb).expect("read"), "");
+    }
+
+    #[test]
+    fn get_named_set_named_roundtrip_text() {
+        let name = named("roundtrip");
+        set_named(&name, "glass-named-probe-\u{1F9EA}").expect("set_named");
+        assert_eq!(get_named(&name).expect("get_named"), "glass-named-probe-\u{1F9EA}");
+    }
+
+    #[test]
+    fn get_named_is_empty_when_pasteboard_has_no_text() {
+        let name = named("empty");
+        assert_eq!(get_named(&name).expect("get_named"), "");
+    }
+
+    #[test]
+    fn shim_present_is_false_without_the_sentinel() {
+        let name = named("no-sentinel");
+        assert!(!shim_present(&name));
+    }
+
+    #[test]
+    fn shim_present_is_true_once_the_sentinel_type_is_written() {
+        // Mirrors exactly what `glass-clip-shim-macos::imp::install` does on a real injected
+        // launch — write the sentinel type to the named pasteboard — without depending on the
+        // shim dylib itself.
+        let name = named("sentinel");
+        let pb = NSPasteboard::pasteboardWithName(&NSString::from_str(&name));
+        let sentinel_type = NSString::from_str(SHIM_SENTINEL_TYPE);
+        let value = NSString::from_str("1");
+        assert!(pb.setString_forType(&value, &sentinel_type));
+        assert!(shim_present(&name));
     }
 }

--- a/crates/glass-macos/src/clipboard.rs
+++ b/crates/glass-macos/src/clipboard.rs
@@ -9,8 +9,8 @@
 //! - **`Private(name)`** (contained + injectable + the clip shim confirmed): [`get_named`]/
 //!   [`set_named`] act on the private named pasteboard the shim redirected the contained
 //!   app's `NSPasteboard.generalPasteboard` to — the real general pasteboard is never
-//!   touched. [`shim_present`] confirms the shim's sentinel item landed there before
-//!   `start_app` trusts this route.
+//!   touched. [`shim_present`] confirms the shim's sentinel item landed on the dedicated
+//!   `<name>.ready` board before `start_app` trusts this route.
 //!
 //! `Unsupported` (contained, non-injectable/unconfirmed) never reaches this module at all —
 //! `MacosPlatform::get_clipboard`/`set_clipboard` short-circuit to `GlassError::Unsupported`
@@ -26,9 +26,9 @@ use objc2_app_kit::{NSPasteboard, NSPasteboardType, NSPasteboardTypeString};
 use objc2_foundation::NSString;
 
 /// The clip shim's sentinel pasteboard-item type (`glass-clip-shim-macos`'s
-/// `SENTINEL_TYPE`) — written to the private named pasteboard once the shim's swizzle is
+/// `SENTINEL_TYPE`) — written to the session's `<name>.ready` board once the shim's swizzle is
 /// live, so [`shim_present`] can confirm injection actually took rather than trusting
-/// `injectable` (codesign-derived) alone.
+/// injectability (codesign-derived) alone.
 const SHIM_SENTINEL_TYPE: &str = "tech.fixedwidth.glass.clip-shim";
 
 /// The plain-text pasteboard type constant.
@@ -64,14 +64,39 @@ pub(crate) fn set_named(name: &str, text: &str) -> Result<()> {
     write(&NSPasteboard::pasteboardWithName(&NSString::from_str(name)), text)
 }
 
-/// Whether the clip shim's sentinel item ([`SHIM_SENTINEL_TYPE`]) is present on the named
-/// pasteboard `name` — confirms the shim's swizzle-and-write actually took, not merely that
-/// the target was injectable. `start_app` calls this to decide whether a `Private(name)`
-/// route is trustworthy.
+/// Whether the clip shim's sentinel item ([`SHIM_SENTINEL_TYPE`]) is present on the session's
+/// dedicated `<name>.ready` sentinel board — confirms the shim's swizzle-and-write actually
+/// took, not merely that the target was injectable. `start_app` calls this to decide whether a
+/// `Private(name)` route is trustworthy.
+///
+/// The sentinel lives on a SEPARATE `.ready` board (not the `name` content board the app
+/// itself uses) so the app's own `clearContents` on a write can never wipe it — that would
+/// make a live injection read as unconfirmed.
 pub(crate) fn shim_present(name: &str) -> bool {
-    let pb = NSPasteboard::pasteboardWithName(&NSString::from_str(name));
+    let ready_name = format!("{name}.ready");
+    let pb = NSPasteboard::pasteboardWithName(&NSString::from_str(&ready_name));
     let sentinel_type = NSString::from_str(SHIM_SENTINEL_TYPE);
     pb.stringForType(&sentinel_type).is_some()
+}
+
+/// Release a named pasteboard's server-side resources. Named pasteboards persist system-wide
+/// until explicitly released, so `stop_app` calls this on both the session's content board and
+/// its `<name>.ready` sentinel board — hygiene, plus defense against a stale sentinel ever
+/// masking a later failed injection (see [`shim_present`] / `crate::clipboard_route`).
+///
+/// Sends `-[NSPasteboard releaseGlobally]` via `msg_send!` because that (deprecated) selector
+/// is absent from objc2-app-kit 0.3.2's generated bindings (skipped in its translation
+/// config), so there is no safe wrapper to call.
+pub(crate) fn release_named(name: &str) {
+    let pb = NSPasteboard::pasteboardWithName(&NSString::from_str(name));
+    // SAFETY: `releaseGlobally` is a zero-argument `void` instance method; `pb` is a live,
+    // non-null `Retained<NSPasteboard>` from `pasteboardWithName`, so it matches exactly the
+    // receiver and (empty) argument list `-[NSPasteboard releaseGlobally]` expects. The call
+    // returns no object, so no ownership/lifetime obligation follows; the local `Retained`
+    // still drops (releases its own reference) normally afterward.
+    unsafe {
+        let _: () = objc2::msg_send![&*pb, releaseGlobally];
+    }
 }
 
 /// Read `pb`'s plain-text value; `""` when it holds no string of that type. Split from [`get`]
@@ -161,13 +186,13 @@ mod tests {
     #[test]
     fn shim_present_is_true_once_the_sentinel_type_is_written() {
         // Mirrors exactly what `glass-clip-shim-macos::imp::install` does on a real injected
-        // launch — write the sentinel type to the named pasteboard — without depending on the
-        // shim dylib itself.
+        // launch — write the sentinel type to the dedicated `<name>.ready` board — without
+        // depending on the shim dylib itself.
         let name = named("sentinel");
-        let pb = NSPasteboard::pasteboardWithName(&NSString::from_str(&name));
+        let ready = NSPasteboard::pasteboardWithName(&NSString::from_str(&format!("{name}.ready")));
         let sentinel_type = NSString::from_str(SHIM_SENTINEL_TYPE);
         let value = NSString::from_str("1");
-        assert!(pb.setString_forType(&value, &sentinel_type));
+        assert!(ready.setString_forType(&value, &sentinel_type));
         assert!(shim_present(&name));
     }
 }

--- a/crates/glass-macos/src/clipboard_route.rs
+++ b/crates/glass-macos/src/clipboard_route.rs
@@ -1,0 +1,86 @@
+//! Pure clipboard-routing policy for the macOS backend. Decides how `glass_clipboard_get/set`
+//! behave for the active session, mirroring the Windows `ClipboardRoute`. No OS calls — unit
+//! -tested on the Linux dev box.
+#![forbid(unsafe_code)]
+
+use glass_core::platform::SandboxLevel;
+
+/// How `MacosPlatform` routes clipboard for the active session. Set at `start_app`, reset on
+/// `stop_app`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum ClipboardRoute {
+    /// `sandbox: off` — the real general system pasteboard.
+    #[default]
+    RealGeneral,
+    /// Contained + injectable + the shim's sentinel was observed — a private named pasteboard
+    /// the shim redirected the app to; glass shares it by this name.
+    Private(String),
+    /// Contained + hardened (injection would be stripped), or injectable-but-injection-
+    /// unconfirmed — clipboard is isolated with no bridge (fail-closed).
+    Unsupported,
+}
+
+/// Decide the route from the launch facts. `injectable` = the target is not hardened-runtime
+/// (so DYLD injection can take); `shim_confirmed` = the shim's sentinel was seen on the named
+/// pasteboard after launch (injection actually took).
+pub fn decide_route(
+    level: SandboxLevel,
+    name: &str,
+    injectable: bool,
+    shim_confirmed: bool,
+) -> ClipboardRoute {
+    if level == SandboxLevel::Off {
+        return ClipboardRoute::RealGeneral;
+    }
+    if injectable && shim_confirmed {
+        ClipboardRoute::Private(name.to_owned())
+    } else {
+        ClipboardRoute::Unsupported
+    }
+}
+
+/// The per-session named-pasteboard name shared between glass and the shim (glass sets it in
+/// the child's `GLASS_CLIP_PASTEBOARD` env var). `token` is a per-spawn unique value (an
+/// atomic counter) so concurrent/relaunched sessions never collide.
+pub fn session_pasteboard_name(token: u64) -> String {
+    format!("tech.fixedwidth.glass.clip.{token}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn off_is_real_general() {
+        assert_eq!(
+            decide_route(SandboxLevel::Off, "n", false, false),
+            ClipboardRoute::RealGeneral
+        );
+    }
+    #[test]
+    fn contained_injectable_confirmed_is_private() {
+        assert_eq!(
+            decide_route(SandboxLevel::Default, "n", true, true),
+            ClipboardRoute::Private("n".into())
+        );
+    }
+    #[test]
+    fn contained_hardened_is_unsupported() {
+        assert_eq!(
+            decide_route(SandboxLevel::Strict, "n", false, false),
+            ClipboardRoute::Unsupported
+        );
+    }
+    #[test]
+    fn contained_injectable_but_unconfirmed_is_unsupported() {
+        assert_eq!(
+            decide_route(SandboxLevel::Default, "n", true, false),
+            ClipboardRoute::Unsupported
+        );
+    }
+    #[test]
+    fn session_name_is_token_scoped() {
+        assert_eq!(session_pasteboard_name(7), "tech.fixedwidth.glass.clip.7");
+        assert_ne!(session_pasteboard_name(1), session_pasteboard_name(2));
+    }
+}

--- a/crates/glass-macos/src/clipboard_route.rs
+++ b/crates/glass-macos/src/clipboard_route.rs
@@ -6,44 +6,48 @@
 use glass_core::platform::SandboxLevel;
 
 /// How `MacosPlatform` routes clipboard for the active session. Set at `start_app`, reset on
-/// `stop_app`.
+/// `stop_app`. The default is the fail-closed `Unsupported` route: until `start_app` proves a
+/// safe route, clipboard access is denied rather than silently reaching the real pasteboard.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum ClipboardRoute {
     /// `sandbox: off` — the real general system pasteboard.
-    #[default]
     RealGeneral,
     /// Contained + injectable + the shim's sentinel was observed — a private named pasteboard
     /// the shim redirected the app to; glass shares it by this name.
     Private(String),
     /// Contained + hardened (injection would be stripped), or injectable-but-injection-
-    /// unconfirmed — clipboard is isolated with no bridge (fail-closed).
+    /// unconfirmed — clipboard is isolated with no bridge (fail-closed). The default route.
+    #[default]
     Unsupported,
 }
 
-/// Decide the route from the launch facts. `injectable` = the target is not hardened-runtime
-/// (so DYLD injection can take); `shim_confirmed` = the shim's sentinel was seen on the named
-/// pasteboard after launch (injection actually took).
-pub fn decide_route(
-    level: SandboxLevel,
-    name: &str,
-    injectable: bool,
-    shim_confirmed: bool,
-) -> ClipboardRoute {
+/// Decide the route from the launch facts. `attempt` is `Some((name, shim_confirmed))` for a
+/// contained, injectable launch — `name` is the private named pasteboard glass shares with the
+/// shim, and `shim_confirmed` is whether the shim's sentinel was observed after launch
+/// (injection actually took) — or `None` for an uncontained (`sandbox: off`) or non-injectable
+/// launch.
+///
+/// Fail-closed: only `SandboxLevel::Off` (→ `RealGeneral`) or a confirmed injection
+/// (→ `Private`) reaches a real/private pasteboard; every other case is `Unsupported`.
+pub fn decide_route(level: SandboxLevel, attempt: Option<(&str, bool)>) -> ClipboardRoute {
     if level == SandboxLevel::Off {
         return ClipboardRoute::RealGeneral;
     }
-    if injectable && shim_confirmed {
-        ClipboardRoute::Private(name.to_owned())
-    } else {
-        ClipboardRoute::Unsupported
+    match attempt {
+        Some((name, true)) => ClipboardRoute::Private(name.to_owned()),
+        _ => ClipboardRoute::Unsupported,
     }
 }
 
 /// The per-session named-pasteboard name shared between glass and the shim (glass sets it in
-/// the child's `GLASS_CLIP_PASTEBOARD` env var). `token` is a per-spawn unique value (an
-/// atomic counter) so concurrent/relaunched sessions never collide.
-pub fn session_pasteboard_name(token: u64) -> String {
-    format!("tech.fixedwidth.glass.clip.{token}")
+/// the child's `GLASS_CLIP_PASTEBOARD` env var). Combines the launching `glass-mcp` process's
+/// `pid`, a per-launch `nonce` (wall-clock nanoseconds), and a per-spawn `token` (an atomic
+/// counter) so the name is unique per launch. The `pid`/`nonce` components are what keep it
+/// unique ACROSS `glass-mcp` restarts: a bare counter resets to its start value on every
+/// restart, so a reused name would let a stale, system-wide named pasteboard (they persist
+/// until released) mask a failed injection with an old sentinel.
+pub fn session_pasteboard_name(pid: u32, nonce: u64, token: u64) -> String {
+    format!("tech.fixedwidth.glass.clip.{pid}.{nonce}.{token}")
 }
 
 #[cfg(test)]
@@ -52,35 +56,48 @@ mod tests {
 
     #[test]
     fn off_is_real_general() {
+        assert_eq!(decide_route(SandboxLevel::Off, None), ClipboardRoute::RealGeneral);
+    }
+    #[test]
+    fn off_is_real_general_even_with_a_confirmed_attempt() {
+        // `Off` short-circuits before the attempt is considered — an uncontained launch never
+        // carries one, but the precedence must be explicit.
         assert_eq!(
-            decide_route(SandboxLevel::Off, "n", false, false),
+            decide_route(SandboxLevel::Off, Some(("n", true))),
             ClipboardRoute::RealGeneral
         );
     }
     #[test]
     fn contained_injectable_confirmed_is_private() {
         assert_eq!(
-            decide_route(SandboxLevel::Default, "n", true, true),
+            decide_route(SandboxLevel::Default, Some(("n", true))),
             ClipboardRoute::Private("n".into())
         );
     }
     #[test]
-    fn contained_hardened_is_unsupported() {
-        assert_eq!(
-            decide_route(SandboxLevel::Strict, "n", false, false),
-            ClipboardRoute::Unsupported
-        );
+    fn contained_with_no_attempt_is_unsupported() {
+        assert_eq!(decide_route(SandboxLevel::Strict, None), ClipboardRoute::Unsupported);
     }
     #[test]
     fn contained_injectable_but_unconfirmed_is_unsupported() {
         assert_eq!(
-            decide_route(SandboxLevel::Default, "n", true, false),
+            decide_route(SandboxLevel::Default, Some(("n", false))),
             ClipboardRoute::Unsupported
         );
     }
     #[test]
-    fn session_name_is_token_scoped() {
-        assert_eq!(session_pasteboard_name(7), "tech.fixedwidth.glass.clip.7");
-        assert_ne!(session_pasteboard_name(1), session_pasteboard_name(2));
+    fn default_route_is_fail_closed_unsupported() {
+        assert_eq!(ClipboardRoute::default(), ClipboardRoute::Unsupported);
+    }
+    #[test]
+    fn session_name_includes_pid_nonce_and_token() {
+        assert_eq!(session_pasteboard_name(42, 7, 3), "tech.fixedwidth.glass.clip.42.7.3");
+    }
+    #[test]
+    fn session_name_differs_when_any_input_differs() {
+        let base = session_pasteboard_name(1, 1, 1);
+        assert_ne!(base, session_pasteboard_name(2, 1, 1), "pid differs");
+        assert_ne!(base, session_pasteboard_name(1, 2, 1), "nonce differs");
+        assert_ne!(base, session_pasteboard_name(1, 1, 2), "token differs");
     }
 }

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -1,11 +1,12 @@
 //! The macOS `Platform` backend for glass (ScreenCaptureKit + CGEvent + AXUIElement,
 //! rendered onto a `CGVirtualDisplay`).
 //!
-//! Like `glass-windows`, the pure logic ([`keymap`], [`coords`]) is crate-level and
-//! unit-tested on the Linux dev box; the OS-touching modules and the `MacosPlatform`
-//! impl are gated `#[cfg(target_os = "macos")]`. Off macOS the crate exposes only the
-//! pure modules.
+//! Like `glass-windows`, the pure logic ([`keymap`], [`coords`], [`clipboard_route`]) is
+//! crate-level and unit-tested on the Linux dev box; the OS-touching modules and the
+//! `MacosPlatform` impl are gated `#[cfg(target_os = "macos")]`. Off macOS the crate exposes
+//! only the pure modules.
 
+pub mod clipboard_route; // pure clipboard-routing policy — cross-platform, host-tested
 pub mod coords; // pure window-relative <-> global math — cross-platform, host-tested
 pub mod keymap; // pure ASCII -> (keycode, shift) US map — cross-platform, host-tested
 

--- a/crates/glass-macos/src/process.rs
+++ b/crates/glass-macos/src/process.rs
@@ -60,8 +60,8 @@ pub(crate) fn spawn(spec: &AppSpec, logs: LogSink) -> Result<Child> {
         let cwd = std::fs::canonicalize(&cwd).unwrap_or(cwd);
         let program =
             std::fs::canonicalize(&spec.run[0]).unwrap_or_else(|_| PathBuf::from(&spec.run[0]));
-        // TODO: a later task finalizes allow_pasteboard for injectable (contained) targets whose
-        // shim redirects the pasteboard; for now this keeps prior (always-deny) behavior.
+        // Pasteboard stays denied here; a caller that injects the redirecting shim into an
+        // injectable target sets this to true once that wiring exists.
         let opts = ProfileOpts {
             cwd,
             program,

--- a/crates/glass-macos/src/process.rs
+++ b/crates/glass-macos/src/process.rs
@@ -10,12 +10,22 @@
 //!
 //! Window discovery is a separate concern ([`crate::scwindow::find_window_for_pids`]);
 //! this module only owns the process lifecycle.
+//!
+//! Clip-shim injection: a contained launch whose target is not hardened-runtime signed
+//! ([`target_is_injectable`]) gets `glass-clip-shim-macos`'s built dylib
+//! ([`shim_dylib_path`]) loaded via `DYLD_INSERT_LIBRARIES`, plus a per-spawn private
+//! pasteboard name in `GLASS_CLIP_PASTEBOARD` — both set on the `Command` before the fork
+//! in [`spawn`], so they're already part of the child's environment when `pre_exec`'s
+//! `sandbox_init` call runs. [`ClipLaunch`] carries those facts back to `start_app`, which
+//! holds them until the launched window is confirmed and the clipboard route can be
+//! decided (a later step; not this module's concern).
 
 use std::ffi::CString;
 use std::io::{BufRead, BufReader};
 use std::os::unix::process::CommandExt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -24,6 +34,87 @@ use rustix::process::{kill_process, Pid, Signal};
 use glass_core::platform::{AppSpec, SandboxLevel};
 use glass_core::{GlassError, Result, Stream};
 use glass_sandbox_macos::{build_profile, ProfileOpts};
+
+/// Per-spawn counter seeding [`crate::clipboard_route::session_pasteboard_name`] — starts
+/// at 1 (not 0) purely so a default-initialized `u64` elsewhere in the codebase can never
+/// be mistaken for a real token; the exact starting value has no other significance.
+static CLIP_TOKEN: AtomicU64 = AtomicU64::new(1);
+
+/// Clip-shim facts for one contained, injectable launch: the private pasteboard name the
+/// shim redirects `NSPasteboard.generalPasteboard` to, and whether injection was attempted
+/// (`true` whenever [`spawn`] returns `Some` — see its doc). `start_app` holds this until
+/// the launched window is confirmed, then uses it to decide clipboard routing (a later,
+/// separate step).
+///
+/// Neither field is read yet (only constructed and moved through `MacosPlatform::clip`) —
+/// that later step is what reads them; `expect` rather than a blanket `allow` so this
+/// attribute itself starts failing the build once that step lands and actually reads them,
+/// as a forcing function to remove it then.
+#[expect(dead_code, reason = "read by clipboard routing, which lands in a later, separate step")]
+pub(crate) struct ClipLaunch {
+    pub name: String,
+    pub injectable: bool,
+}
+
+/// True iff `stderr` — `codesign --display --verbose=2`'s report — shows no hardened
+/// runtime, i.e. `DYLD_INSERT_LIBRARIES` injection can take on this target. Factored out of
+/// [`target_is_injectable`] as a pure string check so the decision itself is unit-testable
+/// without shelling out to `codesign`.
+fn injectable_from_codesign_report(stderr: &str) -> bool {
+    !stderr.contains("runtime")
+}
+
+/// True iff `program` is not hardened-runtime signed, so injecting the clip shim via
+/// `DYLD_INSERT_LIBRARIES` can take. Shells out to `codesign --display --verbose=2`
+/// (codesign writes its report to stderr, not stdout) rather than linking a
+/// Security-framework binding — simplest option, no new framework dependency.
+///
+/// Conservative and fail-closed: any uncertainty (`codesign` missing or unspawnable, its
+/// output not valid UTF-8) reports `false` (non-injectable), never `true` — an unsigned or
+/// adhoc-signed binary reports `false` from codesign's own exit status, but its stderr
+/// still won't mention `runtime`, so [`injectable_from_codesign_report`] correctly reports
+/// `true` for it regardless of that exit status.
+fn target_is_injectable(program: &Path) -> bool {
+    let Ok(output) = Command::new("codesign")
+        .arg("--display")
+        .arg("--verbose=2")
+        .arg(program)
+        .output()
+    else {
+        return false;
+    };
+    let Ok(stderr) = String::from_utf8(output.stderr) else {
+        return false;
+    };
+    injectable_from_codesign_report(&stderr)
+}
+
+/// Env var overriding [`shim_dylib_path`]'s resolution — tests and non-standard layouts.
+const SHIM_DYLIB_ENV: &str = "GLASS_CLIP_SHIM_DYLIB";
+
+/// File name of the shim's build artifact: `glass-clip-shim-macos`'s `crate-type =
+/// ["cdylib"]` compiles to `lib<crate name, underscored>.dylib` on macOS.
+const SHIM_DYLIB_NAME: &str = "libglass_clip_shim_macos.dylib";
+
+/// Resolve the injected clip shim's dylib: [`SHIM_DYLIB_ENV`] (trusted as given, no
+/// existence check — an explicit override is the caller's own responsibility) → next to the
+/// running executable → the cargo target dir one level up from it (`current_exe` is
+/// `target/<profile>/<bin>` for a normal build, or `target/<profile>/deps/<bin>-<hash>`
+/// under `cargo test`, one directory deeper than the shim's own build output — hence the
+/// second candidate). `None` if none of these exist: callers treat that as "not
+/// injectable" (fail-closed — no resolvable shim, no injection).
+fn shim_dylib_path() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var(SHIM_DYLIB_ENV) {
+        return Some(PathBuf::from(path));
+    }
+    let exe_dir = std::env::current_exe().ok()?.parent()?.to_path_buf();
+    let next_to_exe = exe_dir.join(SHIM_DYLIB_NAME);
+    if next_to_exe.is_file() {
+        return Some(next_to_exe);
+    }
+    let target_dir = exe_dir.parent()?.join(SHIM_DYLIB_NAME);
+    target_dir.is_file().then_some(target_dir)
+}
 
 /// Log lines captured by the per-stream reader threads spawned in [`spawn`], drained by
 /// `MacosPlatform::drain_logs`. `Arc<Mutex<_>>` (not a bare `Vec`) because the reader
@@ -43,12 +134,19 @@ const TERMINATE_GRACE: Duration = Duration::from_millis(500);
 /// macOS process containment: [`SandboxLevel::Default`]/[`SandboxLevel::Strict`] apply a
 /// generated Seatbelt (`sandbox_init`) profile to the launched app via a fork-safe
 /// `pre_exec` (see below). [`SandboxLevel::Off`] spawns unchanged.
-pub(crate) fn spawn(spec: &AppSpec, logs: LogSink) -> Result<Child> {
+///
+/// The second return value is the clip-shim launch facts ([`ClipLaunch`]), `Some` only for
+/// a contained launch whose target is injectable (see [`target_is_injectable`]) and whose
+/// shim dylib resolved (see [`shim_dylib_path`]); `None` for `SandboxLevel::Off` or a
+/// non-injectable/unresolved target. The caller (`MacosPlatform::start_app`) holds it for a
+/// later clipboard-routing decision — this function only sets up the injection.
+pub(crate) fn spawn(spec: &AppSpec, logs: LogSink) -> Result<(Child, Option<ClipLaunch>)> {
     let mut cmd = Command::new(&spec.run[0]);
 
     // Containment: for Default/Strict, apply a generated Seatbelt profile to the launched app
     // in a fork-safe pre_exec (build the CString here, before fork; the closure only makes the
     // sandbox_init syscall). Off spawns unchanged. Build (run_build) is never contained.
+    let mut clip: Option<ClipLaunch> = None;
     if spec.sandbox != SandboxLevel::Off {
         // Resolve to absolute paths: a relative `(subpath ".")` never matches the child's real
         // cwd, and `build_profile`'s guard needs absolute paths to reason about home exposure.
@@ -60,14 +158,39 @@ pub(crate) fn spawn(spec: &AppSpec, logs: LogSink) -> Result<Child> {
         let cwd = std::fs::canonicalize(&cwd).unwrap_or(cwd);
         let program =
             std::fs::canonicalize(&spec.run[0]).unwrap_or_else(|_| PathBuf::from(&spec.run[0]));
-        // Pasteboard stays denied here; a caller that injects the redirecting shim into an
-        // injectable target sets this to true once that wiring exists.
+
+        // Decide injection before building the profile: `allow_pasteboard` depends on it.
+        // `dylib_path` is resolved once and reused below (rather than a second
+        // `shim_dylib_path()` call) so a transient filesystem hiccup between the two checks
+        // can't make `injectable` and the later `.expect` disagree.
+        let dylib_path = shim_dylib_path();
+        let injectable = target_is_injectable(&program) && dylib_path.is_some();
+        let allow_pasteboard = injectable;
+        if injectable {
+            let token = CLIP_TOKEN.fetch_add(1, Ordering::Relaxed);
+            let name = crate::clipboard_route::session_pasteboard_name(token);
+            let dylib = dylib_path.expect("checked Some above");
+            // Set BEFORE the fork below: `Command::env` populates the child's environment at
+            // exec time, so both vars are already present when `pre_exec`'s `sandbox_init`
+            // call runs, and survive it into the launched app — same timing guarantee the
+            // profile CString relies on.
+            cmd.env("DYLD_INSERT_LIBRARIES", dylib);
+            cmd.env("GLASS_CLIP_PASTEBOARD", &name);
+            clip = Some(ClipLaunch {
+                name,
+                injectable: true,
+            });
+        }
+
+        // Pasteboard is allowed only for an injectable target (the shim's redirect is the
+        // actual isolation there); a hardened/non-injectable target keeps it denied, same as
+        // before this task.
         let opts = ProfileOpts {
             cwd,
             program,
             ro_binds: vec![],
             rw_binds: vec![],
-            allow_pasteboard: false,
+            allow_pasteboard,
         };
         let profile = build_profile(spec.sandbox, &opts);
         let profile_c = CString::new(profile).map_err(|e| {
@@ -112,7 +235,7 @@ pub(crate) fn spawn(spec: &AppSpec, logs: LogSink) -> Result<Child> {
     spawn_reader(stdout, Stream::Stdout, logs.clone());
     spawn_reader(stderr, Stream::Stderr, logs);
 
-    Ok(child)
+    Ok((child, clip))
 }
 
 /// Pipe a child stream's lines into the shared log sink on a background thread. Exits
@@ -223,7 +346,7 @@ mod tests {
         denied.sandbox = SandboxLevel::Default;
         denied.cwd = Some(proj.clone());
         let logs = empty_sink();
-        let mut child =
+        let (mut child, _clip) =
             spawn(&denied, logs.clone()).unwrap_or_else(|e| panic!("sandboxed spawn should succeed: {e}"));
         child.wait().expect("wait");
         std::thread::sleep(Duration::from_millis(100));
@@ -243,7 +366,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     fn spawn_pipes_stdout_and_stderr_lines() {
         let logs = empty_sink();
-        let mut child = spawn(&spec(&["/bin/sh", "-c", "echo out; echo err 1>&2"]), logs.clone())
+        let (mut child, _clip) = spawn(&spec(&["/bin/sh", "-c", "echo out; echo err 1>&2"]), logs.clone())
             .expect("spawn /bin/sh");
         child.wait().expect("wait for /bin/sh to exit");
         // The reader threads finish shortly after the child's fds close on exit; give them
@@ -266,7 +389,7 @@ mod tests {
     #[test]
     #[cfg(target_os = "macos")]
     fn terminate_kills_a_long_running_child() {
-        let mut child = spawn(&spec(&["/bin/sleep", "100"]), empty_sink()).expect("spawn /bin/sleep");
+        let (mut child, _clip) = spawn(&spec(&["/bin/sleep", "100"]), empty_sink()).expect("spawn /bin/sleep");
         terminate(&mut child);
         let status = child.try_wait().expect("try_wait after terminate");
         assert!(status.is_some(), "child should have exited after terminate");
@@ -275,10 +398,47 @@ mod tests {
     #[test]
     #[cfg(target_os = "macos")]
     fn terminate_is_idempotent_on_an_already_exited_child() {
-        let mut child = spawn(&spec(&["/bin/echo", "hi"]), empty_sink()).expect("spawn /bin/echo");
+        let (mut child, _clip) = spawn(&spec(&["/bin/echo", "hi"]), empty_sink()).expect("spawn /bin/echo");
         child.wait().expect("wait for /bin/echo to exit");
         // Already reaped; terminate must not panic or hang.
         terminate(&mut child);
         terminate(&mut child);
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn injectable_from_codesign_report_true_for_unsigned_or_adhoc() {
+        // codesign's report for an unsigned binary never mentions "runtime" at all.
+        assert!(injectable_from_codesign_report(
+            "TestApp: code object is not signed at all\n"
+        ));
+        // Nor does an adhoc/linker-signed binary's flags line.
+        assert!(injectable_from_codesign_report(
+            "CodeDirectory v=20400 size=91 flags=0x2(adhoc) hashes=3+3 location=embedded\n"
+        ));
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn injectable_from_codesign_report_false_when_hardened_runtime_flag_present() {
+        assert!(!injectable_from_codesign_report(
+            "CodeDirectory v=20500 size=634 flags=0x10000(runtime) hashes=13+3 location=embedded\n"
+        ));
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn shim_dylib_path_trusts_an_explicit_env_override_without_checking_existence() {
+        // A deliberately nonexistent path: the override tier is trusted as given (matches
+        // `glass-windows`'s `hook_dll_path` precedent for its own DLL override), unlike the
+        // exe-dir/target-dir fallback tiers below it, which do check.
+        let previous = std::env::var(SHIM_DYLIB_ENV).ok();
+        std::env::set_var(SHIM_DYLIB_ENV, "/nonexistent/glass-clip-shim-test.dylib");
+        let resolved = shim_dylib_path();
+        match previous {
+            Some(v) => std::env::set_var(SHIM_DYLIB_ENV, v),
+            None => std::env::remove_var(SHIM_DYLIB_ENV),
+        }
+        assert_eq!(resolved, Some(PathBuf::from("/nonexistent/glass-clip-shim-test.dylib")));
     }
 }

--- a/crates/glass-macos/src/process.rs
+++ b/crates/glass-macos/src/process.rs
@@ -50,6 +50,7 @@ static CLIP_TOKEN: AtomicU64 = AtomicU64::new(1);
 /// `Option` itself — there is no separate flag. `start_app` holds this until the launched
 /// window is confirmed, then combines `name` with a live shim-confirmation check to decide the
 /// session's `ClipboardRoute` (`crate::clipboard_route::decide_route`).
+#[derive(Debug)]
 pub(crate) struct ClipLaunch {
     pub name: String,
 }

--- a/crates/glass-macos/src/process.rs
+++ b/crates/glass-macos/src/process.rs
@@ -73,7 +73,12 @@ pub(crate) struct ClipLaunch {
 /// output with no `flags=` line — is treated as non-injectable, so "couldn't determine" never
 /// grants injection.
 fn injectable_from_codesign_report(stderr: &str, status_success: bool) -> bool {
-    if stderr.contains("code object is not signed at all") {
+    // A genuinely unsigned binary's report is ONLY the "not signed" diagnostic — it can never
+    // also carry a `flags=` line (there is no signature to describe one). Requiring that
+    // absence stops the marker being smuggled in via attacker-controlled report text — codesign
+    // echoes `Executable=<path>`, and `<path>` is the caller-chosen `spec.run[0]` — to force a
+    // genuinely signed, possibly hardened-runtime target to classify as injectable.
+    if stderr.contains("code object is not signed at all") && !stderr.contains("flags=") {
         return true;
     }
     status_success && stderr.contains("flags=") && !stderr.contains("runtime")
@@ -510,6 +515,18 @@ mod tests {
             "test-binary: a codesign error that happens not to mention the h-word\n",
             false,
         ));
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn injectable_from_codesign_report_false_when_marker_only_in_path() {
+        // A genuinely hardened, successfully-signed target whose PATH happens to contain the
+        // unsigned marker (codesign echoes `Executable=<path>`, and the path is the
+        // caller-chosen `spec.run[0]`) must still fail closed — the marker in path text must
+        // not override a real `flags=(...runtime...)` line.
+        let report = "Executable=/tmp/code object is not signed at all/App.app/Contents/MacOS/App\n\
+                      CodeDirectory v=20400 flags=0x10000(runtime) hashes=3+3 location=embedded\n";
+        assert!(!injectable_from_codesign_report(report, true));
     }
 
     #[test]

--- a/crates/glass-macos/src/process.rs
+++ b/crates/glass-macos/src/process.rs
@@ -14,11 +14,13 @@
 //! Clip-shim injection: a contained launch whose target is not hardened-runtime signed
 //! ([`target_is_injectable`]) gets `glass-clip-shim-macos`'s built dylib
 //! ([`shim_dylib_path`]) loaded via `DYLD_INSERT_LIBRARIES`, plus a per-spawn private
-//! pasteboard name in `GLASS_CLIP_PASTEBOARD` — both set on the `Command` before the fork
-//! in [`spawn`], so they're already part of the child's environment when `pre_exec`'s
-//! `sandbox_init` call runs. [`ClipLaunch`] carries those facts back to `start_app`, which
-//! holds them until the launched window is confirmed and the clipboard route can be
-//! decided (a later step; not this module's concern).
+//! pasteboard name in `GLASS_CLIP_PASTEBOARD` — both set on the `Command` before
+//! `cmd.spawn()` in [`spawn`]. `Command`'s envp is applied at the `exec` that follows
+//! `pre_exec`'s `sandbox_init` call (not at fork/`pre_exec` time), so both vars are present
+//! in the launched app's environment, having survived the sandbox. [`ClipLaunch`] carries
+//! those facts back to `start_app`, which holds them until the launched window is
+//! confirmed and the clipboard route can be decided (a later step; not this module's
+//! concern).
 
 use std::ffi::CString;
 use std::io::{BufRead, BufReader};
@@ -96,16 +98,21 @@ const SHIM_DYLIB_ENV: &str = "GLASS_CLIP_SHIM_DYLIB";
 /// ["cdylib"]` compiles to `lib<crate name, underscored>.dylib` on macOS.
 const SHIM_DYLIB_NAME: &str = "libglass_clip_shim_macos.dylib";
 
-/// Resolve the injected clip shim's dylib: [`SHIM_DYLIB_ENV`] (trusted as given, no
-/// existence check — an explicit override is the caller's own responsibility) → next to the
-/// running executable → the cargo target dir one level up from it (`current_exe` is
+/// Resolve the injected clip shim's dylib: [`SHIM_DYLIB_ENV`] → next to the running
+/// executable → the cargo target dir one level up from it (`current_exe` is
 /// `target/<profile>/<bin>` for a normal build, or `target/<profile>/deps/<bin>-<hash>`
 /// under `cargo test`, one directory deeper than the shim's own build output — hence the
-/// second candidate). `None` if none of these exist: callers treat that as "not
+/// second candidate). Every tier, including the env override, is existence-checked
+/// (`.is_file()`) before being returned — a bad override (stale/typo'd path) falls through
+/// to the remaining tiers rather than being trusted blind, same fail-closed discipline as
+/// the rest of this resolution. `None` if none of these exist: callers treat that as "not
 /// injectable" (fail-closed — no resolvable shim, no injection).
 fn shim_dylib_path() -> Option<PathBuf> {
     if let Ok(path) = std::env::var(SHIM_DYLIB_ENV) {
-        return Some(PathBuf::from(path));
+        let path = PathBuf::from(path);
+        if path.is_file() {
+            return Some(path);
+        }
     }
     let exe_dir = std::env::current_exe().ok()?.parent()?.to_path_buf();
     let next_to_exe = exe_dir.join(SHIM_DYLIB_NAME);
@@ -166,15 +173,26 @@ pub(crate) fn spawn(spec: &AppSpec, logs: LogSink) -> Result<(Child, Option<Clip
         let dylib_path = shim_dylib_path();
         let injectable = target_is_injectable(&program) && dylib_path.is_some();
         let allow_pasteboard = injectable;
+        // The shim dylib's parent dir, re-allowed for read in the profile below when
+        // injecting (`None` — no re-allow — otherwise, matching unchanged pre-injection
+        // behavior).
+        let mut shim_dir: Option<PathBuf> = None;
         if injectable {
             let token = CLIP_TOKEN.fetch_add(1, Ordering::Relaxed);
             let name = crate::clipboard_route::session_pasteboard_name(token);
             let dylib = dylib_path.expect("checked Some above");
-            // Set BEFORE the fork below: `Command::env` populates the child's environment at
-            // exec time, so both vars are already present when `pre_exec`'s `sandbox_init`
-            // call runs, and survive it into the launched app — same timing guarantee the
-            // profile CString relies on.
-            cmd.env("DYLD_INSERT_LIBRARIES", dylib);
+            // The shim dylib lives in glass's own `target/<profile>/` tree, typically under
+            // $HOME — which the profile below denies by default (see `build_profile`'s
+            // `/Users` deny). dyld loads the shim AFTER `sandbox_init` applies the profile
+            // (in `pre_exec`, below), so its directory must be re-allowed for read here or
+            // dyld can't open it, injection silently fails, and the sandboxed app never sees
+            // the shim.
+            shim_dir = dylib.parent().map(Path::to_path_buf);
+            // Set BEFORE `cmd.spawn()`: `Command`'s envp is applied at the `exec` that
+            // follows `pre_exec`'s `sandbox_init` call (not at fork/`pre_exec` time), so both
+            // vars are present in the launched app's environment, having survived the
+            // sandbox — same timing guarantee the profile CString relies on.
+            cmd.env("DYLD_INSERT_LIBRARIES", &dylib);
             cmd.env("GLASS_CLIP_PASTEBOARD", &name);
             clip = Some(ClipLaunch {
                 name,
@@ -188,7 +206,7 @@ pub(crate) fn spawn(spec: &AppSpec, logs: LogSink) -> Result<(Child, Option<Clip
         let opts = ProfileOpts {
             cwd,
             program,
-            ro_binds: vec![],
+            ro_binds: shim_dir.into_iter().collect(),
             rw_binds: vec![],
             allow_pasteboard,
         };
@@ -428,17 +446,45 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "macos")]
-    fn shim_dylib_path_trusts_an_explicit_env_override_without_checking_existence() {
-        // A deliberately nonexistent path: the override tier is trusted as given (matches
-        // `glass-windows`'s `hook_dll_path` precedent for its own DLL override), unlike the
-        // exe-dir/target-dir fallback tiers below it, which do check.
+    fn shim_dylib_path_uses_an_explicit_env_override_that_exists() {
+        // The override tier is existence-checked like the exe-dir/target-dir fallback tiers
+        // below it (fail-closed, uniformly) — a real file at the override path is returned.
+        let dir = std::env::temp_dir();
+        let dylib = dir.join(format!("glass-clip-shim-test-{}.dylib", std::process::id()));
+        std::fs::write(&dylib, b"stand-in for the real shim dylib; only existence matters here")
+            .expect("write stand-in dylib file");
+        struct Cleanup(PathBuf);
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_file(&self.0);
+            }
+        }
+        let _cleanup = Cleanup(dylib.clone());
+
         let previous = std::env::var(SHIM_DYLIB_ENV).ok();
-        std::env::set_var(SHIM_DYLIB_ENV, "/nonexistent/glass-clip-shim-test.dylib");
+        std::env::set_var(SHIM_DYLIB_ENV, &dylib);
         let resolved = shim_dylib_path();
         match previous {
             Some(v) => std::env::set_var(SHIM_DYLIB_ENV, v),
             None => std::env::remove_var(SHIM_DYLIB_ENV),
         }
-        assert_eq!(resolved, Some(PathBuf::from("/nonexistent/glass-clip-shim-test.dylib")));
+        assert_eq!(resolved, Some(dylib));
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn shim_dylib_path_falls_through_a_nonexistent_env_override() {
+        // Unlike the old (fail-open) behavior, a bad override — stale env, typo'd path — must
+        // not be trusted blind: it falls through to the remaining tiers (or `None`) rather
+        // than handing dyld an unopenable path, same fail-closed discipline as those tiers.
+        let bogus = PathBuf::from("/nonexistent/glass-clip-shim-test.dylib");
+        let previous = std::env::var(SHIM_DYLIB_ENV).ok();
+        std::env::set_var(SHIM_DYLIB_ENV, &bogus);
+        let resolved = shim_dylib_path();
+        match previous {
+            Some(v) => std::env::set_var(SHIM_DYLIB_ENV, v),
+            None => std::env::remove_var(SHIM_DYLIB_ENV),
+        }
+        assert_ne!(resolved, Some(bogus), "a nonexistent override must not be returned as-is");
     }
 }

--- a/crates/glass-macos/src/process.rs
+++ b/crates/glass-macos/src/process.rs
@@ -37,27 +37,45 @@ use glass_core::platform::{AppSpec, SandboxLevel};
 use glass_core::{GlassError, Result, Stream};
 use glass_sandbox_macos::{build_profile, ProfileOpts};
 
-/// Per-spawn counter seeding [`crate::clipboard_route::session_pasteboard_name`] — starts
-/// at 1 (not 0) purely so a default-initialized `u64` elsewhere in the codebase can never
-/// be mistaken for a real token; the exact starting value has no other significance.
+/// Per-spawn counter feeding one component of
+/// [`crate::clipboard_route::session_pasteboard_name`] (combined there with this process's pid
+/// and a wall-clock nonce). It only disambiguates multiple launches WITHIN a single `glass-mcp`
+/// run; the pid+nonce components are what prevent name reuse ACROSS runs (a bare counter resets
+/// to its start value on every restart). The exact starting value has no significance.
 static CLIP_TOKEN: AtomicU64 = AtomicU64::new(1);
 
 /// Clip-shim facts for one contained, injectable launch: the private pasteboard name the
-/// shim redirects `NSPasteboard.generalPasteboard` to, and whether injection was attempted
-/// (`true` whenever [`spawn`] returns `Some` — see its doc). `start_app` holds this until
-/// the launched window is confirmed, then reads both fields to decide the session's
-/// `ClipboardRoute` (`crate::clipboard_route::decide_route`).
+/// shim redirects `NSPasteboard.generalPasteboard` to. Produced only when [`spawn`] actually
+/// set up injection (its second return value is `Some`), so injectability is encoded by the
+/// `Option` itself — there is no separate flag. `start_app` holds this until the launched
+/// window is confirmed, then combines `name` with a live shim-confirmation check to decide the
+/// session's `ClipboardRoute` (`crate::clipboard_route::decide_route`).
 pub(crate) struct ClipLaunch {
     pub name: String,
-    pub injectable: bool,
 }
 
-/// True iff `stderr` — `codesign --display --verbose=2`'s report — shows no hardened
-/// runtime, i.e. `DYLD_INSERT_LIBRARIES` injection can take on this target. Factored out of
-/// [`target_is_injectable`] as a pure string check so the decision itself is unit-testable
-/// without shelling out to `codesign`.
-fn injectable_from_codesign_report(stderr: &str) -> bool {
-    !stderr.contains("runtime")
+/// Whether `stderr` — a `codesign --display --verbose=2` report, with `status_success`
+/// codesign's exit status — shows a RECOGNIZED non-hardened signature, i.e.
+/// `DYLD_INSERT_LIBRARIES` injection can take on this target. Factored out of
+/// [`target_is_injectable`] as a pure function so the decision is unit-testable without
+/// shelling out to `codesign`.
+///
+/// Fail-closed: `true` only on a recognized non-hardened signal, `false` otherwise (including
+/// any unrecognized/garbled output). Injectable iff either:
+/// - the report contains `code object is not signed at all` (unsigned — codesign exits
+///   non-zero for this, so the status isn't gated for this specific marker), OR
+/// - codesign SUCCEEDED and there is a `flags=` line that does NOT mention `runtime` (an
+///   adhoc/linker-signed or otherwise non-hardened binary; a hardened-runtime binary's flags
+///   line contains `runtime`).
+///
+/// Everything else — an I/O/parse failure, a non-zero exit without the "not signed" marker, or
+/// output with no `flags=` line — is treated as non-injectable, so "couldn't determine" never
+/// grants injection.
+fn injectable_from_codesign_report(stderr: &str, status_success: bool) -> bool {
+    if stderr.contains("code object is not signed at all") {
+        return true;
+    }
+    status_success && stderr.contains("flags=") && !stderr.contains("runtime")
 }
 
 /// True iff `program` is not hardened-runtime signed, so injecting the clip shim via
@@ -66,10 +84,8 @@ fn injectable_from_codesign_report(stderr: &str) -> bool {
 /// Security-framework binding — simplest option, no new framework dependency.
 ///
 /// Conservative and fail-closed: any uncertainty (`codesign` missing or unspawnable, its
-/// output not valid UTF-8) reports `false` (non-injectable), never `true` — an unsigned or
-/// adhoc-signed binary reports `false` from codesign's own exit status, but its stderr
-/// still won't mention `runtime`, so [`injectable_from_codesign_report`] correctly reports
-/// `true` for it regardless of that exit status.
+/// output not valid UTF-8, or an unrecognized report) reports `false` (non-injectable). See
+/// [`injectable_from_codesign_report`] for the exact recognized-signal logic.
 fn target_is_injectable(program: &Path) -> bool {
     let Ok(output) = Command::new("codesign")
         .arg("--display")
@@ -79,10 +95,11 @@ fn target_is_injectable(program: &Path) -> bool {
     else {
         return false;
     };
+    let status_success = output.status.success();
     let Ok(stderr) = String::from_utf8(output.stderr) else {
         return false;
     };
-    injectable_from_codesign_report(&stderr)
+    injectable_from_codesign_report(&stderr, status_success)
 }
 
 /// Env var overriding [`shim_dylib_path`]'s resolution — tests and non-standard layouts.
@@ -144,6 +161,16 @@ const TERMINATE_GRACE: Duration = Duration::from_millis(500);
 pub(crate) fn spawn(spec: &AppSpec, logs: LogSink) -> Result<(Child, Option<ClipLaunch>)> {
     let mut cmd = Command::new(&spec.run[0]);
 
+    // Apply the caller's env FIRST, so glass's own containment/injection vars (set inside the
+    // block below) are written LAST and always win last-write-wins. Otherwise a caller (or an
+    // LLM footgun) could blank `DYLD_INSERT_LIBRARIES`/`GLASS_CLIP_PASTEBOARD` via `spec.env`
+    // and silently defeat injection while the profile had already granted the pasteboard —
+    // fail-OPEN. When not injecting (`sandbox: off` or a non-injectable target), caller env
+    // simply applies normally.
+    for (k, v) in &spec.env {
+        cmd.env(k, v);
+    }
+
     // Containment: for Default/Strict, apply a generated Seatbelt profile to the launched app
     // in a fork-safe pre_exec (build the CString here, before fork; the closure only makes the
     // sandbox_init syscall). Off spawns unchanged. Build (run_build) is never contained.
@@ -167,31 +194,47 @@ pub(crate) fn spawn(spec: &AppSpec, logs: LogSink) -> Result<(Child, Option<Clip
         let dylib_path = shim_dylib_path();
         let injectable = target_is_injectable(&program) && dylib_path.is_some();
         let allow_pasteboard = injectable;
-        // The shim dylib's parent dir, re-allowed for read in the profile below when
-        // injecting (`None` — no re-allow — otherwise, matching unchanged pre-injection
-        // behavior).
-        let mut shim_dir: Option<PathBuf> = None;
+        // The shim dylib FILE, re-allowed for read in the profile below when injecting (`None`
+        // — no re-allow — otherwise, matching unchanged pre-injection behavior).
+        let mut shim_file: Option<PathBuf> = None;
         if injectable {
+            let pid = std::process::id();
+            let nonce = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos() as u64)
+                .unwrap_or(0);
             let token = CLIP_TOKEN.fetch_add(1, Ordering::Relaxed);
-            let name = crate::clipboard_route::session_pasteboard_name(token);
+            // Unique per launch (pid + wall-clock nonce + counter) so the name can never be
+            // reused across `glass-mcp` restarts — a reused name lets a stale, system-wide
+            // named pasteboard mask a failed injection with an old sentinel (fail-OPEN).
+            let name = crate::clipboard_route::session_pasteboard_name(pid, nonce, token);
             let dylib = dylib_path.expect("checked Some above");
+            // Surface, rather than silently swallow, a caller trying to set the injection vars
+            // themselves: glass overrides them below (last-write-wins, above), so their value
+            // is intentionally ignored — say so instead of leaving the caller to wonder.
+            for (k, _) in &spec.env {
+                if matches!(k.as_str(), "DYLD_INSERT_LIBRARIES" | "GLASS_CLIP_PASTEBOARD") {
+                    logs.lock().expect("log sink mutex").push((
+                        Stream::Stderr,
+                        format!("glass: caller-supplied {k} is overridden by clipboard-shim injection"),
+                    ));
+                }
+            }
             // The shim dylib lives in glass's own `target/<profile>/` tree, typically under
             // $HOME — which the profile below denies by default (see `build_profile`'s
             // `/Users` deny). dyld loads the shim AFTER `sandbox_init` applies the profile
-            // (in `pre_exec`, below), so its directory must be re-allowed for read here or
+            // (in `pre_exec`, below), so the FILE itself must be re-allowed for read here or
             // dyld can't open it, injection silently fails, and the sandboxed app never sees
-            // the shim.
-            shim_dir = dylib.parent().map(Path::to_path_buf);
-            // Set BEFORE `cmd.spawn()`: `Command`'s envp is applied at the `exec` that
-            // follows `pre_exec`'s `sandbox_init` call (not at fork/`pre_exec` time), so both
-            // vars are present in the launched app's environment, having survived the
-            // sandbox — same timing guarantee the profile CString relies on.
+            // the shim. Re-allow only the file (not its whole directory) — least privilege.
+            shim_file = Some(dylib.clone());
+            // Set LAST (after `spec.env` above) and BEFORE `cmd.spawn()`: `Command`'s envp is
+            // applied at the `exec` that follows `pre_exec`'s `sandbox_init` call (not at
+            // fork/`pre_exec` time), so both vars are present in the launched app's
+            // environment, having survived the sandbox — same timing guarantee the profile
+            // CString relies on.
             cmd.env("DYLD_INSERT_LIBRARIES", &dylib);
             cmd.env("GLASS_CLIP_PASTEBOARD", &name);
-            clip = Some(ClipLaunch {
-                name,
-                injectable: true,
-            });
+            clip = Some(ClipLaunch { name });
         }
 
         // Pasteboard is allowed only for an injectable target (the shim's redirect is the
@@ -200,7 +243,8 @@ pub(crate) fn spawn(spec: &AppSpec, logs: LogSink) -> Result<(Child, Option<Clip
         let opts = ProfileOpts {
             cwd,
             program,
-            ro_binds: shim_dir.into_iter().collect(),
+            ro_binds: vec![],
+            ro_files: shim_file.into_iter().collect(),
             rw_binds: vec![],
             allow_pasteboard,
         };
@@ -219,9 +263,6 @@ pub(crate) fn spawn(spec: &AppSpec, logs: LogSink) -> Result<(Child, Option<Clip
     cmd.args(&spec.run[1..]);
     if let Some(cwd) = &spec.cwd {
         cmd.current_dir(cwd);
-    }
-    for (k, v) in &spec.env {
-        cmd.env(k, v);
     }
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
@@ -419,14 +460,23 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "macos")]
-    fn injectable_from_codesign_report_true_for_unsigned_or_adhoc() {
-        // codesign's report for an unsigned binary never mentions "runtime" at all.
+    fn injectable_from_codesign_report_true_for_unsigned() {
+        // Unsigned: codesign exits non-zero, but the "not signed at all" marker is an
+        // unambiguous injectable signal, so the exit status isn't gated for this case.
         assert!(injectable_from_codesign_report(
-            "TestApp: code object is not signed at all\n"
+            "TestApp: code object is not signed at all\n",
+            false,
         ));
-        // Nor does an adhoc/linker-signed binary's flags line.
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn injectable_from_codesign_report_true_for_adhoc_flags_line() {
+        // Adhoc/linker-signed: codesign succeeds and the flags line lacks `runtime`. This is
+        // the observed adhoc line shape.
         assert!(injectable_from_codesign_report(
-            "CodeDirectory v=20400 size=91 flags=0x2(adhoc) hashes=3+3 location=embedded\n"
+            "CodeDirectory v=20400 size=91 flags=0x20002(adhoc,linker-signed) hashes=3+3 location=embedded\n",
+            true,
         ));
     }
 
@@ -434,7 +484,41 @@ mod tests {
     #[cfg(target_os = "macos")]
     fn injectable_from_codesign_report_false_when_hardened_runtime_flag_present() {
         assert!(!injectable_from_codesign_report(
-            "CodeDirectory v=20500 size=634 flags=0x10000(runtime) hashes=13+3 location=embedded\n"
+            "CodeDirectory v=20500 size=634 flags=0x10000(runtime) hashes=13+3 location=embedded\n",
+            true,
+        ));
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn injectable_from_codesign_report_false_for_empty_or_garbage() {
+        // Fail-closed: no recognized non-hardened signal (no marker, no `flags=` line) →
+        // non-injectable, whether codesign succeeded or not.
+        assert!(!injectable_from_codesign_report("", true));
+        assert!(!injectable_from_codesign_report("", false));
+        assert!(!injectable_from_codesign_report("garbage output with no flags line", true));
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn injectable_from_codesign_report_false_for_a_non_runtime_error_string() {
+        // The exact regression this fix closes: an error whose text lacks BOTH the "not
+        // signed" marker AND a successful `flags=` line must fail closed. The old
+        // `!contains("runtime")` shape wrongly returned `true` here (fail-OPEN).
+        assert!(!injectable_from_codesign_report(
+            "test-binary: a codesign error that happens not to mention the h-word\n",
+            false,
+        ));
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn injectable_from_codesign_report_false_when_flags_line_present_but_status_failed() {
+        // A non-runtime `flags=` line is trusted only when codesign actually SUCCEEDED; the
+        // same line on a non-zero exit is unrecognized output → fail-closed.
+        assert!(!injectable_from_codesign_report(
+            "CodeDirectory v=20400 size=91 flags=0x2(adhoc) hashes=3+3 location=embedded\n",
+            false,
         ));
     }
 

--- a/crates/glass-macos/src/process.rs
+++ b/crates/glass-macos/src/process.rs
@@ -60,7 +60,15 @@ pub(crate) fn spawn(spec: &AppSpec, logs: LogSink) -> Result<Child> {
         let cwd = std::fs::canonicalize(&cwd).unwrap_or(cwd);
         let program =
             std::fs::canonicalize(&spec.run[0]).unwrap_or_else(|_| PathBuf::from(&spec.run[0]));
-        let opts = ProfileOpts { cwd, program, ro_binds: vec![], rw_binds: vec![] };
+        // TODO: a later task finalizes allow_pasteboard for injectable (contained) targets whose
+        // shim redirects the pasteboard; for now this keeps prior (always-deny) behavior.
+        let opts = ProfileOpts {
+            cwd,
+            program,
+            ro_binds: vec![],
+            rw_binds: vec![],
+            allow_pasteboard: false,
+        };
         let profile = build_profile(spec.sandbox, &opts);
         let profile_c = CString::new(profile).map_err(|e| {
             GlassError::SandboxUnavailable(format!("sandbox profile contains NUL: {e}"))

--- a/crates/glass-macos/src/process.rs
+++ b/crates/glass-macos/src/process.rs
@@ -45,14 +45,8 @@ static CLIP_TOKEN: AtomicU64 = AtomicU64::new(1);
 /// Clip-shim facts for one contained, injectable launch: the private pasteboard name the
 /// shim redirects `NSPasteboard.generalPasteboard` to, and whether injection was attempted
 /// (`true` whenever [`spawn`] returns `Some` — see its doc). `start_app` holds this until
-/// the launched window is confirmed, then uses it to decide clipboard routing (a later,
-/// separate step).
-///
-/// Neither field is read yet (only constructed and moved through `MacosPlatform::clip`) —
-/// that later step is what reads them; `expect` rather than a blanket `allow` so this
-/// attribute itself starts failing the build once that step lands and actually reads them,
-/// as a forcing function to remove it then.
-#[expect(dead_code, reason = "read by clipboard routing, which lands in a later, separate step")]
+/// the launched window is confirmed, then reads both fields to decide the session's
+/// `ClipboardRoute` (`crate::clipboard_route::decide_route`).
 pub(crate) struct ClipLaunch {
     pub name: String,
     pub injectable: bool,

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -197,8 +197,11 @@ impl GlassServer {
                        isolated from your real clipboard on the private Xvfb/sway backends and on \
                        a contained Windows app (a private boxed clipboard). Also the cheap \
                        text-extraction path: glass_do ctrl+a then ctrl+c, then read here (beats \
-                       OCR for selectable text). On macOS this reads your REAL system clipboard — \
-                       macOS has no clipboard isolation yet."
+                       OCR for selectable text). On a contained macOS app (sandbox: Default/Strict), \
+                       an injectable target is transparently redirected to a private pasteboard \
+                       glass shares — isolated from your real clipboard and fully working; a \
+                       hardened-runtime target can't be redirected, so this returns Unsupported. \
+                       Uncontained (sandbox: off) reads your REAL system clipboard."
     )]
     async fn glass_clipboard_get(&self) -> Result<CallToolResult, McpError> {
         self.run(tools::clipboard_get).await
@@ -209,9 +212,12 @@ impl GlassServer {
                        real clipboard on the private Xvfb/sway backends and on a contained Windows \
                        app (a private boxed clipboard); only shared-desktop modes (GLASS_DISPLAY=:0, \
                        or the Windows backend with sandbox=off) write your real clipboard — \
-                       snapshot with glass_clipboard_get first if needed. On macOS this writes your REAL system \
-                       clipboard (no isolation yet) — snapshot with glass_clipboard_get first if you need to \
-                       preserve it."
+                       snapshot with glass_clipboard_get first if needed. On a contained macOS app \
+                       (sandbox: Default/Strict), an injectable target is transparently redirected \
+                       to a private pasteboard glass shares — isolated from your real clipboard and \
+                       fully working; a hardened-runtime target can't be redirected, so this returns \
+                       Unsupported. Uncontained (sandbox: off) writes your REAL system clipboard — \
+                       snapshot with glass_clipboard_get first if you need to preserve it."
     )]
     async fn glass_clipboard_set(
         &self,

--- a/crates/glass-sandbox-macos/src/profile.rs
+++ b/crates/glass-sandbox-macos/src/profile.rs
@@ -26,6 +26,11 @@ pub struct ProfileOpts {
     pub ro_binds: Vec<PathBuf>,
     /// Extra paths re-exposed read-write.
     pub rw_binds: Vec<PathBuf>,
+    /// When true (an injectable contained target), ALLOW `com.apple.pasteboard.1` so the shim's
+    /// private named pasteboard works; when false (hardened/non-injectable), DENY it (the app
+    /// can't reach the real pasteboard). Isolation for injectable targets comes from the shim's
+    /// redirect, not from denying pasteboardd.
+    pub allow_pasteboard: bool,
 }
 
 /// Scratch/cache roots a typical app writes to (also readable via the whole-FS read allow).
@@ -76,8 +81,11 @@ pub fn build_profile(level: SandboxLevel, opts: &ProfileOpts) -> String {
     if level == SandboxLevel::Default {
         p.push_str("(allow network*)\n");
     }
-    // Clipboard isolation: the contained app cannot reach the real pasteboard.
-    p.push_str("(deny mach-lookup (global-name \"com.apple.pasteboard.1\"))\n");
+    // Clipboard: deny the real pasteboard unless this is an injectable target (whose shim
+    // redirects `generalPasteboard` to a private named pasteboard — see glass-clip-shim-macos).
+    if !opts.allow_pasteboard {
+        p.push_str("(deny mach-lookup (global-name \"com.apple.pasteboard.1\"))\n");
+    }
     p
 }
 
@@ -147,6 +155,8 @@ mod tests {
             program: PathBuf::from("/Applications/Demo.app/Contents/MacOS/Demo"),
             ro_binds: vec![],
             rw_binds: vec![],
+            // Default-safe: deny the real pasteboard unless a test opts in.
+            allow_pasteboard: false,
         }
     }
 
@@ -171,11 +181,24 @@ mod tests {
     }
 
     #[test]
-    fn clipboard_is_denied() {
-        let p = build_profile(SandboxLevel::Default, &opts());
+    fn pasteboard_denied_when_not_injectable() {
+        let mut o = opts();
+        o.allow_pasteboard = false;
+        let p = build_profile(SandboxLevel::Default, &o);
         assert!(
             p.contains(r#"(deny mach-lookup (global-name "com.apple.pasteboard.1"))"#),
             "{p}"
+        );
+    }
+
+    #[test]
+    fn pasteboard_allowed_when_injectable() {
+        let mut o = opts();
+        o.allow_pasteboard = true;
+        let p = build_profile(SandboxLevel::Default, &o);
+        assert!(
+            !p.contains("com.apple.pasteboard.1"),
+            "an injectable target must not deny the pasteboard (the shim redirects it):\n{p}"
         );
     }
 

--- a/crates/glass-sandbox-macos/src/profile.rs
+++ b/crates/glass-sandbox-macos/src/profile.rs
@@ -7,8 +7,9 @@
 //! denied so secrets (`~/.ssh` etc.) stay hidden by construction; the working dir, the
 //! launched program's own directory, and any caller `ro_binds` are then re-allowed even if
 //! they happen to live under a home, as long as they aren't the home root itself (see
-//! [`is_safe_reallow`]). Writes stay deny-default: only the working dir, caller `rw_binds`,
-//! and scratch/cache roots.
+//! [`is_safe_reallow`]); individual caller `ro_files` are re-allowed as single-file literals
+//! (used for the injected clip-shim dylib). Writes stay deny-default: only the working dir,
+//! caller `rw_binds`, and scratch/cache roots.
 #![forbid(unsafe_code)]
 
 use std::path::{Path, PathBuf};
@@ -22,8 +23,14 @@ pub struct ProfileOpts {
     pub cwd: PathBuf,
     /// The launched program's path; its directory is read-allowed (the app bundle/binary).
     pub program: PathBuf,
-    /// Extra paths re-exposed read-only (currently none on macOS; kept for parity/extensibility).
+    /// Extra directories re-exposed read-only (a `subpath` re-allow of the whole tree).
     pub ro_binds: Vec<PathBuf>,
+    /// Extra single FILES re-exposed read-only via a `(literal …)` rule — used to re-allow
+    /// exactly the injected clip-shim dylib without exposing its whole directory (a file
+    /// literal, unlike a `subpath`, grants no access to siblings). A file under `/Users` is
+    /// safe to re-allow for read this way, so these are emitted unconditionally after the
+    /// `/Users` deny.
+    pub ro_files: Vec<PathBuf>,
     /// Extra paths re-exposed read-write.
     pub rw_binds: Vec<PathBuf>,
     /// When true (an injectable contained target), ALLOW `com.apple.pasteboard.1` so the shim's
@@ -64,6 +71,13 @@ pub fn build_profile(level: SandboxLevel, opts: &ProfileOpts) -> String {
     for b in opts.ro_binds.iter().filter(|b| is_safe_reallow(b)) {
         emit_read_allow(&mut p, b);
     }
+    // Re-allow reads of individual FILES (a `literal`, not a `subpath`) after the `/Users`
+    // deny — used for the injected clip-shim dylib, which lives under $HOME. A file literal
+    // grants no access to its siblings, so (unlike a directory subpath) it needs no
+    // home-exposure guard.
+    for f in &opts.ro_files {
+        emit_read_allow_file(&mut p, f);
+    }
     // Writes: deny-default; only scratch/caches + the working dir + caller rw_binds.
     p.push_str("(allow file-write*\n");
     for w in SCRATCH_WRITE_ROOTS {
@@ -94,6 +108,15 @@ pub fn build_profile(level: SandboxLevel, opts: &ProfileOpts) -> String {
 fn emit_read_allow(out: &mut String, path: &Path) {
     out.push_str("(allow file-read* file-read-metadata ");
     out.push_str(&format!("(subpath {})", sbpl_quote(&path.to_string_lossy())));
+    out.push_str(")\n");
+}
+
+/// Emit a standalone read-allow for a single FILE (`literal`, not `subpath`), so exactly that
+/// file is re-allowed for read without exposing its directory. Used for the injected clip-shim
+/// dylib (see [`ProfileOpts::ro_files`]).
+fn emit_read_allow_file(out: &mut String, path: &Path) {
+    out.push_str("(allow file-read* file-read-metadata ");
+    out.push_str(&format!("(literal {})", sbpl_quote(&path.to_string_lossy())));
     out.push_str(")\n");
 }
 
@@ -154,6 +177,7 @@ mod tests {
             cwd: PathBuf::from("/work/project"),
             program: PathBuf::from("/Applications/Demo.app/Contents/MacOS/Demo"),
             ro_binds: vec![],
+            ro_files: vec![],
             rw_binds: vec![],
             // Default-safe: deny the real pasteboard unless a test opts in.
             allow_pasteboard: false,
@@ -307,6 +331,34 @@ mod tests {
         let p = build_profile(SandboxLevel::Default, &o);
         assert!(p.contains(r#"(subpath "/opt/data")"#), "{p}");
         assert!(p.contains(r#"(subpath "/opt/scratch")"#), "{p}");
+    }
+
+    /// A `ro_files` entry (the injected clip-shim dylib) must be re-allowed for read as a
+    /// single-file `(literal …)` — never a `(subpath …)` that would expose its whole
+    /// directory — and emitted AFTER the `/Users` deny so SBPL's last-match-wins restores read
+    /// for a file living under $HOME (the shim dylib's normal location in glass's target dir).
+    #[test]
+    fn ro_files_emit_a_file_literal_after_the_home_deny() {
+        let mut o = opts();
+        let dylib = "/Users/dev/proj/target/release/libglass_clip_shim_macos.dylib";
+        o.ro_files = vec![PathBuf::from(dylib)];
+        let p = build_profile(SandboxLevel::Default, &o);
+
+        let literal = format!(r#"(allow file-read* file-read-metadata (literal "{dylib}"))"#);
+        let literal_idx = p.find(&literal).unwrap_or_else(|| {
+            panic!("a ro_files entry must emit a (literal ...) read-allow:\n{p}")
+        });
+        assert!(
+            !p.contains(&format!(r#"(subpath "{dylib}")"#)),
+            "a ro_files entry must NOT widen to a subpath:\n{p}"
+        );
+        let deny_idx = p
+            .find(r#"(deny file-read* (subpath "/Users"))"#)
+            .expect("home deny must be present");
+        assert!(
+            literal_idx > deny_idx,
+            "the file literal must come after the /Users deny so last-match-wins restores it:\n{p}"
+        );
     }
 
     /// A `cwd` containing `"` and `\` must come out of `sbpl_quote` escaped, so the path stays

--- a/docs/running-on-macos.md
+++ b/docs/running-on-macos.md
@@ -161,8 +161,9 @@ driving the AXUIElement tree; they need the same Accessibility grant from step 3
 above (no separate permission).
 
 - **Clipboard** (`glass_clipboard_get`, `glass_clipboard_set`) — read and write the system pasteboard at
-  `sandbox: off`. Under containment (`default`/`strict`) the clipboard is isolated — see
-  [Sandboxing](#sandboxing) below.
+  `sandbox: off`. Under containment (`default`/`strict`) the clipboard is isolated **and
+  working** for an injectable app, and `Unsupported` for a hardened-runtime app — see
+  [Clipboard isolation](#clipboard-isolation) below.
 
 ## Sandboxing
 
@@ -195,16 +196,32 @@ sandboxed app that can't register with the window server returns an empty AX tre
 
 ### Clipboard isolation
 
-Under `default`/`strict` the profile denies the app the real pasteboard
-(`com.apple.pasteboard.1`), so `glass_clipboard_get`/`glass_clipboard_set` return
-`Unsupported` rather than silently falling back to the shared system clipboard. At
-`sandbox: off` clipboard access works normally (see
+Under `default`/`strict`, `glass_clipboard_get`/`glass_clipboard_set` are isolated from your
+real pasteboard **but still work** for an **injectable** app: at launch glass injects a small
+shim (`DYLD_INSERT_LIBRARIES`) that swizzles `+[NSPasteboard generalPasteboard]` inside the
+app process, redirecting it to a private, per-session named pasteboard that glass reads and
+writes from the host side. The app copies/pastes normally against that private pasteboard;
+your real clipboard is never touched. glass confirms the swizzle actually took (a sentinel
+item written to the private pasteboard) before routing to it, so an injection that silently
+failed doesn't get mistaken for a working bridge.
+
+If the target runs under Apple's **hardened runtime**, `DYLD_INSERT_LIBRARIES` injection is
+stripped by the OS and the swizzle can't take. For those apps (and for any injectable app
+whose shim confirmation didn't arrive), the profile also denies the real pasteboard service
+(`com.apple.pasteboard.1`) outright, and `glass_clipboard_get`/`glass_clipboard_set` return
+`Unsupported` — fail-closed, rather than silently falling back to the shared system clipboard.
+At `sandbox: off` clipboard access works normally against the real pasteboard (see
 [Tools available on macOS](#tools-available-on-macos) above).
 
 ### Known limits
 
 - **The mach allow-list is broad** (`(allow mach-lookup)`) — narrowing it to only the
   services a given app actually needs is a hardening follow-up.
+- **The clipboard shim covers `NSPasteboard` only.** It swizzles the high-level
+  `+[NSPasteboard generalPasteboard]` entry point that most apps use; an app that reaches the
+  pasteboard through lower-level Carbon/Core Services APIs isn't redirected. Hardened-runtime
+  apps can't be injected at all, so their clipboard access is `Unsupported` rather than
+  isolated-but-working.
 - **Electron apps may be able to escape their own in-app sandbox** under this
   containment. Seatbelt contains the process from the outside; an Electron app's
   internal renderer/main-process sandboxing is a separate mechanism this doesn't harden.

--- a/docs/running-on-macos.md
+++ b/docs/running-on-macos.md
@@ -206,10 +206,18 @@ item written to the private pasteboard) before routing to it, so an injection th
 failed doesn't get mistaken for a working bridge.
 
 If the target runs under Apple's **hardened runtime**, `DYLD_INSERT_LIBRARIES` injection is
-stripped by the OS and the swizzle can't take. For those apps (and for any injectable app
-whose shim confirmation didn't arrive), the profile also denies the real pasteboard service
-(`com.apple.pasteboard.1`) outright, and `glass_clipboard_get`/`glass_clipboard_set` return
-`Unsupported` — fail-closed, rather than silently falling back to the shared system clipboard.
+stripped by the OS and the swizzle can't take. Such apps aren't injectable, so the Seatbelt
+profile denies them the real pasteboard service (`com.apple.pasteboard.1`) outright and
+`glass_clipboard_get`/`glass_clipboard_set` return `Unsupported` — fail-closed at the profile
+level, not a silent fall-back to the shared system clipboard.
+
+For an *injectable* app whose shim confirmation doesn't arrive (injection silently failed),
+`glass_clipboard_get`/`glass_clipboard_set` also return `Unsupported`: glass decides that
+route after launch, from the missing sentinel, and never bridges to the real clipboard. Note
+this is a glass-side gate — the profile *does* allow the pasteboard service for an injectable
+target (that decision is made before launch, before confirmation is possible), so a silently-
+failed injection leaves the app itself still able to reach the real pasteboard directly. In
+practice injection either takes or the launch fails loudly, so this window is rare.
 At `sandbox: off` clipboard access works normally against the real pasteboard (see
 [Tools available on macOS](#tools-available-on-macos) above).
 


### PR DESCRIPTION
Makes `glass_clipboard_get`/`glass_clipboard_set` **work and stay isolated** under macOS `Default`/`Strict` containment for injectable apps, instead of returning `Unsupported` — closing the disparity with the Linux (private display) and Windows (injected hook) backends.

## How
A new `glass-clip-shim-macos` cdylib is injected into an injectable, contained app via `DYLD_INSERT_LIBRARIES`. Its load-time constructor swizzles `+[NSPasteboard generalPasteboard]` to return a per-session **private named pasteboard**; `glass_clipboard` reads/writes the same name. `pasteboardd` shares a named pasteboard across processes, so no custom IPC or host-side store is needed. The real system pasteboard is never touched.

- **Injectable vs hardened:** `process::spawn` classifies the target via `codesign`. Injectable (non-hardened) → inject + the Seatbelt profile allows `com.apple.pasteboard.1` + a file-literal read-allow for the shim dylib. Hardened (injection stripped by the OS) → the profile keeps denying the pasteboard and the route is `Unsupported` (fail-closed).
- **Confirmation:** the shim writes a sentinel to a dedicated `<name>.ready` pasteboard; `MacosPlatform` confirms it (`shim_present`) before trusting a `Private` route, so a silently-failed injection lands on `Unsupported`, never a dead bridge.
- **Routing:** a pure, Linux-tested `ClipboardRoute { RealGeneral, Private(name), Unsupported }` (fail-closed default) decides behavior once at `start_app`.
- Per-launch-unique pasteboard names (pid + nonce + counter); named pasteboards are released on `stop_app`, the failed-launch path, and `Drop`.

## Testing
- Pure routing/profile logic unit-tested on Linux; the shim + macOS wiring are CI-compiled on `macos-14` and were verified on real hardware (macOS 26.5): shim loads under the production Seatbelt profile, the `.ready` sentinel survives the app's own `clearContents`, the real clipboard stays untouched, dyld loads from the file-only allow, and 88 `glass-macos` unit tests pass.
- Multi-lens review of the whole branch; fail-closed integrity hardened (codesign classifier, injection-plumbing env precedence, unique/released pasteboards).

## Known limits
The shim covers high-level `NSPasteboard` only (not lower-level Carbon/Core Services). Hardened-runtime apps aren't injectable, so their clipboard access is `Unsupported` rather than isolated-but-working.