### PR TITLE
docs(macOS): plainer clipboard wording (drop coined "injectable")

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,9 +16,9 @@ tree — served over MCP (stdio, or `serve --http`). Backends behind a `Platform
 and Wayland (headless sway) on Linux, Windows (WGC/SendInput), Android (native apps in an AVD
 emulator over `adb`, host-OS-agnostic; clipboard + high-fidelity input via an optional
 on-device companion agent), macOS (ScreenCaptureKit capture, CGEvent input, AXUIElement
-windows/logs, accessibility tree, clipboard (isolated + working for injectable apps under
-containment via a `DYLD_INSERT_LIBRARIES` swizzle shim; hardened-runtime apps fall back to
-unsupported), sandboxing (Seatbelt)).
+windows/logs, accessibility tree, clipboard (isolated + working under containment for
+apps not built with hardened runtime, via a `DYLD_INSERT_LIBRARIES` swizzle shim;
+hardened-runtime apps fall back to unsupported), sandboxing (Seatbelt)).
 
 ## Layout
 

--- a/README.md
+++ b/README.md
@@ -209,10 +209,12 @@ A few capabilities worth knowing:
   and Chrome work too; x64) and real-file copy via `CF_HDROP` (virtual-file drag-out
   — shell extensions, zip attachments — is deferred). So they never touch
   your real clipboard unless you set `GLASS_DISPLAY=:0` or run the Windows
-  backend with `sandbox=off`. On **macOS**, a contained **injectable** app gets an
-  isolated-but-working clipboard too: a `DYLD_INSERT_LIBRARIES` shim redirects it to a
-  private named pasteboard glass shares, so the app can copy/paste normally while your
-  real clipboard is never touched; a **hardened-runtime** app can't be redirected, so
+  backend with `sandbox=off`. On **macOS**, a contained app that isn't built with
+  Apple's **hardened runtime** — typically a debug or unsigned build, like the app
+  you're developing — gets an isolated-but-working clipboard too: glass loads a small
+  shim into it that redirects its clipboard to a private pasteboard glass shares, so the
+  app copies and pastes normally while your real clipboard is never touched. An app that
+  *does* run under hardened runtime (App Store or notarized apps) can't be redirected, so
   these tools return `Unsupported` for it (see
   [running-on-macos.md](docs/running-on-macos.md)). On **Android**, clipboard get/set works through the
   optional on-device agent (set `GLASS_ANDROID_AGENT_JAR`) —
@@ -383,7 +385,7 @@ Where glass stands by OS. **✓** supported · **◑** partial · **–** not su
 
 † **Android** is emulator-only. Capture, multi-window, input, and logs work over `adb`, and glass manages the AVD (attach a running one, or boot a headless one). **Clipboard, high-fidelity input, and multi-touch gestures (`glass_gesture`)** use the optional on-device agent, and an optional on-device **AccessibilityService** sharpens the a11y tree (Compose) + `set_value` (both in the Android section of your host guide: [Linux](docs/running-on-linux.md) · [Windows](docs/running-on-windows.md) · [macOS](docs/running-on-macos.md)) — without the agent, input falls back to adb's `input` (single-pointer only — no multi-touch) and clipboard is unavailable; without the service, a11y falls back to `uiautomator`. glass is developed and tested against **Android 14 (API 34)**; the `adb` backend assumes no particular version and the optional companions declare an Android 7.0 (API 24) floor (details in your host guide). Window resize/move (apps are full-screen) and physical devices are non-goals.
 
-‡ **macOS** capture, input, windows, clipboard, and logs are built and CI-tested (ScreenCaptureKit capture, CGEvent input, AXUIElement windows). Containment is Seatbelt (`sandbox_init`): filesystem + process are contained at `default`/`strict`, and `strict` additionally blocks outbound network. The filesystem model is whole-filesystem read (read-only) except your home directory (`/Users`), which is denied so secrets stay hidden, with the working directory re-allowed for reads even when it lives inside your home; writes are limited to the working directory plus scratch/cache dirs (`/tmp`, `/private/var/folders`, `/dev`). Under containment, the clipboard is isolated **and working** for an **injectable** app — a swizzle shim redirects it to a private named pasteboard glass shares; a **hardened-runtime** app can't be redirected, so `glass_clipboard_get`/`set` return `Unsupported` for it. At `sandbox: off` it acts on the real system pasteboard. Known limits: the mach allow-list is broad (a hardening follow-up); Electron apps may be able to escape their own sandbox.
+‡ **macOS** capture, input, windows, clipboard, and logs are built and CI-tested (ScreenCaptureKit capture, CGEvent input, AXUIElement windows). Containment is Seatbelt (`sandbox_init`): filesystem + process are contained at `default`/`strict`, and `strict` additionally blocks outbound network. The filesystem model is whole-filesystem read (read-only) except your home directory (`/Users`), which is denied so secrets stay hidden, with the working directory re-allowed for reads even when it lives inside your home; writes are limited to the working directory plus scratch/cache dirs (`/tmp`, `/private/var/folders`, `/dev`). Under containment, the clipboard is isolated **and working** for an app not built with Apple's **hardened runtime** (typically a debug or unsigned build) — a swizzle shim redirects it to a private named pasteboard glass shares; an app that runs under hardened runtime (App Store / notarized) can't be redirected, so `glass_clipboard_get`/`set` return `Unsupported` for it. At `sandbox: off` it acts on the real system pasteboard. Known limits: the mach allow-list is broad (a hardening follow-up); Electron apps may be able to escape their own sandbox.
 
 The per-platform detail — sandboxing levels, display isolation, the accessibility tree —
 lives in the [Containment](#containment--sandboxing), [Backends](#backends), and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,10 +27,11 @@ The application glass launches is sandboxed by default, per OS:
   [`packaging/windows-sandbox/`](packaging/windows-sandbox).
 - **macOS** — Seatbelt (`sandbox_init`): filesystem + process containment at `default`, plus no
   network at `strict`, applied to the launched app and **fail-closed**. Under containment the
-  clipboard is **isolated and working** for an **injectable** app: an injected shim
-  (`DYLD_INSERT_LIBRARIES`) redirects the app's clipboard calls to a private named pasteboard
-  glass shares, so it can copy/paste normally while your real pasteboard stays untouched. An
-  app running under Apple's **hardened runtime** can't be redirected and falls back to
+  clipboard is **isolated and working** for an app not built with Apple's **hardened runtime**
+  (typically a debug or unsigned build): an injected shim (`DYLD_INSERT_LIBRARIES`) redirects the
+  app's clipboard calls to a private named pasteboard glass shares, so it can copy/paste normally
+  while your real pasteboard stays untouched. An app that runs under Apple's **hardened runtime**
+  (App Store or notarized apps) can't be redirected and falls back to
   `Unsupported` (fail-closed) rather than reaching the real pasteboard. The app
   still **renders on the real desktop** (display isolation is not yet implemented on macOS).
   Known limits: the Mach-service allowlist is currently broad (hardening in progress), Electron

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -198,10 +198,11 @@ impl GlassServer {
                        a contained Windows app (a private boxed clipboard). Also the cheap \
                        text-extraction path: glass_do ctrl+a then ctrl+c, then read here (beats \
                        OCR for selectable text). On a contained macOS app (sandbox: Default/Strict), \
-                       an injectable target is transparently redirected to a private pasteboard \
-                       glass shares — isolated from your real clipboard and fully working; a \
-                       hardened-runtime target can't be redirected, so this returns Unsupported. \
-                       Uncontained (sandbox: off) reads your REAL system clipboard."
+                       an app not built with Apple's hardened runtime (e.g. a debug or unsigned \
+                       build) is transparently redirected to a private pasteboard glass shares — \
+                       isolated from your real clipboard and fully working; an app that runs under \
+                       hardened runtime (App Store / notarized) can't be redirected, so this returns \
+                       Unsupported. Uncontained (sandbox: off) reads your REAL system clipboard."
     )]
     async fn glass_clipboard_get(&self) -> Result<CallToolResult, McpError> {
         self.run(tools::clipboard_get).await
@@ -213,10 +214,12 @@ impl GlassServer {
                        app (a private boxed clipboard); only shared-desktop modes (GLASS_DISPLAY=:0, \
                        or the Windows backend with sandbox=off) write your real clipboard — \
                        snapshot with glass_clipboard_get first if needed. On a contained macOS app \
-                       (sandbox: Default/Strict), an injectable target is transparently redirected \
-                       to a private pasteboard glass shares — isolated from your real clipboard and \
-                       fully working; a hardened-runtime target can't be redirected, so this returns \
-                       Unsupported. Uncontained (sandbox: off) writes your REAL system clipboard — \
+                       (sandbox: Default/Strict), an app not built with Apple's hardened runtime \
+                       (e.g. a debug or unsigned build) is transparently redirected to a private \
+                       pasteboard glass shares — isolated from your real clipboard and fully \
+                       working; an app that runs under hardened runtime (App Store / notarized) \
+                       can't be redirected, so this returns Unsupported. Uncontained (sandbox: off) \
+                       writes your REAL system clipboard — \
                        snapshot with glass_clipboard_get first if you need to preserve it."
     )]
     async fn glass_clipboard_set(

--- a/docs/running-on-macos.md
+++ b/docs/running-on-macos.md
@@ -162,8 +162,8 @@ above (no separate permission).
 
 - **Clipboard** (`glass_clipboard_get`, `glass_clipboard_set`) — read and write the system pasteboard at
   `sandbox: off`. Under containment (`default`/`strict`) the clipboard is isolated **and
-  working** for an injectable app, and `Unsupported` for a hardened-runtime app — see
-  [Clipboard isolation](#clipboard-isolation) below.
+  working** for an app not built with hardened runtime (typically a debug or unsigned build), and
+  `Unsupported` for a hardened-runtime app — see [Clipboard isolation](#clipboard-isolation) below.
 
 ## Sandboxing
 
@@ -197,24 +197,26 @@ sandboxed app that can't register with the window server returns an empty AX tre
 ### Clipboard isolation
 
 Under `default`/`strict`, `glass_clipboard_get`/`glass_clipboard_set` are isolated from your
-real pasteboard **but still work** for an **injectable** app: at launch glass injects a small
-shim (`DYLD_INSERT_LIBRARIES`) that swizzles `+[NSPasteboard generalPasteboard]` inside the
+real pasteboard **but still work** for an app that isn't built with Apple's **hardened runtime**
+— typically a debug or unsigned build, like the app you're developing: at launch glass injects a
+small shim (`DYLD_INSERT_LIBRARIES`) that swizzles `+[NSPasteboard generalPasteboard]` inside the
 app process, redirecting it to a private, per-session named pasteboard that glass reads and
 writes from the host side. The app copies/pastes normally against that private pasteboard;
 your real clipboard is never touched. glass confirms the swizzle actually took (a sentinel
 item written to the private pasteboard) before routing to it, so an injection that silently
 failed doesn't get mistaken for a working bridge.
 
-If the target runs under Apple's **hardened runtime**, `DYLD_INSERT_LIBRARIES` injection is
-stripped by the OS and the swizzle can't take. Such apps aren't injectable, so the Seatbelt
+If the target runs under Apple's **hardened runtime** (App Store or notarized apps),
+`DYLD_INSERT_LIBRARIES` injection is stripped by the OS and the swizzle can't take. Such apps
+can't be injected, so the Seatbelt
 profile denies them the real pasteboard service (`com.apple.pasteboard.1`) outright and
 `glass_clipboard_get`/`glass_clipboard_set` return `Unsupported` — fail-closed at the profile
 level, not a silent fall-back to the shared system clipboard.
 
-For an *injectable* app whose shim confirmation doesn't arrive (injection silently failed),
+For a non-hardened app whose shim confirmation doesn't arrive (injection silently failed),
 `glass_clipboard_get`/`glass_clipboard_set` also return `Unsupported`: glass decides that
 route after launch, from the missing sentinel, and never bridges to the real clipboard. Note
-this is a glass-side gate — the profile *does* allow the pasteboard service for an injectable
+this is a glass-side gate — the profile *does* allow the pasteboard service for a non-hardened
 target (that decision is made before launch, before confirmation is possible), so a silently-
 failed injection leaves the app itself still able to reach the real pasteboard directly. In
 practice injection either takes or the launch fails loudly, so this window is rare.


### PR DESCRIPTION
Follow-up to #67. "injectable" was a coined term with no meaning to users; "hardened runtime" is a real Apple term and stays. The docs + the two clipboard tool descriptions now frame the two cases against it:

- An app **not built with hardened runtime** (typically a debug or unsigned build — the app you're developing) → isolated + working clipboard.
- An app that **runs under hardened runtime** (App Store or notarized apps) → can't be redirected → `Unsupported`.

Touches README, `docs/running-on-macos.md`, `SECURITY.md`, `CLAUDE.md`, and the `glass_clipboard_get`/`set` tool descriptions. No behavior change. Internal code names (`target_is_injectable`) are unchanged.