### PR TITLE
macOS: guided setup + permission UX + bundle the clip shim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,6 +1108,7 @@ dependencies = [
  "rand 0.8.6",
  "reqwest",
  "rmcp",
+ "rustix",
  "schemars",
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ between screenshots cost no vision tokens.
   Apps are **sandboxed by default**; set `GLASS_SANDBOX=off` to run unconfined.
   See [Containment / sandboxing](#containment--sandboxing) for the levels; `glass-mcp doctor`
   checks availability and prints the exact remedy for your system.
+- **macOS only:** the Xcode Command Line Tools (`xcode-select --install`) — building from
+  source needs the macOS SDK and `clang` they provide (the `objc2-*` crates' link step
+  needs them). See [macOS: System requirements](docs/running-on-macos.md#system-requirements).
 
 ### Build from source
 
@@ -56,8 +59,10 @@ cd glass
 cargo build --release -p glass-mcp        # → target/release/glass-mcp
 ```
 
-(Tagged releases also attach prebuilt binaries to the GitHub Releases page, with
-per-platform setup notes under [`packaging/`](packaging).)
+(Tagged releases also attach prebuilt **Linux and Windows** binaries to the GitHub
+Releases page, with per-platform setup notes under [`packaging/`](packaging). macOS
+prebuilt binaries are a future addition — build from source for now, following
+[docs/running-on-macos.md](docs/running-on-macos.md).)
 
 ### Verify
 

--- a/crates/glass-core/src/doctor.rs
+++ b/crates/glass-core/src/doctor.rs
@@ -49,15 +49,24 @@ pub struct Check {
     /// How to fix it, when failing or warning.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub remedy: Option<String>,
+    /// An actionable remedy: a command/URL a tool can run (e.g. open the exact
+    /// Settings pane). Additive to `remedy` (human text); shown as a separate line.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remedy_action: Option<String>,
 }
 
 impl Check {
     pub fn new(name: impl Into<String>, status: CheckStatus, detail: impl Into<String>) -> Self {
-        Check { name: name.into(), status, detail: detail.into(), remedy: None }
+        Check { name: name.into(), status, detail: detail.into(), remedy: None, remedy_action: None }
     }
     /// Attach a remedy (builder style).
     pub fn with_remedy(mut self, remedy: impl Into<String>) -> Self {
         self.remedy = Some(remedy.into());
+        self
+    }
+    /// Attach an actionable remedy (builder style).
+    pub fn with_remedy_action(mut self, action: impl Into<String>) -> Self {
+        self.remedy_action = Some(action.into());
         self
     }
 }
@@ -147,9 +156,12 @@ impl Diagnosis {
                     CheckStatus::Skip => {}
                 }
                 out.push_str(&format!("  {} {}: {}\n", eff.glyph(), c.name, c.detail));
-                if let Some(r) = &c.remedy {
-                    if eff != CheckStatus::Ok {
+                if eff != CheckStatus::Ok {
+                    if let Some(r) = &c.remedy {
                         out.push_str(&format!("      → {r}\n"));
+                    }
+                    if let Some(a) = &c.remedy_action {
+                        out.push_str(&format!("      ↪ {a}\n"));
                     }
                 }
             }
@@ -237,5 +249,20 @@ mod tests {
         let c = Check::new("Xvfb", CheckStatus::Ok, "found");
         let j = serde_json::to_string(&c).unwrap();
         assert_eq!(j, r#"{"name":"Xvfb","status":"ok","detail":"found"}"#);
+    }
+
+    #[test]
+    fn render_shows_remedy_action_line() {
+        let check = Check::new("Screen Recording", CheckStatus::Fail, "not granted")
+            .with_remedy("enable it in System Settings")
+            .with_remedy_action(
+                "open: x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture",
+            );
+        let d = Diagnosis::new(vec![Section::new("macos", Some("macos".into()), vec![check])]);
+        let out = d.render_text("macos");
+        assert!(out.contains("→ enable it in System Settings"));
+        assert!(out.contains(
+            "↪ open: x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+        ));
     }
 }

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -39,5 +39,12 @@ pub use ffi::init_main_thread;
 // and the console session's three-way state (unlocked/locked/no-session-attached).
 #[cfg(target_os = "macos")]
 pub use permissions::{accessibility_granted, accessibility_remedy, screen_recording_granted, screen_recording_remedy};
+// Guided-setup counterparts to the predicates above: pure pane-URL/open helpers (usable
+// anywhere, including `doctor`'s `remedy_action`) and the prompting `request_*` pair
+// (used only by the future `setup` command — never by `preflight`/`doctor`).
+#[cfg(target_os = "macos")]
+pub use permissions::{
+    accessibility_pane_url, open_pane, request_accessibility, request_screen_recording, screen_recording_pane_url,
+};
 #[cfg(target_os = "macos")]
 pub use session::{session_locked, session_state, SessionState};

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -1,14 +1,15 @@
 //! The macOS `Platform` backend for glass (ScreenCaptureKit + CGEvent + AXUIElement,
 //! rendered onto a `CGVirtualDisplay`).
 //!
-//! Like `glass-windows`, the pure logic ([`keymap`], [`coords`], [`clipboard_route`]) is
-//! crate-level and unit-tested on the Linux dev box; the OS-touching modules and the
-//! `MacosPlatform` impl are gated `#[cfg(target_os = "macos")]`. Off macOS the crate exposes
-//! only the pure modules.
+//! Like `glass-windows`, the pure logic ([`keymap`], [`coords`], [`clipboard_route`],
+//! [`shim_path`]) is crate-level and unit-tested on the Linux dev box; the OS-touching
+//! modules and the `MacosPlatform` impl are gated `#[cfg(target_os = "macos")]`. Off macOS
+//! the crate exposes only the pure modules.
 
 pub mod clipboard_route; // pure clipboard-routing policy — cross-platform, host-tested
 pub mod coords; // pure window-relative <-> global math — cross-platform, host-tested
 pub mod keymap; // pure ASCII -> (keycode, shift) US map — cross-platform, host-tested
+pub mod shim_path; // pure clip-shim dylib path resolution — cross-platform, host-tested
 
 #[cfg(target_os = "macos")]
 mod ffi;

--- a/crates/glass-macos/src/permissions.rs
+++ b/crates/glass-macos/src/permissions.rs
@@ -4,6 +4,10 @@
 //! holds them via a stable code-signed identity. Here we only *detect* a missing grant
 //! and return an actionable error — never a blank frame.
 
+use std::ptr::NonNull;
+
+use objc2_core_foundation::{kCFBooleanTrue, CFBoolean, CFDictionary, CFRetained, CFString, CFType};
+
 use glass_core::Result;
 
 /// The two macOS TCC grants glass needs. A local enum keeps the permission names in
@@ -105,6 +109,93 @@ pub(crate) fn preflight() -> Result<()> {
     Ok(())
 }
 
+/// The System Settings deep-link for the Screen Recording privacy pane. Pure (no OS
+/// call), so both `doctor`'s `remedy_action` and the `setup` command can use it without
+/// either one triggering a permission prompt themselves.
+pub fn screen_recording_pane_url() -> &'static str {
+    "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+}
+
+/// The System Settings deep-link for the Accessibility privacy pane. See
+/// [`screen_recording_pane_url`].
+pub fn accessibility_pane_url() -> &'static str {
+    "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+}
+
+/// Open a System Settings pane (or any URL) via the `open` command-line tool. Returns an
+/// error the caller can surface to the agent; never panics.
+pub fn open_pane(url: &str) -> Result<()> {
+    let status = std::process::Command::new("open")
+        .arg(url)
+        .status()
+        .map_err(|e| glass_core::GlassError::Backend(format!("open {url}: {e}")))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(glass_core::GlassError::Backend(format!("open {url} exited {status}")))
+    }
+}
+
+// --- Guided setup: prompting requests --------------------------------------------------
+//
+// Everything above this point only *reads* TCC state (`screen_recording_granted`,
+// `accessibility_granted`, `preflight`) — safe to call from `doctor` on every run. The two
+// functions below are the opposite: they actively trigger the OS consent flow (a system
+// dialog, on first request). They exist only for the future interactive `setup` command
+// and must never be called from `preflight`/`doctor`, which must stay non-prompting.
+
+#[link(name = "CoreGraphics", kind = "framework")]
+extern "C" {
+    // Triggers the Screen Recording consent flow (adds glass to the privacy pane if it
+    // isn't already listed, and shows the system dialog on first request) and returns
+    // the current grant state. Post-10.15 API, C99 `bool` ABI — like
+    // `CGPreflightScreenCaptureAccess` above.
+    fn CGRequestScreenCaptureAccess() -> bool;
+}
+#[link(name = "ApplicationServices", kind = "framework")]
+extern "C" {
+    // With an options dict carrying `kAXTrustedCheckOptionPrompt = true`, shows the
+    // Accessibility consent dialog (when not already trusted) and returns the current
+    // trust state. `Boolean` (u8), not C99 `bool` — see `AXIsProcessTrusted` above for
+    // why that distinction matters for the return-value binding.
+    fn AXIsProcessTrustedWithOptions(options: *const CFDictionary) -> u8;
+}
+
+/// Trigger the Screen Recording consent flow (shows the system dialog and adds glass to
+/// the Privacy & Security > Screen Recording pane) and report whether the grant is
+/// currently held. Only ever called from the `setup` command — `preflight`/`doctor` must
+/// never prompt; they call [`screen_recording_granted`] instead.
+pub fn request_screen_recording() -> bool {
+    // SAFETY: no-argument C call. Unlike `CGPreflightScreenCaptureAccess`, this one's
+    // documented behavior is to prompt; it has no other preconditions and its only
+    // effects are the system dialog plus reading this process's TCC state.
+    unsafe { CGRequestScreenCaptureAccess() }
+}
+
+/// Trigger the Accessibility consent dialog (via `kAXTrustedCheckOptionPrompt`) and
+/// report whether this process is currently trusted. Only ever called from the `setup`
+/// command — `preflight`/`doctor` must never prompt; they call [`accessibility_granted`]
+/// instead.
+pub fn request_accessibility() -> bool {
+    let key = CFString::from_str("AXTrustedCheckOptionPrompt");
+    // SAFETY: `kCFBooleanTrue` is a framework-owned singleton, always live for the
+    // process's lifetime; reading the extern static is a plain global read (same idiom
+    // `axwindow::ax_set_main` and `session.rs`'s tests use).
+    let true_boolean: Option<&CFBoolean> = unsafe { kCFBooleanTrue };
+    // `None` is not a real-world case (the constant is always present on real
+    // CoreFoundation builds) but falling back to the non-prompting predicate instead of
+    // panicking keeps this function total.
+    let Some(true_boolean) = true_boolean else { return accessibility_granted() };
+    let prompt: &CFType = true_boolean;
+    let dict: CFRetained<CFDictionary<CFString, CFType>> = CFDictionary::from_slices(&[&key], &[prompt]);
+    // SAFETY: `AXIsProcessTrustedWithOptions` takes a CFDictionaryRef; `dict` stays alive
+    // for the whole call (it is dropped only when this function returns, after the FFI
+    // call has returned), and the only effects are the documented consent prompt plus
+    // reading this process's trust state (`Boolean`/u8 return, same ABI reasoning as
+    // `AXIsProcessTrusted` above).
+    unsafe { AXIsProcessTrustedWithOptions(NonNull::from(&*dict).cast().as_ptr()) != 0 }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -128,4 +219,22 @@ mod tests {
             Err(e) => panic!("unexpected error: {e}"),
         }
     }
+
+    #[test]
+    fn screen_recording_pane_url_points_at_the_screen_capture_anchor() {
+        assert!(screen_recording_pane_url().contains("Privacy_ScreenCapture"));
+    }
+
+    #[test]
+    fn accessibility_pane_url_points_at_the_accessibility_anchor() {
+        assert!(accessibility_pane_url().contains("Privacy_Accessibility"));
+    }
+
+    // `request_screen_recording`/`request_accessibility` are deliberately not exercised
+    // here: unlike every predicate above, they have a real side effect (they can pop the
+    // OS consent dialog), which is unsafe to trigger unattended in CI — a headless runner
+    // has no user to click through it, and a real one shouldn't have its TCC state
+    // mutated by every test run. Their FFI plumbing is verified by hand against the
+    // granted mini (see the workspace's macOS de-risking notes); `open_pane` is likewise
+    // side-effecting (launches System Settings) and not called here for the same reason.
 }

--- a/crates/glass-macos/src/process.rs
+++ b/crates/glass-macos/src/process.rs
@@ -13,7 +13,8 @@
 //!
 //! Clip-shim injection: a contained launch whose target is not hardened-runtime signed
 //! ([`target_is_injectable`]) gets `glass-clip-shim-macos`'s built dylib
-//! ([`shim_dylib_path`]) loaded via `DYLD_INSERT_LIBRARIES`, plus a per-spawn private
+//! ([`shim_dylib_path`], the macOS wrapper around [`crate::shim_path::resolve_shim`]'s pure
+//! path-tier logic) loaded via `DYLD_INSERT_LIBRARIES`, plus a per-spawn private
 //! pasteboard name in `GLASS_CLIP_PASTEBOARD` — both set on the `Command` before
 //! `cmd.spawn()` in [`spawn`]. `Command`'s envp is applied at the `exec` that follows
 //! `pre_exec`'s `sandbox_init` call (not at fork/`pre_exec` time), so both vars are present
@@ -111,33 +112,14 @@ fn target_is_injectable(program: &Path) -> bool {
 /// Env var overriding [`shim_dylib_path`]'s resolution — tests and non-standard layouts.
 const SHIM_DYLIB_ENV: &str = "GLASS_CLIP_SHIM_DYLIB";
 
-/// File name of the shim's build artifact: `glass-clip-shim-macos`'s `crate-type =
-/// ["cdylib"]` compiles to `lib<crate name, underscored>.dylib` on macOS.
-const SHIM_DYLIB_NAME: &str = "libglass_clip_shim_macos.dylib";
-
-/// Resolve the injected clip shim's dylib: [`SHIM_DYLIB_ENV`] → next to the running
-/// executable → the cargo target dir one level up from it (`current_exe` is
-/// `target/<profile>/<bin>` for a normal build, or `target/<profile>/deps/<bin>-<hash>`
-/// under `cargo test`, one directory deeper than the shim's own build output — hence the
-/// second candidate). Every tier, including the env override, is existence-checked
-/// (`.is_file()`) before being returned — a bad override (stale/typo'd path) falls through
-/// to the remaining tiers rather than being trusted blind, same fail-closed discipline as
-/// the rest of this resolution. `None` if none of these exist: callers treat that as "not
-/// injectable" (fail-closed — no resolvable shim, no injection).
+/// [`crate::shim_path::resolve_shim`] against the real environment: the running executable's
+/// directory and [`SHIM_DYLIB_ENV`]. The tier logic itself is pure and lives in
+/// [`crate::shim_path`] (unit-tested on the Linux dev box); this wrapper only supplies the
+/// two OS-touching inputs it needs.
 fn shim_dylib_path() -> Option<PathBuf> {
-    if let Ok(path) = std::env::var(SHIM_DYLIB_ENV) {
-        let path = PathBuf::from(path);
-        if path.is_file() {
-            return Some(path);
-        }
-    }
+    let env_override = std::env::var(SHIM_DYLIB_ENV).ok().map(PathBuf::from);
     let exe_dir = std::env::current_exe().ok()?.parent()?.to_path_buf();
-    let next_to_exe = exe_dir.join(SHIM_DYLIB_NAME);
-    if next_to_exe.is_file() {
-        return Some(next_to_exe);
-    }
-    let target_dir = exe_dir.parent()?.join(SHIM_DYLIB_NAME);
-    target_dir.is_file().then_some(target_dir)
+    crate::shim_path::resolve_shim(&exe_dir, env_override)
 }
 
 /// Log lines captured by the per-stream reader threads spawned in [`spawn`], drained by

--- a/crates/glass-macos/src/shim_path.rs
+++ b/crates/glass-macos/src/shim_path.rs
@@ -1,0 +1,149 @@
+//! Pure clip-shim dylib path resolution. Cross-platform → unit-tested on the Linux dev box,
+//! same split as [`crate::clipboard_route`]/[`crate::coords`]/[`crate::keymap`]: no OS calls
+//! here, only `Path`/`PathBuf` arithmetic and existence checks against whatever paths the
+//! caller hands in. `glass_macos::process::shim_dylib_path` (macOS-only) is the thin wrapper
+//! that supplies the real executable directory and env override.
+#![forbid(unsafe_code)]
+
+use std::path::{Path, PathBuf};
+
+/// File name of the shim's build artifact: `glass-clip-shim-macos`'s `crate-type =
+/// ["cdylib"]` compiles to `lib<crate name, underscored>.dylib` on macOS.
+pub const SHIM_DYLIB_NAME: &str = "libglass_clip_shim_macos.dylib";
+
+/// Resolve the injected clip shim's dylib, given the running executable's directory and an
+/// already-read env-override value (the caller reads `GLASS_CLIP_SHIM_DYLIB` itself — this
+/// function takes no env/filesystem-location input of its own, only what's passed in).
+///
+/// Tiers, in order:
+/// 1. `env_override`, if `Some`.
+/// 2. `<exe_dir>/../Frameworks/<SHIM_DYLIB_NAME>` — a packaged `.app`'s bundle layout: the
+///    executable lives in `Contents/MacOS`, and a packaged install ships the shim one level
+///    up in `Contents/Frameworks`. Checked before the dev target-dir tier so an installed
+///    bundle always prefers its own bundled shim over a stray dev build on the same machine.
+/// 3. `<exe_dir>/<SHIM_DYLIB_NAME>` — next to the running executable.
+/// 4. `<exe_dir>/../<SHIM_DYLIB_NAME>` — the cargo target dir one level up from it
+///    (`current_exe` is `target/<profile>/<bin>` for a normal build, or
+///    `target/<profile>/deps/<bin>-<hash>` under `cargo test`, one directory deeper than the
+///    shim's own build output — hence this candidate).
+///
+/// Every tier, including the env override, is existence-checked (`.is_file()`) before being
+/// returned — a bad override (stale/typo'd path) falls through to the remaining tiers rather
+/// than being trusted blind, same fail-closed discipline throughout. `None` if none of these
+/// exist: callers treat that as "not injectable" (fail-closed — no resolvable shim, no
+/// injection).
+pub fn resolve_shim(exe_dir: &Path, env_override: Option<PathBuf>) -> Option<PathBuf> {
+    if let Some(path) = env_override {
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+    if let Some(bundled) = exe_dir.parent().map(|contents| contents.join("Frameworks").join(SHIM_DYLIB_NAME)) {
+        if bundled.is_file() {
+            return Some(bundled);
+        }
+    }
+    let next_to_exe = exe_dir.join(SHIM_DYLIB_NAME);
+    if next_to_exe.is_file() {
+        return Some(next_to_exe);
+    }
+    let target_dir = exe_dir.parent()?.join(SHIM_DYLIB_NAME);
+    target_dir.is_file().then_some(target_dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A dropped temp file: `resolve_shim` only ever returns paths that pass `.is_file()`,
+    /// so every positive-case test needs a real file on disk, cleaned up on drop even if an
+    /// assertion panics.
+    struct TempFile(PathBuf);
+    impl TempFile {
+        fn create(path: PathBuf) -> Self {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("create parent dirs");
+            }
+            std::fs::write(&path, b"stand-in dylib contents; only existence matters here")
+                .expect("write stand-in file");
+            Self(path)
+        }
+    }
+    impl Drop for TempFile {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
+        }
+    }
+
+    /// A fresh scratch directory per test (rather than a shared one), so parallel test
+    /// threads never see each other's tiers.
+    fn scratch_dir(tag: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("glass-shim-path-test-{tag}-{}", std::process::id()))
+    }
+
+    #[test]
+    fn env_override_that_exists_wins() {
+        let dir = scratch_dir("env-override");
+        let dylib = TempFile::create(dir.join("override.dylib"));
+        let resolved = resolve_shim(Path::new("/nonexistent/exe/dir"), Some(dylib.0.clone()));
+        assert_eq!(resolved, Some(dylib.0.clone()));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn nonexistent_env_override_falls_through() {
+        // Unlike a fail-open design, a bad override (stale env, typo'd path) must not be
+        // trusted blind: it falls through to the remaining tiers (here, `None`, since no
+        // other tier has a file either) rather than being handed back as-is.
+        let bogus = PathBuf::from("/nonexistent/glass-clip-shim-test.dylib");
+        let resolved = resolve_shim(Path::new("/also/nonexistent/exe/dir"), Some(bogus.clone()));
+        assert_ne!(resolved, Some(bogus), "a nonexistent override must not be returned as-is");
+    }
+
+    #[test]
+    fn bundle_relative_frameworks_dir_is_preferred_over_target_dir() {
+        // `…/Contents/MacOS/` (exe dir) + a file at `…/Contents/Frameworks/<name>` — the
+        // packaged `.app` layout `build-app.sh` produces.
+        let dir = scratch_dir("bundle");
+        let exe_dir = dir.join("Contents").join("MacOS");
+        let bundled = TempFile::create(dir.join("Contents").join("Frameworks").join(SHIM_DYLIB_NAME));
+        // Also drop a file at the target-dir tier's location (`Contents/<name>`) to prove
+        // the bundle tier is checked, and wins, before it.
+        let target_dir_candidate = TempFile::create(dir.join("Contents").join(SHIM_DYLIB_NAME));
+
+        let resolved = resolve_shim(&exe_dir, None);
+        assert_eq!(resolved, Some(bundled.0.clone()));
+        drop(target_dir_candidate);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn next_to_exe_tier_is_used_when_no_bundle_or_override() {
+        let dir = scratch_dir("next-to-exe");
+        let exe_dir = dir.clone();
+        let sibling = TempFile::create(dir.join(SHIM_DYLIB_NAME));
+        let resolved = resolve_shim(&exe_dir, None);
+        assert_eq!(resolved, Some(sibling.0.clone()));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn target_dir_tier_is_used_as_last_resort() {
+        let dir = scratch_dir("target-dir");
+        let exe_dir = dir.join("deps");
+        std::fs::create_dir_all(&exe_dir).expect("create exe dir");
+        let target_dylib = TempFile::create(dir.join(SHIM_DYLIB_NAME));
+        let resolved = resolve_shim(&exe_dir, None);
+        assert_eq!(resolved, Some(target_dylib.0.clone()));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn none_when_nothing_resolves() {
+        let dir = scratch_dir("nothing");
+        let exe_dir = dir.join("Contents").join("MacOS");
+        std::fs::create_dir_all(&exe_dir).expect("create exe dir");
+        assert_eq!(resolve_shim(&exe_dir, None), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/glass-mcp/Cargo.toml
+++ b/crates/glass-mcp/Cargo.toml
@@ -52,6 +52,10 @@ glass-a11y-windows = { path = "../glass-a11y-windows" }
 glass-macos = { path = "../glass-macos" }
 glass-a11y-macos = { path = "../glass-a11y-macos" }
 glass-sandbox-macos.workspace = true
+# `setup`'s `gui/<uid>` LaunchAgent install (`rustix::process::getuid`) — a safe syscall
+# wrapper, so no `unsafe` FFI is needed for this. Already a workspace dependency (glass-macos
+# uses it for process signals); the workspace-level `process` feature covers `getuid`.
+rustix.workspace = true
 
 [build-dependencies]
 embed-manifest = "1"

--- a/crates/glass-mcp/src/cli.rs
+++ b/crates/glass-mcp/src/cli.rs
@@ -60,6 +60,21 @@ pub enum Command {
         #[arg(long)]
         out: Option<String>,
     },
+    /// Guided macOS first-run: request the TCC grants, install the run integration, confirm.
+    Setup {
+        /// Fail instead of prompting (scripting/CI).
+        #[arg(long)]
+        non_interactive: bool,
+        /// Install the gui/uid LaunchAgent (unattended serve --http) instead of asking.
+        #[arg(long)]
+        launchagent: bool,
+        /// Do NOT install the LaunchAgent (attended/stdio) instead of asking.
+        #[arg(long, conflicts_with = "launchagent")]
+        no_launchagent: bool,
+        /// LaunchAgent HTTP bind address (default 127.0.0.1:7300).
+        #[arg(long)]
+        addr: Option<String>,
+    },
 }
 
 #[cfg(test)]
@@ -122,6 +137,44 @@ mod tests {
     #[test]
     fn unknown_subcommand_is_an_error() {
         assert!(Cli::try_parse_from(["glass-mcp", "bogus"]).is_err());
+    }
+
+    #[test]
+    fn setup_flags_parse() {
+        let cli = Cli::try_parse_from(["glass-mcp", "setup", "--non-interactive", "--launchagent"]).unwrap();
+        match cli.command {
+            Some(Command::Setup { non_interactive, launchagent, no_launchagent, addr }) => {
+                assert!(non_interactive);
+                assert!(launchagent);
+                assert!(!no_launchagent);
+                assert!(addr.is_none());
+            }
+            other => panic!("expected setup, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn setup_flags_default_to_false() {
+        let cli = Cli::try_parse_from(["glass-mcp", "setup"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Setup { non_interactive: false, launchagent: false, no_launchagent: false, addr: None })
+        ));
+    }
+
+    #[test]
+    fn setup_addr_parses() {
+        let cli = Cli::try_parse_from(["glass-mcp", "setup", "--addr", "0.0.0.0:7300"]).unwrap();
+        match cli.command {
+            Some(Command::Setup { addr, .. }) => assert_eq!(addr.as_deref(), Some("0.0.0.0:7300")),
+            other => panic!("expected setup, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn setup_launchagent_and_no_launchagent_conflict() {
+        let err = Cli::try_parse_from(["glass-mcp", "setup", "--launchagent", "--no-launchagent"]).unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
     #[test]

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -192,6 +192,7 @@ fn macos_checks_from(
                 "not granted — capture will fail with a permission error",
             )
             .with_remedy(glass_macos::screen_recording_remedy())
+            .with_remedy_action(format!("open {}", glass_macos::screen_recording_pane_url()))
         },
         if accessibility {
             Check::new("Accessibility", CheckStatus::Ok, "granted")
@@ -202,6 +203,7 @@ fn macos_checks_from(
                 "not granted — window management and input injection will fail",
             )
             .with_remedy(glass_macos::accessibility_remedy())
+            .with_remedy_action(format!("open {}", glass_macos::accessibility_pane_url()))
         },
         match session_state {
             glass_macos::SessionState::Unlocked => Check::new("display awake", CheckStatus::Ok, "session unlocked"),
@@ -279,6 +281,7 @@ fn macos_a11y_checks(accessibility_granted: bool) -> Vec<Check> {
                  glass_set_value will fail with a permission error",
             )
             .with_remedy(glass_macos::accessibility_remedy())
+            .with_remedy_action(format!("open {}", glass_macos::accessibility_pane_url()))
         },
     ]
 }
@@ -394,11 +397,31 @@ mod tests {
         }
 
         #[test]
+        fn missing_screen_recording_points_at_the_screen_capture_pane() {
+            let checks = macos_checks_from("macos", false, true, SessionState::Unlocked);
+            let c = checks.iter().find(|c| c.name == "Screen Recording").unwrap();
+            assert_eq!(
+                c.remedy_action.as_deref(),
+                Some(format!("open {}", glass_macos::screen_recording_pane_url()).as_str())
+            );
+        }
+
+        #[test]
         fn missing_accessibility_fails_with_the_shared_remedy() {
             let checks = macos_checks_from("macos", true, false, SessionState::Unlocked);
             let c = checks.iter().find(|c| c.name == "Accessibility").unwrap();
             assert_eq!(c.status, CheckStatus::Fail);
             assert_eq!(c.remedy.as_deref(), Some(glass_macos::accessibility_remedy()));
+        }
+
+        #[test]
+        fn missing_accessibility_points_at_the_accessibility_pane() {
+            let checks = macos_checks_from("macos", true, false, SessionState::Unlocked);
+            let c = checks.iter().find(|c| c.name == "Accessibility").unwrap();
+            assert_eq!(
+                c.remedy_action.as_deref(),
+                Some(format!("open {}", glass_macos::accessibility_pane_url()).as_str())
+            );
         }
 
         #[test]
@@ -481,6 +504,18 @@ mod tests {
             // Same remedy string as the "macos" section's own Accessibility check — no
             // separate, driftable copy here either.
             assert_eq!(c.remedy.as_deref(), Some(glass_macos::accessibility_remedy()));
+        }
+
+        #[test]
+        fn a11y_not_granted_points_at_the_accessibility_pane() {
+            let checks = macos_a11y_checks(false);
+            let c = checks.iter().find(|c| c.name == "Accessibility").unwrap();
+            // Same pane URL as the "macos" section's own Accessibility check — kept in
+            // sync for the same reason as the shared remedy string above.
+            assert_eq!(
+                c.remedy_action.as_deref(),
+                Some(format!("open {}", glass_macos::accessibility_pane_url()).as_str())
+            );
         }
     }
 }

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -7,6 +7,7 @@ pub mod doctor;
 mod env;
 mod params;
 pub(crate) mod server;
+pub mod setup;
 pub(crate) mod shutdown;
 mod tools;
 mod untrusted;

--- a/crates/glass-mcp/src/main.rs
+++ b/crates/glass-mcp/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use glass_mcp::cli::{Cli, Command};
-use glass_mcp::{boot, run_doctor, run_env, run_stdio};
+use glass_mcp::{boot, run_doctor, run_env, run_stdio, setup};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -62,6 +62,10 @@ async fn main() -> anyhow::Result<()> {
                      --no-default-features build omits"
                 )
             }
+        }
+        Some(Command::Setup { non_interactive, launchagent, no_launchagent, addr }) => {
+            setup::run(non_interactive, launchagent, no_launchagent, addr)?;
+            Ok(())
         }
     }
 }

--- a/crates/glass-mcp/src/main.rs
+++ b/crates/glass-mcp/src/main.rs
@@ -64,7 +64,7 @@ async fn main() -> anyhow::Result<()> {
             }
         }
         Some(Command::Setup { non_interactive, launchagent, no_launchagent, addr }) => {
-            setup::run(non_interactive, launchagent, no_launchagent, addr)?;
+            setup::run(setup::SetupArgs { non_interactive, launchagent, no_launchagent, addr })?;
             Ok(())
         }
     }

--- a/crates/glass-mcp/src/setup.rs
+++ b/crates/glass-mcp/src/setup.rs
@@ -1,0 +1,144 @@
+//! `glass-mcp setup`: the guided macOS first-run — request the two TCC grants (Screen
+//! Recording, Accessibility), install the chosen run integration (an unattended
+//! `gui/<uid>` LaunchAgent serving HTTP, or nothing for an attended/stdio client-spawned
+//! run), and confirm with `doctor` plus a ready-to-paste MCP-client registration line.
+//!
+//! This module is split so the parts that don't need macOS are unit-testable on Linux:
+//! [`RunMode`], [`registration_line`], and [`fill_launch_agent`] are pure — no OS call, no
+//! IO — and are exercised here. The interactive grant flow itself
+//! (`#[cfg(target_os = "macos")]` inside [`run`]) is a stub in this task; it lands in a
+//! follow-on task, macOS-only (permission prompts, `launchctl`, file writes).
+
+// `GlassError` itself is only named in the `#[cfg(not(target_os = "macos"))]` arm of `run`
+// (and its test) — on a macOS build that arm doesn't exist, so import only `Result` here
+// and spell out `glass_core::GlassError` at its one use site to avoid an unused-import
+// warning on that platform.
+use glass_core::Result;
+
+/// How the user will run `glass-mcp` after setup completes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RunMode {
+    /// Installed as a `gui/<uid>` LaunchAgent serving Streamable HTTP — starts at login,
+    /// no client to spawn it. The unattended path.
+    Http,
+    /// Spawned by the MCP client over stdio, one process per session. The attended path;
+    /// nothing is installed.
+    Stdio,
+}
+
+/// The ready-to-paste MCP-client registration command for the chosen run mode. `app_bin`
+/// is the resolved path to the `.app`'s `glass-mcp` binary; `addr` is the HTTP bind
+/// address (only used for [`RunMode::Http`]).
+pub fn registration_line(mode: RunMode, app_bin: &str, addr: &str) -> String {
+    match mode {
+        RunMode::Stdio => format!("claude mcp add glass --scope user -- {app_bin}"),
+        RunMode::Http => format!("claude mcp add --transport http glass http://{addr}/"),
+    }
+}
+
+/// Fill the LaunchAgent plist template (`packaging/macos/tech.fixedwidth.glass.plist`):
+/// substitute the app-binary path, the HTTP bind address, and the home directory the two
+/// log paths are rooted under. `template` is the shipped plist text; returns the
+/// ready-to-write plist. Pure string substitution — no IO, so the caller decides where (or
+/// whether) to write the result.
+pub fn fill_launch_agent(template: &str, app_bin: &str, addr: &str, home: &str) -> String {
+    template
+        .replace("/Applications/GlassMcp.app/Contents/MacOS/glass-mcp", app_bin)
+        .replace("127.0.0.1:7300", addr)
+        .replace("/Users/YOU", home)
+}
+
+/// Run `glass-mcp setup`. macOS-only: everywhere else this fails fast with an actionable
+/// error rather than pretending to do something.
+///
+/// The flags mirror the `Setup` clap variant verbatim (see `cli.rs`) so the macOS body can
+/// use them without re-threading the signature: `non_interactive` fails instead of
+/// prompting (scripting/CI); `launchagent`/`no_launchagent` force the run mode instead of
+/// asking; `addr` overrides the LaunchAgent's HTTP bind address.
+pub fn run(non_interactive: bool, launchagent: bool, no_launchagent: bool, addr: Option<String>) -> Result<()> {
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (non_interactive, launchagent, no_launchagent, addr);
+        Err(glass_core::GlassError::Backend("setup is macOS-only".into()))
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let _ = (non_interactive, launchagent, no_launchagent, addr);
+        // The interactive grant flow (request Screen Recording + Accessibility, open the
+        // relevant pane, poll for the grant, decide/install the run mode, confirm via
+        // `doctor` + `registration_line`) is not implemented yet — it lands in a follow-on
+        // task. This stub only proves the dispatch wiring and the macOS build.
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- registration_line ------------------------------------------------------------
+
+    #[test]
+    fn stdio_registration_line_names_the_binary() {
+        let line = registration_line(RunMode::Stdio, "/Applications/GlassMcp.app/Contents/MacOS/glass-mcp", "127.0.0.1:7300");
+        assert!(line.contains("/Applications/GlassMcp.app/Contents/MacOS/glass-mcp"));
+        assert!(line.contains("mcp add glass"));
+    }
+
+    #[test]
+    fn stdio_registration_line_does_not_use_http_transport() {
+        let line = registration_line(RunMode::Stdio, "/bin/glass-mcp", "127.0.0.1:7300");
+        assert!(!line.contains("--transport http"));
+    }
+
+    #[test]
+    fn http_registration_line_names_the_addr() {
+        let line = registration_line(RunMode::Http, "/bin/glass-mcp", "127.0.0.1:7300");
+        assert!(line.contains("127.0.0.1:7300"));
+        assert!(line.contains("--transport http"));
+    }
+
+    // --- fill_launch_agent -------------------------------------------------------------
+
+    /// The real shipped template — kept in sync with `packaging/macos/tech.fixedwidth.glass.plist`
+    /// by inclusion, so a drift in either place breaks this test rather than shipping silently.
+    const TEMPLATE: &str = include_str!("../../../packaging/macos/tech.fixedwidth.glass.plist");
+
+    #[test]
+    fn fill_launch_agent_substitutes_the_app_binary() {
+        let filled = fill_launch_agent(TEMPLATE, "/Applications/GlassMcp.app/Contents/MacOS/glass-mcp", "127.0.0.1:7300", "/Users/alice");
+        assert!(filled.contains("/Applications/GlassMcp.app/Contents/MacOS/glass-mcp"));
+    }
+
+    #[test]
+    fn fill_launch_agent_substitutes_a_custom_app_binary() {
+        let filled = fill_launch_agent(TEMPLATE, "/opt/glass/glass-mcp", "127.0.0.1:7300", "/Users/alice");
+        assert!(filled.contains("/opt/glass/glass-mcp"));
+        assert!(!filled.contains("/Applications/GlassMcp.app"));
+    }
+
+    #[test]
+    fn fill_launch_agent_substitutes_the_addr() {
+        let filled = fill_launch_agent(TEMPLATE, "/opt/glass/glass-mcp", "0.0.0.0:9999", "/Users/alice");
+        assert!(filled.contains("0.0.0.0:9999"));
+        assert!(!filled.contains("127.0.0.1:7300"));
+    }
+
+    #[test]
+    fn fill_launch_agent_substitutes_the_home_in_both_log_paths() {
+        let filled = fill_launch_agent(TEMPLATE, "/opt/glass/glass-mcp", "127.0.0.1:7300", "/Users/alice");
+        assert!(filled.contains("/Users/alice/Library/Logs/GlassMcp/stdout.log"));
+        assert!(filled.contains("/Users/alice/Library/Logs/GlassMcp/stderr.log"));
+        assert!(!filled.contains("/Users/YOU"));
+    }
+
+    // --- run (non-macOS stub) -----------------------------------------------------------
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn run_fails_fast_off_macos() {
+        let err = run(false, false, false, None).expect_err("setup must refuse to run off macOS");
+        assert!(matches!(err, glass_core::GlassError::Backend(_)));
+        assert!(err.to_string().contains("macOS-only"));
+    }
+}

--- a/crates/glass-mcp/src/setup.rs
+++ b/crates/glass-mcp/src/setup.rs
@@ -4,15 +4,19 @@
 //! run), and confirm with `doctor` plus a ready-to-paste MCP-client registration line.
 //!
 //! This module is split so the parts that don't need macOS are unit-testable on Linux:
-//! [`RunMode`], [`registration_line`], and [`fill_launch_agent`] are pure — no OS call, no
+//! [`RunMode`], [`registration_line`], [`fill_launch_agent`], [`run_mode_from_flags`],
+//! [`is_inside_app_bundle`], and [`codesign_report_is_unstable`] are pure — no OS call, no
 //! IO — and are exercised here. The interactive grant flow itself
-//! (`#[cfg(target_os = "macos")]` inside [`run`]) is a stub in this task; it lands in a
-//! follow-on task, macOS-only (permission prompts, `launchctl`, file writes).
+//! (`#[cfg(target_os = "macos")]` inside [`run`], plumbed through the private `macos_impl`
+//! submodule) is macOS-only: permission prompts, `codesign`/`launchctl` shell-outs, real
+//! file writes.
 
 // `GlassError` itself is only named in the `#[cfg(not(target_os = "macos"))]` arm of `run`
 // (and its test) — on a macOS build that arm doesn't exist, so import only `Result` here
 // and spell out `glass_core::GlassError` at its one use site to avoid an unused-import
 // warning on that platform.
+use std::path::Path;
+
 use glass_core::Result;
 
 /// How the user will run `glass-mcp` after setup completes.
@@ -48,6 +52,52 @@ pub fn fill_launch_agent(template: &str, app_bin: &str, addr: &str, home: &str) 
         .replace("/Users/YOU", home)
 }
 
+/// Decide the run mode from the `--launchagent`/`--no-launchagent` flags alone, without
+/// prompting. `None` means neither flag forced a choice — the caller must ask interactively,
+/// or fall back to a non-prompting default (`--non-interactive`). Pure — no OS call, no IO —
+/// same Linux-testable shape as [`registration_line`]/[`fill_launch_agent`] above; the actual
+/// prompt (when both flags are absent and the run is interactive) lives in the macOS-only
+/// body of [`run`], since reading stdin isn't something to unit-test here.
+pub fn run_mode_from_flags(launchagent: bool, no_launchagent: bool) -> Option<RunMode> {
+    if launchagent {
+        Some(RunMode::Http)
+    } else if no_launchagent {
+        Some(RunMode::Stdio)
+    } else {
+        None
+    }
+}
+
+/// True if `exe` sits inside a `<name>.app/Contents/MacOS/` bundle — the shape
+/// `packaging/macos/build-app.sh` produces. A TCC grant is recorded against the *process's*
+/// Designated Requirement (bundle id + signing certificate); running a bare binary outside a
+/// bundle means a grant given today has nothing stable to attach to. Advisory only — [`run`]
+/// warns, never refuses, since `setup` should still be usable from `cargo run` while
+/// iterating. Pure (no filesystem access — just path-shape matching), so it's unit-tested on
+/// Linux against fabricated paths.
+pub fn is_inside_app_bundle(exe: &Path) -> bool {
+    let macos_dir = exe.parent();
+    let contents_dir = macos_dir.and_then(Path::parent);
+    let bundle_dir = contents_dir.and_then(Path::parent);
+    let names =
+        (macos_dir.and_then(Path::file_name), contents_dir.and_then(Path::file_name), bundle_dir.and_then(Path::file_name));
+    matches!(
+        names,
+        (Some(macos), Some(contents), Some(bundle))
+            if macos == "MacOS" && contents == "Contents" && bundle.to_string_lossy().ends_with(".app")
+    )
+}
+
+/// True if a `codesign -dvv` report (stdout and stderr concatenated) shows an unstable
+/// signing identity — ad hoc, or plain unsigned — either of which means a grant won't survive
+/// a rebuild (see [`is_inside_app_bundle`]'s doc for why that matters). Pure string matching
+/// over already-captured text, so it's unit-tested on Linux without shelling out to
+/// `codesign`; [`run`] is the only real caller, feeding it a live report.
+pub fn codesign_report_is_unstable(report: &str) -> bool {
+    let report = report.to_ascii_lowercase();
+    report.contains("adhoc") || report.contains("not signed")
+}
+
 /// Run `glass-mcp setup`. macOS-only: everywhere else this fails fast with an actionable
 /// error rather than pretending to do something.
 ///
@@ -63,11 +113,300 @@ pub fn run(non_interactive: bool, launchagent: bool, no_launchagent: bool, addr:
     }
     #[cfg(target_os = "macos")]
     {
-        let _ = (non_interactive, launchagent, no_launchagent, addr);
-        // The interactive grant flow (request Screen Recording + Accessibility, open the
-        // relevant pane, poll for the grant, decide/install the run mode, confirm via
-        // `doctor` + `registration_line`) is not implemented yet — it lands in a follow-on
-        // task. This stub only proves the dispatch wiring and the macOS build.
+        // Step 1: preconditions. Resolve the running binary's own path — used for the
+        // signing-identity warning right below, and later as both the LaunchAgent's
+        // `ProgramArguments[0]` and the registration line's binary path.
+        let exe = std::env::current_exe()
+            .map_err(|e| glass_core::GlassError::Backend(format!("resolving the running binary's path: {e}")))?;
+        macos_impl::warn_if_signing_identity_unstable(&exe);
+
+        match glass_macos::session_state() {
+            glass_macos::SessionState::NoSession => {
+                eprintln!(
+                    "No account is logged in at the console (or it's sitting at the login \
+                     window). glass needs a real GUI login to request permissions and drive \
+                     anything — log in at the console, or (once already granted) run \
+                     glass-mcp as a `gui/{uid}` LaunchAgent instead (see \
+                     docs/running-on-macos.md). Then run `glass-mcp setup` again.",
+                    uid = macos_impl::console_uid(),
+                );
+                return Err(glass_core::GlassError::Backend("setup needs a logged-in console session".into()));
+            }
+            glass_macos::SessionState::Locked => {
+                println!(
+                    "note: the console session is locked/asleep. That doesn't block \
+                     requesting permissions below, but capture/input won't work until it's \
+                     unlocked (`caffeinate -d` keeps the display awake, no sudo needed)."
+                );
+            }
+            glass_macos::SessionState::Unlocked => {}
+        }
+
+        // Step 2: request the two TCC grants, one at a time. `Some((label, instruction))`
+        // for a grant that's still missing once the poll times out; `None` once `granted()`
+        // itself confirms it — never claimed on the user's say-so alone.
+        println!("\nRequesting permissions:");
+        let screen_recording = macos_impl::ensure_granted(
+            "Screen Recording",
+            glass_macos::screen_recording_pane_url(),
+            glass_macos::screen_recording_remedy(),
+            glass_macos::screen_recording_granted,
+            glass_macos::request_screen_recording,
+            true, // needs_relaunch_note: SR only takes effect for this process after a relaunch
+            non_interactive,
+        );
+        let accessibility = macos_impl::ensure_granted(
+            "Accessibility",
+            glass_macos::accessibility_pane_url(),
+            glass_macos::accessibility_remedy(),
+            glass_macos::accessibility_granted,
+            glass_macos::request_accessibility,
+            false,
+            non_interactive,
+        );
+        let pending: Vec<(&'static str, String)> = [screen_recording, accessibility].into_iter().flatten().collect();
+
+        // Step 3: pick the run mode and, for the unattended LaunchAgent, install it.
+        let mode = match run_mode_from_flags(launchagent, no_launchagent) {
+            Some(mode) => mode,
+            None if non_interactive => RunMode::Stdio, // no prompts allowed; least-invasive default
+            None => macos_impl::prompt_run_mode(),
+        };
+        let app_bin = exe.to_string_lossy().into_owned();
+        let addr = addr.unwrap_or_else(|| macos_impl::DEFAULT_ADDR.to_string());
+        match mode {
+            RunMode::Http => macos_impl::install_launch_agent(&app_bin, &addr)?,
+            RunMode::Stdio => println!(
+                "\nNot installing the LaunchAgent (attended/stdio). If one is already loaded \
+                 from a previous run, remove it with: launchctl bootout gui/{}/tech.fixedwidth.glass",
+                macos_impl::console_uid(),
+            ),
+        }
+
+        // Step 4: confirm via `doctor`, print the copy-paste registration line, and — if a
+        // grant is still pending — end on the actionable instruction, exiting non-zero rather
+        // than claiming success.
+        let backend = crate::default_backend(std::env::var("GLASS_BACKEND").ok().as_deref());
+        print!("\n{}", crate::doctor::diagnose(false).render_text(backend));
+        println!("\n{}", registration_line(mode, &app_bin, &addr));
+
+        if pending.is_empty() {
+            Ok(())
+        } else {
+            println!();
+            for (_, instruction) in &pending {
+                println!("{instruction}");
+            }
+            Err(glass_core::GlassError::PermissionDenied {
+                which: pending.iter().map(|(label, _)| *label).collect::<Vec<_>>().join(", "),
+                remedy: "grant the permission(s) above, then run `glass-mcp setup` again".into(),
+            })
+        }
+    }
+}
+
+/// The macOS-only glue behind [`run`]'s grant flow: side-effecting (stdin/stdout, shelling
+/// out to `codesign`/`launchctl`, real TCC calls), unlike the pure helpers above it in this
+/// file. Kept in its own module so its `use` block doesn't have to be repeated per item, and
+/// so it's obvious at a glance which parts of `setup.rs` only build on macOS.
+#[cfg(target_os = "macos")]
+mod macos_impl {
+    use std::io::Write as _;
+    use std::path::Path;
+    use std::process::Command;
+    use std::time::{Duration, Instant};
+
+    use glass_core::{GlassError, Result};
+
+    use super::RunMode;
+
+    /// Default LaunchAgent HTTP bind address — matches the shipped plist template and
+    /// [`super::registration_line`]'s doctest-style examples.
+    pub(super) const DEFAULT_ADDR: &str = "127.0.0.1:7300";
+
+    /// How often [`poll_until`] rechecks a grant, and how long it waits before giving up.
+    const POLL_INTERVAL: Duration = Duration::from_secs(2);
+    const POLL_TIMEOUT: Duration = Duration::from_secs(60);
+
+    /// The embedded LaunchAgent plist template — the same file
+    /// [`super::tests::fill_launch_agent_substitutes_the_app_binary`] and friends check
+    /// against, so a drift between the two breaks the test rather than shipping silently.
+    const PLIST_TEMPLATE: &str = include_str!("../../../packaging/macos/tech.fixedwidth.glass.plist");
+
+    /// The console user's numeric uid, for `gui/<uid>` LaunchAgent target specs and hint
+    /// text. `rustix::process::getuid` is a safe syscall wrapper, so this needs no `unsafe`
+    /// FFI (unlike a raw `libc::getuid()` call).
+    pub(super) fn console_uid() -> u32 {
+        rustix::process::getuid().as_raw()
+    }
+
+    /// Warn (never fail) if `exe`'s bundle placement or signing identity means a TCC grant
+    /// won't survive a rebuild — see [`super::is_inside_app_bundle`] and
+    /// [`super::codesign_report_is_unstable`] for the two checks.
+    pub(super) fn warn_if_signing_identity_unstable(exe: &Path) {
+        if !super::is_inside_app_bundle(exe) {
+            println!(
+                "note: {} isn't inside a *.app/Contents/MacOS bundle — TCC grants are keyed \
+                 to the bundle id + signing identity, so this build won't keep its grant \
+                 across a rebuild; see docs/running-on-macos.md.",
+                exe.display()
+            );
+        }
+        match Command::new("codesign").arg("-dvv").arg(exe).output() {
+            Ok(output) => {
+                let mut report = String::from_utf8_lossy(&output.stdout).into_owned();
+                report.push_str(&String::from_utf8_lossy(&output.stderr));
+                if super::codesign_report_is_unstable(&report) {
+                    println!(
+                        "note: {} is ad hoc or unsigned — a TCC grant won't stick across \
+                         rebuilds; sign it with a stable identity (see \
+                         docs/running-on-macos.md#1-create-a-signing-identity).",
+                        exe.display()
+                    );
+                }
+            }
+            Err(e) => println!(
+                "note: couldn't run `codesign -dvv` on {} ({e}) — skipping the signing-identity check.",
+                exe.display()
+            ),
+        }
+    }
+
+    /// Poll `granted` every `interval` until it returns `true` or `timeout` elapses, calling
+    /// `on_wait` once per unsuccessful check (progress output only — it doesn't affect the
+    /// result). Returns the final read of `granted()`.
+    fn poll_until(granted: impl Fn() -> bool, interval: Duration, timeout: Duration, mut on_wait: impl FnMut()) -> bool {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if granted() {
+                return true;
+            }
+            on_wait();
+            std::thread::sleep(interval);
+        }
+        granted()
+    }
+
+    /// Ask a yes/no question on stdin; any I/O failure (no controlling terminal, EOF, ...)
+    /// answers `false` rather than blocking or panicking.
+    fn prompt_yes_no(question: &str) -> bool {
+        print!("{question} [y/N] ");
+        let _ = std::io::stdout().flush();
+        let mut line = String::new();
+        if std::io::stdin().read_line(&mut line).is_err() {
+            return false;
+        }
+        matches!(line.trim().to_ascii_lowercase().as_str(), "y" | "yes")
+    }
+
+    /// Ask which run mode to use when neither `--launchagent` nor `--no-launchagent` forced
+    /// one; only reached in an interactive run (`--non-interactive` defaults to `Stdio`
+    /// instead of calling this — see `run`). Any I/O failure answers `Stdio`, the
+    /// least-invasive option (nothing installed).
+    pub(super) fn prompt_run_mode() -> RunMode {
+        print!(
+            "\nRun glass-mcp unattended as a LaunchAgent (serve --http, starts at login) \
+             instead of being spawned by your MCP client over stdio? [y/N] "
+        );
+        let _ = std::io::stdout().flush();
+        let mut line = String::new();
+        if std::io::stdin().read_line(&mut line).is_err() {
+            return RunMode::Stdio;
+        }
+        if line.trim().eq_ignore_ascii_case("y") {
+            RunMode::Http
+        } else {
+            RunMode::Stdio
+        }
+    }
+
+    /// Request one TCC grant if it isn't already held: call `request` (pops the consent
+    /// dialog / adds glass to the pane), open the relevant System Settings pane, then poll
+    /// `granted` for up to [`POLL_TIMEOUT`]. Returns `None` the moment `granted()` itself
+    /// reports success (live-rechecked, never assumed); otherwise `Some((label,
+    /// instruction))` naming the still-missing permission and what to do about it.
+    ///
+    /// `needs_relaunch_note` is `true` only for Screen Recording: unlike Accessibility, a
+    /// Screen Recording grant only takes effect for *this* process after it's relaunched, so
+    /// a still-ungranted read at the poll deadline doesn't necessarily mean the user didn't
+    /// act — ask (interactively) or assume (`--non-interactive`, since there's no one to
+    /// ask) that they did, and say so explicitly rather than reporting a plain "not granted".
+    pub(super) fn ensure_granted(
+        label: &'static str,
+        pane_url: &str,
+        remedy: &str,
+        granted: impl Fn() -> bool,
+        request: impl FnOnce() -> bool,
+        needs_relaunch_note: bool,
+        non_interactive: bool,
+    ) -> Option<(&'static str, String)> {
+        if granted() {
+            println!("  \u{2713} {label}: already granted");
+            return None;
+        }
+        if request() {
+            println!("  \u{2713} {label}: granted");
+            return None;
+        }
+        if let Err(e) = glass_macos::open_pane(pane_url) {
+            eprintln!(
+                "  note: couldn't open System Settings automatically ({e}); open Privacy & \
+                 Security > {label} manually."
+            );
+        }
+        let landed = poll_until(&granted, POLL_INTERVAL, POLL_TIMEOUT, || {
+            println!("  waiting for you to enable glass in the {label} pane…");
+        });
+        if landed {
+            println!("  \u{2713} {label}: granted");
+            return None;
+        }
+        if needs_relaunch_note {
+            let acted = non_interactive || prompt_yes_no(&format!("Did you enable {label} in System Settings?"));
+            if acted {
+                let instruction = format!(
+                    "{label} changes take effect after a relaunch — enable glass, then run \
+                     `glass-mcp setup` again."
+                );
+                println!("  {instruction}");
+                return Some((label, instruction));
+            }
+        }
+        let instruction = format!("{label}: not granted — {remedy}, then run `glass-mcp setup` again.");
+        println!("  \u{2717} {instruction}");
+        Some((label, instruction))
+    }
+
+    /// Write the filled LaunchAgent plist to `~/Library/LaunchAgents/tech.fixedwidth.glass.plist`
+    /// (creating it and `~/Library/Logs/GlassMcp/` if needed) and load it with `launchctl
+    /// bootstrap gui/<uid>`.
+    pub(super) fn install_launch_agent(app_bin: &str, addr: &str) -> Result<()> {
+        let home = std::env::var("HOME")
+            .map_err(|_| GlassError::Backend("HOME is not set; can't resolve ~/Library/LaunchAgents".into()))?;
+        let launch_agents_dir = Path::new(&home).join("Library/LaunchAgents");
+        let logs_dir = Path::new(&home).join("Library/Logs/GlassMcp");
+        std::fs::create_dir_all(&launch_agents_dir)?;
+        std::fs::create_dir_all(&logs_dir)?;
+
+        let filled = super::fill_launch_agent(PLIST_TEMPLATE, app_bin, addr, &home);
+        let plist_path = launch_agents_dir.join("tech.fixedwidth.glass.plist");
+        std::fs::write(&plist_path, filled)?;
+
+        let uid = console_uid();
+        let status = Command::new("launchctl")
+            .arg("bootstrap")
+            .arg(format!("gui/{uid}"))
+            .arg(&plist_path)
+            .status()
+            .map_err(|e| GlassError::Backend(format!("launchctl bootstrap: {e}")))?;
+        if !status.success() {
+            return Err(GlassError::Backend(format!(
+                "launchctl bootstrap exited {status} — is it already loaded? `launchctl \
+                 bootout gui/{uid}/tech.fixedwidth.glass` first, or pass --no-launchagent to \
+                 skip installing it."
+            )));
+        }
+        println!("\n  \u{2713} installed + started gui/{uid}/tech.fixedwidth.glass ({})", plist_path.display());
         Ok(())
     }
 }
@@ -130,6 +469,84 @@ mod tests {
         assert!(filled.contains("/Users/alice/Library/Logs/GlassMcp/stdout.log"));
         assert!(filled.contains("/Users/alice/Library/Logs/GlassMcp/stderr.log"));
         assert!(!filled.contains("/Users/YOU"));
+    }
+
+    // --- run_mode_from_flags -------------------------------------------------------------
+
+    #[test]
+    fn launchagent_flag_forces_http() {
+        assert_eq!(run_mode_from_flags(true, false), Some(RunMode::Http));
+    }
+
+    #[test]
+    fn no_launchagent_flag_forces_stdio() {
+        assert_eq!(run_mode_from_flags(false, true), Some(RunMode::Stdio));
+    }
+
+    #[test]
+    fn neither_flag_leaves_it_unresolved() {
+        assert_eq!(run_mode_from_flags(false, false), None);
+    }
+
+    // --- is_inside_app_bundle -------------------------------------------------------------
+
+    #[test]
+    fn recognizes_a_real_app_bundle_layout() {
+        assert!(is_inside_app_bundle(Path::new("/Applications/GlassMcp.app/Contents/MacOS/glass-mcp")));
+    }
+
+    #[test]
+    fn recognizes_a_non_default_install_location() {
+        assert!(is_inside_app_bundle(Path::new("/opt/GlassMcp.app/Contents/MacOS/glass-mcp")));
+    }
+
+    #[test]
+    fn rejects_a_bare_cargo_build_output_path() {
+        assert!(!is_inside_app_bundle(Path::new("/home/mpd/glass/target/release/glass-mcp")));
+    }
+
+    #[test]
+    fn rejects_a_relative_or_too_shallow_path() {
+        assert!(!is_inside_app_bundle(Path::new("glass-mcp")));
+        assert!(!is_inside_app_bundle(Path::new("MacOS/glass-mcp")));
+    }
+
+    #[test]
+    fn rejects_wrong_cased_bundle_directories() {
+        // "Contents"/"MacOS" is exact Apple bundle casing; a near-miss shouldn't pass.
+        assert!(!is_inside_app_bundle(Path::new("/Applications/GlassMcp.app/contents/macos/glass-mcp")));
+    }
+
+    // --- codesign_report_is_unstable ------------------------------------------------------
+
+    #[test]
+    fn adhoc_signature_is_unstable() {
+        let report = "Executable=/Applications/GlassMcp.app/Contents/MacOS/glass-mcp\n\
+                       Identifier=tech.fixedwidth.glass\n\
+                       Format=Mach-O thin (arm64)\n\
+                       Signature=adhoc\n";
+        assert!(codesign_report_is_unstable(report));
+    }
+
+    #[test]
+    fn unsigned_binary_is_unstable() {
+        let report = "glass-mcp: code object is not signed at all\n";
+        assert!(codesign_report_is_unstable(report));
+    }
+
+    #[test]
+    fn a_stable_identity_is_not_flagged() {
+        // A real (non-adhoc) code-signing identity's report never contains "adhoc" or "not
+        // signed" — this is the shape `codesign -dvv` produces for a self-signed cert made
+        // via Keychain Access (see docs/running-on-macos.md#1-create-a-signing-identity).
+        let report = "Executable=/Applications/GlassMcp.app/Contents/MacOS/glass-mcp\n\
+                       Identifier=tech.fixedwidth.glass\n\
+                       Format=Mach-O thin (arm64)\n\
+                       CodeDirectory v=20400 size=411 flags=0x0(none) hashes=8+3 location=embedded\n\
+                       Signature=DER encoded\n\
+                       Authority=glass-mcp signing\n\
+                       TeamIdentifier=not set\n";
+        assert!(!codesign_report_is_unstable(report));
     }
 
     // --- run (non-macOS stub) -----------------------------------------------------------

--- a/crates/glass-mcp/src/setup.rs
+++ b/crates/glass-mcp/src/setup.rs
@@ -40,16 +40,54 @@ pub fn registration_line(mode: RunMode, app_bin: &str, addr: &str) -> String {
     }
 }
 
+/// The three placeholder literals the shipped plist template
+/// (`packaging/macos/tech.fixedwidth.glass.plist`) carries and that [`fill_launch_agent`]
+/// substitutes. Named once so [`surviving_placeholders`] can detect a drift between these and
+/// the template without re-typing the literals.
+const APP_BIN_PLACEHOLDER: &str = "/Applications/GlassMcp.app/Contents/MacOS/glass-mcp";
+const ADDR_PLACEHOLDER: &str = "127.0.0.1:7300";
+const HOME_PLACEHOLDER: &str = "/Users/YOU";
+
+/// The three runtime values [`fill_launch_agent`] substitutes into the plist template — the
+/// app-binary path, the HTTP bind address, and the home directory the two log paths are rooted
+/// under. A named holder rather than three adjacent `&str` parameters, so a caller can't
+/// transpose two of them into a plausible-but-wrong plist without a field-name mismatch.
+#[derive(Clone, Copy, Debug)]
+pub struct LaunchAgentFields<'a> {
+    /// Absolute path to the `.app`'s `glass-mcp` binary (`ProgramArguments[0]`).
+    pub app_bin: &'a str,
+    /// The HTTP bind address the LaunchAgent serves on.
+    pub addr: &'a str,
+    /// The home directory the two log paths (`~/Library/Logs/GlassMcp/*.log`) live under.
+    pub home: &'a str,
+}
+
 /// Fill the LaunchAgent plist template (`packaging/macos/tech.fixedwidth.glass.plist`):
 /// substitute the app-binary path, the HTTP bind address, and the home directory the two
 /// log paths are rooted under. `template` is the shipped plist text; returns the
 /// ready-to-write plist. Pure string substitution — no IO, so the caller decides where (or
-/// whether) to write the result.
-pub fn fill_launch_agent(template: &str, app_bin: &str, addr: &str, home: &str) -> String {
+/// whether) to write the result (and can run [`surviving_placeholders`] on it first).
+pub fn fill_launch_agent(template: &str, fields: LaunchAgentFields<'_>) -> String {
     template
-        .replace("/Applications/GlassMcp.app/Contents/MacOS/glass-mcp", app_bin)
-        .replace("127.0.0.1:7300", addr)
-        .replace("/Users/YOU", home)
+        .replace(APP_BIN_PLACEHOLDER, fields.app_bin)
+        .replace(ADDR_PLACEHOLDER, fields.addr)
+        .replace(HOME_PLACEHOLDER, fields.home)
+}
+
+/// The template placeholders that survived a [`fill_launch_agent`] — non-empty only when a
+/// template literal drifted out of sync with the strings `fill_launch_agent` replaces, so a
+/// `.replace` silently no-oped and the filled plist still points at a placeholder. A field
+/// whose value equals its own placeholder (the default addr `127.0.0.1:7300`, or an app
+/// installed at the default `/Applications/GlassMcp.app`) is legitimate, not a drift, and is
+/// excluded — so this never false-flags a default configuration. Pure; the
+/// [`RunMode::Http`] install path turns a non-empty result into a fail-closed error rather
+/// than writing a broken plist.
+pub fn surviving_placeholders(filled: &str, fields: LaunchAgentFields<'_>) -> Vec<&'static str> {
+    [(APP_BIN_PLACEHOLDER, fields.app_bin), (ADDR_PLACEHOLDER, fields.addr), (HOME_PLACEHOLDER, fields.home)]
+        .into_iter()
+        .filter(|&(placeholder, value)| value != placeholder && filled.contains(placeholder))
+        .map(|(placeholder, _)| placeholder)
+        .collect()
 }
 
 /// Decide the run mode from the `--launchagent`/`--no-launchagent` flags alone, without
@@ -58,7 +96,12 @@ pub fn fill_launch_agent(template: &str, app_bin: &str, addr: &str, home: &str) 
 /// same Linux-testable shape as [`registration_line`]/[`fill_launch_agent`] above; the actual
 /// prompt (when both flags are absent and the run is interactive) lives in the macOS-only
 /// body of [`run`], since reading stdin isn't something to unit-test here.
+///
+/// Precedence: `--launchagent` wins over `--no-launchagent`. Clap's `conflicts_with` makes the
+/// `(true, true)` combination unreachable from the CLI, so the `debug_assert!` documents that
+/// invariant and trips in debug builds if a future non-clap caller violates it.
 pub fn run_mode_from_flags(launchagent: bool, no_launchagent: bool) -> Option<RunMode> {
+    debug_assert!(!(launchagent && no_launchagent), "clap conflicts_with should prevent --launchagent + --no-launchagent");
     if launchagent {
         Some(RunMode::Http)
     } else if no_launchagent {
@@ -98,14 +141,30 @@ pub fn codesign_report_is_unstable(report: &str) -> bool {
     report.contains("adhoc") || report.contains("not signed")
 }
 
+/// The parsed `setup` invocation, forwarded from the `Setup` clap variant (see `cli.rs`). A
+/// struct rather than four positional arguments to [`run`] so the three adjacent `bool`s can't
+/// be transposed at the call site without a field-name mismatch.
+#[derive(Debug, Clone)]
+pub struct SetupArgs {
+    /// Fail/assume-a-default instead of prompting (scripting/CI).
+    pub non_interactive: bool,
+    /// Force the `gui/<uid>` LaunchAgent (unattended `serve --http`) instead of asking.
+    pub launchagent: bool,
+    /// Force stdio (install nothing) instead of asking.
+    pub no_launchagent: bool,
+    /// Override the LaunchAgent's HTTP bind address (defaults to `127.0.0.1:7300`).
+    pub addr: Option<String>,
+}
+
 /// Run `glass-mcp setup`. macOS-only: everywhere else this fails fast with an actionable
 /// error rather than pretending to do something.
 ///
-/// The flags mirror the `Setup` clap variant verbatim (see `cli.rs`) so the macOS body can
+/// The fields mirror the `Setup` clap variant verbatim (see `cli.rs`) so the macOS body can
 /// use them without re-threading the signature: `non_interactive` fails instead of
 /// prompting (scripting/CI); `launchagent`/`no_launchagent` force the run mode instead of
 /// asking; `addr` overrides the LaunchAgent's HTTP bind address.
-pub fn run(non_interactive: bool, launchagent: bool, no_launchagent: bool, addr: Option<String>) -> Result<()> {
+pub fn run(args: SetupArgs) -> Result<()> {
+    let SetupArgs { non_interactive, launchagent, no_launchagent, addr } = args;
     #[cfg(not(target_os = "macos"))]
     {
         let _ = (non_interactive, launchagent, no_launchagent, addr);
@@ -128,7 +187,7 @@ pub fn run(non_interactive: bool, launchagent: bool, no_launchagent: bool, addr:
                      anything — log in at the console, or (once already granted) run \
                      glass-mcp as a `gui/{uid}` LaunchAgent instead (see \
                      docs/running-on-macos.md). Then run `glass-mcp setup` again.",
-                    uid = macos_impl::console_uid(),
+                    uid = macos_impl::self_uid(),
                 );
                 return Err(glass_core::GlassError::Backend("setup needs a logged-in console session".into()));
             }
@@ -164,7 +223,7 @@ pub fn run(non_interactive: bool, launchagent: bool, no_launchagent: bool, addr:
             false,
             non_interactive,
         );
-        let pending: Vec<(&'static str, String)> = [screen_recording, accessibility].into_iter().flatten().collect();
+        let mut pending: Vec<(&'static str, String)> = [screen_recording, accessibility].into_iter().flatten().collect();
 
         // Step 3: pick the run mode and, for the unattended LaunchAgent, install it.
         let mode = match run_mode_from_flags(launchagent, no_launchagent) {
@@ -175,11 +234,18 @@ pub fn run(non_interactive: bool, launchagent: bool, no_launchagent: bool, addr:
         let app_bin = exe.to_string_lossy().into_owned();
         let addr = addr.unwrap_or_else(|| macos_impl::DEFAULT_ADDR.to_string());
         match mode {
-            RunMode::Http => macos_impl::install_launch_agent(&app_bin, &addr)?,
+            // A LaunchAgent that loaded but isn't yet serving is an outstanding action, not a
+            // success: fold it into the same `pending` / non-zero-exit path a missing grant
+            // uses rather than printing a false "installed + started" (no-silent-success).
+            RunMode::Http => {
+                if let Some(item) = macos_impl::install_launch_agent(&app_bin, &addr)? {
+                    pending.push(item);
+                }
+            }
             RunMode::Stdio => println!(
                 "\nNot installing the LaunchAgent (attended/stdio). If one is already loaded \
                  from a previous run, remove it with: launchctl bootout gui/{}/tech.fixedwidth.glass",
-                macos_impl::console_uid(),
+                macos_impl::self_uid(),
             ),
         }
 
@@ -212,6 +278,7 @@ pub fn run(non_interactive: bool, launchagent: bool, no_launchagent: bool, addr:
 #[cfg(target_os = "macos")]
 mod macos_impl {
     use std::io::Write as _;
+    use std::net::{TcpStream, ToSocketAddrs};
     use std::path::Path;
     use std::process::Command;
     use std::time::{Duration, Instant};
@@ -228,15 +295,23 @@ mod macos_impl {
     const POLL_INTERVAL: Duration = Duration::from_secs(2);
     const POLL_TIMEOUT: Duration = Duration::from_secs(60);
 
+    /// Liveness-probe budget for [`install_launch_agent`]: launchd needs a beat to exec the
+    /// job, so give it ~5s of ~500ms-apart TCP connects before deciding it isn't serving.
+    const LIVENESS_CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
+    const LIVENESS_POLL_INTERVAL: Duration = Duration::from_millis(500);
+    const LIVENESS_TIMEOUT: Duration = Duration::from_secs(5);
+
     /// The embedded LaunchAgent plist template — the same file
     /// [`super::tests::fill_launch_agent_substitutes_the_app_binary`] and friends check
     /// against, so a drift between the two breaks the test rather than shipping silently.
     const PLIST_TEMPLATE: &str = include_str!("../../../packaging/macos/tech.fixedwidth.glass.plist");
 
-    /// The console user's numeric uid, for `gui/<uid>` LaunchAgent target specs and hint
-    /// text. `rustix::process::getuid` is a safe syscall wrapper, so this needs no `unsafe`
-    /// FFI (unlike a raw `libc::getuid()` call).
-    pub(super) fn console_uid() -> u32 {
+    /// This process's own numeric uid, via `rustix::process::getuid` (a safe syscall wrapper,
+    /// so no `unsafe` FFI, unlike a raw `libc::getuid()` call). Used for `gui/<uid>` LaunchAgent
+    /// target specs and hint text. This is *not* an OS-verified console-session owner — just the
+    /// running process's uid. `setup` is always run directly by the console user with no `sudo`,
+    /// so under that assumption it is the correct `gui/<uid>` target.
+    pub(super) fn self_uid() -> u32 {
         rustix::process::getuid().as_raw()
     }
 
@@ -368,7 +443,7 @@ mod macos_impl {
                     "{label} changes take effect after a relaunch — enable glass, then run \
                      `glass-mcp setup` again."
                 );
-                println!("  {instruction}");
+                println!("  \u{2717} {instruction}");
                 return Some((label, instruction));
             }
         }
@@ -378,9 +453,15 @@ mod macos_impl {
     }
 
     /// Write the filled LaunchAgent plist to `~/Library/LaunchAgents/tech.fixedwidth.glass.plist`
-    /// (creating it and `~/Library/Logs/GlassMcp/` if needed) and load it with `launchctl
-    /// bootstrap gui/<uid>`.
-    pub(super) fn install_launch_agent(app_bin: &str, addr: &str) -> Result<()> {
+    /// (creating it and `~/Library/Logs/GlassMcp/` if needed), (re)load it with `launchctl
+    /// bootstrap gui/<uid>`, and confirm it's actually serving before reporting success.
+    ///
+    /// Returns `Ok(None)` once a bounded TCP connect to `addr` confirms the agent is accepting
+    /// connections; `Ok(Some((label, instruction)))` when the job loaded but isn't serving, so
+    /// the caller can fold it into the same pending / non-zero-exit path a missing grant uses
+    /// (never a false "installed + started"); `Err` for a hard failure — no `HOME`, an
+    /// un-writable plist, a drifted template, or `bootstrap` itself erroring.
+    pub(super) fn install_launch_agent(app_bin: &str, addr: &str) -> Result<Option<(&'static str, String)>> {
         let home = std::env::var("HOME")
             .map_err(|_| GlassError::Backend("HOME is not set; can't resolve ~/Library/LaunchAgents".into()))?;
         let launch_agents_dir = Path::new(&home).join("Library/LaunchAgents");
@@ -388,11 +469,29 @@ mod macos_impl {
         std::fs::create_dir_all(&launch_agents_dir)?;
         std::fs::create_dir_all(&logs_dir)?;
 
-        let filled = super::fill_launch_agent(PLIST_TEMPLATE, app_bin, addr, &home);
+        let fields = super::LaunchAgentFields { app_bin, addr, home: &home };
+        let filled = super::fill_launch_agent(PLIST_TEMPLATE, fields);
+        // Fail closed on a template drift: if a placeholder survived substitution, the plist is
+        // broken (points at `/Users/YOU` etc.) — error rather than write it.
+        let survivors = super::surviving_placeholders(&filled, fields);
+        if !survivors.is_empty() {
+            return Err(GlassError::Backend(format!(
+                "LaunchAgent plist still contains template placeholder(s) {survivors:?} after \
+                 substitution — packaging/macos/tech.fixedwidth.glass.plist and setup.rs have \
+                 drifted; refusing to write a broken plist."
+            )));
+        }
         let plist_path = launch_agents_dir.join("tech.fixedwidth.glass.plist");
         std::fs::write(&plist_path, filled)?;
 
-        let uid = console_uid();
+        let uid = self_uid();
+        let target = format!("gui/{uid}/tech.fixedwidth.glass");
+        // Idempotent (re)load. `bootstrap` fails with "already loaded" on a second run — which
+        // the flow itself asks for, since a Screen Recording grant only takes effect after a
+        // relaunch — and wouldn't pick up an `--addr` change. Unload first, ignoring the exit
+        // status (a harmless no-op when nothing is loaded), so every re-run converges.
+        let _ = Command::new("launchctl").arg("bootout").arg(&target).status();
+
         let status = Command::new("launchctl")
             .arg("bootstrap")
             .arg(format!("gui/{uid}"))
@@ -401,13 +500,43 @@ mod macos_impl {
             .map_err(|e| GlassError::Backend(format!("launchctl bootstrap: {e}")))?;
         if !status.success() {
             return Err(GlassError::Backend(format!(
-                "launchctl bootstrap exited {status} — is it already loaded? `launchctl \
-                 bootout gui/{uid}/tech.fixedwidth.glass` first, or pass --no-launchagent to \
-                 skip installing it."
+                "launchctl bootstrap exited {status} — try `launchctl bootout {target}` then \
+                 re-run, or pass --no-launchagent to skip installing it."
             )));
         }
-        println!("\n  \u{2713} installed + started gui/{uid}/tech.fixedwidth.glass ({})", plist_path.display());
-        Ok(())
+
+        // `bootstrap` succeeding only means launchd accepted the job spec, not that the process
+        // came up serving: a port clash on `--addr` crash-loops under `KeepAlive=true` yet
+        // bootstrap still returns success. Confirm real liveness before claiming success.
+        if launch_agent_is_serving(addr) {
+            println!("\n  \u{2713} installed + started {target} ({})", plist_path.display());
+            Ok(None)
+        } else {
+            let instruction = format!(
+                "LaunchAgent {target} loaded but isn't accepting connections on {addr} yet — \
+                 check ~/Library/Logs/GlassMcp/stderr.log (a port clash on --addr crash-loops \
+                 under KeepAlive), resolve it, then run `glass-mcp setup` again."
+            );
+            println!("\n  \u{2717} {instruction}");
+            Ok(Some(("LaunchAgent", instruction)))
+        }
+    }
+
+    /// Bounded liveness probe for a just-bootstrapped agent: TCP-connect to `addr` on a
+    /// [`LIVENESS_POLL_INTERVAL`] cadence up to [`LIVENESS_TIMEOUT`], returning `true` on the
+    /// first successful connect. An `addr` that doesn't resolve to a socket address yields
+    /// `false` — we can't verify it, so it's treated as not-yet-serving, never a silent
+    /// success.
+    fn launch_agent_is_serving(addr: &str) -> bool {
+        let Some(sock) = addr.to_socket_addrs().ok().and_then(|mut addrs| addrs.next()) else {
+            return false;
+        };
+        poll_until(
+            || TcpStream::connect_timeout(&sock, LIVENESS_CONNECT_TIMEOUT).is_ok(),
+            LIVENESS_POLL_INTERVAL,
+            LIVENESS_TIMEOUT,
+            || {},
+        )
     }
 }
 
@@ -445,30 +574,74 @@ mod tests {
 
     #[test]
     fn fill_launch_agent_substitutes_the_app_binary() {
-        let filled = fill_launch_agent(TEMPLATE, "/Applications/GlassMcp.app/Contents/MacOS/glass-mcp", "127.0.0.1:7300", "/Users/alice");
+        let filled = fill_launch_agent(
+            TEMPLATE,
+            LaunchAgentFields { app_bin: "/Applications/GlassMcp.app/Contents/MacOS/glass-mcp", addr: "127.0.0.1:7300", home: "/Users/alice" },
+        );
         assert!(filled.contains("/Applications/GlassMcp.app/Contents/MacOS/glass-mcp"));
     }
 
     #[test]
     fn fill_launch_agent_substitutes_a_custom_app_binary() {
-        let filled = fill_launch_agent(TEMPLATE, "/opt/glass/glass-mcp", "127.0.0.1:7300", "/Users/alice");
+        let filled = fill_launch_agent(
+            TEMPLATE,
+            LaunchAgentFields { app_bin: "/opt/glass/glass-mcp", addr: "127.0.0.1:7300", home: "/Users/alice" },
+        );
         assert!(filled.contains("/opt/glass/glass-mcp"));
         assert!(!filled.contains("/Applications/GlassMcp.app"));
     }
 
     #[test]
     fn fill_launch_agent_substitutes_the_addr() {
-        let filled = fill_launch_agent(TEMPLATE, "/opt/glass/glass-mcp", "0.0.0.0:9999", "/Users/alice");
+        let filled = fill_launch_agent(
+            TEMPLATE,
+            LaunchAgentFields { app_bin: "/opt/glass/glass-mcp", addr: "0.0.0.0:9999", home: "/Users/alice" },
+        );
         assert!(filled.contains("0.0.0.0:9999"));
         assert!(!filled.contains("127.0.0.1:7300"));
     }
 
     #[test]
     fn fill_launch_agent_substitutes_the_home_in_both_log_paths() {
-        let filled = fill_launch_agent(TEMPLATE, "/opt/glass/glass-mcp", "127.0.0.1:7300", "/Users/alice");
+        let filled = fill_launch_agent(
+            TEMPLATE,
+            LaunchAgentFields { app_bin: "/opt/glass/glass-mcp", addr: "127.0.0.1:7300", home: "/Users/alice" },
+        );
         assert!(filled.contains("/Users/alice/Library/Logs/GlassMcp/stdout.log"));
         assert!(filled.contains("/Users/alice/Library/Logs/GlassMcp/stderr.log"));
         assert!(!filled.contains("/Users/YOU"));
+    }
+
+    // --- surviving_placeholders (template-drift guard) -----------------------------------
+
+    #[test]
+    fn a_fully_substituted_plist_has_no_surviving_placeholders() {
+        let fields = LaunchAgentFields { app_bin: "/opt/glass/glass-mcp", addr: "0.0.0.0:9999", home: "/Users/alice" };
+        let filled = fill_launch_agent(TEMPLATE, fields);
+        assert!(surviving_placeholders(&filled, fields).is_empty());
+    }
+
+    #[test]
+    fn default_addr_and_app_path_are_not_reported_as_drift() {
+        // The default addr equals its placeholder, and a default-location install's app path
+        // contains the app-path placeholder — both legitimate, neither a drift.
+        let fields = LaunchAgentFields {
+            app_bin: "/Applications/GlassMcp.app/Contents/MacOS/glass-mcp",
+            addr: "127.0.0.1:7300",
+            home: "/Users/alice",
+        };
+        let filled = fill_launch_agent(TEMPLATE, fields);
+        assert!(surviving_placeholders(&filled, fields).is_empty());
+    }
+
+    #[test]
+    fn an_unsubstituted_placeholder_is_reported() {
+        // A drifted template whose home placeholder `fill_launch_agent` no longer matches: the
+        // filled text still carries `/Users/YOU` though a real home (`/Users/alice`) was asked
+        // for, so the guard must flag it.
+        let fields = LaunchAgentFields { app_bin: "/opt/glass/glass-mcp", addr: "0.0.0.0:9999", home: "/Users/alice" };
+        let drifted = "<string>/Users/YOU/Library/Logs/GlassMcp/stdout.log</string>";
+        assert_eq!(surviving_placeholders(drifted, fields), vec!["/Users/YOU"]);
     }
 
     // --- run_mode_from_flags -------------------------------------------------------------
@@ -554,7 +727,8 @@ mod tests {
     #[test]
     #[cfg(not(target_os = "macos"))]
     fn run_fails_fast_off_macos() {
-        let err = run(false, false, false, None).expect_err("setup must refuse to run off macOS");
+        let err = run(SetupArgs { non_interactive: false, launchagent: false, no_launchagent: false, addr: None })
+            .expect_err("setup must refuse to run off macOS");
         assert!(matches!(err, glass_core::GlassError::Backend(_)));
         assert!(err.to_string().contains("macOS-only"));
     }

--- a/docs/running-on-macos.md
+++ b/docs/running-on-macos.md
@@ -62,10 +62,13 @@ running an unreleased checkout) — end users will get a notarized, pre-signed
 
 ### CLI (headless boxes, or scripting the setup)
 
-The GUI flow above is the simplest when you're sitting at the Mac. For a box
-you're driving over SSH with no one at the keyboard, the same identity can be
-built non-interactively from `openssl` + `security`, landing in a **dedicated
-keychain** (so it never touches your login keychain):
+The GUI flow above is the simplest when you're sitting at the Mac, and it
+establishes the code-signing trust for you. The same identity can also be
+**scripted** with `openssl` + `security` into a **dedicated keychain** (so it
+never touches your login keychain) — useful when you're driving a box over SSH.
+This is *not* fully turnkey-headless, though: the final trust step (step 3 below)
+triggers a one-time authorization prompt, so plan for either a console you can
+click once or the admin-domain / pre-trusted-cert variant noted there.
 
 ```bash
 KEYCHAIN="$HOME/Library/Keychains/glass-signing.keychain-db"
@@ -107,6 +110,17 @@ security import "$WORKDIR/cert.p12" -k "$KEYCHAIN" -P "$KEYCHAIN_PASSWORD" \
 security set-key-partition-list -S apple-tool:,apple:,codesign: -s \
   -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
 
+# 3. Trust the cert for code signing. Importing the key pair is NOT enough on its
+#    own: until it's trusted, `security find-identity -p codesigning` reports "0
+#    valid identities" and `codesign -s "glass-mcp signing"` fails with "no identity
+#    found". This step is the one that is NOT headless — it triggers an authorization
+#    prompt, and on a box with no console it fails with "SecTrustSettingsSetTrust-
+#    Settings: The authorization was denied since no user interaction was possible."
+#    So run it where you can click once (user trust domain, below), or on a truly
+#    headless/CI box use the admin domain (`sudo security add-trusted-cert -d …`), or
+#    start from a cert already trusted for code signing.
+security add-trusted-cert -p codeSign -k "$KEYCHAIN" "$WORKDIR/cert.pem"
+
 rm -rf "$WORKDIR"
 ```
 
@@ -125,10 +139,13 @@ security find-identity -v -p codesigning "$KEYCHAIN"
 codesign -dvv target/macos-app/GlassMcp.app   # want NO "adhoc" / "not signed"
 ```
 
-(The "Troubleshooting: headless / SSH setup" section further down covers the
-`errSecInternalComponent` you'll hit if the keychain is locked when `codesign`
-runs.) If `codesign` can't find or use the identity, fall back to the GUI method
-above — either way this is a one-time step.
+If `find-identity -p codesigning` reports **"0 valid identities"**, the trust step
+(step 3) didn't take — its prompt was denied or skipped; re-run it where you can
+authorize it, or use the admin-domain variant. (The "Troubleshooting: headless /
+SSH setup" section further down covers the `errSecInternalComponent` you'll hit if
+the keychain is locked when `codesign` runs.) If `codesign` still can't find or use
+the identity, fall back to the GUI method above — it establishes the trust for you,
+and either way this is a one-time step.
 
 ## 2. Build and sign the app
 

--- a/docs/running-on-macos.md
+++ b/docs/running-on-macos.md
@@ -9,6 +9,16 @@ Running glass on a macOS host.
 - glass drives apps in the **logged-in Aqua session** (the real desktop, not a
   headless framebuffer) and captures via ScreenCaptureKit / injects input via
   CGEvent — both gated by **macOS's privacy permissions (TCC)**, covered below.
+- **Building from source needs the Xcode Command Line Tools:**
+
+  ```bash
+  xcode-select --install
+  ```
+
+  The `objc2-*` crates that bind Cocoa/CoreGraphics/CoreFoundation need the macOS SDK
+  and `clang` the CLT provides at their build-time link step; without it, `cargo build`
+  fails there. (There's no prebuilt macOS binary yet, so building from source is the
+  only path today — see [Install](../README.md#install) in the main README.)
 
 ## The permission model, in short
 
@@ -29,16 +39,20 @@ code-signing certificate. That has two consequences that shape everything below:
   signed app + LaunchAgent rather than a plain binary you `ssh` in and run.
 
 So the setup is: create a stable signing identity once, build+sign the app with
-it, grant it Screen Recording + Accessibility once via System Settings, then run
-it as a LaunchAgent from then on — rebuilds and restarts never need the dialog
-again.
+it, then run `glass-mcp setup` — it walks you through granting Screen Recording +
+Accessibility and installs whichever run integration you want. From then on,
+rebuilds and restarts never need the dialog again.
 
 ## 1. Create a signing identity
 
 Any code-signing identity works — it doesn't need to be trusted by Apple or tied
 to an Apple Developer account (Developer ID / notarization only matter for
 Gatekeeper-distributing an app to *other* people, not for TCC grants on your own
-machine). The simplest way to make one:
+machine). **This step is only for building from source** (contributors, or
+running an unreleased checkout) — end users will get a notarized, pre-signed
+`.app` in a later release and won't need a signing identity of their own at all.
+
+### GUI (simplest, when you have a keyboard in front of you)
 
 1. Open **Keychain Access**.
 2. Menu bar → **Keychain Access → Certificate Assistant → Create a Certificate…**
@@ -46,10 +60,75 @@ machine). The simplest way to make one:
    Signed Root**; **Certificate Type: Code Signing**.
 4. Click **Create**. It lands in your login keychain, ready for `codesign -s`.
 
-(For a headless box with no one at the keyboard, the same identity can be created
-entirely from the command line into a dedicated keychain with `security
-create-keychain` + `security import`; the interactive Keychain Access flow above
-is simpler when you have a GUI session to run it in.)
+### CLI (headless boxes, or scripting the setup)
+
+The GUI flow above is the simplest when you're sitting at the Mac. For a box
+you're driving over SSH with no one at the keyboard, the same identity can be
+built non-interactively from `openssl` + `security`, landing in a **dedicated
+keychain** (so it never touches your login keychain):
+
+```bash
+KEYCHAIN="$HOME/Library/Keychains/glass-signing.keychain-db"
+KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"   # only unlocks this one keychain
+WORKDIR="$(mktemp -d)"
+
+# 1. A self-signed cert carrying the Code Signing extended key usage codesign
+#    requires. Extensions come from a -config file (not the newer -addext flag),
+#    so this works with both real OpenSSL and the LibreSSL macOS ships as
+#    /usr/bin/openssl.
+cat > "$WORKDIR/codesign.cnf" <<'EOF'
+[req]
+distinguished_name = dn
+x509_extensions = v3_req
+prompt = no
+
+[dn]
+CN = glass-mcp signing
+
+[v3_req]
+basicConstraints = critical, CA:FALSE
+keyUsage = critical, digitalSignature
+extendedKeyUsage = critical, codeSigning
+EOF
+openssl req -x509 -newkey rsa:2048 -sha256 -days 3650 -nodes \
+  -keyout "$WORKDIR/key.pem" -out "$WORKDIR/cert.pem" \
+  -subj "/CN=glass-mcp signing" -config "$WORKDIR/codesign.cnf"
+
+# 2. Bundle it as a PKCS#12 and hand it to a fresh keychain.
+openssl pkcs12 -export -out "$WORKDIR/cert.p12" \
+  -inkey "$WORKDIR/key.pem" -in "$WORKDIR/cert.pem" -passout "pass:$KEYCHAIN_PASSWORD"
+
+security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+security import "$WORKDIR/cert.p12" -k "$KEYCHAIN" -P "$KEYCHAIN_PASSWORD" \
+  -T /usr/bin/codesign -T /usr/bin/security
+# Since macOS Sierra, codesign also needs this explicit ACL grant, or it hits a
+# keychain-access prompt with no one there to click it:
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s \
+  -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+
+rm -rf "$WORKDIR"
+```
+
+`build-app.sh` takes the keychain explicitly (`--keychain`), so nothing needs to
+be added to the default keychain search list:
+
+```bash
+security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"   # each new shell/SSH session
+./packaging/macos/build-app.sh --identity "glass-mcp signing" --keychain "$KEYCHAIN"
+```
+
+Verify the identity landed and is usable before relying on it:
+
+```bash
+security find-identity -v -p codesigning "$KEYCHAIN"
+codesign -dvv target/macos-app/GlassMcp.app   # want NO "adhoc" / "not signed"
+```
+
+(The "Troubleshooting: headless / SSH setup" section further down covers the
+`errSecInternalComponent` you'll hit if the keychain is locked when `codesign`
+runs.) If `codesign` can't find or use the identity, fall back to the GUI method
+above — either way this is a one-time step.
 
 ## 2. Build and sign the app
 
@@ -66,34 +145,69 @@ overrides). Confirm the signature:
 codesign -dv target/macos-app/GlassMcp.app
 ```
 
-## 3. Grant Screen Recording + Accessibility
+## 3. Run `glass-mcp setup`
 
-`glass-mcp doctor` only *checks* grant status — it never triggers the OS consent
-dialogs (that's deliberate: a diagnostic shouldn't pop dialogs). The dialogs
-appear the first time glass actually **drives** something, so register the
-signed binary with your agent and ask it to do something:
-
-```bash
-claude mcp add glass --scope user -- \
-  "$(pwd)/target/macos-app/GlassMcp.app/Contents/MacOS/glass-mcp"
-```
-
-Then, from your agent: *"Use glass to launch TextEdit and take a screenshot."*
-The first capture attempt prompts for **Screen Recording**; the first click or
-keystroke prompts for **Accessibility**. Grant both in **System Settings →
-Privacy & Security → Screen Recording** and **→ Accessibility** (add `GlassMcp`
-if it isn't listed yet, or toggle it on if it is), then ask your agent to try
-again. Confirm both stuck:
+`build-app.sh` produces a signed bundle but doesn't touch permissions or register
+anything with an agent — `glass-mcp setup` is the guided first-run that does the
+rest: it requests both TCC grants, installs (or skips) the run integration, and
+confirms everything via `doctor`.
 
 ```bash
-target/macos-app/GlassMcp.app/Contents/MacOS/glass-mcp doctor
+target/macos-app/GlassMcp.app/Contents/MacOS/glass-mcp setup
 ```
 
-You want the `[macos]` section all `✓`.
+What it does, in order:
 
-As long as you keep signing with this same identity and bundle id, this is a
+1. **Requests Screen Recording, then Accessibility**, one at a time. For each: if
+   already granted, it moves on; otherwise it triggers the OS consent flow, opens
+   the exact System Settings pane (Privacy & Security → Screen Recording /
+   Accessibility) for you with `open`, and polls for up to a minute while you
+   flip the toggle — it only reports a grant once it re-checks and confirms it,
+   never on your say-so alone.
+2. **Screen Recording's relaunch nuance.** Unlike Accessibility, a Screen
+   Recording grant only takes effect for the process that requested it *after
+   that process restarts*. If the poll above times out, `setup` asks whether you
+   enabled it in System Settings (or, under `--non-interactive`, assumes yes,
+   since there's no one to ask) and, if so, tells you to run `glass-mcp setup`
+   again rather than reporting a plain "not granted" — run it a second time and
+   Screen Recording confirms granted.
+3. **Picks the run mode.** Unless you forced one with `--launchagent` /
+   `--no-launchagent`, it asks: *"Run glass-mcp unattended as a LaunchAgent
+   (serve --http, starts at login) instead of being spawned by your MCP client
+   over stdio?"* Choosing the LaunchAgent writes
+   `~/Library/LaunchAgents/tech.fixedwidth.glass.plist` (filled in with the
+   app's path, the HTTP bind address, and your home directory) and loads it with
+   `launchctl bootstrap gui/<uid>`; choosing stdio installs nothing.
+4. **Confirms via `doctor`** and prints a ready-to-paste MCP-client registration
+   line for whichever mode you picked:
+
+   ```bash
+   claude mcp add glass --scope user -- /path/to/GlassMcp.app/Contents/MacOS/glass-mcp        # stdio
+   claude mcp add --transport http glass http://127.0.0.1:7300/                                # LaunchAgent
+   ```
+
+   If a grant is still pending at the end, `setup` exits non-zero and prints the
+   exact instruction for what's left (which permission, and what to do) — act on
+   it and run `glass-mcp setup` again.
+
+Flags:
+
+| Flag | Effect |
+|---|---|
+| `--non-interactive` | Never blocks on stdin (for scripting/CI): defaults the run mode to stdio (the least-invasive option) when neither `--launchagent` nor `--no-launchagent` is given, and assumes-and-notes rather than asks about the Screen Recording relaunch nuance. Still exits non-zero — same as an interactive run — if a grant is genuinely missing once the poll times out. |
+| `--launchagent` | Install the `gui/<uid>` LaunchAgent (unattended `serve --http`) without asking. |
+| `--no-launchagent` | Skip the LaunchAgent (attended/stdio) without asking. |
+| `--addr ADDR` | LaunchAgent HTTP bind address (default `127.0.0.1:7300`). |
+
+`setup` also warns up front — without refusing to run — if the binary you're
+running it from isn't inside a `*.app/Contents/MacOS` bundle, or is ad hoc/unsigned:
+either means a grant won't survive a rebuild (see the permission model above). That
+keeps `setup` usable from a plain `cargo run` while you're iterating on it, even
+though it isn't how you'd run it day to day.
+
+As long as you keep signing with the same identity and bundle id, granting is a
 **one-time step**: rebuilding, moving the app, or restarting the LaunchAgent
-below never re-prompts.
+never re-prompts.
 
 ## 4. Keep the Mac awake
 
@@ -107,54 +221,49 @@ caffeinate -d -i -s &
 `glass-mcp doctor` checks this (the `display awake` line) and names this exact
 command if the session is locked.
 
-## 5. Run it
+## 5. Connect your agent
 
-The interactive setup above (stdio, your agent spawns the signed binary
-directly) is fine for driving apps from a Terminal you're sitting at. For a box
-no one is watching, run it as a LaunchAgent instead — that's what keeps
-glass-mcp launchd-parented so its grant stays attached to a stable process
-rather than to whatever spawns it that day.
-
-### Unattended (LaunchAgent + network transport) — the recommended model
+If `setup` installed the LaunchAgent, it's already running — point your client at
+the HTTP address it printed:
 
 ```bash
-mkdir -p ~/Library/LaunchAgents ~/Library/Logs/GlassMcp
-cp packaging/macos/tech.fixedwidth.glass.plist ~/Library/LaunchAgents/
-# Edit the copy: replace /Users/YOU with your home directory (and the app path
-# if you didn't install GlassMcp.app to /Applications).
-
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/tech.fixedwidth.glass.plist
-launchctl print gui/$(id -u)/tech.fixedwidth.glass   # confirm it's running
+claude mcp add --transport http glass http://127.0.0.1:7300/
 ```
 
-This starts `glass-mcp serve --http --addr 127.0.0.1:7300` — see
-[packaging/macos/README.md](../packaging/macos/README.md) for the load/unload
-commands. No `sudo` is needed anywhere in this flow.
+From another machine, tunnel first (`ssh -L 7300:127.0.0.1:7300 you@themac`), then
+point the client at `http://127.0.0.1:7300/`. Binding beyond loopback follows the
+same fail-closed token rule as the other platforms — see the "Network transport"
+section of [running-on-windows.md](running-on-windows.md) for the `gen-token` /
+`--token-file` flow, which works identically here.
 
-Point a client at it:
+If you chose stdio instead, register the binary directly — the same one-liner
+`setup` printed:
 
 ```bash
-# Same machine: connect straight to loopback — no token needed.
-# From another machine, tunnel it first:
-ssh -L 7300:127.0.0.1:7300 you@themac
+claude mcp add glass --scope user -- \
+  "$(pwd)/target/macos-app/GlassMcp.app/Contents/MacOS/glass-mcp"
 ```
 
-Then point your MCP client at `http://127.0.0.1:7300`. Binding beyond loopback
-follows the same fail-closed token rule as the other platforms — see the "Network
-transport" section of [running-on-windows.md](running-on-windows.md) for the
-`gen-token` / `--token-file` flow, which works identically here.
+### Managing the LaunchAgent by hand
 
-Stop it with:
+`glass-mcp setup --launchagent` installs and starts it for you; to stop, restart,
+or reload it manually (e.g. after moving the app to a new path):
 
 ```bash
-launchctl bootout gui/$(id -u)/tech.fixedwidth.glass
+launchctl bootout gui/$(id -u)/tech.fixedwidth.glass                                 # stop
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/tech.fixedwidth.glass.plist   # start again
+launchctl print gui/$(id -u)/tech.fixedwidth.glass                                    # confirm it's running
 ```
+
+No `sudo` is needed anywhere in this flow. See
+[packaging/macos/README.md](../packaging/macos/README.md) for the plist template
+and what each field means.
 
 ## Tools available on macOS
 
-Once granted (step 3), the agent has `glass_start`, `glass_screenshot`,
-`glass_click`, `glass_type`, `glass_wait_stable`, `glass_diff`, `glass_logs`,
-`glass_list_windows`, `glass_select_window`, and `glass_doctor`. The
+Once `glass-mcp setup` (step 3) confirms both grants, the agent has `glass_start`,
+`glass_screenshot`, `glass_click`, `glass_type`, `glass_wait_stable`, `glass_diff`,
+`glass_logs`, `glass_list_windows`, `glass_select_window`, and `glass_doctor`. The
 accessibility-tree tools — `glass_a11y_snapshot`, `glass_a11y_marks`,
 `glass_click_element`, and `glass_set_value` — also work on macOS, reading and
 driving the AXUIElement tree; they need the same Accessibility grant from step 3
@@ -243,16 +352,23 @@ Check `glass-mcp doctor`'s `[sandbox]` section for the live Seatbelt availabilit
 
 ## Troubleshooting: headless / SSH setup
 
-Two gotchas that only show up when you're driving a box over SSH (no one at the
-keyboard), e.g. re-signing after a code change or building the Swift capture-test
-fixture:
+A few gotchas that only show up when you're driving a box over SSH (no one at the
+keyboard), e.g. re-signing after a code change or running `setup` unattended:
 
+- **`glass-mcp setup` needs a real console login, not just an SSH shell.** If
+  nobody's logged in at the screen (or it's sitting at the login window), `setup`
+  refuses outright — glass needs a real GUI login to request permissions and
+  drive anything. Log in at the console first (or, once permissions are already
+  granted, run `glass-mcp` as the `gui/<uid>` LaunchAgent instead, which doesn't
+  need a fresh `setup` run). Pass `--non-interactive` when scripting a repeatable
+  `setup` run so it fails fast instead of blocking on a prompt no one can answer.
 - **Non-interactive `codesign` needs the keychain unlocked first.** A keychain
   created (or last unlocked) in an earlier login session is locked again by the time
   a bare SSH shell runs `codesign` — you'll see `errSecInternalComponent` rather
   than an obviously-keychain-shaped error. Unlock it explicitly before signing:
   `security unlock-keychain -p <password> <keychain>` (the login keychain if you
-  didn't pass `--keychain` to `build-app.sh`). This has nothing to do with TCC/AX
+  didn't pass `--keychain` to `build-app.sh`, or your dedicated signing keychain if
+  you used the CLI cert recipe above). This has nothing to do with TCC/AX
   grants — it's the code-signing step itself failing to reach the private key.
 - **Any `@main` Swift source (including the `glass-macos` capture-test fixture,
   `crates/glass-macos/fixture/quadrants.swift`) needs `swiftc -parse-as-library`.**

--- a/packaging/README-gnu.md
+++ b/packaging/README-gnu.md
@@ -5,8 +5,10 @@ launches an app, screenshots what's on screen, clicks and types into it, reads i
 logs, and detects visual changes — so the agent can build and debug a GUI on its own
 instead of asking you "does this look right?".
 
-This is the **Linux x86-64 (glibc)** build. (Windows and macOS builds are also available
-— see [docs/running-on-macos.md](../docs/running-on-macos.md).) See the project README for the full picture:
+This is the **Linux x86-64 (glibc)** build. (A prebuilt **Windows** build is also
+available — see [`packaging/README-windows.md`](README-windows.md). macOS has no prebuilt
+binary yet; build from source — see [docs/running-on-macos.md](../docs/running-on-macos.md).)
+See the project README for the full picture:
 <https://github.com/fixed-width/glass>.
 For Linux-specific display/compositor and containment setup, see
 [docs/running-on-linux.md](../docs/running-on-linux.md).

--- a/packaging/README-musl.md
+++ b/packaging/README-musl.md
@@ -7,9 +7,10 @@ instead of asking you "does this look right?".
 
 This is the **statically-linked Linux x86-64** build: **no glibc version requirement**
 and **no shared-library prerequisites** — it runs on essentially any x86-64 Linux.
-(Windows and macOS builds are also available — see
-[docs/running-on-macos.md](../docs/running-on-macos.md).) See the project README
-for the full picture: <https://github.com/fixed-width/glass>.
+(A prebuilt **Windows** build is also available — see
+[`packaging/README-windows.md`](README-windows.md). macOS has no prebuilt binary yet;
+build from source — see [docs/running-on-macos.md](../docs/running-on-macos.md).)
+See the project README for the full picture: <https://github.com/fixed-width/glass>.
 For Linux-specific display/compositor and containment setup, see
 [docs/running-on-linux.md](../docs/running-on-linux.md).
 

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -1,10 +1,10 @@
 # packaging/macos
 
-Assembles `glass-mcp` into a signed macOS app bundle and runs it as a per-user
-LaunchAgent. This is a quick reference for the files here; see
+Assembles `glass-mcp` into a signed macOS app bundle and (optionally) runs it as a
+per-user LaunchAgent. This is a quick reference for the files here; see
 [docs/running-on-macos.md](../../docs/running-on-macos.md) for the full setup
-guide (creating a signing identity, granting Screen Recording / Accessibility,
-connecting a client).
+guide (creating a signing identity, running `glass-mcp setup` to grant Screen
+Recording / Accessibility and install the run integration, connecting a client).
 
 ## Files
 
@@ -30,7 +30,26 @@ connecting a client).
 # -> target/macos-app/GlassMcp.app
 ```
 
-## Load / unload the LaunchAgent
+## Grant permissions + install the run integration
+
+```bash
+target/macos-app/GlassMcp.app/Contents/MacOS/glass-mcp setup
+```
+
+`glass-mcp setup` is the guided first-run: it requests Screen Recording +
+Accessibility (opening the exact System Settings pane and polling for you),
+then either installs this LaunchAgent (`--launchagent`, or answering yes when
+asked) or leaves nothing installed for an attended/stdio client (`--no-launchagent`),
+and confirms the result via `doctor`. See
+[docs/running-on-macos.md](../../docs/running-on-macos.md) for the full flow,
+including the flags (`--non-interactive`, `--addr`) and the Screen-Recording
+relaunch nuance.
+
+## Load / unload the LaunchAgent by hand
+
+`glass-mcp setup --launchagent` does this for you (filling in the template below
+and running `launchctl bootstrap`); use these commands directly to stop it,
+reload it after moving the app, or debug a load failure:
 
 ```bash
 mkdir -p ~/Library/LaunchAgents ~/Library/Logs/GlassMcp

--- a/packaging/macos/build-app.sh
+++ b/packaging/macos/build-app.sh
@@ -93,12 +93,24 @@ if [ ! -x "$bin" ]; then
   exit 1
 fi
 
+echo "==> building glass-clip-shim-macos (release)"
+if [ "$skip_build" -eq 0 ]; then
+  ( cd "$REPO_ROOT" && cargo build --release -p glass-clip-shim-macos )
+fi
+shim="$REPO_ROOT/target/release/libglass_clip_shim_macos.dylib"
+[ -f "$shim" ] || { echo "error: $shim not found (build the shim first)" >&2; exit 1; }
+
 app="$out_dir/GlassMcp.app"
 echo "==> assembling $app"
 rm -rf "$app"
 mkdir -p "$app/Contents/MacOS"
 install -m 0755 "$bin" "$app/Contents/MacOS/glass-mcp"
 cp "$SCRIPT_DIR/Info.plist" "$app/Contents/Info.plist"
+
+# The clip shim ships in the bundle's Frameworks dir, one level up from Contents/MacOS —
+# glass-macos's `shim_dylib_path` resolves it from there ahead of any dev target-dir path.
+mkdir -p "$app/Contents/Frameworks"
+install -m 0644 "$shim" "$app/Contents/Frameworks/libglass_clip_shim_macos.dylib"
 
 /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier $bundle_id" "$app/Contents/Info.plist"
 if [ -n "$version" ]; then
@@ -117,6 +129,9 @@ codesign_args=(--force --options runtime -s "$sign_identity")
 if [ -n "$sign_keychain" ]; then
   codesign_args+=(--keychain "$sign_keychain")
 fi
+# Nested code must be signed before the enclosing bundle, or `codesign --verify --strict
+# "$app"` below fails on the (still unsigned) dylib.
+codesign "${codesign_args[@]}" "$app/Contents/Frameworks/libglass_clip_shim_macos.dylib"
 codesign "${codesign_args[@]}" "$app"
 
 echo "==> verifying"


### PR DESCRIPTION
Makes macOS glass much easier to set up, and ensures the clipboard shim ships in every build so containment clipboard works out of the box. (Increment A of the packaging work; the notarized release + Homebrew cask is a later increment.)

## `glass-mcp setup`
One guided command that replaces the old manual dance:
- Warns if the running binary isn't inside a properly-signed `.app` (a grant to an ad-hoc identity wouldn't persist).
- Requests **Screen Recording** and **Accessibility** (triggers the OS consent, opens the exact Privacy & Security panes) and polls until granted — handling the quirk that Screen Recording only takes effect after a relaunch.
- Installs the `gui/<uid>` LaunchAgent (unattended `serve --http`) or prints the stdio registration line for your MCP client.
- Confirms with `doctor` and exits non-zero if a grant is still pending.

Flags: `--non-interactive`, `--launchagent`/`--no-launchagent`, `--addr`. The LaunchAgent install is idempotent (re-runs converge) and verifies the agent is actually serving before reporting success.

## Permissions + doctor
New request/pane-open helpers in `glass-macos::permissions` (used only by `setup` — `doctor`/`preflight` stay non-prompting). `doctor` now carries an actionable `remedy_action` that opens the exact settings pane.

## Clip shim ships in the bundle
`build-app.sh` now builds, bundles (`Contents/Frameworks/libglass_clip_shim_macos.dylib`), and signs the clipboard shim, and `shim_dylib_path()` resolves it from the bundle — so a packaged install gets isolated, working clipboard under containment with no extra step. Verified on macOS 26.5: the bundled shim loads under the Seatbelt profile and isolates the clipboard.

## Docs
Install walkthrough rewritten around `setup`; the inaccurate "prebuilt macOS binaries on Releases" claim removed; Xcode Command Line Tools prerequisite documented; the self-signed-cert step corrected (Keychain Access GUI as the simple path, with a scripted CLI alternative that honestly notes its one authorized trust step).

## Testing
Pure logic (pane URLs, plist templating, registration rendering, arg parsing, shim resolution) is unit-tested; the macOS FFI/flow is compiled on `macos-14` CI + cross-compile-type-checked, and the packaged clipboard path was verified on-hardware. The interactive grant dialogs need a GUI session to exercise end-to-end.