### PR TITLE
feat(macos): notarized universal release pipeline (inert until signing secrets configured)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,3 +79,99 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           files: dist/*.zip
+
+  macos:
+    name: macos artifact (universal, notarized)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # The macOS release artifact needs Developer ID signing + notarization secrets.
+      # Until the Apple Developer enrollment is approved and these are configured, this
+      # job SKIPS every real step (exit 0) so tagging a release still publishes the
+      # Linux/Windows artifacts. Secrets can't be read in a job-level `if:`, so we probe
+      # one here and gate the rest on its output.
+      - name: Check signing credentials
+        id: creds
+        env:
+          CERT: ${{ secrets.MACOS_DEVELOPER_ID_CERT_P12 }}
+        run: |
+          if [ -n "$CERT" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::macOS signing secrets not configured — skipping notarized macOS artifact (Apple Developer enrollment pending)."
+          fi
+
+      - name: Install pinned toolchain
+        if: steps.creds.outputs.present == 'true'
+        run: |
+          rustup show
+          rustup target add x86_64-apple-darwin
+
+      - uses: Swatinem/rust-cache@v2
+        if: steps.creds.outputs.present == 'true'
+        with:
+          workspaces: .
+
+      - name: Import Developer ID certificate
+        if: steps.creds.outputs.present == 'true'
+        env:
+          CERT_P12: ${{ secrets.MACOS_DEVELOPER_ID_CERT_P12 }}
+          CERT_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_CERT_PASSWORD }}
+        run: |
+          set -euo pipefail
+          keychain="$RUNNER_TEMP/build.keychain-db"
+          kc_pw="$(openssl rand -base64 24)"
+          echo "SIGN_KEYCHAIN=$keychain" >> "$GITHUB_ENV"
+          security create-keychain -p "$kc_pw" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$kc_pw" "$keychain"
+          echo "$CERT_P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$keychain" -P "$CERT_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$kc_pw" "$keychain" >/dev/null
+          # Prepend the build keychain to the search list so codesign resolves the identity.
+          security list-keychains -d user -s "$keychain" $(security list-keychains -d user | sed 's/[",]//g')
+          rm -f "$RUNNER_TEMP/cert.p12"
+
+      - name: Build + sign universal app
+        if: steps.creds.outputs.present == 'true'
+        env:
+          SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          ./packaging/macos/build-app.sh --universal --timestamp \
+            --identity "$SIGN_IDENTITY" --keychain "$SIGN_KEYCHAIN" \
+            --version "${tag#v}" --build "${GITHUB_RUN_NUMBER}"
+
+      - name: Notarize + staple
+        if: steps.creds.outputs.present == 'true'
+        env:
+          NOTARY_KEY_P8: ${{ secrets.MACOS_NOTARY_API_KEY_P8 }}
+          NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_API_KEY_ID }}
+          NOTARY_ISSUER: ${{ secrets.MACOS_NOTARY_API_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          echo "$NOTARY_KEY_P8" | base64 --decode > "$RUNNER_TEMP/AuthKey.p8"
+          ./packaging/macos/notarize.sh \
+            --app target/macos-app/GlassMcp.app \
+            --key "$RUNNER_TEMP/AuthKey.p8" \
+            --key-id "$NOTARY_KEY_ID" --issuer "$NOTARY_ISSUER"
+          rm -f "$RUNNER_TEMP/AuthKey.p8"
+
+      - name: Package
+        if: steps.creds.outputs.present == 'true'
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          name="glass-mcp-${tag}-universal-apple-darwin"
+          mkdir -p dist
+          # ditto (not zip) preserves the bundle layout + signature.
+          ditto -c -k --keepParent target/macos-app/GlassMcp.app "dist/${name}.zip"
+
+      - name: Upload to release
+        if: steps.creds.outputs.present == 'true'
+        uses: softprops/action-gh-release@v3
+        with:
+          files: dist/*.zip

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -67,3 +67,27 @@ No `sudo` is needed anywhere here — a LaunchAgent bootstrapped into your own
 `gui/<uid>` domain is entirely user-scoped, and it's what keeps glass-mcp's
 process launchd-parented (not SSH- or Terminal-parented), which is what makes its
 TCC grants attach reliably to the signed binary itself.
+
+## Release pipeline (maintainers)
+
+Tagging `v*` runs the `macos` job in [`.github/workflows/release.yml`](../../.github/workflows/release.yml),
+which builds a **universal2** (`arm64` + `x86_64`) `GlassMcp.app`, Developer-ID-signs it
+(hardened runtime + secure timestamp, nested clip-shim dylib included), notarizes and
+staples it via `xcrun notarytool` + `stapler`, and uploads
+`glass-mcp-<tag>-universal-apple-darwin.zip` to the GitHub Release.
+
+The job **skips cleanly** (no failure) until these repository secrets are set, so releases
+still publish the Linux/Windows artifacts before macOS signing is available:
+
+| Secret | Contents |
+|--------|----------|
+| `MACOS_DEVELOPER_ID_CERT_P12` | base64 of the "Developer ID Application" cert + key, exported as `.p12` |
+| `MACOS_DEVELOPER_ID_CERT_PASSWORD` | the `.p12` export password |
+| `MACOS_SIGN_IDENTITY` | the identity Common Name (`Developer ID Application: … (TEAMID)`) |
+| `MACOS_NOTARY_API_KEY_P8` | base64 of the App Store Connect API key `.p8` (role: App Manager) |
+| `MACOS_NOTARY_API_KEY_ID` | the API key ID |
+| `MACOS_NOTARY_API_ISSUER_ID` | the App Store Connect issuer UUID |
+
+Base64-encode a file for a secret with `base64 -i <file> | pbcopy`. To run the signing +
+notarization steps locally instead of in CI, use `build-app.sh --universal --timestamp
+--identity …` followed by `notarize.sh --app … --key … --key-id … --issuer …`.

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -91,3 +91,6 @@ still publish the Linux/Windows artifacts before macOS signing is available:
 Base64-encode a file for a secret with `base64 -i <file> | pbcopy`. To run the signing +
 notarization steps locally instead of in CI, use `build-app.sh --universal --timestamp
 --identity …` followed by `notarize.sh --app … --key … --key-id … --issuer …`.
+
+The job's skip-gate probes only `MACOS_DEVELOPER_ID_CERT_P12`; configure all six together —
+a partial configuration will run and fail at the first missing value rather than skip cleanly.

--- a/packaging/macos/build-app.sh
+++ b/packaging/macos/build-app.sh
@@ -96,8 +96,8 @@ fi
 if [ "$universal" -eq 1 ]; then
   echo "==> building glass-mcp + clip shim (release, universal2)"
   if [ "$skip_build" -eq 0 ]; then
-    ( cd "$REPO_ROOT" && cargo build --release --target aarch64-apple-darwin -p glass-mcp -p glass-clip-shim-macos )
-    ( cd "$REPO_ROOT" && cargo build --release --target x86_64-apple-darwin  -p glass-mcp -p glass-clip-shim-macos )
+    ( cd "$REPO_ROOT" && cargo build --release --locked --target aarch64-apple-darwin -p glass-mcp -p glass-clip-shim-macos )
+    ( cd "$REPO_ROOT" && cargo build --release --locked --target x86_64-apple-darwin  -p glass-mcp -p glass-clip-shim-macos )
   fi
   bin="$REPO_ROOT/target/glass-mcp-universal"
   shim="$REPO_ROOT/target/libglass_clip_shim_macos-universal.dylib"

--- a/packaging/macos/build-app.sh
+++ b/packaging/macos/build-app.sh
@@ -22,6 +22,11 @@
 #   --build N            CFBundleVersion (default: the template's).
 #   --skip-build         reuse the existing target/release/glass-mcp binary
 #                        instead of rebuilding — for iterating on packaging only.
+#   --universal          build a universal2 binary (aarch64 + x86_64) via lipo,
+#                        instead of the host arch only. Requires both rustup
+#                        targets (`rustup target add x86_64-apple-darwin`).
+#   --timestamp          add a secure timestamp to the signature (`codesign
+#                        --timestamp`). Required for notarization; needs network.
 #
 # TCC (Screen Recording / Accessibility) grants key on the bundle's Designated
 # Requirement — bundle id + signing certificate — not on the binary's cdhash. So
@@ -34,7 +39,8 @@ set -euo pipefail
 usage() {
   cat >&2 <<'EOF'
 usage: build-app.sh --identity NAME [--bundle-id ID] [--keychain PATH]
-                     [--out DIR] [--version X.Y.Z] [--build N] [--skip-build]
+                     [--out DIR] [--version X.Y.Z] [--build N]
+                     [--universal] [--timestamp] [--skip-build]
 EOF
   exit 1
 }
@@ -49,6 +55,8 @@ out_dir="$REPO_ROOT/target/macos-app"
 version=""
 build_num=""
 skip_build=0
+universal=0
+timestamp=0
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -58,6 +66,8 @@ while [ $# -gt 0 ]; do
     --out)        out_dir="$2"; shift 2 ;;
     --version)    version="$2"; shift 2 ;;
     --build)      build_num="$2"; shift 2 ;;
+    --universal)  universal=1; shift ;;
+    --timestamp)  timestamp=1; shift ;;
     --skip-build) skip_build=1; shift ;;
     -h|--help)    usage ;;
     *) echo "error: unknown argument: $1" >&2; usage ;;
@@ -83,21 +93,36 @@ if ! command -v /usr/libexec/PlistBuddy >/dev/null 2>&1; then
   exit 1
 fi
 
-echo "==> building glass-mcp (release)"
-bin="$REPO_ROOT/target/release/glass-mcp"
-if [ "$skip_build" -eq 0 ]; then
-  ( cd "$REPO_ROOT" && cargo build --release -p glass-mcp )
+if [ "$universal" -eq 1 ]; then
+  echo "==> building glass-mcp + clip shim (release, universal2)"
+  if [ "$skip_build" -eq 0 ]; then
+    ( cd "$REPO_ROOT" && cargo build --release --target aarch64-apple-darwin -p glass-mcp -p glass-clip-shim-macos )
+    ( cd "$REPO_ROOT" && cargo build --release --target x86_64-apple-darwin  -p glass-mcp -p glass-clip-shim-macos )
+  fi
+  bin="$REPO_ROOT/target/glass-mcp-universal"
+  shim="$REPO_ROOT/target/libglass_clip_shim_macos-universal.dylib"
+  lipo -create -output "$bin" \
+    "$REPO_ROOT/target/aarch64-apple-darwin/release/glass-mcp" \
+    "$REPO_ROOT/target/x86_64-apple-darwin/release/glass-mcp"
+  lipo -create -output "$shim" \
+    "$REPO_ROOT/target/aarch64-apple-darwin/release/libglass_clip_shim_macos.dylib" \
+    "$REPO_ROOT/target/x86_64-apple-darwin/release/libglass_clip_shim_macos.dylib"
+else
+  echo "==> building glass-mcp (release)"
+  bin="$REPO_ROOT/target/release/glass-mcp"
+  if [ "$skip_build" -eq 0 ]; then
+    ( cd "$REPO_ROOT" && cargo build --release -p glass-mcp )
+  fi
+  echo "==> building glass-clip-shim-macos (release)"
+  if [ "$skip_build" -eq 0 ]; then
+    ( cd "$REPO_ROOT" && cargo build --release -p glass-clip-shim-macos )
+  fi
+  shim="$REPO_ROOT/target/release/libglass_clip_shim_macos.dylib"
 fi
 if [ ! -x "$bin" ]; then
   echo "error: $bin not found or not executable (run without --skip-build first)" >&2
   exit 1
 fi
-
-echo "==> building glass-clip-shim-macos (release)"
-if [ "$skip_build" -eq 0 ]; then
-  ( cd "$REPO_ROOT" && cargo build --release -p glass-clip-shim-macos )
-fi
-shim="$REPO_ROOT/target/release/libglass_clip_shim_macos.dylib"
 [ -f "$shim" ] || { echo "error: $shim not found (build the shim first)" >&2; exit 1; }
 
 app="$out_dir/GlassMcp.app"
@@ -126,6 +151,9 @@ echo "==> codesigning (identity: $sign_identity, bundle id: $bundle_id)"
 # error — unlock it first with `security unlock-keychain -p <password> <keychain>`
 # (see docs/running-on-macos.md).
 codesign_args=(--force --options runtime -s "$sign_identity")
+if [ "$timestamp" -eq 1 ]; then
+  codesign_args+=(--timestamp)
+fi
 if [ -n "$sign_keychain" ]; then
   codesign_args+=(--keychain "$sign_keychain")
 fi

--- a/packaging/macos/notarize.sh
+++ b/packaging/macos/notarize.sh
@@ -14,10 +14,10 @@ set -euo pipefail
 app="" key="" key_id="" issuer=""
 while [ $# -gt 0 ]; do
   case "$1" in
-    --app)    app="$2"; shift 2 ;;
-    --key)    key="$2"; shift 2 ;;
-    --key-id) key_id="$2"; shift 2 ;;
-    --issuer) issuer="$2"; shift 2 ;;
+    --app)    [ $# -ge 2 ] || { echo "error: --app requires a value" >&2; exit 1; }; app="$2"; shift 2 ;;
+    --key)    [ $# -ge 2 ] || { echo "error: --key requires a value" >&2; exit 1; }; key="$2"; shift 2 ;;
+    --key-id) [ $# -ge 2 ] || { echo "error: --key-id requires a value" >&2; exit 1; }; key_id="$2"; shift 2 ;;
+    --issuer) [ $# -ge 2 ] || { echo "error: --issuer requires a value" >&2; exit 1; }; issuer="$2"; shift 2 ;;
     -h|--help)
       echo "usage: notarize.sh --app PATH --key AuthKey.p8 --key-id ID --issuer UUID" >&2
       exit 1 ;;
@@ -36,11 +36,24 @@ done
 # here rather than after a slow submit round-trip.
 codesign --verify --strict --deep -vv "$app" \
   || { echo "error: $app is not validly signed (sign it before notarizing)" >&2; exit 1; }
-codesign -dvv "$app" 2>&1 | grep -qi "Timestamp=" \
-  || { echo "error: $app signature has no secure timestamp — re-sign with build-app.sh --timestamp" >&2; exit 1; }
+
+# Notarization requires a secure timestamp on the app AND its nested signed code;
+# catch a missing one here rather than after a slow submit round-trip.
+require_timestamp() { # <signed path>
+  codesign -dvv "$1" 2>&1 | grep -qi "Timestamp=" \
+    || { echo "error: $1 signature has no secure timestamp — re-sign with build-app.sh --timestamp" >&2; exit 1; }
+}
+require_timestamp "$app"
+if [ -d "$app/Contents/Frameworks" ]; then
+  for dylib in "$app/Contents/Frameworks"/*.dylib; do
+    [ -e "$dylib" ] || continue   # no match → skip the literal glob
+    require_timestamp "$dylib"
+  done
+fi
 
 # notarytool needs a container to upload; we staple the .app itself afterward.
 sub="$(dirname "$app")/notarize-submission.zip"
+trap 'rm -f "$sub"' EXIT
 rm -f "$sub"
 ditto -c -k --keepParent "$app" "$sub"
 
@@ -53,11 +66,9 @@ if ! out="$(xcrun notarytool submit "$sub" \
     echo "==> notarization failed; fetching log for $sub_id"
     xcrun notarytool log "$sub_id" --key "$key" --key-id "$key_id" --issuer "$issuer" || true
   fi
-  rm -f "$sub"
   exit 1
 fi
 printf '%s\n' "$out"
-rm -f "$sub"
 
 echo "==> stapling ticket into $(basename "$app")"
 xcrun stapler staple "$app"

--- a/packaging/macos/notarize.sh
+++ b/packaging/macos/notarize.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Notarize and staple a signed GlassMcp.app: submit it to Apple's notary service,
+# wait, staple the ticket into the bundle, and verify. Requires an App Store Connect
+# API key (App Manager role). Notarization covers the nested clip-shim dylib too.
+#
+#   ./packaging/macos/notarize.sh --app <path.app> \
+#       --key <AuthKey.p8> --key-id <KEYID> --issuer <ISSUER_UUID>
+#
+# Fails fast (non-zero, actionable) if not on macOS, the app is missing/unsigned, the
+# signature lacks a secure timestamp (notarization would reject it), or a credential is
+# absent. On a notarization failure it dumps `xcrun notarytool log` before exiting.
+set -euo pipefail
+
+app="" key="" key_id="" issuer=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --app)    app="$2"; shift 2 ;;
+    --key)    key="$2"; shift 2 ;;
+    --key-id) key_id="$2"; shift 2 ;;
+    --issuer) issuer="$2"; shift 2 ;;
+    -h|--help)
+      echo "usage: notarize.sh --app PATH --key AuthKey.p8 --key-id ID --issuer UUID" >&2
+      exit 1 ;;
+    *) echo "error: unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+[ "$(uname -s)" = "Darwin" ] || { echo "error: notarize.sh must run on macOS" >&2; exit 1; }
+for v in app key key_id issuer; do
+  [ -n "${!v}" ] || { echo "error: --${v//_/-} is required" >&2; exit 1; }
+done
+[ -d "$app" ]  || { echo "error: app bundle not found: $app" >&2; exit 1; }
+[ -f "$key" ]  || { echo "error: API key file not found: $key" >&2; exit 1; }
+
+# Notarization requires a valid signature WITH a secure timestamp; catch a missing one
+# here rather than after a slow submit round-trip.
+codesign --verify --strict --deep -vv "$app" \
+  || { echo "error: $app is not validly signed (sign it before notarizing)" >&2; exit 1; }
+codesign -dvv "$app" 2>&1 | grep -qi "Timestamp=" \
+  || { echo "error: $app signature has no secure timestamp — re-sign with build-app.sh --timestamp" >&2; exit 1; }
+
+# notarytool needs a container to upload; we staple the .app itself afterward.
+sub="$(dirname "$app")/notarize-submission.zip"
+rm -f "$sub"
+ditto -c -k --keepParent "$app" "$sub"
+
+echo "==> submitting $(basename "$app") to Apple notary service (this can take minutes)"
+if ! out="$(xcrun notarytool submit "$sub" \
+      --key "$key" --key-id "$key_id" --issuer "$issuer" --wait 2>&1)"; then
+  echo "$out"
+  sub_id="$(printf '%s\n' "$out" | awk '/id:/ {print $2; exit}')"
+  if [ -n "${sub_id:-}" ]; then
+    echo "==> notarization failed; fetching log for $sub_id"
+    xcrun notarytool log "$sub_id" --key "$key" --key-id "$key_id" --issuer "$issuer" || true
+  fi
+  rm -f "$sub"
+  exit 1
+fi
+printf '%s\n' "$out"
+rm -f "$sub"
+
+echo "==> stapling ticket into $(basename "$app")"
+xcrun stapler staple "$app"
+
+echo "==> verifying notarized bundle"
+xcrun stapler validate "$app"
+spctl -a -vvv -t exec "$app"
+codesign --verify --deep --strict -vv "$app"
+echo "==> notarized + stapled: $app"


### PR DESCRIPTION
Adds the CI plumbing to build, Developer-ID-sign, notarize, staple, and publish a
**universal2** (arm64 + x86_64) macOS `GlassMcp.app` on `v*` tags — so macOS users get a
Gatekeeper-clean download with durable, shareable TCC grants instead of self-signing from
source.

The pipeline is **inert until signing secrets are configured**: the new `macos` release
job skips cleanly (exit 0, no failure) when the credentials are absent, so tagging a
release today still publishes the existing Linux/Windows artifacts unchanged. Nothing
Apple-related runs until the six documented secrets are set.

## Changes

- **`packaging/macos/build-app.sh`** — new `--universal` flag (build `aarch64`/`x86_64`
  and `lipo`-merge **both** the `glass-mcp` binary and the bundled clip-shim dylib) and
  `--timestamp` (secure timestamp for notarization). Release/universal builds now pass
  `--locked`. Default single-arch dev behavior is unchanged.
- **`packaging/macos/notarize.sh`** (new) — submit a signed `.app` to `xcrun notarytool`
  (App Store Connect API key), staple, and verify (`stapler validate` + `spctl` +
  `codesign`). Fail-fast pre-flight (macOS, app present, signed, secure timestamp on the
  app *and* each nested `Frameworks` dylib) with actionable errors; dumps the notary log
  on failure.
- **`.github/workflows/release.yml`** — new `macos` job on `v*` tags: credential skip-gate
  → import the Developer ID cert into an ephemeral keychain → `build-app.sh --universal
  --timestamp` → `notarize.sh` → `ditto` zip → upload
  `glass-mcp-<tag>-universal-apple-darwin.zip`. Existing `linux`/`windows` jobs are
  untouched.
- **`packaging/macos/README.md`** — a "Release pipeline (maintainers)" section: the
  required repository secrets and the release procedure.

## Verification

- Universal build exercised on Apple Silicon: both the binary and the bundled clip-shim
  dylib come out fat (`lipo -info` → `x86_64 arm64`).
- `shellcheck` + `bash -n` clean on both scripts; workflow YAML validated; skip-gate logic
  confirmed (every real step gated; the probe can't fail the job).
- Workspace CI gate green locally (this branch changes no Rust).

## Not in this PR

- The first live notarized release and the end-user "download the notarized build"
  documentation land once the Apple Developer ID credentials are configured.
- `.dmg` packaging and a Homebrew cask are a later addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
