### PR TITLE
fix(x11): actionable error when a window exceeds the headless display (closes #70)

### DIFF
--- a/crates/glass-testapp/tests/integration.rs
+++ b/crates/glass-testapp/tests/integration.rs
@@ -94,6 +94,29 @@ fn captures_known_quadrant_colors() {
 
 #[test]
 #[ignore = "requires an X server; run via scripts/test-x11.sh"]
+fn oversize_window_capture_returns_actionable_error() {
+    // A display SMALLER than the 320x240 test window, so the window overflows the
+    // screen — the "window bigger than the headless Xvfb" case. Capture must fail
+    // with an actionable message (window + display sizes and the two remedies),
+    // not the raw `GetImage`/`BadMatch` protocol error the agent can't act on.
+    let xvfb = glass_x11::Xvfb::start("200x200x24").expect("spawn Xvfb (is it installed?)");
+    let mut p = X11Platform::connect(Some(&xvfb.display)).unwrap();
+    p.start_app(&app_spec()).unwrap();
+    assert!(wait_for_log(&mut p, "READY", 40), "no READY");
+    std::thread::sleep(std::time::Duration::from_millis(150));
+    let err = p.capture_frame(None).unwrap_err().to_string();
+    assert!(err.contains("320x240"), "names the window size: {err}");
+    assert!(err.contains("200x200"), "names the display size: {err}");
+    assert!(err.contains("GLASS_XVFB_SCREEN"), "names the larger-display remedy: {err}");
+    assert!(
+        !err.contains("get_image"),
+        "should be the pre-flight actionable error, not the raw GetImage failure: {err}"
+    );
+    p.stop_app().unwrap();
+}
+
+#[test]
+#[ignore = "requires an X server; run via scripts/test-x11.sh"]
 fn click_is_delivered_to_the_window() {
     use glass_core::{MouseButton, PointerEvent};
     let xvfb = Xvfb::start();

--- a/crates/glass-x11/src/coords.rs
+++ b/crates/glass-x11/src/coords.rs
@@ -1,8 +1,47 @@
+use glass_core::{GlassError, Region, Result, WindowGeometry};
+
 /// Translate a window-relative point to absolute root coordinates given the
 /// window's origin (top-left) in root coordinates. XTEST motion uses root
 /// coordinates, so callers add the window origin (from `translate_coordinates`).
 pub fn window_to_root(origin_x: i32, origin_y: i32, x: i32, y: i32) -> (i16, i16) {
     ((origin_x + x) as i16, (origin_y + y) as i16)
+}
+
+/// Verify the capture rectangle — the whole window, or `region` within it —
+/// lies entirely within the X11 display (root window). glass runs the app on a
+/// headless Xvfb of a fixed size; a window taller/wider than that screen (or
+/// positioned so part of it is off-screen) makes `GetImage` cover non-viewable
+/// area, and X returns a bare `BadMatch`. Detect that here and return an
+/// actionable error naming both remedies, instead of surfacing the opaque
+/// protocol error the driving agent can't act on.
+///
+/// `geo` is the window's root-relative origin + size; `display` is the root
+/// window's pixel size.
+pub(crate) fn check_capture_fits(
+    geo: &WindowGeometry,
+    region: Option<&Region>,
+    display: (u32, u32),
+) -> Result<()> {
+    let (dw, dh) = (i64::from(display.0), i64::from(display.1));
+    // The capture rectangle in window-local coords, then in root/display coords.
+    let (cx, cy, w, h) = match region {
+        Some(r) => (i64::from(r.x), i64::from(r.y), i64::from(r.width), i64::from(r.height)),
+        None => (0, 0, i64::from(geo.width), i64::from(geo.height)),
+    };
+    let (rx, ry) = (i64::from(geo.x) + cx, i64::from(geo.y) + cy);
+    if rx >= 0 && ry >= 0 && rx + w <= dw && ry + h <= dh {
+        return Ok(());
+    }
+    // A display that would contain this capture rectangle — a concrete value the
+    // operator can drop straight into GLASS_XVFB_SCREEN.
+    let need_w = (rx + w).max(dw);
+    let need_h = (ry + h).max(dh);
+    Err(GlassError::CaptureFailed(format!(
+        "capture area {w}x{h} at ({rx},{ry}) extends beyond the {dw}x{dh} X11 display; \
+         X11 cannot read the off-screen part (GetImage BadMatch). Resize the window to fit \
+         within {dw}x{dh}, or restart glass with a larger display via \
+         GLASS_XVFB_SCREEN={need_w}x{need_h}x24."
+    )))
 }
 
 #[cfg(test)]
@@ -17,5 +56,50 @@ mod tests {
     #[test]
     fn handles_zero_origin() {
         assert_eq!(window_to_root(0, 0, 12, 34), (12, 34));
+    }
+
+    #[test]
+    fn capture_within_display_is_ok() {
+        // An 800x600 window at (10,10) fits well inside a 1280x800 display.
+        let geo = WindowGeometry { x: 10, y: 10, width: 800, height: 600 };
+        assert!(check_capture_fits(&geo, None, (1280, 800)).is_ok());
+    }
+
+    #[test]
+    fn window_exceeding_display_is_actionable_error() {
+        // The reproduced case: a 1400x1000 window at (1,1) on a 1280x800 Xvfb.
+        let geo = WindowGeometry { x: 1, y: 1, width: 1400, height: 1000 };
+        let msg = check_capture_fits(&geo, None, (1280, 800)).unwrap_err().to_string();
+        assert!(msg.contains("1400x1000"), "names the window/capture size: {msg}");
+        assert!(msg.contains("1280x800"), "names the display size: {msg}");
+        assert!(msg.contains("GLASS_XVFB_SCREEN"), "names the larger-display remedy: {msg}");
+        assert!(msg.to_lowercase().contains("resize"), "names the resize remedy: {msg}");
+    }
+
+    #[test]
+    fn onscreen_region_of_an_oversized_window_still_succeeds() {
+        // The window is taller than the display (its lower 200px are off-screen),
+        // but a region on its visible upper part maps fully on-screen — partial
+        // capture of a too-big window must still work, not be rejected wholesale.
+        let geo = WindowGeometry { x: 0, y: 0, width: 1000, height: 1000 };
+        let region = Region { x: 0, y: 0, width: 500, height: 500 };
+        assert!(check_capture_fits(&geo, Some(&region), (1280, 800)).is_ok());
+    }
+
+    #[test]
+    fn region_reaching_the_offscreen_part_of_an_oversized_window_is_caught() {
+        // Same oversized window; this region fits the window (y 600..900 <= 1000)
+        // but reaches below the 800px display edge, so its lower rows are off-root.
+        let geo = WindowGeometry { x: 0, y: 0, width: 1000, height: 1000 };
+        let region = Region { x: 0, y: 600, width: 500, height: 300 };
+        let msg = check_capture_fits(&geo, Some(&region), (1280, 800)).unwrap_err().to_string();
+        assert!(msg.contains("1280x800"), "names the display size: {msg}");
+    }
+
+    #[test]
+    fn window_flush_to_display_edges_is_ok() {
+        // Exactly display-sized at the origin — the boundary case must pass.
+        let geo = WindowGeometry { x: 0, y: 0, width: 1280, height: 800 };
+        assert!(check_capture_fits(&geo, None, (1280, 800)).is_ok());
     }
 }

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -29,7 +29,8 @@ type LogSink = Arc<Mutex<Vec<(Stream, String)>>>;
 /// target app's top-level window, and drives it via X requests + XTEST.
 pub struct X11Platform {
     conn: RustConnection,
-    #[expect(dead_code, reason = "captured from the X setup for completeness; not currently read")]
+    /// The X screen glass connected to; indexes `setup().roots` for the display
+    /// (root window) size, used to reject captures that reach off-screen.
     screen_num: usize,
     root: Window,
     display: String,
@@ -811,6 +812,15 @@ impl Platform for X11Platform {
         if w == 0 || h == 0 {
             return Err(GlassError::CaptureFailed("window has zero area".into()));
         }
+        // A window (or region) reaching past the headless display makes GetImage
+        // cover non-viewable area, which X rejects with a bare BadMatch. Convert
+        // that to an actionable error before issuing the request; the root
+        // window's pixel size is the display size.
+        let display = {
+            let root = &self.conn.setup().roots[self.screen_num];
+            (u32::from(root.width_in_pixels), u32::from(root.height_in_pixels))
+        };
+        crate::coords::check_capture_fits(&geo, region, display)?;
         let image = self
             .conn
             .get_image(ImageFormat::Z_PIXMAP, win, cx as i16, cy as i16, w as u16, h as u16, !0u32)


### PR DESCRIPTION
Closes #70.

On the `x11` backend, capturing a window (or region) larger than the headless Xvfb
screen made `XGetImage` cover non-viewable (off-root) area, so X returned a bare
`BadMatch` — every `glass_screenshot` / `glass_wait_stable` / `glass_diff` failed with
an opaque protocol error the driving agent couldn't act on.

`capture_frame` now checks the capture rectangle against the root window size **before**
issuing `GetImage`, and returns an actionable error naming the window size, the display
size, the cause, and both remedies. The agent now sees, e.g.:

> capture failed: capture area 320x240 at (0,0) extends beyond the 200x200 X11 display;
> X11 cannot read the off-screen part (GetImage BadMatch). Resize the window to fit
> within 200x200, or restart glass with a larger display via `GLASS_XVFB_SCREEN=320x240x24`.

## Scope

This is **x11-specific**. An audit + live reproduction of the sibling backends showed the
failure is unique to x11 — the headless Xvfb has no window manager, so a window freely
overflows the root:

- **wayland** (sway) clamps windows to the output, so the overflow is unreachable;
- **windows** (WGC) and **macOS** (ScreenCaptureKit) capture the window's *own* surface;
- **android** reads the screen size live and clamps the window rect.

## Tests

- `check_capture_fits` (pure containment check) — unit tests for fit, oversize (actionable
  message), an on-screen region of an oversized window (still succeeds), a region reaching
  the off-screen part (rejected), and the boundary flush to the display edge.
- An integration test drives a 320×240 window on a 200×200 Xvfb through the real X path and
  asserts the actionable error, not the raw `get_image` failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
