### PR TITLE
ci: SHA-pin all GitHub Actions to their latest releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # rustup installs the pinned toolchain + rustfmt from rust-toolchain.toml,
       # so CI formats with the same nightly the build uses.
       - name: Install pinned toolchain
@@ -33,12 +33,12 @@ jobs:
     runs-on: ubuntu-latest
     # The Cargo workspace is at the repo root.
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # rustup auto-installs the pinned toolchain + components from
       # rust-toolchain.toml (single source of truth for the nightly).
       - name: Install pinned toolchain
         run: rustup show
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: .
       - run: cargo build --workspace --all-targets --locked
@@ -56,12 +56,12 @@ jobs:
     # The `miri` component is added here (not pinned in rust-toolchain.toml) so a future nightly
     # bump that lacks it fails only this job, not every job's `rustup show`.
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install pinned toolchain
         run: rustup show
       - name: Add miri component
         run: rustup component add miri
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: .
       - run: cargo miri test -p glass-clip-hook -p glass-windows --locked
@@ -70,10 +70,10 @@ jobs:
     name: X11 integration (Xvfb)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install pinned toolchain
         run: rustup show
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: .
       - name: Install system deps
@@ -93,10 +93,10 @@ jobs:
     # (cage was retired; Ubuntu only ships sway 1.9). The bundle is extracted into the
     # glass discovery location so test-wayland.sh finds it with zero config.
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install pinned toolchain
         run: rustup show
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: .
       - name: Install system deps
@@ -126,12 +126,12 @@ jobs:
     # WindowServer-connected TCC context) and run on-box; the runner covers pure +
     # macOS unit tests.
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # rustup auto-installs the pinned toolchain + components from
       # rust-toolchain.toml (single source of truth for the nightly).
       - name: Install pinned toolchain
         run: rustup show
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: .
       - run: cargo build  -p glass-macos --locked
@@ -202,12 +202,12 @@ jobs:
     runs-on: windows-latest
     # The Cargo workspace is at the repo root.
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # rustup auto-installs the pinned toolchain from rust-toolchain.toml for the
       # x86_64-pc-windows-msvc host (MSVC linker ships on the runner).
       - name: Install pinned toolchain
         run: rustup show
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: .
       # --workspace can't be used: glass-wayland/glass-testapp are Unix-only. Scope to
@@ -227,15 +227,15 @@ jobs:
     # (not packaged on the runner) so it self-skips. Unit + X11 are measured.
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install pinned toolchain
         run: rustup show
       - name: Add llvm-tools (required by cargo-llvm-cov)
         run: rustup component add llvm-tools-preview
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2.82.8
         with:
           tool: cargo-llvm-cov
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: .
       - name: Install system deps
@@ -247,7 +247,7 @@ jobs:
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
       - name: Measure coverage (unit + X11; Wayland/AT-SPI self-skip)
         run: ./scripts/coverage.sh --lcov
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-lcov
           path: target/llvm-cov/glass.lcov

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,14 +54,14 @@ jobs:
       id-token: write      # OIDC token for build-provenance signing
       attestations: write  # write the provenance to the attestation API
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install pinned toolchain
         run: rustup show
       - name: Add musl target
         run: rustup target add x86_64-unknown-linux-musl
       - name: Install musl tools
         run: sudo apt-get update && sudo apt-get install -y musl-tools
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: .
       - name: Build (gnu)
@@ -86,7 +86,7 @@ jobs:
           pkg target/x86_64-unknown-linux-musl/release/glass-mcp README-musl.md x86_64-linux-musl
           ( cd dist && for f in *.tar.gz; do sha256sum "$f" > "$f.sha256"; done )
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: 'dist/*.tar.gz'
       - name: Upload to draft release
@@ -109,10 +109,10 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install pinned toolchain
         run: rustup show
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: .
       - name: Build
@@ -129,7 +129,7 @@ jobs:
           $hash = (Get-FileHash "dist/$name.zip" -Algorithm SHA256).Hash.ToLower()
           "$hash  $name.zip" | Out-File "dist/$name.zip.sha256" -Encoding ascii
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: 'dist/*.zip'
       - name: Upload to draft release
@@ -150,7 +150,7 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # The macOS release artifact needs Developer ID signing + notarization secrets.
       # Until the Apple Developer enrollment is approved and these are configured, this
@@ -175,7 +175,7 @@ jobs:
           rustup show
           rustup target add x86_64-apple-darwin
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         if: steps.creds.outputs.present == 'true'
         with:
           workspaces: .
@@ -239,7 +239,7 @@ jobs:
 
       - name: Attest build provenance
         if: steps.creds.outputs.present == 'true'
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: 'dist/*.zip'
 


### PR DESCRIPTION
Pins every GitHub Action in `ci.yml` and `release.yml` to a commit **SHA**, each at its
latest release. Supply-chain hardening — a moved or hijacked tag can no longer silently
change what runs in CI or the release pipeline.

| action | was | now |
|---|---|---|
| `actions/checkout` | v6 | **v7.0.0** (major bump) |
| `Swatinem/rust-cache` | v2 | v2.9.1 |
| `actions/upload-artifact` | v7 | v7.0.1 |
| `taiki-e/install-action` | v2 | v2.82.8 |
| `actions/attest-build-provenance` | v4 (pinned) | v4.1.1 (same SHA, comment made precise) |

`actions/checkout` v7 is the only major bump — and it's the exact SHA pgsafe already runs,
so it's proven in-org. This PR's own CI exercises every pinned action in `ci.yml`; the
release-only `attest-build-provenance` pin is the same SHA the `v0.2.1-rc1` smoke test
already verified end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
