### PR TITLE
feat(macos): drive .app bundles (direct-spawn + LaunchServices handoff adoption)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1712,6 +1712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.1",
+ "block2",
  "libc",
  "objc2",
  "objc2-foundation",
@@ -1766,6 +1767,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,6 +690,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,7 +1086,9 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "objc2-screen-capture-kit",
+ "plist",
  "rustix",
+ "tempfile",
 ]
 
 [[package]]
@@ -1674,6 +1682,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1882,6 +1896,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plist"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml 0.41.0",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1931,6 +1958,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1989,6 +2022,15 @@ checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2617,6 +2659,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3147,7 +3219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
- "quick-xml",
+ "quick-xml 0.39.4",
  "quote",
 ]
 
@@ -3659,7 +3731,7 @@ version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8067892e940ed1727dea64690378601603b31d62dfde019a5335fbb7c0e0ed9"
 dependencies = [
- "quick-xml",
+ "quick-xml 0.39.4",
  "serde",
  "zbus_names",
  "zvariant",

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -60,18 +60,31 @@ objc2-foundation = { version = "0.3.2", default-features = false, features = [
     "NSEnumerator",
     "NSError",
     "NSString",
+    # `NSURL` — `ffi.rs::launch_bundle`'s `NSURL::fileURLWithPath`, building the file URL
+    # `NSWorkspace.openApplicationAtURL:...` takes.
+    "NSURL",
 ] }
 objc2-app-kit = { version = "0.3.2", default-features = false, features = [
     "NSApplication",
     "NSResponder",
-    # `NSRunningApplication` — focus-before-inject (`input.rs::focus`); `libc` unlocks its
-    # `runningApplicationWithProcessIdentifier(pid: libc::pid_t)` class method.
+    # `NSRunningApplication` — focus-before-inject (`input.rs::focus`), plus the
+    # bundle-launch adopt/terminate FFI (`ffi.rs::running_pid_for_bundle_id`/`terminate_app`);
+    # `libc` unlocks its `runningApplicationWithProcessIdentifier(pid: libc::pid_t)` class
+    # method.
     "NSRunningApplication",
+    # `NSWorkspace` — `ffi.rs::launch_bundle`'s `NSWorkspace.openApplication(at:configuration:
+    # completionHandler:)`. Also gates `NSWorkspaceOpenConfiguration` (header-translator
+    # generates both types into the same `NSWorkspace.rs` file, and the whole file is gated
+    # by this one feature — there is no separate `NSWorkspaceOpenConfiguration` feature to
+    # request). `block2` additionally gates the completion-handler method itself (its own
+    # `cfg(all(feature = "NSRunningApplication", feature = "block2"))`).
+    "NSWorkspace",
     # `NSPasteboard` — the general pasteboard read/write behind `Platform`'s clipboard seam
     # (`clipboard.rs`): unlocks `NSPasteboard`, its `generalPasteboard`/`clearContents`/
     # `stringForType`/`setString:forType:` methods, and the `NSPasteboardTypeString` constant.
     "NSPasteboard",
     "libc",
+    "block2",
 ] }
 objc2-screen-capture-kit = { version = "0.3.2", default-features = false, features = [
     "SCShareableContent",

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -40,6 +40,15 @@ harness = false
 name = "a11y"
 harness = false
 
+# Mac-gated `.app`-bundle-launch integration test (crates/glass-macos/tests/bundle_launch.rs)
+# — same harness=false main-thread requirement as `capture`/`input`/`windows`/`a11y` above
+# (start_app's bundle branch reaches AppKit's ffi::app_kit_init() too); drives
+# `MacosPlatform::start_app`'s direct-spawn/NSWorkspace-handoff/fail-closed paths against a
+# built `Demo.app` fixture and the stock `TextEdit.app`. See that file's module doc.
+[[test]]
+name = "bundle_launch"
+harness = false
+
 [dependencies]
 glass-core.workspace = true
 plist = "1"

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -42,6 +42,7 @@ harness = false
 
 [dependencies]
 glass-core.workspace = true
+plist = "1"
 
 # macOS-only FFI deps (objc2 family). Kept in this target table so the crate's pure
 # modules still build on the Linux dev box with zero macOS deps. Versions pinned to
@@ -142,6 +143,9 @@ rustix.workspace = true
 # pre_exec): the pure SBPL generator (`build_profile`) plus the macOS-only `sandbox_init`
 # FFI (`apply_cstr`).
 glass-sandbox-macos.workspace = true
+
+[dev-dependencies]
+tempfile = "3"
 
 # Mac-only: the accessibility-reader integration test (tests/a11y.rs) drives the standalone
 # `glass-a11y-macos` snapshot. Kept in the cfg(macos) dev-dep table so the crate still

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -145,7 +145,7 @@ rustix.workspace = true
 glass-sandbox-macos.workspace = true
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true
 
 # Mac-only: the accessibility-reader integration test (tests/a11y.rs) drives the standalone
 # `glass-a11y-macos` snapshot. Kept in the cfg(macos) dev-dep table so the crate still

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -102,11 +102,39 @@ pub struct MacosPlatform {
     /// handed off to `NSWorkspace` because the direct-spawned inner executable exited before a
     /// window appeared (see `start_bundle`'s doc). `None` in every other case, including a
     /// bundle that direct-spawned successfully (`self.child` is `Some` then, same as a plain
-    /// exec). The `bool` is launched-fresh: `true` when this call's own `ffi::launch_bundle`
-    /// started the app, so `stop_app` terminates it; `false` when `ffi::running_pid_for_bundle_id`
-    /// found an instance already running before this call, so `stop_app` leaves it running
-    /// rather than killing an app glass didn't start.
-    adopted: Option<(i32, bool)>,
+    /// exec). The [`Adopted`]'s `disposition` records how `stop_app`/`Drop` must reap it:
+    /// `Fresh` when this call's own `ffi::launch_bundle` started the app (glass terminates it),
+    /// `PreExisting` when `ffi::running_pid_for_bundle_id` found an instance already running
+    /// before this call (glass leaves it running rather than killing an app it didn't start).
+    adopted: Option<Adopted>,
+}
+
+/// A LaunchServices-adopted app tracked by `start_bundle`'s handoff path, bundled with the
+/// decision of how `stop_app`/`Drop` must reap it. Replaces the former bare `(i32, bool)`
+/// pair so the pid and its reap disposition travel together as one named unit, and the reap
+/// decision itself lives in a pure, testable predicate
+/// ([`crate::bundle::Disposition::should_terminate`]) rather than a lone `bool` hand-decoded
+/// identically at the two reap sites.
+struct Adopted {
+    /// The adopted app's pid — an `NSRunningApplication` process id, always non-negative.
+    pid: i32,
+    /// Whether glass started this instance (reap it) or merely re-found one already running
+    /// (leave it alive) — see [`crate::bundle::Disposition`].
+    disposition: crate::bundle::Disposition,
+}
+
+impl Adopted {
+    /// Reap the adopted app iff glass started it
+    /// ([`crate::bundle::Disposition::should_terminate`]). Uses [`crate::ffi::terminate_app`],
+    /// which is graceful-only (`-[NSRunningApplication terminate]`, no `SIGKILL`
+    /// escalation): an app that vetoes quit (e.g. an unsaved-changes sheet) is left running
+    /// by design, trading a possible stray process for never forcibly killing an app
+    /// mid-edit and losing the user's work.
+    fn reap(self) {
+        if self.disposition.should_terminate() {
+            crate::ffi::terminate_app(self.pid);
+        }
+    }
 }
 
 impl MacosPlatform {
@@ -171,8 +199,14 @@ impl MacosPlatform {
             if let Some(m) = crate::scwindow::query_once(&[pid as i32])? {
                 return Ok(m);
             }
-            if let Ok(Some(status)) = child.try_wait() {
-                return Err(GlassError::AppExited(status.code()));
+            match child.try_wait() {
+                Ok(Some(status)) => return Err(GlassError::AppExited(status.code())),
+                // A `try_wait` error means the child can no longer be reaped (e.g. the pid
+                // is already gone): treat it as an exit, not a bare poll hiccup, so a
+                // transient error here can't mask a handoff as a `Timeout` — `start_bundle`'s
+                // handoff decision keys on `AppExited`.
+                Err(_) => return Err(GlassError::AppExited(None)),
+                Ok(None) => {}
             }
             if Instant::now() >= deadline {
                 return Err(GlassError::Timeout(timeout_ms));
@@ -242,10 +276,11 @@ impl MacosPlatform {
         // A-preferred: direct-spawn the inner executable (logs + containment + window
         // tracking), exactly as the plain-exec path does for a non-bundle `run[0]`.
         let inner = crate::bundle::resolve_inner_exec(bundle)?;
+        // Swap only `run[0]` (the `.app` path) for the resolved inner executable, preserving
+        // any launch args. `run[0]` is guaranteed present — `start_app` checked
+        // `spec.run.first()` before delegating here.
         let mut direct = spec.clone();
-        direct.run = std::iter::once(inner.to_string_lossy().into_owned())
-            .chain(spec.run.iter().skip(1).cloned())
-            .collect();
+        direct.run[0] = inner.to_string_lossy().into_owned();
         let (mut child, clip) = process::spawn(&direct, self.logs.clone())?;
         let pid = child.id();
         match Self::discover_window(&mut child, pid, spec.timeout_ms) {
@@ -254,20 +289,40 @@ impl MacosPlatform {
                 self.child = Some(child);
                 self.app_pid = Some(pid);
                 self.active_window = Some(m.window_id);
+                // Defensive: a direct-spawn is never an adopted session — clear any stale
+                // handoff record from a prior un-stopped session so it can't widen
+                // `stop_app`/`Drop`'s reap blast radius (symmetric with the handoff path
+                // below clearing `self.child`).
+                self.adopted = None;
                 self.clipboard_route = decide_clip(spec.sandbox, clip.as_ref());
                 self.clip = clip;
                 Ok(m.geometry)
             }
-            Err(GlassError::AppExited(_)) => {
-                // Handoff: the direct-spawned process was a stub that re-launched the real app
-                // through LaunchServices. Don't leak the (dead) child or its pasteboards.
+            Err(e) => {
+                // The direct-spawned process is done with — dead (an `AppExited` stub) or
+                // simply never grew a window. Tear it down: terminate the child and release
+                // any clip-shim pasteboards it created. On a *successful* handoff `clip` is
+                // always `None` (handoff requires sandbox:off, which is never shim-injected),
+                // so `release_clip` there is a no-op; it does real work only for a contained
+                // launch that failed (a plain failure, or a contained stub the gate rejects
+                // just below).
                 process::terminate(&mut child);
                 release_clip(clip.as_ref());
+                // Only an early inner-exec exit (`AppExited`) is the handoff signal — a stub
+                // that re-launched the real app through LaunchServices. Any other failure
+                // (e.g. `Timeout`: the process is alive but never grew a window) is propagated
+                // as-is, exactly as the plain-exec path does. NOTE: `AppExited` here conflates
+                // a genuine early crash of the inner exec with a deliberate re-exec stub; both
+                // fall through to the handoff below, which then either finds/relaunches a real
+                // window or fails.
+                let GlassError::AppExited(_) = e else {
+                    return Err(e);
+                };
                 // Fail-closed: only sandbox:off may adopt an app glass can no longer contain.
                 crate::bundle::handoff_gate(spec.sandbox)?;
                 let id = crate::bundle::bundle_identifier(bundle)?;
-                let (pid, fresh) = match crate::ffi::running_pid_for_bundle_id(&id) {
-                    Some(pid) => (pid, false),
+                let (pid, disposition) = match crate::ffi::running_pid_for_bundle_id(&id) {
+                    Some(pid) => (pid, crate::bundle::Disposition::PreExisting),
                     // NOTE (runtime-verified in Task 4): `ffi::launch_bundle` blocks this
                     // thread on a channel until `NSWorkspace`'s completion handler fires: if
                     // LaunchServices needs the main run loop to spin to complete the launch,
@@ -275,18 +330,28 @@ impl MacosPlatform {
                     // main-thread-affinity notes), that handler could need a run-loop turn this
                     // blocked thread isn't pumping. Wired here per the design; the on-box round
                     // confirms whether it actually stalls.
-                    None => (crate::ffi::launch_bundle(bundle, spec.timeout_ms)?, true),
+                    None => match crate::ffi::launch_bundle(bundle, spec.timeout_ms) {
+                        Ok(pid) => (pid, crate::bundle::Disposition::Fresh),
+                        // `launch_bundle` can start the app yet still error before its pid is
+                        // delivered (e.g. its completion handler timed out) — an orphan. The
+                        // `None` just found above means any instance running now is one we
+                        // spawned, so best-effort reclaim it before propagating the error.
+                        Err(e) => {
+                            if let Some(pid) = crate::ffi::running_pid_for_bundle_id(&id) {
+                                crate::ffi::terminate_app(pid);
+                            }
+                            return Err(e);
+                        }
+                    },
                 };
                 // Don't orphan a fresh launch whose window never appears in time: adopt only
                 // after discovery succeeds, since `self.adopted` (what `stop_app`/`Drop` reap)
-                // isn't set until below. Terminate only a `fresh` launch — an already-running
-                // instance we merely re-found is not ours to kill.
+                // isn't set until below. Reaping here terminates only a `Fresh` launch — an
+                // already-running instance we merely re-found is not ours to kill.
                 let m = match Self::discover_window_pid(pid, spec.timeout_ms) {
                     Ok(m) => m,
                     Err(e) => {
-                        if fresh {
-                            crate::ffi::terminate_app(pid);
-                        }
+                        Adopted { pid, disposition }.reap();
                         return Err(e);
                     }
                 };
@@ -298,16 +363,11 @@ impl MacosPlatform {
                 // call sites, which cast the other direction).
                 self.app_pid = Some(pid as u32);
                 self.active_window = Some(m.window_id);
-                self.adopted = Some((pid, fresh));
+                self.adopted = Some(Adopted { pid, disposition });
                 self.clip = None;
                 self.clipboard_route =
                     crate::clipboard_route::decide_route(SandboxLevel::Off, None);
                 Ok(m.geometry)
-            }
-            Err(e) => {
-                process::terminate(&mut child);
-                release_clip(clip.as_ref());
-                Err(e)
             }
         }
     }
@@ -496,6 +556,11 @@ impl Platform for MacosPlatform {
             Ok(m) => {
                 self.child = Some(child);
                 self.app_pid = Some(pid);
+                // Defensive: a plain exec is never an adopted session — clear any stale
+                // handoff record from a prior un-stopped session so it can't widen
+                // `stop_app`/`Drop`'s reap blast radius (symmetric with `start_bundle`'s
+                // handoff path clearing `self.child`).
+                self.adopted = None;
                 // NOTE: this seeds the active-window model (Plan 4 design decision 2): the
                 // first window discovered for the launched app becomes the implicit target
                 // of capture/input, exactly as `select_window` (a later task) will retarget
@@ -539,10 +604,8 @@ impl Platform for MacosPlatform {
     /// structurally identical (both reap `adopted`, then `child`, then release pasteboards)
     /// instead of `stop_app` carrying its own divergent early-return.
     fn stop_app(&mut self) -> Result<()> {
-        if let Some((pid, fresh)) = self.adopted.take() {
-            if fresh {
-                crate::ffi::terminate_app(pid);
-            }
+        if let Some(a) = self.adopted.take() {
+            a.reap();
         }
         if let Some(mut child) = self.child.take() {
             process::terminate(&mut child);
@@ -808,10 +871,8 @@ impl Drop for MacosPlatform {
     /// this backend launched" reason; an activated-existing adoptee is left running, same as
     /// in `stop_app`.
     fn drop(&mut self) {
-        if let Some((pid, fresh)) = self.adopted.take() {
-            if fresh {
-                crate::ffi::terminate_app(pid);
-            }
+        if let Some(a) = self.adopted.take() {
+            a.reap();
         }
         if let Some(mut child) = self.child.take() {
             process::terminate(&mut child);
@@ -937,6 +998,83 @@ mod tests {
         };
         assert!(p.stop_app().is_ok());
         assert!(p.clip.is_none());
+    }
+
+    #[test]
+    fn stop_app_reaps_a_fresh_adoption_and_resets_state() {
+        // A `Fresh` adoptee is terminated on `stop_app` (glass started it). Pid 999_999
+        // resolves to no live app, so `ffi::terminate_app` is a no-op — this exercises the
+        // reap + full state reset without a real process, needing no TCC grant or main
+        // thread. Every per-session field must clear so a later `start_app` decides fresh.
+        let mut p = MacosPlatform {
+            logs: Arc::new(Mutex::new(Vec::new())),
+            app_pid: Some(999_999),
+            child: None,
+            active_window: Some(7),
+            clipboard_route: ClipboardRoute::Private("tech.fixedwidth.glass.clip.9.1.1".into()),
+            clip: None,
+            adopted: Some(Adopted {
+                pid: 999_999,
+                disposition: crate::bundle::Disposition::Fresh,
+            }),
+        };
+        assert!(p.stop_app().is_ok());
+        assert!(p.adopted.is_none());
+        assert_eq!(p.app_pid(), None);
+        assert_eq!(p.active_window, None);
+        assert_eq!(p.clipboard_route, ClipboardRoute::default());
+    }
+
+    #[test]
+    fn stop_app_leaves_a_pre_existing_adoption_but_resets_state() {
+        // A `PreExisting` adoptee is left running (glass only raised it), but the adopted
+        // record and the rest of the per-session state must still clear on `stop_app`.
+        let mut p = MacosPlatform {
+            logs: Arc::new(Mutex::new(Vec::new())),
+            app_pid: Some(999_999),
+            child: None,
+            active_window: Some(7),
+            clipboard_route: ClipboardRoute::default(),
+            clip: None,
+            adopted: Some(Adopted {
+                pid: 999_999,
+                disposition: crate::bundle::Disposition::PreExisting,
+            }),
+        };
+        assert!(p.stop_app().is_ok());
+        assert!(p.adopted.is_none());
+        assert_eq!(p.app_pid(), None);
+        assert_eq!(p.active_window, None);
+    }
+
+    #[test]
+    fn start_app_rejects_an_empty_run() {
+        // `start_app` must reject a spec with an empty `run` (no executable to launch) with a
+        // structured `AppNotStarted`, before any FFI/main-thread work — construct the struct
+        // directly (as the other tests here do) to bypass `new()`'s TCC preflight.
+        let mut p = MacosPlatform {
+            logs: Arc::new(Mutex::new(Vec::new())),
+            app_pid: None,
+            child: None,
+            active_window: None,
+            clipboard_route: ClipboardRoute::default(),
+            clip: None,
+            adopted: None,
+        };
+        let spec = AppSpec {
+            build: None,
+            run: vec![],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 1000,
+            sandbox: SandboxLevel::Off,
+            a11y: false,
+        };
+        assert!(matches!(
+            p.start_app(&spec),
+            Err(GlassError::AppNotStarted(_))
+        ));
     }
 
     #[test]

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -2,6 +2,7 @@
 //! window-server methods stubbed; Plan 2 fills capture + display provisioning, Plan 3
 //! input, Plan 4 windows. `new()` runs the TCC preflight so a missing grant fails fast.
 
+use std::path::Path;
 use std::process::Child;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -11,7 +12,8 @@ use objc2_application_services::AXUIElement;
 use glass_core::frame::{Frame, Region};
 use glass_core::logbuf::Stream;
 use glass_core::platform::{
-    AppSpec, KeyEvent, Platform, PointerEvent, WindowGeometry, WindowId, WindowInfo, WindowOp,
+    AppSpec, KeyEvent, Platform, PointerEvent, SandboxLevel, WindowGeometry, WindowId, WindowInfo,
+    WindowOp,
 };
 use glass_core::{GlassError, Result};
 
@@ -96,6 +98,15 @@ pub struct MacosPlatform {
     /// that depends on it can run after the launched window is confirmed; reset in
     /// `stop_app`.
     clip: Option<ClipLaunch>,
+    /// Set when the active window belongs to a LaunchServices-adopted app — one `start_bundle`
+    /// handed off to `NSWorkspace` because the direct-spawned inner executable exited before a
+    /// window appeared (see `start_bundle`'s doc). `None` in every other case, including a
+    /// bundle that direct-spawned successfully (`self.child` is `Some` then, same as a plain
+    /// exec). The `bool` is launched-fresh: `true` when this call's own `ffi::launch_bundle`
+    /// started the app, so `stop_app` terminates it; `false` when `ffi::running_pid_for_bundle_id`
+    /// found an instance already running before this call, so `stop_app` leaves it running
+    /// rather than killing an app glass didn't start.
+    adopted: Option<(i32, bool)>,
 }
 
 impl MacosPlatform {
@@ -109,6 +120,7 @@ impl MacosPlatform {
             active_window: None,
             clipboard_route: ClipboardRoute::default(),
             clip: None,
+            adopted: None,
         })
     }
 
@@ -169,6 +181,26 @@ impl MacosPlatform {
         }
     }
 
+    /// Poll for a window owned by `pid` alone, with no `Child` to race against —
+    /// `start_bundle`'s handoff path adopts a pid `NSWorkspace`/LaunchServices owns (found
+    /// already-running via `ffi::running_pid_for_bundle_id`, or just started via
+    /// `ffi::launch_bundle`), so unlike [`discover_window`] there is no local `Child` handle
+    /// (`std::process::Child`) to `try_wait` if the adopted app dies before its window
+    /// appears; this loop only re-queries `scwindow::query_once` until `timeout_ms` elapses.
+    fn discover_window_pid(pid: i32, timeout_ms: u64) -> Result<crate::scwindow::WindowMatch> {
+        crate::ffi::app_kit_init();
+        let deadline = Instant::now() + Duration::from_millis(timeout_ms.max(1));
+        loop {
+            if let Some(m) = crate::scwindow::query_once(&[pid])? {
+                return Ok(m);
+            }
+            if Instant::now() >= deadline {
+                return Err(GlassError::Timeout(timeout_ms));
+            }
+            std::thread::sleep(DISCOVERY_POLL_INTERVAL);
+        }
+    }
+
     /// Resolve the window `capture_frame`/`send_pointer`/`send_key` should target *this*
     /// call: `scwindow::find_window_by_id(active_window, [pid], ..)` once `select_window`
     /// (or `start_app`'s initial discovery) has set an active `CGWindowID` — the retargeting
@@ -188,6 +220,114 @@ impl MacosPlatform {
             Some(id) => crate::scwindow::find_window_by_id(id, &[pid], WINDOW_RESOLVE_TIMEOUT),
             None => crate::scwindow::find_window_for_pids(&[pid], WINDOW_RESOLVE_TIMEOUT),
         }
+    }
+
+    /// `start_app`'s bundle path, taken when `spec.run[0]` names a `.app` directory
+    /// (`bundle::is_app_bundle`): A-preferred, direct-spawn the bundle's inner executable
+    /// (`bundle::resolve_inner_exec`) exactly like a plain exec — same logs, containment, and
+    /// window-tracking as the non-bundle path — and only fall back to handing the launch off
+    /// to `NSWorkspace` if that direct spawn's process exits before a window ever appears
+    /// (`GlassError::AppExited`, e.g. an app that re-execs itself via LaunchServices and
+    /// leaves the direct-spawned process a dead stub). Any other discovery failure (e.g.
+    /// `GlassError::Timeout`) is NOT treated as a handoff signal — the direct-spawned process
+    /// is still alive and simply never grew a window, so it's terminated and the error
+    /// propagated, same as the plain-exec path.
+    ///
+    /// The handoff itself can't be Seatbelt-contained (`bundle::handoff_gate` fails closed:
+    /// only `sandbox: off` may adopt it), and has no clipboard shim (an
+    /// `NSWorkspace`-launched process is never `direct.env`'s `DYLD_INSERT_LIBRARIES`
+    /// target), so its `ClipboardRoute` is decided directly as the sandbox-off/no-shim case
+    /// rather than via [`decide_clip`].
+    fn start_bundle(&mut self, spec: &AppSpec, bundle: &Path) -> Result<WindowGeometry> {
+        // A-preferred: direct-spawn the inner executable (logs + containment + window
+        // tracking), exactly as the plain-exec path does for a non-bundle `run[0]`.
+        let inner = crate::bundle::resolve_inner_exec(bundle)?;
+        let mut direct = spec.clone();
+        direct.run = std::iter::once(inner.to_string_lossy().into_owned())
+            .chain(spec.run.iter().skip(1).cloned())
+            .collect();
+        let (mut child, clip) = process::spawn(&direct, self.logs.clone())?;
+        let pid = child.id();
+        match Self::discover_window(&mut child, pid, spec.timeout_ms) {
+            Ok(m) => {
+                // Foreground app: adopt exactly as the plain-exec Ok arm does.
+                self.child = Some(child);
+                self.app_pid = Some(pid);
+                self.active_window = Some(m.window_id);
+                self.clipboard_route = decide_clip(spec.sandbox, clip.as_ref());
+                self.clip = clip;
+                Ok(m.geometry)
+            }
+            Err(GlassError::AppExited(_)) => {
+                // Handoff: the direct-spawned process was a stub that re-launched the real app
+                // through LaunchServices. Don't leak the (dead) child or its pasteboards.
+                process::terminate(&mut child);
+                release_clip(clip.as_ref());
+                // Fail-closed: only sandbox:off may adopt an app glass can no longer contain.
+                crate::bundle::handoff_gate(spec.sandbox)?;
+                let id = crate::bundle::bundle_identifier(bundle)?;
+                let (pid, fresh) = match crate::ffi::running_pid_for_bundle_id(&id) {
+                    Some(pid) => (pid, false),
+                    // NOTE (runtime-verified in Task 4): `ffi::launch_bundle` blocks this
+                    // thread on a channel until `NSWorkspace`'s completion handler fires: if
+                    // LaunchServices needs the main run loop to spin to complete the launch,
+                    // and this call runs on the true main thread (see this module's
+                    // main-thread-affinity notes), that handler could need a run-loop turn this
+                    // blocked thread isn't pumping. Wired here per the design; the on-box round
+                    // confirms whether it actually stalls.
+                    None => (crate::ffi::launch_bundle(bundle, spec.timeout_ms)?, true),
+                };
+                let m = Self::discover_window_pid(pid, spec.timeout_ms)?;
+                self.child = None;
+                // `app_pid` is `u32` (every other pid in this struct comes from
+                // `std::process::Child::id()`); AppKit's pids are `i32` but always
+                // non-negative for a real process, so this cast is exact, matching every
+                // other `pid as {i32,u32}` cast in this file (see e.g. `resolve_active_window`'s
+                // call sites, which cast the other direction).
+                self.app_pid = Some(pid as u32);
+                self.active_window = Some(m.window_id);
+                self.adopted = Some((pid, fresh));
+                self.clip = None;
+                self.clipboard_route =
+                    crate::clipboard_route::decide_route(SandboxLevel::Off, None);
+                Ok(m.geometry)
+            }
+            Err(e) => {
+                process::terminate(&mut child);
+                release_clip(clip.as_ref());
+                Err(e)
+            }
+        }
+    }
+}
+
+/// Decide the launched session's `ClipboardRoute` from the sandbox level and the clip-shim
+/// launch facts `process::spawn` produced (`None` for an uncontained or non-injectable
+/// launch) — shared by `start_app`'s and `start_bundle`'s direct-spawn success paths, both of
+/// which reach this only once the launched window is confirmed. `clip`'s presence only means
+/// the launch was injectable; a live `clipboard::shim_present` check confirms the swizzle
+/// actually took before a `Private` route is trusted (an injectable target whose injection
+/// silently failed must still land on `Unsupported`, not a `Private` route to a pasteboard
+/// the app was never redirected to).
+fn decide_clip(sandbox: SandboxLevel, clip: Option<&ClipLaunch>) -> ClipboardRoute {
+    match clip {
+        Some(c) => {
+            let confirmed = crate::clipboard::shim_present(&c.name);
+            crate::clipboard_route::decide_route(sandbox, Some((&c.name, confirmed)))
+        }
+        None => crate::clipboard_route::decide_route(sandbox, None),
+    }
+}
+
+/// Release `clip`'s named pasteboards (the content board and its `.ready` sentinel), a no-op
+/// when `clip` is `None`. Named pasteboards persist system-wide until released, so every path
+/// that ends a `ClipLaunch`'s lifetime — `start_app`'s/`start_bundle`'s discovery-failure arms
+/// (the launch never became a session), and `stop_app`/`Drop` (an established session ended) —
+/// must release it here, or the boards leak for the life of the host process.
+fn release_clip(clip: Option<&ClipLaunch>) {
+    if let Some(c) = clip {
+        crate::clipboard::release_named(&c.name);
+        crate::clipboard::release_named(&format!("{}.ready", c.name));
     }
 }
 
@@ -323,8 +463,21 @@ impl Platform for MacosPlatform {
     /// requires the true main thread (`MainThreadMarker` panics off it). In Plan 2 this is
     /// exercised only by Task 6's `harness=false` main-thread test; wiring it under
     /// glass-mcp's worker-thread dispatcher (main-thread marshaling) is deferred to Plan 5.
+    ///
+    /// **`.app` bundles:** when `spec.run[0]` names a `.app` bundle directory
+    /// (`bundle::is_app_bundle`), this delegates to [`Self::start_bundle`] instead of the
+    /// plain-exec path below — see its doc for the direct-spawn-then-NSWorkspace-handoff
+    /// design. Every other `run[0]` (the plain-exec case) takes the unchanged path that
+    /// follows.
     fn start_app(&mut self, spec: &AppSpec) -> Result<WindowGeometry> {
         Self::run_build(spec)?;
+        let run0 = spec
+            .run
+            .first()
+            .ok_or_else(|| GlassError::AppNotStarted("empty run".into()))?;
+        if crate::bundle::is_app_bundle(run0) {
+            return self.start_bundle(spec, Path::new(run0));
+        }
         let (mut child, clip) = process::spawn(spec, self.logs.clone())?;
         let pid = child.id();
         match Self::discover_window(&mut child, pid, spec.timeout_ms) {
@@ -339,22 +492,8 @@ impl Platform for MacosPlatform {
                 // this field on every call.
                 self.active_window = Some(m.window_id);
                 // Decide the session's clipboard route now that the launched window is
-                // confirmed: `clip` only carries the shim's launch-time name (its presence
-                // means the launch was injectable), so a live `clipboard::shim_present` check
-                // confirms the swizzle actually took before a `Private` route is trusted (an
-                // injectable target whose injection silently failed must still land on
-                // `Unsupported`, not a `Private` route to a pasteboard the app was never
-                // redirected to).
-                self.clipboard_route = match &clip {
-                    Some(c) => {
-                        let confirmed = crate::clipboard::shim_present(&c.name);
-                        crate::clipboard_route::decide_route(
-                            spec.sandbox,
-                            Some((&c.name, confirmed)),
-                        )
-                    }
-                    None => crate::clipboard_route::decide_route(spec.sandbox, None),
-                };
+                // confirmed — see `decide_clip`'s doc.
+                self.clipboard_route = decide_clip(spec.sandbox, clip.as_ref());
                 self.clip = clip;
                 // Scale/origin/geometry are NOT cached here: `send_pointer` re-resolves the
                 // window fresh on every call instead (see its doc) since it may move/resize
@@ -368,11 +507,8 @@ impl Platform for MacosPlatform {
                 process::terminate(&mut child);
                 // Nor the named pasteboards the shim may already have created — the app (and
                 // its ctor) ran before discovery. `self.clip` is never set on this path, so
-                // `stop_app` wouldn't release them; do it here.
-                if let Some(c) = &clip {
-                    crate::clipboard::release_named(&c.name);
-                    crate::clipboard::release_named(&format!("{}.ready", c.name));
-                }
+                // `stop_app` wouldn't release them; do it here (`release_clip`'s doc).
+                release_clip(clip.as_ref());
                 Err(e)
             }
         }
@@ -380,7 +516,23 @@ impl Platform for MacosPlatform {
 
     /// Terminate the launched child (if any) and clear the active pid/window. Idempotent —
     /// a call with nothing running is `Ok(())`.
+    ///
+    /// An `adopted` app (`start_bundle`'s NSWorkspace-handoff path — no `self.child` to
+    /// terminate) is handled first and returns early: a freshly-launched adoptee is
+    /// terminated via `ffi::terminate_app` (glass started it, so glass stops it), while an
+    /// activated-existing one is left running (glass only raised it, so it isn't glass's to
+    /// kill) — see the `adopted` field's doc for the two cases.
     fn stop_app(&mut self) -> Result<()> {
+        if let Some((pid, fresh)) = self.adopted.take() {
+            if fresh {
+                crate::ffi::terminate_app(pid);
+            }
+            self.app_pid = None;
+            self.active_window = None;
+            self.clipboard_route = ClipboardRoute::default();
+            self.clip = None;
+            return Ok(());
+        }
         if let Some(mut child) = self.child.take() {
             process::terminate(&mut child);
         }
@@ -389,10 +541,7 @@ impl Platform for MacosPlatform {
         // released, and a leftover sentinel could otherwise mask a failed injection in a later
         // session (see `crate::clipboard_route`). Only released when a shim launch name is
         // known (an injectable, contained launch); uncontained/hardened launches have none.
-        if let Some(clip) = &self.clip {
-            crate::clipboard::release_named(&clip.name);
-            crate::clipboard::release_named(&format!("{}.ready", clip.name));
-        }
+        release_clip(self.clip.as_ref());
         self.app_pid = None;
         self.active_window = None;
         // Reset the clipboard route too, so a later start_app on the same MacosPlatform can't
@@ -642,17 +791,24 @@ impl Drop for MacosPlatform {
     /// the process-exit backstop path) does not orphan its child. `process::terminate`
     /// is idempotent, and `child.take()` in `stop_app` means this is a no-op if
     /// `stop_app` already ran.
+    ///
+    /// A freshly-launched `adopted` app (`start_bundle`'s handoff path — no `self.child`)
+    /// gets the same treatment via `ffi::terminate_app`, for the same "don't orphan what
+    /// this backend launched" reason; an activated-existing adoptee is left running, same as
+    /// in `stop_app`.
     fn drop(&mut self) {
+        if let Some((pid, fresh)) = self.adopted.take() {
+            if fresh {
+                crate::ffi::terminate_app(pid);
+            }
+        }
         if let Some(mut child) = self.child.take() {
             process::terminate(&mut child);
         }
         // Release this session's named pasteboards too if `stop_app` didn't run (panic-unwind
         // or the process-exit backstop). `stop_app` sets `self.clip = None`, so this is a no-op
         // when it already ran; otherwise the boards would leak system-wide.
-        if let Some(clip) = &self.clip {
-            crate::clipboard::release_named(&clip.name);
-            crate::clipboard::release_named(&format!("{}.ready", clip.name));
-        }
+        release_clip(self.clip.as_ref());
     }
 }
 
@@ -671,6 +827,7 @@ mod tests {
             active_window: None,
             clipboard_route: ClipboardRoute::default(),
             clip: None,
+            adopted: None,
         };
         assert_eq!(p.drain_logs().len(), 1);
         assert!(p.drain_logs().is_empty());
@@ -685,6 +842,7 @@ mod tests {
             active_window: None,
             clipboard_route: ClipboardRoute::default(),
             clip: None,
+            adopted: None,
         };
         assert_eq!(p.app_pid(), Some(42));
     }
@@ -701,6 +859,7 @@ mod tests {
             active_window: None,
             clipboard_route: ClipboardRoute::default(),
             clip: None,
+            adopted: None,
         };
         assert!(p.stop_app().is_ok());
         assert!(p.stop_app().is_ok(), "a second call must also be Ok");
@@ -719,6 +878,7 @@ mod tests {
             active_window: Some(7),
             clipboard_route: ClipboardRoute::default(),
             clip: None,
+            adopted: None,
         };
         assert!(p.stop_app().is_ok());
         assert_eq!(p.active_window, None);
@@ -739,6 +899,7 @@ mod tests {
             active_window: Some(7),
             clipboard_route: ClipboardRoute::Private("tech.fixedwidth.glass.clip.42.1.1".into()),
             clip: None,
+            adopted: None,
         };
         assert!(p.stop_app().is_ok());
         assert_eq!(p.clipboard_route, ClipboardRoute::default());
@@ -761,6 +922,7 @@ mod tests {
             clip: Some(ClipLaunch {
                 name: "tech.fixedwidth.glass.clip.42.1.1".into(),
             }),
+            adopted: None,
         };
         assert!(p.stop_app().is_ok());
         assert!(p.clip.is_none());
@@ -779,6 +941,7 @@ mod tests {
             active_window: None,
             clipboard_route: ClipboardRoute::Unsupported,
             clip: None,
+            adopted: None,
         };
         assert!(matches!(p.get_clipboard(), Err(GlassError::Unsupported(_))));
         assert!(matches!(
@@ -800,6 +963,7 @@ mod tests {
             active_window: None,
             clipboard_route: ClipboardRoute::RealGeneral,
             clip: None,
+            adopted: None,
         };
         assert!(!matches!(
             p.get_clipboard(),

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -277,7 +277,19 @@ impl MacosPlatform {
                     // confirms whether it actually stalls.
                     None => (crate::ffi::launch_bundle(bundle, spec.timeout_ms)?, true),
                 };
-                let m = Self::discover_window_pid(pid, spec.timeout_ms)?;
+                // Don't orphan a fresh launch whose window never appears in time: adopt only
+                // after discovery succeeds, since `self.adopted` (what `stop_app`/`Drop` reap)
+                // isn't set until below. Terminate only a `fresh` launch — an already-running
+                // instance we merely re-found is not ours to kill.
+                let m = match Self::discover_window_pid(pid, spec.timeout_ms) {
+                    Ok(m) => m,
+                    Err(e) => {
+                        if fresh {
+                            crate::ffi::terminate_app(pid);
+                        }
+                        return Err(e);
+                    }
+                };
                 self.child = None;
                 // `app_pid` is `u32` (every other pid in this struct comes from
                 // `std::process::Child::id()`); AppKit's pids are `i32` but always
@@ -514,24 +526,23 @@ impl Platform for MacosPlatform {
         }
     }
 
-    /// Terminate the launched child (if any) and clear the active pid/window. Idempotent —
-    /// a call with nothing running is `Ok(())`.
+    /// Terminate the launched app (however it was launched) and clear the active pid/window.
+    /// Idempotent — a call with nothing running is `Ok(())`.
     ///
     /// An `adopted` app (`start_bundle`'s NSWorkspace-handoff path — no `self.child` to
-    /// terminate) is handled first and returns early: a freshly-launched adoptee is
-    /// terminated via `ffi::terminate_app` (glass started it, so glass stops it), while an
-    /// activated-existing one is left running (glass only raised it, so it isn't glass's to
-    /// kill) — see the `adopted` field's doc for the two cases.
+    /// terminate) is reaped first: a freshly-launched adoptee is terminated via
+    /// `ffi::terminate_app` (glass started it, so glass stops it), while an activated-existing
+    /// one is left running (glass only raised it, so it isn't glass's to kill) — see the
+    /// `adopted` field's doc. This then falls through to the child/pasteboard cleanup below
+    /// rather than returning early: a session is only ever `adopted` XOR `child`-backed, so the
+    /// fall-through is a no-op for an adopted session, but it keeps `stop_app` and `Drop`
+    /// structurally identical (both reap `adopted`, then `child`, then release pasteboards)
+    /// instead of `stop_app` carrying its own divergent early-return.
     fn stop_app(&mut self) -> Result<()> {
         if let Some((pid, fresh)) = self.adopted.take() {
             if fresh {
                 crate::ffi::terminate_app(pid);
             }
-            self.app_pid = None;
-            self.active_window = None;
-            self.clipboard_route = ClipboardRoute::default();
-            self.clip = None;
-            return Ok(());
         }
         if let Some(mut child) = self.child.take() {
             process::terminate(&mut child);

--- a/crates/glass-macos/src/bundle.rs
+++ b/crates/glass-macos/src/bundle.rs
@@ -1,0 +1,114 @@
+//! Pure `.app`-bundle logic: detection, Info.plist resolution, and the fail-closed
+//! containment gate. Host-agnostic (no FFI) so it unit-tests on any host, like
+//! `glass-windows/src/discovery.rs`.
+#![allow(dead_code)]
+
+use glass_core::{platform::SandboxLevel, GlassError, Result};
+use std::path::{Path, PathBuf};
+
+/// True when `run[0]` names a `.app` bundle directory (the trigger for the NSWorkspace-capable
+/// launch path). A plain executable path returns false and takes the unchanged direct-spawn path.
+pub(crate) fn is_app_bundle(run0: &str) -> bool {
+    let p = Path::new(run0);
+    p.extension().is_some_and(|e| e.eq_ignore_ascii_case("app"))
+        && p.join("Contents/Info.plist").is_file()
+}
+
+/// `Contents/MacOS/<CFBundleExecutable>` for the bundle.
+pub(crate) fn resolve_inner_exec(bundle: &Path) -> Result<PathBuf> {
+    let name = plist_string(bundle, "CFBundleExecutable")?;
+    Ok(bundle.join("Contents/MacOS").join(name))
+}
+
+/// The bundle's `CFBundleIdentifier` (used to find the handed-off LaunchServices instance).
+pub(crate) fn bundle_identifier(bundle: &Path) -> Result<String> {
+    plist_string(bundle, "CFBundleIdentifier")
+}
+
+/// Fail-closed: a handed-off app can't be Seatbelt-contained, so only `Off` may adopt it.
+pub(crate) fn handoff_gate(level: SandboxLevel) -> Result<()> {
+    match level {
+        SandboxLevel::Off => Ok(()),
+        _ => Err(GlassError::AppNotStarted(
+            "app handed off to LaunchServices and can't be Seatbelt-contained; \
+             relaunch with sandbox:\"off\""
+                .into(),
+        )),
+    }
+}
+
+fn plist_string(bundle: &Path, key: &str) -> Result<String> {
+    let path = bundle.join("Contents/Info.plist");
+    let val = plist::Value::from_file(&path)
+        .map_err(|e| GlassError::AppNotStarted(format!("reading {}: {e}", path.display())))?;
+    val.as_dictionary()
+        .and_then(|d| d.get(key))
+        .and_then(|v| v.as_string())
+        .map(str::to_owned)
+        .ok_or_else(|| GlassError::AppNotStarted(format!("{key} missing in {}", path.display())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn write_bundle(dir: &Path, info_plist: &str) -> PathBuf {
+        let app = dir.join("Demo.app");
+        fs::create_dir_all(app.join("Contents/MacOS")).unwrap();
+        fs::write(app.join("Contents/Info.plist"), info_plist).unwrap();
+        app
+    }
+
+    const INFO: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>CFBundleExecutable</key><string>Demo</string>
+<key>CFBundleIdentifier</key><string>tech.fixedwidth.demo</string>
+</dict></plist>"#;
+
+    #[test]
+    fn detects_app_bundle_only_with_info_plist() {
+        let tmp = tempfile::tempdir().unwrap();
+        let app = write_bundle(tmp.path(), INFO);
+        assert!(is_app_bundle(app.to_str().unwrap()));
+        assert!(!is_app_bundle("/usr/bin/true"));
+        assert!(!is_app_bundle(
+            tmp.path().join("NoPlist.app").to_str().unwrap()
+        ));
+    }
+
+    #[test]
+    fn resolves_inner_exec_and_bundle_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let app = write_bundle(tmp.path(), INFO);
+        assert_eq!(
+            resolve_inner_exec(&app).unwrap(),
+            app.join("Contents/MacOS/Demo")
+        );
+        assert_eq!(bundle_identifier(&app).unwrap(), "tech.fixedwidth.demo");
+    }
+
+    #[test]
+    fn missing_key_is_structured_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let app = write_bundle(tmp.path(), "<plist version=\"1.0\"><dict></dict></plist>");
+        assert!(matches!(
+            resolve_inner_exec(&app),
+            Err(GlassError::AppNotStarted(_))
+        ));
+    }
+
+    #[test]
+    fn handoff_gate_only_allows_off() {
+        assert!(handoff_gate(SandboxLevel::Off).is_ok());
+        assert!(matches!(
+            handoff_gate(SandboxLevel::Default),
+            Err(GlassError::AppNotStarted(_))
+        ));
+        assert!(matches!(
+            handoff_gate(SandboxLevel::Strict),
+            Err(GlassError::AppNotStarted(_))
+        ));
+    }
+}

--- a/crates/glass-macos/src/bundle.rs
+++ b/crates/glass-macos/src/bundle.rs
@@ -60,6 +60,38 @@ pub(crate) fn handoff_gate(level: SandboxLevel) -> Result<()> {
     }
 }
 
+/// Whether an app adopted via the LaunchServices handoff path (`backend.rs`'s
+/// `start_bundle`) is one glass itself started on this call — and so must reap when the
+/// session ends — or one it merely re-found already running, which it must leave alive.
+/// Carried in [`backend::MacosPlatform`]'s `Adopted` record and consulted by
+/// `stop_app`/`Drop` via [`Disposition::should_terminate`].
+///
+/// Derivation caveat: this can't distinguish a genuinely pre-existing user instance from a
+/// stub-spawned LaunchServices copy that briefly raced ahead of the adoption lookup. The
+/// derivation is therefore biased deliberately toward the safer `PreExisting` ("leave the
+/// app alive") whenever it can't be certain glass started the instance — never toward
+/// terminating an app glass may not own.
+#[derive(Clone, Copy)]
+pub(crate) enum Disposition {
+    /// This call's own `ffi::launch_bundle` started the app — glass owns its lifetime, so
+    /// it is terminated when the session ends.
+    Fresh,
+    /// `ffi::running_pid_for_bundle_id` found an instance already running before this call —
+    /// glass only raised it, so it is left running.
+    PreExisting,
+}
+
+impl Disposition {
+    /// Pure reap predicate: only a `Fresh` adoption is terminated on `stop_app`/`Drop`. Kept
+    /// as a standalone predicate (rather than an inline `if fresh`) so the "which
+    /// disposition gets terminated" decision has one unit-testable definition — a boolean
+    /// inversion here would terminate a user's pre-existing app, so it carries a dedicated
+    /// off-macOS test (see `disposition_only_terminates_fresh`).
+    pub(crate) fn should_terminate(self) -> bool {
+        matches!(self, Disposition::Fresh)
+    }
+}
+
 fn plist_string(bundle: &Path, key: &str) -> Result<String> {
     let path = bundle.join("Contents/Info.plist");
     let val = plist::Value::from_file(&path)
@@ -130,17 +162,54 @@ mod tests {
 
     #[test]
     fn non_bare_executable_name_is_rejected() {
+        // Every non-bare `CFBundleExecutable` form must be rejected before the resolved path
+        // is ever handed to `exec`. Each string exercises a different branch of
+        // `is_bare_filename`:
+        //   - `../../etc/evil` — a `..` traversal (leading `ParentDir` component)
+        //   - `/etc/evil`      — a bare absolute path (leading `RootDir` component)
+        //   - `sub/exec`       — a nested, non-traversing name (two `Normal` components, so
+        //                        the second `components.next()` is `Some`, not `None`)
+        //   - `Demo/`          — a trailing slash: one `Normal` component, but its
+        //                        reconstructed bytes ("Demo") differ from the raw string
+        //                        ("Demo/"), caught by the byte-equality guard
         let tmp = tempfile::tempdir().unwrap();
-        let app = write_bundle(
-            tmp.path(),
-            r#"<plist version="1.0"><dict>
-<key>CFBundleExecutable</key><string>../../etc/evil</string>
-</dict></plist>"#,
-        );
+        for evil in ["../../etc/evil", "/etc/evil", "sub/exec", "Demo/"] {
+            let app = write_bundle(
+                tmp.path(),
+                &format!(
+                    r#"<plist version="1.0"><dict>
+<key>CFBundleExecutable</key><string>{evil}</string>
+</dict></plist>"#
+                ),
+            );
+            assert!(
+                matches!(resolve_inner_exec(&app), Err(GlassError::AppNotStarted(_))),
+                "expected {evil:?} to be rejected as a non-bare CFBundleExecutable"
+            );
+        }
+    }
+
+    #[test]
+    fn unparseable_plist_is_structured_error() {
+        // A genuinely malformed Info.plist (not merely one missing a key) must surface as a
+        // structured `AppNotStarted` from the `plist::Value::from_file` read itself — a
+        // distinct failure from `missing_key_is_structured_error` above, which parses fine
+        // but lacks the key.
+        let tmp = tempfile::tempdir().unwrap();
+        let app = write_bundle(tmp.path(), "not a plist");
         assert!(matches!(
             resolve_inner_exec(&app),
             Err(GlassError::AppNotStarted(_))
         ));
+    }
+
+    #[test]
+    fn disposition_only_terminates_fresh() {
+        // Pure CI backstop for the reap decision (runs off macOS): a boolean inversion here
+        // would make `stop_app`/`Drop` terminate a user's pre-existing app (`PreExisting`) or
+        // orphan a glass-started one (`Fresh`).
+        assert!(Disposition::Fresh.should_terminate());
+        assert!(!Disposition::PreExisting.should_terminate());
     }
 
     #[test]

--- a/crates/glass-macos/src/bundle.rs
+++ b/crates/glass-macos/src/bundle.rs
@@ -1,10 +1,14 @@
 //! Pure `.app`-bundle logic: detection, Info.plist resolution, and the fail-closed
 //! containment gate. Host-agnostic (no FFI) so it unit-tests on any host, like
 //! `glass-windows/src/discovery.rs`.
-#![allow(dead_code)]
+#![forbid(unsafe_code)]
+// These fns are consumed by the cfg(macos) launch path (tasks 2/3) and exercised by the
+// unit tests below, so off-macOS non-test builds see them as dead. Keep the lint live on
+// macOS. Same pattern as `glass-windows/src/doctor.rs`.
+#![cfg_attr(not(target_os = "macos"), allow(dead_code))]
 
 use glass_core::{platform::SandboxLevel, GlassError, Result};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 /// True when `run[0]` names a `.app` bundle directory (the trigger for the NSWorkspace-capable
 /// launch path). A plain executable path returns false and takes the unchanged direct-spawn path.
@@ -14,10 +18,29 @@ pub(crate) fn is_app_bundle(run0: &str) -> bool {
         && p.join("Contents/Info.plist").is_file()
 }
 
-/// `Contents/MacOS/<CFBundleExecutable>` for the bundle.
+/// `Contents/MacOS/<CFBundleExecutable>` for the bundle. The executable name must be a
+/// bare filename — the resolved path is `exec`'d by a later task, so a value that is
+/// absolute or contains a separator / `..` traversal is rejected as a structured error.
 pub(crate) fn resolve_inner_exec(bundle: &Path) -> Result<PathBuf> {
     let name = plist_string(bundle, "CFBundleExecutable")?;
+    if !is_bare_filename(&name) {
+        return Err(GlassError::AppNotStarted(format!(
+            "CFBundleExecutable {name:?} is not a bare filename in {}",
+            bundle.join("Contents/Info.plist").display()
+        )));
+    }
     Ok(bundle.join("Contents/MacOS").join(name))
+}
+
+/// True only when `name` is a single normal path component: not absolute, no separators,
+/// no `.`/`..` traversal. Guards the `CFBundleExecutable` value before it is joined and
+/// handed to `exec`.
+fn is_bare_filename(name: &str) -> bool {
+    let mut components = Path::new(name).components();
+    matches!(
+        (components.next(), components.next()),
+        (Some(Component::Normal(c)), None) if c.as_encoded_bytes() == name.as_bytes()
+    )
 }
 
 /// The bundle's `CFBundleIdentifier` (used to find the handed-off LaunchServices instance).
@@ -72,10 +95,16 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let app = write_bundle(tmp.path(), INFO);
         assert!(is_app_bundle(app.to_str().unwrap()));
+        // A plain executable path is not a bundle.
         assert!(!is_app_bundle("/usr/bin/true"));
+        // A `.app` path that doesn't exist is not a bundle.
         assert!(!is_app_bundle(
             tmp.path().join("NoPlist.app").to_str().unwrap()
         ));
+        // An existing `.app` directory MISSING `Contents/Info.plist` is not a bundle.
+        let empty_app = tmp.path().join("Empty.app");
+        fs::create_dir_all(empty_app.join("Contents/MacOS")).unwrap();
+        assert!(!is_app_bundle(empty_app.to_str().unwrap()));
     }
 
     #[test]
@@ -93,6 +122,21 @@ mod tests {
     fn missing_key_is_structured_error() {
         let tmp = tempfile::tempdir().unwrap();
         let app = write_bundle(tmp.path(), "<plist version=\"1.0\"><dict></dict></plist>");
+        assert!(matches!(
+            resolve_inner_exec(&app),
+            Err(GlassError::AppNotStarted(_))
+        ));
+    }
+
+    #[test]
+    fn non_bare_executable_name_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let app = write_bundle(
+            tmp.path(),
+            r#"<plist version="1.0"><dict>
+<key>CFBundleExecutable</key><string>../../etc/evil</string>
+</dict></plist>"#,
+        );
         assert!(matches!(
             resolve_inner_exec(&app),
             Err(GlassError::AppNotStarted(_))

--- a/crates/glass-macos/src/ffi.rs
+++ b/crates/glass-macos/src/ffi.rs
@@ -50,14 +50,26 @@
 //!   type (`Retained<T>` / `Option<Retained<T>>` / `bool` / a primitive) and the
 //!   selector's method family (`new`/`alloc`/`init`/`copy`) — no `msg_send_id!` needed
 //!   (deprecated in objc2 0.6).
+//! - Not every generated binding needs an `unsafe` block: header-translator marks a method
+//!   `unsafe fn` only when it judges the call genuinely unsafe (e.g. `SCShareableContent`'s
+//!   completion-handler registration); plenty of others — every `NSRunningApplication`/
+//!   `NSWorkspace` method used below, `NSString::from_str`, `NSURL::fileURLWithPath` — are
+//!   plain safe `fn`s. Read each generated signature rather than wrapping defensively; an
+//!   `unsafe` block around an already-safe call trips the `unused_unsafe` lint under this
+//!   workspace's `-D warnings` gate.
 
-use std::sync::Once;
+use std::path::Path;
+use std::sync::{mpsc, Once};
+use std::time::Duration;
 
+use block2::RcBlock;
 use objc2::MainThreadMarker;
-use objc2_app_kit::NSApplication;
-use objc2_foundation::NSError;
+use objc2_app_kit::{
+    NSApplication, NSRunningApplication, NSWorkspace, NSWorkspaceOpenConfiguration,
+};
+use objc2_foundation::{NSError, NSString, NSURL};
 
-use glass_core::GlassError;
+use glass_core::{GlassError, Result};
 
 use crate::permissions::Permission;
 
@@ -150,6 +162,89 @@ pub(crate) fn classify_null_result(err_ptr: *mut NSError, fallback_msg: &str) ->
         Permission::ScreenRecording.denied_with_detail(detail)
     } else {
         GlassError::CaptureFailed(detail)
+    }
+}
+
+/// The first running application whose `CFBundleIdentifier` equals `bundle_id`, or `None`
+/// if none is currently running. `backend.rs`'s bundle-launch path (task 3) uses
+/// this to detect that `LaunchServices` handed the launch off to an already-running
+/// instance rather than spawning the process this call started.
+///
+/// No `unsafe` needed: `NSRunningApplication::runningApplicationsWithBundleIdentifier` and
+/// `processIdentifier` are both plain safe bindings (see this module's doc) — same shape as
+/// `input.rs::focus`'s `runningApplicationWithProcessIdentifier` lookup.
+pub(crate) fn running_pid_for_bundle_id(bundle_id: &str) -> Option<i32> {
+    let id = NSString::from_str(bundle_id);
+    let apps = NSRunningApplication::runningApplicationsWithBundleIdentifier(&id);
+    apps.iter().next().map(|app| app.processIdentifier())
+}
+
+/// Launch (or, per `NSWorkspaceOpenConfiguration`'s default `createsNewApplicationInstance
+/// == false`, adopt an already-running instance of) the `.app` bundle at `bundle` via
+/// `NSWorkspace.openApplication(at:configuration:completionHandler:)`, blocking the calling
+/// thread on the async completion handler for up to `timeout_ms` (this module's documented
+/// async-bridge convention: the block sends only a plain `Result<i32, String>` — never a
+/// `Retained<NSRunningApplication>` — across the channel). Returns the launched/adopted
+/// app's pid.
+///
+/// [`GlassError::AppNotStarted`] carries the framework's own `NSError` description when the
+/// completion handler reports failure. `NSWorkspace` documents the handler as being called
+/// with either a non-nil app or a non-nil error, never neither — but per
+/// [`classify_null_result`]'s identical stance on ScreenCaptureKit's completion handlers,
+/// that contract is handled defensively rather than assumed, so a (framework-violating)
+/// null/null callback still yields a message instead of silently dropping the reply.
+/// [`GlassError::Timeout`] covers a completion handler that never fires within `timeout_ms`.
+pub(crate) fn launch_bundle(bundle: &Path, timeout_ms: u64) -> Result<i32> {
+    let (tx, rx) = mpsc::channel::<std::result::Result<i32, String>>();
+
+    let url = NSURL::fileURLWithPath(&NSString::from_str(&bundle.to_string_lossy()));
+    let configuration = NSWorkspaceOpenConfiguration::configuration();
+    let workspace = NSWorkspace::sharedWorkspace();
+
+    // The completion handler decides success/failure synchronously inside the callback (this
+    // module's async-bridge convention) and only ever sends the plain owned `Result<i32,
+    // String>` declared above — never a `Retained<NSRunningApplication>` — across the channel.
+    let handler = RcBlock::new(move |app: *mut NSRunningApplication, err: *mut NSError| {
+        // SAFETY: `openApplication`'s completion handler hands back either a valid, live
+        // `NSRunningApplication` pointer (success) or a valid, live `NSError` pointer
+        // (failure); at most one of `app`/`err` is non-null. `as_ref()` turns each raw
+        // pointer into `Option<&T>`, safe regardless of which one (if either) is null.
+        let app = unsafe { app.as_ref() };
+        if let Some(app) = app {
+            let _ = tx.send(Ok(app.processIdentifier()));
+            return;
+        }
+        // SAFETY: same guarantee as above, applied to `err` instead of `app`.
+        let err = unsafe { err.as_ref() };
+        let msg = err
+            .map(|e| e.localizedDescription().to_string())
+            .unwrap_or_else(|| "openApplication failed with no error".to_string());
+        let _ = tx.send(Err(msg));
+    });
+
+    // No `unsafe` needed: `openApplicationAtURL:configuration:completionHandler:` is a plain
+    // safe binding (see this module's doc) — unlike `SCShareableContent`'s equivalent.
+    workspace.openApplicationAtURL_configuration_completionHandler(
+        &url,
+        &configuration,
+        Some(&handler),
+    );
+
+    match rx.recv_timeout(Duration::from_millis(timeout_ms.max(1))) {
+        Ok(Ok(pid)) => Ok(pid),
+        Ok(Err(msg)) => Err(GlassError::AppNotStarted(msg)),
+        Err(_) => Err(GlassError::Timeout(timeout_ms)),
+    }
+}
+
+/// Gracefully terminate the running application with this pid; a no-op if the pid is
+/// already gone. Cleanup-only (unlike `input.rs::focus`'s identical lookup, which treats a
+/// missing pid as the hard error `GlassError::AppExited` because a caller is depending on
+/// the activation landing) — `backend.rs`'s `stop_app` path doesn't need to know whether the
+/// app was already gone before it asked.
+pub(crate) fn terminate_app(pid: i32) {
+    if let Some(app) = NSRunningApplication::runningApplicationWithProcessIdentifier(pid) {
+        app.terminate();
     }
 }
 

--- a/crates/glass-macos/src/ffi.rs
+++ b/crates/glass-macos/src/ffi.rs
@@ -193,7 +193,9 @@ pub(crate) fn running_pid_for_bundle_id(bundle_id: &str) -> Option<i32> {
 /// [`classify_null_result`]'s identical stance on ScreenCaptureKit's completion handlers,
 /// that contract is handled defensively rather than assumed, so a (framework-violating)
 /// null/null callback still yields a message instead of silently dropping the reply.
-/// [`GlassError::Timeout`] covers a completion handler that never fires within `timeout_ms`.
+/// [`GlassError::Timeout`] covers a completion handler that never fires within `timeout_ms`;
+/// a handler dropped without ever firing (the channel sender gone) is reported as
+/// [`GlassError::AppNotStarted`] instead, kept distinct from that never-fired-in-time timeout.
 pub(crate) fn launch_bundle(bundle: &Path, timeout_ms: u64) -> Result<i32> {
     let (tx, rx) = mpsc::channel::<std::result::Result<i32, String>>();
 
@@ -233,7 +235,14 @@ pub(crate) fn launch_bundle(bundle: &Path, timeout_ms: u64) -> Result<i32> {
     match rx.recv_timeout(Duration::from_millis(timeout_ms.max(1))) {
         Ok(Ok(pid)) => Ok(pid),
         Ok(Err(msg)) => Err(GlassError::AppNotStarted(msg)),
-        Err(_) => Err(GlassError::Timeout(timeout_ms)),
+        Err(mpsc::RecvTimeoutError::Timeout) => Err(GlassError::Timeout(timeout_ms)),
+        // The sender was dropped without ever sending — i.e. `NSWorkspace` dropped the
+        // completion block without invoking it. Distinct from a genuine timeout: surface it
+        // as a structured start failure rather than mislabeling a never-invoked handler as a
+        // slow launch that might still be in flight.
+        Err(mpsc::RecvTimeoutError::Disconnected) => Err(GlassError::AppNotStarted(
+            "NSWorkspace dropped the openApplication completion handler without invoking it".into(),
+        )),
     }
 }
 

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -6,6 +6,7 @@
 //! modules and the `MacosPlatform` impl are gated `#[cfg(target_os = "macos")]`. Off macOS
 //! the crate exposes only the pure modules.
 
+pub mod bundle; // pure .app-bundle logic — cross-platform, host-tested
 pub mod clipboard_route; // pure clipboard-routing policy — cross-platform, host-tested
 pub mod coords; // pure window-relative <-> global math — cross-platform, host-tested
 pub mod keymap; // pure ASCII -> (keycode, shift) US map — cross-platform, host-tested

--- a/crates/glass-macos/tests/bundle_launch.rs
+++ b/crates/glass-macos/tests/bundle_launch.rs
@@ -236,13 +236,40 @@ mod macos_main {
         }
     }
 
+    /// The result of running one check. Kept distinct from a plain `Result` so a missing
+    /// precondition for ONE check (`Skipped`) is reported as skipped-not-passed and, crucially,
+    /// never causes the OTHER checks to be skipped — the pathological "the whole test silently
+    /// passes because a single precondition was absent" shape. `Ran(Ok(()))` passed;
+    /// `Ran(Err(_))` failed with a reason; `Skipped(_)` asserted nothing. Each check gates
+    /// itself on ONLY the precondition it actually needs (swiftc for check 1; `TextEdit.app`
+    /// for checks 2/3), so `run` no longer has any blanket gate that could skip everything.
+    enum Outcome {
+        Ran(Result<(), String>),
+        Skipped(String),
+    }
+
     /// Check 1 — foreground `.app`, direct-spawn: build `Demo.app`, `start_app` it under
     /// the default sandbox, click it, and confirm the click round-tripped through captured
     /// stdout. A captured `click: <x>,<y>` line is the only externally-observable proof this
     /// went through `process::spawn`'s child path (see this file's module doc) — an
     /// `NSWorkspace`-adopted process (check 2) has nothing piped at all, so its `drain_logs`
     /// is asserted empty instead.
-    fn run_foreground_check() -> Result<(), String> {
+    ///
+    /// Precondition: `swiftc` (to build the fixture bundle). This check alone needs it —
+    /// checks 2/3 use the stock `TextEdit.app` and no compiler — so its absence skips only
+    /// this check, never the others.
+    fn run_foreground_check() -> Outcome {
+        if !swiftc_available() {
+            return Outcome::Skipped(
+                "swiftc unavailable (needed to compile the Demo.app fixture)".to_string(),
+            );
+        }
+        Outcome::Ran(foreground_check_body())
+    }
+
+    /// Check 1's body, split out so [`run_foreground_check`] can gate on `swiftc` and wrap
+    /// this in [`Outcome`] while the body itself keeps using `?` over `Result`.
+    fn foreground_check_body() -> Result<(), String> {
         let (bundle, build_dir) = build_demo_app()?;
         println!("built fixture bundle at {}", bundle.display());
 
@@ -303,10 +330,22 @@ mod macos_main {
     /// orphaned. If `TextEdit` was already running before this test, `stop_app` is expected
     /// to leave it running (glass only raised an existing instance, not one it started), so
     /// the orphan check is skipped in that case rather than asserting the wrong thing.
-    fn run_handoff_check() -> Result<(), String> {
+    ///
+    /// Precondition: `/System/Applications/TextEdit.app` (the handoff target). This check
+    /// needs no `swiftc`, so a missing swiftc must never skip it — its own missing-TextEdit
+    /// gate is the only thing that skips it.
+    fn run_handoff_check() -> Outcome {
         if !Path::new(TEXT_EDIT).is_dir() {
-            return Err(format!("{TEXT_EDIT} not found on this machine"));
+            return Outcome::Skipped(format!(
+                "{TEXT_EDIT} not found (the handoff check needs a stock TextEdit.app)"
+            ));
         }
+        Outcome::Ran(handoff_check_body())
+    }
+
+    /// Check 2's body, split out so [`run_handoff_check`] can gate on `TextEdit.app` and
+    /// wrap this in [`Outcome`].
+    fn handoff_check_body() -> Result<(), String> {
         let text_edit_was_running = process_running("TextEdit");
 
         let mut platform =
@@ -386,11 +425,21 @@ mod macos_main {
     /// Check 3 — fail-closed: the same handoff trigger as check 2, but `sandbox: Default`.
     /// `bundle::handoff_gate` must reject the adoption before it happens, so `start_app`
     /// returns `Err(GlassError::AppNotStarted(_))` rather than ever adopting TextEdit.
-    fn run_fail_closed_check() -> Result<(), String> {
+    ///
+    /// Precondition: `/System/Applications/TextEdit.app` (same target as check 2, no
+    /// `swiftc`). Gates on that alone.
+    fn run_fail_closed_check() -> Outcome {
         if !Path::new(TEXT_EDIT).is_dir() {
-            return Err(format!("{TEXT_EDIT} not found on this machine"));
+            return Outcome::Skipped(format!(
+                "{TEXT_EDIT} not found (the fail-closed check needs a stock TextEdit.app)"
+            ));
         }
+        Outcome::Ran(fail_closed_check_body())
+    }
 
+    /// Check 3's body, split out so [`run_fail_closed_check`] can gate on `TextEdit.app` and
+    /// wrap this in [`Outcome`].
+    fn fail_closed_check_body() -> Result<(), String> {
         let mut platform =
             MacosPlatform::new().map_err(|e| format!("MacosPlatform::new(): {e}"))?;
 
@@ -417,38 +466,59 @@ mod macos_main {
     }
 
     pub(super) fn run() {
-        if !swiftc_available() {
-            println!("skipped (no swiftc)");
-            return;
-        }
-        if !Path::new(TEXT_EDIT).is_dir() {
-            fail(format!(
-                "{TEXT_EDIT} not found -- checks 2/3 need a stock TextEdit.app"
-            ));
-        }
-
+        // No blanket precondition gate here — each check declines itself (returning
+        // `Outcome::Skipped`) when the ONE precondition it needs is absent, so a missing
+        // `swiftc` can never skip the handoff/fail-closed checks and a missing `TextEdit.app`
+        // can never skip the foreground check. Failures fail the run; skips are reported
+        // distinctly (SKIPPED, never counted as a pass) and do not block the PASS banner for
+        // the checks that did run and pass. On the mini both preconditions are present, so
+        // all three run.
         let mut failures = Vec::new();
+        let mut skips = Vec::new();
 
-        println!("--- check 1: foreground .app (direct-spawn) ---");
-        if let Err(e) = run_foreground_check() {
-            failures.push(format!("foreground check: {e}"));
-        }
+        // Takes the check as a `fn` (not an already-evaluated `Outcome`) so the header prints
+        // BEFORE the check runs — otherwise the check's own progress output would land above
+        // its header.
+        let mut record = |label: &str, header: &str, check: fn() -> Outcome| {
+            println!("--- {header} ---");
+            match check() {
+                Outcome::Ran(Ok(())) => {}
+                Outcome::Ran(Err(e)) => failures.push(format!("{label}: {e}")),
+                Outcome::Skipped(reason) => {
+                    println!("SKIPPED: {label}: {reason}");
+                    skips.push(label.to_string());
+                }
+            }
+        };
 
-        println!("--- check 2: handoff app (NSWorkspace adopt) ---");
-        if let Err(e) = run_handoff_check() {
-            failures.push(format!("handoff check: {e}"));
-        }
+        record(
+            "foreground check",
+            "check 1: foreground .app (direct-spawn)",
+            run_foreground_check,
+        );
+        record(
+            "handoff check",
+            "check 2: handoff app (NSWorkspace adopt)",
+            run_handoff_check,
+        );
+        record(
+            "fail-closed check",
+            "check 3: fail-closed (sandboxed handoff)",
+            run_fail_closed_check,
+        );
 
-        println!("--- check 3: fail-closed (sandboxed handoff) ---");
-        if let Err(e) = run_fail_closed_check() {
-            failures.push(format!("fail-closed check: {e}"));
-        }
-
-        if failures.is_empty() {
-            println!("BUNDLE_LAUNCH_INTEGRATION_PASS");
-            std::process::exit(0);
-        } else {
+        if !failures.is_empty() {
             fail(failures.join("\n"));
         }
+        if skips.is_empty() {
+            println!("BUNDLE_LAUNCH_INTEGRATION_PASS");
+        } else {
+            println!(
+                "BUNDLE_LAUNCH_INTEGRATION_PASS ({} check(s) skipped: {})",
+                skips.len(),
+                skips.join(", ")
+            );
+        }
+        std::process::exit(0);
     }
 }

--- a/crates/glass-macos/tests/bundle_launch.rs
+++ b/crates/glass-macos/tests/bundle_launch.rs
@@ -1,0 +1,454 @@
+//! Mac-gated `.app`-bundle-launch integration test — the first real-bundle proof of
+//! `MacosPlatform::start_app`'s `.app` branch (`backend.rs::start_bundle`): direct-spawn
+//! the bundle's inner executable first, fall back to an `NSWorkspace` handoff only if that
+//! stub exits before a window appears, and fail closed if the handoff would need
+//! Seatbelt containment it can't provide (`bundle::handoff_gate`). Three checks, run in
+//! sequence from one process:
+//!
+//! 1. **Foreground `.app`** (direct-spawn): a fresh `Demo.app` fixture (this file's own
+//!    `build_demo_app`, compiling `fixture/quadrants.swift` into
+//!    `Demo.app/Contents/MacOS/Demo`) direct-spawns successfully — `start_app(sandbox:
+//!    Default)` returns `Ok`, and a click's `click: <x>,<y>` line comes back through
+//!    `drain_logs`. That captured log line is the only externally-observable proof this
+//!    launch went through `process::spawn`'s child path rather than the handoff path below:
+//!    `self.child`/`self.adopted` are private to `glass-macos`, but only a direct-spawned
+//!    child has its stdout/stderr piped into the log buffer at all (see check 2).
+//! 2. **Handoff app** (`NSWorkspace` adopt): `/System/Applications/TextEdit.app` re-execs
+//!    itself through LaunchServices, so its directly-spawned stub exits before a window
+//!    appears and `start_bundle` hands off to `NSWorkspace` — `start_app(sandbox: Off)`
+//!    returns `Ok`, `drain_logs` is empty (the adopted pid was never `process::spawn`ed, so
+//!    nothing was ever piped), and a live `glass_a11y_macos::MacosA11y::snapshot` against the
+//!    adopted window returns a non-empty AX tree. Also confirms `stop_app`'s terminate path:
+//!    when this run's own launch was the fresh instance (no `TextEdit` already running
+//!    beforehand), the adopted pid must actually be gone afterward, not orphaned.
+//! 3. **Fail-closed**: the same handoff trigger as check 2, but with `sandbox: Default` —
+//!    `bundle::handoff_gate` rejects any sandbox level except `Off` before the adoption ever
+//!    happens, so `start_app` must return `Err(GlassError::AppNotStarted(_))`.
+//!
+//! **`harness = false`** (see `Cargo.toml`'s `[[test]] name = "bundle_launch"` entry), for
+//! the same reason as `tests/capture.rs`/`tests/a11y.rs`/`tests/input.rs`/`tests/windows.rs`:
+//! `start_app`'s bundle branch reaches `ffi::app_kit_init()` (via `backend.rs`'s
+//! `discover_window`/`discover_window_pid`), which requires the process's TRUE main thread
+//! (`objc2::MainThreadMarker`) — libtest's per-`#[test]` worker threads can't provide that,
+//! so this file defines its own `fn main()` instead, run directly rather than through
+//! libtest. There is accordingly no `#[ignore]` attribute anywhere in this file — none of
+//! the sibling mac-gated integration tests use one either; the gate is this file not being
+//! built at all by a plain `cargo test -p glass-macos` (`scripts/test-macos.sh` restricts
+//! that invocation to `--lib`), only on request (see that script's `GLASS_MACOS_ONBOX` gate
+//! for the sibling tests).
+//!
+//! Needs the same two TCC grants as `tests/input.rs` (Screen Recording for window
+//! discovery/capture, Accessibility for the AX snapshot in check 2), held by the signed,
+//! granted `GlassProbe.app` bundle on this project's dev Mac (`mini`) — same granted-run
+//! procedure as `capture.rs`/`input.rs`: copy this built test binary into the bundle,
+//! re-sign, run via a `gui/501` LaunchAgent so it inherits the bundle's grants. See
+//! `.superpowers/sdd/objc2-spike-report.md` and `.superpowers/sdd/task-6-brief.md` for the
+//! exact procedure. Check 2/3 additionally require `/System/Applications/TextEdit.app` to
+//! exist on the test machine (true on every stock macOS install) and, like `tests/input.rs`,
+//! an unlocked screen session (TextEdit's window must actually receive focus for the AX
+//! snapshot in check 2 to see real content).
+
+#[cfg(not(target_os = "macos"))]
+fn main() {
+    println!("skipped (not macOS)");
+}
+
+#[cfg(target_os = "macos")]
+fn main() {
+    macos_main::run();
+}
+
+#[cfg(target_os = "macos")]
+mod macos_main {
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+    use std::time::Duration;
+
+    use glass_a11y_macos::MacosA11y;
+    use glass_core::platform::{MouseButton, PointerEvent};
+    use glass_core::{
+        Accessibility, AppSpec, AxContext, GlassError, Platform, SandboxLevel, Stream,
+    };
+    use glass_macos::MacosPlatform;
+
+    /// A stock-macOS handoff app: re-execs itself through LaunchServices, so directly
+    /// spawning `Contents/MacOS/TextEdit` exits before a window appears and
+    /// `start_bundle` falls into its `NSWorkspace` branch — exactly the fixture checks 2
+    /// and 3 need, without shipping a second custom `.app`. Present on every stock macOS
+    /// install (unlike a third-party app), so no availability probe is needed.
+    const TEXT_EDIT: &str = "/System/Applications/TextEdit.app";
+
+    /// `CFBundleIdentifier` [`build_demo_app`] writes into the fixture's `Info.plist` —
+    /// used only to identify the fixture in logs/Info.plist; check 1 never looks an app up
+    /// by bundle id (that's the handoff path's job, checks 2/3), so this need not resolve to
+    /// anything real.
+    const DEMO_BUNDLE_ID: &str = "tech.fixedwidth.quadrants-demo";
+
+    /// Window-relative pixel [`run_foreground_check`] clicks — the center of
+    /// `quadrants.swift`'s top-left quadrant in its 400x400 window, mirroring
+    /// `tests/input.rs`'s identical `CLICK_TARGET`.
+    const CLICK_TARGET: (i32, i32) = (100, 100);
+
+    /// Settle after `start_app`/`send_pointer` before reading logs/snapshotting — generous
+    /// relative to each backend call's own internal settling, mirroring the sibling
+    /// integration tests' identically-reasoned constants.
+    const STARTUP_SETTLE: Duration = Duration::from_millis(500);
+    const ACTION_SETTLE: Duration = Duration::from_millis(400);
+    /// How long to wait after `stop_app` before checking a freshly-adopted pid has actually
+    /// exited (check 2's no-orphan assertion) — `ffi::terminate_app` posts a terminate
+    /// request and returns; this gives the target process a moment to actually unwind.
+    const TERMINATE_SETTLE: Duration = Duration::from_secs(1);
+
+    /// Print a clear failure message and exit non-zero — the `harness = false` contract (no
+    /// libtest to format a panic for us). Mirrors the sibling integration tests.
+    fn fail(msg: impl AsRef<str>) -> ! {
+        eprintln!("FAIL: {}", msg.as_ref());
+        std::process::exit(1);
+    }
+
+    /// Like the sibling tests' identical helper: returns the error as a `String` instead of
+    /// exiting, so a failure inside a check function still lets that check's own cleanup
+    /// (`stop_app`, fixture-dir removal) run before the message propagates.
+    fn try_expect<T, E: std::fmt::Display>(
+        result: Result<T, E>,
+        context: &str,
+    ) -> Result<T, String> {
+        result.map_err(|e| format!("{context}: {e}"))
+    }
+
+    fn swiftc_available() -> bool {
+        Command::new("swiftc")
+            .arg("--version")
+            .output()
+            .is_ok_and(|o| o.status.success())
+    }
+
+    /// True if a process named `name` is currently running (`pgrep -x`) — used by
+    /// [`run_handoff_check`] to tell a genuinely fresh `NSWorkspace` launch (no prior
+    /// instance) from re-adopting one that was already running, since only the fresh case
+    /// is expected to leave nothing behind after `stop_app` (see that function's doc).
+    fn process_running(name: &str) -> bool {
+        Command::new("pgrep")
+            .arg("-x")
+            .arg(name)
+            .output()
+            .is_ok_and(|o| o.status.success())
+    }
+
+    /// Compile `fixture/quadrants.swift` into a minimal `.app` bundle at
+    /// `<build_dir>/Demo.app/Contents/MacOS/Demo`, with an `Info.plist` carrying exactly the
+    /// three keys `bundle::is_app_bundle`/`resolve_inner_exec`/`bundle_identifier` need
+    /// (`CFBundleExecutable`, `CFBundleIdentifier`, `CFBundlePackageType`) — the smallest
+    /// bundle `is_app_bundle`'s `Contents/Info.plist`-presence check and `resolve_inner_exec`'s
+    /// `CFBundleExecutable` lookup both accept. Returns the bundle's path and the temp build
+    /// dir it lives in (the caller removes the dir once done, mirroring `capture.rs`'s
+    /// `build_fixture`).
+    fn build_demo_app() -> Result<(PathBuf, PathBuf), String> {
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let source = manifest_dir.join("fixture").join("quadrants.swift");
+        if !source.is_file() {
+            return Err(format!("fixture source not found at {}", source.display()));
+        }
+
+        let out_dir = std::env::temp_dir().join(format!(
+            "glass-macos-bundle-launch-test-{}",
+            std::process::id()
+        ));
+        let bundle = out_dir.join("Demo.app");
+        let macos_dir = bundle.join("Contents/MacOS");
+        std::fs::create_dir_all(&macos_dir)
+            .map_err(|e| format!("creating {}: {e}", macos_dir.display()))?;
+
+        let exe = macos_dir.join("Demo");
+        let status = Command::new("swiftc")
+            .arg("-O")
+            .arg("-parse-as-library")
+            .arg(&source)
+            .arg("-o")
+            .arg(&exe)
+            .status();
+        match status {
+            Ok(s) if s.success() => {}
+            Ok(s) => {
+                return Err(format!(
+                    "swiftc exited with {s} building {}",
+                    source.display()
+                ))
+            }
+            Err(e) => return Err(format!("failed to run swiftc: {e}")),
+        }
+
+        let info_plist = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>CFBundleExecutable</key><string>Demo</string>
+<key>CFBundleIdentifier</key><string>{DEMO_BUNDLE_ID}</string>
+<key>CFBundlePackageType</key><string>APPL</string>
+</dict></plist>"#
+        );
+        let plist_path = bundle.join("Contents/Info.plist");
+        std::fs::write(&plist_path, info_plist)
+            .map_err(|e| format!("writing {}: {e}", plist_path.display()))?;
+
+        Ok((bundle, out_dir))
+    }
+
+    /// Build the `AppSpec` every check here launches: `run[0]` is `run0` (a `.app` bundle
+    /// path in every call site), sandboxed at `sandbox`, with the fixed no-build/no-a11y/
+    /// 8s-timeout settings none of the three checks vary. Extracted because checks 2 and 3
+    /// launch the identical `TEXT_EDIT` target and differ only in `sandbox`.
+    fn bundle_spec(run0: impl Into<String>, sandbox: SandboxLevel) -> AppSpec {
+        AppSpec {
+            build: None,
+            run: vec![run0.into()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 8000,
+            sandbox,
+            a11y: false,
+        }
+    }
+
+    /// Run `body`, then always call `platform.stop_app()` before returning — regardless of
+    /// whether `body` succeeded — so a failing check never leaks whatever it started.
+    /// Mirrors the sibling tests' `run()`/`run_checks` cleanup-always-runs discipline,
+    /// collapsed into one helper since each check function here owns a short-lived
+    /// `MacosPlatform` of its own rather than sharing one across the whole file. On success,
+    /// a `stop_app` failure becomes the check's own failure; on an already-failing `body`,
+    /// a `stop_app` failure is only logged (the original failure is more informative and
+    /// must not be masked).
+    fn with_stop_app<T>(
+        platform: &mut MacosPlatform,
+        body: impl FnOnce(&mut MacosPlatform) -> Result<T, String>,
+    ) -> Result<T, String> {
+        let result = body(platform);
+        let stop_result = platform.stop_app();
+        match result {
+            Ok(v) => try_expect(stop_result, "stop_app").map(|()| v),
+            Err(e) => {
+                if let Err(stop_err) = stop_result {
+                    eprintln!("(additionally) stop_app failed: {stop_err}");
+                }
+                Err(e)
+            }
+        }
+    }
+
+    /// Check 1 — foreground `.app`, direct-spawn: build `Demo.app`, `start_app` it under
+    /// the default sandbox, click it, and confirm the click round-tripped through captured
+    /// stdout. A captured `click: <x>,<y>` line is the only externally-observable proof this
+    /// went through `process::spawn`'s child path (see this file's module doc) — an
+    /// `NSWorkspace`-adopted process (check 2) has nothing piped at all, so its `drain_logs`
+    /// is asserted empty instead.
+    fn run_foreground_check() -> Result<(), String> {
+        let (bundle, build_dir) = build_demo_app()?;
+        println!("built fixture bundle at {}", bundle.display());
+
+        let mut platform = match MacosPlatform::new() {
+            Ok(p) => p,
+            Err(e) => {
+                let _ = std::fs::remove_dir_all(&build_dir);
+                return Err(format!("MacosPlatform::new(): {e}"));
+            }
+        };
+
+        let result = with_stop_app(&mut platform, |platform| {
+            let spec = bundle_spec(bundle.to_string_lossy().into_owned(), SandboxLevel::Default);
+            let geometry = try_expect(
+                platform.start_app(&spec),
+                "start_app(Demo.app, sandbox: Default)",
+            )?;
+            println!("started Demo.app foreground window: {geometry:?}");
+            std::thread::sleep(STARTUP_SETTLE);
+
+            let click_event = PointerEvent::Click {
+                x: CLICK_TARGET.0,
+                y: CLICK_TARGET.1,
+                button: MouseButton::Left,
+                count: 1,
+                modifiers: vec![],
+            };
+            try_expect(platform.send_pointer(&click_event), "send_pointer(Click)")?;
+            std::thread::sleep(ACTION_SETTLE);
+
+            let logs = platform.drain_logs();
+            let saw_click = logs
+                .iter()
+                .any(|(stream, line)| *stream == Stream::Stdout && line.starts_with("click: "));
+            if !saw_click {
+                return Err(format!(
+                    "expected a captured 'click: ' stdout line proving the direct-spawn/log \
+                     path; captured logs: {logs:?}"
+                ));
+            }
+            println!(
+                "foreground .app direct-spawn OK: click landed and was reported via captured \
+                 stdout (proves this launch used process::spawn's child path, not a handoff)"
+            );
+            Ok(())
+        });
+
+        let _ = std::fs::remove_dir_all(&build_dir);
+        result
+    }
+
+    /// Check 2 — handoff app, `NSWorkspace` adopt: `start_app(TextEdit.app, sandbox: Off)`
+    /// must succeed via the handoff path (no captured logs, since nothing was
+    /// `process::spawn`ed for the adopted pid), and a live AX snapshot against it must come
+    /// back non-empty. Also verifies the terminate path: if this run's own launch was the
+    /// fresh instance (`process_running("TextEdit")` was false beforehand — no prior
+    /// instance to merely re-adopt), the adopted pid must be gone after `stop_app`, not
+    /// orphaned. If `TextEdit` was already running before this test, `stop_app` is expected
+    /// to leave it running (glass only raised an existing instance, not one it started), so
+    /// the orphan check is skipped in that case rather than asserting the wrong thing.
+    fn run_handoff_check() -> Result<(), String> {
+        if !Path::new(TEXT_EDIT).is_dir() {
+            return Err(format!("{TEXT_EDIT} not found on this machine"));
+        }
+        let text_edit_was_running = process_running("TextEdit");
+
+        let mut platform =
+            MacosPlatform::new().map_err(|e| format!("MacosPlatform::new(): {e}"))?;
+
+        let result = with_stop_app(&mut platform, |platform| {
+            let spec = bundle_spec(TEXT_EDIT, SandboxLevel::Off);
+            let geometry = try_expect(
+                platform.start_app(&spec),
+                "start_app(TextEdit.app, sandbox: Off)",
+            )?;
+            println!("adopted TextEdit window: {geometry:?}");
+            std::thread::sleep(STARTUP_SETTLE);
+
+            let logs = platform.drain_logs();
+            if !logs.is_empty() {
+                return Err(format!(
+                    "expected no captured logs for an NSWorkspace-adopted app (nothing was \
+                     process::spawn'd for it), got: {logs:?}"
+                ));
+            }
+
+            let ctx = AxContext {
+                pids: platform.app_pids(),
+                window: geometry,
+                window_handle: None,
+                a11y_bus_addr: None,
+            };
+            let mut a11y = MacosA11y::new();
+            let mut tree = try_expect(a11y.snapshot(&ctx), "a11y snapshot(TextEdit)")?;
+            tree.assign_ids();
+            if tree.count == 0 {
+                return Err("expected a non-empty AX tree for TextEdit, got 0 nodes".into());
+            }
+            println!(
+                "handoff app OK: TextEdit adopted with no captured logs, AX snapshot has {} \
+                 nodes",
+                tree.count
+            );
+            Ok(())
+        });
+
+        // Orphan check: only meaningful once the main check above actually adopted
+        // TextEdit, and only asserted when this test's own call was the fresh launch —
+        // re-run the same `process_running` probe used above (now post-`stop_app`, via
+        // `with_stop_app`) rather than tracking the adopted pid directly, since
+        // `MacosPlatform`'s `adopted`/`app_pid` fields are private to `glass-macos`. A
+        // `match` on both facts (rather than if/else-if) keeps all three outcomes explicit,
+        // including the "main check already failed" case, which has nothing to verify here.
+        match (&result, text_edit_was_running) {
+            (Ok(()), false) => {
+                std::thread::sleep(TERMINATE_SETTLE);
+                if process_running("TextEdit") {
+                    return Err(
+                        "TextEdit is still running after stop_app on a launch this test \
+                         itself started fresh (no prior instance existed) -- stop_app's \
+                         fresh-adoption terminate path did not actually terminate it"
+                            .to_string(),
+                    );
+                }
+                println!("no-orphan check OK: fresh TextEdit adoption was terminated by stop_app");
+            }
+            (Ok(()), true) => println!(
+                "TextEdit was already running before this check -- skipping the no-orphan \
+                 assertion (stop_app correctly leaves a pre-existing instance running, which \
+                 is not an orphan)"
+            ),
+            (Err(_), _) => {
+                // The main check already failed; the orphan probe only makes sense after a
+                // successful adoption, so there's nothing more to verify here.
+            }
+        }
+
+        result
+    }
+
+    /// Check 3 — fail-closed: the same handoff trigger as check 2, but `sandbox: Default`.
+    /// `bundle::handoff_gate` must reject the adoption before it happens, so `start_app`
+    /// returns `Err(GlassError::AppNotStarted(_))` rather than ever adopting TextEdit.
+    fn run_fail_closed_check() -> Result<(), String> {
+        if !Path::new(TEXT_EDIT).is_dir() {
+            return Err(format!("{TEXT_EDIT} not found on this machine"));
+        }
+
+        let mut platform =
+            MacosPlatform::new().map_err(|e| format!("MacosPlatform::new(): {e}"))?;
+
+        with_stop_app(&mut platform, |platform| {
+            let spec = bundle_spec(TEXT_EDIT, SandboxLevel::Default);
+            match platform.start_app(&spec) {
+                Err(GlassError::AppNotStarted(msg)) => {
+                    println!(
+                        "fail-closed OK: start_app(TextEdit.app, sandbox: Default) -> \
+                         AppNotStarted({msg:?})"
+                    );
+                    Ok(())
+                }
+                Ok(geometry) => Err(format!(
+                    "expected Err(AppNotStarted(_)) for a sandboxed handoff attempt, but \
+                     start_app unexpectedly succeeded with geometry {geometry:?}"
+                )),
+                Err(other) => Err(format!(
+                    "expected Err(AppNotStarted(_)) for a sandboxed handoff attempt, got \
+                     {other:?} instead"
+                )),
+            }
+        })
+    }
+
+    pub(super) fn run() {
+        if !swiftc_available() {
+            println!("skipped (no swiftc)");
+            return;
+        }
+        if !Path::new(TEXT_EDIT).is_dir() {
+            fail(format!(
+                "{TEXT_EDIT} not found -- checks 2/3 need a stock TextEdit.app"
+            ));
+        }
+
+        let mut failures = Vec::new();
+
+        println!("--- check 1: foreground .app (direct-spawn) ---");
+        if let Err(e) = run_foreground_check() {
+            failures.push(format!("foreground check: {e}"));
+        }
+
+        println!("--- check 2: handoff app (NSWorkspace adopt) ---");
+        if let Err(e) = run_handoff_check() {
+            failures.push(format!("handoff check: {e}"));
+        }
+
+        println!("--- check 3: fail-closed (sandboxed handoff) ---");
+        if let Err(e) = run_fail_closed_check() {
+            failures.push(format!("fail-closed check: {e}"));
+        }
+
+        if failures.is_empty() {
+            println!("BUNDLE_LAUNCH_INTEGRATION_PASS");
+            std::process::exit(0);
+        } else {
+            fail(failures.join("\n"));
+        }
+    }
+}


### PR DESCRIPTION
## What

Lets `glass_start` launch and drive macOS **`.app` bundles** (e.g. an app you're
developing, or a system app like TextEdit). Previously the macOS backend could only
track an app that ran as the foreground process it spawned, so a LaunchServices
bundle — which re-execs to a new process and exits the one glass launched — was
never acquired.

## How

`glass_start` branches on `run[0]`:

- **Plain executable** → unchanged (direct spawn + window discovery).
- **`.app` bundle** → resolve the inner executable (`CFBundleExecutable`) and
  **direct-spawn it first**. If it runs foreground (most apps under development), it
  stays glass-owned — **stdout/stderr logs and Seatbelt containment are preserved**,
  the full loop. If it instead hands off to LaunchServices, glass **adopts the real
  process via `NSWorkspace`** and drives that.

A handed-off app is not glass's child and can't be Seatbelt-contained, so the handoff
path is **fail-closed**: it requires `sandbox: "off"` and otherwise returns a
structured error rather than silently running the app uncontained.

On a handed-off app, capture, input, and the accessibility tree all work
(AX is ambient once granted); **stdout capture and clipboard isolation do not**
(glass doesn't own the process) — this is documented. Stopping a session terminates
an app glass launched but leaves an app it merely activated running.

## Scope

All changes are in `glass-macos` — new pure `bundle.rs` (detection / Info.plist
resolution / a path-traversal guard on the inner-exec name / the containment gate),
`NSWorkspace`/`NSRunningApplication` FFI in `ffi.rs`, and the `start_app` branch +
adopted lifecycle in `backend.rs`. `glass-core` and the MCP tool surface are
unchanged (`glass_start`'s existing `run`/`sandbox`/`timeout_ms` carry everything).

## Testing

- Pure unit tests (host-agnostic): bundle detection, Info.plist parse/missing-key/
  parse-failure, the path-traversal guard (absolute / nested / trailing-slash), the
  fail-closed gate per sandbox level, the terminate-on-stop decision, empty-`run`.
- macOS integration tests + `stop_app` state tests.
- Verified on Apple Silicon: a foreground `.app` drives with log capture; TextEdit is
  driven via handoff adoption (real window + AX tree); the default-sandbox handoff is
  refused with the structured error; on stop, a glass-launched instance is terminated
  and a pre-existing one is left running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
