### PR TITLE
feat(input): accept cmd/command as a Super modifier alias

### DIFF
--- a/crates/glass-core/src/keys.rs
+++ b/crates/glass-core/src/keys.rs
@@ -16,7 +16,7 @@ impl Modifier {
             "shift" => Some(Modifier::Shift),
             "ctrl" | "control" => Some(Modifier::Control),
             "alt" => Some(Modifier::Alt),
-            "super" | "meta" | "win" => Some(Modifier::Super),
+            "super" | "meta" | "win" | "cmd" | "command" => Some(Modifier::Super),
             _ => None,
         }
     }
@@ -83,7 +83,9 @@ pub fn parse_chord(chord: &str) -> Result<(Vec<Modifier>, u32)> {
     let mut modifiers = Vec::new();
     for m in mods {
         let modifier = Modifier::from_name(m).ok_or_else(|| {
-            GlassError::InvalidKey(format!("unknown modifier '{m}' in '{chord}'"))
+            GlassError::InvalidKey(format!(
+                "unknown modifier '{m}' in '{chord}' (use ctrl/shift/alt/super/cmd)"
+            ))
         })?;
         modifiers.push(modifier);
     }
@@ -167,5 +169,18 @@ mod tests {
         assert_eq!(Modifier::from_name("super"), Some(Modifier::Super));
         assert_eq!(Modifier::from_name("win"), Some(Modifier::Super));
         assert_eq!(Modifier::from_name("hyper"), None);
+    }
+
+    #[test]
+    fn modifier_cmd_is_super() {
+        // ⌘ is spelled `cmd`/`command` in the macOS idiom; both alias to Super (which the
+        // macOS backend renders as the Command flag), so cmd-chords parse like super-chords.
+        assert_eq!(Modifier::from_name("cmd"), Some(Modifier::Super));
+        assert_eq!(Modifier::from_name("command"), Some(Modifier::Super));
+        assert_eq!(Modifier::from_name("Cmd"), Some(Modifier::Super)); // case-insensitive
+        assert_eq!(
+            parse_chord("cmd+a").unwrap(),
+            parse_chord("super+a").unwrap()
+        );
     }
 }

--- a/crates/glass-mcp/src/tools/input.rs
+++ b/crates/glass-mcp/src/tools/input.rs
@@ -8,10 +8,9 @@ use crate::tools::{parse_button, ToolOutput, ToolResult};
 pub(crate) fn parse_modifiers(mods: Option<&[String]>) -> Result<Vec<Modifier>, String> {
     let mut out = Vec::new();
     for m in mods.unwrap_or(&[]) {
-        out.push(
-            Modifier::from_name(m)
-                .ok_or_else(|| format!("unknown modifier '{m}' (use ctrl/shift/alt/super)"))?,
-        );
+        out.push(Modifier::from_name(m).ok_or_else(|| {
+            format!("unknown modifier '{m}' (use ctrl/shift/alt/super; cmd = super on macOS)")
+        })?);
     }
     Ok(out)
 }


### PR DESCRIPTION
## What

Modifier chords now accept `cmd` and `command` as aliases for `super`. On macOS `super` already maps to the Command (⌘) flag, so this makes the natural macOS spelling work — `glass_key "cmd+z"`, `cmd+a`, `cmd+v`, etc. Previously these errored `unknown modifier 'cmd'`.

## Why

⌘ is the macOS keyboard-shortcut idiom, so an agent driving a macOS app naturally writes `cmd+…`. The alias is cross-backend: every backend accepts the spelling, and only macOS maps `Super` → Command — nothing platform-specific is added.

## Change

- `glass-core` (`keys.rs`): add `"cmd" | "command"` to the `Super` arm of `Modifier::from_name`, and list the accepted modifiers in the chord-parse error message.
- `glass-mcp` (`tools/input.rs`): update the modifier-error hint to mention `cmd`.
- Test: `modifier_cmd_is_super` asserts `cmd`/`command`/`Cmd` → `Super` and that `parse_chord("cmd+a")` is identical to `parse_chord("super+a")`.

Verified on macOS: `glass_key "cmd+z"` fires an egui app's ⌘Z (Command+Z) undo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
