### PR TITLE
fix(a11y): absorb macOS a11y-snapshot startup race + honest error for clipped click_element

### DIFF
--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -65,6 +65,15 @@ const SET_VALUE_VERIFY_MS: u64 = 800;
 /// Interval between read-back poll attempts.
 const SET_VALUE_POLL_MS: u64 = 20;
 
+/// How long [`resolve_window`] polls for the app's first `AXWindow` to register before giving
+/// up. The window server publishes a freshly-launched window's AX element a beat after the
+/// window exists, so a snapshot taken immediately after `start` can find an empty `AXWindows`
+/// list and spuriously `WindowNotFound`; this budget absorbs that startup race while still
+/// failing fast for an app that genuinely has no window.
+const RESOLVE_WINDOW_BUDGET_MS: u64 = 500;
+/// Interval between `AXWindows` poll attempts while waiting out the startup race.
+const RESOLVE_WINDOW_POLL_MS: u64 = 40;
+
 /// Remedy text for a missing Accessibility grant. Kept in sync with `glass-macos`'s
 /// `permissions.rs` wording (this crate can't depend on that private module).
 const ACCESSIBILITY_REMEDY: &str =
@@ -166,9 +175,25 @@ fn resolve_window(ctx: &AxContext) -> Result<(CFRetained<AXUIElement>, f64)> {
 
     let &pid = ctx.pids.first().ok_or(GlassError::WindowNotFound)?;
     let app = ffi::app_element(pid as i32);
-    // A failed `AXWindows` read is "no windows" → fall through to `WindowNotFound`.
-    let windows = ffi::app_windows(&app).unwrap_or_default();
-    select_window(&windows, &ctx.window).ok_or(GlassError::WindowNotFound)
+
+    // The app's `AXWindows` list can be transiently EMPTY right after launch (the window
+    // server registers the AX window a beat after the window exists), so a snapshot taken
+    // immediately after `start` races it. Poll ONLY the empty-list case: as soon as any
+    // window is present, `select_window` decides the match — and if none fits, that is a real
+    // geometry mismatch (it logs its diagnostics), which retrying would not fix, so it is
+    // returned immediately rather than polled. A failed `AXWindows` read reads as "no windows"
+    // and is likewise retried until the budget, then `WindowNotFound`.
+    let deadline = Instant::now() + Duration::from_millis(RESOLVE_WINDOW_BUDGET_MS);
+    loop {
+        let windows = ffi::app_windows(&app).unwrap_or_default();
+        if !windows.is_empty() {
+            return select_window(&windows, &ctx.window).ok_or(GlassError::WindowNotFound);
+        }
+        if Instant::now() >= deadline {
+            return Err(GlassError::WindowNotFound);
+        }
+        std::thread::sleep(Duration::from_millis(RESOLVE_WINDOW_POLL_MS));
+    }
 }
 
 /// Select the `AXWindow` matching the backend's reported `win` and recover its point→pixel

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -178,15 +178,28 @@ pub struct AxRect {
 }
 
 impl AxRect {
-    /// Center point, clamped into `[0,win_w) × [0,win_h)`. Returns `None` if the
-    /// rect or the window has zero area (nothing clickable).
+    /// The click point for this element: the center of its intersection with the window,
+    /// always inside `[0,win_w) × [0,win_h)`. Returns `None` when there is nothing to click —
+    /// the rect or window has zero area, or the element has no visible overlap with the window
+    /// (fully clipped off-screen) — so the caller surfaces a not-clickable error instead of a
+    /// click on the window edge that never lands on the element.
     pub fn clamped_center(&self, win_w: u32, win_h: u32) -> Option<(i32, i32)> {
         if self.width == 0 || self.height == 0 || win_w == 0 || win_h == 0 {
             return None;
         }
-        let cx = (self.x + self.width as i32 / 2).clamp(0, win_w as i32 - 1);
-        let cy = (self.y + self.height as i32 / 2).clamp(0, win_h as i32 - 1);
-        Some((cx, cy))
+        // Click the center of the element's *intersection* with the window — the visible
+        // portion — not the raw center clamped to the window edge. A partially-clipped element
+        // is then still clicked on itself, and a fully-clipped element (no overlap) returns
+        // `None`, surfaced as a not-clickable error rather than a silent click on the window
+        // edge that never lands on the element (the "no silent fallbacks" invariant).
+        let left = self.x.max(0);
+        let top = self.y.max(0);
+        let right = (self.x + self.width as i32).min(win_w as i32);
+        let bottom = (self.y + self.height as i32).min(win_h as i32);
+        if right <= left || bottom <= top {
+            return None;
+        }
+        Some(((left + right) / 2, (top + bottom) / 2))
     }
 }
 
@@ -617,15 +630,43 @@ mod tests {
     }
 
     #[test]
-    fn clamped_center_clamps_to_window() {
+    fn clamped_center_rejects_fully_offscreen() {
+        // Element entirely past the window's right/bottom edge → no visible portion → None
+        // (a not-clickable error, not a silent click on the window corner that misses it).
         let r = AxRect {
             x: 90,
             y: 90,
             width: 40,
             height: 40,
         };
-        // center would be (110,110); clamps to (63,47) for a 64x48 window.
-        assert_eq!(r.clamped_center(64, 48), Some((63, 47)));
+        assert_eq!(r.clamped_center(64, 48), None);
+    }
+
+    #[test]
+    fn clamped_center_uses_visible_portion_when_partially_clipped() {
+        // Element spans x[60,100] in an 80-wide window → visible x[60,80], center x=70; y
+        // fully inside. The click lands on the visible part of the element, not the edge.
+        let r = AxRect {
+            x: 60,
+            y: 10,
+            width: 40,
+            height: 20,
+        };
+        assert_eq!(r.clamped_center(80, 100), Some((70, 20)));
+    }
+
+    #[test]
+    fn clamped_center_uses_visible_portion_when_clipped_top_left() {
+        // Element hangs off the top-left (a negative origin is valid — see `AxRect.x/y`):
+        // spans x[-10,30] in an 80-wide window → visible x[0,30], center 15; y[-4,16] → visible
+        // y[0,16], center 8. Exercises the `.max(0)` clip on the left/top edges.
+        let r = AxRect {
+            x: -10,
+            y: -4,
+            width: 40,
+            height: 20,
+        };
+        assert_eq!(r.clamped_center(80, 100), Some((15, 8)));
     }
 
     #[test]


### PR DESCRIPTION
## What

Two robustness fixes on the accessibility path, both surfaced by macOS testing.

**1. a11y-snapshot startup race** (`glass-a11y-macos`). The window server registers a freshly-launched window's AX element a beat after the window itself exists, so `glass_a11y_snapshot` called immediately after `glass_start` could intermittently return `WindowNotFound`. `resolve_window` now polls the empty-`AXWindows` case for up to 500ms before giving up; a present-but-mismatched window list is still returned immediately (a real geometry mismatch, where retrying wouldn't help). Verified on macOS: 30/30 immediate-after-start snapshots succeed (previously ~1 in 17 spuriously 404'd).

**2. Clipped `click_element` silently clicked the window edge** (`glass-core`, cross-backend). `AxRect::clamped_center` clamped an element's raw center into the window, so `click_element` on an element clipped past the window edge clicked the window border and returned `ok` without ever landing on the element. It now clicks the center of the element's **intersection** with the window (the visible portion), and returns `None` → `AxElementNotClickable` when the element is fully off-window — an honest error, per the no-silent-fallbacks invariant. Fully-visible elements are unaffected (the intersection center equals the old center). Verified on macOS: an off-window `click_element` now returns `element #N has no clickable on-screen geometry` instead of a false success.

## Tests

- `glass-core`: `clamped_center` unit tests for fully-visible (unchanged), fully-offscreen (→ `None`), right-edge partial clip, and top-left (negative-origin) partial clip.
- Full Linux gate green (workspace test / clippy / fmt, macOS cross-check). On-box verified on Apple Silicon; no regression to scroll / keys / drag.

## Not in scope (follow-up)

A separate, lower-probability startup race — a window can register in `AXWindows` before its `AXPosition`/`AXSize` settle, so `select_window` could transiently mismatch — is left out of scope: higher-level snapshot polling re-attempts, and distinguishing "not settled yet" from a genuine mismatch needs more than a retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
