### PR TITLE
fix(wayland): capture on software renderers that advertise only 24-bpp shm (Bgr888)

### DIFF
--- a/crates/glass-wayland/src/pixels.rs
+++ b/crates/glass-wayland/src/pixels.rs
@@ -2,14 +2,18 @@ use glass_core::pixels::{to_opaque_rgba, SourceOrder};
 use glass_core::{GlassError, Result};
 use wayland_client::protocol::wl_shm::Format;
 
-/// Convert a 32-bit `wl_shm` screencopy buffer to tightly-packed RGBA, forcing
-/// alpha opaque and honoring row `stride` padding. Handles both channel orders
-/// wlroots compositors emit:
-/// - `Xrgb8888`/`Argb8888` are little-endian byte order `[B, G, R, _]` → swap R/B.
-/// - `Xbgr8888`/`Abgr8888` are `[R, G, B, _]` → already in order.
+/// Convert a `wl_shm` screencopy buffer to tightly-packed opaque RGBA, honoring row
+/// `stride` padding. Handles the 32-bpp layouts GPU compositors emit and the 24-bpp packed
+/// layouts software renderers negotiate (headless sway advertises only `Bgr888`):
+/// - `Xrgb8888`/`Argb8888` — little-endian byte order `[B, G, R, _]` → swap R/B.
+/// - `Xbgr8888`/`Abgr8888` — `[R, G, B, _]` → already in order.
+/// - `Bgr888` — 3 bytes/pixel, `[R, G, B]` → already in order.
+/// - `Rgb888` — 3 bytes/pixel, `[B, G, R]` → swap R/B.
 ///
-/// Stride padding is dropped row-by-row; the per-pixel swizzle is the shared SIMD
-/// kernel in [`glass_core::pixels`]. Errors on any other format.
+/// The `wl_shm`/DRM format *name* is the big-endian channel order; the bytes in memory are
+/// its little-endian reverse (so `Xrgb8888` is `[B, G, R, _]` and `Bgr888` is `[R, G, B]`).
+/// The 32-bpp swizzle uses the shared SIMD kernel in [`glass_core::pixels`]; the 24-bpp path
+/// expands 3→4 bytes scalar. Errors on any other format.
 pub fn to_rgba(
     src: &[u8],
     format: Format,
@@ -17,19 +21,39 @@ pub fn to_rgba(
     height: u32,
     stride: u32,
 ) -> Result<Vec<u8>> {
-    let order = match format {
-        Format::Xrgb8888 | Format::Argb8888 => SourceOrder::Bgr,
-        Format::Xbgr8888 | Format::Abgr8888 => SourceOrder::Rgb,
+    let (w, h, stride) = (width as usize, height as usize, stride as usize);
+    let mut out = vec![0u8; w * h * 4];
+    match format {
+        Format::Xrgb8888 | Format::Argb8888 => {
+            unpack32(src, &mut out, w, h, stride, SourceOrder::Bgr)?
+        }
+        Format::Xbgr8888 | Format::Abgr8888 => {
+            unpack32(src, &mut out, w, h, stride, SourceOrder::Rgb)?
+        }
+        Format::Bgr888 => unpack24(src, &mut out, w, h, stride, SourceOrder::Rgb)?,
+        Format::Rgb888 => unpack24(src, &mut out, w, h, stride, SourceOrder::Bgr)?,
         other => {
             return Err(GlassError::CaptureFailed(format!(
                 "unsupported screencopy format {other:?}"
             )))
         }
-    };
-    let (w, h, stride) = (width as usize, height as usize, stride as usize);
-    if stride < w * 4 {
+    }
+    Ok(out)
+}
+
+/// Validate a source buffer's `stride`/size for `bytes_per_pixel`, returning the packed
+/// (unpadded) row width in bytes.
+fn check_src(
+    src: &[u8],
+    w: usize,
+    h: usize,
+    stride: usize,
+    bytes_per_pixel: usize,
+) -> Result<usize> {
+    let row = w * bytes_per_pixel;
+    if stride < row {
         return Err(GlassError::CaptureFailed(format!(
-            "stride {stride} < {w}*4"
+            "stride {stride} < {w}*{bytes_per_pixel}"
         )));
     }
     let needed = stride
@@ -41,14 +65,75 @@ pub fn to_rgba(
             src.len()
         )));
     }
-    let row = w * 4;
-    let mut out = vec![0u8; w * h * 4];
+    Ok(row)
+}
+
+/// 32-bpp source: swap R/B per `order`, force alpha opaque, via the shared SIMD kernel.
+fn unpack32(
+    src: &[u8],
+    out: &mut [u8],
+    w: usize,
+    h: usize,
+    stride: usize,
+    order: SourceOrder,
+) -> Result<()> {
+    let row = check_src(src, w, h, stride, 4)?;
     for y in 0..h {
         let s = &src[y * stride..y * stride + row];
         let d = &mut out[y * row..y * row + row];
         to_opaque_rgba(s, d, order);
     }
-    Ok(out)
+    Ok(())
+}
+
+/// 24-bpp packed source: expand 3 bytes/pixel to opaque RGBA, swapping R/B per `order`.
+fn unpack24(
+    src: &[u8],
+    out: &mut [u8],
+    w: usize,
+    h: usize,
+    stride: usize,
+    order: SourceOrder,
+) -> Result<()> {
+    let row = check_src(src, w, h, stride, 3)?;
+    let dst_row = w * 4;
+    for y in 0..h {
+        let s = &src[y * stride..y * stride + row];
+        let d = &mut out[y * dst_row..y * dst_row + dst_row];
+        for (px, dst) in s.chunks_exact(3).zip(d.chunks_exact_mut(4)) {
+            let (r, b) = match order {
+                SourceOrder::Bgr => (px[2], px[0]),
+                SourceOrder::Rgb => (px[0], px[2]),
+            };
+            dst[0] = r;
+            dst[1] = px[1];
+            dst[2] = b;
+            dst[3] = 255;
+        }
+    }
+    Ok(())
+}
+
+/// The 32-bit `wl_shm` formats [`to_rgba`] converts via the shared SIMD kernel.
+fn is_preferred_format(f: Format) -> bool {
+    matches!(
+        f,
+        Format::Xrgb8888 | Format::Argb8888 | Format::Xbgr8888 | Format::Abgr8888
+    )
+}
+
+/// Choose which advertised screencopy buffer to request. wlr-screencopy v3 advertises one
+/// entry per supported shm format `(format, width, height, stride)`; prefer a 32-bit one
+/// [`to_rgba`] handles, so capture reuses the well-tested SIMD path instead of whatever a
+/// software renderer happens to list first (e.g. a packed 24-bit format). Falls back to the
+/// first advertised entry when no preferred format is offered; `None` only when the list is
+/// empty.
+pub fn pick_shm_format(advertised: &[(Format, u32, u32, u32)]) -> Option<(Format, u32, u32, u32)> {
+    advertised
+        .iter()
+        .copied()
+        .find(|(f, ..)| is_preferred_format(*f))
+        .or_else(|| advertised.first().copied())
 }
 
 #[cfg(test)]
@@ -87,5 +172,56 @@ mod tests {
     fn rejects_short_buffer() {
         let err = to_rgba(&[0u8; 8], Format::Argb8888, 2, 2, 8).unwrap_err();
         assert!(matches!(err, GlassError::CaptureFailed(_)));
+    }
+
+    #[test]
+    fn converts_bgr888_24bpp_respecting_stride() {
+        // Bgr888 memory bytes are [R,G,B] (already RGBA order), 3 bytes/pixel.
+        // 2x2, stride 8 (6 used + 2 pad per row).
+        let src = vec![
+            10, 20, 30, 40, 50, 60, 0, 0, // row 0 (+pad)
+            70, 80, 90, 100, 110, 120, 0, 0, // row 1 (+pad)
+        ];
+        let out = to_rgba(&src, Format::Bgr888, 2, 2, 8).unwrap();
+        assert_eq!(
+            out,
+            vec![10, 20, 30, 255, 40, 50, 60, 255, 70, 80, 90, 255, 100, 110, 120, 255]
+        );
+    }
+
+    #[test]
+    fn converts_rgb888_24bpp_swapping_red_blue() {
+        // Rgb888 memory bytes are [B,G,R]; swap to RGBA. 2x1, tight stride 6.
+        let src = vec![10, 20, 30, 40, 50, 60];
+        let out = to_rgba(&src, Format::Rgb888, 2, 1, 6).unwrap();
+        assert_eq!(out, vec![30, 20, 10, 255, 60, 50, 40, 255]);
+    }
+
+    #[test]
+    fn prefers_a_32bit_format_over_others() {
+        // A software compositor may advertise a 24-bit format (which to_rgba can't convert)
+        // alongside a 32-bit one; pick the 32-bit one so capture reuses the SIMD path.
+        let advertised = [
+            (Format::Bgr888, 100, 50, 300),
+            (Format::Xrgb8888, 100, 50, 400),
+        ];
+        assert_eq!(
+            pick_shm_format(&advertised),
+            Some((Format::Xrgb8888, 100, 50, 400))
+        );
+    }
+
+    #[test]
+    fn falls_back_to_first_when_no_32bit_advertised() {
+        let advertised = [(Format::Bgr888, 100, 50, 300)];
+        assert_eq!(
+            pick_shm_format(&advertised),
+            Some((Format::Bgr888, 100, 50, 300))
+        );
+    }
+
+    #[test]
+    fn none_when_nothing_advertised() {
+        assert_eq!(pick_shm_format(&[]), None);
     }
 }

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -22,7 +22,7 @@ use tempfile::TempDir;
 use wayland_client::globals::registry_queue_init;
 use wayland_client::protocol::wl_pointer::{Axis, ButtonState};
 use wayland_client::protocol::{wl_buffer, wl_output, wl_seat, wl_shm};
-use wayland_client::{Connection, Dispatch, EventQueue, QueueHandle, WEnum};
+use wayland_client::{Connection, Dispatch, EventQueue, Proxy, QueueHandle, WEnum};
 use wayland_protocols_misc::zwp_virtual_keyboard_v1::client::zwp_virtual_keyboard_manager_v1::ZwpVirtualKeyboardManagerV1;
 use wayland_protocols_misc::zwp_virtual_keyboard_v1::client::zwp_virtual_keyboard_v1::ZwpVirtualKeyboardV1;
 use wayland_protocols_wlr::screencopy::v1::client::zwlr_screencopy_frame_v1::{
@@ -232,8 +232,9 @@ struct State {
     registry: RegistryState,
     output: OutputState,
     shm: Shm,
-    frame_buffer: Option<(wl_shm::Format, u32, u32, u32)>, // format, w, h, stride
-    capture_done: Option<Result<()>>,                      // Some(Ok)=ready, Some(Err)=failed
+    shm_buffers: Vec<(wl_shm::Format, u32, u32, u32)>, // advertised formats (format, w, h, stride)
+    buffer_done: bool,                                 // v3: end of the format advertisement list
+    capture_done: Option<Result<()>>,                  // Some(Ok)=ready, Some(Err)=failed
 }
 
 impl ProvidesRegistryState for State {
@@ -305,14 +306,15 @@ impl Dispatch<ZwlrScreencopyFrameV1, ()> for State {
                 height,
                 stride,
             } => {
-                state.frame_buffer = Some((f, width, height, stride));
+                state.shm_buffers.push((f, width, height, stride));
             }
+            Event::BufferDone => state.buffer_done = true,
             Event::Ready { .. } => state.capture_done = Some(Ok(())),
             Event::Failed => {
                 state.capture_done =
                     Some(Err(GlassError::CaptureFailed("screencopy failed".into())))
             }
-            _ => {} // Flags, Damage, LinuxDmabuf, BufferDone, etc.
+            _ => {} // Flags, Damage, LinuxDmabuf, etc.
         }
     }
 }
@@ -415,11 +417,12 @@ fn open_session(
         registry: RegistryState::new(&globals),
         output: OutputState::new(&globals, &qh),
         shm: Shm::bind(&globals, &qh).map_err(|e| GlassError::Backend(format!("bind shm: {e}")))?,
-        frame_buffer: None,
+        shm_buffers: Vec::new(),
+        buffer_done: false,
         capture_done: None,
     };
     let manager: ZwlrScreencopyManagerV1 = globals
-        .bind(&qh, 1..=1, ())
+        .bind(&qh, 1..=3, ())
         .map_err(|e| GlassError::Backend(format!("bind screencopy: {e}")))?;
     let seat: wl_seat::WlSeat = globals
         .bind(&qh, 1..=8, ())
@@ -988,7 +991,8 @@ impl Platform for WaylandPlatform {
 
     fn capture_frame(&mut self, region: Option<&Region>) -> Result<Frame> {
         let session = self.active.as_mut().ok_or(GlassError::NoActiveSession)?;
-        session.state.frame_buffer = None;
+        session.state.shm_buffers.clear();
+        session.state.buffer_done = false;
         session.state.capture_done = None;
         let qh = session.queue.handle();
 
@@ -1016,14 +1020,25 @@ impl Platform for WaylandPlatform {
 
         let deadline = Instant::now() + Duration::from_millis(5000);
 
-        // Phase 1: dispatch until the compositor advertises the buffer geometry.
+        // Phase 1: dispatch until the compositor has advertised its buffer formats, then pick
+        // one we can convert (preferring 32-bit). v3 marks the end of the format list with
+        // `buffer_done`; v1/v2 advertise a single format and never send it, so there we proceed
+        // as soon as one arrives.
+        let manager_v3 = session.manager.version() >= 3;
         let (format, w, h, stride) = loop {
             session
                 .queue
                 .blocking_dispatch(&mut session.state)
                 .map_err(|e| GlassError::CaptureFailed(format!("dispatch: {e}")))?;
-            if let Some(b) = session.state.frame_buffer {
-                break b;
+            let advertised = if manager_v3 {
+                session.state.buffer_done
+            } else {
+                !session.state.shm_buffers.is_empty()
+            };
+            if advertised {
+                break crate::pixels::pick_shm_format(&session.state.shm_buffers).ok_or_else(
+                    || GlassError::CaptureFailed("screencopy: no shm format advertised".into()),
+                )?;
             }
             if let Some(Err(e)) = session.state.capture_done.take() {
                 return Err(e);


### PR DESCRIPTION
## Problem

On a Wayland/sway session whose renderer falls back to software (no usable GPU — e.g. an nvidia-headless box where wlroots can't get a clean EGL/GBM path, or a GPU-less CI runner), `zwlr_screencopy` advertises only the packed 24-bpp `Bgr888` shm format. glass bound screencopy at **v1**, which offers no format choice — so it took `Bgr888` and `to_rgba` rejected it. Every frame-capture tool then failed with `capture failed: unsupported screencopy format Bgr888`, making the entire pixel half of glass unusable on Wayland there. See #83.

## Root cause

- `platform.rs` bound `ZwlrScreencopyManagerV1` at `1..=1`. In v1 the compositor advertises a single, compositor-chosen shm format via one `buffer` event; the client can't select. glass just kept the last one advertised.
- `pixels.rs::to_rgba` only handled the four 32-bpp formats and errored on everything else.

glass configures sway as `WLR_BACKENDS=headless` + `WLR_RENDERER_ALLOW_SOFTWARE=1` — i.e. it deliberately targets no-GPU/software rendering, so the software renderer's format is a first-class case, not an edge one.

## Fix

Handle the format instead of coercing the renderer (keeps glass's no-GPU design intact):

1. **Bind screencopy v3** (`1..=3`). v3 advertises one `buffer` event per supported shm format, ending with `buffer_done`. Collect them all, then `pick_shm_format` **prefers a 32-bit format** `to_rgba` converts via the shared SIMD kernel. A GPU compositor that offers both keeps the fast path automatically; a version guard falls back to the single-format behavior on v1/v2-only compositors.
2. **Add a 24-bpp `Bgr888`/`Rgb888` path** to `to_rgba` for renderers that offer nothing else, expanding 3→4 bytes with the correct R/B order (the `wl_shm`/DRM name is big-endian channel order; memory is its little-endian reverse, so `Bgr888` is `[R,G,B]`).

## Why not `WLR_RENDERER=gles`?

Pinning a GL renderer would force 32-bit on this box, but it ties Wayland capture to a working GL/EGL stack (hardware or llvmpipe+Mesa) — reintroducing the GPU dependency glass avoids by allowing pixman, and leaning on the exact flaky nvidia-headless-GL path that caused this. Handling the format keeps glass working on any renderer, GPU or not.

## Tests

- Unit (`pixels.rs`): `pick_shm_format` prefers 32-bit / falls back to first / `None` when empty; `to_rgba` converts `Bgr888` (no swap) and `Rgb888` (swap) respecting stride.
- Integration, against the bundled sway 1.12 (which advertises only `Bgr888` here): the **full Wayland suite passes, 16/16**, including `captures_active_window_pixels`, whose exact-color assertions (TL red / TR green / BL blue / BR white) confirm the 24-bpp byte order end to end.

Local gate green: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace`, `scripts/test-wayland.sh`.

Fixes #83
