### PR TITLE
fix(a11y-linux): set_value on a spin button writes through the Value interface

### DIFF
--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -152,6 +152,16 @@ async fn snapshot_async(ctx: &AxContext) -> Result<AxTree> {
     Ok(tree)
 }
 
+/// Whether `set_value` must write through the AT-SPI `Value` interface only, skipping
+/// `EditableText`. A `GtkSpinButton` exposes both interfaces, but `EditableText` writes its
+/// inner entry buffer without committing to the adjustment (the value silently reverts);
+/// numeric/range widgets with a numeric target must go through `Value`, the sole interface
+/// that applies the change.
+fn writes_value_only(role: glass_core::AxRole, text: &str) -> bool {
+    use glass_core::AxRole::*;
+    matches!(role, Slider | SpinButton | ScrollBar) && text.parse::<f64>().is_ok()
+}
+
 async fn set_value_async(ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
     let (app_ref, conn) = find_app(ctx).await?;
     let app = app_ref.as_accessible_proxy(&conn).await.map_err(bus_err)?;
@@ -170,19 +180,23 @@ async fn set_value_async(ctx: &AxContext, target: &AxTarget, text: &str) -> Resu
 
     let dest = node.inner().destination().to_owned();
     let path = node.inner().path().to_owned();
-    // Prefer EditableText (text fields); fall back to Value (numeric). The builder
-    // `.ok()` chaining mirrors the working ComponentProxy build in `extents`.
-    let editable = atspi::proxy::editable_text::EditableTextProxy::builder(&conn)
-        .destination(dest.clone())
-        .ok()
-        .and_then(|b| b.path(path.clone()).ok());
-    if let Some(b) = editable {
-        if let Ok(et) = b.build().await {
-            match et.set_text_contents(text).await {
-                Ok(true) => return Ok(()),
-                // EditableText is present but rejected the write — don't try Value.
-                Ok(false) => return Err(GlassError::AxElementNotEditable(target.id.0)),
-                Err(_) => {} // interface absent / call failed — fall through to Value
+    // Numeric/range widgets go through Value only (see `writes_value_only`): a GtkSpinButton
+    // also exposes EditableText, but writing its entry buffer doesn't commit to the adjustment.
+    // Text widgets prefer EditableText, falling back to Value for anything numeric that lacks it.
+    // The builder `.ok()` chaining mirrors the working ComponentProxy build in `extents`.
+    if !writes_value_only(role, text) {
+        let editable = atspi::proxy::editable_text::EditableTextProxy::builder(&conn)
+            .destination(dest.clone())
+            .ok()
+            .and_then(|b| b.path(path.clone()).ok());
+        if let Some(b) = editable {
+            if let Ok(et) = b.build().await {
+                match et.set_text_contents(text).await {
+                    Ok(true) => return Ok(()),
+                    // EditableText is present but rejected the write — don't try Value.
+                    Ok(false) => return Err(GlassError::AxElementNotEditable(target.id.0)),
+                    Err(_) => {} // interface absent / call failed — fall through to Value
+                }
             }
         }
     }
@@ -374,5 +388,23 @@ mod tests {
             !msg.contains("relaunch with a11y:true"),
             "distinct from the bus/opt-in error"
         );
+    }
+
+    #[test]
+    fn writes_value_only_for_numeric_range_widgets() {
+        use glass_core::AxRole::*;
+        assert!(writes_value_only(SpinButton, "4"));
+        assert!(writes_value_only(Slider, "50.5"));
+        assert!(writes_value_only(ScrollBar, "0"));
+    }
+
+    #[test]
+    fn writes_value_only_is_false_for_text_or_non_numeric() {
+        use glass_core::AxRole::*;
+        // A text field uses EditableText even when its content is numeric.
+        assert!(!writes_value_only(TextField, "4"));
+        // A non-numeric target isn't the value path.
+        assert!(!writes_value_only(SpinButton, "abc"));
+        assert!(!writes_value_only(Button, "x"));
     }
 }

--- a/crates/glass-a11y-linux/tests/fixtures/a11y_fixture.py
+++ b/crates/glass-a11y-linux/tests/fixtures/a11y_fixture.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Minimal GTK4 app with a known accessibility tree, for glass-a11y-linux tests.
 Window "Glass A11y Fixture" containing a Label "Ready", a Button "Save", a
-CheckButton "Enable", and an Entry "Field" (initial text "hello"). Run by
-scripts/test-a11y.sh via glass (which sets DISPLAY).
+CheckButton "Enable", an Entry "Field" (initial text "hello"), and a SpinButton
+"Amount" (initial value 1). Run by scripts/test-a11y.sh via glass (which sets DISPLAY).
 
 Uses Gio.ApplicationFlags.NON_UNIQUE so the app skips D-Bus singleton registration
 and presents its window immediately without waiting for portal services to settle."""
@@ -32,6 +32,14 @@ class FixtureApp(Gtk.Application):
         entry.set_text("hello")
         entry.update_property([Gtk.AccessibleProperty.LABEL], ["Field"])
         box.append(entry)
+        # A SpinButton exposes BOTH the AT-SPI EditableText and Value interfaces; only
+        # Value commits to the adjustment, so set_value must go through Value.
+        spin = Gtk.SpinButton(
+            adjustment=Gtk.Adjustment(value=1, lower=0, upper=10, step_increment=1),
+            digits=0,
+        )
+        spin.update_property([Gtk.AccessibleProperty.LABEL], ["Amount"])
+        box.append(spin)
         win.set_child(box)
         win.present()
 

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -239,6 +239,52 @@ fn set_value_on_button_is_not_editable() {
     glass.stop().expect("stop");
 }
 
+#[test]
+#[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
+fn set_value_changes_spinbutton() {
+    let fixture = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/a11y_fixture.py"
+    );
+    let mut glass = glass_x11_with_a11y();
+    glass
+        .start(&AppSpec {
+            build: None,
+            run: vec!["python3".into(), fixture.into()],
+            cwd: None,
+            env: vec![
+                ("LIBGL_ALWAYS_SOFTWARE".into(), "1".into()),
+                ("GDK_BACKEND".into(), "x11".into()),
+            ],
+            window_hint: Some(WindowHint {
+                title: Some("Glass A11y Fixture".into()),
+                class: None,
+            }),
+            timeout_ms: 35_000,
+            sandbox: glass_core::SandboxLevel::Off,
+            a11y: true,
+        })
+        .expect("launch");
+    std::thread::sleep(std::time::Duration::from_millis(3_000));
+
+    // A GtkSpinButton exposes both EditableText and Value; set_value must write through the
+    // Value interface (the only one that commits to the adjustment) rather than the entry
+    // buffer, which reverts.
+    let tree = glass.a11y_snapshot().expect("snapshot");
+    let spin = find_role(&tree.root, glass_core::AxRole::SpinButton).expect("spinbutton");
+    assert_eq!(spin.value.as_deref(), Some("1"), "fixture starts at 1");
+    glass.set_value(spin.id, "4").expect("set_value");
+
+    let tree2 = glass.a11y_snapshot().expect("snapshot 2");
+    let spin2 = find_role(&tree2.root, glass_core::AxRole::SpinButton).expect("spinbutton 2");
+    assert_eq!(
+        spin2.value.as_deref(),
+        Some("4"),
+        "value should commit through the Value interface, not silently revert"
+    );
+    glass.stop().expect("stop");
+}
+
 // Pre-order search for the first node of a given role.
 fn find_role(node: &glass_core::AxNode, role: glass_core::AxRole) -> Option<&glass_core::AxNode> {
     if node.role == role {


### PR DESCRIPTION
## Problem

`set_value` on a GtkSpinButton returned success but the underlying value didn't change — the "never trust `ok`" case from #81.

## Root cause

`set_value_async` tried the AT-SPI **EditableText** interface first and returned `Ok` as soon as `set_text_contents` succeeded. A GtkSpinButton exposes *both* EditableText (its inner entry) and Value, but only **Value** commits to the adjustment — writing the entry buffer via EditableText doesn't apply, so the displayed value reverts. The Value fallback (`set_current_value`) was never reached.

## Fix

Route numeric/range roles through Value, skipping EditableText:

```rust
fn writes_value_only(role: AxRole, text: &str) -> bool {
    matches!(role, Slider | SpinButton | ScrollBar) && text.parse::<f64>().is_ok()
}
```

When true, `set_value_async` skips the EditableText attempt and writes through the Value interface. Text widgets are unchanged (EditableText first, Value fallback for anything numeric that lacks it). A non-numeric target on a spin button (`writes_value_only == false`) still falls to the existing path.

## Verification (end to end, against a real GtkSpinButton over AT-SPI)

- Added a `Gtk.SpinButton "Amount"` (initial value 1) to the a11y fixture — it exposes both interfaces, so it reproduces the exact bug.
- New integration test `set_value_changes_spinbutton`: snapshot → `set_value(id, "4")` → re-snapshot, assert the Value-interface readback is `"4"`. **Fails before this change** (`left: Some("1")`, so the value silently reverted) and **passes after**.
- Unit tests for `writes_value_only` (numeric range widgets → true; text field / non-numeric / button → false).
- No regressions: `set_value_changes_entry`, `set_value_on_button_is_not_editable`, and the **full a11y integration suite (12/12)** stay green.

Gate green: `cargo fmt --all --check`, `cargo clippy -p glass-a11y-linux --all-targets --locked -- -D warnings`, `cargo test -p glass-a11y-linux`, `scripts/test-a11y.sh`.

Fixes #81
