### PR TITLE
feat(diff): scope glass_diff to a window-relative sub-region (#87)

### DIFF
--- a/crates/glass-core/src/session.rs
+++ b/crates/glass-core/src/session.rs
@@ -793,12 +793,30 @@ impl Glass {
         self.baselines.save(name, &frame)
     }
 
-    /// Load the named baseline and capture the current window frame.
-    fn baseline_and_current(&mut self, name: &str) -> Result<(Frame, Frame)> {
-        let baseline = self.baselines.load(name)?;
+    /// Load the named baseline and capture the current window frame, both scoped
+    /// to `region` when set (the whole window otherwise). Baselines are stored
+    /// whole and cropped here, so one saved baseline can be compared against any
+    /// sub-region — and both operands are always cropped consistently, never
+    /// silently mismatched.
+    fn baseline_and_current(
+        &mut self,
+        name: &str,
+        region: Option<&Region>,
+    ) -> Result<(Frame, Frame)> {
+        if let Some(r) = region {
+            let geo = self.require_active()?.geometry.clone();
+            r.check_fits(geo.width, geo.height)?;
+        }
+        let baseline = {
+            let base = self.baselines.load(name)?;
+            match region {
+                Some(r) => base.crop(r)?,
+                None => base,
+            }
+        };
         let current = {
             let s = self.active_mut()?;
-            let frame = s.platform.capture_frame(None)?;
+            let frame = s.platform.capture_frame(region)?;
             s.pump();
             frame
         };
@@ -806,8 +824,14 @@ impl Glass {
     }
 
     /// Exact per-channel diff of the current frame against a saved baseline.
-    pub fn diff_baseline(&mut self, name: &str, tolerance: u8) -> Result<DiffResult> {
-        self.diff_baseline_with_frame(name, tolerance)
+    /// `region` scopes the comparison to a window-relative sub-rectangle.
+    pub fn diff_baseline(
+        &mut self,
+        name: &str,
+        region: Option<&Region>,
+        tolerance: u8,
+    ) -> Result<DiffResult> {
+        self.diff_baseline_with_frame(name, region, tolerance)
             .map(|(r, _)| r)
     }
 
@@ -815,18 +839,25 @@ impl Glass {
     pub fn diff_baseline_with_frame(
         &mut self,
         name: &str,
+        region: Option<&Region>,
         tolerance: u8,
     ) -> Result<(DiffResult, Frame)> {
-        let (baseline, current) = self.baseline_and_current(name)?;
+        let (baseline, current) = self.baseline_and_current(name, region)?;
         let r = diff(&baseline, &current, tolerance)?;
         Ok((r, current))
     }
 
     /// Perceptual diff (YIQ + anti-alias suppression) against a saved baseline —
     /// the default for regression, robust to anti-aliasing / sub-pixel / GPU-font
-    /// rendering noise. `threshold` ∈ [0,1] (smaller = stricter).
-    pub fn diff_baseline_perceptual(&mut self, name: &str, threshold: f32) -> Result<DiffResult> {
-        self.diff_baseline_perceptual_with_frame(name, threshold)
+    /// rendering noise. `threshold` ∈ [0,1] (smaller = stricter). `region` scopes
+    /// the comparison to a window-relative sub-rectangle.
+    pub fn diff_baseline_perceptual(
+        &mut self,
+        name: &str,
+        region: Option<&Region>,
+        threshold: f32,
+    ) -> Result<DiffResult> {
+        self.diff_baseline_perceptual_with_frame(name, region, threshold)
             .map(|(r, _)| r)
     }
 
@@ -834,9 +865,10 @@ impl Glass {
     pub fn diff_baseline_perceptual_with_frame(
         &mut self,
         name: &str,
+        region: Option<&Region>,
         threshold: f32,
     ) -> Result<(DiffResult, Frame)> {
-        let (baseline, current) = self.baseline_and_current(name)?;
+        let (baseline, current) = self.baseline_and_current(name, region)?;
         let r = diff_perceptual(&baseline, &current, threshold)?;
         Ok((r, current))
     }
@@ -1461,7 +1493,7 @@ mod tests {
         let mut g = glass_with(platform);
         g.start(&spec()).unwrap();
         g.save_baseline("main").unwrap();
-        let result = g.diff_baseline("main", 0).unwrap();
+        let result = g.diff_baseline("main", None, 0).unwrap();
         assert_eq!(result.changed_pixels, 1);
     }
 
@@ -1472,9 +1504,73 @@ mod tests {
         let mut g = glass_with(platform);
         g.start(&spec()).unwrap();
         assert!(matches!(
-            g.diff_baseline("absent", 0).unwrap_err(),
+            g.diff_baseline("absent", None, 0).unwrap_err(),
             GlassError::BaselineMissing(_)
         ));
+    }
+
+    #[test]
+    fn diff_region_scopes_comparison_to_subrectangle() {
+        // A single whole baseline is compared against several sub-regions: the
+        // baseline is stored whole and cropped per-call, so both operands always
+        // cover the same rectangle.
+        let base = Frame::solid(4, 4, [0, 0, 0, 255]);
+        let mut changed = base.clone();
+        changed.pixels[(3 * 4 + 3) * 4] = 255; // pixel (3,3)
+        let platform = FakePlatform::new(4, 4).with_frames(vec![base, changed]);
+        let mut g = glass_with(platform);
+        g.start(&spec()).unwrap();
+        g.save_baseline("m").unwrap();
+        let top_left = Region {
+            x: 0,
+            y: 0,
+            width: 2,
+            height: 2,
+        };
+        let bottom_right = Region {
+            x: 2,
+            y: 2,
+            width: 2,
+            height: 2,
+        };
+        // Region excludes the changed pixel -> no change.
+        assert_eq!(
+            g.diff_baseline("m", Some(&top_left), 0)
+                .unwrap()
+                .changed_pixels,
+            0
+        );
+        // Region includes the changed pixel -> sees exactly it.
+        assert_eq!(
+            g.diff_baseline("m", Some(&bottom_right), 0)
+                .unwrap()
+                .changed_pixels,
+            1
+        );
+        // Whole-frame diff still sees it.
+        assert_eq!(g.diff_baseline("m", None, 0).unwrap().changed_pixels, 1);
+    }
+
+    #[test]
+    fn diff_region_out_of_bounds_is_rejected() {
+        let base = Frame::solid(4, 4, [0, 0, 0, 255]);
+        let platform = FakePlatform::new(4, 4).with_frames(vec![base.clone(), base]);
+        let mut g = glass_with(platform);
+        g.start(&spec()).unwrap();
+        g.save_baseline("m").unwrap();
+        let err = g
+            .diff_baseline(
+                "m",
+                Some(&Region {
+                    x: 0,
+                    y: 0,
+                    width: 9,
+                    height: 1,
+                }),
+                0,
+            )
+            .unwrap_err();
+        assert!(matches!(err, GlassError::InvalidRegion(_)));
     }
 
     #[test]

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -298,6 +298,11 @@ pub struct DiffArgs {
     /// Also return the current frame cropped to the changed region (default
     /// false). No image is returned when nothing changed.
     pub include_image: Option<bool>,
+    /// Optional window-relative sub-rectangle to diff; omit to diff the whole
+    /// window. Scopes the comparison (and the reported `bbox`, which becomes
+    /// region-relative) to just this area — the way to ask "did *only* this part
+    /// change?" Mirrors `glass_wait_for_region`'s `region`.
+    pub region: Option<RegionArgs>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -398,6 +403,17 @@ mod tests {
         let a: ScreenshotArgs =
             serde_json::from_str(r#"{"region":{"x":1,"y":2,"width":3,"height":4}}"#).unwrap();
         let r = a.region.unwrap();
+        assert_eq!((r.x, r.y, r.width, r.height), (1, 2, 3, 4));
+    }
+
+    #[test]
+    fn diff_args_region_defaults_none_and_parses() {
+        let none: DiffArgs = serde_json::from_str(r#"{"name":"m"}"#).unwrap();
+        assert!(none.region.is_none());
+        let some: DiffArgs =
+            serde_json::from_str(r#"{"name":"m","region":{"x":1,"y":2,"width":3,"height":4}}"#)
+                .unwrap();
+        let r = some.region.unwrap();
         assert_eq!((r.x, r.y, r.width, r.height), (1, 2, 3, 4));
     }
 

--- a/crates/glass-mcp/src/tools/batch.rs
+++ b/crates/glass-mcp/src/tools/batch.rs
@@ -289,6 +289,7 @@ mod tests {
                 then: Some(ThenArgs {
                     settle: None,
                     diff: Some(DiffArgs {
+                        region: None,
                         name: "absent".into(),
                         mode: None,
                         threshold: None,

--- a/crates/glass-mcp/src/tools/capture.rs
+++ b/crates/glass-mcp/src/tools/capture.rs
@@ -79,11 +79,16 @@ pub fn baseline_save(glass: &mut Glass, a: &BaselineSaveArgs) -> ToolResult {
 }
 
 pub fn diff(glass: &mut Glass, a: &DiffArgs) -> ToolResult {
+    let region = a.region.as_ref().map(Region::from);
     let (r, current) = match a.mode.as_deref().unwrap_or("perceptual") {
-        "perceptual" => {
-            glass.diff_baseline_perceptual_with_frame(&a.name, a.threshold.unwrap_or(0.1))
+        "perceptual" => glass.diff_baseline_perceptual_with_frame(
+            &a.name,
+            region.as_ref(),
+            a.threshold.unwrap_or(0.1),
+        ),
+        "exact" => {
+            glass.diff_baseline_with_frame(&a.name, region.as_ref(), a.tolerance.unwrap_or(0))
         }
-        "exact" => glass.diff_baseline_with_frame(&a.name, a.tolerance.unwrap_or(0)),
         other => {
             return Err(format!(
                 "unknown diff mode '{other}' (use perceptual/exact)"
@@ -95,16 +100,19 @@ pub fn diff(glass: &mut Glass, a: &DiffArgs) -> ToolResult {
     let bbox = r
         .bbox
         .map(|b| json!({ "x": b.x, "y": b.y, "width": b.width, "height": b.height }));
-    let text = OutContent::Text(
-        json!({
-            "changed_pixels": r.changed_pixels,
-            "total_pixels": r.total_pixels,
-            "changed_pct": r.changed_pct,
-            "aa_ignored": r.aa_ignored,
-            "bbox": bbox,
-        })
-        .to_string(),
-    );
+    let mut body = json!({
+        "changed_pixels": r.changed_pixels,
+        "total_pixels": r.total_pixels,
+        "changed_pct": r.changed_pct,
+        "aa_ignored": r.aa_ignored,
+        "bbox": bbox,
+    });
+    // Echo the region so the caller can map the region-relative bbox back to
+    // window coordinates.
+    if let Some(rr) = a.region.as_ref() {
+        body["region"] = json!({ "x": rr.x, "y": rr.y, "width": rr.width, "height": rr.height });
+    }
+    let text = OutContent::Text(body.to_string());
 
     // Opt-in: when something changed, attach the current frame cropped to the
     // changed region (token-minimal, exactly what differs). Nothing changed ->
@@ -322,6 +330,7 @@ mod tests {
         let out = diff(
             &mut g,
             &DiffArgs {
+                region: None,
                 name: "main".into(),
                 mode: None,
                 threshold: None,
@@ -337,6 +346,43 @@ mod tests {
     }
 
     #[test]
+    fn diff_with_region_scopes_and_echoes_region() {
+        // Whole baseline; current differs only outside the region.
+        let base = Frame::solid(4, 4, [0, 0, 0, 255]);
+        let mut changed = base.clone();
+        changed.pixels[(3 * 4 + 3) * 4] = 255; // pixel (3,3), outside (0,0,2,2)
+        let mut g = started_with(FakePlatform::new(4, 4).with_frames(vec![base, changed]));
+        baseline_save(&mut g, &BaselineSaveArgs { name: "m".into() }).unwrap();
+        let out = diff(
+            &mut g,
+            &DiffArgs {
+                region: Some(RegionArgs {
+                    x: 0,
+                    y: 0,
+                    width: 2,
+                    height: 2,
+                }),
+                name: "m".into(),
+                mode: None,
+                threshold: None,
+                tolerance: None,
+                include_image: None,
+            },
+        )
+        .unwrap();
+        match &out.0[0] {
+            OutContent::Text(t) => {
+                assert!(
+                    t.contains("\"changed_pixels\":0"),
+                    "region excludes change: {t}"
+                );
+                assert!(t.contains("\"region\":{"), "region echoed: {t}");
+            }
+            _ => panic!("expected text"),
+        }
+    }
+
+    #[test]
     fn diff_exact_mode_and_unknown_mode() {
         let base = Frame::solid(2, 2, [0, 0, 0, 255]);
         let mut changed = base.clone();
@@ -347,6 +393,7 @@ mod tests {
         let out = diff(
             &mut g,
             &DiffArgs {
+                region: None,
                 name: "m".into(),
                 mode: Some("exact".into()),
                 threshold: None,
@@ -363,6 +410,7 @@ mod tests {
         let err = diff(
             &mut g,
             &DiffArgs {
+                region: None,
                 name: "m".into(),
                 mode: Some("fuzzy".into()),
                 threshold: None,
@@ -384,6 +432,7 @@ mod tests {
         let err = diff(
             &mut g,
             &DiffArgs {
+                region: None,
                 name: "absent".into(),
                 mode: None,
                 threshold: None,
@@ -482,6 +531,7 @@ mod tests {
         let out = diff(
             &mut g,
             &DiffArgs {
+                region: None,
                 name: "m".into(),
                 mode: None,
                 threshold: None,
@@ -516,6 +566,7 @@ mod tests {
         let out = diff(
             &mut g,
             &DiffArgs {
+                region: None,
                 name: "m".into(),
                 mode: None,
                 threshold: None,
@@ -655,6 +706,7 @@ mod tests {
         let out = diff(
             &mut g,
             &DiffArgs {
+                region: None,
                 name: "m".into(),
                 mode: None,
                 threshold: None,
@@ -691,6 +743,7 @@ mod tests {
         let out = diff(
             &mut g,
             &DiffArgs {
+                region: None,
                 name: "m".into(),
                 mode: None,
                 threshold: None,


### PR DESCRIPTION
## What

Adds an optional `region` parameter to **`glass_diff`**, mirroring the existing `glass_wait_for_region`. It scopes a baseline comparison to a window-relative sub-rectangle.

When one action changes several unrelated areas at once — e.g. a search box's text **and** ~150 table rows **and** a status-bar count, all from one keystroke — a whole-frame diff can only report the union bounding box, so it can't answer *"did **only** the status bar change?"*. A region-scoped diff can.

## Behaviour

- `glass_diff{name, region:{x,y,width,height}}` compares only that sub-rectangle.
- The reported `bbox` is now **region-relative**; the result echoes the `region` back so a caller can map it to window coordinates.
- Out-of-bounds regions return a structured `InvalidRegion` error (no silent clamp).

Baselines remain **whole-window** frames, cropped to the region at compare time. That means one saved baseline can be compared against any sub-region, and both operands (baseline + current) are always cropped to the *same* rectangle — never silently mismatched.

## Scope note — `baseline_save` region deferred (see #87)

The issue also proposed `region` on `glass_baseline_save`. It's **intentionally omitted**: a region-scoped *stored* baseline loses its window-coordinate context, so re-comparing it can't be made safe without persisting the saved offset — a same-size region at a different offset would silently compare the wrong pixels (a silent mis-comparison, which we don't allow). It needs baseline metadata and is left as a follow-up. Whole-baseline + compare-time `region` fully covers the reported need and is strictly more flexible (no second region to keep in sync at save time). This was caught in pre-merge review.

## Tests

- Core: region diff scopes to the sub-rectangle (excludes / includes a change, plus whole-frame), and out-of-bounds region is rejected.
- MCP: `glass_diff` region scoping + region echo in the result meta; `DiffArgs` region parse/default.
- Verified the shared `capture_frame(Some(region))` production path against the real X11 backend (`scripts/test-x11.sh region`).
- `cargo fmt --check`, `cargo clippy -D warnings`, and `cargo test --workspace` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)