### PR TITLE
feat(a11y): set_value for switches and dropdowns (#82)

### DIFF
--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -178,6 +178,19 @@ async fn set_value_async(ctx: &AxContext, target: &AxTarget, text: &str) -> Resu
         return Err(GlassError::AxElementChanged(target.id.0));
     }
 
+    // Boolean widgets (switch/checkbox/toggle/radio) have no text buffer: set them
+    // through the Action interface (`toggle`) + `Checked` state, before the
+    // EditableText/Value paths. Combos are handled a layer up (session-level
+    // keyboard navigation), never reaching here.
+    {
+        use glass_core::AxRole::{CheckBox, RadioButton, ToggleButton};
+        if matches!(role, CheckBox | ToggleButton | RadioButton) {
+            if let Some(on) = parse_bool(text) {
+                return set_toggle(&conn, &node, role, on, target.id.0).await;
+            }
+        }
+    }
+
     let dest = node.inner().destination().to_owned();
     let path = node.inner().path().to_owned();
     // Numeric/range widgets go through Value only (see `writes_value_only`): a GtkSpinButton
@@ -295,6 +308,84 @@ async fn walk(proxy: &AccessibleProxy<'_>, conn: &zbus::Connection) -> Result<Ax
         bounds,
         children,
     })
+}
+
+/// Parse a boolean target for a toggle widget. Accepts the common textual and
+/// numeric spellings; `None` means "not a boolean" (so the caller falls through
+/// to another path rather than guessing).
+fn parse_bool(text: &str) -> Option<bool> {
+    match text.trim().to_ascii_lowercase().as_str() {
+        "true" | "1" | "on" | "yes" | "checked" | "check" => Some(true),
+        "false" | "0" | "off" | "no" | "unchecked" | "uncheck" => Some(false),
+        _ => None,
+    }
+}
+
+/// AT-SPI action names that flip / activate a boolean widget. A GtkSwitch exposes
+/// `"toggle"`; buttons/checkboxes expose `"click"`/`"activate"`/`"press"`.
+const TOGGLE_ACTION_NAMES: &[&str] = &[
+    "toggle", "click", "activate", "press", "check", "uncheck", "switch",
+];
+
+/// Invoke the node's first activating Action (see [`TOGGLE_ACTION_NAMES`]).
+/// Returns whether an action was found and reported success.
+async fn invoke_activating_action(conn: &zbus::Connection, node: &AccessibleProxy<'_>) -> bool {
+    let dest = node.inner().destination().to_owned();
+    let path = node.inner().path().to_owned();
+    let Some(action) = atspi::proxy::action::ActionProxy::builder(conn)
+        .destination(dest)
+        .ok()
+        .and_then(|b| b.path(path).ok())
+    else {
+        return false;
+    };
+    let Ok(a) = action.build().await else {
+        return false;
+    };
+    let n = a.n_actions().await.unwrap_or(0);
+    for i in 0..n {
+        let name = a.get_name(i).await.unwrap_or_default().to_ascii_lowercase();
+        if TOGGLE_ACTION_NAMES.contains(&name.as_str()) {
+            return a.do_action(i).await.unwrap_or(false);
+        }
+    }
+    false
+}
+
+/// Set a boolean widget (switch/checkbox/toggle/radio) to `target_on`. Idempotent:
+/// only invokes the toggle action when the boolean state differs, then confirms the
+/// state actually changed (the toolkit applies the action on its next loop) — so a
+/// no-op activation (e.g. a radio can't be *un*-selected by clicking it) is reported
+/// as `AxValueNotApplied`, never a silent success. Toggle buttons expose their state
+/// via `Pressed`; checkboxes/switches/radios via `Checked`.
+async fn set_toggle(
+    conn: &zbus::Connection,
+    node: &AccessibleProxy<'_>,
+    role: glass_core::AxRole,
+    target_on: bool,
+    id: u32,
+) -> Result<()> {
+    let flag = if role == glass_core::AxRole::ToggleButton {
+        atspi_common::State::Pressed
+    } else {
+        atspi_common::State::Checked
+    };
+    if node.get_state().await.map_err(bus_err)?.contains(flag) == target_on {
+        return Ok(()); // already in the desired state
+    }
+    if !invoke_activating_action(conn, node).await {
+        // No toggle action (e.g. a GTK4 GtkCheckButton exposes none) — can't set it
+        // through accessibility; the caller should drive it with click_element.
+        return Err(GlassError::AxElementNotEditable(id));
+    }
+    // Poll until the toolkit applies it; a no-op activation never converges.
+    for _ in 0..6 {
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        if node.get_state().await.map_err(bus_err)?.contains(flag) == target_on {
+            return Ok(());
+        }
+    }
+    Err(GlassError::AxValueNotApplied(id))
 }
 
 /// Window-relative bounds via the Component interface, or `None` if the node has no

--- a/crates/glass-a11y-linux/tests/fixtures/a11y_fixture.py
+++ b/crates/glass-a11y-linux/tests/fixtures/a11y_fixture.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Minimal GTK4 app with a known accessibility tree, for glass-a11y-linux tests.
 Window "Glass A11y Fixture" containing a Label "Ready", a Button "Save", a
-CheckButton "Enable", an Entry "Field" (initial text "hello"), and a SpinButton
-"Amount" (initial value 1). Run by scripts/test-a11y.sh via glass (which sets DISPLAY).
+CheckButton "Enable", an Entry "Field" (initial text "hello"), a SpinButton
+"Amount" (initial value 1), a DropDown "Company" (Acme/Globex/Initech), and a
+Switch "Active" (off). Run by scripts/test-a11y.sh via glass (which sets DISPLAY).
 
 Uses Gio.ApplicationFlags.NON_UNIQUE so the app skips D-Bus singleton registration
 and presents its window immediately without waiting for portal services to settle."""
@@ -40,6 +41,18 @@ class FixtureApp(Gtk.Application):
         )
         spin.update_property([Gtk.AccessibleProperty.LABEL], ["Amount"])
         box.append(spin)
+        # A GtkDropDown. Its options only commit on row activation (Enter/click), not
+        # via AT-SPI SelectChild, so glass drives it with the keyboard. Starts on
+        # "Acme" (index 0).
+        dropdown = Gtk.DropDown.new_from_strings(["Acme", "Globex", "Initech"])
+        dropdown.update_property([Gtk.AccessibleProperty.LABEL], ["Company"])
+        box.append(dropdown)
+        # A GtkSwitch exposes the AT-SPI Action interface + a boolean CHECKED state;
+        # set_value should toggle it to a target boolean. Starts off.
+        switch = Gtk.Switch()
+        switch.set_halign(Gtk.Align.START)
+        switch.update_property([Gtk.AccessibleProperty.LABEL], ["Active"])
+        box.append(switch)
         win.set_child(box)
         win.present()
 

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -293,6 +293,117 @@ fn find_role(node: &glass_core::AxNode, role: glass_core::AxRole) -> Option<&gla
     node.children.iter().find_map(|c| find_role(c, role))
 }
 
+// Pre-order search for the first node of a given role whose name matches.
+fn find_role_name<'a>(
+    node: &'a glass_core::AxNode,
+    role: glass_core::AxRole,
+    name: &str,
+) -> Option<&'a glass_core::AxNode> {
+    if node.role == role && node.name.as_deref() == Some(name) {
+        return Some(node);
+    }
+    node.children
+        .iter()
+        .find_map(|c| find_role_name(c, role, name))
+}
+
+fn launch_fixture() -> Glass {
+    let fixture = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/a11y_fixture.py"
+    );
+    let mut glass = glass_x11_with_a11y();
+    glass
+        .start(&AppSpec {
+            build: None,
+            run: vec!["python3".into(), fixture.into()],
+            cwd: None,
+            env: vec![
+                ("LIBGL_ALWAYS_SOFTWARE".into(), "1".into()),
+                ("GDK_BACKEND".into(), "x11".into()),
+            ],
+            window_hint: Some(WindowHint {
+                title: Some("Glass A11y Fixture".into()),
+                class: None,
+            }),
+            timeout_ms: 35_000,
+            sandbox: glass_core::SandboxLevel::Off,
+            a11y: true,
+        })
+        .expect("launch");
+    std::thread::sleep(std::time::Duration::from_millis(3_000));
+    glass
+}
+
+#[test]
+#[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
+fn set_value_toggles_switch() {
+    let mut glass = launch_fixture();
+    // The GtkSwitch "Active" starts off; set_value must flip it on via the Action
+    // "toggle" (it exposes no text/Value interface).
+    let tree = glass.a11y_snapshot().expect("snapshot");
+    let sw = find_role_name(&tree.root, glass_core::AxRole::CheckBox, "Active").expect("switch");
+    assert!(!sw.states.checked, "switch starts off");
+    glass.set_value(sw.id, "true").expect("set_value true"); // set_value polls until applied
+
+    let tree2 = glass.a11y_snapshot().expect("snapshot 2");
+    let sw2 =
+        find_role_name(&tree2.root, glass_core::AxRole::CheckBox, "Active").expect("switch 2");
+    assert!(
+        sw2.states.checked,
+        "switch should be on after set_value true"
+    );
+
+    // Idempotent: setting true again is a no-op, and false turns it back off.
+    glass
+        .set_value(sw2.id, "true")
+        .expect("set_value true again");
+    let tree3 = glass.a11y_snapshot().expect("snapshot 3");
+    let sw3 =
+        find_role_name(&tree3.root, glass_core::AxRole::CheckBox, "Active").expect("switch 3");
+    assert!(sw3.states.checked, "still on after idempotent set");
+    glass.set_value(sw3.id, "false").expect("set_value false");
+    let tree4 = glass.a11y_snapshot().expect("snapshot 4");
+    let sw4 =
+        find_role_name(&tree4.root, glass_core::AxRole::CheckBox, "Active").expect("switch 4");
+    assert!(
+        !sw4.states.checked,
+        "switch should be off after set_value false"
+    );
+    glass.stop().expect("stop");
+}
+
+#[test]
+#[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
+fn set_value_selects_dropdown_option() {
+    let mut glass = launch_fixture();
+    // The GtkDropDown starts on "Acme"; set_value must select "Globex" by opening
+    // the popup and picking the option through the Selection interface.
+    let tree = glass.a11y_snapshot().expect("snapshot");
+    let combo = find_role(&tree.root, glass_core::AxRole::ComboBox).expect("combo box");
+    assert_eq!(combo.name.as_deref(), Some("Acme"), "starts on Acme");
+    glass
+        .set_value(combo.id, "Globex")
+        .expect("set_value Globex");
+
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    let tree2 = glass.a11y_snapshot().expect("snapshot 2");
+    let combo2 = find_role(&tree2.root, glass_core::AxRole::ComboBox).expect("combo box 2");
+    assert_eq!(
+        combo2.name.as_deref(),
+        Some("Globex"),
+        "dropdown should now show Globex"
+    );
+
+    // A non-existent option returns a clear error listing the choices.
+    let err = glass.set_value(combo2.id, "Nope").unwrap_err();
+    assert!(
+        matches!(err, glass_core::GlassError::AxOptionNotFound(_, _, _)),
+        "got: {err:?}"
+    );
+    glass.stop().expect("stop");
+}
+
 #[test]
 #[ignore = "needs Xvfb + GTK4 fixture; run via scripts/test-a11y.sh"]
 fn snapshot_without_a11y_flag_errors() {

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -65,6 +65,9 @@ pub enum GlassError {
     #[error("element #{0} is not editable")]
     AxElementNotEditable(u32),
 
+    #[error("element #{0} has no option matching {1:?}; available options: {2}")]
+    AxOptionNotFound(u32, String, String),
+
     #[error("element #{0} changed since the snapshot; re-snapshot")]
     AxElementChanged(u32),
 

--- a/crates/glass-core/src/session.rs
+++ b/crates/glass-core/src/session.rs
@@ -1,6 +1,6 @@
 use crate::accessibility::{
-    element_match, Accessibility, AxContext, AxNodeId, AxRole, AxTarget, AxTree, ElementCondition,
-    ElementInfo, ElementMatch,
+    element_match, Accessibility, AxContext, AxNode, AxNodeId, AxRole, AxTarget, AxTree,
+    ElementCondition, ElementInfo, ElementMatch,
 };
 use crate::baseline::BaselineStore;
 use crate::diff::{diff, diff_perceptual, region_satisfied, BBox, DiffResult, RegionUntil};
@@ -178,6 +178,91 @@ pub struct Glass {
     active: Option<ActiveSession>,
     audit: Option<Box<dyn crate::audit::AuditSink>>,
     shutdown_hook: Option<Box<dyn FnOnce() + Send>>,
+}
+
+/// First node of `role` in pre-order, or `None`.
+fn find_role(node: &AxNode, role: AxRole) -> Option<&AxNode> {
+    if node.role == role {
+        return Some(node);
+    }
+    node.children.iter().find_map(|c| find_role(c, role))
+}
+
+fn rect_center(r: &crate::accessibility::AxRect) -> (i64, i64) {
+    (
+        r.x as i64 + r.width as i64 / 2,
+        r.y as i64 + r.height as i64 / 2,
+    )
+}
+
+/// The ComboBox nearest `target` bounds — disambiguates when several combos exist,
+/// since ids don't survive a re-snapshot. Falls back to the first ComboBox when
+/// bounds are unknown (single-combo apps, the common case).
+fn find_combo_near<'a>(
+    root: &'a AxNode,
+    target: Option<&crate::accessibility::AxRect>,
+) -> Option<&'a AxNode> {
+    let Some(t) = target else {
+        return find_role(root, AxRole::ComboBox);
+    };
+    let (tx, ty) = rect_center(t);
+    fn walk<'a>(node: &'a AxNode, tx: i64, ty: i64, best: &mut Option<(&'a AxNode, i64)>) {
+        if node.role == AxRole::ComboBox {
+            if let Some(b) = &node.bounds {
+                let (cx, cy) = rect_center(b);
+                let d = (cx - tx).pow(2) + (cy - ty).pow(2);
+                if best.is_none_or(|(_, bd)| d < bd) {
+                    *best = Some((node, d));
+                }
+            }
+        }
+        for c in &node.children {
+            walk(c, tx, ty, best);
+        }
+    }
+    let mut best = None;
+    walk(root, tx, ty, &mut best);
+    best.map(|(n, _)| n)
+        .or_else(|| find_role(root, AxRole::ComboBox))
+}
+
+/// The open (expanded) ComboBox, if any — disambiguates the one whose popup is up.
+fn find_expanded_combo(node: &AxNode) -> Option<&AxNode> {
+    if node.role == AxRole::ComboBox && node.states.expanded {
+        return Some(node);
+    }
+    node.children.iter().find_map(find_expanded_combo)
+}
+
+/// A combo's option rows, in order, as `(label, is_selected)`. An open dropdown
+/// realizes its options as `ListItem`s, each carrying its text on a nested label.
+fn collect_combo_options(combo: &AxNode) -> Vec<(String, bool)> {
+    let mut out = Vec::new();
+    collect_list_items(combo, &mut out);
+    out
+}
+
+fn collect_list_items(node: &AxNode, out: &mut Vec<(String, bool)>) {
+    if node.role == AxRole::ListItem {
+        if let Some(label) = first_label(node) {
+            out.push((label, node.states.selected));
+        }
+        return; // an item's text is a leaf; don't descend for nested items
+    }
+    for c in &node.children {
+        collect_list_items(c, out);
+    }
+}
+
+/// First non-empty accessible name in this subtree (an option's text lives on a
+/// nested label, not the `ListItem` itself).
+fn first_label(node: &AxNode) -> Option<String> {
+    if let Some(n) = &node.name {
+        if !n.is_empty() {
+            return Some(n.clone());
+        }
+    }
+    node.children.iter().find_map(first_label)
 }
 
 impl Glass {
@@ -596,6 +681,13 @@ impl Glass {
             };
             (target, ctx)
         };
+        // A dropdown/combo has no committing accessibility write: its `Selection`
+        // interface only moves the popup's *preview* selection, and the model commits
+        // only on row activation (Enter/click). So drive it like a person does —
+        // open it, keyboard-navigate to the option, and press Enter.
+        if target.role == AxRole::ComboBox {
+            return self.set_combo_value(id, &target, text);
+        }
         let s = self.active_mut()?;
         s.accessibility
             .as_mut()
@@ -603,6 +695,77 @@ impl Glass {
             .set_value(&ctx, &target, text)?;
         s.pump();
         Ok(())
+    }
+
+    /// Select an option in a dropdown/combo by label (case-insensitive). Opens the
+    /// popup, arrow-navigates from the current selection to the target, and presses
+    /// Enter to commit — verifying the button label changed (else `AxValueNotApplied`).
+    fn set_combo_value(&mut self, id: AxNodeId, target: &AxTarget, text: &str) -> Result<()> {
+        let want = text.trim();
+        // Already showing it? (the combo's name is its current selection label)
+        if target
+            .name
+            .as_deref()
+            .is_some_and(|n| n.eq_ignore_ascii_case(want))
+        {
+            return Ok(());
+        }
+        // Open the popup (the combo button is in the main window, so this click lands).
+        self.click_element(id)?;
+        self.settle_for_popup();
+        // Re-read the realized options + which one is currently selected. The open
+        // combo is `expanded`; when several combos exist, ids don't survive the
+        // re-snapshot, so fall back to the one nearest the target's bounds.
+        let tree = self.a11y_snapshot()?;
+        let combo = find_expanded_combo(&tree.root)
+            .or_else(|| find_combo_near(&tree.root, target.bounds.as_ref()))
+            .ok_or(GlassError::AxElementChanged(id.0))?;
+        let options = collect_combo_options(combo);
+        if options.is_empty() {
+            return Err(GlassError::AxElementNotEditable(id.0));
+        }
+        let target_idx = options
+            .iter()
+            .position(|(label, _)| label.eq_ignore_ascii_case(want));
+        let Some(target_idx) = target_idx else {
+            // Unknown option — dismiss the popup so the UI is left neutral, then report.
+            let _ = self.key(&KeyEvent::Chord("Escape".to_string()));
+            let choices = options
+                .iter()
+                .map(|(l, _)| l.clone())
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(GlassError::AxOptionNotFound(
+                id.0,
+                text.to_string(),
+                choices,
+            ));
+        };
+        // Opening focuses the current selection; step from it to the target, then Enter.
+        let current_idx = options.iter().position(|(_, sel)| *sel).unwrap_or(0);
+        let delta = target_idx as i32 - current_idx as i32;
+        let chord = if delta >= 0 { "Down" } else { "Up" };
+        for _ in 0..delta.unsigned_abs() {
+            self.key(&KeyEvent::Chord(chord.to_string()))?;
+        }
+        self.key(&KeyEvent::Chord("Return".to_string()))?;
+        self.settle_for_popup();
+        // Verify the model actually committed — the *target* combo (matched by bounds,
+        // now closed so nothing is `expanded`) must read the wanted label.
+        let tree = self.a11y_snapshot()?;
+        let ok = find_combo_near(&tree.root, target.bounds.as_ref())
+            .and_then(|c| c.name.as_deref())
+            .is_some_and(|n| n.eq_ignore_ascii_case(want));
+        if ok {
+            Ok(())
+        } else {
+            Err(GlassError::AxValueNotApplied(id.0))
+        }
+    }
+
+    /// Let a just-opened/closed popup realize in the a11y tree before re-reading.
+    fn settle_for_popup(&self) {
+        std::thread::sleep(std::time::Duration::from_millis(250));
     }
 
     pub fn wait_stable(&mut self, params: &WaitStableParams) -> Result<WaitStableOutcome> {

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -106,7 +106,10 @@ pub struct ClickElementArgs {
 pub struct SetValueArgs {
     /// The element `#id` from `glass_a11y_snapshot`.
     pub id: u32,
-    /// The text/value to set.
+    /// The value to set. For a text field, the text. For a spin/slider, a number.
+    /// For a switch/checkbox/toggle, a boolean (`"true"`/`"false"`/`"on"`/`"off"`/
+    /// `"1"`/`"0"`) — idempotent. For a dropdown/combo box, an option label
+    /// (case-insensitive); glass opens it and picks that option.
     pub text: String,
     /// Optional observe folded into the result: "snapshot" (a fresh a11y tree, also
     /// refreshing the snapshot cache), "settle" (wait for the UI to stop changing,


### PR DESCRIPTION
## What

`glass_set_value` used to return *"element is not editable"* for any non-text widget. It now drives the two interactive-widget classes the GTK4 dogfood hit:

- **Switch / checkbox / toggle / radio** — set a boolean (`"true"`/`"false"`/`"on"`/`"off"`/`"1"`/`"0"`) via the AT-SPI `Action` `"toggle"` + the `Checked`/`Pressed` state. Idempotent (acts only when the state differs), and **verified** by polling until the toolkit applies it.
- **Dropdown / combo box** — set an option by label (case-insensitive): `set_value{id: <combo>, text: "Globex"}`.

## Why the dropdown path is keyboard-driven (not `SelectChild`)

The obvious approach — the AT-SPI `Selection` interface — does **not** work for a `GtkDropDown`. I verified this exhaustively with an **independent `pyatspi` client (no glass)** against a real GTK 4.14 dropdown, using the widget's own `notify::selected` / `notify::selected-item` as oracles:

- `Selection.SelectChild(i)` returns `true` and flips the a11y `Selected` flag, but **never moves the model** — the popup's `GtkListView` is backed by a *separate* preview `GtkSingleSelection`; the real selection commits only in `row_activated` (Enter or a click on the row).
- No AT-SPI action on the rows activates them (they expose only `listitem.scroll-to`).

So `set_value` for a combo is handled at the **session layer** (which has both the a11y reader and key injection) and drives the widget the way a person does: open the popup → arrow-navigate to the target option → press **Enter** → verify the button label changed. A row *click* would be the other activation route, but the option row lives in an override-redirect popover, so it currently trips #84 — keyboard avoids that entirely.

## No silent failures

Both paths **verify** and never report a non-change as success:
- toggle: polls the `Checked`/`Pressed` state after acting; a no-op activation (e.g. a radio can't be un-selected by clicking) → `AxValueNotApplied`.
- combo: re-reads the button label after Enter; if it didn't commit → `AxValueNotApplied`. The target combo is matched by **bounds** so a multi-combo window verifies the right one. An unknown option → `AxOptionNotFound` (new error, lists the available options), after dismissing the popup with Escape.

Known toolkit limit: a GTK4 `GtkCheckButton` exposes *no* AT-SPI action, so it can't be toggled through accessibility — that returns a structured error (drive it with `click_element`).

## Tests
- New integration tests: `set_value_toggles_switch` (on/idempotent/off) and `set_value_selects_dropdown_option` (commit + `AxOptionNotFound`), against a GTK4 fixture extended with a `DropDown` and a `Switch`.
- `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test --workspace`, and the a11y integration suite (`scripts/test-a11y.sh`) all green.
- Pre-merge review pass; fixed two silent-failure risks it caught (toggle-button `Pressed` state + verify; bounds-based combo disambiguation).

Closes #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)