### PR TITLE
feat: window_id to observe a second window without changing the active one (#88)

### DIFF
--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -427,10 +427,10 @@ fn screenshot_includes_open_popover() {
     let combo = find_role(&tree.root, glass_core::AxRole::ComboBox).expect("combo");
     let combo_id = combo.id;
     let combo_bounds = combo.bounds.expect("combo box must report bounds");
-    let before = glass.screenshot(None).expect("before");
+    let before = glass.screenshot(None, None).expect("before");
     glass.click_element(combo_id).expect("open");
     std::thread::sleep(std::time::Duration::from_millis(600));
-    let after = glass.screenshot(None).expect("after");
+    let after = glass.screenshot(None, None).expect("after");
     assert_eq!((before.width, before.height), (after.width, after.height));
 
     let width = after.width as usize;

--- a/crates/glass-core/src/platform.rs
+++ b/crates/glass-core/src/platform.rs
@@ -182,6 +182,15 @@ pub trait Platform {
     /// whole window.
     fn capture_frame(&mut self, region: Option<&Region>) -> Result<Frame>;
 
+    /// Capture a specific window's region from the compositor/root WITHOUT changing
+    /// the active window (unlike `select_window`). `region` (if set, relative to
+    /// `id`'s own geometry) captures only that sub-rectangle; `None` captures the
+    /// whole window. `WindowNotFound` if `id` is not currently one of the app's
+    /// windows. Default: unsupported.
+    fn capture_window(&mut self, _id: WindowId, _region: Option<&Region>) -> Result<Frame> {
+        Err(GlassError::Unsupported("capture_window".into()))
+    }
+
     /// Inject a pointer event (coordinates are window-relative).
     fn send_pointer(&mut self, event: &PointerEvent) -> Result<()>;
 
@@ -299,5 +308,47 @@ mod tests {
             a11y: false,
         };
         assert_eq!(spec.run[0], "./app");
+    }
+
+    /// A bare-minimum `Platform` that overrides nothing — every optional method
+    /// falls through to its default (erroring) implementation.
+    struct MinimalPlatform;
+    impl Platform for MinimalPlatform {
+        fn start_app(&mut self, _spec: &AppSpec) -> Result<WindowGeometry> {
+            Ok(WindowGeometry::default())
+        }
+        fn stop_app(&mut self) -> Result<()> {
+            Ok(())
+        }
+        fn capture_frame(&mut self, _region: Option<&Region>) -> Result<Frame> {
+            Err(GlassError::CaptureFailed("minimal".into()))
+        }
+        fn send_pointer(&mut self, _event: &PointerEvent) -> Result<()> {
+            Ok(())
+        }
+        fn send_key(&mut self, _event: &KeyEvent) -> Result<()> {
+            Ok(())
+        }
+        fn window(&mut self, _op: &WindowOp) -> Result<WindowGeometry> {
+            Ok(WindowGeometry::default())
+        }
+        fn list_windows(&mut self) -> Result<Vec<WindowInfo>> {
+            Ok(vec![])
+        }
+        fn select_window(&mut self, _id: WindowId) -> Result<WindowGeometry> {
+            Err(GlassError::WindowNotFound)
+        }
+        fn drain_logs(&mut self) -> Vec<(Stream, String)> {
+            vec![]
+        }
+    }
+
+    #[test]
+    fn default_capture_window_is_unsupported() {
+        // A backend with no `capture_window` override (the common case today)
+        // reports `Unsupported`, not a silently-wrong capture of the active window.
+        let mut p = MinimalPlatform;
+        let err = p.capture_window(WindowId(1), None).unwrap_err();
+        assert!(matches!(err, GlassError::Unsupported(_)), "{err}");
     }
 }

--- a/crates/glass-core/src/session.rs
+++ b/crates/glass-core/src/session.rs
@@ -795,12 +795,12 @@ impl Glass {
     }
 
     pub fn wait_stable(&mut self, params: &WaitStableParams) -> Result<WaitStableOutcome> {
-        self.require_active()?;
+        let active = self.require_active()?;
         // The active window's cached geometry only bounds a stability_region when
         // watching the active window itself; a specific `window` is validated by
         // the backend against its own geometry instead (see `capture`).
         if params.window.is_none() {
-            let geo = self.require_active()?.geometry.clone();
+            let geo = active.geometry.clone();
             if let Some(r) = &params.stability_region {
                 r.check_fits(geo.width, geo.height)?;
             }
@@ -864,12 +864,12 @@ impl Glass {
     /// current window size — a size change since it was saved returns `SizeMismatch`;
     /// crop to a stable `region` to avoid this.
     pub fn wait_for_region(&mut self, params: &WaitRegionParams) -> Result<WaitRegionOutcome> {
-        self.require_active()?;
+        let active = self.require_active()?;
         // As in `wait_stable`: the active window's cached geometry only bounds
         // `region` when watching the active window; a specific `window` is
         // validated by the backend against its own geometry instead.
         if params.window.is_none() {
-            let geo = self.require_active()?.geometry.clone();
+            let geo = active.geometry.clone();
             if let Some(r) = &params.region {
                 r.check_fits(geo.width, geo.height)?;
             }

--- a/crates/glass-core/src/session.rs
+++ b/crates/glass-core/src/session.rs
@@ -24,6 +24,9 @@ pub struct WaitStableParams {
     /// When set, the settle decision compares only this sub-rectangle of each
     /// frame; the returned frame is still the full window.
     pub stability_region: Option<Region>,
+    /// When set, watch this window's own region instead of the active window's —
+    /// without changing which window is active.
+    pub window: Option<WindowId>,
 }
 
 /// Outcome of a wait-until-stable: the final frame and whether it settled
@@ -77,6 +80,9 @@ pub struct WaitRegionParams {
     pub tolerance: u8,
     pub interval_ms: u64,
     pub timeout_ms: u64,
+    /// When set, watch this window's own region instead of the active window's —
+    /// without changing which window is active.
+    pub window: Option<WindowId>,
 }
 
 /// Outcome of [`Glass::wait_for_region`]. `frame` is the last captured region
@@ -471,12 +477,32 @@ impl Glass {
         Ok(self.require_active()?.geometry.clone())
     }
 
-    pub fn screenshot(&mut self, region: Option<Region>) -> Result<Frame> {
+    /// Capture the active window, or — when `window` is set — a different
+    /// window's region WITHOUT changing which window is active (unlike
+    /// `select_window`). `region` is relative to whichever window is captured.
+    pub fn screenshot(
+        &mut self,
+        region: Option<Region>,
+        window: Option<WindowId>,
+    ) -> Result<Frame> {
+        self.capture(window, region.as_ref())
+    }
+
+    /// Capture `window`'s region (or, when `None`, the active window's), pumping
+    /// logs afterward either way. A specific window's own geometry governs its
+    /// capture — the backend validates `id` and any region against it — so the
+    /// active window's cached `s.geometry` is only consulted for the `None` case.
+    fn capture(&mut self, window: Option<WindowId>, region: Option<&Region>) -> Result<Frame> {
         let s = self.active_mut()?;
-        if let Some(r) = &region {
-            r.check_fits(s.geometry.width, s.geometry.height)?;
-        }
-        let frame = s.platform.capture_frame(region.as_ref())?;
+        let frame = match window {
+            Some(id) => s.platform.capture_window(id, region)?,
+            None => {
+                if let Some(r) = region {
+                    r.check_fits(s.geometry.width, s.geometry.height)?;
+                }
+                s.platform.capture_frame(region)?
+            }
+        };
         s.pump();
         Ok(frame)
     }
@@ -603,7 +629,7 @@ impl Glass {
     /// accessibility elements. Returns the annotated frame and the marks legend.
     /// Caches the snapshot, so `click_element` resolves a mark's id afterward.
     pub fn a11y_marks(&mut self) -> Result<(Frame, Vec<Mark>)> {
-        let frame = self.screenshot(None)?;
+        let frame = self.screenshot(None, None)?;
         let tree = self.a11y_snapshot()?;
         Ok(crate::marks::render(&frame, &tree))
     }
@@ -769,17 +795,22 @@ impl Glass {
     }
 
     pub fn wait_stable(&mut self, params: &WaitStableParams) -> Result<WaitStableOutcome> {
-        let geo = self.require_active()?.geometry.clone();
-        if let Some(r) = &params.stability_region {
-            r.check_fits(geo.width, geo.height)?;
+        self.require_active()?;
+        // The active window's cached geometry only bounds a stability_region when
+        // watching the active window itself; a specific `window` is validated by
+        // the backend against its own geometry instead (see `capture`).
+        if params.window.is_none() {
+            let geo = self.require_active()?.geometry.clone();
+            if let Some(r) = &params.stability_region {
+                r.check_fits(geo.width, geo.height)?;
+            }
         }
         let mut tracker = StabilityTracker::new(params.settle_frames, params.tolerance);
         let region = params.stability_region;
+        let window = params.window;
         let outcome = crate::poll::poll_until(params.interval_ms, params.timeout_ms, || {
-            let s = self.active_mut()?;
             // Poll only the watched region (cheap) when one is set; else the full window.
-            let frame = s.platform.capture_frame(region.as_ref())?;
-            s.pump();
+            let frame = self.capture(window, region.as_ref())?;
             let settled = tracker.observe(frame)?;
             Ok(if settled { Some(()) } else { None })
         })?;
@@ -787,7 +818,7 @@ impl Glass {
         // Return the full window: a fresh capture if we were polling a sub-region
         // (the genuinely-settled state), else the just-observed full frame.
         let frame = match region {
-            Some(_) => self.active_mut()?.platform.capture_frame(None)?,
+            Some(_) => self.capture(window, None)?,
             None => tracker.last().cloned().expect("a frame was just observed"),
         };
         Ok(WaitStableOutcome {
@@ -833,9 +864,15 @@ impl Glass {
     /// current window size — a size change since it was saved returns `SizeMismatch`;
     /// crop to a stable `region` to avoid this.
     pub fn wait_for_region(&mut self, params: &WaitRegionParams) -> Result<WaitRegionOutcome> {
-        let geo = self.require_active()?.geometry.clone();
-        if let Some(r) = &params.region {
-            r.check_fits(geo.width, geo.height)?;
+        self.require_active()?;
+        // As in `wait_stable`: the active window's cached geometry only bounds
+        // `region` when watching the active window; a specific `window` is
+        // validated by the backend against its own geometry instead.
+        if params.window.is_none() {
+            let geo = self.require_active()?.geometry.clone();
+            if let Some(r) = &params.region {
+                r.check_fits(geo.width, geo.height)?;
+            }
         }
         // Reference: a saved baseline (cropped to the region) or the current frame.
         let reference: Frame = match &params.baseline {
@@ -846,25 +883,19 @@ impl Glass {
                     None => base,
                 }
             }
-            None => {
-                let s = self.active_mut()?;
-                let f = s.platform.capture_frame(params.region.as_ref())?;
-                s.pump();
-                f
-            }
+            None => self.capture(params.window, params.region.as_ref())?,
         };
-        let (perceptual, threshold, tolerance, until, region) = (
+        let (perceptual, threshold, tolerance, until, region, window) = (
             params.perceptual,
             params.threshold,
             params.tolerance,
             params.until,
             params.region,
+            params.window,
         );
         let mut last: Option<(f32, Option<BBox>, Frame)> = None;
         let outcome = crate::poll::poll_until(params.interval_ms, params.timeout_ms, || {
-            let s = self.active_mut()?;
-            let current = s.platform.capture_frame(region.as_ref())?;
-            s.pump();
+            let current = self.capture(window, region.as_ref())?;
             let d = if perceptual {
                 diff_perceptual(&reference, &current, threshold)?
             } else {
@@ -1059,6 +1090,10 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
+    /// Every `capture_window(id, region)` call `FakePlatform` recorded, for
+    /// asserting it (not `capture_frame`) was used, and with what arguments.
+    type CaptureWindowLog = Arc<Mutex<Vec<(WindowId, Option<Region>)>>>;
+
     /// Scriptable in-memory backend for testing the session manager.
     #[derive(Default)]
     struct FakePlatform {
@@ -1073,6 +1108,12 @@ mod tests {
         stop_count: Option<Arc<Mutex<u32>>>,
         windows: Vec<WindowInfo>,
         clipboard: String,
+        /// Frames `capture_window` serves, keyed by window id — independent of
+        /// `frames` (the active-window `capture_frame` script).
+        window_frames: std::collections::HashMap<WindowId, Frame>,
+        /// Every `capture_window(id, region)` call, for asserting it (not
+        /// `capture_frame`) was used, and with what arguments.
+        capture_window_log: CaptureWindowLog,
     }
 
     impl FakePlatform {
@@ -1111,6 +1152,14 @@ mod tests {
             self.windows = windows;
             self
         }
+        fn with_window_frame(mut self, id: WindowId, frame: Frame) -> Self {
+            self.window_frames.insert(id, frame);
+            self
+        }
+        fn with_capture_window_log(mut self, log: CaptureWindowLog) -> Self {
+            self.capture_window_log = log;
+            self
+        }
     }
 
     impl Platform for FakePlatform {
@@ -1136,6 +1185,21 @@ mod tests {
                 }
                 None => return Err(GlassError::CaptureFailed("no scripted frames".into())),
             };
+            match region {
+                Some(r) => frame.crop(r),
+                None => Ok(frame),
+            }
+        }
+        fn capture_window(&mut self, id: WindowId, region: Option<&Region>) -> Result<Frame> {
+            self.capture_window_log
+                .lock()
+                .unwrap()
+                .push((id, region.copied()));
+            let frame = self
+                .window_frames
+                .get(&id)
+                .cloned()
+                .ok_or(GlassError::WindowNotFound)?;
             match region {
                 Some(r) => frame.crop(r),
                 None => Ok(frame),
@@ -1330,7 +1394,7 @@ mod tests {
     fn operations_require_an_active_session() {
         let mut g = glass_with(FakePlatform::new(10, 10));
         assert!(matches!(
-            g.screenshot(None).unwrap_err(),
+            g.screenshot(None, None).unwrap_err(),
             GlassError::NoActiveSession
         ));
         assert!(matches!(g.stop().unwrap_err(), GlassError::NoActiveSession));
@@ -1365,7 +1429,7 @@ mod tests {
         let platform = FakePlatform::new(4, 4).with_frames(vec![frame.clone()]);
         let mut g = glass_with(platform);
         g.start(&spec()).unwrap();
-        assert_eq!(g.screenshot(None).unwrap(), frame);
+        assert_eq!(g.screenshot(None, None).unwrap(), frame);
     }
 
     #[test]
@@ -1442,6 +1506,7 @@ mod tests {
                 tolerance: 0,
                 timeout_ms: 1000,
                 stability_region: None,
+                window: None,
             })
             .unwrap();
         assert!(outcome.settled);
@@ -1468,6 +1533,7 @@ mod tests {
                 tolerance: 0,
                 timeout_ms: 0, // give up after the first non-settling capture
                 stability_region: None,
+                window: None,
             })
             .unwrap();
         assert!(!outcome.settled);
@@ -1507,6 +1573,7 @@ mod tests {
                     width: 2,
                     height: 2,
                 }),
+                window: None,
             })
             .unwrap();
         assert!(
@@ -1545,6 +1612,7 @@ mod tests {
                 tolerance: 0,
                 timeout_ms: 1000,
                 stability_region: Some(region),
+                window: None,
             })
             .unwrap();
         assert!(outcome.settled);
@@ -1579,6 +1647,7 @@ mod tests {
                 tolerance: 0,
                 timeout_ms: 1000,
                 stability_region: None,
+                window: None,
             })
             .unwrap();
         assert!(outcome.settled);
@@ -1607,9 +1676,75 @@ mod tests {
                     width: 99,
                     height: 1,
                 }),
+                window: None,
             })
             .unwrap_err();
         assert!(matches!(err, GlassError::InvalidRegion(_)));
+    }
+
+    #[test]
+    fn wait_stable_with_window_id_uses_capture_window_and_leaves_active_untouched() {
+        // Window B is constant, so it settles immediately; watching it must go
+        // through capture_window (never capture_frame), and must not disturb the
+        // active window (A).
+        let a = WindowInfo {
+            id: WindowId(1),
+            title: Some("A".into()),
+            class: None,
+            geometry: WindowGeometry {
+                x: 0,
+                y: 0,
+                width: 4,
+                height: 4,
+            },
+            active: true,
+        };
+        let b = WindowInfo {
+            id: WindowId(2),
+            title: Some("B".into()),
+            class: None,
+            geometry: WindowGeometry {
+                x: 100,
+                y: 0,
+                width: 4,
+                height: 4,
+            },
+            active: false,
+        };
+        let frame_b = Frame::solid(4, 4, [3, 3, 3, 255]);
+        let capture_log = Arc::new(Mutex::new(Vec::new()));
+        let capture_window_log = Arc::new(Mutex::new(Vec::new()));
+        let platform = FakePlatform::new(4, 4)
+            .with_windows(vec![a.clone(), b])
+            .with_capture_log(capture_log.clone())
+            .with_capture_window_log(capture_window_log.clone())
+            .with_window_frame(WindowId(2), frame_b.clone());
+        let mut g = glass_with(platform);
+        g.start(&spec()).unwrap();
+        g.select_window(WindowId(1)).unwrap(); // A is active
+
+        let outcome = g
+            .wait_stable(&WaitStableParams {
+                interval_ms: 0,
+                settle_frames: 2,
+                tolerance: 0,
+                timeout_ms: 1000,
+                stability_region: None,
+                window: Some(WindowId(2)),
+            })
+            .unwrap();
+        assert!(outcome.settled);
+        assert_eq!(outcome.frame, frame_b);
+        assert_eq!(
+            g.geometry().unwrap(),
+            a.geometry,
+            "active window is still A after watching B"
+        );
+        assert!(
+            capture_log.lock().unwrap().is_empty(),
+            "watching a specific window must not go through capture_frame"
+        );
+        assert!(!capture_window_log.lock().unwrap().is_empty());
     }
 
     #[test]
@@ -1619,12 +1754,15 @@ mod tests {
         let mut g = glass_with(platform);
         g.start(&spec()).unwrap();
         let out = g
-            .screenshot(Some(Region {
-                x: 1,
-                y: 1,
-                width: 2,
-                height: 2,
-            }))
+            .screenshot(
+                Some(Region {
+                    x: 1,
+                    y: 1,
+                    width: 2,
+                    height: 2,
+                }),
+                None,
+            )
             .unwrap();
         assert_eq!((out.width, out.height), (2, 2));
     }
@@ -1636,14 +1774,87 @@ mod tests {
         let mut g = glass_with(platform);
         g.start(&spec()).unwrap();
         let err = g
-            .screenshot(Some(Region {
-                x: 0,
-                y: 0,
-                width: 9,
-                height: 1,
-            }))
+            .screenshot(
+                Some(Region {
+                    x: 0,
+                    y: 0,
+                    width: 9,
+                    height: 1,
+                }),
+                None,
+            )
             .unwrap_err();
         assert!(matches!(err, GlassError::InvalidRegion(_)));
+    }
+
+    #[test]
+    fn screenshot_with_window_id_captures_that_window_without_changing_active() {
+        // Two windows: A (active) and B. screenshot(None, Some(B.id)) must return
+        // B's frame — via capture_window, NOT capture_frame — while the session's
+        // active window (still A) is left untouched.
+        let frame_b = Frame::solid(8, 8, [9, 9, 9, 255]);
+        let a = WindowInfo {
+            id: WindowId(1),
+            title: Some("A".into()),
+            class: None,
+            geometry: WindowGeometry {
+                x: 0,
+                y: 0,
+                width: 4,
+                height: 4,
+            },
+            active: true,
+        };
+        let b = WindowInfo {
+            id: WindowId(2),
+            title: Some("B".into()),
+            class: None,
+            geometry: WindowGeometry {
+                x: 100,
+                y: 0,
+                width: 8,
+                height: 8,
+            },
+            active: false,
+        };
+        let capture_log = Arc::new(Mutex::new(Vec::new()));
+        let capture_window_log = Arc::new(Mutex::new(Vec::new()));
+        let platform = FakePlatform::new(4, 4)
+            .with_windows(vec![a.clone(), b.clone()])
+            .with_capture_log(capture_log.clone())
+            .with_capture_window_log(capture_window_log.clone())
+            .with_window_frame(WindowId(2), frame_b.clone());
+        let mut g = glass_with(platform);
+        g.start(&spec()).unwrap();
+        g.select_window(WindowId(1)).unwrap(); // A is active
+
+        let out = g.screenshot(None, Some(WindowId(2))).unwrap();
+        assert_eq!(out, frame_b, "screenshot(window: B) returns B's frame");
+        assert_eq!(
+            g.geometry().unwrap(),
+            a.geometry,
+            "active window is still A after capturing B"
+        );
+        assert!(
+            capture_log.lock().unwrap().is_empty(),
+            "capturing a specific window must not go through capture_frame"
+        );
+        assert_eq!(
+            *capture_window_log.lock().unwrap(),
+            vec![(WindowId(2), None)]
+        );
+    }
+
+    #[test]
+    fn screenshot_with_unknown_window_id_errors() {
+        let platform =
+            FakePlatform::new(4, 4).with_frames(vec![Frame::solid(4, 4, [0, 0, 0, 255])]);
+        let mut g = glass_with(platform);
+        g.start(&spec()).unwrap();
+        assert!(matches!(
+            g.screenshot(None, Some(WindowId(999))).unwrap_err(),
+            GlassError::WindowNotFound
+        ));
     }
 
     #[test]
@@ -2056,6 +2267,7 @@ mod tests {
                 tolerance: 0,
                 interval_ms: 0,
                 timeout_ms: 1000,
+                window: None,
             })
             .unwrap();
         assert!(o.matched);
@@ -2079,6 +2291,7 @@ mod tests {
                 tolerance: 0,
                 interval_ms: 0,
                 timeout_ms: 0,
+                window: None,
             })
             .unwrap();
         assert!(!o.matched);
@@ -2104,10 +2317,82 @@ mod tests {
                 tolerance: 0,
                 interval_ms: 0,
                 timeout_ms: 1000,
+                window: None,
             })
             .unwrap();
         assert!(o.matched);
         assert_eq!(o.changed_pct, 0.0);
+    }
+
+    #[test]
+    fn wait_for_region_with_window_id_uses_capture_window_and_leaves_active_untouched() {
+        // Window B is constant, so it matches its own initial capture immediately;
+        // watching it must go through capture_window (never capture_frame), and
+        // must not disturb the active window (A).
+        let a = WindowInfo {
+            id: WindowId(1),
+            title: Some("A".into()),
+            class: None,
+            geometry: WindowGeometry {
+                x: 0,
+                y: 0,
+                width: 4,
+                height: 4,
+            },
+            active: true,
+        };
+        let b = WindowInfo {
+            id: WindowId(2),
+            title: Some("B".into()),
+            class: None,
+            geometry: WindowGeometry {
+                x: 100,
+                y: 0,
+                width: 4,
+                height: 4,
+            },
+            active: false,
+        };
+        let frame_b = Frame::solid(4, 4, [5, 5, 5, 255]);
+        let capture_log = Arc::new(Mutex::new(Vec::new()));
+        let capture_window_log = Arc::new(Mutex::new(Vec::new()));
+        let platform = FakePlatform::new(4, 4)
+            .with_windows(vec![a.clone(), b])
+            .with_capture_log(capture_log.clone())
+            .with_capture_window_log(capture_window_log.clone())
+            .with_window_frame(WindowId(2), frame_b);
+        let mut g = glass_with(platform);
+        g.start(&spec()).unwrap();
+        g.select_window(WindowId(1)).unwrap(); // A is active
+
+        let o = g
+            .wait_for_region(&WaitRegionParams {
+                baseline: None,
+                region: None,
+                until: RegionUntil::Matches,
+                perceptual: false,
+                threshold: 0.1,
+                tolerance: 0,
+                interval_ms: 0,
+                timeout_ms: 1000,
+                window: Some(WindowId(2)),
+            })
+            .unwrap();
+        assert!(o.matched);
+        assert_eq!(o.changed_pct, 0.0);
+        assert_eq!(
+            g.geometry().unwrap(),
+            a.geometry,
+            "active window is still A after watching B"
+        );
+        assert!(
+            capture_log.lock().unwrap().is_empty(),
+            "watching a specific window must not go through capture_frame"
+        );
+        assert!(
+            capture_window_log.lock().unwrap().len() >= 2,
+            "reference capture + at least one poll"
+        );
     }
 
     #[test]
@@ -2416,7 +2701,7 @@ mod tests {
         g.set_audit_sink(Box::new(sink.clone()));
 
         g.start(&spec()).unwrap();
-        let _ = g.screenshot(None).unwrap(); // read
+        let _ = g.screenshot(None, None).unwrap(); // read
         let tree = g.a11y_snapshot().unwrap(); // read (populates last_ax)
         g.pointer(&PointerEvent::Click {
             x: 1,

--- a/crates/glass-mcp/src/audit.rs
+++ b/crates/glass-mcp/src/audit.rs
@@ -788,7 +788,14 @@ mod tests {
             },
         )
         .unwrap();
-        tools::screenshot(&mut g, &ScreenshotArgs { region: None }).unwrap(); // read — not logged
+        tools::screenshot(
+            &mut g,
+            &ScreenshotArgs {
+                region: None,
+                window_id: None,
+            },
+        )
+        .unwrap(); // read — not logged
         tools::type_text(
             &mut g,
             &TypeArgs {

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -28,6 +28,10 @@ impl From<&RegionArgs> for Region {
 pub struct ScreenshotArgs {
     /// Optional window-relative sub-rectangle to capture; omit for the whole window.
     pub region: Option<RegionArgs>,
+    /// Capture/observe this window (id from `glass_list_windows`) instead of the
+    /// active one, without changing which window subsequent ops target. Omit for
+    /// the active window.
+    pub window_id: Option<u64>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -220,6 +224,10 @@ pub struct WaitStableArgs {
     /// text-only `{settled,width,height}` result with no WebP — cheap when the
     /// next step is a text `glass_diff`. `region` is ignored when false.
     pub include_image: Option<bool>,
+    /// Capture/observe this window (id from `glass_list_windows`) instead of the
+    /// active one, without changing which window subsequent ops target. Omit for
+    /// the active window.
+    pub window_id: Option<u64>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -260,6 +268,10 @@ pub struct WaitForRegionArgs {
     pub timeout_ms: Option<u64>,
     /// On match, also return the watched region as an image (default false).
     pub include_image: Option<bool>,
+    /// Capture/observe this window (id from `glass_list_windows`) instead of the
+    /// active one, without changing which window subsequent ops target. Omit for
+    /// the active window.
+    pub window_id: Option<u64>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -410,6 +422,14 @@ mod tests {
     }
 
     #[test]
+    fn screenshot_args_window_id_defaults_none_and_parses() {
+        let none: ScreenshotArgs = serde_json::from_str("{}").unwrap();
+        assert!(none.window_id.is_none());
+        let some: ScreenshotArgs = serde_json::from_str(r#"{"window_id":42}"#).unwrap();
+        assert_eq!(some.window_id, Some(42));
+    }
+
+    #[test]
     fn diff_args_region_defaults_none_and_parses() {
         let none: DiffArgs = serde_json::from_str(r#"{"name":"m"}"#).unwrap();
         assert!(none.region.is_none());
@@ -434,6 +454,14 @@ mod tests {
                 .unwrap();
         let r = a.stability_region.unwrap();
         assert_eq!((r.x, r.y, r.width, r.height), (0, 0, 2, 2));
+    }
+
+    #[test]
+    fn wait_stable_args_window_id_defaults_none_and_parses() {
+        let none: WaitStableArgs = serde_json::from_str("{}").unwrap();
+        assert!(none.window_id.is_none());
+        let some: WaitStableArgs = serde_json::from_str(r#"{"window_id":7}"#).unwrap();
+        assert_eq!(some.window_id, Some(7));
     }
 
     #[test]
@@ -496,6 +524,14 @@ mod tests {
         assert_eq!(a.baseline.as_deref(), Some("login"));
         assert_eq!(a.mode.as_deref(), Some("exact"));
         assert!(a.region.is_none());
+    }
+
+    #[test]
+    fn wait_for_region_args_window_id_defaults_none_and_parses() {
+        let none: WaitForRegionArgs = serde_json::from_str(r#"{}"#).unwrap();
+        assert!(none.window_id.is_none());
+        let some: WaitForRegionArgs = serde_json::from_str(r#"{"window_id":13}"#).unwrap();
+        assert_eq!(some.window_id, Some(13));
     }
 
     #[test]

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -150,6 +150,7 @@ fn settle_text_only_args() -> WaitStableArgs {
         region: None,
         stability_region: None,
         include_image: Some(false),
+        window_id: None,
     }
 }
 

--- a/crates/glass-mcp/src/tools/batch.rs
+++ b/crates/glass-mcp/src/tools/batch.rs
@@ -19,6 +19,7 @@ fn settle_args(s: &SettleArgs) -> WaitStableArgs {
         region: None,
         stability_region: s.stability_region.clone(),
         include_image: Some(false),
+        window_id: None,
     }
 }
 
@@ -223,7 +224,10 @@ mod tests {
                 then: Some(ThenArgs {
                     settle: None,
                     diff: None,
-                    screenshot: Some(ScreenshotArgs { region: None }),
+                    screenshot: Some(ScreenshotArgs {
+                        region: None,
+                        window_id: None,
+                    }),
                 }),
             },
         )

--- a/crates/glass-mcp/src/tools/capture.rs
+++ b/crates/glass-mcp/src/tools/capture.rs
@@ -16,7 +16,10 @@ fn crop_frame(frame: Frame, region: Option<&RegionArgs>) -> Result<Frame, String
 
 pub fn screenshot(glass: &mut Glass, a: &ScreenshotArgs) -> ToolResult {
     let frame = glass
-        .screenshot(a.region.as_ref().map(|r| r.into()))
+        .screenshot(
+            a.region.as_ref().map(|r| r.into()),
+            a.window_id.map(glass_core::WindowId),
+        )
         .map_err(|e| e.to_string())?;
     let img = frame_to_webp(&frame).map_err(|e| e.to_string())?;
     let mut meta = json!({ "width": frame.width, "height": frame.height });
@@ -38,6 +41,7 @@ pub fn wait_stable(glass: &mut Glass, a: &WaitStableArgs) -> ToolResult {
         tolerance: a.tolerance.unwrap_or(0),
         timeout_ms: a.timeout_ms.unwrap_or(5000),
         stability_region: a.stability_region.as_ref().map(|r| r.into()),
+        window: a.window_id.map(glass_core::WindowId),
     };
     let outcome = glass.wait_stable(&params).map_err(|e| e.to_string())?;
     let settled = outcome.settled;
@@ -198,7 +202,14 @@ mod tests {
     fn screenshot_returns_image_then_meta() {
         let frame = Frame::solid(4, 4, [1, 2, 3, 255]);
         let mut g = started_with(FakePlatform::new(4, 4).with_frames(vec![frame]));
-        let out = screenshot(&mut g, &ScreenshotArgs { region: None }).unwrap();
+        let out = screenshot(
+            &mut g,
+            &ScreenshotArgs {
+                region: None,
+                window_id: None,
+            },
+        )
+        .unwrap();
         assert!(matches!(out.0[0], OutContent::Image(_)));
         match &out.0[1] {
             OutContent::Text(t) => assert!(t.contains("\"width\":4")),
@@ -224,6 +235,7 @@ mod tests {
                 width: 2,
                 height: 2,
             }),
+            window_id: None,
         };
         let out = screenshot(&mut g, &a).unwrap();
         match &out.0[1] {
@@ -256,8 +268,27 @@ mod tests {
                 width: 99,
                 height: 99,
             }),
+            window_id: None,
         };
         assert!(screenshot(&mut g, &a).unwrap_err().contains("region"));
+    }
+
+    #[test]
+    fn screenshot_with_window_id_routes_through_capture_window() {
+        // testutil's FakePlatform doesn't override capture_window, so a window_id
+        // must reach the backend's (Unsupported) capture_window rather than
+        // silently falling back to the scripted capture_frame frame.
+        let mut g = started_with(FakePlatform::new(4, 4).with_frames(vec![Frame::solid(
+            4,
+            4,
+            [0, 0, 0, 255],
+        )]));
+        let a = ScreenshotArgs {
+            region: None,
+            window_id: Some(7),
+        };
+        let err = screenshot(&mut g, &a).unwrap_err();
+        assert!(err.contains("not supported"), "got: {err}");
     }
 
     #[test]
@@ -280,6 +311,7 @@ mod tests {
             }),
             stability_region: None,
             include_image: None,
+            window_id: None,
         };
         let out = wait_stable(&mut g, &a).unwrap();
         if let OutContent::Image(bytes) = &out.0[0] {
@@ -310,8 +342,33 @@ mod tests {
                 height: 1,
             }),
             include_image: None,
+            window_id: None,
         };
         assert!(wait_stable(&mut g, &a).unwrap_err().contains("region"));
+    }
+
+    #[test]
+    fn wait_stable_with_window_id_routes_through_capture_window() {
+        // As above: testutil's FakePlatform has no capture_window override, so a
+        // window_id must reach it (Unsupported) rather than silently polling the
+        // active window's scripted capture_frame frames.
+        let mut g = started_with(FakePlatform::new(4, 4).with_frames(vec![Frame::solid(
+            4,
+            4,
+            [0, 0, 0, 255],
+        )]));
+        let a = WaitStableArgs {
+            interval_ms: Some(1),
+            settle_frames: Some(1),
+            tolerance: None,
+            timeout_ms: Some(200),
+            region: None,
+            stability_region: None,
+            include_image: None,
+            window_id: Some(3),
+        };
+        let err = wait_stable(&mut g, &a).unwrap_err();
+        assert!(err.contains("not supported"), "got: {err}");
     }
 
     #[test]
@@ -502,6 +559,7 @@ mod tests {
             region: None,
             stability_region: None,
             include_image: Some(false),
+            window_id: None,
         };
         let out = wait_stable(&mut g, &a).unwrap();
         assert_eq!(
@@ -594,6 +652,7 @@ mod tests {
             region: None,
             stability_region: None,
             include_image: Some(true),
+            window_id: None,
         };
         let out = wait_stable(&mut g, &a).unwrap();
         // must have [Image, meta-Text, IMAGE_NOTE-Text]
@@ -642,6 +701,7 @@ mod tests {
             region: None,
             stability_region: None,
             include_image: Some(false),
+            window_id: None,
         };
         let out = wait_stable(&mut g, &a).unwrap();
         // no image -> no IMAGE_NOTE
@@ -667,7 +727,14 @@ mod tests {
     fn screenshot_image_note_present_and_meta_unmarked() {
         let frame = Frame::solid(4, 4, [1, 2, 3, 255]);
         let mut g = started_with(FakePlatform::new(4, 4).with_frames(vec![frame]));
-        let out = screenshot(&mut g, &ScreenshotArgs { region: None }).unwrap();
+        let out = screenshot(
+            &mut g,
+            &ScreenshotArgs {
+                region: None,
+                window_id: None,
+            },
+        )
+        .unwrap();
         // must have at least 3 items: Image, meta-Text, note-Text
         assert!(
             out.0.len() >= 3,

--- a/crates/glass-mcp/src/tools/wait.rs
+++ b/crates/glass-mcp/src/tools/wait.rs
@@ -70,6 +70,7 @@ pub fn wait_for_region(glass: &mut Glass, a: &WaitForRegionArgs) -> ToolResult {
         tolerance: a.tolerance.unwrap_or(0),
         interval_ms: a.interval_ms.unwrap_or(100),
         timeout_ms: a.timeout_ms.unwrap_or(10_000),
+        window: a.window_id.map(glass_core::WindowId),
     };
     let o = glass.wait_for_region(&params).map_err(|e| e.to_string())?;
     // `wait_for_region` diffs region-cropped frames, so its bbox originates at
@@ -272,6 +273,7 @@ mod tests {
             interval_ms: Some(0),
             timeout_ms: Some(1000),
             include_image: None,
+            window_id: None,
         }
     }
 
@@ -361,6 +363,18 @@ mod tests {
         assert!(wait_for_region(&mut g, &b)
             .unwrap_err()
             .contains("unknown mode"));
+    }
+
+    #[test]
+    fn region_with_window_id_routes_through_capture_window() {
+        // testutil's FakePlatform has no capture_window override, so a window_id
+        // must reach it (Unsupported) rather than silently watching the active
+        // window's scripted capture_frame frames.
+        let mut g = started_frames(vec![Frame::solid(2, 2, [0, 0, 0, 255])]);
+        let mut a = region_args();
+        a.window_id = Some(9);
+        let err = wait_for_region(&mut g, &a).unwrap_err();
+        assert!(err.contains("not supported"), "got: {err}");
     }
 
     fn started_logs(logs: Vec<(glass_core::Stream, &str)>) -> Glass {

--- a/crates/glass-testapp/tests/integration.rs
+++ b/crates/glass-testapp/tests/integration.rs
@@ -579,6 +579,27 @@ fn capture_window_reads_a_specific_window_without_changing_the_active_one() {
     assert_eq!((region_frame.width, region_frame.height), (20, 20));
     assert_eq!(pixel(&region_frame, 10, 10), [255, 0, 255, 255]);
 
+    // A region that overshoots the TARGET window's own geometry (320x240) is
+    // rejected even though it still lands well inside the shared Xvfb display
+    // (default 1280x800) — otherwise this would silently capture pixels from
+    // outside `extra` (desktop / other windows) instead of erroring, violating
+    // the documented "region relative to id's own geometry" contract.
+    let err = p
+        .capture_window(
+            extra.id,
+            Some(&glass_core::Region {
+                x: 150,
+                y: 110,
+                width: 300,
+                height: 200,
+            }),
+        )
+        .unwrap_err();
+    assert!(
+        matches!(err, glass_core::GlassError::InvalidRegion(_)),
+        "expected InvalidRegion for a region overshooting the target window's own geometry, got {err:?}"
+    );
+
     // An unknown window id is rejected (no silent fallback to the active window).
     assert!(matches!(
         p.capture_window(glass_core::WindowId(0xDEAD_BEEF), None),

--- a/crates/glass-testapp/tests/integration.rs
+++ b/crates/glass-testapp/tests/integration.rs
@@ -518,6 +518,78 @@ fn enumerates_and_selects_multiple_windows() {
 
 #[test]
 #[ignore = "requires an X server; run via scripts/test-x11.sh"]
+fn capture_window_reads_a_specific_window_without_changing_the_active_one() {
+    let xvfb = Xvfb::start();
+    let mut p = X11Platform::connect(Some(&xvfb.display)).unwrap();
+    let spec = AppSpec {
+        build: None,
+        run: vec![TESTAPP.to_string(), "--windows".into(), "2".into()],
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        timeout_ms: 5000,
+        sandbox: glass_core::SandboxLevel::Off,
+        a11y: false,
+    };
+    p.start_app(&spec)
+        .unwrap_or_else(|e| panic!("start_app failed: {e}"));
+    assert!(wait_for_log(&mut p, "READY", 40), "no READY");
+    std::thread::sleep(std::time::Duration::from_millis(200)); // let both windows draw
+
+    let windows = p.list_windows().unwrap();
+    let main = windows
+        .iter()
+        .find(|w| w.title.as_deref() == Some("glass-testapp"))
+        .expect("main window");
+    let extra = windows
+        .iter()
+        .find(|w| w.title.as_deref() == Some("glass-testapp-1"))
+        .expect("extra window");
+    assert_ne!(main.id, extra.id);
+
+    // Active window stays MAIN throughout (never call select_window).
+    let f = p.capture_window(extra.id, None).unwrap();
+    assert_eq!(
+        pixel(&f, 160, 120),
+        [255, 0, 255, 255],
+        "capture_window(extra) should read the extra window's magenta fill"
+    );
+
+    // The active window (never switched) still reads as MAIN's own content via
+    // the normal capture_frame path — proof capture_window did not retarget it.
+    let f = p.capture_frame(None).unwrap();
+    assert_eq!(
+        pixel(&f, 80, 60),
+        [255, 0, 0, 255],
+        "active window is still MAIN after capture_window(extra)"
+    );
+
+    // A region on the target window is honored (window-relative to `extra`).
+    let region_frame = p
+        .capture_window(
+            extra.id,
+            Some(&glass_core::Region {
+                x: 150,
+                y: 110,
+                width: 20,
+                height: 20,
+            }),
+        )
+        .unwrap();
+    assert_eq!((region_frame.width, region_frame.height), (20, 20));
+    assert_eq!(pixel(&region_frame, 10, 10), [255, 0, 255, 255]);
+
+    // An unknown window id is rejected (no silent fallback to the active window).
+    assert!(matches!(
+        p.capture_window(glass_core::WindowId(0xDEAD_BEEF), None),
+        Err(glass_core::GlassError::WindowNotFound)
+    ));
+
+    p.stop_app().unwrap();
+}
+
+#[test]
+#[ignore = "requires an X server; run via scripts/test-x11.sh"]
 fn modified_click_carries_modifier_state() {
     use glass_core::{Modifier, MouseButton, PointerEvent};
     let xvfb = Xvfb::start();

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -953,6 +953,13 @@ impl Platform for X11Platform {
             return Err(GlassError::WindowNotFound);
         }
         let geo = self.geometry_of(target)?;
+        if let Some(r) = region {
+            // `region` must fit the TARGET window's own geometry, not just the
+            // shared Xvfb display — otherwise an over-large region that still
+            // lands inside the display would silently capture pixels outside
+            // this window (desktop / other windows) instead of erroring.
+            r.check_fits(geo.width, geo.height)?;
+        }
         let (sx, sy, w, h) = self.resolve_capture_rect(&geo, region)?;
         self.capture_screen_rect(sx, sy, w, h)
     }

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -626,6 +626,70 @@ impl X11Platform {
             .map_err(|e| GlassError::Backend(format!("flush: {e}")))?;
         Ok(())
     }
+
+    /// Resolve a window-relative `region` (or the whole window) against `geo`
+    /// into an absolute root-coordinate capture rectangle, rejecting a zero-area
+    /// region and one that reaches off the (headless) display before any
+    /// `GetImage` request is issued.
+    fn resolve_capture_rect(
+        &self,
+        geo: &WindowGeometry,
+        region: Option<&Region>,
+    ) -> Result<(i32, i32, u32, u32)> {
+        let (cx, cy, w, h) = match region {
+            Some(r) => (r.x, r.y, r.width, r.height),
+            None => (0, 0, geo.width, geo.height),
+        };
+        if w == 0 || h == 0 {
+            return Err(GlassError::CaptureFailed("window has zero area".into()));
+        }
+        // A window (or region) reaching past the headless display makes GetImage
+        // cover non-viewable area, which X rejects with a bare BadMatch. Convert
+        // that to an actionable error before issuing the request; the root
+        // window's pixel size is the display size.
+        let display = {
+            let root = &self.conn.setup().roots[self.screen_num];
+            (
+                u32::from(root.width_in_pixels),
+                u32::from(root.height_in_pixels),
+            )
+        };
+        crate::coords::check_capture_fits(geo, region, display)?;
+        Ok((geo.x + cx as i32, geo.y + cy as i32, w, h))
+    }
+
+    /// `GetImage` a `w`x`h` rectangle at root-coordinate `(sx,sy)` and decode it to
+    /// an RGBA `Frame`. Always reads from the ROOT drawable (not a specific
+    /// window's own drawable) so overlapping popovers (separate override-redirect
+    /// top-levels) are included in the capture.
+    fn capture_screen_rect(&self, sx: i32, sy: i32, w: u32, h: u32) -> Result<Frame> {
+        let image = self
+            .conn
+            .get_image(
+                ImageFormat::Z_PIXMAP,
+                self.root,
+                sx as i16,
+                sy as i16,
+                w as u16,
+                h as u16,
+                !0u32,
+            )
+            .map_err(|e| GlassError::CaptureFailed(format!("get_image: {e}")))?
+            .reply()
+            .map_err(|e| GlassError::CaptureFailed(format!("get_image reply: {e}")))?;
+        let bpp = self
+            .conn
+            .setup()
+            .pixmap_formats
+            .iter()
+            .find(|f| f.depth == image.depth)
+            .map(|f| f.bits_per_pixel as usize / 8)
+            .ok_or_else(|| {
+                GlassError::CaptureFailed(format!("no pixmap format for depth {}", image.depth))
+            })?;
+        let rgba = crate::pixels::xdata_to_rgba(&image.data, w, h, bpp)?;
+        Frame::new(w, h, rgba)
+    }
 }
 
 fn spawn_reader<R: std::io::Read + Send + 'static>(reader: R, stream: Stream, sink: LogSink) {
@@ -869,56 +933,28 @@ impl Platform for X11Platform {
         // `window_geometry()` itself calls `require_window()`, so it doubles as
         // the "is there an active window" guard — no separate binding needed.
         let geo = self.window_geometry()?;
-        let (cx, cy, w, h) = match region {
-            Some(r) => (r.x, r.y, r.width, r.height),
-            None => (0, 0, geo.width, geo.height),
-        };
-        if w == 0 || h == 0 {
-            return Err(GlassError::CaptureFailed("window has zero area".into()));
-        }
-        // A window (or region) reaching past the headless display makes GetImage
-        // cover non-viewable area, which X rejects with a bare BadMatch. Convert
-        // that to an actionable error before issuing the request; the root
-        // window's pixel size is the display size.
-        let display = {
-            let root = &self.conn.setup().roots[self.screen_num];
-            (
-                u32::from(root.width_in_pixels),
-                u32::from(root.height_in_pixels),
-            )
-        };
-        crate::coords::check_capture_fits(&geo, region, display)?;
+        let (sx, sy, w, h) = self.resolve_capture_rect(&geo, region)?;
         // Capture from ROOT over the window's screen region so overlapping popovers
         // (separate override-redirect top-levels) are included, not just this window's
         // own (possibly-obscured) drawable.
-        let sx = geo.x + cx as i32;
-        let sy = geo.y + cy as i32;
-        let image = self
-            .conn
-            .get_image(
-                ImageFormat::Z_PIXMAP,
-                self.root,
-                sx as i16,
-                sy as i16,
-                w as u16,
-                h as u16,
-                !0u32,
-            )
-            .map_err(|e| GlassError::CaptureFailed(format!("get_image: {e}")))?
-            .reply()
-            .map_err(|e| GlassError::CaptureFailed(format!("get_image reply: {e}")))?;
-        let bpp = self
-            .conn
-            .setup()
-            .pixmap_formats
-            .iter()
-            .find(|f| f.depth == image.depth)
-            .map(|f| f.bits_per_pixel as usize / 8)
-            .ok_or_else(|| {
-                GlassError::CaptureFailed(format!("no pixmap format for depth {}", image.depth))
-            })?;
-        let rgba = crate::pixels::xdata_to_rgba(&image.data, w, h, bpp)?;
-        Frame::new(w, h, rgba)
+        self.capture_screen_rect(sx, sy, w, h)
+    }
+
+    fn capture_window(&mut self, id: WindowId, region: Option<&Region>) -> Result<Frame> {
+        // Mirror select_window's WindowId -> Window mapping/validation, but never
+        // touch `self.window` — this must not retarget the active window.
+        let pids: Vec<u32> = self
+            .child
+            .as_ref()
+            .map(|c| proc_tree_pids(c.id()))
+            .unwrap_or_default();
+        let target = id.0 as Window;
+        if !self.scan_all_windows(&pids)?.contains(&target) {
+            return Err(GlassError::WindowNotFound);
+        }
+        let geo = self.geometry_of(target)?;
+        let (sx, sy, w, h) = self.resolve_capture_rect(&geo, region)?;
+        self.capture_screen_rect(sx, sy, w, h)
     }
 
     fn send_pointer(&mut self, event: &PointerEvent) -> Result<()> {


### PR DESCRIPTION
## What

Adds an optional `window_id` to `glass_screenshot`, `glass_wait_for_region`, and `glass_wait_stable`, so a caller can capture/observe a **specific** window's region **without** changing the persistent active window (or moving focus, which `select_window` does). This composes "act on window A, observe window B" into a single call — needed when an action on one surface produces a short-lived effect on another (e.g. a delete-confirmation toast on the main window triggered from a context menu).

## How

- New `Platform::capture_window(id, region)` seam (default: `Unsupported`; X11 implements it). It resolves the window's screen geometry and captures that region from the root, **without** touching `self.window`/the active window.
- Region is validated against the **target window's own geometry** (not just the display), so an over-large region returns `InvalidRegion` rather than silently reading neighboring pixels.
- Session `screenshot(region, window)` + `WaitRegionParams.window` + `WaitStableParams.window` route through `capture_window` when set (reference frame and every poll); omitted → unchanged active-window behavior. `s.geometry`/active window are never mutated.
- MCP `window_id: Option<u64>` on the three arg structs, threaded through.
- The X11 root-region capture is factored into a shared helper reused by `capture_frame` and `capture_window`.

Other backends return a structured `Unsupported` error (X11-first per the popover-cluster scope; Wayland/macOS/Windows are follow-ups).

## Test

Unit tests (fake platform, two distinct windows) assert `screenshot(None, Some(B))` / windowed `wait_stable` return B's frame **and leave A active**. X11 integration tests capture a specific non-active window (distinct colors) and assert `WindowNotFound` for a bad id and `InvalidRegion` for an over-large region. `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test --workspace`, and `./scripts/test-x11.sh` all green.

Closes #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)