### PR TITLE
feat: click_element auto-routes into an owning popover window (#84)

### DIFF
--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -307,6 +307,16 @@ fn find_role_name<'a>(
         .find_map(|c| find_role_name(c, role, name))
 }
 
+// Pre-order search for the first node with an exact accessible name, any role — an
+// open dropdown's option row is a ListItem, not addressable by role alone the way
+// find_role_name is.
+fn find_node<'a>(node: &'a glass_core::AxNode, name: &str) -> Option<&'a glass_core::AxNode> {
+    if node.name.as_deref() == Some(name) {
+        return Some(node);
+    }
+    node.children.iter().find_map(|c| find_node(c, name))
+}
+
 fn launch_fixture() -> Glass {
     let fixture = concat!(
         env!("CARGO_MANIFEST_DIR"),
@@ -464,6 +474,32 @@ fn screenshot_includes_open_popover() {
         "opening the dropdown should change many captured pixels in the region below the \
          combo button, where the popover's option rows draw (popover composited); \
          changed_below_combo={changed_below_combo}"
+    );
+    glass.stop().expect("stop");
+}
+
+// Regression (#84): the open GtkDropDown's option rows render in a separate
+// override-redirect popover window, not the app's active window — click_element must
+// auto-route the click into that popover (see glass_core::session's owning_popover /
+// menu_container_bounds) rather than clicking the active window's coordinates and
+// silently missing. Exercises the full click_element -> commit path end to end.
+#[test]
+#[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
+fn click_element_commits_dropdown_option() {
+    let mut glass = launch_fixture();
+    let tree = glass.a11y_snapshot().expect("snapshot");
+    let combo = find_role(&tree.root, glass_core::AxRole::ComboBox).expect("combo");
+    glass.click_element(combo.id).expect("open");
+    std::thread::sleep(std::time::Duration::from_millis(600));
+    let t2 = glass.a11y_snapshot().expect("snap2");
+    let globex = find_node(&t2.root, "Globex").expect("globex");
+    glass.click_element(globex.id).expect("click option");
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    let t3 = glass.a11y_snapshot().expect("snap3");
+    assert_eq!(
+        find_role(&t3.root, glass_core::AxRole::ComboBox).and_then(|c| c.name.as_deref()),
+        Some("Globex"),
+        "clicking the popover's option row should commit the dropdown selection"
     );
     glass.stop().expect("stop");
 }

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -74,6 +74,9 @@ pub enum GlassError {
     #[error("set_value on element #{0} reported success but the value did not change (read-only a11y projection — use keystrokes)")]
     AxValueNotApplied(u32),
 
+    #[error("element #{0} is inside a popover glass could not map to a window; select_window it and click by coordinate")]
+    AxElementInUnmappedPopover(u32),
+
     #[error("accessibility unavailable: {0}")]
     AccessibilityUnavailable(String),
 
@@ -156,6 +159,10 @@ mod tests {
         assert_eq!(
             GlassError::AxElementChanged(2).to_string(),
             "element #2 changed since the snapshot; re-snapshot"
+        );
+        assert_eq!(
+            GlassError::AxElementInUnmappedPopover(9).to_string(),
+            "element #9 is inside a popover glass could not map to a window; select_window it and click by coordinate"
         );
     }
 

--- a/crates/glass-core/src/session.rs
+++ b/crates/glass-core/src/session.rs
@@ -271,6 +271,70 @@ fn first_label(node: &AxNode) -> Option<String> {
     node.children.iter().find_map(first_label)
 }
 
+/// The non-active window (from `windows`) whose screen rect contains the projected
+/// screen center of `bounds` (an element's window-relative bounds within the active
+/// window). Recovers the case where an element's a11y bounds are reported relative to
+/// the active window but the element actually renders in a separate popover window
+/// (e.g. an open dropdown's option list) — headless a11y backends don't always report
+/// bounds relative to the popover's own origin. `None` when no non-active window
+/// contains the point; the smallest-area match wins when several do (an outer window
+/// fully behind/around a smaller popover shouldn't shadow it).
+fn owning_popover(
+    bounds: crate::accessibility::AxRect,
+    active: &WindowGeometry,
+    windows: &[WindowInfo],
+) -> Option<WindowId> {
+    let screen_x = active.x + bounds.x + bounds.width as i32 / 2;
+    let screen_y = active.y + bounds.y + bounds.height as i32 / 2;
+    windows
+        .iter()
+        .filter(|w| !w.active)
+        .filter(|w| {
+            let g = &w.geometry;
+            screen_x >= g.x
+                && screen_x < g.x + g.width as i32
+                && screen_y >= g.y
+                && screen_y < g.y + g.height as i32
+        })
+        .min_by_key(|w| w.geometry.width as u64 * w.geometry.height as u64)
+        .map(|w| w.id)
+}
+
+/// Path of nodes from `root` to `target` (inclusive of both ends), in that order —
+/// `None` if `target` isn't in this tree.
+fn ancestor_path(root: &AxNode, target: AxNodeId) -> Option<Vec<&AxNode>> {
+    if root.id == target {
+        return Some(vec![root]);
+    }
+    for child in &root.children {
+        if let Some(mut path) = ancestor_path(child, target) {
+            path.insert(0, root);
+            return Some(path);
+        }
+    }
+    None
+}
+
+/// The bounds of the ancestor of `target` (searching from `target` upward) whose size
+/// matches `popover`'s window size within 16px tolerance on each dimension — the
+/// element's realized menu/list container, e.g. a dropdown popup's `List`. Its origin
+/// recovers the popover-relative offset of elements inside it, since their own reported
+/// bounds are skewed relative to the *active* window rather than the popover. `None`
+/// if no ancestor's bounds match (or `target` isn't in `root`'s tree).
+fn menu_container_bounds(
+    root: &AxNode,
+    target: AxNodeId,
+    popover: &WindowGeometry,
+) -> Option<crate::accessibility::AxRect> {
+    let path = ancestor_path(root, target)?;
+    path.iter().rev().find_map(|node| {
+        node.bounds.filter(|b| {
+            (b.width as i32 - popover.width as i32).abs() <= 16
+                && (b.height as i32 - popover.height as i32).abs() <= 16
+        })
+    })
+}
+
 impl Glass {
     pub fn new(
         factory: PlatformFactory,
@@ -649,15 +713,48 @@ impl Glass {
     }
 
     fn click_element_inner(&mut self, id: AxNodeId) -> Result<()> {
-        let (x, y) = {
+        let (bounds, active_geo) = {
             let s = self.require_active()?;
             let tree = s.last_ax.as_ref().ok_or(GlassError::NoAxSnapshot)?;
             let node = tree.find(id).ok_or(GlassError::AxElementNotFound(id.0))?;
             let bounds = node.bounds.ok_or(GlassError::AxElementNotClickable(id.0))?;
-            bounds
-                .clamped_center(s.geometry.width, s.geometry.height)
-                .ok_or(GlassError::AxElementNotClickable(id.0))?
+            (bounds, s.geometry.clone())
         };
+        // The element's a11y bounds are reported relative to the active window, but it
+        // may actually render in a separate popover window (e.g. an open dropdown's
+        // option list) whose own origin they don't reflect. Detect that and route the
+        // click into the popover instead of silently missing.
+        let windows = self.list_windows()?;
+        if let Some(popover_id) = owning_popover(bounds, &active_geo, &windows) {
+            let popover_geo = windows
+                .iter()
+                .find(|w| w.id == popover_id)
+                .map(|w| w.geometry.clone())
+                .ok_or(GlassError::WindowNotFound)?;
+            let container = {
+                let s = self.require_active()?;
+                let tree = s.last_ax.as_ref().ok_or(GlassError::NoAxSnapshot)?;
+                menu_container_bounds(&tree.root, id, &popover_geo)
+            }
+            .ok_or(GlassError::AxElementInUnmappedPopover(id.0))?;
+            let prev = windows.iter().find(|w| w.active).map(|w| w.id);
+            self.select_window(popover_id)?;
+            let result = self.pointer_inner(&PointerEvent::Click {
+                x: bounds.x - container.x,
+                y: bounds.y - container.y,
+                button: MouseButton::Left,
+                count: 1,
+                modifiers: vec![],
+            });
+            // Best-effort restore: the click's own result (ok or err) still wins.
+            if let Some(prev) = prev {
+                let _ = self.select_window(prev);
+            }
+            return result;
+        }
+        let (x, y) = bounds
+            .clamped_center(active_geo.width, active_geo.height)
+            .ok_or(GlassError::AxElementNotClickable(id.0))?;
         self.pointer_inner(&PointerEvent::Click {
             x,
             y,
@@ -1114,6 +1211,9 @@ mod tests {
         /// Every `capture_window(id, region)` call, for asserting it (not
         /// `capture_frame`) was used, and with what arguments.
         capture_window_log: CaptureWindowLog,
+        /// Every `select_window(id)` call, in order — for asserting popover routing
+        /// selects the popover then restores the previously-active window.
+        select_log: Arc<Mutex<Vec<WindowId>>>,
     }
 
     impl FakePlatform {
@@ -1138,6 +1238,10 @@ mod tests {
         }
         fn with_click_log(mut self, log: Arc<Mutex<Vec<(i32, i32)>>>) -> Self {
             self.click_log = log;
+            self
+        }
+        fn with_select_log(mut self, log: Arc<Mutex<Vec<WindowId>>>) -> Self {
+            self.select_log = log;
             self
         }
         fn counting_stops(mut self, c: Arc<Mutex<u32>>) -> Self {
@@ -1247,6 +1351,7 @@ mod tests {
             }
         }
         fn select_window(&mut self, id: WindowId) -> Result<WindowGeometry> {
+            self.select_log.lock().unwrap().push(id);
             if self.windows.is_empty() {
                 return if id == WindowId(0) {
                     Ok(self.geometry.clone())
@@ -1340,6 +1445,195 @@ mod tests {
             ..Default::default()
         };
         t
+    }
+
+    fn window_info(id: u64, geometry: WindowGeometry, active: bool) -> WindowInfo {
+        WindowInfo {
+            id: WindowId(id),
+            title: None,
+            class: None,
+            geometry,
+            active,
+        }
+    }
+
+    #[test]
+    fn owning_popover_none_when_element_only_in_active_window() {
+        let active = WindowGeometry {
+            x: 0,
+            y: 0,
+            width: 340,
+            height: 300,
+        };
+        let bounds = AxRect {
+            x: 50,
+            y: 50,
+            width: 20,
+            height: 20,
+        };
+        let windows = vec![window_info(1, active.clone(), true)];
+        assert_eq!(owning_popover(bounds, &active, &windows), None);
+    }
+
+    #[test]
+    fn owning_popover_finds_containing_non_active_window() {
+        // Validated numbers from the real Xvfb spike: an open GtkDropDown's popover
+        // window at (-3,220,326,135); the option row "Globex" has a11y bounds (20,248).
+        let active = WindowGeometry {
+            x: 0,
+            y: 0,
+            width: 340,
+            height: 300,
+        };
+        let bounds = AxRect {
+            x: 20,
+            y: 248,
+            width: 80,
+            height: 27,
+        };
+        let popover_geo = WindowGeometry {
+            x: -3,
+            y: 220,
+            width: 326,
+            height: 135,
+        };
+        let windows = vec![
+            window_info(1, active.clone(), true),
+            window_info(2, popover_geo, false),
+        ];
+        assert_eq!(owning_popover(bounds, &active, &windows), Some(WindowId(2)));
+    }
+
+    #[test]
+    fn owning_popover_picks_smallest_area_when_multiple_contain_the_point() {
+        let active = WindowGeometry {
+            x: 0,
+            y: 0,
+            width: 340,
+            height: 300,
+        };
+        // Zero-size bounds project exactly to (50,50) — both candidate windows below
+        // contain that point.
+        let bounds = AxRect {
+            x: 50,
+            y: 50,
+            width: 0,
+            height: 0,
+        };
+        let big = WindowGeometry {
+            x: 0,
+            y: 0,
+            width: 200,
+            height: 200,
+        };
+        let small = WindowGeometry {
+            x: 40,
+            y: 40,
+            width: 20,
+            height: 20,
+        };
+        let windows = vec![
+            window_info(1, active.clone(), true),
+            window_info(2, big, false),
+            window_info(3, small, false),
+        ];
+        assert_eq!(
+            owning_popover(bounds, &active, &windows),
+            Some(WindowId(3)),
+            "the smallest containing window should win"
+        );
+    }
+
+    fn ax_node(id: u32, role: AxRole, bounds: Option<AxRect>, children: Vec<AxNode>) -> AxNode {
+        AxNode {
+            id: AxNodeId(id),
+            role,
+            raw_role: format!("{role:?}"),
+            name: None,
+            value: None,
+            states: AxStates::default(),
+            bounds,
+            children,
+        }
+    }
+
+    #[test]
+    fn menu_container_bounds_finds_the_list_sized_ancestor() {
+        // Target nested under a `List` node sized like the popover window.
+        let list_bounds = AxRect {
+            x: 0,
+            y: 194,
+            width: 326,
+            height: 129,
+        };
+        let target = ax_node(
+            2,
+            AxRole::ListItem,
+            Some(AxRect {
+                x: 20,
+                y: 248,
+                width: 80,
+                height: 27,
+            }),
+            vec![],
+        );
+        let list = ax_node(1, AxRole::List, Some(list_bounds), vec![target]);
+        let root = ax_node(
+            0,
+            AxRole::Window,
+            Some(AxRect {
+                x: 0,
+                y: 0,
+                width: 340,
+                height: 300,
+            }),
+            vec![list],
+        );
+        let popover = WindowGeometry {
+            x: -3,
+            y: 220,
+            width: 326,
+            height: 135,
+        };
+        assert_eq!(
+            menu_container_bounds(&root, AxNodeId(2), &popover),
+            Some(list_bounds)
+        );
+    }
+
+    #[test]
+    fn menu_container_bounds_none_without_a_matching_ancestor() {
+        // No `List` container this time — target hangs directly off root, and root's
+        // own bounds don't match the popover's size.
+        let target = ax_node(
+            1,
+            AxRole::ListItem,
+            Some(AxRect {
+                x: 20,
+                y: 248,
+                width: 80,
+                height: 27,
+            }),
+            vec![],
+        );
+        let root = ax_node(
+            0,
+            AxRole::Window,
+            Some(AxRect {
+                x: 0,
+                y: 0,
+                width: 340,
+                height: 300,
+            }),
+            vec![target],
+        );
+        let popover = WindowGeometry {
+            x: -3,
+            y: 220,
+            width: 326,
+            height: 135,
+        };
+        assert_eq!(menu_container_bounds(&root, AxNodeId(1), &popover), None);
     }
 
     fn glass_with(platform: FakePlatform) -> Glass {
@@ -2173,6 +2467,224 @@ mod tests {
         assert!(matches!(
             g.click_element(AxNodeId(2)).unwrap_err(),
             GlassError::AxElementNotClickable(2)
+        ));
+    }
+
+    /// Builds the tree used by the popover-routing tests: root Window > `List`
+    /// (sized like the popover window) > `ListItem` "Globex" (the click target),
+    /// with the validated real-Xvfb numbers (see `owning_popover`/
+    /// `menu_container_bounds` unit tests above).
+    fn fake_tree_with_popover_option() -> AxTree {
+        let globex = AxNode {
+            id: AxNodeId(0),
+            role: AxRole::ListItem,
+            raw_role: "list item".into(),
+            name: Some("Globex".into()),
+            value: None,
+            states: AxStates::default(),
+            bounds: Some(AxRect {
+                x: 20,
+                y: 248,
+                width: 80,
+                height: 27,
+            }),
+            children: vec![],
+        };
+        let list = AxNode {
+            id: AxNodeId(0),
+            role: AxRole::List,
+            raw_role: "list".into(),
+            name: None,
+            value: None,
+            states: AxStates::default(),
+            bounds: Some(AxRect {
+                x: 0,
+                y: 194,
+                width: 326,
+                height: 129,
+            }),
+            children: vec![globex],
+        };
+        let root = AxNode {
+            id: AxNodeId(0),
+            role: AxRole::Window,
+            raw_role: "frame".into(),
+            name: Some("Win".into()),
+            value: None,
+            states: AxStates::default(),
+            bounds: Some(AxRect {
+                x: 0,
+                y: 0,
+                width: 340,
+                height: 300,
+            }),
+            children: vec![list],
+        };
+        AxTree { root, count: 0 }
+    }
+
+    #[test]
+    fn click_element_without_popover_clicks_clamped_center_and_never_selects_a_window() {
+        let clicks = Arc::new(Mutex::new(Vec::new()));
+        let select_log = Arc::new(Mutex::new(Vec::new()));
+        let a = window_info(
+            1,
+            WindowGeometry {
+                x: 0,
+                y: 0,
+                width: 100,
+                height: 100,
+            },
+            true,
+        );
+        // A non-active window that does NOT contain the Button's projected center —
+        // present so `list_windows` isn't trivially empty, still no routing occurs.
+        let b = window_info(
+            2,
+            WindowGeometry {
+                x: 1000,
+                y: 1000,
+                width: 50,
+                height: 50,
+            },
+            false,
+        );
+        let platform = FakePlatform::new(100, 100)
+            .with_windows(vec![a, b])
+            .with_click_log(clicks.clone())
+            .with_select_log(select_log.clone());
+        let mut g = glass_with_a11y(platform, fake_tree());
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot().unwrap();
+        g.click_element(AxNodeId(1)).unwrap(); // the Button at (10,10 20x20)
+        assert_eq!(
+            clicks.lock().unwrap().last().copied(),
+            Some((20, 20)),
+            "unrouted click still lands on the element's own clamped center"
+        );
+        assert!(
+            select_log.lock().unwrap().is_empty(),
+            "no popover routing means no select_window call"
+        );
+    }
+
+    #[test]
+    fn click_element_routes_into_owning_popover_and_restores_active_window() {
+        let clicks = Arc::new(Mutex::new(Vec::new()));
+        let select_log = Arc::new(Mutex::new(Vec::new()));
+        let a = window_info(
+            1,
+            WindowGeometry {
+                x: 0,
+                y: 0,
+                width: 340,
+                height: 300,
+            },
+            true,
+        );
+        let b = window_info(
+            2,
+            WindowGeometry {
+                x: -3,
+                y: 220,
+                width: 326,
+                height: 135,
+            },
+            false,
+        );
+        let platform = FakePlatform::new(340, 300)
+            .with_windows(vec![a, b])
+            .with_click_log(clicks.clone())
+            .with_select_log(select_log.clone());
+        let mut g = glass_with_a11y(platform, fake_tree_with_popover_option());
+        g.start(&spec()).unwrap();
+        let tree = g.a11y_snapshot().unwrap();
+        // assign_ids in pre-order: root=0, List=1, Globex(ListItem)=2.
+        let globex_id = tree.root.children[0].children[0].id;
+        assert_eq!(globex_id, AxNodeId(2));
+
+        g.click_element(globex_id).unwrap();
+
+        assert_eq!(
+            clicks.lock().unwrap().last().copied(),
+            Some((20, 54)),
+            "click lands at (Globex.bounds - List.bounds), per the validated algorithm"
+        );
+        assert_eq!(
+            *select_log.lock().unwrap(),
+            vec![WindowId(2), WindowId(1)],
+            "selects the popover to click, then restores the previously-active window"
+        );
+        assert_eq!(
+            g.geometry().unwrap().width,
+            340,
+            "active window geometry is restored after the routed click"
+        );
+    }
+
+    #[test]
+    fn click_element_in_popover_without_a_mappable_container_errors() {
+        // Same popover-owning geometry, but the target has no List-sized ancestor to
+        // recover a container origin from — must error, not silently mis-click.
+        let globex = AxNode {
+            id: AxNodeId(0),
+            role: AxRole::ListItem,
+            raw_role: "list item".into(),
+            name: Some("Globex".into()),
+            value: None,
+            states: AxStates::default(),
+            bounds: Some(AxRect {
+                x: 20,
+                y: 248,
+                width: 80,
+                height: 27,
+            }),
+            children: vec![],
+        };
+        let root = AxNode {
+            id: AxNodeId(0),
+            role: AxRole::Window,
+            raw_role: "frame".into(),
+            name: Some("Win".into()),
+            value: None,
+            states: AxStates::default(),
+            bounds: Some(AxRect {
+                x: 0,
+                y: 0,
+                width: 340,
+                height: 300,
+            }),
+            children: vec![globex],
+        };
+        let tree = AxTree { root, count: 0 };
+        let a = window_info(
+            1,
+            WindowGeometry {
+                x: 0,
+                y: 0,
+                width: 340,
+                height: 300,
+            },
+            true,
+        );
+        let b = window_info(
+            2,
+            WindowGeometry {
+                x: -3,
+                y: 220,
+                width: 326,
+                height: 135,
+            },
+            false,
+        );
+        let platform = FakePlatform::new(340, 300).with_windows(vec![a, b]);
+        let mut g = glass_with_a11y(platform, tree);
+        g.start(&spec()).unwrap();
+        let snapshot = g.a11y_snapshot().unwrap();
+        let globex_id = snapshot.root.children[0].id;
+        assert!(matches!(
+            g.click_element(globex_id).unwrap_err(),
+            GlassError::AxElementInUnmappedPopover(id) if id == globex_id.0
         ));
     }
 

--- a/crates/glass-core/src/session.rs
+++ b/crates/glass-core/src/session.rs
@@ -315,24 +315,35 @@ fn ancestor_path(root: &AxNode, target: AxNodeId) -> Option<Vec<&AxNode>> {
     None
 }
 
-/// The bounds of the ancestor of `target` (searching from `target` upward) whose size
-/// matches `popover`'s window size within 16px tolerance on each dimension — the
-/// element's realized menu/list container, e.g. a dropdown popup's `List`. Its origin
-/// recovers the popover-relative offset of elements inside it, since their own reported
-/// bounds are skewed relative to the *active* window rather than the popover. `None`
-/// if no ancestor's bounds match (or `target` isn't in `root`'s tree).
+/// The bounds of the ancestor of `target` whose size most closely matches `popover`'s
+/// window size (within 16px tolerance on each dimension) — the element's realized
+/// menu/list container, e.g. a dropdown popup's `List`. Its origin recovers the
+/// popover-relative offset of elements inside it, since their own reported bounds are
+/// skewed relative to the *active* window rather than the popover. `None` if no
+/// ancestor's bounds match (or `target` isn't in `root`'s tree).
+///
+/// A real widget tree nests the menu container inside several layout wrapper groups
+/// (padding/scroll containers) whose bounds are *also* within tolerance of the
+/// popover's size — so the nearest matching ancestor to `target` is often one of those
+/// wrappers, not the container itself. Scoring every matching ancestor by closeness to
+/// the popover's exact size (not proximity to `target`) picks the real container: it
+/// tracks the popover's size most tightly, while wrappers trimmed by padding/scrollbars
+/// drift further from it.
 fn menu_container_bounds(
     root: &AxNode,
     target: AxNodeId,
     popover: &WindowGeometry,
 ) -> Option<crate::accessibility::AxRect> {
     let path = ancestor_path(root, target)?;
-    path.iter().rev().find_map(|node| {
-        node.bounds.filter(|b| {
-            (b.width as i32 - popover.width as i32).abs() <= 16
-                && (b.height as i32 - popover.height as i32).abs() <= 16
+    path.iter()
+        .filter_map(|node| {
+            let b = node.bounds?;
+            let dw = (b.width as i32 - popover.width as i32).abs();
+            let dh = (b.height as i32 - popover.height as i32).abs();
+            (dw <= 16 && dh <= 16).then_some((b, dw + dh))
         })
-    })
+        .min_by_key(|&(_, score)| score)
+        .map(|(b, _)| b)
 }
 
 impl Glass {
@@ -1634,6 +1645,100 @@ mod tests {
             height: 135,
         };
         assert_eq!(menu_container_bounds(&root, AxNodeId(1), &popover), None);
+    }
+
+    #[test]
+    fn menu_container_bounds_prefers_closest_size_over_nearest_ancestor() {
+        // Reproduces the real GTK4 widget tree (captured from the Xvfb spike): several
+        // layout wrapper `Group`s sit between the option row and the actual menu `List`,
+        // and their bounds *also* fall within the 16px tolerance of the popover's size —
+        // so picking the ancestor NEAREST `target` returns a wrapper Group, not the real
+        // container. The real container (List, id 2) must win because its size is
+        // closest to the popover's, even though it's farther up the chain.
+        let popover = WindowGeometry {
+            x: -3,
+            y: 220,
+            width: 326,
+            height: 135,
+        };
+        let container_bounds = AxRect {
+            x: 0,
+            y: 194,
+            width: 326,
+            height: 129,
+        };
+        let target = ax_node(
+            6,
+            AxRole::ListItem,
+            Some(AxRect {
+                x: 20,
+                y: 248,
+                width: 302,
+                height: 35,
+            }),
+            vec![],
+        );
+        let inner_list = ax_node(
+            5,
+            AxRole::List,
+            Some(AxRect {
+                x: 12,
+                y: 205,
+                width: 302,
+                height: 105,
+            }),
+            vec![target],
+        );
+        let group3 = ax_node(
+            4,
+            AxRole::Group,
+            Some(AxRect {
+                x: 4,
+                y: 197,
+                width: 318,
+                height: 121,
+            }),
+            vec![inner_list],
+        );
+        let group2 = ax_node(
+            3,
+            AxRole::Group,
+            Some(AxRect {
+                x: 4,
+                y: 197,
+                width: 318,
+                height: 121,
+            }),
+            vec![group3],
+        );
+        let group1 = ax_node(
+            2,
+            AxRole::Group,
+            Some(AxRect {
+                x: 4,
+                y: 197,
+                width: 320,
+                height: 123,
+            }),
+            vec![group2],
+        );
+        let container = ax_node(1, AxRole::List, Some(container_bounds), vec![group1]);
+        let root = ax_node(
+            0,
+            AxRole::ComboBox,
+            Some(AxRect {
+                x: 0,
+                y: 188,
+                width: 320,
+                height: 34,
+            }),
+            vec![container],
+        );
+        assert_eq!(
+            menu_container_bounds(&root, AxNodeId(6), &popover),
+            Some(container_bounds),
+            "the real container (closest in size to the popover) must win over nearer wrapper groups"
+        );
     }
 
     fn glass_with(platform: FakePlatform) -> Glass {

--- a/crates/glass-core/src/session.rs
+++ b/crates/glass-core/src/session.rs
@@ -278,7 +278,20 @@ fn first_label(node: &AxNode) -> Option<String> {
 /// (e.g. an open dropdown's option list) — headless a11y backends don't always report
 /// bounds relative to the popover's own origin. `None` when no non-active window
 /// contains the point; the smallest-area match wins when several do (an outer window
-/// fully behind/around a smaller popover shouldn't shadow it).
+/// fully behind/around a smaller popover shouldn't shadow it). If several windows tie
+/// on area, the first one in `windows`' order wins (`min_by_key` keeps the first
+/// minimum) — i.e. whatever order the platform's `list_windows` enumerated them in;
+/// this doesn't matter in practice since same-area overlapping windows aren't a shape
+/// any backend produces.
+///
+/// Known best-effort limitation: this detection is purely geometric — it has no way to
+/// tell "the app's own popover" apart from an unrelated second top-level window of the
+/// same app that happens to overlap the element's projected point. The
+/// `menu_container_bounds` size-matching gate below guards against that residual case:
+/// a genuinely non-popover window is very unlikely to *also* have an ancestor whose size
+/// coincidentally matches its own within tolerance, so the common outcome of a
+/// mis-detection is a clear `AxElementInUnmappedPopover` error, not a silent click into
+/// the wrong window.
 fn owning_popover(
     bounds: crate::accessibility::AxRect,
     active: &WindowGeometry,
@@ -328,7 +341,10 @@ fn ancestor_path(root: &AxNode, target: AxNodeId) -> Option<Vec<&AxNode>> {
 /// wrappers, not the container itself. Scoring every matching ancestor by closeness to
 /// the popover's exact size (not proximity to `target`) picks the real container: it
 /// tracks the popover's size most tightly, while wrappers trimmed by padding/scrollbars
-/// drift further from it.
+/// drift further from it. Ties (equal score) break toward the shallower ancestor — the
+/// one closer to `root` — since `ancestor_path` walks root-to-target and `min_by_key`
+/// keeps the first minimum; in practice two ancestors matching to the exact same pixel
+/// is vanishingly rare (padding/scrollbar trims almost always differ by at least 1px).
 fn menu_container_bounds(
     root: &AxNode,
     target: AxNodeId,
@@ -735,7 +751,14 @@ impl Glass {
         // may actually render in a separate popover window (e.g. an open dropdown's
         // option list) whose own origin they don't reflect. Detect that and route the
         // click into the popover instead of silently missing.
-        let windows = self.list_windows()?;
+        //
+        // This enumeration is a best-effort popover probe, not something an ordinary
+        // click depends on: a backend where `list_windows` is heavier or flaky must
+        // never turn a normal click into a failure just because the probe failed. An
+        // `Err` here degrades to an empty list, which makes `owning_popover` return
+        // `None` below and falls straight through to the unchanged `clamped_center`
+        // click path.
+        let windows = self.list_windows().unwrap_or_default();
         if let Some(popover_id) = owning_popover(bounds, &active_geo, &windows) {
             let popover_geo = windows
                 .iter()
@@ -1225,6 +1248,10 @@ mod tests {
         /// Every `select_window(id)` call, in order — for asserting popover routing
         /// selects the popover then restores the previously-active window.
         select_log: Arc<Mutex<Vec<WindowId>>>,
+        /// When set, `list_windows` errors instead of returning its scripted list — for
+        /// proving a failed popover-probe enumeration degrades to the normal click path
+        /// instead of propagating.
+        fail_list_windows: bool,
     }
 
     impl FakePlatform {
@@ -1273,6 +1300,10 @@ mod tests {
         }
         fn with_capture_window_log(mut self, log: CaptureWindowLog) -> Self {
             self.capture_window_log = log;
+            self
+        }
+        fn with_failing_list_windows(mut self) -> Self {
+            self.fail_list_windows = true;
             self
         }
     }
@@ -1349,6 +1380,9 @@ mod tests {
             Ok(self.geometry.clone())
         }
         fn list_windows(&mut self) -> Result<Vec<WindowInfo>> {
+            if self.fail_list_windows {
+                return Err(GlassError::Backend("list_windows unavailable".into()));
+            }
             if self.windows.is_empty() {
                 Ok(vec![WindowInfo {
                     id: WindowId(0),
@@ -1738,6 +1772,58 @@ mod tests {
             menu_container_bounds(&root, AxNodeId(6), &popover),
             Some(container_bounds),
             "the real container (closest in size to the popover) must win over nearer wrapper groups"
+        );
+    }
+
+    #[test]
+    fn menu_container_bounds_prefers_content_container_over_window_root_sized_ancestor() {
+        // Disambiguates the two kinds of ancestor that both commonly fall within
+        // tolerance of the popover's size: an outer node sized like the popover
+        // window's own frame (e.g. the toplevel root, a few px *larger* — decorations/
+        // margins), and the inner content container a few px *smaller* (the real
+        // GTK4 shape: a `List` a little inside the window's own bounds). Both are
+        // "near" the popover size, so this proves the scoring picks whichever is
+        // numerically closest — the content container — not whichever is outermost.
+        let popover = WindowGeometry {
+            x: -3,
+            y: 220,
+            width: 326,
+            height: 135,
+        };
+        let content_bounds = AxRect {
+            x: 2,
+            y: 222,
+            width: 322,  // 4px narrower than the popover
+            height: 132, // 3px shorter than the popover
+        };
+        let target = ax_node(
+            2,
+            AxRole::ListItem,
+            Some(AxRect {
+                x: 20,
+                y: 248,
+                width: 80,
+                height: 27,
+            }),
+            vec![],
+        );
+        let content = ax_node(1, AxRole::List, Some(content_bounds), vec![target]);
+        let root = ax_node(
+            0,
+            AxRole::Window,
+            Some(AxRect {
+                x: -3,
+                y: 220,
+                width: 338,  // 12px wider than the popover (outer window-root frame)
+                height: 145, // 10px taller than the popover
+            }),
+            vec![content],
+        );
+        assert_eq!(
+            menu_container_bounds(&root, AxNodeId(2), &popover),
+            Some(content_bounds),
+            "both root and content are within tolerance, but content is numerically \
+             closest to the popover's size and must win over the outer window root"
         );
     }
 
@@ -2674,6 +2760,33 @@ mod tests {
     }
 
     #[test]
+    fn click_element_survives_a_failing_list_windows_and_clicks_normally() {
+        // The popover-routing probe (`list_windows`) is best-effort: if the backend's
+        // enumeration errors, an ordinary click must still succeed via the unchanged
+        // `clamped_center` path rather than propagating the enumeration failure.
+        let clicks = Arc::new(Mutex::new(Vec::new()));
+        let select_log = Arc::new(Mutex::new(Vec::new()));
+        let platform = FakePlatform::new(100, 100)
+            .with_click_log(clicks.clone())
+            .with_select_log(select_log.clone())
+            .with_failing_list_windows();
+        let mut g = glass_with_a11y(platform, fake_tree());
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot().unwrap();
+        g.click_element(AxNodeId(1))
+            .expect("a failing list_windows must not block an ordinary click");
+        assert_eq!(
+            clicks.lock().unwrap().last().copied(),
+            Some((20, 20)),
+            "click still lands on the element's own clamped center"
+        );
+        assert!(
+            select_log.lock().unwrap().is_empty(),
+            "no popover routing was attempted since the probe's result was treated as empty"
+        );
+    }
+
+    #[test]
     fn click_element_routes_into_owning_popover_and_restores_active_window() {
         let clicks = Arc::new(Mutex::new(Vec::new()));
         let select_log = Arc::new(Mutex::new(Vec::new()));
@@ -2731,6 +2844,12 @@ mod tests {
     fn click_element_in_popover_without_a_mappable_container_errors() {
         // Same popover-owning geometry, but the target has no List-sized ancestor to
         // recover a container origin from — must error, not silently mis-click.
+        //
+        // This also stands in for the residual `owning_popover` false-positive case
+        // documented on that function: a normal element whose projected point happens to
+        // land inside another real window is indistinguishable, geometrically, from a
+        // genuine popover — the size-matching gate is what turns that misdetection into
+        // this clear, catchable error instead of a silent click into the wrong window.
         let globex = AxNode {
             id: AxNodeId(0),
             role: AxRole::ListItem,
@@ -2782,7 +2901,12 @@ mod tests {
             },
             false,
         );
-        let platform = FakePlatform::new(340, 300).with_windows(vec![a, b]);
+        let clicks = Arc::new(Mutex::new(Vec::new()));
+        let select_log = Arc::new(Mutex::new(Vec::new()));
+        let platform = FakePlatform::new(340, 300)
+            .with_windows(vec![a, b])
+            .with_click_log(clicks.clone())
+            .with_select_log(select_log.clone());
         let mut g = glass_with_a11y(platform, tree);
         g.start(&spec()).unwrap();
         let snapshot = g.a11y_snapshot().unwrap();
@@ -2791,6 +2915,16 @@ mod tests {
             g.click_element(globex_id).unwrap_err(),
             GlassError::AxElementInUnmappedPopover(id) if id == globex_id.0
         ));
+        assert!(
+            clicks.lock().unwrap().is_empty(),
+            "a detection that can't be resolved to a container must never fall back to \
+             clicking anywhere — no click of any kind is recorded"
+        );
+        assert!(
+            select_log.lock().unwrap().is_empty(),
+            "the candidate window is never selected either — the container gate runs \
+             before select_window, so a mis-detection can't even transiently switch focus"
+        );
     }
 
     #[test]

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -97,7 +97,11 @@ pub struct SelectWindowArgs {
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ClickElementArgs {
     /// The element `#id` from `glass_a11y_snapshot`. Valid only within the latest
-    /// snapshot — re-snapshot if the UI changed.
+    /// snapshot — re-snapshot if the UI changed. If the element actually renders in a
+    /// popover owned by a different window than the active one (e.g. an open
+    /// dropdown's option row), the click is automatically routed into that popover
+    /// window and the previously-active window is restored afterward — no extra step
+    /// needed.
     pub id: u32,
     /// Optional observe folded into the result: "snapshot" (a fresh a11y tree, also
     /// refreshing the snapshot cache), "settle" (wait for the UI to stop changing,

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -344,11 +344,15 @@ impl GlassServer {
 
     #[tool(
         description = "Click an element by its #id from glass_a11y_snapshot (clicks the \
-                       center of its bounds, via the normal click path). Ids are only valid \
-                       within the latest snapshot — re-run glass_a11y_snapshot if the UI changed. \
-                       Optional `return`: \"snapshot\" folds a fresh a11y tree into the result \
-                       (and refreshes the snapshot cache); \"settle\" waits for the UI to stop \
-                       changing (text-only); omit or \"none\" for no observe (default)."
+                       center of its bounds, via the normal click path). If the element actually \
+                       renders in a popover owned by a different window than the active one \
+                       (e.g. an open dropdown's option row), the click is automatically routed \
+                       into that popover window and the previously-active window is restored \
+                       afterward. Ids are only valid within the latest snapshot — re-run \
+                       glass_a11y_snapshot if the UI changed. Optional `return`: \"snapshot\" \
+                       folds a fresh a11y tree into the result (and refreshes the snapshot \
+                       cache); \"settle\" waits for the UI to stop changing (text-only); omit or \
+                       \"none\" for no observe (default)."
     )]
     async fn glass_click_element(
         &self,


### PR DESCRIPTION
## What

`click_element(id)` used to clamp the element's a11y bounds to the **active** window and offset the click by the active window's origin. An element that actually lives in a **popover** (a separate override-redirect X window — e.g. an open dropdown's option row) was therefore clicked in the main window and silently missed. This auto-routes such clicks to the owning popover window, so `click_element` just works on popover items (or fails with a clear error).

## How (all in `glass-core`, platform-agnostic)

When resolving `click_element(id)`:
1. Project the element's center to screen and best-effort scan `list_windows` for a **non-active** window whose screen rect contains it (a popover). If enumeration fails, fall straight through to the normal click — an ordinary click is never blocked by the probe.
2. If a popover owns the element: find its **menu container** (the ancestor whose a11y size is closest to the popover window's size), `select_window(popover)`, click at `(element_bounds − menu_container_bounds)`, then restore the previously-active window (best-effort). The `(item − container)` subtraction plus `select_window`'s origin offset recovers the element's true screen position, correcting the headless a11y-coordinate skew.
3. If a popover is detected but no size-matching container maps, return the structured error `AxElementInUnmappedPopover` — the mapping runs **before** any focus switch or click, so a mis-detection degrades to a clear error, never a silent wrong click or transient focus change.

Naturally no-ops where popovers aren't separate windows (Wayland popups aren't in the window model — those stay keyboard-driven).

## Validated & tested

The recipe was validated end-to-end before implementation (`select_window(popover)` + click `(item − List)` commits a dropdown option). Tests: unit tests for owning-window detection (screen projection, non-active containment, smallest-area tiebreak), menu-container closest-size scoring (incl. window-root-vs-content-container ambiguity), the unmapped-popover error path (asserts no click/focus change), and enumeration-failure fallback. Ignored X11 integration test `click_element_commits_dropdown_option` opens the dropdown and asserts the option commits. `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test --workspace`, and the a11y suite are green.

Closes #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)