### PR TITLE
x11: clip off-screen captures to the display instead of a BadMatch hard-fail

### DIFF
--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -148,7 +148,7 @@ impl GlassServer {
     }
 
     #[tool(
-        description = "Capture the app window (or an optional window-relative `region`) as a screenshot (lossless WebP image)."
+        description = "Capture the app window (or an optional window-relative `region`) as a screenshot (lossless WebP image). A capture reaching off the display edge is clipped to the on-screen portion — the returned `width`/`height` are the actual captured size, so a frame smaller than the window/region means it was clipped; only a fully off-screen surface errors."
     )]
     async fn glass_screenshot(
         &self,

--- a/crates/glass-testapp/tests/integration.rs
+++ b/crates/glass-testapp/tests/integration.rs
@@ -121,26 +121,52 @@ fn captures_known_quadrant_colors() {
 
 #[test]
 #[ignore = "requires an X server; run via scripts/test-x11.sh"]
-fn oversize_window_capture_returns_actionable_error() {
+fn oversize_window_capture_is_clipped_to_the_display() {
     // A display SMALLER than the 320x240 test window, so the window overflows the
-    // screen — the "window bigger than the headless Xvfb" case. Capture must fail
-    // with an actionable message (window + display sizes and the two remedies),
-    // not the raw `GetImage`/`BadMatch` protocol error the agent can't act on.
+    // screen — the "window bigger than the headless Xvfb" case. Rather than fail
+    // with the raw `GetImage`/`BadMatch` protocol error the agent can't act on,
+    // glass clips the capture to the on-screen portion and returns a partial frame
+    // (a partial view beats none). This exercises the real GetImage-on-clipped-rect
+    // path: proof the clipped rectangle is actually readable, not another BadMatch.
+    let (dw, dh) = (200i32, 200i32);
     let xvfb = glass_x11::Xvfb::start("200x200x24").expect("spawn Xvfb (is it installed?)");
     let mut p = X11Platform::connect(Some(&xvfb.display)).unwrap();
     p.start_app(&app_spec()).unwrap();
     assert!(wait_for_log(&mut p, "READY", 40), "no READY");
     std::thread::sleep(std::time::Duration::from_millis(150));
-    let err = p.capture_frame(None).unwrap_err().to_string();
-    assert!(err.contains("320x240"), "names the window size: {err}");
-    assert!(err.contains("200x200"), "names the display size: {err}");
+
+    // Compute the exact on-display intersection from the window's real geometry,
+    // so the assertion has teeth: a bug that over- or under-clips fails, not just
+    // "any frame smaller than the window".
+    let geo = p
+        .list_windows()
+        .unwrap()
+        .into_iter()
+        .find(|w| w.title.as_deref() == Some("glass-testapp"))
+        .expect("test window")
+        .geometry;
+    let ix = geo.x.max(0);
+    let iy = geo.y.max(0);
+    let exp_w = ((geo.x + geo.width as i32).min(dw) - ix) as u32;
+    let exp_h = ((geo.y + geo.height as i32).min(dh) - iy) as u32;
     assert!(
-        err.contains("GLASS_XVFB_SCREEN"),
-        "names the larger-display remedy: {err}"
+        exp_w > 0 && exp_h > 0,
+        "precondition: window {geo:?} must overlap the {dw}x{dh} display"
     );
     assert!(
-        !err.contains("get_image"),
-        "should be the pre-flight actionable error, not the raw GetImage failure: {err}"
+        exp_w < geo.width || exp_h < geo.height,
+        "precondition: window {geo:?} must overflow the {dw}x{dh} display to exercise clipping"
+    );
+
+    let frame = p
+        .capture_frame(None)
+        .expect("oversize-window capture should clip to the display, not error");
+    // The returned frame is exactly the on-display portion — proof it was clipped
+    // to a readable rectangle, not a BadMatch and not garbage/full-window pixels.
+    assert_eq!(
+        (frame.width, frame.height),
+        (exp_w, exp_h),
+        "capture should be clipped to exactly the on-display intersection of {geo:?}"
     );
     p.stop_app().unwrap();
 }

--- a/crates/glass-x11/src/coords.rs
+++ b/crates/glass-x11/src/coords.rs
@@ -7,23 +7,43 @@ pub fn window_to_root(origin_x: i32, origin_y: i32, x: i32, y: i32) -> (i16, i16
     ((origin_x + x) as i16, (origin_y + y) as i16)
 }
 
-/// Verify the capture rectangle — the whole window, or `region` within it —
-/// lies entirely within the X11 display (root window). glass runs the app on a
-/// headless Xvfb of a fixed size; a window taller/wider than that screen (or
-/// positioned so part of it is off-screen) makes `GetImage` cover non-viewable
-/// area, and X returns a bare `BadMatch`. Detect that here and return an
-/// actionable error naming both remedies, instead of surfacing the opaque
-/// protocol error the driving agent can't act on.
+/// A capture rectangle fitted to the X11 display: the on-display root-coordinate
+/// sub-rectangle actually read by `GetImage`, plus whether it was shrunk from
+/// what the caller asked for.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ClippedRect {
+    /// Root-coordinate top-left of the portion to capture.
+    pub sx: i32,
+    pub sy: i32,
+    /// Size of the on-display portion (always > 0).
+    pub w: u32,
+    pub h: u32,
+    /// True when the requested rectangle reached off the display and was shrunk
+    /// to its on-display part (the returned frame is therefore a partial view).
+    pub clipped: bool,
+}
+
+/// Fit the requested capture rectangle — the whole window, or `region` within
+/// it — to the X11 display (root window), returning the on-display portion.
+///
+/// glass runs the app on a headless Xvfb of a fixed size; a window taller/wider
+/// than that screen (or positioned so part of it is off-screen) makes `GetImage`
+/// cover non-viewable area, and X rejects it with a bare `BadMatch`. Rather than
+/// fail the whole capture, intersect the requested rectangle with the display
+/// and read only the visible part — a partial capture is strictly more useful
+/// than none, and is exactly the surface (an off-screen-anchored popover) whose
+/// contents the caller most wants to see. A rectangle lying *entirely* off the
+/// display has nothing to show and stays an actionable error.
 ///
 /// `geo` is the window's root-relative origin + size; `display` is the root
 /// window's pixel size.
-pub(crate) fn check_capture_fits(
+pub(crate) fn clip_capture_to_display(
     geo: &WindowGeometry,
     region: Option<&Region>,
     display: (u32, u32),
-) -> Result<()> {
+) -> Result<ClippedRect> {
     let (dw, dh) = (i64::from(display.0), i64::from(display.1));
-    // The capture rectangle in window-local coords, then in root/display coords.
+    // The requested rectangle in window-local coords, then in root/display coords.
     let (cx, cy, w, h) = match region {
         Some(r) => (
             i64::from(r.x),
@@ -34,19 +54,31 @@ pub(crate) fn check_capture_fits(
         None => (0, 0, i64::from(geo.width), i64::from(geo.height)),
     };
     let (rx, ry) = (i64::from(geo.x) + cx, i64::from(geo.y) + cy);
-    if rx >= 0 && ry >= 0 && rx + w <= dw && ry + h <= dh {
-        return Ok(());
+    // Intersect the requested rectangle with the display [0,dw) x [0,dh).
+    let ix = rx.max(0);
+    let iy = ry.max(0);
+    let iw = (rx + w).min(dw) - ix;
+    let ih = (ry + h).min(dh) - iy;
+    if iw <= 0 || ih <= 0 {
+        // A display that would contain the requested rectangle — a concrete value
+        // the operator can drop straight into GLASS_XVFB_SCREEN.
+        let need_w = (rx + w).max(dw);
+        let need_h = (ry + h).max(dh);
+        return Err(GlassError::CaptureFailed(format!(
+            "capture area {w}x{h} at ({rx},{ry}) lies entirely outside the {dw}x{dh} X11 \
+             display; there is nothing on-screen to read (GetImage BadMatch). Reposition or \
+             resize the window to overlap the display, or restart glass with a larger display \
+             via GLASS_XVFB_SCREEN={need_w}x{need_h}x24."
+        )));
     }
-    // A display that would contain this capture rectangle — a concrete value the
-    // operator can drop straight into GLASS_XVFB_SCREEN.
-    let need_w = (rx + w).max(dw);
-    let need_h = (ry + h).max(dh);
-    Err(GlassError::CaptureFailed(format!(
-        "capture area {w}x{h} at ({rx},{ry}) extends beyond the {dw}x{dh} X11 display; \
-         X11 cannot read the off-screen part (GetImage BadMatch). Resize the window to fit \
-         within {dw}x{dh}, or restart glass with a larger display via \
-         GLASS_XVFB_SCREEN={need_w}x{need_h}x24."
-    )))
+    let clipped = ix != rx || iy != ry || iw != w || ih != h;
+    Ok(ClippedRect {
+        sx: ix as i32,
+        sy: iy as i32,
+        w: iw as u32,
+        h: ih as u32,
+        clipped,
+    })
 }
 
 #[cfg(test)]
@@ -64,49 +96,57 @@ mod tests {
     }
 
     #[test]
-    fn capture_within_display_is_ok() {
-        // An 800x600 window at (10,10) fits well inside a 1280x800 display.
+    fn capture_within_display_is_unclipped() {
+        // An 800x600 window at (10,10) fits well inside a 1280x800 display: the
+        // whole window is read, nothing is clipped.
         let geo = WindowGeometry {
             x: 10,
             y: 10,
             width: 800,
             height: 600,
         };
-        assert!(check_capture_fits(&geo, None, (1280, 800)).is_ok());
+        let r = clip_capture_to_display(&geo, None, (1280, 800)).unwrap();
+        assert_eq!(
+            r,
+            ClippedRect {
+                sx: 10,
+                sy: 10,
+                w: 800,
+                h: 600,
+                clipped: false
+            }
+        );
     }
 
     #[test]
-    fn window_exceeding_display_is_actionable_error() {
-        // The reproduced case: a 1400x1000 window at (1,1) on a 1280x800 Xvfb.
+    fn window_exceeding_display_is_clipped_to_visible() {
+        // Formerly a hard error: a 1400x1000 window at (1,1) on a 1280x800 Xvfb.
+        // Now the on-display 1279x799 portion is read and flagged clipped, so the
+        // caller gets a partial frame instead of BadMatch.
         let geo = WindowGeometry {
             x: 1,
             y: 1,
             width: 1400,
             height: 1000,
         };
-        let msg = check_capture_fits(&geo, None, (1280, 800))
-            .unwrap_err()
-            .to_string();
-        assert!(
-            msg.contains("1400x1000"),
-            "names the window/capture size: {msg}"
-        );
-        assert!(msg.contains("1280x800"), "names the display size: {msg}");
-        assert!(
-            msg.contains("GLASS_XVFB_SCREEN"),
-            "names the larger-display remedy: {msg}"
-        );
-        assert!(
-            msg.to_lowercase().contains("resize"),
-            "names the resize remedy: {msg}"
+        let r = clip_capture_to_display(&geo, None, (1280, 800)).unwrap();
+        assert_eq!(
+            r,
+            ClippedRect {
+                sx: 1,
+                sy: 1,
+                w: 1279,
+                h: 799,
+                clipped: true
+            }
         );
     }
 
     #[test]
-    fn onscreen_region_of_an_oversized_window_still_succeeds() {
+    fn onscreen_region_of_an_oversized_window_is_unclipped() {
         // The window is taller than the display (its lower 200px are off-screen),
-        // but a region on its visible upper part maps fully on-screen — partial
-        // capture of a too-big window must still work, not be rejected wholesale.
+        // but a region on its visible upper part maps fully on-screen — a partial
+        // capture of a too-big window reads exactly the region, unclipped.
         let geo = WindowGeometry {
             x: 0,
             y: 0,
@@ -119,13 +159,24 @@ mod tests {
             width: 500,
             height: 500,
         };
-        assert!(check_capture_fits(&geo, Some(&region), (1280, 800)).is_ok());
+        let r = clip_capture_to_display(&geo, Some(&region), (1280, 800)).unwrap();
+        assert_eq!(
+            r,
+            ClippedRect {
+                sx: 0,
+                sy: 0,
+                w: 500,
+                h: 500,
+                clipped: false
+            }
+        );
     }
 
     #[test]
-    fn region_reaching_the_offscreen_part_of_an_oversized_window_is_caught() {
+    fn region_reaching_the_offscreen_part_of_an_oversized_window_is_clipped() {
         // Same oversized window; this region fits the window (y 600..900 <= 1000)
-        // but reaches below the 800px display edge, so its lower rows are off-root.
+        // but reaches below the 800px display edge, so its lower 100 rows are
+        // off-root. The visible 500x200 top of the region is read and clipped.
         let geo = WindowGeometry {
             x: 0,
             y: 0,
@@ -138,21 +189,87 @@ mod tests {
             width: 500,
             height: 300,
         };
-        let msg = check_capture_fits(&geo, Some(&region), (1280, 800))
-            .unwrap_err()
-            .to_string();
-        assert!(msg.contains("1280x800"), "names the display size: {msg}");
+        let r = clip_capture_to_display(&geo, Some(&region), (1280, 800)).unwrap();
+        assert_eq!(
+            r,
+            ClippedRect {
+                sx: 0,
+                sy: 600,
+                w: 500,
+                h: 200,
+                clipped: true
+            }
+        );
     }
 
     #[test]
-    fn window_flush_to_display_edges_is_ok() {
-        // Exactly display-sized at the origin — the boundary case must pass.
+    fn negative_origin_popover_is_clipped_to_visible() {
+        // The issue repro: an override-redirect popover anchored partly off the
+        // left edge (x:-3). Its left 3 columns are off-root; the visible 323x135
+        // is read (sx snapped to 0) and flagged clipped, not a BadMatch.
+        let geo = WindowGeometry {
+            x: -3,
+            y: 25,
+            width: 326,
+            height: 135,
+        };
+        let r = clip_capture_to_display(&geo, None, (1280, 800)).unwrap();
+        assert_eq!(
+            r,
+            ClippedRect {
+                sx: 0,
+                sy: 25,
+                w: 323,
+                h: 135,
+                clipped: true
+            }
+        );
+    }
+
+    #[test]
+    fn rectangle_entirely_off_display_is_actionable_error() {
+        // A window pushed fully past the right edge has no on-screen pixels: a
+        // partial capture is impossible, so this stays an actionable error.
+        let geo = WindowGeometry {
+            x: 2000,
+            y: 0,
+            width: 100,
+            height: 100,
+        };
+        let msg = clip_capture_to_display(&geo, None, (1280, 800))
+            .unwrap_err()
+            .to_string();
+        assert!(msg.contains("1280x800"), "names the display size: {msg}");
+        assert!(
+            msg.contains("GLASS_XVFB_SCREEN"),
+            "names the larger-display remedy: {msg}"
+        );
+        assert!(
+            msg.to_lowercase().contains("outside"),
+            "explains nothing is on-screen: {msg}"
+        );
+    }
+
+    #[test]
+    fn window_flush_to_display_edges_is_unclipped() {
+        // Exactly display-sized at the origin — the boundary case reads the whole
+        // window with nothing clipped.
         let geo = WindowGeometry {
             x: 0,
             y: 0,
             width: 1280,
             height: 800,
         };
-        assert!(check_capture_fits(&geo, None, (1280, 800)).is_ok());
+        let r = clip_capture_to_display(&geo, None, (1280, 800)).unwrap();
+        assert_eq!(
+            r,
+            ClippedRect {
+                sx: 0,
+                sy: 0,
+                w: 1280,
+                h: 800,
+                clipped: false
+            }
+        );
     }
 }

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -629,23 +629,24 @@ impl X11Platform {
 
     /// Resolve a window-relative `region` (or the whole window) against `geo`
     /// into an absolute root-coordinate capture rectangle, rejecting a zero-area
-    /// region and one that reaches off the (headless) display before any
-    /// `GetImage` request is issued.
+    /// region and fitting the result to the (headless) display: a rectangle
+    /// reaching off-screen is clipped to its visible portion (flagged in the
+    /// returned [`ClippedRect`]) rather than issuing a doomed `GetImage`.
     fn resolve_capture_rect(
         &self,
         geo: &WindowGeometry,
         region: Option<&Region>,
-    ) -> Result<(i32, i32, u32, u32)> {
-        let (cx, cy, w, h) = match region {
-            Some(r) => (r.x, r.y, r.width, r.height),
-            None => (0, 0, geo.width, geo.height),
+    ) -> Result<crate::coords::ClippedRect> {
+        let (w, h) = match region {
+            Some(r) => (r.width, r.height),
+            None => (geo.width, geo.height),
         };
         if w == 0 || h == 0 {
             return Err(GlassError::CaptureFailed("window has zero area".into()));
         }
         // A window (or region) reaching past the headless display makes GetImage
-        // cover non-viewable area, which X rejects with a bare BadMatch. Convert
-        // that to an actionable error before issuing the request; the root
+        // cover non-viewable area, which X rejects with a bare BadMatch. Clip to
+        // the on-display portion here (a partial frame beats none); the root
         // window's pixel size is the display size.
         let display = {
             let root = &self.conn.setup().roots[self.screen_num];
@@ -654,8 +655,7 @@ impl X11Platform {
                 u32::from(root.height_in_pixels),
             )
         };
-        crate::coords::check_capture_fits(geo, region, display)?;
-        Ok((geo.x + cx as i32, geo.y + cy as i32, w, h))
+        crate::coords::clip_capture_to_display(geo, region, display)
     }
 
     /// `GetImage` a `w`x`h` rectangle at root-coordinate `(sx,sy)` and decode it to
@@ -689,6 +689,21 @@ impl X11Platform {
             })?;
         let rgba = crate::pixels::xdata_to_rgba(&image.data, w, h, bpp)?;
         Frame::new(w, h, rgba)
+    }
+}
+
+/// Emit a one-line diagnostic when a capture was clipped to the display, so the
+/// smaller-than-requested frame the caller receives isn't a silent surprise.
+/// glass's own stderr is its diagnostic channel (same as the focus-on-launch
+/// warning); the MCP `screenshot` result additionally reports the true (clipped)
+/// dimensions, so a frame smaller than the window/region signals the clip.
+fn note_if_clipped(rect: &crate::coords::ClippedRect) {
+    if rect.clipped {
+        eprintln!(
+            "glass: capture reached past the headless display and was clipped to the visible \
+             {}x{} region at ({},{}); returning a partial frame",
+            rect.w, rect.h, rect.sx, rect.sy
+        );
     }
 }
 
@@ -933,11 +948,12 @@ impl Platform for X11Platform {
         // `window_geometry()` itself calls `require_window()`, so it doubles as
         // the "is there an active window" guard — no separate binding needed.
         let geo = self.window_geometry()?;
-        let (sx, sy, w, h) = self.resolve_capture_rect(&geo, region)?;
+        let rect = self.resolve_capture_rect(&geo, region)?;
+        note_if_clipped(&rect);
         // Capture from ROOT over the window's screen region so overlapping popovers
         // (separate override-redirect top-levels) are included, not just this window's
         // own (possibly-obscured) drawable.
-        self.capture_screen_rect(sx, sy, w, h)
+        self.capture_screen_rect(rect.sx, rect.sy, rect.w, rect.h)
     }
 
     fn capture_window(&mut self, id: WindowId, region: Option<&Region>) -> Result<Frame> {
@@ -960,8 +976,9 @@ impl Platform for X11Platform {
             // this window (desktop / other windows) instead of erroring.
             r.check_fits(geo.width, geo.height)?;
         }
-        let (sx, sy, w, h) = self.resolve_capture_rect(&geo, region)?;
-        self.capture_screen_rect(sx, sy, w, h)
+        let rect = self.resolve_capture_rect(&geo, region)?;
+        note_if_clipped(&rect);
+        self.capture_screen_rect(rect.sx, rect.sy, rect.w, rect.h)
     }
 
     fn send_pointer(&mut self, event: &PointerEvent) -> Result<()> {


### PR DESCRIPTION
## What

An X11 capture rectangle reaching past the headless display made `XGetImage`
cover non-viewable area, which X rejects with a bare `BadMatch` — a hard failure
of the whole capture. This happens for a window larger than the screen, or a
popover anchored partly off an edge (e.g. `x:-3`) — exactly the surface whose
contents you most want to confirm.

Now the requested rectangle is **intersected with the display** and only the
on-screen portion is read: a partial capture is strictly more useful than none.
A rectangle lying *entirely* off-display has nothing to show and stays an
actionable error.

## How

- `check_capture_fits` (was `Result<()>`) → `clip_capture_to_display` returning a
  `ClippedRect { sx, sy, w, h, clipped }`.
- `capture_frame` and `capture_window` read the clipped rect and emit a one-line
  stderr diagnostic when it was clipped.
- The clip lives in the shared `resolve_capture_rect` layer, so it covers
  screenshot, diff, wait_*, and the specific-window capture path alike.
- The clip is deterministic per window geometry, so baseline / wait_stable / diff
  stay size-consistent in the normal (static window) case; a window that moved
  between baseline and compare yields a structured `SizeMismatch`, never a panic.
- The MCP `screenshot` result already reports the true (clipped) dimensions; a
  tool-doc note explains that a smaller-than-requested frame means it was clipped.

## Tests

- `coords.rs` unit tests pin the intersection math: exact fit (unclipped), each
  overhang edge, negative-origin popover (`x:-3` → visible `323x135`), and the
  entirely-off-display error case.
- The X11 integration test flips from "asserts BadMatch error" to asserting the
  oversize-window capture succeeds and returns **exactly** the on-display
  intersection computed from the window's real geometry — proof the clipped
  rectangle is actually readable, not another `BadMatch`.
- `cargo test --workspace`, `cargo clippy -D warnings`, `cargo fmt --check`, and
  `./scripts/test-x11.sh` (capture suite) all green locally.

Resolves the off-screen half of #85. (The overlapping-popover composite half was
handled separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)