### PR TITLE
glass_scroll_to_element: scroll a container until an element is visible (#86)

### DIFF
--- a/crates/glass-a11y-linux/tests/fixtures/a11y_fixture.py
+++ b/crates/glass-a11y-linux/tests/fixtures/a11y_fixture.py
@@ -3,8 +3,8 @@
 Window "Glass A11y Fixture" containing a Label "Ready", a Button "Save", a
 CheckButton "Enable", an Entry "Field" (initial text "hello"), a SpinButton
 "Amount" (initial value 1), a DropDown "Company" (Acme/Globex/Initech), a
-Switch "Active" (off), and a virtualized GtkListView of 200 rows ("Row 000".."Row
-199") in a small scroller. Run by scripts/test-a11y.sh via glass (which sets DISPLAY).
+Switch "Active" (off), and a virtualized GtkListView of 80 rows ("Row 000".."Row
+079") in a small scroller. Run by scripts/test-a11y.sh via glass (which sets DISPLAY).
 
 Uses Gio.ApplicationFlags.NON_UNIQUE so the app skips D-Bus singleton registration
 and presents its window immediately without waiting for portal services to settle."""
@@ -13,7 +13,7 @@ import gi
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("Gio", "2.0")
-from gi.repository import Gdk, Gio, Gtk  # noqa: E402
+from gi.repository import Gio, Gtk  # noqa: E402
 
 
 class FixtureApp(Gtk.Application):
@@ -24,25 +24,6 @@ class FixtureApp(Gtk.Application):
         )
 
     def do_activate(self):
-        # GtkScrolledWindow paints a thin "undershoot/overshoot" shadow at a scroll
-        # boundary, and repaints it (with a pixel or two of antialiasing jitter)
-        # every time a further scroll is attempted past that boundary — even
-        # though the adjustment's value itself is fully clamped and unchanging.
-        # scroll_to_element treats any such pixel change as "still moving", so
-        # left alone this defeats its bidirectional sweep's own end-of-scroll
-        # detection: it would never see "no motion" and so never reverse
-        # direction. Suppress the indicator so a clamped scroll is visually a
-        # true no-op.
-        css = Gtk.CssProvider()
-        css.load_from_string(
-            "scrolledwindow > undershoot, scrolledwindow > overshoot { "
-            "background: none; background-image: none; box-shadow: none; }"
-        )
-        Gtk.StyleContext.add_provider_for_display(
-            Gdk.Display.get_default(),
-            css,
-            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
-        )
         win = Gtk.ApplicationWindow(application=self, title="Glass A11y Fixture")
         win.set_default_size(320, 420)
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
@@ -73,14 +54,14 @@ class FixtureApp(Gtk.Application):
         switch.set_halign(Gtk.Align.START)
         switch.update_property([Gtk.AccessibleProperty.LABEL], ["Active"])
         box.append(switch)
-        # A virtualized GtkListView of 200 rows in a small scroller. GtkListView
-        # only realizes rows near the viewport, so a late row ("Row 180") is ABSENT
+        # A virtualized GtkListView of 80 rows in a small scroller. GtkListView
+        # only realizes rows near the viewport, so a late row ("Row 060") is ABSENT
         # from the a11y tree until scrolled into view — the case scroll_to_element
-        # must overcome (a non-virtualizing GtkListBox would realize all 200 rows and
+        # must overcome (a non-virtualizing GtkListBox would realize all 80 rows and
         # let a test pass without scrolling). On selection it prints "SELECTED <name>"
         # so a click can be confirmed from the logs regardless of where GTK places the
         # selected state in the a11y tree.
-        rows = Gtk.StringList.new([f"Row {i:03d}" for i in range(200)])
+        rows = Gtk.StringList.new([f"Row {i:03d}" for i in range(80)])
         selection = Gtk.SingleSelection(model=rows)
         selection.set_autoselect(False)
         selection.set_can_unselect(True)

--- a/crates/glass-a11y-linux/tests/fixtures/a11y_fixture.py
+++ b/crates/glass-a11y-linux/tests/fixtures/a11y_fixture.py
@@ -2,8 +2,9 @@
 """Minimal GTK4 app with a known accessibility tree, for glass-a11y-linux tests.
 Window "Glass A11y Fixture" containing a Label "Ready", a Button "Save", a
 CheckButton "Enable", an Entry "Field" (initial text "hello"), a SpinButton
-"Amount" (initial value 1), a DropDown "Company" (Acme/Globex/Initech), and a
-Switch "Active" (off). Run by scripts/test-a11y.sh via glass (which sets DISPLAY).
+"Amount" (initial value 1), a DropDown "Company" (Acme/Globex/Initech), a
+Switch "Active" (off), and a virtualized GtkListView of 200 rows ("Row 000".."Row
+199") in a small scroller. Run by scripts/test-a11y.sh via glass (which sets DISPLAY).
 
 Uses Gio.ApplicationFlags.NON_UNIQUE so the app skips D-Bus singleton registration
 and presents its window immediately without waiting for portal services to settle."""
@@ -12,7 +13,7 @@ import gi
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("Gio", "2.0")
-from gi.repository import Gio, Gtk  # noqa: E402
+from gi.repository import Gdk, Gio, Gtk  # noqa: E402
 
 
 class FixtureApp(Gtk.Application):
@@ -23,8 +24,27 @@ class FixtureApp(Gtk.Application):
         )
 
     def do_activate(self):
+        # GtkScrolledWindow paints a thin "undershoot/overshoot" shadow at a scroll
+        # boundary, and repaints it (with a pixel or two of antialiasing jitter)
+        # every time a further scroll is attempted past that boundary — even
+        # though the adjustment's value itself is fully clamped and unchanging.
+        # scroll_to_element treats any such pixel change as "still moving", so
+        # left alone this defeats its bidirectional sweep's own end-of-scroll
+        # detection: it would never see "no motion" and so never reverse
+        # direction. Suppress the indicator so a clamped scroll is visually a
+        # true no-op.
+        css = Gtk.CssProvider()
+        css.load_from_string(
+            "scrolledwindow > undershoot, scrolledwindow > overshoot { "
+            "background: none; background-image: none; box-shadow: none; }"
+        )
+        Gtk.StyleContext.add_provider_for_display(
+            Gdk.Display.get_default(),
+            css,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
+        )
         win = Gtk.ApplicationWindow(application=self, title="Glass A11y Fixture")
-        win.set_default_size(320, 200)
+        win.set_default_size(320, 420)
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
         box.append(Gtk.Label(label="Ready"))
         box.append(Gtk.Button(label="Save"))
@@ -53,6 +73,38 @@ class FixtureApp(Gtk.Application):
         switch.set_halign(Gtk.Align.START)
         switch.update_property([Gtk.AccessibleProperty.LABEL], ["Active"])
         box.append(switch)
+        # A virtualized GtkListView of 200 rows in a small scroller. GtkListView
+        # only realizes rows near the viewport, so a late row ("Row 180") is ABSENT
+        # from the a11y tree until scrolled into view — the case scroll_to_element
+        # must overcome (a non-virtualizing GtkListBox would realize all 200 rows and
+        # let a test pass without scrolling). On selection it prints "SELECTED <name>"
+        # so a click can be confirmed from the logs regardless of where GTK places the
+        # selected state in the a11y tree.
+        rows = Gtk.StringList.new([f"Row {i:03d}" for i in range(200)])
+        selection = Gtk.SingleSelection(model=rows)
+        selection.set_autoselect(False)
+        selection.set_can_unselect(True)
+        selection.set_selected(Gtk.INVALID_LIST_POSITION)
+
+        def _on_selection_changed(sel, _pos, _n_items):
+            i = sel.get_selected()
+            if i != Gtk.INVALID_LIST_POSITION:
+                print(f"SELECTED {rows.get_string(i)}", flush=True)
+
+        selection.connect("selection-changed", _on_selection_changed)
+        factory = Gtk.SignalListItemFactory()
+        factory.connect("setup", lambda _f, item: item.set_child(Gtk.Label()))
+        factory.connect(
+            "bind",
+            lambda _f, item: item.get_child().set_text(item.get_item().get_string()),
+        )
+        listview = Gtk.ListView(model=selection, factory=factory)
+        scroller = Gtk.ScrolledWindow()
+        scroller.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scroller.set_min_content_height(120)
+        scroller.set_max_content_height(120)
+        scroller.set_child(listview)
+        box.append(scroller)
         win.set_child(box)
         win.present()
 

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -663,3 +663,91 @@ fn wayland_a11y_default_sandbox() {
 fn wayland_a11y_strict_sandbox() {
     wayland_a11y_finds_widgets(glass_core::SandboxLevel::Strict);
 }
+
+// ---- #86: scroll_to_element against a virtualized GtkListView ----
+
+#[test]
+#[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
+fn scroll_to_element_reaches_a_virtualized_offscreen_row() {
+    let mut glass = launch_fixture();
+    // Precondition: "Row 180" is virtualized — absent from the initial tree. If it
+    // were present, the test would prove nothing (no scroll needed).
+    let tree = glass.a11y_snapshot().expect("snapshot");
+    assert!(
+        find_node(&tree.root, "Row 180").is_none(),
+        "Row 180 should be off-screen/virtualized at start, but was in the tree"
+    );
+    // Anchor the scroll over the list: use a realized early row's center, so the
+    // wheel lands on the scroller regardless of exact window layout.
+    let seed = find_node(&tree.root, "Row 000").expect("an early row realized at start");
+    let sb = seed.bounds.expect("row bounds");
+    let anchor = (sb.x + sb.width as i32 / 2, sb.y + sb.height as i32 / 2);
+
+    let out = glass
+        .scroll_to_element(&glass_core::ScrollToElementParams {
+            name: Some("Row 180".into()),
+            role: None,
+            value_contains: None,
+            direction: glass_core::ScrollDirection::Down,
+            anchor: Some(anchor),
+            step: glass_core::SCROLL_TO_DEFAULT_STEP,
+            timeout_ms: glass_core::SCROLL_TO_DEFAULT_TIMEOUT_MS,
+        })
+        .expect("scroll_to_element");
+    assert!(
+        out.matched,
+        "Row 180 should be reached by scrolling; {out:?}"
+    );
+    assert!(out.steps > 0, "should have scrolled at least once");
+    let elem = out.element.expect("matched element");
+    assert!(
+        elem.name.as_deref().is_some_and(|n| n.contains("Row 180")),
+        "matched the wrong node: {:?}",
+        elem.name
+    );
+
+    // The returned id is from the final snapshot → click it and confirm the fixture
+    // selected exactly that row (via its stdout).
+    glass
+        .click_element(elem.id)
+        .expect("click the realized row");
+    let seen = glass
+        .wait_for_log(&glass_core::WaitLogParams {
+            contains: "SELECTED Row 180".into(),
+            stream: None,
+            cursor: None,
+            interval_ms: 100,
+            timeout_ms: 4000,
+        })
+        .expect("wait_for_log");
+    assert!(seen.matched, "click did not select Row 180");
+    glass.stop().expect("stop");
+}
+
+#[test]
+#[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
+fn scroll_to_element_reports_unmatched_for_an_absent_row() {
+    let mut glass = launch_fixture();
+    let tree = glass.a11y_snapshot().expect("snapshot");
+    let seed = find_node(&tree.root, "Row 000").expect("an early row realized at start");
+    let sb = seed.bounds.expect("row bounds");
+    let anchor = (sb.x + sb.width as i32 / 2, sb.y + sb.height as i32 / 2);
+
+    // "Row 999" does not exist (rows are 000..199): a full bidirectional sweep must
+    // terminate with matched:false and reversed:true, not hang.
+    let out = glass
+        .scroll_to_element(&glass_core::ScrollToElementParams {
+            name: Some("Row 999".into()),
+            role: None,
+            value_contains: None,
+            direction: glass_core::ScrollDirection::Down,
+            anchor: Some(anchor),
+            step: glass_core::SCROLL_TO_DEFAULT_STEP,
+            timeout_ms: glass_core::SCROLL_TO_DEFAULT_TIMEOUT_MS,
+        })
+        .expect("scroll_to_element");
+    assert!(!out.matched, "Row 999 must not match; {out:?}");
+    assert!(out.element.is_none());
+    assert!(out.reversed, "should have swept both ends; {out:?}");
+    glass.stop().expect("stop");
+}

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -670,12 +670,12 @@ fn wayland_a11y_strict_sandbox() {
 #[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
 fn scroll_to_element_reaches_a_virtualized_offscreen_row() {
     let mut glass = launch_fixture();
-    // Precondition: "Row 180" is virtualized — absent from the initial tree. If it
+    // Precondition: "Row 060" is virtualized — absent from the initial tree. If it
     // were present, the test would prove nothing (no scroll needed).
     let tree = glass.a11y_snapshot().expect("snapshot");
     assert!(
-        find_node(&tree.root, "Row 180").is_none(),
-        "Row 180 should be off-screen/virtualized at start, but was in the tree"
+        find_node(&tree.root, "Row 060").is_none(),
+        "Row 060 should be off-screen/virtualized at start, but was in the tree"
     );
     // Anchor the scroll over the list: use a realized early row's center, so the
     // wheel lands on the scroller regardless of exact window layout.
@@ -685,7 +685,7 @@ fn scroll_to_element_reaches_a_virtualized_offscreen_row() {
 
     let out = glass
         .scroll_to_element(&glass_core::ScrollToElementParams {
-            name: Some("Row 180".into()),
+            name: Some("Row 060".into()),
             role: None,
             value_contains: None,
             direction: glass_core::ScrollDirection::Down,
@@ -696,12 +696,12 @@ fn scroll_to_element_reaches_a_virtualized_offscreen_row() {
         .expect("scroll_to_element");
     assert!(
         out.matched,
-        "Row 180 should be reached by scrolling; {out:?}"
+        "Row 060 should be reached by scrolling; {out:?}"
     );
     assert!(out.steps > 0, "should have scrolled at least once");
     let elem = out.element.expect("matched element");
     assert!(
-        elem.name.as_deref().is_some_and(|n| n.contains("Row 180")),
+        elem.name.as_deref().is_some_and(|n| n.contains("Row 060")),
         "matched the wrong node: {:?}",
         elem.name
     );
@@ -713,14 +713,14 @@ fn scroll_to_element_reaches_a_virtualized_offscreen_row() {
         .expect("click the realized row");
     let seen = glass
         .wait_for_log(&glass_core::WaitLogParams {
-            contains: "SELECTED Row 180".into(),
+            contains: "SELECTED Row 060".into(),
             stream: None,
             cursor: None,
             interval_ms: 100,
             timeout_ms: 4000,
         })
         .expect("wait_for_log");
-    assert!(seen.matched, "click did not select Row 180");
+    assert!(seen.matched, "click did not select Row 060");
     glass.stop().expect("stop");
 }
 
@@ -733,8 +733,9 @@ fn scroll_to_element_reports_unmatched_for_an_absent_row() {
     let sb = seed.bounds.expect("row bounds");
     let anchor = (sb.x + sb.width as i32 / 2, sb.y + sb.height as i32 / 2);
 
-    // "Row 999" does not exist (rows are 000..199): a full bidirectional sweep must
-    // terminate with matched:false and reversed:true, not hang.
+    // "Row 999" does not exist (rows are 000..079): a full bidirectional sweep must
+    // saturate the down end, reverse, saturate the up end, and terminate with
+    // matched:false and reversed:true, not hang.
     let out = glass
         .scroll_to_element(&glass_core::ScrollToElementParams {
             name: Some("Row 999".into()),

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -75,6 +75,8 @@ pub use audit::{Actuation, ActuationContext, AuditOutcome, AuditSink, ElementRef
 
 pub mod session;
 pub use session::{
-    Backend, Glass, PlatformFactory, WaitElementOutcome, WaitElementParams, WaitLogOutcome,
-    WaitLogParams, WaitRegionOutcome, WaitRegionParams, WaitStableOutcome, WaitStableParams,
+    Backend, Glass, PlatformFactory, ScrollDirection, ScrollToElementOutcome,
+    ScrollToElementParams, WaitElementOutcome, WaitElementParams, WaitLogOutcome, WaitLogParams,
+    WaitRegionOutcome, WaitRegionParams, WaitStableOutcome, WaitStableParams,
+    SCROLL_TO_DEFAULT_STEP, SCROLL_TO_DEFAULT_TIMEOUT_MS,
 };

--- a/crates/glass-core/src/session.rs
+++ b/crates/glass-core/src/session.rs
@@ -71,6 +71,9 @@ pub struct WaitElementOutcome {
 pub const SCROLL_TO_DEFAULT_STEP: u32 = 3;
 /// Overall wall-clock bound for a `scroll_to_element` sweep.
 pub const SCROLL_TO_DEFAULT_TIMEOUT_MS: u64 = 20_000;
+/// Hard cap on scroll steps issued across a full bidirectional sweep, independent
+/// of `timeout_ms` — bounds the sweep even if the caller passes an enormous timeout.
+const SCROLL_TO_MAX_STEPS: u32 = 500;
 
 /// A vertical scroll sweep direction.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1056,6 +1059,120 @@ impl Glass {
             element: outcome.value.flatten(),
             elapsed_ms: outcome.elapsed_ms,
         })
+    }
+
+    /// Scroll a container (at `anchor`, default the active window's center) until an
+    /// element matching name/role/value realizes in the a11y tree, then return it —
+    /// its id is from the final snapshot, so it is immediately `click_element`-able.
+    /// For a virtualized list the target row is absent from the tree until scrolled
+    /// into range; this checks the current view, sweeps the primary `direction` to
+    /// its end (pixel-motion saturation = end reached), then reverses to cover the
+    /// other end. A target never realized after a full bidirectional sweep or
+    /// `timeout_ms` yields a soft `{matched:false}` (not an error), like
+    /// `wait_for_element`. The scroll actions themselves are audited via the pointer
+    /// path; there is no separate top-level audit entry.
+    pub fn scroll_to_element(
+        &mut self,
+        params: &ScrollToElementParams,
+    ) -> Result<ScrollToElementOutcome> {
+        self.require_active()?;
+        let start = std::time::Instant::now();
+        let geo = self.geometry()?;
+        let (ax, ay) = params
+            .anchor
+            .unwrap_or((geo.width as i32 / 2, geo.height as i32 / 2));
+
+        // Already realized in the current view? Return without scrolling.
+        if let Some(info) = self.match_current(params)? {
+            return Ok(ScrollToElementOutcome {
+                matched: true,
+                element: Some(info),
+                elapsed_ms: start.elapsed().as_millis() as u64,
+                steps: 0,
+                reversed: false,
+            });
+        }
+
+        // Short settle after each scroll: `saw_motion` is the ground-truth "the view
+        // moved" signal (false ⇒ this end reached). A small tolerance ignores AA noise;
+        // we only read `saw_motion`, not `settled`, so an occasional settle-timeout is
+        // harmless.
+        let settle = WaitStableParams {
+            interval_ms: 50,
+            settle_frames: 2,
+            tolerance: 2,
+            timeout_ms: 800,
+            stability_region: None,
+            window: None,
+        };
+
+        let mut steps: u32 = 0;
+        for (i, dir) in [params.direction, params.direction.opposite()]
+            .into_iter()
+            .enumerate()
+        {
+            let reversed = i == 1;
+            loop {
+                if start.elapsed().as_millis() as u64 >= params.timeout_ms
+                    || steps >= SCROLL_TO_MAX_STEPS
+                {
+                    return Ok(ScrollToElementOutcome {
+                        matched: false,
+                        element: None,
+                        elapsed_ms: start.elapsed().as_millis() as u64,
+                        steps,
+                        reversed,
+                    });
+                }
+                self.pointer(&PointerEvent::Scroll {
+                    x: ax,
+                    y: ay,
+                    dx: 0,
+                    dy: dir.dy(params.step),
+                    modifiers: vec![],
+                })?;
+                steps += 1;
+                let moved = self.wait_stable(&settle)?.saw_motion;
+                if let Some(info) = self.match_current(params)? {
+                    return Ok(ScrollToElementOutcome {
+                        matched: true,
+                        element: Some(info),
+                        elapsed_ms: start.elapsed().as_millis() as u64,
+                        steps,
+                        reversed,
+                    });
+                }
+                if !moved {
+                    break; // this end reached; sweep the opposite direction
+                }
+            }
+        }
+        Ok(ScrollToElementOutcome {
+            matched: false,
+            element: None,
+            elapsed_ms: start.elapsed().as_millis() as u64,
+            steps,
+            reversed: true,
+        })
+    }
+
+    /// Snapshot the current view and return the matched element (owned) if the
+    /// selector is satisfied, else `None`. The snapshot is cached, so a returned
+    /// element's id is usable with `click_element`.
+    fn match_current(&mut self, params: &ScrollToElementParams) -> Result<Option<ElementInfo>> {
+        let tree = self.a11y_snapshot()?;
+        Ok(
+            match element_match(
+                &tree,
+                params.name.as_deref(),
+                params.role,
+                params.value_contains.as_deref(),
+                ElementCondition::Appears,
+            ) {
+                ElementMatch::Satisfied(node) => node.map(ElementInfo::from_node),
+                ElementMatch::Pending => None,
+            },
+        )
     }
 
     /// Block until a watched region diverges from / converges to a reference.
@@ -3068,6 +3185,60 @@ mod tests {
             })
             .unwrap_err();
         assert!(matches!(err, GlassError::AxUnsupported));
+    }
+
+    #[test]
+    fn scroll_to_element_returns_already_visible_without_scrolling() {
+        // The target is present in the current view → return it immediately, steps=0,
+        // and no scroll is issued.
+        let clicks = Arc::new(Mutex::new(Vec::new()));
+        let platform = FakePlatform::new(100, 100)
+            .with_click_log(clicks)
+            .with_frames(vec![Frame::solid(100, 100, [0, 0, 0, 255])]);
+        let mut g = glass_with_a11y(platform, fake_tree()); // fake_tree has Button "Save"
+        g.start(&spec()).unwrap();
+        let out = g
+            .scroll_to_element(&ScrollToElementParams {
+                name: Some("Save".into()),
+                role: None,
+                value_contains: None,
+                direction: ScrollDirection::Down,
+                anchor: None,
+                step: SCROLL_TO_DEFAULT_STEP,
+                timeout_ms: SCROLL_TO_DEFAULT_TIMEOUT_MS,
+            })
+            .unwrap();
+        assert!(out.matched);
+        assert_eq!(out.steps, 0);
+        assert!(!out.reversed);
+        assert_eq!(out.element.unwrap().name.as_deref(), Some("Save"));
+    }
+
+    #[test]
+    fn scroll_to_element_absent_sweeps_both_ends_then_reports_unmatched() {
+        // The target never appears and the view never moves (a single repeated
+        // frame → wait_stable sees no motion), so each direction saturates after one
+        // step. The sweep must terminate (not hang), reversed, matched:false.
+        let platform =
+            FakePlatform::new(100, 100).with_frames(vec![Frame::solid(100, 100, [0, 0, 0, 255])]);
+        let mut g = glass_with_a11y(platform, fake_tree()); // no node named "Ghost"
+        g.start(&spec()).unwrap();
+        let out = g
+            .scroll_to_element(&ScrollToElementParams {
+                name: Some("Ghost".into()),
+                role: None,
+                value_contains: None,
+                direction: ScrollDirection::Down,
+                anchor: None,
+                step: SCROLL_TO_DEFAULT_STEP,
+                timeout_ms: SCROLL_TO_DEFAULT_TIMEOUT_MS,
+            })
+            .unwrap();
+        assert!(!out.matched);
+        assert!(out.element.is_none());
+        assert!(out.reversed, "must have reversed to sweep the other end");
+        // One saturating step per direction: no motion breaks each sweep immediately.
+        assert_eq!(out.steps, 2);
     }
 
     #[test]

--- a/crates/glass-core/src/session.rs
+++ b/crates/glass-core/src/session.rs
@@ -75,6 +75,10 @@ pub const SCROLL_TO_DEFAULT_TIMEOUT_MS: u64 = 20_000;
 /// of `timeout_ms` — bounds the sweep even if the caller passes an enormous timeout.
 const SCROLL_TO_MAX_STEPS: u32 = 500;
 /// Milliseconds to let scrolled rows realize in the a11y tree before re-reading.
+/// 250ms is the validated floor on the headless a11y bus: the tree is read once
+/// per step (for both the match and the end-of-scroll comparison), so a settle
+/// shorter than the toolkit's realize latency would read an unchanged tree and
+/// misfire as premature saturation.
 const SCROLL_TO_SETTLE_MS: u64 = 250;
 
 /// A vertical scroll sweep direction.
@@ -1076,6 +1080,14 @@ impl Glass {
     /// bidirectional sweep or `timeout_ms` yields a soft `{matched:false}` (not an
     /// error), like `wait_for_element`. The scroll actions are audited via the pointer
     /// path; there is no separate top-level audit entry.
+    ///
+    /// Limitations of the a11y-tree end-of-scroll signal: (1) a container holding a
+    /// continuously-repainting a11y node — a live region, a clock, a progress bar —
+    /// never leaves the tree "unchanged", so the sweep runs to `timeout_ms` in the
+    /// primary direction and returns `{matched:false}` instead of reversing; pass the
+    /// `direction` the target actually lies in to avoid the wasted sweep. (2) A very
+    /// long list can exceed `timeout_ms` before a distant target scrolls into range —
+    /// raise `timeout_ms`, or `step` to cover more per move.
     pub fn scroll_to_element(
         &mut self,
         params: &ScrollToElementParams,

--- a/crates/glass-core/src/session.rs
+++ b/crates/glass-core/src/session.rs
@@ -74,6 +74,8 @@ pub const SCROLL_TO_DEFAULT_TIMEOUT_MS: u64 = 20_000;
 /// Hard cap on scroll steps issued across a full bidirectional sweep, independent
 /// of `timeout_ms` — bounds the sweep even if the caller passes an enormous timeout.
 const SCROLL_TO_MAX_STEPS: u32 = 500;
+/// Milliseconds to let scrolled rows realize in the a11y tree before re-reading.
+const SCROLL_TO_SETTLE_MS: u64 = 250;
 
 /// A vertical scroll sweep direction.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1066,10 +1068,13 @@ impl Glass {
     /// its id is from the final snapshot, so it is immediately `click_element`-able.
     /// For a virtualized list the target row is absent from the tree until scrolled
     /// into range; this checks the current view, sweeps the primary `direction` to
-    /// its end (pixel-motion saturation = end reached), then reverses to cover the
-    /// other end. A target never realized after a full bidirectional sweep or
-    /// `timeout_ms` yields a soft `{matched:false}` (not an error), like
-    /// `wait_for_element`. The scroll actions themselves are audited via the pointer
+    /// its end, then reverses to cover the other end. End-of-scroll is detected from
+    /// the accessibility tree: when a scroll step leaves the tree's outline unchanged,
+    /// the container did not advance (immune to cosmetic repaints — a scroller's
+    /// boundary shadow, a focus ring, a blinking caret — that a pixel-motion signal
+    /// would misread as "still scrolling"). A target never realized after a full
+    /// bidirectional sweep or `timeout_ms` yields a soft `{matched:false}` (not an
+    /// error), like `wait_for_element`. The scroll actions are audited via the pointer
     /// path; there is no separate top-level audit entry.
     pub fn scroll_to_element(
         &mut self,
@@ -1082,8 +1087,10 @@ impl Glass {
             .anchor
             .unwrap_or((geo.width as i32 / 2, geo.height as i32 / 2));
 
-        // Already realized in the current view? Return without scrolling.
-        if let Some(info) = self.match_current(params)? {
+        // Snapshot the current view: return immediately if already realized, and seed
+        // the outline the first scroll step is compared against.
+        let (found, mut prev_outline) = self.snapshot_match_outline(params)?;
+        if let Some(info) = found {
             return Ok(ScrollToElementOutcome {
                 matched: true,
                 element: Some(info),
@@ -1092,19 +1099,6 @@ impl Glass {
                 reversed: false,
             });
         }
-
-        // Short settle after each scroll: `saw_motion` is the ground-truth "the view
-        // moved" signal (false ⇒ this end reached). A small tolerance ignores AA noise;
-        // we only read `saw_motion`, not `settled`, so an occasional settle-timeout is
-        // harmless.
-        let settle = WaitStableParams {
-            interval_ms: 50,
-            settle_frames: 2,
-            tolerance: 2,
-            timeout_ms: 800,
-            stability_region: None,
-            window: None,
-        };
 
         let mut steps: u32 = 0;
         for (i, dir) in [params.direction, params.direction.opposite()]
@@ -1132,8 +1126,10 @@ impl Glass {
                     modifiers: vec![],
                 })?;
                 steps += 1;
-                let moved = self.wait_stable(&settle)?.saw_motion;
-                if let Some(info) = self.match_current(params)? {
+                // Let the scrolled rows realize in the a11y tree before re-reading.
+                std::thread::sleep(std::time::Duration::from_millis(SCROLL_TO_SETTLE_MS));
+                let (found, outline) = self.snapshot_match_outline(params)?;
+                if let Some(info) = found {
                     return Ok(ScrollToElementOutcome {
                         matched: true,
                         element: Some(info),
@@ -1142,8 +1138,12 @@ impl Glass {
                         reversed,
                     });
                 }
-                if !moved {
-                    break; // this end reached; sweep the opposite direction
+                // No change in the a11y tree ⇒ the container did not advance ⇒ this
+                // end is reached; sweep the opposite direction.
+                let saturated = outline == prev_outline;
+                prev_outline = outline;
+                if saturated {
+                    break;
                 }
             }
         }
@@ -1156,23 +1156,26 @@ impl Glass {
         })
     }
 
-    /// Snapshot the current view and return the matched element (owned) if the
-    /// selector is satisfied, else `None`. The snapshot is cached, so a returned
-    /// element's id is usable with `click_element`.
-    fn match_current(&mut self, params: &ScrollToElementParams) -> Result<Option<ElementInfo>> {
+    /// Snapshot the current view once; return the matched element (if the selector is
+    /// satisfied) and the tree's outline. The snapshot is cached, so a returned
+    /// element's id is usable with `click_element`. The outline is the end-of-scroll
+    /// signal: unchanged across a scroll step ⇒ the container did not advance.
+    fn snapshot_match_outline(
+        &mut self,
+        params: &ScrollToElementParams,
+    ) -> Result<(Option<ElementInfo>, String)> {
         let tree = self.a11y_snapshot()?;
-        Ok(
-            match element_match(
-                &tree,
-                params.name.as_deref(),
-                params.role,
-                params.value_contains.as_deref(),
-                ElementCondition::Appears,
-            ) {
-                ElementMatch::Satisfied(node) => node.map(ElementInfo::from_node),
-                ElementMatch::Pending => None,
-            },
-        )
+        let found = match element_match(
+            &tree,
+            params.name.as_deref(),
+            params.role,
+            params.value_contains.as_deref(),
+            ElementCondition::Appears,
+        ) {
+            ElementMatch::Satisfied(node) => node.map(ElementInfo::from_node),
+            ElementMatch::Pending => None,
+        };
+        Ok((found, tree.to_outline()))
     }
 
     /// Block until a watched region diverges from / converges to a reference.
@@ -3191,10 +3194,7 @@ mod tests {
     fn scroll_to_element_returns_already_visible_without_scrolling() {
         // The target is present in the current view → return it immediately, steps=0,
         // and no scroll is issued.
-        let clicks = Arc::new(Mutex::new(Vec::new()));
-        let platform = FakePlatform::new(100, 100)
-            .with_click_log(clicks)
-            .with_frames(vec![Frame::solid(100, 100, [0, 0, 0, 255])]);
+        let platform = FakePlatform::new(100, 100);
         let mut g = glass_with_a11y(platform, fake_tree()); // fake_tree has Button "Save"
         g.start(&spec()).unwrap();
         let out = g
@@ -3216,11 +3216,10 @@ mod tests {
 
     #[test]
     fn scroll_to_element_absent_sweeps_both_ends_then_reports_unmatched() {
-        // The target never appears and the view never moves (a single repeated
-        // frame → wait_stable sees no motion), so each direction saturates after one
-        // step. The sweep must terminate (not hang), reversed, matched:false.
-        let platform =
-            FakePlatform::new(100, 100).with_frames(vec![Frame::solid(100, 100, [0, 0, 0, 255])]);
+        // The target never appears and the a11y tree's outline never changes (the
+        // fixture tree is fixed), so each direction saturates after one step. The
+        // sweep must terminate (not hang), reversed, matched:false.
+        let platform = FakePlatform::new(100, 100);
         let mut g = glass_with_a11y(platform, fake_tree()); // no node named "Ghost"
         g.start(&spec()).unwrap();
         let out = g

--- a/crates/glass-core/src/session.rs
+++ b/crates/glass-core/src/session.rs
@@ -97,11 +97,14 @@ impl ScrollDirection {
         }
     }
     /// Signed vertical wheel delta (notches): `Down` is positive (wheel-down),
-    /// `Up` negative.
+    /// `Up` negative. Saturates a huge `step` to `i32::MAX` so an absurd caller
+    /// value can't overflow (a plain `step as i32` would wrap, and `-(i32::MIN)`
+    /// panics in debug) — real steps are single digits.
     pub fn dy(self, step: u32) -> i32 {
+        let s = i32::try_from(step).unwrap_or(i32::MAX);
         match self {
-            ScrollDirection::Down => step as i32,
-            ScrollDirection::Up => -(step as i32),
+            ScrollDirection::Down => s,
+            ScrollDirection::Up => -s,
         }
     }
     /// Parse from a tool string (case-insensitive). `None` for unknown.
@@ -3769,6 +3772,9 @@ mod tests {
         // Down = wheel-down = positive notches; Up = negative.
         assert_eq!(ScrollDirection::Down.dy(3), 3);
         assert_eq!(ScrollDirection::Up.dy(3), -3);
+        // An absurd step saturates instead of overflowing/panicking.
+        assert_eq!(ScrollDirection::Down.dy(u32::MAX), i32::MAX);
+        assert_eq!(ScrollDirection::Up.dy(u32::MAX), -i32::MAX);
         assert_eq!(
             ScrollDirection::from_name("DOWN"),
             Some(ScrollDirection::Down)

--- a/crates/glass-core/src/session.rs
+++ b/crates/glass-core/src/session.rs
@@ -66,6 +66,76 @@ pub struct WaitElementOutcome {
     pub elapsed_ms: u64,
 }
 
+/// Wheel notches per scroll step; chosen so a step realizes at most a few rows
+/// (won't skip a virtualized row's realized band). Overridable per call.
+pub const SCROLL_TO_DEFAULT_STEP: u32 = 3;
+/// Overall wall-clock bound for a `scroll_to_element` sweep.
+pub const SCROLL_TO_DEFAULT_TIMEOUT_MS: u64 = 20_000;
+
+/// A vertical scroll sweep direction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ScrollDirection {
+    Down,
+    Up,
+}
+
+impl ScrollDirection {
+    /// The other sweep direction.
+    pub fn opposite(self) -> ScrollDirection {
+        match self {
+            ScrollDirection::Down => ScrollDirection::Up,
+            ScrollDirection::Up => ScrollDirection::Down,
+        }
+    }
+    /// Signed vertical wheel delta (notches): `Down` is positive (wheel-down),
+    /// `Up` negative.
+    pub fn dy(self, step: u32) -> i32 {
+        match self {
+            ScrollDirection::Down => step as i32,
+            ScrollDirection::Up => -(step as i32),
+        }
+    }
+    /// Parse from a tool string (case-insensitive). `None` for unknown.
+    pub fn from_name(s: &str) -> Option<ScrollDirection> {
+        match s.to_ascii_lowercase().as_str() {
+            "down" => Some(ScrollDirection::Down),
+            "up" => Some(ScrollDirection::Up),
+            _ => None,
+        }
+    }
+}
+
+/// Parameters for [`Glass::scroll_to_element`].
+#[derive(Clone, Debug)]
+pub struct ScrollToElementParams {
+    pub name: Option<String>,
+    pub role: Option<AxRole>,
+    pub value_contains: Option<String>,
+    /// Primary sweep direction; the search reverses to the other end if the
+    /// target isn't found first.
+    pub direction: ScrollDirection,
+    /// Scroll anchor (window-relative). `None` → the active window's center.
+    pub anchor: Option<(i32, i32)>,
+    /// Wheel notches issued per scroll step.
+    pub step: u32,
+    /// Overall wall-clock bound.
+    pub timeout_ms: u64,
+}
+
+/// Outcome of [`Glass::scroll_to_element`].
+#[derive(Clone, Debug)]
+pub struct ScrollToElementOutcome {
+    pub matched: bool,
+    /// The matched element (absent when `matched` is false). Its id is from the
+    /// final snapshot, so it is usable with `click_element`.
+    pub element: Option<ElementInfo>,
+    pub elapsed_ms: u64,
+    /// Total scroll steps issued across the sweep.
+    pub steps: u32,
+    /// Whether the sweep had reversed past the primary direction when it returned.
+    pub reversed: bool,
+}
+
 /// Parameters for [`Glass::wait_for_region`].
 #[derive(Clone, Debug)]
 pub struct WaitRegionParams {
@@ -3508,5 +3578,20 @@ mod tests {
             modifiers: vec![],
         })
         .unwrap();
+    }
+
+    #[test]
+    fn scroll_direction_opposite_and_dy() {
+        assert_eq!(ScrollDirection::Down.opposite(), ScrollDirection::Up);
+        assert_eq!(ScrollDirection::Up.opposite(), ScrollDirection::Down);
+        // Down = wheel-down = positive notches; Up = negative.
+        assert_eq!(ScrollDirection::Down.dy(3), 3);
+        assert_eq!(ScrollDirection::Up.dy(3), -3);
+        assert_eq!(
+            ScrollDirection::from_name("DOWN"),
+            Some(ScrollDirection::Down)
+        );
+        assert_eq!(ScrollDirection::from_name("up"), Some(ScrollDirection::Up));
+        assert_eq!(ScrollDirection::from_name("sideways"), None);
     }
 }

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -253,6 +253,31 @@ pub struct WaitForElementArgs {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct ScrollToElementArgs {
+    /// Substring of the target element's accessible name (selector). `name` and/or
+    /// `role` is required.
+    pub name: Option<String>,
+    /// Element role filter, e.g. "ListItem", "Button" (selector).
+    pub role: Option<String>,
+    /// Additionally require the matched element's `value` to contain this substring.
+    /// Not a standalone selector — `name` and/or `role` is still required.
+    pub value_contains: Option<String>,
+    /// Primary sweep direction: "down" (default) or "up". The search reverses to the
+    /// other end if the target isn't found first.
+    pub direction: Option<String>,
+    /// Scroll anchor x (window-relative). Defaults with `y` to the window center;
+    /// set both to point the wheel at a specific scrollable container.
+    pub x: Option<i32>,
+    /// Scroll anchor y (window-relative). See `x`.
+    pub y: Option<i32>,
+    /// Wheel notches per scroll step (default 3). A calibration escape hatch — larger
+    /// covers distance faster but risks stepping past a row's realized band.
+    pub step: Option<u32>,
+    /// Give up after this long (default 20000ms); returns `{matched:false}`.
+    pub timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct WaitForRegionArgs {
     /// Saved baseline name to compare against; omit to use the frame at call start.
     pub baseline: Option<String>,

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -418,6 +418,28 @@ impl GlassServer {
     }
 
     #[tool(
+        description = "Scroll a container until an accessibility element becomes visible, then \
+                       return it (text-only, no image). For a virtualized list only on-screen \
+                       rows exist in the a11y tree, so an off-screen row can't be clicked until \
+                       scrolled to; this collapses the scroll+snapshot loop into one call. Select \
+                       by `name` (accessible-name substring) and/or `role` (e.g. \"ListItem\"); \
+                       optional `value_contains`. `direction` \"down\" (default) or \"up\" — it \
+                       sweeps that way to the end, then reverses to cover the other end. Optional \
+                       `x`,`y` aim the wheel at a specific container (default: window center); \
+                       `step` sets wheel notches per move (default 3). Returns \
+                       {matched,elapsed_ms,element{id,role,name,bounds,states},scrolled{steps,reversed}} \
+                       — the id is usable with glass_click_element. Returns {matched:false} if the \
+                       element never appears after sweeping both ends or `timeout_ms` (default \
+                       20000). Errors if the app exposes no accessibility tree."
+    )]
+    async fn glass_scroll_to_element(
+        &self,
+        Parameters(a): Parameters<ScrollToElementArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        self.run(move |g| tools::scroll_to_element(g, &a)).await
+    }
+
+    #[tool(
         description = "Block until a visual region changes (diverges from a reference) or matches \
                        (converges to a saved baseline), then return text metrics (no image unless \
                        `include_image:true`). `until`: \"changes\" (default) or \"matches\" (needs \

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -867,7 +867,7 @@ mod tests {
         assert!(has_note, "IMAGE_NOTE must be present in a11y_marks output");
     }
 
-    fn started_a11y_frames(frames: Vec<glass_core::Frame>) -> Glass {
+    pub(crate) fn started_a11y_frames(frames: Vec<glass_core::Frame>) -> Glass {
         let mut g = glass_with_a11y(FakePlatform::new(100, 100).with_frames(frames), fake_tree());
         g.start(&AppSpec {
             build: None,

--- a/crates/glass-mcp/src/tools/wait.rs
+++ b/crates/glass-mcp/src/tools/wait.rs
@@ -2,8 +2,9 @@
 //! text-only JSON (region can opt into an image). Mirrors the capture-tool style.
 
 use glass_core::{
-    frame_to_webp, AxRole, ElementCondition, Glass, RegionUntil, Stream, WaitElementParams,
-    WaitLogParams, WaitRegionParams,
+    frame_to_webp, AxRole, ElementCondition, Glass, RegionUntil, ScrollDirection,
+    ScrollToElementParams, Stream, WaitElementParams, WaitLogParams, WaitRegionParams,
+    SCROLL_TO_DEFAULT_STEP, SCROLL_TO_DEFAULT_TIMEOUT_MS,
 };
 use serde_json::json;
 
@@ -44,6 +45,58 @@ pub fn wait_for_element(glass: &mut Glass, a: &WaitForElementArgs) -> ToolResult
     });
     let body =
         json!({ "matched": o.matched, "elapsed_ms": o.elapsed_ms, "element": element }).to_string();
+    Ok(ToolOutput::text(crate::untrusted::wrap_untrusted(&body)))
+}
+
+pub fn scroll_to_element(glass: &mut Glass, a: &ScrollToElementArgs) -> ToolResult {
+    if a.name.is_none() && a.role.is_none() {
+        return Err("specify `name` and/or `role` to select the element to scroll to".into());
+    }
+    let role = match a.role.as_deref() {
+        Some(r) => Some(AxRole::from_name(r).ok_or_else(|| format!("unknown role '{r}'"))?),
+        None => None,
+    };
+    let direction = match a.direction.as_deref() {
+        None => ScrollDirection::Down,
+        Some(d) => ScrollDirection::from_name(d)
+            .ok_or_else(|| format!("unknown direction '{d}' (use down/up)"))?,
+    };
+    // Anchor: both x and y, or neither (window center). One without the other is a
+    // caller mistake worth naming rather than silently half-defaulting.
+    let anchor = match (a.x, a.y) {
+        (Some(x), Some(y)) => Some((x, y)),
+        (None, None) => None,
+        _ => return Err("specify both `x` and `y` for a scroll anchor, or neither".into()),
+    };
+    let params = ScrollToElementParams {
+        name: a.name.clone(),
+        role,
+        value_contains: a.value_contains.clone(),
+        direction,
+        anchor,
+        step: a.step.unwrap_or(SCROLL_TO_DEFAULT_STEP),
+        timeout_ms: a.timeout_ms.unwrap_or(SCROLL_TO_DEFAULT_TIMEOUT_MS),
+    };
+    let o = glass
+        .scroll_to_element(&params)
+        .map_err(|e| e.to_string())?;
+    let element = o.element.map(|e| {
+        json!({
+            "id": e.id.0,
+            "role": format!("{:?}", e.role),
+            "name": e.name,
+            "value": e.value,
+            "bounds": e.bounds.map(|b| json!({ "x": b.x, "y": b.y, "width": b.width, "height": b.height })),
+            "states": e.states.active(),
+        })
+    });
+    let body = json!({
+        "matched": o.matched,
+        "elapsed_ms": o.elapsed_ms,
+        "element": element,
+        "scrolled": { "steps": o.steps, "reversed": o.reversed },
+    })
+    .to_string();
     Ok(ToolOutput::text(crate::untrusted::wrap_untrusted(&body)))
 }
 
@@ -141,6 +194,31 @@ mod tests {
     use super::*;
     use crate::tools::testutil::*;
     use glass_core::AppSpec;
+
+    #[test]
+    fn scroll_to_element_requires_a_selector() {
+        // Neither name nor role → a clear argument error, before any session work.
+        let mut g = crate::tools::tests::started_a11y_frames(vec![glass_core::Frame::solid(
+            100,
+            100,
+            [0, 0, 0, 255],
+        )]);
+        let err = scroll_to_element(
+            &mut g,
+            &ScrollToElementArgs {
+                name: None,
+                role: None,
+                value_contains: None,
+                direction: None,
+                x: None,
+                y: None,
+                step: None,
+                timeout_ms: None,
+            },
+        )
+        .unwrap_err();
+        assert!(err.contains("name") && err.contains("role"), "got: {err}");
+    }
 
     fn started_a11y() -> Glass {
         let mut g = glass_with_a11y(FakePlatform::new(100, 100), fake_tree());


### PR DESCRIPTION
## What

Adds `glass_scroll_to_element` — one call that scrolls a container and polls the accessibility tree until a name/role-matched element realizes, returning its `click_element`-able id. It collapses the old manual loop (guess-click → scroll → snapshot → repeat, calibrating notches-per-row per toolkit) into a single tool, and reaches **virtualized** rows that aren't in the a11y tree until scrolled into view.

```
glass_scroll_to_element { name?, role?, value_contains?, direction?, x?, y?, step?, timeout_ms? }
  -> { matched, elapsed_ms, element{id,role,name,value,bounds,states}, scrolled{steps,reversed} }
```

## How

- Pure `glass-core` session method (`Glass::scroll_to_element`) composing existing primitives — pointer scroll at a window-relative anchor, `a11y_snapshot`, `element_match`. No backend code, so it works on any backend with scroll + a11y.
- **Bidirectional sweep:** check the current view; sweep the primary `direction` to its end; if not found, reverse to cover the other end; soft `{matched:false}` on a full miss or timeout (like `wait_for_element`).
- **End-of-scroll is detected from the a11y tree**, not pixels: when a scroll step leaves the tree's outline unchanged, the container didn't advance. This is immune to cosmetic repaints — a `GtkScrolledWindow`'s boundary shadow, a focus ring, a blinking caret — that a pixel-motion signal misreads as "still scrolling" (which would leave the sweep unable to detect the end and reverse). The returned id comes from the final snapshot, so it resolves against the cached tree for `click_element`.

## Tests

- glass-core unit tests: `ScrollDirection` (incl. saturating `dy` on absurd input), already-visible short-circuit (`steps:0`), absent target → bidirectional termination (`steps:2, reversed:true`).
- MCP tool: selector-required arg validation.
- Real AT-SPI-bus integration tests (`#[ignore]`d, run via `scripts/test-a11y.sh`) against a **virtualized GtkListView** whose target row is genuinely absent from the initial tree: `scroll_to_element` reaches it and the returned id clicks the right row (confirmed via the fixture's stdout); an absent name completes a full bidirectional sweep and returns `{matched:false}`. Both pass with a **default** GtkScrolledWindow (boundary shadow present) — proving the a11y-tree end-of-scroll signal.
- `cargo test --workspace`, `cargo clippy --workspace --all-targets -D warnings`, `cargo fmt --all --check` all green locally.

## Known limitations (documented on the method)

- A container holding a continuously-repainting a11y node (live region, clock, progress bar) never leaves the tree "unchanged", so the sweep runs to `timeout_ms` in the primary direction rather than reversing — pass the correct `direction`.
- A very long list can exceed the default `timeout_ms` before a distant target scrolls in; raise `timeout_ms` or `step`.

Resolves #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)