### PR TITLE
docs: link the glass-drive skill's repo

### DIFF
--- a/docs/how-to/drive-glass-well.md
+++ b/docs/how-to/drive-glass-well.md
@@ -11,8 +11,9 @@ several turns rediscovering the loop by trial and error. The habits that matter:
 - **Pace drags** so a frame-based GUI samples the motion, and **reach for multi-touch** where the app
   needs it.
 
-These are packaged as **glass-drive**, an open [Agent Skill](https://agentskills.io) that works across
-agents (Claude Code, Codex, Cursor, OpenCode, …):
+These are packaged as [**glass-drive**](https://github.com/fixed-width/skills), an open
+[Agent Skill](https://agentskills.io) that works across agents (Claude Code, Codex, Cursor,
+OpenCode, …):
 
 ```bash
 npx skills add fixed-width/skills -s glass-drive


### PR DESCRIPTION
Follow-up to #102: `docs/how-to/drive-glass-well.md` names `fixed-width/skills` in the install command but didn't link the skill's repo. Adds a link on the **glass-drive** mention to https://github.com/fixed-width/skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)