### PR TITLE
fix: describe the macOS default backend correctly

### DIFF
--- a/crates/glass-mcp/src/env.rs
+++ b/crates/glass-mcp/src/env.rs
@@ -56,7 +56,7 @@ pub(crate) struct EnvVarDoc {
 pub(crate) const GLASS_ENV: &[EnvVarDoc] = &[
     EnvVarDoc { name: "GLASS_BACKEND", scope: EnvScope::All,
         purpose: "Default backend when glass_start omits `backend`",
-        default: "x11 (or windows on a Windows host)", secret: false },
+        default: "x11 (or windows on Windows, macos on macOS)", secret: false },
     EnvVarDoc { name: "GLASS_SANDBOX", scope: EnvScope::All,
         purpose: "Default containment level (off/default/strict)",
         default: "default", secret: false },
@@ -337,7 +337,7 @@ mod tests {
         // an unset non-secret shows (unset → default)
         assert!(out.contains("GLASS_BACKEND"), "{out}");
         assert!(
-            out.contains("(unset \u{2192} x11 (or windows on a Windows host))"),
+            out.contains("(unset \u{2192} x11 (or windows on Windows, macos on macOS))"),
             "{out}"
         );
         // standard-env + ignored-DISPLAY note present

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -53,8 +53,9 @@ pub struct StartArgs {
     /// Program and arguments to launch; `run[0]` is the executable.
     pub run: Vec<String>,
     /// Backend to launch under: `"x11"` or `"wayland"` (Linux), `"windows"` (on a
-    /// Windows host), or `"android"` (an AVD emulator, any host). Omit for the server
-    /// default (`GLASS_BACKEND`, else `windows` on Windows, else x11).
+    /// Windows host), `"macos"` (on a macOS host), or `"android"` (an AVD emulator, any
+    /// host). Omit for the server default (`GLASS_BACKEND`, else `windows` on Windows,
+    /// `macos` on macOS, else x11).
     pub backend: Option<String>,
     /// Containment level for the launched app: `"default"` (filesystem/process
     /// containment, network on), `"strict"` (also no network), or `"off"` (no

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -123,7 +123,7 @@ impl GlassServer {
     }
 
     #[tool(
-        description = "Build, launch, and locate a native GUI app; returns its window geometry. Optional `backend`: \"x11\" (headless Xvfb) or \"wayland\" (headless sway) on Linux, or \"windows\" on a Windows host, or \"android\" for an AVD emulator on any host; defaults to the host backend (windows on Windows, else x11). Optional `window_hint` ({ title?, class? }) picks the right window when several appear, or locates one the launched process hands off to an unrelated process (some packaged Windows apps)."
+        description = "Build, launch, and locate a native GUI app; returns its window geometry. Optional `backend`: \"x11\" (headless Xvfb) or \"wayland\" (headless sway) on Linux, or \"windows\" on a Windows host, or \"macos\" on a macOS host, or \"android\" for an AVD emulator on any host; defaults to the host backend (windows on Windows, macos on macOS, else x11). Optional `window_hint` ({ title?, class? }) picks the right window when several appear, or locates one the launched process hands off to an unrelated process (some packaged Windows apps)."
     )]
     async fn glass_start(
         &self,

--- a/docs/explanation/backends.md
+++ b/docs/explanation/backends.md
@@ -9,7 +9,8 @@ setup differs.
 ## The backend is chosen per launch
 
 The backend is selected **per `glass_start`**, via its `backend` argument. When omitted it falls back
-to `GLASS_BACKEND`, then to the host default (`windows` on a Windows host, otherwise `x11`). Because
+to `GLASS_BACKEND`, then to the host default (`windows` on a Windows host, `macos` on a macOS host,
+otherwise `x11`). Because
 the choice is per-call, an agent can drive an X11 app and a Wayland app in the same session with no
 server restart. The backend is built when the app is launched, so the server boots even on a host with
 no display or compositor at all.

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -15,7 +15,7 @@ the argument wins when both are present.
 
 | Variable | Purpose | Default | Scope |
 |---|---|---|---|
-| `GLASS_BACKEND` | Default backend when `glass_start`'s `backend` is omitted | `windows` on a Windows host, else `x11` | all |
+| `GLASS_BACKEND` | Default backend when `glass_start`'s `backend` is omitted | `windows` on a Windows host, `macos` on a macOS host, else `x11` | all |
 | `GLASS_DISPLAY` | X11 display target: unset = spawn a private headless `Xvfb`; `:N` = attach to a display you manage; `:0` = drive your real desktop | unset (private `Xvfb`) | X11 |
 | `GLASS_XVFB` | `Xvfb` binary | `Xvfb` (on `PATH`) | X11 |
 | `GLASS_XVFB_SCREEN` | Private `Xvfb` screen geometry | `1280x800x24` | X11 |

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -33,9 +33,9 @@ Build, launch, and locate a native GUI app; returns its window geometry.
 - `build` (string) — shell command run in `cwd` before launching.
 - `cwd` (string) — working directory for `build` and `run`.
 - `env` (array of `[name, value]` pairs) — extra environment for the launched app.
-- `backend` (string) — `"x11"` or `"wayland"` (Linux), `"windows"` (Windows host), or `"android"`
-  (an AVD emulator, any host). Omit for the server default (`GLASS_BACKEND`, else `windows` on
-  Windows, else `x11`).
+- `backend` (string) — `"x11"` or `"wayland"` (Linux), `"windows"` (Windows host), `"macos"` (macOS
+  host), or `"android"` (an AVD emulator, any host). Omit for the server default (`GLASS_BACKEND`,
+  else `windows` on Windows, `macos` on macOS, else `x11`).
 - `sandbox` (string) — `"default"`, `"strict"`, or `"off"`. Omit for the server default
   (`GLASS_SANDBOX`, else `default`). See [explanation/containment.md](../explanation/containment.md).
 - `window_hint` (`{ title?, class? }`) — disambiguate which window is the app's when several appear,


### PR DESCRIPTION
`default_backend()` resolves an unset `GLASS_BACKEND` to the **macos** backend on a macOS host:

```rust
None if cfg!(windows)             => "windows",
None if cfg!(target_os = "macos") => "macos",
_                                 => "x11",
```

…but the docs and the agent-facing strings all said *"windows on Windows, else x11"*, omitting macOS — so an agent reading the `glass_start` tool description on a Mac was misinformed. Fixes the tool description (`server.rs`), the `backend` param doc (`params.rs`), the `glass-mcp env` default string (`env.rs`) + its test, and the reorganized docs (`tools.md`, `environment.md`, `backends.md`).

Verified: `glass-mcp env` now prints `x11 (or windows on Windows, macos on macOS)`; fmt/clippy/test all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)