### PR TITLE
fix(doctor): correct Android deep-probe skip hint when backend not selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+### Fixed
+- `doctor --deep` no longer tells you to "run with --deep" for the Android `screencap` and
+  `uiautomator` probes when you already passed `--deep`. Those deep probes only run when
+  Android is the selected backend, so on another host backend the skip reason now points at
+  the real gate: "set `GLASS_BACKEND=android`".
+
 ## [0.3.1] - 2026-07-07
 
 ### Changed

--- a/crates/glass-android/src/doctor.rs
+++ b/crates/glass-android/src/doctor.rs
@@ -11,6 +11,13 @@ use crate::avd::{decide, parse_list_avds, resolve_emulator_bin, Action, Lifecycl
 use crate::axmap::check_dump_status;
 use crate::target::{parse_devices, Device};
 
+/// Skip detail the deep-capture checks (`screencap`, `uiautomator`) emit when `--deep`
+/// wasn't requested. Exposed so `glass-mcp` can recognise it and correct the wording when
+/// the flag *was* passed but android isn't the selected backend (the aggregator collapses
+/// `deep && android_selected` into the single bool this crate sees, so it can't tell the
+/// two cases apart itself). See `glass_mcp::doctor::soften_inactive_android`.
+pub const DEEP_NOT_REQUESTED_DETAIL: &str = "run with --deep to probe capture";
+
 /// Observed host state for the Android doctor checks. Captured by `probe`, consumed
 /// by the pure `build_checks` so all branch logic is unit-testable without subprocesses.
 struct Probe {
@@ -348,7 +355,7 @@ fn deep_checks(p: &Probe) -> (Check, Check) {
         return skip("skipped — adb unavailable");
     }
     if !p.deep_requested {
-        return skip("run with --deep to probe capture");
+        return skip(DEEP_NOT_REQUESTED_DETAIL);
     }
     let Some(d) = &p.deep else {
         return skip("no device selected to probe");

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -140,7 +140,7 @@ fn diagnose_inner(deep: bool, audit: Option<&crate::audit::AuditReport>) -> Diag
     let android_selected = backend == "android";
     let mut android_checks = glass_android::doctor::checks(deep && android_selected);
     if !android_selected {
-        soften_inactive_android(&mut android_checks);
+        soften_inactive_android(&mut android_checks, deep);
     }
     sections.push(Section::new(
         "android",
@@ -177,10 +177,17 @@ fn audit_section(report: &crate::audit::AuditReport) -> Section {
     Section::new("audit", None, vec![Check::new("audit log", status, detail)])
 }
 
-/// When android isn't the active backend, its presence checks are advisory: downgrade any
-/// `Fail` to `Warn` (noting why) so a missing adb/emulator — irrelevant to the current
-/// backend — doesn't fail the overall diagnosis. The actual status is still reported.
-fn soften_inactive_android(checks: &mut [Check]) {
+/// When android isn't the active backend, its presence checks are advisory, so adjust them
+/// to read honestly for a user on another backend:
+/// - downgrade any `Fail` to `Warn` (noting why) so a missing adb/emulator — irrelevant to
+///   the current backend — doesn't fail the overall diagnosis, and
+/// - when `--deep` *was* requested, correct the deep-capture probes' skip reason: they were
+///   gated off because android isn't the selected backend, not because `--deep` was missing.
+///   The android crate only sees the collapsed `deep && android_selected` bool, so it emits
+///   its "run with --deep" hint (which the user already did); point at the real gate instead.
+///
+/// The actual status is still reported.
+fn soften_inactive_android(checks: &mut [Check], deep_requested: bool) {
     for c in checks {
         if c.status == CheckStatus::Fail {
             c.status = CheckStatus::Warn;
@@ -188,6 +195,13 @@ fn soften_inactive_android(checks: &mut [Check]) {
                 "{} (only required when the android backend is selected)",
                 c.detail
             );
+        } else if deep_requested
+            && c.status == CheckStatus::Skip
+            && c.detail == glass_android::doctor::DEEP_NOT_REQUESTED_DETAIL
+        {
+            c.detail = "deep probes run only for the selected backend — set GLASS_BACKEND=android \
+                 to probe capture"
+                .to_string();
         }
     }
 }
@@ -328,7 +342,7 @@ mod tests {
             Check::new("agent", CheckStatus::Skip, "not configured"),
             Check::new("device", CheckStatus::Ok, "1 online"),
         ];
-        soften_inactive_android(&mut checks);
+        soften_inactive_android(&mut checks, false);
         assert_eq!(checks[0].status, CheckStatus::Warn); // Fail → Warn
         assert!(checks[0]
             .detail
@@ -337,6 +351,47 @@ mod tests {
         assert_eq!(checks[1].status, CheckStatus::Warn); // Warn untouched
         assert_eq!(checks[2].status, CheckStatus::Skip); // Skip untouched
         assert_eq!(checks[3].status, CheckStatus::Ok); // Ok untouched
+    }
+
+    #[test]
+    fn inactive_android_deep_requested_corrects_capture_skip_message() {
+        // --deep WAS passed, but android isn't the selected backend, so its deep probes were
+        // gated off. The android crate can only emit its "run with --deep" hint (it sees the
+        // collapsed bool) — which is misleading, since the user already passed --deep. The
+        // aggregator must correct it to point at the real gate (GLASS_BACKEND), not the flag.
+        let mut checks = vec![Check::new(
+            "screencap",
+            CheckStatus::Skip,
+            glass_android::doctor::DEEP_NOT_REQUESTED_DETAIL,
+        )];
+        soften_inactive_android(&mut checks, true);
+        assert_eq!(checks[0].status, CheckStatus::Skip); // still skipped, just honestly
+        assert!(
+            !checks[0].detail.contains("--deep"),
+            "must not tell the user to pass --deep — they already did: {}",
+            checks[0].detail
+        );
+        assert!(
+            checks[0].detail.contains("GLASS_BACKEND"),
+            "should point at the real gate: {}",
+            checks[0].detail
+        );
+    }
+
+    #[test]
+    fn inactive_android_deep_not_requested_keeps_run_with_deep_hint() {
+        // --deep was NOT passed: the "run with --deep" hint is the correct next step, so it
+        // must be left intact (only the `deep_requested` case is misleading).
+        let mut checks = vec![Check::new(
+            "screencap",
+            CheckStatus::Skip,
+            glass_android::doctor::DEEP_NOT_REQUESTED_DETAIL,
+        )];
+        soften_inactive_android(&mut checks, false);
+        assert_eq!(
+            checks[0].detail,
+            glass_android::doctor::DEEP_NOT_REQUESTED_DETAIL
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

`glass-mcp doctor --deep` on a non-Android host backend told the user to *"run with --deep to probe capture"* for the Android `screencap` and `uiautomator` checks — **even when `--deep` was already passed.**

```
# GLASS_BACKEND unset (host default = macos), --deep passed:
– screencap: run with --deep to probe capture      ← misleading, --deep WAS passed
– uiautomator: run with --deep to probe capture
```

## Why

The aggregator gates the Android *deep* probes on Android being the selected backend and passes the collapsed `deep && android_selected` bool into `glass_android::doctor::checks`. So when `--deep` is passed but android isn't the active backend, the android crate sees `deep = false` and can't distinguish "no `--deep`" from "`--deep`, but android isn't selected" — it emits its generic hint, which is wrong in the second case. The gating itself is intentional (a passive `doctor` on another backend shouldn't boot an AVD / install the agent as a side effect); only the wording was misleading.

## Fix

- Expose the hint as `glass_android::doctor::DEEP_NOT_REQUESTED_DETAIL` (compile-checked coupling instead of a fragile string literal).
- In `soften_inactive_android` (which already post-processes the inactive-Android checks, and knows both the CLI `deep` flag and `android_selected`), rewrite that specific skip reason to point at the real gate when `--deep` was requested:

```
– screencap: deep probes run only for the selected backend — set GLASS_BACKEND=android to probe capture
```

The adb-unavailable reason and the genuine no-`--deep` hint are left intact.

## Testing

- TDD: added `inactive_android_deep_requested_corrects_capture_skip_message` (watched it fail first) and `inactive_android_deep_not_requested_keeps_run_with_deep_hint`.
- Verified against the **real binary** (all three paths): `--deep` + adb present + android not selected → corrected message; no `--deep` → hint preserved; `--deep` + adb absent → "adb unavailable" preserved (not clobbered).
- Gate green locally: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)