### PR TITLE
Windows first-run parity: access-model doc + gated exe signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,43 @@ jobs:
           workspaces: .
       - name: Build
         run: cargo build --release -p glass-mcp --locked
+
+      # Windows Authenticode signing (Azure Trusted Signing). Until the Trusted Signing
+      # account is provisioned and its secrets are set, this SKIPS signing (exit 0) and
+      # still uploads the (unsigned) artifact — same as before. Secrets can't be read in a
+      # job-level `if:`, so we probe one here and gate the sign step on its output.
+      # Required secrets: AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET,
+      # WINDOWS_TRUSTED_SIGNING_ENDPOINT, WINDOWS_TRUSTED_SIGNING_ACCOUNT,
+      # WINDOWS_TRUSTED_SIGNING_CERT_PROFILE. Provisioning runbook: internal.
+      - name: Check signing credentials
+        id: creds
+        shell: pwsh
+        env:
+          SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+        run: |
+          if ($env:SECRET) {
+            "present=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          } else {
+            "present=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            Write-Output "::notice::Windows signing secrets not configured — shipping unsigned artifact."
+          }
+
+      - name: Sign glass-mcp.exe (Authenticode)
+        if: steps.creds.outputs.present == 'true'
+        uses: Azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: ${{ secrets.WINDOWS_TRUSTED_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.WINDOWS_TRUSTED_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ secrets.WINDOWS_TRUSTED_SIGNING_CERT_PROFILE }}
+          files-folder: target/release
+          files-folder-filter: exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
       - name: Package
         shell: pwsh
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+### Added
+- A [Windows access model](docs/explanation/windows-permissions.md) explanation: Windows needs no
+  per-app permission grants (unlike macOS), what actually gates access (interactive session, UAC/UIPI
+  integrity levels, SmartScreen on unsigned downloads), and how to get past the first-run SmartScreen
+  prompt.
+
 ### Changed
 - Installing the optional Android companions is simpler and better documented: the setup guide,
   `glass doctor`, and `glass-mcp env` now lead with the easiest path — download `glass-agent.jar`

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,3 +47,4 @@ way it does? The explanations.
 - [Backends and display isolation](explanation/backends.md)
 - [Containment and sandboxing](explanation/containment.md)
 - [The macOS permission model](explanation/macos-permissions.md)
+- [The Windows access model](explanation/windows-permissions.md)

--- a/docs/explanation/windows-permissions.md
+++ b/docs/explanation/windows-permissions.md
@@ -1,0 +1,53 @@
+# The Windows access model
+
+macOS gates screen capture and input injection behind its privacy system (TCC), so glass on the Mac
+ships as a signed app plus a LaunchAgent and walks you through two one-time grants. **Windows works
+differently: there are no per-app permissions to grant.** In a normal logged-in session, glass's three
+core capabilities all work with no consent prompt and nothing to click:
+
+- **Screen capture** (Windows.Graphics.Capture)
+- **Input injection** (SendInput)
+- **The accessibility tree** (UI Automation)
+
+This is why Windows glass ships as a plain `glass-mcp.exe` with no onboarding flow: there is no grant
+for an onboarding flow to collect. `glass-mcp doctor` verifies *environment* facts (an interactive
+session, a supported Windows build, DPI awareness, containment), never a permission grant.
+
+## What actually constrains access on Windows
+
+Three things gate what glass can reach — none of them a privacy-consent dialog.
+
+**The interactive session.** Only the active, logged-in *console* session composes a desktop that
+Windows.Graphics.Capture can grab. A process in **Session 0** — a Windows service, or a bare
+`ssh user@box` shell — has no rendering desktop, so capture has nothing to read. Run glass in a normal
+logged-in session (the doctor's `interactive session` check reports this). See
+[how-to/setup-windows.md](../how-to/setup-windows.md).
+
+**Integrity levels (UAC / UIPI).** Windows isolates processes by *integrity level*. A normal
+(medium-integrity) glass process cannot inject input into — or fully automate — a window owned by a
+**higher-integrity** process, such as an app launched *Run as administrator* or a UAC elevation prompt.
+It also cannot capture the **secure desktop** that hosts UAC prompts, the lock screen, and
+Ctrl+Alt+Del. This is the closest thing Windows has to a "permission," but it is a launch-context
+relationship, not a consent grant: to drive an elevated app, run glass at the same (elevated) integrity
+so the two processes match. Most apps run at medium integrity, where the default works with no special
+handling.
+
+**SmartScreen and Defender (distribution, not runtime).** These gate *installing* an unknown binary,
+not *what a running binary may do*. An unsigned download of `glass-mcp.exe` triggers Microsoft Defender
+SmartScreen's "Windows protected your PC" banner — a publisher-trust prompt, not an access grant. A
+signed release clears it; an unsigned build runs after **More info → Run anyway**. See the install
+steps in [how-to/setup-windows.md](../how-to/setup-windows.md).
+
+## Why there's no grant to click
+
+macOS TCC records each grant in a per-app consent database keyed to the app's code-signing identity, so
+the grant must be requested, is snapshotted at launch, and is re-checked on every rebuild. Windows has
+no such per-app capability database for capture, input, or UI Automation. Access is decided by *where
+the process runs* — its session and its integrity level — not by a stored per-app decision. Two
+consequences follow: rebuilding or moving `glass-mcp.exe` never re-prompts (there is no grant to lose),
+and glass needs no responsible-process or LaunchAgent gymnastics to hold one — the reasons the macOS
+build is packaged the way it is simply don't arise on Windows.
+
+For how launched apps are sandboxed on Windows see [explanation/containment.md](containment.md); for the
+capability matrix and requirements see [reference/platforms.md](../reference/platforms.md). The
+contrasting macOS model is in [explanation/macos-permissions.md](macos-permissions.md).

--- a/docs/how-to/setup-windows.md
+++ b/docs/how-to/setup-windows.md
@@ -34,6 +34,11 @@ copy glass-mcp.exe $env:USERPROFILE\bin\glass-mcp.exe
 (Tagged releases attach a prebuilt Windows binary; to build it yourself see
 [build-from-source.md](build-from-source.md).)
 
+> **First run — SmartScreen.** Prebuilt binaries are not yet Authenticode-signed, so the first launch
+> may show Microsoft Defender SmartScreen's "Windows protected your PC". Click **More info → Run
+> anyway**. This is a publisher-trust prompt, not a permission request — glass needs no permission
+> grants on Windows ([why](../explanation/windows-permissions.md)).
+
 ## Verify
 
 ```powershell

--- a/docs/reference/platforms.md
+++ b/docs/reference/platforms.md
@@ -28,7 +28,9 @@ explained in [explanation/backends.md](../explanation/backends.md) and
   [how-to/setup-linux.md](../how-to/setup-linux.md).
 - **Windows** — Windows 10 or 11, x86-64. No Visual C++ Redistributable needed (the binary statically
   links the VC++ runtime; the Universal CRT is built in). Drives apps on the interactive desktop, so
-  it needs a logged-in session. See [how-to/setup-windows.md](../how-to/setup-windows.md).
+  it needs a logged-in session. No permission grants are required — see
+  [explanation/windows-permissions.md](../explanation/windows-permissions.md). Setup:
+  [how-to/setup-windows.md](../how-to/setup-windows.md).
 - **macOS** — macOS 14 or later, developed and tested on Apple Silicon; the shipped `.dmg` is a
   universal binary (arm64 + x86_64), but Intel Macs aren't yet verified. Drives the logged-in Aqua
   session and is gated by the two TCC permissions. See [how-to/setup-macos.md](../how-to/setup-macos.md).

--- a/packaging/README-windows.md
+++ b/packaging/README-windows.md
@@ -37,6 +37,11 @@ mkdir $env:USERPROFILE\bin -Force
 copy glass-mcp.exe $env:USERPROFILE\bin\glass-mcp.exe
 ```
 
+> **First run — SmartScreen.** These binaries are not yet Authenticode-signed, so the first launch may
+> show Microsoft Defender SmartScreen's "Windows protected your PC". Click **More info → Run anyway**.
+> It's a publisher-trust prompt, not a permission request — glass needs no permission grants on Windows
+> (see [docs/explanation/windows-permissions.md](../docs/explanation/windows-permissions.md)).
+
 ## 3. Verify your setup
 
 glass ships a built-in checker:


### PR DESCRIPTION
## What & why

Windows first-run had two rough edges next to the macOS onboarding work. Neither is a permission-grant problem: Windows has no per-app consent system for screen capture, input injection, or UI Automation, so there is nothing for a user to grant. The real friction is (1) no explanation of that model, and (2) an unsigned `glass-mcp.exe` that trips SmartScreen on first launch. This PR addresses both.

## Changes

**1. `docs/explanation/windows-permissions.md` (new) + wiring**
- Explains that Windows needs no permission grants, what actually constrains access (the interactive session, UAC/UIPI integrity levels, and SmartScreen on unsigned downloads), and why there is no grant to click.
- Linked from the docs index, the platforms reference, the Windows setup guide, and the packaging README; adds a first-run **More info → Run anyway** SmartScreen note to the setup guide and packaging README.
- `CHANGELOG.md` `[Unreleased]` entry.

**2. Gated Authenticode signing in `.github/workflows/release.yml`**
- The `windows:` job signs `glass-mcp.exe` (before packaging, so the `.zip` and its sha256 cover the signed binary) via `Azure/artifact-signing-action`, pinned to a full commit SHA (`c7ab2a86…`, v2.0.0).
- Gated on signing secrets, mirroring the existing macOS credential gate: with no secrets set, the job builds → attests → uploads the **unsigned** artifact exactly as today. **Safe to merge before any signing account exists** — the signing step is inert until the secrets are configured.

## Verification

- Docs: all relative links resolve; rendered read-through.
- Workflow: `actionlint` clean; the pinned action SHA and every input verified against the upstream `action.yml` at that commit.
- No Rust changed, so the Rust CI gate is unaffected; `cargo fmt --all --check` is clean.
- The signed path (Authenticode) cannot run without an Azure account; its acceptance gate is a throwaway `-rc` tag dry-run once the signing secrets are provisioned — that run should confirm the signed `.exe` inside the `.zip` verifies (`Get-AuthenticodeSignature` → `Valid`) with an RFC-3161 timestamp, and that removing the secrets still ships the unsigned artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
