### PR TITLE
feat: add an iOS Simulator backend (glass-ios)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ internal refactors, CI, or test-only changes.
 ## [Unreleased]
 
 ### Added
+- An [iOS Simulator backend](docs/how-to/setup-ios.md) (`GLASS_BACKEND=ios`, macOS only): launch, capture,
+  log streaming, and clipboard for native iOS apps in the Simulator, driven through `xcrun simctl`, plus a
+  `glass doctor` preflight for Xcode, an installed iOS runtime, and an available simulator. This release is
+  observe-oriented — tapping/typing and the accessibility tree are not yet available.
 - A [Windows access model](docs/explanation/windows-permissions.md) explanation: Windows needs no
   per-app permission grants (unlike macOS), what actually gates access (interactive session, UAC/UIPI
   integrity levels, SmartScreen on unsigned downloads), and how to get past the first-run SmartScreen

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,8 @@ hardened-runtime apps fall back to unsupported), sandboxing (Seatbelt)).
 
 Cargo workspace at the repo root. Crates: `glass-core` (platform-agnostic heart — the
 `Platform`/`Accessibility` seams, session, `Frame`, diff, stability, log buffer), the
-backends (`glass-x11`, `glass-wayland`, `glass-windows`, `glass-android`), the a11y readers
+backends (`glass-x11`, `glass-wayland`, `glass-windows`, `glass-android`, `glass-ios` (the iOS
+Simulator backend over `xcrun simctl`), `glass-macos`), the a11y readers
 (`glass-a11y-linux`, `glass-a11y-windows`, `glass-a11y-macos`; the Android `uiautomator`
 reader lives in `glass-android`), `glass-sandbox-linux`, `glass-sandbox-macos`, the `glass-mcp` server binary, and the
 `glass-testapp` fixture. `glass-android` also holds the host-side client + lifecycle for two

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,9 @@ read logs, diff against baselines, wait-until-stable, and read/drive the accessi
 tree — served over MCP (stdio, or `serve --http`). Backends behind a `Platform` seam: X11
 and Wayland (headless sway) on Linux, Windows (WGC/SendInput), Android (native apps in an AVD
 emulator over `adb`, host-OS-agnostic; clipboard + high-fidelity input via an optional
-on-device companion agent), macOS (ScreenCaptureKit capture, CGEvent input, AXUIElement
+on-device companion agent), iOS (native apps in the Simulator over `xcrun simctl`; this
+release: capture, logs, clipboard — no input/accessibility yet), macOS (ScreenCaptureKit
+capture, CGEvent input, AXUIElement
 windows/logs, accessibility tree, clipboard (isolated + working under containment for
 apps not built with hardened runtime, via a `DYLD_INSERT_LIBRARIES` swizzle shim;
 hardened-runtime apps fall back to unsupported), sandboxing (Seatbelt)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +570,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -821,10 +836,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -1069,6 +1103,16 @@ dependencies = [
  "tempfile",
  "tokio",
  "zbus",
+]
+
+[[package]]
+name = "glass-ios"
+version = "0.0.0"
+dependencies = [
+ "glass-core",
+ "image",
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -1493,6 +1537,7 @@ dependencies = [
  "image-webp",
  "moxcms",
  "num-traits",
+ "png",
 ]
 
 [[package]]
@@ -1649,6 +1694,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -1937,6 +1992,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -2475,6 +2543,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,6 +1151,7 @@ dependencies = [
  "glass-a11y-windows",
  "glass-android",
  "glass-core",
+ "glass-ios",
  "glass-macos",
  "glass-sandbox-linux",
  "glass-sandbox-macos",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/glass-core", "crates/glass-x11", "crates/glass-testapp", "crates/glass-mcp", "crates/glass-wayland", "crates/glass-a11y-linux", "crates/glass-windows", "crates/glass-a11y-windows", "crates/glass-sandbox-linux", "crates/glass-proc-linux", "crates/glass-clip-hook", "crates/glass-dbus-linux", "crates/glass-android", "crates/glass-macos", "crates/glass-a11y-macos", "crates/glass-sandbox-macos", "crates/glass-clip-shim-macos"]
+members = ["crates/glass-core", "crates/glass-x11", "crates/glass-testapp", "crates/glass-mcp", "crates/glass-wayland", "crates/glass-a11y-linux", "crates/glass-windows", "crates/glass-a11y-windows", "crates/glass-sandbox-linux", "crates/glass-proc-linux", "crates/glass-clip-hook", "crates/glass-dbus-linux", "crates/glass-android", "crates/glass-macos", "crates/glass-a11y-macos", "crates/glass-sandbox-macos", "crates/glass-clip-shim-macos", "crates/glass-ios"]
 # glass-fixture-egui is intentionally excluded: heavy egui deps, only exercised by #[ignore]d
 # on-box a11y tests CI can't run. Built on-demand on the box.
 exclude = ["crates/glass-fixture-egui"]
@@ -30,6 +30,7 @@ image = { version = "0.25", default-features = false, features = ["webp"] }
 tempfile = "3"
 x11rb = { version = "0.13", features = ["xtest"] }
 glass-android = { path = "crates/glass-android" }
+glass-ios = { path = "crates/glass-ios" }
 glass-core = { path = "crates/glass-core" }
 glass-sandbox-linux = { path = "crates/glass-sandbox-linux" }
 glass-sandbox-macos = { path = "crates/glass-sandbox-macos" }

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ independently instead of asking the user "does this look right?".
 
 glass drives apps as an external black box, so it works with any native GUI app regardless of toolkit
 or language. It has two Linux backends (**X11** and **Wayland**), a **Windows** backend, an
-**Android** backend (an AVD emulator, driven over `adb` from any host), and a **macOS** backend, behind
-a platform-agnostic core.
+**Android** backend (an AVD emulator, driven over `adb` from any host), an **iOS** backend (native
+apps in the Simulator over `xcrun simctl`; this release: capture, logs, clipboard — no
+input/accessibility yet), and a **macOS** backend, behind a platform-agnostic core.
 
 ## The loop in practice
 
@@ -44,6 +45,7 @@ pinned nightly installs automatically), then set up your host:
   no build needed)
 - **Android** — [docs/how-to/setup-android.md](docs/how-to/setup-android.md) (an AVD emulator, from any
   host)
+- **iOS** — [docs/how-to/setup-ios.md](docs/how-to/setup-ios.md) (the Simulator, macOS host only)
 
 Then [connect glass to your agent](docs/how-to/connect-an-agent.md) and run `glass-mcp doctor` to check
 the environment. New here? Follow [the tutorial](docs/tutorial/first-drive.md) for a guaranteed first

--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ thing you can add** when pointing an agent at glass.
 
 <!-- KEEP IN SYNC with docs/reference/platforms.md (the canonical matrix) and the code. -->
 
-| Capability | Linux (X11 + Wayland) | Windows | Android (AVD) | macOS |
-|---|:--:|:--:|:--:|:--:|
-| Capture · input · windows · clipboard · logs | ✓ | ✓ | ✓ | ✓ |
-| Accessibility (semantic addressing) | ✓ AT-SPI | ✓ UI Automation | ✓ UIAutomator | ✓ AX |
-| Containment / sandboxing | ✓ bubblewrap | ✓ Sandboxie | ✓ the emulator VM | ✓ Seatbelt |
-| Display isolation (app off your desktop) | ✓ headless Xvfb / sway | ◑ virtual display · VM tier | ✓ headless emulator | 🚧 |
+| Capability | Linux (X11 + Wayland) | Windows | Android (AVD) | iOS (Simulator) | macOS |
+|---|:--:|:--:|:--:|:--:|:--:|
+| Capture · input · windows · clipboard · logs | ✓ | ✓ | ✓ | ◑ no input yet | ✓ |
+| Accessibility (semantic addressing) | ✓ AT-SPI | ✓ UI Automation | ✓ UIAutomator | – | ✓ AX |
+| Containment / sandboxing | ✓ bubblewrap | ✓ Sandboxie | ✓ the emulator VM | ✓ the Simulator | ✓ Seatbelt |
+| Display isolation (app off your desktop) | ✓ headless Xvfb / sway | ◑ virtual display · VM tier | ✓ headless emulator | ✓ headless simctl boot | 🚧 |
 
 Full matrix, per-capability detail, and system requirements:
 [docs/reference/platforms.md](docs/reference/platforms.md). Transport is MCP over stdio (default) or

--- a/crates/glass-ios/Cargo.toml
+++ b/crates/glass-ios/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "glass-ios"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[lib]
+bench = false
+
+[dependencies]
+glass-core.workspace = true
+serde_json.workspace = true
+tempfile.workspace = true
+image = { version = "0.25", default-features = false, features = ["png"] }
+
+[lints]
+workspace = true

--- a/crates/glass-ios/src/capture.rs
+++ b/crates/glass-ios/src/capture.rs
@@ -10,16 +10,9 @@ use crate::simctl::Simctl;
 
 /// Capture the whole device screen as an RGBA `Frame` via `simctl io <udid> screenshot`.
 ///
-/// Not yet called outside tests (nothing wires a `Simctl`/UDID pair to it yet) and, unlike
-/// the pure helpers in `device.rs`/`target.rs`, it needs a real simulator so it has no unit
-/// test either — an unconditional `allow` is required rather than the `cfg_attr(not(test),
-/// ...)` used elsewhere in this crate for items a unit test does exercise. `expect` (rather
-/// than `allow`) keeps this self-removing: it will itself fail the lint gate once a caller
-/// wires this in and the dead-code warning stops firing.
-#[expect(
-    dead_code,
-    reason = "not wired in yet; no real simulator in unit tests"
-)]
+/// Unlike the pure helpers in `device.rs`/`target.rs`, this needs a real simulator, so it
+/// has no unit test — it is exercised by `IosPlatform` and covered by the on-simulator
+/// integration suite instead.
 pub fn screenshot(simctl: &Simctl, udid: &str) -> Result<Frame> {
     let tmp = tempfile::Builder::new()
         .suffix(".png")

--- a/crates/glass-ios/src/capture.rs
+++ b/crates/glass-ios/src/capture.rs
@@ -1,0 +1,37 @@
+//! Captures the iOS Simulator screen as an RGBA `Frame`.
+//!
+//! `simctl io screenshot` only writes to a file, so a full-screen capture round-trips
+//! through a temp PNG file that is then decoded to raw RGBA. Callers crop to a region
+//! with [`glass_core::Frame::crop`].
+
+use glass_core::{Frame, GlassError, Result};
+
+use crate::simctl::Simctl;
+
+/// Capture the whole device screen as an RGBA `Frame` via `simctl io <udid> screenshot`.
+///
+/// Not yet called outside tests (nothing wires a `Simctl`/UDID pair to it yet) and, unlike
+/// the pure helpers in `device.rs`/`target.rs`, it needs a real simulator so it has no unit
+/// test either — an unconditional `allow` is required rather than the `cfg_attr(not(test),
+/// ...)` used elsewhere in this crate for items a unit test does exercise. `expect` (rather
+/// than `allow`) keeps this self-removing: it will itself fail the lint gate once a caller
+/// wires this in and the dead-code warning stops firing.
+#[expect(
+    dead_code,
+    reason = "not wired in yet; no real simulator in unit tests"
+)]
+pub fn screenshot(simctl: &Simctl, udid: &str) -> Result<Frame> {
+    let tmp = tempfile::Builder::new()
+        .suffix(".png")
+        .tempfile()
+        .map_err(|e| GlassError::CaptureFailed(format!("temp file: {e}")))?;
+    let path = tmp.path().to_string_lossy().into_owned();
+    simctl.run(&["io", udid, "screenshot", "--type", "png", &path])?;
+    let bytes = std::fs::read(&path)
+        .map_err(|e| GlassError::CaptureFailed(format!("read screenshot: {e}")))?;
+    let img = image::load_from_memory(&bytes)
+        .map_err(|e| GlassError::CaptureFailed(format!("decode PNG: {e}")))?
+        .to_rgba8();
+    let (w, h) = (img.width(), img.height());
+    Frame::new(w, h, img.into_raw())
+}

--- a/crates/glass-ios/src/device.rs
+++ b/crates/glass-ios/src/device.rs
@@ -80,11 +80,12 @@ fn is_ios_family(runtime: &str) -> bool {
 ///
 /// Order: an explicit `want_udid` always wins (attach, trusting the caller). Otherwise
 /// prefer a device that is already `Booted`, restricted to the iOS family (so a booted
-/// watchOS/tvOS/visionOS simulator is never picked up), with an iPhone preferred over any
-/// other iOS-family device on a tie. Otherwise boot the newest available iOS-family device
-/// (again preferring an iPhone), or one matching `want_name` if given — `want_name` accepts
-/// any iOS-family device, e.g. an iPad, not just an iPhone. If nothing qualifies, return an
-/// actionable error.
+/// watchOS/tvOS/visionOS simulator is never picked up); among those an iPhone is preferred
+/// over any other iOS-family device (iPhone-ness is the primary key, so an older-runtime
+/// iPhone outranks a newer-runtime iPad), and the newest runtime breaks ties within a family.
+/// Otherwise boot the newest available iOS-family device (again preferring an iPhone), or one
+/// matching `want_name` if given — `want_name` accepts any iOS-family device, e.g. an iPad,
+/// not just an iPhone. If nothing qualifies, return an actionable error.
 ///
 /// `max_by_key` keeps the *last* element on a tie, so both selections below iterate in
 /// reverse to make the *first*-listed device win a tie — one consistent policy across the

--- a/crates/glass-ios/src/device.rs
+++ b/crates/glass-ios/src/device.rs
@@ -1,0 +1,189 @@
+//! Parses `xcrun simctl list devices available --json` and decides whether to attach to a
+//! running simulator or boot one. Pure functions, no I/O — the command run and its output are
+//! wired in by the caller.
+//!
+//! These items are not yet called outside tests; a planned follow-up will use them to pick a
+//! device before driving it. Each carries a per-item `#[cfg_attr(not(test), allow(dead_code))]`
+//! so the lint stays live for any *new* code added here — remove each suppression once its item
+//! is wired in.
+
+use glass_core::{GlassError, Result};
+use serde_json::Value;
+
+/// One entry from `xcrun simctl list devices available --json`.
+#[cfg_attr(not(test), allow(dead_code))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SimDevice {
+    pub udid: String,
+    pub name: String,
+    pub state: String,
+    pub runtime: String,
+    pub is_available: bool,
+}
+
+/// Where to attach or what to boot, decided by [`resolve`].
+#[cfg_attr(not(test), allow(dead_code))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Resolve {
+    /// Attach to an already-running device by UDID.
+    Attach(String),
+    /// Boot this device (by UDID) before attaching.
+    Boot(String),
+    /// No usable device; the message explains why.
+    Error(String),
+}
+
+/// Parse `xcrun simctl list devices available --json` into a flat device list.
+#[cfg_attr(not(test), allow(dead_code))]
+pub fn parse_devices(json: &str) -> Result<Vec<SimDevice>> {
+    let v: Value = serde_json::from_str(json)
+        .map_err(|e| GlassError::Backend(format!("simctl list JSON parse failed: {e}")))?;
+    let map = v
+        .get("devices")
+        .and_then(Value::as_object)
+        .ok_or_else(|| GlassError::Backend("simctl list JSON missing `devices` object".into()))?;
+    let mut out = Vec::new();
+    for (runtime, arr) in map {
+        for d in arr.as_array().into_iter().flatten() {
+            let s = |k: &str| {
+                d.get(k)
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string()
+            };
+            out.push(SimDevice {
+                udid: s("udid"),
+                name: s("name"),
+                state: s("state"),
+                runtime: runtime.clone(),
+                is_available: d
+                    .get("isAvailable")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+            });
+        }
+    }
+    Ok(out)
+}
+
+/// Sort key so the newest runtime sorts last: compare the runtime identifier's version
+/// digits (iOS-26-5 > iOS-18-0). Falls back to 0 for an unrecognized identifier.
+#[cfg_attr(not(test), allow(dead_code))]
+fn runtime_rank(runtime: &str) -> (u32, u32) {
+    let tail = runtime.rsplit("iOS-").next().unwrap_or(runtime);
+    let mut it = tail.split('-').filter_map(|p| p.parse::<u32>().ok());
+    (it.next().unwrap_or(0), it.next().unwrap_or(0))
+}
+
+/// Decide whether to attach to a running simulator or boot one, given the current
+/// device list and the caller's optional UDID/name preference.
+///
+/// Order: an explicit `want_udid` always wins (attach, trusting the caller). Otherwise
+/// prefer a device that is already `Booted` (an iPhone over any other booted device).
+/// Otherwise boot the newest available iPhone, or one matching `want_name` if given.
+/// If nothing qualifies, return an actionable error.
+///
+/// `max_by_key` keeps the *last* element on a tie, so both selections below iterate in
+/// reverse to make the *first*-listed device win a tie — one consistent policy across the
+/// attach and boot branches.
+#[cfg_attr(not(test), allow(dead_code))]
+pub fn resolve(devices: &[SimDevice], want_udid: Option<&str>, want_name: Option<&str>) -> Resolve {
+    if let Some(u) = want_udid {
+        return Resolve::Attach(u.to_string());
+    }
+    // Tie-break only bites when several iPhones are booted at once: the first-listed wins.
+    if let Some(d) = devices
+        .iter()
+        .rev()
+        .filter(|d| d.state == "Booted")
+        .max_by_key(|d| (d.name.starts_with("iPhone"), runtime_rank(&d.runtime)))
+    {
+        return Resolve::Attach(d.udid.clone());
+    }
+    // A tie between two newest-runtime iPhones resolves to whichever came first in the listing.
+    let candidate = devices
+        .iter()
+        .rev()
+        .filter(|d| d.is_available && d.name.starts_with("iPhone"))
+        .filter(|d| want_name.is_none_or(|n| d.name == n))
+        .max_by_key(|d| runtime_rank(&d.runtime));
+    match candidate {
+        Some(d) => Resolve::Boot(d.udid.clone()),
+        None => Resolve::Error(match want_name {
+            Some(n) => format!(
+                "no available simulator named {n:?}; run `xcrun simctl list devices available`"
+            ),
+            None => "no available iPhone simulator found; install one via Xcode".into(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"{
+      "devices": {
+        "com.apple.CoreSimulator.SimRuntime.iOS-26-5": [
+          {"udid":"AAA","name":"iPhone 17","state":"Shutdown","isAvailable":true},
+          {"udid":"BBB","name":"iPhone 17 Pro","state":"Booted","isAvailable":true}
+        ],
+        "com.apple.CoreSimulator.SimRuntime.iOS-18-0": [
+          {"udid":"CCC","name":"iPhone 15","state":"Shutdown","isAvailable":true}
+        ]
+      }
+    }"#;
+
+    #[test]
+    fn parses_devices_with_runtime() {
+        let d = parse_devices(SAMPLE).unwrap();
+        assert_eq!(d.len(), 3);
+        let booted = d.iter().find(|x| x.udid == "BBB").unwrap();
+        assert_eq!(booted.state, "Booted");
+        assert!(booted.runtime.contains("iOS-26-5"));
+    }
+
+    #[test]
+    fn explicit_udid_attaches() {
+        let d = parse_devices(SAMPLE).unwrap();
+        assert_eq!(
+            resolve(&d, Some("AAA"), None),
+            Resolve::Attach("AAA".into())
+        );
+    }
+
+    #[test]
+    fn prefers_already_booted_iphone() {
+        let d = parse_devices(SAMPLE).unwrap();
+        assert_eq!(resolve(&d, None, None), Resolve::Attach("BBB".into()));
+    }
+
+    #[test]
+    fn boots_newest_iphone_when_none_booted() {
+        let mut d = parse_devices(SAMPLE).unwrap();
+        for x in &mut d {
+            x.state = "Shutdown".into();
+        }
+        // Newest runtime (iOS-26-5) iPhone wins; iPhone 17 (AAA) or 17 Pro (BBB) both qualify —
+        // tie broken by list order within the newest runtime, i.e. AAA.
+        assert_eq!(resolve(&d, None, None), Resolve::Boot("AAA".into()));
+    }
+
+    #[test]
+    fn honors_device_name() {
+        let mut d = parse_devices(SAMPLE).unwrap();
+        for x in &mut d {
+            x.state = "Shutdown".into();
+        }
+        assert_eq!(
+            resolve(&d, None, Some("iPhone 17 Pro")),
+            Resolve::Boot("BBB".into())
+        );
+    }
+
+    #[test]
+    fn errors_when_no_iphone() {
+        let d: Vec<SimDevice> = vec![];
+        assert!(matches!(resolve(&d, None, None), Resolve::Error(_)));
+    }
+}

--- a/crates/glass-ios/src/device.rs
+++ b/crates/glass-ios/src/device.rs
@@ -1,17 +1,11 @@
 //! Parses `xcrun simctl list devices available --json` and decides whether to attach to a
 //! running simulator or boot one. Pure functions, no I/O — the command run and its output are
-//! wired in by the caller.
-//!
-//! These items are not yet called outside tests; a planned follow-up will use them to pick a
-//! device before driving it. Each carries a per-item `#[cfg_attr(not(test), allow(dead_code))]`
-//! so the lint stays live for any *new* code added here — remove each suppression once its item
-//! is wired in.
+//! wired in by the caller ([`crate::target::SimTarget::from_env`]).
 
 use glass_core::{GlassError, Result};
 use serde_json::Value;
 
 /// One entry from `xcrun simctl list devices available --json`.
-#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SimDevice {
     pub udid: String,
@@ -22,7 +16,6 @@ pub struct SimDevice {
 }
 
 /// Where to attach or what to boot, decided by [`resolve`].
-#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Resolve {
     /// Attach to an already-running device by UDID.
@@ -34,7 +27,6 @@ pub enum Resolve {
 }
 
 /// Parse `xcrun simctl list devices available --json` into a flat device list.
-#[cfg_attr(not(test), allow(dead_code))]
 pub fn parse_devices(json: &str) -> Result<Vec<SimDevice>> {
     let v: Value = serde_json::from_str(json)
         .map_err(|e| GlassError::Backend(format!("simctl list JSON parse failed: {e}")))?;
@@ -68,7 +60,6 @@ pub fn parse_devices(json: &str) -> Result<Vec<SimDevice>> {
 
 /// Sort key so the newest runtime sorts last: compare the runtime identifier's version
 /// digits (iOS-26-5 > iOS-18-0). Falls back to 0 for an unrecognized identifier.
-#[cfg_attr(not(test), allow(dead_code))]
 fn runtime_rank(runtime: &str) -> (u32, u32) {
     let tail = runtime.rsplit("iOS-").next().unwrap_or(runtime);
     let mut it = tail.split('-').filter_map(|p| p.parse::<u32>().ok());
@@ -86,7 +77,6 @@ fn runtime_rank(runtime: &str) -> (u32, u32) {
 /// `max_by_key` keeps the *last* element on a tie, so both selections below iterate in
 /// reverse to make the *first*-listed device win a tie — one consistent policy across the
 /// attach and boot branches.
-#[cfg_attr(not(test), allow(dead_code))]
 pub fn resolve(devices: &[SimDevice], want_udid: Option<&str>, want_name: Option<&str>) -> Resolve {
     if let Some(u) = want_udid {
         return Resolve::Attach(u.to_string());

--- a/crates/glass-ios/src/device.rs
+++ b/crates/glass-ios/src/device.rs
@@ -59,20 +59,32 @@ pub fn parse_devices(json: &str) -> Result<Vec<SimDevice>> {
 }
 
 /// Sort key so the newest runtime sorts last: compare the runtime identifier's version
-/// digits (iOS-26-5 > iOS-18-0). Falls back to 0 for an unrecognized identifier.
+/// digits (iOS-26-5 > iOS-18-0). Falls back to `(0, 0)` — oldest — for an unrecognized
+/// identifier, so a future change to Apple's runtime-id format ranks that device as oldest
+/// rather than failing resolution outright.
 fn runtime_rank(runtime: &str) -> (u32, u32) {
     let tail = runtime.rsplit("iOS-").next().unwrap_or(runtime);
     let mut it = tail.split('-').filter_map(|p| p.parse::<u32>().ok());
     (it.next().unwrap_or(0), it.next().unwrap_or(0))
 }
 
+/// Is `runtime` an iOS (as opposed to watchOS/tvOS/visionOS) simulator runtime? The runtime
+/// identifier looks like `com.apple.CoreSimulator.SimRuntime.iOS-26-5`; the sibling platforms'
+/// identifiers (`watchOS-...`, `tvOS-...`, `xrOS-...`) do not contain the substring `iOS`.
+fn is_ios_family(runtime: &str) -> bool {
+    runtime.contains("iOS")
+}
+
 /// Decide whether to attach to a running simulator or boot one, given the current
 /// device list and the caller's optional UDID/name preference.
 ///
 /// Order: an explicit `want_udid` always wins (attach, trusting the caller). Otherwise
-/// prefer a device that is already `Booted` (an iPhone over any other booted device).
-/// Otherwise boot the newest available iPhone, or one matching `want_name` if given.
-/// If nothing qualifies, return an actionable error.
+/// prefer a device that is already `Booted`, restricted to the iOS family (so a booted
+/// watchOS/tvOS/visionOS simulator is never picked up), with an iPhone preferred over any
+/// other iOS-family device on a tie. Otherwise boot the newest available iOS-family device
+/// (again preferring an iPhone), or one matching `want_name` if given — `want_name` accepts
+/// any iOS-family device, e.g. an iPad, not just an iPhone. If nothing qualifies, return an
+/// actionable error.
 ///
 /// `max_by_key` keeps the *last* element on a tie, so both selections below iterate in
 /// reverse to make the *first*-listed device win a tie — one consistent policy across the
@@ -81,22 +93,24 @@ pub fn resolve(devices: &[SimDevice], want_udid: Option<&str>, want_name: Option
     if let Some(u) = want_udid {
         return Resolve::Attach(u.to_string());
     }
-    // Tie-break only bites when several iPhones are booted at once: the first-listed wins.
+    // Tie-break only bites when several iOS-family devices are booted at once: the
+    // first-listed wins, with an iPhone preferred over any other iOS-family device.
     if let Some(d) = devices
         .iter()
         .rev()
-        .filter(|d| d.state == "Booted")
+        .filter(|d| d.state == "Booted" && is_ios_family(&d.runtime))
         .max_by_key(|d| (d.name.starts_with("iPhone"), runtime_rank(&d.runtime)))
     {
         return Resolve::Attach(d.udid.clone());
     }
-    // A tie between two newest-runtime iPhones resolves to whichever came first in the listing.
+    // A tie between two newest-runtime iOS-family devices resolves to whichever came first
+    // in the listing, with an iPhone preferred over any other iOS-family device.
     let candidate = devices
         .iter()
         .rev()
-        .filter(|d| d.is_available && d.name.starts_with("iPhone"))
+        .filter(|d| d.is_available && is_ios_family(&d.runtime))
         .filter(|d| want_name.is_none_or(|n| d.name == n))
-        .max_by_key(|d| runtime_rank(&d.runtime));
+        .max_by_key(|d| (d.name.starts_with("iPhone"), runtime_rank(&d.runtime)));
     match candidate {
         Some(d) => Resolve::Boot(d.udid.clone()),
         None => Resolve::Error(match want_name {
@@ -175,5 +189,100 @@ mod tests {
     fn errors_when_no_iphone() {
         let d: Vec<SimDevice> = vec![];
         assert!(matches!(resolve(&d, None, None), Resolve::Error(_)));
+    }
+
+    #[test]
+    fn attach_prefers_first_listed_among_equal_rank_booted_iphones() {
+        let json = r#"{
+          "devices": {
+            "com.apple.CoreSimulator.SimRuntime.iOS-26-5": [
+              {"udid":"AAA","name":"iPhone 17","state":"Booted","isAvailable":true},
+              {"udid":"BBB","name":"iPhone 17 Pro","state":"Booted","isAvailable":true}
+            ]
+          }
+        }"#;
+        let d = parse_devices(json).unwrap();
+        assert_eq!(resolve(&d, None, None), Resolve::Attach("AAA".into()));
+    }
+
+    #[test]
+    fn booted_watch_is_not_attached_iphone_boots_instead() {
+        let json = r#"{
+          "devices": {
+            "com.apple.CoreSimulator.SimRuntime.watchOS-10-4": [
+              {"udid":"WWW","name":"Apple Watch Series 9","state":"Booted","isAvailable":true}
+            ],
+            "com.apple.CoreSimulator.SimRuntime.iOS-26-5": [
+              {"udid":"AAA","name":"iPhone 17","state":"Shutdown","isAvailable":true}
+            ]
+          }
+        }"#;
+        let d = parse_devices(json).unwrap();
+        assert_eq!(resolve(&d, None, None), Resolve::Boot("AAA".into()));
+    }
+
+    #[test]
+    fn booted_watch_only_errors_when_no_iphone_available() {
+        let json = r#"{
+          "devices": {
+            "com.apple.CoreSimulator.SimRuntime.watchOS-10-4": [
+              {"udid":"WWW","name":"Apple Watch Series 9","state":"Booted","isAvailable":true}
+            ]
+          }
+        }"#;
+        let d = parse_devices(json).unwrap();
+        assert!(matches!(resolve(&d, None, None), Resolve::Error(_)));
+    }
+
+    #[test]
+    fn explicit_device_name_boots_a_named_ipad() {
+        let json = r#"{
+          "devices": {
+            "com.apple.CoreSimulator.SimRuntime.iOS-26-5": [
+              {"udid":"III","name":"iPad Pro 13-inch","state":"Shutdown","isAvailable":true}
+            ]
+          }
+        }"#;
+        let d = parse_devices(json).unwrap();
+        assert_eq!(
+            resolve(&d, None, Some("iPad Pro 13-inch")),
+            Resolve::Boot("III".into())
+        );
+    }
+
+    #[test]
+    fn booted_ipad_is_attached_when_no_iphone_booted() {
+        let json = r#"{
+          "devices": {
+            "com.apple.CoreSimulator.SimRuntime.iOS-26-5": [
+              {"udid":"III","name":"iPad Pro 13-inch","state":"Booted","isAvailable":true}
+            ]
+          }
+        }"#;
+        let d = parse_devices(json).unwrap();
+        assert_eq!(resolve(&d, None, None), Resolve::Attach("III".into()));
+    }
+
+    #[test]
+    fn unavailable_iphone_with_nothing_else_errors() {
+        let json = r#"{
+          "devices": {
+            "com.apple.CoreSimulator.SimRuntime.iOS-26-5": [
+              {"udid":"AAA","name":"iPhone 17","state":"Shutdown","isAvailable":false}
+            ]
+          }
+        }"#;
+        let d = parse_devices(json).unwrap();
+        assert!(matches!(resolve(&d, None, None), Resolve::Error(_)));
+    }
+
+    #[test]
+    fn parse_devices_rejects_non_json() {
+        assert!(parse_devices("not json").is_err());
+    }
+
+    #[test]
+    fn parse_devices_rejects_json_missing_devices_key() {
+        assert!(parse_devices(r#"{"foo":1}"#).is_err());
     }
 }

--- a/crates/glass-ios/src/doctor.rs
+++ b/crates/glass-ios/src/doctor.rs
@@ -5,6 +5,8 @@
 //! Pure `build_checks(&Probe)` over observed state, plus the thin subprocess-probing
 //! `checks(deep)` entry point the aggregator calls.
 
+use std::process::Command;
+
 use glass_core::{Check, CheckStatus};
 
 /// Observed host state for the iOS doctor checks. Captured by `run`, consumed by the
@@ -97,8 +99,6 @@ fn device_check(p: &Probe) -> Check {
 /// not-ok with a remedy, rather than failing this function. `_deep` is accepted for
 /// signature parity with the other backends' doctors; iOS has no expensive deep probe.
 pub fn checks(_deep: bool) -> Vec<Check> {
-    use std::process::Command;
-
     let xcode_dir = Command::new("xcode-select")
         .arg("-p")
         .output()
@@ -168,6 +168,30 @@ mod tests {
         assert_eq!(xcode.status, CheckStatus::Fail);
         assert!(
             xcode.remedy.as_deref().unwrap().contains("full Xcode"),
+            "{:?}",
+            xcode.remedy
+        );
+        // CLT-only also means `simctl` itself is unavailable — assert that check fails too,
+        // not just `xcode`.
+        assert_eq!(
+            cs.iter().find(|c| c.name == "simctl").unwrap().status,
+            CheckStatus::Fail
+        );
+    }
+
+    #[test]
+    fn no_active_developer_directory_fails_with_install_xcode_remedy() {
+        let p = Probe {
+            xcode_dir: None,
+            simctl_ok: false,
+            runtimes: &[],
+            iphones: &[],
+        };
+        let cs = build_checks(&p);
+        let xcode = cs.iter().find(|c| c.name == "xcode").unwrap();
+        assert_eq!(xcode.status, CheckStatus::Fail);
+        assert!(
+            xcode.remedy.as_deref().unwrap().contains("Xcode"),
             "{:?}",
             xcode.remedy
         );

--- a/crates/glass-ios/src/doctor.rs
+++ b/crates/glass-ios/src/doctor.rs
@@ -1,0 +1,194 @@
+//! `glass doctor` checks for the iOS Simulator backend: is a full Xcode install active,
+//! does `xcrun simctl` work, is at least one iOS runtime downloaded, and is an iPhone
+//! simulator available to run apps on?
+//!
+//! Pure `build_checks(&Probe)` over observed state, plus the thin subprocess-probing
+//! `checks(deep)` entry point the aggregator calls.
+
+use glass_core::{Check, CheckStatus};
+
+/// Observed host state for the iOS doctor checks. Captured by `run`, consumed by the
+/// pure `checks` so all branch logic is unit-testable without subprocesses.
+pub struct Probe<'a> {
+    /// `xcode-select -p` output: the active developer directory, if any.
+    pub xcode_dir: Option<String>,
+    /// Whether `xcrun simctl help` ran successfully.
+    pub simctl_ok: bool,
+    /// iOS runtime lines from `xcrun simctl list runtimes`.
+    pub runtimes: &'a [String],
+    /// iPhone simulator lines from `xcrun simctl list devices available`.
+    pub iphones: &'a [String],
+}
+
+const INSTALL_XCODE_REMEDY: &str =
+    "install full Xcode and run `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`";
+
+/// Build the iOS doctor checks from observed state. Pure — no OS calls — so all branch
+/// logic is unit-testable without subprocesses.
+fn build_checks(p: &Probe) -> Vec<Check> {
+    vec![
+        xcode_check(p),
+        simctl_check(p),
+        runtime_check(p),
+        device_check(p),
+    ]
+}
+
+fn xcode_check(p: &Probe) -> Check {
+    match &p.xcode_dir {
+        Some(dir) if dir.contains("Xcode.app") => Check::new(
+            "xcode",
+            CheckStatus::Ok,
+            format!("active developer dir: {dir}"),
+        ),
+        Some(dir) => Check::new(
+            "xcode",
+            CheckStatus::Fail,
+            format!("active developer dir is Command Line Tools only: {dir}"),
+        )
+        .with_remedy(INSTALL_XCODE_REMEDY),
+        None => Check::new("xcode", CheckStatus::Fail, "no active developer directory")
+            .with_remedy("install Xcode from the App Store"),
+    }
+}
+
+fn simctl_check(p: &Probe) -> Check {
+    if p.simctl_ok {
+        Check::new("simctl", CheckStatus::Ok, "xcrun simctl is available")
+    } else {
+        Check::new("simctl", CheckStatus::Fail, "xcrun simctl is unavailable")
+            .with_remedy(INSTALL_XCODE_REMEDY)
+    }
+}
+
+fn runtime_check(p: &Probe) -> Check {
+    if p.runtimes.is_empty() {
+        Check::new(
+            "runtime",
+            CheckStatus::Fail,
+            "no iOS simulator runtime installed",
+        )
+        .with_remedy("download one with `xcodebuild -downloadPlatform iOS`")
+    } else {
+        Check::new(
+            "runtime",
+            CheckStatus::Ok,
+            format!("iOS runtimes: {}", p.runtimes.join(", ")),
+        )
+    }
+}
+
+fn device_check(p: &Probe) -> Check {
+    if p.iphones.is_empty() {
+        Check::new("device", CheckStatus::Fail, "no iPhone simulator available").with_remedy(
+            "create one in Xcode (Window > Devices and Simulators) or with `xcrun simctl create`",
+        )
+    } else {
+        Check::new(
+            "device",
+            CheckStatus::Ok,
+            format!("{} iPhone simulator(s) available", p.iphones.len()),
+        )
+    }
+}
+
+/// Build the iOS doctor checks by probing the host with real `xcrun`/`xcode-select`
+/// calls. Best-effort: a missing tool simply makes the corresponding check report
+/// not-ok with a remedy, rather than failing this function. `_deep` is accepted for
+/// signature parity with the other backends' doctors; iOS has no expensive deep probe.
+pub fn checks(_deep: bool) -> Vec<Check> {
+    use std::process::Command;
+
+    let xcode_dir = Command::new("xcode-select")
+        .arg("-p")
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
+
+    let simctl_out = |args: &[&str]| {
+        Command::new("xcrun")
+            .args(args)
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
+    };
+
+    let simctl_ok = simctl_out(&["simctl", "help"]).is_some();
+    let runtimes: Vec<String> = simctl_out(&["simctl", "list", "runtimes"])
+        .unwrap_or_default()
+        .lines()
+        .filter(|l| l.contains("iOS"))
+        .map(|l| l.trim().to_string())
+        .collect();
+    let iphones: Vec<String> = simctl_out(&["simctl", "list", "devices", "available"])
+        .unwrap_or_default()
+        .lines()
+        .filter(|l| l.contains("iPhone"))
+        .map(|l| l.trim().to_string())
+        .collect();
+
+    build_checks(&Probe {
+        xcode_dir,
+        simctl_ok,
+        runtimes: &runtimes,
+        iphones: &iphones,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_green_when_fully_configured() {
+        let runtimes = vec!["iOS 26.5".to_string()];
+        let iphones = vec!["iPhone 17".to_string()];
+        let p = Probe {
+            xcode_dir: Some("/Applications/Xcode.app/Contents/Developer".into()),
+            simctl_ok: true,
+            runtimes: &runtimes,
+            iphones: &iphones,
+        };
+        let cs = build_checks(&p);
+        assert!(cs.iter().all(|c| c.status == CheckStatus::Ok), "{cs:?}");
+    }
+
+    #[test]
+    fn flags_command_line_tools_only() {
+        let p = Probe {
+            xcode_dir: Some("/Library/Developer/CommandLineTools".into()),
+            simctl_ok: false,
+            runtimes: &[],
+            iphones: &[],
+        };
+        let cs = build_checks(&p);
+        let xcode = cs.iter().find(|c| c.name == "xcode").unwrap();
+        assert_eq!(xcode.status, CheckStatus::Fail);
+        assert!(
+            xcode.remedy.as_deref().unwrap().contains("full Xcode"),
+            "{:?}",
+            xcode.remedy
+        );
+    }
+
+    #[test]
+    fn flags_missing_runtime_and_device() {
+        let p = Probe {
+            xcode_dir: Some("/Applications/Xcode.app/Contents/Developer".into()),
+            simctl_ok: true,
+            runtimes: &[],
+            iphones: &[],
+        };
+        let cs = build_checks(&p);
+        assert_eq!(
+            cs.iter().find(|c| c.name == "runtime").unwrap().status,
+            CheckStatus::Fail
+        );
+        assert_eq!(
+            cs.iter().find(|c| c.name == "device").unwrap().status,
+            CheckStatus::Fail
+        );
+    }
+}

--- a/crates/glass-ios/src/lib.rs
+++ b/crates/glass-ios/src/lib.rs
@@ -3,8 +3,7 @@
 //! macOS-only in practice (the tools are Apple's), but the code links nothing
 //! platform-specific — it shells out. The Simulator is the isolation boundary,
 //! so there is no sandbox machinery here. Input and the accessibility tree are
-//! not implemented yet; a planned follow-up will add them via an on-simulator
-//! driver.
+//! not implemented yet.
 #![forbid(unsafe_code)]
 
 mod capture;

--- a/crates/glass-ios/src/lib.rs
+++ b/crates/glass-ios/src/lib.rs
@@ -11,8 +11,10 @@ mod capture;
 mod device;
 pub mod doctor;
 mod logs;
+mod platform;
 mod simctl;
 mod target;
 
+pub use platform::IosPlatform;
 pub use simctl::Simctl;
 pub use target::{SimTarget, SimulatorRegistry};

--- a/crates/glass-ios/src/lib.rs
+++ b/crates/glass-ios/src/lib.rs
@@ -1,0 +1,12 @@
+//! iOS Simulator backend for glass: drives native apps over `xcrun simctl`.
+//!
+//! macOS-only in practice (the tools are Apple's), but the code links nothing
+//! platform-specific — it shells out. The Simulator is the isolation boundary,
+//! so there is no sandbox machinery here. Input and the accessibility tree are
+//! not implemented yet; a planned follow-up will add them via an on-simulator
+//! driver.
+#![forbid(unsafe_code)]
+
+mod simctl;
+
+pub use simctl::Simctl;

--- a/crates/glass-ios/src/lib.rs
+++ b/crates/glass-ios/src/lib.rs
@@ -9,6 +9,7 @@
 
 mod capture;
 mod device;
+mod logs;
 mod simctl;
 mod target;
 

--- a/crates/glass-ios/src/lib.rs
+++ b/crates/glass-ios/src/lib.rs
@@ -9,6 +9,7 @@
 
 mod capture;
 mod device;
+pub mod doctor;
 mod logs;
 mod simctl;
 mod target;

--- a/crates/glass-ios/src/lib.rs
+++ b/crates/glass-ios/src/lib.rs
@@ -7,6 +7,7 @@
 //! driver.
 #![forbid(unsafe_code)]
 
+mod device;
 mod simctl;
 
 pub use simctl::Simctl;

--- a/crates/glass-ios/src/lib.rs
+++ b/crates/glass-ios/src/lib.rs
@@ -9,5 +9,7 @@
 
 mod device;
 mod simctl;
+mod target;
 
 pub use simctl::Simctl;
+pub use target::{SimTarget, SimulatorRegistry};

--- a/crates/glass-ios/src/lib.rs
+++ b/crates/glass-ios/src/lib.rs
@@ -7,6 +7,7 @@
 //! driver.
 #![forbid(unsafe_code)]
 
+mod capture;
 mod device;
 mod simctl;
 mod target;

--- a/crates/glass-ios/src/logs.rs
+++ b/crates/glass-ios/src/logs.rs
@@ -8,14 +8,9 @@ use std::sync::{Arc, Mutex};
 use glass_core::Stream;
 
 /// Thread-safe line buffer shared between the pump thread and `drain`.
-///
-/// Used directly by the unit test below; not yet constructed outside tests until
-/// `LogStream` is wired into a target.
-#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Clone, Default)]
 pub struct SharedLog(Arc<Mutex<Vec<(Stream, String)>>>);
 
-#[cfg_attr(not(test), allow(dead_code))]
 impl SharedLog {
     /// Append a line. A poisoned lock means some other thread already panicked while
     /// holding it, so propagating here (rather than swallowing the line) surfaces that
@@ -31,26 +26,14 @@ impl SharedLog {
 }
 
 /// A running `xcrun simctl spawn <udid> log stream` whose lines feed a [`SharedLog`].
-///
-/// Not yet constructed anywhere; a planned follow-up attaches it to a target alongside
-/// capture and input.
-#[expect(
-    dead_code,
-    reason = "not wired in yet; a planned follow-up attaches it to a target"
-)]
 pub struct LogStream {
     child: Option<Child>,
     buf: SharedLog,
 }
 
-#[expect(
-    dead_code,
-    reason = "not wired in yet; a planned follow-up attaches it to a target"
-)]
 impl LogStream {
     /// Stream the device's unified log. `log stream` prints all system logs; that is
-    /// noisy but honest — callers filter. A planned follow-up can narrow it with
-    /// `--predicate`.
+    /// noisy but honest — callers filter.
     ///
     /// Best-effort: if `xcrun` fails to spawn, `child` is `None` and `drain` simply
     /// yields nothing, matching the sibling Android backend's behavior when `adb` is

--- a/crates/glass-ios/src/logs.rs
+++ b/crates/glass-ios/src/logs.rs
@@ -12,16 +12,21 @@ use glass_core::Stream;
 pub struct SharedLog(Arc<Mutex<Vec<(Stream, String)>>>);
 
 impl SharedLog {
-    /// Append a line. A poisoned lock means some other thread already panicked while
-    /// holding it, so propagating here (rather than swallowing the line) surfaces that
-    /// failure instead of silently continuing with a possibly-inconsistent buffer.
+    /// Append a line. A poisoned lock (some other thread already panicked while holding it)
+    /// simply drops the line rather than panicking here too, matching `glass-android`'s
+    /// `LogSink`.
     pub fn push(&self, stream: Stream, line: String) {
-        self.0.lock().expect("log lock").push((stream, line));
+        if let Ok(mut g) = self.0.lock() {
+            g.push((stream, line));
+        }
     }
 
     /// Take and clear all buffered lines.
     pub fn drain(&self) -> Vec<(Stream, String)> {
-        std::mem::take(&mut *self.0.lock().expect("log lock"))
+        self.0
+            .lock()
+            .map(|mut g| std::mem::take(&mut *g))
+            .unwrap_or_default()
     }
 }
 
@@ -72,6 +77,8 @@ impl Drop for LogStream {
     fn drop(&mut self) {
         if let Some(mut c) = self.child.take() {
             let _ = c.kill();
+            // Reap it so it doesn't linger as a zombie once killed.
+            let _ = c.wait();
         }
     }
 }

--- a/crates/glass-ios/src/logs.rs
+++ b/crates/glass-ios/src/logs.rs
@@ -1,0 +1,115 @@
+//! Streams the device's unified log via `xcrun simctl spawn <udid> log stream` into a
+//! drainable buffer, mirroring the `LogcatStream` pattern in `glass-android`.
+
+use std::io::{BufRead, BufReader};
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex};
+
+use glass_core::Stream;
+
+/// Thread-safe line buffer shared between the pump thread and `drain`.
+///
+/// Used directly by the unit test below; not yet constructed outside tests until
+/// `LogStream` is wired into a target.
+#[cfg_attr(not(test), allow(dead_code))]
+#[derive(Clone, Default)]
+pub struct SharedLog(Arc<Mutex<Vec<(Stream, String)>>>);
+
+#[cfg_attr(not(test), allow(dead_code))]
+impl SharedLog {
+    /// Append a line. A poisoned lock means some other thread already panicked while
+    /// holding it, so propagating here (rather than swallowing the line) surfaces that
+    /// failure instead of silently continuing with a possibly-inconsistent buffer.
+    pub fn push(&self, stream: Stream, line: String) {
+        self.0.lock().expect("log lock").push((stream, line));
+    }
+
+    /// Take and clear all buffered lines.
+    pub fn drain(&self) -> Vec<(Stream, String)> {
+        std::mem::take(&mut *self.0.lock().expect("log lock"))
+    }
+}
+
+/// A running `xcrun simctl spawn <udid> log stream` whose lines feed a [`SharedLog`].
+///
+/// Not yet constructed anywhere; a planned follow-up attaches it to a target alongside
+/// capture and input.
+#[expect(
+    dead_code,
+    reason = "not wired in yet; a planned follow-up attaches it to a target"
+)]
+pub struct LogStream {
+    child: Option<Child>,
+    buf: SharedLog,
+}
+
+#[expect(
+    dead_code,
+    reason = "not wired in yet; a planned follow-up attaches it to a target"
+)]
+impl LogStream {
+    /// Stream the device's unified log. `log stream` prints all system logs; that is
+    /// noisy but honest — callers filter. A planned follow-up can narrow it with
+    /// `--predicate`.
+    ///
+    /// Best-effort: if `xcrun` fails to spawn, `child` is `None` and `drain` simply
+    /// yields nothing, matching the sibling Android backend's behavior when `adb` is
+    /// unavailable.
+    pub fn spawn(udid: &str) -> Self {
+        let buf = SharedLog::default();
+        // Take the piped stdout before storing `child` — reading `child.stdout` after
+        // moving `child` into `Self` would not borrow-check.
+        let mut child = Command::new("xcrun")
+            .args([
+                "simctl", "spawn", udid, "log", "stream", "--style", "compact",
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .ok();
+        let out = child.as_mut().and_then(|c| c.stdout.take());
+        if let Some(out) = out {
+            let sink = buf.clone();
+            std::thread::spawn(move || {
+                for line in BufReader::new(out).lines().map_while(Result::ok) {
+                    sink.push(Stream::Stdout, line);
+                }
+            });
+        }
+        Self { child, buf }
+    }
+
+    /// Take and clear all buffered lines since the last drain.
+    pub fn drain(&self) -> Vec<(Stream, String)> {
+        self.buf.drain()
+    }
+}
+
+impl Drop for LogStream {
+    fn drop(&mut self) {
+        if let Some(mut c) = self.child.take() {
+            let _ = c.kill();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use glass_core::Stream;
+
+    #[test]
+    fn drain_returns_and_clears_buffer() {
+        let buf = SharedLog::default();
+        buf.push(Stream::Stdout, "line-1".into());
+        buf.push(Stream::Stdout, "line-2".into());
+        assert_eq!(
+            buf.drain(),
+            vec![
+                (Stream::Stdout, "line-1".to_string()),
+                (Stream::Stdout, "line-2".to_string()),
+            ]
+        );
+        assert!(buf.drain().is_empty(), "second drain is empty");
+    }
+}

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -11,7 +11,6 @@ use glass_core::{
 
 use crate::capture::screenshot;
 use crate::logs::LogStream;
-use crate::simctl::Simctl;
 use crate::target::{SimTarget, SimulatorRegistry};
 
 /// The single foreground app this backend drives.
@@ -24,9 +23,17 @@ struct RunningApp {
 /// Drives a native app on an iOS Simulator over `xcrun simctl`. A single foreground app at a
 /// time, reported as one fullscreen window; there is no window management to speak of.
 pub struct IosPlatform {
-    simctl: Simctl,
-    udid: String,
+    target: SimTarget,
     app: Option<RunningApp>,
+}
+
+/// The Simulator reports exactly one fullscreen window per running app.
+const IOS_WINDOW_ID: WindowId = WindowId(1);
+
+/// Does `s` name an on-disk `.app` bundle path, as opposed to a bare bundle id of an app
+/// already installed on the simulator?
+fn looks_like_app_path(s: &str) -> bool {
+    s.ends_with(".app") || s.contains('/')
 }
 
 /// Split `spec.run` into `(optional install path, bundle id)`. `run[0]` naming a path (it
@@ -37,7 +44,7 @@ pub(crate) fn bundle_id_from_run(run: &[String]) -> Result<(Option<String>, Stri
     let first = run
         .first()
         .ok_or_else(|| GlassError::Backend("cannot start app: run command is empty".into()))?;
-    if first.ends_with(".app") || first.contains('/') {
+    if looks_like_app_path(first) {
         let plist = format!("{first}/Info.plist");
         let out = Command::new("plutil")
             .args(["-extract", "CFBundleIdentifier", "raw", "-o", "-", &plist])
@@ -45,7 +52,8 @@ pub(crate) fn bundle_id_from_run(run: &[String]) -> Result<(Option<String>, Stri
             .map_err(|e| GlassError::Backend(format!("plutil: {e}")))?;
         if !out.status.success() {
             return Err(GlassError::Backend(format!(
-                "could not read CFBundleIdentifier from {plist}"
+                "could not read CFBundleIdentifier from {plist}: {}",
+                String::from_utf8_lossy(&out.stderr).trim()
             )));
         }
         let bundle_id = String::from_utf8_lossy(&out.stdout).trim().to_string();
@@ -59,11 +67,7 @@ impl IosPlatform {
     /// Resolve (attaching to or booting) a simulator per the `GLASS_IOS_*` env vars.
     pub fn from_env(reg: &SimulatorRegistry) -> Result<Self> {
         let target = SimTarget::from_env(reg)?;
-        Ok(Self {
-            simctl: target.simctl().clone(),
-            udid: target.udid().to_string(),
-            app: None,
-        })
+        Ok(Self { target, app: None })
     }
 
     fn running(&self) -> Result<&RunningApp> {
@@ -74,29 +78,55 @@ impl IosPlatform {
 impl Platform for IosPlatform {
     fn start_app(&mut self, spec: &AppSpec) -> Result<WindowGeometry> {
         if let Some(build) = &spec.build {
-            let status = Command::new("sh")
-                .arg("-c")
-                .arg(build)
+            let mut cmd = Command::new("sh");
+            cmd.arg("-c").arg(build);
+            if let Some(dir) = &spec.cwd {
+                cmd.current_dir(dir);
+            }
+            cmd.envs(spec.env.iter().map(|(k, v)| (k, v)));
+            let status = cmd
                 .status()
                 .map_err(|e| GlassError::Backend(format!("build step: {e}")))?;
             if !status.success() {
-                return Err(GlassError::Backend("build step failed".into()));
+                return Err(GlassError::Backend(format!(
+                    "build command failed with status {status}"
+                )));
             }
         }
 
+        let udid = self.target.udid();
         let (install, bundle_id) = bundle_id_from_run(&spec.run)?;
         if let Some(path) = install {
-            self.simctl.run(&["install", &self.udid, &path])?;
+            self.target.simctl().run(&["install", udid, &path])?;
         }
-        self.simctl.run(&[
+        // `SIMCTL_CHILD_<KEY>` is Apple's convention for passing environment variables through
+        // `simctl launch` to the launched process, so `spec.env` is set that way rather than on
+        // this (glass's own) process.
+        let mut launch = Command::new(self.target.simctl().program());
+        launch.args(self.target.simctl().full_args(&[
             "launch",
             "--terminate-running-process",
-            &self.udid,
+            udid,
             &bundle_id,
-        ])?;
+        ]));
+        for (k, v) in &spec.env {
+            launch.env(format!("SIMCTL_CHILD_{k}"), v);
+        }
+        let out = launch
+            .output()
+            .map_err(|e| GlassError::Backend(format!("simctl launch: {e}")))?;
+        if !out.status.success() {
+            return Err(GlassError::Backend(format!(
+                "simctl launch failed: {}",
+                String::from_utf8_lossy(&out.stderr).trim()
+            )));
+        }
 
-        // Capture once, purely to learn the device's pixel dimensions for the geometry we report.
-        let frame = screenshot(&self.simctl, &self.udid)?;
+        // Capture once, purely to learn the device's pixel dimensions for the geometry we
+        // report. These are device *pixels* (the screenshot's raw resolution), not UIKit
+        // points — the two differ by the device's point-to-pixel scale factor, which will
+        // matter once pointer input is added.
+        let frame = screenshot(self.target.simctl(), udid)?;
         let geometry = WindowGeometry {
             x: 0,
             y: 0,
@@ -106,20 +136,24 @@ impl Platform for IosPlatform {
         self.app = Some(RunningApp {
             bundle_id,
             geometry: geometry.clone(),
-            logs: LogStream::spawn(&self.udid),
+            logs: LogStream::spawn(udid),
         });
         Ok(geometry)
     }
 
     fn stop_app(&mut self) -> Result<()> {
         if let Some(app) = self.app.take() {
-            let _ = self.simctl.run(&["terminate", &self.udid, &app.bundle_id]);
+            let _ = self
+                .target
+                .simctl()
+                .run(&["terminate", self.target.udid(), &app.bundle_id]);
         }
         Ok(())
     }
 
     fn capture_frame(&mut self, region: Option<&Region>) -> Result<Frame> {
-        let frame = screenshot(&self.simctl, &self.udid)?;
+        self.running()?;
+        let frame = screenshot(self.target.simctl(), self.target.udid())?;
         match region {
             None => Ok(frame),
             Some(r) => frame.crop(r),
@@ -139,34 +173,47 @@ impl Platform for IosPlatform {
     }
 
     fn get_clipboard(&mut self) -> Result<String> {
-        self.simctl.run(&["pbpaste", &self.udid])
+        self.running()?;
+        self.target.simctl().run(&["pbpaste", self.target.udid()])
     }
 
     fn set_clipboard(&mut self, text: &str) -> Result<()> {
+        self.running()?;
         // `simctl pbcopy` reads the clipboard text from stdin, so it needs a piped child
         // rather than the `Simctl::run` one-shot-output helper.
-        let mut child = Command::new(self.simctl.program())
-            .args(self.simctl.full_args(&["pbcopy", &self.udid]))
+        let mut child = Command::new(self.target.simctl().program())
+            .args(
+                self.target
+                    .simctl()
+                    .full_args(&["pbcopy", self.target.udid()]),
+            )
             .stdin(Stdio::piped())
+            .stderr(Stdio::piped())
             .spawn()
             .map_err(|e| GlassError::Backend(format!("pbcopy: {e}")))?;
         let mut stdin = child
             .stdin
             .take()
             .ok_or_else(|| GlassError::Backend("pbcopy: failed to open stdin".into()))?;
-        stdin
-            .write_all(text.as_bytes())
-            .map_err(|e| GlassError::Backend(format!("pbcopy write: {e}")))?;
+        if let Err(e) = stdin.write_all(text.as_bytes()) {
+            // Reap the child before returning so it doesn't outlive us as a zombie; its exit
+            // status doesn't matter here since we're already reporting the write failure.
+            let _ = child.wait();
+            return Err(GlassError::Backend(format!("pbcopy write: {e}")));
+        }
         // Close our end so `pbcopy` sees EOF and exits; holding it open past this point
-        // would deadlock the `wait()` below.
+        // would deadlock the `wait_with_output()` below.
         drop(stdin);
-        let status = child
-            .wait()
+        let out = child
+            .wait_with_output()
             .map_err(|e| GlassError::Backend(format!("pbcopy wait: {e}")))?;
-        if status.success() {
+        if out.status.success() {
             Ok(())
         } else {
-            Err(GlassError::Backend("pbcopy failed".into()))
+            Err(GlassError::Backend(format!(
+                "pbcopy failed: {}",
+                String::from_utf8_lossy(&out.stderr).trim()
+            )))
         }
     }
 
@@ -183,7 +230,7 @@ impl Platform for IosPlatform {
     fn list_windows(&mut self) -> Result<Vec<WindowInfo>> {
         let app = self.running()?;
         Ok(vec![WindowInfo {
-            id: WindowId(1),
+            id: IOS_WINDOW_ID,
             title: Some(app.bundle_id.clone()),
             class: None,
             geometry: app.geometry.clone(),
@@ -192,7 +239,7 @@ impl Platform for IosPlatform {
     }
 
     fn select_window(&mut self, id: WindowId) -> Result<WindowGeometry> {
-        if id == WindowId(1) {
+        if id == IOS_WINDOW_ID {
             Ok(self.running()?.geometry.clone())
         } else {
             Err(GlassError::WindowNotFound)
@@ -222,5 +269,162 @@ mod tests {
     #[test]
     fn run_empty_is_error() {
         assert!(bundle_id_from_run(&[]).is_err());
+    }
+
+    #[test]
+    fn looks_like_app_path_recognizes_bundle_paths() {
+        assert!(looks_like_app_path("/x/App.app"));
+        assert!(looks_like_app_path("MyApp.app"));
+        assert!(looks_like_app_path("./rel/App.app"));
+    }
+
+    #[test]
+    fn looks_like_app_path_rejects_bundle_ids() {
+        assert!(!looks_like_app_path("tech.fixedwidth.demo"));
+    }
+}
+
+/// State-machine tests: `IosPlatform` built directly (bypassing `from_env`) with a fake
+/// `RunningApp` (or none), so none of these touch a real simulator — `xcrun` is never
+/// invoked, only the pure in-memory branching.
+#[cfg(test)]
+mod state_machine_tests {
+    use super::*;
+
+    fn geometry() -> WindowGeometry {
+        WindowGeometry {
+            x: 0,
+            y: 0,
+            width: 390,
+            height: 844,
+        }
+    }
+
+    fn running_platform() -> IosPlatform {
+        IosPlatform {
+            target: SimTarget::for_test(),
+            app: Some(RunningApp {
+                bundle_id: "tech.fixedwidth.demo".into(),
+                geometry: geometry(),
+                logs: LogStream::spawn("fake"),
+            }),
+        }
+    }
+
+    fn idle_platform() -> IosPlatform {
+        IosPlatform {
+            target: SimTarget::for_test(),
+            app: None,
+        }
+    }
+
+    #[test]
+    fn send_pointer_is_unsupported() {
+        let mut p = running_platform();
+        let err = p
+            .send_pointer(&PointerEvent::Move { x: 1, y: 1 })
+            .unwrap_err();
+        assert!(matches!(err, GlassError::Unsupported(_)), "{err:?}");
+    }
+
+    #[test]
+    fn send_key_is_unsupported() {
+        let mut p = running_platform();
+        let err = p.send_key(&KeyEvent::Text("hi".into())).unwrap_err();
+        assert!(matches!(err, GlassError::Unsupported(_)), "{err:?}");
+    }
+
+    #[test]
+    fn window_geometry_returns_stored_geometry() {
+        let mut p = running_platform();
+        assert_eq!(p.window(&WindowOp::Geometry).unwrap(), geometry());
+    }
+
+    #[test]
+    fn window_focus_returns_stored_geometry() {
+        let mut p = running_platform();
+        assert_eq!(p.window(&WindowOp::Focus).unwrap(), geometry());
+    }
+
+    #[test]
+    fn window_resize_is_unsupported() {
+        let mut p = running_platform();
+        let err = p
+            .window(&WindowOp::Resize {
+                width: 100,
+                height: 100,
+            })
+            .unwrap_err();
+        assert!(matches!(err, GlassError::Unsupported(_)), "{err:?}");
+    }
+
+    #[test]
+    fn window_move_is_unsupported() {
+        let mut p = running_platform();
+        let err = p.window(&WindowOp::Move { x: 1, y: 1 }).unwrap_err();
+        assert!(matches!(err, GlassError::Unsupported(_)), "{err:?}");
+    }
+
+    #[test]
+    fn window_with_no_active_session_errors() {
+        let mut p = idle_platform();
+        assert!(matches!(
+            p.window(&WindowOp::Geometry).unwrap_err(),
+            GlassError::NoActiveSession
+        ));
+    }
+
+    #[test]
+    fn list_windows_returns_one_window() {
+        let mut p = running_platform();
+        let windows = p.list_windows().unwrap();
+        assert_eq!(windows.len(), 1);
+        let w = &windows[0];
+        assert_eq!(w.id, IOS_WINDOW_ID);
+        assert!(w.active);
+        assert_eq!(w.title.as_deref(), Some("tech.fixedwidth.demo"));
+        assert_eq!(w.geometry, geometry());
+    }
+
+    #[test]
+    fn select_window_matching_id_returns_geometry() {
+        let mut p = running_platform();
+        assert_eq!(p.select_window(IOS_WINDOW_ID).unwrap(), geometry());
+    }
+
+    #[test]
+    fn select_window_other_id_is_not_found() {
+        let mut p = running_platform();
+        assert!(matches!(
+            p.select_window(WindowId(2)).unwrap_err(),
+            GlassError::WindowNotFound
+        ));
+    }
+
+    #[test]
+    fn capture_frame_with_no_active_session_errors() {
+        let mut p = idle_platform();
+        assert!(matches!(
+            p.capture_frame(None).unwrap_err(),
+            GlassError::NoActiveSession
+        ));
+    }
+
+    #[test]
+    fn get_clipboard_with_no_active_session_errors() {
+        let mut p = idle_platform();
+        assert!(matches!(
+            p.get_clipboard().unwrap_err(),
+            GlassError::NoActiveSession
+        ));
+    }
+
+    #[test]
+    fn set_clipboard_with_no_active_session_errors() {
+        let mut p = idle_platform();
+        assert!(matches!(
+            p.set_clipboard("x").unwrap_err(),
+            GlassError::NoActiveSession
+        ));
     }
 }

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -1,0 +1,226 @@
+//! `IosPlatform`: the `glass_core::Platform` implementation that drives a single
+//! foreground app on an iOS Simulator over `xcrun simctl`.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use glass_core::{
+    AppSpec, Frame, GlassError, KeyEvent, Platform, PointerEvent, Region, Result, Stream,
+    WindowGeometry, WindowId, WindowInfo, WindowOp,
+};
+
+use crate::capture::screenshot;
+use crate::logs::LogStream;
+use crate::simctl::Simctl;
+use crate::target::{SimTarget, SimulatorRegistry};
+
+/// The single foreground app this backend drives.
+struct RunningApp {
+    bundle_id: String,
+    geometry: WindowGeometry,
+    logs: LogStream,
+}
+
+/// Drives a native app on an iOS Simulator over `xcrun simctl`. A single foreground app at a
+/// time, reported as one fullscreen window; there is no window management to speak of.
+pub struct IosPlatform {
+    simctl: Simctl,
+    udid: String,
+    app: Option<RunningApp>,
+}
+
+/// Split `spec.run` into `(optional install path, bundle id)`. `run[0]` naming a path (it
+/// ends in `.app` or contains a `/`) is installed via `simctl install`, with its bundle id
+/// read from the bundle's `Info.plist`; otherwise `run[0]` is used directly as the bundle id
+/// of an app already installed on the simulator.
+pub(crate) fn bundle_id_from_run(run: &[String]) -> Result<(Option<String>, String)> {
+    let first = run
+        .first()
+        .ok_or_else(|| GlassError::Backend("cannot start app: run command is empty".into()))?;
+    if first.ends_with(".app") || first.contains('/') {
+        let plist = format!("{first}/Info.plist");
+        let out = Command::new("plutil")
+            .args(["-extract", "CFBundleIdentifier", "raw", "-o", "-", &plist])
+            .output()
+            .map_err(|e| GlassError::Backend(format!("plutil: {e}")))?;
+        if !out.status.success() {
+            return Err(GlassError::Backend(format!(
+                "could not read CFBundleIdentifier from {plist}"
+            )));
+        }
+        let bundle_id = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        Ok((Some(first.clone()), bundle_id))
+    } else {
+        Ok((None, first.clone()))
+    }
+}
+
+impl IosPlatform {
+    /// Resolve (attaching to or booting) a simulator per the `GLASS_IOS_*` env vars.
+    pub fn from_env(reg: &SimulatorRegistry) -> Result<Self> {
+        let target = SimTarget::from_env(reg)?;
+        Ok(Self {
+            simctl: target.simctl().clone(),
+            udid: target.udid().to_string(),
+            app: None,
+        })
+    }
+
+    fn running(&self) -> Result<&RunningApp> {
+        self.app.as_ref().ok_or(GlassError::NoActiveSession)
+    }
+}
+
+impl Platform for IosPlatform {
+    fn start_app(&mut self, spec: &AppSpec) -> Result<WindowGeometry> {
+        if let Some(build) = &spec.build {
+            let status = Command::new("sh")
+                .arg("-c")
+                .arg(build)
+                .status()
+                .map_err(|e| GlassError::Backend(format!("build step: {e}")))?;
+            if !status.success() {
+                return Err(GlassError::Backend("build step failed".into()));
+            }
+        }
+
+        let (install, bundle_id) = bundle_id_from_run(&spec.run)?;
+        if let Some(path) = install {
+            self.simctl.run(&["install", &self.udid, &path])?;
+        }
+        self.simctl.run(&[
+            "launch",
+            "--terminate-running-process",
+            &self.udid,
+            &bundle_id,
+        ])?;
+
+        // Capture once, purely to learn the device's pixel dimensions for the geometry we report.
+        let frame = screenshot(&self.simctl, &self.udid)?;
+        let geometry = WindowGeometry {
+            x: 0,
+            y: 0,
+            width: frame.width,
+            height: frame.height,
+        };
+        self.app = Some(RunningApp {
+            bundle_id,
+            geometry: geometry.clone(),
+            logs: LogStream::spawn(&self.udid),
+        });
+        Ok(geometry)
+    }
+
+    fn stop_app(&mut self) -> Result<()> {
+        if let Some(app) = self.app.take() {
+            let _ = self.simctl.run(&["terminate", &self.udid, &app.bundle_id]);
+        }
+        Ok(())
+    }
+
+    fn capture_frame(&mut self, region: Option<&Region>) -> Result<Frame> {
+        let frame = screenshot(&self.simctl, &self.udid)?;
+        match region {
+            None => Ok(frame),
+            Some(r) => frame.crop(r),
+        }
+    }
+
+    fn send_pointer(&mut self, _event: &PointerEvent) -> Result<()> {
+        Err(GlassError::Unsupported(
+            "pointer input on the iOS backend".into(),
+        ))
+    }
+
+    fn send_key(&mut self, _event: &KeyEvent) -> Result<()> {
+        Err(GlassError::Unsupported(
+            "keyboard input on the iOS backend".into(),
+        ))
+    }
+
+    fn get_clipboard(&mut self) -> Result<String> {
+        self.simctl.run(&["pbpaste", &self.udid])
+    }
+
+    fn set_clipboard(&mut self, text: &str) -> Result<()> {
+        // `simctl pbcopy` reads the clipboard text from stdin, so it needs a piped child
+        // rather than the `Simctl::run` one-shot-output helper.
+        let mut child = Command::new(self.simctl.program())
+            .args(self.simctl.full_args(&["pbcopy", &self.udid]))
+            .stdin(Stdio::piped())
+            .spawn()
+            .map_err(|e| GlassError::Backend(format!("pbcopy: {e}")))?;
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| GlassError::Backend("pbcopy: failed to open stdin".into()))?;
+        stdin
+            .write_all(text.as_bytes())
+            .map_err(|e| GlassError::Backend(format!("pbcopy write: {e}")))?;
+        // Close our end so `pbcopy` sees EOF and exits; holding it open past this point
+        // would deadlock the `wait()` below.
+        drop(stdin);
+        let status = child
+            .wait()
+            .map_err(|e| GlassError::Backend(format!("pbcopy wait: {e}")))?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(GlassError::Backend("pbcopy failed".into()))
+        }
+    }
+
+    fn window(&mut self, op: &WindowOp) -> Result<WindowGeometry> {
+        let geometry = self.running()?.geometry.clone();
+        match op {
+            WindowOp::Geometry | WindowOp::Focus => Ok(geometry),
+            WindowOp::Resize { .. } | WindowOp::Move { .. } => Err(GlassError::Unsupported(
+                "window resize/move (iOS Simulator apps are fullscreen)".into(),
+            )),
+        }
+    }
+
+    fn list_windows(&mut self) -> Result<Vec<WindowInfo>> {
+        let app = self.running()?;
+        Ok(vec![WindowInfo {
+            id: WindowId(1),
+            title: Some(app.bundle_id.clone()),
+            class: None,
+            geometry: app.geometry.clone(),
+            active: true,
+        }])
+    }
+
+    fn select_window(&mut self, id: WindowId) -> Result<WindowGeometry> {
+        if id == WindowId(1) {
+            Ok(self.running()?.geometry.clone())
+        } else {
+            Err(GlassError::WindowNotFound)
+        }
+    }
+
+    fn drain_logs(&mut self) -> Vec<(Stream, String)> {
+        self.app
+            .as_ref()
+            .map(|a| a.logs.drain())
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_bundle_id_passthrough() {
+        // A reverse-DNS bundle id (no path) is used directly, nothing to install.
+        let (install, bid) = bundle_id_from_run(&["tech.fixedwidth.demo".into()]).unwrap();
+        assert_eq!(install, None);
+        assert_eq!(bid, "tech.fixedwidth.demo");
+    }
+
+    #[test]
+    fn run_empty_is_error() {
+        assert!(bundle_id_from_run(&[]).is_err());
+    }
+}

--- a/crates/glass-ios/src/simctl.rs
+++ b/crates/glass-ios/src/simctl.rs
@@ -2,36 +2,20 @@ use std::process::Command;
 
 use glass_core::{GlassError, Result};
 
-/// Typed wrapper over `xcrun simctl`. Pure arg construction; a thin runner.
+/// A stateless `xcrun simctl <argv>` runner. Every call site passes the target device's UDID
+/// positionally in `sub` (matching how `simctl` itself takes it), so this holds no per-device
+/// state.
 #[derive(Clone, Debug, Default)]
-pub struct Simctl {
-    udid: Option<String>,
-}
+pub struct Simctl;
 
 impl Simctl {
-    /// A wrapper with no device bound yet.
+    /// A new runner. There is nothing to configure — `Simctl` is stateless.
     pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Bind a resolved device UDID (callers pass it positionally where a subcommand wants it).
-    pub fn bind(mut self, udid: impl Into<String>) -> Self {
-        self.udid = Some(udid.into());
-        self
-    }
-
-    /// The bound device UDID, if one has been set.
-    pub fn udid(&self) -> Option<&str> {
-        self.udid.as_deref()
+        Self
     }
 
     pub(crate) fn program(&self) -> &'static str {
         "xcrun"
-    }
-
-    /// The simctl subcommand args, unchanged (kept as a seam for tests/consistency).
-    pub fn args_for(&self, sub: &[&str]) -> Vec<String> {
-        sub.iter().map(|s| s.to_string()).collect()
     }
 
     /// Full argv passed to `xcrun`: `simctl <sub...>`.
@@ -45,11 +29,6 @@ impl Simctl {
     pub fn run(&self, sub: &[&str]) -> Result<String> {
         let out = self.output(sub)?;
         Ok(String::from_utf8_lossy(&out).into_owned())
-    }
-
-    /// Run `xcrun simctl <sub...>` and return captured stdout as raw bytes.
-    pub fn run_bytes(&self, sub: &[&str]) -> Result<Vec<u8>> {
-        self.output(sub)
     }
 
     fn output(&self, sub: &[&str]) -> Result<Vec<u8>> {
@@ -71,21 +50,6 @@ impl Simctl {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn args_prefix_is_xcrun_simctl_free() {
-        // args_for returns only the simctl subcommand args; the runner prepends `simctl`.
-        let s = Simctl::new();
-        assert_eq!(
-            s.args_for(&["list", "devices", "available", "--json"]),
-            vec![
-                "list".to_string(),
-                "devices".to_string(),
-                "available".to_string(),
-                "--json".to_string()
-            ]
-        );
-    }
 
     #[test]
     fn program_is_xcrun_with_simctl_first_arg() {

--- a/crates/glass-ios/src/simctl.rs
+++ b/crates/glass-ios/src/simctl.rs
@@ -1,0 +1,99 @@
+use std::process::Command;
+
+use glass_core::{GlassError, Result};
+
+/// Typed wrapper over `xcrun simctl`. Pure arg construction; a thin runner.
+#[derive(Clone, Debug, Default)]
+pub struct Simctl {
+    udid: Option<String>,
+}
+
+impl Simctl {
+    /// A wrapper with no device bound yet.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Bind a resolved device UDID (callers pass it positionally where a subcommand wants it).
+    pub fn bind(mut self, udid: impl Into<String>) -> Self {
+        self.udid = Some(udid.into());
+        self
+    }
+
+    /// The bound device UDID, if one has been set.
+    pub fn udid(&self) -> Option<&str> {
+        self.udid.as_deref()
+    }
+
+    pub(crate) fn program(&self) -> &'static str {
+        "xcrun"
+    }
+
+    /// The simctl subcommand args, unchanged (kept as a seam for tests/consistency).
+    pub fn args_for(&self, sub: &[&str]) -> Vec<String> {
+        sub.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// Full argv passed to `xcrun`: `simctl <sub...>`.
+    pub(crate) fn full_args(&self, sub: &[&str]) -> Vec<String> {
+        let mut v = vec!["simctl".to_string()];
+        v.extend(sub.iter().map(|s| s.to_string()));
+        v
+    }
+
+    /// Run `xcrun simctl <sub...>` and return captured stdout as lossy UTF-8 text.
+    pub fn run(&self, sub: &[&str]) -> Result<String> {
+        let out = self.output(sub)?;
+        Ok(String::from_utf8_lossy(&out).into_owned())
+    }
+
+    /// Run `xcrun simctl <sub...>` and return captured stdout as raw bytes.
+    pub fn run_bytes(&self, sub: &[&str]) -> Result<Vec<u8>> {
+        self.output(sub)
+    }
+
+    fn output(&self, sub: &[&str]) -> Result<Vec<u8>> {
+        let out = Command::new(self.program())
+            .args(self.full_args(sub))
+            .output()
+            .map_err(|e| GlassError::Backend(format!("failed to run xcrun simctl: {e}")))?;
+        if !out.status.success() {
+            return Err(GlassError::Backend(format!(
+                "simctl {:?} failed: {}",
+                sub,
+                String::from_utf8_lossy(&out.stderr).trim()
+            )));
+        }
+        Ok(out.stdout)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn args_prefix_is_xcrun_simctl_free() {
+        // args_for returns only the simctl subcommand args; the runner prepends `simctl`.
+        let s = Simctl::new();
+        assert_eq!(
+            s.args_for(&["list", "devices", "available", "--json"]),
+            vec![
+                "list".to_string(),
+                "devices".to_string(),
+                "available".to_string(),
+                "--json".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn program_is_xcrun_with_simctl_first_arg() {
+        let s = Simctl::new();
+        assert_eq!(s.program(), "xcrun");
+        assert_eq!(
+            s.full_args(&["help"]),
+            vec!["simctl".to_string(), "help".to_string()]
+        );
+    }
+}

--- a/crates/glass-ios/src/target.rs
+++ b/crates/glass-ios/src/target.rs
@@ -97,10 +97,7 @@ impl SimTarget {
                 u
             }
         };
-        Ok(Self {
-            simctl: base.bind(udid.clone()),
-            udid,
-        })
+        Ok(Self { simctl: base, udid })
     }
 
     /// The `Simctl` client bound to the resolved device.
@@ -111,6 +108,16 @@ impl SimTarget {
     /// The resolved device's UDID.
     pub fn udid(&self) -> &str {
         &self.udid
+    }
+
+    /// A `SimTarget` for `IosPlatform` unit tests that never touch a real simulator (a
+    /// `NoActiveSession`/state-machine guard fires before `target` is used).
+    #[cfg(test)]
+    pub(crate) fn for_test() -> Self {
+        Self {
+            simctl: Simctl::new(),
+            udid: "test-udid".to_string(),
+        }
     }
 }
 

--- a/crates/glass-ios/src/target.rs
+++ b/crates/glass-ios/src/target.rs
@@ -98,13 +98,11 @@ impl SimTarget {
     }
 
     /// The `Simctl` client bound to the resolved device.
-    #[cfg_attr(not(test), allow(dead_code))]
     pub fn simctl(&self) -> &Simctl {
         &self.simctl
     }
 
     /// The resolved device's UDID.
-    #[cfg_attr(not(test), allow(dead_code))]
     pub fn udid(&self) -> &str {
         &self.udid
     }

--- a/crates/glass-ios/src/target.rs
+++ b/crates/glass-ios/src/target.rs
@@ -1,0 +1,140 @@
+//! Resolves an iOS Simulator to drive: which UDID, and whether it needs booting.
+//! Delegates the pure attach-or-boot decision to [`crate::device::resolve`], then does the
+//! one piece of I/O this crate performs proactively — running `bootstatus -b` to boot and
+//! wait for a device this crate chose to start.
+
+use std::sync::Mutex;
+
+use glass_core::{GlassError, Result};
+
+use crate::device::{parse_devices, resolve, Resolve};
+use crate::simctl::Simctl;
+
+/// Shuts down simulators glass booted, on drop, unless the user asked to keep them.
+#[derive(Default)]
+pub struct SimulatorRegistry {
+    booted: Mutex<Vec<String>>,
+}
+
+impl SimulatorRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a simulator UDID glass booted, so it gets shut down on drop.
+    pub fn register(&self, udid: String) {
+        // Recover a poisoned lock rather than panic: the vec is a plain list of UDIDs and a
+        // prior panic can't have left it in a state that matters for a best-effort sweep.
+        self.booted
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(udid);
+    }
+}
+
+impl Drop for SimulatorRegistry {
+    fn drop(&mut self) {
+        let s = Simctl::new();
+        // Never panic inside drop: a panic here during unwind would abort the process. Recover
+        // a poisoned lock and shut down whatever UDIDs we recorded, ignoring per-command errors.
+        for udid in self
+            .booted
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .drain(..)
+        {
+            let _ = s.run(&["shutdown", &udid]);
+        }
+    }
+}
+
+/// Read the UDID/name/keep preferences from `GLASS_IOS_UDID`, `GLASS_IOS_DEVICE`, and
+/// `GLASS_SIMULATOR_KEEP` via the given getter (env lookup is injected so this stays pure
+/// and testable without touching real process env).
+#[cfg_attr(not(test), allow(dead_code))]
+pub fn wants(get: &dyn Fn(&str) -> Option<String>) -> (Option<String>, Option<String>, bool) {
+    let udid = get("GLASS_IOS_UDID").filter(|s| !s.is_empty());
+    let name = get("GLASS_IOS_DEVICE").filter(|s| !s.is_empty());
+    let keep = get("GLASS_SIMULATOR_KEEP")
+        .filter(|s| !s.is_empty())
+        .is_some();
+    (udid, name, keep)
+}
+
+/// A resolved, booted iOS Simulator: its UDID and a `Simctl` bound to it.
+pub struct SimTarget {
+    simctl: Simctl,
+    udid: String,
+}
+
+impl SimTarget {
+    /// Resolve a device from env/list (attach if one's already running or named, else boot
+    /// the newest available iPhone), booting and waiting for it via `bootstatus -b` when
+    /// needed, and registering it in `reg` for shutdown-on-drop unless `GLASS_SIMULATOR_KEEP`
+    /// is set.
+    pub fn from_env(reg: &SimulatorRegistry) -> Result<Self> {
+        let get = |k: &str| std::env::var(k).ok();
+        let (want_udid, want_name, keep) = wants(&get);
+
+        let base = Simctl::new();
+        let list = base.run(&["list", "devices", "available", "--json"])?;
+        let devices = parse_devices(&list)?;
+        let udid = match resolve(&devices, want_udid.as_deref(), want_name.as_deref()) {
+            Resolve::Attach(u) => u,
+            Resolve::Error(msg) => return Err(GlassError::Backend(msg)),
+            Resolve::Boot(u) => {
+                // `bootstatus -b` boots if needed and blocks until fully booted.
+                base.run(&["bootstatus", &u, "-b"])?;
+                if !keep {
+                    reg.register(u.clone());
+                }
+                u
+            }
+        };
+        Ok(Self {
+            simctl: base.bind(udid.clone()),
+            udid,
+        })
+    }
+
+    /// The `Simctl` client bound to the resolved device.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn simctl(&self) -> &Simctl {
+        &self.simctl
+    }
+
+    /// The resolved device's UDID.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn udid(&self) -> &str {
+        &self.udid
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn getter(m: HashMap<&'static str, &'static str>) -> impl Fn(&str) -> Option<String> {
+        move |k: &str| m.get(k).map(|s| s.to_string())
+    }
+
+    #[test]
+    fn wants_reads_all_three_env_vars() {
+        let g = getter(HashMap::from([
+            ("GLASS_IOS_UDID", "AAA"),
+            ("GLASS_IOS_DEVICE", "iPhone 17"),
+            ("GLASS_SIMULATOR_KEEP", "1"),
+        ]));
+        assert_eq!(
+            wants(&g),
+            (Some("AAA".into()), Some("iPhone 17".into()), true)
+        );
+    }
+
+    #[test]
+    fn wants_empty_keep_is_false() {
+        let g = getter(HashMap::from([("GLASS_SIMULATOR_KEEP", "")]));
+        assert_eq!(wants(&g), (None, None, false));
+    }
+}

--- a/crates/glass-ios/src/target.rs
+++ b/crates/glass-ios/src/target.rs
@@ -3,17 +3,22 @@
 //! one piece of I/O this crate performs proactively — running `bootstatus -b` to boot and
 //! wait for a device this crate chose to start.
 
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use glass_core::{GlassError, Result};
 
 use crate::device::{parse_devices, resolve, Resolve};
 use crate::simctl::Simctl;
 
-/// Shuts down simulators glass booted, on drop, unless the user asked to keep them.
-#[derive(Default)]
+/// UDIDs of simulators glass booted itself, so they can be shut down explicitly rather than
+/// left running. Cloneable + `Send` (shared `Arc`); glass-mcp threads one clone into the
+/// platform factory (to register boots) and another into the `Glass` shutdown hook (to shut
+/// them down). No `Drop` impl: a clone going out of scope (e.g. the factory clone, dropped
+/// after each `glass_start`) must not shut down simulators that are still in use — only an
+/// explicit `shutdown_all` call does that.
+#[derive(Clone, Default)]
 pub struct SimulatorRegistry {
-    booted: Mutex<Vec<String>>,
+    booted: Arc<Mutex<Vec<String>>>,
 }
 
 impl SimulatorRegistry {
@@ -21,30 +26,31 @@ impl SimulatorRegistry {
         Self::default()
     }
 
-    /// Record a simulator UDID glass booted, so it gets shut down on drop.
+    /// Record a simulator UDID glass booted.
     pub fn register(&self, udid: String) {
-        // Recover a poisoned lock rather than panic: the vec is a plain list of UDIDs and a
-        // prior panic can't have left it in a state that matters for a best-effort sweep.
-        self.booted
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .push(udid);
+        if let Ok(mut g) = self.booted.lock() {
+            g.push(udid);
+        }
     }
-}
 
-impl Drop for SimulatorRegistry {
-    fn drop(&mut self) {
-        let s = Simctl::new();
-        // Never panic inside drop: a panic here during unwind would abort the process. Recover
-        // a poisoned lock and shut down whatever UDIDs we recorded, ignoring per-command errors.
-        for udid in self
+    /// Shut down every registered simulator (`xcrun simctl shutdown <udid>`) and clear the
+    /// list. Best-effort: a simulator already stopped, or a host with no simulator support at
+    /// all, is fine — each shutdown's result is discarded.
+    pub fn shutdown_all(&self) {
+        let udids = self
             .booted
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .drain(..)
-        {
+            .map(|mut g| std::mem::take(&mut *g))
+            .unwrap_or_default();
+        let s = Simctl::new();
+        for udid in udids {
             let _ = s.run(&["shutdown", &udid]);
         }
+    }
+
+    #[cfg(test)]
+    pub fn udids(&self) -> Vec<String> {
+        self.booted.lock().map(|g| g.clone()).unwrap_or_default()
     }
 }
 
@@ -70,8 +76,8 @@ pub struct SimTarget {
 impl SimTarget {
     /// Resolve a device from env/list (attach if one's already running or named, else boot
     /// the newest available iPhone), booting and waiting for it via `bootstatus -b` when
-    /// needed, and registering it in `reg` for shutdown-on-drop unless `GLASS_SIMULATOR_KEEP`
-    /// is set.
+    /// needed, and registering it in `reg` — for shutdown by a later `reg.shutdown_all()` call
+    /// — unless `GLASS_SIMULATOR_KEEP` is set.
     pub fn from_env(reg: &SimulatorRegistry) -> Result<Self> {
         let get = |k: &str| std::env::var(k).ok();
         let (want_udid, want_name, keep) = wants(&get);
@@ -134,5 +140,24 @@ mod tests {
     fn wants_empty_keep_is_false() {
         let g = getter(HashMap::from([("GLASS_SIMULATOR_KEEP", "")]));
         assert_eq!(wants(&g), (None, None, false));
+    }
+
+    #[test]
+    fn registry_records_udids_across_clones() {
+        let r = SimulatorRegistry::new();
+        let r2 = r.clone();
+        r.register("AAA".into());
+        r2.register("BBB".into());
+        assert_eq!(r.udids(), vec!["AAA".to_string(), "BBB".to_string()]);
+    }
+
+    #[test]
+    fn shutdown_all_clears_the_registry() {
+        let r = SimulatorRegistry::new();
+        r.register("AAA".into());
+        // Best-effort: `xcrun simctl shutdown` may fail in a CI sandbox with no real
+        // simulator, but the registry is cleared regardless.
+        r.shutdown_all();
+        assert!(r.udids().is_empty());
     }
 }

--- a/crates/glass-ios/tests/smoke_integration.rs
+++ b/crates/glass-ios/tests/smoke_integration.rs
@@ -1,0 +1,87 @@
+//! On-box smoke test for the iOS Simulator backend: launches a real `.app` on a booted
+//! Simulator and drives it through `glass_core::Platform`'s core surface — start, capture,
+//! clipboard round-trip, stop — exactly the sequence `glass_start`/`glass_screenshot`/
+//! `glass_clipboard_*`/`glass_stop` exercise over MCP.
+//!
+//! `#[ignore]`d so a plain `cargo test` (Linux dev host, CI) skips it; the backend shells out
+//! to `xcrun simctl`, which only exists on macOS with Xcode installed, and this test additionally
+//! needs a booted Simulator and a real app to launch. Run explicitly on a macOS host with a
+//! Simulator already booted:
+//!
+//! ```sh
+//! GLASS_IOS_APP=/path/to/YourApp.app cargo test -p glass-ios --test smoke_integration -- --ignored
+//! ```
+//!
+//! `GLASS_IOS_APP` must be a `.app` bundle path (not a bare bundle id) so `start_app` installs
+//! it itself — no separate `simctl install` step is required. `GLASS_IOS_UDID` / `GLASS_IOS_DEVICE`
+//! / `GLASS_SIMULATOR_KEEP` (all optional) select and manage the Simulator the same way they do
+//! for `glass-mcp`; see `docs/how-to/setup-ios.md`.
+
+use glass_core::{AppSpec, Platform, SandboxLevel};
+use glass_ios::{IosPlatform, SimulatorRegistry};
+
+#[test]
+#[ignore = "on-box only: needs a macOS host with Xcode + a booted iOS Simulator, and GLASS_IOS_APP \
+            pointing at a built .app to launch"]
+fn smoke_launch_capture_clipboard_stop() {
+    let app = std::env::var("GLASS_IOS_APP")
+        .expect("GLASS_IOS_APP must be set to a built .app path for this test to launch");
+
+    let spec = AppSpec {
+        build: None,
+        run: vec![app],
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        timeout_ms: 30_000,
+        sandbox: SandboxLevel::Off,
+        a11y: false,
+    };
+
+    let reg = SimulatorRegistry::new();
+    let mut platform = IosPlatform::from_env(&reg)
+        .expect("IosPlatform::from_env (resolve/boot a Simulator per GLASS_IOS_* env)");
+
+    let geometry = platform
+        .start_app(&spec)
+        .expect("start_app must install (if needed), launch, and report the device's geometry");
+    assert!(
+        geometry.width > 0 && geometry.height > 0,
+        "launched app geometry must be non-zero, got {geometry:?}"
+    );
+
+    // Give the freshly launched app a moment to actually render before capturing, mirroring the
+    // settle used by the sibling on-box integration tests (glass-windows, glass-macos).
+    std::thread::sleep(std::time::Duration::from_millis(1000));
+
+    let frame = platform
+        .capture_frame(None)
+        .expect("capture_frame(None) must screenshot the whole device");
+    assert_eq!(
+        (frame.width, frame.height),
+        (geometry.width, geometry.height),
+        "captured frame dimensions must match the geometry reported by start_app"
+    );
+    assert_eq!(
+        frame.pixels.len(),
+        (frame.width as usize) * (frame.height as usize) * 4,
+        "RGBA buffer must be exactly width*height*4 bytes"
+    );
+
+    // Non-ASCII to exercise the same UTF-8 round-trip the sibling backends' clipboard tests do.
+    const SENTINEL: &str = "glass-ios-smoke-\u{2713}-\u{e9}";
+    platform
+        .set_clipboard(SENTINEL)
+        .expect("set_clipboard (simctl pbcopy)");
+    assert_eq!(
+        platform
+            .get_clipboard()
+            .expect("get_clipboard (simctl pbpaste)"),
+        SENTINEL,
+        "clipboard round-trip must return exactly what was set"
+    );
+
+    platform
+        .stop_app()
+        .expect("stop_app must terminate the launched app");
+}

--- a/crates/glass-mcp/Cargo.toml
+++ b/crates/glass-mcp/Cargo.toml
@@ -18,7 +18,6 @@ network = [
 
 [dependencies]
 glass-android.workspace = true
-glass-ios.workspace = true
 glass-core.workspace = true
 rmcp = { version = "1.7", features = ["server", "macros", "transport-io"] }
 tokio = { version = "1", features = ["full"] }
@@ -53,6 +52,11 @@ glass-a11y-windows = { path = "../glass-a11y-windows" }
 glass-macos = { path = "../glass-macos" }
 glass-a11y-macos = { path = "../glass-a11y-macos" }
 glass-sandbox-macos.workspace = true
+# The iOS Simulator backend links `image`'s `png` codec chain (see glass-ios/Cargo.toml);
+# macOS is the only host that can actually drive `xcrun simctl`, so keep that chain out of
+# the Linux/Windows glass-mcp binary. glass-ios stays a workspace member either way — its
+# own unit tests still run on every host.
+glass-ios = { path = "../glass-ios" }
 # `setup`'s `gui/<uid>` LaunchAgent install (`rustix::process::getuid`) — a safe syscall
 # wrapper, so no `unsafe` FFI is needed for this. Already a workspace dependency (glass-macos
 # uses it for process signals); the workspace-level `process` feature covers `getuid`.

--- a/crates/glass-mcp/Cargo.toml
+++ b/crates/glass-mcp/Cargo.toml
@@ -18,6 +18,7 @@ network = [
 
 [dependencies]
 glass-android.workspace = true
+glass-ios.workspace = true
 glass-core.workspace = true
 rmcp = { version = "1.7", features = ["server", "macros", "transport-io"] }
 tokio = { version = "1", features = ["full"] }

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -190,51 +190,52 @@ fn audit_section(report: &crate::audit::AuditReport) -> Section {
     Section::new("audit", None, vec![Check::new("audit log", status, detail)])
 }
 
-/// When android isn't the active backend, its presence checks are advisory, so adjust them
-/// to read honestly for a user on another backend:
-/// - downgrade any `Fail` to `Warn` (noting why) so a missing adb/emulator — irrelevant to
-///   the current backend — doesn't fail the overall diagnosis, and
-/// - when `--deep` *was* requested, correct the deep-capture probes' skip reason: they were
-///   gated off because android isn't the selected backend, not because `--deep` was missing.
-///   The android crate only sees the collapsed `deep && android_selected` bool, so it emits
-///   its "run with --deep" hint (which the user already did); point at the real gate instead.
-///
-/// The actual status is still reported.
-fn soften_inactive_android(checks: &mut [Check], deep_requested: bool) {
+/// Downgrade any `Fail` check to `Warn`, noting that it's only required when `backend` is
+/// selected — shared by [`soften_inactive_android`] and [`soften_inactive_ios`] so a missing
+/// tool for a backend the user isn't driving doesn't fail the overall diagnosis. The actual
+/// status is still reported, just softened.
+fn soften_inactive_fails(checks: &mut [Check], backend: &str) {
     for c in checks {
         if c.status == CheckStatus::Fail {
             c.status = CheckStatus::Warn;
             c.detail = format!(
-                "{} (only required when the android backend is selected)",
+                "{} (only required when the {backend} backend is selected)",
                 c.detail
             );
-        } else if deep_requested
-            && c.status == CheckStatus::Skip
-            && c.detail == glass_android::doctor::DEEP_NOT_REQUESTED_DETAIL
-        {
-            c.detail = "deep probes run only for the selected backend — set GLASS_BACKEND=android \
-                 to probe capture"
-                .to_string();
+        }
+    }
+}
+
+/// When android isn't the active backend, its presence checks are advisory, so adjust them
+/// to read honestly for a user on another backend: soften any `Fail` via
+/// [`soften_inactive_fails`], and, when `--deep` *was* requested, correct the deep-capture
+/// probes' skip reason — they were gated off because android isn't the selected backend, not
+/// because `--deep` was missing. The android crate only sees the collapsed
+/// `deep && android_selected` bool, so it emits its "run with --deep" hint (which the user
+/// already did); point at the real gate instead.
+fn soften_inactive_android(checks: &mut [Check], deep_requested: bool) {
+    soften_inactive_fails(checks, "android");
+    if deep_requested {
+        for c in checks {
+            if c.status == CheckStatus::Skip
+                && c.detail == glass_android::doctor::DEEP_NOT_REQUESTED_DETAIL
+            {
+                c.detail =
+                    "deep probes run only for the selected backend — set GLASS_BACKEND=android \
+                     to probe capture"
+                        .to_string();
+            }
         }
     }
 }
 
 /// When ios isn't the active backend, its presence checks are advisory — same rationale as
-/// [`soften_inactive_android`], downgrading any `Fail` to `Warn` so a missing Xcode/simctl
-/// irrelevant to the current backend doesn't fail the overall diagnosis. Unlike android, ios
+/// [`soften_inactive_android`], via the shared [`soften_inactive_fails`]. Unlike android, ios
 /// has no deep-probe skip message to correct: `glass_ios::doctor::checks` accepts `deep` only
 /// for signature parity (iOS has no expensive probe of its own), so it never emits a
 /// "run with --deep" hint that would need re-pointing.
 fn soften_inactive_ios(checks: &mut [Check]) {
-    for c in checks {
-        if c.status == CheckStatus::Fail {
-            c.status = CheckStatus::Warn;
-            c.detail = format!(
-                "{} (only required when the ios backend is selected)",
-                c.detail
-            );
-        }
-    }
+    soften_inactive_fails(checks, "ios");
 }
 
 /// macOS checks: the two TCC grants (Screen Recording, Accessibility), the console

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -61,10 +61,13 @@ fn diagnose_inner(deep: bool, audit: Option<&crate::audit::AuditReport>) -> Diag
     // sections below — "macos" (the platform backend's own TCC posture), "sandbox" (Seatbelt
     // containment posture, mirroring the Linux/Windows "sandbox" sections), and
     // "accessibility (macos)" (the a11y-tool reader's readiness, kept separate from "macos" —
-    // see the comment there for why). Android and iOS are the exception: both crates shell
-    // out to a separate SDK's own tools (adb/emulator; xcrun simctl) rather than linking an
-    // OS framework, so they're host-OS-agnostic and always compiled in — their sections are
-    // always emitted, gated at runtime (see below) rather than by cfg.
+    // see the comment there for why). Android is the exception: it shells out to a separate
+    // SDK's own tools (adb/emulator) rather than linking an OS framework, so it's
+    // host-OS-agnostic and always compiled in — its section is always emitted, gated at
+    // runtime (see below) rather than by cfg. iOS also shells out to a separate SDK's tools
+    // (`xcrun simctl`), but only macOS can actually run them, and `glass-ios` pulls in an
+    // `image` PNG codec chain that a non-macOS binary has no use for — so glass-mcp only
+    // depends on `glass-ios` on macOS, and its section is compiled in accordingly.
     let mut sections = vec![general, network];
 
     #[cfg(target_os = "linux")]
@@ -149,17 +152,20 @@ fn diagnose_inner(deep: bool, audit: Option<&crate::audit::AuditReport>) -> Diag
         android_checks,
     ));
 
-    // iOS Simulator backend: same rationale as android above — the crate shells out to
-    // Apple's own `xcrun simctl`, so it's compiled in unconditionally rather than gated to
-    // macOS builds, and its basic presence checks run regardless of the selected backend.
-    // Soften Fails to Warns when ios isn't active so a missing Xcode/simctl on a non-macOS
-    // host (or a Mac not driving iOS) doesn't fail the overall doctor verdict.
-    let ios_selected = backend == "ios";
-    let mut ios_checks = glass_ios::doctor::checks(deep && ios_selected);
-    if !ios_selected {
-        soften_inactive_ios(&mut ios_checks);
+    // iOS Simulator backend: unlike android above, `glass-ios` is only a dependency of
+    // glass-mcp on macOS (the only host that can drive `xcrun simctl` — see this crate's
+    // Cargo.toml), so its section only exists in a macOS build. Soften Fails to Warns when
+    // ios isn't active so a Mac not currently driving iOS doesn't fail the overall doctor
+    // verdict.
+    #[cfg(target_os = "macos")]
+    {
+        let ios_selected = backend == "ios";
+        let mut ios_checks = glass_ios::doctor::checks(deep && ios_selected);
+        if !ios_selected {
+            soften_inactive_ios(&mut ios_checks);
+        }
+        sections.push(Section::new("ios", Some("ios".into()), ios_checks));
     }
-    sections.push(Section::new("ios", Some("ios".into()), ios_checks));
 
     if let Some(report) = audit {
         sections.push(audit_section(report));
@@ -233,7 +239,9 @@ fn soften_inactive_android(checks: &mut [Check], deep_requested: bool) {
 /// [`soften_inactive_android`], via the shared [`soften_inactive_fails`]. Unlike android, ios
 /// has no deep-probe skip message to correct: `glass_ios::doctor::checks` accepts `deep` only
 /// for signature parity (iOS has no expensive probe of its own), so it never emits a
-/// "run with --deep" hint that would need re-pointing.
+/// "run with --deep" hint that would need re-pointing. Only used from the macOS-only ios
+/// section above (see this crate's Cargo.toml for why `glass-ios` itself is macOS-only).
+#[cfg(target_os = "macos")]
 fn soften_inactive_ios(checks: &mut [Check]) {
     soften_inactive_fails(checks, "ios");
 }
@@ -410,6 +418,7 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn inactive_ios_fails_soften_to_warn() {
         let mut checks = vec![
@@ -451,11 +460,12 @@ mod tests {
         // is asserted, so it's deterministic regardless of host.
         let d = diagnose(false);
         let titles: Vec<&str> = d.sections.iter().map(|s| s.title.as_str()).collect();
-        // Platform-gated backends compiled into THIS binary get a section; android and ios
-        // are always present (host-OS-agnostic crates) via a runtime gate. No "not built
-        // into this binary" placeholders. Accessibility is per-OS (AT-SPI on Linux, UIA on
-        // Windows); macOS's grants (Screen Recording, Accessibility) live inside its own
-        // "macos" section rather than a separate accessibility section.
+        // Platform-gated backends compiled into THIS binary get a section; android is always
+        // present (a host-OS-agnostic crate) via a runtime gate. iOS is compiled into
+        // glass-mcp — and so gets a section — only on macOS (see this crate's Cargo.toml).
+        // No "not built into this binary" placeholders. Accessibility is per-OS (AT-SPI on
+        // Linux, UIA on Windows); macOS's grants (Screen Recording, Accessibility) live
+        // inside its own "macos" section rather than a separate accessibility section.
         #[cfg(target_os = "linux")]
         assert_eq!(
             titles,
@@ -466,8 +476,7 @@ mod tests {
                 "wayland",
                 "sandbox",
                 "accessibility (linux)",
-                "android",
-                "ios"
+                "android"
             ]
         );
         #[cfg(windows)]
@@ -479,8 +488,7 @@ mod tests {
                 "windows",
                 "sandbox",
                 "accessibility (windows)",
-                "android",
-                "ios"
+                "android"
             ]
         );
         #[cfg(target_os = "macos")]
@@ -496,11 +504,10 @@ mod tests {
                 "ios"
             ]
         );
-        // Android's and iOS's sections are always present and non-empty — their basic
-        // presence checks now run unconditionally (deep probes gated to the selected
-        // backend; Fails softened to Warn when not active). Asserting non-empty catches
-        // accidental removal of the section, without depending on which backend the
-        // ambient env resolves to.
+        // Android's section is always present and non-empty — its basic presence checks run
+        // unconditionally (deep probes gated to the selected backend; Fails softened to Warn
+        // when not active). Asserting non-empty catches accidental removal of the section,
+        // without depending on which backend the ambient env resolves to.
         let android = d
             .sections
             .iter()
@@ -508,13 +515,19 @@ mod tests {
             .expect("android section");
         assert_eq!(android.backend.as_deref(), Some("android"));
         assert!(!android.checks.is_empty());
-        let ios = d
-            .sections
-            .iter()
-            .find(|s| s.title == "ios")
-            .expect("ios section");
-        assert_eq!(ios.backend.as_deref(), Some("ios"));
-        assert!(!ios.checks.is_empty());
+        // iOS's section follows the same non-empty shape, but only exists on macOS.
+        #[cfg(target_os = "macos")]
+        {
+            let ios = d
+                .sections
+                .iter()
+                .find(|s| s.title == "ios")
+                .expect("ios section");
+            assert_eq!(ios.backend.as_deref(), Some("ios"));
+            assert!(!ios.checks.is_empty());
+        }
+        #[cfg(not(target_os = "macos"))]
+        assert!(!titles.contains(&"ios"));
         // The `network` section is always present (Ok when compiled in, else Skip).
         let net = d
             .sections

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -61,9 +61,10 @@ fn diagnose_inner(deep: bool, audit: Option<&crate::audit::AuditReport>) -> Diag
     // sections below — "macos" (the platform backend's own TCC posture), "sandbox" (Seatbelt
     // containment posture, mirroring the Linux/Windows "sandbox" sections), and
     // "accessibility (macos)" (the a11y-tool reader's readiness, kept separate from "macos" —
-    // see the comment there for why). Android is the exception: its crate is
-    // host-OS-agnostic and always compiled in, so its section is always emitted, gated
-    // at runtime (see below) rather than by cfg.
+    // see the comment there for why). Android and iOS are the exception: both crates shell
+    // out to a separate SDK's own tools (adb/emulator; xcrun simctl) rather than linking an
+    // OS framework, so they're host-OS-agnostic and always compiled in — their sections are
+    // always emitted, gated at runtime (see below) rather than by cfg.
     let mut sections = vec![general, network];
 
     #[cfg(target_os = "linux")]
@@ -148,6 +149,18 @@ fn diagnose_inner(deep: bool, audit: Option<&crate::audit::AuditReport>) -> Diag
         android_checks,
     ));
 
+    // iOS Simulator backend: same rationale as android above — the crate shells out to
+    // Apple's own `xcrun simctl`, so it's compiled in unconditionally rather than gated to
+    // macOS builds, and its basic presence checks run regardless of the selected backend.
+    // Soften Fails to Warns when ios isn't active so a missing Xcode/simctl on a non-macOS
+    // host (or a Mac not driving iOS) doesn't fail the overall doctor verdict.
+    let ios_selected = backend == "ios";
+    let mut ios_checks = glass_ios::doctor::checks(deep && ios_selected);
+    if !ios_selected {
+        soften_inactive_ios(&mut ios_checks);
+    }
+    sections.push(Section::new("ios", Some("ios".into()), ios_checks));
+
     if let Some(report) = audit {
         sections.push(audit_section(report));
     }
@@ -202,6 +215,24 @@ fn soften_inactive_android(checks: &mut [Check], deep_requested: bool) {
             c.detail = "deep probes run only for the selected backend — set GLASS_BACKEND=android \
                  to probe capture"
                 .to_string();
+        }
+    }
+}
+
+/// When ios isn't the active backend, its presence checks are advisory — same rationale as
+/// [`soften_inactive_android`], downgrading any `Fail` to `Warn` so a missing Xcode/simctl
+/// irrelevant to the current backend doesn't fail the overall diagnosis. Unlike android, ios
+/// has no deep-probe skip message to correct: `glass_ios::doctor::checks` accepts `deep` only
+/// for signature parity (iOS has no expensive probe of its own), so it never emits a
+/// "run with --deep" hint that would need re-pointing.
+fn soften_inactive_ios(checks: &mut [Check]) {
+    for c in checks {
+        if c.status == CheckStatus::Fail {
+            c.status = CheckStatus::Warn;
+            c.detail = format!(
+                "{} (only required when the ios backend is selected)",
+                c.detail
+            );
         }
     }
 }
@@ -379,6 +410,25 @@ mod tests {
     }
 
     #[test]
+    fn inactive_ios_fails_soften_to_warn() {
+        let mut checks = vec![
+            Check::new("xcode", CheckStatus::Fail, "no active developer directory")
+                .with_remedy("install Xcode from the App Store"),
+            Check::new("device", CheckStatus::Ok, "1 iPhone simulator(s) available"),
+        ];
+        soften_inactive_ios(&mut checks);
+        assert_eq!(checks[0].status, CheckStatus::Warn); // Fail → Warn
+        assert!(checks[0]
+            .detail
+            .contains("only required when the ios backend is selected"));
+        assert_eq!(
+            checks[0].remedy.as_deref(),
+            Some("install Xcode from the App Store")
+        ); // remedy preserved
+        assert_eq!(checks[1].status, CheckStatus::Ok); // Ok untouched
+    }
+
+    #[test]
     fn inactive_android_deep_not_requested_keeps_run_with_deep_hint() {
         // --deep was NOT passed: the "run with --deep" hint is the correct next step, so it
         // must be left intact (only the `deep_requested` case is misleading).
@@ -400,9 +450,9 @@ mod tests {
         // is asserted, so it's deterministic regardless of host.
         let d = diagnose(false);
         let titles: Vec<&str> = d.sections.iter().map(|s| s.title.as_str()).collect();
-        // Platform-gated backends compiled into THIS binary get a section; android is
-        // always present (host-OS-agnostic crate) via a runtime gate. No "not built into
-        // this binary" placeholders. Accessibility is per-OS (AT-SPI on Linux, UIA on
+        // Platform-gated backends compiled into THIS binary get a section; android and ios
+        // are always present (host-OS-agnostic crates) via a runtime gate. No "not built
+        // into this binary" placeholders. Accessibility is per-OS (AT-SPI on Linux, UIA on
         // Windows); macOS's grants (Screen Recording, Accessibility) live inside its own
         // "macos" section rather than a separate accessibility section.
         #[cfg(target_os = "linux")]
@@ -415,7 +465,8 @@ mod tests {
                 "wayland",
                 "sandbox",
                 "accessibility (linux)",
-                "android"
+                "android",
+                "ios"
             ]
         );
         #[cfg(windows)]
@@ -427,7 +478,8 @@ mod tests {
                 "windows",
                 "sandbox",
                 "accessibility (windows)",
-                "android"
+                "android",
+                "ios"
             ]
         );
         #[cfg(target_os = "macos")]
@@ -439,13 +491,15 @@ mod tests {
                 "macos",
                 "sandbox",
                 "accessibility (macos)",
-                "android"
+                "android",
+                "ios"
             ]
         );
-        // Android's section is always present and non-empty — its basic presence checks now
-        // run unconditionally (deep probes gated to the selected backend; Fails softened to
-        // Warn when android isn't active). Asserting non-empty catches accidental removal of
-        // the section, without depending on which backend the ambient env resolves to.
+        // Android's and iOS's sections are always present and non-empty — their basic
+        // presence checks now run unconditionally (deep probes gated to the selected
+        // backend; Fails softened to Warn when not active). Asserting non-empty catches
+        // accidental removal of the section, without depending on which backend the
+        // ambient env resolves to.
         let android = d
             .sections
             .iter()
@@ -453,6 +507,13 @@ mod tests {
             .expect("android section");
         assert_eq!(android.backend.as_deref(), Some("android"));
         assert!(!android.checks.is_empty());
+        let ios = d
+            .sections
+            .iter()
+            .find(|s| s.title == "ios")
+            .expect("ios section");
+        assert_eq!(ios.backend.as_deref(), Some("ios"));
+        assert!(!ios.checks.is_empty());
         // The `network` section is always present (Ok when compiled in, else Skip).
         let net = d
             .sections

--- a/crates/glass-mcp/src/env.rs
+++ b/crates/glass-mcp/src/env.rs
@@ -134,7 +134,7 @@ pub(crate) const GLASS_ENV: &[EnvVarDoc] = &[
         purpose: "exact iOS Simulator UDID to drive when several are available",
         default: "the newest booted/available iPhone simulator", secret: false },
     EnvVarDoc { name: "GLASS_IOS_DEVICE", scope: EnvScope::Ios,
-        purpose: "device name to boot when none is running, e.g. \"iPhone 17\" (ignored if GLASS_IOS_UDID is set)",
+        purpose: "device name to boot when none is running, e.g. \"iPhone 17\" or \"iPad Pro 13-inch\" (ignored if GLASS_IOS_UDID is set)",
         default: "the newest available iPhone simulator", secret: false },
     EnvVarDoc { name: "GLASS_SIMULATOR_KEEP", scope: EnvScope::Ios,
         purpose: "leave a glass-booted iOS Simulator running at shutdown instead of stopping it",

--- a/crates/glass-mcp/src/env.rs
+++ b/crates/glass-mcp/src/env.rs
@@ -14,6 +14,7 @@ pub(crate) enum EnvScope {
     Linux,
     Windows,
     Android,
+    Ios,
     Network,
 }
 
@@ -26,19 +27,22 @@ impl EnvScope {
             EnvScope::Linux => "linux",
             EnvScope::Windows => "windows",
             EnvScope::Android => "android",
+            EnvScope::Ios => "ios",
             EnvScope::Network => "network",
         }
     }
 }
 
-/// Fixed group order for output: general → display servers → OS containment → android → network.
-const SCOPE_ORDER: [EnvScope; 7] = [
+/// Fixed group order for output: general → display servers → OS containment → android → ios →
+/// network.
+const SCOPE_ORDER: [EnvScope; 8] = [
     EnvScope::All,
     EnvScope::X11,
     EnvScope::Wayland,
     EnvScope::Linux,
     EnvScope::Windows,
     EnvScope::Android,
+    EnvScope::Ios,
     EnvScope::Network,
 ];
 
@@ -126,6 +130,15 @@ pub(crate) const GLASS_ENV: &[EnvVarDoc] = &[
     EnvVarDoc { name: "GLASS_ANDROID_A11Y", scope: EnvScope::Android,
         purpose: "auto|off \u{2014} disable the a11y service even when the APK is set",
         default: "auto", secret: false },
+    EnvVarDoc { name: "GLASS_IOS_UDID", scope: EnvScope::Ios,
+        purpose: "exact iOS Simulator UDID to drive when several are available",
+        default: "the newest booted/available iPhone simulator", secret: false },
+    EnvVarDoc { name: "GLASS_IOS_DEVICE", scope: EnvScope::Ios,
+        purpose: "device name to boot when none is running, e.g. \"iPhone 17\" (ignored if GLASS_IOS_UDID is set)",
+        default: "the newest available iPhone simulator", secret: false },
+    EnvVarDoc { name: "GLASS_SIMULATOR_KEEP", scope: EnvScope::Ios,
+        purpose: "leave a glass-booted iOS Simulator running at shutdown instead of stopping it",
+        default: "stop it", secret: false },
     EnvVarDoc { name: "GLASS_TOKEN", scope: EnvScope::Network,
         purpose: "Bearer token for the serve --http transport",
         default: "(none)", secret: true },
@@ -310,6 +323,9 @@ mod tests {
             "GLASS_ANDROID_AGENT",
             "GLASS_ANDROID_A11Y_APK",
             "GLASS_ANDROID_A11Y",
+            "GLASS_IOS_UDID",
+            "GLASS_IOS_DEVICE",
+            "GLASS_SIMULATOR_KEEP",
             "GLASS_TOKEN",
             "GLASS_AUDIT_LOG",
             "GLASS_AUDIT_CONTENT",
@@ -355,7 +371,7 @@ mod tests {
             out.find(s)
                 .unwrap_or_else(|| panic!("missing {s} in:\n{out}"))
         };
-        // group order: all < x11 < wayland < linux < windows < android < network
+        // group order: all < x11 < wayland < linux < windows < android < ios < network
         assert!(idx("GLASS_BACKEND") < idx("GLASS_DISPLAY"));
         assert!(idx("GLASS_DISPLAY") < idx("GLASS_SWAY"));
         assert!(idx("GLASS_SWAY") < idx("GLASS_BWRAP"));
@@ -364,7 +380,9 @@ mod tests {
         assert!(idx("GLASS_ANDROID_AGENT_JAR") < idx("GLASS_ANDROID_A11Y_APK"));
         // Use unique purpose snippets to distinguish A11Y_APK from A11Y (prefix-match hazard).
         assert!(idx("glass-a11y.apk") < idx("disable the a11y service"));
-        assert!(idx("disable the a11y service") < idx("GLASS_TOKEN"));
+        assert!(idx("disable the a11y service") < idx("GLASS_IOS_UDID"));
+        assert!(idx("GLASS_IOS_UDID") < idx("GLASS_SIMULATOR_KEEP"));
+        assert!(idx("GLASS_SIMULATOR_KEEP") < idx("GLASS_TOKEN"));
         // adjacency within the windows group
         assert!(idx("GLASS_WIN_SANDBOX_PROVIDER") < idx("GLASS_SANDBOXIE_DIR"));
     }

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -50,8 +50,9 @@ pub fn make_platform(
     registry: &glass_android::EmulatorRegistry,
     agents: &glass_android::AgentRegistry,
     a11y: &glass_android::A11yServiceRegistry,
-    sim_registry: &glass_ios::SimulatorRegistry,
+    #[cfg(target_os = "macos")] sim_registry: &glass_ios::SimulatorRegistry,
 ) -> Result<Backend> {
+    #[cfg(target_os = "macos")]
     if backend == "ios" {
         // No accessibility reader for the iOS Simulator backend yet.
         let platform = glass_ios::IosPlatform::from_env(sim_registry)?;
@@ -102,9 +103,9 @@ pub fn make_platform(
         "macos" => Box::new(glass_macos::MacosPlatform::new()?),
         other => {
             #[cfg(target_os = "linux")]
-            let valid = "\"x11\", \"wayland\", \"android\", or \"ios\"";
+            let valid = "\"x11\", \"wayland\", or \"android\"";
             #[cfg(windows)]
-            let valid = "\"windows\", \"android\", or \"ios\"";
+            let valid = "\"windows\" or \"android\"";
             #[cfg(target_os = "macos")]
             let valid = "\"macos\", \"android\", or \"ios\"";
             return Err(GlassError::Backend(format!(
@@ -276,29 +277,36 @@ pub fn boot(audit: Option<Box<dyn glass_core::AuditSink>>) -> Glass {
     let registry = glass_android::EmulatorRegistry::new();
     let agents = glass_android::AgentRegistry::new();
     let a11y = glass_android::A11yServiceRegistry::new();
+    #[cfg(target_os = "macos")]
     let sim_registry = glass_ios::SimulatorRegistry::new();
     let reg_factory = registry.clone();
     let agents_factory = agents.clone();
     let a11y_factory = a11y.clone();
+    #[cfg(target_os = "macos")]
     let sim_factory = sim_registry.clone();
-    let mut glass = Glass::new(
-        Box::new(move |b| {
-            make_platform(
-                b,
-                &reg_factory,
-                &agents_factory,
-                &a11y_factory,
-                &sim_factory,
-            )
-        }),
-        default,
-        baselines,
-        10_000,
-    );
+    // Two shapes of the same factory closure, so the iOS Simulator registry (and the
+    // glass-ios dependency it requires) only exists on macOS — the only host that can
+    // actually drive `xcrun simctl`. `#[cfg]` on a closure's captured argument isn't
+    // stable, so the closure itself is defined once per branch instead.
+    #[cfg(target_os = "macos")]
+    let platform_factory: glass_core::PlatformFactory = Box::new(move |b| {
+        make_platform(
+            b,
+            &reg_factory,
+            &agents_factory,
+            &a11y_factory,
+            &sim_factory,
+        )
+    });
+    #[cfg(not(target_os = "macos"))]
+    let platform_factory: glass_core::PlatformFactory =
+        Box::new(move |b| make_platform(b, &reg_factory, &agents_factory, &a11y_factory));
+    let mut glass = Glass::new(platform_factory, default, baselines, 10_000);
     glass.set_shutdown_hook(Box::new(move || {
         a11y.shutdown();
         agents.shutdown();
         registry.kill_all();
+        #[cfg(target_os = "macos")]
         sim_registry.shutdown_all();
     }));
     if let Some(sink) = audit {

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -50,7 +50,16 @@ pub fn make_platform(
     registry: &glass_android::EmulatorRegistry,
     agents: &glass_android::AgentRegistry,
     a11y: &glass_android::A11yServiceRegistry,
+    sim_registry: &glass_ios::SimulatorRegistry,
 ) -> Result<Backend> {
+    if backend == "ios" {
+        // No accessibility reader for the iOS Simulator backend yet.
+        let platform = glass_ios::IosPlatform::from_env(sim_registry)?;
+        return Ok(Backend {
+            platform: Box::new(platform),
+            accessibility: None,
+        });
+    }
     if backend == "android" {
         let platform = glass_android::AndroidPlatform::from_env(registry, agents)?;
         let get = |k: &str| std::env::var(k).ok();
@@ -93,11 +102,11 @@ pub fn make_platform(
         "macos" => Box::new(glass_macos::MacosPlatform::new()?),
         other => {
             #[cfg(target_os = "linux")]
-            let valid = "\"x11\", \"wayland\", or \"android\"";
+            let valid = "\"x11\", \"wayland\", \"android\", or \"ios\"";
             #[cfg(windows)]
-            let valid = "\"windows\" or \"android\"";
+            let valid = "\"windows\", \"android\", or \"ios\"";
             #[cfg(target_os = "macos")]
-            let valid = "\"macos\" or \"android\"";
+            let valid = "\"macos\", \"android\", or \"ios\"";
             return Err(GlassError::Backend(format!(
                 "unknown backend {other:?}; use {valid}"
             )));
@@ -127,11 +136,12 @@ pub fn make_platform(
 }
 
 /// Default backend name from `GLASS_BACKEND` (case-insensitive
-/// `wayland`/`windows`/`macos`/`x11`/`android`). Unset defaults to the windows backend on
-/// a Windows host, the macos backend on a macOS host, else X11.
+/// `wayland`/`windows`/`macos`/`x11`/`android`/`ios`). Unset defaults to the windows backend
+/// on a Windows host, the macos backend on a macOS host, else X11.
 pub fn default_backend(env: Option<&str>) -> &'static str {
     match env {
         Some(v) if v.eq_ignore_ascii_case("android") => "android",
+        Some(v) if v.eq_ignore_ascii_case("ios") => "ios",
         Some(v) if v.eq_ignore_ascii_case("wayland") => "wayland",
         Some(v) if v.eq_ignore_ascii_case("windows") => "windows",
         Some(v) if v.eq_ignore_ascii_case("macos") => "macos",
@@ -266,11 +276,21 @@ pub fn boot(audit: Option<Box<dyn glass_core::AuditSink>>) -> Glass {
     let registry = glass_android::EmulatorRegistry::new();
     let agents = glass_android::AgentRegistry::new();
     let a11y = glass_android::A11yServiceRegistry::new();
+    let sim_registry = glass_ios::SimulatorRegistry::new();
     let reg_factory = registry.clone();
     let agents_factory = agents.clone();
     let a11y_factory = a11y.clone();
+    let sim_factory = sim_registry.clone();
     let mut glass = Glass::new(
-        Box::new(move |b| make_platform(b, &reg_factory, &agents_factory, &a11y_factory)),
+        Box::new(move |b| {
+            make_platform(
+                b,
+                &reg_factory,
+                &agents_factory,
+                &a11y_factory,
+                &sim_factory,
+            )
+        }),
         default,
         baselines,
         10_000,
@@ -279,6 +299,7 @@ pub fn boot(audit: Option<Box<dyn glass_core::AuditSink>>) -> Glass {
         a11y.shutdown();
         agents.shutdown();
         registry.kill_all();
+        sim_registry.shutdown_all();
     }));
     if let Some(sink) = audit {
         glass.set_audit_sink(sink);
@@ -317,6 +338,12 @@ mod tests {
     fn android_backend_is_selectable_by_name() {
         assert_eq!(super::default_backend(Some("android")), "android");
         assert_eq!(super::default_backend(Some("ANDROID")), "android");
+    }
+
+    #[test]
+    fn default_backend_accepts_ios() {
+        assert_eq!(default_backend(Some("ios")), "ios");
+        assert_eq!(default_backend(Some("IOS")), "ios");
     }
 
     #[test]

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -53,9 +53,9 @@ pub struct StartArgs {
     /// Program and arguments to launch; `run[0]` is the executable.
     pub run: Vec<String>,
     /// Backend to launch under: `"x11"` or `"wayland"` (Linux), `"windows"` (on a
-    /// Windows host), `"macos"` (on a macOS host), or `"android"` (an AVD emulator, any
-    /// host). Omit for the server default (`GLASS_BACKEND`, else `windows` on Windows,
-    /// `macos` on macOS, else x11).
+    /// Windows host), `"macos"` (on a macOS host), `"android"` (an AVD emulator, any
+    /// host), or `"ios"` (an iOS Simulator, macOS host). Omit for the server default
+    /// (`GLASS_BACKEND`, else `windows` on Windows, `macos` on macOS, else x11).
     pub backend: Option<String>,
     /// Containment level for the launched app: `"default"` (filesystem/process
     /// containment, network on), `"strict"` (also no network), or `"off"` (no

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ way it does? The explanations.
 - [Windows](how-to/setup-windows.md)
 - [macOS](how-to/setup-macos.md)
 - [Android](how-to/setup-android.md) — an AVD emulator, from any host
+- [iOS](how-to/setup-ios.md) — the Simulator, macOS host only
 
 **Connect and drive**
 

--- a/docs/explanation/backends.md
+++ b/docs/explanation/backends.md
@@ -15,7 +15,7 @@ the choice is per-call, an agent can drive an X11 app and a Wayland app in the s
 server restart. The backend is built when the app is launched, so the server boots even on a host with
 no display or compositor at all.
 
-## The five backends
+## The six backends
 
 - **X11 (Linux)** — spawns its own private headless `Xvfb`, or attaches to a display you name.
 - **Wayland (Linux)** — spawns a private headless `sway` (a wlroots compositor) per session. sway also
@@ -24,6 +24,10 @@ no display or compositor at all.
   Automation), so it needs a logged-in session to render and capture.
 - **Android** — drives a native app in an AVD emulator over `adb`; host-OS-agnostic, since it just
   shells out to `adb`. The VM *is* the sandbox.
+- **iOS** — drives a native app on an iOS Simulator over `xcrun simctl`; macOS-host-only, since the
+  Simulator and `simctl` ship with Xcode. The Simulator *is* the sandbox. This backend captures, reads
+  logs, and drives the clipboard; pointer/keyboard input and the accessibility tree are not implemented
+  yet.
 - **macOS** — drives the logged-in Aqua session (ScreenCaptureKit capture, CGEvent input, AXUIElement
   windows), gated by macOS's privacy permissions.
 
@@ -48,7 +52,8 @@ persistent display you manage (handy for watching over VNC); and `:0` deliberate
 desktop — which only ever happens because you asked for it by name.
 
 On **Android**, the emulator provides the same isolation for free: glass can boot a headless AVD that
-is entirely separate from your session.
+is entirely separate from your session. On **iOS**, the Simulator gives the same result: glass boots it
+through `simctl` without opening the Simulator app, so the app it drives never appears on your desktop.
 
 On **Windows**, isolation is weaker. There is one interactive desktop, and even a virtual-display
 driver only adds a monitor to *that* desktop rather than walling the app off — for full isolation you

--- a/docs/explanation/containment.md
+++ b/docs/explanation/containment.md
@@ -24,12 +24,14 @@ code doing what you asked, whereas the launched app is the thing under test.
 
 ## Per-OS mechanisms
 
-Containment is one idea with four implementations:
+Containment has a different implementation per OS:
 
 - **Linux** — [bubblewrap](https://github.com/containers/bubblewrap), which also needs unprivileged
   user namespaces enabled.
 - **Windows** — [Sandboxie](https://sandboxie-plus.com) (Classic, the free default, or Plus).
 - **Android** — the emulator VM itself; there is no separate containment step.
+- **iOS** — the Simulator itself is the isolation boundary; like Android, there is no separate
+  containment step (and no sandbox crate).
 - **macOS** — the OS's built-in **Seatbelt** sandbox (`sandbox_init`); nothing to install.
 
 ## The macOS Seatbelt profile

--- a/docs/how-to/setup-ios.md
+++ b/docs/how-to/setup-ios.md
@@ -1,0 +1,81 @@
+# Set up glass for iOS
+
+The iOS backend drives a native app on an **iOS Simulator** over `xcrun simctl`. It is
+**macOS-only** — the Simulator only runs on macOS, and `xcrun`/`simctl` ship with Xcode — so
+unlike the Android backend, there is no cross-host story here.
+
+Select the backend per launch with `glass_start`'s `backend: "ios"`, or make it the default with
+`GLASS_BACKEND=ios`.
+
+> This release observes iOS apps — launch, screenshot, logs, clipboard. Tapping/typing and the
+> accessibility tree are not yet available; `glass_click`/`glass_type`/`glass_key` and the a11y
+> tools return an unsupported error on this backend.
+
+## Install Xcode and a Simulator runtime
+
+You need the **full Xcode** app (not just the Command Line Tools) — it ships `simctl` and the
+Simulator app itself:
+
+```bash
+xcode-select -p   # should print .../Xcode.app/Contents/Developer, not CommandLineTools
+```
+
+If it prints a Command Line Tools path, or nothing, install Xcode from the App Store, then point
+`xcode-select` at it:
+
+```bash
+sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+```
+
+Xcode doesn't bundle an iOS runtime by default. Download one (this can take a while — it's a
+multi-GB image):
+
+```bash
+xcodebuild -downloadPlatform iOS
+```
+
+You also need at least one iPhone simulator device. Xcode creates a few by default; if none
+exist, create one:
+
+```bash
+xcrun simctl list devices available   # see what's already there
+xcrun simctl create "iPhone glass" "iPhone 17"
+```
+
+## Attach-or-boot
+
+Like the Android backend, glass prefers to attach: if a Simulator is already booted it uses it;
+otherwise it boots the newest available iPhone simulator itself and shuts it down again on
+shutdown.
+
+- `GLASS_IOS_UDID` — drive an exact device by UDID (see `xcrun simctl list devices`).
+- `GLASS_IOS_DEVICE` — boot a device by name, e.g. `"iPhone 17"`, when none is running (ignored
+  if `GLASS_IOS_UDID` is set).
+- `GLASS_SIMULATOR_KEEP` — set to keep a glass-booted Simulator running past shutdown instead of
+  shutting it down.
+
+(All variables: [reference/environment.md](../reference/environment.md).)
+
+## Launching an app
+
+`glass_start`'s `run[0]` is either a path to a `.app` bundle (glass installs it on the Simulator
+for you) or the bundle id of an app already installed, e.g.:
+
+```jsonc
+glass_start { "backend": "ios", "run": ["/path/to/YourApp.app"] }
+// or, already installed:
+glass_start { "backend": "ios", "run": ["tech.example.YourApp"] }
+```
+
+The Simulator reports one fullscreen window per app — there's no window management (resize/move
+are unsupported, matching a real device).
+
+## Check the setup
+
+```bash
+GLASS_BACKEND=ios glass-mcp doctor
+```
+
+Reports whether full Xcode is active, `simctl` works, an iOS runtime is downloaded, and an iPhone
+simulator is available — each failing check comes with its own remedy (the commands above). Then
+[connect your agent](connect-an-agent.md).

--- a/docs/how-to/setup-ios.md
+++ b/docs/how-to/setup-ios.md
@@ -49,8 +49,10 @@ otherwise it boots the newest available iPhone simulator itself and shuts it dow
 shutdown.
 
 - `GLASS_IOS_UDID` — drive an exact device by UDID (see `xcrun simctl list devices`).
-- `GLASS_IOS_DEVICE` — boot a device by name, e.g. `"iPhone 17"`, when none is running (ignored
-  if `GLASS_IOS_UDID` is set).
+- `GLASS_IOS_DEVICE` — boot a device by name, e.g. `"iPhone 17"` or `"iPad Pro 13-inch"`, when
+  none is running (ignored if `GLASS_IOS_UDID` is set). Names any iOS-family simulator — iPhone or
+  iPad; watchOS, tvOS, and visionOS simulators are not eligible, whether attaching to an
+  already-booted one or booting one by name.
 - `GLASS_SIMULATOR_KEEP` — set to keep a glass-booted Simulator running past shutdown instead of
   shutting it down.
 

--- a/docs/how-to/setup-macos.md
+++ b/docs/how-to/setup-macos.md
@@ -87,6 +87,7 @@ remove glass entirely.
   behaviour are in [explanation/containment.md](../explanation/containment.md).
 - **Building from source** (contributors, unreleased checkouts): [build-from-source.md](build-from-source.md).
 - **Android** from a macOS host: [setup-android.md](setup-android.md).
+- **iOS** (the Simulator, on this macOS host): [setup-ios.md](setup-ios.md).
 
 ## Problems?
 

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -65,6 +65,18 @@ The companion files are auto-discovered next to the `glass-mcp` binary or in gla
 easiest setup is to drop `glass-agent.jar` / `glass-a11y.apk` there; the `*_JAR` / `*_APK` vars above only
 override that with an explicit path. Full setup is in [how-to/setup-android.md](../how-to/setup-android.md).
 
+## iOS
+
+| Variable | Purpose | Default | Scope |
+|---|---|---|---|
+| `GLASS_IOS_UDID` | Exact Simulator UDID to drive when several are available | the newest booted/available iPhone simulator | iOS |
+| `GLASS_IOS_DEVICE` | Device name to boot when none is running, e.g. `iPhone 17` (ignored if `GLASS_IOS_UDID` is set) | the newest available iPhone simulator | iOS |
+| `GLASS_SIMULATOR_KEEP` | Leave a glass-booted iOS Simulator running at shutdown instead of stopping it | stop it | iOS |
+
+Attach-or-boot works the same way as the Android group above: glass attaches to an already-booted
+Simulator, or boots the newest available iPhone simulator itself. Full setup is in
+[how-to/setup-ios.md](../how-to/setup-ios.md).
+
 ## Network transport
 
 | Variable | Purpose | Default | Scope |

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -70,11 +70,13 @@ override that with an explicit path. Full setup is in [how-to/setup-android.md](
 | Variable | Purpose | Default | Scope |
 |---|---|---|---|
 | `GLASS_IOS_UDID` | Exact Simulator UDID to drive when several are available | the newest booted/available iPhone simulator | iOS |
-| `GLASS_IOS_DEVICE` | Device name to boot when none is running, e.g. `iPhone 17` (ignored if `GLASS_IOS_UDID` is set) | the newest available iPhone simulator | iOS |
+| `GLASS_IOS_DEVICE` | Device name to boot when none is running, e.g. `iPhone 17` or `iPad Pro 13-inch` (ignored if `GLASS_IOS_UDID` is set) | the newest available iPhone simulator | iOS |
 | `GLASS_SIMULATOR_KEEP` | Leave a glass-booted iOS Simulator running at shutdown instead of stopping it | stop it | iOS |
 
 Attach-or-boot works the same way as the Android group above: glass attaches to an already-booted
-Simulator, or boots the newest available iPhone simulator itself. Full setup is in
+Simulator, or boots the newest available iPhone simulator itself. `GLASS_IOS_DEVICE` names any
+iOS-family simulator (iPhone or iPad); watchOS, tvOS, and visionOS simulators are never eligible,
+whether attaching to an already-booted one or booting one by name. Full setup is in
 [how-to/setup-ios.md](../how-to/setup-ios.md).
 
 ## Network transport

--- a/docs/reference/platforms.md
+++ b/docs/reference/platforms.md
@@ -4,12 +4,12 @@
 
 Where glass stands by OS. **✓** supported · **◑** partial · **–** not supported · **🚧** planned.
 
-| Capability | Linux (X11 + Wayland) | Windows | Android (AVD) | macOS |
-|---|:--:|:--:|:--:|:--:|
-| Capture · input · windows · clipboard · logs | ✓ | ✓ | ✓ † | ✓ ‡ |
-| Accessibility (semantic addressing) | ✓ AT-SPI | ✓ UI Automation | ✓ UIAutomator | ✓ AX |
-| Containment / sandboxing | ✓ bubblewrap | ✓ Sandboxie Classic | ✓ the emulator VM | ✓ ‡ |
-| Display isolation (app off your desktop) | ✓ headless Xvfb / sway | ◑ virtual display · VM tier | ✓ headless emulator | 🚧 |
+| Capability | Linux (X11 + Wayland) | Windows | Android (AVD) | iOS (Simulator) | macOS |
+|---|:--:|:--:|:--:|:--:|:--:|
+| Capture · input · windows · clipboard · logs | ✓ | ✓ | ✓ † | ◑ § | ✓ ‡ |
+| Accessibility (semantic addressing) | ✓ AT-SPI | ✓ UI Automation | ✓ UIAutomator | – | ✓ AX |
+| Containment / sandboxing | ✓ bubblewrap | ✓ Sandboxie Classic | ✓ the emulator VM | ✓ the Simulator | ✓ ‡ |
+| Display isolation (app off your desktop) | ✓ headless Xvfb / sway | ◑ virtual display · VM tier | ✓ headless emulator | ✓ headless simctl boot | 🚧 |
 
 **Transport:** MCP over **stdio** (default, all platforms) or **network HTTP** (`glass-mcp serve
 --http`, all platforms) — the network transport is behind the default-on `network` cargo feature (a
@@ -19,7 +19,8 @@ Per-tool platform notes live in [reference/tools.md](tools.md); the mechanisms b
 explained in [explanation/backends.md](../explanation/backends.md) and
 [explanation/containment.md](../explanation/containment.md). Setup is per host:
 [Linux](../how-to/setup-linux.md) · [Windows](../how-to/setup-windows.md) ·
-[macOS](../how-to/setup-macos.md) · [Android](../how-to/setup-android.md).
+[macOS](../how-to/setup-macos.md) · [Android](../how-to/setup-android.md) ·
+[iOS](../how-to/setup-ios.md).
 
 ## System requirements
 
@@ -37,6 +38,10 @@ explained in [explanation/backends.md](../explanation/backends.md) and
 - **Android** — emulator-only; developed and tested against **Android 14 (API 34)**. The `adb` backend
   assumes no particular version; the optional on-device companions declare an Android 7.0 (API 24)
   floor. See [how-to/setup-android.md](../how-to/setup-android.md).
+- **iOS** — Simulator-only; **macOS host required** (`xcrun`/`simctl` ship with Xcode). No particular
+  iOS runtime version is assumed — whichever runtime Xcode has downloaded works; real iPhones are out
+  of scope, matching the Android backend's emulator-only stance. See
+  [how-to/setup-ios.md](../how-to/setup-ios.md).
 
 ## Notes
 
@@ -47,6 +52,16 @@ AccessibilityService sharpens the a11y tree (Compose) and `glass_set_value`. Wit
 falls back to `adb`'s `input` (single-pointer only) and clipboard is unavailable; without the service,
 a11y falls back to `uiautomator`. Window resize/move (apps are full-screen) and physical devices are
 non-goals.
+
+**§ iOS** is Simulator-only — macOS host required (`xcrun`/`simctl` ship with Xcode). Capture,
+clipboard, and logs are implemented; the on-box path is exercised by a manual smoke test on a macOS
+host with a booted Simulator (this backend has no macOS CI runner yet, so only its host-independent
+logic — device resolution, `simctl` argument construction, doctor checks — runs in CI). Window support
+is geometry/focus only: resize and move are unsupported, since Simulator apps, like a real device, are
+always fullscreen. Pointer/keyboard input and the accessibility tree are not implemented yet;
+`glass_click`/`glass_type`/`glass_key` and the a11y tools return an unsupported error on this backend.
+Containment has no separate glass-managed step, the same as Android — the Simulator's per-app data
+container is the isolation boundary.
 
 **‡ macOS** capture, input, windows, clipboard, and logs are built and CI-tested (ScreenCaptureKit
 capture, CGEvent input, AXUIElement windows). Containment is Seatbelt (`sandbox_init`): filesystem and
@@ -64,6 +79,10 @@ CI-tested. An **Android** backend drives native apps in an AVD emulator over `ad
 logcat, multi-window, a `uiautomator` accessibility tree, a managed AVD (attach-or-boot), and two
 optional on-device companions (an agent for clipboard + high-fidelity input, and an
 AccessibilityService for a Compose-rich a11y tree + high-fidelity `set_value`); built and unit-tested
-in CI and validated on-device. The **macOS** backend (ScreenCaptureKit capture, CGEvent input,
-AXUIElement windows/logs, an AXUIElement accessibility tree, and Seatbelt process containment) is
-built and CI-tested.
+in CI and validated on-device. An **iOS** backend drives native apps on an iOS Simulator over `xcrun
+simctl` — capture, clipboard, logs, and a managed Simulator (attach-or-boot, matching the Android
+emulator's model); window support is geometry/focus only, and pointer/keyboard input and the
+accessibility tree are not implemented yet. Its host-independent logic is unit-tested in CI; the
+on-box path against a real Simulator is exercised manually on a macOS host. The **macOS** backend
+(ScreenCaptureKit capture, CGEvent input, AXUIElement windows/logs, an AXUIElement accessibility tree,
+and Seatbelt process containment) is built and CI-tested.

--- a/docs/reference/platforms.md
+++ b/docs/reference/platforms.md
@@ -55,7 +55,7 @@ non-goals.
 
 **§ iOS** is Simulator-only — macOS host required (`xcrun`/`simctl` ship with Xcode). Capture,
 clipboard, and logs are implemented; the on-box path is exercised by a manual smoke test on a macOS
-host with a booted Simulator (this backend has no macOS CI runner yet, so only its host-independent
+host with a booted Simulator (no CI wiring on the macOS runner yet, so only its host-independent
 logic — device resolution, `simctl` argument construction, doctor checks — runs in CI). Window support
 is geometry/focus only: resize and move are unsupported, since Simulator apps, like a real device, are
 always fullscreen. Pointer/keyboard input and the accessibility tree are not implemented yet;

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -34,8 +34,8 @@ Build, launch, and locate a native GUI app; returns its window geometry.
 - `cwd` (string) — working directory for `build` and `run`.
 - `env` (array of `[name, value]` pairs) — extra environment for the launched app.
 - `backend` (string) — `"x11"` or `"wayland"` (Linux), `"windows"` (Windows host), `"macos"` (macOS
-  host), or `"android"` (an AVD emulator, any host). Omit for the server default (`GLASS_BACKEND`,
-  else `windows` on Windows, `macos` on macOS, else `x11`).
+  host), `"android"` (an AVD emulator, any host), or `"ios"` (an iOS Simulator, macOS host). Omit for
+  the server default (`GLASS_BACKEND`, else `windows` on Windows, `macos` on macOS, else `x11`).
 - `sandbox` (string) — `"default"`, `"strict"`, or `"off"`. Omit for the server default
   (`GLASS_SANDBOX`, else `default`). See [explanation/containment.md](../explanation/containment.md).
 - `window_hint` (`{ title?, class? }`) — disambiguate which window is the app's when several appear,
@@ -161,6 +161,9 @@ Returns `{matched, line{seq, stream, text}, cursor, elapsed_ms}`; resume reading
 `["ctrl"]`, `["ctrl","shift"]`) held during the action — enabling shift/ctrl-click multi-select,
 modified drags, and Ctrl+scroll.
 
+The input tools are not available on the **iOS** backend this release: `glass_click`, `glass_type`,
+`glass_key`, `glass_scroll`, and `glass_drag` return an unsupported error there.
+
 ### `glass_click`
 
 Click at window-relative coordinates.
@@ -257,14 +260,16 @@ Focus, resize, or move the active window, or read its geometry.
 - `x`, `y` (integer) — target position for `"move"`.
 - `width`, `height` (integer) — target size for `"resize"`.
 
-Resize/move are non-goals on Android (apps are full-screen).
+Resize/move are non-goals on Android and iOS (apps are full-screen); those backends serve `"focus"`
+and `"geometry"` but return an unsupported error for `"resize"`/`"move"`.
 
 ## Accessibility (semantic addressing)
 
 Deterministic, low-token element addressing that complements the pixel loop. Available where the app
 exposes an accessibility tree (most GTK/Qt/toolkit apps — not bare canvas/game UIs); these tools
 **error** for an app with no accessible UI rather than return a fake tree, so fall back to
-`glass_screenshot` then. On Linux, start the app with `glass_start`'s `a11y:true`. See
+`glass_screenshot` then. On Linux, start the app with `glass_start`'s `a11y:true`. The **iOS** backend
+has no accessibility tree this release, so these tools return an unsupported error there. See
 [reference/platforms.md](platforms.md) for per-OS backends (AT-SPI / UI Automation / uiautomator / AX).
 
 ### `glass_a11y_snapshot`
@@ -325,7 +330,8 @@ Both act on the **app's** clipboard, isolated from your real clipboard on the pr
 backends, on a contained Windows app (a private boxed clipboard), and on a contained macOS app that
 isn't built with Apple's hardened runtime (a shim redirects it to a private pasteboard glass shares).
 A hardened-runtime macOS app (App Store / notarized) can't be redirected, so these return
-`Unsupported`; on Android they need the on-device agent. Only shared-desktop modes (`GLASS_DISPLAY=:0`,
+`Unsupported`; on Android they need the on-device agent; on iOS they act on the Simulator's own
+pasteboard, which is separate from the host's. Only shared-desktop modes (`GLASS_DISPLAY=:0`,
 or the Windows/macOS backend with `sandbox:off`) touch your **real** clipboard. See
 [explanation/containment.md](../explanation/containment.md#clipboard-isolation).
 


### PR DESCRIPTION
## Summary

Adds `glass-ios`, a backend that drives native iOS apps in the **iOS Simulator** by shelling out to `xcrun simctl` (pure shell-out, `#![forbid(unsafe_code)]`, no platform-specific linking). Its structure mirrors the existing `glass-android` backend; the Simulator is the isolation boundary, so there is no sandbox crate. Select it with `GLASS_BACKEND=ios`.

## What works in this release

- **Launch / stop** an app — install a `.app` (bundle id read from its `Info.plist`) or launch an already-installed bundle id.
- **Capture** — `simctl io screenshot` decoded to an RGBA `Frame`; region crops reuse `glass_core::Frame::crop`.
- **Logs** — `simctl log stream` drained incrementally into the log buffer.
- **Clipboard** — get/set via `simctl pbcopy`/`pbpaste` (native to the Simulator; no on-device agent needed).
- **Doctor** — a preflight that checks the active Xcode, an installed iOS runtime, and an available iPhone simulator, each with an actionable remedy.

**Not yet supported:** pointer/keyboard input return `Unsupported`, and there is no accessibility tree. A later release adds them via an on-simulator driver. This boundary is stated in the user docs and the capability matrix.

## Host requirement & backend selection

- Requires macOS + Xcode + an installed iOS runtime — the tooling is Apple's. The backend is **compile-time gated to macOS**: `glass-mcp` depends on `glass-ios` only under `[target.'cfg(target_os = "macos")'.dependencies]`, so Linux and Windows builds carry neither the crate nor its `image`/PNG-codec dependency. `glass-ios` remains a workspace member, so its unit tests still run in CI. `GLASS_BACKEND=ios` is macOS-only and never a host default; on other hosts it reports a clear unknown-backend error.
- Env vars: `GLASS_IOS_UDID` (exact device), `GLASS_IOS_DEVICE` (device name, any iOS-family simulator incl. iPad), `GLASS_SIMULATOR_KEEP` (don't shut down a simulator glass booted). Resolution attaches to a booted iOS-family simulator (preferring iPhone) or boots the newest available one; watchOS/tvOS/visionOS simulators are never selected.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass on both Linux (glass-mcp + glass-ios unit tests) and macOS (where the backend compiles in). glass-ios carries 41 unit tests covering device resolution, doctor logic, the platform state machine, capture crop, and arg building.
- An `#[ignore]`d end-to-end smoke test (`crates/glass-ios/tests/smoke_integration.rs`, launch → capture → clipboard round-trip → stop) was run against a real iPhone simulator (iOS 26.5, Xcode 26.6) and passes.
- Reviewed with the multi-lens PR review panel; findings were addressed (session-state guards on capture/clipboard so a call before launch returns a structured error rather than a stale frame; process reaping on the log-stream and clipboard paths; iOS-family device filtering; macOS gating so non-macOS binaries stay free of the iOS crate and its codec dependency).

## Docs

Adds `docs/how-to/setup-ios.md` and brings iOS into the capability matrix, the environment-variable reference, the backend list, and the tool reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
