### PR TITLE
docs: make the repo self-sufficient for installation, and bind the tool reference to the registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ internal refactors, CI, or test-only changes.
   releases and drop them next to the `glass-mcp` binary, where glass discovers them automatically
   (no environment variables, no build step). `GLASS_ANDROID_AGENT_JAR` / `GLASS_ANDROID_A11Y_APK`
   are documented as overrides of that auto-discovery.
+- Installing glass now starts from the Releases page rather than a source build: `README.md`,
+  `docs/how-to/setup-linux.md`, and `docs/how-to/setup-windows.md` lead with the prebuilt binary.
+- `docs/reference/platforms.md` documents the assets each release attaches.
 
 ### Fixed
 - `doctor --deep` no longer tells you to "run with --deep" for the Android `screencap` and

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ screenshots cost no vision tokens. Why the loop is shaped this way:
 
 ## Install at a glance
 
-Build the server with `cargo build --release -p glass-mcp` (Rust via [rustup](https://rustup.rs); the
-pinned nightly installs automatically), then set up your host:
+Download the latest build for your platform from the
+[Releases page](https://github.com/fixed-width/glass/releases/latest), then set up your host:
 
 - **Linux** — [docs/how-to/setup-linux.md](docs/how-to/setup-linux.md) (X11 or Wayland; `Xvfb` /
   `sway` + bubblewrap)
@@ -46,6 +46,10 @@ pinned nightly installs automatically), then set up your host:
 - **Android** — [docs/how-to/setup-android.md](docs/how-to/setup-android.md) (an AVD emulator, from any
   host)
 - **iOS** — [docs/how-to/setup-ios.md](docs/how-to/setup-ios.md) (the Simulator, macOS host only)
+
+Every asset is listed in [docs/reference/platforms.md](docs/reference/platforms.md#release-artifacts).
+Prefer to compile, or on an architecture with no published asset? See
+[docs/how-to/build-from-source.md](docs/how-to/build-from-source.md) — it is a single `cargo build`.
 
 Then [connect glass to your agent](docs/how-to/connect-an-agent.md) and run `glass-mcp doctor` to check
 the environment. New here? Follow [the tutorial](docs/tutorial/first-drive.md) for a guaranteed first

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -532,6 +532,7 @@ impl ServerHandler for GlassServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
 
     fn first_text(r: &CallToolResult) -> String {
         r.content[0].as_text().expect("text content").text.clone()
@@ -561,5 +562,45 @@ mod tests {
             "an Ok must surface as a success result"
         );
         assert!(first_text(&r).contains("done"), "got {:?}", first_text(&r));
+    }
+
+    /// The tool reference is the only user-facing list of glass's tools. Bind it to the
+    /// registry so a tool added, removed, or renamed in code cannot silently diverge from
+    /// the documentation.
+    const TOOLS_MD: &str = include_str!("../../../docs/reference/tools.md");
+
+    /// Tool names are keyed off level-3 headings wrapping the name in backticks. Prose also
+    /// mentions a `glass_wait_for_*` family glob, which a looser scan would report as a tool.
+    fn documented_tools() -> BTreeSet<String> {
+        TOOLS_MD
+            .lines()
+            .filter_map(|line| line.strip_prefix("### `"))
+            .filter_map(|rest| rest.strip_suffix('`'))
+            .map(str::to_owned)
+            .collect()
+    }
+
+    fn registered_tools() -> BTreeSet<String> {
+        GlassServer::tool_router()
+            .list_all()
+            .into_iter()
+            .map(|tool| tool.name.into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn tool_reference_documents_exactly_the_registry() {
+        let documented = documented_tools();
+        let registered = registered_tools();
+
+        let undocumented: Vec<_> = registered.difference(&documented).collect();
+        let phantom: Vec<_> = documented.difference(&registered).collect();
+
+        assert!(
+            undocumented.is_empty() && phantom.is_empty(),
+            "docs/reference/tools.md is out of sync with the #[tool] registry\n  \
+             registered but undocumented: {undocumented:?}\n  \
+             documented but not registered: {phantom:?}"
+        );
     }
 }

--- a/docs/how-to/setup-linux.md
+++ b/docs/how-to/setup-linux.md
@@ -5,11 +5,26 @@ private headless display, so there is no desktop or window manager to configure.
 prerequisites and the per-backend specifics; for *why* the display model works this way, see
 [explanation/backends.md](../explanation/backends.md).
 
+## Install the binary
+
+Download the latest Linux build from the
+[Releases page](https://github.com/fixed-width/glass/releases/latest) and extract it:
+
+```bash
+tar xzf glass-mcp-*-x86_64-linux-gnu.tar.gz
+cd glass-mcp-*-x86_64-linux-gnu
+```
+
+Use the `…-x86_64-linux-musl.tar.gz` build instead if you need a fully static binary with no glibc
+dependency — Alpine, or any musl distro. If you are on an architecture with no published asset (an
+aarch64 host, say), [build from source](build-from-source.md) instead; that is also the path if you
+want to hack on glass. The full asset list is in
+[reference/platforms.md](../reference/platforms.md#release-artifacts).
+
 ## Prerequisites
 
-**Rust**, via [rustup](https://rustup.rs). glass pins a nightly toolchain in `rust-toolchain.toml`;
-rustup installs it automatically on the first build. (To build the binary, see
-[build-from-source.md](build-from-source.md); tagged releases also attach prebuilt Linux binaries.)
+glass needs a display dependency for your backend and a containment runtime, both covered below.
+Nothing else — the released binary is self-contained.
 
 ## X11 (the default)
 

--- a/docs/how-to/setup-linux.md
+++ b/docs/how-to/setup-linux.md
@@ -22,6 +22,10 @@ mkdir -p ~/.local/bin
 cp glass-mcp ~/.local/bin/glass-mcp
 ```
 
+If `glass-mcp` is not found afterwards, start a new login shell — many distributions add
+`~/.local/bin` to `PATH` only when it already exists at login — or add the directory to your `PATH`
+yourself.
+
 Use the `…-x86_64-linux-musl.tar.gz` build instead if you need a fully static binary with no glibc
 dependency — Alpine, or any musl distro. If you are on an architecture with no published asset (an
 aarch64 host, say), [build from source](build-from-source.md) instead; that is also the path if you

--- a/docs/how-to/setup-linux.md
+++ b/docs/how-to/setup-linux.md
@@ -1,9 +1,9 @@
 # Set up glass on Linux
 
 Linux has two backends — **X11** (the default) and **Wayland** (a headless sway). Both spawn their own
-private headless display, so there is no desktop or window manager to configure. This guide covers the
-prerequisites and the per-backend specifics; for *why* the display model works this way, see
-[explanation/backends.md](../explanation/backends.md).
+private headless display, so there is no desktop or window manager to configure. This guide covers
+installing the binary, the prerequisites, and the per-backend specifics; for *why* the display model
+works this way, see [explanation/backends.md](../explanation/backends.md).
 
 ## Install the binary
 
@@ -13,6 +13,13 @@ Download the latest Linux build from the
 ```bash
 tar xzf glass-mcp-*-x86_64-linux-gnu.tar.gz
 cd glass-mcp-*-x86_64-linux-gnu
+```
+
+Put `glass-mcp` somewhere on your PATH, e.g. `~/.local/bin`:
+
+```bash
+mkdir -p ~/.local/bin
+cp glass-mcp ~/.local/bin/glass-mcp
 ```
 
 Use the `…-x86_64-linux-musl.tar.gz` build instead if you need a fully static binary with no glibc

--- a/docs/how-to/setup-windows.md
+++ b/docs/how-to/setup-windows.md
@@ -24,15 +24,16 @@ install directory. `GLASS_WIN_SANDBOX_PROVIDER` (`auto`|`sandboxie`|`none`) sele
 
 ## Install the binary
 
+Download `glass-mcp-*-x86_64-windows.zip` from the
+[Releases page](https://github.com/fixed-width/glass/releases/latest) and extract it. (The full asset
+list is in [reference/platforms.md](../reference/platforms.md#release-artifacts).)
+
 Copy `glass-mcp.exe` somewhere on your PATH, e.g. `%USERPROFILE%\bin`:
 
 ```powershell
 mkdir $env:USERPROFILE\bin -Force
 copy glass-mcp.exe $env:USERPROFILE\bin\glass-mcp.exe
 ```
-
-(Tagged releases attach a prebuilt Windows binary; to build it yourself see
-[build-from-source.md](build-from-source.md).)
 
 > **First run — SmartScreen.** Prebuilt binaries are not yet Authenticode-signed, so the first launch
 > may show Microsoft Defender SmartScreen's "Windows protected your PC". Click **More info → Run

--- a/docs/how-to/setup-windows.md
+++ b/docs/how-to/setup-windows.md
@@ -35,6 +35,9 @@ mkdir $env:USERPROFILE\bin -Force
 copy glass-mcp.exe $env:USERPROFILE\bin\glass-mcp.exe
 ```
 
+If you want to hack on glass or are on an architecture with no published asset,
+[build from source](build-from-source.md) instead.
+
 > **First run — SmartScreen.** Prebuilt binaries are not yet Authenticode-signed, so the first launch
 > may show Microsoft Defender SmartScreen's "Windows protected your PC". Click **More info → Run
 > anyway**. This is a publisher-trust prompt, not a permission request — glass needs no permission

--- a/docs/how-to/setup-windows.md
+++ b/docs/how-to/setup-windows.md
@@ -35,6 +35,10 @@ mkdir $env:USERPROFILE\bin -Force
 copy glass-mcp.exe $env:USERPROFILE\bin\glass-mcp.exe
 ```
 
+`%USERPROFILE%\bin` is not on `PATH` by default, so `glass-mcp` won't be found afterwards —
+add the directory via Windows' Environment Variables settings and open a new terminal, or
+copy `glass-mcp.exe` into a directory that's already on `PATH` instead.
+
 If you want to hack on glass or are on an architecture with no published asset,
 [build from source](build-from-source.md) instead.
 

--- a/docs/reference/platforms.md
+++ b/docs/reference/platforms.md
@@ -49,7 +49,7 @@ Every tagged release attaches these assets, where `<tag>` is the release tag (e.
 
 | Platform | Asset |
 |---|---|
-| macOS (universal) | `glass-mcp-<tag>-universal-apple-darwin.dmg` — notarized; also a `.zip` of `GlassMcp.app` |
+| macOS (universal) | `glass-mcp-<tag>-universal-apple-darwin.dmg` — notarized; also `glass-mcp-<tag>-universal-apple-darwin.zip` of `GlassMcp.app` |
 | Linux x86-64 (glibc) | `glass-mcp-<tag>-x86_64-linux-gnu.tar.gz` |
 | Linux x86-64 (static) | `glass-mcp-<tag>-x86_64-linux-musl.tar.gz` — no glibc dependency (Alpine and other musl distros) |
 | Windows x86-64 | `glass-mcp-<tag>-x86_64-windows.zip` |

--- a/docs/reference/platforms.md
+++ b/docs/reference/platforms.md
@@ -43,6 +43,21 @@ explained in [explanation/backends.md](../explanation/backends.md) and
   of scope, matching the Android backend's emulator-only stance. See
   [how-to/setup-ios.md](../how-to/setup-ios.md).
 
+## Release artifacts
+
+Every tagged release attaches these assets, where `<tag>` is the release tag (e.g. `v0.3.1`):
+
+| Platform | Asset |
+|---|---|
+| macOS (universal) | `glass-mcp-<tag>-universal-apple-darwin.dmg` — notarized; also a `.zip` of `GlassMcp.app` |
+| Linux x86-64 (glibc) | `glass-mcp-<tag>-x86_64-linux-gnu.tar.gz` |
+| Linux x86-64 (static) | `glass-mcp-<tag>-x86_64-linux-musl.tar.gz` — no glibc dependency (Alpine and other musl distros) |
+| Windows x86-64 | `glass-mcp-<tag>-x86_64-windows.zip` |
+
+Each asset is accompanied by a `.sha256` checksum file, and every release carries Sigstore build
+provenance attestations. No aarch64 Linux asset is published; that architecture is built from source
+(see [how-to/build-from-source.md](../how-to/build-from-source.md)).
+
 ## Notes
 
 **† Android** is emulator-only. Capture, multi-window, input, and logs work over `adb`, and glass


### PR DESCRIPTION
The repo's install path assumed a source build. `README.md` opened with `cargo build --release -p glass-mcp`, `docs/how-to/setup-linux.md` had no install step at all — its prerequisites led with "Rust, via rustup" — and `docs/how-to/setup-windows.md` said to copy `glass-mcp.exe` onto `PATH` without ever saying where the `.exe` came from. So the docs routed every new reader into compiling, even though releases ship a notarized `.dmg`, two Linux tarballs, and a Windows `.zip`.

Now all three desktop guides start at the Releases page. macOS was already correct and is untouched.

## What changed

**Reference.** `docs/reference/platforms.md` gains a `## Release artifacts` section describing the assets each release attaches, as `<tag>` patterns so the table cannot go stale per release. Names verified against `.github/workflows/release.yml`.

**How-to.** `setup-linux.md` gains an `## Install the binary` section and drops Rust from its prerequisites (Rust is a prerequisite of `build-from-source.md`, not of running a released binary). `setup-windows.md`'s install section now says where the `.exe` comes from. Both guides link the reference table rather than restating it, and both now tell the reader what to do when the install directory isn't on `PATH` — without which the bare `glass-mcp doctor` in each guide's `## Verify` was false as written.

No new page: installing is a how-to and belongs inside each per-OS guide, so a reader is never bounced out to a separate install page and back. The artifact names are reference facts and live once.

**Signpost.** `README.md`'s "Install at a glance" leads with the Releases page; `cargo build` is demoted to a pointer at `build-from-source.md` rather than removed.

**Test.** `docs/reference/tools.md` is the only user-facing list of the `glass_*` tools, and nothing tied it to the code. A unit test now enumerates the real `#[tool]` registry through the generated `tool_router` and asserts the reference documents exactly it — so a tool added, removed, or renamed in `server.rs` cannot silently diverge from its documentation. Tool names are keyed off ``### `glass_x` `` headings, because prose mentions a `glass_wait_for_*` family glob that a looser scan would report as a tool.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` are clean. The new test was confirmed to fail — not merely to pass — by removing a tool heading from the reference and observing `registered but undocumented: ["glass_diff"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)