### PR TITLE
glass doctor --deep: verify idb_companion actually starts (#114)

### DIFF
--- a/crates/glass-ios/src/doctor.rs
+++ b/crates/glass-ios/src/doctor.rs
@@ -5,9 +5,13 @@
 //! Pure `build_checks(&Probe)` over observed state, plus the thin subprocess-probing
 //! `checks(deep)` entry point the aggregator calls.
 
-use std::process::Command;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 use glass_core::{Check, CheckStatus};
+
+use crate::idb::companion::companion_bin;
 
 /// Observed host state for the iOS doctor checks. Captured by `run`, consumed by the
 /// pure `checks` so all branch logic is unit-testable without subprocesses.
@@ -137,6 +141,105 @@ pub fn checks(_deep: bool) -> Vec<Check> {
     })
 }
 
+/// Outcome of the `--deep` iOS `idb_companion` health probe (see [`probe_companion`]). Pure
+/// data — the aggregator (`glass-mcp`) maps it to a `Check`. `NotFound` means the binary is
+/// unresolvable; `Started`/`FailedToStart` come from a real spawn against an already-booted
+/// simulator; `SelfTestOk`/`SelfTestFailed` come from the bounded `--version` fallback used
+/// when no simulator is booted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompanionProbe {
+    NotFound,
+    Started,
+    FailedToStart(String),
+    SelfTestOk,
+    SelfTestFailed(String),
+}
+
+/// Self-test flag. `idb_companion --version` needs no simulator, exits promptly with status
+/// 0, and prints a build-info line (confirmed against idb-companion 1.1.8). It may print a
+/// benign objc dyld warning to *stderr* while still exiting 0, so success keys on the exit
+/// status — never on empty stderr.
+#[cfg_attr(not(test), allow(dead_code))]
+const SELF_TEST_ARG: &str = "--version";
+/// Backstop only: `--version` returns near-instantly, so this bounds a wedged/hung binary.
+#[cfg_attr(not(test), allow(dead_code))]
+const SELF_TEST_TIMEOUT: Duration = Duration::from_secs(5);
+/// Poll interval while waiting for the self-test child to exit.
+#[cfg_attr(not(test), allow(dead_code))]
+const SELF_TEST_POLL: Duration = Duration::from_millis(50);
+
+/// Run the companion's bounded `--version` self-test: does the binary actually execute? Used
+/// only when no simulator is booted (so a real spawn isn't possible without booting one).
+/// Captures stderr to a temp file — a file can't fill and block, mirroring `IdbCompanion` —
+/// and surfaces it as the cause on failure. Success ⇒ [`CompanionProbe::SelfTestOk`].
+///
+/// Not yet called from `checks()` — the probe orchestration that picks between a real spawn
+/// and this fallback lands in a follow-up change.
+#[allow(dead_code)]
+fn self_test() -> CompanionProbe {
+    self_test_with(&companion_bin(&|k| std::env::var(k).ok()))
+}
+
+/// [`self_test`] against an explicit binary path — the testable seam (no env / no real
+/// companion needed).
+#[cfg_attr(not(test), allow(dead_code))]
+fn self_test_with(bin: &str) -> CompanionProbe {
+    // A uniquely-named temp file (rather than a name keyed on this process's pid) — several
+    // self-tests can run concurrently in one process, e.g. this module's own tests running in
+    // parallel, and a pid-only name would let them collide on the same log file.
+    let log = match tempfile::NamedTempFile::new() {
+        Ok(f) => f,
+        Err(e) => return CompanionProbe::SelfTestFailed(format!("create self-test log: {e}")),
+    };
+    let stderr = match log.reopen() {
+        Ok(f) => f,
+        Err(e) => return CompanionProbe::SelfTestFailed(format!("create self-test log: {e}")),
+    };
+    let mut child = match Command::new(bin)
+        .arg(SELF_TEST_ARG)
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(stderr))
+        .stdin(Stdio::null())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            return CompanionProbe::SelfTestFailed(format!("spawn {bin} {SELF_TEST_ARG}: {e}"))
+        }
+    };
+    let deadline = Instant::now() + SELF_TEST_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) if status.success() => break CompanionProbe::SelfTestOk,
+            Ok(Some(status)) => {
+                let stderr = read_trimmed(log.path()).filter(|s| !s.is_empty());
+                break CompanionProbe::SelfTestFailed(match stderr {
+                    Some(s) => format!("{SELF_TEST_ARG} exited {status}: {s}"),
+                    None => format!("{SELF_TEST_ARG} exited {status}"),
+                });
+            }
+            Ok(None) if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                break CompanionProbe::SelfTestFailed(format!(
+                    "{SELF_TEST_ARG} timed out after {SELF_TEST_TIMEOUT:?}"
+                ));
+            }
+            Ok(None) => std::thread::sleep(SELF_TEST_POLL),
+            Err(e) => break CompanionProbe::SelfTestFailed(format!("try_wait: {e}")),
+        }
+    }
+    // `log` (a `NamedTempFile`) removes its file on drop here.
+}
+
+/// Read a file and trim it, or `None` if it can't be read.
+#[cfg_attr(not(test), allow(dead_code))]
+fn read_trimmed(path: &Path) -> Option<String> {
+    std::fs::read_to_string(path)
+        .ok()
+        .map(|s| s.trim().to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -214,5 +317,49 @@ mod tests {
             cs.iter().find(|c| c.name == "device").unwrap().status,
             CheckStatus::Fail
         );
+    }
+
+    #[test]
+    fn self_test_ok_when_binary_exits_zero() {
+        // `/bin/echo --version` prints and exits 0 regardless of args — stands in for a
+        // healthy idb_companion whose real `--version` also exits 0.
+        assert_eq!(self_test_with("/bin/echo"), CompanionProbe::SelfTestOk);
+    }
+
+    #[test]
+    fn self_test_fails_and_captures_cause_on_nonzero_exit() {
+        // A fake binary that writes to stderr and exits non-zero: the probe must surface both
+        // the exit status and the captured stderr as the cause. idb_companion prints a benign
+        // objc warning to stderr while still exiting 0, so success keys on exit status — this
+        // asserts the *failure* branch does read stderr for the cause.
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("fake_companion");
+        std::fs::write(&script, "#!/bin/sh\necho 'boom-from-stderr' >&2\nexit 3\n").expect("write");
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+
+        match self_test_with(script.to_str().unwrap()) {
+            CompanionProbe::SelfTestFailed(cause) => {
+                assert!(
+                    cause.contains("boom-from-stderr"),
+                    "cause missing stderr: {cause}"
+                );
+                assert!(cause.contains('3'), "cause missing exit status: {cause}");
+            }
+            other => panic!("expected SelfTestFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn self_test_fails_when_binary_is_unspawnable() {
+        match self_test_with("/nonexistent/definitely-not-a-binary") {
+            CompanionProbe::SelfTestFailed(cause) => {
+                assert!(
+                    cause.contains("spawn"),
+                    "cause should name the spawn failure: {cause}"
+                );
+            }
+            other => panic!("expected SelfTestFailed, got {other:?}"),
+        }
     }
 }

--- a/crates/glass-ios/src/doctor.rs
+++ b/crates/glass-ios/src/doctor.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
-use glass_core::{Check, CheckStatus};
+use glass_core::{Check, CheckStatus, GlassError};
 
 use crate::device::{parse_devices, resolve, Resolve, SimDevice};
 use crate::idb::companion::{companion_bin, IdbCompanion};
@@ -263,10 +263,22 @@ pub fn probe_companion() -> CompanionProbe {
                 drop(companion);
                 CompanionProbe::Started
             }
-            // The error already embeds the companion's captured stderr.
-            Err(e) => CompanionProbe::FailedToStart(e.to_string()),
+            // The error already embeds the companion's captured stderr; strip the redundant
+            // `GlassError::Backend` Display prefix (the mapping frames it "failed to start: …").
+            Err(e) => CompanionProbe::FailedToStart(spawn_cause(e)),
         },
         None => self_test(),
+    }
+}
+
+/// The human cause from a failed [`IdbCompanion::spawn`], stripped of `GlassError::Backend`'s
+/// `"backend error: "` Display prefix — the doctor already frames it as "failed to start: …",
+/// so the prefix would read redundantly in user-facing output. Any other variant falls back
+/// to its full Display.
+fn spawn_cause(e: GlassError) -> String {
+    match e {
+        GlassError::Backend(msg) => msg,
+        other => other.to_string(),
     }
 }
 
@@ -294,6 +306,18 @@ fn booted_from(devices: &[SimDevice]) -> Option<String> {
 mod tests {
     use super::*;
     use crate::device::SimDevice;
+
+    #[test]
+    fn spawn_cause_strips_backend_error_prefix() {
+        // `FailedToStart` detail is framed "failed to start: {cause}", so the
+        // `GlassError::Backend` Display prefix ("backend error: ") would read redundantly.
+        assert_eq!(
+            spawn_cause(GlassError::Backend(
+                "idb_companion exited (exit status: 1) before serving its socket".into()
+            )),
+            "idb_companion exited (exit status: 1) before serving its socket"
+        );
+    }
 
     fn dev(udid: &str, name: &str, state: &str) -> SimDevice {
         SimDevice {

--- a/crates/glass-ios/src/doctor.rs
+++ b/crates/glass-ios/src/doctor.rs
@@ -11,7 +11,9 @@ use std::time::{Duration, Instant};
 
 use glass_core::{Check, CheckStatus};
 
-use crate::idb::companion::companion_bin;
+use crate::device::{parse_devices, resolve, Resolve, SimDevice};
+use crate::idb::companion::{companion_bin, IdbCompanion};
+use crate::simctl::Simctl;
 
 /// Observed host state for the iOS doctor checks. Captured by `run`, consumed by the
 /// pure `checks` so all branch logic is unit-testable without subprocesses.
@@ -159,30 +161,22 @@ pub enum CompanionProbe {
 /// 0, and prints a build-info line (confirmed against idb-companion 1.1.8). It may print a
 /// benign objc dyld warning to *stderr* while still exiting 0, so success keys on the exit
 /// status — never on empty stderr.
-#[cfg_attr(not(test), allow(dead_code))]
 const SELF_TEST_ARG: &str = "--version";
 /// Backstop only: `--version` returns near-instantly, so this bounds a wedged/hung binary.
-#[cfg_attr(not(test), allow(dead_code))]
 const SELF_TEST_TIMEOUT: Duration = Duration::from_secs(5);
 /// Poll interval while waiting for the self-test child to exit.
-#[cfg_attr(not(test), allow(dead_code))]
 const SELF_TEST_POLL: Duration = Duration::from_millis(50);
 
 /// Run the companion's bounded `--version` self-test: does the binary actually execute? Used
 /// only when no simulator is booted (so a real spawn isn't possible without booting one).
 /// Captures stderr to a temp file — a file can't fill and block, mirroring `IdbCompanion` —
 /// and surfaces it as the cause on failure. Success ⇒ [`CompanionProbe::SelfTestOk`].
-///
-/// Not yet called from `checks()` — the probe orchestration that picks between a real spawn
-/// and this fallback lands in a follow-up change.
-#[allow(dead_code)]
 fn self_test() -> CompanionProbe {
     self_test_with(&companion_bin(&|k| std::env::var(k).ok()))
 }
 
 /// [`self_test`] against an explicit binary path — the testable seam (no env / no real
 /// companion needed).
-#[cfg_attr(not(test), allow(dead_code))]
 fn self_test_with(bin: &str) -> CompanionProbe {
     // A uniquely-named temp file (rather than a name keyed on this process's pid) — several
     // self-tests can run concurrently in one process, e.g. this module's own tests running in
@@ -233,16 +227,101 @@ fn self_test_with(bin: &str) -> CompanionProbe {
 }
 
 /// Read a file and trim it, or `None` if it can't be read.
-#[cfg_attr(not(test), allow(dead_code))]
 fn read_trimmed(path: &Path) -> Option<String> {
     std::fs::read_to_string(path)
         .ok()
         .map(|s| s.trim().to_string())
 }
 
+/// Is the companion binary resolvable — `GLASS_IDB_COMPANION` naming an existing file, or
+/// `idb_companion` found on `PATH`? The passive (non-`--deep`) presence signal, and the
+/// `NotFound` gate for [`probe_companion`]. Uses the same [`companion_bin`] resolution the
+/// runtime spawn does.
+pub fn companion_present() -> bool {
+    let bin = companion_bin(&|k| std::env::var(k).ok());
+    if bin.contains('/') {
+        Path::new(&bin).is_file()
+    } else {
+        std::env::var_os("PATH")
+            .is_some_and(|path| std::env::split_paths(&path).any(|dir| dir.join(&bin).is_file()))
+    }
+}
+
+/// The `--deep` iOS companion health probe: does `idb_companion` actually start? Reuses the
+/// real runtime spawn path against an *already-booted* simulator — never booting one, so it
+/// stays bounded (the spawn carries its own 10s socket deadline) and non-mutating. When no
+/// simulator is booted, falls back to the bounded [`self_test`] so `--deep` still yields a
+/// signal. Only the aggregator's macOS-only ios section calls this.
+pub fn probe_companion() -> CompanionProbe {
+    if !companion_present() {
+        return CompanionProbe::NotFound;
+    }
+    match booted_udid() {
+        Some(udid) => match IdbCompanion::spawn(&udid) {
+            // Dropping the companion kills+reaps the child and removes its socket.
+            Ok(companion) => {
+                drop(companion);
+                CompanionProbe::Started
+            }
+            // The error already embeds the companion's captured stderr.
+            Err(e) => CompanionProbe::FailedToStart(e.to_string()),
+        },
+        None => self_test(),
+    }
+}
+
+/// UDID of an already-booted iOS simulator, or `None` if none is booted (or the device list
+/// can't be read). A `simctl`/parse failure yields `None` so [`probe_companion`] falls back
+/// to the self-test rather than erroring.
+fn booted_udid() -> Option<String> {
+    let list = Simctl::new()
+        .run(&["list", "devices", "available", "--json"])
+        .ok()?;
+    booted_from(&parse_devices(&list).ok()?)
+}
+
+/// Pure booted-sim selection: `resolve(_, None, None)` returns `Attach` iff an iOS sim is
+/// already booted, so `Attach` is exactly "spawn against it without booting"; `Boot`/`Error`
+/// mean nothing is booted. The testable seam for [`booted_udid`].
+fn booted_from(devices: &[SimDevice]) -> Option<String> {
+    match resolve(devices, None, None) {
+        Resolve::Attach(udid) => Some(udid),
+        Resolve::Boot(_) | Resolve::Error(_) => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::device::SimDevice;
+
+    fn dev(udid: &str, name: &str, state: &str) -> SimDevice {
+        SimDevice {
+            udid: udid.into(),
+            name: name.into(),
+            state: state.into(),
+            runtime: "com.apple.CoreSimulator.SimRuntime.iOS-26-5".into(),
+            is_available: true,
+        }
+    }
+
+    #[test]
+    fn booted_from_picks_a_booted_ios_sim() {
+        let devices = vec![
+            dev("AAA", "iPhone 17", "Shutdown"),
+            dev("BBB", "iPhone 17 Pro", "Booted"),
+        ];
+        assert_eq!(booted_from(&devices), Some("BBB".to_string()));
+    }
+
+    #[test]
+    fn booted_from_is_none_when_nothing_is_booted() {
+        let devices = vec![
+            dev("AAA", "iPhone 17", "Shutdown"),
+            dev("CCC", "iPhone 15", "Shutdown"),
+        ];
+        assert_eq!(booted_from(&devices), None);
+    }
 
     #[test]
     fn all_green_when_fully_configured() {

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -252,15 +252,20 @@ fn soften_inactive_ios(checks: &mut [Check]) {
     soften_inactive_fails(checks, "ios");
 }
 
-/// Whether `idb_companion` — the process that serves iOS Simulator input and the
-/// accessibility tree — is resolvable, and the remedy to show when it isn't. Pure: takes
-/// the already-resolved fact so it's unit-tested without touching PATH/env;
-/// [`idb_companion_present`] gathers the real fact on macOS, the only host that runs it.
-/// A missing binary is a `Warn`, not a `Fail`: `glass_ios::doctor::checks` already fails
-/// the run over a genuinely broken iOS setup (no Xcode, no simulator); this just flags a
-/// companion tool that's one `brew install` away. Its only caller is macOS-only (above);
-/// kept out of `#[cfg]` (instead of gating the fn itself) so the test below still runs in
-/// CI on every host.
+/// The shared `idb_companion` install remedy.
+#[cfg_attr(not(any(target_os = "macos", test)), allow(dead_code))]
+const IDB_COMPANION_REMEDY: &str =
+    "brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion";
+
+/// The check for a resolvable/unresolvable `idb_companion` on the *passive* (non-`--deep`)
+/// path — takes the already-resolved presence fact so it's unit-tested without touching
+/// PATH/env; `glass_ios::doctor::companion_present` gathers the real fact on macOS. A missing
+/// companion is a **Fail**, not a Warn: unlike android — which keeps barebones function
+/// without its companions — the iOS companion is required to drive apps at all, so without it
+/// iOS is observe-only (unusable for development). Because this check is only added when iOS
+/// is the *selected* backend, the Fail reddens the verdict only for someone actually driving
+/// iOS. Kept out of `#[cfg]` (only its caller is macOS-only) so the test still runs on every
+/// host.
 #[cfg_attr(not(any(target_os = "macos", test)), allow(dead_code))]
 pub(crate) fn idb_companion_check(found: bool) -> Check {
     if found {
@@ -270,13 +275,20 @@ pub(crate) fn idb_companion_check(found: bool) -> Check {
             "idb_companion found — input + accessibility are available",
         )
     } else {
-        Check::new(
-            "idb_companion",
-            CheckStatus::Warn,
-            "idb_companion not found — input + accessibility are unavailable",
-        )
-        .with_remedy("brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion")
+        idb_companion_not_found_check()
     }
+}
+
+/// The Fail check for an absent `idb_companion`, shared by the passive presence path and the
+/// `--deep` probe's CompanionProbe::NotFound mapping.
+#[cfg_attr(not(any(target_os = "macos", test)), allow(dead_code))]
+fn idb_companion_not_found_check() -> Check {
+    Check::new(
+        "idb_companion",
+        CheckStatus::Fail,
+        "idb_companion not found — input + accessibility are unavailable (iOS cannot drive apps)",
+    )
+    .with_remedy(IDB_COMPANION_REMEDY)
 }
 
 /// Real-environment probe for [`idb_companion_check`]: is `idb_companion` resolvable —
@@ -422,13 +434,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn idb_companion_check_warns_when_absent_and_oks_when_present() {
+    fn idb_companion_check_fails_when_absent_and_oks_when_present() {
+        // The iOS companion is *required* to drive apps (unlike android's optional companions);
+        // without it iOS is observe-only, which is not a usable dev workflow — so absent is a
+        // Fail, not a Warn.
         let absent = idb_companion_check(false);
-        assert_eq!(absent.status, CheckStatus::Warn);
-        assert_eq!(
-            absent.remedy.as_deref(),
-            Some("brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion")
-        );
+        assert_eq!(absent.status, CheckStatus::Fail);
+        assert_eq!(absent.remedy.as_deref(), Some(IDB_COMPANION_REMEDY));
         let present = idb_companion_check(true);
         assert_eq!(present.status, CheckStatus::Ok);
         assert_eq!(present.remedy, None);

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -161,11 +161,17 @@ fn diagnose_inner(deep: bool, audit: Option<&crate::audit::AuditReport>) -> Diag
     {
         let ios_selected = backend == "ios";
         let mut ios_checks = glass_ios::doctor::checks(deep && ios_selected);
-        // idb_companion drives input and the accessibility reader; only worth reporting
-        // when ios is actually the backend in play, mirroring how android's deep probes
-        // are gated to `android_selected` above.
+        // The companion drives input + the accessibility reader; only worth reporting when
+        // ios is actually the backend in play, mirroring android's gated deep probes. On
+        // --deep, probe it for real (spawn against a booted sim, else a bounded self-test);
+        // otherwise just report resolvable-on-PATH presence.
         if ios_selected {
-            ios_checks.push(idb_companion_check(idb_companion_present()));
+            let companion = if deep {
+                companion_deep_check(glass_ios::doctor::probe_companion())
+            } else {
+                idb_companion_check(glass_ios::doctor::companion_present())
+            };
+            ios_checks.push(companion);
         }
         if !ios_selected {
             soften_inactive_ios(&mut ios_checks);
@@ -280,7 +286,7 @@ pub(crate) fn idb_companion_check(found: bool) -> Check {
 }
 
 /// The Fail check for an absent `idb_companion`, shared by the passive presence path and the
-/// `--deep` probe's CompanionProbe::NotFound mapping.
+/// `--deep` probe's `CompanionProbe::NotFound` mapping.
 #[cfg_attr(not(any(target_os = "macos", test)), allow(dead_code))]
 fn idb_companion_not_found_check() -> Check {
     Check::new(
@@ -291,18 +297,42 @@ fn idb_companion_not_found_check() -> Check {
     .with_remedy(IDB_COMPANION_REMEDY)
 }
 
-/// Real-environment probe for [`idb_companion_check`]: is `idb_companion` resolvable —
-/// `GLASS_IDB_COMPANION` naming an existing file, or `idb_companion` found on `PATH`?
-/// Mirrors `glass_ios`'s own resolution of the same binary (`idb::companion::companion_bin`),
-/// duplicated here because that module is private to `glass-ios`.
+/// Map a `--deep` iOS companion probe ([`glass_ios::doctor::probe_companion`]) to a `Check`.
+/// Pure — the probe's I/O is done by the caller — so it's unit-tested per variant without a
+/// real companion. Broken (`FailedToStart`/`SelfTestFailed`) or missing (`NotFound`) ⇒ Fail:
+/// iOS cannot drive apps without the companion. Unverified (`SelfTestOk` — the binary runs but
+/// no booted simulator was available to exercise a real start) ⇒ Warn. macOS-gated: it names a
+/// `glass-ios` type, and glass-mcp only depends on glass-ios on macOS (mirrors `macos_checks_from`).
 #[cfg(target_os = "macos")]
-fn idb_companion_present() -> bool {
-    let bin = glass_core::tool_path("GLASS_IDB_COMPANION", "idb_companion");
-    if bin.contains('/') {
-        std::path::Path::new(&bin).is_file()
-    } else {
-        std::env::var_os("PATH")
-            .is_some_and(|path| std::env::split_paths(&path).any(|dir| dir.join(&bin).is_file()))
+pub(crate) fn companion_deep_check(probe: glass_ios::doctor::CompanionProbe) -> Check {
+    use glass_ios::doctor::CompanionProbe;
+    match probe {
+        CompanionProbe::Started => Check::new(
+            "idb_companion",
+            CheckStatus::Ok,
+            "started and served its gRPC socket — input + accessibility are available",
+        ),
+        CompanionProbe::SelfTestOk => Check::new(
+            "idb_companion",
+            CheckStatus::Warn,
+            "binary runs, but no booted simulator was available to verify a real start — \
+             boot one and re-run with --deep to exercise the companion",
+        ),
+        CompanionProbe::FailedToStart(cause) => Check::new(
+            "idb_companion",
+            CheckStatus::Fail,
+            format!(
+                "failed to start: {cause} — input + accessibility are unavailable (iOS is observe-only)"
+            ),
+        )
+        .with_remedy(IDB_COMPANION_REMEDY),
+        CompanionProbe::SelfTestFailed(cause) => Check::new(
+            "idb_companion",
+            CheckStatus::Fail,
+            format!("binary failed to execute: {cause} — input + accessibility are unavailable"),
+        )
+        .with_remedy(IDB_COMPANION_REMEDY),
+        CompanionProbe::NotFound => idb_companion_not_found_check(),
     }
 }
 
@@ -642,6 +672,16 @@ mod tests {
     }
 
     #[test]
+    fn missing_companion_fails_the_ios_verdict() {
+        // A Fail companion check in the ios section must escalate the overall verdict to Fail
+        // (exit code 1) when ios is the backend — iOS is unusable without the companion.
+        let ios = Section::new("ios", Some("ios".into()), vec![idb_companion_check(false)]);
+        let d = Diagnosis::new(vec![ios]);
+        assert_eq!(d.overall("ios"), CheckStatus::Fail);
+        assert_eq!(d.exit_code("ios"), 1);
+    }
+
+    #[test]
     fn diagnose_with_audit_reports_posture() {
         let on = crate::audit::AuditReport {
             enabled: true,
@@ -841,6 +881,41 @@ mod tests {
                 c.remedy_action.as_deref(),
                 Some(format!("open {}", glass_macos::accessibility_pane_url()).as_str())
             );
+        }
+
+        #[test]
+        fn companion_deep_check_maps_every_probe_outcome() {
+            use glass_ios::doctor::CompanionProbe;
+
+            let started = companion_deep_check(CompanionProbe::Started);
+            assert_eq!(started.status, CheckStatus::Ok);
+            assert_eq!(started.remedy, None);
+
+            let unverified = companion_deep_check(CompanionProbe::SelfTestOk);
+            assert_eq!(unverified.status, CheckStatus::Warn);
+
+            let broken =
+                companion_deep_check(CompanionProbe::FailedToStart("exited 1: boom".into()));
+            assert_eq!(broken.status, CheckStatus::Fail);
+            assert!(
+                broken.detail.contains("boom"),
+                "cause must surface: {}",
+                broken.detail
+            );
+            assert_eq!(broken.remedy.as_deref(), Some(IDB_COMPANION_REMEDY));
+
+            let unrunnable =
+                companion_deep_check(CompanionProbe::SelfTestFailed("spawn: nope".into()));
+            assert_eq!(unrunnable.status, CheckStatus::Fail);
+            assert!(
+                unrunnable.detail.contains("nope"),
+                "cause must surface: {}",
+                unrunnable.detail
+            );
+
+            let missing = companion_deep_check(CompanionProbe::NotFound);
+            assert_eq!(missing.status, CheckStatus::Fail);
+            assert_eq!(missing.remedy.as_deref(), Some(IDB_COMPANION_REMEDY));
         }
     }
 }


### PR DESCRIPTION
Closes #114.

## What changed

`glass doctor --deep` now verifies the iOS `idb_companion` companion actually **starts**, instead of reporting OK on mere PATH presence. A present-but-broken companion (a resolvable binary that fails on spawn — e.g. an incompatible version) previously read green while the backend silently degraded to observe-only at runtime.

On the `--deep` iOS path (when iOS is the selected backend), the doctor now:

- **Spawns the companion for real against an already-booted simulator** — reusing the runtime `IdbCompanion::spawn` path, bounded by its existing socket deadline. It **never boots** a simulator, so the probe stays bounded and non-mutating.
- **Falls back to a bounded `idb_companion --version` self-test** when no simulator is booted, so `--deep` still yields a signal (reported as an unverified **Warn**).
- **Reports the real outcome with the captured cause** (no silent OK):
  - started + served its gRPC socket → **OK**
  - binary runs but no booted sim to verify → **Warn**
  - failed to start / binary won't execute → **Fail**, with the companion's captured cause
  - not found → **Fail**

A broken **or missing** companion now **Fails** the iOS verdict (previously a missing companion was only a Warn). Unlike Android — which keeps barebones function without its companions — the iOS companion is required to drive apps; without it the backend is observe-only, which isn't a usable workflow. This only reddens the verdict when iOS is the selected backend.

Also removes glass-mcp's duplicated companion-binary resolver in favor of the new `glass_ios::doctor::companion_present`.

## Verification

Unit tests (host-agnostic on Linux CI + a macOS-gated mapping test). Real-behavior checks on macOS (`glass-mcp doctor --deep`, `GLASS_BACKEND=ios`):

| scenario | result |
|---|---|
| `idb_companion --version` | exits 0 |
| booted sim, real companion | `✓ idb_companion: started and served its gRPC socket` |
| booted sim, incompatible binary | `✗ idb_companion: failed to start: idb_companion exited (exit status: 1) before serving its socket: … — input + accessibility are unavailable (iOS is observe-only)` |
| no booted sim | `⚠ idb_companion: binary runs, but no booted simulator was available to verify a real start` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
