### PR TITLE
docs: changelog — doctor --deep verifies idb_companion actually starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,10 @@ internal refactors, CI, or test-only changes.
   log streaming, and clipboard for native iOS apps in the Simulator, driven through `xcrun simctl`, plus
   input (tap/click, type, swipe, scroll) and the accessibility tree (snapshot, click-element, set-value)
   over [`idb_companion`](docs/how-to/setup-ios.md#input--accessibility) when it is installed. Includes a
-  `glass doctor` preflight for Xcode, an installed iOS runtime, an available simulator, and `idb_companion`.
+  `glass doctor` preflight for Xcode, an installed iOS runtime, an available simulator, and `idb_companion`;
+  with `--deep`, the preflight spawns `idb_companion` for real against an already-booted simulator (or runs a
+  bounded `idb_companion --version` self-test when none is booted) and fails if the companion is broken or
+  missing, rather than trusting that it is merely resolvable on `PATH`.
   Multi-touch gestures (`glass_gesture`) are not supported on the Simulator yet.
 - A [Windows access model](docs/explanation/windows-permissions.md) explanation: Windows needs no
   per-app permission grants (unlike macOS), what actually gates access (interactive session, UAC/UIPI


### PR DESCRIPTION
Follow-up to #120: refines the unreleased iOS-backend `[Unreleased]` changelog bullet to note that `glass doctor --deep` now spawns `idb_companion` for real against a booted simulator (or a bounded `--version` self-test) and fails on a broken/missing companion, rather than trusting mere PATH presence.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)