### PR TITLE
test(glass-ios): de-flake two glass-ios tests (dead-socket + ETXTBSY self-test)

### DIFF
--- a/crates/glass-ios/src/doctor.rs
+++ b/crates/glass-ios/src/doctor.rs
@@ -440,17 +440,33 @@ mod tests {
         let script = dir.path().join("fake_companion");
         std::fs::write(&script, "#!/bin/sh\necho 'boom-from-stderr' >&2\nexit 3\n").expect("write");
         std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        let bin = script.to_str().unwrap();
 
-        match self_test_with(script.to_str().unwrap()) {
-            CompanionProbe::SelfTestFailed(cause) => {
-                assert!(
-                    cause.contains("boom-from-stderr"),
-                    "cause missing stderr: {cause}"
-                );
-                assert!(cause.contains('3'), "cause missing exit status: {cause}");
+        // Retry past a transient ETXTBSY ("Text file busy", os error 26): `cargo test` runs
+        // tests on parallel threads, and a sibling thread's `Command::spawn` (fork) can
+        // momentarily inherit the write fd of the just-written fixture, so exec'ing it races
+        // until that fork execs and closes the fd. This affects only a freshly-written test
+        // fixture, never the already-installed real idb_companion, so the retry lives here
+        // rather than in `self_test_with`.
+        let mut cause = None;
+        for _ in 0..100 {
+            match self_test_with(bin) {
+                CompanionProbe::SelfTestFailed(c) if c.contains("Text file busy") => {
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+                CompanionProbe::SelfTestFailed(c) => {
+                    cause = Some(c);
+                    break;
+                }
+                other => panic!("expected SelfTestFailed, got {other:?}"),
             }
-            other => panic!("expected SelfTestFailed, got {other:?}"),
         }
+        let cause = cause.expect("self_test_with kept returning ETXTBSY after 100 retries");
+        assert!(
+            cause.contains("boom-from-stderr"),
+            "cause missing stderr: {cause}"
+        );
+        assert!(cause.contains('3'), "cause missing exit status: {cause}");
     }
 
     #[test]

--- a/crates/glass-ios/src/idb/client.rs
+++ b/crates/glass-ios/src/idb/client.rs
@@ -194,22 +194,30 @@ mod tests {
     }
 
     #[test]
-    fn connect_to_dead_socket_errors_cleanly() {
-        // A UDS path that exists but has no listener behind it — the "stale idb
-        // socket" case (companion died, leaving its socket file). `connect` is
-        // refused at the transport layer (ECONNREFUSED) and maps to a structured
-        // Backend error, no panic, promptly.
-        //
-        // Deterministic by construction: bind then immediately drop the listener,
-        // so the socket file lingers with nothing listening. There is no live peer,
-        // hence no accept-vs-handshake timing race (an earlier version raced on
-        // whether tonic's h2 preface write buffered before the peer's reset).
+    fn dead_socket_is_handled_cleanly_at_connect_or_first_rpc() {
+        // A stale socket file — the companion died, leaving its socket behind. Whether the
+        // failure surfaces at `connect` or at the first RPC is a tonic/HTTP-2 timing detail:
+        // `connect` can return `Ok` once the stream dials and the client preface is buffered,
+        // before the peer's reset is observed. `connect` makes no promise to reject a dead
+        // socket — liveness is really validated earlier (the companion's `await_socket` at
+        // spawn) and backstopped by `RPC_TIMEOUT` on the first RPC. What we guarantee, and
+        // assert here deterministically so it can't flake on connect's timing, is that a dead
+        // socket is handled cleanly: a structured `Backend` error, never a panic, at one of
+        // those two points (`map_timed` folds every RPC transport error/timeout into `Backend`).
         let dir = tempfile::tempdir().expect("tempdir");
         let sock = dir.path().join("idb.sock");
         {
             let _listener = std::os::unix::net::UnixListener::bind(&sock).expect("bind");
         }
-        let err = IdbClient::connect(&sock).unwrap_err();
-        assert!(matches!(err, glass_core::GlassError::Backend(_)), "{err:?}");
+        match IdbClient::connect(&sock) {
+            // Refused at the transport layer — the common case.
+            Err(GlassError::Backend(_)) => {}
+            // `connect` optimistically succeeded; the first RPC must then fail cleanly.
+            Ok(client) => assert!(
+                matches!(client.describe_all(), Err(GlassError::Backend(_))),
+                "first RPC on a dead socket must be a clean Backend error"
+            ),
+            Err(other) => panic!("unexpected non-Backend error from connect: {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
Two intermittent CI failures in glass-ios's `build · clippy · test`, both test-only (no production behavior change):

**1. `idb::client::tests` dead-socket test** (pre-existing, from #113). It asserted connecting to a stale socket *always* errors at `connect`, but tonic's `connect_with_connector` can return `Ok` once the stream dials and the client preface buffers — before the peer's reset is observed. Liveness is really validated at spawn (`await_socket`) and backstopped by `RPC_TIMEOUT`. Rewritten to assert the real guarantee — a clean `Backend` error (never a panic) at **connect or the first RPC** — deterministic regardless of connect's timing.

**2. `doctor::tests::self_test_fails_and_captures_cause_on_nonzero_exit`** (introduced in #120). The test writes an executable fixture then execs it; under `cargo test`'s parallel threads a sibling `Command::spawn` (fork) can momentarily inherit the fixture's write fd, so the exec races into `Text file busy` (ETXTBSY, os error 26). Retries past that transient state — it affects only the freshly-written fixture, never the real installed `idb_companion`.

Each fix verified by looping the affected test 150×/60× locally with no flake. Full glass-ios suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)