### PR TITLE
test(glass-ios): testability seams + Linux tests for idb driver lifecycle paths

### DIFF
--- a/crates/glass-ios/src/idb/companion.rs
+++ b/crates/glass-ios/src/idb/companion.rs
@@ -64,8 +64,20 @@ impl IdbCompanion {
     /// or a socket that never comes up leaves no child behind: both paths
     /// kill + reap before returning `Err`.
     pub fn spawn(udid: &str) -> Result<IdbCompanion> {
-        let get = |k: &str| std::env::var(k).ok();
-        let bin = companion_bin(&get);
+        Self::spawn_with(udid, &|k| std::env::var(k).ok(), SOCKET_READY_TIMEOUT)
+    }
+
+    /// [`spawn`](Self::spawn) with the companion-binary env resolution and the socket-ready
+    /// deadline injected — the seam that makes the failure-cleanup path testable without a
+    /// real simulator. A test points `GLASS_IDB_COMPANION` at a stub through `get_env`
+    /// *without* mutating this process's environment (which would race parallel tests), and
+    /// passes a short `ready_timeout` so a stub that never serves its socket fails fast.
+    fn spawn_with(
+        udid: &str,
+        get_env: &dyn Fn(&str) -> Option<String>,
+        ready_timeout: Duration,
+    ) -> Result<IdbCompanion> {
+        let bin = companion_bin(get_env);
         let dir = std::env::temp_dir();
         let pid = std::process::id();
         let sock = socket_path(&dir, udid, pid);
@@ -112,7 +124,7 @@ impl IdbCompanion {
             stderr_log,
         };
         // From here any failure must kill+reap the child, so a failed spawn never leaks it.
-        if let Err(e) = this.await_socket(Instant::now() + SOCKET_READY_TIMEOUT) {
+        if let Err(e) = this.await_socket(Instant::now() + ready_timeout) {
             let _ = this.child.kill();
             let _ = this.child.wait();
             return Err(e);
@@ -260,5 +272,90 @@ mod tests {
         let sock = dir.path().join("idb.sock");
         let _listener = std::os::unix::net::UnixListener::bind(&sock).expect("bind");
         assert!(socket_ready(&sock));
+    }
+
+    #[test]
+    fn spawn_reaps_the_child_when_the_socket_never_opens() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let stub = dir.path().join("stub_companion");
+        let pidfile = dir.path().join("child.pid");
+        // A stub that records its own pid, then sleeps without ever opening the gRPC socket,
+        // so `await_socket` can only time out. `exec` preserves the pid, so the recorded pid
+        // is exactly the child `spawn_with` owns and must kill+reap on the failure path.
+        std::fs::write(
+            &stub,
+            format!("#!/bin/sh\necho $$ > {pidfile:?}\nexec sleep 10\n"),
+        )
+        .expect("write stub");
+        std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+
+        // Point GLASS_IDB_COMPANION at the stub through the injected getter — never through
+        // this process's real env, which would race parallel tests. A short ready deadline
+        // keeps the never-served socket from costing the full production timeout.
+        let stub_path = stub.to_str().expect("utf-8 stub path").to_string();
+        let get_env = |k: &str| (k == "GLASS_IDB_COMPANION").then(|| stub_path.clone());
+        const READY: Duration = Duration::from_millis(500);
+        // A unique udid keeps this test's socket file name from colliding with another test
+        // in the same process (the socket path is keyed on the udid prefix + this pid).
+        const UDID: &str = "REAPTEST-0000-0000-0000-000000000000";
+
+        // Retry past a transient ETXTBSY on the freshly-written stub: a sibling test thread's
+        // fork can momentarily hold the write fd open, racing our exec. This affects only the
+        // just-written fixture, never the installed idb_companion (same rationale as doctor).
+        let mut err = None;
+        for _ in 0..100 {
+            match IdbCompanion::spawn_with(UDID, &get_env, READY) {
+                Ok(_) => panic!("stub never opens a socket, so spawn_with must fail"),
+                Err(GlassError::Backend(m)) if m.contains("Text file busy") => {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(e) => {
+                    err = Some(e);
+                    break;
+                }
+            }
+        }
+        let err = err.expect("spawn_with kept returning ETXTBSY after 100 retries");
+        assert!(
+            matches!(&err, GlassError::Backend(m) if m.contains("never opened its socket")),
+            "expected a socket-timeout failure, got: {err:?}"
+        );
+
+        // The stub records its pid before sleeping, and reaching the timeout above means it
+        // got that far; read it back, briefly tolerating a slow start under load.
+        let start = Instant::now();
+        let pid = loop {
+            if let Ok(s) = std::fs::read_to_string(&pidfile) {
+                let t = s.trim();
+                if !t.is_empty() {
+                    break t.to_string();
+                }
+            }
+            assert!(
+                start.elapsed() < Duration::from_secs(2),
+                "stub never recorded its pid"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        };
+
+        // The heart of the test: after the failure the child must be gone — killed AND reaped
+        // — not left running or lingering as a zombie. `kill -0` succeeds for a live *or*
+        // zombie pid and fails (ESRCH) only once it is fully reaped, so a still-signalable
+        // pid means `spawn_with` leaked it.
+        let alive = Command::new("kill")
+            .args(["-0", &pid])
+            // Silence its stderr: on the expected (reaped) path `kill -0` prints
+            // "No such process", which would clutter passing-test output. The `.success()`
+            // check below is what the assertion reads.
+            .stderr(Stdio::null())
+            .status()
+            .expect("run kill -0")
+            .success();
+        assert!(
+            !alive,
+            "spawn_with leaked child pid {pid}: it was not killed+reaped on the failure path"
+        );
     }
 }

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -199,36 +199,40 @@ impl IosPlatform {
     }
 }
 
-/// Discover the device's point→pixel scale by dividing the capture's pixel width by the
-/// accessibility root's logical-point width. `describe` can briefly lag a launch, so the
-/// empty-tree (not-rendered-yet) case is retried a few times. A genuine describe/RPC error
-/// is NOT retried — it can't be fixed by waiting, and a timeout would cost the full deadline
-/// each attempt — so it is surfaced immediately with its cause. It never falls back to a
-/// placeholder: an undetermined scale would place every tap at the wrong point, so the
-/// failure surfaces as an error and the caller leaves the session unstarted.
-fn discover_scale(client: &IdbClient, frame_px_width: u32) -> Result<f64> {
-    const ATTEMPTS: usize = 3;
-    const RETRY_DELAY: Duration = Duration::from_millis(200);
-    for attempt in 0..ATTEMPTS {
-        match client.describe_all() {
-            Ok(json) => {
-                if let Some(scale) = crate::axmap::scale_from_width(&json, frame_px_width) {
-                    return Ok(scale);
-                }
-                // Parsed, but no positive root width yet: the app may still be rendering.
-                // This is the transient case worth retrying.
-            }
+/// How many times [`retry_for_scale`] polls for a positive scale before giving up.
+const SCALE_ATTEMPTS: usize = 3;
+/// How long [`retry_for_scale`] waits between polls while the tree is still empty.
+const SCALE_RETRY_DELAY: Duration = Duration::from_millis(200);
+
+/// Poll `next_scale` up to [`SCALE_ATTEMPTS`] times, `delay` apart, for the device's
+/// point→pixel scale. Each outcome is handled distinctly:
+///
+/// - `Ok(Some(scale))` — discovered; returned immediately.
+/// - `Ok(None)` — the tree parsed but has no positive root width yet (the app may still be
+///   rendering). This is the transient case worth retrying.
+/// - `Err(e)` — a real describe/RPC failure (dead transport, unparseable JSON, a timeout).
+///   Retrying can't help and a per-attempt timeout would cost the full deadline each try, so
+///   it is surfaced at once, wrapped with its cause.
+///
+/// If every attempt yields `Ok(None)`, the give-up error names the still-unrendered tree.
+/// `delay` is a parameter (rather than the [`SCALE_RETRY_DELAY`] constant inline) purely so
+/// tests can drive the loop with no sleeps.
+fn retry_for_scale(
+    delay: Duration,
+    mut next_scale: impl FnMut() -> Result<Option<f64>>,
+) -> Result<f64> {
+    for attempt in 0..SCALE_ATTEMPTS {
+        match next_scale() {
+            Ok(Some(scale)) => return Ok(scale),
+            Ok(None) => {}
             Err(e) => {
-                // A real describe/RPC failure (dead transport, unparseable JSON, a
-                // timeout). Retrying can't help and a timeout would cost the full deadline
-                // each attempt, so surface it now with its actual cause.
                 return Err(GlassError::Backend(format!(
                     "could not determine the iOS display scale; last describe error: {e}"
                 )));
             }
         }
-        if attempt + 1 < ATTEMPTS {
-            std::thread::sleep(RETRY_DELAY);
+        if attempt + 1 < SCALE_ATTEMPTS {
+            std::thread::sleep(delay);
         }
     }
     Err(GlassError::Backend(
@@ -236,6 +240,18 @@ fn discover_scale(client: &IdbClient, frame_px_width: u32) -> Result<f64> {
          the app may not have finished rendering"
             .into(),
     ))
+}
+
+/// Discover the device's point→pixel scale by dividing the capture's pixel width by the
+/// accessibility root's logical-point width. `describe` can briefly lag a launch, so the
+/// retry loop in [`retry_for_scale`] tolerates a transient empty tree. It never falls back
+/// to a placeholder: an undetermined scale would place every tap at the wrong point, so the
+/// failure surfaces as an error and the caller leaves the session unstarted.
+fn discover_scale(client: &IdbClient, frame_px_width: u32) -> Result<f64> {
+    retry_for_scale(SCALE_RETRY_DELAY, || {
+        let json = client.describe_all()?;
+        Ok(crate::axmap::scale_from_width(&json, frame_px_width))
+    })
 }
 
 impl Platform for IosPlatform {
@@ -464,6 +480,56 @@ mod tests {
     #[test]
     fn looks_like_app_path_rejects_bundle_ids() {
         assert!(!looks_like_app_path("tech.fixedwidth.demo"));
+    }
+
+    #[test]
+    fn retry_for_scale_returns_the_first_positive_scale() {
+        // Empty tree twice (still rendering), then a real scale on the third poll: it must
+        // keep trying and return that scale — the `describe`-lags-a-launch case.
+        let calls = std::cell::Cell::new(0usize);
+        let scale = retry_for_scale(Duration::ZERO, || {
+            let n = calls.get();
+            calls.set(n + 1);
+            Ok(if n < 2 { None } else { Some(3.0) })
+        })
+        .expect("scale should be discovered on the third poll");
+        assert_eq!(scale, 3.0);
+        assert_eq!(calls.get(), 3, "should have polled exactly three times");
+    }
+
+    #[test]
+    fn retry_for_scale_gives_up_after_the_last_attempt() {
+        // A tree that never gains a width: after exhausting every attempt, give up with the
+        // still-rendering error rather than looping forever or inventing a scale.
+        let calls = std::cell::Cell::new(0usize);
+        let err = retry_for_scale(Duration::ZERO, || {
+            calls.set(calls.get() + 1);
+            Ok(None)
+        })
+        .expect_err("an always-empty tree must give up, not succeed");
+        assert_eq!(calls.get(), SCALE_ATTEMPTS, "should exhaust every attempt");
+        assert!(
+            matches!(&err, GlassError::Backend(m) if m.contains("finished rendering")),
+            "give-up error should name the unrendered tree: {err:?}"
+        );
+    }
+
+    #[test]
+    fn retry_for_scale_surfaces_a_describe_error_without_retrying() {
+        // A hard describe/RPC failure can't be fixed by waiting, so it must surface on the
+        // first poll with its cause — never retried (retrying would cost a full deadline).
+        let calls = std::cell::Cell::new(0usize);
+        let err = retry_for_scale(Duration::ZERO, || {
+            calls.set(calls.get() + 1);
+            Err(GlassError::Backend("dead transport".into()))
+        })
+        .expect_err("a describe error must surface, not be retried");
+        assert_eq!(calls.get(), 1, "a hard error must not be retried");
+        assert!(
+            matches!(&err, GlassError::Backend(m)
+                if m.contains("last describe error") && m.contains("dead transport")),
+            "error should wrap the describe cause: {err:?}"
+        );
     }
 }
 


### PR DESCRIPTION
Closes #115.

Two lifecycle/orchestration paths added in #113 were exercised only by the on-box `#[ignore]`d E2E. Each now has a small injection seam so it can be unit-tested on Linux CI, with behavior and error messages preserved exactly.

## `discover_scale` retry / give-up (`platform.rs`)
Extracted the 3-attempt / 200ms loop into `retry_for_scale(delay, next_scale)`:
- the scale source is an injected `impl FnMut() -> Result<Option<f64>>`, and the inter-attempt delay is a parameter (like `await_socket`'s injected deadline), so tests drive the loop with scripted responses and no sleeps;
- `discover_scale` is now a thin wrapper feeding it `describe_all()` + `scale_from_width`.

I used `Result<Option<f64>>` rather than the issue's suggested bare `Option` so the seam keeps **all three** outcomes — success, transient empty tree (retry), and a hard describe/RPC error (surfaced immediately, *not* retried). That lets the "hard error is not retried" invariant the code comment emphasizes be covered too.

Tests: succeeds on the third poll; gives up after the last attempt (asserting the give-up error); surfaces a describe error on the first poll without retrying (asserting call count = 1).

## `IdbCompanion::spawn` failure cleanup (`companion.rs`)
Extracted `spawn_with(udid, get_env, ready_timeout)`, injecting the env lookup and the socket-ready deadline; `spawn` forwards the real env and `SOCKET_READY_TIMEOUT`, so production is unchanged.

The test points `GLASS_IDB_COMPANION` at a spawns-then-sleeps stub **through the injected getter** — not by mutating this process's env, which would race parallel tests — with a short deadline so the never-served socket fails fast. The stub records its pid (`exec` preserves it); after `spawn_with` returns `Err`, the test asserts that pid is gone (`kill -0` fails), catching **both** a still-running child and an un-reaped zombie. Reuses the ETXTBSY retry idiom already used for freshly-written exec fixtures in `doctor.rs`.

## Verification
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` all green (glass-ios lib 106 → 110 tests).
- TDD throughout: watched all four tests fail first, including proving the reaping test catches a genuine leak (temporary `std::mem::forget`, since `IdbCompanion::Drop` also reaps).
- No CHANGELOG entry — the changelog excludes test-only changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)