### PR TITLE
chore(lint): enforce `unsafe_code = "deny"` workspace-wide

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,14 @@ publish = false
 # (CI still adds `-D warnings` to also catch rustc warnings). The `all` group sits at
 # priority -1 so any specific lint override below it wins on conflict.
 [workspace.lints.rust]
-future_incompatible = "warn"
-nonstandard_style = "deny"
+# The two groups sit at priority -1 so the specific `unsafe_code` lint below wins on conflict
+# (clippy's `lint_groups_priority` otherwise flags the ambiguous same-priority ordering).
+future_incompatible = { level = "warn", priority = -1 }
+nonstandard_style = { level = "deny", priority = -1 }
+# Enforce the CLAUDE.md "avoid unsafe" invariant: pure crates carry no `unsafe` at all. The six
+# FFI backends (glass-macos/-windows/-clip-hook/-a11y-macos/-sandbox-macos/-clip-shim-macos) opt
+# back in per-target with a documented `#![allow(unsafe_code)]`; every site has a `// SAFETY:`.
+unsafe_code = "deny"
 
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }

--- a/crates/glass-a11y-macos/src/lib.rs
+++ b/crates/glass-a11y-macos/src/lib.rs
@@ -1,5 +1,10 @@
 //! macOS accessibility-tree reader for glass (AXUIElement behind glass-core's Accessibility seam).
 
+// FFI backend: the AXUIElement reader needs `unsafe`, so this crate opts out of the workspace
+// `unsafe_code = "deny"`; each site carries a `// SAFETY:` note (see CLAUDE.md). The pure
+// `mapping` module stays `unsafe`-free by convention.
+#![allow(unsafe_code)]
+
 pub mod mapping; // pure AX->normalized mapping — cross-platform, unit-tested on the Linux dev box
 
 // The cfg(macos) AXUIElement reader: `ffi` holds every `unsafe` AX read primitive, `reader`

--- a/crates/glass-clip-hook/examples/clipprobe.rs
+++ b/crates/glass-clip-hook/examples/clipprobe.rs
@@ -10,6 +10,10 @@
 //! v1 hook detours. Windows-only; a no-op elsewhere so the Linux dev box stays green.
 //!   cargo build -p glass-clip-hook --release --example clipprobe
 
+// On-box FFI probe: opts out of the workspace `unsafe_code = "deny"` (each `unsafe` site is
+// `// SAFETY:`-documented).
+#![allow(unsafe_code)]
+
 #[cfg(windows)]
 use glass_clip_hook::{HGlobalLock, OwnedHGlobal};
 

--- a/crates/glass-clip-hook/src/lib.rs
+++ b/crates/glass-clip-hook/src/lib.rs
@@ -6,6 +6,11 @@
 //! host-side [`store`], reused by `glass-windows`. Only [`hook`] is Win32 — the rest is pure
 //! and unit-tested on the Linux dev box.
 
+// FFI backend: the Win32 hook needs `unsafe`, so this crate opts out of the workspace
+// `unsafe_code = "deny"`; each site carries a `// SAFETY:` note (see CLAUDE.md). The pure
+// `proto`/`store`/codec modules stay `unsafe`-free by convention.
+#![allow(unsafe_code)]
+
 pub mod proto;
 pub mod store;
 

--- a/crates/glass-clip-shim-macos/src/lib.rs
+++ b/crates/glass-clip-shim-macos/src/lib.rs
@@ -11,6 +11,9 @@
 //! name from the host side; the real general pasteboard — and anything else on the desktop
 //! — is never touched.
 #![cfg_attr(not(target_os = "macos"), allow(unused_crate_dependencies))]
+// FFI shim: the `NSPasteboard` swizzle IMP needs `unsafe`, so this crate opts out of the
+// workspace `unsafe_code = "deny"`; each site carries a `// SAFETY:` note (see CLAUDE.md).
+#![allow(unsafe_code)]
 
 #[cfg(target_os = "macos")]
 mod imp {

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -6,6 +6,11 @@
 //! modules and the `MacosPlatform` impl are gated `#[cfg(target_os = "macos")]`. Off macOS
 //! the crate exposes only the pure modules.
 
+// FFI backend: the OS-touching modules need `unsafe`, so this crate opts out of the workspace
+// `unsafe_code = "deny"`; each site carries a `// SAFETY:` note (see CLAUDE.md). The pure
+// modules below stay `unsafe`-free by convention.
+#![allow(unsafe_code)]
+
 pub mod bundle; // pure .app-bundle logic — cross-platform, host-tested
 pub mod clipboard_route; // pure clipboard-routing policy — cross-platform, host-tested
 pub mod coords; // pure window-relative <-> global math — cross-platform, host-tested

--- a/crates/glass-sandbox-macos/src/lib.rs
+++ b/crates/glass-sandbox-macos/src/lib.rs
@@ -5,6 +5,11 @@
 //! elsewhere, so `glass doctor` can report on this crate from any host. Mirrors
 //! `glass-sandbox-linux`'s split (pure `wrap_argv` + OS mechanism).
 
+// FFI backend: the `sandbox_init` mechanism needs `unsafe`, so this crate opts out of the
+// workspace `unsafe_code = "deny"`; each site carries a `// SAFETY:` note (see CLAUDE.md). The
+// pure `profile`/`doctor` modules stay `unsafe`-free by convention.
+#![allow(unsafe_code)]
+
 pub mod doctor;
 pub mod profile;
 

--- a/crates/glass-testapp/tests/network.rs
+++ b/crates/glass-testapp/tests/network.rs
@@ -1,6 +1,10 @@
 //! End-to-end: drive glass-mcp over HTTP against the testapp under Xvfb. `#[ignore]d`;
 //! run via `./scripts/test-x11.sh network_screenshot_over_http`.
 
+// This test needs one `unsafe { env::set_var }` for pre-spawn setup (see the `// SAFETY:` note
+// below), so it opts out of the workspace `unsafe_code = "deny"`.
+#![allow(unsafe_code)]
+
 mod common;
 
 use std::time::Duration;

--- a/crates/glass-windows/examples/onbox.rs
+++ b/crates/glass-windows/examples/onbox.rs
@@ -9,6 +9,10 @@
 //! On non-Windows hosts it is a no-op, so `cargo test` / `clippy --all-targets` stay green on the
 //! Linux dev box.
 
+// On-box FFI harness: opts out of the workspace `unsafe_code = "deny"` (each `unsafe` site is
+// `// SAFETY:`-documented).
+#![allow(unsafe_code)]
+
 fn main() {
     #[cfg(windows)]
     imp::run();

--- a/crates/glass-windows/examples/onbox_windows.rs
+++ b/crates/glass-windows/examples/onbox_windows.rs
@@ -7,6 +7,10 @@
 //! unavailable, default/strict report `SandboxUnavailable` (fail-closed). No-op off Windows.
 //! Run: cargo run -p glass-windows --example onbox_windows
 
+// On-box FFI harness: opts out of the workspace `unsafe_code = "deny"` (each `unsafe` site is
+// `// SAFETY:`-documented).
+#![allow(unsafe_code)]
+
 fn main() {
     #[cfg(windows)]
     imp::run();

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -5,6 +5,11 @@
 //! crate-level gate) so the pure [`dpi`] coordinate math still compiles and is
 //! unit-tested on the Linux dev box. Off Windows the crate exposes only `dpi`.
 
+// FFI backend: the OS-touching modules need `unsafe`, so this crate opts out of the workspace
+// `unsafe_code = "deny"`; each site carries a `// SAFETY:` note (see CLAUDE.md). The pure
+// modules below stay `unsafe`-free by convention.
+#![allow(unsafe_code)]
+
 pub mod containment; // Windows containment provider seam (pure config is host-tested)
 pub mod discovery; // pure window-discovery poll-loop decision — cross-platform, host-tested
 pub mod doctor; // pure check-mapping cross-platform; Windows fact-gathering is cfg(windows)

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -5,6 +5,9 @@
 //! (`--test-threads=1`) and by a process-global lock (so a direct `cargo test --ignored` is safe too)
 //! since each spawns apps/windows.
 #![cfg(windows)]
+// On-box E2E: opts out of the workspace `unsafe_code = "deny"` (each `unsafe` site is
+// `// SAFETY:`-documented).
+#![allow(unsafe_code)]
 
 use std::sync::Mutex;
 use std::time::Duration;


### PR DESCRIPTION
## What

Enforces glass's CLAUDE.md invariant — *"Avoid `unsafe` — prefer safe abstractions; isolate + document any required `unsafe` with `// SAFETY:`"* — at the compiler level. It was previously convention-only; nothing stopped a pure crate (e.g. `glass-core`) from silently gaining `unsafe`.

- **`[workspace.lints.rust]`** gains `unsafe_code = "deny"`. The 12 pure crates (core, x11, wayland, the Linux a11y/sandbox/proc/dbus crates, android, ios, mcp, testapp lib) are now machine-locked: any `unsafe` is a compile error.
- The **6 FFI backends** (`glass-macos`, `-windows`, `-clip-hook`, `-a11y-macos`, `-sandbox-macos`, `-clip-shim-macos`) opt back in per-target with a documented `#![allow(unsafe_code)]`. Every `unsafe` site in them already carries a `// SAFETY:` note.
- Four non-lib targets that legitimately use `unsafe` carry the same opt-out: two on-box `glass-windows` examples, the `glass-clip-hook` `clipprobe` example, the on-box `glass-windows` integration test, and the `glass-testapp` network integration test (one `unsafe { env::set_var }` for pre-spawn setup).
- The two rust lint **groups** drop to `priority = -1` so the specific `unsafe_code` lint wins — clippy's `lint_groups_priority` otherwise errors on the same-priority tie.

## Why `deny`, not `forbid`

`forbid` can't be relaxed by an inner `#![allow]`, which the FFI crates need. `deny` still makes accidental `unsafe` a hard error in the pure crates; the only escape hatch is an explicit, greppable, reviewed `#[allow(unsafe_code)]`.

## Design note

Cargo forbids combining `[lints] workspace = true` with per-crate lint overrides, so the tidier "add `forbid` to each pure crate" approach isn't available without duplicating the whole lint table per crate. The chosen approach keeps the workspace table as the single source of truth; its failure mode is a *loud* CI error (a new unsafe target fails until annotated), not silent lint-coverage drift.

## Verification

| Platform | Command | Result |
|---|---|---|
| Linux native | `clippy --workspace --all-targets -- -D warnings`, `test --workspace --locked`, `fmt --check` | ✅ 18 crates, 125 tests, all doctests |
| Windows cross | `clippy --target x86_64-pc-windows-gnu -p glass-windows -p glass-clip-hook -p glass-a11y-windows --all-targets` | ✅ real Win32 `unsafe` (lib+examples+test) |
| macOS native | `clippy --target aarch64-apple-darwin` for the 4 macOS FFI crates `--all-targets` | ✅ real objc2/ScreenCaptureKit/AX `unsafe` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)