### PR TITLE
refactor(proc-linux): share the child-output log reader across backends

### DIFF
--- a/crates/glass-proc-linux/src/lib.rs
+++ b/crates/glass-proc-linux/src/lib.rs
@@ -16,7 +16,9 @@
 //! the Windows backend for the same reason — the OS APIs can't share an impl.
 
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::io::{BufRead, BufReader, Read};
 use std::process::Child;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use rustix::process::{kill_process, kill_process_group, Pid, Signal};
@@ -119,6 +121,26 @@ fn collect_descendants(root: u32, parent_of: &HashMap<u32, u32>) -> Vec<u32> {
         }
     }
     out
+}
+
+/// Drain a child's piped output line-by-line into a shared buffer on a background
+/// thread, tagging each line with `tag`. The X11 and Wayland backends both spawn an
+/// app and capture its stdout/stderr this way; sharing it here keeps them from
+/// re-implementing the reader. Generic over the tag so this crate needn't depend on
+/// glass-core's `Stream` enum.
+pub fn spawn_reader<S: Copy + Send + 'static, R: Read + Send + 'static>(
+    reader: R,
+    tag: S,
+    sink: Arc<Mutex<Vec<(S, String)>>>,
+) {
+    std::thread::spawn(move || {
+        for line in BufReader::new(reader).lines() {
+            match line {
+                Ok(text) => sink.lock().expect("log sink mutex").push((tag, text)),
+                Err(_) => break,
+            }
+        }
+    });
 }
 
 #[cfg(test)]

--- a/crates/glass-wayland/src/command.rs
+++ b/crates/glass-wayland/src/command.rs
@@ -1,5 +1,4 @@
 use std::ffi::OsString;
-use std::io::{BufRead, BufReader};
 use std::os::unix::process::CommandExt;
 use std::path::Path;
 use std::process::Command;
@@ -140,18 +139,6 @@ pub fn build_sway_command(
         cmd.current_dir(dir);
     }
     cmd
-}
-
-/// Pipe a child stream's lines into the shared log sink (background thread).
-pub fn spawn_reader<R: std::io::Read + Send + 'static>(reader: R, stream: Stream, sink: LogSink) {
-    std::thread::spawn(move || {
-        for line in BufReader::new(reader).lines() {
-            match line {
-                Ok(text) => sink.lock().expect("log sink mutex").push((stream, text)),
-                Err(_) => break,
-            }
-        }
-    });
 }
 
 #[cfg(test)]

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -34,7 +34,7 @@ use wayland_protocols_wlr::virtual_pointer::v1::client::zwlr_virtual_pointer_v1:
 
 use std::collections::HashMap;
 
-use crate::command::{build_sway_command, spawn_reader, sway_config, LogSink};
+use crate::command::{build_sway_command, sway_config, LogSink};
 use crate::input::evdev_button;
 use crate::swayipc::{Ipc, Window as SwayWindow};
 
@@ -516,10 +516,10 @@ fn bring_up_session(
         .spawn()
         .map_err(|e| GlassError::AppNotStarted(format!("spawn sway: {e}")))?;
     if let Some(out) = child.stdout.take() {
-        spawn_reader(out, Stream::Stdout, logs.clone());
+        glass_proc_linux::spawn_reader(out, Stream::Stdout, logs.clone());
     }
     if let Some(err) = child.stderr.take() {
-        spawn_reader(err, Stream::Stderr, logs.clone());
+        glass_proc_linux::spawn_reader(err, Stream::Stderr, logs.clone());
     }
 
     let deadline = Instant::now() + Duration::from_millis(spec.timeout_ms.max(1));

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -1,4 +1,3 @@
-use std::io::{BufRead, BufReader};
 use std::process::{Child, Stdio};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -7,7 +6,7 @@ use glass_core::{
     AppSpec, Frame, GlassError, KeyEvent, Platform, PointerEvent, Region, Result, Stream,
     WindowGeometry, WindowHint, WindowId, WindowInfo, WindowOp,
 };
-use glass_proc_linux::proc_tree_pids;
+use glass_proc_linux::{proc_tree_pids, spawn_reader};
 use x11rb::connection::Connection;
 use x11rb::errors::ReplyError;
 use x11rb::protocol::xproto::*;
@@ -705,18 +704,6 @@ fn note_if_clipped(rect: &crate::coords::ClippedRect) {
             rect.w, rect.h, rect.sx, rect.sy
         );
     }
-}
-
-fn spawn_reader<R: std::io::Read + Send + 'static>(reader: R, stream: Stream, sink: LogSink) {
-    std::thread::spawn(move || {
-        let buf = BufReader::new(reader);
-        for line in buf.lines() {
-            match line {
-                Ok(text) => sink.lock().expect("log sink mutex").push((stream, text)),
-                Err(_) => break,
-            }
-        }
-    });
 }
 
 // The process-tree walk (`/proc`-based) that maps the spawned child to the


### PR DESCRIPTION
## What

The X11 and Wayland Linux backends each carried their own **identical** `spawn_reader` — spawn a background thread, drain a child's piped stdout/stderr line-by-line into a shared `Arc<Mutex<Vec<(Stream, String)>>>`. The code already flagged them as mirrors (*"used by both the X11 and Wayland backends"*).

This moves it into the existing shared **`glass-proc-linux`** crate, which already holds the sibling process helpers (`proc_tree_pids`, `reap_group`). It's made **generic over the line tag** (`spawn_reader<S: Copy, R: Read>`) so `glass-proc-linux` stays a leaf utility with no `glass-core` dependency — each backend still passes its `Stream` tag and keeps its trivial one-line `LogSink` alias.

This is the small, well-contained residue found while investigating whether the two `platform.rs` backends duplicate: they don't (different display protocols, and the gesture-sequencing + process-tree logic was already shared) — this reader was the one genuine leftover.

## Change

- `glass-proc-linux`: `+ pub fn spawn_reader<S, R>(…)` (generic).
- `glass-x11` / `glass-wayland`: delete the local `spawn_reader`, call `glass_proc_linux::spawn_reader`.

Net −4 lines; the reader logic now exists once.

## Verification

- Pure move — no behavior change (the shared fn is byte-identical logic to both originals).
- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --locked`, `cargo fmt --check` — green.
- **X11 integration suite (31 + 1 tests, under Xvfb)** — exercises `start_app → spawn_reader → drain_logs` end-to-end (the testapp's stderr `READY` line is captured through the shared reader). Wayland uses the same generic function (compile-verified, identical wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)