### PR TITLE
test(clipboard): cover MIME selection, empty-clipboard, and X11 TARGETS paths

### DIFF
--- a/crates/glass-testapp/tests/integration.rs
+++ b/crates/glass-testapp/tests/integration.rs
@@ -891,6 +891,124 @@ fn clipboard_get_reads_a_foreign_owner() {
     p.stop_app().ok();
 }
 
+#[test]
+#[ignore = "requires an X server; run via scripts/test-x11.sh"]
+fn clipboard_get_with_no_owner_returns_empty() {
+    // On a fresh server nobody owns CLIPBOARD, so no SelectionNotify ever arrives. `get_clipboard`
+    // must treat that as an empty clipboard (Ok("")), not hang or error.
+    let xvfb = Xvfb::start();
+    let mut p = X11Platform::connect(Some(&xvfb.display)).unwrap();
+    assert_eq!(p.get_clipboard().unwrap(), "");
+    p.stop_app().ok();
+}
+
+/// Ask whoever owns CLIPBOARD to convert the selection to `target` (by atom name), reading the reply
+/// on a private connection. Returns the granted property reply, or `None` if the owner refused
+/// (SelectionNotify with `property == NONE`). Mirrors how a real paste client (GTK/Qt/xclip) probes
+/// an owner — the inverse of `serve_clipboard_once`, which plays the owner.
+fn request_clipboard_target(
+    display: &str,
+    target: &[u8],
+) -> Option<x11rb::protocol::xproto::GetPropertyReply> {
+    use x11rb::connection::Connection;
+    use x11rb::protocol::xproto::*;
+
+    let (conn, screen_num) = x11rb::connect(Some(display)).expect("request: connect");
+    let root = conn.setup().roots[screen_num].root;
+    let screen = &conn.setup().roots[screen_num];
+    let intern = |name: &[u8]| conn.intern_atom(false, name).unwrap().reply().unwrap().atom;
+    let clipboard = intern(b"CLIPBOARD");
+    let target_atom = intern(target);
+    let prop = intern(b"GLASS_TEST_REQ");
+
+    let win = conn.generate_id().unwrap();
+    conn.create_window(
+        0,
+        win,
+        root,
+        0,
+        0,
+        1,
+        1,
+        0,
+        WindowClass::INPUT_ONLY,
+        screen.root_visual,
+        &CreateWindowAux::default(),
+    )
+    .unwrap()
+    .check()
+    .unwrap();
+    conn.convert_selection(win, clipboard, target_atom, prop, x11rb::CURRENT_TIME)
+        .unwrap()
+        .check()
+        .unwrap();
+    conn.flush().unwrap();
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    let result = loop {
+        if std::time::Instant::now() >= deadline {
+            break None;
+        }
+        match conn.poll_for_event() {
+            Ok(Some(x11rb::protocol::Event::SelectionNotify(notify)))
+                if notify.requestor == win =>
+            {
+                if notify.property == x11rb::NONE {
+                    break None;
+                }
+                break Some(
+                    conn.get_property(true, win, notify.property, AtomEnum::ANY, 0, u32::MAX / 4)
+                        .unwrap()
+                        .reply()
+                        .unwrap(),
+                );
+            }
+            Ok(_) => std::thread::sleep(std::time::Duration::from_millis(10)),
+            Err(_) => break None,
+        }
+    };
+    conn.destroy_window(win).unwrap().check().ok();
+    conn.flush().ok();
+    result
+}
+
+#[test]
+#[ignore = "requires an X server; run via scripts/test-x11.sh"]
+fn clipboard_owner_answers_targets_and_refuses_unknown_target() {
+    use x11rb::protocol::xproto::ConnectionExt as _;
+
+    let xvfb = Xvfb::start();
+    let mut p = X11Platform::connect(Some(&xvfb.display)).unwrap();
+    p.set_clipboard("glass-owns-this").unwrap(); // glass now owns CLIPBOARD
+
+    // A real paste client asks TARGETS first to discover the offered formats. glass must answer with
+    // an ATOM list that advertises UTF8_STRING — otherwise external apps can't find the text to paste.
+    let reply = request_clipboard_target(&xvfb.display, b"TARGETS")
+        .expect("TARGETS must be granted, not refused");
+    let advertised: Vec<u32> = reply
+        .value32()
+        .expect("a TARGETS reply is a 32-bit ATOM list")
+        .collect();
+    let (conn, _n) = x11rb::connect(Some(&xvfb.display)).unwrap();
+    let utf8 = conn
+        .intern_atom(false, b"UTF8_STRING")
+        .unwrap()
+        .reply()
+        .unwrap()
+        .atom;
+    assert!(
+        advertised.contains(&utf8),
+        "TARGETS must advertise UTF8_STRING; got {advertised:?}"
+    );
+
+    // A target glass does not offer must be refused with property == NONE (not a bogus grant).
+    assert!(
+        request_clipboard_target(&xvfb.display, b"image/png").is_none(),
+        "an unsupported target must be refused with property == NONE"
+    );
+    p.stop_app().ok();
+}
+
 // ---------------------------------------------------------------------------
 // Sandbox integration tests (bwrap + Xvfb)
 // ---------------------------------------------------------------------------

--- a/crates/glass-testapp/tests/wayland.rs
+++ b/crates/glass-testapp/tests/wayland.rs
@@ -484,6 +484,18 @@ fn clipboard_set_then_get_roundtrips() {
     p.stop_app().ok();
 }
 
+#[test]
+#[ignore = "requires sway; run via scripts/test-wayland.sh"]
+fn clipboard_get_with_no_selection_returns_empty() {
+    // Nothing has set the selection on this freshly-spawned compositor, so no data-control offer
+    // exists. `get_clipboard` must report an empty clipboard (Ok("")), not error.
+    let mut p = WaylandPlatform::new().unwrap();
+    start(&mut p, &spec(vec![TESTAPP.to_string()], APP_TIMEOUT_MS));
+    assert!(drain_until(&mut p, "READY", READY_TRIES), "no READY");
+    assert_eq!(p.get_clipboard().unwrap(), "");
+    p.stop_app().ok();
+}
+
 // ---------------------------------------------------------------------------
 // Sandbox integration tests (bwrap + sway)
 // ---------------------------------------------------------------------------

--- a/crates/glass-wayland/src/clipboard.rs
+++ b/crates/glass-wayland/src/clipboard.rs
@@ -763,4 +763,23 @@ mod tests {
         let got = read_to_eof_bounded(read_end, CLIP_READ_TIMEOUT).expect("read ok");
         assert_eq!(got, b"clip!");
     }
+
+    #[test]
+    fn pick_mime_prefers_charset_utf8_then_plain_then_utf8_string() {
+        use super::{pick_mime, MIME_PLAIN, MIME_UTF8, MIME_UTF8_STR};
+        let list = |v: &[&str]| v.iter().map(|s| (*s).to_string()).collect::<Vec<_>>();
+
+        // Preference order wins over the order the owner advertised them in.
+        assert_eq!(pick_mime(&list(&[MIME_PLAIN, MIME_UTF8])), Some(MIME_UTF8));
+        // Falls through to text/plain when the charset form is absent.
+        assert_eq!(
+            pick_mime(&list(&[MIME_UTF8_STR, MIME_PLAIN])),
+            Some(MIME_PLAIN)
+        );
+        // Falls through to UTF8_STRING when it is the only text form offered.
+        assert_eq!(pick_mime(&list(&[MIME_UTF8_STR])), Some(MIME_UTF8_STR));
+        // No text representation offered -> None (get short-circuits to an empty string).
+        assert_eq!(pick_mime(&list(&["image/png", "text/html"])), None);
+        assert_eq!(pick_mime(&[]), None);
+    }
 }


### PR DESCRIPTION
Add tests for untested behavior in the X11/Wayland clipboard backends. **Test-only — no product change.**

## What

- **`glass-wayland` unit** — `pick_mime` MIME preference (`text/plain;charset=utf-8` > `text/plain` > `UTF8_STRING`) and the no-text `None` fallback. The lines were incidentally executed but nothing asserted the ordering, so a reordering regression would pass CI (a real compositor happens to offer the preferred type) yet make `get_clipboard` transfer the wrong representation. Pure logic, no display.
- **X11 integration** (`scripts/test-x11.sh`, self-starts Xvfb):
  - `get_clipboard` with **no selection owner** returns `Ok("")` — an empty clipboard, not an error or a hang.
  - As glass owns the selection, a foreign requestor asking **`TARGETS`** gets an ATOM list advertising `UTF8_STRING`, and an **unsupported target** is refused with `property == NONE`. This is the path a real paste client (GTK/Qt/xclip) hits first — glass's own `get()` requests `UTF8_STRING` directly, so it never exercised the owner's `TARGETS`/refusal branches.
- **Wayland integration** (`scripts/test-wayland.sh`): `get_clipboard` with no selection returns `Ok("")`.

Added a `request_clipboard_target` requestor helper (the inverse of the existing `serve_clipboard_once` owner helper).

## Verification
- `pick_mime` unit test passes in the default `cargo test`.
- The 3 `#[ignore]`d integration tests pass under Xvfb / sway.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` all clean.