### PR TITLE
refactor(android): extract locate_editable_target for testable set_value guard

### DIFF
--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -3,7 +3,7 @@
 //! lazily, since the `Accessibility` trait is handed only an `AxContext`.
 
 use glass_core::accessibility::{Accessibility, AxContext, AxTarget, AxTree};
-use glass_core::{GlassError, KeyEvent, MouseButton, PointerEvent, Result};
+use glass_core::{GlassError, KeyEvent, MouseButton, PointerEvent, Result, WindowGeometry};
 
 use crate::adb::Adb;
 use crate::axmap::{build_tree, check_dump_status};
@@ -60,6 +60,32 @@ impl Default for AndroidA11y {
     }
 }
 
+/// Locate `target` in an already-numbered `tree` and return the window-relative tap point for
+/// editing it. Errors specifically when the target is gone (`AxElementNotFound`), has drifted in
+/// role/name/bounds (`AxElementChanged`), is not editable (`AxElementNotEditable`), or has no
+/// clickable on-screen center (`AxElementNotClickable`). Pure (no device I/O) so `set_value`'s
+/// re-validation — the guard that stops it typing into the wrong element after a re-snapshot — is
+/// testable without a device.
+fn locate_editable_target(
+    tree: &AxTree,
+    target: &AxTarget,
+    window: &WindowGeometry,
+) -> Result<(i32, i32)> {
+    let node = tree
+        .find(target.id)
+        .ok_or(GlassError::AxElementNotFound(target.id.0))?;
+    if !target.matches(node.role, node.name.as_deref()) || !target.bounds_consistent(node.bounds, 8)
+    {
+        return Err(GlassError::AxElementChanged(target.id.0));
+    }
+    if !node.states.editable {
+        return Err(GlassError::AxElementNotEditable(target.id.0));
+    }
+    node.bounds
+        .and_then(|b| b.clamped_center(window.width, window.height))
+        .ok_or(GlassError::AxElementNotClickable(target.id.0))
+}
+
 impl Accessibility for AndroidA11y {
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
         let window = ctx.window.clone();
@@ -77,21 +103,7 @@ impl Accessibility for AndroidA11y {
         // Re-snapshot and number nodes to locate the target by its pre-order id.
         let mut tree = self.snapshot(ctx)?;
         tree.assign_ids();
-        let node = tree
-            .find(target.id)
-            .ok_or(GlassError::AxElementNotFound(target.id.0))?;
-        if !target.matches(node.role, node.name.as_deref())
-            || !target.bounds_consistent(node.bounds, 8)
-        {
-            return Err(GlassError::AxElementChanged(target.id.0));
-        }
-        if !node.states.editable {
-            return Err(GlassError::AxElementNotEditable(target.id.0));
-        }
-        let (cx, cy) = node
-            .bounds
-            .and_then(|b| b.clamped_center(window.width, window.height))
-            .ok_or(GlassError::AxElementNotClickable(target.id.0))?;
+        let (cx, cy) = locate_editable_target(&tree, target, &window)?;
 
         let adb = self.ensure_adb()?;
         // Tap to focus, select-all, delete, type — reusing the P2 input builders.
@@ -115,5 +127,112 @@ impl Accessibility for AndroidA11y {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::locate_editable_target;
+    use glass_core::accessibility::{AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree};
+    use glass_core::{GlassError, WindowGeometry};
+
+    const WIN: WindowGeometry = WindowGeometry {
+        x: 0,
+        y: 0,
+        width: 1080,
+        height: 2400,
+    };
+    const BOUNDS: AxRect = AxRect {
+        x: 100,
+        y: 200,
+        width: 400,
+        height: 80,
+    };
+
+    /// A single-node tree (`root` = the target after `assign_ids` sets id 0).
+    fn tree(role: AxRole, name: Option<&str>, bounds: Option<AxRect>, editable: bool) -> AxTree {
+        let root = AxNode {
+            id: AxNodeId(0),
+            role,
+            raw_role: String::new(),
+            name: name.map(Into::into),
+            value: None,
+            states: AxStates {
+                editable,
+                ..Default::default()
+            },
+            bounds,
+            children: vec![],
+        };
+        let mut t = AxTree { root, count: 0 };
+        t.assign_ids();
+        t
+    }
+
+    fn target(id: u32, name: Option<&str>, bounds: Option<AxRect>) -> AxTarget {
+        AxTarget {
+            id: AxNodeId(id),
+            role: AxRole::TextField,
+            name: name.map(Into::into),
+            bounds,
+        }
+    }
+
+    #[test]
+    fn returns_the_visible_center_for_a_matching_editable_target() {
+        let t = tree(AxRole::TextField, Some("Search"), Some(BOUNDS), true);
+        // Center of [100,500] x [200,280].
+        assert_eq!(
+            locate_editable_target(&t, &target(0, Some("Search"), Some(BOUNDS)), &WIN).unwrap(),
+            (300, 240)
+        );
+    }
+
+    #[test]
+    fn absent_id_is_element_not_found() {
+        let t = tree(AxRole::TextField, Some("Search"), Some(BOUNDS), true);
+        assert!(matches!(
+            locate_editable_target(&t, &target(9, Some("Search"), Some(BOUNDS)), &WIN),
+            Err(GlassError::AxElementNotFound(9))
+        ));
+    }
+
+    #[test]
+    fn drifted_name_is_element_changed() {
+        // Same id lands on a different-named element (tree drift) — must refuse, not overwrite.
+        let t = tree(AxRole::TextField, Some("Search"), Some(BOUNDS), true);
+        assert!(matches!(
+            locate_editable_target(&t, &target(0, Some("Other"), Some(BOUNDS)), &WIN),
+            Err(GlassError::AxElementChanged(0))
+        ));
+    }
+
+    #[test]
+    fn drifted_bounds_is_element_changed() {
+        let t = tree(AxRole::TextField, Some("Search"), Some(BOUNDS), true);
+        let moved = AxRect { x: 700, ..BOUNDS };
+        assert!(matches!(
+            locate_editable_target(&t, &target(0, Some("Search"), Some(moved)), &WIN),
+            Err(GlassError::AxElementChanged(0))
+        ));
+    }
+
+    #[test]
+    fn non_editable_target_is_element_not_editable() {
+        let t = tree(AxRole::TextField, Some("Search"), Some(BOUNDS), false);
+        assert!(matches!(
+            locate_editable_target(&t, &target(0, Some("Search"), Some(BOUNDS)), &WIN),
+            Err(GlassError::AxElementNotEditable(0))
+        ));
+    }
+
+    #[test]
+    fn zero_area_bounds_is_element_not_clickable() {
+        let flat = AxRect { width: 0, ..BOUNDS };
+        let t = tree(AxRole::TextField, Some("Search"), Some(flat), true);
+        assert!(matches!(
+            locate_editable_target(&t, &target(0, Some("Search"), Some(flat)), &WIN),
+            Err(GlassError::AxElementNotClickable(0))
+        ));
     }
 }


### PR DESCRIPTION
`AndroidA11y::set_value` re-snapshots the tree and **re-validates the target** — same role/name, consistent bounds, still editable, has an on-screen center — before typing, so tree drift can't make it overwrite the wrong element. That correctness guard was buried in the device-only `set_value` method and had no test.

## Change
Extract the validation into a pure `locate_editable_target(tree, target, window) -> Result<(cx, cy)>` (mirrors how `axmap` and wayland's `read_to_eof_bounded` split pure logic from I/O), and unit-test its five outcomes with constructed `AxTree`s — **no emulator**:

- matching editable target → the visible-center tap point
- absent id → `AxElementNotFound`
- role/name drift → `AxElementChanged`
- bounds drift beyond tolerance → `AxElementChanged`
- not editable → `AxElementNotEditable`
- zero-area / off-screen bounds → `AxElementNotClickable`

**Behavior-preserving** — the device tap/select-all/type path in `set_value` is unchanged; it now calls the extracted fn.

`cargo test --workspace`, `clippy --workspace --all-targets -- -D warnings`, and `fmt --check` all clean.