### PR TITLE
docs: changelog for v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-07-10
+
 ### Added
 - An [iOS Simulator backend](docs/how-to/setup-ios.md) (`GLASS_BACKEND=ios`, macOS only): launch, capture,
   log streaming, and clipboard for native iOS apps in the Simulator, driven through `xcrun simctl`, plus
@@ -168,7 +170,8 @@ First public release — open core, Apache-2.0.
 - Core tools: `glass_start`, `glass_stop`, `glass_screenshot`, `glass_click`,
   `glass_list_windows`, `glass_select_window`, and `glass_doctor`.
 
-[Unreleased]: https://github.com/fixed-width/glass/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/fixed-width/glass/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/fixed-width/glass/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/fixed-width/glass/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/fixed-width/glass/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/fixed-width/glass/compare/v0.1.2...v0.2.0


### PR DESCRIPTION
Cut the v0.4.0 changelog: rename `[Unreleased]` → `[0.4.0] - 2026-07-10`, add a fresh empty `[Unreleased]`, and update the compare links. Tagging `v0.4.0` on the merge of this PR triggers the release pipeline.

## What's in v0.4.0 (since v0.3.1)

**Added**
- An **iOS Simulator backend** (`GLASS_BACKEND=ios`, macOS only): launch, capture, log streaming, clipboard via `xcrun simctl`, plus input and the accessibility tree over `idb_companion` when installed, with a `glass doctor` preflight (`--deep` spawns `idb_companion` for real). Multi-touch gestures not supported on the Simulator yet.
- A **Windows access-model** explanation doc: what actually gates access (interactive session, UAC/UIPI integrity, SmartScreen) and how to get past first-run.

**Changed**
- Simpler, better-documented Android companion install: drop `glass-agent.jar` / `glass-a11y.apk` next to the `glass-mcp` binary for auto-discovery (env vars are now overrides).
- Install docs lead with the prebuilt binary from Releases (README + Linux/Windows setup).
- `docs/reference/platforms.md` documents per-release assets.

**Fixed**
- iOS `glass_drag` / `idb` HID gestures longer than 30s no longer abort mid-swipe (RPC deadline scales with gesture duration).
- `doctor --deep` gives the correct skip hint for Android probes when Android isn't the selected backend.
- `glass_diff` tool reference now documents its `region` parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)