### PR TITLE
docs: use UTC release dates in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,16 @@ and glass adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!--
 Maintenance: add entries under [Unreleased] as user-facing changes merge to
-master. At release time, rename [Unreleased] to the new version with its date,
-add a fresh empty [Unreleased] above it, and update the compare links at the
+master. At release time, rename [Unreleased] to the new version with its UTC
+release date (the GitHub release's `published_at` date, so the changelog matches
+the site's release list), add a fresh empty [Unreleased] above it, and update the compare links at the
 bottom. Keep entries user-facing — what changed for someone using glass — not
 internal refactors, CI, or test-only changes.
 -->
 
 ## [Unreleased]
 
-## [0.4.0] - 2026-07-10
+## [0.4.0] - 2026-07-11
 
 ### Added
 - An [iOS Simulator backend](docs/how-to/setup-ios.md) (`GLASS_BACKEND=ios`, macOS only): launch, capture,
@@ -55,7 +56,7 @@ internal refactors, CI, or test-only changes.
 - The `glass_diff` tool reference now documents its `region` parameter — a window-relative scoped
   diff that also makes the reported `bbox` region-relative — which had been usable but undocumented.
 
-## [0.3.1] - 2026-07-07
+## [0.3.1] - 2026-07-08
 
 ### Changed
 - Documentation reorganized into a [Diátaxis](https://diataxis.fr) structure under
@@ -134,7 +135,7 @@ internal refactors, CI, or test-only changes.
 - Share one SIMD pixel-swizzle kernel across the X11, Windows, and Wayland
   capture paths for faster frame conversion.
 
-## [0.1.1] - 2026-06-17
+## [0.1.1] - 2026-06-18
 
 ### Added
 - **Linux accessibility (opt-in).** An `a11y` flag starts a private AT-SPI


### PR DESCRIPTION
Align each release heading in `CHANGELOG.md` with the GitHub release's `published_at` (UTC) date, so the in-repo changelog matches the site's release list (`web/src/pages/glass/changelog.astro`, which renders `published_at`).

Previously some headings used the local authoring date, which drifted a day behind the UTC publish time.

- `0.4.0`: 2026-07-10 → 2026-07-11
- `0.3.1`: 2026-07-07 → 2026-07-08
- `0.1.1`: 2026-06-17 → 2026-06-18

(`0.3.0`, `0.2.0`, `0.1.2` already matched. `0.1.0` predates tagging — its `2026-06-08` is the immutable commit date, left unchanged.)

Also documents the UTC convention in the changelog's maintenance note so future releases stay aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)