### PR TITLE
ios: work on a signed-app / LaunchAgent install with no manual config (auto-discover idb_companion; writable baselines)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+### Fixed
+- iOS: a Homebrew-installed `idb_companion` is now found automatically even when glass is launched by
+  launchd (the `.app` / LaunchAgent), whose minimal `PATH` omits Homebrew's bindir — so input and the
+  accessibility tree work without setting `GLASS_IDB_COMPANION` by hand.
+- Visual baselines (`glass_baseline_save` / `glass_diff`) are written to an absolute, always-writable
+  location instead of a working-directory-relative one that failed under launchd's read-only `/` cwd.
+
 ## [0.4.0] - 2026-07-11
 
 ### Added

--- a/crates/glass-ios/src/doctor.rs
+++ b/crates/glass-ios/src/doctor.rs
@@ -234,9 +234,9 @@ fn read_trimmed(path: &Path) -> Option<String> {
 }
 
 /// Is the companion binary resolvable — `GLASS_IDB_COMPANION` naming an existing file, or
-/// `idb_companion` found on `PATH`? The passive (non-`--deep`) presence signal, and the
-/// `NotFound` gate for [`probe_companion`]. Uses the same [`companion_bin`] resolution the
-/// runtime spawn does.
+/// `idb_companion` found on `PATH` or in Homebrew's standard prefixes? The passive
+/// (non-`--deep`) presence signal, and the `NotFound` gate for [`probe_companion`]. Uses the
+/// same [`companion_bin`] resolution the runtime spawn does.
 pub fn companion_present() -> bool {
     let bin = companion_bin(&|k| std::env::var(k).ok());
     if bin.contains('/') {

--- a/crates/glass-ios/src/doctor.rs
+++ b/crates/glass-ios/src/doctor.rs
@@ -12,7 +12,7 @@ use std::time::{Duration, Instant};
 use glass_core::{Check, CheckStatus, GlassError};
 
 use crate::device::{parse_devices, resolve, Resolve, SimDevice};
-use crate::idb::companion::{companion_bin, IdbCompanion};
+use crate::idb::companion::{companion_bin, companion_present_with, IdbCompanion};
 use crate::simctl::Simctl;
 
 /// Observed host state for the iOS doctor checks. Captured by `run`, consumed by the
@@ -238,13 +238,7 @@ fn read_trimmed(path: &Path) -> Option<String> {
 /// (non-`--deep`) presence signal, and the `NotFound` gate for [`probe_companion`]. Uses the
 /// same [`companion_bin`] resolution the runtime spawn does.
 pub fn companion_present() -> bool {
-    let bin = companion_bin(&|k| std::env::var(k).ok());
-    if bin.contains('/') {
-        Path::new(&bin).is_file()
-    } else {
-        std::env::var_os("PATH")
-            .is_some_and(|path| std::env::split_paths(&path).any(|dir| dir.join(&bin).is_file()))
-    }
+    companion_present_with(&|k| std::env::var(k).ok(), &|p| p.is_file())
 }
 
 /// The `--deep` iOS companion health probe: does `idb_companion` actually start? Reuses the

--- a/crates/glass-ios/src/idb/companion.rs
+++ b/crates/glass-ios/src/idb/companion.rs
@@ -80,6 +80,21 @@ fn on_path(
         .find(|p| exists(p))
 }
 
+/// Whether the companion resolves to an existing binary — the testable core of the doctor's
+/// presence check, mirroring [`companion_bin`]'s resolution so the two never drift: an explicit
+/// `GLASS_IDB_COMPANION` path must exist (a bare name must be on `PATH`); otherwise auto-discovery
+/// (`PATH`, then Homebrew prefixes) must find one. `get`/`exists` are seams for tests.
+pub(crate) fn companion_present_with(
+    get: &dyn Fn(&str) -> Option<String>,
+    exists: &dyn Fn(&Path) -> bool,
+) -> bool {
+    match get("GLASS_IDB_COMPANION").filter(|s| !s.is_empty()) {
+        Some(bin) if bin.contains('/') => exists(Path::new(&bin)),
+        Some(bin) => on_path(&bin, get, exists).is_some(),
+        None => discover_companion(get, exists).is_some(),
+    }
+}
+
 /// The Unix-domain socket path the companion is told to serve on, under `dir`.
 /// Kept deliberately short: macOS caps `sun_path` at [`SUN_PATH_MAX`] bytes and its
 /// per-user temp dir (`/var/folders/…/T/`) already spends ~50 of them, so a longer name
@@ -342,6 +357,34 @@ mod tests {
             discover_companion(&env(&[("PATH", "/usr/bin:/bin")]), &|_: &Path| false),
             None
         );
+    }
+
+    #[test]
+    fn present_with_validates_that_an_override_path_exists() {
+        let get = env(&[("GLASS_IDB_COMPANION", "/opt/idb_companion")]);
+        assert!(companion_present_with(&get, &|p: &Path| p == Path::new("/opt/idb_companion")));
+        assert!(!companion_present_with(&get, &|_: &Path| false));
+    }
+
+    #[test]
+    fn present_with_resolves_a_bare_name_override_on_path() {
+        let get = env(&[("GLASS_IDB_COMPANION", "my_idb"), ("PATH", "/usr/bin:/bin")]);
+        assert!(companion_present_with(&get, &|p: &Path| p == Path::new("/bin/my_idb")));
+    }
+
+    #[test]
+    fn present_with_finds_homebrew_when_off_path() {
+        let get = env(&[("PATH", "/usr/bin:/bin")]);
+        assert!(companion_present_with(&get, &|p: &Path| p
+            == Path::new("/opt/homebrew/bin/idb_companion")));
+    }
+
+    #[test]
+    fn present_with_is_false_when_absent_everywhere() {
+        assert!(!companion_present_with(
+            &env(&[("PATH", "/usr/bin")]),
+            &|_: &Path| false
+        ));
     }
 
     #[test]

--- a/crates/glass-ios/src/idb/companion.rs
+++ b/crates/glass-ios/src/idb/companion.rs
@@ -19,11 +19,65 @@ const SOCKET_POLL_INTERVAL: Duration = Duration::from_millis(200);
 /// How long to wait for the companion to open its socket before giving up.
 const SOCKET_READY_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// `GLASS_IDB_COMPANION`, else `idb_companion` on PATH.
+/// Standard Homebrew `idb_companion` locations, probed when it is not on `PATH`. A `.app` or
+/// LaunchAgent glass is launched by launchd with a minimal `PATH` that omits Homebrew's bindir,
+/// so a `brew install idb-companion` would otherwise be invisible and input/accessibility would
+/// go dark with no way for the user to fix it short of setting an env var. Apple-silicon prefix
+/// first, then Intel.
+const HOMEBREW_COMPANION_PATHS: [&str; 2] = [
+    "/opt/homebrew/bin/idb_companion",
+    "/usr/local/bin/idb_companion",
+];
+
+/// The program to hand `Command::new` for the companion spawn. `GLASS_IDB_COMPANION` wins
+/// verbatim (an explicit override is trusted — a wrong path surfaces a clear spawn error);
+/// otherwise `idb_companion` is auto-discovered on `PATH`, then in Homebrew's standard prefixes;
+/// failing all that, the bare name is returned so the spawn fails with the actionable
+/// "install idb_companion" error rather than a silent no-op.
 pub fn companion_bin(get: &dyn Fn(&str) -> Option<String>) -> String {
-    get("GLASS_IDB_COMPANION")
-        .filter(|s| !s.is_empty())
+    companion_program(get, &|p| p.is_file())
+}
+
+/// [`companion_bin`] with the filesystem-existence check injected, so tests can drive resolution
+/// without touching the real environment.
+fn companion_program(
+    get: &dyn Fn(&str) -> Option<String>,
+    exists: &dyn Fn(&Path) -> bool,
+) -> String {
+    if let Some(explicit) = get("GLASS_IDB_COMPANION").filter(|s| !s.is_empty()) {
+        return explicit;
+    }
+    discover_companion(get, exists)
+        .map(|p| p.to_string_lossy().into_owned())
         .unwrap_or_else(|| "idb_companion".to_string())
+}
+
+/// Auto-discover `idb_companion` when `GLASS_IDB_COMPANION` is unset: on `PATH` first, then in
+/// the standard Homebrew prefixes ([`HOMEBREW_COMPANION_PATHS`]). `None` if it is nowhere to be
+/// found. `get`/`exists` are seams so tests drive it deterministically.
+fn discover_companion(
+    get: &dyn Fn(&str) -> Option<String>,
+    exists: &dyn Fn(&Path) -> bool,
+) -> Option<PathBuf> {
+    on_path("idb_companion", get, exists).or_else(|| {
+        HOMEBREW_COMPANION_PATHS
+            .iter()
+            .copied()
+            .map(PathBuf::from)
+            .find(|p| exists(p))
+    })
+}
+
+/// The first `PATH` entry containing a file named `name`, if any.
+fn on_path(
+    name: &str,
+    get: &dyn Fn(&str) -> Option<String>,
+    exists: &dyn Fn(&Path) -> bool,
+) -> Option<PathBuf> {
+    let path = get("PATH")?;
+    std::env::split_paths(&path)
+        .map(|dir| dir.join(name))
+        .find(|p| exists(p))
 }
 
 /// The Unix-domain socket path the companion is told to serve on, under `dir`.
@@ -225,18 +279,69 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
+    /// Build an env getter from a fixed set of pairs.
+    fn env(pairs: &[(&'static str, &'static str)]) -> impl Fn(&str) -> Option<String> {
+        let m: HashMap<&'static str, &'static str> = pairs.iter().copied().collect();
+        move |k: &str| m.get(k).map(|s| s.to_string())
+    }
+
     #[test]
-    fn companion_bin_prefers_env_then_default() {
-        let with =
-            |m: HashMap<&'static str, &'static str>| move |k: &str| m.get(k).map(|s| s.to_string());
+    fn companion_program_uses_the_env_override_verbatim() {
+        // An explicit override is trusted even when the file is absent — the spawn surfaces the error.
         assert_eq!(
-            companion_bin(&with(HashMap::from([(
-                "GLASS_IDB_COMPANION",
-                "/opt/idb_companion"
-            )]))),
+            companion_program(
+                &env(&[("GLASS_IDB_COMPANION", "/opt/idb_companion")]),
+                &|_: &Path| false,
+            ),
             "/opt/idb_companion"
         );
-        assert_eq!(companion_bin(&with(HashMap::new())), "idb_companion");
+    }
+
+    #[test]
+    fn companion_program_falls_back_to_the_bare_name_when_nothing_resolves() {
+        assert_eq!(
+            companion_program(&env(&[("PATH", "/usr/bin:/bin")]), &|_: &Path| false),
+            "idb_companion"
+        );
+    }
+
+    #[test]
+    fn discover_prefers_path_over_homebrew() {
+        let exists = |p: &Path| {
+            p == Path::new("/usr/bin/idb_companion")
+                || p == Path::new("/opt/homebrew/bin/idb_companion")
+        };
+        assert_eq!(
+            discover_companion(&env(&[("PATH", "/usr/bin")]), &exists),
+            Some(PathBuf::from("/usr/bin/idb_companion"))
+        );
+    }
+
+    #[test]
+    fn discover_finds_homebrew_when_off_path() {
+        // launchd's minimal PATH omits Homebrew's bindir; discovery still finds the brew install.
+        let exists = |p: &Path| p == Path::new("/opt/homebrew/bin/idb_companion");
+        assert_eq!(
+            discover_companion(&env(&[("PATH", "/usr/bin:/bin")]), &exists),
+            Some(PathBuf::from("/opt/homebrew/bin/idb_companion"))
+        );
+    }
+
+    #[test]
+    fn discover_prefers_apple_silicon_over_intel_prefix() {
+        // Both prefixes "exist"; the arm64 prefix is chosen first.
+        assert_eq!(
+            discover_companion(&env(&[]), &|_: &Path| true),
+            Some(PathBuf::from("/opt/homebrew/bin/idb_companion"))
+        );
+    }
+
+    #[test]
+    fn discover_is_none_when_absent_everywhere() {
+        assert_eq!(
+            discover_companion(&env(&[("PATH", "/usr/bin:/bin")]), &|_: &Path| false),
+            None
+        );
     }
 
     #[test]

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -279,13 +279,21 @@ pub fn run_doctor(deep: bool, json: bool, audit_log: Option<&str>) -> ! {
 }
 
 /// Directory for visual baselines. Deliberately **absolute** and under the system temp dir:
-/// baselines are per-session (they do not outlive a `glass_start`), and a cwd-relative path
-/// breaks when glass runs with a read-only working directory — e.g. a `.app`/LaunchAgent glass
-/// launched by launchd, whose cwd is `/`, where the old cwd-relative store failed every
+/// baselines are per-session (they do not outlive the process), and a cwd-relative path breaks
+/// when glass runs with a read-only working directory — e.g. a `.app`/LaunchAgent glass launched
+/// by launchd, whose cwd is `/`, where the old cwd-relative store failed every
 /// `glass_baseline_save` with a read-only-filesystem error. `std::env::temp_dir()` is always
 /// writable and honors `TMPDIR`.
+///
+/// **Scoped by process id** (like the iOS companion's socket path): the base temp dir can be
+/// shared across users (Linux `/tmp`), so an unscoped `…/glass/baselines` would let concurrent
+/// sessions clobber each other's baselines by name and, on a multi-user host, leave the directory
+/// owned by whoever ran glass first — readable by others and un-writable by everyone else. A
+/// per-pid segment gives each server its own store owned by the user running it.
 fn default_baseline_dir() -> std::path::PathBuf {
-    std::env::temp_dir().join("glass").join("baselines")
+    std::env::temp_dir()
+        .join(format!("glass-{}", std::process::id()))
+        .join("baselines")
 }
 
 /// Build the `Glass` session manager, installing the audit sink if one is configured.
@@ -377,6 +385,16 @@ mod tests {
         // A cwd-relative baseline dir fails every save when glass runs with cwd `/` (a launchd
         // `.app`/LaunchAgent). The default must be absolute.
         assert!(super::default_baseline_dir().is_absolute());
+    }
+
+    #[test]
+    fn baseline_dir_is_process_scoped_so_concurrent_sessions_dont_collide() {
+        // The temp root can be shared across users/sessions; a per-pid segment keeps each
+        // server's baselines separate and user-owned.
+        let dir = super::default_baseline_dir();
+        assert!(dir
+            .to_string_lossy()
+            .contains(&std::process::id().to_string()));
     }
 
     #[test]

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -278,10 +278,20 @@ pub fn run_doctor(deep: bool, json: bool, audit_log: Option<&str>) -> ! {
     std::process::exit(diag.exit_code(backend));
 }
 
+/// Directory for visual baselines. Deliberately **absolute** and under the system temp dir:
+/// baselines are per-session (they do not outlive a `glass_start`), and a cwd-relative path
+/// breaks when glass runs with a read-only working directory — e.g. a `.app`/LaunchAgent glass
+/// launched by launchd, whose cwd is `/`, where the old cwd-relative store failed every
+/// `glass_baseline_save` with a read-only-filesystem error. `std::env::temp_dir()` is always
+/// writable and honors `TMPDIR`.
+fn default_baseline_dir() -> std::path::PathBuf {
+    std::env::temp_dir().join("glass").join("baselines")
+}
+
 /// Build the `Glass` session manager, installing the audit sink if one is configured.
 pub fn boot(audit: Option<Box<dyn glass_core::AuditSink>>) -> Glass {
     let default = default_backend(std::env::var("GLASS_BACKEND").ok().as_deref()).to_string();
-    let baselines = BaselineStore::new(".glass/baselines");
+    let baselines = BaselineStore::new(default_baseline_dir());
     let registry = glass_android::EmulatorRegistry::new();
     let agents = glass_android::AgentRegistry::new();
     let a11y = glass_android::A11yServiceRegistry::new();
@@ -360,6 +370,13 @@ mod tests {
     fn default_backend_accepts_ios() {
         assert_eq!(default_backend(Some("ios")), "ios");
         assert_eq!(default_backend(Some("IOS")), "ios");
+    }
+
+    #[test]
+    fn baseline_dir_is_absolute_so_it_survives_a_read_only_cwd() {
+        // A cwd-relative baseline dir fails every save when glass runs with cwd `/` (a launchd
+        // `.app`/LaunchAgent). The default must be absolute.
+        assert!(super::default_baseline_dir().is_absolute());
     }
 
     #[test]

--- a/crates/glass-mcp/src/setup.rs
+++ b/crates/glass-mcp/src/setup.rs
@@ -1028,6 +1028,22 @@ mod tests {
         assert!(!filled.contains("/Users/YOU"));
     }
 
+    #[test]
+    fn fill_launch_agent_pins_a_writable_working_directory() {
+        // launchd's default cwd `/` is read-only and breaks glass_baseline_save; the LaunchAgent
+        // must pin a writable WorkingDirectory (the resolved home).
+        let filled = fill_launch_agent(
+            TEMPLATE,
+            LaunchAgentFields {
+                app_bin: "/opt/glass/glass-mcp",
+                addr: "127.0.0.1:7300",
+                home: "/Users/alice",
+            },
+        )
+        .replace("\r\n", "\n");
+        assert!(filled.contains("<key>WorkingDirectory</key>\n\t<string>/Users/alice</string>"));
+    }
+
     // --- plist template shape (menu-bar launch, KeepAlive) --------------------------------
 
     #[test]

--- a/docs/how-to/setup-ios.md
+++ b/docs/how-to/setup-ios.md
@@ -97,8 +97,11 @@ Multi-touch gestures (`glass_gesture` — pinch, rotate, two-finger swipe) are n
 Simulator yet. If `idb_companion` isn't installed, the input and accessibility tools return an
 unsupported error, while capture, logs, and clipboard keep working.
 
-Set `GLASS_IDB_COMPANION` to the `idb_companion` binary's path if it isn't on `PATH` (or to pin a
-specific build).
+glass finds `idb_companion` on `PATH`, and — because a `.app` / LaunchAgent launch runs with a
+minimal `PATH` that omits Homebrew's bindir — also probes the standard Homebrew locations
+(`/opt/homebrew/bin`, `/usr/local/bin`), so a `brew install` is picked up with no extra setup. Set
+`GLASS_IDB_COMPANION` to the binary's path only to override that — an install elsewhere, or to pin a
+specific build.
 
 ## Check the setup
 

--- a/packaging/macos/tech.fixedwidth.glass.plist
+++ b/packaging/macos/tech.fixedwidth.glass.plist
@@ -32,6 +32,14 @@
 		<string>127.0.0.1:7300</string>
 	</array>
 
+	<!--
+	  A writable working directory. launchd otherwise starts the job with cwd `/` (a
+	  read-only sealed volume), which makes glass_baseline_save / glass_diff fail with a
+	  read-only-filesystem error. The home dir is always writable.
+	-->
+	<key>WorkingDirectory</key>
+	<string>/Users/YOU</string>
+
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>GLASS_BACKEND</key>


### PR DESCRIPTION
## Problem

When glass is installed as the signed macOS app and run from its LaunchAgent (the recommended
setup for the macOS/iOS host), launchd starts it with a **minimal `PATH`** (no Homebrew bindir)
and a **working directory of `/`** (a read-only sealed volume). Two things break for a user who
did nothing wrong:

- **iOS input + accessibility go dark.** `idb_companion` is resolved only via `GLASS_IDB_COMPANION`
  or a bare `PATH` lookup, so a `brew install idb-companion` at `/opt/homebrew/bin` is invisible to
  the LaunchAgent. `glass_a11y_snapshot`/`glass_click`/`glass_drag`/… all return `Unsupported`, and
  the only fix was to hand-set an env var — not something an app-bundle user can be expected to do.
- **Baselines can't be saved.** `glass_baseline_save` wrote to a **cwd-relative** `.glass/baselines`;
  under launchd's cwd `/` every save/diff failed with `Read-only file system`, taking down the whole
  pixel-diff verification path — even on backends that don't use `idb_companion` at all.

## Fix

- **Auto-discover `idb_companion`.** When `GLASS_IDB_COMPANION` is unset, resolve `idb_companion` on
  `PATH` first, then in the standard Homebrew prefixes (`/opt/homebrew/bin`, `/usr/local/bin`). An
  explicit `GLASS_IDB_COMPANION` still wins verbatim. `glass doctor`'s presence check uses the same
  resolution.
- **Write baselines to an absolute, always-writable directory** under `std::env::temp_dir()` instead
  of a cwd-relative path (baselines are per-session and don't outlive a `glass_start`, so temp is the
  right home; it honors `TMPDIR`). Also pin `WorkingDirectory` in the shipped LaunchAgent plist as
  defense-in-depth.

Net effect: a Homebrew + signed-app install now drives the iOS Simulator with **no manual
configuration**.

## Tests

- New unit tests for the companion resolution (env override, PATH, Homebrew fallback order,
  none-found) via injected env/fs seams, and for the baseline dir being absolute + the plist pinning
  `WorkingDirectory`.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and
  `cargo test --workspace` all green.
- Verified end-to-end on an Apple-silicon host under exact launchd conditions (`env -i`, cwd `/`, no
  `GLASS_IDB_COMPANION`): `glass doctor --deep` reports the companion served, and a real
  `glass_start` → `glass_baseline_save` → `glass_a11y_snapshot` → `glass_click` all succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
