### PR TITLE
fix(ios): capture launch-time unified-log lines (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ internal refactors, CI, or test-only changes.
 ## [Unreleased]
 
 ### Fixed
+- iOS: a log line an app emits at launch — before its first frame (e.g. an `applicationDidFinishLaunching`
+  / `App.init` `os_log`) — is now captured, so you can gate readiness on it with `glass_wait_for_log`.
+  Previously the unified-log stream attached only after the app had already launched, so launch-time lines
+  were lost to the live tail; the stream now starts before launch and the launch waits until it is
+  delivering.
 - iOS: a Homebrew-installed `idb_companion` is now found automatically even when glass is launched by
   launchd (the `.app` / LaunchAgent), whose minimal `PATH` omits Homebrew's bindir — so input and the
   accessibility tree work without setting `GLASS_IDB_COMPANION` by hand.

--- a/crates/glass-ios/src/logs.rs
+++ b/crates/glass-ios/src/logs.rs
@@ -58,9 +58,11 @@ impl SharedLog {
     /// absent stream returns `false` at once rather than burning the full `timeout`.
     pub fn wait_ready(&self, timeout: Duration) -> bool {
         let (lock, cv) = &*self.0;
-        let Ok(guard) = lock.lock() else {
-            return false;
-        };
+        // Recover the guard on poison rather than bailing to `false`: the lock holders run no
+        // panic-prone code so poison is unreachable, but were it ever poisoned the real
+        // `first_line` state is still the honest answer — symmetric with the post-wait
+        // recovery below.
+        let guard = lock.lock().unwrap_or_else(|e| e.into_inner());
         let guard = match cv
             .wait_timeout_while(guard, timeout, |inner| !inner.first_line && !inner.finished)
         {

--- a/crates/glass-ios/src/logs.rs
+++ b/crates/glass-ios/src/logs.rs
@@ -3,29 +3,78 @@
 
 use std::io::{BufRead, BufReader};
 use std::process::{Child, Command, Stdio};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::Duration;
 
 use glass_core::Stream;
 
-/// Thread-safe line buffer shared between the pump thread and `drain`.
+/// Buffered lines plus the one-shot readiness flags the pump thread signals.
+#[derive(Default)]
+struct Inner {
+    lines: Vec<(Stream, String)>,
+    /// Set once the pump delivers its first line: the `log stream` subscription is active, so
+    /// the stream is provably live.
+    first_line: bool,
+    /// Set once the pump's read loop ends (EOF) — the child died / produced nothing — or when
+    /// there is no child at all. Distinct from `first_line` so a dead stream unblocks a waiter
+    /// without ever claiming to be live.
+    finished: bool,
+}
+
+/// Thread-safe line buffer shared between the pump thread and `drain`, carrying a readiness
+/// signal so a caller can wait until the stream has proven itself live before proceeding.
 #[derive(Clone, Default)]
-pub struct SharedLog(Arc<Mutex<Vec<(Stream, String)>>>);
+pub struct SharedLog(Arc<(Mutex<Inner>, Condvar)>);
 
 impl SharedLog {
     /// Append a line. A poisoned lock (some other thread already panicked while holding it)
     /// simply drops the line rather than panicking here too, matching `glass-android`'s
-    /// `LogSink`.
+    /// `LogSink`. The first line also flips the readiness signal and wakes any waiter.
     pub fn push(&self, stream: Stream, line: String) {
-        if let Ok(mut g) = self.0.lock() {
-            g.push((stream, line));
+        let (lock, cv) = &*self.0;
+        if let Ok(mut inner) = lock.lock() {
+            inner.lines.push((stream, line));
+            if !inner.first_line {
+                inner.first_line = true;
+                cv.notify_all();
+            }
         }
+    }
+
+    /// Mark the stream finished: the pump reached EOF, or no child was ever spawned. This
+    /// wakes a readiness waiter so it stops waiting for a line that will never come.
+    pub fn mark_done(&self) {
+        let (lock, cv) = &*self.0;
+        if let Ok(mut inner) = lock.lock() {
+            if !inner.finished {
+                inner.finished = true;
+                cv.notify_all();
+            }
+        }
+    }
+
+    /// Block until the stream proves live (a first line arrived), or is known dead (EOF / no
+    /// child), or `timeout` elapses. Returns `true` only when a line was seen. A dead or
+    /// absent stream returns `false` at once rather than burning the full `timeout`.
+    pub fn wait_ready(&self, timeout: Duration) -> bool {
+        let (lock, cv) = &*self.0;
+        let Ok(guard) = lock.lock() else {
+            return false;
+        };
+        let guard = match cv
+            .wait_timeout_while(guard, timeout, |inner| !inner.first_line && !inner.finished)
+        {
+            Ok((guard, _)) => guard,
+            Err(poisoned) => poisoned.into_inner().0,
+        };
+        guard.first_line
     }
 
     /// Take and clear all buffered lines.
     pub fn drain(&self) -> Vec<(Stream, String)> {
-        self.0
-            .lock()
-            .map(|mut g| std::mem::take(&mut *g))
+        let (lock, _cv) = &*self.0;
+        lock.lock()
+            .map(|mut g| std::mem::take(&mut g.lines))
             .unwrap_or_default()
     }
 }
@@ -62,9 +111,25 @@ impl LogStream {
                 for line in BufReader::new(out).lines().map_while(Result::ok) {
                     sink.push(Stream::Stdout, line);
                 }
+                // EOF: the child exited (or was killed) — no more lines will arrive. Signal
+                // readiness-finished so a waiter blocked in `wait_until_ready` stops waiting.
+                sink.mark_done();
             });
+        } else {
+            // No child or no stdout pipe (spawn failed): nothing will ever be delivered, so
+            // the stream is immediately finished — a readiness wait returns `false` at once
+            // instead of blocking for the full timeout.
+            buf.mark_done();
         }
         Self { child, buf }
+    }
+
+    /// Block until the stream is confirmed live (its first line arrived), or known dead / not
+    /// spawned, or `timeout` elapses. Returns `true` only when the stream proved live. Used to
+    /// gate `simctl launch` on an active subscription so launch-time log lines are not lost to
+    /// the live-tail race.
+    pub fn wait_until_ready(&self, timeout: Duration) -> bool {
+        self.buf.wait_ready(timeout)
     }
 
     /// Take and clear all buffered lines since the last drain.
@@ -87,6 +152,7 @@ impl Drop for LogStream {
 mod tests {
     use super::*;
     use glass_core::Stream;
+    use std::time::Duration;
 
     #[test]
     fn drain_returns_and_clears_buffer() {
@@ -101,5 +167,39 @@ mod tests {
             ]
         );
         assert!(buf.drain().is_empty(), "second drain is empty");
+    }
+
+    #[test]
+    fn wait_ready_is_false_immediately_when_nothing_seen() {
+        // No line, no EOF: the stream has not proven itself live, so a zero-timeout wait
+        // returns `false` at once (it does not block for the cap).
+        let buf = SharedLog::default();
+        assert!(!buf.wait_ready(Duration::ZERO));
+    }
+
+    #[test]
+    fn wait_ready_is_true_after_a_line() {
+        // One delivered line proves the subscription is active — the stream is live.
+        let buf = SharedLog::default();
+        buf.push(Stream::Stdout, "some system line".into());
+        assert!(buf.wait_ready(Duration::ZERO));
+    }
+
+    #[test]
+    fn wait_ready_is_false_after_eof_without_a_line() {
+        // The pump reached EOF (the `log stream` child died / produced nothing) before any
+        // line: not live, and it must return immediately rather than burn the full cap.
+        let buf = SharedLog::default();
+        buf.mark_done();
+        assert!(!buf.wait_ready(Duration::ZERO));
+    }
+
+    #[test]
+    fn wait_ready_wakes_when_a_line_arrives() {
+        // A line pushed from another thread wakes a blocked waiter well before the cap.
+        let buf = SharedLog::default();
+        let other = buf.clone();
+        std::thread::spawn(move || other.push(Stream::Stdout, "some system line".into()));
+        assert!(buf.wait_ready(Duration::from_secs(2)));
     }
 }

--- a/crates/glass-ios/src/logs.rs
+++ b/crates/glass-ios/src/logs.rs
@@ -8,15 +8,26 @@ use std::time::Duration;
 
 use glass_core::Stream;
 
+/// Does `line` look like a real `log stream --style compact` entry, as opposed to the tool's
+/// own startup output? Compact entries begin with an ISO-ish timestamp (`2026-07-11 ...`), so a
+/// leading ASCII digit distinguishes them from the `Timestamp  Ty Process[PID:TID]` column
+/// header and the `getpwuid_r ...` warning the `log` tool prints *before* it begins streaming.
+/// Readiness keys off this so the launch gate opens only once logd is actually delivering, not
+/// merely once the tool has announced itself.
+fn is_log_entry(line: &str) -> bool {
+    line.as_bytes().first().is_some_and(u8::is_ascii_digit)
+}
+
 /// Buffered lines plus the one-shot readiness flags the pump thread signals.
 #[derive(Default)]
 struct Inner {
     lines: Vec<(Stream, String)>,
-    /// Set once the pump delivers its first line: the `log stream` subscription is active, so
-    /// the stream is provably live.
-    first_line: bool,
+    /// Set once the pump delivers a genuine log entry (per [`is_log_entry`]): logd is actually
+    /// delivering, so the subscription is active and the stream is provably live. The tool's
+    /// header/warning banner does not set this.
+    saw_entry: bool,
     /// Set once the pump's read loop ends (EOF) — the child died / produced nothing — or when
-    /// there is no child at all. Distinct from `first_line` so a dead stream unblocks a waiter
+    /// there is no child at all. Distinct from `saw_entry` so a dead stream unblocks a waiter
     /// without ever claiming to be live.
     finished: bool,
 }
@@ -29,13 +40,15 @@ pub struct SharedLog(Arc<(Mutex<Inner>, Condvar)>);
 impl SharedLog {
     /// Append a line. A poisoned lock (some other thread already panicked while holding it)
     /// simply drops the line rather than panicking here too, matching `glass-android`'s
-    /// `LogSink`. The first line also flips the readiness signal and wakes any waiter.
+    /// `LogSink`. The first *genuine log entry* (not the tool's header/warning banner) also
+    /// flips the readiness signal and wakes any waiter.
     pub fn push(&self, stream: Stream, line: String) {
         let (lock, cv) = &*self.0;
         if let Ok(mut inner) = lock.lock() {
+            let is_entry = is_log_entry(&line);
             inner.lines.push((stream, line));
-            if !inner.first_line {
-                inner.first_line = true;
+            if is_entry && !inner.saw_entry {
+                inner.saw_entry = true;
                 cv.notify_all();
             }
         }
@@ -53,23 +66,23 @@ impl SharedLog {
         }
     }
 
-    /// Block until the stream proves live (a first line arrived), or is known dead (EOF / no
-    /// child), or `timeout` elapses. Returns `true` only when a line was seen. A dead or
-    /// absent stream returns `false` at once rather than burning the full `timeout`.
+    /// Block until the stream proves live (a genuine log entry arrived), or is known dead (EOF
+    /// / no child), or `timeout` elapses. Returns `true` only when a real entry was seen. A
+    /// dead or absent stream returns `false` at once rather than burning the full `timeout`.
     pub fn wait_ready(&self, timeout: Duration) -> bool {
         let (lock, cv) = &*self.0;
         // Recover the guard on poison rather than bailing to `false`: the lock holders run no
         // panic-prone code so poison is unreachable, but were it ever poisoned the real
-        // `first_line` state is still the honest answer — symmetric with the post-wait
-        // recovery below.
+        // `saw_entry` state is still the honest answer — symmetric with the post-wait recovery
+        // below.
         let guard = lock.lock().unwrap_or_else(|e| e.into_inner());
         let guard = match cv
-            .wait_timeout_while(guard, timeout, |inner| !inner.first_line && !inner.finished)
+            .wait_timeout_while(guard, timeout, |inner| !inner.saw_entry && !inner.finished)
         {
             Ok((guard, _)) => guard,
             Err(poisoned) => poisoned.into_inner().0,
         };
-        guard.first_line
+        guard.saw_entry
     }
 
     /// Take and clear all buffered lines.
@@ -126,10 +139,10 @@ impl LogStream {
         Self { child, buf }
     }
 
-    /// Block until the stream is confirmed live (its first line arrived), or known dead / not
-    /// spawned, or `timeout` elapses. Returns `true` only when the stream proved live. Used to
-    /// gate `simctl launch` on an active subscription so launch-time log lines are not lost to
-    /// the live-tail race.
+    /// Block until the stream is confirmed live (a genuine log entry arrived — not just the
+    /// tool's startup banner), or known dead / not spawned, or `timeout` elapses. Returns
+    /// `true` only when the stream proved live. Used to gate `simctl launch` on an active
+    /// subscription so launch-time log lines are not lost to the live-tail race.
     pub fn wait_until_ready(&self, timeout: Duration) -> bool {
         self.buf.wait_ready(timeout)
     }
@@ -179,12 +192,43 @@ mod tests {
         assert!(!buf.wait_ready(Duration::ZERO));
     }
 
+    /// A representative `log stream --style compact` entry line (starts with a timestamp).
+    const ENTRY: &str = "2026-07-11 10:03:28.611 A  backboardd[2823:28ff3] hello";
+
     #[test]
-    fn wait_ready_is_true_after_a_line() {
-        // One delivered line proves the subscription is active — the stream is live.
+    fn wait_ready_is_true_after_a_real_entry() {
+        // A genuine timestamped entry proves the logd subscription is delivering — live.
         let buf = SharedLog::default();
-        buf.push(Stream::Stdout, "some system line".into());
+        buf.push(Stream::Stdout, ENTRY.into());
         assert!(buf.wait_ready(Duration::ZERO));
+    }
+
+    #[test]
+    fn wait_ready_ignores_the_stream_header_and_warning() {
+        // `log stream --style compact` prints a "Timestamp  Ty Process[PID:TID]" column
+        // header and a "getpwuid_r ..." tool warning before any real entry. Those are the
+        // tool announcing itself, NOT proof the logd subscription is active, so they must not
+        // flip readiness — otherwise the launch gate could open before the stream is truly
+        // live and lose the app's launch-time line (the #136 race).
+        let buf = SharedLog::default();
+        buf.push(
+            Stream::Stdout,
+            "getpwuid_r did not find a match for uid 501".into(),
+        );
+        buf.push(
+            Stream::Stdout,
+            "Timestamp               Ty Process[PID:TID]".into(),
+        );
+        assert!(
+            !buf.wait_ready(Duration::ZERO),
+            "the header/warning banner must not count as live"
+        );
+        // The lines are still buffered — only the readiness signal ignores them.
+        buf.push(Stream::Stdout, ENTRY.into());
+        assert!(
+            buf.wait_ready(Duration::ZERO),
+            "a real entry after the banner proves live"
+        );
     }
 
     #[test]
@@ -198,10 +242,10 @@ mod tests {
 
     #[test]
     fn wait_ready_wakes_when_a_line_arrives() {
-        // A line pushed from another thread wakes a blocked waiter well before the cap.
+        // A real entry pushed from another thread wakes a blocked waiter well before the cap.
         let buf = SharedLog::default();
         let other = buf.clone();
-        std::thread::spawn(move || other.push(Stream::Stdout, "some system line".into()));
+        std::thread::spawn(move || other.push(Stream::Stdout, ENTRY.into()));
         assert!(buf.wait_ready(Duration::from_secs(2)));
     }
 }

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -199,6 +199,12 @@ impl IosPlatform {
     }
 }
 
+/// How long [`Platform::start_app`] waits for the unified-log stream to prove itself live
+/// before launching the app. A booted simulator emits system log lines continuously, so this
+/// is reached in milliseconds in practice; the cap only bounds a pathologically quiet or
+/// failed stream so launch is never blocked for long.
+const LOG_STREAM_READY_TIMEOUT: Duration = Duration::from_secs(2);
+
 /// How many times [`retry_for_scale`] polls for a positive scale before giving up.
 const SCALE_ATTEMPTS: usize = 3;
 /// How long [`retry_for_scale`] waits between polls while the tree is still empty.
@@ -278,6 +284,22 @@ impl Platform for IosPlatform {
         if let Some(path) = install {
             self.target.simctl().run(&["install", udid, &path])?;
         }
+
+        // Start the unified-log stream BEFORE launching, and do not launch until its
+        // subscription is provably live. `log stream` is a live tail with no backlog, so a
+        // subscription that attaches after `simctl launch` misses the app's launch-time lines
+        // (an `onAppear` / `applicationDidFinishLaunching` `os_log`). Gating launch on a
+        // confirmed-live stream closes that race. Logs stay best-effort: a stream that never
+        // comes up does not fail the launch — it only means a launch-time line may be missed,
+        // which is noted rather than swallowed.
+        let logs = LogStream::spawn(udid);
+        if !logs.wait_until_ready(LOG_STREAM_READY_TIMEOUT) {
+            eprintln!(
+                "glass-ios: unified-log stream not confirmed live before launch; a \
+                 launch-time log line may be missed"
+            );
+        }
+
         // `SIMCTL_CHILD_<KEY>` is Apple's convention for passing environment variables through
         // `simctl launch` to the launched process, so `spec.env` is set that way rather than on
         // this (glass's own) process.
@@ -328,7 +350,7 @@ impl Platform for IosPlatform {
         self.app = Some(RunningApp {
             bundle_id,
             geometry: geometry.clone(),
-            logs: LogStream::spawn(udid),
+            logs,
             injector,
         });
         Ok(geometry)

--- a/crates/glass-ios/tests/startup_log_integration.rs
+++ b/crates/glass-ios/tests/startup_log_integration.rs
@@ -1,0 +1,84 @@
+//! On-box proof for glass-ios #136: a log line an app emits at launch — before its first
+//! frame — is captured.
+//!
+//! Before the fix, the unified-log stream (`xcrun simctl spawn <udid> log stream`) attached
+//! only *after* `simctl launch` returned. `log stream` is a live tail with no backlog, so an
+//! `applicationDidFinishLaunching` / `App.init` `os_log` was emitted before the subscription
+//! existed and was lost; `glass_wait_for_log` on it timed out. The backend now starts the
+//! stream before launch and gates the launch on a confirmed-live subscription, so the line is
+//! buffered by the time `start_app` returns. This test drives the real `Platform` path and
+//! asserts the launch-time marker reaches `drain_logs()`.
+//!
+//! `#[ignore]`d so a plain `cargo test` (Linux dev host, CI) skips it: the backend shells out
+//! to `xcrun simctl` (macOS + Xcode only) and needs a booted Simulator plus an app that logs a
+//! known line at launch. Point it at such an app and tell it the exact line to expect:
+//!
+//! ```sh
+//! GLASS_IOS_APP=/path/to/StartupLogger.app \
+//! GLASS_IOS_STARTUP_MARKER='GLASS_IOS_STARTUP_MARKER' \
+//!   cargo test -p glass-ios --test startup_log_integration -- --ignored --nocapture
+//! ```
+//!
+//! The marker MUST be emitted at the app's earliest launch point (not a delayed `onAppear`),
+//! so it exercises the race the fix closes. `GLASS_IOS_UDID` / `GLASS_IOS_DEVICE` select the
+//! Simulator the same way they do for `glass-mcp`; see `docs/how-to/setup-ios.md`.
+
+use std::time::Duration;
+
+use glass_core::{AppSpec, Platform, SandboxLevel};
+use glass_ios::{IosPlatform, SimulatorRegistry};
+
+#[test]
+#[ignore = "on-box only: needs a macOS host with Xcode + a booted iOS Simulator, GLASS_IOS_APP \
+            pointing at a built .app that emits GLASS_IOS_STARTUP_MARKER at launch"]
+fn launch_time_log_line_is_captured() {
+    let app = std::env::var("GLASS_IOS_APP")
+        .expect("GLASS_IOS_APP must point at a built .app that logs at launch");
+    let marker = std::env::var("GLASS_IOS_STARTUP_MARKER")
+        .expect("GLASS_IOS_STARTUP_MARKER must be the exact line the app emits at launch");
+
+    let spec = AppSpec {
+        build: None,
+        run: vec![app],
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        timeout_ms: 30_000,
+        sandbox: SandboxLevel::Off,
+        a11y: false,
+    };
+
+    let reg = SimulatorRegistry::new();
+    let mut platform = IosPlatform::from_env(&reg)
+        .expect("IosPlatform::from_env (resolve/boot a Simulator per GLASS_IOS_* env)");
+
+    platform
+        .start_app(&spec)
+        .expect("start_app must install (if needed), launch, and report geometry");
+
+    // With the stream confirmed live before launch, the marker is already buffered when
+    // start_app returns. Poll a few times with a short settle regardless: the unified log can
+    // deliver a launch line a beat after `simctl launch` returns, and draining is destructive
+    // so each batch is inspected as it arrives.
+    let mut captured = false;
+    'poll: for _ in 0..20 {
+        for (_, line) in platform.drain_logs() {
+            if line.contains(&marker) {
+                captured = true;
+                break 'poll;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+
+    // Stop before asserting so a failure still tears the app down.
+    platform
+        .stop_app()
+        .expect("stop_app must terminate the launched app");
+
+    assert!(
+        captured,
+        "launch-time log line {marker:?} must be captured after start_app (glass-ios #136); \
+         it was never seen in the drained logs"
+    );
+}


### PR DESCRIPTION
## Problem

Fixes #136. The iOS backend streamed the Simulator's unified log via
`xcrun simctl spawn <udid> log stream`, but the stream was started at the **end** of
`IosPlatform::start_app` — *after* `simctl launch` had already returned. `log stream` is a
live tail with no backlog, so a line the app logs at launch (an `applicationDidFinishLaunching`
/ `App.init` / `onAppear` `os_log`) was emitted before the subscription attached and was never
captured. `glass_wait_for_log` on such a line timed out even though `log show` proved it was
emitted. (Android doesn't hit this: `adb logcat` reads a persistent ring buffer.)

## Fix — reorder + readiness gate

Start the live stream **before** `simctl launch`, and don't launch until the stream has proven
it is subscribed:

- `SharedLog` now carries a `Condvar` readiness signal. `LogStream::wait_until_ready(timeout)`
  blocks until the stream is confirmed live, is known dead (EOF / no child spawned), or a 2s cap
  elapses.
- Readiness fires on the first **genuine log entry**, not the first stdout line. On-device
  inspection showed `log stream --style compact` prints its own banner first — a `getpwuid_r …`
  warning and a `Timestamp  Ty Process[PID:TID]` header — before logd delivers anything. Gating
  on those would open the launch gate too early. `is_log_entry` (leading timestamp digit)
  distinguishes a real entry; the banner is still buffered, only ignored for the signal.
- Logs stay **best-effort**: a stream that never comes up logs a one-line stderr note and does
  not fail the launch (matches the Android backend).

## Verification

- Unit tests for the readiness primitive (empty→false, real entry→true, banner→not-live,
  EOF→false, cross-thread wake). Full `cargo test --workspace`, `clippy -D warnings`, and
  `cargo fmt --check` are green.
- Added `tests/startup_log_integration.rs` (`#[ignore]`d, on-box).
- **On a real Simulator (Mac mini, iPhone 17, iOS 26.5):** a fixture app that logs
  `GLASS_IOS_STARTUP_MARKER` at `App.init` — with this branch the marker **is** captured in
  `drain_logs()`; with the two source files reverted to `master` the same test **fails**
  ("never seen in the drained logs"). That is #136 reproduced and fixed through the real
  `Platform` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
