### PR TITLE
docs(ios): clarify touch-backend glass_scroll semantics (#137)

### DIFF
--- a/docs/how-to/setup-ios.md
+++ b/docs/how-to/setup-ios.md
@@ -88,7 +88,9 @@ brew install idb-companion
 With `idb_companion` on `PATH`, these tools work against the Simulator:
 
 - **Input** — `glass_click`, `glass_type`, `glass_key`, `glass_scroll`, and `glass_drag` map to
-  synthetic touches and keystrokes.
+  synthetic touches and keystrokes. As on any touch backend, `glass_scroll` is delivered as a real
+  one-finger swipe (it is *input*, not an inert wheel event), so over an interactive surface it can
+  mutate app state — see [`glass_scroll`](../reference/tools.md#glass_scroll).
 - **Accessibility** — `glass_a11y_snapshot`, `glass_a11y_marks`, `glass_click_element`,
   `glass_set_value`, `glass_wait_for_element`, and `glass_scroll_to_element` read and drive the
   Simulator's accessibility tree.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -197,9 +197,28 @@ Scroll at window-relative coordinates by wheel notches.
 
 - `x`, `y` (integer, **required**) — window-relative point.
 - `dx`, `dy` (integer) — horizontal/vertical scroll in **wheel notches** (discrete clicks — small
-  integers like 1–5, not pixels). Positive `dy` is wheel-down, negative wheel-up; glass clicks
-  `|dy|` times. How an app maps a notch to its view (lines, pixels, zoom) is the app's choice.
+  integers like 1–5, not pixels). Positive `dy` is wheel-down, negative wheel-up; positive `dx`
+  reveals content to the **right**, negative to the left. glass clicks `|dx|`/`|dy|` times. How an
+  app maps a notch to its view (lines, pixels, zoom) is the app's choice.
 - `modifiers` (array of string) — keys held during the scroll.
+
+> **On touch backends (Android, iOS), `glass_scroll` is a real one-finger swipe — it is *input*,
+> not an inert viewport nudge.** There is no wheel on touch; glass reproduces a scroll as a finger
+> drag anchored at `x,y`, travelling roughly `notches × 120 px` opposite the wheel direction (the
+> resulting pan is then amplified and made non-linear by the view's fling/deceleration, so it is not
+> a fixed distance per notch). Three things follow:
+>
+> - **It can mutate app state.** Over an *interactive* surface — a drawing canvas, a slider, a
+>   swipe-to-act row — the swipe registers as input (e.g. commits a stroke). Scroll from an inert
+>   part of the container, or start the anchor on a non-actionable element.
+> - **A scroll against the container's edge is an expected no-op.** At a scroll boundary there is
+>   nothing to reveal in that direction, so nothing moves — and the tool still returns `ok`. That is
+>   not a failure or a dropped `dx`; scroll the other way, or from a position that has room.
+> - **Verify a pan by the accessibility tree, not a whole-window diff.** A thin container (a
+>   toolbar) pans only a small fraction of the window, so `glass_diff`'s `changed_pct` barely moves
+>   even when the scroll worked. Snapshot before/after and compare a container element's `bounds`
+>   (they shift by the pan distance); items scrolled off-screen keep reporting `bounds` outside
+>   `[0,width)`, which is the tell that it panned.
 
 ### `glass_drag`
 
@@ -322,7 +341,10 @@ app exposes no accessibility tree.
 - `value_contains` (string) — additionally require the matched element's value to contain this
   substring; not a standalone selector.
 - `direction` (string, default `down`) — primary sweep direction (`"down"`/`"up"`); the search
-  reverses to the other end if the target isn't found first.
+  reverses to the other end if the target isn't found first. **Vertical only** — this tool cannot
+  drive a *horizontal* container. To reach an off-screen item in a horizontal `ScrollView` (e.g. an
+  overflowing toolbar), pan it yourself with `glass_scroll` `dx` (or a `glass_drag` swipe), snapshot,
+  then `glass_click_element`.
 - `x`, `y` (integer) — scroll anchor (window-relative); default to the window center. Set both to aim
   the wheel at a specific scrollable container.
 - `step` (integer, default 3) — wheel notches per scroll step; larger covers distance faster but risks


### PR DESCRIPTION
Resolves the documentation half of #137, and corrects the code half after on-device investigation.

## What I found (iOS Simulator, real `idb_companion` path)

I drove the real `glass-mcp` binary against the actual `Paint.app` from the dogfood run (and a synthetic `ScrollView(.horizontal)` fixture), measuring the pan by a toolbar element's **accessibility bounds**:

| `glass_scroll` @ toolbar (y≈256) | "Red" button a11y x | whole-window `changed_pct` |
|---|---|---|
| `dx=+1` | 24 → −56 | 0.28% |
| `dx=+3` | 24 → −840 | 0.32% |
| `dx=+8` | 24 → −1701 | 0.36% |
| `dx=−8` (at the left boundary) | 24 → **24** (no-op) | — |
| `dx=+5` then `dx=−5` | 24 → −1251 → **27** (pans back) | — |

**Horizontal `dx` already maps to a horizontal pan** — the a11y bounds move by hundreds–thousands of pixels, in both directions. The reported "silent no-op" was:

1. a scroll **against the container boundary** (nothing to reveal that way — still returns `ok`), and/or
2. judging the pan by a **whole-window `changed_pct`**, which is ~0.3% for a thin toolbar even when it worked — indistinguishable from "nothing happened."

So there is **no code bug** in the `dx` → pan mapping (an earlier clamp attempt was reverted — the off-screen endpoint pans fine; the Simulator handles it). This is a docs/clarification fix.

## Docs changes

- `docs/reference/tools.md` — `glass_scroll`: on touch backends it's a **real one-finger swipe (input)** that can mutate an interactive surface (a canvas stroke); the pan is amplified/non-linear (fling); a scroll against an edge is an **expected no-op**; `+dx` reveals right / `-dx` left; **verify a pan via accessibility bounds, not a whole-window diff**.
- `docs/reference/tools.md` — `glass_scroll_to_element`: note it is **vertical-only**, so a horizontal container is panned with `glass_scroll`/`glass_drag` instead.
- `docs/how-to/setup-ios.md` — one-line pointer that `glass_scroll` is real input on touch.

Docs-only; no code, no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)