### PR TITLE
docs(ios): document the clipboard paste-consent two-step (#139)

### DIFF
--- a/docs/how-to/setup-ios.md
+++ b/docs/how-to/setup-ios.md
@@ -105,6 +105,28 @@ minimal `PATH` that omits Homebrew's bindir — also probes the standard Homebre
 `GLASS_IDB_COMPANION` to the binary's path only to override that — an install elsewhere, or to pin a
 specific build.
 
+## Clipboard
+
+`glass_clipboard_get` and `glass_clipboard_set` act on the **Simulator's own** pasteboard (separate
+from your host's) over `simctl`, and work without `idb_companion`.
+
+One iOS policy to expect: when the **app under test** reads a pasteboard that *another* app wrote —
+which is exactly `glass_clipboard_set` followed by an in-app paste — iOS raises a SpringBoard
+**paste-consent** alert (*"YourApp would like to paste from …"*) and the **first read returns
+`nil`**. So a set-then-paste is a **two-step** flow:
+
+1. `glass_clipboard_set { "text": "…" }`, then drive the app control that reads
+   `UIPasteboard.general`.
+2. That first read comes back empty and the consent alert appears. glass surfaces it in the
+   accessibility tree — the frontmost app's name briefly blanks to `" "` while SpringBoard's alert is
+   up — so `glass_a11y_snapshot`, then `glass_click_element` the **Allow Paste** button.
+3. Drive the control again; the app now reads the value (the grant sticks, so the retry doesn't
+   re-prompt).
+
+Expect the modal: a bare `glass_wait_for_log` on the paste times out on the first tap and looks like
+a dropped clipboard when it is really the consent gate. `glass_clipboard_get` is unaffected — it
+reads the pasteboard over `simctl`, not through an in-app `UIPasteboard` read, so it never prompts.
+
 ## Check the setup
 
 ```bash

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -380,6 +380,11 @@ Write text to the clipboard so the app can paste it.
 
 - `text` (string, **required**) — the text to write.
 
+> **iOS paste-consent:** when the app then reads a pasteboard glass wrote (`glass_clipboard_set` → an
+> in-app `UIPasteboard` read), iOS raises a SpringBoard consent alert and the *first* read returns
+> nothing. Click **Allow Paste** (it appears in the a11y tree) and retry — the two-step flow is in
+> [setup-ios.md](../how-to/setup-ios.md#clipboard).
+
 ## Logs & diagnostics
 
 ### `glass_logs`


### PR DESCRIPTION
Closes #139.

## What

`glass_clipboard_set` writes the iOS Simulator pasteboard fine, but when the app under test then reads `UIPasteboard.general`, iOS pops a SpringBoard **paste-consent** alert (*"… would like to paste from …"*) and the **first read returns `nil`**. It's iOS policy, not a glass bug — but a bare `glass_wait_for_log` on the paste looks like a dropped clipboard until you expect the modal.

## Docs-only, no behavior change

The two-step is already fully driveable with existing tools: glass surfaces the consent alert in the accessibility tree (the frontmost app's name briefly blanks while SpringBoard's alert is up), so an agent snapshots, `glass_click_element`s **Allow Paste**, and retries. So this documents the flow rather than adding anything:

- **`docs/how-to/setup-ios.md`** — new *Clipboard* section: the `glass_clipboard_set` → expect-alert → **Allow Paste** → retry recipe, plus the note that `glass_clipboard_get` reads over `simctl` (not an in-app `UIPasteboard` read) so it never prompts.
- **`docs/reference/tools.md`** — a short iOS paste-consent note on `glass_clipboard_set` linking to the how-to.

## On auto-accept (declined)

The issue floats optionally auto-accepting the alert. Not doing that: it's an OS **consent** prompt, and a black-box automation tool silently clicking through it is the wrong default to bake in — the a11y tree already exposes **Allow Paste**, so a caller that wants it can accept it explicitly in one `glass_click_element`. Happy to revisit as an opt-in if there's demand.

Facts verified against the 2026-07-11 iOS dogfood run (exact alert text, the `" "` name-blank, the **Allow Paste** label, retry-succeeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)