### PR TITLE
Backend-neutral MCP tool descriptions + drift guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ internal refactors, CI, or test-only changes.
 - `glass_scroll_to_element` returns an element only once it is actually **on-screen** — previously
   it could return one that was present in the accessibility tree but off-screen (which
   `glass_click_element` then refused). The result gains a `direction` field.
+- MCP tool descriptions and the [tools reference](docs/reference/tools.md) are now backend-neutral:
+  removed stale/mismatched per-platform text and the duplicated backend list from the tool and
+  `get_info` descriptions. The accepted backends are documented once, on `glass_start`'s `backend`
+  param; per-OS clipboard/gesture/doctor specifics now live in the tools reference's per-tool
+  **Platform notes**.
 
 ### Fixed
 - Wayland: text entry (`glass_type` and a typed `KeyEvent::Text`) is reliable under heavy machine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,10 @@ internal refactors, CI, or test-only changes.
 - `glass_scroll_to_element` returns an element only once it is actually **on-screen** — previously
   it could return one that was present in the accessibility tree but off-screen (which
   `glass_click_element` then refused). The result gains a `direction` field.
-- MCP tool descriptions and the [tools reference](docs/reference/tools.md) are now backend-neutral:
-  removed stale/mismatched per-platform text and the duplicated backend list from the tool and
-  `get_info` descriptions. The accepted backends are documented once, on `glass_start`'s `backend`
-  param; per-OS clipboard/gesture/doctor specifics now live in the tools reference's per-tool
-  **Platform notes**.
+- The MCP tool descriptions and `get_info` are now backend-neutral (no per-platform text or
+  duplicated backend list); the accepted backends are documented once on the `glass_start`
+  `backend` param, and the per-OS clipboard/gesture/doctor specifics are collected in the
+  [tools reference](docs/reference/tools.md)'s per-tool **Platform notes**.
 
 ### Fixed
 - Wayland: text entry (`glass_type` and a typed `KeyEvent::Text`) is reliable under heavy machine

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -147,6 +147,11 @@ pub fn make_platform(
 /// The canonical list of backend names glass accepts. Single source of truth: the
 /// `backend` param doc, the description guard, and `default_backend` all key off this.
 /// Adding a backend is one edit here (plus its `make_platform` arm).
+///
+/// Membership here is a backend-*name* vocabulary fact, not a this-host-*buildable* fact:
+/// `make_platform`'s `#[cfg(...)]`-gated arms are the host-availability authority, so a
+/// backend that's named here but unavailable on the current host (e.g. `"windows"` on a
+/// Linux build) errors there, when actually constructed — not in `default_backend`.
 pub const BACKENDS: &[&str] = &["x11", "wayland", "windows", "macos", "android", "ios"];
 
 /// Default backend name from `GLASS_BACKEND` (case-insensitive; one of [`BACKENDS`]).

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -144,20 +144,26 @@ pub fn make_platform(
     })
 }
 
-/// Default backend name from `GLASS_BACKEND` (case-insensitive
-/// `wayland`/`windows`/`macos`/`x11`/`android`/`ios`). Unset defaults to the windows backend
-/// on a Windows host, the macos backend on a macOS host, else X11.
+/// The canonical list of backend names glass accepts. Single source of truth: the
+/// `backend` param doc, the description guard, and `default_backend` all key off this.
+/// Adding a backend is one edit here (plus its `make_platform` arm).
+pub const BACKENDS: &[&str] = &["x11", "wayland", "windows", "macos", "android", "ios"];
+
+/// Default backend name from `GLASS_BACKEND` (case-insensitive; one of [`BACKENDS`]).
+/// Unset defaults to the windows backend on a Windows host, the macos backend on a macOS
+/// host, else X11.
 pub fn default_backend(env: Option<&str>) -> &'static str {
-    match env {
-        Some(v) if v.eq_ignore_ascii_case("android") => "android",
-        Some(v) if v.eq_ignore_ascii_case("ios") => "ios",
-        Some(v) if v.eq_ignore_ascii_case("wayland") => "wayland",
-        Some(v) if v.eq_ignore_ascii_case("windows") => "windows",
-        Some(v) if v.eq_ignore_ascii_case("macos") => "macos",
-        Some(v) if v.eq_ignore_ascii_case("x11") => "x11",
-        None if cfg!(windows) => "windows",
-        None if cfg!(target_os = "macos") => "macos",
-        _ => "x11",
+    if let Some(v) = env {
+        if let Some(b) = BACKENDS.iter().find(|b| v.eq_ignore_ascii_case(b)) {
+            return b;
+        }
+    }
+    if cfg!(windows) {
+        "windows"
+    } else if cfg!(target_os = "macos") {
+        "macos"
+    } else {
+        "x11"
     }
 }
 
@@ -413,5 +419,24 @@ mod tests {
         assert_eq!(default_backend(None), "macos");
         #[cfg(not(any(windows, target_os = "macos")))]
         assert_eq!(default_backend(None), "x11");
+    }
+
+    #[test]
+    fn backends_list_is_the_source_of_truth_default_resolves_each() {
+        // BACKENDS is the single list of accepted backend names.
+        assert_eq!(
+            super::BACKENDS,
+            &["x11", "wayland", "windows", "macos", "android", "ios"]
+        );
+        // default_backend must resolve every listed name (either case) to itself, so the
+        // resolver can never disagree with the list.
+        for b in super::BACKENDS {
+            assert_eq!(super::default_backend(Some(b)), *b, "lower {b}");
+            assert_eq!(
+                super::default_backend(Some(&b.to_uppercase())),
+                *b,
+                "upper {b}"
+            );
+        }
     }
 }

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -154,9 +154,11 @@ pub const BACKENDS: &[&str] = &["x11", "wayland", "windows", "macos", "android",
 /// host, else X11.
 pub fn default_backend(env: Option<&str>) -> &'static str {
     if let Some(v) = env {
-        if let Some(b) = BACKENDS.iter().find(|b| v.eq_ignore_ascii_case(b)) {
-            return b;
-        }
+        return BACKENDS
+            .iter()
+            .find(|b| v.eq_ignore_ascii_case(b))
+            .copied()
+            .unwrap_or("x11");
     }
     if cfg!(windows) {
         "windows"

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -38,8 +38,7 @@ pub struct ScreenshotArgs {
 pub struct WindowHintArgs {
     /// Case-insensitive substring matched against window titles. Used to pick the
     /// right window when several appear, and — since it ignores the process tree —
-    /// to locate a window the launched process hands off to an unrelated process
-    /// (e.g. some packaged Windows apps).
+    /// to locate a window the launched process hands off to an unrelated process.
     pub title: Option<String>,
     /// Exact window-class match. Same purpose as `title` but more stable, since
     /// class names rarely carry the dynamic prefixes/suffixes that titles do.
@@ -66,8 +65,8 @@ pub struct StartArgs {
     pub env: Vec<(String, String)>,
     /// Optional `{ title?, class? }` to disambiguate which window is the app's when
     /// more than one appears, or to find a window the launched process hands off to
-    /// an unrelated process (some packaged Windows apps). Omit to take the first
-    /// window owned by the launched process or a descendant it can follow.
+    /// an unrelated process. Omit to take the first window owned by the launched
+    /// process or a descendant it can follow.
     pub window_hint: Option<WindowHintArgs>,
     pub timeout_ms: Option<u64>,
     /// Spawn a private accessibility (AT-SPI) bus so `glass_a11y_snapshot` / `marks` /
@@ -154,8 +153,8 @@ pub struct DragArgs {
     /// Modifier keys to hold during the action, e.g. ["ctrl"] or ["ctrl","shift"] for multi/range-select.
     pub modifiers: Option<Vec<String>>,
     /// Span the drag's motion over this many milliseconds so a frame-based GUI
-    /// (egui/winit) samples the path across multiple frames (and registers the
-    /// drag even while it repaints). Default 200. Lower = faster but coarser.
+    /// samples the path across multiple frames (and registers the drag even while
+    /// it repaints). Default 200. Lower = faster but coarser.
     pub duration_ms: Option<u64>,
 }
 

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -557,6 +557,54 @@ mod tests {
         assert!(first_text(&r).contains("done"), "got {:?}", first_text(&r));
     }
 
+    // "windows" is excluded from `banned` below (collides with the plain noun, e.g.
+    // glass_list_windows). These phrases name the Windows *backend* specifically and don't
+    // occur as innocent noun usage, so match them directly.
+    const WINDOWS_BACKEND_PHRASES: &[&str] = &["windows backend", "windows host", "on windows"];
+
+    /// True if `text` names a Windows-*backend* phrase. Each phrase must appear as a run of
+    /// CONSECUTIVE words (same word-boundary tokenizer as `names` below), case-insensitively —
+    /// a raw substring match would false-positive on e.g. "repositi·on windows".
+    fn names_windows_backend(text: &str) -> bool {
+        let words: Vec<&str> = text
+            .split(|c: char| !c.is_ascii_alphanumeric())
+            .filter(|w| !w.is_empty())
+            .collect();
+        WINDOWS_BACKEND_PHRASES.iter().any(|phrase| {
+            let needle: Vec<&str> = phrase.split(' ').collect();
+            words.windows(needle.len()).any(|run| {
+                run.iter()
+                    .zip(&needle)
+                    .all(|(w, n)| w.eq_ignore_ascii_case(n))
+            })
+        })
+    }
+
+    #[test]
+    fn windows_backend_phrase_is_flagged_not_the_plain_noun() {
+        for phrase in [
+            "Only supported on the Windows backend.",
+            "runs on Windows host",
+            "available on Windows",
+        ] {
+            assert!(
+                names_windows_backend(phrase),
+                "should flag windows-backend phrase: {phrase:?}"
+            );
+        }
+        for phrase in [
+            "tile the windows",
+            "lists top-level windows",
+            "reposition windows to tile them",
+            "position windows on the screen",
+        ] {
+            assert!(
+                !names_windows_backend(phrase),
+                "should not flag the plain noun: {phrase:?}"
+            );
+        }
+    }
+
     /// A session runs one backend, so naming a backend in a description is a mode-conditional
     /// the agent can't resolve — and even a single named gate rots the day another backend
     /// gains the capability. Which backends support a capability is a runtime property, not
@@ -564,34 +612,46 @@ mod tests {
     /// e.g. glass_list_windows) plus the two Linux display servers that ARE those backends.
     #[test]
     fn descriptions_name_no_backend() {
-        let mut banned: Vec<String> = crate::BACKENDS
+        let banned: Vec<&str> = crate::BACKENDS
             .iter()
-            .filter(|b| **b != "windows")
-            .map(|b| b.to_string())
+            .copied()
+            .filter(|&b| b != "windows")
+            .chain(["xvfb", "sway"])
             .collect();
-        banned.push("xvfb".to_string());
-        banned.push("sway".to_string());
 
         // Case-insensitive, word-boundary match so "ios" can't hit inside another word.
         fn names(text: &str, tok: &str) -> bool {
-            text.to_ascii_lowercase()
-                .split(|c: char| !c.is_ascii_alphanumeric())
-                .any(|w| w == tok)
+            text.split(|c: char| !c.is_ascii_alphanumeric())
+                .any(|w| w.eq_ignore_ascii_case(tok))
         }
 
         let mut problems: Vec<String> = Vec::new();
         for tool in GlassServer::tool_router().list_all() {
-            let desc = tool.description.as_deref().unwrap_or("");
+            // A tool with no description gives the guard nothing to check — that's a gap in
+            // the guard, not a pass, so it's a recorded problem rather than silently ok.
+            let desc = match tool.description.as_deref() {
+                Some(d) if !d.is_empty() => d,
+                _ => {
+                    problems.push(format!("  {}: has no description to check", tool.name));
+                    continue;
+                }
+            };
             for tok in &banned {
                 if names(desc, tok) {
                     problems.push(format!("  {}: names backend '{tok}'", tool.name));
                 }
+            }
+            if names_windows_backend(desc) {
+                problems.push(format!("  {}: names the Windows backend", tool.name));
             }
         }
         for tok in &banned {
             if names(SERVER_INSTRUCTIONS, tok) {
                 problems.push(format!("  get_info: names backend '{tok}'"));
             }
+        }
+        if names_windows_backend(SERVER_INSTRUCTIONS) {
+            problems.push("  get_info: names the Windows backend".to_string());
         }
         assert!(
             problems.is_empty(),
@@ -765,9 +825,10 @@ mod tests {
             .and_then(|v| v.as_str())
             .expect("backend param has a description")
             .to_ascii_lowercase();
-        let missing: Vec<&&str> = crate::BACKENDS
+        let missing: Vec<&str> = crate::BACKENDS
             .iter()
-            .filter(|b| !doc.contains(**b))
+            .copied()
+            .filter(|b| !doc.contains(*b))
             .collect();
         assert!(
             missing.is_empty(),

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -123,7 +123,7 @@ impl GlassServer {
     }
 
     #[tool(
-        description = "Build, launch, and locate a native GUI app; returns its window geometry. Optional `backend`: \"x11\" (headless Xvfb) or \"wayland\" (headless sway) on Linux, or \"windows\" on a Windows host, or \"macos\" on a macOS host, or \"android\" for an AVD emulator on any host; defaults to the host backend (windows on Windows, macos on macOS, else x11). Optional `window_hint` ({ title?, class? }) picks the right window when several appear, or locates one the launched process hands off to an unrelated process (some packaged Windows apps)."
+        description = "Build, launch, and locate a native GUI app; returns its window geometry. Choose a backend with the `backend` param (defaults to the host); pass `a11y` to enable the accessibility tools. Optional `window_hint` ({ title?, class? }) picks the right window when several appear, or locates one the launched process hands off to another process."
     )]
     async fn glass_start(
         &self,
@@ -210,7 +210,8 @@ impl GlassServer {
                        segment in window-relative px, all down together at t=0 and up at \
                        duration_ms. Pinch = two pointers toward/apart; rotate = two on an arc; \
                        two-finger swipe = two parallel segments; a from==to pointer is held. \
-                       Android backend only (needs the on-device agent)."
+                       Multi-touch isn't available on every backend — it returns a clear \
+                       Unsupported error where the active backend can't do it."
     )]
     async fn glass_gesture(
         &self,
@@ -236,34 +237,18 @@ impl GlassServer {
     }
 
     #[tool(
-        description = "Read the clipboard as text (\"\" if empty). Acts on the app's clipboard — \
-                       isolated from your real clipboard on the private Xvfb/sway backends and on \
-                       a contained Windows app (a private boxed clipboard). Also the cheap \
-                       text-extraction path: glass_do ctrl+a then ctrl+c, then read here (beats \
-                       OCR for selectable text). On a contained macOS app (sandbox: Default/Strict), \
-                       an app not built with Apple's hardened runtime (e.g. a debug or unsigned \
-                       build) is transparently redirected to a private pasteboard glass shares — \
-                       isolated from your real clipboard and fully working; an app that runs under \
-                       hardened runtime (App Store / notarized) can't be redirected, so this returns \
-                       Unsupported. Uncontained (sandbox: off) reads your REAL system clipboard."
+        description = "Read the app's clipboard as text (\"\" if empty). Also the cheap \
+                       text-extraction path: glass_do ctrl+a then ctrl+c, then read here \
+                       (beats OCR for selectable text). Returns Unsupported where the backend \
+                       can't provide clipboard access."
     )]
     async fn glass_clipboard_get(&self) -> Result<CallToolResult, McpError> {
         self.run(tools::clipboard_get).await
     }
 
     #[tool(
-        description = "Write text to the clipboard so the app can paste it. Isolated from your \
-                       real clipboard on the private Xvfb/sway backends and on a contained Windows \
-                       app (a private boxed clipboard); only shared-desktop modes (GLASS_DISPLAY=:0, \
-                       or the Windows backend with sandbox=off) write your real clipboard — \
-                       snapshot with glass_clipboard_get first if needed. On a contained macOS app \
-                       (sandbox: Default/Strict), an app not built with Apple's hardened runtime \
-                       (e.g. a debug or unsigned build) is transparently redirected to a private \
-                       pasteboard glass shares — isolated from your real clipboard and fully \
-                       working; an app that runs under hardened runtime (App Store / notarized) \
-                       can't be redirected, so this returns Unsupported. Uncontained (sandbox: off) \
-                       writes your REAL system clipboard — \
-                       snapshot with glass_clipboard_get first if you need to preserve it."
+        description = "Write text to the app's clipboard so it can paste it. Returns \
+                       Unsupported where the backend can't provide clipboard access."
     )]
     async fn glass_clipboard_set(
         &self,
@@ -291,10 +276,10 @@ impl GlassServer {
     }
 
     #[tool(
-        description = "Diagnose the glass environment (Xvfb, sway, software GL) and report \
-                       per-check status + how to fix anything missing. Use this to self-diagnose \
-                       a glass_start failure. Optional `deep`: also spawn+tear-down the default \
-                       backend's headless display to verify it actually starts."
+        description = "Diagnose the glass environment and report per-check status + how to \
+                       fix anything missing. Use this to self-diagnose a glass_start failure. \
+                       Optional `deep`: also spin up and tear down the default backend's \
+                       headless display to verify it starts."
     )]
     async fn glass_doctor(
         &self,
@@ -491,44 +476,49 @@ impl GlassServer {
     }
 }
 
+/// Server-level instructions shown once to the agent, describing glass's tool loop.
+/// Must not name a backend (see `descriptions_name_no_backend`): capability support is a
+/// runtime property, not documentation.
+const SERVER_INSTRUCTIONS: &str =
+    "glass gives you a build → see → interact → debug loop over a real native GUI \
+     app — no app integration needed. One active session; tools target it implicitly; \
+     choose a backend at glass_start (defaults to the host; see the `backend` param).\n\n\
+     Loop: glass_start launches the app and captures its logs; glass_screenshot to see \
+     it; glass_click / glass_type / glass_key / glass_scroll / glass_drag (and \
+     glass_gesture for multi-touch where supported) to interact \
+     (coordinates are WINDOW-RELATIVE — 0,0 is the app window's top-left); \
+     glass_wait_stable to let a render settle before you look or compare; glass_logs \
+     for the app's stdout/stderr.\n\n\
+     Verify cheaply on the CPU: glass_baseline_save a good frame, act, then \
+     glass_wait_stable with include_image=false and glass_diff, which returns \
+     changed_pct and a bbox as TEXT (no image). Only call glass_diff with \
+     include_image=true (a cropped image of the changed region) when changed_pct shows \
+     something moved — don't screenshot to check every step.\n\n\
+     Wait for a specific condition instead of polling with screenshots: \
+     glass_wait_for_element (until a UI element reaches a state, e.g. Save becomes \
+     enabled — returns the element id for glass_click_element), glass_wait_for_region \
+     (until a region changes, or matches a saved baseline), glass_wait_for_log (until \
+     a log line appears). All return text only and time out softly with \
+     {matched:false} — branch on that rather than retrying blindly.\n\n\
+     Batch a known input sequence into one call with glass_do (actions: click/type/key/\
+     move/drag/scroll/settle), with an optional text-first `then` observe \
+     (settle/diff/screenshot) — fewer round-trips, and it fails fast naming the action \
+     that broke.\n\n\
+     Semantic addressing (when the app exposes an accessibility tree): \
+     glass_a11y_snapshot returns the elements as text (#id, role, name, \
+     window-relative bounds); glass_click_element clicks one by #id \
+     and glass_set_value writes an editable element's value by #id. Prefer \
+     this over pixel-hunting when it works; it errors for canvas/black-box \
+     apps, so fall back to screenshots then.\n\n\
+     Multiple windows: glass_list_windows and glass_select_window. Errors are real — a \
+     failed capture or input returns a message, never a blank or stale frame; fix the \
+     cause instead of retrying blindly.";
+
 #[tool_handler(router = self.tool_router)]
 impl ServerHandler for GlassServer {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build()).with_instructions(
-            "glass gives you a build → see → interact → debug loop over a real native GUI \
-                 app — no app integration needed. One active session; tools target it implicitly; \
-                 choose a backend (x11 or wayland) at glass_start.\n\n\
-                 Loop: glass_start launches the app and captures its logs; glass_screenshot to see \
-                 it; glass_click / glass_type / glass_key / glass_scroll / glass_drag (and \
-                 glass_gesture for android multi-touch) to interact \
-                 (coordinates are WINDOW-RELATIVE — 0,0 is the app window's top-left); \
-                 glass_wait_stable to let a render settle before you look or compare; glass_logs \
-                 for the app's stdout/stderr.\n\n\
-                 Verify cheaply on the CPU: glass_baseline_save a good frame, act, then \
-                 glass_wait_stable with include_image=false and glass_diff, which returns \
-                 changed_pct and a bbox as TEXT (no image). Only call glass_diff with \
-                 include_image=true (a cropped image of the changed region) when changed_pct shows \
-                 something moved — don't screenshot to check every step.\n\n\
-                 Wait for a specific condition instead of polling with screenshots: \
-                 glass_wait_for_element (until a UI element reaches a state, e.g. Save becomes \
-                 enabled — returns the element id for glass_click_element), glass_wait_for_region \
-                 (until a region changes, or matches a saved baseline), glass_wait_for_log (until \
-                 a log line appears). All return text only and time out softly with \
-                 {matched:false} — branch on that rather than retrying blindly.\n\n\
-                 Batch a known input sequence into one call with glass_do (actions: click/type/key/\
-                 move/drag/scroll/settle), with an optional text-first `then` observe \
-                 (settle/diff/screenshot) — fewer round-trips, and it fails fast naming the action \
-                 that broke.\n\n\
-                 Semantic addressing (when the app exposes an accessibility tree): \
-                 glass_a11y_snapshot returns the elements as text (#id, role, name, \
-                 window-relative bounds); glass_click_element clicks one by #id \
-                 and glass_set_value writes an editable element's value by #id. Prefer \
-                 this over pixel-hunting when it works; it errors for canvas/black-box \
-                 apps, so fall back to screenshots then.\n\n\
-                 Multiple windows: glass_list_windows and glass_select_window. Errors are real — a \
-                 failed capture or input returns a message, never a blank or stale frame; fix the \
-                 cause instead of retrying blindly.",
-        )
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_instructions(SERVER_INSTRUCTIONS)
     }
 }
 
@@ -565,6 +555,50 @@ mod tests {
             "an Ok must surface as a success result"
         );
         assert!(first_text(&r).contains("done"), "got {:?}", first_text(&r));
+    }
+
+    /// A session runs one backend, so naming a backend in a description is a mode-conditional
+    /// the agent can't resolve — and even a single named gate rots the day another backend
+    /// gains the capability. Which backends support a capability is a runtime property, not
+    /// documentation. Vocabulary = BACKENDS minus "windows" (collides with the plain noun,
+    /// e.g. glass_list_windows) plus the two Linux display servers that ARE those backends.
+    #[test]
+    fn descriptions_name_no_backend() {
+        let mut banned: Vec<String> = crate::BACKENDS
+            .iter()
+            .filter(|b| **b != "windows")
+            .map(|b| b.to_string())
+            .collect();
+        banned.push("xvfb".to_string());
+        banned.push("sway".to_string());
+
+        // Case-insensitive, word-boundary match so "ios" can't hit inside another word.
+        fn names(text: &str, tok: &str) -> bool {
+            text.to_ascii_lowercase()
+                .split(|c: char| !c.is_ascii_alphanumeric())
+                .any(|w| w == tok)
+        }
+
+        let mut problems: Vec<String> = Vec::new();
+        for tool in GlassServer::tool_router().list_all() {
+            let desc = tool.description.as_deref().unwrap_or("");
+            for tok in &banned {
+                if names(desc, tok) {
+                    problems.push(format!("  {}: names backend '{tok}'", tool.name));
+                }
+            }
+        }
+        for tok in &banned {
+            if names(SERVER_INSTRUCTIONS, tok) {
+                problems.push(format!("  get_info: names backend '{tok}'"));
+            }
+        }
+        assert!(
+            problems.is_empty(),
+            "tool descriptions/instructions must not name a backend \
+             (capability support is dynamic, not documentation):\n{}",
+            problems.join("\n")
+        );
     }
 
     /// The tool reference is the only user-facing list of glass's tools. Bind it to the

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -747,6 +747,34 @@ mod tests {
         );
     }
 
+    /// The `backend` param doc is the single place the backend list is spelled out for agents.
+    /// Lock it to BACKENDS so a backend added in code can't ship undocumented — the bug that
+    /// left `ios` out of glass_start's description text.
+    #[test]
+    fn backend_param_documents_every_backend() {
+        let start = GlassServer::tool_router()
+            .list_all()
+            .into_iter()
+            .find(|t| t.name == "glass_start")
+            .expect("glass_start is registered");
+        let doc = start
+            .input_schema
+            .get("properties")
+            .and_then(|v| v.get("backend"))
+            .and_then(|v| v.get("description"))
+            .and_then(|v| v.as_str())
+            .expect("backend param has a description")
+            .to_ascii_lowercase();
+        let missing: Vec<&&str> = crate::BACKENDS
+            .iter()
+            .filter(|b| !doc.contains(**b))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "the `backend` param doc must name every backend in BACKENDS; missing: {missing:?}"
+        );
+    }
+
     #[test]
     fn tool_reference_documents_exactly_the_registry() {
         let documented = documented_tools();

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -240,14 +240,15 @@ Move the pointer to window-relative coordinates.
 
 Perform a multi-touch gesture: 2–10 pointers, each a straight `from→to` segment, all down together
 at `t=0` and up at `duration_ms`. Pinch = two pointers toward/apart; rotate = two on an arc;
-two-finger swipe = two parallel segments; a `from==to` pointer is held in place.
+two-finger swipe = two parallel segments; a `from==to` pointer is held in place. Multi-touch isn't
+available on every backend — it returns a clear `Unsupported` error where the active backend can't
+do it.
 
 - `pointers` (array of `{ from{x,y}, to{x,y} }`, **required**) — 2–10 window-relative segments.
 - `duration_ms` (integer, default 250) — gesture span.
 
-**Android only** (requires the on-device agent — `adb`'s `input` has no multi-touch command). The
-`adb` fallback, the iOS Simulator backend, and the desktop backends refuse rather than degrade to a
-single pointer.
+**Platform notes:** multi-touch is currently implemented on the Android backend (via the optional
+on-device companion agent); other backends return `Unsupported`.
 
 ### `glass_do`
 
@@ -359,26 +360,39 @@ the `id` is usable with `glass_click_element`.
 
 ## Clipboard
 
-Both act on the **app's** clipboard, isolated from your real clipboard on the private Xvfb/sway
-backends, on a contained Windows app (a private boxed clipboard), and on a contained macOS app that
-isn't built with Apple's hardened runtime (a shim redirects it to a private pasteboard glass shares).
-A hardened-runtime macOS app (App Store / notarized) can't be redirected, so these return
-`Unsupported`; on Android they need the on-device agent; on iOS they act on the Simulator's own
-pasteboard, which is separate from the host's. Only shared-desktop modes (`GLASS_DISPLAY=:0`,
-or the Windows/macOS backend with `sandbox:off`) touch your **real** clipboard. See
-[explanation/containment.md](../explanation/containment.md#clipboard-isolation).
+Both act on the app's clipboard. How isolated that is from your real desktop clipboard — or whether
+it *is* your real clipboard — depends on the backend and sandbox; see the Platform notes on each tool
+below, and [explanation/containment.md](../explanation/containment.md#clipboard-isolation) for the
+mechanism.
 
 ### `glass_clipboard_get`
 
-Read the clipboard as text (`""` if empty). No parameters. Also the cheap text-extraction path:
+Read the app's clipboard as text (`""` if empty). No parameters. Also the cheap text-extraction path:
 `glass_do` `ctrl+a` then `ctrl+c`, then read here — faster and token-free versus OCR for any app
-with selectable text.
+with selectable text. Returns `Unsupported` where the backend can't provide clipboard access.
+
+**Platform notes:** clipboard containment depends on the backend and sandbox. On the private headless
+Linux displays and a contained Windows app, the clipboard is a private box isolated from your real
+system clipboard. In shared-desktop mode (`GLASS_DISPLAY=:0`) or an uncontained backend
+(`sandbox: off`), get/set act on your **real** system clipboard — snapshot with `glass_clipboard_get`
+first to preserve it. On a contained macOS app **not** built with the hardened runtime, glass
+redirects to a private pasteboard it shares (isolated, fully working); a hardened-runtime app (App
+Store / notarized) can't be redirected and returns Unsupported.
 
 ### `glass_clipboard_set`
 
-Write text to the clipboard so the app can paste it.
+Write text to the app's clipboard so it can paste it. Returns `Unsupported` where the backend can't
+provide clipboard access.
 
 - `text` (string, **required**) — the text to write.
+
+**Platform notes:** clipboard containment depends on the backend and sandbox. On the private headless
+Linux displays and a contained Windows app, the clipboard is a private box isolated from your real
+system clipboard. In shared-desktop mode (`GLASS_DISPLAY=:0`) or an uncontained backend
+(`sandbox: off`), get/set act on your **real** system clipboard — snapshot with `glass_clipboard_get`
+first to preserve it. On a contained macOS app **not** built with the hardened runtime, glass
+redirects to a private pasteboard it shares (isolated, fully working); a hardened-runtime app (App
+Store / notarized) can't be redirected and returns Unsupported.
 
 > **iOS paste-consent:** when the app then reads a pasteboard glass wrote (`glass_clipboard_set` → an
 > in-app `UIPasteboard` read), iOS raises a SpringBoard consent alert and the *first* read returns
@@ -398,11 +412,13 @@ Read captured stdout/stderr log lines with a resumable cursor.
 
 ### `glass_doctor`
 
-Diagnose the glass environment (display dependency, containment runtime, software GL, external tool
-paths) and report per-check status with a remedy for anything missing. Use it to self-diagnose a
-`glass_start` failure.
+Diagnose the glass environment and report per-check status with a remedy for anything missing. Use
+it to self-diagnose a `glass_start` failure.
 
 - `deep` (boolean, default false) — also spawn and tear down the default backend's headless display
   to verify it actually starts (slower).
+
+**Platform notes:** on Linux the checks cover the headless display servers (Xvfb for x11, sway for
+wayland) and software GL; the report names exactly the checks it ran for the selected backend.
 
 Mirrors the `glass-mcp doctor` CLI — see [reference/cli.md](cli.md).


### PR DESCRIPTION
## What & why

A glass session runs exactly one backend, but several MCP tool descriptions carried an all-platform tour — a mode-conditional that the session-blind description string can't resolve — and nothing checked description text, so the strings had drifted. Most visibly, `glass_start`'s description enumerated backends but omitted `ios`, which its own `backend` param already accepts (the list was written twice and one copy fell behind).

This makes every agent-visible description backend-neutral, single-sources the backend list, relocates the per-OS detail to the tools reference, and adds guard tests so the strings can't rot again.

## Changes

- **Canonical `BACKENDS` list** (`crates/glass-mcp/src/lib.rs`) as the single source of truth for backend names; `default_backend` resolves through it. This is the root-cause fix for the `ios` drift.
- **Backend-neutral descriptions:** rewrote `glass_start`, `glass_gesture`, `glass_clipboard_get`/`glass_clipboard_set`, and `glass_doctor` to name no backend, and extracted the `get_info` instructions to a `SERVER_INSTRUCTIONS` const and neutralized it. Capability boundaries are stated backend-free ("returns a clear Unsupported error where the active backend can't do it").
- **Param-doc cleanup:** dropped platform-specific examples from the `window_hint` and `drag` param docs.
- **Docs:** the per-OS clipboard/gesture/doctor specifics moved to `docs/reference/tools.md` "Platform notes" — the right home for a per-OS matrix, versus a session-blind tool description.
- **Guard tests:**
  - `descriptions_name_no_backend` — no tool description or the `get_info` blob may name a backend. Vocabulary is derived from `BACKENDS` (so it auto-extends to new backends), word-boundary matched, and also catches Windows-backend phrases.
  - `backend_param_documents_every_backend` — locks the `backend` param doc to name every `BACKENDS` entry, so a backend added in code can't ship undocumented.

## Testing

`cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, and `cargo test --workspace --locked` all pass locally.

## Follow-ups (not in this PR)

- Dynamic capability querying (a `glass_capabilities` tool parameterized by backend) so an agent can ask what a backend supports at runtime, instead of reading it from static description text.
- An unrecognized `GLASS_BACKEND` value silently falls back to x11 — pre-existing behavior, tracked as a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
