### PR TITLE
Add glass_capabilities tool: live per-operation capability query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,15 @@ internal refactors, CI, or test-only changes.
 ## [Unreleased]
 
 ### Added
-- `glass_capabilities` — a new tool reporting which operations (multi-touch, clipboard,
+- `glass_capabilities` — a new tool reporting which operations (input, multi-touch, clipboard,
   accessibility, window move/resize) can be performed right now on a backend, and any setup a
   blocked one needs, so an agent can check before acting instead of hitting an Unsupported error.
-  Takes an optional `backend` (defaults to the active one); a backend not built into the running
-  binary reports `available: false`.
+  Each operation reports a live status — `supported`, `degraded` (works now at reduced fidelity,
+  e.g. Android's adb-only input without its on-device agent), `requires_setup`, or `unsupported`
+  — plus the specific tools that operation gates (e.g. `accessibility` names
+  `glass_a11y_snapshot`, `glass_click_element`, and friends), so a degraded or blocked entry
+  points straight at the tool calls it affects. Takes an optional `backend` (defaults to the
+  active one); a backend not built into the running binary reports `available: false`.
 - `glass_scroll_to_element` now drives **horizontal** containers, not just vertical: `direction`
   accepts `left`/`right` as well as `up`/`down`, and when omitted it **infers** the direction from
   the target's off-screen position. It anchors the scroll on the target's own row/column, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ internal refactors, CI, or test-only changes.
 ## [Unreleased]
 
 ### Added
+- `glass_capabilities` — a new tool reporting which operations (multi-touch, clipboard,
+  accessibility, window move/resize) can be performed right now on a backend, and any setup a
+  blocked one needs, so an agent can check before acting instead of hitting an Unsupported error.
+  Takes an optional `backend` (defaults to the active one); a backend not built into the running
+  binary reports `available: false`.
 - `glass_scroll_to_element` now drives **horizontal** containers, not just vertical: `direction`
   accepts `left`/`right` as well as `up`/`down`, and when omitted it **infers** the direction from
   the target's off-screen position. It anchors the scroll on the target's own row/column, so a

--- a/crates/glass-android/src/lib.rs
+++ b/crates/glass-android/src/lib.rs
@@ -28,3 +28,64 @@ pub use agent::{AgentClient, AgentRegistry};
 pub use avd::EmulatorRegistry;
 pub use platform::AndroidPlatform;
 pub use target::{AdbTarget, AttachedDevice};
+
+use glass_core::capability::{CapabilityMap, CapabilityStatus};
+
+/// This backend's live capability map. `multi_touch`/`clipboard` need the on-device
+/// agent — gated on [`agent::agent_enabled`], the same predicate the runtime uses to
+/// pick `AgentInjector` vs `ShellInjector`, so this can't disagree with real behavior.
+pub fn capabilities() -> CapabilityMap {
+    capabilities_with(crate::agent::agent_enabled(&|k| std::env::var(k).ok()))
+}
+
+fn capabilities_with(agent_enabled: bool) -> CapabilityMap {
+    let gated = if agent_enabled {
+        CapabilityStatus::supported()
+    } else {
+        CapabilityStatus::requires_setup(
+            "on-device agent not detected; set GLASS_ANDROID_AGENT_JAR",
+        )
+    };
+    CapabilityMap {
+        multi_touch: gated,
+        clipboard: gated,
+        accessibility: CapabilityStatus::supported(),
+        window_move_resize: CapabilityStatus::unsupported(Some("apps are full-screen")),
+    }
+}
+
+#[cfg(test)]
+mod capability_tests {
+    use super::*;
+    use glass_core::capability::Support;
+
+    #[test]
+    fn agent_present_makes_multi_touch_and_clipboard_supported() {
+        let c = capabilities_with(true);
+        assert_eq!(c.multi_touch.status, Support::Supported);
+        assert_eq!(c.clipboard.status, Support::Supported);
+        assert!(c.multi_touch.note.is_none());
+    }
+
+    #[test]
+    fn agent_absent_makes_them_requires_setup_with_env_hint() {
+        let c = capabilities_with(false);
+        assert_eq!(c.multi_touch.status, Support::RequiresSetup);
+        assert_eq!(c.clipboard.status, Support::RequiresSetup);
+        assert!(c
+            .multi_touch
+            .note
+            .unwrap()
+            .contains("GLASS_ANDROID_AGENT_JAR"));
+    }
+
+    #[test]
+    fn constant_cells_do_not_depend_on_the_agent() {
+        for signal in [true, false] {
+            let c = capabilities_with(signal);
+            assert_eq!(c.accessibility.status, Support::Supported);
+            assert_eq!(c.window_move_resize.status, Support::Unsupported);
+            assert_eq!(c.window_move_resize.note, Some("apps are full-screen"));
+        }
+    }
+}

--- a/crates/glass-android/src/lib.rs
+++ b/crates/glass-android/src/lib.rs
@@ -31,25 +31,44 @@ pub use target::{AdbTarget, AttachedDevice};
 
 use glass_core::capability::{CapabilityMap, CapabilityStatus};
 
-/// This backend's live capability map. `multi_touch`/`clipboard` need the on-device
-/// agent — gated on [`agent::agent_enabled`], the same predicate the runtime uses to
-/// pick `AgentInjector` vs `ShellInjector`, so this can't disagree with real behavior.
+/// This backend's live capability map. `input` degrades and `multi_touch`/`clipboard`
+/// need the on-device agent — gated on [`agent::agent_enabled`], the same predicate the
+/// runtime uses to pick `AgentInjector` vs `ShellInjector`, so this can't disagree with
+/// real behavior. `accessibility` degrades without the a11y APK — gated on
+/// [`a11y_service::a11y_apk`], the same predicate the runtime uses to pick the Compose-rich
+/// reader vs the basic `uiautomator` one.
 pub fn capabilities() -> CapabilityMap {
-    capabilities_with(crate::agent::agent_enabled(&|k| std::env::var(k).ok()))
+    let get = |k: &str| std::env::var(k).ok();
+    capabilities_with(
+        crate::agent::agent_enabled(&get),
+        crate::a11y_service::a11y_apk(&get).is_some(),
+    )
 }
 
-fn capabilities_with(agent_enabled: bool) -> CapabilityMap {
-    let gated = if agent_enabled {
+fn capabilities_with(agent: bool, a11y_apk: bool) -> CapabilityMap {
+    let agent_gated = if agent {
         CapabilityStatus::supported()
     } else {
-        CapabilityStatus::requires_setup(
-            "on-device agent not detected; set GLASS_ANDROID_AGENT_JAR",
-        )
+        CapabilityStatus::requires_setup("needs the on-device agent; set GLASS_ANDROID_AGENT_JAR")
     };
     CapabilityMap {
-        multi_touch: gated,
-        clipboard: gated,
-        accessibility: CapabilityStatus::supported(),
+        input: if agent {
+            CapabilityStatus::supported()
+        } else {
+            CapabilityStatus::degraded(
+                "adb input only; set GLASS_ANDROID_AGENT_JAR for high-fidelity input",
+            )
+        },
+        multi_touch: agent_gated,
+        clipboard: agent_gated,
+        accessibility: if a11y_apk {
+            CapabilityStatus::supported()
+        } else {
+            CapabilityStatus::degraded(
+                "basic uiautomator tree only; set GLASS_ANDROID_A11Y_APK for the Compose tree + \
+                 high-fidelity set_value",
+            )
+        },
         window_move_resize: CapabilityStatus::unsupported(Some("apps are full-screen")),
     }
 }
@@ -60,32 +79,40 @@ mod capability_tests {
     use glass_core::capability::Support;
 
     #[test]
-    fn agent_present_makes_multi_touch_and_clipboard_supported() {
-        let c = capabilities_with(true);
-        assert_eq!(c.multi_touch.status, Support::Supported);
-        assert_eq!(c.clipboard.status, Support::Supported);
-        assert!(c.multi_touch.note.is_none());
+    fn input_degrades_without_the_agent() {
+        assert_eq!(
+            capabilities_with(true, true).input.status,
+            Support::Supported
+        );
+        let c = capabilities_with(false, true);
+        assert_eq!(c.input.status, Support::Degraded);
+        assert!(c.input.note.unwrap().contains("GLASS_ANDROID_AGENT_JAR"));
     }
 
     #[test]
-    fn agent_absent_makes_them_requires_setup_with_env_hint() {
-        let c = capabilities_with(false);
+    fn multi_touch_and_clipboard_require_the_agent() {
+        let c = capabilities_with(false, true);
         assert_eq!(c.multi_touch.status, Support::RequiresSetup);
         assert_eq!(c.clipboard.status, Support::RequiresSetup);
-        assert!(c
-            .multi_touch
-            .note
-            .unwrap()
-            .contains("GLASS_ANDROID_AGENT_JAR"));
+        assert_eq!(
+            capabilities_with(true, true).multi_touch.status,
+            Support::Supported
+        );
     }
 
     #[test]
-    fn constant_cells_do_not_depend_on_the_agent() {
-        for signal in [true, false] {
-            let c = capabilities_with(signal);
-            assert_eq!(c.accessibility.status, Support::Supported);
-            assert_eq!(c.window_move_resize.status, Support::Unsupported);
-            assert_eq!(c.window_move_resize.note, Some("apps are full-screen"));
-        }
+    fn accessibility_degrades_without_the_a11y_apk() {
+        assert_eq!(
+            capabilities_with(true, true).accessibility.status,
+            Support::Supported
+        );
+        let c = capabilities_with(true, false);
+        assert_eq!(c.accessibility.status, Support::Degraded);
+        assert!(c
+            .accessibility
+            .note
+            .unwrap()
+            .contains("GLASS_ANDROID_A11Y_APK"));
+        assert_eq!(c.window_move_resize.status, Support::Unsupported);
     }
 }

--- a/crates/glass-core/src/capability.rs
+++ b/crates/glass-core/src/capability.rs
@@ -1,0 +1,111 @@
+//! Backend capability descriptors: which operations an agent can perform right now.
+//!
+//! A [`CapabilityMap`] is produced per backend (each backend crate's `capabilities()`)
+//! and surfaced by the `glass_capabilities` MCP tool. The map's named fields make
+//! capability completeness a compile-time guarantee: add a [`Capability`] variant and
+//! every `CapabilityMap` literal fails to compile until it fills the new field.
+
+use serde::{Deserialize, Serialize};
+
+/// The operations whose availability varies by backend or environment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Capability {
+    MultiTouch,
+    Clipboard,
+    Accessibility,
+    WindowMoveResize,
+}
+
+impl Capability {
+    /// Every capability, for consumers/tests that iterate the set. The named fields of
+    /// [`CapabilityMap`] remain the completeness authority.
+    pub const ALL: &'static [Capability] = &[
+        Capability::MultiTouch,
+        Capability::Clipboard,
+        Capability::Accessibility,
+        Capability::WindowMoveResize,
+    ];
+}
+
+/// Whether an operation can be performed right now.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Support {
+    /// Works right now.
+    Supported,
+    /// Supported by this backend in principle, but a setup step is missing right now.
+    RequiresSetup,
+    /// This backend can never do it (a code-constant fact).
+    Unsupported,
+}
+
+/// One capability's status plus an optional human note (what's missing / why).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct CapabilityStatus {
+    pub status: Support,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<&'static str>,
+}
+
+impl CapabilityStatus {
+    pub const fn new(status: Support, note: Option<&'static str>) -> Self {
+        Self { status, note }
+    }
+    pub const fn supported() -> Self {
+        Self::new(Support::Supported, None)
+    }
+    pub const fn unsupported(note: Option<&'static str>) -> Self {
+        Self::new(Support::Unsupported, note)
+    }
+    pub const fn requires_setup(note: &'static str) -> Self {
+        Self::new(Support::RequiresSetup, Some(note))
+    }
+}
+
+/// One status per capability. Serializes to a JSON object keyed by field name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct CapabilityMap {
+    pub multi_touch: CapabilityStatus,
+    pub clipboard: CapabilityStatus,
+    pub accessibility: CapabilityStatus,
+    pub window_move_resize: CapabilityStatus,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn map_serializes_to_keyed_object_snake_case_notes_omitted_when_none() {
+        let m = CapabilityMap {
+            multi_touch: CapabilityStatus::requires_setup("need agent"),
+            clipboard: CapabilityStatus::supported(),
+            accessibility: CapabilityStatus::supported(),
+            window_move_resize: CapabilityStatus::unsupported(Some("full-screen")),
+        };
+        let v = serde_json::to_value(m).unwrap();
+        assert_eq!(v["multi_touch"]["status"], "requires_setup");
+        assert_eq!(v["multi_touch"]["note"], "need agent");
+        assert_eq!(v["clipboard"]["status"], "supported");
+        assert!(
+            v["clipboard"].get("note").is_none(),
+            "note omitted when None"
+        );
+        assert_eq!(v["window_move_resize"]["status"], "unsupported");
+        assert_eq!(v["window_move_resize"]["note"], "full-screen");
+    }
+
+    #[test]
+    fn capability_all_lists_every_variant_snake_case() {
+        assert_eq!(Capability::ALL.len(), 4);
+        assert_eq!(
+            serde_json::to_value(Capability::MultiTouch).unwrap(),
+            "multi_touch"
+        );
+        assert_eq!(
+            serde_json::to_value(Capability::WindowMoveResize).unwrap(),
+            "window_move_resize"
+        );
+    }
+}

--- a/crates/glass-core/src/capability.rs
+++ b/crates/glass-core/src/capability.rs
@@ -14,6 +14,8 @@ use serde::{Deserialize, Serialize};
 pub enum Support {
     /// Works right now.
     Supported,
+    /// Works now but at reduced fidelity/coverage (note says what's lost + how to restore).
+    Degraded,
     /// Supported by this backend in principle, but a setup step is missing right now.
     RequiresSetup,
     /// This backend can never do it (a code-constant fact).
@@ -35,6 +37,9 @@ impl CapabilityStatus {
     pub const fn supported() -> Self {
         Self::new(Support::Supported, None)
     }
+    pub const fn degraded(note: &'static str) -> Self {
+        Self::new(Support::Degraded, Some(note))
+    }
     pub const fn unsupported(note: Option<&'static str>) -> Self {
         Self::new(Support::Unsupported, note)
     }
@@ -46,6 +51,8 @@ impl CapabilityStatus {
 /// One status per capability. Serializes to a JSON object keyed by field name.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub struct CapabilityMap {
+    /// Pointer + keyboard injection (glass_type/click/key/drag/scroll/move/do).
+    pub input: CapabilityStatus,
     pub multi_touch: CapabilityStatus,
     pub clipboard: CapabilityStatus,
     pub accessibility: CapabilityStatus,
@@ -59,20 +66,18 @@ mod tests {
     #[test]
     fn map_serializes_to_keyed_object_snake_case_notes_omitted_when_none() {
         let m = CapabilityMap {
+            input: CapabilityStatus::degraded("adb only"),
             multi_touch: CapabilityStatus::requires_setup("need agent"),
             clipboard: CapabilityStatus::supported(),
             accessibility: CapabilityStatus::supported(),
             window_move_resize: CapabilityStatus::unsupported(Some("full-screen")),
         };
         let v = serde_json::to_value(m).unwrap();
+        assert_eq!(v["input"]["status"], "degraded");
+        assert_eq!(v["input"]["note"], "adb only");
         assert_eq!(v["multi_touch"]["status"], "requires_setup");
-        assert_eq!(v["multi_touch"]["note"], "need agent");
         assert_eq!(v["clipboard"]["status"], "supported");
-        assert!(
-            v["clipboard"].get("note").is_none(),
-            "note omitted when None"
-        );
+        assert!(v["clipboard"].get("note").is_none());
         assert_eq!(v["window_move_resize"]["status"], "unsupported");
-        assert_eq!(v["window_move_resize"]["note"], "full-screen");
     }
 }

--- a/crates/glass-core/src/capability.rs
+++ b/crates/glass-core/src/capability.rs
@@ -1,32 +1,12 @@
 //! Backend capability descriptors: which operations an agent can perform right now.
 //!
 //! A [`CapabilityMap`] is produced per backend (each backend crate's `capabilities()`)
-//! and surfaced by the `glass_capabilities` MCP tool. The map's named fields make
-//! capability completeness a compile-time guarantee: add a [`Capability`] variant and
-//! every `CapabilityMap` literal fails to compile until it fills the new field.
+//! and surfaced by the `glass_capabilities` MCP tool. `CapabilityMap`'s named fields are
+//! the completeness authority: a capability is added by adding a field, and every
+//! backend's `capabilities()` literal then fails to compile until it supplies that field,
+//! so no backend can silently omit a capability.
 
 use serde::{Deserialize, Serialize};
-
-/// The operations whose availability varies by backend or environment.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum Capability {
-    MultiTouch,
-    Clipboard,
-    Accessibility,
-    WindowMoveResize,
-}
-
-impl Capability {
-    /// Every capability, for consumers/tests that iterate the set. The named fields of
-    /// [`CapabilityMap`] remain the completeness authority.
-    pub const ALL: &'static [Capability] = &[
-        Capability::MultiTouch,
-        Capability::Clipboard,
-        Capability::Accessibility,
-        Capability::WindowMoveResize,
-    ];
-}
 
 /// Whether an operation can be performed right now.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -94,18 +74,5 @@ mod tests {
         );
         assert_eq!(v["window_move_resize"]["status"], "unsupported");
         assert_eq!(v["window_move_resize"]["note"], "full-screen");
-    }
-
-    #[test]
-    fn capability_all_lists_every_variant_snake_case() {
-        assert_eq!(Capability::ALL.len(), 4);
-        assert_eq!(
-            serde_json::to_value(Capability::MultiTouch).unwrap(),
-            "multi_touch"
-        );
-        assert_eq!(
-            serde_json::to_value(Capability::WindowMoveResize).unwrap(),
-            "window_move_resize"
-        );
     }
 }

--- a/crates/glass-core/src/capability.rs
+++ b/crates/glass-core/src/capability.rs
@@ -6,10 +6,10 @@
 //! backend's `capabilities()` literal then fails to compile until it supplies that field,
 //! so no backend can silently omit a capability.
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 /// Whether an operation can be performed right now.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Support {
     /// Works right now.
@@ -57,6 +57,28 @@ pub struct CapabilityMap {
     pub clipboard: CapabilityStatus,
     pub accessibility: CapabilityStatus,
     pub window_move_resize: CapabilityStatus,
+}
+
+impl CapabilityMap {
+    /// Every (operation-name, status) pair, in report order. The exhaustive destructure (no
+    /// `..`) extends the named-field completeness guarantee into rendering: adding a field to
+    /// `CapabilityMap` fails THIS to compile until it is listed here too.
+    pub fn entries(&self) -> [(&'static str, CapabilityStatus); 5] {
+        let CapabilityMap {
+            input,
+            multi_touch,
+            clipboard,
+            accessibility,
+            window_move_resize,
+        } = *self;
+        [
+            ("input", input),
+            ("multi_touch", multi_touch),
+            ("clipboard", clipboard),
+            ("accessibility", accessibility),
+            ("window_move_resize", window_move_resize),
+        ]
+    }
 }
 
 #[cfg(test)]

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -44,7 +44,7 @@ pub mod doctor;
 pub use doctor::{Check, CheckStatus, Diagnosis, Section};
 
 pub mod capability;
-pub use capability::{Capability, CapabilityMap, CapabilityStatus, Support};
+pub use capability::{CapabilityMap, CapabilityStatus, Support};
 
 pub mod stability;
 pub use stability::StabilityTracker;

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -43,6 +43,9 @@ pub use diff::{diff, diff_perceptual, region_satisfied, BBox, DiffResult, Region
 pub mod doctor;
 pub use doctor::{Check, CheckStatus, Diagnosis, Section};
 
+pub mod capability;
+pub use capability::{Capability, CapabilityMap, CapabilityStatus, Support};
+
 pub mod stability;
 pub use stability::StabilityTracker;
 

--- a/crates/glass-ios/src/lib.rs
+++ b/crates/glass-ios/src/lib.rs
@@ -26,25 +26,30 @@ pub use target::{SimTarget, SimulatorRegistry};
 
 use glass_core::capability::{CapabilityMap, CapabilityStatus, Support};
 
-/// This backend's live capability map. `accessibility` needs `idb_companion` — gated on
-/// [`doctor::companion_present`], the same presence signal the runtime spawn resolves.
+/// This backend's live capability map. `input`/`accessibility` need `idb_companion` —
+/// gated on [`doctor::companion_present`], the same presence signal the runtime spawn
+/// resolves.
 pub fn capabilities() -> CapabilityMap {
     capabilities_with(crate::doctor::companion_present())
 }
 
-fn capabilities_with(companion_present: bool) -> CapabilityMap {
-    let accessibility = if companion_present {
-        CapabilityStatus::supported()
-    } else {
-        CapabilityStatus::requires_setup("idb_companion not found (needed for accessibility)")
-    };
+fn capabilities_with(companion: bool) -> CapabilityMap {
     CapabilityMap {
+        input: if companion {
+            CapabilityStatus::degraded("US-ASCII input only; non-ASCII characters are unsupported")
+        } else {
+            CapabilityStatus::requires_setup("needs idb_companion (observe-only without it)")
+        },
         multi_touch: CapabilityStatus::unsupported(Some("idb provides single-contact touch only")),
         clipboard: CapabilityStatus::new(
             Support::Supported,
             Some("paste needs on-screen consent (Allow Paste)"),
         ),
-        accessibility,
+        accessibility: if companion {
+            CapabilityStatus::supported()
+        } else {
+            CapabilityStatus::requires_setup("idb_companion not found (needed for accessibility)")
+        },
         window_move_resize: CapabilityStatus::unsupported(Some("apps are full-screen")),
     }
 }
@@ -55,28 +60,32 @@ mod capability_tests {
     use glass_core::capability::Support;
 
     #[test]
-    fn companion_present_makes_accessibility_supported() {
+    fn input_is_degraded_with_companion_requires_setup_without() {
+        let c = capabilities_with(true);
+        assert_eq!(c.input.status, Support::Degraded);
+        assert!(c.input.note.unwrap().contains("ASCII"));
         assert_eq!(
-            capabilities_with(true).accessibility.status,
-            Support::Supported
+            capabilities_with(false).input.status,
+            Support::RequiresSetup
         );
     }
 
     #[test]
-    fn companion_absent_makes_accessibility_requires_setup() {
-        let c = capabilities_with(false);
-        assert_eq!(c.accessibility.status, Support::RequiresSetup);
-        assert!(c.accessibility.note.unwrap().contains("idb_companion"));
+    fn accessibility_gates_on_companion() {
+        assert_eq!(
+            capabilities_with(true).accessibility.status,
+            Support::Supported
+        );
+        assert_eq!(
+            capabilities_with(false).accessibility.status,
+            Support::RequiresSetup
+        );
     }
 
     #[test]
     fn constant_cells_are_fixed() {
         let c = capabilities_with(true);
         assert_eq!(c.multi_touch.status, Support::Unsupported);
-        assert_eq!(
-            c.multi_touch.note,
-            Some("idb provides single-contact touch only")
-        );
         assert_eq!(c.clipboard.status, Support::Supported);
         assert_eq!(
             c.clipboard.note,

--- a/crates/glass-ios/src/lib.rs
+++ b/crates/glass-ios/src/lib.rs
@@ -73,6 +73,10 @@ mod capability_tests {
     fn constant_cells_are_fixed() {
         let c = capabilities_with(true);
         assert_eq!(c.multi_touch.status, Support::Unsupported);
+        assert_eq!(
+            c.multi_touch.note,
+            Some("idb provides single-contact touch only")
+        );
         assert_eq!(c.clipboard.status, Support::Supported);
         assert_eq!(
             c.clipboard.note,

--- a/crates/glass-ios/src/lib.rs
+++ b/crates/glass-ios/src/lib.rs
@@ -86,6 +86,10 @@ mod capability_tests {
     fn constant_cells_are_fixed() {
         let c = capabilities_with(true);
         assert_eq!(c.multi_touch.status, Support::Unsupported);
+        assert_eq!(
+            c.multi_touch.note,
+            Some("idb provides single-contact touch only")
+        );
         assert_eq!(c.clipboard.status, Support::Supported);
         assert_eq!(
             c.clipboard.note,

--- a/crates/glass-ios/src/lib.rs
+++ b/crates/glass-ios/src/lib.rs
@@ -23,3 +23,61 @@ pub use a11y::IosA11y;
 pub use platform::IosPlatform;
 pub use simctl::Simctl;
 pub use target::{SimTarget, SimulatorRegistry};
+
+use glass_core::capability::{CapabilityMap, CapabilityStatus, Support};
+
+/// This backend's live capability map. `accessibility` needs `idb_companion` — gated on
+/// [`doctor::companion_present`], the same presence signal the runtime spawn resolves.
+pub fn capabilities() -> CapabilityMap {
+    capabilities_with(crate::doctor::companion_present())
+}
+
+fn capabilities_with(companion_present: bool) -> CapabilityMap {
+    let accessibility = if companion_present {
+        CapabilityStatus::supported()
+    } else {
+        CapabilityStatus::requires_setup("idb_companion not found (needed for accessibility)")
+    };
+    CapabilityMap {
+        multi_touch: CapabilityStatus::unsupported(Some("idb provides single-contact touch only")),
+        clipboard: CapabilityStatus::new(
+            Support::Supported,
+            Some("paste needs on-screen consent (Allow Paste)"),
+        ),
+        accessibility,
+        window_move_resize: CapabilityStatus::unsupported(Some("apps are full-screen")),
+    }
+}
+
+#[cfg(test)]
+mod capability_tests {
+    use super::*;
+    use glass_core::capability::Support;
+
+    #[test]
+    fn companion_present_makes_accessibility_supported() {
+        assert_eq!(
+            capabilities_with(true).accessibility.status,
+            Support::Supported
+        );
+    }
+
+    #[test]
+    fn companion_absent_makes_accessibility_requires_setup() {
+        let c = capabilities_with(false);
+        assert_eq!(c.accessibility.status, Support::RequiresSetup);
+        assert!(c.accessibility.note.unwrap().contains("idb_companion"));
+    }
+
+    #[test]
+    fn constant_cells_are_fixed() {
+        let c = capabilities_with(true);
+        assert_eq!(c.multi_touch.status, Support::Unsupported);
+        assert_eq!(c.clipboard.status, Support::Supported);
+        assert_eq!(
+            c.clipboard.note,
+            Some("paste needs on-screen consent (Allow Paste)")
+        );
+        assert_eq!(c.window_move_resize.status, Support::Unsupported);
+    }
+}

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -59,6 +59,7 @@ pub use ffi::init_main_thread;
 /// grants — macOS TCC, Linux AT-SPI — are surfaced by `glass_doctor`).
 pub fn capabilities() -> CapabilityMap {
     CapabilityMap {
+        input: CapabilityStatus::supported(),
         multi_touch: CapabilityStatus::unsupported(None),
         clipboard: CapabilityStatus::supported(),
         accessibility: CapabilityStatus::supported(),
@@ -95,6 +96,7 @@ mod capability_tests {
     #[test]
     fn desktop_constant_capability_map() {
         let c = capabilities();
+        assert_eq!(c.input.status, Support::Supported);
         assert_eq!(c.multi_touch.status, Support::Unsupported);
         assert_eq!(c.clipboard.status, Support::Supported);
         assert_eq!(c.accessibility.status, Support::Supported);

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -66,20 +66,6 @@ pub fn capabilities() -> CapabilityMap {
     }
 }
 
-#[cfg(test)]
-mod capability_tests {
-    use super::capabilities;
-    use glass_core::capability::Support;
-
-    #[test]
-    fn desktop_constant_capability_map() {
-        let c = capabilities();
-        assert_eq!(c.multi_touch.status, Support::Unsupported);
-        assert_eq!(c.clipboard.status, Support::Supported);
-        assert_eq!(c.accessibility.status, Support::Supported);
-        assert_eq!(c.window_move_resize.status, Support::Supported);
-    }
-}
 // `doctor`-facing predicates (glass-mcp's doctor.rs): the two TCC grants (+ the exact
 // remedy text `preflight`'s `PermissionDenied` error also uses, so the two can't drift)
 // and the console session's three-way state (unlocked/locked/no-session-attached).
@@ -97,3 +83,21 @@ pub use permissions::{
 };
 #[cfg(target_os = "macos")]
 pub use session::{session_locked, session_state, SessionState};
+
+// Kept last: a `#[cfg(test)]` module must not be followed by other items
+// (clippy::items_after_test_module), and the macOS-gated `pub use`s above are absent off
+// macOS — so this test module goes at the end of the file where nothing can follow it.
+#[cfg(test)]
+mod capability_tests {
+    use super::capabilities;
+    use glass_core::capability::Support;
+
+    #[test]
+    fn desktop_constant_capability_map() {
+        let c = capabilities();
+        assert_eq!(c.multi_touch.status, Support::Unsupported);
+        assert_eq!(c.clipboard.status, Support::Supported);
+        assert_eq!(c.accessibility.status, Support::Supported);
+        assert_eq!(c.window_move_resize.status, Support::Supported);
+    }
+}

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -4,7 +4,7 @@
 //! Like `glass-windows`, the pure logic ([`keymap`], [`coords`], [`clipboard_route`],
 //! [`shim_path`]) is crate-level and unit-tested on the Linux dev box; the OS-touching
 //! modules and the `MacosPlatform` impl are gated `#[cfg(target_os = "macos")]`. Off macOS
-//! the crate exposes only the pure modules.
+//! the crate exposes only the pure modules and the code-constant [`capabilities`] map.
 
 // FFI backend: the OS-touching modules need `unsafe`, so this crate opts out of the workspace
 // `unsafe_code = "deny"`; each site carries a `// SAFETY:` note (see CLAUDE.md). The pure

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -11,6 +11,8 @@
 // modules below stay `unsafe`-free by convention.
 #![allow(unsafe_code)]
 
+use glass_core::capability::{CapabilityMap, CapabilityStatus};
+
 pub mod bundle; // pure .app-bundle logic — cross-platform, host-tested
 pub mod clipboard_route; // pure clipboard-routing policy — cross-platform, host-tested
 pub mod coords; // pure window-relative <-> global math — cross-platform, host-tested
@@ -51,6 +53,33 @@ mod session;
 pub use backend::MacosPlatform;
 #[cfg(target_os = "macos")]
 pub use ffi::init_main_thread;
+
+/// This backend's capability map. All cells are code-constant here (desktop
+/// accessibility is reported Supported when the backend ships an a11y reader; per-OS
+/// grants — macOS TCC, Linux AT-SPI — are surfaced by `glass_doctor`).
+pub fn capabilities() -> CapabilityMap {
+    CapabilityMap {
+        multi_touch: CapabilityStatus::unsupported(None),
+        clipboard: CapabilityStatus::supported(),
+        accessibility: CapabilityStatus::supported(),
+        window_move_resize: CapabilityStatus::supported(),
+    }
+}
+
+#[cfg(test)]
+mod capability_tests {
+    use super::capabilities;
+    use glass_core::capability::Support;
+
+    #[test]
+    fn desktop_constant_capability_map() {
+        let c = capabilities();
+        assert_eq!(c.multi_touch.status, Support::Unsupported);
+        assert_eq!(c.clipboard.status, Support::Supported);
+        assert_eq!(c.accessibility.status, Support::Supported);
+        assert_eq!(c.window_move_resize.status, Support::Supported);
+    }
+}
 // `doctor`-facing predicates (glass-mcp's doctor.rs): the two TCC grants (+ the exact
 // remedy text `preflight`'s `PermissionDenied` error also uses, so the two can't drift)
 // and the console session's three-way state (unlocked/locked/no-session-attached).

--- a/crates/glass-mcp/src/capabilities.rs
+++ b/crates/glass-mcp/src/capabilities.rs
@@ -1,0 +1,172 @@
+//! Backend capability reporting for the `glass_capabilities` MCP tool.
+//!
+//! A projection over existing environment signals, not a new prober: each compiled-in
+//! backend crate's `capabilities()` supplies its live map; a valid backend name not
+//! compiled into this binary is reported `NotOnThisHost`. Dispatch is cfg-gated exactly
+//! like `make_platform`/`doctor` (android is always compiled; the rest per host OS).
+
+use glass_core::capability::CapabilityMap;
+
+/// A backend's capability report on this host.
+pub enum CapabilityReport {
+    /// Compiled into this binary — here is its live capability map.
+    Available(CapabilityMap),
+    /// A valid backend name, but not compiled into this binary (cannot be probed here).
+    NotOnThisHost,
+}
+
+/// Dispatch to the compiled-in backend's `capabilities()`. Expects a canonical
+/// [`crate::BACKENDS`] name; unknown names fall through to `NotOnThisHost` (the tool
+/// validates the name and errors before calling — see [`render_json`]).
+pub fn capabilities_for(backend: &str) -> CapabilityReport {
+    // android is always compiled in (it shells out to adb; host-OS-agnostic).
+    if backend == "android" {
+        return CapabilityReport::Available(glass_android::capabilities());
+    }
+    #[cfg(target_os = "linux")]
+    {
+        match backend {
+            "x11" => return CapabilityReport::Available(glass_x11::capabilities()),
+            "wayland" => return CapabilityReport::Available(glass_wayland::capabilities()),
+            _ => {}
+        }
+    }
+    #[cfg(windows)]
+    {
+        if backend == "windows" {
+            return CapabilityReport::Available(glass_windows::capabilities());
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        match backend {
+            "macos" => return CapabilityReport::Available(glass_macos::capabilities()),
+            "ios" => return CapabilityReport::Available(glass_ios::capabilities()),
+            _ => {}
+        }
+    }
+    CapabilityReport::NotOnThisHost
+}
+
+/// Resolve `backend` (None => the default backend) and render the report as JSON text.
+/// `Err` names the valid backends when `backend` is an unrecognized value.
+pub fn render_json(backend: Option<&str>) -> Result<String, String> {
+    let name: &'static str = match backend {
+        Some(v) => crate::BACKENDS
+            .iter()
+            .find(|b| v.eq_ignore_ascii_case(b))
+            .ok_or_else(|| {
+                format!(
+                    "unknown backend {v:?}; use one of: {}",
+                    crate::BACKENDS.join(", ")
+                )
+            })?,
+        None => crate::default_backend(std::env::var("GLASS_BACKEND").ok().as_deref()),
+    };
+    let json = match capabilities_for(name) {
+        CapabilityReport::Available(map) => serde_json::json!({
+            "backend": name,
+            "available": true,
+            "capabilities": map,
+        }),
+        CapabilityReport::NotOnThisHost => serde_json::json!({
+            "backend": name,
+            "available": false,
+            "reason": format!("not in this glass build (host: {})", std::env::consts::OS),
+        }),
+    };
+    Ok(serde_json::to_string(&json).expect("capability report serializes"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn available_only_for_compiled_in_backends() {
+        // android is always compiled in (host-OS-agnostic).
+        assert!(matches!(
+            capabilities_for("android"),
+            CapabilityReport::Available(_)
+        ));
+
+        #[cfg(target_os = "linux")]
+        {
+            assert!(matches!(
+                capabilities_for("x11"),
+                CapabilityReport::Available(_)
+            ));
+            assert!(matches!(
+                capabilities_for("wayland"),
+                CapabilityReport::Available(_)
+            ));
+            for b in ["windows", "macos", "ios"] {
+                assert!(
+                    matches!(capabilities_for(b), CapabilityReport::NotOnThisHost),
+                    "{b}"
+                );
+            }
+        }
+        #[cfg(windows)]
+        {
+            assert!(matches!(
+                capabilities_for("windows"),
+                CapabilityReport::Available(_)
+            ));
+            for b in ["x11", "wayland", "macos", "ios"] {
+                assert!(
+                    matches!(capabilities_for(b), CapabilityReport::NotOnThisHost),
+                    "{b}"
+                );
+            }
+        }
+        #[cfg(target_os = "macos")]
+        {
+            for b in ["macos", "ios"] {
+                assert!(
+                    matches!(capabilities_for(b), CapabilityReport::Available(_)),
+                    "{b}"
+                );
+            }
+            for b in ["x11", "wayland", "windows"] {
+                assert!(
+                    matches!(capabilities_for(b), CapabilityReport::NotOnThisHost),
+                    "{b}"
+                );
+            }
+        }
+
+        // Every canonical name resolves without panicking.
+        for b in crate::BACKENDS {
+            let _ = capabilities_for(b);
+        }
+    }
+
+    #[test]
+    fn render_json_shapes_available_and_canonicalizes() {
+        let v: serde_json::Value =
+            serde_json::from_str(&render_json(Some("ANDROID")).unwrap()).unwrap();
+        assert_eq!(v["backend"], "android"); // canonicalized, case-insensitive input
+        assert_eq!(v["available"], true);
+        assert!(v["capabilities"]["multi_touch"]["status"].is_string());
+        assert!(v.get("reason").is_none());
+    }
+
+    #[test]
+    fn render_json_errors_on_unknown_backend() {
+        let e = render_json(Some("nope")).unwrap_err();
+        assert!(e.contains("nope"));
+        assert!(e.contains("x11")); // lists the valid backends
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn render_json_not_on_this_host_shape() {
+        let v: serde_json::Value =
+            serde_json::from_str(&render_json(Some("ios")).unwrap()).unwrap();
+        assert_eq!(v["backend"], "ios");
+        assert_eq!(v["available"], false);
+        assert!(v["reason"].as_str().unwrap().contains("host: linux"));
+        assert!(v.get("capabilities").is_none());
+    }
+}

--- a/crates/glass-mcp/src/capabilities.rs
+++ b/crates/glass-mcp/src/capabilities.rs
@@ -15,37 +15,42 @@ pub enum CapabilityReport {
     NotOnThisHost,
 }
 
-/// Dispatch to the compiled-in backend's `capabilities()`. Expects a canonical
-/// [`crate::BACKENDS`] name; unknown names fall through to `NotOnThisHost` (the tool
-/// validates the name and errors before calling — see [`render_json`]).
-pub fn capabilities_for(backend: &str) -> CapabilityReport {
+/// Dispatch to the compiled-in backend's `capabilities()`.
+///
+/// `None` ⇒ `backend` is not a known [`crate::BACKENDS`] name. `Some(NotOnThisHost)` ⇒ a
+/// known backend name that isn't compiled into this binary. `Some(Available(_))` ⇒
+/// compiled into this binary, with its live capability map.
+pub fn capabilities_for(backend: &str) -> Option<CapabilityReport> {
+    if !crate::BACKENDS.contains(&backend) {
+        return None;
+    }
     // android is always compiled in (it shells out to adb; host-OS-agnostic).
     if backend == "android" {
-        return CapabilityReport::Available(glass_android::capabilities());
+        return Some(CapabilityReport::Available(glass_android::capabilities()));
     }
     #[cfg(target_os = "linux")]
     {
         match backend {
-            "x11" => return CapabilityReport::Available(glass_x11::capabilities()),
-            "wayland" => return CapabilityReport::Available(glass_wayland::capabilities()),
+            "x11" => return Some(CapabilityReport::Available(glass_x11::capabilities())),
+            "wayland" => return Some(CapabilityReport::Available(glass_wayland::capabilities())),
             _ => {}
         }
     }
     #[cfg(windows)]
     {
         if backend == "windows" {
-            return CapabilityReport::Available(glass_windows::capabilities());
+            return Some(CapabilityReport::Available(glass_windows::capabilities()));
         }
     }
     #[cfg(target_os = "macos")]
     {
         match backend {
-            "macos" => return CapabilityReport::Available(glass_macos::capabilities()),
-            "ios" => return CapabilityReport::Available(glass_ios::capabilities()),
+            "macos" => return Some(CapabilityReport::Available(glass_macos::capabilities())),
+            "ios" => return Some(CapabilityReport::Available(glass_ios::capabilities())),
             _ => {}
         }
     }
-    CapabilityReport::NotOnThisHost
+    Some(CapabilityReport::NotOnThisHost)
 }
 
 /// Resolve `backend` (None => the default backend) and render the report as JSON text.
@@ -55,6 +60,7 @@ pub fn render_json(backend: Option<&str>) -> Result<String, String> {
         Some(v) => crate::BACKENDS
             .iter()
             .find(|b| v.eq_ignore_ascii_case(b))
+            .copied()
             .ok_or_else(|| {
                 format!(
                     "unknown backend {v:?}; use one of: {}",
@@ -63,7 +69,9 @@ pub fn render_json(backend: Option<&str>) -> Result<String, String> {
             })?,
         None => crate::default_backend(std::env::var("GLASS_BACKEND").ok().as_deref()),
     };
-    let json = match capabilities_for(name) {
+    let report =
+        capabilities_for(name).expect("render_json resolved name to a canonical BACKENDS entry");
+    let json = match report {
         CapabilityReport::Available(map) => serde_json::json!({
             "backend": name,
             "available": true,
@@ -87,22 +95,22 @@ mod tests {
         // android is always compiled in (host-OS-agnostic).
         assert!(matches!(
             capabilities_for("android"),
-            CapabilityReport::Available(_)
+            Some(CapabilityReport::Available(_))
         ));
 
         #[cfg(target_os = "linux")]
         {
             assert!(matches!(
                 capabilities_for("x11"),
-                CapabilityReport::Available(_)
+                Some(CapabilityReport::Available(_))
             ));
             assert!(matches!(
                 capabilities_for("wayland"),
-                CapabilityReport::Available(_)
+                Some(CapabilityReport::Available(_))
             ));
             for b in ["windows", "macos", "ios"] {
                 assert!(
-                    matches!(capabilities_for(b), CapabilityReport::NotOnThisHost),
+                    matches!(capabilities_for(b), Some(CapabilityReport::NotOnThisHost)),
                     "{b}"
                 );
             }
@@ -111,11 +119,11 @@ mod tests {
         {
             assert!(matches!(
                 capabilities_for("windows"),
-                CapabilityReport::Available(_)
+                Some(CapabilityReport::Available(_))
             ));
             for b in ["x11", "wayland", "macos", "ios"] {
                 assert!(
-                    matches!(capabilities_for(b), CapabilityReport::NotOnThisHost),
+                    matches!(capabilities_for(b), Some(CapabilityReport::NotOnThisHost)),
                     "{b}"
                 );
             }
@@ -124,17 +132,19 @@ mod tests {
         {
             for b in ["macos", "ios"] {
                 assert!(
-                    matches!(capabilities_for(b), CapabilityReport::Available(_)),
+                    matches!(capabilities_for(b), Some(CapabilityReport::Available(_))),
                     "{b}"
                 );
             }
             for b in ["x11", "wayland", "windows"] {
                 assert!(
-                    matches!(capabilities_for(b), CapabilityReport::NotOnThisHost),
+                    matches!(capabilities_for(b), Some(CapabilityReport::NotOnThisHost)),
                     "{b}"
                 );
             }
         }
+
+        assert!(capabilities_for("nope").is_none());
 
         // Every canonical name resolves without panicking.
         for b in crate::BACKENDS {
@@ -168,5 +178,17 @@ mod tests {
         assert_eq!(v["available"], false);
         assert!(v["reason"].as_str().unwrap().contains("host: linux"));
         assert!(v.get("capabilities").is_none());
+    }
+
+    #[test]
+    fn render_json_none_resolves_to_the_default_backend() {
+        let default = crate::default_backend(std::env::var("GLASS_BACKEND").ok().as_deref());
+        // Omitting `backend` is identical to naming the resolved default.
+        assert_eq!(
+            render_json(None).unwrap(),
+            render_json(Some(default)).unwrap()
+        );
+        let v: serde_json::Value = serde_json::from_str(&render_json(None).unwrap()).unwrap();
+        assert_eq!(v["backend"], default);
     }
 }

--- a/crates/glass-mcp/src/capabilities.rs
+++ b/crates/glass-mcp/src/capabilities.rs
@@ -44,18 +44,20 @@ fn tools_for(op: &str) -> &'static [&'static str] {
         .iter()
         .find(|(name, _)| *name == op)
         .map(|(_, t)| *t)
-        .unwrap_or(&[])
+        .unwrap_or_else(|| panic!("no OPERATION_TOOLS entry for operation {op:?}"))
 }
 
-/// One rendered operation entry: the live status/note + the tools it gates.
+/// One rendered operation entry: the live status/note (via `CapabilityStatus`'s own
+/// serialization — single source for the `note`-omit policy) + the tools it gates.
 fn entry(op: &str, st: &CapabilityStatus) -> serde_json::Value {
-    let mut m = serde_json::Map::new();
-    m.insert("status".into(), serde_json::to_value(st.status).unwrap());
-    if let Some(note) = st.note {
-        m.insert("note".into(), serde_json::Value::String(note.to_string()));
-    }
-    m.insert("tools".into(), serde_json::to_value(tools_for(op)).unwrap());
-    serde_json::Value::Object(m)
+    let mut v = serde_json::to_value(st).expect("CapabilityStatus serializes");
+    v.as_object_mut()
+        .expect("CapabilityStatus serializes to a JSON object")
+        .insert(
+            "tools".into(),
+            serde_json::to_value(tools_for(op)).expect("tool list serializes"),
+        );
+    v
 }
 
 /// A backend's capability report on this host.
@@ -123,17 +125,18 @@ pub fn render_json(backend: Option<&str>) -> Result<String, String> {
     let report =
         capabilities_for(name).expect("render_json resolved name to a canonical BACKENDS entry");
     let json = match report {
-        CapabilityReport::Available(map) => serde_json::json!({
-            "backend": name,
-            "available": true,
-            "capabilities": {
-                "input": entry("input", &map.input),
-                "multi_touch": entry("multi_touch", &map.multi_touch),
-                "clipboard": entry("clipboard", &map.clipboard),
-                "accessibility": entry("accessibility", &map.accessibility),
-                "window_move_resize": entry("window_move_resize", &map.window_move_resize),
-            },
-        }),
+        CapabilityReport::Available(map) => {
+            let caps: serde_json::Map<String, serde_json::Value> = map
+                .entries()
+                .iter()
+                .map(|(op, st)| ((*op).to_string(), entry(op, st)))
+                .collect();
+            serde_json::json!({
+                "backend": name,
+                "available": true,
+                "capabilities": caps,
+            })
+        }
         CapabilityReport::NotOnThisHost => serde_json::json!({
             "backend": name,
             "available": false,
@@ -248,5 +251,51 @@ mod tests {
         );
         let v: serde_json::Value = serde_json::from_str(&render_json(None).unwrap()).unwrap();
         assert_eq!(v["backend"], default);
+    }
+
+    // android/x11 are both compiled in on Linux (android is host-OS-agnostic; x11 is a
+    // Linux-only dependency — see Cargo.toml). Gated like `render_json_not_on_this_host_shape`
+    // so it compiles out (not fails) on the macOS/Windows CI legs that also run this suite.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn render_attaches_notes_and_tools_on_the_shipped_path() {
+        // degraded/requires_setup carry a note; the note rides the rendered JSON.
+        let v: serde_json::Value =
+            serde_json::from_str(&render_json(Some("android")).unwrap()).unwrap();
+        assert_eq!(v["capabilities"]["input"]["status"], "degraded");
+        assert!(v["capabilities"]["input"]["note"]
+            .as_str()
+            .unwrap()
+            .contains("GLASS_ANDROID_AGENT_JAR"));
+        assert!(v["capabilities"]["input"]["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|t| t == "glass_type"));
+        // a plain `supported` op omits `note`.
+        let v: serde_json::Value =
+            serde_json::from_str(&render_json(Some("x11")).unwrap()).unwrap();
+        assert_eq!(v["capabilities"]["input"]["status"], "supported");
+        assert!(v["capabilities"]["input"].get("note").is_none());
+    }
+
+    #[test]
+    fn operation_tools_covers_every_rendered_operation() {
+        use glass_core::capability::{CapabilityMap, CapabilityStatus};
+        let dummy = CapabilityMap {
+            input: CapabilityStatus::supported(),
+            multi_touch: CapabilityStatus::supported(),
+            clipboard: CapabilityStatus::supported(),
+            accessibility: CapabilityStatus::supported(),
+            window_move_resize: CapabilityStatus::supported(),
+        };
+        let rendered: std::collections::BTreeSet<&str> =
+            dummy.entries().iter().map(|(op, _)| *op).collect();
+        let mapped: std::collections::BTreeSet<&str> =
+            OPERATION_TOOLS.iter().map(|(op, _)| *op).collect();
+        assert_eq!(
+            rendered, mapped,
+            "OPERATION_TOOLS keys must match the operations render emits"
+        );
     }
 }

--- a/crates/glass-mcp/src/capabilities.rs
+++ b/crates/glass-mcp/src/capabilities.rs
@@ -5,7 +5,58 @@
 //! compiled into this binary is reported `NotOnThisHost`. Dispatch is cfg-gated exactly
 //! like `make_platform`/`doctor` (android is always compiled; the rest per host OS).
 
-use glass_core::capability::CapabilityMap;
+use glass_core::capability::{CapabilityMap, CapabilityStatus};
+
+/// Operation → the registered MCP tools it gates. One source; the `server` test
+/// `every_mapped_tool_is_a_registered_tool` pins it to the registry (that test lives in
+/// `server.rs`, the only module that can reach `tool_router()`).
+pub(crate) const OPERATION_TOOLS: &[(&str, &[&str])] = &[
+    (
+        "input",
+        &[
+            "glass_type",
+            "glass_click",
+            "glass_key",
+            "glass_drag",
+            "glass_scroll",
+            "glass_move",
+            "glass_do",
+        ],
+    ),
+    ("multi_touch", &["glass_gesture"]),
+    ("clipboard", &["glass_clipboard_get", "glass_clipboard_set"]),
+    (
+        "accessibility",
+        &[
+            "glass_a11y_snapshot",
+            "glass_a11y_marks",
+            "glass_click_element",
+            "glass_set_value",
+            "glass_wait_for_element",
+            "glass_scroll_to_element",
+        ],
+    ),
+    ("window_move_resize", &["glass_window"]),
+];
+
+fn tools_for(op: &str) -> &'static [&'static str] {
+    OPERATION_TOOLS
+        .iter()
+        .find(|(name, _)| *name == op)
+        .map(|(_, t)| *t)
+        .unwrap_or(&[])
+}
+
+/// One rendered operation entry: the live status/note + the tools it gates.
+fn entry(op: &str, st: &CapabilityStatus) -> serde_json::Value {
+    let mut m = serde_json::Map::new();
+    m.insert("status".into(), serde_json::to_value(st.status).unwrap());
+    if let Some(note) = st.note {
+        m.insert("note".into(), serde_json::Value::String(note.to_string()));
+    }
+    m.insert("tools".into(), serde_json::to_value(tools_for(op)).unwrap());
+    serde_json::Value::Object(m)
+}
 
 /// A backend's capability report on this host.
 pub enum CapabilityReport {
@@ -75,7 +126,13 @@ pub fn render_json(backend: Option<&str>) -> Result<String, String> {
         CapabilityReport::Available(map) => serde_json::json!({
             "backend": name,
             "available": true,
-            "capabilities": map,
+            "capabilities": {
+                "input": entry("input", &map.input),
+                "multi_touch": entry("multi_touch", &map.multi_touch),
+                "clipboard": entry("clipboard", &map.clipboard),
+                "accessibility": entry("accessibility", &map.accessibility),
+                "window_move_resize": entry("window_move_resize", &map.window_move_resize),
+            },
         }),
         CapabilityReport::NotOnThisHost => serde_json::json!({
             "backend": name,
@@ -158,7 +215,8 @@ mod tests {
             serde_json::from_str(&render_json(Some("ANDROID")).unwrap()).unwrap();
         assert_eq!(v["backend"], "android"); // canonicalized, case-insensitive input
         assert_eq!(v["available"], true);
-        assert!(v["capabilities"]["multi_touch"]["status"].is_string());
+        assert!(v["capabilities"]["input"]["status"].is_string());
+        assert!(v["capabilities"]["input"]["tools"][0].is_string());
         assert!(v.get("reason").is_none());
     }
 

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -2,6 +2,7 @@
 //! path is reachable from integration tests.
 
 pub mod audit;
+pub mod capabilities;
 pub mod cli;
 pub mod doctor;
 mod env;

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -334,6 +334,15 @@ pub struct DoctorArgs {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct CapabilitiesArgs {
+    /// Which backend to report: `x11`, `wayland`, `windows`, `macos`, `android`, or
+    /// `ios`. Omit for the active/default backend (`GLASS_BACKEND`, else the host
+    /// default). A valid name for a backend not built into this binary reports
+    /// `available: false`.
+    pub backend: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct DiffArgs {
     pub name: String,
     /// `"perceptual"` (default) or `"exact"`.

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -298,6 +298,22 @@ impl GlassServer {
     }
 
     #[tool(
+        description = "Report which operations (multi-touch, clipboard, accessibility, \
+                       window move/resize) can be performed right now on a backend, and any \
+                       setup a blocked one needs — so you can check before acting instead of \
+                       hitting an Unsupported error. Pass `backend` to query a specific \
+                       backend by name; omit for the active one. Static — no session required."
+    )]
+    async fn glass_capabilities(
+        &self,
+        Parameters(a): Parameters<CapabilitiesArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(map_tool_result(
+            crate::capabilities::render_json(a.backend.as_deref()).map(ToolOutput::text),
+        ))
+    }
+
+    #[tool(
         description = "List the app's top-level windows: id, title, class, geometry, and which is active. Returns a JSON array. Window ids are not stable across calls — re-list after windows open/close instead of caching ids."
     )]
     async fn glass_list_windows(&self) -> Result<CallToolResult, McpError> {
@@ -555,6 +571,32 @@ mod tests {
             "an Ok must surface as a success result"
         );
         assert!(first_text(&r).contains("done"), "got {:?}", first_text(&r));
+    }
+
+    /// android is always compiled in (host-OS-agnostic), so it's a stable choice for
+    /// exercising the registered handler end to end without depending on the host OS.
+    #[tokio::test]
+    async fn glass_capabilities_returns_json_for_the_active_backend() {
+        let glass =
+            crate::tools::testutil::glass_with(crate::tools::testutil::FakePlatform::new(100, 100));
+        let report = crate::audit::report_from_config(None, |_| None);
+        let server = GlassServer::new(glass, report);
+
+        let out = server
+            .glass_capabilities(Parameters(CapabilitiesArgs {
+                backend: Some("android".into()),
+            }))
+            .await
+            .unwrap();
+
+        let text = first_text(&out);
+        let v: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(v["backend"], "android");
+        assert_eq!(v["available"], true);
+        assert_eq!(
+            v["capabilities"]["window_move_resize"]["status"],
+            "unsupported"
+        );
     }
 
     // "windows" is excluded from `banned` below (collides with the plain noun, e.g.

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -298,11 +298,16 @@ impl GlassServer {
     }
 
     #[tool(
-        description = "Report which operations (multi-touch, clipboard, accessibility, \
+        description = "Report which operations (input, multi-touch, clipboard, accessibility, \
                        window move/resize) can be performed right now on a backend, and any \
                        setup a blocked one needs — so you can check before acting instead of \
-                       hitting an Unsupported error. Pass `backend` to query a specific \
-                       backend by name; omit for the active one. Static — no session required."
+                       hitting an Unsupported error. Each operation reports a live `status` \
+                       (`supported`, `degraded` — works now at reduced fidelity, `note` says \
+                       what's lost; `requires_setup` — a setup step is missing, `note` says \
+                       what; or `unsupported` — this backend never does it) plus the `tools` \
+                       it gates, so a degraded or blocked operation names exactly which tool \
+                       calls to expect trouble from. Pass `backend` to query a specific backend \
+                       by name; omit for the active one. Static — no session required."
     )]
     async fn glass_capabilities(
         &self,
@@ -892,5 +897,23 @@ mod tests {
              registered but undocumented: {undocumented:?}\n  \
              documented but not registered: {phantom:?}"
         );
+    }
+
+    /// `glass_capabilities`'s per-operation tool lists (`OPERATION_TOOLS`, single-sourced in
+    /// `capabilities.rs`) must each name a tool actually in the registry — otherwise the
+    /// reported `tools` array would point an agent at a tool that doesn't exist. `tool_router`
+    /// is only reachable from this module (see `registered_tools` above), so the test lives
+    /// here rather than alongside the table in `capabilities.rs`.
+    #[test]
+    fn every_mapped_tool_is_a_registered_tool() {
+        let registered = registered_tools();
+        for (op, tools) in crate::capabilities::OPERATION_TOOLS {
+            for t in *tools {
+                assert!(
+                    registered.contains(*t),
+                    "operation {op:?} maps to unregistered tool {t:?}"
+                );
+            }
+        }
     }
 }

--- a/crates/glass-wayland/src/lib.rs
+++ b/crates/glass-wayland/src/lib.rs
@@ -1,6 +1,8 @@
 //! glass-wayland: the Linux/Wayland `Platform` backend (wlroots protocols,
 //! per-session headless `sway` compositor).
 
+use glass_core::capability::{CapabilityMap, CapabilityStatus};
+
 pub mod clipboard;
 pub mod command;
 pub mod doctor;
@@ -12,3 +14,30 @@ pub mod platform;
 pub mod swayipc;
 
 pub use platform::WaylandPlatform;
+
+/// This backend's capability map. All cells are code-constant here (desktop
+/// accessibility is reported Supported when the backend ships an a11y reader; per-OS
+/// grants — macOS TCC, Linux AT-SPI — are surfaced by `glass_doctor`).
+pub fn capabilities() -> CapabilityMap {
+    CapabilityMap {
+        multi_touch: CapabilityStatus::unsupported(None),
+        clipboard: CapabilityStatus::supported(),
+        accessibility: CapabilityStatus::supported(),
+        window_move_resize: CapabilityStatus::supported(),
+    }
+}
+
+#[cfg(test)]
+mod capability_tests {
+    use super::capabilities;
+    use glass_core::capability::Support;
+
+    #[test]
+    fn desktop_constant_capability_map() {
+        let c = capabilities();
+        assert_eq!(c.multi_touch.status, Support::Unsupported);
+        assert_eq!(c.clipboard.status, Support::Supported);
+        assert_eq!(c.accessibility.status, Support::Supported);
+        assert_eq!(c.window_move_resize.status, Support::Supported);
+    }
+}

--- a/crates/glass-wayland/src/lib.rs
+++ b/crates/glass-wayland/src/lib.rs
@@ -20,6 +20,7 @@ pub use platform::WaylandPlatform;
 /// grants — macOS TCC, Linux AT-SPI — are surfaced by `glass_doctor`).
 pub fn capabilities() -> CapabilityMap {
     CapabilityMap {
+        input: CapabilityStatus::supported(),
         multi_touch: CapabilityStatus::unsupported(None),
         clipboard: CapabilityStatus::supported(),
         accessibility: CapabilityStatus::supported(),
@@ -35,6 +36,7 @@ mod capability_tests {
     #[test]
     fn desktop_constant_capability_map() {
         let c = capabilities();
+        assert_eq!(c.input.status, Support::Supported);
         assert_eq!(c.multi_touch.status, Support::Unsupported);
         assert_eq!(c.clipboard.status, Support::Supported);
         assert_eq!(c.accessibility.status, Support::Supported);

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -3,7 +3,8 @@
 //! v1 drives the interactive desktop. The OS-touching modules and the
 //! `WindowsPlatform` impl are gated per-item with `#[cfg(windows)]` (not a
 //! crate-level gate) so the pure [`dpi`] coordinate math still compiles and is
-//! unit-tested on the Linux dev box. Off Windows the crate exposes only `dpi`.
+//! unit-tested on the Linux dev box. Off Windows the crate exposes only `dpi` and the
+//! code-constant [`capabilities`] map.
 
 // FFI backend: the OS-touching modules need `unsafe`, so this crate opts out of the workspace
 // `unsafe_code = "deny"`; each site carries a `// SAFETY:` note (see CLAUDE.md). The pure

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -44,6 +44,7 @@ pub(crate) fn disclose_clip_disabled(dll: &str) {
 /// grants — macOS TCC, Linux AT-SPI — are surfaced by `glass_doctor`).
 pub fn capabilities() -> CapabilityMap {
     CapabilityMap {
+        input: CapabilityStatus::supported(),
         multi_touch: CapabilityStatus::unsupported(None),
         clipboard: CapabilityStatus::supported(),
         accessibility: CapabilityStatus::supported(),
@@ -77,6 +78,7 @@ mod capability_tests {
     #[test]
     fn desktop_constant_capability_map() {
         let c = capabilities();
+        assert_eq!(c.input.status, Support::Supported);
         assert_eq!(c.multi_touch.status, Support::Unsupported);
         assert_eq!(c.clipboard.status, Support::Supported);
         assert_eq!(c.accessibility.status, Support::Supported);

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -10,6 +10,8 @@
 // modules below stay `unsafe`-free by convention.
 #![allow(unsafe_code)]
 
+use glass_core::capability::{CapabilityMap, CapabilityStatus};
+
 pub mod containment; // Windows containment provider seam (pure config is host-tested)
 pub mod discovery; // pure window-discovery poll-loop decision — cross-platform, host-tested
 pub mod doctor; // pure check-mapping cross-platform; Windows fact-gathering is cfg(windows)
@@ -36,6 +38,18 @@ pub(crate) fn disclose_clip_disabled(dll: &str) {
     });
 }
 
+/// This backend's capability map. All cells are code-constant here (desktop
+/// accessibility is reported Supported when the backend ships an a11y reader; per-OS
+/// grants — macOS TCC, Linux AT-SPI — are surfaced by `glass_doctor`).
+pub fn capabilities() -> CapabilityMap {
+    CapabilityMap {
+        multi_touch: CapabilityStatus::unsupported(None),
+        clipboard: CapabilityStatus::supported(),
+        accessibility: CapabilityStatus::supported(),
+        window_move_resize: CapabilityStatus::supported(),
+    }
+}
+
 #[cfg(windows)]
 mod capture;
 #[cfg(windows)]
@@ -53,6 +67,21 @@ mod windows;
 
 #[cfg(windows)]
 pub use backend::WindowsPlatform;
+
+#[cfg(test)]
+mod capability_tests {
+    use super::capabilities;
+    use glass_core::capability::Support;
+
+    #[test]
+    fn desktop_constant_capability_map() {
+        let c = capabilities();
+        assert_eq!(c.multi_touch.status, Support::Unsupported);
+        assert_eq!(c.clipboard.status, Support::Supported);
+        assert_eq!(c.accessibility.status, Support::Supported);
+        assert_eq!(c.window_move_resize.status, Support::Supported);
+    }
+}
 
 #[cfg(windows)]
 mod backend {

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -70,22 +70,6 @@ mod windows;
 #[cfg(windows)]
 pub use backend::WindowsPlatform;
 
-#[cfg(test)]
-mod capability_tests {
-    use super::capabilities;
-    use glass_core::capability::Support;
-
-    #[test]
-    fn desktop_constant_capability_map() {
-        let c = capabilities();
-        assert_eq!(c.input.status, Support::Supported);
-        assert_eq!(c.multi_touch.status, Support::Unsupported);
-        assert_eq!(c.clipboard.status, Support::Supported);
-        assert_eq!(c.accessibility.status, Support::Supported);
-        assert_eq!(c.window_move_resize.status, Support::Supported);
-    }
-}
-
 #[cfg(windows)]
 mod backend {
     use std::sync::{Arc, Mutex};
@@ -375,5 +359,21 @@ mod backend {
                 app.kill();
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod capability_tests {
+    use super::capabilities;
+    use glass_core::capability::Support;
+
+    #[test]
+    fn desktop_constant_capability_map() {
+        let c = capabilities();
+        assert_eq!(c.input.status, Support::Supported);
+        assert_eq!(c.multi_touch.status, Support::Unsupported);
+        assert_eq!(c.clipboard.status, Support::Supported);
+        assert_eq!(c.accessibility.status, Support::Supported);
+        assert_eq!(c.window_move_resize.status, Support::Supported);
     }
 }

--- a/crates/glass-x11/src/lib.rs
+++ b/crates/glass-x11/src/lib.rs
@@ -2,6 +2,8 @@
 
 // Modules are added task-by-task.
 
+use glass_core::capability::{CapabilityMap, CapabilityStatus};
+
 pub mod clipboard;
 pub mod command;
 pub mod coords;
@@ -11,3 +13,30 @@ pub mod platform;
 pub mod xvfb;
 pub use platform::X11Platform;
 pub use xvfb::Xvfb;
+
+/// This backend's capability map. All cells are code-constant here (desktop
+/// accessibility is reported Supported when the backend ships an a11y reader; per-OS
+/// grants — macOS TCC, Linux AT-SPI — are surfaced by `glass_doctor`).
+pub fn capabilities() -> CapabilityMap {
+    CapabilityMap {
+        multi_touch: CapabilityStatus::unsupported(None),
+        clipboard: CapabilityStatus::supported(),
+        accessibility: CapabilityStatus::supported(),
+        window_move_resize: CapabilityStatus::supported(),
+    }
+}
+
+#[cfg(test)]
+mod capability_tests {
+    use super::capabilities;
+    use glass_core::capability::Support;
+
+    #[test]
+    fn desktop_constant_capability_map() {
+        let c = capabilities();
+        assert_eq!(c.multi_touch.status, Support::Unsupported);
+        assert_eq!(c.clipboard.status, Support::Supported);
+        assert_eq!(c.accessibility.status, Support::Supported);
+        assert_eq!(c.window_move_resize.status, Support::Supported);
+    }
+}

--- a/crates/glass-x11/src/lib.rs
+++ b/crates/glass-x11/src/lib.rs
@@ -19,6 +19,7 @@ pub use xvfb::Xvfb;
 /// grants — macOS TCC, Linux AT-SPI — are surfaced by `glass_doctor`).
 pub fn capabilities() -> CapabilityMap {
     CapabilityMap {
+        input: CapabilityStatus::supported(),
         multi_touch: CapabilityStatus::unsupported(None),
         clipboard: CapabilityStatus::supported(),
         accessibility: CapabilityStatus::supported(),
@@ -34,6 +35,7 @@ mod capability_tests {
     #[test]
     fn desktop_constant_capability_map() {
         let c = capabilities();
+        assert_eq!(c.input.status, Support::Supported);
         assert_eq!(c.multi_touch.status, Support::Unsupported);
         assert_eq!(c.clipboard.status, Support::Supported);
         assert_eq!(c.accessibility.status, Support::Supported);

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -422,3 +422,28 @@ it to self-diagnose a `glass_start` failure.
 wayland) and software GL; the report names exactly the checks it ran for the selected backend.
 
 Mirrors the `glass-mcp doctor` CLI — see [reference/cli.md](cli.md).
+
+### `glass_capabilities`
+
+Report which operations can be performed **right now** on a backend — so you can check before you
+act, instead of discovering an `Unsupported` error by trying. Static: no session required, works
+before `glass_start`.
+
+- `backend` (string, optional) — which backend to report: `x11`, `wayland`, `windows`, `macos`,
+  `android`, `ios`. Omit for the active/default backend.
+
+Returns JSON. For a backend compiled into this binary:
+
+`{ "backend", "available": true, "capabilities": { <capability>: { "status", "note"? } } }`
+
+where each capability (`multi_touch`, `clipboard`, `accessibility`, `window_move_resize`) has a
+`status` of `supported`, `requires_setup` (a setup step is missing now — `note` says what), or
+`unsupported` (this backend never does it). For a valid backend **not** built into the running
+binary: `{ "backend", "available": false, "reason": "..." }`.
+
+**Platform notes:** availability is live. android `multi_touch`/`clipboard` need the on-device
+agent (`GLASS_ANDROID_AGENT_JAR`) and iOS `accessibility` needs `idb_companion`, so those read
+`requires_setup` until set up. Desktop-backend `accessibility` is reported `supported` when the
+backend ships an a11y reader; whether a given window exposes a tree, and per-OS grants (the macOS
+accessibility permission, the Linux AT-SPI stack), are surfaced by `glass_doctor` and when you call
+the a11y tools.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -440,8 +440,9 @@ Each of the five operations — `input`, `multi_touch`, `clipboard`, `accessibil
 `window_move_resize` — carries a live `status`, one of four states: `supported` (works now),
 `degraded` (works now at reduced fidelity/coverage — `note` says what's lost and how to restore
 it), `requires_setup` (a setup step is missing right now — `note` says what), or `unsupported`
-(this backend never does it). `note` is present for `degraded`, `requires_setup`, and some
-`unsupported` cases; absent for plain `supported`.
+(this backend never does it). `note` is present when there's something to explain (what's
+degraded/missing, or a caveat — even a plain `supported` op can carry one, e.g. iOS `clipboard`
+being supported but needing on-screen paste consent); omitted otherwise.
 
 Every entry also carries `tools`: the MCP tools that operation gates, so a
 `degraded`/`requires_setup`/`unsupported` entry tells you exactly which calls to expect trouble

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -434,15 +434,33 @@ before `glass_start`.
 
 Returns JSON. For a backend compiled into this binary:
 
-`{ "backend", "available": true, "capabilities": { <capability>: { "status", "note"? } } }`
+`{ "backend", "available": true, "capabilities": { <operation>: { "status", "note"?, "tools" } } }`
 
-where each capability (`multi_touch`, `clipboard`, `accessibility`, `window_move_resize`) has a
-`status` of `supported`, `requires_setup` (a setup step is missing now — `note` says what), or
-`unsupported` (this backend never does it). For a valid backend **not** built into the running
-binary: `{ "backend", "available": false, "reason": "..." }`.
+Each of the five operations — `input`, `multi_touch`, `clipboard`, `accessibility`,
+`window_move_resize` — carries a live `status`, one of four states: `supported` (works now),
+`degraded` (works now at reduced fidelity/coverage — `note` says what's lost and how to restore
+it), `requires_setup` (a setup step is missing right now — `note` says what), or `unsupported`
+(this backend never does it). `note` is present for `degraded`, `requires_setup`, and some
+`unsupported` cases; absent for plain `supported`.
 
-**Platform notes:** availability is live. android `multi_touch`/`clipboard` need the on-device
-agent (`GLASS_ANDROID_AGENT_JAR`) and iOS `accessibility` needs `idb_companion`, so those read
+Every entry also carries `tools`: the MCP tools that operation gates, so a
+`degraded`/`requires_setup`/`unsupported` entry tells you exactly which calls to expect trouble
+from:
+
+- **input** → `glass_type`, `glass_click`, `glass_key`, `glass_drag`, `glass_scroll`,
+  `glass_move`, `glass_do`
+- **multi_touch** → `glass_gesture`
+- **clipboard** → `glass_clipboard_get`, `glass_clipboard_set`
+- **accessibility** → `glass_a11y_snapshot`, `glass_a11y_marks`, `glass_click_element`,
+  `glass_set_value`, `glass_wait_for_element`, `glass_scroll_to_element`
+- **window_move_resize** → `glass_window`
+
+For a valid backend **not** built into the running binary:
+`{ "backend", "available": false, "reason": "..." }`.
+
+**Platform notes:** availability is live. android `input` is `degraded` (adb-only injection
+unless the on-device agent is set up) and its `multi_touch`/`clipboard` need that same agent
+(`GLASS_ANDROID_AGENT_JAR`); iOS `accessibility` needs `idb_companion`; those read
 `requires_setup` until set up. Desktop-backend `accessibility` is reported `supported` when the
 backend ships an a11y reader; whether a given window exposes a tree, and per-OS grants (the macOS
 accessibility permission, the Linux AT-SPI stack), are surfaced by `glass_doctor` and when you call


### PR DESCRIPTION
## What & why

An agent driving glass can't tell, before or mid-task, whether an operation will work on the backend it's targeting — it finds out by *trying* and reading an `Unsupported` error. And the deciding factor is often live: does it work **right now**, and **how well**? `glass_capabilities` answers that up front, so the agent can decide whether to continue an approach or switch.

## What it does

`glass_capabilities { backend? }` reports, per operation (`input`, `multi_touch`, `clipboard`, `accessibility`, `window_move_resize`), a **live** status:

- `supported` — works now, full fidelity
- `degraded` — **works now but reduced** (note says what's lost + how to restore) — the state that drives continue-vs-give-up
- `requires_setup` — not available now, a setup step enables it
- `unsupported` — this backend never does it

Each entry also carries the **tools** it gates, so the live status is actionable against the specific tool the agent is about to call. Omit `backend` for the active one; name any backend to query it without touching `GLASS_BACKEND`. A valid backend not built into this binary returns `{ "available": false, "reason": … }`. Static — no session required; works before `glass_start`.

It's a **projection over existing signals, not a new prober.** The live cells reuse the runtime's own gates — android `agent_enabled` (the injector selector) and the a11y-apk presence, iOS `companion_present` — so a report can't drift from what the backend actually does.

Example — android with no on-device agent wired (the "call an audible" moment):

```json
{
  "backend": "android",
  "available": true,
  "capabilities": {
    "input":         { "status": "degraded", "note": "adb input only; set GLASS_ANDROID_AGENT_JAR for high-fidelity input",
                       "tools": ["glass_type", "glass_click", "glass_key", "glass_drag", "glass_scroll", "glass_move", "glass_do"] },
    "multi_touch":   { "status": "requires_setup", "note": "needs the on-device agent; set GLASS_ANDROID_AGENT_JAR", "tools": ["glass_gesture"] },
    "clipboard":     { "status": "requires_setup", "note": "needs the on-device agent; set GLASS_ANDROID_AGENT_JAR", "tools": ["glass_clipboard_get", "glass_clipboard_set"] },
    "accessibility": { "status": "degraded", "note": "basic uiautomator tree only; set GLASS_ANDROID_A11Y_APK for the Compose tree + high-fidelity set_value",
                       "tools": ["glass_a11y_snapshot", "glass_a11y_marks", "glass_click_element", "glass_set_value", "glass_wait_for_element", "glass_scroll_to_element"] },
    "window_move_resize": { "status": "unsupported", "note": "apps are full-screen", "tools": ["glass_window"] }
  }
}
```

The agent reads that and adapts — screenshots + OCR instead of the shallow a11y tree, extra waits around adb-fidelity input — which it could never derive from static tool descriptions.

## Changes

- **`glass-core`** (`capability.rs`): `Support` (4-state incl. `degraded`) / `CapabilityStatus` / `CapabilityMap` (5 named fields incl. `input`). Named fields make operation-completeness a compile-time guarantee — extended into rendering via `CapabilityMap::entries()`.
- **Each backend crate**: `pub fn capabilities() -> CapabilityMap` — the live cells reuse existing helpers (`agent_enabled`, `a11y_service::a11y_apk`, `doctor::companion_present`); the rest are code-constant.
- **`glass-mcp`**: cfg-gated `capabilities_for` dispatch (mirrors `doctor`) + `render_json`, which attaches each operation's `tools` from a single `OPERATION_TOOLS` table (a no-rot test pins every mapped tool to the live registry). Unknown backend → a real MCP error listing the valid backends.
- **Docs**: `docs/reference/tools.md` section; `CHANGELOG.md` entry.

## Testing

`cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, and `cargo test --workspace --locked` all pass (1006 tests). Both branches of every live-degradation seam are tested; the `degraded` states and their notes are asserted on the shipped render path; the cfg dispatch is asserted per host; the tool-description / registry / param / mapping guards stay green. A full multi-lens review ran on the branch before this PR.

## Follow-ups (not in this PR)

- Make the runtime `Unsupported` **errors** informative — generate them from each backend's `capabilities()` (#150).
- Make desktop-backend `accessibility` **live** — distil each a11y doctor's checks into a shared bool signal (Linux AT-SPI, macOS accessibility grant, Windows UIA); reported `supported` for now (#151).
- Pre-existing: an unrecognized `GLASS_BACKEND` still silently falls back to x11 on the omitted-backend path (#148).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
