### PR TITLE
fix: surface an unrecognized GLASS_BACKEND instead of silently defaulting

### DIFF
--- a/crates/glass-mcp/src/capabilities.rs
+++ b/crates/glass-mcp/src/capabilities.rs
@@ -109,22 +109,38 @@ pub fn capabilities_for(backend: &str) -> Option<CapabilityReport> {
 /// Resolve `backend` (None => the default backend) and render the report as JSON text.
 /// `Err` names the valid backends when `backend` is an unrecognized value.
 pub fn render_json(backend: Option<&str>) -> Result<String, String> {
+    render_json_resolved(backend, std::env::var("GLASS_BACKEND").ok().as_deref())
+}
+
+/// Pure core of [`render_json`], with the `GLASS_BACKEND` value passed in (`env`) so the
+/// default-resolution branch is testable without mutating the process environment. `env` is
+/// consulted only when `backend` is `None`.
+fn render_json_resolved(backend: Option<&str>, env: Option<&str>) -> Result<String, String> {
+    // A `None` caller with a set-but-unrecognized GLASS_BACKEND resolves to the host default;
+    // surface that in the report the way `boot`/`doctor` do, rather than reporting the wrong
+    // backend's capabilities with no indication the requested one was dropped.
+    let mut warning: Option<String> = None;
     let name: &'static str = match backend {
-        Some(v) => crate::BACKENDS
-            .iter()
-            .find(|b| v.eq_ignore_ascii_case(b))
-            .copied()
-            .ok_or_else(|| {
-                format!(
-                    "unknown backend {v:?}; use one of: {}",
-                    crate::BACKENDS.join(", ")
-                )
-            })?,
-        None => crate::default_backend(std::env::var("GLASS_BACKEND").ok().as_deref()),
+        Some(v) => crate::recognized_backend(v).ok_or_else(|| {
+            format!(
+                "unknown backend {v:?}; use one of: {}",
+                crate::BACKENDS.join(", ")
+            )
+        })?,
+        None => {
+            if crate::backend_env_unrecognized(env) {
+                warning = Some(format!(
+                    "GLASS_BACKEND={:?} is not a recognized backend; reporting {} instead",
+                    env.unwrap_or_default(),
+                    crate::default_backend(env),
+                ));
+            }
+            crate::default_backend(env)
+        }
     };
     let report =
         capabilities_for(name).expect("render_json resolved name to a canonical BACKENDS entry");
-    let json = match report {
+    let mut json = match report {
         CapabilityReport::Available(map) => {
             let caps: serde_json::Map<String, serde_json::Value> = map
                 .entries()
@@ -143,6 +159,11 @@ pub fn render_json(backend: Option<&str>) -> Result<String, String> {
             "reason": format!("not in this glass build (host: {})", std::env::consts::OS),
         }),
     };
+    if let Some(w) = warning {
+        json.as_object_mut()
+            .expect("capability report is a JSON object")
+            .insert("warning".to_string(), serde_json::Value::String(w));
+    }
     Ok(serde_json::to_string(&json).expect("capability report serializes"))
 }
 
@@ -239,6 +260,25 @@ mod tests {
         assert_eq!(v["available"], false);
         assert!(v["reason"].as_str().unwrap().contains("host: linux"));
         assert!(v.get("capabilities").is_none());
+    }
+
+    #[test]
+    fn render_json_resolved_warns_on_unrecognized_env_backend() {
+        // No explicit backend + a typo'd GLASS_BACKEND: report the host default's caps, but
+        // attach a `warning` naming the dropped value so the fallback isn't silent (#148).
+        let host_default = crate::default_backend(None);
+        let v: serde_json::Value =
+            serde_json::from_str(&render_json_resolved(None, Some("andriod")).unwrap()).unwrap();
+        assert_eq!(v["backend"], host_default);
+        let warn = v["warning"].as_str().expect("warning field present");
+        assert!(warn.contains("andriod"), "warning: {warn}");
+
+        // A recognized value (or unset) attaches no warning — normal output is unchanged.
+        for env in [Some("android"), None] {
+            let v: serde_json::Value =
+                serde_json::from_str(&render_json_resolved(None, env).unwrap()).unwrap();
+            assert!(v.get("warning").is_none(), "unexpected warning for {env:?}");
+        }
     }
 
     #[test]

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -17,18 +17,50 @@ pub fn diagnose_with_audit(deep: bool, report: &crate::audit::AuditReport) -> Di
     diagnose_inner(deep, Some(report))
 }
 
-fn diagnose_inner(deep: bool, audit: Option<&crate::audit::AuditReport>) -> Diagnosis {
-    let backend = crate::default_backend(std::env::var("GLASS_BACKEND").ok().as_deref());
+/// The "default backend" line of the `general` section. `Warn` (not `Ok`) when `GLASS_BACKEND`
+/// is *set* to an unrecognized value — surfacing the silent host-default fallback that
+/// [`crate::default_backend`] would otherwise make invisibly — and echoing the raw value so a
+/// typo is obvious. `Ok` when unset or a recognized name. Pure in `raw` (the read
+/// `GLASS_BACKEND` value), so the `Warn` branch is unit-testable without touching the process
+/// environment.
+fn default_backend_check(raw: Option<&str>) -> Check {
+    let backend = crate::default_backend(raw);
+    match raw {
+        // `{v:?}` (not `{v}`) so an empty or whitespace value is still visible in the message
+        // instead of collapsing to a blank — matching `boot`'s warning.
+        Some(v) if crate::backend_env_unrecognized(raw) => Check::new(
+            "default backend",
+            CheckStatus::Warn,
+            format!(
+                "{backend} (GLASS_BACKEND = {v:?} is not a recognized backend; using {backend})"
+            ),
+        )
+        .with_remedy(format!(
+            "unset GLASS_BACKEND or set it to one of: {}",
+            crate::BACKENDS.join(", ")
+        )),
+        Some(v) => Check::new(
+            "default backend",
+            CheckStatus::Ok,
+            format!("{backend} (GLASS_BACKEND = {v})"),
+        ),
+        None => Check::new(
+            "default backend",
+            CheckStatus::Ok,
+            format!("{backend} (GLASS_BACKEND unset)"),
+        ),
+    }
+}
 
-    let backend_detail = match std::env::var("GLASS_BACKEND") {
-        Ok(v) => format!("{backend} (GLASS_BACKEND = {v})"),
-        Err(_) => format!("{backend} (GLASS_BACKEND unset)"),
-    };
+fn diagnose_inner(deep: bool, audit: Option<&crate::audit::AuditReport>) -> Diagnosis {
+    let raw = std::env::var("GLASS_BACKEND").ok();
+    let backend = crate::default_backend(raw.as_deref());
+
     let general = Section::new(
         "general",
         None,
         vec![
-            Check::new("default backend", CheckStatus::Ok, backend_detail),
+            default_backend_check(raw.as_deref()),
             Check::new("glass", CheckStatus::Ok, env!("CARGO_PKG_VERSION")),
         ],
     );
@@ -466,6 +498,37 @@ fn macos_a11y_checks(accessibility_granted: bool) -> Vec<Check> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn default_backend_check_warns_only_on_a_set_but_unrecognized_value() {
+        // Recognized name → Ok, echoing the value.
+        let ok = default_backend_check(Some("wayland"));
+        assert_eq!(ok.status, CheckStatus::Ok);
+        assert!(ok.detail.contains("wayland"), "detail: {}", ok.detail);
+        // Unset → Ok (the legitimate host-default case).
+        assert_eq!(default_backend_check(None).status, CheckStatus::Ok);
+        // Set-but-unknown → Warn, surfacing the raw value so the typo is visible instead of a
+        // silent host-default fallback, and carrying a remedy listing the valid backends.
+        let warn = default_backend_check(Some("andriod"));
+        assert_eq!(warn.status, CheckStatus::Warn);
+        assert!(warn.detail.contains("andriod"), "detail: {}", warn.detail);
+        assert!(warn.remedy.is_some(), "expected a remedy on the warning");
+    }
+
+    #[test]
+    fn unrecognized_backend_warns_but_doctor_still_exits_zero() {
+        // The #148 contract: a mis-set GLASS_BACKEND must *surface* (Warn) yet not *fail*
+        // doctor. Pin the composition — the `general` section is critical (backend None), so a
+        // regression that made this check `Fail`, or moved it to a non-critical section, would
+        // silently flip the exit code with the isolated per-check tests still green.
+        let diag = Diagnosis::new(vec![Section::new(
+            "general",
+            None,
+            vec![default_backend_check(Some("andriod"))],
+        )]);
+        assert_eq!(diag.overall("x11"), CheckStatus::Warn);
+        assert_eq!(diag.exit_code("x11"), 0);
+    }
 
     #[test]
     fn idb_companion_check_fails_when_absent_and_oks_when_present() {

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -156,16 +156,28 @@ pub fn make_platform(
 pub const BACKENDS: &[&str] = &["x11", "wayland", "windows", "macos", "android", "ios"];
 
 /// Default backend name from `GLASS_BACKEND` (case-insensitive; one of [`BACKENDS`]).
-/// Unset defaults to the windows backend on a Windows host, the macos backend on a macOS
-/// host, else X11.
+/// Both *unset* and *set-but-unrecognized* fall back to `host_default_backend` — the windows
+/// backend on a Windows host, the macos backend on a macOS host, else X11. The unrecognized
+/// case is additionally surfaced (a `boot` warning / `glass_doctor` `Warn`, via
+/// `backend_env_unrecognized`) so a mis-set backend can't pass unnoticed, but a typo still
+/// lands on the same backend an unset var would rather than surprising a mac/windows host with
+/// x11.
 pub fn default_backend(env: Option<&str>) -> &'static str {
-    if let Some(v) = env {
-        return BACKENDS
-            .iter()
-            .find(|b| v.eq_ignore_ascii_case(b))
-            .copied()
-            .unwrap_or("x11");
-    }
+    env.and_then(recognized_backend)
+        .unwrap_or_else(host_default_backend)
+}
+
+/// The single backend-recognition predicate: the canonical [`BACKENDS`] entry `v` names
+/// (case-insensitively), or `None`. `default_backend`, `backend_env_unrecognized`, and
+/// `capabilities::render_json` all key off this one function, so "which values are recognized"
+/// can never drift between the resolver and the code that warns about a mis-set value.
+pub(crate) fn recognized_backend(v: &str) -> Option<&'static str> {
+    BACKENDS.iter().find(|b| v.eq_ignore_ascii_case(b)).copied()
+}
+
+/// The backend to use when `GLASS_BACKEND` gives no usable name: the windows backend on a
+/// Windows host, the macos backend on a macOS host, else X11.
+fn host_default_backend() -> &'static str {
     if cfg!(windows) {
         "windows"
     } else if cfg!(target_os = "macos") {
@@ -173,6 +185,15 @@ pub fn default_backend(env: Option<&str>) -> &'static str {
     } else {
         "x11"
     }
+}
+
+/// True when `GLASS_BACKEND` is *set* to a value `recognized_backend` doesn't match — the case
+/// where `default_backend` falls back to the host default instead of honoring the request (a
+/// typo like `andriod`, or a backend name from a newer glass). Distinct from *unset* (`None`),
+/// which legitimately means "use the host default". Callers surface this — a `boot` startup
+/// warning, a `glass_doctor` `Warn` — so a mis-set backend can't pass unnoticed.
+pub(crate) fn backend_env_unrecognized(env: Option<&str>) -> bool {
+    matches!(env, Some(v) if recognized_backend(v).is_none())
 }
 
 /// `glass-mcp env [--json]`: print glass's configuration env vars (secrets redacted).
@@ -312,7 +333,19 @@ fn default_baseline_dir() -> std::path::PathBuf {
 
 /// Build the `Glass` session manager, installing the audit sink if one is configured.
 pub fn boot(audit: Option<Box<dyn glass_core::AuditSink>>) -> Glass {
-    let default = default_backend(std::env::var("GLASS_BACKEND").ok().as_deref()).to_string();
+    let raw = std::env::var("GLASS_BACKEND").ok();
+    let default = default_backend(raw.as_deref()).to_string();
+    if backend_env_unrecognized(raw.as_deref()) {
+        // `default_backend` fell back to the host default because GLASS_BACKEND holds an
+        // unrecognized value; say so rather than launching a surprising backend silently.
+        // (stdout carries the MCP protocol, so diagnostics go to stderr.)
+        eprintln!(
+            "glass: GLASS_BACKEND={:?} is not a recognized backend; defaulting to {default}. \
+             Recognized backends: {}.",
+            raw.as_deref().unwrap_or_default(),
+            BACKENDS.join(", "),
+        );
+    }
     let baselines = BaselineStore::new(default_baseline_dir());
     let registry = glass_android::EmulatorRegistry::new();
     let agents = glass_android::AgentRegistry::new();
@@ -420,13 +453,42 @@ mod tests {
         assert_eq!(default_backend(Some("macos")), "macos");
         assert_eq!(default_backend(Some("MACOS")), "macos");
         assert_eq!(default_backend(Some("x11")), "x11");
-        assert_eq!(default_backend(Some("nonsense")), "x11");
         #[cfg(windows)]
         assert_eq!(default_backend(None), "windows");
         #[cfg(target_os = "macos")]
         assert_eq!(default_backend(None), "macos");
         #[cfg(not(any(windows, target_os = "macos")))]
         assert_eq!(default_backend(None), "x11");
+        // A set-but-unrecognized value falls to the host default — the same backend an unset
+        // var resolves to — not a hardcoded x11 that would surprise a mac/windows host.
+        assert_eq!(default_backend(Some("nonsense")), default_backend(None));
+    }
+
+    #[test]
+    fn backend_env_unrecognized_flags_only_set_but_unknown() {
+        use super::backend_env_unrecognized as unrec;
+        // Unset is the legitimate "host default" case — not a warning.
+        assert!(!unrec(None));
+        // Every recognized name (either case) is accepted silently.
+        for b in super::BACKENDS {
+            assert!(!unrec(Some(b)), "lower {b}");
+            assert!(!unrec(Some(&b.to_uppercase())), "upper {b}");
+        }
+        // A typo or a backend name from a newer glass is flagged, as is an empty value.
+        assert!(unrec(Some("andriod")));
+        assert!(unrec(Some("vnc")));
+        assert!(unrec(Some("")));
+        // No trimming: a stray space/newline (env-file or copy-paste) is unrecognized, so it
+        // warns + host-defaults rather than being silently accepted. Pins the no-trim contract.
+        assert!(unrec(Some("wayland ")));
+        assert!(unrec(Some(" x11")));
+    }
+
+    #[test]
+    fn host_default_backend_is_itself_a_recognized_backend() {
+        // `default_backend`'s fallback must be a real BACKENDS entry, or the resolver could
+        // hand `make_platform`/`capabilities_for` a name they'd reject.
+        assert!(super::BACKENDS.contains(&super::host_default_backend()));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`default_backend` resolved `GLASS_BACKEND` against the accepted backend names and, for any unrecognized value, silently fell back to a hardcoded `"x11"`. A typo (`GLASS_BACKEND=andriod`) or a value from a newer glass made every default `glass_start` launch under x11 with no log or error — the session-wide default, so it hit every `glass_start` that omits an explicit `backend`. This contradicts glass's **no silent fallbacks** invariant (the explicit-param path already errors loudly for an unknown backend; only the env-var path was silent).

Fixes #148.

## Change

- **Unset *and* set-but-unrecognized** now fall back to the host default (`host_default_backend`: windows/macos/x11 by platform). A typo lands on the same backend an unset var would, instead of surprising a mac/windows host with an x11 it can't even construct.
- **`boot()`** logs a one-line stderr warning naming the value and the recognized backends when `GLASS_BACKEND` is set but unrecognized. (stdout carries the MCP protocol, so diagnostics go to stderr.)
- **`glass_doctor`** — the "default backend" check goes `Ok` → `Warn` on an unrecognized value, echoes the raw value (quoted, so an empty/whitespace value stays visible), and carries a remedy listing the valid backends. `Warn` is non-fatal — doctor still exits 0.
- **`glass_capabilities`** (`render_json`) attaches a `warning` field when the default resolves from an unrecognized `GLASS_BACKEND`, closing the same silent path on that tool.

A single `recognized_backend` predicate now backs the resolver, the warning check, and the capability report, so "which values are recognized" can't drift between them.

```
⚠ default backend: x11 (GLASS_BACKEND = "andriod" is not a recognized backend; using x11)
    → unset GLASS_BACKEND or set it to one of: x11, wayland, windows, macos, android, ios
```

## Tests

New unit tests (env-free — the resolution logic is pure in its input, so no process-env mutation): the recognition predicate across recognized/typo/empty/whitespace values, the host-default equivalence (`default_backend(Some("nonsense")) == default_backend(None)`, correct on every platform), a `host_default_backend ∈ BACKENDS` tripwire, the doctor `Warn`→exit-0 composition, and the capabilities `warning` field. Full workspace `fmt` + `clippy -D warnings` + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)