### PR TITLE
Generate Unsupported errors from per-backend capabilities() (#150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,10 +39,11 @@ internal refactors, CI, or test-only changes.
   duplicated backend list); the accepted backends are documented once on the `glass_start`
   `backend` param, and the per-OS clipboard/gesture/doctor specifics are collected in the
   [tools reference](docs/reference/tools.md)'s per-tool **Platform notes**.
-- When an operation isn't available on the active backend, the `Unsupported` error now names that
-  backend and points at `glass_capabilities` (which lists what the backend can do), instead of a
-  terse or sometimes misleading message — for example gesture/multi-touch on the desktop backends
-  no longer claims it is "only supported on the android backend".
+- Operation-unsupported errors now name the active backend and point at `glass_capabilities`
+  (which lists what the backend can do), instead of a terse or sometimes misleading message.
+  This covers gesture/multi-touch (every backend) and window resize/move (the mobile backends)
+  — for example the desktop backends no longer claim gestures are "only supported on the
+  android backend".
 
 ### Fixed
 - Wayland: text entry (`glass_type` and a typed `KeyEvent::Text`) is reliable under heavy machine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ internal refactors, CI, or test-only changes.
   duplicated backend list); the accepted backends are documented once on the `glass_start`
   `backend` param, and the per-OS clipboard/gesture/doctor specifics are collected in the
   [tools reference](docs/reference/tools.md)'s per-tool **Platform notes**.
+- When an operation isn't available on the active backend, the `Unsupported` error now names that
+  backend and points at `glass_capabilities` (which lists what the backend can do), instead of a
+  terse or sometimes misleading message — for example gesture/multi-touch on the desktop backends
+  no longer claims it is "only supported on the android backend".
 
 ### Fixed
 - Wayland: text entry (`glass_type` and a typed `KeyEvent::Text`) is reliable under heavy machine

--- a/crates/glass-android/src/lib.rs
+++ b/crates/glass-android/src/lib.rs
@@ -31,6 +31,9 @@ pub use target::{AdbTarget, AttachedDevice};
 
 use glass_core::capability::{CapabilityMap, CapabilityStatus};
 
+/// This backend's canonical name (matches the `glass_capabilities` / `GLASS_BACKEND` value).
+pub const BACKEND: &str = "android";
+
 /// This backend's live capability map. `input` degrades and `multi_touch`/`clipboard`
 /// need the on-device agent — gated on [`agent::agent_enabled`], the same predicate the
 /// runtime uses to pick `AgentInjector` vs `ShellInjector`, so this can't disagree with
@@ -114,5 +117,18 @@ mod capability_tests {
             .unwrap()
             .contains("GLASS_ANDROID_A11Y_APK"));
         assert_eq!(c.window_move_resize.status, Support::Unsupported);
+    }
+
+    #[test]
+    fn window_move_resize_unsupported_message_names_the_android_backend() {
+        let msg = glass_core::GlassError::unsupported(
+            "window_move_resize",
+            crate::BACKEND,
+            crate::capabilities().window_move_resize.note,
+        )
+        .to_string();
+        assert!(msg.contains("android backend"), "{msg}");
+        assert!(msg.contains("full-screen"), "{msg}");
+        assert!(msg.contains("glass_capabilities"), "{msg}");
     }
 }

--- a/crates/glass-android/src/lib.rs
+++ b/crates/glass-android/src/lib.rs
@@ -76,6 +76,16 @@ fn capabilities_with(agent: bool, a11y_apk: bool) -> CapabilityMap {
     }
 }
 
+/// The `Unsupported` error this backend returns for window move/resize — one source for
+/// the call site (`window()`'s `Resize`/`Move` arm) and its test.
+pub(crate) fn unsupported_window_move_resize() -> glass_core::GlassError {
+    glass_core::GlassError::unsupported(
+        "window_move_resize",
+        BACKEND,
+        capabilities().window_move_resize.note,
+    )
+}
+
 #[cfg(test)]
 mod capability_tests {
     use super::*;
@@ -121,12 +131,7 @@ mod capability_tests {
 
     #[test]
     fn window_move_resize_unsupported_message_names_the_android_backend() {
-        let msg = glass_core::GlassError::unsupported(
-            "window_move_resize",
-            crate::BACKEND,
-            crate::capabilities().window_move_resize.note,
-        )
-        .to_string();
+        let msg = crate::unsupported_window_move_resize().to_string();
         assert!(msg.contains("android backend"), "{msg}");
         assert!(msg.contains("full-screen"), "{msg}");
         assert!(msg.contains("glass_capabilities"), "{msg}");

--- a/crates/glass-android/src/platform.rs
+++ b/crates/glass-android/src/platform.rs
@@ -248,8 +248,10 @@ impl Platform for AndroidPlatform {
                 app.window = window.clone();
                 Ok(window)
             }
-            WindowOp::Resize { .. } | WindowOp::Move { .. } => Err(GlassError::Unsupported(
-                "window resize/move (Android apps are full-screen)".into(),
+            WindowOp::Resize { .. } | WindowOp::Move { .. } => Err(GlassError::unsupported(
+                "window_move_resize",
+                crate::BACKEND,
+                crate::capabilities().window_move_resize.note,
             )),
         }
     }

--- a/crates/glass-android/src/platform.rs
+++ b/crates/glass-android/src/platform.rs
@@ -248,11 +248,9 @@ impl Platform for AndroidPlatform {
                 app.window = window.clone();
                 Ok(window)
             }
-            WindowOp::Resize { .. } | WindowOp::Move { .. } => Err(GlassError::unsupported(
-                "window_move_resize",
-                crate::BACKEND,
-                crate::capabilities().window_move_resize.note,
-            )),
+            WindowOp::Resize { .. } | WindowOp::Move { .. } => {
+                Err(crate::unsupported_window_move_resize())
+            }
         }
     }
 

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -103,13 +103,15 @@ pub enum GlassError {
 
 impl GlassError {
     /// Runtime "this operation is unsupported on the active backend" error, worded
-    /// consistently and generated from the backend's own capability map.
+    /// consistently.
     ///
-    /// `operation` is the [`crate::CapabilityMap`] field key (e.g. `"multi_touch"`) so
-    /// the message matches exactly what `glass_capabilities` prints — the agent can
-    /// cross-reference the two. `backend` is the **active** backend's name. `note` is that
-    /// capability's own note (single source), folded in when present. Always points the
-    /// agent at `glass_capabilities`.
+    /// Callers pass the capability's own key and `note` (read from that backend's
+    /// [`crate::CapabilityMap`]), so the message stays in sync with that backend's
+    /// capability map without this constructor reaching into it itself. `operation` is
+    /// the [`crate::CapabilityMap`] field key (e.g. `"multi_touch"`); the message embeds
+    /// it verbatim, so it is the exact key `glass_capabilities` lists — the agent can
+    /// cross-reference the two. `backend` is the **active** backend's name. `note` is
+    /// folded in when present. Always points the agent at `glass_capabilities`.
     pub fn unsupported(operation: &str, backend: &str, note: Option<&str>) -> Self {
         use std::fmt::Write as _;
         let mut msg = format!("{operation} is not supported by the {backend} backend");

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -85,7 +85,7 @@ pub enum GlassError {
     #[error("{0}")]
     SandboxUnavailable(String),
 
-    #[error("{0} is not supported by this backend")]
+    #[error("{0}")]
     Unsupported(String),
 
     /// A required OS permission is not granted. Carries which permission and how to
@@ -99,6 +99,26 @@ pub enum GlassError {
 
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
+}
+
+impl GlassError {
+    /// Runtime "this operation is unsupported on the active backend" error, worded
+    /// consistently and generated from the backend's own capability map.
+    ///
+    /// `operation` is the [`crate::CapabilityMap`] field key (e.g. `"multi_touch"`) so
+    /// the message matches exactly what `glass_capabilities` prints — the agent can
+    /// cross-reference the two. `backend` is the **active** backend's name. `note` is that
+    /// capability's own note (single source), folded in when present. Always points the
+    /// agent at `glass_capabilities`.
+    pub fn unsupported(operation: &str, backend: &str, note: Option<&str>) -> Self {
+        use std::fmt::Write as _;
+        let mut msg = format!("{operation} is not supported by the {backend} backend");
+        if let Some(n) = note {
+            let _ = write!(msg, " ({n})");
+        }
+        msg.push_str("; call glass_capabilities to see what this backend can do");
+        GlassError::Unsupported(msg)
+    }
 }
 
 /// Convenience alias used throughout glass-core.
@@ -168,9 +188,43 @@ mod tests {
 
     #[test]
     fn unsupported_message_is_actionable() {
+        // Default trait impls that cannot know the active backend keep the generic phrase.
         assert_eq!(
-            GlassError::Unsupported("clipboard".into()).to_string(),
+            GlassError::Unsupported("clipboard is not supported by this backend".into())
+                .to_string(),
             "clipboard is not supported by this backend"
+        );
+    }
+
+    #[test]
+    fn unsupported_display_is_the_raw_payload() {
+        assert_eq!(
+            GlassError::Unsupported("anything at all".into()).to_string(),
+            "anything at all"
+        );
+    }
+
+    #[test]
+    fn unsupported_constructor_names_backend_and_points_at_capabilities() {
+        let e = GlassError::unsupported("multi_touch", "x11", None);
+        assert_eq!(
+            e.to_string(),
+            "multi_touch is not supported by the x11 backend; \
+             call glass_capabilities to see what this backend can do"
+        );
+    }
+
+    #[test]
+    fn unsupported_constructor_folds_in_the_note_when_present() {
+        let e = GlassError::unsupported(
+            "window_move_resize",
+            "android",
+            Some("apps are full-screen"),
+        );
+        assert_eq!(
+            e.to_string(),
+            "window_move_resize is not supported by the android backend (apps are full-screen); \
+             call glass_capabilities to see what this backend can do"
         );
     }
 

--- a/crates/glass-core/src/platform.rs
+++ b/crates/glass-core/src/platform.rs
@@ -188,7 +188,9 @@ pub trait Platform {
     /// whole window. `WindowNotFound` if `id` is not currently one of the app's
     /// windows. Default: unsupported.
     fn capture_window(&mut self, _id: WindowId, _region: Option<&Region>) -> Result<Frame> {
-        Err(GlassError::Unsupported("capture_window".into()))
+        Err(GlassError::Unsupported(
+            "capture_window is not supported by this backend".into(),
+        ))
     }
 
     /// Inject a pointer event (coordinates are window-relative).
@@ -199,12 +201,16 @@ pub trait Platform {
 
     /// Read the clipboard as UTF-8 text ("" if it holds no text).
     fn get_clipboard(&mut self) -> Result<String> {
-        Err(GlassError::Unsupported("clipboard".into()))
+        Err(GlassError::Unsupported(
+            "clipboard is not supported by this backend".into(),
+        ))
     }
     /// Write UTF-8 text to the clipboard. On X11/Wayland this installs a
     /// session-lived serving owner; it is torn down on `stop_app`.
     fn set_clipboard(&mut self, _text: &str) -> Result<()> {
-        Err(GlassError::Unsupported("clipboard".into()))
+        Err(GlassError::Unsupported(
+            "clipboard is not supported by this backend".into(),
+        ))
     }
 
     /// Perform a window operation, returning the resulting geometry.

--- a/crates/glass-ios/src/injector/mod.rs
+++ b/crates/glass-ios/src/injector/mod.rs
@@ -125,8 +125,10 @@ impl IdbInjector {
                 vec![swipe(point(x, y, s), point(ex, ey, s), SWIPE_SECS)]
             }
             PointerEvent::Gesture { .. } => {
-                return Err(GlassError::Unsupported(
-                    "multi-touch gestures are not supported by the iOS backend yet".into(),
+                return Err(GlassError::unsupported(
+                    "multi_touch",
+                    crate::BACKEND,
+                    crate::capabilities().multi_touch.note,
                 ))
             }
         })

--- a/crates/glass-ios/src/injector/mod.rs
+++ b/crates/glass-ios/src/injector/mod.rs
@@ -87,8 +87,10 @@ impl IdbInjector {
     /// Maps one glass `PointerEvent` to the idb HID events that reproduce it as a
     /// touch: a `Click` is a touch DOWN then UP at the same point (repeated `count`
     /// times); a `Drag`/`Scroll` is a single swipe; a `Move` is empty — touch has no
-    /// hover state to emit. `Gesture` (multi-touch) is not implemented yet and
-    /// returns `Unsupported` rather than silently dropping the pointers.
+    /// hover state to emit. `Gesture` (multi-touch) returns `Unsupported` rather than
+    /// silently dropping the pointers: idb's raw-touch primitive is single-contact
+    /// (a second concurrent DOWN relocates the same finger), so there is no general
+    /// N-finger primitive to map it to.
     pub fn pointer_events(&self, e: &PointerEvent) -> Result<Vec<proto::HidEvent>> {
         let s = self.scale;
         Ok(match *e {

--- a/crates/glass-ios/src/injector/mod.rs
+++ b/crates/glass-ios/src/injector/mod.rs
@@ -308,10 +308,13 @@ mod pointer_tests {
             pointers: vec![],
             duration_ms: 100,
         };
-        assert!(matches!(
-            inj.pointer_events(&g),
-            Err(glass_core::GlassError::Unsupported(_))
-        ));
+        let err = inj.pointer_events(&g).unwrap_err();
+        assert!(matches!(err, glass_core::GlassError::Unsupported(_)));
+        let msg = err.to_string();
+        assert!(msg.contains("ios backend"), "{msg}");
+        assert!(msg.contains("multi_touch"), "{msg}");
+        assert!(msg.contains("glass_capabilities"), "{msg}");
+        assert!(msg.contains("single-contact"), "{msg}");
     }
 
     #[test]

--- a/crates/glass-ios/src/lib.rs
+++ b/crates/glass-ios/src/lib.rs
@@ -26,6 +26,9 @@ pub use target::{SimTarget, SimulatorRegistry};
 
 use glass_core::capability::{CapabilityMap, CapabilityStatus, Support};
 
+/// This backend's canonical name (matches the `glass_capabilities` / `GLASS_BACKEND` value).
+pub const BACKEND: &str = "ios";
+
 /// This backend's live capability map. `input`/`accessibility` need `idb_companion` —
 /// gated on [`doctor::companion_present`], the same presence signal the runtime spawn
 /// resolves.
@@ -96,5 +99,33 @@ mod capability_tests {
             Some("paste needs on-screen consent (Allow Paste)")
         );
         assert_eq!(c.window_move_resize.status, Support::Unsupported);
+    }
+}
+
+#[cfg(test)]
+mod unsupported_message_tests {
+    #[test]
+    fn multi_touch_unsupported_message_names_the_ios_backend_with_note() {
+        let msg = glass_core::GlassError::unsupported(
+            "multi_touch",
+            crate::BACKEND,
+            crate::capabilities().multi_touch.note,
+        )
+        .to_string();
+        assert!(msg.contains("ios backend"), "{msg}");
+        assert!(msg.contains("single-contact"), "{msg}");
+        assert!(msg.contains("glass_capabilities"), "{msg}");
+    }
+
+    #[test]
+    fn window_move_resize_unsupported_message_names_the_ios_backend() {
+        let msg = glass_core::GlassError::unsupported(
+            "window_move_resize",
+            crate::BACKEND,
+            crate::capabilities().window_move_resize.note,
+        )
+        .to_string();
+        assert!(msg.contains("ios backend"), "{msg}");
+        assert!(msg.contains("full-screen"), "{msg}");
     }
 }

--- a/crates/glass-ios/src/lib.rs
+++ b/crates/glass-ios/src/lib.rs
@@ -4,7 +4,8 @@
 //! platform-specific — it shells out. The Simulator is the isolation boundary,
 //! so there is no sandbox machinery here. The backend drives input (tap, type,
 //! swipe, scroll) and reads the accessibility tree via `idb_companion`;
-//! multi-touch gestures are not yet supported.
+//! multi-touch gestures are unsupported — `idb`'s raw-touch primitive is
+//! single-contact, with no general N-finger primitive to drive them.
 #![forbid(unsafe_code)]
 
 mod a11y;

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -743,6 +743,11 @@ mod state_machine_tests {
             })
             .unwrap_err();
         assert!(matches!(err, GlassError::Unsupported(_)), "{err:?}");
+        let msg = err.to_string();
+        assert!(msg.contains("ios backend"), "{msg}");
+        assert!(msg.contains("window_move_resize"), "{msg}");
+        assert!(msg.contains("full-screen"), "{msg}");
+        assert!(msg.contains("glass_capabilities"), "{msg}");
     }
 
     #[test]
@@ -750,6 +755,11 @@ mod state_machine_tests {
         let mut p = running_platform();
         let err = p.window(&WindowOp::Move { x: 1, y: 1 }).unwrap_err();
         assert!(matches!(err, GlassError::Unsupported(_)), "{err:?}");
+        let msg = err.to_string();
+        assert!(msg.contains("ios backend"), "{msg}");
+        assert!(msg.contains("window_move_resize"), "{msg}");
+        assert!(msg.contains("full-screen"), "{msg}");
+        assert!(msg.contains("glass_capabilities"), "{msg}");
     }
 
     #[test]

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -442,8 +442,10 @@ impl Platform for IosPlatform {
         let geometry = self.running()?.geometry.clone();
         match op {
             WindowOp::Geometry | WindowOp::Focus => Ok(geometry),
-            WindowOp::Resize { .. } | WindowOp::Move { .. } => Err(GlassError::Unsupported(
-                "window resize/move (iOS Simulator apps are fullscreen)".into(),
+            WindowOp::Resize { .. } | WindowOp::Move { .. } => Err(GlassError::unsupported(
+                "window_move_resize",
+                crate::BACKEND,
+                crate::capabilities().window_move_resize.note,
             )),
         }
     }

--- a/crates/glass-macos/src/input.rs
+++ b/crates/glass-macos/src/input.rs
@@ -83,8 +83,10 @@ pub(crate) fn send_pointer(
     // that can never succeed (also keeps `focus`'s now-fallible missing-process check, fix
     // 4, from masking this call-shape error behind an unrelated `AppExited`).
     if matches!(event, PointerEvent::Gesture { .. }) {
-        return Err(GlassError::Unsupported(
-            "multi-touch gesture is not supported on macOS".into(),
+        return Err(GlassError::unsupported(
+            "multi_touch",
+            crate::BACKEND,
+            crate::capabilities().multi_touch.note,
         ));
     }
     focus(pid)?;
@@ -173,8 +175,10 @@ pub(crate) fn send_pointer(
         // match stays exhaustive over `PointerEvent`'s variants and a future variant added
         // to the enum still forces an explicit decision at this call site.
         PointerEvent::Gesture { .. } => {
-            return Err(GlassError::Unsupported(
-                "multi-touch gesture is not supported on macOS".into(),
+            return Err(GlassError::unsupported(
+                "multi_touch",
+                crate::BACKEND,
+                crate::capabilities().multi_touch.note,
             ));
         }
     }

--- a/crates/glass-macos/src/input.rs
+++ b/crates/glass-macos/src/input.rs
@@ -593,6 +593,10 @@ mod tests {
             matches!(&err, Err(GlassError::Unsupported(_))),
             "expected Unsupported, got {err:?}"
         );
+        let msg = err.unwrap_err().to_string();
+        assert!(msg.contains("macos backend"), "{msg}");
+        assert!(msg.contains("multi_touch"), "{msg}");
+        assert!(msg.contains("glass_capabilities"), "{msg}");
     }
 
     #[test]

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -85,6 +85,9 @@ pub use permissions::{
 #[cfg(target_os = "macos")]
 pub use session::{session_locked, session_state, SessionState};
 
+/// This backend's canonical name (matches the `glass_capabilities` / `GLASS_BACKEND` value).
+pub const BACKEND: &str = "macos";
+
 // Kept last: a `#[cfg(test)]` module must not be followed by other items
 // (clippy::items_after_test_module), and the macOS-gated `pub use`s above are absent off
 // macOS — so this test module goes at the end of the file where nothing can follow it.
@@ -101,5 +104,17 @@ mod capability_tests {
         assert_eq!(c.clipboard.status, Support::Supported);
         assert_eq!(c.accessibility.status, Support::Supported);
         assert_eq!(c.window_move_resize.status, Support::Supported);
+    }
+
+    #[test]
+    fn multi_touch_unsupported_message_names_the_macos_backend() {
+        let msg = glass_core::GlassError::unsupported(
+            "multi_touch",
+            crate::BACKEND,
+            crate::capabilities().multi_touch.note,
+        )
+        .to_string();
+        assert!(msg.contains("macos backend"), "{msg}");
+        assert!(msg.contains("glass_capabilities"), "{msg}");
     }
 }

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -116,5 +116,6 @@ mod capability_tests {
         .to_string();
         assert!(msg.contains("macos backend"), "{msg}");
         assert!(msg.contains("glass_capabilities"), "{msg}");
+        assert!(!msg.contains("android"), "{msg}");
     }
 }

--- a/crates/glass-mcp/src/capabilities.rs
+++ b/crates/glass-mcp/src/capabilities.rs
@@ -319,6 +319,65 @@ mod tests {
         assert!(v["capabilities"]["input"].get("note").is_none());
     }
 
+    /// Ties each compiled-in backend's `glass_<x>::BACKEND` const to this crate's own
+    /// registry ([`crate::BACKENDS`]) and dispatch ([`capabilities_for`]) — so a backend
+    /// crate renaming its `BACKEND` const (a drifting third copy of the backend name,
+    /// alongside `BACKENDS` and the `capabilities_for` match arms) fails here instead of
+    /// silently reporting `NotOnThisHost` at runtime. Gated exactly like `capabilities_for`
+    /// itself: android is always compiled in; the rest per host OS.
+    mod backend_const_matches_registry {
+        use super::*;
+
+        #[test]
+        fn android() {
+            assert!(crate::BACKENDS.contains(&glass_android::BACKEND));
+            assert!(matches!(
+                capabilities_for(glass_android::BACKEND),
+                Some(CapabilityReport::Available(_))
+            ));
+        }
+
+        #[cfg(target_os = "linux")]
+        #[test]
+        fn x11_and_wayland() {
+            assert!(crate::BACKENDS.contains(&glass_x11::BACKEND));
+            assert!(matches!(
+                capabilities_for(glass_x11::BACKEND),
+                Some(CapabilityReport::Available(_))
+            ));
+            assert!(crate::BACKENDS.contains(&glass_wayland::BACKEND));
+            assert!(matches!(
+                capabilities_for(glass_wayland::BACKEND),
+                Some(CapabilityReport::Available(_))
+            ));
+        }
+
+        #[cfg(windows)]
+        #[test]
+        fn windows() {
+            assert!(crate::BACKENDS.contains(&glass_windows::BACKEND));
+            assert!(matches!(
+                capabilities_for(glass_windows::BACKEND),
+                Some(CapabilityReport::Available(_))
+            ));
+        }
+
+        #[cfg(target_os = "macos")]
+        #[test]
+        fn macos_and_ios() {
+            assert!(crate::BACKENDS.contains(&glass_macos::BACKEND));
+            assert!(matches!(
+                capabilities_for(glass_macos::BACKEND),
+                Some(CapabilityReport::Available(_))
+            ));
+            assert!(crate::BACKENDS.contains(&glass_ios::BACKEND));
+            assert!(matches!(
+                capabilities_for(glass_ios::BACKEND),
+                Some(CapabilityReport::Available(_))
+            ));
+        }
+    }
+
     #[test]
     fn operation_tools_covers_every_rendered_operation() {
         use glass_core::capability::{CapabilityMap, CapabilityStatus};

--- a/crates/glass-wayland/src/lib.rs
+++ b/crates/glass-wayland/src/lib.rs
@@ -15,6 +15,9 @@ pub mod swayipc;
 
 pub use platform::WaylandPlatform;
 
+/// This backend's canonical name (matches the `glass_capabilities` / `GLASS_BACKEND` value).
+pub const BACKEND: &str = "wayland";
+
 /// This backend's capability map. All cells are code-constant here (desktop
 /// accessibility is reported Supported when the backend ships an a11y reader; per-OS
 /// grants — macOS TCC, Linux AT-SPI — are surfaced by `glass_doctor`).
@@ -41,5 +44,18 @@ mod capability_tests {
         assert_eq!(c.clipboard.status, Support::Supported);
         assert_eq!(c.accessibility.status, Support::Supported);
         assert_eq!(c.window_move_resize.status, Support::Supported);
+    }
+
+    #[test]
+    fn multi_touch_unsupported_message_names_this_backend_not_android() {
+        let msg = glass_core::GlassError::unsupported(
+            "multi_touch",
+            crate::BACKEND,
+            crate::capabilities().multi_touch.note,
+        )
+        .to_string();
+        assert!(msg.contains("wayland backend"), "{msg}");
+        assert!(msg.contains("glass_capabilities"), "{msg}");
+        assert!(!msg.contains("android"), "{msg}");
     }
 }

--- a/crates/glass-wayland/src/lib.rs
+++ b/crates/glass-wayland/src/lib.rs
@@ -31,6 +31,12 @@ pub fn capabilities() -> CapabilityMap {
     }
 }
 
+/// The `Unsupported` error this backend returns for a multi-touch gesture — one source
+/// for the call site (`send_pointer`'s `Gesture` arm) and its test.
+pub(crate) fn unsupported_multi_touch() -> glass_core::GlassError {
+    glass_core::GlassError::unsupported("multi_touch", BACKEND, capabilities().multi_touch.note)
+}
+
 #[cfg(test)]
 mod capability_tests {
     use super::capabilities;
@@ -48,12 +54,7 @@ mod capability_tests {
 
     #[test]
     fn multi_touch_unsupported_message_names_this_backend_not_android() {
-        let msg = glass_core::GlassError::unsupported(
-            "multi_touch",
-            crate::BACKEND,
-            crate::capabilities().multi_touch.note,
-        )
-        .to_string();
+        let msg = crate::unsupported_multi_touch().to_string();
         assert!(msg.contains("wayland backend"), "{msg}");
         assert!(msg.contains("glass_capabilities"), "{msg}");
         assert!(!msg.contains("android"), "{msg}");

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -1169,8 +1169,10 @@ impl Platform for WaylandPlatform {
                 glass_core::run_scroll(&mut sink, !modifiers.is_empty())?;
             }
             PointerEvent::Gesture { .. } => {
-                return Err(GlassError::Unsupported(
-                    "multi-touch gestures are only supported on the android backend".into(),
+                return Err(GlassError::unsupported(
+                    "multi_touch",
+                    crate::BACKEND,
+                    crate::capabilities().multi_touch.note,
                 ));
             }
         }

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -1169,11 +1169,7 @@ impl Platform for WaylandPlatform {
                 glass_core::run_scroll(&mut sink, !modifiers.is_empty())?;
             }
             PointerEvent::Gesture { .. } => {
-                return Err(GlassError::unsupported(
-                    "multi_touch",
-                    crate::BACKEND,
-                    crate::capabilities().multi_touch.note,
-                ));
+                return Err(crate::unsupported_multi_touch());
             }
         }
         session

--- a/crates/glass-windows/src/input.rs
+++ b/crates/glass-windows/src/input.rs
@@ -404,8 +404,10 @@ pub(crate) fn send_pointer(active_hwnd: isize, event: &PointerEvent) -> Result<(
             glass_core::run_scroll(&mut sink, !modifiers.is_empty())?;
         }
         PointerEvent::Gesture { .. } => {
-            return Err(GlassError::Unsupported(
-                "multi-touch gestures are only supported on the android backend".into(),
+            return Err(GlassError::unsupported(
+                "multi_touch",
+                crate::BACKEND,
+                crate::capabilities().multi_touch.note,
             ));
         }
     }

--- a/crates/glass-windows/src/input.rs
+++ b/crates/glass-windows/src/input.rs
@@ -404,11 +404,7 @@ pub(crate) fn send_pointer(active_hwnd: isize, event: &PointerEvent) -> Result<(
             glass_core::run_scroll(&mut sink, !modifiers.is_empty())?;
         }
         PointerEvent::Gesture { .. } => {
-            return Err(GlassError::unsupported(
-                "multi_touch",
-                crate::BACKEND,
-                crate::capabilities().multi_touch.note,
-            ));
+            return Err(crate::unsupported_multi_touch());
         }
     }
     Ok(())

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -55,6 +55,12 @@ pub fn capabilities() -> CapabilityMap {
     }
 }
 
+/// The `Unsupported` error this backend returns for a multi-touch gesture — one source
+/// for the call site (`send_pointer`'s `Gesture` arm) and its test.
+pub(crate) fn unsupported_multi_touch() -> glass_core::GlassError {
+    glass_core::GlassError::unsupported("multi_touch", BACKEND, capabilities().multi_touch.note)
+}
+
 #[cfg(windows)]
 mod capture;
 #[cfg(windows)]
@@ -382,12 +388,7 @@ mod capability_tests {
 
     #[test]
     fn multi_touch_unsupported_message_names_this_backend_not_android() {
-        let msg = glass_core::GlassError::unsupported(
-            "multi_touch",
-            crate::BACKEND,
-            crate::capabilities().multi_touch.note,
-        )
-        .to_string();
+        let msg = crate::unsupported_multi_touch().to_string();
         assert!(msg.contains("windows backend"), "{msg}");
         assert!(msg.contains("glass_capabilities"), "{msg}");
         assert!(!msg.contains("android"), "{msg}");

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -24,6 +24,9 @@ pub mod onbox_support;
 pub mod pixels; // pure BGRA->RGBA swizzle — cross-platform, unit-tested on the Linux dev box
 pub mod vkmap; // pure named-keysym->VK map — cross-platform, unit-tested on the Linux dev box // env-resolved paths shared by the on-box examples + tests; host-tested
 
+/// This backend's canonical name (matches the `glass_capabilities` / `GLASS_BACKEND` value).
+pub const BACKEND: &str = "windows";
+
 /// One-time stderr note when a contained app can't get a private clipboard (hook DLL missing):
 /// the app's clipboard is disabled to protect the user's — never a silent revert to sharing it.
 #[cfg(windows)]
@@ -375,5 +378,18 @@ mod capability_tests {
         assert_eq!(c.clipboard.status, Support::Supported);
         assert_eq!(c.accessibility.status, Support::Supported);
         assert_eq!(c.window_move_resize.status, Support::Supported);
+    }
+
+    #[test]
+    fn multi_touch_unsupported_message_names_this_backend_not_android() {
+        let msg = glass_core::GlassError::unsupported(
+            "multi_touch",
+            crate::BACKEND,
+            crate::capabilities().multi_touch.note,
+        )
+        .to_string();
+        assert!(msg.contains("windows backend"), "{msg}");
+        assert!(msg.contains("glass_capabilities"), "{msg}");
+        assert!(!msg.contains("android"), "{msg}");
     }
 }

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -57,6 +57,9 @@ pub fn capabilities() -> CapabilityMap {
 
 /// The `Unsupported` error this backend returns for a multi-touch gesture — one source
 /// for the call site (`send_pointer`'s `Gesture` arm) and its test.
+// Consumed only by the cfg(windows) `input::send_pointer` and the Linux unit test, so a
+// non-test Linux build sees this as dead (mirrors jobcfg.rs/doctor.rs in this crate).
+#[cfg_attr(not(windows), allow(dead_code))]
 pub(crate) fn unsupported_multi_touch() -> glass_core::GlassError {
     glass_core::GlassError::unsupported("multi_touch", BACKEND, capabilities().multi_touch.note)
 }

--- a/crates/glass-x11/src/lib.rs
+++ b/crates/glass-x11/src/lib.rs
@@ -14,6 +14,9 @@ pub mod xvfb;
 pub use platform::X11Platform;
 pub use xvfb::Xvfb;
 
+/// This backend's canonical name (matches the `glass_capabilities` / `GLASS_BACKEND` value).
+pub const BACKEND: &str = "x11";
+
 /// This backend's capability map. All cells are code-constant here (desktop
 /// accessibility is reported Supported when the backend ships an a11y reader; per-OS
 /// grants — macOS TCC, Linux AT-SPI — are surfaced by `glass_doctor`).
@@ -40,5 +43,18 @@ mod capability_tests {
         assert_eq!(c.clipboard.status, Support::Supported);
         assert_eq!(c.accessibility.status, Support::Supported);
         assert_eq!(c.window_move_resize.status, Support::Supported);
+    }
+
+    #[test]
+    fn multi_touch_unsupported_message_names_this_backend_not_android() {
+        let msg = glass_core::GlassError::unsupported(
+            "multi_touch",
+            crate::BACKEND,
+            crate::capabilities().multi_touch.note,
+        )
+        .to_string();
+        assert!(msg.contains("x11 backend"), "{msg}");
+        assert!(msg.contains("glass_capabilities"), "{msg}");
+        assert!(!msg.contains("android"), "{msg}");
     }
 }

--- a/crates/glass-x11/src/lib.rs
+++ b/crates/glass-x11/src/lib.rs
@@ -30,6 +30,12 @@ pub fn capabilities() -> CapabilityMap {
     }
 }
 
+/// The `Unsupported` error this backend returns for a multi-touch gesture — one source
+/// for the call site (`send_pointer`'s `Gesture` arm) and its test.
+pub(crate) fn unsupported_multi_touch() -> glass_core::GlassError {
+    glass_core::GlassError::unsupported("multi_touch", BACKEND, capabilities().multi_touch.note)
+}
+
 #[cfg(test)]
 mod capability_tests {
     use super::capabilities;
@@ -47,12 +53,7 @@ mod capability_tests {
 
     #[test]
     fn multi_touch_unsupported_message_names_this_backend_not_android() {
-        let msg = glass_core::GlassError::unsupported(
-            "multi_touch",
-            crate::BACKEND,
-            crate::capabilities().multi_touch.note,
-        )
-        .to_string();
+        let msg = crate::unsupported_multi_touch().to_string();
         assert!(msg.contains("x11 backend"), "{msg}");
         assert!(msg.contains("glass_capabilities"), "{msg}");
         assert!(!msg.contains("android"), "{msg}");

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -1033,11 +1033,7 @@ impl Platform for X11Platform {
                 glass_core::run_drag(&mut sink, &gesture)?;
             }
             PointerEvent::Gesture { .. } => {
-                return Err(GlassError::unsupported(
-                    "multi_touch",
-                    crate::BACKEND,
-                    crate::capabilities().multi_touch.note,
-                ));
+                return Err(crate::unsupported_multi_touch());
             }
         }
         self.conn

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -1033,8 +1033,10 @@ impl Platform for X11Platform {
                 glass_core::run_drag(&mut sink, &gesture)?;
             }
             PointerEvent::Gesture { .. } => {
-                return Err(GlassError::Unsupported(
-                    "multi-touch gestures are only supported on the android backend".into(),
+                return Err(GlassError::unsupported(
+                    "multi_touch",
+                    crate::BACKEND,
+                    crate::capabilities().multi_touch.note,
                 ));
             }
         }


### PR DESCRIPTION
Closes #150.

Runtime `GlassError::Unsupported` messages were ad-hoc and duplicated across backend crates, and — because the variant's `Display` was `"{0} is not supported by this backend"` — full-sentence payloads (e.g. the three backends carrying the literal "multi-touch gestures are only supported on the android backend") rendered garbled and named a *different* backend.

This change:
- Renders `Unsupported`'s payload verbatim (`#[error("{0}")]`) and adds `GlassError::unsupported(operation, backend, note)`, which names the **active** backend and points the agent at `glass_capabilities`, with the explanation single-sourced from that backend's own capability map.
- Adds `pub const BACKEND` per backend crate (validated against the `glass_capabilities`/`GLASS_BACKEND` registry by a new test).
- Rewrites the operation-level constant `Unsupported` sites — multi-touch (all backends) and window resize/move (the mobile backends) — to use it, via a small per-crate helper the call site and its test share (so the test drives the real construction code).
- Fixes 3 core default trait impls that relied on the old suffix; tightens the related docs + CHANGELOG.

Example — `glass_gesture` on x11 now returns:
`multi_touch is not supported by the x11 backend; call glass_capabilities to see what this backend can do`

**Verification:** `cargo test --workspace` + `clippy --all-targets -D warnings` + `fmt --check` on Linux; glass-windows via the windows cross-target clippy; glass-macos / glass-ios / glass-mcp built and tested on macOS (incl. the new backend-const registry test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)