### PR TITLE
Make desktop-backend accessibility a live capability (#151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,12 @@ internal refactors, CI, or test-only changes.
   e.g. Android's adb-only input without its on-device agent), `requires_setup`, or `unsupported`
   — plus the specific tools that operation gates (e.g. `accessibility` names
   `glass_a11y_snapshot`, `glass_click_element`, and friends), so a degraded or blocked entry
-  points straight at the tool calls it affects. Takes an optional `backend` (defaults to the
-  active one); a backend not built into the running binary reports `available: false`.
+  points straight at the tool calls it affects. `accessibility` is reported live on every
+  backend — the desktop backends read `requires_setup` when their a11y stack isn't ready (the
+  Linux AT-SPI runtime isn't installed, the macOS Accessibility permission isn't granted, or
+  Windows UI Automation can't initialize) rather than a blanket `supported`. Takes an optional
+  `backend` (defaults to the active one); a backend not built into the running binary reports
+  `available: false`.
 - `glass_scroll_to_element` now drives **horizontal** containers, not just vertical: `direction`
   accepts `left`/`right` as well as `up`/`down`, and when omitted it **infers** the direction from
   the target's off-screen position. It anchors the scroll on the target's own row/column, so a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,6 +1312,7 @@ name = "glass-wayland"
 version = "0.0.0"
 dependencies = [
  "criterion",
+ "glass-a11y-linux",
  "glass-core",
  "glass-dbus-linux",
  "glass-proc-linux",
@@ -1343,6 +1344,7 @@ name = "glass-x11"
 version = "0.0.0"
 dependencies = [
  "criterion",
+ "glass-a11y-linux",
  "glass-core",
  "glass-dbus-linux",
  "glass-proc-linux",

--- a/crates/glass-a11y-linux/src/doctor.rs
+++ b/crates/glass-a11y-linux/src/doctor.rs
@@ -8,7 +8,29 @@
 
 use std::time::Duration;
 
+use glass_core::capability::CapabilityStatus;
 use glass_core::{Check, CheckStatus};
+
+/// Live: is the AT-SPI bus launcher installed, so glass can spawn its private a11y bus?
+/// This is the desktop-a11y capability signal for the Linux backends — the *same* fact the
+/// doctor's head "a11y" check reads (both go through [`find_registry`]), so `glass_capabilities`
+/// and `glass doctor` can't drift. It is only a precondition ("glass can do a11y at all"), never
+/// a promise that a given window exposes a tree — that's up to the app.
+pub fn accessibility_launcher_present() -> bool {
+    find_registry().is_some()
+}
+
+/// The desktop-`accessibility` capability cell for a Linux backend, from the launcher-present
+/// signal. Shared by glass-x11 and glass-wayland (identical stacks) so their note can't drift.
+pub const fn accessibility_capability(launcher_present: bool) -> CapabilityStatus {
+    if launcher_present {
+        CapabilityStatus::supported()
+    } else {
+        CapabilityStatus::requires_setup(
+            "AT-SPI not installed; install at-spi2-core so glass can spawn its private a11y bus",
+        )
+    }
+}
 
 /// Read `/proc` for dbus-daemon entries (impure). Errors degrade to an empty list.
 fn read_proc_entries() -> Vec<ProcEntry> {
@@ -95,7 +117,7 @@ fn gather_host_a11y() -> HostA11yFacts {
 
 /// Probe whether the AT-SPI accessibility stack is usable.
 pub fn checks() -> Vec<Check> {
-    a11y_checks(find_registry().is_some(), &gather_host_a11y())
+    a11y_checks(accessibility_launcher_present(), &gather_host_a11y())
 }
 
 /// Health of the *host* (operator's desktop) AT-SPI bus — distinct from glass's private bus.
@@ -237,11 +259,26 @@ fn find_registry() -> Option<std::path::PathBuf> {
         "/usr/libexec/at-spi-bus-launcher",
         "/usr/lib/at-spi2-core/at-spi-bus-launcher",
         "/usr/lib/at-spi2/at-spi-bus-launcher",
-        "/usr/lib/x86_64-linux-gnu/at-spi2-core/at-spi-bus-launcher",
     ];
-    CANDIDATES
+    find_launcher(CANDIDATES, "/usr/lib")
+}
+
+/// Find the launcher among `fixed` absolute paths, then (if none hit) by scanning
+/// `multiarch_root/<triplet>/at-spi2-core/at-spi-bus-launcher`. The triplet directory is
+/// arch-specific (`x86_64-linux-gnu`, `aarch64-linux-gnu`, …), so scanning rather than
+/// hardcoding one arch keeps the AT-SPI-present signal correct on non-x86_64 hosts.
+fn find_launcher(fixed: &[&str], multiarch_root: &str) -> Option<std::path::PathBuf> {
+    if let Some(p) = fixed
         .iter()
         .map(std::path::PathBuf::from)
+        .find(|p| p.is_file())
+    {
+        return Some(p);
+    }
+    std::fs::read_dir(multiarch_root)
+        .ok()?
+        .flatten()
+        .map(|e| e.path().join("at-spi2-core/at-spi-bus-launcher"))
         .find(|p| p.is_file())
 }
 
@@ -274,6 +311,64 @@ fn probe_a11y_bus() -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use glass_core::capability::Support;
+
+    // ---- capability signal (shared with glass-x11 / glass-wayland `capabilities()`) ----
+    #[test]
+    fn launcher_present_predicate_matches_find_registry() {
+        // The capability signal must be the *same* fact the doctor's head check reads —
+        // one source, so `glass_capabilities` and `glass doctor` can't disagree.
+        assert_eq!(accessibility_launcher_present(), find_registry().is_some());
+    }
+
+    #[test]
+    fn accessibility_capability_supported_when_launcher_present() {
+        let c = accessibility_capability(true);
+        assert_eq!(c.status, Support::Supported);
+        assert!(c.note.is_none());
+    }
+
+    #[test]
+    fn accessibility_capability_requires_setup_when_launcher_absent() {
+        let c = accessibility_capability(false);
+        assert_eq!(c.status, Support::RequiresSetup);
+        assert!(c.note.unwrap().contains("at-spi2-core"));
+    }
+
+    // ---- launcher discovery (impure FS scan, driven with a tempdir) ----
+    #[test]
+    fn find_launcher_prefers_a_present_fixed_candidate() {
+        let dir = tempfile::tempdir().unwrap();
+        let fixed = dir.path().join("at-spi-bus-launcher");
+        std::fs::write(&fixed, b"").unwrap();
+        let fixed_str = fixed.to_str().unwrap();
+        assert_eq!(
+            find_launcher(&[fixed_str], "/nonexistent-root"),
+            Some(fixed)
+        );
+    }
+
+    #[test]
+    fn find_launcher_scans_any_multiarch_triplet_dir() {
+        // The launcher under an arbitrary <triplet>/at-spi2-core/ dir must be found — not just
+        // x86_64 (regression guard: an aarch64 host must not report AT-SPI missing).
+        let root = tempfile::tempdir().unwrap();
+        let launcher = root
+            .path()
+            .join("aarch64-linux-gnu/at-spi2-core/at-spi-bus-launcher");
+        std::fs::create_dir_all(launcher.parent().unwrap()).unwrap();
+        std::fs::write(&launcher, b"").unwrap();
+        assert_eq!(
+            find_launcher(&[], root.path().to_str().unwrap()),
+            Some(launcher)
+        );
+    }
+
+    #[test]
+    fn find_launcher_none_when_absent() {
+        let root = tempfile::tempdir().unwrap();
+        assert_eq!(find_launcher(&[], root.path().to_str().unwrap()), None);
+    }
 
     // ---- pure helpers ----
     #[test]

--- a/crates/glass-a11y-windows/src/doctor.rs
+++ b/crates/glass-a11y-windows/src/doctor.rs
@@ -2,12 +2,36 @@
 //! `a11y_checks` maps gathered facts to `Check`s and is unit-tested without UIA; `checks`
 //! gathers the real environment (UIA is creatable).
 
+use glass_core::capability::CapabilityStatus;
 use glass_core::{Check, CheckStatus};
 
 /// Probe whether UI Automation is usable.
 pub fn checks(_deep: bool) -> Vec<Check> {
     let uia_ok = probe_uia();
     a11y_checks(uia_ok)
+}
+
+/// Live: is UI Automation creatable right now? This is the desktop-`accessibility` capability
+/// signal for the Windows backend — the *same* [`probe_uia`] the doctor's check reads, so
+/// `glass_capabilities` and `glass doctor` can't drift. `false` off Windows (the backend is
+/// never dispatched there; the map still compiles for host unit tests).
+pub fn accessibility_available() -> bool {
+    probe_uia().is_ok()
+}
+
+/// The desktop-`accessibility` capability cell for the Windows backend, from the
+/// UIA-availability signal. Kept next to [`probe_uia`] so the note stays with the failure
+/// knowledge it describes. The note hedges the cause (UIA can fail to initialize for reasons
+/// beyond Session 0); the doctor's check carries the exact underlying error.
+pub const fn accessibility_capability(available: bool) -> CapabilityStatus {
+    if available {
+        CapabilityStatus::supported()
+    } else {
+        CapabilityStatus::requires_setup(
+            "UI Automation could not be initialized (commonly a non-interactive Session 0 \
+             context); run glass in an interactive desktop session",
+        )
+    }
 }
 
 /// Pure: build the a11y checks from gathered facts. `uia` is the result of actually
@@ -54,6 +78,12 @@ fn probe_uia() -> std::result::Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn accessibility_available_matches_uia_probe() {
+        // The capability signal must read the *same* probe the doctor's check uses — one
+        // source, so `glass_capabilities` and `glass doctor` can't disagree.
+        assert_eq!(accessibility_available(), probe_uia().is_ok());
+    }
     #[test]
     fn uia_ok_is_ok() {
         assert_eq!(a11y_checks(Ok(())).len(), 1);

--- a/crates/glass-macos/src/input.rs
+++ b/crates/glass-macos/src/input.rs
@@ -86,7 +86,7 @@ pub(crate) fn send_pointer(
         return Err(GlassError::unsupported(
             "multi_touch",
             crate::BACKEND,
-            crate::capabilities().multi_touch.note,
+            crate::MULTI_TOUCH.note,
         ));
     }
     focus(pid)?;

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -4,7 +4,8 @@
 //! Like `glass-windows`, the pure logic ([`keymap`], [`coords`], [`clipboard_route`],
 //! [`shim_path`]) is crate-level and unit-tested on the Linux dev box; the OS-touching
 //! modules and the `MacosPlatform` impl are gated `#[cfg(target_os = "macos")]`. Off macOS
-//! the crate exposes only the pure modules and the code-constant [`capabilities`] map.
+//! the crate exposes only the pure modules and the [`capabilities`] map (whose `accessibility`
+//! cell is live; every other cell is constant).
 
 // FFI backend: the OS-touching modules need `unsafe`, so this crate opts out of the workspace
 // `unsafe_code = "deny"`; each site carries a `// SAFETY:` note (see CLAUDE.md). The pure
@@ -54,15 +55,46 @@ pub use backend::MacosPlatform;
 #[cfg(target_os = "macos")]
 pub use ffi::init_main_thread;
 
-/// This backend's capability map. All cells are code-constant here (desktop
-/// accessibility is reported Supported when the backend ships an a11y reader; per-OS
-/// grants — macOS TCC, Linux AT-SPI — are surfaced by `glass_doctor`).
+/// This backend's capability map. Every cell but `accessibility` is code-constant; the
+/// `accessibility` cell is live — gated on the macOS Accessibility TCC grant
+/// (`AXIsProcessTrusted`, via [`accessibility_granted`]), the same predicate `glass_doctor`
+/// reads, so an ungranted process reports `requires_setup` rather than a confident
+/// `supported`.
 pub fn capabilities() -> CapabilityMap {
+    capabilities_with(accessibility_capability_live())
+}
+
+/// The live Accessibility-grant signal feeding the capability map. On macOS it is the TCC
+/// grant ([`accessibility_granted`]). Off macOS this backend is never dispatched
+/// (`capabilities_for` gates on `target_os`), so this is a compile-only stub — the map still
+/// compiles for the host unit tests, which drive [`capabilities_with`] directly.
+#[cfg(target_os = "macos")]
+fn accessibility_capability_live() -> bool {
+    permissions::accessibility_granted()
+}
+#[cfg(not(target_os = "macos"))]
+fn accessibility_capability_live() -> bool {
+    false
+}
+
+/// Multi-touch is a code-constant `Unsupported` on this desktop backend. One source for both
+/// the capability map and the gesture-rejection error (`input::send_pointer`'s `Gesture`
+/// arm) — so that error path reads a `const` note instead of routing through the now-live
+/// `capabilities()`, which calls the `AXIsProcessTrusted` FFI.
+pub(crate) const MULTI_TOUCH: CapabilityStatus = CapabilityStatus::unsupported(None);
+
+fn capabilities_with(a11y_granted: bool) -> CapabilityMap {
     CapabilityMap {
         input: CapabilityStatus::supported(),
-        multi_touch: CapabilityStatus::unsupported(None),
+        multi_touch: MULTI_TOUCH,
         clipboard: CapabilityStatus::supported(),
-        accessibility: CapabilityStatus::supported(),
+        accessibility: if a11y_granted {
+            CapabilityStatus::supported()
+        } else {
+            CapabilityStatus::requires_setup(
+                "Accessibility grant not held; enable glass in System Settings > Privacy & Security > Accessibility",
+            )
+        },
         window_move_resize: CapabilityStatus::supported(),
     }
 }
@@ -93,17 +125,40 @@ pub const BACKEND: &str = "macos";
 // macOS — so this test module goes at the end of the file where nothing can follow it.
 #[cfg(test)]
 mod capability_tests {
-    use super::capabilities;
+    use super::capabilities_with;
     use glass_core::capability::Support;
 
     #[test]
-    fn desktop_constant_capability_map() {
-        let c = capabilities();
+    fn constant_capability_cells() {
+        // Everything but `accessibility` is code-constant on this desktop backend.
+        let c = capabilities_with(true);
         assert_eq!(c.input.status, Support::Supported);
         assert_eq!(c.multi_touch.status, Support::Unsupported);
         assert_eq!(c.clipboard.status, Support::Supported);
-        assert_eq!(c.accessibility.status, Support::Supported);
         assert_eq!(c.window_move_resize.status, Support::Supported);
+    }
+
+    #[test]
+    fn accessibility_is_live_on_the_tcc_grant() {
+        assert_eq!(
+            capabilities_with(true).accessibility.status,
+            Support::Supported
+        );
+        let ungranted = capabilities_with(false).accessibility;
+        assert_eq!(ungranted.status, Support::RequiresSetup);
+        assert!(ungranted.note.unwrap().contains("Accessibility"));
+    }
+
+    // The live signal is the macOS TCC grant (`AXIsProcessTrusted`), so it can only be read
+    // on macOS; off-macOS the backend is never dispatched. Tie the public map to the same
+    // predicate `glass_doctor` reads, proving no parallel probe.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn public_capabilities_reads_the_live_tcc_grant() {
+        assert_eq!(
+            super::capabilities().accessibility,
+            capabilities_with(super::accessibility_granted()).accessibility
+        );
     }
 
     #[test]
@@ -111,7 +166,7 @@ mod capability_tests {
         let msg = glass_core::GlassError::unsupported(
             "multi_touch",
             crate::BACKEND,
-            crate::capabilities().multi_touch.note,
+            crate::MULTI_TOUCH.note,
         )
         .to_string();
         assert!(msg.contains("macos backend"), "{msg}");

--- a/crates/glass-wayland/Cargo.toml
+++ b/crates/glass-wayland/Cargo.toml
@@ -13,6 +13,12 @@ bench = false
 
 [dependencies]
 glass-core.workspace = true
+# The desktop-a11y capability signal (AT-SPI launcher present) lives with the a11y reader
+# and its doctor. This backend->a11y-reader direction mirrors glass-windows -> glass-a11y-windows
+# (which is acyclic). Here it forms a Cargo-legal *dev*-dependency cycle: glass-a11y-linux
+# dev-depends back on this crate (for its integration tests), and Cargo permits a cycle whose
+# reverse edge is a dev-dependency.
+glass-a11y-linux.workspace = true
 glass-dbus-linux = { path = "../glass-dbus-linux" }
 glass-sandbox-linux.workspace = true
 glass-proc-linux.workspace = true

--- a/crates/glass-wayland/src/lib.rs
+++ b/crates/glass-wayland/src/lib.rs
@@ -18,38 +18,73 @@ pub use platform::WaylandPlatform;
 /// This backend's canonical name (matches the `glass_capabilities` / `GLASS_BACKEND` value).
 pub const BACKEND: &str = "wayland";
 
-/// This backend's capability map. All cells are code-constant here (desktop
-/// accessibility is reported Supported when the backend ships an a11y reader; per-OS
-/// grants — macOS TCC, Linux AT-SPI — are surfaced by `glass_doctor`).
+/// This backend's capability map. Every cell but `accessibility` is code-constant; the
+/// `accessibility` cell is live — gated on whether the AT-SPI bus launcher is installed
+/// (`glass_a11y_linux::doctor::accessibility_launcher_present`), the same signal
+/// `glass_doctor` reads, so an uninstalled AT-SPI stack reports `requires_setup` rather
+/// than a confident `supported`.
 pub fn capabilities() -> CapabilityMap {
+    capabilities_with(glass_a11y_linux::doctor::accessibility_launcher_present())
+}
+
+fn capabilities_with(a11y_launcher_present: bool) -> CapabilityMap {
     CapabilityMap {
         input: CapabilityStatus::supported(),
-        multi_touch: CapabilityStatus::unsupported(None),
+        multi_touch: MULTI_TOUCH,
         clipboard: CapabilityStatus::supported(),
-        accessibility: CapabilityStatus::supported(),
+        accessibility: glass_a11y_linux::doctor::accessibility_capability(a11y_launcher_present),
         window_move_resize: CapabilityStatus::supported(),
     }
 }
 
+/// Multi-touch is a code-constant `Unsupported` on this desktop backend. One source for both
+/// the capability map and the gesture-rejection error ([`unsupported_multi_touch`]) — so the
+/// error path reads a `const` note instead of routing through the now-live `capabilities()`,
+/// which probes the a11y stack.
+const MULTI_TOUCH: CapabilityStatus = CapabilityStatus::unsupported(None);
+
 /// The `Unsupported` error this backend returns for a multi-touch gesture — one source
 /// for the call site (`send_pointer`'s `Gesture` arm) and its test.
 pub(crate) fn unsupported_multi_touch() -> glass_core::GlassError {
-    glass_core::GlassError::unsupported("multi_touch", BACKEND, capabilities().multi_touch.note)
+    glass_core::GlassError::unsupported("multi_touch", BACKEND, MULTI_TOUCH.note)
 }
 
 #[cfg(test)]
 mod capability_tests {
-    use super::capabilities;
+    use super::{capabilities, capabilities_with};
     use glass_core::capability::Support;
 
     #[test]
-    fn desktop_constant_capability_map() {
-        let c = capabilities();
+    fn constant_capability_cells() {
+        // Everything but `accessibility` is code-constant on this desktop backend.
+        let c = capabilities_with(true);
         assert_eq!(c.input.status, Support::Supported);
         assert_eq!(c.multi_touch.status, Support::Unsupported);
         assert_eq!(c.clipboard.status, Support::Supported);
-        assert_eq!(c.accessibility.status, Support::Supported);
         assert_eq!(c.window_move_resize.status, Support::Supported);
+    }
+
+    #[test]
+    fn accessibility_is_live_on_the_at_spi_launcher() {
+        assert_eq!(
+            capabilities_with(true).accessibility.status,
+            Support::Supported
+        );
+        let absent = capabilities_with(false).accessibility;
+        assert_eq!(absent.status, Support::RequiresSetup);
+        assert!(absent.note.unwrap().contains("at-spi2-core"));
+    }
+
+    #[test]
+    fn public_capabilities_reads_the_live_launcher_signal() {
+        // No parallel probe: the public map's `accessibility` cell is exactly what the
+        // shared launcher-present signal produces.
+        assert_eq!(
+            capabilities().accessibility,
+            glass_a11y_linux::doctor::accessibility_capability(
+                glass_a11y_linux::doctor::accessibility_launcher_present()
+            )
+        );
     }
 
     #[test]

--- a/crates/glass-windows/Cargo.toml
+++ b/crates/glass-windows/Cargo.toml
@@ -14,6 +14,10 @@ bench = false
 [dependencies]
 glass-core.workspace = true
 glass-clip-hook = { path = "../glass-clip-hook" }
+# The desktop-a11y capability signal (UI Automation creatable) reuses the a11y reader's own
+# `probe_uia`. Cross-platform dep: the crate's Windows-only bits are cfg(windows)-gated, so it
+# compiles on the Linux host where `capabilities()` is unit-tested.
+glass-a11y-windows = { path = "../glass-a11y-windows" }
 
 [target.'cfg(windows)'.dependencies]
 windows-capture = "2"
@@ -33,10 +37,10 @@ windows = { version = "0.62", features = [
 ] }
 
 # The onbox examples + tests set Per-Monitor-V2 awareness at runtime (they carry no manifest); the
-# on-box a11y tests (tests/onbox.rs) also drive the UIA reader to validate the accessibility path.
+# on-box a11y tests (tests/onbox.rs) also drive the UIA reader (a normal dependency, above) to
+# validate the accessibility path.
 [target.'cfg(windows)'.dev-dependencies]
 windows = { version = "0.62", features = ["Win32_Foundation", "Win32_UI_HiDpi", "Win32_UI_WindowsAndMessaging"] }
-glass-a11y-windows = { path = "../glass-a11y-windows" }
 
 # The pixel conversion is cross-platform, so its bench builds and runs everywhere.
 [dev-dependencies]

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -4,7 +4,7 @@
 //! `WindowsPlatform` impl are gated per-item with `#[cfg(windows)]` (not a
 //! crate-level gate) so the pure [`dpi`] coordinate math still compiles and is
 //! unit-tested on the Linux dev box. Off Windows the crate exposes only `dpi` and the
-//! code-constant [`capabilities`] map.
+//! [`capabilities`] map (whose `accessibility` cell is live; every other cell is constant).
 
 // FFI backend: the OS-touching modules need `unsafe`, so this crate opts out of the workspace
 // `unsafe_code = "deny"`; each site carries a `// SAFETY:` note (see CLAUDE.md). The pure
@@ -42,18 +42,30 @@ pub(crate) fn disclose_clip_disabled(dll: &str) {
     });
 }
 
-/// This backend's capability map. All cells are code-constant here (desktop
-/// accessibility is reported Supported when the backend ships an a11y reader; per-OS
-/// grants — macOS TCC, Linux AT-SPI — are surfaced by `glass_doctor`).
+/// This backend's capability map. Every cell but `accessibility` is code-constant; the
+/// `accessibility` cell is live — gated on whether UI Automation is creatable right now
+/// (`glass_a11y_windows::doctor::accessibility_available`), the same probe `glass_doctor`
+/// reads, so a Session-0/non-interactive context where UIA can't initialize reports
+/// `requires_setup` rather than a confident `supported`.
 pub fn capabilities() -> CapabilityMap {
+    capabilities_with(glass_a11y_windows::doctor::accessibility_available())
+}
+
+fn capabilities_with(a11y_available: bool) -> CapabilityMap {
     CapabilityMap {
         input: CapabilityStatus::supported(),
-        multi_touch: CapabilityStatus::unsupported(None),
+        multi_touch: MULTI_TOUCH,
         clipboard: CapabilityStatus::supported(),
-        accessibility: CapabilityStatus::supported(),
+        accessibility: glass_a11y_windows::doctor::accessibility_capability(a11y_available),
         window_move_resize: CapabilityStatus::supported(),
     }
 }
+
+/// Multi-touch is a code-constant `Unsupported` on this desktop backend. One source for both
+/// the capability map and the gesture-rejection error ([`unsupported_multi_touch`]) — so the
+/// error path reads a `const` note instead of routing through the now-live `capabilities()`,
+/// which probes the a11y stack.
+const MULTI_TOUCH: CapabilityStatus = CapabilityStatus::unsupported(None);
 
 /// The `Unsupported` error this backend returns for a multi-touch gesture — one source
 /// for the call site (`send_pointer`'s `Gesture` arm) and its test.
@@ -61,7 +73,7 @@ pub fn capabilities() -> CapabilityMap {
 // non-test Linux build sees this as dead (mirrors jobcfg.rs/doctor.rs in this crate).
 #[cfg_attr(not(windows), allow(dead_code))]
 pub(crate) fn unsupported_multi_touch() -> glass_core::GlassError {
-    glass_core::GlassError::unsupported("multi_touch", BACKEND, capabilities().multi_touch.note)
+    glass_core::GlassError::unsupported("multi_touch", BACKEND, MULTI_TOUCH.note)
 }
 
 #[cfg(windows)]
@@ -376,17 +388,38 @@ mod backend {
 
 #[cfg(test)]
 mod capability_tests {
-    use super::capabilities;
+    use super::{capabilities, capabilities_with};
     use glass_core::capability::Support;
 
     #[test]
-    fn desktop_constant_capability_map() {
-        let c = capabilities();
+    fn constant_capability_cells() {
+        // Everything but `accessibility` is code-constant on this desktop backend.
+        let c = capabilities_with(true);
         assert_eq!(c.input.status, Support::Supported);
         assert_eq!(c.multi_touch.status, Support::Unsupported);
         assert_eq!(c.clipboard.status, Support::Supported);
-        assert_eq!(c.accessibility.status, Support::Supported);
         assert_eq!(c.window_move_resize.status, Support::Supported);
+    }
+
+    #[test]
+    fn accessibility_is_live_on_ui_automation() {
+        assert_eq!(
+            capabilities_with(true).accessibility.status,
+            Support::Supported
+        );
+        let absent = capabilities_with(false).accessibility;
+        assert_eq!(absent.status, Support::RequiresSetup);
+        assert!(absent.note.unwrap().contains("Session 0"));
+    }
+
+    #[test]
+    fn public_capabilities_reads_the_live_uia_signal() {
+        // No parallel probe: the public map's `accessibility` cell is exactly what the
+        // shared UIA-availability signal produces.
+        assert_eq!(
+            capabilities().accessibility,
+            capabilities_with(glass_a11y_windows::doctor::accessibility_available()).accessibility
+        );
     }
 
     #[test]

--- a/crates/glass-x11/Cargo.toml
+++ b/crates/glass-x11/Cargo.toml
@@ -13,6 +13,12 @@ bench = false
 
 [dependencies]
 glass-core.workspace = true
+# The desktop-a11y capability signal (AT-SPI launcher present) lives with the a11y reader
+# and its doctor. This backend->a11y-reader direction mirrors glass-windows -> glass-a11y-windows
+# (which is acyclic). Here it forms a Cargo-legal *dev*-dependency cycle: glass-a11y-linux
+# dev-depends back on this crate (for its integration tests), and Cargo permits a cycle whose
+# reverse edge is a dev-dependency.
+glass-a11y-linux.workspace = true
 glass-sandbox-linux.workspace = true
 glass-proc-linux.workspace = true
 glass-dbus-linux.workspace = true

--- a/crates/glass-x11/src/lib.rs
+++ b/crates/glass-x11/src/lib.rs
@@ -17,38 +17,73 @@ pub use xvfb::Xvfb;
 /// This backend's canonical name (matches the `glass_capabilities` / `GLASS_BACKEND` value).
 pub const BACKEND: &str = "x11";
 
-/// This backend's capability map. All cells are code-constant here (desktop
-/// accessibility is reported Supported when the backend ships an a11y reader; per-OS
-/// grants — macOS TCC, Linux AT-SPI — are surfaced by `glass_doctor`).
+/// This backend's capability map. Every cell but `accessibility` is code-constant; the
+/// `accessibility` cell is live — gated on whether the AT-SPI bus launcher is installed
+/// (`glass_a11y_linux::doctor::accessibility_launcher_present`), the same signal
+/// `glass_doctor` reads, so an uninstalled AT-SPI stack reports `requires_setup` rather
+/// than a confident `supported`.
 pub fn capabilities() -> CapabilityMap {
+    capabilities_with(glass_a11y_linux::doctor::accessibility_launcher_present())
+}
+
+fn capabilities_with(a11y_launcher_present: bool) -> CapabilityMap {
     CapabilityMap {
         input: CapabilityStatus::supported(),
-        multi_touch: CapabilityStatus::unsupported(None),
+        multi_touch: MULTI_TOUCH,
         clipboard: CapabilityStatus::supported(),
-        accessibility: CapabilityStatus::supported(),
+        accessibility: glass_a11y_linux::doctor::accessibility_capability(a11y_launcher_present),
         window_move_resize: CapabilityStatus::supported(),
     }
 }
 
+/// Multi-touch is a code-constant `Unsupported` on this desktop backend. One source for both
+/// the capability map and the gesture-rejection error ([`unsupported_multi_touch`]) — so the
+/// error path reads a `const` note instead of routing through the now-live `capabilities()`,
+/// which probes the a11y stack.
+const MULTI_TOUCH: CapabilityStatus = CapabilityStatus::unsupported(None);
+
 /// The `Unsupported` error this backend returns for a multi-touch gesture — one source
 /// for the call site (`send_pointer`'s `Gesture` arm) and its test.
 pub(crate) fn unsupported_multi_touch() -> glass_core::GlassError {
-    glass_core::GlassError::unsupported("multi_touch", BACKEND, capabilities().multi_touch.note)
+    glass_core::GlassError::unsupported("multi_touch", BACKEND, MULTI_TOUCH.note)
 }
 
 #[cfg(test)]
 mod capability_tests {
-    use super::capabilities;
+    use super::{capabilities, capabilities_with};
     use glass_core::capability::Support;
 
     #[test]
-    fn desktop_constant_capability_map() {
-        let c = capabilities();
+    fn constant_capability_cells() {
+        // Everything but `accessibility` is code-constant on this desktop backend.
+        let c = capabilities_with(true);
         assert_eq!(c.input.status, Support::Supported);
         assert_eq!(c.multi_touch.status, Support::Unsupported);
         assert_eq!(c.clipboard.status, Support::Supported);
-        assert_eq!(c.accessibility.status, Support::Supported);
         assert_eq!(c.window_move_resize.status, Support::Supported);
+    }
+
+    #[test]
+    fn accessibility_is_live_on_the_at_spi_launcher() {
+        assert_eq!(
+            capabilities_with(true).accessibility.status,
+            Support::Supported
+        );
+        let absent = capabilities_with(false).accessibility;
+        assert_eq!(absent.status, Support::RequiresSetup);
+        assert!(absent.note.unwrap().contains("at-spi2-core"));
+    }
+
+    #[test]
+    fn public_capabilities_reads_the_live_launcher_signal() {
+        // No parallel probe: the public map's `accessibility` cell is exactly what the
+        // shared launcher-present signal produces.
+        assert_eq!(
+            capabilities().accessibility,
+            glass_a11y_linux::doctor::accessibility_capability(
+                glass_a11y_linux::doctor::accessibility_launcher_present()
+            )
+        );
     }
 
     #[test]

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -462,7 +462,9 @@ For a valid backend **not** built into the running binary:
 **Platform notes:** availability is live. android `input` is `degraded` (adb-only injection
 unless the on-device agent is set up) and its `multi_touch`/`clipboard` need that same agent
 (`GLASS_ANDROID_AGENT_JAR`); iOS `accessibility` needs `idb_companion`; those read
-`requires_setup` until set up. Desktop-backend `accessibility` is reported `supported` when the
-backend ships an a11y reader; whether a given window exposes a tree, and per-OS grants (the macOS
-accessibility permission, the Linux AT-SPI stack), are surfaced by `glass_doctor` and when you call
-the a11y tools.
+`requires_setup` until set up. Desktop-backend `accessibility` is live too: it reads
+`requires_setup` when the enabling stack isn't ready — the Linux AT-SPI runtime isn't installed,
+the macOS Accessibility grant isn't held, or Windows UI Automation can't initialize (e.g. a
+non-interactive Session 0) — and `supported` once it is. Whether a given *window* then exposes a
+tree is still app-dependent (bare canvas/game UIs don't), surfaced when you call the a11y tools;
+`glass_doctor` reports the same per-OS readiness in more detail.


### PR DESCRIPTION
Closes #151 (follow-up B from the `glass_capabilities` work, #149).

## What

The desktop backends reported `glass_capabilities` → `accessibility` as a code-constant `supported` ("the backend ships an a11y reader"). This makes that cell **live**: each backend gates it on a bool distilled from its a11y doctor's own signal — reused, never re-probed — so a broken/ungranted a11y stack reports `requires_setup` with an actionable note instead of a confident `supported`.

| backend | live signal (shared with `glass_doctor`) |
|---|---|
| x11 / wayland | AT-SPI bus launcher installed — `glass_a11y_linux::doctor::accessibility_launcher_present` |
| windows | UI Automation creatable — `glass_a11y_windows::doctor::accessibility_available` (reuses the doctor's `probe_uia`) |
| macos | Accessibility TCC grant — `AXIsProcessTrusted` via `accessibility_granted` |

Each backend gains a `capabilities_with(bool)` seam (host-testable), mirroring the existing android/ios pattern. The x11+wayland cell is a shared `accessibility_capability(bool)` in `glass-a11y-linux` so their identical note can't drift; the Windows cell lives next to `probe_uia` for the same reason.

## Non-duplication

The capability cell and the doctor check read the **same fact** on every backend (Linux: `find_registry()`; Windows: `probe_uia()`; macOS: `accessibility_granted()`), pinned by per-backend unit tests, so `glass_capabilities` and `glass doctor` can't drift.

## Also in this PR (from pre-merge review)

- `find_registry()` now scans any multiarch triplet dir (`/usr/lib/<triplet>/at-spi2-core/…`) instead of hardcoding `x86_64-linux-gnu`, so aarch64 hosts aren't wrongly reported as missing AT-SPI. TDD'd with a tempdir.
- The gesture-rejection error path reads a `const MULTI_TOUCH` note instead of the now-live `capabilities()`, so rejecting a gesture no longer triggers the a11y probe (notably the macOS `AXIsProcessTrusted` FFI, in an arm documented to be side-effect-free).
- Windows `requires_setup` note hedges the cause ("commonly a non-interactive Session 0 context") since UIA can fail to initialize for other reasons; the doctor carries the exact underlying error.

## Dependency wiring

- `glass-x11` / `glass-wayland` normal-depend on `glass-a11y-linux` — a Cargo-legal dev-dependency cycle (`glass-a11y-linux` dev-depends back on them for integration tests).
- `glass-a11y-windows` promoted from a `cfg(windows)` dev-dependency to a cross-platform normal dependency of `glass-windows` (acyclic; its Windows-only bits stay `cfg(windows)`-gated, so it still compiles on the Linux host).

## Docs

`docs/reference/tools.md` "Platform notes" corrected (desktop a11y is no longer described as always `supported`); `CHANGELOG.md` `[Unreleased]` entry updated.

## Testing

- `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --locked` — all green on the Linux host.
- Cross-clippy for `x86_64-pc-windows-gnu` (real `uiautomation` probe path) and `x86_64-apple-darwin` (real `AXIsProcessTrusted` arm) — both green.
- Per-backend tests drive `capabilities_with(true/false)` both ways, assert the notes, and tie the public map to the shared signal (no parallel probe).

**Known limit:** the macOS granted→`Supported` path can't be proven on a hosted CI runner (TCC grants are absent); it's validated on the on-box granted harness, matching the existing macOS test pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)