### PR TITLE
chore: scrub dev-environment specifics from public comments

### DIFF
--- a/crates/glass-android/src/input.rs
+++ b/crates/glass-android/src/input.rs
@@ -282,7 +282,7 @@ pub(crate) fn agent_pointer(origin: &WindowGeometry, event: &PointerEvent) -> Ve
                 .saturating_sub(dy.saturating_mul(SCROLL_STEP_PX))
                 .clamp(origin.y, hi_y);
             // Interpolate so the swipe carries real velocity (a fling), not a single jump —
-            // a 2-point swipe under-scrolls and stalls on long lists (dogfood #17).
+            // a 2-point swipe under-scrolls and stalls on long lists.
             vec![agent_path(cx, cy, ex, ey, SWIPE_MS)]
         }
         PointerEvent::Gesture { .. } => vec![], // handled by AgentInjector::pointer directly
@@ -427,7 +427,7 @@ mod agent_inject_tests {
             }
         );
         // Real ACTION_MOVE samples between DOWN and UP — a 2-point path is swallowed by
-        // Android touch-slop (onDragStart fires at the end coordinate). See dogfood F8.
+        // Android touch-slop (onDragStart fires at the end coordinate).
         assert!(
             path.len() >= 8,
             "expected interpolated samples, got {}",
@@ -480,7 +480,7 @@ mod agent_inject_tests {
             }
         );
         // Interpolated samples give the swipe real velocity → a fling, so deep scrolls
-        // don't stall. Dogfood finding #17.
+        // don't stall.
         assert!(
             path.len() >= 8,
             "scroll should fling with interpolated samples, got {}",

--- a/crates/glass-clip-hook/src/hook.rs
+++ b/crates/glass-clip-hook/src/hook.rs
@@ -1,4 +1,4 @@
-//! user32 clipboard detours + the pipe client (cfg windows; runtime-validated on LOTUS).
+//! user32 clipboard detours + the pipe client (cfg windows; runtime-validated on a real Windows host).
 //!
 //! Emulates a per-app clipboard backed by the host store. The detours NEVER call the real
 //! clipboard APIs (the box also has `OpenClipboard=n`), so the user's clipboard is untouched.
@@ -8,7 +8,7 @@
 //! data only — delayed rendering (`SetClipboardData(_, NULL)`) and OLE are out of scope.
 //!
 //! Compile-time verified by cross-compiling to `x86_64-pc-windows-gnu`. Runtime interception is
-//! finalized on a real Windows box (LOTUS); the detour table is authored complete so that on-box
+//! finalized on a real Windows box; the detour table is authored complete so that on-box
 //! work is debugging, not authoring.
 
 use std::sync::OnceLock;

--- a/crates/glass-clip-hook/src/hook/detour_impl.rs
+++ b/crates/glass-clip-hook/src/hook/detour_impl.rs
@@ -8,7 +8,7 @@
 //! denied; we fully substitute them.
 //!
 //! Compile-time verified by cross-compiling to `x86_64-pc-windows-gnu`. Whether the detours
-//! actually intercept at runtime is finalized on a real Windows box (LOTUS).
+//! actually intercept at runtime is finalized on a real Windows box.
 
 use std::cell::{Cell, RefCell};
 

--- a/crates/glass-dbus-linux/src/lib.rs
+++ b/crates/glass-dbus-linux/src/lib.rs
@@ -311,10 +311,10 @@ mod tests {
     /// Regression: the private a11y bus must stay inside our private runtime dir even
     /// when `org.a11y.Bus` is brought up by **D-Bus activation** rather than the launcher
     /// we spawn directly. We force that path by pointing `GLASS_ATSPI_LAUNCHER` at a no-op
-    /// (`/bin/true` exits without claiming the name — exactly the zombie a dogfood run
-    /// produced), so the session bus must activate the real launcher itself. If the
+    /// (`/bin/true` exits without claiming the name — exactly the zombie observed in
+    /// practice), so the session bus must activate the real launcher itself. If the
     /// activated launcher escapes to the ambient `XDG_RUNTIME_DIR`, it attaches to the
-    /// host accessibility bus — breaking isolation and (as that run showed) wedging on the
+    /// host accessibility bus — breaking isolation and (as observed) wedging on the
     /// contended host bus. Run this under a throwaway `XDG_RUNTIME_DIR` (test-a11y.sh does)
     /// so "ambient" is a sacrificial dir, never the operator's real `/run/user/UID`.
     #[test]

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -56,12 +56,12 @@ plist = "1"
 # macOS-only FFI deps (objc2 family). Kept in this target table so the crate's pure
 # modules still build on the Linux dev box with zero macOS deps. Versions pinned to
 # exactly what the objc2 spike proved compiles + runs cleanly
-# (zero warnings) against the real frameworks on mini. Each `objc2-*` framework crate
+# (zero warnings) against the real frameworks on macOS. Each `objc2-*` framework crate
 # gates its ObjC types behind per-type Cargo features; `default-features = false` +
 # an explicit minimal `features` list keeps unused framework bindings (AVFoundation,
 # Metal, CoreData, CloudKit, etc. — pulled in wholesale by each crate's `default`
 # feature set) out of the build entirely. Each list was derived and verified empirically
-# on mini.
+# on macOS.
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.4"
 objc2-foundation = { version = "0.3.2", default-features = false, features = [

--- a/crates/glass-macos/src/permissions.rs
+++ b/crates/glass-macos/src/permissions.rs
@@ -252,6 +252,6 @@ mod tests {
     // OS consent dialog), which is unsafe to trigger unattended in CI — a headless runner
     // has no user to click through it, and a real one shouldn't have its TCC state
     // mutated by every test run. Their FFI plumbing is verified by hand against the
-    // granted mini (see the workspace's macOS de-risking notes); `open_pane` is likewise
+    // granted dev Mac; `open_pane` is likewise
     // side-effecting (launches System Settings) and not called here for the same reason.
 }

--- a/crates/glass-macos/src/session.rs
+++ b/crates/glass-macos/src/session.rs
@@ -13,7 +13,7 @@
 //! calling process: it isn't "returns NULL whenever you're on a bare SSH shell" — a
 //! bare-SSH `doctor` run on a box where an account IS logged in at the console still
 //! sees that account's real (locked/unlocked) session dict, same as a GUI-launched
-//! process would (verified by hand: `doctor` run over plain SSH against the `mini`
+//! process would (verified by hand: `doctor` run over plain SSH against the dev Mac
 //! host, logged-in-but-unattended, reported the true unlocked state, not NoSession).
 //! What NULL actually signals is "capture/input have nothing to attach to *regardless
 //! of who calls this*" — which is not "a present, unlocked session" and so

--- a/crates/glass-macos/tests/a11y.rs
+++ b/crates/glass-macos/tests/a11y.rs
@@ -27,7 +27,7 @@
 //!
 //! Needs the Accessibility (and Screen Recording, for `MacosPlatform::new`'s preflight) TCC
 //! grants, which only the signed, granted `GlassProbe.app` bundle holds on this project's
-//! dev Mac (`mini`) — see `capture.rs`'s module doc and `scripts/test-macos.sh` for how the
+//! dev Mac — see `capture.rs`'s module doc and `scripts/test-macos.sh` for how the
 //! granted run copies this binary into that bundle. The fixture binary path is taken from
 //! `GLASS_A11Y_FIXTURE_BIN` when set (the granted run pre-builds it); otherwise this builds
 //! `fixture/a11y_fixture.swift` with `swiftc`, or skips if neither is available.

--- a/crates/glass-macos/tests/bundle_launch.rs
+++ b/crates/glass-macos/tests/bundle_launch.rs
@@ -39,7 +39,7 @@
 //!
 //! Needs the same two TCC grants as `tests/input.rs` (Screen Recording for window
 //! discovery/capture, Accessibility for the AX snapshot in check 2), held by the signed,
-//! granted `GlassProbe.app` bundle on this project's dev Mac (`mini`) — same granted-run
+//! granted `GlassProbe.app` bundle on this project's dev Mac — same granted-run
 //! procedure as `capture.rs`/`input.rs`: copy this built test binary into the bundle,
 //! re-sign, run via a `gui/501` LaunchAgent so it inherits the bundle's grants.
 //! Check 2/3 additionally require `/System/Applications/TextEdit.app` to
@@ -470,7 +470,7 @@ mod macos_main {
         // `swiftc` can never skip the handoff/fail-closed checks and a missing `TextEdit.app`
         // can never skip the foreground check. Failures fail the run; skips are reported
         // distinctly (SKIPPED, never counted as a pass) and do not block the PASS banner for
-        // the checks that did run and pass. On the mini both preconditions are present, so
+        // the checks that did run and pass. On the dev Mac both preconditions are present, so
         // all three run.
         let mut failures = Vec::new();
         let mut skips = Vec::new();

--- a/crates/glass-macos/tests/capture.rs
+++ b/crates/glass-macos/tests/capture.rs
@@ -12,7 +12,7 @@
 //! real main thread.
 //!
 //! Needs the Screen Recording TCC grant, which only a signed, granted app bundle holds on
-//! this project's dev Mac (`mini`). A plain `cargo test --test capture` build (this file
+//! this project's dev Mac. A plain `cargo test --test capture` build (this file
 //! compiles and can run) will still fail at the grant check unless run in that granted
 //! context — the actual granted run copies this test binary into the granted
 //! `GlassProbe.app` bundle, re-signs it, and launches it via a `gui/501` LaunchAgent so it

--- a/crates/glass-macos/tests/input.rs
+++ b/crates/glass-macos/tests/input.rs
@@ -20,13 +20,13 @@
 //!
 //! Needs the Accessibility TCC grant (CGEvent posting) in addition to Screen Recording
 //! (window discovery via ScreenCaptureKit), both held by the signed, granted `GlassProbe.app`
-//! bundle on this project's dev Mac (`mini`) — same granted-run procedure as
+//! bundle on this project's dev Mac — same granted-run procedure as
 //! `tests/capture.rs`: copy this built test binary into the bundle, re-sign, run via a
 //! `gui/501` LaunchAgent so it inherits the bundle's grants. See `scripts/test-macos.sh`'s
 //! `GLASS_MACOS_ONBOX` gate for how this fits the test scripts.
 //!
-//! **Additional runtime precondition beyond the two TCC grants: `mini`'s screen session
-//! must not be locked.** Debugging on `mini` empirically proved that while the console
+//! **Additional runtime precondition beyond the two TCC grants: the Mac's screen session
+//! must not be locked.** Debugging empirically proved that while the console
 //! session is locked
 //! (`CGSSessionScreenIsLocked=1`), macOS's secure-input protection pins
 //! `NSWorkspace.frontmostApplication` to `loginwindow` and silently drops every synthetic
@@ -291,7 +291,7 @@ mod macos_main {
         // the content DOWN" convention (see input.rs's module doc / glass-x11's
         // `scroll_button(5=down,4=up, dy)`). `MacScrollSink::wheel` posts `wheel1 = -dy`, but
         // what `NSEvent.scrollingDeltaY` the window server ultimately delivers to the fixture
-        // also depends on `mini`'s **natural-scrolling** system setting
+        // also depends on the target Mac's **natural-scrolling** system setting
         // (`com.apple.swipescrolldirection`), which inverts the effective on-screen direction
         // independent of anything `input.rs` controls. So only `read_scroll`'s non-zero check
         // is hard-asserted here — the SIGN itself is recorded via `println!` rather than
@@ -314,7 +314,7 @@ mod macos_main {
         println!(
             "send_pointer(Scroll) OK: sent dx=0,dy=5 (glass 'scroll down') -> fixture reported \
              scrollingDeltaX={reported_dx},scrollingDeltaY={reported_dy} (sign depends on \
-             mini's natural-scrolling setting — see this file's module doc)"
+             the target Mac's natural-scrolling setting — see this file's module doc)"
         );
 
         Ok(())

--- a/crates/glass-macos/tests/windows.rs
+++ b/crates/glass-macos/tests/windows.rs
@@ -19,12 +19,12 @@
 //!
 //! Needs the same two TCC grants as `tests/input.rs` (Screen Recording for window discovery/
 //! capture, Accessibility for the AX window ops), held by the signed, granted `GlassProbe.app`
-//! bundle on this project's dev Mac (`mini`) — same granted-run procedure as `capture.rs`/
+//! bundle on this project's dev Mac — same granted-run procedure as `capture.rs`/
 //! `input.rs`: copy this built test binary into the bundle, re-sign, run via a `gui/501`
 //! LaunchAgent so it inherits the bundle's grants. See `scripts/test-macos.sh`'s
 //! `GLASS_MACOS_ONBOX` gate for how this fits the test scripts.
 //!
-//! **Additional runtime precondition beyond the two TCC grants: `mini`'s screen session must
+//! **Additional runtime precondition beyond the two TCC grants: the Mac's screen session must
 //! not be locked** — same secure-input restriction `tests/input.rs`'s module doc documents in
 //! detail (a locked screen silently drops synthetic input and pins frontmost-app queries to
 //! `loginwindow`). `select_window`/`window(op)` both activate/raise the target window, so this

--- a/crates/glass-mcp/src/setup.rs
+++ b/crates/glass-mcp/src/setup.rs
@@ -920,7 +920,7 @@ mod tests {
         // A bare `cargo run` output isn't inside a bundle → name the default install path so
         // the instruction still points somewhere concrete.
         assert_eq!(
-            app_bundle_path(Path::new("/home/mpd/glass/target/release/glass-mcp")),
+            app_bundle_path(Path::new("/home/u/glass/target/release/glass-mcp")),
             DEFAULT_APP_PATH
         );
     }
@@ -1134,7 +1134,7 @@ mod tests {
     #[test]
     fn rejects_a_bare_cargo_build_output_path() {
         assert!(!is_inside_app_bundle(Path::new(
-            "/home/mpd/glass/target/release/glass-mcp"
+            "/home/u/glass/target/release/glass-mcp"
         )));
     }
 

--- a/crates/glass-windows/src/containment/build_onbox.rs
+++ b/crates/glass-windows/src/containment/build_onbox.rs
@@ -1,4 +1,4 @@
-//! On-box (LOTUS) validation that the build step runs UNCONFINED even under Sandboxie
+//! On-box validation that the build step runs UNCONFINED even under Sandboxie
 //! containment — only the launched *run* is the security boundary. Completes the Windows
 //! follow-on of `2026-06-11-unsandbox-build-design`. `#[ignore]`d: needs Sandboxie. No window is
 //! launched, so this runs over SSH (no interactive desktop required).

--- a/crates/glass-windows/src/containment/clip_onbox.rs
+++ b/crates/glass-windows/src/containment/clip_onbox.rs
@@ -1,9 +1,9 @@
-//! On-box (LOTUS) deterministic validation of the private-clipboard hook. `#[ignore]`d — it needs
+//! On-box deterministic validation of the private-clipboard hook. `#[ignore]`d — it needs
 //! Sandboxie running, the built `glass_clip_hook.dll` (path in `GLASS_CLIP_HOOK_DLL`), and the built
 //! `clipprobe` example. No GUI / interactive desktop is needed: the probe only calls user32
 //! clipboard APIs, so it runs over SSH. Run on the box with:
 //! ```text
-//!   set GLASS_CLIP_HOOK_DLL=C:\Users\mpd\glass\target\release\glass_clip_hook.dll
+//!   set GLASS_CLIP_HOOK_DLL=C:\Users\<user>\glass\target\release\glass_clip_hook.dll
 //!   cargo test -p glass-windows --release private_clipboard_isolation -- --ignored --nocapture
 //! ```
 

--- a/crates/glass-windows/src/containment/mod.rs
+++ b/crates/glass-windows/src/containment/mod.rs
@@ -9,12 +9,12 @@ mod clip_server;
 #[cfg(windows)]
 mod sandboxie;
 
-// On-box (LOTUS) deterministic validation of the private-clipboard hook. Compiled only for the
+// On-box deterministic validation of the private-clipboard hook. Compiled only for the
 // Windows test profile; the tests inside are `#[ignore]`d (need Sandboxie + the built DLL).
 #[cfg(all(test, windows))]
 mod clip_onbox;
 
-// On-box (LOTUS) validation that the build step runs unconfined even under Sandboxie. `#[ignore]`d
+// On-box validation that the build step runs unconfined even under Sandboxie. `#[ignore]`d
 // (needs Sandboxie); launches no window, so it runs over SSH.
 #[cfg(all(test, windows))]
 mod build_onbox;

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -458,7 +458,7 @@ fn onbox_clipboard_roundtrip() {
     );
 }
 
-// The dogfood found that a CONTAINED app's own clipboard write was invisible to glass: glass set/get
+// A CONTAINED app's own clipboard write was invisible to glass: glass set/get
 // round-tripped and glass->app paste worked, but the app's ctx.copy_text (-> arboard -> user32
 // SetClipboardData, detoured into the private store) read back empty. This reproduces it with the
 // fixture auto-copying a sentinel under Sandboxie, and isolates the app-write path from the store


### PR DESCRIPTION
Genericizes environment-specific references that had crept into source comments and test fixtures across several crates — private hostnames, absolute user-home paths, an internal planning-doc pointer, and internal tracker IDs — replacing them with the repo's existing generic placeholders or plain behavioral descriptions.

Comment- and string-literal-only; no logic or behavior changes.

**Local gate:** `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)