### PR TITLE
fix(serve): take over the session slot on reconnect instead of rejecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,12 @@ internal refactors, CI, or test-only changes.
   a remedy, and `glass_capabilities` attaches a `warning` field. The fallback also now resolves to
   the host default (macos/windows/x11) rather than a hardcoded x11, so a typo on a mac/Windows host
   no longer drops to an x11 that host can't drive.
+- `serve --http`: reconnecting an agent no longer fails with "another session is active". A
+  Streamable-HTTP session is decoupled from its TCP connection and lingers until an explicit
+  shutdown or a 5-minute idle timeout, so a client that dropped without cleanly disconnecting used
+  to be locked out of its own server until that timeout expired. A new client now takes over the
+  single live slot (last-client-wins), evicting the stale session, so reconnects succeed
+  immediately.
 
 ## [0.4.0] - 2026-07-11
 

--- a/crates/glass-mcp/src/serve/session_gate.rs
+++ b/crates/glass-mcp/src/serve/session_gate.rs
@@ -1,17 +1,30 @@
-//! Single-client admission gate: at most one live MCP session at a time.
+//! Single live MCP session with last-client-wins takeover.
 //!
-//! Wraps rmcp's [`LocalSessionManager`] and enforces that only one MCP session
-//! is alive at a time. `create_session` claims a single slot (rejecting a second
-//! client while one is live); `close_session` releases it. Every other
-//! [`SessionManager`] method is pure delegation to the inner manager.
+//! Wraps rmcp's [`LocalSessionManager`] so at most one MCP session is live at a
+//! time, but a *new* client always wins: `create_session` evicts whatever
+//! session currently holds the slot and admits the newcomer. This is what makes
+//! reconnect work under `serve --http`. A streamable-HTTP session is decoupled
+//! from its TCP connection by design (so it can survive a drop and resume), and
+//! (as of rmcp 1.7.0) rmcp only tears it down on an explicit `DELETE` or after
+//! its `keep_alive` idle timeout (default 5 min). An agent that dies or restarts almost never
+//! sends `DELETE`, so its session lingers as a zombie — and a plain admission
+//! gate would reject the agent's own reconnect until that zombie expired.
+//! Takeover displaces the stale session instead. glass is a single-user dev
+//! tool, so favouring the newcomer is the right trade.
 //!
-//! The slot is released in `close_session`, but ONLY for the admitted session's
-//! id. rmcp's `handle_delete` forwards the client's `Mcp-Session-Id` header
-//! without validating it (and `LocalSessionManager::close_session` returns `Ok`
-//! for an unknown id), and `spawn_session_worker` calls `close_session` on every
-//! worker end — including a superseded session's. Matching the id ensures a
-//! stale/bogus close can't free a live session's slot (which would let a second
-//! client in alongside the first).
+//! Only a create that is *genuinely in flight* (`Reserving`) rejects a
+//! concurrent create: there is no known id to evict yet, and two initializes
+//! racing in the same instant is not a reconnect.
+//!
+//! The slot is released in `close_session`, but ONLY for the session id that
+//! currently holds it. rmcp's `handle_delete` forwards the client's
+//! `Mcp-Session-Id` header without validating it (and
+//! `LocalSessionManager::close_session` returns `Ok` for an unknown id), and
+//! `spawn_session_worker` calls `close_session` on every worker end — including
+//! an evicted session's late one. Matching the id ensures a stale/bogus close
+//! can't clear a *live* session's slot; if it could, single-session tracking
+//! would be lost and a later client would run alongside the live one instead of
+//! taking it over.
 
 use std::io;
 use std::sync::Mutex;
@@ -32,18 +45,22 @@ enum Slot {
     /// No session — a `create_session` is admitted.
     #[default]
     Empty,
-    /// A `create_session` has claimed the slot but its id isn't known yet (the
-    /// inner `create_session().await` is in flight). A concurrent create is
-    /// rejected; a close (which carries some other id) can't match.
+    /// A `create_session` has claimed the slot but its id isn't known yet — held
+    /// from claiming the slot, through the eviction close of any superseded
+    /// session, until the inner `create_session().await` resolves to `Active`.
+    /// A concurrent create is rejected; a close (which carries some other id)
+    /// can't match. A `create_session` whose future is dropped mid-flight would
+    /// strand this state, so the reservation is held under a revert guard (see
+    /// `create_session`).
     Reserving,
     /// Held by the admitted session; only a close for this id releases it.
     Active(SessionId),
 }
 
-/// Wraps [`LocalSessionManager`], enforcing at most one concurrent session.
-///
-/// A second `create_session` while one is live returns an error (surfaced to the
-/// second client as an error response — "another session is active").
+/// Wraps [`LocalSessionManager`], keeping at most one live session with
+/// last-client-wins takeover: a new `create_session` evicts the current session
+/// and admits the newcomer. Only a create racing another still-in-flight create
+/// is rejected.
 #[derive(Debug, Default)]
 pub struct SingleSessionManager {
     inner: LocalSessionManager,
@@ -54,15 +71,51 @@ pub struct SingleSessionManager {
     slot: Mutex<Slot>,
 }
 
-/// The error returned when a second client tries to attach while one is live.
+/// The error returned when a create races another create that is still in
+/// flight (the `Reserving` window). NOT used for reconnect: a stale session is
+/// evicted and the newcomer admitted, never rejected.
 ///
 /// `LocalSessionManagerError` has no free-form / "already exists" variant, so we
 /// carry the message through its `SessionError(SessionError::Io(_))` path, which
 /// renders as a clear human-readable string.
 fn busy_error() -> LocalSessionManagerError {
     LocalSessionManagerError::SessionError(SessionError::Io(io::Error::other(
-        "glass serves one client at a time; another session is active",
+        "glass: another client is initializing a session; retry in a moment",
     )))
+}
+
+/// Reverts a `Reserving` reservation to `Empty` if the `create_session` future
+/// is dropped (task cancellation or a panic) before it commits to `Active`/
+/// `Empty`. Without this, a client that disconnects mid-handshake — rmcp awaits
+/// `create_session` inline in the request task, so hyper drops the future at its
+/// suspended await — would strand the slot at `Reserving`, and every subsequent
+/// create would `busy_error()` forever (a permanent lockout, the exact failure
+/// this gate exists to prevent). Disarmed once the create commits.
+struct ReservationGuard<'a> {
+    slot: &'a Mutex<Slot>,
+    armed: bool,
+}
+
+impl ReservationGuard<'_> {
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ReservationGuard<'_> {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        // Recover a poisoned lock rather than double-panic: reverting the stranded
+        // reservation matters more than propagating an unrelated prior panic. Only
+        // clear the slot if it's still our `Reserving` — a committed `Active`/
+        // `Empty` (or another create's reservation) must never be clobbered.
+        let mut slot = self.slot.lock().unwrap_or_else(|e| e.into_inner());
+        if matches!(*slot, Slot::Reserving) {
+            *slot = Slot::Empty;
+        }
+    }
 }
 
 impl SessionManager for SingleSessionManager {
@@ -70,22 +123,48 @@ impl SessionManager for SingleSessionManager {
     type Transport = <LocalSessionManager as SessionManager>::Transport;
 
     async fn create_session(&self) -> Result<(SessionId, Self::Transport), Self::Error> {
-        // Claim the single slot before the await; reject if already taken.
-        {
+        // Claim the slot before the await. Take over an existing session (the
+        // common reconnect case: a client died leaving a lingering session);
+        // reject only a create that is itself still in flight, since there's no
+        // known id to evict yet.
+        let evict = {
             let mut slot = self.slot.lock().expect("session slot mutex");
-            if !matches!(*slot, Slot::Empty) {
-                return Err(busy_error());
+            match &*slot {
+                Slot::Reserving => return Err(busy_error()),
+                Slot::Active(old) => {
+                    let old = old.clone();
+                    *slot = Slot::Reserving;
+                    Some(old)
+                }
+                Slot::Empty => {
+                    *slot = Slot::Reserving;
+                    None
+                }
             }
-            *slot = Slot::Reserving;
+        };
+        // From here until we commit, a dropped future must not strand `Reserving`.
+        let mut guard = ReservationGuard {
+            slot: &self.slot,
+            armed: true,
+        };
+        // Best-effort eviction of the superseded session, never holding the lock
+        // across the await. The result is ignored: the goal is to admit the
+        // newcomer, and a stale worker exits on its own `keep_alive` timeout even
+        // if this close races it. The id guard in `close_session` keeps that
+        // session's own late worker-end close from clearing the new slot below.
+        if let Some(old) = evict {
+            let _ = self.inner.close_session(&old).await;
         }
         match self.inner.create_session().await {
             Ok((id, transport)) => {
                 *self.slot.lock().expect("session slot mutex") = Slot::Active(id.clone());
+                guard.disarm();
                 Ok((id, transport))
             }
             Err(e) => {
                 // Release the slot if the inner manager failed to create.
                 *self.slot.lock().expect("session slot mutex") = Slot::Empty;
+                guard.disarm();
                 Err(e)
             }
         }
@@ -149,19 +228,51 @@ impl SessionManager for SingleSessionManager {
 }
 
 #[cfg(test)]
+impl SingleSessionManager {
+    /// Test-only view of which session (if any) currently holds the slot.
+    /// `None` covers both `Empty` and the transient `Reserving`.
+    fn active_id(&self) -> Option<SessionId> {
+        match &*self.slot.lock().expect("session slot mutex") {
+            Slot::Active(id) => Some(id.clone()),
+            Slot::Empty | Slot::Reserving => None,
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn admits_one_rejects_second_releases_on_close() {
+    async fn reconnect_takes_over_then_close_releases() {
         let m = SingleSessionManager::default();
-        let (id, _t) = m.create_session().await.expect("first session admitted");
-        assert!(
-            m.create_session().await.is_err(),
-            "second session must be rejected while one is live"
+        let (id1, _t1) = m.create_session().await.expect("first session admitted");
+        assert_eq!(m.active_id().as_ref(), Some(&id1));
+
+        // A new client (the reconnect case) takes over the live slot instead of
+        // being rejected. It gets a fresh session; the slot now tracks it.
+        let (id2, _t2) = m
+            .create_session()
+            .await
+            .expect("reconnect takes over the slot");
+        assert_ne!(id1, id2, "takeover admits a fresh session");
+        assert_eq!(m.active_id().as_ref(), Some(&id2));
+
+        // The evicted session's own late worker-end close must NOT clear the new
+        // slot (id guard) — otherwise the next client would coexist, not take over.
+        m.close_session(&id1).await.expect("stale close returns Ok");
+        assert_eq!(
+            m.active_id().as_ref(),
+            Some(&id2),
+            "a close for the evicted id must not clear the live slot"
         );
-        m.close_session(&id).await.expect("close releases the slot");
-        let (_id2, _t2) = m.create_session().await.expect("slot reusable after close");
+
+        // The active session's own close releases the slot to Empty.
+        m.close_session(&id2)
+            .await
+            .expect("close releases the slot");
+        assert_eq!(m.active_id(), None);
+        let (_id3, _t3) = m.create_session().await.expect("slot reusable after close");
     }
 
     #[tokio::test]
@@ -171,21 +282,113 @@ mod tests {
         let (id, _t) = m.create_session().await.expect("first session admitted");
         // rmcp's handle_delete forwards the client's Mcp-Session-Id header without
         // validating it, and LocalSessionManager::close_session returns Ok for an
-        // unknown id — so a DELETE carrying a bogus/stale id (or a superseded
-        // session's late worker-end) must NOT free the live slot.
+        // unknown id — so a DELETE carrying a bogus/stale id (or an evicted
+        // session's late worker-end) must NOT clear the live slot. If it did,
+        // single-session tracking would be lost and the next create would admit a
+        // second live session instead of taking over the first.
         let bogus: SessionId = Arc::from("not-the-active-session");
         let _ = m.close_session(&bogus).await;
-        assert!(
-            m.create_session().await.is_err(),
-            "slot must stay claimed after a close for a non-active id"
+        assert_eq!(
+            m.active_id().as_ref(),
+            Some(&id),
+            "slot must still track the live session after a foreign-id close"
         );
         // The admitted session's own close still releases it.
         m.close_session(&id)
             .await
             .expect("closing the active session releases");
-        let (_id2, _t2) = m
-            .create_session()
-            .await
-            .expect("slot reusable after the real close");
+        assert_eq!(m.active_id(), None);
+    }
+
+    #[tokio::test]
+    async fn takeover_evicts_old_session_from_inner_manager() {
+        // Takeover must actually evict the superseded session from the inner
+        // manager, not merely swap the slot — otherwise the stale session lingers
+        // (routable, until its 5-min keep_alive) and this fix's purpose is lost.
+        let m = SingleSessionManager::default();
+        let (id1, _t1) = m.create_session().await.expect("first session admitted");
+        assert!(
+            m.has_session(&id1).await.expect("has_session"),
+            "id1 live before takeover"
+        );
+
+        let (id2, _t2) = m.create_session().await.expect("takeover admits newcomer");
+        assert!(
+            !m.has_session(&id1).await.expect("has_session"),
+            "the superseded session must be evicted from the inner manager"
+        );
+        assert!(
+            m.has_session(&id2).await.expect("has_session"),
+            "newcomer is live"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_while_reserving_is_rejected() {
+        // The one remaining rejection path: a create arriving while another is
+        // genuinely in flight (`Reserving`) has no known id to evict, so it's
+        // rejected rather than admitted — two concurrent initializes must not both
+        // proceed. A real await-interleaving race isn't deterministic, so drive the
+        // state directly (the `Slot` machine is the contract under test).
+        let m = SingleSessionManager::default();
+        *m.slot.lock().expect("session slot mutex") = Slot::Reserving;
+        assert!(
+            m.create_session().await.is_err(),
+            "a create must be rejected while another is in flight"
+        );
+        assert!(
+            matches!(*m.slot.lock().expect("session slot mutex"), Slot::Reserving),
+            "the rejected create must not clobber the in-flight reservation"
+        );
+    }
+
+    #[test]
+    fn reservation_guard_reverts_stranded_reserving_on_drop() {
+        // A `create_session` future dropped mid-flight (client vanished during the
+        // handshake) must self-heal the slot instead of wedging it at `Reserving`.
+        let m = SingleSessionManager::default();
+        *m.slot.lock().expect("session slot mutex") = Slot::Reserving;
+        drop(ReservationGuard {
+            slot: &m.slot,
+            armed: true,
+        });
+        assert!(
+            matches!(*m.slot.lock().expect("session slot mutex"), Slot::Empty),
+            "a dropped armed guard must revert a stranded reservation to Empty"
+        );
+    }
+
+    #[test]
+    fn reservation_guard_disarmed_is_a_noop() {
+        // Once the create commits, dropping the guard must leave the slot alone.
+        let m = SingleSessionManager::default();
+        *m.slot.lock().expect("session slot mutex") = Slot::Reserving;
+        let mut g = ReservationGuard {
+            slot: &m.slot,
+            armed: true,
+        };
+        g.disarm();
+        drop(g);
+        assert!(
+            matches!(*m.slot.lock().expect("session slot mutex"), Slot::Reserving),
+            "a disarmed guard must not touch the slot"
+        );
+    }
+
+    #[tokio::test]
+    async fn reservation_guard_leaves_a_committed_session_untouched() {
+        // If the slot has already advanced to `Active` by the time an armed guard
+        // drops (e.g. another path committed), the guard must not clobber it.
+        let m = SingleSessionManager::default();
+        let (id, _t) = m.create_session().await.expect("session admitted");
+        drop(ReservationGuard {
+            slot: &m.slot,
+            armed: true,
+        });
+        assert_eq!(
+            m.active_id().as_ref(),
+            Some(&id),
+            "an armed guard must only revert `Reserving`, never a live `Active`"
+        );
     }
 }

--- a/crates/glass-mcp/tests/network_roundtrip.rs
+++ b/crates/glass-mcp/tests/network_roundtrip.rs
@@ -1,5 +1,5 @@
 //! Always-on network-transport tests: a real MCP handshake + tool call over HTTP,
-//! plus auth and single-client enforcement. Display-free (uses glass_doctor).
+//! plus auth and single-live-session takeover. Display-free (uses glass_doctor).
 
 #![cfg(feature = "network")]
 
@@ -76,10 +76,22 @@ async fn rejects_missing_token() {
 }
 
 #[tokio::test]
-async fn second_client_is_rejected() {
+async fn second_client_takes_over() {
     let url = start_server(Some("tok")).await;
-    let _c1 = ().serve(client_transport(&url, Some("tok"))).await.expect("first client");
-    // Second initialize must fail while the first session is live.
-    let c2 = ().serve(client_transport(&url, Some("tok"))).await;
-    assert!(c2.is_err(), "second concurrent client must be rejected");
+    let c1 = ().serve(client_transport(&url, Some("tok"))).await.expect("first client");
+    // A second client takes over the single live slot instead of being rejected —
+    // this is the reconnect path (a client that dropped without a clean DELETE
+    // would otherwise be locked out of its own server until the zombie expired).
+    let c2 = ().serve(client_transport(&url, Some("tok"))).await.expect("second client takes over");
+    // The newcomer is fully live over the taken-over slot.
+    c2.call_tool(CallToolRequestParams::new("glass_doctor"))
+        .await
+        .expect("taken-over session serves calls");
+    // c1's session was evicted server-side (its next request would 404). We don't
+    // assert on c1 here: the rmcp client transparently re-initializes on a 404, so
+    // a c1 call would silently heal into a fresh session rather than surface the
+    // eviction. The one-live-slot invariant is covered precisely by the
+    // session_gate unit tests; this test's job is the real-path reconnect admission.
+    let _ = c1;
+    c2.cancel().await.ok();
 }


### PR DESCRIPTION
## Problem

Under `serve --http`, reconnecting an MCP client fails with **"another session is active"** for up to 5 minutes.

A Streamable-HTTP MCP session is decoupled from its TCP connection by design (so it can survive a drop and resume), so rmcp only tears it down on an explicit `DELETE` or after its `keep_alive` idle timeout (default 5 min). An agent that dies or restarts almost never sends `DELETE`, so its session lingers as a zombie holding the single-session slot — and the agent's *own* reconnect is rejected until the timeout expires. `stdio` has no gate and is unaffected.

## Fix

Make the gate **last-client-wins**: `create_session` now evicts the session currently holding the slot and admits the newcomer. Only a create racing another still-in-flight create (the `Reserving` window) is rejected — there's no known id to evict yet, and two initializes racing in the same instant isn't a reconnect. glass is a single-user dev tool, so favouring the newcomer is the right trade.

### Also hardened: a pre-existing permanent-lockout risk

rmcp awaits `create_session` inline in the request task, so a client that disconnects **mid-handshake** drops the future and would strand the slot at `Reserving` — locking out *every* future client permanently (the exact failure this gate exists to prevent, and the takeover change widened the window). An RAII revert guard now resets the slot to `Empty` if the future is dropped before it commits. Surfaced by the pre-merge review panel.

The `close_session` id-match guard is retained: an evicted session's late worker-end close (or an unvalidated `DELETE` header) must not clear a *live* slot, or single-session tracking would be lost and a later client would run alongside the live one instead of taking over.

## Tests

- **Unit** (`session_gate.rs`): takeover admits a fresh session; the superseded session is actually evicted from the inner manager (via `has_session`); the `Reserving` reject branch; the revert guard (reverts stranded `Reserving`, no-op when disarmed, never clobbers a live `Active`); the id-guard under the eviction interleaving.
- **Real-path integration** (`network_roundtrip.rs`): two real rmcp clients over HTTP — the second takes over and serves `glass_doctor` (previously asserted the second was rejected).

`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, and `cargo test --workspace` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)