### PR TITLE
Freeze the MCP tool surface: uniform {ok,tool,result} envelope + typed params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+### Changed
+- **Every tool now returns a uniform result envelope.** On success, a tool's leading text block is
+  `{"ok": true, "tool": "<name>", "result": { … }}`, with the tool-specific fields under `result`.
+  Text the target app controls (the accessibility outline, log lines, clipboard contents, window
+  titles, and a matched element or log line) continues to arrive in its own block wrapped in the
+  untrusted marker — never inside `result`. Image tools return the image block first, then the
+  envelope, then the image note. An agent that read a tool's bare top-level JSON should now read the
+  fields under `result`.
+- **`glass_start`'s `env` is now a JSON object** `{ "KEY": "VALUE" }` instead of an array of
+  `[key, value]` pairs.
+- **`glass_logs`'s `max_lines` is a plain integer** (a `u32`).
+
 ## [0.5.0] - 2026-07-13
 
 ### Added

--- a/crates/glass-mcp/src/audit.rs
+++ b/crates/glass-mcp/src/audit.rs
@@ -781,7 +781,7 @@ mod tests {
                 backend: None,
                 sandbox: Some("off".into()),
                 cwd: None,
-                env: vec![],
+                env: std::collections::BTreeMap::new(),
                 window_hint: None,
                 timeout_ms: None,
                 a11y: None,

--- a/crates/glass-mcp/src/capabilities.rs
+++ b/crates/glass-mcp/src/capabilities.rs
@@ -106,16 +106,26 @@ pub fn capabilities_for(backend: &str) -> Option<CapabilityReport> {
     Some(CapabilityReport::NotOnThisHost)
 }
 
+/// Resolve `backend` (None => the default backend) and render the report as a JSON value
+/// (used by the MCP tool's envelope). `Err` names the valid backends when `backend` is an
+/// unrecognized value.
+pub fn render_value(backend: Option<&str>) -> Result<serde_json::Value, String> {
+    render_value_resolved(backend, std::env::var("GLASS_BACKEND").ok().as_deref())
+}
+
 /// Resolve `backend` (None => the default backend) and render the report as JSON text.
 /// `Err` names the valid backends when `backend` is an unrecognized value.
 pub fn render_json(backend: Option<&str>) -> Result<String, String> {
-    render_json_resolved(backend, std::env::var("GLASS_BACKEND").ok().as_deref())
+    render_value(backend).map(|v| v.to_string())
 }
 
-/// Pure core of [`render_json`], with the `GLASS_BACKEND` value passed in (`env`) so the
+/// Pure core of [`render_value`], with the `GLASS_BACKEND` value passed in (`env`) so the
 /// default-resolution branch is testable without mutating the process environment. `env` is
 /// consulted only when `backend` is `None`.
-fn render_json_resolved(backend: Option<&str>, env: Option<&str>) -> Result<String, String> {
+fn render_value_resolved(
+    backend: Option<&str>,
+    env: Option<&str>,
+) -> Result<serde_json::Value, String> {
     // A `None` caller with a set-but-unrecognized GLASS_BACKEND resolves to the host default;
     // surface that in the report the way `boot`/`doctor` do, rather than reporting the wrong
     // backend's capabilities with no indication the requested one was dropped.
@@ -139,7 +149,7 @@ fn render_json_resolved(backend: Option<&str>, env: Option<&str>) -> Result<Stri
         }
     };
     let report =
-        capabilities_for(name).expect("render_json resolved name to a canonical BACKENDS entry");
+        capabilities_for(name).expect("render_value resolved name to a canonical BACKENDS entry");
     let mut json = match report {
         CapabilityReport::Available(map) => {
             let caps: serde_json::Map<String, serde_json::Value> = map
@@ -164,7 +174,7 @@ fn render_json_resolved(backend: Option<&str>, env: Option<&str>) -> Result<Stri
             .expect("capability report is a JSON object")
             .insert("warning".to_string(), serde_json::Value::String(w));
     }
-    Ok(serde_json::to_string(&json).expect("capability report serializes"))
+    Ok(json)
 }
 
 #[cfg(test)]
@@ -234,6 +244,23 @@ mod tests {
     }
 
     #[test]
+    fn render_value_returns_a_json_object_not_a_string() {
+        let v = render_value(Some("android")).unwrap();
+        assert!(v.is_object(), "expected a JSON object, got {v:?}");
+        assert_eq!(v["backend"], "android");
+        assert_eq!(v["available"], true);
+    }
+
+    #[test]
+    fn render_value_matches_render_json_parsed() {
+        // render_json is a thin string wrapper over render_value; the two must agree.
+        let value = render_value(Some("android")).unwrap();
+        let parsed: serde_json::Value =
+            serde_json::from_str(&render_json(Some("android")).unwrap()).unwrap();
+        assert_eq!(value, parsed);
+    }
+
+    #[test]
     fn render_json_shapes_available_and_canonicalizes() {
         let v: serde_json::Value =
             serde_json::from_str(&render_json(Some("ANDROID")).unwrap()).unwrap();
@@ -263,20 +290,18 @@ mod tests {
     }
 
     #[test]
-    fn render_json_resolved_warns_on_unrecognized_env_backend() {
+    fn render_value_resolved_warns_on_unrecognized_env_backend() {
         // No explicit backend + a typo'd GLASS_BACKEND: report the host default's caps, but
         // attach a `warning` naming the dropped value so the fallback isn't silent (#148).
         let host_default = crate::default_backend(None);
-        let v: serde_json::Value =
-            serde_json::from_str(&render_json_resolved(None, Some("andriod")).unwrap()).unwrap();
+        let v = render_value_resolved(None, Some("andriod")).unwrap();
         assert_eq!(v["backend"], host_default);
         let warn = v["warning"].as_str().expect("warning field present");
         assert!(warn.contains("andriod"), "warning: {warn}");
 
         // A recognized value (or unset) attaches no warning — normal output is unchanged.
         for env in [Some("android"), None] {
-            let v: serde_json::Value =
-                serde_json::from_str(&render_json_resolved(None, env).unwrap()).unwrap();
+            let v = render_value_resolved(None, env).unwrap();
             assert!(v.get("warning").is_none(), "unexpected warning for {env:?}");
         }
     }

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -439,6 +439,13 @@ mod tests {
     }
 
     #[test]
+    fn start_env_rejects_array_of_pairs() {
+        // Locks the breaking change from the old `[["K","V"]]` array-of-pairs shape to the
+        // `{"K":"V"}` object: the array shape must no longer deserialize.
+        assert!(serde_json::from_str::<StartArgs>(r#"{"run":["app"],"env":[["K","V"]]}"#).is_err());
+    }
+
+    #[test]
     fn click_args_parse_with_optionals() {
         let a: ClickArgs =
             serde_json::from_str(r#"{"x":3,"y":4,"button":"right","count":2}"#).unwrap();

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -61,8 +61,9 @@ pub struct StartArgs {
     /// containment). Omit for the server default (`GLASS_SANDBOX`, else `default`).
     pub sandbox: Option<String>,
     pub cwd: Option<String>,
+    /// Extra environment variables for the launched app, as a `{ "KEY": "VALUE" }` object.
     #[serde(default)]
-    pub env: Vec<(String, String)>,
+    pub env: std::collections::BTreeMap<String, String>,
     /// Optional `{ title?, class? }` to disambiguate which window is the app's when
     /// more than one appears, or to find a window the launched process hands off to
     /// an unrelated process. Omit to take the first window owned by the launched
@@ -421,6 +422,20 @@ mod tests {
         assert_eq!(a.run, vec!["./app".to_string()]);
         assert!(a.env.is_empty());
         assert!(a.build.is_none());
+    }
+
+    #[test]
+    fn start_env_deserializes_as_object() {
+        let a: StartArgs =
+            serde_json::from_str(r#"{"run":["app"],"env":{"K":"V","A":"B"}}"#).unwrap();
+        assert_eq!(a.env.get("K").map(String::as_str), Some("V"));
+        assert_eq!(a.env.get("A").map(String::as_str), Some("B"));
+    }
+
+    #[test]
+    fn start_env_defaults_to_empty_when_omitted() {
+        let a: StartArgs = serde_json::from_str(r#"{"run":["app"]}"#).unwrap();
+        assert!(a.env.is_empty());
     }
 
     #[test]

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -365,7 +365,7 @@ pub struct DiffArgs {
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct LogsArgs {
     pub cursor: Option<u64>,
-    pub max_lines: Option<usize>,
+    pub max_lines: Option<u32>,
     /// "stdout", "stderr", or "both" (default).
     pub stream: Option<String>,
     pub contains: Option<String>,
@@ -461,6 +461,13 @@ mod tests {
     fn logs_args_default_to_none() {
         let a: LogsArgs = serde_json::from_str("{}").unwrap();
         assert!(a.cursor.is_none() && a.stream.is_none());
+    }
+
+    #[test]
+    fn logs_max_lines_is_u32() {
+        let a: LogsArgs = serde_json::from_str(r#"{"max_lines": 50}"#).unwrap();
+        let n: Option<u32> = a.max_lines; // compile-time: field is Option<u32>
+        assert_eq!(n, Some(50));
     }
 
     #[test]

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -294,7 +294,10 @@ impl GlassServer {
             tokio::task::spawn_blocking(move || crate::doctor::diagnose_with_audit(deep, &report))
                 .await
                 .expect("doctor task panicked");
-        Ok(to_call_result(ToolOutput::text(diag.render_text(backend))))
+        Ok(to_call_result(ToolOutput::result(
+            "glass_doctor",
+            serde_json::json!({ "report": diag.render_text(backend) }),
+        )))
     }
 
     #[tool(
@@ -314,7 +317,8 @@ impl GlassServer {
         Parameters(a): Parameters<CapabilitiesArgs>,
     ) -> Result<CallToolResult, McpError> {
         Ok(map_tool_result(
-            crate::capabilities::render_json(a.backend.as_deref()).map(ToolOutput::text),
+            crate::capabilities::render_value(a.backend.as_deref())
+                .map(|v| ToolOutput::result("glass_capabilities", v)),
         ))
     }
 
@@ -596,11 +600,56 @@ mod tests {
 
         let text = first_text(&out);
         let v: serde_json::Value = serde_json::from_str(&text).unwrap();
-        assert_eq!(v["backend"], "android");
-        assert_eq!(v["available"], true);
+        assert_eq!(v["ok"], true);
+        assert_eq!(v["tool"], "glass_capabilities");
+        let result = &v["result"];
+        assert_eq!(result["backend"], "android");
+        assert_eq!(result["available"], true);
         assert_eq!(
-            v["capabilities"]["window_move_resize"]["status"],
+            result["capabilities"]["window_move_resize"]["status"],
             "unsupported"
+        );
+    }
+
+    #[tokio::test]
+    async fn glass_capabilities_rejects_an_unknown_backend() {
+        let glass =
+            crate::tools::testutil::glass_with(crate::tools::testutil::FakePlatform::new(100, 100));
+        let report = crate::audit::report_from_config(None, |_| None);
+        let server = GlassServer::new(glass, report);
+
+        let out = server
+            .glass_capabilities(Parameters(CapabilitiesArgs {
+                backend: Some("nope".into()),
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(out.is_error, Some(true));
+        assert!(first_text(&out).contains("nope"));
+    }
+
+    #[tokio::test]
+    async fn glass_doctor_envelopes_the_report_text() {
+        let glass =
+            crate::tools::testutil::glass_with(crate::tools::testutil::FakePlatform::new(100, 100));
+        let report = crate::audit::report_from_config(None, |_| None);
+        let server = GlassServer::new(glass, report);
+
+        let out = server
+            .glass_doctor(Parameters(DoctorArgs { deep: None }))
+            .await
+            .unwrap();
+
+        let text = first_text(&out);
+        let v: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(v["ok"], true);
+        assert_eq!(v["tool"], "glass_doctor");
+        assert!(
+            v["result"]["report"]
+                .as_str()
+                .is_some_and(|s| !s.is_empty()),
+            "expected a non-empty result.report string, got {v}"
         );
     }
 

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -573,7 +573,10 @@ mod tests {
 
     #[test]
     fn map_tool_result_marks_ok_as_success() {
-        let r = map_tool_result(Ok(ToolOutput::text("done")));
+        let r = map_tool_result(Ok(ToolOutput::result(
+            "glass_test",
+            serde_json::json!("done"),
+        )));
         assert_eq!(
             r.is_error,
             Some(false),

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -547,6 +547,20 @@ impl ServerHandler for GlassServer {
     }
 }
 
+/// The live `#[tool]` registry's names. The doc-sync guard tests below bind
+/// `docs/reference/tools.md` to this; [`crate::tools::testutil::assert_envelope`] binds a
+/// test's expected envelope `tool` string to it too, so a co-typo shared between a tool impl
+/// and its test (e.g. both saying `"glass_stop"` when the registered name is `"glass_stopp"`)
+/// fails loudly instead of passing green.
+#[cfg(test)]
+pub(crate) fn registered_tools() -> std::collections::BTreeSet<String> {
+    GlassServer::tool_router()
+        .list_all()
+        .into_iter()
+        .map(|tool| tool.name.into_owned())
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -773,14 +787,6 @@ mod tests {
             .filter_map(|line| line.strip_prefix("### `"))
             .filter_map(|rest| rest.strip_suffix('`'))
             .map(str::to_owned)
-            .collect()
-    }
-
-    fn registered_tools() -> BTreeSet<String> {
-        GlassServer::tool_router()
-            .list_all()
-            .into_iter()
-            .map(|tool| tool.name.into_owned())
             .collect()
     }
 

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -46,7 +46,7 @@ impl ToolOutput {
 }
 
 /// Serialize the success envelope. `ok` is always true — errors take the `Err` path.
-fn envelope(tool: &str, result: serde_json::Value) -> String {
+pub(crate) fn envelope(tool: &str, result: serde_json::Value) -> String {
     serde_json::json!({ "ok": true, "tool": tool, "result": result }).to_string()
 }
 

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -33,17 +33,11 @@ impl ToolOutput {
 
     /// Wrap a tool's trusted result payload in the uniform 1.0 success envelope
     /// as the sole leading content block.
-    // `expect(dead_code)` doesn't fit: nothing calls this outside `mod tests` yet, so
-    // dead_code fires on the plain lib target but not the cfg(test) one, and `expect`
-    // demands the lint fire in every compilation. Later tool-surface-freeze tasks wire
-    // this into the tool handlers, which will make `allow` unneeded — remove it then.
-    #[allow(dead_code)]
     pub fn result(tool: &str, result: serde_json::Value) -> Self {
         ToolOutput(vec![OutContent::Text(envelope(tool, result))])
     }
 
     /// Envelope block first, then app-controlled/image sibling blocks unchanged.
-    #[allow(dead_code)]
     pub fn result_with(tool: &str, result: serde_json::Value, mut extra: Vec<OutContent>) -> Self {
         let mut v = vec![OutContent::Text(envelope(tool, result))];
         v.append(&mut extra);
@@ -59,8 +53,8 @@ fn envelope(tool: &str, result: serde_json::Value) -> String {
 /// Tool result: Ok(content) or Err(agent-readable message).
 pub type ToolResult = Result<ToolOutput, String>;
 
-fn geometry_json(g: &WindowGeometry) -> String {
-    json!({ "x": g.x, "y": g.y, "width": g.width, "height": g.height }).to_string()
+fn geometry_value(g: &WindowGeometry) -> serde_json::Value {
+    json!({ "x": g.x, "y": g.y, "width": g.width, "height": g.height })
 }
 
 /// Resolve the sandbox level: explicit arg → `GLASS_SANDBOX` env → `Default`.
@@ -100,12 +94,12 @@ pub fn start(glass: &mut Glass, a: &StartArgs) -> ToolResult {
         None => glass.start(&spec),
     }
     .map_err(|e| e.to_string())?;
-    Ok(ToolOutput::text(geometry_json(&geo)))
+    Ok(ToolOutput::result("glass_start", geometry_value(&geo)))
 }
 
 pub fn stop(glass: &mut Glass) -> ToolResult {
     glass.stop().map_err(|e| e.to_string())?;
-    Ok(ToolOutput::text("stopped"))
+    Ok(ToolOutput::result("glass_stop", serde_json::json!({})))
 }
 
 pub fn window(glass: &mut Glass, a: &WindowArgs) -> ToolResult {
@@ -127,7 +121,7 @@ pub fn window(glass: &mut Glass, a: &WindowArgs) -> ToolResult {
         other => return Err(format!("unknown window op '{other}'")),
     };
     let geo = glass.window(&op).map_err(|e| e.to_string())?;
-    Ok(ToolOutput::text(geometry_json(&geo)))
+    Ok(ToolOutput::result("glass_window", geometry_value(&geo)))
 }
 
 pub fn list_windows(glass: &mut Glass) -> ToolResult {
@@ -148,67 +142,108 @@ pub fn list_windows(glass: &mut Glass) -> ToolResult {
         })
         .collect();
     let body = serde_json::Value::Array(arr).to_string();
-    Ok(ToolOutput::text(crate::untrusted::wrap_untrusted(&body)))
+    Ok(ToolOutput::result_with(
+        "glass_list_windows",
+        serde_json::json!({ "count": windows.len() }),
+        vec![OutContent::Text(crate::untrusted::wrap_untrusted(&body))],
+    ))
 }
 
 pub fn select_window(glass: &mut Glass, a: &SelectWindowArgs) -> ToolResult {
     let geo = glass
         .select_window(WindowId(a.id))
         .map_err(|e| e.to_string())?;
-    Ok(ToolOutput::text(geometry_json(&geo)))
+    Ok(ToolOutput::result(
+        "glass_select_window",
+        geometry_value(&geo),
+    ))
 }
 
 pub fn a11y_snapshot(glass: &mut Glass) -> ToolResult {
     let tree = glass.a11y_snapshot().map_err(|e| e.to_string())?;
     let body = tree.to_outline();
-    Ok(ToolOutput::text(crate::untrusted::wrap_untrusted(&body)))
+    Ok(ToolOutput::result_with(
+        "glass_a11y_snapshot",
+        serde_json::json!({}),
+        vec![OutContent::Text(crate::untrusted::wrap_untrusted(&body))],
+    ))
 }
 
-/// A text-only `wait_stable` (default knobs, no image) for the `return:"settle"` observe.
-fn settle_text_only_args() -> WaitStableArgs {
-    WaitStableArgs {
-        interval_ms: None,
-        settle_frames: None,
-        tolerance: None,
-        timeout_ms: None,
-        region: None,
+/// Defaults matching the text-only settle the observe used before.
+fn settle_params() -> glass_core::WaitStableParams {
+    glass_core::WaitStableParams {
+        interval_ms: 100,
+        settle_frames: 3,
+        tolerance: 0,
+        timeout_ms: 5000,
         stability_region: None,
-        include_image: Some(false),
-        window_id: None,
+        window: None,
     }
 }
 
-/// Append the optional post-action observe (`return`) to a tool's output.
-fn append_return(
+/// Apply the optional `return` observe. `settle` → `Some(metadata)` to merge under
+/// `result.observed`; `snapshot` → an untrusted outline sibling to append; none/absent
+/// → neither. Calls the `Glass` methods directly (not the `a11y_snapshot`/`wait_stable`
+/// tool functions) so a composed observe never nests another envelope. Unknown value
+/// → `Err` (unchanged rejection).
+fn resolve_return(
     glass: &mut Glass,
     ret: Option<&str>,
-    out: &mut Vec<OutContent>,
-) -> Result<(), String> {
+) -> Result<(Option<serde_json::Value>, Vec<OutContent>), String> {
     match ret {
-        None | Some("none") => {}
-        Some("settle") => out.extend(wait_stable(glass, &settle_text_only_args())?.0),
-        Some("snapshot") => out.extend(a11y_snapshot(glass)?.0),
-        Some(o) => return Err(format!("unknown return '{o}' (use none/settle/snapshot)")),
+        None | Some("none") => Ok((None, vec![])),
+        Some("settle") => {
+            let o = glass
+                .wait_stable(&settle_params())
+                .map_err(|e| e.to_string())?;
+            Ok((
+                Some(serde_json::json!({
+                    "settled": o.settled,
+                    "saw_motion": o.saw_motion,
+                    "observed_ms": o.observed_ms,
+                })),
+                vec![],
+            ))
+        }
+        Some("snapshot") => {
+            let tree = glass.a11y_snapshot().map_err(|e| e.to_string())?;
+            Ok((
+                None,
+                vec![OutContent::Text(crate::untrusted::wrap_untrusted(
+                    &tree.to_outline(),
+                ))],
+            ))
+        }
+        Some(o) => Err(format!("unknown return '{o}' (use none/settle/snapshot)")),
     }
-    Ok(())
 }
 
 pub fn click_element(glass: &mut Glass, a: &ClickElementArgs) -> ToolResult {
     glass
         .click_element(AxNodeId(a.id))
         .map_err(|e| e.to_string())?;
-    let mut out = vec![OutContent::Text(format!("clicked element #{}", a.id))];
-    append_return(glass, a.return_.as_deref(), &mut out)?;
-    Ok(ToolOutput(out))
+    let (observed, extra) = resolve_return(glass, a.return_.as_deref())?;
+    let mut result = serde_json::json!({ "id": a.id });
+    if let Some(o) = observed {
+        result["observed"] = o;
+    }
+    Ok(ToolOutput::result_with(
+        "glass_click_element",
+        result,
+        extra,
+    ))
 }
 
 pub fn set_value(glass: &mut Glass, a: &SetValueArgs) -> ToolResult {
     glass
         .set_value(AxNodeId(a.id), &a.text)
         .map_err(|e| e.to_string())?;
-    let mut out = vec![OutContent::Text(format!("set value of element #{}", a.id))];
-    append_return(glass, a.return_.as_deref(), &mut out)?;
-    Ok(ToolOutput(out))
+    let (observed, extra) = resolve_return(glass, a.return_.as_deref())?;
+    let mut result = serde_json::json!({ "id": a.id });
+    if let Some(o) = observed {
+        result["observed"] = o;
+    }
+    Ok(ToolOutput::result_with("glass_set_value", result, extra))
 }
 
 pub fn a11y_marks(glass: &mut Glass) -> ToolResult {
@@ -228,6 +263,10 @@ pub fn a11y_marks(glass: &mut Glass) -> ToolResult {
     };
     Ok(ToolOutput(vec![
         OutContent::Image(img),
+        OutContent::Text(envelope(
+            "glass_a11y_marks",
+            serde_json::json!({ "count": marks.len() }),
+        )),
         OutContent::Text(crate::untrusted::wrap_untrusted(&legend)),
         OutContent::Text(crate::untrusted::IMAGE_NOTE.to_string()),
     ]))
@@ -528,6 +567,18 @@ mod tests {
     use super::*;
     use glass_core::{AppSpec, SandboxLevel};
 
+    /// Parse `out.0[0]` as the leading envelope, assert its `ok`/`tool` shape,
+    /// and return the parsed value so a test can read `result.*` off it.
+    fn envelope_value(out: &ToolOutput, tool: &str) -> serde_json::Value {
+        let OutContent::Text(t) = &out.0[0] else {
+            panic!("expected envelope text as the first item")
+        };
+        let v: serde_json::Value = serde_json::from_str(t).expect("envelope must be valid JSON");
+        assert_eq!(v["ok"], json!(true), "envelope: {v}");
+        assert_eq!(v["tool"], json!(tool), "envelope: {v}");
+        v
+    }
+
     fn start_args() -> StartArgs {
         StartArgs {
             build: None,
@@ -564,13 +615,9 @@ mod tests {
     fn start_returns_geometry_json() {
         let mut g = glass_with(FakePlatform::new(80, 60));
         let out = start(&mut g, &start_args()).unwrap();
-        match &out.0[0] {
-            OutContent::Text(t) => {
-                assert!(t.contains("\"width\":80"));
-                assert!(t.contains("\"height\":60"));
-            }
-            _ => panic!("expected text"),
-        }
+        let v = envelope_value(&out, "glass_start");
+        assert_eq!(v["result"]["width"], json!(80));
+        assert_eq!(v["result"]["height"], json!(60));
     }
 
     #[test]
@@ -614,12 +661,9 @@ mod tests {
             height: Some(44),
         };
         let out = window(&mut g, &a).unwrap();
-        match &out.0[0] {
-            OutContent::Text(t) => {
-                assert!(t.contains("\"width\":33") && t.contains("\"height\":44"))
-            }
-            _ => panic!("expected text"),
-        }
+        let v = envelope_value(&out, "glass_window");
+        assert_eq!(v["result"]["width"], json!(33));
+        assert_eq!(v["result"]["height"], json!(44));
     }
 
     #[test]
@@ -647,7 +691,8 @@ mod tests {
         })
         .unwrap();
         let out = a11y_snapshot(&mut g).unwrap();
-        match &out.0[0] {
+        envelope_value(&out, "glass_a11y_snapshot");
+        match &out.0[1] {
             OutContent::Text(t) => {
                 assert!(
                     t.starts_with(crate::untrusted::NOTE),
@@ -709,10 +754,8 @@ mod tests {
             },
         )
         .unwrap();
-        match &out.0[0] {
-            OutContent::Text(t) => assert!(t.contains("set value of element #1"), "msg: {t}"),
-            _ => panic!("expected text"),
-        }
+        let v = envelope_value(&out, "glass_set_value");
+        assert_eq!(v["result"]["id"], json!(1), "envelope: {v}");
         // unknown id surfaces the actionable message
         let err = set_value(
             &mut g,
@@ -835,14 +878,21 @@ mod tests {
             matches!(out.0[0], OutContent::Image(_)),
             "first item is the image"
         );
-        match &out.0[1] {
+        let OutContent::Text(t) = &out.0[1] else {
+            panic!("expected envelope text as the second item")
+        };
+        let v: serde_json::Value = serde_json::from_str(t).expect("envelope must be valid JSON");
+        assert_eq!(v["ok"], json!(true), "envelope: {v}");
+        assert_eq!(v["tool"], json!("glass_a11y_marks"), "envelope: {v}");
+        assert_eq!(v["result"]["count"], json!(1), "envelope: {v}");
+        match &out.0[2] {
             OutContent::Text(t) => assert!(t.contains("#1 Button \"Save\""), "legend: {t}"),
             _ => panic!("expected legend text"),
         }
     }
 
     #[test]
-    fn a11y_marks_legend_enveloped_and_image_note_present() {
+    fn a11y_marks_legend_untrusted_wrapped_and_image_note_present() {
         use glass_core::Frame;
         let platform =
             FakePlatform::new(100, 100).with_frames(vec![Frame::solid(100, 100, [0, 0, 0, 255])]);
@@ -859,14 +909,29 @@ mod tests {
         })
         .unwrap();
         let out = a11y_marks(&mut g).unwrap();
-        // [Image, legend-Text (enveloped), IMAGE_NOTE-Text]
+        // [Image, envelope-Text, legend-Text (untrusted-wrapped), IMAGE_NOTE-Text]
         assert!(
-            out.0.len() >= 3,
-            "expected [Image, legend, IMAGE_NOTE], got {} items",
+            out.0.len() >= 4,
+            "expected [Image, envelope, legend, IMAGE_NOTE], got {} items",
             out.0.len()
         );
-        // legend must be enveloped
+        assert!(
+            matches!(out.0[0], OutContent::Image(_)),
+            "image leads: {:?}",
+            out.0
+        );
+        // the trusted envelope comes right after the image
         match &out.0[1] {
+            OutContent::Text(t) => {
+                let v: serde_json::Value =
+                    serde_json::from_str(t).expect("envelope must be valid JSON");
+                assert_eq!(v["ok"], json!(true), "envelope: {v}");
+                assert_eq!(v["tool"], json!("glass_a11y_marks"), "envelope: {v}");
+            }
+            _ => panic!("expected envelope text as second item"),
+        }
+        // legend must be untrusted-wrapped
+        match &out.0[2] {
             OutContent::Text(t) => {
                 assert!(
                     t.starts_with(crate::untrusted::NOTE),
@@ -874,14 +939,14 @@ mod tests {
                 );
                 assert!(
                     t.contains("⟦untrusted:") && t.contains("⟦/untrusted:"),
-                    "legend must be in envelope: {t}"
+                    "legend must be untrusted-wrapped: {t}"
                 );
                 assert!(
                     t.contains("#1 Button"),
                     "legend must still contain element: {t}"
                 );
             }
-            _ => panic!("expected legend text as second item"),
+            _ => panic!("expected legend text as third item"),
         }
         // IMAGE_NOTE must be present
         let has_note = out
@@ -919,7 +984,11 @@ mod tests {
             },
         )
         .unwrap();
-        assert_eq!(out.0.len(), 1);
+        assert_eq!(out.0.len(), 1, "just the envelope, no siblings");
+        let v = envelope_value(&out, "glass_click_element");
+        assert_eq!(v["result"]["id"], json!(1), "envelope: {v}");
+        assert!(v["result"]["observed"].is_null(), "envelope: {v}");
+
         let out2 = click_element(
             &mut g,
             &ClickElementArgs {
@@ -959,12 +1028,14 @@ mod tests {
         assert_eq!(
             out.0.len(),
             2,
-            "snapshot return appends exactly one item (the a11y outline)"
+            "envelope + exactly one sibling (the a11y outline)"
         );
-        match &out.0[0] {
-            OutContent::Text(t) => assert!(t.contains("clicked element #1"), "got: {t}"),
-            _ => panic!("expected confirmation text"),
-        }
+        let v = envelope_value(&out, "glass_click_element");
+        assert_eq!(v["result"]["id"], json!(1), "envelope: {v}");
+        assert!(
+            v["result"]["observed"].is_null(),
+            "snapshot doesn't populate `observed`: {v}"
+        );
         match &out.0[1] {
             OutContent::Text(t) => {
                 assert!(
@@ -1002,10 +1073,18 @@ mod tests {
             },
         )
         .unwrap();
-        match &out.0[1] {
-            OutContent::Text(t) => assert!(t.contains("\"settled\":true"), "got: {t}"),
-            _ => panic!("expected settle text"),
-        }
+        assert_eq!(
+            out.0.len(),
+            1,
+            "settle folds into `result.observed`, no extra sibling"
+        );
+        let v = envelope_value(&out, "glass_click_element");
+        assert_eq!(v["result"]["id"], json!(1), "envelope: {v}");
+        assert_eq!(
+            v["result"]["observed"]["settled"],
+            json!(true),
+            "envelope: {v}"
+        );
     }
 
     #[test]
@@ -1020,10 +1099,8 @@ mod tests {
             },
         )
         .unwrap();
-        match &out.0[0] {
-            OutContent::Text(t) => assert!(t.contains("set value of element #1"), "got: {t}"),
-            _ => panic!("expected confirmation"),
-        }
+        let v = envelope_value(&out, "glass_set_value");
+        assert_eq!(v["result"]["id"], json!(1), "envelope: {v}");
         assert!(
             matches!(&out.0[1], OutContent::Text(t) if t.starts_with(crate::untrusted::NOTE) && t.contains("#1 Button")),
             "outline appended"
@@ -1046,7 +1123,9 @@ mod tests {
         .unwrap();
 
         let out = list_windows(&mut g).unwrap();
-        let text = match &out.0[0] {
+        let v = envelope_value(&out, "glass_list_windows");
+        assert_eq!(v["result"]["count"], json!(1), "envelope: {v}");
+        let text = match &out.0[1] {
             OutContent::Text(t) => t.clone(),
             _ => panic!("expected text"),
         };

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -80,7 +80,7 @@ pub fn start(glass: &mut Glass, a: &StartArgs) -> ToolResult {
         build: a.build.clone(),
         run: a.run.clone(),
         cwd: a.cwd.clone().map(PathBuf::from),
-        env: a.env.clone(),
+        env: a.env.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
         window_hint: a.window_hint.as_ref().map(|h| WindowHint {
             title: h.title.clone(),
             class: h.class.clone(),
@@ -586,7 +586,7 @@ mod tests {
             backend: None,
             sandbox: None,
             cwd: None,
-            env: vec![],
+            env: std::collections::BTreeMap::new(),
             window_hint: None,
             timeout_ms: None,
             a11y: None,

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -27,10 +27,6 @@ pub enum OutContent {
 pub struct ToolOutput(pub Vec<OutContent>);
 
 impl ToolOutput {
-    pub fn text(s: impl Into<String>) -> Self {
-        ToolOutput(vec![OutContent::Text(s.into())])
-    }
-
     /// Wrap a tool's trusted result payload in the uniform 1.0 success envelope
     /// as the sole leading content block.
     pub fn result(tool: &str, result: serde_json::Value) -> Self {

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -629,6 +629,18 @@ mod tests {
     }
 
     #[test]
+    fn start_rejects_unknown_sandbox() {
+        // Locks rejection at the `glass_start` tool boundary (not just the
+        // `resolve_sandbox`/`SandboxLevel::FromStr` units below it) — an unknown
+        // `sandbox` must not be silently coerced to the default level.
+        let mut g = glass_with(FakePlatform::new(10, 10));
+        let mut a = start_args();
+        a.sandbox = Some("bogus".into());
+        let err = start(&mut g, &a).unwrap_err();
+        assert!(err.contains("unknown sandbox level"), "got: {err}");
+    }
+
+    #[test]
     fn stop_without_session_errors_with_message() {
         let mut g = glass_with(FakePlatform::new(10, 10));
         let err = stop(&mut g).unwrap_err();
@@ -664,6 +676,21 @@ mod tests {
         let v = envelope_value(&out, "glass_window");
         assert_eq!(v["result"]["width"], json!(33));
         assert_eq!(v["result"]["height"], json!(44));
+    }
+
+    #[test]
+    fn window_rejects_unknown_op() {
+        let mut g = glass_with(FakePlatform::new(10, 10));
+        start(&mut g, &start_args()).unwrap();
+        let a = WindowArgs {
+            op: "levitate".into(),
+            x: None,
+            y: None,
+            width: None,
+            height: None,
+        };
+        let err = window(&mut g, &a).unwrap_err();
+        assert!(err.contains("unknown window op"), "got: {err}");
     }
 
     #[test]

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -323,6 +323,8 @@ pub(crate) mod testutil {
         WindowInfo, WindowOp,
     };
 
+    use super::{OutContent, ToolOutput};
+
     #[derive(Default)]
     pub struct FakePlatform {
         pub geometry: WindowGeometry,
@@ -574,6 +576,28 @@ pub(crate) mod testutil {
         });
         Glass::new(factory, "x11".into(), BaselineStore::new(root), 100)
     }
+
+    /// Parse content block `i` as the `{ok,tool,result}` envelope.
+    pub(crate) fn envelope_at(out: &ToolOutput, i: usize) -> serde_json::Value {
+        let OutContent::Text(t) = &out.0[i] else {
+            panic!("expected envelope text at block {i}")
+        };
+        serde_json::from_str(t).expect("envelope must be valid JSON")
+    }
+
+    /// Assert block 0 is the success envelope for `tool` — and that `tool` is a REGISTERED
+    /// `#[tool]` name, so a co-typo shared between the tool impl's envelope literal and the
+    /// test's expected string (both say `"glass_stopp"`) still fails loudly. Returns `result`.
+    pub(crate) fn assert_envelope(out: &ToolOutput, tool: &str) -> serde_json::Value {
+        let v = envelope_at(out, 0);
+        assert_eq!(v["ok"], serde_json::json!(true), "envelope: {v}");
+        assert_eq!(v["tool"], serde_json::json!(tool), "envelope: {v}");
+        assert!(
+            crate::server::registered_tools().iter().any(|t| t == tool),
+            "envelope tool {tool:?} is not a registered #[tool]"
+        );
+        v["result"].clone()
+    }
 }
 
 #[cfg(test)]
@@ -581,18 +605,6 @@ mod tests {
     use super::testutil::*;
     use super::*;
     use glass_core::{AppSpec, SandboxLevel};
-
-    /// Parse `out.0[0]` as the leading envelope, assert its `ok`/`tool` shape,
-    /// and return the parsed value so a test can read `result.*` off it.
-    fn envelope_value(out: &ToolOutput, tool: &str) -> serde_json::Value {
-        let OutContent::Text(t) = &out.0[0] else {
-            panic!("expected envelope text as the first item")
-        };
-        let v: serde_json::Value = serde_json::from_str(t).expect("envelope must be valid JSON");
-        assert_eq!(v["ok"], json!(true), "envelope: {v}");
-        assert_eq!(v["tool"], json!(tool), "envelope: {v}");
-        v
-    }
 
     fn start_args() -> StartArgs {
         StartArgs {
@@ -630,9 +642,9 @@ mod tests {
     fn start_returns_geometry_json() {
         let mut g = glass_with(FakePlatform::new(80, 60));
         let out = start(&mut g, &start_args()).unwrap();
-        let v = envelope_value(&out, "glass_start");
-        assert_eq!(v["result"]["width"], json!(80));
-        assert_eq!(v["result"]["height"], json!(60));
+        let v = assert_envelope(&out, "glass_start");
+        assert_eq!(v["width"], json!(80));
+        assert_eq!(v["height"], json!(60));
     }
 
     #[test]
@@ -663,6 +675,15 @@ mod tests {
     }
 
     #[test]
+    fn stop_running_session_returns_empty_envelope() {
+        let mut g = glass_with(FakePlatform::new(10, 10));
+        start(&mut g, &start_args()).unwrap();
+        let out = stop(&mut g).unwrap();
+        let v = assert_envelope(&out, "glass_stop");
+        assert_eq!(v, json!({}), "envelope: {v}");
+    }
+
+    #[test]
     fn window_resize_requires_dimensions() {
         let mut g = glass_with(FakePlatform::new(10, 10));
         start(&mut g, &start_args()).unwrap();
@@ -688,9 +709,9 @@ mod tests {
             height: Some(44),
         };
         let out = window(&mut g, &a).unwrap();
-        let v = envelope_value(&out, "glass_window");
-        assert_eq!(v["result"]["width"], json!(33));
-        assert_eq!(v["result"]["height"], json!(44));
+        let v = assert_envelope(&out, "glass_window");
+        assert_eq!(v["width"], json!(33));
+        assert_eq!(v["height"], json!(44));
     }
 
     #[test]
@@ -733,7 +754,7 @@ mod tests {
         })
         .unwrap();
         let out = a11y_snapshot(&mut g).unwrap();
-        envelope_value(&out, "glass_a11y_snapshot");
+        assert_envelope(&out, "glass_a11y_snapshot");
         match &out.0[1] {
             OutContent::Text(t) => {
                 assert!(
@@ -796,8 +817,8 @@ mod tests {
             },
         )
         .unwrap();
-        let v = envelope_value(&out, "glass_set_value");
-        assert_eq!(v["result"]["id"], json!(1), "envelope: {v}");
+        let v = assert_envelope(&out, "glass_set_value");
+        assert_eq!(v["id"], json!(1), "envelope: {v}");
         // unknown id surfaces the actionable message
         let err = set_value(
             &mut g,
@@ -1027,9 +1048,9 @@ mod tests {
         )
         .unwrap();
         assert_eq!(out.0.len(), 1, "just the envelope, no siblings");
-        let v = envelope_value(&out, "glass_click_element");
-        assert_eq!(v["result"]["id"], json!(1), "envelope: {v}");
-        assert!(v["result"]["observed"].is_null(), "envelope: {v}");
+        let v = assert_envelope(&out, "glass_click_element");
+        assert_eq!(v["id"], json!(1), "envelope: {v}");
+        assert!(v["observed"].is_null(), "envelope: {v}");
 
         let out2 = click_element(
             &mut g,
@@ -1072,10 +1093,10 @@ mod tests {
             2,
             "envelope + exactly one sibling (the a11y outline)"
         );
-        let v = envelope_value(&out, "glass_click_element");
-        assert_eq!(v["result"]["id"], json!(1), "envelope: {v}");
+        let v = assert_envelope(&out, "glass_click_element");
+        assert_eq!(v["id"], json!(1), "envelope: {v}");
         assert!(
-            v["result"]["observed"].is_null(),
+            v["observed"].is_null(),
             "snapshot doesn't populate `observed`: {v}"
         );
         match &out.0[1] {
@@ -1120,13 +1141,9 @@ mod tests {
             1,
             "settle folds into `result.observed`, no extra sibling"
         );
-        let v = envelope_value(&out, "glass_click_element");
-        assert_eq!(v["result"]["id"], json!(1), "envelope: {v}");
-        assert_eq!(
-            v["result"]["observed"]["settled"],
-            json!(true),
-            "envelope: {v}"
-        );
+        let v = assert_envelope(&out, "glass_click_element");
+        assert_eq!(v["id"], json!(1), "envelope: {v}");
+        assert_eq!(v["observed"]["settled"], json!(true), "envelope: {v}");
     }
 
     #[test]
@@ -1141,12 +1158,37 @@ mod tests {
             },
         )
         .unwrap();
-        let v = envelope_value(&out, "glass_set_value");
-        assert_eq!(v["result"]["id"], json!(1), "envelope: {v}");
+        let v = assert_envelope(&out, "glass_set_value");
+        assert_eq!(v["id"], json!(1), "envelope: {v}");
         assert!(
             matches!(&out.0[1], OutContent::Text(t) if t.starts_with(crate::untrusted::NOTE) && t.contains("#1 Button")),
             "outline appended"
         );
+    }
+
+    #[test]
+    fn set_value_return_settle_folds_into_observed() {
+        use glass_core::Frame;
+        // Mirrors `return_settle_appends_settled_text` for `click_element`: wait_stable
+        // needs frames; one solid frame (repeated by the fake) settles.
+        let mut g = started_a11y_frames(vec![Frame::solid(100, 100, [0, 0, 0, 255])]);
+        let out = set_value(
+            &mut g,
+            &SetValueArgs {
+                id: 1,
+                text: "x".into(),
+                return_: Some("settle".into()),
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            out.0.len(),
+            1,
+            "settle folds into `result.observed`, no extra sibling"
+        );
+        let v = assert_envelope(&out, "glass_set_value");
+        assert_eq!(v["id"], json!(1), "envelope: {v}");
+        assert_eq!(v["observed"]["settled"], json!(true), "envelope: {v}");
     }
 
     #[test]
@@ -1165,8 +1207,8 @@ mod tests {
         .unwrap();
 
         let out = list_windows(&mut g).unwrap();
-        let v = envelope_value(&out, "glass_list_windows");
-        assert_eq!(v["result"]["count"], json!(1), "envelope: {v}");
+        let v = assert_envelope(&out, "glass_list_windows");
+        assert_eq!(v["count"], json!(1), "envelope: {v}");
         let text = match &out.0[1] {
             OutContent::Text(t) => t.clone(),
             _ => panic!("expected text"),
@@ -1192,7 +1234,10 @@ mod tests {
             "json should include geometry width: {text}"
         );
 
-        assert!(select_window(&mut g, &SelectWindowArgs { id: 0 }).is_ok());
+        let out = select_window(&mut g, &SelectWindowArgs { id: 0 }).unwrap();
+        let v = assert_envelope(&out, "glass_select_window");
+        assert_eq!(v["width"], json!(320), "envelope: {v}");
+        assert_eq!(v["height"], json!(240), "envelope: {v}");
         assert!(select_window(&mut g, &SelectWindowArgs { id: 42 }).is_err());
     }
 

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -30,6 +30,30 @@ impl ToolOutput {
     pub fn text(s: impl Into<String>) -> Self {
         ToolOutput(vec![OutContent::Text(s.into())])
     }
+
+    /// Wrap a tool's trusted result payload in the uniform 1.0 success envelope
+    /// as the sole leading content block.
+    // `expect(dead_code)` doesn't fit: nothing calls this outside `mod tests` yet, so
+    // dead_code fires on the plain lib target but not the cfg(test) one, and `expect`
+    // demands the lint fire in every compilation. Later tool-surface-freeze tasks wire
+    // this into the tool handlers, which will make `allow` unneeded — remove it then.
+    #[allow(dead_code)]
+    pub fn result(tool: &str, result: serde_json::Value) -> Self {
+        ToolOutput(vec![OutContent::Text(envelope(tool, result))])
+    }
+
+    /// Envelope block first, then app-controlled/image sibling blocks unchanged.
+    #[allow(dead_code)]
+    pub fn result_with(tool: &str, result: serde_json::Value, mut extra: Vec<OutContent>) -> Self {
+        let mut v = vec![OutContent::Text(envelope(tool, result))];
+        v.append(&mut extra);
+        ToolOutput(v)
+    }
+}
+
+/// Serialize the success envelope. `ok` is always true — errors take the `Err` path.
+fn envelope(tool: &str, result: serde_json::Value) -> String {
+    serde_json::json!({ "ok": true, "tool": tool, "result": result }).to_string()
 }
 
 /// Tool result: Ok(content) or Err(agent-readable message).
@@ -1049,5 +1073,28 @@ mod tests {
 
         assert!(select_window(&mut g, &SelectWindowArgs { id: 0 }).is_ok());
         assert!(select_window(&mut g, &SelectWindowArgs { id: 42 }).is_err());
+    }
+
+    #[test]
+    fn result_envelope_is_leading_and_shaped() {
+        let out = ToolOutput::result("glass_stop", serde_json::json!({}));
+        let OutContent::Text(t) = &out.0[0] else {
+            panic!("expected text")
+        };
+        let v: serde_json::Value = serde_json::from_str(t).unwrap();
+        assert_eq!(v["ok"], serde_json::json!(true));
+        assert_eq!(v["tool"], serde_json::json!("glass_stop"));
+        assert_eq!(v["result"], serde_json::json!({}));
+    }
+
+    #[test]
+    fn result_with_puts_envelope_first_then_extra() {
+        let out = ToolOutput::result_with(
+            "glass_screenshot",
+            serde_json::json!({ "width": 4, "height": 4 }),
+            vec![OutContent::Image(vec![1, 2, 3])],
+        );
+        assert!(matches!(out.0[0], OutContent::Text(_)), "envelope leads");
+        assert!(matches!(out.0[1], OutContent::Image(_)), "extra follows");
     }
 }

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -39,10 +39,32 @@ impl ToolOutput {
         v.append(&mut extra);
         ToolOutput(v)
     }
+
+    /// Capture-style result: the image block (when present) leads, then the envelope,
+    /// then any extra sibling blocks, then the trailing IMAGE_NOTE — emitted only when an
+    /// image was attached.
+    pub fn image_result(
+        tool: &str,
+        image: Option<Vec<u8>>,
+        result: serde_json::Value,
+        mut siblings: Vec<OutContent>,
+    ) -> Self {
+        let has_image = image.is_some();
+        let mut v = Vec::new();
+        if let Some(img) = image {
+            v.push(OutContent::Image(img));
+        }
+        v.push(OutContent::Text(envelope(tool, result)));
+        v.append(&mut siblings);
+        if has_image {
+            v.push(OutContent::Text(crate::untrusted::IMAGE_NOTE.to_string()));
+        }
+        ToolOutput(v)
+    }
 }
 
 /// Serialize the success envelope. `ok` is always true — errors take the `Err` path.
-pub(crate) fn envelope(tool: &str, result: serde_json::Value) -> String {
+fn envelope(tool: &str, result: serde_json::Value) -> String {
     serde_json::json!({ "ok": true, "tool": tool, "result": result }).to_string()
 }
 
@@ -257,15 +279,12 @@ pub fn a11y_marks(glass: &mut Glass) -> ToolResult {
             .collect::<Vec<_>>()
             .join("\n")
     };
-    Ok(ToolOutput(vec![
-        OutContent::Image(img),
-        OutContent::Text(envelope(
-            "glass_a11y_marks",
-            serde_json::json!({ "count": marks.len() }),
-        )),
-        OutContent::Text(crate::untrusted::wrap_untrusted(&legend)),
-        OutContent::Text(crate::untrusted::IMAGE_NOTE.to_string()),
-    ]))
+    Ok(ToolOutput::image_result(
+        "glass_a11y_marks",
+        Some(img),
+        serde_json::json!({ "count": marks.len() }),
+        vec![OutContent::Text(crate::untrusted::wrap_untrusted(&legend))],
+    ))
 }
 
 pub(crate) fn parse_button(s: Option<&str>) -> Result<MouseButton, String> {

--- a/crates/glass-mcp/src/tools/batch.rs
+++ b/crates/glass-mcp/src/tools/batch.rs
@@ -11,18 +11,30 @@ use crate::tools::{
 
 /// Split a sub-tool's enveloped output into (its `result` payload, its non-envelope
 /// sibling blocks — images and the IMAGE_NOTE). The envelope text block itself is consumed.
+///
+/// settle/diff/screenshot are glass's own functions and always emit an `{ok,tool,result}`
+/// envelope block — that's an internal invariant, not something driven by untrusted app
+/// input. So a sub-tool output with no envelope block is a bug in glass itself, and this
+/// panics rather than silently defaulting to `{}` (a silent `{}` here would mask a broken
+/// invariant behind a plausible-looking empty result).
 fn split_sub(out: ToolOutput) -> (serde_json::Value, Vec<OutContent>) {
-    let mut result = json!({});
+    let mut result = None;
     let mut siblings = Vec::new();
     for c in out.0 {
         match c {
             OutContent::Text(t) => match serde_json::from_str::<serde_json::Value>(&t) {
-                Ok(v) if v.get("result").is_some() => result = v["result"].clone(),
+                // Require the real envelope shape (`ok` + `tool`), not just any JSON
+                // object that happens to have a `result` key — a future JSON-shaped
+                // untrusted sibling must not be misclassified as the envelope.
+                Ok(v) if v.get("ok").is_some() && v.get("tool").is_some() => {
+                    result = Some(v["result"].clone());
+                }
                 _ => siblings.push(OutContent::Text(t)), // e.g. IMAGE_NOTE (not JSON)
             },
             img => siblings.push(img),
         }
     }
+    let result = result.expect("glass_do sub-tool must emit an {ok,tool,result} envelope");
     (result, siblings)
 }
 
@@ -348,5 +360,45 @@ mod tests {
         assert!(err.contains("all 1 actions executed"), "got: {err}");
         assert!(err.contains("terminal observe failed"), "got: {err}");
         assert!(err.contains("baseline"), "got: {err}");
+    }
+
+    #[test]
+    fn split_sub_requires_ok_and_tool_and_keeps_siblings() {
+        // A well-formed sub-tool output (screenshot's shape): [Image, envelope, IMAGE_NOTE].
+        // The envelope carries a `result` key alongside `ok`/`tool`; a bare JSON object
+        // with only a `result` key (no `ok`/`tool`) must NOT match the tightened
+        // predicate — it's included here as a leading sibling to prove that.
+        let out = ToolOutput(vec![
+            OutContent::Text(json!({ "result": "not the real envelope" }).to_string()),
+            OutContent::Image(vec![1, 2, 3]),
+            OutContent::Text(
+                json!({ "ok": true, "tool": "glass_screenshot", "result": { "width": 4 } })
+                    .to_string(),
+            ),
+            OutContent::Text(crate::untrusted::IMAGE_NOTE.to_string()),
+        ]);
+        let (result, siblings) = split_sub(out);
+        assert_eq!(
+            result,
+            json!({ "width": 4 }),
+            "real envelope's result extracted"
+        );
+        assert_eq!(
+            siblings.len(),
+            3,
+            "the fake-envelope text, image, and IMAGE_NOTE all ride as siblings"
+        );
+        assert!(
+            matches!(&siblings[0], OutContent::Text(t) if t.contains("not the real envelope")),
+            "JSON with `result` but no ok/tool is not misclassified as the envelope"
+        );
+        assert!(
+            matches!(siblings[1], OutContent::Image(_)),
+            "image sibling preserved"
+        );
+        assert!(
+            matches!(&siblings[2], OutContent::Text(t) if t == crate::untrusted::IMAGE_NOTE),
+            "IMAGE_NOTE sibling preserved"
+        );
     }
 }

--- a/crates/glass-mcp/src/tools/batch.rs
+++ b/crates/glass-mcp/src/tools/batch.rs
@@ -124,7 +124,7 @@ mod tests {
     use super::*;
     use crate::tools::start as start_tool;
     use crate::tools::testutil::*;
-    use crate::tools::OutContent;
+    use crate::tools::{baseline_save, OutContent};
     use glass_core::Frame;
     use std::sync::{Arc, Mutex};
 
@@ -155,19 +155,6 @@ mod tests {
         })
     }
 
-    /// Parse the leading content block as the `{ok,tool,result}` envelope and
-    /// return its `result` payload.
-    fn envelope_result(out: &ToolOutput) -> serde_json::Value {
-        match &out.0[0] {
-            OutContent::Text(t) => {
-                let v: serde_json::Value =
-                    serde_json::from_str(t).expect("leading block must be the JSON envelope");
-                v["result"].clone()
-            }
-            _ => panic!("expected envelope text as first item"),
-        }
-    }
-
     #[test]
     fn runs_actions_in_order() {
         let log = Arc::new(Mutex::new(Vec::new()));
@@ -192,7 +179,7 @@ mod tests {
             *log.lock().unwrap(),
             vec!["click(10,20)", "type(alice)", "key(Tab)"]
         );
-        let result = envelope_result(&out);
+        let result = assert_envelope(&out, "glass_do");
         assert_eq!(result["executed"], json!(3));
     }
 
@@ -265,7 +252,7 @@ mod tests {
             1,
             "settle folded into the envelope, no separate/image block"
         );
-        let result = envelope_result(&out);
+        let result = assert_envelope(&out, "glass_do");
         assert_eq!(result["then"]["settle"]["settled"], json!(true));
     }
 
@@ -288,7 +275,7 @@ mod tests {
             },
         )
         .unwrap();
-        let result = envelope_result(&out);
+        let result = assert_envelope(&out, "glass_do");
         assert_eq!(result["executed"], json!(1));
         assert_eq!(result["then"]["screenshot"]["width"], json!(4));
         assert!(
@@ -330,8 +317,86 @@ mod tests {
             },
         )
         .unwrap();
-        let result = envelope_result(&out);
+        let result = assert_envelope(&out, "glass_do");
         assert_eq!(result["then"]["settle"]["settled"], json!(false));
+    }
+
+    #[test]
+    fn then_diff_reports_change_text_only() {
+        let base = Frame::solid(2, 2, [0, 0, 0, 255]);
+        let mut changed = base.clone();
+        changed.pixels[0] = 255;
+        let mut g = started(FakePlatform::new(2, 2).with_frames(vec![base, changed]));
+        baseline_save(&mut g, &BaselineSaveArgs { name: "m".into() }).unwrap();
+        let out = do_actions(
+            &mut g,
+            &DoArgs {
+                actions: vec![click(0, 0)],
+                then: Some(ThenArgs {
+                    settle: None,
+                    diff: Some(DiffArgs {
+                        region: None,
+                        name: "m".into(),
+                        mode: None,
+                        threshold: None,
+                        tolerance: None,
+                        include_image: Some(false),
+                    }),
+                    screenshot: None,
+                }),
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            out.0.len(),
+            1,
+            "no image -> the envelope alone, no nested envelope"
+        );
+        let result = assert_envelope(&out, "glass_do");
+        assert_eq!(result["then"]["diff"]["changed_pixels"], json!(1));
+    }
+
+    #[test]
+    fn then_diff_with_image_appends_image_sibling() {
+        let base = Frame::solid(2, 2, [0, 0, 0, 255]);
+        let mut changed = base.clone();
+        changed.pixels[0] = 255;
+        let mut g = started(FakePlatform::new(2, 2).with_frames(vec![base, changed]));
+        baseline_save(&mut g, &BaselineSaveArgs { name: "m".into() }).unwrap();
+        let out = do_actions(
+            &mut g,
+            &DoArgs {
+                actions: vec![click(0, 0)],
+                then: Some(ThenArgs {
+                    settle: None,
+                    diff: Some(DiffArgs {
+                        region: None,
+                        name: "m".into(),
+                        mode: None,
+                        threshold: None,
+                        tolerance: None,
+                        include_image: Some(true),
+                    }),
+                    screenshot: None,
+                }),
+            },
+        )
+        .unwrap();
+        let result = assert_envelope(&out, "glass_do");
+        assert_eq!(result["then"]["diff"]["changed_pixels"], json!(1));
+        assert_eq!(
+            out.0.len(),
+            3,
+            "envelope + diff image + IMAGE_NOTE (metrics folded into result.then.diff)"
+        );
+        assert!(
+            matches!(out.0[1], OutContent::Image(_)),
+            "diff's changed-region image rides alongside as a sibling"
+        );
+        assert!(
+            matches!(&out.0[2], OutContent::Text(t) if *t == crate::untrusted::IMAGE_NOTE),
+            "IMAGE_NOTE follows the image"
+        );
     }
 
     #[test]

--- a/crates/glass-mcp/src/tools/batch.rs
+++ b/crates/glass-mcp/src/tools/batch.rs
@@ -9,6 +9,23 @@ use crate::tools::{
     ToolOutput, ToolResult,
 };
 
+/// Split a sub-tool's enveloped output into (its `result` payload, its non-envelope
+/// sibling blocks — images and the IMAGE_NOTE). The envelope text block itself is consumed.
+fn split_sub(out: ToolOutput) -> (serde_json::Value, Vec<OutContent>) {
+    let mut result = json!({});
+    let mut siblings = Vec::new();
+    for c in out.0 {
+        match c {
+            OutContent::Text(t) => match serde_json::from_str::<serde_json::Value>(&t) {
+                Ok(v) if v.get("result").is_some() => result = v["result"].clone(),
+                _ => siblings.push(OutContent::Text(t)), // e.g. IMAGE_NOTE (not JSON)
+            },
+            img => siblings.push(img),
+        }
+    }
+    (result, siblings)
+}
+
 /// Build a text-only `WaitStableArgs` from a `SettleArgs` (no image, no crop).
 fn settle_args(s: &SettleArgs) -> WaitStableArgs {
     WaitStableArgs {
@@ -52,28 +69,42 @@ pub fn do_actions(glass: &mut Glass, a: &DoArgs) -> ToolResult {
         }
     }
 
-    let mut out = vec![OutContent::Text(json!({ "executed": n }).to_string())];
+    let mut result = json!({ "executed": n });
+    let mut siblings = Vec::new();
     if let Some(then) = &a.then {
-        let mut items = run_then(glass, then)
+        let (meta, sib) = run_then(glass, then)
             .map_err(|msg| format!("all {n} actions executed; terminal observe failed: {msg}"))?;
-        out.append(&mut items);
+        result["then"] = meta;
+        siblings = sib;
     }
-    Ok(ToolOutput(out))
+    Ok(ToolOutput::result_with("glass_do", result, siblings))
 }
 
-/// Run the terminal observe in fixed order: settle → diff → screenshot.
-fn run_then(glass: &mut Glass, then: &ThenArgs) -> Result<Vec<OutContent>, String> {
-    let mut items = Vec::new();
+/// Run the terminal observe in fixed order: settle → diff → screenshot. Returns
+/// the `then` metadata object (each ran sub-tool's `result` payload keyed by
+/// name) and the collected image/IMAGE_NOTE sibling blocks, in run order.
+fn run_then(
+    glass: &mut Glass,
+    then: &ThenArgs,
+) -> Result<(serde_json::Value, Vec<OutContent>), String> {
+    let mut meta = json!({});
+    let mut siblings = Vec::new();
     if let Some(s) = &then.settle {
-        items.extend(wait_stable(glass, &settle_args(s))?.0);
+        let (r, mut sib) = split_sub(wait_stable(glass, &settle_args(s))?);
+        meta["settle"] = r;
+        siblings.append(&mut sib);
     }
     if let Some(d) = &then.diff {
-        items.extend(diff(glass, d)?.0);
+        let (r, mut sib) = split_sub(diff(glass, d)?);
+        meta["diff"] = r;
+        siblings.append(&mut sib);
     }
     if let Some(sc) = &then.screenshot {
-        items.extend(screenshot(glass, sc)?.0);
+        let (r, mut sib) = split_sub(screenshot(glass, sc)?);
+        meta["screenshot"] = r;
+        siblings.append(&mut sib);
     }
-    Ok(items)
+    Ok((meta, siblings))
 }
 
 #[cfg(test)]
@@ -112,6 +143,19 @@ mod tests {
         })
     }
 
+    /// Parse the leading content block as the `{ok,tool,result}` envelope and
+    /// return its `result` payload.
+    fn envelope_result(out: &ToolOutput) -> serde_json::Value {
+        match &out.0[0] {
+            OutContent::Text(t) => {
+                let v: serde_json::Value =
+                    serde_json::from_str(t).expect("leading block must be the JSON envelope");
+                v["result"].clone()
+            }
+            _ => panic!("expected envelope text as first item"),
+        }
+    }
+
     #[test]
     fn runs_actions_in_order() {
         let log = Arc::new(Mutex::new(Vec::new()));
@@ -136,10 +180,8 @@ mod tests {
             *log.lock().unwrap(),
             vec!["click(10,20)", "type(alice)", "key(Tab)"]
         );
-        match &out.0[0] {
-            OutContent::Text(t) => assert!(t.contains("\"executed\":3"), "got: {t}"),
-            _ => panic!("expected executed text"),
-        }
+        let result = envelope_result(&out);
+        assert_eq!(result["executed"], json!(3));
     }
 
     #[test]
@@ -206,11 +248,13 @@ mod tests {
             },
         )
         .unwrap();
-        assert_eq!(out.0.len(), 2, "executed text + settle text, no image");
-        match &out.0[1] {
-            OutContent::Text(t) => assert!(t.contains("\"settled\":true"), "got: {t}"),
-            _ => panic!("expected settle text, not an image"),
-        }
+        assert_eq!(
+            out.0.len(),
+            1,
+            "settle folded into the envelope, no separate/image block"
+        );
+        let result = envelope_result(&out);
+        assert_eq!(result["then"]["settle"]["settled"], json!(true));
     }
 
     #[test]
@@ -232,22 +276,20 @@ mod tests {
             },
         )
         .unwrap();
-        assert!(matches!(&out.0[0], OutContent::Text(t) if t.contains("\"executed\":1")));
+        let result = envelope_result(&out);
+        assert_eq!(result["executed"], json!(1));
+        assert_eq!(result["then"]["screenshot"]["width"], json!(4));
         assert!(
             matches!(out.0[1], OutContent::Image(_)),
             "screenshot image appended"
         );
         assert_eq!(
             out.0.len(),
-            4,
-            "executed text + screenshot image + dims text + IMAGE_NOTE"
+            3,
+            "envelope + screenshot image + IMAGE_NOTE (dims folded into result.then.screenshot)"
         );
         assert!(
-            matches!(&out.0[2], OutContent::Text(t) if t.contains("\"width\":4")),
-            "dims text after image"
-        );
-        assert!(
-            matches!(&out.0[3], OutContent::Text(t) if *t == crate::untrusted::IMAGE_NOTE),
+            matches!(&out.0[2], OutContent::Text(t) if *t == crate::untrusted::IMAGE_NOTE),
             "IMAGE_NOTE last"
         );
     }
@@ -276,10 +318,8 @@ mod tests {
             },
         )
         .unwrap();
-        match &out.0[1] {
-            OutContent::Text(t) => assert!(t.contains("\"settled\":false"), "got: {t}"),
-            _ => panic!("expected settle text"),
-        }
+        let result = envelope_result(&out);
+        assert_eq!(result["then"]["settle"]["settled"], json!(false));
     }
 
     #[test]

--- a/crates/glass-mcp/src/tools/batch.rs
+++ b/crates/glass-mcp/src/tools/batch.rs
@@ -124,7 +124,7 @@ mod tests {
             backend: None,
             sandbox: None,
             cwd: None,
-            env: vec![],
+            env: std::collections::BTreeMap::new(),
             window_hint: None,
             timeout_ms: None,
             a11y: None,

--- a/crates/glass-mcp/src/tools/capture.rs
+++ b/crates/glass-mcp/src/tools/capture.rs
@@ -4,7 +4,7 @@ use glass_core::{frame_to_webp, Frame, Glass, Region, Stream};
 use serde_json::json;
 
 use crate::params::*;
-use crate::tools::{envelope, OutContent, ToolOutput, ToolResult};
+use crate::tools::{OutContent, ToolOutput, ToolResult};
 
 /// Crop the captured frame to the requested region, or return it whole.
 fn crop_frame(frame: Frame, region: Option<&RegionArgs>) -> Result<Frame, String> {
@@ -27,11 +27,12 @@ pub fn screenshot(glass: &mut Glass, a: &ScreenshotArgs) -> ToolResult {
         meta["x"] = json!(r.x);
         meta["y"] = json!(r.y);
     }
-    Ok(ToolOutput(vec![
-        OutContent::Image(img),
-        OutContent::Text(envelope("glass_screenshot", meta)),
-        OutContent::Text(crate::untrusted::IMAGE_NOTE.to_string()),
-    ]))
+    Ok(ToolOutput::image_result(
+        "glass_screenshot",
+        Some(img),
+        meta,
+        vec![],
+    ))
 }
 
 pub fn wait_stable(glass: &mut Glass, a: &WaitStableArgs) -> ToolResult {
@@ -70,11 +71,12 @@ pub fn wait_stable(glass: &mut Glass, a: &WaitStableArgs) -> ToolResult {
         meta["x"] = json!(r.x);
         meta["y"] = json!(r.y);
     }
-    Ok(ToolOutput(vec![
-        OutContent::Image(img),
-        OutContent::Text(envelope("glass_wait_stable", meta)),
-        OutContent::Text(crate::untrusted::IMAGE_NOTE.to_string()),
-    ]))
+    Ok(ToolOutput::image_result(
+        "glass_wait_stable",
+        Some(img),
+        meta,
+        vec![],
+    ))
 }
 
 pub fn baseline_save(glass: &mut Glass, a: &BaselineSaveArgs) -> ToolResult {
@@ -123,8 +125,7 @@ pub fn diff(glass: &mut Glass, a: &DiffArgs) -> ToolResult {
     // Opt-in: when something changed, attach the current frame cropped to the
     // changed region (token-minimal, exactly what differs). Nothing changed ->
     // no image.
-    let mut out = Vec::new();
-    let mut image_produced = false;
+    let mut image = None;
     if a.include_image.unwrap_or(false) {
         if let Some(b) = r.bbox {
             let region = Region {
@@ -134,17 +135,10 @@ pub fn diff(glass: &mut Glass, a: &DiffArgs) -> ToolResult {
                 height: b.height,
             };
             let cropped = current.crop(&region).map_err(|e| e.to_string())?;
-            out.push(OutContent::Image(
-                frame_to_webp(&cropped).map_err(|e| e.to_string())?,
-            ));
-            image_produced = true;
+            image = Some(frame_to_webp(&cropped).map_err(|e| e.to_string())?);
         }
     }
-    out.push(OutContent::Text(envelope("glass_diff", body)));
-    if image_produced {
-        out.push(OutContent::Text(crate::untrusted::IMAGE_NOTE.to_string()));
-    }
-    Ok(ToolOutput(out))
+    Ok(ToolOutput::image_result("glass_diff", image, body, vec![]))
 }
 
 pub fn logs(glass: &mut Glass, a: &LogsArgs) -> ToolResult {

--- a/crates/glass-mcp/src/tools/capture.rs
+++ b/crates/glass-mcp/src/tools/capture.rs
@@ -195,7 +195,7 @@ mod tests {
             backend: None,
             sandbox: None,
             cwd: None,
-            env: vec![],
+            env: std::collections::BTreeMap::new(),
             window_hint: None,
             timeout_ms: None,
             a11y: None,

--- a/crates/glass-mcp/src/tools/capture.rs
+++ b/crates/glass-mcp/src/tools/capture.rs
@@ -211,10 +211,14 @@ mod tests {
         )
         .unwrap();
         assert!(matches!(out.0[0], OutContent::Image(_)));
-        match &out.0[1] {
-            OutContent::Text(t) => assert!(t.contains("\"width\":4")),
-            _ => panic!("expected meta text"),
-        }
+        // The image leads, so the envelope is the second block; parsing it (rather than a
+        // substring check) catches the envelope wrapper being dropped — a bare
+        // `{"width":4,...}` meta block would still substring-match `"width":4`.
+        let v = envelope_at(&out, 1);
+        assert_eq!(v["ok"], json!(true), "envelope: {v}");
+        assert_eq!(v["tool"], json!("glass_screenshot"), "envelope: {v}");
+        assert_eq!(v["result"]["width"], json!(4), "envelope: {v}");
+        assert_eq!(v["result"]["height"], json!(4), "envelope: {v}");
         if let OutContent::Image(bytes) = &out.0[0] {
             let decoded = glass_core::frame_from_webp(bytes).unwrap();
             assert_eq!((decoded.width, decoded.height), (4, 4));
@@ -238,14 +242,12 @@ mod tests {
             window_id: None,
         };
         let out = screenshot(&mut g, &a).unwrap();
-        match &out.0[1] {
-            OutContent::Text(t) => {
-                assert!(t.contains("\"width\":2"));
-                assert!(t.contains("\"height\":2"));
-                assert!(t.contains("\"x\":1"));
-            }
-            _ => panic!("expected meta text"),
-        }
+        let v = envelope_at(&out, 1);
+        assert_eq!(v["ok"], json!(true), "envelope: {v}");
+        assert_eq!(v["tool"], json!("glass_screenshot"), "envelope: {v}");
+        assert_eq!(v["result"]["width"], json!(2), "envelope: {v}");
+        assert_eq!(v["result"]["height"], json!(2), "envelope: {v}");
+        assert_eq!(v["result"]["x"], json!(1), "envelope: {v}");
         if let OutContent::Image(bytes) = &out.0[0] {
             let decoded = glass_core::frame_from_webp(bytes).unwrap();
             assert_eq!((decoded.width, decoded.height), (2, 2));
@@ -377,13 +379,16 @@ mod tests {
         let mut changed = base.clone();
         changed.pixels[0] = 255;
         let mut g = started_with(FakePlatform::new(2, 2).with_frames(vec![base, changed]));
-        baseline_save(
+        let out = baseline_save(
             &mut g,
             &BaselineSaveArgs {
                 name: "main".into(),
             },
         )
         .unwrap();
+        let v = assert_envelope(&out, "glass_baseline_save");
+        assert_eq!(v["name"], json!("main"), "envelope: {v}");
+
         let out = diff(
             &mut g,
             &DiffArgs {
@@ -396,10 +401,8 @@ mod tests {
             },
         )
         .unwrap();
-        match &out.0[0] {
-            OutContent::Text(t) => assert!(t.contains("\"changed_pixels\":1")),
-            _ => panic!("expected text"),
-        }
+        let v = assert_envelope(&out, "glass_diff");
+        assert_eq!(v["changed_pixels"], json!(1), "envelope: {v}");
     }
 
     #[test]
@@ -427,16 +430,13 @@ mod tests {
             },
         )
         .unwrap();
-        match &out.0[0] {
-            OutContent::Text(t) => {
-                assert!(
-                    t.contains("\"changed_pixels\":0"),
-                    "region excludes change: {t}"
-                );
-                assert!(t.contains("\"region\":{"), "region echoed: {t}");
-            }
-            _ => panic!("expected text"),
-        }
+        let v = assert_envelope(&out, "glass_diff");
+        assert_eq!(v["changed_pixels"], json!(0), "region excludes change: {v}");
+        assert_eq!(
+            v["region"],
+            json!({ "x": 0, "y": 0, "width": 2, "height": 2 }),
+            "region echoed: {v}"
+        );
     }
 
     #[test]
@@ -459,10 +459,8 @@ mod tests {
             },
         )
         .unwrap();
-        match &out.0[0] {
-            OutContent::Text(t) => assert!(t.contains("\"changed_pixels\":1")),
-            _ => panic!("expected text"),
-        }
+        let v = assert_envelope(&out, "glass_diff");
+        assert_eq!(v["changed_pixels"], json!(1), "envelope: {v}");
         // unknown mode is rejected (no silent fallback)
         let err = diff(
             &mut g,
@@ -516,16 +514,8 @@ mod tests {
         )
         .unwrap();
         // envelope leads, carrying the cursor
-        match &out.0[0] {
-            OutContent::Text(t) => {
-                let v: serde_json::Value =
-                    serde_json::from_str(t).expect("envelope must be valid JSON");
-                assert_eq!(v["ok"], json!(true), "envelope: {v}");
-                assert_eq!(v["tool"], json!("glass_logs"), "envelope: {v}");
-                assert_eq!(v["result"]["cursor"], json!(1), "envelope: {v}");
-            }
-            _ => panic!("expected envelope text as first item"),
-        }
+        let v = assert_envelope(&out, "glass_logs");
+        assert_eq!(v["cursor"], json!(1), "envelope: {v}");
         // untrusted lines sibling follows, carrying the app-controlled lines
         match &out.0[1] {
             OutContent::Text(t) => {
@@ -578,16 +568,10 @@ mod tests {
             1,
             "text-only should emit a single content item"
         );
-        match &out.0[0] {
-            OutContent::Text(t) => {
-                assert!(t.contains("\"settled\":true"), "got: {t}");
-                assert!(
-                    t.contains("\"width\":4") && t.contains("\"height\":4"),
-                    "got: {t}"
-                );
-            }
-            _ => panic!("expected text-only, got an image"),
-        }
+        let v = assert_envelope(&out, "glass_wait_stable");
+        assert_eq!(v["settled"], json!(true), "envelope: {v}");
+        assert_eq!(v["width"], json!(4), "envelope: {v}");
+        assert_eq!(v["height"], json!(4), "envelope: {v}");
     }
 
     #[test]
@@ -621,10 +605,13 @@ mod tests {
             }
             _ => panic!("expected image first"),
         }
-        match &out.0[1] {
-            OutContent::Text(t) => assert!(t.contains("\"changed_pixels\":1"), "got: {t}"),
-            _ => panic!("expected metrics text"),
-        }
+        // The image leads, so the envelope is the second block; parse it (rather than a
+        // substring check) so a dropped envelope wrapper can't hide behind a matching
+        // top-level `"changed_pixels":1` field.
+        let v = envelope_at(&out, 1);
+        assert_eq!(v["ok"], json!(true), "envelope: {v}");
+        assert_eq!(v["tool"], json!("glass_diff"), "envelope: {v}");
+        assert_eq!(v["result"]["changed_pixels"], json!(1), "envelope: {v}");
     }
 
     #[test]

--- a/crates/glass-mcp/src/tools/capture.rs
+++ b/crates/glass-mcp/src/tools/capture.rs
@@ -157,7 +157,7 @@ pub fn logs(glass: &mut Glass, a: &LogsArgs) -> ToolResult {
     let (lines, cursor) = glass
         .logs(
             a.cursor.unwrap_or(0),
-            a.max_lines.unwrap_or(200),
+            a.max_lines.unwrap_or(200) as usize,
             stream,
             a.contains.as_deref(),
         )

--- a/crates/glass-mcp/src/tools/capture.rs
+++ b/crates/glass-mcp/src/tools/capture.rs
@@ -4,7 +4,7 @@ use glass_core::{frame_to_webp, Frame, Glass, Region, Stream};
 use serde_json::json;
 
 use crate::params::*;
-use crate::tools::{OutContent, ToolOutput, ToolResult};
+use crate::tools::{envelope, OutContent, ToolOutput, ToolResult};
 
 /// Crop the captured frame to the requested region, or return it whole.
 fn crop_frame(frame: Frame, region: Option<&RegionArgs>) -> Result<Frame, String> {
@@ -29,7 +29,7 @@ pub fn screenshot(glass: &mut Glass, a: &ScreenshotArgs) -> ToolResult {
     }
     Ok(ToolOutput(vec![
         OutContent::Image(img),
-        OutContent::Text(meta.to_string()),
+        OutContent::Text(envelope("glass_screenshot", meta)),
         OutContent::Text(crate::untrusted::IMAGE_NOTE.to_string()),
     ]))
 }
@@ -60,7 +60,7 @@ pub fn wait_stable(glass: &mut Glass, a: &WaitStableArgs) -> ToolResult {
             "width": outcome.frame.width,
             "height": outcome.frame.height,
         });
-        return Ok(ToolOutput::text(meta.to_string()));
+        return Ok(ToolOutput::result("glass_wait_stable", meta));
     }
 
     let frame = crop_frame(outcome.frame, a.region.as_ref())?;
@@ -72,14 +72,17 @@ pub fn wait_stable(glass: &mut Glass, a: &WaitStableArgs) -> ToolResult {
     }
     Ok(ToolOutput(vec![
         OutContent::Image(img),
-        OutContent::Text(meta.to_string()),
+        OutContent::Text(envelope("glass_wait_stable", meta)),
         OutContent::Text(crate::untrusted::IMAGE_NOTE.to_string()),
     ]))
 }
 
 pub fn baseline_save(glass: &mut Glass, a: &BaselineSaveArgs) -> ToolResult {
     glass.save_baseline(&a.name).map_err(|e| e.to_string())?;
-    Ok(ToolOutput::text(format!("saved baseline '{}'", a.name)))
+    Ok(ToolOutput::result(
+        "glass_baseline_save",
+        json!({ "name": a.name }),
+    ))
 }
 
 pub fn diff(glass: &mut Glass, a: &DiffArgs) -> ToolResult {
@@ -116,7 +119,6 @@ pub fn diff(glass: &mut Glass, a: &DiffArgs) -> ToolResult {
     if let Some(rr) = a.region.as_ref() {
         body["region"] = json!({ "x": rr.x, "y": rr.y, "width": rr.width, "height": rr.height });
     }
-    let text = OutContent::Text(body.to_string());
 
     // Opt-in: when something changed, attach the current frame cropped to the
     // changed region (token-minimal, exactly what differs). Nothing changed ->
@@ -138,7 +140,7 @@ pub fn diff(glass: &mut Glass, a: &DiffArgs) -> ToolResult {
             image_produced = true;
         }
     }
-    out.push(text);
+    out.push(OutContent::Text(envelope("glass_diff", body)));
     if image_produced {
         out.push(OutContent::Text(crate::untrusted::IMAGE_NOTE.to_string()));
     }
@@ -170,8 +172,12 @@ pub fn logs(glass: &mut Glass, a: &LogsArgs) -> ToolResult {
             })
         })
         .collect();
-    let body = json!({ "lines": json_lines, "cursor": cursor }).to_string();
-    Ok(ToolOutput::text(crate::untrusted::wrap_untrusted(&body)))
+    let body = json!({ "lines": json_lines }).to_string();
+    Ok(ToolOutput::result_with(
+        "glass_logs",
+        json!({ "cursor": cursor }),
+        vec![OutContent::Text(crate::untrusted::wrap_untrusted(&body))],
+    ))
 }
 
 #[cfg(test)]
@@ -515,7 +521,19 @@ mod tests {
             },
         )
         .unwrap();
+        // envelope leads, carrying the cursor
         match &out.0[0] {
+            OutContent::Text(t) => {
+                let v: serde_json::Value =
+                    serde_json::from_str(t).expect("envelope must be valid JSON");
+                assert_eq!(v["ok"], json!(true), "envelope: {v}");
+                assert_eq!(v["tool"], json!("glass_logs"), "envelope: {v}");
+                assert_eq!(v["result"]["cursor"], json!(1), "envelope: {v}");
+            }
+            _ => panic!("expected envelope text as first item"),
+        }
+        // untrusted lines sibling follows, carrying the app-controlled lines
+        match &out.0[1] {
             OutContent::Text(t) => {
                 assert!(
                     t.starts_with(crate::untrusted::NOTE),
@@ -526,9 +544,8 @@ mod tests {
                     "enveloped: {t}"
                 );
                 assert!(t.contains("\"text\":\"ready\""));
-                assert!(t.contains("\"cursor\":1"));
             }
-            _ => panic!("expected text"),
+            _ => panic!("expected untrusted lines text as second item"),
         }
     }
 

--- a/crates/glass-mcp/src/tools/clipboard.rs
+++ b/crates/glass-mcp/src/tools/clipboard.rs
@@ -3,16 +3,23 @@
 use glass_core::Glass;
 
 use crate::params::ClipboardSetArgs;
-use crate::tools::{ToolOutput, ToolResult};
+use crate::tools::{OutContent, ToolOutput, ToolResult};
 
 pub fn clipboard_get(glass: &mut Glass) -> ToolResult {
     let text = glass.get_clipboard().map_err(|e| e.to_string())?;
-    Ok(ToolOutput::text(crate::untrusted::wrap_untrusted(&text)))
+    Ok(ToolOutput::result_with(
+        "glass_clipboard_get",
+        serde_json::json!({}),
+        vec![OutContent::Text(crate::untrusted::wrap_untrusted(&text))],
+    ))
 }
 
 pub fn clipboard_set(glass: &mut Glass, a: &ClipboardSetArgs) -> ToolResult {
     glass.set_clipboard(&a.text).map_err(|e| e.to_string())?;
-    Ok(ToolOutput::text("ok"))
+    Ok(ToolOutput::result(
+        "glass_clipboard_set",
+        serde_json::json!({}),
+    ))
 }
 
 #[cfg(test)]
@@ -39,24 +46,37 @@ mod tests {
         g
     }
 
-    fn text(out: &ToolOutput) -> &str {
-        match &out.0[0] {
+    fn text_at(out: &ToolOutput, i: usize) -> &str {
+        match &out.0[i] {
             OutContent::Text(t) => t,
-            _ => panic!("expected text"),
+            _ => panic!("expected text at index {i}"),
         }
+    }
+
+    /// Parse `out.0[0]` as the leading envelope and assert its `ok`/`tool` shape.
+    fn envelope_value(out: &ToolOutput, tool: &str) -> serde_json::Value {
+        let v: serde_json::Value =
+            serde_json::from_str(text_at(out, 0)).expect("envelope must be valid JSON");
+        assert_eq!(v["ok"], serde_json::json!(true), "envelope: {v}");
+        assert_eq!(v["tool"], serde_json::json!(tool), "envelope: {v}");
+        v
     }
 
     #[test]
     fn clipboard_set_then_get_roundtrips() {
         let mut g = started();
-        // clipboard_set returns glass's own "ok" — NOT wrapped.
-        assert_eq!(
-            text(&clipboard_set(&mut g, &ClipboardSetArgs { text: "foo".into() }).unwrap()),
-            "ok"
-        );
-        // clipboard_get returns app-derived text — MUST be wrapped.
+        // clipboard_set returns the uniform envelope with an empty result.
+        let out = clipboard_set(&mut g, &ClipboardSetArgs { text: "foo".into() }).unwrap();
+        let v = envelope_value(&out, "glass_clipboard_set");
+        assert_eq!(v["result"], serde_json::json!({}), "envelope: {v}");
+
+        // clipboard_get returns the envelope, then app-derived text as an
+        // untrusted sibling block — the clipboard body is NOT trusted metadata.
         let out = clipboard_get(&mut g).unwrap();
-        let got = text(&out);
+        let v = envelope_value(&out, "glass_clipboard_get");
+        assert_eq!(v["result"], serde_json::json!({}), "envelope: {v}");
+
+        let got = text_at(&out, 1);
         assert!(
             got.starts_with(crate::untrusted::NOTE),
             "must be marked untrusted: {got}"
@@ -72,7 +92,8 @@ mod tests {
     fn clipboard_get_empty_is_blank() {
         let mut g = started();
         let out = clipboard_get(&mut g).unwrap();
-        let got = text(&out);
+        envelope_value(&out, "glass_clipboard_get");
+        let got = text_at(&out, 1);
         assert!(
             got.starts_with(crate::untrusted::NOTE),
             "must be marked untrusted: {got}"

--- a/crates/glass-mcp/src/tools/clipboard.rs
+++ b/crates/glass-mcp/src/tools/clipboard.rs
@@ -53,28 +53,19 @@ mod tests {
         }
     }
 
-    /// Parse `out.0[0]` as the leading envelope and assert its `ok`/`tool` shape.
-    fn envelope_value(out: &ToolOutput, tool: &str) -> serde_json::Value {
-        let v: serde_json::Value =
-            serde_json::from_str(text_at(out, 0)).expect("envelope must be valid JSON");
-        assert_eq!(v["ok"], serde_json::json!(true), "envelope: {v}");
-        assert_eq!(v["tool"], serde_json::json!(tool), "envelope: {v}");
-        v
-    }
-
     #[test]
     fn clipboard_set_then_get_roundtrips() {
         let mut g = started();
         // clipboard_set returns the uniform envelope with an empty result.
         let out = clipboard_set(&mut g, &ClipboardSetArgs { text: "foo".into() }).unwrap();
-        let v = envelope_value(&out, "glass_clipboard_set");
-        assert_eq!(v["result"], serde_json::json!({}), "envelope: {v}");
+        let v = assert_envelope(&out, "glass_clipboard_set");
+        assert_eq!(v, serde_json::json!({}), "envelope: {v}");
 
         // clipboard_get returns the envelope, then app-derived text as an
         // untrusted sibling block — the clipboard body is NOT trusted metadata.
         let out = clipboard_get(&mut g).unwrap();
-        let v = envelope_value(&out, "glass_clipboard_get");
-        assert_eq!(v["result"], serde_json::json!({}), "envelope: {v}");
+        let v = assert_envelope(&out, "glass_clipboard_get");
+        assert_eq!(v, serde_json::json!({}), "envelope: {v}");
 
         let got = text_at(&out, 1);
         assert!(
@@ -92,7 +83,7 @@ mod tests {
     fn clipboard_get_empty_is_blank() {
         let mut g = started();
         let out = clipboard_get(&mut g).unwrap();
-        envelope_value(&out, "glass_clipboard_get");
+        assert_envelope(&out, "glass_clipboard_get");
         let got = text_at(&out, 1);
         assert!(
             got.starts_with(crate::untrusted::NOTE),

--- a/crates/glass-mcp/src/tools/clipboard.rs
+++ b/crates/glass-mcp/src/tools/clipboard.rs
@@ -30,7 +30,7 @@ mod tests {
             backend: None,
             sandbox: None,
             cwd: None,
-            env: vec![],
+            env: std::collections::BTreeMap::new(),
             window_hint: None,
             timeout_ms: None,
             a11y: None,

--- a/crates/glass-mcp/src/tools/input.rs
+++ b/crates/glass-mcp/src/tools/input.rs
@@ -115,8 +115,8 @@ pub fn key(glass: &mut Glass, a: &KeyArgs) -> ToolResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tools::start as start_tool;
     use crate::tools::testutil::*;
-    use crate::tools::{start as start_tool, OutContent};
 
     fn started() -> Glass {
         let mut g = glass_with(FakePlatform::new(100, 100));
@@ -135,18 +135,11 @@ mod tests {
         g
     }
 
-    fn result_json(out: &ToolOutput) -> serde_json::Value {
-        let OutContent::Text(t) = &out.0[0] else {
-            panic!("expected text")
-        };
-        serde_json::from_str(t).unwrap()
-    }
-
+    /// These input tools all return an empty `result` on success; assert the envelope
+    /// shape (ok/tool/registered) plus that emptiness in one call.
     fn assert_ok(out: &ToolOutput, tool: &str) {
-        let v = result_json(out);
-        assert_eq!(v["ok"], serde_json::json!(true));
-        assert_eq!(v["tool"], serde_json::json!(tool));
-        assert_eq!(v["result"], serde_json::json!({}));
+        let v = assert_envelope(out, tool);
+        assert_eq!(v, serde_json::json!({}), "envelope result: {v}");
     }
 
     #[test]
@@ -160,6 +153,13 @@ mod tests {
             modifiers: None,
         };
         assert_ok(&click(&mut g, &a).unwrap(), "glass_click");
+    }
+
+    #[test]
+    fn move_in_bounds_ok() {
+        let mut g = started();
+        let a = MoveArgs { x: 10, y: 20 };
+        assert_ok(&mouse_move(&mut g, &a).unwrap(), "glass_move");
     }
 
     #[test]

--- a/crates/glass-mcp/src/tools/input.rs
+++ b/crates/glass-mcp/src/tools/input.rs
@@ -27,14 +27,14 @@ pub fn click(glass: &mut Glass, a: &ClickArgs) -> ToolResult {
             modifiers,
         })
         .map_err(|e| e.to_string())?;
-    Ok(ToolOutput::text("ok"))
+    Ok(ToolOutput::result("glass_click", serde_json::json!({})))
 }
 
 pub fn mouse_move(glass: &mut Glass, a: &MoveArgs) -> ToolResult {
     glass
         .pointer(&PointerEvent::Move { x: a.x, y: a.y })
         .map_err(|e| e.to_string())?;
-    Ok(ToolOutput::text("ok"))
+    Ok(ToolOutput::result("glass_move", serde_json::json!({})))
 }
 
 pub fn drag(glass: &mut Glass, a: &DragArgs) -> ToolResult {
@@ -51,7 +51,7 @@ pub fn drag(glass: &mut Glass, a: &DragArgs) -> ToolResult {
             duration_ms: a.duration_ms.unwrap_or(200).min(10_000),
         })
         .map_err(|e| e.to_string())?;
-    Ok(ToolOutput::text("ok"))
+    Ok(ToolOutput::result("glass_drag", serde_json::json!({})))
 }
 
 pub fn gesture(glass: &mut Glass, a: &GestureArgs) -> ToolResult {
@@ -81,7 +81,7 @@ pub fn gesture(glass: &mut Glass, a: &GestureArgs) -> ToolResult {
             duration_ms: a.duration_ms.unwrap_or(250).min(10_000),
         })
         .map_err(|e| e.to_string())?;
-    Ok(ToolOutput::text("ok"))
+    Ok(ToolOutput::result("glass_gesture", serde_json::json!({})))
 }
 
 pub fn scroll(glass: &mut Glass, a: &ScrollArgs) -> ToolResult {
@@ -95,21 +95,21 @@ pub fn scroll(glass: &mut Glass, a: &ScrollArgs) -> ToolResult {
             modifiers,
         })
         .map_err(|e| e.to_string())?;
-    Ok(ToolOutput::text("ok"))
+    Ok(ToolOutput::result("glass_scroll", serde_json::json!({})))
 }
 
 pub fn type_text(glass: &mut Glass, a: &TypeArgs) -> ToolResult {
     glass
         .key(&KeyEvent::Text(a.text.clone()))
         .map_err(|e| e.to_string())?;
-    Ok(ToolOutput::text("ok"))
+    Ok(ToolOutput::result("glass_type", serde_json::json!({})))
 }
 
 pub fn key(glass: &mut Glass, a: &KeyArgs) -> ToolResult {
     glass
         .key(&KeyEvent::Chord(a.chord.clone()))
         .map_err(|e| e.to_string())?;
-    Ok(ToolOutput::text("ok"))
+    Ok(ToolOutput::result("glass_key", serde_json::json!({})))
 }
 
 #[cfg(test)]
@@ -135,11 +135,18 @@ mod tests {
         g
     }
 
-    fn text(out: &ToolOutput) -> &str {
-        match &out.0[0] {
-            OutContent::Text(t) => t,
-            _ => panic!("expected text"),
-        }
+    fn result_json(out: &ToolOutput) -> serde_json::Value {
+        let OutContent::Text(t) = &out.0[0] else {
+            panic!("expected text")
+        };
+        serde_json::from_str(t).unwrap()
+    }
+
+    fn assert_ok(out: &ToolOutput, tool: &str) {
+        let v = result_json(out);
+        assert_eq!(v["ok"], serde_json::json!(true));
+        assert_eq!(v["tool"], serde_json::json!(tool));
+        assert_eq!(v["result"], serde_json::json!({}));
     }
 
     #[test]
@@ -152,7 +159,7 @@ mod tests {
             count: None,
             modifiers: None,
         };
-        assert_eq!(text(&click(&mut g, &a).unwrap()), "ok");
+        assert_ok(&click(&mut g, &a).unwrap(), "glass_click");
     }
 
     #[test]
@@ -184,21 +191,19 @@ mod tests {
     #[test]
     fn type_and_key_ok() {
         let mut g = started();
-        assert_eq!(
-            text(&type_text(&mut g, &TypeArgs { text: "hi".into() }).unwrap()),
-            "ok"
+        assert_ok(
+            &type_text(&mut g, &TypeArgs { text: "hi".into() }).unwrap(),
+            "glass_type",
         );
-        assert_eq!(
-            text(
-                &key(
-                    &mut g,
-                    &KeyArgs {
-                        chord: "ctrl+s".into()
-                    }
-                )
-                .unwrap()
-            ),
-            "ok"
+        assert_ok(
+            &key(
+                &mut g,
+                &KeyArgs {
+                    chord: "ctrl+s".into(),
+                },
+            )
+            .unwrap(),
+            "glass_key",
         );
     }
 
@@ -214,7 +219,7 @@ mod tests {
             modifiers: None,
             duration_ms: None,
         };
-        assert_eq!(text(&drag(&mut g, &d).unwrap()), "ok");
+        assert_ok(&drag(&mut g, &d).unwrap(), "glass_drag");
         let s = ScrollArgs {
             x: 5,
             y: 6,
@@ -222,7 +227,7 @@ mod tests {
             dy: Some(2),
             modifiers: None,
         };
-        assert_eq!(text(&scroll(&mut g, &s).unwrap()), "ok");
+        assert_ok(&scroll(&mut g, &s).unwrap(), "glass_scroll");
     }
 
     #[test]
@@ -241,7 +246,7 @@ mod tests {
             ],
             duration_ms: Some(120),
         };
-        assert_eq!(text(&gesture(&mut g, &a).unwrap()), "ok");
+        assert_ok(&gesture(&mut g, &a).unwrap(), "glass_gesture");
     }
 
     #[test]
@@ -267,7 +272,7 @@ mod tests {
             count: None,
             modifiers: Some(vec!["ctrl".into()]),
         };
-        assert_eq!(text(&click(&mut g, &ok).unwrap()), "ok");
+        assert_ok(&click(&mut g, &ok).unwrap(), "glass_click");
         let bad = ClickArgs {
             x: 1,
             y: 1,

--- a/crates/glass-mcp/src/tools/input.rs
+++ b/crates/glass-mcp/src/tools/input.rs
@@ -126,7 +126,7 @@ mod tests {
             backend: None,
             sandbox: None,
             cwd: None,
-            env: vec![],
+            env: std::collections::BTreeMap::new(),
             window_hint: None,
             timeout_ms: None,
             a11y: None,

--- a/crates/glass-mcp/src/tools/wait.rs
+++ b/crates/glass-mcp/src/tools/wait.rs
@@ -33,18 +33,37 @@ pub fn wait_for_element(glass: &mut Glass, a: &WaitForElementArgs) -> ToolResult
         timeout_ms: a.timeout_ms.unwrap_or(10_000),
     };
     let o = glass.wait_for_element(&params).map_err(|e| e.to_string())?;
-    let element = o.element.map(|e| {
-        json!({
-            "id": e.id.0,
-            "role": format!("{:?}", e.role),
-            "name": e.name,
-            "value": e.value,
-            "bounds": e.bounds.map(|b| json!({ "x": b.x, "y": b.y, "width": b.width, "height": b.height })),
-            "states": e.states.active(),
-        })
-    });
-    let body = json!({ "matched": o.matched, "elapsed_ms": o.elapsed_ms, "element": element });
-    Ok(ToolOutput::result("glass_wait_for_element", body))
+    // `matched`/`elapsed_ms` are glass-derived and stay trusted; the matched element
+    // carries app-controlled name/value, so it rides in an untrusted sibling.
+    let result = json!({ "matched": o.matched, "elapsed_ms": o.elapsed_ms });
+    let extra = element_sibling(o.element);
+    Ok(ToolOutput::result_with(
+        "glass_wait_for_element",
+        result,
+        extra,
+    ))
+}
+
+/// The matched a11y element as an untrusted sibling block (empty when nothing
+/// matched). Its `name`/`value` are app-controlled, so they must never ride in the
+/// trusted `result` envelope.
+fn element_sibling(element: Option<glass_core::ElementInfo>) -> Vec<OutContent> {
+    match element {
+        Some(e) => {
+            let json = json!({
+                "id": e.id.0,
+                "role": format!("{:?}", e.role),
+                "name": e.name,
+                "value": e.value,
+                "bounds": e.bounds.map(|b| json!({ "x": b.x, "y": b.y, "width": b.width, "height": b.height })),
+                "states": e.states.active(),
+            });
+            vec![OutContent::Text(crate::untrusted::wrap_untrusted(
+                &json.to_string(),
+            ))]
+        }
+        None => vec![],
+    }
 }
 
 pub fn scroll_to_element(glass: &mut Glass, a: &ScrollToElementArgs) -> ToolResult {
@@ -82,23 +101,19 @@ pub fn scroll_to_element(glass: &mut Glass, a: &ScrollToElementArgs) -> ToolResu
     let o = glass
         .scroll_to_element(&params)
         .map_err(|e| e.to_string())?;
-    let element = o.element.map(|e| {
-        json!({
-            "id": e.id.0,
-            "role": format!("{:?}", e.role),
-            "name": e.name,
-            "value": e.value,
-            "bounds": e.bounds.map(|b| json!({ "x": b.x, "y": b.y, "width": b.width, "height": b.height })),
-            "states": e.states.active(),
-        })
-    });
-    let body = json!({
+    // `matched`/`elapsed_ms`/`scrolled` are glass-computed and stay trusted; the
+    // matched element carries app-controlled name/value, so it rides untrusted.
+    let result = json!({
         "matched": o.matched,
         "elapsed_ms": o.elapsed_ms,
-        "element": element,
         "scrolled": { "steps": o.steps, "reversed": o.reversed, "direction": o.direction.as_str() },
     });
-    Ok(ToolOutput::result("glass_scroll_to_element", body))
+    let extra = element_sibling(o.element);
+    Ok(ToolOutput::result_with(
+        "glass_scroll_to_element",
+        result,
+        extra,
+    ))
 }
 
 pub fn wait_for_region(glass: &mut Glass, a: &WaitForRegionArgs) -> ToolResult {
@@ -174,18 +189,27 @@ pub fn wait_for_log(glass: &mut Glass, a: &WaitForLogArgs) -> ToolResult {
         timeout_ms: a.timeout_ms.unwrap_or(10_000),
     };
     let o = glass.wait_for_log(&params).map_err(|e| e.to_string())?;
-    let line = o.line.map(|l| {
-        json!({
-            "seq": l.seq,
-            "stream": match l.stream { Stream::Stdout => "stdout", Stream::Stderr => "stderr" },
-            "text": l.text,
-        })
-    });
-    let mut body = json!({ "matched": o.matched, "line": line, "cursor": o.cursor, "elapsed_ms": o.elapsed_ms });
+    // `matched`/`cursor`/`elapsed_ms`/`note` are glass-generated and stay trusted;
+    // the matched line carries app-controlled text, so it rides untrusted.
+    let mut result =
+        json!({ "matched": o.matched, "cursor": o.cursor, "elapsed_ms": o.elapsed_ms });
     if let Some(note) = &o.note {
-        body["note"] = json!(note);
+        result["note"] = json!(note);
     }
-    Ok(ToolOutput::result("glass_wait_for_log", body))
+    let extra = match o.line {
+        Some(l) => {
+            let json = json!({
+                "seq": l.seq,
+                "stream": match l.stream { Stream::Stdout => "stdout", Stream::Stderr => "stderr" },
+                "text": l.text,
+            });
+            vec![OutContent::Text(crate::untrusted::wrap_untrusted(
+                &json.to_string(),
+            ))]
+        }
+        None => vec![],
+    };
+    Ok(ToolOutput::result_with("glass_wait_for_log", result, extra))
 }
 
 #[cfg(test)]
@@ -256,15 +280,38 @@ mod tests {
         let mut a = scroll_args();
         a.name = Some("Save".into());
         let out = scroll_to_element(&mut g, &a).unwrap();
+        // `scrolled` is glass-computed and stays in the trusted result.
         match &out.0[0] {
             OutContent::Text(t) => {
-                assert!(t.contains("\"scrolled\""), "got: {t}");
+                let v: serde_json::Value =
+                    serde_json::from_str(t).expect("envelope must be valid JSON");
+                assert_eq!(v["result"]["matched"], json!(true), "envelope: {v}");
+                assert_eq!(
+                    v["result"]["scrolled"]["direction"],
+                    json!("down"),
+                    "resolved direction must be serialized in result; got: {v}"
+                );
                 assert!(
-                    t.contains("\"direction\":\"down\""),
-                    "resolved direction must be serialized; got: {t}"
+                    v["result"]["element"].is_null(),
+                    "app element must not ride in the trusted result: {v}"
                 );
             }
             _ => panic!("expected text"),
+        }
+        // Save is on-screen -> matched -> the element rides as an untrusted sibling.
+        match &out.0[1] {
+            OutContent::Text(t) => {
+                assert!(
+                    t.starts_with(crate::untrusted::NOTE),
+                    "must be marked untrusted: {t}"
+                );
+                assert!(
+                    t.contains("⟦untrusted:") && t.contains("⟦/untrusted:"),
+                    "enveloped: {t}"
+                );
+                assert!(t.contains("\"name\":\"Save\""), "app-controlled name: {t}");
+            }
+            _ => panic!("expected untrusted element sibling"),
         }
     }
 
@@ -324,15 +371,24 @@ mod tests {
         let mut a = scroll_args();
         a.name = Some("Save".into());
         let out = scroll_to_element(&mut g, &a).unwrap();
+        assert_eq!(
+            out.0.len(),
+            1,
+            "no match -> single envelope block, no untrusted sibling"
+        );
         match &out.0[0] {
             OutContent::Text(t) => {
-                assert!(
-                    t.contains("\"matched\":false"),
-                    "off-screen target never realizes in the static tree; got: {t}"
+                let v: serde_json::Value =
+                    serde_json::from_str(t).expect("envelope must be valid JSON");
+                assert_eq!(
+                    v["result"]["matched"],
+                    json!(false),
+                    "off-screen target never realizes in the static tree; got: {v}"
                 );
-                assert!(
-                    t.contains("\"direction\":\"right\""),
-                    "resolved direction must be inferred from the off-screen bounds; got: {t}"
+                assert_eq!(
+                    v["result"]["scrolled"]["direction"],
+                    json!("right"),
+                    "resolved direction must be inferred from the off-screen bounds; got: {v}"
                 );
             }
             _ => panic!("expected text"),
@@ -402,6 +458,8 @@ mod tests {
         a.role = Some("Button".into());
         a.condition = Some("enabled".into());
         let out = wait_for_element(&mut g, &a).unwrap();
+        // Trusted scalars ride in the envelope result; the app-controlled element
+        // does NOT.
         match &out.0[0] {
             OutContent::Text(t) => {
                 let v: serde_json::Value =
@@ -409,14 +467,29 @@ mod tests {
                 assert_eq!(v["ok"], json!(true), "envelope: {v}");
                 assert_eq!(v["tool"], json!("glass_wait_for_element"), "envelope: {v}");
                 assert_eq!(v["result"]["matched"], json!(true), "envelope: {v}");
-                assert_eq!(v["result"]["element"]["id"], json!(1), "envelope: {v}");
-                assert_eq!(
-                    v["result"]["element"]["name"],
-                    json!("Save"),
-                    "envelope: {v}"
+                assert!(v["result"]["elapsed_ms"].is_number(), "envelope: {v}");
+                assert!(
+                    v["result"]["element"].is_null(),
+                    "app element must not ride in the trusted result: {v}"
                 );
             }
             _ => panic!("expected text"),
+        }
+        // The matched element (app-controlled name/value) rides in an untrusted sibling.
+        match &out.0[1] {
+            OutContent::Text(t) => {
+                assert!(
+                    t.starts_with(crate::untrusted::NOTE),
+                    "must be marked untrusted: {t}"
+                );
+                assert!(
+                    t.contains("⟦untrusted:") && t.contains("⟦/untrusted:"),
+                    "enveloped: {t}"
+                );
+                assert!(t.contains("\"id\":1"), "element id: {t}");
+                assert!(t.contains("\"name\":\"Save\""), "app-controlled name: {t}");
+            }
+            _ => panic!("expected untrusted element sibling"),
         }
     }
 
@@ -428,6 +501,11 @@ mod tests {
         a.condition = Some("checked".into()); // never true
         a.timeout_ms = Some(0);
         let out = wait_for_element(&mut g, &a).unwrap();
+        assert_eq!(
+            out.0.len(),
+            1,
+            "no match -> single envelope block, no untrusted sibling"
+        );
         match &out.0[0] {
             OutContent::Text(t) => {
                 let v: serde_json::Value =
@@ -435,7 +513,6 @@ mod tests {
                 assert_eq!(v["ok"], json!(true), "envelope: {v}");
                 assert_eq!(v["tool"], json!("glass_wait_for_element"), "envelope: {v}");
                 assert_eq!(v["result"]["matched"], json!(false), "envelope: {v}");
-                assert!(v["result"]["element"].is_null(), "envelope: {v}");
             }
             _ => panic!("expected text"),
         }
@@ -604,6 +681,7 @@ mod tests {
             timeout_ms: Some(1000),
         };
         let out = wait_for_log(&mut g, &a).unwrap();
+        // Trusted scalars ride in the envelope result; the app-controlled line does NOT.
         match &out.0[0] {
             OutContent::Text(t) => {
                 let v: serde_json::Value =
@@ -611,13 +689,31 @@ mod tests {
                 assert_eq!(v["ok"], json!(true), "envelope: {v}");
                 assert_eq!(v["tool"], json!("glass_wait_for_log"), "envelope: {v}");
                 assert_eq!(v["result"]["matched"], json!(true), "envelope: {v}");
-                assert_eq!(
-                    v["result"]["line"]["text"],
-                    json!("build done"),
-                    "envelope: {v}"
+                assert!(v["result"]["cursor"].is_number(), "cursor scalar: {v}");
+                assert!(
+                    v["result"]["line"].is_null(),
+                    "app line must not ride in the trusted result: {v}"
                 );
             }
             _ => panic!("expected text"),
+        }
+        // The matched line (app-controlled text) rides in an untrusted sibling.
+        match &out.0[1] {
+            OutContent::Text(t) => {
+                assert!(
+                    t.starts_with(crate::untrusted::NOTE),
+                    "must be marked untrusted: {t}"
+                );
+                assert!(
+                    t.contains("⟦untrusted:") && t.contains("⟦/untrusted:"),
+                    "enveloped: {t}"
+                );
+                assert!(
+                    t.contains("\"text\":\"build done\""),
+                    "app-controlled log text: {t}"
+                );
+            }
+            _ => panic!("expected untrusted line sibling"),
         }
     }
 
@@ -659,6 +755,11 @@ mod tests {
             timeout_ms: Some(0),
         };
         let out = wait_for_log(&mut g, &a).unwrap();
+        assert_eq!(
+            out.0.len(),
+            1,
+            "no match -> single envelope block, no untrusted sibling"
+        );
         match &out.0[0] {
             OutContent::Text(t) => {
                 let v: serde_json::Value =
@@ -666,7 +767,6 @@ mod tests {
                 assert_eq!(v["ok"], json!(true), "envelope: {v}");
                 assert_eq!(v["tool"], json!("glass_wait_for_log"), "envelope: {v}");
                 assert_eq!(v["result"]["matched"], json!(false), "envelope: {v}");
-                assert!(v["result"]["line"].is_null(), "envelope: {v}");
             }
             _ => panic!("expected text"),
         }

--- a/crates/glass-mcp/src/tools/wait.rs
+++ b/crates/glass-mcp/src/tools/wait.rs
@@ -9,7 +9,7 @@ use glass_core::{
 use serde_json::json;
 
 use crate::params::*;
-use crate::tools::{OutContent, ToolOutput, ToolResult};
+use crate::tools::{envelope, OutContent, ToolOutput, ToolResult};
 
 pub fn wait_for_element(glass: &mut Glass, a: &WaitForElementArgs) -> ToolResult {
     if a.name.is_none() && a.role.is_none() {
@@ -43,9 +43,8 @@ pub fn wait_for_element(glass: &mut Glass, a: &WaitForElementArgs) -> ToolResult
             "states": e.states.active(),
         })
     });
-    let body =
-        json!({ "matched": o.matched, "elapsed_ms": o.elapsed_ms, "element": element }).to_string();
-    Ok(ToolOutput::text(crate::untrusted::wrap_untrusted(&body)))
+    let body = json!({ "matched": o.matched, "elapsed_ms": o.elapsed_ms, "element": element });
+    Ok(ToolOutput::result("glass_wait_for_element", body))
 }
 
 pub fn scroll_to_element(glass: &mut Glass, a: &ScrollToElementArgs) -> ToolResult {
@@ -98,9 +97,8 @@ pub fn scroll_to_element(glass: &mut Glass, a: &ScrollToElementArgs) -> ToolResu
         "elapsed_ms": o.elapsed_ms,
         "element": element,
         "scrolled": { "steps": o.steps, "reversed": o.reversed, "direction": o.direction.as_str() },
-    })
-    .to_string();
-    Ok(ToolOutput::text(crate::untrusted::wrap_untrusted(&body)))
+    });
+    Ok(ToolOutput::result("glass_scroll_to_element", body))
 }
 
 pub fn wait_for_region(glass: &mut Glass, a: &WaitForRegionArgs) -> ToolResult {
@@ -151,7 +149,7 @@ pub fn wait_for_region(glass: &mut Glass, a: &WaitForRegionArgs) -> ToolResult {
         ));
         image_produced = true;
     }
-    out.push(OutContent::Text(meta.to_string()));
+    out.push(OutContent::Text(envelope("glass_wait_for_region", meta)));
     if image_produced {
         out.push(OutContent::Text(crate::untrusted::IMAGE_NOTE.to_string()));
     }
@@ -187,9 +185,7 @@ pub fn wait_for_log(glass: &mut Glass, a: &WaitForLogArgs) -> ToolResult {
     if let Some(note) = &o.note {
         body["note"] = json!(note);
     }
-    Ok(ToolOutput::text(crate::untrusted::wrap_untrusted(
-        &body.to_string(),
-    )))
+    Ok(ToolOutput::result("glass_wait_for_log", body))
 }
 
 #[cfg(test)]
@@ -408,17 +404,17 @@ mod tests {
         let out = wait_for_element(&mut g, &a).unwrap();
         match &out.0[0] {
             OutContent::Text(t) => {
-                assert!(
-                    t.starts_with(crate::untrusted::NOTE),
-                    "must be marked untrusted: {t}"
+                let v: serde_json::Value =
+                    serde_json::from_str(t).expect("envelope must be valid JSON");
+                assert_eq!(v["ok"], json!(true), "envelope: {v}");
+                assert_eq!(v["tool"], json!("glass_wait_for_element"), "envelope: {v}");
+                assert_eq!(v["result"]["matched"], json!(true), "envelope: {v}");
+                assert_eq!(v["result"]["element"]["id"], json!(1), "envelope: {v}");
+                assert_eq!(
+                    v["result"]["element"]["name"],
+                    json!("Save"),
+                    "envelope: {v}"
                 );
-                assert!(
-                    t.contains("⟦untrusted:") && t.contains("⟦/untrusted:"),
-                    "enveloped: {t}"
-                );
-                assert!(t.contains("\"matched\":true"), "got: {t}");
-                assert!(t.contains("\"id\":1"), "got: {t}");
-                assert!(t.contains("\"name\":\"Save\""), "got: {t}");
             }
             _ => panic!("expected text"),
         }
@@ -434,16 +430,12 @@ mod tests {
         let out = wait_for_element(&mut g, &a).unwrap();
         match &out.0[0] {
             OutContent::Text(t) => {
-                assert!(
-                    t.starts_with(crate::untrusted::NOTE),
-                    "must be marked untrusted: {t}"
-                );
-                assert!(
-                    t.contains("⟦untrusted:") && t.contains("⟦/untrusted:"),
-                    "enveloped: {t}"
-                );
-                assert!(t.contains("\"matched\":false"), "got: {t}");
-                assert!(t.contains("\"element\":null"), "got: {t}");
+                let v: serde_json::Value =
+                    serde_json::from_str(t).expect("envelope must be valid JSON");
+                assert_eq!(v["ok"], json!(true), "envelope: {v}");
+                assert_eq!(v["tool"], json!("glass_wait_for_element"), "envelope: {v}");
+                assert_eq!(v["result"]["matched"], json!(false), "envelope: {v}");
+                assert!(v["result"]["element"].is_null(), "envelope: {v}");
             }
             _ => panic!("expected text"),
         }
@@ -528,17 +520,19 @@ mod tests {
         match out.0.last().unwrap() {
             OutContent::Text(t) => {
                 let v: serde_json::Value = serde_json::from_str(t).unwrap();
-                assert_eq!(v["matched"], true, "got: {t}");
+                assert_eq!(v["ok"], json!(true), "envelope: {v}");
+                assert_eq!(v["tool"], json!("glass_wait_for_region"), "envelope: {v}");
+                assert_eq!(v["result"]["matched"], true, "got: {t}");
                 assert_eq!(
-                    v["bbox"]["x"], 2,
+                    v["result"]["bbox"]["x"], 2,
                     "bbox x must be window-relative; got: {t}"
                 );
                 assert_eq!(
-                    v["bbox"]["y"], 2,
+                    v["result"]["bbox"]["y"], 2,
                     "bbox y must be window-relative; got: {t}"
                 );
-                assert_eq!(v["bbox"]["width"], 2, "got: {t}");
-                assert_eq!(v["bbox"]["height"], 2, "got: {t}");
+                assert_eq!(v["result"]["bbox"]["width"], 2, "got: {t}");
+                assert_eq!(v["result"]["bbox"]["height"], 2, "got: {t}");
             }
             _ => panic!("expected text"),
         }
@@ -612,16 +606,16 @@ mod tests {
         let out = wait_for_log(&mut g, &a).unwrap();
         match &out.0[0] {
             OutContent::Text(t) => {
-                assert!(
-                    t.starts_with(crate::untrusted::NOTE),
-                    "must be marked untrusted: {t}"
+                let v: serde_json::Value =
+                    serde_json::from_str(t).expect("envelope must be valid JSON");
+                assert_eq!(v["ok"], json!(true), "envelope: {v}");
+                assert_eq!(v["tool"], json!("glass_wait_for_log"), "envelope: {v}");
+                assert_eq!(v["result"]["matched"], json!(true), "envelope: {v}");
+                assert_eq!(
+                    v["result"]["line"]["text"],
+                    json!("build done"),
+                    "envelope: {v}"
                 );
-                assert!(
-                    t.contains("⟦untrusted:") && t.contains("⟦/untrusted:"),
-                    "enveloped: {t}"
-                );
-                assert!(t.contains("\"matched\":true"), "got: {t}");
-                assert!(t.contains("\"text\":\"build done\""), "got: {t}");
             }
             _ => panic!("expected text"),
         }
@@ -667,16 +661,12 @@ mod tests {
         let out = wait_for_log(&mut g, &a).unwrap();
         match &out.0[0] {
             OutContent::Text(t) => {
-                assert!(
-                    t.starts_with(crate::untrusted::NOTE),
-                    "must be marked untrusted: {t}"
-                );
-                assert!(
-                    t.contains("⟦untrusted:") && t.contains("⟦/untrusted:"),
-                    "enveloped: {t}"
-                );
-                assert!(t.contains("\"matched\":false"), "got: {t}");
-                assert!(t.contains("\"line\":null"), "got: {t}");
+                let v: serde_json::Value =
+                    serde_json::from_str(t).expect("envelope must be valid JSON");
+                assert_eq!(v["ok"], json!(true), "envelope: {v}");
+                assert_eq!(v["tool"], json!("glass_wait_for_log"), "envelope: {v}");
+                assert_eq!(v["result"]["matched"], json!(false), "envelope: {v}");
+                assert!(v["result"]["line"].is_null(), "envelope: {v}");
             }
             _ => panic!("expected text"),
         }

--- a/crates/glass-mcp/src/tools/wait.rs
+++ b/crates/glass-mcp/src/tools/wait.rs
@@ -9,7 +9,7 @@ use glass_core::{
 use serde_json::json;
 
 use crate::params::*;
-use crate::tools::{envelope, OutContent, ToolOutput, ToolResult};
+use crate::tools::{OutContent, ToolOutput, ToolResult};
 
 pub fn wait_for_element(glass: &mut Glass, a: &WaitForElementArgs) -> ToolResult {
     if a.name.is_none() && a.role.is_none() {
@@ -156,19 +156,17 @@ pub fn wait_for_region(glass: &mut Glass, a: &WaitForRegionArgs) -> ToolResult {
         "bbox": bbox,
         "elapsed_ms": o.elapsed_ms,
     });
-    let mut out = Vec::new();
-    let mut image_produced = false;
-    if o.matched && a.include_image.unwrap_or(false) {
-        out.push(OutContent::Image(
-            frame_to_webp(&o.frame).map_err(|e| e.to_string())?,
-        ));
-        image_produced = true;
-    }
-    out.push(OutContent::Text(envelope("glass_wait_for_region", meta)));
-    if image_produced {
-        out.push(OutContent::Text(crate::untrusted::IMAGE_NOTE.to_string()));
-    }
-    Ok(ToolOutput(out))
+    let image = if o.matched && a.include_image.unwrap_or(false) {
+        Some(frame_to_webp(&o.frame).map_err(|e| e.to_string())?)
+    } else {
+        None
+    };
+    Ok(ToolOutput::image_result(
+        "glass_wait_for_region",
+        image,
+        meta,
+        vec![],
+    ))
 }
 
 pub fn wait_for_log(glass: &mut Glass, a: &WaitForLogArgs) -> ToolResult {

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -160,10 +160,11 @@ Wait until the window stops changing, then return the settled frame.
 - `window_id` (integer) — observe this window (id from `glass_list_windows`) instead of the active
   one, without changing which window subsequent ops target.
 
-Returns `{settled, saw_motion, observed_ms, width, height}` (plus `x, y` — the region's origin —
-when `region` was given) whether or not `include_image` attached a frame. `saw_motion` and
-`observed_ms` make `settled` non-opaque: `settled:true` with `saw_motion:false` over a short
-`observed_ms` is only a brief quiet window, not necessarily a finished animation.
+Returns `{settled, saw_motion, observed_ms, width, height}`; `x, y` — the region's origin — are
+added only when `include_image` attached a frame and `region` was given (the text-only result never
+includes them). `saw_motion` and `observed_ms` make `settled` non-opaque: `settled:true` with
+`saw_motion:false` over a short `observed_ms` is only a brief quiet window, not necessarily a
+finished animation.
 
 ### `glass_wait_for_element`
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -19,9 +19,57 @@ supports, see [reference/platforms.md](platforms.md).
   return **text only**, so routine checks between screenshots cost no vision tokens.
 - **Element ids** from `glass_a11y_snapshot` / `glass_a11y_marks`, and **window ids** from
   `glass_list_windows`, are valid only within the latest snapshot/listing — re-read rather than
-  caching them.
+  caching them. (Wire types for both are in [Type conventions](#type-conventions) below.)
 - **No silent fallbacks.** A failed capture or input returns a structured error, never a blank or
   stale frame.
+- **Unknown enum values are rejected, not silently coerced.** An out-of-set value for any closed
+  choice — `button`, `op`, `condition`, `direction`, `mode`, `stream`, `backend`, `sandbox`, a
+  `glass_do` action kind, and so on — comes back as a structured error naming the valid options.
+
+## Result envelope
+
+Every tool returns, on success, one leading text content block in a fixed shape:
+
+`{ "ok": true, "tool": "<tool name>", "result": { ... } }`
+
+Each tool's entry below gives its `result` shape as a "Returns" line.
+
+`result` holds only glass-computed or glass-echoed fields — ids, geometry, counts, elapsed times,
+matched flags. Bulk text the *target app* controls — the `glass_a11y_snapshot` outline, `glass_logs`
+lines, clipboard text, the `glass_list_windows` array (window titles are app-supplied), the
+`glass_a11y_marks` legend — never rides inside `result`. It follows as its own subsequent content
+block, wrapped in an untrusted marker, so an app that puts an instruction-shaped string in a window
+title or a log line can't pass it off as glass itself instructing the agent.
+
+A capture tool (`glass_screenshot`, `glass_wait_stable` with an image, `glass_a11y_marks`, and
+`glass_diff` / `glass_wait_for_region` when they attach one) emits the image content block *first*,
+then the envelope, then a trailing note that the image is untrusted too. Every other tool — including
+`glass_do`'s optional `then.screenshot`/`then.diff` image — puts the envelope first, with any sibling
+blocks (an image, an app-controlled text block) following it.
+
+A failed call comes back as an MCP **error** result, not this envelope — check for an error before
+parsing `result`.
+
+Most input/action tools (`glass_click`, `glass_move`, `glass_drag`, `glass_scroll`, `glass_gesture`,
+`glass_type`, `glass_key`, `glass_stop`, `glass_clipboard_set`) return an empty `{}` — `ok:true` in
+the envelope is itself the confirmation that the action ran.
+
+## Type conventions
+
+Exact wire types for the ids and coordinates used throughout this reference (freshness rules for
+ids are in [Conventions](#conventions) above):
+
+- **Element ids** — the `#id` in a `glass_a11y_snapshot` line, and the `id` param of
+  `glass_click_element` / `glass_set_value` — are `u32`.
+- **Window ids** — `glass_list_windows`' `id`, `glass_select_window`'s `id` param, and every tool's
+  `window_id` param — are `u64`, carrying the platform's own window handle.
+- **Input coordinates** — `x`/`y` (and `x1,y1,x2,y2`, and gesture `from`/`to`) on
+  `glass_click`/`glass_move`/`glass_drag`/`glass_scroll`/`glass_gesture` — are signed `i32`,
+  window-relative. A negative value addresses a point off the window's top-left edge rather than
+  being rejected.
+- **Region coordinates** — `region`/`stability_region` (`x,y,width,height`), wherever a tool accepts
+  one — are unsigned `u32`; they can never be negative.
+- `glass_logs`' `max_lines` is a `u32`.
 
 ## Session lifecycle
 
@@ -32,7 +80,7 @@ Build, launch, and locate a native GUI app; returns its window geometry.
 - `run` (array of string, **required**) — program and arguments; `run[0]` is the executable.
 - `build` (string) — shell command run in `cwd` before launching.
 - `cwd` (string) — working directory for `build` and `run`.
-- `env` (array of `[name, value]` pairs) — extra environment for the launched app.
+- `env` (object) — extra environment variables for the launched app, as `{ "KEY": "VALUE" }` pairs.
 - `backend` (string) — `"x11"` or `"wayland"` (Linux), `"windows"` (Windows host), `"macos"` (macOS
   host), `"android"` (an AVD emulator, any host), or `"ios"` (an iOS Simulator, macOS host). Omit for
   the server default (`GLASS_BACKEND`, else `windows` on Windows, `macos` on macOS, else `x11`).
@@ -45,11 +93,11 @@ Build, launch, and locate a native GUI app; returns its window geometry.
   tools work against this app. Opt-in, since it spawns extra processes.
 - `timeout_ms` (integer) — launch timeout.
 
-Returns the located window's geometry.
+Returns the located window's geometry: `{x, y, width, height}`.
 
 ### `glass_stop`
 
-Stop the running app and end the session. No parameters.
+Stop the running app and end the session. No parameters. Returns `{}`.
 
 ## Capture & visual comparison
 
@@ -62,11 +110,16 @@ Capture the app window, or an optional sub-rectangle, as a lossless WebP image.
 - `window_id` (integer) — capture this window (id from `glass_list_windows`) instead of the active
   one, without changing which window subsequent ops target. Omit for the active window.
 
+Returns `{width, height}` — the captured frame's dimensions — plus `x, y` (the region's origin) when
+`region` was given.
+
 ### `glass_baseline_save`
 
 Save the current frame as a named visual baseline for later `glass_diff` / `glass_wait_for_region`.
 
 - `name` (string, **required**) — baseline name.
+
+Returns `{name}`, echoing the saved name.
 
 ### `glass_diff`
 
@@ -82,8 +135,9 @@ Diff the current frame against a named baseline; returns change stats and a boun
   window. Scopes the comparison (and the reported `bbox`, which becomes region-relative) to just
   this area — the way to ask "did *only* this part change?".
 
-Returns `changed_pct` and a `bbox`; only attaches an image when `include_image:true` and something
-changed.
+Returns `{changed_pixels, total_pixels, changed_pct, aa_ignored, bbox}` (`bbox` is `null` when
+nothing changed), plus the given `region` echoed back when one was passed; only attaches an image
+when `include_image:true` and something changed.
 
 ## Settling & waiting
 
@@ -94,8 +148,8 @@ than erroring — branch on that instead of retrying blindly.
 
 Wait until the window stops changing, then return the settled frame.
 
-- `include_image` (boolean, default true) — set false for a text-only `{settled,width,height}`
-  result with no image (cheap before a text `glass_diff`); `region` is ignored when false.
+- `include_image` (boolean, default true) — set false for a text-only result (no image; cheap
+  before a text `glass_diff`); `region` is ignored when false.
 - `region` (`{x,y,width,height}`) — crop the returned frame.
 - `stability_region` (`{x,y,width,height}`) — watch only this sub-rectangle for settling, ignoring
   unrelated motion (a clock, a spinner) elsewhere. Independent of `region`.
@@ -105,6 +159,11 @@ Wait until the window stops changing, then return the settled frame.
 - `tolerance` (integer 0–255) — per-frame change tolerance.
 - `window_id` (integer) — observe this window (id from `glass_list_windows`) instead of the active
   one, without changing which window subsequent ops target.
+
+Returns `{settled, saw_motion, observed_ms, width, height}` (plus `x, y` — the region's origin —
+when `region` was given) whether or not `include_image` attached a frame. `saw_motion` and
+`observed_ms` make `settled` non-opaque: `settled:true` with `saw_motion:false` over a short
+`observed_ms` is only a brief quiet window, not necessarily a finished animation.
 
 ### `glass_wait_for_element`
 
@@ -121,8 +180,8 @@ no accessibility tree.
 - `interval_ms` (integer, default 200) — poll interval (one a11y snapshot per tick).
 - `timeout_ms` (integer, default 10000) — returns `{matched:false}` on timeout.
 
-Returns `{matched, elapsed_ms, element{id, role, name, bounds, states}}` — the `id` is usable with
-`glass_click_element`.
+Returns `{matched, elapsed_ms, element{id, role, name, value, bounds, states}}` — `element` is
+`null` when `matched:false`; otherwise its `id` is usable with `glass_click_element`.
 
 ### `glass_wait_for_region`
 
@@ -156,13 +215,18 @@ Block until a log line containing `contains` appears, then return it as text.
 - `interval_ms` (integer, default 100) — poll interval.
 - `timeout_ms` (integer, default 10000) — returns `{matched:false}` on timeout.
 
-Returns `{matched, line{seq, stream, text}, cursor, elapsed_ms}`; resume reading from the returned
-`cursor`.
+Returns `{matched, line{seq, stream, text}, cursor, elapsed_ms}` (`line` is `null` when unmatched),
+plus `note` on a default-cursor timeout when the substring was already in the log before this call —
+it points you at `cursor:0`. Resume reading from the returned `cursor`.
 
 ## Input
 
-`glass_click`, `glass_drag`, and `glass_scroll` accept an optional `modifiers` array (e.g.
-`["ctrl"]`, `["ctrl","shift"]`) held during the action — enabling shift/ctrl-click multi-select,
+Every tool in this section returns an empty `result:{}` on success — `ok:true` in the envelope is
+itself the confirmation that the action ran; there is nothing else to report.
+
+`glass_click`, `glass_drag`, and `glass_scroll` accept an optional `modifiers` array — `"ctrl"`,
+`"shift"`, `"alt"`, or `"super"` (e.g. `["ctrl"]`, `["ctrl","shift"]`; macOS calls this key ⌘ and
+also accepts `"cmd"` as an alias) — held during the action, enabling shift/ctrl-click multi-select,
 modified drags, and Ctrl+scroll.
 
 On the **iOS** backend `glass_click`, `glass_type`, `glass_key`, `glass_scroll`, and `glass_drag`
@@ -265,12 +329,18 @@ Fails fast: if an action errors it reports which index failed and how many ran. 
 sequences (login, form-fill, menu→item); if you must see a result to choose the next action, don't
 batch that part.
 
+Returns `{executed}` (the number of actions that ran) plus, when `then` was given, a `then` object
+keyed by whichever of `settle`/`diff`/`screenshot` you asked for — each key holds that sub-tool's
+own `result` shape from its entry above.
+
 ## Windows
 
 ### `glass_list_windows`
 
-List the app's top-level windows — `id`, `title`, `class`, geometry, and which is active — as a JSON
-array. Ids are not stable across calls; re-list after windows open or close.
+List the app's top-level windows. Returns `{count}`; the window array itself — `id`, `title`,
+`class`, geometry, and which is active, as JSON — rides as an untrusted sibling text block, since a
+window's `title` is app-controlled text. Ids are not stable across calls; re-list after windows open
+or close.
 
 ### `glass_select_window`
 
@@ -278,6 +348,8 @@ Make a window active by `id` (from `glass_list_windows`). Subsequent capture/cli
 target it, with window-relative coordinates.
 
 - `id` (integer, **required**) — window id from the latest listing.
+
+Returns the now-active window's geometry: `{x, y, width, height}`.
 
 ### `glass_window`
 
@@ -289,6 +361,8 @@ Focus, resize, or move the active window, or read its geometry.
 
 Resize/move are non-goals on Android and iOS (apps are full-screen); those backends serve `"focus"`
 and `"geometry"` but return an unsupported error for `"resize"`/`"move"`.
+
+Returns the window's geometry after the op: `{x, y, width, height}`.
 
 ## Accessibility (semantic addressing)
 
@@ -302,23 +376,29 @@ reads the Simulator's accessibility tree over `idb_companion` (install it — se
 
 ### `glass_a11y_snapshot`
 
-Capture the active window's accessibility tree as compact text. No parameters. Each line is
+Capture the active window's accessibility tree as compact text. No parameters. Returns `{}`; the
+tree itself rides as an untrusted sibling text block, one line per element:
 `#<id> <Role> "<name>" (x,y wxh) [states]`; pass an `#id` to `glass_click_element`.
 
 ### `glass_a11y_marks`
 
 Screenshot of the active window with a numbered Set-of-Mark box on each interactable element, plus a
-text legend (`#<id> <Role> "<name>"`). No parameters. Same ids as `glass_a11y_snapshot`. The box is
-only as precise as the toolkit's a11y geometry (can drift ~10–20px), but the `#id` and the click are
-exact.
+text legend (`#<id> <Role> "<name>"`). No parameters. Returns `{count}` — the number of marked
+elements; the image and the legend text follow as siblings (the legend untrusted-wrapped), per the
+image ordering above. Same ids as `glass_a11y_snapshot`. The box is only as precise as the toolkit's
+a11y geometry (can drift ~10–20px), but the `#id` and the click are exact.
 
 ### `glass_click_element`
 
 Click an element by its `#id` (clicks the center of its bounds, via the normal click path).
 
 - `id` (integer, **required**) — the `#id` from the latest snapshot.
-- `return` (string) — `"snapshot"` folds a fresh a11y tree into the result (and refreshes the
-  cache), `"settle"` waits for the UI to stop changing (text-only), or `"none"` (default).
+- `return` (string) — `"snapshot"` appends a fresh a11y outline as an untrusted sibling block (and
+  refreshes the id cache), `"settle"` folds settle metadata into `result.observed`, or `"none"`
+  (default) adds nothing.
+
+Returns `{id}` — the `#id` you clicked — plus `observed: {settled, saw_motion, observed_ms}` when
+`return:"settle"`.
 
 ### `glass_set_value`
 
@@ -328,6 +408,9 @@ element isn't editable, changed since the snapshot, or the app exposes no access
 - `id` (integer, **required**) — the element's `#id`.
 - `text` (string, **required**) — the value to set.
 - `return` (string) — `"snapshot"`, `"settle"`, or `"none"` (default), as for `glass_click_element`.
+
+Returns `{id}` plus `observed: {settled, saw_motion, observed_ms}` when `return:"settle"`, exactly
+as for `glass_click_element`.
 
 ### `glass_scroll_to_element`
 
@@ -354,9 +437,9 @@ Errors if the app exposes no accessibility tree.
   larger covers distance faster but risks stepping past a row's/column's realized band.
 - `timeout_ms` (integer, default 20000) — returns `{matched:false}` on timeout.
 
-Returns `{matched, elapsed_ms, element{id, role, name, bounds, states}, scrolled{steps,
-reversed, direction}}` — `direction` is the resolved (possibly inferred) sweep direction, and
-the `id` is usable with `glass_click_element`.
+Returns `{matched, elapsed_ms, element{id, role, name, value, bounds, states}, scrolled{steps,
+reversed, direction}}` — `element` is `null` when `matched:false`; `direction` is the resolved
+(possibly inferred) sweep direction, and the `id` is usable with `glass_click_element`.
 
 ## Clipboard
 
@@ -367,7 +450,8 @@ mechanism.
 
 ### `glass_clipboard_get`
 
-Read the app's clipboard as text (`""` if empty). No parameters. Also the cheap text-extraction path:
+Read the app's clipboard as text (`""` if empty). No parameters. On success, `result` is `{}`; the
+clipboard text itself rides as an untrusted sibling text block. Also the cheap text-extraction path:
 `glass_do` `ctrl+a` then `ctrl+c`, then read here — faster and token-free versus OCR for any app
 with selectable text. Returns `Unsupported` where the backend can't provide clipboard access.
 
@@ -381,8 +465,8 @@ Store / notarized) can't be redirected and returns Unsupported.
 
 ### `glass_clipboard_set`
 
-Write text to the app's clipboard so it can paste it. Returns `Unsupported` where the backend can't
-provide clipboard access.
+Write text to the app's clipboard so it can paste it. On success, `result` is `{}`. Returns
+`Unsupported` where the backend can't provide clipboard access.
 
 - `text` (string, **required**) — the text to write.
 
@@ -408,7 +492,10 @@ Read captured stdout/stderr log lines with a resumable cursor.
 - `contains` (string) — return only lines containing this substring.
 - `stream` (string) — `"stdout"`, `"stderr"`, or `"both"` (default).
 - `cursor` (integer) — resume from this cursor.
-- `max_lines` (integer) — cap the number of lines returned.
+- `max_lines` (integer, `u32`) — cap the number of lines returned.
+
+Returns `{cursor}` — resume a later call from here; the matched lines themselves (each
+`{seq, stream, text}`) ride as an untrusted sibling text block, since log output is app-controlled.
 
 ### `glass_doctor`
 
@@ -421,6 +508,8 @@ it to self-diagnose a `glass_start` failure.
 **Platform notes:** on Linux the checks cover the headless display servers (Xvfb for x11, sway for
 wayland) and software GL; the report names exactly the checks it ran for the selected backend.
 
+Returns `{report}` — the human-readable diagnostic text above, as a single string.
+
 Mirrors the `glass-mcp doctor` CLI — see [reference/cli.md](cli.md).
 
 ### `glass_capabilities`
@@ -432,7 +521,8 @@ before `glass_start`.
 - `backend` (string, optional) — which backend to report: `x11`, `wayland`, `windows`, `macos`,
   `android`, `ios`. Omit for the active/default backend.
 
-Returns JSON. For a backend compiled into this binary:
+Returns JSON as `result` (no untrusted siblings — capability data is glass-computed, not read from
+the app). For a backend compiled into this binary:
 
 `{ "backend", "available": true, "capabilities": { <operation>: { "status", "note"?, "tools" } } }`
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -37,9 +37,11 @@ Each tool's entry below gives its `result` shape as a "Returns" line.
 `result` holds only glass-computed or glass-echoed fields — ids, geometry, counts, elapsed times,
 matched flags. Bulk text the *target app* controls — the `glass_a11y_snapshot` outline, `glass_logs`
 lines, clipboard text, the `glass_list_windows` array (window titles are app-supplied), the
-`glass_a11y_marks` legend — never rides inside `result`. It follows as its own subsequent content
-block, wrapped in an untrusted marker, so an app that puts an instruction-shaped string in a window
-title or a log line can't pass it off as glass itself instructing the agent.
+`glass_a11y_marks` legend, and the matched element from `glass_wait_for_element` /
+`glass_scroll_to_element` and matched line from `glass_wait_for_log` — never rides inside `result`. It
+follows as its own subsequent content block, wrapped in an untrusted marker, so an app that puts an
+instruction-shaped string in an element name or a log line can't pass it off as glass itself
+instructing the agent.
 
 A capture tool (`glass_screenshot`, `glass_wait_stable` with an image, `glass_a11y_marks`, and
 `glass_diff` / `glass_wait_for_region` when they attach one) emits the image content block *first*,
@@ -181,8 +183,9 @@ no accessibility tree.
 - `interval_ms` (integer, default 200) — poll interval (one a11y snapshot per tick).
 - `timeout_ms` (integer, default 10000) — returns `{matched:false}` on timeout.
 
-Returns `{matched, elapsed_ms, element{id, role, name, value, bounds, states}}` — `element` is
-`null` when `matched:false`; otherwise its `id` is usable with `glass_click_element`.
+Returns `{matched, elapsed_ms}`. On a match, the matched element (`{id, role, name, value, bounds,
+states}`) rides as an untrusted sibling text block, since its `name`/`value` are app-controlled; its
+`id` is usable with `glass_click_element`. No sibling on timeout.
 
 ### `glass_wait_for_region`
 
@@ -216,9 +219,10 @@ Block until a log line containing `contains` appears, then return it as text.
 - `interval_ms` (integer, default 100) — poll interval.
 - `timeout_ms` (integer, default 10000) — returns `{matched:false}` on timeout.
 
-Returns `{matched, line{seq, stream, text}, cursor, elapsed_ms}` (`line` is `null` when unmatched),
-plus `note` on a default-cursor timeout when the substring was already in the log before this call —
-it points you at `cursor:0`. Resume reading from the returned `cursor`.
+Returns `{matched, cursor, elapsed_ms}`, plus `note` on a default-cursor timeout when the substring
+was already in the log before this call — it points you at `cursor:0`. On a match, the matched line
+(`{seq, stream, text}`) rides as an untrusted sibling text block, since log output is app-controlled;
+no sibling on timeout. Resume reading from the returned `cursor`.
 
 ## Input
 
@@ -438,9 +442,10 @@ Errors if the app exposes no accessibility tree.
   larger covers distance faster but risks stepping past a row's/column's realized band.
 - `timeout_ms` (integer, default 20000) — returns `{matched:false}` on timeout.
 
-Returns `{matched, elapsed_ms, element{id, role, name, value, bounds, states}, scrolled{steps,
-reversed, direction}}` — `element` is `null` when `matched:false`; `direction` is the resolved
-(possibly inferred) sweep direction, and the `id` is usable with `glass_click_element`.
+Returns `{matched, elapsed_ms, scrolled{steps, reversed, direction}}` — `direction` is the resolved
+(possibly inferred) sweep direction. On a match, the matched element (`{id, role, name, value, bounds,
+states}`) rides as an untrusted sibling text block, since its `name`/`value` are app-controlled; its
+`id` is usable with `glass_click_element`. No sibling on timeout.
 
 ## Clipboard
 


### PR DESCRIPTION
## Summary

Freezes the MCP tool surface behind a single, uniform result shape so it can carry a stable
semver contract. Every one of the 30 tools now returns, on success, a leading text block:

```json
{ "ok": true, "tool": "glass_<name>", "result": { /* per-tool, glass-trusted fields */ } }
```

`result` holds only glass-computed, trusted fields. Text the target app controls — the accessibility
outline, log lines, clipboard contents, window titles, the marks legend, and matched a11y
element/log-line objects — continues to ride in its own subsequent block wrapped in the untrusted
marker, so an app can't put an instruction-shaped string in a title or a log line and have it read as
glass instructing the agent. Image tools keep the image block first, then the envelope, then the
image-note.

## What changed

- **Uniform `{ok,tool,result}` envelope** on all 30 tools (`glass_start` … `glass_do`), via
  `ToolOutput::result` / `result_with` / `image_result` constructors.
- **`glass_do`** folds each `then` observe's metadata under `result.then.{settle,diff,screenshot}`
  (no nested envelopes); any observe image rides as a sibling.
- **`glass_start` `env`** is now a JSON object `{ "KEY": "VALUE" }` instead of an array of pairs.
- **`glass_logs` `max_lines`** is a `u32` (was a platform-width-ambiguous `usize`).
- **Enum params reject unknown values** with a structured error naming the valid options; this PR adds
  the missing reject-tests so every frozen enum (`op`, `button`, `return`, `condition`, `direction`,
  `until`, `mode`, `stream`, `backend`, `sandbox`, `action`, `modifiers`) is locked.
- **`docs/reference/tools.md`** documents the frozen surface: the envelope, each tool's `result`
  shape, the accepted enum values, and the id/coordinate **type conventions** (element ids `u32`,
  window ids `u64`, input coords `i32`, region coords `u32`).

## Security

A review caught that `glass_wait_for_element`, `glass_scroll_to_element`, and `glass_wait_for_log`
had moved app-controlled strings (a11y `name`/`value`, log-line `text`) into the trusted `result`
during the refactor — dropping the untrusted wrapper those tools previously applied. This is fixed:
their `result` now carries only trusted scalars (`matched`, `elapsed_ms`, `cursor`, `note`,
`scrolled`) and the app-controlled element/line object rides in an untrusted sibling block, matching
`glass_logs` and `glass_list_windows`.

## Testing

- `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, and
  `cargo fmt --check` all clean.
- New/strengthened tests lock every tool's frozen `result` shape (parsing the envelope rather than
  substring-matching), the untrusted-sibling separation, `glass_do` flattening, the `env` object
  (and rejection of the old array shape), and reject-unknown coverage for every enum param.
- A test binds each tool's envelope `tool` string to the registered tool set, so a typo can't ship a
  wrong frozen name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
