### PR TITLE
Lock release-artifact naming into the 1.0 guarantee + sync guard

### DIFF
--- a/crates/glass-mcp/tests/release_artifact_names.rs
+++ b/crates/glass-mcp/tests/release_artifact_names.rs
@@ -1,0 +1,55 @@
+//! Guard: the release-artifact platform suffixes documented in `docs/reference/platforms.md` must
+//! each be produced by `.github/workflows/release.yml`. The asset names are part of the 1.x
+//! stability guarantee (see `docs/reference/stability.md`), so a rename/removal in the workflow that
+//! forgets the doc — or a documented suffix the workflow never builds — is a drift this test catches.
+//!
+//! Direction: doc -> workflow. Each `glass-mcp-<tag>-<suffix>` in platforms.md must appear as a
+//! literal in release.yml. Known limitation: only this direction is checked (the reverse — scanning
+//! release.yml for asset patterns to confirm each is documented — is not implemented), so a brand-new
+//! *undocumented* asset added to the workflow would not be caught; every rename/removal of a
+//! documented suffix is.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    // crates/glass-mcp -> repo root
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("resolve repo root from CARGO_MANIFEST_DIR")
+}
+
+/// Platform suffixes documented as `glass-mcp-<tag>-<suffix>.<ext>` in platforms.md, excluding the
+/// `<platform>` placeholder used in prose.
+fn documented_suffixes(platforms_md: &str) -> BTreeSet<String> {
+    platforms_md
+        .split("glass-mcp-<tag>-")
+        .skip(1)
+        .map(|rest| rest.chars().take_while(|c| *c != '.').collect::<String>())
+        .filter(|s| !s.is_empty() && !s.contains('<') && !s.contains('>'))
+        .collect()
+}
+
+#[test]
+fn documented_release_suffixes_are_produced_by_the_workflow() {
+    let root = repo_root();
+    let platforms = std::fs::read_to_string(root.join("docs/reference/platforms.md"))
+        .expect("read docs/reference/platforms.md");
+    let release_yml = std::fs::read_to_string(root.join(".github/workflows/release.yml"))
+        .expect("read .github/workflows/release.yml");
+
+    let suffixes = documented_suffixes(&platforms);
+    assert!(
+        suffixes.len() >= 4,
+        "expected the four documented artifact suffixes, found {suffixes:?}"
+    );
+
+    for suffix in &suffixes {
+        assert!(
+            release_yml.contains(suffix.as_str()),
+            "release.yml no longer references the `{suffix}` artifact suffix documented in \
+             platforms.md — update one so the 1.x-stable asset names stay in sync"
+        );
+    }
+}

--- a/docs/reference/platforms.md
+++ b/docs/reference/platforms.md
@@ -58,6 +58,10 @@ Each asset is accompanied by a `.sha256` checksum file, and every release carrie
 provenance attestations. No aarch64 Linux asset is published; that architecture is built from source
 (see [how-to/build-from-source.md](../how-to/build-from-source.md)).
 
+These asset names are **stable across the 1.x series** — an installer or script can depend on the
+`glass-mcp-<tag>-<platform>.<ext>` pattern and the per-platform suffixes above. See
+[Stability and versioning](stability.md) for the guarantee.
+
 ## Notes
 
 **† Android** is emulator-only. Capture, multi-window, input, and logs work over `adb`, and glass

--- a/docs/reference/stability.md
+++ b/docs/reference/stability.md
@@ -29,6 +29,10 @@ Within a major version, these are stable — glass will not change them incompat
   [Environment variables](environment.md).
 - **Type conventions** — element ids are `u32`, window ids are `u64`, input coordinates are signed
   `i32` (window-relative), and region coordinates are unsigned `u32`.
+- **Release-artifact names and layout** — the `glass-mcp-<tag>-<platform>.<ext>` assets on the
+  [Releases](https://github.com/fixed-width/glass/releases) page, their per-platform suffixes, and the
+  accompanying `.sha256` files. An installer or script can depend on the download-URL pattern. See
+  [Platform support](platforms.md#release-artifacts) for the exact names.
 
 ## What is not covered
 


### PR DESCRIPTION
## Summary

Locks the release-artifact naming so an installer or script can depend on the download-URL pattern
across the 1.x series. The names were already stable and documented accurately in `platforms.md`; this
adds the **commitment** and a guard against future drift.

## What changed

- **`stability.md`** — adds "release-artifact names and layout" to the covered surface: the
  `glass-mcp-<tag>-<platform>.<ext>` assets, their per-platform suffixes, and the `.sha256` sidecars
  are stable within a major version.
- **`platforms.md`** — notes in the Release artifacts section that the names are stable across 1.x,
  with a link to the stability policy.
- **Guard test** (`crates/glass-mcp/tests/release_artifact_names.rs`) — derives the documented platform
  suffixes from `platforms.md` and asserts each appears in `.github/workflows/release.yml`, so a
  rename/removal in the workflow that forgets the doc fails the build. (Verified it fails on a bogus
  suffix.) Its one-directional limitation is documented in the test.

No artifact was renamed and no behavior changed — freeze means the names stay as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
