### PR TITLE
ci(release): rename Windows signing secrets to WINDOWS_TRUSTED_SIGNING_ prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,14 +122,16 @@ jobs:
       # account is provisioned and its secrets are set, this SKIPS signing (exit 0) and
       # still uploads the (unsigned) artifact — same as before. Secrets can't be read in a
       # job-level `if:`, so we probe one here and gate the sign step on its output.
-      # Required secrets: AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET,
+      # Required secrets (all org-level, WINDOWS_TRUSTED_SIGNING_* prefix):
       # WINDOWS_TRUSTED_SIGNING_ENDPOINT, WINDOWS_TRUSTED_SIGNING_ACCOUNT,
-      # WINDOWS_TRUSTED_SIGNING_CERT_PROFILE. Provisioning runbook: internal.
+      # WINDOWS_TRUSTED_SIGNING_CERT_PROFILE, WINDOWS_TRUSTED_SIGNING_AZURE_TENANT_ID,
+      # WINDOWS_TRUSTED_SIGNING_AZURE_CLIENT_ID, WINDOWS_TRUSTED_SIGNING_AZURE_CLIENT_SECRET.
+      # Provisioning runbook: internal.
       - name: Check signing credentials
         id: creds
         shell: pwsh
         env:
-          SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          SECRET: ${{ secrets.WINDOWS_TRUSTED_SIGNING_AZURE_CLIENT_SECRET }}
         run: |
           if ($env:SECRET) {
             "present=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
@@ -142,9 +144,9 @@ jobs:
         if: steps.creds.outputs.present == 'true'
         uses: Azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
-          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          azure-tenant-id: ${{ secrets.WINDOWS_TRUSTED_SIGNING_AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.WINDOWS_TRUSTED_SIGNING_AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.WINDOWS_TRUSTED_SIGNING_AZURE_CLIENT_SECRET }}
           endpoint: ${{ secrets.WINDOWS_TRUSTED_SIGNING_ENDPOINT }}
           signing-account-name: ${{ secrets.WINDOWS_TRUSTED_SIGNING_ACCOUNT }}
           certificate-profile-name: ${{ secrets.WINDOWS_TRUSTED_SIGNING_CERT_PROFILE }}


### PR DESCRIPTION
The Azure Trusted Signing account is org-scoped, so its six CI secrets are provisioned as **org-level** GitHub secrets sharing the `WINDOWS_TRUSTED_SIGNING_` prefix (scoped to selected repos). This updates the release workflow to read the service-principal secrets under their new names in both the credential-gate probe and the `Azure/artifact-signing-action` inputs, and refreshes the required-secrets comment.

Renamed refs (bare `AZURE_*` → prefixed):
- `AZURE_TENANT_ID` → `WINDOWS_TRUSTED_SIGNING_AZURE_TENANT_ID`
- `AZURE_CLIENT_ID` → `WINDOWS_TRUSTED_SIGNING_AZURE_CLIENT_ID`
- `AZURE_CLIENT_SECRET` → `WINDOWS_TRUSTED_SIGNING_AZURE_CLIENT_SECRET`

The other three (`ENDPOINT`, `ACCOUNT`, `CERT_PROFILE`) already carried the prefix and are unchanged.

**No behavior change:** an absent secret still skips signing (exit 0) and ships the unsigned artifact — signing switches on only once all six are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)