### PR TITLE
ci: pin taiki-e/install-action to its latest release SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
         run: rustup show
       - name: Add llvm-tools (required by cargo-llvm-cov)
         run: rustup component add llvm-tools-preview
-      - uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2.82.8
+      - uses: taiki-e/install-action@ed67fa35ac944f3a9b33f12c4dd43b6f31a47e20 # v2.83.3
         with:
           tool: cargo-llvm-cov
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1


### PR DESCRIPTION
CI already pins every action to a full-length commit SHA, as required by
`sha_pinning_required`. `taiki-e/install-action` was the one reference behind
its latest release — bump it and keep it SHA-pinned.

- `taiki-e/install-action` v2.82.8 → **v2.83.3** (`ed67fa3`)

Verified: `.github/workflows/*.yml` parse; every `uses:` resolves to a 40-char SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)