### PR TITLE
ci(release): mark hyphenated (pre-release) tags as --prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,12 @@ jobs:
             fi
             echo "release $TAG already exists as a draft (re-run) — reusing it."
           else
-            gh release create "$TAG" --draft --generate-notes --title "$TAG"
+            # A semver pre-release tag carries a hyphen (v1.0.0-rc1, v0.9.0-beta). Mark it
+            # --prerelease so GitHub never surfaces it as the repo's "Latest" release; a final
+            # tag (v1.0.0) has no hyphen and publishes as a normal release.
+            PRERELEASE=""
+            case "$TAG" in *-*) PRERELEASE="--prerelease" ;; esac
+            gh release create "$TAG" --draft $PRERELEASE --generate-notes --title "$TAG"
           fi
 
   linux:
@@ -324,4 +329,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
-        run: gh release edit "$TAG" --draft=false
+        # Reaffirm the prerelease flag at publish (idempotent) so a hyphenated tag stays a
+        # pre-release even if its draft was created before this flag existed. --latest=false on
+        # a pre-release keeps it from taking the "Latest" badge; a final tag flips both live.
+        run: |
+          set -euo pipefail
+          case "$TAG" in
+            *-*) gh release edit "$TAG" --draft=false --prerelease --latest=false ;;
+            *)   gh release edit "$TAG" --draft=false --latest ;;
+          esac

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ perf.data.old
 # Editor / OS cruft
 *.swp
 .DS_Store
+.idea/
 
 # Pulled-back artifacts from scripts/test-windows.sh on-box runs
 /.windows-artifacts/


### PR DESCRIPTION
The release pipeline published every tag as a normal release with no prerelease flag. A semver pre-release tag (`v1.0.0-rc1`, `v0.9.0-beta`) whose version sorts above the current latest would therefore grab GitHub's **"Latest"** badge — wrong for a release candidate.

**Change:**
- **Create step:** hyphenated tag → `gh release create … --prerelease`.
- **Publish step:** hyphenated tag → `gh release edit --draft=false --prerelease --latest=false` (idempotent — corrects a draft created before this flag); final tag (no hyphen) → `--draft=false --latest`.

**Why now:** unblocks cutting `v1.0.0-rc` through the immutable pipeline for the B5 dogfood without polluting the release badge. No effect on final releases beyond pinning `--latest` explicitly (previously auto-determined).

🤖 Generated with [Claude Code](https://claude.com/claude-code)