### PR TITLE
fix(a11y): make the set_value 'not editable' error actionable

### DIFF
--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -62,7 +62,7 @@ pub enum GlassError {
     #[error("element #{0} has no clickable on-screen geometry")]
     AxElementNotClickable(u32),
 
-    #[error("element #{0} is not editable")]
+    #[error("element #{0} is not editable via the accessibility API (its a11y projection exposes no writable value — a common toolkit gap even when the element accepts typed input); focus it with glass_click, then enter text with glass_type / glass_key instead")]
     AxElementNotEditable(u32),
 
     #[error("element #{0} has no option matching {1:?}; available options: {2}")]
@@ -176,7 +176,7 @@ mod tests {
         );
         assert_eq!(
             GlassError::AxElementNotEditable(5).to_string(),
-            "element #5 is not editable"
+            "element #5 is not editable via the accessibility API (its a11y projection exposes no writable value — a common toolkit gap even when the element accepts typed input); focus it with glass_click, then enter text with glass_type / glass_key instead"
         );
         assert_eq!(
             GlassError::AxElementChanged(2).to_string(),


### PR DESCRIPTION
## What

`AxElementNotEditable` rendered as a bare **`element #N is not editable`**. That message names a cause but no remedy — and it *contradicts* an accessibility snapshot that marks the same element `[editable]` (accesskit/egui advertise an editable text field whose AT-SPI value is nonetheless read-only, so `set_value` is refused while typing works).

This changes the message to name the remedy, matching the existing `AxValueNotApplied` precedent ("read-only a11y projection — use keystrokes"):

> element #N is not editable via the accessibility API (its a11y projection exposes no writable value — a common toolkit gap even when the element accepts typed input); focus it with glass_click, then enter text with glass_type / glass_key instead

## Why

A **clean-room usability pass** — a subagent restricted to the MCP tool schemas/errors, forbidden to read glass source — stalled on exactly this error on both X11 (egui text field) and Android (a ToggleButton), recovering only by independently knowing to fall back to click+type. An agent that reads schemas + errors at runtime (the 1.0 stability premise) should get the remedy from the error itself.

## Scope

Message string only (+ its unit-test assertion). No behavior change. `cargo fmt/clippy/test -p glass-core` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)