### PR TITLE
fix(a11y): honest toggle state — AxStates.checkable gates checked/unchecked conditions

### DIFF
--- a/crates/glass-a11y-linux/src/mapping.rs
+++ b/crates/glass-a11y-linux/src/mapping.rs
@@ -116,4 +116,13 @@ mod tests {
         let plain = map_states(&StateSet::empty());
         assert!(!plain.checkable);
     }
+
+    #[test]
+    fn checkable_and_checked_are_independent_fields() {
+        // Checkable but NOT checked — a fixture with checkable != checked catches a
+        // swapped-field bug that `checkable_from_atspi_state`'s checkable+checked-together
+        // fixture cannot.
+        let m = map_states(&StateSet::new(State::Checkable));
+        assert!(m.checkable && !m.checked);
+    }
 }

--- a/crates/glass-a11y-linux/src/mapping.rs
+++ b/crates/glass-a11y-linux/src/mapping.rs
@@ -63,6 +63,7 @@ pub(crate) fn map_states(states: &StateSet) -> AxStates {
         visible: states.contains(State::Showing),
         selected: states.contains(State::Selected),
         checked: states.contains(State::Checked),
+        checkable: states.contains(State::Checkable),
         expanded: states.contains(State::Expanded),
         editable: states.contains(State::Editable),
     }
@@ -105,5 +106,14 @@ mod tests {
         let m = map_states(&StateSet::new(State::Checked | State::Editable));
         assert!(m.checked && m.editable);
         assert!(!m.focused);
+    }
+
+    #[test]
+    fn checkable_from_atspi_state() {
+        let on = StateSet::new(State::Checkable | State::Checked);
+        let m = map_states(&on);
+        assert!(m.checkable && m.checked);
+        let plain = map_states(&StateSet::empty());
+        assert!(!plain.checkable);
     }
 }

--- a/crates/glass-a11y-macos/src/mapping.rs
+++ b/crates/glass-a11y-macos/src/mapping.rs
@@ -138,6 +138,19 @@ mod tests {
     }
 
     #[test]
+    fn checkable_and_checked_are_independent_fields() {
+        // checkable != checked — a fixture like this catches a swapped-field bug that
+        // `checkable_fact_maps_through`'s checkable+checked-together fixture cannot.
+        let f = AxStateFacts {
+            checkable: true,
+            checked: false,
+            ..Default::default()
+        };
+        let s = map_states(&f);
+        assert!(s.checkable && !s.checked);
+    }
+
+    #[test]
     fn visible_and_selected_and_checked_map() {
         let f = AxStateFacts {
             visible: true,

--- a/crates/glass-a11y-macos/src/mapping.rs
+++ b/crates/glass-a11y-macos/src/mapping.rs
@@ -49,6 +49,7 @@ pub struct AxStateFacts {
     pub focusable: bool,
     pub selected: bool,
     pub checked: bool,
+    pub checkable: bool,
     pub expanded: bool,
     pub editable: bool,
     pub visible: bool,
@@ -63,6 +64,7 @@ pub fn map_states(f: &AxStateFacts) -> AxStates {
         visible: f.visible,
         selected: f.selected,
         checked: f.checked,
+        checkable: f.checkable,
         expanded: f.expanded,
         editable: f.editable,
     }
@@ -122,6 +124,17 @@ mod tests {
         assert_eq!(map_role("AXRadioGroup"), AxRole::Group);
         assert_eq!(map_role("AXProgressIndicator"), AxRole::ProgressBar);
         assert_eq!(map_role("AXScrollBar"), AxRole::ScrollBar);
+    }
+
+    #[test]
+    fn checkable_fact_maps_through() {
+        let f = AxStateFacts {
+            checkable: true,
+            checked: true,
+            ..Default::default()
+        };
+        assert!(map_states(&f).checkable && map_states(&f).checked);
+        assert!(!map_states(&AxStateFacts::default()).checkable);
     }
 
     #[test]

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -284,6 +284,7 @@ fn walk(
 
     let ax_role = ffi::attribute_string(el, attr::ROLE).unwrap_or_default();
     let role = mapping::map_role(&ax_role);
+    let states = mapping::map_states(&gather_states(el, &ax_role));
     // `AXRoleDescription` is the human-readable role ("button", "text field"); fall back to the
     // raw AX role string when it's absent. If both are absent (an element exposing neither)
     // `raw_role` is the empty string — a "role unknown" signal, not a guaranteed-populated
@@ -296,7 +297,6 @@ fn walk(
         .or_else(|| ffi::attribute_string(el, attr::DESCRIPTION));
     let value = ffi::attribute_string(el, attr::VALUE);
     let bounds = window_relative_rect(el, scale, win);
-    let states = mapping::map_states(&gather_states(el));
 
     let mut children = Vec::new();
     if depth < MAX_DEPTH && *count < MAX_NODES {
@@ -407,15 +407,19 @@ fn window_relative_rect(el: &AXUIElement, scale: f64, win: &WindowGeometry) -> O
 }
 
 /// Gather the plain state facts `mapping::map_states` normalizes: `AXEnabled`/`AXFocused`
-/// (boolean attributes) and `editable`/`focusable` (whether `AXValue`/`AXFocused` are
-/// writable). The remaining facts stay at their defaults — macOS doesn't expose them as
-/// simple universal attributes, and the reader never over-claims a state it didn't read.
-fn gather_states(el: &AXUIElement) -> AxStateFacts {
+/// (boolean attributes), `editable`/`focusable` (whether `AXValue`/`AXFocused` are
+/// writable), and `checkable` (macOS AX exposes no direct "checkable" attribute, so it's
+/// derived from the toggle role — AppKit checkboxes and switches both surface as
+/// `AXCheckBox`). The remaining facts stay at their defaults — macOS doesn't expose them
+/// as simple universal attributes, and the reader never over-claims a state it didn't
+/// read.
+fn gather_states(el: &AXUIElement, ax_role: &str) -> AxStateFacts {
     AxStateFacts {
         enabled: ffi::attribute_bool(el, attr::ENABLED).unwrap_or(false),
         focused: ffi::attribute_bool(el, attr::FOCUSED).unwrap_or(false),
         focusable: ffi::is_settable(el, attr::FOCUSED),
         editable: ffi::is_settable(el, attr::VALUE),
+        checkable: matches!(ax_role, "AXCheckBox" | "AXRadioButton"),
         ..Default::default()
     }
 }

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -284,7 +284,6 @@ fn walk(
 
     let ax_role = ffi::attribute_string(el, attr::ROLE).unwrap_or_default();
     let role = mapping::map_role(&ax_role);
-    let states = mapping::map_states(&gather_states(el, &ax_role));
     // `AXRoleDescription` is the human-readable role ("button", "text field"); fall back to the
     // raw AX role string when it's absent. If both are absent (an element exposing neither)
     // `raw_role` is the empty string — a "role unknown" signal, not a guaranteed-populated
@@ -297,6 +296,7 @@ fn walk(
         .or_else(|| ffi::attribute_string(el, attr::DESCRIPTION));
     let value = ffi::attribute_string(el, attr::VALUE);
     let bounds = window_relative_rect(el, scale, win);
+    let states = mapping::map_states(&gather_states(el));
 
     let mut children = Vec::new();
     if depth < MAX_DEPTH && *count < MAX_NODES {
@@ -407,19 +407,25 @@ fn window_relative_rect(el: &AXUIElement, scale: f64, win: &WindowGeometry) -> O
 }
 
 /// Gather the plain state facts `mapping::map_states` normalizes: `AXEnabled`/`AXFocused`
-/// (boolean attributes), `editable`/`focusable` (whether `AXValue`/`AXFocused` are
-/// writable), and `checkable` (macOS AX exposes no direct "checkable" attribute, so it's
-/// derived from the toggle role — AppKit checkboxes and switches both surface as
-/// `AXCheckBox`). The remaining facts stay at their defaults — macOS doesn't expose them
-/// as simple universal attributes, and the reader never over-claims a state it didn't
-/// read.
-fn gather_states(el: &AXUIElement, ax_role: &str) -> AxStateFacts {
+/// (boolean attributes) and `editable`/`focusable` (whether `AXValue`/`AXFocused` are
+/// writable). The remaining facts stay at their defaults — macOS doesn't expose them as
+/// simple universal attributes, and the reader never over-claims a state it didn't read.
+fn gather_states(el: &AXUIElement) -> AxStateFacts {
     AxStateFacts {
         enabled: ffi::attribute_bool(el, attr::ENABLED).unwrap_or(false),
         focused: ffi::attribute_bool(el, attr::FOCUSED).unwrap_or(false),
         focusable: ffi::is_settable(el, attr::FOCUSED),
         editable: ffi::is_settable(el, attr::VALUE),
-        checkable: matches!(ax_role, "AXCheckBox" | "AXRadioButton"),
+        // Known limitation: this reader does not yet read the AX checked state (`AXValue`
+        // is 0/1/2 for a checkbox/switch/radio button), so `checkable` stays `false` here
+        // rather than being derived from role alone — a real ON checkbox would otherwise
+        // be reported `checkable` with an unread (always-false) `checked`, mis-rendering
+        // as "unchecked" and satisfying `condition:"unchecked"`. Leaving both at their
+        // default makes the `Checked`/`Unchecked` wait conditions match neither instead,
+        // mirroring the iOS reader's precedent (`crates/glass-ios/src/axmap.rs`).
+        // Follow-up: read `AXValue` to populate `checkable`+`checked` for real (needs
+        // on-device mini verification).
+        checkable: false,
         ..Default::default()
     }
 }

--- a/crates/glass-a11y-windows/src/mapping.rs
+++ b/crates/glass-a11y-windows/src/mapping.rs
@@ -45,7 +45,9 @@ pub fn map_role(control_type_id: u32) -> AxRole {
 
 /// Plain state facts the reader gathers from a UIA element (no `uiautomation` types here,
 /// so this stays unit-testable on Linux). `editable` is the reader's derived
-/// "text control AND not read-only"; `toggled_on` is `TogglePattern.ToggleState == On`.
+/// "text control AND not read-only"; `toggled_on` is `TogglePattern.ToggleState == On`;
+/// `checkable` is Toggle-pattern *availability* — the pattern is present on the element,
+/// independent of whether its current toggle state was actually readable.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct StateFacts {
     pub enabled: bool,
@@ -128,5 +130,18 @@ mod tests {
         };
         assert!(map_states(&f).checkable && map_states(&f).checked);
         assert!(!map_states(&StateFacts::default()).checkable);
+    }
+
+    #[test]
+    fn checkable_and_checked_are_independent_fields() {
+        // checkable != toggled_on — a fixture like this catches a swapped-field bug that
+        // `checkable_from_toggle_pattern_fact`'s checkable+toggled_on-together fixture cannot.
+        let f = StateFacts {
+            checkable: true,
+            toggled_on: false,
+            ..Default::default()
+        };
+        let s = map_states(&f);
+        assert!(s.checkable && !s.checked);
     }
 }

--- a/crates/glass-a11y-windows/src/mapping.rs
+++ b/crates/glass-a11y-windows/src/mapping.rs
@@ -56,6 +56,7 @@ pub struct StateFacts {
     pub toggled_on: bool,
     pub expanded: bool,
     pub editable: bool,
+    pub checkable: bool,
 }
 
 /// Map gathered facts to the normalized `AxStates`.
@@ -67,6 +68,7 @@ pub fn map_states(f: &StateFacts) -> AxStates {
         visible: !f.offscreen,
         selected: f.selected,
         checked: f.toggled_on,
+        checkable: f.checkable,
         expanded: f.expanded,
         editable: f.editable,
     }
@@ -116,5 +118,15 @@ mod tests {
         let s = map_states(&f);
         assert!(s.focused && s.focusable && s.editable);
         assert!(!s.selected && !s.checked);
+    }
+    #[test]
+    fn checkable_from_toggle_pattern_fact() {
+        let f = StateFacts {
+            checkable: true,
+            toggled_on: true,
+            ..Default::default()
+        };
+        assert!(map_states(&f).checkable && map_states(&f).checked);
+        assert!(!map_states(&StateFacts::default()).checkable);
     }
 }

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -169,10 +169,16 @@ fn walk(
 /// so we don't make a live cross-process `get_pattern` call for a pattern the control can't support
 /// (UIA is chatty — each probe is an out-of-process COM round-trip).
 fn gather(el: &UIElement, ct_id: u32) -> (crate::mapping::StateFacts, Option<String>) {
-    let toggled_on = matches!(ct_id, 50000 | 50002 | 50011 | 50031) // Button/CheckBox/MenuItem/SplitButton
-        && el.get_pattern::<UITogglePattern>().ok()
-            .and_then(|p| p.get_toggle_state().ok())
-            .map(|s| s == ToggleState::On).unwrap_or(false);
+    // Fetch the Toggle pattern once: its mere presence is `checkable` (the control exposes
+    // on/off semantics at all), independent of whether we can also read its current state.
+    let toggle_pattern = matches!(ct_id, 50000 | 50002 | 50011 | 50031) // Button/CheckBox/MenuItem/SplitButton
+        .then(|| el.get_pattern::<UITogglePattern>().ok())
+        .flatten();
+    let checkable = toggle_pattern.is_some();
+    let toggled_on = toggle_pattern
+        .and_then(|p| p.get_toggle_state().ok())
+        .map(|s| s == ToggleState::On)
+        .unwrap_or(false);
     let selected = matches!(ct_id, 50007 | 50019 | 50024 | 50029) // ListItem/TabItem/TreeItem/DataItem
         && el.get_pattern::<UISelectionItemPattern>().ok()
             .and_then(|p| p.is_selected().ok()).unwrap_or(false);
@@ -205,6 +211,7 @@ fn gather(el: &UIElement, ct_id: u32) -> (crate::mapping::StateFacts, Option<Str
         toggled_on,
         expanded,
         editable,
+        checkable,
     };
     (facts, value)
 }

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -71,6 +71,9 @@ fn json_to_node(v: &Value, win: &WindowGeometry) -> Result<AxNode> {
             // Android "focusable" is keyboard-only; map isClickable -> focusable as the actability proxy.
             focusable: flag("clickable"),
             visible: true,
+            // Known limitation: the device `tree` JSON protocol does not yet carry
+            // `checkable`/`checked`, so both stay at their `AxStates::default()` (false)
+            // here — mirrors the iOS reader's precedent (`crates/glass-ios/src/axmap.rs`).
             ..Default::default()
         },
         bounds: Some(AxRect {

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -118,7 +118,12 @@ fn map_node(node: roxmltree::Node, window: &WindowGeometry) -> AxNode {
         visible: true,
         selected: boolean("selected"),
         checked: boolean("checked"),
-        checkable: boolean("checkable"),
+        // OR in `checked`: uiautomator on a Compose toggle can under-report
+        // `checkable="false"` while `checked="true"` (see
+        // `checkable_reflects_the_uiautomator_attribute`). OR-ing keeps a `checked="true"`
+        // reading trustworthy (its `Checked` wait condition still matches) while a plain
+        // non-toggle (`checkable="false" checked="false"`) still matches neither.
+        checkable: boolean("checkable") || boolean("checked"),
         expanded: false,
         editable,
     };
@@ -248,7 +253,8 @@ mod tests {
 
     #[test]
     fn checkable_reflects_the_uiautomator_attribute() {
-        // A Switch reported NOT checkable (Compose gap) vs a real checkable Switch.
+        // A Switch reported NOT checkable (Compose gap) vs a real checkable Switch vs a
+        // Compose-ON switch that under-reports checkable="false" while checked="true".
         let xml = concat!(
             "<?xml version='1.0'?><hierarchy rotation=\"0\">",
             "<node index=\"0\" text=\"\" class=\"android.widget.Switch\" content-desc=\"NotReal\" ",
@@ -257,6 +263,9 @@ mod tests {
             "<node index=\"1\" text=\"\" class=\"android.widget.Switch\" content-desc=\"RealOn\" ",
             "enabled=\"true\" focusable=\"true\" focused=\"false\" selected=\"false\" ",
             "checkable=\"true\" checked=\"true\" password=\"false\" bounds=\"[0,60][100,110]\" />",
+            "<node index=\"2\" text=\"\" class=\"android.widget.Switch\" content-desc=\"ComposeOn\" ",
+            "enabled=\"true\" focusable=\"true\" focused=\"false\" selected=\"false\" ",
+            "checkable=\"false\" checked=\"true\" password=\"false\" bounds=\"[0,120][100,170]\" />",
             "</hierarchy>",
         );
         let w = WindowGeometry {
@@ -268,6 +277,7 @@ mod tests {
         let tree = build_tree(xml, &w).unwrap();
         let not_real = &tree.root.children[0];
         let real_on = &tree.root.children[1];
+        let compose_on = &tree.root.children[2];
         assert!(
             !not_real.states.checkable,
             "checkable=false attr must map to checkable=false"
@@ -275,6 +285,11 @@ mod tests {
         assert!(
             real_on.states.checkable && real_on.states.checked,
             "real Switch → checkable+checked"
+        );
+        assert!(
+            compose_on.states.checkable && compose_on.states.checked,
+            "checkable=false checked=true (Compose under-report) must still map to \
+             checkable=true so the Checked condition matches"
         );
     }
 }

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -118,6 +118,7 @@ fn map_node(node: roxmltree::Node, window: &WindowGeometry) -> AxNode {
         visible: true,
         selected: boolean("selected"),
         checked: boolean("checked"),
+        checkable: boolean("checkable"),
         expanded: false,
         editable,
     };
@@ -243,5 +244,37 @@ mod tests {
             build_tree("<other/>", &win()),
             Err(GlassError::AccessibilityUnavailable(_))
         ));
+    }
+
+    #[test]
+    fn checkable_reflects_the_uiautomator_attribute() {
+        // A Switch reported NOT checkable (Compose gap) vs a real checkable Switch.
+        let xml = concat!(
+            "<?xml version='1.0'?><hierarchy rotation=\"0\">",
+            "<node index=\"0\" text=\"\" class=\"android.widget.Switch\" content-desc=\"NotReal\" ",
+            "enabled=\"true\" focusable=\"true\" focused=\"false\" selected=\"false\" ",
+            "checkable=\"false\" checked=\"false\" password=\"false\" bounds=\"[0,0][100,50]\" />",
+            "<node index=\"1\" text=\"\" class=\"android.widget.Switch\" content-desc=\"RealOn\" ",
+            "enabled=\"true\" focusable=\"true\" focused=\"false\" selected=\"false\" ",
+            "checkable=\"true\" checked=\"true\" password=\"false\" bounds=\"[0,60][100,110]\" />",
+            "</hierarchy>",
+        );
+        let w = WindowGeometry {
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 200,
+        };
+        let tree = build_tree(xml, &w).unwrap();
+        let not_real = &tree.root.children[0];
+        let real_on = &tree.root.children[1];
+        assert!(
+            !not_real.states.checkable,
+            "checkable=false attr must map to checkable=false"
+        );
+        assert!(
+            real_on.states.checkable && real_on.states.checked,
+            "real Switch → checkable+checked"
+        );
     }
 }

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -130,6 +130,8 @@ pub struct AxStates {
     pub visible: bool,
     pub selected: bool,
     pub checked: bool,
+    /// The element exposes a real toggle state (`checked` is only meaningful when this is true).
+    pub checkable: bool,
     pub expanded: bool,
     pub editable: bool,
 }
@@ -153,8 +155,8 @@ impl AxStates {
         if self.selected {
             v.push("selected");
         }
-        if self.checked {
-            v.push("checked");
+        if self.checkable {
+            v.push(if self.checked { "checked" } else { "unchecked" });
         }
         if self.expanded {
             v.push("expanded");
@@ -421,8 +423,8 @@ impl ElementCondition {
             Appears | Disappears => |_| true,
             Enabled => |s| s.enabled,
             Disabled => |s| !s.enabled,
-            Checked => |s| s.checked,
-            Unchecked => |s| !s.checked,
+            Checked => |s| s.checkable && s.checked,
+            Unchecked => |s| s.checkable && !s.checked,
             Selected => |s| s.selected,
             Unselected => |s| !s.selected,
             Expanded => |s| s.expanded,
@@ -704,6 +706,7 @@ mod tests {
             focusable: true,
             enabled: true,
             checked: true,
+            checkable: true,
             ..Default::default()
         };
         assert_eq!(s.active(), vec!["focusable", "enabled", "checked"]);
@@ -1031,5 +1034,55 @@ mod tests {
             ),
             ElementMatch::Pending
         ));
+    }
+
+    #[test]
+    fn checked_conditions_require_checkable() {
+        let non_toggle = AxStates {
+            checkable: false,
+            checked: false,
+            ..Default::default()
+        };
+        let off = AxStates {
+            checkable: true,
+            checked: false,
+            ..Default::default()
+        };
+        let on = AxStates {
+            checkable: true,
+            checked: true,
+            ..Default::default()
+        };
+        let pred = |c: ElementCondition| c.state_pred();
+        // non-checkable matches NEITHER (the fix)
+        assert!(!(pred(ElementCondition::Unchecked))(&non_toggle));
+        assert!(!(pred(ElementCondition::Checked))(&non_toggle));
+        // real toggle matches per its checked state
+        assert!((pred(ElementCondition::Unchecked))(&off));
+        assert!(!(pred(ElementCondition::Checked))(&off));
+        assert!((pred(ElementCondition::Checked))(&on));
+        assert!(!(pred(ElementCondition::Unchecked))(&on));
+    }
+
+    #[test]
+    fn active_renders_toggle_state_only_when_checkable() {
+        let on = AxStates {
+            checkable: true,
+            checked: true,
+            ..Default::default()
+        };
+        let off = AxStates {
+            checkable: true,
+            checked: false,
+            ..Default::default()
+        };
+        let plain = AxStates {
+            checkable: false,
+            checked: false,
+            ..Default::default()
+        };
+        assert!(on.active().contains(&"checked"));
+        assert!(off.active().contains(&"unchecked"));
+        assert!(!plain.active().contains(&"checked") && !plain.active().contains(&"unchecked"));
     }
 }

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -1053,6 +1053,14 @@ mod tests {
             checked: true,
             ..Default::default()
         };
+        // The asymmetric case: a backend that (incorrectly) reports `checked:true` without
+        // `checkable:true` — this is what distinguishes the gated `s.checkable && s.checked`
+        // arm from an ungated `s.checked` arm, which would wrongly satisfy `Checked` here.
+        let checked_but_not_checkable = AxStates {
+            checkable: false,
+            checked: true,
+            ..Default::default()
+        };
         let pred = |c: ElementCondition| c.state_pred();
         // non-checkable matches NEITHER (the fix)
         assert!(!(pred(ElementCondition::Unchecked))(&non_toggle));
@@ -1062,6 +1070,14 @@ mod tests {
         assert!(!(pred(ElementCondition::Checked))(&off));
         assert!((pred(ElementCondition::Checked))(&on));
         assert!(!(pred(ElementCondition::Unchecked))(&on));
+        // checked:true with checkable:false still matches NEITHER — checked alone is not
+        // enough without checkable.
+        assert!(!(pred(ElementCondition::Checked))(
+            &checked_but_not_checkable
+        ));
+        assert!(!(pred(ElementCondition::Unchecked))(
+            &checked_but_not_checkable
+        ));
     }
 
     #[test]
@@ -1081,8 +1097,20 @@ mod tests {
             checked: false,
             ..Default::default()
         };
+        // The asymmetric case: `checked:true` without `checkable:true` — distinguishes
+        // `active()`'s `if self.checkable { push checked/unchecked }` gating from a
+        // hypothetical ungated version that renders off `self.checked` alone.
+        let checked_but_not_checkable = AxStates {
+            checkable: false,
+            checked: true,
+            ..Default::default()
+        };
         assert!(on.active().contains(&"checked"));
         assert!(off.active().contains(&"unchecked"));
         assert!(!plain.active().contains(&"checked") && !plain.active().contains(&"unchecked"));
+        assert!(
+            !checked_but_not_checkable.active().contains(&"checked")
+                && !checked_but_not_checkable.active().contains(&"unchecked")
+        );
     }
 }

--- a/crates/glass-ios/src/axmap.rs
+++ b/crates/glass-ios/src/axmap.rs
@@ -156,6 +156,10 @@ fn map_node(n: &Value, scale: f64) -> AxNode {
         // is always false here (a known limitation of this backend).
         focused: false,
         editable,
+        // idb's accessibility_info exposes no checked/checkable trait, so iOS toggles
+        // are out of scope here (a known limitation of this backend); `checked` stays
+        // at its `AxStates::default()` value below alongside it.
+        checkable: false,
         ..AxStates::default()
     };
     let bounds = n.get("frame").and_then(|f| frame_to_rect(f, scale));

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -243,6 +243,8 @@ pub struct WaitForElementArgs {
     pub role: Option<String>,
     /// What to wait for (default "appears"): appears|disappears|enabled|disabled|
     /// checked|unchecked|selected|unselected|expanded|collapsed|focused|visible|hidden.
+    /// `checked`/`unchecked` only match a checkable element (one exposing a real toggle
+    /// state) — a non-toggle element matches neither.
     pub condition: Option<String>,
     /// Additionally require the matched element's `value` to contain this substring.
     /// Not a standalone selector — `name` and/or `role` is still required.


### PR DESCRIPTION
## What

Adds `AxStates.checkable` and gates the accessibility toggle conditions on it:
- `wait_for_element condition:"checked"` → `checkable && checked`; `"unchecked"` → `checkable && !checked`. A **non-checkable element now matches neither** — an honest "not a readable toggle" instead of a false "it's off."
- The a11y outline renders `checked`/`unchecked` **only** for checkable elements (toggle state now visible in the snapshot; non-toggles show neither).
- `checkable` is populated per backend from its native signal: Android `checkable` XML attr **OR** `checked` (a `checked=true` Compose toggle is never gated invisible), AT-SPI `State::Checkable`, UIA Toggle-pattern availability. macOS/iOS set `checkable=false` for now (see Known limitations).

## Why

A **clean-room usability pass** (an agent restricted to the MCP tool surface, forbidden to read glass source) found `wait_for_element condition:"unchecked"` returning a false positive on an Android Settings "Dark theme" row that was visually ON: glass read uiautomator's `checked` but ignored `checkable`, and per the AccessibilityNodeInfo contract `checked` is only meaningful when `checkable` is true.

## Known limitations (documented in-code, deferred follow-ups)

- **macOS** does not yet read the AX checked state (AXValue); `checkable=false` there so toggle conditions match neither rather than mis-report (mirrors iOS). Follow-up: wire AXValue `checked` + role-derived `checkable`.
- **iOS** (idb) and the **Android on-device AccessibilityService companion** JSON expose no checkable/checked trait — known-limitation comments added; the companion follow-up lives in `glass-android-agent`.

## Review

Built brainstorm→spec→plan→TDD (6 tasks, per-task reviewed), then a whole-branch **pr-review-toolkit 5-lens** pass — which caught two real regressions the per-task (single-diff) reviews couldn't see (macOS over-claiming `checkable` while never reading `checked`; an Android false-negative on a `checked=true` Compose toggle) plus tautological test fixtures. All fixed and re-verified. `cargo test --workspace --locked`, `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, and both `x86_64-pc-windows-gnu` / `x86_64-apple-darwin` cross-target clippy runs are green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)