### PR TITLE
a11y: report toggle state on macOS + iOS, and fix the iOS switch tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+### Added
+- **macOS and iOS accessibility now report toggle state.** A checkbox, radio button, or switch read
+  via `glass_a11y_snapshot` / `glass_wait_for_element` now carries its `checkable`/`checked` state on
+  the macOS and iOS backends (previously only Linux, Windows, and Android did), so
+  `glass_wait_for_element {condition: "checked"}` (or `"unchecked"`) works against those controls.
+  State is reported only when it can be read for certain — an indeterminate or unreadable control
+  matches neither condition rather than being misreported.
+
+### Fixed
+- **`glass_click_element` now reliably toggles an iOS switch.** iOS reports a switch's frame as its
+  whole table row, so a click aimed at the geometric center landed on the inert label and did nothing;
+  the click now targets the trailing control.
+
 ### Changed
 - **Every tool now returns a uniform result envelope.** On success, a tool's leading text block is
   `{"ok": true, "tool": "<name>", "result": { … }}`, with the tool-specific fields under `result`.

--- a/crates/glass-a11y-macos/src/ffi.rs
+++ b/crates/glass-a11y-macos/src/ffi.rs
@@ -171,10 +171,11 @@ pub(crate) fn attribute_bool(el: &AXUIElement, attr_name: &str) -> Option<bool> 
     value.downcast_ref::<CFBoolean>().map(CFBoolean::as_bool)
 }
 
-/// Read `el`'s `attr_name` as an `i64` (`CFNumber`), or `None` when the attribute is absent or
-/// isn't a number. A checkbox/radio/switch exposes `AXValue` as a `CFNumber` (0/1/2), which
-/// `attribute_string`/`attribute_bool` cannot read — this is how the reader learns the checked
-/// state. Absence collapses to `None` (via `copy_attribute(...).ok()`), like the siblings.
+/// Read `el`'s `attr_name` as an `i64` (`CFNumber`), or `None` when the attribute is absent,
+/// isn't a `CFNumber`, or holds a value that doesn't fit an `i64`. A checkbox/radio/switch
+/// exposes `AXValue` as a `CFNumber` (`0`/`1` for off/on), which `attribute_string`/
+/// `attribute_bool` cannot read — this is how the reader learns the checked state. Absence
+/// collapses to `None` (via `copy_attribute(...).ok()`), like the siblings.
 pub(crate) fn attribute_i64(el: &AXUIElement, attr_name: &str) -> Option<i64> {
     let value = copy_attribute(el, attr_name).ok()?;
     let num = value.downcast_ref::<CFNumber>()?;

--- a/crates/glass-a11y-macos/src/ffi.rs
+++ b/crates/glass-a11y-macos/src/ffi.rs
@@ -29,7 +29,9 @@
 use std::ptr::NonNull;
 
 use objc2_application_services::{AXError, AXUIElement, AXValue, AXValueType};
-use objc2_core_foundation::{CFArray, CFBoolean, CFRetained, CFString, CFType, CGPoint, CGSize};
+use objc2_core_foundation::{
+    CFArray, CFBoolean, CFNumber, CFNumberType, CFRetained, CFString, CFType, CGPoint, CGSize,
+};
 
 use glass_core::{GlassError, Result};
 
@@ -167,6 +169,23 @@ pub(crate) fn attribute_string_checked(
 pub(crate) fn attribute_bool(el: &AXUIElement, attr_name: &str) -> Option<bool> {
     let value = copy_attribute(el, attr_name).ok()?;
     value.downcast_ref::<CFBoolean>().map(CFBoolean::as_bool)
+}
+
+/// Read `el`'s `attr_name` as an `i64` (`CFNumber`), or `None` when the attribute is absent or
+/// isn't a number. A checkbox/radio/switch exposes `AXValue` as a `CFNumber` (0/1/2), which
+/// `attribute_string`/`attribute_bool` cannot read — this is how the reader learns the checked
+/// state. Absence collapses to `None` (via `copy_attribute(...).ok()`), like the siblings.
+pub(crate) fn attribute_i64(el: &AXUIElement, attr_name: &str) -> Option<i64> {
+    let value = copy_attribute(el, attr_name).ok()?;
+    let num = value.downcast_ref::<CFNumber>()?;
+    let mut out: i64 = 0;
+    // SAFETY: `num` was downcast-verified to be a real `CFNumber`; `out` is a valid, correctly
+    // sized `i64` slot matching the requested `SInt64Type`. `CFNumberGetValue` writes at most 8
+    // bytes into `out` and returns false (→ `None`) when the stored value isn't exactly
+    // representable as an `i64` — the same out-param idiom `ax_position`/`ax_size` use for
+    // `AXValue`.
+    let ok = unsafe { num.value(CFNumberType::SInt64Type, (&mut out as *mut i64).cast()) };
+    ok.then_some(out)
 }
 
 /// Whether `attr_name` is writable on `el` (`AXUIElement::is_attribute_settable`). `false`

--- a/crates/glass-a11y-macos/src/mapping.rs
+++ b/crates/glass-a11y-macos/src/mapping.rs
@@ -70,11 +70,13 @@ pub fn map_states(f: &AxStateFacts) -> AxStates {
     }
 }
 
-/// macOS `(checkable, checked)` from the normalized role and its `AXValue` as an integer
-/// (a checkbox/radio/switch exposes `AXValue` 0=off, 1=on, 2=mixed). Claims `checkable` ONLY
-/// for a determinate on/off value (the #170 invariant); mixed (2), an unexpected value, or an
-/// unread value (`None`) → `(false, false)` so a mixed box never matches `condition:"unchecked"`.
-/// A macOS `NSSwitch` reports role `AXCheckBox`, so `CheckBox` already covers switches.
+/// macOS `(checkable, checked)` from the normalized role and its `AXValue` as an integer. A
+/// checkbox/radio/switch exposes `AXValue` as `0` (off) or `1` (on); a mixed/indeterminate
+/// checkbox reports some other value (AppKit's mixed state is not `0`/`1` — its exact AX
+/// encoding, `2`/`-1`/…, is deliberately not relied on here). Claims `checkable` ONLY for a
+/// determinate `0`/`1` (the #170 invariant); every other value, and an unread `None`, →
+/// `(false, false)`, so a mixed or unreadable box matches neither `condition:"checked"` nor
+/// `"unchecked"`. A macOS `NSSwitch` reports role `AXCheckBox`, so `CheckBox` covers switches.
 pub fn checkable_checked(role: AxRole, ax_value: Option<i64>) -> (bool, bool) {
     match role {
         AxRole::CheckBox | AxRole::RadioButton => match ax_value {
@@ -186,9 +188,12 @@ mod tests {
         assert_eq!(checkable_checked(CheckBox, Some(1)), (true, true));
         assert_eq!(checkable_checked(CheckBox, Some(0)), (true, false));
         assert_eq!(checkable_checked(RadioButton, Some(1)), (true, true));
-        // Mixed (2), unexpected, unread, or a non-checkable role → neither (the #170 invariant):
-        // a mixed checkbox must not match `condition:"unchecked"`.
+        assert_eq!(checkable_checked(RadioButton, Some(0)), (true, false));
+        // A mixed/indeterminate value (whatever AppKit's AX encoding — 2, -1, …), an unread
+        // value, or a non-checkable role → neither (the #170 invariant): a mixed or unreadable
+        // box must not match `condition:"unchecked"`.
         assert_eq!(checkable_checked(CheckBox, Some(2)), (false, false));
+        assert_eq!(checkable_checked(CheckBox, Some(-1)), (false, false));
         assert_eq!(checkable_checked(CheckBox, None), (false, false));
         assert_eq!(checkable_checked(Button, Some(1)), (false, false));
         assert_eq!(checkable_checked(Slider, Some(1)), (false, false));

--- a/crates/glass-a11y-macos/src/mapping.rs
+++ b/crates/glass-a11y-macos/src/mapping.rs
@@ -70,6 +70,22 @@ pub fn map_states(f: &AxStateFacts) -> AxStates {
     }
 }
 
+/// macOS `(checkable, checked)` from the normalized role and its `AXValue` as an integer
+/// (a checkbox/radio/switch exposes `AXValue` 0=off, 1=on, 2=mixed). Claims `checkable` ONLY
+/// for a determinate on/off value (the #170 invariant); mixed (2), an unexpected value, or an
+/// unread value (`None`) → `(false, false)` so a mixed box never matches `condition:"unchecked"`.
+/// A macOS `NSSwitch` reports role `AXCheckBox`, so `CheckBox` already covers switches.
+pub fn checkable_checked(role: AxRole, ax_value: Option<i64>) -> (bool, bool) {
+    match role {
+        AxRole::CheckBox | AxRole::RadioButton => match ax_value {
+            Some(1) => (true, true),
+            Some(0) => (true, false),
+            _ => (false, false),
+        },
+        _ => (false, false),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -162,5 +178,19 @@ mod tests {
         let s = map_states(&f);
         assert!(s.visible && s.selected && s.checked && s.expanded);
         assert!(!s.enabled && !s.focused && !s.focusable && !s.editable);
+    }
+
+    #[test]
+    fn macos_checkable_checked_only_claims_a_determinate_toggle() {
+        use AxRole::*;
+        assert_eq!(checkable_checked(CheckBox, Some(1)), (true, true));
+        assert_eq!(checkable_checked(CheckBox, Some(0)), (true, false));
+        assert_eq!(checkable_checked(RadioButton, Some(1)), (true, true));
+        // Mixed (2), unexpected, unread, or a non-checkable role → neither (the #170 invariant):
+        // a mixed checkbox must not match `condition:"unchecked"`.
+        assert_eq!(checkable_checked(CheckBox, Some(2)), (false, false));
+        assert_eq!(checkable_checked(CheckBox, None), (false, false));
+        assert_eq!(checkable_checked(Button, Some(1)), (false, false));
+        assert_eq!(checkable_checked(Slider, Some(1)), (false, false));
     }
 }

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -415,8 +415,15 @@ fn window_relative_rect(el: &AXUIElement, scale: f64, win: &WindowGeometry) -> O
 /// expose them as simple universal attributes, and the reader never over-claims a state it
 /// didn't read.
 fn gather_states(el: &AXUIElement, role: AxRole) -> AxStateFacts {
-    let (checkable, checked) =
-        mapping::checkable_checked(role, ffi::attribute_i64(el, attr::VALUE));
+    // Only a checkbox/radio/switch carries a checked state, so read the numeric `AXValue` (an
+    // extra AX IPC round-trip) only for those roles — every other node skips it. `map_role`
+    // maps an `NSSwitch` to `CheckBox`, so switches are covered.
+    let (checkable, checked) = match role {
+        AxRole::CheckBox | AxRole::RadioButton => {
+            mapping::checkable_checked(role, ffi::attribute_i64(el, attr::VALUE))
+        }
+        _ => (false, false),
+    };
     AxStateFacts {
         enabled: ffi::attribute_bool(el, attr::ENABLED).unwrap_or(false),
         focused: ffi::attribute_bool(el, attr::FOCUSED).unwrap_or(false),

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -19,7 +19,8 @@ use std::time::{Duration, Instant};
 use glass_core::coords::pixel_geometry_from_content_rect;
 use glass_core::platform::WindowGeometry;
 use glass_core::{
-    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget, AxTree, GlassError, Result,
+    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxTarget, AxTree, GlassError,
+    Result,
 };
 use objc2_application_services::AXUIElement;
 use objc2_core_foundation::CFRetained;
@@ -296,7 +297,7 @@ fn walk(
         .or_else(|| ffi::attribute_string(el, attr::DESCRIPTION));
     let value = ffi::attribute_string(el, attr::VALUE);
     let bounds = window_relative_rect(el, scale, win);
-    let states = mapping::map_states(&gather_states(el));
+    let states = mapping::map_states(&gather_states(el, role));
 
     let mut children = Vec::new();
     if depth < MAX_DEPTH && *count < MAX_NODES {
@@ -407,25 +408,22 @@ fn window_relative_rect(el: &AXUIElement, scale: f64, win: &WindowGeometry) -> O
 }
 
 /// Gather the plain state facts `mapping::map_states` normalizes: `AXEnabled`/`AXFocused`
-/// (boolean attributes) and `editable`/`focusable` (whether `AXValue`/`AXFocused` are
-/// writable). The remaining facts stay at their defaults — macOS doesn't expose them as
-/// simple universal attributes, and the reader never over-claims a state it didn't read.
-fn gather_states(el: &AXUIElement) -> AxStateFacts {
+/// (boolean attributes), `editable`/`focusable` (whether `AXValue`/`AXFocused` are writable),
+/// and — for a checkbox/radio/switch — `checkable`/`checked` derived from `AXValue`
+/// (`mapping::checkable_checked`; a determinate 0/1 only, per the #170 invariant, so a mixed or
+/// unreadable value claims neither). The remaining facts stay at their defaults — macOS doesn't
+/// expose them as simple universal attributes, and the reader never over-claims a state it
+/// didn't read.
+fn gather_states(el: &AXUIElement, role: AxRole) -> AxStateFacts {
+    let (checkable, checked) =
+        mapping::checkable_checked(role, ffi::attribute_i64(el, attr::VALUE));
     AxStateFacts {
         enabled: ffi::attribute_bool(el, attr::ENABLED).unwrap_or(false),
         focused: ffi::attribute_bool(el, attr::FOCUSED).unwrap_or(false),
         focusable: ffi::is_settable(el, attr::FOCUSED),
         editable: ffi::is_settable(el, attr::VALUE),
-        // Known limitation: this reader does not yet read the AX checked state (`AXValue`
-        // is 0/1/2 for a checkbox/switch/radio button), so `checkable` stays `false` here
-        // rather than being derived from role alone — a real ON checkbox would otherwise
-        // be reported `checkable` with an unread (always-false) `checked`, mis-rendering
-        // as "unchecked" and satisfying `condition:"unchecked"`. Leaving both at their
-        // default makes the `Checked`/`Unchecked` wait conditions match neither instead,
-        // mirroring the iOS reader's precedent (`crates/glass-ios/src/axmap.rs`).
-        // Follow-up: read `AXValue` to populate `checkable`+`checked` for real (needs
-        // on-device mini verification).
-        checkable: false,
+        checkable,
+        checked,
         ..Default::default()
     }
 }

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -203,6 +203,31 @@ impl AxRect {
         }
         Some(((left + right) / 2, (top + bottom) / 2))
     }
+
+    /// Actuation point for a **row-shaped checkable** element. A backend (iOS/idb) can report
+    /// a table-cell switch's frame as the whole row, whose control sits at the trailing edge;
+    /// the geometric [`Self::clamped_center`] then lands on the label and a tap no-ops. This
+    /// aims near the trailing control: `x = right_edge - inset`, floored at the horizontal
+    /// center so it never crosses back past the middle; `y` = vertical center. The inset tracks
+    /// the visible height (a switch's width ≈ its row height), which is scale-independent.
+    /// Clamped to the window's visible intersection exactly like `clamped_center`, with the
+    /// same zero-area / fully-offscreen `None`.
+    pub fn clamped_trailing_point(&self, win_w: u32, win_h: u32) -> Option<(i32, i32)> {
+        if self.width == 0 || self.height == 0 || win_w == 0 || win_h == 0 {
+            return None;
+        }
+        let left = self.x.max(0);
+        let top = self.y.max(0);
+        let right = (self.x + self.width as i32).min(win_w as i32);
+        let bottom = (self.y + self.height as i32).min(win_h as i32);
+        if right <= left || bottom <= top {
+            return None;
+        }
+        let center_x = (left + right) / 2;
+        let inset = bottom - top; // visible height; the control is ~this far from the edge
+        let x = (right - inset).max(center_x);
+        Some((x, (top + bottom) / 2))
+    }
 }
 
 /// A synthetic node id, assigned by `glass-core` (not the backend) in pre-order
@@ -698,6 +723,50 @@ mod tests {
             .clamped_center(0, 10),
             None
         );
+    }
+
+    #[test]
+    fn clamped_trailing_point_targets_the_trailing_control() {
+        // A row-shaped element (idb's whole-cell switch frame): the trailing point sits
+        // right of center, near the right edge — not the geometric center.
+        let r = AxRect {
+            x: 0,
+            y: 0,
+            width: 300,
+            height: 30,
+        };
+        let (x, y) = r.clamped_trailing_point(400, 400).expect("has a point");
+        let (cx, _) = r.clamped_center(400, 400).unwrap();
+        assert!(x > cx, "trailing point is right of center ({x} !> {cx})");
+        assert!(
+            (270..300).contains(&x),
+            "near the right edge, inset ~= height"
+        );
+        assert_eq!(y, 15, "vertical center");
+    }
+
+    #[test]
+    fn clamped_trailing_point_never_crosses_left_of_center() {
+        // A near-square element: right - height would fall left of center, so it floors at center.
+        let r = AxRect {
+            x: 0,
+            y: 0,
+            width: 30,
+            height: 30,
+        };
+        let (x, _) = r.clamped_trailing_point(400, 400).unwrap();
+        assert_eq!(x, r.clamped_center(400, 400).unwrap().0);
+    }
+
+    #[test]
+    fn clamped_trailing_point_rejects_offscreen_like_clamped_center() {
+        let r = AxRect {
+            x: 500,
+            y: 500,
+            width: 40,
+            height: 20,
+        };
+        assert_eq!(r.clamped_trailing_point(400, 400), None);
     }
 
     #[test]

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -180,27 +180,30 @@ pub struct AxRect {
 }
 
 impl AxRect {
-    /// The click point for this element: the center of its intersection with the window,
-    /// always inside `[0,win_w) × [0,win_h)`. Returns `None` when there is nothing to click —
-    /// the rect or window has zero area, or the element has no visible overlap with the window
-    /// (fully clipped off-screen) — so the caller surfaces a not-clickable error instead of a
-    /// click on the window edge that never lands on the element.
-    pub fn clamped_center(&self, win_w: u32, win_h: u32) -> Option<(i32, i32)> {
+    /// The element's visible intersection with `[0,win_w) × [0,win_h)`, as
+    /// `(left, top, right, bottom)`. `None` when the rect or window has zero area, or the element
+    /// has no visible overlap with the window (fully clipped off-screen). Every actuation point
+    /// below derives from this one clip so their intersection semantics can't drift: a
+    /// partially-clipped element is still acted on within its own visible portion, and a
+    /// fully-clipped one returns `None` — surfaced as a not-clickable error rather than a silent
+    /// click on the window edge that never lands on the element (the "no silent fallbacks"
+    /// invariant).
+    fn visible_intersection(&self, win_w: u32, win_h: u32) -> Option<(i32, i32, i32, i32)> {
         if self.width == 0 || self.height == 0 || win_w == 0 || win_h == 0 {
             return None;
         }
-        // Click the center of the element's *intersection* with the window — the visible
-        // portion — not the raw center clamped to the window edge. A partially-clipped element
-        // is then still clicked on itself, and a fully-clipped element (no overlap) returns
-        // `None`, surfaced as a not-clickable error rather than a silent click on the window
-        // edge that never lands on the element (the "no silent fallbacks" invariant).
         let left = self.x.max(0);
         let top = self.y.max(0);
         let right = (self.x + self.width as i32).min(win_w as i32);
         let bottom = (self.y + self.height as i32).min(win_h as i32);
-        if right <= left || bottom <= top {
-            return None;
-        }
+        (right > left && bottom > top).then_some((left, top, right, bottom))
+    }
+
+    /// The click point for this element: the center of its visible intersection with the window,
+    /// always inside `[0,win_w) × [0,win_h)`. `None` when there is nothing to click (see
+    /// [`Self::visible_intersection`]).
+    pub fn clamped_center(&self, win_w: u32, win_h: u32) -> Option<(i32, i32)> {
+        let (left, top, right, bottom) = self.visible_intersection(win_w, win_h)?;
         Some(((left + right) / 2, (top + bottom) / 2))
     }
 
@@ -208,21 +211,12 @@ impl AxRect {
     /// a table-cell switch's frame as the whole row, whose control sits at the trailing edge;
     /// the geometric [`Self::clamped_center`] then lands on the label and a tap no-ops. This
     /// aims near the trailing control: `x = right_edge - inset`, floored at the horizontal
-    /// center so it never crosses back past the middle; `y` = vertical center. The inset tracks
-    /// the visible height (a switch's width ≈ its row height), which is scale-independent.
-    /// Clamped to the window's visible intersection exactly like `clamped_center`, with the
-    /// same zero-area / fully-offscreen `None`.
+    /// center so it never crosses back past the middle; `y` = vertical center. The inset is the
+    /// visible height rather than a fixed pixel amount, so it scales with the control at any
+    /// device scale (a switch's width ≈ its row height). Shares [`Self::visible_intersection`]
+    /// with `clamped_center`, so the clip / zero-area / fully-offscreen `None` are identical.
     pub fn clamped_trailing_point(&self, win_w: u32, win_h: u32) -> Option<(i32, i32)> {
-        if self.width == 0 || self.height == 0 || win_w == 0 || win_h == 0 {
-            return None;
-        }
-        let left = self.x.max(0);
-        let top = self.y.max(0);
-        let right = (self.x + self.width as i32).min(win_w as i32);
-        let bottom = (self.y + self.height as i32).min(win_h as i32);
-        if right <= left || bottom <= top {
-            return None;
-        }
+        let (left, top, right, bottom) = self.visible_intersection(win_w, win_h)?;
         let center_x = (left + right) / 2;
         let inset = bottom - top; // visible height; the control is ~this far from the edge
         let x = (right - inset).max(center_x);

--- a/crates/glass-core/src/platform.rs
+++ b/crates/glass-core/src/platform.rs
@@ -254,6 +254,18 @@ pub trait Platform {
     fn active_window_handle(&self) -> Option<i64> {
         None
     }
+
+    /// Whether this backend reports a checkable element's a11y frame as the whole containing
+    /// *row*, with the actual control at the row's **trailing** edge — as iOS/idb does for a
+    /// `UISwitch` in a grouped table cell. When true, `click_element` aims a row-shaped
+    /// checkable's tap at the trailing control instead of the geometric center, which would
+    /// otherwise land on the inert label and no-op. Default `false`: every other backend
+    /// reports a switch's frame as the tight control (its center is the right target), so the
+    /// trailing-aim would misfire on a wide *labeled* checkbox whose indicator is at the
+    /// leading edge — hence this is opt-in per backend rather than a geometry heuristic.
+    fn a11y_toggle_control_at_trailing_edge(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -1,9 +1,10 @@
 //! `Glass` accessibility ops: snapshot, marks, click, and set-value.
 use super::*;
 
-/// A checkable element wider than this multiple of its height is treated as "row-shaped" — a
-/// backend (iOS/idb) reporting the whole table row as a switch's frame — so `click_element`
-/// aims at the trailing control instead of the row center.
+/// A checkable element wider than this multiple of its height is treated as "row-shaped". On a
+/// backend that frames a switch as its whole row (`Platform::a11y_toggle_control_at_trailing_edge`),
+/// `click_element` aims a row-shaped checkable's tap at the trailing control instead of the row
+/// center.
 const ROW_ASPECT: u32 = 4;
 
 impl Glass {
@@ -54,12 +55,17 @@ impl Glass {
     }
 
     fn click_element_inner(&mut self, id: AxNodeId) -> Result<()> {
-        let (bounds, checkable, active_geo) = {
+        let (bounds, checkable, trailing_toggle_backend, active_geo) = {
             let s = self.require_active()?;
             let tree = s.last_ax.as_ref().ok_or(GlassError::NoAxSnapshot)?;
             let node = tree.find(id).ok_or(GlassError::AxElementNotFound(id.0))?;
             let bounds = node.bounds.ok_or(GlassError::AxElementNotClickable(id.0))?;
-            (bounds, node.states.checkable, s.geometry.clone())
+            (
+                bounds,
+                node.states.checkable,
+                s.platform.a11y_toggle_control_at_trailing_edge(),
+                s.geometry.clone(),
+            )
         };
         // The element's a11y bounds are reported relative to the active window, but it
         // may actually render in a separate popover window (e.g. an open dropdown's
@@ -100,11 +106,18 @@ impl Glass {
             }
             return result;
         }
-        // A row-shaped checkable (a switch whose backend reports the whole row as its frame,
-        // e.g. iOS/idb) has its control at the trailing edge, so the geometric center lands on
-        // the label. Aim trailing there; every backend whose switch bounds are the tight control
-        // is not row-shaped and uses the unchanged center.
-        let (x, y) = if checkable && bounds.width > bounds.height.saturating_mul(ROW_ASPECT) {
+        // A switch whose backend reports the whole row as its frame with the control at the
+        // trailing edge (iOS/idb) is mis-tapped at the geometric center — that lands on the inert
+        // label. For such a backend, aim a row-shaped checkable's tap at the trailing control.
+        // Gated on the backend capability, NOT geometry alone: a wide *labeled* checkbox on a
+        // desktop backend is also row-shaped but has its indicator at the LEADING edge, so the
+        // trailing-aim must not apply there. The row-shape test uses the raw-bounds aspect as a
+        // cheap pre-filter; `clamped_trailing_point` derives its inset from the clamped visible
+        // height.
+        let (x, y) = if checkable
+            && trailing_toggle_backend
+            && bounds.width > bounds.height.saturating_mul(ROW_ASPECT)
+        {
             bounds.clamped_trailing_point(active_geo.width, active_geo.height)
         } else {
             bounds.clamped_center(active_geo.width, active_geo.height)
@@ -920,7 +933,10 @@ mod tests {
                 leaf(AxRole::ListItem, "row", false),
             ],
         };
-        let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
+        // A backend that frames a switch as its whole row (iOS/idb) opts into the trailing-aim.
+        let platform = FakePlatform::new(100, 100)
+            .with_click_log(clicks.clone())
+            .with_trailing_toggle_backend();
         let mut g = glass_with_a11y(platform, AxTree { root, count: 0 });
         g.start(&spec()).unwrap();
         g.a11y_snapshot().unwrap();
@@ -937,6 +953,112 @@ mod tests {
         assert_eq!(
             clicks.lock().unwrap().last().copied(),
             bounds.clamped_center(100, 100)
+        );
+    }
+
+    #[test]
+    fn click_element_uses_center_for_a_row_shaped_checkable_on_a_non_trailing_backend() {
+        // The trailing-aim is opt-in per backend. A desktop backend (default FakePlatform: no
+        // `with_trailing_toggle_backend`) frames a labeled checkbox as a wide row too, but its
+        // indicator is at the LEADING edge — so a row-shaped checkable here must still click
+        // center, never trailing. This is the guard that keeps the iOS fix from misfiring
+        // on macOS/Windows/Linux/Android.
+        let clicks = Arc::new(Mutex::new(Vec::new()));
+        let bounds = AxRect {
+            x: 10,
+            y: 10,
+            width: 80,
+            height: 15,
+        }; // identical row-shaped bounds to the trailing test
+        let root = AxNode {
+            id: AxNodeId(0),
+            role: AxRole::Window,
+            raw_role: "window".into(),
+            name: None,
+            value: None,
+            states: AxStates::default(),
+            bounds: Some(AxRect {
+                x: 0,
+                y: 0,
+                width: 100,
+                height: 100,
+            }),
+            children: vec![AxNode {
+                id: AxNodeId(0),
+                role: AxRole::CheckBox,
+                raw_role: "checkbox".into(),
+                name: Some("labeled".into()),
+                value: None,
+                states: AxStates {
+                    checkable: true,
+                    ..Default::default()
+                },
+                bounds: Some(bounds),
+                children: vec![],
+            }],
+        };
+        let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
+        let mut g = glass_with_a11y(platform, AxTree { root, count: 0 });
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot().unwrap();
+        g.click_element(AxNodeId(1)).unwrap();
+        assert_eq!(
+            clicks.lock().unwrap().last().copied(),
+            bounds.clamped_center(100, 100),
+            "a row-shaped checkable on a non-trailing backend clicks center, not trailing"
+        );
+    }
+
+    #[test]
+    fn click_element_uses_center_for_a_checkable_that_is_not_row_shaped() {
+        // Even on a trailing-toggle backend, a checkable whose bounds are NOT row-shaped clicks
+        // center. Uses exactly 4:1 (60x15) to pin the strict `>` boundary: 60 is NOT > 4*15=60,
+        // so it is treated as tight → center.
+        let clicks = Arc::new(Mutex::new(Vec::new()));
+        let bounds = AxRect {
+            x: 10,
+            y: 10,
+            width: 60,
+            height: 15,
+        }; // 60 == 4*15 exactly → not row-shaped (strict >)
+        let root = AxNode {
+            id: AxNodeId(0),
+            role: AxRole::Window,
+            raw_role: "window".into(),
+            name: None,
+            value: None,
+            states: AxStates::default(),
+            bounds: Some(AxRect {
+                x: 0,
+                y: 0,
+                width: 100,
+                height: 100,
+            }),
+            children: vec![AxNode {
+                id: AxNodeId(0),
+                role: AxRole::CheckBox,
+                raw_role: "checkbox".into(),
+                name: Some("tight".into()),
+                value: None,
+                states: AxStates {
+                    checkable: true,
+                    ..Default::default()
+                },
+                bounds: Some(bounds),
+                children: vec![],
+            }],
+        };
+        let platform = FakePlatform::new(100, 100)
+            .with_click_log(clicks.clone())
+            .with_trailing_toggle_backend();
+        let mut g = glass_with_a11y(platform, AxTree { root, count: 0 });
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot().unwrap();
+        g.click_element(AxNodeId(1)).unwrap();
+        assert_eq!(
+            clicks.lock().unwrap().last().copied(),
+            bounds.clamped_center(100, 100),
+            "exactly 4:1 is not row-shaped (strict >), so it clicks center"
         );
     }
 

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -1,6 +1,11 @@
 //! `Glass` accessibility ops: snapshot, marks, click, and set-value.
 use super::*;
 
+/// A checkable element wider than this multiple of its height is treated as "row-shaped" — a
+/// backend (iOS/idb) reporting the whole table row as a switch's frame — so `click_element`
+/// aims at the trailing control instead of the row center.
+const ROW_ASPECT: u32 = 4;
+
 impl Glass {
     /// Snapshot the active window's accessibility tree (normalized, window-
     /// relative, ids assigned by the core). Caches it for `click_element`.
@@ -33,8 +38,9 @@ impl Glass {
         Ok(crate::marks::render(&frame, &tree))
     }
 
-    /// Click the element with id `id` from the most recent `a11y_snapshot`
-    /// (clicks the center of its bounds, via the normal pointer path).
+    /// Click the element with id `id` from the most recent `a11y_snapshot` via the normal
+    /// pointer path — the center of its bounds, or the trailing control for a row-shaped
+    /// checkable (see [`AxRect::clamped_trailing_point`]).
     pub fn click_element(&mut self, id: AxNodeId) -> Result<()> {
         let t = std::time::Instant::now();
         let element = self.element_ref(id);
@@ -48,12 +54,12 @@ impl Glass {
     }
 
     fn click_element_inner(&mut self, id: AxNodeId) -> Result<()> {
-        let (bounds, active_geo) = {
+        let (bounds, checkable, active_geo) = {
             let s = self.require_active()?;
             let tree = s.last_ax.as_ref().ok_or(GlassError::NoAxSnapshot)?;
             let node = tree.find(id).ok_or(GlassError::AxElementNotFound(id.0))?;
             let bounds = node.bounds.ok_or(GlassError::AxElementNotClickable(id.0))?;
-            (bounds, s.geometry.clone())
+            (bounds, node.states.checkable, s.geometry.clone())
         };
         // The element's a11y bounds are reported relative to the active window, but it
         // may actually render in a separate popover window (e.g. an open dropdown's
@@ -94,9 +100,16 @@ impl Glass {
             }
             return result;
         }
-        let (x, y) = bounds
-            .clamped_center(active_geo.width, active_geo.height)
-            .ok_or(GlassError::AxElementNotClickable(id.0))?;
+        // A row-shaped checkable (a switch whose backend reports the whole row as its frame,
+        // e.g. iOS/idb) has its control at the trailing edge, so the geometric center lands on
+        // the label. Aim trailing there; every backend whose switch bounds are the tight control
+        // is not row-shaped and uses the unchanged center.
+        let (x, y) = if checkable && bounds.width > bounds.height.saturating_mul(ROW_ASPECT) {
+            bounds.clamped_trailing_point(active_geo.width, active_geo.height)
+        } else {
+            bounds.clamped_center(active_geo.width, active_geo.height)
+        }
+        .ok_or(GlassError::AxElementNotClickable(id.0))?;
         self.pointer_inner(&PointerEvent::Click {
             x,
             y,
@@ -861,6 +874,69 @@ mod tests {
         assert!(
             select_log.lock().unwrap().is_empty(),
             "no popover routing means no select_window call"
+        );
+    }
+
+    #[test]
+    fn click_element_taps_trailing_edge_for_a_row_shaped_checkable() {
+        // A checkable node whose bounds are row-shaped (w > 4h) — a backend (iOS/idb) that
+        // reports the whole cell as a switch's frame. The click must land near the trailing
+        // control (right of center); a non-checkable node of the SAME bounds still clicks center.
+        let clicks = Arc::new(Mutex::new(Vec::new()));
+        let bounds = AxRect {
+            x: 10,
+            y: 10,
+            width: 80,
+            height: 15,
+        }; // 80 > 4 * 15 ⇒ row-shaped
+        let leaf = |role: AxRole, name: &str, checkable: bool| AxNode {
+            id: AxNodeId(0),
+            role,
+            raw_role: name.into(),
+            name: Some(name.into()),
+            value: None,
+            states: AxStates {
+                checkable,
+                ..Default::default()
+            },
+            bounds: Some(bounds),
+            children: vec![],
+        };
+        let root = AxNode {
+            id: AxNodeId(0),
+            role: AxRole::Window,
+            raw_role: "window".into(),
+            name: None,
+            value: None,
+            states: AxStates::default(),
+            bounds: Some(AxRect {
+                x: 0,
+                y: 0,
+                width: 100,
+                height: 100,
+            }),
+            children: vec![
+                leaf(AxRole::CheckBox, "switch", true),
+                leaf(AxRole::ListItem, "row", false),
+            ],
+        };
+        let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
+        let mut g = glass_with_a11y(platform, AxTree { root, count: 0 });
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot().unwrap();
+
+        // node #1 = the row-shaped checkable → trailing point (right of center).
+        g.click_element(AxNodeId(1)).unwrap();
+        let trailing = bounds.clamped_trailing_point(100, 100).unwrap();
+        assert_eq!(clicks.lock().unwrap().last().copied(), Some(trailing));
+        assert!(trailing.0 > bounds.clamped_center(100, 100).unwrap().0);
+
+        // node #2 = the non-checkable row of identical bounds → geometric center (gate needs
+        // checkable, so a plain wide list row is unaffected).
+        g.click_element(AxNodeId(2)).unwrap();
+        assert_eq!(
+            clicks.lock().unwrap().last().copied(),
+            bounds.clamped_center(100, 100)
         );
     }
 

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -44,6 +44,9 @@ pub(crate) struct FakePlatform {
     /// proving a failed popover-probe enumeration degrades to the normal click path
     /// instead of propagating.
     fail_list_windows: bool,
+    /// Stands in for a backend (iOS) that reports a switch's frame as the whole row — makes
+    /// `a11y_toggle_control_at_trailing_edge` return true so the trailing-aim path is testable.
+    a11y_trailing_toggle: bool,
 }
 
 impl FakePlatform {
@@ -100,6 +103,10 @@ impl FakePlatform {
     }
     pub(crate) fn with_failing_list_windows(mut self) -> Self {
         self.fail_list_windows = true;
+        self
+    }
+    pub(crate) fn with_trailing_toggle_backend(mut self) -> Self {
+        self.a11y_trailing_toggle = true;
         self
     }
 }
@@ -159,6 +166,9 @@ impl Platform for FakePlatform {
     }
     fn app_pid(&self) -> Option<u32> {
         Some(4242)
+    }
+    fn a11y_toggle_control_at_trailing_edge(&self) -> bool {
+        self.a11y_trailing_toggle
     }
     fn send_key(&mut self, event: &KeyEvent) -> Result<()> {
         self.key_events.push(event.clone());

--- a/crates/glass-ios/src/axmap.rs
+++ b/crates/glass-ios/src/axmap.rs
@@ -163,9 +163,8 @@ fn map_node(n: &Value, scale: f64) -> AxNode {
     } else {
         None
     };
-    // A UISwitch reports role AXCheckBox/AXSwitch/AXToggle with AXValue "0"/"1"; derive the
-    // toggle state from it. idb exposes no per-element focus state, so `focused` stays false
-    // (a real limitation of this backend).
+    // `checkable`/`checked` from the switch's AXValue (see `checkable_checked`). idb exposes no
+    // per-element focus state, so `focused` stays false — a real limitation of this backend.
     let (checkable, checked) = checkable_checked(role, s("AXValue").as_deref());
     let states = AxStates {
         enabled: n.get("enabled").and_then(Value::as_bool).unwrap_or(true),
@@ -251,6 +250,10 @@ mod tests {
         assert_eq!(ax_role("AXTextField"), AxRole::TextField);
         assert_eq!(ax_role("AXApplication"), AxRole::Application);
         assert_eq!(ax_role("AXImage"), AxRole::Image);
+        // The checkable roles the toggle-state derivation depends on.
+        assert_eq!(ax_role("AXSwitch"), AxRole::ToggleButton);
+        assert_eq!(ax_role("AXToggle"), AxRole::ToggleButton);
+        assert_eq!(ax_role("AXCheckBox"), AxRole::CheckBox);
         assert_eq!(ax_role("AXWhatever"), AxRole::Other);
     }
 

--- a/crates/glass-ios/src/axmap.rs
+++ b/crates/glass-ios/src/axmap.rs
@@ -121,6 +121,20 @@ pub fn scale_from_width(json: &str, frame_px_width: u32) -> Option<f64> {
         .map(|pt| f64::from(frame_px_width) / pt)
 }
 
+/// iOS `(checkable, checked)` from the normalized role and idb's `AXValue` string. A UISwitch
+/// reports role AXCheckBox/AXSwitch/AXToggle with AXValue "0"/"1". Claims `checkable` ONLY for a
+/// determinate "0"/"1" on a checkable role (the #170 invariant); anything else → (false, false).
+fn checkable_checked(role: AxRole, ax_value: Option<&str>) -> (bool, bool) {
+    match role {
+        AxRole::CheckBox | AxRole::ToggleButton => match ax_value {
+            Some("1") => (true, true),
+            Some("0") => (true, false),
+            _ => (false, false),
+        },
+        _ => (false, false),
+    }
+}
+
 fn map_node(n: &Value, scale: f64) -> AxNode {
     // Read a string field, collapsing both a JSON `null` (missing/non-string) and an
     // empty string to `None` so absent and blank values are treated alike.
@@ -149,17 +163,17 @@ fn map_node(n: &Value, scale: f64) -> AxNode {
     } else {
         None
     };
+    // A UISwitch reports role AXCheckBox/AXSwitch/AXToggle with AXValue "0"/"1"; derive the
+    // toggle state from it. idb exposes no per-element focus state, so `focused` stays false
+    // (a real limitation of this backend).
+    let (checkable, checked) = checkable_checked(role, s("AXValue").as_deref());
     let states = AxStates {
         enabled: n.get("enabled").and_then(Value::as_bool).unwrap_or(true),
         visible: true,
-        // idb's accessibility_info exposes no per-element focus state, so `focused`
-        // is always false here (a known limitation of this backend).
         focused: false,
         editable,
-        // idb's accessibility_info exposes no checked/checkable trait, so iOS toggles
-        // are out of scope here (a known limitation of this backend); `checked` stays
-        // at its `AxStates::default()` value below alongside it.
-        checkable: false,
+        checkable,
+        checked,
         ..AxStates::default()
     };
     let bounds = n.get("frame").and_then(|f| frame_to_rect(f, scale));
@@ -400,5 +414,36 @@ mod tests {
         // caller ever divides by a zero-or-negative point width.
         assert_eq!(scale_from_width("[]", 1206), None);
         assert_eq!(scale_from_width(r#"[{"frame":{"width":0}}]"#, 1206), None);
+    }
+
+    #[test]
+    fn ios_checkable_checked_only_claims_a_determinate_toggle() {
+        use AxRole::*;
+        assert_eq!(checkable_checked(CheckBox, Some("1")), (true, true));
+        assert_eq!(checkable_checked(CheckBox, Some("0")), (true, false));
+        assert_eq!(checkable_checked(ToggleButton, Some("1")), (true, true));
+        assert_eq!(checkable_checked(ToggleButton, Some("0")), (true, false));
+        // Not a determinate 0/1, or not a checkable role → neither (the #170 invariant).
+        assert_eq!(checkable_checked(CheckBox, Some("mixed")), (false, false));
+        assert_eq!(checkable_checked(CheckBox, None), (false, false));
+        assert_eq!(checkable_checked(TextField, Some("1")), (false, false));
+        assert_eq!(checkable_checked(Button, Some("0")), (false, false));
+    }
+
+    #[test]
+    fn build_tree_reads_switch_checked_state_and_keeps_label_as_value() {
+        // A UISwitch as idb reports it: role AXCheckBox, stable id, label, AXValue "1" (on).
+        let j = r#"[{"role":"AXCheckBox","subrole":"AXSwitch","AXUniqueId":"boldText",
+                     "AXLabel":"Bold Text","AXValue":"1",
+                     "frame":{"x":0,"y":0,"width":100,"height":30}}]"#;
+        let mut tree = build_tree(j, 1.0, &win()).expect("parses");
+        tree.assign_ids();
+        let sw = find_by_name(&tree.root, "boldText").expect("switch present");
+        assert!(
+            sw.states.checkable && sw.states.checked,
+            "an on switch → checkable + checked"
+        );
+        // `checked` carries the state; the label still lives in `value` (unchanged behavior).
+        assert_eq!(sw.value.as_deref(), Some("Bold Text"));
     }
 }

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -261,6 +261,13 @@ fn discover_scale(client: &IdbClient, frame_px_width: u32) -> Result<f64> {
 }
 
 impl Platform for IosPlatform {
+    /// idb reports a `UISwitch` in a grouped table cell with the whole cell as its frame and
+    /// the control at the trailing edge, so a centered `click_element` tap lands on the inert
+    /// label. Opt into the trailing-aim (see the trait default's rationale).
+    fn a11y_toggle_control_at_trailing_edge(&self) -> bool {
+        true
+    }
+
     fn start_app(&mut self, spec: &AppSpec) -> Result<WindowGeometry> {
         if let Some(build) = &spec.build {
             let mut cmd = Command::new("sh");


### PR DESCRIPTION
## What

Completes the accessibility `checkable`/`checked` work from #170 on the two backends it left stubbed, plus a related iOS actuation fix.

- **macOS** — read a checkbox/radio/switch's `AXValue` (a `CFNumber`) and derive `checkable`/`checked`. New `ffi::attribute_i64` (the existing string/bool readers can't read a number).
- **iOS** — derive `checkable`/`checked` for a `UISwitch` from idb's `AXValue` `"0"`/`"1"`.
- **iOS click fix** — idb reports a switch's frame as its whole table row (control at the trailing edge), so `glass_click_element` aimed at the geometric center landed on the inert label and no-op'd. `click_element` now aims at the trailing control for a row-shaped checkable, gated on a new per-backend `Platform` capability (`a11y_toggle_control_at_trailing_edge`) so it applies only where a backend frames switches that way (iOS) and never mis-aims a wide *labeled* desktop checkbox whose indicator is at the leading edge.

## Invariant

Per #170: `checkable = true` only when a *determinate* on/off state was read. An unread, mixed, or unexpected value reports neither `checkable` nor `checked`, so `condition:"unchecked"` never matches a control that isn't actually off.

## Testing

- Pure derivation, geometry, and the click gate are unit-tested on Linux (`glass-core`, `glass-ios`, `glass-a11y-macos` mapping). The macOS `ffi`/`reader` are macOS-only; built + unit-tested + clippy/fmt-clean on a macOS host.
- Full pr-review-toolkit panel (6 lenses) + a focused re-review of the follow-up commit: no outstanding findings.
- On-device runtime verification of the real-widget behavior (macOS checkbox/switch state; iOS switch state + tap) is the remaining pre-merge gate.