### PR TITLE
macos: activate the launched app at start; make WindowNotFound actionable (B4 #4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ internal refactors, CI, or test-only changes.
 - **`glass_click_element` now reliably toggles an iOS switch.** iOS reports a switch's frame as its
   whole table row, so a click aimed at the geometric center landed on the inert label and did nothing;
   the click now targets the trailing control.
+- **macOS: a newly-launched app is brought frontmost at `glass_start`**, so `glass_a11y_snapshot`
+  resolves its window immediately instead of returning `window not found` until the first `glass_click`
+  activated the app. The `window not found` message also now suggests a remedy.
 
 ### Changed
 - **Every tool now returns a uniform result envelope.** On success, a tool's leading text block is

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -15,7 +15,9 @@ pub enum GlassError {
     #[error("app exited (code {0:?})")]
     AppExited(Option<i32>),
 
-    #[error("window not found")]
+    #[error(
+        "window not found — the target app may not have opened its window yet; wait for it to appear and retry"
+    )]
     WindowNotFound,
 
     #[error("capture failed: {0}")]
@@ -146,6 +148,10 @@ mod tests {
         assert_eq!(
             GlassError::BaselineMissing("main".into()).to_string(),
             "baseline not found: main"
+        );
+        assert_eq!(
+            GlassError::WindowNotFound.to_string(),
+            "window not found — the target app may not have opened its window yet; wait for it to appear and retry"
         );
     }
 

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -547,48 +547,63 @@ impl Platform for MacosPlatform {
             .run
             .first()
             .ok_or_else(|| GlassError::AppNotStarted("empty run".into()))?;
-        if crate::bundle::is_app_bundle(run0) {
-            return self.start_bundle(spec, Path::new(run0));
-        }
-        let (mut child, clip) = process::spawn(spec, self.logs.clone())?;
-        let pid = child.id();
-        match Self::discover_window(&mut child, pid, spec.timeout_ms) {
-            Ok(m) => {
-                self.child = Some(child);
-                self.app_pid = Some(pid);
-                // Defensive: a plain exec is never an adopted session — clear any stale
-                // handoff record from a prior un-stopped session so it can't widen
-                // `stop_app`/`Drop`'s reap blast radius (symmetric with `start_bundle`'s
-                // handoff path clearing `self.child`).
-                self.adopted = None;
-                // NOTE: this seeds the active-window model (Plan 4 design decision 2): the
-                // first window discovered for the launched app becomes the implicit target
-                // of capture/input, exactly as `select_window` (a later task) will retarget
-                // it to a different window later. `resolve_active_window` (used by
-                // `capture_frame`/`send_pointer`/`send_key` below) is what actually honors
-                // this field on every call.
-                self.active_window = Some(m.window_id);
-                // Decide the session's clipboard route now that the launched window is
-                // confirmed — see `decide_clip`'s doc.
-                self.clipboard_route = decide_clip(spec.sandbox, clip.as_ref());
-                self.clip = clip;
-                // Scale/origin/geometry are NOT cached here: `send_pointer` re-resolves the
-                // window fresh on every call instead (see its doc) since it may move/resize
-                // after this initial discovery. Only the initial geometry is returned to the
-                // caller, matching every other backend's `start_app` contract.
-                Ok(m.geometry)
+        let geometry = if crate::bundle::is_app_bundle(run0) {
+            self.start_bundle(spec, Path::new(run0))?
+        } else {
+            let (mut child, clip) = process::spawn(spec, self.logs.clone())?;
+            let pid = child.id();
+            match Self::discover_window(&mut child, pid, spec.timeout_ms) {
+                Ok(m) => {
+                    self.child = Some(child);
+                    self.app_pid = Some(pid);
+                    // Defensive: a plain exec is never an adopted session — clear any stale
+                    // handoff record from a prior un-stopped session so it can't widen
+                    // `stop_app`/`Drop`'s reap blast radius (symmetric with `start_bundle`'s
+                    // handoff path clearing `self.child`).
+                    self.adopted = None;
+                    // NOTE: this seeds the active-window model (Plan 4 design decision 2): the
+                    // first window discovered for the launched app becomes the implicit target
+                    // of capture/input, exactly as `select_window` (a later task) will retarget
+                    // it to a different window later. `resolve_active_window` (used by
+                    // `capture_frame`/`send_pointer`/`send_key` below) is what actually honors
+                    // this field on every call.
+                    self.active_window = Some(m.window_id);
+                    // Decide the session's clipboard route now that the launched window is
+                    // confirmed — see `decide_clip`'s doc.
+                    self.clipboard_route = decide_clip(spec.sandbox, clip.as_ref());
+                    self.clip = clip;
+                    // Scale/origin/geometry are NOT cached here: `send_pointer` re-resolves the
+                    // window fresh on every call instead (see its doc) since it may move/resize
+                    // after this initial discovery. Only the initial geometry is returned to the
+                    // caller, matching every other backend's `start_app` contract.
+                    m.geometry
+                }
+                Err(e) => {
+                    // The window never appeared (or discovery otherwise failed): don't leak
+                    // the spawned child.
+                    process::terminate(&mut child);
+                    // Nor the named pasteboards the shim may already have created — the app (and
+                    // its ctor) ran before discovery. `self.clip` is never set on this path, so
+                    // `stop_app` wouldn't release them; do it here (`release_clip`'s doc).
+                    release_clip(clip.as_ref());
+                    return Err(e);
+                }
             }
-            Err(e) => {
-                // The window never appeared (or discovery otherwise failed): don't leak
-                // the spawned child.
-                process::terminate(&mut child);
-                // Nor the named pasteboards the shim may already have created — the app (and
-                // its ctor) ran before discovery. `self.clip` is never set on this path, so
-                // `stop_app` wouldn't release them; do it here (`release_clip`'s doc).
-                release_clip(clip.as_ref());
-                Err(e)
+        };
+        // Bring the launched app frontmost so its windows register with the AX API — otherwise
+        // `glass_a11y_snapshot` `WindowNotFound`s until the first input activates it. Best-effort:
+        // capture and the activate-on-first-input path both still work, so a declined activation
+        // (the OS can deprioritize a launch — see `input::focus`) is logged, never fatal. This is
+        // the same activation the first `glass_click`/`glass_type` already makes, only earlier.
+        if let Some(pid) = self.app_pid {
+            if let Err(e) = crate::input::focus(pid as i32) {
+                eprintln!(
+                    "glass-macos: could not activate launched app (pid {pid}): {e}; \
+                     a11y may need a glass_click to raise the window"
+                );
             }
         }
+        Ok(geometry)
     }
 
     /// Terminate the launched app (however it was launched) and clear the active pid/window.

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -403,6 +403,27 @@ fn release_clip(clip: Option<&ClipLaunch>) {
     }
 }
 
+/// Bring the launched app (`app_pid`) frontmost so its windows register with the AX API —
+/// otherwise `glass_a11y_snapshot` `WindowNotFound`s until the first input activates it. This
+/// front-loads the raise the first `glass_click`/`glass_type` would do anyway (`send_pointer`/
+/// `send_key` both call `input::focus` first).
+///
+/// **Best-effort — never fatal.** `input::focus` already tolerates an OS-deprioritized
+/// (declined) activation by discarding `activateWithOptions`'s `false` and returning `Ok`, so
+/// the *only* error it can yield is `AppExited` — the app died in the gap after
+/// `discover_window` confirmed its window. The launch still succeeded (the returned geometry is
+/// from a window that was confirmed present), and the next capture/a11y/input op surfaces that
+/// `AppExited` with a structured error, so here we log and continue rather than fail the launch.
+fn activate_launched(app_pid: Option<u32>) {
+    if let Some(pid) = app_pid {
+        if let Err(e) = crate::input::focus(pid as i32) {
+            eprintln!(
+                "glass-macos: launched app (pid {pid}) exited before it could be activated: {e}"
+            );
+        }
+    }
+}
+
 /// Bounds-check every window-relative coordinate `event` carries against `geom` via
 /// `coords::check_in_bounds`, failing with `GlassError::CoordOutOfBounds` before
 /// `input::send_pointer` ever maps a coordinate to a global point — the "no
@@ -590,19 +611,9 @@ impl Platform for MacosPlatform {
                 }
             }
         };
-        // Bring the launched app frontmost so its windows register with the AX API — otherwise
-        // `glass_a11y_snapshot` `WindowNotFound`s until the first input activates it. Best-effort:
-        // capture and the activate-on-first-input path both still work, so a declined activation
-        // (the OS can deprioritize a launch — see `input::focus`) is logged, never fatal. This is
-        // the same activation the first `glass_click`/`glass_type` already makes, only earlier.
-        if let Some(pid) = self.app_pid {
-            if let Err(e) = crate::input::focus(pid as i32) {
-                eprintln!(
-                    "glass-macos: could not activate launched app (pid {pid}): {e}; \
-                     a11y may need a glass_click to raise the window"
-                );
-            }
-        }
+        // Activate the launched app so its window registers with the AX API (best-effort — see
+        // `activate_launched`); the launch itself already succeeded above.
+        activate_launched(self.app_pid);
         Ok(geometry)
     }
 
@@ -1090,6 +1101,23 @@ mod tests {
             p.start_app(&spec),
             Err(GlassError::AppNotStarted(_))
         ));
+    }
+
+    #[test]
+    fn activate_launched_none_is_a_noop() {
+        // No launched pid → nothing to activate; must short-circuit before touching AppKit.
+        activate_launched(None);
+    }
+
+    #[test]
+    fn activate_launched_swallows_a_dead_pid() {
+        // The best-effort contract: a pid with no live app makes `input::focus` return
+        // `AppExited` — it resolves `runningApplicationWithProcessIdentifier` to `None` before
+        // ever calling `activateWithOptions`, so this needs no grant, no app, and no main
+        // thread (same as `stop_app`'s pid-999_999 tests). `activate_launched` must log and
+        // return, never panic or propagate: a regression tightening its `if let Err` into `?`
+        // would change its `()` signature and fail to compile against `start_app`'s call.
+        activate_launched(Some(999_999));
     }
 
     #[test]


### PR DESCRIPTION
## What

A glass-launched macOS app was never brought frontmost, so its windows didn't register with the AX API and `glass_a11y_snapshot` returned `WindowNotFound` until the first `glass_click`/`glass_type` activated it (capture worked throughout). Two changes:

- **`glass_start` activates the launched app frontmost** (both the plain-exec and `.app`-bundle paths) via the existing `input::focus`, at a single tail in `start_app` reached by every launch path through `self.app_pid`. **Best-effort** — a launched app that dies in the gap after window discovery yields an `AppExited` that is logged and swallowed (the next capture/a11y/input op surfaces it), never failing the launch. This is the same activation the first input already performed, moved earlier.
- **`WindowNotFound` gains a remedy** — the bare `"window not found"` becomes `"window not found — the target app may not have opened its window yet; wait for it to appear and retry"` (error text isn't part of the frozen surface; the message fits both the capture and a11y callers).

The a11y reader stays read-only — activation is a launch-time side effect, never a snapshot one.

## Testing

- `WindowNotFound` message: exact-string unit test on Linux.
- The activation is macOS-gated; built + clippy/fmt clean + 112 lib tests on the macOS runner and host. The `activate_launched` never-fatal contract is unit-tested (a dead pid → `AppExited`, swallowed) without needing a grant.
- pr-review-toolkit panel (code-reviewer, silent-failure-hunter, comment-analyzer, pr-test-analyzer): behavior-preservation of the `start_app` restructure confirmed; findings applied.
- Real-widget effect (launch → immediate `a11y_snapshot` resolves) is verified on rc3 with the rest of B4.