### PR TITLE
windows-a11y: read Slider/Spinner/ProgressBar value via RangeValuePattern (B4 #8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ internal refactors, CI, or test-only changes.
   `glass_wait_for_element {condition: "checked"}` (or `"unchecked"`) works against those controls.
   State is reported only when it can be read for certain — an indeterminate or unreadable control
   matches neither condition rather than being misreported.
+- **Windows: a Slider, Spinner, or ProgressBar's numeric value is now readable** through the
+  accessibility tree (via its `RangeValuePattern` position), so `glass_wait_for_element
+  {value_contains}` can match a range control's number; previously these controls exposed no value.
+  The value is the control's raw numeric position (a `0..1` slider shown as "50%" reads as `0.5`).
 
 ### Fixed
 - **`glass_click_element` now reliably toggles an iOS switch.** iOS reports a switch's frame as its

--- a/crates/glass-a11y-windows/src/mapping.rs
+++ b/crates/glass-a11y-windows/src/mapping.rs
@@ -76,6 +76,14 @@ pub fn map_states(f: &StateFacts) -> AxStates {
     }
 }
 
+/// Render a `RangeValuePattern` numeric value (a slider/spinner/progress position) as the node's
+/// `value` string. Uses `f64`'s shortest round-tripping `Display`, so a whole number has no
+/// trailing `.0` (a slider at `50.0` → `"50"`, matching `value_contains:"50"`) while a fractional
+/// position keeps its digits (`50.5` → `"50.5"`).
+pub fn format_range_value(v: f64) -> String {
+    format!("{v}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -143,5 +151,14 @@ mod tests {
         };
         let s = map_states(&f);
         assert!(s.checkable && !s.checked);
+    }
+
+    #[test]
+    fn range_value_formats_without_trailing_zero() {
+        assert_eq!(format_range_value(50.0), "50");
+        assert_eq!(format_range_value(0.0), "0");
+        assert_eq!(format_range_value(100.0), "100");
+        assert_eq!(format_range_value(50.5), "50.5");
+        assert_eq!(format_range_value(-3.0), "-3");
     }
 }

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -10,7 +10,8 @@ use glass_core::{
     Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget, AxTree, GlassError, Result,
 };
 use uiautomation::patterns::{
-    UIExpandCollapsePattern, UISelectionItemPattern, UITogglePattern, UIValuePattern,
+    UIExpandCollapsePattern, UIRangeValuePattern, UISelectionItemPattern, UITogglePattern,
+    UIValuePattern,
 };
 use uiautomation::types::{ExpandCollapseState, Handle, Rect, ToggleState};
 use uiautomation::{UIAutomation, UIElement, UITreeWalker};
@@ -187,7 +188,7 @@ fn gather(el: &UIElement, ct_id: u32) -> (crate::mapping::StateFacts, Option<Str
             .and_then(|p| p.get_state().ok())
             .map(|s| s == ExpandCollapseState::Expanded).unwrap_or(false);
     // Value pattern: one fetch for both the value string and read-only (Edit/ComboBox/Document)
-    let (value, readonly) = if matches!(ct_id, 50003 | 50004 | 50030) {
+    let (value_text, readonly) = if matches!(ct_id, 50003 | 50004 | 50030) {
         match el.get_pattern::<UIValuePattern>() {
             Ok(p) => (p.get_value().ok().and_then(nonempty), p.is_readonly().ok()),
             Err(_) => (None, None),
@@ -195,6 +196,19 @@ fn gather(el: &UIElement, ct_id: u32) -> (crate::mapping::StateFacts, Option<Str
     } else {
         (None, None)
     };
+    // RangeValue pattern: a Slider/Spinner/ProgressBar exposes its numeric position here, never
+    // via ValuePattern, so read it (gated by control type — `get_pattern` is a COM round-trip) so
+    // `value_contains`/`wait_for_element` can match the number.
+    let value = value_text.or_else(|| {
+        matches!(ct_id, 50012 | 50015 | 50016) // ProgressBar/Slider/Spinner
+            .then(|| {
+                el.get_pattern::<UIRangeValuePattern>()
+                    .ok()
+                    .and_then(|p| p.get_value().ok())
+                    .map(crate::mapping::format_range_value)
+            })
+            .flatten()
+    });
     // Editable iff a writable ValuePattern is present — for ANY value-bearing
     // control (Edit/ComboBox/Document), not just Edit; otherwise a writable
     // ComboBox/Document reports editable=false while set_value would succeed on


### PR DESCRIPTION
## What

A Windows Slider/Spinner/ProgressBar exposes its number through **`RangeValuePattern`**, never `ValuePattern`, so `reader::gather` (which only fetched `ValuePattern` for ComboBox/Edit/Document) always left their `value` `None` — `glass_wait_for_element {value_contains}` could never match a range control. This reads it:

- Pure `mapping::format_range_value(f64) -> String` (Linux-unit-tested) — `f64`'s shortest `Display`, so `50.0 → "50"`, `50.5 → "50.5"`.
- `gather` falls back to `UIRangeValuePattern::get_value()` for control types `50012`/`50015`/`50016` (ProgressBar/Slider/Spinner) when `ValuePattern` has no value. Gated by control type (the two gates are disjoint), so the extra COM round-trip happens only for range controls.

The `readonly`/`editable`/`set_value` paths are unchanged — this is a read-only value; a slider stays non-editable via `ValuePattern`, and setting a slider is out of scope. The value is the raw numeric position (a `0..1` slider shown as "50%" reads as `0.5`), documented on the formatter.

## Testing

- `format_range_value`: Linux unit test (`50.0→"50"`, `50.5→"50.5"`, `0.0→"0"`, `-3.0→"-3"`).
- The `gather` branch is `#[cfg(windows)]` — compiles + clippy-clean under the `x86_64-pc-windows-gnu` cross-target and on the Windows CI runner.
- pr-review-toolkit (code-reviewer + silent-failure-hunter): control-type IDs verified against the UIA spec, the best-effort read confirmed honest + consistent with the reader's pattern, no edit-path impact — no findings.
- Real slider/spinner/progress value round-trip verified on a Windows host at rc3.