### PR TITLE
mcp: return:snapshot settles the UI before folding the tree (B4 #7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ internal refactors, CI, or test-only changes.
 - **macOS: a newly-launched app is brought frontmost at `glass_start`**, so `glass_a11y_snapshot`
   resolves its window immediately instead of returning `window not found` until the first `glass_click`
   activated the app. The `window not found` message also now suggests a remedy.
+- **`return:"snapshot"` now waits for the UI to settle before folding the a11y tree.** A
+  screen-changing `glass_click_element` / `glass_set_value` with `return:"snapshot"` returns the
+  post-transition tree instead of a mid-transition one (best-effort — a continuously-animating UI still
+  returns the freshest tree at the settle deadline).
 
 ### Changed
 - **Every tool now returns a uniform result envelope.** On success, a tool's leading text block is

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -104,9 +104,9 @@ pub struct ClickElementArgs {
     /// window and the previously-active window is restored afterward — no extra step
     /// needed.
     pub id: u32,
-    /// Optional observe folded into the result: "snapshot" (a fresh a11y tree, also
-    /// refreshing the snapshot cache), "settle" (wait for the UI to stop changing,
-    /// text-only), or "none" (default).
+    /// Optional observe folded into the result: "snapshot" (wait for the UI to settle, then
+    /// fold a fresh a11y tree, also refreshing the snapshot cache), "settle" (wait for the UI
+    /// to stop changing, text-only), or "none" (default).
     #[serde(rename = "return")]
     pub return_: Option<String>,
 }
@@ -120,9 +120,9 @@ pub struct SetValueArgs {
     /// `"1"`/`"0"`) — idempotent. For a dropdown/combo box, an option label
     /// (case-insensitive); glass opens it and picks that option.
     pub text: String,
-    /// Optional observe folded into the result: "snapshot" (a fresh a11y tree, also
-    /// refreshing the snapshot cache), "settle" (wait for the UI to stop changing,
-    /// text-only), or "none" (default).
+    /// Optional observe folded into the result: "snapshot" (wait for the UI to settle, then
+    /// fold a fresh a11y tree, also refreshing the snapshot cache), "settle" (wait for the UI
+    /// to stop changing, text-only), or "none" (default).
     #[serde(rename = "return")]
     pub return_: Option<String>,
 }

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -360,7 +360,8 @@ impl GlassServer {
                        into that popover window and the previously-active window is restored \
                        afterward. Ids are only valid within the latest snapshot — re-run \
                        glass_a11y_snapshot if the UI changed. Optional `return`: \"snapshot\" \
-                       folds a fresh a11y tree into the result (and refreshes the snapshot \
+                       settles the UI then folds a fresh a11y tree into the result (and \
+                       refreshes the snapshot \
                        cache); \"settle\" waits for the UI to stop changing (text-only); omit or \
                        \"none\" for no observe (default)."
     )]
@@ -376,8 +377,9 @@ impl GlassServer {
                        keystrokes) — pick the element's #id from glass_a11y_snapshot. Errors if the \
                        element isn't editable, if it changed since the snapshot (re-snapshot), or if \
                        the app exposes no accessibility tree. \
-                       Optional `return`: \"snapshot\" folds a fresh a11y tree into the result \
-                       (and refreshes the snapshot cache); \"settle\" waits for the UI to stop \
+                       Optional `return`: \"snapshot\" settles the UI then folds a fresh a11y \
+                       tree into the result (and refreshes the snapshot cache); \"settle\" waits \
+                       for the UI to stop \
                        changing (text-only); omit or \"none\" for no observe (default)."
     )]
     async fn glass_set_value(

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -227,8 +227,8 @@ fn resolve_return(
             // Let the UI settle before folding the tree so a screen-changing action (a
             // navigating click) doesn't fold a mid-transition tree. Best-effort: `wait_stable`
             // soft-times-out (`settled:false`, not an error) on a non-settling UI, and a rare
-            // real capture failure is swallowed because `a11y_snapshot` reads the AX/UIA tree
-            // (not pixels) and still returns the freshest tree — the caller asked for the tree.
+            // real capture failure is swallowed because `a11y_snapshot` reads the accessibility
+            // tree (not pixels) and still returns the freshest tree — the caller asked for it.
             let _ = glass.wait_stable(&settle_params());
             let tree = glass.a11y_snapshot().map_err(|e| e.to_string())?;
             Ok((

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -224,6 +224,12 @@ fn resolve_return(
             ))
         }
         Some("snapshot") => {
+            // Let the UI settle before folding the tree so a screen-changing action (a
+            // navigating click) doesn't fold a mid-transition tree. Best-effort: `wait_stable`
+            // soft-times-out (`settled:false`, not an error) on a non-settling UI, and a rare
+            // real capture failure is swallowed because `a11y_snapshot` reads the AX/UIA tree
+            // (not pixels) and still returns the freshest tree — the caller asked for the tree.
+            let _ = glass.wait_stable(&settle_params());
             let tree = glass.a11y_snapshot().map_err(|e| e.to_string())?;
             Ok((
                 None,
@@ -335,6 +341,9 @@ pub(crate) mod testutil {
         pub started: bool,
         pub events: Arc<Mutex<Vec<String>>>,
         pub clipboard: String,
+        /// Count of `capture_frame` calls — lets a test assert a settle actually captured
+        /// frames (e.g. `return:"snapshot"` settling before it folds the tree).
+        pub captures: Arc<Mutex<usize>>,
     }
 
     impl FakePlatform {
@@ -361,6 +370,10 @@ pub(crate) mod testutil {
             self.events = log;
             self
         }
+        pub fn with_capture_log(mut self, log: Arc<Mutex<usize>>) -> Self {
+            self.captures = log;
+            self
+        }
     }
 
     impl Platform for FakePlatform {
@@ -373,6 +386,7 @@ pub(crate) mod testutil {
             Ok(())
         }
         fn capture_frame(&mut self, region: Option<&Region>) -> Result<Frame> {
+            *self.captures.lock().unwrap() += 1;
             let frame = match self.frames.pop_front() {
                 Some(f) => {
                     if self.frames.is_empty() {
@@ -1079,7 +1093,9 @@ mod tests {
 
     #[test]
     fn return_snapshot_appends_tree_and_refreshes_cache() {
-        let mut g = started_a11y_frames(vec![]); // click + a11y_snapshot don't capture frames
+        // vec![] → the snapshot arm's best-effort settle can't capture and is swallowed; the
+        // tree still folds (the assertions below are unaffected by the settle).
+        let mut g = started_a11y_frames(vec![]);
         let out = click_element(
             &mut g,
             &ClickElementArgs {
@@ -1121,6 +1137,68 @@ mod tests {
             }
         )
         .is_ok());
+    }
+
+    #[test]
+    fn return_snapshot_settles_before_folding() {
+        use glass_core::Frame;
+        use std::sync::{Arc, Mutex};
+        // A settleable frame + a capture counter, wired inline (started_a11y_frames doesn't
+        // expose a capture log).
+        let captures = Arc::new(Mutex::new(0usize));
+        let platform = FakePlatform::new(100, 100)
+            .with_frames(vec![Frame::solid(100, 100, [0, 0, 0, 255])])
+            .with_capture_log(captures.clone());
+        let mut g = glass_with_a11y(platform, fake_tree());
+        g.start(&AppSpec {
+            build: None,
+            run: vec!["x".into()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 1,
+            sandbox: SandboxLevel::Off,
+            a11y: false,
+        })
+        .unwrap();
+        a11y_snapshot(&mut g).unwrap(); // seed last_ax for click_element
+        let before = *captures.lock().unwrap();
+        let out = click_element(
+            &mut g,
+            &ClickElementArgs {
+                id: 1,
+                return_: Some("snapshot".into()),
+            },
+        )
+        .unwrap();
+        // The a11y outline is still folded (envelope + one untrusted sibling) ...
+        assert_eq!(out.0.len(), 2, "envelope + a11y outline sibling");
+        // ... AND the settle captured frames before the fold. This guards the `wait_stable`
+        // line: remove it and `captures` stays at `before`.
+        assert!(
+            *captures.lock().unwrap() > before,
+            "return:snapshot must settle (capture frames) before folding"
+        );
+    }
+
+    #[test]
+    fn return_snapshot_without_frames_still_folds() {
+        // No frames → the settle's `wait_stable` errors (no scripted frames); the `let _ =`
+        // swallows it and the tree is still folded. A `?` there would deny the tree.
+        let mut g = started_a11y_frames(vec![]);
+        let out = click_element(
+            &mut g,
+            &ClickElementArgs {
+                id: 1,
+                return_: Some("snapshot".into()),
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            out.0.len(),
+            2,
+            "tree still folds even when the settle can't run"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

`resolve_return`'s `"snapshot"` arm (used by `glass_click_element` / `glass_set_value` with `return:"snapshot"`) called `a11y_snapshot()` *immediately* after the action, folding a **mid-transition** a11y tree when the action changed the screen (observed on Android + iOS, but the arm is the shared MCP layer). It now settles first:

```rust
let _ = glass.wait_stable(&settle_params());   // best-effort; reuses the "settle" arm's params
let tree = glass.a11y_snapshot()?;
```

**Best-effort:** `wait_stable` soft-times-out (`settled:false`, not an error) on a non-settling UI, so the tree is still taken; a rare hard capture failure is swallowed because `a11y_snapshot` reads the accessibility tree (not pixels) and still returns the freshest tree — the caller asked for the tree. The `"settle"` / `"none"` arms are unchanged. The four agent-facing `"snapshot"` doc sites (params ×2, server ×2) were swept to say it settles first.

## Testing (Linux — the return tests run on the dev box)

- Added a `captures` count to the test `FakePlatform`. **T1** (`return_snapshot_settles_before_folding`) asserts the settle actually captured frames *before* the fold (valid because click + `a11y_snapshot` never capture — so removing the settle line drops `captures` to 0 and fails). **T2** (`return_snapshot_without_frames_still_folds`) asserts the swallow — with no frames the settle errors, is swallowed, and the tree still folds (a `?` there would deny it). All 264 glass-mcp lib tests pass; fmt + clippy clean.
- pr-review-toolkit (code-reviewer + silent-failure-hunter + comment-analyzer): all clean — behavior-preservation confirmed, the swallow judged honest + convention-consistent, the doc sweep + string-continuations verified accurate. No blocking findings.
- Android/iOS post-navigation confirmation is a bonus at rc3.