### PR TITLE
android: surface companion checkable/checked in the a11y tree (B4 #11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ internal refactors, CI, or test-only changes.
   accessibility tree (via its `RangeValuePattern` position), so `glass_wait_for_element
   {value_contains}` can match a range control's number; previously these controls exposed no value.
   The value is the control's raw numeric position (a `0..1` slider shown as "50%" reads as `0.5`).
+- **Android: the on-device accessibility companion now reports toggle state.** A checkbox / switch /
+  toggle read via the high-fidelity `AccessibilityService` companion now carries its
+  `checkable`/`checked` state (the baseline `uiautomator` reader already did), so
+  `glass_wait_for_element {condition: "checked"}` works against Android toggles through the companion
+  path too.
 
 ### Fixed
 - **`glass_click_element` now reliably toggles an iOS switch.** iOS reports a switch's frame as its

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -71,9 +71,11 @@ fn json_to_node(v: &Value, win: &WindowGeometry) -> Result<AxNode> {
             // Android "focusable" is keyboard-only; map isClickable -> focusable as the actability proxy.
             focusable: flag("clickable"),
             visible: true,
-            // Known limitation: the device `tree` JSON protocol does not yet carry
-            // `checkable`/`checked`, so both stay at their `AxStates::default()` (false)
-            // here — mirrors the iOS reader's precedent (`crates/glass-ios/src/axmap.rs`).
+            // The companion carries isCheckable/isChecked (authoritative, unlike the baseline
+            // uiautomator reader), so surface them directly; `AxStates::active()` and the
+            // Checked/Unchecked `state_pred`s gate `checked` on `checkable`.
+            checkable: flag("checkable"),
+            checked: flag("checked"),
             ..Default::default()
         },
         bounds: Some(AxRect {
@@ -460,6 +462,28 @@ mod tests {
         let save = t.find(AxNodeId(2)).unwrap();
         assert_eq!(save.role, AxRole::Button);
         assert_eq!(save.name.as_deref(), Some("Save"));
+    }
+
+    #[test]
+    fn reads_checkable_and_checked_from_json() {
+        // The companion now carries isCheckable/isChecked; surface them on the node's states.
+        let on = json!({
+            "class": "android.widget.CheckBox", "bounds": {"x": 0, "y": 100, "w": 10, "h": 10},
+            "checkable": true, "checked": true
+        });
+        let n = json_to_node(&on, &win()).unwrap();
+        assert!(
+            n.states.checkable && n.states.checked,
+            "on checkbox → checkable + checked"
+        );
+        let plain = json!({
+            "class": "android.widget.TextView", "bounds": {"x": 0, "y": 100, "w": 10, "h": 10}
+        });
+        let p = json_to_node(&plain, &win()).unwrap();
+        assert!(
+            !p.states.checkable && !p.states.checked,
+            "a node with no checkable/checked keys stays false"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

The glass side of B4 #11 (paired with `fixed-width/glass-android-agent#<companion PR>`). The on-device `AccessibilityService` companion now carries `checkable`/`checked` in its node JSON; `glass-android/src/a11y_service.rs::json_to_node` reads them into `AxStates` (was hardcoded default-false with a "not carried yet" comment).

Direct mapping — the companion's `isCheckable`/`isChecked` are authoritative (unlike the baseline `uiautomator` reader, whose unreliable `checkable` needs the `checkable||checked` workaround in `axmap.rs`). The `#170` invariant holds downstream: `AxStates::active()` and the `Checked`/`Unchecked` `state_pred`s gate `checked` on `checkable`. A missing key (older companion) reads false — pre-change behavior, no regression.

## Testing

- `cargo test -p glass-android` (145 pass) incl. a new `reads_checkable_and_checked_from_json` (`json_to_node` is pure serde_json, unit-tested on Linux); fmt + clippy clean.
- pr-review-toolkit (code-reviewer + silent-failure-hunter): the cross-repo JSON keys match, back-compat defaults honest, invariant enforced — no findings.
- AVD end-to-end (real checkable widget → companion emit → glass read) folds into rc3.

Merge the companion PR first; this side tolerates the keys being absent, so ordering is safe.