### PR TITLE
core: a11y_snapshot refreshes window geometry so click_element uses the current window (B4 #6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ internal refactors, CI, or test-only changes.
 - **macOS: a newly-launched app is brought frontmost at `glass_start`**, so `glass_a11y_snapshot`
   resolves its window immediately instead of returning `window not found` until the first `glass_click`
   activated the app. The `window not found` message also now suggests a remedy.
+- **Accessibility actions now work after an app resizes its own window** (e.g. macOS Calculator
+  opening its sidebar). `glass_a11y_snapshot` re-reads the current window geometry, so
+  `glass_click_element` / `glass_set_value` clamp against the window's actual size instead of a stale
+  cached one — elements that moved beyond the old bounds are no longer reported unclickable.
 - **`return:"snapshot"` now waits for the UI to settle before folding the a11y tree.** A
   screen-changing `glass_click_element` / `glass_set_value` with `return:"snapshot"` returns the
   post-transition tree instead of a mid-transition one (best-effort — a continuously-animating UI still

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -13,10 +13,20 @@ impl Glass {
     /// `AxUnsupported` if the backend has no accessibility reader.
     pub fn a11y_snapshot(&mut self) -> Result<AxTree> {
         let s = self.active_mut()?;
+        // Reader-presence check up front (mirrors set_value_inner) so `AxUnsupported` keeps
+        // precedence over — and a reader-less backend skips — the geometry round-trip below.
+        if s.accessibility.is_none() {
+            return Err(GlassError::AxUnsupported);
+        }
         // Re-read the current window geometry: an app can resize itself (open a sidebar / panel)
-        // without a glass_window op, leaving `s.geometry` stale so the tree — and the subsequent
-        // click_element / set_value, which clamp against `s.geometry` — would map to the old
-        // window bounds and clip elements now beyond them.
+        // without a glass_window op, leaving `s.geometry` stale so the tree's scale/origin — and
+        // the subsequent click_element clamp / set_value context, which read `s.geometry` — would
+        // map to the old window bounds and clip elements now beyond them. Strict by design: a
+        // failure propagates rather than silently reusing a stale cache. Note: on macOS this
+        // resolves the window via ScreenCaptureKit, so a snapshot depends on that and can fail on
+        // a momentarily off-screen window — accepted for correctness. (Android reports a cached
+        // fullscreen window, so a freeform self-resize wouldn't refresh — a residual limitation,
+        // moot while Android apps run fullscreen.)
         let window = s.platform.window(&WindowOp::Geometry)?;
         s.geometry = window.clone();
         let pids = s.platform.app_pids();

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -13,8 +13,13 @@ impl Glass {
     /// `AxUnsupported` if the backend has no accessibility reader.
     pub fn a11y_snapshot(&mut self) -> Result<AxTree> {
         let s = self.active_mut()?;
+        // Re-read the current window geometry: an app can resize itself (open a sidebar / panel)
+        // without a glass_window op, leaving `s.geometry` stale so the tree — and the subsequent
+        // click_element / set_value, which clamp against `s.geometry` — would map to the old
+        // window bounds and clip elements now beyond them.
+        let window = s.platform.window(&WindowOp::Geometry)?;
+        s.geometry = window.clone();
         let pids = s.platform.app_pids();
-        let window = s.geometry.clone();
         let window_handle = s.platform.active_window_handle();
         let a11y_bus_addr = s.platform.a11y_bus_addr();
         let acc = s.accessibility.as_mut().ok_or(GlassError::AxUnsupported)?;
@@ -783,6 +788,62 @@ mod tests {
         g.click_element(AxNodeId(1)).unwrap();
         // The Button at (10,10 20x20) → center (20,20), via the normal pointer path.
         assert_eq!(clicks.lock().unwrap().last().copied(), Some((20, 20)));
+    }
+
+    #[test]
+    fn a11y_snapshot_refreshes_geometry_so_click_element_uses_current_window() {
+        // #6: an app resizes itself (opens a sidebar) without a glass_window op; a11y_snapshot
+        // must re-read the current geometry, else click_element clamps against the stale (smaller)
+        // window and clips elements now beyond it. Start 230 wide, platform now reports 458; a
+        // Button at x=292 is off a stale 230 window but on-screen in the real 458 one.
+        let clicks = Arc::new(Mutex::new(Vec::new()));
+        let bounds = AxRect {
+            x: 292,
+            y: 241,
+            width: 48,
+            height: 48,
+        };
+        let root = AxNode {
+            id: AxNodeId(0),
+            role: AxRole::Window,
+            raw_role: "window".into(),
+            name: None,
+            value: None,
+            states: AxStates::default(),
+            bounds: Some(AxRect {
+                x: 0,
+                y: 0,
+                width: 458,
+                height: 408,
+            }),
+            children: vec![AxNode {
+                id: AxNodeId(0),
+                role: AxRole::Button,
+                raw_role: "button".into(),
+                name: Some("5".into()),
+                value: None,
+                states: AxStates::default(),
+                bounds: Some(bounds),
+                children: vec![],
+            }],
+        };
+        let platform = FakePlatform::new(230, 408)
+            .resized_to(WindowGeometry {
+                x: 0,
+                y: 0,
+                width: 458,
+                height: 408,
+            })
+            .with_click_log(clicks.clone());
+        let mut g = glass_with_a11y(platform, AxTree { root, count: 0 });
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot().unwrap(); // must refresh s.geometry 230 → 458
+        g.click_element(AxNodeId(1)).unwrap(); // the Button at x=292 — on-screen only in 458
+        assert_eq!(
+            clicks.lock().unwrap().last().copied(),
+            bounds.clamped_center(458, 408),
+            "click_element clamps against the refreshed 458 window, not the stale 230"
+        );
     }
 
     #[test]

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -47,6 +47,10 @@ pub(crate) struct FakePlatform {
     /// Stands in for a backend (iOS) that reports a switch's frame as the whole row — makes
     /// `a11y_toggle_control_at_trailing_edge` return true so the trailing-aim path is testable.
     a11y_trailing_toggle: bool,
+    /// When set, a `WindowOp::Geometry` read reports this geometry — models an app that resized
+    /// itself (e.g. opened a sidebar) without a `glass_window` op, so the session's cached
+    /// geometry is stale until `a11y_snapshot` refreshes it.
+    resized_to: Option<WindowGeometry>,
 }
 
 impl FakePlatform {
@@ -107,6 +111,10 @@ impl FakePlatform {
     }
     pub(crate) fn with_trailing_toggle_backend(mut self) -> Self {
         self.a11y_trailing_toggle = true;
+        self
+    }
+    pub(crate) fn resized_to(mut self, g: WindowGeometry) -> Self {
+        self.resized_to = Some(g);
         self
     }
 }
@@ -184,7 +192,12 @@ impl Platform for FakePlatform {
                 self.geometry.x = x;
                 self.geometry.y = y;
             }
-            WindowOp::Focus | WindowOp::Geometry => {}
+            WindowOp::Focus => {}
+            WindowOp::Geometry => {
+                if let Some(g) = &self.resized_to {
+                    self.geometry = g.clone();
+                }
+            }
         }
         Ok(self.geometry.clone())
     }


### PR DESCRIPTION
## What

`Glass::a11y_snapshot` used the session's **cached** `s.geometry`, which is refreshed only by explicit `glass_window`/`select_window` ops. So when an app resizes **itself** (e.g. macOS Calculator opening its sidebar, 230→458), the cache stayed stale — and `click_element`'s `clamped_center(active_geo.width)` clipped every element now beyond the old width, returning `AxElementNotClickable`. Diagnosed on-device: clicking the "5" key (now at `x=292`) after the sidebar opened → `element #N has no clickable on-screen geometry`.

`a11y_snapshot` now re-reads `platform.window(&WindowOp::Geometry)` and updates `s.geometry` before building the `AxContext`, so the tree **and** the subsequent `click_element`/`set_value` (which read `s.geometry`) map to the window's current size.

- **Strict** (`?`-propagated), not best-effort: silently reusing a stale cache is the bug this fixes. A reader-presence check runs first so `AxUnsupported` keeps precedence and reader-less backends skip the round-trip.
- **Trade-off (accepted, documented):** on macOS `window(Geometry)` resolves the window via ScreenCaptureKit, so a snapshot now depends on that and can fail on a momentarily off-screen window (a *click* there already failed). Android reports a cached fullscreen window, so a freeform self-resize wouldn't refresh — a residual limitation, moot while Android apps run fullscreen.

## Testing

- Linux unit test via a `resized_to` fake: start 230-wide, platform now reports 458, a button at `x=292`; `a11y_snapshot` then `click_element` succeeds — and **fails (`AxElementNotClickable`) without the refresh**, so it guards the fix. `cargo test --workspace` green (glass-core 236 + all crates), fmt + clippy clean.
- Root cause **proven on-device** (mini, granted serve). The fix re-confirms on-device at rc3 (the fix in the rc3 build).
- pr-review-toolkit (code-reviewer + silent-failure-hunter): correct + honest (removes a silent-wrong stale path); the one Important trade-off (macOS cost) consciously accepted; Minors applied.