### PR TITLE
a11y: toggle iOS switches with a trailing-edge swipe (B4 #12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,9 @@ internal refactors, CI, or test-only changes.
   path too.
 
 ### Fixed
-- **`glass_click_element` now reliably toggles an iOS switch.** iOS reports a switch's frame as its
-  whole table row, so a click aimed at the geometric center landed on the inert label and did nothing;
-  the click now targets the trailing control.
+- iOS: `glass_click_element` and `glass_set_value` now toggle a `UISwitch` by swiping its control (a tap
+  does not actuate a UISwitch); `glass_set_value` verifies the switch reached the requested state instead
+  of returning a premature `ok`. Other backends are unchanged.
 - **macOS: a newly-launched app is brought frontmost at `glass_start`**, so `glass_a11y_snapshot`
   resolves its window immediately instead of returning `window not found` until the first `glass_click`
   activated the app. The `window not found` message also now suggests a remedy.

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -9,7 +9,7 @@
 use std::fmt::Write as _;
 
 use crate::error::Result;
-use crate::platform::WindowGeometry;
+use crate::platform::{Segment, WindowGeometry};
 
 /// Normalized accessibility role — the union of the AT-SPI / AX / UIA
 /// vocabularies. A backend maps its native role in; anything unmapped becomes
@@ -227,22 +227,29 @@ impl AxRect {
     /// element — the gesture that toggles a control (e.g. an iOS `UISwitch`) which does NOT actuate
     /// on a tap. Anchored at the same trailing point as [`Self::clamped_trailing_point`]; the span is
     /// ~1.5×the control height (`inset`), matching the proven idb swipe. `None` for an off-screen rect,
-    /// exactly like [`Self::clamped_center`]. The segment lies entirely in the trailing (right) region,
-    /// so it never begins in the left-edge back-swipe zone.
-    pub fn trailing_toggle_swipe(
-        &self,
-        win_w: u32,
-        win_h: u32,
-    ) -> Option<((i32, i32), (i32, i32))> {
+    /// exactly like [`Self::clamped_center`]. For a genuinely row-shaped input — the shape the
+    /// caller gates on (see `ROW_ASPECT` in `session::a11y`) — the segment lies entirely in the
+    /// trailing (right) region, clear of the left-edge back-swipe zone; that is an emergent
+    /// property of row-shaped bounds, not a guarantee this method makes for arbitrary input.
+    ///
+    /// Always left-to-right, never direction-aware — deliberately: on-device testing showed three
+    /// IDENTICAL left-to-right swipes alternate a `UISwitch` unchecked -> checked -> unchecked ->
+    /// checked. A short swipe here registers as a TOGGLE gesture, not a directional drag-to-value,
+    /// so there is no "swipe right to turn on" physics to encode — direction is irrelevant to the
+    /// outcome. Do not "fix" this into direction-dependent logic.
+    pub fn trailing_toggle_swipe(&self, win_w: u32, win_h: u32) -> Option<Segment> {
         let (left, top, right, bottom) = self.visible_intersection(win_w, win_h)?;
-        let cy = (top + bottom) / 2;
+        let (anchor_x, anchor_y) = self.clamped_trailing_point(win_w, win_h)?;
         let inset = bottom - top; // control ~this far from the trailing edge and ~this tall
-        let center_x = (left + right) / 2;
-        let anchor_x = (right - inset).max(center_x); // == clamped_trailing_point().x
-        let half = (inset * 3 / 4).max(1); // span 1.5*inset; matches the proven px-945->1074 swipe on inset 84; floor of 1 keeps a thin control's swipe non-zero-length
+        let half = (inset * 3 / 4).max(1); // span 1.5*inset; matches the proven ~951->1077 px swipe on inset 84; floor of 1 keeps a thin control's swipe non-zero-length
         let from_x = (anchor_x - half).max(left);
         let to_x = (anchor_x + half).min(right);
-        Some(((from_x, cy), (to_x, cy)))
+        Some(Segment {
+            from_x,
+            from_y: anchor_y,
+            to_x,
+            to_y: anchor_y,
+        })
     }
 }
 
@@ -795,19 +802,19 @@ mod tests {
             width: 990,
             height: 84,
         };
-        let ((fx, fy), (tx, ty)) = r.trailing_toggle_swipe(1206, 2622).expect("has a segment");
+        let seg = r.trailing_toggle_swipe(1206, 2622).expect("has a segment");
         // Anchor == clamped_trailing_point.x; swipe is centered on it, span = 1.5*inset(84) = 126.
         let (anchor_x, anchor_y) = r.clamped_trailing_point(1206, 2622).unwrap();
-        assert_eq!(fy, anchor_y);
+        assert_eq!(seg.from_y, anchor_y);
         assert_eq!(
-            ty, anchor_y,
+            seg.to_y, anchor_y,
             "horizontal swipe stays at the control's vertical center"
         );
-        assert!(fx < tx, "real left-to-right movement");
-        assert_eq!(fx, anchor_x - 63);
-        assert_eq!(tx, anchor_x + 63);
+        assert!(seg.from_x < seg.to_x, "real left-to-right movement");
+        assert_eq!(seg.from_x, anchor_x - 63);
+        assert_eq!(seg.to_x, anchor_x + 63);
         // Entirely in the right half — structurally clear of the left-edge back-swipe zone.
-        assert!(fx > (r.x + r.x + r.width as i32) / 2);
+        assert!(seg.from_x > (r.x + r.x + r.width as i32) / 2);
     }
 
     #[test]
@@ -822,10 +829,10 @@ mod tests {
             width: 20,
             height: 40,
         };
-        let ((fx, _), (tx, _)) = r.trailing_toggle_swipe(400, 400).unwrap();
-        assert_eq!(fx, 0, "from clamps to the left edge");
-        assert_eq!(tx, 20, "to clamps to the right edge");
-        assert!(fx < tx, "still a real left-to-right movement");
+        let seg = r.trailing_toggle_swipe(400, 400).unwrap();
+        assert_eq!(seg.from_x, 0, "from clamps to the left edge");
+        assert_eq!(seg.to_x, 20, "to clamps to the right edge");
+        assert!(seg.from_x < seg.to_x, "still a real left-to-right movement");
     }
 
     #[test]
@@ -837,9 +844,9 @@ mod tests {
             width: 100,
             height: 1,
         };
-        let ((fx, _), (tx, _)) = r.trailing_toggle_swipe(400, 400).unwrap();
+        let seg = r.trailing_toggle_swipe(400, 400).unwrap();
         assert!(
-            fx < tx,
+            seg.from_x < seg.to_x,
             "even a 1px-tall control yields a real swipe, not a zero-length tap"
         );
     }

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -239,7 +239,7 @@ impl AxRect {
         let inset = bottom - top; // control ~this far from the trailing edge and ~this tall
         let center_x = (left + right) / 2;
         let anchor_x = (right - inset).max(center_x); // == clamped_trailing_point().x
-        let half = inset * 3 / 4; // span 1.5*inset; matches the proven px-945->1074 swipe on inset 84
+        let half = (inset * 3 / 4).max(1); // span 1.5*inset; matches the proven px-945->1074 swipe on inset 84; floor of 1 keeps a thin control's swipe non-zero-length
         let from_x = (anchor_x - half).max(left);
         let to_x = (anchor_x + half).min(right);
         Some(((from_x, cy), (to_x, cy)))
@@ -812,15 +812,36 @@ mod tests {
 
     #[test]
     fn trailing_toggle_swipe_clamps_into_visible_bounds() {
-        // Control hard against the window's right edge: `to` clamps to `right`, `from` stays inside.
+        // A tall/narrow control (height > width/2): the anchor falls back to center_x and the
+        // half-span (1.5*inset) overshoots BOTH edges, so both clamps must fire.
+        // rect 20x40 in a 400x400 window: inset=40, center_x=10, anchor_x=10, half=30 →
+        // unclamped (-20, 40) → clamped to (0, 20). Deleting either clamp breaks these asserts.
         let r = AxRect {
             x: 0,
             y: 0,
-            width: 400,
+            width: 20,
             height: 40,
         };
         let ((fx, _), (tx, _)) = r.trailing_toggle_swipe(400, 400).unwrap();
-        assert!(fx >= 0 && tx <= 400 && fx < tx);
+        assert_eq!(fx, 0, "from clamps to the left edge");
+        assert_eq!(tx, 20, "to clamps to the right edge");
+        assert!(fx < tx, "still a real left-to-right movement");
+    }
+
+    #[test]
+    fn trailing_toggle_swipe_keeps_a_nonzero_span_for_a_thin_control() {
+        // A 1px-tall control: inset*3/4 == 0 without the .max(1) guard → a zero-length "tap".
+        let r = AxRect {
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 1,
+        };
+        let ((fx, _), (tx, _)) = r.trailing_toggle_swipe(400, 400).unwrap();
+        assert!(
+            fx < tx,
+            "even a 1px-tall control yields a real swipe, not a zero-length tap"
+        );
     }
 
     #[test]

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -222,6 +222,28 @@ impl AxRect {
         let x = (right - inset).max(center_x);
         Some((x, (top + bottom) / 2))
     }
+
+    /// Endpoints of a short horizontal swipe centered on the trailing control of a row-shaped
+    /// element — the gesture that toggles a control (e.g. an iOS `UISwitch`) which does NOT actuate
+    /// on a tap. Anchored at the same trailing point as [`Self::clamped_trailing_point`]; the span is
+    /// ~1.5×the control height (`inset`), matching the proven idb swipe. `None` for an off-screen rect,
+    /// exactly like [`Self::clamped_center`]. The segment lies entirely in the trailing (right) region,
+    /// so it never begins in the left-edge back-swipe zone.
+    pub fn trailing_toggle_swipe(
+        &self,
+        win_w: u32,
+        win_h: u32,
+    ) -> Option<((i32, i32), (i32, i32))> {
+        let (left, top, right, bottom) = self.visible_intersection(win_w, win_h)?;
+        let cy = (top + bottom) / 2;
+        let inset = bottom - top; // control ~this far from the trailing edge and ~this tall
+        let center_x = (left + right) / 2;
+        let anchor_x = (right - inset).max(center_x); // == clamped_trailing_point().x
+        let half = inset * 3 / 4; // span 1.5*inset; matches the proven px-945->1074 swipe on inset 84
+        let from_x = (anchor_x - half).max(left);
+        let to_x = (anchor_x + half).min(right);
+        Some(((from_x, cy), (to_x, cy)))
+    }
 }
 
 /// A synthetic node id, assigned by `glass-core` (not the backend) in pre-order
@@ -761,6 +783,55 @@ mod tests {
             height: 20,
         };
         assert_eq!(r.clamped_trailing_point(400, 400), None);
+    }
+
+    #[test]
+    fn trailing_toggle_swipe_crosses_the_trailing_control() {
+        // A row-shaped switch (idb's whole-cell frame): 990 wide, 84 tall, at (108,439),
+        // window 1206x2622 — the rc3 KeyboardVisceral geometry.
+        let r = AxRect {
+            x: 108,
+            y: 439,
+            width: 990,
+            height: 84,
+        };
+        let ((fx, fy), (tx, ty)) = r.trailing_toggle_swipe(1206, 2622).expect("has a segment");
+        // Anchor == clamped_trailing_point.x; swipe is centered on it, span = 1.5*inset(84) = 126.
+        let (anchor_x, anchor_y) = r.clamped_trailing_point(1206, 2622).unwrap();
+        assert_eq!(fy, anchor_y);
+        assert_eq!(
+            ty, anchor_y,
+            "horizontal swipe stays at the control's vertical center"
+        );
+        assert!(fx < tx, "real left-to-right movement");
+        assert_eq!(fx, anchor_x - 63);
+        assert_eq!(tx, anchor_x + 63);
+        // Entirely in the right half — structurally clear of the left-edge back-swipe zone.
+        assert!(fx > (r.x + r.x + r.width as i32) / 2);
+    }
+
+    #[test]
+    fn trailing_toggle_swipe_clamps_into_visible_bounds() {
+        // Control hard against the window's right edge: `to` clamps to `right`, `from` stays inside.
+        let r = AxRect {
+            x: 0,
+            y: 0,
+            width: 400,
+            height: 40,
+        };
+        let ((fx, _), (tx, _)) = r.trailing_toggle_swipe(400, 400).unwrap();
+        assert!(fx >= 0 && tx <= 400 && fx < tx);
+    }
+
+    #[test]
+    fn trailing_toggle_swipe_rejects_offscreen_like_clamped_center() {
+        let r = AxRect {
+            x: 500,
+            y: 500,
+            width: 40,
+            height: 20,
+        };
+        assert_eq!(r.trailing_toggle_swipe(400, 400), None);
     }
 
     #[test]

--- a/crates/glass-core/src/platform.rs
+++ b/crates/glass-core/src/platform.rs
@@ -258,11 +258,12 @@ pub trait Platform {
     /// Whether this backend reports a checkable element's a11y frame as the whole containing
     /// *row*, with the actual control at the row's **trailing** edge — as iOS/idb does for a
     /// `UISwitch` in a grouped table cell. When true, `click_element` aims a row-shaped
-    /// checkable's tap at the trailing control instead of the geometric center, which would
-    /// otherwise land on the inert label and no-op. Default `false`: every other backend
-    /// reports a switch's frame as the tight control (its center is the right target), so the
-    /// trailing-aim would misfire on a wide *labeled* checkbox whose indicator is at the
-    /// leading edge — hence this is opt-in per backend rather than a geometry heuristic.
+    /// checkable's actuation at the trailing control (a swipe, since a tap doesn't actuate a
+    /// UISwitch) instead of the geometric center, which would otherwise land on the inert label
+    /// and no-op. Default `false`: every other backend reports a switch's frame as the tight
+    /// control (its center is the right target), so the trailing-aim would misfire on a wide
+    /// *labeled* checkbox whose indicator is at the leading edge — hence this is opt-in per
+    /// backend rather than a geometry heuristic.
     fn a11y_toggle_control_at_trailing_edge(&self) -> bool {
         false
     }

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -7,6 +7,10 @@ use super::*;
 /// center.
 const ROW_ASPECT: u32 = 4;
 
+/// Duration of the trailing-toggle swipe (ms) — long enough for idb's HID swipe to register as a
+/// pan on a UISwitch; matches the proven ~250ms on-device swipe.
+const TOGGLE_SWIPE_MS: u64 = 250;
+
 impl Glass {
     /// Snapshot the active window's accessibility tree (normalized, window-
     /// relative, ids assigned by the core). Caches it for `click_element`.
@@ -55,8 +59,8 @@ impl Glass {
     }
 
     /// Click the element with id `id` from the most recent `a11y_snapshot` via the normal
-    /// pointer path — the center of its bounds, or the trailing control for a row-shaped
-    /// checkable (see [`AxRect::clamped_trailing_point`]).
+    /// pointer path — the center of its bounds, or a swipe across the trailing control for a
+    /// row-shaped checkable on a trailing-toggle backend (see [`AxRect::trailing_toggle_swipe`]).
     pub fn click_element(&mut self, id: AxNodeId) -> Result<()> {
         let t = std::time::Instant::now();
         let element = self.element_ref(id);
@@ -123,28 +127,41 @@ impl Glass {
         }
         // A switch whose backend reports the whole row as its frame with the control at the
         // trailing edge (iOS/idb) is mis-tapped at the geometric center — that lands on the inert
-        // label. For such a backend, aim a row-shaped checkable's tap at the trailing control.
-        // Gated on the backend capability, NOT geometry alone: a wide *labeled* checkbox on a
-        // desktop backend is also row-shaped but has its indicator at the LEADING edge, so the
-        // trailing-aim must not apply there. The row-shape test uses the raw-bounds aspect as a
-        // cheap pre-filter; `clamped_trailing_point` derives its inset from the clamped visible
-        // height.
-        let (x, y) = if checkable
+        // label, and even aimed at the control a `UISwitch` does NOT actuate on a tap: it needs a
+        // short swipe (see `AxRect::trailing_toggle_swipe`). For such a backend, swipe a
+        // row-shaped checkable's trailing control instead of clicking it. Gated on the backend
+        // capability, NOT geometry alone: a wide *labeled* checkbox on a desktop backend is also
+        // row-shaped but has its indicator at the LEADING edge, so the trailing-aim must not
+        // apply there. The row-shape test uses the raw-bounds aspect as a cheap pre-filter;
+        // `trailing_toggle_swipe` derives its inset from the clamped visible height.
+        let row_shaped_toggle = checkable
             && trailing_toggle_backend
-            && bounds.width > bounds.height.saturating_mul(ROW_ASPECT)
-        {
-            bounds.clamped_trailing_point(active_geo.width, active_geo.height)
+            && bounds.width > bounds.height.saturating_mul(ROW_ASPECT);
+        if row_shaped_toggle {
+            let (from, to) = bounds
+                .trailing_toggle_swipe(active_geo.width, active_geo.height)
+                .ok_or(GlassError::AxElementNotClickable(id.0))?;
+            self.pointer_inner(&PointerEvent::Drag {
+                from_x: from.0,
+                from_y: from.1,
+                to_x: to.0,
+                to_y: to.1,
+                duration_ms: TOGGLE_SWIPE_MS,
+                button: MouseButton::Left,
+                modifiers: vec![],
+            })
         } else {
-            bounds.clamped_center(active_geo.width, active_geo.height)
+            let (x, y) = bounds
+                .clamped_center(active_geo.width, active_geo.height)
+                .ok_or(GlassError::AxElementNotClickable(id.0))?;
+            self.pointer_inner(&PointerEvent::Click {
+                x,
+                y,
+                button: MouseButton::Left,
+                count: 1,
+                modifiers: vec![],
+            })
         }
-        .ok_or(GlassError::AxElementNotClickable(id.0))?;
-        self.pointer_inner(&PointerEvent::Click {
-            x,
-            y,
-            button: MouseButton::Left,
-            count: 1,
-            modifiers: vec![],
-        })
     }
 
     /// Set the value/text of element `id` (from the latest `a11y_snapshot`) via the
@@ -962,11 +979,13 @@ mod tests {
     }
 
     #[test]
-    fn click_element_taps_trailing_edge_for_a_row_shaped_checkable() {
+    fn click_element_swipes_the_trailing_control_for_a_row_shaped_checkable() {
         // A checkable node whose bounds are row-shaped (w > 4h) — a backend (iOS/idb) that
-        // reports the whole cell as a switch's frame. The click must land near the trailing
-        // control (right of center); a non-checkable node of the SAME bounds still clicks center.
+        // reports the whole cell as a switch's frame. A `UISwitch` does not actuate on a tap, so
+        // the click must emit a swipe across the trailing control instead of a `Click`; a
+        // non-checkable node of the SAME bounds still clicks center.
         let clicks = Arc::new(Mutex::new(Vec::new()));
+        let drags: Arc<Mutex<Vec<PointerEvent>>> = Arc::new(Mutex::new(Vec::new()));
         let bounds = AxRect {
             x: 10,
             y: 10,
@@ -1007,23 +1026,48 @@ mod tests {
         // A backend that frames a switch as its whole row (iOS/idb) opts into the trailing-aim.
         let platform = FakePlatform::new(100, 100)
             .with_click_log(clicks.clone())
+            .with_drag_log(drags.clone())
             .with_trailing_toggle_backend();
         let mut g = glass_with_a11y(platform, AxTree { root, count: 0 });
         g.start(&spec()).unwrap();
         g.a11y_snapshot().unwrap();
 
-        // node #1 = the row-shaped checkable → trailing point (right of center).
+        // node #1 = the row-shaped checkable → a swipe across the trailing control, not a click.
         g.click_element(AxNodeId(1)).unwrap();
-        let trailing = bounds.clamped_trailing_point(100, 100).unwrap();
-        assert_eq!(clicks.lock().unwrap().last().copied(), Some(trailing));
-        assert!(trailing.0 > bounds.clamped_center(100, 100).unwrap().0);
+        let expected = bounds.trailing_toggle_swipe(100, 100).unwrap();
+        {
+            let d = drags.lock().unwrap();
+            assert_eq!(d.len(), 1, "a swipe was emitted");
+            match d[0] {
+                PointerEvent::Drag {
+                    from_x,
+                    from_y,
+                    to_x,
+                    to_y,
+                    ..
+                } => {
+                    assert_eq!((from_x, from_y), expected.0);
+                    assert_eq!((to_x, to_y), expected.1);
+                }
+                ref e => panic!("expected a Drag, got {e:?}"),
+            }
+        }
+        assert!(
+            clicks.lock().unwrap().is_empty(),
+            "the row-shaped checkable must swipe, not click"
+        );
 
-        // node #2 = the non-checkable row of identical bounds → geometric center (gate needs
-        // checkable, so a plain wide list row is unaffected).
+        // node #2 = the non-checkable row of identical bounds → geometric center click (gate
+        // needs checkable, so a plain wide list row is unaffected).
         g.click_element(AxNodeId(2)).unwrap();
         assert_eq!(
             clicks.lock().unwrap().last().copied(),
             bounds.clamped_center(100, 100)
+        );
+        assert_eq!(
+            drags.lock().unwrap().len(),
+            1,
+            "the non-checkable row must not also emit a swipe"
         );
     }
 

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -211,6 +211,38 @@ impl Glass {
         if target.role == AxRole::ComboBox {
             return self.set_combo_value(id, &target, text);
         }
+        // A trailing-toggle backend (iOS) has no accessibility value-set; a checkable there is
+        // driven by the same trailing-edge swipe as click_element. Set-to-target = toggle iff
+        // current != target, then verify (never a silent ok). Read the needed state and DROP the
+        // `&self` borrow before calling click_element_inner (which needs `&mut self`).
+        let (trailing, node_state) = {
+            let s = self.require_active()?;
+            (
+                s.platform.a11y_toggle_control_at_trailing_edge(),
+                s.last_ax
+                    .as_ref()
+                    .and_then(|t| t.find(id))
+                    .map(|n| (n.states.checkable, n.states.checked)),
+            )
+        };
+        if trailing {
+            if let (Some((true, checked)), Some(want)) = (node_state, parse_bool(text)) {
+                if checked == want {
+                    return Ok(()); // already in the requested state
+                }
+                self.click_element_inner(id)?; // the swipe toggle
+                self.settle_for_popup();
+                let tree = self.a11y_snapshot()?;
+                let now = find_named(&tree.root, target.name.as_deref())
+                    .map(|n| n.states.checkable && n.states.checked == want)
+                    .unwrap_or(false);
+                return if now {
+                    Ok(())
+                } else {
+                    Err(GlassError::AxValueNotApplied(id.0))
+                };
+            }
+        }
         let s = self.active_mut()?;
         s.accessibility
             .as_mut()
@@ -298,6 +330,26 @@ fn find_role(node: &AxNode, role: AxRole) -> Option<&AxNode> {
         return Some(node);
     }
     node.children.iter().find_map(|c| find_role(c, role))
+}
+
+/// Parse a `set_value` boolean for a switch/checkbox. Case-insensitive; `None` for anything else
+/// (which falls through to the backend's normal `set_value` path).
+fn parse_bool(text: &str) -> Option<bool> {
+    match text.trim().to_ascii_lowercase().as_str() {
+        "true" | "on" | "1" | "yes" => Some(true),
+        "false" | "off" | "0" | "no" => Some(false),
+        _ => None,
+    }
+}
+
+/// First node whose accessible name equals `name` (case-sensitive), pre-order. `None` if `name`
+/// is `None` (a nameless element cannot be re-found after a snapshot → caller reports not-applied).
+fn find_named<'a>(root: &'a AxNode, name: Option<&str>) -> Option<&'a AxNode> {
+    let name = name?;
+    if root.name.as_deref() == Some(name) {
+        return Some(root);
+    }
+    root.children.iter().find_map(|c| find_named(c, Some(name)))
 }
 
 fn rect_center(r: &crate::accessibility::AxRect) -> (i64, i64) {
@@ -1443,5 +1495,105 @@ mod tests {
             g.set_value(AxNodeId(1), "x").unwrap_err(),
             GlassError::AxElementNotEditable(1)
         ));
+    }
+
+    /// A row-shaped CheckBox "Sw" (300x30 at the origin) as the single child of a root Window —
+    /// the iOS-switch fixture shared by the trailing-toggle `set_value` tests below. Pre-order
+    /// numbering gives the switch id 1.
+    fn sw(checked: bool) -> AxTree {
+        let switch = AxNode {
+            id: AxNodeId(0),
+            role: AxRole::CheckBox,
+            raw_role: "switch".into(),
+            name: Some("Sw".into()),
+            value: None,
+            states: AxStates {
+                checkable: true,
+                checked,
+                ..Default::default()
+            },
+            bounds: Some(AxRect {
+                x: 0,
+                y: 0,
+                width: 300,
+                height: 30,
+            }),
+            children: vec![],
+        };
+        let root = AxNode {
+            id: AxNodeId(0),
+            role: AxRole::Window,
+            raw_role: "frame".into(),
+            name: Some("Win".into()),
+            value: None,
+            states: AxStates::default(),
+            bounds: Some(AxRect {
+                x: 0,
+                y: 0,
+                width: 400,
+                height: 400,
+            }),
+            children: vec![switch],
+        };
+        AxTree { root, count: 0 }
+    }
+
+    #[test]
+    fn set_value_true_swipes_an_unchecked_ios_switch_and_verifies() {
+        let drags: Arc<Mutex<Vec<PointerEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let platform = FakePlatform::new(400, 400)
+            .with_drag_log(drags.clone())
+            .with_trailing_toggle_backend();
+        // Snapshot #1 (cached read) = unchecked; snapshot #2 (verify re-read) = checked.
+        let mut g = glass_with_a11y_seq(platform, vec![sw(false), sw(true)]);
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot().unwrap(); // caches unchecked
+
+        g.set_value(AxNodeId(1), "true").unwrap();
+
+        assert_eq!(drags.lock().unwrap().len(), 1, "a toggle swipe was emitted");
+    }
+
+    #[test]
+    fn set_value_true_is_a_noop_when_already_checked() {
+        let drags: Arc<Mutex<Vec<PointerEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let platform = FakePlatform::new(400, 400)
+            .with_drag_log(drags.clone())
+            .with_trailing_toggle_backend();
+        let mut g = glass_with_a11y(platform, sw(true));
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot().unwrap();
+
+        g.set_value(AxNodeId(1), "true").unwrap();
+
+        assert!(
+            drags.lock().unwrap().is_empty(),
+            "already true -> no actuation"
+        );
+    }
+
+    #[test]
+    fn set_value_errors_when_the_toggle_does_not_apply() {
+        let platform = FakePlatform::new(400, 400)
+            .with_drag_log(Arc::new(Mutex::new(Vec::new())))
+            .with_trailing_toggle_backend();
+        // Both reads unchecked: the swipe "did not take" -> honest error, not false ok.
+        let mut g = glass_with_a11y_seq(platform, vec![sw(false), sw(false)]);
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot().unwrap();
+
+        let err = g.set_value(AxNodeId(1), "true").unwrap_err();
+        assert!(matches!(err, GlassError::AxValueNotApplied(_)));
+    }
+
+    #[test]
+    fn parse_bool_accepts_the_documented_spellings() {
+        for t in ["true", "on", "1", "yes", "TRUE"] {
+            assert_eq!(parse_bool(t), Some(true));
+        }
+        for f in ["false", "off", "0", "no", "OFF"] {
+            assert_eq!(parse_bool(f), Some(false));
+        }
+        assert_eq!(parse_bool("banana"), None);
     }
 }

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -233,8 +233,8 @@ impl Glass {
                 self.click_element_inner(id)?; // the swipe toggle
                 self.settle_for_popup();
                 let tree = self.a11y_snapshot()?;
-                let now = find_named(&tree.root, target.name.as_deref())
-                    .map(|n| n.states.checkable && n.states.checked == want)
+                let now = find_checkable_near(&tree.root, target.bounds.as_ref())
+                    .map(|n| n.states.checked == want)
                     .unwrap_or(false);
                 return if now {
                     Ok(())
@@ -342,16 +342,6 @@ fn parse_bool(text: &str) -> Option<bool> {
     }
 }
 
-/// First node whose accessible name equals `name` (case-sensitive), pre-order. `None` if `name`
-/// is `None` (a nameless element cannot be re-found after a snapshot → caller reports not-applied).
-fn find_named<'a>(root: &'a AxNode, name: Option<&str>) -> Option<&'a AxNode> {
-    let name = name?;
-    if root.name.as_deref() == Some(name) {
-        return Some(root);
-    }
-    root.children.iter().find_map(|c| find_named(c, Some(name)))
-}
-
 fn rect_center(r: &crate::accessibility::AxRect) -> (i64, i64) {
     (
         r.x as i64 + r.width as i64 / 2,
@@ -388,6 +378,39 @@ fn find_combo_near<'a>(
     walk(root, tx, ty, &mut best);
     best.map(|(n, _)| n)
         .or_else(|| find_role(root, AxRole::ComboBox))
+}
+
+/// The CHECKABLE node nearest `bounds` — disambiguates same-named checkable siblings (e.g. two
+/// generic `UISwitch` rows) when re-locating a toggled switch after a re-snapshot, since ids
+/// don't survive it either. Matching by name alone risks latching onto a same-named sibling
+/// that already happens to sit in the wanted state, turning a no-op sibling into a false `Ok`
+/// for the element that was actually supposed to move — bounds are the disambiguator instead,
+/// same as `find_combo_near` uses for combos. Unlike `find_combo_near`, there is no
+/// single-element fallback when `bounds` is `None`: a toggle verify with no captured bounds
+/// must error rather than risk matching the wrong same-named node.
+fn find_checkable_near<'a>(
+    root: &'a AxNode,
+    bounds: Option<&crate::accessibility::AxRect>,
+) -> Option<&'a AxNode> {
+    let t = bounds?;
+    let (tx, ty) = rect_center(t);
+    fn walk<'a>(node: &'a AxNode, tx: i64, ty: i64, best: &mut Option<(&'a AxNode, i64)>) {
+        if node.states.checkable {
+            if let Some(b) = &node.bounds {
+                let (cx, cy) = rect_center(b);
+                let d = (cx - tx).pow(2) + (cy - ty).pow(2);
+                if best.is_none_or(|(_, bd)| d < bd) {
+                    *best = Some((node, d));
+                }
+            }
+        }
+        for c in &node.children {
+            walk(c, tx, ty, best);
+        }
+    }
+    let mut best = None;
+    walk(root, tx, ty, &mut best);
+    best.map(|(n, _)| n)
 }
 
 /// The open (expanded) ComboBox, if any — disambiguates the one whose popup is up.
@@ -1584,6 +1607,146 @@ mod tests {
 
         let err = g.set_value(AxNodeId(1), "true").unwrap_err();
         assert!(matches!(err, GlassError::AxValueNotApplied(_)));
+    }
+
+    /// Two same-named ("Sw") row-shaped switches at DIFFERENT bounds — a `sibling` listed
+    /// before the `target` (so a naive first-match-by-name search hits the sibling first,
+    /// the exact silent-success risk `find_checkable_near` exists to rule out), and a
+    /// `target` at the bounds `set_value` actually addresses. Pre-order id assignment gives
+    /// the sibling id 1 and the target id 2. Shared by the disambiguation tests below.
+    fn two_switches(sibling_checked: bool, target_checked: bool) -> AxTree {
+        let make = |checked: bool, y: i32| AxNode {
+            id: AxNodeId(0),
+            role: AxRole::CheckBox,
+            raw_role: "switch".into(),
+            name: Some("Sw".into()),
+            value: None,
+            states: AxStates {
+                checkable: true,
+                checked,
+                ..Default::default()
+            },
+            bounds: Some(AxRect {
+                x: 0,
+                y,
+                width: 300,
+                height: 30,
+            }),
+            children: vec![],
+        };
+        let sibling = make(sibling_checked, 0);
+        let target = make(target_checked, 200);
+        let root = AxNode {
+            id: AxNodeId(0),
+            role: AxRole::Window,
+            raw_role: "frame".into(),
+            name: Some("Win".into()),
+            value: None,
+            states: AxStates::default(),
+            bounds: Some(AxRect {
+                x: 0,
+                y: 0,
+                width: 400,
+                height: 400,
+            }),
+            children: vec![sibling, target],
+        };
+        AxTree { root, count: 0 }
+    }
+
+    #[test]
+    fn set_value_true_verifies_the_target_by_bounds_when_a_same_named_sibling_is_already_checked() {
+        // The sibling "Sw" is already checked (the wanted state) throughout; only the TARGET
+        // flips false -> true on the verify re-snapshot. A name-only verify (the old,
+        // pre-order-first `find_named`) would match the sibling — listed first — and return Ok
+        // regardless of whether the target itself ever moved. The bounds-nearest verify must
+        // instead confirm THIS node (the target, at its own captured bounds) reached the
+        // wanted state.
+        let drags: Arc<Mutex<Vec<PointerEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let platform = FakePlatform::new(400, 400)
+            .with_drag_log(drags.clone())
+            .with_trailing_toggle_backend();
+        let mut g = glass_with_a11y_seq(
+            platform,
+            vec![two_switches(true, false), two_switches(true, true)],
+        );
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot().unwrap(); // caches: sibling already checked, target unchecked
+
+        // Target is id 2 (sibling listed first gets id 1; see `two_switches`).
+        g.set_value(AxNodeId(2), "true").unwrap();
+
+        assert_eq!(drags.lock().unwrap().len(), 1, "a toggle swipe was emitted");
+    }
+
+    #[test]
+    fn set_value_true_errors_when_only_a_same_named_sibling_is_checked() {
+        // Same same-named-sibling setup, but this time the swipe "does not take": the target
+        // stays unchecked on the verify re-snapshot while the sibling remains (coincidentally)
+        // already checked. A name-only verify would match the sibling first and return a false
+        // Ok — exactly the silent-success bug this fixture guards against. The bounds-nearest
+        // verify must instead see the ACTUAL target still unchecked and report
+        // `AxValueNotApplied`, proving a same-name collision can never fake a false ok.
+        let platform = FakePlatform::new(400, 400)
+            .with_drag_log(Arc::new(Mutex::new(Vec::new())))
+            .with_trailing_toggle_backend();
+        let mut g = glass_with_a11y_seq(
+            platform,
+            vec![two_switches(true, false), two_switches(true, false)],
+        );
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot().unwrap();
+
+        let err = g.set_value(AxNodeId(2), "true").unwrap_err();
+        assert!(matches!(err, GlassError::AxValueNotApplied(2)));
+    }
+
+    #[test]
+    fn set_value_on_a_non_checkable_element_ignores_the_trailing_toggle_gate() {
+        // The iOS toggle gate (`set_value_inner`'s trailing-toggle branch) must only intercept
+        // CHECKABLE elements. A non-checkable element (e.g. a plain button) on a
+        // trailing-toggle backend must fall straight through to the normal accessibility
+        // `set_value` delegate path, unchanged — no swipe/drag is ever emitted, and the
+        // backend's `set_value` is the one that actually runs.
+        let drags: Arc<Mutex<Vec<PointerEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let log = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("baselines");
+        std::mem::forget(dir);
+        let log2 = log.clone();
+        let mut held: Option<Backend> = Some(Backend {
+            platform: Box::new(
+                FakePlatform::new(100, 100)
+                    .with_drag_log(drags.clone())
+                    .with_trailing_toggle_backend(),
+            ),
+            accessibility: Some(Box::new(FakeAccessibility {
+                tree: fake_tree(), // #1 is a non-checkable Button "Save"
+                set_log: log2,
+                set_fail: false,
+            })),
+        });
+        let factory: PlatformFactory = Box::new(move |_b| {
+            held.take()
+                .ok_or_else(|| GlassError::Backend("twice".into()))
+        });
+        let mut g = Glass::new(factory, "x11".into(), BaselineStore::new(root), 100);
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot().unwrap();
+
+        g.set_value(AxNodeId(1), "hello").unwrap();
+
+        let calls = log.lock().unwrap();
+        assert_eq!(
+            calls.len(),
+            1,
+            "the delegate accessibility set_value path was taken"
+        );
+        assert_eq!(calls[0].1, "hello");
+        assert!(
+            drags.lock().unwrap().is_empty(),
+            "a non-checkable element must never trigger the toggle swipe"
+        );
     }
 
     #[test]

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -3,13 +3,20 @@ use super::*;
 
 /// A checkable element wider than this multiple of its height is treated as "row-shaped". On a
 /// backend that frames a switch as its whole row (`Platform::a11y_toggle_control_at_trailing_edge`),
-/// `click_element` aims a row-shaped checkable's tap at the trailing control instead of the row
+/// `click_element` swipes a row-shaped checkable's trailing control instead of clicking the row
 /// center.
 const ROW_ASPECT: u32 = 4;
 
 /// Duration of the trailing-toggle swipe (ms) — long enough for idb's HID swipe to register as a
 /// pan on a UISwitch; matches the proven ~250ms on-device swipe.
 const TOGGLE_SWIPE_MS: u64 = 250;
+
+/// Poll cadence for `set_value`'s post-toggle verify: how often to re-snapshot while waiting for
+/// the swiped switch to read back the wanted state.
+const TOGGLE_VERIFY_INTERVAL_MS: u64 = 50;
+/// Bound on the post-toggle verify poll — generous enough to absorb a lagging a11y-tree update
+/// under load without turning a real actuation failure into an indefinite hang.
+const TOGGLE_VERIFY_TIMEOUT_MS: u64 = 2000;
 
 impl Glass {
     /// Snapshot the active window's accessibility tree (normalized, window-
@@ -138,14 +145,14 @@ impl Glass {
             && trailing_toggle_backend
             && bounds.width > bounds.height.saturating_mul(ROW_ASPECT);
         if row_shaped_toggle {
-            let (from, to) = bounds
+            let seg = bounds
                 .trailing_toggle_swipe(active_geo.width, active_geo.height)
                 .ok_or(GlassError::AxElementNotClickable(id.0))?;
             self.pointer_inner(&PointerEvent::Drag {
-                from_x: from.0,
-                from_y: from.1,
-                to_x: to.0,
-                to_y: to.1,
+                from_x: seg.from_x,
+                from_y: seg.from_y,
+                to_x: seg.to_x,
+                to_y: seg.to_y,
                 duration_ms: TOGGLE_SWIPE_MS,
                 button: MouseButton::Left,
                 modifiers: vec![],
@@ -211,10 +218,14 @@ impl Glass {
         if target.role == AxRole::ComboBox {
             return self.set_combo_value(id, &target, text);
         }
-        // A trailing-toggle backend (iOS) has no accessibility value-set; a checkable there is
-        // driven by the same trailing-edge swipe as click_element. Set-to-target = toggle iff
-        // current != target, then verify (never a silent ok). Read the needed state and DROP the
-        // `&self` borrow before calling click_element_inner (which needs `&mut self`).
+        // iOS's value-set (tap+type) doesn't apply to a checkable — a tap doesn't toggle a
+        // UISwitch and there's no text to type — so a checkable is driven by the trailing-edge
+        // swipe instead. Set-to-target = toggle iff current != target, then verify by a bounded
+        // poll (never a silent ok). Gated on `checkable` alone (NOT row-shape): a checkable
+        // switch that isn't row-shaped on a trailing backend must still fail-safe through this
+        // branch (parse/verify → error) rather than fall through to the delegate below, which
+        // would silently tap the inert label and type into nothing. Read the needed state and
+        // DROP the `&self` borrow before calling click_element_inner (which needs `&mut self`).
         let (trailing, node_state) = {
             let s = self.require_active()?;
             (
@@ -222,25 +233,36 @@ impl Glass {
                 s.last_ax
                     .as_ref()
                     .and_then(|t| t.find(id))
-                    .map(|n| (n.states.checkable, n.states.checked)),
+                    .map(|n| n.states),
             )
         };
         if trailing {
-            if let (Some((true, checked)), Some(want)) = (node_state, parse_bool(text)) {
-                if checked == want {
-                    return Ok(()); // already in the requested state
+            if let Some(st) = node_state {
+                if st.checkable {
+                    // A checkable switch expects a boolean; unrecognized text must NOT fall
+                    // through to the tap+type delegate (which would silently no-op a UISwitch).
+                    // Erroring here preserves the "never a silent ok" invariant.
+                    let want = parse_bool(text).ok_or(GlassError::AxValueNotApplied(id.0))?;
+                    if st.checked == want {
+                        return Ok(()); // truthful no-op, no actuation
+                    }
+                    self.click_element_inner(id)?; // the toggle actuation (a swipe for a row-shaped control)
+                    let outcome = crate::poll::poll_until(
+                        TOGGLE_VERIFY_INTERVAL_MS,
+                        TOGGLE_VERIFY_TIMEOUT_MS,
+                        || {
+                            let tree = self.a11y_snapshot()?;
+                            let now = find_checkable_near(&tree.root, target.bounds.as_ref())
+                                .is_some_and(|n| n.states.checked == want);
+                            Ok(now.then_some(()))
+                        },
+                    )?;
+                    return if outcome.value.is_some() {
+                        Ok(())
+                    } else {
+                        Err(GlassError::AxValueNotApplied(id.0))
+                    };
                 }
-                self.click_element_inner(id)?; // the swipe toggle
-                self.settle_for_popup();
-                let tree = self.a11y_snapshot()?;
-                let now = find_checkable_near(&tree.root, target.bounds.as_ref())
-                    .map(|n| n.states.checked == want)
-                    .unwrap_or(false);
-                return if now {
-                    Ok(())
-                } else {
-                    Err(GlassError::AxValueNotApplied(id.0))
-                };
             }
         }
         let s = self.active_mut()?;
@@ -1119,10 +1141,15 @@ mod tests {
                     from_y,
                     to_x,
                     to_y,
+                    duration_ms,
                     ..
                 } => {
-                    assert_eq!((from_x, from_y), expected.0);
-                    assert_eq!((to_x, to_y), expected.1);
+                    assert_eq!((from_x, from_y), (expected.from_x, expected.from_y));
+                    assert_eq!((to_x, to_y), (expected.to_x, expected.to_y));
+                    assert_eq!(
+                        duration_ms, TOGGLE_SWIPE_MS,
+                        "a too-short duration would make idb treat this as a tap, not a swipe"
+                    );
                 }
                 ref e => panic!("expected a Drag, got {e:?}"),
             }
@@ -1609,6 +1636,45 @@ mod tests {
         assert!(matches!(err, GlassError::AxValueNotApplied(_)));
     }
 
+    #[test]
+    fn set_value_false_swipes_a_checked_ios_switch_and_verifies() {
+        // The mirror of `set_value_true_swipes_an_unchecked_ios_switch_and_verifies` — proves
+        // the toggle path handles a checked -> unchecked transition too, not just off -> on.
+        // The fixed swipe is a TOGGLE gesture (proven on-device: identical swipes alternate
+        // off/on/off/on — see `AxRect::trailing_toggle_swipe`), so the same swipe that turns a
+        // switch on also turns it off; there is no direction logic to exercise separately.
+        let drags: Arc<Mutex<Vec<PointerEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let platform = FakePlatform::new(400, 400)
+            .with_drag_log(drags.clone())
+            .with_trailing_toggle_backend();
+        // Snapshot #1 (cached read) = checked; snapshot #2 (verify re-read) = unchecked.
+        let mut g = glass_with_a11y_seq(platform, vec![sw(true), sw(false)]);
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot().unwrap(); // caches checked
+
+        g.set_value(AxNodeId(1), "false").unwrap();
+
+        assert_eq!(drags.lock().unwrap().len(), 1, "a toggle swipe was emitted");
+    }
+
+    #[test]
+    fn set_value_false_is_a_noop_when_already_unchecked() {
+        let drags: Arc<Mutex<Vec<PointerEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let platform = FakePlatform::new(400, 400)
+            .with_drag_log(drags.clone())
+            .with_trailing_toggle_backend();
+        let mut g = glass_with_a11y(platform, sw(false));
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot().unwrap();
+
+        g.set_value(AxNodeId(1), "false").unwrap();
+
+        assert!(
+            drags.lock().unwrap().is_empty(),
+            "already false -> no actuation"
+        );
+    }
+
     /// Two same-named ("Sw") row-shaped switches at DIFFERENT bounds — a `sibling` listed
     /// before the `target` (so a naive first-match-by-name search hits the sibling first,
     /// the exact silent-success risk `find_checkable_near` exists to rule out), and a
@@ -1704,10 +1770,14 @@ mod tests {
     #[test]
     fn set_value_on_a_non_checkable_element_ignores_the_trailing_toggle_gate() {
         // The iOS toggle gate (`set_value_inner`'s trailing-toggle branch) must only intercept
-        // CHECKABLE elements. A non-checkable element (e.g. a plain button) on a
-        // trailing-toggle backend must fall straight through to the normal accessibility
-        // `set_value` delegate path, unchanged — no swipe/drag is ever emitted, and the
-        // backend's `set_value` is the one that actually runs.
+        // CHECKABLE elements — `checkable` is the discriminator, not "did the text parse as a
+        // bool". Uses a BOOLEAN value ("true") deliberately: with non-bool text, a dropped
+        // `checkable` guard is invisible (both arms fall through to the delegate the same way),
+        // so this must exercise the boolean path to actually catch a removed guard. A boolean
+        // value on a non-checkable element (e.g. a plain button) must still fall straight
+        // through to the normal accessibility `set_value` delegate path, unchanged — no
+        // swipe/drag is ever emitted, and the backend's `set_value` is the one that actually
+        // runs.
         let drags: Arc<Mutex<Vec<PointerEvent>>> = Arc::new(Mutex::new(Vec::new()));
         let log = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let dir = tempfile::tempdir().unwrap();
@@ -1734,7 +1804,7 @@ mod tests {
         g.start(&spec()).unwrap();
         g.a11y_snapshot().unwrap();
 
-        g.set_value(AxNodeId(1), "hello").unwrap();
+        g.set_value(AxNodeId(1), "true").unwrap();
 
         let calls = log.lock().unwrap();
         assert_eq!(
@@ -1742,10 +1812,55 @@ mod tests {
             1,
             "the delegate accessibility set_value path was taken"
         );
-        assert_eq!(calls[0].1, "hello");
+        assert_eq!(calls[0].1, "true");
         assert!(
             drags.lock().unwrap().is_empty(),
             "a non-checkable element must never trigger the toggle swipe"
+        );
+    }
+
+    #[test]
+    fn set_value_on_a_checkable_rejects_non_boolean_text() {
+        // FIX 1's core invariant: a non-boolean value on a checkable+trailing target must ERROR,
+        // never fall through to the tap+type delegate (which would tap the inert label, type
+        // into nothing, and still report Ok — the exact silent success this branch exists to
+        // kill). No actuation (no swipe) and no delegate call either.
+        let drags: Arc<Mutex<Vec<PointerEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let log = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("baselines");
+        std::mem::forget(dir);
+        let log2 = log.clone();
+        let mut held: Option<Backend> = Some(Backend {
+            platform: Box::new(
+                FakePlatform::new(400, 400)
+                    .with_drag_log(drags.clone())
+                    .with_trailing_toggle_backend(),
+            ),
+            accessibility: Some(Box::new(FakeAccessibility {
+                tree: sw(false), // #1 is the checkable switch "Sw"
+                set_log: log2,
+                set_fail: false,
+            })),
+        });
+        let factory: PlatformFactory = Box::new(move |_b| {
+            held.take()
+                .ok_or_else(|| GlassError::Backend("twice".into()))
+        });
+        let mut g = Glass::new(factory, "x11".into(), BaselineStore::new(root), 100);
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot().unwrap();
+
+        let err = g.set_value(AxNodeId(1), "banana").unwrap_err();
+
+        assert!(matches!(err, GlassError::AxValueNotApplied(1)), "{err}");
+        assert!(
+            drags.lock().unwrap().is_empty(),
+            "an unparseable value must never trigger the toggle swipe"
+        );
+        assert!(
+            log.lock().unwrap().is_empty(),
+            "an unparseable value must never fall through to the tap+type delegate"
         );
     }
 

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -28,6 +28,7 @@ pub(crate) struct FakePlatform {
     capture_log: Arc<Mutex<Vec<Option<Region>>>>,
     click_log: Arc<Mutex<Vec<(i32, i32)>>>,
     scroll_log: Arc<Mutex<Vec<PointerEvent>>>,
+    drag_log: Arc<Mutex<Vec<PointerEvent>>>,
     stop_count: Option<Arc<Mutex<u32>>>,
     windows: Vec<WindowInfo>,
     clipboard: String,
@@ -79,6 +80,10 @@ impl FakePlatform {
     }
     pub(crate) fn with_scroll_log(mut self, log: Arc<Mutex<Vec<PointerEvent>>>) -> Self {
         self.scroll_log = log;
+        self
+    }
+    pub(crate) fn with_drag_log(mut self, log: Arc<Mutex<Vec<PointerEvent>>>) -> Self {
+        self.drag_log = log;
         self
     }
     pub(crate) fn with_select_log(mut self, log: Arc<Mutex<Vec<WindowId>>>) -> Self {
@@ -168,6 +173,9 @@ impl Platform for FakePlatform {
         }
         if let PointerEvent::Scroll { .. } = event {
             self.scroll_log.lock().unwrap().push(event.clone());
+        }
+        if let PointerEvent::Drag { .. } = event {
+            self.drag_log.lock().unwrap().push(event.clone());
         }
         self.pointer_events.push(event.clone());
         Ok(())


### PR DESCRIPTION
An iOS `UISwitch` does not actuate on a tap — it toggles on a short swipe across its control. rc-verification proved this on device (a tap, including idb's own `ui tap`, leaves the switch unchanged; a short trailing-edge swipe flips it, and a *fixed* short swipe toggles both directions deterministically). This supersedes the earlier tap-aim approach.

- `AxRect::trailing_toggle_swipe` computes a short horizontal swipe segment across the trailing control (returns the existing `Segment` type; anchored on `clamped_trailing_point`).
- `glass_click_element` emits that swipe (a `Drag`) instead of a `Click` when the existing iOS-only row-shaped-checkable gate fires. Every non-iOS backend is unchanged (the gate defaults off; only the iOS backend enables it).
- `glass_set_value` on such a switch reads the current state, swipes iff it differs from the requested boolean, and **verifies** the result — returning an error instead of a premature `ok`. A non-boolean value on a switch now errors rather than silently typing into nothing.

Verified by unit tests (geometry, the swipe/gate three-way, the toggle+verify triad including same-name-collision and non-boolean guards). Behavior on device is confirmed at the rc level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)