### PR TITLE
a11y: actionable error when set_value gets a non-boolean for a switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ internal refactors, CI, or test-only changes.
 - iOS: `glass_click_element` and `glass_set_value` now toggle a `UISwitch` by swiping its control (a tap
   does not actuate a UISwitch); `glass_set_value` verifies the switch reached the requested state instead
   of returning a premature `ok`. Other backends are unchanged.
+- `glass_set_value` on a switch/checkbox now returns an actionable error naming the accepted boolean
+  spellings (`true/false`, `on/off`, `1/0`, `yes/no`) when given a non-boolean value, instead of a generic
+  "value did not change — use keystrokes" message that misdirected the agent.
 - **macOS: a newly-launched app is brought frontmost at `glass_start`**, so `glass_a11y_snapshot`
   resolves its window immediately instead of returning `window not found` until the first `glass_click`
   activated the app. The `window not found` message also now suggests a remedy.

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -76,6 +76,9 @@ pub enum GlassError {
     #[error("set_value on element #{0} reported success but the value did not change (read-only a11y projection — use keystrokes)")]
     AxValueNotApplied(u32),
 
+    #[error("set_value on element #{0} is a switch/checkbox and expects a boolean — one of true/false, on/off, 1/0, yes/no (got {1:?})")]
+    AxValueNotBoolean(u32, String),
+
     #[error("element #{0} is inside a popover glass could not map to a window; select_window it and click by coordinate")]
     AxElementInUnmappedPopover(u32),
 

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -241,8 +241,11 @@ impl Glass {
                 if st.checkable {
                     // A checkable switch expects a boolean; unrecognized text must NOT fall
                     // through to the tap+type delegate (which would silently no-op a UISwitch).
-                    // Erroring here preserves the "never a silent ok" invariant.
-                    let want = parse_bool(text).ok_or(GlassError::AxValueNotApplied(id.0))?;
+                    // Erroring here preserves the "never a silent ok" invariant — and the error
+                    // must tell the agent to pass a boolean, not misdirect it (a generic
+                    // "value not applied — use keystrokes" would send it down a futile path).
+                    let want = parse_bool(text)
+                        .ok_or_else(|| GlassError::AxValueNotBoolean(id.0, text.to_string()))?;
                     if st.checked == want {
                         return Ok(()); // truthful no-op, no actuation
                     }
@@ -1853,7 +1856,18 @@ mod tests {
 
         let err = g.set_value(AxNodeId(1), "banana").unwrap_err();
 
-        assert!(matches!(err, GlassError::AxValueNotApplied(1)), "{err}");
+        // The error must be the switch-specific "expects a boolean" one, and its message must
+        // actually guide the agent (name the accepted values + echo the bad input) — NOT a generic
+        // "value not applied — use keystrokes", which would send the agent down a futile path.
+        assert!(
+            matches!(err, GlassError::AxValueNotBoolean(1, ref got) if got == "banana"),
+            "{err}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("true/false") && msg.contains("banana"),
+            "error must tell the agent to pass a boolean, not misdirect it: {msg}"
+        );
         assert!(
             drags.lock().unwrap().is_empty(),
             "an unparseable value must never trigger the toggle swipe"


### PR DESCRIPTION
Passing a non-boolean value (`"checked"`, `"enabled"`, `"banana"`, …) to `glass_set_value` on a switch/checkbox returned the generic `AxValueNotApplied` message — *"value did not change (read-only a11y projection — use keystrokes)"* — which sends the agent toward keystrokes when the correct action is to pass a boolean.

New `AxValueNotBoolean` names the accepted spellings (`true/false`, `on/off`, `1/0`, `yes/no`) and echoes the bad input. Behavior is unchanged (a non-boolean is still an error, never a silent `ok`); only the guidance is corrected so the error is actionable rather than misleading.

Unit-tested: the non-boolean case now asserts the switch-specific variant *and* that its message names the accepted values + echoes the input (guards against regressing to a misleading message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)