### PR TITLE
docs: fix stale claims + broken links in release-bundled READMEs; add a guard

### DIFF
--- a/crates/glass-mcp/tests/bundled_readme_links.rs
+++ b/crates/glass-mcp/tests/bundled_readme_links.rs
@@ -1,0 +1,86 @@
+//! Guard: the per-platform READMEs bundled INTO the release archives
+//! (`packaging/README-{gnu,musl,windows}.md`) ship standalone — `release.yml` puts only the
+//! binary and that one file (renamed `README.md`) in each tarball/zip, no other repo files. So
+//! every inline link in them must be an ABSOLUTE URL (or an in-page anchor): a repo-relative link
+//! like `../docs/…` or a sibling `README-windows.md` resolves on GitHub but is broken the moment a
+//! user extracts the archive. This test also forbids the exact stale claims a past drift shipped
+//! (macOS "no prebuilt", Windows "not yet signed"), now that the product ships a notarized macOS
+//! `.dmg` and a signed Windows `.exe`.
+
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    // crates/glass-mcp -> repo root
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("resolve repo root from CARGO_MANIFEST_DIR")
+}
+
+const BUNDLED: &[&str] = &[
+    "packaging/README-gnu.md",
+    "packaging/README-musl.md",
+    "packaging/README-windows.md",
+];
+
+/// Every inline link / image target `](target)` in the markdown, target read up to the first `)`.
+fn link_targets(md: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut rest = md;
+    while let Some(pos) = rest.find("](") {
+        let after = &rest[pos + 2..];
+        match after.find(')') {
+            Some(end) => {
+                out.push(after[..end].to_string());
+                rest = &after[end + 1..];
+            }
+            None => break,
+        }
+    }
+    out
+}
+
+#[test]
+fn bundled_readmes_have_only_absolute_links() {
+    let root = repo_root();
+    for rel in BUNDLED {
+        let md =
+            std::fs::read_to_string(root.join(rel)).unwrap_or_else(|e| panic!("read {rel}: {e}"));
+        for target in link_targets(&md) {
+            let absolute = target.starts_with("https://")
+                || target.starts_with("http://")
+                || target.starts_with("mailto:")
+                || target.starts_with('#');
+            assert!(
+                absolute,
+                "{rel} has the repo-relative link `]({target})`. This file ships STANDALONE inside \
+                 the release archive (only the binary + this README are extracted), so a relative \
+                 link breaks for the user. Use an absolute https:// URL \
+                 (e.g. https://github.com/fixed-width/glass/blob/master/…)."
+            );
+        }
+    }
+}
+
+#[test]
+fn bundled_readmes_do_not_carry_stale_prebuilt_or_signing_claims() {
+    let root = repo_root();
+    // Exact stale claims a past drift shipped. The product now has a notarized macOS `.dmg` and a
+    // signed Windows `.exe`, so none of these may reappear in a bundled README.
+    let forbidden = [
+        "no prebuilt binary yet",
+        "not yet Authenticode-signed",
+        "not yet signed",
+    ];
+    for rel in BUNDLED {
+        let md =
+            std::fs::read_to_string(root.join(rel)).unwrap_or_else(|e| panic!("read {rel}: {e}"));
+        for phrase in forbidden {
+            assert!(
+                !md.contains(phrase),
+                "{rel} contains the stale claim {phrase:?} — the product ships a notarized macOS \
+                 .dmg and a signed Windows exe; correct the README."
+            );
+        }
+    }
+}

--- a/docs/explanation/windows-permissions.md
+++ b/docs/explanation/windows-permissions.md
@@ -32,11 +32,12 @@ relationship, not a consent grant: to drive an elevated app, run glass at the sa
 so the two processes match. Most apps run at medium integrity, where the default works with no special
 handling.
 
-**SmartScreen and Defender (distribution, not runtime).** These gate *installing* an unknown binary,
-not *what a running binary may do*. An unsigned download of `glass-mcp.exe` triggers Microsoft Defender
-SmartScreen's "Windows protected your PC" banner — a publisher-trust prompt, not an access grant. A
-signed release clears it; an unsigned build runs after **More info → Run anyway**. See the install
-steps in [how-to/setup-windows.md](../how-to/setup-windows.md).
+**SmartScreen and Defender (distribution, not runtime).** These gate *installing* a downloaded binary,
+not *what a running binary may do*. The release `glass-mcp.exe` is Authenticode-signed (publisher: Fixed
+Width LLC), which establishes the publisher; Microsoft Defender SmartScreen may still show "Windows
+protected your PC" on first download until the certificate builds reputation — a publisher-trust prompt,
+not an access grant, cleared with **More info → Run anyway**. See the install steps in
+[how-to/setup-windows.md](../how-to/setup-windows.md).
 
 ## Why there's no grant to click
 

--- a/docs/how-to/setup-windows.md
+++ b/docs/how-to/setup-windows.md
@@ -42,10 +42,11 @@ copy `glass-mcp.exe` into a directory that's already on `PATH` instead.
 If you want to hack on glass or are on an architecture with no published asset,
 [build from source](build-from-source.md) instead.
 
-> **First run — SmartScreen.** Prebuilt binaries are not yet Authenticode-signed, so the first launch
-> may show Microsoft Defender SmartScreen's "Windows protected your PC". Click **More info → Run
-> anyway**. This is a publisher-trust prompt, not a permission request — glass needs no permission
-> grants on Windows ([why](../explanation/windows-permissions.md)).
+> **First run — SmartScreen.** The prebuilt `glass-mcp.exe` is Authenticode-signed (publisher: **Fixed
+> Width LLC**). Windows may still show Microsoft Defender SmartScreen's "Windows protected your PC" on
+> first download until the certificate builds reputation; if it does, click **More info → Run anyway**.
+> This is a publisher-trust prompt, not a permission request — glass needs no permission grants on Windows
+> ([why](../explanation/windows-permissions.md)).
 
 ## Verify
 

--- a/packaging/README-gnu.md
+++ b/packaging/README-gnu.md
@@ -5,13 +5,13 @@ launches an app, screenshots what's on screen, clicks and types into it, reads i
 logs, and detects visual changes — so the agent can build and debug a GUI on its own
 instead of asking you "does this look right?".
 
-This is the **Linux x86-64 (glibc)** build. (A prebuilt **Windows** build is also
-available — see [`packaging/README-windows.md`](README-windows.md). macOS has no prebuilt
-binary yet; build from source — see [docs/how-to/build-from-source.md](../docs/how-to/build-from-source.md).)
+This is the **Linux x86-64 (glibc)** build. Prebuilt builds are also available for
+**Windows** (see [`packaging/README-windows.md`](https://github.com/fixed-width/glass/blob/master/packaging/README-windows.md)) and **macOS** (a
+notarized `.dmg` — see [docs/how-to/setup-macos.md](https://github.com/fixed-width/glass/blob/master/docs/how-to/setup-macos.md)).
 See the project README for the full picture:
 <https://github.com/fixed-width/glass>.
 For Linux-specific display/compositor and containment setup, see
-[docs/how-to/setup-linux.md](../docs/how-to/setup-linux.md).
+[docs/how-to/setup-linux.md](https://github.com/fixed-width/glass/blob/master/docs/how-to/setup-linux.md).
 
 > **Prefer the static build if you can.** A statically-linked build is also available
 > that needs no glibc version and no shared libs at all — only `xvfb`. Use this glibc

--- a/packaging/README-musl.md
+++ b/packaging/README-musl.md
@@ -7,12 +7,12 @@ instead of asking you "does this look right?".
 
 This is the **statically-linked Linux x86-64** build: **no glibc version requirement**
 and **no shared-library prerequisites** — it runs on essentially any x86-64 Linux.
-(A prebuilt **Windows** build is also available — see
-[`packaging/README-windows.md`](README-windows.md). macOS has no prebuilt binary yet;
-build from source — see [docs/how-to/build-from-source.md](../docs/how-to/build-from-source.md).)
+Prebuilt builds are also available for **Windows** (see
+[`packaging/README-windows.md`](https://github.com/fixed-width/glass/blob/master/packaging/README-windows.md)) and **macOS** (a notarized `.dmg` —
+see [docs/how-to/setup-macos.md](https://github.com/fixed-width/glass/blob/master/docs/how-to/setup-macos.md)).
 See the project README for the full picture: <https://github.com/fixed-width/glass>.
 For Linux-specific display/compositor and containment setup, see
-[docs/how-to/setup-linux.md](../docs/how-to/setup-linux.md).
+[docs/how-to/setup-linux.md](https://github.com/fixed-width/glass/blob/master/docs/how-to/setup-linux.md).
 
 ---
 

--- a/packaging/README-windows.md
+++ b/packaging/README-windows.md
@@ -8,7 +8,7 @@ instead of asking you "does this look right?".
 This is the **Windows x86-64** build. See the project README for the full picture:
 <https://github.com/fixed-width/glass>.
 For Windows-specific setup (containment runtime, network transport, Android-on-Windows),
-see [docs/how-to/setup-windows.md](../docs/how-to/setup-windows.md).
+see [docs/how-to/setup-windows.md](https://github.com/fixed-width/glass/blob/master/docs/how-to/setup-windows.md).
 
 ---
 
@@ -37,10 +37,12 @@ mkdir $env:USERPROFILE\bin -Force
 copy glass-mcp.exe $env:USERPROFILE\bin\glass-mcp.exe
 ```
 
-> **First run — SmartScreen.** These binaries are not yet Authenticode-signed, so the first launch may
-> show Microsoft Defender SmartScreen's "Windows protected your PC". Click **More info → Run anyway**.
-> It's a publisher-trust prompt, not a permission request — glass needs no permission grants on Windows
-> (see [docs/explanation/windows-permissions.md](../docs/explanation/windows-permissions.md)).
+> **First run — SmartScreen.** The binary is Authenticode-signed (publisher: **Fixed Width LLC** — you can
+> confirm it in the file's Properties → Digital Signatures). Windows may still show Microsoft Defender
+> SmartScreen's "Windows protected your PC" on first download until the certificate builds reputation; if
+> it does, click **More info → Run anyway**. It's a publisher-trust prompt, not a permission request —
+> glass needs no permission grants on Windows
+> (see [docs/explanation/windows-permissions.md](https://github.com/fixed-width/glass/blob/master/docs/explanation/windows-permissions.md)).
 
 ## 3. Verify your setup
 


### PR DESCRIPTION
The per-platform READMEs that ship **inside** the release archives (`packaging/README-{gnu,musl,windows}.md`, extracted as the archive's `README.md` next to just the binary) had drifted from the current main README + setup guides, and — because they ship standalone — their relative links were broken on extraction.

**Stale facts corrected (both *undersold* shipped work):**
- Linux gnu/musl READMEs: "macOS has no prebuilt binary yet; build from source" → a notarized `.dmg` now ships.
- Windows README: "not yet Authenticode-signed → SmartScreen" → the exe **is** signed (Fixed Width LLC); the SmartScreen-reputation nuance is stated accurately. Same correction in `docs/how-to/setup-windows.md` and `docs/explanation/windows-permissions.md`.

**Broken links fixed:** every relative link (`../docs/…`, sibling `README-windows.md`) in the three bundled READMEs is now an absolute URL, so it resolves when a user extracts the archive (which contains no other repo files).

**Parity guard** (`crates/glass-mcp/tests/bundled_readme_links.rs`): fails CI if a bundled README ever gains a relative link or reintroduces the stale prebuilt/signing claims. Verified it catches an injected relative link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)