### PR TITLE
examples: add tasks_demo.py — a buggy GTK4 app for the build/debug loop

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,41 @@
+# examples
+
+Small apps for trying glass's **build → see → interact → debug** loop with an agent.
+
+## `tasks_demo.py` — a GTK4 app with a bug to find
+
+A tiny "Tasks" app: a text entry, an **Add** button, and a list. It ships with a deliberate bug —
+clicking **Add** does nothing — so you can watch an agent drive glass through the whole loop: run
+the app, reproduce the bug **from the accessibility tree** (no screenshots), fix the code, and
+verify the fix.
+
+Requires Python 3 with GTK 4 introspection:
+
+```bash
+# Debian / Ubuntu
+sudo apt install python3-gi gir1.2-gtk-4.0
+```
+
+[Connect glass to your agent](../docs/how-to/connect-an-agent.md), then paste:
+
+> Use glass to run `examples/tasks_demo.py` with accessibility on. There's a bug: clicking
+> **Add** doesn't add the typed task. Reproduce it by driving the UI and checking the
+> accessibility tree (don't just screenshot), then find and fix the bug in the code and verify a
+> task actually appears.
+
+A good run launches with `a11y: true`, types a task, clicks **Add**, and sees from
+`glass_a11y_snapshot` that the list is still empty — then, after the fix, that a new list item
+appears. The app edits the agent makes are to `tasks_demo.py`; `git checkout examples/tasks_demo.py`
+resets it to the buggy version to run the demo again.
+
+<details>
+<summary>The answer (spoiler)</summary>
+
+The `on_add` handler is correct, but the **Add** button is never connected to it. The one-line fix:
+
+```python
+add = Gtk.Button(label="Add")
+add.connect("clicked", self.on_add)   # <- the missing line
+```
+
+</details>

--- a/examples/tasks_demo.py
+++ b/examples/tasks_demo.py
@@ -1,0 +1,54 @@
+"""A tiny GTK4 "Tasks" app — with a deliberate bug — for trying glass end to end.
+
+There's a bug: clicking **Add** does nothing. Point an agent at glass and have it run this app,
+reproduce the bug from the accessibility tree, find and fix it in the code, and verify a task
+appears. See examples/README.md for the prompt (and, if you want it, the answer).
+
+Run directly to see the bug yourself:  python3 examples/tasks_demo.py
+(needs Python 3 + GTK 4 introspection: `apt install python3-gi gir1.2-gtk-4.0`)
+"""
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk
+
+
+class TaskWindow(Gtk.ApplicationWindow):
+    def __init__(self, app):
+        super().__init__(application=app, title="Tasks")
+        self.set_default_size(360, 420)
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        for margin in ("top", "bottom", "start", "end"):
+            getattr(box, f"set_margin_{margin}")(12)
+        self.set_child(box)
+
+        input_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        self.entry = Gtk.Entry()
+        self.entry.set_placeholder_text("New task")
+        self.entry.set_hexpand(True)
+        add = Gtk.Button(label="Add")
+        input_row.append(self.entry)
+        input_row.append(add)
+        box.append(input_row)
+
+        self.tasks = Gtk.ListBox()
+        box.append(self.tasks)
+
+    def on_add(self, _button):
+        text = self.entry.get_text().strip()
+        if not text:
+            return
+        self.tasks.append(Gtk.Label(label=text, xalign=0))
+        self.entry.set_text("")
+
+
+def main():
+    app = Gtk.Application(application_id="tech.fixedwidth.glass.tasks")
+    app.connect("activate", lambda a: TaskWindow(a).present())
+    app.run(None)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds `examples/tasks_demo.py` (+ `examples/README.md`): a tiny GTK4 Tasks app with a deliberate bug (the **Add** button is never connected to its handler, so clicking it does nothing). It's a fixture for driving glass end to end with an agent — run the app, reproduce the bug from the accessibility tree, fix the code, verify. The README carries the agent prompt and, behind a spoiler, the one-line fix. Standalone Python; not part of the cargo workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)