### PR TITLE
examples: strip demo-meta from tasks_demo (don't spoil the bug the agent should find)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,10 +4,10 @@ Small apps for trying glass's **build → see → interact → debug** loop with
 
 ## `tasks_demo.py` — a GTK4 app with a bug to find
 
-A tiny "Tasks" app: a text entry, an **Add** button, and a list. It ships with a deliberate bug —
-clicking **Add** does nothing — so you can watch an agent drive glass through the whole loop: run
-the app, reproduce the bug **from the accessibility tree** (no screenshots), fix the code, and
-verify the fix.
+A tiny "Tasks" app: a text entry, an **Add** button, and a list. It has a bug — clicking **Add**
+doesn't add the typed task — so you can watch an agent drive glass through the whole loop: run the
+app, reproduce the bug **from the accessibility tree** (no screenshots), find and fix it in the
+code, and verify.
 
 Requires Python 3 with GTK 4 introspection:
 
@@ -23,19 +23,5 @@ sudo apt install python3-gi gir1.2-gtk-4.0
 > accessibility tree (don't just screenshot), then find and fix the bug in the code and verify a
 > task actually appears.
 
-A good run launches with `a11y: true`, types a task, clicks **Add**, and sees from
-`glass_a11y_snapshot` that the list is still empty — then, after the fix, that a new list item
-appears. The app edits the agent makes are to `tasks_demo.py`; `git checkout examples/tasks_demo.py`
-resets it to the buggy version to run the demo again.
-
-<details>
-<summary>The answer (spoiler)</summary>
-
-The `on_add` handler is correct, but the **Add** button is never connected to it. The one-line fix:
-
-```python
-add = Gtk.Button(label="Add")
-add.connect("clicked", self.on_add)   # <- the missing line
-```
-
-</details>
+Let the agent find it — the fix is a single line. Run `git checkout examples/tasks_demo.py` to
+reset the app to its buggy state and try again.

--- a/examples/tasks_demo.py
+++ b/examples/tasks_demo.py
@@ -1,12 +1,4 @@
-"""A tiny GTK4 "Tasks" app — with a deliberate bug — for trying glass end to end.
-
-There's a bug: clicking **Add** does nothing. Point an agent at glass and have it run this app,
-reproduce the bug from the accessibility tree, find and fix it in the code, and verify a task
-appears. See examples/README.md for the prompt (and, if you want it, the answer).
-
-Run directly to see the bug yourself:  python3 examples/tasks_demo.py
-(needs Python 3 + GTK 4 introspection: `apt install python3-gi gir1.2-gtk-4.0`)
-"""
+"""A tiny GTK4 "Tasks" app: type a task, click Add, and it appears in the list."""
 
 import gi
 


### PR DESCRIPTION
Follow-up to #182. The merged fixture's docstring described the bug and approach, and its README spoiled the one-line fix behind a `<details>`. When an agent opens `tasks_demo.py` to debug it (the whole point of the demo), it reads the answer instead of finding it — inauthentic, and the docstring's imperative meta-text is self-referential instruction sitting in the code the agent reads directly (not wrapped as untrusted like glass's app-content is).

Neutral one-line docstring on the app; the README keeps the setup + agent prompt but drops the answer. The bug (Add button never wired to its handler) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)