### PR TITLE
sandbox: make the launch target reachable under the default containment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ internal refactors, CI, or test-only changes.
   path too.
 
 ### Fixed
+- **Linux: apps whose program or files live under your home directory now start under the default
+  sandbox.** The default sandbox hides your home directory (and `/tmp`) from the launched app, which
+  previously also hid the app's *own* launch target — so an app passed by absolute path under home
+  (`python3 /home/you/app.py`), reached through a symlink (a virtualenv or asdf/pyenv shim), found on
+  a `PATH` entry under home (a `cargo install`/`pipx`/`npm -g` tool), or given by a relative path
+  would fail to start (it exited before its window appeared). glass now makes the launch target
+  reachable inside the sandbox — and defaults the working directory to glass's — while still keeping
+  your home directory hidden. A contained app that still exits before its window now reports the
+  likely cause and how to fix it (`set cwd`, or run with `sandbox:"off"`) instead of a bare exit code.
 - **Linux: accessibility-enabled launches are no longer slow.** On X11 and Wayland, starting an app
   with `a11y: true` (needed for `glass_a11y_snapshot`, `glass_click_element`, and the other
   accessibility tools) previously added a fixed ~25-second delay before the app's window appeared.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,6 +1350,7 @@ dependencies = [
  "glass-dbus-linux",
  "glass-proc-linux",
  "glass-sandbox-linux",
+ "tempfile",
  "x11rb",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,6 +1280,7 @@ name = "glass-sandbox-linux"
 version = "0.0.0"
 dependencies = [
  "glass-core",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -16,12 +16,12 @@ pub enum GlassError {
     AppExited(Option<i32>),
 
     /// Same failure as `AppExited`, but the launch was sandboxed — so the
-    /// exit may be the contained app failing to find a file that a bind
-    /// mount hides. Carries a remedy rather than internal threat-model
-    /// detail.
+    /// exit may be the contained app failing to find a file the ephemeral
+    /// tmpfs hides. Carries an actionable remedy rather than internal sandbox
+    /// mechanics.
     #[error(
-        "app exited (code {0:?}) before its window appeared. If it was sandboxed, a file it needs \
-         may be hidden by the ephemeral $HOME/tmp — set `cwd`, add a bind, or run with \
+        "app exited (code {0:?}) before its window appeared. The launch was sandboxed, so a file \
+         it needs may be hidden by the ephemeral $HOME or /tmp — set `cwd`, or run with \
          sandbox:\"off\"."
     )]
     SandboxedAppExited(Option<i32>),
@@ -140,10 +140,13 @@ impl GlassError {
 
     /// The error for "the child exited before `discover_window` found its
     /// window" — `SandboxedAppExited` (with the path-visibility remedy) when
-    /// the launch was contained, plain `AppExited` otherwise. Shared by every
-    /// backend's discovery loop so the conditional isn't triplicated.
-    pub fn app_exited_during_discovery(code: Option<i32>, sandboxed: bool) -> Self {
-        if sandboxed {
+    /// the launch was contained, plain `AppExited` otherwise. Shared by the
+    /// Linux backends' discovery loops so the conditional isn't triplicated.
+    ///
+    /// Takes the launch's [`SandboxLevel`] (not a pre-computed bool) so the
+    /// "was this contained?" decision lives here, in one place.
+    pub fn app_exited_during_discovery(code: Option<i32>, sandbox: crate::SandboxLevel) -> Self {
+        if sandbox != crate::SandboxLevel::Off {
             GlassError::SandboxedAppExited(code)
         } else {
             GlassError::AppExited(code)
@@ -271,13 +274,13 @@ mod tests {
 
     #[test]
     fn app_exited_during_discovery_picks_the_sandboxed_variant_when_sandboxed() {
-        let err = GlassError::app_exited_during_discovery(Some(2), true);
+        let err = GlassError::app_exited_during_discovery(Some(2), crate::SandboxLevel::Default);
         assert!(matches!(err, GlassError::SandboxedAppExited(Some(2))));
     }
 
     #[test]
     fn app_exited_during_discovery_picks_the_plain_variant_when_not_sandboxed() {
-        let err = GlassError::app_exited_during_discovery(Some(2), false);
+        let err = GlassError::app_exited_during_discovery(Some(2), crate::SandboxLevel::Off);
         assert!(matches!(err, GlassError::AppExited(Some(2))));
     }
 

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -15,6 +15,17 @@ pub enum GlassError {
     #[error("app exited (code {0:?})")]
     AppExited(Option<i32>),
 
+    /// Same failure as `AppExited`, but the launch was sandboxed — so the
+    /// exit may be the contained app failing to find a file that a bind
+    /// mount hides. Carries a remedy rather than internal threat-model
+    /// detail.
+    #[error(
+        "app exited (code {0:?}) before its window appeared. If it was sandboxed, a file it needs \
+         may be hidden by the ephemeral $HOME/tmp — set `cwd`, add a bind, or run with \
+         sandbox:\"off\"."
+    )]
+    SandboxedAppExited(Option<i32>),
+
     #[error(
         "window not found — the target app may not have opened its window yet; wait for it to appear and retry"
     )]
@@ -125,6 +136,18 @@ impl GlassError {
         }
         msg.push_str("; call glass_capabilities to see what this backend can do");
         GlassError::Unsupported(msg)
+    }
+
+    /// The error for "the child exited before `discover_window` found its
+    /// window" — `SandboxedAppExited` (with the path-visibility remedy) when
+    /// the launch was contained, plain `AppExited` otherwise. Shared by every
+    /// backend's discovery loop so the conditional isn't triplicated.
+    pub fn app_exited_during_discovery(code: Option<i32>, sandboxed: bool) -> Self {
+        if sandboxed {
+            GlassError::SandboxedAppExited(code)
+        } else {
+            GlassError::AppExited(code)
+        }
     }
 }
 
@@ -237,6 +260,25 @@ mod tests {
             "window_move_resize is not supported by the android backend (apps are full-screen); \
              call glass_capabilities to see what this backend can do"
         );
+    }
+
+    #[test]
+    fn sandboxed_app_exited_message_hints_the_remedy() {
+        let msg = GlassError::SandboxedAppExited(Some(2)).to_string();
+        assert!(msg.contains("sandbox:\"off\""), "{msg}");
+        assert!(msg.contains("$HOME"), "{msg}");
+    }
+
+    #[test]
+    fn app_exited_during_discovery_picks_the_sandboxed_variant_when_sandboxed() {
+        let err = GlassError::app_exited_during_discovery(Some(2), true);
+        assert!(matches!(err, GlassError::SandboxedAppExited(Some(2))));
+    }
+
+    #[test]
+    fn app_exited_during_discovery_picks_the_plain_variant_when_not_sandboxed() {
+        let err = GlassError::app_exited_during_discovery(Some(2), false);
+        assert!(matches!(err, GlassError::AppExited(Some(2))));
     }
 
     #[test]

--- a/crates/glass-sandbox-linux/Cargo.toml
+++ b/crates/glass-sandbox-linux/Cargo.toml
@@ -9,5 +9,8 @@ publish.workspace = true
 [dependencies]
 glass-core.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [lints]
 workspace = true

--- a/crates/glass-sandbox-linux/src/lib.rs
+++ b/crates/glass-sandbox-linux/src/lib.rs
@@ -61,19 +61,6 @@ pub struct WrapOpts {
     pub rw_binds: Vec<PathBuf>,
 }
 
-/// Read-only binds needed to reach the program binary inside the namespace: the
-/// program path itself when it is absolute (it may live under `$HOME`, which the
-/// ephemeral-HOME tmpfs shadows). Bare-name programs resolve via PATH (covered by
-/// `--ro-bind / /`), so they need no extra bind.
-pub fn program_ro_binds(program: &OsStr) -> Vec<std::path::PathBuf> {
-    let p = std::path::Path::new(program);
-    if p.is_absolute() {
-        vec![p.to_path_buf()]
-    } else {
-        vec![]
-    }
-}
-
 /// Read-only binds that make the launch target reachable inside the namespace: the program and
 /// every `run` argument that names an existing absolute path. The ephemeral-`$HOME` and `/tmp`
 /// tmpfs shadow anything under those roots, so a script/asset passed by absolute path must be
@@ -478,21 +465,6 @@ mod tests {
         assert!(
             s.windows(2).any(|w| w == ["--chdir", "/home/u/proj"]),
             "cwd subdir of home must emit --chdir <cwd>; got: {s:?}"
-        );
-    }
-
-    #[test]
-    fn program_ro_binds_absolute_returns_that_path() {
-        let binds = super::program_ro_binds(OsStr::new("/home/u/myapp"));
-        assert_eq!(binds, vec![PathBuf::from("/home/u/myapp")]);
-    }
-
-    #[test]
-    fn program_ro_binds_bare_name_returns_empty() {
-        let binds = super::program_ro_binds(OsStr::new("app"));
-        assert!(
-            binds.is_empty(),
-            "bare name needs no extra bind; got: {binds:?}"
         );
     }
 

--- a/crates/glass-sandbox-linux/src/lib.rs
+++ b/crates/glass-sandbox-linux/src/lib.rs
@@ -7,7 +7,9 @@
 #![cfg(target_os = "linux")]
 
 use std::ffi::{OsStr, OsString};
-use std::path::PathBuf;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use glass_core::{AppSpec, Check, CheckStatus, GlassError, Result, SandboxLevel};
@@ -61,53 +63,143 @@ pub struct WrapOpts {
     pub rw_binds: Vec<PathBuf>,
 }
 
-/// Read-only binds that make the launch target reachable inside the namespace: the program and
-/// every `run` argument that names an existing absolute path. The ephemeral-`$HOME` and `/tmp`
-/// tmpfs shadow anything under those roots, so a script/asset passed by absolute path must be
-/// re-bound to be visible. Bare-name programs (resolved via `PATH` under `--ro-bind / /`) and
-/// relative args (covered by the `cwd` bind) contribute nothing.
+/// Read-only binds that make the LITERAL launch target reachable inside the namespace: the
+/// program and every `run` argument that resolves to an existing path. The ephemeral-`$HOME` and
+/// `/tmp` tmpfs shadow anything under those roots, so a script/asset/binary living there must be
+/// re-bound to be visible.
 ///
-/// Each target is exposed by its directory (so sibling modules/assets are reachable), EXCEPT when
-/// that directory is a tmpfs-shadowed root (`home` or `/tmp`) or an ancestor of one — binding it
-/// would re-mount the real subtree over the tmpfs, so only the file itself is bound. A target that
-/// IS itself a shadowed root or an ancestor of one (e.g. an arg of `/tmp`, `home`, or `/`)
-/// contributes no bind at all, for the same reason. Read-only, de-duplicated. Mirrors the `cwd`
-/// guard in `WrapOpts`.
-pub fn launch_ro_binds(program: &OsStr, args: &[OsString], home: &OsStr) -> Vec<PathBuf> {
-    let home = canon(std::path::Path::new(home));
-    let shadowed_roots = [home.as_path(), std::path::Path::new("/tmp")];
+/// Three resolution rules mirror how the child is actually exec'd, so the paths bwrap opens match
+/// the paths the launch touches:
+/// - **`run[0]` as a bare name** (no `/`) is resolved against `$PATH` like `execvp`; the resolving
+///   directory is bound only when it is under a shadowed root (e.g. `~/.cargo/bin`, an asdf shim).
+///   A match under `/usr/bin` etc. is already visible via `--ro-bind / /`, so it contributes
+///   nothing. Arguments are NOT `$PATH`-resolved.
+/// - **A relative token** (program-with-`/` or any relative argument) is resolved against `cwd`
+///   (`cwd.join(token)`) before binding, so `./start.sh` / `sub/asset` reach their real location.
+/// - **An absolute token** is bound as-is.
+///
+/// For each resolved token, bwrap opens the path *as written*, but a symlink's target may live
+/// elsewhere, so BOTH the literal path's directory (so the symlink/file is readable where it is
+/// named) and the resolved target's directory (so the target is readable) are exposed — deduped,
+/// so a non-symlink collapses to a single bind. Each directory is exposed EXCEPT when it is a
+/// tmpfs-shadowed root (`home` or `/tmp`) or an ancestor of one — binding it would re-mount the
+/// real subtree over the tmpfs, so only the file itself is bound. A target that IS itself a
+/// shadowed root or an ancestor of one (e.g. an arg of `/tmp`, `home`, or `/`) contributes no bind
+/// at all, for the same reason. Read-only, de-duplicated. Mirrors the `cwd` guard in `WrapOpts`.
+pub fn launch_ro_binds(
+    program: &OsStr,
+    args: &[OsString],
+    home: &Path,
+    cwd: &Path,
+) -> Vec<PathBuf> {
+    let home = canon(home);
+    let shadowed_roots = [home.as_path(), Path::new("/tmp")];
     let mut out: Vec<PathBuf> = Vec::new();
-    for tok in std::iter::once(program).chain(args.iter().map(|a| a.as_os_str())) {
-        let p = std::path::Path::new(tok);
-        if !p.is_absolute() {
-            continue; // bare-name (PATH) or relative (cwd) — already reachable
+
+    // run[0] (the program).
+    if program.as_bytes().contains(&b'/') {
+        // A path program: absolute, or relative (e.g. `./start.sh`) → resolved against cwd.
+        push_token_binds(
+            &mut out,
+            &abs_token(Path::new(program), cwd),
+            &shadowed_roots,
+        );
+    } else if let Some(resolved) = resolve_on_path(program) {
+        // A bare name → resolve via `$PATH` like execvp. Bind the resolving directory ONLY when
+        // it is under a shadowed root (a `$HOME`/`/tmp` PATH dir such as `~/.cargo/bin`, an asdf
+        // shim); a match under `/usr/bin` etc. is already visible via `--ro-bind / /`.
+        let dir = canon(resolved.parent().unwrap_or(&resolved));
+        if shadowed_roots.iter().any(|root| dir.starts_with(root)) {
+            push_token_binds(&mut out, &resolved, &shadowed_roots);
         }
-        let real = canon(p);
-        let Ok(meta) = std::fs::metadata(&real) else {
-            continue; // not an existing path (a flag/value) — nothing to bind
-        };
-        // Never auto-expose a shadowed root itself (or an ancestor of one) — binding it would
-        // re-mount the real subtree over the tmpfs. Such targets need cwd / an explicit bind /
-        // sandbox off.
-        if shadowed_roots.iter().any(|root| root.starts_with(&real)) {
-            continue;
+    }
+
+    // run[1..] (arguments): absolute or cwd-relative path tokens (never $PATH-resolved).
+    for a in args {
+        push_token_binds(&mut out, &abs_token(Path::new(a), cwd), &shadowed_roots);
+    }
+    out
+}
+
+/// Resolve a token to an absolute host path: an absolute token as-is, a relative one against
+/// `cwd` (`execvp`/shell semantics), so a relative launch argument reaches its real location.
+fn abs_token(tok: &Path, cwd: &Path) -> PathBuf {
+    if tok.is_absolute() {
+        tok.to_path_buf()
+    } else {
+        cwd.join(tok)
+    }
+}
+
+/// The first `$PATH` entry holding an executable regular file named `program`, resolved the way
+/// `execvp` resolves a bare command name. `None` when `$PATH` is unset or nothing matches. Mirrors
+/// the `PATH` scan in [`runnable`], but returns the match (not just a bool) and requires an execute
+/// bit so a same-named non-executable file is skipped like `execvp` skips it.
+fn resolve_on_path(program: &OsStr) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    resolve_on_path_in(program, &path)
+}
+
+/// [`resolve_on_path`] against an explicit `$PATH` value — the testable seam (no global env).
+fn resolve_on_path_in(program: &OsStr, path: &OsStr) -> Option<PathBuf> {
+    std::env::split_paths(path)
+        .map(|dir| dir.join(program))
+        .find(|cand| is_executable_file(cand))
+}
+
+/// Whether `p` is (or resolves through symlinks to) a regular file with at least one execute bit —
+/// `execvp`'s "is this runnable" test.
+fn is_executable_file(p: &Path) -> bool {
+    std::fs::metadata(p)
+        .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+/// Append the guarded read-only binds that make `lit` — an absolute launch-target path already
+/// resolved against `cwd`/`$PATH` — reachable, de-duplicated into `out`.
+///
+/// bwrap opens the LITERAL path, but a symlink's target may live elsewhere, so BOTH the literal
+/// path's directory and the resolved target's directory are exposed. The directory used for every
+/// shadowed-root guard check is CANONICALIZED so a `..` component cannot sneak a shadowed root past
+/// the guard.
+fn push_token_binds(out: &mut Vec<PathBuf>, lit: &Path, roots: &[&Path]) {
+    // `metadata` follows symlinks. ANY stat error — NotFound, EACCES, a dangling symlink, ELOOP,
+    // … — is DELIBERATELY treated as "not a bindable path" and skipped: a token we cannot even
+    // stat (a flag, a value, a missing file) contributes no bind. This is the fail-safe — we never
+    // bind something we cannot confirm exists.
+    if std::fs::metadata(lit).is_err() {
+        return;
+    }
+    let real = canon(lit); // the resolved target (symlinks followed)
+                           // Never auto-expose a shadowed root itself (or an ancestor of one) — binding it would re-mount
+                           // the real subtree over the tmpfs. Such a target needs cwd / sandbox off.
+    if roots.iter().any(|root| root.starts_with(&real)) {
+        return;
+    }
+    // The directory to expose for a path: the path itself when it is a directory, else its parent.
+    // Canonicalized so the guard checks below see a `..`-free path.
+    let dir_of = |p: &Path| -> PathBuf {
+        if p.is_dir() {
+            canon(p)
+        } else {
+            canon(p.parent().unwrap_or(p))
         }
-        let dir: &std::path::Path = if meta.is_dir() {
-            &real
+    };
+    // Where the token is WRITTEN (so a symlink is readable at its literal location) AND where its
+    // target actually LIVES. These coincide for a non-symlink (or same-dir symlink), so dedup
+    // collapses them to one bind.
+    for dir in [dir_of(lit), dir_of(&real)] {
+        // A shadowed-root (or ancestor) directory must never be bound as a directory; the target
+        // is a genuine file/subpath under it (checked above), so bind just the file.
+        let bind = if roots.iter().any(|root| root.starts_with(&dir)) {
+            real.clone()
         } else {
-            real.parent().unwrap_or(&real)
-        };
-        // Never re-expose a tmpfs-shadowed root (or an ancestor of one) as a directory.
-        let bind = if shadowed_roots.iter().any(|root| root.starts_with(dir)) {
-            real.clone() // real is a genuine file/subpath under a shadowed root (checked above) → safe
-        } else {
-            dir.to_path_buf()
+            dir
         };
         if !out.contains(&bind) {
             out.push(bind);
         }
     }
-    out
 }
 
 /// The ephemeral HOME path to use: the real `$HOME` (so apps that hardcode the path
@@ -472,11 +564,20 @@ mod tests {
     // launch_ro_binds tests
     // -------------------------------------------------------------------------
 
+    /// `launch_ro_binds` with a throwaway EMPTY `cwd`, so no relative token resolves against it —
+    /// for the cases that exercise only bare-name/absolute tokens. Cases that test cwd-relative
+    /// resolution call `launch_ro_binds` directly with a populated `cwd`.
+    fn ro_binds(program: &OsStr, args: &[OsString], home: &Path) -> Vec<PathBuf> {
+        let cwd = tempfile::tempdir().unwrap();
+        launch_ro_binds(program, args, home, cwd.path())
+    }
+
     #[test]
-    fn bare_name_program_binds_nothing() {
+    fn bare_name_program_via_usr_bin_binds_nothing() {
+        // `python3` resolves under /usr/bin (already visible via --ro-bind / /), not a $HOME/tmp
+        // PATH dir, so it contributes no bind.
         let home = tempfile::tempdir().unwrap();
-        let out = launch_ro_binds(OsStr::new("python3"), &[], home.path().as_os_str());
-        assert!(out.is_empty());
+        assert!(ro_binds(OsStr::new("python3"), &[], home.path()).is_empty());
     }
 
     #[test]
@@ -486,7 +587,7 @@ mod tests {
         std::fs::create_dir_all(&proj).unwrap();
         let bin = proj.join("bin");
         std::fs::write(&bin, b"").unwrap();
-        let out = launch_ro_binds(bin.as_os_str(), &[], home.path().as_os_str());
+        let out = ro_binds(bin.as_os_str(), &[], home.path());
         assert_eq!(out, vec![proj.canonicalize().unwrap()]); // the file's directory, not the file
     }
 
@@ -497,10 +598,10 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let script = dir.join("app.py");
         std::fs::write(&script, b"").unwrap();
-        let out = launch_ro_binds(
+        let out = ro_binds(
             OsStr::new("python3"),
             &[OsString::from(&script)],
-            home.path().as_os_str(),
+            home.path(),
         );
         assert_eq!(out, vec![dir.canonicalize().unwrap()]);
     }
@@ -510,10 +611,10 @@ mod tests {
         let home = tempfile::tempdir().unwrap();
         let data = home.path().join("proj/data");
         std::fs::create_dir_all(&data).unwrap();
-        let out = launch_ro_binds(
+        let out = ro_binds(
             OsStr::new("srv"),
             &[OsString::from("--root"), OsString::from(&data)],
-            home.path().as_os_str(),
+            home.path(),
         );
         assert_eq!(out, vec![data.canonicalize().unwrap()]);
     }
@@ -523,10 +624,10 @@ mod tests {
         let home = tempfile::tempdir().unwrap();
         let script = home.path().join("app.py"); // parent dir == home
         std::fs::write(&script, b"").unwrap();
-        let out = launch_ro_binds(
+        let out = ro_binds(
             OsStr::new("python3"),
             &[OsString::from(&script)],
-            home.path().as_os_str(),
+            home.path(),
         );
         assert_eq!(out, vec![script.canonicalize().unwrap()]); // guard: never bind home itself as a dir
         assert!(!out
@@ -535,9 +636,12 @@ mod tests {
     }
 
     #[test]
-    fn nonpath_and_relative_args_contribute_nothing() {
+    fn nonexistent_tokens_contribute_nothing() {
+        // Flags/values and missing paths — bare, relative, or absolute — are not bindable. With an
+        // empty cwd the relative tokens (`http.server`, `app.py`) resolve to nothing, so the whole
+        // launch yields no binds.
         let home = tempfile::tempdir().unwrap();
-        let out = launch_ro_binds(
+        let out = ro_binds(
             OsStr::new("python3"),
             &[
                 OsString::from("-m"),
@@ -545,7 +649,7 @@ mod tests {
                 OsString::from("app.py"),
                 OsString::from("/no/such/abs/path"),
             ],
-            home.path().as_os_str(),
+            home.path(),
         );
         assert!(out.is_empty());
     }
@@ -559,10 +663,10 @@ mod tests {
         std::fs::write(&a, b"").unwrap();
         let b = dir.join("b.py");
         std::fs::write(&b, b"").unwrap();
-        let out = launch_ro_binds(
+        let out = ro_binds(
             OsStr::new("python3"),
             &[OsString::from(&a), OsString::from(&b)],
-            home.path().as_os_str(),
+            home.path(),
         );
         assert_eq!(out, vec![dir.canonicalize().unwrap()]);
     }
@@ -570,10 +674,10 @@ mod tests {
     #[test]
     fn arg_equal_to_tmp_is_skipped() {
         let home = tempfile::tempdir().unwrap();
-        let out = launch_ro_binds(
+        let out = ro_binds(
             OsStr::new("python3"),
             &[OsString::from("/tmp")],
-            home.path().as_os_str(),
+            home.path(),
         );
         assert!(out.is_empty());
     }
@@ -581,10 +685,10 @@ mod tests {
     #[test]
     fn arg_equal_to_home_is_skipped() {
         let home = tempfile::tempdir().unwrap();
-        let out = launch_ro_binds(
+        let out = ro_binds(
             OsStr::new("python3"),
             &[OsString::from(home.path())],
-            home.path().as_os_str(),
+            home.path(),
         );
         assert!(out.is_empty());
     }
@@ -595,11 +699,7 @@ mod tests {
         let home = root.path().join("a/b/c");
         std::fs::create_dir_all(&home).unwrap();
         let ancestor = root.path().join("a/b"); // ancestor of home, not home itself
-        let out = launch_ro_binds(
-            OsStr::new("python3"),
-            &[OsString::from(&ancestor)],
-            home.as_os_str(),
-        );
+        let out = ro_binds(OsStr::new("python3"), &[OsString::from(&ancestor)], &home);
         assert!(out.is_empty());
     }
 
@@ -607,12 +707,215 @@ mod tests {
     fn file_directly_under_tmp_binds_the_file_only() {
         let home = tempfile::tempdir().unwrap(); // unrelated to the /tmp file below
         let file = tempfile::Builder::new().tempfile_in("/tmp").unwrap();
+        let out = ro_binds(
+            OsStr::new("python3"),
+            &[OsString::from(file.path())],
+            home.path(),
+        );
+        assert_eq!(out, vec![file.path().canonicalize().unwrap()]);
+    }
+
+    // --- literal-path (symlink) reachability -------------------------------------------------
+
+    /// A symlink under `home` whose target lives OUTSIDE both shadowed roots (a venv/pyenv-style
+    /// `bin/python` → a system binary): bwrap opens the LITERAL symlink, so its directory must be
+    /// bound, not only the resolved target's. This is the `run[0]` regression the first increment
+    /// re-introduced by deciding binds from `canonicalize()` alone.
+    #[test]
+    fn symlink_program_binds_the_literal_dir_even_when_target_is_outside_roots() {
+        let home = tempfile::tempdir().unwrap();
+        let bindir = home.path().join("venv/bin");
+        std::fs::create_dir_all(&bindir).unwrap();
+        let target = Path::new("/bin/sh"); // a real binary outside home and /tmp
+        assert!(target.exists(), "test needs /bin/sh present");
+        let link = bindir.join("python");
+        std::os::unix::fs::symlink(target, &link).unwrap();
+        let out = ro_binds(link.as_os_str(), &[], home.path());
+        assert!(
+            out.contains(&bindir.canonicalize().unwrap()),
+            "literal symlink's dir must be bound so bwrap can open it as written; got {out:?}"
+        );
+    }
+
+    /// A symlink under `home` whose target ALSO lives under `home` (a different directory): BOTH the
+    /// literal symlink's directory and the resolved target's directory must be bound.
+    #[test]
+    fn symlink_program_target_under_home_binds_both_dirs() {
+        let home = tempfile::tempdir().unwrap();
+        let bindir = home.path().join("venv/bin");
+        let libdir = home.path().join("venv/lib");
+        std::fs::create_dir_all(&bindir).unwrap();
+        std::fs::create_dir_all(&libdir).unwrap();
+        let target = libdir.join("python3.real");
+        std::fs::write(&target, b"").unwrap();
+        let link = bindir.join("python");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        let out = ro_binds(link.as_os_str(), &[], home.path());
+        assert!(
+            out.contains(&bindir.canonicalize().unwrap()),
+            "literal symlink's dir missing: {out:?}"
+        );
+        assert!(
+            out.contains(&libdir.canonicalize().unwrap()),
+            "resolved target's dir missing: {out:?}"
+        );
+    }
+
+    // --- bare-name program via $PATH ---------------------------------------------------------
+
+    #[test]
+    fn resolve_on_path_in_finds_first_executable_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let exe = dir.path().join("mytool");
+        std::fs::write(&exe, b"").unwrap();
+        std::fs::set_permissions(&exe, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let path = std::env::join_paths([dir.path()]).unwrap();
+        assert_eq!(resolve_on_path_in(OsStr::new("mytool"), &path), Some(exe));
+    }
+
+    #[test]
+    fn resolve_on_path_in_skips_non_executable_and_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let plain = dir.path().join("mytool");
+        std::fs::write(&plain, b"").unwrap(); // exists but NOT executable
+        std::fs::set_permissions(&plain, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let path = std::env::join_paths([dir.path()]).unwrap();
+        assert_eq!(resolve_on_path_in(OsStr::new("mytool"), &path), None);
+        assert_eq!(resolve_on_path_in(OsStr::new("absent"), &path), None);
+    }
+
+    /// A bare-name program installed only under a `$HOME` `PATH` dir (`~/.cargo/bin`, an asdf shim)
+    /// is hidden by the home tmpfs, so its resolving directory must be bound. Prepends a home bin
+    /// dir to `PATH` (keeping the rest, so concurrent readers still resolve their own binaries) and
+    /// installs a uniquely named executable there; a RAII guard restores `PATH` even on panic.
+    #[test]
+    fn bare_name_program_on_a_home_path_dir_binds_that_dir() {
+        struct PathGuard(std::ffi::OsString);
+        impl Drop for PathGuard {
+            fn drop(&mut self) {
+                std::env::set_var("PATH", &self.0);
+            }
+        }
+
+        let home = tempfile::tempdir().unwrap();
+        let bindir = home.path().join(".local/bin");
+        std::fs::create_dir_all(&bindir).unwrap();
+        let tool = bindir.join("glass-uniq-tool-xyzzy");
+        std::fs::write(&tool, b"#!/bin/sh\n").unwrap();
+        std::fs::set_permissions(&tool, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let cwd = tempfile::tempdir().unwrap();
+        let out = {
+            let original = std::env::var_os("PATH").unwrap_or_default();
+            let mut prepended = bindir.clone().into_os_string();
+            prepended.push(":");
+            prepended.push(&original);
+            std::env::set_var("PATH", &prepended);
+            let _guard = PathGuard(original);
+            launch_ro_binds(
+                OsStr::new("glass-uniq-tool-xyzzy"),
+                &[],
+                home.path(),
+                cwd.path(),
+            )
+        };
+        assert_eq!(out, vec![bindir.canonicalize().unwrap()]);
+    }
+
+    // --- relative token resolution against cwd -----------------------------------------------
+
+    /// A relative launch argument (`assets/data.bin`) is resolved against `cwd` and its directory
+    /// bound, so a contained launch that names files relative to its working dir reaches them.
+    #[test]
+    fn relative_arg_is_resolved_against_cwd_and_bound() {
+        let home = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        let sub = cwd.path().join("assets");
+        std::fs::create_dir_all(&sub).unwrap();
+        std::fs::write(sub.join("data.bin"), b"").unwrap();
+        let out = launch_ro_binds(
+            OsStr::new("python3"),
+            &[OsString::from("assets/data.bin")],
+            home.path(),
+            cwd.path(),
+        );
+        assert_eq!(out, vec![sub.canonicalize().unwrap()]);
+    }
+
+    // --- /tmp guard isolated from home (load-bearing for the /tmp shadowed root) --------------
+
+    /// The `/tmp` guard must hold even when `home` is unrelated to `/tmp`: a real file directly
+    /// under `/tmp` is bound file-only (never `/tmp` as a directory), and an arg of exactly `/tmp`
+    /// is skipped. `home` is a NONEXISTENT path OUTSIDE `/tmp` (canon falls back to it), so ONLY
+    /// the literal `/tmp` entry in `shadowed_roots` protects `/tmp` — remove it and this test
+    /// fails (the file's dir `/tmp` would be bound, and `/tmp` itself would bind rather than skip).
+    #[test]
+    fn tmp_guard_holds_when_home_is_outside_tmp() {
+        let home = Path::new("/nonexistent-glass-home-outside-tmp");
+        let cwd = tempfile::tempdir().unwrap();
+        let file = tempfile::Builder::new().tempfile_in("/tmp").unwrap();
+
+        // A real file directly under /tmp → bind the FILE only, never /tmp as a directory.
         let out = launch_ro_binds(
             OsStr::new("python3"),
             &[OsString::from(file.path())],
-            home.path().as_os_str(),
+            home,
+            cwd.path(),
         );
         assert_eq!(out, vec![file.path().canonicalize().unwrap()]);
+        assert!(!out.iter().any(|p| *p == Path::new("/tmp")));
+
+        // An arg of exactly /tmp → skipped entirely.
+        let out2 = launch_ro_binds(
+            OsStr::new("python3"),
+            &[OsString::from("/tmp")],
+            home,
+            cwd.path(),
+        );
+        assert!(
+            out2.is_empty(),
+            "an arg of /tmp must be skipped; got {out2:?}"
+        );
+    }
+
+    // --- secret-isolation invariant ----------------------------------------------------------
+
+    /// The hard invariant over a mixed launch: no produced bind may equal a shadowed root
+    /// (`home`, `/tmp`) or be an ancestor of one.
+    #[test]
+    fn no_bind_equals_a_shadowed_root_or_ancestor() {
+        let home = tempfile::tempdir().unwrap();
+        let cwd = home.path().join("proj");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let in_home = home.path().join("top.py");
+        std::fs::write(&in_home, b"").unwrap();
+        let tmpfile = tempfile::Builder::new().tempfile_in("/tmp").unwrap();
+        std::fs::write(cwd.join("r.sh"), b"").unwrap();
+        let out = launch_ro_binds(
+            OsStr::new("python3"),
+            &[
+                OsString::from(&in_home),       // file directly under home
+                OsString::from(tmpfile.path()), // file directly under /tmp
+                OsString::from("/tmp"),         // a shadowed root itself
+                OsString::from(home.path()),    // home itself
+                OsString::from("r.sh"),         // relative → cwd/r.sh
+            ],
+            home.path(),
+            &cwd,
+        );
+        let home_c = home.path().canonicalize().unwrap();
+        let roots = [home_c.as_path(), Path::new("/tmp")];
+        for b in &out {
+            // `root.starts_with(b)` is true iff `b` equals a root or is an ancestor of one.
+            assert!(
+                !roots.iter().any(|root| root.starts_with(b)),
+                "bind {b:?} equals a shadowed root or an ancestor of one"
+            );
+        }
+        assert!(
+            !out.is_empty(),
+            "sanity: the launch should still bind something"
+        );
     }
 
     #[test]

--- a/crates/glass-sandbox-linux/src/lib.rs
+++ b/crates/glass-sandbox-linux/src/lib.rs
@@ -76,6 +76,8 @@ pub struct WrapOpts {
 ///   nothing. Arguments are NOT `$PATH`-resolved.
 /// - **A relative token** (program-with-`/` or any relative argument) is resolved against `cwd`
 ///   (`cwd.join(token)`) before binding, so `./start.sh` / `sub/asset` reach their real location.
+///   When `cwd` is `None` (glass could not resolve a default working directory) a relative token
+///   is SKIPPED rather than resolved against a wrong root.
 /// - **An absolute token** is bound as-is.
 ///
 /// For each resolved token, bwrap opens the path *as written*, but a symlink's target may live
@@ -90,7 +92,7 @@ pub fn launch_ro_binds(
     program: &OsStr,
     args: &[OsString],
     home: &Path,
-    cwd: &Path,
+    cwd: Option<&Path>,
 ) -> Vec<PathBuf> {
     let home = canon(home);
     let shadowed_roots = [home.as_path(), Path::new("/tmp")];
@@ -98,12 +100,11 @@ pub fn launch_ro_binds(
 
     // run[0] (the program).
     if program.as_bytes().contains(&b'/') {
-        // A path program: absolute, or relative (e.g. `./start.sh`) → resolved against cwd.
-        push_token_binds(
-            &mut out,
-            &abs_token(Path::new(program), cwd),
-            &shadowed_roots,
-        );
+        // A path program: absolute, or relative (e.g. `./start.sh`) → resolved against cwd. A
+        // relative token with no known cwd resolves to nothing and is skipped (not bound to `/`).
+        if let Some(p) = abs_token(Path::new(program), cwd) {
+            push_token_binds(&mut out, &p, &shadowed_roots);
+        }
     } else if let Some(resolved) = resolve_on_path(program) {
         // A bare name → resolve via `$PATH` like execvp. Bind the resolving directory ONLY when
         // it is under a shadowed root (a `$HOME`/`/tmp` PATH dir such as `~/.cargo/bin`, an asdf
@@ -116,18 +117,22 @@ pub fn launch_ro_binds(
 
     // run[1..] (arguments): absolute or cwd-relative path tokens (never $PATH-resolved).
     for a in args {
-        push_token_binds(&mut out, &abs_token(Path::new(a), cwd), &shadowed_roots);
+        if let Some(p) = abs_token(Path::new(a), cwd) {
+            push_token_binds(&mut out, &p, &shadowed_roots);
+        }
     }
     out
 }
 
 /// Resolve a token to an absolute host path: an absolute token as-is, a relative one against
 /// `cwd` (`execvp`/shell semantics), so a relative launch argument reaches its real location.
-fn abs_token(tok: &Path, cwd: &Path) -> PathBuf {
+/// Returns `None` for a relative token when `cwd` is unknown — the token is then skipped rather
+/// than resolved against a wrong root like `/`.
+fn abs_token(tok: &Path, cwd: Option<&Path>) -> Option<PathBuf> {
     if tok.is_absolute() {
-        tok.to_path_buf()
+        Some(tok.to_path_buf())
     } else {
-        cwd.join(tok)
+        cwd.map(|c| c.join(tok))
     }
 }
 
@@ -277,20 +282,21 @@ pub fn wrap_argv(program: &OsStr, args: &[OsString], opts: &WrapOpts) -> Vec<OsS
     if let Some(cwd) = &opts.cwd {
         let home_c = canon(std::path::Path::new(&opts.home));
         let cwd_c = canon(cwd);
-        // Guard: skip the rw bind when cwd IS home or an ancestor of home.
+        // Guard: skip the rw bind when cwd IS a tmpfs-shadowed root (`home` or `/tmp`) or an
+        // ancestor of one. Mirrors the `shadowed_roots` prefix logic in `launch_ro_binds`.
         //
-        // `--tmpfs <home>` mounts an ephemeral tmpfs over the real $HOME to hide
-        // ~/.ssh and other secrets.  If we also emit `--bind <cwd> <cwd>` and cwd
-        // equals home (or is a parent of home, e.g. cwd="/home" home="/home/u"),
-        // that bind re-mounts the real HOME subtree OVER the tmpfs — re-exposing
-        // everything we just hid.
+        // `--tmpfs <home>` and `--tmpfs /tmp` mount ephemeral tmpfs over the real $HOME (hiding
+        // ~/.ssh etc.) and /tmp. If we also emit `--bind <cwd> <cwd>` and cwd equals a shadowed
+        // root (or is a parent of one — e.g. cwd="/home" with home="/home/u", or cwd="/tmp" now
+        // that cwd defaults to glass's current dir), that bind re-mounts the real subtree OVER the
+        // tmpfs, re-exposing everything we just hid.
         //
-        // `home_c.starts_with(&cwd_c)` is true in both the equal case and the
-        // ancestor case, so we skip the bind in both.  The common subdir case
-        // (cwd="/home/u/proj") gives starts_with=false and is bound rw as usual.
-        // The `--ro-bind / /` + tmpfs already provide the path for the skipped
-        // cases so `--chdir` still works.
-        if !home_c.starts_with(&cwd_c) {
+        // `root.starts_with(&cwd_c)` is true when cwd equals a root or is an ancestor of it, so we
+        // skip the bind in both cases. The common subdir case (cwd="/home/u/proj" or "/tmp/scratch")
+        // gives false and is bound rw as usual. The `--ro-bind / /` + tmpfs already provide the path
+        // for the skipped cases so `--chdir` still works.
+        let shadowed_roots = [home_c.as_path(), std::path::Path::new("/tmp")];
+        if !shadowed_roots.iter().any(|root| root.starts_with(&cwd_c)) {
             v.push(OsString::from("--bind"));
             v.push(cwd.clone().into_os_string());
             v.push(cwd.clone().into_os_string());
@@ -560,6 +566,30 @@ mod tests {
         );
     }
 
+    /// `/tmp` is a tmpfs-shadowed root too. Now that cwd defaults to glass's own working
+    /// directory, glass running with cwd exactly `/tmp` must NOT emit `--bind /tmp /tmp` (that
+    /// would re-mount host `/tmp` over the ephemeral tmpfs), but `--chdir /tmp` must still appear.
+    #[test]
+    fn cwd_equal_to_tmp_skips_bind_but_keeps_chdir() {
+        let o = WrapOpts {
+            level: SandboxLevel::Default,
+            home: OsString::from("/home/u"),
+            // cwd == /tmp: the dangerous case the home-only guard used to miss.
+            cwd: Some(PathBuf::from("/tmp")),
+            ro_binds: vec![],
+            rw_binds: vec![],
+        };
+        let s = argv_strings(&wrap_argv(OsStr::new("app"), &[], &o));
+        assert!(
+            !s.windows(3).any(|w| w == ["--bind", "/tmp", "/tmp"]),
+            "cwd==/tmp must not emit --bind /tmp /tmp; got: {s:?}"
+        );
+        assert!(
+            s.windows(2).any(|w| w == ["--chdir", "/tmp"]),
+            "cwd==/tmp must still emit --chdir /tmp; got: {s:?}"
+        );
+    }
+
     // -------------------------------------------------------------------------
     // launch_ro_binds tests
     // -------------------------------------------------------------------------
@@ -569,15 +599,17 @@ mod tests {
     /// resolution call `launch_ro_binds` directly with a populated `cwd`.
     fn ro_binds(program: &OsStr, args: &[OsString], home: &Path) -> Vec<PathBuf> {
         let cwd = tempfile::tempdir().unwrap();
-        launch_ro_binds(program, args, home, cwd.path())
+        launch_ro_binds(program, args, home, Some(cwd.path()))
     }
 
     #[test]
     fn bare_name_program_via_usr_bin_binds_nothing() {
-        // `python3` resolves under /usr/bin (already visible via --ro-bind / /), not a $HOME/tmp
-        // PATH dir, so it contributes no bind.
+        // `env` is a coreutils tool guaranteed on the system PATH under a non-shadowed dir
+        // (/usr/bin, already visible via --ro-bind / /), so resolving it contributes no bind. Using
+        // `env` rather than `python3` guarantees the "resolves under a non-shadowed dir → no bind"
+        // branch is actually exercised (a missing program would take the None path instead).
         let home = tempfile::tempdir().unwrap();
-        assert!(ro_binds(OsStr::new("python3"), &[], home.path()).is_empty());
+        assert!(ro_binds(OsStr::new("env"), &[], home.path()).is_empty());
     }
 
     #[test]
@@ -816,7 +848,7 @@ mod tests {
                 OsStr::new("glass-uniq-tool-xyzzy"),
                 &[],
                 home.path(),
-                cwd.path(),
+                Some(cwd.path()),
             )
         };
         assert_eq!(out, vec![bindir.canonicalize().unwrap()]);
@@ -837,7 +869,26 @@ mod tests {
             OsStr::new("python3"),
             &[OsString::from("assets/data.bin")],
             home.path(),
-            cwd.path(),
+            Some(cwd.path()),
+        );
+        assert_eq!(out, vec![sub.canonicalize().unwrap()]);
+    }
+
+    /// A relative token with NO known `cwd` (`None`) is SKIPPED, not resolved against `/` — so it
+    /// never binds a wrong top-level directory. An absolute token in the same call still binds, so
+    /// the ONLY bind here is that absolute path's directory.
+    #[test]
+    fn relative_token_with_no_cwd_is_skipped() {
+        let home = tempfile::tempdir().unwrap();
+        let sub = home.path().join("sub");
+        std::fs::create_dir_all(&sub).unwrap();
+        let abs = sub.join("keep.bin");
+        std::fs::write(&abs, b"").unwrap();
+        let out = launch_ro_binds(
+            OsStr::new("./run.sh"), // relative program → skipped when cwd is None
+            &[OsString::from("assets/data.bin"), OsString::from(&abs)],
+            home.path(),
+            None,
         );
         assert_eq!(out, vec![sub.canonicalize().unwrap()]);
     }
@@ -860,7 +911,7 @@ mod tests {
             OsStr::new("python3"),
             &[OsString::from(file.path())],
             home,
-            cwd.path(),
+            Some(cwd.path()),
         );
         assert_eq!(out, vec![file.path().canonicalize().unwrap()]);
         assert!(!out.iter().any(|p| *p == Path::new("/tmp")));
@@ -870,7 +921,7 @@ mod tests {
             OsStr::new("python3"),
             &[OsString::from("/tmp")],
             home,
-            cwd.path(),
+            Some(cwd.path()),
         );
         assert!(
             out2.is_empty(),
@@ -901,7 +952,7 @@ mod tests {
                 OsString::from("r.sh"),         // relative → cwd/r.sh
             ],
             home.path(),
-            &cwd,
+            Some(cwd.as_path()),
         );
         let home_c = home.path().canonicalize().unwrap();
         let roots = [home_c.as_path(), Path::new("/tmp")];

--- a/crates/glass-sandbox-linux/src/lib.rs
+++ b/crates/glass-sandbox-linux/src/lib.rs
@@ -74,6 +74,50 @@ pub fn program_ro_binds(program: &OsStr) -> Vec<std::path::PathBuf> {
     }
 }
 
+/// Read-only binds that make the launch target reachable inside the namespace: the program and
+/// every `run` argument that names an existing absolute path. The ephemeral-`$HOME` and `/tmp`
+/// tmpfs shadow anything under those roots, so a script/asset passed by absolute path must be
+/// re-bound to be visible. Bare-name programs (resolved via `PATH` under `--ro-bind / /`) and
+/// relative args (covered by the `cwd` bind) contribute nothing.
+///
+/// Each target is exposed by its directory (so sibling modules/assets are reachable), EXCEPT when
+/// that directory is a tmpfs-shadowed root (`home` or `/tmp`) or an ancestor of one — binding it
+/// would re-mount the real subtree over the tmpfs, so only the file itself is bound. Read-only,
+/// de-duplicated. Mirrors the `cwd` guard in `WrapOpts`.
+pub fn launch_ro_binds(program: &OsStr, args: &[OsString], home: &OsStr) -> Vec<PathBuf> {
+    let home = canon(std::path::Path::new(home));
+    let shadowed_roots = [home.as_path(), std::path::Path::new("/tmp")];
+    let mut out: Vec<PathBuf> = Vec::new();
+    for tok in std::iter::once(program).chain(args.iter().map(|a| a.as_os_str())) {
+        let p = std::path::Path::new(tok);
+        if !p.is_absolute() {
+            continue; // bare-name (PATH) or relative (cwd) — already reachable
+        }
+        let real = canon(p);
+        if std::fs::metadata(&real).is_err() {
+            continue; // not an existing path (a flag/value) — nothing to bind
+        }
+        let is_dir = std::fs::metadata(&real)
+            .map(|m| m.is_dir())
+            .unwrap_or(false);
+        let dir: &std::path::Path = if is_dir {
+            &real
+        } else {
+            real.parent().unwrap_or(&real)
+        };
+        // Never re-expose a tmpfs-shadowed root (or an ancestor of one) as a directory.
+        let bind = if shadowed_roots.iter().any(|root| root.starts_with(dir)) {
+            real.clone()
+        } else {
+            dir.to_path_buf()
+        };
+        if !out.contains(&bind) {
+            out.push(bind);
+        }
+    }
+    out
+}
+
 /// The ephemeral HOME path to use: the real `$HOME` (so apps that hardcode the path
 /// still work — it's shadowed by a tmpfs), else a fixed fallback.
 pub fn ephemeral_home() -> OsString {
@@ -445,6 +489,103 @@ mod tests {
             binds.is_empty(),
             "bare name needs no extra bind; got: {binds:?}"
         );
+    }
+
+    // -------------------------------------------------------------------------
+    // launch_ro_binds tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn bare_name_program_binds_nothing() {
+        let home = tempfile::tempdir().unwrap();
+        let out = launch_ro_binds(OsStr::new("python3"), &[], home.path().as_os_str());
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn program_under_a_project_dir_binds_its_directory() {
+        let home = tempfile::tempdir().unwrap();
+        let proj = home.path().join("proj/app");
+        std::fs::create_dir_all(&proj).unwrap();
+        let bin = proj.join("bin");
+        std::fs::write(&bin, b"").unwrap();
+        let out = launch_ro_binds(bin.as_os_str(), &[], home.path().as_os_str());
+        assert_eq!(out, vec![proj.canonicalize().unwrap()]); // the file's directory, not the file
+    }
+
+    #[test]
+    fn arg_script_binds_its_directory_so_siblings_are_reachable() {
+        let home = tempfile::tempdir().unwrap();
+        let dir = home.path().join("proj");
+        std::fs::create_dir_all(&dir).unwrap();
+        let script = dir.join("app.py");
+        std::fs::write(&script, b"").unwrap();
+        let out = launch_ro_binds(
+            OsStr::new("python3"),
+            &[OsString::from(&script)],
+            home.path().as_os_str(),
+        );
+        assert_eq!(out, vec![dir.canonicalize().unwrap()]);
+    }
+
+    #[test]
+    fn existing_directory_arg_binds_itself() {
+        let home = tempfile::tempdir().unwrap();
+        let data = home.path().join("proj/data");
+        std::fs::create_dir_all(&data).unwrap();
+        let out = launch_ro_binds(
+            OsStr::new("srv"),
+            &[OsString::from("--root"), OsString::from(&data)],
+            home.path().as_os_str(),
+        );
+        assert_eq!(out, vec![data.canonicalize().unwrap()]);
+    }
+
+    #[test]
+    fn target_directly_in_home_binds_only_the_file() {
+        let home = tempfile::tempdir().unwrap();
+        let script = home.path().join("app.py"); // parent dir == home
+        std::fs::write(&script, b"").unwrap();
+        let out = launch_ro_binds(
+            OsStr::new("python3"),
+            &[OsString::from(&script)],
+            home.path().as_os_str(),
+        );
+        assert_eq!(out, vec![script.canonicalize().unwrap()]); // guard: never bind home itself as a dir
+        assert!(!out.iter().any(|p| p == home.path()));
+    }
+
+    #[test]
+    fn nonpath_and_relative_args_contribute_nothing() {
+        let home = tempfile::tempdir().unwrap();
+        let out = launch_ro_binds(
+            OsStr::new("python3"),
+            &[
+                OsString::from("-m"),
+                OsString::from("http.server"),
+                OsString::from("app.py"),
+                OsString::from("/no/such/abs/path"),
+            ],
+            home.path().as_os_str(),
+        );
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn duplicate_dirs_are_collapsed() {
+        let home = tempfile::tempdir().unwrap();
+        let dir = home.path().join("proj");
+        std::fs::create_dir_all(&dir).unwrap();
+        let a = dir.join("a.py");
+        std::fs::write(&a, b"").unwrap();
+        let b = dir.join("b.py");
+        std::fs::write(&b, b"").unwrap();
+        let out = launch_ro_binds(
+            OsStr::new("python3"),
+            &[OsString::from(&a), OsString::from(&b)],
+            home.path().as_os_str(),
+        );
+        assert_eq!(out, vec![dir.canonicalize().unwrap()]);
     }
 
     #[test]

--- a/crates/glass-sandbox-linux/src/lib.rs
+++ b/crates/glass-sandbox-linux/src/lib.rs
@@ -82,8 +82,10 @@ pub fn program_ro_binds(program: &OsStr) -> Vec<std::path::PathBuf> {
 ///
 /// Each target is exposed by its directory (so sibling modules/assets are reachable), EXCEPT when
 /// that directory is a tmpfs-shadowed root (`home` or `/tmp`) or an ancestor of one — binding it
-/// would re-mount the real subtree over the tmpfs, so only the file itself is bound. Read-only,
-/// de-duplicated. Mirrors the `cwd` guard in `WrapOpts`.
+/// would re-mount the real subtree over the tmpfs, so only the file itself is bound. A target that
+/// IS itself a shadowed root or an ancestor of one (e.g. an arg of `/tmp`, `home`, or `/`)
+/// contributes no bind at all, for the same reason. Read-only, de-duplicated. Mirrors the `cwd`
+/// guard in `WrapOpts`.
 pub fn launch_ro_binds(program: &OsStr, args: &[OsString], home: &OsStr) -> Vec<PathBuf> {
     let home = canon(std::path::Path::new(home));
     let shadowed_roots = [home.as_path(), std::path::Path::new("/tmp")];
@@ -94,20 +96,23 @@ pub fn launch_ro_binds(program: &OsStr, args: &[OsString], home: &OsStr) -> Vec<
             continue; // bare-name (PATH) or relative (cwd) — already reachable
         }
         let real = canon(p);
-        if std::fs::metadata(&real).is_err() {
+        let Ok(meta) = std::fs::metadata(&real) else {
             continue; // not an existing path (a flag/value) — nothing to bind
+        };
+        // Never auto-expose a shadowed root itself (or an ancestor of one) — binding it would
+        // re-mount the real subtree over the tmpfs. Such targets need cwd / an explicit bind /
+        // sandbox off.
+        if shadowed_roots.iter().any(|root| root.starts_with(&real)) {
+            continue;
         }
-        let is_dir = std::fs::metadata(&real)
-            .map(|m| m.is_dir())
-            .unwrap_or(false);
-        let dir: &std::path::Path = if is_dir {
+        let dir: &std::path::Path = if meta.is_dir() {
             &real
         } else {
             real.parent().unwrap_or(&real)
         };
         // Never re-expose a tmpfs-shadowed root (or an ancestor of one) as a directory.
         let bind = if shadowed_roots.iter().any(|root| root.starts_with(dir)) {
-            real.clone()
+            real.clone() // real is a genuine file/subpath under a shadowed root (checked above) → safe
         } else {
             dir.to_path_buf()
         };
@@ -552,7 +557,9 @@ mod tests {
             home.path().as_os_str(),
         );
         assert_eq!(out, vec![script.canonicalize().unwrap()]); // guard: never bind home itself as a dir
-        assert!(!out.iter().any(|p| p == home.path()));
+        assert!(!out
+            .iter()
+            .any(|p| *p == home.path().canonicalize().unwrap()));
     }
 
     #[test]
@@ -586,6 +593,54 @@ mod tests {
             home.path().as_os_str(),
         );
         assert_eq!(out, vec![dir.canonicalize().unwrap()]);
+    }
+
+    #[test]
+    fn arg_equal_to_tmp_is_skipped() {
+        let home = tempfile::tempdir().unwrap();
+        let out = launch_ro_binds(
+            OsStr::new("python3"),
+            &[OsString::from("/tmp")],
+            home.path().as_os_str(),
+        );
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn arg_equal_to_home_is_skipped() {
+        let home = tempfile::tempdir().unwrap();
+        let out = launch_ro_binds(
+            OsStr::new("python3"),
+            &[OsString::from(home.path())],
+            home.path().as_os_str(),
+        );
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn ancestor_of_home_is_skipped() {
+        let root = tempfile::tempdir().unwrap();
+        let home = root.path().join("a/b/c");
+        std::fs::create_dir_all(&home).unwrap();
+        let ancestor = root.path().join("a/b"); // ancestor of home, not home itself
+        let out = launch_ro_binds(
+            OsStr::new("python3"),
+            &[OsString::from(&ancestor)],
+            home.as_os_str(),
+        );
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn file_directly_under_tmp_binds_the_file_only() {
+        let home = tempfile::tempdir().unwrap(); // unrelated to the /tmp file below
+        let file = tempfile::Builder::new().tempfile_in("/tmp").unwrap();
+        let out = launch_ro_binds(
+            OsStr::new("python3"),
+            &[OsString::from(file.path())],
+            home.path().as_os_str(),
+        );
+        assert_eq!(out, vec![file.path().canonicalize().unwrap()]);
     }
 
     #[test]

--- a/crates/glass-testapp/tests/integration.rs
+++ b/crates/glass-testapp/tests/integration.rs
@@ -1498,9 +1498,10 @@ fn window_op_on_a_closed_window_reports_window_not_found() {
 /// the `--ro-bind / /` PATH lookup) execs `run.sh` (the arg needing the fix), which execs
 /// the sibling testapp binary (now visible in the same bound dir).
 ///
-/// Before the fix, `launch_ro_binds` considered only `run[0]` (`sh`, a bare name that
-/// contributes no bind), so the temp dir stayed hidden behind the tmpfs shadow, `sh`
-/// could not read `run.sh`, and `start_app` failed with `SandboxedAppExited`.
+/// Load-bearing: `run.sh`'s directory is exposed ONLY because `launch_ro_binds` binds the
+/// directory of the `run[1]` path argument. Stub that bind away and the temp dir stays hidden
+/// behind the tmpfs shadow, `sh` cannot read `run.sh`, and `start_app` fails with
+/// `SandboxedAppExited` — the check that keeps this test honest.
 #[test]
 #[ignore = "requires an X server + bwrap; run via scripts/test-x11.sh"]
 fn sandbox_default_reaches_launch_target_via_argument_path() {
@@ -1541,6 +1542,131 @@ fn sandbox_default_reaches_launch_target_via_argument_path() {
     assert!(
         wait_for_log(&mut p, "READY", 60),
         "never saw READY on stdout (sandboxed, arg-path launch)"
+    );
+    p.stop_app().unwrap();
+}
+
+/// A **relative** launch token with `cwd: None` must still resolve under the default sandbox.
+/// With no `cwd`, glass defaults the sandbox working directory to its OWN cwd, so it emits
+/// `--chdir <cwd>` + a guarded rw bind of that directory and resolves relative tokens against it.
+/// The test `chdir`s into a fresh temp dir holding `run.sh` (+ a sibling `glass-testapp` copy it
+/// execs), then launches `sh ./run.sh` with `cwd: None`.
+///
+/// Load-bearing: without the cwd default, `cwd: None` leaves the child's cwd on the empty ephemeral
+/// `$HOME` tmpfs and passes no cwd to `launch_ro_binds`, so `./run.sh` cannot resolve and the app
+/// exits with `SandboxedAppExited`. A RAII guard restores the process cwd even on panic; the suite
+/// runs `--test-threads=1`.
+#[test]
+#[ignore = "requires an X server + bwrap; run via scripts/test-x11.sh"]
+fn sandbox_default_reaches_relative_launch_token_with_defaulted_cwd() {
+    use std::os::unix::fs::PermissionsExt;
+
+    struct CwdGuard(std::path::PathBuf);
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.0);
+        }
+    }
+
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let testapp_copy = dir.path().join("glass-testapp");
+    std::fs::copy(TESTAPP, &testapp_copy).expect("copy glass-testapp into temp dir");
+    let run_sh = dir.path().join("run.sh");
+    std::fs::write(
+        &run_sh,
+        format!("#!/bin/sh\nexec \"{}\"\n", testapp_copy.display()),
+    )
+    .expect("write run.sh");
+    std::fs::set_permissions(&run_sh, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod +x run.sh");
+
+    let original_cwd = std::env::current_dir().expect("read cwd");
+    let _cwd_guard = CwdGuard(original_cwd);
+    std::env::set_current_dir(dir.path()).expect("chdir into temp dir");
+
+    let xvfb = Xvfb::start();
+    let mut p = X11Platform::connect(Some(&xvfb.display)).unwrap();
+    let spec = AppSpec {
+        build: None,
+        // Relative token; cwd is None so it must resolve against glass's defaulted cwd.
+        run: vec!["sh".to_string(), "./run.sh".to_string()],
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        timeout_ms: 8000,
+        sandbox: glass_core::SandboxLevel::Default,
+        a11y: false,
+    };
+    let geom = p
+        .start_app(&spec)
+        .unwrap_or_else(|e| panic!("relative launch token unreachable with a defaulted cwd: {e}"));
+    assert_eq!(geom.width, 320);
+    assert_eq!(geom.height, 240);
+    assert!(
+        wait_for_log(&mut p, "READY", 60),
+        "never saw READY on stdout (relative token, defaulted cwd)"
+    );
+    p.stop_app().unwrap();
+}
+
+/// A **bare-name** program resolvable only via a `PATH` directory under a tmpfs-shadowed root
+/// (`~/.cargo/bin`, an asdf shim; here a temp dir under `/tmp`) must still launch under the default
+/// sandbox. `launch_ro_binds` resolves `run[0]` against `$PATH` like `execvp` and binds the
+/// resolving directory when it is shadowed, so the child's own `execvp` finds it inside bwrap.
+///
+/// Load-bearing: without the `$PATH`-resolution bind the bin dir stays hidden behind the `/tmp`
+/// tmpfs, the child's `execvp` fails, and the launch exits with `SandboxedAppExited`. A RAII guard
+/// restores `PATH`; the suite runs `--test-threads=1`.
+#[test]
+#[ignore = "requires an X server + bwrap; run via scripts/test-x11.sh"]
+fn sandbox_default_reaches_bare_name_program_on_a_shadowed_path_dir() {
+    use std::os::unix::fs::PermissionsExt;
+
+    struct PathGuard(std::ffi::OsString);
+    impl Drop for PathGuard {
+        fn drop(&mut self) {
+            std::env::set_var("PATH", &self.0);
+        }
+    }
+
+    let dir = tempfile::tempdir().expect("create temp dir"); // under /tmp (tmpfs-shadowed)
+    let bindir = dir.path().join("bin");
+    std::fs::create_dir_all(&bindir).expect("create bin dir");
+    let tool = bindir.join("glass-testapp-bare");
+    std::fs::copy(TESTAPP, &tool).expect("copy glass-testapp as a bare-name tool");
+    std::fs::set_permissions(&tool, std::fs::Permissions::from_mode(0o755)).expect("chmod +x tool");
+
+    let xvfb = Xvfb::start();
+    let mut p = X11Platform::connect(Some(&xvfb.display)).unwrap();
+
+    // Prepend the shadowed bin dir to PATH (keep the rest so bwrap/Xvfb still resolve).
+    let original_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut prepended = bindir.clone().into_os_string();
+    prepended.push(":");
+    prepended.push(&original_path);
+    std::env::set_var("PATH", &prepended);
+    let _path_guard = PathGuard(original_path);
+
+    let spec = AppSpec {
+        build: None,
+        run: vec!["glass-testapp-bare".to_string()], // bare name resolved via the shadowed PATH dir
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        timeout_ms: 8000,
+        sandbox: glass_core::SandboxLevel::Default,
+        a11y: false,
+    };
+    let geom = p.start_app(&spec).unwrap_or_else(|e| {
+        panic!(
+            "bare-name program on a shadowed PATH dir unreachable under the default sandbox: {e}"
+        )
+    });
+    assert_eq!(geom.width, 320);
+    assert_eq!(geom.height, 240);
+    assert!(
+        wait_for_log(&mut p, "READY", 60),
+        "never saw READY on stdout (bare-name on a shadowed PATH dir)"
     );
     p.stop_app().unwrap();
 }

--- a/crates/glass-testapp/tests/integration.rs
+++ b/crates/glass-testapp/tests/integration.rs
@@ -1487,3 +1487,60 @@ fn window_op_on_a_closed_window_reports_window_not_found() {
 
     p.stop_app().ok();
 }
+
+/// Reproduces the reported bug: a launch target reached only through an **argument**
+/// (`run[1]`), not `run[0]` itself, must still be reachable under the default sandbox.
+/// `launch_ro_binds` binds the *directory* of every `run` token that is an absolute,
+/// existing path — so placing `run.sh` in a fresh temp dir (under `/tmp`, which the
+/// sandbox's tmpfs shadows) alongside a copy of `glass-testapp`, and having `run.sh`
+/// `exec` that sibling copy, means the one bind for `run.sh`'s directory also exposes
+/// the testapp copy. The whole launch chain then succeeds: `sh` (bare name, reached via
+/// the `--ro-bind / /` PATH lookup) execs `run.sh` (the arg needing the fix), which execs
+/// the sibling testapp binary (now visible in the same bound dir).
+///
+/// Before the fix, `launch_ro_binds` considered only `run[0]` (`sh`, a bare name that
+/// contributes no bind), so the temp dir stayed hidden behind the tmpfs shadow, `sh`
+/// could not read `run.sh`, and `start_app` failed with `SandboxedAppExited`.
+#[test]
+#[ignore = "requires an X server + bwrap; run via scripts/test-x11.sh"]
+fn sandbox_default_reaches_launch_target_via_argument_path() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let testapp_copy = dir.path().join("glass-testapp");
+    std::fs::copy(TESTAPP, &testapp_copy).expect("copy glass-testapp into temp dir");
+
+    let run_sh = dir.path().join("run.sh");
+    std::fs::write(
+        &run_sh,
+        format!("#!/bin/sh\nexec \"{}\"\n", testapp_copy.display()),
+    )
+    .expect("write run.sh");
+    // `fs::copy` preserves the source's executable bit, but `fs::write` does not —
+    // the wrapper script needs it set explicitly.
+    std::fs::set_permissions(&run_sh, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod +x run.sh");
+
+    let xvfb = Xvfb::start();
+    let mut p = X11Platform::connect(Some(&xvfb.display)).unwrap();
+    let spec = AppSpec {
+        build: None,
+        run: vec!["sh".to_string(), run_sh.to_string_lossy().into_owned()],
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        timeout_ms: 8000,
+        sandbox: glass_core::SandboxLevel::Default,
+        a11y: false,
+    };
+    let geom = p.start_app(&spec).unwrap_or_else(|e| {
+        panic!("arg-path launch target unreachable under the default sandbox: {e}")
+    });
+    assert_eq!(geom.width, 320);
+    assert_eq!(geom.height, 240);
+    assert!(
+        wait_for_log(&mut p, "READY", 60),
+        "never saw READY on stdout (sandboxed, arg-path launch)"
+    );
+    p.stop_app().unwrap();
+}

--- a/crates/glass-testapp/tests/wayland.rs
+++ b/crates/glass-testapp/tests/wayland.rs
@@ -621,6 +621,56 @@ fn fail_closed_when_bwrap_missing_wayland() {
     );
 }
 
+/// Wayland twin of the X11 `sandbox_default_reaches_launch_target_via_argument_path`
+/// test: the reported bug reproduced on the other Linux backend, which shares the same
+/// `launch_ro_binds` fix. A launch target reached only through an **argument**
+/// (`run[1]`), not `run[0]` itself, must still be reachable under the default sandbox.
+/// See the X11 test in `tests/integration.rs` for the full rationale — the fixture
+/// shape (temp dir + sibling testapp copy + `run.sh`) is identical.
+#[test]
+#[ignore = "requires sway + bwrap; run via scripts/test-wayland.sh"]
+fn sandbox_default_reaches_launch_target_via_argument_path() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let testapp_copy = dir.path().join("glass-testapp");
+    std::fs::copy(TESTAPP, &testapp_copy).expect("copy glass-testapp into temp dir");
+
+    let run_sh = dir.path().join("run.sh");
+    std::fs::write(
+        &run_sh,
+        format!("#!/bin/sh\nexec \"{}\"\n", testapp_copy.display()),
+    )
+    .expect("write run.sh");
+    // `fs::copy` preserves the source's executable bit, but `fs::write` does not —
+    // the wrapper script needs it set explicitly.
+    std::fs::set_permissions(&run_sh, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod +x run.sh");
+
+    let mut p = WaylandPlatform::new().unwrap();
+    let sandboxed_spec = AppSpec {
+        build: None,
+        run: vec!["sh".to_string(), run_sh.to_string_lossy().into_owned()],
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        timeout_ms: APP_TIMEOUT_MS,
+        sandbox: glass_core::SandboxLevel::Default,
+        a11y: false,
+    };
+    let geom = start(&mut p, &sandboxed_spec);
+    assert_eq!(
+        (geom.width, geom.height),
+        (320, 240),
+        "arg-path launch target unreachable under the default sandbox"
+    );
+    assert!(
+        drain_until(&mut p, "READY", READY_TRIES),
+        "never saw READY (sandboxed, arg-path launch)"
+    );
+    p.stop_app().unwrap();
+}
+
 // ---------------------------------------------------------------------------
 // Build-step integration tests (bwrap + sway)
 // ---------------------------------------------------------------------------

--- a/crates/glass-testapp/tests/wayland.rs
+++ b/crates/glass-testapp/tests/wayland.rs
@@ -671,6 +671,119 @@ fn sandbox_default_reaches_launch_target_via_argument_path() {
     p.stop_app().unwrap();
 }
 
+/// Wayland twin of the X11 `sandbox_default_reaches_relative_launch_token_with_defaulted_cwd`.
+/// A relative launch token with `cwd: None` resolves against glass's DEFAULTED cwd (its own
+/// working directory), which is `--chdir`'d and rw-bound into the namespace. See the X11 test for
+/// the full rationale; the fixture and the shared `launch_ro_binds` / cwd-default wiring are
+/// identical. Load-bearing on the same code path (verified on X11 by stubbing the cwd default).
+#[test]
+#[ignore = "requires sway + bwrap; run via scripts/test-wayland.sh"]
+fn sandbox_default_reaches_relative_launch_token_with_defaulted_cwd() {
+    use std::os::unix::fs::PermissionsExt;
+
+    struct CwdGuard(std::path::PathBuf);
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.0);
+        }
+    }
+
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let testapp_copy = dir.path().join("glass-testapp");
+    std::fs::copy(TESTAPP, &testapp_copy).expect("copy glass-testapp into temp dir");
+    let run_sh = dir.path().join("run.sh");
+    std::fs::write(
+        &run_sh,
+        format!("#!/bin/sh\nexec \"{}\"\n", testapp_copy.display()),
+    )
+    .expect("write run.sh");
+    std::fs::set_permissions(&run_sh, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod +x run.sh");
+
+    let original_cwd = std::env::current_dir().expect("read cwd");
+    let _cwd_guard = CwdGuard(original_cwd);
+    std::env::set_current_dir(dir.path()).expect("chdir into temp dir");
+
+    let mut p = WaylandPlatform::new().unwrap();
+    let sandboxed_spec = AppSpec {
+        build: None,
+        run: vec!["sh".to_string(), "./run.sh".to_string()],
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        timeout_ms: APP_TIMEOUT_MS,
+        sandbox: glass_core::SandboxLevel::Default,
+        a11y: false,
+    };
+    let geom = start(&mut p, &sandboxed_spec);
+    assert_eq!(
+        (geom.width, geom.height),
+        (320, 240),
+        "relative launch token unreachable with a defaulted cwd"
+    );
+    assert!(
+        drain_until(&mut p, "READY", READY_TRIES),
+        "never saw READY (relative token, defaulted cwd)"
+    );
+    p.stop_app().unwrap();
+}
+
+/// Wayland twin of the X11 `sandbox_default_reaches_bare_name_program_on_a_shadowed_path_dir`.
+/// A bare-name program resolvable only via a `PATH` dir under a shadowed root must launch under the
+/// default sandbox because `launch_ro_binds` resolves `run[0]` against `$PATH` and binds the
+/// resolving directory. See the X11 test for the full rationale. Load-bearing on the same shared
+/// code path (verified on X11 by stubbing the resolution bind).
+#[test]
+#[ignore = "requires sway + bwrap; run via scripts/test-wayland.sh"]
+fn sandbox_default_reaches_bare_name_program_on_a_shadowed_path_dir() {
+    use std::os::unix::fs::PermissionsExt;
+
+    struct PathGuard(std::ffi::OsString);
+    impl Drop for PathGuard {
+        fn drop(&mut self) {
+            std::env::set_var("PATH", &self.0);
+        }
+    }
+
+    let dir = tempfile::tempdir().expect("create temp dir"); // under /tmp (tmpfs-shadowed)
+    let bindir = dir.path().join("bin");
+    std::fs::create_dir_all(&bindir).expect("create bin dir");
+    let tool = bindir.join("glass-testapp-bare");
+    std::fs::copy(TESTAPP, &tool).expect("copy glass-testapp as a bare-name tool");
+    std::fs::set_permissions(&tool, std::fs::Permissions::from_mode(0o755)).expect("chmod +x tool");
+
+    let mut p = WaylandPlatform::new().unwrap();
+
+    let original_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut prepended = bindir.clone().into_os_string();
+    prepended.push(":");
+    prepended.push(&original_path);
+    std::env::set_var("PATH", &prepended);
+    let _path_guard = PathGuard(original_path);
+
+    let sandboxed_spec = AppSpec {
+        build: None,
+        run: vec!["glass-testapp-bare".to_string()],
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        timeout_ms: APP_TIMEOUT_MS,
+        sandbox: glass_core::SandboxLevel::Default,
+        a11y: false,
+    };
+    let geom = start(&mut p, &sandboxed_spec);
+    assert_eq!(
+        (geom.width, geom.height),
+        (320, 240),
+        "bare-name program on a shadowed PATH dir unreachable under the default sandbox"
+    );
+    assert!(
+        drain_until(&mut p, "READY", READY_TRIES),
+        "never saw READY (bare-name on a shadowed PATH dir)"
+    );
+    p.stop_app().unwrap();
+}
+
 // ---------------------------------------------------------------------------
 // Build-step integration tests (bwrap + sway)
 // ---------------------------------------------------------------------------

--- a/crates/glass-wayland/src/command.rs
+++ b/crates/glass-wayland/src/command.rs
@@ -54,10 +54,10 @@ pub fn sway_config(spec: &AppSpec, runtime_dir: &Path, a11y_bind_dir: Option<&Pa
         level => {
             let prog = OsString::from(&spec.run[0]);
             let args: Vec<OsString> = spec.run[1..].iter().map(OsString::from).collect();
-            // Re-expose the program binary when it is absolute (it may live under
-            // $HOME, which the ephemeral tmpfs shadows). PATH-resolved bare names
-            // are covered by `--ro-bind / /` and need no extra bind.
-            let mut ro_binds = glass_sandbox_linux::program_ro_binds(&prog);
+            // Re-expose the launch target — the program and any path-argument under $HOME/tmp, which
+            // the ephemeral tmpfs shadows.
+            let mut ro_binds =
+                glass_sandbox_linux::launch_ro_binds(&prog, &args, &ephemeral_home());
             if let Some(dir) = a11y_bind_dir {
                 ro_binds.push(dir.to_path_buf());
             }

--- a/crates/glass-wayland/src/command.rs
+++ b/crates/glass-wayland/src/command.rs
@@ -57,8 +57,20 @@ pub fn sway_config(spec: &AppSpec, runtime_dir: &Path, a11y_bind_dir: Option<&Pa
             // Default the working directory to glass's own cwd when the spec sets none, so a
             // contained launch with no `cwd` still gets `--chdir` + a guarded rw bind of that
             // directory (matching `sandbox:"off"`) and any relative launch token resolves against
-            // it. Computed once and shared by both `launch_ro_binds` and `WrapOpts.cwd`.
-            let effective_cwd = spec.cwd.clone().or_else(|| std::env::current_dir().ok());
+            // it. Computed ONCE (as an `Option<PathBuf>`) and shared by both consumers verbatim:
+            // `launch_ro_binds` via `as_deref()` and `WrapOpts.cwd` by move. If `current_dir()`
+            // fails, the error is logged and both consumers see `None` (no `--chdir`/bind; relative
+            // tokens are skipped, never resolved against a wrong root).
+            let effective_cwd = spec.cwd.clone().or_else(|| {
+                std::env::current_dir()
+                    .inspect_err(|e| {
+                        eprintln!(
+                            "glass: could not resolve a default cwd for the sandboxed launch: {e}; \
+                             relative launch tokens may not resolve"
+                        )
+                    })
+                    .ok()
+            });
             let home_os = ephemeral_home();
             // Re-expose the launch target — the program and any path token under $HOME or /tmp,
             // which the ephemeral tmpfs shadows.
@@ -66,7 +78,7 @@ pub fn sway_config(spec: &AppSpec, runtime_dir: &Path, a11y_bind_dir: Option<&Pa
                 &prog,
                 &args,
                 Path::new(&home_os),
-                effective_cwd.as_deref().unwrap_or_else(|| Path::new("/")),
+                effective_cwd.as_deref(),
             );
             if let Some(dir) = a11y_bind_dir {
                 ro_binds.push(dir.to_path_buf());
@@ -318,6 +330,39 @@ mod tests {
             cfg.contains(&needle),
             "arg dir not bound into the exec bwrap:\nwant: {needle}\ngot:\n{cfg}"
         );
+    }
+
+    #[test]
+    fn sway_config_defaults_cwd_to_current_dir_when_unset() {
+        // With cwd: None and a sandbox, glass defaults the working directory to its OWN cwd, so the
+        // exec bwrap must carry `--chdir <current_dir>` (and, unless current_dir is the ephemeral
+        // HOME/tmp or an ancestor, a rw `--bind <current_dir> <current_dir>`). Both test and code
+        // read current_dir() in-process, so it's a literal-value assertion.
+        use glass_core::SandboxLevel;
+        let cwd = std::env::current_dir().unwrap();
+        let mut s = spec(&["/bin/app"]);
+        s.sandbox = SandboxLevel::Default;
+        s.cwd = None;
+        let cfg = sway_config(&s, std::path::Path::new("/run/glass-rt"), None);
+        let cwd_s = cwd.to_string_lossy();
+        assert!(
+            cfg.contains(&format!("'--chdir' '{cwd_s}'")),
+            "expected --chdir {cwd_s} in exec:\n{cfg}"
+        );
+        let home = ephemeral_home();
+        let home_c = std::path::Path::new(&home)
+            .canonicalize()
+            .unwrap_or_else(|_| std::path::PathBuf::from(&home));
+        let cwd_c = cwd.canonicalize().unwrap_or_else(|_| cwd.clone());
+        let cwd_is_root_or_ancestor = [home_c.as_path(), std::path::Path::new("/tmp")]
+            .iter()
+            .any(|root| root.starts_with(&cwd_c));
+        if !cwd_is_root_or_ancestor {
+            assert!(
+                cfg.contains(&format!("'--bind' '{cwd_s}' '{cwd_s}'")),
+                "expected --bind {cwd_s} {cwd_s} in exec:\n{cfg}"
+            );
+        }
     }
 
     #[test]

--- a/crates/glass-wayland/src/command.rs
+++ b/crates/glass-wayland/src/command.rs
@@ -54,17 +54,27 @@ pub fn sway_config(spec: &AppSpec, runtime_dir: &Path, a11y_bind_dir: Option<&Pa
         level => {
             let prog = OsString::from(&spec.run[0]);
             let args: Vec<OsString> = spec.run[1..].iter().map(OsString::from).collect();
-            // Re-expose the launch target — the program and any path-argument under $HOME/tmp, which
-            // the ephemeral tmpfs shadows.
-            let mut ro_binds =
-                glass_sandbox_linux::launch_ro_binds(&prog, &args, &ephemeral_home());
+            // Default the working directory to glass's own cwd when the spec sets none, so a
+            // contained launch with no `cwd` still gets `--chdir` + a guarded rw bind of that
+            // directory (matching `sandbox:"off"`) and any relative launch token resolves against
+            // it. Computed once and shared by both `launch_ro_binds` and `WrapOpts.cwd`.
+            let effective_cwd = spec.cwd.clone().or_else(|| std::env::current_dir().ok());
+            let home_os = ephemeral_home();
+            // Re-expose the launch target — the program and any path token under $HOME or /tmp,
+            // which the ephemeral tmpfs shadows.
+            let mut ro_binds = glass_sandbox_linux::launch_ro_binds(
+                &prog,
+                &args,
+                Path::new(&home_os),
+                effective_cwd.as_deref().unwrap_or_else(|| Path::new("/")),
+            );
             if let Some(dir) = a11y_bind_dir {
                 ro_binds.push(dir.to_path_buf());
             }
             let opts = WrapOpts {
                 level,
-                home: ephemeral_home(),
-                cwd: spec.cwd.clone(),
+                home: home_os,
+                cwd: effective_cwd,
                 ro_binds,
                 rw_binds: vec![runtime_dir.to_path_buf()],
             };
@@ -285,6 +295,28 @@ mod tests {
         assert_eq!(
             dbus.as_deref(),
             Some("unix:path=/tmp/glass-a11y/session-bus")
+        );
+    }
+
+    #[test]
+    fn sway_config_binds_an_absolute_argument_path_dir() {
+        // A launch target reached only through an ARGUMENT path (not run[0]) must be re-exposed:
+        // the arg's directory is bound into the exec bwrap argv. Runs under the default
+        // (display-less) `cargo test`, catching an `&args` mis-wire the #[ignore]d integration
+        // test would otherwise be the only guard against.
+        use glass_core::SandboxLevel;
+        let dir = tempfile::Builder::new().tempdir_in("/tmp").unwrap(); // under /tmp, not $HOME
+        let asset = dir.path().join("asset.bin");
+        std::fs::write(&asset, b"").unwrap();
+        let asset_s = asset.to_string_lossy();
+        let mut s = spec(&["/bin/cat", asset_s.as_ref()]);
+        s.sandbox = SandboxLevel::Default;
+        let cfg = sway_config(&s, std::path::Path::new("/run/glass-rt"), None);
+        let argdir = dir.path().canonicalize().unwrap();
+        let needle = format!("'--ro-bind-try' '{d}' '{d}'", d = argdir.to_string_lossy());
+        assert!(
+            cfg.contains(&needle),
+            "arg dir not bound into the exec bwrap:\nwant: {needle}\ngot:\n{cfg}"
         );
     }
 

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -533,7 +533,10 @@ fn bring_up_session(
             // group, not just the leader, or a leaked Xwayland holds the X
             // display in the global namespace and breaks the next session.
             glass_proc_linux::reap_group(&mut child, glass_proc_linux::REAP_GRACE);
-            return Err(GlassError::AppExited(status.code()));
+            return Err(GlassError::app_exited_during_discovery(
+                status.code(),
+                spec.sandbox != glass_core::SandboxLevel::Off,
+            ));
         }
         if Instant::now() >= deadline {
             glass_proc_linux::reap_group(&mut child, glass_proc_linux::REAP_GRACE);
@@ -569,7 +572,10 @@ fn bring_up_session(
                 // Reap the whole group (see the socket-wait loop above): an
                 // unclean sway exit can orphan Xwayland + the app otherwise.
                 glass_proc_linux::reap_group(&mut child, glass_proc_linux::REAP_GRACE);
-                return Err(GlassError::AppExited(status.code()));
+                return Err(GlassError::app_exited_during_discovery(
+                    status.code(),
+                    spec.sandbox != glass_core::SandboxLevel::Off,
+                ));
             }
             if Instant::now() >= deadline {
                 glass_proc_linux::reap_group(&mut child, glass_proc_linux::REAP_GRACE);

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -535,7 +535,7 @@ fn bring_up_session(
             glass_proc_linux::reap_group(&mut child, glass_proc_linux::REAP_GRACE);
             return Err(GlassError::app_exited_during_discovery(
                 status.code(),
-                spec.sandbox != glass_core::SandboxLevel::Off,
+                spec.sandbox,
             ));
         }
         if Instant::now() >= deadline {
@@ -574,7 +574,7 @@ fn bring_up_session(
                 glass_proc_linux::reap_group(&mut child, glass_proc_linux::REAP_GRACE);
                 return Err(GlassError::app_exited_during_discovery(
                     status.code(),
-                    spec.sandbox != glass_core::SandboxLevel::Off,
+                    spec.sandbox,
                 ));
             }
             if Instant::now() >= deadline {

--- a/crates/glass-x11/Cargo.toml
+++ b/crates/glass-x11/Cargo.toml
@@ -26,6 +26,7 @@ x11rb.workspace = true
 
 [dev-dependencies]
 criterion = { workspace = true }
+tempfile = { workspace = true }
 
 [[bench]]
 name = "pixels"

--- a/crates/glass-x11/src/command.rs
+++ b/crates/glass-x11/src/command.rs
@@ -32,12 +32,14 @@ pub fn build_command(spec: &AppSpec, display: &str, a11y: Option<glass_core::A11
         level => {
             let prog = OsString::from(&spec.run[0]);
             let args: Vec<OsString> = spec.run[1..].iter().map(OsString::from).collect();
-            // Always re-expose the X11 socket dir; also re-expose the program
-            // binary itself when it is absolute (it may live under $HOME, which
-            // the ephemeral tmpfs shadows). PATH-resolved bare names are covered
-            // by `--ro-bind / /` and need no extra bind.
+            // Always re-expose the X11 socket dir; also re-expose the launch target — the program and
+            // any argument that names a path under $HOME/tmp, which the ephemeral tmpfs shadows.
             let mut ro_binds = vec![std::path::PathBuf::from("/tmp/.X11-unix")];
-            ro_binds.extend(glass_sandbox_linux::program_ro_binds(&prog));
+            ro_binds.extend(glass_sandbox_linux::launch_ro_binds(
+                &prog,
+                &args,
+                &ephemeral_home(),
+            ));
             // Re-expose the private a11y bus dir (session-bus + at-spi sockets) so a sandboxed
             // app can reach the advertised unix:path= sockets, like the X11 socket above.
             if let Some(dir) = a11y_bind_dir {

--- a/crates/glass-x11/src/command.rs
+++ b/crates/glass-x11/src/command.rs
@@ -35,8 +35,20 @@ pub fn build_command(spec: &AppSpec, display: &str, a11y: Option<glass_core::A11
             // Default the working directory to glass's own cwd when the spec sets none, so a
             // contained launch with no `cwd` still gets `--chdir` + a guarded rw bind of that
             // directory (matching `sandbox:"off"`) and any relative launch token resolves against
-            // it. Computed once and shared by both `launch_ro_binds` and `WrapOpts.cwd`.
-            let effective_cwd = spec.cwd.clone().or_else(|| std::env::current_dir().ok());
+            // it. Computed ONCE (as an `Option<PathBuf>`) and shared by both consumers verbatim:
+            // `launch_ro_binds` via `as_deref()` and `WrapOpts.cwd` by move. If `current_dir()`
+            // fails, the error is logged and both consumers see `None` (no `--chdir`/bind; relative
+            // tokens are skipped, never resolved against a wrong root).
+            let effective_cwd = spec.cwd.clone().or_else(|| {
+                std::env::current_dir()
+                    .inspect_err(|e| {
+                        eprintln!(
+                            "glass: could not resolve a default cwd for the sandboxed launch: {e}; \
+                             relative launch tokens may not resolve"
+                        )
+                    })
+                    .ok()
+            });
             let home_os = ephemeral_home();
             // Always re-expose the X11 socket dir; also re-expose the launch target — the program
             // and any path token under $HOME or /tmp, which the ephemeral tmpfs shadows.
@@ -45,9 +57,7 @@ pub fn build_command(spec: &AppSpec, display: &str, a11y: Option<glass_core::A11
                 &prog,
                 &args,
                 std::path::Path::new(&home_os),
-                effective_cwd
-                    .as_deref()
-                    .unwrap_or_else(|| std::path::Path::new("/")),
+                effective_cwd.as_deref(),
             ));
             // Re-expose the private a11y bus dir (session-bus + at-spi sockets) so a sandboxed
             // app can reach the advertised unix:path= sockets, like the X11 socket above.
@@ -276,6 +286,46 @@ mod tests {
                 .any(|w| w[0] == "--ro-bind-try" && w[1] == argdir && w[2] == argdir),
             "arg dir {argdir} not bound into bwrap argv: {args:?}"
         );
+    }
+
+    #[test]
+    fn build_command_defaults_cwd_to_current_dir_when_unset() {
+        // With cwd: None and a sandbox, glass defaults the working directory to its OWN cwd, so the
+        // bwrap argv must carry `--chdir <current_dir>` (and, unless current_dir is the ephemeral
+        // HOME/tmp or an ancestor, a rw `--bind <current_dir> <current_dir>`). Both this test and
+        // the code read current_dir() in-process, so it's a literal-value assertion.
+        use glass_core::SandboxLevel;
+        let cwd = std::env::current_dir().unwrap();
+        let mut s = spec(&["/bin/app"]);
+        s.sandbox = SandboxLevel::Default;
+        s.cwd = None;
+        let cmd = build_command(&s, ":99", None);
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        let cwd_s = cwd.to_string_lossy().into_owned();
+        assert!(
+            args.windows(2).any(|w| w[0] == "--chdir" && w[1] == cwd_s),
+            "expected --chdir {cwd_s} in argv: {args:?}"
+        );
+        // The rw bind is suppressed only when current_dir is a shadowed root or an ancestor of one
+        // (the secret-isolation guard); assert it otherwise (the normal project-dir case).
+        let home = ephemeral_home();
+        let home_c = std::path::Path::new(&home)
+            .canonicalize()
+            .unwrap_or_else(|_| std::path::PathBuf::from(&home));
+        let cwd_c = cwd.canonicalize().unwrap_or_else(|_| cwd.clone());
+        let cwd_is_root_or_ancestor = [home_c.as_path(), std::path::Path::new("/tmp")]
+            .iter()
+            .any(|root| root.starts_with(&cwd_c));
+        if !cwd_is_root_or_ancestor {
+            assert!(
+                args.windows(3)
+                    .any(|w| w[0] == "--bind" && w[1] == cwd_s && w[2] == cwd_s),
+                "expected --bind {cwd_s} {cwd_s} in argv: {args:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/glass-x11/src/command.rs
+++ b/crates/glass-x11/src/command.rs
@@ -32,13 +32,22 @@ pub fn build_command(spec: &AppSpec, display: &str, a11y: Option<glass_core::A11
         level => {
             let prog = OsString::from(&spec.run[0]);
             let args: Vec<OsString> = spec.run[1..].iter().map(OsString::from).collect();
-            // Always re-expose the X11 socket dir; also re-expose the launch target — the program and
-            // any argument that names a path under $HOME/tmp, which the ephemeral tmpfs shadows.
+            // Default the working directory to glass's own cwd when the spec sets none, so a
+            // contained launch with no `cwd` still gets `--chdir` + a guarded rw bind of that
+            // directory (matching `sandbox:"off"`) and any relative launch token resolves against
+            // it. Computed once and shared by both `launch_ro_binds` and `WrapOpts.cwd`.
+            let effective_cwd = spec.cwd.clone().or_else(|| std::env::current_dir().ok());
+            let home_os = ephemeral_home();
+            // Always re-expose the X11 socket dir; also re-expose the launch target — the program
+            // and any path token under $HOME or /tmp, which the ephemeral tmpfs shadows.
             let mut ro_binds = vec![std::path::PathBuf::from("/tmp/.X11-unix")];
             ro_binds.extend(glass_sandbox_linux::launch_ro_binds(
                 &prog,
                 &args,
-                &ephemeral_home(),
+                std::path::Path::new(&home_os),
+                effective_cwd
+                    .as_deref()
+                    .unwrap_or_else(|| std::path::Path::new("/")),
             ));
             // Re-expose the private a11y bus dir (session-bus + at-spi sockets) so a sandboxed
             // app can reach the advertised unix:path= sockets, like the X11 socket above.
@@ -47,8 +56,8 @@ pub fn build_command(spec: &AppSpec, display: &str, a11y: Option<glass_core::A11
             }
             let opts = WrapOpts {
                 level,
-                home: ephemeral_home(),
-                cwd: spec.cwd.clone(),
+                home: home_os,
+                cwd: effective_cwd,
                 ro_binds,
                 rw_binds: vec![],
             };
@@ -236,6 +245,37 @@ mod tests {
             .find(|(k, _)| *k == std::ffi::OsStr::new("DISPLAY"))
             .and_then(|(_, v)| v);
         assert_eq!(disp, Some(std::ffi::OsStr::new(":99")));
+    }
+
+    #[test]
+    fn build_command_binds_an_absolute_argument_path_dir() {
+        // A launch target reached only through an ARGUMENT path (not run[0]) must be re-exposed:
+        // the arg's directory is bound into the bwrap argv. This runs under the default
+        // (display-less) `cargo test`, so it catches an `&args` mis-wire that the #[ignore]d
+        // integration test would otherwise be the only guard against.
+        use glass_core::SandboxLevel;
+        let dir = tempfile::Builder::new().tempdir_in("/tmp").unwrap(); // under /tmp, not $HOME
+        let asset = dir.path().join("asset.bin");
+        std::fs::write(&asset, b"").unwrap();
+        let asset_s = asset.to_string_lossy();
+        let mut s = spec(&["/bin/cat", asset_s.as_ref()]);
+        s.sandbox = SandboxLevel::Default;
+        let cmd = build_command(&s, ":99", None);
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        let argdir = dir
+            .path()
+            .canonicalize()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        assert!(
+            args.windows(3)
+                .any(|w| w[0] == "--ro-bind-try" && w[1] == argdir && w[2] == argdir),
+            "arg dir {argdir} not bound into bwrap argv: {args:?}"
+        );
     }
 
     #[test]

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -333,7 +333,10 @@ impl X11Platform {
             }
             if let Some(child) = self.child.as_mut() {
                 if let Ok(Some(status)) = child.try_wait() {
-                    return Err(GlassError::AppExited(status.code()));
+                    return Err(GlassError::app_exited_during_discovery(
+                        status.code(),
+                        spec.sandbox != glass_core::SandboxLevel::Off,
+                    ));
                 }
             }
             if Instant::now() >= deadline {

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -335,7 +335,7 @@ impl X11Platform {
                 if let Ok(Some(status)) = child.try_wait() {
                     return Err(GlassError::app_exited_during_discovery(
                         status.code(),
-                        spec.sandbox != glass_core::SandboxLevel::Off,
+                        spec.sandbox,
                     ));
                 }
             }


### PR DESCRIPTION
## Problem

The default Linux sandbox mounts a tmpfs over `$HOME` (and `/tmp`) for secret isolation, but only
re-bound `run[0]` and `cwd`. So a launch target hidden by that tmpfs would fail to start — the app
exited before its window appeared, surfacing only as a bare `app exited (code N)`:

- a script/asset passed by **absolute path** under `$HOME` (`python3 /home/u/app.py`);
- a **symlinked** program under `$HOME` (a venv `bin/python`, an asdf/pyenv/nvm shim);
- a **bare-name** program resolved via a `$HOME` `PATH` entry (`cargo install`/`pipx --user`/`npm -g`);
- a **relative** launch token with no `cwd` (`run:["./start.sh"]`) — bwrap fell the child's cwd back
  to the empty ephemeral `$HOME`.

## Fix

A `launch_ro_binds` reachability pass makes the launch target reachable inside the namespace without
weakening isolation:

- ro-binds the **directory** of the program and of each argument that names an existing absolute
  path — **both** the literal path (as bwrap opens it) and its `canonicalize()`d target, so symlinks
  resolve;
- resolves a **bare-name program** against `$PATH` (like `execvp`) and binds the resolving dir when
  it's under a shadowed root;
- defaults the sandbox working directory to the launcher's cwd (with `--chdir` + a guarded bind) so
  **relative** tokens resolve.

A **guard** ensures a tmpfs-shadowed root (`$HOME`, `/tmp`) or an ancestor is never bound as a
directory — a target sitting directly on a root is bound file-only, and the whole root is skipped.
When a *contained* app still exits before its window, the error now names the likely cause and the
remedy (`SandboxedAppExited`) instead of a bare exit code.

Linux bwrap only; targets are read-only; the secret-isolation invariant is preserved.

## Testing

- Unit tests for every guard branch (literal/canonical, symlink→outside/→inside a root, bare-name
  under `$HOME`-PATH vs `/usr/bin`, whole-root/ancestor skip, the `/tmp` guard isolated from `$HOME`,
  relative-vs-cwd, dedup) — each verified load-bearing, plus a property-style
  `no_bind_equals_a_shadowed_root_or_ancestor`.
- Fast launcher-wiring tests asserting the emitted bwrap argv.
- `#[ignore]`d X11 + Wayland integration tests that launch via argument / relative / bare-name paths
  under the default sandbox and assert the window is discovered.
- Verified end-to-end through the MCP on a real GTK app launched by absolute and relative path under
  the default sandbox with no `cwd`.

`unsafe` stays forbidden; `cargo fmt`/`clippy -D warnings`/`test --workspace` clean; the X11 and
Wayland sandbox integration suites pass.
