### PR TITLE
add server.json for the official MCP registry

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.fixed-width/glass",
+  "title": "glass",
+  "description": "MCP server giving a coding agent a build→see→interact→debug loop over native GUI apps.",
+  "version": "1.0.1",
+  "websiteUrl": "https://fixedwidth.tech/glass",
+  "repository": {
+    "url": "https://github.com/fixed-width/glass",
+    "source": "github"
+  }
+}


### PR DESCRIPTION
Adds a `server.json` so glass can be published to the [official MCP Registry](https://registry.modelcontextprotocol.io).

**A minimal, no-package descriptor** — validated against the `2025-12-11` `server.schema.json` (`ServerDetail`: required `name`/`description`/`version` present; description 86/100; `name` matches the namespace pattern).

glass ships as platform binaries from GitHub Releases and is set up via `claude mcp add` + the permission/`doctor` flow — it isn't a package-manager install, and it's a high-privilege tool that shouldn't be one-click auto-installed. So the entry lists the repo + `websiteUrl` (the setup docs) rather than claiming an `npm`/`pypi`/`oci`/`mcpb` package. (An `mcpb` bundle for one-click install in registry-consuming clients is a possible future addition.)

## After merge
Publish with the `mcp-publisher` CLI (`login github` for the `io.github.fixed-width` namespace → `publish`). This is a metadata push to the registry, decoupled from the binary release pipeline — it registers the existing v1.0.1, no new release.