### PR TITLE
ci: publish server.json to the MCP registry (OIDC)

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,48 @@
+name: Publish to MCP Registry
+
+# Publishes server.json (a no-package descriptor pointing at the repo + website) to the official
+# MCP Registry. Authentication is GitHub OIDC — the workflow runs in a repo under the `fixed-width`
+# org, which proves ownership of the `io.github.fixed-width` namespace, so no stored secret is
+# needed. Runs on a version tag (each release republishes) and on manual dispatch (to publish the
+# current server.json out of band — e.g. the first listing of an already-released version).
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  id-token: write # OIDC token used to authenticate to the registry
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      # On a tag build, set server.json's version from the tag so the registry entry matches the
+      # release exactly; a manual dispatch keeps the committed version.
+      - name: Sync version from tag
+        if: github.ref_type == 'tag'
+        env:
+          TAG_REF: ${{ github.ref }}
+        run: |
+          VERSION="${TAG_REF#refs/tags/v}"
+          # Guard: only a plain semver-ish tag becomes the version; anything else keeps the committed
+          # value (defense-in-depth — the tag is maintainer-controlled, but never trust it into a file).
+          if printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'; then
+            jq --arg v "$VERSION" '.version = $v' server.json > server.tmp && mv server.tmp server.json
+          else
+            echo "tag '$VERSION' is not a plain version; keeping the committed server.json version"
+          fi
+
+      - name: Authenticate to the MCP Registry (OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish
+        run: ./mcp-publisher publish

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -21,9 +21,19 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Install mcp-publisher
+      # Pin the publisher to a specific release and verify its checksum BEFORE running it — this
+      # binary executes in a job holding the OIDC token, so an unpinned `latest` download would be a
+      # supply-chain hole. The runner is always linux/amd64. Bump both fields together to update.
+      - name: Install mcp-publisher (pinned + checksum-verified)
+        env:
+          MCP_PUBLISHER_VERSION: v1.8.0
+          MCP_PUBLISHER_SHA256: 1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          set -euo pipefail
+          curl -fsSL -o mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
+          echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum -c -
+          tar xzf mcp-publisher.tar.gz mcp-publisher
 
       # On a tag build, set server.json's version from the tag so the registry entry matches the
       # release exactly; a manual dispatch keeps the committed version.


### PR DESCRIPTION
Adds `.github/workflows/publish-mcp.yml` to publish `server.json` to the [official MCP Registry](https://registry.modelcontextprotocol.io) via **GitHub OIDC** — no stored secret; running in a repo under the `fixed-width` org proves the `io.github.fixed-width` namespace.

- **Triggers:** `push` on `v*` tags (every release republishes) **and** `workflow_dispatch` (to list an already-released version out of band — e.g. the first listing of 1.0.1).
- **No npm/build steps** — glass has no package; the step just installs `mcp-publisher` and pushes the no-package `server.json` metadata.
- On a tag build it syncs `server.json`'s version from the tag (semver-validated, `env:`-quoted — no injection); a manual dispatch keeps the committed version.
- `actions/checkout` SHA-pinned per the repo rule; the only `uses:`.

After merge I'll `workflow_dispatch` it to publish 1.0.1.