### PR TITLE
Add GitHub issue forms for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,113 @@
+name: Bug report
+description: Something in glass behaves incorrectly — a tool returns the wrong result, a backend misbehaves, or the loop breaks.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug.
+
+        - Please **[search existing issues](https://github.com/fixed-width/glass/issues?q=is%3Aissue)** first — yours may already be reported.
+        - This form is **not for security vulnerabilities**. glass injects input and captures the screen; report those privately via a [security advisory](https://github.com/fixed-width/glass/security/advisories/new).
+        - Not sure it's a bug? Ask in [Discussions](https://github.com/fixed-width/glass/discussions) instead.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did glass actually do? Include the exact error message or tool response if there was one.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: >
+        The sequence that triggers it. Include the `glass_*` tool calls (with their arguments) where
+        relevant, and the target app if it matters.
+      placeholder: |
+        1. glass_start { "run": ["target/release/my-app"] }
+        2. glass_click { "x": 240, "y": 160 }
+        3. glass_screenshot  → the window is blank
+    validations:
+      required: true
+
+  - type: dropdown
+    id: backend
+    attributes:
+      label: Backend
+      description: Which backend were you driving? (See `glass-mcp doctor`, or the `backend` argument to `glass_start`.)
+      options:
+        - X11 (Linux)
+        - Wayland (Linux)
+        - Windows
+        - macOS
+        - Android
+        - iOS
+        - Multiple / not sure
+    validations:
+      required: true
+
+  - type: input
+    id: host-os
+    attributes:
+      label: Host OS and version
+      description: The machine running glass.
+      placeholder: "e.g. Ubuntu 24.04, macOS 26.5, Windows 11 23H2"
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: glass version
+      description: Output of `glass-mcp --version` (or the release tag / commit you built from).
+      placeholder: "e.g. glass-mcp 1.0.0"
+    validations:
+      required: true
+
+  - type: input
+    id: agent
+    attributes:
+      label: Agent / MCP client
+      description: What is driving glass?
+      placeholder: "e.g. Claude Code, Cursor, a custom MCP client"
+    validations:
+      required: false
+
+  - type: textarea
+    id: doctor
+    attributes:
+      label: "`glass-mcp doctor` output"
+      description: Paste the output of `glass-mcp doctor` — it captures the environment and saves a round-trip. Automatically formatted; no backticks needed.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Anything from `glass_logs` or the app's stderr that looks related. Automatically formatted; no backticks needed.
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+        - label: This is not a security vulnerability (those go to a [private advisory](https://github.com/fixed-width/glass/security/advisories/new)).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or idea to discuss
+    url: https://github.com/fixed-width/glass/discussions
+    about: How do I drive app X? Is this the right approach? Open-ended ideas belong in Discussions.
+  - name: Report a security vulnerability
+    url: https://github.com/fixed-width/glass/security/advisories/new
+    about: glass injects input and captures the screen. Report vulnerabilities privately here — never as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,61 @@
+name: Feature request
+description: Suggest a new capability or an improvement to an existing one.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion!
+
+        - Please **[search existing issues](https://github.com/fixed-width/glass/issues?q=is%3Aissue)** first.
+        - Still exploring the idea, or want to gauge interest? Start in [Discussions](https://github.com/fixed-width/glass/discussions) — concrete, scoped proposals belong here.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do that glass can't do today? Describe the situation, not just the fix.
+      placeholder: "When driving <app> on <backend>, I need to … but glass has no way to …"
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like glass to do? A new tool, a new argument, changed behavior — whatever you have in mind.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: backends
+    attributes:
+      label: Which backends does this involve?
+      description: Select all that apply, or "All / core" if it isn't backend-specific.
+      multiple: true
+      options:
+        - All / core (backend-agnostic)
+        - X11 (Linux)
+        - Wayland (Linux)
+        - Windows
+        - macOS
+        - Android
+        - iOS
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you tried or thought about, and why they fall short.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true


### PR DESCRIPTION
Adds the repo's first issue templates as GitHub **YAML issue forms** under `.github/ISSUE_TEMPLATE/`. Forms enforce required fields and produce structured, greppable triage data — which matters for a tool with six backends, where "which backend?" is triage question #1.

## Files

- **`config.yml`** — disables blank issues; redirects **questions/ideas → Discussions** and **vulnerabilities → a private security advisory** (never a public issue, per `SECURITY.md`).
- **`bug_report.yml`** (labels: `bug`) — requires what-happened / expected / repro (with the `glass_*` call sequence) / **backend** dropdown / host OS / **glass version**, plus a "not a security issue" acknowledgement. `glass-mcp doctor` output and logs are optional-but-encouraged.
- **`feature_request.yml`** (labels: `enhancement`) — requires the problem/use-case; multi-select backend dropdown; proposal and alternatives optional.

## Notes

- Minimal required set so reporters aren't scared off — but the required fields are exactly the ones that otherwise cost a round-trip (backend, version).
- All three validated as parseable YAML.
- Templates only take effect once merged to the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)