### PR TITLE
Ignore regions for visual comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,10 @@ internal refactors, CI, or test-only changes.
   `glass_wait_stable`, and `glass_do`'s `settle` action accept `ignore` — window-relative
   rectangles excluded from the comparison — so perpetually animating content (a blinking text
   caret, a clock, a spinner) no longer keeps `changed_pct` permanently non-zero or prevents a
-  settle from ever completing. `glass_diff` reports the excluded count as `ignored_pixels`, and
-  `changed_pct` is measured over the pixels that remain.
+  settle from ever completing. `glass_diff`, `glass_wait_stable`, and `glass_wait_for_region` each
+  report the excluded count as `ignored_pixels` — so a mask that covers the whole compared area is
+  visible rather than hidden behind a hollow `settled`/`matched` — and `changed_pct` is measured
+  over the pixels that remain.
 
 ## [1.0.1] - 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+### Added
+- **Ignore regions for visual comparison.** `glass_diff`, `glass_wait_for_region`, and
+  `glass_wait_stable` accept `ignore` — window-relative rectangles excluded from the comparison —
+  so perpetually animating content (a blinking text caret, a clock, a spinner) no longer keeps
+  `changed_pct` permanently non-zero or prevents `glass_wait_stable` from ever settling.
+  `glass_diff` reports the excluded count as `ignored_pixels`, and `changed_pct` is measured over
+  the pixels that remain.
+
 ## [1.0.1] - 2026-07-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,12 @@ internal refactors, CI, or test-only changes.
 ## [Unreleased]
 
 ### Added
-- **Ignore regions for visual comparison.** `glass_diff`, `glass_wait_for_region`, and
-  `glass_wait_stable` accept `ignore` — window-relative rectangles excluded from the comparison —
-  so perpetually animating content (a blinking text caret, a clock, a spinner) no longer keeps
-  `changed_pct` permanently non-zero or prevents `glass_wait_stable` from ever settling.
-  `glass_diff` reports the excluded count as `ignored_pixels`, and `changed_pct` is measured over
-  the pixels that remain.
+- **Ignore regions for visual comparison.** `glass_diff`, `glass_wait_for_region`,
+  `glass_wait_stable`, and `glass_do`'s `settle` action accept `ignore` — window-relative
+  rectangles excluded from the comparison — so perpetually animating content (a blinking text
+  caret, a clock, a spinner) no longer keeps `changed_pct` permanently non-zero or prevents a
+  settle from ever completing. `glass_diff` reports the excluded count as `ignored_pixels`, and
+  `changed_pct` is measured over the pixels that remain.
 
 ## [1.0.1] - 2026-07-21
 

--- a/crates/glass-core/src/diff.rs
+++ b/crates/glass-core/src/diff.rs
@@ -23,6 +23,10 @@ pub struct DiffResult {
     /// Pixels that differed but were suppressed as anti-aliasing by the perceptual
     /// diff (always 0 for the exact diff). Surfaces how much was filtered.
     pub aa_ignored: u64,
+    /// Pixels excluded from the comparison by an [`IgnoreMask`], counting
+    /// overlapping rects once. `changed_pct` is measured over the remaining
+    /// (considered) pixels.
+    pub ignored_pixels: u64,
 }
 
 /// Rectangles excluded from a comparison, precomputed into merged per-row
@@ -195,6 +199,18 @@ fn pixel_changed(ra: &[u8], rb: &[u8], off: usize, tolerance: u8) -> bool {
 /// Compare two same-size frames. A pixel counts as changed when the maximum
 /// per-channel absolute difference exceeds `tolerance`.
 pub fn diff(a: &Frame, b: &Frame, tolerance: u8) -> Result<DiffResult> {
+    diff_with_mask(a, b, tolerance, &IgnoreMask::empty())
+}
+
+/// Like [`diff`], but pixels covered by `mask` are excluded: they never count as
+/// changed, never extend the bbox, and are removed from the `changed_pct`
+/// denominator. The mask never mutates pixel data.
+pub fn diff_with_mask(
+    a: &Frame,
+    b: &Frame,
+    tolerance: u8,
+    mask: &IgnoreMask,
+) -> Result<DiffResult> {
     if a.width != b.width || a.height != b.height {
         return Err(GlassError::SizeMismatch {
             a: (a.width, a.height),
@@ -210,17 +226,28 @@ pub fn diff(a: &Frame, b: &Frame, tolerance: u8) -> Result<DiffResult> {
         let base = y as usize * row_bytes;
         let ra = &a.pixels[base..base + row_bytes];
         let rb = &b.pixels[base..base + row_bytes];
+        let masked_row = !mask.spans_for_row(y).is_empty();
         let mut off = 0usize;
         let mut col = 0u32;
         // SIMD over full 32-byte (8-pixel) chunks: skip chunks with no change.
         while off + LANES <= row_bytes {
+            let chunk_end = col + (LANES / 4) as u32;
+            // Whole-chunk skip: the cheap win when a mask is large.
+            if masked_row && mask.covers_span(y, col, chunk_end) {
+                off += LANES;
+                col = chunk_end;
+                continue;
+            }
             let va = u8x32::from_slice(&ra[off..off + LANES]);
             let vb = u8x32::from_slice(&rb[off..off + LANES]);
             let d = va.simd_max(vb) - va.simd_min(vb);
             if d.simd_gt(tol_vec).any() {
                 for px in 0..(LANES / 4) {
+                    let cx = col + px as u32;
+                    if masked_row && mask.is_ignored(cx, y) {
+                        continue;
+                    }
                     if pixel_changed(ra, rb, off + px * 4, tolerance) {
-                        let cx = col + px as u32;
                         changed += 1;
                         min_x = min_x.min(cx);
                         min_y = min_y.min(y);
@@ -230,11 +257,11 @@ pub fn diff(a: &Frame, b: &Frame, tolerance: u8) -> Result<DiffResult> {
                 }
             }
             off += LANES;
-            col += (LANES / 4) as u32;
+            col = chunk_end;
         }
         // Scalar tail (< 8 pixels left in the row).
         while off < row_bytes {
-            if pixel_changed(ra, rb, off, tolerance) {
+            if !(masked_row && mask.is_ignored(col, y)) && pixel_changed(ra, rb, off, tolerance) {
                 changed += 1;
                 min_x = min_x.min(col);
                 min_y = min_y.min(y);
@@ -247,24 +274,31 @@ pub fn diff(a: &Frame, b: &Frame, tolerance: u8) -> Result<DiffResult> {
     }
 
     let total = a.pixel_count();
+    let ignored = mask.ignored_count().min(total);
     let bbox = (changed > 0).then(|| BBox {
         x: min_x,
         y: min_y,
         width: max_x - min_x + 1,
         height: max_y - min_y + 1,
     });
-    let changed_pct = if total > 0 {
-        (changed as f64 / total as f64 * 100.0) as f32
-    } else {
-        0.0
-    };
     Ok(DiffResult {
         changed_pixels: changed,
         total_pixels: total,
-        changed_pct,
+        changed_pct: pct(changed, total - ignored),
         bbox,
         aa_ignored: 0,
+        ignored_pixels: ignored,
     })
+}
+
+/// `changed` as a percentage of `considered`; 0.0 when nothing was considered.
+#[inline]
+fn pct(changed: u64, considered: u64) -> f32 {
+    if considered > 0 {
+        (changed as f64 / considered as f64 * 100.0) as f32
+    } else {
+        0.0
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -522,6 +556,7 @@ pub fn diff_perceptual(a: &Frame, b: &Frame, threshold: f32) -> Result<DiffResul
         changed_pct,
         bbox,
         aa_ignored,
+        ignored_pixels: 0,
     })
 }
 
@@ -676,6 +711,7 @@ mod tests {
             changed_pct,
             bbox,
             aa_ignored: 0,
+            ignored_pixels: 0,
         }
     }
 
@@ -878,6 +914,7 @@ mod tests {
             changed_pct,
             bbox,
             aa_ignored,
+            ignored_pixels: 0,
         }
     }
 
@@ -927,6 +964,7 @@ mod tests {
                 None
             },
             aa_ignored: 0,
+            ignored_pixels: 0,
         }
     }
 
@@ -1046,5 +1084,157 @@ mod tests {
             rect(0, 0, 10, 10).intersect(&rect(5, 5, 10, 10)),
             Some(rect(5, 5, 5, 5))
         );
+    }
+
+    // ---- masked exact diff ----
+
+    #[test]
+    fn masked_pixels_do_not_count_as_changed() {
+        let a = Frame::solid(4, 4, [0, 0, 0, 255]);
+        let mut b = a.clone();
+        // Change (1,2) and (3,3); mask only (1,2).
+        for (x, y) in [(1u32, 2u32), (3, 3)] {
+            b.pixels[((y * 4 + x) * 4) as usize] = 255;
+        }
+        let mask = IgnoreMask::new(&[rect(1, 2, 1, 1)], 4, 4).unwrap();
+        let r = diff_with_mask(&a, &b, 0, &mask).unwrap();
+        assert_eq!(r.changed_pixels, 1, "only the unmasked change counts");
+        assert_eq!(r.ignored_pixels, 1);
+        assert_eq!(
+            r.bbox,
+            Some(BBox {
+                x: 3,
+                y: 3,
+                width: 1,
+                height: 1
+            }),
+            "bbox must not stretch to the masked pixel"
+        );
+    }
+
+    #[test]
+    fn changed_pct_uses_the_considered_denominator() {
+        // 4x4 = 16 px; mask 8 px; 1 changed px among the 8 considered => 12.5%.
+        let a = Frame::solid(4, 4, [0, 0, 0, 255]);
+        let mut b = a.clone();
+        b.pixels[0] = 255; // (0,0), unmasked
+        let mask = IgnoreMask::new(&[rect(0, 2, 4, 2)], 4, 4).unwrap();
+        let r = diff_with_mask(&a, &b, 0, &mask).unwrap();
+        assert_eq!(r.ignored_pixels, 8);
+        assert_eq!(r.total_pixels, 16);
+        assert_eq!(r.changed_pixels, 1);
+        assert!((r.changed_pct - 12.5).abs() < 1e-4, "got {}", r.changed_pct);
+    }
+
+    #[test]
+    fn fully_masked_frame_reports_zeros() {
+        let a = Frame::solid(4, 4, [0, 0, 0, 255]);
+        let b = Frame::solid(4, 4, [255, 255, 255, 255]);
+        let mask = IgnoreMask::new(&[rect(0, 0, 4, 4)], 4, 4).unwrap();
+        let r = diff_with_mask(&a, &b, 0, &mask).unwrap();
+        assert_eq!(r.changed_pixels, 0);
+        assert_eq!(r.bbox, None);
+        assert_eq!(r.changed_pct, 0.0);
+        assert_eq!(r.ignored_pixels, r.total_pixels);
+    }
+
+    #[test]
+    fn unmasked_diff_is_unchanged_by_the_new_field() {
+        let a = make(33, 9, 0);
+        let b = make(33, 9, 4);
+        let old = diff(&a, &b, 0).unwrap();
+        let new = diff_with_mask(&a, &b, 0, &IgnoreMask::empty()).unwrap();
+        assert_eq!(old, new);
+        assert_eq!(old.ignored_pixels, 0);
+    }
+
+    #[test]
+    fn masked_simd_matches_masked_scalar_reference() {
+        // Masks chosen to land on and across 8-pixel SIMD chunk boundaries.
+        let sizes = [
+            (1u32, 1u32),
+            (7, 3),
+            (8, 8),
+            (9, 9),
+            (33, 17),
+            (64, 8),
+            (100, 40),
+        ];
+        for &(w, h) in &sizes {
+            let a = make(w, h, 0);
+            let b = make(w, h, 7);
+            let masks = mask_matrix(w, h);
+            for (label, m) in masks {
+                for tol in [0u8, 10] {
+                    assert_eq!(
+                        diff_with_mask(&a, &b, tol, &m).unwrap(),
+                        reference_diff_masked(&a, &b, tol, &m),
+                        "{w}x{h} tol={tol} mask={label}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Mask shapes that exercise empty, sub-chunk, chunk-aligned, cross-chunk,
+    /// full-row, and full-frame coverage.
+    fn mask_matrix(w: u32, h: u32) -> Vec<(&'static str, IgnoreMask)> {
+        let mut out = vec![("empty", IgnoreMask::empty())];
+        let mk = |label, rects: Vec<Region>| (label, IgnoreMask::new(&rects, w, h).unwrap());
+        if w > 0 && h > 0 {
+            out.push(mk("single-px", vec![rect(0, 0, 1, 1)]));
+            out.push(mk("full-frame", vec![rect(0, 0, w, h)]));
+            out.push(mk("first-row", vec![rect(0, 0, w, 1)]));
+        }
+        if w >= 8 && h >= 2 {
+            out.push(mk("chunk-aligned", vec![rect(0, 0, 8, 2)]));
+            out.push(mk("cross-chunk", vec![rect(4, 0, 8, 2)]));
+            out.push(mk("overlapping", vec![rect(0, 0, 6, 2), rect(3, 0, 6, 2)]));
+        }
+        out
+    }
+
+    /// Naive masked reference — the straightforward loop the optimized masked
+    /// diff must agree with.
+    fn reference_diff_masked(a: &Frame, b: &Frame, tolerance: u8, mask: &IgnoreMask) -> DiffResult {
+        let mut changed = 0u64;
+        let (mut min_x, mut min_y, mut max_x, mut max_y) = (u32::MAX, u32::MAX, 0u32, 0u32);
+        for y in 0..a.height {
+            for x in 0..a.width {
+                if mask.is_ignored(x, y) {
+                    continue;
+                }
+                let off = ((y * a.width + x) * 4) as usize;
+                if pixel_changed(&a.pixels, &b.pixels, off, tolerance) {
+                    changed += 1;
+                    min_x = min_x.min(x);
+                    min_y = min_y.min(y);
+                    max_x = max_x.max(x);
+                    max_y = max_y.max(y);
+                }
+            }
+        }
+        let total = a.pixel_count();
+        let ignored = mask.ignored_count().min(total);
+        let considered = total - ignored;
+        let bbox = (changed > 0).then(|| BBox {
+            x: min_x,
+            y: min_y,
+            width: max_x - min_x + 1,
+            height: max_y - min_y + 1,
+        });
+        let changed_pct = if considered > 0 {
+            (changed as f64 / considered as f64 * 100.0) as f32
+        } else {
+            0.0
+        };
+        DiffResult {
+            changed_pixels: changed,
+            total_pixels: total,
+            changed_pct,
+            bbox,
+            aa_ignored: 0,
+            ignored_pixels: ignored,
+        }
     }
 }

--- a/crates/glass-core/src/diff.rs
+++ b/crates/glass-core/src/diff.rs
@@ -1,5 +1,5 @@
 use crate::error::{GlassError, Result};
-use crate::frame::Frame;
+use crate::frame::{Frame, Region};
 use std::simd::cmp::{SimdOrd, SimdPartialOrd};
 use std::simd::{u8x32, Simd};
 
@@ -23,6 +23,139 @@ pub struct DiffResult {
     /// Pixels that differed but were suppressed as anti-aliasing by the perceptual
     /// diff (always 0 for the exact diff). Surfaces how much was filtered.
     pub aa_ignored: u64,
+}
+
+/// Rectangles excluded from a comparison, precomputed into merged per-row
+/// column spans. Built once per diff; the rect list is small in practice, so
+/// per-row spans are cheaper than a per-pixel bitmap over the whole frame.
+///
+/// Spans are half-open `[start, end)`, sorted, and non-overlapping — merging is
+/// what makes overlapping rects count once in [`ignored_count`].
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct IgnoreMask {
+    rows: Vec<Vec<(u32, u32)>>,
+    ignored: u64,
+}
+
+impl IgnoreMask {
+    /// A mask that excludes nothing.
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Build a mask over a `width`×`height` area. Rects are clamped to that area;
+    /// a rect entirely outside contributes nothing (its mistake shows up as a zero
+    /// `ignored_count`, not an error). A zero-area rect is a caller bug and errors.
+    pub fn new(rects: &[Region], width: u32, height: u32) -> Result<Self> {
+        for r in rects {
+            if r.width == 0 || r.height == 0 {
+                return Err(GlassError::InvalidRegion(format!(
+                    "ignore rect has zero area: {}x{} at ({},{})",
+                    r.width, r.height, r.x, r.y
+                )));
+            }
+        }
+        if rects.is_empty() || width == 0 || height == 0 {
+            return Ok(Self::default());
+        }
+
+        let mut rows: Vec<Vec<(u32, u32)>> = vec![Vec::new(); height as usize];
+        for r in rects {
+            let x0 = r.x.min(width);
+            let y0 = r.y.min(height);
+            let x1 = r.x.saturating_add(r.width).min(width);
+            let y1 = r.y.saturating_add(r.height).min(height);
+            if x0 >= x1 || y0 >= y1 {
+                continue; // fully outside the frame
+            }
+            for row in rows.iter_mut().take(y1 as usize).skip(y0 as usize) {
+                row.push((x0, x1));
+            }
+        }
+
+        let mut ignored = 0u64;
+        for spans in &mut rows {
+            spans.sort_unstable();
+            let mut merged: Vec<(u32, u32)> = Vec::with_capacity(spans.len());
+            for &(s, e) in spans.iter() {
+                match merged.last_mut() {
+                    // `s <= last.1` merges touching spans too, not just overlapping.
+                    Some(last) if s <= last.1 => last.1 = last.1.max(e),
+                    _ => merged.push((s, e)),
+                }
+            }
+            ignored += merged.iter().map(|&(s, e)| u64::from(e - s)).sum::<u64>();
+            *spans = merged;
+        }
+
+        Ok(Self { rows, ignored })
+    }
+
+    /// Build a mask for a comparison scoped to `region`: each rect is intersected
+    /// with the region and translated into region-local coordinates, so callers
+    /// always pass window-relative rects regardless of scoping.
+    pub fn for_region(
+        rects: &[Region],
+        region: Option<&Region>,
+        width: u32,
+        height: u32,
+    ) -> Result<Self> {
+        let Some(region) = region else {
+            return Self::new(rects, width, height);
+        };
+        for r in rects {
+            if r.width == 0 || r.height == 0 {
+                return Err(GlassError::InvalidRegion(format!(
+                    "ignore rect has zero area: {}x{} at ({},{})",
+                    r.width, r.height, r.x, r.y
+                )));
+            }
+        }
+        let local: Vec<Region> = rects
+            .iter()
+            .filter_map(|r| r.intersect(region))
+            .map(|i| Region {
+                x: i.x - region.x,
+                y: i.y - region.y,
+                width: i.width,
+                height: i.height,
+            })
+            .collect();
+        Self::new(&local, region.width, region.height)
+    }
+
+    /// True when nothing is excluded — lets callers take the unmasked fast path.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.ignored == 0
+    }
+
+    /// Total excluded pixels, counting overlaps once.
+    #[inline]
+    pub fn ignored_count(&self) -> u64 {
+        self.ignored
+    }
+
+    /// Merged, sorted excluded column spans for row `y`.
+    #[inline]
+    pub fn spans_for_row(&self, y: u32) -> &[(u32, u32)] {
+        self.rows.get(y as usize).map_or(&[], Vec::as_slice)
+    }
+
+    /// True when column `x` of row `y` is excluded.
+    #[inline]
+    pub fn is_ignored(&self, x: u32, y: u32) -> bool {
+        self.spans_for_row(y).iter().any(|&(s, e)| x >= s && x < e)
+    }
+
+    /// True when the half-open column run `[x0, x1)` of row `y` is *entirely*
+    /// excluded — the whole-SIMD-chunk skip test.
+    #[inline]
+    pub fn covers_span(&self, y: u32, x0: u32, x1: u32) -> bool {
+        self.spans_for_row(y)
+            .iter()
+            .any(|&(s, e)| s <= x0 && x1 <= e)
+    }
 }
 
 /// Direction of a region wait: diverge from a reference, or converge to it.
@@ -807,5 +940,111 @@ mod tests {
     fn region_matches_satisfied_when_identical() {
         assert!(region_satisfied(&diff_result(0), RegionUntil::Matches));
         assert!(!region_satisfied(&diff_result(5), RegionUntil::Matches));
+    }
+
+    // ---- ignore mask ----
+
+    fn rect(x: u32, y: u32, width: u32, height: u32) -> Region {
+        Region {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    #[test]
+    fn empty_mask_ignores_nothing() {
+        let m = IgnoreMask::new(&[], 10, 10).unwrap();
+        assert!(m.is_empty());
+        assert_eq!(m.ignored_count(), 0);
+        assert!(!m.is_ignored(0, 0));
+    }
+
+    #[test]
+    fn mask_counts_a_single_rect() {
+        let m = IgnoreMask::new(&[rect(1, 1, 2, 3)], 10, 10).unwrap();
+        assert_eq!(m.ignored_count(), 6);
+        assert!(m.is_ignored(1, 1));
+        assert!(m.is_ignored(2, 3));
+        assert!(!m.is_ignored(3, 1), "x=3 is outside [1,3)");
+        assert!(!m.is_ignored(1, 4), "y=4 is outside [1,4)");
+    }
+
+    #[test]
+    fn overlapping_rects_count_each_pixel_once() {
+        // Two 4x4 rects overlapping in a 2x2 corner: 16 + 16 - 4 = 28.
+        let m = IgnoreMask::new(&[rect(0, 0, 4, 4), rect(2, 2, 4, 4)], 10, 10).unwrap();
+        assert_eq!(m.ignored_count(), 28);
+    }
+
+    #[test]
+    fn adjacent_spans_merge_into_one() {
+        let m = IgnoreMask::new(&[rect(0, 0, 2, 1), rect(2, 0, 2, 1)], 10, 10).unwrap();
+        assert_eq!(m.spans_for_row(0), &[(0, 4)]);
+        assert_eq!(m.ignored_count(), 4);
+    }
+
+    #[test]
+    fn rect_partly_out_of_bounds_is_clamped() {
+        // 4 wide starting at x=8 in a 10-wide frame => only x in [8,10) masks.
+        let m = IgnoreMask::new(&[rect(8, 0, 4, 1)], 10, 10).unwrap();
+        assert_eq!(m.ignored_count(), 2);
+        assert_eq!(m.spans_for_row(0), &[(8, 10)]);
+    }
+
+    #[test]
+    fn rect_fully_out_of_bounds_ignores_nothing_and_does_not_error() {
+        let m = IgnoreMask::new(&[rect(50, 50, 4, 4)], 10, 10).unwrap();
+        assert!(m.is_empty());
+        assert_eq!(m.ignored_count(), 0);
+    }
+
+    #[test]
+    fn zero_area_rect_is_an_error() {
+        assert!(matches!(
+            IgnoreMask::new(&[rect(0, 0, 0, 4)], 10, 10).unwrap_err(),
+            GlassError::InvalidRegion(_)
+        ));
+        assert!(matches!(
+            IgnoreMask::new(&[rect(0, 0, 4, 0)], 10, 10).unwrap_err(),
+            GlassError::InvalidRegion(_)
+        ));
+    }
+
+    #[test]
+    fn covers_span_detects_fully_masked_runs() {
+        let m = IgnoreMask::new(&[rect(0, 0, 8, 1)], 16, 4).unwrap();
+        assert!(m.covers_span(0, 0, 8), "[0,8) is inside [0,8)");
+        assert!(!m.covers_span(0, 4, 12), "[4,12) runs past the mask");
+        assert!(!m.covers_span(1, 0, 8), "row 1 is unmasked");
+    }
+
+    #[test]
+    fn for_region_intersects_and_translates_into_region_space() {
+        // Frame 100x100, region at (10,10) 20x20, mask rect at (15,15) 10x10.
+        // Intersection is (15,15)-(25,25) clipped to the region => (15,15) 10x10,
+        // translated to region-local (5,5) 10x10 => 100 px.
+        let region = rect(10, 10, 20, 20);
+        let m = IgnoreMask::for_region(&[rect(15, 15, 10, 10)], Some(&region), 100, 100).unwrap();
+        assert_eq!(m.ignored_count(), 100);
+        assert!(m.is_ignored(5, 5), "region-local origin of the mask");
+        assert!(!m.is_ignored(4, 5), "just outside the translated mask");
+    }
+
+    #[test]
+    fn for_region_drops_rects_outside_the_region() {
+        let region = rect(0, 0, 10, 10);
+        let m = IgnoreMask::for_region(&[rect(50, 50, 5, 5)], Some(&region), 100, 100).unwrap();
+        assert!(m.is_empty());
+    }
+
+    #[test]
+    fn region_intersect_returns_none_when_disjoint() {
+        assert_eq!(rect(0, 0, 5, 5).intersect(&rect(10, 10, 5, 5)), None);
+        assert_eq!(
+            rect(0, 0, 10, 10).intersect(&rect(5, 5, 10, 10)),
+            Some(rect(5, 5, 5, 5))
+        );
     }
 }

--- a/crates/glass-core/src/diff.rs
+++ b/crates/glass-core/src/diff.rs
@@ -466,11 +466,24 @@ fn classify(a: &[u8], b: &[u8], x: u32, y: u32, w: u32, h: u32, max_delta: f32) 
     }
 }
 
-/// Compare two same-size frames perceptually. `threshold` ∈ [0,1] sets sensitivity
-/// (smaller = stricter; ~0.1 is a sensible default). A pixel counts as changed only
-/// when its perceptual delta exceeds the threshold **and** it isn't anti-aliasing in
-/// either frame; suppressed anti-alias pixels are reported in `aa_ignored`.
+/// Compare two same-size frames perceptually. See [`diff_perceptual_with_mask`];
+/// pixels covered by `mask` are excluded exactly as in [`diff_with_mask`].
 pub fn diff_perceptual(a: &Frame, b: &Frame, threshold: f32) -> Result<DiffResult> {
+    diff_perceptual_with_mask(a, b, threshold, &IgnoreMask::empty())
+}
+
+/// Like [`diff_perceptual`], but pixels covered by `mask` are excluded: they never
+/// count as changed or anti-aliased, never extend the bbox, and are removed from the
+/// `changed_pct` denominator. Neighbour reads for anti-alias classification still hit
+/// the unmodified frames, so a masked pixel's real value can still confirm an edge in
+/// an unmasked neighbour. `threshold` ∈ [0,1] sets sensitivity (smaller = stricter;
+/// ~0.1 is a sensible default).
+pub fn diff_perceptual_with_mask(
+    a: &Frame,
+    b: &Frame,
+    threshold: f32,
+    mask: &IgnoreMask,
+) -> Result<DiffResult> {
     if a.width != b.width || a.height != b.height {
         return Err(GlassError::SizeMismatch {
             a: (a.width, a.height),
@@ -489,18 +502,30 @@ pub fn diff_perceptual(a: &Frame, b: &Frame, threshold: f32) -> Result<DiffResul
         let base = y as usize * row_bytes;
         let ra = &a.pixels[base..base + row_bytes];
         let rb = &b.pixels[base..base + row_bytes];
+        let masked_row = !mask.spans_for_row(y).is_empty();
         let mut off = 0usize;
         let mut col = 0u32;
         // SIMD pre-scan: byte-identical 8-pixel chunks (the common case) can't
         // contain a change, so skip the per-pixel perceptual + AA work entirely.
         while off + LANES <= row_bytes {
+            let chunk_end = col + (LANES / 4) as u32;
+            // Whole-chunk skip: the cheap win when a mask is large.
+            if masked_row && mask.covers_span(y, col, chunk_end) {
+                off += LANES;
+                col = chunk_end;
+                continue;
+            }
             if u8x32::from_slice(&ra[off..off + LANES]) != u8x32::from_slice(&rb[off..off + LANES])
             {
                 for px in 0..(LANES / 4) as u32 {
+                    let cx = col + px;
+                    if masked_row && mask.is_ignored(cx, y) {
+                        continue;
+                    }
                     classify_into(
                         a,
                         b,
-                        col + px,
+                        cx,
                         y,
                         w,
                         h,
@@ -515,48 +540,46 @@ pub fn diff_perceptual(a: &Frame, b: &Frame, threshold: f32) -> Result<DiffResul
                 }
             }
             off += LANES;
-            col += (LANES / 4) as u32;
+            col = chunk_end;
         }
         while off < row_bytes {
-            classify_into(
-                a,
-                b,
-                col,
-                y,
-                w,
-                h,
-                max_delta,
-                &mut changed,
-                &mut aa_ignored,
-                &mut min_x,
-                &mut min_y,
-                &mut max_x,
-                &mut max_y,
-            );
+            if !(masked_row && mask.is_ignored(col, y)) {
+                classify_into(
+                    a,
+                    b,
+                    col,
+                    y,
+                    w,
+                    h,
+                    max_delta,
+                    &mut changed,
+                    &mut aa_ignored,
+                    &mut min_x,
+                    &mut min_y,
+                    &mut max_x,
+                    &mut max_y,
+                );
+            }
             off += 4;
             col += 1;
         }
     }
 
     let total = a.pixel_count();
+    let ignored = mask.ignored_count().min(total);
     let bbox = (changed > 0).then(|| BBox {
         x: min_x,
         y: min_y,
         width: max_x - min_x + 1,
         height: max_y - min_y + 1,
     });
-    let changed_pct = if total > 0 {
-        (changed as f64 / total as f64 * 100.0) as f32
-    } else {
-        0.0
-    };
     Ok(DiffResult {
         changed_pixels: changed,
         total_pixels: total,
-        changed_pct,
+        changed_pct: pct(changed, total - ignored),
         bbox,
         aa_ignored,
-        ignored_pixels: 0,
+        ignored_pixels: ignored,
     })
 }
 
@@ -1234,6 +1257,134 @@ mod tests {
             changed_pct,
             bbox,
             aa_ignored: 0,
+            ignored_pixels: ignored,
+        }
+    }
+
+    // ---- masked perceptual diff ----
+
+    #[test]
+    fn perceptual_mask_excludes_pixels_and_keeps_denominator_honest() {
+        let a = Frame::solid(10, 10, [0, 0, 0, 255]);
+        let b = Frame::solid(10, 10, [255, 255, 255, 255]);
+        // Mask the top 5 rows: 50 of 100 px considered, all of which changed.
+        let mask = IgnoreMask::new(&[rect(0, 0, 10, 5)], 10, 10).unwrap();
+        let r = diff_perceptual_with_mask(&a, &b, 0.1, &mask).unwrap();
+        assert_eq!(r.ignored_pixels, 50);
+        assert_eq!(r.changed_pixels, 50);
+        assert!(
+            (r.changed_pct - 100.0).abs() < 1e-4,
+            "got {}",
+            r.changed_pct
+        );
+        assert_eq!(
+            r.bbox,
+            Some(BBox {
+                x: 0,
+                y: 5,
+                width: 10,
+                height: 5
+            })
+        );
+    }
+
+    #[test]
+    fn perceptual_unmasked_is_unchanged() {
+        let a = make(33, 17, 1);
+        let b = make(33, 17, 5);
+        let old = diff_perceptual(&a, &b, 0.1).unwrap();
+        let new = diff_perceptual_with_mask(&a, &b, 0.1, &IgnoreMask::empty()).unwrap();
+        assert_eq!(old, new);
+    }
+
+    /// The decisive guard on masking in-loop rather than copying frame A's masked
+    /// rects into frame B: anti-alias detection must keep reading real neighbours,
+    /// so a pixel next to a mask classifies exactly as it does unmasked.
+    #[test]
+    fn perceptual_mask_does_not_disturb_neighbouring_aa_classification() {
+        let a = edge_frame(16, 8, 6);
+        let b = edge_frame(16, 8, 7);
+        let unmasked = diff_perceptual(&a, &b, 0.1).unwrap();
+        // Mask a band far from the seam; the seam's own classification must not move.
+        let mask = IgnoreMask::new(&[rect(0, 0, 16, 2)], 16, 8).unwrap();
+        let masked = diff_perceptual_with_mask(&a, &b, 0.1, &mask).unwrap();
+
+        // Rows 0..2 are masked; those rows contributed 1/4 of every count before.
+        let rows_kept = 6u64;
+        let rows_all = 8u64;
+        assert_eq!(
+            masked.changed_pixels,
+            unmasked.changed_pixels / rows_all * rows_kept,
+            "per-row uniform frame: masking 2 of 8 rows removes exactly their share"
+        );
+        assert_eq!(
+            masked.aa_ignored,
+            unmasked.aa_ignored / rows_all * rows_kept,
+            "AA classification of surviving rows must be identical"
+        );
+    }
+
+    #[test]
+    fn masked_perceptual_matches_masked_naive_reference() {
+        let sizes = [(1u32, 1u32), (7, 3), (8, 8), (9, 9), (33, 17), (64, 8)];
+        for &(w, h) in &sizes {
+            let a = make(w, h, 1);
+            let b = make(w, h, 5);
+            for (label, m) in mask_matrix(w, h) {
+                for thr in [0.02f32, 0.1, 0.4] {
+                    assert_eq!(
+                        diff_perceptual_with_mask(&a, &b, thr, &m).unwrap(),
+                        reference_perceptual_masked(&a, &b, thr, &m),
+                        "{w}x{h} thr={thr} mask={label}"
+                    );
+                }
+            }
+        }
+    }
+
+    fn reference_perceptual_masked(
+        a: &Frame,
+        b: &Frame,
+        threshold: f32,
+        mask: &IgnoreMask,
+    ) -> DiffResult {
+        let (w, h) = (a.width, a.height);
+        let max_delta = MAX_YIQ_DELTA * threshold.clamp(0.0, 1.0).powi(2);
+        let mut changed = 0u64;
+        let mut aa_ignored = 0u64;
+        let (mut min_x, mut min_y, mut max_x, mut max_y) = (u32::MAX, u32::MAX, 0u32, 0u32);
+        for y in 0..h {
+            for x in 0..w {
+                if mask.is_ignored(x, y) {
+                    continue;
+                }
+                match classify(&a.pixels, &b.pixels, x, y, w, h, max_delta) {
+                    PixelClass::Same => {}
+                    PixelClass::AntiAliased => aa_ignored += 1,
+                    PixelClass::Changed => {
+                        changed += 1;
+                        min_x = min_x.min(x);
+                        min_y = min_y.min(y);
+                        max_x = max_x.max(x);
+                        max_y = max_y.max(y);
+                    }
+                }
+            }
+        }
+        let total = a.pixel_count();
+        let ignored = mask.ignored_count().min(total);
+        let bbox = (changed > 0).then(|| BBox {
+            x: min_x,
+            y: min_y,
+            width: max_x - min_x + 1,
+            height: max_y - min_y + 1,
+        });
+        DiffResult {
+            changed_pixels: changed,
+            total_pixels: total,
+            changed_pct: pct(changed, total - ignored),
+            bbox,
+            aa_ignored,
             ignored_pixels: ignored,
         }
     }

--- a/crates/glass-core/src/diff.rs
+++ b/crates/glass-core/src/diff.rs
@@ -1298,29 +1298,77 @@ mod tests {
     }
 
     /// The decisive guard on masking in-loop rather than copying frame A's masked
-    /// rects into frame B: anti-alias detection must keep reading real neighbours,
-    /// so a pixel next to a mask classifies exactly as it does unmasked.
+    /// rects into frame B before diffing: anti-alias detection must keep reading
+    /// real neighbours, so a pixel next to a mask classifies exactly as it would
+    /// from the true, unmutated frame data.
+    ///
+    /// Geometry is load-bearing here, and deliberately small — do not "simplify"
+    /// this to a bigger/rounder frame. `is_antialiased`'s "3+ identical
+    /// neighbours" flat-region check (`has_many_siblings`) is satisfied by *any*
+    /// matching neighbour; a wide or tall frame is mostly uniform black/white
+    /// padding, which hands it redundant confirmations everywhere, including
+    /// right next to a mask. That redundancy is exactly what let a previous,
+    /// larger version of this fixture (16x8, 2 masked rows) pass identically
+    /// under both the in-loop and the copy-into-B designs — the two designs
+    /// only diverge when the surviving row bordering the mask has *no* spare
+    /// matching neighbour to fall back on.
+    ///
+    /// A 4-wide, 3-row frame with only row 0 masked gives row 1 (the row right
+    /// below the mask) exactly that: at the seam, row 1's own vertical neighbour
+    /// is row 0. Verified by hand-tracing `is_antialiased` and by an experimental
+    /// copy-into-B implementation: under the correct design, pixels (1,1) and
+    /// (2,1) classify `Changed` (row 1 reads B's real row 0, seam at column 2);
+    /// under the rejected design they classify `AntiAliased` instead, because
+    /// row 0 in the diffed copy of B would hold A's seam (column 1) copied in
+    /// before diffing — a value B never actually had. Row 2 isn't adjacent to
+    /// the mask, so its classification (`AntiAliased`) doesn't move either way;
+    /// it is what makes this fixture assert something beyond "row 1 disappeared".
     #[test]
     fn perceptual_mask_does_not_disturb_neighbouring_aa_classification() {
-        let a = edge_frame(16, 8, 6);
-        let b = edge_frame(16, 8, 7);
-        let unmasked = diff_perceptual(&a, &b, 0.1).unwrap();
-        // Mask a band far from the seam; the seam's own classification must not move.
-        let mask = IgnoreMask::new(&[rect(0, 0, 16, 2)], 16, 8).unwrap();
+        // Seam 1 -> 2 in a 4-wide frame differs only at columns 1 and 2:
+        // a = [black, gray(seam), white, white], b = [black, black, gray(seam), white].
+        let a = edge_frame(4, 3, 1);
+        let b = edge_frame(4, 3, 2);
+        // Mask only row 0, leaving row 1 (adjacent to the mask) and row 2 (not
+        // adjacent) to survive.
+        let mask = IgnoreMask::new(&[rect(0, 0, 4, 1)], 4, 3).unwrap();
+
         let masked = diff_perceptual_with_mask(&a, &b, 0.1, &mask).unwrap();
 
-        // Rows 0..2 are masked; those rows contributed 1/4 of every count before.
-        let rows_kept = 6u64;
-        let rows_all = 8u64;
+        // The real invariant: every surviving pixel must classify exactly as it
+        // would from the true, unmutated frames. `reference_perceptual_masked`
+        // is that definition made concrete — it calls `classify` on `a.pixels`
+        // and `b.pixels` verbatim and never mutates either frame. Equality here
+        // is what "in-loop masking never disturbs anti-alias classification"
+        // means; it would still hold trivially if this fixture didn't
+        // discriminate, which is why the concrete counts below matter too.
+        let reference = reference_perceptual_masked(&a, &b, 0.1, &mask);
         assert_eq!(
-            masked.changed_pixels,
-            unmasked.changed_pixels / rows_all * rows_kept,
-            "per-row uniform frame: masking 2 of 8 rows removes exactly their share"
+            masked, reference,
+            "masked diff must match direct per-pixel classification of the real, unmutated frames"
+        );
+
+        // Pin the concrete counts so a regression is legible without diffing a
+        // DiffResult by hand (see the doc comment above for how these were
+        // derived and cross-checked against the rejected design).
+        assert_eq!(masked.ignored_pixels, 4, "row 0 (4 px) is excluded");
+        assert_eq!(
+            masked.changed_pixels, 2,
+            "(1,1) and (2,1): row 1's seam pixels see B's real row-0 neighbour, not A's copied-in seam"
         );
         assert_eq!(
-            masked.aa_ignored,
-            unmasked.aa_ignored / rows_all * rows_kept,
-            "AA classification of surviving rows must be identical"
+            masked.aa_ignored, 2,
+            "(1,2) and (2,2): row 2's seam pixels are unaffected by the mask either way"
+        );
+        assert_eq!(
+            masked.bbox,
+            Some(BBox {
+                x: 1,
+                y: 1,
+                width: 2,
+                height: 1
+            }),
+            "only row 1's pixels are real changes; row 2's are suppressed as AA"
         );
     }
 

--- a/crates/glass-core/src/diff.rs
+++ b/crates/glass-core/src/diff.rs
@@ -211,6 +211,11 @@ pub fn diff(a: &Frame, b: &Frame, tolerance: u8) -> Result<DiffResult> {
 /// Like [`diff`], but pixels covered by `mask` are excluded: they never count as
 /// changed, never extend the bbox, and are removed from the `changed_pct`
 /// denominator. The mask never mutates pixel data.
+///
+/// The `mask` must be built for `a`'s dimensions. A mask sized for a different
+/// frame silently miscompares — it masks the wrong columns/rows and can subtract
+/// more than the frame holds; the internal `.min(total)` clamp only keeps the
+/// arithmetic sound, not the result meaningful.
 pub fn diff_with_mask(
     a: &Frame,
     b: &Frame,
@@ -484,6 +489,11 @@ pub fn diff_perceptual(a: &Frame, b: &Frame, threshold: f32) -> Result<DiffResul
 /// the unmodified frames, so a masked pixel's real value can still confirm an edge in
 /// an unmasked neighbour. `threshold` ∈ [0,1] sets sensitivity (smaller = stricter;
 /// ~0.1 is a sensible default).
+///
+/// The `mask` must be built for `a`'s dimensions. A mask sized for a different
+/// frame silently miscompares — it masks the wrong columns/rows and can subtract
+/// more than the frame holds; the internal `.min(total)` clamp only keeps the
+/// arithmetic sound, not the result meaningful.
 pub fn diff_perceptual_with_mask(
     a: &Frame,
     b: &Frame,
@@ -1104,6 +1114,19 @@ mod tests {
         let region = rect(0, 0, 10, 10);
         let m = IgnoreMask::for_region(&[rect(50, 50, 5, 5)], &region).unwrap();
         assert!(m.is_empty());
+    }
+
+    #[test]
+    fn for_region_rejects_a_zero_area_rect_before_intersecting() {
+        // `for_region` validates zero-area up front — before intersecting with the
+        // region — so region-scoping can't launder a zero-area rect into a silent
+        // drop. Exercises `for_region`'s own validation branch, distinct from
+        // `new`'s (covered by `zero_area_rect_is_an_error`).
+        let region = rect(0, 0, 10, 10);
+        assert!(matches!(
+            IgnoreMask::for_region(&[rect(0, 0, 0, 4)], &region).unwrap_err(),
+            GlassError::InvalidRegion(_)
+        ));
     }
 
     #[test]

--- a/crates/glass-core/src/diff.rs
+++ b/crates/glass-core/src/diff.rs
@@ -47,10 +47,13 @@ impl IgnoreMask {
         Self::default()
     }
 
-    /// Build a mask over a `width`×`height` area. Rects are clamped to that area;
-    /// a rect entirely outside contributes nothing (its mistake shows up as a zero
-    /// `ignored_count`, not an error). A zero-area rect is a caller bug and errors.
-    pub fn new(rects: &[Region], width: u32, height: u32) -> Result<Self> {
+    /// Reject a zero-area rect up front: it can never mask anything, so it is a
+    /// caller bug worth naming rather than silently dropping. Shared by [`new`]
+    /// and [`for_region`] so both entry points validate identically.
+    ///
+    /// [`new`]: Self::new
+    /// [`for_region`]: Self::for_region
+    fn ensure_no_zero_area(rects: &[Region]) -> Result<()> {
         for r in rects {
             if r.width == 0 || r.height == 0 {
                 return Err(GlassError::InvalidRegion(format!(
@@ -59,6 +62,14 @@ impl IgnoreMask {
                 )));
             }
         }
+        Ok(())
+    }
+
+    /// Build a mask over a `width`×`height` area. Rects are clamped to that area;
+    /// a rect entirely outside contributes nothing (its mistake shows up as a zero
+    /// `ignored_count`, not an error). A zero-area rect is a caller bug and errors.
+    pub fn new(rects: &[Region], width: u32, height: u32) -> Result<Self> {
+        Self::ensure_no_zero_area(rects)?;
         if rects.is_empty() || width == 0 || height == 0 {
             return Ok(Self::default());
         }
@@ -92,29 +103,24 @@ impl IgnoreMask {
             *spans = merged;
         }
 
+        if ignored == 0 {
+            // Every rect fell outside the area, so this masks nothing. Collapse to
+            // the canonical empty mask rather than keeping a rows-of-empty-spans
+            // representation, so an all-out-of-bounds list compares `Eq` with
+            // `empty()` — both exclude exactly nothing.
+            return Ok(Self::default());
+        }
         Ok(Self { rows, ignored })
     }
 
     /// Build a mask for a comparison scoped to `region`: each rect is intersected
     /// with the region and translated into region-local coordinates, so callers
-    /// always pass window-relative rects regardless of scoping.
-    pub fn for_region(
-        rects: &[Region],
-        region: Option<&Region>,
-        width: u32,
-        height: u32,
-    ) -> Result<Self> {
-        let Some(region) = region else {
-            return Self::new(rects, width, height);
-        };
-        for r in rects {
-            if r.width == 0 || r.height == 0 {
-                return Err(GlassError::InvalidRegion(format!(
-                    "ignore rect has zero area: {}x{} at ({},{})",
-                    r.width, r.height, r.x, r.y
-                )));
-            }
-        }
+    /// always pass window-relative rects regardless of scoping. The mask is sized
+    /// from the region — the space the scoped comparison runs in. A zero-area rect
+    /// is rejected up front, before intersecting, so region-scoping can't launder
+    /// it into a silent drop.
+    pub fn for_region(rects: &[Region], region: &Region) -> Result<Self> {
+        Self::ensure_no_zero_area(rects)?;
         let local: Vec<Region> = rects
             .iter()
             .filter_map(|r| r.intersect(region))
@@ -1087,7 +1093,7 @@ mod tests {
         // Intersection is (15,15)-(25,25) clipped to the region => (15,15) 10x10,
         // translated to region-local (5,5) 10x10 => 100 px.
         let region = rect(10, 10, 20, 20);
-        let m = IgnoreMask::for_region(&[rect(15, 15, 10, 10)], Some(&region), 100, 100).unwrap();
+        let m = IgnoreMask::for_region(&[rect(15, 15, 10, 10)], &region).unwrap();
         assert_eq!(m.ignored_count(), 100);
         assert!(m.is_ignored(5, 5), "region-local origin of the mask");
         assert!(!m.is_ignored(4, 5), "just outside the translated mask");
@@ -1096,7 +1102,7 @@ mod tests {
     #[test]
     fn for_region_drops_rects_outside_the_region() {
         let region = rect(0, 0, 10, 10);
-        let m = IgnoreMask::for_region(&[rect(50, 50, 5, 5)], Some(&region), 100, 100).unwrap();
+        let m = IgnoreMask::for_region(&[rect(50, 50, 5, 5)], &region).unwrap();
         assert!(m.is_empty());
     }
 

--- a/crates/glass-core/src/frame.rs
+++ b/crates/glass-core/src/frame.rs
@@ -41,6 +41,26 @@ impl Region {
         }
         Ok(())
     }
+
+    /// Overlap of two regions, or `None` when they are disjoint.
+    pub fn intersect(&self, other: &Region) -> Option<Region> {
+        let x0 = self.x.max(other.x);
+        let y0 = self.y.max(other.y);
+        let x1 = self
+            .x
+            .saturating_add(self.width)
+            .min(other.x.saturating_add(other.width));
+        let y1 = self
+            .y
+            .saturating_add(self.height)
+            .min(other.y.saturating_add(other.height));
+        (x0 < x1 && y0 < y1).then(|| Region {
+            x: x0,
+            y: y0,
+            width: x1 - x0,
+            height: y1 - y0,
+        })
+    }
 }
 
 /// The tightly-packed RGBA byte length for a `width`×`height` frame, or `None`

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -40,8 +40,8 @@ pub use image_io::{frame_from_webp, frame_to_webp};
 
 pub mod diff;
 pub use diff::{
-    diff, diff_perceptual, diff_with_mask, region_satisfied, BBox, DiffResult, IgnoreMask,
-    RegionUntil,
+    diff, diff_perceptual, diff_perceptual_with_mask, diff_with_mask, region_satisfied, BBox,
+    DiffResult, IgnoreMask, RegionUntil,
 };
 pub mod doctor;
 pub use doctor::{Check, CheckStatus, Diagnosis, Section};

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -39,7 +39,10 @@ pub mod image_io;
 pub use image_io::{frame_from_webp, frame_to_webp};
 
 pub mod diff;
-pub use diff::{diff, diff_perceptual, region_satisfied, BBox, DiffResult, RegionUntil};
+pub use diff::{
+    diff, diff_perceptual, diff_with_mask, region_satisfied, BBox, DiffResult, IgnoreMask,
+    RegionUntil,
+};
 pub mod doctor;
 pub use doctor::{Check, CheckStatus, Diagnosis, Section};
 

--- a/crates/glass-core/src/session/baseline.rs
+++ b/crates/glass-core/src/session/baseline.rs
@@ -44,13 +44,18 @@ impl Glass {
 
     /// Exact per-channel diff of the current frame against a saved baseline.
     /// `region` scopes the comparison to a window-relative sub-rectangle.
+    /// `ignore` rects are window-relative animated regions to exclude from the
+    /// comparison — pixels there never count as changed. When `region` is set,
+    /// each rect is intersected with it and translated into region-local
+    /// coordinates, so the caller always passes window-relative rects.
     pub fn diff_baseline(
         &mut self,
         name: &str,
         region: Option<&Region>,
+        ignore: &[Region],
         tolerance: u8,
     ) -> Result<DiffResult> {
-        self.diff_baseline_with_frame(name, region, tolerance)
+        self.diff_baseline_with_frame(name, region, ignore, tolerance)
             .map(|(r, _)| r)
     }
 
@@ -59,24 +64,28 @@ impl Glass {
         &mut self,
         name: &str,
         region: Option<&Region>,
+        ignore: &[Region],
         tolerance: u8,
     ) -> Result<(DiffResult, Frame)> {
         let (baseline, current) = self.baseline_and_current(name, region)?;
-        let r = diff(&baseline, &current, tolerance)?;
+        let mask = IgnoreMask::for_region(ignore, region, baseline.width, baseline.height)?;
+        let r = diff_with_mask(&baseline, &current, tolerance, &mask)?;
         Ok((r, current))
     }
 
     /// Perceptual diff (YIQ + anti-alias suppression) against a saved baseline —
     /// the default for regression, robust to anti-aliasing / sub-pixel / GPU-font
     /// rendering noise. `threshold` ∈ [0,1] (smaller = stricter). `region` scopes
-    /// the comparison to a window-relative sub-rectangle.
+    /// the comparison to a window-relative sub-rectangle. `ignore` behaves as in
+    /// [`diff_baseline`].
     pub fn diff_baseline_perceptual(
         &mut self,
         name: &str,
         region: Option<&Region>,
+        ignore: &[Region],
         threshold: f32,
     ) -> Result<DiffResult> {
-        self.diff_baseline_perceptual_with_frame(name, region, threshold)
+        self.diff_baseline_perceptual_with_frame(name, region, ignore, threshold)
             .map(|(r, _)| r)
     }
 
@@ -85,10 +94,12 @@ impl Glass {
         &mut self,
         name: &str,
         region: Option<&Region>,
+        ignore: &[Region],
         threshold: f32,
     ) -> Result<(DiffResult, Frame)> {
         let (baseline, current) = self.baseline_and_current(name, region)?;
-        let r = diff_perceptual(&baseline, &current, threshold)?;
+        let mask = IgnoreMask::for_region(ignore, region, baseline.width, baseline.height)?;
+        let r = diff_perceptual_with_mask(&baseline, &current, threshold, &mask)?;
         Ok((r, current))
     }
 }
@@ -107,7 +118,7 @@ mod tests {
         let mut g = glass_with(platform);
         g.start(&spec()).unwrap();
         g.save_baseline("main").unwrap();
-        let result = g.diff_baseline("main", None, 0).unwrap();
+        let result = g.diff_baseline("main", None, &[], 0).unwrap();
         assert_eq!(result.changed_pixels, 1);
     }
 
@@ -118,7 +129,7 @@ mod tests {
         let mut g = glass_with(platform);
         g.start(&spec()).unwrap();
         assert!(matches!(
-            g.diff_baseline("absent", None, 0).unwrap_err(),
+            g.diff_baseline("absent", None, &[], 0).unwrap_err(),
             GlassError::BaselineMissing(_)
         ));
     }
@@ -149,20 +160,23 @@ mod tests {
         };
         // Region excludes the changed pixel -> no change.
         assert_eq!(
-            g.diff_baseline("m", Some(&top_left), 0)
+            g.diff_baseline("m", Some(&top_left), &[], 0)
                 .unwrap()
                 .changed_pixels,
             0
         );
         // Region includes the changed pixel -> sees exactly it.
         assert_eq!(
-            g.diff_baseline("m", Some(&bottom_right), 0)
+            g.diff_baseline("m", Some(&bottom_right), &[], 0)
                 .unwrap()
                 .changed_pixels,
             1
         );
         // Whole-frame diff still sees it.
-        assert_eq!(g.diff_baseline("m", None, 0).unwrap().changed_pixels, 1);
+        assert_eq!(
+            g.diff_baseline("m", None, &[], 0).unwrap().changed_pixels,
+            1
+        );
     }
 
     #[test]
@@ -181,9 +195,60 @@ mod tests {
                     width: 9,
                     height: 1,
                 }),
+                &[],
                 0,
             )
             .unwrap_err();
         assert!(matches!(err, GlassError::InvalidRegion(_)));
+    }
+
+    #[test]
+    fn diff_baseline_honours_an_ignore_rect() {
+        let baseline_frame = Frame::solid(8, 8, [0, 0, 0, 255]);
+        let mut changed = baseline_frame.clone();
+        // Change one pixel inside the masked band and one outside it.
+        changed.pixels[9 * 4] = 255; // (1,1), masked
+        changed.pixels[45 * 4] = 255; // (5,5), visible
+        let platform = FakePlatform::new(8, 8).with_frames(vec![baseline_frame, changed]);
+        let mut g = glass_with(platform);
+        g.start(&spec()).unwrap();
+        g.save_baseline("b").unwrap();
+        let ignore = [Region {
+            x: 0,
+            y: 0,
+            width: 8,
+            height: 3,
+        }];
+        let r = g.diff_baseline("b", None, &ignore, 0).unwrap();
+        assert_eq!(r.changed_pixels, 1, "the masked change must not count");
+        assert_eq!(r.ignored_pixels, 24);
+    }
+
+    #[test]
+    fn baseline_ignore_is_window_relative_under_a_region() {
+        let baseline_frame = Frame::solid(8, 8, [0, 0, 0, 255]);
+        let mut changed = baseline_frame.clone();
+        changed.pixels[45 * 4] = 255; // (5,5)
+        let platform = FakePlatform::new(8, 8).with_frames(vec![baseline_frame, changed]);
+        let mut g = glass_with(platform);
+        g.start(&spec()).unwrap();
+        g.save_baseline("b").unwrap();
+        let region = Region {
+            x: 4,
+            y: 4,
+            width: 4,
+            height: 4,
+        };
+        // Window-relative mask over (5,5) -- must translate into region space.
+        let ignore = [Region {
+            x: 5,
+            y: 5,
+            width: 1,
+            height: 1,
+        }];
+        let r = g.diff_baseline("b", Some(&region), &ignore, 0).unwrap();
+        assert_eq!(r.changed_pixels, 0);
+        assert_eq!(r.ignored_pixels, 1);
+        assert_eq!(r.total_pixels, 16, "region is 4x4");
     }
 }

--- a/crates/glass-core/src/session/baseline.rs
+++ b/crates/glass-core/src/session/baseline.rs
@@ -68,7 +68,7 @@ impl Glass {
         tolerance: u8,
     ) -> Result<(DiffResult, Frame)> {
         let (baseline, current) = self.baseline_and_current(name, region)?;
-        let mask = IgnoreMask::for_region(ignore, region, baseline.width, baseline.height)?;
+        let mask = mask_for(ignore, region, baseline.width, baseline.height)?;
         let r = diff_with_mask(&baseline, &current, tolerance, &mask)?;
         Ok((r, current))
     }
@@ -98,7 +98,7 @@ impl Glass {
         threshold: f32,
     ) -> Result<(DiffResult, Frame)> {
         let (baseline, current) = self.baseline_and_current(name, region)?;
-        let mask = IgnoreMask::for_region(ignore, region, baseline.width, baseline.height)?;
+        let mask = mask_for(ignore, region, baseline.width, baseline.height)?;
         let r = diff_perceptual_with_mask(&baseline, &current, threshold, &mask)?;
         Ok((r, current))
     }

--- a/crates/glass-core/src/session/mod.rs
+++ b/crates/glass-core/src/session/mod.rs
@@ -7,8 +7,8 @@ use crate::accessibility::{
 };
 use crate::baseline::BaselineStore;
 use crate::diff::{
-    diff, diff_perceptual, diff_perceptual_with_mask, diff_with_mask, region_satisfied, BBox,
-    DiffResult, IgnoreMask, RegionUntil,
+    diff_perceptual_with_mask, diff_with_mask, region_satisfied, BBox, DiffResult, IgnoreMask,
+    RegionUntil,
 };
 use crate::error::{GlassError, Result};
 use crate::frame::{Frame, Region};

--- a/crates/glass-core/src/session/mod.rs
+++ b/crates/glass-core/src/session/mod.rs
@@ -175,6 +175,25 @@ impl Glass {
     }
 }
 
+/// Build the ignore mask for a comparison over a `frame_w`×`frame_h` frame,
+/// optionally scoped to `region`. Without a region the window-relative rects mask
+/// the frame directly; with one they are intersected with it and translated into
+/// region-local space — the space the scoped comparison runs in — so callers
+/// always pass window-relative rects regardless of scoping. Picking the right
+/// [`IgnoreMask`] constructor here keeps each one unambiguous: [`IgnoreMask::new`]
+/// sizes from the frame, [`IgnoreMask::for_region`] from the region.
+fn mask_for(
+    ignore: &[Region],
+    region: Option<&Region>,
+    frame_w: u32,
+    frame_h: u32,
+) -> Result<IgnoreMask> {
+    match region {
+        Some(r) => IgnoreMask::for_region(ignore, r),
+        None => IgnoreMask::new(ignore, frame_w, frame_h),
+    }
+}
+
 #[cfg(test)]
 mod test_support;
 

--- a/crates/glass-core/src/session/mod.rs
+++ b/crates/glass-core/src/session/mod.rs
@@ -6,7 +6,10 @@ use crate::accessibility::{
     ElementCondition, ElementInfo, ElementMatch,
 };
 use crate::baseline::BaselineStore;
-use crate::diff::{diff, diff_perceptual, region_satisfied, BBox, DiffResult, RegionUntil};
+use crate::diff::{
+    diff, diff_perceptual, diff_perceptual_with_mask, diff_with_mask, region_satisfied, BBox,
+    DiffResult, IgnoreMask, RegionUntil,
+};
 use crate::error::{GlassError, Result};
 use crate::frame::{Frame, Region};
 use crate::logbuf::{LogBuffer, LogLine, Stream};

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -34,7 +34,8 @@ pub struct WaitStableOutcome {
     /// `saw_motion:false` over a short `observed_ms` is a *brief* quiet window — a slow
     /// animation can still hide under it, so use `wait_for_region {until:"changes"}` to
     /// positively assert motion. `settled:true` with `saw_motion:true` means it was moving
-    /// and then quieted.
+    /// and then quieted. Motion confined to an `ignore` rect does not count — it is masked
+    /// out of the comparison, so it can never set this flag.
     pub saw_motion: bool,
     /// How long (ms) frames were observed before settling or timing out.
     pub observed_ms: u64,
@@ -288,34 +289,48 @@ pub struct WaitLogOutcome {
 impl Glass {
     pub fn wait_stable(&mut self, params: &WaitStableParams) -> Result<WaitStableOutcome> {
         let active = self.require_active()?;
-        let geo = active.geometry.clone();
         // The active window's cached geometry only bounds a stability_region when
         // watching the active window itself; a specific `window` is validated by
         // the backend against its own geometry instead (see `capture`).
         if params.window.is_none() {
+            let geo = active.geometry.clone();
             if let Some(r) = &params.stability_region {
                 r.check_fits(geo.width, geo.height)?;
             }
         }
         let region = params.stability_region;
-        // `capture` returns frames cropped to `region` when one is set (see
-        // `wait_stable_polls_only_the_region_and_captures_full_once`), so the
-        // settle comparison happens in that cropped space — the mask must match
-        // it. `for_region` builds exactly that: passed the full (uncropped)
-        // geometry plus the region, it intersects `ignore` with the region and
-        // translates into region-local coordinates, same as the baseline diff
-        // path. `geo` is the active window's geometry; as with the bounds check
-        // above, a specific `window` bypasses this sizing for the same reason —
-        // its own geometry is validated by the backend, not cached here.
-        let mask = IgnoreMask::for_region(&params.ignore, region.as_ref(), geo.width, geo.height)?;
-        let mut tracker = StabilityTracker::with_mask(params.settle_frames, params.tolerance, mask);
         let window = params.window;
+        // The mask is built lazily, on the first poll tick, sized from that
+        // captured frame's own dimensions rather than the session's cached
+        // geometry — which can belong to a different window than the one being
+        // watched, or be stale if the watched window resized itself since the
+        // cache was last refreshed. `for_region` intersects `ignore` with
+        // `region` and translates into region-local coordinates (`capture`
+        // crops to `region` when one is set, so the settle comparison and the
+        // mask must agree on that same cropped space).
+        let mut tracker: Option<StabilityTracker> = None;
         let outcome = crate::poll::poll_until(params.interval_ms, params.timeout_ms, || {
             // Poll only the watched region (cheap) when one is set; else the full window.
             let frame = self.capture(window, region.as_ref())?;
-            let settled = tracker.observe(frame)?;
-            Ok(if settled { Some(()) } else { None })
+            let t = match tracker {
+                Some(ref mut t) => t,
+                None => {
+                    let mask = IgnoreMask::for_region(
+                        &params.ignore,
+                        region.as_ref(),
+                        frame.width,
+                        frame.height,
+                    )?;
+                    tracker.insert(StabilityTracker::with_mask(
+                        params.settle_frames,
+                        params.tolerance,
+                        mask,
+                    ))
+                }
+            };
+            Ok(if t.observe(frame)? { Some(()) } else { None })
         })?;
+        let tracker = tracker.expect("poll_until ticks at least once");
         let settled = outcome.value.is_some();
         // Return the full window: a fresh capture if we were polling a sub-region
         // (the genuinely-settled state), else the just-observed full frame.
@@ -764,6 +779,49 @@ mod tests {
             log.lock().unwrap().len(),
             3,
             "must settle on the 3 supplied frames, not by outlasting them into FakePlatform's repeat"
+        );
+    }
+
+    #[test]
+    fn wait_stable_ignore_is_window_relative_under_a_stability_region() {
+        // (3,3) blinks and is INSIDE the watched region, so the cropped frames
+        // differ every poll; only a window-relative rect translated into
+        // region-local space masks it.
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let f0 = frame_4x4_corner([10, 0, 0, 255]);
+        let f1 = frame_4x4_corner([20, 0, 0, 255]);
+        let f2 = frame_4x4_corner([30, 0, 0, 255]);
+        let platform = FakePlatform::new(4, 4)
+            .with_frames(vec![f0, f1, f2])
+            .with_capture_log(log.clone());
+        let mut g = glass_with(platform);
+        g.start(&spec()).unwrap();
+        let outcome = g
+            .wait_stable(&WaitStableParams {
+                interval_ms: 0,
+                settle_frames: 2,
+                tolerance: 0,
+                timeout_ms: 1000,
+                stability_region: Some(Region {
+                    x: 2,
+                    y: 2,
+                    width: 2,
+                    height: 2,
+                }),
+                ignore: vec![Region {
+                    x: 3,
+                    y: 3,
+                    width: 1,
+                    height: 1,
+                }],
+                window: None,
+            })
+            .unwrap();
+        assert!(outcome.settled);
+        assert_eq!(
+            log.lock().unwrap().len(),
+            4,
+            "3 region polls + 1 final full capture"
         );
     }
 

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -323,12 +323,8 @@ impl Glass {
             let t = match tracker {
                 Some(ref mut t) => t,
                 None => {
-                    let mask = IgnoreMask::for_region(
-                        &params.ignore,
-                        region.as_ref(),
-                        frame.width,
-                        frame.height,
-                    )?;
+                    let mask =
+                        mask_for(&params.ignore, region.as_ref(), frame.width, frame.height)?;
                     tracker.insert(StabilityTracker::with_mask(
                         params.settle_frames,
                         params.tolerance,
@@ -563,7 +559,7 @@ impl Glass {
         // `current` frame is required to match `reference`'s size (the masked
         // diff functions error otherwise via `SizeMismatch`), so `reference`'s own
         // dimensions are exactly the comparison's real size, cropped or not.
-        let mask = IgnoreMask::for_region(
+        let mask = mask_for(
             &params.ignore,
             params.region.as_ref(),
             reference.width,

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -12,6 +12,13 @@ pub struct WaitStableParams {
     /// When set, the settle decision compares only this sub-rectangle of each
     /// frame; the returned frame is still the full window.
     pub stability_region: Option<Region>,
+    /// Window-relative sub-rectangles excluded from the settle comparison — pixels
+    /// there never count as changed, so a perpetually animating region (a blinking
+    /// caret, a clock) cannot prevent the stream from settling. When
+    /// `stability_region` is set, each rect is intersected with it and translated
+    /// into region-local coordinates, so `ignore` is always window-relative
+    /// regardless of scoping.
+    pub ignore: Vec<Region>,
     /// When set, watch this window's own region instead of the active window's —
     /// without changing which window is active.
     pub window: Option<WindowId>,
@@ -281,17 +288,27 @@ pub struct WaitLogOutcome {
 impl Glass {
     pub fn wait_stable(&mut self, params: &WaitStableParams) -> Result<WaitStableOutcome> {
         let active = self.require_active()?;
+        let geo = active.geometry.clone();
         // The active window's cached geometry only bounds a stability_region when
         // watching the active window itself; a specific `window` is validated by
         // the backend against its own geometry instead (see `capture`).
         if params.window.is_none() {
-            let geo = active.geometry.clone();
             if let Some(r) = &params.stability_region {
                 r.check_fits(geo.width, geo.height)?;
             }
         }
-        let mut tracker = StabilityTracker::new(params.settle_frames, params.tolerance);
         let region = params.stability_region;
+        // `capture` returns frames cropped to `region` when one is set (see
+        // `wait_stable_polls_only_the_region_and_captures_full_once`), so the
+        // settle comparison happens in that cropped space — the mask must match
+        // it. `for_region` builds exactly that: passed the full (uncropped)
+        // geometry plus the region, it intersects `ignore` with the region and
+        // translates into region-local coordinates, same as the baseline diff
+        // path. `geo` is the active window's geometry; as with the bounds check
+        // above, a specific `window` bypasses this sizing for the same reason —
+        // its own geometry is validated by the backend, not cached here.
+        let mask = IgnoreMask::for_region(&params.ignore, region.as_ref(), geo.width, geo.height)?;
+        let mut tracker = StabilityTracker::with_mask(params.settle_frames, params.tolerance, mask);
         let window = params.window;
         let outcome = crate::poll::poll_until(params.interval_ms, params.timeout_ms, || {
             // Poll only the watched region (cheap) when one is set; else the full window.
@@ -627,6 +644,7 @@ mod tests {
                 tolerance: 0,
                 timeout_ms: 1000,
                 stability_region: None,
+                ignore: Vec::new(),
                 window: None,
             })
             .unwrap();
@@ -654,6 +672,7 @@ mod tests {
                 tolerance: 0,
                 timeout_ms: 0, // give up after the first non-settling capture
                 stability_region: None,
+                ignore: Vec::new(),
                 window: None,
             })
             .unwrap();
@@ -683,6 +702,7 @@ mod tests {
                     width: 2,
                     height: 2,
                 }),
+                ignore: Vec::new(),
                 window: None,
             })
             .unwrap();
@@ -693,6 +713,57 @@ mod tests {
         assert_eq!(
             outcome.frame, f2,
             "wait_stable returns the FULL frame, not the cropped region"
+        );
+    }
+
+    #[test]
+    fn wait_stable_settles_using_ignore_to_mask_a_blinking_pixel() {
+        // Pixel (3,3) blinks every frame — a stand-in for a blinking caret or a
+        // clock — while the rest of the 4x4 frame stays constant black. Without
+        // `ignore` this pixel would mean the full-frame comparison never settles;
+        // masking it lets the (otherwise-constant) frame settle normally.
+        //
+        // Asserting the capture count matters: `FakePlatform` repeats its last
+        // supplied frame forever once exhausted, so a generous timeout would
+        // eventually report `settled` even WITHOUT masking (comparing the
+        // repeated final frame to itself) — that would prove nothing about
+        // `ignore`. Pinning the count to exactly 3 (the frames actually
+        // supplied) rules that out: it can only happen if the blink was masked
+        // from the very first comparison.
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let f0 = frame_4x4_corner([10, 0, 0, 255]);
+        let f1 = frame_4x4_corner([20, 0, 0, 255]);
+        let f2 = frame_4x4_corner([30, 0, 0, 255]);
+        let platform = FakePlatform::new(4, 4)
+            .with_frames(vec![f0, f1, f2.clone()])
+            .with_capture_log(log.clone());
+        let mut g = glass_with(platform);
+        g.start(&spec()).unwrap();
+        let outcome = g
+            .wait_stable(&WaitStableParams {
+                interval_ms: 0,
+                settle_frames: 2,
+                tolerance: 0,
+                timeout_ms: 1000,
+                stability_region: None,
+                ignore: vec![Region {
+                    x: 3,
+                    y: 3,
+                    width: 1,
+                    height: 1,
+                }],
+                window: None,
+            })
+            .unwrap();
+        assert!(
+            outcome.settled,
+            "the blinking pixel is masked, so the stream is stable"
+        );
+        assert_eq!(outcome.frame, f2);
+        assert_eq!(
+            log.lock().unwrap().len(),
+            3,
+            "must settle on the 3 supplied frames, not by outlasting them into FakePlatform's repeat"
         );
     }
 
@@ -722,6 +793,7 @@ mod tests {
                 tolerance: 0,
                 timeout_ms: 1000,
                 stability_region: Some(region),
+                ignore: Vec::new(),
                 window: None,
             })
             .unwrap();
@@ -757,6 +829,7 @@ mod tests {
                 tolerance: 0,
                 timeout_ms: 1000,
                 stability_region: None,
+                ignore: Vec::new(),
                 window: None,
             })
             .unwrap();
@@ -786,6 +859,7 @@ mod tests {
                     width: 99,
                     height: 1,
                 }),
+                ignore: Vec::new(),
                 window: None,
             })
             .unwrap_err();
@@ -840,6 +914,7 @@ mod tests {
                 tolerance: 0,
                 timeout_ms: 1000,
                 stability_region: None,
+                ignore: Vec::new(),
                 window: Some(WindowId(2)),
             })
             .unwrap();

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -239,6 +239,13 @@ pub struct WaitRegionParams {
     pub tolerance: u8,
     pub interval_ms: u64,
     pub timeout_ms: u64,
+    /// Window-relative sub-rectangles excluded from the comparison — pixels there
+    /// never count toward `changed`/`matches`, so a perpetually animating area (a
+    /// blinking caret, a clock) inside the watched region cannot itself satisfy
+    /// `until: Changes`, nor block `until: Matches` from converging. When `region`
+    /// is set, each rect is intersected with it and translated into region-local
+    /// coordinates, so `ignore` is always window-relative regardless of scoping.
+    pub ignore: Vec<Region>,
     /// When set, watch this window's own region instead of the active window's —
     /// without changing which window is active.
     pub window: Option<WindowId>,
@@ -524,7 +531,9 @@ impl Glass {
     /// captured frame is returned for an optional image at the tool layer.
     /// If `baseline` is set and `region` is `None`, the baseline must match the
     /// current window size — a size change since it was saved returns `SizeMismatch`;
-    /// crop to a stable `region` to avoid this.
+    /// crop to a stable `region` to avoid this. `ignore` excludes window-relative
+    /// sub-rectangles from every comparison — pixels there never count toward
+    /// `changed`/`matches` (see `WaitRegionParams::ignore`).
     pub fn wait_for_region(&mut self, params: &WaitRegionParams) -> Result<WaitRegionOutcome> {
         let active = self.require_active()?;
         // As in `wait_stable`: the active window's cached geometry only bounds
@@ -547,6 +556,19 @@ impl Glass {
             }
             None => self.capture(params.window, params.region.as_ref())?,
         };
+        // The mask is built once, sized from `reference` — the frame that will
+        // actually be compared every tick — not from the session's cached window
+        // geometry, which can be stale or belong to a different window (the same
+        // trap `wait_stable` hit: see its mask-build comment). Every polled
+        // `current` frame is required to match `reference`'s size (the masked
+        // diff functions error otherwise via `SizeMismatch`), so `reference`'s own
+        // dimensions are exactly the comparison's real size, cropped or not.
+        let mask = IgnoreMask::for_region(
+            &params.ignore,
+            params.region.as_ref(),
+            reference.width,
+            reference.height,
+        )?;
         let (perceptual, threshold, tolerance, until, region, window) = (
             params.perceptual,
             params.threshold,
@@ -559,9 +581,9 @@ impl Glass {
         let outcome = crate::poll::poll_until(params.interval_ms, params.timeout_ms, || {
             let current = self.capture(window, region.as_ref())?;
             let d = if perceptual {
-                diff_perceptual(&reference, &current, threshold)?
+                diff_perceptual_with_mask(&reference, &current, threshold, &mask)?
             } else {
-                diff(&reference, &current, tolerance)?
+                diff_with_mask(&reference, &current, tolerance, &mask)?
             };
             let satisfied = region_satisfied(&d, until);
             last = Some((d.changed_pct, d.bbox, current));
@@ -1489,6 +1511,7 @@ mod tests {
                 tolerance: 0,
                 interval_ms: 0,
                 timeout_ms: 1000,
+                ignore: Vec::new(),
                 window: None,
             })
             .unwrap();
@@ -1513,6 +1536,7 @@ mod tests {
                 tolerance: 0,
                 interval_ms: 0,
                 timeout_ms: 0,
+                ignore: Vec::new(),
                 window: None,
             })
             .unwrap();
@@ -1539,11 +1563,114 @@ mod tests {
                 tolerance: 0,
                 interval_ms: 0,
                 timeout_ms: 1000,
+                ignore: Vec::new(),
                 window: None,
             })
             .unwrap();
         assert!(o.matched);
         assert_eq!(o.changed_pct, 0.0);
+    }
+
+    #[test]
+    fn wait_for_region_ignore_masks_a_changing_rect_so_changes_never_matches() {
+        // Pixel (3,3) blinks every frame — a stand-in for a blinking caret or a
+        // clock — while the rest of the 4x4 frame stays constant. Masking it means
+        // `until: Changes` has nothing left to react to: the corner is the only
+        // pixel that ever differs, and it is excluded from the comparison.
+        //
+        // `timeout_ms: 0` bounds the wait to exactly one poll after the reference
+        // capture (see `poll_until`), so a generous timeout letting `FakePlatform`
+        // outlast its scripted frames into its repeat-forever fallback can't be
+        // what makes this pass — the outcome is decided by that single real
+        // comparison. Pinning the capture count to 2 (reference + one poll) makes
+        // that explicit.
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let f0 = frame_4x4_corner([10, 0, 0, 255]);
+        let f1 = frame_4x4_corner([20, 0, 0, 255]);
+        let platform = FakePlatform::new(4, 4)
+            .with_frames(vec![f0, f1])
+            .with_capture_log(log.clone());
+        let mut g = glass_with(platform);
+        g.start(&spec()).unwrap();
+        let o = g
+            .wait_for_region(&WaitRegionParams {
+                baseline: None,
+                region: None,
+                until: RegionUntil::Changes,
+                perceptual: false,
+                threshold: 0.1,
+                tolerance: 0,
+                interval_ms: 0,
+                timeout_ms: 0,
+                ignore: vec![Region {
+                    x: 3,
+                    y: 3,
+                    width: 1,
+                    height: 1,
+                }],
+                window: None,
+            })
+            .unwrap();
+        assert!(
+            !o.matched,
+            "the only real difference (the corner) is masked, so nothing should register as a change"
+        );
+        assert_eq!(
+            log.lock().unwrap().len(),
+            2,
+            "reference capture + exactly one poll, not outlasted into FakePlatform's repeat"
+        );
+    }
+
+    #[test]
+    fn wait_for_region_ignore_lets_matches_converge_despite_a_changing_rect() {
+        // The baseline is saved while the corner is 10; the polled stream then
+        // serves a frame with the corner at 20 — otherwise identical. Without
+        // masking, that real corner difference would keep `until: Matches` from
+        // ever being satisfied; masking it lets the (otherwise-constant) rest of
+        // the frame converge on the very first poll.
+        //
+        // Pinning the capture count to 2 (the baseline save + one poll) rules out
+        // a generous timeout eventually matching by other means: it can only
+        // happen if the corner was masked from that first real comparison.
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let f0 = frame_4x4_corner([10, 0, 0, 255]);
+        let f1 = frame_4x4_corner([20, 0, 0, 255]);
+        let platform = FakePlatform::new(4, 4)
+            .with_frames(vec![f0, f1])
+            .with_capture_log(log.clone());
+        let mut g = glass_with(platform);
+        g.start(&spec()).unwrap();
+        g.save_baseline("b").unwrap(); // consumes f0
+        let o = g
+            .wait_for_region(&WaitRegionParams {
+                baseline: Some("b".into()),
+                region: None,
+                until: RegionUntil::Matches,
+                perceptual: false,
+                threshold: 0.1,
+                tolerance: 0,
+                interval_ms: 0,
+                timeout_ms: 1000,
+                ignore: vec![Region {
+                    x: 3,
+                    y: 3,
+                    width: 1,
+                    height: 1,
+                }],
+                window: None,
+            })
+            .unwrap();
+        assert!(
+            o.matched,
+            "the corner is masked, so the rest of the frame matches the baseline immediately"
+        );
+        assert_eq!(o.changed_pct, 0.0);
+        assert_eq!(
+            log.lock().unwrap().len(),
+            2,
+            "baseline save + exactly one poll — matched on the first real comparison"
+        );
     }
 
     #[test]
@@ -1597,6 +1724,7 @@ mod tests {
                 tolerance: 0,
                 interval_ms: 0,
                 timeout_ms: 1000,
+                ignore: Vec::new(),
                 window: Some(WindowId(2)),
             })
             .unwrap();

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -251,6 +251,8 @@ pub struct WaitRegionParams {
     /// `until: Changes`, nor block `until: Matches` from converging. When `region`
     /// is set, each rect is intersected with it and translated into region-local
     /// coordinates, so `ignore` is always window-relative regardless of scoping.
+    /// With `window` set, "window-relative" means relative to the watched window,
+    /// not the active one.
     pub ignore: Vec<Region>,
     /// When set, watch this window's own region instead of the active window's —
     /// without changing which window is active.
@@ -766,17 +768,17 @@ mod tests {
     #[test]
     fn wait_stable_settles_using_ignore_to_mask_a_blinking_pixel() {
         // Pixel (3,3) blinks every frame — a stand-in for a blinking caret or a
-        // clock — while the rest of the 4x4 frame stays constant black. Without
-        // `ignore` this pixel would mean the full-frame comparison never settles;
-        // masking it lets the (otherwise-constant) frame settle normally.
+        // clock — while the rest of the 4x4 frame stays constant black. Masking
+        // it lets the (otherwise-constant) frame settle on the scripted frames.
         //
-        // Asserting the capture count matters: `FakePlatform` repeats its last
-        // supplied frame forever once exhausted, so a generous timeout would
-        // eventually report `settled` even WITHOUT masking (comparing the
-        // repeated final frame to itself) — that would prove nothing about
-        // `ignore`. Pinning the count to exactly 3 (the frames actually
-        // supplied) rules that out: it can only happen if the blink was masked
-        // from the very first comparison.
+        // `settled` alone is NOT the discriminator: without the mask the stream
+        // still settles, just *late*. `FakePlatform` repeats its last supplied
+        // frame forever once exhausted, so once polling outlasts the 3 scripted
+        // frames it compares that repeated final frame to itself and "settles"
+        // trivially — proving nothing about `ignore`. Pinning the capture count to
+        // exactly 3 (the frames actually supplied) rules that out: settling within
+        // them can only happen if the blink was masked from the very first
+        // comparison.
         let log = Arc::new(Mutex::new(Vec::new()));
         let f0 = frame_4x4_corner([10, 0, 0, 255]);
         let f1 = frame_4x4_corner([20, 0, 0, 255]);
@@ -1661,6 +1663,64 @@ mod tests {
             log.lock().unwrap().len(),
             2,
             "reference capture + exactly one poll, not outlasted into FakePlatform's repeat"
+        );
+    }
+
+    #[test]
+    fn wait_for_region_ignore_is_window_relative_under_a_region() {
+        // (3,3) blinks and is INSIDE the watched region (2,2,2,2), so the cropped
+        // frames differ every poll; only a window-relative rect translated into
+        // region-local space masks it. The region-scoped path was the last one
+        // left unexercised for `ignore`; the siblings are
+        // `wait_stable_ignore_is_window_relative_under_a_stability_region` and
+        // `baseline_ignore_is_window_relative_under_a_region`.
+        //
+        // Pinning the capture count to 2 (reference + exactly one poll, via
+        // `timeout_ms: 0`) makes the translation load-bearing: this can only be
+        // `!matched` if the window-relative rect was translated into region-local
+        // space and masked the blink on that single real comparison. Drop the
+        // translation (build the mask with no region) and the rect lands outside
+        // the 2x2 crop, the blink registers, and this flips to `matched`.
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let f0 = frame_4x4_corner([10, 0, 0, 255]);
+        let f1 = frame_4x4_corner([20, 0, 0, 255]);
+        let platform = FakePlatform::new(4, 4)
+            .with_frames(vec![f0, f1])
+            .with_capture_log(log.clone());
+        let mut g = glass_with(platform);
+        g.start(&spec()).unwrap();
+        let o = g
+            .wait_for_region(&WaitRegionParams {
+                baseline: None,
+                region: Some(Region {
+                    x: 2,
+                    y: 2,
+                    width: 2,
+                    height: 2,
+                }),
+                until: RegionUntil::Changes,
+                perceptual: false,
+                threshold: 0.1,
+                tolerance: 0,
+                interval_ms: 0,
+                timeout_ms: 0,
+                ignore: vec![Region {
+                    x: 3,
+                    y: 3,
+                    width: 1,
+                    height: 1,
+                }],
+                window: None,
+            })
+            .unwrap();
+        assert!(
+            !o.matched,
+            "the window-relative rect must translate into region-local space and mask the blink"
+        );
+        assert_eq!(
+            log.lock().unwrap().len(),
+            2,
+            "reference capture + exactly one poll — pins that the translated mask suppressed the only change on the first real comparison"
         );
     }
 

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -17,7 +17,8 @@ pub struct WaitStableParams {
     /// caret, a clock) cannot prevent the stream from settling. When
     /// `stability_region` is set, each rect is intersected with it and translated
     /// into region-local coordinates, so `ignore` is always window-relative
-    /// regardless of scoping.
+    /// regardless of scoping. With `window` set, "window-relative" means relative
+    /// to the watched window, not the active one.
     pub ignore: Vec<Region>,
     /// When set, watch this window's own region instead of the active window's —
     /// without changing which window is active.
@@ -783,6 +784,55 @@ mod tests {
     }
 
     #[test]
+    fn wait_stable_masks_by_captured_frame_size_not_stale_cached_geometry() {
+        // The cached window geometry is a deliberately stale/smaller 2x2 —
+        // `FakePlatform::new(2, 2)` — while `with_frames` serves the same 4x4
+        // blinking frames as the sibling test above. This models watching a
+        // window whose real size the session's geometry cache doesn't reflect
+        // (a different window, or a self-resize since the cache was last
+        // refreshed). The `ignore` rect at (3,3) falls outside the stale 2x2
+        // bounds but inside the actual 4x4 frame: if the mask were ever sized
+        // from the cached geometry instead of the captured frame, (3,3) would be
+        // clamped away, the blink would go unmasked, and the frames would never
+        // settle within the timeout.
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let f0 = frame_4x4_corner([10, 0, 0, 255]);
+        let f1 = frame_4x4_corner([20, 0, 0, 255]);
+        let f2 = frame_4x4_corner([30, 0, 0, 255]);
+        let platform = FakePlatform::new(2, 2)
+            .with_frames(vec![f0, f1, f2.clone()])
+            .with_capture_log(log.clone());
+        let mut g = glass_with(platform);
+        g.start(&spec()).unwrap();
+        let outcome = g
+            .wait_stable(&WaitStableParams {
+                interval_ms: 0,
+                settle_frames: 2,
+                tolerance: 0,
+                timeout_ms: 1000,
+                stability_region: None,
+                ignore: vec![Region {
+                    x: 3,
+                    y: 3,
+                    width: 1,
+                    height: 1,
+                }],
+                window: None,
+            })
+            .unwrap();
+        assert!(
+            outcome.settled,
+            "the mask must be sized from the captured 4x4 frame, not the stale 2x2 cached geometry"
+        );
+        assert_eq!(outcome.frame, f2);
+        assert_eq!(
+            log.lock().unwrap().len(),
+            3,
+            "must settle on the 3 supplied frames, not by outlasting them into FakePlatform's repeat"
+        );
+    }
+
+    #[test]
     fn wait_stable_ignore_is_window_relative_under_a_stability_region() {
         // (3,3) blinks and is INSIDE the watched region, so the cropped frames
         // differ every poll; only a window-relative rect translated into
@@ -918,6 +968,35 @@ mod tests {
                     height: 1,
                 }),
                 ignore: Vec::new(),
+                window: None,
+            })
+            .unwrap_err();
+        assert!(matches!(err, GlassError::InvalidRegion(_)));
+    }
+
+    #[test]
+    fn wait_stable_rejects_zero_area_ignore_rect() {
+        // `IgnoreMask` validates this directly, but the mask is now built lazily
+        // inside the poll closure — pin that the error still propagates out of
+        // `wait_stable` itself, so a future change that swallowed it in there
+        // (e.g. treating a build failure as "not yet stable") would be caught.
+        let platform =
+            FakePlatform::new(4, 4).with_frames(vec![Frame::solid(4, 4, [0, 0, 0, 255])]);
+        let mut g = glass_with(platform);
+        g.start(&spec()).unwrap();
+        let err = g
+            .wait_stable(&WaitStableParams {
+                interval_ms: 0,
+                settle_frames: 2,
+                tolerance: 0,
+                timeout_ms: 1000,
+                stability_region: None,
+                ignore: vec![Region {
+                    x: 0,
+                    y: 0,
+                    width: 0,
+                    height: 1,
+                }],
                 window: None,
             })
             .unwrap_err();

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -40,6 +40,12 @@ pub struct WaitStableOutcome {
     pub saw_motion: bool,
     /// How long (ms) frames were observed before settling or timing out.
     pub observed_ms: u64,
+    /// Pixels an `ignore` mask excluded from every settle comparison (counting
+    /// overlaps once); 0 when no `ignore` rects were in effect. `settled:true`
+    /// with `ignored_pixels` equal to the compared area means the mask covered
+    /// everything, so nothing was actually compared — the same signal `glass_diff`
+    /// surfaces.
+    pub ignored_pixels: u64,
 }
 
 /// Parameters for [`Glass::wait_for_element`].
@@ -265,6 +271,11 @@ pub struct WaitRegionOutcome {
     pub frame: Frame,
     /// Wall-clock milliseconds elapsed when the wait returned.
     pub elapsed_ms: u64,
+    /// Pixels an `ignore` mask excluded from the last comparison (counting
+    /// overlaps once); 0 when no `ignore` rects were in effect. Mirrors
+    /// `glass_diff`'s `ignored_pixels`: when it equals the watched area nothing
+    /// was actually compared, so `matched`/`changed_pct` describe an empty diff.
+    pub ignored_pixels: u64,
 }
 
 /// Parameters for [`Glass::wait_for_log`].
@@ -347,6 +358,7 @@ impl Glass {
             settled,
             saw_motion: tracker.saw_change(),
             observed_ms: outcome.elapsed_ms,
+            ignored_pixels: tracker.ignored_count(),
         })
     }
 
@@ -573,7 +585,7 @@ impl Glass {
             params.region,
             params.window,
         );
-        let mut last: Option<(f32, Option<BBox>, Frame)> = None;
+        let mut last: Option<(f32, Option<BBox>, u64, Frame)> = None;
         let outcome = crate::poll::poll_until(params.interval_ms, params.timeout_ms, || {
             let current = self.capture(window, region.as_ref())?;
             let d = if perceptual {
@@ -582,16 +594,17 @@ impl Glass {
                 diff_with_mask(&reference, &current, tolerance, &mask)?
             };
             let satisfied = region_satisfied(&d, until);
-            last = Some((d.changed_pct, d.bbox, current));
+            last = Some((d.changed_pct, d.bbox, d.ignored_pixels, current));
             Ok(if satisfied { Some(()) } else { None })
         })?;
-        let (changed_pct, bbox, frame) = last.expect("at least one poll ran");
+        let (changed_pct, bbox, ignored_pixels, frame) = last.expect("at least one poll ran");
         Ok(WaitRegionOutcome {
             matched: outcome.value.is_some(),
             changed_pct,
             bbox,
             frame,
             elapsed_ms: outcome.elapsed_ms,
+            ignored_pixels,
         })
     }
 
@@ -798,6 +811,39 @@ mod tests {
             log.lock().unwrap().len(),
             3,
             "must settle on the 3 supplied frames, not by outlasting them into FakePlatform's repeat"
+        );
+    }
+
+    #[test]
+    fn wait_stable_reports_ignored_pixels_masked_out_of_the_settle_comparison() {
+        // A single ignore rect covering the whole 4x4 frame leaves nothing to
+        // compare, so the stream settles trivially — and the outcome must surface
+        // the full masked count so an agent can tell it compared nothing, rather
+        // than reading a hollow `settled: true` (the gap `glass_diff` never had).
+        let a = Frame::solid(4, 4, [0, 0, 0, 255]);
+        let b = Frame::solid(4, 4, [255, 255, 255, 255]);
+        let platform = FakePlatform::new(4, 4).with_frames(vec![a, b]);
+        let mut g = glass_with(platform);
+        g.start(&spec()).unwrap();
+        let outcome = g
+            .wait_stable(&WaitStableParams {
+                interval_ms: 0,
+                settle_frames: 2,
+                tolerance: 0,
+                timeout_ms: 1000,
+                stability_region: None,
+                ignore: vec![Region {
+                    x: 0,
+                    y: 0,
+                    width: 4,
+                    height: 4,
+                }],
+                window: None,
+            })
+            .unwrap();
+        assert_eq!(
+            outcome.ignored_pixels, 16,
+            "the mask covers the whole 4x4 frame, so every pixel was excluded"
         );
     }
 
@@ -1666,6 +1712,41 @@ mod tests {
             log.lock().unwrap().len(),
             2,
             "baseline save + exactly one poll — matched on the first real comparison"
+        );
+    }
+
+    #[test]
+    fn wait_for_region_reports_ignored_pixels_from_the_last_diff() {
+        // The whole 2x2 area is masked, so `until: Changes` never sees a change and
+        // the wait times out — but the outcome must still carry the masked count
+        // from the final diff, giving the agent the same signal `glass_diff` does.
+        let a = Frame::solid(2, 2, [0, 0, 0, 255]);
+        let b = Frame::solid(2, 2, [255, 255, 255, 255]);
+        let platform = FakePlatform::new(2, 2).with_frames(vec![a, b]);
+        let mut g = glass_with(platform);
+        g.start(&spec()).unwrap();
+        let o = g
+            .wait_for_region(&WaitRegionParams {
+                baseline: None,
+                region: None,
+                until: RegionUntil::Changes,
+                perceptual: false,
+                threshold: 0.1,
+                tolerance: 0,
+                interval_ms: 0,
+                timeout_ms: 0,
+                ignore: vec![Region {
+                    x: 0,
+                    y: 0,
+                    width: 2,
+                    height: 2,
+                }],
+                window: None,
+            })
+            .unwrap();
+        assert_eq!(
+            o.ignored_pixels, 4,
+            "the mask covers the whole 2x2 area, so every pixel was excluded from the diff"
         );
     }
 

--- a/crates/glass-core/src/stability.rs
+++ b/crates/glass-core/src/stability.rs
@@ -1,4 +1,4 @@
-use crate::diff::diff;
+use crate::diff::{diff_with_mask, IgnoreMask};
 use crate::error::Result;
 use crate::frame::Frame;
 
@@ -13,6 +13,10 @@ use crate::frame::Frame;
 pub struct StabilityTracker {
     settle_frames: u32,
     tolerance: u8,
+    /// Pixels excluded from the settle comparison — a perpetually animating region
+    /// (a blinking caret, a clock) can toggle here forever without ever preventing
+    /// a settle.
+    mask: IgnoreMask,
     last: Option<Frame>,
     stable_count: u32,
     saw_change: bool,
@@ -20,9 +24,17 @@ pub struct StabilityTracker {
 
 impl StabilityTracker {
     pub fn new(settle_frames: u32, tolerance: u8) -> Self {
+        Self::with_mask(settle_frames, tolerance, IgnoreMask::empty())
+    }
+
+    /// Like [`new`](Self::new), but pixels covered by `mask` are excluded from the
+    /// frame-to-frame comparison — so a perpetually animating region (a blinking
+    /// caret, a clock) cannot prevent the stream from settling.
+    pub fn with_mask(settle_frames: u32, tolerance: u8, mask: IgnoreMask) -> Self {
         Self {
             settle_frames: settle_frames.max(1),
             tolerance,
+            mask,
             last: None,
             stable_count: 0,
             saw_change: false,
@@ -35,7 +47,9 @@ impl StabilityTracker {
         let had_prev = self.last.is_some();
         let unchanged = match &self.last {
             None => false,
-            Some(prev) => diff(prev, &frame, self.tolerance)?.changed_pixels == 0,
+            Some(prev) => {
+                diff_with_mask(prev, &frame, self.tolerance, &self.mask)?.changed_pixels == 0
+            }
         };
         if had_prev && !unchanged {
             self.saw_change = true;
@@ -61,6 +75,7 @@ impl StabilityTracker {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::frame::Region;
 
     #[test]
     fn settles_after_consecutive_identical_frames() {
@@ -91,6 +106,44 @@ mod tests {
         t.observe(a).unwrap();
         t.observe(b.clone()).unwrap();
         assert_eq!(t.last(), Some(&b));
+    }
+
+    #[test]
+    fn a_masked_blinking_pixel_still_counts_as_settled() {
+        let mask = IgnoreMask::new(
+            &[Region {
+                x: 0,
+                y: 0,
+                width: 1,
+                height: 1,
+            }],
+            4,
+            4,
+        )
+        .unwrap();
+        let mut t = StabilityTracker::with_mask(2, 0, mask);
+        let base = Frame::solid(4, 4, [0, 0, 0, 255]);
+        let mut blink = base.clone();
+        blink.pixels[0] = 255; // only the masked pixel toggles
+
+        assert!(!t.observe(base.clone()).unwrap());
+        assert!(!t.observe(blink.clone()).unwrap());
+        assert!(
+            t.observe(base.clone()).unwrap(),
+            "the toggling pixel is masked, so the stream is stable"
+        );
+    }
+
+    #[test]
+    fn an_unmasked_blinking_pixel_never_settles() {
+        let mut t = StabilityTracker::new(2, 0);
+        let base = Frame::solid(4, 4, [0, 0, 0, 255]);
+        let mut blink = base.clone();
+        blink.pixels[0] = 255;
+        for _ in 0..6 {
+            assert!(!t.observe(base.clone()).unwrap());
+            assert!(!t.observe(blink.clone()).unwrap());
+        }
     }
 
     #[test]

--- a/crates/glass-core/src/stability.rs
+++ b/crates/glass-core/src/stability.rs
@@ -64,6 +64,14 @@ impl StabilityTracker {
         self.last.as_ref()
     }
 
+    /// Pixels the mask excluded from every frame-to-frame comparison (counting
+    /// overlaps once). Zero when no `ignore` rects were in effect. Lets a caller
+    /// tell a genuine settle from one where the mask covered the whole compared
+    /// area, so nothing was actually compared.
+    pub fn ignored_count(&self) -> u64 {
+        self.mask.ignored_count()
+    }
+
     /// Whether any frame-to-frame change was observed during this watch. `false` after a
     /// settle means the window was quiet throughout — but a watch shorter than an
     /// animation's period can still miss it, so this is a hint, not a guarantee of idleness.

--- a/crates/glass-mcp/src/audit.rs
+++ b/crates/glass-mcp/src/audit.rs
@@ -820,6 +820,7 @@ mod tests {
                         tolerance: None,
                         timeout_ms: Some(500),
                         stability_region: None,
+                        ignore: None,
                     }),
                 ],
                 then: None,

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -234,8 +234,9 @@ pub struct WaitStableArgs {
     /// the settle decision ignores changes outside it. Independent of `region`.
     pub stability_region: Option<RegionArgs>,
     /// Return the settled frame as an image (default true). Set false for a
-    /// text-only `{settled,width,height}` result with no WebP — cheap when the
-    /// next step is a text `glass_diff`. `region` is ignored when false.
+    /// text-only `{settled, saw_motion, observed_ms, width, height}` result
+    /// with no WebP — cheap when the next step is a text `glass_diff`.
+    /// `region` is ignored when false.
     pub include_image: Option<bool>,
     /// Capture/observe this window (id from `glass_list_windows`) instead of the
     /// active one, without changing which window subsequent ops target. Omit for
@@ -247,9 +248,11 @@ pub struct WaitStableArgs {
     /// inside a rect never count as changed and never set `saw_motion`.
     /// Combines with `stability_region`: rects are always window-relative and
     /// are intersected with it. Independent of `region`, which only crops the
-    /// returned image. A rect entirely outside the frame is silently clamped
-    /// away and masks nothing — this tool reports no `ignored_pixels` count to
-    /// reveal that mistake, so double-check placement.
+    /// returned image. A rect that falls partially or entirely outside the
+    /// compared area — the frame, or the `stability_region` sub-rectangle when
+    /// one is set — is silently clamped or dropped, masking less than
+    /// requested or nothing at all; this tool reports no `ignored_pixels`
+    /// count to reveal that, so double-check placement.
     pub ignore: Option<Vec<RegionArgs>>,
 }
 
@@ -330,9 +333,11 @@ pub struct WaitForRegionArgs {
     /// spinner — which otherwise keeps `changed_pct` permanently non-zero.
     /// `changed_pct` is measured over the pixels that remain. Combines with
     /// `region`: rects are always window-relative and are intersected with it.
-    /// A rect entirely outside the frame is silently clamped away and masks
-    /// nothing — this tool reports no `ignored_pixels` count to reveal that
-    /// mistake, so double-check placement.
+    /// A rect that falls partially or entirely outside the compared area —
+    /// the frame, or the `region` sub-rectangle when one is set — is silently
+    /// clamped or dropped, masking less than requested or nothing at all;
+    /// this tool reports no `ignored_pixels` count to reveal that, so
+    /// double-check placement.
     pub ignore: Option<Vec<RegionArgs>>,
 }
 
@@ -431,12 +436,11 @@ pub struct SettleArgs {
     pub stability_region: Option<RegionArgs>,
     /// Window-relative rectangles to exclude from the settle comparison. Use for
     /// perpetually animating content — a blinking text caret, a clock, a
-    /// spinner — which otherwise keeps the window from ever settling. Pixels
-    /// inside a rect never count as changed and never set `saw_motion`.
+    /// spinner — which otherwise keeps the window from ever settling.
     /// Combines with `stability_region`: rects are always window-relative and
-    /// are intersected with it. A rect entirely outside the frame is silently
-    /// clamped away and masks nothing — this tool reports no `ignored_pixels`
-    /// count to reveal that mistake, so double-check placement.
+    /// are intersected with it. A rect that falls partially or entirely
+    /// outside the compared area is silently clamped or dropped, masking less
+    /// than requested or nothing at all — double-check placement.
     pub ignore: Option<Vec<RegionArgs>>,
 }
 

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -234,9 +234,9 @@ pub struct WaitStableArgs {
     /// the settle decision ignores changes outside it. Independent of `region`.
     pub stability_region: Option<RegionArgs>,
     /// Return the settled frame as an image (default true). Set false for a
-    /// text-only `{settled, saw_motion, observed_ms, width, height}` result
-    /// with no WebP — cheap when the next step is a text `glass_diff`.
-    /// `region` is ignored when false.
+    /// text-only `{settled, saw_motion, observed_ms, ignored_pixels, width,
+    /// height}` result with no WebP — cheap when the next step is a text
+    /// `glass_diff`. `region` is ignored when false.
     pub include_image: Option<bool>,
     /// Capture/observe this window (id from `glass_list_windows`) instead of the
     /// active one, without changing which window subsequent ops target. Omit for
@@ -251,8 +251,8 @@ pub struct WaitStableArgs {
     /// returned image. A rect that falls partially or entirely outside the
     /// compared area — the frame, or the `stability_region` sub-rectangle when
     /// one is set — is silently clamped or dropped, masking less than
-    /// requested or nothing at all; this tool reports no `ignored_pixels`
-    /// count to reveal that, so double-check placement.
+    /// requested or nothing at all; the excluded count is reported as
+    /// `ignored_pixels`, so a smaller-than-expected value flags a misplaced rect.
     pub ignore: Option<Vec<RegionArgs>>,
 }
 
@@ -335,9 +335,9 @@ pub struct WaitForRegionArgs {
     /// `region`: rects are always window-relative and are intersected with it.
     /// A rect that falls partially or entirely outside the compared area —
     /// the frame, or the `region` sub-rectangle when one is set — is silently
-    /// clamped or dropped, masking less than requested or nothing at all;
-    /// this tool reports no `ignored_pixels` count to reveal that, so
-    /// double-check placement.
+    /// clamped or dropped, masking less than requested or nothing at all; the
+    /// excluded count is reported as `ignored_pixels`, so a smaller-than-
+    /// expected value flags a misplaced rect.
     pub ignore: Option<Vec<RegionArgs>>,
 }
 

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -24,6 +24,12 @@ impl From<&RegionArgs> for Region {
     }
 }
 
+/// Window-relative ignore rects as core `Region`s; empty when omitted.
+pub fn ignore_regions(args: Option<&Vec<RegionArgs>>) -> Vec<Region> {
+    args.map(|v| v.iter().map(Region::from).collect())
+        .unwrap_or_default()
+}
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ScreenshotArgs {
     /// Optional window-relative sub-rectangle to capture; omit for the whole window.
@@ -235,6 +241,13 @@ pub struct WaitStableArgs {
     /// active one, without changing which window subsequent ops target. Omit for
     /// the active window.
     pub window_id: Option<u64>,
+    /// Window-relative rectangles to exclude from the comparison. Use for
+    /// perpetually animating content — a blinking text caret, a clock, a
+    /// spinner — which otherwise keeps `changed_pct` permanently non-zero.
+    /// `changed_pct` is measured over the pixels that remain; the excluded
+    /// count is reported as `ignored_pixels`. Combines with `region`: rects are
+    /// always window-relative and are intersected with it.
+    pub ignore: Option<Vec<RegionArgs>>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -309,6 +322,13 @@ pub struct WaitForRegionArgs {
     /// active one, without changing which window subsequent ops target. Omit for
     /// the active window.
     pub window_id: Option<u64>,
+    /// Window-relative rectangles to exclude from the comparison. Use for
+    /// perpetually animating content — a blinking text caret, a clock, a
+    /// spinner — which otherwise keeps `changed_pct` permanently non-zero.
+    /// `changed_pct` is measured over the pixels that remain; the excluded
+    /// count is reported as `ignored_pixels`. Combines with `region`: rects are
+    /// always window-relative and are intersected with it.
+    pub ignore: Option<Vec<RegionArgs>>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -364,6 +384,13 @@ pub struct DiffArgs {
     /// region-relative) to just this area — the way to ask "did *only* this part
     /// change?" Mirrors `glass_wait_for_region`'s `region`.
     pub region: Option<RegionArgs>,
+    /// Window-relative rectangles to exclude from the comparison. Use for
+    /// perpetually animating content — a blinking text caret, a clock, a
+    /// spinner — which otherwise keeps `changed_pct` permanently non-zero.
+    /// `changed_pct` is measured over the pixels that remain; the excluded
+    /// count is reported as `ignored_pixels`. Combines with `region`: rects are
+    /// always window-relative and are intersected with it.
+    pub ignore: Option<Vec<RegionArgs>>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -512,6 +539,87 @@ mod tests {
                 .unwrap();
         let r = some.region.unwrap();
         assert_eq!((r.x, r.y, r.width, r.height), (1, 2, 3, 4));
+    }
+
+    #[test]
+    fn diff_args_ignore_defaults_none_and_parses() {
+        let none: DiffArgs = serde_json::from_str(r#"{"name":"m"}"#).unwrap();
+        assert!(none.ignore.is_none());
+        let some: DiffArgs =
+            serde_json::from_str(r#"{"name":"m","ignore":[{"x":1,"y":2,"width":3,"height":4}]}"#)
+                .unwrap();
+        let regions = some.ignore.unwrap();
+        assert_eq!(regions.len(), 1);
+        assert_eq!(
+            (
+                regions[0].x,
+                regions[0].y,
+                regions[0].width,
+                regions[0].height
+            ),
+            (1, 2, 3, 4)
+        );
+    }
+
+    #[test]
+    fn wait_stable_args_ignore_defaults_none_and_parses() {
+        let none: WaitStableArgs = serde_json::from_str("{}").unwrap();
+        assert!(none.ignore.is_none());
+        let some: WaitStableArgs =
+            serde_json::from_str(r#"{"ignore":[{"x":0,"y":0,"width":2,"height":2}]}"#).unwrap();
+        assert_eq!(some.ignore.unwrap().len(), 1);
+    }
+
+    #[test]
+    fn wait_for_region_args_ignore_defaults_none_and_parses() {
+        let none: WaitForRegionArgs = serde_json::from_str("{}").unwrap();
+        assert!(none.ignore.is_none());
+        let some: WaitForRegionArgs =
+            serde_json::from_str(r#"{"ignore":[{"x":0,"y":0,"width":2,"height":2}]}"#).unwrap();
+        assert_eq!(some.ignore.unwrap().len(), 1);
+    }
+
+    #[test]
+    fn ignore_regions_maps_none_to_empty_vec() {
+        assert!(ignore_regions(None).is_empty());
+    }
+
+    #[test]
+    fn ignore_regions_maps_some_to_core_regions() {
+        let rects = vec![
+            RegionArgs {
+                x: 1,
+                y: 2,
+                width: 3,
+                height: 4,
+            },
+            RegionArgs {
+                x: 5,
+                y: 6,
+                width: 7,
+                height: 8,
+            },
+        ];
+        let regions = ignore_regions(Some(&rects));
+        assert_eq!(regions.len(), 2);
+        assert_eq!(
+            (
+                regions[0].x,
+                regions[0].y,
+                regions[0].width,
+                regions[0].height
+            ),
+            (1, 2, 3, 4)
+        );
+        assert_eq!(
+            (
+                regions[1].x,
+                regions[1].y,
+                regions[1].width,
+                regions[1].height
+            ),
+            (5, 6, 7, 8)
+        );
     }
 
     #[test]

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -25,7 +25,7 @@ impl From<&RegionArgs> for Region {
 }
 
 /// Window-relative ignore rects as core `Region`s; empty when omitted.
-pub fn ignore_regions(args: Option<&Vec<RegionArgs>>) -> Vec<Region> {
+pub fn ignore_regions(args: Option<&[RegionArgs]>) -> Vec<Region> {
     args.map(|v| v.iter().map(Region::from).collect())
         .unwrap_or_default()
 }
@@ -241,12 +241,15 @@ pub struct WaitStableArgs {
     /// active one, without changing which window subsequent ops target. Omit for
     /// the active window.
     pub window_id: Option<u64>,
-    /// Window-relative rectangles to exclude from the comparison. Use for
+    /// Window-relative rectangles to exclude from the settle comparison. Use for
     /// perpetually animating content — a blinking text caret, a clock, a
-    /// spinner — which otherwise keeps `changed_pct` permanently non-zero.
-    /// `changed_pct` is measured over the pixels that remain; the excluded
-    /// count is reported as `ignored_pixels`. Combines with `region`: rects are
-    /// always window-relative and are intersected with it.
+    /// spinner — which otherwise keeps the window from ever settling. Pixels
+    /// inside a rect never count as changed and never set `saw_motion`.
+    /// Combines with `stability_region`: rects are always window-relative and
+    /// are intersected with it. Independent of `region`, which only crops the
+    /// returned image. A rect entirely outside the frame is silently clamped
+    /// away and masks nothing — this tool reports no `ignored_pixels` count to
+    /// reveal that mistake, so double-check placement.
     pub ignore: Option<Vec<RegionArgs>>,
 }
 
@@ -325,9 +328,11 @@ pub struct WaitForRegionArgs {
     /// Window-relative rectangles to exclude from the comparison. Use for
     /// perpetually animating content — a blinking text caret, a clock, a
     /// spinner — which otherwise keeps `changed_pct` permanently non-zero.
-    /// `changed_pct` is measured over the pixels that remain; the excluded
-    /// count is reported as `ignored_pixels`. Combines with `region`: rects are
-    /// always window-relative and are intersected with it.
+    /// `changed_pct` is measured over the pixels that remain. Combines with
+    /// `region`: rects are always window-relative and are intersected with it.
+    /// A rect entirely outside the frame is silently clamped away and masks
+    /// nothing — this tool reports no `ignored_pixels` count to reveal that
+    /// mistake, so double-check placement.
     pub ignore: Option<Vec<RegionArgs>>,
 }
 
@@ -424,6 +429,15 @@ pub struct SettleArgs {
     pub tolerance: Option<u8>,
     pub timeout_ms: Option<u64>,
     pub stability_region: Option<RegionArgs>,
+    /// Window-relative rectangles to exclude from the settle comparison. Use for
+    /// perpetually animating content — a blinking text caret, a clock, a
+    /// spinner — which otherwise keeps the window from ever settling. Pixels
+    /// inside a rect never count as changed and never set `saw_motion`.
+    /// Combines with `stability_region`: rects are always window-relative and
+    /// are intersected with it. A rect entirely outside the frame is silently
+    /// clamped away and masks nothing — this tool reports no `ignored_pixels`
+    /// count to reveal that mistake, so double-check placement.
+    pub ignore: Option<Vec<RegionArgs>>,
 }
 
 /// Optional terminal observe after a `glass_do` sequence (run settle → diff →
@@ -580,6 +594,17 @@ mod tests {
     }
 
     #[test]
+    fn settle_args_ignore_defaults_none_and_parses() {
+        // A `glass_do` settle action/`then.settle` carries the same `ignore`
+        // knob as the standalone `glass_wait_stable` tool.
+        let none: SettleArgs = serde_json::from_str("{}").unwrap();
+        assert!(none.ignore.is_none());
+        let some: SettleArgs =
+            serde_json::from_str(r#"{"ignore":[{"x":0,"y":0,"width":2,"height":2}]}"#).unwrap();
+        assert_eq!(some.ignore.unwrap().len(), 1);
+    }
+
+    #[test]
     fn ignore_regions_maps_none_to_empty_vec() {
         assert!(ignore_regions(None).is_empty());
     }
@@ -600,7 +625,7 @@ mod tests {
                 height: 8,
             },
         ];
-        let regions = ignore_regions(Some(&rects));
+        let regions = ignore_regions(Some(rects.as_slice()));
         assert_eq!(regions.len(), 2);
         assert_eq!(
             (

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -971,6 +971,37 @@ mod tests {
         );
     }
 
+    /// `glass_diff`, `glass_wait_stable`, and `glass_wait_for_region` must each advertise an
+    /// `ignore` schema property typed as an array (`Option<Vec<RegionArgs>>` renders as
+    /// `type: ["array","null"]` under schemars 1.x) — the shape an agent's MCP client reads to
+    /// know it can pass ignore rects at all.
+    #[test]
+    fn ignore_param_is_an_array_on_diff_and_the_waits() {
+        let router = GlassServer::tool_router();
+        for tool_name in ["glass_diff", "glass_wait_stable", "glass_wait_for_region"] {
+            let tool = router
+                .list_all()
+                .into_iter()
+                .find(|t| t.name == tool_name)
+                .unwrap_or_else(|| panic!("{tool_name} is registered"));
+            let ignore_type = tool
+                .input_schema
+                .get("properties")
+                .and_then(|p| p.get("ignore"))
+                .and_then(|v| v.get("type"))
+                .unwrap_or_else(|| panic!("{tool_name} has no `ignore` schema property"));
+            let is_array = match ignore_type {
+                serde_json::Value::String(s) => s == "array",
+                serde_json::Value::Array(vs) => vs.iter().any(|v| v == "array"),
+                _ => false,
+            };
+            assert!(
+                is_array,
+                "{tool_name}'s `ignore` property must be array-typed; got {ignore_type:?}"
+            );
+        }
+    }
+
     #[test]
     fn tool_reference_documents_exactly_the_registry() {
         let documented = documented_tools();

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -974,7 +974,10 @@ mod tests {
     /// `glass_diff`, `glass_wait_stable`, and `glass_wait_for_region` must each advertise an
     /// `ignore` schema property typed as an array (`Option<Vec<RegionArgs>>` renders as
     /// `type: ["array","null"]` under schemars 1.x) — the shape an agent's MCP client reads to
-    /// know it can pass ignore rects at all.
+    /// know it can pass ignore rects at all. Also pin the item shape itself: schemars renders
+    /// `Vec<RegionArgs>`'s `items` as a `$ref` to the shared `RegionArgs` `$defs` entry, so this
+    /// must resolve there — an `items` typed as a bare integer (or anything else) would still
+    /// pass the array-only check above but reject every `{x,y,width,height}` rect a caller sends.
     #[test]
     fn ignore_param_is_an_array_on_diff_and_the_waits() {
         let router = GlassServer::tool_router();
@@ -984,11 +987,13 @@ mod tests {
                 .into_iter()
                 .find(|t| t.name == tool_name)
                 .unwrap_or_else(|| panic!("{tool_name} is registered"));
-            let ignore_type = tool
+            let ignore_prop = tool
                 .input_schema
                 .get("properties")
                 .and_then(|p| p.get("ignore"))
-                .and_then(|v| v.get("type"))
+                .unwrap_or_else(|| panic!("{tool_name} has no `ignore` schema property"));
+            let ignore_type = ignore_prop
+                .get("type")
                 .unwrap_or_else(|| panic!("{tool_name} has no `ignore` schema property"));
             let is_array = match ignore_type {
                 serde_json::Value::String(s) => s == "array",
@@ -998,6 +1003,17 @@ mod tests {
             assert!(
                 is_array,
                 "{tool_name}'s `ignore` property must be array-typed; got {ignore_type:?}"
+            );
+            let items_ref = ignore_prop
+                .get("items")
+                .and_then(|v| v.get("$ref"))
+                .and_then(|v| v.as_str())
+                .unwrap_or_else(|| {
+                    panic!("{tool_name}'s `ignore.items` must be a $ref (got {ignore_prop:?})")
+                });
+            assert_eq!(
+                items_ref, "#/$defs/RegionArgs",
+                "{tool_name}'s `ignore.items` must reference the shared RegionArgs $def; got {items_ref}"
             );
         }
     }

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -250,6 +250,7 @@ fn settle_params() -> glass_core::WaitStableParams {
         tolerance: 0,
         timeout_ms: 5000,
         stability_region: None,
+        ignore: Vec::new(), // no ignore rects yet — the tool doesn't accept them until a later change
         window: None,
     }
 }

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -250,7 +250,8 @@ fn settle_params() -> glass_core::WaitStableParams {
         tolerance: 0,
         timeout_ms: 5000,
         stability_region: None,
-        ignore: Vec::new(), // no ignore rects yet — the tool doesn't accept them until a later change
+        // the return:"settle" observe has no arg surface to carry ignore rects — always masks nothing
+        ignore: Vec::new(),
         window: None,
     }
 }

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -432,6 +432,19 @@ pub(crate) mod testutil {
         }
     }
 
+    /// A 4x4 opaque frame, constant everywhere except pixel (3,3), set to `corner` —
+    /// a stand-in for a perpetually animating rect (a blinking caret, a clock) in
+    /// `ignore`-masking tests. Mirrors glass-core's own test helper of the same name.
+    pub fn frame_4x4_corner(corner: [u8; 4]) -> Frame {
+        let mut px = vec![0u8; 4 * 4 * 4];
+        for i in 0..16 {
+            px[i * 4 + 3] = 255; // alpha
+        }
+        let idx = (3 * 4 + 3) * 4;
+        px[idx..idx + 4].copy_from_slice(&corner);
+        Frame::new(4, 4, px).expect("4x4 frame is well-formed")
+    }
+
     impl Platform for FakePlatform {
         fn start_app(&mut self, _spec: &AppSpec) -> Result<WindowGeometry> {
             self.started = true;

--- a/crates/glass-mcp/src/tools/batch.rs
+++ b/crates/glass-mcp/src/tools/batch.rs
@@ -49,6 +49,7 @@ fn settle_args(s: &SettleArgs) -> WaitStableArgs {
         stability_region: s.stability_region.clone(),
         include_image: Some(false),
         window_id: None,
+        ignore: None,
     }
 }
 
@@ -341,6 +342,7 @@ mod tests {
                         threshold: None,
                         tolerance: None,
                         include_image: Some(false),
+                        ignore: None,
                     }),
                     screenshot: None,
                 }),
@@ -376,6 +378,7 @@ mod tests {
                         threshold: None,
                         tolerance: None,
                         include_image: Some(true),
+                        ignore: None,
                     }),
                     screenshot: None,
                 }),
@@ -416,6 +419,7 @@ mod tests {
                         threshold: None,
                         tolerance: None,
                         include_image: None,
+                        ignore: None,
                     }),
                     screenshot: None,
                 }),

--- a/crates/glass-mcp/src/tools/batch.rs
+++ b/crates/glass-mcp/src/tools/batch.rs
@@ -49,7 +49,7 @@ fn settle_args(s: &SettleArgs) -> WaitStableArgs {
         stability_region: s.stability_region.clone(),
         include_image: Some(false),
         window_id: None,
-        ignore: None,
+        ignore: s.ignore.clone(),
     }
 }
 
@@ -241,6 +241,7 @@ mod tests {
                         tolerance: None,
                         timeout_ms: Some(200),
                         stability_region: None,
+                        ignore: None,
                     }),
                     diff: None,
                     screenshot: None,
@@ -255,6 +256,75 @@ mod tests {
         );
         let result = assert_envelope(&out, "glass_do");
         assert_eq!(result["then"]["settle"]["settled"], json!(true));
+    }
+
+    #[test]
+    fn then_settle_ignore_masks_a_blinking_pixel_so_it_settles() {
+        // Regression for `settle_args()` silently dropping `SettleArgs.ignore`
+        // instead of forwarding it into `WaitStableParams.ignore`: with no
+        // `#[serde(deny_unknown_fields)]` in this crate, a dropped field would
+        // still parse fine and just do nothing. Pixel (1,1) blinks across the
+        // three scripted frames — a stand-in for a blinking caret — while the
+        // rest of the 2x2 frame stays constant; only masking that rect lets it
+        // settle within `settle_frames`.
+        //
+        // Pinning the capture count to 3 (the frames actually supplied) rules
+        // out a generous timeout settling by outlasting the scripted frames
+        // into `FakePlatform`'s repeat-forever fallback, which would "settle"
+        // even without masking by comparing the repeated final frame to itself.
+        let log = Arc::new(Mutex::new(0usize));
+        let mut f0 = Frame::solid(2, 2, [10, 10, 10, 255]);
+        let mut f1 = f0.clone();
+        let mut f2 = f0.clone();
+        let idx = 3 * 4; // pixel (1,1): row 1 * width 2 + col 1 = 3, 4 bytes/pixel
+        f0.pixels[idx] = 10;
+        f1.pixels[idx] = 20;
+        f2.pixels[idx] = 30;
+        let mut g = started(
+            FakePlatform::new(2, 2)
+                .with_frames(vec![f0, f1, f2])
+                .with_capture_log(log.clone()),
+        );
+        let out = do_actions(
+            &mut g,
+            &DoArgs {
+                actions: vec![click(0, 0)],
+                then: Some(ThenArgs {
+                    settle: Some(SettleArgs {
+                        interval_ms: Some(0),
+                        settle_frames: Some(2),
+                        tolerance: None,
+                        timeout_ms: Some(1000),
+                        stability_region: None,
+                        ignore: Some(vec![RegionArgs {
+                            x: 1,
+                            y: 1,
+                            width: 1,
+                            height: 1,
+                        }]),
+                    }),
+                    diff: None,
+                    screenshot: None,
+                }),
+            },
+        )
+        .unwrap();
+        let result = assert_envelope(&out, "glass_do");
+        assert_eq!(
+            result["then"]["settle"]["settled"],
+            json!(true),
+            "the blinking pixel is masked, so the stream is stable: {result}"
+        );
+        assert_eq!(
+            result["then"]["settle"]["saw_motion"],
+            json!(false),
+            "masked motion must never set saw_motion: {result}"
+        );
+        assert_eq!(
+            *log.lock().unwrap(),
+            3,
+            "must settle on the 3 supplied frames, not by outlasting them into FakePlatform's repeat"
+        );
     }
 
     #[test]
@@ -311,6 +381,7 @@ mod tests {
                         tolerance: None,
                         timeout_ms: Some(0),
                         stability_region: None,
+                        ignore: None,
                     }),
                     diff: None,
                     screenshot: None,

--- a/crates/glass-mcp/src/tools/capture.rs
+++ b/crates/glass-mcp/src/tools/capture.rs
@@ -384,18 +384,20 @@ mod tests {
     }
 
     #[test]
-    fn wait_stable_with_ignore_settles_despite_a_blinking_rect() {
+    fn wait_stable_with_ignore_masks_saw_motion_without_outlasting_scripted_frames() {
         // Pixel (3,3) blinks every frame — a stand-in for a blinking text
         // caret, a clock, a spinner — while the rest of the 4x4 frame stays
         // constant. Without `ignore` reaching `WaitStableParams`, the full-
         // frame comparison would never settle; masking it lets the
         // otherwise-constant stream settle normally.
         //
-        // Pinning the capture count to 3 (the frames actually supplied) rules
-        // out a generous timeout settling by outlasting the scripted frames
-        // into `FakePlatform`'s repeat-forever fallback (comparing the
-        // repeated final frame to itself would "settle" even without
-        // masking, proving nothing about the wiring).
+        // `settled:true` alone is NOT the discriminator here: a generous
+        // timeout would eventually settle even without `ignore` reaching
+        // core, once polling outlasts the 3 scripted frames into
+        // `FakePlatform`'s repeat-forever fallback (the repeated final frame
+        // compared to itself "settles" trivially, proving nothing about the
+        // wiring). `saw_motion:false` and pinning the capture count to
+        // exactly 3 (the frames actually supplied) are what rule that out.
         let log = std::sync::Arc::new(std::sync::Mutex::new(0usize));
         let f0 = frame_4x4_corner([10, 0, 0, 255]);
         let f1 = frame_4x4_corner([20, 0, 0, 255]);

--- a/crates/glass-mcp/src/tools/capture.rs
+++ b/crates/glass-mcp/src/tools/capture.rs
@@ -42,8 +42,7 @@ pub fn wait_stable(glass: &mut Glass, a: &WaitStableArgs) -> ToolResult {
         tolerance: a.tolerance.unwrap_or(0),
         timeout_ms: a.timeout_ms.unwrap_or(5000),
         stability_region: a.stability_region.as_ref().map(|r| r.into()),
-        // No ignore rects yet — the tool doesn't accept them until a later change.
-        ignore: Vec::new(),
+        ignore: ignore_regions(a.ignore.as_ref()),
         window: a.window_id.map(glass_core::WindowId),
     };
     let outcome = glass.wait_stable(&params).map_err(|e| e.to_string())?;
@@ -91,17 +90,20 @@ pub fn baseline_save(glass: &mut Glass, a: &BaselineSaveArgs) -> ToolResult {
 
 pub fn diff(glass: &mut Glass, a: &DiffArgs) -> ToolResult {
     let region = a.region.as_ref().map(Region::from);
+    let ignore = ignore_regions(a.ignore.as_ref());
     let (r, current) = match a.mode.as_deref().unwrap_or("perceptual") {
-        // `&[]`: no ignore rects yet — the tool doesn't accept them until a later change.
         "perceptual" => glass.diff_baseline_perceptual_with_frame(
             &a.name,
             region.as_ref(),
-            &[],
+            &ignore,
             a.threshold.unwrap_or(0.1),
         ),
-        "exact" => {
-            glass.diff_baseline_with_frame(&a.name, region.as_ref(), &[], a.tolerance.unwrap_or(0))
-        }
+        "exact" => glass.diff_baseline_with_frame(
+            &a.name,
+            region.as_ref(),
+            &ignore,
+            a.tolerance.unwrap_or(0),
+        ),
         other => {
             return Err(format!(
                 "unknown diff mode '{other}' (use perceptual/exact)"
@@ -118,6 +120,7 @@ pub fn diff(glass: &mut Glass, a: &DiffArgs) -> ToolResult {
         "total_pixels": r.total_pixels,
         "changed_pct": r.changed_pct,
         "aa_ignored": r.aa_ignored,
+        "ignored_pixels": r.ignored_pixels,
         "bbox": bbox,
     });
     // Echo the region so the caller can map the region-relative bbox back to
@@ -318,6 +321,7 @@ mod tests {
             stability_region: None,
             include_image: None,
             window_id: None,
+            ignore: None,
         };
         let out = wait_stable(&mut g, &a).unwrap();
         if let OutContent::Image(bytes) = &out.0[0] {
@@ -349,6 +353,7 @@ mod tests {
             }),
             include_image: None,
             window_id: None,
+            ignore: None,
         };
         assert!(wait_stable(&mut g, &a).unwrap_err().contains("region"));
     }
@@ -372,6 +377,7 @@ mod tests {
             stability_region: None,
             include_image: None,
             window_id: Some(3),
+            ignore: None,
         };
         let err = wait_stable(&mut g, &a).unwrap_err();
         assert!(err.contains("not supported"), "got: {err}");
@@ -402,11 +408,50 @@ mod tests {
                 threshold: None,
                 tolerance: None,
                 include_image: None,
+                ignore: None,
             },
         )
         .unwrap();
         let v = assert_envelope(&out, "glass_diff");
         assert_eq!(v["changed_pixels"], json!(1), "envelope: {v}");
+    }
+
+    #[test]
+    fn diff_with_ignore_excludes_rect_and_reports_ignored_pixels() {
+        let base = Frame::solid(4, 4, [0, 0, 0, 255]);
+        let mut changed = base.clone();
+        changed.pixels[0] = 255; // pixel (0,0) changes, inside the ignore rect below
+        let mut g = started_with(FakePlatform::new(4, 4).with_frames(vec![base, changed]));
+        baseline_save(&mut g, &BaselineSaveArgs { name: "m".into() }).unwrap();
+        let out = diff(
+            &mut g,
+            &DiffArgs {
+                region: None,
+                name: "m".into(),
+                mode: None,
+                threshold: None,
+                tolerance: None,
+                include_image: None,
+                ignore: Some(vec![RegionArgs {
+                    x: 0,
+                    y: 0,
+                    width: 2,
+                    height: 2,
+                }]),
+            },
+        )
+        .unwrap();
+        let v = assert_envelope(&out, "glass_diff");
+        assert_eq!(
+            v["changed_pixels"],
+            json!(0),
+            "the only change sits inside the ignore rect: {v}"
+        );
+        assert_eq!(
+            v["ignored_pixels"],
+            json!(4),
+            "the 2x2 ignore rect excludes 4 pixels: {v}"
+        );
     }
 
     #[test]
@@ -431,6 +476,7 @@ mod tests {
                 threshold: None,
                 tolerance: None,
                 include_image: None,
+                ignore: None,
             },
         )
         .unwrap();
@@ -460,6 +506,7 @@ mod tests {
                 threshold: None,
                 tolerance: Some(0),
                 include_image: None,
+                ignore: None,
             },
         )
         .unwrap();
@@ -475,6 +522,7 @@ mod tests {
                 threshold: None,
                 tolerance: None,
                 include_image: None,
+                ignore: None,
             },
         )
         .unwrap_err();
@@ -497,6 +545,7 @@ mod tests {
                 threshold: None,
                 tolerance: None,
                 include_image: None,
+                ignore: None,
             },
         )
         .unwrap_err();
@@ -565,6 +614,7 @@ mod tests {
             stability_region: None,
             include_image: Some(false),
             window_id: None,
+            ignore: None,
         };
         let out = wait_stable(&mut g, &a).unwrap();
         assert_eq!(
@@ -594,6 +644,7 @@ mod tests {
                 threshold: None,
                 tolerance: None,
                 include_image: Some(true),
+                ignore: None,
             },
         )
         .unwrap();
@@ -632,6 +683,7 @@ mod tests {
                 threshold: None,
                 tolerance: None,
                 include_image: Some(true),
+                ignore: None,
             },
         )
         .unwrap();
@@ -655,6 +707,7 @@ mod tests {
             stability_region: None,
             include_image: Some(true),
             window_id: None,
+            ignore: None,
         };
         let out = wait_stable(&mut g, &a).unwrap();
         // must have [Image, meta-Text, IMAGE_NOTE-Text]
@@ -704,6 +757,7 @@ mod tests {
             stability_region: None,
             include_image: Some(false),
             window_id: None,
+            ignore: None,
         };
         let out = wait_stable(&mut g, &a).unwrap();
         // no image -> no IMAGE_NOTE
@@ -781,6 +835,7 @@ mod tests {
                 threshold: None,
                 tolerance: None,
                 include_image: Some(true),
+                ignore: None,
             },
         )
         .unwrap();
@@ -818,6 +873,7 @@ mod tests {
                 threshold: None,
                 tolerance: None,
                 include_image: Some(true),
+                ignore: None,
             },
         )
         .unwrap();

--- a/crates/glass-mcp/src/tools/capture.rs
+++ b/crates/glass-mcp/src/tools/capture.rs
@@ -42,6 +42,8 @@ pub fn wait_stable(glass: &mut Glass, a: &WaitStableArgs) -> ToolResult {
         tolerance: a.tolerance.unwrap_or(0),
         timeout_ms: a.timeout_ms.unwrap_or(5000),
         stability_region: a.stability_region.as_ref().map(|r| r.into()),
+        // No ignore rects yet — the tool doesn't accept them until a later change.
+        ignore: Vec::new(),
         window: a.window_id.map(glass_core::WindowId),
     };
     let outcome = glass.wait_stable(&params).map_err(|e| e.to_string())?;

--- a/crates/glass-mcp/src/tools/capture.rs
+++ b/crates/glass-mcp/src/tools/capture.rs
@@ -90,13 +90,15 @@ pub fn baseline_save(glass: &mut Glass, a: &BaselineSaveArgs) -> ToolResult {
 pub fn diff(glass: &mut Glass, a: &DiffArgs) -> ToolResult {
     let region = a.region.as_ref().map(Region::from);
     let (r, current) = match a.mode.as_deref().unwrap_or("perceptual") {
+        // `&[]`: no ignore rects yet — the tool doesn't accept them until a later change.
         "perceptual" => glass.diff_baseline_perceptual_with_frame(
             &a.name,
             region.as_ref(),
+            &[],
             a.threshold.unwrap_or(0.1),
         ),
         "exact" => {
-            glass.diff_baseline_with_frame(&a.name, region.as_ref(), a.tolerance.unwrap_or(0))
+            glass.diff_baseline_with_frame(&a.name, region.as_ref(), &[], a.tolerance.unwrap_or(0))
         }
         other => {
             return Err(format!(

--- a/crates/glass-mcp/src/tools/capture.rs
+++ b/crates/glass-mcp/src/tools/capture.rs
@@ -42,7 +42,7 @@ pub fn wait_stable(glass: &mut Glass, a: &WaitStableArgs) -> ToolResult {
         tolerance: a.tolerance.unwrap_or(0),
         timeout_ms: a.timeout_ms.unwrap_or(5000),
         stability_region: a.stability_region.as_ref().map(|r| r.into()),
-        ignore: ignore_regions(a.ignore.as_ref()),
+        ignore: ignore_regions(a.ignore.as_deref()),
         window: a.window_id.map(glass_core::WindowId),
     };
     let outcome = glass.wait_stable(&params).map_err(|e| e.to_string())?;
@@ -90,7 +90,7 @@ pub fn baseline_save(glass: &mut Glass, a: &BaselineSaveArgs) -> ToolResult {
 
 pub fn diff(glass: &mut Glass, a: &DiffArgs) -> ToolResult {
     let region = a.region.as_ref().map(Region::from);
-    let ignore = ignore_regions(a.ignore.as_ref());
+    let ignore = ignore_regions(a.ignore.as_deref());
     let (r, current) = match a.mode.as_deref().unwrap_or("perceptual") {
         "perceptual" => glass.diff_baseline_perceptual_with_frame(
             &a.name,
@@ -381,6 +381,63 @@ mod tests {
         };
         let err = wait_stable(&mut g, &a).unwrap_err();
         assert!(err.contains("not supported"), "got: {err}");
+    }
+
+    #[test]
+    fn wait_stable_with_ignore_settles_despite_a_blinking_rect() {
+        // Pixel (3,3) blinks every frame — a stand-in for a blinking text
+        // caret, a clock, a spinner — while the rest of the 4x4 frame stays
+        // constant. Without `ignore` reaching `WaitStableParams`, the full-
+        // frame comparison would never settle; masking it lets the
+        // otherwise-constant stream settle normally.
+        //
+        // Pinning the capture count to 3 (the frames actually supplied) rules
+        // out a generous timeout settling by outlasting the scripted frames
+        // into `FakePlatform`'s repeat-forever fallback (comparing the
+        // repeated final frame to itself would "settle" even without
+        // masking, proving nothing about the wiring).
+        let log = std::sync::Arc::new(std::sync::Mutex::new(0usize));
+        let f0 = frame_4x4_corner([10, 0, 0, 255]);
+        let f1 = frame_4x4_corner([20, 0, 0, 255]);
+        let f2 = frame_4x4_corner([30, 0, 0, 255]);
+        let mut g = started_with(
+            FakePlatform::new(4, 4)
+                .with_frames(vec![f0, f1, f2])
+                .with_capture_log(log.clone()),
+        );
+        let a = WaitStableArgs {
+            interval_ms: Some(0),
+            settle_frames: Some(2),
+            tolerance: None,
+            timeout_ms: Some(1000),
+            region: None,
+            stability_region: None,
+            include_image: Some(false),
+            window_id: None,
+            ignore: Some(vec![RegionArgs {
+                x: 3,
+                y: 3,
+                width: 1,
+                height: 1,
+            }]),
+        };
+        let out = wait_stable(&mut g, &a).unwrap();
+        let v = assert_envelope(&out, "glass_wait_stable");
+        assert_eq!(
+            v["settled"],
+            json!(true),
+            "the blinking rect is masked, so the stream is stable: {v}"
+        );
+        assert_eq!(
+            v["saw_motion"],
+            json!(false),
+            "motion confined to an ignore rect must never set saw_motion: {v}"
+        );
+        assert_eq!(
+            *log.lock().unwrap(),
+            3,
+            "must settle on the 3 supplied frames, not by outlasting them into FakePlatform's repeat"
+        );
     }
 
     #[test]

--- a/crates/glass-mcp/src/tools/capture.rs
+++ b/crates/glass-mcp/src/tools/capture.rs
@@ -51,6 +51,10 @@ pub fn wait_stable(glass: &mut Glass, a: &WaitStableArgs) -> ToolResult {
     // over a short observed_ms is only a brief quiet window (a slow animation can hide).
     let saw_motion = outcome.saw_motion;
     let observed_ms = outcome.observed_ms;
+    // Surfaced exactly as `glass_diff` does: `settled:true` with `ignored_pixels`
+    // equal to the compared area means the mask covered everything, so nothing was
+    // actually compared.
+    let ignored_pixels = outcome.ignored_pixels;
 
     // Text-only: report the settle status + full-frame dims, no WebP. `region`
     // (which only crops the returned image) is intentionally ignored here.
@@ -59,6 +63,7 @@ pub fn wait_stable(glass: &mut Glass, a: &WaitStableArgs) -> ToolResult {
             "settled": settled,
             "saw_motion": saw_motion,
             "observed_ms": observed_ms,
+            "ignored_pixels": ignored_pixels,
             "width": outcome.frame.width,
             "height": outcome.frame.height,
         });
@@ -67,7 +72,7 @@ pub fn wait_stable(glass: &mut Glass, a: &WaitStableArgs) -> ToolResult {
 
     let frame = crop_frame(outcome.frame, a.region.as_ref())?;
     let img = frame_to_webp(&frame).map_err(|e| e.to_string())?;
-    let mut meta = json!({ "settled": settled, "saw_motion": saw_motion, "observed_ms": observed_ms, "width": frame.width, "height": frame.height });
+    let mut meta = json!({ "settled": settled, "saw_motion": saw_motion, "observed_ms": observed_ms, "ignored_pixels": ignored_pixels, "width": frame.width, "height": frame.height });
     if let Some(r) = a.region.as_ref() {
         meta["x"] = json!(r.x);
         meta["y"] = json!(r.y);
@@ -439,6 +444,42 @@ mod tests {
             *log.lock().unwrap(),
             3,
             "must settle on the 3 supplied frames, not by outlasting them into FakePlatform's repeat"
+        );
+    }
+
+    #[test]
+    fn wait_stable_envelope_reports_ignored_pixels() {
+        // The ignore rect covers the whole 4x4 frame, so the settle comparison
+        // considers nothing; the text envelope must surface the masked count (the
+        // signal glass_diff already carries) so a caller isn't left with a hollow
+        // settled:true.
+        let mut g = started_with(FakePlatform::new(4, 4).with_frames(vec![Frame::solid(
+            4,
+            4,
+            [0, 0, 0, 255],
+        )]));
+        let a = WaitStableArgs {
+            interval_ms: Some(0),
+            settle_frames: Some(1),
+            tolerance: None,
+            timeout_ms: Some(1000),
+            region: None,
+            stability_region: None,
+            include_image: Some(false),
+            window_id: None,
+            ignore: Some(vec![RegionArgs {
+                x: 0,
+                y: 0,
+                width: 4,
+                height: 4,
+            }]),
+        };
+        let out = wait_stable(&mut g, &a).unwrap();
+        let v = assert_envelope(&out, "glass_wait_stable");
+        assert_eq!(
+            v["ignored_pixels"],
+            json!(16),
+            "the whole-frame mask excludes all 16 pixels: {v}"
         );
     }
 

--- a/crates/glass-mcp/src/tools/wait.rs
+++ b/crates/glass-mcp/src/tools/wait.rs
@@ -139,7 +139,7 @@ pub fn wait_for_region(glass: &mut Glass, a: &WaitForRegionArgs) -> ToolResult {
         tolerance: a.tolerance.unwrap_or(0),
         interval_ms: a.interval_ms.unwrap_or(100),
         timeout_ms: a.timeout_ms.unwrap_or(10_000),
-        ignore: ignore_regions(a.ignore.as_ref()),
+        ignore: ignore_regions(a.ignore.as_deref()),
         window: a.window_id.map(glass_core::WindowId),
     };
     let o = glass.wait_for_region(&params).map_err(|e| e.to_string())?;
@@ -651,6 +651,63 @@ mod tests {
         a.window_id = Some(9);
         let err = wait_for_region(&mut g, &a).unwrap_err();
         assert!(err.contains("not supported"), "got: {err}");
+    }
+
+    #[test]
+    fn region_with_ignore_masks_a_changing_rect_so_changes_never_matches() {
+        // Pixel (3,3) blinks between the reference (captured at call start,
+        // since no baseline is given) and the polled frame — a stand-in for a
+        // blinking text caret or a clock — while the rest of the 4x4 frame
+        // stays constant. Masking it means `until: "changes"` (the default)
+        // has nothing left to react to: the corner is the only pixel that
+        // ever differs, and it is excluded from the comparison.
+        //
+        // `timeout_ms: 0` bounds the wait to exactly one poll after the
+        // reference capture, so a generous timeout letting `FakePlatform`
+        // outlast its scripted frames into its repeat-forever fallback can't
+        // be what makes this pass — the outcome is decided by that single
+        // real comparison. Pinning the capture count to 2 (reference + one
+        // poll) makes that explicit.
+        let log = std::sync::Arc::new(std::sync::Mutex::new(0usize));
+        let f0 = frame_4x4_corner([10, 0, 0, 255]);
+        let f1 = frame_4x4_corner([20, 0, 0, 255]);
+        let mut g = glass_with(
+            FakePlatform::new(4, 4)
+                .with_frames(vec![f0, f1])
+                .with_capture_log(log.clone()),
+        );
+        g.start(&AppSpec {
+            build: None,
+            run: vec!["x".into()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 1,
+            sandbox: glass_core::SandboxLevel::Off,
+            a11y: false,
+        })
+        .unwrap();
+        let mut a = region_args();
+        a.timeout_ms = Some(0);
+        a.ignore = Some(vec![RegionArgs {
+            x: 3,
+            y: 3,
+            width: 1,
+            height: 1,
+        }]);
+        let out = wait_for_region(&mut g, &a).unwrap();
+        match out.0.last().unwrap() {
+            OutContent::Text(t) => assert!(
+                t.contains("\"matched\":false"),
+                "the only real difference (the corner) is masked, so nothing should register as a change: {t}"
+            ),
+            _ => panic!("expected text"),
+        }
+        assert_eq!(
+            *log.lock().unwrap(),
+            2,
+            "reference capture + exactly one poll, not outlasted into FakePlatform's repeat"
+        );
     }
 
     fn started_logs(logs: Vec<(glass_core::Stream, &str)>) -> Glass {

--- a/crates/glass-mcp/src/tools/wait.rs
+++ b/crates/glass-mcp/src/tools/wait.rs
@@ -139,6 +139,8 @@ pub fn wait_for_region(glass: &mut Glass, a: &WaitForRegionArgs) -> ToolResult {
         tolerance: a.tolerance.unwrap_or(0),
         interval_ms: a.interval_ms.unwrap_or(100),
         timeout_ms: a.timeout_ms.unwrap_or(10_000),
+        // No ignore rects yet — the tool doesn't accept them until a later change.
+        ignore: Vec::new(),
         window: a.window_id.map(glass_core::WindowId),
     };
     let o = glass.wait_for_region(&params).map_err(|e| e.to_string())?;

--- a/crates/glass-mcp/src/tools/wait.rs
+++ b/crates/glass-mcp/src/tools/wait.rs
@@ -156,6 +156,7 @@ pub fn wait_for_region(glass: &mut Glass, a: &WaitForRegionArgs) -> ToolResult {
         "changed_pct": o.changed_pct,
         "bbox": bbox,
         "elapsed_ms": o.elapsed_ms,
+        "ignored_pixels": o.ignored_pixels,
     });
     let image = if o.matched && a.include_image.unwrap_or(false) {
         Some(frame_to_webp(&o.frame).map_err(|e| e.to_string())?)
@@ -708,6 +709,36 @@ mod tests {
             2,
             "reference capture + exactly one poll, not outlasted into FakePlatform's repeat"
         );
+    }
+
+    #[test]
+    fn region_envelope_reports_ignored_pixels() {
+        // The ignore rect covers the whole 2x2 window, so nothing is compared and
+        // the wait times out — but the envelope must still report the masked count,
+        // matching glass_diff's ignored_pixels signal.
+        let black = Frame::solid(2, 2, [0, 0, 0, 255]);
+        let white = Frame::solid(2, 2, [255, 255, 255, 255]);
+        let mut g = started_frames(vec![black, white]);
+        let mut a = region_args();
+        a.timeout_ms = Some(0);
+        a.ignore = Some(vec![RegionArgs {
+            x: 0,
+            y: 0,
+            width: 2,
+            height: 2,
+        }]);
+        let out = wait_for_region(&mut g, &a).unwrap();
+        match out.0.last().unwrap() {
+            OutContent::Text(t) => {
+                let v: serde_json::Value = serde_json::from_str(t).unwrap();
+                assert_eq!(
+                    v["result"]["ignored_pixels"],
+                    json!(4),
+                    "the whole-window mask excludes all 4 pixels: {t}"
+                );
+            }
+            _ => panic!("expected text"),
+        }
     }
 
     fn started_logs(logs: Vec<(glass_core::Stream, &str)>) -> Glass {

--- a/crates/glass-mcp/src/tools/wait.rs
+++ b/crates/glass-mcp/src/tools/wait.rs
@@ -139,8 +139,7 @@ pub fn wait_for_region(glass: &mut Glass, a: &WaitForRegionArgs) -> ToolResult {
         tolerance: a.tolerance.unwrap_or(0),
         interval_ms: a.interval_ms.unwrap_or(100),
         timeout_ms: a.timeout_ms.unwrap_or(10_000),
-        // No ignore rects yet — the tool doesn't accept them until a later change.
-        ignore: Vec::new(),
+        ignore: ignore_regions(a.ignore.as_ref()),
         window: a.window_id.map(glass_core::WindowId),
     };
     let o = glass.wait_for_region(&params).map_err(|e| e.to_string())?;
@@ -548,6 +547,7 @@ mod tests {
             timeout_ms: Some(1000),
             include_image: None,
             window_id: None,
+            ignore: None,
         }
     }
 

--- a/crates/glass-testapp/src/main.rs
+++ b/crates/glass-testapp/src/main.rs
@@ -3,6 +3,7 @@
 //! received input/configure events to stdout (one `EVENT ...` line each).
 
 use std::io::Write;
+use std::time::{Duration, Instant};
 
 use x11rb::connection::Connection;
 use x11rb::protocol::xproto::*;
@@ -12,6 +13,19 @@ use x11rb::CURRENT_TIME;
 
 const WIDTH: u16 = 320;
 const HEIGHT: u16 = 240;
+
+// `--blink` mode: a small rectangle repainted on a fixed schedule — a deterministic stand-in
+// for a blinking text caret / clock / spinner, for tests proving glass's `ignore` masks keep a
+// perpetually animating region from blocking wait_stable/diff. Fully inside the TL quadrant
+// (0..160 x 0..120), clear of any seam, so masking it can't accidentally exclude real content.
+const BLINK_X: i16 = 16;
+const BLINK_Y: i16 = 16;
+const BLINK_W: u16 = 32;
+const BLINK_H: u16 = 32;
+// The painted grayscale level advances every this many ms, derived from wall-clock elapsed
+// time rather than an incrementing counter, so it needs no cross-thread state. It never
+// repeats within a short observation window (wraps every 256 * BLINK_TICK_MS ≈ 1.3s).
+const BLINK_TICK_MS: u128 = 5;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // `--no-wm-pid` suppresses _NET_WM_PID so tests can exercise glass's
@@ -26,6 +40,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // pid as `EVENT child_pid=<n>`, so tests can verify glass reaps the whole
     // process group on shutdown rather than orphaning the app's children.
     let fork_child = std::env::args().any(|a| a == "--fork-child");
+    // `--blink` repaints a small rectangle on a fixed schedule instead of blocking on X11
+    // events — see the BLINK_* constants. Default (unset) behavior is unchanged: the loop
+    // below still just blocks on `wait_for_event`.
+    let blink = std::env::args().any(|a| a == "--blink");
     // `--windows N` opens N-1 extra plain top-levels (titled glass-testapp-1..)
     // alongside the main quadrant window, each a distinct solid color, so
     // multi-window enumeration can be tested. Default 1 = unchanged behavior.
@@ -199,46 +217,116 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("READY w={WIDTH} h={HEIGHT}");
     std::io::stdout().flush()?;
 
+    if blink {
+        run_blink_loop(&conn, win, gc, &extras)
+    } else {
+        run_event_loop(&conn, win, gc, &extras)
+    }
+}
+
+/// Handle one X11 event the same way regardless of loop mode: paint on Expose, echo
+/// input/geometry to stdout for the test harness to assert on.
+fn dispatch_event(
+    conn: &impl Connection,
+    win: Window,
+    gc: Gcontext,
+    extras: &[(Window, u32)],
+    event: Event,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match event {
+        Event::Expose(e) => {
+            if e.window == win {
+                draw_quadrants(conn, win, gc)?;
+            } else if let Some(&(ewin, color)) = extras.iter().find(|(w, _)| *w == e.window) {
+                draw_solid(conn, ewin, gc, color)?;
+            }
+            conn.flush()?;
+        }
+        Event::ButtonPress(e) => {
+            println!(
+                "EVENT button={} x={} y={} state={}",
+                e.detail,
+                e.event_x,
+                e.event_y,
+                u16::from(e.state)
+            );
+            std::io::stdout().flush()?;
+        }
+        Event::MotionNotify(e) => {
+            println!("EVENT motion x={} y={}", e.event_x, e.event_y);
+            std::io::stdout().flush()?;
+        }
+        Event::KeyPress(e) => {
+            // Fetch the keysym for this keycode under the *current* keymap so
+            // a dynamically-uploaded keymap (Wayland backend) is reflected.
+            let m = conn.get_keyboard_mapping(e.detail, 1)?.reply()?;
+            let ks = m.keysyms.first().copied().unwrap_or(0);
+            println!("EVENT keysym={ks}");
+            std::io::stdout().flush()?;
+        }
+        Event::ConfigureNotify(e) => {
+            println!("EVENT configure w={} h={}", e.width, e.height);
+            std::io::stdout().flush()?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Default loop: block on X11 events. Behavior unchanged from before `--blink` existed.
+fn run_event_loop(
+    conn: &impl Connection,
+    win: Window,
+    gc: Gcontext,
+    extras: &[(Window, u32)],
+) -> Result<(), Box<dyn std::error::Error>> {
     loop {
         let event = conn.wait_for_event()?;
-        match event {
-            Event::Expose(e) => {
-                if e.window == win {
-                    draw_quadrants(&conn, win, gc)?;
-                } else if let Some(&(ewin, color)) = extras.iter().find(|(w, _)| *w == e.window) {
-                    draw_solid(&conn, ewin, gc, color)?;
-                }
-                conn.flush()?;
-            }
-            Event::ButtonPress(e) => {
-                println!(
-                    "EVENT button={} x={} y={} state={}",
-                    e.detail,
-                    e.event_x,
-                    e.event_y,
-                    u16::from(e.state)
-                );
-                std::io::stdout().flush()?;
-            }
-            Event::MotionNotify(e) => {
-                println!("EVENT motion x={} y={}", e.event_x, e.event_y);
-                std::io::stdout().flush()?;
-            }
-            Event::KeyPress(e) => {
-                // Fetch the keysym for this keycode under the *current* keymap so
-                // a dynamically-uploaded keymap (Wayland backend) is reflected.
-                let m = conn.get_keyboard_mapping(e.detail, 1)?.reply()?;
-                let ks = m.keysyms.first().copied().unwrap_or(0);
-                println!("EVENT keysym={ks}");
-                std::io::stdout().flush()?;
-            }
-            Event::ConfigureNotify(e) => {
-                println!("EVENT configure w={} h={}", e.width, e.height);
-                std::io::stdout().flush()?;
-            }
-            _ => {}
-        }
+        dispatch_event(conn, win, gc, extras, event)?;
     }
+}
+
+/// `--blink`: repaint the blink rect at the current wall-clock-derived grayscale level on
+/// every tick, while still servicing events non-blockingly.
+fn run_blink_loop(
+    conn: &impl Connection,
+    win: Window,
+    gc: Gcontext,
+    extras: &[(Window, u32)],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let start = Instant::now();
+    loop {
+        while let Some(event) = conn.poll_for_event()? {
+            dispatch_event(conn, win, gc, extras, event)?;
+        }
+        let level = ((start.elapsed().as_millis() / BLINK_TICK_MS) % 256) as u8;
+        draw_blink(conn, win, gc, level)?;
+        conn.flush()?;
+        std::thread::sleep(Duration::from_millis(BLINK_TICK_MS as u64));
+    }
+}
+
+/// Fill the blink rectangle with a flat grayscale fill at `level`.
+fn draw_blink(
+    conn: &impl Connection,
+    win: Window,
+    gc: Gcontext,
+    level: u8,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let level = u32::from(level);
+    let color = (level << 16) | (level << 8) | level;
+    conn.change_gc(gc, &ChangeGCAux::new().foreground(color))?;
+    conn.poly_fill_rectangle(
+        win,
+        gc,
+        &[Rectangle {
+            x: BLINK_X,
+            y: BLINK_Y,
+            width: BLINK_W,
+            height: BLINK_H,
+        }],
+    )?;
+    Ok(())
 }
 
 /// Distinct solid fill color for extra window `i` (1-based).

--- a/crates/glass-testapp/tests/common/mcp_ignore.rs
+++ b/crates/glass-testapp/tests/common/mcp_ignore.rs
@@ -1,0 +1,178 @@
+//! Shared body for the X11/Wayland "ignore regions" end-to-end tests
+//! (`ignore_regions_e2e.rs` / `wayland_ignore_regions_e2e.rs`).
+//!
+//! Everything glass ships for `ignore` regions elsewhere is unit-tested against a fake
+//! `Platform` or by calling glass-core's library API directly — neither path exercises the
+//! MCP tool-argument parsing, the window-relative coordinate mapping, or the JSON schema the
+//! rmcp server actually advertises. This drives a real `glass-mcp` server in-process over HTTP
+//! (like `network.rs`'s roundtrip) against `glass-testapp --blink`, a small rectangle repainted
+//! on a fixed schedule that stands in for a perpetually animating region (a blinking caret, a
+//! clock). The user-facing motivation: such content prevents `wait_stable` from ever settling
+//! and poisons baseline diffs unless the caller masks it out.
+
+use std::time::Duration;
+
+use glass_mcp::serve::config::ServeConfig;
+use rmcp::model::CallToolRequestParams;
+use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+use rmcp::transport::StreamableHttpClientTransport;
+use rmcp::{Peer, RoleClient, ServiceExt};
+use serde_json::{json, Value};
+
+/// The blink rectangle glass-testapp's `--blink` mode animates (see its BLINK_* constants) —
+/// fully inside the top-left quadrant, well clear of any seam, so masking it can't
+/// accidentally exclude real (non-animating) content too.
+const BLINK_REGION: (u32, u32, u32, u32) = (16, 16, 32, 32);
+
+fn blink_region_json() -> Value {
+    let (x, y, width, height) = BLINK_REGION;
+    json!({ "x": x, "y": y, "width": width, "height": height })
+}
+
+/// Call `tool` with `args` (a JSON object), assert it did not error, and return the parsed
+/// success envelope's `result` object — see glass-mcp's `tools::envelope`
+/// (`{"ok":true,"tool":..., "result": {...}}`).
+async fn call(client: &Peer<RoleClient>, tool: &str, args: Value) -> Value {
+    let arguments = args
+        .as_object()
+        .unwrap_or_else(|| panic!("{tool} args must be a JSON object: {args}"))
+        .clone();
+    let result = client
+        .call_tool(CallToolRequestParams::new(tool.to_string()).with_arguments(arguments))
+        .await
+        .unwrap_or_else(|e| panic!("{tool} call failed: {e}"));
+    assert_ne!(
+        result.is_error,
+        Some(true),
+        "{tool} returned an error result: {result:?}"
+    );
+    let text = result
+        .content
+        .iter()
+        .find_map(|c| c.as_text().map(|t| t.text.clone()))
+        .unwrap_or_else(|| panic!("{tool} returned no text content: {result:?}"));
+    let envelope: Value = serde_json::from_str(&text)
+        .unwrap_or_else(|e| panic!("{tool} text content is not JSON ({e}): {text}"));
+    envelope["result"].clone()
+}
+
+/// Drive a real `glass-mcp` server end to end against `testapp --blink` launched under
+/// `backend`: `wait_stable` must fail to settle without an `ignore` mask over the blink rect
+/// (the region really is changing), must settle once masked (and never count the masked
+/// motion as `saw_motion`), and a baseline diff with the same mask must report zero real
+/// change plus exactly the masked pixel count.
+pub async fn assert_blink_region_e2e(testapp: &str, backend: &str, start_timeout_ms: u64) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral loopback port");
+    let addr = listener.local_addr().unwrap();
+    let glass = glass_mcp::boot(None);
+    let report = glass_mcp::audit::report_from_config(None, |_| None);
+    tokio::spawn(async move {
+        let cfg = ServeConfig {
+            addr,
+            token: Some("e2e".into()),
+        };
+        let _ = glass_mcp::serve::run_on(listener, cfg, glass, report).await;
+    });
+    // Give the listener a beat to start accepting.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let mut tcfg = StreamableHttpClientTransportConfig::with_uri(format!("http://{addr}/"));
+    tcfg = tcfg.auth_header("e2e".to_string());
+    let client =
+        ().serve(StreamableHttpClientTransport::from_config(tcfg))
+            .await
+            .expect("initialize over http");
+
+    call(
+        &client,
+        "glass_start",
+        json!({
+            "run": [testapp, "--blink"],
+            "backend": backend,
+            "timeout_ms": start_timeout_ms,
+        }),
+    )
+    .await;
+
+    // No ignore: the blink rect changes on every ~5ms tick, far faster than the 50ms poll
+    // interval, so 3 consecutive identical polls (settle_frames) never happen within 400ms.
+    let unmasked = call(
+        &client,
+        "glass_wait_stable",
+        json!({
+            "interval_ms": 50,
+            "settle_frames": 3,
+            "timeout_ms": 400,
+            "include_image": false,
+        }),
+    )
+    .await;
+    assert_eq!(
+        unmasked["settled"],
+        json!(false),
+        "must not settle without a mask over the blinking rect: {unmasked}"
+    );
+    assert_eq!(
+        unmasked["saw_motion"],
+        json!(true),
+        "the blink must actually be observed changing: {unmasked}"
+    );
+
+    // Same interval, now masked: the rest of the fixture is static, so it settles quickly —
+    // and the masked motion must never be reported as saw_motion (proves the mask, not a
+    // merely-generous timeout, is why this settled).
+    let masked = call(
+        &client,
+        "glass_wait_stable",
+        json!({
+            "interval_ms": 50,
+            "settle_frames": 3,
+            "timeout_ms": 3_000,
+            "include_image": false,
+            "ignore": [blink_region_json()],
+        }),
+    )
+    .await;
+    assert_eq!(
+        masked["settled"],
+        json!(true),
+        "must settle once the blinking rect is masked: {masked}"
+    );
+    assert_eq!(
+        masked["saw_motion"],
+        json!(false),
+        "motion confined to the ignore rect must never set saw_motion: {masked}"
+    );
+
+    call(&client, "glass_baseline_save", json!({ "name": "e2e" })).await;
+    // Let the blink keep animating so the diff below genuinely exercises live, masked motion —
+    // not two captures that happen to land in the same ~5ms tick.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let diff = call(
+        &client,
+        "glass_diff",
+        json!({
+            "name": "e2e",
+            "mode": "exact",
+            "tolerance": 0,
+            "ignore": [blink_region_json()],
+        }),
+    )
+    .await;
+    assert_eq!(
+        diff["changed_pixels"],
+        json!(0),
+        "the only real change is the masked blink rect: {diff}"
+    );
+    let (_, _, w, h) = BLINK_REGION;
+    assert_eq!(
+        diff["ignored_pixels"],
+        json!(u64::from(w * h)),
+        "the mask must exclude exactly its own area: {diff}"
+    );
+
+    client.cancel().await.ok();
+}

--- a/crates/glass-testapp/tests/common/mod.rs
+++ b/crates/glass-testapp/tests/common/mod.rs
@@ -6,6 +6,13 @@
 
 use std::ops::Deref;
 
+// Shared body for the X11/Wayland ignore-regions MCP end-to-end tests. Only pulled in by the
+// test binaries that declare `mod common;` and actually call it
+// (ignore_regions_e2e.rs / wayland_ignore_regions_e2e.rs); this file's `#![allow(dead_code)]`
+// covers it for the other `mod common;` binaries (integration.rs, network.rs, harness_smoke.rs)
+// that don't.
+pub mod mcp_ignore;
+
 pub struct Xvfb(glass_x11::Xvfb);
 
 impl Xvfb {

--- a/crates/glass-testapp/tests/ignore_regions_e2e.rs
+++ b/crates/glass-testapp/tests/ignore_regions_e2e.rs
@@ -1,0 +1,27 @@
+//! End-to-end: drive glass-mcp over HTTP (the real MCP tool schema, not glass-core's library
+//! API — see `common::mcp_ignore` for why) against a `--blink`ing glass-testapp under Xvfb, to
+//! prove `ignore` regions work through the whole stack: parameter parsing, coordinate mapping,
+//! and the settle/diff logic together. `#[ignore]`d; run via
+//! `./scripts/test-x11.sh blink_region_settles_with_ignore_and_masks_diff`.
+
+// This test needs one `unsafe { env::set_var }` for pre-spawn setup (see the `// SAFETY:` note
+// below), so it opts out of the workspace `unsafe_code = "deny"` — same as network.rs.
+#![allow(unsafe_code)]
+
+mod common;
+
+use common::mcp_ignore::assert_blink_region_e2e;
+use common::Xvfb;
+
+const TESTAPP: &str = env!("CARGO_BIN_EXE_glass-testapp");
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires an X server; run via scripts/test-x11.sh"]
+async fn blink_region_settles_with_ignore_and_masks_diff() {
+    let xvfb = Xvfb::start();
+    // The x11 backend reads GLASS_DISPLAY (never ambient $DISPLAY).
+    // SAFETY: single-threaded test setup; runs before any server task spawns.
+    unsafe { std::env::set_var("GLASS_DISPLAY", &xvfb.display) };
+
+    assert_blink_region_e2e(TESTAPP, "x11", 5_000).await;
+}

--- a/crates/glass-testapp/tests/wayland_ignore_regions_e2e.rs
+++ b/crates/glass-testapp/tests/wayland_ignore_regions_e2e.rs
@@ -1,0 +1,20 @@
+//! End-to-end: the Wayland-backend twin of `ignore_regions_e2e.rs` — same assertion, same real
+//! glass-mcp server over HTTP, against sway/Xwayland instead of Xvfb (no private display setup
+//! needed here; `WaylandPlatform` manages its own compositor). The diff/settle path is shared
+//! with X11, so a failure here that X11 doesn't reproduce points at the fixture or the backend,
+//! not the mask. `#[ignore]`d; run via
+//! `./scripts/test-wayland.sh blink_region_settles_with_ignore_and_masks_diff`.
+
+mod common;
+
+use common::mcp_ignore::assert_blink_region_e2e;
+
+const TESTAPP: &str = env!("CARGO_BIN_EXE_glass-testapp");
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires sway; run via scripts/test-wayland.sh"]
+async fn blink_region_settles_with_ignore_and_masks_diff() {
+    // A freshly-spawned sway + Xwayland needs longer to come up than Xvfb; mirrors
+    // wayland.rs's APP_TIMEOUT_MS.
+    assert_blink_region_e2e(TESTAPP, "wayland", 15_000).await;
+}

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -172,8 +172,10 @@ Wait until the window stops changing, then return the settled frame.
   would otherwise keep the window from ever settling; pixels inside a rect never count as changed
   and never set `saw_motion`. Combines with `stability_region`: rects are always window-relative
   and are intersected with it. Independent of `region`, which only crops the returned image. A
-  rect entirely outside the frame is silently clamped away and masks nothing — this tool reports
-  no `ignored_pixels` count to reveal that mistake, so double-check placement.
+  rect that falls partially or entirely outside the compared area — the frame, or the
+  `stability_region` sub-rectangle when one is set — is silently clamped or dropped, masking less
+  than requested or nothing at all; this tool reports no `ignored_pixels` count to reveal that, so
+  double-check placement.
 
 Returns `{settled, saw_motion, observed_ms, width, height}`; `x, y` — the region's origin — are
 added only when `include_image` attached a frame and `region` was given (the text-only result never
@@ -220,8 +222,10 @@ baseline), then return text metrics.
   comparison. Use for perpetually animating content (a blinking caret, a clock, a spinner) that
   would otherwise keep `changed_pct` non-zero forever. `changed_pct` is measured over the pixels
   that remain. Combines with `region`: ignore rects are always window-relative and are intersected
-  with it. A rect entirely outside the frame is silently clamped away and masks nothing — this
-  tool reports no `ignored_pixels` count to reveal that mistake, so double-check placement.
+  with it. A rect that falls partially or entirely outside the compared area — the frame, or the
+  `region` sub-rectangle when one is set — is silently clamped or dropped, masking less than
+  requested or nothing at all; this tool reports no `ignored_pixels` count to reveal that, so
+  double-check placement.
 
 Returns `{matched, changed_pct, bbox, elapsed_ms}`. Use `until:"matches"` to confirm the UI reached
 an approved design without spending vision tokens. For the non-blocking case — one already-captured
@@ -344,8 +348,12 @@ Run an ordered sequence of input actions in one call (collapsing per-action roun
 optionally observe.
 
 - `actions` (array, **required**, non-empty) — each item is `{ action: "click"|"move"|"drag"|
-  "scroll"|"type"|"key"|"settle", ...same fields as the matching tool }`. A `settle` action waits
-  for the screen to stop changing between steps.
+  "scroll"|"type"|"key"|"settle", ...fields }`. Click/move/drag/scroll/type/key take the same
+  fields as their matching tool. A `settle` action takes a *subset* of `glass_wait_stable`'s
+  fields — `interval_ms`, `settle_frames`, `tolerance`, `timeout_ms`, `stability_region`, and
+  `ignore` (the same window-relative-rectangles knob) — but no `window_id`, `region`, or
+  `include_image`: it always settles the active window and never returns an image. It waits for
+  the screen to stop changing between steps.
 - `then` (`{ settle?, diff?, screenshot? }`) — a terminal observe after all actions succeed; text-
   first, returning an image only for `screenshot` (or `diff` with its own `include_image`).
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -136,10 +136,15 @@ Diff the current frame against a named baseline; returns change stats and a boun
 - `region` (`{x,y,width,height}`) — window-relative sub-rectangle to diff; omit to diff the whole
   window. Scopes the comparison (and the reported `bbox`, which becomes region-relative) to just
   this area — the way to ask "did *only* this part change?".
+- `ignore` (array of `{x,y,width,height}`) — window-relative rectangles excluded from the
+  comparison. Use for perpetually animating content (a blinking caret, a clock, a spinner) that
+  would otherwise keep `changed_pct` non-zero forever. Combines with `region`: ignore rects are
+  always window-relative and are intersected with it.
 
-Returns `{changed_pixels, total_pixels, changed_pct, aa_ignored, bbox}` (`bbox` is `null` when
-nothing changed), plus the given `region` echoed back when one was passed; only attaches an image
-when `include_image:true` and something changed.
+Returns `{changed_pixels, total_pixels, changed_pct, aa_ignored, ignored_pixels, bbox}` (`bbox` is
+`null` when nothing changed), plus the given `region` echoed back when one was passed; only attaches
+an image when `include_image:true` and something changed. `ignored_pixels` is the count excluded by
+`ignore`; `changed_pct` is measured over `total_pixels - ignored_pixels`.
 
 ## Settling & waiting
 
@@ -161,6 +166,10 @@ Wait until the window stops changing, then return the settled frame.
 - `tolerance` (integer 0–255) — per-frame change tolerance.
 - `window_id` (integer) — observe this window (id from `glass_list_windows`) instead of the active
   one, without changing which window subsequent ops target.
+- `ignore` (array of `{x,y,width,height}`) — window-relative rectangles excluded from the
+  comparison. Use for perpetually animating content (a blinking caret, a clock, a spinner) that
+  would otherwise keep `changed_pct` non-zero forever. Combines with `region`: ignore rects are
+  always window-relative and are intersected with it.
 
 Returns `{settled, saw_motion, observed_ms, width, height}`; `x, y` — the region's origin — are
 added only when `include_image` attached a frame and `region` was given (the text-only result never
@@ -203,6 +212,10 @@ baseline), then return text metrics.
 - `include_image` (boolean, default false) — on match, also return the watched region as an image.
 - `window_id` (integer) — observe this window (id from `glass_list_windows`) instead of the active
   one, without changing which window subsequent ops target.
+- `ignore` (array of `{x,y,width,height}`) — window-relative rectangles excluded from the
+  comparison. Use for perpetually animating content (a blinking caret, a clock, a spinner) that
+  would otherwise keep `changed_pct` non-zero forever. Combines with `region`: ignore rects are
+  always window-relative and are intersected with it.
 
 Returns `{matched, changed_pct, bbox, elapsed_ms}`. Use `until:"matches"` to confirm the UI reached
 an approved design without spending vision tokens. For the non-blocking case — one already-captured

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -69,8 +69,9 @@ ids are in [Conventions](#conventions) above):
   `glass_click`/`glass_move`/`glass_drag`/`glass_scroll`/`glass_gesture` — are signed `i32`,
   window-relative. A negative value addresses a point off the window's top-left edge rather than
   being rejected.
-- **Region coordinates** — `region`/`stability_region` (`x,y,width,height`), wherever a tool accepts
-  one — are unsigned `u32`; they can never be negative.
+- **Region coordinates** — `region`/`stability_region`/the rects inside `ignore`
+  (`x,y,width,height`), wherever a tool accepts one — are unsigned `u32`; they can never be
+  negative.
 - `glass_logs`' `max_lines` is a `u32`.
 
 ## Session lifecycle
@@ -166,10 +167,13 @@ Wait until the window stops changing, then return the settled frame.
 - `tolerance` (integer 0–255) — per-frame change tolerance.
 - `window_id` (integer) — observe this window (id from `glass_list_windows`) instead of the active
   one, without changing which window subsequent ops target.
-- `ignore` (array of `{x,y,width,height}`) — window-relative rectangles excluded from the
+- `ignore` (array of `{x,y,width,height}`) — window-relative rectangles excluded from the settle
   comparison. Use for perpetually animating content (a blinking caret, a clock, a spinner) that
-  would otherwise keep `changed_pct` non-zero forever. Combines with `region`: ignore rects are
-  always window-relative and are intersected with it.
+  would otherwise keep the window from ever settling; pixels inside a rect never count as changed
+  and never set `saw_motion`. Combines with `stability_region`: rects are always window-relative
+  and are intersected with it. Independent of `region`, which only crops the returned image. A
+  rect entirely outside the frame is silently clamped away and masks nothing — this tool reports
+  no `ignored_pixels` count to reveal that mistake, so double-check placement.
 
 Returns `{settled, saw_motion, observed_ms, width, height}`; `x, y` — the region's origin — are
 added only when `include_image` attached a frame and `region` was given (the text-only result never
@@ -214,8 +218,10 @@ baseline), then return text metrics.
   one, without changing which window subsequent ops target.
 - `ignore` (array of `{x,y,width,height}`) — window-relative rectangles excluded from the
   comparison. Use for perpetually animating content (a blinking caret, a clock, a spinner) that
-  would otherwise keep `changed_pct` non-zero forever. Combines with `region`: ignore rects are
-  always window-relative and are intersected with it.
+  would otherwise keep `changed_pct` non-zero forever. `changed_pct` is measured over the pixels
+  that remain. Combines with `region`: ignore rects are always window-relative and are intersected
+  with it. A rect entirely outside the frame is silently clamped away and masks nothing — this
+  tool reports no `ignored_pixels` count to reveal that mistake, so double-check placement.
 
 Returns `{matched, changed_pct, bbox, elapsed_ms}`. Use `until:"matches"` to confirm the UI reached
 an approved design without spending vision tokens. For the non-blocking case — one already-captured

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -174,14 +174,15 @@ Wait until the window stops changing, then return the settled frame.
   and are intersected with it. Independent of `region`, which only crops the returned image. A
   rect that falls partially or entirely outside the compared area — the frame, or the
   `stability_region` sub-rectangle when one is set — is silently clamped or dropped, masking less
-  than requested or nothing at all; this tool reports no `ignored_pixels` count to reveal that, so
-  double-check placement.
+  than requested or nothing at all; the excluded count is reported as `ignored_pixels`, so a
+  smaller-than-expected value flags a misplaced rect.
 
-Returns `{settled, saw_motion, observed_ms, width, height}`; `x, y` — the region's origin — are
-added only when `include_image` attached a frame and `region` was given (the text-only result never
-includes them). `saw_motion` and `observed_ms` make `settled` non-opaque: `settled:true` with
-`saw_motion:false` over a short `observed_ms` is only a brief quiet window, not necessarily a
-finished animation.
+Returns `{settled, saw_motion, observed_ms, ignored_pixels, width, height}`; `x, y` — the region's
+origin — are added only when `include_image` attached a frame and `region` was given (the text-only
+result never includes them). `saw_motion` and `observed_ms` make `settled` non-opaque: `settled:true`
+with `saw_motion:false` over a short `observed_ms` is only a brief quiet window, not necessarily a
+finished animation. `ignored_pixels` is the count an `ignore` mask excluded from the settle
+comparison; when it equals the compared area, the mask covered everything and nothing was compared.
 
 ### `glass_wait_for_element`
 
@@ -224,12 +225,14 @@ baseline), then return text metrics.
   that remain. Combines with `region`: ignore rects are always window-relative and are intersected
   with it. A rect that falls partially or entirely outside the compared area — the frame, or the
   `region` sub-rectangle when one is set — is silently clamped or dropped, masking less than
-  requested or nothing at all; this tool reports no `ignored_pixels` count to reveal that, so
-  double-check placement.
+  requested or nothing at all; the excluded count is reported as `ignored_pixels`, so a
+  smaller-than-expected value flags a misplaced rect.
 
-Returns `{matched, changed_pct, bbox, elapsed_ms}`. Use `until:"matches"` to confirm the UI reached
-an approved design without spending vision tokens. For the non-blocking case — one already-captured
-frame instead of polling — `glass_diff` takes the same `region`.
+Returns `{matched, changed_pct, bbox, elapsed_ms, ignored_pixels}`. Use `until:"matches"` to confirm
+the UI reached an approved design without spending vision tokens. `ignored_pixels` is the count an
+`ignore` mask excluded from the last comparison; when it equals the watched area, nothing was
+compared. For the non-blocking case — one already-captured frame instead of polling — `glass_diff`
+takes the same `region`.
 
 ### `glass_wait_for_log`
 

--- a/scripts/test-wayland.sh
+++ b/scripts/test-wayland.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Run the #[ignore]d Wayland integration tests. Skips cleanly if no
-# glass-discoverable sway >=1.12 is present (build+install via https://github.com/fixed-width/sway-build).
+# Run the #[ignore]d Wayland integration tests (tests/wayland.rs and the ignore-regions MCP
+# e2e in tests/wayland_ignore_regions_e2e.rs). Skips cleanly if no glass-discoverable sway
+# >=1.12 is present (build+install via https://github.com/fixed-width/sway-build).
 #
 # NOTE: the sandbox_* tests in tests/wayland.rs require 'bubblewrap' to be installed
 # (sudo apt-get install -y bubblewrap on Debian/Ubuntu) AND unprivileged user namespaces
@@ -18,4 +19,4 @@ if [ ! -x "$SWAY_BUNDLE" ] && ! { command -v sway >/dev/null 2>&1 && sway --vers
 fi
 # --test-threads=1: each test spawns its own sway (and Xwayland); serialize
 # so concurrent compositors don't contend for the display.
-exec cargo test -p glass-testapp --test wayland -- --ignored --test-threads=1 "$@"
+exec cargo test -p glass-testapp --test wayland --test wayland_ignore_regions_e2e -- --ignored --test-threads=1 "$@"

--- a/scripts/test-x11.sh
+++ b/scripts/test-x11.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-# Run the X11 integration suite (the #[ignore]d tests in tests/integration.rs and
-# the over-HTTP e2e in tests/network.rs). Each test starts its own private Xvfb, so
-# this only requires Xvfb to be installed. (The Wayland tests live in tests/wayland.rs
-# and run via scripts/test-wayland.sh — kept separate so the
-# Wayland tests' Xwayland and the X11 tests' Xvfb don't contend.)
+# Run the X11 integration suite (the #[ignore]d tests in tests/integration.rs, the over-HTTP
+# e2e in tests/network.rs, and the ignore-regions MCP e2e in tests/ignore_regions_e2e.rs).
+# Each test starts its own private Xvfb, so this only requires Xvfb to be installed. (The
+# Wayland tests live in tests/wayland.rs and tests/wayland_ignore_regions_e2e.rs, run via
+# scripts/test-wayland.sh — kept separate so the Wayland tests' Xwayland and the X11 tests'
+# Xvfb don't contend.)
 #
 # NOTE: the sandbox_* tests (sandbox_default_app_still_runs_and_captures,
 # sandbox_default_build_step_cannot_write_real_home, etc.) require 'bubblewrap'
@@ -15,4 +16,4 @@
 # sandbox level explicitly in the AppSpec.
 set -euo pipefail
 cd "$(dirname "$0")/.."
-exec cargo test -p glass-testapp --test integration --test network -- --ignored --test-threads=1 "$@"
+exec cargo test -p glass-testapp --test integration --test network --test ignore_regions_e2e -- --ignored --test-threads=1 "$@"


### PR DESCRIPTION
`glass_diff`, `glass_wait_for_region`, `glass_wait_stable`, and `glass_do`'s `settle` action accept
`ignore` — window-relative rectangles excluded from the comparison.

## Why

Perpetually animating content — a blinking text caret, a clock, a spinner — previously made
`changed_pct` permanently non-zero and meant `glass_wait_stable` never settled, so every call burned
its full timeout and returned a false negative. The existing `region` parameter is a *positive*
scope and cannot express "compare everything except this". `threshold`/`tolerance` can't either — a
caret is a real high-contrast change, so any sensitivity that hides it also hides genuine changes.

## What

- `ignore: [{x,y,width,height}]` on the three tools plus `glass_do`'s `settle`. Rects are
  window-relative; when a `region`/`stability_region` scopes the comparison, they are intersected
  with it and translated into region-local space, so the agent never switches coordinate systems.
- `changed_pct` is measured over the pixels that remain. `glass_diff`, `glass_wait_stable`, and
  `glass_wait_for_region` all report `ignored_pixels`, so a whole-area mask (which would otherwise
  report a hollow "settled"/"matched"/"no change") is visible as `ignored_pixels == total`, and a
  misplaced rect shows `ignored_pixels == 0`. With `ignore` omitted, every number is identical to
  before.
- Masking happens inside the diff loops, not by pre-copying pixels, so anti-alias detection keeps
  reading real neighbours and classification near a mask border is unchanged.

## Tests

- Core: exact-SIMD and perceptual masked diffs cross-checked against independent naive references
  across SIMD-boundary widths and mask shapes (chunk-aligned, cross-chunk, overlapping, full-row,
  full-frame); overlap dedup, out-of-bounds clamp, zero-area error, fully-masked, and
  empty-mask-equals-unchanged all covered; a dedicated guard that anti-alias classification of a
  pixel next to a mask is byte-identical to the unmasked result.
- Region-relative translation is guarded on all three surfaces (`diff_baseline`, `wait_stable`,
  `wait_for_region`) with tests that fail if the translation is dropped.
- End-to-end through the real MCP runtime, on both X11 and Wayland, against a fixture with an
  animating region: `glass_wait_stable` burns its timeout without a mask and settles with one.

Verified locally: `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`,
`cargo fmt --check`, plus the X11 and Wayland integration suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)