### PR TITLE
Host compatibility: verified-host reference + two-transport conformance tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ internal refactors, CI, or test-only changes.
   over the pixels that remain.
 - How-to: measure the verification-loop cost (semantic vs screenshot) —
   [docs/how-to/verification-cost.md](docs/how-to/verification-cost.md).
+- Reference: host compatibility — which MCP hosts are verified against glass, and what glass needs
+  from any host — [docs/reference/host-compatibility.md](docs/reference/host-compatibility.md).
 
 ### Fixed
 - **Linux `a11y:true` now reaches AccessKit-based apps (egui/winit and other Rust GUI

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ An agent building a GUI app runs it under glass, reproduces a bug **from the acc
 ## Try it in 60 seconds
 
 1. Download glass for your platform from the [Releases page](https://github.com/fixed-width/glass/releases/latest)
-   and [connect it to your agent](docs/how-to/connect-an-agent.md).
+   and [connect it to your agent](docs/how-to/connect-an-agent.md) — glass works with any MCP host
+   ([which are verified](docs/reference/host-compatibility.md)).
 2. Get the example app — clone this repo, or download
    [`examples/tasks_demo.py`](examples/tasks_demo.py) (on Linux it needs
    `sudo apt install python3-gi gir1.2-gtk-4.0`).

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ An agent building a GUI app runs it under glass, reproduces a bug **from the acc
 
 1. Download glass for your platform from the [Releases page](https://github.com/fixed-width/glass/releases/latest)
    and [connect it to your agent](docs/how-to/connect-an-agent.md) — glass works with any MCP host
-   ([which are verified](docs/reference/host-compatibility.md)).
+   ([see which are verified](docs/reference/host-compatibility.md)).
 2. Get the example app — clone this repo, or download
    [`examples/tasks_demo.py`](examples/tasks_demo.py) (on Linux it needs
    `sudo apt install python3-gi gir1.2-gtk-4.0`).

--- a/crates/glass-testapp/tests/host_conformance.rs
+++ b/crates/glass-testapp/tests/host_conformance.rs
@@ -7,6 +7,10 @@
 //!
 //! `#[ignore]d` (needs Xvfb + the testapp); run via `./scripts/test-x11.sh`.
 
+// The HTTP path needs one `unsafe { env::set_var }` for pre-spawn setup (mirrors
+// tests/network.rs's `// SAFETY:` note); opt out of the workspace `unsafe_code = "deny"`.
+#![allow(unsafe_code)]
+
 mod common;
 
 use std::io::{BufRead, BufReader, Write};
@@ -15,6 +19,12 @@ use std::time::Duration;
 
 use base64::Engine;
 use common::Xvfb;
+use glass_mcp::serve::config::ServeConfig;
+use rmcp::model::CallToolRequestParams;
+use rmcp::service::RunningService;
+use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+use rmcp::transport::StreamableHttpClientTransport;
+use rmcp::{RoleClient, ServiceExt};
 
 const TESTAPP: &str = env!("CARGO_BIN_EXE_glass-testapp");
 
@@ -236,4 +246,89 @@ fn stdio_host_can_initialize_list_tools_and_get_an_image() {
     assert_image_nonblank(webp_b64);
 
     let _ = srv.call("glass_stop", serde_json::json!({}));
+}
+
+// ---- streamable HTTP (what an rmcp-based host does) ----
+
+/// Boot an in-process glass-mcp HTTP server on an ephemeral loopback port bound to
+/// `display`, and return an initialized rmcp client. Mirrors tests/network.rs.
+async fn boot_http_client(display: &str) -> RunningService<RoleClient, ()> {
+    // SAFETY: single-threaded test setup; runs before any server task spawns.
+    unsafe { std::env::set_var("GLASS_DISPLAY", display) };
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let glass = glass_mcp::boot(None);
+    let report = glass_mcp::audit::report_from_config(None, |_| None);
+    tokio::spawn(async move {
+        let cfg = ServeConfig {
+            addr,
+            token: Some("conf".into()),
+        };
+        let _ = glass_mcp::serve::run_on(listener, cfg, glass, report).await;
+    });
+    // Give the listener a beat to start accepting.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // `auth_header` takes the BARE token; the reqwest transport prepends `Bearer `.
+    let mut tcfg = StreamableHttpClientTransportConfig::with_uri(format!("http://{addr}/"));
+    tcfg = tcfg.auth_header("conf".to_string());
+    ().serve(StreamableHttpClientTransport::from_config(tcfg))
+        .await
+        .expect("initialize over http")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires Xvfb + the testapp; run via ./scripts/test-x11.sh"]
+async fn http_host_can_initialize_list_tools_and_get_an_image() {
+    let xvfb = Xvfb::start();
+    let client = boot_http_client(&xvfb.display).await;
+
+    // A successful `.serve().await` already means initialize negotiated; confirm the
+    // client holds the server's negotiated info.
+    assert!(
+        client.peer_info().is_some(),
+        "no negotiated server info over http"
+    );
+
+    let names: Vec<String> = client
+        .list_all_tools()
+        .await
+        .expect("list_all_tools")
+        .into_iter()
+        .map(|t| t.name.to_string())
+        .collect();
+    assert_tool_surface(&names);
+
+    let mut start_args = serde_json::Map::new();
+    start_args.insert("run".to_string(), serde_json::json!([TESTAPP]));
+    let start = client
+        .call_tool(CallToolRequestParams::new("glass_start").with_arguments(start_args))
+        .await
+        .expect("glass_start call");
+    assert_ne!(
+        start.is_error,
+        Some(true),
+        "glass_start returned an error result: {start:?}"
+    );
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let shot = client
+        .call_tool(CallToolRequestParams::new("glass_screenshot"))
+        .await
+        .expect("glass_screenshot call");
+    assert_ne!(
+        shot.is_error,
+        Some(true),
+        "glass_screenshot returned an error result: {shot:?}"
+    );
+    let webp_b64 = shot
+        .content
+        .iter()
+        .find_map(|c| c.as_image().map(|img| img.data.clone()))
+        .expect("screenshot returned image content");
+    assert_image_nonblank(&webp_b64);
+
+    client.cancel().await.ok();
 }

--- a/crates/glass-testapp/tests/host_conformance.rs
+++ b/crates/glass-testapp/tests/host_conformance.rs
@@ -1,0 +1,239 @@
+//! Host-conformance: prove glass's host-facing MCP surface on BOTH transports
+//! (a spawned stdio child + an in-process HTTP server), the way a real MCP host
+//! consumes it. Each path asserts: `initialize` negotiates a protocol version,
+//! `tools/list` advertises the core loop tools, and a tool call returns a
+//! decodable non-blank IMAGE content block. Cross-transport parity of the tool
+//! set is asserted in `tool_sets_match_across_transports` (Task 3).
+//!
+//! `#[ignore]d` (needs Xvfb + the testapp); run via `./scripts/test-x11.sh`.
+
+mod common;
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::time::Duration;
+
+use base64::Engine;
+use common::Xvfb;
+
+const TESTAPP: &str = env!("CARGO_BIN_EXE_glass-testapp");
+
+/// Path to the `glass-mcp` binary. `env!("CARGO_BIN_EXE_glass-mcp")` isn't usable here:
+/// Cargo only injects `CARGO_BIN_EXE_<name>` for binaries owned by the package the test
+/// itself belongs to, and this test lives in `glass-testapp`, not `glass-mcp`. Every
+/// workspace binary lands in the same Cargo output directory, so derive the path from the
+/// sibling `glass-testapp` binary Cargo *does* inject the var for.
+fn glass_mcp_path() -> std::path::PathBuf {
+    std::path::Path::new(TESTAPP)
+        .with_file_name(format!("glass-mcp{}", std::env::consts::EXE_SUFFIX))
+}
+
+/// The build → see → interact → debug loop tools every host must see. A subset;
+/// the full set is compared across transports at runtime in the parity test, not
+/// pinned here (the exact count changes as tools are added).
+const CORE_TOOLS: &[&str] = &[
+    "glass_start",
+    "glass_screenshot",
+    "glass_click",
+    "glass_stop",
+    "glass_list_windows",
+];
+
+/// Non-emptiness floor for `tools/list` — guards against an empty or truncated
+/// listing without pinning the exact count (compared at runtime in the parity test).
+const MIN_TOOLS: usize = 20;
+
+/// Assert the listed tool names include the core loop and clear the floor.
+fn assert_tool_surface(names: &[String]) {
+    for t in CORE_TOOLS {
+        assert!(
+            names.iter().any(|n| n == t),
+            "tools/list missing core tool {t}; got {names:?}"
+        );
+    }
+    assert!(
+        names.len() >= MIN_TOOLS,
+        "tools/list returned only {} tools (< floor {MIN_TOOLS}): {names:?}",
+        names.len()
+    );
+}
+
+/// Assert base64 WebP decodes to a real, non-blank frame (image content crossed the wire).
+fn assert_image_nonblank(webp_b64: &str) {
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(webp_b64)
+        .expect("screenshot image is valid base64");
+    let img = image::load_from_memory(&bytes)
+        .expect("screenshot image decodes as WebP")
+        .to_rgba8();
+    assert!(
+        img.width() >= 320 && img.height() >= 240,
+        "unexpected screenshot dims {:?}",
+        img.dimensions()
+    );
+    let first = img.get_pixel(0, 0);
+    assert!(
+        img.pixels().any(|p| p != first),
+        "screenshot is uniform/blank — image content did not cross the wire"
+    );
+}
+
+// ---- raw JSON-RPC over stdio (what an arbitrary, non-rmcp host does) ----
+
+fn send(stdin: &mut impl Write, msg: &serde_json::Value) {
+    stdin.write_all(msg.to_string().as_bytes()).unwrap();
+    stdin.write_all(b"\n").unwrap();
+    stdin.flush().unwrap();
+}
+
+fn read_response(reader: &mut impl BufRead, id: i64) -> serde_json::Value {
+    let mut line = String::new();
+    for _ in 0..1000 {
+        line.clear();
+        if reader.read_line(&mut line).unwrap() == 0 {
+            panic!("server closed stdout before responding to id {id}");
+        }
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(line.trim()) {
+            if v.get("id").and_then(|i| i.as_i64()) == Some(id) {
+                return v;
+            }
+        }
+    }
+    panic!("no response with id {id}");
+}
+
+/// A glass-mcp child driven over stdio with newline-delimited JSON-RPC.
+struct StdioServer {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: i64,
+}
+
+impl StdioServer {
+    fn start(display: &str) -> StdioServer {
+        // The x11 backend reads GLASS_DISPLAY (never ambient $DISPLAY); set it on the child.
+        let mut child = Command::new(glass_mcp_path())
+            .env("GLASS_DISPLAY", display)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .expect("spawn glass-mcp");
+        let stdin = child.stdin.take().unwrap();
+        let stdout = BufReader::new(child.stdout.take().unwrap());
+        StdioServer {
+            child,
+            stdin,
+            stdout,
+            next_id: 1,
+        }
+    }
+
+    fn request(&mut self, method: &str, params: serde_json::Value) -> serde_json::Value {
+        let id = self.next_id;
+        self.next_id += 1;
+        send(
+            &mut self.stdin,
+            &serde_json::json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params }),
+        );
+        read_response(&mut self.stdout, id)
+    }
+
+    fn notify(&mut self, method: &str) {
+        send(
+            &mut self.stdin,
+            &serde_json::json!({ "jsonrpc": "2.0", "method": method }),
+        );
+    }
+
+    /// Send initialize + the initialized notification; return the initialize `result`.
+    fn initialize(&mut self) -> serde_json::Value {
+        let resp = self.request(
+            "initialize",
+            serde_json::json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": { "name": "glass-host-conformance", "version": "0" }
+            }),
+        );
+        assert!(resp.get("result").is_some(), "initialize failed: {resp}");
+        self.notify("notifications/initialized");
+        resp["result"].clone()
+    }
+
+    fn list_tool_names(&mut self) -> Vec<String> {
+        let resp = self.request("tools/list", serde_json::json!({}));
+        resp["result"]["tools"]
+            .as_array()
+            .expect("tools array")
+            .iter()
+            .map(|t| t["name"].as_str().unwrap_or("").to_string())
+            .collect()
+    }
+
+    /// Call a tool; return its `result` object.
+    fn call(&mut self, name: &str, arguments: serde_json::Value) -> serde_json::Value {
+        let resp = self.request(
+            "tools/call",
+            serde_json::json!({ "name": name, "arguments": arguments }),
+        );
+        resp["result"].clone()
+    }
+}
+
+impl Drop for StdioServer {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[test]
+#[ignore = "requires Xvfb + the testapp; run via ./scripts/test-x11.sh"]
+fn stdio_host_can_initialize_list_tools_and_get_an_image() {
+    let xvfb = Xvfb::start();
+    let mut srv = StdioServer::start(&xvfb.display);
+
+    let init = srv.initialize();
+    let ver = init["protocolVersion"].as_str().unwrap_or("");
+    assert!(
+        !ver.is_empty(),
+        "initialize did not negotiate a protocolVersion: {init}"
+    );
+
+    let names = srv.list_tool_names();
+    assert_tool_surface(&names);
+
+    let start = srv.call("glass_start", serde_json::json!({ "run": [TESTAPP] }));
+    assert_ne!(
+        start["isError"].as_bool(),
+        Some(true),
+        "glass_start returned an error result: {start}"
+    );
+
+    // Let the window render (mirrors the proven timing in tests/network.rs).
+    std::thread::sleep(Duration::from_millis(300));
+
+    let shot = srv.call("glass_screenshot", serde_json::json!({}));
+    assert_ne!(
+        shot["isError"].as_bool(),
+        Some(true),
+        "glass_screenshot returned an error result: {shot}"
+    );
+    let webp_b64 = shot["content"]
+        .as_array()
+        .expect("content array")
+        .iter()
+        .find_map(|c| {
+            if c["type"] == "image" {
+                c["data"].as_str()
+            } else {
+                None
+            }
+        })
+        .expect("screenshot returned an image content block");
+    assert_image_nonblank(webp_b64);
+
+    let _ = srv.call("glass_stop", serde_json::json!({}));
+}

--- a/crates/glass-testapp/tests/host_conformance.rs
+++ b/crates/glass-testapp/tests/host_conformance.rs
@@ -3,19 +3,24 @@
 //! consumes it. Each path asserts: `initialize` negotiates a protocol version,
 //! `tools/list` advertises the core loop tools, and a tool call returns a
 //! decodable non-blank IMAGE content block. Cross-transport parity of the tool
-//! set is asserted in `tool_sets_match_across_transports` (Task 3).
+//! set is asserted in `tool_sets_match_across_transports`.
 //!
 //! `#[ignore]d` (needs Xvfb + the testapp); run via `./scripts/test-x11.sh`.
+//! To run a single test, filter on its function-name substring, e.g.
+//! `./scripts/test-x11.sh stdio_host_can` (the bare file name `host_conformance`
+//! is not a test name and matches nothing).
 
 // The HTTP path needs one `unsafe { env::set_var }` for pre-spawn setup (mirrors
-// tests/network.rs's `// SAFETY:` note); opt out of the workspace `unsafe_code = "deny"`.
+// tests/network.rs); opt out of the workspace `unsafe_code = "deny"`.
 #![allow(unsafe_code)]
 
 mod common;
 
 use std::io::{BufRead, BufReader, Write};
-use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
-use std::time::Duration;
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc::{self, Receiver};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
 
 use base64::Engine;
 use common::Xvfb;
@@ -28,14 +33,26 @@ use rmcp::{RoleClient, ServiceExt};
 
 const TESTAPP: &str = env!("CARGO_BIN_EXE_glass-testapp");
 
+/// Wall-clock ceiling for a single stdio JSON-RPC response. Generous (the child
+/// replies in milliseconds); its job is to turn a hung child into a fast, legible
+/// failure instead of blocking the whole `--test-threads=1` X11 suite until CI's
+/// job timeout.
+const READ_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Path to the `glass-mcp` binary. `env!("CARGO_BIN_EXE_glass-mcp")` isn't usable here:
 /// Cargo only injects `CARGO_BIN_EXE_<name>` for binaries owned by the package the test
 /// itself belongs to, and this test lives in `glass-testapp`, not `glass-mcp`. Every
 /// workspace binary lands in the same Cargo output directory, so derive the path from the
 /// sibling `glass-testapp` binary Cargo *does* inject the var for.
 fn glass_mcp_path() -> std::path::PathBuf {
-    std::path::Path::new(TESTAPP)
-        .with_file_name(format!("glass-mcp{}", std::env::consts::EXE_SUFFIX))
+    let p = std::path::Path::new(TESTAPP)
+        .with_file_name(format!("glass-mcp{}", std::env::consts::EXE_SUFFIX));
+    assert!(
+        p.exists(),
+        "glass-mcp binary not found at {p:?}; build it first: \
+         cargo build -p glass-mcp --bin glass-mcp (scripts/test-x11.sh does this for you)"
+    );
+    p
 }
 
 /// The build → see → interact → debug loop tools every host must see. A subset;
@@ -96,27 +113,14 @@ fn send(stdin: &mut impl Write, msg: &serde_json::Value) {
     stdin.flush().unwrap();
 }
 
-fn read_response(reader: &mut impl BufRead, id: i64) -> serde_json::Value {
-    let mut line = String::new();
-    for _ in 0..1000 {
-        line.clear();
-        if reader.read_line(&mut line).unwrap() == 0 {
-            panic!("server closed stdout before responding to id {id}");
-        }
-        if let Ok(v) = serde_json::from_str::<serde_json::Value>(line.trim()) {
-            if v.get("id").and_then(|i| i.as_i64()) == Some(id) {
-                return v;
-            }
-        }
-    }
-    panic!("no response with id {id}");
-}
-
-/// A glass-mcp child driven over stdio with newline-delimited JSON-RPC.
+/// A glass-mcp child driven over stdio with newline-delimited JSON-RPC. A reader
+/// thread pumps stdout lines into a channel so responses can be awaited with a
+/// wall-clock timeout rather than a blocking read that could hang the suite.
 struct StdioServer {
     child: Child,
     stdin: ChildStdin,
-    stdout: BufReader<ChildStdout>,
+    lines: Receiver<String>,
+    reader: Option<JoinHandle<()>>,
     next_id: i64,
 }
 
@@ -131,12 +135,56 @@ impl StdioServer {
             .spawn()
             .expect("spawn glass-mcp");
         let stdin = child.stdin.take().unwrap();
-        let stdout = BufReader::new(child.stdout.take().unwrap());
+        let stdout = child.stdout.take().unwrap();
+        let (tx, lines) = mpsc::channel();
+        let reader = std::thread::spawn(move || {
+            let mut r = BufReader::new(stdout);
+            let mut line = String::new();
+            loop {
+                line.clear();
+                match r.read_line(&mut line) {
+                    Ok(0) | Err(_) => break, // EOF (child gone) or read error: stop pumping.
+                    Ok(_) => {
+                        if tx.send(std::mem::take(&mut line)).is_err() {
+                            break; // receiver dropped; nothing left to read for.
+                        }
+                    }
+                }
+            }
+        });
         StdioServer {
             child,
             stdin,
-            stdout,
+            lines,
+            reader: Some(reader),
             next_id: 1,
+        }
+    }
+
+    /// Block until the JSON-RPC response with `id` arrives, skipping unrelated lines,
+    /// or panic after `READ_TIMEOUT` (or if the child closes stdout first).
+    fn read_response(&self, id: i64) -> serde_json::Value {
+        let deadline = Instant::now() + READ_TIMEOUT;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                panic!("timed out after {READ_TIMEOUT:?} waiting for response id {id}");
+            }
+            match self.lines.recv_timeout(remaining) {
+                Ok(line) => {
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(line.trim()) {
+                        if v.get("id").and_then(|i| i.as_i64()) == Some(id) {
+                            return v;
+                        }
+                    }
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    panic!("timed out after {READ_TIMEOUT:?} waiting for response id {id}")
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    panic!("server closed stdout before responding to id {id}")
+                }
+            }
         }
     }
 
@@ -147,7 +195,7 @@ impl StdioServer {
             &mut self.stdin,
             &serde_json::json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params }),
         );
-        read_response(&mut self.stdout, id)
+        self.read_response(id)
     }
 
     fn notify(&mut self, method: &str) {
@@ -176,17 +224,23 @@ impl StdioServer {
         let resp = self.request("tools/list", serde_json::json!({}));
         resp["result"]["tools"]
             .as_array()
-            .expect("tools array")
+            .unwrap_or_else(|| panic!("no tools array in tools/list response: {resp}"))
             .iter()
             .map(|t| t["name"].as_str().unwrap_or("").to_string())
             .collect()
     }
 
-    /// Call a tool; return its `result` object.
+    /// Call a tool; return its `result` object. Panics if the server replied with a
+    /// JSON-RPC top-level error (no `result`) — otherwise a protocol-level failure would
+    /// read as `Null` and silently pass an `isError` success check at the call site.
     fn call(&mut self, name: &str, arguments: serde_json::Value) -> serde_json::Value {
         let resp = self.request(
             "tools/call",
             serde_json::json!({ "name": name, "arguments": arguments }),
+        );
+        assert!(
+            resp.get("result").is_some(),
+            "tools/call {name} failed at the JSON-RPC level: {resp}"
         );
         resp["result"].clone()
     }
@@ -195,7 +249,10 @@ impl StdioServer {
 impl Drop for StdioServer {
     fn drop(&mut self) {
         let _ = self.child.kill();
-        let _ = self.child.wait();
+        let _ = self.child.wait(); // closes stdout, so the reader thread's read_line returns EOF.
+        if let Some(reader) = self.reader.take() {
+            let _ = reader.join();
+        }
     }
 }
 
@@ -231,9 +288,10 @@ fn stdio_host_can_initialize_list_tools_and_get_an_image() {
         Some(true),
         "glass_screenshot returned an error result: {shot}"
     );
-    let webp_b64 = shot["content"]
+    let content = shot["content"]
         .as_array()
-        .expect("content array")
+        .unwrap_or_else(|| panic!("no content array in glass_screenshot response: {shot}"));
+    let webp_b64 = content
         .iter()
         .find_map(|c| {
             if c["type"] == "image" {
@@ -244,6 +302,12 @@ fn stdio_host_can_initialize_list_tools_and_get_an_image() {
         })
         .expect("screenshot returned an image content block");
     assert_image_nonblank(webp_b64);
+    // The screenshot response is multi-block (image + a text envelope + an untrusted-content
+    // note); assert a text block survived the wire alongside the image.
+    assert!(
+        content.iter().any(|c| c["type"] == "text"),
+        "screenshot response carried no text block alongside the image: {shot}"
+    );
 
     let _ = srv.call("glass_stop", serde_json::json!({}));
 }
@@ -253,7 +317,9 @@ fn stdio_host_can_initialize_list_tools_and_get_an_image() {
 /// Boot an in-process glass-mcp HTTP server on an ephemeral loopback port bound to
 /// `display`, and return an initialized rmcp client. Mirrors tests/network.rs.
 async fn boot_http_client(display: &str) -> RunningService<RoleClient, ()> {
-    // SAFETY: single-threaded test setup; runs before any server task spawns.
+    // SAFETY: no other thread reads or writes env vars concurrently here — this runs
+    // before any server task (or any code that could read GLASS_DISPLAY) is spawned,
+    // even though the test's tokio runtime is itself multi-threaded.
     unsafe { std::env::set_var("GLASS_DISPLAY", display) };
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -278,26 +344,34 @@ async fn boot_http_client(display: &str) -> RunningService<RoleClient, ()> {
         .expect("initialize over http")
 }
 
+/// List the advertised tool names over the rmcp HTTP client.
+async fn http_tool_names(client: &RunningService<RoleClient, ()>) -> Vec<String> {
+    client
+        .list_all_tools()
+        .await
+        .expect("list_all_tools")
+        .into_iter()
+        .map(|t| t.name.to_string())
+        .collect()
+}
+
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "requires Xvfb + the testapp; run via ./scripts/test-x11.sh"]
 async fn http_host_can_initialize_list_tools_and_get_an_image() {
     let xvfb = Xvfb::start();
     let client = boot_http_client(&xvfb.display).await;
 
-    // A successful `.serve().await` already means initialize negotiated; confirm the
-    // client holds the server's negotiated info.
+    // `boot_http_client` already `.expect`s a successful initialize; assert the negotiated
+    // protocol version is non-empty, matching the stdio path's rigor.
+    let info = client
+        .peer_info()
+        .expect("no negotiated server info over http");
     assert!(
-        client.peer_info().is_some(),
-        "no negotiated server info over http"
+        !info.protocol_version.as_str().is_empty(),
+        "http initialize did not negotiate a protocolVersion"
     );
 
-    let names: Vec<String> = client
-        .list_all_tools()
-        .await
-        .expect("list_all_tools")
-        .into_iter()
-        .map(|t| t.name.to_string())
-        .collect();
+    let names = http_tool_names(&client).await;
     assert_tool_surface(&names);
 
     let mut start_args = serde_json::Map::new();
@@ -329,6 +403,11 @@ async fn http_host_can_initialize_list_tools_and_get_an_image() {
         .find_map(|c| c.as_image().map(|img| img.data.clone()))
         .expect("screenshot returned image content");
     assert_image_nonblank(&webp_b64);
+    // Assert a text block survived alongside the image (see the stdio test for why).
+    assert!(
+        shot.content.iter().any(|c| c.as_text().is_some()),
+        "screenshot response carried no text block alongside the image: {shot:?}"
+    );
 
     client.cancel().await.ok();
 }
@@ -350,13 +429,7 @@ async fn tool_sets_match_across_transports() {
 
     // http listing, in-process.
     let client = boot_http_client(&xvfb.display).await;
-    let mut http_names: Vec<String> = client
-        .list_all_tools()
-        .await
-        .expect("list_all_tools")
-        .into_iter()
-        .map(|t| t.name.to_string())
-        .collect();
+    let mut http_names = http_tool_names(&client).await;
     client.cancel().await.ok();
 
     stdio_names.sort();

--- a/crates/glass-testapp/tests/host_conformance.rs
+++ b/crates/glass-testapp/tests/host_conformance.rs
@@ -332,3 +332,38 @@ async fn http_host_can_initialize_list_tools_and_get_an_image() {
 
     client.cancel().await.ok();
 }
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires Xvfb; run via ./scripts/test-x11.sh"]
+async fn tool_sets_match_across_transports() {
+    let xvfb = Xvfb::start();
+
+    // stdio listing is blocking; run it off the async runtime.
+    let stdio_display = xvfb.display.clone();
+    let mut stdio_names = tokio::task::spawn_blocking(move || {
+        let mut srv = StdioServer::start(&stdio_display);
+        srv.initialize();
+        srv.list_tool_names()
+    })
+    .await
+    .expect("stdio listing task");
+
+    // http listing, in-process.
+    let client = boot_http_client(&xvfb.display).await;
+    let mut http_names: Vec<String> = client
+        .list_all_tools()
+        .await
+        .expect("list_all_tools")
+        .into_iter()
+        .map(|t| t.name.to_string())
+        .collect();
+    client.cancel().await.ok();
+
+    stdio_names.sort();
+    http_names.sort();
+    assert!(!stdio_names.is_empty(), "no tools advertised over stdio");
+    assert_eq!(
+        stdio_names, http_names,
+        "tool set differs across transports:\n stdio={stdio_names:?}\n http={http_names:?}"
+    );
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,7 @@ way it does? The explanations.
 ## Reference — look up a fact
 
 - [Tools](reference/tools.md) — every `glass_*` tool, its parameters, and platform support
+- [Host compatibility](reference/host-compatibility.md) — which MCP hosts are verified, and what glass needs from any host
 - [Stability and versioning](reference/stability.md) — the semver promise: what's covered from 1.0
 - [Environment variables](reference/environment.md) — every `GLASS_*` variable
 - [CLI](reference/cli.md) — `glass-mcp` subcommands

--- a/docs/how-to/connect-an-agent.md
+++ b/docs/how-to/connect-an-agent.md
@@ -2,7 +2,9 @@
 
 glass speaks the Model Context Protocol, so you register it with your MCP client once and your agent
 gains the glass tools. glass works with any MCP client; the examples below use Claude Code and a
-generic JSON config. There are two transports — pick by how glass is running.
+generic JSON config. For the verified-host list and what glass needs from a host, see
+[Host compatibility](../reference/host-compatibility.md). There are two transports — pick by how
+glass is running.
 
 - If glass runs on the **same machine** as your agent (the Linux and Windows default), use **stdio**.
 - If glass runs as a **network server** (the macOS menu-bar LaunchAgent, or the agent and app on

--- a/docs/reference/host-compatibility.md
+++ b/docs/reference/host-compatibility.md
@@ -1,0 +1,50 @@
+# Host compatibility
+
+glass is a standard [Model Context Protocol](https://modelcontextprotocol.io) server, so any
+spec-compliant MCP host can drive it. This page records what glass needs from a host and which
+hosts have been verified end to end.
+
+## What glass needs from a host
+
+A host can drive glass if it:
+
+- speaks MCP over **stdio** or **HTTP** (streamable) — glass serves both;
+- renders **image content blocks** — `glass_screenshot` and `glass_diff` return WebP images;
+- handles glass's tool set (~30 tools).
+
+These are exactly the capabilities the host-conformance tests exercise
+(`crates/glass-testapp/tests/host_conformance.rs`): on both transports they negotiate a protocol
+version, list the full tool set, and return a decodable screenshot image.
+
+## Verified hosts
+
+A host is *verified* when its own MCP client connects to glass, lists the tools, and drives a real
+loop — a tool call that returns text and one that returns an image — with the results crossing back.
+
+| Host | stdio | HTTP | Basis |
+|------|:-----:|:----:|-------|
+| [Claude Code](https://docs.claude.com/en/docs/claude-code) | ✅ | ✅ | Driven in day-to-day development; covered by the host-conformance tests |
+
+Registration for a host is in [Connect glass to your agent](../how-to/connect-an-agent.md).
+
+## Any other MCP host
+
+glass depends on nothing host-specific, so any host that meets the requirements above should work.
+A host is listed here only after it has been verified against the standard — an unverified list
+would not tell you anything you can rely on. If you drive glass from a host that is not yet listed,
+follow the recipe below and open an issue; we will add it.
+
+## Verify a new host
+
+To verify a host and get it added to the table:
+
+1. Register glass with the host over stdio or HTTP — see
+   [Connect glass to your agent](../how-to/connect-an-agent.md).
+2. Confirm the agent lists the glass tools (it can see, e.g., `glass_start` and `glass_screenshot`).
+3. Have the agent run a real loop: `glass_start` an app, `glass_screenshot` it (an image comes
+   back), then `glass_stop`.
+4. Open an issue noting the host and version, the transport(s) you used, and that the screenshot
+   image came back.
+
+For the tools themselves, see [Tools](tools.md). To have the agent drive glass well from its first
+turn, install the [glass-drive skill](../how-to/drive-glass-well.md).

--- a/docs/reference/host-compatibility.md
+++ b/docs/reference/host-compatibility.md
@@ -9,12 +9,14 @@ hosts have been verified end to end.
 A host can drive glass if it:
 
 - speaks MCP over **stdio** or **HTTP** (streamable) — glass serves both;
-- renders **image content blocks** — `glass_screenshot` and `glass_diff` return WebP images;
+- renders **image content blocks** — `glass_screenshot` always returns one, and tools like
+  `glass_diff` return one only when asked (`include_image: true`);
 - handles glass's tool set (~30 tools).
 
 These are exactly the capabilities the host-conformance tests exercise
 (`crates/glass-testapp/tests/host_conformance.rs`): on both transports they negotiate a protocol
-version, list the full tool set, and return a decodable screenshot image.
+version, list the tool set (compared for cross-transport parity), and return a decodable screenshot
+image.
 
 ## Verified hosts
 

--- a/scripts/test-x11.sh
+++ b/scripts/test-x11.sh
@@ -16,4 +16,8 @@
 # sandbox level explicitly in the AppSpec.
 set -euo pipefail
 cd "$(dirname "$0")/.."
+# host_conformance spawns the glass-mcp *binary* as a stdio child. `cargo test -p glass-testapp`
+# builds glass-mcp only as a library dependency, not its binary, so build the binary explicitly
+# — otherwise the test can't find it in a clean checkout (e.g. CI, which runs only this script).
+cargo build -p glass-mcp --bin glass-mcp
 exec cargo test -p glass-testapp --test integration --test network --test ignore_regions_e2e --test host_conformance -- --ignored --test-threads=1 "$@"

--- a/scripts/test-x11.sh
+++ b/scripts/test-x11.sh
@@ -16,4 +16,4 @@
 # sandbox level explicitly in the AppSpec.
 set -euo pipefail
 cd "$(dirname "$0")/.."
-exec cargo test -p glass-testapp --test integration --test network --test ignore_regions_e2e -- --ignored --test-threads=1 "$@"
+exec cargo test -p glass-testapp --test integration --test network --test ignore_regions_e2e --test host_conformance -- --ignored --test-threads=1 "$@"


### PR DESCRIPTION
Adds a **host-compatibility reference** and a **host-conformance test harness**, so a reader can see which MCP hosts glass is verified against and what glass needs from any host.

## What this adds

- **`docs/reference/host-compatibility.md`** — what glass needs from a host (standard MCP over stdio or HTTP, image content blocks, ~30 tools), a *verified hosts* table (currently Claude Code, stdio + HTTP), a capability-only statement for everything else, and a recipe for verifying and adding a new host. Linked from the docs index, the connect guide, the README, and the changelog.
- **`crates/glass-testapp/tests/host_conformance.rs`** (`#[ignore]`d, run under Xvfb via `scripts/test-x11.sh`) — proves glass's host-facing MCP surface on **both** transports the way a real host consumes it:
  - a spawned `glass-mcp` stdio child driven over raw newline-delimited JSON-RPC (representative of any host, not just rmcp), and an in-process HTTP server driven over the rmcp streamable-HTTP client;
  - each asserts `initialize` negotiates a protocol version, `tools/list` advertises the core loop tools, and `glass_screenshot` returns a decodable, non-blank image content block plus a surviving text block;
  - a third test asserts the tool set is identical across transports.
- **`scripts/test-x11.sh`** builds the `glass-mcp` binary (the stdio test spawns it) and runs the new test target.

No product/runtime code changes — tests, docs, and one test script only. No new dependencies.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, and `cargo test --workspace` all clean; the three `host_conformance` tests pass under Xvfb. The suite went through a 5-lens review (code / tests / silent-failure / comments-docs / type-design); findings fixed in the final commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)