### PR TITLE
docs: mark Antigravity as a verified host

### DIFF
--- a/docs/how-to/connect-an-agent.md
+++ b/docs/how-to/connect-an-agent.md
@@ -42,6 +42,10 @@ claude mcp add glass --scope user -- "$env:USERPROFILE\bin\glass-mcp.exe"
 }
 ```
 
+**Antigravity:** open **Settings → Customizations → Open MCP Config** to edit its `mcp_config.json`,
+add glass under `mcpServers` (the same shape as the generic config above), then reload the MCP
+servers (or restart Antigravity).
+
 No `env` block is needed: glass uses your host's default backend and, where the host supports it,
 gives each session its own isolated display with nothing to set up. Add an `env` block only to
 override a default — the specific variables are in [reference/environment.md](../reference/environment.md).

--- a/docs/reference/host-compatibility.md
+++ b/docs/reference/host-compatibility.md
@@ -26,6 +26,7 @@ loop — a tool call that returns text and one that returns an image — with th
 | Host | stdio | HTTP | Basis |
 |------|:-----:|:----:|-------|
 | [Claude Code](https://docs.claude.com/en/docs/claude-code) | ✅ | ✅ | Driven in day-to-day development; covered by the host-conformance tests |
+| Antigravity | ✅ | — | Driven end-to-end (v2.3.1): the agent listed the glass tools and a launch → screenshot → stop loop returned a screenshot |
 
 Registration for a host is in [Connect glass to your agent](../how-to/connect-an-agent.md).
 

--- a/docs/reference/host-compatibility.md
+++ b/docs/reference/host-compatibility.md
@@ -26,7 +26,7 @@ loop — a tool call that returns text and one that returns an image — with th
 | Host | stdio | HTTP | Basis |
 |------|:-----:|:----:|-------|
 | [Claude Code](https://docs.claude.com/en/docs/claude-code) | ✅ | ✅ | Driven in day-to-day development; covered by the host-conformance tests |
-| [Antigravity](https://antigravity.google) | ✅ | — | Driven end-to-end (v2.3.1): the agent listed the glass tools and a launch → screenshot → stop loop returned a screenshot |
+| [Antigravity](https://antigravity.google) | ✅ | ✅ | Driven end-to-end (v2.3.1) over both transports: the agent listed the glass tools and a launch → screenshot → stop loop returned a screenshot |
 
 Registration for a host is in [Connect glass to your agent](../how-to/connect-an-agent.md).
 

--- a/docs/reference/host-compatibility.md
+++ b/docs/reference/host-compatibility.md
@@ -26,7 +26,7 @@ loop — a tool call that returns text and one that returns an image — with th
 | Host | stdio | HTTP | Basis |
 |------|:-----:|:----:|-------|
 | [Claude Code](https://docs.claude.com/en/docs/claude-code) | ✅ | ✅ | Driven in day-to-day development; covered by the host-conformance tests |
-| Antigravity | ✅ | — | Driven end-to-end (v2.3.1): the agent listed the glass tools and a launch → screenshot → stop loop returned a screenshot |
+| [Antigravity](https://antigravity.google) | ✅ | — | Driven end-to-end (v2.3.1): the agent listed the glass tools and a launch → screenshot → stop loop returned a screenshot |
 
 Registration for a host is in [Connect glass to your agent](../how-to/connect-an-agent.md).
 


### PR DESCRIPTION
Adds **Antigravity** (v2.3.1) as a verified host, over **both transports**, plus its registration steps.

## Changes
- **`docs/reference/host-compatibility.md`** — new verified-host row: Antigravity, **stdio ✅ / HTTP ✅**, linked to [antigravity.google](https://antigravity.google).
- **`docs/how-to/connect-an-agent.md`** — Antigravity registration steps: **Settings → Customizations → Open MCP Config** to edit its `mcp_config.json`, then the standard `mcpServers` entry (the generic `command` form for stdio; the `type: http` / `url` form worked as-is for HTTP).

## Verification (against the doc's own standard)
Antigravity's agent connected to glass, listed the glass tools, and drove a real loop (launch an app → screenshot → stop) with the screenshot image returning across the wire — confirmed over **stdio** and over **HTTP** (`http://127.0.0.1:7300/`).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)