### PR TITLE
Software-render env defaults under containment (GTK4/Qt render, not black)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
         # bubblewrap: sandbox_* integration tests need unprivileged user namespaces.
         # Ubuntu 24.04 runners restrict them via AppArmor (bwrap then fails "setting up
         # uid map: Permission denied"), so re-enable them (no-op on images without the knob).
+        # python3-gi + gir1.2-gtk-4.0: the software_render integration test drives a real GTK4 app.
         run: |
           sudo apt-get update && sudo apt-get install -y xvfb bubblewrap python3-gi gir1.2-gtk-4.0
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
@@ -242,6 +243,7 @@ jobs:
         # xvfb + bubblewrap so the X11 integration suite (incl. sandbox_*) runs under coverage.
         # Ubuntu 24.04 runners restrict unprivileged user namespaces via AppArmor; re-enable
         # them for bubblewrap (no-op on images without the knob).
+        # python3-gi + gir1.2-gtk-4.0: the software_render integration test drives a real GTK4 app.
         run: |
           sudo apt-get update && sudo apt-get install -y xvfb bubblewrap python3-gi gir1.2-gtk-4.0
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         # Ubuntu 24.04 runners restrict them via AppArmor (bwrap then fails "setting up
         # uid map: Permission denied"), so re-enable them (no-op on images without the knob).
         run: |
-          sudo apt-get update && sudo apt-get install -y xvfb bubblewrap
+          sudo apt-get update && sudo apt-get install -y xvfb bubblewrap python3-gi gir1.2-gtk-4.0
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
       - run: ./scripts/test-x11.sh
 
@@ -243,7 +243,7 @@ jobs:
         # Ubuntu 24.04 runners restrict unprivileged user namespaces via AppArmor; re-enable
         # them for bubblewrap (no-op on images without the knob).
         run: |
-          sudo apt-get update && sudo apt-get install -y xvfb bubblewrap
+          sudo apt-get update && sudo apt-get install -y xvfb bubblewrap python3-gi gir1.2-gtk-4.0
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
       - name: Measure coverage (unit + X11; Wayland/AT-SPI self-skip)
         run: ./scripts/coverage.sh --lcov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ internal refactors, CI, or test-only changes.
 - **GTK4/Qt apps render under containment on the headless Linux display instead of black.** When
   glass launches an app in its sandbox on Linux, it now sets software-render env defaults
   (`GSK_RENDERER=cairo`, `QT_X11_NO_MITSHM=1`, `QT_QUICK_BACKEND=software`) so the GPU/shared-memory
-  rendering paths the sandbox blocks don't leave the window black. Pass the variable in
+  rendering paths the sandbox blocks don't leave the window black. Pass the relevant variable in
   `glass_start`'s `env` to override.
 
 ## [1.0.1] - 2026-07-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ internal refactors, CI, or test-only changes.
   bus's GSettings backend tried to persist it via a D-Bus service glass's isolated bus doesn't
   expose), so such apps stayed invisible to `glass_a11y_snapshot` and friends even though the
   bus itself was reachable — GTK/Qt apps, which don't gate on the advertisement, were unaffected.
+- **GTK4/Qt apps render under containment on the headless Linux display instead of black.** When
+  glass launches an app in its sandbox on Linux, it now sets software-render env defaults
+  (`GSK_RENDERER=cairo`, `QT_X11_NO_MITSHM=1`, `QT_QUICK_BACKEND=software`) so the GPU/shared-memory
+  rendering paths the sandbox blocks don't leave the window black. Pass the variable in
+  `glass_start`'s `env` to override.
 
 ## [1.0.1] - 2026-07-21
 

--- a/crates/glass-sandbox-linux/src/lib.rs
+++ b/crates/glass-sandbox-linux/src/lib.rs
@@ -14,12 +14,14 @@ use std::process::Command;
 use glass_core::{AppSpec, Check, CheckStatus, GlassError, Result, SandboxLevel};
 use glass_sandbox_core::{abs_token, canon, dir_of, resolve_on_path};
 
-/// App-level environment that forces GPU/MIT-SHM-dependent GUI toolkits onto a software,
-/// non-shared-memory present path. glass's containment breaks accelerated rendering on the
-/// headless display: `wrap_argv` passes `--unshare-ipc` (so X11 MIT-SHM cannot attach to the
-/// out-of-sandbox X server) and `--dev /dev` (no `/dev/dri`, so DRI3/GPU access fails). Under
-/// that, GTK4's GL renderer paints a black window. These vars select the CPU path instead; each
-/// is a no-op for a toolkit that does not read it.
+/// App-level environment that makes GUI toolkits present frames without X11 MIT-SHM. glass's
+/// containment breaks shared-memory rendering on the headless display: `wrap_argv` passes
+/// `--unshare-ipc`, which isolates the SysV IPC namespace so MIT-SHM can't attach to the
+/// out-of-sandbox X server. That is the operative cause — GTK4's GL renderer, and even the Mesa
+/// software (llvmpipe) path it falls back to once `--dev /dev` also withholds `/dev/dri`, both need
+/// MIT-SHM to present, so the window stays black. These vars pick a renderer that presents via
+/// plain X instead (GTK4's cairo renderer; Qt's non-SHM / software paths); each is a no-op for a
+/// toolkit that does not read it.
 pub const SOFTWARE_RENDER_ENV: &[(&str, &str)] = &[
     ("GSK_RENDERER", "cairo"),        // GTK4
     ("QT_X11_NO_MITSHM", "1"),        // Qt (X11 widgets)
@@ -1064,5 +1066,26 @@ mod tests {
             got,
             vec![("QT_X11_NO_MITSHM", "1"), ("QT_QUICK_BACKEND", "software")]
         );
+    }
+
+    #[test]
+    fn multiple_user_overrides_are_all_excluded() {
+        let got = software_render_env(&spec_with(
+            SandboxLevel::Default,
+            vec![
+                ("GSK_RENDERER".into(), "gl".into()),
+                ("QT_QUICK_BACKEND".into(), "hardware".into()),
+            ],
+        ));
+        assert_eq!(got, vec![("QT_X11_NO_MITSHM", "1")]);
+    }
+
+    #[test]
+    fn unrelated_user_env_key_filters_nothing() {
+        let got = software_render_env(&spec_with(
+            SandboxLevel::Default,
+            vec![("FOO".into(), "bar".into())],
+        ));
+        assert_eq!(got, SOFTWARE_RENDER_ENV.to_vec());
     }
 }

--- a/crates/glass-sandbox-linux/src/lib.rs
+++ b/crates/glass-sandbox-linux/src/lib.rs
@@ -14,6 +14,32 @@ use std::process::Command;
 use glass_core::{AppSpec, Check, CheckStatus, GlassError, Result, SandboxLevel};
 use glass_sandbox_core::{abs_token, canon, dir_of, resolve_on_path};
 
+/// App-level environment that forces GPU/MIT-SHM-dependent GUI toolkits onto a software,
+/// non-shared-memory present path. glass's containment breaks accelerated rendering on the
+/// headless display: `wrap_argv` passes `--unshare-ipc` (so X11 MIT-SHM cannot attach to the
+/// out-of-sandbox X server) and `--dev /dev` (no `/dev/dri`, so DRI3/GPU access fails). Under
+/// that, GTK4's GL renderer paints a black window. These vars select the CPU path instead; each
+/// is a no-op for a toolkit that does not read it.
+pub const SOFTWARE_RENDER_ENV: &[(&str, &str)] = &[
+    ("GSK_RENDERER", "cairo"),        // GTK4
+    ("QT_X11_NO_MITSHM", "1"),        // Qt (X11 widgets)
+    ("QT_QUICK_BACKEND", "software"), // Qt Quick / QML
+];
+
+/// The [`SOFTWARE_RENDER_ENV`] defaults to inject for a launch: the full set for a contained
+/// launch, minus any key the user already set in `spec.env` (an explicit override always wins);
+/// empty for `sandbox: off` (the app keeps full GPU/SHM access and may legitimately want GL).
+pub fn software_render_env(spec: &AppSpec) -> Vec<(&'static str, &'static str)> {
+    if spec.sandbox == SandboxLevel::Off {
+        return Vec::new();
+    }
+    SOFTWARE_RENDER_ENV
+        .iter()
+        .copied()
+        .filter(|(k, _)| !spec.env.iter().any(|(user_key, _)| user_key.as_str() == *k))
+        .collect()
+}
+
 /// The bubblewrap binary glass invokes: `$GLASS_BWRAP`, else `bwrap` (on `PATH`).
 fn bwrap_bin() -> String {
     glass_core::tool_path("GLASS_BWRAP", "bwrap")
@@ -993,6 +1019,50 @@ mod tests {
         assert!(
             run_build(&make_spec(Some("false"), SandboxLevel::Default)).is_err(),
             "failing build → Err"
+        );
+    }
+
+    fn spec_with(sandbox: SandboxLevel, env: Vec<(String, String)>) -> AppSpec {
+        AppSpec {
+            build: None,
+            run: vec!["app".into()],
+            cwd: None,
+            env,
+            window_hint: None,
+            timeout_ms: 1000,
+            sandbox,
+            a11y: false,
+        }
+    }
+
+    #[test]
+    fn software_render_env_is_empty_when_sandbox_off() {
+        assert!(software_render_env(&spec_with(SandboxLevel::Off, vec![])).is_empty());
+    }
+
+    #[test]
+    fn software_render_env_injects_all_defaults_when_contained() {
+        assert_eq!(
+            software_render_env(&spec_with(SandboxLevel::Default, vec![])),
+            SOFTWARE_RENDER_ENV.to_vec()
+        );
+        // Strict is also a contained level.
+        assert_eq!(
+            software_render_env(&spec_with(SandboxLevel::Strict, vec![])),
+            SOFTWARE_RENDER_ENV.to_vec()
+        );
+    }
+
+    #[test]
+    fn user_env_overrides_the_matching_default() {
+        let got = software_render_env(&spec_with(
+            SandboxLevel::Default,
+            vec![("GSK_RENDERER".into(), "gl".into())],
+        ));
+        // GSK_RENDERER omitted (user set it); the Qt defaults remain.
+        assert_eq!(
+            got,
+            vec![("QT_X11_NO_MITSHM", "1"), ("QT_QUICK_BACKEND", "software")]
         );
     }
 }

--- a/crates/glass-testapp/tests/software_render.rs
+++ b/crates/glass-testapp/tests/software_render.rs
@@ -1,0 +1,104 @@
+//! GTK4/GPU-toolkit apps render (not black) under containment on the headless X11 display —
+//! proof that glass injects software-render env defaults for sandboxed launches. `#[ignore]d`
+//! (needs Xvfb + python3-gi/GTK 4); run via `./scripts/test-x11.sh`.
+
+mod common;
+
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use common::Xvfb;
+use glass_core::{AppSpec, Platform, SandboxLevel};
+use glass_x11::X11Platform;
+
+const TASKS_DEMO: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../examples/tasks_demo.py");
+
+/// True if this host can run the GTK4 demo (python3 + PyGObject + the GTK 4 typelib).
+fn gtk4_available() -> bool {
+    Command::new("python3")
+        .args([
+            "-c",
+            "import gi; gi.require_version('Gtk','4.0'); from gi.repository import Gtk",
+        ])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn demo_spec(env: Vec<(String, String)>) -> AppSpec {
+    AppSpec {
+        build: None,
+        run: vec!["python3".into(), TASKS_DEMO.into()],
+        cwd: None,
+        env,
+        window_hint: None,
+        timeout_ms: 15_000,
+        sandbox: SandboxLevel::Default,
+        a11y: false,
+    }
+}
+
+/// All pixels identical → a uniform (e.g. all-black) frame.
+fn is_uniform(frame: &glass_core::Frame) -> bool {
+    let Some(first) = frame.pixels.get(0..4) else {
+        return true;
+    };
+    frame.pixels.chunks_exact(4).all(|px| px == first)
+}
+
+/// Poll the window until it paints something (a non-uniform frame) or the deadline passes.
+fn rendered_within(p: &mut X11Platform, deadline: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < deadline {
+        if let Ok(frame) = p.capture_frame(None) {
+            if !is_uniform(&frame) {
+                return true;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    false
+}
+
+#[test]
+#[ignore = "requires Xvfb + python3-gi/GTK 4; run via ./scripts/test-x11.sh"]
+fn gtk4_app_renders_under_default_sandbox() {
+    if !gtk4_available() {
+        eprintln!("skipping: python3-gi / GTK 4 not available (install python3-gi gir1.2-gtk-4.0)");
+        return;
+    }
+    let xvfb = Xvfb::start();
+    let mut p = X11Platform::connect(Some(&xvfb.display)).unwrap();
+    p.start_app(&demo_spec(vec![]))
+        .unwrap_or_else(|e| panic!("start_app failed: {e}"));
+    // With the injected GSK_RENDERER=cairo default, GTK4 renders on the headless display.
+    let rendered = rendered_within(&mut p, Duration::from_secs(8));
+    p.stop_app().ok();
+    assert!(
+        rendered,
+        "GTK4 app stayed blank under default containment — software-render default not applied"
+    );
+}
+
+#[test]
+#[ignore = "requires Xvfb + python3-gi/GTK 4; run via ./scripts/test-x11.sh"]
+fn gtk4_gl_renderer_stays_black_under_sandbox() {
+    if !gtk4_available() {
+        eprintln!("skipping: python3-gi / GTK 4 not available (install python3-gi gir1.2-gtk-4.0)");
+        return;
+    }
+    let xvfb = Xvfb::start();
+    let mut p = X11Platform::connect(Some(&xvfb.display)).unwrap();
+    // Force the GL renderer, overriding the injected cairo default. This both reproduces the
+    // failure the fix exists for (GL can't attach MIT-SHM or reach a GPU under containment) and
+    // proves an explicit spec.env entry overrides the default.
+    p.start_app(&demo_spec(vec![("GSK_RENDERER".into(), "gl".into())]))
+        .unwrap_or_else(|e| panic!("start_app failed: {e}"));
+    let rendered = rendered_within(&mut p, Duration::from_secs(6));
+    p.stop_app().ok();
+    assert!(
+        !rendered,
+        "GTK4 GL renderer unexpectedly rendered under containment — the fixture no longer \
+         reproduces the black-frame failure the fix guards against; revisit the fix's necessity"
+    );
+}

--- a/crates/glass-testapp/tests/software_render.rs
+++ b/crates/glass-testapp/tests/software_render.rs
@@ -8,21 +8,28 @@ use std::process::Command;
 use std::time::{Duration, Instant};
 
 use common::Xvfb;
-use glass_core::{AppSpec, Platform, SandboxLevel};
+use glass_core::{AppSpec, Platform, SandboxLevel, Stream};
 use glass_x11::X11Platform;
 
 const TASKS_DEMO: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../examples/tasks_demo.py");
 
-/// True if this host can run the GTK4 demo (python3 + PyGObject + the GTK 4 typelib).
-fn gtk4_available() -> bool {
-    Command::new("python3")
+/// Fail loudly if this host can't run the GTK4 demo (python3 + PyGObject + the GTK 4 typelib).
+/// A hard requirement, not a silent skip: CI installs the packages, and a green pass here must
+/// mean the rendering was actually verified. The dep-free wiring is covered by the backend unit
+/// tests in `glass-x11`/`glass-wayland`.
+fn require_gtk4() {
+    let ok = Command::new("python3")
         .args([
             "-c",
             "import gi; gi.require_version('Gtk','4.0'); from gi.repository import Gtk",
         ])
         .status()
         .map(|s| s.success())
-        .unwrap_or(false)
+        .unwrap_or(false);
+    assert!(
+        ok,
+        "python3-gi / GTK 4 not available — install: sudo apt-get install python3-gi gir1.2-gtk-4.0"
+    );
 }
 
 fn demo_spec(env: Vec<(String, String)>) -> AppSpec {
@@ -46,59 +53,96 @@ fn is_uniform(frame: &glass_core::Frame) -> bool {
     frame.pixels.chunks_exact(4).all(|px| px == first)
 }
 
-/// Poll the window until it paints something (a non-uniform frame) or the deadline passes.
-fn rendered_within(p: &mut X11Platform, deadline: Duration) -> bool {
+enum RenderOutcome {
+    /// Painted a non-uniform frame.
+    Rendered,
+    /// Captured throughout, but every frame stayed uniform (e.g. all black).
+    Blank,
+    /// Capture never succeeded — the window/process likely died mid-poll.
+    NoCapture,
+}
+
+/// Poll the window until it paints something (non-uniform) or the deadline passes. Distinguishes a
+/// genuinely-blank window from one that stopped being capturable (a crash) — a swallowed capture
+/// error must not read as "stayed blank".
+fn poll_render(p: &mut X11Platform, deadline: Duration) -> RenderOutcome {
     let start = Instant::now();
+    let mut captured_any = false;
     while start.elapsed() < deadline {
-        if let Ok(frame) = p.capture_frame(None) {
-            if !is_uniform(&frame) {
-                return true;
+        match p.capture_frame(None) {
+            Ok(frame) => {
+                captured_any = true;
+                if !is_uniform(&frame) {
+                    return RenderOutcome::Rendered;
+                }
             }
+            Err(e) => eprintln!("capture_frame error while polling for render: {e}"),
         }
         std::thread::sleep(Duration::from_millis(200));
     }
-    false
+    if captured_any {
+        RenderOutcome::Blank
+    } else {
+        RenderOutcome::NoCapture
+    }
+}
+
+fn fmt_logs(logs: &[(Stream, String)]) -> String {
+    if logs.is_empty() {
+        return "(no app output captured)".into();
+    }
+    logs.iter()
+        .map(|(s, line)| format!("[{s:?}] {line}"))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 #[test]
 #[ignore = "requires Xvfb + python3-gi/GTK 4; run via ./scripts/test-x11.sh"]
 fn gtk4_app_renders_under_default_sandbox() {
-    if !gtk4_available() {
-        eprintln!("skipping: python3-gi / GTK 4 not available (install python3-gi gir1.2-gtk-4.0)");
-        return;
-    }
+    require_gtk4();
     let xvfb = Xvfb::start();
     let mut p = X11Platform::connect(Some(&xvfb.display)).unwrap();
     p.start_app(&demo_spec(vec![]))
         .unwrap_or_else(|e| panic!("start_app failed: {e}"));
-    // With the injected GSK_RENDERER=cairo default, GTK4 renders on the headless display.
-    let rendered = rendered_within(&mut p, Duration::from_secs(8));
+    // With the injected GSK_RENDERER=cairo default, GTK4 presents via plain X and renders.
+    let outcome = poll_render(&mut p, Duration::from_secs(15));
+    let logs = p.drain_logs();
     p.stop_app().ok();
     assert!(
-        rendered,
-        "GTK4 app stayed blank under default containment — software-render default not applied"
+        matches!(outcome, RenderOutcome::Rendered),
+        "GTK4 app did not render under default containment — the software-render default was not \
+         applied, or the app failed to start. App output:\n{}",
+        fmt_logs(&logs)
     );
 }
 
 #[test]
 #[ignore = "requires Xvfb + python3-gi/GTK 4; run via ./scripts/test-x11.sh"]
 fn gtk4_gl_renderer_stays_black_under_sandbox() {
-    if !gtk4_available() {
-        eprintln!("skipping: python3-gi / GTK 4 not available (install python3-gi gir1.2-gtk-4.0)");
-        return;
-    }
+    require_gtk4();
     let xvfb = Xvfb::start();
     let mut p = X11Platform::connect(Some(&xvfb.display)).unwrap();
-    // Force the GL renderer, overriding the injected cairo default. This both reproduces the
-    // failure the fix exists for (GL can't attach MIT-SHM or reach a GPU under containment) and
-    // proves an explicit spec.env entry overrides the default.
+    // Force the GL renderer, overriding the injected cairo default. Under containment X11 MIT-SHM
+    // can't attach (bwrap's --unshare-ipc), so the GL path can't present a frame — reproducing the
+    // black window the fix targets, and proving an explicit spec.env entry overrides the default.
     p.start_app(&demo_spec(vec![("GSK_RENDERER".into(), "gl".into())]))
         .unwrap_or_else(|e| panic!("start_app failed: {e}"));
-    let rendered = rendered_within(&mut p, Duration::from_secs(6));
+    let outcome = poll_render(&mut p, Duration::from_secs(6));
+    let logs = p.drain_logs();
     p.stop_app().ok();
-    assert!(
-        !rendered,
-        "GTK4 GL renderer unexpectedly rendered under containment — the fixture no longer \
-         reproduces the black-frame failure the fix guards against; revisit the fix's necessity"
-    );
+    match outcome {
+        RenderOutcome::Blank => {} // Expected: window is alive but stays black.
+        RenderOutcome::Rendered => panic!(
+            "GTK4 GL renderer unexpectedly rendered under containment — the fixture no longer \
+             reproduces the black-frame failure the fix guards against; revisit the fix's \
+             necessity. App output:\n{}",
+            fmt_logs(&logs)
+        ),
+        RenderOutcome::NoCapture => panic!(
+            "capture never succeeded — the GL-forced app likely crashed instead of rendering \
+             black, so this test can't confirm the black-frame behavior. App output:\n{}",
+            fmt_logs(&logs)
+        ),
+    }
 }

--- a/crates/glass-wayland/src/command.rs
+++ b/crates/glass-wayland/src/command.rs
@@ -154,9 +154,12 @@ pub fn build_sway_command(
         // exec's bwrap inherits it too (no --clearenv). spec.env below still overrides.
         cmd.env("DBUS_SESSION_BUS_ADDRESS", addr);
     }
-    // Under containment, force GPU/MIT-SHM-dependent toolkits (GTK4, Qt) onto a software present
-    // path (sway itself already gets WLR_RENDERER_ALLOW_SOFTWARE above). Applied before spec.env
-    // so an explicit override still wins.
+    // Apply the same software-render defaults as X11, for consistency and as a safe default under
+    // the headless compositor (which already software-renders via WLR_RENDERER_ALLOW_SOFTWARE
+    // above). A native-Wayland client presents via wl_shm/memfd rather than X11 MIT-SHM, so the
+    // X11 black-frame cause may not apply here — these are harmless when unneeded and still cover an
+    // app routed through Xwayland. Set on sway's env, forwarded to the exec'd app like the DBUS
+    // address above; applied before spec.env so an explicit override still wins.
     for (k, v) in glass_sandbox_linux::software_render_env(spec) {
         cmd.env(k, v);
     }
@@ -313,6 +316,57 @@ mod tests {
         assert_eq!(
             dbus.as_deref(),
             Some("unix:path=/tmp/glass-a11y/session-bus")
+        );
+    }
+
+    /// Effective value of `key` in the built command.
+    fn env_of(cmd: &Command, key: &str) -> Option<String> {
+        cmd.get_envs()
+            .find(|(k, _)| *k == std::ffi::OsStr::new(key))
+            .and_then(|(_, v)| v)
+            .map(|v| v.to_string_lossy().into_owned())
+    }
+
+    fn sway_cmd(s: &AppSpec) -> Command {
+        build_sway_command(
+            std::path::Path::new("/usr/bin/sway"),
+            std::path::Path::new("/tmp/cfg"),
+            s,
+            std::path::Path::new("/run/glass-rt"),
+            None,
+        )
+    }
+
+    #[test]
+    fn build_sway_command_injects_software_render_defaults_under_sandbox() {
+        let mut s = spec(&["app"]);
+        s.sandbox = glass_core::SandboxLevel::Default;
+        let cmd = sway_cmd(&s);
+        assert_eq!(env_of(&cmd, "GSK_RENDERER").as_deref(), Some("cairo"));
+        assert_eq!(env_of(&cmd, "QT_X11_NO_MITSHM").as_deref(), Some("1"));
+        assert_eq!(
+            env_of(&cmd, "QT_QUICK_BACKEND").as_deref(),
+            Some("software")
+        );
+    }
+
+    #[test]
+    fn build_sway_command_omits_software_render_defaults_when_sandbox_off() {
+        let s = spec(&["app"]); // sandbox: Off
+        let cmd = sway_cmd(&s);
+        assert_eq!(env_of(&cmd, "GSK_RENDERER"), None);
+    }
+
+    #[test]
+    fn build_sway_command_lets_spec_env_override_software_render_default() {
+        let mut s = spec(&["app"]);
+        s.sandbox = glass_core::SandboxLevel::Default;
+        s.env = vec![("GSK_RENDERER".into(), "gl".into())];
+        let cmd = sway_cmd(&s);
+        assert_eq!(env_of(&cmd, "GSK_RENDERER").as_deref(), Some("gl"));
+        assert_eq!(
+            env_of(&cmd, "QT_QUICK_BACKEND").as_deref(),
+            Some("software")
         );
     }
 

--- a/crates/glass-wayland/src/command.rs
+++ b/crates/glass-wayland/src/command.rs
@@ -154,6 +154,12 @@ pub fn build_sway_command(
         // exec's bwrap inherits it too (no --clearenv). spec.env below still overrides.
         cmd.env("DBUS_SESSION_BUS_ADDRESS", addr);
     }
+    // Under containment, force GPU/MIT-SHM-dependent toolkits (GTK4, Qt) onto a software present
+    // path (sway itself already gets WLR_RENDERER_ALLOW_SOFTWARE above). Applied before spec.env
+    // so an explicit override still wins.
+    for (k, v) in glass_sandbox_linux::software_render_env(spec) {
+        cmd.env(k, v);
+    }
     for (k, v) in &spec.env {
         cmd.env(k, v);
     }

--- a/crates/glass-x11/src/command.rs
+++ b/crates/glass-x11/src/command.rs
@@ -94,10 +94,10 @@ pub fn build_command(spec: &AppSpec, display: &str, a11y: Option<glass_core::A11
         // path resolves inside bwrap too. Keeps a11y resolution isolated AND on a live bus.
         cmd.env("XDG_RUNTIME_DIR", dir);
     }
-    // Under containment, force GPU/MIT-SHM-dependent toolkits (GTK4, Qt) onto a software present
-    // path so they render on the headless display instead of black (see
-    // glass_sandbox_linux::software_render_env). Applied before spec.env so an explicit override
-    // still wins.
+    // Under containment, X11 MIT-SHM can't attach to glass's out-of-sandbox X server (bwrap's
+    // --unshare-ipc), so GTK4/Qt's default present paths paint black on the headless display; force
+    // a non-SHM renderer instead (see glass_sandbox_linux::software_render_env). Applied before
+    // spec.env so an explicit override still wins.
     for (k, v) in glass_sandbox_linux::software_render_env(spec) {
         cmd.env(k, v);
     }
@@ -199,6 +199,49 @@ mod tests {
             .last()
             .and_then(|(_, v)| v);
         assert_eq!(addr, Some(OsStr::new("unix:path=/tmp/override")));
+    }
+
+    /// Effective value of `key` in the built command (last `.env()` wins).
+    fn env_of<'a>(cmd: &'a std::process::Command, key: &str) -> Option<&'a OsStr> {
+        cmd.get_envs()
+            .filter(|(k, _)| *k == OsStr::new(key))
+            .last()
+            .and_then(|(_, v)| v)
+    }
+
+    #[test]
+    fn build_command_injects_software_render_defaults_under_sandbox() {
+        let mut s = spec(&["app"]);
+        s.sandbox = glass_core::SandboxLevel::Default;
+        let cmd = build_command(&s, ":99", None);
+        assert_eq!(env_of(&cmd, "GSK_RENDERER"), Some(OsStr::new("cairo")));
+        assert_eq!(env_of(&cmd, "QT_X11_NO_MITSHM"), Some(OsStr::new("1")));
+        assert_eq!(
+            env_of(&cmd, "QT_QUICK_BACKEND"),
+            Some(OsStr::new("software"))
+        );
+    }
+
+    #[test]
+    fn build_command_omits_software_render_defaults_when_sandbox_off() {
+        let s = spec(&["app"]); // sandbox: Off
+        let cmd = build_command(&s, ":99", None);
+        assert_eq!(env_of(&cmd, "GSK_RENDERER"), None);
+        assert_eq!(env_of(&cmd, "QT_X11_NO_MITSHM"), None);
+    }
+
+    #[test]
+    fn build_command_lets_spec_env_override_software_render_default() {
+        let mut s = spec(&["app"]);
+        s.sandbox = glass_core::SandboxLevel::Default;
+        s.env = vec![("GSK_RENDERER".into(), "gl".into())];
+        let cmd = build_command(&s, ":99", None);
+        assert_eq!(env_of(&cmd, "GSK_RENDERER"), Some(OsStr::new("gl")));
+        // The other defaults are still injected.
+        assert_eq!(
+            env_of(&cmd, "QT_QUICK_BACKEND"),
+            Some(OsStr::new("software"))
+        );
     }
 
     #[test]

--- a/crates/glass-x11/src/command.rs
+++ b/crates/glass-x11/src/command.rs
@@ -94,6 +94,13 @@ pub fn build_command(spec: &AppSpec, display: &str, a11y: Option<glass_core::A11
         // path resolves inside bwrap too. Keeps a11y resolution isolated AND on a live bus.
         cmd.env("XDG_RUNTIME_DIR", dir);
     }
+    // Under containment, force GPU/MIT-SHM-dependent toolkits (GTK4, Qt) onto a software present
+    // path so they render on the headless display instead of black (see
+    // glass_sandbox_linux::software_render_env). Applied before spec.env so an explicit override
+    // still wins.
+    for (k, v) in glass_sandbox_linux::software_render_env(spec) {
+        cmd.env(k, v);
+    }
     // Applied last so an explicit spec.env entry wins over the forced defaults.
     for (k, v) in &spec.env {
         cmd.env(k, v);

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -52,9 +52,12 @@ don't leave the window black:
 | `QT_X11_NO_MITSHM` | `1` | Qt (X11 widgets) |
 | `QT_QUICK_BACKEND` | `software` | Qt Quick / QML |
 
-The sandbox isolates the SysV IPC namespace (so X11 MIT-SHM can't attach to glass's X server) and
-exposes no GPU device, so an accelerated renderer would paint a black window. These defaults select
-the CPU path instead; each is ignored by toolkits that don't read it.
+The sandbox isolates the SysV IPC namespace, so X11 MIT-SHM can't attach to glass's X server — and
+GTK4's GL renderer, even the software fallback it lands on without a GPU, needs MIT-SHM to present,
+so an unset default leaves the window black. These defaults select a renderer that presents without
+MIT-SHM; each is ignored by toolkits that don't read it. Unlike the `GLASS_*` variables elsewhere in
+this file, glass *sets* these for the launched app rather than reading them, so they don't appear in
+`glass-mcp env`.
 
 To override one — for example to force a GPU renderer against a display that has one — pass the
 variable explicitly in `glass_start`'s `env`; an explicit value always wins. `sandbox: off` launches

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -40,6 +40,26 @@ standard `ANDROID_SDK_ROOT` / `ANDROID_HOME` (see the Android group below).
 `default` and `strict` are fail-closed; the levels and per-OS mechanisms are explained in
 [explanation/containment.md](../explanation/containment.md).
 
+## Rendering under containment (Linux)
+
+When glass launches an app **under containment** (`sandbox` is not `off`) on Linux, it sets
+software-render environment defaults so GPU / shared-memory rendering paths the sandbox blocks
+don't leave the window black:
+
+| Variable | Value | Toolkit |
+|---|---|---|
+| `GSK_RENDERER` | `cairo` | GTK4 |
+| `QT_X11_NO_MITSHM` | `1` | Qt (X11 widgets) |
+| `QT_QUICK_BACKEND` | `software` | Qt Quick / QML |
+
+The sandbox isolates the SysV IPC namespace (so X11 MIT-SHM can't attach to glass's X server) and
+exposes no GPU device, so an accelerated renderer would paint a black window. These defaults select
+the CPU path instead; each is ignored by toolkits that don't read it.
+
+To override one — for example to force a GPU renderer against a display that has one — pass the
+variable explicitly in `glass_start`'s `env`; an explicit value always wins. `sandbox: off` launches
+receive none of these defaults.
+
 ## Build & input
 
 | Variable | Purpose | Default | Scope |

--- a/scripts/test-x11.sh
+++ b/scripts/test-x11.sh
@@ -20,4 +20,4 @@ cd "$(dirname "$0")/.."
 # builds glass-mcp only as a library dependency, not its binary, so build the binary explicitly
 # — otherwise the test can't find it in a clean checkout (e.g. CI, which runs only this script).
 cargo build -p glass-mcp --bin glass-mcp
-exec cargo test -p glass-testapp --test integration --test network --test ignore_regions_e2e --test host_conformance -- --ignored --test-threads=1 "$@"
+exec cargo test -p glass-testapp --test integration --test network --test ignore_regions_e2e --test host_conformance --test software_render -- --ignored --test-threads=1 "$@"

--- a/scripts/test-x11.sh
+++ b/scripts/test-x11.sh
@@ -14,6 +14,11 @@
 # The GLASS_SANDBOX env var controls containment for glass-mcp-launched apps generally
 # (off / default / strict); it has no effect on integration tests, which set their
 # sandbox level explicitly in the AppSpec.
+#
+# NOTE: the software_render tests (gtk4_app_renders_under_default_sandbox,
+# gtk4_gl_renderer_stays_black_under_sandbox) require 'python3-gi' + 'gir1.2-gtk-4.0'
+# (they drive a real GTK4 app) and fail loudly if absent — install them, or run a subset
+# with a filter (e.g. ./scripts/test-x11.sh network_screenshot_over_http) to skip them.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 # host_conformance spawns the glass-mcp *binary* as a stdio child. `cargo test -p glass-testapp`


### PR DESCRIPTION
When glass launches an app **under containment** (`sandbox != off`) on Linux, GPU/shared-memory-dependent GUI toolkits (GTK4, Qt) rendered a **black window** on the headless display — including `examples/tasks_demo.py`, the README quickstart app. This fixes that without weakening containment.

## Root cause
The bwrap sandbox passes `--unshare-ipc`, which isolates the SysV IPC namespace so X11 **MIT-SHM** can't attach to glass's out-of-sandbox X server. GTK4's GL renderer — and even the Mesa software (llvmpipe) path it falls back to once `--dev /dev` also withholds `/dev/dri` — both need MIT-SHM to present, so the window stays black.

## Fix (env-only, containment untouched)
For sandboxed Linux launches, glass injects software-render env defaults that select a present path needing no MIT-SHM/GPU:
- `GSK_RENDERER=cairo` (GTK4), `QT_X11_NO_MITSHM=1` (Qt widgets), `QT_QUICK_BACKEND=software` (Qt Quick).

Applied only when `sandbox != off`, and only for keys the user didn't set in `glass_start`'s `env` (an explicit override always wins). No sandbox/bwrap change — no new binds, no `/dev/dri`, no relaxed namespaces.

## Where
A shared constant + `software_render_env(spec)` in `glass-sandbox-linux`; both Linux backends' `command.rs` apply it before their `spec.env` loop.

## Tests
- Unit (always-on): `software_render_env` off/contained/override cases, plus **Command-level** `get_envs()` tests on both backends (present when sandboxed, absent when off, overridden by `spec.env`).
- Integration (`#[ignore]`d, X11, `python3-gi` CI dep): a real GTK4 app renders under the default sandbox; forcing `GSK_RENDERER=gl` reproduces the black frame and proves the override. The poll distinguishes a genuinely-black window from a crashed process and prints app logs on failure.

Docs: `reference/environment.md` + CHANGELOG. Went through the 5-lens review; findings folded into the final commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)