### PR TITLE
docs: mark Codex CLI as a verified host (stdio + HTTP)

### DIFF
--- a/docs/how-to/connect-an-agent.md
+++ b/docs/how-to/connect-an-agent.md
@@ -46,6 +46,9 @@ claude mcp add glass --scope user -- "$env:USERPROFILE\bin\glass-mcp.exe"
 add glass under `mcpServers` (the same shape as the generic config above), then reload the MCP
 servers (or restart Antigravity).
 
+**Codex CLI:** `codex mcp add glass -- /absolute/path/to/glass-mcp` — or add a `[mcp_servers.glass]`
+table with `command` / `args` to `~/.codex/config.toml`.
+
 No `env` block is needed: glass uses your host's default backend and, where the host supports it,
 gives each session its own isolated display with nothing to set up. Add an `env` block only to
 override a default — the specific variables are in [reference/environment.md](../reference/environment.md).
@@ -69,6 +72,8 @@ claude mcp add --transport http glass http://127.0.0.1:7300/
   }
 }
 ```
+
+**Codex CLI:** `codex mcp add glass --url http://127.0.0.1:7300/`.
 
 A loopback endpoint (`127.0.0.1`) needs no token. To reach glass from another machine, or to bind a
 non-loopback address, follow [run-over-the-network.md](run-over-the-network.md) for the token and

--- a/docs/reference/host-compatibility.md
+++ b/docs/reference/host-compatibility.md
@@ -27,6 +27,7 @@ loop — a tool call that returns text and one that returns an image — with th
 |------|:-----:|:----:|-------|
 | [Claude Code](https://docs.claude.com/en/docs/claude-code) | ✅ | ✅ | Driven in day-to-day development; covered by the host-conformance tests |
 | [Antigravity](https://antigravity.google) | ✅ | ✅ | Driven end-to-end (v2.3.1) over both transports: the agent listed the glass tools and a launch → screenshot → stop loop returned a screenshot |
+| [Codex CLI](https://github.com/openai/codex) | ✅ | ✅ | Driven end-to-end (codex-cli 0.145.0) over both transports: the agent called `glass_start` → `glass_screenshot` → `glass_stop` and the screenshot returned an image |
 
 Registration for a host is in [Connect glass to your agent](../how-to/connect-an-agent.md).
 


### PR DESCRIPTION
Adds **Codex CLI** (codex-cli 0.145.0) to the verified-hosts table over **both transports** (stdio + HTTP), plus its registration steps (`codex mcp add` / `~/.codex/config.toml`). Verified end-to-end: the agent drove glass_start → glass_screenshot → glass_stop with an image returned, over each transport. Docs-only.