### PR TITLE
fix: clamp glass_a11y_marks boxes to the window (#185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ internal refactors, CI, or test-only changes.
   (`GSK_RENDERER=cairo`, `QT_X11_NO_MITSHM=1`, `QT_QUICK_BACKEND=software`) so the GPU/shared-memory
   rendering paths the sandbox blocks don't leave the window black. Pass the relevant variable in
   `glass_start`'s `env` to override.
+- **`glass_a11y_marks` boxes stay inside the window.** An element whose accessibility extent
+  reaches past the window edge (toolkit a11y geometry can over-report by ~10–20px) had its outline
+  drawn off-frame, where it was clipped at the capture edge and read as a rendering glitch. Each
+  mark box is now clamped to the window bounds, so an overrunning edge lands on the frame edge. The
+  `#id` and the `glass_click_element` target (the element center) are unchanged.
 
 ## [1.0.1] - 2026-07-21
 

--- a/crates/glass-core/src/marks.rs
+++ b/crates/glass-core/src/marks.rs
@@ -68,8 +68,19 @@ fn collect(node: &AxNode, frame: &mut Frame, legend: &mut Vec<Mark>) {
 }
 
 fn draw_mark(frame: &mut Frame, b: AxRect, id: u32) {
-    // 1. element outline
-    draw_rect_outline(frame, b.x, b.y, b.width as i32, b.height as i32, OUTLINE);
+    // 1. element outline, clamped to the frame. Toolkit a11y extents can overrun the
+    //    window (AT-SPI/GTK over-reports by ~10-20px), which would draw a border off
+    //    the frame edge where it gets clipped away and reads as a rendering bug. Clamp
+    //    the box to [0,0,width,height] so an overrunning edge lands *on* the frame edge.
+    let fw = frame.width as i32;
+    let fh = frame.height as i32;
+    let left = b.x.max(0);
+    let top = b.y.max(0);
+    let right = (b.x + b.width as i32).min(fw);
+    let bottom = (b.y + b.height as i32).min(fh);
+    if right > left && bottom > top {
+        draw_rect_outline(frame, left, top, right - left, bottom - top, OUTLINE);
+    }
 
     // 2. numbered chip, anchored OUTSIDE the element's top-left (up & left), then
     //    clamped into the frame so an edge-hugging element still shows its chip.
@@ -260,6 +271,46 @@ mod tests {
         let (out, legend) = render(&frame, &label_only);
         assert!(legend.is_empty());
         assert_eq!(out, frame);
+    }
+
+    /// A single interactable Button with the given bounds, ids assigned.
+    fn one_button(bounds: AxRect) -> AxTree {
+        let root = node(0, AxRole::Button, "b", Some(bounds));
+        let mut t = AxTree { root, count: 0 };
+        t.assign_ids();
+        t
+    }
+
+    #[test]
+    fn mark_box_right_edge_clamped_to_frame() {
+        // Button overruns the frame's right edge (x=90,w=30 in a 100-wide frame).
+        // Its right border must be redrawn at the last in-frame column (99), not
+        // clipped off past the edge. (99,50) is on the *vertical* right border only
+        // (not a top/bottom corner, clear of the chip), so it distinguishes a
+        // clamped box from the old clipped-away one.
+        let tree = one_button(AxRect {
+            x: 90,
+            y: 40,
+            width: 30,
+            height: 20,
+        });
+        let (out, _) = render(&Frame::solid(100, 100, [0, 0, 0, 255]), &tree);
+        assert_eq!(px(&out, 99, 50), OUTLINE);
+    }
+
+    #[test]
+    fn mark_box_bottom_edge_clamped_to_frame() {
+        // Button overruns the frame's bottom edge (y=90,h=30 in a 100-tall frame).
+        // Its bottom border must land on the last in-frame row (99); (50,99) is on
+        // the horizontal bottom border only, clear of the chip.
+        let tree = one_button(AxRect {
+            x: 40,
+            y: 90,
+            width: 20,
+            height: 30,
+        });
+        let (out, _) = render(&Frame::solid(100, 100, [0, 0, 0, 255]), &tree);
+        assert_eq!(px(&out, 50, 99), OUTLINE);
     }
 
     #[test]


### PR DESCRIPTION
## What

`glass_a11y_marks` drew each element's outline directly from the accessibility tree's reported extents. When a toolkit over-reports an extent past the window edge (AT-SPI/GTK can drift ~10–20px), the box's right/bottom border was drawn off-frame, where `put_px` clipped it at the capture edge — leaving an *open-ended* rectangle that reads as a rendering glitch.

This intersects each mark box with `[0, 0, width, height]` before drawing, so an overrunning edge lands **on** the window edge and the box stays closed. The `#id` and the `glass_click_element` target (the element center) are unchanged. Scope is the marks rendering only; the underlying a11y-extent imprecision is upstream in the toolkit.

## Visual

Rendered from the fixed renderer, mirroring the issue geometry (360×420 window; an "Add" button whose a11y extent overruns to x=365):

- Box **#1** (in-bounds): normal closed rectangle.
- Box **#2** (overruns the right edge): right border now drawn at the window's right edge — a closed box — instead of being pushed off-frame and clipped away.

## Tests

Two unit tests in `glass-core::marks` cover a right-edge and a bottom-edge overrun, each asserting the clamped border is drawn at the last in-frame column/row (a mid-border pixel, clear of the numbered chip, so it distinguishes a clamped box from the old clipped-away one). Both fail before the change and pass after. Existing marks tests (including the fully-off-frame case) stay green.

Closes #185.