### PR TITLE
feat: error-guidance audit — failures name the recovery action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ internal refactors, CI, or test-only changes.
   `glass_set_value`, text-only, no image tokens) as the default way to see and drive the UI, with
   screenshots and pixel coordinates as the fallback for canvas/black-box apps — so an agent reaches
   for the cheap path first. No tool behavior changed.
+- **Error messages point to the recovery action.** Three common failures now name what to do next
+  instead of dead-ending: "no active session" tells you to `glass_start`; the accessibility-
+  unsupported error points to the pixel loop (`glass_screenshot` + `glass_click`); and an element
+  with no clickable geometry suggests `glass_scroll_to_element` to bring it into view (or locating it
+  by screenshot). The remaining failure paths already carried a next step.
 
 ### Fixed
 - **Linux `a11y:true` now reaches AccessKit-based apps (egui/winit and other Rust GUI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ internal refactors, CI, or test-only changes.
   unsupported error points to the pixel loop (`glass_screenshot` + `glass_click`); and an element
   with no clickable geometry suggests `glass_scroll_to_element` to bring it into view (or locating it
   by screenshot). The remaining failure paths already carried a next step.
+- **`glass_a11y_snapshot` says what to do when the app exposes no elements.** When a snapshot comes
+  back with only the window root (no addressable elements) — common for an app that doesn't publish an
+  accessibility tree — the result now appends a hint to drive the app by pixels (`glass_screenshot` +
+  `glass_click`), instead of returning a bare root-only outline. Previously only the Linux "no a11y
+  bus" path guided the agent; this covers the thin-tree outcome on every backend.
 
 ### Fixed
 - **Linux `a11y:true` now reaches AccessKit-based apps (egui/winit and other Rust GUI

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -335,6 +335,20 @@ impl AxTree {
         walk(&self.root, 0, &mut out);
         out
     }
+
+    /// Guidance to surface when a snapshot exposes nothing to address — only the window
+    /// root, with no child elements. That means the app isn't publishing a usable
+    /// accessibility tree, which (outside the Linux no-bus path, which errors before a
+    /// tree is ever built) otherwise returns a bare root-only outline with no next step.
+    /// Backend-agnostic: the same thin-tree outcome on Windows/macOS/Android now steers
+    /// the agent to the pixel loop the way the Linux reader's no-tree error already does.
+    pub fn empty_guidance(&self) -> Option<&'static str> {
+        self.root.children.is_empty().then_some(
+            "no accessibility elements exposed — the app may not publish an a11y tree \
+             (some toolkits need it enabled, e.g. relaunch with a11y:true; canvas/game apps \
+             never will). Drive it by pixels instead: glass_screenshot, then glass_click at x,y.",
+        )
+    }
 }
 
 /// Context the display backend supplies so the a11y reader can locate the right
@@ -886,6 +900,24 @@ mod tests {
             bounds: None,
             children: vec![],
         }
+    }
+
+    #[test]
+    fn empty_guidance_flags_a_treeless_snapshot() {
+        // Only the window root, no children → nothing to address → steer to pixels.
+        let empty = AxTree {
+            root: leaf(AxRole::Window, "App"),
+            count: 0,
+        };
+        let hint = empty
+            .empty_guidance()
+            .expect("a root-only tree must yield guidance");
+        assert!(
+            hint.contains("glass_screenshot"),
+            "guidance names the pixel path: {hint}"
+        );
+        // A tree with real elements has something to address — no hint.
+        assert!(sample_tree().empty_guidance().is_none());
     }
 
     fn sample_tree() -> AxTree {

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 /// agent. Backend crates fold their OS-specific failures into `Backend`.
 #[derive(Debug, Error)]
 pub enum GlassError {
-    #[error("no active session")]
+    #[error("no active session — call glass_start to launch an app first")]
     NoActiveSession,
 
     #[error("app failed to start: {0}")]
@@ -63,7 +63,10 @@ pub enum GlassError {
     #[error("image codec error: {0}")]
     ImageCodec(String),
 
-    #[error("accessibility is not supported by this backend")]
+    #[error(
+        "accessibility is not supported by this backend — see the app with glass_screenshot \
+         and drive it by pixel coordinates (glass_click) instead"
+    )]
     AxUnsupported,
 
     #[error("no accessibility snapshot yet; call glass_a11y_snapshot first")]
@@ -72,7 +75,11 @@ pub enum GlassError {
     #[error("element #{0} is not in the current snapshot; re-snapshot")]
     AxElementNotFound(u32),
 
-    #[error("element #{0} has no clickable on-screen geometry")]
+    #[error(
+        "element #{0} has no clickable on-screen geometry — it's off-screen or its a11y node \
+         reports no bounds; bring it into view with glass_scroll_to_element (re-snapshots), then \
+         retry, or locate it with glass_screenshot and click by coordinate"
+    )]
     AxElementNotClickable(u32),
 
     #[error("element #{0} is not editable via the accessibility API (its a11y projection exposes no writable value — a common toolkit gap even when the element accepts typed input); focus it with glass_click, then enter text with glass_type / glass_key instead")]
@@ -163,7 +170,10 @@ mod tests {
 
     #[test]
     fn display_messages_are_actionable() {
-        assert_eq!(GlassError::NoActiveSession.to_string(), "no active session");
+        assert_eq!(
+            GlassError::NoActiveSession.to_string(),
+            "no active session — call glass_start to launch an app first"
+        );
         assert_eq!(
             GlassError::CoordOutOfBounds {
                 x: 5,
@@ -195,7 +205,7 @@ mod tests {
     fn a11y_messages_are_actionable() {
         assert_eq!(
             GlassError::AxUnsupported.to_string(),
-            "accessibility is not supported by this backend"
+            "accessibility is not supported by this backend — see the app with glass_screenshot and drive it by pixel coordinates (glass_click) instead"
         );
         assert_eq!(
             GlassError::NoAxSnapshot.to_string(),
@@ -207,7 +217,7 @@ mod tests {
         );
         assert_eq!(
             GlassError::AxElementNotClickable(3).to_string(),
-            "element #3 has no clickable on-screen geometry"
+            "element #3 has no clickable on-screen geometry — it's off-screen or its a11y node reports no bounds; bring it into view with glass_scroll_to_element (re-snapshots), then retry, or locate it with glass_screenshot and click by coordinate"
         );
         assert_eq!(
             GlassError::AxElementNotEditable(5).to_string(),

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -235,10 +235,16 @@ pub fn select_window(glass: &mut Glass, a: &SelectWindowArgs) -> ToolResult {
 pub fn a11y_snapshot(glass: &mut Glass) -> ToolResult {
     let tree = glass.a11y_snapshot().map_err(|e| e.to_string())?;
     let body = tree.to_outline();
+    // The outline is app-derived → untrusted-wrapped. When the tree has nothing to
+    // address, add glass's own (trusted, unwrapped) hint steering to the pixel loop.
+    let mut contents = vec![OutContent::Text(crate::untrusted::wrap_untrusted(&body))];
+    if let Some(hint) = tree.empty_guidance() {
+        contents.push(OutContent::Text(hint.to_string()));
+    }
     Ok(ToolOutput::result_with(
         "glass_a11y_snapshot",
         serde_json::json!({}),
-        vec![OutContent::Text(crate::untrusted::wrap_untrusted(&body))],
+        contents,
     ))
 }
 
@@ -632,6 +638,26 @@ pub(crate) mod testutil {
         AxTree { root, count: 0 }
     }
 
+    /// A window root with no child elements — the "app publishes no usable tree" shape.
+    pub fn empty_tree() -> AxTree {
+        let root = AxNode {
+            id: AxNodeId(0),
+            role: AxRole::Window,
+            raw_role: "frame".into(),
+            name: Some("Win".into()),
+            value: None,
+            states: AxStates::default(),
+            bounds: Some(AxRect {
+                x: 0,
+                y: 0,
+                width: 100,
+                height: 100,
+            }),
+            children: vec![],
+        };
+        AxTree { root, count: 0 }
+    }
+
     pub fn glass_with_a11y(platform: FakePlatform, tree: AxTree) -> Glass {
         glass_with_a11y_outcome(platform, tree, SetOutcome::Ok)
     }
@@ -915,6 +941,35 @@ mod tests {
                 );
             }
             _ => panic!("expected text"),
+        }
+    }
+
+    #[test]
+    fn a11y_snapshot_appends_pixel_hint_when_treeless() {
+        let mut g = glass_with_a11y(FakePlatform::new(100, 100), empty_tree());
+        g.start(&AppSpec {
+            build: None,
+            run: vec!["x".into()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 1,
+            sandbox: SandboxLevel::Off,
+            a11y: false,
+        })
+        .unwrap();
+        let out = a11y_snapshot(&mut g).unwrap();
+        assert_envelope(&out, "glass_a11y_snapshot");
+        // [0]=envelope, [1]=untrusted root-only outline, [2]=glass's trusted pixel hint.
+        match &out.0[2] {
+            OutContent::Text(t) => {
+                assert!(t.contains("glass_screenshot"), "pixel hint: {t}");
+                assert!(
+                    !t.starts_with(crate::untrusted::NOTE),
+                    "the hint is glass's own guidance, not untrusted app content: {t}"
+                );
+            }
+            _ => panic!("expected the pixel-hint text"),
         }
     }
 


### PR DESCRIPTION
## What

An audit of glass's agent-facing failure surface, asking of each: does the message tell the agent its *next action*, or dead-end? Most already guided well (re-snapshot; relaunch with `a11y:true`; focus then type; wait for the window; use the pixel loop). Two gaps are closed here.

### 1. Three backend-agnostic messages now name the recovery

In `glass-core`, so every backend benefits:

| Failure | Was | Now adds |
|---|---|---|
| no active session | "no active session" | "— call `glass_start` to launch an app first" |
| a11y unsupported | "accessibility is not supported by this backend" | "— see the app with `glass_screenshot` and drive it by pixel coordinates (`glass_click`) instead" |
| element not clickable | "element #N has no clickable on-screen geometry" | "— it's off-screen or its a11y node reports no bounds; bring it into view with `glass_scroll_to_element` (re-snapshots), then retry, or locate it with `glass_screenshot`…" |

Existing substring assertions (`"no active session"`, `"not supported"`) are preserved.

### 2. Empty snapshot steers to pixels on every backend

The friendly "no accessibility tree — use the pixel loop" guidance previously existed **only** on the Linux no-bus path (which errors before a tree is built). On Windows/macOS/Android, an app that publishes nothing came back as a bare root-only outline with **no next step**.

New `AxTree::empty_guidance()` (glass-core): when a snapshot has only the window root (no addressable elements), `glass_a11y_snapshot` appends a **trusted, unwrapped** hint to drive by pixels. Backend-agnostic — one seam, every backend, including a Linux app that publishes a bare root under `a11y:true`.

## Scope note

Per-backend diagnostic passthroughs (UI Automation / uiautomator error strings) carry the cause and are left as-is — a next-action there would need per-backend on-device validation. The `wait_for_*` soft-timeout `{matched:false}` payload is unchanged; its guidance lives in the tool description, and a per-response hint would bloat every wait.

## Tests

TDD throughout: `NoActiveSession` / `AxUnsupported` / `AxElementNotClickable` message assertions; `empty_guidance_flags_a_treeless_snapshot` (glass-core); `a11y_snapshot_appends_pixel_hint_when_treeless` (glass-mcp, asserts the hint is present and *not* untrusted-wrapped). Full workspace gate green.