### PR TITLE
feat: enable accessibility by default at glass_start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ internal refactors, CI, or test-only changes.
   from any host — [docs/reference/host-compatibility.md](docs/reference/host-compatibility.md).
 
 ### Changed
+- **Accessibility is on by default at launch.** `glass_start` now enables the accessibility tools
+  without an explicit `a11y: true` — the semantic path (address elements by `#id`, verify from text,
+  no image tokens) works out of the box, matching how glass is meant to be driven. Pass `a11y: false`
+  to skip spawning the private accessibility bus for canvas/pixel-only apps. Linux only in effect;
+  other backends already read accessibility ambiently.
 - **Server instructions lead with the low-token accessibility path.** The guidance an MCP host
   shows the agent now presents semantic addressing (`glass_a11y_snapshot` → `glass_click_element` /
   `glass_set_value`, text-only, no image tokens) as the default way to see and drive the UI, with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,10 @@ internal refactors, CI, or test-only changes.
 - **Accessibility is on by default at launch.** `glass_start` now enables the accessibility tools
   without an explicit `a11y: true` — the semantic path (address elements by `#id`, verify from text,
   no image tokens) works out of the box, matching how glass is meant to be driven. Pass `a11y: false`
-  to skip spawning the private accessibility bus for canvas/pixel-only apps. Linux only in effect;
-  other backends already read accessibility ambiently.
+  to skip spawning the private accessibility bus for canvas/pixel-only apps. On a Linux host that
+  can't start an accessibility bus (e.g. `at-spi2-core` isn't installed), the default quietly falls
+  back to pixel-only rather than failing the launch; an explicit `a11y: true` still fails loudly.
+  Linux only in effect; other backends already read accessibility ambiently.
 - **Server instructions lead with the low-token accessibility path.** The guidance an MCP host
   shows the agent now presents semantic addressing (`glass_a11y_snapshot` → `glass_click_element` /
   `glass_set_value`, text-only, no image tokens) as the default way to see and drive the UI, with

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,6 +1246,7 @@ dependencies = [
  "glass-a11y-windows",
  "glass-android",
  "glass-core",
+ "glass-dbus-linux",
  "glass-ios",
  "glass-macos",
  "glass-sandbox-linux",

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ tree, the agent drives it semantically — addressing widgets by `#id` and confi
 text, no per-step screenshot:
 
 ```jsonc
-glass_start            { "run": ["python3", "app.py"], "a11y": true }   // launch (+ private a11y bus)
+glass_start            { "run": ["python3", "app.py"] }   // launch (accessibility on by default)
 glass_a11y_snapshot                        // the tree: role, name, #id, bounds — as text
 glass_click_element    { "id": 5 }         // click by #id, not pixels
 glass_wait_for_element { "name": "Save", "condition": "enabled" }       // wait on state — no polling

--- a/crates/glass-core/src/platform.rs
+++ b/crates/glass-core/src/platform.rs
@@ -187,8 +187,10 @@ pub struct AppSpec {
     /// How aggressively to contain the launched process tree.
     pub sandbox: SandboxLevel,
     /// Spawn a private, isolated AT-SPI bus for this launch so the app publishes an
-    /// accessibility tree glass can read. Opt-in: when false, no a11y processes are
-    /// spawned and the a11y tools return a "relaunch with a11y:true" error.
+    /// accessibility tree glass can read. On by default at the tool boundary (the a11y
+    /// path is the low-token default); when false, no a11y processes are spawned and the
+    /// a11y tools return a "relaunch with a11y:true" error. Only affects Linux backends;
+    /// others read accessibility ambiently.
     pub a11y: bool,
 }
 

--- a/crates/glass-dbus-linux/src/lib.rs
+++ b/crates/glass-dbus-linux/src/lib.rs
@@ -241,6 +241,28 @@ fn find_launcher() -> Option<PathBuf> {
     CANDIDATES.iter().map(PathBuf::from).find(|p| p.is_file())
 }
 
+/// Cheap, non-spawning preflight: are the binaries a private a11y bus needs resolvable on
+/// this host? Lets a caller decide whether a best-effort (default-on) a11y launch is worth
+/// attempting or should quietly fall back to pixel-only, without the cost and teardown churn
+/// of actually starting the bus. Not a guarantee [`PrivateBus::start`] will succeed — a
+/// resolvable binary can still fail to spawn — but it catches the common "AT-SPI not
+/// installed" and misconfigured-path cases.
+pub fn available() -> std::result::Result<(), String> {
+    if find_launcher().is_none() {
+        return Err(
+            "at-spi-bus-launcher not found (install at-spi2-core), or set GLASS_ATSPI_LAUNCHER"
+                .into(),
+        );
+    }
+    // `tool_path` returns an explicit path (from GLASS_DBUS_DAEMON) or the bare "dbus-daemon"
+    // name resolved on PATH at spawn time. Only an explicit path can be checked here.
+    let dbus = glass_core::tool_path("GLASS_DBUS_DAEMON", "dbus-daemon");
+    if dbus.contains('/') && !std::path::Path::new(&dbus).is_file() {
+        return Err(format!("dbus-daemon not found at {dbus}"));
+    }
+    Ok(())
+}
+
 #[zbus::proxy(
     interface = "org.a11y.Bus",
     default_service = "org.a11y.Bus",
@@ -357,6 +379,28 @@ fn resolve_a11y_address(session_addr: &str) -> Result<String> {
 mod tests {
     use super::*;
     use std::time::Instant;
+
+    #[test]
+    fn available_errors_when_the_atspi_launcher_is_missing() {
+        // Point the launcher override at a nonexistent path so the check is deterministic
+        // regardless of whether at-spi2-core is installed on the test host. Restore on drop.
+        struct Guard(Option<std::ffi::OsString>);
+        impl Drop for Guard {
+            fn drop(&mut self) {
+                match &self.0 {
+                    Some(v) => std::env::set_var("GLASS_ATSPI_LAUNCHER", v),
+                    None => std::env::remove_var("GLASS_ATSPI_LAUNCHER"),
+                }
+            }
+        }
+        let _g = Guard(std::env::var_os("GLASS_ATSPI_LAUNCHER"));
+        std::env::set_var("GLASS_ATSPI_LAUNCHER", "/nonexistent/glass-no-atspi");
+        let err = available().expect_err("missing launcher must report unavailable");
+        assert!(
+            err.contains("at-spi-bus-launcher"),
+            "actionable message: {err}"
+        );
+    }
 
     #[test]
     #[ignore = "spawns dbus-daemon + at-spi-bus-launcher; run explicitly"]

--- a/crates/glass-mcp/Cargo.toml
+++ b/crates/glass-mcp/Cargo.toml
@@ -42,6 +42,7 @@ futures = { version = "0.3", optional = true }
 glass-x11 = { path = "../glass-x11" }
 glass-wayland = { path = "../glass-wayland" }
 glass-a11y-linux = { path = "../glass-a11y-linux" }
+glass-dbus-linux = { path = "../glass-dbus-linux" }
 glass-sandbox-linux.workspace = true
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -79,9 +79,11 @@ pub struct StartArgs {
     pub window_hint: Option<WindowHintArgs>,
     pub timeout_ms: Option<u64>,
     /// Spawn a private accessibility (AT-SPI) bus so `glass_a11y_snapshot` / `marks` /
-    /// `set_value` / `click_element` / `wait_for_element` work against this app. Opt-in
-    /// (default false) — only set when you need the accessibility tree; it spawns extra
-    /// processes. Linux only.
+    /// `set_value` / `click_element` / `wait_for_element` work against this app. **On by
+    /// default** — the accessibility path is the cheap, low-token way to drive a UI, so it
+    /// is available unless you opt out. Pass `false` to skip the bus for canvas/pixel-only
+    /// apps (it spawns extra processes). Effective on Linux only; other backends read
+    /// accessibility ambiently and ignore this flag.
     #[serde(default)]
     pub a11y: Option<bool>,
 }

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -123,7 +123,7 @@ impl GlassServer {
     }
 
     #[tool(
-        description = "Build, launch, and locate a native GUI app; returns its window geometry. Choose a backend with the `backend` param (defaults to the host); pass `a11y` to enable the accessibility tools. Optional `window_hint` ({ title?, class? }) picks the right window when several appear, or locates one the launched process hands off to another process."
+        description = "Build, launch, and locate a native GUI app; returns its window geometry. Choose a backend with the `backend` param (defaults to the host). The accessibility tools are enabled by default; pass `a11y:false` to skip the accessibility bus for canvas/pixel-only apps. Optional `window_hint` ({ title?, class? }) picks the right window when several appear, or locates one the launched process hands off to another process."
     )]
     async fn glass_start(
         &self,

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -119,6 +119,15 @@ fn resolve_sandbox(
     }
 }
 
+/// Resolve the `a11y` launch flag. On by default: the accessibility path (semantic
+/// addressing, text-only verification) is glass's cheap, low-token default, so omitting
+/// the flag enables it rather than leaving it off. Pass `a11y: false` to skip spawning
+/// the accessibility bus for canvas/pixel-only work. (The flag only has effect on Linux,
+/// which spawns a private AT-SPI bus; other backends read accessibility ambiently.)
+fn resolve_a11y(arg: Option<bool>) -> bool {
+    arg.unwrap_or(true)
+}
+
 /// Read the operator floor env, distinguishing "unset" from "set-but-unreadable". A floor whose
 /// bytes are not valid UTF-8 must NOT be silently treated as unset — that would drop the operator's
 /// floor (fail-OPEN). It is an error, so the launch is refused until it's fixed (fail-closed),
@@ -160,7 +169,7 @@ pub fn start(glass: &mut Glass, a: &StartArgs) -> ToolResult {
         }),
         timeout_ms: a.timeout_ms.unwrap_or(10_000),
         sandbox,
-        a11y: a.a11y.unwrap_or(false),
+        a11y: resolve_a11y(a.a11y),
     };
     let geo = match a.backend.as_deref() {
         Some(b) => glass.start_on(b, &spec),
@@ -728,6 +737,14 @@ mod tests {
             timeout_ms: None,
             a11y: None,
         }
+    }
+
+    #[test]
+    fn a11y_defaults_on_when_omitted() {
+        // The a11y-first path is the low-token default, so an omitted flag enables it.
+        assert!(resolve_a11y(None), "omitted a11y must default on");
+        assert!(resolve_a11y(Some(true)));
+        assert!(!resolve_a11y(Some(false)), "explicit false opts out");
     }
 
     #[test]

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -128,6 +128,21 @@ fn resolve_a11y(arg: Option<bool>) -> bool {
     arg.unwrap_or(true)
 }
 
+/// Non-spawning preflight for the accessibility bus, so a best-effort (default-on) a11y
+/// launch can degrade to pixel-only on a host that can't provide it (e.g. AT-SPI not
+/// installed) instead of failing. Only the Linux backends spawn a private AT-SPI bus and
+/// read `spec.a11y`; on every other target the flag is a no-op, so the preflight is a
+/// no-op too. An explicit `a11y: true` skips this and still fails loudly if the bus can't
+/// start (no silent fallback).
+#[cfg(target_os = "linux")]
+fn a11y_bus_preflight() -> Result<(), String> {
+    glass_dbus_linux::available()
+}
+#[cfg(not(target_os = "linux"))]
+fn a11y_bus_preflight() -> Result<(), String> {
+    Ok(())
+}
+
 /// Read the operator floor env, distinguishing "unset" from "set-but-unreadable". A floor whose
 /// bytes are not valid UTF-8 must NOT be silently treated as unset — that would drop the operator's
 /// floor (fail-OPEN). It is an error, so the launch is refused until it's fixed (fail-closed),
@@ -158,7 +173,7 @@ pub fn start(glass: &mut Glass, a: &StartArgs) -> ToolResult {
         sandbox_env.as_deref(),
         floor_env.as_deref(),
     )?;
-    let spec = AppSpec {
+    let mut spec = AppSpec {
         build: a.build.clone(),
         run: a.run.clone(),
         cwd: a.cwd.clone().map(PathBuf::from),
@@ -171,6 +186,19 @@ pub fn start(glass: &mut Glass, a: &StartArgs) -> ToolResult {
         sandbox,
         a11y: resolve_a11y(a.a11y),
     };
+    // Best-effort default: a11y is on unless the caller opts out, but a host that can't bring
+    // up the accessibility bus must still launch and pixel-drive. When a11y is on only because
+    // it defaults on (not explicitly requested) and the bus can't start here, launch without
+    // it. An explicit a11y:true is left to fail loudly at the backend (no silent fallback).
+    if spec.a11y && a.a11y.is_none() {
+        if let Err(why) = a11y_bus_preflight() {
+            eprintln!(
+                "glass: accessibility is on by default but this host can't start its bus \
+                 ({why}); launching without it — pass a11y:true to require it."
+            );
+            spec.a11y = false;
+        }
+    }
     let geo = match a.backend.as_deref() {
         Some(b) => glass.start_on(b, &spec),
         None => glass.start(&spec),

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -77,7 +77,7 @@ receive none of these defaults.
 | `GLASS_DBUS_DAEMON` | `dbus-daemon` binary for the private AT-SPI bus | `dbus-daemon` (on `PATH`) | Linux |
 | `GLASS_ATSPI_LAUNCHER` | `at-spi-bus-launcher` binary; forces this one and skips discovery (fails closed if wrong) | auto-discovered (well-known install paths) | Linux |
 
-Only used when a launch requests `a11y: true` (see [reference/tools.md](tools.md)): glass spawns a
+Only used when a launch has a11y enabled — the default; see [reference/tools.md](tools.md): glass spawns a
 private D-Bus session bus and AT-SPI bus per launch rather than touching your desktop's shared
 accessibility bus.
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -92,8 +92,10 @@ Build, launch, and locate a native GUI app; returns its window geometry.
 - `window_hint` (`{ title?, class? }`) — disambiguate which window is the app's when several appear,
   or find a window the launched process hands off to an unrelated process (some packaged Windows
   apps). `title` is a case-insensitive substring; `class` is an exact match.
-- `a11y` (boolean, default false) — **Linux only.** Spawn a private AT-SPI bus so the accessibility
-  tools work against this app. Opt-in, since it spawns extra processes.
+- `a11y` (boolean, default true) — **Linux only.** Spawn a private AT-SPI bus so the accessibility
+  tools work against this app. On by default (the accessibility path is the cheap, low-token way to
+  drive a UI); pass `false` to skip the bus for canvas/pixel-only apps, since it spawns extra
+  processes. Other backends read accessibility ambiently and ignore this flag.
 - `timeout_ms` (integer) — launch timeout.
 
 Returns the located window's geometry: `{x, y, width, height}`.
@@ -404,7 +406,8 @@ Returns the window's geometry after the op: `{x, y, width, height}`.
 Deterministic, low-token element addressing that complements the pixel loop. Available where the app
 exposes an accessibility tree (most GTK/Qt/toolkit apps — not bare canvas/game UIs); these tools
 **error** for an app with no accessible UI rather than return a fake tree, so fall back to
-`glass_screenshot` then. On Linux, start the app with `glass_start`'s `a11y:true`. The **iOS** backend
+`glass_screenshot` then. On Linux the accessibility bus is on by default — only relevant if you
+launched with `a11y:false`, in which case relaunch without it. The **iOS** backend
 reads the Simulator's accessibility tree over `idb_companion` (install it — see
 [setup-ios.md](../how-to/setup-ios.md#input--accessibility)). See
 [reference/platforms.md](platforms.md) for per-OS backends (AT-SPI / UI Automation / uiautomator / AX / idb).

--- a/docs/tutorial/first-drive.md
+++ b/docs/tutorial/first-drive.md
@@ -172,8 +172,8 @@ Three things to do next:
 
 - **Give your agent this loop permanently.** Install the [glass-drive skill](../how-to/drive-glass-well.md)
   so it arrives already knowing the cheap-verify habits you just saw.
-- **Address elements by name, not pixels.** This egui app exposes an accessibility tree, so relaunch it
-  with `glass_start`'s `a11y: true` and try `glass_a11y_snapshot` — you'll get the **Text** field, the
+- **Address elements by name, not pixels.** This egui app exposes an accessibility tree, so try
+  `glass_a11y_snapshot` (the accessibility bus is on by default) — you'll get the **Text** field, the
   **Value** slider, and the **Apply** button as addressable elements. Then `glass_set_value` the slider
   or `glass_click_element` the button by `#id`, no coordinates needed. See the
   [tool reference](../reference/tools.md).


### PR DESCRIPTION
## What

glass leads with the accessibility path — address elements by `#id`, verify from text, no image tokens — as the cheap way to drive a UI (the server instructions and README both lead with it). But `glass_start` required an explicit `a11y: true` to make those tools available, so the advertised path failed on the first try and the agent had to recover from an error.

This flips the default: **an omitted `a11y` flag now enables the accessibility tools.** Pass `a11y: false` to skip spawning the bus for canvas/pixel-only apps.

## Why it's safe / narrow

- **Linux-only in effect.** The flag gates spawning a private AT-SPI bus at launch. Windows, macOS, Android, and iOS read accessibility ambiently and ignore the flag — so this only changes Linux launches.
- **No app-behavior side effect.** The private bus process gets `GSETTINGS_BACKEND=memory`, not the launched app; the app only receives the bus address.
- **Tool boundary only.** `AppSpec`'s internal default stays `false`; only the `glass_start` argument resolution defaults on (extracted to `resolve_a11y()` and guarded by a test, mirroring `resolve_sandbox()`). Internal `AppSpec` construction (sub-flows, integration fixtures) is unchanged.
- **Cost:** a bus spawn per Linux launch (tens of ms); pure-pixel/canvas sessions opt out with `a11y:false`.

## Docs

`README` (example drops the now-redundant flag), `docs/reference/tools.md`, `docs/reference/environment.md`, `docs/tutorial/first-drive.md`, and the `StartArgs` / `AppSpec.a11y` doc comments all updated to "on by default". CHANGELOG under `[Unreleased] › Changed`.

## Test

`a11y_defaults_on_when_omitted` (`None → true`, `Some(true) → true`, `Some(false) → false`), written test-first. Full workspace gate green.