### PR TITLE
docs: state the Windows sandbox write-vs-read boundary in the setup guide

### DIFF
--- a/docs/how-to/setup-windows.md
+++ b/docs/how-to/setup-windows.md
@@ -24,6 +24,13 @@ install directory. `GLASS_WIN_SANDBOX_PROVIDER` (`auto`|`sandboxie`|`none`) sele
 set `GLASS_SANDBOX_FLOOR` above `off` on this host, that default is raised to the floor for a launch
 that doesn't ask for a level, and an explicit per-launch `sandbox:"off"` request is refused.
 
+> **What the Windows sandbox covers.** Sandboxie contains the launched app's *writes* (into a private
+> store, so your real files are never modified) and, under `strict`, its network — but it does **not**
+> block *reads*. A contained app can still read files under `%USERPROFILE%`, including secrets like SSH
+> keys, unlike the Linux and macOS profiles, which hide your home from reads. Treat it as write-and-
+> network containment, and don't rely on it to hide read-side secrets. See
+> [Known limits](../explanation/containment.md#known-limits).
+
 ## Install the binary
 
 Download `glass-mcp-*-x86_64-windows.zip` from the


### PR DESCRIPTION
## What

The Windows setup guide's **Containment runtime** section explained that glass sandboxes launched apps (Sandboxie, fail-closed) but didn't state the security-relevant boundary: Sandboxie contains the app's **writes** (into a private store) and, under `strict`, its **network** — but it does **not** block **reads**. A contained app can still read files under `%USERPROFILE%`, including secrets like SSH keys, unlike the Linux (`--tmpfs $HOME`) and macOS (home denied) profiles.

This adds a brief, honest note right where a Windows user configures containment, pointing to the containment explanation's [Known limits](../explanation/containment.md#known-limits) for the full treatment (which already documented this).

## Why documentation-only

This is a genuine property of write-virtualization, not a bug — the fix is to set expectations, not to over-claim containment glass doesn't provide. The setup guide is where a Windows user forms those expectations; the reference `sandbox` param and the containment explanation already cross-link, so no other doc needed changing.

Documentation only; no code changes.