### PR TITLE
chore(release): v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-23
+
 ### Added
 - **Ignore regions for visual comparison.** `glass_diff`, `glass_wait_for_region`,
   `glass_wait_stable`, and `glass_do`'s `settle` action accept `ignore` — window-relative
@@ -29,6 +31,10 @@ internal refactors, CI, or test-only changes.
   [docs/how-to/verification-cost.md](docs/how-to/verification-cost.md).
 - Reference: host compatibility — which MCP hosts are verified against glass, and what glass needs
   from any host — [docs/reference/host-compatibility.md](docs/reference/host-compatibility.md).
+- How-to: drive a native iOS app in the Simulator — build the bundled
+  [`examples/ios-greeter/`](examples/ios-greeter/) demo app and drive it end to end (launch, read the
+  accessibility tree, act, verify from text and by diff) —
+  [docs/how-to/drive-an-ios-app.md](docs/how-to/drive-an-ios-app.md).
 
 ### Changed
 - **Accessibility is on by default at launch.** `glass_start` now enables the accessibility tools
@@ -388,7 +394,8 @@ First public release — open core, Apache-2.0.
 - Core tools: `glass_start`, `glass_stop`, `glass_screenshot`, `glass_click`,
   `glass_list_windows`, `glass_select_window`, and `glass_doctor`.
 
-[Unreleased]: https://github.com/fixed-width/glass/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/fixed-width/glass/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/fixed-width/glass/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/fixed-width/glass/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/fixed-width/glass/compare/v0.5.0...v1.0.0
 [0.5.0]: https://github.com/fixed-width/glass/compare/v0.4.0...v0.5.0


### PR DESCRIPTION
Cuts **v1.1.0** — the accumulated `[Unreleased]` changes since v1.0.1, renamed with today's date, fresh `[Unreleased]` above, compare links updated.

## Highlights
**Added**
- Ignore regions for visual comparison (`ignore` on `glass_diff` / `glass_wait_for_region` / `glass_wait_stable` / `glass_do` settle; `ignored_pixels` reported).
- How-tos: verification-loop cost, drive a native iOS app in the Simulator (+ the `examples/ios-greeter` demo). Reference: host compatibility.

**Changed**
- **Accessibility on by default at launch** (best-effort; `a11y:false` opts out; degrades to pixel-only where no a11y bus).
- Server instructions lead with the low-token a11y path.
- Error messages name the recovery action; empty a11y snapshots hint toward pixels.

**Fixed**
- Linux `a11y:true` reaches AccessKit apps (egui/winit); GTK4/Qt render under containment instead of black; `glass_a11y_marks` boxes clamp to the window.

Version derives from the release tag at build time (Cargo.toml stays `0.0.0`). Tag `v1.1.0` on the merge commit publishes the release.