### PR TITLE
a11y: compact snapshot outline + disclose truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+### Changed
+- `glass_a11y_snapshot` now returns a compacted outline: chains of unnamed single-child
+  container elements are collapsed. Element ids are unchanged and every element remains
+  addressable with `glass_click_element` / `glass_set_value`.
+
+### Fixed
+- The accessibility tree now reports when a snapshot was truncated. Previously a tree that hit
+  an internal size limit was returned as though it were complete, so a missing element was
+  indistinguishable from one that does not exist. All backends now share the same limits and
+  disclose when one is reached.
+
 ## [1.1.0] - 2026-07-23
 
 ### Added

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -11,6 +11,7 @@ use atspi::proxy::component::ComponentProxy;
 use atspi_common::{CoordType, ObjectRefOwned};
 use glass_core::{
     Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget, AxTree, GlassError, Result,
+    TruncationLimit, WalkBudget, MAX_SIBLINGS,
 };
 
 use crate::mapping::{map_role, map_states};
@@ -143,8 +144,10 @@ async fn snapshot_async(ctx: &AxContext) -> Result<AxTree> {
         .await
         .map_err(bus_err)?;
 
-    let root_node = Box::pin(walk(&app, &zbus_conn)).await?;
+    let mut budget = WalkBudget::new();
+    let root_node = Box::pin(walk(&app, &zbus_conn, 0, &mut budget)).await?;
     let mut tree = AxTree::new(root_node);
+    tree.truncated = budget.truncation();
     tree.assign_ids();
     Ok(tree)
 }
@@ -162,8 +165,8 @@ fn writes_value_only(role: glass_core::AxRole, text: &str) -> bool {
 async fn set_value_async(ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
     let (app_ref, conn) = find_app(ctx).await?;
     let app = app_ref.as_accessible_proxy(&conn).await.map_err(bus_err)?;
-    let mut counter = 0u32;
-    let node_ref = Box::pin(find_nth(&app_ref, &app, &conn, target.id.0, &mut counter))
+    let mut budget = WalkBudget::new();
+    let node_ref = Box::pin(find_nth(&app_ref, &app, &conn, 0, target.id.0, &mut budget))
         .await?
         .ok_or(GlassError::AxElementChanged(target.id.0))?;
     let node = node_ref.as_accessible_proxy(&conn).await.map_err(bus_err)?;
@@ -226,29 +229,56 @@ async fn set_value_async(ctx: &AxContext, target: &AxTarget, text: &str) -> Resu
     Err(GlassError::AxElementNotEditable(target.id.0))
 }
 
-/// Pre-order DFS to the node at index `target`, mirroring `walk` exactly: visit
-/// the node (its id is the arrival counter), then recurse each child in
-/// `get_children` order, **skipping children whose proxy fails to build** (just
-/// like `walk`'s `let Ok(child) = … else continue`, so ids stay aligned). The
-/// proxy is passed by reference and never returned; the owned `ObjectRefOwned`
-/// (cloned on match) is returned, so nothing borrows the connection.
+/// Pre-order DFS to the node at index `target`, mirroring `walk` exactly: visit the node (its
+/// id is the arrival count), then recurse each child in `get_children` order, skipping children
+/// whose proxy fails to build — **and stopping at the same depth/node/sibling bounds**. The
+/// bounds must stay in lockstep with `walk`: if this traversal visited nodes `walk` skipped,
+/// a `set_value` id would resolve against a different tree and write to the wrong element.
 async fn find_nth(
     node_ref: &ObjectRefOwned,
     proxy: &AccessibleProxy<'_>,
     conn: &zbus::Connection,
+    depth: usize,
     target: u32,
-    counter: &mut u32,
+    budget: &mut WalkBudget,
 ) -> Result<Option<ObjectRefOwned>> {
-    if *counter == target {
+    if budget.nodes_walked() == target as usize {
         return Ok(Some(node_ref.clone()));
     }
-    *counter += 1;
+    budget.visit();
+    if budget.depth_exhausted(depth) {
+        budget.hit(TruncationLimit::Depth);
+        return Ok(None);
+    }
+    if budget.nodes_exhausted() {
+        budget.hit(TruncationLimit::Nodes);
+        return Ok(None);
+    }
+    let mut siblings = 0usize;
     for child_ref in proxy.get_children().await.map_err(bus_err)? {
+        siblings += 1;
+        if siblings > MAX_SIBLINGS {
+            budget.hit(TruncationLimit::Siblings);
+            break;
+        }
         let Ok(child) = child_ref.as_accessible_proxy(conn).await else {
             continue;
         };
-        if let Some(found) = Box::pin(find_nth(&child_ref, &child, conn, target, counter)).await? {
+        if let Some(found) = Box::pin(find_nth(
+            &child_ref,
+            &child,
+            conn,
+            depth + 1,
+            target,
+            budget,
+        ))
+        .await?
+        {
             return Ok(Some(found));
+        }
+        if budget.nodes_exhausted() {
+            budget.hit(TruncationLimit::Nodes);
+            break;
         }
     }
     Ok(None)
@@ -277,8 +307,17 @@ async fn app_matches(app_ref: &ObjectRefOwned, ctx: &AxContext, conn: &zbus::Con
     }
 }
 
-/// Recursively build a normalized node from an AT-SPI accessible.
-async fn walk(proxy: &AccessibleProxy<'_>, conn: &zbus::Connection) -> Result<AxNode> {
+/// Recursively build a normalized node from an AT-SPI accessible, bounded by
+/// [`WalkBudget`] (node count, nesting depth, and per-level sibling scan) so a
+/// pathological tree can't burn the outer [`SNAPSHOT_TIMEOUT`] with no tree to
+/// show for it.
+async fn walk(
+    proxy: &AccessibleProxy<'_>,
+    conn: &zbus::Connection,
+    depth: usize,
+    budget: &mut WalkBudget,
+) -> Result<AxNode> {
+    budget.visit();
     let role = proxy.get_role().await.map_err(bus_err)?;
     let raw_role = proxy.get_role_name().await.unwrap_or_default();
     let name = nonempty(proxy.name().await.unwrap_or_default());
@@ -286,11 +325,27 @@ async fn walk(proxy: &AccessibleProxy<'_>, conn: &zbus::Connection) -> Result<Ax
     let bounds = extents(proxy, conn).await;
 
     let mut children = Vec::new();
-    for child_ref in proxy.get_children().await.map_err(bus_err)? {
-        let Ok(child) = child_ref.as_accessible_proxy(conn).await else {
-            continue;
-        };
-        children.push(Box::pin(walk(&child, conn)).await?);
+    if budget.depth_exhausted(depth) {
+        budget.hit(TruncationLimit::Depth);
+    } else if budget.nodes_exhausted() {
+        budget.hit(TruncationLimit::Nodes);
+    } else {
+        let mut siblings = 0usize;
+        for child_ref in proxy.get_children().await.map_err(bus_err)? {
+            siblings += 1;
+            if siblings > MAX_SIBLINGS {
+                budget.hit(TruncationLimit::Siblings);
+                break;
+            }
+            let Ok(child) = child_ref.as_accessible_proxy(conn).await else {
+                continue;
+            };
+            children.push(Box::pin(walk(&child, conn, depth + 1, budget)).await?);
+            if budget.nodes_exhausted() {
+                budget.hit(TruncationLimit::Nodes);
+                break;
+            }
+        }
     }
 
     let value = read_value(proxy, conn, map_role(role)).await;

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -230,7 +230,9 @@ async fn set_value_async(ctx: &AxContext, target: &AxTarget, text: &str) -> Resu
 }
 
 /// Whether this node's children may be explored, recording the bound that stopped the walk
-/// when they may not.
+/// when they may not. Callers only consult this once they already know the child list is
+/// non-empty — calling it for a childless node would record a truncation for declining to
+/// explore a list that was never going to be walked anyway.
 ///
 /// `walk` and `find_nth` MUST consult this one function at the same point in their
 /// traversal. They assign a node's id by arrival order, and `set_value` re-walks to a
@@ -266,11 +268,20 @@ async fn find_nth(
         return Ok(Some(node_ref.clone()));
     }
     budget.visit();
-    if !may_explore_children(budget, depth) {
+    // Resolved before the gate: a childless node must never be reported truncated for
+    // declining to explore a list that was already empty.
+    let child_refs = proxy.get_children().await.map_err(bus_err)?;
+    if child_refs.is_empty() || !may_explore_children(budget, depth) {
         return Ok(None);
     }
     let mut siblings = 0usize;
-    for child_ref in proxy.get_children().await.map_err(bus_err)? {
+    for child_ref in child_refs {
+        // Checked before processing each child (not after) so the child that merely
+        // completes the tree doesn't get mistaken for one the walk declined to visit.
+        if budget.nodes_exhausted() {
+            budget.hit(TruncationLimit::Nodes);
+            break;
+        }
         siblings += 1;
         if siblings > MAX_SIBLINGS {
             budget.hit(TruncationLimit::Siblings);
@@ -290,10 +301,6 @@ async fn find_nth(
         .await?
         {
             return Ok(Some(found));
-        }
-        if budget.nodes_exhausted() {
-            budget.hit(TruncationLimit::Nodes);
-            break;
         }
     }
     Ok(None)
@@ -340,9 +347,18 @@ async fn walk(
     let bounds = extents(proxy, conn).await;
 
     let mut children = Vec::new();
-    if may_explore_children(budget, depth) {
+    // Resolved before the gate: a childless node must never be reported truncated for
+    // declining to explore a list that was already empty.
+    let child_refs = proxy.get_children().await.map_err(bus_err)?;
+    if !child_refs.is_empty() && may_explore_children(budget, depth) {
         let mut siblings = 0usize;
-        for child_ref in proxy.get_children().await.map_err(bus_err)? {
+        for child_ref in child_refs {
+            // Checked before processing each child (not after) so the child that merely
+            // completes the tree doesn't get mistaken for one the walk declined to visit.
+            if budget.nodes_exhausted() {
+                budget.hit(TruncationLimit::Nodes);
+                break;
+            }
             siblings += 1;
             if siblings > MAX_SIBLINGS {
                 budget.hit(TruncationLimit::Siblings);
@@ -352,10 +368,6 @@ async fn walk(
                 continue;
             };
             children.push(Box::pin(walk(&child, conn, depth + 1, budget)).await?);
-            if budget.nodes_exhausted() {
-                budget.hit(TruncationLimit::Nodes);
-                break;
-            }
         }
     }
 

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -229,6 +229,26 @@ async fn set_value_async(ctx: &AxContext, target: &AxTarget, text: &str) -> Resu
     Err(GlassError::AxElementNotEditable(target.id.0))
 }
 
+/// Whether this node's children may be explored, recording the bound that stopped the walk
+/// when they may not.
+///
+/// `walk` and `find_nth` MUST consult this one function at the same point in their
+/// traversal. They assign a node's id by arrival order, and `set_value` re-walks to a
+/// caller-supplied id — so a bound applied in one traversal but not the other resolves the
+/// id against a different tree and writes to the wrong element. Sharing the decision makes
+/// that divergence impossible to introduce by editing only one of them.
+fn may_explore_children(budget: &mut WalkBudget, depth: usize) -> bool {
+    if budget.depth_exhausted(depth) {
+        budget.hit(TruncationLimit::Depth);
+        return false;
+    }
+    if budget.nodes_exhausted() {
+        budget.hit(TruncationLimit::Nodes);
+        return false;
+    }
+    true
+}
+
 /// Pre-order DFS to the node at index `target`, mirroring `walk` exactly: visit the node (its
 /// id is the arrival count), then recurse each child in `get_children` order, skipping children
 /// whose proxy fails to build — **and stopping at the same depth/node/sibling bounds**. The
@@ -246,12 +266,7 @@ async fn find_nth(
         return Ok(Some(node_ref.clone()));
     }
     budget.visit();
-    if budget.depth_exhausted(depth) {
-        budget.hit(TruncationLimit::Depth);
-        return Ok(None);
-    }
-    if budget.nodes_exhausted() {
-        budget.hit(TruncationLimit::Nodes);
+    if !may_explore_children(budget, depth) {
         return Ok(None);
     }
     let mut siblings = 0usize;
@@ -325,11 +340,7 @@ async fn walk(
     let bounds = extents(proxy, conn).await;
 
     let mut children = Vec::new();
-    if budget.depth_exhausted(depth) {
-        budget.hit(TruncationLimit::Depth);
-    } else if budget.nodes_exhausted() {
-        budget.hit(TruncationLimit::Nodes);
-    } else {
+    if may_explore_children(budget, depth) {
         let mut siblings = 0usize;
         for child_ref in proxy.get_children().await.map_err(bus_err)? {
             siblings += 1;
@@ -517,6 +528,50 @@ fn nonempty(s: String) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use glass_core::{MAX_DEPTH, MAX_NODES};
+
+    #[test]
+    fn below_the_caps_children_may_be_explored_and_nothing_is_recorded() {
+        let mut budget = WalkBudget::new();
+        assert!(may_explore_children(&mut budget, 0));
+        assert!(budget.truncation().is_none());
+    }
+
+    #[test]
+    fn at_max_depth_the_depth_bound_is_recorded_and_children_may_not_be_explored() {
+        let mut budget = WalkBudget::new();
+        assert!(!may_explore_children(&mut budget, MAX_DEPTH));
+        assert_eq!(
+            budget.truncation().map(|t| t.limit),
+            Some(TruncationLimit::Depth)
+        );
+    }
+
+    #[test]
+    fn with_the_node_budget_spent_the_nodes_bound_is_recorded_and_children_may_not_be_explored() {
+        let mut budget = WalkBudget::new();
+        for _ in 0..MAX_NODES {
+            budget.visit();
+        }
+        assert!(!may_explore_children(&mut budget, 0));
+        assert_eq!(
+            budget.truncation().map(|t| t.limit),
+            Some(TruncationLimit::Nodes)
+        );
+    }
+
+    #[test]
+    fn when_both_bounds_are_exhausted_the_recorded_limit_is_depth() {
+        let mut budget = WalkBudget::new();
+        for _ in 0..MAX_NODES {
+            budget.visit();
+        }
+        assert!(!may_explore_children(&mut budget, MAX_DEPTH));
+        assert_eq!(
+            budget.truncation().map(|t| t.limit),
+            Some(TruncationLimit::Depth)
+        );
+    }
 
     #[test]
     fn no_matching_app_message_is_developer_framed() {

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -243,8 +243,11 @@ async fn set_value_async(ctx: &AxContext, target: &AxTarget, text: &str) -> Resu
 // The exactly-at-cap regression — a complete tree of MAX_NODES nodes must report `None`, since
 // the last node to arrive wasn't declined — is unit-tested directly in the Android and iOS
 // mappers, which build a synthetic tree in-process. This reader shares that loop shape but reads
-// a live system tree over IPC, where a tree at the cap would run ~1500 nodes at several
-// round-trips each — landing on `SNAPSHOT_TIMEOUT` and yielding a flaky test, not a reliable one.
+// a live tree over IPC, and `walk` currently spends several sequential round-trips per node, so a
+// tree at the cap would land on `SNAPSHOT_TIMEOUT` and yield a flaky test rather than a reliable
+// one. That is a cost problem, not a fundamental one: reducing the per-node round-trips (batching
+// the attribute reads, or issuing the independent ones concurrently) brings a live at-cap test
+// back within budget, and it should be added alongside that work.
 fn may_explore_children(budget: &mut WalkBudget, depth: usize) -> bool {
     if budget.depth_exhausted(depth) {
         budget.hit(TruncationLimit::Depth);

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -144,10 +144,7 @@ async fn snapshot_async(ctx: &AxContext) -> Result<AxTree> {
         .map_err(bus_err)?;
 
     let root_node = Box::pin(walk(&app, &zbus_conn)).await?;
-    let mut tree = AxTree {
-        root: root_node,
-        count: 0,
-    };
+    let mut tree = AxTree::new(root_node);
     tree.assign_ids();
     Ok(tree)
 }

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -239,6 +239,12 @@ async fn set_value_async(ctx: &AxContext, target: &AxTarget, text: &str) -> Resu
 /// caller-supplied id — so a bound applied in one traversal but not the other resolves the
 /// id against a different tree and writes to the wrong element. Sharing the decision makes
 /// that divergence impossible to introduce by editing only one of them.
+//
+// The exactly-at-cap regression — a complete tree of MAX_NODES nodes must report `None`, since
+// the last node to arrive wasn't declined — is unit-tested directly in the Android and iOS
+// mappers, which build a synthetic tree in-process. This reader shares that loop shape but reads
+// a live system tree over IPC, where a tree at the cap would run ~1500 nodes at several
+// round-trips each — landing on `SNAPSHOT_TIMEOUT` and yielding a flaky test, not a reliable one.
 fn may_explore_children(budget: &mut WalkBudget, depth: usize) -> bool {
     if budget.depth_exhausted(depth) {
         budget.hit(TruncationLimit::Depth);

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -20,25 +20,13 @@ use glass_core::coords::pixel_geometry_from_content_rect;
 use glass_core::platform::WindowGeometry;
 use glass_core::{
     Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxTarget, AxTree, GlassError,
-    Result,
+    Result, TruncationLimit, WalkBudget, MAX_SIBLINGS,
 };
 use objc2_application_services::AXUIElement;
 use objc2_core_foundation::CFRetained;
 
 use crate::ffi::{self, attr};
 use crate::mapping::{self, AxStateFacts};
-
-/// Deepest subtree level walked. Bounds work on a pathological/cyclic tree together with
-/// [`MAX_NODES`]; sized generously so it never truncates a real macOS UI.
-const MAX_DEPTH: usize = 30;
-/// Global cap on nodes *entered* — the hard ceiling on snapshot size.
-const MAX_NODES: usize = 1500;
-/// Per-level cap on siblings *examined* (on- or off-screen). [`MAX_NODES`] only counts
-/// entered nodes and [`should_skip`] siblings are skipped without entering, so an
-/// all-skipped level (a virtualized list of thousands) could iterate without ever tripping
-/// `MAX_NODES`. Cap the per-level scan so the walk is genuinely bounded regardless of
-/// breadth (mirrors the Windows reader).
-const MAX_SIBLINGS: usize = 4096;
 
 /// Per-axis pixel tolerance when matching an `AXWindow`'s origin against the backend's
 /// reported window origin. Same basis as `axwindow.rs`'s geometry-match fallback. Sized for
@@ -94,11 +82,13 @@ impl Accessibility for MacosA11y {
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
         let (window_el, scale) = resolve_window(ctx)?;
 
-        let mut count = 0usize;
-        let root = walk(&window_el, &ctx.window, scale, 0, &mut count);
+        let mut budget = WalkBudget::new();
+        let root = walk(&window_el, &ctx.window, scale, 0, &mut budget);
+        let mut tree = AxTree::new(root);
+        tree.truncated = budget.truncation();
         // Ids/count are assigned by `glass-core` (`AxTree::assign_ids`) so numbering is
         // identical across OS backends.
-        Ok(AxTree::new(root))
+        Ok(tree)
     }
 
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
@@ -107,8 +97,8 @@ impl Accessibility for MacosA11y {
         // Start at 0 so `find_nth`'s pre-order numbering matches `snapshot`'s `walk` +
         // `AxTree::assign_ids` (root id = 0); the role+name+bounds fingerprint below
         // backstops any residual drift between the snapshot and this re-walk.
-        let mut count = 0usize;
-        let el = find_nth(window_el, 0, &mut count, target.id.0)
+        let mut budget = WalkBudget::new();
+        let el = find_nth(window_el, 0, &mut budget, target.id.0)
             .ok_or(GlassError::AxElementNotFound(target.id.0))?;
 
         // Verify role + name + bounds (guards a stale id / tree drift): if drift landed a
@@ -272,16 +262,17 @@ fn select_window(
 }
 
 /// Pre-order walk: build this element's [`AxNode`], then recurse into its (non-skipped)
-/// children in array order. `count` is the running node total, incremented on entry and
-/// shared across the whole walk so [`MAX_NODES`] bounds the entire tree.
+/// children in array order. `budget` tracks the running node total and records which
+/// bound (if any) stopped the walk early — shared across the whole walk, and with
+/// [`find_nth`], so the two traversals stay in lockstep.
 fn walk(
     el: &AXUIElement,
     win: &WindowGeometry,
     scale: f64,
     depth: usize,
-    count: &mut usize,
+    budget: &mut WalkBudget,
 ) -> AxNode {
-    *count += 1;
+    budget.visit();
 
     let ax_role = ffi::attribute_string(el, attr::ROLE).unwrap_or_default();
     let role = mapping::map_role(&ax_role);
@@ -300,12 +291,13 @@ fn walk(
     let states = mapping::map_states(&gather_states(el, role));
 
     let mut children = Vec::new();
-    if depth < MAX_DEPTH && *count < MAX_NODES {
+    if may_explore_children(budget, depth) {
         // `ffi::children` returns `Ok(vec![])` for a legitimately-childless (or absent-
         // `AXChildren`) node and only `Err` for a *real* AX read failure. Degrade a real
         // failure to "no children" so one broken node can't fail the whole snapshot — but log
         // it (mirroring `select_window`'s no-match diagnostic) so the dropped subtree is
-        // observable, never silent.
+        // observable, never silent. This is a different condition from a bound firing (below),
+        // and already reports itself via the log line, so it never touches `budget`.
         let child_els = ffi::children(el).unwrap_or_else(|err| {
             eprintln!(
                 "glass-a11y-macos: walk: AXChildren read failed for role={raw_role:?} \
@@ -313,16 +305,22 @@ fn walk(
             );
             Vec::new()
         });
+        // `MAX_NODES` only counts nodes actually entered, and `should_skip` siblings are
+        // skipped without entering, so an all-skipped level (a virtualized list of thousands)
+        // could otherwise iterate without ever tripping it. `MAX_SIBLINGS` bounds the
+        // per-level scan regardless of how many are skipped (mirrors the Windows reader).
         let mut siblings = 0usize;
         for child in child_els {
             siblings += 1;
             if siblings > MAX_SIBLINGS {
+                budget.hit(TruncationLimit::Siblings);
                 break;
             }
             if !should_skip(&child) {
-                children.push(walk(&child, win, scale, depth + 1, count));
+                children.push(walk(&child, win, scale, depth + 1, budget));
             }
-            if *count >= MAX_NODES {
+            if budget.nodes_exhausted() {
+                budget.hit(TruncationLimit::Nodes);
                 break;
             }
         }
@@ -349,41 +347,63 @@ fn should_skip(el: &AXUIElement) -> bool {
     matches!(ffi::ax_size(el), Ok((w, h)) if w <= 0.0 || h <= 0.0)
 }
 
+/// Whether this node's children may be explored, recording the bound that stopped the walk
+/// when they may not.
+///
+/// `walk` and `find_nth` MUST consult this one function at the same point in their
+/// traversal. They assign a node's id by arrival order, and `set_value` re-walks to a
+/// caller-supplied id — so a bound applied in one traversal but not the other resolves the
+/// id against a different tree and writes to the wrong element. Sharing the decision makes
+/// that divergence impossible to introduce by editing only one of them.
+fn may_explore_children(budget: &mut WalkBudget, depth: usize) -> bool {
+    if budget.depth_exhausted(depth) {
+        budget.hit(TruncationLimit::Depth);
+        return false;
+    }
+    if budget.nodes_exhausted() {
+        budget.hit(TruncationLimit::Nodes);
+        return false;
+    }
+    true
+}
+
 /// Pre-order walk mirroring [`walk`]'s traversal — same `should_skip` predicate, same
-/// `AXChildren` order, same `MAX_DEPTH`/`MAX_NODES`/`MAX_SIBLINGS` bounds — to locate the
-/// element at pre-order index `target`. That is the same numbering
-/// `glass_core::AxTree::assign_ids` gives the tree `snapshot` returns (root = 0), so a
-/// `target.id` captured from a snapshot lands on the same element here. `count` doubles as
-/// the running id (a node's id is `count`'s value on arrival, before it increments) and the
-/// `MAX_NODES` bound, identically to `walk`. Takes (and, on a mismatch, drops) ownership of
-/// each candidate rather than borrowing, since a matched child must outlive the `Vec` of
-/// siblings `ffi::children` returns.
+/// `AXChildren` order, same bounds via [`may_explore_children`] — to locate the element at
+/// pre-order index `target`. That is the same numbering `glass_core::AxTree::assign_ids`
+/// gives the tree `snapshot` returns (root = 0), so a `target.id` captured from a snapshot
+/// lands on the same element here. `budget` doubles as the running id (a node's id is
+/// `budget.nodes_walked()`'s value on arrival, before [`WalkBudget::visit`]) and the node
+/// bound, identically to `walk`. Takes (and, on a mismatch, drops) ownership of each
+/// candidate rather than borrowing, since a matched child must outlive the `Vec` of siblings
+/// `ffi::children` returns.
 fn find_nth(
     el: CFRetained<AXUIElement>,
     depth: usize,
-    count: &mut usize,
+    budget: &mut WalkBudget,
     target: u32,
 ) -> Option<CFRetained<AXUIElement>> {
-    let my_id = *count as u32;
-    *count += 1;
-    if my_id == target {
+    if budget.nodes_walked() == target as usize {
         return Some(el);
     }
-    if depth < MAX_DEPTH && *count < MAX_NODES {
-        let mut siblings = 0usize;
-        for child in ffi::children(&el).unwrap_or_default() {
-            siblings += 1;
-            if siblings > MAX_SIBLINGS {
-                break; // same per-level bound as walk(), so find_nth can't spin either
+    budget.visit();
+    if !may_explore_children(budget, depth) {
+        return None;
+    }
+    let mut siblings = 0usize;
+    for child in ffi::children(&el).unwrap_or_default() {
+        siblings += 1;
+        if siblings > MAX_SIBLINGS {
+            budget.hit(TruncationLimit::Siblings);
+            break; // same per-level bound as walk(), so find_nth can't spin either
+        }
+        if !should_skip(&child) {
+            if let Some(found) = find_nth(child, depth + 1, budget, target) {
+                return Some(found);
             }
-            if !should_skip(&child) {
-                if let Some(found) = find_nth(child, depth + 1, count, target) {
-                    return Some(found);
-                }
-            }
-            if *count >= MAX_NODES {
-                break;
-            }
+        }
+        if budget.nodes_exhausted() {
+            budget.hit(TruncationLimit::Nodes);
+            break;
         }
     }
     None
@@ -461,7 +481,54 @@ fn read_back_confirms(read_back: Option<&str>, before: Option<&str>, requested: 
 
 #[cfg(test)]
 mod tests {
-    use super::{read_back_confirms, set_value_took};
+    use glass_core::{MAX_DEPTH, MAX_NODES};
+
+    use super::{
+        may_explore_children, read_back_confirms, set_value_took, TruncationLimit, WalkBudget,
+    };
+
+    #[test]
+    fn below_the_caps_children_may_be_explored_and_nothing_is_recorded() {
+        let mut budget = WalkBudget::new();
+        assert!(may_explore_children(&mut budget, 0));
+        assert!(budget.truncation().is_none());
+    }
+
+    #[test]
+    fn at_max_depth_the_depth_bound_is_recorded_and_children_may_not_be_explored() {
+        let mut budget = WalkBudget::new();
+        assert!(!may_explore_children(&mut budget, MAX_DEPTH));
+        assert_eq!(
+            budget.truncation().map(|t| t.limit),
+            Some(TruncationLimit::Depth)
+        );
+    }
+
+    #[test]
+    fn with_the_node_budget_spent_the_nodes_bound_is_recorded_and_children_may_not_be_explored() {
+        let mut budget = WalkBudget::new();
+        for _ in 0..MAX_NODES {
+            budget.visit();
+        }
+        assert!(!may_explore_children(&mut budget, 0));
+        assert_eq!(
+            budget.truncation().map(|t| t.limit),
+            Some(TruncationLimit::Nodes)
+        );
+    }
+
+    #[test]
+    fn when_both_bounds_are_exhausted_the_recorded_limit_is_depth() {
+        let mut budget = WalkBudget::new();
+        for _ in 0..MAX_NODES {
+            budget.visit();
+        }
+        assert!(!may_explore_children(&mut budget, MAX_DEPTH));
+        assert_eq!(
+            budget.truncation().map(|t| t.limit),
+            Some(TruncationLimit::Depth)
+        );
+    }
 
     #[test]
     fn noop_is_not_taken() {

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -291,26 +291,35 @@ fn walk(
     let states = mapping::map_states(&gather_states(el, role));
 
     let mut children = Vec::new();
-    if may_explore_children(budget, depth) {
-        // `ffi::children` returns `Ok(vec![])` for a legitimately-childless (or absent-
-        // `AXChildren`) node and only `Err` for a *real* AX read failure. Degrade a real
-        // failure to "no children" so one broken node can't fail the whole snapshot — but log
-        // it (mirroring `select_window`'s no-match diagnostic) so the dropped subtree is
-        // observable, never silent. This is a different condition from a bound firing (below),
-        // and already reports itself via the log line, so it never touches `budget`.
-        let child_els = ffi::children(el).unwrap_or_else(|err| {
-            eprintln!(
-                "glass-a11y-macos: walk: AXChildren read failed for role={raw_role:?} \
-                 bounds={bounds:?}: {err}; treating as no children"
-            );
-            Vec::new()
-        });
+    // `ffi::children` returns `Ok(vec![])` for a legitimately-childless (or absent-
+    // `AXChildren`) node and only `Err` for a *real* AX read failure. Degrade a real
+    // failure to "no children" so one broken node can't fail the whole snapshot — but log
+    // it (mirroring `select_window`'s no-match diagnostic) so the dropped subtree is
+    // observable, never silent. This is a different condition from a bound firing (below),
+    // and already reports itself via the log line, so it never touches `budget`.
+    //
+    // Resolved before the gate below: a childless node must never be reported truncated
+    // for declining to explore a list that was already empty.
+    let child_els = ffi::children(el).unwrap_or_else(|err| {
+        eprintln!(
+            "glass-a11y-macos: walk: AXChildren read failed for role={raw_role:?} \
+             bounds={bounds:?}: {err}; treating as no children"
+        );
+        Vec::new()
+    });
+    if !child_els.is_empty() && may_explore_children(budget, depth) {
         // `MAX_NODES` only counts nodes actually entered, and `should_skip` siblings are
         // skipped without entering, so an all-skipped level (a virtualized list of thousands)
         // could otherwise iterate without ever tripping it. `MAX_SIBLINGS` bounds the
         // per-level scan regardless of how many are skipped (mirrors the Windows reader).
         let mut siblings = 0usize;
         for child in child_els {
+            // Checked before processing each child (not after) so the child that merely
+            // completes the tree doesn't get mistaken for one the walk declined to visit.
+            if budget.nodes_exhausted() {
+                budget.hit(TruncationLimit::Nodes);
+                break;
+            }
             siblings += 1;
             if siblings > MAX_SIBLINGS {
                 budget.hit(TruncationLimit::Siblings);
@@ -318,10 +327,6 @@ fn walk(
             }
             if !should_skip(&child) {
                 children.push(walk(&child, win, scale, depth + 1, budget));
-            }
-            if budget.nodes_exhausted() {
-                budget.hit(TruncationLimit::Nodes);
-                break;
             }
         }
     }
@@ -348,7 +353,9 @@ fn should_skip(el: &AXUIElement) -> bool {
 }
 
 /// Whether this node's children may be explored, recording the bound that stopped the walk
-/// when they may not.
+/// when they may not. Callers only consult this once they already know the child list is
+/// non-empty — calling it for a childless node would record a truncation for declining to
+/// explore a list that was never going to be walked anyway.
 ///
 /// `walk` and `find_nth` MUST consult this one function at the same point in their
 /// traversal. They assign a node's id by arrival order, and `set_value` re-walks to a
@@ -386,11 +393,20 @@ fn find_nth(
         return Some(el);
     }
     budget.visit();
-    if !may_explore_children(budget, depth) {
+    // Resolved before the gate: a childless node must never be reported truncated for
+    // declining to explore a list that was already empty.
+    let child_els = ffi::children(&el).unwrap_or_default();
+    if child_els.is_empty() || !may_explore_children(budget, depth) {
         return None;
     }
     let mut siblings = 0usize;
-    for child in ffi::children(&el).unwrap_or_default() {
+    for child in child_els {
+        // Checked before processing each child (not after) so the child that merely
+        // completes the tree doesn't get mistaken for one the walk declined to visit.
+        if budget.nodes_exhausted() {
+            budget.hit(TruncationLimit::Nodes);
+            break;
+        }
         siblings += 1;
         if siblings > MAX_SIBLINGS {
             budget.hit(TruncationLimit::Siblings);
@@ -400,10 +416,6 @@ fn find_nth(
             if let Some(found) = find_nth(child, depth + 1, budget, target) {
                 return Some(found);
             }
-        }
-        if budget.nodes_exhausted() {
-            budget.hit(TruncationLimit::Nodes);
-            break;
         }
     }
     None

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -307,6 +307,10 @@ fn walk(
         );
         Vec::new()
     });
+    // Gated on the raw `child_els`, not filtered by `should_skip` first. A node whose children
+    // are all skipped, reached once the node/depth budget is spent, still records a truncation
+    // though nothing real was declined. Pre-filtering would mean calling `should_skip` — a live
+    // AX round trip — over the whole list, exactly the scan `MAX_SIBLINGS` below exists to bound.
     if !child_els.is_empty() && may_explore_children(budget, depth) {
         // `MAX_NODES` only counts nodes actually entered, and `should_skip` siblings are
         // skipped without entering, so an all-skipped level (a virtualized list of thousands)
@@ -396,6 +400,10 @@ fn find_nth(
     // Resolved before the gate: a childless node must never be reported truncated for
     // declining to explore a list that was already empty.
     let child_els = ffi::children(&el).unwrap_or_default();
+    // Same gap as `walk`: gated on the raw `child_els`, before `should_skip` runs. A node whose
+    // children are all skipped, reached once the budget is spent, still records a truncation
+    // though nothing real was declined — left as-is for the same reason: pre-filtering means
+    // calling `should_skip` over the whole list, the scan `MAX_SIBLINGS` exists to bound.
     if child_els.is_empty() || !may_explore_children(budget, depth) {
         return None;
     }

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -98,7 +98,7 @@ impl Accessibility for MacosA11y {
         let root = walk(&window_el, &ctx.window, scale, 0, &mut count);
         // Ids/count are assigned by `glass-core` (`AxTree::assign_ids`) so numbering is
         // identical across OS backends.
-        Ok(AxTree { root, count: 0 })
+        Ok(AxTree::new(root))
     }
 
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -95,10 +95,7 @@ fn run_snapshot(ctx: &AxContext) -> Result<AxTree> {
     let origin = (ctx.window.x, ctx.window.y);
     let mut count = 0usize;
     let root_node = walk(&walker, &window, origin, 0, &mut count)?;
-    let mut tree = AxTree {
-        root: root_node,
-        count: 0,
-    };
+    let mut tree = AxTree::new(root_node);
     tree.assign_ids();
     Ok(tree)
 }

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -127,14 +127,23 @@ fn walk(
     let states = crate::mapping::map_states(&facts);
 
     let mut children = Vec::new();
-    if may_explore_children(budget, depth) {
+    // Resolved before the gate: a childless node must never be reported truncated for
+    // declining to explore a list that was already empty.
+    let first_child = walker.get_first_child(el).ok();
+    if first_child.is_some() && may_explore_children(budget, depth) {
         // Offscreen children are skipped without entering, so they never count against
         // `MAX_NODES` — a virtualized list of thousands (or a cyclic `get_next_sibling`
         // chain) would otherwise scan this level forever. `MAX_SIBLINGS` bounds the
         // per-level scan regardless of how many are skipped.
-        let mut child = walker.get_first_child(el).ok();
+        let mut child = first_child;
         let mut siblings = 0usize;
         while let Some(c) = child {
+            // Checked before processing each child (not after) so the child that merely
+            // completes the tree doesn't get mistaken for one the walk declined to visit.
+            if budget.nodes_exhausted() {
+                budget.hit(TruncationLimit::Nodes);
+                break;
+            }
             siblings += 1;
             if siblings > MAX_SIBLINGS {
                 budget.hit(TruncationLimit::Siblings);
@@ -142,10 +151,6 @@ fn walk(
             }
             if !c.is_offscreen().unwrap_or(false) {
                 children.push(walk(walker, &c, origin, depth + 1, budget)?);
-            }
-            if budget.nodes_exhausted() {
-                budget.hit(TruncationLimit::Nodes);
-                break;
             }
             child = walker.get_next_sibling(&c).ok();
         }
@@ -298,7 +303,9 @@ fn run_set_value(ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
 }
 
 /// Whether this node's children may be explored, recording the bound that stopped the walk
-/// when they may not.
+/// when they may not. Callers only consult this once they already know the child list is
+/// non-empty — calling it for a childless node would record a truncation for declining to
+/// explore a list that was never going to be walked anyway.
 ///
 /// `walk` and `find_nth` MUST consult this one function at the same point in their
 /// traversal. They assign a node's id by arrival order, and `set_value` re-walks to a
@@ -333,12 +340,21 @@ fn find_nth(
         return Some(el.clone());
     }
     budget.visit();
-    if !may_explore_children(budget, depth) {
+    // Resolved before the gate: a childless node must never be reported truncated for
+    // declining to explore a list that was already empty.
+    let first_child = walker.get_first_child(el).ok();
+    if first_child.is_none() || !may_explore_children(budget, depth) {
         return None;
     }
-    let mut child = walker.get_first_child(el).ok();
+    let mut child = first_child;
     let mut siblings = 0usize;
     while let Some(c) = child {
+        // Checked before processing each child (not after) so the child that merely
+        // completes the tree doesn't get mistaken for one the walk declined to visit.
+        if budget.nodes_exhausted() {
+            budget.hit(TruncationLimit::Nodes);
+            break;
+        }
         siblings += 1;
         if siblings > MAX_SIBLINGS {
             budget.hit(TruncationLimit::Siblings);
@@ -348,10 +364,6 @@ fn find_nth(
             if let Some(found) = find_nth(walker, &c, depth + 1, budget, target) {
                 return Some(found);
             }
-        }
-        if budget.nodes_exhausted() {
-            budget.hit(TruncationLimit::Nodes);
-            break;
         }
         child = walker.get_next_sibling(&c).ok();
     }

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -130,6 +130,10 @@ fn walk(
     // Resolved before the gate: a childless node must never be reported truncated for
     // declining to explore a list that was already empty.
     let first_child = walker.get_first_child(el).ok();
+    // Tests only whether a first child exists, before `is_offscreen` filters it. A node whose
+    // children are all offscreen, reached once the budget is spent, still records a truncation
+    // though nothing real was declined. Pre-filtering would mean walking the whole
+    // `get_first_child`/`get_next_sibling` chain — the unbounded scan `MAX_SIBLINGS` bounds.
     if first_child.is_some() && may_explore_children(budget, depth) {
         // Offscreen children are skipped without entering, so they never count against
         // `MAX_NODES` — a virtualized list of thousands (or a cyclic `get_next_sibling`
@@ -343,6 +347,10 @@ fn find_nth(
     // Resolved before the gate: a childless node must never be reported truncated for
     // declining to explore a list that was already empty.
     let first_child = walker.get_first_child(el).ok();
+    // Same gap as `walk`: only tests whether a first child exists, before `is_offscreen` runs.
+    // A node whose children are all offscreen, reached once the budget is spent, still records
+    // a truncation though nothing real was declined — left as-is for the same reason: it would
+    // mean walking the whole sibling chain, exactly the scan `MAX_SIBLINGS` exists to bound.
     if first_child.is_none() || !may_explore_children(budget, depth) {
         return None;
     }

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant};
 
 use glass_core::{
     Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget, AxTree, GlassError, Result,
+    TruncationLimit, WalkBudget, MAX_SIBLINGS,
 };
 use uiautomation::patterns::{
     UIExpandCollapsePattern, UIRangeValuePattern, UISelectionItemPattern, UITogglePattern,
@@ -18,16 +19,6 @@ use uiautomation::{UIAutomation, UIElement, UITreeWalker};
 
 /// Hard cap so a hung UIA provider can't block the calling tool forever.
 const SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(10);
-/// Bounds so a pathological tree can't make a snapshot unbounded (tunable; sized on the box).
-const MAX_DEPTH: usize = 30;
-const MAX_NODES: usize = 1500;
-/// Per-level cap on siblings *examined* (on- or off-screen). `MAX_NODES` only counts
-/// nodes entered, and offscreen siblings are skipped without entering — so an
-/// all-offscreen run (a virtualized list of thousands) or a cyclic `get_next_sibling`
-/// would iterate without ever tripping `MAX_NODES`, spinning the worker thread. Cap the
-/// per-level scan so the walk is genuinely bounded regardless of offscreen breadth.
-/// Generous enough not to truncate real UIs; with `MAX_DEPTH` it bounds total work.
-const MAX_SIBLINGS: usize = 4096;
 /// Per-edge tolerance (px) for the set_value bounds-fingerprint check. Window-relative
 /// bounds are stable for a static element across snapshot→set_value (window moves cancel),
 /// so this only absorbs sub-pixel/timing jitter; a different element that drift landed on
@@ -93,9 +84,10 @@ fn run_snapshot(ctx: &AxContext) -> Result<AxTree> {
     let window = find_app_window(&automation, ctx)?;
 
     let origin = (ctx.window.x, ctx.window.y);
-    let mut count = 0usize;
-    let root_node = walk(&walker, &window, origin, 0, &mut count)?;
+    let mut budget = WalkBudget::new();
+    let root_node = walk(&walker, &window, origin, 0, &mut budget)?;
     let mut tree = AxTree::new(root_node);
+    tree.truncated = budget.truncation();
     tree.assign_ids();
     Ok(tree)
 }
@@ -116,15 +108,17 @@ fn find_app_window(automation: &UIAutomation, ctx: &AxContext) -> Result<UIEleme
         .map_err(uia_err)
 }
 
-/// Recursively build a normalized node, bounded by depth + global node count.
+/// Recursively build a normalized node, bounded by [`WalkBudget`] (node count, nesting depth,
+/// and per-level sibling scan) so a pathological tree can't burn the outer [`SNAPSHOT_TIMEOUT`]
+/// with no tree to show for it.
 fn walk(
     walker: &UITreeWalker,
     el: &UIElement,
     origin: (i32, i32),
     depth: usize,
-    count: &mut usize,
+    budget: &mut WalkBudget,
 ) -> Result<AxNode> {
-    *count += 1;
+    budget.visit();
     let ct_id = el.get_control_type().map_err(uia_err)? as i32 as u32;
     let raw_role = el.get_localized_control_type().unwrap_or_default();
     let name = nonempty(el.get_name().unwrap_or_default());
@@ -133,18 +127,24 @@ fn walk(
     let states = crate::mapping::map_states(&facts);
 
     let mut children = Vec::new();
-    if depth < MAX_DEPTH && *count < MAX_NODES {
+    if may_explore_children(budget, depth) {
+        // Offscreen children are skipped without entering, so they never count against
+        // `MAX_NODES` — a virtualized list of thousands (or a cyclic `get_next_sibling`
+        // chain) would otherwise scan this level forever. `MAX_SIBLINGS` bounds the
+        // per-level scan regardless of how many are skipped.
         let mut child = walker.get_first_child(el).ok();
         let mut siblings = 0usize;
         while let Some(c) = child {
             siblings += 1;
             if siblings > MAX_SIBLINGS {
-                break; // bound the per-level scan (offscreen breadth / cyclic sibling chain)
+                budget.hit(TruncationLimit::Siblings);
+                break;
             }
             if !c.is_offscreen().unwrap_or(false) {
-                children.push(walk(walker, &c, origin, depth + 1, count)?);
+                children.push(walk(walker, &c, origin, depth + 1, budget)?);
             }
-            if *count >= MAX_NODES {
+            if budget.nodes_exhausted() {
+                budget.hit(TruncationLimit::Nodes);
                 break;
             }
             child = walker.get_next_sibling(&c).ok();
@@ -255,8 +255,8 @@ fn run_set_value(ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
 
     // Start at 0 so find_nth's pre-order numbering matches snapshot's walk +
     // assign_ids (root id = 0); the role+name verify backstops any drift.
-    let mut count = 0usize;
-    let el = find_nth(&walker, &window, 0, &mut count, target.id.0)
+    let mut budget = WalkBudget::new();
+    let el = find_nth(&walker, &window, 0, &mut budget, target.id.0)
         .ok_or(GlassError::AxElementChanged(target.id.0))?;
 
     // Verify role + name + bounds (guards a stale id / tree drift). role+name
@@ -297,40 +297,63 @@ fn run_set_value(ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
     }
 }
 
-/// Pre-order walk mirroring `walk`'s traversal (offscreen skip + depth/MAX_NODES
-/// bounds) to find the element at pre-order index `target`. A single `count`
-/// serves as both the id (a node's id is `count` at arrival) and the MAX_NODES
-/// bound — identical accounting to `walk`, so ids line up with `assign_ids`.
+/// Whether this node's children may be explored, recording the bound that stopped the walk
+/// when they may not.
+///
+/// `walk` and `find_nth` MUST consult this one function at the same point in their
+/// traversal. They assign a node's id by arrival order, and `set_value` re-walks to a
+/// caller-supplied id — so a bound applied in one traversal but not the other resolves the
+/// id against a different tree and writes to the wrong element. Sharing the decision makes
+/// that divergence impossible to introduce by editing only one of them.
+fn may_explore_children(budget: &mut WalkBudget, depth: usize) -> bool {
+    if budget.depth_exhausted(depth) {
+        budget.hit(TruncationLimit::Depth);
+        return false;
+    }
+    if budget.nodes_exhausted() {
+        budget.hit(TruncationLimit::Nodes);
+        return false;
+    }
+    true
+}
+
+/// Pre-order DFS to the node at index `target`, mirroring `walk` exactly: visit the node (its
+/// id is the arrival count), then recurse each unskipped child in tree-walker order — **and
+/// stopping at the same depth/node/sibling bounds**. The bounds must stay in lockstep with
+/// `walk`: if this traversal visited nodes `walk` skipped, a `set_value` id would resolve
+/// against a different tree and write to the wrong element.
 fn find_nth(
     walker: &UITreeWalker,
     el: &UIElement,
     depth: usize,
-    count: &mut usize,
+    budget: &mut WalkBudget,
     target: u32,
 ) -> Option<UIElement> {
-    let my_id = *count as u32;
-    *count += 1;
-    if my_id == target {
+    if budget.nodes_walked() == target as usize {
         return Some(el.clone());
     }
-    if depth < MAX_DEPTH && *count < MAX_NODES {
-        let mut child = walker.get_first_child(el).ok();
-        let mut siblings = 0usize;
-        while let Some(c) = child {
-            siblings += 1;
-            if siblings > MAX_SIBLINGS {
-                break; // same per-level bound as walk(), so find_nth can't spin either
-            }
-            if !c.is_offscreen().unwrap_or(false) {
-                if let Some(found) = find_nth(walker, &c, depth + 1, count, target) {
-                    return Some(found);
-                }
-            }
-            if *count >= MAX_NODES {
-                break;
-            }
-            child = walker.get_next_sibling(&c).ok();
+    budget.visit();
+    if !may_explore_children(budget, depth) {
+        return None;
+    }
+    let mut child = walker.get_first_child(el).ok();
+    let mut siblings = 0usize;
+    while let Some(c) = child {
+        siblings += 1;
+        if siblings > MAX_SIBLINGS {
+            budget.hit(TruncationLimit::Siblings);
+            break; // same per-level bound as walk(), so find_nth can't spin either
         }
+        if !c.is_offscreen().unwrap_or(false) {
+            if let Some(found) = find_nth(walker, &c, depth + 1, budget, target) {
+                return Some(found);
+            }
+        }
+        if budget.nodes_exhausted() {
+            budget.hit(TruncationLimit::Nodes);
+            break;
+        }
+        child = walker.get_next_sibling(&c).ok();
     }
     None
 }
@@ -367,7 +390,51 @@ fn read_back_confirms(read_back: Option<&str>, before: Option<&str>, requested: 
 
 #[cfg(test)]
 mod tests {
-    use super::{read_back_confirms, set_value_took};
+    use super::*;
+    use glass_core::{MAX_DEPTH, MAX_NODES};
+
+    #[test]
+    fn below_the_caps_children_may_be_explored_and_nothing_is_recorded() {
+        let mut budget = WalkBudget::new();
+        assert!(may_explore_children(&mut budget, 0));
+        assert!(budget.truncation().is_none());
+    }
+
+    #[test]
+    fn at_max_depth_the_depth_bound_is_recorded_and_children_may_not_be_explored() {
+        let mut budget = WalkBudget::new();
+        assert!(!may_explore_children(&mut budget, MAX_DEPTH));
+        assert_eq!(
+            budget.truncation().map(|t| t.limit),
+            Some(TruncationLimit::Depth)
+        );
+    }
+
+    #[test]
+    fn with_the_node_budget_spent_the_nodes_bound_is_recorded_and_children_may_not_be_explored() {
+        let mut budget = WalkBudget::new();
+        for _ in 0..MAX_NODES {
+            budget.visit();
+        }
+        assert!(!may_explore_children(&mut budget, 0));
+        assert_eq!(
+            budget.truncation().map(|t| t.limit),
+            Some(TruncationLimit::Nodes)
+        );
+    }
+
+    #[test]
+    fn when_both_bounds_are_exhausted_the_recorded_limit_is_depth() {
+        let mut budget = WalkBudget::new();
+        for _ in 0..MAX_NODES {
+            budget.visit();
+        }
+        assert!(!may_explore_children(&mut budget, MAX_DEPTH));
+        assert_eq!(
+            budget.truncation().map(|t| t.limit),
+            Some(TruncationLimit::Depth)
+        );
+    }
 
     #[test]
     fn noop_is_not_taken() {

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -164,7 +164,7 @@ mod tests {
             bounds,
             children: vec![],
         };
-        let mut t = AxTree { root, count: 0 };
+        let mut t = AxTree::new(root);
         t.assign_ids();
         t
     }

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -90,11 +90,7 @@ fn json_to_node(v: &Value, win: &WindowGeometry) -> Result<AxNode> {
 
 /// Build the `AxTree` from a device `tree` response value (the `"tree"` object).
 pub(crate) fn tree_from_json(tree: &Value, win: &WindowGeometry) -> Result<AxTree> {
-    // count stays 0 until the caller runs AxTree::assign_ids (per the Accessibility trait contract).
-    Ok(AxTree {
-        root: json_to_node(tree, win)?,
-        count: 0,
-    })
+    Ok(AxTree::new(json_to_node(tree, win)?))
 }
 
 /// Line-JSON client to the on-device a11y service (mirrors `AgentClient`).

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -58,30 +58,35 @@ fn json_to_node(
     let flag = |k: &str| v.get(k).and_then(Value::as_bool).unwrap_or(false);
     // Recursion is bounded by `budget` (depth, node count, siblings per level), so a
     // pathologically deep or wide device tree cannot blow the stack or the token budget.
-    let children = if budget.depth_exhausted(depth) {
-        budget.hit(TruncationLimit::Depth);
-        vec![]
-    } else if budget.nodes_exhausted() {
-        budget.hit(TruncationLimit::Nodes);
-        vec![]
-    } else {
-        match v.get("children").and_then(Value::as_array) {
-            Some(arr) => {
-                let mut out = Vec::new();
-                for (i, c) in arr.iter().enumerate() {
-                    if i >= MAX_SIBLINGS {
-                        budget.hit(TruncationLimit::Siblings);
-                        break;
-                    }
-                    out.push(json_to_node(c, win, depth + 1, budget)?);
-                    if budget.nodes_exhausted() {
-                        budget.hit(TruncationLimit::Nodes);
-                        break;
-                    }
+    // The child array is resolved before either bound is consulted: a childless node must
+    // never be reported truncated for declining to explore a list that was already empty.
+    let children = match v.get("children").and_then(Value::as_array) {
+        None => vec![],
+        Some(arr) if arr.is_empty() => vec![],
+        Some(_) if budget.depth_exhausted(depth) => {
+            budget.hit(TruncationLimit::Depth);
+            vec![]
+        }
+        Some(_) if budget.nodes_exhausted() => {
+            budget.hit(TruncationLimit::Nodes);
+            vec![]
+        }
+        Some(arr) => {
+            let mut out = Vec::new();
+            for (i, c) in arr.iter().enumerate() {
+                // Checked before processing each child (not after) so the child that merely
+                // completes the tree doesn't get mistaken for one the walk declined to visit.
+                if budget.nodes_exhausted() {
+                    budget.hit(TruncationLimit::Nodes);
+                    break;
                 }
-                out
+                if i >= MAX_SIBLINGS {
+                    budget.hit(TruncationLimit::Siblings);
+                    break;
+                }
+                out.push(json_to_node(c, win, depth + 1, budget)?);
             }
-            None => vec![],
+            out
         }
     };
     Ok(AxNode {
@@ -547,6 +552,48 @@ mod tests {
         // child must still carry the name matching its own id-derived index.
         let third = tree.find(AxNodeId(3)).expect("id 3 survives");
         assert_eq!(third.name.as_deref(), Some("btn2"));
+    }
+
+    #[test]
+    fn a_complete_tree_of_exactly_max_nodes_reports_no_truncation() {
+        // `tree_from_json` walks the device root itself (no synthetic wrapper), so root (1) +
+        // MAX_NODES-1 flat children = MAX_NODES nodes walked in total, and the LAST child is
+        // what pushes the running count to MAX_NODES. Nothing was declined, so this must NOT
+        // be reported truncated (regression for the false-positive-at-the-cap bug).
+        let json = wide_device_json(glass_core::MAX_NODES - 1);
+        let mut tree = tree_from_json(&json, &win()).expect("tree parses");
+        tree.assign_ids();
+        assert_eq!(tree.count, glass_core::MAX_NODES);
+        assert_eq!(tree.truncated, None);
+    }
+
+    #[test]
+    fn a_tree_of_max_nodes_plus_one_still_reports_nodes_truncation() {
+        // One more child than the complete case above: now there really is a node the walk
+        // declines to visit, so the cap must still fire — proving the fix didn't just
+        // disable it.
+        let json = wide_device_json(glass_core::MAX_NODES);
+        let tree = tree_from_json(&json, &win()).expect("tree parses");
+        assert_eq!(
+            tree.truncated.map(|t| t.limit),
+            Some(TruncationLimit::Nodes)
+        );
+    }
+
+    #[test]
+    fn a_childless_node_at_the_spent_node_budget_records_no_truncation() {
+        // A leaf with no "children" key, reached once the node budget is already spent, must
+        // not be reported truncated merely for declining to explore an empty list.
+        let leaf = json!({
+            "class": "android.widget.TextView",
+            "bounds": {"x": 0, "y": 0, "w": 10, "h": 10}
+        });
+        let mut budget = WalkBudget::new();
+        for _ in 0..glass_core::MAX_NODES {
+            budget.visit();
+        }
+        let _ = json_to_node(&leaf, &win(), 0, &mut budget).unwrap();
+        assert!(budget.truncation().is_none());
     }
 
     #[test]

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -8,6 +8,7 @@ use serde_json::{json, Value};
 
 use glass_core::accessibility::{
     Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxStates, AxTarget, AxTree,
+    TruncationLimit, WalkBudget, MAX_SIBLINGS,
 };
 use glass_core::platform::WindowGeometry;
 use glass_core::{GlassError, Result};
@@ -25,7 +26,13 @@ use crate::conn::Conn;
 /// reordering — a node with malformed/missing bounds errors the whole snapshot rather than being
 /// dropped (which would shift every later id). So `set_value` can send `target.id.0` as the device
 /// `ref` and hit the right node. Keep both walks pre-order if either side changes.
-fn json_to_node(v: &Value, win: &WindowGeometry) -> Result<AxNode> {
+fn json_to_node(
+    v: &Value,
+    win: &WindowGeometry,
+    depth: usize,
+    budget: &mut WalkBudget,
+) -> Result<AxNode> {
+    budget.visit();
     let cls = v.get("class").and_then(Value::as_str).unwrap_or("");
     let text = v.get("text").and_then(Value::as_str);
     let desc = v.get("desc").and_then(Value::as_str);
@@ -49,13 +56,33 @@ fn json_to_node(v: &Value, win: &WindowGeometry) -> Result<AxNode> {
     };
     let (x, y, w, h) = (bi("x"), bi("y"), bu("w"), bu("h"));
     let flag = |k: &str| v.get(k).and_then(Value::as_bool).unwrap_or(false);
-    // Recursion depth = a11y tree depth (shallow in practice; not hardened against adversarial nesting).
-    let children = match v.get("children").and_then(Value::as_array) {
-        Some(arr) => arr
-            .iter()
-            .map(|c| json_to_node(c, win))
-            .collect::<Result<Vec<_>>>()?,
-        None => vec![],
+    // Recursion is bounded by `budget` (depth, node count, siblings per level), so a
+    // pathologically deep or wide device tree cannot blow the stack or the token budget.
+    let children = if budget.depth_exhausted(depth) {
+        budget.hit(TruncationLimit::Depth);
+        vec![]
+    } else if budget.nodes_exhausted() {
+        budget.hit(TruncationLimit::Nodes);
+        vec![]
+    } else {
+        match v.get("children").and_then(Value::as_array) {
+            Some(arr) => {
+                let mut out = Vec::new();
+                for (i, c) in arr.iter().enumerate() {
+                    if i >= MAX_SIBLINGS {
+                        budget.hit(TruncationLimit::Siblings);
+                        break;
+                    }
+                    out.push(json_to_node(c, win, depth + 1, budget)?);
+                    if budget.nodes_exhausted() {
+                        budget.hit(TruncationLimit::Nodes);
+                        break;
+                    }
+                }
+                out
+            }
+            None => vec![],
+        }
     };
     Ok(AxNode {
         id: AxNodeId(0),
@@ -90,7 +117,11 @@ fn json_to_node(v: &Value, win: &WindowGeometry) -> Result<AxNode> {
 
 /// Build the `AxTree` from a device `tree` response value (the `"tree"` object).
 pub(crate) fn tree_from_json(tree: &Value, win: &WindowGeometry) -> Result<AxTree> {
-    Ok(AxTree::new(json_to_node(tree, win)?))
+    let mut budget = WalkBudget::new();
+    let root = json_to_node(tree, win, 0, &mut budget)?;
+    let mut tree = AxTree::new(root);
+    tree.truncated = budget.truncation();
+    Ok(tree)
 }
 
 /// Line-JSON client to the on-device a11y service (mirrors `AgentClient`).
@@ -467,7 +498,7 @@ mod tests {
             "class": "android.widget.CheckBox", "bounds": {"x": 0, "y": 100, "w": 10, "h": 10},
             "checkable": true, "checked": true
         });
-        let n = json_to_node(&on, &win()).unwrap();
+        let n = json_to_node(&on, &win(), 0, &mut WalkBudget::new()).unwrap();
         assert!(
             n.states.checkable && n.states.checked,
             "on checkbox → checkable + checked"
@@ -475,11 +506,47 @@ mod tests {
         let plain = json!({
             "class": "android.widget.TextView", "bounds": {"x": 0, "y": 100, "w": 10, "h": 10}
         });
-        let p = json_to_node(&plain, &win()).unwrap();
+        let p = json_to_node(&plain, &win(), 0, &mut WalkBudget::new()).unwrap();
         assert!(
             !p.states.checkable && !p.states.checked,
             "a node with no checkable/checked keys stays false"
         );
+    }
+
+    /// Device JSON for a root with `n` flat children, each a distinctly-named Button.
+    fn wide_device_json(n: usize) -> Value {
+        let kids: Vec<Value> = (0..n)
+            .map(|i| {
+                json!({
+                    "class": "android.widget.Button",
+                    "text": format!("btn{i}"),
+                    "bounds": {"x": 0, "y": i, "w": 10, "h": 10},
+                    "children": []
+                })
+            })
+            .collect();
+        json!({
+            "class": "android.widget.FrameLayout",
+            "bounds": {"x": 0, "y": 0, "w": 100, "h": 100},
+            "children": kids
+        })
+    }
+
+    #[test]
+    fn truncation_stops_the_walk_and_never_shifts_surviving_ids() {
+        // The device numbers refs in pre-order over the SAME node set. If truncation dropped
+        // nodes from the middle instead of stopping at the end, every later id would shift and
+        // set_value would write to the wrong element.
+        let json = wide_device_json(glass_core::MAX_NODES + 50);
+        let mut tree = tree_from_json(&json, &win()).expect("tree parses");
+        tree.assign_ids();
+
+        assert!(tree.truncated.is_some(), "the node cap must have been hit");
+        // `tree_from_json` maps the device root directly (no synthetic wrapper), so the
+        // FrameLayout itself is id 0 and child at array index i is id i+1 — every surviving
+        // child must still carry the name matching its own id-derived index.
+        let third = tree.find(AxNodeId(3)).expect("id 3 survives");
+        assert_eq!(third.name.as_deref(), Some("btn2"));
     }
 
     #[test]

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -1,6 +1,8 @@
 //! Pure mapping from `uiautomator dump` XML into glass's normalized `AxTree`.
 
-use glass_core::accessibility::{AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTree};
+use glass_core::accessibility::{
+    AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTree, TruncationLimit, WalkBudget, MAX_SIBLINGS,
+};
 use glass_core::{GlassError, Result, WindowGeometry};
 
 /// Map an Android widget class (`android.widget.Button`, …) to a normalized role.
@@ -78,11 +80,23 @@ pub fn build_tree(xml: &str, window: &WindowGeometry) -> Result<AxTree> {
             "uiautomator XML has no <hierarchy> root".into(),
         ));
     }
-    let children = hierarchy
+    let mut budget = WalkBudget::new();
+    let mut children = Vec::new();
+    for (i, n) in hierarchy
         .children()
         .filter(|n| n.is_element() && n.tag_name().name() == "node")
-        .map(|n| map_node(n, window))
-        .collect();
+        .enumerate()
+    {
+        if i >= MAX_SIBLINGS {
+            budget.hit(TruncationLimit::Siblings);
+            break;
+        }
+        children.push(map_node(n, window, 0, &mut budget));
+        if budget.nodes_exhausted() {
+            budget.hit(TruncationLimit::Nodes);
+            break;
+        }
+    }
     let root = AxNode {
         id: AxNodeId(0),
         role: AxRole::Window,
@@ -98,10 +112,18 @@ pub fn build_tree(xml: &str, window: &WindowGeometry) -> Result<AxTree> {
         }),
         children,
     };
-    Ok(AxTree::new(root))
+    let mut tree = AxTree::new(root);
+    tree.truncated = budget.truncation();
+    Ok(tree)
 }
 
-fn map_node(node: roxmltree::Node, window: &WindowGeometry) -> AxNode {
+fn map_node(
+    node: roxmltree::Node,
+    window: &WindowGeometry,
+    depth: usize,
+    budget: &mut WalkBudget,
+) -> AxNode {
+    budget.visit();
     let attr = |k: &str| node.attribute(k).unwrap_or("");
     let boolean = |k: &str| node.attribute(k) == Some("true");
     let class = attr("class");
@@ -127,11 +149,33 @@ fn map_node(node: roxmltree::Node, window: &WindowGeometry) -> AxNode {
         expanded: false,
         editable,
     };
-    let children = node
-        .children()
-        .filter(|n| n.is_element() && n.tag_name().name() == "node")
-        .map(|n| map_node(n, window))
-        .collect();
+    // Recursion is bounded by `budget` (depth, node count, siblings per level), so a
+    // pathologically deep or wide device tree cannot blow the stack or the token budget.
+    let children = if budget.depth_exhausted(depth) {
+        budget.hit(TruncationLimit::Depth);
+        vec![]
+    } else if budget.nodes_exhausted() {
+        budget.hit(TruncationLimit::Nodes);
+        vec![]
+    } else {
+        let mut out = Vec::new();
+        for (i, n) in node
+            .children()
+            .filter(|n| n.is_element() && n.tag_name().name() == "node")
+            .enumerate()
+        {
+            if i >= MAX_SIBLINGS {
+                budget.hit(TruncationLimit::Siblings);
+                break;
+            }
+            out.push(map_node(n, window, depth + 1, budget));
+            if budget.nodes_exhausted() {
+                budget.hit(TruncationLimit::Nodes);
+                break;
+            }
+        }
+        out
+    };
     AxNode {
         id: AxNodeId(0),
         role,
@@ -241,6 +285,35 @@ mod tests {
             (AxRole::Button, Some("Save"))
         );
         assert_eq!(kids[2].bounds.unwrap().width, 1000);
+    }
+
+    /// A `<hierarchy>` with `n` flat top-level `<node>` elements, each a distinctly-named Button.
+    fn wide_hierarchy_xml(n: usize) -> String {
+        let mut kids = String::new();
+        for i in 0..n {
+            let top = i;
+            let bottom = i + 10;
+            kids.push_str(&format!(
+                r#"<node text="btn{i}" class="android.widget.Button" bounds="[0,{top}][10,{bottom}]" />"#
+            ));
+        }
+        format!(r#"<?xml version='1.0'?><hierarchy rotation="0">{kids}</hierarchy>"#)
+    }
+
+    #[test]
+    fn truncation_stops_the_walk_and_never_shifts_surviving_ids() {
+        // ids are assigned in the same pre-order the tree is walked, so a truncation that
+        // dropped a node from the middle rather than stopping at the end would shift every
+        // later id off the node its own index implies.
+        let xml = wide_hierarchy_xml(glass_core::MAX_NODES + 50);
+        let mut tree = build_tree(&xml, &win()).unwrap();
+        tree.assign_ids();
+
+        assert!(tree.truncated.is_some(), "the node cap must have been hit");
+        // The synthetic Window root is id 0 (never counted against the budget); top-level
+        // child at array index i is id i+1.
+        let third = tree.find(AxNodeId(3)).expect("id 3 survives");
+        assert_eq!(third.name.as_deref(), Some("btn2"));
     }
 
     #[test]

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -98,7 +98,7 @@ pub fn build_tree(xml: &str, window: &WindowGeometry) -> Result<AxTree> {
         }),
         children,
     };
-    Ok(AxTree { root, count: 0 })
+    Ok(AxTree::new(root))
 }
 
 fn map_node(node: roxmltree::Node, window: &WindowGeometry) -> AxNode {

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -87,15 +87,18 @@ pub fn build_tree(xml: &str, window: &WindowGeometry) -> Result<AxTree> {
         .filter(|n| n.is_element() && n.tag_name().name() == "node")
         .enumerate()
     {
+        // Checked before processing each child (not after) so a child that merely
+        // completes the tree — the last one, pushing the count to MAX_NODES — doesn't
+        // get mistaken for a child the walk declined to visit.
+        if budget.nodes_exhausted() {
+            budget.hit(TruncationLimit::Nodes);
+            break;
+        }
         if i >= MAX_SIBLINGS {
             budget.hit(TruncationLimit::Siblings);
             break;
         }
         children.push(map_node(n, window, 0, &mut budget));
-        if budget.nodes_exhausted() {
-            budget.hit(TruncationLimit::Nodes);
-            break;
-        }
     }
     let root = AxNode {
         id: AxNodeId(0),
@@ -151,7 +154,15 @@ fn map_node(
     };
     // Recursion is bounded by `budget` (depth, node count, siblings per level), so a
     // pathologically deep or wide device tree cannot blow the stack or the token budget.
-    let children = if budget.depth_exhausted(depth) {
+    // The child list is resolved before either bound is consulted: a childless node must
+    // never be reported truncated for declining to explore a list that was already empty.
+    let child_nodes: Vec<roxmltree::Node> = node
+        .children()
+        .filter(|n| n.is_element() && n.tag_name().name() == "node")
+        .collect();
+    let children = if child_nodes.is_empty() {
+        vec![]
+    } else if budget.depth_exhausted(depth) {
         budget.hit(TruncationLimit::Depth);
         vec![]
     } else if budget.nodes_exhausted() {
@@ -159,20 +170,18 @@ fn map_node(
         vec![]
     } else {
         let mut out = Vec::new();
-        for (i, n) in node
-            .children()
-            .filter(|n| n.is_element() && n.tag_name().name() == "node")
-            .enumerate()
-        {
+        for (i, n) in child_nodes.into_iter().enumerate() {
+            // Checked before processing each child (not after) so the child that merely
+            // completes the tree doesn't get mistaken for one the walk declined to visit.
+            if budget.nodes_exhausted() {
+                budget.hit(TruncationLimit::Nodes);
+                break;
+            }
             if i >= MAX_SIBLINGS {
                 budget.hit(TruncationLimit::Siblings);
                 break;
             }
             out.push(map_node(n, window, depth + 1, budget));
-            if budget.nodes_exhausted() {
-                budget.hit(TruncationLimit::Nodes);
-                break;
-            }
         }
         out
     };
@@ -314,6 +323,45 @@ mod tests {
         // child at array index i is id i+1.
         let third = tree.find(AxNodeId(3)).expect("id 3 survives");
         assert_eq!(third.name.as_deref(), Some("btn2"));
+    }
+
+    #[test]
+    fn a_complete_tree_of_exactly_max_nodes_reports_no_truncation() {
+        // MAX_NODES flat top-level nodes: the walk visits every one of them, and the LAST
+        // one is what pushes the running count to MAX_NODES. Nothing was declined, so this
+        // must NOT be reported truncated (regression for the false-positive-at-the-cap bug).
+        let xml = wide_hierarchy_xml(glass_core::MAX_NODES);
+        let tree = build_tree(&xml, &win()).unwrap();
+        assert_eq!(tree.truncated, None);
+    }
+
+    #[test]
+    fn a_tree_of_max_nodes_plus_one_still_reports_nodes_truncation() {
+        // One more node than the complete case above: now there really is a node the walk
+        // declines to visit, so the cap must still fire — proving the fix didn't just
+        // disable it.
+        let xml = wide_hierarchy_xml(glass_core::MAX_NODES + 1);
+        let tree = build_tree(&xml, &win()).unwrap();
+        assert_eq!(
+            tree.truncated.map(|t| t.limit),
+            Some(TruncationLimit::Nodes)
+        );
+    }
+
+    #[test]
+    fn a_childless_node_at_the_spent_node_budget_records_no_truncation() {
+        // A leaf with no <node> children, reached once the node budget is already spent,
+        // must not be reported truncated merely for declining to explore an empty list.
+        let doc = roxmltree::Document::parse(
+            r#"<?xml version='1.0'?><node class="android.widget.TextView" text="leaf" bounds="[0,0][10,10]" />"#,
+        )
+        .unwrap();
+        let mut budget = WalkBudget::new();
+        for _ in 0..glass_core::MAX_NODES {
+            budget.visit();
+        }
+        let _ = map_node(doc.root_element(), &win(), 0, &mut budget);
+        assert!(budget.truncation().is_none());
     }
 
     #[test]

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -439,19 +439,7 @@ impl AxTree {
     /// elided when absent. Two spaces of indent per depth level.
     pub fn to_outline(&self) -> String {
         fn walk(node: &AxNode, depth: usize, out: &mut String) {
-            let indent = "  ".repeat(depth);
-            let _ = write!(out, "{indent}#{} {:?}", node.id.0, node.role);
-            if let Some(name) = &node.name {
-                let _ = write!(out, " {name:?}");
-            }
-            if let Some(b) = &node.bounds {
-                let _ = write!(out, " ({},{} {}x{})", b.x, b.y, b.width, b.height);
-            }
-            let states = node.states.active();
-            if !states.is_empty() {
-                let _ = write!(out, " [{}]", states.join(","));
-            }
-            out.push('\n');
+            crate::outline::write_line(node, depth, out);
             for child in &node.children {
                 walk(child, depth + 1, out);
             }

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -274,15 +274,140 @@ pub struct AxNode {
     pub children: Vec<AxNode>,
 }
 
+/// Bounds on how much of an app's accessibility tree a backend walks. Shared by every OS
+/// backend so a tree's size limits never depend on which platform produced it.
+///
+/// `MAX_NODES` bounds the whole tree; `MAX_DEPTH` bounds nesting; `MAX_SIBLINGS` bounds the
+/// per-level scan, because `MAX_NODES` only counts nodes actually *kept* — a level with a
+/// pathological number of skipped siblings would otherwise iterate without ever tripping it.
+pub const MAX_NODES: usize = 1500;
+/// See [`MAX_NODES`].
+pub const MAX_DEPTH: usize = 30;
+/// See [`MAX_NODES`].
+pub const MAX_SIBLINGS: usize = 4096;
+
+/// Which bound stopped a walk early.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TruncationLimit {
+    Nodes,
+    Depth,
+    Siblings,
+}
+
+impl TruncationLimit {
+    /// The limit's numeric value, for the disclosure notice.
+    pub fn value(self) -> usize {
+        match self {
+            TruncationLimit::Nodes => MAX_NODES,
+            TruncationLimit::Depth => MAX_DEPTH,
+            TruncationLimit::Siblings => MAX_SIBLINGS,
+        }
+    }
+
+    /// Human-readable unit for the disclosure notice.
+    fn label(self) -> &'static str {
+        match self {
+            TruncationLimit::Nodes => "nodes",
+            TruncationLimit::Depth => "levels deep",
+            TruncationLimit::Siblings => "siblings per level",
+        }
+    }
+}
+
+/// Record of a walk that stopped early. Its presence on an [`AxTree`] means elements are
+/// missing from the tree — and therefore cannot be addressed by id.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Truncation {
+    pub limit: TruncationLimit,
+    pub nodes_walked: usize,
+}
+
+impl Truncation {
+    /// The disclosure appended to every rendered outline. Says plainly that elements are
+    /// missing and names the pixel fallback — the same shape as [`AxTree::empty_guidance`],
+    /// because a truncated tree fails the agent the same way a treeless one does.
+    pub fn notice(&self) -> String {
+        format!(
+            "… tree truncated at {} {} ({} nodes walked). Some elements are NOT shown and \
+             cannot be addressed by id. Narrow the UI, or drive by pixels: glass_screenshot, \
+             then glass_click at x,y.",
+            self.limit.value(),
+            self.limit.label(),
+            self.nodes_walked,
+        )
+    }
+}
+
+/// Bookkeeping for a bounded pre-order walk. Every backend threads one of these through its
+/// traversal so the caps and the truncation record are computed one way rather than five.
+#[derive(Debug, Default)]
+pub struct WalkBudget {
+    count: usize,
+    truncated: Option<Truncation>,
+}
+
+impl WalkBudget {
+    pub fn new() -> WalkBudget {
+        WalkBudget::default()
+    }
+
+    /// Count a visited node. Call exactly once on entry to each node, before its children.
+    pub fn visit(&mut self) {
+        self.count += 1;
+    }
+
+    pub fn nodes_walked(&self) -> usize {
+        self.count
+    }
+
+    /// Whether the node budget is spent.
+    pub fn nodes_exhausted(&self) -> bool {
+        self.count >= MAX_NODES
+    }
+
+    /// Whether `depth` has reached the nesting bound (so children must not be walked).
+    pub fn depth_exhausted(&self, depth: usize) -> bool {
+        depth >= MAX_DEPTH
+    }
+
+    /// Record that a bound stopped the walk. Only the FIRST hit is kept: it is the cause,
+    /// while any later hit is a consequence of having continued.
+    pub fn hit(&mut self, limit: TruncationLimit) {
+        let nodes_walked = self.count;
+        self.truncated.get_or_insert(Truncation {
+            limit,
+            nodes_walked,
+        });
+    }
+
+    /// The recorded truncation, or `None` when the walk completed.
+    pub fn truncation(&self) -> Option<Truncation> {
+        self.truncated
+    }
+}
+
 /// The active window's accessibility subtree.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AxTree {
     pub root: AxNode,
     /// Total node count; set by [`AxTree::assign_ids`].
     pub count: usize,
+    /// `Some` when the backend stopped walking early — see [`Truncation`]. `None` means the
+    /// tree is complete.
+    pub truncated: Option<Truncation>,
 }
 
 impl AxTree {
+    /// A complete (non-truncated) tree. Callers still run [`AxTree::assign_ids`]. A backend
+    /// that stopped early sets [`AxTree::truncated`] afterward.
+    pub fn new(root: AxNode) -> AxTree {
+        AxTree {
+            root,
+            count: 0,
+            truncated: None,
+        }
+    }
+
     /// Number nodes in pre-order DFS (`root = 0`) and set `count`. Backends leave
     /// ids unset; the core assigns them so numbering is identical across OSes.
     pub fn assign_ids(&mut self) {
@@ -333,6 +458,12 @@ impl AxTree {
         }
         let mut out = String::new();
         walk(&self.root, 0, &mut out);
+        // Truncation is a fact about the tree, not a rendering style, so BOTH renderers
+        // disclose it. A capped tree that rendered as complete would read as "the element
+        // does not exist" — the silent fallback this field exists to prevent.
+        if let Some(t) = self.truncated {
+            let _ = writeln!(out, "{}", t.notice());
+        }
         out
     }
 
@@ -905,10 +1036,7 @@ mod tests {
     #[test]
     fn empty_guidance_flags_a_treeless_snapshot() {
         // Only the window root, no children → nothing to address → steer to pixels.
-        let empty = AxTree {
-            root: leaf(AxRole::Window, "App"),
-            count: 0,
-        };
+        let empty = AxTree::new(leaf(AxRole::Window, "App"));
         let hint = empty
             .empty_guidance()
             .expect("a root-only tree must yield guidance");
@@ -948,7 +1076,7 @@ mod tests {
             }),
             children: vec![button, leaf(AxRole::Label, "Ready")],
         };
-        AxTree { root, count: 0 }
+        AxTree::new(root)
     }
 
     #[test]
@@ -1100,7 +1228,7 @@ mod tests {
             bounds: None,
             children: vec![clickable, inert],
         };
-        let t = AxTree { root, count: 0 };
+        let t = AxTree::new(root);
         assert!(
             matches!(
                 element_match(&t, Some("Submit"), Some(AxRole::Button), None, ElementCondition::Appears),
@@ -1152,7 +1280,7 @@ mod tests {
             bounds: None,
             children: vec![container],
         };
-        let t = AxTree { root, count: 0 };
+        let t = AxTree::new(root);
         assert!(
             matches!(
                 element_match(
@@ -1306,5 +1434,73 @@ mod tests {
             !checked_but_not_checkable.active().contains(&"checked")
                 && !checked_but_not_checkable.active().contains(&"unchecked")
         );
+    }
+
+    #[test]
+    fn walk_budget_records_the_first_limit_hit_not_the_last() {
+        // The FIRST bound is the cause; a later one is a consequence of continuing to walk.
+        let mut b = WalkBudget::new();
+        b.visit();
+        b.hit(TruncationLimit::Depth);
+        b.hit(TruncationLimit::Nodes);
+        assert_eq!(
+            b.truncation().map(|t| t.limit),
+            Some(TruncationLimit::Depth)
+        );
+    }
+
+    #[test]
+    fn walk_budget_reports_no_truncation_when_no_limit_was_hit() {
+        let mut b = WalkBudget::new();
+        b.visit();
+        assert_eq!(b.truncation(), None);
+    }
+
+    #[test]
+    fn walk_budget_nodes_exhausted_flips_at_the_node_cap() {
+        let mut b = WalkBudget::new();
+        for _ in 0..MAX_NODES - 1 {
+            b.visit();
+        }
+        assert!(!b.nodes_exhausted(), "one visit short of the cap");
+    }
+
+    #[test]
+    fn truncation_notice_states_elements_are_missing_and_names_the_pixel_fallback() {
+        let n = Truncation {
+            limit: TruncationLimit::Nodes,
+            nodes_walked: 1500,
+        }
+        .notice();
+        assert!(
+            n.contains("NOT shown") && n.contains("glass_screenshot"),
+            "notice must be unmissable and steer to pixels: {n}"
+        );
+    }
+
+    #[test]
+    fn outline_appends_the_truncation_notice_when_the_walk_stopped_early() {
+        let mut t = sample_tree();
+        t.assign_ids();
+        t.truncated = Some(Truncation {
+            limit: TruncationLimit::Depth,
+            nodes_walked: 42,
+        });
+        assert!(
+            t.to_outline().contains("truncated"),
+            "a truncated tree must never render as if complete"
+        );
+    }
+
+    #[test]
+    fn outline_appends_nothing_when_the_tree_is_complete() {
+        let mut t = sample_tree();
+        t.assign_ids();
+        assert!(!t.to_outline().contains("truncated"));
+    }
+
+    #[test]
+    fn new_builds_a_complete_tree() {
+        assert_eq!(AxTree::new(leaf(AxRole::Window, "App")).truncated, None);
     }
 }

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -6,8 +6,6 @@
 //! `glass-a11y-linux`) map their native roles/states into the normalized types
 //! here; no OS/AT-SPI/D-Bus types appear in this module.
 
-use std::fmt::Write as _;
-
 use crate::error::Result;
 use crate::platform::{Segment, WindowGeometry};
 
@@ -295,8 +293,9 @@ pub enum TruncationLimit {
 }
 
 impl TruncationLimit {
-    /// The limit's numeric value, for the disclosure notice.
-    pub fn value(self) -> usize {
+    /// The limit's numeric value, for the disclosure notice. Private: the only caller is
+    /// [`Truncation::notice`] in this module; nothing outside needs the raw number.
+    fn value(self) -> usize {
         match self {
             TruncationLimit::Nodes => MAX_NODES,
             TruncationLimit::Depth => MAX_DEPTH,
@@ -437,6 +436,12 @@ impl AxTree {
     /// Render a compact indented outline, one line per node:
     /// `#<id> <Role> "<name>" (<x>,<y> <w>x<h>) [<states>]` — name/bounds/states
     /// elided when absent. Two spaces of indent per depth level.
+    ///
+    /// Pure tree text — no truncation notice is appended here. Keeping this render pure
+    /// means `scroll_to_element`'s saturation check (which diffs consecutive `to_outline`
+    /// strings) can't be perturbed by a truncation-status flip that has nothing to do with
+    /// scrolling, and it keeps the notice out of the untrusted envelope the caller wraps
+    /// this text in at the MCP boundary. See [`Self::truncation_notice`].
     pub fn to_outline(&self) -> String {
         fn walk(node: &AxNode, depth: usize, out: &mut String) {
             crate::outline::write_line(node, depth, out);
@@ -446,13 +451,14 @@ impl AxTree {
         }
         let mut out = String::new();
         walk(&self.root, 0, &mut out);
-        // Truncation is a fact about the tree, not a rendering style, so it is disclosed
-        // wherever the tree is rendered. A capped tree that rendered as complete would read
-        // as "the element does not exist" — the silent fallback this field exists to prevent.
-        if let Some(t) = self.truncated {
-            let _ = writeln!(out, "{}", t.notice());
-        }
         out
+    }
+
+    /// The trusted truncation steer for the MCP boundary to surface as its own content
+    /// block — NOT baked into a render, so it is never buried inside the untrusted-content
+    /// envelope the app-derived outline is wrapped in. `None` when the tree is complete.
+    pub fn truncation_notice(&self) -> Option<String> {
+        self.truncated.map(|t| t.notice())
     }
 
     /// Guidance to surface when a snapshot exposes nothing to address — only the window
@@ -1472,24 +1478,26 @@ mod tests {
     }
 
     #[test]
-    fn outline_appends_the_truncation_notice_when_the_walk_stopped_early() {
+    fn truncation_notice_is_some_when_the_walk_stopped_early() {
+        // `to_outline` itself stays pure tree text (see its doc comment); the truncation
+        // fact is surfaced separately via `truncation_notice` so a caller can never render
+        // a truncated tree as if it were complete without actively dropping this `Some`.
         let mut t = sample_tree();
         t.assign_ids();
         t.truncated = Some(Truncation {
             limit: TruncationLimit::Depth,
             nodes_walked: 42,
         });
-        assert!(
-            t.to_outline().contains("truncated"),
-            "a truncated tree must never render as if complete"
-        );
+        assert!(!t.to_outline().contains("truncated"), "pure tree text");
+        let notice = t.truncation_notice().expect("a truncated tree has one");
+        assert!(notice.contains("truncated"), "notice: {notice}");
     }
 
     #[test]
-    fn outline_appends_nothing_when_the_tree_is_complete() {
+    fn truncation_notice_is_none_when_the_tree_is_complete() {
         let mut t = sample_tree();
         t.assign_ids();
-        assert!(!t.to_outline().contains("truncated"));
+        assert!(t.truncation_notice().is_none());
     }
 
     #[test]

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -458,9 +458,9 @@ impl AxTree {
         }
         let mut out = String::new();
         walk(&self.root, 0, &mut out);
-        // Truncation is a fact about the tree, not a rendering style, so BOTH renderers
-        // disclose it. A capped tree that rendered as complete would read as "the element
-        // does not exist" — the silent fallback this field exists to prevent.
+        // Truncation is a fact about the tree, not a rendering style, so it is disclosed
+        // wherever the tree is rendered. A capped tree that rendered as complete would read
+        // as "the element does not exist" — the silent fallback this field exists to prevent.
         if let Some(t) = self.truncated {
             let _ = writeln!(out, "{}", t.notice());
         }
@@ -1463,6 +1463,11 @@ mod tests {
             b.visit();
         }
         assert!(!b.nodes_exhausted(), "one visit short of the cap");
+        b.visit();
+        assert!(
+            b.nodes_exhausted(),
+            "the cap is reached at exactly MAX_NODES"
+        );
     }
 
     #[test]

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -70,7 +70,8 @@ pub use platform::{
 pub mod accessibility;
 pub use accessibility::{
     element_match, Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget,
-    AxTree, ElementCondition, ElementInfo, ElementMatch,
+    AxTree, ElementCondition, ElementInfo, ElementMatch, Truncation, TruncationLimit, WalkBudget,
+    MAX_DEPTH, MAX_NODES, MAX_SIBLINGS,
 };
 
 pub mod marks;

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -77,6 +77,8 @@ pub use accessibility::{
 pub mod marks;
 pub use marks::Mark;
 
+pub mod outline;
+
 pub mod audit;
 pub use audit::{Actuation, ActuationContext, AuditOutcome, AuditSink, ElementRef, WindowRef};
 

--- a/crates/glass-core/src/marks.rs
+++ b/crates/glass-core/src/marks.rs
@@ -223,7 +223,7 @@ mod tests {
             }),
             children: vec![button, label],
         };
-        let mut t = AxTree { root, count: 0 };
+        let mut t = AxTree::new(root);
         t.assign_ids();
         t
     }
@@ -263,7 +263,7 @@ mod tests {
                     height: 4,
                 }),
             );
-            let mut t = AxTree { root, count: 0 };
+            let mut t = AxTree::new(root);
             t.assign_ids();
             t
         };
@@ -276,7 +276,7 @@ mod tests {
     /// A single interactable Button with the given bounds, ids assigned.
     fn one_button(bounds: AxRect) -> AxTree {
         let root = node(0, AxRole::Button, "b", Some(bounds));
-        let mut t = AxTree { root, count: 0 };
+        let mut t = AxTree::new(root);
         t.assign_ids();
         t
     }
@@ -327,7 +327,7 @@ mod tests {
                     height: 40,
                 }),
             );
-            let mut t = AxTree { root, count: 0 };
+            let mut t = AxTree::new(root);
             t.assign_ids();
             t
         };

--- a/crates/glass-core/src/outline.rs
+++ b/crates/glass-core/src/outline.rs
@@ -1,0 +1,256 @@
+//! Agent-facing outline rendering for an [`AxTree`] — the same information
+//! [`AxTree::to_outline`] renders, with pure structural scaffolding collapsed away.
+//! Pure text work, no OS dependencies.
+//!
+//! Toolkits (GTK, Jetpack Compose, UIKit) wrap real widgets in towers of unnamed
+//! single-child containers. Those lines carry no name, value, state or addressable meaning,
+//! yet they dominate the outline an agent pays tokens to read.
+//!
+//! Collapsing them is lossless for addressing: ids are assigned over the FULL tree before
+//! rendering, and `click_element` resolves against the full cached tree — so an elided node
+//! keeps its id and stays clickable. Only the text shrinks.
+//!
+//! [`AxTree::to_outline`] deliberately does NOT compact: `scroll_to_element` compares
+//! consecutive outlines to detect saturation, and elided wrappers still carry bounds that
+//! change as content scrolls. Compacting there could make a still-scrolling view render
+//! identically twice and be declared saturated.
+
+use std::fmt::Write as _;
+
+use crate::accessibility::{AxNode, AxRole, AxTree};
+
+/// Whether `node` is pure structural scaffolding — a container that conveys nothing its
+/// single child does not already convey.
+///
+/// Every conjunct is load-bearing:
+/// - a semantic role is never scaffolding, even unnamed;
+/// - a named or valued container is real structure an agent may reason about;
+/// - a **focusable** container is actable: Jetpack Compose surfaces a real button as a
+///   clickable `Group` with the role lost (see `accessibility::element_match`), so eliding
+///   it would hide a button that is still clickable — invisible but addressable;
+/// - a multi-child container conveys grouping; a single-child one does not.
+fn is_scaffolding(node: &AxNode) -> bool {
+    matches!(node.role, AxRole::Group | AxRole::Other)
+        && node.name.is_none()
+        && node.value.is_none()
+        && !node.states.focusable
+        && node.children.len() == 1
+}
+
+/// Write one node's line: `#<id> <Role> "<name>" (<x>,<y> <w>x<h>) [<states>]`, name/bounds/
+/// states elided when absent, two spaces of indent per depth level.
+///
+/// Shared by [`AxTree::to_outline`] and [`render_compact`] so the two renders cannot drift —
+/// a test asserts they are identical for a tree with nothing to elide.
+pub(crate) fn write_line(node: &AxNode, depth: usize, out: &mut String) {
+    let indent = "  ".repeat(depth);
+    let _ = write!(out, "{indent}#{} {:?}", node.id.0, node.role);
+    if let Some(name) = &node.name {
+        let _ = write!(out, " {name:?}");
+    }
+    if let Some(b) = &node.bounds {
+        let _ = write!(out, " ({},{} {}x{})", b.x, b.y, b.width, b.height);
+    }
+    let states = node.states.active();
+    if !states.is_empty() {
+        let _ = write!(out, " [{}]", states.join(","));
+    }
+    out.push('\n');
+}
+
+/// Render the agent-facing outline: scaffolding chains collapsed, truncation disclosed.
+/// Total — this cannot fail.
+pub fn render_compact(tree: &AxTree) -> String {
+    let mut out = String::new();
+    // The root anchors the outline and is rendered unconditionally, even when it is itself
+    // an unnamed single-child container.
+    write_line(&tree.root, 0, &mut out);
+    write_children(&tree.root, 1, &mut out);
+    if let Some(t) = tree.truncated {
+        let _ = writeln!(out, "{}", t.notice());
+    }
+    out
+}
+
+/// Render `parent`'s children at `depth`. A scaffolding child is not rendered; the first
+/// non-scaffolding descendant takes its place at the SAME depth, so a chain of wrappers
+/// collapses entirely rather than leaving a growing indent.
+fn write_children(parent: &AxNode, depth: usize, out: &mut String) {
+    for child in &parent.children {
+        let mut node = child;
+        while is_scaffolding(node) {
+            // `is_scaffolding` guarantees exactly one child; `first()` keeps this total
+            // rather than relying on that invariant holding at an index.
+            let Some(only) = node.children.first() else {
+                break;
+            };
+            node = only;
+        }
+        write_line(node, depth, out);
+        write_children(node, depth + 1, out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::accessibility::{AxNode, AxNodeId, AxRect, AxStates, Truncation, TruncationLimit};
+
+    /// A node with the given role/name and no children.
+    fn node(role: AxRole, name: Option<&str>) -> AxNode {
+        AxNode {
+            id: AxNodeId(0),
+            role,
+            raw_role: String::new(),
+            name: name.map(Into::into),
+            value: None,
+            states: AxStates::default(),
+            bounds: None,
+            children: vec![],
+        }
+    }
+
+    /// Wrap `child` in `depth` unnamed, non-focusable, single-child Groups.
+    fn wrap(child: AxNode, depth: usize) -> AxNode {
+        (0..depth).fold(child, |acc, _| {
+            let mut g = node(AxRole::Group, None);
+            g.children = vec![acc];
+            g
+        })
+    }
+
+    /// A tree rooted at a Window whose single child is `child`, ids assigned.
+    fn tree_of(child: AxNode) -> AxTree {
+        let mut root = node(AxRole::Window, Some("App"));
+        root.children = vec![child];
+        let mut t = AxTree::new(root);
+        t.assign_ids();
+        t
+    }
+
+    #[test]
+    fn a_single_wrapper_group_is_elided() {
+        let t = tree_of(wrap(node(AxRole::Button, Some("Save")), 1));
+        assert!(!render_compact(&t).contains("Group"));
+    }
+
+    #[test]
+    fn a_deep_wrapper_chain_collapses_entirely() {
+        let t = tree_of(wrap(node(AxRole::Button, Some("Save")), 10));
+        assert_eq!(
+            render_compact(&t).lines().count(),
+            2,
+            "Window + Button only:\n{}",
+            render_compact(&t)
+        );
+    }
+
+    #[test]
+    fn the_button_keeps_its_id_after_collapsing() {
+        // 10 wrappers => Window #0, wrappers #1..#10, Button #11. Compaction must not renumber.
+        let t = tree_of(wrap(node(AxRole::Button, Some("Save")), 10));
+        assert!(
+            render_compact(&t).contains("#11 Button"),
+            "ids are assigned over the FULL tree:\n{}",
+            render_compact(&t)
+        );
+    }
+
+    #[test]
+    fn a_named_group_is_kept() {
+        let mut g = node(AxRole::Group, Some("Toolbar"));
+        g.children = vec![node(AxRole::Button, Some("Save"))];
+        assert!(render_compact(&tree_of(g)).contains("Toolbar"));
+    }
+
+    #[test]
+    fn a_focusable_group_is_kept() {
+        // Jetpack Compose surfaces a real button as a clickable Group with the role lost.
+        // Eliding it would hide a button that is still clickable — invisible but addressable.
+        let mut g = node(AxRole::Group, None);
+        g.states = AxStates {
+            focusable: true,
+            ..AxStates::default()
+        };
+        g.children = vec![node(AxRole::Label, Some("Submit"))];
+        assert!(
+            render_compact(&tree_of(g)).contains("Group"),
+            "a focusable Group is actable and must never be elided"
+        );
+    }
+
+    #[test]
+    fn a_group_with_a_value_is_kept() {
+        let mut g = node(AxRole::Group, None);
+        g.value = Some("42".into());
+        g.children = vec![node(AxRole::Label, Some("Count"))];
+        assert!(render_compact(&tree_of(g)).contains("Group"));
+    }
+
+    #[test]
+    fn a_multi_child_group_is_kept() {
+        let mut g = node(AxRole::Group, None);
+        g.children = vec![
+            node(AxRole::Button, Some("Ok")),
+            node(AxRole::Button, Some("Cancel")),
+        ];
+        assert!(
+            render_compact(&tree_of(g)).contains("Group"),
+            "a multi-child container conveys real grouping"
+        );
+    }
+
+    #[test]
+    fn a_childless_group_is_kept() {
+        assert!(render_compact(&tree_of(node(AxRole::Group, None))).contains("Group"));
+    }
+
+    #[test]
+    fn a_semantic_role_is_never_elided() {
+        let mut list = node(AxRole::List, None);
+        list.children = vec![node(AxRole::ListItem, Some("Row"))];
+        assert!(render_compact(&tree_of(list)).contains("List"));
+    }
+
+    #[test]
+    fn the_root_is_never_elided() {
+        // An unnamed single-child Group ROOT still anchors the outline.
+        let mut root = node(AxRole::Group, None);
+        root.children = vec![node(AxRole::Button, Some("Save"))];
+        let mut t = AxTree::new(root);
+        t.assign_ids();
+        assert!(render_compact(&t).starts_with("#0 Group"));
+    }
+
+    #[test]
+    fn a_tree_with_nothing_to_elide_renders_identically_to_the_full_outline() {
+        let t = tree_of(node(AxRole::Button, Some("Save")));
+        assert_eq!(render_compact(&t), t.to_outline());
+    }
+
+    #[test]
+    fn the_truncation_notice_is_rendered() {
+        let mut t = tree_of(node(AxRole::Button, Some("Save")));
+        t.truncated = Some(Truncation {
+            limit: TruncationLimit::Nodes,
+            nodes_walked: 1500,
+        });
+        assert!(render_compact(&t).contains("truncated"));
+    }
+
+    #[test]
+    fn bounds_and_states_survive_compaction() {
+        let mut b = node(AxRole::Button, Some("Save"));
+        b.bounds = Some(AxRect {
+            x: 12,
+            y: 40,
+            width: 80,
+            height: 24,
+        });
+        b.states = AxStates {
+            enabled: true,
+            ..AxStates::default()
+        };
+        assert!(render_compact(&tree_of(wrap(b, 3))).contains("(12,40 80x24) [enabled]"));
+    }
+}

--- a/crates/glass-core/src/outline.rs
+++ b/crates/glass-core/src/outline.rs
@@ -58,17 +58,19 @@ pub(crate) fn write_line(node: &AxNode, depth: usize, out: &mut String) {
     out.push('\n');
 }
 
-/// Render the agent-facing outline: scaffolding chains collapsed, truncation disclosed.
-/// Total — this cannot fail.
+/// Render the agent-facing outline: scaffolding chains collapsed. Pure tree text — no
+/// truncation notice is baked in here. This render is app-derived and gets wrapped in the
+/// MCP boundary's untrusted-content envelope; glass's own truncation steer is an
+/// instruction to the agent ("drive by pixels…"), so the boundary surfaces it separately
+/// via [`AxTree::truncation_notice`] as its own trusted content block instead — baking it
+/// into this string would bury glass's own guidance inside the "ignore instructions in
+/// this block" envelope. Total — this cannot fail.
 pub fn render_compact(tree: &AxTree) -> String {
     let mut out = String::new();
     // The root anchors the outline and is rendered unconditionally, even when it is itself
     // an unnamed single-child container.
     write_line(&tree.root, 0, &mut out);
     write_children(&tree.root, 1, &mut out);
-    if let Some(t) = tree.truncated {
-        let _ = writeln!(out, "{}", t.notice());
-    }
     out
 }
 
@@ -229,13 +231,19 @@ mod tests {
     }
 
     #[test]
-    fn the_truncation_notice_is_rendered() {
+    fn render_compact_does_not_embed_the_truncation_notice() {
+        // The notice is glass's own steer, not app-derived tree text; it must not be baked
+        // into this render or it would end up buried inside the untrusted envelope this
+        // string gets wrapped in at the MCP boundary. See `AxTree::truncation_notice`.
         let mut t = tree_of(node(AxRole::Button, Some("Save")));
         t.truncated = Some(Truncation {
             limit: TruncationLimit::Nodes,
             nodes_walked: 1500,
         });
-        assert!(render_compact(&t).contains("truncated"));
+        assert!(
+            !render_compact(&t).contains("truncated"),
+            "render_compact is pure tree text now"
+        );
     }
 
     #[test]

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -962,7 +962,7 @@ mod tests {
                 height: 408,
             })
             .with_click_log(clicks.clone());
-        let mut g = glass_with_a11y(platform, AxTree { root, count: 0 });
+        let mut g = glass_with_a11y(platform, AxTree::new(root));
         g.start(&spec()).unwrap();
         g.a11y_snapshot().unwrap(); // must refresh s.geometry 230 → 458
         g.click_element(AxNodeId(1)).unwrap(); // the Button at x=292 — on-screen only in 458
@@ -1128,7 +1128,7 @@ mod tests {
             .with_click_log(clicks.clone())
             .with_drag_log(drags.clone())
             .with_trailing_toggle_backend();
-        let mut g = glass_with_a11y(platform, AxTree { root, count: 0 });
+        let mut g = glass_with_a11y(platform, AxTree::new(root));
         g.start(&spec()).unwrap();
         g.a11y_snapshot().unwrap();
 
@@ -1218,7 +1218,7 @@ mod tests {
             }],
         };
         let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
-        let mut g = glass_with_a11y(platform, AxTree { root, count: 0 });
+        let mut g = glass_with_a11y(platform, AxTree::new(root));
         g.start(&spec()).unwrap();
         g.a11y_snapshot().unwrap();
         g.click_element(AxNodeId(1)).unwrap();
@@ -1271,7 +1271,7 @@ mod tests {
         let platform = FakePlatform::new(100, 100)
             .with_click_log(clicks.clone())
             .with_trailing_toggle_backend();
-        let mut g = glass_with_a11y(platform, AxTree { root, count: 0 });
+        let mut g = glass_with_a11y(platform, AxTree::new(root));
         g.start(&spec()).unwrap();
         g.a11y_snapshot().unwrap();
         g.click_element(AxNodeId(1)).unwrap();
@@ -1403,7 +1403,7 @@ mod tests {
             }),
             children: vec![globex],
         };
-        let tree = AxTree { root, count: 0 };
+        let tree = AxTree::new(root);
         let a = window_info(
             1,
             WindowGeometry {
@@ -1588,7 +1588,7 @@ mod tests {
             }),
             children: vec![switch],
         };
-        AxTree { root, count: 0 }
+        AxTree::new(root)
     }
 
     #[test]
@@ -1720,7 +1720,7 @@ mod tests {
             }),
             children: vec![sibling, target],
         };
-        AxTree { root, count: 0 }
+        AxTree::new(root)
     }
 
     #[test]

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -309,7 +309,7 @@ pub(crate) fn fake_tree() -> AxTree {
         }),
         children: vec![button],
     };
-    AxTree { root, count: 0 }
+    AxTree::new(root)
 }
 
 /// Like `fake_tree` but the Button "Save" is enabled.
@@ -447,7 +447,7 @@ pub(crate) fn tree_with(win_w: u32, win_h: u32, children: Vec<AxNode>) -> AxTree
         }),
         children,
     };
-    AxTree { root, count: 0 }
+    AxTree::new(root)
 }
 
 pub(crate) fn spec() -> AppSpec {
@@ -532,7 +532,7 @@ pub(crate) fn fake_tree_with_popover_option() -> AxTree {
         }),
         children: vec![list],
     };
-    AxTree { root, count: 0 }
+    AxTree::new(root)
 }
 
 /// A bare-minimum `Platform` that overrides nothing — every optional method

--- a/crates/glass-fixture-egui/src/main.rs
+++ b/crates/glass-fixture-egui/src/main.rs
@@ -11,6 +11,26 @@ fn log(line: &str) {
     let _ = std::io::stdout().flush();
 }
 
+/// Wrap `add_contents` in an unnamed container exposed to the accessibility tree with an
+/// explicit `Pane` role, rather than the plain `Frame::group`/`ui.group` default. A plain
+/// group's container is registered internally with accesskit's `GenericContainer` role, which
+/// accesskit's own AT-SPI adapter always elides (its node filter drops every
+/// `GenericContainer` regardless of name or children — see `accesskit_consumer::filters`), so
+/// it would never reach glass's accessibility tree. `Pane` is a distinct, non-generic role
+/// that survives that filter, so it lands in the a11y tree as a real, unnamed, single-child
+/// container — the wrapper chain this fixture's on-box a11y tests need `render_compact` to
+/// have something to collapse.
+fn wrap_in_pane<R>(ui: &mut egui::Ui, add_contents: impl FnOnce(&mut egui::Ui) -> R) -> R {
+    let mut prepared = egui::Frame::group(ui.style()).begin(ui);
+    ui.ctx()
+        .accesskit_node_builder(prepared.content_ui.unique_id(), |node| {
+            node.set_role(egui::accesskit::Role::Pane);
+        });
+    let ret = add_contents(&mut prepared.content_ui);
+    prepared.end(ui);
+    ret
+}
+
 #[derive(Default)]
 struct Fixture {
     text: String,
@@ -89,9 +109,18 @@ impl eframe::App for Fixture {
             {
                 log(&format!("[fixture] value={}", self.value));
             }
-            if ui.button("Apply").clicked() {
-                log("[fixture] apply");
-            }
+            // Nest Apply inside a pair of unnamed, single-child panes (see `wrap_in_pane`) —
+            // this fixture's accessibility tree is otherwise flat, so on-box a11y tests that
+            // assert the outline's compact render is smaller than its full render need this
+            // chain to have something to collapse. Doesn't change Apply's own role, name, or
+            // behavior.
+            wrap_in_pane(ui, |ui| {
+                wrap_in_pane(ui, |ui| {
+                    if ui.button("Apply").clicked() {
+                        log("[fixture] apply");
+                    }
+                });
+            });
         });
     }
 }

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -138,7 +138,7 @@ mod tests {
             }),
             children: vec![field],
         };
-        let mut t = AxTree { root, count: 0 };
+        let mut t = AxTree::new(root);
         t.assign_ids();
         t
     }

--- a/crates/glass-ios/src/axmap.rs
+++ b/crates/glass-ios/src/axmap.rs
@@ -82,7 +82,7 @@ pub fn build_tree(json: &str, scale: f64, window: &WindowGeometry) -> Result<AxT
         }),
         children,
     };
-    Ok(AxTree { root, count: 0 })
+    Ok(AxTree::new(root))
 }
 
 /// The widest top-level element's logical-point width from idb's nested

--- a/crates/glass-ios/src/axmap.rs
+++ b/crates/glass-ios/src/axmap.rs
@@ -71,15 +71,18 @@ pub fn build_tree(json: &str, scale: f64, window: &WindowGeometry) -> Result<AxT
         Value::Array(a) => {
             let mut out = Vec::new();
             for (i, n) in a.iter().enumerate() {
+                // Checked before processing each element (not after) so the element that
+                // merely completes the tree doesn't get mistaken for one the walk declined
+                // to visit.
+                if budget.nodes_exhausted() {
+                    budget.hit(TruncationLimit::Nodes);
+                    break;
+                }
                 if i >= MAX_SIBLINGS {
                     budget.hit(TruncationLimit::Siblings);
                     break;
                 }
                 out.push(map_node(n, scale, 0, &mut budget));
-                if budget.nodes_exhausted() {
-                    budget.hit(TruncationLimit::Nodes);
-                    break;
-                }
             }
             out
         }
@@ -204,29 +207,37 @@ fn map_node(n: &Value, scale: f64, depth: usize, budget: &mut WalkBudget) -> AxN
     let bounds = n.get("frame").and_then(|f| frame_to_rect(f, scale));
     // Recursion is bounded by `budget` (depth, node count, siblings per level), so a
     // pathologically deep or wide accessibility tree cannot blow the stack or the token
-    // budget.
-    let children = if budget.depth_exhausted(depth) {
-        budget.hit(TruncationLimit::Depth);
-        vec![]
-    } else if budget.nodes_exhausted() {
-        budget.hit(TruncationLimit::Nodes);
-        vec![]
-    } else {
-        let mut out = Vec::new();
-        if let Some(kids) = n.get("children").and_then(Value::as_array) {
+    // budget. The child array is resolved before either bound is consulted: a childless
+    // node must never be reported truncated for declining to explore a list that was
+    // already empty.
+    let children = match n.get("children").and_then(Value::as_array) {
+        None => vec![],
+        Some(arr) if arr.is_empty() => vec![],
+        Some(_) if budget.depth_exhausted(depth) => {
+            budget.hit(TruncationLimit::Depth);
+            vec![]
+        }
+        Some(_) if budget.nodes_exhausted() => {
+            budget.hit(TruncationLimit::Nodes);
+            vec![]
+        }
+        Some(kids) => {
+            let mut out = Vec::new();
             for (i, c) in kids.iter().enumerate() {
+                // Checked before processing each child (not after) so the child that merely
+                // completes the tree doesn't get mistaken for one the walk declined to visit.
+                if budget.nodes_exhausted() {
+                    budget.hit(TruncationLimit::Nodes);
+                    break;
+                }
                 if i >= MAX_SIBLINGS {
                     budget.hit(TruncationLimit::Siblings);
                     break;
                 }
                 out.push(map_node(c, scale, depth + 1, budget));
-                if budget.nodes_exhausted() {
-                    budget.hit(TruncationLimit::Nodes);
-                    break;
-                }
             }
+            out
         }
-        out
     };
     AxNode {
         id: AxNodeId(0),
@@ -506,6 +517,47 @@ mod tests {
         // top-level element at array index i is id i+1.
         let third = tree.find(AxNodeId(3)).expect("id 3 survives");
         assert_eq!(third.name.as_deref(), Some("btn2"));
+    }
+
+    #[test]
+    fn a_complete_tree_of_exactly_max_nodes_reports_no_truncation() {
+        // MAX_NODES flat top-level elements: the walk visits every one of them, and the
+        // LAST one is what pushes the running count to MAX_NODES. Nothing was declined, so
+        // this must NOT be reported truncated (regression for the false-positive-at-the-cap
+        // bug).
+        let json = wide_array_json(glass_core::MAX_NODES);
+        let tree = build_tree(&json, 1.0, &win()).expect("tree builds");
+        assert_eq!(tree.truncated, None);
+    }
+
+    #[test]
+    fn a_tree_of_max_nodes_plus_one_still_reports_nodes_truncation() {
+        // One more element than the complete case above: now there really is a node the
+        // walk declines to visit, so the cap must still fire — proving the fix didn't just
+        // disable it.
+        let json = wide_array_json(glass_core::MAX_NODES + 1);
+        let tree = build_tree(&json, 1.0, &win()).expect("tree builds");
+        assert_eq!(
+            tree.truncated.map(|t| t.limit),
+            Some(TruncationLimit::Nodes)
+        );
+    }
+
+    #[test]
+    fn a_childless_node_at_the_spent_node_budget_records_no_truncation() {
+        // A leaf with no "children" key, reached once the node budget is already spent,
+        // must not be reported truncated merely for declining to explore an empty list.
+        let leaf = serde_json::json!({
+            "role": "AXButton",
+            "AXLabel": "leaf",
+            "frame": {"x": 0, "y": 0, "width": 10, "height": 10}
+        });
+        let mut budget = WalkBudget::new();
+        for _ in 0..glass_core::MAX_NODES {
+            budget.visit();
+        }
+        let _ = map_node(&leaf, 1.0, 0, &mut budget);
+        assert!(budget.truncation().is_none());
     }
 
     #[test]

--- a/crates/glass-ios/src/axmap.rs
+++ b/crates/glass-ios/src/axmap.rs
@@ -18,7 +18,9 @@
 //! idb's `accessibility_info` exposes no per-element focus state (there is no focus
 //! key anywhere in the output), so [`AxStates::focused`] is always false from this
 //! backend — a known limitation.
-use glass_core::accessibility::{AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTree};
+use glass_core::accessibility::{
+    AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTree, TruncationLimit, WalkBudget, MAX_SIBLINGS,
+};
 use glass_core::{GlassError, Result, WindowGeometry};
 use serde_json::Value;
 
@@ -54,13 +56,34 @@ pub fn ax_role(ax_type: &str) -> AxRole {
 /// Returns [`GlassError::AccessibilityUnavailable`] if the JSON does not parse or
 /// its root is neither an element object nor an array of elements — a malformed
 /// response never yields an empty tree passed off as success.
+///
+/// The walk is bounded by a [`WalkBudget`] (node count, nesting depth, and per-level
+/// sibling scan) shared with every other backend; a bound firing stops the walk rather
+/// than dropping nodes out of the middle, so ids assigned afterward by
+/// [`AxTree::assign_ids`] stay stable for every surviving node. [`AxTree::truncated`]
+/// records which bound fired, if any.
 pub fn build_tree(json: &str, scale: f64, window: &WindowGeometry) -> Result<AxTree> {
     let v: Value = serde_json::from_str(json)
         .map_err(|e| GlassError::AccessibilityUnavailable(format!("idb a11y JSON parse: {e}")))?;
+    let mut budget = WalkBudget::new();
     // idb may return either a single root object or an array of top-level elements.
     let children: Vec<AxNode> = match &v {
-        Value::Array(a) => a.iter().map(|n| map_node(n, scale)).collect(),
-        obj @ Value::Object(_) => vec![map_node(obj, scale)],
+        Value::Array(a) => {
+            let mut out = Vec::new();
+            for (i, n) in a.iter().enumerate() {
+                if i >= MAX_SIBLINGS {
+                    budget.hit(TruncationLimit::Siblings);
+                    break;
+                }
+                out.push(map_node(n, scale, 0, &mut budget));
+                if budget.nodes_exhausted() {
+                    budget.hit(TruncationLimit::Nodes);
+                    break;
+                }
+            }
+            out
+        }
+        obj @ Value::Object(_) => vec![map_node(obj, scale, 0, &mut budget)],
         _ => {
             return Err(GlassError::AccessibilityUnavailable(
                 "idb a11y JSON: unexpected root".into(),
@@ -82,7 +105,9 @@ pub fn build_tree(json: &str, scale: f64, window: &WindowGeometry) -> Result<AxT
         }),
         children,
     };
-    Ok(AxTree::new(root))
+    let mut tree = AxTree::new(root);
+    tree.truncated = budget.truncation();
+    Ok(tree)
 }
 
 /// The widest top-level element's logical-point width from idb's nested
@@ -135,7 +160,8 @@ fn checkable_checked(role: AxRole, ax_value: Option<&str>) -> (bool, bool) {
     }
 }
 
-fn map_node(n: &Value, scale: f64) -> AxNode {
+fn map_node(n: &Value, scale: f64, depth: usize, budget: &mut WalkBudget) -> AxNode {
+    budget.visit();
     // Read a string field, collapsing both a JSON `null` (missing/non-string) and an
     // empty string to `None` so absent and blank values are treated alike.
     let s = |k: &str| {
@@ -176,11 +202,32 @@ fn map_node(n: &Value, scale: f64) -> AxNode {
         ..AxStates::default()
     };
     let bounds = n.get("frame").and_then(|f| frame_to_rect(f, scale));
-    let children = n
-        .get("children")
-        .and_then(Value::as_array)
-        .map(|a| a.iter().map(|c| map_node(c, scale)).collect())
-        .unwrap_or_default();
+    // Recursion is bounded by `budget` (depth, node count, siblings per level), so a
+    // pathologically deep or wide accessibility tree cannot blow the stack or the token
+    // budget.
+    let children = if budget.depth_exhausted(depth) {
+        budget.hit(TruncationLimit::Depth);
+        vec![]
+    } else if budget.nodes_exhausted() {
+        budget.hit(TruncationLimit::Nodes);
+        vec![]
+    } else {
+        let mut out = Vec::new();
+        if let Some(kids) = n.get("children").and_then(Value::as_array) {
+            for (i, c) in kids.iter().enumerate() {
+                if i >= MAX_SIBLINGS {
+                    budget.hit(TruncationLimit::Siblings);
+                    break;
+                }
+                out.push(map_node(c, scale, depth + 1, budget));
+                if budget.nodes_exhausted() {
+                    budget.hit(TruncationLimit::Nodes);
+                    break;
+                }
+            }
+        }
+        out
+    };
     AxNode {
         id: AxNodeId(0),
         role,
@@ -431,6 +478,34 @@ mod tests {
         assert_eq!(checkable_checked(CheckBox, None), (false, false));
         assert_eq!(checkable_checked(TextField, Some("1")), (false, false));
         assert_eq!(checkable_checked(Button, Some("0")), (false, false));
+    }
+
+    /// Array JSON of `n` flat top-level elements, each a distinctly-labeled `AXButton`
+    /// with no `AXUniqueId` (so `map_node` falls back to `AXLabel` for the name).
+    fn wide_array_json(n: usize) -> String {
+        let mut elems = Vec::with_capacity(n);
+        for i in 0..n {
+            elems.push(format!(
+                r#"{{"role":"AXButton","AXLabel":"btn{i}","frame":{{"x":0,"y":0,"width":10,"height":10}}}}"#
+            ));
+        }
+        format!("[{}]", elems.join(","))
+    }
+
+    #[test]
+    fn truncation_stops_the_walk_and_never_shifts_surviving_ids() {
+        // ids are assigned in the same pre-order the tree is walked, so a truncation
+        // that dropped a node from the middle rather than stopping at the end would
+        // shift every later id off the node its own index implies.
+        let json = wide_array_json(glass_core::MAX_NODES + 50);
+        let mut tree = build_tree(&json, 1.0, &win()).expect("tree builds");
+        tree.assign_ids();
+
+        assert!(tree.truncated.is_some(), "the node cap must have been hit");
+        // The synthetic Window root is id 0 (never counted against the budget); the
+        // top-level element at array index i is id i+1.
+        let third = tree.find(AxNodeId(3)).expect("id 3 survives");
+        assert_eq!(third.name.as_deref(), Some("btn2"));
     }
 
     #[test]

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -672,7 +672,7 @@ pub(crate) mod testutil {
             }),
             children: vec![button],
         };
-        AxTree { root, count: 0 }
+        AxTree::new(root)
     }
 
     /// A window root with no child elements — the "app publishes no usable tree" shape.
@@ -692,7 +692,7 @@ pub(crate) mod testutil {
             }),
             children: vec![],
         };
-        AxTree { root, count: 0 }
+        AxTree::new(root)
     }
 
     pub fn glass_with_a11y(platform: FakePlatform, tree: AxTree) -> Glass {

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -271,14 +271,21 @@ pub fn select_window(glass: &mut Glass, a: &SelectWindowArgs) -> ToolResult {
 
 pub fn a11y_snapshot(glass: &mut Glass) -> ToolResult {
     let tree = glass.a11y_snapshot().map_err(|e| e.to_string())?;
-    // The agent-facing render: wrapper chains collapsed, truncation disclosed. The session
-    // cache keeps the full tree, so every elided node is still addressable by id.
+    // The agent-facing render: wrapper chains collapsed. The session cache keeps the full
+    // tree, so every elided node is still addressable by id. Truncation is disclosed
+    // separately below, not baked into this text — see the comment there.
     let body = glass_core::outline::render_compact(&tree);
-    // The outline is app-derived → untrusted-wrapped. When the tree has nothing to
-    // address, add glass's own (trusted, unwrapped) hint steering to the pixel loop.
+    // The outline is app-derived → untrusted-wrapped. glass's own steers (the empty-tree
+    // hint, the truncation notice) are trusted, separate, unwrapped blocks — never baked
+    // into the untrusted-wrapped body, or an instruction of glass's own ("drive by
+    // pixels…") would end up under a directive telling the agent to ignore instructions
+    // in that block.
     let mut contents = vec![OutContent::Text(crate::untrusted::wrap_untrusted(&body))];
     if let Some(hint) = tree.empty_guidance() {
         contents.push(OutContent::Text(hint.to_string()));
+    }
+    if let Some(notice) = tree.truncation_notice() {
+        contents.push(OutContent::Text(notice));
     }
     Ok(ToolOutput::result_with(
         "glass_a11y_snapshot",
@@ -333,12 +340,18 @@ fn resolve_return(
             // tree (not pixels) and still returns the freshest tree — the caller asked for it.
             let _ = glass.wait_stable(&settle_params());
             let tree = glass.a11y_snapshot().map_err(|e| e.to_string())?;
-            Ok((
-                None,
-                vec![OutContent::Text(crate::untrusted::wrap_untrusted(
-                    &glass_core::outline::render_compact(&tree),
-                ))],
-            ))
+            // Same shape as `a11y_snapshot`: the app-derived outline stays untrusted-wrapped;
+            // glass's own steers are separate trusted blocks, not baked into that body.
+            let mut extra = vec![OutContent::Text(crate::untrusted::wrap_untrusted(
+                &glass_core::outline::render_compact(&tree),
+            ))];
+            if let Some(hint) = tree.empty_guidance() {
+                extra.push(OutContent::Text(hint.to_string()));
+            }
+            if let Some(notice) = tree.truncation_notice() {
+                extra.push(OutContent::Text(notice));
+            }
+            Ok((None, extra))
         }
         Some(o) => Err(format!("unknown return '{o}' (use none/settle/snapshot)")),
     }
@@ -427,8 +440,8 @@ pub(crate) mod testutil {
     use glass_core::{
         Accessibility, AppSpec, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget,
         AxTree, Backend, BaselineStore, Frame, Glass, GlassError, KeyEvent, Platform,
-        PlatformFactory, PointerEvent, Region, Result, Stream, WindowGeometry, WindowId,
-        WindowInfo, WindowOp,
+        PlatformFactory, PointerEvent, Region, Result, Stream, Truncation, TruncationLimit,
+        WindowGeometry, WindowId, WindowInfo, WindowOp,
     };
 
     use super::{OutContent, ToolOutput};
@@ -695,6 +708,18 @@ pub(crate) mod testutil {
             children: vec![],
         };
         AxTree::new(root)
+    }
+
+    /// `fake_tree` with `truncated` set — the "walk stopped early" shape, for testing that
+    /// the truncation steer surfaces as its own trusted block rather than being baked into
+    /// the untrusted-wrapped outline.
+    pub fn truncated_tree() -> AxTree {
+        let mut t = fake_tree();
+        t.truncated = Some(Truncation {
+            limit: TruncationLimit::Nodes,
+            nodes_walked: 1500,
+        });
+        t
     }
 
     pub fn glass_with_a11y(platform: FakePlatform, tree: AxTree) -> Glass {
@@ -1017,6 +1042,66 @@ mod tests {
                 );
             }
             _ => panic!("expected the pixel-hint text"),
+        }
+    }
+
+    #[test]
+    fn a11y_snapshot_truncation_steer_is_a_trusted_block_outside_the_untrusted_envelope() {
+        // Regression for the finding that glass's own truncation steer was getting baked
+        // into `render_compact`'s output and so ended up buried inside the untrusted
+        // envelope — under a directive telling the agent to ignore instructions in that
+        // block, even though the steer ("drive by pixels…") IS an instruction from glass
+        // itself. It must be its own trusted, unwrapped `OutContent::Text` block.
+        let mut g = glass_with_a11y(FakePlatform::new(100, 100), truncated_tree());
+        g.start(&AppSpec {
+            build: None,
+            run: vec!["x".into()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 1,
+            sandbox: SandboxLevel::Off,
+            a11y: false,
+        })
+        .unwrap();
+        let out = a11y_snapshot(&mut g).unwrap();
+        assert_envelope(&out, "glass_a11y_snapshot");
+        // [0]=envelope, [1]=untrusted-wrapped outline, [2]=glass's trusted truncation steer.
+        assert_eq!(
+            out.0.len(),
+            3,
+            "envelope + wrapped outline + trusted truncation steer"
+        );
+        match &out.0[1] {
+            OutContent::Text(t) => {
+                assert!(
+                    t.starts_with(crate::untrusted::NOTE)
+                        && t.contains("⟦untrusted:")
+                        && t.contains("⟦/untrusted:"),
+                    "the outline itself stays untrusted-wrapped: {t}"
+                );
+                assert!(
+                    !t.contains("truncated"),
+                    "the truncation notice must NOT be baked into the untrusted-wrapped \
+                     outline body: {t}"
+                );
+            }
+            _ => panic!("expected the wrapped outline text"),
+        }
+        match &out.0[2] {
+            OutContent::Text(t) => {
+                assert!(t.contains("truncated"), "truncation steer: {t}");
+                assert!(
+                    t.contains("glass_screenshot"),
+                    "the steer names the pixel fallback: {t}"
+                );
+                assert!(
+                    !t.starts_with(crate::untrusted::NOTE) && !t.contains("⟦untrusted:"),
+                    "the steer is glass's own trusted guidance, outside the untrusted \
+                     markers entirely: {t}"
+                );
+            }
+            _ => panic!("expected the trusted truncation-steer text"),
         }
     }
 

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -271,7 +271,9 @@ pub fn select_window(glass: &mut Glass, a: &SelectWindowArgs) -> ToolResult {
 
 pub fn a11y_snapshot(glass: &mut Glass) -> ToolResult {
     let tree = glass.a11y_snapshot().map_err(|e| e.to_string())?;
-    let body = tree.to_outline();
+    // The agent-facing render: wrapper chains collapsed, truncation disclosed. The session
+    // cache keeps the full tree, so every elided node is still addressable by id.
+    let body = glass_core::outline::render_compact(&tree);
     // The outline is app-derived → untrusted-wrapped. When the tree has nothing to
     // address, add glass's own (trusted, unwrapped) hint steering to the pixel loop.
     let mut contents = vec![OutContent::Text(crate::untrusted::wrap_untrusted(&body))];
@@ -334,7 +336,7 @@ fn resolve_return(
             Ok((
                 None,
                 vec![OutContent::Text(crate::untrusted::wrap_untrusted(
-                    &tree.to_outline(),
+                    &glass_core::outline::render_compact(&tree),
                 ))],
             ))
         }

--- a/crates/glass-mcp/src/tools/wait.rs
+++ b/crates/glass-mcp/src/tools/wait.rs
@@ -354,7 +354,7 @@ mod tests {
             }),
             children: vec![button],
         };
-        AxTree { root, count: 0 }
+        AxTree::new(root)
     }
 
     #[test]

--- a/crates/glass-testapp/tests/common/mcp_cost.rs
+++ b/crates/glass-testapp/tests/common/mcp_cost.rs
@@ -12,8 +12,9 @@
 //! --workspace` regardless.
 
 use std::path::PathBuf;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
+use glass_core::{AppSpec, AxNodeId, AxTree, Glass, SandboxLevel};
 use glass_mcp::serve::config::ServeConfig;
 use rmcp::model::CallToolRequestParams;
 use rmcp::service::RunningService;
@@ -623,6 +624,116 @@ pub async fn run_verification_cost(client: &Peer<RoleClient>) -> (ArmReport, Arm
 async fn restart_fixture(client: &Peer<RoleClient>) {
     call(client, "glass_stop", json!({})).await;
     start_fixture(client).await;
+}
+
+/// Sync counterpart to `start_fixture`: launches the same fixture app directly against a
+/// `glass_core::Glass` session instead of over the MCP wire. The wire has no route to the
+/// property this file's cost-and-integrity test needs — `glass_a11y_snapshot` always answers
+/// with `render_compact`'s output (see `glass_mcp::tools::a11y_snapshot`), never the
+/// uncompacted `AxTree::to_outline` render — so that test drives `Glass` directly to see both.
+/// Leaves `GLASS_DISPLAY` unset so the x11 backend spawns its own private headless display
+/// (see `glass_x11::X11Platform::from_env`), which avoids the `unsafe { env::set_var }` the
+/// wire-based tests in this suite need for attach mode.
+fn start_fixture_sync(glass: &mut Glass) {
+    let (build, run, cwd) = fixture_run_spec();
+    let spec = AppSpec {
+        build: Some(build),
+        run: vec![run],
+        cwd: Some(PathBuf::from(cwd)),
+        env: vec![],
+        window_hint: None,
+        timeout_ms: 120_000, // first egui build is slow, same as start_fixture
+        sandbox: SandboxLevel::Off,
+        a11y: true,
+    };
+    glass
+        .start_on("x11", &spec)
+        .unwrap_or_else(|e| panic!("start_on(x11) failed: {e}"));
+}
+
+/// Sync counterpart to `wait_for_widgets`: polls `Glass::a11y_snapshot` directly rather than
+/// an MCP `Peer`, for the same reason as `start_fixture_sync`. Same retry reasoning as
+/// `wait_for_widgets`/`a11y_outline`: the launched app's toolkit can transiently error (its
+/// AT-SPI subtree not registered yet) or answer with a placeholder root before its widgets are
+/// filled in, so both are retried up to the combined budget.
+fn wait_for_widgets_sync(glass: &mut Glass) -> AxTree {
+    let deadline = Instant::now() + A11Y_SETTLE_TIMEOUT + WIDGETS_SETTLE_TIMEOUT;
+    loop {
+        match glass.a11y_snapshot() {
+            Ok(tree) => {
+                let outline = tree.to_outline();
+                let ready = find_named_button(&outline, "Apply").is_some()
+                    && find_by_role(&outline, "slider").is_some()
+                    && find_by_role(&outline, "text").is_some();
+                if ready {
+                    return tree;
+                }
+                if Instant::now() >= deadline {
+                    panic!(
+                        "wait_for_widgets_sync: timed out waiting for the fixture's widgets; \
+                         last-seen outline:\n{outline}"
+                    );
+                }
+            }
+            Err(e) if Instant::now() < deadline => {
+                let _ = e; // transient during app startup; keep polling
+            }
+            Err(e) => panic!("a11y_snapshot errored: {e}"),
+        }
+        std::thread::sleep(A11Y_POLL_INTERVAL);
+    }
+}
+
+/// Every `#<n>` id at the start of an outline's lines (see `find_by_role`'s doc for the line
+/// shape) — `split_whitespace` + `strip_prefix('#')`, no regex dependency.
+fn ids_in(outline: &str) -> Vec<AxNodeId> {
+    let mut ids = Vec::new();
+    for line in outline.lines() {
+        let Some(tok) = line.split_whitespace().next() else {
+            continue;
+        };
+        let Some(digits) = tok.strip_prefix('#') else {
+            continue;
+        };
+        let Ok(id) = digits.parse::<u32>() else {
+            continue;
+        };
+        ids.push(AxNodeId(id));
+    }
+    ids
+}
+
+/// `render_compact` must remove lines from a real tree (the direction of the change; the exact
+/// ratio is fixture-dependent and deliberately not asserted), and every id it keeps must still
+/// resolve in the full tree — the property that keeps an elided element addressable by
+/// `glass_click_element` / `glass_set_value` after compaction: ids are assigned over the full
+/// tree and compaction must never invent or renumber one.
+#[test]
+#[ignore = "requires an X server + AT-SPI bus; run via scripts/verification-cost.sh"]
+fn compact_outline_is_smaller_and_every_id_still_resolves() {
+    let mut glass = glass_mcp::boot(None);
+    start_fixture_sync(&mut glass);
+    let tree = wait_for_widgets_sync(&mut glass);
+
+    let full = tree.to_outline();
+    let compact = glass_core::outline::render_compact(&tree);
+
+    assert!(
+        compact.lines().count() < full.lines().count(),
+        "compaction must remove lines (full {} / compact {})",
+        full.lines().count(),
+        compact.lines().count()
+    );
+    for id in ids_in(&compact) {
+        assert!(
+            tree.find(id).is_some(),
+            "#{} appears in the compact outline but resolves to nothing — compaction must \
+             never invent or renumber ids",
+            id.0
+        );
+    }
+
+    let _ = glass.stop();
 }
 
 #[cfg(test)]

--- a/crates/glass-testapp/tests/common/mcp_cost.rs
+++ b/crates/glass-testapp/tests/common/mcp_cost.rs
@@ -11,6 +11,13 @@
 //! calls it) — which means the `#[cfg(test)]` unit tests below run under `cargo test
 //! --workspace` regardless.
 
+// One `unsafe { env::set_var }` for pre-spawn GLASS_DISPLAY setup in
+// `compact_outline_is_smaller_and_every_id_still_resolves` (see its `// SAFETY:` note), same
+// opt-out as verification_cost.rs / ignore_regions_e2e.rs / network.rs. It lives here, on this
+// module, rather than on each binary's crate root: this file is compiled into several test
+// binaries (see above) and only this one test needs it.
+#![allow(unsafe_code)]
+
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
@@ -22,6 +29,8 @@ use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig
 use rmcp::transport::StreamableHttpClientTransport;
 use rmcp::{Peer, RoleClient, ServiceExt};
 use serde_json::{json, Value};
+
+use super::Xvfb;
 
 /// Repo root: `crates/glass-testapp` is two levels below it.
 fn repo_root() -> PathBuf {
@@ -631,9 +640,9 @@ async fn restart_fixture(client: &Peer<RoleClient>) {
 /// property this file's cost-and-integrity test needs — `glass_a11y_snapshot` always answers
 /// with `render_compact`'s output (see `glass_mcp::tools::a11y_snapshot`), never the
 /// uncompacted `AxTree::to_outline` render — so that test drives `Glass` directly to see both.
-/// Leaves `GLASS_DISPLAY` unset so the x11 backend spawns its own private headless display
-/// (see `glass_x11::X11Platform::from_env`), which avoids the `unsafe { env::set_var }` the
-/// wire-based tests in this suite need for attach mode.
+/// The caller must point `GLASS_DISPLAY` at a live Xvfb before calling this, the same as the
+/// wire-based tests in this suite: `start_on("x11", ...)` attaches to whatever display
+/// `GLASS_DISPLAY` names rather than spawning its own.
 fn start_fixture_sync(glass: &mut Glass) {
     let (build, run, cwd) = fixture_run_spec();
     let spec = AppSpec {
@@ -711,6 +720,10 @@ fn ids_in(outline: &str) -> Vec<AxNodeId> {
 #[test]
 #[ignore = "requires an X server + AT-SPI bus; run via scripts/verification-cost.sh"]
 fn compact_outline_is_smaller_and_every_id_still_resolves() {
+    let xvfb = Xvfb::start();
+    // SAFETY: single-threaded test setup; runs before any server task spawns.
+    unsafe { std::env::set_var("GLASS_DISPLAY", &xvfb.display) };
+
     let mut glass = glass_mcp::boot(None);
     start_fixture_sync(&mut glass);
     let tree = wait_for_widgets_sync(&mut glass);

--- a/crates/glass-testapp/tests/common/mcp_cost.rs
+++ b/crates/glass-testapp/tests/common/mcp_cost.rs
@@ -11,17 +11,9 @@
 //! calls it) — which means the `#[cfg(test)]` unit tests below run under `cargo test
 //! --workspace` regardless.
 
-// One `unsafe { env::set_var }` for pre-spawn GLASS_DISPLAY setup in
-// `compact_outline_is_smaller_and_every_id_still_resolves` (see its `// SAFETY:` note), same
-// opt-out as verification_cost.rs / ignore_regions_e2e.rs / network.rs. It lives here, on this
-// module, rather than on each binary's crate root: this file is compiled into several test
-// binaries (see above) and only this one test needs it.
-#![allow(unsafe_code)]
-
 use std::path::PathBuf;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
-use glass_core::{AppSpec, AxNodeId, AxTree, Glass, SandboxLevel};
 use glass_mcp::serve::config::ServeConfig;
 use rmcp::model::CallToolRequestParams;
 use rmcp::service::RunningService;
@@ -29,8 +21,6 @@ use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig
 use rmcp::transport::StreamableHttpClientTransport;
 use rmcp::{Peer, RoleClient, ServiceExt};
 use serde_json::{json, Value};
-
-use super::Xvfb;
 
 /// Repo root: `crates/glass-testapp` is two levels below it.
 fn repo_root() -> PathBuf {
@@ -143,8 +133,8 @@ pub async fn start_fixture(client: &Peer<RoleClient>) {
 
 /// How long `a11y_outline` retries a snapshot that reports the launched app isn't publishing
 /// an accessibility tree yet.
-const A11Y_SETTLE_TIMEOUT: Duration = Duration::from_secs(5);
-const A11Y_POLL_INTERVAL: Duration = Duration::from_millis(200);
+pub(crate) const A11Y_SETTLE_TIMEOUT: Duration = Duration::from_secs(5);
+pub(crate) const A11Y_POLL_INTERVAL: Duration = Duration::from_millis(200);
 
 /// Snapshot the a11y tree; return the full text (envelope + untrusted outline). Retries for
 /// up to `A11Y_SETTLE_TIMEOUT`: immediately after `glass_start` returns, the launched app's
@@ -375,7 +365,7 @@ impl std::fmt::Display for ArmReport {
 /// tree before giving up. The larger of the two deadlines this consolidates (mcp_cost.rs
 /// previously used 5s, `verification_cost.rs`'s now-removed `poll_until_widgets_present`
 /// used 10s) so the shared function has the more generous headroom of the two under load.
-const WIDGETS_SETTLE_TIMEOUT: Duration = Duration::from_secs(10);
+pub(crate) const WIDGETS_SETTLE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Poll (unmetered) until the fixture's three widgets are all present in the a11y tree, or
 /// `WIDGETS_SETTLE_TIMEOUT` elapses (in which case this panics, embedding the last-seen
@@ -633,120 +623,6 @@ pub async fn run_verification_cost(client: &Peer<RoleClient>) -> (ArmReport, Arm
 async fn restart_fixture(client: &Peer<RoleClient>) {
     call(client, "glass_stop", json!({})).await;
     start_fixture(client).await;
-}
-
-/// Sync counterpart to `start_fixture`: launches the same fixture app directly against a
-/// `glass_core::Glass` session instead of over the MCP wire. The wire has no route to the
-/// property this file's cost-and-integrity test needs — `glass_a11y_snapshot` always answers
-/// with `render_compact`'s output (see `glass_mcp::tools::a11y_snapshot`), never the
-/// uncompacted `AxTree::to_outline` render — so that test drives `Glass` directly to see both.
-/// The caller must point `GLASS_DISPLAY` at a live Xvfb before calling this, the same as the
-/// wire-based tests in this suite: `start_on("x11", ...)` attaches to whatever display
-/// `GLASS_DISPLAY` names rather than spawning its own.
-fn start_fixture_sync(glass: &mut Glass) {
-    let (build, run, cwd) = fixture_run_spec();
-    let spec = AppSpec {
-        build: Some(build),
-        run: vec![run],
-        cwd: Some(PathBuf::from(cwd)),
-        env: vec![],
-        window_hint: None,
-        timeout_ms: 120_000, // first egui build is slow, same as start_fixture
-        sandbox: SandboxLevel::Off,
-        a11y: true,
-    };
-    glass
-        .start_on("x11", &spec)
-        .unwrap_or_else(|e| panic!("start_on(x11) failed: {e}"));
-}
-
-/// Sync counterpart to `wait_for_widgets`: polls `Glass::a11y_snapshot` directly rather than
-/// an MCP `Peer`, for the same reason as `start_fixture_sync`. Same retry reasoning as
-/// `wait_for_widgets`/`a11y_outline`: the launched app's toolkit can transiently error (its
-/// AT-SPI subtree not registered yet) or answer with a placeholder root before its widgets are
-/// filled in, so both are retried up to the combined budget.
-fn wait_for_widgets_sync(glass: &mut Glass) -> AxTree {
-    let deadline = Instant::now() + A11Y_SETTLE_TIMEOUT + WIDGETS_SETTLE_TIMEOUT;
-    loop {
-        match glass.a11y_snapshot() {
-            Ok(tree) => {
-                let outline = tree.to_outline();
-                let ready = find_named_button(&outline, "Apply").is_some()
-                    && find_by_role(&outline, "slider").is_some()
-                    && find_by_role(&outline, "text").is_some();
-                if ready {
-                    return tree;
-                }
-                if Instant::now() >= deadline {
-                    panic!(
-                        "wait_for_widgets_sync: timed out waiting for the fixture's widgets; \
-                         last-seen outline:\n{outline}"
-                    );
-                }
-            }
-            Err(e) if Instant::now() < deadline => {
-                let _ = e; // transient during app startup; keep polling
-            }
-            Err(e) => panic!("a11y_snapshot errored: {e}"),
-        }
-        std::thread::sleep(A11Y_POLL_INTERVAL);
-    }
-}
-
-/// Every `#<n>` id at the start of an outline's lines (see `find_by_role`'s doc for the line
-/// shape) — `split_whitespace` + `strip_prefix('#')`, no regex dependency.
-fn ids_in(outline: &str) -> Vec<AxNodeId> {
-    let mut ids = Vec::new();
-    for line in outline.lines() {
-        let Some(tok) = line.split_whitespace().next() else {
-            continue;
-        };
-        let Some(digits) = tok.strip_prefix('#') else {
-            continue;
-        };
-        let Ok(id) = digits.parse::<u32>() else {
-            continue;
-        };
-        ids.push(AxNodeId(id));
-    }
-    ids
-}
-
-/// `render_compact` must remove lines from a real tree (the direction of the change; the exact
-/// ratio is fixture-dependent and deliberately not asserted), and every id it keeps must still
-/// resolve in the full tree — the property that keeps an elided element addressable by
-/// `glass_click_element` / `glass_set_value` after compaction: ids are assigned over the full
-/// tree and compaction must never invent or renumber one.
-#[test]
-#[ignore = "requires an X server + AT-SPI bus; run via scripts/verification-cost.sh"]
-fn compact_outline_is_smaller_and_every_id_still_resolves() {
-    let xvfb = Xvfb::start();
-    // SAFETY: single-threaded test setup; runs before any server task spawns.
-    unsafe { std::env::set_var("GLASS_DISPLAY", &xvfb.display) };
-
-    let mut glass = glass_mcp::boot(None);
-    start_fixture_sync(&mut glass);
-    let tree = wait_for_widgets_sync(&mut glass);
-
-    let full = tree.to_outline();
-    let compact = glass_core::outline::render_compact(&tree);
-
-    assert!(
-        compact.lines().count() < full.lines().count(),
-        "compaction must remove lines (full {} / compact {})",
-        full.lines().count(),
-        compact.lines().count()
-    );
-    for id in ids_in(&compact) {
-        assert!(
-            tree.find(id).is_some(),
-            "#{} appears in the compact outline but resolves to nothing — compaction must \
-             never invent or renumber ids",
-            id.0
-        );
-    }
-
-    let _ = glass.stop();
 }
 
 #[cfg(test)]

--- a/crates/glass-testapp/tests/verification_cost.rs
+++ b/crates/glass-testapp/tests/verification_cost.rs
@@ -8,6 +8,11 @@
 
 mod common;
 
+use std::path::PathBuf;
+use std::time::Instant;
+
+use glass_core::{AppSpec, AxNodeId, AxTree, Glass, SandboxLevel};
+
 use common::mcp_cost;
 use common::Xvfb;
 
@@ -128,4 +133,119 @@ async fn verification_cost_semantic_beats_screenshot() {
     assert!(a.text_bytes > 0 && b.text_bytes > 0);
 
     client.cancel().await.ok();
+}
+
+/// Sync counterpart to `mcp_cost::start_fixture`: launches the same fixture app directly
+/// against a `glass_core::Glass` session instead of over the MCP wire. The wire has no route
+/// to the property this file's cost-and-integrity test needs — `glass_a11y_snapshot` always
+/// answers with `render_compact`'s output (see `glass_mcp::tools::a11y_snapshot`), never the
+/// uncompacted `AxTree::to_outline` render — so that test drives `Glass` directly to see both.
+/// The caller must point `GLASS_DISPLAY` at a live Xvfb before calling this, the same as the
+/// wire-based tests in this suite: `start_on("x11", ...)` attaches to whatever display
+/// `GLASS_DISPLAY` names rather than spawning its own.
+fn start_fixture_sync(glass: &mut Glass) {
+    let (build, run, cwd) = mcp_cost::fixture_run_spec();
+    let spec = AppSpec {
+        build: Some(build),
+        run: vec![run],
+        cwd: Some(PathBuf::from(cwd)),
+        env: vec![],
+        window_hint: None,
+        timeout_ms: 120_000, // first egui build is slow, same as start_fixture
+        sandbox: SandboxLevel::Off,
+        a11y: true,
+    };
+    glass
+        .start_on("x11", &spec)
+        .unwrap_or_else(|e| panic!("start_on(x11) failed: {e}"));
+}
+
+/// Sync counterpart to `mcp_cost::wait_for_widgets`: polls `Glass::a11y_snapshot` directly
+/// rather than an MCP `Peer`, for the same reason as `start_fixture_sync`. Same retry
+/// reasoning as `wait_for_widgets`/`a11y_outline`: the launched app's toolkit can transiently
+/// error (its AT-SPI subtree not registered yet) or answer with a placeholder root before its
+/// widgets are filled in, so both are retried up to the combined budget.
+fn wait_for_widgets_sync(glass: &mut Glass) -> AxTree {
+    let deadline =
+        Instant::now() + mcp_cost::A11Y_SETTLE_TIMEOUT + mcp_cost::WIDGETS_SETTLE_TIMEOUT;
+    loop {
+        match glass.a11y_snapshot() {
+            Ok(tree) => {
+                let outline = tree.to_outline();
+                let ready = mcp_cost::find_named_button(&outline, "Apply").is_some()
+                    && mcp_cost::find_by_role(&outline, "slider").is_some()
+                    && mcp_cost::find_by_role(&outline, "text").is_some();
+                if ready {
+                    return tree;
+                }
+                if Instant::now() >= deadline {
+                    panic!(
+                        "wait_for_widgets_sync: timed out waiting for the fixture's widgets; \
+                         last-seen outline:\n{outline}"
+                    );
+                }
+            }
+            Err(e) if Instant::now() < deadline => {
+                let _ = e; // transient during app startup; keep polling
+            }
+            Err(e) => panic!("a11y_snapshot errored: {e}"),
+        }
+        std::thread::sleep(mcp_cost::A11Y_POLL_INTERVAL);
+    }
+}
+
+/// Every `#<n>` id at the start of an outline's lines (see `mcp_cost::find_by_role`'s doc for
+/// the line shape) — `split_whitespace` + `strip_prefix('#')`, no regex dependency.
+fn ids_in(outline: &str) -> Vec<AxNodeId> {
+    let mut ids = Vec::new();
+    for line in outline.lines() {
+        let Some(tok) = line.split_whitespace().next() else {
+            continue;
+        };
+        let Some(digits) = tok.strip_prefix('#') else {
+            continue;
+        };
+        let Ok(id) = digits.parse::<u32>() else {
+            continue;
+        };
+        ids.push(AxNodeId(id));
+    }
+    ids
+}
+
+/// `render_compact` must remove lines from a real tree (the direction of the change; the exact
+/// ratio is fixture-dependent and deliberately not asserted), and every id it keeps must still
+/// resolve in the full tree — the property that keeps an elided element addressable by
+/// `glass_click_element` / `glass_set_value` after compaction: ids are assigned over the full
+/// tree and compaction must never invent or renumber one.
+#[test]
+#[ignore = "requires an X server + AT-SPI bus; run via scripts/verification-cost.sh"]
+fn compact_outline_is_smaller_and_every_id_still_resolves() {
+    let xvfb = Xvfb::start();
+    // SAFETY: single-threaded test setup; runs before any server task spawns.
+    unsafe { std::env::set_var("GLASS_DISPLAY", &xvfb.display) };
+
+    let mut glass = glass_mcp::boot(None);
+    start_fixture_sync(&mut glass);
+    let tree = wait_for_widgets_sync(&mut glass);
+
+    let full = tree.to_outline();
+    let compact = glass_core::outline::render_compact(&tree);
+
+    assert!(
+        compact.lines().count() < full.lines().count(),
+        "compaction must remove lines (full {} / compact {})",
+        full.lines().count(),
+        compact.lines().count()
+    );
+    for id in ids_in(&compact) {
+        assert!(
+            tree.find(id).is_some(),
+            "#{} appears in the compact outline but resolves to nothing — compaction must \
+             never invent or renumber ids",
+            id.0
+        );
+    }
+
+    let _ = glass.stop();
 }


### PR DESCRIPTION
## What

Two changes to the accessibility snapshot, applied across all five OS backends.

**Compact outline.** `glass_a11y_snapshot` now collapses chains of unnamed, non-focusable,
single-child container elements out of the rendered outline — the wrapper scaffolding toolkits
emit that carries no addressable information. Element ids are assigned over the full tree and the
session cache keeps every node, so an elided element remains addressable by `glass_click_element`
/ `glass_set_value`. A focusable container is never elided, so a control a toolkit exposes as a
clickable container (with its role lost) stays visible in the outline rather than becoming
invisible-but-clickable.

**Honest truncation.** Every backend now shares one set of size limits and records which one
stopped a walk; the outline discloses it. Previously two backends capped silently — a truncated
tree was indistinguishable from a complete one, so a missing element read as "does not exist" —
and three had no bound at all (on Linux a large tree could exhaust the snapshot timeout and return
*no* tree). The disclosure is a partial-success notice, never an error.

## Why it is safe

- Compaction is **render-level only**. `AxTree::to_outline()` is unchanged and still used by
  `scroll_to_element`'s saturation check, which compares consecutive outlines — elided wrappers
  carry bounds that change as content scrolls, so compacting there could make a still-scrolling
  view look saturated. The two renderers share one line writer so they cannot drift.
- In the Linux, Windows and macOS readers the tree-building walk and the `set_value` mirror walk
  share a single children-gating decision, so a bound can never fire in one and not the other —
  which would otherwise resolve a caller-supplied id against a different tree and write to the
  wrong element.
- On Android, truncation stops the walk rather than skipping nodes, preserving the
  `AxNodeId(n) == device ref n` alignment that `set_value` depends on.

## Known limitations (documented in code)

- On macOS and Windows the "has children to explore" gate tests the raw child list before the
  per-child visibility filter, so a node whose children are all filtered, reached exactly at
  budget exhaustion, can record a truncation although nothing real was declined. Closing it would
  require walking the whole sibling chain — the unbounded scan the sibling cap exists to bound —
  so the narrower false positive is accepted and documented at each gate site.
- There is no live regression test at exactly the node cap on the IPC-backed readers; a tree at
  the cap would exceed the snapshot timeout at the current per-node round-trip cost. It is
  unit-tested directly in the Android and iOS mappers (which build synthetic trees in-process),
  and a live version rides with a separate per-node-cost reduction.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
  `cargo test --workspace` — green (66 test groups, 0 failed)
- Windows cross-compile (`x86_64-pc-windows-gnu`) and macOS build+clippy — green
- Live AT-SPI suite — 24/24
- Windows on-box accessibility suite — 3/3, no spurious truncation on a real UI tree
- Cost/integrity test on a real X11+AT-SPI fixture tree: the compact render is strictly smaller
  than the full one, and every id it keeps resolves in the full tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)
