### PR TITLE
feat(a11y): configurable snapshot limits (max_nodes) — no more hardwall caps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@ internal refactors, CI, or test-only changes.
 - Linux accessibility snapshots are faster on large trees: the AT-SPI reader now issues each
   element's independent property reads concurrently instead of one at a time.
 - `glass_a11y_snapshot` accepts an optional `max_nodes`: raise the element cap for a large app,
-  or pass `0` for the full tree. The default cap is unchanged, and when a snapshot is truncated
-  the notice now says how to widen it.
+  or pass `0` to remove the element-count limit. The default cap is unchanged, and when a snapshot
+  is truncated the notice now reports the actual limit and says how to widen it.
 
 ### Fixed
 - The accessibility tree now reports when a snapshot was truncated. Previously a tree that hit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ internal refactors, CI, or test-only changes.
   addressable with `glass_click_element` / `glass_set_value`.
 - Linux accessibility snapshots are faster on large trees: the AT-SPI reader now issues each
   element's independent property reads concurrently instead of one at a time.
+- `glass_a11y_snapshot` accepts an optional `max_nodes`: raise the element cap for a large app,
+  or pass `0` for the full tree. The default cap is unchanged, and when a snapshot is truncated
+  the notice now says how to widen it.
 
 ### Fixed
 - The accessibility tree now reports when a snapshot was truncated. Previously a tree that hit

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -11,7 +11,7 @@ use atspi::proxy::component::ComponentProxy;
 use atspi_common::{CoordType, ObjectRefOwned};
 use glass_core::{
     Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget, AxTree, GlassError, Result,
-    TruncationLimit, WalkBudget, MAX_SIBLINGS,
+    TruncationLimit, WalkBudget,
 };
 
 use crate::mapping::{map_role, map_states};
@@ -144,7 +144,7 @@ async fn snapshot_async(ctx: &AxContext) -> Result<AxTree> {
         .await
         .map_err(bus_err)?;
 
-    let mut budget = WalkBudget::new();
+    let mut budget = WalkBudget::with_limits(ctx.limits);
     let root_node = Box::pin(walk(&app, &zbus_conn, 0, &mut budget)).await?;
     let mut tree = AxTree::new(root_node);
     tree.truncated = budget.truncation();
@@ -165,7 +165,7 @@ fn writes_value_only(role: glass_core::AxRole, text: &str) -> bool {
 async fn set_value_async(ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
     let (app_ref, conn) = find_app(ctx).await?;
     let app = app_ref.as_accessible_proxy(&conn).await.map_err(bus_err)?;
-    let mut budget = WalkBudget::new();
+    let mut budget = WalkBudget::with_limits(ctx.limits);
     let node_ref = Box::pin(find_nth(&app_ref, &app, &conn, 0, target.id.0, &mut budget))
         .await?
         .ok_or(GlassError::AxElementChanged(target.id.0))?;
@@ -291,7 +291,7 @@ async fn find_nth(
             break;
         }
         siblings += 1;
-        if siblings > MAX_SIBLINGS {
+        if siblings > budget.max_siblings() {
             budget.hit(TruncationLimit::Siblings);
             break;
         }
@@ -382,7 +382,7 @@ async fn walk(
                 break;
             }
             siblings += 1;
-            if siblings > MAX_SIBLINGS {
+            if siblings > budget.max_siblings() {
                 budget.hit(TruncationLimit::Siblings);
                 break;
             }

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -808,13 +808,11 @@ fn scroll_to_element_reports_unmatched_for_an_absent_row() {
     glass.stop().expect("stop");
 }
 
-/// A real AT-SPI tree larger than `MAX_NODES` snapshots into a bounded, complete prefix flagged
-/// `Nodes` — the live end-to-end truncation path the in-process Android/iOS mapper unit tests
-/// cannot cover. Also logs the snapshot wall-time (a fast walk is why this test is practical;
-/// asserted for correctness only, never a latency bound, so it cannot flake on a loaded machine).
-#[test]
-#[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
-fn snapshot_past_node_cap_is_bounded_complete_and_flagged() {
+/// Launches the bench fixture (`a11y_bench_fixture.py`, ~1900 realized widgets) with a11y
+/// enabled and waits for its AT-SPI tree to populate. Shared by the over-cap parity test and
+/// the configurable-limits tests below — this fixture is the only one wide enough to exceed
+/// `MAX_NODES`.
+fn launch_bench() -> Glass {
     let fixture = concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/tests/fixtures/a11y_bench_fixture.py"
@@ -844,6 +842,17 @@ fn snapshot_past_node_cap_is_bounded_complete_and_flagged() {
     // fixture realizes ~1300 widgets, so registration with the AT-SPI registry lags the
     // window map more than the small fixture's does.
     std::thread::sleep(std::time::Duration::from_millis(3_000));
+    glass
+}
+
+/// A real AT-SPI tree larger than `MAX_NODES` snapshots into a bounded, complete prefix flagged
+/// `Nodes` — the live end-to-end truncation path the in-process Android/iOS mapper unit tests
+/// cannot cover. Also logs the snapshot wall-time (a fast walk is why this test is practical;
+/// asserted for correctness only, never a latency bound, so it cannot flake on a loaded machine).
+#[test]
+#[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
+fn snapshot_past_node_cap_is_bounded_complete_and_flagged() {
+    let mut glass = launch_bench();
 
     let started = std::time::Instant::now();
     let tree = glass.a11y_snapshot(None).expect("a11y snapshot");
@@ -871,5 +880,70 @@ fn snapshot_past_node_cap_is_bounded_complete_and_flagged() {
     assert!(
         find_role(&tree.root, glass_core::AxRole::Button).is_some(),
         "the bounded prefix still contains real widgets from the top of the tree"
+    );
+}
+
+/// max_nodes:0 (unbounded) returns the WHOLE bench tree — past the default cap, not truncated.
+#[test]
+#[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
+fn unbounded_snapshot_returns_the_full_tree_past_the_default_cap() {
+    let mut glass = launch_bench();
+    let tree = glass.a11y_snapshot(Some(0)).expect("unbounded snapshot");
+    glass.stop().expect("stop");
+    assert!(tree.truncated.is_none(), "unbounded walk is not truncated");
+    assert!(
+        tree.to_outline().lines().count() > glass_core::MAX_NODES,
+        "the full tree exceeds the default cap"
+    );
+}
+
+/// A raised numeric cap stops at exactly that many nodes.
+#[test]
+#[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
+fn raised_cap_snapshot_stops_at_the_requested_count() {
+    let mut glass = launch_bench();
+    let tree = glass
+        .a11y_snapshot(Some(2000))
+        .expect("raised-cap snapshot");
+    glass.stop().expect("stop");
+    assert_eq!(
+        tree.to_outline().lines().count(),
+        2000,
+        "the walk stops at the raised cap"
+    );
+    assert_eq!(
+        tree.truncated.map(|t| t.limit),
+        Some(glass_core::TruncationLimit::Nodes)
+    );
+}
+
+/// Lockstep across a raised cap: an id assigned PAST the old cap by an unbounded snapshot is still
+/// resolvable by set_value — find_nth re-walks with the session's stored (unbounded) limits. If
+/// the limits weren't reused, find_nth would truncate at the default cap and fail to resolve the id
+/// (AxElementChanged). Reaching the node (a non-editable one → AxElementNotEditable) proves lockstep.
+#[test]
+#[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
+fn set_value_resolves_an_id_past_the_default_cap_from_an_unbounded_snapshot() {
+    let mut glass = launch_bench();
+    let tree = glass.a11y_snapshot(Some(0)).expect("unbounded snapshot");
+    let last = tree.to_outline().lines().count() - 1;
+    assert!(
+        last > glass_core::MAX_NODES,
+        "an id past the default cap exists"
+    );
+    let err = glass
+        .set_value(glass_core::AxNodeId(last as u32), "x")
+        .unwrap_err();
+    glass.stop().expect("stop");
+    let msg = err.to_string();
+    // The failure mode (lockstep broken) is `AxElementChanged`: "element #N changed since the
+    // snapshot; re-snapshot" — find_nth re-walked with the default (not the stored unbounded)
+    // limits, truncated before reaching `last`, and returned None. The success mode (lockstep
+    // held, node reached but not editable) is `AxElementNotEditable`: "element #N is not
+    // editable via the accessibility API ...". Neither "changed" nor "not found" appears in the
+    // not-editable message, so this substring pair cleanly distinguishes the two.
+    assert!(
+        !msg.to_lowercase().contains("changed") && !msg.to_lowercase().contains("not found"),
+        "the id past the old cap resolved (lockstep held); got: {msg}"
     );
 }

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -94,7 +94,7 @@ fn snapshot_finds_gtk_widgets() {
     // blocking on a D-Bus activation timeout.
     std::thread::sleep(std::time::Duration::from_millis(3_000));
 
-    let tree = glass.a11y_snapshot().expect("a11y snapshot");
+    let tree = glass.a11y_snapshot(None).expect("a11y snapshot");
     let outline = tree.to_outline();
     assert!(
         outline.contains("Button \"Save\""),
@@ -152,7 +152,10 @@ fn a11y_launch_is_fast_without_the_portal_hang() {
     );
 
     std::thread::sleep(std::time::Duration::from_millis(3_000));
-    let outline = glass.a11y_snapshot().expect("a11y snapshot").to_outline();
+    let outline = glass
+        .a11y_snapshot(None)
+        .expect("a11y snapshot")
+        .to_outline();
     assert!(
         outline.contains("Button \"Save\""),
         "a11y tree missing after a fast launch:\n{outline}"
@@ -189,7 +192,7 @@ fn snapshot_reads_entry_value() {
         .expect("launch GTK fixture");
     std::thread::sleep(std::time::Duration::from_millis(3_000));
 
-    let tree = glass.a11y_snapshot().expect("a11y snapshot");
+    let tree = glass.a11y_snapshot(None).expect("a11y snapshot");
     let outline = tree.to_outline();
     // GTK4 Gtk.Entry exposes AT-SPI Role::Text, which maps to AxRole::TextArea.
     // read_value handles both TextField and TextArea via the Text interface.
@@ -232,7 +235,7 @@ fn set_value_changes_entry() {
         .expect("launch");
     std::thread::sleep(std::time::Duration::from_millis(3_000));
 
-    let tree = glass.a11y_snapshot().expect("snapshot");
+    let tree = glass.a11y_snapshot(None).expect("snapshot");
     // GTK4 Gtk.Entry exposes AT-SPI Role::Text -> maps to AxRole::TextArea.
     let entry = find_role(&tree.root, glass_core::AxRole::TextArea)
         .or_else(|| find_role(&tree.root, glass_core::AxRole::TextField))
@@ -241,7 +244,7 @@ fn set_value_changes_entry() {
     glass.set_value(entry_id, "changed").expect("set_value");
 
     // Re-snapshot and confirm the new value.
-    let tree2 = glass.a11y_snapshot().expect("snapshot 2");
+    let tree2 = glass.a11y_snapshot(None).expect("snapshot 2");
     let entry2 = find_role(&tree2.root, glass_core::AxRole::TextArea)
         .or_else(|| find_role(&tree2.root, glass_core::AxRole::TextField))
         .expect("entry 2");
@@ -281,7 +284,7 @@ fn set_value_on_button_is_not_editable() {
         .expect("launch");
     std::thread::sleep(std::time::Duration::from_millis(3_000));
 
-    let tree = glass.a11y_snapshot().expect("snapshot");
+    let tree = glass.a11y_snapshot(None).expect("snapshot");
     let button = find_role(&tree.root, glass_core::AxRole::Button).expect("button");
     let err = glass.set_value(button.id, "x").unwrap_err();
     assert!(
@@ -322,12 +325,12 @@ fn set_value_changes_spinbutton() {
     // A GtkSpinButton exposes both EditableText and Value; set_value must write through the
     // Value interface (the only one that commits to the adjustment) rather than the entry
     // buffer, which reverts.
-    let tree = glass.a11y_snapshot().expect("snapshot");
+    let tree = glass.a11y_snapshot(None).expect("snapshot");
     let spin = find_role(&tree.root, glass_core::AxRole::SpinButton).expect("spinbutton");
     assert_eq!(spin.value.as_deref(), Some("1"), "fixture starts at 1");
     glass.set_value(spin.id, "4").expect("set_value");
 
-    let tree2 = glass.a11y_snapshot().expect("snapshot 2");
+    let tree2 = glass.a11y_snapshot(None).expect("snapshot 2");
     let spin2 = find_role(&tree2.root, glass_core::AxRole::SpinButton).expect("spinbutton 2");
     assert_eq!(
         spin2.value.as_deref(),
@@ -403,12 +406,12 @@ fn set_value_toggles_switch() {
     let mut glass = launch_fixture();
     // The GtkSwitch "Active" starts off; set_value must flip it on via the Action
     // "toggle" (it exposes no text/Value interface).
-    let tree = glass.a11y_snapshot().expect("snapshot");
+    let tree = glass.a11y_snapshot(None).expect("snapshot");
     let sw = find_role_name(&tree.root, glass_core::AxRole::CheckBox, "Active").expect("switch");
     assert!(!sw.states.checked, "switch starts off");
     glass.set_value(sw.id, "true").expect("set_value true"); // set_value polls until applied
 
-    let tree2 = glass.a11y_snapshot().expect("snapshot 2");
+    let tree2 = glass.a11y_snapshot(None).expect("snapshot 2");
     let sw2 =
         find_role_name(&tree2.root, glass_core::AxRole::CheckBox, "Active").expect("switch 2");
     assert!(
@@ -420,12 +423,12 @@ fn set_value_toggles_switch() {
     glass
         .set_value(sw2.id, "true")
         .expect("set_value true again");
-    let tree3 = glass.a11y_snapshot().expect("snapshot 3");
+    let tree3 = glass.a11y_snapshot(None).expect("snapshot 3");
     let sw3 =
         find_role_name(&tree3.root, glass_core::AxRole::CheckBox, "Active").expect("switch 3");
     assert!(sw3.states.checked, "still on after idempotent set");
     glass.set_value(sw3.id, "false").expect("set_value false");
-    let tree4 = glass.a11y_snapshot().expect("snapshot 4");
+    let tree4 = glass.a11y_snapshot(None).expect("snapshot 4");
     let sw4 =
         find_role_name(&tree4.root, glass_core::AxRole::CheckBox, "Active").expect("switch 4");
     assert!(
@@ -441,7 +444,7 @@ fn set_value_selects_dropdown_option() {
     let mut glass = launch_fixture();
     // The GtkDropDown starts on "Acme"; set_value must select "Globex" by opening
     // the popup and picking the option through the Selection interface.
-    let tree = glass.a11y_snapshot().expect("snapshot");
+    let tree = glass.a11y_snapshot(None).expect("snapshot");
     let combo = find_role(&tree.root, glass_core::AxRole::ComboBox).expect("combo box");
     assert_eq!(combo.name.as_deref(), Some("Acme"), "starts on Acme");
     glass
@@ -449,7 +452,7 @@ fn set_value_selects_dropdown_option() {
         .expect("set_value Globex");
 
     std::thread::sleep(std::time::Duration::from_millis(500));
-    let tree2 = glass.a11y_snapshot().expect("snapshot 2");
+    let tree2 = glass.a11y_snapshot(None).expect("snapshot 2");
     let combo2 = find_role(&tree2.root, glass_core::AxRole::ComboBox).expect("combo box 2");
     assert_eq!(
         combo2.name.as_deref(),
@@ -485,7 +488,7 @@ fn set_value_selects_dropdown_option() {
 #[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
 fn screenshot_includes_open_popover() {
     let mut glass = launch_fixture();
-    let tree = glass.a11y_snapshot().expect("snapshot");
+    let tree = glass.a11y_snapshot(None).expect("snapshot");
     let combo = find_role(&tree.root, glass_core::AxRole::ComboBox).expect("combo");
     let combo_id = combo.id;
     let combo_bounds = combo.bounds.expect("combo box must report bounds");
@@ -539,15 +542,15 @@ fn screenshot_includes_open_popover() {
 #[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
 fn click_element_commits_dropdown_option() {
     let mut glass = launch_fixture();
-    let tree = glass.a11y_snapshot().expect("snapshot");
+    let tree = glass.a11y_snapshot(None).expect("snapshot");
     let combo = find_role(&tree.root, glass_core::AxRole::ComboBox).expect("combo");
     glass.click_element(combo.id).expect("open");
     std::thread::sleep(std::time::Duration::from_millis(600));
-    let t2 = glass.a11y_snapshot().expect("snap2");
+    let t2 = glass.a11y_snapshot(None).expect("snap2");
     let globex = find_node(&t2.root, "Globex").expect("globex");
     glass.click_element(globex.id).expect("click option");
     std::thread::sleep(std::time::Duration::from_millis(500));
-    let t3 = glass.a11y_snapshot().expect("snap3");
+    let t3 = glass.a11y_snapshot(None).expect("snap3");
     assert_eq!(
         find_role(&t3.root, glass_core::AxRole::ComboBox).and_then(|c| c.name.as_deref()),
         Some("Globex"),
@@ -588,7 +591,7 @@ fn snapshot_without_a11y_flag_errors() {
     std::thread::sleep(std::time::Duration::from_millis(3_000));
 
     let err = glass
-        .a11y_snapshot()
+        .a11y_snapshot(None)
         .expect_err("snapshot must fail without a11y:true");
     match err {
         glass_core::GlassError::AccessibilityUnavailable(msg) => {
@@ -626,7 +629,7 @@ fn sandboxed_a11y_finds_widgets(level: glass_core::SandboxLevel) {
         .unwrap_or_else(|e| panic!("launch GTK fixture sandboxed ({level:?}): {e}"));
     std::thread::sleep(std::time::Duration::from_millis(3_000));
     let outline = glass
-        .a11y_snapshot()
+        .a11y_snapshot(None)
         .expect("a11y snapshot (sandboxed)")
         .to_outline();
     assert!(
@@ -688,7 +691,7 @@ fn wayland_a11y_finds_widgets(level: glass_core::SandboxLevel) {
         .unwrap_or_else(|e| panic!("wayland a11y launch ({level:?}): {e}"));
     std::thread::sleep(std::time::Duration::from_millis(3_000));
     let outline = glass
-        .a11y_snapshot()
+        .a11y_snapshot(None)
         .expect("a11y snapshot (wayland)")
         .to_outline();
     assert!(
@@ -724,7 +727,7 @@ fn scroll_to_element_reaches_a_virtualized_offscreen_row() {
     let mut glass = launch_fixture();
     // Precondition: "Row 060" is virtualized — absent from the initial tree. If it
     // were present, the test would prove nothing (no scroll needed).
-    let tree = glass.a11y_snapshot().expect("snapshot");
+    let tree = glass.a11y_snapshot(None).expect("snapshot");
     assert!(
         find_node(&tree.root, "Row 060").is_none(),
         "Row 060 should be off-screen/virtualized at start, but was in the tree"
@@ -780,7 +783,7 @@ fn scroll_to_element_reaches_a_virtualized_offscreen_row() {
 #[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
 fn scroll_to_element_reports_unmatched_for_an_absent_row() {
     let mut glass = launch_fixture();
-    let tree = glass.a11y_snapshot().expect("snapshot");
+    let tree = glass.a11y_snapshot(None).expect("snapshot");
     let seed = find_node(&tree.root, "Row 000").expect("an early row realized at start");
     let sb = seed.bounds.expect("row bounds");
     let anchor = (sb.x + sb.width as i32 / 2, sb.y + sb.height as i32 / 2);
@@ -843,7 +846,7 @@ fn snapshot_past_node_cap_is_bounded_complete_and_flagged() {
     std::thread::sleep(std::time::Duration::from_millis(3_000));
 
     let started = std::time::Instant::now();
-    let tree = glass.a11y_snapshot().expect("a11y snapshot");
+    let tree = glass.a11y_snapshot(None).expect("a11y snapshot");
     eprintln!(
         "over-cap snapshot: {} nodes in {:?}",
         tree.to_outline().lines().count(),

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -20,7 +20,7 @@ use glass_core::coords::pixel_geometry_from_content_rect;
 use glass_core::platform::WindowGeometry;
 use glass_core::{
     Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxTarget, AxTree, GlassError,
-    Result, TruncationLimit, WalkBudget, MAX_SIBLINGS,
+    Result, TruncationLimit, WalkBudget,
 };
 use objc2_application_services::AXUIElement;
 use objc2_core_foundation::CFRetained;
@@ -82,7 +82,7 @@ impl Accessibility for MacosA11y {
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
         let (window_el, scale) = resolve_window(ctx)?;
 
-        let mut budget = WalkBudget::new();
+        let mut budget = WalkBudget::with_limits(ctx.limits);
         let root = walk(&window_el, &ctx.window, scale, 0, &mut budget);
         let mut tree = AxTree::new(root);
         tree.truncated = budget.truncation();
@@ -97,7 +97,7 @@ impl Accessibility for MacosA11y {
         // Start at 0 so `find_nth`'s pre-order numbering matches `snapshot`'s `walk` +
         // `AxTree::assign_ids` (root id = 0); the role+name+bounds fingerprint below
         // backstops any residual drift between the snapshot and this re-walk.
-        let mut budget = WalkBudget::new();
+        let mut budget = WalkBudget::with_limits(ctx.limits);
         let el = find_nth(window_el, 0, &mut budget, target.id.0)
             .ok_or(GlassError::AxElementNotFound(target.id.0))?;
 
@@ -325,7 +325,7 @@ fn walk(
                 break;
             }
             siblings += 1;
-            if siblings > MAX_SIBLINGS {
+            if siblings > budget.max_siblings() {
                 budget.hit(TruncationLimit::Siblings);
                 break;
             }
@@ -416,7 +416,7 @@ fn find_nth(
             break;
         }
         siblings += 1;
-        if siblings > MAX_SIBLINGS {
+        if siblings > budget.max_siblings() {
             budget.hit(TruncationLimit::Siblings);
             break; // same per-level bound as walk(), so find_nth can't spin either
         }

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 
 use glass_core::{
     Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget, AxTree, GlassError, Result,
-    TruncationLimit, WalkBudget, MAX_SIBLINGS,
+    TruncationLimit, WalkBudget,
 };
 use uiautomation::patterns::{
     UIExpandCollapsePattern, UIRangeValuePattern, UISelectionItemPattern, UITogglePattern,
@@ -84,7 +84,7 @@ fn run_snapshot(ctx: &AxContext) -> Result<AxTree> {
     let window = find_app_window(&automation, ctx)?;
 
     let origin = (ctx.window.x, ctx.window.y);
-    let mut budget = WalkBudget::new();
+    let mut budget = WalkBudget::with_limits(ctx.limits);
     let root_node = walk(&walker, &window, origin, 0, &mut budget)?;
     let mut tree = AxTree::new(root_node);
     tree.truncated = budget.truncation();
@@ -149,7 +149,7 @@ fn walk(
                 break;
             }
             siblings += 1;
-            if siblings > MAX_SIBLINGS {
+            if siblings > budget.max_siblings() {
                 budget.hit(TruncationLimit::Siblings);
                 break;
             }
@@ -264,7 +264,7 @@ fn run_set_value(ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
 
     // Start at 0 so find_nth's pre-order numbering matches snapshot's walk +
     // assign_ids (root id = 0); the role+name verify backstops any drift.
-    let mut budget = WalkBudget::new();
+    let mut budget = WalkBudget::with_limits(ctx.limits);
     let el = find_nth(&walker, &window, 0, &mut budget, target.id.0)
         .ok_or(GlassError::AxElementChanged(target.id.0))?;
 
@@ -364,7 +364,7 @@ fn find_nth(
             break;
         }
         siblings += 1;
-        if siblings > MAX_SIBLINGS {
+        if siblings > budget.max_siblings() {
             budget.hit(TruncationLimit::Siblings);
             break; // same per-level bound as walk(), so find_nth can't spin either
         }

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -95,7 +95,7 @@ impl Accessibility for AndroidA11y {
         let status = adb.run(["shell", "uiautomator", "dump", DUMP_PATH])?;
         check_dump_status(&status)?;
         let xml = adb.run(["shell", "cat", DUMP_PATH])?;
-        build_tree(&xml, &window)
+        build_tree(&xml, &window, ctx.limits)
     }
 
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 
 use glass_core::accessibility::{
     Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxStates, AxTarget, AxTree,
-    TruncationLimit, WalkBudget, MAX_SIBLINGS,
+    TruncationLimit, WalkBudget, WalkLimits,
 };
 use glass_core::platform::WindowGeometry;
 use glass_core::{GlassError, Result};
@@ -80,7 +80,7 @@ fn json_to_node(
                     budget.hit(TruncationLimit::Nodes);
                     break;
                 }
-                if i >= MAX_SIBLINGS {
+                if i >= budget.max_siblings() {
                     budget.hit(TruncationLimit::Siblings);
                     break;
                 }
@@ -121,8 +121,12 @@ fn json_to_node(
 }
 
 /// Build the `AxTree` from a device `tree` response value (the `"tree"` object).
-pub(crate) fn tree_from_json(tree: &Value, win: &WindowGeometry) -> Result<AxTree> {
-    let mut budget = WalkBudget::new();
+pub(crate) fn tree_from_json(
+    tree: &Value,
+    win: &WindowGeometry,
+    limits: WalkLimits,
+) -> Result<AxTree> {
+    let mut budget = WalkBudget::with_limits(limits);
     let root = json_to_node(tree, win, 0, &mut budget)?;
     let mut tree = AxTree::new(root);
     tree.truncated = budget.truncation();
@@ -197,7 +201,7 @@ impl ServiceA11y {
 impl Accessibility for ServiceA11y {
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
         let tree = self.client.tree(&self.package)?;
-        tree_from_json(&tree, &ctx.window)
+        tree_from_json(&tree, &ctx.window, ctx.limits)
     }
 
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
@@ -483,7 +487,7 @@ mod tests {
                  "editable": false, "clickable": true, "enabled": true, "scrollable": false}
             ]
         });
-        let mut t = tree_from_json(&v, &win()).unwrap();
+        let mut t = tree_from_json(&v, &win(), WalkLimits::DEFAULT).unwrap();
         t.assign_ids();
         assert_eq!(t.count, 3);
         let email = t.find(AxNodeId(1)).unwrap();
@@ -543,7 +547,7 @@ mod tests {
         // nodes from the middle instead of stopping at the end, every later id would shift and
         // set_value would write to the wrong element.
         let json = wide_device_json(glass_core::MAX_NODES + 50);
-        let mut tree = tree_from_json(&json, &win()).expect("tree parses");
+        let mut tree = tree_from_json(&json, &win(), WalkLimits::DEFAULT).expect("tree parses");
         tree.assign_ids();
 
         assert!(tree.truncated.is_some(), "the node cap must have been hit");
@@ -561,7 +565,7 @@ mod tests {
         // what pushes the running count to MAX_NODES. Nothing was declined, so this must NOT
         // be reported truncated (regression for the false-positive-at-the-cap bug).
         let json = wide_device_json(glass_core::MAX_NODES - 1);
-        let mut tree = tree_from_json(&json, &win()).expect("tree parses");
+        let mut tree = tree_from_json(&json, &win(), WalkLimits::DEFAULT).expect("tree parses");
         tree.assign_ids();
         assert_eq!(tree.count, glass_core::MAX_NODES);
         assert_eq!(tree.truncated, None);
@@ -573,7 +577,7 @@ mod tests {
         // declines to visit, so the cap must still fire — proving the fix didn't just
         // disable it.
         let json = wide_device_json(glass_core::MAX_NODES);
-        let tree = tree_from_json(&json, &win()).expect("tree parses");
+        let tree = tree_from_json(&json, &win(), WalkLimits::DEFAULT).expect("tree parses");
         assert_eq!(
             tree.truncated.map(|t| t.limit),
             Some(TruncationLimit::Nodes)
@@ -604,7 +608,8 @@ mod tests {
             "bounds": {"x": -5, "y": 10, "w": -3, "h": 0},
             "editable": false, "clickable": false, "enabled": true, "scrollable": false
         });
-        let t = tree_from_json(&v, &win()).expect("degenerate bounds must not error the snapshot");
+        let t = tree_from_json(&v, &win(), WalkLimits::DEFAULT)
+            .expect("degenerate bounds must not error the snapshot");
         let b = t.root.bounds.unwrap();
         assert_eq!((b.width, b.height), (0, 0)); // negative/zero w/h clamp to 0
         assert_eq!((b.x, b.y), (-5, -90)); // window-relative: x -5-0, y 10-100

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -1,7 +1,7 @@
 //! Pure mapping from `uiautomator dump` XML into glass's normalized `AxTree`.
 
 use glass_core::accessibility::{
-    AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTree, TruncationLimit, WalkBudget, MAX_SIBLINGS,
+    AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTree, TruncationLimit, WalkBudget, WalkLimits,
 };
 use glass_core::{GlassError, Result, WindowGeometry};
 
@@ -71,7 +71,7 @@ pub fn check_dump_status(stdout: &str) -> Result<()> {
 /// Parse uiautomator XML into an `AxTree`. Ids are left unset (the caller runs
 /// `AxTree::assign_ids`). The hierarchy is wrapped in a synthetic `Window` root
 /// sized to the app window.
-pub fn build_tree(xml: &str, window: &WindowGeometry) -> Result<AxTree> {
+pub fn build_tree(xml: &str, window: &WindowGeometry, limits: WalkLimits) -> Result<AxTree> {
     let doc = roxmltree::Document::parse(xml)
         .map_err(|e| GlassError::AccessibilityUnavailable(format!("uiautomator XML parse: {e}")))?;
     let hierarchy = doc.root_element();
@@ -80,7 +80,7 @@ pub fn build_tree(xml: &str, window: &WindowGeometry) -> Result<AxTree> {
             "uiautomator XML has no <hierarchy> root".into(),
         ));
     }
-    let mut budget = WalkBudget::new();
+    let mut budget = WalkBudget::with_limits(limits);
     let mut children = Vec::new();
     for (i, n) in hierarchy
         .children()
@@ -94,7 +94,7 @@ pub fn build_tree(xml: &str, window: &WindowGeometry) -> Result<AxTree> {
             budget.hit(TruncationLimit::Nodes);
             break;
         }
-        if i >= MAX_SIBLINGS {
+        if i >= budget.max_siblings() {
             budget.hit(TruncationLimit::Siblings);
             break;
         }
@@ -177,7 +177,7 @@ fn map_node(
                 budget.hit(TruncationLimit::Nodes);
                 break;
             }
-            if i >= MAX_SIBLINGS {
+            if i >= budget.max_siblings() {
                 budget.hit(TruncationLimit::Siblings);
                 break;
             }
@@ -274,7 +274,7 @@ mod tests {
 
     #[test]
     fn build_tree_shapes_the_hierarchy() {
-        let mut tree = build_tree(XML, &win()).unwrap();
+        let mut tree = build_tree(XML, &win(), WalkLimits::DEFAULT).unwrap();
         tree.assign_ids();
         assert_eq!(tree.root.role, AxRole::Window);
         let frame = &tree.root.children[0];
@@ -315,7 +315,7 @@ mod tests {
         // dropped a node from the middle rather than stopping at the end would shift every
         // later id off the node its own index implies.
         let xml = wide_hierarchy_xml(glass_core::MAX_NODES + 50);
-        let mut tree = build_tree(&xml, &win()).unwrap();
+        let mut tree = build_tree(&xml, &win(), WalkLimits::DEFAULT).unwrap();
         tree.assign_ids();
 
         assert!(tree.truncated.is_some(), "the node cap must have been hit");
@@ -331,7 +331,7 @@ mod tests {
         // one is what pushes the running count to MAX_NODES. Nothing was declined, so this
         // must NOT be reported truncated (regression for the false-positive-at-the-cap bug).
         let xml = wide_hierarchy_xml(glass_core::MAX_NODES);
-        let tree = build_tree(&xml, &win()).unwrap();
+        let tree = build_tree(&xml, &win(), WalkLimits::DEFAULT).unwrap();
         assert_eq!(tree.truncated, None);
     }
 
@@ -341,7 +341,7 @@ mod tests {
         // declines to visit, so the cap must still fire — proving the fix didn't just
         // disable it.
         let xml = wide_hierarchy_xml(glass_core::MAX_NODES + 1);
-        let tree = build_tree(&xml, &win()).unwrap();
+        let tree = build_tree(&xml, &win(), WalkLimits::DEFAULT).unwrap();
         assert_eq!(
             tree.truncated.map(|t| t.limit),
             Some(TruncationLimit::Nodes)
@@ -367,7 +367,7 @@ mod tests {
     #[test]
     fn build_tree_rejects_non_hierarchy_xml() {
         assert!(matches!(
-            build_tree("<other/>", &win()),
+            build_tree("<other/>", &win(), WalkLimits::DEFAULT),
             Err(GlassError::AccessibilityUnavailable(_))
         ));
     }
@@ -395,7 +395,7 @@ mod tests {
             width: 100,
             height: 200,
         };
-        let tree = build_tree(xml, &w).unwrap();
+        let tree = build_tree(xml, &w, WalkLimits::DEFAULT).unwrap();
         let not_real = &tree.root.children[0];
         let real_on = &tree.root.children[1];
         let compose_on = &tree.root.children[2];

--- a/crates/glass-android/tests/a11y_loop.rs
+++ b/crates/glass-android/tests/a11y_loop.rs
@@ -5,7 +5,7 @@
 //! Launches com.android.settings, snapshots its a11y tree, and asserts the tree
 //! is non-trivial and carries named, role-typed elements.
 
-use glass_core::accessibility::{Accessibility, AxContext};
+use glass_core::accessibility::{Accessibility, AxContext, WalkLimits};
 use glass_core::{AppSpec, Platform, SandboxLevel};
 
 fn settings_spec() -> AppSpec {
@@ -38,6 +38,7 @@ fn snapshot_has_named_role_typed_nodes() {
         window,
         window_handle: None,
         a11y_bus_addr: None,
+        limits: WalkLimits::DEFAULT,
     };
     let mut a11y = glass_android::AndroidA11y::new();
     let mut tree = a11y.snapshot(&ctx).expect("snapshot");

--- a/crates/glass-android/tests/a11y_service_loop.rs
+++ b/crates/glass-android/tests/a11y_service_loop.rs
@@ -6,7 +6,7 @@
 use glass_android::{
     A11yServiceRegistry, AgentRegistry, AndroidPlatform, EmulatorRegistry, ServiceA11y,
 };
-use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget};
+use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, WalkLimits};
 use glass_core::{AppSpec, Platform, SandboxLevel, WindowGeometry};
 
 #[test]
@@ -43,6 +43,7 @@ fn a11y_service_snapshot_and_actions() {
         },
         window_handle: None,
         a11y_bus_addr: None,
+        limits: WalkLimits::DEFAULT,
     };
 
     let mut tree = a11y.snapshot(&ctx).expect("snapshot");

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -284,6 +284,49 @@ pub const MAX_DEPTH: usize = 30;
 /// See [`MAX_NODES`].
 pub const MAX_SIBLINGS: usize = 4096;
 
+/// Runtime bounds for one accessibility walk: the caps that were compile-time consts
+/// (`MAX_NODES`/`MAX_DEPTH`/`MAX_SIBLINGS`). `usize::MAX` in a field means "unbounded"; a
+/// plain `>=`/`>` check never trips there, so unbounded needs no special-casing. Carried by
+/// [`WalkBudget`] and threaded through [`AxContext`] so a caller can raise or lift the caps.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WalkLimits {
+    pub nodes: usize,
+    pub depth: usize,
+    pub siblings: usize,
+}
+
+impl WalkLimits {
+    /// The historical caps — the behavior when a caller passes no override.
+    pub const DEFAULT: WalkLimits = WalkLimits {
+        nodes: MAX_NODES,
+        depth: MAX_DEPTH,
+        siblings: MAX_SIBLINGS,
+    };
+
+    /// Map the MCP `max_nodes` surface to limits: `None` → default; `Some(0)` → fully
+    /// unbounded (all three lifted); `Some(n)` → cap nodes at `n`, depth/siblings default.
+    pub fn from_max_nodes(max_nodes: Option<usize>) -> WalkLimits {
+        match max_nodes {
+            None => WalkLimits::DEFAULT,
+            Some(0) => WalkLimits {
+                nodes: usize::MAX,
+                depth: usize::MAX,
+                siblings: usize::MAX,
+            },
+            Some(n) => WalkLimits {
+                nodes: n,
+                ..WalkLimits::DEFAULT
+            },
+        }
+    }
+}
+
+impl Default for WalkLimits {
+    fn default() -> WalkLimits {
+        WalkLimits::DEFAULT
+    }
+}
+
 /// Which bound stopped a walk early.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TruncationLimit {
@@ -343,11 +386,27 @@ impl Truncation {
 pub struct WalkBudget {
     count: usize,
     truncated: Option<Truncation>,
+    limits: WalkLimits,
 }
 
 impl WalkBudget {
+    /// A budget with the default (historical) limits.
     pub fn new() -> WalkBudget {
-        WalkBudget::default()
+        WalkBudget::with_limits(WalkLimits::DEFAULT)
+    }
+
+    /// A budget bounded by `limits`.
+    pub fn with_limits(limits: WalkLimits) -> WalkBudget {
+        WalkBudget {
+            count: 0,
+            truncated: None,
+            limits,
+        }
+    }
+
+    /// The per-level sibling-scan bound (readers/mappers compare against this).
+    pub fn max_siblings(&self) -> usize {
+        self.limits.siblings
     }
 
     /// Count a visited node. Call exactly once on entry to each node, before its children.
@@ -361,12 +420,12 @@ impl WalkBudget {
 
     /// Whether the node budget is spent.
     pub fn nodes_exhausted(&self) -> bool {
-        self.count >= MAX_NODES
+        self.count >= self.limits.nodes
     }
 
     /// Whether `depth` has reached the nesting bound (so children must not be walked).
     pub fn depth_exhausted(&self, depth: usize) -> bool {
-        depth >= MAX_DEPTH
+        depth >= self.limits.depth
     }
 
     /// Record that a bound stopped the walk. Only the FIRST hit is kept: it is the cause,
@@ -1461,6 +1520,51 @@ mod tests {
         assert!(
             b.nodes_exhausted(),
             "the cap is reached at exactly MAX_NODES"
+        );
+    }
+
+    #[test]
+    fn walklimits_default_matches_the_legacy_consts() {
+        assert_eq!(WalkLimits::DEFAULT.nodes, MAX_NODES);
+        assert_eq!(WalkLimits::DEFAULT.depth, MAX_DEPTH);
+        assert_eq!(WalkLimits::DEFAULT.siblings, MAX_SIBLINGS);
+    }
+
+    #[test]
+    fn from_max_nodes_none_is_default_some_zero_is_unbounded_some_n_caps_nodes_only() {
+        assert_eq!(WalkLimits::from_max_nodes(None), WalkLimits::DEFAULT);
+        let unbounded = WalkLimits::from_max_nodes(Some(0));
+        assert_eq!(unbounded.nodes, usize::MAX);
+        assert_eq!(unbounded.depth, usize::MAX);
+        assert_eq!(unbounded.siblings, usize::MAX);
+        let capped = WalkLimits::from_max_nodes(Some(42));
+        assert_eq!(capped.nodes, 42);
+        assert_eq!(capped.depth, WalkLimits::DEFAULT.depth);
+        assert_eq!(capped.siblings, WalkLimits::DEFAULT.siblings);
+    }
+
+    #[test]
+    fn with_limits_stops_nodes_at_the_configured_cap_not_the_default() {
+        let mut b = WalkBudget::with_limits(WalkLimits::from_max_nodes(Some(3)));
+        b.visit();
+        b.visit();
+        b.visit();
+        assert!(b.nodes_exhausted(), "3 visits hits a cap of 3");
+        assert_eq!(b.max_siblings(), MAX_SIBLINGS);
+    }
+
+    #[test]
+    fn unbounded_limits_never_report_exhausted_past_the_default_cap() {
+        let mut b = WalkBudget::with_limits(WalkLimits::from_max_nodes(Some(0)));
+        // Visit well past the OLD node cap: under DEFAULT this would exhaust; unbounded must not,
+        // so this fails if `Some(0)` left `nodes` at MAX_NODES instead of lifting it.
+        for _ in 0..(MAX_NODES + 10) {
+            b.visit();
+        }
+        assert!(!b.nodes_exhausted(), "unbounded nodes never exhaust");
+        assert!(
+            !b.depth_exhausted(MAX_DEPTH + 1000),
+            "unbounded depth never exhausts"
         );
     }
 

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -303,15 +303,20 @@ impl WalkLimits {
         siblings: MAX_SIBLINGS,
     };
 
-    /// Map the MCP `max_nodes` surface to limits: `None` → default; `Some(0)` → fully
-    /// unbounded (all three lifted); `Some(n)` → cap nodes at `n`, depth/siblings default.
+    /// Map the MCP `max_nodes` surface to limits: `None` → default; `Some(0)` → lift the node
+    /// cap (`nodes = usize::MAX`) for the full tree; `Some(n)` → cap nodes at `n`. `max_nodes`
+    /// controls the node count ONLY — `depth` and `siblings` always keep their defaults. Those
+    /// two are structural safety rails, not a size budget: the recursive native-tree walkers
+    /// (AT-SPI / AX / UIA) have no cycle detection, so an unbounded depth on a cyclic or
+    /// pathological tree would recurse to a stack overflow (which aborts the process). The
+    /// generous defaults (`MAX_DEPTH`/`MAX_SIBLINGS`) never bite a real UI, so keeping them costs
+    /// the caller nothing while preserving that backstop even under `max_nodes: 0`.
     pub fn from_max_nodes(max_nodes: Option<usize>) -> WalkLimits {
         match max_nodes {
             None => WalkLimits::DEFAULT,
             Some(0) => WalkLimits {
                 nodes: usize::MAX,
-                depth: usize::MAX,
-                siblings: usize::MAX,
+                ..WalkLimits::DEFAULT
             },
             Some(n) => WalkLimits {
                 nodes: n,
@@ -1535,12 +1540,15 @@ mod tests {
     }
 
     #[test]
-    fn from_max_nodes_none_is_default_some_zero_is_unbounded_some_n_caps_nodes_only() {
+    fn from_max_nodes_controls_nodes_only_keeping_depth_and_sibling_rails() {
         assert_eq!(WalkLimits::from_max_nodes(None), WalkLimits::DEFAULT);
+        // Some(0) lifts the node cap for the full tree, but depth/siblings keep their defaults
+        // (structural safety rails against a cyclic/pathological native tree — see from_max_nodes).
         let unbounded = WalkLimits::from_max_nodes(Some(0));
         assert_eq!(unbounded.nodes, usize::MAX);
-        assert_eq!(unbounded.depth, usize::MAX);
-        assert_eq!(unbounded.siblings, usize::MAX);
+        assert_eq!(unbounded.depth, WalkLimits::DEFAULT.depth);
+        assert_eq!(unbounded.siblings, WalkLimits::DEFAULT.siblings);
+        // Some(n) caps nodes at n, depth/siblings default.
         let capped = WalkLimits::from_max_nodes(Some(42));
         assert_eq!(capped.nodes, 42);
         assert_eq!(capped.depth, WalkLimits::DEFAULT.depth);
@@ -1558,17 +1566,18 @@ mod tests {
     }
 
     #[test]
-    fn unbounded_limits_never_report_exhausted_past_the_default_cap() {
+    fn max_nodes_zero_lifts_the_node_cap_but_keeps_the_depth_rail() {
         let mut b = WalkBudget::with_limits(WalkLimits::from_max_nodes(Some(0)));
-        // Visit well past the OLD node cap: under DEFAULT this would exhaust; unbounded must not,
-        // so this fails if `Some(0)` left `nodes` at MAX_NODES instead of lifting it.
+        // Visit well past the OLD node cap: under DEFAULT this would exhaust; a lifted node cap
+        // must not, so this fails if `Some(0)` left `nodes` at MAX_NODES instead of lifting it.
         for _ in 0..(MAX_NODES + 10) {
             b.visit();
         }
-        assert!(!b.nodes_exhausted(), "unbounded nodes never exhaust");
+        assert!(!b.nodes_exhausted(), "a lifted node cap never exhausts");
+        // The depth rail is deliberately KEPT even under max_nodes:0 (cycle/stack-overflow guard).
         assert!(
-            !b.depth_exhausted(MAX_DEPTH + 1000),
-            "unbounded depth never exhausts"
+            b.depth_exhausted(MAX_DEPTH),
+            "the depth safety rail is preserved under a lifted node cap"
         );
     }
 

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -341,16 +341,6 @@ pub enum TruncationLimit {
 }
 
 impl TruncationLimit {
-    /// The limit's numeric value, for the disclosure notice. Private: the only caller is
-    /// [`Truncation::notice`] in this module; nothing outside needs the raw number.
-    fn value(self) -> usize {
-        match self {
-            TruncationLimit::Nodes => MAX_NODES,
-            TruncationLimit::Depth => MAX_DEPTH,
-            TruncationLimit::Siblings => MAX_SIBLINGS,
-        }
-    }
-
     /// Human-readable unit for the disclosure notice.
     fn label(self) -> &'static str {
         match self {
@@ -366,6 +356,10 @@ impl TruncationLimit {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Truncation {
     pub limit: TruncationLimit,
+    /// The actual limit value that fired — the runtime [`WalkLimits`] field in effect, not the
+    /// compile-time default — so the notice reports the cap the caller was really subject to
+    /// (e.g. a `max_nodes: 42` snapshot reads "truncated at 42 nodes", not "1500").
+    pub limit_value: usize,
     pub nodes_walked: usize,
 }
 
@@ -378,7 +372,7 @@ impl Truncation {
             "… tree truncated at {} {} ({} nodes walked). Some elements are NOT shown and \
              cannot be addressed by id. Narrow the UI, or drive by pixels: glass_screenshot, \
              then glass_click at x,y.",
-            self.limit.value(),
+            self.limit_value,
             self.limit.label(),
             self.nodes_walked,
         )
@@ -437,8 +431,14 @@ impl WalkBudget {
     /// while any later hit is a consequence of having continued.
     pub fn hit(&mut self, limit: TruncationLimit) {
         let nodes_walked = self.count;
+        let limit_value = match limit {
+            TruncationLimit::Nodes => self.limits.nodes,
+            TruncationLimit::Depth => self.limits.depth,
+            TruncationLimit::Siblings => self.limits.siblings,
+        };
         self.truncated.get_or_insert(Truncation {
             limit,
+            limit_value,
             nodes_walked,
         });
     }
@@ -1585,12 +1585,32 @@ mod tests {
     fn truncation_notice_states_elements_are_missing_and_names_the_pixel_fallback() {
         let n = Truncation {
             limit: TruncationLimit::Nodes,
+            limit_value: MAX_NODES,
             nodes_walked: 1500,
         }
         .notice();
         assert!(
             n.contains("NOT shown") && n.contains("glass_screenshot"),
             "notice must be unmissable and steer to pixels: {n}"
+        );
+    }
+
+    #[test]
+    fn truncation_notice_reports_the_actual_runtime_cap_not_the_default() {
+        // A raised/lowered cap that fires must render its OWN number, not the compile-time const.
+        let mut b = WalkBudget::with_limits(WalkLimits::from_max_nodes(Some(42)));
+        for _ in 0..42 {
+            b.visit();
+        }
+        b.hit(TruncationLimit::Nodes);
+        let notice = b.truncation().expect("hit recorded").notice();
+        assert!(
+            notice.contains("42 nodes"),
+            "notice reports the runtime cap (42), not MAX_NODES: {notice}"
+        );
+        assert!(
+            !notice.contains(&MAX_NODES.to_string()),
+            "notice must not show the default cap when a custom one fired: {notice}"
         );
     }
 
@@ -1603,6 +1623,7 @@ mod tests {
         t.assign_ids();
         t.truncated = Some(Truncation {
             limit: TruncationLimit::Depth,
+            limit_value: MAX_DEPTH,
             nodes_walked: 42,
         });
         assert!(!t.to_outline().contains("truncated"), "pure tree text");

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -555,6 +555,10 @@ pub struct AxContext {
     /// `AccessibilityUnavailable` (instructing the caller to relaunch with `a11y:true`) — it does
     /// NOT fall back to any host/ambient bus. Non-Linux backends ignore this field.
     pub a11y_bus_addr: Option<String>,
+    /// The size bounds for this walk. The reader/mapper builds its `WalkBudget` from these.
+    /// Set from the session's stored limits so a snapshot and a later `set_value` walk the
+    /// tree with the same bounds (ids stay resolvable).
+    pub limits: WalkLimits,
 }
 
 /// A fingerprint identifying the element a value-set targets: its synthetic id

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -71,7 +71,7 @@ pub mod accessibility;
 pub use accessibility::{
     element_match, Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget,
     AxTree, ElementCondition, ElementInfo, ElementMatch, Truncation, TruncationLimit, WalkBudget,
-    MAX_DEPTH, MAX_NODES, MAX_SIBLINGS,
+    WalkLimits, MAX_DEPTH, MAX_NODES, MAX_SIBLINGS,
 };
 
 pub mod marks;

--- a/crates/glass-core/src/outline.rs
+++ b/crates/glass-core/src/outline.rs
@@ -238,6 +238,7 @@ mod tests {
         let mut t = tree_of(node(AxRole::Button, Some("Save")));
         t.truncated = Some(Truncation {
             limit: TruncationLimit::Nodes,
+            limit_value: 1500,
             nodes_walked: 1500,
         });
         assert!(

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -23,9 +23,28 @@ impl Glass {
     /// relative, ids assigned by the core). Caches it for `click_element`.
     /// `AxUnsupported` if the backend has no accessibility reader.
     pub fn a11y_snapshot(&mut self, max_nodes: Option<usize>) -> Result<AxTree> {
-        let limits = crate::accessibility::WalkLimits::from_max_nodes(max_nodes);
+        // A user-facing snapshot sets the limits for the id-space that follows: `set_value`
+        // re-walks with them, and internal re-snapshots reuse them via `a11y_resnapshot`. So
+        // this is the ONLY place that changes `a11y_limits` from a caller's `max_nodes`.
+        self.active_mut()?.a11y_limits =
+            crate::accessibility::WalkLimits::from_max_nodes(max_nodes);
+        self.snapshot_at_current_limits()
+    }
+
+    /// Re-snapshot the active window reusing the limits the last user snapshot set — it does NOT
+    /// reset them. Used by compound operations (the `return:"snapshot"` fold, `wait_for_element`,
+    /// and the scroll/combo/toggle loops) so an agent working in a raised-cap tree keeps that
+    /// id-space instead of silently reverting to the default cap on the next internal snapshot.
+    pub fn a11y_resnapshot(&mut self) -> Result<AxTree> {
+        self.snapshot_at_current_limits()
+    }
+
+    /// The snapshot worker: walks the active window's tree bounded by the session's current
+    /// `a11y_limits` and caches it. Callers set `a11y_limits` first (or reuse it) — see
+    /// [`Glass::a11y_snapshot`] / [`Glass::a11y_resnapshot`].
+    fn snapshot_at_current_limits(&mut self) -> Result<AxTree> {
         let s = self.active_mut()?;
-        s.a11y_limits = limits;
+        let limits = s.a11y_limits;
         // Reader-presence check up front (mirrors set_value_inner) so `AxUnsupported` keeps
         // precedence over — and a reader-less backend skips — the geometry round-trip below.
         if s.accessibility.is_none() {
@@ -64,7 +83,7 @@ impl Glass {
     /// Caches the snapshot, so `click_element` resolves a mark's id afterward.
     pub fn a11y_marks(&mut self) -> Result<(Frame, Vec<Mark>)> {
         let frame = self.screenshot(None, None)?;
-        let tree = self.a11y_snapshot(None)?;
+        let tree = self.a11y_resnapshot()?;
         Ok(crate::marks::render(&frame, &tree))
     }
 
@@ -258,7 +277,7 @@ impl Glass {
                         TOGGLE_VERIFY_INTERVAL_MS,
                         TOGGLE_VERIFY_TIMEOUT_MS,
                         || {
-                            let tree = self.a11y_snapshot(None)?;
+                            let tree = self.a11y_resnapshot()?;
                             let now = find_checkable_near(&tree.root, target.bounds.as_ref())
                                 .is_some_and(|n| n.states.checked == want);
                             Ok(now.then_some(()))
@@ -300,7 +319,7 @@ impl Glass {
         // Re-read the realized options + which one is currently selected. The open
         // combo is `expanded`; when several combos exist, ids don't survive the
         // re-snapshot, so fall back to the one nearest the target's bounds.
-        let tree = self.a11y_snapshot(None)?;
+        let tree = self.a11y_resnapshot()?;
         let combo = find_expanded_combo(&tree.root)
             .or_else(|| find_combo_near(&tree.root, target.bounds.as_ref()))
             .ok_or(GlassError::AxElementChanged(id.0))?;
@@ -336,7 +355,7 @@ impl Glass {
         self.settle_for_popup();
         // Verify the model actually committed — the *target* combo (matched by bounds,
         // now closed so nothing is `expanded`) must read the wanted label.
-        let tree = self.a11y_snapshot(None)?;
+        let tree = self.a11y_resnapshot()?;
         let ok = find_combo_near(&tree.root, target.bounds.as_ref())
             .and_then(|c| c.name.as_deref())
             .is_some_and(|n| n.eq_ignore_ascii_case(want));

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -22,8 +22,10 @@ impl Glass {
     /// Snapshot the active window's accessibility tree (normalized, window-
     /// relative, ids assigned by the core). Caches it for `click_element`.
     /// `AxUnsupported` if the backend has no accessibility reader.
-    pub fn a11y_snapshot(&mut self) -> Result<AxTree> {
+    pub fn a11y_snapshot(&mut self, max_nodes: Option<usize>) -> Result<AxTree> {
+        let limits = crate::accessibility::WalkLimits::from_max_nodes(max_nodes);
         let s = self.active_mut()?;
+        s.a11y_limits = limits;
         // Reader-presence check up front (mirrors set_value_inner) so `AxUnsupported` keeps
         // precedence over — and a reader-less backend skips — the geometry round-trip below.
         if s.accessibility.is_none() {
@@ -49,6 +51,7 @@ impl Glass {
             window,
             window_handle,
             a11y_bus_addr,
+            limits,
         })?;
         tree.assign_ids();
         s.last_ax = Some(tree.clone());
@@ -61,7 +64,7 @@ impl Glass {
     /// Caches the snapshot, so `click_element` resolves a mark's id afterward.
     pub fn a11y_marks(&mut self) -> Result<(Frame, Vec<Mark>)> {
         let frame = self.screenshot(None, None)?;
-        let tree = self.a11y_snapshot()?;
+        let tree = self.a11y_snapshot(None)?;
         Ok(crate::marks::render(&frame, &tree))
     }
 
@@ -208,6 +211,7 @@ impl Glass {
                 window: s.geometry.clone(),
                 window_handle: s.platform.active_window_handle(),
                 a11y_bus_addr: s.platform.a11y_bus_addr(),
+                limits: s.a11y_limits,
             };
             (target, ctx)
         };
@@ -254,7 +258,7 @@ impl Glass {
                         TOGGLE_VERIFY_INTERVAL_MS,
                         TOGGLE_VERIFY_TIMEOUT_MS,
                         || {
-                            let tree = self.a11y_snapshot()?;
+                            let tree = self.a11y_snapshot(None)?;
                             let now = find_checkable_near(&tree.root, target.bounds.as_ref())
                                 .is_some_and(|n| n.states.checked == want);
                             Ok(now.then_some(()))
@@ -296,7 +300,7 @@ impl Glass {
         // Re-read the realized options + which one is currently selected. The open
         // combo is `expanded`; when several combos exist, ids don't survive the
         // re-snapshot, so fall back to the one nearest the target's bounds.
-        let tree = self.a11y_snapshot()?;
+        let tree = self.a11y_snapshot(None)?;
         let combo = find_expanded_combo(&tree.root)
             .or_else(|| find_combo_near(&tree.root, target.bounds.as_ref()))
             .ok_or(GlassError::AxElementChanged(id.0))?;
@@ -332,7 +336,7 @@ impl Glass {
         self.settle_for_popup();
         // Verify the model actually committed — the *target* combo (matched by bounds,
         // now closed so nothing is `expanded`) must read the wanted label.
-        let tree = self.a11y_snapshot()?;
+        let tree = self.a11y_snapshot(None)?;
         let ok = find_combo_near(&tree.root, target.bounds.as_ref())
             .and_then(|c| c.name.as_deref())
             .is_some_and(|n| n.eq_ignore_ascii_case(want));
@@ -889,7 +893,7 @@ mod tests {
     fn a11y_snapshot_assigns_ids_and_counts() {
         let mut g = glass_with_a11y(FakePlatform::new(100, 100), fake_tree());
         g.start(&spec()).unwrap();
-        let tree = g.a11y_snapshot().unwrap();
+        let tree = g.a11y_snapshot(None).unwrap();
         assert_eq!(tree.count, 2);
         assert_eq!(tree.root.id, AxNodeId(0));
         assert_eq!(tree.root.children[0].id, AxNodeId(1));
@@ -900,7 +904,7 @@ mod tests {
         let mut g = glass_with(FakePlatform::new(40, 30));
         g.start(&spec()).unwrap();
         assert!(matches!(
-            g.a11y_snapshot().unwrap_err(),
+            g.a11y_snapshot(None).unwrap_err(),
             GlassError::AxUnsupported
         ));
     }
@@ -911,7 +915,7 @@ mod tests {
         let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
         let mut g = glass_with_a11y(platform, fake_tree());
         g.start(&spec()).unwrap();
-        g.a11y_snapshot().unwrap();
+        g.a11y_snapshot(None).unwrap();
         g.click_element(AxNodeId(1)).unwrap();
         // The Button at (10,10 20x20) → center (20,20), via the normal pointer path.
         assert_eq!(clicks.lock().unwrap().last().copied(), Some((20, 20)));
@@ -964,7 +968,7 @@ mod tests {
             .with_click_log(clicks.clone());
         let mut g = glass_with_a11y(platform, AxTree::new(root));
         g.start(&spec()).unwrap();
-        g.a11y_snapshot().unwrap(); // must refresh s.geometry 230 → 458
+        g.a11y_snapshot(None).unwrap(); // must refresh s.geometry 230 → 458
         g.click_element(AxNodeId(1)).unwrap(); // the Button at x=292 — on-screen only in 458
         assert_eq!(
             clicks.lock().unwrap().last().copied(),
@@ -987,7 +991,7 @@ mod tests {
     fn click_element_unknown_id_errors() {
         let mut g = glass_with_a11y(FakePlatform::new(100, 100), fake_tree());
         g.start(&spec()).unwrap();
-        g.a11y_snapshot().unwrap();
+        g.a11y_snapshot(None).unwrap();
         assert!(matches!(
             g.click_element(AxNodeId(99)).unwrap_err(),
             GlassError::AxElementNotFound(99)
@@ -1025,7 +1029,7 @@ mod tests {
         });
         let mut g = glass_with_a11y(FakePlatform::new(100, 100), tree);
         g.start(&spec()).unwrap();
-        g.a11y_snapshot().unwrap();
+        g.a11y_snapshot(None).unwrap();
         // node #2 is the boundless Label.
         assert!(matches!(
             g.click_element(AxNodeId(2)).unwrap_err(),
@@ -1065,7 +1069,7 @@ mod tests {
             .with_select_log(select_log.clone());
         let mut g = glass_with_a11y(platform, fake_tree());
         g.start(&spec()).unwrap();
-        g.a11y_snapshot().unwrap();
+        g.a11y_snapshot(None).unwrap();
         g.click_element(AxNodeId(1)).unwrap(); // the Button at (10,10 20x20)
         assert_eq!(
             clicks.lock().unwrap().last().copied(),
@@ -1130,7 +1134,7 @@ mod tests {
             .with_trailing_toggle_backend();
         let mut g = glass_with_a11y(platform, AxTree::new(root));
         g.start(&spec()).unwrap();
-        g.a11y_snapshot().unwrap();
+        g.a11y_snapshot(None).unwrap();
 
         // node #1 = the row-shaped checkable → a swipe across the trailing control, not a click.
         g.click_element(AxNodeId(1)).unwrap();
@@ -1220,7 +1224,7 @@ mod tests {
         let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
         let mut g = glass_with_a11y(platform, AxTree::new(root));
         g.start(&spec()).unwrap();
-        g.a11y_snapshot().unwrap();
+        g.a11y_snapshot(None).unwrap();
         g.click_element(AxNodeId(1)).unwrap();
         assert_eq!(
             clicks.lock().unwrap().last().copied(),
@@ -1273,7 +1277,7 @@ mod tests {
             .with_trailing_toggle_backend();
         let mut g = glass_with_a11y(platform, AxTree::new(root));
         g.start(&spec()).unwrap();
-        g.a11y_snapshot().unwrap();
+        g.a11y_snapshot(None).unwrap();
         g.click_element(AxNodeId(1)).unwrap();
         assert_eq!(
             clicks.lock().unwrap().last().copied(),
@@ -1295,7 +1299,7 @@ mod tests {
             .with_failing_list_windows();
         let mut g = glass_with_a11y(platform, fake_tree());
         g.start(&spec()).unwrap();
-        g.a11y_snapshot().unwrap();
+        g.a11y_snapshot(None).unwrap();
         g.click_element(AxNodeId(1))
             .expect("a failing list_windows must not block an ordinary click");
         assert_eq!(
@@ -1339,7 +1343,7 @@ mod tests {
             .with_select_log(select_log.clone());
         let mut g = glass_with_a11y(platform, fake_tree_with_popover_option());
         g.start(&spec()).unwrap();
-        let tree = g.a11y_snapshot().unwrap();
+        let tree = g.a11y_snapshot(None).unwrap();
         // assign_ids in pre-order: root=0, List=1, Globex(ListItem)=2.
         let globex_id = tree.root.children[0].children[0].id;
         assert_eq!(globex_id, AxNodeId(2));
@@ -1432,7 +1436,7 @@ mod tests {
             .with_select_log(select_log.clone());
         let mut g = glass_with_a11y(platform, tree);
         g.start(&spec()).unwrap();
-        let snapshot = g.a11y_snapshot().unwrap();
+        let snapshot = g.a11y_snapshot(None).unwrap();
         let globex_id = snapshot.root.children[0].id;
         assert!(matches!(
             g.click_element(globex_id).unwrap_err(),
@@ -1464,7 +1468,7 @@ mod tests {
     fn set_value_unknown_id_errors() {
         let mut g = glass_with_a11y(FakePlatform::new(100, 100), fake_tree());
         g.start(&spec()).unwrap();
-        g.a11y_snapshot().unwrap();
+        g.a11y_snapshot(None).unwrap();
         assert!(matches!(
             g.set_value(AxNodeId(99), "x").unwrap_err(),
             GlassError::AxElementNotFound(99)
@@ -1495,6 +1499,7 @@ mod tests {
                 tree: fake_tree(),
                 set_log: log2,
                 set_fail: false,
+                limits_log: Arc::new(Mutex::new(None)),
             })),
         });
         let factory: PlatformFactory = Box::new(move |_b| {
@@ -1503,7 +1508,7 @@ mod tests {
         });
         let mut g = Glass::new(factory, "x11".into(), BaselineStore::new(root), 100);
         g.start(&spec()).unwrap();
-        g.a11y_snapshot().unwrap(); // fake_tree: #1 is Button "Save"
+        g.a11y_snapshot(None).unwrap(); // fake_tree: #1 is Button "Save"
         g.set_value(AxNodeId(1), "hello").unwrap();
         let calls = log.lock().unwrap();
         assert_eq!(calls.len(), 1);
@@ -1525,6 +1530,57 @@ mod tests {
     }
 
     #[test]
+    fn a11y_snapshot_threads_max_nodes_into_ctx_limits_and_set_value_reuses_them() {
+        // Same mock harness as `set_value_passes_target_and_text_to_backend`, but this
+        // time inspecting `limits_log` — the `AxContext.limits` the backend actually
+        // received — to prove `max_nodes` reaches the ctx, and that `set_value` reuses
+        // whatever the last `a11y_snapshot` recorded rather than falling back to the
+        // default cap. Real backends still ignore `limits` in this task (they build
+        // `WalkBudget::new()`), so this is the only way to observe the plumbing.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("baselines");
+        std::mem::forget(dir);
+        let limits_log = Arc::new(Mutex::new(None));
+        let mut held: Option<Backend> = Some(Backend {
+            platform: Box::new(FakePlatform::new(100, 100)),
+            accessibility: Some(Box::new(FakeAccessibility {
+                tree: fake_tree(),
+                set_log: Arc::new(Mutex::new(Vec::new())),
+                set_fail: false,
+                limits_log: limits_log.clone(),
+            })),
+        });
+        let factory: PlatformFactory = Box::new(move |_b| {
+            held.take()
+                .ok_or_else(|| GlassError::Backend("twice".into()))
+        });
+        let mut g = Glass::new(factory, "x11".into(), BaselineStore::new(root), 100);
+        g.start(&spec()).unwrap();
+
+        g.a11y_snapshot(Some(5000)).unwrap();
+        assert_eq!(
+            limits_log
+                .lock()
+                .unwrap()
+                .expect("snapshot recorded ctx.limits")
+                .nodes,
+            5000,
+            "snapshot ctx carries the raised cap"
+        );
+
+        g.set_value(AxNodeId(1), "x").unwrap(); // fake_tree: #1 is Button "Save"
+        assert_eq!(
+            limits_log
+                .lock()
+                .unwrap()
+                .expect("set_value recorded ctx.limits")
+                .nodes,
+            5000,
+            "set_value reuses the snapshot's limits"
+        );
+    }
+
+    #[test]
     fn set_value_propagates_backend_error() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().join("baselines");
@@ -1535,6 +1591,7 @@ mod tests {
                 tree: fake_tree(),
                 set_log: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
                 set_fail: true,
+                limits_log: Arc::new(Mutex::new(None)),
             })),
         });
         let factory: PlatformFactory = Box::new(move |_b| {
@@ -1543,7 +1600,7 @@ mod tests {
         });
         let mut g = Glass::new(factory, "x11".into(), BaselineStore::new(root), 100);
         g.start(&spec()).unwrap();
-        g.a11y_snapshot().unwrap();
+        g.a11y_snapshot(None).unwrap();
         assert!(matches!(
             g.set_value(AxNodeId(1), "x").unwrap_err(),
             GlassError::AxElementNotEditable(1)
@@ -1600,7 +1657,7 @@ mod tests {
         // Snapshot #1 (cached read) = unchecked; snapshot #2 (verify re-read) = checked.
         let mut g = glass_with_a11y_seq(platform, vec![sw(false), sw(true)]);
         g.start(&spec()).unwrap();
-        g.a11y_snapshot().unwrap(); // caches unchecked
+        g.a11y_snapshot(None).unwrap(); // caches unchecked
 
         g.set_value(AxNodeId(1), "true").unwrap();
 
@@ -1615,7 +1672,7 @@ mod tests {
             .with_trailing_toggle_backend();
         let mut g = glass_with_a11y(platform, sw(true));
         g.start(&spec()).unwrap();
-        g.a11y_snapshot().unwrap();
+        g.a11y_snapshot(None).unwrap();
 
         g.set_value(AxNodeId(1), "true").unwrap();
 
@@ -1633,7 +1690,7 @@ mod tests {
         // Both reads unchecked: the swipe "did not take" -> honest error, not false ok.
         let mut g = glass_with_a11y_seq(platform, vec![sw(false), sw(false)]);
         g.start(&spec()).unwrap();
-        g.a11y_snapshot().unwrap();
+        g.a11y_snapshot(None).unwrap();
 
         let err = g.set_value(AxNodeId(1), "true").unwrap_err();
         assert!(matches!(err, GlassError::AxValueNotApplied(_)));
@@ -1653,7 +1710,7 @@ mod tests {
         // Snapshot #1 (cached read) = checked; snapshot #2 (verify re-read) = unchecked.
         let mut g = glass_with_a11y_seq(platform, vec![sw(true), sw(false)]);
         g.start(&spec()).unwrap();
-        g.a11y_snapshot().unwrap(); // caches checked
+        g.a11y_snapshot(None).unwrap(); // caches checked
 
         g.set_value(AxNodeId(1), "false").unwrap();
 
@@ -1668,7 +1725,7 @@ mod tests {
             .with_trailing_toggle_backend();
         let mut g = glass_with_a11y(platform, sw(false));
         g.start(&spec()).unwrap();
-        g.a11y_snapshot().unwrap();
+        g.a11y_snapshot(None).unwrap();
 
         g.set_value(AxNodeId(1), "false").unwrap();
 
@@ -1740,7 +1797,7 @@ mod tests {
             vec![two_switches(true, false), two_switches(true, true)],
         );
         g.start(&spec()).unwrap();
-        g.a11y_snapshot().unwrap(); // caches: sibling already checked, target unchecked
+        g.a11y_snapshot(None).unwrap(); // caches: sibling already checked, target unchecked
 
         // Target is id 2 (sibling listed first gets id 1; see `two_switches`).
         g.set_value(AxNodeId(2), "true").unwrap();
@@ -1764,7 +1821,7 @@ mod tests {
             vec![two_switches(true, false), two_switches(true, false)],
         );
         g.start(&spec()).unwrap();
-        g.a11y_snapshot().unwrap();
+        g.a11y_snapshot(None).unwrap();
 
         let err = g.set_value(AxNodeId(2), "true").unwrap_err();
         assert!(matches!(err, GlassError::AxValueNotApplied(2)));
@@ -1797,6 +1854,7 @@ mod tests {
                 tree: fake_tree(), // #1 is a non-checkable Button "Save"
                 set_log: log2,
                 set_fail: false,
+                limits_log: Arc::new(Mutex::new(None)),
             })),
         });
         let factory: PlatformFactory = Box::new(move |_b| {
@@ -1805,7 +1863,7 @@ mod tests {
         });
         let mut g = Glass::new(factory, "x11".into(), BaselineStore::new(root), 100);
         g.start(&spec()).unwrap();
-        g.a11y_snapshot().unwrap();
+        g.a11y_snapshot(None).unwrap();
 
         g.set_value(AxNodeId(1), "true").unwrap();
 
@@ -1844,6 +1902,7 @@ mod tests {
                 tree: sw(false), // #1 is the checkable switch "Sw"
                 set_log: log2,
                 set_fail: false,
+                limits_log: Arc::new(Mutex::new(None)),
             })),
         });
         let factory: PlatformFactory = Box::new(move |_b| {
@@ -1852,7 +1911,7 @@ mod tests {
         });
         let mut g = Glass::new(factory, "x11".into(), BaselineStore::new(root), 100);
         g.start(&spec()).unwrap();
-        g.a11y_snapshot().unwrap();
+        g.a11y_snapshot(None).unwrap();
 
         let err = g.set_value(AxNodeId(1), "banana").unwrap_err();
 

--- a/crates/glass-core/src/session/lifecycle.rs
+++ b/crates/glass-core/src/session/lifecycle.rs
@@ -34,6 +34,7 @@ impl Glass {
             platform,
             accessibility,
             last_ax: None,
+            a11y_limits: WalkLimits::DEFAULT,
             geometry: geometry.clone(),
             logs: LogBuffer::new(self.log_capacity),
             active_window: None,

--- a/crates/glass-core/src/session/mod.rs
+++ b/crates/glass-core/src/session/mod.rs
@@ -3,7 +3,7 @@
 
 use crate::accessibility::{
     element_match, Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxTarget, AxTree,
-    ElementCondition, ElementInfo, ElementMatch,
+    ElementCondition, ElementInfo, ElementMatch, WalkLimits,
 };
 use crate::baseline::BaselineStore;
 use crate::diff::{
@@ -41,6 +41,9 @@ struct ActiveSession {
     // last-captured tree (read by the a11y tools).
     accessibility: Option<Box<dyn Accessibility + Send>>,
     last_ax: Option<AxTree>,
+    /// Limits the most recent `a11y_snapshot` used; reused by `set_value` so ids from a
+    /// raised-cap snapshot stay resolvable. Defaults to `WalkLimits::DEFAULT`.
+    a11y_limits: WalkLimits,
     geometry: WindowGeometry,
     logs: LogBuffer,
     /// Best-effort active window for audit attribution (id from list_windows/select_window).
@@ -220,7 +223,7 @@ mod tests {
 
         g.start(&spec()).unwrap();
         let _ = g.screenshot(None, None).unwrap(); // read
-        let tree = g.a11y_snapshot().unwrap(); // read (populates last_ax)
+        let tree = g.a11y_snapshot(None).unwrap(); // read (populates last_ax)
         g.pointer(&PointerEvent::Click {
             x: 1,
             y: 2,

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -259,13 +259,19 @@ pub(crate) struct FakeAccessibility {
     pub(crate) tree: AxTree,
     pub(crate) set_log: std::sync::Arc<std::sync::Mutex<Vec<(AxTarget, String)>>>,
     pub(crate) set_fail: bool,
+    /// The `limits` from the most recent `AxContext` this backend received (either
+    /// `snapshot` or `set_value`) — lets a test prove `max_nodes` actually reached the
+    /// backend, not just the session's own bookkeeping. `None` when unset.
+    pub(crate) limits_log: Arc<Mutex<Option<crate::accessibility::WalkLimits>>>,
 }
 
 impl Accessibility for FakeAccessibility {
-    fn snapshot(&mut self, _ctx: &AxContext) -> Result<AxTree> {
+    fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
+        *self.limits_log.lock().unwrap() = Some(ctx.limits);
         Ok(self.tree.clone())
     }
-    fn set_value(&mut self, _ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
+    fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
+        *self.limits_log.lock().unwrap() = Some(ctx.limits);
         if self.set_fail {
             return Err(GlassError::AxElementNotEditable(target.id.0));
         }
@@ -393,6 +399,7 @@ pub(crate) fn glass_with_a11y(platform: FakePlatform, tree: AxTree) -> Glass {
             tree,
             set_log: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
             set_fail: false,
+            limits_log: Arc::new(Mutex::new(None)),
         }),
     )
 }

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -371,7 +371,7 @@ impl Glass {
     pub fn wait_for_element(&mut self, params: &WaitElementParams) -> Result<WaitElementOutcome> {
         self.require_active()?; // fail fast; a11y_snapshot rechecks inside the loop
         let outcome = crate::poll::poll_until(params.interval_ms, params.timeout_ms, || {
-            let tree = self.a11y_snapshot(None)?; // fresh snapshot; assigns ids, caches, pumps
+            let tree = self.a11y_resnapshot()?; // fresh snapshot; assigns ids, caches, pumps
             Ok(
                 match element_match(
                     &tree,
@@ -522,7 +522,7 @@ impl Glass {
         &mut self,
         params: &ScrollToElementParams,
     ) -> Result<(Option<ElementInfo>, String)> {
-        let tree = self.a11y_snapshot(None)?;
+        let tree = self.a11y_resnapshot()?;
         let found = match element_match(
             &tree,
             params.name.as_deref(),

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -371,7 +371,7 @@ impl Glass {
     pub fn wait_for_element(&mut self, params: &WaitElementParams) -> Result<WaitElementOutcome> {
         self.require_active()?; // fail fast; a11y_snapshot rechecks inside the loop
         let outcome = crate::poll::poll_until(params.interval_ms, params.timeout_ms, || {
-            let tree = self.a11y_snapshot()?; // fresh snapshot; assigns ids, caches, pumps
+            let tree = self.a11y_snapshot(None)?; // fresh snapshot; assigns ids, caches, pumps
             Ok(
                 match element_match(
                     &tree,
@@ -522,7 +522,7 @@ impl Glass {
         &mut self,
         params: &ScrollToElementParams,
     ) -> Result<(Option<ElementInfo>, String)> {
-        let tree = self.a11y_snapshot()?;
+        let tree = self.a11y_snapshot(None)?;
         let found = match element_match(
             &tree,
             params.name.as_deref(),

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -41,7 +41,7 @@ impl IosA11y {
                 "could not determine the iOS accessibility scale from the tree".into(),
             )
         })?;
-        let mut tree = axmap::build_tree(&json, scale, &ctx.window)?;
+        let mut tree = axmap::build_tree(&json, scale, &ctx.window, ctx.limits)?;
         tree.assign_ids();
         Ok((tree, scale))
     }

--- a/crates/glass-ios/src/axmap.rs
+++ b/crates/glass-ios/src/axmap.rs
@@ -19,7 +19,7 @@
 //! key anywhere in the output), so [`AxStates::focused`] is always false from this
 //! backend — a known limitation.
 use glass_core::accessibility::{
-    AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTree, TruncationLimit, WalkBudget, MAX_SIBLINGS,
+    AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTree, TruncationLimit, WalkBudget, WalkLimits,
 };
 use glass_core::{GlassError, Result, WindowGeometry};
 use serde_json::Value;
@@ -62,10 +62,15 @@ pub fn ax_role(ax_type: &str) -> AxRole {
 /// than dropping nodes out of the middle, so ids assigned afterward by
 /// [`AxTree::assign_ids`] stay stable for every surviving node. [`AxTree::truncated`]
 /// records which bound fired, if any.
-pub fn build_tree(json: &str, scale: f64, window: &WindowGeometry) -> Result<AxTree> {
+pub fn build_tree(
+    json: &str,
+    scale: f64,
+    window: &WindowGeometry,
+    limits: WalkLimits,
+) -> Result<AxTree> {
     let v: Value = serde_json::from_str(json)
         .map_err(|e| GlassError::AccessibilityUnavailable(format!("idb a11y JSON parse: {e}")))?;
-    let mut budget = WalkBudget::new();
+    let mut budget = WalkBudget::with_limits(limits);
     // idb may return either a single root object or an array of top-level elements.
     let children: Vec<AxNode> = match &v {
         Value::Array(a) => {
@@ -78,7 +83,7 @@ pub fn build_tree(json: &str, scale: f64, window: &WindowGeometry) -> Result<AxT
                     budget.hit(TruncationLimit::Nodes);
                     break;
                 }
-                if i >= MAX_SIBLINGS {
+                if i >= budget.max_siblings() {
                     budget.hit(TruncationLimit::Siblings);
                     break;
                 }
@@ -230,7 +235,7 @@ fn map_node(n: &Value, scale: f64, depth: usize, budget: &mut WalkBudget) -> AxN
                     budget.hit(TruncationLimit::Nodes);
                     break;
                 }
-                if i >= MAX_SIBLINGS {
+                if i >= budget.max_siblings() {
                     budget.hit(TruncationLimit::Siblings);
                     break;
                 }
@@ -288,7 +293,8 @@ mod tests {
     }
 
     fn built() -> AxTree {
-        let mut tree = build_tree(FIXTURE, SCALE, &win()).expect("fixture must parse");
+        let mut tree =
+            build_tree(FIXTURE, SCALE, &win(), WalkLimits::DEFAULT).expect("fixture must parse");
         tree.assign_ids();
         tree
     }
@@ -414,14 +420,14 @@ mod tests {
 
     #[test]
     fn build_tree_errors_on_malformed_json() {
-        let err = build_tree("this is not json", SCALE, &win()).unwrap_err();
+        let err = build_tree("this is not json", SCALE, &win(), WalkLimits::DEFAULT).unwrap_err();
         assert!(matches!(err, GlassError::AccessibilityUnavailable(_)));
     }
 
     #[test]
     fn build_tree_errors_on_unexpected_root_shape() {
         // A bare scalar is neither an element object nor an array of elements.
-        let err = build_tree("42", SCALE, &win()).unwrap_err();
+        let err = build_tree("42", SCALE, &win(), WalkLimits::DEFAULT).unwrap_err();
         assert!(matches!(err, GlassError::AccessibilityUnavailable(_)));
     }
 
@@ -509,7 +515,7 @@ mod tests {
         // that dropped a node from the middle rather than stopping at the end would
         // shift every later id off the node its own index implies.
         let json = wide_array_json(glass_core::MAX_NODES + 50);
-        let mut tree = build_tree(&json, 1.0, &win()).expect("tree builds");
+        let mut tree = build_tree(&json, 1.0, &win(), WalkLimits::DEFAULT).expect("tree builds");
         tree.assign_ids();
 
         assert!(tree.truncated.is_some(), "the node cap must have been hit");
@@ -526,7 +532,7 @@ mod tests {
         // this must NOT be reported truncated (regression for the false-positive-at-the-cap
         // bug).
         let json = wide_array_json(glass_core::MAX_NODES);
-        let tree = build_tree(&json, 1.0, &win()).expect("tree builds");
+        let tree = build_tree(&json, 1.0, &win(), WalkLimits::DEFAULT).expect("tree builds");
         assert_eq!(tree.truncated, None);
     }
 
@@ -536,7 +542,7 @@ mod tests {
         // walk declines to visit, so the cap must still fire — proving the fix didn't just
         // disable it.
         let json = wide_array_json(glass_core::MAX_NODES + 1);
-        let tree = build_tree(&json, 1.0, &win()).expect("tree builds");
+        let tree = build_tree(&json, 1.0, &win(), WalkLimits::DEFAULT).expect("tree builds");
         assert_eq!(
             tree.truncated.map(|t| t.limit),
             Some(TruncationLimit::Nodes)
@@ -566,7 +572,7 @@ mod tests {
         let j = r#"[{"role":"AXCheckBox","subrole":"AXSwitch","AXUniqueId":"boldText",
                      "AXLabel":"Bold Text","AXValue":"1",
                      "frame":{"x":0,"y":0,"width":100,"height":30}}]"#;
-        let mut tree = build_tree(j, 1.0, &win()).expect("parses");
+        let mut tree = build_tree(j, 1.0, &win(), WalkLimits::DEFAULT).expect("parses");
         tree.assign_ids();
         let sw = find_by_name(&tree.root, "boldText").expect("switch present");
         assert!(

--- a/crates/glass-ios/tests/drive_integration.rs
+++ b/crates/glass-ios/tests/drive_integration.rs
@@ -26,7 +26,7 @@
 
 use std::time::Duration;
 
-use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, AxTree};
+use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, AxTree, WalkLimits};
 use glass_core::{AppSpec, KeyEvent, MouseButton, Platform, PointerEvent, SandboxLevel};
 use glass_ios::{IosA11y, IosPlatform, SimulatorRegistry};
 
@@ -129,6 +129,7 @@ fn drive_fixture_snapshot_tap_and_type_end_to_end() {
         window: window.clone(),
         window_handle: None,
         a11y_bus_addr: None,
+        limits: WalkLimits::DEFAULT,
     };
 
     // 1) Snapshot: the fixture's elements must appear, and the status starts at READY. The

--- a/crates/glass-macos/tests/a11y.rs
+++ b/crates/glass-macos/tests/a11y.rs
@@ -51,7 +51,7 @@ mod macos_main {
     use glass_core::platform::{MouseButton, PointerEvent};
     use glass_core::{
         Accessibility, AppSpec, AxContext, AxNode, AxRole, AxTarget, GlassError, Platform,
-        SandboxLevel, Stream,
+        SandboxLevel, Stream, WalkLimits,
     };
     use glass_macos::MacosPlatform;
 
@@ -202,6 +202,7 @@ mod macos_main {
             window: geometry.clone(),
             window_handle: None,
             a11y_bus_addr: None,
+            limits: WalkLimits::DEFAULT,
         };
 
         let mut a11y = glass_a11y_macos::MacosA11y::new();

--- a/crates/glass-macos/tests/bundle_launch.rs
+++ b/crates/glass-macos/tests/bundle_launch.rs
@@ -66,7 +66,7 @@ mod macos_main {
     use glass_a11y_macos::MacosA11y;
     use glass_core::platform::{MouseButton, PointerEvent};
     use glass_core::{
-        Accessibility, AppSpec, AxContext, GlassError, Platform, SandboxLevel, Stream,
+        Accessibility, AppSpec, AxContext, GlassError, Platform, SandboxLevel, Stream, WalkLimits,
     };
     use glass_macos::MacosPlatform;
 
@@ -372,6 +372,7 @@ mod macos_main {
                 window: geometry,
                 window_handle: None,
                 a11y_bus_addr: None,
+                limits: WalkLimits::DEFAULT,
             };
             let mut a11y = MacosA11y::new();
             let mut tree = try_expect(a11y.snapshot(&ctx), "a11y snapshot(TextEdit)")?;

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -137,6 +137,15 @@ pub struct SetValueArgs {
     pub return_: Option<String>,
 }
 
+/// Arguments for `glass_a11y_snapshot`.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct A11ySnapshotArgs {
+    /// Maximum number of elements to include. Omit for the default cap (protects the token
+    /// budget). Pass a larger number to raise it, or `0` for the full tree (no limit). A
+    /// snapshot renumbers ids, so re-read them after changing this.
+    pub max_nodes: Option<u32>,
+}
+
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ClickArgs {
     pub x: i32,

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -347,7 +347,7 @@ impl GlassServer {
                        #id to glass_click_element. Errors if the backend or app exposes no \
                        accessibility tree (e.g. a canvas/black-box app) — fall back to \
                        glass_screenshot then. Optional max_nodes: raise the element cap, or 0 \
-                       for the full tree (default caps protect the token budget)."
+                       to remove the element-count limit (default caps protect the token budget)."
     )]
     async fn glass_a11y_snapshot(
         &self,

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -346,10 +346,14 @@ impl GlassServer {
                        Each line is `#<id> <Role> \"<name>\" (x,y wxh) [states]`; pass an \
                        #id to glass_click_element. Errors if the backend or app exposes no \
                        accessibility tree (e.g. a canvas/black-box app) — fall back to \
-                       glass_screenshot then."
+                       glass_screenshot then. Optional max_nodes: raise the element cap, or 0 \
+                       for the full tree (default caps protect the token budget)."
     )]
-    async fn glass_a11y_snapshot(&self) -> Result<CallToolResult, McpError> {
-        self.run(tools::a11y_snapshot).await
+    async fn glass_a11y_snapshot(
+        &self,
+        Parameters(a): Parameters<A11ySnapshotArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        self.run(move |g| tools::a11y_snapshot(g, &a)).await
     }
 
     #[tool(

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -740,6 +740,7 @@ pub(crate) mod testutil {
         let mut t = fake_tree();
         t.truncated = Some(Truncation {
             limit: TruncationLimit::Nodes,
+            limit_value: 1500,
             nodes_walked: 1500,
         });
         t

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -269,8 +269,19 @@ pub fn select_window(glass: &mut Glass, a: &SelectWindowArgs) -> ToolResult {
     ))
 }
 
-pub fn a11y_snapshot(glass: &mut Glass) -> ToolResult {
-    let tree = glass.a11y_snapshot().map_err(|e| e.to_string())?;
+/// The truncation steer for a snapshot outline: the core notice plus the MCP-level recourse
+/// (how to widen the cap). Kept here, not in `glass-core`, so core stays tool-agnostic; used by
+/// both `a11y_snapshot` and the `return:"snapshot"` fold so both disclose the recourse identically.
+fn a11y_truncation_steer(tree: &glass_core::AxTree) -> Option<String> {
+    tree.truncation_notice().map(|notice| {
+        format!("{notice} Pass max_nodes to raise the limit, or max_nodes: 0 for the full tree.")
+    })
+}
+
+pub fn a11y_snapshot(glass: &mut Glass, a: &A11ySnapshotArgs) -> ToolResult {
+    let tree = glass
+        .a11y_snapshot(a.max_nodes.map(|n| n as usize))
+        .map_err(|e| e.to_string())?;
     // The agent-facing render: wrapper chains collapsed. The session cache keeps the full
     // tree, so every elided node is still addressable by id. Truncation is disclosed
     // separately below, not baked into this text — see the comment there.
@@ -284,8 +295,8 @@ pub fn a11y_snapshot(glass: &mut Glass) -> ToolResult {
     if let Some(hint) = tree.empty_guidance() {
         contents.push(OutContent::Text(hint.to_string()));
     }
-    if let Some(notice) = tree.truncation_notice() {
-        contents.push(OutContent::Text(notice));
+    if let Some(steer) = a11y_truncation_steer(&tree) {
+        contents.push(OutContent::Text(steer));
     }
     Ok(ToolOutput::result_with(
         "glass_a11y_snapshot",
@@ -339,7 +350,7 @@ fn resolve_return(
             // real capture failure is swallowed because `a11y_snapshot` reads the accessibility
             // tree (not pixels) and still returns the freshest tree — the caller asked for it.
             let _ = glass.wait_stable(&settle_params());
-            let tree = glass.a11y_snapshot().map_err(|e| e.to_string())?;
+            let tree = glass.a11y_snapshot(None).map_err(|e| e.to_string())?;
             // Same shape as `a11y_snapshot`: the app-derived outline stays untrusted-wrapped;
             // glass's own steers are separate trusted blocks, not baked into that body.
             let mut extra = vec![OutContent::Text(crate::untrusted::wrap_untrusted(
@@ -348,8 +359,8 @@ fn resolve_return(
             if let Some(hint) = tree.empty_guidance() {
                 extra.push(OutContent::Text(hint.to_string()));
             }
-            if let Some(notice) = tree.truncation_notice() {
-                extra.push(OutContent::Text(notice));
+            if let Some(steer) = a11y_truncation_steer(&tree) {
+                extra.push(OutContent::Text(steer));
             }
             Ok((None, extra))
         }
@@ -994,7 +1005,7 @@ mod tests {
             a11y: false,
         })
         .unwrap();
-        let out = a11y_snapshot(&mut g).unwrap();
+        let out = a11y_snapshot(&mut g, &A11ySnapshotArgs { max_nodes: None }).unwrap();
         assert_envelope(&out, "glass_a11y_snapshot");
         match &out.0[1] {
             OutContent::Text(t) => {
@@ -1030,7 +1041,7 @@ mod tests {
             a11y: false,
         })
         .unwrap();
-        let out = a11y_snapshot(&mut g).unwrap();
+        let out = a11y_snapshot(&mut g, &A11ySnapshotArgs { max_nodes: None }).unwrap();
         assert_envelope(&out, "glass_a11y_snapshot");
         // [0]=envelope, [1]=untrusted root-only outline, [2]=glass's trusted pixel hint.
         match &out.0[2] {
@@ -1064,7 +1075,7 @@ mod tests {
             a11y: false,
         })
         .unwrap();
-        let out = a11y_snapshot(&mut g).unwrap();
+        let out = a11y_snapshot(&mut g, &A11ySnapshotArgs { max_nodes: None }).unwrap();
         assert_envelope(&out, "glass_a11y_snapshot");
         // [0]=envelope, [1]=untrusted-wrapped outline, [2]=glass's trusted truncation steer.
         assert_eq!(
@@ -1119,7 +1130,7 @@ mod tests {
             a11y: false,
         })
         .unwrap();
-        let err = a11y_snapshot(&mut g).unwrap_err();
+        let err = a11y_snapshot(&mut g, &A11ySnapshotArgs { max_nodes: None }).unwrap_err();
         assert!(err.contains("not supported"), "msg: {err}");
     }
 
@@ -1137,7 +1148,7 @@ mod tests {
             a11y: false,
         })
         .unwrap();
-        a11y_snapshot(&mut g).unwrap();
+        a11y_snapshot(&mut g, &A11ySnapshotArgs { max_nodes: None }).unwrap();
         let out = set_value(
             &mut g,
             &SetValueArgs {
@@ -1183,7 +1194,7 @@ mod tests {
             SetOutcome::NotEditable,
         );
         g.start(&spec).unwrap();
-        a11y_snapshot(&mut g).unwrap();
+        a11y_snapshot(&mut g, &A11ySnapshotArgs { max_nodes: None }).unwrap();
         let err = set_value(
             &mut g,
             &SetValueArgs {
@@ -1202,7 +1213,7 @@ mod tests {
             SetOutcome::Changed,
         );
         g.start(&spec).unwrap();
-        a11y_snapshot(&mut g).unwrap();
+        a11y_snapshot(&mut g, &A11ySnapshotArgs { max_nodes: None }).unwrap();
         let err = set_value(
             &mut g,
             &SetValueArgs {
@@ -1229,7 +1240,7 @@ mod tests {
             a11y: false,
         })
         .unwrap();
-        a11y_snapshot(&mut g).unwrap();
+        a11y_snapshot(&mut g, &A11ySnapshotArgs { max_nodes: None }).unwrap();
         assert!(click_element(
             &mut g,
             &ClickElementArgs {
@@ -1362,7 +1373,7 @@ mod tests {
             a11y: false,
         })
         .unwrap();
-        a11y_snapshot(&mut g).unwrap(); // populate last_ax for click_element/set_value
+        a11y_snapshot(&mut g, &A11ySnapshotArgs { max_nodes: None }).unwrap(); // populate last_ax for click_element/set_value
         g
     }
 
@@ -1477,7 +1488,7 @@ mod tests {
             a11y: false,
         })
         .unwrap();
-        a11y_snapshot(&mut g).unwrap(); // seed last_ax for click_element
+        a11y_snapshot(&mut g, &A11ySnapshotArgs { max_nodes: None }).unwrap(); // seed last_ax for click_element
         let before = *captures.lock().unwrap();
         let out = click_element(
             &mut g,

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -273,8 +273,18 @@ pub fn select_window(glass: &mut Glass, a: &SelectWindowArgs) -> ToolResult {
 /// (how to widen the cap). Kept here, not in `glass-core`, so core stays tool-agnostic; used by
 /// both `a11y_snapshot` and the `return:"snapshot"` fold so both disclose the recourse identically.
 fn a11y_truncation_steer(tree: &glass_core::AxTree) -> Option<String> {
-    tree.truncation_notice().map(|notice| {
+    let notice = tree.truncation_notice()?;
+    // Only a Nodes truncation is raisable via `max_nodes`. A Depth/Siblings hit is structural
+    // (max_nodes doesn't touch those rails), and the core notice already steers to narrowing the
+    // UI / driving by pixels — so don't dangle a `max_nodes` recourse that wouldn't help.
+    let raisable = matches!(
+        tree.truncated.map(|t| t.limit),
+        Some(glass_core::TruncationLimit::Nodes)
+    );
+    Some(if raisable {
         format!("{notice} Pass max_nodes to raise the limit, or max_nodes: 0 for the full tree.")
+    } else {
+        notice
     })
 }
 
@@ -350,7 +360,9 @@ fn resolve_return(
             // real capture failure is swallowed because `a11y_snapshot` reads the accessibility
             // tree (not pixels) and still returns the freshest tree — the caller asked for it.
             let _ = glass.wait_stable(&settle_params());
-            let tree = glass.a11y_snapshot(None).map_err(|e| e.to_string())?;
+            // Reuse the session's current limits so a fold after a raised/unbounded snapshot
+            // isn't silently re-truncated to the default cap.
+            let tree = glass.a11y_resnapshot().map_err(|e| e.to_string())?;
             // Same shape as `a11y_snapshot`: the app-derived outline stays untrusted-wrapped;
             // glass's own steers are separate trusted blocks, not baked into that body.
             let mut extra = vec![OutContent::Text(crate::untrusted::wrap_untrusted(

--- a/crates/glass-testapp/tests/verification_cost.rs
+++ b/crates/glass-testapp/tests/verification_cost.rs
@@ -169,7 +169,7 @@ fn wait_for_widgets_sync(glass: &mut Glass) -> AxTree {
     let deadline =
         Instant::now() + mcp_cost::A11Y_SETTLE_TIMEOUT + mcp_cost::WIDGETS_SETTLE_TIMEOUT;
     loop {
-        match glass.a11y_snapshot() {
+        match glass.a11y_snapshot(None) {
             Ok(tree) => {
                 let outline = tree.to_outline();
                 let ready = mcp_cost::find_named_button(&outline, "Apply").is_some()

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use glass_a11y_windows::WindowsA11y;
 use glass_core::{
     Accessibility, AppSpec, AxContext, AxNode, AxRole, AxTarget, GlassError, KeyEvent, Modifier,
-    MouseButton, Platform, PointerEvent, WindowGeometry, WindowHint, WindowOp,
+    MouseButton, Platform, PointerEvent, WalkLimits, WindowGeometry, WindowHint, WindowOp,
 };
 use glass_windows::WindowsPlatform;
 
@@ -282,6 +282,7 @@ fn onbox_a11y_snapshot_and_click() {
         window: geo.clone(),
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
+        limits: WalkLimits::DEFAULT,
     };
     let tree = a11y.snapshot(&ctx).expect("a11y snapshot");
     assert!(tree.count > 0, "snapshot must have nodes");
@@ -392,6 +393,7 @@ fn onbox_modifier_click() {
         window: geo.clone(),
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
+        limits: WalkLimits::DEFAULT,
     };
     let tree = a11y.snapshot(&ctx).expect("a11y snapshot");
     let mut hit = None;
@@ -512,6 +514,7 @@ fn onbox_a11y_set_value() {
         window: geo.clone(),
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
+        limits: WalkLimits::DEFAULT,
     };
     let tree = a11y.snapshot(&ctx).expect("a11y snapshot");
 
@@ -577,6 +580,7 @@ fn onbox_egui_set_value_honesty() {
         window: geo.clone(),
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
+        limits: WalkLimits::DEFAULT,
     };
     let tree = a11y
         .snapshot(&ctx)
@@ -758,6 +762,7 @@ fn onbox_a11y_edge_multiprocess() {
         window: geo.clone(),
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
+        limits: WalkLimits::DEFAULT,
     };
     let tree = a11y
         .snapshot(&ctx)

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -419,8 +419,9 @@ rides as an untrusted sibling text block, one line per element:
 `#<id> <Role> "<name>" (x,y wxh) [states]`; pass an `#id` to `glass_click_element`.
 
 - `max_nodes` (integer) — raise the element cap above the default (which protects the token
-  budget), or `0` for the full tree (no limit). Omit for the default cap. A snapshot renumbers
-  ids, so re-read them after changing this.
+  budget), or `0` to remove the element-count limit. Omit for the default cap. (Structural
+  depth/sibling safety rails still apply, so a pathologically deep tree can still truncate — the
+  notice says which limit was hit.) A snapshot renumbers ids, so re-read them after changing this.
 
 ### `glass_a11y_marks`
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -414,9 +414,13 @@ reads the Simulator's accessibility tree over `idb_companion` (install it — se
 
 ### `glass_a11y_snapshot`
 
-Capture the active window's accessibility tree as compact text. No parameters. Returns `{}`; the
-tree itself rides as an untrusted sibling text block, one line per element:
+Capture the active window's accessibility tree as compact text. Returns `{}`; the tree itself
+rides as an untrusted sibling text block, one line per element:
 `#<id> <Role> "<name>" (x,y wxh) [states]`; pass an `#id` to `glass_click_element`.
+
+- `max_nodes` (integer) — raise the element cap above the default (which protects the token
+  budget), or `0` for the full tree (no limit). Omit for the default cap. A snapshot renumbers
+  ids, so re-read them after changing this.
 
 ### `glass_a11y_marks`
 


### PR DESCRIPTION
## What

The accessibility snapshot's size limits (`MAX_NODES=1500`, `MAX_DEPTH=30`, `MAX_SIBLINGS=4096`)
were compile-time constants — a real app with more than 1500 accessible elements was silently
capped with no recourse. This makes the **element cap runtime-adjustable** via a new optional
`max_nodes` on `glass_a11y_snapshot`:

- **absent** → today's default cap (unchanged).
- **`n`** → cap the tree at `n` elements.
- **`0`** → remove the element-count limit (return the full tree).

The default behavior is byte-for-byte unchanged; this only adds an opt-in override.

## How

A new `glass_core::WalkLimits { nodes, depth, siblings }` (default = the old consts) is carried by
`WalkBudget` and threaded through `AxContext`. `Glass::a11y_snapshot(max_nodes)` computes the limits,
stores them on the session, and every backend builds its `WalkBudget` from `ctx.limits`. All five
backends honor it (Linux AT-SPI, Windows UIA, macOS AX, Android uiautomator + service, iOS).

**`set_value` stays in lockstep:** the limits a snapshot used are stored on the session and reused
by `set_value`, so an id handed out by a raised-cap snapshot still resolves against the same tree —
otherwise a caller id would map to a different element. Internal re-snapshots (the `return:"snapshot"`
fold, `wait_for_element`, scroll/combo/toggle loops) reuse the session's limits rather than resetting
to the default, so a raised-cap id-space survives compound operations.

## Safety

- **`max_nodes` controls the element count only.** `depth` and `siblings` keep their (generous)
  defaults even under `max_nodes: 0` — they are structural rails, not a size budget. The recursive
  native-tree walkers have no cycle detection, so an unbounded depth on a cyclic/pathological tree
  would recurse to a stack overflow (which aborts the process). The defaults never bite a real UI.
- Unbounded walks on Linux remain backstopped by the 10s snapshot timeout.
- A truncated snapshot's notice now reports the **actual** limit that fired (a `max_nodes: 42`
  truncation reads "truncated at 42 nodes", not the default), and only offers the `max_nodes`
  recourse when the element cap — not a structural rail — was the cause.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` — green.
- Linux live AT-SPI suite (`scripts/test-a11y.sh`) — 23 + 5, including new capability tests: an
  unbounded snapshot returns the full >1500-node tree untruncated; a raised cap stops at exactly the
  requested count; and `set_value` resolves an id past the old cap from an unbounded snapshot
  (lockstep across a raised cap).
- Windows on-box (UIA) 3/3; macOS (AX) build+clippy+22; Android 153; iOS 142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
