### PR TITLE
feat(mcp): optional `return` observe on glass_type (settle/snapshot parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+### Added
+- `glass_type` accepts an optional `return` observe (`"settle"` or `"snapshot"`), matching
+  `glass_click_element` and `glass_set_value` — type text and confirm the UI settled (or fold a
+  fresh accessibility tree) in one call. Inside a `glass_do` `type` action the field is rejected
+  with guidance to use a `settle` action or the terminal `then` observe instead.
+
 ### Changed
 - `glass_a11y_snapshot` now returns a compacted outline: chains of unnamed single-child
   container elements are collapsed. Element ids are unchanged and every element remains

--- a/crates/glass-mcp/src/audit.rs
+++ b/crates/glass-mcp/src/audit.rs
@@ -800,6 +800,7 @@ mod tests {
             &mut g,
             &TypeArgs {
                 text: "secret".into(),
+                return_: None,
             },
         )
         .unwrap(); // "type"

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -219,6 +219,12 @@ pub struct ScrollArgs {
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct TypeArgs {
     pub text: String,
+    /// Optional observe folded into the result: "snapshot" (wait for the UI to settle, then
+    /// fold a fresh a11y tree, also refreshing the snapshot cache), "settle" (wait for the UI
+    /// to stop changing, text-only), or "none" (default). Not accepted inside a `glass_do`
+    /// `type` action — use a `settle` action or the terminal `then` observe there.
+    #[serde(rename = "return")]
+    pub return_: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -726,6 +732,15 @@ mod tests {
             serde_json::from_str(r#"{"id":2,"text":"hi","return":"settle"}"#).unwrap();
         assert_eq!(a.id, 2);
         assert_eq!(a.return_.as_deref(), Some("settle"));
+    }
+
+    #[test]
+    fn type_args_parse_return() {
+        let a: TypeArgs = serde_json::from_str(r#"{"text":"hi","return":"settle"}"#).unwrap();
+        assert_eq!(a.text, "hi");
+        assert_eq!(a.return_.as_deref(), Some("settle"));
+        let b: TypeArgs = serde_json::from_str(r#"{"text":"hi"}"#).unwrap();
+        assert!(b.return_.is_none());
     }
 
     #[test]

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -220,7 +220,11 @@ impl GlassServer {
         self.run(move |g| tools::gesture(g, &a)).await
     }
 
-    #[tool(description = "Type a string of text into the focused window.")]
+    #[tool(description = "Type a string of text into the focused window. \
+                       Optional `return`: \"snapshot\" settles the UI then folds a fresh a11y \
+                       tree into the result (and refreshes the snapshot cache); \"settle\" waits \
+                       for the UI to stop changing (text-only); omit or \"none\" for no observe \
+                       (default).")]
     async fn glass_type(
         &self,
         Parameters(a): Parameters<TypeArgs>,

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -496,7 +496,9 @@ impl GlassServer {
         description = "Run an ordered sequence of input actions in ONE call (collapsing per-action \
                        round-trips), then optionally observe. `actions` is a list of \
                        {\"action\":\"click|move|drag|scroll|type|key|settle\", …same fields as the \
-                       matching tool}; `settle` waits for the screen to stop changing between steps. \
+                       matching tool — except `type`'s `return` observe, rejected here (use a \
+                       settle action or `then`)}; `settle` waits for the screen to stop changing \
+                       between steps. \
                        Optional `then` runs after all actions succeed: {settle?, diff?, screenshot?} \
                        (text-only unless screenshot/diff image). Fails fast: if an action errors it \
                        reports which index failed and how many ran. Use for KNOWN sequences (login, \

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -1610,6 +1610,61 @@ mod tests {
     }
 
     #[test]
+    fn type_return_settle_folds_into_observed() {
+        use glass_core::Frame;
+        // Mirrors the click_element/set_value settle observes: wait_stable needs frames;
+        // one solid frame (repeated by the fake) settles.
+        let mut g = started_a11y_frames(vec![Frame::solid(100, 100, [0, 0, 0, 255])]);
+        let out = type_text(
+            &mut g,
+            &TypeArgs {
+                text: "hi".into(),
+                return_: Some("settle".into()),
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            out.0.len(),
+            1,
+            "settle folds into `result.observed`, no extra sibling"
+        );
+        let v = assert_envelope(&out, "glass_type");
+        assert_eq!(v["observed"]["settled"], json!(true), "envelope: {v}");
+    }
+
+    #[test]
+    fn type_return_snapshot_appends_outline() {
+        let mut g = started_a11y_frames(vec![]);
+        let out = type_text(
+            &mut g,
+            &TypeArgs {
+                text: "x".into(),
+                return_: Some("snapshot".into()),
+            },
+        )
+        .unwrap();
+        assert_envelope(&out, "glass_type");
+        assert!(
+            matches!(&out.0[1], OutContent::Text(t) if t.starts_with(crate::untrusted::NOTE) && t.contains("#1 Button")),
+            "outline appended"
+        );
+    }
+
+    #[test]
+    fn type_unknown_return_rejected() {
+        let mut g = started_a11y_frames(vec![]);
+        let err = type_text(
+            &mut g,
+            &TypeArgs {
+                text: "x".into(),
+                return_: Some("bogus".into()),
+            },
+        )
+        .unwrap_err();
+        assert!(err.contains("unknown return"), "msg: {err}");
+    }
+
+    #[test]
     fn list_and_select_window_tools() {
         let mut g = glass_with(FakePlatform::new(320, 240));
         g.start(&AppSpec {

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -329,6 +329,17 @@ fn settle_params() -> glass_core::WaitStableParams {
     }
 }
 
+/// Reject an unknown `return` value without touching the session. For a tool whose
+/// action mutates the app (typing, clicking), call this BEFORE acting — a bad
+/// argument must not leave the action applied, or an agent retrying the errored
+/// call applies it twice.
+pub(crate) fn validate_return(ret: Option<&str>) -> Result<(), String> {
+    match ret {
+        None | Some("none" | "settle" | "snapshot") => Ok(()),
+        Some(o) => Err(format!("unknown return '{o}' (use none/settle/snapshot)")),
+    }
+}
+
 /// Apply the optional `return` observe. `settle` → `Some(metadata)` to merge under
 /// `result.observed`; `snapshot` → an untrusted outline sibling to append; none/absent
 /// → neither. Calls the `Glass` methods directly (not the `a11y_snapshot`/`wait_stable`
@@ -381,6 +392,8 @@ fn resolve_return(
 }
 
 pub fn click_element(glass: &mut Glass, a: &ClickElementArgs) -> ToolResult {
+    // Bad `return` value → reject before the click lands (see `validate_return`).
+    validate_return(a.return_.as_deref())?;
     glass
         .click_element(AxNodeId(a.id))
         .map_err(|e| e.to_string())?;
@@ -397,6 +410,8 @@ pub fn click_element(glass: &mut Glass, a: &ClickElementArgs) -> ToolResult {
 }
 
 pub fn set_value(glass: &mut Glass, a: &SetValueArgs) -> ToolResult {
+    // Bad `return` value → reject before the value is written (see `validate_return`).
+    validate_return(a.return_.as_deref())?;
     glass
         .set_value(AxNodeId(a.id), &a.text)
         .map_err(|e| e.to_string())?;
@@ -1643,16 +1658,45 @@ mod tests {
             },
         )
         .unwrap();
+        assert_eq!(
+            out.0.len(),
+            2,
+            "envelope + exactly one sibling (the a11y outline)"
+        );
         assert_envelope(&out, "glass_type");
         assert!(
             matches!(&out.0[1], OutContent::Text(t) if t.starts_with(crate::untrusted::NOTE) && t.contains("#1 Button")),
             "outline appended"
         );
+        // the snapshot refreshed last_ax -> a follow-up id-based action still resolves
+        assert!(click_element(
+            &mut g,
+            &ClickElementArgs {
+                id: 1,
+                return_: None
+            }
+        )
+        .is_ok());
     }
 
     #[test]
-    fn type_unknown_return_rejected() {
-        let mut g = started_a11y_frames(vec![]);
+    fn type_unknown_return_rejected_before_any_keystroke() {
+        use std::sync::{Arc, Mutex};
+        // A bad `return` value must fail BEFORE the text is injected — an agent that
+        // retries after this error must not end up with the text typed twice.
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let mut g = glass_with(FakePlatform::new(100, 100).with_event_log(log.clone()));
+        g.start(&AppSpec {
+            build: None,
+            run: vec!["x".into()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 1,
+            sandbox: SandboxLevel::Off,
+            a11y: false,
+        })
+        .unwrap();
         let err = type_text(
             &mut g,
             &TypeArgs {
@@ -1662,6 +1706,42 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.contains("unknown return"), "msg: {err}");
+        assert!(
+            log.lock().unwrap().is_empty(),
+            "no input injected on a rejected `return`: {:?}",
+            log.lock().unwrap()
+        );
+    }
+
+    #[test]
+    fn type_observe_failure_says_text_was_typed() {
+        use std::sync::{Arc, Mutex};
+        // A runtime observe failure (here: `snapshot` on a session with no a11y reader)
+        // happens AFTER the keystrokes landed. The error must say so, or an agent
+        // retries the whole call and the field ends up with the text twice.
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let mut g = glass_with(FakePlatform::new(100, 100).with_event_log(log.clone()));
+        g.start(&AppSpec {
+            build: None,
+            run: vec!["x".into()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 1,
+            sandbox: SandboxLevel::Off,
+            a11y: false,
+        })
+        .unwrap();
+        let err = type_text(
+            &mut g,
+            &TypeArgs {
+                text: "hi".into(),
+                return_: Some("snapshot".into()),
+            },
+        )
+        .unwrap_err();
+        assert!(err.contains("text was typed"), "msg: {err}");
+        assert_eq!(*log.lock().unwrap(), vec!["type(hi)"], "keystrokes landed");
     }
 
     #[test]

--- a/crates/glass-mcp/src/tools/batch.rs
+++ b/crates/glass-mcp/src/tools/batch.rs
@@ -61,6 +61,21 @@ pub fn do_actions(glass: &mut Glass, a: &DoArgs) -> ToolResult {
     if a.actions.is_empty() {
         return Err("`actions` must contain at least one action".into());
     }
+    // Pre-flight: a `type` action's `return` observe would have its output discarded
+    // mid-sequence, so it's rejected — and the rejection is decidable from the argument
+    // list alone, so it happens BEFORE any input is injected (never a half-applied
+    // sequence for a pure argument-shape error). An explicit `"none"` is the documented
+    // no-observe default and passes.
+    for (i, action) in a.actions.iter().enumerate() {
+        if let Action::Type(args) = action {
+            if matches!(args.return_.as_deref(), Some(r) if r != "none") {
+                return Err(format!(
+                    "action[{i}] (type): `return` is not accepted inside glass_do — use a \
+                     `settle` action or the terminal `then` observe"
+                ));
+            }
+        }
+    }
     let n = a.actions.len();
     for (i, action) in a.actions.iter().enumerate() {
         let (kind, result): (&str, ToolResult) = match action {
@@ -68,16 +83,6 @@ pub fn do_actions(glass: &mut Glass, a: &DoArgs) -> ToolResult {
             Action::Move(args) => ("move", mouse_move(glass, args)),
             Action::Drag(args) => ("drag", drag(glass, args)),
             Action::Scroll(args) => ("scroll", scroll(glass, args)),
-            // `return` composes an observe into a standalone glass_type result; mid-sequence
-            // that observe's output would be discarded, so reject rather than run-and-drop.
-            Action::Type(args) if args.return_.is_some() => (
-                "type",
-                Err(
-                    "`return` is not accepted inside glass_do — use a `settle` action or the \
-                     terminal `then` observe"
-                        .into(),
-                ),
-            ),
             Action::Type(args) => ("type", type_text(glass, args)),
             Action::Key(args) => ("key", key(glass, args)),
             // A settle's text-only output is discarded mid-sequence; only its
@@ -196,22 +201,55 @@ mod tests {
     }
 
     #[test]
-    fn type_action_with_return_is_rejected() {
-        let mut g = started(FakePlatform::new(100, 100));
+    fn type_action_with_return_is_rejected_before_any_action_runs() {
+        // The rejection is decidable from the argument list alone, so it must
+        // pre-flight: no earlier action may be injected before the batch errors.
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let mut g = started(FakePlatform::new(100, 100).with_event_log(log.clone()));
         let err = do_actions(
             &mut g,
             &DoArgs {
-                actions: vec![Action::Type(TypeArgs {
-                    text: "hi".into(),
-                    return_: Some("settle".into()),
-                })],
+                actions: vec![
+                    click(10, 10),
+                    Action::Type(TypeArgs {
+                        text: "hi".into(),
+                        return_: Some("settle".into()),
+                    }),
+                ],
                 then: None,
             },
         )
         .unwrap_err();
-        assert!(err.contains("action[0]"), "got: {err}");
+        assert!(err.contains("action[1]"), "got: {err}");
         assert!(err.contains("`return`"), "got: {err}");
-        assert!(err.contains("then"), "got: {err}");
+        assert!(err.contains("terminal `then` observe"), "got: {err}");
+        assert!(
+            log.lock().unwrap().is_empty(),
+            "pre-flight must reject before any input is injected: {:?}",
+            log.lock().unwrap()
+        );
+    }
+
+    #[test]
+    fn type_action_with_return_none_is_allowed() {
+        // "none" is the documented no-observe default — an explicit `"return":"none"`
+        // is semantically identical to omitting the field and must not be rejected.
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let mut g = started(FakePlatform::new(100, 100).with_event_log(log.clone()));
+        let out = do_actions(
+            &mut g,
+            &DoArgs {
+                actions: vec![Action::Type(TypeArgs {
+                    text: "hi".into(),
+                    return_: Some("none".into()),
+                })],
+                then: None,
+            },
+        )
+        .unwrap();
+        assert_eq!(*log.lock().unwrap(), vec!["type(hi)"]);
+        let result = assert_envelope(&out, "glass_do");
+        assert_eq!(result["executed"], json!(1));
     }
 
     #[test]

--- a/crates/glass-mcp/src/tools/batch.rs
+++ b/crates/glass-mcp/src/tools/batch.rs
@@ -68,6 +68,16 @@ pub fn do_actions(glass: &mut Glass, a: &DoArgs) -> ToolResult {
             Action::Move(args) => ("move", mouse_move(glass, args)),
             Action::Drag(args) => ("drag", drag(glass, args)),
             Action::Scroll(args) => ("scroll", scroll(glass, args)),
+            // `return` composes an observe into a standalone glass_type result; mid-sequence
+            // that observe's output would be discarded, so reject rather than run-and-drop.
+            Action::Type(args) if args.return_.is_some() => (
+                "type",
+                Err(
+                    "`return` is not accepted inside glass_do — use a `settle` action or the \
+                     terminal `then` observe"
+                        .into(),
+                ),
+            ),
             Action::Type(args) => ("type", type_text(glass, args)),
             Action::Key(args) => ("key", key(glass, args)),
             // A settle's text-only output is discarded mid-sequence; only its
@@ -167,6 +177,7 @@ mod tests {
                     click(10, 20),
                     Action::Type(TypeArgs {
                         text: "alice".into(),
+                        return_: None,
                     }),
                     Action::Key(KeyArgs {
                         chord: "Tab".into(),
@@ -182,6 +193,25 @@ mod tests {
         );
         let result = assert_envelope(&out, "glass_do");
         assert_eq!(result["executed"], json!(3));
+    }
+
+    #[test]
+    fn type_action_with_return_is_rejected() {
+        let mut g = started(FakePlatform::new(100, 100));
+        let err = do_actions(
+            &mut g,
+            &DoArgs {
+                actions: vec![Action::Type(TypeArgs {
+                    text: "hi".into(),
+                    return_: Some("settle".into()),
+                })],
+                then: None,
+            },
+        )
+        .unwrap_err();
+        assert!(err.contains("action[0]"), "got: {err}");
+        assert!(err.contains("`return`"), "got: {err}");
+        assert!(err.contains("then"), "got: {err}");
     }
 
     #[test]

--- a/crates/glass-mcp/src/tools/input.rs
+++ b/crates/glass-mcp/src/tools/input.rs
@@ -102,7 +102,12 @@ pub fn type_text(glass: &mut Glass, a: &TypeArgs) -> ToolResult {
     glass
         .key(&KeyEvent::Text(a.text.clone()))
         .map_err(|e| e.to_string())?;
-    Ok(ToolOutput::result("glass_type", serde_json::json!({})))
+    let (observed, extra) = crate::tools::resolve_return(glass, a.return_.as_deref())?;
+    let mut result = serde_json::json!({});
+    if let Some(o) = observed {
+        result["observed"] = o;
+    }
+    Ok(ToolOutput::result_with("glass_type", result, extra))
 }
 
 pub fn key(glass: &mut Glass, a: &KeyArgs) -> ToolResult {
@@ -192,7 +197,14 @@ mod tests {
     fn type_and_key_ok() {
         let mut g = started();
         assert_ok(
-            &type_text(&mut g, &TypeArgs { text: "hi".into() }).unwrap(),
+            &type_text(
+                &mut g,
+                &TypeArgs {
+                    text: "hi".into(),
+                    return_: None,
+                },
+            )
+            .unwrap(),
             "glass_type",
         );
         assert_ok(

--- a/crates/glass-mcp/src/tools/input.rs
+++ b/crates/glass-mcp/src/tools/input.rs
@@ -99,10 +99,15 @@ pub fn scroll(glass: &mut Glass, a: &ScrollArgs) -> ToolResult {
 }
 
 pub fn type_text(glass: &mut Glass, a: &TypeArgs) -> ToolResult {
+    // Bad `return` value → reject before injecting anything (see `validate_return`).
+    crate::tools::validate_return(a.return_.as_deref())?;
     glass
         .key(&KeyEvent::Text(a.text.clone()))
         .map_err(|e| e.to_string())?;
-    let (observed, extra) = crate::tools::resolve_return(glass, a.return_.as_deref())?;
+    // Past this point the keystrokes have landed: a failing observe (e.g. `snapshot`
+    // with no a11y reader) must say so, or an agent retries and types the text twice.
+    let (observed, extra) = crate::tools::resolve_return(glass, a.return_.as_deref())
+        .map_err(|msg| format!("text was typed; return observe failed: {msg}"))?;
     let mut result = serde_json::json!({});
     if let Some(o) = observed {
         result["observed"] = o;

--- a/docs/how-to/drive-an-ios-app.md
+++ b/docs/how-to/drive-an-ios-app.md
@@ -140,8 +140,8 @@ detected on top of the semantic check above.
 - **Don't verify right after an input call.** `glass_type` and `glass_click_element` return as soon
   as the input is injected, not once the app has finished re-rendering — checking state immediately
   can race it. Wait for the outcome you expect instead: `glass_wait_for_element` (as used above)
-  polls until it appears, and `glass_set_value` takes `return: "settle"` to fold a settle into the
-  call itself (`glass_type` has no such option).
+  polls until it appears, and `glass_set_value` and `glass_type` take `return: "settle"` to fold a
+  settle into the call itself.
 - **Toggles:** if a control is a switch, drive it with a short swipe across its trailing edge rather
   than a tap.
 - **Multi-touch** gestures (`glass_gesture`) are not supported on the Simulator

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -54,7 +54,8 @@ parsing `result`.
 
 Most input/action tools (`glass_click`, `glass_move`, `glass_drag`, `glass_scroll`, `glass_gesture`,
 `glass_type`, `glass_key`, `glass_stop`, `glass_clipboard_set`) return an empty `{}` — `ok:true` in
-the envelope is itself the confirmation that the action ran.
+the envelope is itself the confirmation that the action ran. (`glass_type` can fold an optional
+observe into that result via `return` — see its entry.)
 
 ## Type conventions
 
@@ -281,6 +282,12 @@ Click at window-relative coordinates.
 Type a string into the focused window.
 
 - `text` (string, **required**).
+- `return` (string) — `"snapshot"`, `"settle"`, or `"none"` (default), as for
+  `glass_click_element`. Not accepted inside a `glass_do` `type` action — use a `settle`
+  action or the terminal `then` observe there.
+
+Returns `{}` plus `observed: {settled, saw_motion, observed_ms}` when `return:"settle"`,
+exactly as for `glass_click_element`.
 
 ### `glass_key`
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -256,7 +256,9 @@ no sibling on timeout. Resume reading from the returned `cursor`.
 ## Input
 
 Every tool in this section returns an empty `result:{}` on success — `ok:true` in the envelope is
-itself the confirmation that the action ran; there is nothing else to report.
+itself the confirmation that the action ran. The one exception is `glass_type`'s optional `return`
+observe, which folds settle metadata (or appends an accessibility outline) into the result — see
+its entry.
 
 `glass_click`, `glass_drag`, and `glass_scroll` accept an optional `modifiers` array — `"ctrl"`,
 `"shift"`, `"alt"`, or `"super"` (e.g. `["ctrl"]`, `["ctrl","shift"]`; macOS calls this key ⌘ and
@@ -361,7 +363,9 @@ optionally observe.
 
 - `actions` (array, **required**, non-empty) — each item is `{ action: "click"|"move"|"drag"|
   "scroll"|"type"|"key"|"settle", ...fields }`. Click/move/drag/scroll/type/key take the same
-  fields as their matching tool. A `settle` action takes a *subset* of `glass_wait_stable`'s
+  fields as their matching tool, except that a `type` action rejects `return` (its observe output
+  would be discarded mid-sequence — use a `settle` action or `then`; an explicit `"none"` is
+  accepted). A `settle` action takes a *subset* of `glass_wait_stable`'s
   fields — `interval_ms`, `settle_frames`, `tolerance`, `timeout_ms`, `stability_region`, and
   `ignore` (the same window-relative-rectangles knob) — but no `window_id`, `region`, or
   `include_image`: it always settles the active window and never returns an image. It waits for


### PR DESCRIPTION
## What

`glass_type` now accepts the same optional `return` observe as `glass_click_element` and `glass_set_value`:

- `"settle"` — waits for the UI to stop changing and folds `{settled, saw_motion, observed_ms}` into `result.observed` (text-only).
- `"snapshot"` — settles, then appends a fresh accessibility outline (refreshing the snapshot id cache).
- `"none"` / omitted — unchanged empty `{}`.

Type-and-confirm collapses into one call instead of `glass_type` + `glass_wait_stable`.

## Hardening (from pre-merge review)

- The `return` value is validated **before** any input is injected — on all three observe-bearing tools. A bad value can no longer leave the action applied under an errored call, where an agent retry would type/click/set twice.
- A runtime observe failure after typing (e.g. `snapshot` on a session with no accessibility reader) reports `text was typed; return observe failed: …` so the caller knows the input landed.
- Inside a `glass_do` `type` action, `return` is rejected by a **pre-flight** check (mid-sequence sub-tool output is discarded, so honoring it would run-and-drop; pre-flight means no half-applied sequence). An explicit `"none"` is accepted as the documented no-observe default.

## Docs

`docs/reference/tools.md` (entry + Input/Result conventions + `glass_do` field-parity note), `docs/how-to/drive-an-ios-app.md` (dropped the now-false "glass_type has no such option"), tool descriptions, CHANGELOG `[Unreleased]`.

## Testing

- 9 new/strengthened unit tests (TDD; params parse, settle/snapshot observes, pre-injection validation via event log, typed-then-failed wording, glass_do pre-flight + `"none"` acceptance, snapshot id-cache refresh).
- Local: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --locked` (1311 passed), `test-x11.sh`, `test-wayland.sh`, `test-a11y.sh` — all green.
- Real-MCP smoke over stdio JSON-RPC: `glass_type` schema exposes `return` with its description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)