### PR TITLE
fix(x11): retry a wedged Xvfb once and surface its stderr on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ internal refactors, CI, or test-only changes.
   is truncated the notice now reports the actual limit and says how to widen it.
 
 ### Fixed
+- A transiently stalled Xvfb no longer fails `glass_start` on Linux/X11: if the private X
+  server doesn't report its display within 10s, glass kills it and retries once with a fresh
+  server (worst-case start latency in the still-failing case is ~24s). When startup still
+  fails, the error now includes the head of Xvfb's stderr output and names the recovery
+  (attach to an existing display with `GLASS_DISPLAY=:N`, or run Xvfb manually to diagnose).
+  Previously the first stall failed the session outright, with Xvfb's stderr discarded.
+  `glass doctor --deep`'s Xvfb probe budget now covers the retry, so it no longer reports a
+  failure for a stall the real start path survives.
 - The accessibility tree now reports when a snapshot was truncated. Previously a tree that hit
   an internal size limit was returned as though it were complete, so a missing element was
   indistinguishable from one that does not exist. All backends now share the same limits and

--- a/crates/glass-x11/src/doctor.rs
+++ b/crates/glass-x11/src/doctor.rs
@@ -117,8 +117,15 @@ fn can_connect(display: &str) -> bool {
 
 /// Spawn a private Xvfb and tear it down, with a timeout so a wedged Xvfb can't hang
 /// doctor. Returns the display it came up on, or an error string.
+///
+/// The budget must cover `Xvfb::start`'s OWN worst case (which includes one
+/// retry of a wedged server) plus margin — a shorter budget here would report
+/// Fail for the exact transient class the start path survives, with a wrong
+/// remedy. Sized that way, the backstop effectively never fires and the probe
+/// thread always finishes and reaps its child (no orphan).
 fn probe_xvfb() -> Result<String, String> {
     let screen = std::env::var("GLASS_XVFB_SCREEN").unwrap_or_else(|_| "1280x800x24".into());
+    let budget = crate::xvfb::start_deadline() + Duration::from_secs(2);
     let (tx, rx) = mpsc::channel();
     std::thread::spawn(move || {
         // The Xvfb is dropped at the end of `map` (after we read its display),
@@ -129,9 +136,12 @@ fn probe_xvfb() -> Result<String, String> {
                 .map_err(|e| e.to_string()),
         );
     });
-    match rx.recv_timeout(Duration::from_secs(8)) {
+    match rx.recv_timeout(budget) {
         Ok(r) => r,
-        Err(_) => Err("Xvfb did not become ready within 8s".into()),
+        Err(_) => Err(format!(
+            "Xvfb did not become ready within {}s (including one retry of a stalled server)",
+            budget.as_secs()
+        )),
     }
 }
 

--- a/crates/glass-x11/src/xvfb.rs
+++ b/crates/glass-x11/src/xvfb.rs
@@ -3,9 +3,9 @@
 //! Uses `-displayfd`: the server picks a free display and reports it once ready,
 //! avoiding display-number and readiness races.
 
-use std::io::{BufRead, BufReader};
-use std::process::{Child, ChildStdout, Command, Stdio};
-use std::sync::mpsc;
+use std::io::{BufRead, BufReader, Read};
+use std::process::{Child, ChildStderr, ChildStdout, Command, Stdio};
+use std::sync::{mpsc, Arc, Condvar, Mutex};
 use std::time::Duration;
 
 use glass_core::{GlassError, Result};
@@ -13,8 +13,23 @@ use glass_core::{GlassError, Result};
 /// How long to wait for Xvfb to report its display before treating it as wedged.
 /// Readiness is normally well under a second; this ceiling is generous so a
 /// slow/loaded host isn't falsely failed, while a hung Xvfb can't block start-up.
+/// A wedge gets one retry (see `start_binary`), so the worst still-failing start
+/// is two of these plus two reap graces — about 24s; see `start_deadline`.
 const READY_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Upper bound on how long `Xvfb::start` can take before it returns (both
+/// attempts wedge, each reaped): callers that put their own timeout around a
+/// start (doctor's deep probe) must budget at least this or they'll misreport
+/// a start that would have succeeded on the retry.
+pub(crate) fn start_deadline() -> Duration {
+    2 * (READY_TIMEOUT + glass_proc_linux::REAP_GRACE)
+}
+
+/// How much of Xvfb's stderr to keep for error messages. Failures print early;
+/// past the cap the pipe is still drained (see `StderrTail`) but bytes are dropped.
+const STDERR_CAP: usize = 8 * 1024;
+
+#[derive(Debug)]
 pub struct Xvfb {
     child: Child,
     /// The chosen display, formatted `:N`.
@@ -32,43 +47,194 @@ impl Xvfb {
     /// ready. `screen` is a `WxHxDepth` string (e.g. `"1280x800x24"`).
     pub fn start(screen: &str) -> Result<Xvfb> {
         let xvfb = glass_core::tool_path("GLASS_XVFB", "Xvfb");
-        let mut child = Command::new(&xvfb)
-            .args(["-displayfd", "1", "-screen", "0", screen])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .spawn()
-            .map_err(|e| {
-                GlassError::Backend(format!(
-                    "could not spawn {xvfb} ({e}); install it (e.g. `apt install xvfb`), \
-                     set GLASS_XVFB to its path, or set GLASS_DISPLAY=:N to attach to an \
-                     existing display"
-                ))
-            })?;
+        start_binary(&xvfb, screen, READY_TIMEOUT)
+    }
+}
 
-        let stdout = child.stdout.take().expect("piped stdout");
-        match read_displayfd(stdout, READY_TIMEOUT) {
-            Ok((num, displayfd)) => Ok(Xvfb {
-                child,
-                display: format!(":{num}"),
-                displayfd,
-            }),
-            Err(e) => {
-                glass_proc_linux::reap_graceful(&mut child, glass_proc_linux::REAP_GRACE);
-                Err(GlassError::Backend(match e {
-                    ReadErr::Closed => {
-                        "Xvfb exited without reporting a display (failed to start)".into()
-                    }
-                    ReadErr::Garbage(line) => {
-                        format!("unexpected Xvfb -displayfd output: {line:?}")
-                    }
-                    ReadErr::TimedOut => format!(
-                        "Xvfb spawned but did not report a display within {}s (wedged); \
-                         not blocking start-up",
-                        READY_TIMEOUT.as_secs()
-                    ),
-                }))
-            }
+/// One spawn attempt's failure, carrying whatever the server wrote to stderr —
+/// the only diagnostics a failed Xvfb offers.
+enum StartErr {
+    /// `exec` itself failed — the binary is missing/not runnable.
+    Spawn(String),
+    /// Xvfb exited before reporting a display.
+    Exited { stderr: String },
+    /// A line arrived on `-displayfd` but wasn't a display number.
+    Garbage { line: String, stderr: String },
+    /// Alive but silent past the deadline.
+    Wedged { stderr: String },
+}
+
+/// Spawn `xvfb` and wait for its `-displayfd` report. A wedge (spawned but
+/// silent past `ready_timeout`) gets ONE retry against a fresh server — it's the
+/// transient failure class (seen under heavy host load), and on a user's first
+/// run a single quiet retry is the difference between working and giving up.
+/// Exit/garbage failures are deterministic (bad binary/args/env); retrying those
+/// would only double the time to the same error.
+fn start_binary(xvfb: &str, screen: &str, ready_timeout: Duration) -> Result<Xvfb> {
+    match start_once(xvfb, screen, ready_timeout) {
+        Ok(x) => Ok(x),
+        Err(StartErr::Wedged { .. }) => {
+            eprintln!(
+                "glass: Xvfb did not report a display within {}s; \
+                 killing it and retrying once with a fresh server",
+                ready_timeout.as_secs()
+            );
+            start_once(xvfb, screen, ready_timeout)
+                .map_err(|e| into_glass_error(xvfb, e, ready_timeout))
         }
+        Err(e) => Err(into_glass_error(xvfb, e, ready_timeout)),
+    }
+}
+
+/// A single spawn-and-wait attempt. On failure the child is reaped before
+/// returning, so a retry never overlaps a dying server.
+fn start_once(
+    xvfb: &str,
+    screen: &str,
+    ready_timeout: Duration,
+) -> std::result::Result<Xvfb, StartErr> {
+    let mut child = Command::new(xvfb)
+        .args(["-displayfd", "1", "-screen", "0", screen])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| StartErr::Spawn(e.to_string()))?;
+
+    let stderr_tail = StderrTail::drain(child.stderr.take().expect("piped stderr"));
+    let stdout = child.stdout.take().expect("piped stdout");
+    match read_displayfd(stdout, ready_timeout) {
+        Ok((num, displayfd)) => Ok(Xvfb {
+            child,
+            display: format!(":{num}"),
+            displayfd,
+        }),
+        Err(e) => {
+            glass_proc_linux::reap_graceful(&mut child, glass_proc_linux::REAP_GRACE);
+            // The child is dead, so its stderr pipe has EOF'd (or will within
+            // moments); wait briefly for the drain to finish so the message is
+            // complete rather than racing the reader thread.
+            let stderr = stderr_tail.snapshot(Duration::from_millis(500));
+            Err(match e {
+                ReadErr::Closed => StartErr::Exited { stderr },
+                ReadErr::Garbage(line) => StartErr::Garbage { line, stderr },
+                ReadErr::TimedOut => StartErr::Wedged { stderr },
+            })
+        }
+    }
+}
+
+/// Render a final (post-retry) failure as a user-facing error that names the
+/// recovery and carries the server's stderr.
+fn into_glass_error(xvfb: &str, e: StartErr, ready_timeout: Duration) -> GlassError {
+    let msg = match e {
+        StartErr::Spawn(e) => format!(
+            "could not spawn {xvfb} ({e}); install it (e.g. `apt install xvfb`), \
+             set GLASS_XVFB to its path, or set GLASS_DISPLAY=:N to attach to an \
+             existing display"
+        ),
+        StartErr::Exited { stderr } => with_stderr(
+            "Xvfb exited without reporting a display (failed to start); \
+             set GLASS_DISPLAY=:N to attach to an existing display instead"
+                .into(),
+            &stderr,
+        ),
+        StartErr::Garbage { line, stderr } => with_stderr(
+            format!("unexpected Xvfb -displayfd output: {line:?}"),
+            &stderr,
+        ),
+        StartErr::Wedged { stderr } => with_stderr(
+            format!(
+                "Xvfb did not report a display within {}s, twice (the first server \
+                 was killed and a fresh one retried); try again, set GLASS_DISPLAY=:N \
+                 to attach to an existing display, or run `Xvfb -displayfd 1` \
+                 manually to see why it stalls",
+                ready_timeout.as_secs()
+            ),
+            &stderr,
+        ),
+    };
+    GlassError::Backend(msg)
+}
+
+/// How much of the captured stderr to render into an error message. X servers
+/// dump their whole option table (~5KB) after a config error, with the fatal
+/// line FIRST — so the head is the useful part and the rest is disclosed as a
+/// byte count rather than pasted into a one-line check/detail.
+const STDERR_SHOWN: usize = 512;
+
+fn with_stderr(msg: String, stderr: &str) -> String {
+    if stderr.is_empty() {
+        return format!("{msg} (Xvfb printed nothing to stderr)");
+    }
+    if stderr.len() <= STDERR_SHOWN {
+        return format!("{msg}; Xvfb stderr: {stderr}");
+    }
+    let mut cut = STDERR_SHOWN;
+    while !stderr.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    format!(
+        "{msg}; Xvfb stderr (first {cut} bytes of {}): {}…",
+        stderr.len(),
+        &stderr[..cut]
+    )
+}
+
+/// Drains a child's stderr on a helper thread for the child's whole lifetime
+/// (so a chatty server can never stall on a full pipe), keeping the first
+/// `STDERR_CAP` bytes for diagnostics.
+struct StderrTail(Arc<TailState>);
+
+struct TailState {
+    buf: Mutex<TailBuf>,
+    eof: Condvar,
+}
+
+struct TailBuf {
+    bytes: Vec<u8>,
+    done: bool,
+}
+
+impl StderrTail {
+    fn drain(mut stderr: ChildStderr) -> StderrTail {
+        let state = Arc::new(TailState {
+            buf: Mutex::new(TailBuf {
+                bytes: Vec::new(),
+                done: false,
+            }),
+            eof: Condvar::new(),
+        });
+        let s = state.clone();
+        std::thread::spawn(move || {
+            let mut chunk = [0u8; 4096];
+            loop {
+                match stderr.read(&mut chunk) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => {
+                        let mut g = s.buf.lock().unwrap();
+                        let room = STDERR_CAP.saturating_sub(g.bytes.len());
+                        g.bytes.extend_from_slice(&chunk[..n.min(room)]);
+                        // keep looping past the cap — the pipe must stay drained
+                    }
+                }
+            }
+            let mut g = s.buf.lock().unwrap();
+            g.done = true;
+            s.eof.notify_all();
+        });
+        StderrTail(state)
+    }
+
+    /// The captured stderr, waiting up to `timeout` for the pipe to EOF first
+    /// (call after the child is reaped). Lossy UTF-8, trimmed.
+    fn snapshot(&self, timeout: Duration) -> String {
+        let g = self.0.buf.lock().unwrap();
+        let (g, _) = self
+            .0
+            .eof
+            .wait_timeout_while(g, timeout, |b| !b.done)
+            .unwrap();
+        String::from_utf8_lossy(&g.bytes).trim().to_string()
     }
 }
 
@@ -126,9 +292,155 @@ impl Drop for Xvfb {
 
 #[cfg(test)]
 mod tests {
-    use super::{read_displayfd, ReadErr};
+    use super::{read_displayfd, start_binary, ReadErr, Xvfb};
+    use glass_core::{GlassError, Result};
     use std::process::{Command, Stdio};
     use std::time::Duration;
+
+    /// Call `start_binary` on a fixture script, retrying past a transient
+    /// ETXTBSY: a sibling test thread's fork can momentarily hold the freshly
+    /// written script's fd open, racing our exec (same rationale as the
+    /// glass-ios companion tests). Resets the script's `$0.ran` marker before
+    /// each attempt so a stateful fixture always re-runs from invocation one.
+    fn start_fixture(script: &std::path::Path, timeout: Duration) -> Result<Xvfb> {
+        let marker = format!("{}.ran", script.display());
+        let mut last = None;
+        for _ in 0..100 {
+            let _ = std::fs::remove_file(&marker);
+            match start_binary(script.to_str().unwrap(), "640x480x24", timeout) {
+                Err(GlassError::Backend(m)) if m.contains("Text file busy") => {
+                    std::thread::sleep(Duration::from_millis(10));
+                    last = Some(m);
+                }
+                r => return r,
+            }
+        }
+        panic!("ETXTBSY persisted after 100 retries: {last:?}")
+    }
+
+    /// Write an executable fake-Xvfb shell script into a unique temp dir and
+    /// return its path. `$0.ran` is the script's own scratch marker.
+    fn fixture(name: &str, body: &str) -> std::path::PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!("glass-xvfb-fixture-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let p = dir.join(name);
+        std::fs::write(&p, format!("#!/bin/sh\n{body}")).unwrap();
+        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+        p
+    }
+
+    #[test]
+    fn stderr_render_keeps_the_head_and_says_how_much_was_clipped() {
+        // Real Xvfb dumps its whole option table (~5KB) on a config error, with
+        // the fatal line FIRST. The rendered error must keep the head and
+        // disclose the clip, not paste kilobytes into a one-line check/detail.
+        let fatal = "fatal: something specific went wrong";
+        let noise = "usage noise line\n".repeat(200); // ~3.4KB
+        let out = super::with_stderr("Xvfb failed".into(), &format!("{fatal}\n{noise}"));
+        assert!(out.contains(fatal), "fatal first line kept: {out}");
+        assert!(
+            out.len() < 800,
+            "rendered error stays bounded, got {} bytes",
+            out.len()
+        );
+        assert!(
+            out.contains("bytes"),
+            "clip must be disclosed with sizes: {out}"
+        );
+    }
+
+    #[test]
+    fn short_stderr_renders_whole_without_clip_note() {
+        let out = super::with_stderr("Xvfb failed".into(), "one useful line");
+        assert!(out.contains("one useful line"), "{out}");
+        assert!(
+            !out.contains("bytes of"),
+            "no clip note when nothing clipped: {out}"
+        );
+    }
+
+    #[test]
+    fn chatty_stderr_before_report_does_not_stall_startup() {
+        // The drain thread must keep reading past STDERR_CAP: a server writing
+        // more than the 64KiB pipe buffer before reporting its display would
+        // otherwise block on write() forever and turn every start into a wedge.
+        let script = fixture(
+            "chatty.sh",
+            "dd if=/dev/zero bs=1024 count=1024 2>/dev/null | tr '\\0' e >&2\n\
+             echo 4321\n\
+             exec sleep 30\n",
+        );
+        let t0 = std::time::Instant::now();
+        let x = start_fixture(&script, Duration::from_secs(5)).expect("must start");
+        assert_eq!(x.display, ":4321");
+        assert!(
+            t0.elapsed() < Duration::from_secs(4),
+            "1MiB of stderr must not wedge the start (took {:?})",
+            t0.elapsed()
+        );
+    }
+
+    #[test]
+    fn wedged_first_attempt_is_killed_and_retried_once() {
+        // First invocation wedges (alive, silent); second reports a display.
+        // A transient wedge must cost one retry, not the whole session.
+        let script = fixture(
+            "wedge-then-ok.sh",
+            "if [ -e \"$0.ran\" ]; then echo 4321; exec sleep 30; fi\n\
+             touch \"$0.ran\"\n\
+             exec sleep 30\n",
+        );
+        let x = start_fixture(&script, Duration::from_millis(300))
+            .expect("second attempt must succeed");
+        assert_eq!(x.display, ":4321");
+    }
+
+    #[test]
+    fn wedged_twice_error_names_recovery_and_includes_stderr() {
+        // Both attempts wedge. The error must carry the server's stderr (the
+        // only diagnostics it offers) and name a recovery, not internal
+        // rationale.
+        let script = fixture(
+            "wedge-always.sh",
+            "echo 'fixture stderr complaint' >&2\nexec sleep 30\n",
+        );
+        let err = start_fixture(&script, Duration::from_millis(200))
+            .expect_err("must fail after the retry")
+            .to_string();
+        assert!(err.contains("did not report a display"), "msg: {err}");
+        assert!(
+            err.contains("retried"),
+            "must say it already retried: {err}"
+        );
+        assert!(err.contains("GLASS_DISPLAY"), "must name a recovery: {err}");
+        assert!(
+            err.contains("fixture stderr complaint"),
+            "must include Xvfb stderr: {err}"
+        );
+    }
+
+    #[test]
+    fn immediate_exit_is_not_retried_and_includes_stderr() {
+        // Exit-without-display is deterministic (bad binary/args/env) — a retry
+        // would only double the wait. The fixture would SUCCEED on a second
+        // invocation, so a wrongly-added retry turns this Err into Ok.
+        let script = fixture(
+            "exit-then-ok.sh",
+            "if [ -e \"$0.ran\" ]; then echo 4321; exec sleep 30; fi\n\
+             touch \"$0.ran\"\n\
+             echo 'exiting complaint' >&2\n\
+             exit 1\n",
+        );
+        let err = start_fixture(&script, Duration::from_millis(500))
+            .expect_err("exit must fail without retry")
+            .to_string();
+        assert!(err.contains("exited without reporting"), "msg: {err}");
+        assert!(
+            err.contains("exiting complaint"),
+            "must include Xvfb stderr: {err}"
+        );
+    }
 
     #[test]
     fn read_displayfd_times_out_on_a_silent_child() {


### PR DESCRIPTION
## Problem

A transient Xvfb stall — spawned but silent past the 10s `-displayfd` deadline — failed `glass_start` outright. Observed once on a loaded CI runner ([this run](https://github.com/fixed-width/glass/actions/runs/30112467654)); the same path runs on a user's **first** `glass_start`, where one stall means glass just doesn't work. Xvfb's stderr was discarded (`Stdio::null`), so the error could never say why, and the message leaked internal phrasing ("not blocking start-up") and named no recovery.

## Change

- **Wedge → one retry against a fresh server.** The wedged child is fully reaped before the respawn (no overlapping servers; a SIGKILLed server's stale lock is self-healing — the X server removes locks whose pid is gone, verified). Deterministic failures (exit, garbage `-displayfd` output) are not retried. Worst still-failing start is ~24s; the retry is logged to stderr.
- **stderr captured and rendered bounded.** Piped + drained on a lifetime thread (8KiB kept, pipe drained past the cap so a chatty server can't stall on a full 64KiB pipe — locked by a 1MiB-stderr fixture test). Errors render the first 512 bytes (X servers print the fatal line first, then a ~5KB option table) and disclose the clip.
- **Errors name the recovery**: `GLASS_DISPLAY=:N` to attach to an existing display, or run Xvfb manually to diagnose.
- **`doctor --deep` probe budget** now derives from the start path's worst case (`start_deadline()`) instead of a hardcoded 8s that was below even one attempt — it no longer reports Fail (with a wrong remedy) for the exact transient the start path survives, and the probe thread now always reaps its child.

Wayland checked for the sibling gap: sway's stderr is already piped/surfaced and its socket wait polls — no matching hazard.

## Testing

- 8 new unit tests (TDD) via fake-Xvfb shell fixtures: wedge→retry succeeds; wedge×2 error names recovery + stderr; immediate exit **not** retried (fixture succeeds on a second run, so a wrongly-added retry flips the test to Ok); chatty 1MiB stderr doesn't stall; stderr render bounded + clip disclosed; ETXTBSY-hardened fixture runner.
- Real-path checks: `doctor --deep` green on a healthy host; `GLASS_XVFB_SCREEN=bogusxbogus doctor --deep` report shrinks 147→50 lines with the fatal line leading.
- Local: fmt, clippy `-D warnings` `--locked`, `cargo test --workspace --locked`, `test-x11.sh`, `test-wayland.sh`, `test-a11y.sh` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)