### PR TITLE
feat(a11y): native accessibility-action invoke for click_element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,12 +33,16 @@ internal refactors, CI, or test-only changes.
   is truncated the notice now reports the actual limit and says how to widen it.
 - `glass_click_element` now actuates via the platform's native accessibility action
   when the element exposes one (AT-SPI Action on Linux, UIA patterns on Windows,
-  AXPress on macOS), falling back to the synthetic pointer click otherwise. The
+  AXPress on macOS), falling back to the synthetic pointer click when the element —
+  or the backend — exposes none. A native action that was dispatched but failed
+  reports the error rather than falling back, so a click never actuates twice. The
   result's new `method` field reports which path ran (`native-action`/`pointer`),
   with `native_fallback` explaining any fallback. Native actuation works for
   occluded or scrolled-off-screen elements and, on macOS, no longer moves the
-  cursor. A click whose element no longer matches the snapshot now errors
-  (`element changed; re-snapshot`) instead of clicking stale coordinates.
+  cursor. On those three backends the click also re-checks the element against the
+  live tree, so one that no longer matches the snapshot errors (`element changed;
+  re-snapshot`) instead of clicking stale coordinates — the pointer-only iOS and
+  Android paths have no such live check.
 
 ### Fixed
 - A transiently stalled Xvfb no longer fails `glass_start` on Linux/X11: if the private X

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ internal refactors, CI, or test-only changes.
 - `glass_a11y_snapshot` accepts an optional `max_nodes`: raise the element cap for a large app,
   or pass `0` to remove the element-count limit. The default cap is unchanged, and when a snapshot
   is truncated the notice now reports the actual limit and says how to widen it.
+- `glass_click_element` now actuates via the platform's native accessibility action
+  when the element exposes one (AT-SPI Action on Linux, UIA patterns on Windows,
+  AXPress on macOS), falling back to the synthetic pointer click otherwise. The
+  result's new `method` field reports which path ran (`native-action`/`pointer`),
+  with `native_fallback` explaining any fallback. Native actuation works for
+  occluded or scrolled-off-screen elements and, on macOS, no longer moves the
+  cursor. A click whose element no longer matches the snapshot now errors
+  (`element changed; re-snapshot`) instead of clicking stale coordinates.
 
 ### Fixed
 - A transiently stalled Xvfb no longer fails `glass_start` on Linux/X11: if the private X

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1347,6 +1347,7 @@ dependencies = [
  "glass-a11y-windows",
  "glass-clip-hook",
  "glass-core",
+ "tempfile",
  "windows",
  "windows-capture",
 ]

--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ For a canvas or custom-rendered app with no accessibility tree, drive it by pixe
 text, so routine checks between screenshots cost no vision tokens. Why the loop is shaped this way:
 [the build → see → interact → debug loop](docs/explanation/the-loop.md).
 
+`glass_click_element` tries the platform's native accessibility action first — AT-SPI `Action` on
+Linux, a UI Automation invocation pattern on Windows, `AXPress` on macOS — which actuates elements
+that are occluded or scrolled off-screen and, on macOS, without moving the cursor. Not every
+control exposes one (some toolkit checkbuttons expose no action even on a backend that otherwise
+supports it), so the click falls back to a synthetic pointer click at the element's center when it
+doesn't. iOS and Android always use the pointer path today. The result's `method` field
+(`native-action`/`pointer`) says which path actually ran for that click, with `native_fallback`
+explaining why when it fell back — the source of truth per click, not the backend alone. If the
+element no longer matches the latest snapshot, the click errors instead of clicking stale
+coordinates.
+
 ## Install at a glance
 
 Download the latest build for your platform from the

--- a/README.md
+++ b/README.md
@@ -67,15 +67,16 @@ text, so routine checks between screenshots cost no vision tokens. Why the loop 
 [the build → see → interact → debug loop](docs/explanation/the-loop.md).
 
 `glass_click_element` tries the platform's native accessibility action first — AT-SPI `Action` on
-Linux, a UI Automation invocation pattern on Windows, `AXPress` on macOS — which actuates elements
+Linux, UI Automation patterns on Windows, `AXPress` on macOS — which actuates elements
 that are occluded or scrolled off-screen and, on macOS, without moving the cursor. Not every
 control exposes one (some toolkit checkbuttons expose no action even on a backend that otherwise
 supports it), so the click falls back to a synthetic pointer click at the element's center when it
 doesn't. iOS and Android always use the pointer path today. The result's `method` field
 (`native-action`/`pointer`) says which path actually ran for that click, with `native_fallback`
-explaining why when it fell back — the source of truth per click, not the backend alone. If the
-element no longer matches the latest snapshot, the click errors instead of clicking stale
-coordinates.
+explaining why when it fell back — the source of truth per click, not the backend alone. On those
+three backends the native attempt re-checks the element against the live tree, so a click whose
+element no longer matches errors instead of clicking stale coordinates; the pointer-only iOS and
+Android paths have no such live check.
 
 ## Install at a glance
 

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -71,8 +71,13 @@ impl Accessibility for LinuxA11y {
         });
         match rx.recv_timeout(SNAPSHOT_TIMEOUT) {
             Ok(r) => r,
+            // The worker thread outlives this timeout, so the action may already have been
+            // dispatched — say so. This error is NOT fallback-eligible (see
+            // `GlassError::invoke_fallback_eligible`), so no pointer click is layered on top.
             Err(_) => Err(GlassError::AccessibilityUnavailable(
-                "accessibility invoke timed out (a11y bus not responding)".into(),
+                "accessibility invoke timed out (a11y bus not responding); the action may \
+                 still land — re-snapshot before retrying"
+                    .into(),
             )),
         }
     }

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -524,7 +524,7 @@ async fn set_toggle(
 }
 
 /// AT-SPI action names that activate a widget for a generic click. Broader than
-/// TOGGLE_ACTION_NAMES on the activation side (push/jump), narrower on the
+/// [`TOGGLE_ACTION_NAMES`] on the activation side (push/jump), narrower on the
 /// check/uncheck side — those are set_value verbs, not clicks.
 const ACTIVATE_ACTION_NAMES: &[&str] = &["click", "activate", "press", "push", "jump", "toggle"];
 

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -61,6 +61,21 @@ impl Accessibility for LinuxA11y {
             )),
         }
     }
+
+    fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<()> {
+        let ctx = ctx.clone();
+        let target = target.clone();
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(run_invoke(&ctx, &target));
+        });
+        match rx.recv_timeout(SNAPSHOT_TIMEOUT) {
+            Ok(r) => r,
+            Err(_) => Err(GlassError::AccessibilityUnavailable(
+                "accessibility invoke timed out (a11y bus not responding)".into(),
+            )),
+        }
+    }
 }
 
 fn run_snapshot(ctx: &AxContext) -> Result<AxTree> {
@@ -77,6 +92,14 @@ fn run_set_value(ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
         .build()
         .map_err(|e| GlassError::AccessibilityUnavailable(format!("runtime: {e}")))?;
     rt.block_on(set_value_async(ctx, target, text))
+}
+
+fn run_invoke(ctx: &AxContext, target: &AxTarget) -> Result<()> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| GlassError::AccessibilityUnavailable(format!("runtime: {e}")))?;
+    rt.block_on(invoke_async(ctx, target))
 }
 
 fn bus_err(e: impl std::fmt::Display) -> GlassError {
@@ -498,6 +521,40 @@ async fn set_toggle(
         }
     }
     Err(GlassError::AxValueNotApplied(id))
+}
+
+/// AT-SPI action names that activate a widget for a generic click. Broader than
+/// TOGGLE_ACTION_NAMES on the activation side (push/jump), narrower on the
+/// check/uncheck side — those are set_value verbs, not clicks.
+const ACTIVATE_ACTION_NAMES: &[&str] = &["click", "activate", "press", "push", "jump", "toggle"];
+
+/// Actuate the element identified by `target` via its native AT-SPI Action — the
+/// backend for `Accessibility::invoke`. Re-walks pre-order to `target.id`, verifies
+/// the fingerprint (same gate as `set_value_async`, guarding a stale id / mirror
+/// drift), then fires the first action in [`ACTIVATE_ACTION_NAMES`].
+async fn invoke_async(ctx: &AxContext, target: &AxTarget) -> Result<()> {
+    let (app_ref, conn) = find_app(ctx).await?;
+    let app = app_ref.as_accessible_proxy(&conn).await.map_err(bus_err)?;
+    let mut budget = WalkBudget::with_limits(ctx.limits);
+    let node_ref = Box::pin(find_nth(&app_ref, &app, &conn, 0, target.id.0, &mut budget))
+        .await?
+        .ok_or(GlassError::AxElementChanged(target.id.0))?;
+    let node = node_ref.as_accessible_proxy(&conn).await.map_err(bus_err)?;
+    // Verify role + name against the fingerprint (guards a stale id / mirror drift) —
+    // same gate as set_value_async.
+    let role = map_role(node.get_role().await.map_err(bus_err)?);
+    let name = nonempty(node.name().await.unwrap_or_default());
+    if !target.matches(role, name.as_deref()) {
+        return Err(GlassError::AxElementChanged(target.id.0));
+    }
+    match try_action(&conn, &node, ACTIVATE_ACTION_NAMES).await {
+        ActionAttempt::Fired(true) => Ok(()),
+        ActionAttempt::Fired(false) => Err(GlassError::AxActionFailed(
+            target.id.0,
+            "the toolkit reported the action did not run".into(),
+        )),
+        ActionAttempt::Unavailable => Err(GlassError::AxActionUnavailable(target.id.0)),
+    }
 }
 
 /// Window-relative bounds via the Component interface, or `None` if the node has no

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -457,11 +457,21 @@ enum ActionAttempt {
     /// An action from the ladder was found and fired; the bool is the
     /// bus-reported success.
     Fired(bool),
-    /// No Action interface, or none of `names` present.
+    /// The node exposes no Action interface, or none of `names` is among its actions.
+    /// Nothing was dispatched.
     Unavailable,
+    /// An AT-SPI call failed, so the outcome is genuinely unknown — in particular a
+    /// failed `DoAction` may still have reached the toolkit. Distinct from
+    /// `Fired(false)` (the toolkit answered "I did not run it") so a caller can't
+    /// report a transport failure as a truthful "did not run".
+    Error(String),
 }
 
 /// Fire the node's first Action whose name is in `names`.
+///
+/// A proxy that cannot be *built* is `Unavailable`: construction dispatches no action, and
+/// the overwhelmingly common cause is the node not implementing the Action interface at all.
+/// From `NActions` onward every RPC failure is `Error`.
 async fn try_action(
     conn: &zbus::Connection,
     node: &AccessibleProxy<'_>,
@@ -479,11 +489,20 @@ async fn try_action(
     let Ok(a) = action.build().await else {
         return ActionAttempt::Unavailable;
     };
-    let n = a.n_actions().await.unwrap_or(0);
+    let n = match a.n_actions().await {
+        Ok(n) => n,
+        Err(e) => return ActionAttempt::Error(format!("NActions: {e}")),
+    };
     for i in 0..n {
-        let name = a.get_name(i).await.unwrap_or_default().to_ascii_lowercase();
+        let name = match a.get_name(i).await {
+            Ok(name) => name.to_ascii_lowercase(),
+            Err(e) => return ActionAttempt::Error(format!("GetName({i}): {e}")),
+        };
         if names.contains(&name.as_str()) {
-            return ActionAttempt::Fired(a.do_action(i).await.unwrap_or(false));
+            return match a.do_action(i).await {
+                Ok(ok) => ActionAttempt::Fired(ok),
+                Err(e) => ActionAttempt::Error(format!("DoAction({i}): {e}")),
+            };
         }
     }
     ActionAttempt::Unavailable
@@ -510,6 +529,10 @@ async fn set_toggle(
     if node.get_state().await.map_err(bus_err)?.contains(flag) == target_on {
         return Ok(()); // already in the desired state
     }
+    // `Error` (an AT-SPI call that failed) folds in with "did not fire" here, keeping
+    // `set_value`'s behavior unchanged: this path verifies the state below and reports
+    // `AxValueNotApplied` on no change, so an ambiguous outcome is caught by that check
+    // rather than needing its own classification.
     if !matches!(
         try_action(conn, node, TOGGLE_ACTION_NAMES).await,
         ActionAttempt::Fired(true)
@@ -559,6 +582,12 @@ async fn invoke_async(ctx: &AxContext, target: &AxTarget) -> Result<()> {
             "the toolkit reported the action did not run".into(),
         )),
         ActionAttempt::Unavailable => Err(GlassError::AxActionUnavailable(target.id.0)),
+        // Not `AxActionUnavailable`: the call may have reached the toolkit, so this must not
+        // be fallback-eligible (see `GlassError::invoke_fallback_eligible`) — a pointer click
+        // on top of a landed action would actuate the control twice.
+        ActionAttempt::Error(msg) => Err(GlassError::AccessibilityUnavailable(format!(
+            "AT-SPI action call failed: {msg}"
+        ))),
     }
 }
 

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -454,9 +454,10 @@ const TOGGLE_ACTION_NAMES: &[&str] = &[
 
 /// Outcome of one AT-SPI Action attempt on a node.
 enum ActionAttempt {
-    /// An action from the ladder was found and fired; the bool is the
-    /// bus-reported success.
-    Fired(bool),
+    /// An action from the ladder was found and fired: `ok` is the bus-reported success,
+    /// `action` the (lowercased) action name that ran — the caller uses it to decide
+    /// whether a post-fire state verify applies.
+    Fired { ok: bool, action: String },
     /// The node exposes no Action interface, or none of `names` is among its actions.
     /// Nothing was dispatched.
     Unavailable,
@@ -500,7 +501,7 @@ async fn try_action(
         };
         if names.contains(&name.as_str()) {
             return match a.do_action(i).await {
-                Ok(ok) => ActionAttempt::Fired(ok),
+                Ok(ok) => ActionAttempt::Fired { ok, action: name },
                 Err(e) => ActionAttempt::Error(format!("DoAction({i}): {e}")),
             };
         }
@@ -508,12 +509,29 @@ async fn try_action(
     ActionAttempt::Unavailable
 }
 
+/// The AT-SPI state flag carrying a widget's boolean state: toggle buttons expose it as
+/// `Pressed`, checkboxes/switches/radios as `Checked`. Shared by `set_value`'s toggle write
+/// and `invoke`'s toggle verify so the two can never read a control's state differently.
+fn toggle_state_flag(role: glass_core::AxRole) -> atspi_common::State {
+    if role == glass_core::AxRole::ToggleButton {
+        atspi_common::State::Pressed
+    } else {
+        atspi_common::State::Checked
+    }
+}
+
+/// Poll bound for confirming a toggle actually moved: the toolkit applies the action on a
+/// later main-loop pass, so the first read after firing is expected to be stale. Generous
+/// enough for a loaded headless session without letting a real failure hang the tool.
+const TOGGLE_VERIFY_POLLS: usize = 6;
+/// See [`TOGGLE_VERIFY_POLLS`].
+const TOGGLE_VERIFY_INTERVAL: Duration = Duration::from_millis(120);
+
 /// Set a boolean widget (switch/checkbox/toggle/radio) to `target_on`. Idempotent:
 /// only invokes the toggle action when the boolean state differs, then confirms the
 /// state actually changed (the toolkit applies the action on its next loop) — so a
 /// no-op activation (e.g. a radio can't be *un*-selected by clicking it) is reported
-/// as `AxValueNotApplied`, never a silent success. Toggle buttons expose their state
-/// via `Pressed`; checkboxes/switches/radios via `Checked`.
+/// as `AxValueNotApplied`, never a silent success.
 async fn set_toggle(
     conn: &zbus::Connection,
     node: &AccessibleProxy<'_>,
@@ -521,11 +539,7 @@ async fn set_toggle(
     target_on: bool,
     id: u32,
 ) -> Result<()> {
-    let flag = if role == glass_core::AxRole::ToggleButton {
-        atspi_common::State::Pressed
-    } else {
-        atspi_common::State::Checked
-    };
+    let flag = toggle_state_flag(role);
     if node.get_state().await.map_err(bus_err)?.contains(flag) == target_on {
         return Ok(()); // already in the desired state
     }
@@ -535,15 +549,15 @@ async fn set_toggle(
     // rather than needing its own classification.
     if !matches!(
         try_action(conn, node, TOGGLE_ACTION_NAMES).await,
-        ActionAttempt::Fired(true)
+        ActionAttempt::Fired { ok: true, .. }
     ) {
         // No toggle action (e.g. a GTK4 GtkCheckButton exposes none) — can't set it
         // through accessibility; the caller should drive it with click_element.
         return Err(GlassError::AxElementNotEditable(id));
     }
     // Poll until the toolkit applies it; a no-op activation never converges.
-    for _ in 0..6 {
-        tokio::time::sleep(Duration::from_millis(120)).await;
+    for _ in 0..TOGGLE_VERIFY_POLLS {
+        tokio::time::sleep(TOGGLE_VERIFY_INTERVAL).await;
         if node.get_state().await.map_err(bus_err)?.contains(flag) == target_on {
             return Ok(());
         }
@@ -551,15 +565,48 @@ async fn set_toggle(
     Err(GlassError::AxValueNotApplied(id))
 }
 
+/// The one AT-SPI action whose meaning is "flip this control's boolean state" — and so the
+/// one rung whose success can be checked by re-reading that state after firing.
+const TOGGLE_ACTION: &str = "toggle";
+
 /// AT-SPI action names that activate a widget for a generic click. Broader than
 /// [`TOGGLE_ACTION_NAMES`] on the activation side (push/jump), narrower on the
 /// check/uncheck side — those are set_value verbs, not clicks.
-const ACTIVATE_ACTION_NAMES: &[&str] = &["click", "activate", "press", "push", "jump", "toggle"];
+const ACTIVATE_ACTION_NAMES: &[&str] =
+    &["click", "activate", "press", "push", "jump", TOGGLE_ACTION];
+
+/// Confirm a fired `toggle` action actually moved the control: poll its boolean state until
+/// it differs from `was_on`. Without this, a toolkit that accepts and acknowledges the action
+/// but never applies it (or applies it to nothing) reports a successful click on a control
+/// that did not move — a silent failure. The failure is `AxActionFailed`, which propagates
+/// rather than falling back to a pointer click: the action was dispatched, so a second
+/// actuation could land on top of a late-applying toggle.
+async fn verify_toggle_flipped(
+    node: &AccessibleProxy<'_>,
+    flag: atspi_common::State,
+    was_on: bool,
+    id: u32,
+) -> Result<()> {
+    for _ in 0..TOGGLE_VERIFY_POLLS {
+        tokio::time::sleep(TOGGLE_VERIFY_INTERVAL).await;
+        if node.get_state().await.map_err(bus_err)?.contains(flag) != was_on {
+            return Ok(());
+        }
+    }
+    Err(GlassError::AxActionFailed(
+        id,
+        "the toggle action was acknowledged but the state did not change".into(),
+    ))
+}
 
 /// Actuate the element identified by `target` via its native AT-SPI Action — the
 /// backend for `Accessibility::invoke`. Re-walks pre-order to `target.id`, verifies
 /// the fingerprint (same gate as `set_value_async`, guarding a stale id / mirror
 /// drift), then fires the first action in [`ACTIVATE_ACTION_NAMES`].
+///
+/// When the action that fired is [`TOGGLE_ACTION`], the ack alone is not accepted as
+/// success: the control's boolean state must be observed to change (see
+/// [`verify_toggle_flipped`]).
 async fn invoke_async(ctx: &AxContext, target: &AxTarget) -> Result<()> {
     let (app_ref, conn) = find_app(ctx).await?;
     let app = app_ref.as_accessible_proxy(&conn).await.map_err(bus_err)?;
@@ -575,9 +622,19 @@ async fn invoke_async(ctx: &AxContext, target: &AxTarget) -> Result<()> {
     if !target.matches(role, name.as_deref()) {
         return Err(GlassError::AxElementChanged(target.id.0));
     }
+    // Read the control's boolean state BEFORE firing, so a `toggle` action can be verified by
+    // an actual flip below — afterwards there is nothing left to compare against. Costs one
+    // property read on every native click; the alternative is trusting a toolkit ack that a
+    // switch may never honor. Meaningless for a control with no boolean state (a plain
+    // button), which is why only the `toggle` rung consults it.
+    let flag = toggle_state_flag(role);
+    let was_on = node.get_state().await.map_err(bus_err)?.contains(flag);
     match try_action(&conn, &node, ACTIVATE_ACTION_NAMES).await {
-        ActionAttempt::Fired(true) => Ok(()),
-        ActionAttempt::Fired(false) => Err(GlassError::AxActionFailed(
+        ActionAttempt::Fired { ok: true, action } if action == TOGGLE_ACTION => {
+            verify_toggle_flipped(&node, flag, was_on, target.id.0).await
+        }
+        ActionAttempt::Fired { ok: true, .. } => Ok(()),
+        ActionAttempt::Fired { ok: false, .. } => Err(GlassError::AxActionFailed(
             target.id.0,
             "the toolkit reported the action did not run".into(),
         )),

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -424,9 +424,21 @@ const TOGGLE_ACTION_NAMES: &[&str] = &[
     "toggle", "click", "activate", "press", "check", "uncheck", "switch",
 ];
 
-/// Invoke the node's first activating Action (see [`TOGGLE_ACTION_NAMES`]).
-/// Returns whether an action was found and reported success.
-async fn invoke_activating_action(conn: &zbus::Connection, node: &AccessibleProxy<'_>) -> bool {
+/// Outcome of one AT-SPI Action attempt on a node.
+enum ActionAttempt {
+    /// An action from the ladder was found and fired; the bool is the
+    /// bus-reported success.
+    Fired(bool),
+    /// No Action interface, or none of `names` present.
+    Unavailable,
+}
+
+/// Fire the node's first Action whose name is in `names`.
+async fn try_action(
+    conn: &zbus::Connection,
+    node: &AccessibleProxy<'_>,
+    names: &[&str],
+) -> ActionAttempt {
     let dest = node.inner().destination().to_owned();
     let path = node.inner().path().to_owned();
     let Some(action) = atspi::proxy::action::ActionProxy::builder(conn)
@@ -434,19 +446,19 @@ async fn invoke_activating_action(conn: &zbus::Connection, node: &AccessibleProx
         .ok()
         .and_then(|b| b.path(path).ok())
     else {
-        return false;
+        return ActionAttempt::Unavailable;
     };
     let Ok(a) = action.build().await else {
-        return false;
+        return ActionAttempt::Unavailable;
     };
     let n = a.n_actions().await.unwrap_or(0);
     for i in 0..n {
         let name = a.get_name(i).await.unwrap_or_default().to_ascii_lowercase();
-        if TOGGLE_ACTION_NAMES.contains(&name.as_str()) {
-            return a.do_action(i).await.unwrap_or(false);
+        if names.contains(&name.as_str()) {
+            return ActionAttempt::Fired(a.do_action(i).await.unwrap_or(false));
         }
     }
-    false
+    ActionAttempt::Unavailable
 }
 
 /// Set a boolean widget (switch/checkbox/toggle/radio) to `target_on`. Idempotent:
@@ -470,7 +482,10 @@ async fn set_toggle(
     if node.get_state().await.map_err(bus_err)?.contains(flag) == target_on {
         return Ok(()); // already in the desired state
     }
-    if !invoke_activating_action(conn, node).await {
+    if !matches!(
+        try_action(conn, node, TOGGLE_ACTION_NAMES).await,
+        ActionAttempt::Fired(true)
+    ) {
         // No toggle action (e.g. a GTK4 GtkCheckButton exposes none) — can't set it
         // through accessibility; the caller should drive it with click_element.
         return Err(GlassError::AxElementNotEditable(id));

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -572,6 +572,10 @@ const TOGGLE_ACTION: &str = "toggle";
 /// AT-SPI action names that activate a widget for a generic click. Broader than
 /// [`TOGGLE_ACTION_NAMES`] on the activation side (push/jump), narrower on the
 /// check/uncheck side — those are set_value verbs, not clicks.
+///
+/// This is a membership set, not a priority order: [`try_action`] fires the node's first
+/// action that appears in this list, so the widget's own action-index order decides which
+/// one runs when it exposes several.
 const ACTIVATE_ACTION_NAMES: &[&str] =
     &["click", "activate", "press", "push", "jump", TOGGLE_ACTION];
 

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -403,16 +403,14 @@ fn launch_fixture() -> Glass {
 /// The GTK fixture's Switch "Active" exposes an AT-SPI activation action ("toggle") —
 /// click_element must take the native path and actually toggle it.
 ///
-/// Deviation from the design brief: the brief specified the CheckButton "Enable" for
-/// this test. Probed against this box's real GTK4 (4.14.5), a bare `Gtk.CheckButton`
-/// publishes ZERO AT-SPI actions (confirmed with an instrumented `try_action` that
-/// enumerated 0 actions on it, while the same probe found "click" on the Save button) —
-/// consistent with the pre-existing comment on `set_toggle` ("a GTK4 GtkCheckButton
-/// exposes none"). A test asserting `ClickMethod::NativeAction` against that widget
-/// would never pass on real GTK4, so it targets the Switch instead: same fixture, same
-/// production code path (`click_element` -> `try_native_invoke` -> `Accessibility::invoke`),
-/// a widget already proven (via `set_value_toggles_switch`, same target) to expose a
-/// real AT-SPI action.
+/// A bare `Gtk.CheckButton` publishes ZERO AT-SPI actions (verified on GTK 4.14.5 with
+/// an instrumented `try_action` that enumerated 0 actions on the fixture's "Enable"
+/// checkbutton, while the same probe found "click" on the Save button) — matching the
+/// pre-existing comment on `set_toggle` ("a GTK4 GtkCheckButton exposes none"). The
+/// Switch is the fixture's action-exposing toggle, so it's the right target for proving
+/// the native path here: same fixture, same production code path (`click_element` ->
+/// `try_native_invoke` -> `Accessibility::invoke`), and a widget already proven (via
+/// `set_value_toggles_switch`, same target) to expose a real AT-SPI action.
 #[test]
 #[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
 fn click_element_native_invokes_gtk_switch() {

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -400,6 +400,48 @@ fn launch_fixture() -> Glass {
     glass
 }
 
+/// The GTK fixture's Switch "Active" exposes an AT-SPI activation action ("toggle") —
+/// click_element must take the native path and actually toggle it.
+///
+/// Deviation from the design brief: the brief specified the CheckButton "Enable" for
+/// this test. Probed against this box's real GTK4 (4.14.5), a bare `Gtk.CheckButton`
+/// publishes ZERO AT-SPI actions (confirmed with an instrumented `try_action` that
+/// enumerated 0 actions on it, while the same probe found "click" on the Save button) —
+/// consistent with the pre-existing comment on `set_toggle` ("a GTK4 GtkCheckButton
+/// exposes none"). A test asserting `ClickMethod::NativeAction` against that widget
+/// would never pass on real GTK4, so it targets the Switch instead: same fixture, same
+/// production code path (`click_element` -> `try_native_invoke` -> `Accessibility::invoke`),
+/// a widget already proven (via `set_value_toggles_switch`, same target) to expose a
+/// real AT-SPI action.
+#[test]
+#[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
+fn click_element_native_invokes_gtk_switch() {
+    let mut glass = launch_fixture();
+    let tree = glass.a11y_snapshot(None).expect("snapshot");
+    let switch = find_node(&tree.root, "Active").expect("switch");
+    assert!(!switch.states.checked, "fixture starts unchecked");
+    let method = glass.click_element(switch.id).expect("click");
+    assert_eq!(
+        method,
+        glass_core::ClickMethod::NativeAction,
+        "a GTK Switch exposes an activation action; the native path must take it"
+    );
+    // The toolkit applies the action on its next main-loop pass — poll briefly.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    loop {
+        let t = glass.a11y_snapshot(None).expect("re-snapshot");
+        if find_node(&t.root, "Active").is_some_and(|n| n.states.checked) {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "native action never toggled the Switch"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    glass.stop().expect("stop");
+}
+
 #[test]
 #[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
 fn set_value_toggles_switch() {

--- a/crates/glass-a11y-macos/src/ffi.rs
+++ b/crates/glass-a11y-macos/src/ffi.rs
@@ -220,15 +220,23 @@ pub(crate) fn set_string_value(el: &AXUIElement, text: &str) -> Result<()> {
     Ok(())
 }
 
-/// The element's `AXActionNames` (`AXUIElementCopyActionNames`). Empty on ANY
-/// failure — callers treat "no actions" and "cannot read actions" identically
-/// (neither yields a native invoke), so the two outcomes may share a shape.
+/// The element's `AXActionNames` (`AXUIElementCopyActionNames`). Empty on any failure, or on
+/// an unexpected null result — callers treat "no actions" and "cannot read actions"
+/// identically (neither yields a native invoke), so the two outcomes may share a shape. A
+/// failed read still logs to stderr, so the difference is diagnosable rather than silent.
 pub(crate) fn action_names(el: &AXUIElement) -> Vec<String> {
     let mut raw: *const CFArray = std::ptr::null();
     // SAFETY: `el` is a live `AXUIElement`; `raw` is a valid local out-param slot matching
     // `AXUIElementCopyActionNames`'s documented signature (mirrors `copy_attribute_checked`).
     let err = unsafe { el.copy_action_names(NonNull::from(&mut raw)) };
     if err != AXError::Success {
+        // Dev-tool diagnostic (stderr only, same shape as the reader's): an element reported
+        // as exposing no action reads identically whether it truly has none or the read
+        // failed, and only this line tells the two apart after the fact.
+        eprintln!(
+            "glass-a11y-macos: AXActionNames read failed (AXError {})",
+            err.0
+        );
         return Vec::new();
     }
     let Some(nn) = NonNull::new(raw.cast_mut()) else {

--- a/crates/glass-a11y-macos/src/ffi.rs
+++ b/crates/glass-a11y-macos/src/ffi.rs
@@ -220,6 +220,46 @@ pub(crate) fn set_string_value(el: &AXUIElement, text: &str) -> Result<()> {
     Ok(())
 }
 
+/// The element's `AXActionNames` (`AXUIElementCopyActionNames`). Empty on ANY
+/// failure — callers treat "no actions" and "cannot read actions" identically
+/// (neither yields a native invoke), so the two outcomes may share a shape.
+pub(crate) fn action_names(el: &AXUIElement) -> Vec<String> {
+    let mut raw: *const CFArray = std::ptr::null();
+    // SAFETY: `el` is a live `AXUIElement`; `raw` is a valid local out-param slot matching
+    // `AXUIElementCopyActionNames`'s documented signature (mirrors `copy_attribute_checked`).
+    let err = unsafe { el.copy_action_names(NonNull::from(&mut raw)) };
+    if err != AXError::Success {
+        return Vec::new();
+    }
+    let Some(nn) = NonNull::new(raw.cast_mut()) else {
+        return Vec::new();
+    };
+    // SAFETY: `AXUIElementCopyActionNames` follows Core Foundation's Copy/Create ownership
+    // rule — an already-retained (+1) `CFArrayRef` on success — so `CFRetained::from_raw`
+    // takes ownership without an extra retain (mirrors `copy_attribute_checked`).
+    let arr: CFRetained<CFArray> = unsafe { CFRetained::from_raw(nn) };
+    // SAFETY: `AXActionNames` is documented by Apple to hold `CFStringRef`s; this only
+    // attaches compile-time element-type information (no runtime effect) — the same
+    // technique `array_of_elements` uses for `AXChildren`/`AXWindows`.
+    let typed: CFRetained<CFArray<CFString>> = unsafe { CFRetained::cast_unchecked(arr) };
+    typed.iter().map(|s| s.to_string()).collect()
+}
+
+/// Perform `name` on `el` (`AXUIElementPerformAction`). Any non-`Success`
+/// `AXError` is an `Err` carrying the code — the caller decides the element id
+/// context.
+pub(crate) fn perform_action(el: &AXUIElement, name: &str) -> std::result::Result<(), String> {
+    let action = CFString::from_str(name);
+    // SAFETY: `el` is a live `AXUIElement`; `action` is a valid `CFString` matching
+    // `AXUIElementPerformAction`'s documented contract (element + action name, no other
+    // preconditions) — the same call `axwindow::ax_raise` already makes for `AXRaise`.
+    let err = unsafe { el.perform_action(&action) };
+    if err != AXError::Success {
+        return Err(format!("{name} failed (AXError {})", err.0));
+    }
+    Ok(())
+}
+
 /// Read `el`'s `AXPosition` (top-left, in points — Quartz's top-left-origin global screen
 /// space, the same unit `AXSize` and `glass_core::coords` convert to/from pixels).
 pub(crate) fn ax_position(el: &AXUIElement) -> Result<(f64, f64)> {

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -150,6 +150,36 @@ impl Accessibility for MacosA11y {
             std::thread::sleep(Duration::from_millis(SET_VALUE_POLL_MS));
         }
     }
+
+    fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<()> {
+        let (window_el, scale) = resolve_window(ctx)?;
+
+        // Start at 0, same numbering rationale as `set_value`. Unlike `set_value` (whose
+        // miss is `AxElementNotFound` — the id itself is unknown), a miss here is
+        // `AxElementChanged`: it means the tree drifted since the id was captured (same
+        // classification the Linux/Windows readers' `invoke` use), which is also what the
+        // fingerprint mismatch just below reports.
+        let mut budget = WalkBudget::with_limits(ctx.limits);
+        let el = find_nth(window_el, 0, &mut budget, target.id.0)
+            .ok_or(GlassError::AxElementChanged(target.id.0))?;
+
+        // Same fingerprint gate as set_value: role + name + bounds.
+        let ax_role = ffi::attribute_string(&el, attr::ROLE).unwrap_or_default();
+        let role = mapping::map_role(&ax_role);
+        let name = ffi::attribute_string(&el, attr::TITLE)
+            .or_else(|| ffi::attribute_string(&el, attr::DESCRIPTION));
+        let bounds = window_relative_rect(&el, scale, &ctx.window);
+        if !target.matches(role, name.as_deref())
+            || !target.bounds_consistent(bounds, SET_VALUE_BOUNDS_TOL)
+        {
+            return Err(GlassError::AxElementChanged(target.id.0));
+        }
+
+        if !ffi::action_names(&el).iter().any(|a| a == "AXPress") {
+            return Err(GlassError::AxActionUnavailable(target.id.0));
+        }
+        ffi::perform_action(&el, "AXPress").map_err(|e| GlassError::AxActionFailed(target.id.0, e))
+    }
 }
 
 /// Resolve the `AXWindow` + point→pixel `scale` for `ctx`: the grant gate, pid, app element,

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -178,6 +178,10 @@ impl Accessibility for MacosA11y {
         if !ffi::action_names(&el).iter().any(|a| a == "AXPress") {
             return Err(GlassError::AxActionUnavailable(target.id.0));
         }
+        // No post-actuation verify here (unlike the Linux/Windows toggle rungs): AXPress is a
+        // generic press with no universal post-state to read back — a checkbox's AXValue, a
+        // button's nothing, a menu item's opened menu — so there is nothing to confirm against.
+        // Accepted parity gap: a control that accepts AXPress without acting reports success.
         ffi::perform_action(&el, "AXPress").map_err(|e| GlassError::AxActionFailed(target.id.0, e))
     }
 }

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -11,8 +11,8 @@ use glass_core::{
     TruncationLimit, WalkBudget,
 };
 use uiautomation::patterns::{
-    UIExpandCollapsePattern, UIRangeValuePattern, UISelectionItemPattern, UITogglePattern,
-    UIValuePattern,
+    UIExpandCollapsePattern, UIInvokePattern, UIRangeValuePattern, UISelectionItemPattern,
+    UITogglePattern, UIValuePattern,
 };
 use uiautomation::types::{ExpandCollapseState, Handle, Rect, ToggleState};
 use uiautomation::{UIAutomation, UIElement, UITreeWalker};
@@ -66,6 +66,21 @@ impl Accessibility for WindowsA11y {
             Ok(r) => r,
             Err(_) => Err(GlassError::AccessibilityUnavailable(
                 "accessibility set_value timed out (UIA not responding)".into(),
+            )),
+        }
+    }
+
+    fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<()> {
+        let ctx = ctx.clone();
+        let target = target.clone();
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(run_invoke(&ctx, &target));
+        });
+        match rx.recv_timeout(SNAPSHOT_TIMEOUT) {
+            Ok(r) => r,
+            Err(_) => Err(GlassError::AccessibilityUnavailable(
+                "accessibility invoke timed out (UIA not responding)".into(),
             )),
         }
     }
@@ -304,6 +319,57 @@ fn run_set_value(ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
         }
         std::thread::sleep(Duration::from_millis(20));
     }
+}
+
+/// Actuate `target` via the first UIA action pattern its control publishes. Walks pre-order to
+/// `target.id` and verifies the same role+name+bounds fingerprint as `run_set_value` (guards a
+/// stale id / tree drift) before touching any pattern.
+///
+/// Ladder order mirrors how a real client picks a control's actuation verb, most-specific first:
+/// Invoke (buttons, menu items — "press this") -> Toggle (checkboxes/switches, which don't
+/// implement Invoke) -> SelectionItem (list/tab/tree rows — "select", not "press") ->
+/// ExpandCollapse (tree/combo expanders — flip between the two states rather than invoke). The
+/// first pattern the control exposes wins; a control that publishes none of the four is
+/// `AxActionUnavailable` (the reader itself is fine — this element just offers no actuation verb),
+/// which `click_element` (glass-core) treats as a fall-back-to-pointer signal, not a fatal error.
+fn run_invoke(ctx: &AxContext, target: &AxTarget) -> Result<()> {
+    let automation = UIAutomation::new().map_err(|e| {
+        GlassError::AccessibilityUnavailable(format!("UI Automation unavailable: {e}"))
+    })?;
+    let walker = automation.get_control_view_walker().map_err(uia_err)?;
+    let window = find_app_window(&automation, ctx)?;
+
+    // Start at 0 so find_nth's pre-order numbering matches snapshot's walk + assign_ids, same as
+    // run_set_value.
+    let mut budget = WalkBudget::with_limits(ctx.limits);
+    let el = find_nth(&walker, &window, 0, &mut budget, target.id.0)
+        .ok_or(GlassError::AxElementChanged(target.id.0))?;
+
+    // Same fingerprint gate as run_set_value: role + name + bounds.
+    let role = crate::mapping::map_role(el.get_control_type().map_err(uia_err)? as i32 as u32);
+    let name = nonempty(el.get_name().unwrap_or_default());
+    let bounds = window_relative_bounds(&el, (ctx.window.x, ctx.window.y));
+    if !target.matches(role, name.as_deref())
+        || !target.bounds_consistent(bounds, SET_VALUE_BOUNDS_TOL)
+    {
+        return Err(GlassError::AxElementChanged(target.id.0));
+    }
+
+    let fail = |e: uiautomation::Error| GlassError::AxActionFailed(target.id.0, e.to_string());
+    if let Ok(p) = el.get_pattern::<UIInvokePattern>() {
+        return p.invoke().map_err(fail);
+    }
+    if let Ok(p) = el.get_pattern::<UITogglePattern>() {
+        return p.toggle().map_err(fail);
+    }
+    if let Ok(p) = el.get_pattern::<UISelectionItemPattern>() {
+        return p.select().map_err(fail);
+    }
+    if let Ok(p) = el.get_pattern::<UIExpandCollapsePattern>() {
+        let expanded = p.get_state().map_err(fail)? == ExpandCollapseState::Expanded;
+        return if expanded { p.collapse() } else { p.expand() }.map_err(fail);
+    }
+    Err(GlassError::AxActionUnavailable(target.id.0))
 }
 
 /// Whether this node's children may be explored, recording the bound that stopped the walk

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -343,6 +343,14 @@ fn run_set_value(ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
 ///
 /// Only the Toggle rung has a post-state a client can read back, so only it verifies actuation;
 /// the other three are fire-and-report, exactly as their patterns define.
+///
+/// Known limitation, deliberate: `get_pattern` returning `Err` is indistinguishable here between
+/// "this control does not implement the pattern" and "the COM call itself failed", so both land
+/// on `AxActionUnavailable` and fall back to a pointer click. That is the safe direction —
+/// `get_pattern` dispatches no action, so the fallback actuates exactly once. UIA does publish
+/// `Is<Pattern>Available` properties that could tell the two apart, but acting on them would turn
+/// a disagreement between property and `get_pattern` into a hard, non-falling-back click failure
+/// (an error after dispatch never falls back), trading a harmless pointer click for a dead one.
 fn run_invoke(ctx: &AxContext, target: &AxTarget) -> Result<()> {
     let automation = UIAutomation::new().map_err(|e| {
         GlassError::AccessibilityUnavailable(format!("UI Automation unavailable: {e}"))

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -25,8 +25,11 @@ const SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(10);
 /// the id sits far enough away to be rejected. Generous to avoid false-rejects.
 const SET_VALUE_BOUNDS_TOL: i64 = 12;
 /// How long `run_set_value` polls the read-back for the value to change before declaring the
-/// write a no-op. A real numeric set lands within a frame or two; well under the 10s outer cap.
+/// write a no-op — also the bound `run_invoke`'s Toggle rung gives the state to flip. A real
+/// numeric set lands within a frame or two; well under the 10s outer cap.
 const SET_VALUE_VERIFY_MS: u64 = 800;
+/// Interval between read-backs while waiting for a write / toggle to land.
+const VERIFY_POLL_MS: u64 = 20;
 
 #[derive(Default)]
 pub struct WindowsA11y;
@@ -322,7 +325,7 @@ fn run_set_value(ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
         if Instant::now() >= deadline {
             return Err(GlassError::AxValueNotApplied(target.id.0));
         }
-        std::thread::sleep(Duration::from_millis(20));
+        std::thread::sleep(Duration::from_millis(VERIFY_POLL_MS));
     }
 }
 
@@ -337,6 +340,9 @@ fn run_set_value(ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
 /// first pattern the control exposes wins; a control that publishes none of the four is
 /// `AxActionUnavailable` (the reader itself is fine — this element just offers no actuation verb),
 /// which `click_element` (glass-core) treats as a fall-back-to-pointer signal, not a fatal error.
+///
+/// Only the Toggle rung has a post-state a client can read back, so only it verifies actuation;
+/// the other three are fire-and-report, exactly as their patterns define.
 fn run_invoke(ctx: &AxContext, target: &AxTarget) -> Result<()> {
     let automation = UIAutomation::new().map_err(|e| {
         GlassError::AccessibilityUnavailable(format!("UI Automation unavailable: {e}"))
@@ -365,7 +371,27 @@ fn run_invoke(ctx: &AxContext, target: &AxTarget) -> Result<()> {
         return p.invoke().map_err(fail);
     }
     if let Ok(p) = el.get_pattern::<UITogglePattern>() {
-        return p.toggle().map_err(fail);
+        // Toggle is the one rung with a readable post-state, so don't take the ack as proof:
+        // a provider that accepts `Toggle()` without applying it would otherwise report a
+        // successful click on a control that never moved. Read before, fire, then poll until
+        // the state differs — same cadence as `run_set_value`'s write verify.
+        let before = p.get_toggle_state().map_err(fail)?;
+        p.toggle().map_err(fail)?;
+        let deadline = Instant::now() + Duration::from_millis(SET_VALUE_VERIFY_MS);
+        loop {
+            if p.get_toggle_state().map_err(fail)? != before {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                // `AxActionFailed`, not `AxActionUnavailable`: the toggle WAS dispatched, so
+                // this must not fall back to a pointer click that could actuate it twice.
+                return Err(GlassError::AxActionFailed(
+                    target.id.0,
+                    "the toggle action was acknowledged but the state did not change".into(),
+                ));
+            }
+            std::thread::sleep(Duration::from_millis(VERIFY_POLL_MS));
+        }
     }
     if let Ok(p) = el.get_pattern::<UISelectionItemPattern>() {
         return p.select().map_err(fail);

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -342,7 +342,9 @@ fn run_set_value(ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
 /// which `click_element` (glass-core) treats as a fall-back-to-pointer signal, not a fatal error.
 ///
 /// Only the Toggle rung has a post-state a client can read back, so only it verifies actuation;
-/// the other three are fire-and-report, exactly as their patterns define.
+/// the other three are fire-and-report, exactly as their patterns define. That rung is also the
+/// one exception to "first pattern wins": if its state can't be read it is skipped rather than
+/// failed, since it cannot be verified and nothing has been dispatched yet.
 ///
 /// Known limitation, deliberate: `get_pattern` returning `Err` is indistinguishable here between
 /// "this control does not implement the pattern" and "the COM call itself failed", so both land
@@ -383,22 +385,31 @@ fn run_invoke(ctx: &AxContext, target: &AxTarget) -> Result<()> {
         // a provider that accepts `Toggle()` without applying it would otherwise report a
         // successful click on a control that never moved. Read before, fire, then poll until
         // the state differs — same cadence as `run_set_value`'s write verify.
-        let before = p.get_toggle_state().map_err(fail)?;
-        p.toggle().map_err(fail)?;
-        let deadline = Instant::now() + Duration::from_millis(SET_VALUE_VERIFY_MS);
-        loop {
-            if p.get_toggle_state().map_err(fail)? != before {
-                return Ok(());
+        //
+        // A pattern whose state can't even be READ can't be verify-toggled, so this rung is
+        // unusable — fall through to the rest of the ladder instead of reporting a failure.
+        // Nothing has been dispatched at this point, so falling through is safe: the worst
+        // outcome is `AxActionUnavailable` and a single pointer click, whereas an error here
+        // would propagate (an error after dispatch never falls back) and kill the click.
+        if let Ok(before) = p.get_toggle_state() {
+            p.toggle().map_err(fail)?;
+            let deadline = Instant::now() + Duration::from_millis(SET_VALUE_VERIFY_MS);
+            loop {
+                // Past the dispatch, a failed read IS a failure: `fail` (AxActionFailed) is
+                // right here, because the toggle may have landed and must not be re-actuated.
+                if p.get_toggle_state().map_err(fail)? != before {
+                    return Ok(());
+                }
+                if Instant::now() >= deadline {
+                    // `AxActionFailed`, not `AxActionUnavailable`: the toggle WAS dispatched,
+                    // so this must not fall back to a pointer click that could actuate twice.
+                    return Err(GlassError::AxActionFailed(
+                        target.id.0,
+                        "the toggle action was acknowledged but the state did not change".into(),
+                    ));
+                }
+                std::thread::sleep(Duration::from_millis(VERIFY_POLL_MS));
             }
-            if Instant::now() >= deadline {
-                // `AxActionFailed`, not `AxActionUnavailable`: the toggle WAS dispatched, so
-                // this must not fall back to a pointer click that could actuate it twice.
-                return Err(GlassError::AxActionFailed(
-                    target.id.0,
-                    "the toggle action was acknowledged but the state did not change".into(),
-                ));
-            }
-            std::thread::sleep(Duration::from_millis(VERIFY_POLL_MS));
         }
     }
     if let Ok(p) = el.get_pattern::<UISelectionItemPattern>() {

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -79,8 +79,13 @@ impl Accessibility for WindowsA11y {
         });
         match rx.recv_timeout(SNAPSHOT_TIMEOUT) {
             Ok(r) => r,
+            // The worker thread outlives this timeout, so the pattern call may already have
+            // been dispatched — say so. This error is NOT fallback-eligible (see
+            // `GlassError::invoke_fallback_eligible`), so no pointer click is layered on top.
             Err(_) => Err(GlassError::AccessibilityUnavailable(
-                "accessibility invoke timed out (UIA not responding)".into(),
+                "accessibility invoke timed out (UIA not responding); the action may still \
+                 land — re-snapshot before retrying"
+                    .into(),
             )),
         }
     }

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -625,6 +625,46 @@ pub trait Accessibility {
     fn set_value(&mut self, _ctx: &AxContext, _target: &AxTarget, _text: &str) -> Result<()> {
         Err(crate::error::GlassError::AxUnsupported)
     }
+
+    /// Actuate the element identified by `target` via the platform's native
+    /// accessibility action (the OS-level "press this control" verb). The
+    /// backend re-walks pre-order to `target.id`, verifies the fingerprint
+    /// (role+name, and bounds where its `set_value` does), then fires the
+    /// action. `AxElementChanged` on fingerprint mismatch — the caller treats
+    /// that as fatal, never as a fall-back-to-pointer signal, because a
+    /// drifted tree would mis-click by stale coordinates too.
+    /// Default: unsupported.
+    fn invoke(&mut self, _ctx: &AxContext, _target: &AxTarget) -> Result<()> {
+        Err(crate::error::GlassError::AxUnsupported)
+    }
+}
+
+/// How `click_element` actuated the target.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ClickMethod {
+    /// The platform's native accessibility action fired; no pointer was synthesized.
+    NativeAction,
+    /// The synthetic pointer path ran; `native_fallback` says why the native
+    /// action was not used (there is always a reason — invoke is attempted first).
+    Pointer { native_fallback: String },
+}
+
+impl ClickMethod {
+    /// Stable label for result payloads and the audit log.
+    pub fn label(&self) -> &'static str {
+        match self {
+            ClickMethod::NativeAction => "native-action",
+            ClickMethod::Pointer { .. } => "pointer",
+        }
+    }
+
+    /// The fallback reason, when the pointer path ran.
+    pub fn native_fallback(&self) -> Option<&str> {
+        match self {
+            ClickMethod::NativeAction => None,
+            ClickMethod::Pointer { native_fallback } => Some(native_fallback),
+        }
+    }
 }
 
 /// A precise wait condition over an accessibility element. State variants assert
@@ -1641,5 +1681,48 @@ mod tests {
     #[test]
     fn new_builds_a_complete_tree() {
         assert_eq!(AxTree::new(leaf(AxRole::Window, "App")).truncated, None);
+    }
+
+    #[test]
+    fn invoke_default_is_unsupported() {
+        struct NoInvoke;
+        impl Accessibility for NoInvoke {
+            fn snapshot(&mut self, _ctx: &AxContext) -> Result<AxTree> {
+                unreachable!("not exercised")
+            }
+        }
+        let ctx = AxContext {
+            pids: vec![],
+            window: crate::platform::WindowGeometry {
+                x: 0,
+                y: 0,
+                width: 640,
+                height: 480,
+            },
+            window_handle: None,
+            a11y_bus_addr: None,
+            limits: WalkLimits::DEFAULT,
+        };
+        let target = AxTarget {
+            id: AxNodeId(1),
+            role: AxRole::Button,
+            name: None,
+            bounds: None,
+        };
+        assert!(matches!(
+            NoInvoke.invoke(&ctx, &target),
+            Err(crate::error::GlassError::AxUnsupported)
+        ));
+    }
+
+    #[test]
+    fn click_method_labels_and_fallback_access() {
+        assert_eq!(ClickMethod::NativeAction.label(), "native-action");
+        assert_eq!(ClickMethod::NativeAction.native_fallback(), None);
+        let p = ClickMethod::Pointer {
+            native_fallback: "reason".into(),
+        };
+        assert_eq!(p.label(), "pointer");
+        assert_eq!(p.native_fallback(), Some("reason"));
     }
 }

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -630,9 +630,21 @@ pub trait Accessibility {
     /// accessibility action (the OS-level "press this control" verb). The
     /// backend re-walks pre-order to `target.id`, verifies the fingerprint
     /// (role+name, and bounds where its `set_value` does), then fires the
-    /// action. `AxElementChanged` on fingerprint mismatch — the caller treats
-    /// that as fatal, never as a fall-back-to-pointer signal, because a
-    /// drifted tree would mis-click by stale coordinates too.
+    /// action.
+    ///
+    /// **Error contract.** The caller falls back to a synthetic pointer click for
+    /// exactly two outcomes, both meaning *nothing was dispatched*:
+    /// [`crate::GlassError::AxUnsupported`] (this backend has no invoke) and
+    /// [`crate::GlassError::AxActionUnavailable`] (the element exposes no activation
+    /// action). Every other error propagates to the agent. So an implementation MUST
+    /// report anything that may have dispatched — an action the toolkit ran but
+    /// reported failed, a transport error whose answer was lost, a timeout — as
+    /// `AxActionFailed`/`AccessibilityUnavailable`, and MUST NOT flatten such a case
+    /// into `AxActionUnavailable`: a pointer click layered on top of a native action
+    /// that still lands actuates the control twice. `AxElementChanged` (fingerprint
+    /// mismatch) likewise propagates — a drifted tree would mis-click by stale
+    /// coordinates too.
+    ///
     /// Default: unsupported.
     fn invoke(&mut self, _ctx: &AxContext, _target: &AxTarget) -> Result<()> {
         Err(crate::error::GlassError::AxUnsupported)

--- a/crates/glass-core/src/audit.rs
+++ b/crates/glass-core/src/audit.rs
@@ -5,6 +5,7 @@
 
 use std::time::Duration;
 
+use crate::accessibility::ClickMethod;
 use crate::error::Result;
 use crate::platform::{AppSpec, KeyEvent, PointerEvent, WindowOp};
 
@@ -75,9 +76,10 @@ pub enum Actuation<'a> {
     },
     ClickElement {
         element: ElementRef,
-        /// `ClickMethod::label()` of the path that actuated; `None` when the
-        /// click errored before either path completed.
-        method: Option<&'static str>,
+        /// How the click actuated — the sink renders its label and, for the pointer
+        /// path, the reason the native action was not used. `None` when the click
+        /// ultimately failed (neither path succeeded).
+        method: Option<&'a ClickMethod>,
     },
     SetValue {
         element: ElementRef,
@@ -124,16 +126,22 @@ mod tests {
             role: Some("Button".into()),
             name: Some("Save".into()),
         };
+        let method = ClickMethod::Pointer {
+            native_fallback: "element exposes no activation action".into(),
+        };
         let act = Actuation::ClickElement {
             element,
-            method: Some("native-action"),
+            method: Some(&method),
         };
-        assert!(matches!(
-            act,
-            Actuation::ClickElement {
-                method: Some("native-action"),
-                ..
-            }
-        ));
+        let Actuation::ClickElement { method: got, .. } = act else {
+            panic!("wrong variant");
+        };
+        // The sink renders both halves; borrowing the whole method (not a pre-rendered
+        // label) is what keeps the fallback reason reachable.
+        assert_eq!(got.map(ClickMethod::label), Some(method.label()));
+        assert_eq!(
+            got.and_then(ClickMethod::native_fallback),
+            Some("element exposes no activation action")
+        );
     }
 }

--- a/crates/glass-core/src/audit.rs
+++ b/crates/glass-core/src/audit.rs
@@ -56,14 +56,33 @@ impl AuditOutcome {
 /// event so the sink can format without `glass-core` depending on serde/JSON.
 #[derive(Debug)]
 pub enum Actuation<'a> {
-    Launch { spec: &'a AppSpec, backend: &'a str },
+    Launch {
+        spec: &'a AppSpec,
+        backend: &'a str,
+    },
     Stop,
-    Pointer { event: &'a PointerEvent },
-    Key { event: &'a KeyEvent },
-    ClipboardSet { text: &'a str },
-    Window { op: &'a WindowOp },
-    ClickElement { element: ElementRef },
-    SetValue { element: ElementRef, text: &'a str },
+    Pointer {
+        event: &'a PointerEvent,
+    },
+    Key {
+        event: &'a KeyEvent,
+    },
+    ClipboardSet {
+        text: &'a str,
+    },
+    Window {
+        op: &'a WindowOp,
+    },
+    ClickElement {
+        element: ElementRef,
+        /// `ClickMethod::label()` of the path that actuated; `None` when the
+        /// click errored before either path completed.
+        method: Option<&'static str>,
+    },
+    SetValue {
+        element: ElementRef,
+        text: &'a str,
+    },
 }
 
 /// Receives every actuation. Implemented in `glass-mcp` (`JsonlSink`). `Send` so it
@@ -96,5 +115,25 @@ mod tests {
         let e = AuditOutcome::from_result(&err);
         assert!(!e.ok);
         assert!(e.error.unwrap().to_lowercase().contains("session"));
+    }
+
+    #[test]
+    fn click_element_actuation_carries_the_actuating_method() {
+        let element = ElementRef {
+            id: 1,
+            role: Some("Button".into()),
+            name: Some("Save".into()),
+        };
+        let act = Actuation::ClickElement {
+            element,
+            method: Some("native-action"),
+        };
+        assert!(matches!(
+            act,
+            Actuation::ClickElement {
+                method: Some("native-action"),
+                ..
+            }
+        ));
     }
 }

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -94,6 +94,12 @@ pub enum GlassError {
     #[error("set_value on element #{0} reported success but the value did not change (read-only a11y projection — use keystrokes)")]
     AxValueNotApplied(u32),
 
+    #[error("element #{0} exposes no native activation action")]
+    AxActionUnavailable(u32),
+
+    #[error("native action on element #{0} failed: {1}")]
+    AxActionFailed(u32, String),
+
     #[error("set_value on element #{0} is a switch/checkbox and expects a boolean — one of true/false, on/off, 1/0, yes/no (got {1:?})")]
     AxValueNotBoolean(u32, String),
 
@@ -230,6 +236,18 @@ mod tests {
         assert_eq!(
             GlassError::AxElementInUnmappedPopover(9).to_string(),
             "element #9 is inside a popover glass could not map to a window; select_window it and click by coordinate"
+        );
+    }
+
+    #[test]
+    fn ax_action_errors_name_the_element_and_cause() {
+        assert_eq!(
+            GlassError::AxActionUnavailable(7).to_string(),
+            "element #7 exposes no native activation action"
+        );
+        assert_eq!(
+            GlassError::AxActionFailed(7, "action reported failure".into()).to_string(),
+            "native action on element #7 failed: action reported failure"
         );
     }
 

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -131,6 +131,24 @@ pub enum GlassError {
 }
 
 impl GlassError {
+    /// Whether a failed native-invoke attempt may safely fall back to the synthetic
+    /// pointer path. True only for outcomes where **no native action was dispatched**:
+    /// the backend has no invoke at all ([`GlassError::AxUnsupported`]), or the element
+    /// exposes no activation action ([`GlassError::AxActionUnavailable`]).
+    ///
+    /// Everything else fails CLOSED. A failure *after* dispatch — or an ambiguous
+    /// transport/timeout error, which cannot be distinguished from one — must propagate,
+    /// because a pointer click on top of a native action that may still land actuates the
+    /// control twice (submitting a form twice, sending a message twice). The wildcard arm
+    /// is deliberate: a new error variant is treated as "may have dispatched" until it is
+    /// proven otherwise.
+    pub fn invoke_fallback_eligible(&self) -> bool {
+        matches!(
+            self,
+            GlassError::AxUnsupported | GlassError::AxActionUnavailable(_)
+        )
+    }
+
     /// Runtime "this operation is unsupported on the active backend" error, worded
     /// consistently.
     ///
@@ -249,6 +267,32 @@ mod tests {
             GlassError::AxActionFailed(7, "action reported failure".into()).to_string(),
             "native action on element #7 failed: action reported failure"
         );
+    }
+
+    #[test]
+    fn invoke_fallback_is_eligible_only_when_nothing_was_dispatched() {
+        // Eligible: the backend never dispatched an action, so a pointer click actuates once.
+        for e in [
+            GlassError::AxUnsupported,
+            GlassError::AxActionUnavailable(3),
+        ] {
+            assert!(e.invoke_fallback_eligible(), "{e}");
+        }
+        // Everything else fails CLOSED — including the two that may mean "dispatched, outcome
+        // unknown" (`AxActionFailed`, `AccessibilityUnavailable`, which carries the invoke
+        // timeout), the drift/pre-check errors, and any variant not named at all (the wildcard).
+        for e in [
+            GlassError::AxActionFailed(3, "boom".into()),
+            GlassError::AccessibilityUnavailable("invoke timed out".into()),
+            GlassError::AxElementChanged(3),
+            GlassError::NoAxSnapshot,
+            GlassError::AxElementNotFound(3),
+            GlassError::NoActiveSession,
+            GlassError::Timeout(10),
+            GlassError::Backend("bus died".into()),
+        ] {
+            assert!(!e.invoke_fallback_eligible(), "{e}");
+        }
     }
 
     #[test]

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -70,8 +70,8 @@ pub use platform::{
 pub mod accessibility;
 pub use accessibility::{
     element_match, Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget,
-    AxTree, ElementCondition, ElementInfo, ElementMatch, Truncation, TruncationLimit, WalkBudget,
-    WalkLimits, MAX_DEPTH, MAX_NODES, MAX_SIBLINGS,
+    AxTree, ClickMethod, ElementCondition, ElementInfo, ElementMatch, Truncation, TruncationLimit,
+    WalkBudget, WalkLimits, MAX_DEPTH, MAX_NODES, MAX_SIBLINGS,
 };
 
 pub mod marks;

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -103,10 +103,14 @@ impl Glass {
         self.audited_click(id, Self::click_element_inner)
     }
 
-    /// Run one element click and record it through the audit seam. Every path that actuates
-    /// an element by id goes through here — the native-first [`Glass::click_element`] and the
-    /// deliberately pointer-only combo open alike — so the log can't miss an actuation just
-    /// because an internal caller took a different route to it.
+    /// Run one element click and record it through the audit seam. Both clicks that stand on
+    /// their own go through here — the native-first [`Glass::click_element`] and the
+    /// deliberately pointer-only combo open — so the log can't miss one just because an
+    /// internal caller took a different route to the same actuation.
+    ///
+    /// The exception is `set_value_inner`'s trailing-toggle branch, which calls
+    /// `click_element_inner` directly: there the click is one step *inside* a `set_value`, and
+    /// the enclosing `SetValue` record already accounts for it.
     fn audited_click(
         &mut self,
         id: AxNodeId,
@@ -312,13 +316,28 @@ impl Glass {
     }
 
     fn set_value_inner(&mut self, id: AxNodeId, text: &str) -> Result<()> {
-        let (target, ctx) = {
-            let s = self.require_active()?;
+        {
+            let s = self.active_mut()?;
             // Check for reader availability before consulting the snapshot, so that
-            // `AxUnsupported` takes precedence when there is no accessibility backend.
+            // `AxUnsupported` takes precedence when there is no accessibility backend — and so
+            // a reader-less backend skips the geometry round-trip below.
             if s.accessibility.is_none() {
                 return Err(GlassError::AxUnsupported);
             }
+            // Re-read the window geometry, as `a11y_snapshot` and `try_native_invoke` do: the
+            // Windows/macOS `set_value` fingerprints the element by window-RELATIVE bounds
+            // derived from `ctx.window`, so a window moved since the snapshot would make every
+            // element look displaced and reject the write as drift.
+            //
+            // Best-effort, unlike the snapshot's strict refresh: a write must not fail because
+            // a geometry probe hiccuped, so an `Err` keeps the cached value and carries on —
+            // worst case the backend's own fingerprint check rejects, exactly as before.
+            if let Ok(window) = s.platform.window(&WindowOp::Geometry) {
+                s.geometry = window;
+            }
+        }
+        let (target, ctx) = {
+            let s = self.require_active()?;
             let tree = s.last_ax.as_ref().ok_or(GlassError::NoAxSnapshot)?;
             let node = tree.find(id).ok_or(GlassError::AxElementNotFound(id.0))?;
             let target = AxTarget {
@@ -2017,6 +2036,43 @@ mod tests {
             g.set_value(AxNodeId(0), "x").unwrap_err(),
             GlassError::AxUnsupported
         ));
+    }
+
+    #[test]
+    fn set_value_refreshes_geometry_so_the_backend_sees_the_current_window() {
+        // The mirror of `click_element_refreshes_geometry_so_the_native_invoke_sees_the_current_window`:
+        // `set_value` fingerprints the element the same way `invoke` does (Windows/macOS compare
+        // window-RELATIVE bounds derived from `ctx.window`), so a window moved since the snapshot
+        // would make every element look displaced and reject the write as drift.
+        let snapshot_geo = WindowGeometry {
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 100,
+        };
+        let moved_geo = WindowGeometry {
+            x: 640,
+            y: 480,
+            width: 100,
+            height: 100,
+        };
+        let platform = FakePlatform::new(100, 100)
+            .resized_to(snapshot_geo)
+            .resized_to(moved_geo.clone());
+        // The invoke knob is irrelevant here (set_value never invokes); this builder is just the
+        // one that hands back the ctx log.
+        let (mut g, _, ctx_log) =
+            glass_with_a11y_invoke_ctx(platform, fake_tree(), InvokeBehavior::Unsupported);
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot(None).unwrap(); // consumes the first scripted geometry read
+
+        g.set_value(AxNodeId(1), "hello").unwrap(); // fake_tree: #1 is Button "Save"
+
+        assert_eq!(
+            ctx_log.lock().unwrap().as_ref().map(|c| c.window.clone()),
+            Some(moved_geo),
+            "set_value's ctx carries the refreshed window, not the snapshot's stale one"
+        );
     }
 
     #[test]

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -244,11 +244,30 @@ impl Glass {
     /// One native-invoke attempt: same fingerprint + context assembly as
     /// `set_value_inner`, then the backend's `invoke`.
     fn try_native_invoke(&mut self, id: AxNodeId) -> Result<()> {
-        let (target, ctx) = {
-            let s = self.require_active()?;
+        {
+            let s = self.active_mut()?;
+            // Reader-presence check up front (mirrors `snapshot_at_current_limits`) so
+            // `AxUnsupported` keeps precedence over — and a reader-less backend skips — the
+            // geometry round-trip below.
             if s.accessibility.is_none() {
                 return Err(GlassError::AxUnsupported);
             }
+            // Re-read the window geometry, as `a11y_snapshot` does: the Windows/macOS `invoke`
+            // fingerprints the element by window-RELATIVE bounds derived from `ctx.window`, so
+            // a window the user moved since the snapshot would make every element look
+            // displaced and reject the invoke as drift. Storing it back also keeps the pointer
+            // fallback clamping against the same window.
+            //
+            // Best-effort, unlike the snapshot's strict refresh: a click must not become
+            // unclickable because a geometry probe hiccuped, so an `Err` keeps the cached
+            // value and carries on — worst case the fingerprint check below rejects, exactly
+            // as it did before this refresh existed.
+            if let Ok(window) = s.platform.window(&WindowOp::Geometry) {
+                s.geometry = window;
+            }
+        }
+        let (target, ctx) = {
+            let s = self.require_active()?;
             let tree = s.last_ax.as_ref().ok_or(GlassError::NoAxSnapshot)?;
             let node = tree.find(id).ok_or(GlassError::AxElementNotFound(id.0))?;
             let target = AxTarget {
@@ -1105,6 +1124,47 @@ mod tests {
     }
 
     #[test]
+    fn click_element_refreshes_geometry_so_the_native_invoke_sees_the_current_window() {
+        // The Windows/macOS `invoke` fingerprints the element by window-RELATIVE bounds,
+        // derived from `ctx.window`. If the window moved since the snapshot and the click
+        // handed the backend the stale origin, every element would look displaced and the
+        // invoke would be rejected as drift. The snapshot refreshes geometry, so the invoke
+        // path must too: script the geometry read to report a moved window after the
+        // snapshot's own read, and prove the ctx the backend received carries the new origin.
+        let snapshot_geo = WindowGeometry {
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 100,
+        };
+        let moved_geo = WindowGeometry {
+            x: 640,
+            y: 480,
+            width: 100,
+            height: 100,
+        };
+        let platform = FakePlatform::new(100, 100)
+            .resized_to(snapshot_geo)
+            .resized_to(moved_geo.clone());
+        let (mut g, invoke_log, ctx_log) =
+            glass_with_a11y_invoke_ctx(platform, fake_tree(), InvokeBehavior::Succeed);
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot(None).unwrap(); // consumes the first scripted geometry read
+
+        assert_eq!(
+            g.click_element(AxNodeId(1)).unwrap(),
+            ClickMethod::NativeAction
+        );
+
+        assert_eq!(invoke_log.lock().unwrap().len(), 1, "the native path ran");
+        assert_eq!(
+            ctx_log.lock().unwrap().as_ref().map(|c| c.window.clone()),
+            Some(moved_geo),
+            "invoke's ctx carries the refreshed window, not the snapshot's stale one"
+        );
+    }
+
+    #[test]
     fn click_element_without_snapshot_errors() {
         let mut g = glass_with_a11y(FakePlatform::new(100, 100), fake_tree());
         g.start(&spec()).unwrap();
@@ -1878,7 +1938,7 @@ mod tests {
                 tree: fake_tree(),
                 set_log: log2,
                 set_fail: false,
-                limits_log: Arc::new(Mutex::new(None)),
+                ctx_log: Arc::new(Mutex::new(None)),
                 invoke_behavior: InvokeBehavior::Unsupported,
                 invoke_log: Arc::new(Mutex::new(Vec::new())),
             })),
@@ -1913,7 +1973,7 @@ mod tests {
     #[test]
     fn a11y_snapshot_threads_max_nodes_into_ctx_limits_and_set_value_reuses_them() {
         // Same mock harness as `set_value_passes_target_and_text_to_backend`, but this
-        // time inspecting `limits_log` — the `AxContext.limits` the backend actually
+        // time inspecting `ctx_log` — the `AxContext.limits` the backend actually
         // received — to prove `max_nodes` reaches the ctx, and that `set_value` reuses
         // whatever the last `a11y_snapshot` recorded rather than falling back to the
         // default cap. Real backends still ignore `limits` in this task (they build
@@ -1921,14 +1981,14 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().join("baselines");
         std::mem::forget(dir);
-        let limits_log = Arc::new(Mutex::new(None));
+        let ctx_log = Arc::new(Mutex::new(None));
         let mut held: Option<Backend> = Some(Backend {
             platform: Box::new(FakePlatform::new(100, 100)),
             accessibility: Some(Box::new(FakeAccessibility {
                 tree: fake_tree(),
                 set_log: Arc::new(Mutex::new(Vec::new())),
                 set_fail: false,
-                limits_log: limits_log.clone(),
+                ctx_log: ctx_log.clone(),
                 invoke_behavior: InvokeBehavior::Unsupported,
                 invoke_log: Arc::new(Mutex::new(Vec::new())),
             })),
@@ -1942,10 +2002,12 @@ mod tests {
 
         g.a11y_snapshot(Some(5000)).unwrap();
         assert_eq!(
-            limits_log
+            ctx_log
                 .lock()
                 .unwrap()
-                .expect("snapshot recorded ctx.limits")
+                .as_ref()
+                .expect("snapshot recorded its ctx")
+                .limits
                 .nodes,
             5000,
             "snapshot ctx carries the raised cap"
@@ -1953,10 +2015,12 @@ mod tests {
 
         g.set_value(AxNodeId(1), "x").unwrap(); // fake_tree: #1 is Button "Save"
         assert_eq!(
-            limits_log
+            ctx_log
                 .lock()
                 .unwrap()
-                .expect("set_value recorded ctx.limits")
+                .as_ref()
+                .expect("set_value recorded its ctx")
+                .limits
                 .nodes,
             5000,
             "set_value reuses the snapshot's limits"
@@ -1974,7 +2038,7 @@ mod tests {
                 tree: fake_tree(),
                 set_log: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
                 set_fail: true,
-                limits_log: Arc::new(Mutex::new(None)),
+                ctx_log: Arc::new(Mutex::new(None)),
                 invoke_behavior: InvokeBehavior::Unsupported,
                 invoke_log: Arc::new(Mutex::new(Vec::new())),
             })),
@@ -2239,7 +2303,7 @@ mod tests {
                 tree: fake_tree(), // #1 is a non-checkable Button "Save"
                 set_log: log2,
                 set_fail: false,
-                limits_log: Arc::new(Mutex::new(None)),
+                ctx_log: Arc::new(Mutex::new(None)),
                 invoke_behavior: InvokeBehavior::Unsupported,
                 invoke_log: Arc::new(Mutex::new(Vec::new())),
             })),
@@ -2289,7 +2353,7 @@ mod tests {
                 tree: sw(false), // #1 is the checkable switch "Sw"
                 set_log: log2,
                 set_fail: false,
-                limits_log: Arc::new(Mutex::new(None)),
+                ctx_log: Arc::new(Mutex::new(None)),
                 invoke_behavior: InvokeBehavior::Unsupported,
                 invoke_log: Arc::new(Mutex::new(Vec::new())),
             })),

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -87,10 +87,14 @@ impl Glass {
         Ok(crate::marks::render(&frame, &tree))
     }
 
-    /// Click the element with id `id` from the most recent `a11y_snapshot` via the normal
-    /// pointer path — the center of its bounds, or a swipe across the trailing control for a
-    /// row-shaped checkable on a trailing-toggle backend (see [`AxRect::trailing_toggle_swipe`]).
-    pub fn click_element(&mut self, id: AxNodeId) -> Result<()> {
+    /// Click the element with id `id` from the most recent `a11y_snapshot`. Tries the
+    /// platform's native accessibility action first (works for occluded/off-screen/boundless
+    /// elements, and on some backends never moves the pointer); when that's unavailable or
+    /// fails, falls back to the normal synthetic-pointer path — the center of the element's
+    /// bounds, or a swipe across the trailing control for a row-shaped checkable on a
+    /// trailing-toggle backend (see [`AxRect::trailing_toggle_swipe`]). The returned
+    /// [`ClickMethod`] says which path actually fired.
+    pub fn click_element(&mut self, id: AxNodeId) -> Result<ClickMethod> {
         let t = std::time::Instant::now();
         let element = self.element_ref(id);
         let result = self.click_element_inner(id);
@@ -102,7 +106,20 @@ impl Glass {
         result
     }
 
-    fn click_element_inner(&mut self, id: AxNodeId) -> Result<()> {
+    fn click_element_inner(&mut self, id: AxNodeId) -> Result<ClickMethod> {
+        // Native action first: works for occluded/off-screen/boundless elements and
+        // (on backends whose action API is out-of-band) doesn't move the cursor.
+        let native_fallback = match self.try_native_invoke(id) {
+            Ok(()) => return Ok(ClickMethod::NativeAction),
+            // Propagate-class: a drifted tree mis-clicks by stale bounds too, and the
+            // pre-checks (no snapshot / unknown id) fail the pointer path identically.
+            Err(
+                e @ (GlassError::AxElementChanged(_)
+                | GlassError::NoAxSnapshot
+                | GlassError::AxElementNotFound(_)),
+            ) => return Err(e),
+            Err(e) => native_fallback_reason(&e),
+        };
         let (bounds, checkable, trailing_toggle_backend, active_geo) = {
             let s = self.require_active()?;
             let tree = s.last_ax.as_ref().ok_or(GlassError::NoAxSnapshot)?;
@@ -152,7 +169,7 @@ impl Glass {
             if let Some(prev) = prev {
                 let _ = self.select_window(prev);
             }
-            return result;
+            return result.map(|()| ClickMethod::Pointer { native_fallback });
         }
         // A switch whose backend reports the whole row as its frame with the control at the
         // trailing edge (iOS/idb) is mis-tapped at the geometric center — that lands on the inert
@@ -179,6 +196,7 @@ impl Glass {
                 button: MouseButton::Left,
                 modifiers: vec![],
             })
+            .map(|()| ClickMethod::Pointer { native_fallback })
         } else {
             let (x, y) = bounds
                 .clamped_center(active_geo.width, active_geo.height)
@@ -190,7 +208,42 @@ impl Glass {
                 count: 1,
                 modifiers: vec![],
             })
+            .map(|()| ClickMethod::Pointer { native_fallback })
         }
+    }
+
+    /// One native-invoke attempt: same fingerprint + context assembly as
+    /// `set_value_inner`, then the backend's `invoke`.
+    fn try_native_invoke(&mut self, id: AxNodeId) -> Result<()> {
+        let (target, ctx) = {
+            let s = self.require_active()?;
+            if s.accessibility.is_none() {
+                return Err(GlassError::AxUnsupported);
+            }
+            let tree = s.last_ax.as_ref().ok_or(GlassError::NoAxSnapshot)?;
+            let node = tree.find(id).ok_or(GlassError::AxElementNotFound(id.0))?;
+            let target = AxTarget {
+                id,
+                role: node.role,
+                name: node.name.clone(),
+                bounds: node.bounds,
+            };
+            let ctx = AxContext {
+                pids: s.platform.app_pids(),
+                window: s.geometry.clone(),
+                window_handle: s.platform.active_window_handle(),
+                a11y_bus_addr: s.platform.a11y_bus_addr(),
+                limits: s.a11y_limits,
+            };
+            (target, ctx)
+        };
+        let s = self.active_mut()?;
+        s.accessibility
+            .as_mut()
+            .ok_or(GlassError::AxUnsupported)?
+            .invoke(&ctx, &target)?;
+        s.pump();
+        Ok(())
     }
 
     /// Set the value/text of element `id` (from the latest `a11y_snapshot`) via the
@@ -369,6 +422,18 @@ impl Glass {
     /// Let a just-opened/closed popup realize in the a11y tree before re-reading.
     fn settle_for_popup(&self) {
         std::thread::sleep(std::time::Duration::from_millis(250));
+    }
+}
+
+/// Short, agent-facing reason a native-invoke attempt fell back to the pointer path.
+/// `AxUnsupported`'s own `Display` is snapshot-oriented (it tells the agent to screenshot
+/// instead), which would mislead in a click result — map it.
+fn native_fallback_reason(e: &GlassError) -> String {
+    match e {
+        GlassError::AxUnsupported => "backend has no native action path".into(),
+        GlassError::AxActionUnavailable(_) => "element exposes no activation action".into(),
+        GlassError::AxActionFailed(_, msg) => format!("native action failed: {msg}"),
+        other => format!("native action error: {other}"),
     }
 }
 
@@ -1057,6 +1122,152 @@ mod tests {
     }
 
     #[test]
+    fn click_element_prefers_native_invoke_and_synthesizes_no_pointer() {
+        let clicks = Arc::new(Mutex::new(Vec::new()));
+        let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
+        let (mut g, invoke_log) =
+            glass_with_a11y_invoke(platform, fake_tree(), InvokeBehavior::Succeed);
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot(None).unwrap();
+        let method = g.click_element(AxNodeId(1)).unwrap();
+        assert_eq!(method, ClickMethod::NativeAction);
+        assert!(
+            clicks.lock().unwrap().is_empty(),
+            "no pointer event on the native path"
+        );
+        let log = invoke_log.lock().unwrap();
+        assert_eq!(log.len(), 1);
+        assert_eq!(log[0].id, AxNodeId(1));
+        assert_eq!(log[0].role, AxRole::Button);
+        assert_eq!(log[0].name.as_deref(), Some("Save"));
+        assert!(
+            log[0].bounds.is_some(),
+            "fingerprint carries the snapshot bounds"
+        );
+    }
+
+    #[test]
+    fn click_element_falls_back_when_element_has_no_action_and_discloses() {
+        let clicks = Arc::new(Mutex::new(Vec::new()));
+        let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
+        let (mut g, _) = glass_with_a11y_invoke(platform, fake_tree(), InvokeBehavior::NoAction);
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot(None).unwrap();
+        let method = g.click_element(AxNodeId(1)).unwrap();
+        assert_eq!(
+            method,
+            ClickMethod::Pointer {
+                native_fallback: "element exposes no activation action".into()
+            }
+        );
+        assert_eq!(clicks.lock().unwrap().last().copied(), Some((20, 20)));
+    }
+
+    #[test]
+    fn click_element_falls_back_when_backend_has_no_invoke() {
+        // Default knob = Unsupported = a backend that never implemented invoke (iOS/Android).
+        let clicks = Arc::new(Mutex::new(Vec::new()));
+        let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
+        let mut g = glass_with_a11y(platform, fake_tree());
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot(None).unwrap();
+        let method = g.click_element(AxNodeId(1)).unwrap();
+        assert_eq!(
+            method,
+            ClickMethod::Pointer {
+                native_fallback: "backend has no native action path".into()
+            }
+        );
+        assert_eq!(clicks.lock().unwrap().last().copied(), Some((20, 20)));
+    }
+
+    #[test]
+    fn click_element_falls_back_when_the_action_fails() {
+        let clicks = Arc::new(Mutex::new(Vec::new()));
+        let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
+        let (mut g, _) = glass_with_a11y_invoke(platform, fake_tree(), InvokeBehavior::Fail);
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot(None).unwrap();
+        let method = g.click_element(AxNodeId(1)).unwrap();
+        match method {
+            ClickMethod::Pointer { native_fallback } => {
+                assert!(
+                    native_fallback.starts_with("native action failed:"),
+                    "{native_fallback}"
+                )
+            }
+            m => panic!("expected pointer fallback, got {m:?}"),
+        }
+        assert_eq!(clicks.lock().unwrap().last().copied(), Some((20, 20)));
+    }
+
+    #[test]
+    fn click_element_drift_propagates_and_never_pointer_clicks() {
+        // AxElementChanged means the tree drifted; a pointer click at the stale bounds
+        // would hit the wrong element, so there must be NO fallback.
+        let clicks = Arc::new(Mutex::new(Vec::new()));
+        let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
+        let (mut g, _) = glass_with_a11y_invoke(platform, fake_tree(), InvokeBehavior::Drifted);
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot(None).unwrap();
+        assert!(matches!(
+            g.click_element(AxNodeId(1)).unwrap_err(),
+            GlassError::AxElementChanged(1)
+        ));
+        assert!(
+            clicks.lock().unwrap().is_empty(),
+            "no pointer event after drift"
+        );
+    }
+
+    #[test]
+    fn click_element_boundless_element_clicks_via_invoke() {
+        // Today a boundless node is AxElementNotClickable; with a native action it works.
+        let mut tree = fake_tree();
+        tree.root.children.push(AxNode {
+            id: AxNodeId(0),
+            role: AxRole::Button,
+            raw_role: "button".into(),
+            name: Some("hidden".into()),
+            value: None,
+            states: AxStates::default(),
+            bounds: None,
+            children: vec![],
+        });
+        let (mut g, _) =
+            glass_with_a11y_invoke(FakePlatform::new(100, 100), tree, InvokeBehavior::Succeed);
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot(None).unwrap();
+        assert_eq!(
+            g.click_element(AxNodeId(2)).unwrap(),
+            ClickMethod::NativeAction
+        );
+    }
+
+    #[test]
+    fn click_element_boundless_element_without_action_stays_not_clickable() {
+        let mut tree = fake_tree();
+        tree.root.children.push(AxNode {
+            id: AxNodeId(0),
+            role: AxRole::Button,
+            raw_role: "button".into(),
+            name: Some("hidden".into()),
+            value: None,
+            states: AxStates::default(),
+            bounds: None,
+            children: vec![],
+        });
+        let (mut g, _) =
+            glass_with_a11y_invoke(FakePlatform::new(100, 100), tree, InvokeBehavior::NoAction);
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot(None).unwrap();
+        assert!(matches!(
+            g.click_element(AxNodeId(2)).unwrap_err(),
+            GlassError::AxElementNotClickable(2)
+        ));
+    }
+
+    #[test]
     fn click_element_without_popover_clicks_clamped_center_and_never_selects_a_window() {
         let clicks = Arc::new(Mutex::new(Vec::new()));
         let select_log = Arc::new(Mutex::new(Vec::new()));
@@ -1156,7 +1367,11 @@ mod tests {
         g.a11y_snapshot(None).unwrap();
 
         // node #1 = the row-shaped checkable → a swipe across the trailing control, not a click.
-        g.click_element(AxNodeId(1)).unwrap();
+        let method = g.click_element(AxNodeId(1)).unwrap();
+        assert!(
+            matches!(method, ClickMethod::Pointer { .. }),
+            "the swipe path is pointer-class (the fake's default invoke is Unsupported)"
+        );
         let expected = bounds.trailing_toggle_swipe(100, 100).unwrap();
         {
             let d = drags.lock().unwrap();
@@ -1367,8 +1582,12 @@ mod tests {
         let globex_id = tree.root.children[0].children[0].id;
         assert_eq!(globex_id, AxNodeId(2));
 
-        g.click_element(globex_id).unwrap();
+        let method = g.click_element(globex_id).unwrap();
 
+        assert!(
+            matches!(method, ClickMethod::Pointer { .. }),
+            "the fake's default invoke behavior is Unsupported, so this still routes pointer"
+        );
         assert_eq!(
             clicks.lock().unwrap().last().copied(),
             Some((20, 54)),
@@ -1519,6 +1738,8 @@ mod tests {
                 set_log: log2,
                 set_fail: false,
                 limits_log: Arc::new(Mutex::new(None)),
+                invoke_behavior: InvokeBehavior::Unsupported,
+                invoke_log: Arc::new(Mutex::new(Vec::new())),
             })),
         });
         let factory: PlatformFactory = Box::new(move |_b| {
@@ -1567,6 +1788,8 @@ mod tests {
                 set_log: Arc::new(Mutex::new(Vec::new())),
                 set_fail: false,
                 limits_log: limits_log.clone(),
+                invoke_behavior: InvokeBehavior::Unsupported,
+                invoke_log: Arc::new(Mutex::new(Vec::new())),
             })),
         });
         let factory: PlatformFactory = Box::new(move |_b| {
@@ -1611,6 +1834,8 @@ mod tests {
                 set_log: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
                 set_fail: true,
                 limits_log: Arc::new(Mutex::new(None)),
+                invoke_behavior: InvokeBehavior::Unsupported,
+                invoke_log: Arc::new(Mutex::new(Vec::new())),
             })),
         });
         let factory: PlatformFactory = Box::new(move |_b| {
@@ -1874,6 +2099,8 @@ mod tests {
                 set_log: log2,
                 set_fail: false,
                 limits_log: Arc::new(Mutex::new(None)),
+                invoke_behavior: InvokeBehavior::Unsupported,
+                invoke_log: Arc::new(Mutex::new(Vec::new())),
             })),
         });
         let factory: PlatformFactory = Box::new(move |_b| {
@@ -1922,6 +2149,8 @@ mod tests {
                 set_log: log2,
                 set_fail: false,
                 limits_log: Arc::new(Mutex::new(None)),
+                invoke_behavior: InvokeBehavior::Unsupported,
+                invoke_log: Arc::new(Mutex::new(Vec::new())),
             })),
         });
         let factory: PlatformFactory = Box::new(move |_b| {

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -1709,6 +1709,100 @@ mod tests {
         );
     }
 
+    /// The popover-routing platform: an active window plus the dropdown's popover window,
+    /// with click + select logs — shared by the popover × native-invoke tests below.
+    fn popover_platform(
+        clicks: Arc<Mutex<Vec<(i32, i32)>>>,
+        select_log: Arc<Mutex<Vec<WindowId>>>,
+    ) -> FakePlatform {
+        let active = window_info(
+            1,
+            WindowGeometry {
+                x: 0,
+                y: 0,
+                width: 340,
+                height: 300,
+            },
+            true,
+        );
+        let popover = window_info(
+            2,
+            WindowGeometry {
+                x: -3,
+                y: 220,
+                width: 326,
+                height: 135,
+            },
+            false,
+        );
+        FakePlatform::new(340, 300)
+            .with_windows(vec![active, popover])
+            .with_click_log(clicks)
+            .with_select_log(select_log)
+    }
+
+    #[test]
+    fn click_element_native_invoke_succeeds_for_popover_hosted_element_without_window_select() {
+        // The native action addresses the element directly, so the whole popover machinery —
+        // enumerate windows, select the popover, click at a container-relative offset, restore
+        // the previous window — must be skipped: no focus change, no pointer event.
+        let clicks = Arc::new(Mutex::new(Vec::new()));
+        let select_log = Arc::new(Mutex::new(Vec::new()));
+        let (mut g, invoke_log) = glass_with_a11y_invoke(
+            popover_platform(clicks.clone(), select_log.clone()),
+            fake_tree_with_popover_option(),
+            InvokeBehavior::Succeed,
+        );
+        g.start(&spec()).unwrap();
+        let tree = g.a11y_snapshot(None).unwrap();
+        let globex_id = tree.root.children[0].children[0].id;
+
+        assert_eq!(
+            g.click_element(globex_id).unwrap(),
+            ClickMethod::NativeAction
+        );
+
+        assert_eq!(invoke_log.lock().unwrap().len(), 1, "the native path ran");
+        assert!(
+            clicks.lock().unwrap().is_empty(),
+            "no pointer event for a natively-invoked popover element"
+        );
+        assert!(
+            select_log.lock().unwrap().is_empty(),
+            "the popover is never raised — the native action needs no window focus"
+        );
+    }
+
+    #[test]
+    fn click_element_native_invoke_drifted_for_popover_hosted_element_is_fatal() {
+        // Drift is fatal wherever the element lives: routing into the popover and clicking
+        // its stale bounds would hit whatever moved into that spot.
+        let clicks = Arc::new(Mutex::new(Vec::new()));
+        let select_log = Arc::new(Mutex::new(Vec::new()));
+        let (mut g, _) = glass_with_a11y_invoke(
+            popover_platform(clicks.clone(), select_log.clone()),
+            fake_tree_with_popover_option(),
+            InvokeBehavior::Drifted,
+        );
+        g.start(&spec()).unwrap();
+        let tree = g.a11y_snapshot(None).unwrap();
+        let globex_id = tree.root.children[0].children[0].id;
+
+        assert!(matches!(
+            g.click_element(globex_id).unwrap_err(),
+            GlassError::AxElementChanged(id) if id == globex_id.0
+        ));
+
+        assert!(
+            clicks.lock().unwrap().is_empty(),
+            "no pointer event after drift"
+        );
+        assert!(
+            select_log.lock().unwrap().is_empty(),
+            "and no window was raised on the way to failing"
+        );
+    }
+
     #[test]
     fn click_element_in_popover_without_a_mappable_container_errors() {
         // Same popover-owning geometry, but the target has no List-sized ancestor to
@@ -2111,6 +2205,38 @@ mod tests {
         g.set_value(AxNodeId(1), "true").unwrap();
 
         assert_eq!(drags.lock().unwrap().len(), 1, "a toggle swipe was emitted");
+    }
+
+    #[test]
+    fn set_value_toggle_path_uses_native_invoke_when_available() {
+        // The trailing-toggle `set_value` branch actuates through `click_element_inner`, so on
+        // a backend that HAS a native action the toggle must fire natively — no swipe — and
+        // still verify the flip by re-snapshot. (The iOS backend this branch exists for has no
+        // invoke today, so only a fake can pin the interaction.)
+        let drags: Arc<Mutex<Vec<PointerEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let platform = FakePlatform::new(400, 400)
+            .with_drag_log(drags.clone())
+            .with_trailing_toggle_backend();
+        // Snapshot #1 (cached read) = unchecked; snapshot #2 (verify re-read) = checked.
+        let (mut g, invoke_log) = glass_with_a11y_seq_invoke(
+            platform,
+            vec![sw(false), sw(true)],
+            InvokeBehavior::Succeed,
+        );
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot(None).unwrap();
+
+        g.set_value(AxNodeId(1), "true").unwrap();
+
+        assert_eq!(
+            invoke_log.lock().unwrap().len(),
+            1,
+            "the toggle actuated once, natively"
+        );
+        assert!(
+            drags.lock().unwrap().is_empty(),
+            "the native action replaces the swipe — actuating both would toggle twice"
+        );
     }
 
     #[test]

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -99,7 +99,10 @@ impl Glass {
         let element = self.element_ref(id);
         let result = self.click_element_inner(id);
         self.emit_audit(
-            &crate::audit::Actuation::ClickElement { element },
+            &crate::audit::Actuation::ClickElement {
+                element,
+                method: result.as_ref().ok().map(ClickMethod::label),
+            },
             crate::audit::AuditOutcome::from_result(&result),
             t.elapsed(),
         );

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -241,8 +241,9 @@ impl Glass {
         }
     }
 
-    /// One native-invoke attempt: same fingerprint + context assembly as
-    /// `set_value_inner`, then the backend's `invoke`.
+    /// One native-invoke attempt: the same fingerprint + context assembly as
+    /// `set_value_inner` (over freshly re-read window geometry — see below), then the
+    /// backend's `invoke`.
     fn try_native_invoke(&mut self, id: AxNodeId) -> Result<()> {
         {
             let s = self.active_mut()?;

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -118,7 +118,7 @@ impl Glass {
         self.emit_audit(
             &crate::audit::Actuation::ClickElement {
                 element,
-                method: result.as_ref().ok().map(ClickMethod::label),
+                method: result.as_ref().ok(),
             },
             crate::audit::AuditOutcome::from_result(&result),
             t.elapsed(),

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -11,6 +11,11 @@ const ROW_ASPECT: u32 = 4;
 /// pan on a UISwitch; matches the proven ~250ms on-device swipe.
 const TOGGLE_SWIPE_MS: u64 = 250;
 
+/// Disclosed as the click method's fallback reason when `set_combo_value` opens a dropdown:
+/// that one click is pointer-only by design, not because the native action was unavailable.
+const COMBO_OPEN_POINTER_REASON: &str =
+    "combo popup opened by pointer so the keyboard commit lands in it";
+
 /// Poll cadence for `set_value`'s post-toggle verify: how often to re-snapshot while waiting for
 /// the swiped switch to read back the wanted state.
 const TOGGLE_VERIFY_INTERVAL_MS: u64 = 50;
@@ -95,9 +100,21 @@ impl Glass {
     /// trailing-toggle backend (see [`AxRect::trailing_toggle_swipe`]). The returned
     /// [`ClickMethod`] says which path actually fired.
     pub fn click_element(&mut self, id: AxNodeId) -> Result<ClickMethod> {
+        self.audited_click(id, Self::click_element_inner)
+    }
+
+    /// Run one element click and record it through the audit seam. Every path that actuates
+    /// an element by id goes through here — the native-first [`Glass::click_element`] and the
+    /// deliberately pointer-only combo open alike — so the log can't miss an actuation just
+    /// because an internal caller took a different route to it.
+    fn audited_click(
+        &mut self,
+        id: AxNodeId,
+        click: impl FnOnce(&mut Self, AxNodeId) -> Result<ClickMethod>,
+    ) -> Result<ClickMethod> {
         let t = std::time::Instant::now();
         let element = self.element_ref(id);
-        let result = self.click_element_inner(id);
+        let result = click(self, id);
         self.emit_audit(
             &crate::audit::Actuation::ClickElement {
                 element,
@@ -124,6 +141,16 @@ impl Glass {
             Err(e) if !e.invoke_fallback_eligible() => return Err(e),
             Err(e) => native_fallback_reason(&e),
         };
+        self.click_element_pointer_only(id)
+            .map(|()| ClickMethod::Pointer { native_fallback })
+    }
+
+    /// The synthetic-pointer half of [`Glass::click_element`], on its own: the center of the
+    /// element's bounds — routed into the owning popover window when the element renders in
+    /// one, or swiped across the trailing control for a row-shaped checkable on a
+    /// trailing-toggle backend. Callable directly by an internal caller that must NOT take
+    /// the native action (see [`Glass::set_combo_value`]).
+    fn click_element_pointer_only(&mut self, id: AxNodeId) -> Result<()> {
         let (bounds, checkable, trailing_toggle_backend, active_geo) = {
             let s = self.require_active()?;
             let tree = s.last_ax.as_ref().ok_or(GlassError::NoAxSnapshot)?;
@@ -173,7 +200,7 @@ impl Glass {
             if let Some(prev) = prev {
                 let _ = self.select_window(prev);
             }
-            return result.map(|()| ClickMethod::Pointer { native_fallback });
+            return result;
         }
         // A switch whose backend reports the whole row as its frame with the control at the
         // trailing edge (iOS/idb) is mis-tapped at the geometric center — that lands on the inert
@@ -200,7 +227,6 @@ impl Glass {
                 button: MouseButton::Left,
                 modifiers: vec![],
             })
-            .map(|()| ClickMethod::Pointer { native_fallback })
         } else {
             let (x, y) = bounds
                 .clamped_center(active_geo.width, active_geo.height)
@@ -212,7 +238,6 @@ impl Glass {
                 count: 1,
                 modifiers: vec![],
             })
-            .map(|()| ClickMethod::Pointer { native_fallback })
         }
     }
 
@@ -370,8 +395,18 @@ impl Glass {
         {
             return Ok(());
         }
-        // Open the popup (the combo button is in the main window, so this click lands).
-        self.click_element(id)?;
+        // Open the popup with a real pointer click, deliberately NOT the native action (the
+        // combo button is in the main window, so this click lands). A programmatic expand —
+        // UIA's `ExpandCollapsePattern` is the concrete case — opens the popup without moving
+        // keyboard focus, and everything below is keyboard navigation (Down/Up/Return), which
+        // would then go to whatever held focus instead of the popup. Clicking focuses the
+        // combo the way a person's click does.
+        self.audited_click(id, |g, id| {
+            g.click_element_pointer_only(id)
+                .map(|()| ClickMethod::Pointer {
+                    native_fallback: COMBO_OPEN_POINTER_REASON.into(),
+                })
+        })?;
         self.settle_for_popup();
         // Re-read the realized options + which one is currently selected. The open
         // combo is `expanded`; when several combos exist, ids don't survive the
@@ -1699,6 +1734,103 @@ mod tests {
             "the candidate window is never selected either — the container gate runs \
              before select_window, so a mis-detection can't even transiently switch focus"
         );
+    }
+
+    /// The combo fixture: a single `ComboBox` named `name`, optionally `expanded` with its
+    /// option rows realized underneath (an open GtkDropDown's shape — `ListItem`s carrying
+    /// their label, the current one `selected`).
+    fn combo(name: &str, options: &[&str]) -> AxTree {
+        let bounds = AxRect {
+            x: 0,
+            y: 188,
+            width: 320,
+            height: 34,
+        };
+        let items: Vec<AxNode> = options
+            .iter()
+            .enumerate()
+            .map(|(i, opt)| AxNode {
+                states: AxStates {
+                    selected: *opt == name,
+                    ..Default::default()
+                },
+                ..named_node(
+                    0,
+                    AxRole::ListItem,
+                    opt,
+                    AxRect {
+                        x: 20,
+                        y: 200 + 30 * i as i32,
+                        width: 280,
+                        height: 27,
+                    },
+                )
+            })
+            .collect();
+        let children = if options.is_empty() {
+            vec![]
+        } else {
+            vec![AxNode {
+                children: items,
+                ..ax_node(
+                    0,
+                    AxRole::List,
+                    Some(AxRect {
+                        x: 0,
+                        y: 194,
+                        width: 320,
+                        height: 129,
+                    }),
+                    vec![],
+                )
+            }]
+        };
+        let combo = AxNode {
+            name: Some(name.into()),
+            states: AxStates {
+                expanded: !options.is_empty(),
+                ..Default::default()
+            },
+            children,
+            ..ax_node(0, AxRole::ComboBox, Some(bounds), vec![])
+        };
+        tree_with(340, 300, vec![combo])
+    }
+
+    #[test]
+    fn set_value_on_a_combo_opens_the_popup_with_a_pointer_click_even_when_invoke_succeeds() {
+        // The combo commit loop is keyboard navigation (Down/Up/Return), so the popup must be
+        // opened by something that takes keyboard focus. A native "expand" action doesn't
+        // (UIA's ExpandCollapsePattern is the concrete case), which would send the keystrokes
+        // to whatever had focus instead. So this one click stays pointer-only even on a
+        // backend whose invoke works.
+        let clicks = Arc::new(Mutex::new(Vec::new()));
+        let platform = FakePlatform::new(340, 300).with_click_log(clicks.clone());
+        let (mut g, invoke_log) = glass_with_a11y_seq_invoke(
+            platform,
+            vec![
+                combo("Acme", &[]),                 // cached: closed, showing Acme
+                combo("Acme", &["Acme", "Globex"]), // after the open: expanded + options
+                combo("Globex", &[]),               // after the commit: closed, Globex
+            ],
+            InvokeBehavior::Succeed,
+        );
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot(None).unwrap();
+
+        g.set_value(AxNodeId(1), "Globex").unwrap();
+
+        assert!(
+            invoke_log.lock().unwrap().is_empty(),
+            "the popup open must not use the native action — it wouldn't take keyboard focus"
+        );
+        let clicks = clicks.lock().unwrap();
+        assert_eq!(
+            clicks.len(),
+            1,
+            "exactly one pointer click: the popup open, {clicks:?}"
+        );
+        assert_eq!(clicks[0], (160, 205), "the combo's own clamped center");
     }
 
     #[test]

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -112,15 +112,16 @@ impl Glass {
     fn click_element_inner(&mut self, id: AxNodeId) -> Result<ClickMethod> {
         // Native action first: works for occluded/off-screen/boundless elements and
         // (on backends whose action API is out-of-band) doesn't move the cursor.
+        //
+        // Falling back is an allowlist, not a denylist: only an attempt that dispatched
+        // NOTHING may be retried with the pointer (see
+        // [`GlassError::invoke_fallback_eligible`]). Anything else — a reported action
+        // failure, an ambiguous transport error, a drifted tree, the pre-check errors —
+        // propagates, because clicking on top of a native action that may still land would
+        // actuate the control twice while the result claimed only "pointer" ran.
         let native_fallback = match self.try_native_invoke(id) {
             Ok(()) => return Ok(ClickMethod::NativeAction),
-            // Propagate-class: a drifted tree mis-clicks by stale bounds too, and the
-            // pre-checks (no snapshot / unknown id) fail the pointer path identically.
-            Err(
-                e @ (GlassError::AxElementChanged(_)
-                | GlassError::NoAxSnapshot
-                | GlassError::AxElementNotFound(_)),
-            ) => return Err(e),
+            Err(e) if !e.invoke_fallback_eligible() => return Err(e),
             Err(e) => native_fallback_reason(&e),
         };
         let (bounds, checkable, trailing_toggle_backend, active_geo) = {
@@ -431,11 +432,15 @@ impl Glass {
 /// Short, agent-facing reason a native-invoke attempt fell back to the pointer path.
 /// `AxUnsupported`'s own `Display` is snapshot-oriented (it tells the agent to screenshot
 /// instead), which would mislead in a click result — map it.
+///
+/// Only the two fallback-eligible errors reach here (see
+/// [`GlassError::invoke_fallback_eligible`], the single place that decides). The `other` arm
+/// is unreachable defence-in-depth, kept so this stays a total function if the eligibility
+/// set ever widens.
 fn native_fallback_reason(e: &GlassError) -> String {
     match e {
         GlassError::AxUnsupported => "backend has no native action path".into(),
         GlassError::AxActionUnavailable(_) => "element exposes no activation action".into(),
-        GlassError::AxActionFailed(_, msg) => format!("native action failed: {msg}"),
         other => format!("native action error: {other}"),
     }
 }
@@ -1185,23 +1190,24 @@ mod tests {
     }
 
     #[test]
-    fn click_element_falls_back_when_the_action_fails() {
+    fn click_element_action_failure_propagates_and_never_pointer_clicks() {
+        // A native action that reported failure may still have been DISPATCHED (the backend
+        // fires it on a detached worker and can lose the answer), so a pointer click on top
+        // of it would actuate the control twice. Only outcomes that dispatched nothing may
+        // fall back — everything else fails closed.
         let clicks = Arc::new(Mutex::new(Vec::new()));
         let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
         let (mut g, _) = glass_with_a11y_invoke(platform, fake_tree(), InvokeBehavior::Fail);
         g.start(&spec()).unwrap();
         g.a11y_snapshot(None).unwrap();
-        let method = g.click_element(AxNodeId(1)).unwrap();
-        match method {
-            ClickMethod::Pointer { native_fallback } => {
-                assert!(
-                    native_fallback.starts_with("native action failed:"),
-                    "{native_fallback}"
-                )
-            }
-            m => panic!("expected pointer fallback, got {m:?}"),
-        }
-        assert_eq!(clicks.lock().unwrap().last().copied(), Some((20, 20)));
+        assert!(matches!(
+            g.click_element(AxNodeId(1)).unwrap_err(),
+            GlassError::AxActionFailed(1, _)
+        ));
+        assert!(
+            clicks.lock().unwrap().is_empty(),
+            "no pointer event after a possibly-dispatched native action"
+        );
     }
 
     #[test]

--- a/crates/glass-core/src/session/mod.rs
+++ b/crates/glass-core/src/session/mod.rs
@@ -3,7 +3,7 @@
 
 use crate::accessibility::{
     element_match, Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxTarget, AxTree,
-    ElementCondition, ElementInfo, ElementMatch, WalkLimits,
+    ClickMethod, ElementCondition, ElementInfo, ElementMatch, WalkLimits,
 };
 use crate::baseline::BaselineStore;
 use crate::diff::{

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -254,6 +254,22 @@ impl Platform for FakePlatform {
     }
 }
 
+/// Scripts `FakeAccessibility::invoke`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum InvokeBehavior {
+    /// Mirror a backend that never implemented `invoke` (trait-default shape).
+    #[default]
+    Unsupported,
+    /// Native action fires and reports success.
+    Succeed,
+    /// Element exposes no activation action.
+    NoAction,
+    /// Action fired but the toolkit reported failure.
+    Fail,
+    /// Fingerprint mismatch — tree drifted since the snapshot.
+    Drifted,
+}
+
 /// A scriptable `Accessibility` returning a fixed tree.
 pub(crate) struct FakeAccessibility {
     pub(crate) tree: AxTree,
@@ -263,6 +279,14 @@ pub(crate) struct FakeAccessibility {
     /// `snapshot` or `set_value`) — lets a test prove `max_nodes` actually reached the
     /// backend, not just the session's own bookkeeping. `None` when unset.
     pub(crate) limits_log: Arc<Mutex<Option<crate::accessibility::WalkLimits>>>,
+    /// Scripts this backend's `invoke` outcome. Defaults to `Unsupported`, mirroring a
+    /// backend that never implemented it (the trait's default shape) — so every existing
+    /// test that doesn't opt in still exercises the pointer-fallback path unchanged.
+    pub(crate) invoke_behavior: InvokeBehavior,
+    /// Every target `invoke` "actuated" (only recorded when `invoke_behavior ==
+    /// Succeed`) — lets a test prove the native path fired instead of / in addition to the
+    /// pointer path.
+    pub(crate) invoke_log: Arc<Mutex<Vec<AxTarget>>>,
 }
 
 impl Accessibility for FakeAccessibility {
@@ -280,6 +304,22 @@ impl Accessibility for FakeAccessibility {
             .unwrap()
             .push((target.clone(), text.to_string()));
         Ok(())
+    }
+    fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<()> {
+        *self.limits_log.lock().unwrap() = Some(ctx.limits);
+        match self.invoke_behavior {
+            InvokeBehavior::Unsupported => Err(GlassError::AxUnsupported),
+            InvokeBehavior::Succeed => {
+                self.invoke_log.lock().unwrap().push(target.clone());
+                Ok(())
+            }
+            InvokeBehavior::NoAction => Err(GlassError::AxActionUnavailable(target.id.0)),
+            InvokeBehavior::Fail => Err(GlassError::AxActionFailed(
+                target.id.0,
+                "action reported failure".into(),
+            )),
+            InvokeBehavior::Drifted => Err(GlassError::AxElementChanged(target.id.0)),
+        }
     }
 }
 
@@ -400,8 +440,33 @@ pub(crate) fn glass_with_a11y(platform: FakePlatform, tree: AxTree) -> Glass {
             set_log: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
             set_fail: false,
             limits_log: Arc::new(Mutex::new(None)),
+            invoke_behavior: InvokeBehavior::Unsupported,
+            invoke_log: Arc::new(Mutex::new(Vec::new())),
         }),
     )
+}
+
+/// Like `glass_with_a11y`, but scripts the backend's `invoke` outcome — for tests of the
+/// native-invoke-first `click_element` path. Returns the invoke log alongside the session
+/// so a test can assert what (if anything) was "actuated" natively.
+pub(crate) fn glass_with_a11y_invoke(
+    platform: FakePlatform,
+    tree: AxTree,
+    behavior: InvokeBehavior,
+) -> (Glass, Arc<Mutex<Vec<AxTarget>>>) {
+    let invoke_log = Arc::new(Mutex::new(Vec::new()));
+    let g = glass_with_backend(
+        platform,
+        Box::new(FakeAccessibility {
+            tree,
+            set_log: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+            set_fail: false,
+            limits_log: Arc::new(Mutex::new(None)),
+            invoke_behavior: behavior,
+            invoke_log: invoke_log.clone(),
+        }),
+    );
+    (g, invoke_log)
 }
 
 /// An `Accessibility` that returns a scripted sequence of trees — one per

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -16,6 +16,10 @@ pub(crate) use std::time::Duration;
 /// asserting it (not `capture_frame`) was used, and with what arguments.
 pub(crate) type CaptureWindowLog = Arc<Mutex<Vec<(WindowId, Option<Region>)>>>;
 
+/// The last `AxContext` a fake `Accessibility` was called with — see
+/// [`FakeAccessibility::ctx_log`].
+pub(crate) type CtxLog = Arc<Mutex<Option<AxContext>>>;
+
 /// Scriptable in-memory backend for testing the session manager.
 #[derive(Default)]
 pub(crate) struct FakePlatform {
@@ -48,10 +52,11 @@ pub(crate) struct FakePlatform {
     /// Stands in for a backend (iOS) that reports a switch's frame as the whole row — makes
     /// `a11y_toggle_control_at_trailing_edge` return true so the trailing-aim path is testable.
     a11y_trailing_toggle: bool,
-    /// When set, a `WindowOp::Geometry` read reports this geometry — models an app that resized
-    /// itself (e.g. opened a sidebar) without a `glass_window` op, so the session's cached
-    /// geometry is stale until `a11y_snapshot` refreshes it.
-    resized_to: Option<WindowGeometry>,
+    /// Geometries successive `WindowOp::Geometry` reads report, in order, the last repeating
+    /// forever (same idiom as `frames`) — models an app that resizes/moves itself without a
+    /// `glass_window` op, so the session's cached geometry is stale until something re-reads
+    /// it. Empty means "report the current geometry unchanged".
+    resized_to: VecDeque<WindowGeometry>,
 }
 
 impl FakePlatform {
@@ -118,8 +123,10 @@ impl FakePlatform {
         self.a11y_trailing_toggle = true;
         self
     }
+    /// Script the next `WindowOp::Geometry` read. Call once for "the app resized itself and
+    /// stays that size"; call repeatedly to script successive reads (the last repeats).
     pub(crate) fn resized_to(mut self, g: WindowGeometry) -> Self {
-        self.resized_to = Some(g);
+        self.resized_to.push_back(g);
         self
     }
 }
@@ -202,8 +209,11 @@ impl Platform for FakePlatform {
             }
             WindowOp::Focus => {}
             WindowOp::Geometry => {
-                if let Some(g) = &self.resized_to {
-                    self.geometry = g.clone();
+                if let Some(g) = self.resized_to.front().cloned() {
+                    if self.resized_to.len() > 1 {
+                        self.resized_to.pop_front(); // the last scripted geometry repeats
+                    }
+                    self.geometry = g;
                 }
             }
         }
@@ -297,10 +307,11 @@ pub(crate) struct FakeAccessibility {
     pub(crate) tree: AxTree,
     pub(crate) set_log: std::sync::Arc<std::sync::Mutex<Vec<(AxTarget, String)>>>,
     pub(crate) set_fail: bool,
-    /// The `limits` from the most recent `AxContext` this backend received (either
-    /// `snapshot` or `set_value`) — lets a test prove `max_nodes` actually reached the
-    /// backend, not just the session's own bookkeeping. `None` when unset.
-    pub(crate) limits_log: Arc<Mutex<Option<crate::accessibility::WalkLimits>>>,
+    /// The most recent `AxContext` this backend received (from `snapshot`, `set_value`, or
+    /// `invoke`) — lets a test prove what actually reached the backend (the `max_nodes`
+    /// limits, the window geometry the fingerprint is checked against), not just the
+    /// session's own bookkeeping. `None` when unset.
+    pub(crate) ctx_log: CtxLog,
     /// Scripts this backend's `invoke` outcome. Defaults to `Unsupported`, mirroring a
     /// backend that never implemented it (the trait's default shape) — so every existing
     /// test that doesn't opt in still exercises the pointer-fallback path unchanged.
@@ -313,11 +324,11 @@ pub(crate) struct FakeAccessibility {
 
 impl Accessibility for FakeAccessibility {
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
-        *self.limits_log.lock().unwrap() = Some(ctx.limits);
+        *self.ctx_log.lock().unwrap() = Some(ctx.clone());
         Ok(self.tree.clone())
     }
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
-        *self.limits_log.lock().unwrap() = Some(ctx.limits);
+        *self.ctx_log.lock().unwrap() = Some(ctx.clone());
         if self.set_fail {
             return Err(GlassError::AxElementNotEditable(target.id.0));
         }
@@ -328,7 +339,7 @@ impl Accessibility for FakeAccessibility {
         Ok(())
     }
     fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<()> {
-        *self.limits_log.lock().unwrap() = Some(ctx.limits);
+        *self.ctx_log.lock().unwrap() = Some(ctx.clone());
         scripted_invoke(self.invoke_behavior, &self.invoke_log, target)
     }
 }
@@ -449,7 +460,7 @@ pub(crate) fn glass_with_a11y(platform: FakePlatform, tree: AxTree) -> Glass {
             tree,
             set_log: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
             set_fail: false,
-            limits_log: Arc::new(Mutex::new(None)),
+            ctx_log: Arc::new(Mutex::new(None)),
             invoke_behavior: InvokeBehavior::Unsupported,
             invoke_log: Arc::new(Mutex::new(Vec::new())),
         }),
@@ -464,19 +475,32 @@ pub(crate) fn glass_with_a11y_invoke(
     tree: AxTree,
     behavior: InvokeBehavior,
 ) -> (Glass, Arc<Mutex<Vec<AxTarget>>>) {
+    let (g, invoke_log, _) = glass_with_a11y_invoke_ctx(platform, tree, behavior);
+    (g, invoke_log)
+}
+
+/// [`glass_with_a11y_invoke`] plus the ctx log — for a test that must prove what
+/// [`AxContext`] the backend was handed (e.g. the window geometry the fingerprint is
+/// checked against), not just that `invoke` ran.
+pub(crate) fn glass_with_a11y_invoke_ctx(
+    platform: FakePlatform,
+    tree: AxTree,
+    behavior: InvokeBehavior,
+) -> (Glass, Arc<Mutex<Vec<AxTarget>>>, CtxLog) {
     let invoke_log = Arc::new(Mutex::new(Vec::new()));
+    let ctx_log: CtxLog = Arc::new(Mutex::new(None));
     let g = glass_with_backend(
         platform,
         Box::new(FakeAccessibility {
             tree,
             set_log: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
             set_fail: false,
-            limits_log: Arc::new(Mutex::new(None)),
+            ctx_log: ctx_log.clone(),
             invoke_behavior: behavior,
             invoke_log: invoke_log.clone(),
         }),
     );
-    (g, invoke_log)
+    (g, invoke_log, ctx_log)
 }
 
 /// An `Accessibility` that returns a scripted sequence of trees — one per

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -543,7 +543,7 @@ pub(crate) fn glass_with_a11y_seq_invoke(
 ) -> (Glass, Arc<Mutex<Vec<AxTarget>>>) {
     debug_assert!(
         !trees.is_empty(),
-        "glass_with_a11y_seq needs at least one tree (snapshot indexes trees.len() - 1)"
+        "glass_with_a11y_seq_invoke needs at least one tree (snapshot indexes trees.len() - 1)"
     );
     let invoke_log = Arc::new(Mutex::new(Vec::new()));
     let g = glass_with_backend(

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -270,6 +270,28 @@ pub(crate) enum InvokeBehavior {
     Drifted,
 }
 
+/// The scripted `Accessibility::invoke` body shared by [`FakeAccessibility`] and
+/// [`SeqAccessibility`], so both fakes model a backend's invoke identically.
+fn scripted_invoke(
+    behavior: InvokeBehavior,
+    log: &Arc<Mutex<Vec<AxTarget>>>,
+    target: &AxTarget,
+) -> Result<()> {
+    match behavior {
+        InvokeBehavior::Unsupported => Err(GlassError::AxUnsupported),
+        InvokeBehavior::Succeed => {
+            log.lock().unwrap().push(target.clone());
+            Ok(())
+        }
+        InvokeBehavior::NoAction => Err(GlassError::AxActionUnavailable(target.id.0)),
+        InvokeBehavior::Fail => Err(GlassError::AxActionFailed(
+            target.id.0,
+            "action reported failure".into(),
+        )),
+        InvokeBehavior::Drifted => Err(GlassError::AxElementChanged(target.id.0)),
+    }
+}
+
 /// A scriptable `Accessibility` returning a fixed tree.
 pub(crate) struct FakeAccessibility {
     pub(crate) tree: AxTree,
@@ -307,19 +329,7 @@ impl Accessibility for FakeAccessibility {
     }
     fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<()> {
         *self.limits_log.lock().unwrap() = Some(ctx.limits);
-        match self.invoke_behavior {
-            InvokeBehavior::Unsupported => Err(GlassError::AxUnsupported),
-            InvokeBehavior::Succeed => {
-                self.invoke_log.lock().unwrap().push(target.clone());
-                Ok(())
-            }
-            InvokeBehavior::NoAction => Err(GlassError::AxActionUnavailable(target.id.0)),
-            InvokeBehavior::Fail => Err(GlassError::AxActionFailed(
-                target.id.0,
-                "action reported failure".into(),
-            )),
-            InvokeBehavior::Drifted => Err(GlassError::AxElementChanged(target.id.0)),
-        }
+        scripted_invoke(self.invoke_behavior, &self.invoke_log, target)
     }
 }
 
@@ -471,10 +481,14 @@ pub(crate) fn glass_with_a11y_invoke(
 
 /// An `Accessibility` that returns a scripted sequence of trees — one per
 /// `snapshot()` call, repeating the last — so a test can model rows/columns
-/// realizing on-screen as the container scrolls.
+/// realizing on-screen as the container scrolls. Its `invoke` is scriptable too
+/// (default: unsupported), so a compound operation that re-snapshots between steps
+/// can also be driven over a backend that has a native action.
 pub(crate) struct SeqAccessibility {
     trees: Vec<AxTree>,
     idx: usize,
+    invoke_behavior: InvokeBehavior,
+    invoke_log: Arc<Mutex<Vec<AxTarget>>>,
 }
 
 impl Accessibility for SeqAccessibility {
@@ -486,14 +500,38 @@ impl Accessibility for SeqAccessibility {
     fn set_value(&mut self, _ctx: &AxContext, _t: &AxTarget, _s: &str) -> Result<()> {
         Ok(())
     }
+    fn invoke(&mut self, _ctx: &AxContext, target: &AxTarget) -> Result<()> {
+        scripted_invoke(self.invoke_behavior, &self.invoke_log, target)
+    }
 }
 
 pub(crate) fn glass_with_a11y_seq(platform: FakePlatform, trees: Vec<AxTree>) -> Glass {
+    glass_with_a11y_seq_invoke(platform, trees, InvokeBehavior::Unsupported).0
+}
+
+/// Like [`glass_with_a11y_seq`] but with a scripted `invoke` — for compound operations
+/// (`set_value`'s toggle path, `set_combo_value`) that re-snapshot between steps AND run
+/// over a backend with a native action. Returns the invoke log alongside the session.
+pub(crate) fn glass_with_a11y_seq_invoke(
+    platform: FakePlatform,
+    trees: Vec<AxTree>,
+    behavior: InvokeBehavior,
+) -> (Glass, Arc<Mutex<Vec<AxTarget>>>) {
     debug_assert!(
         !trees.is_empty(),
         "glass_with_a11y_seq needs at least one tree (snapshot indexes trees.len() - 1)"
     );
-    glass_with_backend(platform, Box::new(SeqAccessibility { trees, idx: 0 }))
+    let invoke_log = Arc::new(Mutex::new(Vec::new()));
+    let g = glass_with_backend(
+        platform,
+        Box::new(SeqAccessibility {
+            trees,
+            idx: 0,
+            invoke_behavior: behavior,
+            invoke_log: invoke_log.clone(),
+        }),
+    );
+    (g, invoke_log)
 }
 
 pub(crate) fn named_node(id: u32, role: AxRole, name: &str, bounds: AxRect) -> AxNode {

--- a/crates/glass-macos/fixture/a11y_fixture.swift
+++ b/crates/glass-macos/fixture/a11y_fixture.swift
@@ -1,12 +1,18 @@
 // a11y_fixture.swift — glass-macos accessibility-tree test fixture.
 //
-// A minimal Cocoa app whose window exposes a real NSAccessibility tree with three named
+// A minimal Cocoa app whose window exposes a real NSAccessibility tree with four named
 // controls, for the macOS a11y reader's on-box tests to drive by name:
 //
-//   - an NSButton titled "Save" — prints `SAVE_CLICKED` to stdout (flushed) when clicked,
-//     so a later bounds-agreement test can grep the app's captured stdout for the marker.
+//   - an NSButton titled "Save" — prints `SAVE_CLICKED` to stdout (flushed) when its action
+//     fires, so both the bounds-agreement test (a real pointer click) and the native-invoke
+//     test (AXPress) can grep the app's captured stdout for the same marker: AXPress on an
+//     NSButton runs the identical target/action as a real click, so one marker line proves
+//     both paths reach the real handler — no separate "invoke" marker needed.
 //   - an NSButton checkbox labelled "Enable".
 //   - an editable NSTextField labelled "Note", initial value "hello".
+//   - a non-editable, non-interactive NSTextField label ("Status") — exposes no AXPress
+//     action, so the native-invoke test can confirm it is rejected as `AxActionUnavailable`
+//     rather than silently doing nothing.
 //
 // Each control sets an explicit `accessibilityLabel` so the reader can find it by name
 // regardless of its visible title/string value. Sibling to `quadrants.swift` (the
@@ -38,10 +44,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         note.frame = NSRect(x: 20, y: 60, width: 200, height: 24)
         note.setAccessibilityLabel("Note")
 
+        // `labelWithString:` configures a non-editable, non-selectable, borderless text
+        // field — AppKit's standard "static label" idiom, which reports AX role
+        // `AXStaticText` (glass's `AxRole::Label`) rather than `AXTextField`, and exposes no
+        // `AXPress` action.
+        let status = NSTextField(labelWithString: "ready")
+        status.frame = NSRect(x: 20, y: 20, width: 120, height: 20)
+        status.setAccessibilityLabel("Status")
+
         let contentView = NSView(frame: window.contentView!.bounds)
         contentView.addSubview(save)
         contentView.addSubview(enable)
         contentView.addSubview(note)
+        contentView.addSubview(status)
         window.contentView = contentView
         window.title = "glass a11y fixture"
         window.makeKeyAndOrderFront(nil)

--- a/crates/glass-macos/fixture/a11y_fixture.swift
+++ b/crates/glass-macos/fixture/a11y_fixture.swift
@@ -66,8 +66,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // `print` is fully buffered (not line-buffered) once stdout is a pipe rather than a
     // TTY — and a later task's bounds-agreement test captures this app's stdout through a
     // pipe and greps it for the marker, so the write must be flushed explicitly or it may
-    // never arrive before the test gives up. The brief's original
-    // `FileHandle.standardOutput.synchronizeFile()` calls `fsync(2)` under the hood,
+    // never arrive before the test gives up. Do NOT reach for
+    // `FileHandle.standardOutput.synchronizeFile()`: it calls `fsync(2)` under the hood,
     // which fails — and raises an uncatchable Objective-C exception, crashing the
     // process — on a non-seekable fd such as a pipe. `fflush(stdout)`, the convention
     // already used throughout `quadrants.swift`, is the safe equivalent here.

--- a/crates/glass-macos/tests/a11y.rs
+++ b/crates/glass-macos/tests/a11y.rs
@@ -1,11 +1,17 @@
 //! Mac-gated accessibility-reader integration test — the first real-AX-tree proof through
-//! the whole `glass-a11y-macos` snapshot + set_value path (`MacosPlatform::start_app` ->
-//! `AxContext` -> `MacosA11y::snapshot`/`set_value` -> AXUIElement walk -> `AxTree`), driven
-//! against the `a11y_fixture` Cocoa app (a "Save" button, an "Enable" checkbox, and an
-//! editable "Note" field — labeled "Note" via `setAccessibilityLabel`, holding the content
-//! "hello"). After the snapshot checks, it round-trips `set_value` on the "Note" field
-//! ("hello" -> "world") and confirms the non-editable "Save" button rejects a write with
-//! `AxElementNotEditable`.
+//! the whole `glass-a11y-macos` snapshot + set_value + invoke path (`MacosPlatform::start_app`
+//! -> `AxContext` -> `MacosA11y::snapshot`/`set_value`/`invoke` -> AXUIElement walk ->
+//! `AxTree`), driven against the `a11y_fixture` Cocoa app (a "Save" button, an "Enable"
+//! checkbox, an editable "Note" field — labeled "Note" via `setAccessibilityLabel`, holding
+//! the content "hello" — and a non-interactive "Status" label). After the snapshot checks,
+//! it round-trips `set_value` on the "Note" field ("hello" -> "world") and confirms the
+//! non-editable "Save" button rejects a write with `AxElementNotEditable`.
+//!
+//! Then, a **native-invoke** check: `invoke` fires `AXPress` on the "Save" button and
+//! confirms the fixture's own `onSave` handler ran (via the same `SAVE_CLICKED` marker the
+//! bounds-agreement check below also uses — AXPress runs the identical target/action a real
+//! click does, so reusing the marker is a stronger proof, not a weaker one), then confirms
+//! the non-actionable "Status" label rejects `invoke` with `AxActionUnavailable`.
 //!
 //! Finally, a **bounds-agreement drift guard**: it clamped-centers the "Save" node's
 //! a11y-reported `bounds` into window-relative pixels and dispatches a real
@@ -55,21 +61,23 @@ mod macos_main {
     };
     use glass_macos::MacosPlatform;
 
-    /// Settle after the a11y-bounds click before draining logs, mirroring `input.rs`'s
-    /// `ACTION_SETTLE` — generous relative to `send_pointer`'s own internal focus-settle so
-    /// the fixture's `fflush`ed `SAVE_CLICKED` line has definitely been read by the
-    /// platform's background log reader before we drain.
+    /// Settle after an action that should print `SAVE_CLICKED` — native `invoke` or the
+    /// a11y-bounds pointer click — before draining logs, mirroring `input.rs`'s
+    /// `ACTION_SETTLE`. Generous relative to the action's own internal focus-settle so the
+    /// fixture's `fflush`ed line has definitely been read by the platform's background log
+    /// reader before we drain.
     const CLICK_SETTLE: Duration = Duration::from_millis(400);
 
-    /// The three elements the fixture exposes, asserted as substrings of the tree outline.
+    /// The four elements the fixture exposes, asserted as substrings of the tree outline.
     /// `to_outline` renders each node as `#<id> <Role> "<name>" ...`, using only `name` (never
     /// `value`) — so the editable field's stable label (`setAccessibilityLabel("Note")`,
     /// surfaced as `AXDescription`) is what appears here, not its volatile content ("hello").
     /// The content is checked separately, via [`find_text_field`], against `AxNode::value`.
-    const NEEDLES: [&str; 3] = [
+    const NEEDLES: [&str; 4] = [
         "Button \"Save\"",
         "CheckBox \"Enable\"",
         "TextField \"Note\"",
+        "Label \"Status\"",
     ];
 
     /// Pre-order search for the first `TextField` node — the fixture's editable "Note" field.
@@ -282,6 +290,42 @@ mod macos_main {
         }
 
         println!("A11Y_SETVALUE_PASS");
+
+        // --- Native invoke: fire AXPress on the "Save" button through `invoke` and confirm
+        // the fixture's own `onSave` handler ran — reusing SAVE_CLICKED (rather than a
+        // dedicated marker) since AXPress on an NSButton runs the identical target/action a
+        // real click does, and nothing has printed it yet at this point in the run. ---
+        try_expect(a11y.invoke(&ctx, &save_tgt), "invoke(Save)")?;
+        std::thread::sleep(CLICK_SETTLE);
+        let invoke_logs = platform.drain_logs();
+        if !logs_contain(&invoke_logs, "SAVE_CLICKED") {
+            return Err(format!(
+                "invoke(Save) did not fire the button's action (fixture stdout: {invoke_logs:?})"
+            ));
+        }
+
+        // A label exposes no AXPress: invoke must report AxActionUnavailable, not silently
+        // no-op or fall back.
+        let status = match find_by_name(&tree2.root, "Status") {
+            Some(n) => n,
+            None => return Err(format!("no \"Status\" label in re-snapshot:\n{outline2}")),
+        };
+        let status_tgt = AxTarget {
+            id: status.id,
+            role: status.role,
+            name: status.name.clone(),
+            bounds: status.bounds,
+        };
+        match a11y.invoke(&ctx, &status_tgt) {
+            Err(GlassError::AxActionUnavailable(_)) => {}
+            other => {
+                return Err(format!(
+                    "expected AxActionUnavailable for Status, got {other:?}"
+                ))
+            }
+        }
+
+        println!("A11Y_INVOKE_PASS");
 
         // --- Bounds-agreement drift guard: clamped-center Save's a11y bounds into
         // window-relative pixels, click there through the real input path, and confirm

--- a/crates/glass-mcp/src/audit.rs
+++ b/crates/glass-mcp/src/audit.rs
@@ -200,7 +200,19 @@ fn describe(act: &Actuation) -> Option<(&'static str, Value, Option<String>)> {
             ("window", args, None)
         }
         Actuation::ClickElement { method, .. } => {
-            ("click_element", json!({ "method": method }), None)
+            // A failed click has no method: omit the key rather than writing a null, so a
+            // reader never has to distinguish "no method recorded" from "method: null".
+            let args = match method {
+                Some(m) => {
+                    let mut args = json!({ "method": m.label() });
+                    if let Some(reason) = m.native_fallback() {
+                        args["native_fallback"] = json!(reason);
+                    }
+                    args
+                }
+                None => json!({}),
+            };
+            ("click_element", args, None)
         }
         Actuation::SetValue { text, .. } => ("set_value", json!({}), Some((*text).to_string())),
     })
@@ -440,8 +452,8 @@ pub fn resolve(
 mod tests {
     use super::*;
     use glass_core::{
-        Actuation, ActuationContext, AuditOutcome, ElementRef, KeyEvent, MouseButton, PointerEvent,
-        WindowRef,
+        Actuation, ActuationContext, AuditOutcome, ClickMethod, ElementRef, KeyEvent, MouseButton,
+        PointerEvent, WindowRef,
     };
     use std::io::Write;
     use std::sync::{Arc, Mutex};
@@ -632,19 +644,25 @@ mod tests {
         assert_eq!(r["content"]["len"], 1);
     }
 
-    #[test]
-    fn click_element_carries_the_actuating_method() {
-        let buf = Arc::new(Mutex::new(Vec::new()));
-        let s = JsonlSink::with_writer(Box::new(Buf(buf.clone())), AuditConfig::default());
-        let el = ElementRef {
+    fn click_el() -> ElementRef {
+        ElementRef {
             id: 1,
             role: Some("Button".into()),
             name: Some("Save".into()),
+        }
+    }
+
+    #[test]
+    fn click_element_carries_the_actuating_method_and_its_fallback_reason() {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let s = JsonlSink::with_writer(Box::new(Buf(buf.clone())), AuditConfig::default());
+        let method = ClickMethod::Pointer {
+            native_fallback: "element exposes no activation action".into(),
         };
         s.record(
             &Actuation::ClickElement {
-                element: el,
-                method: Some("pointer"),
+                element: click_el(),
+                method: Some(&method),
             },
             &ActuationContext::default(),
             &ok(),
@@ -652,7 +670,57 @@ mod tests {
         );
         let r = &lines(&buf)[0];
         assert_eq!(r["action"], "click_element");
-        assert_eq!(r["args"]["method"], "pointer");
+        assert_eq!(r["args"]["method"], method.label());
+        assert_eq!(
+            r["args"]["native_fallback"], "element exposes no activation action",
+            "the pointer path records WHY the native action wasn't used: {r}"
+        );
+    }
+
+    #[test]
+    fn click_element_native_action_records_no_fallback_reason() {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let s = JsonlSink::with_writer(Box::new(Buf(buf.clone())), AuditConfig::default());
+        let method = ClickMethod::NativeAction;
+        s.record(
+            &Actuation::ClickElement {
+                element: click_el(),
+                method: Some(&method),
+            },
+            &ActuationContext::default(),
+            &ok(),
+            Duration::from_millis(1),
+        );
+        let r = &lines(&buf)[0];
+        assert_eq!(r["args"]["method"], method.label());
+        assert!(
+            r["args"].get("native_fallback").is_none(),
+            "nothing fell back: {r}"
+        );
+    }
+
+    #[test]
+    fn click_element_failure_omits_method() {
+        // Neither path actuated, so there is no method — the key must be ABSENT, not null.
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let s = JsonlSink::with_writer(Box::new(Buf(buf.clone())), AuditConfig::default());
+        s.record(
+            &Actuation::ClickElement {
+                element: click_el(),
+                method: None,
+            },
+            &ActuationContext::default(),
+            &AuditOutcome {
+                ok: false,
+                error: Some("element #1 changed since the snapshot; re-snapshot".into()),
+            },
+            Duration::from_millis(1),
+        );
+        let r = &lines(&buf)[0];
+        assert_eq!(r["action"], "click_element");
+        assert_eq!(r["result"]["ok"], false);
+        assert!(r["args"].get("method").is_none(), "no null method: {r}");
+        assert!(r["args"].get("native_fallback").is_none(), "{r}");
     }
 
     #[test]

--- a/crates/glass-mcp/src/audit.rs
+++ b/crates/glass-mcp/src/audit.rs
@@ -199,14 +199,16 @@ fn describe(act: &Actuation) -> Option<(&'static str, Value, Option<String>)> {
             };
             ("window", args, None)
         }
-        Actuation::ClickElement { .. } => ("click_element", json!({}), None),
+        Actuation::ClickElement { method, .. } => {
+            ("click_element", json!({ "method": method }), None)
+        }
         Actuation::SetValue { text, .. } => ("set_value", json!({}), Some((*text).to_string())),
     })
 }
 
 fn target_json(act: &Actuation, ctx: &ActuationContext) -> Value {
     match act {
-        Actuation::ClickElement { element } | Actuation::SetValue { element, .. } => {
+        Actuation::ClickElement { element, .. } | Actuation::SetValue { element, .. } => {
             json!({ "element": { "id": element.id, "role": element.role, "name": element.name } })
         }
         _ => match &ctx.window {
@@ -628,6 +630,29 @@ mod tests {
         assert_eq!(r["target"]["element"]["id"], 5);
         assert_eq!(r["target"]["element"]["role"], "PasswordField");
         assert_eq!(r["content"]["len"], 1);
+    }
+
+    #[test]
+    fn click_element_carries_the_actuating_method() {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let s = JsonlSink::with_writer(Box::new(Buf(buf.clone())), AuditConfig::default());
+        let el = ElementRef {
+            id: 1,
+            role: Some("Button".into()),
+            name: Some("Save".into()),
+        };
+        s.record(
+            &Actuation::ClickElement {
+                element: el,
+                method: Some("pointer"),
+            },
+            &ActuationContext::default(),
+            &ok(),
+            Duration::from_millis(1),
+        );
+        let r = &lines(&buf)[0];
+        assert_eq!(r["action"], "click_element");
+        assert_eq!(r["args"]["method"], "pointer");
     }
 
     #[test]

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -113,6 +113,12 @@ pub struct ClickElementArgs {
     /// dropdown's option row), the click is automatically routed into that popover
     /// window and the previously-active window is restored afterward — no extra step
     /// needed.
+    ///
+    /// Clicks via the platform's native accessibility action when the element exposes
+    /// one (works even when the element is occluded or scrolled off-screen), falling
+    /// back to a synthetic pointer click at the element's center; the result's
+    /// `method` field says which path ran, and `native_fallback` says why when the
+    /// pointer path was used.
     pub id: u32,
     /// Optional observe folded into the result: "snapshot" (wait for the UI to settle, then
     /// fold a fresh a11y tree, also refreshing the snapshot cache), "settle" (wait for the UI

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -361,8 +361,12 @@ impl GlassServer {
     }
 
     #[tool(
-        description = "Click an element by its #id from glass_a11y_snapshot (clicks the \
-                       center of its bounds, via the normal click path). If the element actually \
+        description = "Click an element by its #id from glass_a11y_snapshot (actuates via the \
+                       platform's native accessibility action when the element exposes one — \
+                       works even when it's occluded or scrolled off-screen — else falls back \
+                       to a synthetic pointer click at the center of its bounds; the result's \
+                       `method` field says which path ran, and `native_fallback` says why when \
+                       the pointer path was used). If the element actually \
                        renders in a popover owned by a different window than the active one \
                        (e.g. an open dropdown's option row), the click is automatically routed \
                        into that popover window and the previously-active window is restored \
@@ -405,7 +409,8 @@ impl GlassServer {
                        glass_a11y_snapshot). Chips sit just outside each element so small icon \
                        buttons stay visible. The box is only as precise as the toolkit's \
                        accessibility geometry (it can drift ~10-20px), but the #id and the click \
-                       are exact (click_element targets the element's center). Errors if no \
+                       are exact (click_element actuates via the native accessibility action \
+                       when available, else clicks the element's center). Errors if no \
                        accessibility tree is available — use glass_screenshot then."
     )]
     async fn glass_a11y_marks(&self) -> Result<CallToolResult, McpError> {

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -394,11 +394,14 @@ fn resolve_return(
 pub fn click_element(glass: &mut Glass, a: &ClickElementArgs) -> ToolResult {
     // Bad `return` value → reject before the click lands (see `validate_return`).
     validate_return(a.return_.as_deref())?;
-    glass
+    let method = glass
         .click_element(AxNodeId(a.id))
         .map_err(|e| e.to_string())?;
     let (observed, extra) = resolve_return(glass, a.return_.as_deref())?;
-    let mut result = serde_json::json!({ "id": a.id });
+    let mut result = serde_json::json!({ "id": a.id, "method": method.label() });
+    if let Some(reason) = method.native_fallback() {
+        result["native_fallback"] = serde_json::json!(reason);
+    }
     if let Some(o) = observed {
         result["observed"] = o;
     }
@@ -663,10 +666,22 @@ pub(crate) mod testutil {
         Changed,
     }
 
+    /// What `FakeAccessibility::invoke` should do. Default mirrors the trait's own
+    /// default (unsupported) — a backend that never implemented the native action,
+    /// so `click_element` falls back to the pointer path unless a test opts into
+    /// [`InvokeOutcome::Ok`].
+    #[derive(Clone, Copy, Default, PartialEq)]
+    pub enum InvokeOutcome {
+        #[default]
+        Unsupported,
+        Ok,
+    }
+
     pub struct FakeAccessibility {
         pub tree: AxTree,
         pub set_log: std::sync::Arc<std::sync::Mutex<Vec<(AxTarget, String)>>>,
         pub set_outcome: SetOutcome,
+        pub invoke_outcome: InvokeOutcome,
     }
 
     impl Accessibility for FakeAccessibility {
@@ -686,6 +701,12 @@ pub(crate) mod testutil {
                 .unwrap()
                 .push((target.clone(), text.to_string()));
             Ok(())
+        }
+        fn invoke(&mut self, _ctx: &AxContext, _target: &AxTarget) -> Result<()> {
+            match self.invoke_outcome {
+                InvokeOutcome::Unsupported => Err(GlassError::AxUnsupported),
+                InvokeOutcome::Ok => Ok(()),
+            }
         }
     }
 
@@ -766,11 +787,28 @@ pub(crate) mod testutil {
     }
 
     /// Like [`glass_with_a11y`] but with a chosen `set_value` outcome, so a test can
-    /// drive the not-editable / changed-since-snapshot rejection paths.
+    /// drive the not-editable / changed-since-snapshot rejection paths. `invoke` stays
+    /// at its default (unsupported) — use [`glass_with_a11y_invoke_ok`] for the
+    /// native-action path.
     pub fn glass_with_a11y_outcome(
         platform: FakePlatform,
         tree: AxTree,
         set_outcome: SetOutcome,
+    ) -> Glass {
+        glass_with_a11y_full(platform, tree, set_outcome, InvokeOutcome::Unsupported)
+    }
+
+    /// Like [`glass_with_a11y`] but with `invoke` wired to succeed, so a test can drive
+    /// `click_element`'s native-action path (no pointer event, no fallback disclosed).
+    pub fn glass_with_a11y_invoke_ok(platform: FakePlatform, tree: AxTree) -> Glass {
+        glass_with_a11y_full(platform, tree, SetOutcome::Ok, InvokeOutcome::Ok)
+    }
+
+    fn glass_with_a11y_full(
+        platform: FakePlatform,
+        tree: AxTree,
+        set_outcome: SetOutcome,
+        invoke_outcome: InvokeOutcome,
     ) -> Glass {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().join("baselines");
@@ -781,6 +819,7 @@ pub(crate) mod testutil {
                 tree,
                 set_log: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
                 set_outcome,
+                invoke_outcome,
             })),
         });
         let factory: PlatformFactory = Box::new(move |_backend| {
@@ -1420,6 +1459,13 @@ mod tests {
         let v = assert_envelope(&out, "glass_click_element");
         assert_eq!(v["id"], json!(1), "envelope: {v}");
         assert!(v["observed"].is_null(), "envelope: {v}");
+        // The fake's default invoke is unsupported (trait default), so the pointer
+        // path ran and the fallback reason must be disclosed.
+        assert_eq!(v["method"], json!("pointer"), "envelope: {v}");
+        assert!(
+            v["native_fallback"].as_str().is_some_and(|s| !s.is_empty()),
+            "envelope: {v}"
+        );
 
         let out2 = click_element(
             &mut g,
@@ -1430,6 +1476,37 @@ mod tests {
         )
         .unwrap();
         assert_eq!(out2.0.len(), 1);
+    }
+
+    #[test]
+    fn click_element_discloses_native_action_with_no_fallback() {
+        let mut g = glass_with_a11y_invoke_ok(FakePlatform::new(100, 100), fake_tree());
+        g.start(&AppSpec {
+            build: None,
+            run: vec!["x".into()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 1,
+            sandbox: SandboxLevel::Off,
+            a11y: false,
+        })
+        .unwrap();
+        a11y_snapshot(&mut g, &A11ySnapshotArgs { max_nodes: None }).unwrap();
+        let out = click_element(
+            &mut g,
+            &ClickElementArgs {
+                id: 1,
+                return_: None,
+            },
+        )
+        .unwrap();
+        let v = assert_envelope(&out, "glass_click_element");
+        assert_eq!(v["method"], json!("native-action"), "envelope: {v}");
+        assert!(
+            v.get("native_fallback").is_none(),
+            "no fallback key on the native-action path: {v}"
+        );
     }
 
     #[test]

--- a/crates/glass-windows/Cargo.toml
+++ b/crates/glass-windows/Cargo.toml
@@ -41,6 +41,8 @@ windows = { version = "0.62", features = [
 # validate the accessibility path.
 [target.'cfg(windows)'.dev-dependencies]
 windows = { version = "0.62", features = ["Win32_Foundation", "Win32_UI_HiDpi", "Win32_UI_WindowsAndMessaging"] }
+# onbox.rs's Glass-session harness (glass_windows_with_a11y) needs a scratch baseline dir.
+tempfile.workspace = true
 
 # The pixel conversion is cross-platform, so its bench builds and runs everywhere.
 [dev-dependencies]

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -14,8 +14,9 @@ use std::time::Duration;
 
 use glass_a11y_windows::WindowsA11y;
 use glass_core::{
-    Accessibility, AppSpec, AxContext, AxNode, AxRole, AxTarget, GlassError, KeyEvent, Modifier,
-    MouseButton, Platform, PointerEvent, WalkLimits, WindowGeometry, WindowHint, WindowOp,
+    Accessibility, AppSpec, AxContext, AxNode, AxRole, AxTarget, Backend, BaselineStore, Glass,
+    GlassError, KeyEvent, Modifier, MouseButton, Platform, PlatformFactory, PointerEvent,
+    WalkLimits, WindowGeometry, WindowHint, WindowOp,
 };
 use glass_windows::WindowsPlatform;
 
@@ -52,6 +53,25 @@ fn charmap_spec() -> AppSpec {
         sandbox: glass_core::SandboxLevel::Off,
         a11y: false,
     }
+}
+
+/// A `Glass` session wired to the real Windows backend + UIA reader (as opposed to the bare
+/// `WindowsPlatform`/`WindowsA11y` the other on-box tests drive directly) — needed wherever a test
+/// wants the production `click_element` orchestration (invoke-first, pointer-fallback,
+/// `ClickMethod` disclosure) rather than the reader alone. Mirrors the X11 integration suite's
+/// `glass_x11_with_a11y()`. The baseline dir is leaked (not needed: this is a short-lived on-box
+/// test process, and `Glass` never deletes it itself).
+fn glass_windows_with_a11y() -> Glass {
+    let factory: PlatformFactory = Box::new(|_backend| {
+        Ok(Backend {
+            platform: Box::new(WindowsPlatform::new()?),
+            accessibility: Some(Box::new(WindowsA11y::new())),
+        })
+    });
+    let dir = tempfile::tempdir().expect("tempdir for baseline store");
+    let root = dir.path().join("baselines");
+    std::mem::forget(dir);
+    Glass::new(factory, "windows".into(), BaselineStore::new(root), 100)
 }
 
 /// The egui input/a11y fixture (built on demand; excluded from the workspace). Paths derive from the
@@ -272,19 +292,11 @@ fn onbox_isolated_edge_killtree() {
 fn onbox_a11y_snapshot_and_click() {
     let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     dpi_aware_once();
-    let mut p = WindowsPlatform::new().expect("WindowsPlatform::new");
-    let geo = p.start_app(&charmap_spec()).expect("start charmap");
+    let mut glass = glass_windows_with_a11y();
+    let geo = glass.start(&charmap_spec()).expect("start charmap");
     std::thread::sleep(Duration::from_millis(1500));
 
-    let mut a11y = WindowsA11y::new();
-    let ctx = AxContext {
-        pids: p.app_pids(),
-        window: geo.clone(),
-        window_handle: p.active_window_handle(),
-        a11y_bus_addr: None,
-        limits: WalkLimits::DEFAULT,
-    };
-    let tree = a11y.snapshot(&ctx).expect("a11y snapshot");
+    let tree = glass.a11y_snapshot(None).expect("a11y snapshot");
     assert!(tree.count > 0, "snapshot must have nodes");
     let (mut total, mut inter) = (0usize, 0usize);
     counts(&tree.root, &mut total, &mut inter);
@@ -296,23 +308,26 @@ fn onbox_a11y_snapshot_and_click() {
     let mut hit = None;
     first_clickable(&tree.root, &mut hit);
     let n = hit.expect("an interactable element with on-screen bounds");
-    let (cx, cy) = n
-        .bounds
-        .and_then(|b| b.clamped_center(geo.width, geo.height))
-        .expect("first interactable has a clampable center");
-    // Capture before/after so we verify the click actually changed the UI (exercising the
-    // bounds -> clamped_center -> click coordinate path), not merely that send_pointer returned Ok.
-    let before = p.capture_frame(None).expect("capture before click");
-    p.send_pointer(&PointerEvent::Click {
-        x: cx,
-        y: cy,
-        button: MouseButton::Left,
-        count: 1,
-        modifiers: vec![],
-    })
-    .expect("click element by center");
+    let id = n.id;
+    assert!(
+        n.bounds
+            .and_then(|b| b.clamped_center(geo.width, geo.height))
+            .is_some(),
+        "first interactable has a clampable center"
+    );
+    // Capture before/after so we verify the click actually changed the UI, not merely that
+    // click_element returned Ok. A Win32 Button (charmap's "Select"/"Copy", same as an
+    // egui/accesskit button) publishes the UIA InvokePattern, so the production click_element
+    // path must take the native-action branch here, never synthesize a pointer event.
+    let before = glass.screenshot(None, None).expect("capture before click");
+    let method = glass.click_element(id).expect("click element by id");
+    assert_eq!(
+        method,
+        glass_core::ClickMethod::NativeAction,
+        "a Win32 Button publishes UIA InvokePattern; click_element must take the native path"
+    );
     std::thread::sleep(Duration::from_millis(700));
-    let after = p.capture_frame(None).expect("capture after click");
+    let after = glass.screenshot(None, None).expect("capture after click");
     assert_eq!(
         before.pixels.len(),
         after.pixels.len(),
@@ -323,7 +338,7 @@ fn onbox_a11y_snapshot_and_click() {
         "clicking the element must change the UI"
     );
 
-    let _ = p.stop_app();
+    let _ = glass.stop();
 }
 
 #[test]

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -305,15 +305,18 @@ fn onbox_a11y_snapshot_and_click() {
         "charmap must expose interactable elements, got {inter}"
     );
 
+    // A Button specifically, not just the first interactable: `first_clickable` lands on
+    // charmap's font ComboBox, whose actuation verb is ExpandCollapse, not Invoke — a weaker
+    // (and differently-behaving) subject for the native-path assertion below.
     let mut hit = None;
-    first_clickable(&tree.root, &mut hit);
-    let n = hit.expect("an interactable element with on-screen bounds");
+    first_role(&tree.root, AxRole::Button, &mut hit);
+    let n = hit.expect("charmap exposes a Button");
     let id = n.id;
     assert!(
         n.bounds
             .and_then(|b| b.clamped_center(geo.width, geo.height))
             .is_some(),
-        "first interactable has a clampable center"
+        "the Button has a clampable center"
     );
     // Capture before/after so we verify the click actually changed the UI, not merely that
     // click_element returned Ok. A Win32 Button (charmap's "Select"/"Copy", same as an

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -180,6 +180,17 @@ fn first_role<'a>(n: &'a AxNode, role: AxRole, out: &mut Option<&'a AxNode>) {
     }
 }
 
+/// Like [`first_role`], but only nodes that actually report geometry — for a test that goes on
+/// to click the node, where a bounds-less match would make the follow-on assertions luck.
+fn first_role_with_bounds<'a>(n: &'a AxNode, role: AxRole, out: &mut Option<&'a AxNode>) {
+    if out.is_none() && n.role == role && n.bounds.is_some() {
+        *out = Some(n);
+    }
+    for c in &n.children {
+        first_role_with_bounds(c, role, out);
+    }
+}
+
 /// Count msedge.exe processes whose command line carries `marker` (our isolated user-data-dir), via
 /// CIM so the box's background Edge isn't counted.
 fn our_edge_count(marker: &str) -> i32 {
@@ -307,10 +318,11 @@ fn onbox_a11y_snapshot_and_click() {
 
     // A Button specifically, not just the first interactable: `first_clickable` lands on
     // charmap's font ComboBox, whose actuation verb is ExpandCollapse, not Invoke — a weaker
-    // (and differently-behaving) subject for the native-path assertion below.
+    // (and differently-behaving) subject for the native-path assertion below. Still requires
+    // bounds (as `first_clickable` did), so the clampable-center check below stays meaningful.
     let mut hit = None;
-    first_role(&tree.root, AxRole::Button, &mut hit);
-    let n = hit.expect("charmap exposes a Button");
+    first_role_with_bounds(&tree.root, AxRole::Button, &mut hit);
+    let n = hit.expect("charmap exposes a Button with on-screen bounds");
     let id = n.id;
     assert!(
         n.bounds


### PR DESCRIPTION
## What

`glass_click_element` now actuates via the platform's native accessibility action when the element exposes one, falling back to the synthetic pointer click otherwise — always disclosing which path ran.

- New `Accessibility::invoke` seam (default: unsupported). Backends: AT-SPI `Action` ladder (Linux), UIA pattern ladder Invoke → Toggle → SelectionItem → ExpandCollapse (Windows), `AXPress` (macOS). iOS/Android keep the pointer path (no native action API on those transports).
- Result JSON gains `method` (`"native-action"` / `"pointer"`) and `native_fallback` (why the pointer path ran). The audit record carries both.
- **Fail-closed fallback**: pointer fallback happens only when nothing was dispatched (`backend has no native action path` / `element exposes no activation action`). Any dispatched-or-ambiguous native failure propagates instead — a pointer click on top of an action that may still land would actuate the control twice.
- Toggle rungs verify the state actually flipped (bounded poll); an acked-but-inert toggle errors rather than reporting success.
- Drift honesty: an element that no longer matches the snapshot errors (`re-snapshot`) on native-path backends instead of clicking stale coordinates.
- Combo popups still open via a real pointer click (programmatic expand doesn't take keyboard focus; the keyboard-nav commit loop needs it).
- Window geometry is re-read best-effort before invoke/set_value fingerprinting, so a moved window doesn't fail every click until re-snapshot.
- Native actuation works for occluded, scrolled-off-screen, and boundless elements, and on macOS no longer moves the cursor or steals focus.

## How verified

- Workspace unit suite (1339 tests), fmt, clippy `-D warnings` (host + `x86_64-pc-windows-gnu` + `x86_64-apple-darwin` type-check).
- Full AT-SPI integration suite (24 tests, GTK4 fixture) including a new native-invoke switch test and the dropdown/popover regression tests.
- X11 integration suite.
- Real MCP stdio smoke: `glass_click_element` returns `"method":"native-action"` end-to-end.
- Windows on-box (`onbox_a11y`, 3/3): Button click takes the native path on real UIA; set_value + multiprocess unaffected.
- macOS: unit + clippy green on-host; the granted-run integration check is queued behind a machine-local permission re-grant and runs before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)