### PR TITLE
a11y: declare and test cross-backend role support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,0 @@
-# Enforce LF line endings for text files to ensure consistency across platforms
-*.md text eol=lf
-*.rs text eol=lf
-*.toml text eol=lf
-*.yml text eol=lf
-*.yaml text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Enforce LF line endings for text files to ensure consistency across platforms
+*.md text eol=lf
+*.rs text eol=lf
+*.toml text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,13 @@ internal refactors, CI, or test-only changes.
   `glass_click_element` and `glass_set_value` — type text and confirm the UI settled (or fold a
   fresh accessibility tree) in one call. Inside a `glass_do` `type` action the field is rejected
   with guidance to use a `settle` action or the terminal `then` observe instead.
+- [docs/reference/a11y-roles.md](docs/reference/a11y-roles.md) documents which accessibility roles
+  each platform backend can produce, and why a role is unavailable where it is.
 
 ### Changed
+- The `raw_role` reported for each accessibility node on Windows and macOS is now the platform's
+  own role token (the UIA control-type name, the AX role string) instead of a localized display
+  string, so it is the same on every machine.
 - `glass_a11y_snapshot` now returns a compacted outline: chains of unnamed single-child
   container elements are collapsed. Element ids are unchanged and every element remains
   addressable with `glass_click_element` / `glass_set_value`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,11 @@ internal refactors, CI, or test-only changes.
   each platform backend can produce, and why a role is unavailable where it is.
 
 ### Changed
-- The `raw_role` reported for each accessibility node on Windows and macOS is now the platform's
-  own role token (the UIA control-type name, the AX role string) instead of a localized display
-  string, so it is the same on every machine.
+- The `glass_a11y_snapshot` outline now names the platform's own role token for an element glass
+  has no role mapping for: the line reads `Other(AXDisclosureTriangle)` rather than a bare
+  `Other`, so a custom control is still identifiable. The token is the platform's stable
+  identifier — the AT-SPI role, the UIA control-type name, the AX role string, the Android widget
+  class, the iOS role string — and reads the same on every machine.
 - `glass_a11y_snapshot` now returns a compacted outline: chains of unnamed single-child
   container elements are collapsed. Element ids are unchanged and every element remains
   addressable with `glass_click_element` / `glass_set_value`.

--- a/crates/glass-a11y-linux/src/mapping.rs
+++ b/crates/glass-a11y-linux/src/mapping.rs
@@ -175,7 +175,7 @@ mod tests {
         use glass_core::role_support::{support, AxBackend, RoleSupport};
         for role in AxRole::ALL {
             let mapped = ROLE_SAMPLES.iter().any(|(_, r)| *r == role);
-            match support(role, AxBackend::Linux) {
+            match support(role, AxBackend::Linux).expect("declared in ROLE_SUPPORT") {
                 RoleSupport::Mapped => {
                     assert!(
                         mapped,

--- a/crates/glass-a11y-linux/src/mapping.rs
+++ b/crates/glass-a11y-linux/src/mapping.rs
@@ -125,4 +125,68 @@ mod tests {
         let m = map_states(&StateSet::new(State::Checkable));
         assert!(m.checkable && !m.checked);
     }
+
+    /// One AT-SPI role per normalized role — the witness list the parity test walks.
+    const ROLE_SAMPLES: &[(Role, AxRole)] = &[
+        (Role::Application, AxRole::Application),
+        (Role::Frame, AxRole::Window),
+        (Role::Dialog, AxRole::Dialog),
+        (Role::Panel, AxRole::Group),
+        (Role::Button, AxRole::Button),
+        (Role::ToggleButton, AxRole::ToggleButton),
+        (Role::RadioButton, AxRole::RadioButton),
+        (Role::CheckBox, AxRole::CheckBox),
+        (Role::MenuBar, AxRole::MenuBar),
+        (Role::Menu, AxRole::Menu),
+        (Role::MenuItem, AxRole::MenuItem),
+        (Role::Label, AxRole::Label),
+        (Role::Entry, AxRole::TextField),
+        (Role::Text, AxRole::TextArea),
+        (Role::ComboBox, AxRole::ComboBox),
+        (Role::List, AxRole::List),
+        (Role::ListItem, AxRole::ListItem),
+        (Role::Table, AxRole::Table),
+        (Role::TableCell, AxRole::Cell),
+        (Role::Tree, AxRole::Tree),
+        (Role::TreeItem, AxRole::TreeItem),
+        (Role::PageTabList, AxRole::TabList),
+        (Role::PageTab, AxRole::Tab),
+        (Role::ScrollBar, AxRole::ScrollBar),
+        (Role::Slider, AxRole::Slider),
+        (Role::SpinButton, AxRole::SpinButton),
+        (Role::ProgressBar, AxRole::ProgressBar),
+        (Role::Image, AxRole::Image),
+        (Role::Link, AxRole::Link),
+        (Role::Separator, AxRole::Separator),
+        (Role::ToolBar, AxRole::Toolbar),
+        (Role::StatusBar, AxRole::StatusBar),
+        (Role::Heading, AxRole::Heading),
+    ];
+
+    #[test]
+    fn every_sample_maps_as_claimed() {
+        for (atspi, expected) in ROLE_SAMPLES {
+            assert_eq!(map_role(*atspi), *expected, "{atspi:?}");
+        }
+    }
+
+    #[test]
+    fn map_matches_declared_column() {
+        use glass_core::role_support::{support, AxBackend, RoleSupport};
+        for role in AxRole::ALL {
+            let mapped = ROLE_SAMPLES.iter().any(|(_, r)| *r == role);
+            match support(role, AxBackend::Linux) {
+                RoleSupport::Mapped => {
+                    assert!(
+                        mapped,
+                        "{role:?} declared Mapped but no AT-SPI sample maps to it"
+                    )
+                }
+                RoleSupport::NotApplicable(_) | RoleSupport::Gap(_) => assert!(
+                    !mapped,
+                    "{role:?} is produced by an AT-SPI role but the matrix does not declare it"
+                ),
+            }
+        }
+    }
 }

--- a/crates/glass-a11y-linux/tests/fixtures/a11y_fixture.py
+++ b/crates/glass-a11y-linux/tests/fixtures/a11y_fixture.py
@@ -3,8 +3,11 @@
 Window "Glass A11y Fixture" containing a Label "Ready", a Button "Save", a
 CheckButton "Enable", an Entry "Field" (initial text "hello"), a SpinButton
 "Amount" (initial value 1), a DropDown "Company" (Acme/Globex/Initech), a
-Switch "Active" (off), and a virtualized GtkListView of 80 rows ("Row 000".."Row
-079") in a small scroller. Run by scripts/test-a11y.sh via glass (which sets DISPLAY).
+Switch "Active" (off), a virtualized GtkListView of 80 rows ("Row 000".."Row
+079") in a small scroller, a Scale "Volume", a ProgressBar "Progress", a
+horizontal Separator, a Toolbar containing a Button "Cut", a LinkButton "Docs",
+and a Notebook with two pages ("One", "Two"). Run by scripts/test-a11y.sh via
+glass (which sets DISPLAY).
 
 Uses Gio.ApplicationFlags.NON_UNIQUE so the app skips D-Bus singleton registration
 and presents its window immediately without waiting for portal services to settle."""
@@ -86,6 +89,42 @@ class FixtureApp(Gtk.Application):
         scroller.set_max_content_height(120)
         scroller.set_child(listview)
         box.append(scroller)
+
+        # Widgets added for the role-coverage test. Labels are deliberately distinct from the
+        # existing fixture widgets so name-based lookups in other tests stay unambiguous.
+        # Accessible names go through update_property, the GTK4 idiom already used above —
+        # GTK3's get_accessible()/ATK path does not exist in GTK4.
+        scale = Gtk.Scale(
+            orientation=Gtk.Orientation.HORIZONTAL,
+            adjustment=Gtk.Adjustment(value=25, lower=0, upper=100, step_increment=1),
+        )
+        scale.update_property([Gtk.AccessibleProperty.LABEL], ["Volume"])
+        box.append(scale)
+
+        progress = Gtk.ProgressBar()
+        progress.set_fraction(0.4)
+        progress.update_property([Gtk.AccessibleProperty.LABEL], ["Progress"])
+        box.append(progress)
+
+        box.append(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL))
+
+        # A plain box carrying the TOOLBAR accessible role — GTK4 sets the role at
+        # construction, so it cannot be changed after the widget exists.
+        toolbar = Gtk.Box(
+            orientation=Gtk.Orientation.HORIZONTAL,
+            accessible_role=Gtk.AccessibleRole.TOOLBAR,
+        )
+        toolbar.append(Gtk.Button(label="Cut"))
+        box.append(toolbar)
+
+        link = Gtk.LinkButton(uri="https://example.invalid", label="Docs")
+        box.append(link)
+
+        notebook = Gtk.Notebook()
+        notebook.append_page(Gtk.Label(label="first page"), Gtk.Label(label="One"))
+        notebook.append_page(Gtk.Label(label="second page"), Gtk.Label(label="Two"))
+        box.append(notebook)
+
         win.set_child(box)
         win.present()
 

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -443,29 +443,8 @@ fn find_node<'a>(node: &'a glass_core::AxNode, name: &str) -> Option<&'a glass_c
 }
 
 fn launch_fixture() -> Glass {
-    let fixture = concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/tests/fixtures/a11y_fixture.py"
-    );
     let mut glass = glass_x11_with_a11y();
-    glass
-        .start(&AppSpec {
-            build: None,
-            run: vec!["python3".into(), fixture.into()],
-            cwd: None,
-            env: vec![
-                ("LIBGL_ALWAYS_SOFTWARE".into(), "1".into()),
-                ("GDK_BACKEND".into(), "x11".into()),
-            ],
-            window_hint: Some(WindowHint {
-                title: Some("Glass A11y Fixture".into()),
-                class: None,
-            }),
-            timeout_ms: 10_000,
-            sandbox: glass_core::SandboxLevel::Off,
-            a11y: true,
-        })
-        .expect("launch");
+    glass.start(&fixture_spec()).expect("launch");
     std::thread::sleep(std::time::Duration::from_millis(3_000));
     glass
 }

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -19,6 +19,32 @@ fn glass_x11_with_a11y() -> Glass {
     Glass::new(factory, "x11".into(), BaselineStore::new(root), 100)
 }
 
+/// The common `AppSpec` for launching the GTK4 fixture under X11 with a11y enabled —
+/// factored out so tests that need only the spec (not a started+settled `Glass`, which
+/// `launch_fixture` below provides) don't duplicate the literal.
+fn fixture_spec() -> AppSpec {
+    let fixture = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/a11y_fixture.py"
+    );
+    AppSpec {
+        build: None,
+        run: vec!["python3".into(), fixture.into()],
+        cwd: None,
+        env: vec![
+            ("LIBGL_ALWAYS_SOFTWARE".into(), "1".into()),
+            ("GDK_BACKEND".into(), "x11".into()),
+        ],
+        window_hint: Some(WindowHint {
+            title: Some("Glass A11y Fixture".into()),
+            class: None,
+        }),
+        timeout_ms: 10_000,
+        sandbox: glass_core::SandboxLevel::Off,
+        a11y: true,
+    }
+}
+
 /// Regression: the real MCP runs the (blocking) `glass_start` from *inside* its
 /// multi-thread tokio runtime. `PrivateBus::start` must bring up the a11y bus without
 /// nesting a runtime — nesting panics ("Cannot start a runtime from within a runtime"),
@@ -106,6 +132,50 @@ fn snapshot_finds_gtk_widgets() {
     );
 
     glass.stop().expect("stop");
+}
+
+/// The AT-SPI map claims full role coverage; this proves the claim on a real bus for the
+/// roles the fixture can actually show. Complements the in-crate column test, which only
+/// checks the map against the declared matrix.
+#[test]
+#[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
+fn snapshot_covers_the_declared_linux_roles() {
+    use glass_core::{role_histogram, AxRole};
+
+    let mut glass = glass_x11_with_a11y();
+    glass.start(&fixture_spec()).expect("start fixture");
+    // Give the AT-SPI tree a moment to populate after the window maps, same convention as
+    // snapshot_finds_gtk_widgets et al.
+    std::thread::sleep(std::time::Duration::from_millis(3_000));
+    let tree = glass.a11y_snapshot(None).expect("snapshot");
+    glass.stop().expect("stop");
+
+    let seen: Vec<AxRole> = role_histogram(&tree).into_iter().map(|t| t.role).collect();
+    // A GTK4 Entry reports AT-SPI `Text`, so the fixture's text input is a `TextArea`, not a
+    // `TextField` — see the existing note on the set_value tests in this file.
+    for expected in [
+        AxRole::Window,
+        AxRole::Button,
+        AxRole::CheckBox,
+        AxRole::TextArea,
+        AxRole::Label,
+        AxRole::ComboBox,
+        AxRole::List,
+        AxRole::ListItem,
+        AxRole::Slider,
+        AxRole::SpinButton,
+        AxRole::ProgressBar,
+        AxRole::Separator,
+        AxRole::Toolbar,
+        AxRole::TabList,
+        AxRole::Tab,
+        AxRole::Link,
+    ] {
+        assert!(
+            seen.contains(&expected),
+            "fixture tree has no {expected:?}; roles seen: {seen:?}"
+        );
+    }
 }
 
 /// Regression guard for the private-bus portal-activation hang: launching a GtkApplication

--- a/crates/glass-a11y-macos/src/ffi.rs
+++ b/crates/glass-a11y-macos/src/ffi.rs
@@ -43,6 +43,7 @@ use glass_core::{GlassError, Result};
 pub(crate) mod attr {
     pub(crate) const VALUE: &str = "AXValue";
     pub(crate) const ROLE: &str = "AXRole";
+    pub(crate) const ROLE_DESCRIPTION: &str = "AXRoleDescription";
     pub(crate) const TITLE: &str = "AXTitle";
     pub(crate) const DESCRIPTION: &str = "AXDescription";
     pub(crate) const CHILDREN: &str = "AXChildren";

--- a/crates/glass-a11y-macos/src/ffi.rs
+++ b/crates/glass-a11y-macos/src/ffi.rs
@@ -43,7 +43,6 @@ use glass_core::{GlassError, Result};
 pub(crate) mod attr {
     pub(crate) const VALUE: &str = "AXValue";
     pub(crate) const ROLE: &str = "AXRole";
-    pub(crate) const ROLE_DESCRIPTION: &str = "AXRoleDescription";
     pub(crate) const TITLE: &str = "AXTitle";
     pub(crate) const DESCRIPTION: &str = "AXDescription";
     pub(crate) const CHILDREN: &str = "AXChildren";

--- a/crates/glass-a11y-macos/src/mapping.rs
+++ b/crates/glass-a11y-macos/src/mapping.rs
@@ -7,37 +7,43 @@
 
 use glass_core::{AxRole, AxStates};
 
+/// Every AX role string glass maps. AX role strings are canonical constants, so lookup is
+/// case-sensitive.
+pub const ROLE_TOKENS: &[(&str, AxRole)] = &[
+    ("AXButton", AxRole::Button),
+    ("AXCheckBox", AxRole::CheckBox),
+    ("AXRadioButton", AxRole::RadioButton),
+    ("AXRadioGroup", AxRole::Group),
+    ("AXTextField", AxRole::TextField),
+    ("AXTextArea", AxRole::TextArea),
+    ("AXStaticText", AxRole::Label),
+    ("AXWindow", AxRole::Window),
+    ("AXGroup", AxRole::Group),
+    ("AXMenu", AxRole::Menu),
+    ("AXMenuItem", AxRole::MenuItem),
+    ("AXMenuBar", AxRole::MenuBar),
+    ("AXImage", AxRole::Image),
+    ("AXLink", AxRole::Link),
+    ("AXSlider", AxRole::Slider),
+    ("AXComboBox", AxRole::ComboBox),
+    ("AXPopUpButton", AxRole::ComboBox),
+    ("AXList", AxRole::List),
+    ("AXRow", AxRole::ListItem),
+    ("AXCell", AxRole::Cell),
+    ("AXToolbar", AxRole::Toolbar),
+    ("AXTabGroup", AxRole::TabList),
+    ("AXProgressIndicator", AxRole::ProgressBar),
+    ("AXScrollBar", AxRole::ScrollBar),
+];
+
 /// Map an AX role string to the normalized `AxRole`; unmapped roles become
-/// `AxRole::Other` (the reader keeps the original string in `raw_role`). AX role
-/// strings are canonical, so the match is case-sensitive.
+/// `AxRole::Other` (the reader keeps the AX role string in `raw_role`).
 pub fn map_role(ax_role: &str) -> AxRole {
-    match ax_role {
-        "AXButton" => AxRole::Button,
-        "AXCheckBox" => AxRole::CheckBox,
-        "AXRadioButton" => AxRole::RadioButton,
-        "AXRadioGroup" => AxRole::Group,
-        "AXTextField" => AxRole::TextField,
-        "AXTextArea" => AxRole::TextArea,
-        "AXStaticText" => AxRole::Label,
-        "AXWindow" => AxRole::Window,
-        "AXGroup" => AxRole::Group,
-        "AXMenu" => AxRole::Menu,
-        "AXMenuItem" => AxRole::MenuItem,
-        "AXMenuBar" => AxRole::MenuBar,
-        "AXImage" => AxRole::Image,
-        "AXLink" => AxRole::Link,
-        "AXSlider" => AxRole::Slider,
-        "AXComboBox" => AxRole::ComboBox,
-        "AXPopUpButton" => AxRole::ComboBox,
-        "AXList" => AxRole::List,
-        "AXRow" => AxRole::ListItem,
-        "AXCell" => AxRole::Cell,
-        "AXToolbar" => AxRole::Toolbar,
-        "AXTabGroup" => AxRole::TabList,
-        "AXProgressIndicator" => AxRole::ProgressBar,
-        "AXScrollBar" => AxRole::ScrollBar,
-        _ => AxRole::Other,
-    }
+    ROLE_TOKENS
+        .iter()
+        .find(|(token, _)| *token == ax_role)
+        .map(|(_, role)| *role)
+        .unwrap_or(AxRole::Other)
 }
 
 /// Plain state facts the reader gathers from an AXUIElement (no objc2/AX types here, so
@@ -180,6 +186,33 @@ mod tests {
         let s = map_states(&f);
         assert!(s.visible && s.selected && s.checked && s.expanded);
         assert!(!s.enabled && !s.focused && !s.focusable && !s.editable);
+    }
+
+    #[test]
+    fn role_tokens_have_no_duplicate_strings() {
+        for (i, (token, _)) in ROLE_TOKENS.iter().enumerate() {
+            assert!(
+                !ROLE_TOKENS[i + 1..].iter().any(|(other, _)| other == token),
+                "{token} listed twice"
+            );
+        }
+    }
+
+    #[test]
+    fn map_matches_declared_column() {
+        use glass_core::role_support::{support, AxBackend, RoleSupport};
+        for role in AxRole::ALL {
+            let mapped = ROLE_TOKENS.iter().any(|(_, r)| *r == role);
+            match support(role, AxBackend::MacOs) {
+                RoleSupport::Mapped => {
+                    assert!(mapped, "{role:?} declared Mapped but no AX role maps to it")
+                }
+                RoleSupport::NotApplicable(_) | RoleSupport::Gap(_) => assert!(
+                    !mapped,
+                    "{role:?} is produced by an AX role but the matrix does not declare it"
+                ),
+            }
+        }
     }
 
     #[test]

--- a/crates/glass-a11y-macos/src/mapping.rs
+++ b/crates/glass-a11y-macos/src/mapping.rs
@@ -203,7 +203,7 @@ mod tests {
         use glass_core::role_support::{support, AxBackend, RoleSupport};
         for role in AxRole::ALL {
             let mapped = ROLE_TOKENS.iter().any(|(_, r)| *r == role);
-            match support(role, AxBackend::MacOs) {
+            match support(role, AxBackend::MacOs).expect("declared in ROLE_SUPPORT") {
                 RoleSupport::Mapped => {
                     assert!(mapped, "{role:?} declared Mapped but no AX role maps to it")
                 }

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -310,11 +310,12 @@ fn walk(
 
     let ax_role = ffi::attribute_string(el, attr::ROLE).unwrap_or_default();
     let role = mapping::map_role(&ax_role);
-    // `AXRoleDescription` is the human-readable role ("button", "text field"); fall back to the
-    // raw AX role string when it's absent. If both are absent (an element exposing neither)
-    // `raw_role` is the empty string — a "role unknown" signal, not a guaranteed-populated
-    // field.
-    let raw_role = ffi::attribute_string(el, attr::ROLE_DESCRIPTION).unwrap_or(ax_role);
+    // `raw_role` is the same AX role string `map_role` just matched on — the token, not
+    // `AXRoleDescription`'s localized human phrase ("button" / "bouton"), which is useless as
+    // a mapping key and not worth a second attribute read. Absent (an element exposing no
+    // `AXRole`) leaves it the empty string — a "role unknown" signal, not a guaranteed-
+    // populated field.
+    let raw_role = ax_role;
     // Name = title, else description — both stable labels (e.g. `setAccessibilityLabel`
     // surfaces as `AXDescription`). Never fold in `AXValue`: it's volatile content, and a
     // node's name must stay stable for the `AxTarget` fingerprint `set_value` relies on.

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -310,12 +310,21 @@ fn walk(
 
     let ax_role = ffi::attribute_string(el, attr::ROLE).unwrap_or_default();
     let role = mapping::map_role(&ax_role);
-    // `raw_role` is the same AX role string `map_role` just matched on — the token, not
-    // `AXRoleDescription`'s localized human phrase ("button" / "bouton"), which is useless as
-    // a mapping key and not worth a second attribute read. Absent (an element exposing no
-    // `AXRole`) leaves it the empty string — a "role unknown" signal, not a guaranteed-
-    // populated field.
-    let raw_role = ax_role;
+    // `raw_role` is normally the same AX role string `map_role` just matched on — the token, not
+    // `AXRoleDescription`'s localized human phrase ("button" / "bouton"), which is useless as a
+    // mapping key and not worth a second attribute read on every node.
+    //
+    // The fallback is conditional because that trade only holds while `AXRole` says something.
+    // A custom or non-standard control is expected to report a generic role — `AXUnknown`, or no
+    // `AXRole` at all — and put what distinguishes it in `AXRoleDescription`; there the
+    // description is the only descriptor there is, so read it rather than emit a node nothing
+    // can identify. Ordinary nodes never pay for the second read. If both are absent `raw_role`
+    // stays the empty string — a "role unknown" signal, not a guaranteed-populated field.
+    let raw_role = if ax_role.is_empty() || ax_role == "AXUnknown" {
+        ffi::attribute_string(el, attr::ROLE_DESCRIPTION).unwrap_or(ax_role)
+    } else {
+        ax_role
+    };
     // Name = title, else description — both stable labels (e.g. `setAccessibilityLabel`
     // surfaces as `AXDescription`). Never fold in `AXValue`: it's volatile content, and a
     // node's name must stay stable for the `AxTarget` fingerprint `set_value` relies on.

--- a/crates/glass-a11y-windows/src/mapping.rs
+++ b/crates/glass-a11y-windows/src/mapping.rs
@@ -5,42 +5,60 @@
 
 use glass_core::{AxRole, AxStates};
 
+/// Every UIA control type glass maps, as `(ControlTypeId, canonical name, role)`. The
+/// canonical name is the control type's documented English name — it is what the reader puts
+/// in `raw_role`, so an unmapped-but-known control type is still legible to a caller and
+/// identical on every machine, unlike UIA's localized control-type string.
+pub const ROLE_TOKENS: &[(u32, &str, AxRole)] = &[
+    (50000, "Button", AxRole::Button),
+    (50002, "CheckBox", AxRole::CheckBox),
+    (50003, "ComboBox", AxRole::ComboBox),
+    (50004, "Edit", AxRole::TextField),
+    (50005, "Hyperlink", AxRole::Link),
+    (50006, "Image", AxRole::Image),
+    (50007, "ListItem", AxRole::ListItem),
+    (50008, "List", AxRole::List),
+    (50009, "Menu", AxRole::Menu),
+    (50010, "MenuBar", AxRole::MenuBar),
+    (50011, "MenuItem", AxRole::MenuItem),
+    (50012, "ProgressBar", AxRole::ProgressBar),
+    (50013, "RadioButton", AxRole::RadioButton),
+    (50014, "ScrollBar", AxRole::ScrollBar),
+    (50015, "Slider", AxRole::Slider),
+    (50016, "Spinner", AxRole::SpinButton),
+    (50017, "StatusBar", AxRole::StatusBar),
+    (50018, "Tab", AxRole::TabList),
+    (50019, "TabItem", AxRole::Tab),
+    (50020, "Text", AxRole::Label),
+    (50021, "ToolBar", AxRole::Toolbar),
+    (50023, "Tree", AxRole::Tree),
+    (50024, "TreeItem", AxRole::TreeItem),
+    (50026, "Group", AxRole::Group),
+    (50028, "DataGrid", AxRole::Table),
+    // A split button is an actionable button carrying a dropdown.
+    (50031, "SplitButton", AxRole::Button),
+    (50032, "Window", AxRole::Window),
+    (50033, "Pane", AxRole::Group),
+    (50036, "Table", AxRole::Table),
+    (50038, "Separator", AxRole::Separator),
+];
+
 /// Map a UIA `ControlTypeId` to the normalized `AxRole`; unmapped ids become
-/// `AxRole::Other` (the reader keeps the localized control-type name in `raw_role`).
+/// `AxRole::Other` (the reader keeps the canonical control-type name in `raw_role`).
 pub fn map_role(control_type_id: u32) -> AxRole {
-    match control_type_id {
-        50000 => AxRole::Button,
-        50002 => AxRole::CheckBox,
-        50003 => AxRole::ComboBox,
-        50004 => AxRole::TextField, // Edit
-        50005 => AxRole::Link,      // Hyperlink
-        50006 => AxRole::Image,
-        50007 => AxRole::ListItem,
-        50008 => AxRole::List,
-        50009 => AxRole::Menu,
-        50010 => AxRole::MenuBar,
-        50011 => AxRole::MenuItem,
-        50012 => AxRole::ProgressBar,
-        50013 => AxRole::RadioButton,
-        50014 => AxRole::ScrollBar,
-        50015 => AxRole::Slider,
-        50016 => AxRole::SpinButton,
-        50017 => AxRole::StatusBar,
-        50018 => AxRole::TabList, // Tab
-        50019 => AxRole::Tab,     // TabItem
-        50020 => AxRole::Label,   // Text
-        50021 => AxRole::Toolbar,
-        50023 => AxRole::Tree,
-        50024 => AxRole::TreeItem,
-        50026 => AxRole::Group,
-        50028 => AxRole::Table,  // DataGrid
-        50031 => AxRole::Button, // SplitButton — an actionable button with a dropdown
-        50032 => AxRole::Window,
-        50033 => AxRole::Group, // Pane
-        50036 => AxRole::Table,
-        50038 => AxRole::Separator,
-        _ => AxRole::Other,
-    }
+    ROLE_TOKENS
+        .iter()
+        .find(|(id, _, _)| *id == control_type_id)
+        .map(|(_, _, role)| *role)
+        .unwrap_or(AxRole::Other)
+}
+
+/// The control type's canonical English name, or `None` for an id glass does not know.
+pub fn canonical_name(control_type_id: u32) -> Option<&'static str> {
+    ROLE_TOKENS
+        .iter()
+        .find(|(id, _, _)| *id == control_type_id)
+        .map(|(_, name, _)| *name)
 }
 
 /// Plain state facts the reader gathers from a UIA element (no `uiautomation` types here,
@@ -160,5 +178,43 @@ mod tests {
         assert_eq!(format_range_value(100.0), "100");
         assert_eq!(format_range_value(50.5), "50.5");
         assert_eq!(format_range_value(-3.0), "-3");
+    }
+
+    #[test]
+    fn role_tokens_have_no_duplicate_ids() {
+        for (i, (id, _, _)) in ROLE_TOKENS.iter().enumerate() {
+            assert!(
+                !ROLE_TOKENS[i + 1..].iter().any(|(other, _, _)| other == id),
+                "control type {id} listed twice"
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_name_is_stable_and_locale_free() {
+        assert_eq!(canonical_name(50000), Some("Button"));
+        assert_eq!(canonical_name(50036), Some("Table"));
+        assert_eq!(canonical_name(49999), None);
+    }
+
+    #[test]
+    fn map_matches_declared_column() {
+        use glass_core::role_support::{support, AxBackend, RoleSupport};
+        use glass_core::AxRole;
+        for role in AxRole::ALL {
+            let mapped = ROLE_TOKENS.iter().any(|(_, _, r)| *r == role);
+            match support(role, AxBackend::Windows) {
+                RoleSupport::Mapped => {
+                    assert!(
+                        mapped,
+                        "{role:?} declared Mapped but no control type maps to it"
+                    )
+                }
+                RoleSupport::NotApplicable(_) | RoleSupport::Gap(_) => assert!(
+                    !mapped,
+                    "{role:?} is produced by a control type but the matrix does not declare it"
+                ),
+            }
+        }
     }
 }

--- a/crates/glass-a11y-windows/src/mapping.rs
+++ b/crates/glass-a11y-windows/src/mapping.rs
@@ -5,60 +5,83 @@
 
 use glass_core::{AxRole, AxStates};
 
-/// Every UIA control type glass maps, as `(ControlTypeId, canonical name, role)`. The
-/// canonical name is the control type's documented English name — it is what the reader puts
-/// in `raw_role`, so an unmapped-but-known control type is still legible to a caller and
-/// identical on every machine, unlike UIA's localized control-type string.
-pub const ROLE_TOKENS: &[(u32, &str, AxRole)] = &[
-    (50000, "Button", AxRole::Button),
-    (50002, "CheckBox", AxRole::CheckBox),
-    (50003, "ComboBox", AxRole::ComboBox),
-    (50004, "Edit", AxRole::TextField),
-    (50005, "Hyperlink", AxRole::Link),
-    (50006, "Image", AxRole::Image),
-    (50007, "ListItem", AxRole::ListItem),
-    (50008, "List", AxRole::List),
-    (50009, "Menu", AxRole::Menu),
-    (50010, "MenuBar", AxRole::MenuBar),
-    (50011, "MenuItem", AxRole::MenuItem),
-    (50012, "ProgressBar", AxRole::ProgressBar),
-    (50013, "RadioButton", AxRole::RadioButton),
-    (50014, "ScrollBar", AxRole::ScrollBar),
-    (50015, "Slider", AxRole::Slider),
-    (50016, "Spinner", AxRole::SpinButton),
-    (50017, "StatusBar", AxRole::StatusBar),
-    (50018, "Tab", AxRole::TabList),
-    (50019, "TabItem", AxRole::Tab),
-    (50020, "Text", AxRole::Label),
-    (50021, "ToolBar", AxRole::Toolbar),
-    (50023, "Tree", AxRole::Tree),
-    (50024, "TreeItem", AxRole::TreeItem),
-    (50026, "Group", AxRole::Group),
-    (50028, "DataGrid", AxRole::Table),
+/// Every documented UIA control type (the contiguous 50000..=50040 range), as
+/// `(ControlTypeId, canonical name, mapped role)`.
+///
+/// The canonical name is the control type's documented English name — it is what the reader puts
+/// in `raw_role`, identical on every machine, unlike UIA's localized control-type string. Every
+/// documented id is listed, so a control type glass does *not* map to a role still reads as e.g.
+/// `DataItem` rather than a bare number; only a vendor-defined or future id falls through to the
+/// reader's numeric `UIA:<id>` form.
+///
+/// The role is `Some` only where glass maps the control type today; `None` means the node gets
+/// [`AxRole::Other`] and is identified by its name alone.
+pub const CONTROL_TYPES: &[(u32, &str, Option<AxRole>)] = &[
+    (50000, "Button", Some(AxRole::Button)),
+    (50001, "Calendar", None),
+    (50002, "CheckBox", Some(AxRole::CheckBox)),
+    (50003, "ComboBox", Some(AxRole::ComboBox)),
+    (50004, "Edit", Some(AxRole::TextField)),
+    (50005, "Hyperlink", Some(AxRole::Link)),
+    (50006, "Image", Some(AxRole::Image)),
+    (50007, "ListItem", Some(AxRole::ListItem)),
+    (50008, "List", Some(AxRole::List)),
+    (50009, "Menu", Some(AxRole::Menu)),
+    (50010, "MenuBar", Some(AxRole::MenuBar)),
+    (50011, "MenuItem", Some(AxRole::MenuItem)),
+    (50012, "ProgressBar", Some(AxRole::ProgressBar)),
+    (50013, "RadioButton", Some(AxRole::RadioButton)),
+    (50014, "ScrollBar", Some(AxRole::ScrollBar)),
+    (50015, "Slider", Some(AxRole::Slider)),
+    (50016, "Spinner", Some(AxRole::SpinButton)),
+    (50017, "StatusBar", Some(AxRole::StatusBar)),
+    (50018, "Tab", Some(AxRole::TabList)),
+    (50019, "TabItem", Some(AxRole::Tab)),
+    (50020, "Text", Some(AxRole::Label)),
+    (50021, "ToolBar", Some(AxRole::Toolbar)),
+    (50022, "ToolTip", None),
+    (50023, "Tree", Some(AxRole::Tree)),
+    (50024, "TreeItem", Some(AxRole::TreeItem)),
+    (50025, "Custom", None),
+    (50026, "Group", Some(AxRole::Group)),
+    (50027, "Thumb", None),
+    (50028, "DataGrid", Some(AxRole::Table)),
+    (50029, "DataItem", None),
+    (50030, "Document", None),
     // A split button is an actionable button carrying a dropdown.
-    (50031, "SplitButton", AxRole::Button),
-    (50032, "Window", AxRole::Window),
-    (50033, "Pane", AxRole::Group),
-    (50036, "Table", AxRole::Table),
-    (50038, "Separator", AxRole::Separator),
+    (50031, "SplitButton", Some(AxRole::Button)),
+    (50032, "Window", Some(AxRole::Window)),
+    (50033, "Pane", Some(AxRole::Group)),
+    (50034, "Header", None),
+    (50035, "HeaderItem", None),
+    (50036, "Table", Some(AxRole::Table)),
+    (50037, "TitleBar", None),
+    (50038, "Separator", Some(AxRole::Separator)),
+    (50039, "SemanticZoom", None),
+    (50040, "AppBar", None),
 ];
 
-/// Map a UIA `ControlTypeId` to the normalized `AxRole`; unmapped ids become
-/// `AxRole::Other` (the reader keeps the canonical control-type name in `raw_role`).
-pub fn map_role(control_type_id: u32) -> AxRole {
-    ROLE_TOKENS
+/// The [`CONTROL_TYPES`] row for an id, shared by [`map_role`] and [`canonical_name`] so the two
+/// can never disagree about which ids are known.
+fn control_type(control_type_id: u32) -> Option<&'static (u32, &'static str, Option<AxRole>)> {
+    CONTROL_TYPES
         .iter()
         .find(|(id, _, _)| *id == control_type_id)
-        .map(|(_, _, role)| *role)
+}
+
+/// Map a UIA `ControlTypeId` to the normalized `AxRole`; a control type glass does not map —
+/// known or not — becomes `AxRole::Other` (the reader keeps the control type's name in
+/// `raw_role`).
+pub fn map_role(control_type_id: u32) -> AxRole {
+    control_type(control_type_id)
+        .and_then(|(_, _, role)| *role)
         .unwrap_or(AxRole::Other)
 }
 
-/// The control type's canonical English name, or `None` for an id glass does not know.
+/// The control type's canonical English name, or `None` for an id outside the documented range
+/// (a vendor-defined or future control type).
 pub fn canonical_name(control_type_id: u32) -> Option<&'static str> {
-    ROLE_TOKENS
-        .iter()
-        .find(|(id, _, _)| *id == control_type_id)
-        .map(|(_, name, _)| *name)
+    control_type(control_type_id).map(|(_, name, _)| *name)
 }
 
 /// Plain state facts the reader gathers from a UIA element (no `uiautomation` types here,
@@ -181,13 +204,28 @@ mod tests {
     }
 
     #[test]
-    fn role_tokens_have_no_duplicate_ids() {
-        for (i, (id, _, _)) in ROLE_TOKENS.iter().enumerate() {
+    fn control_types_have_no_duplicate_ids() {
+        for (i, (id, _, _)) in CONTROL_TYPES.iter().enumerate() {
             assert!(
-                !ROLE_TOKENS[i + 1..].iter().any(|(other, _, _)| other == id),
+                !CONTROL_TYPES[i + 1..]
+                    .iter()
+                    .any(|(other, _, _)| other == id),
                 "control type {id} listed twice"
             );
         }
+    }
+
+    #[test]
+    fn every_documented_control_type_is_listed() {
+        // The documented range is contiguous; a hole would mean a real control type reporting
+        // as an opaque number.
+        for id in 50000..=50040u32 {
+            assert!(
+                canonical_name(id).is_some(),
+                "control type {id} has no name"
+            );
+        }
+        assert_eq!(CONTROL_TYPES.len(), 41);
     }
 
     #[test]
@@ -195,6 +233,19 @@ mod tests {
         assert_eq!(canonical_name(50000), Some("Button"));
         assert_eq!(canonical_name(50036), Some("Table"));
         assert_eq!(canonical_name(49999), None);
+        assert_eq!(canonical_name(50041), None);
+    }
+
+    #[test]
+    fn a_known_but_unmapped_control_type_still_has_a_name() {
+        // These are exactly the ids the role-support matrix's Windows gaps point at, and what
+        // a probe run has to read; reporting them as `UIA:50029` would defeat that.
+        assert_eq!(canonical_name(50029), Some("DataItem"));
+        assert_eq!(canonical_name(50030), Some("Document"));
+        assert_eq!(canonical_name(50034), Some("Header"));
+        assert_eq!(map_role(50029), AxRole::Other);
+        assert_eq!(map_role(50030), AxRole::Other);
+        assert_eq!(map_role(50034), AxRole::Other);
     }
 
     #[test]
@@ -202,7 +253,9 @@ mod tests {
         use glass_core::role_support::{support, AxBackend, RoleSupport};
         use glass_core::AxRole;
         for role in AxRole::ALL {
-            let mapped = ROLE_TOKENS.iter().any(|(_, _, r)| *r == role);
+            // Only a row carrying `Some(role)` produces a role; a named-but-unmapped control
+            // type yields `Other` and must not count as coverage.
+            let mapped = CONTROL_TYPES.iter().any(|(_, _, r)| *r == Some(role));
             match support(role, AxBackend::Windows).expect("declared in ROLE_SUPPORT") {
                 RoleSupport::Mapped => {
                     assert!(

--- a/crates/glass-a11y-windows/src/mapping.rs
+++ b/crates/glass-a11y-windows/src/mapping.rs
@@ -203,7 +203,7 @@ mod tests {
         use glass_core::AxRole;
         for role in AxRole::ALL {
             let mapped = ROLE_TOKENS.iter().any(|(_, _, r)| *r == role);
-            match support(role, AxBackend::Windows) {
+            match support(role, AxBackend::Windows).expect("declared in ROLE_SUPPORT") {
                 RoleSupport::Mapped => {
                     assert!(
                         mapped,

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -143,7 +143,9 @@ fn walk(
 ) -> Result<AxNode> {
     budget.visit();
     let ct_id = el.get_control_type().map_err(uia_err)? as i32 as u32;
-    let raw_role = el.get_localized_control_type().unwrap_or_default();
+    let raw_role = crate::mapping::canonical_name(ct_id)
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("UIA:{ct_id}"));
     let name = nonempty(el.get_name().unwrap_or_default());
     let bounds = window_relative_bounds(el, origin);
     let (facts, value) = gather(el, ct_id);

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -143,6 +143,8 @@ fn walk(
 ) -> Result<AxNode> {
     budget.visit();
     let ct_id = el.get_control_type().map_err(uia_err)? as i32 as u32;
+    // `canonical_name` knows every documented control type, mapped or not, so the numeric form
+    // is reached only by a vendor-defined or future id — still reported, never dropped.
     let raw_role = crate::mapping::canonical_name(ct_id)
         .map(str::to_string)
         .unwrap_or_else(|| format!("UIA:{ct_id}"));

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -465,7 +465,7 @@ mod tests {
                 // which comes from `class_to_role` like any other node. Exempt Window since
                 // `class_to_role` cannot produce it.
                 || role == AxRole::Window;
-            match support(role, AxBackend::Android) {
+            match support(role, AxBackend::Android).expect("declared in ROLE_SUPPORT") {
                 RoleSupport::Mapped => {
                     assert!(mapped, "{role:?} declared Mapped but no class maps to it")
                 }

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -5,36 +5,58 @@ use glass_core::accessibility::{
 };
 use glass_core::{GlassError, Result, WindowGeometry};
 
+/// Every Android widget class glass maps, keyed by the leaf of the class name
+/// (`android.widget.Button` → `Button`). Multiple vendor classes share one role.
+pub const CLASS_TOKENS: &[(&str, AxRole)] = &[
+    ("Button", AxRole::Button),
+    ("ImageButton", AxRole::Button),
+    ("MaterialButton", AxRole::Button),
+    ("AppCompatButton", AxRole::Button),
+    ("EditText", AxRole::TextField),
+    ("AppCompatEditText", AxRole::TextField),
+    ("AutoCompleteTextView", AxRole::TextField),
+    ("TextInputEditText", AxRole::TextField),
+    ("CheckBox", AxRole::CheckBox),
+    ("AppCompatCheckBox", AxRole::CheckBox),
+    ("CheckedTextView", AxRole::CheckBox),
+    ("RadioButton", AxRole::RadioButton),
+    ("AppCompatRadioButton", AxRole::RadioButton),
+    ("Switch", AxRole::ToggleButton),
+    ("SwitchCompat", AxRole::ToggleButton),
+    ("SwitchMaterial", AxRole::ToggleButton),
+    ("ToggleButton", AxRole::ToggleButton),
+    ("CompoundButton", AxRole::ToggleButton),
+    ("TextView", AxRole::Label),
+    ("AppCompatTextView", AxRole::Label),
+    ("ImageView", AxRole::Image),
+    ("AppCompatImageView", AxRole::Image),
+    ("Spinner", AxRole::ComboBox),
+    ("SeekBar", AxRole::Slider),
+    ("ProgressBar", AxRole::ProgressBar),
+    ("ScrollView", AxRole::List),
+    ("HorizontalScrollView", AxRole::List),
+    ("NestedScrollView", AxRole::List),
+    ("RecyclerView", AxRole::List),
+    ("ListView", AxRole::List),
+    ("GridView", AxRole::List),
+    ("WebView", AxRole::Group),
+];
+
+/// Roles reachable only through the container rule in [`class_to_role`] (any leaf ending in
+/// `Layout`, plus `View`/`ViewGroup`), which no fixed token list can express.
+#[allow(dead_code)]
+pub const RULE_ROLES: &[AxRole] = &[AxRole::Group];
+
 /// Map an Android widget class (`android.widget.Button`, …) to a normalized role.
 pub fn class_to_role(class: &str) -> AxRole {
     let leaf = class.rsplit('.').next().unwrap_or(class);
-    match leaf {
-        "Button" | "ImageButton" | "MaterialButton" | "AppCompatButton" => AxRole::Button,
-        "EditText" | "AppCompatEditText" | "AutoCompleteTextView" | "TextInputEditText" => {
-            AxRole::TextField
-        }
-        "CheckBox" | "AppCompatCheckBox" | "CheckedTextView" => AxRole::CheckBox,
-        "RadioButton" | "AppCompatRadioButton" => AxRole::RadioButton,
-        "Switch" | "SwitchCompat" | "SwitchMaterial" | "ToggleButton" | "CompoundButton" => {
-            AxRole::ToggleButton
-        }
-        "TextView" | "AppCompatTextView" => AxRole::Label,
-        "ImageView" | "AppCompatImageView" => AxRole::Image,
-        "Spinner" => AxRole::ComboBox,
-        "SeekBar" => AxRole::Slider,
-        "ProgressBar" => AxRole::ProgressBar,
-        "ScrollView"
-        | "HorizontalScrollView"
-        | "NestedScrollView"
-        | "RecyclerView"
-        | "ListView"
-        | "GridView" => AxRole::List,
-        "WebView" => AxRole::Group,
-        other if other.ends_with("Layout") || other == "View" || other == "ViewGroup" => {
-            AxRole::Group
-        }
-        _ => AxRole::Other,
+    if let Some((_, role)) = CLASS_TOKENS.iter().find(|(token, _)| *token == leaf) {
+        return *role;
     }
+    if leaf.ends_with("Layout") || leaf == "View" || leaf == "ViewGroup" {
+        return AxRole::Group;
+    }
+    AxRole::Other
 }
 
 /// Parse uiautomator `bounds="[l,t][r,b]"` (screen-absolute) into a window-relative `AxRect`.
@@ -412,5 +434,43 @@ mod tests {
             "checkable=false checked=true (Compose under-report) must still map to \
              checkable=true so the Checked condition matches"
         );
+    }
+
+    #[test]
+    fn class_tokens_have_no_duplicates() {
+        for (i, (leaf, _)) in CLASS_TOKENS.iter().enumerate() {
+            assert!(
+                !CLASS_TOKENS[i + 1..].iter().any(|(other, _)| other == leaf),
+                "{leaf} listed twice"
+            );
+        }
+    }
+
+    #[test]
+    fn container_rule_still_applies() {
+        assert_eq!(class_to_role("android.widget.LinearLayout"), AxRole::Group);
+        assert_eq!(class_to_role("android.view.ViewGroup"), AxRole::Group);
+        assert_eq!(class_to_role("com.example.CustomThing"), AxRole::Other);
+    }
+
+    #[test]
+    fn map_matches_declared_column() {
+        use glass_core::role_support::{support, AxBackend, RoleSupport};
+        for role in AxRole::ALL {
+            let mapped = CLASS_TOKENS.iter().any(|(_, r)| *r == role)
+                || RULE_ROLES.contains(&role)
+                // The tree root is synthesized as a window by `AxTree` construction, not by
+                // a class name.
+                || role == AxRole::Window;
+            match support(role, AxBackend::Android) {
+                RoleSupport::Mapped => {
+                    assert!(mapped, "{role:?} declared Mapped but no class maps to it")
+                }
+                RoleSupport::NotApplicable(_) | RoleSupport::Gap(_) => assert!(
+                    !mapped,
+                    "{role:?} is produced by a class but the matrix does not declare it"
+                ),
+            }
+        }
     }
 }

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -42,8 +42,9 @@ pub const CLASS_TOKENS: &[(&str, AxRole)] = &[
     ("WebView", AxRole::Group),
 ];
 
-/// Roles reachable only through the container rule in [`class_to_role`] (any leaf ending in
-/// `Layout`, plus `View`/`ViewGroup`), which no fixed token list can express.
+/// Roles the container rule in [`class_to_role`] can produce (any leaf ending in `Layout`,
+/// plus `View`/`ViewGroup`). These roles cannot be expressed as a fixed token list, so the
+/// column test counts them to verify full role support coverage.
 #[allow(dead_code)]
 pub const RULE_ROLES: &[AxRole] = &[AxRole::Group];
 
@@ -459,8 +460,10 @@ mod tests {
         for role in AxRole::ALL {
             let mapped = CLASS_TOKENS.iter().any(|(_, r)| *r == role)
                 || RULE_ROLES.contains(&role)
-                // The tree root is synthesized as a window by `AxTree` construction, not by
-                // a class name.
+                // Only the uiautomator reader (`build_tree`) synthesizes a Window root; the
+                // on-device AccessibilityService reader roots the tree at the device's node,
+                // which comes from `class_to_role` like any other node. Exempt Window since
+                // `class_to_role` cannot produce it.
                 || role == AxRole::Window;
             match support(role, AxBackend::Android) {
                 RoleSupport::Mapped => {

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -5,8 +5,11 @@ use glass_core::accessibility::{
 };
 use glass_core::{GlassError, Result, WindowGeometry};
 
-/// Every Android widget class glass maps, keyed by the leaf of the class name
+/// The Android widget classes glass maps *by name*, keyed by the leaf of the class name
 /// (`android.widget.Button` → `Button`). Multiple vendor classes share one role.
+///
+/// Not the whole map: [`class_to_role`] also has a container rule, which catches any leaf ending
+/// in `Layout` plus `View`/`ViewGroup` — an open-ended set no table can enumerate.
 pub const CLASS_TOKENS: &[(&str, AxRole)] = &[
     ("Button", AxRole::Button),
     ("ImageButton", AxRole::Button),
@@ -41,12 +44,6 @@ pub const CLASS_TOKENS: &[(&str, AxRole)] = &[
     ("GridView", AxRole::List),
     ("WebView", AxRole::Group),
 ];
-
-/// Roles the container rule in [`class_to_role`] can produce (any leaf ending in `Layout`,
-/// plus `View`/`ViewGroup`). These roles cannot be expressed as a fixed token list, so the
-/// column test counts them to verify full role support coverage.
-#[allow(dead_code)]
-pub const RULE_ROLES: &[AxRole] = &[AxRole::Group];
 
 /// Map an Android widget class (`android.widget.Button`, …) to a normalized role.
 pub fn class_to_role(class: &str) -> AxRole {
@@ -233,6 +230,12 @@ mod tests {
     use super::*;
     use glass_core::accessibility::AxRole;
     use glass_core::{GlassError, WindowGeometry};
+
+    /// Roles the container rule in [`class_to_role`] can produce (any leaf ending in `Layout`,
+    /// plus `View`/`ViewGroup`). They cannot be expressed as a fixed token list, so
+    /// [`map_matches_declared_column`] counts them alongside [`CLASS_TOKENS`] to check the
+    /// declared column against everything the map can actually produce.
+    const RULE_ROLES: &[AxRole] = &[AxRole::Group];
 
     const XML: &str = concat!(
         "<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>",

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -90,6 +90,53 @@ impl AxRole {
         AxRole::Heading,
     ];
 
+    /// Compile-time guard for [`AxRole::ALL`] — never called, and exists only for its exhaustive
+    /// match. The role-parity tests and [`crate::role_support::ROLE_SUPPORT`] quantify their
+    /// completeness claims over `ALL`, so a new variant missing from it would silently weaken
+    /// every one of them; this match stops compiling until the variant is classified — listed in
+    /// the first arm and in `ALL`, or in the second arm as a deliberate exclusion.
+    #[expect(dead_code, reason = "exists only for its exhaustive match")]
+    fn all_is_exhaustive(role: AxRole) {
+        match role {
+            AxRole::Application
+            | AxRole::Window
+            | AxRole::Dialog
+            | AxRole::Group
+            | AxRole::Button
+            | AxRole::ToggleButton
+            | AxRole::RadioButton
+            | AxRole::CheckBox
+            | AxRole::MenuBar
+            | AxRole::Menu
+            | AxRole::MenuItem
+            | AxRole::Label
+            | AxRole::TextField
+            | AxRole::TextArea
+            | AxRole::ComboBox
+            | AxRole::List
+            | AxRole::ListItem
+            | AxRole::Table
+            | AxRole::Cell
+            | AxRole::Tree
+            | AxRole::TreeItem
+            | AxRole::TabList
+            | AxRole::Tab
+            | AxRole::ScrollBar
+            | AxRole::Slider
+            | AxRole::SpinButton
+            | AxRole::ProgressBar
+            | AxRole::Image
+            | AxRole::Link
+            | AxRole::Separator
+            | AxRole::Toolbar
+            | AxRole::StatusBar
+            | AxRole::Heading => {}
+            // Deliberately excluded from `ALL`: the sink for unmapped native tokens, not a
+            // mapping target.
+            AxRole::Other => {}
+        }
+    }
+
     /// Whether this role denotes an element a user acts on (clicks / types into) —
     /// the elements worth a Set-of-Mark number. Containers, the window, and static
     /// text return `false`.

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -51,6 +51,45 @@ pub enum AxRole {
 }
 
 impl AxRole {
+    /// Every role except [`AxRole::Other`], which is the sink for unmapped native tokens
+    /// rather than a mapping target. Used by the per-backend role-parity tests and by
+    /// [`crate::role_support::ROLE_SUPPORT`].
+    pub const ALL: [AxRole; 33] = [
+        AxRole::Application,
+        AxRole::Window,
+        AxRole::Dialog,
+        AxRole::Group,
+        AxRole::Button,
+        AxRole::ToggleButton,
+        AxRole::RadioButton,
+        AxRole::CheckBox,
+        AxRole::MenuBar,
+        AxRole::Menu,
+        AxRole::MenuItem,
+        AxRole::Label,
+        AxRole::TextField,
+        AxRole::TextArea,
+        AxRole::ComboBox,
+        AxRole::List,
+        AxRole::ListItem,
+        AxRole::Table,
+        AxRole::Cell,
+        AxRole::Tree,
+        AxRole::TreeItem,
+        AxRole::TabList,
+        AxRole::Tab,
+        AxRole::ScrollBar,
+        AxRole::Slider,
+        AxRole::SpinButton,
+        AxRole::ProgressBar,
+        AxRole::Image,
+        AxRole::Link,
+        AxRole::Separator,
+        AxRole::Toolbar,
+        AxRole::StatusBar,
+        AxRole::Heading,
+    ];
+
     /// Whether this role denotes an element a user acts on (clicks / types into) —
     /// the elements worth a Set-of-Mark number. Containers, the window, and static
     /// text return `false`.

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -81,6 +81,9 @@ pub mod outline;
 
 pub mod role_support;
 
+pub mod role_histogram;
+pub use role_histogram::{role_histogram, RoleTally};
+
 pub mod audit;
 pub use audit::{Actuation, ActuationContext, AuditOutcome, AuditSink, ElementRef, WindowRef};
 

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -79,6 +79,9 @@ pub use marks::Mark;
 
 pub mod outline;
 
+pub mod role_support;
+pub use role_support::{support, AxBackend, RoleSupport, ROLE_SUPPORT};
+
 pub mod audit;
 pub use audit::{Actuation, ActuationContext, AuditOutcome, AuditSink, ElementRef, WindowRef};
 

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -80,7 +80,6 @@ pub use marks::Mark;
 pub mod outline;
 
 pub mod role_support;
-pub use role_support::{support, AxBackend, RoleSupport, ROLE_SUPPORT};
 
 pub mod audit;
 pub use audit::{Actuation, ActuationContext, AuditOutcome, AuditSink, ElementRef, WindowRef};

--- a/crates/glass-core/src/outline.rs
+++ b/crates/glass-core/src/outline.rs
@@ -40,11 +40,21 @@ fn is_scaffolding(node: &AxNode) -> bool {
 /// Write one node's line: `#<id> <Role> "<name>" (<x>,<y> <w>x<h>) [<states>]`, name/bounds/
 /// states elided when absent, two spaces of indent per depth level.
 ///
+/// A node glass has no role mapping for renders as `Other(<native token>)` — the AT-SPI role,
+/// UIA control-type name, AX role string, Android widget class or iOS role string the backend
+/// reported. A bare `Other` therefore means the backend named no token at all, not that glass
+/// dropped one. `role:` selectors still will not match either.
+///
 /// Shared by [`AxTree::to_outline`] and [`render_compact`] so the two renders cannot drift —
 /// a test asserts they are identical for a tree with nothing to elide.
 pub(crate) fn write_line(node: &AxNode, depth: usize, out: &mut String) {
     let indent = "  ".repeat(depth);
-    let _ = write!(out, "{indent}#{} {:?}", node.id.0, node.role);
+    let _ = write!(out, "{indent}#{}", node.id.0);
+    if node.role == AxRole::Other && !node.raw_role.is_empty() {
+        let _ = write!(out, " Other({})", node.raw_role);
+    } else {
+        let _ = write!(out, " {:?}", node.role);
+    }
     if let Some(name) = &node.name {
         let _ = write!(out, " {name:?}");
     }
@@ -245,6 +255,54 @@ mod tests {
             !render_compact(&t).contains("truncated"),
             "render_compact is pure tree text now"
         );
+    }
+
+    #[test]
+    fn an_unmapped_node_renders_its_native_token() {
+        // The whole point of keeping `raw_role`: an element glass has no role for is still
+        // identifiable by the token the platform reported.
+        let mut n = node(AxRole::Other, Some("Details"));
+        n.raw_role = "AXDisclosureTriangle".into();
+        n.states = AxStates {
+            enabled: true,
+            ..AxStates::default()
+        };
+        let out = render_compact(&tree_of(n));
+        assert!(
+            out.contains("Other(AXDisclosureTriangle) \"Details\" [enabled]"),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn an_unmapped_node_without_a_token_stays_a_bare_other() {
+        let mut n = node(AxRole::Other, Some("Mystery"));
+        n.states = AxStates {
+            focusable: true,
+            ..AxStates::default()
+        };
+        let out = render_compact(&tree_of(n));
+        assert!(out.contains("Other \"Mystery\""), "{out}");
+    }
+
+    #[test]
+    fn a_mapped_role_never_shows_its_native_token() {
+        // Only `Other` carries the token; every other role renders exactly as before.
+        let mut b = node(AxRole::Button, Some("Save"));
+        b.raw_role = "AXButton".into();
+        let out = render_compact(&tree_of(b));
+        assert!(out.contains("Button \"Save\""), "{out}");
+        assert!(!out.contains("AXButton"), "{out}");
+    }
+
+    #[test]
+    fn the_full_and_compact_renders_agree_on_an_unmapped_node() {
+        // `to_outline` and `render_compact` share `write_line`; this pins that they stay
+        // consistent for the token-carrying line specifically.
+        let mut n = node(AxRole::Other, Some("Details"));
+        n.raw_role = "AXDisclosureTriangle".into();
+        let t = tree_of(n);
+        assert_eq!(render_compact(&t), t.to_outline());
     }
 
     #[test]

--- a/crates/glass-core/src/role_histogram.rs
+++ b/crates/glass-core/src/role_histogram.rs
@@ -1,0 +1,133 @@
+//! Tally an accessibility tree by native token — the evidence behind a role mapping.
+//!
+//! Every node keeps the backend's own token in [`AxNode::raw_role`]; anything the backend
+//! does not map shows up as [`AxRole::Other`]. Counting `(token, role)` pairs over a real
+//! app's tree answers two questions at once: which tokens an app actually emits, and which
+//! of them glass still ignores.
+
+use crate::accessibility::{AxNode, AxRole, AxTree};
+
+/// One `(native token, mapped role)` bucket and how often it occurred.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RoleTally {
+    /// The backend's native token, as carried in [`AxNode::raw_role`].
+    pub raw_role: String,
+    /// The role that token produced.
+    pub role: AxRole,
+    /// Number of nodes in the tree with this exact pair.
+    pub count: usize,
+}
+
+/// Tally every node by `(raw_role, role)`.
+///
+/// Unmapped buckets ([`AxRole::Other`]) come first — they are what a probe run is looking for
+/// — then buckets by descending count, then by token. The order is total, so two runs of the
+/// same app diff cleanly.
+pub fn role_histogram(tree: &AxTree) -> Vec<RoleTally> {
+    let mut tallies: Vec<RoleTally> = Vec::new();
+    visit(&tree.root, &mut tallies);
+    tallies.sort_by(|a, b| {
+        let unmapped = |t: &RoleTally| t.role != AxRole::Other;
+        unmapped(a)
+            .cmp(&unmapped(b))
+            .then(b.count.cmp(&a.count))
+            .then(a.raw_role.cmp(&b.raw_role))
+            .then(format!("{:?}", a.role).cmp(&format!("{:?}", b.role)))
+    });
+    tallies
+}
+
+fn visit(node: &AxNode, tallies: &mut Vec<RoleTally>) {
+    match tallies
+        .iter_mut()
+        .find(|t| t.role == node.role && t.raw_role == node.raw_role)
+    {
+        Some(t) => t.count += 1,
+        None => tallies.push(RoleTally {
+            raw_role: node.raw_role.clone(),
+            role: node.role,
+            count: 1,
+        }),
+    }
+    for child in &node.children {
+        visit(child, tallies);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::accessibility::{AxNode, AxNodeId, AxStates};
+
+    fn node(raw: &str, role: AxRole, children: Vec<AxNode>) -> AxNode {
+        AxNode {
+            id: AxNodeId(0),
+            role,
+            raw_role: raw.to_string(),
+            name: None,
+            value: None,
+            states: AxStates::default(),
+            bounds: None,
+            children,
+        }
+    }
+
+    #[test]
+    fn tallies_tokens_with_unmapped_first_then_by_count() {
+        let tree = AxTree::new(node(
+            "window",
+            AxRole::Window,
+            vec![
+                node("push button", AxRole::Button, vec![]),
+                node("push button", AxRole::Button, vec![]),
+                node("ruler", AxRole::Other, vec![]),
+                node("push button", AxRole::Button, vec![]),
+            ],
+        ));
+        let h = role_histogram(&tree);
+        assert_eq!(
+            h,
+            vec![
+                RoleTally {
+                    raw_role: "ruler".into(),
+                    role: AxRole::Other,
+                    count: 1
+                },
+                RoleTally {
+                    raw_role: "push button".into(),
+                    role: AxRole::Button,
+                    count: 3
+                },
+                RoleTally {
+                    raw_role: "window".into(),
+                    role: AxRole::Window,
+                    count: 1
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn same_token_mapping_two_ways_gets_two_buckets() {
+        // A backend may key on more than the token alone (a control type plus a pattern, a
+        // role plus a subrole), so one token can legitimately produce two roles.
+        let tree = AxTree::new(node(
+            "root",
+            AxRole::Window,
+            vec![
+                node("row", AxRole::ListItem, vec![]),
+                node("row", AxRole::TreeItem, vec![]),
+            ],
+        ));
+        let h = role_histogram(&tree);
+        assert_eq!(h.iter().filter(|t| t.raw_role == "row").count(), 2);
+    }
+
+    #[test]
+    fn empty_token_is_kept_as_its_own_bucket() {
+        let tree = AxTree::new(node("", AxRole::Other, vec![]));
+        let h = role_histogram(&tree);
+        assert_eq!(h.len(), 1);
+        assert_eq!(h[0].raw_role, "");
+    }
+}

--- a/crates/glass-core/src/role_histogram.rs
+++ b/crates/glass-core/src/role_histogram.rs
@@ -28,9 +28,11 @@ pub fn role_histogram(tree: &AxTree) -> Vec<RoleTally> {
     let mut tallies: Vec<RoleTally> = Vec::new();
     visit(&tree.root, &mut tallies);
     tallies.sort_by(|a, b| {
-        let unmapped = |t: &RoleTally| t.role != AxRole::Other;
-        unmapped(a)
-            .cmp(&unmapped(b))
+        // `false` sorts before `true`, so ordering on "is mapped" puts the unmapped buckets —
+        // what a probe run is looking for — first.
+        let mapped = |t: &RoleTally| t.role != AxRole::Other;
+        mapped(a)
+            .cmp(&mapped(b))
             .then(b.count.cmp(&a.count))
             .then(a.raw_role.cmp(&b.raw_role))
             .then(format!("{:?}", a.role).cmp(&format!("{:?}", b.role)))

--- a/crates/glass-core/src/role_histogram.rs
+++ b/crates/glass-core/src/role_histogram.rs
@@ -21,8 +21,9 @@ pub struct RoleTally {
 /// Tally every node by `(raw_role, role)`.
 ///
 /// Unmapped buckets ([`AxRole::Other`]) come first — they are what a probe run is looking for
-/// — then buckets by descending count, then by token. The order is total, so two runs of the
-/// same app diff cleanly.
+/// — then buckets by descending count, then by token, then by role (using Debug format as a
+/// tiebreaker so the same token mapping to multiple roles orders consistently). The order is
+/// total, so two runs of the same app diff cleanly.
 pub fn role_histogram(tree: &AxTree) -> Vec<RoleTally> {
     let mut tallies: Vec<RoleTally> = Vec::new();
     visit(&tree.root, &mut tallies);
@@ -110,7 +111,8 @@ mod tests {
     #[test]
     fn same_token_mapping_two_ways_gets_two_buckets() {
         // A backend may key on more than the token alone (a control type plus a pattern, a
-        // role plus a subrole), so one token can legitimately produce two roles.
+        // role plus a subrole), so one token can legitimately produce two roles. When the same
+        // token maps to multiple roles, they are ordered by role Debug format as a tiebreaker.
         let tree = AxTree::new(node(
             "root",
             AxRole::Window,
@@ -120,7 +122,60 @@ mod tests {
             ],
         ));
         let h = role_histogram(&tree);
-        assert_eq!(h.iter().filter(|t| t.raw_role == "row").count(), 2);
+        assert_eq!(
+            h,
+            vec![
+                RoleTally {
+                    raw_role: "root".into(),
+                    role: AxRole::Window,
+                    count: 1
+                },
+                RoleTally {
+                    raw_role: "row".into(),
+                    role: AxRole::ListItem,
+                    count: 1
+                },
+                RoleTally {
+                    raw_role: "row".into(),
+                    role: AxRole::TreeItem,
+                    count: 1
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn token_tiebreak_sorts_lexicographically_when_unmapped_and_count_tie() {
+        // When two buckets tie on unmapped status and count, they sort by token lexicographically.
+        let tree = AxTree::new(node(
+            "unused",
+            AxRole::Window,
+            vec![
+                node("beta", AxRole::Other, vec![]),
+                node("alpha", AxRole::Other, vec![]),
+            ],
+        ));
+        let h = role_histogram(&tree);
+        assert_eq!(
+            h,
+            vec![
+                RoleTally {
+                    raw_role: "alpha".into(),
+                    role: AxRole::Other,
+                    count: 1
+                },
+                RoleTally {
+                    raw_role: "beta".into(),
+                    role: AxRole::Other,
+                    count: 1
+                },
+                RoleTally {
+                    raw_role: "unused".into(),
+                    role: AxRole::Window,
+                    count: 1
+                },
+            ]
+        );
     }
 
     #[test]

--- a/crates/glass-core/src/role_support.rs
+++ b/crates/glass-core/src/role_support.rs
@@ -37,6 +37,21 @@ impl AxBackend {
         AxBackend::Ios,
     ];
 
+    /// Compile-time guard for [`AxBackend::ALL`] — never called, and exists only for its
+    /// exhaustive match. Every completeness claim on the matrix is quantified over `ALL`, so a
+    /// new backend that is not added there would silently weaken all of them; this match stops
+    /// compiling until the new variant is listed here and in `ALL`.
+    #[expect(dead_code, reason = "exists only for its exhaustive match")]
+    fn all_is_exhaustive(backend: AxBackend) {
+        match backend {
+            AxBackend::Linux
+            | AxBackend::Windows
+            | AxBackend::MacOs
+            | AxBackend::Android
+            | AxBackend::Ios => {}
+        }
+    }
+
     /// Human-readable column heading, naming the native vocabulary.
     pub fn label(self) -> &'static str {
         match self {
@@ -54,14 +69,16 @@ impl AxBackend {
 pub enum RoleSupport {
     /// At least one native token maps to this role.
     Mapped,
-    /// The platform has no counterpart. The reason says what it does instead.
+    /// The platform has no counterpart. The reason says why — either what the platform does
+    /// instead, or simply that the concept does not exist there.
     NotApplicable(&'static str),
     /// The platform has a counterpart glass does not map yet. The reason says what is missing.
     Gap(&'static str),
 }
 
-/// Role coverage per backend. Cells are ordered as [`AxBackend::ALL`].
-pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; 5])] =
+/// Role coverage per backend. Cells are ordered as [`AxBackend::ALL`], and the row type is sized
+/// from it so a new backend is a compile error here rather than a silent column mismatch.
+pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] =
     {
         use AxRole as R;
         use RoleSupport::{Gap, Mapped, NotApplicable};
@@ -104,8 +121,8 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; 5])] =
                 Mapped,
                 Gap("UIA exposes a toggle as a control type plus the Toggle pattern, which the \
                      map does not key on yet"),
-                NotApplicable("AppKit reports switches as AXCheckBox; there is no separate \
-                               toggle-button role"),
+                Gap("AppKit reports a switch as AXCheckBox with an AXSwitch or AXToggle \
+                     subrole; subroles are not read yet"),
                 Mapped,
                 Mapped,
             ],
@@ -333,18 +350,19 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; 5])] =
     ]
     };
 
-/// Declared support for one role on one backend. Panics only if [`ROLE_SUPPORT`] is missing a
-/// row, which the module's own test forbids.
-pub fn support(role: AxRole, backend: AxBackend) -> RoleSupport {
-    let idx = AxBackend::ALL
-        .iter()
-        .position(|b| *b == backend)
-        .expect("AxBackend::ALL covers every backend");
+/// Declared support for one role on one backend, or `None` when [`ROLE_SUPPORT`] has no row for
+/// `role`.
+///
+/// [`AxRole::Other`] is the sink for unmapped native tokens rather than a mapping target, so it
+/// deliberately has no row: asking about it — which is what walking a real snapshot's roles
+/// does — answers `None` instead of failing. Total; the backend lookup cannot fail because
+/// [`AxBackend::ALL`] is exhaustive.
+pub fn support(role: AxRole, backend: AxBackend) -> Option<RoleSupport> {
+    let idx = AxBackend::ALL.iter().position(|b| *b == backend)?;
     ROLE_SUPPORT
         .iter()
         .find(|(r, _)| *r == role)
         .map(|(_, cells)| cells[idx])
-        .unwrap_or_else(|| panic!("ROLE_SUPPORT has no row for {role:?}"))
 }
 
 /// Render [`ROLE_SUPPORT`] as the markdown block in `docs/reference/a11y-roles.md`: a
@@ -438,12 +456,19 @@ mod tests {
     fn support_reads_the_right_cell() {
         assert_eq!(
             support(AxRole::Button, AxBackend::Linux),
-            RoleSupport::Mapped
+            Some(RoleSupport::Mapped)
         );
         assert!(matches!(
             support(AxRole::MenuBar, AxBackend::Ios),
-            RoleSupport::NotApplicable(_)
+            Some(RoleSupport::NotApplicable(_))
         ));
+    }
+
+    #[test]
+    fn support_of_other_is_none_rather_than_a_panic() {
+        // `Other` has no row by design, and a caller asking about every role in a real
+        // snapshot will hit it — that must answer `None`, not blow up mid-walk.
+        assert_eq!(support(AxRole::Other, AxBackend::Linux), None);
     }
 
     #[test]
@@ -451,7 +476,7 @@ mod tests {
         // AT-SPI is the reference vocabulary: every role must be reachable there.
         for role in AxRole::ALL {
             assert_eq!(
-                support(role, AxBackend::Linux),
+                support(role, AxBackend::Linux).expect("declared in ROLE_SUPPORT"),
                 RoleSupport::Mapped,
                 "{role:?} unmapped on the reference backend"
             );

--- a/crates/glass-core/src/role_support.rs
+++ b/crates/glass-core/src/role_support.rs
@@ -347,6 +347,52 @@ pub fn support(role: AxRole, backend: AxBackend) -> RoleSupport {
         .unwrap_or_else(|| panic!("ROLE_SUPPORT has no row for {role:?}"))
 }
 
+/// Render [`ROLE_SUPPORT`] as the markdown block in `docs/reference/a11y-roles.md`: a
+/// role × backend table of `yes` / `n/a` / `gap`, then the reason for every cell that is not
+/// `yes`. A test asserts the doc matches this output.
+pub fn render_markdown() -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+
+    out.push_str("| Role |");
+    for b in AxBackend::ALL {
+        let _ = write!(out, " {} |", b.label());
+    }
+    out.push_str("\n|---|");
+    out.push_str(&"---|".repeat(AxBackend::ALL.len()));
+    out.push('\n');
+
+    for (role, cells) in ROLE_SUPPORT {
+        let _ = write!(out, "| `{role:?}` |");
+        for cell in cells {
+            let mark = match cell {
+                RoleSupport::Mapped => "yes",
+                RoleSupport::NotApplicable(_) => "n/a",
+                RoleSupport::Gap(_) => "gap",
+            };
+            let _ = write!(out, " {mark} |");
+        }
+        out.push('\n');
+    }
+
+    out.push_str("\n### Why a cell is not `yes`\n\n");
+    for (role, cells) in ROLE_SUPPORT {
+        for (i, cell) in cells.iter().enumerate() {
+            let (kind, reason) = match cell {
+                RoleSupport::Mapped => continue,
+                RoleSupport::NotApplicable(r) => ("n/a", *r),
+                RoleSupport::Gap(r) => ("gap", *r),
+            };
+            let _ = writeln!(
+                out,
+                "- `{role:?}` / {} — {kind}: {reason}",
+                AxBackend::ALL[i].label()
+            );
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/glass-core/src/role_support.rs
+++ b/crates/glass-core/src/role_support.rs
@@ -1,0 +1,414 @@
+//! What accessibility role each backend can produce — the declared parity matrix.
+//!
+//! A backend maps native tokens (AT-SPI roles, UIA control types, AX role strings, Android
+//! widget classes, iOS role strings) onto [`AxRole`]. Coverage differs per platform: some
+//! roles have no counterpart at all, others simply are not mapped yet. This module states
+//! which is which, so the difference is a checked fact rather than folklore.
+//!
+//! Each backend crate has a unit test that walks its own column and asserts its token table
+//! agrees with what is declared here, so a new mapping cannot land without updating the
+//! matrix and vice versa. `docs/reference/a11y-roles.md` renders the same data.
+
+use crate::accessibility::AxRole;
+
+/// The accessibility backends glass ships. Index order matches the cell arrays in
+/// [`ROLE_SUPPORT`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AxBackend {
+    /// AT-SPI, shared by X11 and Wayland.
+    Linux,
+    /// UI Automation.
+    Windows,
+    /// AXUIElement.
+    MacOs,
+    /// `uiautomator` dumps and the on-device AccessibilityService, which share one map.
+    Android,
+    /// The Simulator's tree, read through `idb`.
+    Ios,
+}
+
+impl AxBackend {
+    /// Every backend, in the cell order used by [`ROLE_SUPPORT`].
+    pub const ALL: [AxBackend; 5] = [
+        AxBackend::Linux,
+        AxBackend::Windows,
+        AxBackend::MacOs,
+        AxBackend::Android,
+        AxBackend::Ios,
+    ];
+
+    /// Human-readable column heading, naming the native vocabulary.
+    pub fn label(self) -> &'static str {
+        match self {
+            AxBackend::Linux => "Linux (AT-SPI)",
+            AxBackend::Windows => "Windows (UIA)",
+            AxBackend::MacOs => "macOS (AX)",
+            AxBackend::Android => "Android",
+            AxBackend::Ios => "iOS",
+        }
+    }
+}
+
+/// Whether a backend can produce a given [`AxRole`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RoleSupport {
+    /// At least one native token maps to this role.
+    Mapped,
+    /// The platform has no counterpart. The reason says what it does instead.
+    NotApplicable(&'static str),
+    /// The platform has a counterpart glass does not map yet. The reason says what is missing.
+    Gap(&'static str),
+}
+
+/// Role coverage per backend. Cells are ordered as [`AxBackend::ALL`].
+pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; 5])] =
+    {
+        use AxRole as R;
+        use RoleSupport::{Gap, Mapped, NotApplicable};
+        &[
+        (
+            R::Application,
+            [
+                Mapped,
+                NotApplicable("UIA has no application control type; the app root is a Window"),
+                Gap("AXApplication is the app element but is not mapped yet"),
+                NotApplicable("Android exposes windows, not an application element"),
+                Mapped,
+            ],
+        ),
+        (R::Window, [Mapped, Mapped, Mapped, Mapped, Mapped]),
+        (
+            R::Dialog,
+            [
+                Mapped,
+                Gap("UIA marks a dialog with the IsDialog property on a Window; not read yet"),
+                Gap("AXSheet, AXPopover and AXDrawer are not mapped yet"),
+                Gap("dialog windows arrive as a generic layout class"),
+                Gap("alert and action-sheet tokens are not mapped yet"),
+            ],
+        ),
+        (
+            R::Group,
+            [
+                Mapped,
+                Mapped,
+                Mapped,
+                Mapped,
+                Gap("no container token is mapped yet"),
+            ],
+        ),
+        (R::Button, [Mapped, Mapped, Mapped, Mapped, Mapped]),
+        (
+            R::ToggleButton,
+            [
+                Mapped,
+                Gap("UIA exposes a toggle as a control type plus the Toggle pattern, which the \
+                     map does not key on yet"),
+                NotApplicable("AppKit reports switches as AXCheckBox; there is no separate \
+                               toggle-button role"),
+                Mapped,
+                Mapped,
+            ],
+        ),
+        (
+            R::RadioButton,
+            [
+                Mapped,
+                Mapped,
+                Mapped,
+                Mapped,
+                Gap("no radio token is mapped yet"),
+            ],
+        ),
+        (R::CheckBox, [Mapped, Mapped, Mapped, Mapped, Mapped]),
+        (
+            R::MenuBar,
+            [
+                Mapped,
+                Mapped,
+                Mapped,
+                NotApplicable("Android apps have no menu bar"),
+                NotApplicable("iOS apps have no menu bar"),
+            ],
+        ),
+        (
+            R::Menu,
+            [
+                Mapped,
+                Mapped,
+                Mapped,
+                Gap("popup menus arrive as list or layout classes"),
+                Gap("context-menu tokens are not mapped yet"),
+            ],
+        ),
+        (
+            R::MenuItem,
+            [
+                Mapped,
+                Mapped,
+                Mapped,
+                Gap("menu entries arrive as their own widget class"),
+                Gap("menu-item tokens are not mapped yet"),
+            ],
+        ),
+        (R::Label, [Mapped, Mapped, Mapped, Mapped, Mapped]),
+        (R::TextField, [Mapped, Mapped, Mapped, Mapped, Mapped]),
+        (
+            R::TextArea,
+            [
+                Mapped,
+                Gap("the UIA Document control type is not mapped yet"),
+                Mapped,
+                NotApplicable("Android uses one editable class for single- and multi-line text"),
+                Mapped,
+            ],
+        ),
+        (
+            R::ComboBox,
+            [
+                Mapped,
+                Mapped,
+                Mapped,
+                Mapped,
+                Gap("picker tokens are not mapped yet"),
+            ],
+        ),
+        (
+            R::List,
+            [Mapped, Mapped, Mapped, Mapped, Gap("no list token is mapped yet")],
+        ),
+        (
+            R::ListItem,
+            [
+                Mapped,
+                Mapped,
+                Mapped,
+                Gap("list children report their own widget class, not a list-item role"),
+                Gap("no list-item token is mapped yet"),
+            ],
+        ),
+        (
+            R::Table,
+            [
+                Mapped,
+                Mapped,
+                Gap("AXTable is not mapped yet"),
+                Gap("table and grid classes collapse into List"),
+                Gap("no table token is mapped yet"),
+            ],
+        ),
+        (
+            R::Cell,
+            [
+                Mapped,
+                Gap("the UIA DataItem control type is not mapped yet"),
+                Mapped,
+                Gap("no cell class is mapped yet"),
+                Mapped,
+            ],
+        ),
+        (
+            R::Tree,
+            [
+                Mapped,
+                Mapped,
+                Gap("AXOutline is not mapped yet"),
+                NotApplicable("Android has no tree widget"),
+                NotApplicable("UIKit has no outline view"),
+            ],
+        ),
+        (
+            R::TreeItem,
+            [
+                Mapped,
+                Mapped,
+                Gap("the outline-row subrole is not read yet"),
+                NotApplicable("Android has no tree widget"),
+                NotApplicable("UIKit has no outline view"),
+            ],
+        ),
+        (
+            R::TabList,
+            [
+                Mapped,
+                Mapped,
+                Mapped,
+                Gap("tab-container classes are not mapped yet"),
+                Mapped,
+            ],
+        ),
+        (
+            R::Tab,
+            [
+                Mapped,
+                Mapped,
+                Gap("AppKit reports tab items as AXRadioButton inside the tab group; the \
+                     containing role is not used to disambiguate yet"),
+                Gap("tab children are not mapped yet"),
+                Gap("tab-item tokens are not mapped yet"),
+            ],
+        ),
+        (
+            R::ScrollBar,
+            [
+                Mapped,
+                Mapped,
+                Mapped,
+                NotApplicable("Android scrollbars are drawn, not exposed as nodes"),
+                NotApplicable("UIKit scroll indicators are not accessibility elements"),
+            ],
+        ),
+        (R::Slider, [Mapped, Mapped, Mapped, Mapped, Mapped]),
+        (
+            R::SpinButton,
+            [
+                Mapped,
+                Mapped,
+                Gap("AXIncrementor is not mapped yet"),
+                Gap("the number-picker class is not mapped yet"),
+                Gap("the stepper token is not mapped yet"),
+            ],
+        ),
+        (
+            R::ProgressBar,
+            [
+                Mapped,
+                Mapped,
+                Mapped,
+                Mapped,
+                Gap("no progress token is mapped yet"),
+            ],
+        ),
+        (R::Image, [Mapped, Mapped, Mapped, Mapped, Mapped]),
+        (
+            R::Link,
+            [
+                Mapped,
+                Mapped,
+                Mapped,
+                NotApplicable("Android links are spans inside a text view, not separate nodes"),
+                Mapped,
+            ],
+        ),
+        (
+            R::Separator,
+            [
+                Mapped,
+                Mapped,
+                Gap("AXSplitter is not mapped yet"),
+                NotApplicable("Android dividers are drawn, not exposed as nodes"),
+                NotApplicable("UIKit exposes no separator element"),
+            ],
+        ),
+        (
+            R::Toolbar,
+            [
+                Mapped,
+                Mapped,
+                Mapped,
+                Gap("the toolbar class is not mapped yet"),
+                Mapped,
+            ],
+        ),
+        (
+            R::StatusBar,
+            [
+                Mapped,
+                Mapped,
+                NotApplicable("AppKit exposes status items as menu-bar items"),
+                NotApplicable("the system status bar is outside the app tree"),
+                NotApplicable("the system status bar is outside the app tree"),
+            ],
+        ),
+        (
+            R::Heading,
+            [
+                Mapped,
+                Gap("the UIA Header control types are not mapped yet"),
+                Gap("AXHeading is not mapped yet"),
+                Gap("heading semantics are not mapped yet"),
+                Gap("the header token is not mapped yet"),
+            ],
+        ),
+    ]
+    };
+
+/// Declared support for one role on one backend. Panics only if [`ROLE_SUPPORT`] is missing a
+/// row, which the module's own test forbids.
+pub fn support(role: AxRole, backend: AxBackend) -> RoleSupport {
+    let idx = AxBackend::ALL
+        .iter()
+        .position(|b| *b == backend)
+        .expect("AxBackend::ALL covers every backend");
+    ROLE_SUPPORT
+        .iter()
+        .find(|(r, _)| *r == role)
+        .map(|(_, cells)| cells[idx])
+        .unwrap_or_else(|| panic!("ROLE_SUPPORT has no row for {role:?}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_role_has_exactly_one_row() {
+        for role in AxRole::ALL {
+            let rows = ROLE_SUPPORT.iter().filter(|(r, _)| *r == role).count();
+            assert_eq!(rows, 1, "{role:?} must appear exactly once in ROLE_SUPPORT");
+        }
+        assert_eq!(ROLE_SUPPORT.len(), AxRole::ALL.len());
+    }
+
+    #[test]
+    fn other_is_not_a_row() {
+        // `Other` is the sink for unmapped tokens, not a mapping target.
+        assert!(!ROLE_SUPPORT.iter().any(|(r, _)| *r == AxRole::Other));
+    }
+
+    #[test]
+    fn unsupported_cells_carry_a_real_reason() {
+        for (role, cells) in ROLE_SUPPORT {
+            for (i, cell) in cells.iter().enumerate() {
+                let reason = match cell {
+                    RoleSupport::Mapped => continue,
+                    RoleSupport::NotApplicable(r) | RoleSupport::Gap(r) => *r,
+                };
+                let backend = AxBackend::ALL[i];
+                assert!(
+                    reason.len() >= 10,
+                    "{role:?}/{backend:?}: reason too thin to be useful: {reason:?}"
+                );
+                let lower = reason.to_ascii_lowercase();
+                assert!(
+                    !lower.contains("tbd") && !lower.contains("todo"),
+                    "{role:?}/{backend:?}: placeholder reason {reason:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn support_reads_the_right_cell() {
+        assert_eq!(
+            support(AxRole::Button, AxBackend::Linux),
+            RoleSupport::Mapped
+        );
+        assert!(matches!(
+            support(AxRole::MenuBar, AxBackend::Ios),
+            RoleSupport::NotApplicable(_)
+        ));
+    }
+
+    #[test]
+    fn linux_column_is_complete() {
+        // AT-SPI is the reference vocabulary: every role must be reachable there.
+        for role in AxRole::ALL {
+            assert_eq!(
+                support(role, AxBackend::Linux),
+                RoleSupport::Mapped,
+                "{role:?} unmapped on the reference backend"
+            );
+        }
+    }
+}

--- a/crates/glass-core/tests/role_support_doc.rs
+++ b/crates/glass-core/tests/role_support_doc.rs
@@ -1,0 +1,22 @@
+//! The reference doc must render exactly from `ROLE_SUPPORT`; a mapping change that skips the
+//! doc fails here rather than drifting silently.
+
+const BEGIN: &str = "<!-- BEGIN GENERATED: role-support -->";
+const END: &str = "<!-- END GENERATED: role-support -->";
+
+#[test]
+fn doc_matches_the_matrix() {
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../docs/reference/a11y-roles.md"
+    );
+    let doc = std::fs::read_to_string(path).expect("read docs/reference/a11y-roles.md");
+    let start = doc.find(BEGIN).expect("generated block start marker") + BEGIN.len();
+    let end = doc.find(END).expect("generated block end marker");
+    let block = doc[start..end].trim();
+    assert_eq!(
+        block,
+        glass_core::role_support::render_markdown().trim(),
+        "docs/reference/a11y-roles.md is stale — regenerate the block between the markers"
+    );
+}

--- a/crates/glass-core/tests/role_support_doc.rs
+++ b/crates/glass-core/tests/role_support_doc.rs
@@ -1,5 +1,9 @@
 //! The reference doc must render exactly from `ROLE_SUPPORT`; a mapping change that skips the
 //! doc fails here rather than drifting silently.
+//!
+//! On Windows, Git's core.autocrlf may check out markdown files with CRLF line endings, while
+//! render_markdown() always produces LF. This test normalizes CRLF → LF after reading the file
+//! from disk to ensure the comparison is line-ending agnostic.
 
 const BEGIN: &str = "<!-- BEGIN GENERATED: role-support -->";
 const END: &str = "<!-- END GENERATED: role-support -->";
@@ -11,6 +15,10 @@ fn doc_matches_the_matrix() {
         "/../../docs/reference/a11y-roles.md"
     );
     let doc = std::fs::read_to_string(path).expect("read docs/reference/a11y-roles.md");
+    // Normalize CRLF → LF so the test passes regardless of how Git checked out the file.
+    // On Windows, core.autocrlf may check out files with CRLF line endings, while render_markdown()
+    // always emits LF. The comparison would fail on every line due to interior \r characters.
+    let doc = doc.replace("\r\n", "\n");
     let start = doc.find(BEGIN).expect("generated block start marker") + BEGIN.len();
     let end = doc.find(END).expect("generated block end marker");
     let block = doc[start..end].trim();
@@ -19,4 +27,22 @@ fn doc_matches_the_matrix() {
         glass_core::role_support::render_markdown().trim(),
         "docs/reference/a11y-roles.md is stale — regenerate the block between the markers"
     );
+}
+
+#[test]
+fn crlf_normalization_works() {
+    // Verify that CRLF normalization correctly converts Windows line endings to Unix line endings.
+    // This is the mechanism that makes doc_matches_the_matrix() pass on a Windows checkout.
+    let crlf_text = "line 1\r\nline 2\r\nline 3\r\n";
+    let normalized = crlf_text.replace("\r\n", "\n");
+    assert_eq!(normalized, "line 1\nline 2\nline 3\n");
+
+    // Verify that the generated markdown can be found within normalized CRLF text.
+    let generated = glass_core::role_support::render_markdown();
+    let crlf_doc = format!("{}{}{}", BEGIN, generated, END).replace("\n", "\r\n");
+    let normalized = crlf_doc.replace("\r\n", "\n");
+    let start = normalized.find(BEGIN).unwrap() + BEGIN.len();
+    let end = normalized.find(END).unwrap();
+    let extracted = normalized[start..end].trim();
+    assert_eq!(extracted, generated.trim());
 }

--- a/crates/glass-ios/src/axmap.rs
+++ b/crates/glass-ios/src/axmap.rs
@@ -24,27 +24,37 @@ use glass_core::accessibility::{
 use glass_core::{GlassError, Result, WindowGeometry};
 use serde_json::Value;
 
+/// Every iOS role string glass maps, as reported through `idb`.
+pub const ROLE_TOKENS: &[(&str, AxRole)] = &[
+    ("AXButton", AxRole::Button),
+    ("AXStaticText", AxRole::Label),
+    ("AXText", AxRole::Label),
+    ("AXTextField", AxRole::TextField),
+    ("AXSearchField", AxRole::TextField),
+    ("AXTextView", AxRole::TextArea),
+    ("AXImage", AxRole::Image),
+    ("AXSwitch", AxRole::ToggleButton),
+    ("AXToggle", AxRole::ToggleButton),
+    ("AXCheckBox", AxRole::CheckBox),
+    ("AXSlider", AxRole::Slider),
+    ("AXLink", AxRole::Link),
+    ("AXCell", AxRole::Cell),
+    ("AXNavigationBar", AxRole::Toolbar),
+    ("AXToolbar", AxRole::Toolbar),
+    ("AXTabBar", AxRole::TabList),
+    ("AXApplication", AxRole::Application),
+    ("AXWindow", AxRole::Window),
+];
+
 /// Map an idb AX role string (e.g. `AXButton`) to a normalized [`AxRole`].
 /// Unrecognized roles become [`AxRole::Other`]; the caller preserves the native
 /// string in [`AxNode::raw_role`].
-pub fn ax_role(ax_type: &str) -> AxRole {
-    match ax_type {
-        "AXButton" => AxRole::Button,
-        "AXStaticText" | "AXText" => AxRole::Label,
-        "AXTextField" | "AXSearchField" => AxRole::TextField,
-        "AXTextView" => AxRole::TextArea,
-        "AXImage" => AxRole::Image,
-        "AXSwitch" | "AXToggle" => AxRole::ToggleButton,
-        "AXCheckBox" => AxRole::CheckBox,
-        "AXSlider" => AxRole::Slider,
-        "AXLink" => AxRole::Link,
-        "AXCell" => AxRole::Cell,
-        "AXNavigationBar" | "AXToolbar" => AxRole::Toolbar,
-        "AXTabBar" => AxRole::TabList,
-        "AXApplication" => AxRole::Application,
-        "AXWindow" => AxRole::Window,
-        _ => AxRole::Other,
-    }
+pub fn ax_role(role: &str) -> AxRole {
+    ROLE_TOKENS
+        .iter()
+        .find(|(token, _)| *token == role)
+        .map(|(_, r)| *r)
+        .unwrap_or(AxRole::Other)
 }
 
 /// Parse idb's nested accessibility JSON into an [`AxTree`]. Each element's
@@ -581,5 +591,32 @@ mod tests {
         );
         // `checked` carries the state; the label still lives in `value` (unchanged behavior).
         assert_eq!(sw.value.as_deref(), Some("Bold Text"));
+    }
+
+    #[test]
+    fn role_tokens_have_no_duplicates() {
+        for (i, (token, _)) in ROLE_TOKENS.iter().enumerate() {
+            assert!(
+                !ROLE_TOKENS[i + 1..].iter().any(|(other, _)| other == token),
+                "{token} listed twice"
+            );
+        }
+    }
+
+    #[test]
+    fn map_matches_declared_column() {
+        use glass_core::role_support::{support, AxBackend, RoleSupport};
+        for role in AxRole::ALL {
+            let mapped = ROLE_TOKENS.iter().any(|(_, r)| *r == role);
+            match support(role, AxBackend::Ios) {
+                RoleSupport::Mapped => {
+                    assert!(mapped, "{role:?} declared Mapped but no token maps to it")
+                }
+                RoleSupport::NotApplicable(_) | RoleSupport::Gap(_) => assert!(
+                    !mapped,
+                    "{role:?} is produced by a token but the matrix does not declare it"
+                ),
+            }
+        }
     }
 }

--- a/crates/glass-ios/src/axmap.rs
+++ b/crates/glass-ios/src/axmap.rs
@@ -608,7 +608,7 @@ mod tests {
         use glass_core::role_support::{support, AxBackend, RoleSupport};
         for role in AxRole::ALL {
             let mapped = ROLE_TOKENS.iter().any(|(_, r)| *r == role);
-            match support(role, AxBackend::Ios) {
+            match support(role, AxBackend::Ios).expect("declared in ROLE_SUPPORT") {
                 RoleSupport::Mapped => {
                     assert!(mapped, "{role:?} declared Mapped but no token maps to it")
                 }

--- a/crates/glass-macos/tests/a11y.rs
+++ b/crates/glass-macos/tests/a11y.rs
@@ -225,6 +225,20 @@ mod macos_main {
             }
         }
 
+        // `raw_role` must be the platform's own AX role token, not `AXRoleDescription`'s
+        // localized human phrase ("button" / "bouton"): the fixture's Save button is an
+        // NSButton, which reports exactly `AXButton` on every machine and every locale.
+        let save_raw = match find_by_name(&tree.root, "Save") {
+            Some(n) => n,
+            None => return Err(format!("no \"Save\" button in tree:\n{outline}")),
+        };
+        if save_raw.raw_role != "AXButton" {
+            return Err(format!(
+                "Save raw_role = {:?}, want \"AXButton\":\n{outline}",
+                save_raw.raw_role
+            ));
+        }
+
         // The outline only proves `name`; confirm `value` is read separately, straight off
         // the field's content — not folded into `name` (that was the bug this test guards).
         let field = match find_text_field(&tree.root) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ way it does? The explanations.
 - [Environment variables](reference/environment.md) — every `GLASS_*` variable
 - [CLI](reference/cli.md) — `glass-mcp` subcommands
 - [Platform support](reference/platforms.md) — the capability matrix and system requirements
+- [Accessibility roles by platform](reference/a11y-roles.md) — which roles each backend can produce
 - [Audit log](reference/audit-log.md) — the JSONL record schema and redaction
 
 ## Explanation — understand why

--- a/docs/reference/a11y-roles.md
+++ b/docs/reference/a11y-roles.md
@@ -1,0 +1,112 @@
+# Accessibility roles by platform
+
+`glass_a11y_snapshot` normalizes every platform's accessibility vocabulary into one set of
+roles. This page states which roles each backend can produce.
+
+Each node also carries the backend's own token — the AT-SPI role, the UIA control type, the AX
+role string, the Android widget class, the iOS role string. When glass has no mapping for a
+token the role is `Other` and the token is still reported, so nothing is hidden; a `role:`
+selector just will not match it.
+
+A cell reads:
+
+- `yes` — the backend produces this role.
+- `n/a` — the platform has no counterpart. The reason says what it does instead.
+- `gap` — the platform has a counterpart glass does not map yet.
+
+<!-- BEGIN GENERATED: role-support -->
+| Role | Linux (AT-SPI) | Windows (UIA) | macOS (AX) | Android | iOS |
+|---|---|---|---|---|---|
+| `Application` | yes | n/a | gap | n/a | yes |
+| `Window` | yes | yes | yes | yes | yes |
+| `Dialog` | yes | gap | gap | gap | gap |
+| `Group` | yes | yes | yes | yes | gap |
+| `Button` | yes | yes | yes | yes | yes |
+| `ToggleButton` | yes | gap | n/a | yes | yes |
+| `RadioButton` | yes | yes | yes | yes | gap |
+| `CheckBox` | yes | yes | yes | yes | yes |
+| `MenuBar` | yes | yes | yes | n/a | n/a |
+| `Menu` | yes | yes | yes | gap | gap |
+| `MenuItem` | yes | yes | yes | gap | gap |
+| `Label` | yes | yes | yes | yes | yes |
+| `TextField` | yes | yes | yes | yes | yes |
+| `TextArea` | yes | gap | yes | n/a | yes |
+| `ComboBox` | yes | yes | yes | yes | gap |
+| `List` | yes | yes | yes | yes | gap |
+| `ListItem` | yes | yes | yes | gap | gap |
+| `Table` | yes | yes | gap | gap | gap |
+| `Cell` | yes | gap | yes | gap | yes |
+| `Tree` | yes | yes | gap | n/a | n/a |
+| `TreeItem` | yes | yes | gap | n/a | n/a |
+| `TabList` | yes | yes | yes | gap | yes |
+| `Tab` | yes | yes | gap | gap | gap |
+| `ScrollBar` | yes | yes | yes | n/a | n/a |
+| `Slider` | yes | yes | yes | yes | yes |
+| `SpinButton` | yes | yes | gap | gap | gap |
+| `ProgressBar` | yes | yes | yes | yes | gap |
+| `Image` | yes | yes | yes | yes | yes |
+| `Link` | yes | yes | yes | n/a | yes |
+| `Separator` | yes | yes | gap | n/a | n/a |
+| `Toolbar` | yes | yes | yes | gap | yes |
+| `StatusBar` | yes | yes | n/a | n/a | n/a |
+| `Heading` | yes | gap | gap | gap | gap |
+
+### Why a cell is not `yes`
+
+- `Application` / Windows (UIA) — n/a: UIA has no application control type; the app root is a Window
+- `Application` / macOS (AX) — gap: AXApplication is the app element but is not mapped yet
+- `Application` / Android — n/a: Android exposes windows, not an application element
+- `Dialog` / Windows (UIA) — gap: UIA marks a dialog with the IsDialog property on a Window; not read yet
+- `Dialog` / macOS (AX) — gap: AXSheet, AXPopover and AXDrawer are not mapped yet
+- `Dialog` / Android — gap: dialog windows arrive as a generic layout class
+- `Dialog` / iOS — gap: alert and action-sheet tokens are not mapped yet
+- `Group` / iOS — gap: no container token is mapped yet
+- `ToggleButton` / Windows (UIA) — gap: UIA exposes a toggle as a control type plus the Toggle pattern, which the map does not key on yet
+- `ToggleButton` / macOS (AX) — n/a: AppKit reports switches as AXCheckBox; there is no separate toggle-button role
+- `RadioButton` / iOS — gap: no radio token is mapped yet
+- `MenuBar` / Android — n/a: Android apps have no menu bar
+- `MenuBar` / iOS — n/a: iOS apps have no menu bar
+- `Menu` / Android — gap: popup menus arrive as list or layout classes
+- `Menu` / iOS — gap: context-menu tokens are not mapped yet
+- `MenuItem` / Android — gap: menu entries arrive as their own widget class
+- `MenuItem` / iOS — gap: menu-item tokens are not mapped yet
+- `TextArea` / Windows (UIA) — gap: the UIA Document control type is not mapped yet
+- `TextArea` / Android — n/a: Android uses one editable class for single- and multi-line text
+- `ComboBox` / iOS — gap: picker tokens are not mapped yet
+- `List` / iOS — gap: no list token is mapped yet
+- `ListItem` / Android — gap: list children report their own widget class, not a list-item role
+- `ListItem` / iOS — gap: no list-item token is mapped yet
+- `Table` / macOS (AX) — gap: AXTable is not mapped yet
+- `Table` / Android — gap: table and grid classes collapse into List
+- `Table` / iOS — gap: no table token is mapped yet
+- `Cell` / Windows (UIA) — gap: the UIA DataItem control type is not mapped yet
+- `Cell` / Android — gap: no cell class is mapped yet
+- `Tree` / macOS (AX) — gap: AXOutline is not mapped yet
+- `Tree` / Android — n/a: Android has no tree widget
+- `Tree` / iOS — n/a: UIKit has no outline view
+- `TreeItem` / macOS (AX) — gap: the outline-row subrole is not read yet
+- `TreeItem` / Android — n/a: Android has no tree widget
+- `TreeItem` / iOS — n/a: UIKit has no outline view
+- `TabList` / Android — gap: tab-container classes are not mapped yet
+- `Tab` / macOS (AX) — gap: AppKit reports tab items as AXRadioButton inside the tab group; the containing role is not used to disambiguate yet
+- `Tab` / Android — gap: tab children are not mapped yet
+- `Tab` / iOS — gap: tab-item tokens are not mapped yet
+- `ScrollBar` / Android — n/a: Android scrollbars are drawn, not exposed as nodes
+- `ScrollBar` / iOS — n/a: UIKit scroll indicators are not accessibility elements
+- `SpinButton` / macOS (AX) — gap: AXIncrementor is not mapped yet
+- `SpinButton` / Android — gap: the number-picker class is not mapped yet
+- `SpinButton` / iOS — gap: the stepper token is not mapped yet
+- `ProgressBar` / iOS — gap: no progress token is mapped yet
+- `Link` / Android — n/a: Android links are spans inside a text view, not separate nodes
+- `Separator` / macOS (AX) — gap: AXSplitter is not mapped yet
+- `Separator` / Android — n/a: Android dividers are drawn, not exposed as nodes
+- `Separator` / iOS — n/a: UIKit exposes no separator element
+- `Toolbar` / Android — gap: the toolbar class is not mapped yet
+- `StatusBar` / macOS (AX) — n/a: AppKit exposes status items as menu-bar items
+- `StatusBar` / Android — n/a: the system status bar is outside the app tree
+- `StatusBar` / iOS — n/a: the system status bar is outside the app tree
+- `Heading` / Windows (UIA) — gap: the UIA Header control types are not mapped yet
+- `Heading` / macOS (AX) — gap: AXHeading is not mapped yet
+- `Heading` / Android — gap: heading semantics are not mapped yet
+- `Heading` / iOS — gap: the header token is not mapped yet
+<!-- END GENERATED: role-support -->

--- a/docs/reference/a11y-roles.md
+++ b/docs/reference/a11y-roles.md
@@ -5,14 +5,19 @@ roles. This page states which roles each backend can produce.
 
 Each node also carries the backend's own token — the AT-SPI role, the UIA control type, the AX
 role string, the Android widget class, the iOS role string. When glass has no mapping for a
-token the role is `Other` and the token is still reported, so nothing is hidden; a `role:`
-selector just will not match it.
+token the role is `Other` and the outline shows the token in brackets — `Other(AXDisclosureTriangle)`
+— so nothing is hidden; a `role:` selector just will not match it.
 
 A cell reads:
 
 - `yes` — the backend produces this role.
-- `n/a` — the platform has no counterpart. The reason says what it does instead.
+- `n/a` — the platform has no counterpart. The reason says why: what the platform does instead,
+  or that the concept simply does not exist there.
 - `gap` — the platform has a counterpart glass does not map yet.
+
+On Android, `Window` holds for the `uiautomator` reader, which wraps the dump in a window root
+sized to the app window. The on-device accessibility-service reader instead roots the tree at the
+device's own node, which is classified like any other node from its widget class.
 
 <!-- BEGIN GENERATED: role-support -->
 | Role | Linux (AT-SPI) | Windows (UIA) | macOS (AX) | Android | iOS |
@@ -22,7 +27,7 @@ A cell reads:
 | `Dialog` | yes | gap | gap | gap | gap |
 | `Group` | yes | yes | yes | yes | gap |
 | `Button` | yes | yes | yes | yes | yes |
-| `ToggleButton` | yes | gap | n/a | yes | yes |
+| `ToggleButton` | yes | gap | gap | yes | yes |
 | `RadioButton` | yes | yes | yes | yes | gap |
 | `CheckBox` | yes | yes | yes | yes | yes |
 | `MenuBar` | yes | yes | yes | n/a | n/a |
@@ -62,7 +67,7 @@ A cell reads:
 - `Dialog` / iOS — gap: alert and action-sheet tokens are not mapped yet
 - `Group` / iOS — gap: no container token is mapped yet
 - `ToggleButton` / Windows (UIA) — gap: UIA exposes a toggle as a control type plus the Toggle pattern, which the map does not key on yet
-- `ToggleButton` / macOS (AX) — n/a: AppKit reports switches as AXCheckBox; there is no separate toggle-button role
+- `ToggleButton` / macOS (AX) — gap: AppKit reports a switch as AXCheckBox with an AXSwitch or AXToggle subrole; subroles are not read yet
 - `RadioButton` / iOS — gap: no radio token is mapped yet
 - `MenuBar` / Android — n/a: Android apps have no menu bar
 - `MenuBar` / iOS — n/a: iOS apps have no menu bar

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -434,6 +434,9 @@ rides as an untrusted sibling text block, one line per element:
   depth/sibling safety rails still apply, so a pathologically deep tree can still truncate — the
   notice says which limit was hit.) A snapshot renumbers ids, so re-read them after changing this.
 
+Roles are normalized across platforms; see [Accessibility roles by platform](a11y-roles.md) for
+what each backend can produce.
+
 ### `glass_a11y_marks`
 
 Screenshot of the active window with a numbered Set-of-Mark box on each interactable element, plus a

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -427,7 +427,10 @@ reads the Simulator's accessibility tree over `idb_companion` (install it — se
 
 Capture the active window's accessibility tree as compact text. Returns `{}`; the tree itself
 rides as an untrusted sibling text block, one line per element:
-`#<id> <Role> "<name>" (x,y wxh) [states]`; pass an `#id` to `glass_click_element`.
+`#<id> <Role> "<name>" (x,y wxh) [states]`; pass an `#id` to `glass_click_element`. An element
+whose platform role glass has no mapping for renders as `Other(<native token>)` — e.g.
+`#4 Other(AXDisclosureTriangle) "Details" [enabled]` — so the platform's own token is still
+visible; a bare `Other` means the platform named no token at all.
 
 - `max_nodes` (integer) — raise the element cap above the default (which protects the token
   budget), or `0` to remove the element-count limit. Omit for the default cap. (Structural


### PR DESCRIPTION
`glass_a11y_snapshot` normalizes five accessibility vocabularies into one set of roles, but how much of that set each backend can actually produce was undocumented and untested. This adds the declaration, the tests that hold it true, and makes the unmapped case legible.

- `glass-core` gains `role_support`: 33 roles x 5 backends, each cell `Mapped`, `NotApplicable(reason)`, or `Gap(reason)`, with compile-time guards so a new role or backend cannot silently skip the table.
- Each backend's role map becomes a data-driven token table, and each backend crate gains a unit test that walks its own column and asserts the map agrees. Adding a mapping without updating the matrix now fails the build, and vice versa. Linux keeps its exhaustive `match` over the AT-SPI enum (compiler-checked) and carries a witness list instead.
- `docs/reference/a11y-roles.md` renders the same data; a test asserts the doc is not stale.
- An AT-SPI integration test proves the declared Linux coverage against a real tree, with the GTK4 fixture grown to carry the widgets it asserts.
- `glass-core` gains `role_histogram`, which tallies a tree by native token — how a backend's remaining coverage gets measured before it is filled in.

**No role mapping changes here.** Every backend returns exactly the roles it returned before.

What does change is the unmapped case. An element glass has no role for now shows the platform's own token in the outline — `#4 Other(AXDisclosureTriangle) "Details"` — instead of a bare `Other`, so the escape hatch is something an agent can actually act on. Feeding that: Windows reported UI Automation's *localized* control-type string and macOS reported the localized AX role description; both now report the platform's own token, and Windows names every documented control type rather than only the mapped ones. On Windows this also removes a UIA round-trip per node. macOS keeps reading `AXRoleDescription` in the one case where it is the only descriptor an element has — a custom control reporting `AXUnknown`.

Filling the `Gap` cells on Windows, macOS, Android and iOS follows in later PRs, each starting from a probe run so mappings are written only for tokens real apps actually emit.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` — green.
- AT-SPI suite (`scripts/test-a11y.sh`) — 25 passed, including the new role-coverage test.
- Windows-gated code cross-compiled (`x86_64-pc-windows-gnu`), both the crate and `glass-windows --tests`.
- Draft until the macOS reader change and the Windows on-box suite are verified on real hardware — neither compiles on the Linux dev box.