### PR TITLE
chore: pin LF line endings for every checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Line endings are LF in the repository and LF in every working tree, on every
+# platform. Git's `core.autocrlf` would otherwise check text files out with CRLF on
+# Windows, which breaks any test that compares a checked-in file against text the
+# code generates (`crates/glass-core/tests/role_support_doc.rs` hit exactly that,
+# on the Windows CI leg only).
+#
+# `text=auto` lets Git detect binary content, so the two markers below are belt and
+# braces for the assets it must never touch.
+* text=auto eol=lf
+
+*.icns binary
+*.gif binary


### PR DESCRIPTION
Follow-up to #219.

Git's `core.autocrlf` checks text files out with CRLF on Windows. Any test that compares a checked-in file against text the code generates then fails there and only there — `crates/glass-core/tests/role_support_doc.rs` did exactly that on the Windows CI leg, after passing the full local gate, the AT-SPI suite, an on-box Windows run, and a granted macOS run. There is no Linux or macOS checkout that can reproduce it.

#219 fixed that test by normalizing CRLF on the file side, which is the right layer — it works regardless of how any given checkout is configured. This is the other half: new checkouts get LF everywhere, so the next case doesn't have to rediscover the trap.

`* text=auto eol=lf` lets Git detect binary content on its own; the two explicit `binary` markers cover the assets it must never rewrite.

`git add --renormalize .` produces no changes — every tracked file is already LF — so this affects only how future checkouts are written, not any current content.