### PR TITLE
a11y: fill the Windows and macOS role-map gaps the probes found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ internal refactors, CI, or test-only changes.
   with guidance to use a `settle` action or the terminal `then` observe instead.
 - [docs/reference/a11y-roles.md](docs/reference/a11y-roles.md) documents which accessibility roles
   each platform backend can produce, and why a role is unavailable where it is.
+- More elements report a real role instead of `Other`: on Windows, documents and column headers;
+  on macOS, outlines and their rows, split views and their dividers, scroll areas, headings, and
+  menu buttons. `docs/reference/a11y-roles.md` lists what each platform can produce.
 
 ### Changed
 - The `glass_a11y_snapshot` outline now names the platform's own role token for an element glass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,19 @@ internal refactors, CI, or test-only changes.
   with guidance to use a `settle` action or the terminal `then` observe instead.
 - [docs/reference/a11y-roles.md](docs/reference/a11y-roles.md) documents which accessibility roles
   each platform backend can produce, and why a role is unavailable where it is.
-- More elements report a real role instead of `Other`: on Windows, documents and column headers;
-  on macOS, outlines and their rows, split views and their dividers, scroll areas, headings, and
-  menu buttons. `docs/reference/a11y-roles.md` lists what each platform can produce.
+- More elements report a real role instead of `Other`: on Windows, documents; on macOS, outlines
+  and their rows, split views and their dividers, scroll areas, headings, and menu buttons.
+  Windows also distinguishes a button that can be toggled — a formatting bar's Bold or Italic —
+  as `ToggleButton`. `docs/reference/a11y-roles.md` lists what each platform can produce.
 
 ### Changed
+- Two kinds of element now report a different role than before, so a `role:` filter that used to
+  match them no longer does. On Windows, a button that can be toggled (a formatting bar's Bold or
+  Italic) reports `ToggleButton` instead of `Button`; on macOS, a row inside an outline view
+  reports `TreeItem` instead of `ListItem`. `role:` matches exactly — the fallback that also
+  accepts a generically-classified element only rescues ones reported as `Group` or `Other` — so
+  a `glass_wait_for_element` (or any other element selector) asking for `role: "button"` or
+  `role: "listitem"` on those elements needs the new role.
 - The `glass_a11y_snapshot` outline now names the platform's own role token for an element glass
   has no role mapping for: the line reads `Other(AXDisclosureTriangle)` rather than a bare
   `Other`, so a custom control is still identifiable. The token is the platform's stable

--- a/crates/glass-a11y-macos/src/ffi.rs
+++ b/crates/glass-a11y-macos/src/ffi.rs
@@ -43,6 +43,7 @@ use glass_core::{GlassError, Result};
 pub(crate) mod attr {
     pub(crate) const VALUE: &str = "AXValue";
     pub(crate) const ROLE: &str = "AXRole";
+    pub(crate) const SUBROLE: &str = "AXSubrole";
     pub(crate) const ROLE_DESCRIPTION: &str = "AXRoleDescription";
     pub(crate) const TITLE: &str = "AXTitle";
     pub(crate) const DESCRIPTION: &str = "AXDescription";

--- a/crates/glass-a11y-macos/src/mapping.rs
+++ b/crates/glass-a11y-macos/src/mapping.rs
@@ -36,9 +36,21 @@ pub const ROLE_TOKENS: &[(&str, AxRole)] = &[
     ("AXScrollBar", AxRole::ScrollBar),
 ];
 
-/// Map an AX role string to the normalized `AxRole`; unmapped roles become
-/// `AxRole::Other` (the reader keeps the AX role string in `raw_role`).
-pub fn map_role(ax_role: &str) -> AxRole {
+/// AppKit uses `AXSubrole` to say what an element really is only for a handful of base roles —
+/// an `AXRow` is a table row or an outline row, an `AXWindow` is a plain window or a dialog or
+/// a sheet, an `AXTextField` may be a search field. Every other role is already unambiguous,
+/// and each subrole read is an AX IPC round-trip, so the reader asks only for these.
+pub fn subrole_matters(ax_role: &str) -> bool {
+    matches!(
+        ax_role,
+        "AXWindow" | "AXTextField" | "AXRow" | "AXGroup" | "AXUnknown"
+    )
+}
+
+/// Map an AX role string, plus its `AXSubrole` when the reader took one, to the normalized
+/// `AxRole`; unmapped roles become `AxRole::Other` (the reader keeps the token in `raw_role`).
+pub fn map_role(ax_role: &str, subrole: Option<&str>) -> AxRole {
+    let _ = subrole;
     ROLE_TOKENS
         .iter()
         .find(|(token, _)| *token == ax_role)
@@ -101,18 +113,18 @@ mod tests {
 
     #[test]
     fn maps_common_ax_roles() {
-        assert_eq!(map_role("AXButton"), AxRole::Button);
-        assert_eq!(map_role("AXCheckBox"), AxRole::CheckBox);
-        assert_eq!(map_role("AXTextField"), AxRole::TextField);
-        assert_eq!(map_role("AXTextArea"), AxRole::TextArea);
-        assert_eq!(map_role("AXStaticText"), AxRole::Label);
-        assert_eq!(map_role("AXWindow"), AxRole::Window);
+        assert_eq!(map_role("AXButton", None), AxRole::Button);
+        assert_eq!(map_role("AXCheckBox", None), AxRole::CheckBox);
+        assert_eq!(map_role("AXTextField", None), AxRole::TextField);
+        assert_eq!(map_role("AXTextArea", None), AxRole::TextArea);
+        assert_eq!(map_role("AXStaticText", None), AxRole::Label);
+        assert_eq!(map_role("AXWindow", None), AxRole::Window);
     }
 
     #[test]
     fn unmapped_role_is_other() {
-        assert_eq!(map_role("AXRuler"), AxRole::Other);
-        assert_eq!(map_role(""), AxRole::Other);
+        assert_eq!(map_role("AXRuler", None), AxRole::Other);
+        assert_eq!(map_role("", None), AxRole::Other);
     }
 
     #[test]
@@ -130,24 +142,24 @@ mod tests {
 
     #[test]
     fn maps_additional_ax_roles() {
-        assert_eq!(map_role("AXRadioButton"), AxRole::RadioButton);
-        assert_eq!(map_role("AXGroup"), AxRole::Group);
-        assert_eq!(map_role("AXMenu"), AxRole::Menu);
-        assert_eq!(map_role("AXMenuItem"), AxRole::MenuItem);
-        assert_eq!(map_role("AXMenuBar"), AxRole::MenuBar);
-        assert_eq!(map_role("AXImage"), AxRole::Image);
-        assert_eq!(map_role("AXLink"), AxRole::Link);
-        assert_eq!(map_role("AXSlider"), AxRole::Slider);
-        assert_eq!(map_role("AXComboBox"), AxRole::ComboBox);
-        assert_eq!(map_role("AXPopUpButton"), AxRole::ComboBox);
-        assert_eq!(map_role("AXList"), AxRole::List);
-        assert_eq!(map_role("AXRow"), AxRole::ListItem);
-        assert_eq!(map_role("AXCell"), AxRole::Cell);
-        assert_eq!(map_role("AXToolbar"), AxRole::Toolbar);
-        assert_eq!(map_role("AXTabGroup"), AxRole::TabList);
-        assert_eq!(map_role("AXRadioGroup"), AxRole::Group);
-        assert_eq!(map_role("AXProgressIndicator"), AxRole::ProgressBar);
-        assert_eq!(map_role("AXScrollBar"), AxRole::ScrollBar);
+        assert_eq!(map_role("AXRadioButton", None), AxRole::RadioButton);
+        assert_eq!(map_role("AXGroup", None), AxRole::Group);
+        assert_eq!(map_role("AXMenu", None), AxRole::Menu);
+        assert_eq!(map_role("AXMenuItem", None), AxRole::MenuItem);
+        assert_eq!(map_role("AXMenuBar", None), AxRole::MenuBar);
+        assert_eq!(map_role("AXImage", None), AxRole::Image);
+        assert_eq!(map_role("AXLink", None), AxRole::Link);
+        assert_eq!(map_role("AXSlider", None), AxRole::Slider);
+        assert_eq!(map_role("AXComboBox", None), AxRole::ComboBox);
+        assert_eq!(map_role("AXPopUpButton", None), AxRole::ComboBox);
+        assert_eq!(map_role("AXList", None), AxRole::List);
+        assert_eq!(map_role("AXRow", None), AxRole::ListItem);
+        assert_eq!(map_role("AXCell", None), AxRole::Cell);
+        assert_eq!(map_role("AXToolbar", None), AxRole::Toolbar);
+        assert_eq!(map_role("AXTabGroup", None), AxRole::TabList);
+        assert_eq!(map_role("AXRadioGroup", None), AxRole::Group);
+        assert_eq!(map_role("AXProgressIndicator", None), AxRole::ProgressBar);
+        assert_eq!(map_role("AXScrollBar", None), AxRole::ScrollBar);
     }
 
     #[test]
@@ -213,6 +225,29 @@ mod tests {
                 ),
             }
         }
+    }
+
+    #[test]
+    fn subrole_is_read_only_where_it_disambiguates() {
+        // Reading AXSubrole costs an AX IPC round-trip per node, so the reader takes it only
+        // for the base roles where AppKit uses a subrole to say what an element really is.
+        for role in ["AXWindow", "AXTextField", "AXRow", "AXGroup", "AXUnknown"] {
+            assert!(subrole_matters(role), "{role} must be gated in");
+        }
+        for role in ["AXButton", "AXStaticText", "AXCell", "AXImage", ""] {
+            assert!(
+                !subrole_matters(role),
+                "{role} must not pay for a subrole read"
+            );
+        }
+    }
+
+    #[test]
+    fn a_subrole_does_not_change_any_mapping_yet() {
+        // This task wires the subrole through; nothing keys on it until the mapping task.
+        assert_eq!(map_role("AXRow", None), AxRole::ListItem);
+        assert_eq!(map_role("AXRow", Some("AXOutlineRow")), AxRole::ListItem);
+        assert_eq!(map_role("AXButton", Some("AXAnything")), AxRole::Button);
     }
 
     #[test]

--- a/crates/glass-a11y-macos/src/mapping.rs
+++ b/crates/glass-a11y-macos/src/mapping.rs
@@ -42,15 +42,17 @@ pub const ROLE_TOKENS: &[(&str, AxRole)] = &[
     ("AXMenuButton", AxRole::Button),
 ];
 
-/// AppKit uses `AXSubrole` to say what an element really is only for a handful of base roles —
-/// an `AXRow` is a table row or an outline row, an `AXWindow` is a plain window or a dialog or
-/// a sheet, an `AXTextField` may be a search field. Every other role is already unambiguous,
-/// and each subrole read is an AX IPC round-trip, so the reader asks only for these.
+/// Whether the reader should read this base role's `AXSubrole`.
+///
+/// Each subrole read is an AX IPC round-trip on every matching node, so the gate is exactly the
+/// roles whose subrole [`map_role`] actually consults — today `AXRow` alone, where
+/// `AXOutlineRow` separates an outline row ([`AxRole::TreeItem`]) from a plain table row
+/// ([`AxRole::ListItem`]). AppKit gives other base roles subroles too (an `AXWindow` is a plain
+/// window or a dialog or a sheet, an `AXTextField` may be a search field), and they belong here
+/// as soon as something maps them — until then reading them would spend a round-trip per node
+/// on a value nothing reads.
 pub fn subrole_matters(ax_role: &str) -> bool {
-    matches!(
-        ax_role,
-        "AXWindow" | "AXTextField" | "AXRow" | "AXGroup" | "AXUnknown"
-    )
+    ax_role == "AXRow"
 }
 
 /// Map an AX role string, plus its `AXSubrole` when the reader took one, to the normalized
@@ -243,11 +245,21 @@ mod tests {
     #[test]
     fn subrole_is_read_only_where_it_disambiguates() {
         // Reading AXSubrole costs an AX IPC round-trip per node, so the reader takes it only
-        // for the base roles where AppKit uses a subrole to say what an element really is.
-        for role in ["AXWindow", "AXTextField", "AXRow", "AXGroup", "AXUnknown"] {
-            assert!(subrole_matters(role), "{role} must be gated in");
-        }
-        for role in ["AXButton", "AXStaticText", "AXCell", "AXImage", ""] {
+        // for the one base role whose subrole `map_role` consults.
+        assert!(subrole_matters("AXRow"), "AXRow must be gated in");
+        // AXWindow/AXTextField/AXGroup/AXUnknown do carry meaningful subroles, but nothing maps
+        // them, so the read would be paid for and thrown away.
+        for role in [
+            "AXWindow",
+            "AXTextField",
+            "AXGroup",
+            "AXUnknown",
+            "AXButton",
+            "AXStaticText",
+            "AXCell",
+            "AXImage",
+            "",
+        ] {
             assert!(
                 !subrole_matters(role),
                 "{role} must not pay for a subrole read"

--- a/crates/glass-a11y-macos/src/mapping.rs
+++ b/crates/glass-a11y-macos/src/mapping.rs
@@ -34,6 +34,12 @@ pub const ROLE_TOKENS: &[(&str, AxRole)] = &[
     ("AXTabGroup", AxRole::TabList),
     ("AXProgressIndicator", AxRole::ProgressBar),
     ("AXScrollBar", AxRole::ScrollBar),
+    ("AXOutline", AxRole::Tree),
+    ("AXScrollArea", AxRole::Group),
+    ("AXSplitGroup", AxRole::Group),
+    ("AXSplitter", AxRole::Separator),
+    ("AXHeading", AxRole::Heading),
+    ("AXMenuButton", AxRole::Button),
 ];
 
 /// AppKit uses `AXSubrole` to say what an element really is only for a handful of base roles —
@@ -50,7 +56,11 @@ pub fn subrole_matters(ax_role: &str) -> bool {
 /// Map an AX role string, plus its `AXSubrole` when the reader took one, to the normalized
 /// `AxRole`; unmapped roles become `AxRole::Other` (the reader keeps the token in `raw_role`).
 pub fn map_role(ax_role: &str, subrole: Option<&str>) -> AxRole {
-    let _ = subrole;
+    // A row's subrole is what separates an outline row from a table row; AppKit reports both
+    // as AXRow. Every other disambiguation the probe found is expressible in the table.
+    if ax_role == "AXRow" && subrole == Some("AXOutlineRow") {
+        return AxRole::TreeItem;
+    }
     ROLE_TOKENS
         .iter()
         .find(|(token, _)| *token == ax_role)
@@ -214,7 +224,10 @@ mod tests {
     fn map_matches_declared_column() {
         use glass_core::role_support::{support, AxBackend, RoleSupport};
         for role in AxRole::ALL {
-            let mapped = ROLE_TOKENS.iter().any(|(_, r)| *r == role);
+            // The outline-row/table-row split happens outside the token table (see
+            // `map_role`'s subrole check), so table membership alone would miss TreeItem.
+            let mapped = ROLE_TOKENS.iter().any(|(_, r)| *r == role)
+                || map_role("AXRow", Some("AXOutlineRow")) == role;
             match support(role, AxBackend::MacOs).expect("declared in ROLE_SUPPORT") {
                 RoleSupport::Mapped => {
                     assert!(mapped, "{role:?} declared Mapped but no AX role maps to it")
@@ -243,11 +256,38 @@ mod tests {
     }
 
     #[test]
-    fn a_subrole_does_not_change_any_mapping_yet() {
-        // This task wires the subrole through; nothing keys on it until the mapping task.
-        assert_eq!(map_role("AXRow", None), AxRole::ListItem);
-        assert_eq!(map_role("AXRow", Some("AXOutlineRow")), AxRole::ListItem);
+    fn a_subrole_that_does_not_disambiguate_leaves_the_mapping_unchanged() {
+        // AXRow/AXOutlineRow is the one subrole combination that changes the mapped role (see
+        // `an_outline_row_is_a_tree_item_a_plain_row_is_a_list_item`); every other role ignores
+        // whatever subrole the reader happened to pass.
         assert_eq!(map_role("AXButton", Some("AXAnything")), AxRole::Button);
+    }
+
+    #[test]
+    fn observed_tokens_map() {
+        // Every token here was observed in a stock-app probe run. Nothing is mapped that a
+        // real app did not emit.
+        assert_eq!(map_role("AXOutline", None), AxRole::Tree);
+        assert_eq!(map_role("AXScrollArea", None), AxRole::Group);
+        assert_eq!(map_role("AXSplitGroup", None), AxRole::Group);
+        assert_eq!(map_role("AXSplitter", None), AxRole::Separator);
+        assert_eq!(map_role("AXHeading", None), AxRole::Heading);
+        assert_eq!(map_role("AXMenuButton", None), AxRole::Button);
+    }
+
+    #[test]
+    fn an_outline_row_is_a_tree_item_a_plain_row_is_a_list_item() {
+        assert_eq!(map_role("AXRow", Some("AXOutlineRow")), AxRole::TreeItem);
+        assert_eq!(map_role("AXRow", None), AxRole::ListItem);
+        assert_eq!(map_role("AXRow", Some("AXTableRow")), AxRole::ListItem);
+    }
+
+    #[test]
+    fn an_unobserved_token_stays_unmapped() {
+        // AXTable never appeared in any probed app — the lists are outlines. No arm.
+        assert_eq!(map_role("AXTable", None), AxRole::Other);
+        // A column is a table sub-structure with no counterpart in the normalized set.
+        assert_eq!(map_role("AXColumn", None), AxRole::Other);
     }
 
     #[test]

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -105,7 +105,10 @@ impl Accessibility for MacosA11y {
         // different same-role+name element on this pre-order id, its bounds sit elsewhere
         // and it is rejected here rather than silently overwritten.
         let ax_role = ffi::attribute_string(&el, attr::ROLE).unwrap_or_default();
-        let role = mapping::map_role(&ax_role);
+        let subrole = mapping::subrole_matters(&ax_role)
+            .then(|| ffi::attribute_string(&el, attr::SUBROLE))
+            .flatten();
+        let role = mapping::map_role(&ax_role, subrole.as_deref());
         let name = ffi::attribute_string(&el, attr::TITLE)
             .or_else(|| ffi::attribute_string(&el, attr::DESCRIPTION));
         let bounds = window_relative_rect(&el, scale, &ctx.window);
@@ -165,7 +168,10 @@ impl Accessibility for MacosA11y {
 
         // Same fingerprint gate as set_value: role + name + bounds.
         let ax_role = ffi::attribute_string(&el, attr::ROLE).unwrap_or_default();
-        let role = mapping::map_role(&ax_role);
+        let subrole = mapping::subrole_matters(&ax_role)
+            .then(|| ffi::attribute_string(&el, attr::SUBROLE))
+            .flatten();
+        let role = mapping::map_role(&ax_role, subrole.as_deref());
         let name = ffi::attribute_string(&el, attr::TITLE)
             .or_else(|| ffi::attribute_string(&el, attr::DESCRIPTION));
         let bounds = window_relative_rect(&el, scale, &ctx.window);
@@ -309,10 +315,18 @@ fn walk(
     budget.visit();
 
     let ax_role = ffi::attribute_string(el, attr::ROLE).unwrap_or_default();
-    let role = mapping::map_role(&ax_role);
+    // `AXSubrole` costs an AX IPC round-trip, so it's read only for the base roles where
+    // AppKit actually uses it to disambiguate (`mapping::subrole_matters`) — every other node
+    // skips it.
+    let subrole = mapping::subrole_matters(&ax_role)
+        .then(|| ffi::attribute_string(el, attr::SUBROLE))
+        .flatten();
+    let role = mapping::map_role(&ax_role, subrole.as_deref());
     // `raw_role` is normally the same AX role string `map_role` just matched on — the token, not
     // `AXRoleDescription`'s localized human phrase ("button" / "bouton"), which is useless as a
-    // mapping key and not worth a second attribute read on every node.
+    // mapping key and not worth a second attribute read on every node. When a subrole was read
+    // and is non-empty, it's appended (`"AXRow/AXOutlineRow"`) so a probe can see what
+    // disambiguated the role.
     //
     // The fallback is conditional because that trade only holds while `AXRole` says something.
     // A custom or non-standard control is expected to report a generic role — `AXUnknown`, or no
@@ -323,7 +337,10 @@ fn walk(
     let raw_role = if ax_role.is_empty() || ax_role == "AXUnknown" {
         ffi::attribute_string(el, attr::ROLE_DESCRIPTION).unwrap_or(ax_role)
     } else {
-        ax_role
+        match &subrole {
+            Some(sub) if !sub.is_empty() => format!("{ax_role}/{sub}"),
+            _ => ax_role,
+        }
     };
     // Name = title, else description — both stable labels (e.g. `setAccessibilityLabel`
     // surfaces as `AXDescription`). Never fold in `AXValue`: it's volatile content, and a

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -105,10 +105,7 @@ impl Accessibility for MacosA11y {
         // different same-role+name element on this pre-order id, its bounds sit elsewhere
         // and it is rejected here rather than silently overwritten.
         let ax_role = ffi::attribute_string(&el, attr::ROLE).unwrap_or_default();
-        let subrole = mapping::subrole_matters(&ax_role)
-            .then(|| ffi::attribute_string(&el, attr::SUBROLE))
-            .flatten();
-        let role = mapping::map_role(&ax_role, subrole.as_deref());
+        let role = mapping::map_role(&ax_role, read_subrole(&el, &ax_role).as_deref());
         let name = ffi::attribute_string(&el, attr::TITLE)
             .or_else(|| ffi::attribute_string(&el, attr::DESCRIPTION));
         let bounds = window_relative_rect(&el, scale, &ctx.window);
@@ -168,10 +165,7 @@ impl Accessibility for MacosA11y {
 
         // Same fingerprint gate as set_value: role + name + bounds.
         let ax_role = ffi::attribute_string(&el, attr::ROLE).unwrap_or_default();
-        let subrole = mapping::subrole_matters(&ax_role)
-            .then(|| ffi::attribute_string(&el, attr::SUBROLE))
-            .flatten();
-        let role = mapping::map_role(&ax_role, subrole.as_deref());
+        let role = mapping::map_role(&ax_role, read_subrole(&el, &ax_role).as_deref());
         let name = ffi::attribute_string(&el, attr::TITLE)
             .or_else(|| ffi::attribute_string(&el, attr::DESCRIPTION));
         let bounds = window_relative_rect(&el, scale, &ctx.window);
@@ -301,6 +295,39 @@ fn select_window(
     best.map(|(_, w, scale)| (w, scale))
 }
 
+/// `el`'s `AXSubrole`, but only for the base roles whose subrole actually changes the mapped
+/// role ([`mapping::subrole_matters`]) — every other node skips the AX IPC round-trip and gets
+/// `None`.
+///
+/// The one place this read happens, so the three sites that map a role — [`walk`],
+/// `set_value`'s fingerprint and `invoke`'s — cannot gate or read it differently and land on
+/// different roles for the same node (the Windows reader shares its `toggle_pattern` helper for
+/// the same reason: `set_value` re-walks to an id captured from a snapshot, and a fingerprint
+/// computed from a differently-read role would reject an element that never moved).
+///
+/// Reads through the *error-aware* [`ffi::attribute_string_checked`] rather than
+/// [`ffi::attribute_string`], which folds a genuine read failure into the same `None` as a
+/// legitimately-absent attribute: an `AXOutlineRow` whose subrole read broke would silently
+/// degrade to `ListItem` with nothing to show for it. A failure still degrades to `None` — one
+/// unreadable attribute must not fail a whole snapshot — but it logs first, the same
+/// diagnostic-not-silence treatment `ffi::children` and `ffi::action_names` already get. Costs
+/// exactly the one attribute copy the direct read did.
+fn read_subrole(el: &AXUIElement, ax_role: &str) -> Option<String> {
+    if !mapping::subrole_matters(ax_role) {
+        return None;
+    }
+    match ffi::attribute_string_checked(el, attr::SUBROLE) {
+        Ok(sub) => sub,
+        Err(err) => {
+            eprintln!(
+                "glass-a11y-macos: AXSubrole read failed for role={ax_role:?}: {err}; \
+                 treating the element as having no subrole"
+            );
+            None
+        }
+    }
+}
+
 /// Pre-order walk: build this element's [`AxNode`], then recurse into its (non-skipped)
 /// children in array order. `budget` tracks the running node total and records which
 /// bound (if any) stopped the walk early — shared across the whole walk, and with
@@ -315,18 +342,14 @@ fn walk(
     budget.visit();
 
     let ax_role = ffi::attribute_string(el, attr::ROLE).unwrap_or_default();
-    // `AXSubrole` costs an AX IPC round-trip, so it's read only for the base roles where
-    // AppKit actually uses it to disambiguate (`mapping::subrole_matters`) — every other node
-    // skips it.
-    let subrole = mapping::subrole_matters(&ax_role)
-        .then(|| ffi::attribute_string(el, attr::SUBROLE))
-        .flatten();
+    let subrole = read_subrole(el, &ax_role);
     let role = mapping::map_role(&ax_role, subrole.as_deref());
     // `raw_role` is normally the same AX role string `map_role` just matched on — the token, not
     // `AXRoleDescription`'s localized human phrase ("button" / "bouton"), which is useless as a
     // mapping key and not worth a second attribute read on every node. When a subrole was read
-    // and is non-empty, it's appended (`"AXRow/AXOutlineRow"`) so a probe can see what
-    // disambiguated the role.
+    // and is non-empty it is appended (`"AXRow/AXOutlineRow"`); only `AXRow` is ever read (see
+    // `read_subrole`), so that says which kind of row a row is — an outline row (`TreeItem`)
+    // or a plain table row (`ListItem`) — and nothing more.
     //
     // The fallback is conditional because that trade only holds while `AXRole` says something.
     // A custom or non-standard control is expected to report a generic role — `AXUnknown`, or no

--- a/crates/glass-a11y-windows/src/mapping.rs
+++ b/crates/glass-a11y-windows/src/mapping.rs
@@ -52,8 +52,10 @@ pub const CONTROL_TYPES: &[(u32, &str, Option<AxRole>)] = &[
     (50031, "SplitButton", Some(AxRole::Button)),
     (50032, "Window", Some(AxRole::Window)),
     (50033, "Pane", Some(AxRole::Group)),
-    (50034, "Header", Some(AxRole::Heading)),
-    (50035, "HeaderItem", Some(AxRole::Heading)),
+    // Header/HeaderItem are a grid's column-header bar and its individual column headers, not
+    // document headings — deliberately unmapped; see `observed_column_headers_are_not_headings`.
+    (50034, "Header", None),
+    (50035, "HeaderItem", None),
     (50036, "Table", Some(AxRole::Table)),
     (50037, "TitleBar", None),
     (50038, "Separator", Some(AxRole::Separator)),
@@ -215,12 +217,10 @@ mod tests {
     }
 
     #[test]
-    fn document_and_headers_map_from_observed_tokens() {
-        // Observed on a stock text editor (Document) and a stock task manager (Header,
-        // HeaderItem) — see the probe test in crates/glass-windows/tests/onbox.rs.
+    fn document_maps_from_an_observed_token() {
+        // Observed on a stock text editor — see the probe test in
+        // crates/glass-windows/tests/onbox.rs.
         assert_eq!(map_role(50030, false), AxRole::TextArea);
-        assert_eq!(map_role(50034, false), AxRole::Heading);
-        assert_eq!(map_role(50035, false), AxRole::Heading);
     }
 
     #[test]
@@ -229,6 +229,19 @@ mod tests {
         // TreeItem. No observation, no arm.
         assert_eq!(map_role(50029, false), AxRole::Other);
         assert_eq!(canonical_name(50029), Some("DataItem"));
+    }
+
+    #[test]
+    fn observed_column_headers_are_not_headings() {
+        // Header/HeaderItem WERE observed (a stock task manager's and file manager's list
+        // views), so this pin is not about missing evidence: UIA's Header is a grid's
+        // column-header bar and HeaderItem one of its column headers, whereas every other
+        // backend's Heading means a document/section heading (AT-SPI maps only Role::Heading
+        // and lets ColumnHeader fall through). Mapping these would make `role:"heading"` match
+        // a file list's column header here and nothing at all on Linux for the same app, so
+        // they stay `Other` — identified by the name UIA already gives them.
+        assert_eq!(map_role(50034, false), AxRole::Other);
+        assert_eq!(map_role(50035, false), AxRole::Other);
     }
 
     #[test]

--- a/crates/glass-a11y-windows/src/mapping.rs
+++ b/crates/glass-a11y-windows/src/mapping.rs
@@ -47,13 +47,13 @@ pub const CONTROL_TYPES: &[(u32, &str, Option<AxRole>)] = &[
     (50027, "Thumb", None),
     (50028, "DataGrid", Some(AxRole::Table)),
     (50029, "DataItem", None),
-    (50030, "Document", None),
+    (50030, "Document", Some(AxRole::TextArea)),
     // A split button is an actionable button carrying a dropdown.
     (50031, "SplitButton", Some(AxRole::Button)),
     (50032, "Window", Some(AxRole::Window)),
     (50033, "Pane", Some(AxRole::Group)),
-    (50034, "Header", None),
-    (50035, "HeaderItem", None),
+    (50034, "Header", Some(AxRole::Heading)),
+    (50035, "HeaderItem", Some(AxRole::Heading)),
     (50036, "Table", Some(AxRole::Table)),
     (50037, "TitleBar", None),
     (50038, "Separator", Some(AxRole::Separator)),
@@ -69,10 +69,21 @@ fn control_type(control_type_id: u32) -> Option<&'static (u32, &'static str, Opt
         .find(|(id, _, _)| *id == control_type_id)
 }
 
-/// Map a UIA `ControlTypeId` to the normalized `AxRole`; a control type glass does not map —
-/// known or not — becomes `AxRole::Other` (the reader keeps the control type's name in
-/// `raw_role`).
-pub fn map_role(control_type_id: u32) -> AxRole {
+/// Map a UIA `ControlTypeId` plus Toggle-pattern availability to the normalized `AxRole`.
+///
+/// UIA has no dedicated "toggle button" control type — a formatting-bar button (Bold, Italic,
+/// ...) reports as a plain `Button` (50000) and carries the Toggle pattern instead, the same
+/// pattern a `CheckBox`/`RadioButton` carries. `toggleable` is that pattern's *availability*
+/// (see `StateFacts::checkable`), passed in because computing it means a live UIA call this
+/// module cannot make. Only `Button` is affected: `CheckBox` (50002) and `RadioButton` (50013)
+/// already have their own roles regardless of `toggleable`.
+///
+/// A control type glass does not map — known or not — becomes `AxRole::Other` (the reader keeps
+/// the control type's name in `raw_role`).
+pub fn map_role(control_type_id: u32, toggleable: bool) -> AxRole {
+    if control_type_id == 50000 && toggleable {
+        return AxRole::ToggleButton;
+    }
     control_type(control_type_id)
         .and_then(|(_, _, role)| *role)
         .unwrap_or(AxRole::Other)
@@ -131,20 +142,20 @@ mod tests {
 
     #[test]
     fn common_control_types_map() {
-        assert_eq!(map_role(50000), AxRole::Button);
-        assert_eq!(map_role(50002), AxRole::CheckBox);
-        assert_eq!(map_role(50004), AxRole::TextField);
-        assert_eq!(map_role(50011), AxRole::MenuItem);
-        assert_eq!(map_role(50018), AxRole::TabList);
-        assert_eq!(map_role(50019), AxRole::Tab);
-        assert_eq!(map_role(50032), AxRole::Window);
-        assert_eq!(map_role(50020), AxRole::Label);
-        assert_eq!(map_role(50031), AxRole::Button); // SplitButton
+        assert_eq!(map_role(50000, false), AxRole::Button);
+        assert_eq!(map_role(50002, false), AxRole::CheckBox);
+        assert_eq!(map_role(50004, false), AxRole::TextField);
+        assert_eq!(map_role(50011, false), AxRole::MenuItem);
+        assert_eq!(map_role(50018, false), AxRole::TabList);
+        assert_eq!(map_role(50019, false), AxRole::Tab);
+        assert_eq!(map_role(50032, false), AxRole::Window);
+        assert_eq!(map_role(50020, false), AxRole::Label);
+        assert_eq!(map_role(50031, false), AxRole::Button); // SplitButton
     }
     #[test]
     fn unmapped_control_type_is_other() {
-        assert_eq!(map_role(50001), AxRole::Other); // Calendar
-        assert_eq!(map_role(99999), AxRole::Other);
+        assert_eq!(map_role(50001, false), AxRole::Other); // Calendar
+        assert_eq!(map_role(99999, false), AxRole::Other);
     }
     #[test]
     fn offscreen_clears_visible_and_toggle_sets_checked() {
@@ -204,6 +215,42 @@ mod tests {
     }
 
     #[test]
+    fn document_and_headers_map_from_observed_tokens() {
+        // Observed on a stock text editor (Document) and a stock task manager (Header,
+        // HeaderItem) — see the probe test in crates/glass-windows/tests/onbox.rs.
+        assert_eq!(map_role(50030, false), AxRole::TextArea);
+        assert_eq!(map_role(50034, false), AxRole::Heading);
+        assert_eq!(map_role(50035, false), AxRole::Heading);
+    }
+
+    #[test]
+    fn unobserved_control_types_stay_unmapped() {
+        // DataItem is documented but no probed app emitted it — a data grid's rows arrived as
+        // TreeItem. No observation, no arm.
+        assert_eq!(map_role(50029, false), AxRole::Other);
+        assert_eq!(canonical_name(50029), Some("DataItem"));
+    }
+
+    #[test]
+    fn toggleable_button_maps_to_toggle_button() {
+        // Observed on a stock text editor's formatting bar: Button nodes carrying the Toggle
+        // pattern (Bold, Italic, Strikethrough, Link, Clear formatting).
+        assert_eq!(map_role(50000, true), AxRole::ToggleButton);
+    }
+
+    #[test]
+    fn non_toggleable_button_stays_button() {
+        assert_eq!(map_role(50000, false), AxRole::Button);
+    }
+
+    #[test]
+    fn toggleable_checkbox_stays_checkbox() {
+        // The toggle-capable rule is scoped to Button; CheckBox already has its own role and
+        // the probe explicitly excluded it.
+        assert_eq!(map_role(50002, true), AxRole::CheckBox);
+    }
+
+    #[test]
     fn control_types_have_no_duplicate_ids() {
         for (i, (id, _, _)) in CONTROL_TYPES.iter().enumerate() {
             assert!(
@@ -238,14 +285,10 @@ mod tests {
 
     #[test]
     fn a_known_but_unmapped_control_type_still_has_a_name() {
-        // These are exactly the ids the role-support matrix's Windows gaps point at, and what
-        // a probe run has to read; reporting them as `UIA:50029` would defeat that.
+        // DataItem is exactly the id the role-support matrix's remaining Windows Cell gap points
+        // at, and what a probe run has to read; reporting it as `UIA:50029` would defeat that.
         assert_eq!(canonical_name(50029), Some("DataItem"));
-        assert_eq!(canonical_name(50030), Some("Document"));
-        assert_eq!(canonical_name(50034), Some("Header"));
-        assert_eq!(map_role(50029), AxRole::Other);
-        assert_eq!(map_role(50030), AxRole::Other);
-        assert_eq!(map_role(50034), AxRole::Other);
+        assert_eq!(map_role(50029, false), AxRole::Other);
     }
 
     #[test]
@@ -254,8 +297,12 @@ mod tests {
         use glass_core::AxRole;
         for role in AxRole::ALL {
             // Only a row carrying `Some(role)` produces a role; a named-but-unmapped control
-            // type yields `Other` and must not count as coverage.
-            let mapped = CONTROL_TYPES.iter().any(|(_, _, r)| *r == Some(role));
+            // type yields `Other` and must not count as coverage. `ToggleButton` is the one
+            // role no `CONTROL_TYPES` row produces on its own — it comes from `map_role`'s
+            // Button-plus-Toggle-pattern rule — so it is checked by calling the real function
+            // with the fact that triggers it, not by a hardcoded exception.
+            let mapped = CONTROL_TYPES.iter().any(|(_, _, r)| *r == Some(role))
+                || map_role(50000, true) == role;
             match support(role, AxBackend::Windows).expect("declared in ROLE_SUPPORT") {
                 RoleSupport::Mapped => {
                     assert!(

--- a/crates/glass-a11y-windows/src/mapping.rs
+++ b/crates/glass-a11y-windows/src/mapping.rs
@@ -75,10 +75,14 @@ fn control_type(control_type_id: u32) -> Option<&'static (u32, &'static str, Opt
 ///
 /// UIA has no dedicated "toggle button" control type — a formatting-bar button (Bold, Italic,
 /// ...) reports as a plain `Button` (50000) and carries the Toggle pattern instead, the same
-/// pattern a `CheckBox`/`RadioButton` carries. `toggleable` is that pattern's *availability*
+/// pattern a `CheckBox` carries. A `RadioButton` does not: UIA documents the Toggle pattern as
+/// never supported on a radio button, whose on/off is *selection* (SelectionItem), which is why
+/// the reader's pattern gate leaves it out. `toggleable` is that pattern's *availability*
 /// (see `StateFacts::checkable`), passed in because computing it means a live UIA call this
 /// module cannot make. Only `Button` is affected: `CheckBox` (50002) and `RadioButton` (50013)
-/// already have their own roles regardless of `toggleable`.
+/// already have their own roles regardless of `toggleable`, and so do the other two control
+/// types the reader fetches the pattern for — `MenuItem` (50011), which really can arrive
+/// toggle-capable as a checkable menu entry, and `SplitButton` (50031).
 ///
 /// A control type glass does not map — known or not — becomes `AxRole::Other` (the reader keeps
 /// the control type's name in `raw_role`).
@@ -266,6 +270,21 @@ mod tests {
     }
 
     #[test]
+    fn toggleable_menu_item_stays_menu_item() {
+        // Not hypothetical: the reader fetches the Toggle pattern for MenuItem, and a checkable
+        // menu entry really does carry it, so `toggleable == true` reaches here in production.
+        // "Only Button is affected" has to hold for it.
+        assert_eq!(map_role(50011, true), AxRole::MenuItem);
+    }
+
+    #[test]
+    fn toggleable_split_button_stays_button() {
+        // The fourth control type in the reader's Toggle-pattern gate. A SplitButton maps to
+        // Button either way — the toggle-capable rule is scoped to control type 50000 alone.
+        assert_eq!(map_role(50031, true), AxRole::Button);
+    }
+
+    #[test]
     fn control_types_have_no_duplicate_ids() {
         for (i, (id, _, _)) in CONTROL_TYPES.iter().enumerate() {
             assert!(
@@ -294,6 +313,12 @@ mod tests {
     fn canonical_name_is_stable_and_locale_free() {
         assert_eq!(canonical_name(50000), Some("Button"));
         assert_eq!(canonical_name(50036), Some("Table"));
+        // Document and Header are what the reader puts in `raw_role` for two control types a
+        // probe run has to be able to read back by name — Header especially, since it maps to
+        // no role at all (see `observed_column_headers_are_not_headings`) and the name is the
+        // only thing identifying it.
+        assert_eq!(canonical_name(50030), Some("Document"));
+        assert_eq!(canonical_name(50034), Some("Header"));
         assert_eq!(canonical_name(49999), None);
         assert_eq!(canonical_name(50041), None);
     }

--- a/crates/glass-a11y-windows/src/mapping.rs
+++ b/crates/glass-a11y-windows/src/mapping.rs
@@ -239,15 +239,17 @@ mod tests {
     }
 
     #[test]
-    fn non_toggleable_button_stays_button() {
-        assert_eq!(map_role(50000, false), AxRole::Button);
-    }
-
-    #[test]
     fn toggleable_checkbox_stays_checkbox() {
         // The toggle-capable rule is scoped to Button; CheckBox already has its own role and
         // the probe explicitly excluded it.
         assert_eq!(map_role(50002, true), AxRole::CheckBox);
+    }
+
+    #[test]
+    fn toggleable_radio_button_stays_radio_button() {
+        // Same scoping as CheckBox above: RadioButton already has its own role and the probe
+        // explicitly excluded it too.
+        assert_eq!(map_role(50013, true), AxRole::RadioButton);
     }
 
     #[test]

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -199,31 +199,34 @@ fn walk(
     })
 }
 
-/// Whether `el` publishes the UIA Toggle pattern, gated by control type (Button/CheckBox/
-/// MenuItem/SplitButton — the only types that carry it) so this never issues a live
-/// cross-process `get_pattern` call for a control that cannot support it. This is the one fact
-/// two different things key off: `StateFacts::checkable` (toggle-pattern availability) and
+/// Fetch `el`'s UIA Toggle pattern, gated by control type (Button/CheckBox/MenuItem/
+/// SplitButton — the only types that carry it) so this never issues a live cross-process
+/// `get_pattern` call for a control that cannot support it. One fetch answers two questions:
+/// `StateFacts::checkable` is this pattern's mere *presence* (the control exposes on/off
+/// semantics at all, independent of whether the current state is also readable), and
 /// `map_role`'s rule that a toggle-capable `Button` — a formatting-bar button, say — is a
-/// `ToggleButton` rather than a plain one. Shared by `gather` and the verify-fingerprint role
-/// lookups in `run_set_value`/`run_invoke` so a node maps to the same role regardless of which
-/// path reads it.
-fn has_toggle_pattern(el: &UIElement, ct_id: u32) -> bool {
+/// `ToggleButton` rather than a plain one keys off the same presence. Shared by `gather` and
+/// the verify-fingerprint role lookups in `run_set_value`/`run_invoke`, so a node maps to the
+/// same role regardless of which path reads it, and only one COM round-trip is spent per node
+/// either way — the same reason the value-pattern probe below fetches once for two facts.
+fn toggle_pattern(el: &UIElement, ct_id: u32) -> Option<UITogglePattern> {
     matches!(ct_id, 50000 | 50002 | 50011 | 50031) // Button/CheckBox/MenuItem/SplitButton
-        && el.get_pattern::<UITogglePattern>().is_ok()
+        .then(|| el.get_pattern::<UITogglePattern>().ok())
+        .flatten()
 }
 
 /// Gather state facts + the value string in one pass, gating each pattern probe by control type
 /// so we don't make a live cross-process `get_pattern` call for a pattern the control can't support
 /// (UIA is chatty — each probe is an out-of-process COM round-trip).
 fn gather(el: &UIElement, ct_id: u32) -> (crate::mapping::StateFacts, Option<String>) {
-    let checkable = has_toggle_pattern(el, ct_id);
-    let toggled_on = checkable
-        && el
-            .get_pattern::<UITogglePattern>()
-            .ok()
-            .and_then(|p| p.get_toggle_state().ok())
-            .map(|s| s == ToggleState::On)
-            .unwrap_or(false);
+    // Fetch the Toggle pattern once: its mere presence is `checkable` (the control exposes
+    // on/off semantics at all), independent of whether we can also read its current state.
+    let pattern = toggle_pattern(el, ct_id);
+    let checkable = pattern.is_some();
+    let toggled_on = pattern
+        .and_then(|p| p.get_toggle_state().ok())
+        .map(|s| s == ToggleState::On)
+        .unwrap_or(false);
     let selected = matches!(ct_id, 50007 | 50019 | 50024 | 50029) // ListItem/TabItem/TreeItem/DataItem
         && el.get_pattern::<UISelectionItemPattern>().ok()
             .and_then(|p| p.is_selected().ok()).unwrap_or(false);
@@ -312,7 +315,7 @@ fn run_set_value(ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
     // bounds fingerprint — the element sits elsewhere — rejects it. A target
     // without captured bounds falls back to role+name only.
     let ct_id = el.get_control_type().map_err(uia_err)? as i32 as u32;
-    let role = crate::mapping::map_role(ct_id, has_toggle_pattern(&el, ct_id));
+    let role = crate::mapping::map_role(ct_id, toggle_pattern(&el, ct_id).is_some());
     let name = nonempty(el.get_name().unwrap_or_default());
     let bounds = window_relative_bounds(&el, (ctx.window.x, ctx.window.y));
     if !target.matches(role, name.as_deref())
@@ -384,7 +387,7 @@ fn run_invoke(ctx: &AxContext, target: &AxTarget) -> Result<()> {
 
     // Same fingerprint gate as run_set_value: role + name + bounds.
     let ct_id = el.get_control_type().map_err(uia_err)? as i32 as u32;
-    let role = crate::mapping::map_role(ct_id, has_toggle_pattern(&el, ct_id));
+    let role = crate::mapping::map_role(ct_id, toggle_pattern(&el, ct_id).is_some());
     let name = nonempty(el.get_name().unwrap_or_default());
     let bounds = window_relative_bounds(&el, (ctx.window.x, ctx.window.y));
     if !target.matches(role, name.as_deref())

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -189,7 +189,7 @@ fn walk(
 
     Ok(AxNode {
         id: AxNodeId(0), // assigned by glass_core::AxTree::assign_ids
-        role: crate::mapping::map_role(ct_id),
+        role: crate::mapping::map_role(ct_id, facts.checkable),
         raw_role,
         name,
         value,
@@ -199,20 +199,31 @@ fn walk(
     })
 }
 
+/// Whether `el` publishes the UIA Toggle pattern, gated by control type (Button/CheckBox/
+/// MenuItem/SplitButton — the only types that carry it) so this never issues a live
+/// cross-process `get_pattern` call for a control that cannot support it. This is the one fact
+/// two different things key off: `StateFacts::checkable` (toggle-pattern availability) and
+/// `map_role`'s rule that a toggle-capable `Button` — a formatting-bar button, say — is a
+/// `ToggleButton` rather than a plain one. Shared by `gather` and the verify-fingerprint role
+/// lookups in `run_set_value`/`run_invoke` so a node maps to the same role regardless of which
+/// path reads it.
+fn has_toggle_pattern(el: &UIElement, ct_id: u32) -> bool {
+    matches!(ct_id, 50000 | 50002 | 50011 | 50031) // Button/CheckBox/MenuItem/SplitButton
+        && el.get_pattern::<UITogglePattern>().is_ok()
+}
+
 /// Gather state facts + the value string in one pass, gating each pattern probe by control type
 /// so we don't make a live cross-process `get_pattern` call for a pattern the control can't support
 /// (UIA is chatty — each probe is an out-of-process COM round-trip).
 fn gather(el: &UIElement, ct_id: u32) -> (crate::mapping::StateFacts, Option<String>) {
-    // Fetch the Toggle pattern once: its mere presence is `checkable` (the control exposes
-    // on/off semantics at all), independent of whether we can also read its current state.
-    let toggle_pattern = matches!(ct_id, 50000 | 50002 | 50011 | 50031) // Button/CheckBox/MenuItem/SplitButton
-        .then(|| el.get_pattern::<UITogglePattern>().ok())
-        .flatten();
-    let checkable = toggle_pattern.is_some();
-    let toggled_on = toggle_pattern
-        .and_then(|p| p.get_toggle_state().ok())
-        .map(|s| s == ToggleState::On)
-        .unwrap_or(false);
+    let checkable = has_toggle_pattern(el, ct_id);
+    let toggled_on = checkable
+        && el
+            .get_pattern::<UITogglePattern>()
+            .ok()
+            .and_then(|p| p.get_toggle_state().ok())
+            .map(|s| s == ToggleState::On)
+            .unwrap_or(false);
     let selected = matches!(ct_id, 50007 | 50019 | 50024 | 50029) // ListItem/TabItem/TreeItem/DataItem
         && el.get_pattern::<UISelectionItemPattern>().ok()
             .and_then(|p| p.is_selected().ok()).unwrap_or(false);
@@ -300,7 +311,8 @@ fn run_set_value(ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
     // drift lands a different same-role+name element on this pre-order id, the
     // bounds fingerprint — the element sits elsewhere — rejects it. A target
     // without captured bounds falls back to role+name only.
-    let role = crate::mapping::map_role(el.get_control_type().map_err(uia_err)? as i32 as u32);
+    let ct_id = el.get_control_type().map_err(uia_err)? as i32 as u32;
+    let role = crate::mapping::map_role(ct_id, has_toggle_pattern(&el, ct_id));
     let name = nonempty(el.get_name().unwrap_or_default());
     let bounds = window_relative_bounds(&el, (ctx.window.x, ctx.window.y));
     if !target.matches(role, name.as_deref())
@@ -371,7 +383,8 @@ fn run_invoke(ctx: &AxContext, target: &AxTarget) -> Result<()> {
         .ok_or(GlassError::AxElementChanged(target.id.0))?;
 
     // Same fingerprint gate as run_set_value: role + name + bounds.
-    let role = crate::mapping::map_role(el.get_control_type().map_err(uia_err)? as i32 as u32);
+    let ct_id = el.get_control_type().map_err(uia_err)? as i32 as u32;
+    let role = crate::mapping::map_role(ct_id, has_toggle_pattern(&el, ct_id));
     let name = nonempty(el.get_name().unwrap_or_default());
     let bounds = window_relative_bounds(&el, (ctx.window.x, ctx.window.y));
     if !target.matches(role, name.as_deref())

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -209,10 +209,38 @@ fn walk(
 /// the verify-fingerprint role lookups in `run_set_value`/`run_invoke`, so a node maps to the
 /// same role regardless of which path reads it, and only one COM round-trip is spent per node
 /// either way — the same reason the value-pattern probe below fetches once for two facts.
+///
+/// "This control has no Toggle pattern" and "the fetch failed" both yield `None` — a failure
+/// must not fail a whole snapshot over one node — but they are not the same event, and only one
+/// of them is a bug: a transient failure reports a toggle-capable `Button` as a plain `Button`,
+/// and since the same value feeds the `run_set_value`/`run_invoke` fingerprint, it surfaces to
+/// the caller as `AxElementChanged` ("the tree drifted") for an element that never moved. So the
+/// failure case logs. The two are told apart by the returned code: UIA documents
+/// `GetCurrentPattern` as returning success with a NULL interface for an unsupported pattern,
+/// which the bindings surface as an error carrying a *non-failure* code (`Error::result()` is
+/// `None`); a real COM failure carries a failure `HRESULT`. Neither path costs an extra
+/// round-trip.
 fn toggle_pattern(el: &UIElement, ct_id: u32) -> Option<UITogglePattern> {
-    matches!(ct_id, 50000 | 50002 | 50011 | 50031) // Button/CheckBox/MenuItem/SplitButton
-        .then(|| el.get_pattern::<UITogglePattern>().ok())
-        .flatten()
+    if !matches!(ct_id, 50000 | 50002 | 50011 | 50031) {
+        // Button/CheckBox/MenuItem/SplitButton
+        return None;
+    }
+    match el.get_pattern::<UITogglePattern>() {
+        Ok(p) => Some(p),
+        Err(e) => {
+            if e.result().is_some() {
+                // Dev-tool diagnostic (stderr only, same shape as `select_window`'s in the
+                // macOS reader): without it, a control whose Toggle fetch broke is
+                // indistinguishable after the fact from one that never had the pattern.
+                eprintln!(
+                    "glass-a11y-windows: Toggle-pattern fetch failed on control type {ct_id} \
+                     (HRESULT {:#010x}: {e}); treating the element as not toggle-capable",
+                    e.code()
+                );
+            }
+            None
+        }
+    }
 }
 
 /// Gather state facts + the value string in one pass, gating each pattern probe by control type

--- a/crates/glass-core/src/role_support.rs
+++ b/crates/glass-core/src/role_support.rs
@@ -234,7 +234,7 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] =
             [
                 Mapped,
                 Mapped,
-                Gap("AXOutline is not mapped yet"),
+                Mapped,
                 NotApplicable("Android has no tree widget"),
                 NotApplicable("UIKit has no outline view"),
             ],
@@ -244,7 +244,7 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] =
             [
                 Mapped,
                 Mapped,
-                Gap("the outline-row subrole is not read yet"),
+                Mapped,
                 NotApplicable("Android has no tree widget"),
                 NotApplicable("UIKit has no outline view"),
             ],
@@ -317,7 +317,7 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] =
             [
                 Mapped,
                 Mapped,
-                Gap("AXSplitter is not mapped yet"),
+                Mapped,
                 NotApplicable("Android dividers are drawn, not exposed as nodes"),
                 NotApplicable("UIKit exposes no separator element"),
             ],
@@ -347,7 +347,7 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] =
             [
                 Mapped,
                 Mapped,
-                Gap("AXHeading is not mapped yet"),
+                Mapped,
                 Gap("heading semantics are not mapped yet"),
                 Gap("the header token is not mapped yet"),
             ],

--- a/crates/glass-core/src/role_support.rs
+++ b/crates/glass-core/src/role_support.rs
@@ -124,7 +124,8 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] =
                 Mapped,
                 Mapped,
                 Gap("AppKit reports a switch as AXCheckBox with an AXSwitch or AXToggle \
-                     subrole; subroles are not read yet"),
+                     subrole; AXCheckBox is outside the reader's subrole gate, and no probed \
+                     app emitted either subrole"),
                 Mapped,
                 Mapped,
             ],
@@ -346,7 +347,8 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] =
             R::Heading,
             [
                 Mapped,
-                Mapped,
+                Gap("UIA's Header and HeaderItem are grid column headers, not document \
+                     headings; the normalized set has no column-header role"),
                 Mapped,
                 Gap("heading semantics are not mapped yet"),
                 Gap("the header token is not mapped yet"),

--- a/crates/glass-core/src/role_support.rs
+++ b/crates/glass-core/src/role_support.rs
@@ -98,7 +98,10 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] =
             R::Dialog,
             [
                 Mapped,
-                Gap("UIA marks a dialog with the IsDialog property on a Window; not read yet"),
+                Gap(
+                    "UIA marks a dialog with the IsDialog property on a Window; the reader does \
+                     not read it",
+                ),
                 Gap("AXSheet, AXPopover and AXDrawer are not mapped yet"),
                 Gap("dialog windows arrive as a generic layout class"),
                 Gap("alert and action-sheet tokens are not mapped yet"),
@@ -119,8 +122,7 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] =
             R::ToggleButton,
             [
                 Mapped,
-                Gap("UIA exposes a toggle as a control type plus the Toggle pattern, which the \
-                     map does not key on yet"),
+                Mapped,
                 Gap("AppKit reports a switch as AXCheckBox with an AXSwitch or AXToggle \
                      subrole; subroles are not read yet"),
                 Mapped,
@@ -174,7 +176,7 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] =
             R::TextArea,
             [
                 Mapped,
-                Gap("the UIA Document control type is not mapped yet"),
+                Mapped,
                 Mapped,
                 NotApplicable("Android uses one editable class for single- and multi-line text"),
                 Mapped,
@@ -209,7 +211,7 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] =
             [
                 Mapped,
                 Mapped,
-                Gap("AXTable is not mapped yet"),
+                Gap("mac lists report AXOutline rather than AXTable; AXOutline maps to Tree"),
                 Gap("table and grid classes collapse into List"),
                 Gap("no table token is mapped yet"),
             ],
@@ -218,7 +220,10 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] =
             R::Cell,
             [
                 Mapped,
-                Gap("the UIA DataItem control type is not mapped yet"),
+                Gap(
+                    "UIA's DataItem control type would carry this, but the data grids probed \
+                     expose their rows as TreeItem",
+                ),
                 Mapped,
                 Gap("no cell class is mapped yet"),
                 Mapped,
@@ -341,7 +346,7 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] =
             R::Heading,
             [
                 Mapped,
-                Gap("the UIA Header control types are not mapped yet"),
+                Mapped,
                 Gap("AXHeading is not mapped yet"),
                 Gap("heading semantics are not mapped yet"),
                 Gap("the header token is not mapped yet"),

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -49,6 +49,18 @@ harness = false
 name = "bundle_launch"
 harness = false
 
+# Mac-gated role-histogram PROBE (crates/glass-macos/tests/role_probe.rs) — not a pass/fail
+# assertion test. Same harness=false main-thread requirement as `capture`/`input`/`windows`/
+# `a11y`/`bundle_launch` above (`MacosPlatform::start_app` reaches AppKit's
+# `ffi::app_kit_init()`). Launches whatever apps `GLASS_A11Y_PROBE_APPS` names, snapshots each
+# through `glass-a11y-macos` with the node cap lifted, and prints `glass_core::role_histogram`
+# — the native AX-token evidence a `Gap` cell in `glass_core::role_support::ROLE_SUPPORT`
+# needs before a match arm can be written for it. With the variable unset it prints what to
+# set and exits 0. See that file's module doc.
+[[test]]
+name = "role_probe"
+harness = false
+
 [dependencies]
 glass-core.workspace = true
 plist = "1"

--- a/crates/glass-macos/tests/role_probe.rs
+++ b/crates/glass-macos/tests/role_probe.rs
@@ -154,9 +154,17 @@ mod macos_main {
                 limits: WalkLimits::from_max_nodes(Some(0)),
             };
             let mut a11y = MacosA11y::new();
-            let tree = a11y
+            let mut tree = a11y
                 .snapshot(&ctx)
                 .map_err(|e| format!("snapshot({run0}): {e}"))?;
+            // `MacosA11y::snapshot` deliberately leaves `count` (and node ids) at their
+            // zero default — `glass-a11y-macos`'s own doc says numbering is assigned by
+            // `glass-core` so it's identical across backends (`tests/a11y.rs` calls this
+            // too, right after its own snapshot). Skipping it here was the earlier bug: the
+            // printed histogram's bucket counts were always right (`role_histogram` walks
+            // the tree structurally, not by id), but the "N nodes" header read 0 regardless
+            // of how big the tree actually was.
+            tree.assign_ids();
             print_role_histogram(run0, &tree);
             Ok(())
         })

--- a/crates/glass-macos/tests/role_probe.rs
+++ b/crates/glass-macos/tests/role_probe.rs
@@ -5,10 +5,13 @@
 //! prints `glass_core::role_histogram`: every native AX role string the app
 //! actually emitted, unmapped ([`glass_core::AxRole::Other`]) tokens first. The project's rule
 //! is probe first, map second — a `Gap` cell in `glass_core::role_support::ROLE_SUPPORT` may
-//! only get a match arm for a token that showed up in output like this — so this file's only
-//! job is to produce that evidence. It never asserts what the tokens should be, and fails a
-//! run only when a snapshot could not be taken at all for one of the requested apps (a real
-//! breakage, distinct from an app simply exposing something unexpected).
+//! only get a match arm for a token that showed up in output like this — so this file's job is
+//! to produce that evidence. It asserts exactly one thing *about* the evidence: a token glass
+//! does map must not come back `AxRole::Other`, which would mean the reader stopped feeding
+//! `map_role` what it reads (see `macos_main::MAPPED_TOKENS`). Otherwise it fails a run only
+//! when an app could not be launched or snapshotted at all — a real breakage, distinct from an
+//! app simply exposing something unexpected. Which role a token *should* map to is never
+//! asserted here.
 //!
 //! With `GLASS_A11Y_PROBE_APPS` unset (or set but empty), prints what to set and exits 0 —
 //! the same skip-not-fail convention `tests/a11y.rs` uses for its own missing fixture, so a
@@ -66,6 +69,43 @@ mod macos_main {
         std::process::exit(1);
     }
 
+    /// AX role tokens glass maps to a role, and that a probed app has actually been seen to
+    /// emit. A histogram bucket carrying one of these must not come back [`AxRole::Other`]: the
+    /// token reached the reader, so a mapped role is the only correct outcome, and `Other` would
+    /// mean the plumbing between the reader and `mapping::map_role` broke. A token that simply
+    /// does not appear in a given app asserts nothing — apps differ, and an absent token is not
+    /// a regression.
+    ///
+    /// `"AXRow/AXOutlineRow"` is the `raw_role` the reader builds for a row whose `AXSubrole`
+    /// says it is an outline row (`role`/`subrole`, joined) — the one node shape where reading
+    /// the subrole changes the mapped role, so it is exactly the wiring most worth pinning.
+    const MAPPED_TOKENS: &[&str] = &[
+        "AXOutline",
+        "AXScrollArea",
+        "AXSplitGroup",
+        "AXSplitter",
+        "AXHeading",
+        "AXMenuButton",
+        "AXRow/AXOutlineRow",
+    ];
+
+    /// Every [`MAPPED_TOKENS`] bucket in `tree` that came back [`AxRole::Other`], described —
+    /// the one thing a histogram can check without becoming brittle about which app exposes
+    /// what. Everything else the probe prints is evidence for a human, not a pass/fail claim.
+    fn mapped_token_violations(label: &str, tree: &AxTree) -> Vec<String> {
+        role_histogram(tree)
+            .into_iter()
+            .filter(|e| e.role == AxRole::Other && MAPPED_TOKENS.contains(&e.raw_role.as_str()))
+            .map(|e| {
+                format!(
+                    "{label}: {} node(s) reported token {:?} as Other, but glass maps that \
+                     token — the reader is not feeding map_role what it reads",
+                    e.count, e.raw_role
+                )
+            })
+            .collect()
+    }
+
     /// Print `role_histogram(tree)` as one line per `(token, role)` bucket — unmapped
     /// ([`AxRole::Other`]) buckets first, which is already the histogram's own sort order, so
     /// the tokens most worth a human's attention are the first thing printed.
@@ -118,11 +158,12 @@ mod macos_main {
     /// Launch `run0`, snapshot it with the node cap lifted (so a big app's tree is never
     /// truncated mid-probe — depth/siblings keep their generous structural-rail defaults
     /// regardless; see [`WalkLimits::from_max_nodes`]), print its role histogram, then stop
-    /// it. Returns `Err` only when the app could not be launched or a snapshot could not be
-    /// taken at all — a real breakage, never merely an unexpected role (see this file's
-    /// module doc). What the histogram actually contains is never asserted here; that's the
-    /// human's job, reading the printed output to decide which `Gap` cell in
-    /// `glass_core::role_support::ROLE_SUPPORT` a real native token now justifies filling.
+    /// it. Returns `Err` when the app could not be launched, a snapshot could not be taken at
+    /// all, or a token glass maps came back unmapped ([`mapped_token_violations`]) — never
+    /// merely because an app exposed something unexpected (see this file's module doc). Beyond
+    /// that one check the histogram's contents are never asserted; reading the printed output
+    /// to decide which `Gap` cell in `glass_core::role_support::ROLE_SUPPORT` a real native
+    /// token now justifies filling is the human's job.
     fn probe_one(run0: &str) -> Result<(), String> {
         println!("\n--- launching {run0} ---");
         let mut platform =
@@ -166,7 +207,14 @@ mod macos_main {
             // of how big the tree actually was.
             tree.assign_ids();
             print_role_histogram(run0, &tree);
-            Ok(())
+            // Checked after the histogram is printed, so the evidence that explains a failure
+            // is already in the output when the failure is reported.
+            let violations = mapped_token_violations(run0, &tree);
+            if violations.is_empty() {
+                Ok(())
+            } else {
+                Err(violations.join("\n"))
+            }
         })
     }
 

--- a/crates/glass-macos/tests/role_probe.rs
+++ b/crates/glass-macos/tests/role_probe.rs
@@ -1,0 +1,200 @@
+//! Role-histogram PROBE for the macOS half of the accessibility role-parity work — not a
+//! pass/fail assertion test. Launches whatever apps `GLASS_A11Y_PROBE_APPS` names (a
+//! comma-separated list of launch commands — see this file's `macos_main::PROBE_APPS_VAR`
+//! doc comment), snapshots each through `glass-a11y-macos` with the node cap lifted, and
+//! prints `glass_core::role_histogram`: every native AX role string the app
+//! actually emitted, unmapped ([`glass_core::AxRole::Other`]) tokens first. The project's rule
+//! is probe first, map second — a `Gap` cell in `glass_core::role_support::ROLE_SUPPORT` may
+//! only get a match arm for a token that showed up in output like this — so this file's only
+//! job is to produce that evidence. It never asserts what the tokens should be, and fails a
+//! run only when a snapshot could not be taken at all for one of the requested apps (a real
+//! breakage, distinct from an app simply exposing something unexpected).
+//!
+//! With `GLASS_A11Y_PROBE_APPS` unset (or set but empty), prints what to set and exits 0 —
+//! the same skip-not-fail convention `tests/a11y.rs` uses for its own missing fixture, so a
+//! plain on-box run that isn't asking for this probe never fails because of it.
+//!
+//! **`harness = false`** (see `Cargo.toml`'s `[[test]] name = "role_probe"` entry): same
+//! reason as `capture.rs`/`input.rs`/`windows.rs`/`a11y.rs`/`bundle_launch.rs` —
+//! `MacosPlatform::start_app` reaches AppKit's `ffi::app_kit_init()`, which needs the
+//! process's TRUE main thread; libtest's per-`#[test]` worker threads can't provide that, so
+//! this file defines its own `fn main()`, run directly rather than through libtest.
+//!
+//! Needs the same Accessibility (and Screen Recording, for `MacosPlatform::new`'s preflight)
+//! TCC grants as `tests/a11y.rs` — see that file's module doc for how a granted run supplies
+//! them.
+
+#[cfg(not(target_os = "macos"))]
+fn main() {
+    println!("skipped (not macOS)");
+}
+
+#[cfg(target_os = "macos")]
+fn main() {
+    macos_main::run();
+}
+
+#[cfg(target_os = "macos")]
+mod macos_main {
+    use std::time::Duration;
+
+    use glass_a11y_macos::MacosA11y;
+    use glass_core::{
+        role_histogram, Accessibility, AppSpec, AxContext, AxRole, AxTree, Platform, SandboxLevel,
+        WalkLimits,
+    };
+    use glass_macos::MacosPlatform;
+
+    /// Comma-separated launch commands to probe, e.g.
+    /// `/System/Applications/TextEdit.app,/System/Applications/Calculator.app`. Each element
+    /// is either a `.app` bundle path or a plain executable path — exactly what
+    /// `AppSpec::run`'s first element accepts (see `MacosPlatform::start_app`'s
+    /// bundle-vs-direct-spawn dispatch, exercised by `tests/bundle_launch.rs`). Read once at
+    /// the top of [`run`]; unset (or set but empty) skips the whole probe — prints what to
+    /// set, exits 0 — rather than failing a run that never asked for it.
+    const PROBE_APPS_VAR: &str = "GLASS_A11Y_PROBE_APPS";
+
+    /// How long to wait after `start_app` before snapshotting — AppKit finishes building the
+    /// accessibility tree behind a window a beat after the window itself appears; mirrors
+    /// `tests/a11y.rs`'s identically-reasoned settle.
+    const STARTUP_SETTLE: Duration = Duration::from_millis(800);
+
+    /// Print a clear failure message and exit non-zero — the `harness = false` contract (no
+    /// libtest to format a panic for us). Mirrors the sibling integration tests.
+    fn fail(msg: impl AsRef<str>) -> ! {
+        eprintln!("FAIL: {}", msg.as_ref());
+        std::process::exit(1);
+    }
+
+    /// Print `role_histogram(tree)` as one line per `(token, role)` bucket — unmapped
+    /// ([`AxRole::Other`]) buckets first, which is already the histogram's own sort order, so
+    /// the tokens most worth a human's attention are the first thing printed.
+    fn print_role_histogram(label: &str, tree: &AxTree) {
+        let hist = role_histogram(tree);
+        println!("\n===== role histogram: {label} =====");
+        println!(
+            "{} nodes, {} distinct (token, role) buckets",
+            tree.count,
+            hist.len()
+        );
+        if let Some(t) = &tree.truncated {
+            println!("  NOTE: {}", t.notice());
+        }
+        for entry in &hist {
+            let tag = if entry.role == AxRole::Other {
+                "UNMAPPED"
+            } else {
+                "mapped"
+            };
+            println!(
+                "  {tag:>8}  x{:<5} role={:?} token={:?}",
+                entry.count, entry.role, entry.raw_role
+            );
+        }
+    }
+
+    /// Run `body`, then always call `platform.stop_app()` afterward regardless of whether
+    /// `body` succeeded — mirrors `tests/bundle_launch.rs`'s identically-named helper.
+    fn with_stop_app<T>(
+        platform: &mut MacosPlatform,
+        label: &str,
+        body: impl FnOnce(&mut MacosPlatform) -> Result<T, String>,
+    ) -> Result<T, String> {
+        let result = body(platform);
+        let stop_result = platform.stop_app();
+        match result {
+            Ok(v) => stop_result
+                .map(|()| v)
+                .map_err(|e| format!("stop_app({label}): {e}")),
+            Err(e) => {
+                if let Err(stop_err) = stop_result {
+                    eprintln!("(additionally) stop_app({label}) failed: {stop_err}");
+                }
+                Err(e)
+            }
+        }
+    }
+
+    /// Launch `run0`, snapshot it with the node cap lifted (so a big app's tree is never
+    /// truncated mid-probe — depth/siblings keep their generous structural-rail defaults
+    /// regardless; see [`WalkLimits::from_max_nodes`]), print its role histogram, then stop
+    /// it. Returns `Err` only when the app could not be launched or a snapshot could not be
+    /// taken at all — a real breakage, never merely an unexpected role (see this file's
+    /// module doc). What the histogram actually contains is never asserted here; that's the
+    /// human's job, reading the printed output to decide which `Gap` cell in
+    /// `glass_core::role_support::ROLE_SUPPORT` a real native token now justifies filling.
+    fn probe_one(run0: &str) -> Result<(), String> {
+        println!("\n--- launching {run0} ---");
+        let mut platform =
+            MacosPlatform::new().map_err(|e| format!("MacosPlatform::new() for {run0}: {e}"))?;
+
+        let spec = AppSpec {
+            build: None,
+            run: vec![run0.to_string()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 15_000,
+            sandbox: SandboxLevel::Off,
+            a11y: false,
+        };
+
+        with_stop_app(&mut platform, run0, |platform| {
+            let geometry = platform
+                .start_app(&spec)
+                .map_err(|e| format!("start_app({run0}): {e}"))?;
+            println!("started {run0}: {geometry:?}");
+            std::thread::sleep(STARTUP_SETTLE);
+
+            let ctx = AxContext {
+                pids: platform.app_pids(),
+                window: geometry,
+                window_handle: None,
+                a11y_bus_addr: None,
+                limits: WalkLimits::from_max_nodes(Some(0)),
+            };
+            let mut a11y = MacosA11y::new();
+            let tree = a11y
+                .snapshot(&ctx)
+                .map_err(|e| format!("snapshot({run0}): {e}"))?;
+            print_role_histogram(run0, &tree);
+            Ok(())
+        })
+    }
+
+    pub(super) fn run() {
+        let apps = match std::env::var(PROBE_APPS_VAR) {
+            Ok(v) if !v.trim().is_empty() => v,
+            _ => {
+                println!(
+                    "skipped: set {PROBE_APPS_VAR} to a comma-separated list of launch \
+                     commands (.app bundle paths or executable paths) to probe, e.g. \
+                     {PROBE_APPS_VAR}=/System/Applications/TextEdit.app"
+                );
+                std::process::exit(0);
+            }
+        };
+        let targets: Vec<&str> = apps
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .collect();
+        if targets.is_empty() {
+            println!("skipped: {PROBE_APPS_VAR} was set but named no launch commands");
+            std::process::exit(0);
+        }
+
+        let mut failures = Vec::new();
+        for run0 in targets {
+            if let Err(e) = probe_one(run0) {
+                failures.push(e);
+            }
+        }
+
+        if !failures.is_empty() {
+            fail(failures.join("\n\n"));
+        }
+        println!("\nROLE_PROBE_PASS");
+        std::process::exit(0);
+    }
+}

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -95,8 +95,9 @@ fn taskmgr_spec() -> AppSpec {
 }
 
 /// Bare `explorer.exe` (no path arg): opens the OS default location — "Quick access" on
-/// Windows 10, "Home" on Windows 11 — the same native file-list control (and so the same
-/// DataGrid/DataItem/Header/HeaderItem UIA tree) any folder view uses. Each File Explorer
+/// Windows 10, "Home" on Windows 11 — the same native file-list control, and so the same UIA
+/// tree, any folder view uses (what that tree actually emitted is recorded in
+/// [`onbox_role_histogram_probe`]'s doc). Each File Explorer
 /// window is its own process (unlike Task Manager, Explorer has no single-instance check —
 /// this is why `explorer.exe <uri>` protocol activation, e.g. `ms-settings:`, is the flaky
 /// shape and a plain `explorer.exe` folder-window launch is not), so pid-set discovery is
@@ -1055,15 +1056,48 @@ fn render_role_histogram(label: &str, tree: &AxTree) -> String {
     out
 }
 
+/// UIA control-type names glass maps to a role, and that a probed app has actually been seen to
+/// emit. A histogram bucket carrying one of these must not come back [`AxRole::Other`]: the
+/// token reached the reader, so a mapped role is the only correct outcome, and `Other` would
+/// mean the plumbing between the reader and `map_role` broke. A token that simply does not
+/// appear in a given app asserts nothing — apps differ, and an absent token is not a
+/// regression.
+///
+/// Deliberately NOT listed: `Header`/`HeaderItem`, which the probe does observe but which map
+/// to no role on purpose (a grid's column headers are not document headings), and `Button`,
+/// whose `ToggleButton` promotion is state-dependent rather than a property of the token.
+const MAPPED_TOKENS: &[&str] = &["Document"];
+
+/// Every [`MAPPED_TOKENS`] bucket in `tree` that came back [`AxRole::Other`], described — the
+/// one thing a histogram can check without becoming brittle about which app exposes what.
+/// Everything else the probe prints is evidence for a human, not a pass/fail claim. Returned
+/// rather than asserted so the caller can finish the run, record the findings in the artifacts
+/// file with the histograms that explain them, and only then fail.
+fn mapped_token_violations(label: &str, tree: &AxTree) -> Vec<String> {
+    role_histogram(tree)
+        .into_iter()
+        .filter(|e| e.role == AxRole::Other && MAPPED_TOKENS.contains(&e.raw_role.as_str()))
+        .map(|e| {
+            format!(
+                "{label}: {} node(s) reported token {:?} as Other, but glass maps that token — \
+                 the reader is not feeding map_role what it reads",
+                e.count, e.raw_role
+            )
+        })
+        .collect()
+}
+
 /// Launch `spec`, snapshot its accessibility tree with the node cap lifted (so a big app's
 /// tree is never truncated mid-probe — depth/siblings keep their generous structural-rail
 /// defaults regardless; see [`WalkLimits::from_max_nodes`]), print its role histogram, append
 /// it to `report`, then stop the app. Panics — failing the test — only when the app can't be
 /// launched or a snapshot can't be taken at all: a real breakage, never merely an unexpected
-/// role. What the histogram actually contains is never asserted here; that's the human's job,
-/// reading it to decide which `Gap` cell in `glass_core::role_support::ROLE_SUPPORT` a real
-/// native token now justifies filling.
-fn probe_role_histogram(label: &str, spec: &AppSpec, report: &mut String) {
+/// role. Returns any [`mapped_token_violations`], which the caller fails on *after* the report
+/// is saved. Beyond that one check the histogram's contents are never asserted; reading it to
+/// decide which `Gap` cell in `glass_core::role_support::ROLE_SUPPORT` a real native token now
+/// justifies filling is the human's job.
+#[must_use]
+fn probe_role_histogram(label: &str, spec: &AppSpec, report: &mut String) -> Vec<String> {
     let mut p = WindowsPlatform::new().expect("WindowsPlatform::new");
     let geo = p
         .start_app(spec)
@@ -1115,15 +1149,26 @@ fn probe_role_histogram(label: &str, spec: &AppSpec, report: &mut String) {
 
     let _ = p.stop_app();
     std::thread::sleep(Duration::from_millis(500)); // let the app fully exit before the next probe
+
+    let violations = mapped_token_violations(label, &tree);
+    for v in &violations {
+        let line = format!("\n  VIOLATION: {v}\n");
+        print!("{line}");
+        report.push_str(&line);
+    }
+    violations
 }
 
 /// The evidence step behind the Windows half of the accessibility role-parity work: launch a
 /// handful of stock apps and record each one's `role_histogram` — every native UIA token the
 /// app actually emitted, unmapped (`AxRole::Other`) tokens first. The project's rule is probe
 /// first, map second: a `Gap` cell in `glass_core::role_support::ROLE_SUPPORT` may only get a
-/// match arm for a token that showed up in output like this. So this test's only job is to
-/// produce that evidence — it never asserts what the tokens should be, and fails only when a
-/// snapshot could not be taken at all (see [`probe_role_histogram`]).
+/// match arm for a token that showed up in output like this. So this test's job is to produce
+/// that evidence. It asserts exactly one thing *about* the evidence — a token glass does map
+/// must not come back `AxRole::Other`, which would mean the reader stopped feeding `map_role`
+/// what it reads (see [`MAPPED_TOKENS`]) — and otherwise fails only when an app could not be
+/// launched or snapshotted at all (see [`probe_role_histogram`]). Which role a token *should*
+/// map to is never asserted here; that is the human's reading.
 ///
 /// The histogram is both printed to stdout AND written to `role-histogram-windows.txt` under
 /// [`artifacts_dir`] (see that function's doc for why the file is required, not just a nicety
@@ -1135,11 +1180,15 @@ fn probe_role_histogram(label: &str, spec: &AppSpec, report: &mut String) {
 /// Runs charmap, Notepad, Task Manager, and File Explorer. charmap/Notepad alone gave clean
 /// output but no tabular UI, so `DataItem` (UIA id 50029), `Header` (50034), and
 /// `HeaderItem` (50035) — exactly the ids the `Table`/`Cell` `Gap` reasons in
-/// `ROLE_SUPPORT` name — went unobserved; Task Manager's process list and File Explorer's
-/// file list are both real UIA `DataGrid`/`DataItem`/`Header` trees, so they were added to
-/// reach those tokens. See [`taskmgr_spec`]/[`explorer_spec`] for why each is expected to be
-/// discovered as reliably as charmap/Notepad despite neither being launched exactly the same
-/// way.
+/// `ROLE_SUPPORT` name — went unobserved, and Task Manager's process list and File Explorer's
+/// file list were added to reach them. They got part of the way: both list views did emit
+/// `Header` and `HeaderItem` for their column-header bars, but neither emitted `DataItem` at
+/// all — their rows arrived as `TreeItem`, which is what the `Cell` row's Windows `Gap` reason
+/// in `ROLE_SUPPORT` now records. (`Header`/`HeaderItem` are observed but deliberately left
+/// unmapped: they are a grid's column headers, not document headings — see
+/// `glass_a11y_windows::mapping`.) See [`taskmgr_spec`]/[`explorer_spec`] for why each is
+/// expected to be discovered as reliably as charmap/Notepad despite neither being launched
+/// exactly the same way.
 ///
 /// The Settings app (`ms-settings:` via `explorer.exe`) was considered and left out: unlike
 /// the four apps run here, its window has no process relationship to the process glass
@@ -1148,8 +1197,7 @@ fn probe_role_histogram(label: &str, spec: &AppSpec, report: &mut String) {
 /// could only find it through the title-substring fallback rung (a system-wide scan by
 /// window title) rather than the pid-based one every app here uses. That fallback rung
 /// exists in the backend for exactly this shape of app, but this probe declined to depend on
-/// it without on-box verification that it resolves reliably; see the report for the full
-/// reasoning.
+/// it without on-box verification that it resolves reliably.
 ///
 /// This probe also can't surface a UIA `Window` with `IsDialog` true (the `Dialog` row's
 /// Windows `Gap` reason in `ROLE_SUPPORT`): none of the four apps opens a dialog on a cold,
@@ -1157,19 +1205,39 @@ fn probe_role_histogram(label: &str, spec: &AppSpec, report: &mut String) {
 /// already reads into an `AxNode` — `IsDialog` is not among those fields (reading it is the
 /// gap itself), so no launch sequence run through this probe could reveal it either way.
 #[test]
-#[ignore = "on-box only: needs the interactive desktop session; prints role histograms and writes them to .windows-artifacts/role-histogram-windows.txt, asserts nothing about their contents"]
+#[ignore = "on-box only: needs the interactive desktop session; prints role histograms and writes them to .windows-artifacts/role-histogram-windows.txt, asserting only that a token glass maps did not come back Other"]
 fn onbox_role_histogram_probe() {
     let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     dpi_aware_once();
 
     let mut report = String::new();
-    probe_role_histogram("charmap.exe (Character Map)", &charmap_spec(), &mut report);
-    probe_role_histogram("notepad.exe (Notepad)", &notepad_spec(), &mut report);
-    probe_role_histogram("taskmgr.exe (Task Manager)", &taskmgr_spec(), &mut report);
-    probe_role_histogram(
+    let mut violations = Vec::new();
+    violations.extend(probe_role_histogram(
+        "charmap.exe (Character Map)",
+        &charmap_spec(),
+        &mut report,
+    ));
+    violations.extend(probe_role_histogram(
+        "notepad.exe (Notepad)",
+        &notepad_spec(),
+        &mut report,
+    ));
+    violations.extend(probe_role_histogram(
+        "taskmgr.exe (Task Manager)",
+        &taskmgr_spec(),
+        &mut report,
+    ));
+    violations.extend(probe_role_histogram(
         "explorer.exe (File Explorer)",
         &explorer_spec(),
         &mut report,
-    );
+    ));
     save_report("role-histogram-windows.txt", &report);
+    // Fail last, after every app has been probed and the artifacts file written: the histograms
+    // are the evidence a violation has to be read against.
+    assert!(
+        violations.is_empty(),
+        "a token glass maps came back unmapped:\n{}",
+        violations.join("\n")
+    );
 }

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -14,9 +14,9 @@ use std::time::Duration;
 
 use glass_a11y_windows::WindowsA11y;
 use glass_core::{
-    Accessibility, AppSpec, AxContext, AxNode, AxRole, AxTarget, Backend, BaselineStore, Glass,
-    GlassError, KeyEvent, Modifier, MouseButton, Platform, PlatformFactory, PointerEvent,
-    WalkLimits, WindowGeometry, WindowHint, WindowOp,
+    role_histogram, Accessibility, AppSpec, AxContext, AxNode, AxRole, AxTarget, AxTree, Backend,
+    BaselineStore, Glass, GlassError, KeyEvent, Modifier, MouseButton, Platform, PlatformFactory,
+    PointerEvent, WalkLimits, WindowGeometry, WindowHint, WindowOp,
 };
 use glass_windows::WindowsPlatform;
 
@@ -49,6 +49,23 @@ fn charmap_spec() -> AppSpec {
             title: Some("Character Map".into()),
             class: None,
         }),
+        timeout_ms: 15_000,
+        sandbox: glass_core::SandboxLevel::Off,
+        a11y: false,
+    }
+}
+
+/// No `window_hint`: Notepad's own process (or, on Win11, the descendant its launcher hands
+/// its UI to — see `onbox_handoff_grace`'s doc) is discovered purely by pid-set membership,
+/// so a title hint isn't needed the way it would be for a hand-off to an *unrelated* process
+/// (see `onbox_role_histogram_probe`'s doc for why that shape was left out of the probe).
+fn notepad_spec() -> AppSpec {
+    AppSpec {
+        build: None,
+        run: vec!["notepad.exe".to_string()],
+        cwd: None,
+        env: vec![],
+        window_hint: None,
         timeout_ms: 15_000,
         sandbox: glass_core::SandboxLevel::Off,
         a11y: false,
@@ -901,4 +918,91 @@ fn onbox_contained_launch_adopts_app_not_console() {
         "expected a boxed app window class (Sandbox:<box>:...), got {class:?}"
     );
     p.stop_app().expect("stop_app");
+}
+
+/// Print `role_histogram(tree)` as one line per `(token, role)` bucket — unmapped
+/// ([`AxRole::Other`]) buckets first, which is already the histogram's own sort order, so
+/// the tokens most worth a human's attention are the first thing printed.
+fn print_role_histogram(label: &str, tree: &AxTree) {
+    let hist = role_histogram(tree);
+    println!("\n===== role histogram: {label} =====");
+    println!(
+        "{} nodes, {} distinct (token, role) buckets",
+        tree.count,
+        hist.len()
+    );
+    if let Some(t) = &tree.truncated {
+        println!("  NOTE: {}", t.notice());
+    }
+    for entry in &hist {
+        let tag = if entry.role == AxRole::Other {
+            "UNMAPPED"
+        } else {
+            "mapped"
+        };
+        println!(
+            "  {tag:>8}  x{:<5} role={:?} token={:?}",
+            entry.count, entry.role, entry.raw_role
+        );
+    }
+}
+
+/// Launch `spec`, snapshot its accessibility tree with the node cap lifted (so a big app's
+/// tree is never truncated mid-probe — depth/siblings keep their generous structural-rail
+/// defaults regardless; see [`WalkLimits::from_max_nodes`]), print its role histogram, then
+/// stop the app. Panics — failing the test — only when the app can't be launched or a
+/// snapshot can't be taken at all: a real breakage, never merely an unexpected role. What the
+/// histogram actually contains is never asserted here; that's the human's job, reading the
+/// printed output to decide which `Gap` cell in `glass_core::role_support::ROLE_SUPPORT` a
+/// real native token now justifies filling.
+fn probe_role_histogram(label: &str, spec: &AppSpec) {
+    let mut p = WindowsPlatform::new().expect("WindowsPlatform::new");
+    let geo = p
+        .start_app(spec)
+        .unwrap_or_else(|e| panic!("{label}: start_app failed: {e}"));
+    std::thread::sleep(Duration::from_millis(1500));
+
+    let mut a11y = WindowsA11y::new();
+    let ctx = AxContext {
+        pids: p.app_pids(),
+        window: geo.clone(),
+        window_handle: p.active_window_handle(),
+        a11y_bus_addr: None,
+        limits: WalkLimits::from_max_nodes(Some(0)),
+    };
+    let tree = a11y
+        .snapshot(&ctx)
+        .unwrap_or_else(|e| panic!("{label}: a11y snapshot failed: {e}"));
+
+    print_role_histogram(label, &tree);
+
+    let _ = p.stop_app();
+    std::thread::sleep(Duration::from_millis(500)); // let the app fully exit before the next probe
+}
+
+/// The evidence step behind the Windows half of the accessibility role-parity work: launch a
+/// handful of stock apps and print each one's `role_histogram` — every native UIA token the
+/// app actually emitted, unmapped (`AxRole::Other`) tokens first. The project's rule is probe
+/// first, map second: a `Gap` cell in `glass_core::role_support::ROLE_SUPPORT` may only get a
+/// match arm for a token that showed up in output like this. So this test's only job is to
+/// produce that evidence — it never asserts what the tokens should be, and fails only when a
+/// snapshot could not be taken at all (see [`probe_role_histogram`]).
+///
+/// Runs charmap and Notepad. The Settings app (`ms-settings:` via `explorer.exe`) was
+/// considered and left out: unlike these two, its window has no process relationship to the
+/// process glass launches — `explorer.exe` hands the request to the shell and exits, and the
+/// Settings window belongs to an unrelated process the launched pid-set never contains — so
+/// discovery could only find it through the title-substring fallback rung (a system-wide scan
+/// by window title) rather than the pid-based one charmap/Notepad use. That fallback rung
+/// exists in the backend for exactly this shape of app, but this probe declined to depend on
+/// it without on-box verification that it resolves reliably; see the report for the full
+/// reasoning.
+#[test]
+#[ignore = "on-box only: needs the interactive desktop session; prints role histograms, asserts nothing about their contents"]
+fn onbox_role_histogram_probe() {
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    dpi_aware_once();
+
+    probe_role_histogram("charmap.exe (Character Map)", &charmap_spec());
+    probe_role_histogram("notepad.exe (Notepad)", &notepad_spec());
 }

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -72,6 +72,54 @@ fn notepad_spec() -> AppSpec {
     }
 }
 
+/// Task Manager's own process directly owns its window — same discoverable-by-pid shape as
+/// charmap/Notepad — *unless* an instance was already running before this test started, in
+/// which case Task Manager's single-instance check makes our freshly spawned process just
+/// activate the existing window and exit. The title hint exists for exactly that case: with
+/// no window in our own pid-set, `poll_decision` keeps polling on the hint alone and the
+/// system-wide title-substring fallback rung picks up the pre-existing window instead.
+fn taskmgr_spec() -> AppSpec {
+    AppSpec {
+        build: None,
+        run: vec!["taskmgr.exe".to_string()],
+        cwd: None,
+        env: vec![],
+        window_hint: Some(WindowHint {
+            title: Some("Task Manager".into()),
+            class: None,
+        }),
+        timeout_ms: 15_000,
+        sandbox: glass_core::SandboxLevel::Off,
+        a11y: false,
+    }
+}
+
+/// Bare `explorer.exe` (no path arg): opens the OS default location — "Quick access" on
+/// Windows 10, "Home" on Windows 11 — the same native file-list control (and so the same
+/// DataGrid/DataItem/Header/HeaderItem UIA tree) any folder view uses. Each File Explorer
+/// window is its own process (unlike Task Manager, Explorer has no single-instance check —
+/// this is why `explorer.exe <uri>` protocol activation, e.g. `ms-settings:`, is the flaky
+/// shape and a plain `explorer.exe` folder-window launch is not), so pid-set discovery is
+/// expected to find it directly. The hint here is `class`, not `title`: `CabinetWClass` is
+/// every File Explorer folder window's documented window class regardless of locale, OS
+/// version, or the current folder's display name — unlike a title, which would vary with
+/// exactly the thing this spec deliberately leaves unset.
+fn explorer_spec() -> AppSpec {
+    AppSpec {
+        build: None,
+        run: vec!["explorer.exe".to_string()],
+        cwd: None,
+        env: vec![],
+        window_hint: Some(WindowHint {
+            title: None,
+            class: Some("CabinetWClass".into()),
+        }),
+        timeout_ms: 15_000,
+        sandbox: glass_core::SandboxLevel::Off,
+        a11y: false,
+    }
+}
+
 /// A `Glass` session wired to the real Windows backend + UIA reader (as opposed to the bare
 /// `WindowsPlatform`/`WindowsA11y` the other on-box tests drive directly) — needed wherever a test
 /// wants the production `click_element` orchestration (invoke-first, pointer-fallback,
@@ -1044,15 +1092,30 @@ fn probe_role_histogram(label: &str, spec: &AppSpec, report: &mut String) {
 /// is the only way the evidence gets out of that path. Printing it too costs nothing and helps
 /// anyone running the test directly on a box with a desktop session.
 ///
-/// Runs charmap and Notepad. The Settings app (`ms-settings:` via `explorer.exe`) was
-/// considered and left out: unlike these two, its window has no process relationship to the
-/// process glass launches — `explorer.exe` hands the request to the shell and exits, and the
-/// Settings window belongs to an unrelated process the launched pid-set never contains — so
-/// discovery could only find it through the title-substring fallback rung (a system-wide scan
-/// by window title) rather than the pid-based one charmap/Notepad use. That fallback rung
+/// Runs charmap, Notepad, Task Manager, and File Explorer. charmap/Notepad alone gave clean
+/// output but no tabular UI, so `DataItem` (UIA id 50029), `Header` (50034), and
+/// `HeaderItem` (50035) — exactly the ids the `Table`/`Cell` `Gap` reasons in
+/// `ROLE_SUPPORT` name — went unobserved; Task Manager's process list and File Explorer's
+/// file list are both real UIA `DataGrid`/`DataItem`/`Header` trees, so they were added to
+/// reach those tokens. See [`taskmgr_spec`]/[`explorer_spec`] for why each is expected to be
+/// discovered as reliably as charmap/Notepad despite neither being launched exactly the same
+/// way.
+///
+/// The Settings app (`ms-settings:` via `explorer.exe`) was considered and left out: unlike
+/// the four apps run here, its window has no process relationship to the process glass
+/// launches — `explorer.exe` hands the request to the shell and exits, and the Settings
+/// window belongs to an unrelated process the launched pid-set never contains — so discovery
+/// could only find it through the title-substring fallback rung (a system-wide scan by
+/// window title) rather than the pid-based one every app here uses. That fallback rung
 /// exists in the backend for exactly this shape of app, but this probe declined to depend on
 /// it without on-box verification that it resolves reliably; see the report for the full
 /// reasoning.
+///
+/// This probe also can't surface a UIA `Window` with `IsDialog` true (the `Dialog` row's
+/// Windows `Gap` reason in `ROLE_SUPPORT`): none of the four apps opens a dialog on a cold,
+/// no-input launch, and `role_histogram` only ever sees what `glass-a11y-windows`'s reader
+/// already reads into an `AxNode` — `IsDialog` is not among those fields (reading it is the
+/// gap itself), so no launch sequence run through this probe could reveal it either way.
 #[test]
 #[ignore = "on-box only: needs the interactive desktop session; prints role histograms and writes them to .windows-artifacts/role-histogram-windows.txt, asserts nothing about their contents"]
 fn onbox_role_histogram_probe() {
@@ -1062,5 +1125,11 @@ fn onbox_role_histogram_probe() {
     let mut report = String::new();
     probe_role_histogram("charmap.exe (Character Map)", &charmap_spec(), &mut report);
     probe_role_histogram("notepad.exe (Notepad)", &notepad_spec(), &mut report);
+    probe_role_histogram("taskmgr.exe (Task Manager)", &taskmgr_spec(), &mut report);
+    probe_role_histogram(
+        "explorer.exe (File Explorer)",
+        &explorer_spec(),
+        &mut report,
+    );
     save_report("role-histogram-windows.txt", &report);
 }

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -263,6 +263,19 @@ fn first_role_with_bounds<'a>(n: &'a AxNode, role: AxRole, out: &mut Option<&'a 
     }
 }
 
+/// Nodes carrying UIA's Toggle pattern that are NOT already a checkbox or radio button —
+/// the evidence for whether a `ToggleButton` mapping has anything to map. `checkable` is
+/// Toggle-pattern availability (see `StateFacts` in glass-a11y-windows), so this needs no
+/// extra UIA call.
+fn toggle_candidates<'a>(node: &'a AxNode, out: &mut Vec<&'a AxNode>) {
+    if node.states.checkable && !matches!(node.role, AxRole::CheckBox | AxRole::RadioButton) {
+        out.push(node);
+    }
+    for child in &node.children {
+        toggle_candidates(child, out);
+    }
+}
+
 /// Count msedge.exe processes whose command line carries `marker` (our isolated user-data-dir), via
 /// CIM so the box's background Edge isn't counted.
 fn our_edge_count(marker: &str) -> i32 {
@@ -1072,6 +1085,33 @@ fn probe_role_histogram(label: &str, spec: &AppSpec, report: &mut String) {
     let block = render_role_histogram(label, &tree);
     print!("{block}");
     report.push_str(&block);
+
+    // Collect toggle-capable non-checkbox/radio nodes (evidence for ToggleButton row parity).
+    let mut candidates = Vec::new();
+    toggle_candidates(&tree.root, &mut candidates);
+    if !candidates.is_empty() {
+        use std::fmt::Write as _;
+        let mut toggle_block = String::new();
+        let _ = writeln!(
+            toggle_block,
+            "\n  toggle-capable (checkable, non-checkbox/radio): {} nodes",
+            candidates.len()
+        );
+        let sample_count = candidates.len().min(5);
+        if sample_count > 0 {
+            let _ = writeln!(toggle_block, "    (first {sample_count}):");
+            for node in candidates.iter().take(5) {
+                let name = node.name.as_deref().unwrap_or("(no name)");
+                let _ = writeln!(
+                    toggle_block,
+                    "      role={:?} raw_role={:?} name={:?}",
+                    node.role, node.raw_role, name
+                );
+            }
+        }
+        print!("{toggle_block}");
+        report.push_str(&toggle_block);
+    }
 
     let _ = p.stop_app();
     std::thread::sleep(Duration::from_millis(500)); // let the app fully exit before the next probe

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -91,14 +91,21 @@ fn glass_windows_with_a11y() -> Glass {
     Glass::new(factory, "windows".into(), BaselineStore::new(root), 100)
 }
 
-/// The egui input/a11y fixture (built on demand; excluded from the workspace). Paths derive from the
-/// build location so the spec isn't pinned to one checkout/user. `sandbox` selects containment.
-fn egui_fixture_spec(sandbox: glass_core::SandboxLevel) -> AppSpec {
-    let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+/// The repo root: two levels above `crates/glass-windows` (this crate's `CARGO_MANIFEST_DIR`),
+/// baked in at build time — so on the box's own `cargo build`, it reflects wherever that box's
+/// checkout actually lives, not a hardcoded path/user.
+fn repo_root() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .ancestors()
         .nth(2)
         .expect("repo root is two levels above crates/glass-windows")
-        .to_path_buf();
+        .to_path_buf()
+}
+
+/// The egui input/a11y fixture (built on demand; excluded from the workspace). Paths derive from the
+/// build location so the spec isn't pinned to one checkout/user. `sandbox` selects containment.
+fn egui_fixture_spec(sandbox: glass_core::SandboxLevel) -> AppSpec {
+    let repo_root = repo_root();
     let fixture_exe =
         repo_root.join("crates/glass-fixture-egui/target/release/glass-fixture-egui.exe");
     AppSpec {
@@ -920,19 +927,57 @@ fn onbox_contained_launch_adopts_app_not_console() {
     p.stop_app().expect("stop_app");
 }
 
-/// Print `role_histogram(tree)` as one line per `(token, role)` bucket — unmapped
+/// Where the role-histogram probe writes its report: `.windows-artifacts` under the repo
+/// root. Mirrors `examples/onbox.rs`'s `out_dir()`/`save()` convention (a resolved-at-runtime
+/// directory + a small write-and-report helper) — but targets `.windows-artifacts` directly
+/// rather than `%USERPROFILE%`. That example's `%USERPROFILE%` files get swept into
+/// `.windows-artifacts` by a step in `tools/windows-validation/run-onbox.ps1` that runs only
+/// for the plain `onbox` example; an `--ignored` test run (this probe's path, via
+/// `scripts/test-windows.sh --tests`) has no such sweep. `.windows-artifacts` itself, though,
+/// is scp'd back to the caller by `scripts/test-windows.sh` after every run regardless — and
+/// it must be, since this probe's stdout is captured by the schtasks bounce into the
+/// interactive session and never reaches the caller at all. So this file is the only way the
+/// histogram gets out.
+fn artifacts_dir() -> std::path::PathBuf {
+    repo_root().join(".windows-artifacts")
+}
+
+/// Write `report` to `name` under [`artifacts_dir`], creating the directory if it doesn't
+/// already exist (`run-onbox.ps1` creates it fresh before every run, but this stays robust
+/// to a direct on-box invocation that skips the harness). Mirrors `examples/onbox.rs`'s
+/// `save()`.
+fn save_report(name: &str, report: &str) {
+    let dir = artifacts_dir();
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        println!("    creating {} FAILED: {e}", dir.display());
+        return;
+    }
+    let path = dir.join(name);
+    match std::fs::write(&path, report) {
+        Ok(()) => println!("    saved {}", path.display()),
+        Err(e) => println!("    save {} FAILED: {e}", path.display()),
+    }
+}
+
+/// Render `role_histogram(tree)` as one line per `(token, role)` bucket — unmapped
 /// ([`AxRole::Other`]) buckets first, which is already the histogram's own sort order, so
-/// the tokens most worth a human's attention are the first thing printed.
-fn print_role_histogram(label: &str, tree: &AxTree) {
+/// the tokens most worth a human's attention are the first thing in the block. Returns the
+/// text (rather than printing it) so [`probe_role_histogram`] can both print it directly
+/// (useful running straight on a box with a desktop session) and fold it into the artifacts
+/// file that's the only way it reaches a caller through the on-box harness.
+fn render_role_histogram(label: &str, tree: &AxTree) -> String {
+    use std::fmt::Write as _;
     let hist = role_histogram(tree);
-    println!("\n===== role histogram: {label} =====");
-    println!(
+    let mut out = String::new();
+    let _ = writeln!(out, "\n===== role histogram: {label} =====");
+    let _ = writeln!(
+        out,
         "{} nodes, {} distinct (token, role) buckets",
         tree.count,
         hist.len()
     );
     if let Some(t) = &tree.truncated {
-        println!("  NOTE: {}", t.notice());
+        let _ = writeln!(out, "  NOTE: {}", t.notice());
     }
     for entry in &hist {
         let tag = if entry.role == AxRole::Other {
@@ -940,22 +985,24 @@ fn print_role_histogram(label: &str, tree: &AxTree) {
         } else {
             "mapped"
         };
-        println!(
+        let _ = writeln!(
+            out,
             "  {tag:>8}  x{:<5} role={:?} token={:?}",
             entry.count, entry.role, entry.raw_role
         );
     }
+    out
 }
 
 /// Launch `spec`, snapshot its accessibility tree with the node cap lifted (so a big app's
 /// tree is never truncated mid-probe — depth/siblings keep their generous structural-rail
-/// defaults regardless; see [`WalkLimits::from_max_nodes`]), print its role histogram, then
-/// stop the app. Panics — failing the test — only when the app can't be launched or a
-/// snapshot can't be taken at all: a real breakage, never merely an unexpected role. What the
-/// histogram actually contains is never asserted here; that's the human's job, reading the
-/// printed output to decide which `Gap` cell in `glass_core::role_support::ROLE_SUPPORT` a
-/// real native token now justifies filling.
-fn probe_role_histogram(label: &str, spec: &AppSpec) {
+/// defaults regardless; see [`WalkLimits::from_max_nodes`]), print its role histogram, append
+/// it to `report`, then stop the app. Panics — failing the test — only when the app can't be
+/// launched or a snapshot can't be taken at all: a real breakage, never merely an unexpected
+/// role. What the histogram actually contains is never asserted here; that's the human's job,
+/// reading it to decide which `Gap` cell in `glass_core::role_support::ROLE_SUPPORT` a real
+/// native token now justifies filling.
+fn probe_role_histogram(label: &str, spec: &AppSpec, report: &mut String) {
     let mut p = WindowsPlatform::new().expect("WindowsPlatform::new");
     let geo = p
         .start_app(spec)
@@ -974,19 +1021,28 @@ fn probe_role_histogram(label: &str, spec: &AppSpec) {
         .snapshot(&ctx)
         .unwrap_or_else(|e| panic!("{label}: a11y snapshot failed: {e}"));
 
-    print_role_histogram(label, &tree);
+    let block = render_role_histogram(label, &tree);
+    print!("{block}");
+    report.push_str(&block);
 
     let _ = p.stop_app();
     std::thread::sleep(Duration::from_millis(500)); // let the app fully exit before the next probe
 }
 
 /// The evidence step behind the Windows half of the accessibility role-parity work: launch a
-/// handful of stock apps and print each one's `role_histogram` — every native UIA token the
+/// handful of stock apps and record each one's `role_histogram` — every native UIA token the
 /// app actually emitted, unmapped (`AxRole::Other`) tokens first. The project's rule is probe
 /// first, map second: a `Gap` cell in `glass_core::role_support::ROLE_SUPPORT` may only get a
 /// match arm for a token that showed up in output like this. So this test's only job is to
 /// produce that evidence — it never asserts what the tokens should be, and fails only when a
 /// snapshot could not be taken at all (see [`probe_role_histogram`]).
+///
+/// The histogram is both printed to stdout AND written to `role-histogram-windows.txt` under
+/// [`artifacts_dir`] (see that function's doc for why the file is required, not just a nicety
+/// on top of stdout): run through `scripts/test-windows.sh`, this test's stdout is captured by
+/// the schtasks bounce into the interactive session and never reaches the caller, so the file
+/// is the only way the evidence gets out of that path. Printing it too costs nothing and helps
+/// anyone running the test directly on a box with a desktop session.
 ///
 /// Runs charmap and Notepad. The Settings app (`ms-settings:` via `explorer.exe`) was
 /// considered and left out: unlike these two, its window has no process relationship to the
@@ -998,11 +1054,13 @@ fn probe_role_histogram(label: &str, spec: &AppSpec) {
 /// it without on-box verification that it resolves reliably; see the report for the full
 /// reasoning.
 #[test]
-#[ignore = "on-box only: needs the interactive desktop session; prints role histograms, asserts nothing about their contents"]
+#[ignore = "on-box only: needs the interactive desktop session; prints role histograms and writes them to .windows-artifacts/role-histogram-windows.txt, asserts nothing about their contents"]
 fn onbox_role_histogram_probe() {
     let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     dpi_aware_once();
 
-    probe_role_histogram("charmap.exe (Character Map)", &charmap_spec());
-    probe_role_histogram("notepad.exe (Notepad)", &notepad_spec());
+    let mut report = String::new();
+    probe_role_histogram("charmap.exe (Character Map)", &charmap_spec(), &mut report);
+    probe_role_histogram("notepad.exe (Notepad)", &notepad_spec(), &mut report);
+    save_report("role-histogram-windows.txt", &report);
 }

--- a/docs/reference/a11y-roles.md
+++ b/docs/reference/a11y-roles.md
@@ -27,7 +27,7 @@ device's own node, which is classified like any other node from its widget class
 | `Dialog` | yes | gap | gap | gap | gap |
 | `Group` | yes | yes | yes | yes | gap |
 | `Button` | yes | yes | yes | yes | yes |
-| `ToggleButton` | yes | gap | gap | yes | yes |
+| `ToggleButton` | yes | yes | gap | yes | yes |
 | `RadioButton` | yes | yes | yes | yes | gap |
 | `CheckBox` | yes | yes | yes | yes | yes |
 | `MenuBar` | yes | yes | yes | n/a | n/a |
@@ -35,7 +35,7 @@ device's own node, which is classified like any other node from its widget class
 | `MenuItem` | yes | yes | yes | gap | gap |
 | `Label` | yes | yes | yes | yes | yes |
 | `TextField` | yes | yes | yes | yes | yes |
-| `TextArea` | yes | gap | yes | n/a | yes |
+| `TextArea` | yes | yes | yes | n/a | yes |
 | `ComboBox` | yes | yes | yes | yes | gap |
 | `List` | yes | yes | yes | yes | gap |
 | `ListItem` | yes | yes | yes | gap | gap |
@@ -54,19 +54,18 @@ device's own node, which is classified like any other node from its widget class
 | `Separator` | yes | yes | gap | n/a | n/a |
 | `Toolbar` | yes | yes | yes | gap | yes |
 | `StatusBar` | yes | yes | n/a | n/a | n/a |
-| `Heading` | yes | gap | gap | gap | gap |
+| `Heading` | yes | yes | gap | gap | gap |
 
 ### Why a cell is not `yes`
 
 - `Application` / Windows (UIA) — n/a: UIA has no application control type; the app root is a Window
 - `Application` / macOS (AX) — gap: AXApplication is the app element but is not mapped yet
 - `Application` / Android — n/a: Android exposes windows, not an application element
-- `Dialog` / Windows (UIA) — gap: UIA marks a dialog with the IsDialog property on a Window; not read yet
+- `Dialog` / Windows (UIA) — gap: UIA marks a dialog with the IsDialog property on a Window; the reader does not read it
 - `Dialog` / macOS (AX) — gap: AXSheet, AXPopover and AXDrawer are not mapped yet
 - `Dialog` / Android — gap: dialog windows arrive as a generic layout class
 - `Dialog` / iOS — gap: alert and action-sheet tokens are not mapped yet
 - `Group` / iOS — gap: no container token is mapped yet
-- `ToggleButton` / Windows (UIA) — gap: UIA exposes a toggle as a control type plus the Toggle pattern, which the map does not key on yet
 - `ToggleButton` / macOS (AX) — gap: AppKit reports a switch as AXCheckBox with an AXSwitch or AXToggle subrole; subroles are not read yet
 - `RadioButton` / iOS — gap: no radio token is mapped yet
 - `MenuBar` / Android — n/a: Android apps have no menu bar
@@ -75,16 +74,15 @@ device's own node, which is classified like any other node from its widget class
 - `Menu` / iOS — gap: context-menu tokens are not mapped yet
 - `MenuItem` / Android — gap: menu entries arrive as their own widget class
 - `MenuItem` / iOS — gap: menu-item tokens are not mapped yet
-- `TextArea` / Windows (UIA) — gap: the UIA Document control type is not mapped yet
 - `TextArea` / Android — n/a: Android uses one editable class for single- and multi-line text
 - `ComboBox` / iOS — gap: picker tokens are not mapped yet
 - `List` / iOS — gap: no list token is mapped yet
 - `ListItem` / Android — gap: list children report their own widget class, not a list-item role
 - `ListItem` / iOS — gap: no list-item token is mapped yet
-- `Table` / macOS (AX) — gap: AXTable is not mapped yet
+- `Table` / macOS (AX) — gap: mac lists report AXOutline rather than AXTable; AXOutline maps to Tree
 - `Table` / Android — gap: table and grid classes collapse into List
 - `Table` / iOS — gap: no table token is mapped yet
-- `Cell` / Windows (UIA) — gap: the UIA DataItem control type is not mapped yet
+- `Cell` / Windows (UIA) — gap: UIA's DataItem control type would carry this, but the data grids probed expose their rows as TreeItem
 - `Cell` / Android — gap: no cell class is mapped yet
 - `Tree` / macOS (AX) — gap: AXOutline is not mapped yet
 - `Tree` / Android — n/a: Android has no tree widget
@@ -110,7 +108,6 @@ device's own node, which is classified like any other node from its widget class
 - `StatusBar` / macOS (AX) — n/a: AppKit exposes status items as menu-bar items
 - `StatusBar` / Android — n/a: the system status bar is outside the app tree
 - `StatusBar` / iOS — n/a: the system status bar is outside the app tree
-- `Heading` / Windows (UIA) — gap: the UIA Header control types are not mapped yet
 - `Heading` / macOS (AX) — gap: AXHeading is not mapped yet
 - `Heading` / Android — gap: heading semantics are not mapped yet
 - `Heading` / iOS — gap: the header token is not mapped yet

--- a/docs/reference/a11y-roles.md
+++ b/docs/reference/a11y-roles.md
@@ -54,7 +54,7 @@ device's own node, which is classified like any other node from its widget class
 | `Separator` | yes | yes | yes | n/a | n/a |
 | `Toolbar` | yes | yes | yes | gap | yes |
 | `StatusBar` | yes | yes | n/a | n/a | n/a |
-| `Heading` | yes | yes | yes | gap | gap |
+| `Heading` | yes | gap | yes | gap | gap |
 
 ### Why a cell is not `yes`
 
@@ -66,7 +66,7 @@ device's own node, which is classified like any other node from its widget class
 - `Dialog` / Android — gap: dialog windows arrive as a generic layout class
 - `Dialog` / iOS — gap: alert and action-sheet tokens are not mapped yet
 - `Group` / iOS — gap: no container token is mapped yet
-- `ToggleButton` / macOS (AX) — gap: AppKit reports a switch as AXCheckBox with an AXSwitch or AXToggle subrole; subroles are not read yet
+- `ToggleButton` / macOS (AX) — gap: AppKit reports a switch as AXCheckBox with an AXSwitch or AXToggle subrole; AXCheckBox is outside the reader's subrole gate, and no probed app emitted either subrole
 - `RadioButton` / iOS — gap: no radio token is mapped yet
 - `MenuBar` / Android — n/a: Android apps have no menu bar
 - `MenuBar` / iOS — n/a: iOS apps have no menu bar
@@ -105,6 +105,7 @@ device's own node, which is classified like any other node from its widget class
 - `StatusBar` / macOS (AX) — n/a: AppKit exposes status items as menu-bar items
 - `StatusBar` / Android — n/a: the system status bar is outside the app tree
 - `StatusBar` / iOS — n/a: the system status bar is outside the app tree
+- `Heading` / Windows (UIA) — gap: UIA's Header and HeaderItem are grid column headers, not document headings; the normalized set has no column-header role
 - `Heading` / Android — gap: heading semantics are not mapped yet
 - `Heading` / iOS — gap: the header token is not mapped yet
 <!-- END GENERATED: role-support -->

--- a/docs/reference/a11y-roles.md
+++ b/docs/reference/a11y-roles.md
@@ -41,8 +41,8 @@ device's own node, which is classified like any other node from its widget class
 | `ListItem` | yes | yes | yes | gap | gap |
 | `Table` | yes | yes | gap | gap | gap |
 | `Cell` | yes | gap | yes | gap | yes |
-| `Tree` | yes | yes | gap | n/a | n/a |
-| `TreeItem` | yes | yes | gap | n/a | n/a |
+| `Tree` | yes | yes | yes | n/a | n/a |
+| `TreeItem` | yes | yes | yes | n/a | n/a |
 | `TabList` | yes | yes | yes | gap | yes |
 | `Tab` | yes | yes | gap | gap | gap |
 | `ScrollBar` | yes | yes | yes | n/a | n/a |
@@ -51,10 +51,10 @@ device's own node, which is classified like any other node from its widget class
 | `ProgressBar` | yes | yes | yes | yes | gap |
 | `Image` | yes | yes | yes | yes | yes |
 | `Link` | yes | yes | yes | n/a | yes |
-| `Separator` | yes | yes | gap | n/a | n/a |
+| `Separator` | yes | yes | yes | n/a | n/a |
 | `Toolbar` | yes | yes | yes | gap | yes |
 | `StatusBar` | yes | yes | n/a | n/a | n/a |
-| `Heading` | yes | yes | gap | gap | gap |
+| `Heading` | yes | yes | yes | gap | gap |
 
 ### Why a cell is not `yes`
 
@@ -84,10 +84,8 @@ device's own node, which is classified like any other node from its widget class
 - `Table` / iOS — gap: no table token is mapped yet
 - `Cell` / Windows (UIA) — gap: UIA's DataItem control type would carry this, but the data grids probed expose their rows as TreeItem
 - `Cell` / Android — gap: no cell class is mapped yet
-- `Tree` / macOS (AX) — gap: AXOutline is not mapped yet
 - `Tree` / Android — n/a: Android has no tree widget
 - `Tree` / iOS — n/a: UIKit has no outline view
-- `TreeItem` / macOS (AX) — gap: the outline-row subrole is not read yet
 - `TreeItem` / Android — n/a: Android has no tree widget
 - `TreeItem` / iOS — n/a: UIKit has no outline view
 - `TabList` / Android — gap: tab-container classes are not mapped yet
@@ -101,14 +99,12 @@ device's own node, which is classified like any other node from its widget class
 - `SpinButton` / iOS — gap: the stepper token is not mapped yet
 - `ProgressBar` / iOS — gap: no progress token is mapped yet
 - `Link` / Android — n/a: Android links are spans inside a text view, not separate nodes
-- `Separator` / macOS (AX) — gap: AXSplitter is not mapped yet
 - `Separator` / Android — n/a: Android dividers are drawn, not exposed as nodes
 - `Separator` / iOS — n/a: UIKit exposes no separator element
 - `Toolbar` / Android — gap: the toolbar class is not mapped yet
 - `StatusBar` / macOS (AX) — n/a: AppKit exposes status items as menu-bar items
 - `StatusBar` / Android — n/a: the system status bar is outside the app tree
 - `StatusBar` / iOS — n/a: the system status bar is outside the app tree
-- `Heading` / macOS (AX) — gap: AXHeading is not mapped yet
 - `Heading` / Android — gap: heading semantics are not mapped yet
 - `Heading` / iOS — gap: the header token is not mapped yet
 <!-- END GENERATED: role-support -->


### PR DESCRIPTION
Follow-up to #219, which declared per backend which normalized accessibility roles it can produce and bound each map to its column by a test. This fills Windows and macOS gaps.

Governing rule: **no arm without an observation.** Every mapping here traces to a token a real app was seen to emit. This PR adds the probe harnesses that produced that evidence — a role histogram per app, on both platforms.

**Windows** (probed: charmap, notepad, Task Manager, File Explorer)
- `Document` → `TextArea`
- `Button` carrying UIA's Toggle pattern → `ToggleButton` — a stock editor's format bar exposes five (Bold, Italic, …). `map_role` takes the toggle fact, which the reader already gathered for `checkable`, so it costs no extra call.

**macOS** (probed: TextEdit, System Settings, Activity Monitor, Contacts, Console, Font Book)
- The reader now reads `AXSubrole`, gated to `AXRow` — AppKit reports a table row and an outline row identically, and every mac list probed is an `AXOutline`.
- `AXOutline` → `Tree`, `AXRow`+`AXOutlineRow` → `TreeItem`, `AXScrollArea`/`AXSplitGroup` → `Group`, `AXSplitter` → `Separator`, `AXHeading` → `Heading`, `AXMenuButton` → `Button`.

**Deliberately still unmapped**, with their matrix reasons corrected to say what the probes found: `DataItem` (data grids exposed their rows as `TreeItem`), `IsDialog` (no dialog reachable without input), `AXTable` (mac lists are outlines), `AXColumn`, `AXValueIndicator`. UIA's `Header`/`HeaderItem` are grid column headers, not document headings — mapping them to `Heading` would have meant one word meaning two things across backends, so they stay unmapped too.

Two roles change for elements that already reported one — see the changelog's Changed section: a toggle-capable Windows button (`Button` → `ToggleButton`) and a macOS outline row (`ListItem` → `TreeItem`). The role filter is exact, so a wait on the old role stops matching those.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` — green.
- AT-SPI suite — 25 passed.
- Windows cross-compiled, then the full on-box suite on real hardware: 16/16. The probe confirms `Document` now reports `TextArea`.
- macOS compiled and run on real hardware in a TCC-granted context: the accessibility integration test passes, and the probe reports `AXOutline` → `Tree` and `AXRow/AXOutlineRow` → `TreeItem` (31 and 10 occurrences across two stock apps).
- Both probes now assert that a token this PR maps never comes back as `Other`, so a wiring regression fails instead of printing a plausible line nobody re-reads.