### PR TITLE
a11y: fill the Android and iOS role-map gaps the probes found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,18 +24,22 @@ internal refactors, CI, or test-only changes.
 - [docs/reference/a11y-roles.md](docs/reference/a11y-roles.md) documents which accessibility roles
   each platform backend can produce, and why a role is unavailable where it is.
 - More elements report a real role instead of `Other`: on Windows, documents; on macOS, outlines
-  and their rows, split views and their dividers, scroll areas, headings, and menu buttons.
-  Windows also distinguishes a button that can be toggled — a formatting bar's Bold or Italic —
-  as `ToggleButton`. `docs/reference/a11y-roles.md` lists what each platform can produce.
+  and their rows, split views and their dividers, scroll areas, headings, and menu buttons; on
+  Android, Material cards, the AppCompat linear layout, the view that hosts a Compose hierarchy
+  and a swipe-paged container; on iOS, content groups (including navigation bars and tab bars) and
+  headings. Windows also distinguishes a button that can be toggled — a formatting bar's Bold or
+  Italic — as `ToggleButton`. `docs/reference/a11y-roles.md` lists what each platform can produce.
 
 ### Changed
-- Two kinds of element now report a different role than before, so a `role:` filter that used to
+- Three kinds of element now report a different role than before, so a `role:` filter that used to
   match them no longer does. On Windows, a button that can be toggled (a formatting bar's Bold or
   Italic) reports `ToggleButton` instead of `Button`; on macOS, a row inside an outline view
-  reports `TreeItem` instead of `ListItem`. `role:` matches exactly — the fallback that also
-  accepts a generically-classified element only rescues ones reported as `Group` or `Other` — so
-  a `glass_wait_for_element` (or any other element selector) asking for `role: "button"` or
-  `role: "listitem"` on those elements needs the new role.
+  reports `TreeItem` instead of `ListItem`; on Android, the root element of a tree read through the
+  on-device accessibility service reports `Window` instead of the role its widget class implied,
+  matching what the `uiautomator` reader has always reported. `role:` matches exactly — the
+  fallback that also accepts a generically-classified element only rescues ones reported as `Group`
+  or `Other` — so a `glass_wait_for_element` (or any other element selector) asking for
+  `role: "button"` or `role: "listitem"` on those elements needs the new role.
 - The `glass_a11y_snapshot` outline now names the platform's own role token for an element glass
   has no role mapping for: the line reads `Other(AXDisclosureTriangle)` rather than a bare
   `Other`, so a custom control is still identifiable. The token is the platform's stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,10 @@ internal refactors, CI, or test-only changes.
   each platform backend can produce, and why a role is unavailable where it is.
 - More elements report a real role instead of `Other`: on Windows, documents; on macOS, outlines
   and their rows, split views and their dividers, scroll areas, headings, and menu buttons; on
-  Android, Material cards, the AppCompat linear layout, the view that hosts a Compose hierarchy
-  and a swipe-paged container; on iOS, content groups (including navigation bars and tab bars) and
-  headings. Windows also distinguishes a button that can be toggled — a formatting bar's Bold or
-  Italic — as `ToggleButton`. `docs/reference/a11y-roles.md` lists what each platform can produce.
+  Android, the AndroidX card container, the AppCompat linear layout, the view that hosts a Compose
+  hierarchy and the `ViewPager` swipe-paged container; on iOS, content groups and headings.
+  Windows also distinguishes a button that can be toggled — a formatting bar's Bold or Italic —
+  as `ToggleButton`. `docs/reference/a11y-roles.md` lists what each platform can produce.
 
 ### Changed
 - Three kinds of element now report a different role than before, so a `role:` filter that used to

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -7,7 +7,7 @@ use std::sync::Mutex;
 use serde_json::{json, Value};
 
 use glass_core::accessibility::{
-    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxStates, AxTarget, AxTree,
+    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree,
     TruncationLimit, WalkBudget, WalkLimits,
 };
 use glass_core::platform::WindowGeometry;
@@ -127,7 +127,15 @@ pub(crate) fn tree_from_json(
     limits: WalkLimits,
 ) -> Result<AxTree> {
     let mut budget = WalkBudget::with_limits(limits);
-    let root = json_to_node(tree, win, 0, &mut budget)?;
+    let mut root = json_to_node(tree, win, 0, &mut budget)?;
+    // The device answers with the root of the ACTIVE WINDOW, so this node is the window —
+    // whatever layout class it happens to carry. Say so, for the same reason the
+    // uiautomator reader wraps its dump in a Window root: both Android readers have to
+    // agree about the root, or a `role:` selector written against one misses on the other.
+    // The node itself is untouched — no synthetic wrapper — because `AxNodeId(n)` is the
+    // device's `ref` n and an extra node would shift every id `set_value` addresses by.
+    // `raw_role` keeps the device's class, so the escape hatch still reports it.
+    root.role = AxRole::Window;
     let mut tree = AxTree::new(root);
     tree.truncated = budget.truncation();
     Ok(tree)
@@ -498,6 +506,48 @@ mod tests {
         let save = t.find(AxNodeId(2)).unwrap();
         assert_eq!(save.role, AxRole::Button);
         assert_eq!(save.name.as_deref(), Some("Save"));
+    }
+
+    /// One device `tree` response: a root layout with two children, shaped like the real
+    /// protocol (bounds in screen coordinates, flags as bools).
+    fn device_tree() -> Value {
+        json!({
+            "class": "android.widget.FrameLayout",
+            "bounds": {"x": 0, "y": 0, "w": 1080, "h": 2400},
+            "children": [
+                {"class": "android.widget.TextView", "text": "Settings",
+                 "bounds": {"x": 0, "y": 100, "w": 400, "h": 60}, "children": []},
+                {"class": "android.widget.Button", "desc": "Save",
+                 "bounds": {"x": 0, "y": 200, "w": 400, "h": 60}, "children": []}
+            ]
+        })
+    }
+
+    #[test]
+    fn the_root_is_a_window_like_the_uiautomator_reader() {
+        let win = WindowGeometry {
+            x: 0,
+            y: 0,
+            width: 1080,
+            height: 2400,
+        };
+        let mut tree = tree_from_json(&device_tree(), &win, WalkLimits::DEFAULT).expect("builds");
+        tree.assign_ids();
+        // The service asks the device for the active window's root, so that node IS the
+        // window — and both Android readers must agree on it, or one `role:` selector
+        // cannot address the root on both.
+        assert_eq!(tree.root.role, AxRole::Window);
+        // The device's own class stays in raw_role: the role is normalized, the escape
+        // hatch still reports what the platform said.
+        assert_eq!(tree.root.raw_role, "android.widget.FrameLayout");
+        // Rooting must not add, drop or reorder a node: ids are the device's refs, and
+        // set_value addresses by them.
+        assert_eq!(tree.root.id, AxNodeId(0));
+        assert_eq!(tree.count, 3);
+        assert_eq!(tree.root.children[0].id, AxNodeId(1));
+        assert_eq!(tree.root.children[0].role, AxRole::Label);
+        assert_eq!(tree.root.children[1].id, AxNodeId(2));
+        assert_eq!(tree.root.children[1].role, AxRole::Button);
     }
 
     #[test]

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -134,7 +134,10 @@ pub(crate) fn tree_from_json(
     // agree about the root, or a `role:` selector written against one misses on the other.
     // The node itself is untouched — no synthetic wrapper — because `AxNodeId(n)` is the
     // device's `ref` n and an extra node would shift every id `set_value` addresses by.
-    // `raw_role` keeps the device's class, so the escape hatch still reports it.
+    // `raw_role` keeps the device's class on the node, so anything that reads the node itself
+    // — the role histogram, a structured client — still has it. It no longer reaches the
+    // outline, though: the outline names a native token only for an element glass has no role
+    // for, and this one is now a Window.
     root.role = AxRole::Window;
     let mut tree = AxTree::new(root);
     tree.truncated = budget.truncation();
@@ -537,8 +540,9 @@ mod tests {
         // window — and both Android readers must agree on it, or one `role:` selector
         // cannot address the root on both.
         assert_eq!(tree.root.role, AxRole::Window);
-        // The device's own class stays in raw_role: the role is normalized, the escape
-        // hatch still reports what the platform said.
+        // The device's own class stays in raw_role, where anything reading the node — the
+        // role histogram, a structured client — still finds it. The outline will not print
+        // it: that only names a token for an element with no mapped role.
         assert_eq!(tree.root.raw_role, "android.widget.FrameLayout");
         // Rooting must not add, drop or reorder a node: ids are the device's refs, and
         // set_value addresses by them.

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -44,8 +44,10 @@ pub const CLASS_TOKENS: &[(&str, AxRole)] = &[
     ("GridView", AxRole::List),
     ("WebView", AxRole::Group),
     // Containers the leaf-suffix rule below cannot catch, each observed in a real app's
-    // tree: a Material card, the AppCompat linear layout (shipped under two package
-    // names), the view that hosts a Compose hierarchy, and a swipe-paged container.
+    // tree: the AndroidX card container, the AppCompat linear layout (shipped under two
+    // package names), the view that hosts a Compose hierarchy, and a swipe-paged container.
+    // Each match is on the exact leaf: Material Components' `MaterialCardView` and the
+    // `ViewPager2` successor have different leaves and are not matched.
     ("CardView", AxRole::Group),
     ("LinearLayoutCompat", AxRole::Group),
     ("ComposeView", AxRole::Group),

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -43,6 +43,14 @@ pub const CLASS_TOKENS: &[(&str, AxRole)] = &[
     ("ListView", AxRole::List),
     ("GridView", AxRole::List),
     ("WebView", AxRole::Group),
+    // Containers the leaf-suffix rule below cannot catch, each observed in a real app's
+    // tree: a Material card, the AppCompat linear layout (shipped under two package
+    // names), the view that hosts a Compose hierarchy, and a swipe-paged container.
+    ("CardView", AxRole::Group),
+    ("LinearLayoutCompat", AxRole::Group),
+    ("ComposeView", AxRole::Group),
+    // A pager holds pages, not list items, so it is a Group rather than a List.
+    ("ViewPager", AxRole::Group),
 ];
 
 /// Map an Android widget class (`android.widget.Button`, …) to a normalized role.
@@ -438,6 +446,23 @@ mod tests {
             "checkable=false checked=true (Compose under-report) must still map to \
              checkable=true so the Checked condition matches"
         );
+    }
+
+    #[test]
+    fn container_classes_the_probe_found_map_to_group() {
+        // Every class here was observed in a real app's uiautomator dump landing in
+        // AxRole::Other. They are all containers, and the container rule cannot catch
+        // them: "CardView" and "ComposeView" do not end in "Layout", "LinearLayoutCompat"
+        // ends in "Compat", and "ViewPager" is neither "View" nor "ViewGroup".
+        for class in [
+            "androidx.cardview.widget.CardView",
+            "androidx.appcompat.widget.LinearLayoutCompat",
+            "android.support.v7.widget.LinearLayoutCompat",
+            "androidx.compose.ui.platform.ComposeView",
+            "androidx.viewpager.widget.ViewPager",
+        ] {
+            assert_eq!(class_to_role(class), AxRole::Group, "{class}");
+        }
     }
 
     #[test]

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -488,10 +488,12 @@ mod tests {
         for role in AxRole::ALL {
             let mapped = CLASS_TOKENS.iter().any(|(_, r)| *r == role)
                 || RULE_ROLES.contains(&role)
-                // Only the uiautomator reader (`build_tree`) synthesizes a Window root; the
-                // on-device AccessibilityService reader roots the tree at the device's node,
-                // which comes from `class_to_role` like any other node. Exempt Window since
-                // `class_to_role` cannot produce it.
+                // Neither reader produces Window from a class name: the uiautomator reader
+                // wraps its dump in a synthetic Window root, and the accessibility-service
+                // reader sets Window on the active window's own root node (see
+                // `a11y_service::tree_from_json`). Exempt it — `class_to_role` cannot
+                // produce it, and the Android column declares it Mapped because both
+                // readers really do report it.
                 || role == AxRole::Window;
             match support(role, AxBackend::Android).expect("declared in ROLE_SUPPORT") {
                 RoleSupport::Mapped => {

--- a/crates/glass-android/tests/role_probe.rs
+++ b/crates/glass-android/tests/role_probe.rs
@@ -69,9 +69,9 @@ const MIN_EVIDENCE_NODES: usize = 4;
 ///
 /// # Panics
 ///
-/// Panics when the variable is set to anything but a whole number of milliseconds. Falling
-/// back to the default there would hand the operator the very half-drawn tree they set the
-/// knob to avoid, without saying so.
+/// Panics when the variable is set to a non-blank value that is not a whole number of
+/// milliseconds; set-but-blank reads as unset. Falling back to the default on a typo would hand
+/// the operator the very half-drawn tree they set the knob to avoid, without saying so.
 fn startup_settle() -> Duration {
     let Some(raw) = std::env::var_os(SETTLE_MS_VAR) else {
         return STARTUP_SETTLE;
@@ -207,6 +207,19 @@ fn spec_for(component: &str) -> AppSpec {
     }
 }
 
+/// Restores the device's accessibility settings — `enabled_accessibility_services`,
+/// `accessibility_enabled` and the `adb forward` — when it drops. `A11yServiceRegistry::ensure`
+/// records the prior values and `shutdown` puts them back, so the only question is whether
+/// `shutdown` is reached: a guard reaches it on the panicking path too, which a plain call at
+/// the end of the test does not.
+struct RestoreServiceState<'a>(&'a A11yServiceRegistry);
+
+impl Drop for RestoreServiceState<'_> {
+    fn drop(&mut self) {
+        self.0.shutdown();
+    }
+}
+
 /// The node cap lifted, so a big app's tree is never truncated mid-probe. Depth and per-level
 /// sibling rails keep their generous structural defaults regardless.
 fn uncapped() -> WalkLimits {
@@ -287,6 +300,10 @@ fn service_role_histogram_probe() {
     let client = registry
         .ensure(&platform.resolved_adb(), &apk)
         .expect("install + enable + connect the accessibility service");
+    // Held for the rest of the run so the settings go back however this probe leaves — a
+    // panicking start_app or snapshot mid-loop would otherwise strand the device in exactly
+    // the state the hoisted `ensure` above exists to avoid.
+    let _restore = RestoreServiceState(&registry);
     let mut a11y = ServiceA11y::new(client, String::new());
     let mut violations = Vec::new();
 
@@ -315,8 +332,9 @@ fn service_role_histogram_probe() {
         platform.stop_app().expect("stop_app");
     }
 
-    registry.shutdown(); // restores enabled_accessibility_services + removes the forward
     drop(platform);
     agents.shutdown();
+    // `_restore` puts the device's accessibility settings back as it drops, after this
+    // assertion has decided the run — on the failing path as much as the passing one.
     assert!(violations.is_empty(), "{}", violations.join("\n"));
 }

--- a/crates/glass-android/tests/role_probe.rs
+++ b/crates/glass-android/tests/role_probe.rs
@@ -1,0 +1,249 @@
+//! Role-histogram PROBE for the Android half of the accessibility role-parity work — not a
+//! pass/fail assertion test. Launches whatever apps `GLASS_A11Y_PROBE_APPS` names (a
+//! comma-separated list of `package/activity` components), snapshots each with the node cap
+//! lifted, and prints `glass_core::role_histogram`: every widget class the device actually
+//! reported, unmapped ([`glass_core::AxRole::Other`]) classes first. The project's rule is
+//! probe first, map second — a `Gap` cell in `glass_core::role_support::ROLE_SUPPORT` may only
+//! get a match arm for a class that showed up in output like this — so this file's job is to
+//! produce that evidence.
+//!
+//! It asserts exactly one thing *about* the evidence: a class glass does map must not come
+//! back `AxRole::Other`, which would mean the reader stopped feeding `axmap::class_to_role`
+//! what it reads (see [`MAPPED_CLASSES`]). Otherwise it fails a run only when an app could not
+//! be launched or snapshotted at all — a real breakage, distinct from an app simply exposing
+//! something unexpected. Which role a class *should* map to is never asserted here.
+//!
+//! Both readers are probed, because both share one map and they do not see the same tree: the
+//! `uiautomator` dump is filtered to nodes marked important-for-accessibility, while the
+//! on-device AccessibilityService walks the live `AccessibilityNodeInfo` tree — which is also
+//! where Jetpack Compose's semantics-to-`className` translation shows up.
+//!
+//! Ignored by default; run against a booted AVD:
+//!
+//! ```sh
+//! GLASS_ADB=/path/to/adb \
+//! GLASS_A11Y_PROBE_APPS=com.android.settings/.Settings \
+//!   cargo test -p glass-android --test role_probe -- --ignored --nocapture
+//! ```
+//!
+//! The service probe additionally needs `GLASS_ANDROID_A11Y_APK` pointing at the built
+//! accessibility-service APK. With `GLASS_A11Y_PROBE_APPS` unset (or set but empty) both
+//! probes print what to set and pass without probing anything, so a run that did not ask for
+//! this never fails because of it.
+
+use std::time::Duration;
+
+use glass_android::{
+    A11yServiceRegistry, AgentRegistry, AndroidA11y, AndroidPlatform, EmulatorRegistry, ServiceA11y,
+};
+use glass_core::accessibility::{Accessibility, AxContext, WalkLimits};
+use glass_core::{role_histogram, AppSpec, AxRole, AxTree, Platform, SandboxLevel};
+
+/// Comma-separated `package/activity` components to probe, e.g.
+/// `com.android.settings/.Settings`. Each element is exactly what `AppSpec::run`'s first
+/// element accepts on this backend. Unset (or set but empty) skips the probe rather than
+/// failing a run that never asked for it.
+const PROBE_APPS_VAR: &str = "GLASS_A11Y_PROBE_APPS";
+
+/// How long to wait after `start_app` before snapshotting — an activity keeps inflating and
+/// animating for a beat after the window appears, and a tree read too early is missing the
+/// content the probe exists to see. Matches the settle the sibling on-device tests use.
+const STARTUP_SETTLE: Duration = Duration::from_millis(1500);
+
+/// Widget classes glass maps to a role, and that a probed app has actually been seen to
+/// report. A histogram bucket carrying one of these must not come back [`AxRole::Other`]: the
+/// class reached the reader, so a mapped role is the only correct outcome, and `Other` would
+/// mean the plumbing between the reader and `axmap::class_to_role` broke. A class that simply
+/// does not appear in a given app asserts nothing — apps differ, and an absent class is not a
+/// regression.
+const MAPPED_CLASSES: &[&str] = &[
+    "android.widget.Button",
+    "android.widget.TextView",
+    "android.widget.EditText",
+    "android.widget.ImageView",
+    "android.widget.ImageButton",
+    "android.widget.FrameLayout",
+    "android.widget.LinearLayout",
+    "android.widget.RelativeLayout",
+    "android.widget.ScrollView",
+    "android.view.View",
+    "android.view.ViewGroup",
+    "androidx.recyclerview.widget.RecyclerView",
+];
+
+/// Every [`MAPPED_CLASSES`] bucket in `tree` that came back [`AxRole::Other`], described — the
+/// one thing a histogram can check without becoming brittle about which app exposes what.
+/// Everything else the probe prints is evidence for a human, not a pass/fail claim.
+fn mapped_class_violations(label: &str, tree: &AxTree) -> Vec<String> {
+    role_histogram(tree)
+        .into_iter()
+        .filter(|e| e.role == AxRole::Other && MAPPED_CLASSES.contains(&e.raw_role.as_str()))
+        .map(|e| {
+            format!(
+                "{label}: {} node(s) reported class {:?} as Other, but glass maps that class \
+                 — the reader is not feeding class_to_role what it reads",
+                e.count, e.raw_role
+            )
+        })
+        .collect()
+}
+
+/// Print `role_histogram(tree)` as one line per `(class, role)` bucket — unmapped
+/// ([`AxRole::Other`]) buckets first, which is already the histogram's own sort order, so the
+/// classes most worth a human's attention are the first thing printed.
+fn print_role_histogram(label: &str, tree: &AxTree) {
+    let hist = role_histogram(tree);
+    println!("\n===== role histogram: {label} =====");
+    println!(
+        "{} nodes, {} distinct (class, role) buckets",
+        tree.count,
+        hist.len()
+    );
+    if let Some(t) = &tree.truncated {
+        println!("  NOTE: {}", t.notice());
+    }
+    for entry in &hist {
+        let tag = if entry.role == AxRole::Other {
+            "UNMAPPED"
+        } else {
+            "mapped"
+        };
+        println!(
+            "  {tag:>8}  x{:<5} role={:?} class={:?}",
+            entry.count, entry.role, entry.raw_role
+        );
+    }
+}
+
+/// The components named by [`PROBE_APPS_VAR`], or `None` when the variable is unset or names
+/// nothing — the caller prints what to set and returns without probing.
+fn probe_targets() -> Option<Vec<String>> {
+    let raw = std::env::var(PROBE_APPS_VAR).ok()?;
+    let targets: Vec<String> = raw
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect();
+    (!targets.is_empty()).then_some(targets)
+}
+
+fn spec_for(component: &str, a11y: bool) -> AppSpec {
+    AppSpec {
+        build: None,
+        run: vec![component.to_string()],
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        timeout_ms: 15_000,
+        sandbox: SandboxLevel::Off,
+        a11y,
+    }
+}
+
+/// The node cap lifted, so a big app's tree is never truncated mid-probe. Depth and per-level
+/// sibling rails keep their generous structural defaults regardless.
+fn uncapped() -> WalkLimits {
+    WalkLimits::from_max_nodes(Some(0))
+}
+
+#[test]
+#[ignore = "requires a booted AVD + GLASS_ADB, and GLASS_A11Y_PROBE_APPS naming components"]
+fn uiautomator_role_histogram_probe() {
+    let Some(targets) = probe_targets() else {
+        println!(
+            "skipped: set {PROBE_APPS_VAR} to a comma-separated list of package/activity \
+             components to probe, e.g. {PROBE_APPS_VAR}=com.android.settings/.Settings"
+        );
+        return;
+    };
+
+    let agents = AgentRegistry::new();
+    let mut platform =
+        AndroidPlatform::from_env(&EmulatorRegistry::new(), &agents).expect("attach to a device");
+    let mut violations = Vec::new();
+
+    for component in &targets {
+        let window = platform
+            .start_app(&spec_for(component, true))
+            .unwrap_or_else(|e| panic!("start_app({component}): {e}"));
+        std::thread::sleep(STARTUP_SETTLE);
+
+        let ctx = AxContext {
+            pids: platform.app_pids(),
+            window,
+            window_handle: None,
+            a11y_bus_addr: None,
+            limits: uncapped(),
+        };
+        let mut a11y = AndroidA11y::new();
+        let mut tree = a11y
+            .snapshot(&ctx)
+            .unwrap_or_else(|e| panic!("snapshot({component}): {e}"));
+        tree.assign_ids();
+        print_role_histogram(component, &tree);
+        violations.extend(mapped_class_violations(component, &tree));
+
+        platform.stop_app().expect("stop_app");
+    }
+
+    drop(platform); // close the platform's agent connection (if any) before the registry
+    agents.shutdown(); // never leak a launched agent
+    assert!(violations.is_empty(), "{}", violations.join("\n"));
+}
+
+#[test]
+#[ignore = "requires a booted AVD + GLASS_ADB + GLASS_ANDROID_A11Y_APK, and GLASS_A11Y_PROBE_APPS"]
+fn service_role_histogram_probe() {
+    let Some(targets) = probe_targets() else {
+        println!(
+            "skipped: set {PROBE_APPS_VAR} to a comma-separated list of package/activity \
+             components to probe, e.g. {PROBE_APPS_VAR}=com.android.settings/.Settings"
+        );
+        return;
+    };
+    let Ok(apk) = std::env::var("GLASS_ANDROID_A11Y_APK") else {
+        println!("skipped: set GLASS_ANDROID_A11Y_APK to the built accessibility-service APK");
+        return;
+    };
+
+    let agents = AgentRegistry::new();
+    let mut platform =
+        AndroidPlatform::from_env(&EmulatorRegistry::new(), &agents).expect("attach to a device");
+    let registry = A11yServiceRegistry::new();
+    let mut violations = Vec::new();
+
+    for component in &targets {
+        let window = platform
+            .start_app(&spec_for(component, false))
+            .unwrap_or_else(|e| panic!("start_app({component}): {e}"));
+        std::thread::sleep(STARTUP_SETTLE);
+
+        let client = registry
+            .ensure(&platform.resolved_adb(), &apk)
+            .expect("install + enable + connect the accessibility service");
+        // The service reports the *active* window's tree, so the package filter stays empty
+        // and whichever activity was just launched is what gets walked.
+        let mut a11y = ServiceA11y::new(client, String::new());
+        let ctx = AxContext {
+            pids: vec![],
+            window,
+            window_handle: None,
+            a11y_bus_addr: None,
+            limits: uncapped(),
+        };
+        let mut tree = a11y
+            .snapshot(&ctx)
+            .unwrap_or_else(|e| panic!("service snapshot({component}): {e}"));
+        tree.assign_ids();
+        let label = format!("{component} (service)");
+        print_role_histogram(&label, &tree);
+        violations.extend(mapped_class_violations(&label, &tree));
+
+        platform.stop_app().expect("stop_app");
+    }
+
+    drop(platform);
+    agents.shutdown();
+    assert!(violations.is_empty(), "{}", violations.join("\n"));
+}

--- a/crates/glass-android/tests/role_probe.rs
+++ b/crates/glass-android/tests/role_probe.rs
@@ -69,6 +69,10 @@ const MAPPED_CLASSES: &[&str] = &[
     "android.view.View",
     "android.view.ViewGroup",
     "androidx.recyclerview.widget.RecyclerView",
+    "androidx.cardview.widget.CardView",
+    "androidx.appcompat.widget.LinearLayoutCompat",
+    "androidx.compose.ui.platform.ComposeView",
+    "androidx.viewpager.widget.ViewPager",
 ];
 
 /// Every [`MAPPED_CLASSES`] bucket in `tree` that came back [`AxRole::Other`], described — the

--- a/crates/glass-android/tests/role_probe.rs
+++ b/crates/glass-android/tests/role_probe.rs
@@ -58,12 +58,12 @@ const STARTUP_SETTLE: Duration = Duration::from_millis(1500);
 /// Overrides [`STARTUP_SETTLE`], in whole milliseconds.
 const SETTLE_MS_VAR: &str = "GLASS_A11Y_PROBE_SETTLE_MS";
 
-/// The smallest tree this probe accepts as evidence. A real app screen reports dozens of
-/// nodes; a snapshot taken before the app finished drawing, or of the wrong window, reports a
-/// near-empty shell — which yields no histogram buckets, no violations, and a green run that
-/// proves nothing. The floor sits well above a root plus a single content node so that case is
-/// caught rather than passed.
-const MIN_EVIDENCE_NODES: usize = 8;
+/// The smallest tree this probe accepts as evidence. A snapshot taken before the app finished
+/// drawing, or of the wrong window, reports a near-empty shell — which yields no histogram
+/// buckets, no violations, and a green run that proves nothing. The floor is deliberately low:
+/// the window root plus one container account for two nodes on their own, so this catches "we
+/// could not look", not "this app is sparse".
+const MIN_EVIDENCE_NODES: usize = 4;
 
 /// [`STARTUP_SETTLE`], or the [`SETTLE_MS_VAR`] override when it is set.
 ///
@@ -76,6 +76,11 @@ fn startup_settle() -> Duration {
     let Some(raw) = std::env::var_os(SETTLE_MS_VAR) else {
         return STARTUP_SETTLE;
     };
+    // Set but blank reads as unset, the same way an empty PROBE_APPS_VAR does — a shell that
+    // exports an unfilled variable has asked for nothing, not for a broken value.
+    if raw.to_str().is_some_and(|v| v.trim().is_empty()) {
+        return STARTUP_SETTLE;
+    }
     let ms: u64 = raw
         .to_str()
         .and_then(|v| v.trim().parse().ok())

--- a/crates/glass-android/tests/role_probe.rs
+++ b/crates/glass-android/tests/role_probe.rs
@@ -47,8 +47,47 @@ const PROBE_APPS_VAR: &str = "GLASS_A11Y_PROBE_APPS";
 
 /// How long to wait after `start_app` before snapshotting — an activity keeps inflating and
 /// animating for a beat after the window appears, and a tree read too early is missing the
-/// content the probe exists to see. Matches the settle the sibling on-device tests use.
+/// content the probe exists to see. A little longer than the sibling on-device tests settle
+/// for, on purpose: they only need the app up, while a probe needs the screen fully populated
+/// or its evidence is a half-drawn tree.
+///
+/// Overridable with [`SETTLE_MS_VAR`]: a Compose-heavy or asynchronously-loading app can still
+/// be showing an empty shell at this default, and an empty shell is evidence of nothing.
 const STARTUP_SETTLE: Duration = Duration::from_millis(1500);
+
+/// Overrides [`STARTUP_SETTLE`], in whole milliseconds.
+const SETTLE_MS_VAR: &str = "GLASS_A11Y_PROBE_SETTLE_MS";
+
+/// The smallest tree this probe accepts as evidence. A real app screen reports dozens of
+/// nodes; a snapshot taken before the app finished drawing, or of the wrong window, reports a
+/// near-empty shell — which yields no histogram buckets, no violations, and a green run that
+/// proves nothing. The floor sits well above a root plus a single content node so that case is
+/// caught rather than passed.
+const MIN_EVIDENCE_NODES: usize = 8;
+
+/// [`STARTUP_SETTLE`], or the [`SETTLE_MS_VAR`] override when it is set.
+///
+/// # Panics
+///
+/// Panics when the variable is set to anything but a whole number of milliseconds. Falling
+/// back to the default there would hand the operator the very half-drawn tree they set the
+/// knob to avoid, without saying so.
+fn startup_settle() -> Duration {
+    let Some(raw) = std::env::var_os(SETTLE_MS_VAR) else {
+        return STARTUP_SETTLE;
+    };
+    let ms: u64 = raw
+        .to_str()
+        .and_then(|v| v.trim().parse().ok())
+        .unwrap_or_else(|| {
+            panic!(
+                "{SETTLE_MS_VAR}={raw:?} is not a whole number of milliseconds — set it to \
+                 e.g. 4000, or unset it for the {}ms default",
+                STARTUP_SETTLE.as_millis()
+            )
+        });
+    Duration::from_millis(ms)
+}
 
 /// Widget classes glass maps to a role, and that a probed app has actually been seen to
 /// report. A histogram bucket carrying one of these must not come back [`AxRole::Other`]: the
@@ -92,6 +131,21 @@ fn mapped_class_violations(label: &str, tree: &AxTree) -> Vec<String> {
         .collect()
 }
 
+/// A description of `tree` being too small to be evidence of anything, or `None` when it
+/// clears [`MIN_EVIDENCE_NODES`]. Returned for collection alongside the mapping violations
+/// rather than panicking mid-loop, so one bad target still lets the rest print their evidence.
+fn thin_tree_violation(label: &str, tree: &AxTree) -> Option<String> {
+    (tree.count < MIN_EVIDENCE_NODES).then(|| {
+        format!(
+            "{label}: the tree has only {} node(s), under the {MIN_EVIDENCE_NODES} a real \
+             screen clears — usually the app had not finished drawing, the wrong window was \
+             foreground, or a system alert was covering the screen. Whatever this run printed \
+             is not evidence; retry, raising {SETTLE_MS_VAR} if the app is slow to populate.",
+            tree.count
+        )
+    })
+}
+
 /// Print `role_histogram(tree)` as one line per `(class, role)` bucket — unmapped
 /// ([`AxRole::Other`]) buckets first, which is already the histogram's own sort order, so the
 /// classes most worth a human's attention are the first thing printed.
@@ -132,7 +186,10 @@ fn probe_targets() -> Option<Vec<String>> {
     (!targets.is_empty()).then_some(targets)
 }
 
-fn spec_for(component: &str, a11y: bool) -> AppSpec {
+/// The launch spec for one `package/activity` component. `AppSpec::a11y` only affects Linux
+/// backends — it gates a private AT-SPI bus for the launch — so on Android, where both readers
+/// read ambiently, its value selects nothing and neither reader depends on it.
+fn spec_for(component: &str) -> AppSpec {
     AppSpec {
         build: None,
         run: vec![component.to_string()],
@@ -141,7 +198,7 @@ fn spec_for(component: &str, a11y: bool) -> AppSpec {
         window_hint: None,
         timeout_ms: 15_000,
         sandbox: SandboxLevel::Off,
-        a11y,
+        a11y: false,
     }
 }
 
@@ -169,9 +226,9 @@ fn uiautomator_role_histogram_probe() {
 
     for component in &targets {
         let window = platform
-            .start_app(&spec_for(component, true))
+            .start_app(&spec_for(component))
             .unwrap_or_else(|e| panic!("start_app({component}): {e}"));
-        std::thread::sleep(STARTUP_SETTLE);
+        std::thread::sleep(startup_settle());
 
         let ctx = AxContext {
             pids: platform.app_pids(),
@@ -186,6 +243,7 @@ fn uiautomator_role_histogram_probe() {
             .unwrap_or_else(|e| panic!("snapshot({component}): {e}"));
         tree.assign_ids();
         print_role_histogram(component, &tree);
+        violations.extend(thin_tree_violation(component, &tree));
         violations.extend(mapped_class_violations(component, &tree));
 
         platform.stop_app().expect("stop_app");
@@ -215,20 +273,24 @@ fn service_role_histogram_probe() {
     let mut platform =
         AndroidPlatform::from_env(&EmulatorRegistry::new(), &agents).expect("attach to a device");
     let registry = A11yServiceRegistry::new();
+    // Enable the service once, for the whole run. `ensure` records the device's prior
+    // accessibility settings so `shutdown` can put them back, so calling it per target would
+    // record a "prior" state that already contains glass's own service — and leak one forward
+    // per target. One reader covers every target anyway: the service reports the *active*
+    // window's tree, which is why the package filter stays empty and whichever activity was
+    // last launched is what gets walked.
+    let client = registry
+        .ensure(&platform.resolved_adb(), &apk)
+        .expect("install + enable + connect the accessibility service");
+    let mut a11y = ServiceA11y::new(client, String::new());
     let mut violations = Vec::new();
 
     for component in &targets {
         let window = platform
-            .start_app(&spec_for(component, false))
+            .start_app(&spec_for(component))
             .unwrap_or_else(|e| panic!("start_app({component}): {e}"));
-        std::thread::sleep(STARTUP_SETTLE);
+        std::thread::sleep(startup_settle());
 
-        let client = registry
-            .ensure(&platform.resolved_adb(), &apk)
-            .expect("install + enable + connect the accessibility service");
-        // The service reports the *active* window's tree, so the package filter stays empty
-        // and whichever activity was just launched is what gets walked.
-        let mut a11y = ServiceA11y::new(client, String::new());
         let ctx = AxContext {
             pids: vec![],
             window,
@@ -242,11 +304,13 @@ fn service_role_histogram_probe() {
         tree.assign_ids();
         let label = format!("{component} (service)");
         print_role_histogram(&label, &tree);
+        violations.extend(thin_tree_violation(&label, &tree));
         violations.extend(mapped_class_violations(&label, &tree));
 
         platform.stop_app().expect("stop_app");
     }
 
+    registry.shutdown(); // restores enabled_accessibility_services + removes the forward
     drop(platform);
     agents.shutdown();
     assert!(violations.is_empty(), "{}", violations.join("\n"));

--- a/crates/glass-core/src/role_support.rs
+++ b/crates/glass-core/src/role_support.rs
@@ -107,16 +107,7 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] =
                 Gap("alert and action-sheet tokens are not mapped yet"),
             ],
         ),
-        (
-            R::Group,
-            [
-                Mapped,
-                Mapped,
-                Mapped,
-                Mapped,
-                Gap("no container token is mapped yet"),
-            ],
-        ),
+        (R::Group, [Mapped, Mapped, Mapped, Mapped, Mapped]),
         (R::Button, [Mapped, Mapped, Mapped, Mapped, Mapped]),
         (
             R::ToggleButton,
@@ -351,7 +342,7 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] =
                      headings; the normalized set has no column-header role"),
                 Mapped,
                 Gap("heading semantics are not mapped yet"),
-                Gap("the header token is not mapped yet"),
+                Mapped,
             ],
         ),
     ]

--- a/crates/glass-core/src/role_support.rs
+++ b/crates/glass-core/src/role_support.rs
@@ -275,8 +275,8 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] =
                      class name marks it as a tab",
                 ),
                 Gap(
-                    "a tab bar and its items arrive as AXGroup; the element identifier names \
-                     the tab bar, the role does not",
+                    "the tab bars seen in probing arrived as AXGroup, named by the element \
+                     identifier rather than the role, and no tab-item token appeared",
                 ),
             ],
         ),

--- a/crates/glass-core/src/role_support.rs
+++ b/crates/glass-core/src/role_support.rs
@@ -104,7 +104,10 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] =
                 ),
                 Gap("AXSheet, AXPopover and AXDrawer are not mapped yet"),
                 Gap("dialog windows arrive as a generic layout class"),
-                Gap("alert and action-sheet tokens are not mapped yet"),
+                Gap(
+                    "an alert exposes its buttons and text directly under the application \
+                     element; no alert, sheet or popover token appears",
+                ),
             ],
         ),
         (R::Group, [Mapped, Mapped, Mapped, Mapped, Mapped]),
@@ -186,7 +189,13 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] =
         ),
         (
             R::List,
-            [Mapped, Mapped, Mapped, Mapped, Gap("no list token is mapped yet")],
+            [
+                Mapped,
+                Mapped,
+                Mapped,
+                Mapped,
+                Gap("collections arrive as AXGroup, which maps to Group; no list token appears"),
+            ],
         ),
         (
             R::ListItem,
@@ -195,7 +204,7 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] =
                 Mapped,
                 Mapped,
                 Gap("list children report their own widget class, not a list-item role"),
-                Gap("no list-item token is mapped yet"),
+                Gap("a collection's children report their own element role, not a list-item role"),
             ],
         ),
         (
@@ -205,7 +214,7 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] =
                 Mapped,
                 Gap("mac lists report AXOutline rather than AXTable; AXOutline maps to Tree"),
                 Gap("table and grid classes collapse into List"),
-                Gap("no table token is mapped yet"),
+                Gap("collections arrive as AXGroup, which maps to Group; no table token appears"),
             ],
         ),
         (
@@ -247,7 +256,10 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] =
                 Mapped,
                 Mapped,
                 Mapped,
-                Gap("tab-container classes are not mapped yet"),
+                Gap(
+                    "a tab container reports a plain layout class; the tab role lives in the \
+                     view's id and selected state, not in the class name",
+                ),
                 Mapped,
             ],
         ),
@@ -258,8 +270,14 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] =
                 Mapped,
                 Gap("AppKit reports tab items as AXRadioButton inside the tab group; the \
                      containing role is not used to disambiguate yet"),
-                Gap("tab children are not mapped yet"),
-                Gap("tab-item tokens are not mapped yet"),
+                Gap(
+                    "a tab reports a plain layout class with selected=true; nothing in the \
+                     class name marks it as a tab",
+                ),
+                Gap(
+                    "a tab bar and its items arrive as AXGroup; the element identifier names \
+                     the tab bar, the role does not",
+                ),
             ],
         ),
         (
@@ -341,7 +359,10 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] =
                 Gap("UIA's Header and HeaderItem are grid column headers, not document \
                      headings; the normalized set has no column-header role"),
                 Mapped,
-                Gap("heading semantics are not mapped yet"),
+                Gap(
+                    "neither reader exposes heading semantics: the uiautomator dump has no \
+                     heading attribute, and the service protocol does not carry isHeading",
+                ),
                 Mapped,
             ],
         ),

--- a/crates/glass-ios/src/axmap.rs
+++ b/crates/glass-ios/src/axmap.rs
@@ -44,6 +44,12 @@ pub const ROLE_TOKENS: &[(&str, AxRole)] = &[
     ("AXTabBar", AxRole::TabList),
     ("AXApplication", AxRole::Application),
     ("AXWindow", AxRole::Window),
+    // A content container. UIKit reports navigation bars and tab bars this way too — the
+    // element's identifier names them, its role does not — so this is the only structural
+    // token most screens expose.
+    ("AXGroup", AxRole::Group),
+    // A screen or section title.
+    ("AXHeading", AxRole::Heading),
 ];
 
 /// Map an idb AX role string (e.g. `AXButton`) to a normalized [`AxRole`].
@@ -591,6 +597,19 @@ mod tests {
         );
         // `checked` carries the state; the label still lives in `value` (unchanged behavior).
         assert_eq!(sw.value.as_deref(), Some("Bold Text"));
+    }
+
+    #[test]
+    fn tokens_the_probe_found_map_to_their_roles() {
+        // Both were observed across most stock apps probed: AXGroup wraps content
+        // (including navigation bars and tab bars, which carry no role of their own), and
+        // AXHeading is a screen or section title.
+        assert_eq!(ax_role("AXGroup"), AxRole::Group);
+        assert_eq!(ax_role("AXHeading"), AxRole::Heading);
+        // A generic element carries no role at all, so it stays Other and the native token
+        // stays visible in the outline. Mapping it to Group would claim a structure that
+        // the platform never reported.
+        assert_eq!(ax_role("AXGenericElement"), AxRole::Other);
     }
 
     #[test]

--- a/crates/glass-ios/src/axmap.rs
+++ b/crates/glass-ios/src/axmap.rs
@@ -44,9 +44,11 @@ pub const ROLE_TOKENS: &[(&str, AxRole)] = &[
     ("AXTabBar", AxRole::TabList),
     ("AXApplication", AxRole::Application),
     ("AXWindow", AxRole::Window),
-    // A content container. UIKit reports navigation bars and tab bars this way too — the
-    // element's identifier names them, its role does not — so this is the only structural
-    // token most screens expose.
+    // A content container, and the only structural token most probed screens exposed: in
+    // those apps the navigation bar and the tab bar arrived as AXGroup as well, named by the
+    // element's identifier rather than by its role. That is what was seen there, not a rule
+    // about UIKit — an app that does report AXNavigationBar or AXTabBar still maps to Toolbar
+    // or TabList through the rows above.
     ("AXGroup", AxRole::Group),
     // A screen or section title.
     ("AXHeading", AxRole::Heading),
@@ -601,9 +603,11 @@ mod tests {
 
     #[test]
     fn tokens_the_probe_found_map_to_their_roles() {
-        // Both were observed across most stock apps probed: AXGroup wraps content
-        // (including navigation bars and tab bars, which carry no role of their own), and
-        // AXHeading is a screen or section title.
+        // Both were observed across most stock apps probed: AXGroup wraps content — in those
+        // apps the navigation bar and the tab bar arrived as AXGroup too, named by the
+        // element identifier rather than by the role — and AXHeading is a screen or section
+        // title. An app that reports AXNavigationBar or AXTabBar instead still maps to
+        // Toolbar or TabList; those rows are unchanged.
         assert_eq!(ax_role("AXGroup"), AxRole::Group);
         assert_eq!(ax_role("AXHeading"), AxRole::Heading);
         // A generic element carries no role at all, so it stays Other and the native token

--- a/crates/glass-ios/tests/role_probe.rs
+++ b/crates/glass-ios/tests/role_probe.rs
@@ -62,9 +62,9 @@ const MIN_EVIDENCE_NODES: usize = 4;
 ///
 /// # Panics
 ///
-/// Panics when the variable is set to anything but a whole number of milliseconds. Falling
-/// back to the default there would hand the operator the very empty shell they set the knob to
-/// avoid, without saying so.
+/// Panics when the variable is set to a non-blank value that is not a whole number of
+/// milliseconds; set-but-blank reads as unset. Falling back to the default on a typo would hand
+/// the operator the very empty shell they set the knob to avoid, without saying so.
 fn startup_settle() -> Duration {
     let Some(raw) = std::env::var_os(SETTLE_MS_VAR) else {
         return STARTUP_SETTLE;

--- a/crates/glass-ios/tests/role_probe.rs
+++ b/crates/glass-ios/tests/role_probe.rs
@@ -1,0 +1,167 @@
+//! Role-histogram PROBE for the iOS half of the accessibility role-parity work — not a
+//! pass/fail assertion test. Launches whatever apps `GLASS_A11Y_PROBE_APPS` names (a
+//! comma-separated list of bundle ids or `.app` paths — exactly what `AppSpec::run`'s first
+//! element accepts on this backend), snapshots each through `idb` with the node cap lifted,
+//! and prints `glass_core::role_histogram`: every AX role string the Simulator actually
+//! reported, unmapped ([`glass_core::AxRole::Other`]) tokens first. The project's rule is
+//! probe first, map second — a `Gap` cell in `glass_core::role_support::ROLE_SUPPORT` may only
+//! get a match arm for a token that showed up in output like this — so this file's job is to
+//! produce that evidence.
+//!
+//! It asserts exactly one thing *about* the evidence: a token glass does map must not come
+//! back `AxRole::Other`, which would mean the reader stopped feeding `axmap::ax_role` what it
+//! reads (see [`MAPPED_TOKENS`]). Otherwise it fails a run only when an app could not be
+//! launched or snapshotted at all — a real breakage, distinct from an app simply exposing
+//! something unexpected. Which role a token *should* map to is never asserted here.
+//!
+//! Ignored by default; run on a macOS host with a booted Simulator and `idb_companion`
+//! available:
+//!
+//! ```sh
+//! GLASS_A11Y_PROBE_APPS=com.apple.Preferences \
+//!   cargo test -p glass-ios --test role_probe -- --ignored --nocapture
+//! ```
+//!
+//! With `GLASS_A11Y_PROBE_APPS` unset (or set but empty) it prints what to set and passes
+//! without probing, so a run that did not ask for this never fails because of it.
+
+use std::time::Duration;
+
+use glass_core::accessibility::{AxContext, WalkLimits};
+use glass_core::Accessibility; // the trait must be in scope to call `snapshot` on the boxed reader
+use glass_core::{role_histogram, AppSpec, AxRole, AxTree, Platform, SandboxLevel};
+use glass_ios::{IosPlatform, SimulatorRegistry};
+
+/// Comma-separated bundle ids or `.app` paths to probe, e.g. `com.apple.Preferences`. Unset
+/// (or set but empty) skips the probe rather than failing a run that never asked for it.
+const PROBE_APPS_VAR: &str = "GLASS_A11Y_PROBE_APPS";
+
+/// How long to wait after `start_app` before snapshotting — UIKit keeps building the view
+/// hierarchy for a beat after the app is up, and a tree read too early is missing the content
+/// the probe exists to see. Matches the settle the sibling on-box tests use.
+const STARTUP_SETTLE: Duration = Duration::from_millis(1500);
+
+/// AX role tokens glass maps to a role, and that a probed app has actually been seen to
+/// report. A histogram bucket carrying one of these must not come back [`AxRole::Other`]: the
+/// token reached the reader, so a mapped role is the only correct outcome, and `Other` would
+/// mean the plumbing between the reader and `axmap::ax_role` broke. A token that simply does
+/// not appear in a given app asserts nothing — apps differ, and an absent token is not a
+/// regression.
+const MAPPED_TOKENS: &[&str] = &[
+    "AXButton",
+    "AXStaticText",
+    "AXTextField",
+    "AXImage",
+    "AXCell",
+    "AXNavigationBar",
+    "AXApplication",
+    "AXWindow",
+];
+
+/// Every [`MAPPED_TOKENS`] bucket in `tree` that came back [`AxRole::Other`], described — the
+/// one thing a histogram can check without becoming brittle about which app exposes what.
+/// Everything else the probe prints is evidence for a human, not a pass/fail claim.
+fn mapped_token_violations(label: &str, tree: &AxTree) -> Vec<String> {
+    role_histogram(tree)
+        .into_iter()
+        .filter(|e| e.role == AxRole::Other && MAPPED_TOKENS.contains(&e.raw_role.as_str()))
+        .map(|e| {
+            format!(
+                "{label}: {} node(s) reported token {:?} as Other, but glass maps that token \
+                 — the reader is not feeding ax_role what it reads",
+                e.count, e.raw_role
+            )
+        })
+        .collect()
+}
+
+/// Print `role_histogram(tree)` as one line per `(token, role)` bucket — unmapped
+/// ([`AxRole::Other`]) buckets first, which is already the histogram's own sort order, so the
+/// tokens most worth a human's attention are the first thing printed.
+fn print_role_histogram(label: &str, tree: &AxTree) {
+    let hist = role_histogram(tree);
+    println!("\n===== role histogram: {label} =====");
+    println!(
+        "{} nodes, {} distinct (token, role) buckets",
+        tree.count,
+        hist.len()
+    );
+    if let Some(t) = &tree.truncated {
+        println!("  NOTE: {}", t.notice());
+    }
+    for entry in &hist {
+        let tag = if entry.role == AxRole::Other {
+            "UNMAPPED"
+        } else {
+            "mapped"
+        };
+        println!(
+            "  {tag:>8}  x{:<5} role={:?} token={:?}",
+            entry.count, entry.role, entry.raw_role
+        );
+    }
+}
+
+#[test]
+#[ignore = "on-box only: needs a macOS host with a booted iOS Simulator + idb_companion, and \
+            GLASS_A11Y_PROBE_APPS naming bundle ids or .app paths"]
+fn role_histogram_probe() {
+    let raw = std::env::var(PROBE_APPS_VAR).unwrap_or_default();
+    let targets: Vec<&str> = raw
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+    if targets.is_empty() {
+        println!(
+            "skipped: set {PROBE_APPS_VAR} to a comma-separated list of bundle ids or .app \
+             paths to probe, e.g. {PROBE_APPS_VAR}=com.apple.Preferences"
+        );
+        return;
+    }
+
+    let registry = SimulatorRegistry::new();
+    let mut platform =
+        IosPlatform::from_env(&registry).expect("from_env: resolve/boot a Simulator");
+    let mut violations = Vec::new();
+
+    for target in targets {
+        let spec = AppSpec {
+            build: None,
+            run: vec![target.to_string()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 30_000,
+            sandbox: SandboxLevel::Off,
+            a11y: true,
+        };
+        let window = platform
+            .start_app(&spec)
+            .unwrap_or_else(|e| panic!("start_app({target}): {e}"));
+        std::thread::sleep(STARTUP_SETTLE);
+
+        let mut a11y = platform
+            .accessibility()
+            .expect("accessibility(): connect an idb client")
+            .expect("companion present on this on-box run, so a reader is available");
+        let ctx = AxContext {
+            pids: vec![],
+            window,
+            window_handle: None,
+            a11y_bus_addr: None,
+            // The node cap lifted, so a big app's tree is never truncated mid-probe. Depth
+            // and per-level sibling rails keep their generous structural defaults regardless.
+            limits: WalkLimits::from_max_nodes(Some(0)),
+        };
+        let mut tree = a11y
+            .snapshot(&ctx)
+            .unwrap_or_else(|e| panic!("snapshot({target}): {e}"));
+        tree.assign_ids();
+        print_role_histogram(target, &tree);
+        violations.extend(mapped_token_violations(target, &tree));
+    }
+
+    platform.stop_app().expect("stop_app");
+    assert!(violations.is_empty(), "{}", violations.join("\n"));
+}

--- a/crates/glass-ios/tests/role_probe.rs
+++ b/crates/glass-ios/tests/role_probe.rs
@@ -50,12 +50,13 @@ const STARTUP_SETTLE: Duration = Duration::from_millis(1500);
 /// Overrides [`STARTUP_SETTLE`], in whole milliseconds.
 const SETTLE_MS_VAR: &str = "GLASS_A11Y_PROBE_SETTLE_MS";
 
-/// The smallest tree this probe accepts as evidence. A real app screen reports dozens of
-/// nodes; a snapshot taken before the app finished drawing, or of the wrong window, reports a
-/// near-empty shell — which yields no histogram buckets, no violations, and a green run that
-/// proves nothing. The floor sits well above a root plus a single content node so that case is
-/// caught rather than passed.
-const MIN_EVIDENCE_NODES: usize = 8;
+/// The smallest tree this probe accepts as evidence. A snapshot taken before the app finished
+/// drawing, or of the wrong window, reports a near-empty shell — which yields no histogram
+/// buckets, no violations, and a green run that proves nothing. The floor is deliberately low:
+/// the synthetic window root plus the application element account for two nodes on their own,
+/// and a legitimate iOS screen can still be small (a document browser's empty state is six).
+/// So this catches "we could not look", not "this app is sparse".
+const MIN_EVIDENCE_NODES: usize = 4;
 
 /// [`STARTUP_SETTLE`], or the [`SETTLE_MS_VAR`] override when it is set.
 ///
@@ -68,6 +69,11 @@ fn startup_settle() -> Duration {
     let Some(raw) = std::env::var_os(SETTLE_MS_VAR) else {
         return STARTUP_SETTLE;
     };
+    // Set but blank reads as unset, the same way an empty PROBE_APPS_VAR does — a shell that
+    // exports an unfilled variable has asked for nothing, not for a broken value.
+    if raw.to_str().is_some_and(|v| v.trim().is_empty()) {
+        return STARTUP_SETTLE;
+    }
     let ms: u64 = raw
         .to_str()
         .and_then(|v| v.trim().parse().ok())

--- a/crates/glass-ios/tests/role_probe.rs
+++ b/crates/glass-ios/tests/role_probe.rs
@@ -39,7 +39,19 @@ const PROBE_APPS_VAR: &str = "GLASS_A11Y_PROBE_APPS";
 /// How long to wait after `start_app` before snapshotting — UIKit keeps building the view
 /// hierarchy for a beat after the app is up, and a tree read too early is missing the content
 /// the probe exists to see. Matches the settle the sibling on-box tests use.
+///
+/// Overridable with `GLASS_A11Y_PROBE_SETTLE_MS`: a stock app that loads its content
+/// asynchronously (a contact list, a document browser) can still be showing an empty shell at
+/// this default, and an empty shell is evidence of nothing.
 const STARTUP_SETTLE: Duration = Duration::from_millis(1500);
+
+/// [`STARTUP_SETTLE`], or the `GLASS_A11Y_PROBE_SETTLE_MS` override when it parses.
+fn startup_settle() -> Duration {
+    std::env::var("GLASS_A11Y_PROBE_SETTLE_MS")
+        .ok()
+        .and_then(|v| v.trim().parse().ok())
+        .map_or(STARTUP_SETTLE, Duration::from_millis)
+}
 
 /// AX role tokens glass maps to a role, and that a probed app has actually been seen to
 /// report. A histogram bucket carrying one of these must not come back [`AxRole::Other`]: the
@@ -139,7 +151,7 @@ fn role_histogram_probe() {
         let window = platform
             .start_app(&spec)
             .unwrap_or_else(|e| panic!("start_app({target}): {e}"));
-        std::thread::sleep(STARTUP_SETTLE);
+        std::thread::sleep(startup_settle());
 
         let mut a11y = platform
             .accessibility()

--- a/crates/glass-ios/tests/role_probe.rs
+++ b/crates/glass-ios/tests/role_probe.rs
@@ -68,7 +68,12 @@ const MAPPED_TOKENS: &[&str] = &[
     "AXNavigationBar",
     "AXApplication",
     "AXWindow",
+    "AXGroup",
+    "AXHeading",
 ];
+
+// `AXGenericElement` is deliberately absent: it carries no role, so `Other` with the token
+// preserved is the correct outcome, and a probe run that reports it is reporting the truth.
 
 /// Every [`MAPPED_TOKENS`] bucket in `tree` that came back [`AxRole::Other`], described — the
 /// one thing a histogram can check without becoming brittle about which app exposes what.

--- a/crates/glass-ios/tests/role_probe.rs
+++ b/crates/glass-ios/tests/role_probe.rs
@@ -38,19 +38,47 @@ const PROBE_APPS_VAR: &str = "GLASS_A11Y_PROBE_APPS";
 
 /// How long to wait after `start_app` before snapshotting — UIKit keeps building the view
 /// hierarchy for a beat after the app is up, and a tree read too early is missing the content
-/// the probe exists to see. Matches the settle the sibling on-box tests use.
+/// the probe exists to see. A little longer than the sibling on-box tests settle for, on
+/// purpose: they only need the app up, while a probe needs the screen fully populated or its
+/// evidence is a half-drawn tree.
 ///
-/// Overridable with `GLASS_A11Y_PROBE_SETTLE_MS`: a stock app that loads its content
-/// asynchronously (a contact list, a document browser) can still be showing an empty shell at
-/// this default, and an empty shell is evidence of nothing.
+/// Overridable with [`SETTLE_MS_VAR`]: a stock app that loads its content asynchronously (a
+/// contact list, a document browser) can still be showing an empty shell at this default, and
+/// an empty shell is evidence of nothing.
 const STARTUP_SETTLE: Duration = Duration::from_millis(1500);
 
-/// [`STARTUP_SETTLE`], or the `GLASS_A11Y_PROBE_SETTLE_MS` override when it parses.
+/// Overrides [`STARTUP_SETTLE`], in whole milliseconds.
+const SETTLE_MS_VAR: &str = "GLASS_A11Y_PROBE_SETTLE_MS";
+
+/// The smallest tree this probe accepts as evidence. A real app screen reports dozens of
+/// nodes; a snapshot taken before the app finished drawing, or of the wrong window, reports a
+/// near-empty shell — which yields no histogram buckets, no violations, and a green run that
+/// proves nothing. The floor sits well above a root plus a single content node so that case is
+/// caught rather than passed.
+const MIN_EVIDENCE_NODES: usize = 8;
+
+/// [`STARTUP_SETTLE`], or the [`SETTLE_MS_VAR`] override when it is set.
+///
+/// # Panics
+///
+/// Panics when the variable is set to anything but a whole number of milliseconds. Falling
+/// back to the default there would hand the operator the very empty shell they set the knob to
+/// avoid, without saying so.
 fn startup_settle() -> Duration {
-    std::env::var("GLASS_A11Y_PROBE_SETTLE_MS")
-        .ok()
+    let Some(raw) = std::env::var_os(SETTLE_MS_VAR) else {
+        return STARTUP_SETTLE;
+    };
+    let ms: u64 = raw
+        .to_str()
         .and_then(|v| v.trim().parse().ok())
-        .map_or(STARTUP_SETTLE, Duration::from_millis)
+        .unwrap_or_else(|| {
+            panic!(
+                "{SETTLE_MS_VAR}={raw:?} is not a whole number of milliseconds — set it to \
+                 e.g. 4000, or unset it for the {}ms default",
+                STARTUP_SETTLE.as_millis()
+            )
+        });
+    Duration::from_millis(ms)
 }
 
 /// AX role tokens glass maps to a role, and that a probed app has actually been seen to
@@ -90,6 +118,21 @@ fn mapped_token_violations(label: &str, tree: &AxTree) -> Vec<String> {
             )
         })
         .collect()
+}
+
+/// A description of `tree` being too small to be evidence of anything, or `None` when it
+/// clears [`MIN_EVIDENCE_NODES`]. Returned for collection alongside the mapping violations
+/// rather than panicking mid-loop, so one bad target still lets the rest print their evidence.
+fn thin_tree_violation(label: &str, tree: &AxTree) -> Option<String> {
+    (tree.count < MIN_EVIDENCE_NODES).then(|| {
+        format!(
+            "{label}: the tree has only {} node(s), under the {MIN_EVIDENCE_NODES} a real \
+             screen clears — usually the app had not finished drawing, the wrong window was \
+             foreground, or a system alert was covering the screen. Whatever this run printed \
+             is not evidence; retry, raising {SETTLE_MS_VAR} if the app is slow to populate.",
+            tree.count
+        )
+    })
 }
 
 /// Print `role_histogram(tree)` as one line per `(token, role)` bucket — unmapped
@@ -176,9 +219,14 @@ fn role_histogram_probe() {
             .unwrap_or_else(|e| panic!("snapshot({target}): {e}"));
         tree.assign_ids();
         print_role_histogram(target, &tree);
+        violations.extend(thin_tree_violation(target, &tree));
         violations.extend(mapped_token_violations(target, &tree));
+
+        // Inside the loop: `start_app` overwrites the platform's stored running app without
+        // terminating the previous one, so stopping only after the loop would leave every
+        // earlier target running on the Simulator.
+        platform.stop_app().expect("stop_app");
     }
 
-    platform.stop_app().expect("stop_app");
     assert!(violations.is_empty(), "{}", violations.join("\n"));
 }

--- a/docs/reference/a11y-roles.md
+++ b/docs/reference/a11y-roles.md
@@ -17,7 +17,9 @@ A cell reads:
 
 On Android, both readers report a `Window` root: the `uiautomator` reader wraps its dump in a
 window root sized to the app window, and the accessibility-service reader labels the active
-window's own root node, whose widget class stays visible as the node's native token.
+window's own root node. That node keeps its widget class as its native token, so a client
+reading the tree still has it, but the outline does not show it — the root has a role now, and
+the outline only names the token of an element that has none.
 
 <!-- BEGIN GENERATED: role-support -->
 | Role | Linux (AT-SPI) | Windows (UIA) | macOS (AX) | Android | iOS |
@@ -90,7 +92,7 @@ window's own root node, whose widget class stays visible as the node's native to
 - `TabList` / Android — gap: a tab container reports a plain layout class; the tab role lives in the view's id and selected state, not in the class name
 - `Tab` / macOS (AX) — gap: AppKit reports tab items as AXRadioButton inside the tab group; the containing role is not used to disambiguate yet
 - `Tab` / Android — gap: a tab reports a plain layout class with selected=true; nothing in the class name marks it as a tab
-- `Tab` / iOS — gap: a tab bar and its items arrive as AXGroup; the element identifier names the tab bar, the role does not
+- `Tab` / iOS — gap: the tab bars seen in probing arrived as AXGroup, named by the element identifier rather than the role, and no tab-item token appeared
 - `ScrollBar` / Android — n/a: Android scrollbars are drawn, not exposed as nodes
 - `ScrollBar` / iOS — n/a: UIKit scroll indicators are not accessibility elements
 - `SpinButton` / macOS (AX) — gap: AXIncrementor is not mapped yet

--- a/docs/reference/a11y-roles.md
+++ b/docs/reference/a11y-roles.md
@@ -17,9 +17,8 @@ A cell reads:
 
 On Android, both readers report a `Window` root: the `uiautomator` reader wraps its dump in a
 window root sized to the app window, and the accessibility-service reader labels the active
-window's own root node. That node keeps its widget class as its native token, so a client
-reading the tree still has it, but the outline does not show it — the root has a role now, and
-the outline only names the token of an element that has none.
+window's own root node. The outline does not name that node's widget class — the root has a role
+now, and the outline only names the token of an element that has none.
 
 <!-- BEGIN GENERATED: role-support -->
 | Role | Linux (AT-SPI) | Windows (UIA) | macOS (AX) | Android | iOS |

--- a/docs/reference/a11y-roles.md
+++ b/docs/reference/a11y-roles.md
@@ -15,9 +15,9 @@ A cell reads:
   or that the concept simply does not exist there.
 - `gap` — the platform has a counterpart glass does not map yet.
 
-On Android, `Window` holds for the `uiautomator` reader, which wraps the dump in a window root
-sized to the app window. The on-device accessibility-service reader instead roots the tree at the
-device's own node, which is classified like any other node from its widget class.
+On Android, both readers report a `Window` root: the `uiautomator` reader wraps its dump in a
+window root sized to the app window, and the accessibility-service reader labels the active
+window's own root node, whose widget class stays visible as the node's native token.
 
 <!-- BEGIN GENERATED: role-support -->
 | Role | Linux (AT-SPI) | Windows (UIA) | macOS (AX) | Android | iOS |
@@ -25,7 +25,7 @@ device's own node, which is classified like any other node from its widget class
 | `Application` | yes | n/a | gap | n/a | yes |
 | `Window` | yes | yes | yes | yes | yes |
 | `Dialog` | yes | gap | gap | gap | gap |
-| `Group` | yes | yes | yes | yes | gap |
+| `Group` | yes | yes | yes | yes | yes |
 | `Button` | yes | yes | yes | yes | yes |
 | `ToggleButton` | yes | yes | gap | yes | yes |
 | `RadioButton` | yes | yes | yes | yes | gap |
@@ -54,7 +54,7 @@ device's own node, which is classified like any other node from its widget class
 | `Separator` | yes | yes | yes | n/a | n/a |
 | `Toolbar` | yes | yes | yes | gap | yes |
 | `StatusBar` | yes | yes | n/a | n/a | n/a |
-| `Heading` | yes | gap | yes | gap | gap |
+| `Heading` | yes | gap | yes | gap | yes |
 
 ### Why a cell is not `yes`
 
@@ -64,8 +64,7 @@ device's own node, which is classified like any other node from its widget class
 - `Dialog` / Windows (UIA) — gap: UIA marks a dialog with the IsDialog property on a Window; the reader does not read it
 - `Dialog` / macOS (AX) — gap: AXSheet, AXPopover and AXDrawer are not mapped yet
 - `Dialog` / Android — gap: dialog windows arrive as a generic layout class
-- `Dialog` / iOS — gap: alert and action-sheet tokens are not mapped yet
-- `Group` / iOS — gap: no container token is mapped yet
+- `Dialog` / iOS — gap: an alert exposes its buttons and text directly under the application element; no alert, sheet or popover token appears
 - `ToggleButton` / macOS (AX) — gap: AppKit reports a switch as AXCheckBox with an AXSwitch or AXToggle subrole; AXCheckBox is outside the reader's subrole gate, and no probed app emitted either subrole
 - `RadioButton` / iOS — gap: no radio token is mapped yet
 - `MenuBar` / Android — n/a: Android apps have no menu bar
@@ -76,22 +75,22 @@ device's own node, which is classified like any other node from its widget class
 - `MenuItem` / iOS — gap: menu-item tokens are not mapped yet
 - `TextArea` / Android — n/a: Android uses one editable class for single- and multi-line text
 - `ComboBox` / iOS — gap: picker tokens are not mapped yet
-- `List` / iOS — gap: no list token is mapped yet
+- `List` / iOS — gap: collections arrive as AXGroup, which maps to Group; no list token appears
 - `ListItem` / Android — gap: list children report their own widget class, not a list-item role
-- `ListItem` / iOS — gap: no list-item token is mapped yet
+- `ListItem` / iOS — gap: a collection's children report their own element role, not a list-item role
 - `Table` / macOS (AX) — gap: mac lists report AXOutline rather than AXTable; AXOutline maps to Tree
 - `Table` / Android — gap: table and grid classes collapse into List
-- `Table` / iOS — gap: no table token is mapped yet
+- `Table` / iOS — gap: collections arrive as AXGroup, which maps to Group; no table token appears
 - `Cell` / Windows (UIA) — gap: UIA's DataItem control type would carry this, but the data grids probed expose their rows as TreeItem
 - `Cell` / Android — gap: no cell class is mapped yet
 - `Tree` / Android — n/a: Android has no tree widget
 - `Tree` / iOS — n/a: UIKit has no outline view
 - `TreeItem` / Android — n/a: Android has no tree widget
 - `TreeItem` / iOS — n/a: UIKit has no outline view
-- `TabList` / Android — gap: tab-container classes are not mapped yet
+- `TabList` / Android — gap: a tab container reports a plain layout class; the tab role lives in the view's id and selected state, not in the class name
 - `Tab` / macOS (AX) — gap: AppKit reports tab items as AXRadioButton inside the tab group; the containing role is not used to disambiguate yet
-- `Tab` / Android — gap: tab children are not mapped yet
-- `Tab` / iOS — gap: tab-item tokens are not mapped yet
+- `Tab` / Android — gap: a tab reports a plain layout class with selected=true; nothing in the class name marks it as a tab
+- `Tab` / iOS — gap: a tab bar and its items arrive as AXGroup; the element identifier names the tab bar, the role does not
 - `ScrollBar` / Android — n/a: Android scrollbars are drawn, not exposed as nodes
 - `ScrollBar` / iOS — n/a: UIKit scroll indicators are not accessibility elements
 - `SpinButton` / macOS (AX) — gap: AXIncrementor is not mapped yet
@@ -106,6 +105,5 @@ device's own node, which is classified like any other node from its widget class
 - `StatusBar` / Android — n/a: the system status bar is outside the app tree
 - `StatusBar` / iOS — n/a: the system status bar is outside the app tree
 - `Heading` / Windows (UIA) — gap: UIA's Header and HeaderItem are grid column headers, not document headings; the normalized set has no column-header role
-- `Heading` / Android — gap: heading semantics are not mapped yet
-- `Heading` / iOS — gap: the header token is not mapped yet
+- `Heading` / Android — gap: neither reader exposes heading semantics: the uiautomator dump has no heading attribute, and the service protocol does not carry isHeading
 <!-- END GENERATED: role-support -->


### PR DESCRIPTION
Third and last slice of the cross-backend accessibility role-parity work, after #219 (the matrix, the token tables and the column tests) and #221 (Windows and macOS). Every mapping here is backed by a probe run against real apps; nothing is written from platform documentation.

## What the probes found

Two new probe tests carry the evidence — `crates/glass-android/tests/role_probe.rs` (both Android readers) and `crates/glass-ios/tests/role_probe.rs`. Each launches the apps named in `GLASS_A11Y_PROBE_APPS`, snapshots them with the node cap lifted, and prints every native token the platform reported with the role glass maps it to, unmapped tokens first.

**Android**, across Settings (four screens), Clock, Files, Contacts, Calendar, Messages, Phone and two fixture apps: five widget classes were landing in `Other`, all of them containers — Material's card, the AppCompat linear layout (shipped under two package names, one leaf token), the view that hosts a Compose hierarchy, and a swipe-paged container. They now map to `Group`.

The on-device accessibility-service reader reported **no** unmapped class at all: Compose translates its semantic roles into framework class names, so a Compose button arrives as `android.widget.Button` and a text field as `android.widget.EditText`. No Compose-specific mapping is needed.

**iOS**, across eleven stock apps plus a fixture, with Settings navigated two levels deep: `AXGroup` appeared in nine of them and `AXHeading` in six, both landing in `Other`. They now map to `Group` and `Heading`. `AXGenericElement` stays unmapped on purpose — it carries no role, and `Other` with the token preserved is the honest answer.

## The Android root

The `uiautomator` reader wraps its dump in a `Window` root; the accessibility-service reader rooted the tree at the device's own node and classified it from its widget class, so the same screen came back `Window` through one reader and `Group` through the other and no single `role:` selector addressed both. The service asks the device for the root of the *active window*, so that node now reports `Window` — the same node, not a synthetic wrapper, because the reader's node ids are the device's own node refs and `glass_set_value` addresses the device by them. The widget class stays visible as the element's native token.

## Gaps that stay open

The probes also decided the wording of gaps that are not closed here, which now record what was seen rather than what seemed likely: an Android tab reports a plain layout class and carries its role in the view id and selected state; neither Android reader exposes heading semantics; an iOS alert exposes its buttons and text directly under the application element with no dialog container token; an iOS tab bar and its items arrive as `AXGroup`, named by the element identifier rather than the role.

## Verification

- Android, `uiautomator` reader — five apps on an emulator: no unmapped class left, probe assertion green.
- Android, accessibility-service reader — three apps: no unmapped class, and exactly one `Window` node per tree, at the root, with its widget class preserved as the token.
- iOS — six stock apps on a Simulator: `AXGroup` and `AXHeading` come back `Group` and `Heading`, probe assertion green.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` all clean locally.
