### PR TITLE
test(ios): fold the on-box fixture app into examples/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ perf.data.old
 
 # Fixture cruft
 **/__pycache__/
+
+# Built .app bundles from the iOS examples' build.sh
+/examples/*/build/

--- a/crates/glass-ios/tests/drive_integration.rs
+++ b/crates/glass-ios/tests/drive_integration.rs
@@ -9,10 +9,11 @@
 //!
 //! `#[ignore]`d so a plain `cargo test` (Linux dev host, CI) skips it: the backend needs
 //! `xcrun simctl` + `idb_companion` (macOS + Xcode only), a booted Simulator, and the
-//! GlassFixture app. Run explicitly on such a host:
+//! GlassFixture app from `examples/ios-fixture/`. Run explicitly on such a host:
 //!
 //! ```sh
-//! GLASS_IOS_APP=/path/to/GlassFixture.app \
+//! ./examples/ios-fixture/build.sh
+//! GLASS_IOS_APP="$PWD/examples/ios-fixture/build/GlassFixture.app" \
 //!   cargo test -p glass-ios --test drive_integration -- --ignored --nocapture
 //! ```
 //!
@@ -22,7 +23,8 @@
 //!
 //! The fixture exposes four accessibility elements (by `AXUniqueId`): `statusLabel` (shows
 //! READY, flips to TAPPED when the button is tapped), `tapButton`, `inputField`, and
-//! `echoLabel` (mirrors the field's text, or `(empty)`).
+//! `echoLabel` (mirrors the field's text, or `(empty)`) — see
+//! `examples/ios-fixture/README.md`.
 
 use std::time::Duration;
 
@@ -93,10 +95,10 @@ fn tap(x: i32, y: i32) -> PointerEvent {
 
 #[test]
 #[ignore = "on-box only: needs a macOS host with Xcode + idb_companion + a booted iOS \
-            Simulator, and GLASS_IOS_APP pointing at the GlassFixture .app"]
+            Simulator, and GLASS_IOS_APP pointing at the examples/ios-fixture .app"]
 fn drive_fixture_snapshot_tap_and_type_end_to_end() {
     let app = std::env::var("GLASS_IOS_APP")
-        .expect("GLASS_IOS_APP must be set to the GlassFixture .app path");
+        .expect("GLASS_IOS_APP must be set to the examples/ios-fixture GlassFixture.app path");
 
     let spec = AppSpec {
         build: None,

--- a/crates/glass-ios/tests/observe_only_integration.rs
+++ b/crates/glass-ios/tests/observe_only_integration.rs
@@ -11,7 +11,8 @@
 //! fixture `.app`. Run explicitly on a macOS host with a Simulator booted:
 //!
 //! ```sh
-//! GLASS_IOS_APP=/path/to/GlassFixture.app \
+//! ./examples/ios-fixture/build.sh
+//! GLASS_IOS_APP="$PWD/examples/ios-fixture/build/GlassFixture.app" \
 //!   cargo test -p glass-ios --test observe_only_integration -- --ignored --nocapture
 //! ```
 
@@ -32,10 +33,10 @@ fn tap(x: i32, y: i32) -> PointerEvent {
 
 #[test]
 #[ignore = "on-box only: needs a macOS host with Xcode + a booted iOS Simulator and \
-            GLASS_IOS_APP pointing at the GlassFixture .app; forces the no-companion path"]
+            GLASS_IOS_APP pointing at the examples/ios-fixture .app; forces the no-companion path"]
 fn observe_only_survives_without_a_companion() {
     let app = std::env::var("GLASS_IOS_APP")
-        .expect("GLASS_IOS_APP must be set to the GlassFixture .app path");
+        .expect("GLASS_IOS_APP must be set to the examples/ios-fixture GlassFixture.app path");
 
     // Force the no-companion path regardless of what's installed on the host: an
     // unresolvable binary makes the driver fail to start, so the backend degrades.

--- a/crates/glass-ios/tests/smoke_integration.rs
+++ b/crates/glass-ios/tests/smoke_integration.rs
@@ -9,7 +9,9 @@
 //! Simulator already booted:
 //!
 //! ```sh
-//! GLASS_IOS_APP=/path/to/YourApp.app cargo test -p glass-ios --test smoke_integration -- --ignored
+//! ./examples/ios-fixture/build.sh   # or point at any other .app
+//! GLASS_IOS_APP="$PWD/examples/ios-fixture/build/GlassFixture.app" \
+//!   cargo test -p glass-ios --test smoke_integration -- --ignored
 //! ```
 //!
 //! `GLASS_IOS_APP` must be a `.app` bundle path (not a bare bundle id) so `start_app` installs

--- a/crates/glass-ios/tests/startup_log_integration.rs
+++ b/crates/glass-ios/tests/startup_log_integration.rs
@@ -14,10 +14,14 @@
 //! known line at launch. Point it at such an app and tell it the exact line to expect:
 //!
 //! ```sh
-//! GLASS_IOS_APP=/path/to/StartupLogger.app \
-//! GLASS_IOS_STARTUP_MARKER='GLASS_IOS_STARTUP_MARKER' \
+//! ./examples/ios-fixture/build.sh
+//! GLASS_IOS_APP="$PWD/examples/ios-fixture/build/GlassFixture.app" \
+//! GLASS_IOS_STARTUP_MARKER=GLASS_FIXTURE_LAUNCHED \
 //!   cargo test -p glass-ios --test startup_log_integration -- --ignored --nocapture
 //! ```
+//!
+//! `examples/ios-fixture/` emits its marker from `App.init`, which is the earliest point that
+//! matters here; any other app works as long as it logs before its first frame.
 //!
 //! The marker MUST be emitted at the app's earliest launch point (not a delayed `onAppear`),
 //! so it exercises the race the fix closes. `GLASS_IOS_UDID` / `GLASS_IOS_DEVICE` select the

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,3 +6,5 @@ Small apps for trying glass's build → see → interact → debug loop. Each li
   [project README's quickstart](../README.md#try-it-in-60-seconds).
 - [`ios-greeter/`](ios-greeter/) — a tiny SwiftUI app driven in the iOS Simulator. See
   [Drive a native iOS app](../docs/how-to/drive-an-ios-app.md).
+- [`ios-fixture/`](ios-fixture/) — the SwiftUI app the `glass-ios` on-box tests drive: four
+  elements with stable accessibility identifiers, plus a launch-time log marker.

--- a/examples/ios-fixture/GlassFixture.swift
+++ b/examples/ios-fixture/GlassFixture.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+import os
+
+private let log = Logger(subsystem: "tech.fixedwidth.glassfixture", category: "fixture")
+
+/// The marker the app emits at its earliest launch point. `startup_log_integration`
+/// asserts this reaches `drain_logs()`, which only holds if the backend attaches the
+/// unified-log stream *before* `simctl launch` — see that test for the race it covers.
+private let startupMarker = "GLASS_FIXTURE_LAUNCHED"
+
+@main
+struct GlassFixtureApp: App {
+    init() {
+        // At `App.init`, not `onAppear`: the line must be emitted before the first frame.
+        log.notice("\(startupMarker, privacy: .public)")
+        print(startupMarker)
+    }
+
+    var body: some Scene {
+        WindowGroup { ContentView() }
+    }
+}
+
+/// Four elements with stable accessibility identifiers, each verifiable from a snapshot
+/// alone: `statusLabel` (READY, flips to TAPPED), `tapButton`, `inputField`, and
+/// `echoLabel` (mirrors the field, or `(empty)`). glass surfaces an iOS element's
+/// identifier as its name, so the identifier is how a test addresses each one.
+struct ContentView: View {
+    @State private var tapped = false
+    @State private var text = ""
+
+    var body: some View {
+        VStack(spacing: 40) {
+            Text(tapped ? "TAPPED" : "READY")
+                .font(.system(size: 44, weight: .bold))
+                .foregroundStyle(tapped ? .green : .primary)
+                .accessibilityIdentifier("statusLabel")
+
+            Button("Tap Me") { tapped.toggle() }
+                .font(.title)
+                .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier("tapButton")
+
+            TextField("type here", text: $text)
+                .textFieldStyle(.roundedBorder)
+                .font(.title2)
+                .padding(.horizontal, 40)
+                .accessibilityIdentifier("inputField")
+
+            Text(text.isEmpty ? "(empty)" : text)
+                .font(.title3)
+                .foregroundStyle(.secondary)
+                .accessibilityIdentifier("echoLabel")
+        }
+        .padding()
+    }
+}

--- a/examples/ios-fixture/Info.plist
+++ b/examples/ios-fixture/Info.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>GlassFixture</string>
+    <key>CFBundleIdentifier</key>
+    <string>tech.fixedwidth.glassfixture</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>GlassFixture</string>
+    <key>CFBundleDisplayName</key>
+    <string>Glass Fixture</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>MinimumOSVersion</key>
+    <string>16.0</string>
+    <key>UIDeviceFamily</key>
+    <array>
+        <integer>1</integer>
+    </array>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+    </array>
+</dict>
+</plist>

--- a/examples/ios-fixture/README.md
+++ b/examples/ios-fixture/README.md
@@ -1,0 +1,39 @@
+# ios-fixture
+
+The app the `glass-ios` on-box tests drive. Four SwiftUI elements, each verifiable from an
+accessibility snapshot alone:
+
+| Identifier | What it is | What it proves |
+|---|---|---|
+| `statusLabel` | Shows `READY`, flips to `TAPPED` | A tap landed on `tapButton`, not merely somewhere |
+| `tapButton` | A button | The point→pixel scale chain maps a snapshot's bounds to a real touch |
+| `inputField` | A text field | Typed text (raw keys, and the `set_value` clear-then-type) reaches the field |
+| `echoLabel` | Mirrors the field, or `(empty)` | The field's value changed, read back from a fresh snapshot |
+
+It also prints `GLASS_FIXTURE_LAUNCHED` from `App.init` — before the first frame — which is
+what the launch-time log capture test asserts on.
+
+## Build
+
+Requires the full Xcode and an iOS Simulator runtime (macOS only):
+
+```bash
+./build.sh   # → build/GlassFixture.app
+```
+
+## Run the on-box tests against it
+
+With a Simulator booted and `idb_companion` on `PATH`:
+
+```bash
+export GLASS_IOS_APP="$PWD/examples/ios-fixture/build/GlassFixture.app"
+export GLASS_IOS_STARTUP_MARKER=GLASS_FIXTURE_LAUNCHED
+cargo test -p glass-ios -- --ignored --test-threads=1
+```
+
+`GLASS_IOS_UDID` / `GLASS_IOS_DEVICE` / `GLASS_IDB_COMPANION` select the Simulator and the
+companion binary the same way they do for `glass-mcp`; see
+[Set up the iOS backend](../../docs/how-to/setup-ios.md).
+
+For driving an app by hand instead, start with [`ios-greeter/`](../ios-greeter/) and
+[Drive a native iOS app](../../docs/how-to/drive-an-ios-app.md).

--- a/examples/ios-fixture/build.sh
+++ b/examples/ios-fixture/build.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Build the GlassFixture SwiftUI app into a Simulator .app bundle.
+# Requires the full Xcode + an iOS Simulator runtime. Used by the glass-ios on-box tests
+# (see crates/glass-ios/tests/); see also docs/how-to/drive-an-ios-app.md.
+set -euo pipefail
+here="$(cd "$(dirname "$0")" && pwd)"
+app="$here/build/GlassFixture.app"
+sdk="$(xcrun --sdk iphonesimulator --show-sdk-path)"
+
+rm -rf "$app"
+mkdir -p "$app"
+xcrun --sdk iphonesimulator swiftc \
+  -target arm64-apple-ios16.0-simulator \
+  -sdk "$sdk" \
+  -parse-as-library \
+  -o "$app/GlassFixture" \
+  "$here/GlassFixture.swift"
+cp "$here/Info.plist" "$app/Info.plist"
+echo "built: $app"


### PR DESCRIPTION
Follow-up to #224. The `glass-ios` on-box tests drive a `GlassFixture.app` that existed only on the machine that first built it: the tests named it, nothing in the repo could produce it, and `startup_log_integration` also needed a `GLASS_IOS_STARTUP_MARKER` value that was written down nowhere.

`examples/ios-fixture/` now carries the SwiftUI source, `Info.plist`, a `build.sh` mirroring `ios-greeter/`, and a README that says what each element proves:

| Identifier | What it proves |
|---|---|
| `statusLabel` | READY→TAPPED — a tap landed on the button, not merely somewhere |
| `tapButton` | The point→pixel scale chain maps snapshot bounds to a real touch |
| `inputField` | Typed text (raw keys and `set_value` clear-then-type) reaches the field |
| `echoLabel` | The field's value changed, read back from a fresh snapshot |

The launch marker moved from `onAppear` to `App.init`, so it is emitted before the first frame — the race `startup_log_integration` exists to cover. Each test's module docs now name the fixture and give the exact command; `examples/*/build/` is gitignored.

## Verification

Built from a clean checkout on a Mac with Xcode and a booted Simulator, then all five on-box tests run against it — `drive_fixture_snapshot_tap_and_type_end_to_end`, `observe_only_survives_without_a_companion`, `role_histogram_probe`, `smoke_launch_capture_clipboard_stop`, `launch_time_log_line_is_captured`: 5 passed, 0 failed. Linux `fmt` / `clippy -D warnings` / `cargo test -p glass-ios` green (the on-box tests stay `#[ignore]`d).