### PR TITLE
a11y: decide the role matrix's unreachable cells by observation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,8 @@ perf.data.old
 # Fixture cruft
 **/__pycache__/
 
-# Built .app bundles from the iOS examples' build.sh
+# Build output from the examples' build.sh — .app bundles (iOS) and the APK (Android)
 /examples/*/build/
+# The Android role fixture's throwaway signing key, generated on first build. It lives outside
+# build/ so rebuilds keep signing with the same key; see that example's build.sh.
+/examples/android-role-fixture/.signing-key.jks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ internal refactors, CI, or test-only changes.
   as `ToggleButton`. `docs/reference/a11y-roles.md` lists what each platform can produce.
 
 ### Changed
+- Every cell of [docs/reference/a11y-roles.md](docs/reference/a11y-roles.md) that is not `yes` now
+  names the native token behind it as its own clause — `n/a (reports AXStaticText instead)`,
+  `gap (AXPopUpButton arrives unmapped)` — instead of leaving it buried in prose. That is the fact
+  an agent holding an `Other(...)` in a snapshot is looking for, and it is data rather than text:
+  each backend's tests resolve it through that backend's own map, and on Windows, where UIA names
+  every documented control type, an invented one fails the build.
 - [docs/reference/a11y-roles.md](docs/reference/a11y-roles.md) now splits a role glass could still
   reach from one only a platform change could, and decides which by putting the control on screen
   and reading the tree back rather than by what a platform's API reference implies. Fourteen cells

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,17 +36,17 @@ internal refactors, CI, or test-only changes.
   as `ToggleButton`. `docs/reference/a11y-roles.md` lists what each platform can produce.
 
 ### Changed
-- [docs/reference/a11y-roles.md](docs/reference/a11y-roles.md) now separates a role no backend
-  vocabulary can carry from one glass has not mapped yet by putting the control on screen and
-  reading the tree back, rather than by what a platform's API reference implies. Fifteen cells
-  that read "not mapped yet" turned out to be unreachable and now say so with what the control
-  actually reports: an iOS stepper arrives as two buttons, a progress view as a generic element, a
-  picker as a slider, an alert and a pull-down menu as loose buttons, a table view and its rows as
-  a group of static text; an Android toolbar arrives as a plain `ViewGroup` and a popup menu as a
-  `ListView`. The cells whose token does arrive now name it — Android's `TabWidget`, `TableLayout`
-  and `NumberPicker` — as do the ones whose semantics sit in a field neither Android reader
-  carries (`CollectionItemInfo`). No role mapping changed; this is what the page claims, not what
-  glass produces.
+- [docs/reference/a11y-roles.md](docs/reference/a11y-roles.md) now splits a role glass could still
+  reach from one only a platform change could, and decides which by putting the control on screen
+  and reading the tree back rather than by what a platform's API reference implies. Fourteen cells
+  marked `gap` turned out to be unreachable and now say so with what the control actually reports:
+  an iOS stepper arrives as two buttons, a progress view as a generic element, an alert and an
+  action sheet as loose buttons, a table view and its rows as a group of static text; an Android
+  toolbar arrives as a plain `ViewGroup` and a popup menu as a `ListView`. The cells that stay
+  `gap` now name what is there and unread — Android's `TabWidget`, `TableLayout` and
+  `NumberPicker`, iOS's `AXPopUpButton` for a menu-style picker, and the `CollectionItemInfo` and
+  `isHeading` fields neither Android reader carries. Each column also records when it was last
+  read. No role mapping changed; this is what the page claims, not what glass produces.
 - Three kinds of element now report a different role than before, so a `role:` filter that used to
   match them no longer does. On Windows, a button that can be toggled (a formatting bar's Bold or
   Italic) reports `ToggleButton` instead of `Button`; on macOS, a row inside an outline view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ internal refactors, CI, or test-only changes.
   with guidance to use a `settle` action or the terminal `then` observe instead.
 - [docs/reference/a11y-roles.md](docs/reference/a11y-roles.md) documents which accessibility roles
   each platform backend can produce, and why a role is unavailable where it is.
+- Two example apps hold the controls that page's cells are decided from — one screen of stock
+  `android.widget` controls in [`examples/android-role-fixture/`](examples/android-role-fixture/)
+  (builds without Gradle) and the UIKit and SwiftUI equivalents in
+  [`examples/ios-role-fixture/`](examples/ios-role-fixture/) — so anyone can read the same trees
+  back.
 - More elements report a real role instead of `Other`: on Windows, documents; on macOS, outlines
   and their rows, split views and their dividers, scroll areas, headings, and menu buttons; on
   Android, the AndroidX card container, the AppCompat linear layout, the view that hosts a Compose
@@ -31,6 +36,17 @@ internal refactors, CI, or test-only changes.
   as `ToggleButton`. `docs/reference/a11y-roles.md` lists what each platform can produce.
 
 ### Changed
+- [docs/reference/a11y-roles.md](docs/reference/a11y-roles.md) now separates a role no backend
+  vocabulary can carry from one glass has not mapped yet by putting the control on screen and
+  reading the tree back, rather than by what a platform's API reference implies. Fifteen cells
+  that read "not mapped yet" turned out to be unreachable and now say so with what the control
+  actually reports: an iOS stepper arrives as two buttons, a progress view as a generic element, a
+  picker as a slider, an alert and a pull-down menu as loose buttons, a table view and its rows as
+  a group of static text; an Android toolbar arrives as a plain `ViewGroup` and a popup menu as a
+  `ListView`. The cells whose token does arrive now name it — Android's `TabWidget`, `TableLayout`
+  and `NumberPicker` — as do the ones whose semantics sit in a field neither Android reader
+  carries (`CollectionItemInfo`). No role mapping changed; this is what the page claims, not what
+  glass produces.
 - Three kinds of element now report a different role than before, so a `role:` filter that used to
   match them no longer does. On Windows, a button that can be toggled (a formatting bar's Bold or
   Italic) reports `ToggleButton` instead of `Button`; on macOS, a row inside an outline view

--- a/crates/glass-a11y-linux/src/mapping.rs
+++ b/crates/glass-a11y-linux/src/mapping.rs
@@ -182,7 +182,7 @@ mod tests {
                         "{role:?} declared Mapped but no AT-SPI sample maps to it"
                     )
                 }
-                RoleSupport::NotApplicable(_) | RoleSupport::Gap(_) => assert!(
+                RoleSupport::NotApplicable { .. } | RoleSupport::Gap { .. } => assert!(
                     !mapped,
                     "{role:?} is produced by an AT-SPI role but the matrix does not declare it"
                 ),

--- a/crates/glass-a11y-macos/src/mapping.rs
+++ b/crates/glass-a11y-macos/src/mapping.rs
@@ -234,10 +234,24 @@ mod tests {
                 RoleSupport::Mapped => {
                     assert!(mapped, "{role:?} declared Mapped but no AX role maps to it")
                 }
-                RoleSupport::NotApplicable(_) | RoleSupport::Gap(_) => assert!(
-                    !mapped,
-                    "{role:?} is produced by an AX role but the matrix does not declare it"
-                ),
+                cell => {
+                    assert!(
+                        !mapped,
+                        "{role:?} is produced by an AX role but the matrix does not declare it"
+                    );
+                    // The named AX role must not resolve to the very role the cell says is out
+                    // of reach. No subrole is passed: a cell naming a bare role is claiming that
+                    // role's own mapping. Largely a second line behind the `!mapped` assertion
+                    // above; a misspelt AX role resolves to `Other` and passes, which only an
+                    // on-box read catches.
+                    if let Some(token) = cell.named_token() {
+                        assert_ne!(
+                            map_role(token, None),
+                            role,
+                            "{role:?} is declared out of reach naming {token}, which maps to it"
+                        );
+                    }
+                }
             }
         }
     }

--- a/crates/glass-a11y-windows/src/mapping.rs
+++ b/crates/glass-a11y-windows/src/mapping.rs
@@ -350,10 +350,29 @@ mod tests {
                         "{role:?} declared Mapped but no control type maps to it"
                     )
                 }
-                RoleSupport::NotApplicable(_) | RoleSupport::Gap(_) => assert!(
-                    !mapped,
-                    "{role:?} is produced by a control type but the matrix does not declare it"
-                ),
+                cell => {
+                    assert!(
+                        !mapped,
+                        "{role:?} is produced by a control type but the matrix does not declare it"
+                    );
+                    // Windows is the one column where a named token is checked for existence,
+                    // not just for what it maps to: `CONTROL_TYPES` carries every documented UIA
+                    // control type by name, so a typo or an invented name fails here rather than
+                    // resolving quietly to `Other` the way a bad AX role or widget class would.
+                    if let Some(token) = cell.named_token() {
+                        let named = CONTROL_TYPES
+                            .iter()
+                            .find(|(_, name, _)| *name == token)
+                            .unwrap_or_else(|| {
+                                panic!("{role:?} names {token}, not a UIA control type")
+                            });
+                        assert_ne!(
+                            named.2,
+                            Some(role),
+                            "{role:?} is declared out of reach naming {token}, which maps to it"
+                        );
+                    }
+                }
             }
         }
     }

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -501,10 +501,25 @@ mod tests {
                 RoleSupport::Mapped => {
                     assert!(mapped, "{role:?} declared Mapped but no class maps to it")
                 }
-                RoleSupport::NotApplicable(_) | RoleSupport::Gap(_) => assert!(
-                    !mapped,
-                    "{role:?} is produced by a class but the matrix does not declare it"
-                ),
+                cell => {
+                    assert!(
+                        !mapped,
+                        "{role:?} is produced by a class but the matrix does not declare it"
+                    );
+                    // The named class must not resolve to the very role the cell says is out
+                    // of reach. Largely a second line behind the `!mapped` assertion above —
+                    // if the class produced the role, that one fires too — but it pins the
+                    // token itself, so a cell rewritten to name a different class is checked
+                    // against the map rather than against nothing. A misspelt class resolves
+                    // to `Other` and passes: only an on-box read catches that.
+                    if let Some(token) = cell.named_token() {
+                        assert_ne!(
+                            class_to_role(token),
+                            role,
+                            "{role:?} is declared out of reach naming {token}, which maps to it"
+                        );
+                    }
+                }
             }
         }
     }

--- a/crates/glass-core/src/role_support.rs
+++ b/crates/glass-core/src/role_support.rs
@@ -84,14 +84,55 @@ pub enum RoleSupport {
     /// At least one native token maps to this role.
     Mapped,
     /// Closing this would take a platform change, not a glass change: either the platform has
-    /// no such control, or it draws one the accessibility layer never marks. The reason says
-    /// which, and what the control was observed to report instead.
-    NotApplicable(&'static str),
+    /// no such control, or it draws one the accessibility layer never marks.
+    NotApplicable {
+        /// The native token the control was observed to report in this role's place, in the
+        /// form that backend's own resolver accepts. `None` where nothing stands in for it —
+        /// the platform has no such control (no menu bar on iOS), or the concept sits outside
+        /// what glass walks at all (the system status bar).
+        instead: Option<&'static str>,
+        /// What was read, and why it forecloses the role.
+        why: &'static str,
+    },
     /// Closing this is glass's own work: the platform already carries the role somewhere glass
     /// reads or could read — a token that arrives unmapped, a documented field the reader
-    /// ignores, a protocol its own companion could send. The reason names what is there and
-    /// unread.
-    Gap(&'static str),
+    /// ignores, a protocol its own companion could send.
+    Gap {
+        /// The native token that arrives carrying this role's meaning and is not mapped to it,
+        /// in the form that backend's own resolver accepts. `None` where the carrier is not a
+        /// token at all but a field or property the reader skips — UIA's `HeadingLevel`,
+        /// `AccessibilityNodeInfo`'s `CollectionItemInfo` — which `why` then names.
+        unmapped: Option<&'static str>,
+        /// What is there and unread, and what it would take to reach it.
+        why: &'static str,
+    },
+}
+
+impl RoleSupport {
+    /// The native token this cell names, whichever variant it is — what the control reports
+    /// instead, or what arrives unmapped. `None` for [`RoleSupport::Mapped`] and for cells whose
+    /// carrier is a field rather than a token.
+    ///
+    /// This is what makes a cell checkable: each backend's column test resolves the token through
+    /// its own map and asserts it does NOT produce this role, so a cell claiming a role is out of
+    /// reach while naming a token that maps straight to it fails the build.
+    pub fn named_token(self) -> Option<&'static str> {
+        match self {
+            RoleSupport::Mapped => None,
+            RoleSupport::NotApplicable { instead: token, .. }
+            | RoleSupport::Gap {
+                unmapped: token, ..
+            } => token,
+        }
+    }
+
+    /// The reason text, or `None` for [`RoleSupport::Mapped`].
+    pub fn why(self) -> Option<&'static str> {
+        match self {
+            RoleSupport::Mapped => None,
+            RoleSupport::NotApplicable { why, .. } | RoleSupport::Gap { why, .. } => Some(why),
+        }
+    }
 }
 
 /// Role coverage per backend. Cells are ordered as [`AxBackend::ALL`], and the row type is sized
@@ -104,9 +145,18 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
             R::Application,
             [
                 Mapped,
-                NotApplicable("UIA has no application control type; the app root is a Window"),
-                Gap("AXApplication is the app element but is not mapped yet"),
-                NotApplicable("Android exposes windows, not an application element"),
+                NotApplicable {
+                    instead: Some("Window"),
+                    why: "UIA has no application control type; the app root is a Window",
+                },
+                Gap {
+                    unmapped: Some("AXApplication"),
+                    why: "AXApplication is the app element but is not mapped yet",
+                },
+                NotApplicable {
+                    instead: None,
+                    why: "Android exposes windows, not an application element",
+                },
                 Mapped,
             ],
         ),
@@ -115,20 +165,26 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
             R::Dialog,
             [
                 Mapped,
-                Gap(
-                    "UIA marks a dialog with the IsDialog property on a Window; the reader does \
+                Gap {
+                    unmapped: None,
+                    why: "UIA marks a dialog with the IsDialog property on a Window; the reader does \
                      not read it",
-                ),
-                Gap("AXSheet, AXPopover and AXDrawer are not mapped yet"),
-                NotApplicable(
-                    "a framework AlertDialog's panels report FrameLayout and LinearLayout under \
+                },
+                Gap {
+                    unmapped: Some("AXSheet"),
+                    why: "AXSheet, AXPopover and AXDrawer are not mapped yet",
+                },
+                NotApplicable {
+                    instead: Some("android.widget.FrameLayout"),
+                    why: "a framework AlertDialog's panels report FrameLayout and LinearLayout under \
                      android:id/parentPanel, and AccessibilityWindowInfo's window types carry no \
                      dialog kind for a reader to fall back on",
-                ),
-                NotApplicable(
-                    "an alert and an action sheet each expose their title, message and buttons \
+                },
+                NotApplicable {
+                    instead: None,
+                    why: "an alert and an action sheet each expose their title, message and buttons \
                      directly under the application element, with no container token between",
-                ),
+                },
             ],
         ),
         (R::Group, [Mapped, Mapped, Mapped, Mapped, Mapped]),
@@ -138,11 +194,12 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
             [
                 Mapped,
                 Mapped,
-                Gap(
-                    "AppKit reports a switch as AXCheckBox with an AXSwitch or AXToggle \
+                Gap {
+                    unmapped: Some("AXCheckBox"),
+                    why: "AppKit reports a switch as AXCheckBox with an AXSwitch or AXToggle \
                      subrole; AXCheckBox is outside the reader's subrole gate, and no probed \
                      app emitted either subrole",
-                ),
+                },
                 Mapped,
                 Mapped,
             ],
@@ -154,10 +211,11 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Mapped,
-                NotApplicable(
-                    "UIKit has no radio control; a UISegmentedControl — the nearest equivalent \
+                NotApplicable {
+                    instead: Some("AXTabGroup"),
+                    why: "UIKit has no radio control; a UISegmentedControl — the nearest equivalent \
                      — reports one AXTabGroup with no per-segment element",
-                ),
+                },
             ],
         ),
         (R::CheckBox, [Mapped, Mapped, Mapped, Mapped, Mapped]),
@@ -167,8 +225,14 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Mapped,
-                NotApplicable("Android apps have no menu bar"),
-                NotApplicable("iOS apps have no menu bar"),
+                NotApplicable {
+                    instead: None,
+                    why: "Android apps have no menu bar",
+                },
+                NotApplicable {
+                    instead: None,
+                    why: "iOS apps have no menu bar",
+                },
             ],
         ),
         (
@@ -177,14 +241,16 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Mapped,
-                NotApplicable(
-                    "a popup menu reports android.widget.ListView; no menu token appears \
+                NotApplicable {
+                    instead: Some("android.widget.ListView"),
+                    why: "a popup menu reports android.widget.ListView; no menu token appears \
                      anywhere in the tree it opens",
-                ),
-                NotApplicable(
-                    "a button's pull-down UIMenu opens as an AXGroup of AXButtons alongside a \
+                },
+                NotApplicable {
+                    instead: Some("AXGroup"),
+                    why: "a button's pull-down UIMenu opens as an AXGroup of AXButtons alongside a \
                      Dismiss context menu button; no menu token appears",
-                ),
+                },
             ],
         ),
         (
@@ -193,11 +259,15 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Mapped,
-                NotApplicable(
-                    "a menu entry reports its item view's layout class — a LinearLayout or \
+                NotApplicable {
+                    instead: Some("android.widget.LinearLayout"),
+                    why: "a menu entry reports its item view's layout class — a LinearLayout or \
                      RelativeLayout holding a TextView title",
-                ),
-                NotApplicable("a menu entry reports AXButton, the same token as any other button"),
+                },
+                NotApplicable {
+                    instead: Some("AXButton"),
+                    why: "a menu entry reports AXButton, the same token as any other button",
+                },
             ],
         ),
         (R::Label, [Mapped, Mapped, Mapped, Mapped, Mapped]),
@@ -208,7 +278,10 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Mapped,
-                NotApplicable("Android uses one editable class for single- and multi-line text"),
+                NotApplicable {
+                    instead: Some("android.widget.EditText"),
+                    why: "Android uses one editable class for single- and multi-line text",
+                },
                 Mapped,
             ],
         ),
@@ -219,11 +292,12 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Mapped,
-                Gap(
-                    "a menu-style SwiftUI Picker reports AXPopUpButton, which is not mapped yet; \
+                Gap {
+                    unmapped: Some("AXPopUpButton"),
+                    why: "a menu-style SwiftUI Picker reports AXPopUpButton, which is not mapped yet; \
                      the inline style reports a heading with buttons, and a UIPickerView reports \
                      AXSlider",
-                ),
+                },
             ],
         ),
         (
@@ -233,10 +307,11 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Mapped,
-                NotApplicable(
-                    "a UITableView and a SwiftUI List both report AXGroup, and their rows report \
+                NotApplicable {
+                    instead: Some("AXGroup"),
+                    why: "a UITableView and a SwiftUI List both report AXGroup, and their rows report \
                      AXStaticText; no list token appears",
-                ),
+                },
             ],
         ),
         (
@@ -245,16 +320,18 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Mapped,
-                Gap(
-                    "AccessibilityNodeInfo's CollectionItemInfo marks a list child, and neither \
+                Gap {
+                    unmapped: None,
+                    why: "AccessibilityNodeInfo's CollectionItemInfo marks a list child, and neither \
                      reader carries it: the uiautomator dump has no such attribute and the \
                      service reader parses only class, text, description and bounds. The child's \
                      own widget class is all that arrives",
-                ),
-                NotApplicable(
-                    "table and collection rows report AXStaticText, including a cell explicitly \
+                },
+                NotApplicable {
+                    instead: Some("AXStaticText"),
+                    why: "table and collection rows report AXStaticText, including a cell explicitly \
                      exposed as its own accessibility element",
-                ),
+                },
             ],
         ),
         (
@@ -262,34 +339,41 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
             [
                 Mapped,
                 Mapped,
-                Gap("mac lists report AXOutline rather than AXTable; AXOutline maps to Tree"),
-                Gap(
-                    "android.widget.TableLayout and TableRow both arrive as tokens: TableLayout \
+                Gap {
+                    unmapped: None,
+                    why: "mac lists report AXOutline rather than AXTable; AXOutline maps to Tree",
+                },
+                Gap {
+                    unmapped: Some("android.widget.TableLayout"),
+                    why: "android.widget.TableLayout and TableRow both arrive as tokens: TableLayout \
                      folds into Group via the container rule, TableRow lands in Other, and \
                      GridView maps to List",
-                ),
-                NotApplicable(
-                    "a table view reports AXGroup like any other container; no table token \
+                },
+                NotApplicable {
+                    instead: Some("AXGroup"),
+                    why: "a table view reports AXGroup like any other container; no table token \
                      appears",
-                ),
+                },
             ],
         ),
         (
             R::Cell,
             [
                 Mapped,
-                Gap(
-                    "UIA's DataItem control type would carry this and is not mapped: the data \
+                Gap {
+                    unmapped: Some("DataItem"),
+                    why: "UIA's DataItem control type would carry this and is not mapped: the data \
                      grids probed expose their rows as TreeItem instead, though Edge does report \
                      an HTML table's header cells as DataItem",
-                ),
+                },
                 Mapped,
-                Gap(
-                    "CollectionItemInfo holds the row and column index, and neither reader \
+                Gap {
+                    unmapped: None,
+                    why: "CollectionItemInfo holds the row and column index, and neither reader \
                      carries it: the uiautomator dump has no such attribute and the service \
                      reader parses only class, text, description and bounds. No cell class \
                      exists to fall back on — a cell is whatever view the app put in the row",
-                ),
+                },
                 Mapped,
             ],
         ),
@@ -299,8 +383,14 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Mapped,
-                NotApplicable("Android has no tree widget"),
-                NotApplicable("UIKit has no outline view"),
+                NotApplicable {
+                    instead: None,
+                    why: "Android has no tree widget",
+                },
+                NotApplicable {
+                    instead: None,
+                    why: "UIKit has no outline view",
+                },
             ],
         ),
         (
@@ -309,8 +399,14 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Mapped,
-                NotApplicable("Android has no tree widget"),
-                NotApplicable("UIKit has no outline view"),
+                NotApplicable {
+                    instead: None,
+                    why: "Android has no tree widget",
+                },
+                NotApplicable {
+                    instead: None,
+                    why: "UIKit has no outline view",
+                },
             ],
         ),
         (
@@ -319,11 +415,12 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Mapped,
-                Gap(
-                    "android.widget.TabWidget and TabHost do arrive as tokens and are not mapped \
+                Gap {
+                    unmapped: Some("android.widget.TabWidget"),
+                    why: "android.widget.TabWidget and TabHost do arrive as tokens and are not mapped \
                      yet; the Material tab strips seen in stock apps report a plain layout class \
                      instead, naming their tabs only by content description",
-                ),
+                },
                 Mapped,
             ],
         ),
@@ -332,20 +429,23 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
             [
                 Mapped,
                 Mapped,
-                Gap(
-                    "AppKit reports tab items as AXRadioButton inside the tab group; the \
+                Gap {
+                    unmapped: Some("AXRadioButton"),
+                    why: "AppKit reports tab items as AXRadioButton inside the tab group; the \
                      containing role is not used to disambiguate yet",
-                ),
-                Gap(
-                    "a framework tab arrives as a LinearLayout with selected=true under a \
+                },
+                Gap {
+                    unmapped: None,
+                    why: "a framework tab arrives as a LinearLayout with selected=true under a \
                      TabWidget parent, which together identify it; the class name alone does \
                      not, and a Material tab strip carries the role in the view id instead",
-                ),
-                NotApplicable(
-                    "a tab bar reports AXGroup and no per-item element appears in idb's \
+                },
+                NotApplicable {
+                    instead: Some("AXGroup"),
+                    why: "a tab bar reports AXGroup and no per-item element appears in idb's \
                      describe; a segmented control reports one AXTabGroup, also with no \
                      per-segment element",
-                ),
+                },
             ],
         ),
         (
@@ -354,8 +454,14 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Mapped,
-                NotApplicable("Android scrollbars are drawn, not exposed as nodes"),
-                NotApplicable("UIKit scroll indicators are not accessibility elements"),
+                NotApplicable {
+                    instead: None,
+                    why: "Android scrollbars are drawn, not exposed as nodes",
+                },
+                NotApplicable {
+                    instead: None,
+                    why: "UIKit scroll indicators are not accessibility elements",
+                },
             ],
         ),
         (R::Slider, [Mapped, Mapped, Mapped, Mapped, Mapped]),
@@ -364,12 +470,19 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
             [
                 Mapped,
                 Mapped,
-                Gap("AXIncrementor is not mapped yet"),
-                Gap("android.widget.NumberPicker does arrive as a token and is not mapped yet"),
-                NotApplicable(
-                    "a UIStepper decomposes into two AXButtons labelled Decrement and \
+                Gap {
+                    unmapped: Some("AXIncrementor"),
+                    why: "AXIncrementor is not mapped yet",
+                },
+                Gap {
+                    unmapped: Some("android.widget.NumberPicker"),
+                    why: "android.widget.NumberPicker does arrive as a token and is not mapped yet",
+                },
+                NotApplicable {
+                    instead: Some("AXButton"),
+                    why: "a UIStepper decomposes into two AXButtons labelled Decrement and \
                      Increment; no stepper token appears",
-                ),
+                },
             ],
         ),
         (
@@ -379,10 +492,11 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Mapped,
-                NotApplicable(
-                    "a UIProgressView reports AXGenericElement carrying its percentage as the \
+                NotApplicable {
+                    instead: Some("AXGenericElement"),
+                    why: "a UIProgressView reports AXGenericElement carrying its percentage as the \
                      value; no progress token appears",
-                ),
+                },
             ],
         ),
         (R::Image, [Mapped, Mapped, Mapped, Mapped, Mapped]),
@@ -392,7 +506,10 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Mapped,
-                NotApplicable("Android links are spans inside a text view, not separate nodes"),
+                NotApplicable {
+                    instead: None,
+                    why: "Android links are spans inside a text view, not separate nodes",
+                },
                 Mapped,
             ],
         ),
@@ -402,8 +519,14 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Mapped,
-                NotApplicable("Android dividers are drawn, not exposed as nodes"),
-                NotApplicable("UIKit exposes no separator element"),
+                NotApplicable {
+                    instead: None,
+                    why: "Android dividers are drawn, not exposed as nodes",
+                },
+                NotApplicable {
+                    instead: None,
+                    why: "UIKit exposes no separator element",
+                },
             ],
         ),
         (
@@ -412,12 +535,13 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Mapped,
-                NotApplicable(
-                    "android.widget.Toolbar was watched to report android.view.ViewGroup — a \
+                NotApplicable {
+                    instead: Some("android.view.ViewGroup"),
+                    why: "android.widget.Toolbar was watched to report android.view.ViewGroup — a \
                      subclass inherits the accessibility class name of the framework class it \
                      extends, and the AppCompat and Material toolbars override neither, so all \
                      three arrive as ViewGroup",
-                ),
+                },
                 Mapped,
             ],
         ),
@@ -426,27 +550,38 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
             [
                 Mapped,
                 Mapped,
-                NotApplicable("AppKit exposes status items as menu-bar items"),
-                NotApplicable("the system status bar is outside the app tree"),
-                NotApplicable("the system status bar is outside the app tree"),
+                NotApplicable {
+                    instead: None,
+                    why: "AppKit exposes status items as menu-bar items",
+                },
+                NotApplicable {
+                    instead: None,
+                    why: "the system status bar is outside the app tree",
+                },
+                NotApplicable {
+                    instead: None,
+                    why: "the system status bar is outside the app tree",
+                },
             ],
         ),
         (
             R::Heading,
             [
                 Mapped,
-                Gap(
-                    "UIA marks a heading with the HeadingLevel property — an h1 arrives as Text \
+                Gap {
+                    unmapped: None,
+                    why: "UIA marks a heading with the HeadingLevel property — an h1 arrives as Text \
                      carrying level 80051 — and the reader maps by control type alone, so it \
                      never sees it. Header and HeaderItem are a grid's column headers, a \
                      different concept the normalized set has no role for",
-                ),
+                },
                 Mapped,
-                Gap(
-                    "AccessibilityNodeInfo's isHeading marks a heading, and neither reader \
+                Gap {
+                    unmapped: None,
+                    why: "AccessibilityNodeInfo's isHeading marks a heading, and neither reader \
                      carries it: the uiautomator dump has no such attribute and the service \
                      reader parses only class, text, description and bounds",
-                ),
+                },
                 Mapped,
             ],
         ),
@@ -488,8 +623,8 @@ pub fn render_markdown() -> String {
         for cell in cells {
             let mark = match cell {
                 RoleSupport::Mapped => "yes",
-                RoleSupport::NotApplicable(_) => "n/a",
-                RoleSupport::Gap(_) => "gap",
+                RoleSupport::NotApplicable { .. } => "n/a",
+                RoleSupport::Gap { .. } => "gap",
             };
             let _ = write!(out, " {mark} |");
         }
@@ -499,14 +634,23 @@ pub fn render_markdown() -> String {
     out.push_str("\n### Why a cell is not `yes`\n\n");
     for (role, cells) in ROLE_SUPPORT {
         for (i, cell) in cells.iter().enumerate() {
-            let (kind, reason) = match cell {
+            // The token, where a cell names one, is rendered as its own clause rather than left
+            // buried in the prose: it is the fact a reader with an `Other(...)` in front of them
+            // is looking for, and the fact each backend's column test checks.
+            let (kind, token) = match cell {
                 RoleSupport::Mapped => continue,
-                RoleSupport::NotApplicable(r) => ("n/a", *r),
-                RoleSupport::Gap(r) => ("gap", *r),
+                RoleSupport::NotApplicable { instead, .. } => {
+                    ("n/a", instead.map(|t| format!("reports `{t}` instead")))
+                }
+                RoleSupport::Gap { unmapped, .. } => {
+                    ("gap", unmapped.map(|t| format!("`{t}` arrives unmapped")))
+                }
             };
+            let reason = cell.why().expect("a non-Mapped cell has a reason");
+            let token = token.map(|t| format!(" ({t})")).unwrap_or_default();
             let _ = writeln!(
                 out,
-                "- `{role:?}` / {} — {kind}: {reason}",
+                "- `{role:?}` / {} — {kind}{token}: {reason}",
                 AxBackend::ALL[i].label()
             );
         }
@@ -537,10 +681,7 @@ mod tests {
     fn unsupported_cells_carry_a_real_reason() {
         for (role, cells) in ROLE_SUPPORT {
             for (i, cell) in cells.iter().enumerate() {
-                let reason = match cell {
-                    RoleSupport::Mapped => continue,
-                    RoleSupport::NotApplicable(r) | RoleSupport::Gap(r) => *r,
-                };
+                let Some(reason) = cell.why() else { continue };
                 let backend = AxBackend::ALL[i];
                 assert!(
                     reason.len() >= 10,
@@ -563,8 +704,28 @@ mod tests {
         );
         assert!(matches!(
             support(AxRole::MenuBar, AxBackend::Ios),
-            Some(RoleSupport::NotApplicable(_))
+            Some(RoleSupport::NotApplicable { .. })
         ));
+    }
+
+    #[test]
+    fn a_cell_naming_a_token_names_one_token_and_not_prose() {
+        // The token is machine-checked by each backend's column test, so it has to be a token:
+        // a phrase slipped into the field would resolve to `Other` and pass every check
+        // vacuously, which is exactly the "reads plausible, proves nothing" failure this
+        // field exists to end.
+        for (role, cells) in ROLE_SUPPORT {
+            for (i, cell) in cells.iter().enumerate() {
+                let Some(token) = cell.named_token() else {
+                    continue;
+                };
+                let backend = AxBackend::ALL[i];
+                assert!(
+                    !token.contains(' ') && !token.is_empty(),
+                    "{role:?}/{backend:?}: {token:?} is prose, not a single native token"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/glass-core/src/role_support.rs
+++ b/crates/glass-core/src/role_support.rs
@@ -5,10 +5,17 @@
 //! roles nothing in the backend's vocabulary carries them, others simply are not mapped yet.
 //! This module states which is which, so the difference is a checked fact rather than folklore.
 //!
-//! Which of the two a cell gets is decided by observation, not by what a platform's API
-//! reference implies exists: a control is put on screen and the tree is read back. A cell says
-//! [`RoleSupport::NotApplicable`] only where the control was watched to arrive carrying no
-//! token for its role.
+//! Where a control exists to look at, which of the two a cell gets is decided by observation
+//! rather than by what a platform's API reference implies: the control is put on screen and the
+//! tree is read back. `examples/android-role-fixture/` and `examples/ios-role-fixture/` hold
+//! those controls so a cell can be re-read. Cells for a control the platform simply does not
+//! have — a radio button on iOS, a tree on Android — rest on the platform's own vocabulary
+//! instead, and say so.
+//!
+//! Reasons are readings, and readings age. The mobile columns were last read on 2026-07-25,
+//! against an API 34 emulator and an iOS 26.5 Simulator through `idb`. What the iOS column can
+//! say is bounded by what `idb`'s `accessibility_info` exposes, which may be narrower than what
+//! UIKit publishes to VoiceOver.
 //!
 //! Each backend crate has a unit test that walks its own column and asserts its token table
 //! agrees with what is declared here, so a new mapping cannot land without updating the
@@ -74,13 +81,14 @@ impl AxBackend {
 pub enum RoleSupport {
     /// At least one native token maps to this role.
     Mapped,
-    /// No token in the vocabulary this backend reads carries the role, so no mapping could
-    /// reach it. That covers both a concept the platform does not have and one it draws on
-    /// screen without marking in its accessibility vocabulary. The reason says which, and what
-    /// the control was observed to report instead.
+    /// Closing this would take a platform change, not a glass change: either the platform has
+    /// no such control, or it draws one the accessibility layer never marks. The reason says
+    /// which, and what the control was observed to report instead.
     NotApplicable(&'static str),
-    /// The vocabulary does carry it — a token arrives, or a documented field holds it — and
-    /// glass does not map it yet. The reason names what is there and unread.
+    /// Closing this is glass's own work: the platform already carries the role somewhere glass
+    /// reads or could read — a token that arrives unmapped, a documented field the reader
+    /// ignores, a protocol its own companion could send. The reason names what is there and
+    /// unread.
     Gap(&'static str),
 }
 
@@ -111,12 +119,13 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 ),
                 Gap("AXSheet, AXPopover and AXDrawer are not mapped yet"),
                 NotApplicable(
-                    "an AlertDialog's panels report FrameLayout and LinearLayout, and Android \
-                     has no dialog window type; nothing in the vocabulary marks a dialog",
+                    "a framework AlertDialog's panels report FrameLayout and LinearLayout under \
+                     android:id/parentPanel, and AccessibilityWindowInfo's window types carry no \
+                     dialog kind for a reader to fall back on",
                 ),
                 NotApplicable(
-                    "an alert exposes its title, message and buttons directly under the \
-                     application element; no alert, sheet or popover token appears",
+                    "an alert and an action sheet each expose their title, message and buttons \
+                     directly under the application element, with no container token between",
                 ),
             ],
         ),
@@ -171,8 +180,8 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                      anywhere in the tree it opens",
                 ),
                 NotApplicable(
-                    "a UIMenu opens as an AXGroup of AXButtons alongside a Dismiss context menu \
-                     button; no menu token appears",
+                    "a button's pull-down UIMenu opens as an AXGroup of AXButtons alongside a \
+                     Dismiss context menu button; no menu token appears",
                 ),
             ],
         ),
@@ -208,9 +217,10 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Mapped,
-                NotApplicable(
-                    "a UIPickerView reports AXSlider and a SwiftUI Picker reports a heading with \
-                     buttons; no picker token appears",
+                Gap(
+                    "a menu-style SwiftUI Picker reports AXPopUpButton, which is not mapped yet; \
+                     the inline style reports a heading with buttons, and a UIPickerView reports \
+                     AXSlider",
                 ),
             ],
         ),
@@ -234,9 +244,10 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Gap(
-                    "a list child reports its own widget class; the row and column live in \
-                     AccessibilityNodeInfo's CollectionItemInfo, which the uiautomator dump has \
-                     no attribute for and the service protocol does not send",
+                    "AccessibilityNodeInfo's CollectionItemInfo marks a list child, and neither \
+                     reader carries it: the uiautomator dump has no such attribute and the \
+                     service reader parses only class, text, description and bounds. The child's \
+                     own widget class is all that arrives",
                 ),
                 NotApplicable(
                     "table and collection rows report AXStaticText, including a cell explicitly \
@@ -251,9 +262,9 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Gap("mac lists report AXOutline rather than AXTable; AXOutline maps to Tree"),
                 Gap(
-                    "android.widget.TableLayout and TableRow do arrive — the container rule \
-                     folds any leaf ending in Layout into Group — and GridView maps to List; \
-                     CollectionInfo's row and column counts reach neither reader",
+                    "android.widget.TableLayout and TableRow both arrive as tokens: TableLayout \
+                     folds into Group via the container rule, TableRow lands in Other, and \
+                     GridView maps to List",
                 ),
                 NotApplicable(
                     "a table view reports AXGroup like any other container; no table token \
@@ -271,9 +282,10 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 ),
                 Mapped,
                 Gap(
-                    "no cell class exists — a cell is whatever view the app put in the row; the \
-                     row and column index live in CollectionItemInfo, which reaches neither \
-                     reader",
+                    "CollectionItemInfo holds the row and column index, and neither reader \
+                     carries it: the uiautomator dump has no such attribute and the service \
+                     reader parses only class, text, description and bounds. No cell class \
+                     exists to fall back on — a cell is whatever view the app put in the row",
                 ),
                 Mapped,
             ],
@@ -306,7 +318,8 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Gap(
                     "android.widget.TabWidget and TabHost do arrive as tokens and are not mapped \
-                     yet; a Material tab strip reports a plain layout class instead",
+                     yet; the Material tab strips seen in stock apps report a plain layout class \
+                     instead, naming their tabs only by content description",
                 ),
                 Mapped,
             ],
@@ -321,13 +334,14 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                      containing role is not used to disambiguate yet",
                 ),
                 Gap(
-                    "a tab reports a plain layout class with selected=true — under a TabWidget \
-                     parent in the framework widget, named only by the view id in a Material \
-                     tab strip — so nothing in the class name marks it as a tab",
+                    "a framework tab arrives as a LinearLayout with selected=true under a \
+                     TabWidget parent, which together identify it; the class name alone does \
+                     not, and a Material tab strip carries the role in the view id instead",
                 ),
                 NotApplicable(
-                    "a tab bar reports AXGroup and its items are not exposed as elements at all; \
-                     a segmented control reports one AXTabGroup with no per-segment element",
+                    "a tab bar reports AXGroup and no per-item element appears in idb's \
+                     describe; a segmented control reports one AXTabGroup, also with no \
+                     per-segment element",
                 ),
             ],
         ),
@@ -396,8 +410,10 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 NotApplicable(
-                    "android.widget.Toolbar reports android.view.ViewGroup, so no toolbar token \
-                     reaches either reader",
+                    "android.widget.Toolbar was watched to report android.view.ViewGroup — a \
+                     subclass inherits the accessibility class name of the framework class it \
+                     extends, and the AppCompat and Material toolbars override neither, so all \
+                     three arrive as ViewGroup",
                 ),
                 Mapped,
             ],
@@ -422,8 +438,9 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 ),
                 Mapped,
                 Gap(
-                    "neither reader exposes heading semantics: the uiautomator dump has no \
-                     heading attribute, and the service protocol does not carry isHeading",
+                    "AccessibilityNodeInfo's isHeading marks a heading, and neither reader \
+                     carries it: the uiautomator dump has no such attribute and the service \
+                     reader parses only class, text, description and bounds",
                 ),
                 Mapped,
             ],

--- a/crates/glass-core/src/role_support.rs
+++ b/crates/glass-core/src/role_support.rs
@@ -1,9 +1,14 @@
 //! What accessibility role each backend can produce — the declared parity matrix.
 //!
 //! A backend maps native tokens (AT-SPI roles, UIA control types, AX role strings, Android
-//! widget classes, iOS role strings) onto [`AxRole`]. Coverage differs per platform: some
-//! roles have no counterpart at all, others simply are not mapped yet. This module states
-//! which is which, so the difference is a checked fact rather than folklore.
+//! widget classes, iOS role strings) onto [`AxRole`]. Coverage differs per platform: for some
+//! roles nothing in the backend's vocabulary carries them, others simply are not mapped yet.
+//! This module states which is which, so the difference is a checked fact rather than folklore.
+//!
+//! Which of the two a cell gets is decided by observation, not by what a platform's API
+//! reference implies exists: a control is put on screen and the tree is read back. A cell says
+//! [`RoleSupport::NotApplicable`] only where the control was watched to arrive carrying no
+//! token for its role.
 //!
 //! Each backend crate has a unit test that walks its own column and asserts its token table
 //! agrees with what is declared here, so a new mapping cannot land without updating the
@@ -69,10 +74,13 @@ impl AxBackend {
 pub enum RoleSupport {
     /// At least one native token maps to this role.
     Mapped,
-    /// The platform has no counterpart. The reason says why — either what the platform does
-    /// instead, or simply that the concept does not exist there.
+    /// No token in the vocabulary this backend reads carries the role, so no mapping could
+    /// reach it. That covers both a concept the platform does not have and one it draws on
+    /// screen without marking in its accessibility vocabulary. The reason says which, and what
+    /// the control was observed to report instead.
     NotApplicable(&'static str),
-    /// The platform has a counterpart glass does not map yet. The reason says what is missing.
+    /// The vocabulary does carry it — a token arrives, or a documented field holds it — and
+    /// glass does not map it yet. The reason names what is there and unread.
     Gap(&'static str),
 }
 
@@ -102,10 +110,13 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                      not read it",
                 ),
                 Gap("AXSheet, AXPopover and AXDrawer are not mapped yet"),
-                Gap("dialog windows arrive as a generic layout class"),
-                Gap(
-                    "an alert exposes its buttons and text directly under the application \
-                     element; no alert, sheet or popover token appears",
+                NotApplicable(
+                    "an AlertDialog's panels report FrameLayout and LinearLayout, and Android \
+                     has no dialog window type; nothing in the vocabulary marks a dialog",
+                ),
+                NotApplicable(
+                    "an alert exposes its title, message and buttons directly under the \
+                     application element; no alert, sheet or popover token appears",
                 ),
             ],
         ),
@@ -132,7 +143,10 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Mapped,
-                Gap("no radio token is mapped yet"),
+                NotApplicable(
+                    "UIKit has no radio control; a UISegmentedControl — the nearest equivalent \
+                     — reports one AXTabGroup with no per-segment element",
+                ),
             ],
         ),
         (R::CheckBox, [Mapped, Mapped, Mapped, Mapped, Mapped]),
@@ -152,8 +166,14 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Mapped,
-                Gap("popup menus arrive as list or layout classes"),
-                Gap("context-menu tokens are not mapped yet"),
+                NotApplicable(
+                    "a popup menu reports android.widget.ListView; no menu token appears \
+                     anywhere in the tree it opens",
+                ),
+                NotApplicable(
+                    "a UIMenu opens as an AXGroup of AXButtons alongside a Dismiss context menu \
+                     button; no menu token appears",
+                ),
             ],
         ),
         (
@@ -162,8 +182,11 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Mapped,
-                Gap("menu entries arrive as their own widget class"),
-                Gap("menu-item tokens are not mapped yet"),
+                NotApplicable(
+                    "a menu entry reports its item view's layout class — a LinearLayout or \
+                     RelativeLayout holding a TextView title",
+                ),
+                NotApplicable("a menu entry reports AXButton, the same token as any other button"),
             ],
         ),
         (R::Label, [Mapped, Mapped, Mapped, Mapped, Mapped]),
@@ -185,7 +208,10 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Mapped,
-                Gap("picker tokens are not mapped yet"),
+                NotApplicable(
+                    "a UIPickerView reports AXSlider and a SwiftUI Picker reports a heading with \
+                     buttons; no picker token appears",
+                ),
             ],
         ),
         (
@@ -195,7 +221,10 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Mapped,
-                Gap("collections arrive as AXGroup, which maps to Group; no list token appears"),
+                NotApplicable(
+                    "a UITableView and a SwiftUI List both report AXGroup, and their rows report \
+                     AXStaticText; no list token appears",
+                ),
             ],
         ),
         (
@@ -204,8 +233,15 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Mapped,
-                Gap("list children report their own widget class, not a list-item role"),
-                Gap("a collection's children report their own element role, not a list-item role"),
+                Gap(
+                    "a list child reports its own widget class; the row and column live in \
+                     AccessibilityNodeInfo's CollectionItemInfo, which the uiautomator dump has \
+                     no attribute for and the service protocol does not send",
+                ),
+                NotApplicable(
+                    "table and collection rows report AXStaticText, including a cell explicitly \
+                     exposed as its own accessibility element",
+                ),
             ],
         ),
         (
@@ -214,8 +250,15 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Gap("mac lists report AXOutline rather than AXTable; AXOutline maps to Tree"),
-                Gap("table and grid classes collapse into List"),
-                Gap("collections arrive as AXGroup, which maps to Group; no table token appears"),
+                Gap(
+                    "android.widget.TableLayout and TableRow do arrive — the container rule \
+                     folds any leaf ending in Layout into Group — and GridView maps to List; \
+                     CollectionInfo's row and column counts reach neither reader",
+                ),
+                NotApplicable(
+                    "a table view reports AXGroup like any other container; no table token \
+                     appears",
+                ),
             ],
         ),
         (
@@ -227,7 +270,11 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                      expose their rows as TreeItem",
                 ),
                 Mapped,
-                Gap("no cell class is mapped yet"),
+                Gap(
+                    "no cell class exists — a cell is whatever view the app put in the row; the \
+                     row and column index live in CollectionItemInfo, which reaches neither \
+                     reader",
+                ),
                 Mapped,
             ],
         ),
@@ -258,8 +305,8 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Gap(
-                    "a tab container reports a plain layout class; the tab role lives in the \
-                     view's id and selected state, not in the class name",
+                    "android.widget.TabWidget and TabHost do arrive as tokens and are not mapped \
+                     yet; a Material tab strip reports a plain layout class instead",
                 ),
                 Mapped,
             ],
@@ -274,12 +321,13 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                      containing role is not used to disambiguate yet",
                 ),
                 Gap(
-                    "a tab reports a plain layout class with selected=true; nothing in the \
-                     class name marks it as a tab",
+                    "a tab reports a plain layout class with selected=true — under a TabWidget \
+                     parent in the framework widget, named only by the view id in a Material \
+                     tab strip — so nothing in the class name marks it as a tab",
                 ),
-                Gap(
-                    "the tab bars seen in probing arrived as AXGroup, named by the element \
-                     identifier rather than the role, and no tab-item token appeared",
+                NotApplicable(
+                    "a tab bar reports AXGroup and its items are not exposed as elements at all; \
+                     a segmented control reports one AXTabGroup with no per-segment element",
                 ),
             ],
         ),
@@ -300,8 +348,11 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Gap("AXIncrementor is not mapped yet"),
-                Gap("the number-picker class is not mapped yet"),
-                Gap("the stepper token is not mapped yet"),
+                Gap("android.widget.NumberPicker does arrive as a token and is not mapped yet"),
+                NotApplicable(
+                    "a UIStepper decomposes into two AXButtons labelled Decrement and \
+                     Increment; no stepper token appears",
+                ),
             ],
         ),
         (
@@ -311,7 +362,10 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Mapped,
-                Gap("no progress token is mapped yet"),
+                NotApplicable(
+                    "a UIProgressView reports AXGenericElement carrying its percentage as the \
+                     value; no progress token appears",
+                ),
             ],
         ),
         (R::Image, [Mapped, Mapped, Mapped, Mapped, Mapped]),
@@ -341,7 +395,10 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 Mapped,
-                Gap("the toolbar class is not mapped yet"),
+                NotApplicable(
+                    "android.widget.Toolbar reports android.view.ViewGroup, so no toolbar token \
+                     reaches either reader",
+                ),
                 Mapped,
             ],
         ),

--- a/crates/glass-core/src/role_support.rs
+++ b/crates/glass-core/src/role_support.rs
@@ -12,11 +12,12 @@
 //! have — a radio button on iOS, a tree on Android — rest on the platform's own vocabulary
 //! instead, and say so.
 //!
-//! Reasons are readings, and readings age. The mobile columns were last read on 2026-07-25,
-//! against an API 34 emulator and an iOS 26.5 Simulator through `idb`, and the Windows `Heading`
-//! cell the same day against Edge on Windows 11. What the iOS column can say is bounded by what
-//! `idb`'s `accessibility_info` exposes, which may be narrower than what UIKit publishes to
-//! VoiceOver.
+//! Reasons are readings, not guarantees: each says what a control was seen to report, and a
+//! platform is free to change that. When a cell was last read is `git log`'s to answer — a date
+//! written here would be one more thing to update and the first thing to go stale — and what it
+//! was read against is the fixture run's, which prints its platform version. What the iOS column
+//! can say is also bounded by what `idb`'s `accessibility_info` exposes, which may be narrower
+//! than what UIKit publishes to VoiceOver.
 //!
 //! Each backend crate has a unit test that walks its own column and asserts its token table
 //! agrees with what is declared here, so a new mapping cannot land without updating the

--- a/crates/glass-core/src/role_support.rs
+++ b/crates/glass-core/src/role_support.rs
@@ -5,12 +5,17 @@
 //! roles nothing in the backend's vocabulary carries them, others simply are not mapped yet.
 //! This module states which is which, so the difference is a checked fact rather than folklore.
 //!
-//! Where a control exists to look at, which of the two a cell gets is decided by observation
-//! rather than by what a platform's API reference implies: the control is put on screen and the
-//! tree is read back. `examples/android-role-fixture/` and `examples/ios-role-fixture/` hold
-//! those controls so a cell can be re-read. Cells for a control the platform simply does not
-//! have — a radio button on iOS, a tree on Android — rest on the platform's own vocabulary
-//! instead, and say so.
+//! Where a control exists to look at, which state a cell gets is decided by observation rather
+//! than by what a platform's API reference implies: the control is put on screen and the tree is
+//! read back. `examples/android-role-fixture/` and `examples/ios-role-fixture/` hold those
+//! controls so a cell can be re-read.
+//!
+//! What that can and cannot establish is the point of [`Basis`]. A cell saying the control was
+//! watched arriving unmarked is a bounded reading — one OS version, one reader, the controls
+//! tried — and on Android and iOS it could never be more than that, because those vocabularies
+//! are open: an app sets its own `AccessibilityNodeInfo` class name, and iOS role strings come
+//! from the Simulator's translator. None of these cells claims a role is impossible; they claim
+//! nothing was found carrying it.
 //!
 //! Reasons are readings, not guarantees: each says what a control was seen to report, and a
 //! platform is free to change that. When a cell was last read is `git log`'s to answer — a date
@@ -83,9 +88,12 @@ impl AxBackend {
 pub enum RoleSupport {
     /// At least one native token maps to this role.
     Mapped,
-    /// Closing this would take a platform change, not a glass change: either the platform has
-    /// no such control, or it draws one the accessibility layer never marks.
+    /// Nothing glass reads carries the role, so no mapping could reach it. [`Basis`] says on what
+    /// footing — which is not the same footing in every cell, and never an exhaustiveness proof.
     NotApplicable {
+        /// What kind of unavailability this is: the control does not exist, exists but arrives
+        /// unmarked, or is exposed somewhere glass does not walk.
+        basis: Basis,
         /// The native token the control was observed to report in this role's place, in the
         /// form that backend's own resolver accepts. `None` where nothing stands in for it —
         /// the platform has no such control (no menu bar on iOS), or the concept sits outside
@@ -135,10 +143,32 @@ impl RoleSupport {
     }
 }
 
+/// On what footing a [`RoleSupport::NotApplicable`] cell stands. None of these is a proof of
+/// impossibility: they record what reading a real control found, bounded by the controls tried,
+/// the OS version, and the reader. Two of the three vocabularies are open — an Android app sets
+/// its own `AccessibilityNodeInfo` class name, and iOS role strings come from the Simulator's
+/// translator — so on those columns no amount of reading could close the question. Only UIA
+/// names a closed, documented set of control types.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Basis {
+    /// The platform has no such control to expose — a radio button on iOS, a tree on Android.
+    /// The claim is about the platform's controls, so no reading of an app could overturn it
+    /// short of an app building the concept itself out of other controls.
+    Absent,
+    /// The control exists and is on screen, and no reading found a token carrying its role: it is
+    /// drawn but unmarked, or folded into a token that means something else. This is the bounded
+    /// one — it says what was watched, not what is possible.
+    Unmarked,
+    /// The control exists and is exposed, but outside what glass walks — the system status bar
+    /// belongs to the OS shell, not to the app whose tree is being read.
+    Elsewhere,
+}
+
 /// Role coverage per backend. Cells are ordered as [`AxBackend::ALL`], and the row type is sized
 /// from it so a new backend is a compile error here rather than a silent column mismatch.
 pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
     use AxRole as R;
+    use Basis::{Absent, Elsewhere, Unmarked};
     use RoleSupport::{Gap, Mapped, NotApplicable};
     &[
         (
@@ -146,6 +176,7 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
             [
                 Mapped,
                 NotApplicable {
+                    basis: Unmarked,
                     instead: Some("Window"),
                     why: "UIA has no application control type; the app root is a Window",
                 },
@@ -154,6 +185,7 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                     why: "AXApplication is the app element but is not mapped yet",
                 },
                 NotApplicable {
+                    basis: Absent,
                     instead: None,
                     why: "Android exposes windows, not an application element",
                 },
@@ -175,12 +207,14 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                     why: "AXSheet, AXPopover and AXDrawer are not mapped yet",
                 },
                 NotApplicable {
+                    basis: Unmarked,
                     instead: Some("android.widget.FrameLayout"),
                     why: "a framework AlertDialog's panels report FrameLayout and LinearLayout under \
                      android:id/parentPanel, and AccessibilityWindowInfo's window types carry no \
                      dialog kind for a reader to fall back on",
                 },
                 NotApplicable {
+                    basis: Unmarked,
                     instead: None,
                     why: "an alert and an action sheet each expose their title, message and buttons \
                      directly under the application element, with no container token between",
@@ -212,7 +246,8 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 NotApplicable {
-                    instead: Some("AXTabGroup"),
+                    basis: Absent,
+                    instead: None,
                     why: "UIKit has no radio control; a UISegmentedControl — the nearest equivalent \
                      — reports one AXTabGroup with no per-segment element",
                 },
@@ -226,10 +261,12 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 NotApplicable {
+                    basis: Absent,
                     instead: None,
                     why: "Android apps have no menu bar",
                 },
                 NotApplicable {
+                    basis: Absent,
                     instead: None,
                     why: "iOS apps have no menu bar",
                 },
@@ -242,11 +279,13 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 NotApplicable {
+                    basis: Unmarked,
                     instead: Some("android.widget.ListView"),
                     why: "a popup menu reports android.widget.ListView; no menu token appears \
                      anywhere in the tree it opens",
                 },
                 NotApplicable {
+                    basis: Unmarked,
                     instead: Some("AXGroup"),
                     why: "a button's pull-down UIMenu opens as an AXGroup of AXButtons alongside a \
                      Dismiss context menu button; no menu token appears",
@@ -260,11 +299,13 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 NotApplicable {
+                    basis: Unmarked,
                     instead: Some("android.widget.LinearLayout"),
                     why: "a menu entry reports its item view's layout class — a LinearLayout or \
                      RelativeLayout holding a TextView title",
                 },
                 NotApplicable {
+                    basis: Unmarked,
                     instead: Some("AXButton"),
                     why: "a menu entry reports AXButton, the same token as any other button",
                 },
@@ -279,6 +320,7 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 NotApplicable {
+                    basis: Unmarked,
                     instead: Some("android.widget.EditText"),
                     why: "Android uses one editable class for single- and multi-line text",
                 },
@@ -308,6 +350,7 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 NotApplicable {
+                    basis: Unmarked,
                     instead: Some("AXGroup"),
                     why: "a UITableView and a SwiftUI List both report AXGroup, and their rows report \
                      AXStaticText; no list token appears",
@@ -328,6 +371,7 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                      own widget class is all that arrives",
                 },
                 NotApplicable {
+                    basis: Unmarked,
                     instead: Some("AXStaticText"),
                     why: "table and collection rows report AXStaticText, including a cell explicitly \
                      exposed as its own accessibility element",
@@ -350,6 +394,7 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                      GridView maps to List",
                 },
                 NotApplicable {
+                    basis: Unmarked,
                     instead: Some("AXGroup"),
                     why: "a table view reports AXGroup like any other container; no table token \
                      appears",
@@ -384,10 +429,12 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 NotApplicable {
+                    basis: Absent,
                     instead: None,
                     why: "Android has no tree widget",
                 },
                 NotApplicable {
+                    basis: Absent,
                     instead: None,
                     why: "UIKit has no outline view",
                 },
@@ -400,10 +447,12 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 NotApplicable {
+                    basis: Absent,
                     instead: None,
                     why: "Android has no tree widget",
                 },
                 NotApplicable {
+                    basis: Absent,
                     instead: None,
                     why: "UIKit has no outline view",
                 },
@@ -441,6 +490,7 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                      not, and a Material tab strip carries the role in the view id instead",
                 },
                 NotApplicable {
+                    basis: Unmarked,
                     instead: Some("AXGroup"),
                     why: "a tab bar reports AXGroup and no per-item element appears in idb's \
                      describe; a segmented control reports one AXTabGroup, also with no \
@@ -455,10 +505,12 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 NotApplicable {
+                    basis: Unmarked,
                     instead: None,
                     why: "Android scrollbars are drawn, not exposed as nodes",
                 },
                 NotApplicable {
+                    basis: Unmarked,
                     instead: None,
                     why: "UIKit scroll indicators are not accessibility elements",
                 },
@@ -479,6 +531,7 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                     why: "android.widget.NumberPicker does arrive as a token and is not mapped yet",
                 },
                 NotApplicable {
+                    basis: Unmarked,
                     instead: Some("AXButton"),
                     why: "a UIStepper decomposes into two AXButtons labelled Decrement and \
                      Increment; no stepper token appears",
@@ -493,6 +546,7 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 NotApplicable {
+                    basis: Unmarked,
                     instead: Some("AXGenericElement"),
                     why: "a UIProgressView reports AXGenericElement carrying its percentage as the \
                      value; no progress token appears",
@@ -507,6 +561,7 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 NotApplicable {
+                    basis: Unmarked,
                     instead: None,
                     why: "Android links are spans inside a text view, not separate nodes",
                 },
@@ -520,10 +575,12 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 NotApplicable {
+                    basis: Unmarked,
                     instead: None,
                     why: "Android dividers are drawn, not exposed as nodes",
                 },
                 NotApplicable {
+                    basis: Unmarked,
                     instead: None,
                     why: "UIKit exposes no separator element",
                 },
@@ -536,6 +593,7 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 NotApplicable {
+                    basis: Unmarked,
                     instead: Some("android.view.ViewGroup"),
                     why: "android.widget.Toolbar was watched to report android.view.ViewGroup — a \
                      subclass inherits the accessibility class name of the framework class it \
@@ -551,14 +609,17 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
                 Mapped,
                 Mapped,
                 NotApplicable {
+                    basis: Unmarked,
                     instead: None,
                     why: "AppKit exposes status items as menu-bar items",
                 },
                 NotApplicable {
+                    basis: Elsewhere,
                     instead: None,
                     why: "the system status bar is outside the app tree",
                 },
                 NotApplicable {
+                    basis: Elsewhere,
                     instead: None,
                     why: "the system status bar is outside the app tree",
                 },
@@ -621,9 +682,15 @@ pub fn render_markdown() -> String {
     for (role, cells) in ROLE_SUPPORT {
         let _ = write!(out, "| `{role:?}` |");
         for cell in cells {
+            // `absent`, `unmarked` and `elsewhere` render apart rather than collapsing into one
+            // `n/a`: they are different claims, and only the middle one is a bounded reading.
             let mark = match cell {
                 RoleSupport::Mapped => "yes",
-                RoleSupport::NotApplicable { .. } => "n/a",
+                RoleSupport::NotApplicable { basis, .. } => match basis {
+                    Basis::Absent => "absent",
+                    Basis::Unmarked => "unmarked",
+                    Basis::Elsewhere => "elsewhere",
+                },
                 RoleSupport::Gap { .. } => "gap",
             };
             let _ = write!(out, " {mark} |");
@@ -639,8 +706,13 @@ pub fn render_markdown() -> String {
             // is looking for, and the fact each backend's column test checks.
             let (kind, token) = match cell {
                 RoleSupport::Mapped => continue,
-                RoleSupport::NotApplicable { instead, .. } => {
-                    ("n/a", instead.map(|t| format!("reports `{t}` instead")))
+                RoleSupport::NotApplicable { basis, instead, .. } => {
+                    let kind = match basis {
+                        Basis::Absent => "absent",
+                        Basis::Unmarked => "unmarked",
+                        Basis::Elsewhere => "elsewhere",
+                    };
+                    (kind, instead.map(|t| format!("reports `{t}` instead")))
                 }
                 RoleSupport::Gap { unmapped, .. } => {
                     ("gap", unmapped.map(|t| format!("`{t}` arrives unmapped")))
@@ -702,9 +774,14 @@ mod tests {
             support(AxRole::Button, AxBackend::Linux),
             Some(RoleSupport::Mapped)
         );
+        // iOS has no menu bar to expose, so this one is Absent rather than merely unmarked —
+        // the basis is part of what the cell claims, so pin it.
         assert!(matches!(
             support(AxRole::MenuBar, AxBackend::Ios),
-            Some(RoleSupport::NotApplicable { .. })
+            Some(RoleSupport::NotApplicable {
+                basis: Basis::Absent,
+                ..
+            })
         ));
     }
 
@@ -724,6 +801,29 @@ mod tests {
                     !token.contains(' ') && !token.is_empty(),
                     "{role:?}/{backend:?}: {token:?} is prose, not a single native token"
                 );
+            }
+        }
+    }
+
+    #[test]
+    fn an_absent_control_reports_nothing_in_its_place() {
+        // `Absent` says the platform has no such control. A control that does not exist cannot
+        // have been watched reporting something else, so naming a token there would mean one of
+        // the two is wrong — most likely the basis, which is the stronger claim of the pair.
+        for (role, cells) in ROLE_SUPPORT {
+            for (i, cell) in cells.iter().enumerate() {
+                if let RoleSupport::NotApplicable {
+                    basis: Basis::Absent,
+                    instead: Some(token),
+                    ..
+                } = cell
+                {
+                    panic!(
+                        "{role:?}/{:?}: declared Absent but names {token} as what it reports \
+                         instead — if a control reported that, it is Unmarked, not Absent",
+                        AxBackend::ALL[i]
+                    );
+                }
             }
         }
     }

--- a/crates/glass-core/src/role_support.rs
+++ b/crates/glass-core/src/role_support.rs
@@ -13,9 +13,10 @@
 //! instead, and say so.
 //!
 //! Reasons are readings, and readings age. The mobile columns were last read on 2026-07-25,
-//! against an API 34 emulator and an iOS 26.5 Simulator through `idb`. What the iOS column can
-//! say is bounded by what `idb`'s `accessibility_info` exposes, which may be narrower than what
-//! UIKit publishes to VoiceOver.
+//! against an API 34 emulator and an iOS 26.5 Simulator through `idb`, and the Windows `Heading`
+//! cell the same day against Edge on Windows 11. What the iOS column can say is bounded by what
+//! `idb`'s `accessibility_info` exposes, which may be narrower than what UIKit publishes to
+//! VoiceOver.
 //!
 //! Each backend crate has a unit test that walks its own column and asserts its token table
 //! agrees with what is declared here, so a new mapping cannot land without updating the
@@ -277,8 +278,9 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
             [
                 Mapped,
                 Gap(
-                    "UIA's DataItem control type would carry this, but the data grids probed \
-                     expose their rows as TreeItem",
+                    "UIA's DataItem control type would carry this and is not mapped: the data \
+                     grids probed expose their rows as TreeItem instead, though Edge does report \
+                     an HTML table's header cells as DataItem",
                 ),
                 Mapped,
                 Gap(
@@ -433,8 +435,10 @@ pub const ROLE_SUPPORT: &[(AxRole, [RoleSupport; AxBackend::ALL.len()])] = {
             [
                 Mapped,
                 Gap(
-                    "UIA's Header and HeaderItem are grid column headers, not document \
-                     headings; the normalized set has no column-header role",
+                    "UIA marks a heading with the HeadingLevel property — an h1 arrives as Text \
+                     carrying level 80051 — and the reader maps by control type alone, so it \
+                     never sees it. Header and HeaderItem are a grid's column headers, a \
+                     different concept the normalized set has no role for",
                 ),
                 Mapped,
                 Gap(

--- a/crates/glass-ios/src/axmap.rs
+++ b/crates/glass-ios/src/axmap.rs
@@ -643,10 +643,25 @@ mod tests {
                 RoleSupport::Mapped => {
                     assert!(mapped, "{role:?} declared Mapped but no token maps to it")
                 }
-                RoleSupport::NotApplicable(_) | RoleSupport::Gap(_) => assert!(
-                    !mapped,
-                    "{role:?} is produced by a token but the matrix does not declare it"
-                ),
+                cell => {
+                    assert!(
+                        !mapped,
+                        "{role:?} is produced by a token but the matrix does not declare it"
+                    );
+                    // The named token must not resolve to the very role the cell says is out
+                    // of reach. Largely a second line behind the `!mapped` assertion above —
+                    // if the token produced the role, that one fires too — but it pins the
+                    // token itself, so a cell rewritten to name a different token is checked
+                    // against the map rather than against nothing. A misspelt token resolves
+                    // to `Other` and passes: only an on-box read catches that.
+                    if let Some(token) = cell.named_token() {
+                        assert_ne!(
+                            ax_role(token),
+                            role,
+                            "{role:?} is declared out of reach naming {token}, which maps to it"
+                        );
+                    }
+                }
             }
         }
     }

--- a/crates/glass-ios/src/axmap.rs
+++ b/crates/glass-ios/src/axmap.rs
@@ -44,11 +44,12 @@ pub const ROLE_TOKENS: &[(&str, AxRole)] = &[
     ("AXTabBar", AxRole::TabList),
     ("AXApplication", AxRole::Application),
     ("AXWindow", AxRole::Window),
-    // A content container, and the only structural token most probed screens exposed: in
-    // those apps the navigation bar and the tab bar arrived as AXGroup as well, named by the
-    // element's identifier rather than by its role. That is what was seen there, not a rule
-    // about UIKit — an app that does report AXNavigationBar or AXTabBar still maps to Toolbar
-    // or TabList through the rows above.
+    // A content container, and the only structural token most probed screens exposed: navigation
+    // bars, tab bars and collections all arrived as AXGroup, named by the element's identifier
+    // rather than by its role. That is what was seen, not a rule about UIKit — an app that does
+    // report AXNavigationBar or AXTabBar still maps to Toolbar or TabList through the rows above.
+    // The Toolbar, TabList and List rows of `glass_core::role_support::ROLE_SUPPORT` carry what
+    // each was read to report.
     ("AXGroup", AxRole::Group),
     // A screen or section title.
     ("AXHeading", AxRole::Heading),
@@ -614,6 +615,13 @@ mod tests {
         // stays visible in the outline. Mapping it to Group would claim a structure that
         // the platform never reported.
         assert_eq!(ax_role("AXGenericElement"), AxRole::Other);
+        // Two tokens the role fixture (examples/ios-role-fixture) was seen to emit that nothing
+        // maps yet: a segmented control reports AXTabGroup, and a menu-style SwiftUI Picker
+        // reports AXPopUpButton. Pinned as Other so the observation lives somewhere a reader
+        // hits, and so mapping either later is a deliberate edit rather than a silent one — see
+        // the TabList and ComboBox rows of `glass_core::role_support::ROLE_SUPPORT`.
+        assert_eq!(ax_role("AXTabGroup"), AxRole::Other);
+        assert_eq!(ax_role("AXPopUpButton"), AxRole::Other);
     }
 
     #[test]

--- a/docs/reference/a11y-roles.md
+++ b/docs/reference/a11y-roles.md
@@ -10,18 +10,27 @@ token the role is `Other` and the outline shows the token in brackets — `Other
 
 A cell reads:
 
-- `yes` — the backend produces this role.
-- `n/a` — no token in the vocabulary this backend reads carries the role, so no mapping could
-  reach it. That covers a concept the platform does not have and one it draws on screen without
-  marking; the reason says which, and what the control reports instead.
-- `gap` — the vocabulary does carry it and glass does not map it yet. The reason names what is
-  there and unread.
+- `yes` — glass maps a native token to this role.
+- `gap` — closing it is glass's own work. The platform carries the role somewhere glass reads or
+  could read — a token that arrives unmapped, a documented field the reader ignores, a protocol
+  its own companion could send — and the reason names what is there and unread.
+- `n/a` — closing it would take a platform change. Either the platform has no such control, or it
+  draws one its accessibility layer never marks; the reason says which, and what the control
+  reports instead.
 
-Each cell is decided by putting the control on screen and reading the tree back, not from what a
-platform's API reference implies exists — a role is `n/a` only where the control was watched to
-arrive carrying no token for it. Two example apps hold those controls, one per question, so the
-reading is repeatable: [`examples/android-role-fixture/`](../../examples/android-role-fixture/)
-and [`examples/ios-role-fixture/`](../../examples/ios-role-fixture/).
+Where there is a control to look at, `gap` and `n/a` are decided by putting it on screen and
+reading the tree back rather than from what a platform's API reference implies. Two example apps
+hold those controls, one per question, so the reading is repeatable:
+[`examples/android-role-fixture/`](../../examples/android-role-fixture/) and
+[`examples/ios-role-fixture/`](../../examples/ios-role-fixture/). Cells for a control a platform
+simply does not have — a radio button on iOS, a tree on Android — rest on its vocabulary instead
+and say so. A `yes` is map-backed, not reading-backed: it says a token is mapped, not that an app
+was seen to emit it.
+
+Reasons are readings, and readings age. The Android and iOS columns were last read on 2026-07-25,
+against an API 34 emulator and an iOS 26.5 Simulator. What the iOS column can say is bounded by
+what `idb`'s accessibility tree exposes, which may be narrower than what UIKit publishes to
+VoiceOver.
 
 On Android, both readers report a `Window` root: the `uiautomator` reader wraps its dump in a
 window root sized to the app window, and the accessibility-service reader labels the active
@@ -45,7 +54,7 @@ now, and the outline only names the token of an element that has none.
 | `Label` | yes | yes | yes | yes | yes |
 | `TextField` | yes | yes | yes | yes | yes |
 | `TextArea` | yes | yes | yes | n/a | yes |
-| `ComboBox` | yes | yes | yes | yes | n/a |
+| `ComboBox` | yes | yes | yes | yes | gap |
 | `List` | yes | yes | yes | yes | n/a |
 | `ListItem` | yes | yes | yes | gap | n/a |
 | `Table` | yes | yes | gap | gap | n/a |
@@ -72,34 +81,34 @@ now, and the outline only names the token of an element that has none.
 - `Application` / Android — n/a: Android exposes windows, not an application element
 - `Dialog` / Windows (UIA) — gap: UIA marks a dialog with the IsDialog property on a Window; the reader does not read it
 - `Dialog` / macOS (AX) — gap: AXSheet, AXPopover and AXDrawer are not mapped yet
-- `Dialog` / Android — n/a: an AlertDialog's panels report FrameLayout and LinearLayout, and Android has no dialog window type; nothing in the vocabulary marks a dialog
-- `Dialog` / iOS — n/a: an alert exposes its title, message and buttons directly under the application element; no alert, sheet or popover token appears
+- `Dialog` / Android — n/a: a framework AlertDialog's panels report FrameLayout and LinearLayout under android:id/parentPanel, and AccessibilityWindowInfo's window types carry no dialog kind for a reader to fall back on
+- `Dialog` / iOS — n/a: an alert and an action sheet each expose their title, message and buttons directly under the application element, with no container token between
 - `ToggleButton` / macOS (AX) — gap: AppKit reports a switch as AXCheckBox with an AXSwitch or AXToggle subrole; AXCheckBox is outside the reader's subrole gate, and no probed app emitted either subrole
 - `RadioButton` / iOS — n/a: UIKit has no radio control; a UISegmentedControl — the nearest equivalent — reports one AXTabGroup with no per-segment element
 - `MenuBar` / Android — n/a: Android apps have no menu bar
 - `MenuBar` / iOS — n/a: iOS apps have no menu bar
 - `Menu` / Android — n/a: a popup menu reports android.widget.ListView; no menu token appears anywhere in the tree it opens
-- `Menu` / iOS — n/a: a UIMenu opens as an AXGroup of AXButtons alongside a Dismiss context menu button; no menu token appears
+- `Menu` / iOS — n/a: a button's pull-down UIMenu opens as an AXGroup of AXButtons alongside a Dismiss context menu button; no menu token appears
 - `MenuItem` / Android — n/a: a menu entry reports its item view's layout class — a LinearLayout or RelativeLayout holding a TextView title
 - `MenuItem` / iOS — n/a: a menu entry reports AXButton, the same token as any other button
 - `TextArea` / Android — n/a: Android uses one editable class for single- and multi-line text
-- `ComboBox` / iOS — n/a: a UIPickerView reports AXSlider and a SwiftUI Picker reports a heading with buttons; no picker token appears
+- `ComboBox` / iOS — gap: a menu-style SwiftUI Picker reports AXPopUpButton, which is not mapped yet; the inline style reports a heading with buttons, and a UIPickerView reports AXSlider
 - `List` / iOS — n/a: a UITableView and a SwiftUI List both report AXGroup, and their rows report AXStaticText; no list token appears
-- `ListItem` / Android — gap: a list child reports its own widget class; the row and column live in AccessibilityNodeInfo's CollectionItemInfo, which the uiautomator dump has no attribute for and the service protocol does not send
+- `ListItem` / Android — gap: AccessibilityNodeInfo's CollectionItemInfo marks a list child, and neither reader carries it: the uiautomator dump has no such attribute and the service reader parses only class, text, description and bounds. The child's own widget class is all that arrives
 - `ListItem` / iOS — n/a: table and collection rows report AXStaticText, including a cell explicitly exposed as its own accessibility element
 - `Table` / macOS (AX) — gap: mac lists report AXOutline rather than AXTable; AXOutline maps to Tree
-- `Table` / Android — gap: android.widget.TableLayout and TableRow do arrive — the container rule folds any leaf ending in Layout into Group — and GridView maps to List; CollectionInfo's row and column counts reach neither reader
+- `Table` / Android — gap: android.widget.TableLayout and TableRow both arrive as tokens: TableLayout folds into Group via the container rule, TableRow lands in Other, and GridView maps to List
 - `Table` / iOS — n/a: a table view reports AXGroup like any other container; no table token appears
 - `Cell` / Windows (UIA) — gap: UIA's DataItem control type would carry this, but the data grids probed expose their rows as TreeItem
-- `Cell` / Android — gap: no cell class exists — a cell is whatever view the app put in the row; the row and column index live in CollectionItemInfo, which reaches neither reader
+- `Cell` / Android — gap: CollectionItemInfo holds the row and column index, and neither reader carries it: the uiautomator dump has no such attribute and the service reader parses only class, text, description and bounds. No cell class exists to fall back on — a cell is whatever view the app put in the row
 - `Tree` / Android — n/a: Android has no tree widget
 - `Tree` / iOS — n/a: UIKit has no outline view
 - `TreeItem` / Android — n/a: Android has no tree widget
 - `TreeItem` / iOS — n/a: UIKit has no outline view
-- `TabList` / Android — gap: android.widget.TabWidget and TabHost do arrive as tokens and are not mapped yet; a Material tab strip reports a plain layout class instead
+- `TabList` / Android — gap: android.widget.TabWidget and TabHost do arrive as tokens and are not mapped yet; the Material tab strips seen in stock apps report a plain layout class instead, naming their tabs only by content description
 - `Tab` / macOS (AX) — gap: AppKit reports tab items as AXRadioButton inside the tab group; the containing role is not used to disambiguate yet
-- `Tab` / Android — gap: a tab reports a plain layout class with selected=true — under a TabWidget parent in the framework widget, named only by the view id in a Material tab strip — so nothing in the class name marks it as a tab
-- `Tab` / iOS — n/a: a tab bar reports AXGroup and its items are not exposed as elements at all; a segmented control reports one AXTabGroup with no per-segment element
+- `Tab` / Android — gap: a framework tab arrives as a LinearLayout with selected=true under a TabWidget parent, which together identify it; the class name alone does not, and a Material tab strip carries the role in the view id instead
+- `Tab` / iOS — n/a: a tab bar reports AXGroup and no per-item element appears in idb's describe; a segmented control reports one AXTabGroup, also with no per-segment element
 - `ScrollBar` / Android — n/a: Android scrollbars are drawn, not exposed as nodes
 - `ScrollBar` / iOS — n/a: UIKit scroll indicators are not accessibility elements
 - `SpinButton` / macOS (AX) — gap: AXIncrementor is not mapped yet
@@ -109,10 +118,10 @@ now, and the outline only names the token of an element that has none.
 - `Link` / Android — n/a: Android links are spans inside a text view, not separate nodes
 - `Separator` / Android — n/a: Android dividers are drawn, not exposed as nodes
 - `Separator` / iOS — n/a: UIKit exposes no separator element
-- `Toolbar` / Android — n/a: android.widget.Toolbar reports android.view.ViewGroup, so no toolbar token reaches either reader
+- `Toolbar` / Android — n/a: android.widget.Toolbar was watched to report android.view.ViewGroup — a subclass inherits the accessibility class name of the framework class it extends, and the AppCompat and Material toolbars override neither, so all three arrive as ViewGroup
 - `StatusBar` / macOS (AX) — n/a: AppKit exposes status items as menu-bar items
 - `StatusBar` / Android — n/a: the system status bar is outside the app tree
 - `StatusBar` / iOS — n/a: the system status bar is outside the app tree
 - `Heading` / Windows (UIA) — gap: UIA's Header and HeaderItem are grid column headers, not document headings; the normalized set has no column-header role
-- `Heading` / Android — gap: neither reader exposes heading semantics: the uiautomator dump has no heading attribute, and the service protocol does not carry isHeading
+- `Heading` / Android — gap: AccessibilityNodeInfo's isHeading marks a heading, and neither reader carries it: the uiautomator dump has no such attribute and the service reader parses only class, text, description and bounds
 <!-- END GENERATED: role-support -->

--- a/docs/reference/a11y-roles.md
+++ b/docs/reference/a11y-roles.md
@@ -11,9 +11,17 @@ token the role is `Other` and the outline shows the token in brackets — `Other
 A cell reads:
 
 - `yes` — the backend produces this role.
-- `n/a` — the platform has no counterpart. The reason says why: what the platform does instead,
-  or that the concept simply does not exist there.
-- `gap` — the platform has a counterpart glass does not map yet.
+- `n/a` — no token in the vocabulary this backend reads carries the role, so no mapping could
+  reach it. That covers a concept the platform does not have and one it draws on screen without
+  marking; the reason says which, and what the control reports instead.
+- `gap` — the vocabulary does carry it and glass does not map it yet. The reason names what is
+  there and unread.
+
+Each cell is decided by putting the control on screen and reading the tree back, not from what a
+platform's API reference implies exists — a role is `n/a` only where the control was watched to
+arrive carrying no token for it. Two example apps hold those controls, one per question, so the
+reading is repeatable: [`examples/android-role-fixture/`](../../examples/android-role-fixture/)
+and [`examples/ios-role-fixture/`](../../examples/ios-role-fixture/).
 
 On Android, both readers report a `Window` root: the `uiautomator` reader wraps its dump in a
 window root sized to the app window, and the accessibility-service reader labels the active
@@ -25,35 +33,35 @@ now, and the outline only names the token of an element that has none.
 |---|---|---|---|---|---|
 | `Application` | yes | n/a | gap | n/a | yes |
 | `Window` | yes | yes | yes | yes | yes |
-| `Dialog` | yes | gap | gap | gap | gap |
+| `Dialog` | yes | gap | gap | n/a | n/a |
 | `Group` | yes | yes | yes | yes | yes |
 | `Button` | yes | yes | yes | yes | yes |
 | `ToggleButton` | yes | yes | gap | yes | yes |
-| `RadioButton` | yes | yes | yes | yes | gap |
+| `RadioButton` | yes | yes | yes | yes | n/a |
 | `CheckBox` | yes | yes | yes | yes | yes |
 | `MenuBar` | yes | yes | yes | n/a | n/a |
-| `Menu` | yes | yes | yes | gap | gap |
-| `MenuItem` | yes | yes | yes | gap | gap |
+| `Menu` | yes | yes | yes | n/a | n/a |
+| `MenuItem` | yes | yes | yes | n/a | n/a |
 | `Label` | yes | yes | yes | yes | yes |
 | `TextField` | yes | yes | yes | yes | yes |
 | `TextArea` | yes | yes | yes | n/a | yes |
-| `ComboBox` | yes | yes | yes | yes | gap |
-| `List` | yes | yes | yes | yes | gap |
-| `ListItem` | yes | yes | yes | gap | gap |
-| `Table` | yes | yes | gap | gap | gap |
+| `ComboBox` | yes | yes | yes | yes | n/a |
+| `List` | yes | yes | yes | yes | n/a |
+| `ListItem` | yes | yes | yes | gap | n/a |
+| `Table` | yes | yes | gap | gap | n/a |
 | `Cell` | yes | gap | yes | gap | yes |
 | `Tree` | yes | yes | yes | n/a | n/a |
 | `TreeItem` | yes | yes | yes | n/a | n/a |
 | `TabList` | yes | yes | yes | gap | yes |
-| `Tab` | yes | yes | gap | gap | gap |
+| `Tab` | yes | yes | gap | gap | n/a |
 | `ScrollBar` | yes | yes | yes | n/a | n/a |
 | `Slider` | yes | yes | yes | yes | yes |
-| `SpinButton` | yes | yes | gap | gap | gap |
-| `ProgressBar` | yes | yes | yes | yes | gap |
+| `SpinButton` | yes | yes | gap | gap | n/a |
+| `ProgressBar` | yes | yes | yes | yes | n/a |
 | `Image` | yes | yes | yes | yes | yes |
 | `Link` | yes | yes | yes | n/a | yes |
 | `Separator` | yes | yes | yes | n/a | n/a |
-| `Toolbar` | yes | yes | yes | gap | yes |
+| `Toolbar` | yes | yes | yes | n/a | yes |
 | `StatusBar` | yes | yes | n/a | n/a | n/a |
 | `Heading` | yes | gap | yes | gap | yes |
 
@@ -64,44 +72,44 @@ now, and the outline only names the token of an element that has none.
 - `Application` / Android — n/a: Android exposes windows, not an application element
 - `Dialog` / Windows (UIA) — gap: UIA marks a dialog with the IsDialog property on a Window; the reader does not read it
 - `Dialog` / macOS (AX) — gap: AXSheet, AXPopover and AXDrawer are not mapped yet
-- `Dialog` / Android — gap: dialog windows arrive as a generic layout class
-- `Dialog` / iOS — gap: an alert exposes its buttons and text directly under the application element; no alert, sheet or popover token appears
+- `Dialog` / Android — n/a: an AlertDialog's panels report FrameLayout and LinearLayout, and Android has no dialog window type; nothing in the vocabulary marks a dialog
+- `Dialog` / iOS — n/a: an alert exposes its title, message and buttons directly under the application element; no alert, sheet or popover token appears
 - `ToggleButton` / macOS (AX) — gap: AppKit reports a switch as AXCheckBox with an AXSwitch or AXToggle subrole; AXCheckBox is outside the reader's subrole gate, and no probed app emitted either subrole
-- `RadioButton` / iOS — gap: no radio token is mapped yet
+- `RadioButton` / iOS — n/a: UIKit has no radio control; a UISegmentedControl — the nearest equivalent — reports one AXTabGroup with no per-segment element
 - `MenuBar` / Android — n/a: Android apps have no menu bar
 - `MenuBar` / iOS — n/a: iOS apps have no menu bar
-- `Menu` / Android — gap: popup menus arrive as list or layout classes
-- `Menu` / iOS — gap: context-menu tokens are not mapped yet
-- `MenuItem` / Android — gap: menu entries arrive as their own widget class
-- `MenuItem` / iOS — gap: menu-item tokens are not mapped yet
+- `Menu` / Android — n/a: a popup menu reports android.widget.ListView; no menu token appears anywhere in the tree it opens
+- `Menu` / iOS — n/a: a UIMenu opens as an AXGroup of AXButtons alongside a Dismiss context menu button; no menu token appears
+- `MenuItem` / Android — n/a: a menu entry reports its item view's layout class — a LinearLayout or RelativeLayout holding a TextView title
+- `MenuItem` / iOS — n/a: a menu entry reports AXButton, the same token as any other button
 - `TextArea` / Android — n/a: Android uses one editable class for single- and multi-line text
-- `ComboBox` / iOS — gap: picker tokens are not mapped yet
-- `List` / iOS — gap: collections arrive as AXGroup, which maps to Group; no list token appears
-- `ListItem` / Android — gap: list children report their own widget class, not a list-item role
-- `ListItem` / iOS — gap: a collection's children report their own element role, not a list-item role
+- `ComboBox` / iOS — n/a: a UIPickerView reports AXSlider and a SwiftUI Picker reports a heading with buttons; no picker token appears
+- `List` / iOS — n/a: a UITableView and a SwiftUI List both report AXGroup, and their rows report AXStaticText; no list token appears
+- `ListItem` / Android — gap: a list child reports its own widget class; the row and column live in AccessibilityNodeInfo's CollectionItemInfo, which the uiautomator dump has no attribute for and the service protocol does not send
+- `ListItem` / iOS — n/a: table and collection rows report AXStaticText, including a cell explicitly exposed as its own accessibility element
 - `Table` / macOS (AX) — gap: mac lists report AXOutline rather than AXTable; AXOutline maps to Tree
-- `Table` / Android — gap: table and grid classes collapse into List
-- `Table` / iOS — gap: collections arrive as AXGroup, which maps to Group; no table token appears
+- `Table` / Android — gap: android.widget.TableLayout and TableRow do arrive — the container rule folds any leaf ending in Layout into Group — and GridView maps to List; CollectionInfo's row and column counts reach neither reader
+- `Table` / iOS — n/a: a table view reports AXGroup like any other container; no table token appears
 - `Cell` / Windows (UIA) — gap: UIA's DataItem control type would carry this, but the data grids probed expose their rows as TreeItem
-- `Cell` / Android — gap: no cell class is mapped yet
+- `Cell` / Android — gap: no cell class exists — a cell is whatever view the app put in the row; the row and column index live in CollectionItemInfo, which reaches neither reader
 - `Tree` / Android — n/a: Android has no tree widget
 - `Tree` / iOS — n/a: UIKit has no outline view
 - `TreeItem` / Android — n/a: Android has no tree widget
 - `TreeItem` / iOS — n/a: UIKit has no outline view
-- `TabList` / Android — gap: a tab container reports a plain layout class; the tab role lives in the view's id and selected state, not in the class name
+- `TabList` / Android — gap: android.widget.TabWidget and TabHost do arrive as tokens and are not mapped yet; a Material tab strip reports a plain layout class instead
 - `Tab` / macOS (AX) — gap: AppKit reports tab items as AXRadioButton inside the tab group; the containing role is not used to disambiguate yet
-- `Tab` / Android — gap: a tab reports a plain layout class with selected=true; nothing in the class name marks it as a tab
-- `Tab` / iOS — gap: the tab bars seen in probing arrived as AXGroup, named by the element identifier rather than the role, and no tab-item token appeared
+- `Tab` / Android — gap: a tab reports a plain layout class with selected=true — under a TabWidget parent in the framework widget, named only by the view id in a Material tab strip — so nothing in the class name marks it as a tab
+- `Tab` / iOS — n/a: a tab bar reports AXGroup and its items are not exposed as elements at all; a segmented control reports one AXTabGroup with no per-segment element
 - `ScrollBar` / Android — n/a: Android scrollbars are drawn, not exposed as nodes
 - `ScrollBar` / iOS — n/a: UIKit scroll indicators are not accessibility elements
 - `SpinButton` / macOS (AX) — gap: AXIncrementor is not mapped yet
-- `SpinButton` / Android — gap: the number-picker class is not mapped yet
-- `SpinButton` / iOS — gap: the stepper token is not mapped yet
-- `ProgressBar` / iOS — gap: no progress token is mapped yet
+- `SpinButton` / Android — gap: android.widget.NumberPicker does arrive as a token and is not mapped yet
+- `SpinButton` / iOS — n/a: a UIStepper decomposes into two AXButtons labelled Decrement and Increment; no stepper token appears
+- `ProgressBar` / iOS — n/a: a UIProgressView reports AXGenericElement carrying its percentage as the value; no progress token appears
 - `Link` / Android — n/a: Android links are spans inside a text view, not separate nodes
 - `Separator` / Android — n/a: Android dividers are drawn, not exposed as nodes
 - `Separator` / iOS — n/a: UIKit exposes no separator element
-- `Toolbar` / Android — gap: the toolbar class is not mapped yet
+- `Toolbar` / Android — n/a: android.widget.Toolbar reports android.view.ViewGroup, so no toolbar token reaches either reader
 - `StatusBar` / macOS (AX) — n/a: AppKit exposes status items as menu-bar items
 - `StatusBar` / Android — n/a: the system status bar is outside the app tree
 - `StatusBar` / iOS — n/a: the system status bar is outside the app tree

--- a/docs/reference/a11y-roles.md
+++ b/docs/reference/a11y-roles.md
@@ -27,10 +27,11 @@ simply does not have — a radio button on iOS, a tree on Android — rest on it
 and say so. A `yes` is map-backed, not reading-backed: it says a token is mapped, not that an app
 was seen to emit it.
 
-Reasons are readings, and readings age. The Android and iOS columns were last read on 2026-07-25,
-against an API 34 emulator and an iOS 26.5 Simulator, and the Windows `Heading` cell the same day
-against Edge on Windows 11. What the iOS column can say is bounded by what `idb`'s accessibility
-tree exposes, which may be narrower than what UIKit publishes to VoiceOver.
+Reasons are readings, not guarantees: each says what a control was seen to report, and a platform
+is free to change that. When a cell was last read is answered by `git log` over
+`crates/glass-core/src/role_support.rs`, and what it was read against by re-running the fixture,
+which prints its platform version. What the iOS column can say is also bounded by what `idb`'s
+accessibility tree exposes, which may be narrower than what UIKit publishes to VoiceOver.
 
 On Android, both readers report a `Window` root: the `uiautomator` reader wraps its dump in a
 window root sized to the app window, and the accessibility-service reader labels the active

--- a/docs/reference/a11y-roles.md
+++ b/docs/reference/a11y-roles.md
@@ -77,49 +77,49 @@ now, and the outline only names the token of an element that has none.
 
 ### Why a cell is not `yes`
 
-- `Application` / Windows (UIA) — n/a: UIA has no application control type; the app root is a Window
-- `Application` / macOS (AX) — gap: AXApplication is the app element but is not mapped yet
+- `Application` / Windows (UIA) — n/a (reports `Window` instead): UIA has no application control type; the app root is a Window
+- `Application` / macOS (AX) — gap (`AXApplication` arrives unmapped): AXApplication is the app element but is not mapped yet
 - `Application` / Android — n/a: Android exposes windows, not an application element
 - `Dialog` / Windows (UIA) — gap: UIA marks a dialog with the IsDialog property on a Window; the reader does not read it
-- `Dialog` / macOS (AX) — gap: AXSheet, AXPopover and AXDrawer are not mapped yet
-- `Dialog` / Android — n/a: a framework AlertDialog's panels report FrameLayout and LinearLayout under android:id/parentPanel, and AccessibilityWindowInfo's window types carry no dialog kind for a reader to fall back on
+- `Dialog` / macOS (AX) — gap (`AXSheet` arrives unmapped): AXSheet, AXPopover and AXDrawer are not mapped yet
+- `Dialog` / Android — n/a (reports `android.widget.FrameLayout` instead): a framework AlertDialog's panels report FrameLayout and LinearLayout under android:id/parentPanel, and AccessibilityWindowInfo's window types carry no dialog kind for a reader to fall back on
 - `Dialog` / iOS — n/a: an alert and an action sheet each expose their title, message and buttons directly under the application element, with no container token between
-- `ToggleButton` / macOS (AX) — gap: AppKit reports a switch as AXCheckBox with an AXSwitch or AXToggle subrole; AXCheckBox is outside the reader's subrole gate, and no probed app emitted either subrole
-- `RadioButton` / iOS — n/a: UIKit has no radio control; a UISegmentedControl — the nearest equivalent — reports one AXTabGroup with no per-segment element
+- `ToggleButton` / macOS (AX) — gap (`AXCheckBox` arrives unmapped): AppKit reports a switch as AXCheckBox with an AXSwitch or AXToggle subrole; AXCheckBox is outside the reader's subrole gate, and no probed app emitted either subrole
+- `RadioButton` / iOS — n/a (reports `AXTabGroup` instead): UIKit has no radio control; a UISegmentedControl — the nearest equivalent — reports one AXTabGroup with no per-segment element
 - `MenuBar` / Android — n/a: Android apps have no menu bar
 - `MenuBar` / iOS — n/a: iOS apps have no menu bar
-- `Menu` / Android — n/a: a popup menu reports android.widget.ListView; no menu token appears anywhere in the tree it opens
-- `Menu` / iOS — n/a: a button's pull-down UIMenu opens as an AXGroup of AXButtons alongside a Dismiss context menu button; no menu token appears
-- `MenuItem` / Android — n/a: a menu entry reports its item view's layout class — a LinearLayout or RelativeLayout holding a TextView title
-- `MenuItem` / iOS — n/a: a menu entry reports AXButton, the same token as any other button
-- `TextArea` / Android — n/a: Android uses one editable class for single- and multi-line text
-- `ComboBox` / iOS — gap: a menu-style SwiftUI Picker reports AXPopUpButton, which is not mapped yet; the inline style reports a heading with buttons, and a UIPickerView reports AXSlider
-- `List` / iOS — n/a: a UITableView and a SwiftUI List both report AXGroup, and their rows report AXStaticText; no list token appears
+- `Menu` / Android — n/a (reports `android.widget.ListView` instead): a popup menu reports android.widget.ListView; no menu token appears anywhere in the tree it opens
+- `Menu` / iOS — n/a (reports `AXGroup` instead): a button's pull-down UIMenu opens as an AXGroup of AXButtons alongside a Dismiss context menu button; no menu token appears
+- `MenuItem` / Android — n/a (reports `android.widget.LinearLayout` instead): a menu entry reports its item view's layout class — a LinearLayout or RelativeLayout holding a TextView title
+- `MenuItem` / iOS — n/a (reports `AXButton` instead): a menu entry reports AXButton, the same token as any other button
+- `TextArea` / Android — n/a (reports `android.widget.EditText` instead): Android uses one editable class for single- and multi-line text
+- `ComboBox` / iOS — gap (`AXPopUpButton` arrives unmapped): a menu-style SwiftUI Picker reports AXPopUpButton, which is not mapped yet; the inline style reports a heading with buttons, and a UIPickerView reports AXSlider
+- `List` / iOS — n/a (reports `AXGroup` instead): a UITableView and a SwiftUI List both report AXGroup, and their rows report AXStaticText; no list token appears
 - `ListItem` / Android — gap: AccessibilityNodeInfo's CollectionItemInfo marks a list child, and neither reader carries it: the uiautomator dump has no such attribute and the service reader parses only class, text, description and bounds. The child's own widget class is all that arrives
-- `ListItem` / iOS — n/a: table and collection rows report AXStaticText, including a cell explicitly exposed as its own accessibility element
+- `ListItem` / iOS — n/a (reports `AXStaticText` instead): table and collection rows report AXStaticText, including a cell explicitly exposed as its own accessibility element
 - `Table` / macOS (AX) — gap: mac lists report AXOutline rather than AXTable; AXOutline maps to Tree
-- `Table` / Android — gap: android.widget.TableLayout and TableRow both arrive as tokens: TableLayout folds into Group via the container rule, TableRow lands in Other, and GridView maps to List
-- `Table` / iOS — n/a: a table view reports AXGroup like any other container; no table token appears
-- `Cell` / Windows (UIA) — gap: UIA's DataItem control type would carry this and is not mapped: the data grids probed expose their rows as TreeItem instead, though Edge does report an HTML table's header cells as DataItem
+- `Table` / Android — gap (`android.widget.TableLayout` arrives unmapped): android.widget.TableLayout and TableRow both arrive as tokens: TableLayout folds into Group via the container rule, TableRow lands in Other, and GridView maps to List
+- `Table` / iOS — n/a (reports `AXGroup` instead): a table view reports AXGroup like any other container; no table token appears
+- `Cell` / Windows (UIA) — gap (`DataItem` arrives unmapped): UIA's DataItem control type would carry this and is not mapped: the data grids probed expose their rows as TreeItem instead, though Edge does report an HTML table's header cells as DataItem
 - `Cell` / Android — gap: CollectionItemInfo holds the row and column index, and neither reader carries it: the uiautomator dump has no such attribute and the service reader parses only class, text, description and bounds. No cell class exists to fall back on — a cell is whatever view the app put in the row
 - `Tree` / Android — n/a: Android has no tree widget
 - `Tree` / iOS — n/a: UIKit has no outline view
 - `TreeItem` / Android — n/a: Android has no tree widget
 - `TreeItem` / iOS — n/a: UIKit has no outline view
-- `TabList` / Android — gap: android.widget.TabWidget and TabHost do arrive as tokens and are not mapped yet; the Material tab strips seen in stock apps report a plain layout class instead, naming their tabs only by content description
-- `Tab` / macOS (AX) — gap: AppKit reports tab items as AXRadioButton inside the tab group; the containing role is not used to disambiguate yet
+- `TabList` / Android — gap (`android.widget.TabWidget` arrives unmapped): android.widget.TabWidget and TabHost do arrive as tokens and are not mapped yet; the Material tab strips seen in stock apps report a plain layout class instead, naming their tabs only by content description
+- `Tab` / macOS (AX) — gap (`AXRadioButton` arrives unmapped): AppKit reports tab items as AXRadioButton inside the tab group; the containing role is not used to disambiguate yet
 - `Tab` / Android — gap: a framework tab arrives as a LinearLayout with selected=true under a TabWidget parent, which together identify it; the class name alone does not, and a Material tab strip carries the role in the view id instead
-- `Tab` / iOS — n/a: a tab bar reports AXGroup and no per-item element appears in idb's describe; a segmented control reports one AXTabGroup, also with no per-segment element
+- `Tab` / iOS — n/a (reports `AXGroup` instead): a tab bar reports AXGroup and no per-item element appears in idb's describe; a segmented control reports one AXTabGroup, also with no per-segment element
 - `ScrollBar` / Android — n/a: Android scrollbars are drawn, not exposed as nodes
 - `ScrollBar` / iOS — n/a: UIKit scroll indicators are not accessibility elements
-- `SpinButton` / macOS (AX) — gap: AXIncrementor is not mapped yet
-- `SpinButton` / Android — gap: android.widget.NumberPicker does arrive as a token and is not mapped yet
-- `SpinButton` / iOS — n/a: a UIStepper decomposes into two AXButtons labelled Decrement and Increment; no stepper token appears
-- `ProgressBar` / iOS — n/a: a UIProgressView reports AXGenericElement carrying its percentage as the value; no progress token appears
+- `SpinButton` / macOS (AX) — gap (`AXIncrementor` arrives unmapped): AXIncrementor is not mapped yet
+- `SpinButton` / Android — gap (`android.widget.NumberPicker` arrives unmapped): android.widget.NumberPicker does arrive as a token and is not mapped yet
+- `SpinButton` / iOS — n/a (reports `AXButton` instead): a UIStepper decomposes into two AXButtons labelled Decrement and Increment; no stepper token appears
+- `ProgressBar` / iOS — n/a (reports `AXGenericElement` instead): a UIProgressView reports AXGenericElement carrying its percentage as the value; no progress token appears
 - `Link` / Android — n/a: Android links are spans inside a text view, not separate nodes
 - `Separator` / Android — n/a: Android dividers are drawn, not exposed as nodes
 - `Separator` / iOS — n/a: UIKit exposes no separator element
-- `Toolbar` / Android — n/a: android.widget.Toolbar was watched to report android.view.ViewGroup — a subclass inherits the accessibility class name of the framework class it extends, and the AppCompat and Material toolbars override neither, so all three arrive as ViewGroup
+- `Toolbar` / Android — n/a (reports `android.view.ViewGroup` instead): android.widget.Toolbar was watched to report android.view.ViewGroup — a subclass inherits the accessibility class name of the framework class it extends, and the AppCompat and Material toolbars override neither, so all three arrive as ViewGroup
 - `StatusBar` / macOS (AX) — n/a: AppKit exposes status items as menu-bar items
 - `StatusBar` / Android — n/a: the system status bar is outside the app tree
 - `StatusBar` / iOS — n/a: the system status bar is outside the app tree

--- a/docs/reference/a11y-roles.md
+++ b/docs/reference/a11y-roles.md
@@ -28,9 +28,9 @@ and say so. A `yes` is map-backed, not reading-backed: it says a token is mapped
 was seen to emit it.
 
 Reasons are readings, and readings age. The Android and iOS columns were last read on 2026-07-25,
-against an API 34 emulator and an iOS 26.5 Simulator. What the iOS column can say is bounded by
-what `idb`'s accessibility tree exposes, which may be narrower than what UIKit publishes to
-VoiceOver.
+against an API 34 emulator and an iOS 26.5 Simulator, and the Windows `Heading` cell the same day
+against Edge on Windows 11. What the iOS column can say is bounded by what `idb`'s accessibility
+tree exposes, which may be narrower than what UIKit publishes to VoiceOver.
 
 On Android, both readers report a `Window` root: the `uiautomator` reader wraps its dump in a
 window root sized to the app window, and the accessibility-service reader labels the active
@@ -99,7 +99,7 @@ now, and the outline only names the token of an element that has none.
 - `Table` / macOS (AX) — gap: mac lists report AXOutline rather than AXTable; AXOutline maps to Tree
 - `Table` / Android — gap: android.widget.TableLayout and TableRow both arrive as tokens: TableLayout folds into Group via the container rule, TableRow lands in Other, and GridView maps to List
 - `Table` / iOS — n/a: a table view reports AXGroup like any other container; no table token appears
-- `Cell` / Windows (UIA) — gap: UIA's DataItem control type would carry this, but the data grids probed expose their rows as TreeItem
+- `Cell` / Windows (UIA) — gap: UIA's DataItem control type would carry this and is not mapped: the data grids probed expose their rows as TreeItem instead, though Edge does report an HTML table's header cells as DataItem
 - `Cell` / Android — gap: CollectionItemInfo holds the row and column index, and neither reader carries it: the uiautomator dump has no such attribute and the service reader parses only class, text, description and bounds. No cell class exists to fall back on — a cell is whatever view the app put in the row
 - `Tree` / Android — n/a: Android has no tree widget
 - `Tree` / iOS — n/a: UIKit has no outline view
@@ -122,6 +122,6 @@ now, and the outline only names the token of an element that has none.
 - `StatusBar` / macOS (AX) — n/a: AppKit exposes status items as menu-bar items
 - `StatusBar` / Android — n/a: the system status bar is outside the app tree
 - `StatusBar` / iOS — n/a: the system status bar is outside the app tree
-- `Heading` / Windows (UIA) — gap: UIA's Header and HeaderItem are grid column headers, not document headings; the normalized set has no column-header role
+- `Heading` / Windows (UIA) — gap: UIA marks a heading with the HeadingLevel property — an h1 arrives as Text carrying level 80051 — and the reader maps by control type alone, so it never sees it. Header and HeaderItem are a grid's column headers, a different concept the normalized set has no role for
 - `Heading` / Android — gap: AccessibilityNodeInfo's isHeading marks a heading, and neither reader carries it: the uiautomator dump has no such attribute and the service reader parses only class, text, description and bounds
 <!-- END GENERATED: role-support -->

--- a/docs/reference/a11y-roles.md
+++ b/docs/reference/a11y-roles.md
@@ -14,18 +14,29 @@ A cell reads:
 - `gap` — closing it is glass's own work. The platform carries the role somewhere glass reads or
   could read — a token that arrives unmapped, a documented field the reader ignores, a protocol
   its own companion could send — and the reason names what is there and unread.
-- `n/a` — closing it would take a platform change. Either the platform has no such control, or it
-  draws one its accessibility layer never marks; the reason says which, and what the control
-  reports instead.
+- `absent` — the platform has no such control to expose. iOS has no radio button, Android no tree
+  widget; there is nothing to read.
+- `unmarked` — the control exists and was put on screen, and no reading found a token carrying its
+  role: it is drawn but not exposed, or folded into a token meaning something else. The reason
+  names what it reported instead.
+- `elsewhere` — the control exists and is exposed, but outside what glass walks. The system status
+  bar belongs to the OS shell, not to the app whose tree is being read.
 
-Where there is a control to look at, `gap` and `n/a` are decided by putting it on screen and
-reading the tree back rather than from what a platform's API reference implies. Two example apps
-hold those controls, one per question, so the reading is repeatable:
+**`unmarked` is a reading, not a proof.** It says the standard controls were watched on one OS
+version through one reader and nothing carried the role — not that nothing can. Two of the three
+vocabularies are open, so the question cannot be closed by any amount of reading: an Android app
+sets its own `AccessibilityNodeInfo` class name and may report anything, and iOS role strings come
+from the Simulator's translator. Only UIA names a closed, documented set of control types. Treat
+`unmarked` as "do not expect this role here", not as "this role is impossible here" — and if an
+app you drive does expose one, that is a cell to correct, not a contradiction.
+
+Where there is a control to look at, the cell is decided by putting it on screen and reading the
+tree back rather than from what a platform's API reference implies. Two example apps hold those
+controls, one per question, so the reading is repeatable:
 [`examples/android-role-fixture/`](../../examples/android-role-fixture/) and
-[`examples/ios-role-fixture/`](../../examples/ios-role-fixture/). Cells for a control a platform
-simply does not have — a radio button on iOS, a tree on Android — rest on its vocabulary instead
-and say so. A `yes` is map-backed, not reading-backed: it says a token is mapped, not that an app
-was seen to emit it.
+[`examples/ios-role-fixture/`](../../examples/ios-role-fixture/). A `yes` is the one state that is
+map-backed rather than reading-backed: it says a token is mapped, not that an app was seen to
+emit it.
 
 Reasons are readings, not guarantees: each says what a control was seen to report, and a platform
 is free to change that. When a cell was last read is answered by `git log` over
@@ -41,88 +52,88 @@ now, and the outline only names the token of an element that has none.
 <!-- BEGIN GENERATED: role-support -->
 | Role | Linux (AT-SPI) | Windows (UIA) | macOS (AX) | Android | iOS |
 |---|---|---|---|---|---|
-| `Application` | yes | n/a | gap | n/a | yes |
+| `Application` | yes | unmarked | gap | absent | yes |
 | `Window` | yes | yes | yes | yes | yes |
-| `Dialog` | yes | gap | gap | n/a | n/a |
+| `Dialog` | yes | gap | gap | unmarked | unmarked |
 | `Group` | yes | yes | yes | yes | yes |
 | `Button` | yes | yes | yes | yes | yes |
 | `ToggleButton` | yes | yes | gap | yes | yes |
-| `RadioButton` | yes | yes | yes | yes | n/a |
+| `RadioButton` | yes | yes | yes | yes | absent |
 | `CheckBox` | yes | yes | yes | yes | yes |
-| `MenuBar` | yes | yes | yes | n/a | n/a |
-| `Menu` | yes | yes | yes | n/a | n/a |
-| `MenuItem` | yes | yes | yes | n/a | n/a |
+| `MenuBar` | yes | yes | yes | absent | absent |
+| `Menu` | yes | yes | yes | unmarked | unmarked |
+| `MenuItem` | yes | yes | yes | unmarked | unmarked |
 | `Label` | yes | yes | yes | yes | yes |
 | `TextField` | yes | yes | yes | yes | yes |
-| `TextArea` | yes | yes | yes | n/a | yes |
+| `TextArea` | yes | yes | yes | unmarked | yes |
 | `ComboBox` | yes | yes | yes | yes | gap |
-| `List` | yes | yes | yes | yes | n/a |
-| `ListItem` | yes | yes | yes | gap | n/a |
-| `Table` | yes | yes | gap | gap | n/a |
+| `List` | yes | yes | yes | yes | unmarked |
+| `ListItem` | yes | yes | yes | gap | unmarked |
+| `Table` | yes | yes | gap | gap | unmarked |
 | `Cell` | yes | gap | yes | gap | yes |
-| `Tree` | yes | yes | yes | n/a | n/a |
-| `TreeItem` | yes | yes | yes | n/a | n/a |
+| `Tree` | yes | yes | yes | absent | absent |
+| `TreeItem` | yes | yes | yes | absent | absent |
 | `TabList` | yes | yes | yes | gap | yes |
-| `Tab` | yes | yes | gap | gap | n/a |
-| `ScrollBar` | yes | yes | yes | n/a | n/a |
+| `Tab` | yes | yes | gap | gap | unmarked |
+| `ScrollBar` | yes | yes | yes | unmarked | unmarked |
 | `Slider` | yes | yes | yes | yes | yes |
-| `SpinButton` | yes | yes | gap | gap | n/a |
-| `ProgressBar` | yes | yes | yes | yes | n/a |
+| `SpinButton` | yes | yes | gap | gap | unmarked |
+| `ProgressBar` | yes | yes | yes | yes | unmarked |
 | `Image` | yes | yes | yes | yes | yes |
-| `Link` | yes | yes | yes | n/a | yes |
-| `Separator` | yes | yes | yes | n/a | n/a |
-| `Toolbar` | yes | yes | yes | n/a | yes |
-| `StatusBar` | yes | yes | n/a | n/a | n/a |
+| `Link` | yes | yes | yes | unmarked | yes |
+| `Separator` | yes | yes | yes | unmarked | unmarked |
+| `Toolbar` | yes | yes | yes | unmarked | yes |
+| `StatusBar` | yes | yes | unmarked | elsewhere | elsewhere |
 | `Heading` | yes | gap | yes | gap | yes |
 
 ### Why a cell is not `yes`
 
-- `Application` / Windows (UIA) — n/a (reports `Window` instead): UIA has no application control type; the app root is a Window
+- `Application` / Windows (UIA) — unmarked (reports `Window` instead): UIA has no application control type; the app root is a Window
 - `Application` / macOS (AX) — gap (`AXApplication` arrives unmapped): AXApplication is the app element but is not mapped yet
-- `Application` / Android — n/a: Android exposes windows, not an application element
+- `Application` / Android — absent: Android exposes windows, not an application element
 - `Dialog` / Windows (UIA) — gap: UIA marks a dialog with the IsDialog property on a Window; the reader does not read it
 - `Dialog` / macOS (AX) — gap (`AXSheet` arrives unmapped): AXSheet, AXPopover and AXDrawer are not mapped yet
-- `Dialog` / Android — n/a (reports `android.widget.FrameLayout` instead): a framework AlertDialog's panels report FrameLayout and LinearLayout under android:id/parentPanel, and AccessibilityWindowInfo's window types carry no dialog kind for a reader to fall back on
-- `Dialog` / iOS — n/a: an alert and an action sheet each expose their title, message and buttons directly under the application element, with no container token between
+- `Dialog` / Android — unmarked (reports `android.widget.FrameLayout` instead): a framework AlertDialog's panels report FrameLayout and LinearLayout under android:id/parentPanel, and AccessibilityWindowInfo's window types carry no dialog kind for a reader to fall back on
+- `Dialog` / iOS — unmarked: an alert and an action sheet each expose their title, message and buttons directly under the application element, with no container token between
 - `ToggleButton` / macOS (AX) — gap (`AXCheckBox` arrives unmapped): AppKit reports a switch as AXCheckBox with an AXSwitch or AXToggle subrole; AXCheckBox is outside the reader's subrole gate, and no probed app emitted either subrole
-- `RadioButton` / iOS — n/a (reports `AXTabGroup` instead): UIKit has no radio control; a UISegmentedControl — the nearest equivalent — reports one AXTabGroup with no per-segment element
-- `MenuBar` / Android — n/a: Android apps have no menu bar
-- `MenuBar` / iOS — n/a: iOS apps have no menu bar
-- `Menu` / Android — n/a (reports `android.widget.ListView` instead): a popup menu reports android.widget.ListView; no menu token appears anywhere in the tree it opens
-- `Menu` / iOS — n/a (reports `AXGroup` instead): a button's pull-down UIMenu opens as an AXGroup of AXButtons alongside a Dismiss context menu button; no menu token appears
-- `MenuItem` / Android — n/a (reports `android.widget.LinearLayout` instead): a menu entry reports its item view's layout class — a LinearLayout or RelativeLayout holding a TextView title
-- `MenuItem` / iOS — n/a (reports `AXButton` instead): a menu entry reports AXButton, the same token as any other button
-- `TextArea` / Android — n/a (reports `android.widget.EditText` instead): Android uses one editable class for single- and multi-line text
+- `RadioButton` / iOS — absent: UIKit has no radio control; a UISegmentedControl — the nearest equivalent — reports one AXTabGroup with no per-segment element
+- `MenuBar` / Android — absent: Android apps have no menu bar
+- `MenuBar` / iOS — absent: iOS apps have no menu bar
+- `Menu` / Android — unmarked (reports `android.widget.ListView` instead): a popup menu reports android.widget.ListView; no menu token appears anywhere in the tree it opens
+- `Menu` / iOS — unmarked (reports `AXGroup` instead): a button's pull-down UIMenu opens as an AXGroup of AXButtons alongside a Dismiss context menu button; no menu token appears
+- `MenuItem` / Android — unmarked (reports `android.widget.LinearLayout` instead): a menu entry reports its item view's layout class — a LinearLayout or RelativeLayout holding a TextView title
+- `MenuItem` / iOS — unmarked (reports `AXButton` instead): a menu entry reports AXButton, the same token as any other button
+- `TextArea` / Android — unmarked (reports `android.widget.EditText` instead): Android uses one editable class for single- and multi-line text
 - `ComboBox` / iOS — gap (`AXPopUpButton` arrives unmapped): a menu-style SwiftUI Picker reports AXPopUpButton, which is not mapped yet; the inline style reports a heading with buttons, and a UIPickerView reports AXSlider
-- `List` / iOS — n/a (reports `AXGroup` instead): a UITableView and a SwiftUI List both report AXGroup, and their rows report AXStaticText; no list token appears
+- `List` / iOS — unmarked (reports `AXGroup` instead): a UITableView and a SwiftUI List both report AXGroup, and their rows report AXStaticText; no list token appears
 - `ListItem` / Android — gap: AccessibilityNodeInfo's CollectionItemInfo marks a list child, and neither reader carries it: the uiautomator dump has no such attribute and the service reader parses only class, text, description and bounds. The child's own widget class is all that arrives
-- `ListItem` / iOS — n/a (reports `AXStaticText` instead): table and collection rows report AXStaticText, including a cell explicitly exposed as its own accessibility element
+- `ListItem` / iOS — unmarked (reports `AXStaticText` instead): table and collection rows report AXStaticText, including a cell explicitly exposed as its own accessibility element
 - `Table` / macOS (AX) — gap: mac lists report AXOutline rather than AXTable; AXOutline maps to Tree
 - `Table` / Android — gap (`android.widget.TableLayout` arrives unmapped): android.widget.TableLayout and TableRow both arrive as tokens: TableLayout folds into Group via the container rule, TableRow lands in Other, and GridView maps to List
-- `Table` / iOS — n/a (reports `AXGroup` instead): a table view reports AXGroup like any other container; no table token appears
+- `Table` / iOS — unmarked (reports `AXGroup` instead): a table view reports AXGroup like any other container; no table token appears
 - `Cell` / Windows (UIA) — gap (`DataItem` arrives unmapped): UIA's DataItem control type would carry this and is not mapped: the data grids probed expose their rows as TreeItem instead, though Edge does report an HTML table's header cells as DataItem
 - `Cell` / Android — gap: CollectionItemInfo holds the row and column index, and neither reader carries it: the uiautomator dump has no such attribute and the service reader parses only class, text, description and bounds. No cell class exists to fall back on — a cell is whatever view the app put in the row
-- `Tree` / Android — n/a: Android has no tree widget
-- `Tree` / iOS — n/a: UIKit has no outline view
-- `TreeItem` / Android — n/a: Android has no tree widget
-- `TreeItem` / iOS — n/a: UIKit has no outline view
+- `Tree` / Android — absent: Android has no tree widget
+- `Tree` / iOS — absent: UIKit has no outline view
+- `TreeItem` / Android — absent: Android has no tree widget
+- `TreeItem` / iOS — absent: UIKit has no outline view
 - `TabList` / Android — gap (`android.widget.TabWidget` arrives unmapped): android.widget.TabWidget and TabHost do arrive as tokens and are not mapped yet; the Material tab strips seen in stock apps report a plain layout class instead, naming their tabs only by content description
 - `Tab` / macOS (AX) — gap (`AXRadioButton` arrives unmapped): AppKit reports tab items as AXRadioButton inside the tab group; the containing role is not used to disambiguate yet
 - `Tab` / Android — gap: a framework tab arrives as a LinearLayout with selected=true under a TabWidget parent, which together identify it; the class name alone does not, and a Material tab strip carries the role in the view id instead
-- `Tab` / iOS — n/a (reports `AXGroup` instead): a tab bar reports AXGroup and no per-item element appears in idb's describe; a segmented control reports one AXTabGroup, also with no per-segment element
-- `ScrollBar` / Android — n/a: Android scrollbars are drawn, not exposed as nodes
-- `ScrollBar` / iOS — n/a: UIKit scroll indicators are not accessibility elements
+- `Tab` / iOS — unmarked (reports `AXGroup` instead): a tab bar reports AXGroup and no per-item element appears in idb's describe; a segmented control reports one AXTabGroup, also with no per-segment element
+- `ScrollBar` / Android — unmarked: Android scrollbars are drawn, not exposed as nodes
+- `ScrollBar` / iOS — unmarked: UIKit scroll indicators are not accessibility elements
 - `SpinButton` / macOS (AX) — gap (`AXIncrementor` arrives unmapped): AXIncrementor is not mapped yet
 - `SpinButton` / Android — gap (`android.widget.NumberPicker` arrives unmapped): android.widget.NumberPicker does arrive as a token and is not mapped yet
-- `SpinButton` / iOS — n/a (reports `AXButton` instead): a UIStepper decomposes into two AXButtons labelled Decrement and Increment; no stepper token appears
-- `ProgressBar` / iOS — n/a (reports `AXGenericElement` instead): a UIProgressView reports AXGenericElement carrying its percentage as the value; no progress token appears
-- `Link` / Android — n/a: Android links are spans inside a text view, not separate nodes
-- `Separator` / Android — n/a: Android dividers are drawn, not exposed as nodes
-- `Separator` / iOS — n/a: UIKit exposes no separator element
-- `Toolbar` / Android — n/a (reports `android.view.ViewGroup` instead): android.widget.Toolbar was watched to report android.view.ViewGroup — a subclass inherits the accessibility class name of the framework class it extends, and the AppCompat and Material toolbars override neither, so all three arrive as ViewGroup
-- `StatusBar` / macOS (AX) — n/a: AppKit exposes status items as menu-bar items
-- `StatusBar` / Android — n/a: the system status bar is outside the app tree
-- `StatusBar` / iOS — n/a: the system status bar is outside the app tree
+- `SpinButton` / iOS — unmarked (reports `AXButton` instead): a UIStepper decomposes into two AXButtons labelled Decrement and Increment; no stepper token appears
+- `ProgressBar` / iOS — unmarked (reports `AXGenericElement` instead): a UIProgressView reports AXGenericElement carrying its percentage as the value; no progress token appears
+- `Link` / Android — unmarked: Android links are spans inside a text view, not separate nodes
+- `Separator` / Android — unmarked: Android dividers are drawn, not exposed as nodes
+- `Separator` / iOS — unmarked: UIKit exposes no separator element
+- `Toolbar` / Android — unmarked (reports `android.view.ViewGroup` instead): android.widget.Toolbar was watched to report android.view.ViewGroup — a subclass inherits the accessibility class name of the framework class it extends, and the AppCompat and Material toolbars override neither, so all three arrive as ViewGroup
+- `StatusBar` / macOS (AX) — unmarked: AppKit exposes status items as menu-bar items
+- `StatusBar` / Android — elsewhere: the system status bar is outside the app tree
+- `StatusBar` / iOS — elsewhere: the system status bar is outside the app tree
 - `Heading` / Windows (UIA) — gap: UIA marks a heading with the HeadingLevel property — an h1 arrives as Text carrying level 80051 — and the reader maps by control type alone, so it never sees it. Header and HeaderItem are a grid's column headers, a different concept the normalized set has no role for
 - `Heading` / Android — gap: AccessibilityNodeInfo's isHeading marks a heading, and neither reader carries it: the uiautomator dump has no such attribute and the service reader parses only class, text, description and bounds
 <!-- END GENERATED: role-support -->

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,3 +8,7 @@ Small apps for trying glass's build → see → interact → debug loop. Each li
   [Drive a native iOS app](../docs/how-to/drive-an-ios-app.md).
 - [`ios-fixture/`](ios-fixture/) — the SwiftUI app the `glass-ios` on-box tests drive: four
   elements with stable accessibility identifiers, plus a launch-time log marker.
+- [`android-role-fixture/`](android-role-fixture/) — stock `android.widget` controls, one per
+  question about what Android's accessibility vocabulary can express. Builds without Gradle.
+- [`ios-role-fixture/`](ios-role-fixture/) — the same for UIKit and SwiftUI. Both back the cells
+  in [docs/reference/a11y-roles.md](../docs/reference/a11y-roles.md).

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,8 @@ Small apps for trying glass's build → see → interact → debug loop. Each li
   [Drive a native iOS app](../docs/how-to/drive-an-ios-app.md).
 - [`ios-fixture/`](ios-fixture/) — the SwiftUI app the `glass-ios` on-box tests drive: four
   elements with stable accessibility identifiers, plus a launch-time log marker.
-- [`android-role-fixture/`](android-role-fixture/) — stock `android.widget` controls, one per
-  question about what Android's accessibility vocabulary can express. Builds without Gradle.
-- [`ios-role-fixture/`](ios-role-fixture/) — the same for UIKit and SwiftUI. Both back the cells
-  in [docs/reference/a11y-roles.md](../docs/reference/a11y-roles.md).
+- [`android-role-fixture/`](android-role-fixture/) and
+  [`ios-role-fixture/`](ios-role-fixture/) — one screen of stock platform controls each, one
+  control per question about what that platform's accessibility vocabulary can express. They are
+  the readings behind [docs/reference/a11y-roles.md](../docs/reference/a11y-roles.md); the Android
+  one builds without Gradle.

--- a/examples/android-role-fixture/AndroidManifest.xml
+++ b/examples/android-role-fixture/AndroidManifest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="tech.fixedwidth.glassrolefixture">
+    <application android:label="Glass Role Fixture">
+        <activity android:name=".MainActivity" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/examples/android-role-fixture/README.md
+++ b/examples/android-role-fixture/README.md
@@ -5,7 +5,9 @@ vocabulary can express. Each control answers one question: what widget class doe
 for it? That answer is what a cell in
 [docs/reference/a11y-roles.md](../../docs/reference/a11y-roles.md) records.
 
-Readings below are from an API 34 emulator on 2026-07-25 — re-run them rather than trusting them.
+The table below is what these controls reported on an API 34 emulator — a reading, not a
+guarantee. Re-run it rather than trusting it; the read step below prints the API level it saw, and
+`build.sh` prints the platform it built against.
 
 | Control | Reported |
 |---|---|
@@ -43,6 +45,7 @@ adb shell am start -n tech.fixedwidth.glassrolefixture/.MainActivity
 Either reader answers the same question — the widget class is the token both key off.
 
 ```bash
+adb shell getprop ro.build.version.sdk      # the API level this reading is from
 adb shell uiautomator dump /sdcard/roles.xml && adb shell cat /sdcard/roles.xml
 ```
 

--- a/examples/android-role-fixture/README.md
+++ b/examples/android-role-fixture/README.md
@@ -1,0 +1,51 @@
+# android-role-fixture
+
+One screen of stock `android.widget` controls, for deciding what Android's accessibility
+vocabulary can express. Each control answers one question: what widget class does Android report
+for it? That answer is what a cell in
+[docs/reference/a11y-roles.md](../../docs/reference/a11y-roles.md) records — a role is marked
+`n/a` there only where a control was watched to arrive carrying no token for it.
+
+| Control | Reports (API 34 emulator) |
+|---|---|
+| `Toolbar` | `android.view.ViewGroup` — no toolbar token |
+| `TabHost` / `TabWidget` | themselves; a tab item is a `LinearLayout` with `selected=true` |
+| `ListView`, `GridView` | themselves; items report the item view's own class |
+| `TableLayout`, `TableRow` | themselves; a cell is whatever view the row holds |
+| `NumberPicker` | itself |
+| `ProgressBar` | itself |
+| `PopupMenu` (button) | `android.widget.ListView`, entries `LinearLayout`/`RelativeLayout` |
+| `AlertDialog` (button) | `FrameLayout`/`LinearLayout` panels under `android:id/parentPanel` |
+
+The last two need a tap. Each opens as the topmost window, so dump it separately.
+
+## Build and install
+
+Needs a JDK and an Android SDK (`ANDROID_HOME`, or `~/android-sdk`). No Gradle — the build is
+`javac` → `d8` → `aapt2` → `apksigner`, signed with a throwaway key it generates:
+
+```bash
+./build.sh                                   # → build/role-fixture.apk
+adb install -r build/role-fixture.apk
+adb shell am start -n tech.fixedwidth.glassrolefixture/.MainActivity
+```
+
+## Read the tree
+
+Either reader answers the same question — the class is the token both key off.
+
+```bash
+adb shell uiautomator dump /sdcard/roles.xml && adb shell cat /sdcard/roles.xml
+```
+
+Through glass's own probe, which prints a role histogram per app:
+
+```bash
+GLASS_A11Y_PROBE_APPS=tech.fixedwidth.glassrolefixture/.MainActivity \
+  cargo test -p glass-android --test role_probe -- --ignored --nocapture
+```
+
+Semantics Android carries outside the class name — `CollectionInfo`, `CollectionItemInfo`,
+`isHeading` — reach neither reader: the `uiautomator` dump has no attribute for them and the
+on-device service protocol does not send them. That is why those cells stay `gap` rather than
+`n/a`.

--- a/examples/android-role-fixture/README.md
+++ b/examples/android-role-fixture/README.md
@@ -3,10 +3,11 @@
 One screen of stock `android.widget` controls, for deciding what Android's accessibility
 vocabulary can express. Each control answers one question: what widget class does Android report
 for it? That answer is what a cell in
-[docs/reference/a11y-roles.md](../../docs/reference/a11y-roles.md) records — a role is marked
-`n/a` there only where a control was watched to arrive carrying no token for it.
+[docs/reference/a11y-roles.md](../../docs/reference/a11y-roles.md) records.
 
-| Control | Reports (API 34 emulator) |
+Readings below are from an API 34 emulator on 2026-07-25 — re-run them rather than trusting them.
+
+| Control | Reported |
 |---|---|
 | `Toolbar` | `android.view.ViewGroup` — no toolbar token |
 | `TabHost` / `TabWidget` | themselves; a tab item is a `LinearLayout` with `selected=true` |
@@ -19,10 +20,17 @@ for it? That answer is what a cell in
 
 The last two need a tap. Each opens as the topmost window, so dump it separately.
 
+A subclass inherits the accessibility class name of the framework class it extends unless it
+overrides `getAccessibilityClassName()` — which is why the toolbar arrives as `ViewGroup`, and why
+`androidx.appcompat.widget.Toolbar` and `MaterialToolbar`, neither of which overrides it, arrive
+that way too.
+
 ## Build and install
 
-Needs a JDK and an Android SDK (`ANDROID_HOME`, or `~/android-sdk`). No Gradle — the build is
-`javac` → `d8` → `aapt2` → `apksigner`, signed with a throwaway key it generates:
+Needs a JDK, `zip`, and an Android SDK (`ANDROID_HOME`, `ANDROID_SDK_ROOT`, or one of
+`~/Android/Sdk`, `~/Library/Android/sdk`, `~/android-sdk`). No Gradle — the build is `javac` →
+`d8` → `aapt2` → `apksigner`, signed with a throwaway key generated on first build and kept
+across rebuilds so `adb install -r` keeps working:
 
 ```bash
 ./build.sh                                   # → build/role-fixture.apk
@@ -32,7 +40,7 @@ adb shell am start -n tech.fixedwidth.glassrolefixture/.MainActivity
 
 ## Read the tree
 
-Either reader answers the same question — the class is the token both key off.
+Either reader answers the same question — the widget class is the token both key off.
 
 ```bash
 adb shell uiautomator dump /sdcard/roles.xml && adb shell cat /sdcard/roles.xml
@@ -45,7 +53,10 @@ GLASS_A11Y_PROBE_APPS=tech.fixedwidth.glassrolefixture/.MainActivity \
   cargo test -p glass-android --test role_probe -- --ignored --nocapture
 ```
 
-Semantics Android carries outside the class name — `CollectionInfo`, `CollectionItemInfo`,
-`isHeading` — reach neither reader: the `uiautomator` dump has no attribute for them and the
-on-device service protocol does not send them. That is why those cells stay `gap` rather than
-`n/a`.
+That covers the `uiautomator` reader; add `GLASS_ANDROID_A11Y_APK=<path>` to run the same probe
+through the on-device accessibility service, which otherwise skips.
+
+Semantics Android carries outside the widget class — `CollectionInfo`, `CollectionItemInfo`,
+`isHeading` — reach neither reader: the `uiautomator` dump has no attribute for them, and the
+service reader parses only class, text, description and bounds. Those cells stay `gap` rather than
+`n/a`, because closing them is glass's own work; this fixture cannot show them either way.

--- a/examples/android-role-fixture/build.sh
+++ b/examples/android-role-fixture/build.sh
@@ -1,43 +1,91 @@
 #!/usr/bin/env bash
 # Build the role fixture into an installable APK, without Gradle: javac → d8 → aapt2 → apksigner,
-# which is all this single-Activity app needs. Requires a JDK and an Android SDK with build-tools
-# and a platform android.jar.
+# which is all this single-Activity app needs. Requires a JDK (javac, keytool), `zip`, and an
+# Android SDK with build-tools and a platform android.jar.
 #
 # ANDROID_HOME (or ANDROID_SDK_ROOT) points at the SDK; the newest installed build-tools and
-# platform are used unless BUILD_TOOLS / ANDROID_PLATFORM name one.
+# platform are used unless BUILD_TOOLS / ANDROID_PLATFORM name one. What was chosen is printed,
+# because the tree an app reports depends on what it was built against.
 set -euo pipefail
 here="$(cd "$(dirname "$0")" && pwd)"
 out="$here/build"
+apk="$out/role-fixture.apk"
 
-sdk="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-$HOME/android-sdk}}"
-[ -d "$sdk" ] || { echo "no Android SDK at $sdk — set ANDROID_HOME" >&2; exit 1; }
+# The signing key lives beside the build directory, not inside it: `rm -rf "$out"` below would
+# otherwise mint a new key every build, and Android rejects an update signed with a different
+# key ("signatures do not match newer version") — turning the README's `adb install -r` into a
+# uninstall-first dance from the second build onwards.
+keystore="$here/.signing-key.jks"
 
-pick_newest() { ls "$1" 2>/dev/null | sort -V | tail -1; }
-build_tools="${BUILD_TOOLS:-$(pick_newest "$sdk/build-tools")}"
-platform="${ANDROID_PLATFORM:-$(pick_newest "$sdk/platforms")}"
+# Drop a stale APK before anything can fail: a build that aborts must not leave the previous
+# artifact sitting where the README says to install from, or the next reading comes from an
+# app that predates the change being tested.
+rm -f "$apk"
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || { echo "$2 needs $1 on PATH" >&2; exit 1; }
+}
+need javac "building the fixture"
+need keytool "signing the fixture"
+need zip "packaging the fixture"
+
+sdk="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+if [ -z "$sdk" ]; then
+  for candidate in "$HOME/Android/Sdk" "$HOME/Library/Android/sdk" "$HOME/android-sdk"; do
+    [ -d "$candidate" ] && { sdk="$candidate"; break; }
+  done
+fi
+[ -n "$sdk" ] && [ -d "$sdk" ] || {
+  echo "no Android SDK found — set ANDROID_HOME (tried \$ANDROID_HOME, \$ANDROID_SDK_ROOT, \
+~/Android/Sdk, ~/Library/Android/sdk, ~/android-sdk)" >&2
+  exit 1
+}
+
+# Newest *numeric* entry: `sort -V` would otherwise rank a preview (36.0.0-rc1, android-Baklava)
+# above every released one. `|| true` keeps a missing directory out of `set -e`'s hands so the
+# named diagnostic below runs instead of the script exiting mute.
+pick_newest() {
+  { ls "$1" 2>/dev/null || true; } | grep -E "$2" | sort -V | tail -1
+}
+build_tools="${BUILD_TOOLS:-$(pick_newest "$sdk/build-tools" '^[0-9]+(\.[0-9]+)*$')}"
+platform="${ANDROID_PLATFORM:-$(pick_newest "$sdk/platforms" '^android-[0-9]+$')}"
+[ -n "$build_tools" ] || { echo "no numbered build-tools in $sdk/build-tools" >&2; exit 1; }
+[ -n "$platform" ] || { echo "no numbered platform in $sdk/platforms" >&2; exit 1; }
+
 tools="$sdk/build-tools/$build_tools"
 android_jar="$sdk/platforms/$platform/android.jar"
-[ -x "$tools/aapt2" ] || { echo "no build-tools in $sdk/build-tools" >&2; exit 1; }
+for tool in aapt2 d8 zipalign apksigner; do
+  [ -x "$tools/$tool" ] || { echo "no $tool in $tools" >&2; exit 1; }
+done
 [ -f "$android_jar" ] || { echo "no platform jar at $android_jar" >&2; exit 1; }
+echo "building against $platform with build-tools $build_tools"
 
 rm -rf "$out"
 mkdir -p "$out/classes"
 
 javac --release 17 -classpath "$android_jar" -d "$out/classes" \
   "$here/src/tech/fixedwidth/glassrolefixture/MainActivity.java"
-"$tools/d8" --lib "$android_jar" --output "$out" $(find "$out/classes" -name '*.class')
+# -exec rather than $(find ...): the class list must survive a path containing spaces.
+find "$out/classes" -name '*.class' -exec "$tools/d8" --lib "$android_jar" --output "$out" {} +
+[ -f "$out/classes.dex" ] || { echo "d8 produced no dex" >&2; exit 1; }
 
 "$tools/aapt2" link -o "$out/unsigned.apk" -I "$android_jar" \
   --manifest "$here/AndroidManifest.xml" --min-sdk-version 24 --target-sdk-version 34
-(cd "$out" && zip -q unsigned.apk classes.dex)
+# classes*.dex, not classes.dex: d8 splits past the method limit, and a silently half-packaged
+# APK still installs and runs — until it reaches the missing code.
+(cd "$out" && zip -q unsigned.apk classes*.dex)
 
-# A throwaway signing key: Android refuses to install an unsigned APK, and nothing here is
-# distributed, so the keystore is regenerated with the build rather than checked in.
-keytool -genkeypair -keystore "$out/debug.jks" -storepass android -keypass android \
-  -alias fixture -keyalg RSA -validity 3650 -dname "CN=glass role fixture" >/dev/null 2>&1
+# A throwaway key: nothing here is distributed, so it is generated on first build rather than
+# checked in. PKCS12 is keytool's own default format, which keeps it from warning on every run.
+if [ ! -f "$keystore" ]; then
+  keytool -genkeypair -keystore "$keystore" -storetype PKCS12 \
+    -storepass android -keypass android -alias fixture -keyalg RSA -validity 3650 \
+    -dname "CN=glass role fixture" >/dev/null
+fi
 
 "$tools/zipalign" -f 4 "$out/unsigned.apk" "$out/aligned.apk"
-"$tools/apksigner" sign --ks "$out/debug.jks" --ks-pass pass:android --key-pass pass:android \
-  --out "$out/role-fixture.apk" "$out/aligned.apk"
+"$tools/apksigner" sign --ks "$keystore" --ks-pass pass:android --key-pass pass:android \
+  --out "$apk" "$out/aligned.apk"
+"$tools/apksigner" verify "$apk"
 
-echo "built: $out/role-fixture.apk"
+echo "built: $apk"

--- a/examples/android-role-fixture/build.sh
+++ b/examples/android-role-fixture/build.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Build the role fixture into an installable APK, without Gradle: javac → d8 → aapt2 → apksigner,
+# which is all this single-Activity app needs. Requires a JDK and an Android SDK with build-tools
+# and a platform android.jar.
+#
+# ANDROID_HOME (or ANDROID_SDK_ROOT) points at the SDK; the newest installed build-tools and
+# platform are used unless BUILD_TOOLS / ANDROID_PLATFORM name one.
+set -euo pipefail
+here="$(cd "$(dirname "$0")" && pwd)"
+out="$here/build"
+
+sdk="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-$HOME/android-sdk}}"
+[ -d "$sdk" ] || { echo "no Android SDK at $sdk — set ANDROID_HOME" >&2; exit 1; }
+
+pick_newest() { ls "$1" 2>/dev/null | sort -V | tail -1; }
+build_tools="${BUILD_TOOLS:-$(pick_newest "$sdk/build-tools")}"
+platform="${ANDROID_PLATFORM:-$(pick_newest "$sdk/platforms")}"
+tools="$sdk/build-tools/$build_tools"
+android_jar="$sdk/platforms/$platform/android.jar"
+[ -x "$tools/aapt2" ] || { echo "no build-tools in $sdk/build-tools" >&2; exit 1; }
+[ -f "$android_jar" ] || { echo "no platform jar at $android_jar" >&2; exit 1; }
+
+rm -rf "$out"
+mkdir -p "$out/classes"
+
+javac --release 17 -classpath "$android_jar" -d "$out/classes" \
+  "$here/src/tech/fixedwidth/glassrolefixture/MainActivity.java"
+"$tools/d8" --lib "$android_jar" --output "$out" $(find "$out/classes" -name '*.class')
+
+"$tools/aapt2" link -o "$out/unsigned.apk" -I "$android_jar" \
+  --manifest "$here/AndroidManifest.xml" --min-sdk-version 24 --target-sdk-version 34
+(cd "$out" && zip -q unsigned.apk classes.dex)
+
+# A throwaway signing key: Android refuses to install an unsigned APK, and nothing here is
+# distributed, so the keystore is regenerated with the build rather than checked in.
+keytool -genkeypair -keystore "$out/debug.jks" -storepass android -keypass android \
+  -alias fixture -keyalg RSA -validity 3650 -dname "CN=glass role fixture" >/dev/null 2>&1
+
+"$tools/zipalign" -f 4 "$out/unsigned.apk" "$out/aligned.apk"
+"$tools/apksigner" sign --ks "$out/debug.jks" --ks-pass pass:android --key-pass pass:android \
+  --out "$out/role-fixture.apk" "$out/aligned.apk"
+
+echo "built: $out/role-fixture.apk"

--- a/examples/android-role-fixture/src/tech/fixedwidth/glassrolefixture/MainActivity.java
+++ b/examples/android-role-fixture/src/tech/fixedwidth/glassrolefixture/MainActivity.java
@@ -15,6 +15,7 @@ import android.widget.ListView;
 import android.widget.NumberPicker;
 import android.widget.PopupMenu;
 import android.widget.ProgressBar;
+import android.widget.ScrollView;
 import android.widget.TabHost;
 import android.widget.TableLayout;
 import android.widget.TableRow;
@@ -28,12 +29,21 @@ import android.widget.Toolbar;
  * {@code android.widget} class with no support library, so a {@code uiautomator dump} of this app
  * answers one question per control: what widget class does Android report for it?
  *
- * <p>A role is marked unreachable in the matrix only where a control was watched to arrive
- * carrying no token for it — a toolbar reporting {@code android.view.ViewGroup}, a popup menu
- * reporting {@code android.widget.ListView}. This app is how that is watched.
+ * <p>Where a control exists to look at, that reading is what decides whether its matrix cell is a
+ * gap or unreachable — a toolbar reporting {@code android.view.ViewGroup}, a popup menu reporting
+ * {@code android.widget.ListView}. This app is how it is watched.
  *
  * <p>The two popups need a tap, so they sit behind buttons: the menu and the dialog each replace
  * the dump's topmost window, and are read from a dump of their own.
+ *
+ * <p>The screen scrolls and its sizes are in dp rather than raw pixels, so every control is
+ * reachable on a short screen too. A control scrolled out of view is missing from the dump
+ * entirely, and a missing node reads exactly like a missing token — which is the one mistake
+ * this app must not make.
+ *
+ * <p>{@link TabHost} and {@link TabWidget} are deprecated, and deliberately so here: they are
+ * what emits the framework tab tokens the matrix records. Replacing them with the Material tab
+ * strip real apps use would change the evidence rather than modernize it.
  */
 public class MainActivity extends Activity {
 
@@ -52,11 +62,11 @@ public class MainActivity extends Activity {
         toolbar.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_YES);
         root.addView(toolbar, matchWrap());
 
-        root.addView(tabs(), matchHeight(260));
+        root.addView(tabs(), matchHeight(dp(130)));
         root.addView(label("list"), matchWrap());
-        root.addView(list(), matchHeight(160));
+        root.addView(list(), matchHeight(dp(80)));
         root.addView(label("grid"), matchWrap());
-        root.addView(grid(), matchHeight(160));
+        root.addView(grid(), matchHeight(dp(80)));
         root.addView(label("table"), matchWrap());
         root.addView(table(), matchWrap());
 
@@ -73,7 +83,9 @@ public class MainActivity extends Activity {
         root.addView(menuButton(), matchWrap());
         root.addView(dialogButton(), matchWrap());
 
-        setContentView(root);
+        ScrollView scroller = new ScrollView(this);
+        scroller.addView(root);
+        setContentView(scroller);
     }
 
     /** A framework {@link PopupMenu} with two entries, opened by tapping the button. */
@@ -128,7 +140,7 @@ public class MainActivity extends Activity {
         FrameLayout content = new FrameLayout(this);
         content.setId(android.R.id.tabcontent);
         holder.addView(widget, matchWrap());
-        holder.addView(content, matchHeight(180));
+        holder.addView(content, matchHeight(dp(90)));
         host.addView(holder, matchWrap());
         host.setup();
 
@@ -203,5 +215,10 @@ public class MainActivity extends Activity {
 
     private LinearLayout.LayoutParams matchHeight(int height) {
         return new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, height);
+    }
+
+    /** Density-independent pixels to device pixels, so a height means the same on any screen. */
+    private int dp(int value) {
+        return Math.round(value * getResources().getDisplayMetrics().density);
     }
 }

--- a/examples/android-role-fixture/src/tech/fixedwidth/glassrolefixture/MainActivity.java
+++ b/examples/android-role-fixture/src/tech/fixedwidth/glassrolefixture/MainActivity.java
@@ -1,0 +1,207 @@
+package tech.fixedwidth.glassrolefixture;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.Context;
+import android.os.Bundle;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.FrameLayout;
+import android.widget.GridView;
+import android.widget.LinearLayout;
+import android.widget.ListView;
+import android.widget.NumberPicker;
+import android.widget.PopupMenu;
+import android.widget.ProgressBar;
+import android.widget.TabHost;
+import android.widget.TableLayout;
+import android.widget.TableRow;
+import android.widget.TabWidget;
+import android.widget.TextView;
+import android.widget.Toolbar;
+
+/**
+ * One screen holding the controls whose accessibility vocabulary decides a cell in glass's role
+ * matrix (`glass_core::role_support::ROLE_SUPPORT`). Everything here is a stock
+ * {@code android.widget} class with no support library, so a {@code uiautomator dump} of this app
+ * answers one question per control: what widget class does Android report for it?
+ *
+ * <p>A role is marked unreachable in the matrix only where a control was watched to arrive
+ * carrying no token for it — a toolbar reporting {@code android.view.ViewGroup}, a popup menu
+ * reporting {@code android.widget.ListView}. This app is how that is watched.
+ *
+ * <p>The two popups need a tap, so they sit behind buttons: the menu and the dialog each replace
+ * the dump's topmost window, and are read from a dump of their own.
+ */
+public class MainActivity extends Activity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        LinearLayout root = new LinearLayout(this);
+        root.setOrientation(LinearLayout.VERTICAL);
+
+        // Described and forced visible to accessibility: without a description a bare Toolbar can
+        // be pruned from the dump, and an absent node cannot tell an unmapped token from a
+        // missing one.
+        Toolbar toolbar = new Toolbar(this);
+        toolbar.setTitle("Role fixture");
+        toolbar.setContentDescription("the toolbar");
+        toolbar.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_YES);
+        root.addView(toolbar, matchWrap());
+
+        root.addView(tabs(), matchHeight(260));
+        root.addView(label("list"), matchWrap());
+        root.addView(list(), matchHeight(160));
+        root.addView(label("grid"), matchWrap());
+        root.addView(grid(), matchHeight(160));
+        root.addView(label("table"), matchWrap());
+        root.addView(table(), matchWrap());
+
+        NumberPicker picker = new NumberPicker(this);
+        picker.setMinValue(1);
+        picker.setMaxValue(9);
+        root.addView(picker, wrapWrap());
+
+        ProgressBar progress =
+                new ProgressBar(this, null, android.R.attr.progressBarStyleHorizontal);
+        progress.setProgress(40);
+        root.addView(progress, matchWrap());
+
+        root.addView(menuButton(), matchWrap());
+        root.addView(dialogButton(), matchWrap());
+
+        setContentView(root);
+    }
+
+    /** A framework {@link PopupMenu} with two entries, opened by tapping the button. */
+    private View menuButton() {
+        Button button = new Button(this);
+        button.setText("popup menu");
+        button.setOnClickListener(
+                new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        PopupMenu menu = new PopupMenu(MainActivity.this, view);
+                        menu.getMenu().add("Alpha");
+                        menu.getMenu().add("Beta");
+                        menu.show();
+                    }
+                });
+        return button;
+    }
+
+    /** A framework {@link AlertDialog} with a title, a message and two buttons. */
+    private View dialogButton() {
+        Button button = new Button(this);
+        button.setText("alert dialog");
+        button.setOnClickListener(
+                new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        new AlertDialog.Builder(MainActivity.this)
+                                .setTitle("Dialog title")
+                                .setMessage("Dialog message")
+                                .setPositiveButton("OK", null)
+                                .setNegativeButton("Cancel", null)
+                                .show();
+                    }
+                });
+        return button;
+    }
+
+    /**
+     * A {@link TabHost} built by hand, since the framework widget needs its three well-known ids
+     * ({@code tabhost}, {@code tabs}, {@code tabcontent}) to wire itself up.
+     */
+    private View tabs() {
+        final Context context = this;
+        TabHost host = new TabHost(this, null);
+        host.setId(android.R.id.tabhost);
+
+        LinearLayout holder = new LinearLayout(this);
+        holder.setOrientation(LinearLayout.VERTICAL);
+        TabWidget widget = new TabWidget(this);
+        widget.setId(android.R.id.tabs);
+        FrameLayout content = new FrameLayout(this);
+        content.setId(android.R.id.tabcontent);
+        holder.addView(widget, matchWrap());
+        holder.addView(content, matchHeight(180));
+        host.addView(holder, matchWrap());
+        host.setup();
+
+        for (final String name : new String[] {"First", "Second"}) {
+            TabHost.TabSpec spec = host.newTabSpec(name);
+            spec.setIndicator(name);
+            spec.setContent(
+                    new TabHost.TabContentFactory() {
+                        @Override
+                        public View createTabContent(String tag) {
+                            TextView view = new TextView(context);
+                            view.setText(name + " tab body");
+                            return view;
+                        }
+                    });
+            host.addTab(spec);
+        }
+        return host;
+    }
+
+    private View list() {
+        ListView view = new ListView(this);
+        view.setAdapter(
+                new ArrayAdapter<String>(
+                        this,
+                        android.R.layout.simple_list_item_1,
+                        new String[] {"Row one", "Row two"}));
+        return view;
+    }
+
+    private View grid() {
+        GridView view = new GridView(this);
+        view.setNumColumns(2);
+        view.setAdapter(
+                new ArrayAdapter<String>(
+                        this,
+                        android.R.layout.simple_list_item_1,
+                        new String[] {"Cell A", "Cell B", "Cell C", "Cell D"}));
+        return view;
+    }
+
+    private View table() {
+        TableLayout table = new TableLayout(this);
+        for (int row = 0; row < 2; row++) {
+            TableRow tableRow = new TableRow(this);
+            for (int column = 0; column < 2; column++) {
+                TextView cell = new TextView(this);
+                cell.setText("r" + row + "c" + column);
+                cell.setPadding(24, 12, 24, 12);
+                tableRow.addView(cell);
+            }
+            table.addView(tableRow);
+        }
+        return table;
+    }
+
+    private View label(String text) {
+        TextView view = new TextView(this);
+        view.setText(text);
+        return view;
+    }
+
+    private LinearLayout.LayoutParams matchWrap() {
+        return new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+    }
+
+    private LinearLayout.LayoutParams wrapWrap() {
+        return new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+    }
+
+    private LinearLayout.LayoutParams matchHeight(int height) {
+        return new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, height);
+    }
+}

--- a/examples/ios-role-fixture/Info.plist
+++ b/examples/ios-role-fixture/Info.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>RoleFixture</string>
+    <key>CFBundleIdentifier</key>
+    <string>tech.fixedwidth.glassrolefixture</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>RoleFixture</string>
+    <key>CFBundleDisplayName</key>
+    <string>Glass Role Fixture</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>MinimumOSVersion</key>
+    <string>16.0</string>
+    <key>UIDeviceFamily</key>
+    <array>
+        <integer>1</integer>
+    </array>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+    </array>
+</dict>
+</plist>

--- a/examples/ios-role-fixture/README.md
+++ b/examples/ios-role-fixture/README.md
@@ -1,0 +1,52 @@
+# ios-role-fixture
+
+One screen of stock UIKit controls (plus a SwiftUI screen), for deciding what iOS's accessibility
+vocabulary can express. Each control answers one question: what AX role string does the Simulator
+report for it? That answer is what a cell in
+[docs/reference/a11y-roles.md](../../docs/reference/a11y-roles.md) records — a role is marked
+`n/a` there only where a control was watched to arrive carrying no token for it.
+
+| Control | Reports (iOS 26.5 Simulator) |
+|---|---|
+| `UISegmentedControl` | one `AXTabGroup`, no per-segment element |
+| `UIStepper` | two `AXButton`s, `Decrement` and `Increment` |
+| `UIProgressView` | `AXGenericElement`, percentage in the value |
+| `UIPickerView` | `AXSlider` |
+| `UITableView` | `AXGroup`; rows `AXStaticText`, including one exposed as its own element |
+| `UICollectionView` | `AXGroup`; cells `AXStaticText` |
+| `UIAlertController` (button) | title, message and buttons loose under `AXApplication` |
+| `UIMenu` (button) | `AXGroup` of `AXButton`s plus a `Dismiss context menu` button |
+| `UITabBar` | `AXGroup` labelled `Tab Bar`; its items are not elements at all |
+| SwiftUI `List` | `AXGroup`; rows `AXStaticText`, section header `AXHeading` |
+
+## Build and install
+
+Requires the full Xcode and an iOS Simulator runtime (macOS only):
+
+```bash
+./build.sh                                                    # → build/RoleFixture.app
+xcrun simctl install booted build/RoleFixture.app
+xcrun simctl launch booted tech.fixedwidth.glassrolefixture
+```
+
+A synthetic tap on a tab bar item does not switch tabs — the items are not accessibility elements
+— so the screen is chosen at launch:
+
+```bash
+xcrun simctl launch booted tech.fixedwidth.glassrolefixture --tab collection   # or: swiftui
+```
+
+## Read the tree
+
+With `idb_companion` running against the Simulator:
+
+```bash
+idb ui describe-all --json
+```
+
+Through glass's own probe, which prints a role histogram per app:
+
+```bash
+GLASS_A11Y_PROBE_APPS="$PWD/build/RoleFixture.app" \
+  cargo test -p glass-ios --test role_probe -- --ignored --nocapture
+```

--- a/examples/ios-role-fixture/README.md
+++ b/examples/ios-role-fixture/README.md
@@ -1,12 +1,15 @@
 # ios-role-fixture
 
-One screen of stock UIKit controls (plus a SwiftUI screen), for deciding what iOS's accessibility
-vocabulary can express. Each control answers one question: what AX role string does the Simulator
-report for it? That answer is what a cell in
-[docs/reference/a11y-roles.md](../../docs/reference/a11y-roles.md) records — a role is marked
-`n/a` there only where a control was watched to arrive carrying no token for it.
+One screen of stock UIKit controls, a collection view, and a SwiftUI screen, for deciding what
+iOS's accessibility vocabulary can express. Each control answers one question: what AX role string
+does the Simulator report for it? That answer is what a cell in
+[docs/reference/a11y-roles.md](../../docs/reference/a11y-roles.md) records.
 
-| Control | Reports (iOS 26.5 Simulator) |
+Readings below are from an iOS 26.5 Simulator on 2026-07-25, through `idb` — re-run them rather
+than trusting them. They are bounded by what idb's accessibility tree exposes, which may be
+narrower than what UIKit publishes to VoiceOver.
+
+| Control | Reported |
 |---|---|
 | `UISegmentedControl` | one `AXTabGroup`, no per-segment element |
 | `UIStepper` | two `AXButton`s, `Decrement` and `Increment` |
@@ -14,10 +17,12 @@ report for it? That answer is what a cell in
 | `UIPickerView` | `AXSlider` |
 | `UITableView` | `AXGroup`; rows `AXStaticText`, including one exposed as its own element |
 | `UICollectionView` | `AXGroup`; cells `AXStaticText` |
-| `UIAlertController` (button) | title, message and buttons loose under `AXApplication` |
-| `UIMenu` (button) | `AXGroup` of `AXButton`s plus a `Dismiss context menu` button |
-| `UITabBar` | `AXGroup` labelled `Tab Bar`; its items are not elements at all |
+| `UIAlertController` — alert and action sheet (buttons) | title, message and buttons loose under `AXApplication` |
+| `UIMenu` pull-down (button) | `AXGroup` of `AXButton`s plus a `Dismiss context menu` button |
+| `UITabBar` | `AXGroup` labelled `Tab Bar`; no per-item element |
 | SwiftUI `List` | `AXGroup`; rows `AXStaticText`, section header `AXHeading` |
+| SwiftUI `Picker`, `.inline` | `AXHeading` plus one `AXButton` per option |
+| SwiftUI `Picker`, `.menu` | `AXPopUpButton` — a token glass does not map yet |
 
 ## Build and install
 
@@ -29,20 +34,34 @@ xcrun simctl install booted build/RoleFixture.app
 xcrun simctl launch booted tech.fixedwidth.glassrolefixture
 ```
 
-A synthetic tap on a tab bar item does not switch tabs — the items are not accessibility elements
-— so the screen is chosen at launch:
+The tab bar's items are not accessibility elements, so nothing in the tree can be aimed at to
+switch tabs — and a synthetic tap at the bar's coordinates does not switch them either. The screen
+is chosen at launch instead, by environment variable (what glass can set, via `AppSpec::env`) or
+by launch argument (for driving `simctl` by hand):
 
 ```bash
-xcrun simctl launch booted tech.fixedwidth.glassrolefixture --tab collection   # or: swiftui
+xcrun simctl launch booted tech.fixedwidth.glassrolefixture --tab=collection    # or: swiftui
+SIMCTL_CHILD_ROLE_FIXTURE_TAB=swiftui xcrun simctl launch booted tech.fixedwidth.glassrolefixture
 ```
+
+The value must be joined with `=`. `simctl launch` forwards `--tab=swiftui` but drops the value of
+a separated `--tab swiftui`, which would otherwise have launched the Controls screen while looking
+like it had worked; the app treats that, and an unrecognized name, as fatal. The collection and
+SwiftUI screens also name themselves in the tree — `screen-collection` and `screen-swiftui` appear
+as element identifiers — and the Controls screen is headed `Controls`.
 
 ## Read the tree
 
-With `idb_companion` running against the Simulator:
+With `idb_companion` running against the Simulator, using the `fb-idb` client (`idb`, a separate
+Python package from the companion glass itself needs):
 
 ```bash
-idb ui describe-all --json
+idb ui describe-all --udid <udid> --nested --json
 ```
+
+`--nested` is the format glass reads; without it the response is a flat element list, and none of
+the containment above (a group holding static text, buttons loose under the application) is
+visible.
 
 Through glass's own probe, which prints a role histogram per app:
 
@@ -50,3 +69,6 @@ Through glass's own probe, which prints a role histogram per app:
 GLASS_A11Y_PROBE_APPS="$PWD/build/RoleFixture.app" \
   cargo test -p glass-ios --test role_probe -- --ignored --nocapture
 ```
+
+The probe launches the app without arguments, so it reads the Controls screen; set
+`SIMCTL_CHILD_ROLE_FIXTURE_TAB` in its environment to probe another.

--- a/examples/ios-role-fixture/README.md
+++ b/examples/ios-role-fixture/README.md
@@ -5,9 +5,10 @@ iOS's accessibility vocabulary can express. Each control answers one question: w
 does the Simulator report for it? That answer is what a cell in
 [docs/reference/a11y-roles.md](../../docs/reference/a11y-roles.md) records.
 
-Readings below are from an iOS 26.5 Simulator on 2026-07-25, through `idb` — re-run them rather
-than trusting them. They are bounded by what idb's accessibility tree exposes, which may be
-narrower than what UIKit publishes to VoiceOver.
+The table below is what these controls reported on an iOS 26.5 Simulator through `idb` — a
+reading, not a guarantee. Re-run it rather than trusting it; the read step below prints the runtime
+it saw, and `build.sh` prints the SDK it built against. The readings are bounded by what idb's
+accessibility tree exposes, which may be narrower than what UIKit publishes to VoiceOver.
 
 | Control | Reported |
 |---|---|
@@ -56,6 +57,7 @@ With `idb_companion` running against the Simulator, using the `fb-idb` client (`
 Python package from the companion glass itself needs):
 
 ```bash
+xcrun simctl list devices booted            # the runtime this reading is from
 idb ui describe-all --udid <udid> --nested --json
 ```
 

--- a/examples/ios-role-fixture/RoleFixture.swift
+++ b/examples/ios-role-fixture/RoleFixture.swift
@@ -1,0 +1,205 @@
+import SwiftUI
+import UIKit
+
+/// The controls whose accessibility vocabulary decides a cell in glass's role matrix
+/// (`glass_core::role_support::ROLE_SUPPORT`), built from stock UIKit classes. Reading this app
+/// back through `idb ui describe-all` answers one question per control: what AX role string does
+/// the Simulator report for it?
+///
+/// A role is marked unreachable in the matrix only where a control was watched to arrive
+/// carrying no token for it — a stepper arriving as two buttons, a picker as a slider. This app
+/// is how that is watched.
+final class ControlsViewController: UIViewController, UITableViewDataSource, UITableViewDelegate,
+    UIPickerViewDataSource, UIPickerViewDelegate
+{
+    private let rows = ["Row one", "Row two", "Row three"]
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        title = "Controls"
+
+        let table = UITableView(frame: .zero, style: .insetGrouped)
+        table.dataSource = self
+        table.delegate = self
+        table.accessibilityIdentifier = "the-table"
+
+        let segmented = UISegmentedControl(items: ["Alpha", "Beta", "Gamma"])
+        segmented.selectedSegmentIndex = 0
+        segmented.accessibilityIdentifier = "the-segmented"
+
+        let stepper = UIStepper()
+        stepper.accessibilityIdentifier = "the-stepper"
+
+        let progress = UIProgressView(progressViewStyle: .default)
+        progress.progress = 0.4
+        progress.accessibilityIdentifier = "the-progress"
+
+        let picker = UIPickerView()
+        picker.dataSource = self
+        picker.delegate = self
+        picker.accessibilityIdentifier = "the-picker"
+
+        let alertButton = UIButton(type: .system)
+        alertButton.setTitle("alert dialog", for: .normal)
+        alertButton.accessibilityIdentifier = "the-alert-button"
+        alertButton.addTarget(self, action: #selector(showAlert), for: .touchUpInside)
+
+        let menuButton = UIButton(type: .system)
+        menuButton.setTitle("pull-down menu", for: .normal)
+        menuButton.accessibilityIdentifier = "the-menu-button"
+        menuButton.showsMenuAsPrimaryAction = true
+        menuButton.menu = UIMenu(
+            title: "Menu title",
+            children: [
+                UIAction(title: "Menu item one") { _ in },
+                UIAction(title: "Menu item two") { _ in },
+            ])
+
+        let stack = UIStackView(arrangedSubviews: [
+            segmented, stepper, progress, picker, alertButton, menuButton, table,
+        ])
+        stack.axis = .vertical
+        stack.spacing = 8
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 8),
+            stack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 8),
+            stack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -8),
+            stack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            picker.heightAnchor.constraint(equalToConstant: 100),
+        ])
+    }
+
+    /// Presented without animation so a describe right after the tap reads the settled tree.
+    @objc private func showAlert() {
+        let alert = UIAlertController(
+            title: "Dialog title", message: "Dialog message", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        present(alert, animated: false)
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        rows.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
+        cell.textLabel?.text = rows[indexPath.row]
+        // Row 0 is exposed as its own accessibility element while the rest keep UIKit's default,
+        // so the tree shows whether an explicitly-exposed cell reports a different token.
+        if indexPath.row == 0 {
+            cell.isAccessibilityElement = true
+            cell.accessibilityLabel = rows[indexPath.row]
+        }
+        return cell
+    }
+
+    func numberOfComponents(in pickerView: UIPickerView) -> Int { 1 }
+
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int { 3 }
+
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int)
+        -> String?
+    { "Pick \(row)" }
+}
+
+/// A collection view, whose cells are each their own accessibility element.
+final class CollectionViewController: UICollectionViewController {
+    init() {
+        let layout = UICollectionViewFlowLayout()
+        layout.itemSize = CGSize(width: 100, height: 100)
+        super.init(collectionViewLayout: layout)
+    }
+
+    required init?(coder: NSCoder) { fatalError("not loaded from a nib") }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Collection"
+        collectionView.backgroundColor = .systemBackground
+        collectionView.accessibilityIdentifier = "the-collection"
+        collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "cell")
+    }
+
+    override func collectionView(
+        _ collectionView: UICollectionView, numberOfItemsInSection section: Int
+    ) -> Int { 4 }
+
+    override func collectionView(
+        _ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath
+    ) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "cell", for: indexPath)
+        cell.backgroundColor = .secondarySystemBackground
+        cell.isAccessibilityElement = true
+        cell.accessibilityLabel = "Item \(indexPath.item)"
+        return cell
+    }
+}
+
+/// The same list and picker concepts expressed in SwiftUI rather than UIKit, since a SwiftUI
+/// container could report a token its UIKit equivalent does not.
+struct SwiftUIScreen: View {
+    @State private var pick = 0
+
+    var body: some View {
+        List {
+            Section("Section header") {
+                Text("SwiftUI row one")
+                Text("SwiftUI row two")
+                Picker("Pick one", selection: $pick) {
+                    Text("One").tag(0)
+                    Text("Two").tag(1)
+                }
+                .pickerStyle(.inline)
+            }
+        }
+    }
+}
+
+@main
+final class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    /// The tab named by a `--tab controls|collection|swiftui` launch argument, as an index into
+    /// the tab controller. Anything else — absent, misspelled, out of range — is the first tab,
+    /// so a typo shows a working screen rather than an empty one.
+    private static func requestedTab() -> Int {
+        let arguments = ProcessInfo.processInfo.arguments
+        guard let flag = arguments.firstIndex(of: "--tab"), flag + 1 < arguments.count else {
+            return 0
+        }
+        switch arguments[flag + 1] {
+        case "collection": return 1
+        case "swiftui": return 2
+        default: return 0
+        }
+    }
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions options: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+        let controls = UINavigationController(rootViewController: ControlsViewController())
+        controls.tabBarItem = UITabBarItem(title: "Controls", image: nil, tag: 0)
+        let collection = CollectionViewController()
+        collection.tabBarItem = UITabBarItem(title: "Collection", image: nil, tag: 1)
+        let swiftui = UIHostingController(rootView: SwiftUIScreen())
+        swiftui.tabBarItem = UITabBarItem(title: "SwiftUI", image: nil, tag: 2)
+
+        // The tab bar's items are not exposed as accessibility elements and a synthetic tap on
+        // one does not switch tabs, so the screen to show is chosen at launch instead:
+        // `simctl launch booted tech.fixedwidth.glassrolefixture --tab collection`.
+        let tabs = UITabBarController()
+        tabs.viewControllers = [controls, collection, swiftui]
+        tabs.selectedIndex = Self.requestedTab()
+
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = tabs
+        window.makeKeyAndVisible()
+        self.window = window
+        return true
+    }
+}

--- a/examples/ios-role-fixture/RoleFixture.swift
+++ b/examples/ios-role-fixture/RoleFixture.swift
@@ -3,12 +3,12 @@ import UIKit
 
 /// The controls whose accessibility vocabulary decides a cell in glass's role matrix
 /// (`glass_core::role_support::ROLE_SUPPORT`), built from stock UIKit classes. Reading this app
-/// back through `idb ui describe-all` answers one question per control: what AX role string does
-/// the Simulator report for it?
+/// back through `idb ui describe-all --nested --json` — the format glass itself reads — answers
+/// one question per control: what AX role string does the Simulator report for it?
 ///
-/// A role is marked unreachable in the matrix only where a control was watched to arrive
-/// carrying no token for it — a stepper arriving as two buttons, a picker as a slider. This app
-/// is how that is watched.
+/// Where a control exists to look at, that reading is what decides whether its cell is a gap or
+/// unreachable: a stepper arriving as two buttons, a picker as a slider. It bounds the claim to
+/// what idb exposes, which may be narrower than what UIKit publishes to VoiceOver.
 final class ControlsViewController: UIViewController, UITableViewDataSource, UITableViewDelegate,
     UIPickerViewDataSource, UIPickerViewDelegate
 {
@@ -40,6 +40,11 @@ final class ControlsViewController: UIViewController, UITableViewDataSource, UIT
         picker.delegate = self
         picker.accessibilityIdentifier = "the-picker"
 
+        let sheetButton = UIButton(type: .system)
+        sheetButton.setTitle("action sheet", for: .normal)
+        sheetButton.accessibilityIdentifier = "the-sheet-button"
+        sheetButton.addTarget(self, action: #selector(showSheet), for: .touchUpInside)
+
         let alertButton = UIButton(type: .system)
         alertButton.setTitle("alert dialog", for: .normal)
         alertButton.accessibilityIdentifier = "the-alert-button"
@@ -57,10 +62,13 @@ final class ControlsViewController: UIViewController, UITableViewDataSource, UIT
             ])
 
         let stack = UIStackView(arrangedSubviews: [
-            segmented, stepper, progress, picker, alertButton, menuButton, table,
+            segmented, stepper, progress, picker, sheetButton, alertButton, menuButton, table,
         ])
         stack.axis = .vertical
         stack.spacing = 8
+        // Each screen names itself in the tree: the tab bar's items are not elements, so a
+        // reading otherwise carries nothing saying which screen produced it.
+        stack.accessibilityIdentifier = "screen-controls"
         stack.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(stack)
         NSLayoutConstraint.activate([
@@ -79,6 +87,16 @@ final class ControlsViewController: UIViewController, UITableViewDataSource, UIT
         alert.addAction(UIAlertAction(title: "OK", style: .default))
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
         present(alert, animated: false)
+    }
+
+    /// An action sheet as well as an alert: they are separate presentation styles, and one
+    /// carrying no container token says nothing about the other.
+    @objc private func showSheet() {
+        let sheet = UIAlertController(
+            title: "Sheet title", message: "Sheet message", preferredStyle: .actionSheet)
+        sheet.addAction(UIAlertAction(title: "Sheet one", style: .default))
+        sheet.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        present(sheet, animated: false)
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -120,7 +138,7 @@ final class CollectionViewController: UICollectionViewController {
         super.viewDidLoad()
         title = "Collection"
         collectionView.backgroundColor = .systemBackground
-        collectionView.accessibilityIdentifier = "the-collection"
+        collectionView.accessibilityIdentifier = "screen-collection"
         collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "cell")
     }
 
@@ -154,8 +172,14 @@ struct SwiftUIScreen: View {
                     Text("Two").tag(1)
                 }
                 .pickerStyle(.inline)
+                Picker("Pick menu", selection: $pick) {
+                    Text("Menu one").tag(0)
+                    Text("Menu two").tag(1)
+                }
+                .pickerStyle(.menu)
             }
         }
+        .accessibilityIdentifier("screen-swiftui")
     }
 }
 
@@ -163,18 +187,34 @@ struct SwiftUIScreen: View {
 final class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
-    /// The tab named by a `--tab controls|collection|swiftui` launch argument, as an index into
-    /// the tab controller. Anything else — absent, misspelled, out of range — is the first tab,
-    /// so a typo shows a working screen rather than an empty one.
+    /// The screen to show, as an index into the tab controller.
+    ///
+    /// Named by `ROLE_FIXTURE_TAB=controls|collection|swiftui` in the environment, or by a
+    /// `--tab=<name>` launch argument. The environment is what glass can set (`AppSpec::env`
+    /// reaches the app as `SIMCTL_CHILD_*`), since `AppSpec::run`'s tail is not passed through to
+    /// `simctl launch`; the argument form is for driving `simctl` by hand.
+    ///
+    /// Only the joined `--tab=<name>` form works: `simctl launch` forwards it, but drops the
+    /// value of a separated `--tab <name>`, which would leave this reading a flag with nothing
+    /// after it. That case is fatal here rather than silently first-tab, as is a name it does not
+    /// recognize. This app exists to put one specific screen in front of a reader whose tree
+    /// becomes evidence, and a tree carries no marker of which screen produced it — so falling
+    /// back quietly would hand them a plausible reading of the wrong screen.
     private static func requestedTab() -> Int {
         let arguments = ProcessInfo.processInfo.arguments
-        guard let flag = arguments.firstIndex(of: "--tab"), flag + 1 < arguments.count else {
-            return 0
+        var requested = ProcessInfo.processInfo.environment["ROLE_FIXTURE_TAB"]
+        if let inline = arguments.first(where: { $0.hasPrefix("--tab=") }) {
+            requested = String(inline.dropFirst("--tab=".count))
+        } else if arguments.contains("--tab") {
+            fatalError("--tab needs its value joined: --tab=controls|collection|swiftui")
         }
-        switch arguments[flag + 1] {
+        guard let name = requested else { return 0 }
+        switch name {
+        case "controls": return 0
         case "collection": return 1
         case "swiftui": return 2
-        default: return 0
+        default:
+            fatalError("unknown tab '\(name)' — use controls, collection or swiftui")
         }
     }
 

--- a/examples/ios-role-fixture/build.sh
+++ b/examples/ios-role-fixture/build.sh
@@ -1,18 +1,31 @@
 #!/usr/bin/env bash
 # Build the role fixture into a Simulator .app bundle.
-# Requires the full Xcode + an iOS Simulator runtime. Mirrors examples/ios-fixture/build.sh.
+# Requires the full Xcode + an iOS Simulator runtime. Mirrors examples/ios-fixture/build.sh,
+# with the host architecture read rather than assumed — an Intel Mac's Simulator cannot run an
+# arm64 slice, and that failure would otherwise surface later as an opaque `simctl launch` error.
 set -euo pipefail
 here="$(cd "$(dirname "$0")" && pwd)"
 app="$here/build/RoleFixture.app"
 sdk="$(xcrun --sdk iphonesimulator --show-sdk-path)"
+arch="$(uname -m)"
 
 rm -rf "$app"
 mkdir -p "$app"
 xcrun --sdk iphonesimulator swiftc \
-  -target arm64-apple-ios16.0-simulator \
+  -target "$arch-apple-ios16.0-simulator" \
   -sdk "$sdk" \
   -parse-as-library \
   -o "$app/RoleFixture" \
   "$here/RoleFixture.swift"
+
+# The plist names the executable; a rename on one side alone yields a bundle that installs and
+# then fails to launch, with the build still reporting success.
+plutil -lint "$here/Info.plist" >/dev/null
+executable="$(plutil -extract CFBundleExecutable raw -o - "$here/Info.plist")"
+[ "$executable" = "RoleFixture" ] || {
+  echo "Info.plist CFBundleExecutable is '$executable', but the binary is built as RoleFixture" >&2
+  exit 1
+}
 cp "$here/Info.plist" "$app/Info.plist"
-echo "built: $app"
+
+echo "built: $app ($arch, $(xcrun --sdk iphonesimulator --show-sdk-version) SDK)"

--- a/examples/ios-role-fixture/build.sh
+++ b/examples/ios-role-fixture/build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Build the role fixture into a Simulator .app bundle.
+# Requires the full Xcode + an iOS Simulator runtime. Mirrors examples/ios-fixture/build.sh.
+set -euo pipefail
+here="$(cd "$(dirname "$0")" && pwd)"
+app="$here/build/RoleFixture.app"
+sdk="$(xcrun --sdk iphonesimulator --show-sdk-path)"
+
+rm -rf "$app"
+mkdir -p "$app"
+xcrun --sdk iphonesimulator swiftc \
+  -target arm64-apple-ios16.0-simulator \
+  -sdk "$sdk" \
+  -parse-as-library \
+  -o "$app/RoleFixture" \
+  "$here/RoleFixture.swift"
+cp "$here/Info.plist" "$app/Info.plist"
+echo "built: $app"


### PR DESCRIPTION
Follow-up to #219/#221/#222, which declared per backend which normalized accessibility roles it can produce. Those PRs mapped tokens only from probe evidence — but the *unmapped* cells never got the same treatment. Fifteen of them read "not mapped yet" on the strength of the control existing on the platform, which is not the same claim.

Each questioned control was put on screen and the tree read back, on all three platforms.

## What each control reports

**iOS** (iOS 26.5 Simulator, via `idb`)

| Control | Reports | Cell |
|---|---|---|
| `UIStepper` | two `AXButton`s, `Decrement`/`Increment` | `SpinButton` → unmarked |
| `UIProgressView` | `AXGenericElement`, percentage in the value | `ProgressBar` → unmarked |
| `UIPickerView` / inline SwiftUI `Picker` | `AXSlider` / heading + buttons | see below |
| **menu-style SwiftUI `Picker`** | **`AXPopUpButton`** | `ComboBox` **stays gap** |
| `UIAlertController`, alert and action sheet | title, message, buttons loose under `AXApplication` | `Dialog` → unmarked |
| pull-down `UIMenu` | `AXGroup` of `AXButton`s + `Dismiss context menu` | `Menu`/`MenuItem` → unmarked |
| `UITableView`, `UICollectionView`, SwiftUI `List` | `AXGroup`; rows `AXStaticText` | `List`/`Table`/`ListItem` → unmarked |
| `UITabBar`, `UISegmentedControl` | `AXGroup` / one `AXTabGroup`, no per-item element | `Tab` → unmarked, `RadioButton` → absent |

**Android** (API 34 emulator)

| Control | Reports | Cell |
|---|---|---|
| `android.widget.Toolbar` | `android.view.ViewGroup` | `Toolbar` → unmarked |
| `PopupMenu` | `android.widget.ListView`, entries `LinearLayout`/`RelativeLayout` | `Menu`/`MenuItem` → unmarked |
| `AlertDialog` | `FrameLayout`/`LinearLayout` under `android:id/parentPanel` | `Dialog` → unmarked |
| `TabWidget`, `TabHost`, `TableLayout`, `TableRow`, `NumberPicker` | themselves | stay gap, now naming the token |

The `Toolbar` claim covers the AppCompat and Material toolbars too, on the mechanism rather than on one widget: a custom `ViewGroup` subclass was watched to report `ViewGroup` and a custom `FrameLayout` subclass to report `FrameLayout` — a subclass inherits the framework class's accessibility class name — and neither `androidx.appcompat.widget.Toolbar` nor `MaterialToolbar` overrides `getAccessibilityClassName` (checked in the published AARs).

**Windows** (Windows 11, via Edge, read with a probe built on the `uiautomation` crate glass already depends on)

| Element | ControlType (what glass reads) | HeadingLevel | AriaRole |
|---|---|---|---|
| `<h1>` / `<h2>` / `role="heading"` | `Text(50020)` | 80051 / 80052 / 80053 | heading |
| body text | `Text(50020)` | 80050 (none) | description |
| `<th>` | `DataItem(50029)` | 80050 | columnheader |

So `Heading`/Windows stays `gap`, but for a reason the cell did not give: UIA marks a heading with the `HeadingLevel` property, and the reader maps by control type alone. The same run gave `Cell`/Windows a second observation — Edge reports an HTML table's header cells as `DataItem`, the control type that cell has been waiting on.

Android `ListItem`, `Cell` and `Heading` stay gap for the parallel reason: `CollectionItemInfo` and `isHeading` carry the semantics, and neither reader passes them on.

## What a cell claims

One `n/a` was doing three jobs and rendering them identically, which implied impossibility for all three. `NotApplicable` now carries a `Basis` and they render apart:

- `absent` — no such control exists to expose (iOS radio button, Android tree). 9 cells.
- `unmarked` — the control is on screen and no reading found a token for it. 25 cells.
- `elsewhere` — exposed, but outside what glass walks (the system status bar). 2 cells.

`gap` and `n/a` now split on **whose work it is to close a cell**: glass's or the platform's. And the legend says plainly that `unmarked` is a bounded reading, not a proof — on Android and iOS it could never be more, since an app sets its own `AccessibilityNodeInfo` class name and iOS role strings come from the Simulator's translator. Only UIA names a closed, documented set.

Splitting it caught two cells: Windows `Application` (the application is on screen reporting `Window` — unmarked, not absent) and iOS `RadioButton` (it named a segmented control's token as what a radio button reports instead). An invariant holds that line: a cell claiming the control does not exist cannot also name what it reports.

## The token is data now

Every non-`yes` cell that names a native token carries it as a field rather than in prose, and the page renders it as its own clause — `unmarked (reports AXGroup instead)`, `gap (AXPopUpButton arrives unmapped)`. That is the fact an agent holding an `Other(...)` wants.

What that checks, from running the mutations rather than assuming: prose in the token field fails (`ProgressBar/Ios: "a generic element" is prose, not a single native token`), and on Windows a name that is not a documented UIA control type fails (`Cell names DataItemish, not a UIA control type`, verified on the box since that column is `cfg(windows)`). The resolve check itself mostly sits behind the existing "declared out of reach but a token produces it" assertion, which fires first. A misspelt AX role or widget class resolves to `Other` and passes on both mobile columns — only an on-box read catches that, and the comments say so rather than implying the matrix self-verifies.

## Repeatable evidence

Two example apps hold the controls: `examples/android-role-fixture/` builds `javac` → `d8` → `aapt2` → `apksigner` with no Gradle, `examples/ios-role-fixture/` is a single `swiftc` call. The Android one scrolls and sizes in dp — a control off a short screen is absent from the dump, and an absent node reads exactly like a missing token. The iOS one takes its screen from `ROLE_FIXTURE_TAB` or a joined `--tab=name`, and treats a separated `--tab name` as fatal: `simctl` drops that value, which had been quietly launching the wrong screen.

Neither doc nor fixture hand-writes when a reading was taken: `git log` over `role_support.rs` answers that, and each read recipe opens by printing the API level or booted runtime it saw.

`AXTabGroup` and `AXPopUpButton` are pinned as unmapped in the iOS map's tests, so two observed-but-unmapped tokens live somewhere a reader hits.

## Not in this PR

- **The `yes` direction.** Three iOS cells claim `Mapped` on tokens no probe has seen — `AXCell`, `AXTabBar`, `AXToolbar`/`AXNavigationBar`, all added in #113, before the probe-first rule. Changing them changes what glass produces, not what it claims.
- **`spec.run[1..]` is silently dropped** by `glass-ios`'s `simctl launch` — a latent bug found while writing the fixture, worth its own issue.
- **Process termination.** Windows `stop_app` is job-close + `TerminateProcess` with no `WM_CLOSE`, so a driven app shows its own recovery prompt next launch; macOS is SIGTERM with a 500 ms fuse before SIGKILL. Both are pre-existing and unrelated to this change.

**No role mapping changed.** Every backend returns exactly the roles it returned before.

## Verification

- Android: the fixture plus Clock, Settings, Contacts and Calendar on an API 34 emulator. The toolbar reading was re-taken with a content description and `IMPORTANT_FOR_ACCESSIBILITY_YES`, so a pruned node could not be mistaken for a missing token.
- iOS: the fixture — all three screens, both alert styles, both picker styles, all three tab-selection paths including the two fatal ones — plus stock Settings on an iOS 26.5 Simulator.
- Windows: the heading page read in the interactive desktop session via the `schtasks` bounce `tools/windows-validation/run-onbox.ps1` uses, and `glass-a11y-windows`'s unit tests run on the box against this branch.
- Both fixtures rebuilt from their checked-in `build.sh` and re-read after every change. The Android script's failure paths were exercised directly (missing SDK, rebuild-signing, stale-artifact removal).
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` — green.
- Five-lens pre-merge panel (code review, silent failures, comments, type design, test coverage) run over the branch; its findings are commits 2 onwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)