### PR TITLE
fix(windows,macos): ask an app to close before killing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,9 @@ internal refactors, CI, or test-only changes.
   with a "Restore pages?" prompt instead of its normal first screen, so an agent driving it saw
   a different first screen on every run. An app that ignores or refuses the request is still
   terminated, and glass now says so on stderr rather than reporting an unqualified success.
+  Windows launches under Sandboxie containment are the exception and still get the old
+  teardown: a close request sent from outside the box is accepted by the OS but never reaches
+  the app, so landing one needs a helper running inside the box.
 - iOS: `glass_start` no longer reports a window for an app that died on launch. `simctl launch`
   exits successfully once the process is spawned, so an app that rejects a launch argument or
   trips an assertion at startup was reported as running, and the screenshot behind that geometry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,13 @@ internal refactors, CI, or test-only changes.
   Android paths have no such live check.
 
 ### Fixed
+- Windows and macOS: `glass_stop` now asks the app to close before killing it, so the app runs
+  its own shutdown path. Both backends previously went straight to terminating the process —
+  Windows by closing the job object, macOS by signalling — which an app that records whether it
+  exited cleanly reports as a crash the *next* time it starts. A Chromium-based browser opened
+  with a "Restore pages?" prompt instead of its normal first screen, so an agent driving it saw
+  a different first screen on every run. An app that ignores or refuses the request is still
+  terminated, and glass now says so on stderr rather than reporting an unqualified success.
 - iOS: `glass_start` no longer reports a window for an app that died on launch. `simctl launch`
   exits successfully once the process is spawned, so an app that rejects a launch argument or
   trips an assertion at startup was reported as running, and the screenshot behind that geometry

--- a/crates/glass-a11y-macos/Cargo.toml
+++ b/crates/glass-a11y-macos/Cargo.toml
@@ -10,7 +10,7 @@ publish.workspace = true
 glass-core.workspace = true
 
 # macOS-only FFI deps (objc2 family), used by the cfg-gated reader/ffi modules. Kept
-# in this target table so `mapping.rs` still builds on the Linux dev box with zero macOS
+# in this target table so `mapping.rs` still builds on any host with zero macOS
 # deps. Versions/features copied verbatim from `crates/glass-macos/Cargo.toml` so
 # `--locked` stays satisfiable against the already-resolved lockfile.
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/crates/glass-a11y-macos/Cargo.toml
+++ b/crates/glass-a11y-macos/Cargo.toml
@@ -10,7 +10,7 @@ publish.workspace = true
 glass-core.workspace = true
 
 # macOS-only FFI deps (objc2 family), used by the cfg-gated reader/ffi modules. Kept
-# in this target table so `mapping.rs` still builds on any host with zero macOS
+# in this target table so `mapping.rs` still builds off macOS with zero macOS
 # deps. Versions/features copied verbatim from `crates/glass-macos/Cargo.toml` so
 # `--locked` stays satisfiable against the already-resolved lockfile.
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/crates/glass-a11y-macos/src/lib.rs
+++ b/crates/glass-a11y-macos/src/lib.rs
@@ -5,7 +5,7 @@
 // `mapping` module stays `unsafe`-free by convention.
 #![allow(unsafe_code)]
 
-pub mod mapping; // pure AX->normalized mapping — cross-platform, unit-tested on the Linux dev box
+pub mod mapping; // pure AX->normalized mapping — cross-platform, unit-tested on any host
 
 // The cfg(macos) AXUIElement reader: `ffi` holds every `unsafe` AX read primitive, `reader`
 // the `unsafe`-free root selection + pre-order walk behind glass-core's `Accessibility`

--- a/crates/glass-a11y-macos/src/mapping.rs
+++ b/crates/glass-a11y-macos/src/mapping.rs
@@ -1,7 +1,7 @@
 #![forbid(unsafe_code)]
 //! Pure mapping from AXUIElement role strings + gathered state facts into glass's
-//! normalized `AxRole`/`AxStates`. No AXUIElement/objc2 calls — unit-tested directly on
-//! the Linux dev box. AX role strings (`kAXRoleAttribute`'s value) are the stable
+//! normalized `AxRole`/`AxStates`. No AXUIElement/objc2 calls — unit-tested directly on any
+//! host. AX role strings (`kAXRoleAttribute`'s value) are the stable
 //! `"AXButton"`/`"AXTextField"`/... constants; the reader passes the string so this
 //! module needs no macOS-only dependency.
 

--- a/crates/glass-a11y-windows/src/lib.rs
+++ b/crates/glass-a11y-windows/src/lib.rs
@@ -4,7 +4,7 @@
 //! `glass-a11y-linux`.
 
 pub mod doctor;
-pub mod mapping; // pure UIA->normalized mapping — cross-platform, unit-tested on any host // checks()/a11y_checks() are OS-free (probe_uia is cfg-split), so its tests run on Linux
+pub mod mapping; // pure UIA->normalized mapping — cross-platform, host-tested
 
 #[cfg(windows)]
 mod reader;

--- a/crates/glass-a11y-windows/src/lib.rs
+++ b/crates/glass-a11y-windows/src/lib.rs
@@ -4,7 +4,7 @@
 //! `glass-a11y-linux`.
 
 pub mod doctor;
-pub mod mapping; // pure UIA->normalized mapping — cross-platform, unit-tested on the Linux dev box // checks()/a11y_checks() are OS-free (probe_uia is cfg-split), so its tests run on Linux
+pub mod mapping; // pure UIA->normalized mapping — cross-platform, unit-tested on any host // checks()/a11y_checks() are OS-free (probe_uia is cfg-split), so its tests run on Linux
 
 #[cfg(windows)]
 mod reader;

--- a/crates/glass-a11y-windows/src/mapping.rs
+++ b/crates/glass-a11y-windows/src/mapping.rs
@@ -1,5 +1,5 @@
 //! Pure mapping from UI Automation control-type ids + gathered state facts into glass's
-//! normalized `AxRole`/`AxStates`. No UIA calls — unit-tested directly on the Linux dev box.
+//! normalized `AxRole`/`AxStates`. No UIA calls — unit-tested directly on any host.
 //! Control-type ids are the stable UIA `ControlTypeId` constants (50000..=50040); the reader
 //! passes the numeric id so this module needs no `uiautomation` dependency.
 

--- a/crates/glass-clip-hook/examples/clipprobe.rs
+++ b/crates/glass-clip-hook/examples/clipprobe.rs
@@ -7,7 +7,7 @@
 //! box also carrying `OpenClipboard=n`) the *only* way these calls can succeed is if the injected
 //! hook intercepts them and serves the private store — so a correct `READBACK` proves interception.
 //! Deliberately uses the raw user32 path (not OLE / .NET `Clipboard`), which is exactly what the
-//! v1 hook detours. Windows-only; a no-op elsewhere so the Linux dev box stays green.
+//! v1 hook detours. Windows-only; a no-op elsewhere so non-Windows builds stay green.
 //!   cargo build -p glass-clip-hook --release --example clipprobe
 
 // On-box FFI probe: opts out of the workspace `unsafe_code = "deny"` (each `unsafe` site is

--- a/crates/glass-clip-hook/src/hglobal.rs
+++ b/crates/glass-clip-hook/src/hglobal.rs
@@ -1,7 +1,7 @@
 //! RAII guards over Win32 `HGLOBAL` moveable memory, shared by the clipboard read/write paths
 //! (`glass-windows` clipboard + the injected `hook`). All `GlobalLock`/`GlobalUnlock`/`GlobalAlloc`/
 //! `GlobalFree`/`from_raw_parts` `unsafe` lives here once, behind safe APIs. Windows-only; the crate
-//! cross-compiles to `x86_64-pc-windows-gnu` so this is compile-checked on the Linux dev box.
+//! cross-compiles to `x86_64-pc-windows-gnu` so this is compile-checked on any host.
 
 use core::ffi::c_void;
 

--- a/crates/glass-clip-hook/src/lib.rs
+++ b/crates/glass-clip-hook/src/lib.rs
@@ -4,7 +4,7 @@
 //! `InjectDll64=`, which detours the user32 clipboard APIs and proxies them to a host store
 //! over a named pipe; (2) a pure **library** (`rlib`) exposing the wire [`proto`]col and the
 //! host-side [`store`], reused by `glass-windows`. Only [`hook`] is Win32 — the rest is pure
-//! and unit-tested on the Linux dev box.
+//! and unit-tested on any host.
 
 // FFI backend: the Win32 hook needs `unsafe`, so this crate opts out of the workspace
 // `unsafe_code = "deny"`; each site carries a `// SAFETY:` note (see CLAUDE.md). The pure
@@ -15,7 +15,7 @@ pub mod proto;
 pub mod store;
 
 // Pure clipboard text codecs the windows hook defers to. Compiled for windows (the hook) and for
-// test (so the suite runs + Miri-checks on the Linux dev box); unused on a non-test non-windows
+// test (so the suite runs + Miri-checks on any host); unused on a non-test non-windows
 // build, hence the cfg gate.
 #[cfg(any(windows, test))]
 mod text;

--- a/crates/glass-clip-hook/src/text.rs
+++ b/crates/glass-clip-hook/src/text.rs
@@ -1,4 +1,4 @@
-//! Pure clipboard text codecs (no Win32), unit-tested + Miri-checked on the Linux dev box.
+//! Pure clipboard text codecs (no Win32), unit-tested + Miri-checked on any host.
 //!
 //! The `cfg(windows)` hook does the `unsafe` FFI — locking an `HGLOBAL` into a slice *bounded by
 //! `GlobalSize`* — and defers the actual NUL-terminated parse/encode to these helpers. So the

--- a/crates/glass-core/src/coords.rs
+++ b/crates/glass-core/src/coords.rs
@@ -1,5 +1,5 @@
 //! Pure window-relative / global ↔ point/pixel coordinate scale math. Cross-platform →
-//! unit-tested on the Linux dev box.
+//! unit-tested on any host.
 //!
 //! This is the single source of truth for point↔pixel conversion on macOS, shared by
 //! `glass-macos` (capture/window ops) and `glass-a11y-macos` (the accessibility reader) so
@@ -63,7 +63,7 @@ pub fn point_to_global_pixel(pt: (f64, f64), scale: f64) -> (i32, i32) {
 /// `capture.rs`'s captured frame always agree on width/height in pixels.
 ///
 /// Pure `f64` math (no `CGRect` dependency) so the Retina (2x) scaling is unit-tested here
-/// even on a 1x dev box — `scwindow.rs` itself only compiles on macOS.
+/// even on a 1x host — `scwindow.rs` itself only compiles on macOS.
 ///
 /// Each field rounds independently (`f64::round`, ties away from zero) rather than
 /// truncating, so a fractional point value doesn't consistently lose a pixel. Width/height

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -64,7 +64,8 @@ pub use logbuf::{LogBuffer, LogLine, Stream};
 pub mod platform;
 pub use platform::{
     A11yBind, AppSpec, KeyEvent, MAX_GESTURE_POINTERS, MouseButton, Platform, PointerEvent,
-    SandboxLevel, Segment, WindowGeometry, WindowHint, WindowId, WindowInfo, WindowOp,
+    SandboxLevel, Segment, TEARDOWN_BUDGET, WindowGeometry, WindowHint, WindowId, WindowInfo,
+    WindowOp,
 };
 
 pub mod accessibility;

--- a/crates/glass-core/src/platform.rs
+++ b/crates/glass-core/src/platform.rs
@@ -1,9 +1,22 @@
 use std::path::PathBuf;
+use std::time::Duration;
 
 use crate::error::{GlassError, Result};
 use crate::frame::{Frame, Region};
 use crate::keys::Modifier;
 use crate::logbuf::Stream;
+
+/// The wall-clock budget the whole of teardown gets when the *process* is going away — the
+/// server's stdin closed or a termination signal arrived. `glass-mcp`'s shutdown path spends it
+/// on `Glass::shutdown` and then exits regardless, so anything a [`Platform::stop_app`] impl was
+/// still waiting on is abandoned mid-flight: on a Unix backend that orphans the app to init.
+///
+/// Every backend's teardown must therefore fit inside this, with room for the work that follows
+/// it. A backend that waits on the app being polite has to bound that wait against this constant
+/// — it lives here, rather than as a private number in `glass-mcp`, precisely because the
+/// backends are the ones that have to respect it and they cannot see a private one. Each backend
+/// asserts its own budget against it at compile time; grep for `TEARDOWN_BUDGET` to find them.
+pub const TEARDOWN_BUDGET: Duration = Duration::from_secs(3);
 
 /// How aggressively to contain the process tree a backend launches. Platform-agnostic
 /// *policy*; the Linux mechanism (bubblewrap) lives in the `glass-sandbox-linux` crate.

--- a/crates/glass-ios/tests/drive_integration.rs
+++ b/crates/glass-ios/tests/drive_integration.rs
@@ -7,7 +7,7 @@
 //! center lands on that element (the READY→TAPPED flip), and typed text — both raw
 //! `send_key` and the `set_value` clear-then-type sequence — reaches the field.
 //!
-//! `#[ignore]`d so a plain `cargo test` (a non-macOS host, CI) skips it: the backend needs
+//! `#[ignore]`d so a plain `cargo test` skips it everywhere: the backend needs
 //! `xcrun simctl` + `idb_companion` (macOS + Xcode only), a booted Simulator, and the
 //! GlassFixture app from `examples/ios-fixture/`. Run explicitly on such a host:
 //!

--- a/crates/glass-ios/tests/drive_integration.rs
+++ b/crates/glass-ios/tests/drive_integration.rs
@@ -7,7 +7,7 @@
 //! center lands on that element (the READY→TAPPED flip), and typed text — both raw
 //! `send_key` and the `set_value` clear-then-type sequence — reaches the field.
 //!
-//! `#[ignore]`d so a plain `cargo test` (Linux dev host, CI) skips it: the backend needs
+//! `#[ignore]`d so a plain `cargo test` (a non-macOS host, CI) skips it: the backend needs
 //! `xcrun simctl` + `idb_companion` (macOS + Xcode only), a booted Simulator, and the
 //! GlassFixture app from `examples/ios-fixture/`. Run explicitly on such a host:
 //!

--- a/crates/glass-ios/tests/launch_args_integration.rs
+++ b/crates/glass-ios/tests/launch_args_integration.rs
@@ -7,7 +7,7 @@
 //! the role fixture selects its screen from `--tab=<name>`, and the selected screen is
 //! identifiable in the tree.
 //!
-//! `#[ignore]`d so a plain `cargo test` (a non-macOS host, CI) skips it: the backend needs
+//! `#[ignore]`d so a plain `cargo test` skips it everywhere: the backend needs
 //! `xcrun simctl` + `idb_companion` (macOS + Xcode only), a booted Simulator, and the RoleFixture
 //! app from `examples/ios-role-fixture/`. Run explicitly on such a host:
 //!

--- a/crates/glass-ios/tests/launch_args_integration.rs
+++ b/crates/glass-ios/tests/launch_args_integration.rs
@@ -7,7 +7,7 @@
 //! the role fixture selects its screen from `--tab=<name>`, and the selected screen is
 //! identifiable in the tree.
 //!
-//! `#[ignore]`d so a plain `cargo test` (Linux dev host, CI) skips it: the backend needs
+//! `#[ignore]`d so a plain `cargo test` (a non-macOS host, CI) skips it: the backend needs
 //! `xcrun simctl` + `idb_companion` (macOS + Xcode only), a booted Simulator, and the RoleFixture
 //! app from `examples/ios-role-fixture/`. Run explicitly on such a host:
 //!

--- a/crates/glass-ios/tests/smoke_integration.rs
+++ b/crates/glass-ios/tests/smoke_integration.rs
@@ -3,7 +3,7 @@
 //! clipboard round-trip, stop — exactly the sequence `glass_start`/`glass_screenshot`/
 //! `glass_clipboard_*`/`glass_stop` exercise over MCP.
 //!
-//! `#[ignore]`d so a plain `cargo test` (a non-macOS host, CI) skips it; the backend shells out
+//! `#[ignore]`d so a plain `cargo test` skips it everywhere; the backend shells out
 //! to `xcrun simctl`, which only exists on macOS with Xcode installed, and this test additionally
 //! needs a booted Simulator and a real app to launch. Run explicitly on a macOS host with a
 //! Simulator already booted:

--- a/crates/glass-ios/tests/smoke_integration.rs
+++ b/crates/glass-ios/tests/smoke_integration.rs
@@ -3,7 +3,7 @@
 //! clipboard round-trip, stop — exactly the sequence `glass_start`/`glass_screenshot`/
 //! `glass_clipboard_*`/`glass_stop` exercise over MCP.
 //!
-//! `#[ignore]`d so a plain `cargo test` (Linux dev host, CI) skips it; the backend shells out
+//! `#[ignore]`d so a plain `cargo test` (a non-macOS host, CI) skips it; the backend shells out
 //! to `xcrun simctl`, which only exists on macOS with Xcode installed, and this test additionally
 //! needs a booted Simulator and a real app to launch. Run explicitly on a macOS host with a
 //! Simulator already booted:

--- a/crates/glass-ios/tests/startup_log_integration.rs
+++ b/crates/glass-ios/tests/startup_log_integration.rs
@@ -9,7 +9,7 @@
 //! buffered by the time `start_app` returns. This test drives the real `Platform` path and
 //! asserts the launch-time marker reaches `drain_logs()`.
 //!
-//! `#[ignore]`d so a plain `cargo test` (a non-macOS host, CI) skips it: the backend shells out
+//! `#[ignore]`d so a plain `cargo test` skips it everywhere: the backend shells out
 //! to `xcrun simctl` (macOS + Xcode only) and needs a booted Simulator plus an app that logs a
 //! known line at launch. Point it at such an app and tell it the exact line to expect:
 //!

--- a/crates/glass-ios/tests/startup_log_integration.rs
+++ b/crates/glass-ios/tests/startup_log_integration.rs
@@ -9,7 +9,7 @@
 //! buffered by the time `start_app` returns. This test drives the real `Platform` path and
 //! asserts the launch-time marker reaches `drain_logs()`.
 //!
-//! `#[ignore]`d so a plain `cargo test` (Linux dev host, CI) skips it: the backend shells out
+//! `#[ignore]`d so a plain `cargo test` (a non-macOS host, CI) skips it: the backend shells out
 //! to `xcrun simctl` (macOS + Xcode only) and needs a booted Simulator plus an app that logs a
 //! known line at launch. Point it at such an app and tell it the exact line to expect:
 //!

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -66,7 +66,7 @@ glass-core.workspace = true
 plist = "1"
 
 # macOS-only FFI deps (objc2 family). Kept in this target table so the crate's pure
-# modules still build on the Linux dev box with zero macOS deps. Versions pinned to
+# modules still build on any host with zero macOS deps. Versions pinned to
 # exactly what the objc2 spike proved compiles + runs cleanly
 # (zero warnings) against the real frameworks on macOS. Each `objc2-*` framework crate
 # gates its ObjC types behind per-type Cargo features; `default-features = false` +
@@ -216,7 +216,7 @@ tempfile.workspace = true
 
 # Mac-only: the accessibility-reader integration test (tests/a11y.rs) drives the standalone
 # `glass-a11y-macos` snapshot. Kept in the cfg(macos) dev-dep table so the crate still
-# builds/tests on the Linux dev box (where the cfg(macos) test is a bare skip `main`).
+# builds/tests on any host (where the cfg(macos) test is a bare skip `main`).
 [target.'cfg(target_os = "macos")'.dev-dependencies]
 glass-a11y-macos.workspace = true
 

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -66,7 +66,7 @@ glass-core.workspace = true
 plist = "1"
 
 # macOS-only FFI deps (objc2 family). Kept in this target table so the crate's pure
-# modules still build on any host with zero macOS deps. Versions pinned to
+# modules still build off macOS with zero macOS deps. Versions pinned to
 # exactly what the objc2 spike proved compiles + runs cleanly
 # (zero warnings) against the real frameworks on macOS. Each `objc2-*` framework crate
 # gates its ObjC types behind per-type Cargo features; `default-features = false` +
@@ -216,7 +216,7 @@ tempfile.workspace = true
 
 # Mac-only: the accessibility-reader integration test (tests/a11y.rs) drives the standalone
 # `glass-a11y-macos` snapshot. Kept in the cfg(macos) dev-dep table so the crate still
-# builds/tests on any host (where the cfg(macos) test is a bare skip `main`).
+# builds/tests off macOS (where the cfg(macos) test is a bare skip `main`).
 [target.'cfg(target_os = "macos")'.dev-dependencies]
 glass-a11y-macos.workspace = true
 

--- a/crates/glass-macos/fixture/quadrants.swift
+++ b/crates/glass-macos/fixture/quadrants.swift
@@ -249,6 +249,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.activate(ignoringOtherApps: true)
     }
 
+    /// AppKit's "you are about to quit" notification — the one an app uses to flush state.
+    /// It runs when the app is *asked* to quit and not when it is signalled, so announcing it
+    /// on stdout (already captured, like the input echoes above) lets a test tell those two
+    /// teardowns apart from outside the process.
+    func applicationWillTerminate(_ notification: Notification) {
+        print("quit: shutdown path ran")
+        fflush(stdout)
+    }
+
     private func makeWindow(origin: NSPoint, title: String, palette: QuadrantPalette) -> FixtureWindow {
         let rect = NSRect(origin: origin, size: windowSize)
         let window = FixtureWindow(

--- a/crates/glass-macos/fixture/quadrants.swift
+++ b/crates/glass-macos/fixture/quadrants.swift
@@ -29,10 +29,11 @@
 // stdout, flushing after each — used by the capture test only to confirm the process is
 // alive, but not for pixel assertions.
 //
-// This fixture is shared by THREE integration tests: the Plan 2 capture test (relies on
-// the 4-quadrant colors + exact 400x400 borderless window size), the Plan 3 input test
-// (relies on the event reporting below), and the Plan 4 window test (relies on the
-// SECOND window described next). `QuadrantView` is made key/first-responder so it
+// This fixture is shared by FIVE tests: the Plan 2 capture test (relies on the 4-quadrant
+// colors + exact 400x400 borderless window size), the Plan 3 input test (relies on the
+// event reporting below), the Plan 4 window test (relies on the SECOND window described
+// next), the bundle-launch test, and glass-macos's own `terminate` unit tests (which rely
+// on the `quit:` line and on GLASS_FIXTURE_VETO_QUIT, both described below). `QuadrantView` is made key/first-responder so it
 // actually receives keyboard and mouse events, and reports each one to stdout as a
 // single flushed line so the driving test can assert on injected input landing
 // correctly:
@@ -46,6 +47,13 @@
 //   scroll: <dx>,<dy>      — one line per scrollWheel, `scrollingDeltaX`/`scrollingDeltaY`
 //                             verbatim (sign as macOS reports it), for verifying the
 //                             scroll-wheel sign convention against the tool boundary.
+//   quit: ...              — once, from `applicationWillTerminate:`. AppKit runs that
+//                             method when the app is ASKED to quit and not when it is
+//                             signalled, so its presence tells a test which teardown ran.
+//
+// GLASS_FIXTURE_VETO_QUIT=1 makes the app refuse the quit request (`NSTerminateCancel`),
+// standing in for a real app's unsaved-changes sheet — so a test can drive the case where
+// asking politely is not enough and the signal ladder has to finish the job.
 //
 // Both windows report through these same three prefixes (they're separate instances of
 // the same `QuadrantView` class) — a deliberate simplification: only Plan 4 Task 6's
@@ -256,6 +264,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationWillTerminate(_ notification: Notification) {
         print("quit: shutdown path ran")
         fflush(stdout)
+    }
+
+    /// Opt-in refusal, for testing the teardown path where asking is not enough. A real app
+    /// does this from an unsaved-changes sheet; there is no way to distinguish the two from
+    /// outside, which is the point.
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        if ProcessInfo.processInfo.environment["GLASS_FIXTURE_VETO_QUIT"] == "1" {
+            print("quit: refused")
+            fflush(stdout)
+            return .terminateCancel
+        }
+        return .terminateNow
     }
 
     private func makeWindow(origin: NSPoint, title: String, palette: QuadrantPalette) -> FixtureWindow {

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -130,11 +130,18 @@ impl Adopted {
     /// escalation): an app that vetoes quit (e.g. an unsaved-changes sheet) is left running
     /// by design, trading a possible stray process for never forcibly killing an app
     /// mid-edit and losing the user's work.
+    ///
+    /// Having no escalation to fall back to is exactly why a failed request is *reported*: it
+    /// is the only thing left to do with it, and `stop_app` otherwise returns success while an
+    /// app glass launched is still on screen.
     fn reap(self) {
-        if self.disposition.should_terminate() {
-            // Whether the request landed is deliberately not acted on: there is no escalation
-            // to fall back to on this path, so a `false` would only be something to report.
-            let _ = crate::ffi::terminate_app(self.pid);
+        if self.disposition.should_terminate() && !crate::ffi::terminate_app(self.pid) {
+            eprintln!(
+                "glass: could not ask the app (pid {}) to quit — it is already gone, or no \
+                 longer registered as a running application. If it is still running, quit it \
+                 manually; glass does not force-kill an app it only adopted.",
+                self.pid
+            );
         }
     }
 }
@@ -343,8 +350,16 @@ impl MacosPlatform {
                         // `None` just found above means any instance running now is one we
                         // spawned, so best-effort reclaim it before propagating the error.
                         Err(e) => {
-                            if let Some(pid) = crate::ffi::running_pid_for_bundle_id(&id) {
-                                crate::ffi::terminate_app(pid);
+                            if let Some(pid) = crate::ffi::running_pid_for_bundle_id(&id)
+                                && !crate::ffi::terminate_app(pid)
+                            {
+                                // The launch error propagating below says nothing about this
+                                // stray app, and there is no `Child` here to escalate with.
+                                eprintln!(
+                                    "glass: the launch failed and the instance it started \
+                                     (pid {pid}) could not be asked to quit; if it is still \
+                                     running, quit it manually"
+                                );
                             }
                             return Err(e);
                         }

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -132,7 +132,9 @@ impl Adopted {
     /// mid-edit and losing the user's work.
     fn reap(self) {
         if self.disposition.should_terminate() {
-            crate::ffi::terminate_app(self.pid);
+            // Whether the request landed is deliberately not acted on: there is no escalation
+            // to fall back to on this path, so a `false` would only be something to report.
+            let _ = crate::ffi::terminate_app(self.pid);
         }
     }
 }

--- a/crates/glass-macos/src/clipboard_route.rs
+++ b/crates/glass-macos/src/clipboard_route.rs
@@ -1,6 +1,6 @@
 //! Pure clipboard-routing policy for the macOS backend. Decides how `glass_clipboard_get/set`
 //! behave for the active session, mirroring the Windows `ClipboardRoute`. No OS calls — unit
-//! -tested on the Linux dev box.
+//! -tested on any host.
 #![forbid(unsafe_code)]
 
 use glass_core::platform::SandboxLevel;

--- a/crates/glass-macos/src/coords.rs
+++ b/crates/glass-macos/src/coords.rs
@@ -1,5 +1,4 @@
-//! Pure window-relative ↔ global coordinate math. Cross-platform → unit-tested on the
-//! Linux dev box.
+//! Pure window-relative ↔ global coordinate math. Cross-platform → unit-tested on any host.
 //!
 //! The point↔pixel scale kernel itself lives in [`glass_core::coords`] so glass-macos
 //! (capture/window ops) and glass-a11y-macos (the a11y reader) share ONE implementation —

--- a/crates/glass-macos/src/ffi.rs
+++ b/crates/glass-macos/src/ffi.rs
@@ -268,10 +268,11 @@ pub(crate) fn launch_bundle(bundle: &Path, args: &[String], timeout_ms: u64) -> 
 /// not GUI-registered, or is already gone) or AppKit declined to send, and a caller that
 /// needs the process gone must fall back to signalling it.
 ///
-/// Only signals are available without this: measured on macOS 26, a directly-spawned bundle
-/// executable asked this way runs `applicationWillTerminate:` and exits in ~390 ms, while
-/// `SIGTERM` and `SIGKILL` both end it with that method never called — an app gets no chance
-/// to flush state under either.
+/// Only signals are available without this, and they run no shutdown path at all: AppKit installs
+/// no `SIGTERM` handler, so the default disposition ends the process with
+/// `applicationWillTerminate:` never called and nothing flushed. Measured against a minimal AppKit
+/// app, which ran that method and exited a few hundred milliseconds after being asked this way,
+/// and did not run it under `SIGTERM`.
 ///
 /// The `false` return is advisory, not an error. `backend.rs`'s `stop_app` path doesn't need
 /// to know whether the app was already gone before it asked (unlike `input.rs::focus`'s

--- a/crates/glass-macos/src/ffi.rs
+++ b/crates/glass-macos/src/ffi.rs
@@ -262,15 +262,24 @@ pub(crate) fn launch_bundle(bundle: &Path, args: &[String], timeout_ms: u64) -> 
     }
 }
 
-/// Gracefully terminate the running application with this pid; a no-op if the pid is
-/// already gone. Cleanup-only (unlike `input.rs::focus`'s identical lookup, which treats a
-/// missing pid as the hard error `GlassError::AppExited` because a caller is depending on
-/// the activation landing) — `backend.rs`'s `stop_app` path doesn't need to know whether the
-/// app was already gone before it asked.
-pub(crate) fn terminate_app(pid: i32) {
-    if let Some(app) = NSRunningApplication::runningApplicationWithProcessIdentifier(pid) {
-        app.terminate();
-    }
+/// Ask the running application with this pid to quit through its own shutdown path —
+/// `-[NSRunningApplication terminate]`, the same request Cmd-Q sends. Returns whether the
+/// request was actually delivered: `false` means the pid owns no running application (it is
+/// not GUI-registered, or is already gone) or AppKit declined to send, and a caller that
+/// needs the process gone must fall back to signalling it.
+///
+/// Only signals are available without this: measured on macOS 26, a directly-spawned bundle
+/// executable asked this way runs `applicationWillTerminate:` and exits in ~390 ms, while
+/// `SIGTERM` and `SIGKILL` both end it with that method never called — an app gets no chance
+/// to flush state under either.
+///
+/// The `false` return is advisory, not an error. `backend.rs`'s `stop_app` path doesn't need
+/// to know whether the app was already gone before it asked (unlike `input.rs::focus`'s
+/// identical lookup, which treats a missing pid as the hard error `GlassError::AppExited`
+/// because a caller is depending on the activation landing).
+pub(crate) fn terminate_app(pid: i32) -> bool {
+    NSRunningApplication::runningApplicationWithProcessIdentifier(pid)
+        .is_some_and(|app| app.terminate())
 }
 
 #[cfg(test)]

--- a/crates/glass-macos/src/keymap.rs
+++ b/crates/glass-macos/src/keymap.rs
@@ -1,5 +1,5 @@
 //! Pure US-layout ASCII → (virtual keycode, needs-shift). Cross-platform so it is
-//! unit-tested on the Linux dev box; Plan 3's CGEvent input casts `u16 as CGKeyCode`.
+//! unit-tested on any host; Plan 3's CGEvent input casts `u16 as CGKeyCode`.
 //! Keycodes are the documented Carbon `kVK_ANSI_*` values (validated in inject_input.swift).
 
 /// Map an ASCII character to its US-layout virtual keycode and whether Shift is held.

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -2,7 +2,7 @@
 //! rendered onto a `CGVirtualDisplay`).
 //!
 //! Like `glass-windows`, the pure logic ([`keymap`], [`coords`], [`clipboard_route`],
-//! [`shim_path`]) is crate-level and unit-tested on the Linux dev box; the OS-touching
+//! [`shim_path`]) is crate-level and unit-tested on any host; the OS-touching
 //! modules and the `MacosPlatform` impl are gated `#[cfg(target_os = "macos")]`. Off macOS
 //! the crate exposes only the pure modules and the [`capabilities`] map (whose `accessibility`
 //! cell is live; every other cell is constant).

--- a/crates/glass-macos/src/process.rs
+++ b/crates/glass-macos/src/process.rs
@@ -36,7 +36,7 @@ use std::time::{Duration, Instant};
 use rustix::process::{Pid, Signal, kill_process};
 
 use glass_core::platform::{AppSpec, SandboxLevel};
-use glass_core::{GlassError, Result, Stream};
+use glass_core::{GlassError, Result, Stream, TEARDOWN_BUDGET};
 use glass_sandbox_macos::{ProfileOpts, build_profile, launch_reallows};
 
 /// Per-spawn counter feeding one component of
@@ -140,10 +140,25 @@ pub(crate) type LogSink = Arc<Mutex<Vec<(Stream, String)>>>;
 const TERMINATE_GRACE: Duration = Duration::from_millis(500);
 
 /// How long [`terminate`] waits for the app to quit through its own shutdown path after being
-/// asked ([`crate::ffi::terminate_app`]), before falling back to signals. Only an app that
-/// will not quit pays this in full — a cooperating one ends the wait as soon as it exits
-/// (measured: ~390 ms for a minimal AppKit app). Matches the Windows backend's close grace.
-const QUIT_GRACE: Duration = Duration::from_secs(3);
+/// asked ([`crate::ffi::terminate_app`], which carries the measurement), before falling back to
+/// signals. An app that cannot be asked skips this entirely rather than spending it; only one
+/// that was asked and will not go pays it in full — several times over what a cooperating app
+/// was measured to need. Matches the Windows backend's close grace.
+///
+/// The ladder that follows this — `SIGTERM`, [`TERMINATE_GRACE`], `SIGKILL` — has to fit inside
+/// [`TEARDOWN_BUDGET`] too, and it is the part that actually guarantees the app is gone. When the
+/// *process* is going away, `glass-mcp` abandons teardown once that budget is spent, and a
+/// `spawn_blocking` teardown thread cannot be cancelled: a grace long enough to swallow the budget
+/// would mean the signals were never sent at all and the app outlived glass, orphaned to launchd.
+const QUIT_GRACE: Duration = Duration::from_millis(1500);
+
+// The whole ladder must finish inside the budget glass-mcp allows teardown, or it is abandoned
+// partway and the child is orphaned. This is the only thing keeping the numbers — in different
+// crates — honest about each other.
+const _: () = assert!(
+    QUIT_GRACE.as_millis() + TERMINATE_GRACE.as_millis() < TEARDOWN_BUDGET.as_millis(),
+    "the ask + signal ladder must complete inside glass_core::TEARDOWN_BUDGET"
+);
 
 /// How often the exit waits re-check the child.
 const EXIT_POLL: Duration = Duration::from_millis(20);
@@ -343,9 +358,11 @@ fn spawn_reader<R: std::io::Read + Send + 'static>(reader: R, stream: Stream, si
 }
 
 /// Idempotently terminate `child`: ask it to quit, wait up to [`QUIT_GRACE`], then SIGTERM,
-/// wait up to [`TERMINATE_GRACE`], then SIGKILL, then reap. Safe to call on an already-exited
-/// (or already-terminated) child — `try_wait` is checked first so a second call never
-/// re-signals a pid the kernel may have since recycled.
+/// wait up to [`TERMINATE_GRACE`], then SIGKILL, then reap. A child that *cannot* be asked —
+/// anything not registered as a running application, which is every console-shaped process —
+/// skips the quit grace entirely rather than spending it, so its teardown is as fast as it was
+/// before. Safe to call on an already-exited (or already-terminated) child — `try_wait` is
+/// checked first so a second call never re-signals a pid the kernel may have since recycled.
 ///
 /// The quit request comes first because signals give a Cocoa app no shutdown path at all:
 /// AppKit installs no `SIGTERM` handler, so the default disposition ends the process with
@@ -354,25 +371,29 @@ fn spawn_reader<R: std::io::Read + Send + 'static>(reader: R, stream: Stream, si
 /// full signal ladder afterwards, so teardown always completes; this only adds the chance to
 /// leave cleanly, it does not make the process harder to stop.
 ///
-/// This is the child-backed path. A LaunchServices-adopted app (`backend.rs`'s `Adopted`) is
-/// asked the same way but never escalated — glass did not spawn it as a child and will not
-/// force-kill an app it only adopted; see `Adopted::reap`.
+/// This is the child-backed path. A LaunchServices-adopted app (`backend.rs`'s `Adopted`) that
+/// glass started is asked the same way but never escalated — glass will not force-kill an app it
+/// only adopted — and one that was merely re-found running is not asked at all; see
+/// `Adopted::reap`.
 pub(crate) fn terminate(child: &mut Child) {
     if matches!(child.try_wait(), Ok(Some(_))) {
         return;
     }
 
-    // A pid too large for `i32` cannot be a macOS pid; `None` just means "couldn't ask", which
-    // is the same fallback as an app that isn't GUI-registered.
+    // A pid too large for `i32` cannot be a macOS pid, so a conversion failure lands in the
+    // same place as an app that isn't GUI-registered: couldn't ask, fall through to signals.
     let asked = i32::try_from(child.id()).is_ok_and(crate::ffi::terminate_app);
     if asked && wait_for_exit(child, QUIT_GRACE) {
-        let _ = child.wait(); // Reap so the child doesn't linger as a zombie.
+        // `wait_for_exit` only reports true via `try_wait() == Ok(Some(_))`, which has already
+        // reaped; this just collects the status so the call reads the same as the path below.
+        let _ = child.wait();
         return;
     }
 
     let pid = Pid::from_child(child);
     let _ = kill_process(pid, Signal::TERM);
-    wait_for_exit(child, TERMINATE_GRACE);
+    // Whether SIGTERM was enough or not, SIGKILL follows — it is idempotent on an exited child.
+    let _ = wait_for_exit(child, TERMINATE_GRACE);
 
     let _ = child.kill(); // SIGKILL, tolerates an already-exited child.
     let _ = child.wait(); // Reap so the child doesn't linger as a zombie.
@@ -610,30 +631,14 @@ mod tests {
     #[cfg(target_os = "macos")]
     const LOG_DRAIN_SETTLE: Duration = Duration::from_millis(500);
 
-    #[test]
+    /// Build `fixture/quadrants.swift` to a fresh temp path, returning (binary, build dir).
     #[cfg(target_os = "macos")]
-    fn terminate_asks_a_gui_app_to_quit_before_signalling_it() {
-        // The whole point of the quit request: AppKit installs no SIGTERM handler, so a
-        // signalled Cocoa app never runs `applicationWillTerminate:`. The fixture announces
-        // that method on stdout, so the captured line exists only if `terminate` asked first —
-        // no signal-only teardown can produce it.
-        //
-        // On-device: needs `swiftc` to build the fixture and a window-server session for it to
-        // launch into, so it is gated behind the same `GLASS_MACOS_ONBOX` switch
-        // `scripts/test-macos.sh` uses for its other on-device work rather than run in CI.
-        if std::env::var_os("GLASS_MACOS_ONBOX").is_none() {
-            println!(
-                "terminate_asks_a_gui_app_to_quit_before_signalling_it: SKIPPED — set \
-                 GLASS_MACOS_ONBOX=1 to run it (needs swiftc and a window-server session)"
-            );
-            return;
-        }
-
+    fn build_quit_fixture(tag: &str) -> (PathBuf, PathBuf) {
         let source = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("fixture")
             .join("quadrants.swift");
         let build_dir =
-            std::env::temp_dir().join(format!("glass-quit-fixture-{}", std::process::id()));
+            std::env::temp_dir().join(format!("glass-quit-fixture-{tag}-{}", std::process::id()));
         std::fs::create_dir_all(&build_dir).expect("create fixture build dir");
         let fixture = build_dir.join("quit-fixture");
         let status = Command::new("swiftc")
@@ -648,7 +653,24 @@ mod tests {
             .status()
             .expect("run swiftc");
         assert!(status.success(), "swiftc failed on {}", source.display());
+        (fixture, build_dir)
+    }
 
+    #[test]
+    #[cfg(target_os = "macos")]
+    #[ignore = "on-device only: needs swiftc and a window-server session"]
+    fn terminate_asks_a_gui_app_to_quit_before_signalling_it() {
+        // The whole point of the quit request: AppKit installs no SIGTERM handler, so a
+        // signalled Cocoa app never runs `applicationWillTerminate:`. The fixture announces
+        // that method on stdout, so the captured line exists only if `terminate` asked first —
+        // no signal-only teardown can produce it.
+        //
+        // `#[ignore]`d rather than self-skipping on an env var: it needs `swiftc` to build the
+        // fixture and a real window-server session for that fixture to become a running
+        // application, so on a CI runner it would report a pass having asserted nothing.
+        // `scripts/test-macos.sh` runs it explicitly under `GLASS_MACOS_ONBOX=1`.
+
+        let (fixture, build_dir) = build_quit_fixture("ask");
         let sink = empty_sink();
         let (mut child, _clip) = spawn(
             &spec(&[fixture.to_string_lossy().as_ref()]),
@@ -666,6 +688,53 @@ mod tests {
             logs.iter()
                 .any(|(stream, line)| *stream == Stream::Stdout && line.starts_with("quit: ")),
             "terminate must ask the app to quit before signalling it; captured logs: {logs:?}"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    #[ignore = "on-device only: needs swiftc and a window-server session"]
+    fn terminate_finishes_off_an_app_that_refuses_to_quit() {
+        // `terminate`'s doc promises that an app which vetoes the request still gets the full
+        // signal ladder, so teardown always completes — the one claim on this path that a
+        // cooperating fixture cannot exercise. `GLASS_FIXTURE_VETO_QUIT` makes the fixture
+        // answer `NSTerminateCancel`, standing in for an unsaved-changes sheet.
+        //
+        // The elapsed bound is the load-bearing half: it pins the ladder inside the budget
+        // `glass-mcp` allows teardown. Overrun it and `glass_stop` is abandoned mid-wait with
+        // the app never signalled at all — orphaned to launchd, outliving glass itself.
+        let (fixture, build_dir) = build_quit_fixture("veto");
+        let mut spec = spec(&[fixture.to_string_lossy().as_ref()]);
+        spec.env = vec![("GLASS_FIXTURE_VETO_QUIT".to_string(), "1".to_string())];
+
+        let sink = empty_sink();
+        let (mut child, _clip) = spawn(&spec, Arc::clone(&sink)).expect("spawn the AppKit fixture");
+        std::thread::sleep(FIXTURE_LAUNCH_SETTLE);
+
+        let started = Instant::now();
+        terminate(&mut child);
+        let elapsed = started.elapsed();
+        std::thread::sleep(LOG_DRAIN_SETTLE);
+        let logs = sink.lock().expect("log sink mutex").clone();
+        let _ = std::fs::remove_dir_all(&build_dir);
+
+        assert!(
+            logs.iter().any(
+                |(stream, line)| *stream == Stream::Stdout && line.starts_with("quit: refused")
+            ),
+            "the fixture must actually have refused, or this proves nothing; captured: {logs:?}"
+        );
+        assert!(
+            child
+                .try_wait()
+                .expect("try_wait after terminate")
+                .is_some(),
+            "a vetoing app must still be gone after terminate"
+        );
+        assert!(
+            elapsed < TEARDOWN_BUDGET,
+            "terminate took {elapsed:?}, over the {TEARDOWN_BUDGET:?} glass-mcp allows teardown \
+             — past that the app is left running and glass exits without it"
         );
     }
 

--- a/crates/glass-macos/src/process.rs
+++ b/crates/glass-macos/src/process.rs
@@ -3,8 +3,9 @@
 //! Mirrors `glass-x11`/`glass-wayland`'s `spawn`+`spawn_reader`+`LogSink` shape: a plain
 //! `std::process::Command` built from [`AppSpec`], stdout/stderr piped into a shared,
 //! `Arc<Mutex<_>>`-guarded log buffer via one reader thread per stream, so
-//! `MacosPlatform::drain_logs` can read it without blocking the readers. `terminate`
-//! mirrors `glass-proc-linux::reap`'s SIGTERM -> brief wait -> SIGKILL -> reap sequence,
+//! `MacosPlatform::drain_logs` can read it without blocking the readers. `terminate` asks
+//! the app to quit first — AppKit runs no shutdown path for a signal — and only then falls
+//! back to `glass-proc-linux::reap`'s SIGTERM -> brief wait -> SIGKILL -> reap sequence,
 //! reimplemented here (rather than depending on that crate) because it is `/proc`-based
 //! and therefore Linux-only.
 //!
@@ -133,10 +134,19 @@ fn shim_dylib_path_with(env_override: Option<PathBuf>) -> Option<PathBuf> {
 /// it from the main thread — the same shape `glass-x11`/`glass-wayland` use.
 pub(crate) type LogSink = Arc<Mutex<Vec<(Stream, String)>>>;
 
-/// How long [`terminate`] waits after SIGTERM before escalating to SIGKILL. Short: a
-/// terminate call is already the "shut it down" path (`stop_app` or a failed launch's
-/// cleanup), not a place to make the caller wait for a slow shutdown handler.
+/// How long [`terminate`] waits after SIGTERM before escalating to SIGKILL. Short: by the time
+/// a signal is being sent the app has already declined (or could not be sent) the quit request
+/// that precedes it, so this is the escape hatch, not a place to wait out a shutdown handler.
 const TERMINATE_GRACE: Duration = Duration::from_millis(500);
+
+/// How long [`terminate`] waits for the app to quit through its own shutdown path after being
+/// asked ([`crate::ffi::terminate_app`]), before falling back to signals. Only an app that
+/// will not quit pays this in full — a cooperating one ends the wait as soon as it exits
+/// (measured: ~390 ms for a minimal AppKit app). Matches the Windows backend's close grace.
+const QUIT_GRACE: Duration = Duration::from_secs(3);
+
+/// How often the exit waits re-check the child.
+const EXIT_POLL: Duration = Duration::from_millis(20);
 
 /// Spawn `spec.run` (with `spec.cwd`/`spec.env` applied) with stdout/stderr piped into
 /// `logs` via one reader thread per stream. Returns [`GlassError::AppNotStarted`] if the
@@ -332,32 +342,55 @@ fn spawn_reader<R: std::io::Read + Send + 'static>(reader: R, stream: Stream, si
     });
 }
 
-/// Idempotently terminate `child`: SIGTERM, wait up to [`TERMINATE_GRACE`] for exit, then
-/// SIGKILL, then reap. Safe to call on an already-exited (or already-terminated) child —
-/// `try_wait` is checked first so a second call never re-signals a pid the kernel may have
-/// since recycled.
+/// Idempotently terminate `child`: ask it to quit, wait up to [`QUIT_GRACE`], then SIGTERM,
+/// wait up to [`TERMINATE_GRACE`], then SIGKILL, then reap. Safe to call on an already-exited
+/// (or already-terminated) child — `try_wait` is checked first so a second call never
+/// re-signals a pid the kernel may have since recycled.
+///
+/// The quit request comes first because signals give a Cocoa app no shutdown path at all:
+/// AppKit installs no `SIGTERM` handler, so the default disposition ends the process with
+/// `applicationWillTerminate:` never called and nothing flushed — measured, not assumed (see
+/// [`crate::ffi::terminate_app`]). An app that ignores or vetoes the request still gets the
+/// full signal ladder afterwards, so teardown always completes; this only adds the chance to
+/// leave cleanly, it does not make the process harder to stop.
+///
+/// This is the child-backed path. A LaunchServices-adopted app (`backend.rs`'s `Adopted`) is
+/// asked the same way but never escalated — glass did not spawn it as a child and will not
+/// force-kill an app it only adopted; see `Adopted::reap`.
 pub(crate) fn terminate(child: &mut Child) {
     if matches!(child.try_wait(), Ok(Some(_))) {
         return;
     }
 
+    // A pid too large for `i32` cannot be a macOS pid; `None` just means "couldn't ask", which
+    // is the same fallback as an app that isn't GUI-registered.
+    let asked = i32::try_from(child.id()).is_ok_and(crate::ffi::terminate_app);
+    if asked && wait_for_exit(child, QUIT_GRACE) {
+        let _ = child.wait(); // Reap so the child doesn't linger as a zombie.
+        return;
+    }
+
     let pid = Pid::from_child(child);
     let _ = kill_process(pid, Signal::TERM);
-
-    let deadline = Instant::now() + TERMINATE_GRACE;
-    loop {
-        match child.try_wait() {
-            Ok(Some(_)) => return,
-            Ok(None) if Instant::now() >= deadline => break,
-            Ok(None) => std::thread::sleep(Duration::from_millis(20)),
-            // `try_wait` failing is unexpected (the pid is ours) but not a reason to spin
-            // forever — fall through to the SIGKILL/reap below.
-            Err(_) => break,
-        }
-    }
+    wait_for_exit(child, TERMINATE_GRACE);
 
     let _ = child.kill(); // SIGKILL, tolerates an already-exited child.
     let _ = child.wait(); // Reap so the child doesn't linger as a zombie.
+}
+
+/// Poll `child` for exit for up to `grace`, reporting whether it exited within it. A
+/// `try_wait` error ends the wait reporting "still running": the pid is ours, so a failure is
+/// unexpected, and the caller escalating is the safe reading of an unreadable state.
+fn wait_for_exit(child: &mut Child, grace: Duration) -> bool {
+    let deadline = Instant::now() + grace;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return true,
+            Ok(None) if Instant::now() >= deadline => return false,
+            Ok(None) => std::thread::sleep(EXIT_POLL),
+            Err(_) => return false,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -564,6 +597,102 @@ mod tests {
         terminate(&mut child);
         let status = child.try_wait().expect("try_wait after terminate");
         assert!(status.is_some(), "child should have exited after terminate");
+    }
+
+    /// How long the AppKit fixture gets to finish launching before it is torn down. Until it
+    /// is a *running application* there is nothing to ask, so terminating early would exercise
+    /// the signal fallback and quietly pass for the wrong reason.
+    #[cfg(target_os = "macos")]
+    const FIXTURE_LAUNCH_SETTLE: Duration = Duration::from_secs(3);
+
+    /// How long the reader thread gets to drain the fixture's closing pipe. `terminate`
+    /// returns once the child is reaped; the last line it printed may still be in flight.
+    #[cfg(target_os = "macos")]
+    const LOG_DRAIN_SETTLE: Duration = Duration::from_millis(500);
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn terminate_asks_a_gui_app_to_quit_before_signalling_it() {
+        // The whole point of the quit request: AppKit installs no SIGTERM handler, so a
+        // signalled Cocoa app never runs `applicationWillTerminate:`. The fixture announces
+        // that method on stdout, so the captured line exists only if `terminate` asked first —
+        // no signal-only teardown can produce it.
+        //
+        // On-device: needs `swiftc` to build the fixture and a window-server session for it to
+        // launch into, so it is gated behind the same `GLASS_MACOS_ONBOX` switch
+        // `scripts/test-macos.sh` uses for its other on-device work rather than run in CI.
+        if std::env::var_os("GLASS_MACOS_ONBOX").is_none() {
+            println!(
+                "terminate_asks_a_gui_app_to_quit_before_signalling_it: SKIPPED — set \
+                 GLASS_MACOS_ONBOX=1 to run it (needs swiftc and a window-server session)"
+            );
+            return;
+        }
+
+        let source = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("fixture")
+            .join("quadrants.swift");
+        let build_dir =
+            std::env::temp_dir().join(format!("glass-quit-fixture-{}", std::process::id()));
+        std::fs::create_dir_all(&build_dir).expect("create fixture build dir");
+        let fixture = build_dir.join("quit-fixture");
+        let status = Command::new("swiftc")
+            .arg("-O")
+            // `-parse-as-library`: the fixture declares its entry point with `@main`, which
+            // swiftc rejects in a file it would otherwise treat as a top-level script. Same
+            // flags `tests/capture.rs` builds this fixture with.
+            .arg("-parse-as-library")
+            .arg(&source)
+            .arg("-o")
+            .arg(&fixture)
+            .status()
+            .expect("run swiftc");
+        assert!(status.success(), "swiftc failed on {}", source.display());
+
+        let sink = empty_sink();
+        let (mut child, _clip) = spawn(
+            &spec(&[fixture.to_string_lossy().as_ref()]),
+            Arc::clone(&sink),
+        )
+        .expect("spawn the AppKit fixture");
+        std::thread::sleep(FIXTURE_LAUNCH_SETTLE);
+
+        terminate(&mut child);
+        std::thread::sleep(LOG_DRAIN_SETTLE);
+
+        let logs = sink.lock().expect("log sink mutex").clone();
+        let _ = std::fs::remove_dir_all(&build_dir);
+        assert!(
+            logs.iter()
+                .any(|(stream, line)| *stream == Stream::Stdout && line.starts_with("quit: ")),
+            "terminate must ask the app to quit before signalling it; captured logs: {logs:?}"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn terminate_signals_a_non_gui_child_without_waiting_out_the_quit_grace() {
+        // `/bin/sleep` is not a running *application*, so there is nothing to ask and
+        // `terminate_app` reports that. The quit grace must then be skipped entirely rather
+        // than spent — otherwise asking first would add `QUIT_GRACE` to the teardown of every
+        // app glass cannot ask, which is every console-shaped one.
+        let (mut child, _clip) =
+            spawn(&spec(&["/bin/sleep", "100"]), empty_sink()).expect("spawn /bin/sleep");
+        let started = Instant::now();
+        terminate(&mut child);
+        let elapsed = started.elapsed();
+        assert!(
+            child
+                .try_wait()
+                .expect("try_wait after terminate")
+                .is_some(),
+            "child should have exited after terminate"
+        );
+        assert!(
+            elapsed < QUIT_GRACE,
+            "terminate took {elapsed:?} — it waited out the quit grace ({QUIT_GRACE:?}) for a \
+             process it could not ask"
+        );
     }
 
     #[test]

--- a/crates/glass-macos/src/process.rs
+++ b/crates/glass-macos/src/process.rs
@@ -114,7 +114,7 @@ const SHIM_DYLIB_ENV: &str = "GLASS_CLIP_SHIM_DYLIB";
 
 /// [`crate::shim_path::resolve_shim`] against the real environment: the running executable's
 /// directory and [`SHIM_DYLIB_ENV`]. The tier logic itself is pure and lives in
-/// [`crate::shim_path`] (unit-tested on the Linux dev box); this wrapper only supplies the
+/// [`crate::shim_path`] (unit-tested on any host); this wrapper only supplies the
 /// two OS-touching inputs it needs.
 fn shim_dylib_path() -> Option<PathBuf> {
     shim_dylib_path_with(std::env::var(SHIM_DYLIB_ENV).ok().map(PathBuf::from))
@@ -464,7 +464,7 @@ mod tests {
     /// launched with a `cwd` OUTSIDE `$HOME` would fail to start (it could not even be read to be
     /// exec'd). This is the macOS analog of the Linux
     /// `sandbox_default_reaches_launch_target_via_argument_path` integration test; it runs on real
-    /// macOS hardware (CI macOS runner + on-device), not on the Linux dev box.
+    /// macOS hardware (CI macOS runner + on-device) only.
     #[test]
     #[cfg(target_os = "macos")]
     fn default_sandbox_reaches_launch_target_under_home_when_cwd_is_elsewhere() {

--- a/crates/glass-macos/src/shim_path.rs
+++ b/crates/glass-macos/src/shim_path.rs
@@ -1,4 +1,4 @@
-//! Pure clip-shim dylib path resolution. Cross-platform → unit-tested on the Linux dev box,
+//! Pure clip-shim dylib path resolution. Cross-platform → unit-tested on any host,
 //! same split as [`crate::clipboard_route`]/[`crate::coords`]/[`crate::keymap`]: no OS calls
 //! here, only `Path`/`PathBuf` arithmetic and existence checks against whatever paths the
 //! caller hands in. `glass_macos::process::shim_dylib_path` (macOS-only) is the thin wrapper

--- a/crates/glass-macos/tests/bundle_launch.rs
+++ b/crates/glass-macos/tests/bundle_launch.rs
@@ -316,6 +316,28 @@ mod macos_main {
             Ok(())
         });
 
+        // `with_stop_app` has now run `stop_app`, so the fixture has been torn down. It must
+        // have been ASKED to quit, not merely signalled: AppKit runs no shutdown path for a
+        // signal, so `applicationWillTerminate:` — and the `quit: ` line it prints — appear
+        // only if `process::terminate` asked first. Draining after `stop_app` is deliberate;
+        // the line is written during teardown and cannot exist before it.
+        let result = result.and_then(|()| {
+            std::thread::sleep(ACTION_SETTLE); // let the reader thread drain the closing pipe
+            let logs = platform.drain_logs();
+            let saw_quit = logs
+                .iter()
+                .any(|(stream, line)| *stream == Stream::Stdout && line.starts_with("quit: "));
+            if saw_quit {
+                println!("stop_app asked the app to quit: its shutdown path ran before teardown");
+                Ok(())
+            } else {
+                Err(format!(
+                    "expected a captured 'quit: ' stdout line proving stop_app asked the app to \
+                     quit before signalling it; captured logs: {logs:?}"
+                ))
+            }
+        });
+
         let _ = std::fs::remove_dir_all(&build_dir);
         result
     }

--- a/crates/glass-mcp/build.rs
+++ b/crates/glass-mcp/build.rs
@@ -18,9 +18,8 @@ fn main() {
         .expect("failed to embed application manifest");
     }
     // Statically link only the VCRuntime, leaving the OS-provided UCRT dynamic (paired
-    // with `+crt-static` in .cargo/config.toml). Gated to a Windows host: that's where
-    // the only commercial msvc builds happen, and it keeps the crate
-    // off non-Windows builds entirely so build.rs always compiles there.
+    // with `+crt-static` in .cargo/config.toml). Gated to a Windows host — the msvc
+    // toolchain this configures only exists there — so build.rs still compiles elsewhere.
     #[cfg(windows)]
     static_vcruntime::metabuild();
 

--- a/crates/glass-mcp/build.rs
+++ b/crates/glass-mcp/build.rs
@@ -19,7 +19,7 @@ fn main() {
     }
     // Statically link only the VCRuntime, leaving the OS-provided UCRT dynamic (paired
     // with `+crt-static` in .cargo/config.toml). Gated to a Windows host: that's where
-    // the only commercial msvc builds happen (CI + the dev box), and it keeps the crate
+    // the only commercial msvc builds happen, and it keeps the crate
     // off non-Windows builds entirely so build.rs always compiles there.
     #[cfg(windows)]
     static_vcruntime::metabuild();

--- a/crates/glass-mcp/src/env.rs
+++ b/crates/glass-mcp/src/env.rs
@@ -349,10 +349,6 @@ pub(crate) const INTERNAL_ENV: &[&str] = &[
     // Forces a test-only AX-geometry fallback path (glass-macos/src/axwindow.rs); read only to
     // exercise that path in an integration test, not a supported way to configure glass.
     "GLASS_MACOS_FORCE_AX_GEOMETRY_FALLBACK",
-    // Opts in to the glass-macos tests that need a real Mac to mean anything — a `swiftc` build
-    // and a window-server session (see `scripts/test-macos.sh` and the fixture-driven test in
-    // glass-macos/src/process.rs). A test-suite switch, not a way to configure glass.
-    "GLASS_MACOS_ONBOX",
     // Build-time only: `build.rs` computes the release version and emits it as a
     // `cargo:rustc-env=GLASS_VERSION`, read via `env!` (see `crate::VERSION`). Not read from the
     // process environment and never an operator override.

--- a/crates/glass-mcp/src/env.rs
+++ b/crates/glass-mcp/src/env.rs
@@ -349,6 +349,10 @@ pub(crate) const INTERNAL_ENV: &[&str] = &[
     // Forces a test-only AX-geometry fallback path (glass-macos/src/axwindow.rs); read only to
     // exercise that path in an integration test, not a supported way to configure glass.
     "GLASS_MACOS_FORCE_AX_GEOMETRY_FALLBACK",
+    // Opts in to the glass-macos tests that need a real Mac to mean anything — a `swiftc` build
+    // and a window-server session (see `scripts/test-macos.sh` and the fixture-driven test in
+    // glass-macos/src/process.rs). A test-suite switch, not a way to configure glass.
+    "GLASS_MACOS_ONBOX",
     // Build-time only: `build.rs` computes the release version and emits it as a
     // `cargo:rustc-env=GLASS_VERSION`, read via `env!` (see `crate::VERSION`). Not read from the
     // process environment and never an operator override.

--- a/crates/glass-mcp/src/env.rs
+++ b/crates/glass-mcp/src/env.rs
@@ -349,6 +349,10 @@ pub(crate) const INTERNAL_ENV: &[&str] = &[
     // Forces a test-only AX-geometry fallback path (glass-macos/src/axwindow.rs); read only to
     // exercise that path in an integration test, not a supported way to configure glass.
     "GLASS_MACOS_FORCE_AX_GEOMETRY_FALLBACK",
+    // Makes the macOS test fixture refuse a quit request, standing in for an app with an
+    // unsaved-changes sheet. glass only ever *sets* it, on a fixture it spawns in one of its own
+    // tests (glass-macos/src/process.rs); nothing in glass reads it.
+    "GLASS_FIXTURE_VETO_QUIT",
     // Build-time only: `build.rs` computes the release version and emits it as a
     // `cargo:rustc-env=GLASS_VERSION`, read via `env!` (see `crate::VERSION`). Not read from the
     // process environment and never an operator override.

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -132,7 +132,11 @@ impl GlassServer {
         self.run(move |g| tools::start(g, &a)).await
     }
 
-    #[tool(description = "Stop the running app and end the session.")]
+    #[tool(
+        description = "Stop the running app and end the session. The app is asked to close first, \
+                       so it saves state and starts clean next time; one that will not close is \
+                       terminated, which takes a moment longer."
+    )]
     async fn glass_stop(&self) -> Result<CallToolResult, McpError> {
         self.run(tools::stop).await
     }

--- a/crates/glass-sandbox-macos/src/lib.rs
+++ b/crates/glass-sandbox-macos/src/lib.rs
@@ -1,6 +1,6 @@
 //! macOS process containment (Seatbelt) for glass, implementing `SandboxLevel::Default`/
 //! `Strict`. The pure [`build_profile`] SBPL generator ([`profile`]) is cross-platform and
-//! unit-tested on the Linux dev box — likewise [`launch_reallows`] ([`reachability`]), which
+//! unit-tested on any host — likewise [`launch_reallows`] ([`reachability`]), which
 //! computes the re-allows a launch needs to reach its own target under the profile's home
 //! deny; the `sandbox_init` FFI ([`ffi`]) is macOS-only mechanism. [`doctor`] is
 //! cross-platform: it reports `Ok` on macOS and `Unavailable` elsewhere, so `glass doctor`

--- a/crates/glass-sandbox-macos/src/profile.rs
+++ b/crates/glass-sandbox-macos/src/profile.rs
@@ -1,5 +1,5 @@
-//! Pure SBPL (Seatbelt) profile generator. No `unsafe`, no OS calls — unit-tested on the
-//! Linux dev box. The profile is deny-default and keeps the launched app drivable
+//! Pure SBPL (Seatbelt) profile generator. No `unsafe`, no OS calls — unit-tested on any host. The
+//! profile is deny-default and keeps the launched app drivable
 //! (WindowServer + AX) while containing filesystem, process, and (at `Strict`) network.
 //!
 //! Filesystem model (matches Linux's `--ro-bind / /` + `--tmpfs $HOME`): the whole

--- a/crates/glass-sandbox-macos/src/reachability.rs
+++ b/crates/glass-sandbox-macos/src/reachability.rs
@@ -97,7 +97,7 @@ mod tests {
     // -------------------------------------------------------------------------
 
     /// A representative synthetic bare home root for a few different usernames — used to sweep the
-    /// predicates without needing real files under `/Users` (impossible on this Linux dev box).
+    /// predicates without needing real files under `/Users` (impossible off macOS).
     const SYNTHETIC_HOME_ROOTS: &[&str] = &["/Users/dev", "/Users/alice", "/Users/ci-runner"];
 
     // -------------------------------------------------------------------------
@@ -130,7 +130,7 @@ mod tests {
     // -------------------------------------------------------------------------
     // 2. Arg directly under a bare home root → the FILE in ro_files, the home root NOT in ro_binds.
     // PREDICATE-ONLY: `push_reallows` requires `std::fs::metadata(lit)` to succeed before routing,
-    // and this dev box has no real `/Users` tree to place a file under — placing one is impossible
+    // and a non-macOS host has no real `/Users` tree to place a file under — placing one is impossible
     // without root and would not be legitimate for a portable unit test. Verified instead: the two
     // predicates `push_reallows` actually branches on for this exact scenario. Full end-to-end
     // exercise of this branch is verified on real macOS hardware (Seatbelt does not run here).

--- a/crates/glass-windows/benches/pixels.rs
+++ b/crates/glass-windows/benches/pixels.rs
@@ -1,7 +1,7 @@
 //! Benchmark the per-capture BGRA→RGBA conversion (in place).
 //!
-//! The pixel module is cross-platform (no OS calls), so this runs on the Linux
-//! dev box even though the WGC capture path it feeds is Windows-only.
+//! The pixel module is cross-platform (no OS calls), so this runs on any host even
+//! though the WGC capture path it feeds is Windows-only.
 
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use glass_windows::pixels::bgra_to_rgba;

--- a/crates/glass-windows/examples/onbox.rs
+++ b/crates/glass-windows/examples/onbox.rs
@@ -6,8 +6,7 @@
 //! over SSH (session 0) it is driven via the scheduled-task bridge:
 //!   cargo run -p glass-windows --example onbox
 //!
-//! On non-Windows hosts it is a no-op, so `cargo test` / `clippy --all-targets` stay green on the
-//! Linux dev box.
+//! On non-Windows hosts it is a no-op, so `cargo test` / `clippy --all-targets` stay green on any host.
 
 // On-box FFI harness: opts out of the workspace `unsafe_code = "deny"` (each `unsafe` site is
 // `// SAFETY:`-documented).

--- a/crates/glass-windows/src/containment/config.rs
+++ b/crates/glass-windows/src/containment/config.rs
@@ -1,5 +1,5 @@
 //! Pure provider/box configuration logic for Windows containment — no Win32, no process
-//! spawning — so the policy is unit-tested on the Linux dev box. The cfg(windows) Sandboxie
+//! spawning — so the policy is unit-tested on any host. The cfg(windows) Sandboxie
 //! provider consumes these.
 
 // `decide`/`Decision`/`ProviderChoice` are consumed by the cfg(windows) containment seam,

--- a/crates/glass-windows/src/containment/mod.rs
+++ b/crates/glass-windows/src/containment/mod.rs
@@ -172,7 +172,7 @@ mod imp {
                 Launched::Sandboxie(a) => a.try_wait(),
             }
         }
-        pub(crate) fn kill(self) {
+        pub(crate) fn kill(self) -> crate::process::Closed {
             match self {
                 Launched::Unconfined(a) => a.kill(),
                 Launched::Sandboxie(a) => a.kill(),

--- a/crates/glass-windows/src/containment/sandboxie.rs
+++ b/crates/glass-windows/src/containment/sandboxie.rs
@@ -443,7 +443,13 @@ impl SandboxieApp {
     /// and read everything) → clear the box's config section so per-session `glass_<pid>`
     /// boxes don't accumulate in `Sandboxie.ini` (`SbieIni set <box> * ""` — the
     /// maintainer's documented box-clear).
-    pub(crate) fn kill(mut self) {
+    pub(crate) fn kill(mut self) -> crate::process::Closed {
+        // Ask the BOXED app to close before anything terminates it. This has to happen here
+        // rather than in the wrapped `LaunchedApp::kill` below: the boxed processes are not in
+        // glass's Job (the wrapper hands off to SbieSvc and exits, owning no app window), so by
+        // the time that runs there is nothing left for it to find — and `/terminate` would
+        // already have killed the box outright, which is the ungraceful teardown being avoided.
+        let closed = crate::process::close_pids_and_wait(&self.pids(), || !self.pids().is_empty());
         let _ = Command::new(start_exe(&self.dir))
             .args([&format!("/box:{}", self.box_name), "/terminate"])
             .status();
@@ -451,11 +457,14 @@ impl SandboxieApp {
         for h in self.tailers {
             let _ = h.join();
         }
-        self.inner.kill();
+        // The wrapper's own teardown. Its outcome is not the app's — `Start.exe` exits as soon
+        // as it has handed off, so this reports on a process the user never sees.
+        let _ = self.inner.kill();
         if let Some((_, server)) = self.clip.take() {
             server.stop();
         }
         let _ = std::fs::remove_dir_all(&self.logdir);
         clear_box_section(&self.dir, &self.box_name);
+        closed
     }
 }

--- a/crates/glass-windows/src/containment/sandboxie.rs
+++ b/crates/glass-windows/src/containment/sandboxie.rs
@@ -444,12 +444,6 @@ impl SandboxieApp {
     /// boxes don't accumulate in `Sandboxie.ini` (`SbieIni set <box> * ""` — the
     /// maintainer's documented box-clear).
     pub(crate) fn kill(mut self) -> crate::process::Closed {
-        // Ask the BOXED app to close before anything terminates it. This has to happen here
-        // rather than in the wrapped `LaunchedApp::kill` below: the boxed processes are not in
-        // glass's Job (the wrapper hands off to SbieSvc and exits, owning no app window), so by
-        // the time that runs there is nothing left for it to find — and `/terminate` would
-        // already have killed the box outright, which is the ungraceful teardown being avoided.
-        let closed = crate::process::close_pids_and_wait(&self.pids(), || !self.pids().is_empty());
         let _ = Command::new(start_exe(&self.dir))
             .args([&format!("/box:{}", self.box_name), "/terminate"])
             .status();
@@ -465,6 +459,13 @@ impl SandboxieApp {
         }
         let _ = std::fs::remove_dir_all(&self.logdir);
         clear_box_section(&self.dir, &self.box_name);
-        closed
+        // A boxed app is terminated without ever being asked to close, unlike an unconfined
+        // one. Measured on-box: `PostMessageW(WM_CLOSE)` to a boxed app's top-level windows
+        // *succeeds* — two posts accepted, none refused — and the app neither closes nor runs
+        // its shutdown path, because Sandboxie filters window messages across the box boundary.
+        // The request has to come from inside the box to land, which needs an in-box helper
+        // process; until then a contained app records an unclean exit the same way every
+        // teardown did before this path existed.
+        crate::process::Closed::TerminatedUnasked { refused: 0 }
     }
 }

--- a/crates/glass-windows/src/jobcfg.rs
+++ b/crates/glass-windows/src/jobcfg.rs
@@ -1,7 +1,7 @@
 //! Pure mapping from [`SandboxLevel`] to the set of Job-object limits the Windows
 //! backend applies (Job-based in-OS hardening). No Win32 here — the cfg(windows)
 //! `build_kill_on_close_job` translates this descriptor into `JOBOBJECT_*` flags — so
-//! the policy is unit-tested on the Linux dev box.
+//! the policy is unit-tested on any host.
 
 // Consumed only by the cfg(windows) job builder + the Linux unit tests, so a non-test
 // Linux build sees these as dead.

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -20,10 +20,10 @@ pub mod dpi; // pure coordinate math — cross-platform, unit-tested on any host
 pub mod jobcfg; // pure SandboxLevel -> job-limit descriptor — unit-tested on any host
 pub mod jobpids; // pure JOBOBJECT_BASIC_PROCESS_ID_LIST byte parser — Miri'd on the host
 #[doc(hidden)]
-pub mod onbox_support;
+pub mod onbox_support; // env-resolved paths shared by the on-box examples + tests; host-tested
 pub mod pixels; // pure BGRA->RGBA swizzle — cross-platform, unit-tested on any host
 pub mod teardown; // pure graceful-close decisions — cross-platform, unit-tested on any host
-pub mod vkmap; // pure named-keysym->VK map — cross-platform, unit-tested on any host // env-resolved paths shared by the on-box examples + tests; host-tested
+pub mod vkmap; // pure named-keysym->VK map — cross-platform, host-tested
 
 /// This backend's canonical name (matches the `glass_capabilities` / `GLASS_BACKEND` value).
 pub const BACKEND: &str = "windows";
@@ -70,8 +70,8 @@ const MULTI_TOUCH: CapabilityStatus = CapabilityStatus::unsupported(None);
 
 /// The `Unsupported` error this backend returns for a multi-touch gesture — one source
 /// for the call site (`send_pointer`'s `Gesture` arm) and its test.
-// Consumed only by the cfg(windows) `input::send_pointer` and the Linux unit test, so a
-// non-test Linux build sees this as dead (mirrors jobcfg.rs/doctor.rs in this crate).
+// Consumed only by the cfg(windows) `input::send_pointer` and the off-target unit test, so a
+// non-test off-target build sees this as dead (mirrors jobcfg.rs/doctor.rs in this crate).
 #[cfg_attr(not(windows), allow(dead_code))]
 pub(crate) fn unsupported_multi_touch() -> glass_core::GlassError {
     glass_core::GlassError::unsupported("multi_touch", BACKEND, MULTI_TOUCH.note)
@@ -242,7 +242,10 @@ mod backend {
                 Err(e) => {
                     // Window never appeared (or geometry failed): don't orphan the tree.
                     if let Some(app) = self.app.take() {
-                        app.kill();
+                        // No disclosure here: a launch that never showed a window has no
+                        // shutdown state worth preserving, and the launch error is the
+                        // actionable thing to report.
+                        let _ = app.kill();
                     }
                     self.active_hwnd = None;
                     Err(e)
@@ -252,7 +255,7 @@ mod backend {
 
         fn stop_app(&mut self) -> Result<()> {
             if let Some(app) = self.app.take() {
-                app.kill();
+                crate::process::disclose_teardown(app.kill());
             }
             self.active_hwnd = None;
             Ok(())
@@ -380,7 +383,7 @@ mod backend {
     impl Drop for WindowsPlatform {
         fn drop(&mut self) {
             if let Some(app) = self.app.take() {
-                app.kill();
+                crate::process::disclose_teardown(app.kill());
             }
         }
     }

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -3,7 +3,7 @@
 //! v1 drives the interactive desktop. The OS-touching modules and the
 //! `WindowsPlatform` impl are gated per-item with `#[cfg(windows)]` (not a
 //! crate-level gate) so the pure [`dpi`] coordinate math still compiles and is
-//! unit-tested on the Linux dev box. Off Windows the crate exposes only `dpi` and the
+//! unit-tested on any host. Off Windows the crate exposes only `dpi` and the
 //! [`capabilities`] map (whose `accessibility` cell is live; every other cell is constant).
 
 // FFI backend: the OS-touching modules need `unsafe`, so this crate opts out of the workspace
@@ -16,13 +16,14 @@ use glass_core::capability::{CapabilityMap, CapabilityStatus};
 pub mod containment; // Windows containment provider seam (pure config is host-tested)
 pub mod discovery; // pure window-discovery poll-loop decision — cross-platform, host-tested
 pub mod doctor; // pure check-mapping cross-platform; Windows fact-gathering is cfg(windows)
-pub mod dpi; // pure coordinate math — cross-platform, unit-tested on the Linux dev box
-pub mod jobcfg; // pure SandboxLevel -> job-limit descriptor — unit-tested on the Linux dev box
+pub mod dpi; // pure coordinate math — cross-platform, unit-tested on any host
+pub mod jobcfg; // pure SandboxLevel -> job-limit descriptor — unit-tested on any host
 pub mod jobpids; // pure JOBOBJECT_BASIC_PROCESS_ID_LIST byte parser — Miri'd on the host
 #[doc(hidden)]
 pub mod onbox_support;
-pub mod pixels; // pure BGRA->RGBA swizzle — cross-platform, unit-tested on the Linux dev box
-pub mod vkmap; // pure named-keysym->VK map — cross-platform, unit-tested on the Linux dev box // env-resolved paths shared by the on-box examples + tests; host-tested
+pub mod pixels; // pure BGRA->RGBA swizzle — cross-platform, unit-tested on any host
+pub mod teardown; // pure graceful-close decisions — cross-platform, unit-tested on any host
+pub mod vkmap; // pure named-keysym->VK map — cross-platform, unit-tested on any host // env-resolved paths shared by the on-box examples + tests; host-tested
 
 /// This backend's canonical name (matches the `glass_capabilities` / `GLASS_BACKEND` value).
 pub const BACKEND: &str = "windows";

--- a/crates/glass-windows/src/onbox_support.rs
+++ b/crates/glass-windows/src/onbox_support.rs
@@ -1,6 +1,6 @@
 //! Shared, env-resolved paths for the on-box examples and the `#[ignore]d` tests, so neither
 //! hardcodes a specific user or install location. Pure `std::env`/`std::path`, so it compiles and is
-//! unit-tested on the Linux dev box (like [`crate::dpi`]); off Windows the lookups return temp/None.
+//! unit-tested on any host (like [`crate::dpi`]); off Windows the lookups return temp/None.
 
 use std::path::Path;
 
@@ -27,9 +27,56 @@ pub fn locate_edge() -> Option<String> {
     None
 }
 
+/// Pull Chromium's recorded shutdown disposition out of a `<user-data-dir>/Default/Preferences`
+/// document: the string value of `"exit_type"`, which a Chromium-based browser sets to `"Crashed"`
+/// while a session is in progress and rewrites to `"Normal"` only if it shuts down through its own
+/// exit path. Reading it is how the on-box teardown test asserts that glass asked the app to close
+/// rather than terminating it — the same flag that decides whether the next launch shows a
+/// "Restore pages?" prompt.
+///
+/// A hand-rolled scan rather than a JSON dependency: the file is a large document and this needs
+/// exactly one scalar from it. Returns `None` if the key is absent or its value is not a string.
+pub fn exit_type_from_preferences(prefs: &str) -> Option<&str> {
+    let after_key = prefs.split_once("\"exit_type\"")?.1;
+    let after_colon = after_key.trim_start().strip_prefix(':')?;
+    let value = after_colon.trim_start().strip_prefix('"')?;
+    // Chromium writes these values as plain ASCII words, so no escape handling is needed.
+    value.split_once('"').map(|(v, _)| v)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn exit_type_reads_a_clean_shutdown() {
+        let prefs = r#"{"profile":{"exit_type":"Normal","name":"Person 1"}}"#;
+        assert_eq!(exit_type_from_preferences(prefs), Some("Normal"));
+    }
+
+    #[test]
+    fn exit_type_reads_a_crash() {
+        let prefs = r#"{"profile":{"exit_type":"Crashed"}}"#;
+        assert_eq!(exit_type_from_preferences(prefs), Some("Crashed"));
+    }
+
+    #[test]
+    fn exit_type_tolerates_pretty_printed_whitespace() {
+        // Chromium writes compact JSON, but a hand-inspected/re-saved profile may not be — and a
+        // parser that silently returned None there would make the teardown test pass vacuously.
+        let prefs = "{\n  \"profile\": {\n    \"exit_type\" : \"Normal\"\n  }\n}";
+        assert_eq!(exit_type_from_preferences(prefs), Some("Normal"));
+    }
+
+    #[test]
+    fn exit_type_is_none_when_the_key_is_absent() {
+        assert_eq!(exit_type_from_preferences(r#"{"profile":{}}"#), None);
+    }
+
+    #[test]
+    fn exit_type_is_none_when_the_value_is_not_a_string() {
+        assert_eq!(exit_type_from_preferences(r#"{"exit_type":3}"#), None);
+    }
 
     #[test]
     fn scratch_dir_joins_name_under_a_base() {

--- a/crates/glass-windows/src/pixels.rs
+++ b/crates/glass-windows/src/pixels.rs
@@ -1,4 +1,4 @@
-//! Pure pixel-format helpers (no OS calls), unit-tested on the Linux dev box.
+//! Pure pixel-format helpers (no OS calls), unit-tested on any host.
 
 use glass_core::pixels::{SourceOrder, to_opaque_rgba_in_place};
 

--- a/crates/glass-windows/src/process.rs
+++ b/crates/glass-windows/src/process.rs
@@ -1,7 +1,9 @@
 //! Process lifecycle for the Windows backend: spawn the app **CREATE_SUSPENDED**,
 //! assign it to a `KILL_ON_JOB_CLOSE` Job before it can fork any children, wire
 //! up log readers, then resume — so a launcher that exits and hands off
-//! (Chromium/Electron) cannot escape the Job. Teardown is "close the job handle".
+//! (Chromium/Electron) cannot escape the Job. Teardown asks the app's windows to close and
+//! only then closes the job handle, which is the backstop for whatever did not go (see
+//! [`LaunchedApp::kill`] and [`crate::teardown`]).
 //!
 //! The FFI here is a verbatim port of the validated
 //! `tools/windows-validation/src/proc.rs` probe (proven on real hardware): the
@@ -9,16 +11,17 @@
 //! `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` and `AssignProcessToJobObject`, then resume;
 //! plus the Toolhelp thread enum with `ResumeThread`, and the Toolhelp parent-link
 //! descendant walk. It is restructured into reusable lib types but the unsafe bodies
-//! are unchanged.
+//! are unchanged. The `PostMessageW` close request in [`request_close`] is not from that
+//! probe — it was added later, with its own on-box evidence.
 
 use std::ffi::c_void;
 use std::os::windows::process::CommandExt;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
-use glass_core::{AppSpec, GlassError, Result, SandboxLevel};
+use glass_core::{AppSpec, GlassError, Result, SandboxLevel, TEARDOWN_BUDGET};
 
-use crate::teardown::{CloseStep, close_wait_step, wants_close_request};
+use crate::teardown::{CloseStep, close_wait_step};
 use windows::Win32::Foundation::{CloseHandle, HANDLE, LPARAM, WPARAM};
 use windows::Win32::System::Diagnostics::ToolHelp::{
     CreateToolhelp32Snapshot, PROCESSENTRY32W, Process32FirstW, Process32NextW, TH32CS_SNAPPROCESS,
@@ -39,10 +42,22 @@ use windows::Win32::UI::WindowsAndMessaging::{PostMessageW, WM_CLOSE};
 
 /// How long the app tree gets to close itself after the `WM_CLOSE` broadcast, before the Job is
 /// closed (`TerminateProcess` for whatever is left). Only an app that will not close pays this in
-/// full — a cooperating one ends the wait the moment its tree is gone. Measured on-box: an isolated
-/// Edge tree (15 processes) is fully gone 328 ms after the broadcast, so the budget is generous
-/// enough for a heavier app's shutdown path without making teardown feel slow.
-const CLOSE_GRACE: Duration = Duration::from_secs(3);
+/// full — a cooperating one ends the wait the moment its tree is gone. Measured on-box, an
+/// isolated Edge tree closed in well under half a second, so this is several times the observed
+/// cost while still leaving the Job close room inside [`TEARDOWN_BUDGET`].
+///
+/// It has to leave that room: when the *process* is going away, `glass-mcp` abandons teardown
+/// once the budget is spent. A grace that filled it would mean the Job was never closed from
+/// here — the tree would instead be terminated as a side effect of the handle closing at process
+/// exit, which is the ungraceful teardown this whole path exists to avoid, arrived at slowly.
+const CLOSE_GRACE: Duration = Duration::from_millis(1500);
+
+// Teardown must finish inside the budget it is given, or `glass-mcp` walks away mid-close. This
+// is the only thing keeping the two numbers — in different crates — honest about each other.
+const _: () = assert!(
+    CLOSE_GRACE.as_millis() * 2 <= TEARDOWN_BUDGET.as_millis(),
+    "CLOSE_GRACE must leave the Job close comfortable room inside glass_core::TEARDOWN_BUDGET"
+);
 
 /// How often the close wait re-checks the tree. Short relative to [`CLOSE_GRACE`] so a quick
 /// shutdown is noticed promptly rather than rounded up to the next poll.
@@ -139,64 +154,165 @@ impl LaunchedApp {
     /// records whether it exited cleanly then reports a crash on its *next* launch and greets the
     /// agent with a recovery prompt instead of its normal first screen. See [`crate::teardown`] for
     /// the measurement behind that and for both decisions this drives.
-    pub(crate) fn kill(mut self) {
-        let posted = request_close(&self.live_pids());
-        self.await_close(posted);
+    pub(crate) fn kill(mut self) -> Closed {
+        let asked = request_close(&self.live_pids());
+        let closed_itself = self.await_close(asked.posted);
         // SAFETY: closing the last job handle terminates the entire tree (KILL_ON_JOB_CLOSE).
         unsafe {
             let _ = CloseHandle(self.job.0);
         }
         let _ = self.child.kill(); // belt-and-suspenders: ensure the root is terminated so wait() can't block
         let _ = self.child.wait(); // reap the now-terminated root; avoids a zombie
+        asked.outcome(closed_itself)
     }
 
     /// The app's live process set: the Job's authoritative pid list, falling back to the Toolhelp
-    /// parent-link walk when the Job query fails (it reports failure as an empty list). Without the
-    /// fallback, a failed query would leave a handed-off app with no window to ask.
+    /// parent-link walk when the Job query fails. Without the fallback, a failed query would leave
+    /// a handed-off app with no window to ask.
+    ///
+    /// Job-authoritative rather than a union with the walk (which is what *discovery* uses): this
+    /// set drives a `WM_CLOSE` broadcast, and Windows parent links go stale when a pid is recycled,
+    /// so a union could put an unrelated application's window in the destructive set. Discovery can
+    /// afford that risk because it only ever reads.
     fn live_pids(&self) -> Vec<u32> {
-        let pids = self.job_pids();
-        if pids.is_empty() {
-            descendant_pids(self.pid())
-        } else {
-            pids
-        }
+        job_pids_checked(self.job.0).unwrap_or_else(|| descendant_pids(self.pid()))
     }
 
     /// Poll until the tree has closed itself or [`CLOSE_GRACE`] is spent, per
     /// [`close_wait_step`]. `posted` is how many windows accepted the `WM_CLOSE`.
-    fn await_close(&mut self, posted: usize) {
+    ///
+    /// Note this reads the Job pid-set through [`job_pids_checked`] rather than [`Self::live_pids`]
+    /// — the two want different things from a failed query, and neither substitutes for the other.
+    /// `live_pids` needs *some* pid set to find windows in, so it falls back to the Toolhelp walk;
+    /// that walk always contains the root, so using it here would report the tree as live on every
+    /// poll and spend the full grace on even a cleanly-closing app. What this needs is the honest
+    /// third answer, `None`, which [`close_wait_step`] reads as "unknown, keep waiting".
+    /// Returns whether the tree closed itself before the grace ran out — a `false` means whatever
+    /// is left is about to be terminated. A `try_wait` error counts as "still running": the pid is
+    /// ours, so a failure is unexpected, and waiting is the safe reading of an unreadable state
+    /// (the deadline bounds the cost). Mirrors `glass-macos`'s `wait_for_exit`.
+    fn await_close(&mut self, posted: usize) -> bool {
         let deadline = Instant::now() + CLOSE_GRACE;
         loop {
             let root_exited = matches!(self.child.try_wait(), Ok(Some(_)));
-            let job_reports_live = !self.job_pids().is_empty();
-            let step = close_wait_step(
-                posted,
-                root_exited,
-                job_reports_live,
-                Instant::now() >= deadline,
-            );
-            if step == CloseStep::Proceed {
-                return;
+            let job_live = job_pids_checked(self.job.0).map(|pids| !pids.is_empty());
+            if Instant::now() >= deadline {
+                return false;
+            }
+            if close_wait_step(posted, root_exited, job_live, false) == CloseStep::Proceed {
+                // Distinguish the two non-deadline exits: nothing was asked (so nothing could
+                // have closed itself) from the tree having actually gone.
+                return posted > 0;
             }
             std::thread::sleep(CLOSE_POLL);
         }
     }
 }
 
-/// Post `WM_CLOSE` to every top-level window owned by `pids` that [`wants_close_request`] accepts,
-/// returning how many posts the OS accepted.
+/// How a launched app's process tree actually went away, so `stop_app` can say so. Terminating an
+/// app that was never asked, or asked and refused, is the outcome this whole path exists to avoid
+/// — reporting it as an unqualified success would leave the agent to rediscover it as a recovery
+/// prompt on the next launch, with nothing connecting the two.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Closed {
+    /// Asked, and the tree left through its own shutdown path.
+    Gracefully,
+    /// Nothing accepted a close request — a windowless app, or every post was refused — so the
+    /// tree was terminated without being asked. Carries how many windows were asked but refused
+    /// (UIPI blocks posting to a higher-integrity process), which is actionable in a way the
+    /// windowless case is not.
+    TerminatedUnasked { refused: usize },
+    /// Asked, but still alive when the grace ran out: a modal shutdown prompt, or a hang.
+    TerminatedAfterGrace,
+}
+
+/// Report a teardown that could not be graceful. Silent on [`Closed::Gracefully`] — the good
+/// path is the expectation, not news — and on a windowless app, which has no shutdown path to
+/// have missed. Everything else is something the user can act on, and would otherwise only
+/// surface as an unexplained recovery prompt the *next* time the app is launched.
+pub(crate) fn disclose_teardown(closed: Closed) {
+    match closed {
+        Closed::Gracefully | Closed::TerminatedUnasked { refused: 0 } => {}
+        Closed::TerminatedUnasked { refused } => eprintln!(
+            "glass: {refused} close request(s) were refused, so the app was terminated instead \
+             of asked to close. Windows blocks posting to a higher-integrity process (UIPI); \
+             running glass elevated lets it close the app cleanly. An app that records clean \
+             shutdown may report a crash on its next launch."
+        ),
+        Closed::TerminatedAfterGrace => eprintln!(
+            "glass: the app did not close within {CLOSE_GRACE:?} of being asked (a modal \
+             shutdown prompt will do this), so its process tree was terminated. Unsaved state \
+             was not flushed, and the app may report a crash on its next launch."
+        ),
+    }
+}
+
+/// The result of asking an app's windows to close: how many accepted, and how many refused.
+struct Asked {
+    posted: usize,
+    refused: usize,
+}
+
+impl Asked {
+    fn outcome(&self, closed_itself: bool) -> Closed {
+        match (self.posted, closed_itself) {
+            (0, _) => Closed::TerminatedUnasked {
+                refused: self.refused,
+            },
+            (_, true) => Closed::Gracefully,
+            (_, false) => Closed::TerminatedAfterGrace,
+        }
+    }
+}
+
+/// Ask the windows of `pids` to close and wait — up to [`CLOSE_GRACE`] — for `still_live` to
+/// report the tree gone, then report how it went.
 ///
-/// The count matters: a cross-process post can be refused (UIPI blocks posting to a
-/// higher-integrity process), and a refused window is not one that is going to close — counting it
-/// would make the caller wait out the whole grace for a shutdown nobody was asked to perform.
-fn request_close(pids: &[u32]) -> usize {
-    crate::util::enum_top_windows()
+/// For a teardown that owns its own termination sequence and has no Job handle to poll, so it
+/// cannot use [`LaunchedApp::await_close`]: the Sandboxie provider, whose boxed processes are not
+/// in glass's Job at all and whose liveness comes from `Start.exe /listpids`. The caller must
+/// still terminate afterwards — this only ever *asks*, and returns whether asking was enough.
+pub(crate) fn close_pids_and_wait(pids: &[u32], mut still_live: impl FnMut() -> bool) -> Closed {
+    let asked = request_close(pids);
+    if asked.posted == 0 {
+        return asked.outcome(false);
+    }
+    let deadline = Instant::now() + CLOSE_GRACE;
+    loop {
+        if !still_live() {
+            return asked.outcome(true);
+        }
+        if Instant::now() >= deadline {
+            return asked.outcome(false);
+        }
+        std::thread::sleep(CLOSE_POLL);
+    }
+}
+
+/// Post `WM_CLOSE` to every top-level window belonging to a process in `pids` that
+/// [`wants_close_request`] accepts, reporting how many posts the OS accepted and how many it
+/// refused.
+///
+/// The split matters twice over. A refused window is not one that is going to close, so counting
+/// it would make the caller wait out the whole grace for a shutdown nobody was asked to perform.
+/// And a refusal is a *diagnosable* condition — UIPI blocks posting to a higher-integrity process,
+/// so every teardown of that app will be a hard kill until glass is run elevated — which is worth
+/// telling the user rather than absorbing.
+fn request_close(pids: &[u32]) -> Asked {
+    let candidates: Vec<crate::util::WinInfo> = crate::util::enum_top_windows()
         .into_iter()
-        .filter(|w| pids.contains(&w.pid) && wants_close_request(w.visible, w.owned, w.toolwindow))
+        .filter(|w| pids.contains(&w.pid) && w.wants_close_request())
+        .collect();
+    let posted = candidates
+        .iter()
         // SAFETY: PostMessageW only queues a message on the target window's thread queue — it
         // writes through no pointer we own and does not block waiting for the app to handle it.
         .filter(|w| unsafe { PostMessageW(Some(w.hwnd()), WM_CLOSE, WPARAM(0), LPARAM(0)) }.is_ok())
-        .count()
+        .count();
+    Asked {
+        posted,
+        refused: candidates.len() - posted,
+    }
 }
 
 /// Spawn `cmd` CREATE_SUSPENDED with piped stdout/stderr, create a KILL_ON_JOB_CLOSE Job,
@@ -354,10 +470,20 @@ pub(crate) fn descendant_pids(root: u32) -> Vec<u32> {
     keep
 }
 
-/// The job's authoritative PID set (kernel-tracked) — captures children of an exited launcher
-/// (Electron/Chromium handoff) that a Toolhelp parent-link walk can miss. Empty on any query
-/// failure, so the caller can fall back to descendant_pids().
+/// [`job_pids_checked`], flattening an unreadable pid-set to an empty one — for callers that
+/// only need a list to search and treat "couldn't ask" and "nothing there" alike.
 pub(crate) fn job_pids(job: HANDLE) -> Vec<u32> {
+    job_pids_checked(job).unwrap_or_default()
+}
+
+/// The job's authoritative PID set (kernel-tracked) — captures children of an exited launcher
+/// (Electron/Chromium handoff) that a Toolhelp parent-link walk can miss.
+///
+/// `None` means the query itself failed, which is a genuinely different answer from
+/// `Some(vec![])` ("the job is empty, the tree is gone"). Teardown turns on that difference:
+/// reading an unreadable pid-set as "gone" would let [`LaunchedApp::await_close`] terminate a
+/// handed-off app's children on the first poll, immediately after asking them to close.
+pub(crate) fn job_pids_checked(job: HANDLE) -> Option<Vec<u32>> {
     // JOBOBJECT_BASIC_PROCESS_ID_LIST is variable-length: { NumberOfAssignedProcesses: u32,
     // NumberOfProcessIdsInList: u32, ProcessIdList: [usize; 1] (flexible) }. Size the buffer
     // for `cap` pids and grow on failure (too-small buffer), capped to avoid a pathological loop.
@@ -382,10 +508,10 @@ pub(crate) fn job_pids(job: HANDLE) -> Vec<u32> {
             if cap < 8192 {
                 cap *= 4;
                 continue;
-            } // too-small buffer: grow; terminal error: give up empty
-            return Vec::new();
+            } // too-small buffer: grow; terminal error: report the state as unknown
+            return None;
         }
-        return crate::jobpids::parse_job_pid_list(&buf);
+        return Some(crate::jobpids::parse_job_pid_list(&buf));
     }
 }
 

--- a/crates/glass-windows/src/process.rs
+++ b/crates/glass-windows/src/process.rs
@@ -265,30 +265,6 @@ impl Asked {
     }
 }
 
-/// Ask the windows of `pids` to close and wait — up to [`CLOSE_GRACE`] — for `still_live` to
-/// report the tree gone, then report how it went.
-///
-/// For a teardown that owns its own termination sequence and has no Job handle to poll, so it
-/// cannot use [`LaunchedApp::await_close`]: the Sandboxie provider, whose boxed processes are not
-/// in glass's Job at all and whose liveness comes from `Start.exe /listpids`. The caller must
-/// still terminate afterwards — this only ever *asks*, and returns whether asking was enough.
-pub(crate) fn close_pids_and_wait(pids: &[u32], mut still_live: impl FnMut() -> bool) -> Closed {
-    let asked = request_close(pids);
-    if asked.posted == 0 {
-        return asked.outcome(false);
-    }
-    let deadline = Instant::now() + CLOSE_GRACE;
-    loop {
-        if !still_live() {
-            return asked.outcome(true);
-        }
-        if Instant::now() >= deadline {
-            return asked.outcome(false);
-        }
-        std::thread::sleep(CLOSE_POLL);
-    }
-}
-
 /// Post `WM_CLOSE` to every top-level window belonging to a process in `pids` that
 /// [`wants_close_request`] accepts, reporting how many posts the OS accepted and how many it
 /// refused.

--- a/crates/glass-windows/src/process.rs
+++ b/crates/glass-windows/src/process.rs
@@ -14,10 +14,12 @@
 use std::ffi::c_void;
 use std::os::windows::process::CommandExt;
 use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
 
 use glass_core::{AppSpec, GlassError, Result, SandboxLevel};
 
-use windows::Win32::Foundation::{CloseHandle, HANDLE};
+use crate::teardown::{CloseStep, close_wait_step, wants_close_request};
+use windows::Win32::Foundation::{CloseHandle, HANDLE, LPARAM, WPARAM};
 use windows::Win32::System::Diagnostics::ToolHelp::{
     CreateToolhelp32Snapshot, PROCESSENTRY32W, Process32FirstW, Process32NextW, TH32CS_SNAPPROCESS,
     TH32CS_SNAPTHREAD, THREADENTRY32, Thread32First, Thread32Next,
@@ -33,6 +35,18 @@ use windows::Win32::System::Threading::{
     CREATE_SUSPENDED, OpenProcess, OpenThread, PROCESS_QUERY_INFORMATION, PROCESS_SET_QUOTA,
     PROCESS_TERMINATE, ResumeThread, THREAD_SUSPEND_RESUME,
 };
+use windows::Win32::UI::WindowsAndMessaging::{PostMessageW, WM_CLOSE};
+
+/// How long the app tree gets to close itself after the `WM_CLOSE` broadcast, before the Job is
+/// closed (`TerminateProcess` for whatever is left). Only an app that will not close pays this in
+/// full — a cooperating one ends the wait the moment its tree is gone. Measured on-box: an isolated
+/// Edge tree (15 processes) is fully gone 328 ms after the broadcast, so the budget is generous
+/// enough for a heavier app's shutdown path without making teardown feel slow.
+const CLOSE_GRACE: Duration = Duration::from_secs(3);
+
+/// How often the close wait re-checks the tree. Short relative to [`CLOSE_GRACE`] so a quick
+/// shutdown is noticed promptly rather than rounded up to the next poll.
+const CLOSE_POLL: Duration = Duration::from_millis(50);
 
 /// Run the optional build step in `cwd` via `cmd /C` (the Windows shell), failing
 /// if it exits non-zero. Mirrors the X11 backend's `sh -c` build step. Unconfined
@@ -117,8 +131,17 @@ impl LaunchedApp {
         self.child.try_wait()
     }
 
-    /// Kill the whole tree (close the job) and reap the root.
+    /// Tear the whole tree down, asking it to close first: broadcast `WM_CLOSE` to the app's own
+    /// top-level windows, give it up to [`CLOSE_GRACE`] to leave through its own shutdown path,
+    /// then close the Job (terminating anything left) and reap the root.
+    ///
+    /// The Job close alone is `TerminateProcess`, which runs no shutdown path at all — an app that
+    /// records whether it exited cleanly then reports a crash on its *next* launch and greets the
+    /// agent with a recovery prompt instead of its normal first screen. See [`crate::teardown`] for
+    /// the measurement behind that and for both decisions this drives.
     pub(crate) fn kill(mut self) {
+        let posted = request_close(&self.live_pids());
+        self.await_close(posted);
         // SAFETY: closing the last job handle terminates the entire tree (KILL_ON_JOB_CLOSE).
         unsafe {
             let _ = CloseHandle(self.job.0);
@@ -126,6 +149,54 @@ impl LaunchedApp {
         let _ = self.child.kill(); // belt-and-suspenders: ensure the root is terminated so wait() can't block
         let _ = self.child.wait(); // reap the now-terminated root; avoids a zombie
     }
+
+    /// The app's live process set: the Job's authoritative pid list, falling back to the Toolhelp
+    /// parent-link walk when the Job query fails (it reports failure as an empty list). Without the
+    /// fallback, a failed query would leave a handed-off app with no window to ask.
+    fn live_pids(&self) -> Vec<u32> {
+        let pids = self.job_pids();
+        if pids.is_empty() {
+            descendant_pids(self.pid())
+        } else {
+            pids
+        }
+    }
+
+    /// Poll until the tree has closed itself or [`CLOSE_GRACE`] is spent, per
+    /// [`close_wait_step`]. `posted` is how many windows accepted the `WM_CLOSE`.
+    fn await_close(&mut self, posted: usize) {
+        let deadline = Instant::now() + CLOSE_GRACE;
+        loop {
+            let root_exited = matches!(self.child.try_wait(), Ok(Some(_)));
+            let job_reports_live = !self.job_pids().is_empty();
+            let step = close_wait_step(
+                posted,
+                root_exited,
+                job_reports_live,
+                Instant::now() >= deadline,
+            );
+            if step == CloseStep::Proceed {
+                return;
+            }
+            std::thread::sleep(CLOSE_POLL);
+        }
+    }
+}
+
+/// Post `WM_CLOSE` to every top-level window owned by `pids` that [`wants_close_request`] accepts,
+/// returning how many posts the OS accepted.
+///
+/// The count matters: a cross-process post can be refused (UIPI blocks posting to a
+/// higher-integrity process), and a refused window is not one that is going to close — counting it
+/// would make the caller wait out the whole grace for a shutdown nobody was asked to perform.
+fn request_close(pids: &[u32]) -> usize {
+    crate::util::enum_top_windows()
+        .into_iter()
+        .filter(|w| pids.contains(&w.pid) && wants_close_request(w.visible, w.owned, w.toolwindow))
+        // SAFETY: PostMessageW only queues a message on the target window's thread queue — it
+        // writes through no pointer we own and does not block waiting for the app to handle it.
+        .filter(|w| unsafe { PostMessageW(Some(w.hwnd()), WM_CLOSE, WPARAM(0), LPARAM(0)) }.is_ok())
+        .count()
 }
 
 /// Spawn `cmd` CREATE_SUSPENDED with piped stdout/stderr, create a KILL_ON_JOB_CLOSE Job,

--- a/crates/glass-windows/src/teardown.rs
+++ b/crates/glass-windows/src/teardown.rs
@@ -13,22 +13,27 @@
 
 /// Whether a top-level window belonging to the app's process set should be sent a `WM_CLOSE`.
 ///
-/// - `visible`: a window the user could see. Invisible ones are helper/message-only windows
-///   (Chromium keeps several); a `WM_CLOSE` there is at best ignored and at worst closes a
+/// - `visible`: the `WS_VISIBLE` style bit is set (not "the user can see it" — an occluded,
+///   off-screen or cloaked window still has it). Windows without it are helper/message-only
+///   ones (Chromium keeps several); a `WM_CLOSE` there is at best ignored and at worst closes a
 ///   worker the app expected to outlive the request.
 /// - `owned`: has an owner window — i.e. it is a dialog or palette *belonging* to another
-///   window. Skipped because closing the owner is the app's own business: dismissing its
-///   dialogs from outside can cancel work the owner is mid-way through, and a well-behaved
-///   app tears them down itself once the owner closes.
+///   window. Skipped unless `appwindow`, because closing the owner is the app's own business:
+///   dismissing its dialogs from outside can cancel work the owner is mid-way through, and a
+///   well-behaved app tears them down itself once the owner closes.
+/// - `appwindow`: `WS_EX_APPWINDOW`, the app's own declaration that this is a real taskbar-level
+///   window despite having an owner. Honoured for the same reason the discovery ladder honours
+///   it: glass may well be *driving* such a window, and a window glass drives is one it must ask
+///   to close rather than terminate out from under.
 /// - `toolwindow`: `WS_EX_TOOLWINDOW`, a floating palette rather than a real app window.
 ///
-/// Deliberately *not* filtered on `cloaked`: a window on another virtual desktop is cloaked but
-/// entirely real, and skipping it would leave that part of the app to be terminated instead.
-/// (This is why the discovery ladder's [`crate::util::WinInfo::looks_like_app_window`] is not
-/// reused here — it excludes cloaked windows, which is right for "which window do we drive?"
-/// and wrong for "which windows must be asked to close?")
-pub fn wants_close_request(visible: bool, owned: bool, toolwindow: bool) -> bool {
-    visible && !owned && !toolwindow
+/// This is deliberately the discovery ladder's `WinInfo::looks_like_app_window` filter minus its
+/// `!cloaked` clause, and that one difference is the whole reason the two are not one function: a
+/// window on another virtual desktop is cloaked but entirely real. Excluding it is right for
+/// "which window do we drive?" and wrong for "which windows must be asked to close?", where it
+/// would leave that part of the app to be terminated instead.
+pub fn wants_close_request(visible: bool, owned: bool, appwindow: bool, toolwindow: bool) -> bool {
+    visible && (!owned || appwindow) && !toolwindow
 }
 
 /// What the graceful-close wait should do after one poll.
@@ -48,21 +53,23 @@ pub enum CloseStep {
 ///   cross-process post under UIPI). There is nothing to wait *for*, so the grace is skipped
 ///   entirely rather than spent; teardown stays as fast as it was before.
 /// - `root_exited`: the launched root process has been observed exited.
-/// - `job_reports_live`: the Job's pid-set still lists at least one live process. The root
-///   exiting is not enough on its own: a launcher that hands off (Chromium/Electron) leaves
-///   the real UI running in Job-captured children, and proceeding on root-exit alone would
-///   terminate exactly the processes whose clean shutdown we are waiting for. An unreadable
-///   pid-set reports `false` — the wait then rests on `root_exited` alone, which is no worse
-///   than the unconditional terminate this replaces.
+/// - `job_live`: whether the Job's pid-set still lists a live process — `None` when the query
+///   failed, which is a different answer from `Some(false)` ("the job is empty, the tree is
+///   gone") and must not be collapsed into it. The root exiting is not enough on its own: a
+///   launcher that hands off (Chromium/Electron) leaves the real UI running in Job-captured
+///   children, and proceeding on root-exit alone would terminate exactly the processes whose
+///   clean shutdown we are waiting for. `None` therefore keeps waiting — proceeding is the
+///   destructive branch, so an unreadable state must not be read as permission to take it.
+///   The cost of being wrong is bounded by `past_deadline`.
 /// - `past_deadline`: the grace has elapsed. An app may veto its own close (an unsaved-changes
 ///   sheet) or hang; the Job close is the backstop, so teardown always completes.
 pub fn close_wait_step(
     posted: usize,
     root_exited: bool,
-    job_reports_live: bool,
+    job_live: Option<bool>,
     past_deadline: bool,
 ) -> CloseStep {
-    if posted == 0 || past_deadline || (root_exited && !job_reports_live) {
+    if posted == 0 || past_deadline || (root_exited && job_live == Some(false)) {
         CloseStep::Proceed
     } else {
         CloseStep::KeepWaiting
@@ -75,22 +82,30 @@ mod tests {
 
     #[test]
     fn a_plain_visible_top_level_window_is_asked_to_close() {
-        assert!(wants_close_request(true, false, false));
+        assert!(wants_close_request(true, false, false, false));
     }
 
     #[test]
     fn an_invisible_window_is_not_asked_to_close() {
-        assert!(!wants_close_request(false, false, false));
+        assert!(!wants_close_request(false, false, false, false));
     }
 
     #[test]
     fn an_owned_window_is_not_asked_to_close() {
-        assert!(!wants_close_request(true, true, false));
+        assert!(!wants_close_request(true, true, false, false));
+    }
+
+    #[test]
+    fn an_owned_appwindow_is_asked_to_close() {
+        // `WS_EX_APPWINDOW` is the app declaring an owned window to be a real taskbar-level
+        // one, and the discovery ladder adopts such a window — so glass can be driving it.
+        // Filtering it out here would terminate the very window the agent was working in.
+        assert!(wants_close_request(true, true, true, false));
     }
 
     #[test]
     fn a_toolwindow_is_not_asked_to_close() {
-        assert!(!wants_close_request(true, false, true));
+        assert!(!wants_close_request(true, false, false, true));
     }
 
     #[test]
@@ -98,7 +113,7 @@ mod tests {
         // A windowless app must not pay the grace: with no window asked to close, waiting
         // could only ever burn the full budget before terminating anyway.
         assert_eq!(
-            close_wait_step(0, false, true, false),
+            close_wait_step(0, false, Some(true), false),
             CloseStep::Proceed,
             "no window was asked to close, so there is nothing to wait for"
         );
@@ -107,7 +122,7 @@ mod tests {
     #[test]
     fn a_live_tree_within_the_grace_keeps_waiting() {
         assert_eq!(
-            close_wait_step(1, false, true, false),
+            close_wait_step(1, false, Some(true), false),
             CloseStep::KeepWaiting
         );
     }
@@ -117,7 +132,7 @@ mod tests {
         // The launcher-handoff shape: proceeding here would TerminateProcess the very
         // children whose clean shutdown the WM_CLOSE asked for.
         assert_eq!(
-            close_wait_step(1, true, true, false),
+            close_wait_step(1, true, Some(true), false),
             CloseStep::KeepWaiting,
             "handed-off children are still closing"
         );
@@ -125,27 +140,44 @@ mod tests {
 
     #[test]
     fn an_exited_root_with_an_empty_job_proceeds() {
-        assert_eq!(close_wait_step(1, true, false, false), CloseStep::Proceed);
+        assert_eq!(
+            close_wait_step(1, true, Some(false), false),
+            CloseStep::Proceed
+        );
     }
 
     #[test]
     fn a_still_live_tree_past_the_grace_proceeds() {
         // An app that vetoes its own close (unsaved-changes sheet) must not wedge teardown.
         assert_eq!(
-            close_wait_step(1, false, true, true),
+            close_wait_step(1, false, Some(true), true),
             CloseStep::Proceed,
             "the Job close is the backstop once the grace is spent"
         );
     }
 
     #[test]
-    fn an_unreadable_job_pid_set_waits_only_for_the_root() {
-        // `job_reports_live: false` is also what an unreadable pid-set reports, so the
-        // decision must not require a positive "job is empty" signal to ever proceed.
+    fn an_unreadable_job_pid_set_is_not_read_as_an_empty_one() {
+        // The destructive branch requires a *positive* "the job is empty". An unreadable
+        // pid-set (`None`) must keep waiting even once the root has exited: reading it as
+        // "gone" is exactly how a launcher-handoff app's children would get terminated
+        // milliseconds after being asked to close, with a half-written profile on disk.
         assert_eq!(
-            close_wait_step(1, false, false, false),
-            CloseStep::KeepWaiting
+            close_wait_step(1, true, None, false),
+            CloseStep::KeepWaiting,
+            "unknown is not permission to terminate"
         );
-        assert_eq!(close_wait_step(1, true, false, false), CloseStep::Proceed);
+        assert_eq!(
+            close_wait_step(1, true, Some(false), false),
+            CloseStep::Proceed,
+            "a positive empty reading does proceed"
+        );
+    }
+
+    #[test]
+    fn an_unreadable_job_pid_set_still_gives_up_at_the_deadline() {
+        // The grace bounds the cost of never getting a readable answer, so treating `None`
+        // as "keep waiting" can't wedge teardown.
+        assert_eq!(close_wait_step(1, true, None, true), CloseStep::Proceed);
     }
 }

--- a/crates/glass-windows/src/teardown.rs
+++ b/crates/glass-windows/src/teardown.rs
@@ -1,0 +1,151 @@
+//! Pure decision logic for graceful app teardown, factored out of the (Windows-only)
+//! `process` module so it compiles and is unit-tested on any host — like [`crate::discovery`]
+//! and friends. The backend owns the Win32 side (enumerate top-level windows, `PostMessageW`
+//! a `WM_CLOSE`, `try_wait` the root, query the Job pid-set) and consults these two decisions.
+//!
+//! Why ask before terminating at all: closing the Job handle is `TerminateProcess` for every
+//! process in the tree, which gives an app no chance to run its shutdown path. Apps that
+//! persist a "did I exit cleanly?" flag then report a crash on their *next* launch — measured
+//! on-box, an Edge tree torn down by `TerminateProcess` records `"exit_type": "Crashed"` in its
+//! profile and greets the next run with a "Restore pages?" prompt, while the same tree sent a
+//! `WM_CLOSE` records `"Normal"` and starts clean. A driven app whose first screen changes run
+//! to run is a worse target for an agent than one that costs a few hundred ms to close politely.
+
+/// Whether a top-level window belonging to the app's process set should be sent a `WM_CLOSE`.
+///
+/// - `visible`: a window the user could see. Invisible ones are helper/message-only windows
+///   (Chromium keeps several); a `WM_CLOSE` there is at best ignored and at worst closes a
+///   worker the app expected to outlive the request.
+/// - `owned`: has an owner window — i.e. it is a dialog or palette *belonging* to another
+///   window. Skipped because closing the owner is the app's own business: dismissing its
+///   dialogs from outside can cancel work the owner is mid-way through, and a well-behaved
+///   app tears them down itself once the owner closes.
+/// - `toolwindow`: `WS_EX_TOOLWINDOW`, a floating palette rather than a real app window.
+///
+/// Deliberately *not* filtered on `cloaked`: a window on another virtual desktop is cloaked but
+/// entirely real, and skipping it would leave that part of the app to be terminated instead.
+/// (This is why the discovery ladder's [`crate::util::WinInfo::looks_like_app_window`] is not
+/// reused here — it excludes cloaked windows, which is right for "which window do we drive?"
+/// and wrong for "which windows must be asked to close?")
+pub fn wants_close_request(visible: bool, owned: bool, toolwindow: bool) -> bool {
+    visible && !owned && !toolwindow
+}
+
+/// What the graceful-close wait should do after one poll.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CloseStep {
+    /// The tree is still shutting down and there is grace left — sleep and poll again.
+    KeepWaiting,
+    /// Stop waiting and close the Job (terminating whatever is left).
+    Proceed,
+}
+
+/// Decide whether to keep waiting for the app to close itself.
+///
+/// - `posted`: how many windows actually accepted a `WM_CLOSE`. Zero means nothing was asked
+///   to close — a windowless (console/service) app, or one whose windows all failed the
+///   [`wants_close_request`] filter or the post itself (a higher-integrity app rejects a
+///   cross-process post under UIPI). There is nothing to wait *for*, so the grace is skipped
+///   entirely rather than spent; teardown stays as fast as it was before.
+/// - `root_exited`: the launched root process has been observed exited.
+/// - `job_reports_live`: the Job's pid-set still lists at least one live process. The root
+///   exiting is not enough on its own: a launcher that hands off (Chromium/Electron) leaves
+///   the real UI running in Job-captured children, and proceeding on root-exit alone would
+///   terminate exactly the processes whose clean shutdown we are waiting for. An unreadable
+///   pid-set reports `false` — the wait then rests on `root_exited` alone, which is no worse
+///   than the unconditional terminate this replaces.
+/// - `past_deadline`: the grace has elapsed. An app may veto its own close (an unsaved-changes
+///   sheet) or hang; the Job close is the backstop, so teardown always completes.
+pub fn close_wait_step(
+    posted: usize,
+    root_exited: bool,
+    job_reports_live: bool,
+    past_deadline: bool,
+) -> CloseStep {
+    if posted == 0 || past_deadline || (root_exited && !job_reports_live) {
+        CloseStep::Proceed
+    } else {
+        CloseStep::KeepWaiting
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_plain_visible_top_level_window_is_asked_to_close() {
+        assert!(wants_close_request(true, false, false));
+    }
+
+    #[test]
+    fn an_invisible_window_is_not_asked_to_close() {
+        assert!(!wants_close_request(false, false, false));
+    }
+
+    #[test]
+    fn an_owned_window_is_not_asked_to_close() {
+        assert!(!wants_close_request(true, true, false));
+    }
+
+    #[test]
+    fn a_toolwindow_is_not_asked_to_close() {
+        assert!(!wants_close_request(true, false, true));
+    }
+
+    #[test]
+    fn nothing_posted_skips_the_wait_entirely() {
+        // A windowless app must not pay the grace: with no window asked to close, waiting
+        // could only ever burn the full budget before terminating anyway.
+        assert_eq!(
+            close_wait_step(0, false, true, false),
+            CloseStep::Proceed,
+            "no window was asked to close, so there is nothing to wait for"
+        );
+    }
+
+    #[test]
+    fn a_live_tree_within_the_grace_keeps_waiting() {
+        assert_eq!(
+            close_wait_step(1, false, true, false),
+            CloseStep::KeepWaiting
+        );
+    }
+
+    #[test]
+    fn an_exited_root_with_live_job_children_keeps_waiting() {
+        // The launcher-handoff shape: proceeding here would TerminateProcess the very
+        // children whose clean shutdown the WM_CLOSE asked for.
+        assert_eq!(
+            close_wait_step(1, true, true, false),
+            CloseStep::KeepWaiting,
+            "handed-off children are still closing"
+        );
+    }
+
+    #[test]
+    fn an_exited_root_with_an_empty_job_proceeds() {
+        assert_eq!(close_wait_step(1, true, false, false), CloseStep::Proceed);
+    }
+
+    #[test]
+    fn a_still_live_tree_past_the_grace_proceeds() {
+        // An app that vetoes its own close (unsaved-changes sheet) must not wedge teardown.
+        assert_eq!(
+            close_wait_step(1, false, true, true),
+            CloseStep::Proceed,
+            "the Job close is the backstop once the grace is spent"
+        );
+    }
+
+    #[test]
+    fn an_unreadable_job_pid_set_waits_only_for_the_root() {
+        // `job_reports_live: false` is also what an unreadable pid-set reports, so the
+        // decision must not require a positive "job is empty" signal to ever proceed.
+        assert_eq!(
+            close_wait_step(1, false, false, false),
+            CloseStep::KeepWaiting
+        );
+        assert_eq!(close_wait_step(1, true, false, false), CloseStep::Proceed);
+    }
+}

--- a/crates/glass-windows/src/util.rs
+++ b/crates/glass-windows/src/util.rs
@@ -34,6 +34,23 @@ impl WinInfo {
         self.visible && !self.cloaked && (!self.owned || self.appwindow) && !self.toolwindow
     }
 
+    /// The teardown filter: whether this window should be asked to close before its process
+    /// tree is terminated ([`crate::teardown::wants_close_request`] holds the reasoning).
+    ///
+    /// Contrast [`Self::looks_like_app_window`], which excludes cloaked windows: this one must
+    /// not. A window on another virtual desktop is cloaked but entirely real, and skipping it
+    /// would leave that part of the app to be terminated instead. Keeping both filters here,
+    /// side by side, is what makes that difference visible — and keeps the field projection
+    /// itself in one named place rather than spelled out at the call site.
+    pub fn wants_close_request(&self) -> bool {
+        crate::teardown::wants_close_request(
+            self.visible,
+            self.owned,
+            self.appwindow,
+            self.toolwindow,
+        )
+    }
+
     pub fn hwnd(&self) -> HWND {
         raw_to_hwnd(self.raw)
     }

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -97,11 +97,13 @@ fn taskmgr_spec() -> AppSpec {
 /// Bare `explorer.exe` (no path arg): opens the OS default location — "Quick access" on
 /// Windows 10, "Home" on Windows 11 — the same native file-list control, and so the same UIA
 /// tree, any folder view uses (what that tree actually emitted is recorded in
-/// [`onbox_role_histogram_probe`]'s doc). Each File Explorer
-/// window is its own process (unlike Task Manager, Explorer has no single-instance check —
-/// this is why `explorer.exe <uri>` protocol activation, e.g. `ms-settings:`, is the flaky
-/// shape and a plain `explorer.exe` folder-window launch is not), so pid-set discovery is
-/// expected to find it directly. The hint here is `class`, not `title`: `CabinetWClass` is
+/// [`onbox_role_histogram_probe`]'s doc). The `class` hint is what actually finds it: the
+/// spawned `explorer.exe` hands the request to the already-running shell and exits, so the
+/// folder window belongs to a process that was there before glass started and is in no pid set
+/// glass tracks. That also means `stop_app` cannot close it — teardown reaches the process tree
+/// glass launched, which by then is gone — so the probe closes the adopted window itself (see
+/// [`close_adopted_window`]); without that, every run would leave a folder window on the
+/// desktop. The hint is `class`, not `title`: `CabinetWClass` is
 /// every File Explorer folder window's documented window class regardless of locale, OS
 /// version, or the current folder's display name — unlike a title, which would vary with
 /// exactly the thing this spec deliberately leaves unset.
@@ -1163,6 +1165,25 @@ fn mapped_token_violations(label: &str, tree: &AxTree) -> Vec<String> {
         .collect()
 }
 
+/// Ask a still-open adopted window to close, for the case `stop_app` cannot reach: a window
+/// owned by a process glass did not launch (a launcher that hands off to a long-running shell).
+/// `WM_CLOSE` rather than terminating anything — the owner here is the user's shell process.
+/// A no-op when the handle is absent or its window is already gone.
+fn close_adopted_window(raw: Option<i64>) {
+    use windows::Win32::Foundation::{LPARAM, WPARAM};
+    use windows::Win32::UI::WindowsAndMessaging::{IsWindow, PostMessageW, WM_CLOSE};
+
+    let Some(raw) = raw else { return };
+    let hwnd = windows::Win32::Foundation::HWND(raw as *mut std::ffi::c_void);
+    // SAFETY: both calls only query/queue against an HWND — no pointer we own is written
+    // through, and neither blocks on the target thread. A stale handle fails `IsWindow`.
+    unsafe {
+        if IsWindow(Some(hwnd)).as_bool() {
+            let _ = PostMessageW(Some(hwnd), WM_CLOSE, WPARAM(0), LPARAM(0));
+        }
+    }
+}
+
 /// Launch `spec`, snapshot its accessibility tree with the node cap lifted (so a big app's
 /// tree is never truncated mid-probe — depth/siblings keep their generous structural-rail
 /// defaults regardless; see [`WalkLimits::from_max_nodes`]), print its role histogram, append
@@ -1223,7 +1244,14 @@ fn probe_role_histogram(label: &str, spec: &AppSpec, report: &mut String) -> Vec
         report.push_str(&toggle_block);
     }
 
+    let adopted = p.active_window_handle();
     let _ = p.stop_app();
+    // `stop_app` tears down the process tree glass launched, which is not always the process
+    // that owns the window it adopted: a Win11 File Explorer folder window belongs to the
+    // already-running shell `explorer.exe`, so the process glass spawned exits immediately and
+    // the window it drove outlives teardown. This probe opens four apps in a row and would
+    // otherwise leave one window behind on every run, so it closes what it adopted.
+    close_adopted_window(adopted);
     std::thread::sleep(Duration::from_millis(500)); // let the app fully exit before the next probe
 
     let violations = mapped_token_violations(label, &tree);

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -384,6 +384,82 @@ fn onbox_isolated_edge_killtree() {
     );
 }
 
+/// Wait until no msedge.exe carrying `marker` is left, or `budget` elapses. Returns the final
+/// count so a caller can distinguish "the tree closed itself" from "we ran out of patience".
+fn wait_for_no_edge(marker: &str, budget: Duration) -> i32 {
+    let deadline = std::time::Instant::now() + budget;
+    loop {
+        let n = our_edge_count(marker);
+        if n == 0 || std::time::Instant::now() >= deadline {
+            return n;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+}
+
+#[test]
+#[ignore = "on-box only: needs the interactive desktop session + Edge"]
+fn onbox_stop_app_lets_edge_record_a_clean_exit() {
+    // `stop_app` must ask the app to close before terminating it. Edge is the readable witness:
+    // it records `exit_type` in its profile, and a tree ended by TerminateProcess (closing the
+    // Job, which is all `stop_app` used to do) leaves "Crashed" behind — which is what makes the
+    // next launch open with a "Restore pages?" prompt instead of the app's normal first screen.
+    // Measured on-box before the fix: Crashed. An isolated `--user-data-dir` keeps this away from
+    // the box's own Edge profile.
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    dpi_aware_once();
+    let edge = glass_windows::onbox_support::locate_edge()
+        .expect("msedge.exe not found under Program Files; Edge is required for this test");
+    let marker = "glass-clean-exit-test";
+    let udd = glass_windows::onbox_support::scratch_dir(marker);
+    let _ = std::fs::remove_dir_all(&udd);
+
+    let mut p = WindowsPlatform::new().expect("WindowsPlatform::new");
+    let spec = AppSpec {
+        build: None,
+        run: vec![
+            edge,
+            format!("--user-data-dir={udd}"),
+            "--no-first-run".to_string(),
+            "--no-default-browser-check".to_string(),
+            "--new-window".to_string(),
+            "about:blank".to_string(),
+        ],
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        timeout_ms: 25_000,
+        sandbox: glass_core::SandboxLevel::Off,
+        a11y: false,
+    };
+    let _geo = p
+        .start_app(&spec)
+        .expect("isolated Edge discovery (Job-child window)");
+    std::thread::sleep(Duration::from_secs(6)); // let the profile be written and children spawn
+
+    p.stop_app().expect("stop_app");
+    let survivors = wait_for_no_edge(marker, Duration::from_secs(20));
+    // Settle before reading: Edge rewrites Preferences as part of its shutdown, so a read racing
+    // that write could see the in-session "Crashed" and fail for the wrong reason. A fixed settle
+    // (rather than polling until the value reads "Normal") keeps the assertion able to fail.
+    std::thread::sleep(Duration::from_secs(3));
+    let prefs_path = std::path::Path::new(&udd)
+        .join("Default")
+        .join("Preferences");
+    let prefs = std::fs::read_to_string(&prefs_path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", prefs_path.display()));
+    let exit_type = glass_windows::onbox_support::exit_type_from_preferences(&prefs)
+        .map(str::to_owned)
+        .unwrap_or_else(|| "<no exit_type key>".to_string());
+    let _ = std::fs::remove_dir_all(&udd);
+
+    assert_eq!(survivors, 0, "stop_app must still leave 0 survivors");
+    assert_eq!(
+        exit_type, "Normal",
+        "stop_app must ask the app to close, not just terminate it"
+    );
+}
+
 #[test]
 #[ignore = "on-box only: needs the interactive desktop session"]
 fn onbox_a11y_snapshot_and_click() {

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -113,6 +113,20 @@ Returns the located window's geometry: `{x, y, width, height}`.
 
 Stop the running app and end the session. No parameters. Returns `{}`.
 
+The app is asked to close before anything terminates it, so it runs its own shutdown path and
+saves whatever it saves on quit. This matters for the *next* run: an app that records whether it
+exited cleanly — a Chromium-based browser, say — otherwise opens with a crash-recovery prompt
+instead of its normal first screen, so a driven app's first screen changes from run to run.
+
+An app that ignores the request, or blocks on a "save changes?" prompt, is terminated anyway after
+a short grace, so `glass_stop` always completes. That case is reported on stderr rather than in the
+result, along with what to do about it where anything can be — the result stays `{}` either way.
+
+Two exceptions: a Windows app launched under Sandboxie containment (`sandbox` of `default` or
+`strict`) is terminated without being asked, because a close request from outside the box never
+reaches it; and an app with no window has nothing to ask, so it is terminated immediately as
+before.
+
 ## Capture & visual comparison
 
 ### `glass_screenshot`

--- a/scripts/test-macos.sh
+++ b/scripts/test-macos.sh
@@ -12,7 +12,8 @@ fi
 # (mirrors scripts/test-x11.sh / test-wayland.sh / test-windows.sh).
 cd "$(dirname "$0")/.."
 
-# Pure + macOS unit tests only (`--lib`). `crates/glass-macos/tests/capture.rs` is now a
+# Pure + macOS unit tests only (`--lib`), minus the `#[ignore]`d ones that need a window
+# server (GLASS_MACOS_ONBOX below runs those). `crates/glass-macos/tests/capture.rs` is now a
 # real `[[test]]` target (see Cargo.toml), so a plain `cargo test -p glass-macos` with no
 # `--lib` filter would also try to build+run it — and it needs a granted, WindowServer
 # -connected context (a gui/501 LaunchAgent) that a plain on-box or CI run doesn't have,
@@ -30,6 +31,13 @@ cargo test -p glass-macos --lib "${1:-}"
 # gui/501 LaunchAgent so it inherits the grant. Plain `./scripts/test-macos.sh` (no env
 # set) never touches this.
 if [[ "${GLASS_MACOS_ONBOX:-0}" == "1" ]]; then
+  # The `--ignore`d unit tests that need a real Mac to mean anything: they build a Swift
+  # fixture and launch it into the window server, so a plain `cargo test` (and CI) must skip
+  # them. Unlike the integration binaries below, these DO run here — this is the only
+  # invocation that runs them, and it must be from a session with a window server.
+  echo "GLASS_MACOS_ONBOX=1: running the on-device --lib tests..."
+  cargo test -p glass-macos --lib -- --ignored "${1:-}"
+
   echo "GLASS_MACOS_ONBOX=1: building the capture integration test binary..."
   cargo test -p glass-macos --test capture --no-run
 
@@ -47,4 +55,9 @@ if [[ "${GLASS_MACOS_ONBOX:-0}" == "1" ]]; then
   # out-of-band via the same GlassProbe.app LaunchAgent procedure.
   echo "GLASS_MACOS_ONBOX=1: building the window integration test binary..."
   cargo test -p glass-macos --test windows --no-run
+
+  # Same story for crates/glass-macos/tests/bundle_launch.rs — building it here is what keeps
+  # its assertions from rotting between granted runs, which are rare and manual.
+  echo "GLASS_MACOS_ONBOX=1: building the bundle-launch integration test binary..."
+  cargo test -p glass-macos --test bundle_launch --no-run
 fi


### PR DESCRIPTION
## What

Teardown on Windows and macOS killed the driven app outright. Neither backend ever asked it to
close, so the app never ran its own shutdown path — and an app that records whether it exited
cleanly opens its *next* run with a recovery prompt instead of its normal first screen. For an
agent driving that app, the first screen changing run to run is the whole problem.

Both backends now **ask first, then fall back to what they did before**. Nothing becomes harder
to stop: an app that ignores or refuses the request still gets the old treatment, and now glass
says so instead of reporting an unqualified success.

## Measured, not assumed

**Windows** — an isolated Edge profile records its own verdict in `Default/Preferences`:

| teardown | `exit_type` | tree gone after |
|---|---|---|
| close the Job (what `stop_app` did) | `Crashed` | 75 ms |
| `WM_CLOSE` to its top-level windows | `Normal` | 328 ms |

`Crashed` is exactly what makes Edge offer "Restore pages?" next launch.

**macOS** — a minimal AppKit app that records whether `applicationWillTerminate:` ran:

| teardown | shutdown path ran | exit |
|---|---|---|
| `SIGTERM` (what `terminate` did) | **no** | 84 ms |
| `SIGKILL` | no | 92 ms |
| Apple Event quit | yes | 138 ms |
| `-[NSRunningApplication terminate]` | yes | 393 ms |

AppKit installs no `SIGTERM` handler, so the default disposition ends the process with nothing
flushed. The existing 500 ms SIGTERM grace was buying nothing at all.

## How

**Windows** (`LaunchedApp::kill`): post `WM_CLOSE` to the app's own top-level windows, wait for
the tree to leave through its own shutdown path, then close the Job exactly as before for
anything left. The wait is skipped entirely when no window accepted the request — a windowless
app, or a post UIPI refused — so those tear down as fast as they did.

**macOS** (`process::terminate`): ask via the `ffi::terminate_app` the adopted-app path already
used, wait, then run the unchanged SIGTERM → 500 ms → SIGKILL ladder. `terminate_app` now reports
whether the request was delivered, so a child that owns no running application skips the grace
instead of spending it.

The Windows decisions are pure functions in a new `teardown.rs`, unit-tested off-target; the rest
is the existing FFI.

## What review changed

Five review lenses ran over the first draft. Four findings were real and are fixed here:

- **The graces could swallow the shutdown budget — a regression this branch introduced.**
  `glass-mcp` gives all of teardown 3s when the process is going away, then exits regardless, and
  a `spawn_blocking` teardown thread cannot be cancelled. A 3s grace meant an app that ignored the
  quit request had the budget expire *during* the wait, so on macOS SIGTERM and SIGKILL were never
  sent and the app outlived glass, orphaned to launchd. The budget now lives in
  `glass_core::TEARDOWN_BUDGET`, both backends bound their graces against it with a `const`
  assertion, and a fixture that refuses to quit pins the ladder inside it.
- **An unreadable Job pid-set read as "the tree is gone."** `job_pids` returned an empty vec for
  both, and the two callers wanted opposite things from that — one falls back to a Toolhelp walk,
  the other took it as permission to terminate, on the first poll, milliseconds after asking a
  handed-off app's children to close. Split into `job_pids_checked` returning `Option`.
- **Teardown reported success identically however it went.** `kill` now returns a `Closed`
  outcome and `stop_app` discloses the two bad ones — including that a UIPI refusal is fixable by
  running glass elevated. macOS does the same where it could only ever report: a failed
  adopted-app quit, and a failed orphan reclaim after a bad launch.
- **`wants_close_request` dropped `WS_EX_APPWINDOW`**, so an owned window the discovery ladder
  adopts — one glass may be *driving* — would have been terminated rather than asked.

One finding was real and could **not** be fixed: a Sandboxie-contained launch is still terminated
without being asked. Moving the request ahead of the provider's `/terminate` looked like the fix
and does not work — measured on-box, `PostMessageW(WM_CLOSE)` to a boxed app is *accepted* (two
posts, none refused) and the app neither closes nor runs its shutdown path, because Sandboxie
filters window messages across the box boundary. Landing one needs a helper inside the box. That
attempt is reverted; the limitation is recorded next to the code and in the changelog rather than
left as dead code with a test asserting otherwise.

## Verification

Every claim above was run on real hardware, and every new test was checked against the unfixed
code so none of them pass vacuously.

- **Windows, on-box (session 1):** full suite 17/17. `onbox_stop_app_lets_edge_record_a_clean_exit`
  asserts the `exit_type` Edge actually wrote — green with the fix; with `process.rs` reverted to
  master it fails `left: "Crashed"`, `right: "Normal"`.
- **macOS, on-device:** `terminate_asks_a_gui_app_to_quit_before_signalling_it` requires the
  `quit: ` line the fixture prints from `applicationWillTerminate:`, which no signal-only teardown
  can produce. Green; with the ask stubbed out it fails on `captured logs: []`.
  `terminate_finishes_off_an_app_that_refuses_to_quit` drives the veto case and fails with
  "a vetoing app must still be gone after terminate" if the ladder is cut short.
- **macOS, granted run:** `bundle_launch` passes all three checks, including the new assertion —
  `stop_app asked the app to quit: its shutdown path ran before teardown`.
- `terminate_signals_a_non_gui_child_without_waiting_out_the_quit_grace` pins the other direction,
  so asking first can't quietly add the grace to every console-shaped app's teardown.
- Workspace `cargo test` / `clippy -D warnings` / `fmt --check` green; CI 8/8.

## Also here

- Comments across the workspace described where pure modules are tested by naming the author's
  machine ("unit-tested on the Linux dev box"). What matters is that a module makes no OS calls
  and so is tested off-target; the host is local trivia that rots. Now "on any host", the phrasing
  `discovery.rs` already used.
- The role-histogram probe left a File Explorer window open on every run. A Win11 folder window
  belongs to the already-running shell `explorer.exe`, so the process glass spawned handed off and
  exited and teardown tore down a tree that owned nothing. The probe now closes the window it
  adopted, and the spec comment claiming each folder window is its own process is corrected.

## Known limitations, stated plainly

- Sandboxie-contained Windows launches still get the old teardown (see above).
- The Linux backends have the same *shape* — `glass-proc-linux::reap_graceful` is SIGTERM-first
  with no `WM_DELETE_WINDOW` beforehand, and GTK/Qt install no SIGTERM handler either. Not
  measured, so it is flagged rather than claimed. Android (`am force-stop`) and iOS
  (`simctl terminate`) have no graceful equivalent to reach for.
- Separately found while verifying this, and **not** addressed here: glass direct-spawns a
  bundle's inner executable, and a macOS *system* app carries a launch constraint that makes the
  kernel `SIGKILL` it (`CODESIGNING` / "Launch Constraint Violation"). Every `start_app` against
  an app under `/System/` therefore produces a crash report and a "quit unexpectedly" dialog. The
  handoff path then works, but for a different reason than the code comments claim — they describe
  TextEdit as re-execing itself through LaunchServices, and it does not. Filed for its own change.
