### PR TITLE
fix(macos): don't direct-spawn a system app the kernel will kill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,15 @@ internal refactors, CI, or test-only changes.
   Android paths have no such live check.
 
 ### Fixed
+- macOS: launching a stock Apple app no longer leaves a crash report and a "quit unexpectedly"
+  dialog behind. glass direct-spawns a bundle's inner executable to get piped logs and
+  containment, but macOS gives a system app a launch constraint requiring it to be started by
+  LaunchServices, so the kernel killed the spawned process — measured, 10 of 12 stock apps tried.
+  The launch then succeeded anyway through the LaunchServices fallback, which is why this went
+  unnoticed. glass now recognizes Apple platform code and hands those launches off without
+  attempting the spawn. Your own app is unaffected: only Apple-signed system code takes the new
+  path, and only when `sandbox` is `off` (a contained launch cannot be handed off at all, so it
+  still tries — Terminal and Disk Utility, for instance, do run contained).
 - Windows and macOS: `glass_stop` now asks the app to close before killing it, so the app runs
   its own shutdown path. Both backends previously went straight to terminating the process —
   Windows by closing the job object, macOS by signalling — which an app that records whether it

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -270,8 +270,9 @@ impl MacosPlatform {
     /// (`bundle::resolve_inner_exec`) exactly like a plain exec — same logs, containment, and
     /// window-tracking as the non-bundle path — and only fall back to handing the launch off
     /// to `NSWorkspace` if that direct spawn's process exits before a window ever appears
-    /// (`GlassError::AppExited`, e.g. an app that re-execs itself via LaunchServices and
-    /// leaves the direct-spawned process a dead stub). Any other discovery failure (e.g.
+    /// (`GlassError::AppExited` — an app that re-execs itself via LaunchServices and leaves the
+    /// direct-spawned process a dead stub, or one the kernel refused to run as a child at all;
+    /// see the platform-code note below). Any other discovery failure (e.g.
     /// `GlassError::Timeout`) is NOT treated as a handoff signal — the direct-spawned process
     /// is still alive and simply never grew a window, so it's terminated and the error
     /// propagated, same as the plain-exec path.
@@ -281,7 +282,35 @@ impl MacosPlatform {
     /// `NSWorkspace`-launched process is never `direct.env`'s `DYLD_INSERT_LIBRARIES`
     /// target), so its `ClipboardRoute` is decided directly as the sandbox-off/no-shim case
     /// rather than via [`decide_clip`].
+    ///
+    /// **Apple platform code is handed off without attempting the spawn**, when the spec allows
+    /// a handoff at all. macOS gives a system app a launch constraint requiring it to be started
+    /// by launchd/LaunchServices, and the kernel `SIGKILL`s one spawned as another process's
+    /// child — `EXC_CRASH SIGKILL (Code Signature Invalid)`, `CODESIGNING` / "Launch Constraint
+    /// Violation". The launch still succeeded, via the fallback below, but every attempt left a
+    /// crash report and a "quit unexpectedly" dialog for the user. Measured: 10 of 12 stock apps
+    /// tried (Notes, Preview, Calculator, TextEdit, Reminders, Music, Chess, Dictionary, Console,
+    /// Activity Monitor) die that way; Terminal and Disk Utility survive, as does Safari.
+    ///
+    /// Nothing in the signature distinguishes those two groups — both are `Platform identifier=`
+    /// code, and App Sandbox does not correlate (Music and Console carry no app-sandbox
+    /// entitlement and still die) — so this cannot predict which system apps *would* have
+    /// spawned. It gives up the attempt for all of them rather than crash-report its way to the
+    /// same place, which costs those few their piped logs: an `NSWorkspace` launch has no stdio
+    /// to capture.
+    ///
+    /// **Only when `sandbox: off`.** A contained launch cannot be handed off at all (the gate),
+    /// so extending this to one would turn "run this system app contained" into an error whose
+    /// only remedy is `sandbox: off` — pushing the caller to run system code *less* contained
+    /// than they asked for, to avoid a crash dialog. Not a trade worth making: contained system
+    /// apps do work (Terminal and Disk Utility run fine under the profile), and glass's
+    /// containment is there for the app under development, which is never Apple platform code.
+    /// A constrained app asked for with containment therefore still attempts the spawn, dies,
+    /// and reaches the same gate error it always did.
     fn start_bundle(&mut self, spec: &AppSpec, bundle: &Path) -> Result<WindowGeometry> {
+        if spec.sandbox == SandboxLevel::Off && process::is_apple_platform_code(bundle) {
+            return self.adopt_via_launch_services(spec, bundle);
+        }
         // A-preferred: direct-spawn the inner executable (logs + containment + window
         // tracking), exactly as the plain-exec path does for a non-bundle `run[0]`.
         let inner = crate::bundle::resolve_inner_exec(bundle)?;
@@ -317,80 +346,95 @@ impl MacosPlatform {
                 // just below).
                 process::terminate(&mut child);
                 release_clip(clip.as_ref());
-                // Only an early inner-exec exit (`AppExited`) is the handoff signal — a stub
-                // that re-launched the real app through LaunchServices. Any other failure
-                // (e.g. `Timeout`: the process is alive but never grew a window) is propagated
-                // as-is, exactly as the plain-exec path does. NOTE: `AppExited` here conflates
-                // a genuine early crash of the inner exec with a deliberate re-exec stub; both
-                // fall through to the handoff below, which then either finds/relaunches a real
-                // window or fails.
+                // Only an early inner-exec exit (`AppExited`) is the handoff signal. Any other
+                // failure (e.g. `Timeout`: the process is alive but never grew a window) is
+                // propagated as-is, exactly as the plain-exec path does.
+                //
+                // NOTE: `AppExited` conflates several things — an app that re-execs itself
+                // through LaunchServices and leaves a dead stub, a genuine early crash of the
+                // inner exec, and (before the platform-code check above) the kernel killing a
+                // system app for a launch-constraint violation. All fall through to the handoff,
+                // which then either finds/relaunches a real window or fails.
                 let GlassError::AppExited(_) = e else {
                     return Err(e);
                 };
-                // Fail-closed: only sandbox:off may adopt an app glass can no longer contain.
-                crate::bundle::handoff_gate(spec.sandbox)?;
-                let id = crate::bundle::bundle_identifier(bundle)?;
-                let (pid, disposition) = match crate::ffi::running_pid_for_bundle_id(&id) {
-                    Some(pid) => (pid, crate::bundle::Disposition::PreExisting),
-                    // NOTE (runtime-verified in Task 4): `ffi::launch_bundle` blocks this
-                    // thread on a channel until `NSWorkspace`'s completion handler fires: if
-                    // LaunchServices needs the main run loop to spin to complete the launch,
-                    // and this call runs on the true main thread (see this module's
-                    // main-thread-affinity notes), that handler could need a run-loop turn this
-                    // blocked thread isn't pumping. Wired here per the design; the on-box round
-                    // confirms whether it actually stalls.
-                    None => match crate::ffi::launch_bundle(
-                        bundle,
-                        spec.run.get(1..).unwrap_or_default(),
-                        spec.timeout_ms,
-                    ) {
-                        Ok(pid) => (pid, crate::bundle::Disposition::Fresh),
-                        // `launch_bundle` can start the app yet still error before its pid is
-                        // delivered (e.g. its completion handler timed out) — an orphan. The
-                        // `None` just found above means any instance running now is one we
-                        // spawned, so best-effort reclaim it before propagating the error.
-                        Err(e) => {
-                            if let Some(pid) = crate::ffi::running_pid_for_bundle_id(&id)
-                                && !crate::ffi::terminate_app(pid)
-                            {
-                                // The launch error propagating below says nothing about this
-                                // stray app, and there is no `Child` here to escalate with.
-                                eprintln!(
-                                    "glass: the launch failed and the instance it started \
-                                     (pid {pid}) could not be asked to quit; if it is still \
-                                     running, quit it manually"
-                                );
-                            }
-                            return Err(e);
-                        }
-                    },
-                };
-                // Don't orphan a fresh launch whose window never appears in time: adopt only
-                // after discovery succeeds, since `self.adopted` (what `stop_app`/`Drop` reap)
-                // isn't set until below. Reaping here terminates only a `Fresh` launch — an
-                // already-running instance we merely re-found is not ours to kill.
-                let m = match Self::discover_window_pid(pid, spec.timeout_ms) {
-                    Ok(m) => m,
-                    Err(e) => {
-                        Adopted { pid, disposition }.reap();
-                        return Err(e);
-                    }
-                };
-                self.child = None;
-                // `app_pid` is `u32` (every other pid in this struct comes from
-                // `std::process::Child::id()`); AppKit's pids are `i32` but always
-                // non-negative for a real process, so this cast is exact, matching every
-                // other `pid as {i32,u32}` cast in this file (see e.g. `resolve_active_window`'s
-                // call sites, which cast the other direction).
-                self.app_pid = Some(pid as u32);
-                self.active_window = Some(m.window_id);
-                self.adopted = Some(Adopted { pid, disposition });
-                self.clip = None;
-                self.clipboard_route =
-                    crate::clipboard_route::decide_route(SandboxLevel::Off, None);
-                Ok(m.geometry)
+                self.adopt_via_launch_services(spec, bundle)
             }
         }
+    }
+
+    /// Hand the launch to `NSWorkspace`/LaunchServices and adopt the resulting process: the
+    /// fallback when a direct spawn produced no window, and the direct route for Apple platform
+    /// code (see [`Self::start_bundle`], which explains both entries).
+    ///
+    /// Fails closed unless `sandbox: off` — glass cannot Seatbelt-contain an app LaunchServices
+    /// owns, so it refuses rather than silently dropping the containment the caller asked for.
+    fn adopt_via_launch_services(
+        &mut self,
+        spec: &AppSpec,
+        bundle: &Path,
+    ) -> Result<WindowGeometry> {
+        // Fail-closed: only sandbox:off may adopt an app glass can no longer contain.
+        crate::bundle::handoff_gate(spec.sandbox)?;
+        let id = crate::bundle::bundle_identifier(bundle)?;
+        let (pid, disposition) = match crate::ffi::running_pid_for_bundle_id(&id) {
+            Some(pid) => (pid, crate::bundle::Disposition::PreExisting),
+            // NOTE (runtime-verified in Task 4): `ffi::launch_bundle` blocks this
+            // thread on a channel until `NSWorkspace`'s completion handler fires: if
+            // LaunchServices needs the main run loop to spin to complete the launch,
+            // and this call runs on the true main thread (see this module's
+            // main-thread-affinity notes), that handler could need a run-loop turn this
+            // blocked thread isn't pumping. Wired here per the design; the on-box round
+            // confirms whether it actually stalls.
+            None => match crate::ffi::launch_bundle(
+                bundle,
+                spec.run.get(1..).unwrap_or_default(),
+                spec.timeout_ms,
+            ) {
+                Ok(pid) => (pid, crate::bundle::Disposition::Fresh),
+                // `launch_bundle` can start the app yet still error before its pid is
+                // delivered (e.g. its completion handler timed out) — an orphan. The
+                // `None` just found above means any instance running now is one we
+                // spawned, so best-effort reclaim it before propagating the error.
+                Err(e) => {
+                    if let Some(pid) = crate::ffi::running_pid_for_bundle_id(&id)
+                        && !crate::ffi::terminate_app(pid)
+                    {
+                        // The launch error propagating below says nothing about this
+                        // stray app, and there is no `Child` here to escalate with.
+                        eprintln!(
+                            "glass: the launch failed and the instance it started \
+                             (pid {pid}) could not be asked to quit; if it is still \
+                             running, quit it manually"
+                        );
+                    }
+                    return Err(e);
+                }
+            },
+        };
+        // Don't orphan a fresh launch whose window never appears in time: adopt only
+        // after discovery succeeds, since `self.adopted` (what `stop_app`/`Drop` reap)
+        // isn't set until below. Reaping here terminates only a `Fresh` launch — an
+        // already-running instance we merely re-found is not ours to kill.
+        let m = match Self::discover_window_pid(pid, spec.timeout_ms) {
+            Ok(m) => m,
+            Err(e) => {
+                Adopted { pid, disposition }.reap();
+                return Err(e);
+            }
+        };
+        self.child = None;
+        // `app_pid` is `u32` (every other pid in this struct comes from
+        // `std::process::Child::id()`); AppKit's pids are `i32` but always
+        // non-negative for a real process, so this cast is exact, matching every
+        // other `pid as {i32,u32}` cast in this file (see e.g. `resolve_active_window`'s
+        // call sites, which cast the other direction).
+        self.app_pid = Some(pid as u32);
+        self.active_window = Some(m.window_id);
+        self.adopted = Some(Adopted { pid, disposition });
+        self.clip = None;
+        self.clipboard_route = crate::clipboard_route::decide_route(SandboxLevel::Off, None);
+        Ok(m.geometry)
     }
 }
 

--- a/crates/glass-macos/src/bundle.rs
+++ b/crates/glass-macos/src/bundle.rs
@@ -92,6 +92,25 @@ impl Disposition {
     }
 }
 
+/// Whether a `codesign --display --verbose=2` report describes **Apple platform code** — a
+/// binary signed as part of the OS rather than by a developer. codesign prints a
+/// `Platform identifier=<n>` line for exactly those, and for nothing else: a third-party app,
+/// ad-hoc signed code, and unsigned code all lack it.
+///
+/// This is what [`crate::backend`]'s bundle path uses to decide not to direct-spawn a system
+/// app. It answers "is this OS code", NOT "does this carry a launch constraint" — nothing in a
+/// signature exposes the latter, and the two are not the same population (Terminal and Safari
+/// are platform code and spawn fine). See `start_bundle` for why the broader question is the one
+/// worth acting on.
+///
+/// Fail-open: anything unrecognized reports `false`, which keeps the existing direct-spawn
+/// behaviour rather than diverting an app on a guess.
+pub fn platform_code_from_codesign_report(stderr: &str) -> bool {
+    stderr
+        .lines()
+        .any(|line| line.trim_start().starts_with("Platform identifier="))
+}
+
 fn plist_string(bundle: &Path, key: &str) -> Result<String> {
     let path = bundle.join("Contents/Info.plist");
     let val = plist::Value::from_file(&path)
@@ -201,6 +220,40 @@ mod tests {
             resolve_inner_exec(&app),
             Err(GlassError::AppNotStarted(_))
         ));
+    }
+
+    #[test]
+    fn platform_code_is_recognized_by_its_codesign_line() {
+        let report =
+            "Identifier=com.apple.TextEdit\nPlatform identifier=26\nTeamIdentifier=not set\n";
+        assert!(platform_code_from_codesign_report(report));
+    }
+
+    #[test]
+    fn a_third_party_signature_is_not_platform_code() {
+        // A Developer ID app: has a team, no platform identifier. Diverting one of these to the
+        // LaunchServices handoff would cost it its piped logs and its containment for nothing.
+        let report = "Identifier=com.google.android.studio\nCodeDirectory v=20500 size=6373 flags=0x10000(runtime)\nTeamIdentifier=EQHXZ8M8AV\n";
+        assert!(!platform_code_from_codesign_report(report));
+    }
+
+    #[test]
+    fn an_unreadable_report_is_not_platform_code() {
+        // Fail-open: codesign missing, or output glass can't parse, must leave the launch on the
+        // path it would have taken anyway.
+        assert!(!platform_code_from_codesign_report(""));
+        assert!(!platform_code_from_codesign_report(
+            "code object is not signed at all"
+        ));
+    }
+
+    #[test]
+    fn the_platform_line_must_be_the_key_not_a_substring() {
+        // `Platform identifier=` is matched at the start of a line so an app whose *name* or
+        // path contains the phrase can't fake it — codesign echoes `Executable=<path>`, and that
+        // path comes from the caller's spec.
+        let report = "Executable=/tmp/Platform identifier=26/Evil.app/Contents/MacOS/Evil\nTeamIdentifier=X\n";
+        assert!(!platform_code_from_codesign_report(report));
     }
 
     #[test]

--- a/crates/glass-macos/src/process.rs
+++ b/crates/glass-macos/src/process.rs
@@ -110,6 +110,28 @@ fn target_is_injectable(program: &Path) -> bool {
     injectable_from_codesign_report(&stderr, status_success)
 }
 
+/// Whether `bundle` is Apple platform code — OS code rather than a developer's app. Shells out
+/// to the same `codesign --display --verbose=2` that [`target_is_injectable`] reads (the report
+/// goes to stderr, not stdout); the decision itself is
+/// [`crate::bundle::platform_code_from_codesign_report`], which carries the reasoning.
+///
+/// Fail-open: if codesign can't be run or its output isn't UTF-8, this reports `false` and the
+/// caller keeps the launch path it would have taken anyway.
+pub(crate) fn is_apple_platform_code(bundle: &Path) -> bool {
+    let Ok(output) = Command::new("codesign")
+        .arg("--display")
+        .arg("--verbose=2")
+        .arg(bundle)
+        .output()
+    else {
+        return false;
+    };
+    let Ok(stderr) = String::from_utf8(output.stderr) else {
+        return false;
+    };
+    crate::bundle::platform_code_from_codesign_report(&stderr)
+}
+
 /// Env var overriding [`shim_dylib_path`]'s resolution — tests and non-standard layouts.
 const SHIM_DYLIB_ENV: &str = "GLASS_CLIP_SHIM_DYLIB";
 
@@ -608,6 +630,50 @@ mod tests {
             matches!(err, GlassError::AppNotStarted(_)),
             "expected AppNotStarted, got {err:?}"
         );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn ad_hoc_signed_code_is_not_apple_platform_code() {
+        // The fail-open direction, and the one that matters for a glass user: their own app must
+        // keep the direct-spawn path (piped logs, containment) and never be diverted to the
+        // LaunchServices handoff. Ad-hoc signing a copy of a system binary strips the platform
+        // signature, which is exactly the difference being detected.
+        let dir = std::env::temp_dir().join(format!("glass-platform-code-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let copy = dir.join("echo");
+        std::fs::copy("/bin/echo", &copy).expect("copy /bin/echo");
+        let signed = Command::new("codesign")
+            .args(["-f", "-s", "-"])
+            .arg(&copy)
+            .status()
+            .expect("run codesign");
+        assert!(signed.success(), "ad-hoc signing the copy failed");
+
+        let is_platform = is_apple_platform_code(&copy);
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(
+            !is_platform,
+            "ad-hoc signed code must not be treated as Apple platform code"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    #[ignore = "on-device only: reads the signatures of this machine's stock apps"]
+    fn stock_apps_are_apple_platform_code() {
+        // Both of these are platform code; only the first is killed when direct-spawned. That
+        // asymmetry is the whole reason `start_bundle` acts on "is this OS code" rather than
+        // trying to predict the kill — see its doc.
+        for app in [
+            "/System/Applications/TextEdit.app",
+            "/System/Applications/Utilities/Terminal.app",
+        ] {
+            assert!(
+                is_apple_platform_code(Path::new(app)),
+                "{app} should be recognized as Apple platform code"
+            );
+        }
     }
 
     #[test]

--- a/crates/glass-macos/tests/bundle_launch.rs
+++ b/crates/glass-macos/tests/bundle_launch.rs
@@ -13,9 +13,11 @@
 //!    launch went through `process::spawn`'s child path rather than the handoff path below:
 //!    `self.child`/`self.adopted` are private to `glass-macos`, but only a direct-spawned
 //!    child has its stdout/stderr piped into the log buffer at all (see check 2).
-//! 2. **Handoff app** (`NSWorkspace` adopt): `/System/Applications/TextEdit.app` re-execs
-//!    itself through LaunchServices, so its directly-spawned stub exits before a window
-//!    appears and `start_bundle` hands off to `NSWorkspace` — `start_app(sandbox: Off)`
+//! 2. **Handoff app** (`NSWorkspace` adopt): `/System/Applications/TextEdit.app` is Apple
+//!    platform code, so `start_bundle` hands it to `NSWorkspace` without attempting the direct
+//!    spawn at all (see that function's doc — the kernel kills a directly-spawned system app for
+//!    a launch-constraint violation, and the attempt left a crash report behind). So
+//!    `start_app(sandbox: Off)`
 //!    returns `Ok`, `drain_logs` is empty (the adopted pid was never `process::spawn`ed, so
 //!    nothing was ever piped), and a live `glass_a11y_macos::MacosA11y::snapshot` against the
 //!    adopted window returns a non-empty AX tree. Also confirms `stop_app`'s terminate path:
@@ -70,9 +72,12 @@ mod macos_main {
     };
     use glass_macos::MacosPlatform;
 
-    /// A stock-macOS handoff app: re-execs itself through LaunchServices, so directly
-    /// spawning `Contents/MacOS/TextEdit` exits before a window appears and
-    /// `start_bundle` falls into its `NSWorkspace` branch — exactly the fixture checks 2
+    /// A stock-macOS handoff app. NOTE the mechanism is not what it looks like: it does not
+    /// re-exec itself through LaunchServices. Directly spawning `Contents/MacOS/TextEdit` gets
+    /// the process `SIGKILL`ed by the kernel for a launch-constraint violation (`CODESIGNING`),
+    /// which used to reach `start_bundle` as the same `AppExited` signal a re-exec stub would —
+    /// and left a crash report each time. `start_bundle` now recognizes platform code and hands
+    /// off without spawning, which is the path checks 2
     /// and 3 need, without shipping a second custom `.app`. Present on every stock macOS
     /// install (unlike a third-party app), so no availability probe is needed.
     const TEXT_EDIT: &str = "/System/Applications/TextEdit.app";


### PR DESCRIPTION
## What

Launching a stock Apple app with glass left a crash report and a "quit unexpectedly" dialog every
time. `start_bundle` direct-spawns a bundle's inner executable — that is how glass gets piped logs
and containment — and macOS gives a system app a launch constraint requiring it to be started by
launchd/LaunchServices. The kernel kills one spawned as another process's child:

```
EXC_CRASH SIGKILL (Code Signature Invalid)
termination: {"namespace": "CODESIGNING", "indicator": "Launch Constraint Violation"}
```

The launch then *succeeded* through the LaunchServices fallback, which is why this went unnoticed:
the only visible symptom was a crash dialog nobody connected to glass. `tests/bundle_launch.rs`
uses TextEdit twice, so a granted run produced two.

## Measured

| stock app | direct-spawn | contained (`sandbox: default`) |
|---|---|---|
| Notes, Preview, Calculator, TextEdit, Reminders, Music, Chess, Dictionary, Console, Activity Monitor | **SIGKILL** | — |
| Terminal, Disk Utility | survives | survives |
| Safari | survives | dies (SIGTRAP) |

Nothing in the signature separates the killed group from the survivors: all are
`Platform identifier=` code, and App Sandbox does not correlate — Music and Console carry no
app-sandbox entitlement and still die. So this **does not try to predict the kill.** It acts on the
broader, readable fact — Apple platform code — and gives up the direct spawn for all of it.

## Scope of the change

Only `sandbox: off`, which is the only level a handoff is legal at anyway (`bundle::handoff_gate`).
A contained launch still attempts the spawn, because contained system apps genuinely work — the
table above shows Terminal and Disk Utility running fine under the Seatbelt profile, and diverting
them would trade one regression for another. A constrained app asked for *with* containment still
reaches the same "relaunch with `sandbox: off`" error it always did, one crash report later.

A developer's own app is untouched: platform code is Apple-only, and the predicate fails open, so
anything unreadable keeps the path it takes today.

**The cost:** the few system apps that would have direct-spawned lose their piped logs, because an
`NSWorkspace` launch has no stdio to capture. That is the deliberate half of the trade.

## Also

`backend.rs` and `tests/bundle_launch.rs` both described TextEdit as re-execing itself through
LaunchServices, so its "stub exits before a window appears". It does not re-exec — it is executed
and killed, and `AppExited` was conflating the two. Corrected in both places.

## Verification

- macOS on-device suite green (119 tests + the 3 `#[ignore]`d on-device ones).
- `platform_code_from_codesign_report` is pure and host-tested, including that the marker must be
  a real key and not a substring of an attacker-chosen path — codesign echoes `Executable=<path>`,
  and that path comes from the caller's spec.
- `ad_hoc_signed_code_is_not_apple_platform_code` pins the direction that matters for a glass user:
  their own app keeps the direct-spawn path. Runs in CI on the macOS leg.
- `stock_apps_are_apple_platform_code` (on-device) checks the predicate against this machine's real
  TextEdit and Terminal — deliberately including Terminal, which is platform code and is *not*
  killed, so the test documents that the predicate is broader than the kill.
- **End-to-end, granted run:** all three checks pass, and TextEdit crash reports go from two per
  run to one — check 2 (`sandbox: off`) no longer spawns; check 3 (`sandbox: default`) still does,
  by design. Confirmed by count across two runs (11 → 13).

## The `sandbox: default` case, deliberately left alone

A system app asked for *with* containment still gets the spawn attempt, so a constrained one still
produces a crash dialog on that path before the "relaunch with `sandbox: off`" error. Extending the
skip there would remove the dialog and answer the request with that error instead — which pushes
the caller toward running system code *less* contained than they asked for, to dodge a dialog.
Contained system apps do work (Terminal and Disk Utility, measured), and glass's containment exists
for the app under development, which is never Apple platform code. Driving system apps is not what
this tool is for; the paths that are, are unaffected.
