### PR TITLE
fix(x11,wayland): ask an app to close before signalling it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,16 +109,21 @@ internal refactors, CI, or test-only changes.
   attempting the spawn. Your own app is unaffected: only Apple-signed system code takes the new
   path, and only when `sandbox` is `off` (a contained launch cannot be handed off at all, so it
   still tries — Terminal and Disk Utility, for instance, do run contained).
-- Windows and macOS: `glass_stop` now asks the app to close before killing it, so the app runs
-  its own shutdown path. Both backends previously went straight to terminating the process —
-  Windows by closing the job object, macOS by signalling — which an app that records whether it
-  exited cleanly reports as a crash the *next* time it starts. A Chromium-based browser opened
-  with a "Restore pages?" prompt instead of its normal first screen, so an agent driving it saw
-  a different first screen on every run. An app that ignores or refuses the request is still
-  terminated, and glass now says so on stderr rather than reporting an unqualified success.
-  Windows launches under Sandboxie containment are the exception and still get the old
-  teardown: a close request sent from outside the box is accepted by the OS but never reaches
-  the app, so landing one needs a helper running inside the box.
+- `glass_stop` now asks the app to close before killing it on every desktop backend, so the app
+  runs its own shutdown path. All four previously went straight to terminating the process —
+  Windows by closing the job object, macOS by signalling, X11 and Wayland by signalling the
+  process group — which an app that records whether it exited cleanly reports as a crash the
+  *next* time it starts. A Chromium-based browser opened with a "Restore pages?" prompt instead
+  of its normal first screen, so an agent driving it saw a different first screen on every run.
+  The ask is each platform's own: `WM_CLOSE` on Windows, a quit request on macOS, a
+  `WM_DELETE_WINDOW` client message on X11, and a close request through the compositor on
+  Wayland — measured to be what makes a GTK app run its shutdown handlers, which no signal does.
+  An app that ignores or refuses the request is still terminated, and glass now says so on
+  stderr rather than reporting an unqualified success. Two exceptions keep the old teardown: a
+  Windows launch under Sandboxie containment (a close request sent from outside the box is
+  accepted by the OS but never reaches the app, so landing one needs a helper running inside the
+  box), and an X11 client that never opted into the `WM_DELETE_WINDOW` protocol, which is
+  required to ignore the request.
 - iOS: `glass_start` no longer reports a window for an app that died on launch. `simctl launch`
   exits successfully once the process is spawned, so an app that rejects a launch argument or
   trips an assertion at startup was reported as running, and the screenshot behind that geometry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,13 +117,17 @@ internal refactors, CI, or test-only changes.
   of its normal first screen, so an agent driving it saw a different first screen on every run.
   The ask is each platform's own: `WM_CLOSE` on Windows, a quit request on macOS, a
   `WM_DELETE_WINDOW` client message on X11, and a close request through the compositor on
-  Wayland — measured to be what makes a GTK app run its shutdown handlers, which no signal does.
+  Wayland. On the two Linux backends that was measured directly: a GTK app ran its shutdown
+  handlers when asked and none of them when signalled, because the toolkit installs no `SIGTERM`
+  handler. An app that installs one of its own is the exception.
   An app that ignores or refuses the request is still terminated, and glass now says so on
   stderr rather than reporting an unqualified success. Two exceptions keep the old teardown: a
   Windows launch under Sandboxie containment (a close request sent from outside the box is
   accepted by the OS but never reaches the app, so landing one needs a helper running inside the
-  box), and an X11 client that never opted into the `WM_DELETE_WINDOW` protocol, which is
-  required to ignore the request.
+  box), and an X11 client that never opted into the `WM_DELETE_WINDOW` protocol, which has no
+  handler for the request and will not act on it. Under Wayland the compositor performs the ask,
+  and it disconnects a client that has no close protocol rather than asking it — glass cannot
+  tell that apart from a clean close there, so that case is reported as one.
 - iOS: `glass_start` no longer reports a window for an app that died on launch. `simctl launch`
   exits successfully once the process is spawned, so an app that rejects a launch argument or
   trips an assertion at startup was reported as running, and the screenshot behind that geometry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1230,6 +1230,7 @@ dependencies = [
  "base64 0.23.0",
  "glass-core",
  "glass-mcp",
+ "glass-proc-linux",
  "glass-wayland",
  "glass-x11",
  "image",

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -1036,3 +1036,26 @@ fn set_value_resolves_an_id_past_the_default_cap_from_an_unbounded_snapshot() {
         "the id past the old cap resolved (lockstep held); got: {msg}"
     );
 }
+
+/// Teardown of an a11y-enabled launch has to fit in the budget glass-mcp gives it. The backends
+/// bind their close-request + signal ladder to `TEARDOWN_BUDGET` at compile time, but the private
+/// a11y bus is torn down inside the same budget and is not covered by that assertion — its two
+/// helpers (the AT-SPI registry and the session bus) each get their own reap grace. Past the
+/// budget glass-mcp stops waiting and exits, orphaning whatever is left.
+///
+/// This lives here rather than with the X11 teardown tests because it is the only suite whose
+/// host is guaranteed an AT-SPI launcher.
+#[test]
+#[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
+fn stopping_an_a11y_launch_finishes_inside_the_teardown_budget() {
+    let mut glass = launch_fixture();
+    let t = std::time::Instant::now();
+    glass.stop().expect("stop");
+    let elapsed = t.elapsed();
+    assert!(
+        elapsed < glass_core::TEARDOWN_BUDGET,
+        "tearing down an a11y launch (ask + signal ladder + private bus) must fit in the {:?} \
+         glass-mcp allows teardown; this took {elapsed:?}",
+        glass_core::TEARDOWN_BUDGET
+    );
+}

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -30,8 +30,6 @@ pub(crate) mod status;
 mod tools;
 mod untrusted;
 
-use std::time::Duration;
-
 use anyhow::Context;
 use glass_core::{Backend, BaselineStore, Glass, GlassError, Platform, Result};
 #[cfg(target_os = "linux")]
@@ -409,7 +407,7 @@ pub async fn run_stdio(glass: Glass, report: crate::audit::AuditReport) -> anyho
             true
         }
     };
-    shutdown::run_shutdown(sessions, Duration::from_secs(3)).await;
+    shutdown::run_shutdown(sessions, glass_core::TEARDOWN_BUDGET).await;
     if via_signal {
         std::process::exit(0);
     }

--- a/crates/glass-mcp/src/serve/mod.rs
+++ b/crates/glass-mcp/src/serve/mod.rs
@@ -6,7 +6,6 @@ pub mod session_gate;
 pub mod token;
 
 use std::sync::Arc;
-use std::time::Duration;
 
 use anyhow::Context;
 use axum::Router;
@@ -165,7 +164,7 @@ pub async fn run_on(
         .context("serving MCP over HTTP");
 
     // Tear down the active session through the one bounded path, like stdio.
-    crate::shutdown::run_shutdown(sessions, Duration::from_secs(3)).await;
+    crate::shutdown::run_shutdown(sessions, glass_core::TEARDOWN_BUDGET).await;
     r
 }
 

--- a/crates/glass-proc-linux/src/lib.rs
+++ b/crates/glass-proc-linux/src/lib.rs
@@ -29,10 +29,15 @@ pub const REAP_GRACE: Duration = Duration::from_secs(2);
 /// How long an app that was *asked* to close gets to leave through its own shutdown path
 /// before glass falls back to signalling it.
 ///
-/// Signals give a GUI toolkit no shutdown path at all: GTK and Qt install no `SIGTERM`
-/// handler, so a signalled app never runs its close/shutdown handlers — measured with a GTK 4
-/// client on both Linux backends. Asking first (an X11 `WM_DELETE_WINDOW` client message, or
-/// `kill` on the compositor's container under Wayland) is what lets the app flush its state.
+/// A signalled toolkit app runs no shutdown path at all, because the toolkit installs no
+/// `SIGTERM` handler and the default disposition kills the process outright: verified with GTK 4
+/// on both Linux backends, where a signalled client recorded nothing on the way out and an asked
+/// one ran its close and shutdown handlers (Qt is believed to behave the same way; that was not
+/// tested). Asking first — an X11 `WM_DELETE_WINDOW` client message, or a close request through
+/// the compositor under Wayland — is what lets the app flush its state.
+///
+/// The value also has to leave room for the signal ladder inside the budget teardown gets as a
+/// whole; each backend asserts that against `glass_core::TEARDOWN_BUDGET` at compile time.
 pub const CLOSE_GRACE: Duration = Duration::from_millis(1500);
 
 /// SIGTERM→SIGKILL grace for an app that was already asked to close and did not.
@@ -47,57 +52,135 @@ pub const APP_REAP_GRACE: Duration = Duration::from_millis(1000);
 /// every teardown as an unqualified success. Signalling an app that was never asked destroys
 /// whatever it would have flushed on exit, and the user only learns of it the next time the
 /// app starts up in a recovered/crashed state.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Closed {
-    /// Asked, and the app left through its own shutdown path.
+    /// Asked, and the app left on its own before the grace ran out.
     Gracefully,
-    /// Nothing was asked, so the app was signalled without a chance to shut down. Carries how
-    /// many of its windows were there but could not be asked — an X11 client that never opted
-    /// into `WM_DELETE_WINDOW`, say — which is a different situation from an app that had no
-    /// window to ask (a teardown after a failed launch, or a windowless process).
-    SignalledUnasked { unaskable: usize },
+    /// Nothing was asked, so the app was signalled without a chance to shut down. `reason` says
+    /// why when there is something to say — windows that were there but could not be asked, or
+    /// an enumeration that failed. `None` means there was simply no window to ask (a teardown
+    /// after a failed launch, or a windowless process), which is not worth reporting.
+    SignalledUnasked { reason: Option<String> },
     /// Asked, but still running when [`CLOSE_GRACE`] ran out (a modal save prompt, or a hang),
     /// so it was signalled anyway.
     SignalledAfterGrace,
 }
 
-/// Classify a teardown from how many of the app's windows were asked to close, how many were
-/// there but could not be asked, and whether the app then exited on its own. Pure so it can be
-/// tested off a display.
-pub fn close_outcome(asked: usize, unaskable: usize, exited: bool) -> Closed {
-    match (asked, exited) {
-        (0, _) => Closed::SignalledUnasked { unaskable },
-        (_, true) => Closed::Gracefully,
-        (_, false) => Closed::SignalledAfterGrace,
+/// The result of asking an app's windows to close: how many the request reached, and why the
+/// rest could not be asked. Backends build one of these and hand it to [`Asked::outcome`], so
+/// the counts are never two bare numbers a caller could swap.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Asked {
+    asked: usize,
+    reason: Option<String>,
+}
+
+impl Asked {
+    /// Nothing to ask: the app has no window. Reported as nothing at all — there was no
+    /// shutdown path to miss.
+    pub const fn none() -> Asked {
+        Asked {
+            asked: 0,
+            reason: None,
+        }
+    }
+
+    /// `total` windows were found and `asked` of them accepted a close request. `why_not`
+    /// describes the rest in the backend's own terms — the caller knows whether they lacked a
+    /// protocol, sat outside the launched process tree, or were refused by a compositor.
+    pub fn counted(total: usize, asked: usize, why_not: impl FnOnce(usize) -> String) -> Asked {
+        let unaskable = total.saturating_sub(asked);
+        Asked {
+            asked,
+            reason: (unaskable > 0).then(|| why_not(unaskable)),
+        }
+    }
+
+    /// glass could not find out what to ask — the window enumeration itself failed. Distinct
+    /// from [`Asked::none`] on purpose: "the app has no window" is routine, "glass could not
+    /// look" is a failure of glass's own machinery and must not pass for it.
+    pub fn blocked(reason: impl Into<String>) -> Asked {
+        Asked {
+            asked: 0,
+            reason: Some(reason.into()),
+        }
+    }
+
+    /// Whether anything was actually asked to close.
+    pub fn any(&self) -> bool {
+        self.asked > 0
+    }
+
+    /// Wait for the app to leave on its own — but only if something was asked. With nothing
+    /// asked there is no shutdown to wait for, so the grace is skipped rather than spent.
+    pub fn await_close(&self, grace: Duration, done: impl FnMut() -> bool) -> bool {
+        self.any() && await_condition(grace, done)
+    }
+
+    /// [`Asked::await_close`] for the common case: wait for the spawned child itself to exit.
+    ///
+    /// The wait NEVER signals — that is the whole point, an app asked to close must be left
+    /// alone to run its shutdown path. A `try_wait` error counts as "did not exit", not as an
+    /// exit: the caller's fallback is the signal ladder, which is what actually guarantees the
+    /// process is gone, and skipping it on a reading we could not make would leave the app
+    /// running.
+    pub fn await_child_exit(&self, child: &mut Child, grace: Duration) -> bool {
+        self.await_close(grace, || matches!(child.try_wait(), Ok(Some(_))))
+    }
+
+    /// Classify the teardown: `closed_itself` is whether the app left before the grace ran out.
+    pub fn outcome(self, closed_itself: bool) -> Closed {
+        match (self.asked, closed_itself) {
+            (0, _) => Closed::SignalledUnasked {
+                reason: self.reason,
+            },
+            (_, true) => Closed::Gracefully,
+            (_, false) => Closed::SignalledAfterGrace,
+        }
     }
 }
 
-/// Report a teardown that could not be graceful. Silent on [`Closed::Gracefully`] — the good
-/// path is the expectation, not news — and on an app with no window to ask, which has no
-/// shutdown path to have missed (this also runs on the failed-launch path, where a warning
-/// would be pure noise). The rest is something the user can act on, and would otherwise surface
-/// only as an unexplained recovery prompt the *next* time the app is launched.
-pub fn disclose_teardown(closed: Closed) {
+/// What the user should be told about a teardown, or `None` when there is nothing to say.
+///
+/// Silent on [`Closed::Gracefully`] — the good path is the expectation, not news — and on an app
+/// with no window to ask, which had no shutdown path to miss (that arm also covers the
+/// failed-launch teardown, where a warning would be pure noise). Split from the printing so the
+/// wording is testable; [`disclose_teardown`] is the printing half.
+pub fn teardown_notice(closed: &Closed) -> Option<String> {
     match closed {
-        Closed::Gracefully | Closed::SignalledUnasked { unaskable: 0 } => {}
-        Closed::SignalledUnasked { unaskable } => eprintln!(
-            "glass: {unaskable} window(s) of the app could not be asked to close, so it was \
-             signalled instead. An X11 client that never opted into the WM_DELETE_WINDOW \
-             protocol cannot be asked; toolkit apps opt in. An app that flushes state on exit \
-             did not get to, and may report a crash on its next launch."
-        ),
-        Closed::SignalledAfterGrace => eprintln!(
+        Closed::Gracefully => None,
+        Closed::SignalledUnasked { reason } => reason.as_ref().map(|why| {
+            format!(
+                "glass: the app was signalled instead of being asked to close ({why}). An app \
+                 that flushes state on exit did not get to, and may report a crash on its next \
+                 launch."
+            )
+        }),
+        Closed::SignalledAfterGrace => Some(format!(
             "glass: the app did not close within {CLOSE_GRACE:?} of being asked (a modal \
-             shutdown prompt will do this), so it was signalled. Unsaved state was not flushed, \
-             and the app may report a crash on its next launch."
-        ),
+             shutdown prompt, or an app that ignores close requests, will do this), so it was \
+             signalled. Unsaved state was not flushed, and the app may report a crash on its \
+             next launch."
+        )),
     }
 }
+
+/// Print [`teardown_notice`] to stderr (stdout is the MCP channel).
+pub fn disclose_teardown(closed: &Closed) {
+    if let Some(notice) = teardown_notice(closed) {
+        eprintln!("{notice}");
+    }
+}
+
+/// How often the waits and the signal ladder re-check. One constant so a change here cannot
+/// leave a doc comment elsewhere claiming they match.
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
 
 /// Poll `done` until it reports true or `grace` is spent. Returns whether it reported true.
 ///
-/// The polling interval matches [`reap`]'s, and `done` is called once before any sleep so an
-/// app that has already gone costs nothing.
+/// `done` is called once before any sleep, so an app that has already gone costs nothing. Note
+/// the deadline is only checked *between* calls: `done` must not block for longer than the
+/// caller is willing to wait.
 pub fn await_condition(grace: Duration, mut done: impl FnMut() -> bool) -> bool {
     let deadline = Instant::now() + grace;
     loop {
@@ -107,19 +190,55 @@ pub fn await_condition(grace: Duration, mut done: impl FnMut() -> bool) -> bool 
         if Instant::now() >= deadline {
             return false;
         }
-        std::thread::sleep(Duration::from_millis(20));
+        std::thread::sleep(POLL_INTERVAL);
     }
 }
 
-/// Wait up to `grace` for the child to exit on its own, WITHOUT signalling it. Returns whether
-/// it did; the caller still has to `wait()` (or reap) it. Used after asking an app to close: an
-/// app that leaves through its own shutdown path must not then be signalled for it.
+/// Whether any of `pids` is still a live process.
+pub fn any_alive(pids: &[u32]) -> bool {
+    pids.iter()
+        .any(|pid| std::path::Path::new(&format!("/proc/{pid}")).exists())
+}
+
+/// Reap a whole launch: the child glass spawned, its process group, and every pid in `tree` — a
+/// snapshot of the launch's `/proc` subtree taken *before* any of it exited. SIGTERM everything,
+/// wait up to `grace` for it all to go, then SIGKILL whatever is left, then reap the child.
 ///
-/// A `try_wait` error counts as "did not exit", not as an exit: the caller's fallback is the
-/// signal ladder, which is what actually guarantees the process is gone, and skipping it on a
-/// reading we could not make would leave the app running.
-pub fn await_exit(child: &mut Child, grace: Duration) -> bool {
-    await_condition(grace, || matches!(child.try_wait(), Ok(Some(_))))
+/// The snapshot is load-bearing, because neither of the other two handles is enough on its own:
+///
+/// - The parent link goes away with the parent. Once the child is reaped its descendants are
+///   reparented to init, so a later `proc_tree_pids` no longer finds them.
+/// - The process group does not contain everything the launch produced. sway calls `setsid` for
+///   every app it `exec`s, so under the Wayland backend the app is in neither the compositor's
+///   group nor its session — measured: after a SIGTERM to sway's group, the exec'd tree was
+///   still running, reparented to init.
+///
+/// A pid is only signalled while `/proc/<pid>` still exists. That check races pid reuse the same
+/// way every `kill`-based reaper on Linux does; the alternative is leaking the app's children on
+/// every teardown.
+pub fn reap_launch(child: &mut Child, tree: &[u32], grace: Duration) {
+    let leader = Pid::from_raw(child.id() as i32);
+    let signal_all = |signal| {
+        if let Some(leader) = leader {
+            let _ = kill_process_group(leader, signal);
+        }
+        for &pid in tree {
+            if std::path::Path::new(&format!("/proc/{pid}")).exists()
+                && let Some(pid) = Pid::from_raw(pid as i32)
+            {
+                let _ = kill_process(pid, signal);
+            }
+        }
+    };
+    signal_all(Signal::TERM);
+    let gone = await_condition(grace, || {
+        matches!(child.try_wait(), Ok(Some(_))) && !any_alive(tree)
+    });
+    if !gone {
+        signal_all(Signal::KILL);
+        let _ = child.kill();
+    }
+    let _ = child.wait();
 }
 
 /// Gracefully reap a single child: SIGTERM, poll for exit up to `grace`, then
@@ -155,7 +274,7 @@ fn reap(child: &mut Child, grace: Duration, group: bool) {
                     }
                     break;
                 }
-                Ok(None) => std::thread::sleep(Duration::from_millis(20)),
+                Ok(None) => std::thread::sleep(POLL_INTERVAL),
                 Err(_) => break,
             }
         }
@@ -241,7 +360,9 @@ pub fn spawn_reader<S: Copy + Send + 'static, R: Read + Send + 'static>(
 
 #[cfg(test)]
 mod reap_tests {
-    use super::{REAP_GRACE, reap_graceful, reap_group};
+    use super::{
+        Asked, CLOSE_GRACE, Closed, REAP_GRACE, reap_graceful, reap_group, teardown_notice,
+    };
     use std::io::{BufRead, BufReader};
     use std::os::unix::process::CommandExt;
     use std::process::{Command, Stdio};
@@ -324,28 +445,33 @@ mod reap_tests {
         assert_eq!(REAP_GRACE, Duration::from_secs(2));
     }
 
+    /// An `Asked` that stands for "one window accepted the close request", for the waits below.
+    fn one_window_asked() -> Asked {
+        Asked::counted(1, 1, |_| unreachable!("nothing was left unasked"))
+    }
+
     #[test]
-    fn await_exit_reports_a_child_that_leaves_on_its_own() {
+    fn await_child_exit_reports_a_child_that_leaves_on_its_own() {
         let mut c = Command::new("true").spawn().unwrap();
         assert!(
-            super::await_exit(&mut c, Duration::from_secs(5)),
+            one_window_asked().await_child_exit(&mut c, Duration::from_secs(5)),
             "a child that exits by itself must be reported as exited"
         );
         let _ = c.wait();
     }
 
     #[test]
-    fn await_exit_does_not_signal_the_child_it_waits_for() {
+    fn await_child_exit_does_not_signal_the_child_it_waits_for() {
         // The whole point of the wait: an app that was ASKED to close must be left alone to run
-        // its own shutdown path. If await_exit signalled, this would return true and the pid
-        // would be gone.
+        // its own shutdown path. If the wait signalled, this would return true and the pid would
+        // be gone.
         let mut c = Command::new("sleep").arg("30").spawn().unwrap();
         let grace = Duration::from_millis(200);
         assert!(
-            !super::await_exit(&mut c, grace),
+            !one_window_asked().await_child_exit(&mut c, grace),
             "a still-running child must be reported as not exited"
         );
-        assert!(alive(c.id()), "await_exit must not signal the child");
+        assert!(alive(c.id()), "the wait must not signal the child");
         let _ = c.kill();
         let _ = c.wait();
     }
@@ -373,54 +499,125 @@ mod reap_tests {
 
     #[test]
     fn an_app_that_was_never_asked_is_reported_as_signalled_unasked() {
+        let asked = Asked::counted(2, 0, |n| format!("{n} cannot be asked"));
         assert_eq!(
-            super::close_outcome(0, 2, false),
-            super::Closed::SignalledUnasked { unaskable: 2 }
+            asked.clone().outcome(false),
+            Closed::SignalledUnasked {
+                reason: Some("2 cannot be asked".into())
+            }
         );
         // Even if the app happened to exit on its own, nothing asked it to — the caller has no
         // basis for reporting a graceful close.
         assert_eq!(
-            super::close_outcome(0, 2, true),
-            super::Closed::SignalledUnasked { unaskable: 2 }
+            asked.outcome(true),
+            Closed::SignalledUnasked {
+                reason: Some("2 cannot be asked".into())
+            }
         );
     }
 
     #[test]
     fn an_asked_app_that_exits_is_reported_as_graceful() {
-        assert_eq!(super::close_outcome(1, 0, true), super::Closed::Gracefully);
+        let asked = Asked::counted(1, 1, |_| unreachable!("nothing was left unasked"));
+        assert_eq!(asked.outcome(true), Closed::Gracefully);
     }
 
     #[test]
     fn an_asked_app_that_stays_is_reported_as_signalled_after_the_grace() {
-        assert_eq!(
-            super::close_outcome(1, 0, false),
-            super::Closed::SignalledAfterGrace
-        );
+        let asked = Asked::counted(1, 1, |_| unreachable!("nothing was left unasked"));
+        assert_eq!(asked.outcome(false), Closed::SignalledAfterGrace);
     }
 
     #[test]
-    fn an_app_with_no_window_to_ask_is_distinguishable_from_one_that_refused_the_ask() {
+    fn an_app_with_no_window_to_ask_says_nothing() {
         // Teardown also runs on the failed-launch path, where there is no window and nothing was
-        // missed. `disclose_teardown` stays silent on that, so the two must not collapse into one
-        // outcome.
-        assert_eq!(
-            super::close_outcome(0, 0, false),
-            super::Closed::SignalledUnasked { unaskable: 0 }
-        );
-        assert_ne!(
-            super::close_outcome(0, 0, false),
-            super::close_outcome(0, 1, false)
+        // missed. That must stay silent, while a window glass could not ask must not.
+        assert_eq!(teardown_notice(&Asked::none().outcome(false)), None);
+        assert!(
+            teardown_notice(&Asked::counted(1, 0, |n| format!("{n} unaskable")).outcome(false))
+                .is_some()
         );
     }
 
     #[test]
-    fn the_close_and_signal_graces_leave_the_teardown_budget_headroom() {
-        // The backends bind these to glass_core::TEARDOWN_BUDGET at compile time; this crate
-        // has no glass-core dependency, so assert the shape they rely on: the ask gets the
-        // larger share (it is the one that produces a clean shutdown) and the pair stays well
-        // under the 3s budget.
+    fn an_enumeration_failure_is_reported_rather_than_read_as_nothing_to_ask() {
+        // The failure mode this guards: glass's own machinery breaks (an unreachable display or
+        // compositor), nothing is asked, the app is signalled — and the user is told nothing,
+        // because it looks exactly like an app that had no window.
+        let notice = teardown_notice(&Asked::blocked("the compositor went away").outcome(false))
+            .expect("a blocked ask must be disclosed");
+        assert!(
+            notice.contains("the compositor went away"),
+            "the reason must reach the user: {notice}"
+        );
+    }
+
+    #[test]
+    fn nothing_asked_means_the_close_grace_is_not_spent() {
+        // An app that could not be asked has no shutdown to wait for; spending the grace on it
+        // would add over a second to every such teardown.
+        let t = Instant::now();
+        assert!(!Asked::none().await_close(Duration::from_secs(30), || false));
+        assert!(
+            t.elapsed() < Duration::from_secs(1),
+            "waited {:?} for a close nobody was asked to perform",
+            t.elapsed()
+        );
+    }
+
+    #[test]
+    fn a_graceful_close_is_not_worth_reporting() {
+        assert_eq!(teardown_notice(&Closed::Gracefully), None);
+    }
+
+    #[test]
+    fn an_app_that_ignored_the_request_is_reported_with_the_grace_it_was_given() {
+        let notice = teardown_notice(&Closed::SignalledAfterGrace).expect("must be disclosed");
+        assert!(
+            notice.contains(&format!("{CLOSE_GRACE:?}")),
+            "the notice should say how long the app was given: {notice}"
+        );
+    }
+
+    #[test]
+    fn the_close_grace_gets_the_larger_share_of_the_ladder() {
+        // The ask is the half that produces a clean shutdown, so it gets the longer wait; the
+        // signal ladder only has to make sure the app is gone. The budget the pair has to fit
+        // inside is `glass_core::TEARDOWN_BUDGET`, which this crate deliberately cannot see —
+        // each backend binds them to it with a compile-time assertion.
         assert!(super::CLOSE_GRACE > super::APP_REAP_GRACE);
-        assert!(super::CLOSE_GRACE + super::APP_REAP_GRACE < Duration::from_secs(3));
+    }
+
+    #[test]
+    fn reap_launch_reaps_a_child_that_left_the_process_group() {
+        // sway does exactly this to every app it execs: `setsid` puts the app in its own group
+        // and session, where a signal to the launcher's group never reaches it. Reaping the
+        // snapshot is what covers that.
+        let mut leader = Command::new("sh")
+            .args(["-c", "setsid sleep 30 & echo started; wait"])
+            .process_group(0)
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let mut line = String::new();
+        BufReader::new(leader.stdout.take().unwrap())
+            .read_line(&mut line)
+            .unwrap();
+        assert_eq!(line.trim(), "started");
+        std::thread::sleep(Duration::from_millis(100)); // let setsid re-exec into its own session
+        let tree = super::proc_tree_pids(leader.id());
+        let escaped: Vec<u32> = tree.iter().copied().filter(|&p| p != leader.id()).collect();
+        assert!(
+            !escaped.is_empty(),
+            "the launch should have a child to reap"
+        );
+        super::reap_launch(&mut leader, &tree, Duration::from_secs(5));
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(
+            !super::any_alive(&escaped),
+            "reap_launch must reach every process the launch produced, group or no group: \
+             {escaped:?} survived"
+        );
     }
 }
 

--- a/crates/glass-proc-linux/src/lib.rs
+++ b/crates/glass-proc-linux/src/lib.rs
@@ -26,6 +26,102 @@ use rustix::process::{Pid, Signal, kill_process, kill_process_group};
 /// Grace period a process gets to exit after SIGTERM before SIGKILL.
 pub const REAP_GRACE: Duration = Duration::from_secs(2);
 
+/// How long an app that was *asked* to close gets to leave through its own shutdown path
+/// before glass falls back to signalling it.
+///
+/// Signals give a GUI toolkit no shutdown path at all: GTK and Qt install no `SIGTERM`
+/// handler, so a signalled app never runs its close/shutdown handlers — measured with a GTK 4
+/// client on both Linux backends. Asking first (an X11 `WM_DELETE_WINDOW` client message, or
+/// `kill` on the compositor's container under Wayland) is what lets the app flush its state.
+pub const CLOSE_GRACE: Duration = Duration::from_millis(1500);
+
+/// SIGTERM→SIGKILL grace for an app that was already asked to close and did not.
+///
+/// Shorter than [`REAP_GRACE`] on purpose: this runs *after* [`CLOSE_GRACE`] is already spent,
+/// and the two together have to fit in the budget glass-mcp gives teardown as a whole. An app
+/// that ignored the close request has had its chance to shut down cleanly; what is left is
+/// making sure it is gone.
+pub const APP_REAP_GRACE: Duration = Duration::from_millis(1000);
+
+/// How a launched app actually went away, so the backend can say so rather than reporting
+/// every teardown as an unqualified success. Signalling an app that was never asked destroys
+/// whatever it would have flushed on exit, and the user only learns of it the next time the
+/// app starts up in a recovered/crashed state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Closed {
+    /// Asked, and the app left through its own shutdown path.
+    Gracefully,
+    /// Nothing was asked, so the app was signalled without a chance to shut down. Carries how
+    /// many of its windows were there but could not be asked — an X11 client that never opted
+    /// into `WM_DELETE_WINDOW`, say — which is a different situation from an app that had no
+    /// window to ask (a teardown after a failed launch, or a windowless process).
+    SignalledUnasked { unaskable: usize },
+    /// Asked, but still running when [`CLOSE_GRACE`] ran out (a modal save prompt, or a hang),
+    /// so it was signalled anyway.
+    SignalledAfterGrace,
+}
+
+/// Classify a teardown from how many of the app's windows were asked to close, how many were
+/// there but could not be asked, and whether the app then exited on its own. Pure so it can be
+/// tested off a display.
+pub fn close_outcome(asked: usize, unaskable: usize, exited: bool) -> Closed {
+    match (asked, exited) {
+        (0, _) => Closed::SignalledUnasked { unaskable },
+        (_, true) => Closed::Gracefully,
+        (_, false) => Closed::SignalledAfterGrace,
+    }
+}
+
+/// Report a teardown that could not be graceful. Silent on [`Closed::Gracefully`] — the good
+/// path is the expectation, not news — and on an app with no window to ask, which has no
+/// shutdown path to have missed (this also runs on the failed-launch path, where a warning
+/// would be pure noise). The rest is something the user can act on, and would otherwise surface
+/// only as an unexplained recovery prompt the *next* time the app is launched.
+pub fn disclose_teardown(closed: Closed) {
+    match closed {
+        Closed::Gracefully | Closed::SignalledUnasked { unaskable: 0 } => {}
+        Closed::SignalledUnasked { unaskable } => eprintln!(
+            "glass: {unaskable} window(s) of the app could not be asked to close, so it was \
+             signalled instead. An X11 client that never opted into the WM_DELETE_WINDOW \
+             protocol cannot be asked; toolkit apps opt in. An app that flushes state on exit \
+             did not get to, and may report a crash on its next launch."
+        ),
+        Closed::SignalledAfterGrace => eprintln!(
+            "glass: the app did not close within {CLOSE_GRACE:?} of being asked (a modal \
+             shutdown prompt will do this), so it was signalled. Unsaved state was not flushed, \
+             and the app may report a crash on its next launch."
+        ),
+    }
+}
+
+/// Poll `done` until it reports true or `grace` is spent. Returns whether it reported true.
+///
+/// The polling interval matches [`reap`]'s, and `done` is called once before any sleep so an
+/// app that has already gone costs nothing.
+pub fn await_condition(grace: Duration, mut done: impl FnMut() -> bool) -> bool {
+    let deadline = Instant::now() + grace;
+    loop {
+        if done() {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+/// Wait up to `grace` for the child to exit on its own, WITHOUT signalling it. Returns whether
+/// it did; the caller still has to `wait()` (or reap) it. Used after asking an app to close: an
+/// app that leaves through its own shutdown path must not then be signalled for it.
+///
+/// A `try_wait` error counts as "did not exit", not as an exit: the caller's fallback is the
+/// signal ladder, which is what actually guarantees the process is gone, and skipping it on a
+/// reading we could not make would leave the app running.
+pub fn await_exit(child: &mut Child, grace: Duration) -> bool {
+    await_condition(grace, || matches!(child.try_wait(), Ok(Some(_))))
+}
+
 /// Gracefully reap a single child: SIGTERM, poll for exit up to `grace`, then
 /// SIGKILL as a last resort, then `wait()`. SIGTERM-first lets the process clean
 /// up its own children, sockets, and locks; SIGKILL is the escape hatch only.
@@ -226,6 +322,105 @@ mod reap_tests {
     #[test]
     fn grace_constant_is_two_seconds() {
         assert_eq!(REAP_GRACE, Duration::from_secs(2));
+    }
+
+    #[test]
+    fn await_exit_reports_a_child_that_leaves_on_its_own() {
+        let mut c = Command::new("true").spawn().unwrap();
+        assert!(
+            super::await_exit(&mut c, Duration::from_secs(5)),
+            "a child that exits by itself must be reported as exited"
+        );
+        let _ = c.wait();
+    }
+
+    #[test]
+    fn await_exit_does_not_signal_the_child_it_waits_for() {
+        // The whole point of the wait: an app that was ASKED to close must be left alone to run
+        // its own shutdown path. If await_exit signalled, this would return true and the pid
+        // would be gone.
+        let mut c = Command::new("sleep").arg("30").spawn().unwrap();
+        let grace = Duration::from_millis(200);
+        assert!(
+            !super::await_exit(&mut c, grace),
+            "a still-running child must be reported as not exited"
+        );
+        assert!(alive(c.id()), "await_exit must not signal the child");
+        let _ = c.kill();
+        let _ = c.wait();
+    }
+
+    #[test]
+    fn await_condition_returns_before_the_grace_when_already_done() {
+        let t = Instant::now();
+        assert!(super::await_condition(Duration::from_secs(30), || true));
+        assert!(
+            t.elapsed() < Duration::from_secs(1),
+            "a condition already met must not wait out the grace"
+        );
+    }
+
+    #[test]
+    fn await_condition_gives_up_after_the_grace() {
+        let grace = Duration::from_millis(200);
+        let t = Instant::now();
+        assert!(!super::await_condition(grace, || false));
+        assert!(
+            t.elapsed() >= grace,
+            "must wait the full grace before giving up"
+        );
+    }
+
+    #[test]
+    fn an_app_that_was_never_asked_is_reported_as_signalled_unasked() {
+        assert_eq!(
+            super::close_outcome(0, 2, false),
+            super::Closed::SignalledUnasked { unaskable: 2 }
+        );
+        // Even if the app happened to exit on its own, nothing asked it to — the caller has no
+        // basis for reporting a graceful close.
+        assert_eq!(
+            super::close_outcome(0, 2, true),
+            super::Closed::SignalledUnasked { unaskable: 2 }
+        );
+    }
+
+    #[test]
+    fn an_asked_app_that_exits_is_reported_as_graceful() {
+        assert_eq!(super::close_outcome(1, 0, true), super::Closed::Gracefully);
+    }
+
+    #[test]
+    fn an_asked_app_that_stays_is_reported_as_signalled_after_the_grace() {
+        assert_eq!(
+            super::close_outcome(1, 0, false),
+            super::Closed::SignalledAfterGrace
+        );
+    }
+
+    #[test]
+    fn an_app_with_no_window_to_ask_is_distinguishable_from_one_that_refused_the_ask() {
+        // Teardown also runs on the failed-launch path, where there is no window and nothing was
+        // missed. `disclose_teardown` stays silent on that, so the two must not collapse into one
+        // outcome.
+        assert_eq!(
+            super::close_outcome(0, 0, false),
+            super::Closed::SignalledUnasked { unaskable: 0 }
+        );
+        assert_ne!(
+            super::close_outcome(0, 0, false),
+            super::close_outcome(0, 1, false)
+        );
+    }
+
+    #[test]
+    fn the_close_and_signal_graces_leave_the_teardown_budget_headroom() {
+        // The backends bind these to glass_core::TEARDOWN_BUDGET at compile time; this crate
+        // has no glass-core dependency, so assert the shape they rely on: the ask gets the
+        // larger share (it is the one that produces a clean shutdown) and the pair stays well
+        // under the 3s budget.
+        assert!(super::CLOSE_GRACE > super::APP_REAP_GRACE);
+        assert!(super::CLOSE_GRACE + super::APP_REAP_GRACE < Duration::from_secs(3));
     }
 }
 

--- a/crates/glass-testapp/Cargo.toml
+++ b/crates/glass-testapp/Cargo.toml
@@ -14,6 +14,8 @@ glass-core.workspace = true
 tempfile.workspace = true
 glass-x11 = { path = "../glass-x11" }
 glass-wayland.workspace = true
+# Teardown tests assert against the shared close/reap graces rather than restating them.
+glass-proc-linux = { path = "../glass-proc-linux" }
 x11rb.workspace = true
 # Network pixel-over-HTTP e2e (tests/network.rs). `glass-mcp`'s `network`
 # feature is default-on. rmcp client transport is generic over the HTTP client;

--- a/crates/glass-testapp/src/main.rs
+++ b/crates/glass-testapp/src/main.rs
@@ -34,6 +34,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // behaves like a real toolkit app that does NOT grab focus in a WM-less
     // session — letting tests verify that glass itself focuses the window.
     let no_wm_pid = std::env::args().any(|a| a == "--no-wm-pid");
+    // `--no-wm-delete` drops WM_DELETE_WINDOW from WM_PROTOCOLS, so the fixture behaves like an
+    // app that cannot be *asked* to close (a raw X11 client that never opted into the protocol)
+    // and glass has to fall back to signalling it. Default (registered) matches every real
+    // toolkit app.
+    let no_wm_delete = std::env::args().any(|a| a == "--no-wm-delete");
     let reparent = std::env::args().any(|a| a == "--reparent");
     let no_self_focus = std::env::args().any(|a| a == "--no-self-focus");
     // `--fork-child` spawns a long-lived child process (a `sleep`) and prints its
@@ -102,6 +107,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         AtomEnum::STRING,
         b"glass-testapp\0glass-testapp\0",
     )?;
+
+    // Opt into WM_DELETE_WINDOW on the main window, like any toolkit app: a close request
+    // arrives as a client message this process handles itself (printing `EVENT
+    // closed_gracefully` before exiting) instead of the app being signalled out from under its
+    // own shutdown path. Only the main window carries it — closing it exits the process, which
+    // takes the `--windows N` extras with it.
+    let wm_protocols = conn.intern_atom(false, b"WM_PROTOCOLS")?.reply()?.atom;
+    let wm_delete_window = conn.intern_atom(false, b"WM_DELETE_WINDOW")?.reply()?.atom;
+    if !no_wm_delete {
+        conn.change_property32(
+            PropMode::REPLACE,
+            win,
+            wm_protocols,
+            AtomEnum::ATOM,
+            &[wm_delete_window],
+        )?;
+    }
 
     let gc = conn.generate_id()?;
     conn.create_gc(gc, win, &CreateGCAux::new())?;
@@ -213,15 +235,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::mem::forget(kid); // don't reap on drop; glass's group-reap must get it
     }
 
-    // Announce readiness on stdout (one line, flushed) so tests can sync.
+    // Announce readiness on stdout (one line, flushed) so tests can sync. The pid line lets a
+    // teardown test check the process itself is gone, which `_NET_WM_PID` cannot answer once the
+    // window has been destroyed.
+    println!("EVENT pid={}", std::process::id());
     println!("READY w={WIDTH} h={HEIGHT}");
     std::io::stdout().flush()?;
 
     if blink {
-        run_blink_loop(&conn, win, gc, &extras)
+        run_blink_loop(&conn, win, gc, &extras, (wm_protocols, wm_delete_window))
     } else {
-        run_event_loop(&conn, win, gc, &extras)
+        run_event_loop(&conn, win, gc, &extras, (wm_protocols, wm_delete_window))
     }
+}
+
+/// Whether the event loop should keep running after an event.
+#[derive(PartialEq, Eq)]
+enum Flow {
+    Continue,
+    Quit,
 }
 
 /// Handle one X11 event the same way regardless of loop mode: paint on Expose, echo
@@ -231,9 +263,23 @@ fn dispatch_event(
     win: Window,
     gc: Gcontext,
     extras: &[(Window, u32)],
+    close: (Atom, Atom),
     event: Event,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<Flow, Box<dyn std::error::Error>> {
+    let (wm_protocols, wm_delete_window) = close;
     match event {
+        // A close request (what a window manager sends on a close-button click, and what glass
+        // sends when tearing the app down). Announce that the app's own shutdown path ran, then
+        // exit — the whole point of being asked rather than signalled. Both the message type and
+        // its first data word are checked, so an unrelated client message whose payload happens
+        // to carry the atom's value cannot pass for one.
+        Event::ClientMessage(e)
+            if e.type_ == wm_protocols && e.data.as_data32()[0] == wm_delete_window =>
+        {
+            println!("EVENT closed_gracefully");
+            std::io::stdout().flush()?;
+            return Ok(Flow::Quit);
+        }
         Event::Expose(e) => {
             if e.window == win {
                 draw_quadrants(conn, win, gc)?;
@@ -270,7 +316,7 @@ fn dispatch_event(
         }
         _ => {}
     }
-    Ok(())
+    Ok(Flow::Continue)
 }
 
 /// Default loop: block on X11 events. Behavior unchanged from before `--blink` existed.
@@ -279,10 +325,13 @@ fn run_event_loop(
     win: Window,
     gc: Gcontext,
     extras: &[(Window, u32)],
+    close: (Atom, Atom),
 ) -> Result<(), Box<dyn std::error::Error>> {
     loop {
         let event = conn.wait_for_event()?;
-        dispatch_event(conn, win, gc, extras, event)?;
+        if dispatch_event(conn, win, gc, extras, close, event)? == Flow::Quit {
+            return Ok(());
+        }
     }
 }
 
@@ -293,11 +342,14 @@ fn run_blink_loop(
     win: Window,
     gc: Gcontext,
     extras: &[(Window, u32)],
+    close: (Atom, Atom),
 ) -> Result<(), Box<dyn std::error::Error>> {
     let start = Instant::now();
     loop {
         while let Some(event) = conn.poll_for_event()? {
-            dispatch_event(conn, win, gc, extras, event)?;
+            if dispatch_event(conn, win, gc, extras, close, event)? == Flow::Quit {
+                return Ok(());
+            }
         }
         let level = ((start.elapsed().as_millis() / BLINK_TICK_MS) % 256) as u8;
         draw_blink(conn, win, gc, level)?;

--- a/crates/glass-testapp/src/main.rs
+++ b/crates/glass-testapp/src/main.rs
@@ -34,11 +34,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // behaves like a real toolkit app that does NOT grab focus in a WM-less
     // session — letting tests verify that glass itself focuses the window.
     let no_wm_pid = std::env::args().any(|a| a == "--no-wm-pid");
-    // `--no-wm-delete` drops WM_DELETE_WINDOW from WM_PROTOCOLS, so the fixture behaves like an
-    // app that cannot be *asked* to close (a raw X11 client that never opted into the protocol)
-    // and glass has to fall back to signalling it. Default (registered) matches every real
-    // toolkit app.
+    // `--no-wm-delete` withholds the WM_PROTOCOLS advertisement, so the fixture looks like a raw
+    // X11 client that never opted into the protocol and glass has to fall back to signalling it.
+    // Default (advertised) matches every real toolkit app. The handler below stays wired up
+    // either way, deliberately: that is what makes the negative tests binding — if glass ever
+    // sent a close request to a window that never advertised the protocol, the fixture would
+    // print `EVENT closed_gracefully` and those tests would fail.
     let no_wm_delete = std::env::args().any(|a| a == "--no-wm-delete");
+    // `--ignore-close` advertises WM_DELETE_WINDOW and then does nothing with it — a real app
+    // sitting on a "save changes?" prompt, or one that has hung. glass has to give up on the ask
+    // and signal instead, which is the only way to reach that path from a test.
+    let ignore_close = std::env::args().any(|a| a == "--ignore-close");
+    // `--close-delay-ms N` spends N ms inside the close handler before exiting, standing in for
+    // an app flushing state on the way out. It is how a test can tell "glass waited for the app"
+    // from "the app happened to be quick".
+    let close_delay = std::env::args()
+        .position(|a| a == "--close-delay-ms")
+        .and_then(|i| std::env::args().nth(i + 1))
+        .and_then(|n| n.parse::<u64>().ok())
+        .unwrap_or(0);
     let reparent = std::env::args().any(|a| a == "--reparent");
     let no_self_focus = std::env::args().any(|a| a == "--no-self-focus");
     // `--fork-child` spawns a long-lived child process (a `sleep`) and prints its
@@ -235,18 +249,34 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::mem::forget(kid); // don't reap on drop; glass's group-reap must get it
     }
 
-    // Announce readiness on stdout (one line, flushed) so tests can sync. The pid line lets a
+    // Announce readiness on stdout (two lines, flushed) so tests can sync. The pid line lets a
     // teardown test check the process itself is gone, which `_NET_WM_PID` cannot answer once the
     // window has been destroyed.
     println!("EVENT pid={}", std::process::id());
     println!("READY w={WIDTH} h={HEIGHT}");
     std::io::stdout().flush()?;
 
+    let close = Close {
+        protocols: wm_protocols,
+        delete: wm_delete_window,
+        ignore: ignore_close,
+        delay_ms: close_delay,
+    };
     if blink {
-        run_blink_loop(&conn, win, gc, &extras, (wm_protocols, wm_delete_window))
+        run_blink_loop(&conn, win, gc, &extras, &close)
     } else {
-        run_event_loop(&conn, win, gc, &extras, (wm_protocols, wm_delete_window))
+        run_event_loop(&conn, win, gc, &extras, &close)
     }
+}
+
+/// How the fixture answers a close request: the atoms that identify one, plus the two knobs
+/// (`--ignore-close`, `--close-delay-ms`) that let a test drive the paths a cooperative app
+/// never takes.
+struct Close {
+    protocols: Atom,
+    delete: Atom,
+    ignore: bool,
+    delay_ms: u64,
 }
 
 /// Whether the event loop should keep running after an event.
@@ -263,10 +293,9 @@ fn dispatch_event(
     win: Window,
     gc: Gcontext,
     extras: &[(Window, u32)],
-    close: (Atom, Atom),
+    close: &Close,
     event: Event,
 ) -> Result<Flow, Box<dyn std::error::Error>> {
-    let (wm_protocols, wm_delete_window) = close;
     match event {
         // A close request (what a window manager sends on a close-button click, and what glass
         // sends when tearing the app down). Announce that the app's own shutdown path ran, then
@@ -274,8 +303,14 @@ fn dispatch_event(
         // its first data word are checked, so an unrelated client message whose payload happens
         // to carry the atom's value cannot pass for one.
         Event::ClientMessage(e)
-            if e.type_ == wm_protocols && e.data.as_data32()[0] == wm_delete_window =>
+            if e.type_ == close.protocols && e.data.as_data32()[0] == close.delete =>
         {
+            if close.ignore {
+                println!("EVENT ignoring_close_request");
+                std::io::stdout().flush()?;
+                return Ok(Flow::Continue);
+            }
+            std::thread::sleep(Duration::from_millis(close.delay_ms));
             println!("EVENT closed_gracefully");
             std::io::stdout().flush()?;
             return Ok(Flow::Quit);
@@ -325,7 +360,7 @@ fn run_event_loop(
     win: Window,
     gc: Gcontext,
     extras: &[(Window, u32)],
-    close: (Atom, Atom),
+    close: &Close,
 ) -> Result<(), Box<dyn std::error::Error>> {
     loop {
         let event = conn.wait_for_event()?;
@@ -342,7 +377,7 @@ fn run_blink_loop(
     win: Window,
     gc: Gcontext,
     extras: &[(Window, u32)],
-    close: (Atom, Atom),
+    close: &Close,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let start = Instant::now();
     loop {

--- a/crates/glass-testapp/tests/integration.rs
+++ b/crates/glass-testapp/tests/integration.rs
@@ -1386,9 +1386,9 @@ fn sandbox_off_bypasses_bwrap_check() {
 }
 
 /// Teardown must ask the app to close (a `WM_DELETE_WINDOW` client message) so the app runs its
-/// own shutdown path. A signalled X11 toolkit app runs none — GTK and Qt install no `SIGTERM`
-/// handler — so anything it would flush on exit is lost and it can report a crash next launch.
-/// The fixture prints `EVENT closed_gracefully` from the handler, which only runs if it was asked.
+/// own shutdown path — a signalled toolkit app runs none (see `glass_proc_linux::CLOSE_GRACE`),
+/// so anything it would flush on exit is lost and it can report a crash next launch. The fixture
+/// prints `EVENT closed_gracefully` from the handler, which only runs if it was asked.
 #[test]
 #[ignore = "requires an X server; run via scripts/test-x11.sh"]
 fn stop_app_asks_the_app_to_close_before_signalling_it() {
@@ -1411,8 +1411,163 @@ fn stop_app_asks_the_app_to_close_before_signalling_it() {
     );
 }
 
-/// An app that never opted into `WM_DELETE_WINDOW` cannot be asked — it is required to ignore
-/// the message — so teardown must fall back to signalling it rather than waiting out the grace.
+/// The ask is worth nothing if glass does not wait for the answer. A real app spends hundreds of
+/// milliseconds in its shutdown path; the fixture stands in for that with `--close-delay-ms`, so
+/// a grace shortened by a refactor or a units slip fails here instead of silently signalling
+/// every app mid-flush.
+#[test]
+#[ignore = "requires an X server; run via scripts/test-x11.sh"]
+fn stop_app_waits_for_an_app_that_takes_time_to_shut_down() {
+    let xvfb = Xvfb::start();
+    let mut p = X11Platform::connect(Some(&xvfb.display)).unwrap();
+    // Comfortably longer than a fast exit, comfortably inside CLOSE_GRACE.
+    let delay = std::time::Duration::from_millis(700);
+    let spec = AppSpec {
+        run: vec![
+            TESTAPP.to_string(),
+            "--close-delay-ms".to_string(),
+            delay.as_millis().to_string(),
+        ],
+        ..app_spec()
+    };
+    p.start_app(&spec).unwrap();
+    let pid = wait_for_app_pid(&mut p);
+    let t = std::time::Instant::now();
+    p.stop_app().unwrap();
+    let elapsed = t.elapsed();
+    std::thread::sleep(std::time::Duration::from_millis(200));
+    let logs: Vec<String> = p.drain_logs().into_iter().map(|(_s, l)| l).collect();
+    assert!(
+        logs.iter().any(|l| l.contains("EVENT closed_gracefully")),
+        "the app must be given long enough to finish its shutdown path; got: {logs:?}"
+    );
+    assert!(
+        elapsed >= delay,
+        "stop_app returned in {elapsed:?}, before the app's {delay:?} shutdown path could finish"
+    );
+    assert!(
+        !std::path::Path::new(&format!("/proc/{pid}")).exists(),
+        "the app must be gone after teardown (pid {pid})"
+    );
+}
+
+/// An app that was asked and does not go — a modal "save changes?" prompt, or a hang — must be
+/// signalled once the grace runs out, and the whole teardown must still fit in the budget
+/// glass-mcp allows it. Runs with `a11y: true` so the private bus teardown that follows the
+/// ladder is inside the measurement, which is the configuration the backend's compile-time
+/// budget assertion is silent about.
+#[test]
+#[ignore = "requires an X server; run via scripts/test-x11.sh"]
+fn stop_app_signals_an_app_that_ignores_the_close_request() {
+    let xvfb = Xvfb::start();
+    let mut p = X11Platform::connect(Some(&xvfb.display)).unwrap();
+    let spec = AppSpec {
+        run: vec![TESTAPP.to_string(), "--ignore-close".to_string()],
+        a11y: true,
+        ..app_spec()
+    };
+    p.start_app(&spec).unwrap();
+    let pid = wait_for_app_pid(&mut p);
+    let t = std::time::Instant::now();
+    p.stop_app().unwrap();
+    let elapsed = t.elapsed();
+    std::thread::sleep(std::time::Duration::from_millis(200));
+    let logs: Vec<String> = p.drain_logs().into_iter().map(|(_s, l)| l).collect();
+    assert!(
+        logs.iter()
+            .any(|l| l.contains("EVENT ignoring_close_request")),
+        "the fixture should have received the close request and ignored it; got: {logs:?}"
+    );
+    assert!(
+        !std::path::Path::new(&format!("/proc/{pid}")).exists(),
+        "an app that ignores the request must still be signalled (pid {pid} survived)"
+    );
+    assert!(
+        elapsed >= glass_proc_linux::CLOSE_GRACE,
+        "the app must get the whole close grace before being signalled (took {elapsed:?})"
+    );
+    assert!(
+        elapsed < glass_core::TEARDOWN_BUDGET,
+        "the ask, the signal ladder and the a11y-bus teardown must fit in the budget glass-mcp \
+         gives teardown ({:?}); this took {elapsed:?}",
+        glass_core::TEARDOWN_BUDGET
+    );
+}
+
+/// Every window of a multi-window app is enumerated for the ask, not just the active one. The
+/// fixture advertises the protocol on its main window only, so this is also the mixed case:
+/// some windows askable, some not.
+#[test]
+#[ignore = "requires an X server; run via scripts/test-x11.sh"]
+fn stop_app_asks_a_multi_window_app_to_close() {
+    let xvfb = Xvfb::start();
+    let mut p = X11Platform::connect(Some(&xvfb.display)).unwrap();
+    let spec = AppSpec {
+        run: vec![
+            TESTAPP.to_string(),
+            "--windows".to_string(),
+            "3".to_string(),
+        ],
+        ..app_spec()
+    };
+    p.start_app(&spec).unwrap();
+    let pid = wait_for_app_pid(&mut p);
+    p.stop_app().unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(200));
+    let logs: Vec<String> = p.drain_logs().into_iter().map(|(_s, l)| l).collect();
+    assert!(
+        logs.iter().any(|l| l.contains("EVENT closed_gracefully")),
+        "a multi-window app must still be asked to close; got: {logs:?}"
+    );
+    assert!(
+        !std::path::Path::new(&format!("/proc/{pid}")).exists(),
+        "the app must be gone after teardown (pid {pid})"
+    );
+}
+
+/// Teardown must never close a window belonging to a process glass did not launch. Discovery may
+/// match a window by title/class hint, and that hint can match somebody else's app; asking that
+/// window to close would destroy their state. Here a second, unrelated client is on the same
+/// display when the launched app is torn down.
+#[test]
+#[ignore = "requires an X server; run via scripts/test-x11.sh"]
+fn stop_app_leaves_a_window_it_did_not_launch_alone() {
+    let xvfb = Xvfb::start();
+    let mut bystander = std::process::Command::new(TESTAPP)
+        .env("DISPLAY", &xvfb.display)
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn the bystander client");
+    // Wait for it to map its window, so it is a window teardown could have found.
+    let mut line = String::new();
+    {
+        use std::io::BufRead;
+        let mut out = std::io::BufReader::new(bystander.stdout.take().unwrap());
+        while !line.contains("READY") {
+            line.clear();
+            out.read_line(&mut line).expect("bystander output");
+        }
+    }
+    let mut p = X11Platform::connect(Some(&xvfb.display)).unwrap();
+    p.start_app(&app_spec()).unwrap();
+    let pid = wait_for_app_pid(&mut p);
+    p.stop_app().unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(300));
+    let bystander_alive = matches!(bystander.try_wait(), Ok(None));
+    let _ = bystander.kill();
+    let _ = bystander.wait();
+    assert!(
+        !std::path::Path::new(&format!("/proc/{pid}")).exists(),
+        "the launched app must be gone (pid {pid})"
+    );
+    assert!(
+        bystander_alive,
+        "teardown closed a window belonging to a process glass never launched"
+    );
+}
+
+/// An app that never opted into `WM_DELETE_WINDOW` has no handler for the message and will not
+/// act on it, so teardown must fall back to signalling it rather than waiting out the grace.
 #[test]
 #[ignore = "requires an X server; run via scripts/test-x11.sh"]
 fn stop_app_signals_an_app_that_cannot_be_asked_to_close() {
@@ -1439,8 +1594,8 @@ fn stop_app_signals_an_app_that_cannot_be_asked_to_close() {
     );
     assert!(
         elapsed < glass_proc_linux::CLOSE_GRACE,
-        "teardown must not wait out the close grace for an app that was never asked \
-         (took {elapsed:?})"
+        "the whole of stop_app must finish inside the close grace, which it cannot if an app \
+         that was never asked is nonetheless waited for (took {elapsed:?})"
     );
 }
 

--- a/crates/glass-testapp/tests/integration.rs
+++ b/crates/glass-testapp/tests/integration.rs
@@ -1452,10 +1452,9 @@ fn stop_app_waits_for_an_app_that_takes_time_to_shut_down() {
 }
 
 /// An app that was asked and does not go — a modal "save changes?" prompt, or a hang — must be
-/// signalled once the grace runs out, and the whole teardown must still fit in the budget
-/// glass-mcp allows it. Runs with `a11y: true` so the private bus teardown that follows the
-/// ladder is inside the measurement, which is the configuration the backend's compile-time
-/// budget assertion is silent about.
+/// signalled once the grace runs out, and the ladder must still fit in the budget glass-mcp
+/// allows teardown. (The same measurement with the a11y bus in the picture lives in the a11y
+/// suite, which is the only suite whose host is guaranteed an AT-SPI launcher.)
 #[test]
 #[ignore = "requires an X server; run via scripts/test-x11.sh"]
 fn stop_app_signals_an_app_that_ignores_the_close_request() {
@@ -1463,7 +1462,6 @@ fn stop_app_signals_an_app_that_ignores_the_close_request() {
     let mut p = X11Platform::connect(Some(&xvfb.display)).unwrap();
     let spec = AppSpec {
         run: vec![TESTAPP.to_string(), "--ignore-close".to_string()],
-        a11y: true,
         ..app_spec()
     };
     p.start_app(&spec).unwrap();
@@ -1488,8 +1486,8 @@ fn stop_app_signals_an_app_that_ignores_the_close_request() {
     );
     assert!(
         elapsed < glass_core::TEARDOWN_BUDGET,
-        "the ask, the signal ladder and the a11y-bus teardown must fit in the budget glass-mcp \
-         gives teardown ({:?}); this took {elapsed:?}",
+        "the ask and the signal ladder must fit in the budget glass-mcp gives teardown ({:?}); \
+         this took {elapsed:?}",
         glass_core::TEARDOWN_BUDGET
     );
 }

--- a/crates/glass-testapp/tests/integration.rs
+++ b/crates/glass-testapp/tests/integration.rs
@@ -28,6 +28,24 @@ fn app_spec() -> AppSpec {
     }
 }
 
+/// Wait for the fixture's `EVENT pid=<n>` line (printed with READY at startup) and return it.
+/// Teardown tests need the pid itself: once the window is destroyed there is no `_NET_WM_PID`
+/// left to read it from.
+fn wait_for_app_pid(p: &mut X11Platform) -> u32 {
+    for _ in 0..40 {
+        for (_s, line) in p.drain_logs() {
+            if let Some(pid) = line
+                .strip_prefix("EVENT pid=")
+                .and_then(|r| r.trim().parse().ok())
+            {
+                return pid;
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    panic!("fixture never reported its pid");
+}
+
 /// Drain logs repeatedly until `needle` appears or `tries` attempts elapse.
 fn wait_for_log(p: &mut X11Platform, needle: &str, tries: u32) -> bool {
     for _ in 0..tries {
@@ -1020,6 +1038,35 @@ fn clipboard_owner_answers_targets_and_refuses_unknown_target() {
 // Sandbox integration tests (bwrap + Xvfb)
 // ---------------------------------------------------------------------------
 
+/// A contained app must still be *asked* to close. The close request is addressed to a window
+/// found by `_NET_WM_PID` against the launched process tree, and under containment the process
+/// glass spawned is `bwrap`, not the app — so the window belongs to a descendant pid. If that
+/// walk failed, teardown would silently fall back to signalling every sandboxed app.
+#[test]
+#[ignore = "requires an X server + bwrap; run via scripts/test-x11.sh"]
+fn sandbox_default_app_is_still_asked_to_close() {
+    let xvfb = Xvfb::start();
+    let mut p = X11Platform::connect(Some(&xvfb.display)).unwrap();
+    let spec = AppSpec {
+        sandbox: glass_core::SandboxLevel::Default,
+        timeout_ms: 8000,
+        ..app_spec()
+    };
+    p.start_app(&spec)
+        .unwrap_or_else(|e| panic!("sandboxed start_app failed: {e}"));
+    assert!(
+        wait_for_log(&mut p, "READY", 60),
+        "never saw READY on stdout (sandboxed)"
+    );
+    p.stop_app().unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(200));
+    let logs: Vec<String> = p.drain_logs().into_iter().map(|(_s, l)| l).collect();
+    assert!(
+        logs.iter().any(|l| l.contains("EVENT closed_gracefully")),
+        "a contained app must be asked to close like any other; got: {logs:?}"
+    );
+}
+
 /// Launch `glass-testapp` under `SandboxLevel::Default` — the app must find the
 /// X display through the `/tmp/.X11-unix` bind and render a non-blank frame.
 #[test]
@@ -1336,6 +1383,65 @@ fn sandbox_off_bypasses_bwrap_check() {
     p.start_app(&spec)
         .unwrap_or_else(|e| panic!("Off sandbox should not require bwrap: {e}"));
     p.stop_app().unwrap();
+}
+
+/// Teardown must ask the app to close (a `WM_DELETE_WINDOW` client message) so the app runs its
+/// own shutdown path. A signalled X11 toolkit app runs none — GTK and Qt install no `SIGTERM`
+/// handler — so anything it would flush on exit is lost and it can report a crash next launch.
+/// The fixture prints `EVENT closed_gracefully` from the handler, which only runs if it was asked.
+#[test]
+#[ignore = "requires an X server; run via scripts/test-x11.sh"]
+fn stop_app_asks_the_app_to_close_before_signalling_it() {
+    let xvfb = Xvfb::start();
+    let mut p = X11Platform::connect(Some(&xvfb.display)).unwrap();
+    p.start_app(&app_spec()).unwrap();
+    let pid = wait_for_app_pid(&mut p);
+    p.stop_app().unwrap();
+    // The fixture's line is written just before it exits, so drain after the reader thread has
+    // had a moment to pick it up off the pipe.
+    std::thread::sleep(std::time::Duration::from_millis(200));
+    let logs: Vec<String> = p.drain_logs().into_iter().map(|(_s, l)| l).collect();
+    assert!(
+        logs.iter().any(|l| l.contains("EVENT closed_gracefully")),
+        "stop_app must ask the app to close so its shutdown path runs; got: {logs:?}"
+    );
+    assert!(
+        !std::path::Path::new(&format!("/proc/{pid}")).exists(),
+        "the app must still be gone after a graceful close (pid {pid})"
+    );
+}
+
+/// An app that never opted into `WM_DELETE_WINDOW` cannot be asked — it is required to ignore
+/// the message — so teardown must fall back to signalling it rather than waiting out the grace.
+#[test]
+#[ignore = "requires an X server; run via scripts/test-x11.sh"]
+fn stop_app_signals_an_app_that_cannot_be_asked_to_close() {
+    let xvfb = Xvfb::start();
+    let mut p = X11Platform::connect(Some(&xvfb.display)).unwrap();
+    let spec = AppSpec {
+        run: vec![TESTAPP.to_string(), "--no-wm-delete".to_string()],
+        ..app_spec()
+    };
+    p.start_app(&spec).unwrap();
+    let pid = wait_for_app_pid(&mut p);
+    let t = std::time::Instant::now();
+    p.stop_app().unwrap();
+    let elapsed = t.elapsed();
+    std::thread::sleep(std::time::Duration::from_millis(200));
+    let logs: Vec<String> = p.drain_logs().into_iter().map(|(_s, l)| l).collect();
+    assert!(
+        !logs.iter().any(|l| l.contains("EVENT closed_gracefully")),
+        "an app with no WM_DELETE_WINDOW protocol cannot have closed gracefully; got: {logs:?}"
+    );
+    assert!(
+        !std::path::Path::new(&format!("/proc/{pid}")).exists(),
+        "the app must be gone after teardown (pid {pid})"
+    );
+    assert!(
+        elapsed < glass_proc_linux::CLOSE_GRACE,
+        "teardown must not wait out the close grace for an app that was never asked \
+         (took {elapsed:?})"
+    );
 }
 
 #[test]

--- a/crates/glass-testapp/tests/integration.rs
+++ b/crates/glass-testapp/tests/integration.rs
@@ -1042,6 +1042,10 @@ fn clipboard_owner_answers_targets_and_refuses_unknown_target() {
 /// found by `_NET_WM_PID` against the launched process tree, and under containment the process
 /// glass spawned is `bwrap`, not the app — so the window belongs to a descendant pid. If that
 /// walk failed, teardown would silently fall back to signalling every sandboxed app.
+///
+/// The walk works only because the sandbox deliberately does not unshare the PID namespace: in
+/// one, the app would publish a namespace-relative `_NET_WM_PID` that matches nothing glass can
+/// see. Revisiting that decision breaks this test, which is the intent.
 #[test]
 #[ignore = "requires an X server + bwrap; run via scripts/test-x11.sh"]
 fn sandbox_default_app_is_still_asked_to_close() {

--- a/crates/glass-testapp/tests/wayland.rs
+++ b/crates/glass-testapp/tests/wayland.rs
@@ -241,6 +241,83 @@ fn sway_pids() -> std::collections::HashSet<u32> {
         .unwrap_or_default()
 }
 
+/// Wait for the fixture's `EVENT pid=<n>` startup line and return it, so a teardown test can
+/// check the app process itself is gone (the compositor's window list can't answer that).
+fn wait_for_app_pid(p: &mut WaylandPlatform) -> u32 {
+    for _ in 0..READY_TRIES {
+        for (_s, line) in p.drain_logs() {
+            if let Some(pid) = line
+                .strip_prefix("EVENT pid=")
+                .and_then(|r| r.trim().parse().ok())
+            {
+                return pid;
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    panic!("fixture never reported its pid");
+}
+
+/// Teardown must ask the app to close before signalling the compositor's process group.
+/// Signalling gives a toolkit app no shutdown path at all (GTK and Qt install no `SIGTERM`
+/// handler), so state it would flush on exit is lost. Under Wayland the ask goes through sway,
+/// which sends the client a close request; the fixture prints `EVENT closed_gracefully` from
+/// the handler that only runs when it was asked.
+#[test]
+#[ignore = "requires sway; run via scripts/test-wayland.sh"]
+fn stop_app_asks_the_app_to_close_before_signalling_it() {
+    let mut p = WaylandPlatform::new().unwrap();
+    start(&mut p, &spec(vec![TESTAPP.to_string()], APP_TIMEOUT_MS));
+    let pid = wait_for_app_pid(&mut p);
+    p.stop_app().unwrap();
+    // The fixture writes the line just before exiting; give the reader thread a moment to pick
+    // it up off the pipe (it travels via sway's stdout, one hop further than under X11).
+    std::thread::sleep(std::time::Duration::from_millis(300));
+    let logs: Vec<String> = p.drain_logs().into_iter().map(|(_s, l)| l).collect();
+    assert!(
+        logs.iter().any(|l| l.contains("EVENT closed_gracefully")),
+        "stop_app must ask the app to close so its shutdown path runs; got: {logs:?}"
+    );
+    assert!(
+        !std::path::Path::new(&format!("/proc/{pid}")).exists(),
+        "the app must still be gone after a graceful close (pid {pid})"
+    );
+}
+
+/// An app that never opted into `WM_DELETE_WINDOW` is required to ignore the close request sway
+/// sends it, so teardown falls back to signalling the compositor's group — and must still leave
+/// nothing behind.
+#[test]
+#[ignore = "requires sway; run via scripts/test-wayland.sh"]
+fn stop_app_signals_an_app_that_cannot_be_asked_to_close() {
+    let before = sway_pids();
+    let mut p = WaylandPlatform::new().unwrap();
+    start(
+        &mut p,
+        &spec(
+            vec![TESTAPP.to_string(), "--no-wm-delete".to_string()],
+            APP_TIMEOUT_MS,
+        ),
+    );
+    let pid = wait_for_app_pid(&mut p);
+    p.stop_app().unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(300));
+    let logs: Vec<String> = p.drain_logs().into_iter().map(|(_s, l)| l).collect();
+    assert!(
+        !logs.iter().any(|l| l.contains("EVENT closed_gracefully")),
+        "an app with no WM_DELETE_WINDOW protocol cannot have closed gracefully; got: {logs:?}"
+    );
+    assert!(
+        !std::path::Path::new(&format!("/proc/{pid}")).exists(),
+        "the app must be gone after teardown (pid {pid})"
+    );
+    let leaked: Vec<_> = sway_pids().difference(&before).copied().collect();
+    assert!(
+        leaked.is_empty(),
+        "teardown leaked sway process(es): {leaked:?}"
+    );
+}
+
 #[test]
 #[ignore = "requires sway; run via scripts/test-wayland.sh"]
 fn start_app_failure_leaves_no_orphan() {

--- a/crates/glass-testapp/tests/wayland.rs
+++ b/crates/glass-testapp/tests/wayland.rs
@@ -258,11 +258,10 @@ fn wait_for_app_pid(p: &mut WaylandPlatform) -> u32 {
     panic!("fixture never reported its pid");
 }
 
-/// Teardown must ask the app to close before signalling the compositor's process group.
-/// Signalling gives a toolkit app no shutdown path at all (GTK and Qt install no `SIGTERM`
-/// handler), so state it would flush on exit is lost. Under Wayland the ask goes through sway,
-/// which sends the client a close request; the fixture prints `EVENT closed_gracefully` from
-/// the handler that only runs when it was asked.
+/// Teardown must ask the app to close before signalling it: a signalled toolkit app runs no
+/// shutdown path at all (see `glass_proc_linux::CLOSE_GRACE`), so state it would flush on exit is
+/// lost. Under Wayland the ask goes through sway, which sends the client a close request; the
+/// fixture prints `EVENT closed_gracefully` from the handler that only runs when it was asked.
 #[test]
 #[ignore = "requires sway; run via scripts/test-wayland.sh"]
 fn stop_app_asks_the_app_to_close_before_signalling_it() {
@@ -284,12 +283,96 @@ fn stop_app_asks_the_app_to_close_before_signalling_it() {
     );
 }
 
-/// An app that never opted into `WM_DELETE_WINDOW` is required to ignore the close request sway
-/// sends it, so teardown falls back to signalling the compositor's group — and must still leave
-/// nothing behind.
+/// Teardown must reap what the app forked, not just what dies with the display.
+///
+/// This is the test that binds the signal actually reaching the launch. sway `setsid`s every app
+/// it `exec`s, so the app is in neither the compositor's process group nor its session; a
+/// teardown that signals only that group still *looks* correct, because a display client dies on
+/// its own when its compositor goes away. A forked child that never talks to the display does
+/// not — it is left running with `ppid 1`.
 #[test]
 #[ignore = "requires sway; run via scripts/test-wayland.sh"]
-fn stop_app_signals_an_app_that_cannot_be_asked_to_close() {
+fn stop_app_reaps_the_apps_forked_child() {
+    let mut p = WaylandPlatform::new().unwrap();
+    start(
+        &mut p,
+        &spec(
+            vec![TESTAPP.to_string(), "--fork-child".to_string()],
+            APP_TIMEOUT_MS,
+        ),
+    );
+    let mut child_pid: Option<u32> = None;
+    for _ in 0..READY_TRIES {
+        for (_s, line) in p.drain_logs() {
+            if let Some(rest) = line.strip_prefix("EVENT child_pid=") {
+                child_pid = rest.trim().parse().ok();
+            }
+        }
+        if child_pid.is_some() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let child_pid = child_pid.expect("fixture should report its forked child pid");
+    assert!(
+        std::path::Path::new(&format!("/proc/{child_pid}")).exists(),
+        "the forked child should be alive while the app runs"
+    );
+    p.stop_app().unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(300));
+    assert!(
+        !std::path::Path::new(&format!("/proc/{child_pid}")).exists(),
+        "stop_app must reap the app's forked child (pid {child_pid}), not orphan it"
+    );
+}
+
+/// An app that was asked and does not go must be signalled once the grace runs out, and the
+/// whole teardown must still fit the budget glass-mcp allows it.
+#[test]
+#[ignore = "requires sway; run via scripts/test-wayland.sh"]
+fn stop_app_signals_an_app_that_ignores_the_close_request() {
+    let mut p = WaylandPlatform::new().unwrap();
+    start(
+        &mut p,
+        &spec(
+            vec![TESTAPP.to_string(), "--ignore-close".to_string()],
+            APP_TIMEOUT_MS,
+        ),
+    );
+    let pid = wait_for_app_pid(&mut p);
+    let t = std::time::Instant::now();
+    p.stop_app().unwrap();
+    let elapsed = t.elapsed();
+    std::thread::sleep(std::time::Duration::from_millis(300));
+    let logs: Vec<String> = p.drain_logs().into_iter().map(|(_s, l)| l).collect();
+    assert!(
+        logs.iter()
+            .any(|l| l.contains("EVENT ignoring_close_request")),
+        "the compositor should have passed the close request to the app; got: {logs:?}"
+    );
+    assert!(
+        !std::path::Path::new(&format!("/proc/{pid}")).exists(),
+        "an app that ignores the request must still be signalled (pid {pid} survived)"
+    );
+    assert!(
+        elapsed >= glass_proc_linux::CLOSE_GRACE,
+        "the app must get the whole close grace before being signalled (took {elapsed:?})"
+    );
+    assert!(
+        elapsed < glass_core::TEARDOWN_BUDGET,
+        "teardown must fit in the budget glass-mcp gives it ({:?}); this took {elapsed:?}",
+        glass_core::TEARDOWN_BUDGET
+    );
+}
+
+/// A client that never opted into `WM_DELETE_WINDOW` cannot be asked, and under Wayland glass
+/// cannot tell: sway acknowledges the `kill` command either way, and wlroots closes the X
+/// connection of a client that has no close protocol. What teardown must still guarantee is
+/// what this pins — the app is gone, its shutdown path did not run, and no compositor is left
+/// behind. (The X11 backend, which reads `WM_PROTOCOLS` itself, does report this case.)
+#[test]
+#[ignore = "requires sway; run via scripts/test-wayland.sh"]
+fn stop_app_leaves_nothing_behind_when_the_app_cannot_be_asked() {
     let before = sway_pids();
     let mut p = WaylandPlatform::new().unwrap();
     start(

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -10,7 +10,7 @@ use glass_core::{
     AppSpec, Frame, GlassError, KeyEvent, Platform, PointerEvent, Region, Result, Stream,
     TEARDOWN_BUDGET, WindowGeometry, WindowId, WindowInfo, WindowOp,
 };
-use glass_proc_linux::{APP_REAP_GRACE, CLOSE_GRACE};
+use glass_proc_linux::{APP_REAP_GRACE, Asked, CLOSE_GRACE};
 use smithay_client_toolkit::delegate_dispatch2;
 use smithay_client_toolkit::delegate_registry;
 use smithay_client_toolkit::output::{OutputHandler, OutputState};
@@ -38,10 +38,13 @@ use crate::command::{LogSink, build_sway_command, sway_config};
 use crate::input::evdev_button;
 use crate::swayipc::{Ipc, Window as SwayWindow};
 
-// glass-mcp gives the whole of teardown `TEARDOWN_BUDGET` and then exits regardless, on a
+// glass-mcp gives the whole of teardown `glass_core::TEARDOWN_BUDGET` and then exits regardless, on a
 // `spawn_blocking` thread that cannot be cancelled — so an ask-then-signal ladder that fills the
 // budget would never get to the signal, and sway (plus Xwayland and the app) would outlive glass.
-// Bind both graces to it here; the a11y bus teardown that follows shares the remaining headroom.
+//
+// This binds the ladder only. The a11y bus teardown that follows it in the same budget still
+// reaps at `REAP_GRACE`, so a helper that ignores SIGTERM can take the whole teardown past the
+// budget; that is pre-existing and not what this assertion is about.
 const _: () = assert!(
     CLOSE_GRACE.as_millis() + APP_REAP_GRACE.as_millis() < TEARDOWN_BUDGET.as_millis(),
     "the close request + compositor reap must finish inside glass_core::TEARDOWN_BUDGET"
@@ -89,51 +92,86 @@ impl WaylandPlatform {
         })
     }
 
-    /// Tear the session down: ask the app to close, then reap the compositor subtree.
+    /// Tear the session down: ask the app to close, then reap the whole launch.
     ///
-    /// The app is asked first because signalling the compositor's process group gives a toolkit
-    /// app no shutdown path at all — GTK and Qt install no `SIGTERM` handler, so everything the
-    /// app would have flushed on exit is lost and it can come back reporting a crash. The group
-    /// reap still runs either way: it is what guarantees sway, Xwayland and the app are gone.
+    /// The app is asked first because a signal gives a toolkit app no shutdown path at all (see
+    /// `glass_proc_linux::CLOSE_GRACE`), so everything it would have flushed on exit is lost and
+    /// it can come back reporting a crash.
+    ///
+    /// The reap covers the app's own processes as well as sway's group. sway calls `setsid` for
+    /// every app it `exec`s, so the app is in neither sway's process group nor its session —
+    /// signalling that group alone reaches the compositor and nothing else. A display client
+    /// usually dies anyway once its compositor goes away, but anything the app forked that is
+    /// not a display client would be left running.
     fn kill_session(&mut self) {
         // Tear down the clipboard owner thread before the wayland socket disappears.
         if let Some(owner) = self.clipboard_owner.take() {
             owner.stop();
         }
         if let Some(mut s) = self.active.take() {
-            let (asked, unaskable) = request_close(&mut s.ipc);
-            let closed = asked > 0
-                && glass_proc_linux::await_condition(CLOSE_GRACE, || {
-                    // The app is gone from the compositor once it has no windows left. An IPC
-                    // error means sway is unreachable, which is not evidence the app closed, so
-                    // it reads as "still there" and the group reap below takes over.
+            // Snapshot the launch (sway, Xwayland, the app and anything it forked) before any of
+            // it exits: once sway is reaped its descendants are reparented to init and can no
+            // longer be found from its pid.
+            let tree = glass_proc_linux::proc_tree_pids(s.child.id());
+            let app = app_pids(&tree, s.child.id());
+            let asked = request_close(&mut s.ipc);
+            // Wait on the app's processes, not on sway's window list: an empty list only means
+            // the surface is gone, and a toolkit that flushes state after destroying its window
+            // would still be mid-shutdown. With no app pid to watch (nothing but the compositor
+            // in the tree) fall back to the window list, which is all there is.
+            let closed_itself = asked.await_close(CLOSE_GRACE, || {
+                if app.is_empty() {
                     s.ipc.windows().is_ok_and(|w| w.is_empty())
-                });
-            glass_proc_linux::reap_group(&mut s.child, glass_proc_linux::APP_REAP_GRACE);
-            glass_proc_linux::disclose_teardown(glass_proc_linux::close_outcome(
-                asked, unaskable, closed,
-            ));
+                } else {
+                    !glass_proc_linux::any_alive(&app)
+                }
+            });
+            glass_proc_linux::reap_launch(&mut s.child, &tree, glass_proc_linux::APP_REAP_GRACE);
+            glass_proc_linux::disclose_teardown(&asked.outcome(closed_itself));
         }
         self.dbus = None;
     }
 }
 
-/// Ask every window in the session to close. Reports how many were asked and how many sway
-/// refused to pass the request to, so the caller can tell an app that could not be asked from a
-/// session that had no window to ask.
+/// The launched app's own processes: everything in the session's process tree except the
+/// compositor itself and the Xwayland it starts. Used as the liveness signal during teardown.
+fn app_pids(tree: &[u32], sway_pid: u32) -> Vec<u32> {
+    tree.iter()
+        .copied()
+        .filter(|&pid| pid != sway_pid && !is_xwayland(pid))
+        .collect()
+}
+
+/// Whether `pid` is the compositor's Xwayland, read from `/proc/<pid>/comm`. Xwayland exits with
+/// the compositor and is glass's own plumbing, so waiting on it would mean waiting for sway.
+fn is_xwayland(pid: u32) -> bool {
+    std::fs::read_to_string(format!("/proc/{pid}/comm")).is_ok_and(|comm| comm.trim() == "Xwayland")
+}
+
+/// Ask every window in the session to close.
 ///
-/// sway's `kill` is the compositor-side close request — `xdg_toplevel.close` to a native
-/// Wayland client, `WM_DELETE_WINDOW` to an Xwayland one — not a signal to the process. Under
-/// Wayland the *compositor* owns that ask, so glass goes through sway rather than talking to
-/// the client directly the way the X11 backend does.
+/// sway's `kill` is the compositor-side close request — `xdg_toplevel.close` to a native Wayland
+/// client, `WM_DELETE_WINDOW` to an Xwayland one that advertises the protocol. Under Wayland the
+/// *compositor* owns that ask, so glass goes through sway rather than talking to the client the
+/// way the X11 backend does.
 ///
-/// Each window is asked separately so one failure doesn't drop the rest: a `kill` naming a
-/// container that has already gone is an error from sway, and batching would then abandon the
-/// windows after it in the list.
-fn request_close(ipc: &mut Ipc) -> (usize, usize) {
-    let Ok(windows) = ipc.windows() else {
-        return (0, 0);
+/// **What glass cannot tell here:** sway acknowledges the *command*, not the client's handling of
+/// it, and for an Xwayland client that never opted into `WM_DELETE_WINDOW` wlroots closes the X
+/// connection instead of asking. Both look identical from the outside — the window disappears —
+/// so on this backend a client that was disconnected rather than asked is reported as a clean
+/// close. The X11 backend can distinguish the two because it reads `WM_PROTOCOLS` itself.
+///
+/// Each window is asked separately rather than as one batched command: sway returns one outcome
+/// per command, and a batch collapses them into a single first-failure, which would lose the
+/// per-window accounting this returns.
+fn request_close(ipc: &mut Ipc) -> Asked {
+    let windows = match ipc.windows() {
+        Ok(windows) => windows,
+        Err(e) => return Asked::blocked(format!("glass could not reach the compositor: {e}")),
     };
+    if windows.is_empty() {
+        return Asked::none();
+    }
     let total = windows.len();
     let asked = windows
         .iter()
@@ -142,7 +180,9 @@ fn request_close(ipc: &mut Ipc) -> (usize, usize) {
                 .is_ok()
         })
         .count();
-    (asked, total - asked)
+    Asked::counted(total, asked, |unaskable| {
+        format!("the compositor refused the close request for {unaskable} of its {total} window(s)")
+    })
 }
 
 impl Drop for WaylandPlatform {

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -8,8 +8,9 @@ use std::time::{Duration, Instant};
 
 use glass_core::{
     AppSpec, Frame, GlassError, KeyEvent, Platform, PointerEvent, Region, Result, Stream,
-    WindowGeometry, WindowId, WindowInfo, WindowOp,
+    TEARDOWN_BUDGET, WindowGeometry, WindowId, WindowInfo, WindowOp,
 };
+use glass_proc_linux::{APP_REAP_GRACE, CLOSE_GRACE};
 use smithay_client_toolkit::delegate_dispatch2;
 use smithay_client_toolkit::delegate_registry;
 use smithay_client_toolkit::output::{OutputHandler, OutputState};
@@ -36,6 +37,15 @@ use std::collections::HashMap;
 use crate::command::{LogSink, build_sway_command, sway_config};
 use crate::input::evdev_button;
 use crate::swayipc::{Ipc, Window as SwayWindow};
+
+// glass-mcp gives the whole of teardown `TEARDOWN_BUDGET` and then exits regardless, on a
+// `spawn_blocking` thread that cannot be cancelled — so an ask-then-signal ladder that fills the
+// budget would never get to the signal, and sway (plus Xwayland and the app) would outlive glass.
+// Bind both graces to it here; the a11y bus teardown that follows shares the remaining headroom.
+const _: () = assert!(
+    CLOSE_GRACE.as_millis() + APP_REAP_GRACE.as_millis() < TEARDOWN_BUDGET.as_millis(),
+    "the close request + compositor reap must finish inside glass_core::TEARDOWN_BUDGET"
+);
 
 struct ActiveSession {
     child: Child,
@@ -79,16 +89,60 @@ impl WaylandPlatform {
         })
     }
 
+    /// Tear the session down: ask the app to close, then reap the compositor subtree.
+    ///
+    /// The app is asked first because signalling the compositor's process group gives a toolkit
+    /// app no shutdown path at all — GTK and Qt install no `SIGTERM` handler, so everything the
+    /// app would have flushed on exit is lost and it can come back reporting a crash. The group
+    /// reap still runs either way: it is what guarantees sway, Xwayland and the app are gone.
     fn kill_session(&mut self) {
         // Tear down the clipboard owner thread before the wayland socket disappears.
         if let Some(owner) = self.clipboard_owner.take() {
             owner.stop();
         }
         if let Some(mut s) = self.active.take() {
-            glass_proc_linux::reap_group(&mut s.child, glass_proc_linux::REAP_GRACE);
+            let (asked, unaskable) = request_close(&mut s.ipc);
+            let closed = asked > 0
+                && glass_proc_linux::await_condition(CLOSE_GRACE, || {
+                    // The app is gone from the compositor once it has no windows left. An IPC
+                    // error means sway is unreachable, which is not evidence the app closed, so
+                    // it reads as "still there" and the group reap below takes over.
+                    s.ipc.windows().is_ok_and(|w| w.is_empty())
+                });
+            glass_proc_linux::reap_group(&mut s.child, glass_proc_linux::APP_REAP_GRACE);
+            glass_proc_linux::disclose_teardown(glass_proc_linux::close_outcome(
+                asked, unaskable, closed,
+            ));
         }
         self.dbus = None;
     }
+}
+
+/// Ask every window in the session to close. Reports how many were asked and how many sway
+/// refused to pass the request to, so the caller can tell an app that could not be asked from a
+/// session that had no window to ask.
+///
+/// sway's `kill` is the compositor-side close request — `xdg_toplevel.close` to a native
+/// Wayland client, `WM_DELETE_WINDOW` to an Xwayland one — not a signal to the process. Under
+/// Wayland the *compositor* owns that ask, so glass goes through sway rather than talking to
+/// the client directly the way the X11 backend does.
+///
+/// Each window is asked separately so one failure doesn't drop the rest: a `kill` naming a
+/// container that has already gone is an error from sway, and batching would then abandon the
+/// windows after it in the list.
+fn request_close(ipc: &mut Ipc) -> (usize, usize) {
+    let Ok(windows) = ipc.windows() else {
+        return (0, 0);
+    };
+    let total = windows.len();
+    let asked = windows
+        .iter()
+        .filter(|w| {
+            ipc.run_command(&format!("[con_id={}] kill", w.con_id))
+                .is_ok()
+        })
+        .count();
+    (asked, total - asked)
 }
 
 impl Drop for WaylandPlatform {

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -6,7 +6,7 @@ use glass_core::{
     AppSpec, Frame, GlassError, KeyEvent, Platform, PointerEvent, Region, Result, Stream,
     TEARDOWN_BUDGET, WindowGeometry, WindowHint, WindowId, WindowInfo, WindowOp,
 };
-use glass_proc_linux::{APP_REAP_GRACE, CLOSE_GRACE, proc_tree_pids, spawn_reader};
+use glass_proc_linux::{APP_REAP_GRACE, Asked, CLOSE_GRACE, proc_tree_pids, spawn_reader};
 use x11rb::CURRENT_TIME;
 use x11rb::connection::Connection;
 use x11rb::errors::ReplyError;
@@ -15,10 +15,13 @@ use x11rb::protocol::xproto::*;
 use x11rb::protocol::xtest::ConnectionExt as _;
 use x11rb::rust_connection::RustConnection;
 
-// glass-mcp gives the whole of teardown `TEARDOWN_BUDGET` and then exits regardless, on a
+// glass-mcp gives the whole of teardown `glass_core::TEARDOWN_BUDGET` and then exits regardless, on a
 // `spawn_blocking` thread that cannot be cancelled — so an ask-then-signal ladder that fills the
-// budget would never get to the signal, and the app would outlive glass. Bind both graces to it
-// here: what follows this ladder (the a11y bus, a private Xvfb) shares the remaining headroom.
+// budget would never get to the signal, and the app would outlive glass.
+//
+// This binds the ladder only. What follows it in the same budget — the private a11y bus, then a
+// private Xvfb — still reaps at `REAP_GRACE` each, so a helper that ignores SIGTERM can take the
+// whole teardown past the budget; that is pre-existing and not what this assertion is about.
 const _: () = assert!(
     CLOSE_GRACE.as_millis() + APP_REAP_GRACE.as_millis() < TEARDOWN_BUDGET.as_millis(),
     "the close request + signal ladder must finish inside glass_core::TEARDOWN_BUDGET"
@@ -288,47 +291,73 @@ impl X11Platform {
         Ok(())
     }
 
-    /// Ask every mapped top-level window of the app rooted at `root_pid` to close. Reports how
-    /// many were asked, and how many were there but could not be (the caller reports the second
-    /// so an app that cannot be asked at all is distinguishable from one with no window).
+    /// Ask every mapped top-level window of the app rooted at `root_pid` to close.
     ///
     /// The ask is a `WM_DELETE_WINDOW` client message — the same one a window manager sends
     /// when the user clicks the close button, and the only way a toolkit app gets to run its
-    /// shutdown path (a signal runs none: GTK and Qt install no `SIGTERM` handler). glass runs
-    /// its display with no window manager, so glass sends it itself; the ICCCM lets any client
-    /// do that.
+    /// shutdown path (see `glass_proc_linux::CLOSE_GRACE` for what a signal does instead).
+    /// Nothing restricts who sends it, whether or not a window manager is running: `wmctrl -c`
+    /// does the same thing.
     ///
     /// Only windows that advertise `WM_DELETE_WINDOW` in `WM_PROTOCOLS` are asked. A window
-    /// that does not is required to ignore the message, so counting it would make teardown
-    /// wait out the whole grace for a shutdown nobody was asked to perform.
+    /// that does not has no handler for the message and will not act on it, so counting it
+    /// would make teardown wait out the whole grace for a shutdown nobody was asked to perform.
     ///
     /// The set is the launched process tree's, never the window-hint's. A hint can match a
     /// window belonging to some *other* process — that is the point of the fallback, and it is
     /// safe for discovery, which only reads — but closing one would destroy the state of an app
-    /// glass did not launch, which teardown of a spawned child has never done.
-    fn request_close(&self, root_pid: u32) -> (usize, usize) {
-        let (Ok(protocols), Ok(delete)) = (
+    /// glass did not launch, which teardown of a spawned child has never done. A launch found
+    /// only by hint is therefore signalled, and says so rather than passing for an app with no
+    /// window.
+    fn request_close(&self, root_pid: u32) -> Asked {
+        let (protocols, delete) = match (
             self.intern(b"WM_PROTOCOLS"),
             self.intern(b"WM_DELETE_WINDOW"),
-        ) else {
-            return (0, 0);
+        ) {
+            (Ok(p), Ok(d)) => (p, d),
+            (Err(e), _) | (_, Err(e)) => {
+                return Asked::blocked(format!("glass could not reach the X server: {e}"));
+            }
         };
         // `scan_all_windows` is the same enumeration `list_windows` uses, so the set asked to
         // close is exactly the set glass reports as the app's windows — mapped top-levels whose
         // `_NET_WM_PID` is in the launched process tree.
-        let wins = self
-            .scan_all_windows(&proc_tree_pids(root_pid))
-            .unwrap_or_default();
+        let wins = match self.scan_all_windows(&proc_tree_pids(root_pid)) {
+            Ok(wins) => wins,
+            Err(e) => return Asked::blocked(format!("glass could not enumerate its windows: {e}")),
+        };
+        if wins.is_empty() {
+            // No window in the launched process tree. If glass is nonetheless driving one, it
+            // was matched by the window hint and belongs to a process outside that tree, which
+            // teardown deliberately leaves alone (see above) — worth saying, because the app on
+            // screen is about to be signalled rather than asked.
+            return match self.window {
+                Some(_) => Asked::blocked(
+                    "the app's window was matched by the window hint, not by process id, so it \
+                     belongs to a process glass did not launch and is not sent a close request",
+                ),
+                None => Asked::none(),
+            };
+        }
         let total = wins.len();
         let asked = wins
             .into_iter()
             .filter(|&win| self.accepts_delete(win, protocols, delete))
             .filter(|&win| self.send_delete(win, protocols, delete).is_ok())
             .count();
-        // The client messages are queued on the connection, not sent, until this flush; without
-        // it the app would not see them until glass's next X request, which is after the wait.
-        let _ = self.conn.flush();
-        (asked, total - asked)
+        // x11rb buffers requests: they go out on `flush`, on a call that awaits a reply, or when
+        // the write buffer fills. The wait that follows makes no X calls at all, so without this
+        // flush the app might never receive the request inside the grace. A failed flush means
+        // nothing was delivered, whatever the count above says.
+        if let Err(e) = self.conn.flush() {
+            return Asked::blocked(format!("glass could not deliver the close request: {e}"));
+        }
+        Asked::counted(total, asked, |unaskable| {
+            format!(
+                "{unaskable} of its {total} window(s) do not advertise the WM_DELETE_WINDOW \
+                 protocol, so there is nothing to send them"
+            )
+        })
     }
 
     /// Whether `win` advertises `WM_DELETE_WINDOW` in its `WM_PROTOCOLS` property. A read
@@ -346,8 +375,15 @@ impl X11Platform {
             })
     }
 
-    /// Send one `WM_DELETE_WINDOW` client message to `win` (ICCCM 4.2.8.1: 32-bit format, the
-    /// protocol atom first, a timestamp second, delivered with an empty event mask).
+    /// Send one `WM_DELETE_WINDOW` client message to `win`, in the shape ICCCM 4.2.8 specifies:
+    /// 32-bit format, the protocol atom first, a timestamp second, delivered with an empty event
+    /// mask. The timestamp is `CURRENT_TIME` because there is no triggering event to take one
+    /// from — glass is not reacting to a user action the way a window manager is.
+    ///
+    /// A window destroyed between the scan and this call is NOT reported here: `send_event`
+    /// returns a `VoidCookie`, so the `BadWindow` comes back asynchronously and is dropped. Only
+    /// a connection-level write failure surfaces. That costs at most a wait for a window that
+    /// was already gone, which `await_close` short-circuits.
     fn send_delete(&self, win: Window, protocols: Atom, delete: Atom) -> Result<()> {
         let event = ClientMessageEvent::new(32, win, protocols, [delete, CURRENT_TIME, 0, 0, 0]);
         self.conn
@@ -366,16 +402,18 @@ impl X11Platform {
     /// it is what actually guarantees the process tree is gone.
     fn kill_child(&mut self) {
         if let Some(mut child) = self.child.take() {
-            let (asked, unaskable) = self.request_close(child.id());
-            let exited = asked > 0 && glass_proc_linux::await_exit(&mut child, CLOSE_GRACE);
-            // The group sweep runs either way. An app that closed itself can still have forked
-            // children it never cleaned up, and reaping the group is what keeps those from being
-            // orphaned; the leader is a zombie at this point, so its group is still signalable.
-            // On the graceful path the signals land on an already-exited app and cost nothing.
-            glass_proc_linux::reap_group(&mut child, APP_REAP_GRACE);
-            glass_proc_linux::disclose_teardown(glass_proc_linux::close_outcome(
-                asked, unaskable, exited,
-            ));
+            // Snapshot the launch's process tree before any of it exits. `await_exit` reaps the
+            // child, which reparents its descendants to init and takes them out of the subtree —
+            // after that there is no way to enumerate them again.
+            let tree = proc_tree_pids(child.id());
+            let asked = self.request_close(child.id());
+            let closed_itself =
+                asked.await_close(CLOSE_GRACE, || matches!(child.try_wait(), Ok(Some(_))));
+            // The sweep runs either way: an app that closed itself can still have forked children
+            // it never cleaned up, and on the graceful path the signals land on processes that
+            // are already gone and cost nothing.
+            glass_proc_linux::reap_launch(&mut child, &tree, APP_REAP_GRACE);
+            glass_proc_linux::disclose_teardown(&asked.outcome(closed_itself));
         }
         self.window = None;
         // Drop the private a11y bus, reaping its dbus-daemon / at-spi children. Also

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -4,15 +4,25 @@ use std::time::{Duration, Instant};
 
 use glass_core::{
     AppSpec, Frame, GlassError, KeyEvent, Platform, PointerEvent, Region, Result, Stream,
-    WindowGeometry, WindowHint, WindowId, WindowInfo, WindowOp,
+    TEARDOWN_BUDGET, WindowGeometry, WindowHint, WindowId, WindowInfo, WindowOp,
 };
-use glass_proc_linux::{proc_tree_pids, spawn_reader};
+use glass_proc_linux::{APP_REAP_GRACE, CLOSE_GRACE, proc_tree_pids, spawn_reader};
+use x11rb::CURRENT_TIME;
 use x11rb::connection::Connection;
 use x11rb::errors::ReplyError;
 use x11rb::protocol::ErrorKind;
 use x11rb::protocol::xproto::*;
 use x11rb::protocol::xtest::ConnectionExt as _;
 use x11rb::rust_connection::RustConnection;
+
+// glass-mcp gives the whole of teardown `TEARDOWN_BUDGET` and then exits regardless, on a
+// `spawn_blocking` thread that cannot be cancelled — so an ask-then-signal ladder that fills the
+// budget would never get to the signal, and the app would outlive glass. Bind both graces to it
+// here: what follows this ladder (the a11y bus, a private Xvfb) shares the remaining headroom.
+const _: () = assert!(
+    CLOSE_GRACE.as_millis() + APP_REAP_GRACE.as_millis() < TEARDOWN_BUDGET.as_millis(),
+    "the close request + signal ladder must finish inside glass_core::TEARDOWN_BUDGET"
+);
 
 const XT_MOTION: u8 = 6; // MotionNotify
 const XT_BTN_PRESS: u8 = 4; // ButtonPress
@@ -278,12 +288,94 @@ impl X11Platform {
         Ok(())
     }
 
+    /// Ask every mapped top-level window of the app rooted at `root_pid` to close. Reports how
+    /// many were asked, and how many were there but could not be (the caller reports the second
+    /// so an app that cannot be asked at all is distinguishable from one with no window).
+    ///
+    /// The ask is a `WM_DELETE_WINDOW` client message — the same one a window manager sends
+    /// when the user clicks the close button, and the only way a toolkit app gets to run its
+    /// shutdown path (a signal runs none: GTK and Qt install no `SIGTERM` handler). glass runs
+    /// its display with no window manager, so glass sends it itself; the ICCCM lets any client
+    /// do that.
+    ///
+    /// Only windows that advertise `WM_DELETE_WINDOW` in `WM_PROTOCOLS` are asked. A window
+    /// that does not is required to ignore the message, so counting it would make teardown
+    /// wait out the whole grace for a shutdown nobody was asked to perform.
+    ///
+    /// The set is the launched process tree's, never the window-hint's. A hint can match a
+    /// window belonging to some *other* process — that is the point of the fallback, and it is
+    /// safe for discovery, which only reads — but closing one would destroy the state of an app
+    /// glass did not launch, which teardown of a spawned child has never done.
+    fn request_close(&self, root_pid: u32) -> (usize, usize) {
+        let (Ok(protocols), Ok(delete)) = (
+            self.intern(b"WM_PROTOCOLS"),
+            self.intern(b"WM_DELETE_WINDOW"),
+        ) else {
+            return (0, 0);
+        };
+        // `scan_all_windows` is the same enumeration `list_windows` uses, so the set asked to
+        // close is exactly the set glass reports as the app's windows — mapped top-levels whose
+        // `_NET_WM_PID` is in the launched process tree.
+        let wins = self
+            .scan_all_windows(&proc_tree_pids(root_pid))
+            .unwrap_or_default();
+        let total = wins.len();
+        let asked = wins
+            .into_iter()
+            .filter(|&win| self.accepts_delete(win, protocols, delete))
+            .filter(|&win| self.send_delete(win, protocols, delete).is_ok())
+            .count();
+        // The client messages are queued on the connection, not sent, until this flush; without
+        // it the app would not see them until glass's next X request, which is after the wait.
+        let _ = self.conn.flush();
+        (asked, total - asked)
+    }
+
+    /// Whether `win` advertises `WM_DELETE_WINDOW` in its `WM_PROTOCOLS` property. A read
+    /// failure reads as "no": an unasked window costs a graceful shutdown, a wrongly-asked one
+    /// costs a grace period waiting for a message the app is entitled to ignore.
+    fn accepts_delete(&self, win: Window, protocols: Atom, delete: Atom) -> bool {
+        self.conn
+            .get_property(false, win, protocols, AtomEnum::ATOM, 0, 32)
+            .ok()
+            .and_then(|c| c.reply().ok())
+            .is_some_and(|reply| {
+                reply
+                    .value32()
+                    .is_some_and(|mut a| a.any(|at| at == delete))
+            })
+    }
+
+    /// Send one `WM_DELETE_WINDOW` client message to `win` (ICCCM 4.2.8.1: 32-bit format, the
+    /// protocol atom first, a timestamp second, delivered with an empty event mask).
+    fn send_delete(&self, win: Window, protocols: Atom, delete: Atom) -> Result<()> {
+        let event = ClientMessageEvent::new(32, win, protocols, [delete, CURRENT_TIME, 0, 0, 0]);
+        self.conn
+            .send_event(false, win, EventMask::NO_EVENT, event)
+            .map_err(|e| GlassError::Backend(format!("send WM_DELETE_WINDOW: {e}")))?;
+        Ok(())
+    }
+
     /// Kill and reap the launched child (if any) and forget its window. Used by
     /// `stop_app` and by `start_app`'s failure path so a launch that never finds
     /// a window does not orphan the process.
+    ///
+    /// The app is asked to close first and only signalled if it does not go: a signalled
+    /// toolkit app runs no shutdown path at all, so anything it would have flushed on exit is
+    /// lost and it can come back reporting a crash. The signal ladder stays as the fallback —
+    /// it is what actually guarantees the process tree is gone.
     fn kill_child(&mut self) {
         if let Some(mut child) = self.child.take() {
-            glass_proc_linux::reap_group(&mut child, glass_proc_linux::REAP_GRACE);
+            let (asked, unaskable) = self.request_close(child.id());
+            let exited = asked > 0 && glass_proc_linux::await_exit(&mut child, CLOSE_GRACE);
+            // The group sweep runs either way. An app that closed itself can still have forked
+            // children it never cleaned up, and reaping the group is what keeps those from being
+            // orphaned; the leader is a zombie at this point, so its group is still signalable.
+            // On the graceful path the signals land on an already-exited app and cost nothing.
+            glass_proc_linux::reap_group(&mut child, APP_REAP_GRACE);
+            glass_proc_linux::disclose_teardown(glass_proc_linux::close_outcome(
+                asked, unaskable, exited,
+            ));
         }
         self.window = None;
         // Drop the private a11y bus, reaping its dbus-daemon / at-spi children. Also

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -124,8 +124,9 @@ result, along with what to do about it where anything can be — the result stay
 
 Two exceptions: a Windows app launched under Sandboxie containment (`sandbox` of `default` or
 `strict`) is terminated without being asked, because a close request from outside the box never
-reaches it; and an app with no window has nothing to ask, so it is terminated immediately as
-before.
+reaches it; and an app with no window to ask is terminated immediately as before — one that opened
+none, or (on X11) a client that never opted into the `WM_DELETE_WINDOW` protocol and is required to
+ignore the request. Toolkit apps opt in; a bare-Xlib one may not.
 
 ## Capture & visual comparison
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -124,9 +124,14 @@ result, along with what to do about it where anything can be — the result stay
 
 Two exceptions: a Windows app launched under Sandboxie containment (`sandbox` of `default` or
 `strict`) is terminated without being asked, because a close request from outside the box never
-reaches it; and an app with no window to ask is terminated immediately as before — one that opened
-none, or (on X11) a client that never opted into the `WM_DELETE_WINDOW` protocol and is required to
-ignore the request. Toolkit apps opt in; a bare-Xlib one may not.
+reaches it; and an app with no window to ask is terminated immediately — one that opened none, or
+(on X11) a client that never opted into the `WM_DELETE_WINDOW` protocol, which has no handler for
+the request and will not act on it. Toolkit apps opt in; a bare-Xlib one may not.
+
+One reporting limit: on Wayland the compositor performs the ask, and it disconnects a client that
+has no close protocol instead of asking it. glass sees the same thing either way — the window is
+gone — so that case is reported as a clean close rather than as a termination. The X11 backend
+reads the protocol list itself and does distinguish them.
 
 ## Capture & visual comparison
 


### PR DESCRIPTION
Completes the teardown work #230 started on Windows and macOS: the two Linux backends killed a driven app outright, so it never ran its own shutdown path.

## The measurement

A GTK 4 client, torn down each way, both directions checked:

| Backend | Teardown | App's shutdown path ran? |
|---|---|---|
| X11 | SIGTERM to the process group (before) | **no** |
| X11 | `WM_DELETE_WINDOW` client message | yes — `close-request` + app `shutdown`, then it exits by itself |
| Wayland | SIGTERM to sway's group (before) | **no** |
| Wayland | `[con_id=N] kill` via sway IPC | yes, and sway stays up for the reap that follows |

GTK installs no `SIGTERM` handler, the same reason the macOS half of #230 was a real bug rather than a cosmetic one. Re-verified end-to-end through glass with the same real GTK 4 app, under `sandbox: off` and under bwrap containment, on both backends.

## What changed

- **X11** sends `WM_DELETE_WINDOW` to every mapped top-level of the launched process tree that advertises the protocol in `WM_PROTOCOLS`. Windows found only by the title/class hint are deliberately *not* asked — a hint can match a window belonging to a process glass never launched, and closing one would destroy somebody else's state — and teardown now says so instead of staying quiet.
- **Wayland** asks sway (`[con_id=N] kill`), the compositor-side close request.
- **The signal ladder stays**, and now reaches the whole launch. Each backend snapshots the launch's `/proc` subtree *before* anything exits and signals that, plus the process group. Neither handle is sufficient alone: children orphaned by the app's own exit leave the subtree, and **sway `setsid`s every app it `exec`s**, so under Wayland the app is in neither the compositor's group nor its session.
- **A teardown that could not be graceful is reported** on stderr — separately for "windows were there but could not be asked", "glass could not find out what to ask" (an unreachable X server or compositor), and "asked, but it never went". An app with no window to ask stays silent: that is also the failed-launch path.

## Budget

`glass-mcp` gives all of teardown `glass_core::TEARDOWN_BUDGET` on a `spawn_blocking` thread it cannot cancel, so a ladder that filled the budget would never reach the signal. `CLOSE_GRACE` (1500ms) + `APP_REAP_GRACE` (1000ms) are asserted against it at compile time in each backend. glass-mcp now takes that budget from the constant instead of a literal `3s`, so the assertions bind the real number.

## Review round

A five-lens pre-merge review found three defects in the first commit, all fixed here and all now covered by a test that fails against the old code:

1. **The Wayland fallback never reached the app** (the `setsid` finding above). Measured directly: after `kill -TERM -<sway pgid>`, the exec'd tree was still running with `ppid 1`. A display client dies anyway when its compositor goes, which is why it looked correct — a forked non-display child did not. `stop_app_reaps_the_apps_forked_child` (Wayland) pins it.
2. **A failure of glass's own machinery read as "nothing to ask"** — and that case is deliberately silent, so glass killed the app and said nothing.
3. **Wayland inferred "the app closed itself" from the compositor's window list**, which only says the surface is gone. It now watches the app's own pids.

Known and documented, not fixed: under Wayland the compositor disconnects a client that has no close protocol rather than asking it, and glass cannot distinguish that from a clean close (the X11 backend reads `WM_PROTOCOLS` itself and does). The Wayland test for that case now pins what it actually proves.

## Tests

Every new test was checked against the unfixed code first.

- `glass-proc-linux`: the wait never signals the child it waits for; nothing asked means the grace is not spent; an enumeration failure is disclosed rather than read as "no window"; `reap_launch` reaches a child that left the process group.
- X11: asked-and-closed; **glass really waits** for a slow shutdown path (a 40ms grace used to pass everything); an app that ignores the request is signalled after the grace and inside the budget; a multi-window app is asked; a contained launch is asked (under bwrap the spawned process is `bwrap`, so this is the only test that proves the descendant walk feeds the ask); a window glass did not launch is left alone.
- Wayland: the same, plus the forked-child reap and no leaked sway.
- a11y suite: a launch with the private bus still tears down inside `TEARDOWN_BUDGET` — the part the compile-time assertion cannot cover. It lives there because the X11 CI job has no AT-SPI launcher.

Local: workspace tests, `scripts/test-x11.sh` (43 + 1 + 2), `scripts/test-wayland.sh` (24), `scripts/test-a11y.sh` (31), clippy and fmt green; CI 8/8.

Not in scope: Android (`am force-stop`) and iOS (`simctl terminate`) have no graceful equivalent.