### PR TITLE
fix(wayland): bound every sway IPC request so a wedged compositor cannot hang teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,11 @@ internal refactors, CI, or test-only changes.
   attempting the spawn. Your own app is unaffected: only Apple-signed system code takes the new
   path, and only when `sandbox` is `off` (a contained launch cannot be handed off at all, so it
   still tries — Terminal and Disk Utility, for instance, do run contained).
+- A Wayland session whose compositor stops responding no longer hangs glass. Every sway IPC
+  request is bounded, and a connection that has timed out is not reused — a late reply arriving
+  on it could otherwise be read as the *next* request's, reporting a close request as delivered
+  when it never was. `glass_stop` reports the compositor as unreachable and falls back to
+  signalling the app.
 - `glass_stop` now asks the app to close before killing it on every desktop backend, so the app
   runs its own shutdown path. All four previously went straight to terminating the process —
   Windows by closing the job object, macOS by signalling, X11 and Wayland by signalling the

--- a/crates/glass-wayland/src/swayipc.rs
+++ b/crates/glass-wayland/src/swayipc.rs
@@ -4,6 +4,7 @@
 use std::io::{Read, Write};
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use glass_core::{GlassError, Result};
 use serde::Deserialize;
@@ -92,9 +93,27 @@ impl Node {
     }
 }
 
+/// How long a single IPC round trip may take before glass gives up on the compositor.
+///
+/// sway answers over a unix socket in well under a millisecond, so this is not a performance
+/// budget — it is the difference between a wedged compositor erroring out and hanging glass. It
+/// matters most during teardown, which the MCP server runs against a deadline it cannot cancel:
+/// a blocking read with no timeout there would keep the app, sway and Xwayland alive past the
+/// point where glass has given up and exited.
+const IPC_TIMEOUT: Duration = Duration::from_millis(500);
+
 /// A connected sway IPC client.
 pub struct Ipc {
     sock: UnixStream,
+    /// Where to reconnect after a failed request. `None` for a socket handed in directly (tests),
+    /// which therefore cannot recover.
+    path: Option<PathBuf>,
+    /// Set once any I/O on `sock` fails. A failed read may have consumed part of a reply, so the
+    /// stream is no longer at a message boundary and everything after it would be parsed from the
+    /// wrong offset — including a `run_command` reply that could then read as success. The stream
+    /// is replaced rather than resynchronized: a fresh connection starts at a message boundary by
+    /// construction.
+    broken: bool,
 }
 
 impl Ipc {
@@ -104,32 +123,76 @@ impl Ipc {
             .ok_or_else(|| GlassError::Backend("sway IPC socket not found".into()))?;
         let sock = UnixStream::connect(&path)
             .map_err(|e| GlassError::Backend(format!("connect sway IPC: {e}")))?;
-        Ok(Ipc { sock })
+        let mut ipc = Ipc::from_stream(sock)?;
+        ipc.path = Some(path);
+        Ok(ipc)
+    }
+
+    /// Replace a desynchronized stream with a fresh one. A timed-out request is not evidence that
+    /// the compositor is gone — it may simply have been slow — so the connection is rebuilt on the
+    /// next request rather than staying dead for the rest of the session.
+    fn reconnect(&mut self) -> Result<()> {
+        let path = self.path.as_ref().ok_or_else(|| {
+            GlassError::Backend(
+                "sway IPC connection is broken (an earlier request failed) and cannot be \
+                 reopened"
+                    .into(),
+            )
+        })?;
+        let sock = UnixStream::connect(path)
+            .map_err(|e| GlassError::Backend(format!("reconnect sway IPC: {e}")))?;
+        set_timeouts(&sock)?;
+        self.sock = sock;
+        self.broken = false;
+        Ok(())
+    }
+
+    /// Wrap an already-connected socket, applying the read/write timeouts every request relies
+    /// on to stay bounded.
+    fn from_stream(sock: UnixStream) -> Result<Ipc> {
+        set_timeouts(&sock)?;
+        Ok(Ipc {
+            sock,
+            path: None,
+            broken: false,
+        })
     }
 
     fn request(&mut self, msg_type: u32, payload: &[u8]) -> Result<Vec<u8>> {
+        if self.broken {
+            self.reconnect()?;
+        }
         let mut buf = Vec::with_capacity(14 + payload.len());
         buf.extend_from_slice(MAGIC);
         buf.extend_from_slice(&(payload.len() as u32).to_ne_bytes());
         buf.extend_from_slice(&msg_type.to_ne_bytes());
         buf.extend_from_slice(payload);
-        self.sock
-            .write_all(&buf)
-            .map_err(|e| GlassError::Backend(format!("sway IPC write: {e}")))?;
+        self.io(|sock| sock.write_all(&buf), "write")?;
 
         let mut header = [0u8; 14];
-        self.sock
-            .read_exact(&mut header)
-            .map_err(|e| GlassError::Backend(format!("sway IPC read: {e}")))?;
+        self.io(|sock| sock.read_exact(&mut header), "read")?;
         if &header[0..6] != MAGIC {
+            // Also a desync: whatever is in the stream is not a reply glass can resynchronize to.
+            self.broken = true;
             return Err(GlassError::Backend("sway IPC bad magic".into()));
         }
         let len = u32::from_ne_bytes(header[6..10].try_into().unwrap()) as usize;
         let mut reply = vec![0u8; len];
-        self.sock
-            .read_exact(&mut reply)
-            .map_err(|e| GlassError::Backend(format!("sway IPC read: {e}")))?;
+        self.io(|sock| sock.read_exact(&mut reply), "read")?;
         Ok(reply)
+    }
+
+    /// Run one socket operation, marking the connection broken if it fails. A timeout counts:
+    /// the bytes are still in flight, so the next request would read them as its own reply.
+    fn io(
+        &mut self,
+        op: impl FnOnce(&mut UnixStream) -> std::io::Result<()>,
+        what: &str,
+    ) -> Result<()> {
+        op(&mut self.sock).map_err(|e| {
+            self.broken = true;
+            GlassError::Backend(format!("sway IPC {what}: {e}"))
+        })
     }
 
     /// `get_tree` -> the app windows (those with a foreign-toplevel identifier).
@@ -146,6 +209,14 @@ impl Ipc {
         let reply = self.request(MSG_RUN_COMMAND, cmd.as_bytes())?;
         check_command_reply(&reply, cmd)
     }
+}
+
+/// Bound every request in both directions, so a compositor that stops answering cannot hang a
+/// teardown the MCP server is running against a deadline it cannot cancel.
+fn set_timeouts(sock: &UnixStream) -> Result<()> {
+    sock.set_read_timeout(Some(IPC_TIMEOUT))
+        .and_then(|()| sock.set_write_timeout(Some(IPC_TIMEOUT)))
+        .map_err(|e| GlassError::Backend(format!("set sway IPC timeout: {e}")))
 }
 
 /// One entry of a `RUN_COMMAND` reply (one per command in the payload).
@@ -220,6 +291,52 @@ mod tests {
     #[test]
     fn command_reply_ok_when_all_succeed() {
         assert!(check_command_reply(br#"[{"success":true}]"#, "[con_id=1] focus").is_ok());
+    }
+
+    /// A compositor that accepts the request and never answers must not hang glass. Teardown runs
+    /// against a deadline the MCP server cannot cancel, so a blocking read here would leave sway,
+    /// Xwayland and the app alive past the point glass gave up and exited.
+    #[test]
+    fn a_compositor_that_never_answers_times_out_instead_of_hanging() {
+        let (ours, _theirs) = UnixStream::pair().expect("socketpair");
+        let mut ipc = Ipc::from_stream(ours).expect("wrap");
+        let t = std::time::Instant::now();
+        let err = match ipc.windows() {
+            Ok(_) => panic!("a silent peer must not produce a window list"),
+            Err(e) => e,
+        };
+        let elapsed = t.elapsed();
+        assert!(
+            elapsed < IPC_TIMEOUT * 4,
+            "the request should give up near the timeout, not hang (took {elapsed:?})"
+        );
+        assert!(err.to_string().contains("sway IPC"), "{err}");
+    }
+
+    /// After a failed read the stream is no longer at a message boundary: the reply glass gave up
+    /// on can still arrive and would be read as the *next* request's reply. A `run_command` that
+    /// picked up a stale `{"success":true}` would report a close request as delivered when it was
+    /// not, which is exactly the misreport teardown is supposed to avoid. The live client answers
+    /// this by reconnecting; this socket has no path to reconnect to, so it reports the failure
+    /// instead of reading the stale bytes.
+    #[test]
+    fn a_broken_connection_refuses_further_requests_instead_of_reading_a_stale_reply() {
+        let (ours, theirs) = UnixStream::pair().expect("socketpair");
+        let mut ipc = Ipc::from_stream(ours).expect("wrap");
+        assert!(ipc.windows().is_err(), "first request times out");
+        // The peer answers late, exactly as a recovering compositor would.
+        let mut theirs = theirs;
+        let payload = br#"[{"success":true}]"#;
+        let mut late = Vec::new();
+        late.extend_from_slice(MAGIC);
+        late.extend_from_slice(&(payload.len() as u32).to_ne_bytes());
+        late.extend_from_slice(&MSG_RUN_COMMAND.to_ne_bytes());
+        late.extend_from_slice(payload);
+        theirs.write_all(&late).expect("late reply");
+        let err = ipc
+            .run_command("[con_id=1] kill")
+            .expect_err("a broken connection must not report success from a stale reply");
+        assert!(err.to_string().contains("cannot be"), "{err}");
     }
 
     #[test]

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -303,6 +303,12 @@ impl X11Platform {
     /// that does not has no handler for the message and will not act on it, so counting it
     /// would make teardown wait out the whole grace for a shutdown nobody was asked to perform.
     ///
+    /// Every step here is a blocking X round trip, and x11rb has no per-request timeout: an X
+    /// server that is alive but not answering stalls teardown for as long as it stays that way.
+    /// That is true of every X call glass makes (capture and input included), not something this
+    /// path introduces a way around — bounding it needs a cancellable X path, not a socket
+    /// timeout, which would desynchronize the protocol stream on a spurious trip.
+    ///
     /// The set is the launched process tree's, never the window-hint's. A hint can match a
     /// window belonging to some *other* process — that is the point of the fallback, and it is
     /// safe for discovery, which only reads — but closing one would destroy the state of an app


### PR DESCRIPTION
Follow-up to #232, from the same review round: teardown now polls the compositor, and nothing bounded that I/O.

## The problem

`Ipc` used a blocking `UnixStream` with no read or write timeout. `glass_stop` on the Wayland backend calls `get_tree` while waiting for the app to close, so a compositor that is alive but not answering blocks teardown forever. `glass-mcp` enforces its teardown budget by abandoning the thread, so the app, sway and Xwayland all outlive the glass process that gave up on them. `await_condition` cannot help — it only checks its deadline between polls, never inside one.

## What changed

- **A 500ms timeout in both directions.** Not a performance budget: I instrumented every round trip through the whole Wayland suite and none took over 200ms. It is the difference between erroring out and hanging.
- **A failed request breaks the connection, and the next one rebuilds it.** A timed-out read leaves the stream mid-message — the reply glass gave up on can still arrive and be read as the *next* request's. A `run_command` picking up a stale `{"success":true}` would report a close request as delivered when it never was, which is exactly the misreport #232 exists to avoid. Reconnecting is what makes this safe *and* usable: a fresh socket starts at a message boundary by construction, and a timeout is not evidence the compositor is gone. (An earlier version of this change disabled the connection permanently instead, which would have made one transient error break window discovery for the rest of the session.)

## Tests

- `a_compositor_that_never_answers_times_out_instead_of_hanging` — a socketpair peer that never replies; the request returns an error near the timeout instead of blocking.
- `a_broken_connection_refuses_further_requests_instead_of_reading_a_stale_reply` — the peer answers *late*, as a recovering compositor would; the stale `{"success":true}` must not be read as this request's reply. Verified to fail against the unguarded version.

## Not fixed here: the X11 side

x11rb has no per-request timeout, and a socket timeout is not a safe substitute — a spurious trip desynchronizes the protocol stream, and unlike sway IPC there is no message boundary to reconnect to. Bounding it needs a cancellable X path. The exposure is also not specific to teardown: every X call glass makes (capture, input, geometry) blocks the same way. Documented at the call site rather than half-solved.

Local: workspace tests, `scripts/test-x11.sh` (43 + 1 + 2), `scripts/test-wayland.sh` (24), clippy, fmt.

The Wayland multi-window test flaked during this work. It is the known load-dependent Xwayland surface-mapping race: identical code failed twice in a row and then passed three times in a row, and it reproduces on master.