### PR TITLE
fix(x11): bound the close request so an unresponsive display cannot hang teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,10 @@ internal refactors, CI, or test-only changes.
   attempting the spawn. Your own app is unaffected: only Apple-signed system code takes the new
   path, and only when `sandbox` is `off` (a contained launch cannot be handed off at all, so it
   still tries — Terminal and Disk Utility, for instance, do run contained).
+- An X11 display that stops answering no longer hangs `glass_stop`. Sending the close request is
+  a series of blocking X round trips, so it now runs under a deadline; past it glass reports the
+  display as unresponsive and goes straight to signalling the app, instead of holding teardown
+  open until the process is killed.
 - A Wayland session whose compositor stops responding no longer hangs glass. Every sway IPC
   request is bounded, and a connection that has timed out is not reused — a late reply arriving
   on it could otherwise be read as the *next* request's, reporting a close request as delivered

--- a/crates/glass-testapp/tests/integration.rs
+++ b/crates/glass-testapp/tests/integration.rs
@@ -1568,6 +1568,46 @@ fn stop_app_leaves_a_window_it_did_not_launch_alone() {
     );
 }
 
+/// A display that is running but not answering must not hold teardown open. Sending the close
+/// request is a series of blocking X round trips and x11rb has no per-request timeout, so without
+/// a bound `stop_app` never returns — and glass-mcp enforces its teardown budget by abandoning
+/// the thread, which would leave the app running after glass itself had exited.
+///
+/// `SIGSTOP` on the X server is the only way to produce that state from a test: the socket stays
+/// open and accepts writes, and no reply ever comes.
+#[test]
+#[ignore = "requires an X server; run via scripts/test-x11.sh"]
+fn stop_app_does_not_hang_when_the_x_server_stops_answering() {
+    let xvfb = Xvfb::start();
+    let mut p = X11Platform::connect(Some(&xvfb.display)).unwrap();
+    p.start_app(&app_spec()).unwrap();
+    let pid = wait_for_app_pid(&mut p);
+    let server = xvfb.pid();
+    let signal = |sig: &str| {
+        std::process::Command::new("kill")
+            .args([sig, &server.to_string()])
+            .status()
+            .expect("signal the X server");
+    };
+    signal("-STOP");
+    let t = std::time::Instant::now();
+    let stopped = p.stop_app();
+    let elapsed = t.elapsed();
+    // Let the server run again so its own teardown (and this Xvfb's Drop) behaves normally.
+    signal("-CONT");
+    stopped.expect("stop_app must still report success");
+    assert!(
+        elapsed < glass_core::TEARDOWN_BUDGET,
+        "stop_app must give up on an unresponsive display inside the teardown budget ({:?}); \
+         this took {elapsed:?}",
+        glass_core::TEARDOWN_BUDGET
+    );
+    assert!(
+        !std::path::Path::new(&format!("/proc/{pid}")).exists(),
+        "the app must be signalled even when it could not be asked (pid {pid} survived)"
+    );
+}
+
 /// An app that never opted into `WM_DELETE_WINDOW` has no handler for the message and will not
 /// act on it, so teardown must fall back to signalling it rather than waiting out the grace.
 #[test]

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -23,9 +23,16 @@ use x11rb::rust_connection::RustConnection;
 // private Xvfb — still reaps at `REAP_GRACE` each, so a helper that ignores SIGTERM can take the
 // whole teardown past the budget; that is pre-existing and not what this assertion is about.
 const _: () = assert!(
-    CLOSE_GRACE.as_millis() + APP_REAP_GRACE.as_millis() < TEARDOWN_BUDGET.as_millis(),
-    "the close request + signal ladder must finish inside glass_core::TEARDOWN_BUDGET"
+    ASK_BUDGET.as_millis() + CLOSE_GRACE.as_millis() + APP_REAP_GRACE.as_millis()
+        < TEARDOWN_BUDGET.as_millis(),
+    "sending the close request, waiting it out and the signal ladder must all finish inside \
+     glass_core::TEARDOWN_BUDGET"
 );
+
+/// How long the close request itself may take before glass gives up on the display and goes
+/// straight to signalling. Sending it is a handful of X round trips — sub-millisecond on a
+/// healthy server — so this is a liveness bound, not a budget the ask is expected to use.
+const ASK_BUDGET: Duration = Duration::from_millis(400);
 
 const XT_MOTION: u8 = 6; // MotionNotify
 const XT_BTN_PRESS: u8 = 4; // ButtonPress
@@ -406,15 +413,51 @@ impl X11Platform {
     /// toolkit app runs no shutdown path at all, so anything it would have flushed on exit is
     /// lost and it can come back reporting a crash. The signal ladder stays as the fallback —
     /// it is what actually guarantees the process tree is gone.
+    /// [`Self::request_close`] under a deadline, so a display that has stopped answering cannot
+    /// hold teardown open.
+    ///
+    /// Every step of the ask is a blocking X round trip and x11rb has no per-request timeout, so
+    /// the bound has to come from outside the connection: the ask runs on its own thread with its
+    /// own connection to the same display, and the caller stops waiting after [`ASK_BUDGET`]. The
+    /// second connection is what makes abandoning it safe — the thread cannot leave this backend's
+    /// connection stopped mid-request — and any client may send a close request, so the ask is no
+    /// less valid from there. A socket timeout would not work in its place: a spurious trip
+    /// desynchronizes the X protocol stream, which has no message boundary to resynchronize to.
+    ///
+    /// An abandoned thread stays blocked until the display answers or glass exits. That is the
+    /// cost of x11rb having no cancellation, and it buys the guarantee that matters here — the
+    /// signal ladder still runs, so the app does not outlive the glass process that gave up on it.
+    fn request_close_bounded(&self, root_pid: u32) -> Asked {
+        let (display, active) = (self.display.clone(), self.window);
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let asked = match X11Platform::connect(Some(&display)) {
+                Ok(mut asker) => {
+                    // Carry the active window over so the ask sees what this backend is driving:
+                    // `request_close` reports a launch that was found only by window hint.
+                    asker.window = active;
+                    asker.request_close(root_pid)
+                }
+                Err(e) => Asked::blocked(format!("glass could not reach the X server: {e}")),
+            };
+            let _ = tx.send(asked);
+        });
+        rx.recv_timeout(ASK_BUDGET).unwrap_or_else(|_| {
+            Asked::blocked(format!(
+                "the X server did not answer within {ASK_BUDGET:?}, so the app could not be asked \
+                 to close"
+            ))
+        })
+    }
+
     fn kill_child(&mut self) {
         if let Some(mut child) = self.child.take() {
-            // Snapshot the launch's process tree before any of it exits. `await_exit` reaps the
-            // child, which reparents its descendants to init and takes them out of the subtree —
-            // after that there is no way to enumerate them again.
+            // Snapshot the launch's process tree before any of it exits. Waiting on the child
+            // reaps it, which reparents its descendants to init and takes them out of the
+            // subtree — after that there is no way to enumerate them again.
             let tree = proc_tree_pids(child.id());
-            let asked = self.request_close(child.id());
-            let closed_itself =
-                asked.await_close(CLOSE_GRACE, || matches!(child.try_wait(), Ok(Some(_))));
+            let asked = self.request_close_bounded(child.id());
+            let closed_itself = asked.await_child_exit(&mut child, CLOSE_GRACE);
             // The sweep runs either way: an app that closed itself can still have forked children
             // it never cleaned up, and on the graceful path the signals land on processes that
             // are already gone and cost nothing.

--- a/crates/glass-x11/src/xvfb.rs
+++ b/crates/glass-x11/src/xvfb.rs
@@ -49,6 +49,13 @@ impl Xvfb {
         let xvfb = glass_core::tool_path("GLASS_XVFB", "Xvfb");
         start_binary(&xvfb, screen, READY_TIMEOUT)
     }
+
+    /// The server process's pid. Exposed so a test can put the display itself into a state glass
+    /// has to survive — an X server that is running but not answering, which is otherwise
+    /// impossible to produce from the client side.
+    pub fn pid(&self) -> u32 {
+        self.child.id()
+    }
 }
 
 /// One spawn attempt's failure, carrying whatever the server wrote to stderr —


### PR DESCRIPTION
Closes the last item from #232's review round. #233 did the Wayland half; this is X11.

## The problem

`request_close` is a series of blocking X round trips (intern atoms, `query_tree`, `get_property` per window, `send_event`, flush). x11rb has no per-request timeout, so a display that is running but not answering blocks `glass_stop` forever. glass-mcp enforces its teardown budget by abandoning the thread, so the app outlives the glass process that gave up on it — the exact failure the teardown work exists to prevent.

## Why not a socket timeout

That is what #233 did for sway IPC, and it does not transfer. A spurious timeout mid-request desynchronizes the X protocol stream, and unlike sway's framed IPC there is no message boundary to reconnect at — the connection is simply dead, including for a session that was merely slow.

## What this does instead

The ask runs on its own thread with its own connection to the same display; the caller waits `ASK_BUDGET` (400ms) and otherwise gives up and goes straight to the signal ladder, reporting the display as unresponsive.

- A **second connection** is what makes abandoning it safe: the thread cannot leave this backend's connection stopped mid-request.
- Any client may send a close request, so the ask is no less valid from there.
- An abandoned thread stays blocked until the display answers or glass exits. That is the cost of x11rb having no cancellation, and it buys the guarantee that matters: the signal ladder still runs, so nothing is stranded.
- `ASK_BUDGET` joins the existing compile-time assertion — ask + close grace + signal ladder still fit inside `glass_core::TEARDOWN_BUDGET`.

## Test

`stop_app_does_not_hang_when_the_x_server_stops_answering` `SIGSTOP`s the Xvfb — the only way to produce a display that accepts writes and never replies — then asserts `stop_app` returns inside the budget with the app gone, and `SIGCONT`s so the server's own teardown behaves normally.

Verified both ways: it passes in ~0.5s here, and against the unbounded version it hangs (killed at 90s).

`Xvfb` gains a `pid()` accessor for it — the server's own pid, which no client-side API can provide.

## Not covered

Capture, input and geometry still block the same way. Bounding those needs a per-op deadline policy and a "display stopped responding" error path through the whole backend; the case fixed here is the one that strands processes, because it is the one running against a deadline glass cannot extend.

Local: workspace tests, `scripts/test-x11.sh` (44 + 1 + 2), `scripts/test-wayland.sh` (24), `scripts/test-a11y.sh` (31), clippy, fmt.