### PR TITLE
fix(x11): don't lose the close request when the ask connection closes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,13 @@ internal refactors, CI, or test-only changes.
   Android paths have no such live check.
 
 ### Fixed
+- Linux (`backend: "x11"`): `glass_stop` no longer signals an app that should have been asked to
+  close. The close request went out on a short-lived X connection that was closed immediately
+  afterwards, and a request the server had not processed yet was discarded with it — so the app
+  never saw it, sat out the whole close grace, and was signalled, losing whatever it would have
+  flushed on exit. On a loaded machine 4 of 10 teardowns went that way, with the app's event loop
+  running the whole time. glass now waits for the server to confirm the request before the
+  connection can go away.
 - macOS: launching a stock Apple app no longer leaves a crash report and a "quit unexpectedly"
   dialog behind. glass direct-spawns a bundle's inner executable to get piped logs and
   containment, but macOS gives a system app a launch constraint requiring it to be started by

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -14,6 +14,7 @@ use x11rb::protocol::ErrorKind;
 use x11rb::protocol::xproto::*;
 use x11rb::protocol::xtest::ConnectionExt as _;
 use x11rb::rust_connection::RustConnection;
+use x11rb::wrapper::ConnectionExt as _;
 
 // glass-mcp gives the whole of teardown `glass_core::TEARDOWN_BUDGET` and then exits regardless, on a
 // `spawn_blocking` thread that cannot be cancelled — so an ask-then-signal ladder that fills the
@@ -358,11 +359,15 @@ impl X11Platform {
             .filter(|&win| self.accepts_delete(win, protocols, delete))
             .filter(|&win| self.send_delete(win, protocols, delete).is_ok())
             .count();
-        // x11rb buffers requests: they go out on `flush`, on a call that awaits a reply, or when
-        // the write buffer fills. The wait that follows makes no X calls at all, so without this
-        // flush the app might never receive the request inside the grace. A failed flush means
-        // nothing was delivered, whatever the count above says.
-        if let Err(e) = self.conn.flush() {
+        // Writing the request out is not enough: the ask runs on its own connection, which is
+        // dropped the moment this returns, and a request still unprocessed when its sender
+        // disconnects can be discarded — the app then waits out the whole grace for a message
+        // nobody will deliver, and is signalled instead of asked. Measured on a loaded machine:
+        // 4 of 10 teardowns lost the request that way, with the app's event loop demonstrably
+        // running throughout. `sync` sends everything buffered and waits for the server to
+        // answer a request queued behind it, so the close request has provably been processed
+        // before the connection can go away.
+        if let Err(e) = self.conn.sync() {
             return Asked::blocked(format!("glass could not deliver the close request: {e}"));
         }
         Asked::counted(total, asked, |unaskable| {


### PR DESCRIPTION
## The failure

`glass_stop` asks an app's windows to close (`WM_DELETE_WINDOW`) before signalling, so a toolkit app runs its shutdown path. That ask goes out on a **short-lived X connection** — the thing that bounds it against a display that has stopped answering — and the connection is dropped as soon as the request is written. A request the server hasn't processed yet can be discarded along with it. The app never sees the message, sits out the whole close grace, and gets signalled anyway:

```
glass: the app did not close within 1.5s of being asked ... so it was signalled.
Unsaved state was not flushed, and the app may report a crash on its next launch.
```

This is currently failing on **master** (X11 job, runs 30183779602 and 30181671252) and blocks every PR.

## Why it isn't a too-tight grace

Measured under 40 spinners on 20 cores:

| probe | result |
|---|---|
| baseline | 4/10 teardowns lost the request |
| grace raised 1.5s → **10s** | still lost — `wait_took=10016ms closed=false` |
| heartbeat added to the fixture's event loop | ticked every 100 ms for the **entire** 10 s wait |
| `ask_took` | 26–47 ms, `any=true` — the ask itself succeeded |

So the app was alive, its loop was running, and it never received the message. Waiting longer cannot fix a message that was never delivered.

## The fix

`flush` only writes the bytes out. `sync` writes them out *and* waits for the server to answer a request queued behind them — which cannot happen until the close request has been processed. After that the connection can go away safely.

One extra round trip on a local socket, inside the existing 400 ms ask budget (measured asks were 26–47 ms under load). No budget or grace values change.

X11 backend only: the Wayland backend asks through sway's IPC and reads the reply before the wait starts, so it has no equivalent window.

## Verification

- Same load, with the fix: **12/12** teardowns asked the app (was 4/10 failing).
- All eight `stop_app*` / `sandbox_*_close` tests: **10/10 runs** under 40 spinners with the real 1.5 s grace.
- Full X11 suite: 44 + 3 + 2 + 1 + 1 pass. Full Wayland suite: 24 + 1 pass.
- `cargo test --workspace`, `cargo clippy -p glass-x11 --all-targets -- -D warnings`, `cargo fmt --check`: clean.

The regression guard is the existing teardown suite — it fails 3–4 in 10 under load without this change and 0 in 10 with it. A deterministic unit test isn't possible here: the discarded request is a race inside the X server, and on an idle machine the old code passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)