### PR TITLE
ci(smoke): gate on mutation testing, and fix what it found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,7 +293,7 @@ jobs:
           workspaces: .
       - uses: taiki-e/install-action@ed67fa35ac944f3a9b33f12c4dd43b6f31a47e20 # v2.83.3
         with:
-          tool: cargo-mutants
+          tool: cargo-mutants,cargo-nextest
       - name: Diff the smoke module against the merge base
         # A ref name may contain `;`, `` ` ``, `$` and more, so it reaches the shell as data.
         env:
@@ -310,9 +310,11 @@ jobs:
             -- ':(glob)crates/glass-mcp/src/smoke/**/*.rs' > "$RUNNER_TEMP/pr.diff"
           wc -l "$RUNNER_TEMP/pr.diff"
       - name: Mutation gate
+        # nextest runs each test in its own process, so the module's deliberate
+        # multi-second teardown waits overlap instead of summing: 42s to 11s here.
         run: |
           if [ ! -s "$RUNNER_TEMP/pr.diff" ]; then
             echo "this PR changes no .rs file under crates/glass-mcp/src/smoke/ — nothing to mutate"
             exit 0
           fi
-          scripts/mutants.sh "$RUNNER_TEMP/mutants" --in-diff "$RUNNER_TEMP/pr.diff"
+          scripts/mutants.sh "$RUNNER_TEMP/mutants" --test-tool nextest --in-diff "$RUNNER_TEMP/pr.diff"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,7 @@ jobs:
       # Every shard reports: one red shard must not hide a second one.
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -333,7 +333,7 @@ jobs:
         run: |
           scripts/mutants.sh "$RUNNER_TEMP/mutants" \
             --test-tool nextest \
-            --shard ${{ matrix.shard }}/4 --sharding round-robin \
+            --shard ${{ matrix.shard }}/8 --sharding round-robin \
             --in-diff "$RUNNER_TEMP/pr.diff"
 
   # A matrix job's checks are named per shard, so the branch ruleset has nothing stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,7 +278,9 @@ jobs:
   mutants:
     name: Mutation gate (smoke · in-diff)
     runs-on: ubuntu-latest
-    # Non-blocking until the module's existing survivors are fixed; Task 9 removes this.
+    # A push carries no base ref to diff against; this gate is a pull-request check.
+    if: github.event_name == 'pull_request'
+    # Non-blocking until the module reaches zero surviving mutants.
     continue-on-error: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,8 +280,6 @@ jobs:
     runs-on: ubuntu-latest
     # A push carries no base ref to diff against; this gate is a pull-request check.
     if: github.event_name == 'pull_request'
-    # Non-blocking until the module reaches zero surviving mutants.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,19 +295,24 @@ jobs:
         with:
           tool: cargo-mutants
       - name: Diff the smoke module against the merge base
+        # A ref name may contain `;`, `` ` ``, `$` and more, so it reaches the shell as data.
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          git rev-parse --verify "origin/${{ github.base_ref }}" >/dev/null 2>&1 || {
-            echo "no merge base for origin/${{ github.base_ref }} — the checkout lacks history,"
+          git rev-parse --verify "origin/$BASE_REF" >/dev/null 2>&1 || {
+            echo "no merge base for origin/$BASE_REF — the checkout lacks history,"
             echo "so --in-diff would mutate nothing and this job would pass having gated nothing."
             exit 1
           }
-          git diff "origin/${{ github.base_ref }}...HEAD" -- crates/glass-mcp/src/smoke/ > pr.diff
-          wc -l pr.diff
+          # `:(glob)` so `**` spans directories, matching scripts/mutants.sh's --file; without
+          # it git reads `**` as an ordinary fnmatch pattern and selects nothing at all.
+          git diff "origin/$BASE_REF...HEAD" \
+            -- ':(glob)crates/glass-mcp/src/smoke/**/*.rs' > "$RUNNER_TEMP/pr.diff"
+          wc -l "$RUNNER_TEMP/pr.diff"
       - name: Mutation gate
         run: |
-          if [ ! -s pr.diff ]; then
-            echo "this PR does not touch crates/glass-mcp/src/smoke/ — nothing to mutate"
+          if [ ! -s "$RUNNER_TEMP/pr.diff" ]; then
+            echo "this PR changes no .rs file under crates/glass-mcp/src/smoke/ — nothing to mutate"
             exit 0
           fi
-          cargo mutants --in-diff pr.diff --file 'crates/glass-mcp/src/smoke/*.rs' \
-            -j 2 --package glass-mcp --output "$RUNNER_TEMP/mutants"
+          scripts/mutants.sh "$RUNNER_TEMP/mutants" --in-diff "$RUNNER_TEMP/pr.diff"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,3 +274,40 @@ jobs:
           name: coverage-lcov
           path: target/llvm-cov/glass.lcov
           if-no-files-found: warn
+
+  mutants:
+    name: Mutation gate (smoke · in-diff)
+    runs-on: ubuntu-latest
+    # Non-blocking until the module's existing survivors are fixed; Task 9 removes this.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # `--in-diff` needs a merge base to diff against; the default depth-1 checkout has
+          # none, which would yield an empty diff, mutate nothing, and pass green.
+          fetch-depth: 0
+      - name: Install pinned toolchain
+        run: rustup show
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: .
+      - uses: taiki-e/install-action@ed67fa35ac944f3a9b33f12c4dd43b6f31a47e20 # v2.83.3
+        with:
+          tool: cargo-mutants
+      - name: Diff the smoke module against the merge base
+        run: |
+          git rev-parse --verify "origin/${{ github.base_ref }}" >/dev/null 2>&1 || {
+            echo "no merge base for origin/${{ github.base_ref }} — the checkout lacks history,"
+            echo "so --in-diff would mutate nothing and this job would pass having gated nothing."
+            exit 1
+          }
+          git diff "origin/${{ github.base_ref }}...HEAD" -- crates/glass-mcp/src/smoke/ > pr.diff
+          wc -l pr.diff
+      - name: Mutation gate
+        run: |
+          if [ ! -s pr.diff ]; then
+            echo "this PR does not touch crates/glass-mcp/src/smoke/ — nothing to mutate"
+            exit 0
+          fi
+          cargo mutants --in-diff pr.diff --file 'crates/glass-mcp/src/smoke/*.rs' \
+            -j 2 --package glass-mcp --output "$RUNNER_TEMP/mutants"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,25 +276,23 @@ jobs:
           if-no-files-found: warn
 
   mutants:
-    name: Mutation gate (smoke · in-diff)
+    name: Mutation shard ${{ matrix.shard }} (smoke)
     runs-on: ubuntu-latest
     # A push carries no base ref to diff against; this gate is a pull-request check.
     if: github.event_name == 'pull_request'
+    strategy:
+      # Every shard reports: one red shard must not hide a second one.
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # `--in-diff` needs a merge base to diff against; the default depth-1 checkout has
           # none, which would yield an empty diff, mutate nothing, and pass green.
           fetch-depth: 0
-      - name: Install pinned toolchain
-        run: rustup show
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          workspaces: .
-      - uses: taiki-e/install-action@ed67fa35ac944f3a9b33f12c4dd43b6f31a47e20 # v2.83.3
-        with:
-          tool: cargo-mutants,cargo-nextest
       - name: Diff the smoke module against the merge base
+        id: diff
         # A ref name may contain `;`, `` ` ``, `$` and more, so it reaches the shell as data.
         env:
           BASE_REF: ${{ github.base_ref }}
@@ -309,12 +307,49 @@ jobs:
           git diff "origin/$BASE_REF...HEAD" \
             -- ':(glob)crates/glass-mcp/src/smoke/**/*.rs' > "$RUNNER_TEMP/pr.diff"
           wc -l "$RUNNER_TEMP/pr.diff"
+          if [ -s "$RUNNER_TEMP/pr.diff" ]; then
+            echo "touched=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "touched=false" >> "$GITHUB_OUTPUT"
+            echo "this PR changes no .rs file under crates/glass-mcp/src/smoke/ — nothing to mutate"
+          fi
+      # Installing a toolchain and two cargo tools costs more than the check itself,
+      # so a PR that touches no smoke file skips straight past them.
+      - name: Install pinned toolchain
+        if: steps.diff.outputs.touched == 'true'
+        run: rustup show
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        if: steps.diff.outputs.touched == 'true'
+        with:
+          workspaces: .
+      - uses: taiki-e/install-action@ed67fa35ac944f3a9b33f12c4dd43b6f31a47e20 # v2.83.3
+        if: steps.diff.outputs.touched == 'true'
+        with:
+          tool: cargo-mutants,cargo-nextest
       - name: Mutation gate
+        if: steps.diff.outputs.touched == 'true'
         # nextest runs each test in its own process, so the module's deliberate
         # multi-second teardown waits overlap instead of summing: 42s to 11s here.
         run: |
-          if [ ! -s "$RUNNER_TEMP/pr.diff" ]; then
-            echo "this PR changes no .rs file under crates/glass-mcp/src/smoke/ — nothing to mutate"
-            exit 0
-          fi
-          scripts/mutants.sh "$RUNNER_TEMP/mutants" --test-tool nextest --in-diff "$RUNNER_TEMP/pr.diff"
+          scripts/mutants.sh "$RUNNER_TEMP/mutants" \
+            --test-tool nextest \
+            --shard ${{ matrix.shard }}/4 --sharding round-robin \
+            --in-diff "$RUNNER_TEMP/pr.diff"
+
+  # A matrix job's checks are named per shard, so the branch ruleset has nothing stable
+  # to require. This one has a fixed name and fails if any shard did.
+  mutants-gate:
+    name: Mutation gate (smoke)
+    runs-on: ubuntu-latest
+    needs: mutants
+    if: always()
+    steps:
+      - name: Collect the shard results
+        env:
+          RESULT: ${{ needs.mutants.result }}
+        run: |
+          # `skipped` is the push-event path, where the shards deliberately do not run.
+          case "$RESULT" in
+            success|skipped) echo "mutation shards: $RESULT" ;;
+            *) echo "mutation shards: $RESULT — see the per-shard logs"; exit 1 ;;
+          esac

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -15,8 +15,13 @@ env:
 
 jobs:
   sweep:
-    name: Mutation sweep (smoke · full module)
+    name: Mutation sweep shard ${{ matrix.shard }} (smoke)
     runs-on: ubuntu-latest
+    strategy:
+      # Every shard reports: one red shard must not hide a second one.
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install pinned toolchain
@@ -30,10 +35,13 @@ jobs:
       - name: Sweep
         # nextest runs each test in its own process, so the module's deliberate
         # multi-second teardown waits overlap instead of summing: 42s to 11s here.
-        run: scripts/mutants.sh "$RUNNER_TEMP/mutants" --test-tool nextest
+        run: |
+          scripts/mutants.sh "$RUNNER_TEMP/mutants" \
+            --test-tool nextest \
+            --shard ${{ matrix.shard }}/4 --sharding round-robin
       - name: Upload the outcome
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: mutants-sweep
+          name: mutants-sweep-${{ matrix.shard }}
           path: ${{ runner.temp }}/mutants/mutants.out/

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -26,9 +26,11 @@ jobs:
           workspaces: .
       - uses: taiki-e/install-action@ed67fa35ac944f3a9b33f12c4dd43b6f31a47e20 # v2.83.3
         with:
-          tool: cargo-mutants
+          tool: cargo-mutants,cargo-nextest
       - name: Sweep
-        run: scripts/mutants.sh "$RUNNER_TEMP/mutants"
+        # nextest runs each test in its own process, so the module's deliberate
+        # multi-second teardown waits overlap instead of summing: 42s to 11s here.
+        run: scripts/mutants.sh "$RUNNER_TEMP/mutants" --test-tool nextest
       - name: Upload the outcome
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -1,0 +1,39 @@
+name: Mutation sweep
+
+# The PR gate only mutates lines a PR touches, so a survivor can appear in untouched code when a
+# test changes around it. This sweeps the whole module.
+on:
+  schedule:
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  sweep:
+    name: Mutation sweep (smoke · full module)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Install pinned toolchain
+        run: rustup show
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: .
+      - uses: taiki-e/install-action@ed67fa35ac944f3a9b33f12c4dd43b6f31a47e20 # v2.83.3
+        with:
+          tool: cargo-mutants
+      - name: Sweep
+        run: |
+          cargo mutants --file 'crates/glass-mcp/src/smoke/*.rs' \
+            -j 2 --package glass-mcp --output "$RUNNER_TEMP/mutants"
+      - name: Upload the outcome
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mutants-sweep
+          path: ${{ runner.temp }}/mutants/mutants.out/

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -21,7 +21,7 @@ jobs:
       # Every shard reports: one red shard must not hide a second one.
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install pinned toolchain
@@ -38,7 +38,7 @@ jobs:
         run: |
           scripts/mutants.sh "$RUNNER_TEMP/mutants" \
             --test-tool nextest \
-            --shard ${{ matrix.shard }}/4 --sharding round-robin
+            --shard ${{ matrix.shard }}/8 --sharding round-robin
       - name: Upload the outcome
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -28,9 +28,7 @@ jobs:
         with:
           tool: cargo-mutants
       - name: Sweep
-        run: |
-          cargo mutants --file 'crates/glass-mcp/src/smoke/*.rs' \
-            -j 2 --package glass-mcp --output "$RUNNER_TEMP/mutants"
+        run: scripts/mutants.sh "$RUNNER_TEMP/mutants"
       - name: Upload the outcome
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,8 @@ perf.data.old
 # Coverage output (cargo-llvm-cov)
 *.profraw
 
-# cargo-mutants default output dir
-/mutants.out/
+# cargo-mutants default output dir (root or a crate subdirectory)
+mutants.out/
 
 # Editor / OS cruft
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ perf.data.old
 # Coverage output (cargo-llvm-cov)
 *.profraw
 
+# cargo-mutants default output dir
+/mutants.out/
+
 # Editor / OS cruft
 *.swp
 .DS_Store

--- a/crates/glass-mcp/src/smoke/checks.rs
+++ b/crates/glass-mcp/src/smoke/checks.rs
@@ -486,6 +486,29 @@ mod tests {
         assert!(out.detail.contains("image"), "got: {}", out.detail);
     }
 
+    /// Both dimensions are required. As `&&`, a response missing only one of them passed.
+    #[test]
+    fn screenshot_fails_when_either_dimension_is_missing() {
+        for result in [json!({ "width": 8 }), json!({ "height": 8 }), json!({})] {
+            let mut t = ScriptedTransport::new(vec![(
+                "glass_screenshot",
+                Ok(ok("glass_screenshot", result.clone(), &[], 1)),
+            )]);
+            let out = check_screenshot(&mut t);
+            assert_eq!(
+                out.status,
+                CheckStatus::Fail,
+                "must reject {result}: {}",
+                out.detail
+            );
+            assert!(
+                out.detail.contains("width/height"),
+                "must name the missing geometry: {}",
+                out.detail
+            );
+        }
+    }
+
     #[test]
     fn a11y_requires_a_nonempty_tree_in_an_untrusted_sibling() {
         let outline = "⟦untrusted:abc⟧\n#1 Window \"Untitled\"\n  #2 TextField \"Body\" [editable]\n⟦/untrusted:abc⟧";
@@ -715,6 +738,19 @@ mod tests {
         ];
         script.extend(tail);
         script
+    }
+
+    /// A fixed probe string could collide with text the app already shows, so each run gets a
+    /// distinct one carrying a recognizable prefix.
+    #[test]
+    fn probe_text_is_distinctive_and_fresh_each_call() {
+        let a = probe_text();
+        let b = probe_text();
+        assert!(a.starts_with("glass-smoke-"), "got: {a}");
+        assert_ne!(
+            a, b,
+            "a constant probe cannot distinguish what the run wrote"
+        );
     }
 
     #[test]
@@ -975,6 +1011,27 @@ mod tests {
         let out = check_logs(&mut t);
         assert_eq!(out.status, CheckStatus::Fail);
         assert!(out.detail.contains("lines"), "got: {}", out.detail);
+    }
+
+    #[test]
+    fn excerpt_returns_short_input_unchanged() {
+        assert_eq!(excerpt("short"), "short");
+    }
+
+    /// The boundary the `<=` decides: exactly MAX characters is not too long.
+    #[test]
+    fn excerpt_truncates_only_past_the_limit() {
+        let at_limit: String = "x".repeat(120);
+        assert_eq!(excerpt(&at_limit), at_limit);
+
+        let over = "x".repeat(121);
+        let cut = excerpt(&over);
+        assert!(cut.ends_with('…'), "must mark the truncation: {cut}");
+        assert_eq!(
+            cut.chars().count(),
+            121,
+            "120 kept plus the ellipsis: {cut}"
+        );
     }
 
     #[test]

--- a/crates/glass-mcp/src/smoke/client.rs
+++ b/crates/glass-mcp/src/smoke/client.rs
@@ -32,7 +32,7 @@ const STDERR_TAIL_LINES: usize = 20;
 /// child process. Process concerns — killing a hung server, collecting its stderr — belong to
 /// [`StdioClient`], which wraps this.
 #[derive(Debug)]
-pub struct Session<W: Write> {
+pub(super) struct Session<W: Write> {
     sink: W,
     /// Lines the reader thread has pulled off the server's stdout, oldest first.
     rx: Receiver<String>,
@@ -46,7 +46,7 @@ pub struct Session<W: Write> {
 }
 
 impl<W: Write> Session<W> {
-    pub fn new(sink: W, rx: Receiver<String>, timeout: Duration) -> Self {
+    pub(super) fn new(sink: W, rx: Receiver<String>, timeout: Duration) -> Self {
         Self {
             sink,
             rx,
@@ -57,7 +57,7 @@ impl<W: Write> Session<W> {
     }
 
     /// The version the server reported at `initialize`; `None` when it reported none.
-    pub fn server_version(&self) -> Option<String> {
+    pub(super) fn server_version(&self) -> Option<String> {
         self.version.clone()
     }
 
@@ -71,13 +71,13 @@ impl<W: Write> Session<W> {
             .map_err(|e| format!("flush to server: {e}"))
     }
 
-    pub fn notify(&mut self, method: &str, params: Value) -> Result<(), String> {
+    pub(super) fn notify(&mut self, method: &str, params: Value) -> Result<(), String> {
         self.send(&serde_json::json!({ "jsonrpc": "2.0", "method": method, "params": params }))
     }
 
     /// Send a request and wait for its matching response, bounded by `self.timeout` for the whole
     /// round trip. Killing the child on failure is the caller's job.
-    pub fn request(&mut self, method: &str, params: Value) -> Result<Value, String> {
+    pub(super) fn request(&mut self, method: &str, params: Value) -> Result<Value, String> {
         self.next_id += 1;
         let id = self.next_id;
         self.send(
@@ -86,7 +86,7 @@ impl<W: Write> Session<W> {
         wait_for_response(&self.rx, id, self.timeout).map_err(|e| format!("{method}: {e}"))
     }
 
-    pub fn initialize(&mut self) -> Result<(), String> {
+    pub(super) fn initialize(&mut self) -> Result<(), String> {
         let init = self.request(
             "initialize",
             serde_json::json!({
@@ -106,7 +106,7 @@ impl<W: Write> Session<W> {
         self.notify("notifications/initialized", serde_json::json!({}))
     }
 
-    pub fn call_tool(&mut self, tool: &str, args: Value) -> Result<CallResult, String> {
+    pub(super) fn call_tool(&mut self, tool: &str, args: Value) -> Result<CallResult, String> {
         let v = self.request(
             "tools/call",
             serde_json::json!({ "name": tool, "arguments": args }),
@@ -119,7 +119,7 @@ impl<W: Write> Session<W> {
 
     /// Test-only: recover the sink to assert on what was written.
     #[cfg(test)]
-    pub fn into_sink(self) -> W {
+    fn into_sink(self) -> W {
         self.sink
     }
 }
@@ -191,8 +191,9 @@ impl StdioClient {
         self.session.server_version()
     }
 
-    /// Kill the child and append its stderr on any session failure — a run that gives up on the
-    /// server must not leave it running unattended.
+    /// Kill the child, then append its stderr to `e`. Every session failure lands here — a
+    /// timeout, a closed pipe, or a JSON-RPC error response — so a single rejected call tears the
+    /// server down and the checks that follow will find it gone.
     fn on_failure(&mut self, e: String) -> String {
         self.kill_and_reap();
         let note = self.stderr_note();
@@ -319,7 +320,7 @@ impl McpTransport for StdioClient {
 
 impl Drop for StdioClient {
     fn drop(&mut self) {
-        // Idempotent even if `request` already did this on a timeout — see `kill_and_reap`.
+        // Idempotent even if `on_failure` already did this — see `kill_and_reap`.
         self.kill_and_reap();
         // The reader thread's blocked `read_line` returns only once the child's stdout write
         // end closes, which the kill+wait above guarantees — so this join must stay after it.
@@ -471,7 +472,8 @@ mod tests {
         s.request("first", serde_json::json!({})).expect("first");
         s.request("second", serde_json::json!({})).expect("second");
 
-        let sent = String::from_utf8(s.into_sink()).expect("utf8");
+        let raw = s.into_sink();
+        let sent = String::from_utf8_lossy(&raw);
         let ids: Vec<i64> = sent
             .lines()
             .filter_map(|l| serde_json::from_str::<Value>(l).ok())
@@ -489,7 +491,8 @@ mod tests {
         s.notify("notifications/initialized", serde_json::json!({}))
             .expect("notify");
 
-        let sent = String::from_utf8(s.into_sink()).expect("utf8");
+        let raw = s.into_sink();
+        let sent = String::from_utf8_lossy(&raw);
         let v: Value = serde_json::from_str(sent.trim()).expect("one json line");
         assert_eq!(v["method"], "notifications/initialized");
         assert!(
@@ -558,9 +561,10 @@ mod tests {
         let e = s
             .call_tool("glass_nope", serde_json::json!({}))
             .unwrap_err();
+        assert!(e.contains("glass_nope"), "must name the tool: {e}");
         assert!(
-            e.contains("glass_nope") && e.contains("no such tool"),
-            "got: {e}"
+            e.contains("no such tool"),
+            "must carry the server's message: {e}"
         );
     }
 }

--- a/crates/glass-mcp/src/smoke/client.rs
+++ b/crates/glass-mcp/src/smoke/client.rs
@@ -27,12 +27,107 @@ const CALL_TIMEOUT: Duration = Duration::from_secs(120);
 /// panic message or a degrade warning, bounded so a chatty server cannot grow it without limit.
 const STDERR_TAIL_LINES: usize = 20;
 
+/// The JSON-RPC half of the client: ids, framing, the initialize handshake, and tool calls.
+/// Generic over its sink so a test can drive it with an in-memory buffer and a channel, with no
+/// child process. Process concerns — killing a hung server, collecting its stderr — belong to
+/// [`StdioClient`], which wraps this.
+#[derive(Debug)]
+pub struct Session<W: Write> {
+    sink: W,
+    /// Lines the reader thread has pulled off the server's stdout, oldest first.
+    rx: Receiver<String>,
+    next_id: i64,
+    /// Never seeded from this binary's own `crate::VERSION`: client and server are the same
+    /// executable here, so a seeded value would look like something the server answered.
+    version: Option<String>,
+    /// Per-request deadline, fixed at `CALL_TIMEOUT` in production (`StdioClient::spawn`) and
+    /// overridable so tests can exercise the timeout path without a multi-minute wait.
+    timeout: Duration,
+}
+
+impl<W: Write> Session<W> {
+    pub fn new(sink: W, rx: Receiver<String>, timeout: Duration) -> Self {
+        Self {
+            sink,
+            rx,
+            next_id: 0,
+            version: None,
+            timeout,
+        }
+    }
+
+    /// The version the server reported at `initialize`; `None` when it reported none.
+    pub fn server_version(&self) -> Option<String> {
+        self.version.clone()
+    }
+
+    fn send(&mut self, msg: &Value) -> Result<(), String> {
+        let line = format!("{msg}\n");
+        self.sink
+            .write_all(line.as_bytes())
+            .map_err(|e| format!("write to server: {e}"))?;
+        self.sink
+            .flush()
+            .map_err(|e| format!("flush to server: {e}"))
+    }
+
+    pub fn notify(&mut self, method: &str, params: Value) -> Result<(), String> {
+        self.send(&serde_json::json!({ "jsonrpc": "2.0", "method": method, "params": params }))
+    }
+
+    /// Send a request and wait for its matching response, bounded by `self.timeout` for the whole
+    /// round trip. Killing the child on failure is the caller's job.
+    pub fn request(&mut self, method: &str, params: Value) -> Result<Value, String> {
+        self.next_id += 1;
+        let id = self.next_id;
+        self.send(
+            &serde_json::json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params }),
+        )?;
+        wait_for_response(&self.rx, id, self.timeout).map_err(|e| format!("{method}: {e}"))
+    }
+
+    pub fn initialize(&mut self) -> Result<(), String> {
+        let init = self.request(
+            "initialize",
+            serde_json::json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": { "name": "glass-smoke", "version": crate::VERSION }
+            }),
+        )?;
+        if init.get("result").is_none() {
+            return Err(format!("initialize failed: {init}"));
+        }
+        // A missing `serverInfo.version` is recorded, not fatal: no check asserts on it, so
+        // aborting here would throw away every check's evidence over a missing label.
+        self.version = init["result"]["serverInfo"]["version"]
+            .as_str()
+            .map(str::to_string);
+        self.notify("notifications/initialized", serde_json::json!({}))
+    }
+
+    pub fn call_tool(&mut self, tool: &str, args: Value) -> Result<CallResult, String> {
+        let v = self.request(
+            "tools/call",
+            serde_json::json!({ "name": tool, "arguments": args }),
+        )?;
+        if let Some(err) = v.get("error") {
+            return Err(format!("{tool}: JSON-RPC error {err}"));
+        }
+        Ok(CallResult::from_mcp(&v["result"]))
+    }
+
+    /// Test-only: recover the sink to assert on what was written.
+    #[cfg(test)]
+    pub fn into_sink(self) -> W {
+        self.sink
+    }
+}
+
 #[derive(Debug)]
 pub struct StdioClient {
     child: Child,
-    stdin: ChildStdin,
-    /// Lines the reader thread has pulled off the child's stdout, oldest first.
-    rx: Receiver<String>,
+    session: Session<ChildStdin>,
     /// Joined on drop so no thread outlives the client; `None` once joined.
     reader: Option<JoinHandle<()>>,
     /// The server's last stderr lines. Without these a degrade warning or a panic leaves
@@ -40,16 +135,6 @@ pub struct StdioClient {
     stderr_tail: Arc<Mutex<VecDeque<String>>>,
     /// Joined before the tail is read, so the tail includes the last thing the server said.
     stderr_reader: Option<JoinHandle<()>>,
-    next_id: i64,
-    /// What the server reported in `initialize`'s `serverInfo.version`, or `None` if it
-    /// reported none. Never seeded from this binary's own `crate::VERSION`: client and server
-    /// are the same executable here, so a seeded value would put a version in the report that
-    /// the server never actually answered with.
-    version: Option<String>,
-    /// Per-request deadline. Fixed at `CALL_TIMEOUT` in production
-    /// (`spawn`); overridable so tests can exercise the timeout path without
-    /// a multi-minute wait.
-    timeout: Duration,
 }
 
 impl StdioClient {
@@ -90,76 +175,28 @@ impl StdioClient {
         let stderr_reader = Some(spawn_stderr_reader(stderr, stderr_tail.clone())?);
         let mut c = Self {
             child,
-            stdin,
-            rx,
+            session: Session::new(stdin, rx, timeout),
             reader,
             stderr_tail,
             stderr_reader,
-            next_id: 0,
-            version: None,
-            timeout,
         };
-        c.initialize()?;
-        Ok(c)
-    }
-
-    fn initialize(&mut self) -> Result<(), String> {
-        let init = self.request(
-            "initialize",
-            serde_json::json!({
-                "protocolVersion": "2024-11-05",
-                "capabilities": {},
-                "clientInfo": { "name": "glass-smoke", "version": crate::VERSION }
-            }),
-        )?;
-        if init.get("result").is_none() {
-            return Err(format!("initialize failed: {init}"));
+        if let Err(e) = c.session.initialize() {
+            return Err(c.on_failure(e));
         }
-        // A missing `serverInfo.version` is recorded, not fatal: no check asserts on it, so
-        // aborting here would throw away every check's evidence over a missing label.
-        self.version = init["result"]["serverInfo"]["version"]
-            .as_str()
-            .map(str::to_string);
-        self.notify("notifications/initialized", serde_json::json!({}))
+        Ok(c)
     }
 
     /// The version the server reported at `initialize`; `None` when it reported none.
     pub fn server_version(&self) -> Option<String> {
-        self.version.clone()
+        self.session.server_version()
     }
 
-    fn send(&mut self, msg: &Value) -> Result<(), String> {
-        let line = format!("{msg}\n");
-        self.stdin
-            .write_all(line.as_bytes())
-            .map_err(|e| format!("write to server: {e}"))?;
-        self.stdin
-            .flush()
-            .map_err(|e| format!("flush to server: {e}"))
-    }
-
-    fn notify(&mut self, method: &str, params: Value) -> Result<(), String> {
-        self.send(&serde_json::json!({ "jsonrpc": "2.0", "method": method, "params": params }))
-    }
-
-    /// Send a request and wait for its matching response, bounded by
-    /// `self.timeout` for the whole round trip. A timeout or a closed pipe
-    /// both kill the child before returning — a run that gives up on the
+    /// Kill the child and append its stderr on any session failure — a run that gives up on the
     /// server must not leave it running unattended.
-    fn request(&mut self, method: &str, params: Value) -> Result<Value, String> {
-        self.next_id += 1;
-        let id = self.next_id;
-        self.send(
-            &serde_json::json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params }),
-        )?;
-        match wait_for_response(&self.rx, id, self.timeout) {
-            Ok(v) => Ok(v),
-            Err(e) => {
-                self.kill_and_reap();
-                let note = self.stderr_note();
-                Err(format!("{method}: {e}{note}"))
-            }
-        }
+    fn on_failure(&mut self, e: String) -> String {
+        self.kill_and_reap();
+        let note = self.stderr_note();
+        format!("{e}{note}")
     }
 
     /// The tail of the server's stderr, as a suffix for a failure detail — empty when it
@@ -273,14 +310,10 @@ fn wait_for_response(rx: &Receiver<String>, id: i64, budget: Duration) -> Result
 
 impl McpTransport for StdioClient {
     fn call(&mut self, tool: &str, args: Value) -> Result<CallResult, String> {
-        let v = self.request(
-            "tools/call",
-            serde_json::json!({ "name": tool, "arguments": args }),
-        )?;
-        if let Some(err) = v.get("error") {
-            return Err(format!("{tool}: JSON-RPC error {err}"));
+        match self.session.call_tool(tool, args) {
+            Ok(r) => Ok(r),
+            Err(e) => Err(self.on_failure(e)),
         }
-        Ok(CallResult::from_mcp(&v["result"]))
     }
 }
 
@@ -422,6 +455,112 @@ mod tests {
             start.elapsed() < Duration::from_secs(5),
             "kill+reap of the child must not hang: {:?}",
             start.elapsed()
+        );
+    }
+
+    /// Ids must advance: a counter that goes backwards or stalls makes `wait_for_response`
+    /// match a stale reply, or never match at all.
+    #[test]
+    fn request_ids_advance_by_one() {
+        let (tx, rx) = mpsc::channel();
+        tx.send("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n".into())
+            .unwrap();
+        tx.send("{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{}}\n".into())
+            .unwrap();
+        let mut s = Session::new(Vec::new(), rx, Duration::from_secs(5));
+        s.request("first", serde_json::json!({})).expect("first");
+        s.request("second", serde_json::json!({})).expect("second");
+
+        let sent = String::from_utf8(s.into_sink()).expect("utf8");
+        let ids: Vec<i64> = sent
+            .lines()
+            .filter_map(|l| serde_json::from_str::<Value>(l).ok())
+            .filter_map(|v| v.get("id").and_then(Value::as_i64))
+            .collect();
+        assert_eq!(ids, vec![1, 2], "sent: {sent}");
+    }
+
+    /// A notification is a message with no id. Returning Ok without writing one means the
+    /// server never hears it.
+    #[test]
+    fn notify_writes_a_message_with_no_id() {
+        let (_tx, rx) = mpsc::channel();
+        let mut s = Session::new(Vec::new(), rx, Duration::from_secs(5));
+        s.notify("notifications/initialized", serde_json::json!({}))
+            .expect("notify");
+
+        let sent = String::from_utf8(s.into_sink()).expect("utf8");
+        let v: Value = serde_json::from_str(sent.trim()).expect("one json line");
+        assert_eq!(v["method"], "notifications/initialized");
+        assert!(
+            v.get("id").is_none(),
+            "a notification carries no id: {sent}"
+        );
+    }
+
+    /// The version in the report must be what the server answered, not a default or a
+    /// stand-in — client and server are the same executable, so a seeded value would look right.
+    #[test]
+    fn initialize_captures_the_servers_reported_version() {
+        let (tx, rx) = mpsc::channel();
+        tx.send(
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"serverInfo\":{\"version\":\"9.9.9-test\"}}}\n"
+                .into(),
+        )
+        .unwrap();
+        let mut s = Session::new(Vec::new(), rx, Duration::from_secs(5));
+        s.initialize().expect("initialize");
+        assert_eq!(s.server_version().as_deref(), Some("9.9.9-test"));
+    }
+
+    #[test]
+    fn a_server_reporting_no_version_records_none_rather_than_failing() {
+        let (tx, rx) = mpsc::channel();
+        tx.send("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n".into())
+            .unwrap();
+        let mut s = Session::new(Vec::new(), rx, Duration::from_secs(5));
+        s.initialize()
+            .expect("a missing version is recorded, not fatal");
+        assert_eq!(s.server_version(), None);
+    }
+
+    /// `call_tool` must carry the tool's envelope through, not a default-constructed result —
+    /// every check reads what this returns.
+    #[test]
+    fn call_tool_returns_the_servers_envelope() {
+        let (tx, rx) = mpsc::channel();
+        tx.send(
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"{\\\"ok\\\":true,\\\"tool\\\":\\\"glass_stop\\\",\\\"result\\\":{}}\"}],\"isError\":false}}\n"
+                .into(),
+        )
+        .unwrap();
+        let mut s = Session::new(Vec::new(), rx, Duration::from_secs(5));
+        let r = s
+            .call_tool("glass_stop", serde_json::json!({}))
+            .expect("call");
+        assert_eq!(
+            r.envelope.as_ref().expect("envelope")["tool"],
+            serde_json::json!("glass_stop")
+        );
+    }
+
+    /// A JSON-RPC error is not a tool result; reading it as one would let a failed call be
+    /// graded as a pass.
+    #[test]
+    fn call_tool_rejects_a_json_rpc_error() {
+        let (tx, rx) = mpsc::channel();
+        tx.send(
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32601,\"message\":\"no such tool\"}}\n"
+                .into(),
+        )
+        .unwrap();
+        let mut s = Session::new(Vec::new(), rx, Duration::from_secs(5));
+        let e = s
+            .call_tool("glass_nope", serde_json::json!({}))
+            .unwrap_err();
+        assert!(
+            e.contains("glass_nope") && e.contains("no such tool"),
+            "got: {e}"
         );
     }
 }

--- a/crates/glass-mcp/src/smoke/client.rs
+++ b/crates/glass-mcp/src/smoke/client.rs
@@ -357,9 +357,8 @@ fn spawn_stderr_reader(
     })
 }
 
-/// Keep the newest [`STDERR_TAIL_LINES`] lines: push, then drop from the front when that puts
-/// the tail over the bound. Outside the reader thread's closure so a test can reach it — a wrong
-/// comparison here silently shrinks the tail that carries a server panic into a failure detail.
+/// Kept outside the reader thread's closure so a test can reach it — a wrong comparison here
+/// silently shrinks the tail that carries a server panic into a failure detail.
 fn push_bounded(tail: &mut VecDeque<String>, line: String) {
     tail.push_back(line);
     if tail.len() > STDERR_TAIL_LINES {
@@ -775,7 +774,7 @@ mod tests {
     #[cfg(unix)]
     const STUB_VERSION: &str = "7.7.7-stub";
 
-    /// A stub MCP server that answers `initialize`, answers one `tools/call` by running
+    /// A stub MCP server that answers `initialize`, answers every `tools/call` by running
     /// `on_call`, and exits when its stdin closes.
     #[cfg(unix)]
     fn stub_answering(on_call: &str) -> String {

--- a/crates/glass-mcp/src/smoke/client.rs
+++ b/crates/glass-mcp/src/smoke/client.rs
@@ -9,10 +9,16 @@
 //! writes another byte fails with "no response within Ns" instead of hanging
 //! the caller forever. `send`'s write to the child's stdin has no equivalent
 //! bound.
+//!
+//! Teardown is bounded the same way — it runs *because* something already went
+//! wrong, so a stall there costs the whole report rather than one check: the
+//! reader joins are bounded by [`READER_JOIN_TIMEOUT`], and a failed kill or
+//! reap is reported rather than discarded.
 
 use crate::smoke::transport::{CallResult, McpTransport};
 use serde_json::Value;
 use std::collections::VecDeque;
+use std::convert::Infallible;
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command, Stdio};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
@@ -22,6 +28,11 @@ use std::time::{Duration, Instant};
 
 /// A server that has not answered in this long is treated as hung.
 const CALL_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// How long teardown waits for a reader thread to exit before abandoning it: only something
+/// else still holding the child's write end — a grandchild, say — reaches this bound, and an
+/// unbounded join there hangs forever.
+const READER_JOIN_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// How many of the server's last stderr lines to keep for a failure detail: enough for a
 /// panic message or a degrade warning, bounded so a chatty server cannot grow it without limit.
@@ -117,10 +128,47 @@ impl<W: Write> Session<W> {
         Ok(CallResult::from_mcp(&v["result"]))
     }
 
+    /// Drop the receiving end of the reader thread's channel so its next `send` fails and it
+    /// returns — teardown only, and what stops a child that survived the kill and keeps writing
+    /// from filling a queue nobody will read.
+    fn disconnect(&mut self) {
+        let (_closed, rx) = mpsc::channel();
+        self.rx = rx;
+    }
+
     /// Test-only: recover the sink to assert on what was written.
     #[cfg(test)]
     fn into_sink(self) -> W {
         self.sink
+    }
+}
+
+/// A reader thread and a signal that it has exited. `JoinHandle::join` cannot be bounded, so the
+/// thread holds a sender it never sends on: the channel disconnects when the thread drops it on
+/// the way out, which turns an unbounded join into a `recv_timeout`.
+#[derive(Debug)]
+struct Reader {
+    /// Which pipe this thread drains, for the message a stalled join produces.
+    what: &'static str,
+    handle: JoinHandle<()>,
+    exited: Receiver<Infallible>,
+}
+
+impl Reader {
+    /// Join the thread, waiting at most `budget`; a thread still blocked in `read` at the
+    /// deadline is reported and abandoned, leaving its pipe open but returning control.
+    fn join_bounded(self, budget: Duration) -> Result<(), String> {
+        match self.exited.recv_timeout(budget) {
+            Ok(never) => match never {},
+            Err(RecvTimeoutError::Disconnected) => {
+                let _ = self.handle.join();
+                Ok(())
+            }
+            Err(RecvTimeoutError::Timeout) => Err(format!(
+                "the {} reader was still blocked after {budget:?} and was abandoned",
+                self.what
+            )),
+        }
     }
 }
 
@@ -129,12 +177,12 @@ pub struct StdioClient {
     child: Child,
     session: Session<ChildStdin>,
     /// Joined on drop so no thread outlives the client; `None` once joined.
-    reader: Option<JoinHandle<()>>,
+    reader: Option<Reader>,
     /// The server's last stderr lines. Without these a degrade warning or a panic leaves
     /// only "server closed stdout" or a silent timeout, with nothing saying why.
     stderr_tail: Arc<Mutex<VecDeque<String>>>,
     /// Joined before the tail is read, so the tail includes the last thing the server said.
-    stderr_reader: Option<JoinHandle<()>>,
+    stderr_reader: Option<Reader>,
 }
 
 impl StdioClient {
@@ -201,37 +249,49 @@ impl StdioClient {
     /// timeout, a closed pipe, or a JSON-RPC error response — so a single rejected call tears the
     /// server down and the checks that follow will find it gone.
     fn on_failure(&mut self, e: String) -> String {
-        self.kill_and_reap();
-        let note = self.stderr_note();
-        format!("{e}{note}")
+        let mut msg = e;
+        if let Err(t) = self.kill_and_reap() {
+            msg.push_str(&format!(" — {t}"));
+        }
+        msg.push_str(&self.stderr_note());
+        msg
     }
 
-    /// The tail of the server's stderr, as a suffix for a failure detail — empty when it
-    /// said nothing there. Call only after [`Self::kill_and_reap`]: with the child reaped its
-    /// stderr write end is closed, so joining the reader here is prompt and the tail includes
-    /// the last thing the server managed to say — typically the panic that killed it.
+    /// The tail of the server's stderr, as a suffix for a failure detail — empty when it said
+    /// nothing there and the reader shut down cleanly. Call only after [`Self::kill_and_reap`]:
+    /// with the child reaped its stderr write end is closed, so the join is prompt and the tail
+    /// includes the last thing the server managed to say — typically the panic that killed it.
+    /// A reader still blocked past the bound is named in the suffix, since the tail is then only
+    /// what happened to have arrived.
     fn stderr_note(&mut self) -> String {
-        if let Some(reader) = self.stderr_reader.take() {
-            let _ = reader.join();
+        let stalled = self
+            .stderr_reader
+            .take()
+            .and_then(|r| r.join_bounded(READER_JOIN_TIMEOUT).err());
+        let tail = self.stderr_tail.lock().ok().and_then(|t| {
+            (!t.is_empty()).then(|| t.iter().cloned().collect::<Vec<_>>().join(" ; "))
+        });
+        match (tail, stalled) {
+            (Some(t), None) => format!(" — server stderr: {t}"),
+            (Some(t), Some(w)) => format!(" — server stderr (partial, {w}): {t}"),
+            (None, Some(w)) => format!(" — no server stderr: {w}"),
+            (None, None) => String::new(),
         }
-        let Ok(tail) = self.stderr_tail.lock() else {
-            return String::new();
-        };
-        if tail.is_empty() {
-            return String::new();
-        }
-        format!(
-            " — server stderr: {}",
-            tail.iter().cloned().collect::<Vec<_>>().join(" ; ")
-        )
     }
 
-    /// Kill and reap the child. Safe to call more than once: `std::process::Child` caches
-    /// the exit status after a successful `wait` on Unix and holds a handle to one specific
-    /// kernel object on Windows, so a repeat `kill`/`wait` cannot signal a recycled pid.
-    fn kill_and_reap(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+    /// Kill and reap the child, reporting a failure rather than discarding it: every join in
+    /// teardown waits on a pipe this call closes. Safe to call more than once:
+    /// `std::process::Child` caches the exit status after a successful `wait` on Unix and holds
+    /// a handle to one specific kernel object on Windows, so a repeat `kill`/`wait` cannot
+    /// signal a recycled pid.
+    fn kill_and_reap(&mut self) -> Result<(), String> {
+        self.child
+            .kill()
+            .map_err(|e| format!("could not kill the server: {e}"))?;
+        self.child
+            .wait()
+            .map_err(|e| format!("could not reap the server: {e}"))?;
+        Ok(())
     }
 }
 
@@ -242,23 +302,42 @@ impl StdioClient {
 fn spawn_stdout_reader(
     mut stdout: BufReader<ChildStdout>,
     tx: Sender<String>,
-) -> Result<JoinHandle<()>, String> {
-    thread::Builder::new()
-        .name("smoke-stdout".into())
-        .spawn(move || {
-            loop {
-                let mut line = String::new();
-                match stdout.read_line(&mut line) {
-                    Ok(0) | Err(_) => return,
-                    Ok(_) => {
-                        if tx.send(line).is_err() {
-                            return; // the client was dropped; nothing left to feed
-                        }
+) -> Result<Reader, String> {
+    spawn_reader("stdout", move || {
+        loop {
+            let mut line = String::new();
+            match stdout.read_line(&mut line) {
+                Ok(0) | Err(_) => return,
+                Ok(_) => {
+                    if tx.send(line).is_err() {
+                        return; // the client was dropped; nothing left to feed
                     }
                 }
             }
+        }
+    })
+}
+
+/// Spawn a named reader thread wired to an exit signal, so [`Reader::join_bounded`] can bound a
+/// join that would otherwise wait on a `read` nothing guarantees will return.
+fn spawn_reader(
+    what: &'static str,
+    body: impl FnOnce() + Send + 'static,
+) -> Result<Reader, String> {
+    let (exit_tx, exited) = mpsc::channel::<Infallible>();
+    let handle = thread::Builder::new()
+        .name(format!("smoke-{what}"))
+        .spawn(move || {
+            // Moved in, never sent on: dropping it as this thread ends is the exit signal.
+            let _exit_tx = exit_tx;
+            body();
         })
-        .map_err(|e| format!("could not spawn the stdout-reader thread: {e}"))
+        .map_err(|e| format!("could not spawn the {what}-reader thread: {e}"))?;
+    Ok(Reader {
+        what,
+        handle,
+        exited,
+    })
 }
 
 /// Keeps the last [`STDERR_TAIL_LINES`] lines the server wrote to stderr. Draining the pipe
@@ -267,18 +346,15 @@ fn spawn_stdout_reader(
 fn spawn_stderr_reader(
     stderr: ChildStderr,
     tail: Arc<Mutex<VecDeque<String>>>,
-) -> Result<JoinHandle<()>, String> {
-    thread::Builder::new()
-        .name("smoke-stderr".into())
-        .spawn(move || {
-            for line in BufReader::new(stderr).lines().map_while(Result::ok) {
-                let Ok(mut tail) = tail.lock() else {
-                    return; // a poisoned lock means the client is already unwinding
-                };
-                push_bounded(&mut tail, line);
-            }
-        })
-        .map_err(|e| format!("could not spawn the stderr-reader thread: {e}"))
+) -> Result<Reader, String> {
+    spawn_reader("stderr", move || {
+        for line in BufReader::new(stderr).lines().map_while(Result::ok) {
+            let Ok(mut tail) = tail.lock() else {
+                return; // a poisoned lock means the client is already unwinding
+            };
+            push_bounded(&mut tail, line);
+        }
+    })
 }
 
 /// Keep the newest [`STDERR_TAIL_LINES`] lines: push, then drop from the front when that puts
@@ -333,16 +409,17 @@ impl McpTransport for StdioClient {
 
 impl Drop for StdioClient {
     fn drop(&mut self) {
-        // Idempotent even if `on_failure` already did this — see `kill_and_reap`.
-        self.kill_and_reap();
-        // The reader thread's blocked `read_line` returns only once the child's stdout write
-        // end closes, which the kill+wait above guarantees — so this join must stay after it.
-        if let Some(reader) = self.reader.take() {
-            let _ = reader.join();
-        }
-        // Same reasoning for the stderr reader; `stderr_note` may already have taken it.
-        if let Some(reader) = self.stderr_reader.take() {
-            let _ = reader.join();
+        // Idempotent even if `on_failure` already did this — see `kill_and_reap`. A `drop` has
+        // nowhere to report a failure, so the bounded joins below are what keep one from hanging.
+        let _ = self.kill_and_reap();
+        // A reader's blocked `read` returns once the child's write end closes, which the
+        // kill+reap above normally guarantees — so these joins must stay after it.
+        self.session.disconnect();
+        for reader in [self.reader.take(), self.stderr_reader.take()]
+            .into_iter()
+            .flatten()
+        {
+            let _ = reader.join_bounded(READER_JOIN_TIMEOUT);
         }
     }
 }
@@ -443,11 +520,10 @@ mod tests {
         );
     }
 
-    /// Spawns a real, indefinitely-running process (`yes`, a standard coreutil present on
-    /// every Unix this crate builds for) and drives it through `spawn_with_timeout` end to
-    /// end. Verifies the actual guarantee — that a timed-out request kills the child rather
-    /// than leaving it running — which `wait_for_response`'s unit tests cannot reach: they
-    /// never touch a real `Child`.
+    /// A handshake that times out against a real process which never exits and floods stdout
+    /// (`yes`, a standard coreutil present on every Unix this crate builds for), driven through
+    /// `spawn_with_timeout` end to end — a shape `wait_for_response`'s unit tests cannot reach,
+    /// since they never touch a `Child`.
     #[cfg(unix)]
     #[test]
     fn a_timed_out_request_kills_the_child() {
@@ -457,19 +533,65 @@ mod tests {
             &[],
             Duration::from_millis(100),
         )
-        .unwrap_err();
+        .expect_err("`yes` answers no JSON-RPC request");
         assert!(
             err.contains("no response within"),
             "expected a timeout, got {err}"
         );
-        // If `kill_and_reap` had not terminated `yes` (which never exits on its own), the
-        // `Child::wait` inside it would block for as long as `yes` keeps running. Finishing
-        // quickly is the evidence the child was really killed, not just that the deadline fired.
+        // The bound covers the whole failure path — deadline, kill, both reader joins — so it
+        // shows that path terminates, not that the child was reaped: a blocked reader costs
+        // `READER_JOIN_TIMEOUT` and no more. `a_timed_out_call_reaps_the_server` pins the reaping.
         assert!(
             start.elapsed() < Duration::from_secs(5),
-            "kill+reap of the child must not hang: {:?}",
+            "the failure path must stay bounded: {:?}",
             start.elapsed()
         );
+    }
+
+    /// Teardown must stop the reader thread feeding a channel nobody will read again: a child
+    /// that outlived the kill and keeps writing would otherwise grow the queue without bound.
+    #[test]
+    fn disconnect_closes_the_channel_the_reader_thread_sends_on() {
+        let (tx, rx) = mpsc::channel();
+        let mut s = Session::new(Vec::new(), rx, Duration::from_secs(5));
+        tx.send("before".to_string())
+            .expect("the reader can send while the session holds the receiver");
+        s.disconnect();
+        assert!(
+            tx.send("after".to_string()).is_err(),
+            "the reader must find the channel closed, which is what makes it return"
+        );
+    }
+
+    /// A thread still blocked in `read` must be reported and abandoned rather than waited out,
+    /// or the run produces no report at all.
+    #[test]
+    fn a_blocked_reader_is_reported_rather_than_waited_out() {
+        let (release, blocked) = mpsc::channel::<()>();
+        let reader = spawn_reader("test", move || {
+            let _ = blocked.recv(); // returns only when the test drops `release`
+        })
+        .expect("spawn the reader thread");
+        let start = Instant::now();
+        let err = reader
+            .join_bounded(Duration::from_millis(50))
+            .expect_err("a thread that never exits must not be joined");
+        assert!(err.contains("still blocked"), "got {err}");
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "the join must give up at its bound, not wait for the thread: {:?}",
+            start.elapsed()
+        );
+        drop(release);
+    }
+
+    /// The ordinary case: a reader whose pipe closed is joined, so no thread outlives the client.
+    #[test]
+    fn a_finished_reader_is_joined() {
+        let reader = spawn_reader("test", || {}).expect("spawn the reader thread");
+        reader
+            .join_bounded(Duration::from_secs(5))
+            .expect("a thread that has exited must join");
     }
 
     /// Ids must advance: a counter that goes backwards or stalls makes `wait_for_response`
@@ -658,9 +780,14 @@ exec sleep 10
     /// rationale as the glass-x11 and glass-ios fixture tests).
     #[cfg(unix)]
     fn spawn_stub(exe: &std::path::Path) -> StdioClient {
+        spawn_stub_with_timeout(exe, STUB_TIMEOUT)
+    }
+
+    #[cfg(unix)]
+    fn spawn_stub_with_timeout(exe: &std::path::Path, timeout: Duration) -> StdioClient {
         let mut last = None;
         for _ in 0..100 {
-            match StdioClient::spawn_with_timeout(exe, &[], STUB_TIMEOUT) {
+            match StdioClient::spawn_with_timeout(exe, &[], timeout) {
                 Err(m) if m.contains("Text file busy") => {
                     thread::sleep(Duration::from_millis(10));
                     last = Some(m);
@@ -736,6 +863,25 @@ exec sleep 10
             "must carry the server's stderr: {e}"
         );
         assert!(!pid_is_alive(pid), "pid {pid} survived a rejected call");
+    }
+
+    /// A call that times out must leave no server behind, which only the pid can show: with
+    /// teardown bounded, a surviving child costs `READER_JOIN_TIMEOUT` and no elapsed-time check
+    /// tells it apart. The stub answers nothing and spawns no grandchild, so it is still running
+    /// when the deadline fires and its pid is the only one in play.
+    #[cfg(unix)]
+    #[test]
+    fn a_timed_out_call_reaps_the_server() {
+        let (_dir, exe) = write_stub(&stub_answering("    :"));
+        let mut client = spawn_stub_with_timeout(&exe, Duration::from_millis(200));
+        let pid = client.child_id();
+        assert!(pid_is_alive(pid), "the stub must run before the call");
+
+        let e = client
+            .call("glass_stop", serde_json::json!({}))
+            .expect_err("a stub that never answers must time the call out");
+        assert!(e.contains("no response within"), "expected a timeout: {e}");
+        assert!(!pid_is_alive(pid), "pid {pid} survived a timed-out call");
     }
 
     /// Dropping the client must reap the server: a leaked one outlives the run and holds

--- a/crates/glass-mcp/src/smoke/client.rs
+++ b/crates/glass-mcp/src/smoke/client.rs
@@ -651,6 +651,32 @@ mod tests {
         assert_eq!(s.server_version().as_deref(), Some("9.9.9-test"));
     }
 
+    /// The handshake is not finished when the result arrives: an MCP client must follow it with
+    /// `notifications/initialized`. Dropping that line changes nothing this suite would otherwise
+    /// notice — the other initialize tests read only `server_version` — and cargo-mutants cannot
+    /// see it either, since it replaces whole function bodies rather than deleting statements.
+    #[test]
+    fn initialize_follows_the_result_with_the_initialized_notification() {
+        let (tx, rx) = mpsc::channel();
+        tx.send("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n".into())
+            .unwrap();
+        let mut s = Session::new(Vec::new(), rx, Duration::from_secs(5));
+        s.initialize().expect("initialize");
+
+        let raw = s.into_sink();
+        let sent = String::from_utf8_lossy(&raw);
+        let msgs: Vec<Value> = sent
+            .lines()
+            .map(|l| serde_json::from_str(l).expect("each line is one JSON message"))
+            .collect();
+        assert_eq!(msgs.len(), 2, "the request and the notification: {sent}");
+        assert_eq!(msgs[1]["method"], "notifications/initialized");
+        assert!(
+            msgs[1].get("id").is_none(),
+            "a notification carries no id: {sent}"
+        );
+    }
+
     #[test]
     fn a_server_reporting_no_version_records_none_rather_than_failing() {
         let (tx, rx) = mpsc::channel();
@@ -703,18 +729,45 @@ mod tests {
         );
     }
 
-    /// The tail keeps the LAST lines: a server that logs heavily before panicking must not
-    /// push its panic out of the buffer, and the bound must not collapse the tail.
+    /// The tail keeps the LAST lines: a server that logs heavily before panicking must not push
+    /// its panic out of the buffer. The counts are written out rather than derived from
+    /// [`STDERR_TAIL_LINES`] — a bound checked against itself holds at any value, including one
+    /// too small to carry anything useful.
     #[test]
     fn the_stderr_tail_keeps_the_last_lines_up_to_the_bound() {
         let mut tail = VecDeque::new();
-        for i in 0..(STDERR_TAIL_LINES + 5) {
+        for i in 0..25 {
             push_bounded(&mut tail, format!("line {i}"));
         }
-        let newest: Vec<String> = (5..STDERR_TAIL_LINES + 5)
-            .map(|i| format!("line {i}"))
-            .collect();
+        let newest: Vec<String> = (5..25).map(|i| format!("line {i}")).collect();
         assert_eq!(Vec::from(tail), newest);
+    }
+
+    /// What the tail is for: a server panic reaching the failure detail whole. A Rust panic is
+    /// three lines — the `panicked at` header, the message, and the backtrace note — so a bound
+    /// that keeps fewer still reports something, just never the cause.
+    #[test]
+    fn the_tail_carries_a_whole_panic_past_a_chatty_server() {
+        let panic_lines = [
+            "thread 'main' panicked at src/main.rs:1:1:",
+            "the server fell over",
+            "note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace",
+        ];
+        let mut tail = VecDeque::new();
+        for i in 0..50 {
+            push_bounded(&mut tail, format!("chatter {i}"));
+        }
+        for line in panic_lines {
+            push_bounded(&mut tail, line.to_string());
+        }
+
+        let kept = Vec::from(tail);
+        for line in panic_lines {
+            assert!(
+                kept.contains(&line.to_string()),
+                "the tail dropped {line:?}: {kept:?}"
+            );
+        }
     }
 
     /// What a stub server reports at `initialize` — unlike this crate's own version, which the

--- a/crates/glass-mcp/src/smoke/client.rs
+++ b/crates/glass-mcp/src/smoke/client.rs
@@ -191,6 +191,12 @@ impl StdioClient {
         self.session.server_version()
     }
 
+    /// The spawned server's pid, so a test can assert it was reaped.
+    #[cfg(all(test, unix))]
+    fn child_id(&self) -> u32 {
+        self.child.id()
+    }
+
     /// Kill the child, then append its stderr to `e`. Every session failure lands here — a
     /// timeout, a closed pipe, or a JSON-RPC error response — so a single rejected call tears the
     /// server down and the checks that follow will find it gone.
@@ -269,13 +275,20 @@ fn spawn_stderr_reader(
                 let Ok(mut tail) = tail.lock() else {
                     return; // a poisoned lock means the client is already unwinding
                 };
-                if tail.len() == STDERR_TAIL_LINES {
-                    tail.pop_front();
-                }
-                tail.push_back(line);
+                push_bounded(&mut tail, line);
             }
         })
         .map_err(|e| format!("could not spawn the stderr-reader thread: {e}"))
+}
+
+/// Keep the newest [`STDERR_TAIL_LINES`] lines: push, then drop from the front when that puts
+/// the tail over the bound. Outside the reader thread's closure so a test can reach it — a wrong
+/// comparison here silently shrinks the tail that carries a server panic into a failure detail.
+fn push_bounded(tail: &mut VecDeque<String>, line: String) {
+    tail.push_back(line);
+    if tail.len() > STDERR_TAIL_LINES {
+        tail.pop_front();
+    }
 }
 
 /// Waits on `rx` for a JSON-RPC message whose `id` matches, skipping
@@ -566,5 +579,180 @@ mod tests {
             e.contains("no such tool"),
             "must carry the server's message: {e}"
         );
+    }
+
+    /// The tail keeps the LAST lines: a server that logs heavily before panicking must not
+    /// push its panic out of the buffer, and the bound must not collapse the tail.
+    #[test]
+    fn the_stderr_tail_keeps_the_last_lines_up_to_the_bound() {
+        let mut tail = VecDeque::new();
+        for i in 0..(STDERR_TAIL_LINES + 5) {
+            push_bounded(&mut tail, format!("line {i}"));
+        }
+        let newest: Vec<String> = (5..STDERR_TAIL_LINES + 5)
+            .map(|i| format!("line {i}"))
+            .collect();
+        assert_eq!(Vec::from(tail), newest);
+    }
+
+    /// What a stub server reports at `initialize` — unlike this crate's own version, which the
+    /// client already holds and so could not be told apart from one the server answered.
+    #[cfg(unix)]
+    const STUB_VERSION: &str = "7.7.7-stub";
+
+    /// A stub MCP server that answers `initialize`, answers one `tools/call` by running
+    /// `on_call`, and exits when its stdin closes.
+    #[cfg(unix)]
+    fn stub_answering(on_call: &str) -> String {
+        format!(
+            r#"#!/bin/sh
+while IFS= read -r line; do
+  case "$line" in
+  *'"method":"initialize"'*)
+    printf '%s\n' '{{"jsonrpc":"2.0","id":1,"result":{{"serverInfo":{{"version":"{STUB_VERSION}"}}}}}}'
+    ;;
+  *'"method":"tools/call"'*)
+{on_call}
+    ;;
+  esac
+done
+"#
+        )
+    }
+
+    /// A stub MCP server that answers `initialize` and then stops reading its stdin: dropping
+    /// the client closes that pipe, so a stub still in `read` would exit on its own and a `Drop`
+    /// that reaps nothing would look correct. The `sleep` bounds how long a leaked child runs.
+    #[cfg(unix)]
+    fn stub_outliving_its_stdin() -> String {
+        format!(
+            r#"#!/bin/sh
+IFS= read -r line
+printf '%s\n' '{{"jsonrpc":"2.0","id":1,"result":{{"serverInfo":{{"version":"{STUB_VERSION}"}}}}}}'
+exec sleep 10
+"#
+        )
+    }
+
+    /// Writes `script` as an executable in a fresh temporary directory and returns both. The
+    /// caller must hold the directory: dropping it deletes the script, including while a
+    /// failing assertion unwinds.
+    #[cfg(unix)]
+    fn write_stub(script: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().expect("a temporary directory for the stub server");
+        let exe = dir.path().join("stub-server.sh");
+        std::fs::write(&exe, script).expect("write the stub server");
+        std::fs::set_permissions(&exe, std::fs::Permissions::from_mode(0o755))
+            .expect("make the stub server executable");
+        (dir, exe)
+    }
+
+    /// A stub answers in milliseconds; bounding the session well under `spawn`'s production
+    /// budget keeps a handshake that never completes a fast failure rather than a two-minute stall.
+    #[cfg(unix)]
+    const STUB_TIMEOUT: Duration = Duration::from_secs(5);
+
+    /// Spawn a stub server, retrying past a transient ETXTBSY: a sibling test thread's fork
+    /// can momentarily hold the freshly written script's fd open, racing our exec (same
+    /// rationale as the glass-x11 and glass-ios fixture tests).
+    #[cfg(unix)]
+    fn spawn_stub(exe: &std::path::Path) -> StdioClient {
+        let mut last = None;
+        for _ in 0..100 {
+            match StdioClient::spawn_with_timeout(exe, &[], STUB_TIMEOUT) {
+                Err(m) if m.contains("Text file busy") => {
+                    thread::sleep(Duration::from_millis(10));
+                    last = Some(m);
+                }
+                r => return r.expect("spawn the stub server"),
+            }
+        }
+        panic!("ETXTBSY persisted after 100 retries: {last:?}")
+    }
+
+    /// A reaped child is gone from the process table; a leaked one — running or a zombie —
+    /// still answers signal 0.
+    #[cfg(unix)]
+    fn pid_is_alive(pid: u32) -> bool {
+        std::process::Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .stderr(Stdio::null())
+            .status()
+            .expect("run kill -0")
+            .success()
+    }
+
+    /// The version in the report must be the one that came back over the wire: client and
+    /// server are the same executable in a real run, so only a spawned server reporting a
+    /// version nothing else holds can tell a relayed value from an invented one.
+    #[cfg(unix)]
+    #[test]
+    fn a_spawned_server_reports_the_version_it_sent() {
+        let (_dir, exe) = write_stub(&stub_answering("    :"));
+        let client = spawn_stub(&exe);
+        assert_eq!(client.server_version().as_deref(), Some(STUB_VERSION));
+    }
+
+    /// Every check grades what `call` returns, so it must carry the server's envelope out of
+    /// the process rather than anything the client could have built without asking.
+    #[cfg(unix)]
+    #[test]
+    fn a_spawned_server_call_returns_the_servers_envelope() {
+        let reply = r#"{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"{\"ok\":true,\"tool\":\"glass_stop\",\"result\":{\"stopped\":true}}"}],"isError":false}}"#;
+        let (_dir, exe) = write_stub(&stub_answering(&format!("    printf '%s\\n' '{reply}'")));
+        let mut client = spawn_stub(&exe);
+        let r = client
+            .call("glass_stop", serde_json::json!({}))
+            .expect("the stub answers the call");
+        assert_eq!(
+            r.envelope,
+            Some(serde_json::json!({
+                "ok": true, "tool": "glass_stop", "result": { "stopped": true }
+            }))
+        );
+    }
+
+    /// A JSON-RPC error response reaches `on_failure` like any other session failure, so it
+    /// tears the server down too — a contract no glass tool reaches today, and so one that
+    /// nothing but this test holds in place.
+    #[cfg(unix)]
+    #[test]
+    fn a_json_rpc_error_response_kills_the_server() {
+        let reply = r#"{"jsonrpc":"2.0","id":2,"error":{"code":-32601,"message":"no such tool"}}"#;
+        let on_call = format!(
+            "    printf '%s\\n' 'stub refused the call' >&2\n    printf '%s\\n' '{reply}'\n    exit 0"
+        );
+        let (_dir, exe) = write_stub(&stub_answering(&on_call));
+        let mut client = spawn_stub(&exe);
+        let pid = client.child_id();
+
+        let e = client
+            .call("glass_nope", serde_json::json!({}))
+            .unwrap_err();
+        assert!(e.contains("glass_nope"), "must name the tool: {e}");
+        assert!(
+            e.contains("stub refused the call"),
+            "must carry the server's stderr: {e}"
+        );
+        assert!(!pid_is_alive(pid), "pid {pid} survived a rejected call");
+    }
+
+    /// Dropping the client must reap the server: a leaked one outlives the run and holds
+    /// whatever the run was driving.
+    #[cfg(unix)]
+    #[test]
+    fn dropping_the_client_reaps_the_spawned_server() {
+        let (_dir, exe) = write_stub(&stub_outliving_its_stdin());
+        let client = spawn_stub(&exe);
+        let pid = client.child_id();
+        // Signal 0 must reach the stub while it still runs, or a pid that is not ours — one we
+        // may not signal, or that never existed — would read as reaped below.
+        assert!(
+            pid_is_alive(pid),
+            "the stub must run before the client is dropped"
+        );
+        drop(client);
+        assert!(!pid_is_alive(pid), "pid {pid} outlived the client");
     }
 }

--- a/crates/glass-mcp/src/smoke/mod.rs
+++ b/crates/glass-mcp/src/smoke/mod.rs
@@ -111,8 +111,7 @@ pub fn all_check_names() -> Vec<&'static str> {
     planned_rows().into_iter().map(|(_, name)| name).collect()
 }
 
-/// The step whose `detail` carries an unavailable app: `start` is the check that would hit
-/// the gap, and the one the how-to already sends a reader to when a run goes wrong.
+/// The step whose `detail` carries an unavailable app: `start` is the check that would hit the gap.
 const START_STEP: u8 = 1;
 
 /// `--dry-run`'s rows: every check a real run would produce, each a `skip` saying what it
@@ -451,6 +450,22 @@ mod tests {
             assert!(!candidates.is_empty(), "{name:?} has no candidate apps");
             assert!(seen.insert(*name), "{name:?} appears twice");
         }
+    }
+
+    /// The tests that loop over this list are only as good as the list. Emptying it makes every
+    /// such loop pass vacuously, so the list is pinned to the table it claims to render.
+    #[test]
+    fn drivable_backends_lists_every_row_of_the_table() {
+        let from_table: Vec<&str> = DRIVABLE.iter().map(|(name, _)| *name).collect();
+        assert_eq!(drivable_backends(), from_table);
+        assert!(
+            !drivable_backends().is_empty(),
+            "an empty list makes every loop over it vacuous"
+        );
+        assert!(
+            drivable_backends().iter().all(|b| !b.is_empty()),
+            "an empty name makes `contains` match anything"
+        );
     }
 
     /// `xed` heads both tables, so naming one candidate would not tell the two apart.

--- a/crates/glass-mcp/src/smoke/mod.rs
+++ b/crates/glass-mcp/src/smoke/mod.rs
@@ -452,20 +452,11 @@ mod tests {
         }
     }
 
-    /// The tests that loop over this list are only as good as the list. Emptying it makes every
-    /// such loop pass vacuously, so the list is pinned to the table it claims to render.
+    /// Pinned to [`DRIVABLE`] so emptying it can't make every loop over it pass vacuously.
     #[test]
     fn drivable_backends_lists_every_row_of_the_table() {
         let from_table: Vec<&str> = DRIVABLE.iter().map(|(name, _)| *name).collect();
         assert_eq!(drivable_backends(), from_table);
-        assert!(
-            !drivable_backends().is_empty(),
-            "an empty list makes every loop over it vacuous"
-        );
-        assert!(
-            drivable_backends().iter().all(|b| !b.is_empty()),
-            "an empty name makes `contains` match anything"
-        );
     }
 
     /// `xed` heads both tables, so naming one candidate would not tell the two apart.

--- a/crates/glass-mcp/src/smoke/mod.rs
+++ b/crates/glass-mcp/src/smoke/mod.rs
@@ -452,11 +452,11 @@ mod tests {
         }
     }
 
-    /// Pinned to [`DRIVABLE`] so emptying it can't make every loop over it pass vacuously.
+    /// Written out rather than derived from [`DRIVABLE`] — a list checked against itself pins
+    /// nothing, and would stay green both if a name changed and if the table were emptied.
     #[test]
     fn drivable_backends_lists_every_row_of_the_table() {
-        let from_table: Vec<&str> = DRIVABLE.iter().map(|(name, _)| *name).collect();
-        assert_eq!(drivable_backends(), from_table);
+        assert_eq!(drivable_backends(), ["x11", "wayland"]);
     }
 
     /// `xed` heads both tables, so naming one candidate would not tell the two apart.

--- a/crates/glass-mcp/src/smoke/profile.rs
+++ b/crates/glass-mcp/src/smoke/profile.rs
@@ -478,6 +478,7 @@ mod tests {
     #[test]
     fn parses_every_escape_sequence_it_claims_to_handle() {
         for (escape, decoded) in [
+            ("\\\"", "\""),
             ("\\\\", "\\"),
             ("\\n", "\n"),
             ("\\r", "\r"),

--- a/crates/glass-mcp/src/smoke/profile.rs
+++ b/crates/glass-mcp/src/smoke/profile.rs
@@ -473,6 +473,61 @@ mod tests {
         assert_eq!(nodes[0].states.len(), 2);
     }
 
+    /// Each escape the parser claims to decode, decoded. Deleting any one arm sends that
+    /// sequence to the passthrough branch, which emits the backslash literally.
+    #[test]
+    fn parses_every_escape_sequence_it_claims_to_handle() {
+        for (escape, decoded) in [
+            ("\\\\", "\\"),
+            ("\\n", "\n"),
+            ("\\r", "\r"),
+            ("\\t", "\t"),
+            ("\\0", "\0"),
+        ] {
+            let outline = format!("#1 Label \"a{escape}b\" (0,0 10x10)\n");
+            let nodes = parse_outline(&outline);
+            assert_eq!(
+                nodes.len(),
+                1,
+                "escape {escape:?} broke parsing: {outline:?}"
+            );
+            assert_eq!(
+                nodes[0].name.as_deref(),
+                Some(format!("a{decoded}b").as_str()),
+                "escape {escape:?} decoded wrongly"
+            );
+        }
+    }
+
+    /// The byte accumulator decides where the name ends, so a wrong one takes the remainder —
+    /// and with it the states — from the wrong offset.
+    #[test]
+    fn an_escaped_name_does_not_consume_the_states_that_follow_it() {
+        let outline = "#7 TextField \"a\\tb\" (0,0 10x10) [editable,focusable]\n";
+        let nodes = parse_outline(outline);
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].name.as_deref(), Some("a\tb"));
+        assert!(nodes[0].states.iter().any(|s| s == "editable"));
+        assert!(nodes[0].states.iter().any(|s| s == "focusable"));
+        assert_eq!(nodes[0].states.len(), 2);
+    }
+
+    /// `consumed_len`'s line runs for any escaped char, not just the five named ones, so a
+    /// multi-byte char after the backslash exercises it without touching a match arm: a short
+    /// prefix drives `-=` negative, a long one drives `*=` past the states it should measure.
+    #[test]
+    fn a_multibyte_passthrough_escape_leaves_the_byte_accumulator_correct() {
+        let short_prefix = "#9 Label \"\\\u{e9}b\" (0,0 10x10) [editable,focusable]\n";
+        let nodes = parse_outline(short_prefix);
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].states, vec!["editable", "focusable"]);
+
+        let long_prefix = "#9 Label \"xxxxxxxxxx\\\u{1f980}b\" (0,0 10x10) [editable,focusable]\n";
+        let nodes = parse_outline(long_prefix);
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].states, vec!["editable", "focusable"]);
+    }
+
     #[test]
     fn first_editable_uses_role_fallback_for_textfield() {
         let nodes = vec![OutlineNode {

--- a/crates/glass-mcp/src/smoke/selfcheck.rs
+++ b/crates/glass-mcp/src/smoke/selfcheck.rs
@@ -221,6 +221,7 @@ fn dropped_error_message_scenario() -> Scenario {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::smoke::report::CheckOutcome;
 
     #[test]
     fn every_injected_fault_is_caught() {
@@ -240,5 +241,57 @@ mod tests {
         );
         let err = s.names_an_assertion().unwrap_err();
         assert!(err.contains("unnamed assertion"), "got: {err}");
+    }
+
+    fn scenario(outcome: CheckOutcome, expect_detail: &'static str) -> Scenario {
+        Scenario {
+            name: "fixture",
+            outcome,
+            expect_detail,
+        }
+    }
+
+    #[test]
+    fn a_check_that_failed_for_the_named_reason_is_caught() {
+        let s = scenario(
+            CheckOutcome::fail(1, "start", "expected true, got false"),
+            "expected true",
+        );
+        assert!(s.caught());
+    }
+
+    /// `Fail`, but for the wrong reason — the status-only match the module header argues against.
+    #[test]
+    fn a_check_that_failed_for_another_reason_is_not_caught() {
+        let s = scenario(
+            CheckOutcome::fail(1, "start", "script exhausted"),
+            "expected true",
+        );
+        assert!(!s.caught());
+    }
+
+    /// A passing check has not been caught however well its detail reads.
+    #[test]
+    fn a_check_that_passed_is_not_caught() {
+        let s = scenario(
+            CheckOutcome::pass(1, "start", "expected true"),
+            "expected true",
+        );
+        assert!(!s.caught());
+    }
+
+    /// The Ok message is the only thing a caller sees on success, so it must state what was
+    /// actually exercised rather than an arbitrary string.
+    #[test]
+    fn the_success_message_names_how_many_faults_were_injected() {
+        let msg = run_self_check().expect("the shipped scenarios must all be caught");
+        assert!(
+            msg.contains("injected faults"),
+            "must say what it did: {msg}"
+        );
+        assert!(
+            msg.chars().any(|c| c.is_ascii_digit()),
+            "must state the count: {msg}"
+        );
     }
 }

--- a/crates/glass-mcp/src/smoke/selfcheck.rs
+++ b/crates/glass-mcp/src/smoke/selfcheck.rs
@@ -40,9 +40,15 @@ impl Scenario {
     }
 }
 
+/// How many faults [`run_self_check`] injects. Written out rather than read off the array, and
+/// annotated on it: a scenario dropped without this being changed with it is then a length
+/// mismatch the compiler rejects, rather than a self-check that reports success having injected
+/// one fewer. cargo-mutants does not mutate array literals, so no sweep would report that.
+const INJECTED_FAULTS: usize = 5;
+
 /// Faults, and the check that must catch each one — for the reason each is named after.
 pub fn run_self_check() -> Result<String, String> {
-    let scenarios = [
+    let scenarios: [Scenario; INJECTED_FAULTS] = [
         mutated_envelope_scenario(),
         untrusted_text_in_result_scenario(),
         noop_interaction_scenario(),
@@ -281,17 +287,14 @@ mod tests {
     }
 
     /// The Ok message is the only thing a caller sees on success, so it must state what was
-    /// actually exercised rather than an arbitrary string.
+    /// actually exercised. The count is written out rather than taken from [`INJECTED_FAULTS`]:
+    /// a count checked against its own source is equally true of "0 injected faults, all
+    /// caught", which is what an emptied scenario list would report.
     #[test]
     fn the_success_message_names_how_many_faults_were_injected() {
-        let msg = run_self_check().expect("the shipped scenarios must all be caught");
-        assert!(
-            msg.contains("injected faults"),
-            "must say what it did: {msg}"
-        );
-        assert!(
-            msg.chars().any(|c| c.is_ascii_digit()),
-            "must state the count: {msg}"
+        assert_eq!(
+            run_self_check().expect("the shipped scenarios must all be caught"),
+            "5 injected faults, all caught"
         );
     }
 }

--- a/crates/glass-mcp/src/smoke/selfcheck.rs
+++ b/crates/glass-mcp/src/smoke/selfcheck.rs
@@ -227,7 +227,6 @@ fn dropped_error_message_scenario() -> Scenario {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::smoke::report::CheckOutcome;
 
     #[test]
     fn every_injected_fault_is_caught() {

--- a/scripts/mutants.sh
+++ b/scripts/mutants.sh
@@ -31,11 +31,19 @@ shift
 # step with the git pathspec the in-diff caller uses.
 readonly SMOKE_GLOB='crates/glass-mcp/src/smoke/**/*.rs'
 
+# cargo-mutants derives its per-mutant timeout from the unmutated baseline, which never waits:
+# the teardown paths this module tests are only reached when something fails. A mutant that
+# removes the kill makes four tests each wait out `READER_JOIN_TIMEOUT`, measured at 42s where
+# the baseline takes 7s — so the derived timeout is always too tight, and the mutant is scored
+# TIMEOUT rather than caught. Fixed here so the grade does not depend on how fast the host is.
+readonly MUTANT_TIMEOUT=180
+
 status=0
 cargo mutants \
     --package glass-mcp \
     --file "$SMOKE_GLOB" \
     --cargo-arg=--locked \
+    --timeout "$MUTANT_TIMEOUT" \
     -j "${MUTANTS_JOBS:-2}" \
     --output "$out" \
     "$@" || status=$?

--- a/scripts/mutants.sh
+++ b/scripts/mutants.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Mutation-test the smoke module with cargo-mutants and grade the outcome.
+#
+# Why this wrapper rather than a bare `cargo mutants`: its exit code alone cannot
+# tell a clean run from one that gated nothing.
+#
+#   * It exits 0 whenever it generates no mutants at all — a diff that touches the
+#     module only inside `#[cfg(test)]`, a `--file` glob that stopped matching after
+#     a file moved, a package that was renamed. All three look like success.
+#   * It reports a timeout ahead of a missed mutant, so once any mutant times out a
+#     genuine survivor is invisible at the exit code.
+#
+# So this reads `outcomes.json`, prints the breakdown, and fails on a survivor, a
+# timeout, or a run that generated nothing.
+#
+# Usage:
+#   scripts/mutants.sh <output-dir> [extra cargo-mutants args...]
+#
+#   scripts/mutants.sh target/mutants                     # the whole module
+#   scripts/mutants.sh target/mutants --in-diff pr.diff   # only what a diff touched
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+    echo "usage: scripts/mutants.sh <output-dir> [cargo-mutants args...]" >&2
+    exit 2
+fi
+out=$1
+shift
+
+# `**` so a file moved into a subdirectory of the module stays covered; keep this in
+# step with the git pathspec the in-diff caller uses.
+readonly SMOKE_GLOB='crates/glass-mcp/src/smoke/**/*.rs'
+
+status=0
+cargo mutants \
+    --package glass-mcp \
+    --file "$SMOKE_GLOB" \
+    --cargo-arg=--locked \
+    -j "${MUTANTS_JOBS:-2}" \
+    --output "$out" \
+    "$@" || status=$?
+
+outcomes="$out/mutants.out/outcomes.json"
+if [ ! -f "$outcomes" ]; then
+    echo "mutants tested: 0 — cargo-mutants generated nothing and wrote no outcome."
+    echo "This run gated nothing. Check that --file still matches the files under test"
+    echo "and that the package still exists."
+    exit 1
+fi
+
+read -r total caught missed timed_out unviable < <(
+    jq -r '[.total_mutants, .caught, .missed, .timeout, .unviable] | @tsv' "$outcomes"
+)
+echo "mutants: $total generated, $caught caught, $missed missed, $timed_out timed out, $unviable unviable"
+
+if [ "$total" -eq 0 ]; then
+    echo "This run gated nothing. Check that --file still matches the files under test"
+    echo "and that the package still exists."
+    exit 1
+fi
+if [ "$missed" -gt 0 ]; then
+    echo "Survivors are listed in $out/mutants.out/missed.txt"
+    exit 1
+fi
+if [ "$timed_out" -gt 0 ]; then
+    echo "A timeout also masks any survivor at cargo-mutants' own exit code."
+    echo "Timed-out mutants are listed in $out/mutants.out/timeout.txt"
+    exit 1
+fi
+exit "$status"

--- a/scripts/mutants.sh
+++ b/scripts/mutants.sh
@@ -4,20 +4,29 @@
 # Why this wrapper rather than a bare `cargo mutants`: its exit code alone cannot
 # tell a clean run from one that gated nothing.
 #
-#   * It exits 0 whenever it generates no mutants at all — a diff that touches the
-#     module only inside `#[cfg(test)]`, a `--file` glob that stopped matching after
-#     a file moved, a package that was renamed. All three look like success.
+#   * It exits 0 whenever it generates no mutants at all — a `--file` glob that
+#     stopped matching after a file moved, or a package that was renamed. Both
+#     look exactly like success.
 #   * It reports a timeout ahead of a missed mutant, so once any mutant times out a
 #     genuine survivor is invisible at the exit code.
 #
 # So this reads `outcomes.json`, prints the breakdown, and fails on a survivor, a
-# timeout, or a run that generated nothing.
+# timeout, or a run that gated nothing.
+#
+# The one legitimate way to generate no mutants is a diff that changes only test
+# code. That must not fail — but it must not pass unchecked either, because
+# deleting the test that kills a survivor brings the survivor back while the diff
+# itself contains nothing to mutate. So a `--in-diff` run that yields nothing falls
+# back to mutating the whole of each file the diff touched.
 #
 # Usage:
 #   scripts/mutants.sh <output-dir> [extra cargo-mutants args...]
 #
 #   scripts/mutants.sh target/mutants                     # the whole module
 #   scripts/mutants.sh target/mutants --in-diff pr.diff   # only what a diff touched
+#
+# MUTANTS_JOBS sets concurrency (default 2); `--jobs` cannot be passed through,
+# because cargo-mutants rejects it twice over.
 set -euo pipefail
 
 if [ "$#" -lt 1 ]; then
@@ -38,27 +47,73 @@ readonly SMOKE_GLOB='crates/glass-mcp/src/smoke/**/*.rs'
 # TIMEOUT rather than caught. Fixed here so the grade does not depend on how fast the host is.
 readonly MUTANT_TIMEOUT=180
 
-status=0
-cargo mutants \
-    --package glass-mcp \
-    --file "$SMOKE_GLOB" \
-    --cargo-arg=--locked \
-    --timeout "$MUTANT_TIMEOUT" \
-    -j "${MUTANTS_JOBS:-2}" \
-    --output "$out" \
-    "$@" || status=$?
+# The caller's `--in-diff` path, and the same argument list with it removed — the
+# fallback re-runs without it but must keep everything else, `--test-tool` included.
+diff_file=""
+passthrough=()
+skip_next=false
+for arg in "$@"; do
+    if [ "$skip_next" = true ]; then
+        diff_file=$arg
+        skip_next=false
+        continue
+    fi
+    case "$arg" in
+        --in-diff) skip_next=true ;;
+        --in-diff=*) diff_file=${arg#--in-diff=} ;;
+        *) passthrough+=("$arg") ;;
+    esac
+done
 
-outcomes="$out/mutants.out/outcomes.json"
-if [ ! -f "$outcomes" ]; then
-    echo "mutants tested: 0 — cargo-mutants generated nothing and wrote no outcome."
-    echo "This run gated nothing. Check that --file still matches the files under test"
-    echo "and that the package still exists."
-    exit 1
+total=0 caught=0 missed=0 timed_out=0 unviable=0 status=0
+
+# Run cargo-mutants into $1 with the remaining arguments, and read the outcome counts.
+# A missing outcomes.json means it generated nothing and wrote no report at all.
+attempt() {
+    local dir=$1
+    shift
+    status=0
+    cargo mutants \
+        --package glass-mcp \
+        --cargo-arg=--locked \
+        --timeout "$MUTANT_TIMEOUT" \
+        -j "${MUTANTS_JOBS:-2}" \
+        --output "$dir" \
+        "$@" || status=$?
+
+    local outcomes="$dir/mutants.out/outcomes.json"
+    if [ -f "$outcomes" ]; then
+        read -r total caught missed timed_out unviable < <(
+            jq -r '[.total_mutants, .caught, .missed, .timeout, .unviable] | @tsv' "$outcomes"
+        )
+    else
+        total=0 caught=0 missed=0 timed_out=0 unviable=0
+    fi
+}
+
+attempt "$out" --file "$SMOKE_GLOB" "$@"
+graded=$out
+
+if [ "$total" -eq 0 ] && [ -n "$diff_file" ] && [ -s "$diff_file" ]; then
+    # `+++ b/<path>` names each file the diff writes to; a deletion names /dev/null
+    # and drops out with the `.rs` filter.
+    mapfile -t touched < <(
+        sed -n 's|^+++ b/||p' "$diff_file" | grep -E '\.rs$' | sort -u
+    )
+    if [ "${#touched[@]}" -gt 0 ]; then
+        echo "The diff changed no mutable code — only tests, or only comments."
+        echo "Falling back to the whole of each file it touched, so a deleted test"
+        echo "cannot bring a survivor back unnoticed:"
+        printf '  %s\n' "${touched[@]}"
+        file_args=()
+        for f in "${touched[@]}"; do
+            file_args+=(--file "$f")
+        done
+        graded="$out-files"
+        attempt "$graded" "${file_args[@]}" ${passthrough[@]+"${passthrough[@]}"}
+    fi
 fi
 
-read -r total caught missed timed_out unviable < <(
-    jq -r '[.total_mutants, .caught, .missed, .timeout, .unviable] | @tsv' "$outcomes"
-)
 echo "mutants: $total generated, $caught caught, $missed missed, $timed_out timed out, $unviable unviable"
 
 if [ "$total" -eq 0 ]; then
@@ -67,12 +122,12 @@ if [ "$total" -eq 0 ]; then
     exit 1
 fi
 if [ "$missed" -gt 0 ]; then
-    echo "Survivors are listed in $out/mutants.out/missed.txt"
+    echo "Survivors are listed in $graded/mutants.out/missed.txt"
     exit 1
 fi
 if [ "$timed_out" -gt 0 ]; then
     echo "A timeout also masks any survivor at cargo-mutants' own exit code."
-    echo "Timed-out mutants are listed in $out/mutants.out/timeout.txt"
+    echo "Timed-out mutants are listed in $graded/mutants.out/timeout.txt"
     exit 1
 fi
 exit "$status"

--- a/scripts/mutants.sh
+++ b/scripts/mutants.sh
@@ -65,6 +65,15 @@ for arg in "$@"; do
     esac
 done
 
+# How many mutants a set of scope arguments yields, ignoring any `--shard` the caller
+# passed. Listing costs ~0.1s and builds nothing, so the "did this gate anything"
+# question is answered before a single mutant is compiled — and answered for the whole
+# run rather than for one shard, which may legitimately receive none.
+list_count() {
+    cargo mutants --list --package glass-mcp "$@" \
+        ${diff_file:+--in-diff "$diff_file"} 2>/dev/null | wc -l
+}
+
 total=0 caught=0 missed=0 timed_out=0 unviable=0 status=0
 
 # Run cargo-mutants into $1 with the remaining arguments, and read the outcome counts.
@@ -91,10 +100,13 @@ attempt() {
     fi
 }
 
-attempt "$out" --file "$SMOKE_GLOB" "$@"
-graded=$out
+# Choose the scope before building anything: the module glob, or — when the diff
+# changed only test code and so yields nothing to mutate — the whole of each file it
+# touched, so a deleted test cannot bring a survivor back unnoticed.
+scope=(--file "$SMOKE_GLOB")
+planned=$(list_count "${scope[@]}")
 
-if [ "$total" -eq 0 ] && [ -n "$diff_file" ] && [ -s "$diff_file" ]; then
+if [ "$planned" -eq 0 ] && [ -n "$diff_file" ] && [ -s "$diff_file" ]; then
     # `+++ b/<path>` names each file the diff writes to; a deletion names /dev/null
     # and drops out with the `.rs` filter.
     mapfile -t touched < <(
@@ -105,22 +117,30 @@ if [ "$total" -eq 0 ] && [ -n "$diff_file" ] && [ -s "$diff_file" ]; then
         echo "Falling back to the whole of each file it touched, so a deleted test"
         echo "cannot bring a survivor back unnoticed:"
         printf '  %s\n' "${touched[@]}"
-        file_args=()
+        scope=()
         for f in "${touched[@]}"; do
-            file_args+=(--file "$f")
+            scope+=(--file "$f")
         done
-        graded="$out-files"
-        attempt "$graded" "${file_args[@]}" ${passthrough[@]+"${passthrough[@]}"}
+        diff_file=""
+        planned=$(list_count "${scope[@]}")
     fi
 fi
 
-echo "mutants: $total generated, $caught caught, $missed missed, $timed_out timed out, $unviable unviable"
-
-if [ "$total" -eq 0 ]; then
-    echo "This run gated nothing. Check that --file still matches the files under test"
-    echo "and that the package still exists."
+if [ "$planned" -eq 0 ]; then
+    echo "This run would gate nothing: no mutants under the scope it was given."
+    echo "Check that --file still matches the files under test and that the package"
+    echo "still exists."
     exit 1
 fi
+echo "mutants planned across the whole run: $planned"
+
+attempt "$out" "${scope[@]}" ${diff_file:+--in-diff "$diff_file"} \
+    ${passthrough[@]+"${passthrough[@]}"}
+graded=$out
+
+# A shard may legitimately draw none of the planned mutants; the count above is what
+# proves the run as a whole gated something.
+echo "mutants: $total generated, $caught caught, $missed missed, $timed_out timed out, $unviable unviable"
 if [ "$missed" -gt 0 ]; then
     echo "Survivors are listed in $graded/mutants.out/missed.txt"
     exit 1


### PR DESCRIPTION
Adds a `cargo-mutants` gate over `crates/glass-mcp/src/smoke/` and fixes every mutant that survived it. The module went from **28 survivors to 0**.

## Why

A multi-lens review of the previous branch found six assertions that read correctly and could not fail for the reason they named — a substring matching the wrong clause, a probe conflating "no" with "don't know", a `.contains()` a duplicate map key satisfies, a clap-generated annotation supplying the match. One was introduced by the wave fixing the other five. Human review did not exhaust the class; a mechanical run found two more in fifteen minutes, including `smoke --self-check` reporting `5 injected faults, all caught` while its own verdict was broken.

## What lands

- **`Mutation gate (smoke · in-diff)`** on pull requests, mutating only the lines a PR touches so it stays affordable next to a 3-minute CI.
- **`Mutation sweep`**, a weekly full-module run, since the in-diff gate never sees untouched code.
- **`scripts/mutants.sh`**, which grades the outcome rather than trusting the exit code. `cargo mutants` exits 0 when it generates no mutants at all, and reports a timeout ahead of a missed mutant — so once anything times out, a real survivor is invisible. The script fails on a survivor, a timeout, *or* a run that gated nothing, and prints the count either way.
- **A `Session` seam in `client.rs`**, splitting the JSON-RPC half from the process half so the protocol is drivable from a unit test with an in-memory sink instead of only through the display-dependent end-to-end gates.
- **Bounded teardown.** `kill_and_reap` discarded both its `kill` and `wait` results, and every downstream `join()` terminated only if they took effect — so a server that could not be reaped made `smoke` hang forever producing no report. The joins are now bounded and a failed kill is surfaced rather than swallowed.
- Tests pinning the escape parser's five undocumented arms and its byte accumulator, `check_screenshot`'s geometry guard (as `&&` it passed a response missing `height`), `excerpt`'s truncation boundary, `probe_text`'s freshness, the self-check's own verdict, and the child actually being reaped.

## Verification

A complete sweep on the final tree: **229 generated, 192 caught, 0 missed, 0 timed out, 37 unviable.**

Every assertion added here was shown to fail — its target mutated with a change that compiles, the test confirmed red for the reason the assertion names, then restored.

Draft until CI is green on every job.