### PR TITLE
feat(smoke): drive the android backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ internal refactors, CI, or test-only changes.
   under the backend's headless sway and runs the same eight checks as `x11`. The target is launched
   with `GDK_BACKEND=wayland`, so a toolkit that cannot use the Wayland backend fails the launch
   rather than falling back to Xwayland.
+- `glass-mcp smoke --backend android` drives a stock app on a connected device or emulator,
+  reporting the same eight checks as the x11 and wayland runners. The target is a
+  `package/.Activity` component chosen from a small table rather than probed for; `--app` selects a
+  different one.
 
 ### Changed
 - `glass_start` on Android now fails on a `run` element it cannot use, instead of ignoring it.

--- a/crates/glass-android/src/avd.rs
+++ b/crates/glass-android/src/avd.rs
@@ -201,6 +201,11 @@ impl EmulatorRegistry {
     }
 }
 
+/// How long a booting emulator may take to reach `sys.boot_completed` when
+/// `GLASS_EMULATOR_BOOT_TIMEOUT_MS` is unset. Public because a client that waits out a boot has to
+/// outlast the budget granted here.
+pub const DEFAULT_BOOT_TIMEOUT_MS: u64 = 120_000;
+
 /// Boot the configured AVD headless and return the serial of the device that came up.
 /// Spawns the emulator detached, waits for a new device + `sys.boot_completed`, and
 /// errors (after killing the half-booted emulator) on timeout or spawn failure.
@@ -221,7 +226,7 @@ pub fn boot_avd(base: &Adb, get: &dyn Fn(&str) -> Option<String>) -> Result<Stri
 
     let timeout_ms: u64 = get("GLASS_EMULATOR_BOOT_TIMEOUT_MS")
         .and_then(|s| s.parse().ok())
-        .unwrap_or(120_000);
+        .unwrap_or(DEFAULT_BOOT_TIMEOUT_MS);
     let deadline = Instant::now() + Duration::from_millis(timeout_ms);
     loop {
         if let Ok(Some(status)) = child.try_wait() {

--- a/crates/glass-android/src/lib.rs
+++ b/crates/glass-android/src/lib.rs
@@ -25,7 +25,7 @@ mod target;
 pub use a11y::AndroidA11y;
 pub use a11y_service::{A11yServiceRegistry, ServiceA11y, a11y_apk};
 pub use agent::{AgentClient, AgentRegistry};
-pub use avd::EmulatorRegistry;
+pub use avd::{DEFAULT_BOOT_TIMEOUT_MS, EmulatorRegistry};
 pub use platform::AndroidPlatform;
 pub use target::{AdbTarget, AttachedDevice};
 

--- a/crates/glass-mcp/src/cli.rs
+++ b/crates/glass-mcp/src/cli.rs
@@ -107,7 +107,7 @@ pub enum Command {
         /// Write the JSON report to PATH (the text report always goes to stdout).
         #[arg(long, value_name = "PATH")]
         report: Option<PathBuf>,
-        /// Force a target app instead of probing for the first available one.
+        /// Force a target app instead of the one the backend would choose on its own.
         #[arg(long)]
         app: Option<String>,
         /// Prove the checks can fail: run them against injected faults, then exit. Runs
@@ -363,5 +363,24 @@ mod tests {
                 "the --backend description must name {b:?}: {help}"
             );
         }
+    }
+
+    /// This help outlived the probe it described. Not every backend probes — android's table is
+    /// resolved without one — so `--app` overrides a table position there, not a search. The claim
+    /// is what must stay out; the wording around it is free.
+    #[test]
+    fn the_app_help_does_not_claim_every_backend_probes() {
+        use clap::CommandFactory;
+        let cmd = Cli::command();
+        let smoke = cmd.find_subcommand("smoke").expect("smoke subcommand");
+        let arg = smoke
+            .get_arguments()
+            .find(|a| a.get_id() == "app")
+            .expect("--app argument");
+        let help = arg.get_help().expect("--app help").to_string();
+        assert!(
+            !help.contains("prob"),
+            "not every backend probes for a target app: {help}"
+        );
     }
 }

--- a/crates/glass-mcp/src/cli.rs
+++ b/crates/glass-mcp/src/cli.rs
@@ -101,7 +101,7 @@ pub enum Command {
     /// Drive glass's own MCP tools against a real app and report whether this build
     /// works. Experimental: not part of the stable tool surface.
     Smoke {
-        /// Backend to exercise. The smoke runner drives x11 and wayland.
+        /// Backend to exercise. The smoke runner drives x11, wayland and android.
         #[arg(long, default_value = crate::smoke::DEFAULT_BACKEND)]
         backend: String,
         /// Write the JSON report to PATH (the text report always goes to stdout).

--- a/crates/glass-mcp/src/smoke/checks.rs
+++ b/crates/glass-mcp/src/smoke/checks.rs
@@ -28,7 +28,7 @@ fn excerpt(s: &str) -> String {
 }
 
 /// The candidates this run did not select, as a line telling the caller how to choose one. Which
-/// candidates those are is decided in `smoke::profile_for`, where the resolution policy and the
+/// candidates those are is decided in `smoke::alternatives`, where the resolution policy and the
 /// search path are known; a backend with nothing to offer appends nothing at all.
 fn other_candidates(p: &Profile) -> Option<String> {
     (!p.alternatives.is_empty()).then(|| {
@@ -408,7 +408,7 @@ mod tests {
         }
     }
 
-    /// Offers nothing: what a run offers is `smoke::profile_for`'s decision, so a test that wants
+    /// Offers nothing: what a run offers is decided by `smoke::alternatives`, so a test that wants
     /// an offer states it.
     fn profile() -> Profile {
         Profile {
@@ -567,8 +567,8 @@ mod tests {
         );
     }
 
-    /// Only the launch gets the long budget: a five-minute hang is justified where a boot can happen
-    /// and nowhere else.
+    /// Only the launch gets the derived budget: waiting out a device boot on top of an ordinary
+    /// call is justified where a boot can happen and nowhere else.
     #[test]
     fn a_check_that_cannot_boot_a_device_uses_the_default_deadline() {
         let mut t = ScriptedTransport::new(vec![(

--- a/crates/glass-mcp/src/smoke/checks.rs
+++ b/crates/glass-mcp/src/smoke/checks.rs
@@ -37,15 +37,16 @@ pub fn check_start(t: &mut dyn McpTransport, p: &Profile) -> CheckOutcome {
     outcome(
         1,
         "start",
-        t.call("glass_start", args).and_then(|r| {
-            let result = check_envelope("glass_start", &r)?;
-            for field in ["x", "y", "width", "height"] {
-                if !result[field].is_number() {
-                    return Err(format!("glass_start returned no `{field}` in its geometry"));
+        t.call_with_deadline("glass_start", args, p.start_deadline)
+            .and_then(|r| {
+                let result = check_envelope("glass_start", &r)?;
+                for field in ["x", "y", "width", "height"] {
+                    if !result[field].is_number() {
+                        return Err(format!("glass_start returned no `{field}` in its geometry"));
+                    }
                 }
-            }
-            Ok(format!("{}x{}", result["width"], result["height"]))
-        }),
+                Ok(format!("{}x{}", result["width"], result["height"]))
+            }),
     )
 }
 
@@ -377,7 +378,8 @@ mod tests {
     use super::*;
     use crate::smoke::profile::{WAYLAND_CANDIDATES, X11_CANDIDATES};
     use crate::smoke::report::CheckStatus;
-    use crate::smoke::transport::{CallResult, ScriptedTransport};
+    use crate::smoke::transport::{CALL_TIMEOUT, CallResult, ScriptedTransport};
+    use std::time::Duration;
 
     fn ok(tool: &str, result: Value, siblings: &[&str], images: usize) -> CallResult {
         CallResult::ok(tool, result, siblings, images)
@@ -396,6 +398,7 @@ mod tests {
         Profile {
             backend: "x11".into(),
             app: &X11_CANDIDATES[3],
+            start_deadline: CALL_TIMEOUT,
         }
     }
 
@@ -403,6 +406,7 @@ mod tests {
         Profile {
             backend: "wayland".into(),
             app: &WAYLAND_CANDIDATES[0],
+            start_deadline: CALL_TIMEOUT,
         }
     }
 
@@ -457,6 +461,45 @@ mod tests {
         let _ = check_start(&mut t, &profile());
         let args = t.args_for("glass_start").expect("glass_start was called");
         assert!(args.get("env").is_none(), "got: {args}");
+    }
+
+    /// Check 1 is the only call that may wait out a device boot, and the profile is where that budget
+    /// is decided. A hardcoded deadline here would ignore it silently.
+    #[test]
+    fn start_is_called_with_the_profiles_deadline() {
+        let mut t = ScriptedTransport::new(vec![(
+            "glass_start",
+            Ok(CallResult::ok(
+                "glass_start",
+                json!({ "x": 0, "y": 0, "width": 8, "height": 6 }),
+                &[],
+                0,
+            )),
+        )]);
+        let mut p = profile();
+        p.start_deadline = Duration::from_secs(321);
+        let _ = check_start(&mut t, &p);
+        assert_eq!(
+            t.deadline_for("glass_start"),
+            Some(Duration::from_secs(321))
+        );
+    }
+
+    /// Only the launch gets the long budget: a five-minute hang is justified where a boot can happen
+    /// and nowhere else.
+    #[test]
+    fn a_check_that_cannot_boot_a_device_uses_the_default_deadline() {
+        let mut t = ScriptedTransport::new(vec![(
+            "glass_screenshot",
+            Ok(CallResult::ok(
+                "glass_screenshot",
+                json!({ "width": 8, "height": 6 }),
+                &[],
+                1,
+            )),
+        )]);
+        let _ = check_screenshot(&mut t);
+        assert_eq!(t.deadline_for("glass_screenshot"), Some(CALL_TIMEOUT));
     }
 
     #[test]

--- a/crates/glass-mcp/src/smoke/checks.rs
+++ b/crates/glass-mcp/src/smoke/checks.rs
@@ -27,20 +27,14 @@ fn excerpt(s: &str) -> String {
     format!("{}…", s.chars().take(MAX).collect::<String>())
 }
 
-/// The candidates this run did not select, as a line telling the caller how to choose one.
-/// Derived from the table rather than written per backend: prose that names a table drifts from it
-/// silently, and this is the only place a run without a probe can say what else exists.
+/// The candidates this run did not select, as a line telling the caller how to choose one. Which
+/// candidates those are is decided in `smoke::profile_for`, where the resolution policy and the
+/// search path are known; a backend with nothing to offer appends nothing at all.
 fn other_candidates(p: &Profile) -> Option<String> {
-    let others: Vec<&str> = p
-        .candidates
-        .iter()
-        .filter(|c| c.label != p.app.label)
-        .map(|c| c.label)
-        .collect();
-    (!others.is_empty()).then(|| {
+    (!p.alternatives.is_empty()).then(|| {
         format!(
             "other candidates: {} — select with --app",
-            others.join(", ")
+            p.alternatives.join(", ")
         )
     })
 }
@@ -396,7 +390,7 @@ pub fn check_stop(t: &mut dyn McpTransport) -> CheckOutcome {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::smoke::profile::{ANDROID_CANDIDATES, WAYLAND_CANDIDATES, X11_CANDIDATES};
+    use crate::smoke::profile::{WAYLAND_CANDIDATES, X11_CANDIDATES};
     use crate::smoke::report::CheckStatus;
     use crate::smoke::transport::{CALL_TIMEOUT, CallResult, ScriptedTransport};
     use std::time::Duration;
@@ -414,11 +408,13 @@ mod tests {
         }
     }
 
+    /// Offers nothing: what a run offers is `smoke::profile_for`'s decision, so a test that wants
+    /// an offer states it.
     fn profile() -> Profile {
         Profile {
             backend: "x11".into(),
             app: &X11_CANDIDATES[3],
-            candidates: &X11_CANDIDATES,
+            alternatives: vec![],
             start_deadline: CALL_TIMEOUT,
         }
     }
@@ -427,7 +423,7 @@ mod tests {
         Profile {
             backend: "wayland".into(),
             app: &WAYLAND_CANDIDATES[0],
-            candidates: &WAYLAND_CANDIDATES,
+            alternatives: vec![],
             start_deadline: CALL_TIMEOUT,
         }
     }
@@ -508,7 +504,7 @@ mod tests {
     }
 
     /// A failed launch is the only place a run tells the operator what else it could have driven,
-    /// because nothing probed for alternatives beforehand.
+    /// and the launch error it failed with has to survive alongside the offer.
     #[test]
     fn a_failed_start_names_the_candidates_it_did_not_try() {
         let mut t = ScriptedTransport::new(vec![(
@@ -517,6 +513,7 @@ mod tests {
         )]);
         let mut p = profile();
         p.app = &X11_CANDIDATES[0];
+        p.alternatives = vec!["gnome-text-editor", "zenity", "xterm"];
         let out = check_start(&mut t, &p);
         assert_eq!(out.status, CheckStatus::Fail);
         assert!(
@@ -534,32 +531,14 @@ mod tests {
         assert!(out.detail.contains("--app"), "must say how: {}", out.detail);
     }
 
-    /// The selected candidate is not an alternative to itself; offering it would send the operator
-    /// back to the run that just failed.
+    /// A run with nothing else to offer must append nothing: a dangling "other candidates:" reads
+    /// as an offer.
     #[test]
-    fn the_offer_excludes_the_candidate_the_run_selected() {
+    fn a_run_with_nothing_to_offer_appends_nothing() {
         let mut t = ScriptedTransport::new(vec![("glass_start", Err("boom".to_string()))]);
         let mut p = profile();
         p.app = &X11_CANDIDATES[0];
-        let out = check_start(&mut t, &p);
-        let (_, offered) = out
-            .detail
-            .split_once("other candidates: ")
-            .unwrap_or_else(|| panic!("must carry an offer: {}", out.detail));
-        assert!(
-            !offered.contains(X11_CANDIDATES[0].label),
-            "the failed candidate must not be offered again: {offered}"
-        );
-    }
-
-    /// A table with nothing else in it has nothing to offer, and a dangling "other candidates:" would
-    /// read as one.
-    #[test]
-    fn a_single_candidate_backend_offers_nothing() {
-        let mut t = ScriptedTransport::new(vec![("glass_start", Err("boom".to_string()))]);
-        let mut p = profile();
-        p.candidates = &X11_CANDIDATES[..1];
-        p.app = &X11_CANDIDATES[0];
+        p.alternatives = vec![];
         let out = check_start(&mut t, &p);
         assert_eq!(out.detail, "boom", "nothing to offer, so nothing appended");
     }
@@ -582,33 +561,6 @@ mod tests {
             !out.detail.contains("--app"),
             "a pass has no alternatives to offer: {}",
             out.detail
-        );
-    }
-
-    /// `label` and `bin` coincide in every candidate above, so a filter or map that used `bin`
-    /// where it meant `label` would still pass all of them. Android is the one table where the
-    /// two diverge, and the backend this whole feature exists for — nothing probes it, so a
-    /// mixed-up offer would ship silently and read out a raw component string instead of the
-    /// short name `--app` accepts.
-    #[test]
-    fn an_android_offer_names_the_label_operators_pass_not_the_component() {
-        let mut t = ScriptedTransport::new(vec![("glass_start", Err("boom".to_string()))]);
-        let mut p = profile();
-        p.backend = "android".into();
-        p.candidates = &ANDROID_CANDIDATES;
-        p.app = &ANDROID_CANDIDATES[0];
-        let out = check_start(&mut t, &p);
-        let (_, offered) = out
-            .detail
-            .split_once("other candidates: ")
-            .unwrap_or_else(|| panic!("must carry an offer: {}", out.detail));
-        assert!(
-            offered.contains(ANDROID_CANDIDATES[1].label),
-            "must offer the settings label: {offered}"
-        );
-        assert!(
-            !offered.contains(ANDROID_CANDIDATES[1].bin),
-            "must offer the short label, not the raw component string: {offered}"
         );
     }
 

--- a/crates/glass-mcp/src/smoke/checks.rs
+++ b/crates/glass-mcp/src/smoke/checks.rs
@@ -543,7 +543,8 @@ mod tests {
         assert_eq!(out.detail, "boom", "nothing to offer, so nothing appended");
     }
 
-    /// The offer belongs to failure. A passing launch must report geometry and nothing else.
+    /// The offer belongs to failure. A passing launch must report geometry and nothing else — from
+    /// a profile that has something to offer, or the assertion holds however the offer is scoped.
     #[test]
     fn a_successful_start_carries_no_offer() {
         let mut t = ScriptedTransport::new(vec![(
@@ -555,7 +556,9 @@ mod tests {
                 0,
             )),
         )]);
-        let out = check_start(&mut t, &profile());
+        let mut p = profile();
+        p.alternatives = vec!["gnome-text-editor", "zenity"];
+        let out = check_start(&mut t, &p);
         assert_eq!(out.status, CheckStatus::Pass);
         assert!(
             !out.detail.contains("--app"),

--- a/crates/glass-mcp/src/smoke/checks.rs
+++ b/crates/glass-mcp/src/smoke/checks.rs
@@ -27,6 +27,24 @@ fn excerpt(s: &str) -> String {
     format!("{}…", s.chars().take(MAX).collect::<String>())
 }
 
+/// The candidates this run did not select, as a line telling the caller how to choose one.
+/// Derived from the table rather than written per backend: prose that names a table drifts from it
+/// silently, and this is the only place a run without a probe can say what else exists.
+fn other_candidates(p: &Profile) -> Option<String> {
+    let others: Vec<&str> = p
+        .candidates
+        .iter()
+        .filter(|c| c.label != p.app.label)
+        .map(|c| c.label)
+        .collect();
+    (!others.is_empty()).then(|| {
+        format!(
+            "other candidates: {} — select with --app",
+            others.join(", ")
+        )
+    })
+}
+
 pub fn check_start(t: &mut dyn McpTransport, p: &Profile) -> CheckOutcome {
     let mut run = vec![Value::String(p.app.bin.to_string())];
     run.extend(p.app.args.iter().map(|a| Value::String((*a).to_string())));
@@ -34,20 +52,22 @@ pub fn check_start(t: &mut dyn McpTransport, p: &Profile) -> CheckOutcome {
     if !p.app.env.is_empty() {
         args["env"] = p.app.env.iter().copied().collect();
     }
-    outcome(
-        1,
-        "start",
-        t.call_with_deadline("glass_start", args, p.start_deadline)
-            .and_then(|r| {
-                let result = check_envelope("glass_start", &r)?;
-                for field in ["x", "y", "width", "height"] {
-                    if !result[field].is_number() {
-                        return Err(format!("glass_start returned no `{field}` in its geometry"));
-                    }
+    let launched = t
+        .call_with_deadline("glass_start", args, p.start_deadline)
+        .and_then(|r| {
+            let result = check_envelope("glass_start", &r)?;
+            for field in ["x", "y", "width", "height"] {
+                if !result[field].is_number() {
+                    return Err(format!("glass_start returned no `{field}` in its geometry"));
                 }
-                Ok(format!("{}x{}", result["width"], result["height"]))
-            }),
-    )
+            }
+            Ok(format!("{}x{}", result["width"], result["height"]))
+        })
+        .map_err(|e| match other_candidates(p) {
+            Some(offer) => format!("{e}; {offer}"),
+            None => e,
+        });
+    outcome(1, "start", launched)
 }
 
 pub fn check_health(t: &mut dyn McpTransport, p: &Profile) -> CheckOutcome {
@@ -398,6 +418,7 @@ mod tests {
         Profile {
             backend: "x11".into(),
             app: &X11_CANDIDATES[3],
+            candidates: &X11_CANDIDATES,
             start_deadline: CALL_TIMEOUT,
         }
     }
@@ -406,6 +427,7 @@ mod tests {
         Profile {
             backend: "wayland".into(),
             app: &WAYLAND_CANDIDATES[0],
+            candidates: &WAYLAND_CANDIDATES,
             start_deadline: CALL_TIMEOUT,
         }
     }
@@ -482,6 +504,84 @@ mod tests {
         assert_eq!(
             t.deadline_for("glass_start"),
             Some(Duration::from_secs(321))
+        );
+    }
+
+    /// A failed launch is the only place a run tells the operator what else it could have driven,
+    /// because nothing probed for alternatives beforehand.
+    #[test]
+    fn a_failed_start_names_the_candidates_it_did_not_try() {
+        let mut t = ScriptedTransport::new(vec![(
+            "glass_start",
+            Err("Error type 3: Activity class does not exist".to_string()),
+        )]);
+        let mut p = profile();
+        p.app = &X11_CANDIDATES[0];
+        let out = check_start(&mut t, &p);
+        assert_eq!(out.status, CheckStatus::Fail);
+        assert!(
+            out.detail.contains("Activity class does not exist"),
+            "the launch error must survive: {}",
+            out.detail
+        );
+        for other in ["gnome-text-editor", "zenity", "xterm"] {
+            assert!(
+                out.detail.contains(other),
+                "must offer {other}: {}",
+                out.detail
+            );
+        }
+        assert!(out.detail.contains("--app"), "must say how: {}", out.detail);
+    }
+
+    /// The selected candidate is not an alternative to itself; offering it would send the operator
+    /// back to the run that just failed.
+    #[test]
+    fn the_offer_excludes_the_candidate_the_run_selected() {
+        let mut t = ScriptedTransport::new(vec![("glass_start", Err("boom".to_string()))]);
+        let mut p = profile();
+        p.app = &X11_CANDIDATES[0];
+        let out = check_start(&mut t, &p);
+        let (_, offered) = out
+            .detail
+            .split_once("other candidates: ")
+            .unwrap_or_else(|| panic!("must carry an offer: {}", out.detail));
+        assert!(
+            !offered.contains(X11_CANDIDATES[0].label),
+            "the failed candidate must not be offered again: {offered}"
+        );
+    }
+
+    /// A table with nothing else in it has nothing to offer, and a dangling "other candidates:" would
+    /// read as one.
+    #[test]
+    fn a_single_candidate_backend_offers_nothing() {
+        let mut t = ScriptedTransport::new(vec![("glass_start", Err("boom".to_string()))]);
+        let mut p = profile();
+        p.candidates = &X11_CANDIDATES[..1];
+        p.app = &X11_CANDIDATES[0];
+        let out = check_start(&mut t, &p);
+        assert_eq!(out.detail, "boom", "nothing to offer, so nothing appended");
+    }
+
+    /// The offer belongs to failure. A passing launch must report geometry and nothing else.
+    #[test]
+    fn a_successful_start_carries_no_offer() {
+        let mut t = ScriptedTransport::new(vec![(
+            "glass_start",
+            Ok(CallResult::ok(
+                "glass_start",
+                json!({ "x": 0, "y": 0, "width": 8, "height": 6 }),
+                &[],
+                0,
+            )),
+        )]);
+        let out = check_start(&mut t, &profile());
+        assert_eq!(out.status, CheckStatus::Pass);
+        assert!(
+            !out.detail.contains("--app"),
+            "a pass has no alternatives to offer: {}",
+            out.detail
         );
     }
 

--- a/crates/glass-mcp/src/smoke/checks.rs
+++ b/crates/glass-mcp/src/smoke/checks.rs
@@ -396,7 +396,7 @@ pub fn check_stop(t: &mut dyn McpTransport) -> CheckOutcome {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::smoke::profile::{WAYLAND_CANDIDATES, X11_CANDIDATES};
+    use crate::smoke::profile::{ANDROID_CANDIDATES, WAYLAND_CANDIDATES, X11_CANDIDATES};
     use crate::smoke::report::CheckStatus;
     use crate::smoke::transport::{CALL_TIMEOUT, CallResult, ScriptedTransport};
     use std::time::Duration;
@@ -582,6 +582,33 @@ mod tests {
             !out.detail.contains("--app"),
             "a pass has no alternatives to offer: {}",
             out.detail
+        );
+    }
+
+    /// `label` and `bin` coincide in every candidate above, so a filter or map that used `bin`
+    /// where it meant `label` would still pass all of them. Android is the one table where the
+    /// two diverge, and the backend this whole feature exists for — nothing probes it, so a
+    /// mixed-up offer would ship silently and read out a raw component string instead of the
+    /// short name `--app` accepts.
+    #[test]
+    fn an_android_offer_names_the_label_operators_pass_not_the_component() {
+        let mut t = ScriptedTransport::new(vec![("glass_start", Err("boom".to_string()))]);
+        let mut p = profile();
+        p.backend = "android".into();
+        p.candidates = &ANDROID_CANDIDATES;
+        p.app = &ANDROID_CANDIDATES[0];
+        let out = check_start(&mut t, &p);
+        let (_, offered) = out
+            .detail
+            .split_once("other candidates: ")
+            .unwrap_or_else(|| panic!("must carry an offer: {}", out.detail));
+        assert!(
+            offered.contains(ANDROID_CANDIDATES[1].label),
+            "must offer the settings label: {offered}"
+        );
+        assert!(
+            !offered.contains(ANDROID_CANDIDATES[1].bin),
+            "must offer the short label, not the raw component string: {offered}"
         );
     }
 

--- a/crates/glass-mcp/src/smoke/client.rs
+++ b/crates/glass-mcp/src/smoke/client.rs
@@ -15,7 +15,7 @@
 //! reader joins are bounded by [`READER_JOIN_TIMEOUT`], and a failed kill or
 //! reap is reported rather than discarded.
 
-use crate::smoke::transport::{CallResult, McpTransport};
+use crate::smoke::transport::{CALL_TIMEOUT, CallResult, McpTransport};
 use serde_json::Value;
 use std::collections::VecDeque;
 use std::convert::Infallible;
@@ -25,9 +25,6 @@ use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
-
-/// A server that has not answered in this long is treated as hung.
-const CALL_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// How long teardown waits for a reader thread to exit before abandoning it: only something
 /// else still holding the child's write end — a grandchild, say — reaches this bound, and an
@@ -86,15 +83,25 @@ impl<W: Write> Session<W> {
         self.send(&serde_json::json!({ "jsonrpc": "2.0", "method": method, "params": params }))
     }
 
-    /// Send a request and wait for its matching response, bounded by `self.timeout` for the whole
+    /// Send a request and wait for its matching response, bounded by `deadline` for the whole
     /// round trip. Killing the child on failure is the caller's job.
-    pub(super) fn request(&mut self, method: &str, params: Value) -> Result<Value, String> {
+    pub(super) fn request_with_deadline(
+        &mut self,
+        method: &str,
+        params: Value,
+        deadline: Duration,
+    ) -> Result<Value, String> {
         self.next_id += 1;
         let id = self.next_id;
         self.send(
             &serde_json::json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params }),
         )?;
-        wait_for_response(&self.rx, id, self.timeout).map_err(|e| format!("{method}: {e}"))
+        wait_for_response(&self.rx, id, deadline).map_err(|e| format!("{method}: {e}"))
+    }
+
+    /// Bounded by `self.timeout`, the per-session default set at construction.
+    pub(super) fn request(&mut self, method: &str, params: Value) -> Result<Value, String> {
+        self.request_with_deadline(method, params, self.timeout)
     }
 
     pub(super) fn initialize(&mut self) -> Result<(), String> {
@@ -117,15 +124,28 @@ impl<W: Write> Session<W> {
         self.notify("notifications/initialized", serde_json::json!({}))
     }
 
-    pub(super) fn call_tool(&mut self, tool: &str, args: Value) -> Result<CallResult, String> {
-        let v = self.request(
+    pub(super) fn call_tool_with_deadline(
+        &mut self,
+        tool: &str,
+        args: Value,
+        deadline: Duration,
+    ) -> Result<CallResult, String> {
+        let v = self.request_with_deadline(
             "tools/call",
             serde_json::json!({ "name": tool, "arguments": args }),
+            deadline,
         )?;
         if let Some(err) = v.get("error") {
             return Err(format!("{tool}: JSON-RPC error {err}"));
         }
         Ok(CallResult::from_mcp(&v["result"]))
+    }
+
+    /// Test-only: `StdioClient` always supplies an explicit deadline via
+    /// `call_tool_with_deadline`, so nothing in production calls this any more.
+    #[cfg(test)]
+    pub(super) fn call_tool(&mut self, tool: &str, args: Value) -> Result<CallResult, String> {
+        self.call_tool_with_deadline(tool, args, self.timeout)
     }
 
     /// Drop the receiving end of the reader thread's channel so its next `send` fails and it
@@ -398,8 +418,13 @@ fn wait_for_response(rx: &Receiver<String>, id: i64, budget: Duration) -> Result
 }
 
 impl McpTransport for StdioClient {
-    fn call(&mut self, tool: &str, args: Value) -> Result<CallResult, String> {
-        match self.session.call_tool(tool, args) {
+    fn call_with_deadline(
+        &mut self,
+        tool: &str,
+        args: Value,
+        deadline: Duration,
+    ) -> Result<CallResult, String> {
+        match self.session.call_tool_with_deadline(tool, args, deadline) {
             Ok(r) => Ok(r),
             Err(e) => Err(self.on_failure(e)),
         }
@@ -921,6 +946,9 @@ exec sleep 10
     /// teardown bounded, a surviving child costs `READER_JOIN_TIMEOUT` and no elapsed-time check
     /// tells it apart. The stub answers nothing and spawns no grandchild, so it is still running
     /// when the deadline fires and its pid is the only one in play.
+    ///
+    /// Calls `call_with_deadline` directly rather than `call`: the trait's default always uses
+    /// the production `CALL_TIMEOUT`, so only an explicit deadline keeps this test fast.
     #[cfg(unix)]
     #[test]
     fn a_timed_out_call_reaps_the_server() {
@@ -930,7 +958,11 @@ exec sleep 10
         assert!(pid_is_alive(pid), "the stub must run before the call");
 
         let e = client
-            .call("glass_stop", serde_json::json!({}))
+            .call_with_deadline(
+                "glass_stop",
+                serde_json::json!({}),
+                Duration::from_millis(200),
+            )
             .expect_err("a stub that never answers must time the call out");
         assert!(e.contains("no response within"), "expected a timeout: {e}");
         assert!(!pid_is_alive(pid), "pid {pid} survived a timed-out call");

--- a/crates/glass-mcp/src/smoke/client.rs
+++ b/crates/glass-mcp/src/smoke/client.rs
@@ -925,6 +925,76 @@ exec sleep 10
         );
     }
 
+    /// `call_with_deadline`'s own contract, distinct from `call`'s: it must reach the server and
+    /// carry back what it answered, not a value built without asking. A body replaced by
+    /// `Ok(Default::default())` returns an envelope-less `Ok` and would pass `call`'s coverage
+    /// (which never touches this method) while going undetected here too if this test only
+    /// checked `is_ok()` — so it pins the actual envelope.
+    #[cfg(unix)]
+    #[test]
+    fn call_with_deadline_returns_the_servers_envelope() {
+        let reply = r#"{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"{\"ok\":true,\"tool\":\"glass_stop\",\"result\":{\"stopped\":true}}"}],"isError":false}}"#;
+        let (_dir, exe) = write_stub(&stub_answering(&format!("    printf '%s\\n' '{reply}'")));
+        let mut client = spawn_stub(&exe);
+        let r = client
+            .call_with_deadline("glass_stop", serde_json::json!({}), Duration::from_secs(5))
+            .expect("the stub answers the call");
+        assert_eq!(
+            r.envelope,
+            Some(serde_json::json!({
+                "ok": true, "tool": "glass_stop", "result": { "stopped": true }
+            }))
+        );
+    }
+
+    /// The deadline `call_with_deadline` is *given* governs, not the session's own configured
+    /// timeout: spawned with a 5s session timeout (`spawn_stub`'s `STUB_TIMEOUT`), a call whose
+    /// explicit deadline is a tenth of a second must time out at that tenth of a second, not wait
+    /// out the full 5s. A body that read `self.timeout` instead of `deadline` would pass this
+    /// slowly (5s) rather than fail it — the elapsed-time bound is what tells the two apart.
+    #[cfg(unix)]
+    #[test]
+    fn call_with_deadline_times_out_on_its_own_deadline_not_the_sessions() {
+        let (_dir, exe) = write_stub(&stub_answering("    :"));
+        let mut client = spawn_stub(&exe);
+        let start = Instant::now();
+        let e = client
+            .call_with_deadline(
+                "glass_stop",
+                serde_json::json!({}),
+                Duration::from_millis(100),
+            )
+            .expect_err("a stub that never answers must time out");
+        assert!(e.contains("no response within"), "expected a timeout: {e}");
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "a 100ms deadline must not wait out the session's 5s timeout: {:?}",
+            start.elapsed()
+        );
+    }
+
+    /// The mirror of the previous test, and the one that actually tells "honours its own
+    /// deadline" apart from "honours whichever of the two is shorter": spawned with a 100ms
+    /// session timeout, a call whose explicit deadline is 2s must still succeed against a stub
+    /// that answers after 300ms — past the session's own timeout, but well within the explicit
+    /// deadline. A body that blended or floored the deadline at the session's timeout would time
+    /// this call out; only reading the given deadline on its own lets it succeed.
+    #[cfg(unix)]
+    #[test]
+    fn call_with_deadline_is_not_shortened_by_the_sessions_own_timeout() {
+        let reply = r#"{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"{\"ok\":true,\"tool\":\"glass_stop\",\"result\":{}}"}],"isError":false}}"#;
+        let on_call = format!("    sleep 0.3\n    printf '%s\\n' '{reply}'");
+        let (_dir, exe) = write_stub(&stub_answering(&on_call));
+        let mut client = spawn_stub_with_timeout(&exe, Duration::from_millis(100));
+        let r = client
+            .call_with_deadline("glass_stop", serde_json::json!({}), Duration::from_secs(2))
+            .expect("a 2s deadline must outlast the session's own 100ms timeout");
+        assert_eq!(
+            r.envelope,
+            Some(serde_json::json!({ "ok": true, "tool": "glass_stop", "result": {} }))
+        );
+    }
+
     /// A JSON-RPC error response reaches `on_failure` like any other session failure, so it
     /// tears the server down too — a contract no glass tool reaches today, and so one that
     /// nothing but this test holds in place.

--- a/crates/glass-mcp/src/smoke/client.rs
+++ b/crates/glass-mcp/src/smoke/client.rs
@@ -141,9 +141,6 @@ impl<W: Write> Session<W> {
         Ok(CallResult::from_mcp(&v["result"]))
     }
 
-    /// Test-only: `StdioClient` always supplies an explicit deadline via
-    /// `call_tool_with_deadline`, so nothing in production calls this any more.
-    #[cfg(test)]
     pub(super) fn call_tool(&mut self, tool: &str, args: Value) -> Result<CallResult, String> {
         self.call_tool_with_deadline(tool, args, self.timeout)
     }
@@ -425,6 +422,17 @@ impl McpTransport for StdioClient {
         deadline: Duration,
     ) -> Result<CallResult, String> {
         match self.session.call_tool_with_deadline(tool, args, deadline) {
+            Ok(r) => Ok(r),
+            Err(e) => Err(self.on_failure(e)),
+        }
+    }
+
+    /// Overrides the trait's default rather than inheriting it, so a `Session` constructed with
+    /// its own timeout (the test seam that exercises the hang/timeout path without a real
+    /// multi-minute wait) still governs an un-deadlined call, exactly as it did before
+    /// `call_with_deadline` existed.
+    fn call(&mut self, tool: &str, args: Value) -> Result<CallResult, String> {
+        match self.session.call_tool(tool, args) {
             Ok(r) => Ok(r),
             Err(e) => Err(self.on_failure(e)),
         }
@@ -946,9 +954,6 @@ exec sleep 10
     /// teardown bounded, a surviving child costs `READER_JOIN_TIMEOUT` and no elapsed-time check
     /// tells it apart. The stub answers nothing and spawns no grandchild, so it is still running
     /// when the deadline fires and its pid is the only one in play.
-    ///
-    /// Calls `call_with_deadline` directly rather than `call`: the trait's default always uses
-    /// the production `CALL_TIMEOUT`, so only an explicit deadline keeps this test fast.
     #[cfg(unix)]
     #[test]
     fn a_timed_out_call_reaps_the_server() {
@@ -958,11 +963,7 @@ exec sleep 10
         assert!(pid_is_alive(pid), "the stub must run before the call");
 
         let e = client
-            .call_with_deadline(
-                "glass_stop",
-                serde_json::json!({}),
-                Duration::from_millis(200),
-            )
+            .call("glass_stop", serde_json::json!({}))
             .expect_err("a stub that never answers must time the call out");
         assert!(e.contains("no response within"), "expected a timeout: {e}");
         assert!(!pid_is_alive(pid), "pid {pid} survived a timed-out call");

--- a/crates/glass-mcp/src/smoke/mod.rs
+++ b/crates/glass-mcp/src/smoke/mod.rs
@@ -718,11 +718,21 @@ mod tests {
     }
 
     /// A reader has to know that android's table is not a fallback chain, and the only place the doc
-    /// can learn it is the renderer.
+    /// can learn it is the renderer. Checked per row rather than by substring anywhere in the table:
+    /// a `contains` over the whole table would still pass with the two `Resolution` arms' bodies
+    /// swapped, since both phrases would still appear somewhere, just on the wrong rows.
     #[test]
     fn the_rendered_table_says_how_each_backend_chooses() {
         let t = render_candidate_table();
-        assert!(t.contains("first runnable on `PATH`"), "{t}");
-        assert!(t.contains("the first row is the default"), "{t}");
+        let row = |name: &str| {
+            t.lines()
+                .find(|l| l.starts_with(&format!("| `{name}` |")))
+                .unwrap_or_else(|| panic!("no {name:?} row in {t}"))
+        };
+        assert!(
+            row("android").contains("the first row is the default"),
+            "{t}"
+        );
+        assert!(row("x11").contains("first runnable on `PATH`"), "{t}");
     }
 }

--- a/crates/glass-mcp/src/smoke/mod.rs
+++ b/crates/glass-mcp/src/smoke/mod.rs
@@ -130,15 +130,15 @@ fn backend_for(backend: &str) -> Result<&'static DrivableBackend, String> {
 /// up while the device is still within the budget glass granted it.
 const BOOT_BUDGET_DEFAULT_MS: u64 = 120_000;
 
-/// Extra budget beyond the device's boot, for the install-and-launch that follows it.
-const START_SLACK: Duration = Duration::from_secs(120);
-
 /// How long `glass_start` may take. Derived rather than chosen: a backend that may boot a device
 /// must outlast the device's own boot budget, or this client gives up before the boot it is
 /// waiting for can finish — and reports it as a launch failure, which is the hardest thing there
-/// is to diagnose from the report. A boot budget already inside `CALL_TIMEOUT` needs no slack
-/// added on top of it: the ordinary deadline already covers it. `get` is injected so the
-/// arithmetic is testable without touching the process environment.
+/// is to diagnose from the report. The addend is `CALL_TIMEOUT`, not a fraction of it: once the
+/// device is up, installing and launching the app is just an ordinary call, so it gets an
+/// ordinary call's worth of time on top of the whole boot budget — at every budget, not only
+/// above some threshold. That also means the result always exceeds `CALL_TIMEOUT`, so nothing
+/// has to clamp it back up for a small budget. `get` is injected so the arithmetic is testable
+/// without touching the process environment.
 fn start_deadline(b: &DrivableBackend, get: &dyn Fn(&str) -> Option<String>) -> Duration {
     if !b.boots_a_device {
         return CALL_TIMEOUT;
@@ -146,11 +146,7 @@ fn start_deadline(b: &DrivableBackend, get: &dyn Fn(&str) -> Option<String>) -> 
     let ms = get("GLASS_EMULATOR_BOOT_TIMEOUT_MS")
         .and_then(|v| v.trim().parse::<u64>().ok())
         .unwrap_or(BOOT_BUDGET_DEFAULT_MS);
-    let boot_budget = Duration::from_millis(ms);
-    if boot_budget < CALL_TIMEOUT {
-        return CALL_TIMEOUT;
-    }
-    boot_budget + START_SLACK
+    Duration::from_millis(ms) + CALL_TIMEOUT
 }
 
 /// The checks, in order, except `stop` (appended last). Envelope discipline is not among
@@ -791,7 +787,7 @@ mod tests {
         );
         assert_eq!(
             d,
-            Duration::from_millis(BOOT_BUDGET_DEFAULT_MS) + START_SLACK
+            Duration::from_millis(BOOT_BUDGET_DEFAULT_MS) + CALL_TIMEOUT
         );
     }
 
@@ -802,7 +798,7 @@ mod tests {
         let get = |k: &str| (k == "GLASS_EMULATOR_BOOT_TIMEOUT_MS").then(|| "600000".to_string());
         assert_eq!(
             start_deadline(android(), &get),
-            Duration::from_millis(600_000) + START_SLACK
+            Duration::from_millis(600_000) + CALL_TIMEOUT
         );
     }
 
@@ -814,18 +810,22 @@ mod tests {
             let get = |k: &str| (k == "GLASS_EMULATOR_BOOT_TIMEOUT_MS").then(|| v.to_string());
             assert_eq!(
                 start_deadline(android(), &get),
-                Duration::from_millis(BOOT_BUDGET_DEFAULT_MS) + START_SLACK,
+                Duration::from_millis(BOOT_BUDGET_DEFAULT_MS) + CALL_TIMEOUT,
                 "{v:?} must not shorten the deadline"
             );
         }
     }
 
-    /// A boot budget below the default must not drag the launch deadline below what every other call
-    /// already gets.
+    /// A boot budget smaller than one ordinary call still leaves a full ordinary call's worth of
+    /// time to install and launch after the boot completes — the addend is unconditional, not a
+    /// clamp that only engages above some threshold.
     #[test]
-    fn a_tiny_boot_budget_does_not_shrink_the_deadline_below_the_default() {
+    fn a_tiny_boot_budget_still_leaves_a_full_call_to_launch() {
         let get = |k: &str| (k == "GLASS_EMULATOR_BOOT_TIMEOUT_MS").then(|| "1".to_string());
-        assert_eq!(start_deadline(android(), &get), CALL_TIMEOUT);
+        assert_eq!(
+            start_deadline(android(), &get),
+            Duration::from_millis(1) + CALL_TIMEOUT
+        );
     }
 
     /// The reader is scoped to one variable: reading any name would let an unrelated setting move a

--- a/crates/glass-mcp/src/smoke/mod.rs
+++ b/crates/glass-mcp/src/smoke/mod.rs
@@ -275,6 +275,7 @@ fn run_with(opts: SmokeOptions, path: Option<&OsStr>) -> Result<SmokeReport, Str
     let p = Profile {
         backend: b.name.to_string(),
         app,
+        candidates: b.candidates,
         start_deadline: start_deadline(b, &|k| std::env::var(k).ok()),
     };
 

--- a/crates/glass-mcp/src/smoke/mod.rs
+++ b/crates/glass-mcp/src/smoke/mod.rs
@@ -22,7 +22,7 @@ use transport::CALL_TIMEOUT;
 pub struct SmokeOptions {
     /// Backend to exercise (see [`backend_for`] for the supported set).
     pub backend: String,
-    /// Force a specific candidate app instead of probing for the first one present on the host.
+    /// Drive this candidate instead of the one the backend's resolution would select.
     pub app: Option<String>,
     /// Print the plan and exit without calling anything.
     pub dry_run: bool,
@@ -125,10 +125,10 @@ fn backend_for(backend: &str) -> Result<&'static DrivableBackend, String> {
     })
 }
 
-/// The emulator boot budget glass applies when `GLASS_EMULATOR_BOOT_TIMEOUT_MS` is unset. Kept in
-/// step with the android backend's own default: a smaller value here would make this client give
-/// up while the device is still within the budget glass granted it.
-const BOOT_BUDGET_DEFAULT_MS: u64 = 120_000;
+/// The emulator boot budget glass applies when `GLASS_EMULATOR_BOOT_TIMEOUT_MS` is unset — the
+/// android backend's own constant, not a second copy of the number: a smaller value here would
+/// make this client give up while the device is still within the budget glass granted it.
+const BOOT_BUDGET_DEFAULT_MS: u64 = glass_android::DEFAULT_BOOT_TIMEOUT_MS;
 
 /// How long `glass_start` may take. Derived rather than chosen: a backend that may boot a device
 /// must outlast the device's own boot budget, or this client gives up before the boot it is
@@ -150,6 +150,37 @@ fn start_deadline(b: &DrivableBackend, get: &dyn Fn(&str) -> Option<String>) -> 
         .and_then(|v| v.parse::<u64>().ok())
         .unwrap_or(BOOT_BUDGET_DEFAULT_MS);
     Duration::from_millis(ms) + CALL_TIMEOUT
+}
+
+/// Everything a real run's calls read about the app under test, assembled where the backend row,
+/// its resolution policy and the search path are all in hand. Extracted from [`run_with`] because
+/// a real run spawns a server and no test reaches it: this is the last point at which a derived
+/// deadline and a derived offer can be checked against the backend they came from.
+fn profile_for(
+    b: &'static DrivableBackend,
+    app: &'static Candidate,
+    path: Option<&OsStr>,
+    get: &dyn Fn(&str) -> Option<String>,
+) -> Profile {
+    Profile {
+        backend: b.name.to_string(),
+        app,
+        alternatives: alternatives(b, app, path),
+        start_deadline: start_deadline(b, get),
+    }
+}
+
+/// The candidates a failed launch may offer to try instead. Filtered by the backend's own
+/// resolution, not by the selected label alone: under [`Resolution::OnPath`] this run probed, so
+/// offering a candidate that is not runnable here sends the operator to an `--app` that fails the
+/// same launch — a real run does not probe a forced app. Under [`Resolution::Preinstalled`]
+/// nothing was probed, so nothing is known absent.
+fn alternatives(b: &DrivableBackend, app: &Candidate, path: Option<&OsStr>) -> Vec<&'static str> {
+    b.candidates
+        .iter()
+        .filter(|c| c.label != app.label && profile::runnable(c, path, b.resolution))
+        .map(|c| c.label)
+        .collect()
 }
 
 /// The checks, in order, except `stop` (appended last). Envelope discipline is not among
@@ -272,12 +303,7 @@ fn run_with(opts: SmokeOptions, path: Option<&OsStr>) -> Result<SmokeReport, Str
         None => profile::resolve_app(b.candidates, path, b.resolution)
             .map_err(|e| e.blocking_error(b.candidates))?,
     };
-    let p = Profile {
-        backend: b.name.to_string(),
-        app,
-        candidates: b.candidates,
-        start_deadline: start_deadline(b, &|k| std::env::var(k).ok()),
-    };
+    let p = profile_for(b, app, path, &|k| std::env::var(k).ok());
 
     let exe = std::env::current_exe().map_err(|e| format!("cannot locate this binary: {e}"))?;
     // The spawned server resolves its own backend from `GLASS_BACKEND`, and `glass_doctor`
@@ -508,6 +534,13 @@ mod tests {
             None,
         )
         .unwrap_err();
+        // The branch, not just the backend name: the unknown-backend error also names what was
+        // asked for and carries the same drives clause, so dropping `ios` from `crate::BACKENDS`
+        // would leave this asserting about the wrong error.
+        assert!(
+            err.contains("no smoke candidates for backend"),
+            "must be the not-yet-drivable branch: {err}"
+        );
         assert!(
             err.contains("ios"),
             "must name the backend asked for: {err}"
@@ -524,7 +557,10 @@ mod tests {
     /// Nothing else requires a [`DRIVABLE`] name to be the canonical spelling `recognized_backend`
     /// returns. `("Wayland", …)` compiles, never matches the lookup below it, and conceals itself:
     /// the error prose and the CLI help test both read this table, so both go on calling a dead
-    /// row drivable while `--backend Wayland` errors.
+    /// row drivable while `--backend Wayland` errors. Nor does anything else require a row's
+    /// resolution to be reachable: a [`Resolution::Preinstalled`] row with an empty table resolves
+    /// to an error whose prose tells the caller to install something, on a backend where
+    /// installing is not the remedy.
     #[test]
     fn every_drivable_row_can_actually_be_resolved() {
         let mut seen = std::collections::BTreeSet::new();
@@ -537,25 +573,11 @@ mod tests {
             );
             assert!(
                 !b.candidates.is_empty(),
-                "{:?} has no candidate apps",
-                b.name
-            );
-            assert!(seen.insert(b.name), "{:?} appears twice", b.name);
-        }
-    }
-
-    /// Nothing else requires a row's resolution to be reachable: a `Preinstalled` row whose table is
-    /// empty resolves to an error whose prose tells the caller to install something, on a backend
-    /// where installing is not the remedy.
-    #[test]
-    fn every_drivable_row_has_a_candidate_its_policy_can_return() {
-        for b in DRIVABLE {
-            assert!(
-                !b.candidates.is_empty(),
                 "{:?} has no candidate for {:?} to return",
                 b.name,
                 b.resolution
             );
+            assert!(seen.insert(b.name), "{:?} appears twice", b.name);
         }
     }
 
@@ -843,6 +865,70 @@ mod tests {
             start_deadline(android(), &get),
             Duration::from_millis(1) + CALL_TIMEOUT
         );
+    }
+
+    /// What a real run drives with. A real run spawns a server, so no test reaches it — and a
+    /// profile built with a written-out deadline would leave every test, the lint gate and the
+    /// `#[ignore]`d gates green while a cold boot on a slow host reported itself as a failed launch.
+    #[test]
+    fn a_profile_carries_the_deadline_its_backend_derives() {
+        let android = profile_for(android(), &ANDROID_CANDIDATES[0], None, &|_| None);
+        assert!(
+            android.start_deadline > Duration::from_millis(BOOT_BUDGET_DEFAULT_MS),
+            "a launch that may boot a device must outlast the device's own budget: {:?}",
+            android.start_deadline
+        );
+
+        let (_dir, path) = host_with(&["zenity"]);
+        let x11 = backend_for("x11").expect("x11 must be drivable");
+        let x11 = profile_for(x11, &X11_CANDIDATES[2], Some(&path), &|_| None);
+        assert_eq!(
+            x11.start_deadline, CALL_TIMEOUT,
+            "a backend that launches into a running compositor waits out no boot"
+        );
+    }
+
+    /// The host the offer used to mislead on: only `zenity` and `xterm` are installed, so the run
+    /// selects `zenity` — and the two candidates ahead of it are ones this run's own probe just
+    /// found absent. Offering them sends the operator to an `--app` that fails the same launch,
+    /// because a real run does not probe a forced app.
+    #[test]
+    fn an_offer_from_a_probing_backend_names_only_what_is_installed() {
+        let (_dir, path) = host_with(&["zenity", "xterm"]);
+        let b = backend_for("x11").expect("x11 must be drivable");
+        let app = profile::resolve_app(b.candidates, Some(&path), b.resolution)
+            .expect("zenity is installed");
+        assert_eq!(app.label, "zenity", "the fixture must select a middle row");
+        let p = profile_for(b, app, Some(&path), &|_| None);
+        assert_eq!(p.alternatives, ["xterm"]);
+    }
+
+    /// Nothing probed the device, so nothing about it is known absent and every other row is worth
+    /// offering. `label` and `bin` diverge only on android, so this is also the one table where an
+    /// offer built from `bin` would read out a raw component string instead of the short name
+    /// `--app` accepts.
+    #[test]
+    fn an_offer_from_a_preinstalled_backend_names_every_other_row() {
+        let p = profile_for(android(), &ANDROID_CANDIDATES[0], None, &|_| None);
+        assert_eq!(
+            p.alternatives,
+            ["settings"],
+            "written out, because the component `settings` stands for is not what --app takes"
+        );
+    }
+
+    /// The selected candidate is not an alternative to itself; offering it would send the operator
+    /// back to the run that just failed. Both policies, because each builds its own list.
+    #[test]
+    fn an_offer_never_names_the_candidate_the_run_selected() {
+        let (_dir, path) = host_with(&["zenity", "xterm"]);
+        let b = backend_for("x11").expect("x11 must be drivable");
+        let p = profile_for(b, &X11_CANDIDATES[3], Some(&path), &|_| None);
+        assert_eq!(p.app.label, "xterm");
+        assert_eq!(p.alternatives, ["zenity"]);
+
+        let p = profile_for(android(), &ANDROID_CANDIDATES[1], None, &|_| None);
+        assert_eq!(p.alternatives, ["contacts"]);
     }
 
     /// The reader is scoped to one variable: reading any name would let an unrelated setting move a

--- a/crates/glass-mcp/src/smoke/mod.rs
+++ b/crates/glass-mcp/src/smoke/mod.rs
@@ -10,6 +10,7 @@ pub mod report;
 pub mod selfcheck;
 pub mod transport;
 
+use std::env::VarError;
 use std::ffi::OsStr;
 use std::time::Duration;
 
@@ -125,10 +126,14 @@ fn backend_for(backend: &str) -> Result<&'static DrivableBackend, String> {
     })
 }
 
-/// The emulator boot budget glass applies when `GLASS_EMULATOR_BOOT_TIMEOUT_MS` is unset — the
+/// The emulator boot budget glass applies when [`BOOT_BUDGET_VAR`] is unset — the
 /// android backend's own constant, not a second copy of the number: a smaller value here would
 /// make this client give up while the device is still within the budget glass granted it.
 const BOOT_BUDGET_DEFAULT_MS: u64 = glass_android::DEFAULT_BOOT_TIMEOUT_MS;
+
+/// What an operator raises to grant a slow host a longer boot. Read here and, independently, by
+/// `glass-android` itself, which is why both must derive the same number from it.
+const BOOT_BUDGET_VAR: &str = "GLASS_EMULATOR_BOOT_TIMEOUT_MS";
 
 /// How long `glass_start` may take. Derived rather than chosen: a backend that may boot a device
 /// must outlast the device's own boot budget, or this client gives up before the boot it is
@@ -136,20 +141,48 @@ const BOOT_BUDGET_DEFAULT_MS: u64 = glass_android::DEFAULT_BOOT_TIMEOUT_MS;
 /// is to diagnose from the report. The addend is `CALL_TIMEOUT`, not a fraction of it: once the
 /// device is up, installing and launching the app is just an ordinary call, so it gets an
 /// ordinary call's worth of time on top of the whole boot budget — at every budget, not only
-/// above some threshold. That also means the result always exceeds `CALL_TIMEOUT`, so nothing
-/// has to clamp it back up for a small budget. `get` is injected so the arithmetic is testable
-/// without touching the process environment.
-fn start_deadline(b: &DrivableBackend, get: &dyn Fn(&str) -> Option<String>) -> Duration {
+/// above some threshold. That also means the result is never below `CALL_TIMEOUT`, so nothing
+/// has to clamp it back up for a small budget. `get` and `warn` are injected so the arithmetic
+/// and what it reports are both testable without touching the process environment.
+fn start_deadline(
+    b: &DrivableBackend,
+    get: &dyn Fn(&str) -> Result<String, VarError>,
+    warn: &mut dyn FnMut(String),
+) -> Duration {
     if !b.boots_a_device {
         return CALL_TIMEOUT;
     }
-    // No `.trim()`: `glass-android` reads this same variable with a bare `.parse()`, so a
-    // whitespace-padded value is unreadable to the device too. Trimming here would derive a
-    // deadline from a boot budget the device itself fell back away from.
-    let ms = get("GLASS_EMULATOR_BOOT_TIMEOUT_MS")
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(BOOT_BUDGET_DEFAULT_MS);
+    // Parsed exactly as `glass-android` parses it — no `.trim()`, no wider grammar, non-UTF-8
+    // falling back too — so the two always wait out the same budget. Reading it more liberally
+    // here would derive a deadline from a budget the device itself fell back away from.
+    let ms = match get(BOOT_BUDGET_VAR) {
+        Ok(v) => match v.parse::<u64>() {
+            Ok(ms) => ms,
+            Err(_) => {
+                warn(unusable_boot_budget(&v));
+                BOOT_BUDGET_DEFAULT_MS
+            }
+        },
+        // Set, and unusable to both readers. `std::env::var(..).ok()` would report this as unset,
+        // which is the one thing it is not.
+        Err(VarError::NotUnicode(v)) => {
+            warn(unusable_boot_budget(&v.to_string_lossy()));
+            BOOT_BUDGET_DEFAULT_MS
+        }
+        Err(VarError::NotPresent) => BOOT_BUDGET_DEFAULT_MS,
+    };
     Duration::from_millis(ms) + CALL_TIMEOUT
+}
+
+/// What an operator who raised the boot budget and had it ignored has to be told: the value is
+/// unusable to the boot as well, so the longer wait they asked for is in effect nowhere. Silence
+/// here left a deliberately-raised budget indistinguishable from one never set.
+fn unusable_boot_budget(value: &str) -> String {
+    format!(
+        "warning: {BOOT_BUDGET_VAR} is set to {value:?}, which is not a whole number of \
+         milliseconds — using {BOOT_BUDGET_DEFAULT_MS} instead. glass's android backend reads \
+         this variable the same way, so the boot itself falls back to the same default."
+    )
 }
 
 /// Everything a real run's calls read about the app under test, assembled where the backend row,
@@ -160,13 +193,14 @@ fn profile_for(
     b: &'static DrivableBackend,
     app: &'static Candidate,
     path: Option<&OsStr>,
-    get: &dyn Fn(&str) -> Option<String>,
+    get: &dyn Fn(&str) -> Result<String, VarError>,
+    warn: &mut dyn FnMut(String),
 ) -> Profile {
     Profile {
         backend: b.name.to_string(),
         app,
         alternatives: alternatives(b, app, path),
-        start_deadline: start_deadline(b, get),
+        start_deadline: start_deadline(b, get, warn),
     }
 }
 
@@ -303,7 +337,9 @@ fn run_with(opts: SmokeOptions, path: Option<&OsStr>) -> Result<SmokeReport, Str
         None => profile::resolve_app(b.candidates, path, b.resolution)
             .map_err(|e| e.blocking_error(b.candidates))?,
     };
-    let p = profile_for(b, app, path, &|k| std::env::var(k).ok());
+    let p = profile_for(b, app, path, &|k| std::env::var(k), &mut |m| {
+        eprintln!("glass: {m}")
+    });
 
     let exe = std::env::current_exe().map_err(|e| format!("cannot locate this binary: {e}"))?;
     // The spawned server resolves its own backend from `GLASS_BACKEND`, and `glass_doctor`
@@ -794,19 +830,47 @@ mod tests {
         backend_for("android").expect("android must be drivable")
     }
 
+    /// An environment where nothing at all is set.
+    fn unset(_: &str) -> Result<String, VarError> {
+        Err(VarError::NotPresent)
+    }
+
+    /// An environment holding the boot budget and nothing else, answering as `std::env::var` does.
+    fn budget_of(v: &'static str) -> impl Fn(&str) -> Result<String, VarError> {
+        move |k| match k {
+            "GLASS_EMULATOR_BOOT_TIMEOUT_MS" => Ok(v.to_string()),
+            _ => Err(VarError::NotPresent),
+        }
+    }
+
+    /// The deadline together with everything deriving it warned about, so a test can assert on
+    /// both. A warning nobody can observe is one a test cannot require.
+    fn deadline_and_warnings(
+        b: &DrivableBackend,
+        get: &dyn Fn(&str) -> Result<String, VarError>,
+    ) -> (Duration, Vec<String>) {
+        let mut warnings = Vec::new();
+        let d = start_deadline(b, get, &mut |m| warnings.push(m));
+        (d, warnings)
+    }
+
+    fn deadline(b: &DrivableBackend, get: &dyn Fn(&str) -> Result<String, VarError>) -> Duration {
+        deadline_and_warnings(b, get).0
+    }
+
     /// A backend that launches into a compositor already running does not need to outlast a boot.
     #[test]
     fn a_backend_that_never_boots_a_device_keeps_the_default_deadline() {
         let x11 = backend_for("x11").expect("x11 must be drivable");
         assert!(!x11.boots_a_device);
-        assert_eq!(start_deadline(x11, &|_| None), CALL_TIMEOUT);
+        assert_eq!(deadline(x11, &unset), CALL_TIMEOUT);
     }
 
     /// The relationship the whole function exists for: a client deadline inside the device's own boot
     /// budget makes an ordinary cold boot look like a failed launch.
     #[test]
     fn a_booting_backend_outlasts_the_devices_own_boot_budget() {
-        let d = start_deadline(android(), &|_| None);
+        let d = deadline(android(), &unset);
         assert!(
             d > Duration::from_millis(BOOT_BUDGET_DEFAULT_MS),
             "a deadline inside the boot budget reports the boot as a launch failure: {d:?}"
@@ -817,15 +881,13 @@ mod tests {
         );
     }
 
-    /// Raising the device's budget must raise this one. Leaving it fixed would make the client give
-    /// up first at the exact moment an operator asked to wait longer.
+    /// Raising the device's budget must raise this one, and quietly: a warning on a value that was
+    /// honoured would train an operator to ignore the one that says it was not.
     #[test]
     fn raising_the_boot_budget_raises_the_deadline() {
-        let get = |k: &str| (k == "GLASS_EMULATOR_BOOT_TIMEOUT_MS").then(|| "600000".to_string());
-        assert_eq!(
-            start_deadline(android(), &get),
-            Duration::from_millis(600_000) + CALL_TIMEOUT
-        );
+        let (d, warnings) = deadline_and_warnings(android(), &budget_of("600000"));
+        assert_eq!(d, Duration::from_millis(600_000) + CALL_TIMEOUT);
+        assert_eq!(warnings, Vec::<String>::new());
     }
 
     /// An unreadable value is not a shorter budget: glass falls back to its own default, so this must
@@ -833,9 +895,8 @@ mod tests {
     #[test]
     fn an_unreadable_boot_budget_falls_back_to_the_default() {
         for v in ["", "   ", "soon", "-1", "12.5", "99999999999999999999"] {
-            let get = |k: &str| (k == "GLASS_EMULATOR_BOOT_TIMEOUT_MS").then(|| v.to_string());
             assert_eq!(
-                start_deadline(android(), &get),
+                deadline(android(), &budget_of(v)),
                 Duration::from_millis(BOOT_BUDGET_DEFAULT_MS) + CALL_TIMEOUT,
                 "{v:?} must not shorten the deadline"
             );
@@ -845,14 +906,79 @@ mod tests {
     /// `glass-android` parses this same variable with a bare `.parse()` — no `.trim()` — so a
     /// whitespace-padded value is unreadable to the device too. Trimming it here would derive a
     /// deadline from a boot budget the device itself fell back away from, the two silently
-    /// disagreeing about how long the boot may take.
+    /// disagreeing about how long the boot may take. The padding an operator cannot see is
+    /// exactly why the fallback has to announce itself.
     #[test]
     fn a_whitespace_padded_boot_budget_falls_back_to_the_default_like_glass_android() {
-        let get = |k: &str| (k == "GLASS_EMULATOR_BOOT_TIMEOUT_MS").then(|| " 600000 ".to_string());
+        let (d, warnings) = deadline_and_warnings(android(), &budget_of(" 600000 "));
         assert_eq!(
-            start_deadline(android(), &get),
+            d,
             Duration::from_millis(BOOT_BUDGET_DEFAULT_MS) + CALL_TIMEOUT
         );
+        assert_eq!(warnings.len(), 1, "got: {warnings:?}");
+    }
+
+    /// Falling back is right; falling back in silence is not. The operator who raised the budget
+    /// for a slow host otherwise cannot tell a value that was ignored from one never set — and the
+    /// boot is not getting it either, which is the part they have to hear.
+    #[test]
+    fn an_unreadable_boot_budget_says_so_rather_than_falling_back_in_silence() {
+        let (_, warnings) = deadline_and_warnings(android(), &budget_of("300s"));
+        let [w] = warnings.as_slice() else {
+            panic!("exactly one warning, got: {warnings:?}");
+        };
+        assert!(
+            w.contains("GLASS_EMULATOR_BOOT_TIMEOUT_MS"),
+            "must name the variable: {w}"
+        );
+        assert!(
+            w.contains("300s"),
+            "must quote the value it could not use: {w}"
+        );
+        assert!(
+            w.contains(&BOOT_BUDGET_DEFAULT_MS.to_string()),
+            "must name the budget used instead: {w}"
+        );
+        assert!(
+            w.contains("android backend reads this variable the same way"),
+            "must say the boot falls back too: {w}"
+        );
+    }
+
+    /// An unset variable is not a mistake — it is the ordinary case, and warning about it would
+    /// bury the warning that matters.
+    #[test]
+    fn an_unset_boot_budget_warns_about_nothing() {
+        let (_, warnings) = deadline_and_warnings(android(), &unset);
+        assert_eq!(warnings, Vec::<String>::new());
+    }
+
+    /// A value whose bytes are not UTF-8 is *set* — `std::env::var(..).ok()` reports it as unset,
+    /// which would leave an operator's garbled budget as silent as no budget at all.
+    #[test]
+    fn a_non_utf8_boot_budget_is_set_but_unusable_not_unset() {
+        let (d, warnings) =
+            deadline_and_warnings(android(), &|_| Err(VarError::NotUnicode(not_utf8())));
+        assert_eq!(
+            d,
+            Duration::from_millis(BOOT_BUDGET_DEFAULT_MS) + CALL_TIMEOUT,
+            "the value glass-android derives from it is the default"
+        );
+        assert_eq!(warnings.len(), 1, "got: {warnings:?}");
+    }
+
+    /// A value `std::env::var` would reject as `NotUnicode`, built per platform because a
+    /// non-UTF-8 environment value is spelled in bytes on one and in UTF-16 on the other.
+    #[cfg(unix)]
+    fn not_utf8() -> std::ffi::OsString {
+        use std::os::unix::ffi::OsStringExt;
+        std::ffi::OsString::from_vec(vec![0x33, 0x30, 0x30, 0x80])
+    }
+    #[cfg(windows)]
+    fn not_utf8() -> std::ffi::OsString {
+        use std::os::windows::ffi::OsStringExt;
+        // An unpaired surrogate: representable in a Windows environment block, not in UTF-8.
+        std::ffi::OsString::from_wide(&[0x33, 0x30, 0x30, 0xD800])
     }
 
     /// A boot budget smaller than one ordinary call still leaves a full ordinary call's worth of
@@ -860,9 +986,8 @@ mod tests {
     /// clamp that only engages above some threshold.
     #[test]
     fn a_tiny_boot_budget_still_leaves_a_full_call_to_launch() {
-        let get = |k: &str| (k == "GLASS_EMULATOR_BOOT_TIMEOUT_MS").then(|| "1".to_string());
         assert_eq!(
-            start_deadline(android(), &get),
+            deadline(android(), &budget_of("1")),
             Duration::from_millis(1) + CALL_TIMEOUT
         );
     }
@@ -872,7 +997,7 @@ mod tests {
     /// `#[ignore]`d gates green while a cold boot on a slow host reported itself as a failed launch.
     #[test]
     fn a_profile_carries_the_deadline_its_backend_derives() {
-        let android = profile_for(android(), &ANDROID_CANDIDATES[0], None, &|_| None);
+        let android = profile_for(android(), &ANDROID_CANDIDATES[0], None, &unset, &mut |_| ());
         assert!(
             android.start_deadline > Duration::from_millis(BOOT_BUDGET_DEFAULT_MS),
             "a launch that may boot a device must outlast the device's own budget: {:?}",
@@ -881,7 +1006,7 @@ mod tests {
 
         let (_dir, path) = host_with(&["zenity"]);
         let x11 = backend_for("x11").expect("x11 must be drivable");
-        let x11 = profile_for(x11, &X11_CANDIDATES[2], Some(&path), &|_| None);
+        let x11 = profile_for(x11, &X11_CANDIDATES[2], Some(&path), &unset, &mut |_| ());
         assert_eq!(
             x11.start_deadline, CALL_TIMEOUT,
             "a backend that launches into a running compositor waits out no boot"
@@ -899,7 +1024,7 @@ mod tests {
         let app = profile::resolve_app(b.candidates, Some(&path), b.resolution)
             .expect("zenity is installed");
         assert_eq!(app.label, "zenity", "the fixture must select a middle row");
-        let p = profile_for(b, app, Some(&path), &|_| None);
+        let p = profile_for(b, app, Some(&path), &unset, &mut |_| ());
         assert_eq!(p.alternatives, ["xterm"]);
     }
 
@@ -909,7 +1034,7 @@ mod tests {
     /// `--app` accepts.
     #[test]
     fn an_offer_from_a_preinstalled_backend_names_every_other_row() {
-        let p = profile_for(android(), &ANDROID_CANDIDATES[0], None, &|_| None);
+        let p = profile_for(android(), &ANDROID_CANDIDATES[0], None, &unset, &mut |_| ());
         assert_eq!(
             p.alternatives,
             ["settings"],
@@ -923,11 +1048,11 @@ mod tests {
     fn an_offer_never_names_the_candidate_the_run_selected() {
         let (_dir, path) = host_with(&["zenity", "xterm"]);
         let b = backend_for("x11").expect("x11 must be drivable");
-        let p = profile_for(b, &X11_CANDIDATES[3], Some(&path), &|_| None);
+        let p = profile_for(b, &X11_CANDIDATES[3], Some(&path), &unset, &mut |_| ());
         assert_eq!(p.app.label, "xterm");
         assert_eq!(p.alternatives, ["zenity"]);
 
-        let p = profile_for(android(), &ANDROID_CANDIDATES[1], None, &|_| None);
+        let p = profile_for(android(), &ANDROID_CANDIDATES[1], None, &unset, &mut |_| ());
         assert_eq!(p.alternatives, ["contacts"]);
     }
 
@@ -935,15 +1060,14 @@ mod tests {
     /// deadline nobody connected to it.
     #[test]
     fn the_deadline_reads_only_the_boot_budget_variable() {
-        let get = |k: &str| (k == "GLASS_EMULATOR_BOOT_TIMEOUT_MS").then(|| "600000".to_string());
-        let other = |_: &str| Some("600000".to_string());
+        let every_variable = |_: &str| Ok("600000".to_string());
         assert_ne!(
-            start_deadline(android(), &get),
-            start_deadline(android(), &|_| None)
+            deadline(android(), &budget_of("600000")),
+            deadline(android(), &unset)
         );
         assert_eq!(
-            start_deadline(android(), &other),
-            start_deadline(android(), &get)
+            deadline(android(), &every_variable),
+            deadline(android(), &budget_of("600000"))
         );
     }
 }

--- a/crates/glass-mcp/src/smoke/mod.rs
+++ b/crates/glass-mcp/src/smoke/mod.rs
@@ -29,8 +29,9 @@ pub struct SmokeOptions {
     pub dry_run: bool,
 }
 
-/// One backend the smoke runner drives. The resolution below, the errors it produces, the
-/// reference doc's table and `cli.rs`'s hand-written help all read this table.
+/// One backend the smoke runner drives. The resolution below, the errors it produces and the
+/// reference doc's rendered table all read this table; `cli.rs`'s hand-written help is tested
+/// against it.
 pub struct DrivableBackend {
     pub name: &'static str,
     pub candidates: &'static [Candidate],

--- a/crates/glass-mcp/src/smoke/mod.rs
+++ b/crates/glass-mcp/src/smoke/mod.rs
@@ -12,11 +12,11 @@ pub mod transport;
 
 use std::ffi::OsStr;
 
-use profile::{Candidate, Profile, WAYLAND_CANDIDATES, X11_CANDIDATES};
+use profile::{Candidate, Profile, Resolution, WAYLAND_CANDIDATES, X11_CANDIDATES};
 use report::{CheckOutcome, RunMode, SmokeReport, TargetApp};
 
 pub struct SmokeOptions {
-    /// Backend to exercise (see [`candidates_for`] for the supported set).
+    /// Backend to exercise (see [`backend_for`] for the supported set).
     pub backend: String,
     /// Force a specific candidate app instead of probing for the first one present on the host.
     pub app: Option<String>,
@@ -24,27 +24,53 @@ pub struct SmokeOptions {
     pub dry_run: bool,
 }
 
-/// Every backend the smoke runner drives, with its candidate apps: the resolution below and the
-/// errors it produces read this table, and `cli.rs`'s hand-written help is tested against it.
-const DRIVABLE: &[(&str, &[Candidate])] =
-    &[("x11", &X11_CANDIDATES), ("wayland", &WAYLAND_CANDIDATES)];
+/// One backend the smoke runner drives. The resolution below, the errors it produces, the
+/// reference doc's table and `cli.rs`'s hand-written help all read this table.
+pub struct DrivableBackend {
+    pub name: &'static str,
+    pub candidates: &'static [Candidate],
+    pub resolution: Resolution,
+    /// Whether a launch may boot a device first. Tracked separately from `resolution` because
+    /// they are different facts: an already-attached device needs no boot, and its target is
+    /// preinstalled either way.
+    pub boots_a_device: bool,
+}
+
+const DRIVABLE: &[DrivableBackend] = &[
+    DrivableBackend {
+        name: "x11",
+        candidates: &X11_CANDIDATES,
+        resolution: Resolution::OnPath,
+        boots_a_device: false,
+    },
+    DrivableBackend {
+        name: "wayland",
+        candidates: &WAYLAND_CANDIDATES,
+        resolution: Resolution::OnPath,
+        boots_a_device: false,
+    },
+];
 
 /// The drivable backend names, in table order, for a message that tells the caller what to pass.
 pub fn drivable_backends() -> Vec<&'static str> {
-    DRIVABLE.iter().map(|(name, _)| *name).collect()
+    DRIVABLE.iter().map(|b| b.name).collect()
 }
 
 /// What a bare `smoke` drives. Derived from the table so `--backend`'s clap default and the
 /// error telling a caller what to pass cannot name different backends.
-pub const DEFAULT_BACKEND: &str = DRIVABLE[0].0;
+pub const DEFAULT_BACKEND: &str = DRIVABLE[0].name;
 
 /// The reference doc's target-app table, rendered from [`DRIVABLE`]. A doc-sync test compares it
 /// against the checked-in markdown, so a candidate can't land in the code and not in the docs.
 pub fn render_candidate_table() -> String {
     let mut out = String::from("| Backend | Candidates, in probe order |\n|---|---|\n");
-    for (backend, candidates) in DRIVABLE {
-        let bins: Vec<String> = candidates.iter().map(|c| format!("`{}`", c.bin)).collect();
-        out.push_str(&format!("| `{backend}` | {} |\n", bins.join(", ")));
+    for b in DRIVABLE {
+        let bins: Vec<String> = b
+            .candidates
+            .iter()
+            .map(|c| format!("`{}`", c.bin))
+            .collect();
+        out.push_str(&format!("| `{}` | {} |\n", b.name, bins.join(", ")));
     }
     out
 }
@@ -54,10 +80,10 @@ pub fn render_candidate_table() -> String {
 const DRIVES_CLAUSE: &str = "the smoke runner drives: ";
 
 /// Resolve `--backend` through [`crate::recognized_backend`] — the crate's single
-/// backend-recognition predicate — and return the canonical name alongside its candidate apps.
-/// Keying the table off what that returns is what stops `smoke --backend X11` being rejected
-/// while `GLASS_BACKEND=X11` is honoured everywhere else in the binary.
-fn candidates_for(backend: &str) -> Result<(&'static str, &'static [Candidate]), String> {
+/// backend-recognition predicate — and return the row. Keying the table off what that returns is
+/// what stops `smoke --backend X11` being rejected while `GLASS_BACKEND=X11` is honoured
+/// everywhere else in the binary.
+fn backend_for(backend: &str) -> Result<&'static DrivableBackend, String> {
     let drivable = drivable_backends().join(", ");
     let Some(name) = crate::recognized_backend(backend) else {
         return Err(format!(
@@ -65,16 +91,12 @@ fn candidates_for(backend: &str) -> Result<(&'static str, &'static [Candidate]),
             crate::BACKENDS.join(", ")
         ));
     };
-    DRIVABLE
-        .iter()
-        .find(|(n, _)| *n == name)
-        .map(|(n, c)| (*n, *c))
-        .ok_or_else(|| {
-            format!(
-                "no smoke candidates for backend {name:?} yet — {DRIVES_CLAUSE}{drivable}. \
-                 Pass --backend {DEFAULT_BACKEND}."
-            )
-        })
+    DRIVABLE.iter().find(|b| b.name == name).ok_or_else(|| {
+        format!(
+            "no smoke candidates for backend {name:?} yet — {DRIVES_CLAUSE}{drivable}. \
+             Pass --backend {DEFAULT_BACKEND}."
+        )
+    })
 }
 
 /// The checks, in order, except `stop` (appended last). Envelope discipline is not among
@@ -139,19 +161,25 @@ pub fn run(opts: SmokeOptions) -> Result<SmokeReport, String> {
 /// `PATH` itself — the seam that lets tests drive it against a directory they control instead
 /// of the host's real environment. `run` is the only caller that should pass the host's `PATH`.
 fn run_with(opts: SmokeOptions, path: Option<&OsStr>) -> Result<SmokeReport, String> {
-    let (backend, candidates) = candidates_for(&opts.backend)?;
+    let b = backend_for(&opts.backend)?;
 
     // Resolve an explicit `--app` up front, dry run or not: naming a candidate that doesn't
     // exist in the table is a typo in the caller's input, not an environment gap, so it must
     // be rejected the same way in both modes rather than only once probing would happen.
     let forced = match &opts.app {
-        Some(name) => Some(candidates.iter().find(|c| c.label == name).ok_or_else(|| {
-            let names: Vec<&str> = candidates.iter().map(|c| c.label).collect();
-            format!(
-                "unknown app {name:?} for {backend} — use one of: {}",
-                names.join(", ")
-            )
-        })?),
+        Some(name) => Some(
+            b.candidates
+                .iter()
+                .find(|c| c.label == name)
+                .ok_or_else(|| {
+                    let names: Vec<&str> = b.candidates.iter().map(|c| c.label).collect();
+                    format!(
+                        "unknown app {name:?} for {} — use one of: {}",
+                        b.name,
+                        names.join(", ")
+                    )
+                })?,
+        ),
         None => None,
     };
 
@@ -161,18 +189,20 @@ fn run_with(opts: SmokeOptions, path: Option<&OsStr>) -> Result<SmokeReport, Str
         // instead of erroring. A forced `--app` is probed too: a plan naming an app the host
         // does not have is otherwise indistinguishable from one it does.
         let app = match forced {
-            Some(c) if !profile::runnable(c, path) => TargetApp::Unavailable(format!(
-                "would fail: --app {} was given, but {} is not runnable on PATH",
-                c.label, c.bin
-            )),
+            Some(c) if !profile::runnable(c, path, b.resolution) => {
+                TargetApp::Unavailable(format!(
+                    "would fail: --app {} was given, but {} is not runnable on PATH",
+                    c.label, c.bin
+                ))
+            }
             Some(c) => TargetApp::Selected(c.label.to_string()),
-            None => match profile::resolve_app(candidates, path) {
+            None => match profile::resolve_app(b.candidates, path, b.resolution) {
                 Ok(c) => TargetApp::Selected(c.label.to_string()),
-                Err(e) => TargetApp::Unavailable(e.plan_note(candidates)),
+                Err(e) => TargetApp::Unavailable(e.plan_note(b.candidates)),
             },
         };
         return Ok(SmokeReport {
-            backend: backend.to_string(),
+            backend: b.name.to_string(),
             // No server is spawned, so nothing reports a version over MCP; this is the one
             // compiled into the binary that would have been spawned.
             version: Some(crate::VERSION.to_string()),
@@ -186,10 +216,11 @@ fn run_with(opts: SmokeOptions, path: Option<&OsStr>) -> Result<SmokeReport, Str
     // fall back to here.
     let app = match forced {
         Some(c) => c,
-        None => profile::resolve_app(candidates, path).map_err(|e| e.blocking_error(candidates))?,
+        None => profile::resolve_app(b.candidates, path, b.resolution)
+            .map_err(|e| e.blocking_error(b.candidates))?,
     };
     let p = Profile {
-        backend: backend.to_string(),
+        backend: b.name.to_string(),
         app,
     };
 
@@ -199,7 +230,7 @@ fn run_with(opts: SmokeOptions, path: Option<&OsStr>) -> Result<SmokeReport, Str
     // inheriting the caller's shell, or check 2 would grade a backend this run is not
     // exercising. `check_health` re-reads the active backend, so this plumbing breaking is a
     // visible failure rather than a silently misdirected verdict.
-    let mut t = client::StdioClient::spawn(&exe, &[("GLASS_BACKEND", backend)])?;
+    let mut t = client::StdioClient::spawn(&exe, &[("GLASS_BACKEND", b.name)])?;
     let version = t.server_version();
     let mut out = vec![
         checks::check_start(&mut t, &p),
@@ -213,7 +244,7 @@ fn run_with(opts: SmokeOptions, path: Option<&OsStr>) -> Result<SmokeReport, Str
     out.push(checks::check_error_honesty(&mut t));
     out.push(checks::check_stop(&mut t));
 
-    let checks = out.into_iter().map(|c| ledger::apply(backend, c)).collect();
+    let checks = out.into_iter().map(|c| ledger::apply(b.name, c)).collect();
     Ok(SmokeReport {
         backend: p.backend,
         version,
@@ -441,14 +472,34 @@ mod tests {
     #[test]
     fn every_drivable_row_can_actually_be_resolved() {
         let mut seen = std::collections::BTreeSet::new();
-        for (name, candidates) in DRIVABLE {
+        for b in DRIVABLE {
             assert_eq!(
-                crate::recognized_backend(name),
-                Some(*name),
-                "{name:?} is not the canonical spelling glass resolves to"
+                crate::recognized_backend(b.name),
+                Some(b.name),
+                "{:?} is not the canonical spelling glass resolves to",
+                b.name
             );
-            assert!(!candidates.is_empty(), "{name:?} has no candidate apps");
-            assert!(seen.insert(*name), "{name:?} appears twice");
+            assert!(
+                !b.candidates.is_empty(),
+                "{:?} has no candidate apps",
+                b.name
+            );
+            assert!(seen.insert(b.name), "{:?} appears twice", b.name);
+        }
+    }
+
+    /// Nothing else requires a row's resolution to be reachable: a `Preinstalled` row whose table is
+    /// empty resolves to an error whose prose tells the caller to install something, on a backend
+    /// where installing is not the remedy.
+    #[test]
+    fn every_drivable_row_has_a_candidate_its_policy_can_return() {
+        for b in DRIVABLE {
+            assert!(
+                !b.candidates.is_empty(),
+                "{:?} has no candidate for {:?} to return",
+                b.name,
+                b.resolution
+            );
         }
     }
 
@@ -462,9 +513,9 @@ mod tests {
     /// `xed` heads both tables, so naming one candidate would not tell the two apart.
     #[test]
     fn wayland_resolves_the_wayland_table() {
-        let (name, candidates) = candidates_for("wayland").expect("wayland must be drivable");
-        assert_eq!(name, "wayland");
-        let resolved: Vec<&str> = candidates.iter().map(|c| c.bin).collect();
+        let b = backend_for("wayland").expect("wayland must be drivable");
+        assert_eq!(b.name, "wayland");
+        let resolved: Vec<&str> = b.candidates.iter().map(|c| c.bin).collect();
         let wayland: Vec<&str> = WAYLAND_CANDIDATES.iter().map(|c| c.bin).collect();
         assert_eq!(resolved, wayland);
     }

--- a/crates/glass-mcp/src/smoke/mod.rs
+++ b/crates/glass-mcp/src/smoke/mod.rs
@@ -11,11 +11,13 @@ pub mod selfcheck;
 pub mod transport;
 
 use std::ffi::OsStr;
+use std::time::Duration;
 
 use profile::{
     ANDROID_CANDIDATES, Candidate, Profile, Resolution, WAYLAND_CANDIDATES, X11_CANDIDATES,
 };
 use report::{CheckOutcome, RunMode, SmokeReport, TargetApp};
+use transport::CALL_TIMEOUT;
 
 pub struct SmokeOptions {
     /// Backend to exercise (see [`backend_for`] for the supported set).
@@ -121,6 +123,34 @@ fn backend_for(backend: &str) -> Result<&'static DrivableBackend, String> {
              Pass --backend {DEFAULT_BACKEND}."
         )
     })
+}
+
+/// The emulator boot budget glass applies when `GLASS_EMULATOR_BOOT_TIMEOUT_MS` is unset. Kept in
+/// step with the android backend's own default: a smaller value here would make this client give
+/// up while the device is still within the budget glass granted it.
+const BOOT_BUDGET_DEFAULT_MS: u64 = 120_000;
+
+/// Extra budget beyond the device's boot, for the install-and-launch that follows it.
+const START_SLACK: Duration = Duration::from_secs(120);
+
+/// How long `glass_start` may take. Derived rather than chosen: a backend that may boot a device
+/// must outlast the device's own boot budget, or this client gives up before the boot it is
+/// waiting for can finish — and reports it as a launch failure, which is the hardest thing there
+/// is to diagnose from the report. A boot budget already inside `CALL_TIMEOUT` needs no slack
+/// added on top of it: the ordinary deadline already covers it. `get` is injected so the
+/// arithmetic is testable without touching the process environment.
+fn start_deadline(b: &DrivableBackend, get: &dyn Fn(&str) -> Option<String>) -> Duration {
+    if !b.boots_a_device {
+        return CALL_TIMEOUT;
+    }
+    let ms = get("GLASS_EMULATOR_BOOT_TIMEOUT_MS")
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(BOOT_BUDGET_DEFAULT_MS);
+    let boot_budget = Duration::from_millis(ms);
+    if boot_budget < CALL_TIMEOUT {
+        return CALL_TIMEOUT;
+    }
+    boot_budget + START_SLACK
 }
 
 /// The checks, in order, except `stop` (appended last). Envelope discipline is not among
@@ -246,6 +276,7 @@ fn run_with(opts: SmokeOptions, path: Option<&OsStr>) -> Result<SmokeReport, Str
     let p = Profile {
         backend: b.name.to_string(),
         app,
+        start_deadline: start_deadline(b, &|k| std::env::var(k).ok()),
     };
 
     let exe = std::env::current_exe().map_err(|e| format!("cannot locate this binary: {e}"))?;
@@ -281,6 +312,7 @@ fn run_with(opts: SmokeOptions, path: Option<&OsStr>) -> Result<SmokeReport, Str
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
 
     /// Every row a report must carry, in order, written out rather than derived from
     /// [`CHECK_NAMES`] — a list checked against itself pins nothing. Deleting a check must
@@ -734,5 +766,81 @@ mod tests {
             "{t}"
         );
         assert!(row("x11").contains("first runnable on `PATH`"), "{t}");
+    }
+
+    fn android() -> &'static DrivableBackend {
+        backend_for("android").expect("android must be drivable")
+    }
+
+    /// A backend that launches into a compositor already running does not need to outlast a boot.
+    #[test]
+    fn a_backend_that_never_boots_a_device_keeps_the_default_deadline() {
+        let x11 = backend_for("x11").expect("x11 must be drivable");
+        assert!(!x11.boots_a_device);
+        assert_eq!(start_deadline(x11, &|_| None), CALL_TIMEOUT);
+    }
+
+    /// The relationship the whole function exists for: a client deadline inside the device's own boot
+    /// budget makes an ordinary cold boot look like a failed launch.
+    #[test]
+    fn a_booting_backend_outlasts_the_devices_own_boot_budget() {
+        let d = start_deadline(android(), &|_| None);
+        assert!(
+            d > Duration::from_millis(BOOT_BUDGET_DEFAULT_MS),
+            "a deadline inside the boot budget reports the boot as a launch failure: {d:?}"
+        );
+        assert_eq!(
+            d,
+            Duration::from_millis(BOOT_BUDGET_DEFAULT_MS) + START_SLACK
+        );
+    }
+
+    /// Raising the device's budget must raise this one. Leaving it fixed would make the client give
+    /// up first at the exact moment an operator asked to wait longer.
+    #[test]
+    fn raising_the_boot_budget_raises_the_deadline() {
+        let get = |k: &str| (k == "GLASS_EMULATOR_BOOT_TIMEOUT_MS").then(|| "600000".to_string());
+        assert_eq!(
+            start_deadline(android(), &get),
+            Duration::from_millis(600_000) + START_SLACK
+        );
+    }
+
+    /// An unreadable value is not a shorter budget: glass falls back to its own default, so this must
+    /// too, or the two would disagree about how long a boot may take.
+    #[test]
+    fn an_unreadable_boot_budget_falls_back_to_the_default() {
+        for v in ["", "   ", "soon", "-1", "12.5", "99999999999999999999"] {
+            let get = |k: &str| (k == "GLASS_EMULATOR_BOOT_TIMEOUT_MS").then(|| v.to_string());
+            assert_eq!(
+                start_deadline(android(), &get),
+                Duration::from_millis(BOOT_BUDGET_DEFAULT_MS) + START_SLACK,
+                "{v:?} must not shorten the deadline"
+            );
+        }
+    }
+
+    /// A boot budget below the default must not drag the launch deadline below what every other call
+    /// already gets.
+    #[test]
+    fn a_tiny_boot_budget_does_not_shrink_the_deadline_below_the_default() {
+        let get = |k: &str| (k == "GLASS_EMULATOR_BOOT_TIMEOUT_MS").then(|| "1".to_string());
+        assert_eq!(start_deadline(android(), &get), CALL_TIMEOUT);
+    }
+
+    /// The reader is scoped to one variable: reading any name would let an unrelated setting move a
+    /// deadline nobody connected to it.
+    #[test]
+    fn the_deadline_reads_only_the_boot_budget_variable() {
+        let get = |k: &str| (k == "GLASS_EMULATOR_BOOT_TIMEOUT_MS").then(|| "600000".to_string());
+        let other = |_: &str| Some("600000".to_string());
+        assert_ne!(
+            start_deadline(android(), &get),
+            start_deadline(android(), &|_| None)
+        );
+        assert_eq!(
+            start_deadline(android(), &other),
+            start_deadline(android(), &get)
+        );
     }
 }

--- a/crates/glass-mcp/src/smoke/mod.rs
+++ b/crates/glass-mcp/src/smoke/mod.rs
@@ -12,7 +12,9 @@ pub mod transport;
 
 use std::ffi::OsStr;
 
-use profile::{Candidate, Profile, Resolution, WAYLAND_CANDIDATES, X11_CANDIDATES};
+use profile::{
+    ANDROID_CANDIDATES, Candidate, Profile, Resolution, WAYLAND_CANDIDATES, X11_CANDIDATES,
+};
 use report::{CheckOutcome, RunMode, SmokeReport, TargetApp};
 
 pub struct SmokeOptions {
@@ -49,6 +51,12 @@ const DRIVABLE: &[DrivableBackend] = &[
         resolution: Resolution::OnPath,
         boots_a_device: false,
     },
+    DrivableBackend {
+        name: "android",
+        candidates: &ANDROID_CANDIDATES,
+        resolution: Resolution::Preinstalled,
+        boots_a_device: true,
+    },
 ];
 
 /// The drivable backend names, in table order, for a message that tells the caller what to pass.
@@ -63,16 +71,32 @@ pub const DEFAULT_BACKEND: &str = DRIVABLE[0].name;
 /// The reference doc's target-app table, rendered from [`DRIVABLE`]. A doc-sync test compares it
 /// against the checked-in markdown, so a candidate can't land in the code and not in the docs.
 pub fn render_candidate_table() -> String {
-    let mut out = String::from("| Backend | Candidates, in probe order |\n|---|---|\n");
+    let mut out = String::from("| Backend | Chosen by | Candidates, in order |\n|---|---|---|\n");
     for b in DRIVABLE {
-        let bins: Vec<String> = b
-            .candidates
-            .iter()
-            .map(|c| format!("`{}`", c.bin))
-            .collect();
-        out.push_str(&format!("| `{}` | {} |\n", b.name, bins.join(", ")));
+        let how = match b.resolution {
+            Resolution::OnPath => "first runnable on `PATH`",
+            Resolution::Preinstalled => {
+                "preinstalled; the first row is the default, the rest need `--app`"
+            }
+        };
+        let names: Vec<String> = b.candidates.iter().map(render_candidate).collect();
+        out.push_str(&format!(
+            "| `{}` | {how} | {} |\n",
+            b.name,
+            names.join(", ")
+        ));
     }
     out
+}
+
+/// A candidate as the doc names it: the label alone where it is also the target, and the target
+/// beside it where the two differ — as they do for a component nobody would want to read twice.
+fn render_candidate(c: &Candidate) -> String {
+    if c.label == c.bin {
+        format!("`{}`", c.label)
+    } else {
+        format!("`{}` (`{}`)", c.label, c.bin)
+    }
 }
 
 /// The clause both resolution errors carry, spelled once so a test can scope its assertion to
@@ -445,7 +469,7 @@ mod tests {
     fn a_backend_glass_knows_but_smoke_cannot_drive_yet_says_so() {
         let err = run_with(
             SmokeOptions {
-                backend: "android".into(),
+                backend: "ios".into(),
                 app: None,
                 dry_run: true,
             },
@@ -453,7 +477,7 @@ mod tests {
         )
         .unwrap_err();
         assert!(
-            err.contains("android"),
+            err.contains("ios"),
             "must name the backend asked for: {err}"
         );
         let drives = drives_clause(&err);
@@ -507,7 +531,7 @@ mod tests {
     /// nothing, and would stay green both if a name changed and if the table were emptied.
     #[test]
     fn drivable_backends_lists_every_row_of_the_table() {
-        assert_eq!(drivable_backends(), ["x11", "wayland"]);
+        assert_eq!(drivable_backends(), ["x11", "wayland", "android"]);
     }
 
     /// `xed` heads both tables, so naming one candidate would not tell the two apart.
@@ -613,5 +637,92 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.contains("emacs"), "got: {err}");
+    }
+
+    /// The whole point of `Preinstalled`: an android plan resolves with no search path at all,
+    /// because `PATH` says nothing about what is installed on a device.
+    #[test]
+    fn an_android_plan_names_the_default_component_without_a_search_path() {
+        let r = run_with(
+            SmokeOptions {
+                backend: "android".into(),
+                app: None,
+                dry_run: true,
+            },
+            None,
+        )
+        .expect("android must be drivable with no PATH");
+        assert_eq!(r.backend, "android");
+        assert_eq!(r.app, TargetApp::Selected("contacts".into()));
+        assert_eq!(
+            detail_of(&r, "start"),
+            "dry run",
+            "nothing was probed, so there is no gap to report"
+        );
+    }
+
+    /// Without a probe the table is not a fallback chain — every row but the first exists only for
+    /// `--app`, so `--app` has to reach them.
+    #[test]
+    fn an_android_plan_honours_a_forced_candidate() {
+        let r = run_with(
+            SmokeOptions {
+                backend: "android".into(),
+                app: Some("settings".into()),
+                dry_run: true,
+            },
+            None,
+        )
+        .expect("android must be drivable with no PATH");
+        assert_eq!(r.app, TargetApp::Selected("settings".into()));
+    }
+
+    /// `--app` selects among the backend's own candidates. An x11 label must not resolve here, or a
+    /// run would try to launch `xed` as an activity component.
+    #[test]
+    fn an_android_forced_app_resolves_against_the_android_table() {
+        let err = run_with(
+            SmokeOptions {
+                backend: "android".into(),
+                app: Some("xed".into()),
+                dry_run: true,
+            },
+            None,
+        )
+        .unwrap_err();
+        assert!(err.contains("xed"), "must name the app asked for: {err}");
+        let (_, offered) = err
+            .split_once("use one of: ")
+            .unwrap_or_else(|| panic!("must offer the backend's candidates: {err}"));
+        for label in ["contacts", "settings"] {
+            assert!(offered.contains(label), "must offer {label:?}: {err}");
+        }
+    }
+
+    /// The rendered doc names the component for a candidate whose label is not its target, and does
+    /// not repeat itself for one whose label is. Written against the two shapes rather than against
+    /// the renderer, which would agree with itself.
+    #[test]
+    fn the_rendered_table_names_a_component_but_does_not_repeat_a_bare_label() {
+        let t = render_candidate_table();
+        assert!(
+            t.contains(
+                "`contacts` (`com.google.android.contacts/com.android.contacts.activities.CompactContactEditorActivity`)"
+            ),
+            "an android row must name the component an operator would pass: {t}"
+        );
+        assert!(
+            !t.contains("`xed` (`xed`)"),
+            "a candidate whose label is its target must be named once: {t}"
+        );
+    }
+
+    /// A reader has to know that android's table is not a fallback chain, and the only place the doc
+    /// can learn it is the renderer.
+    #[test]
+    fn the_rendered_table_says_how_each_backend_chooses() {
+        let t = render_candidate_table();
+        assert!(t.contains("first runnable on `PATH`"), "{t}");
+        assert!(t.contains("the first row is the default"), "{t}");
     }
 }

--- a/crates/glass-mcp/src/smoke/mod.rs
+++ b/crates/glass-mcp/src/smoke/mod.rs
@@ -143,8 +143,11 @@ fn start_deadline(b: &DrivableBackend, get: &dyn Fn(&str) -> Option<String>) -> 
     if !b.boots_a_device {
         return CALL_TIMEOUT;
     }
+    // No `.trim()`: `glass-android` reads this same variable with a bare `.parse()`, so a
+    // whitespace-padded value is unreadable to the device too. Trimming here would derive a
+    // deadline from a boot budget the device itself fell back away from.
     let ms = get("GLASS_EMULATOR_BOOT_TIMEOUT_MS")
-        .and_then(|v| v.trim().parse::<u64>().ok())
+        .and_then(|v| v.parse::<u64>().ok())
         .unwrap_or(BOOT_BUDGET_DEFAULT_MS);
     Duration::from_millis(ms) + CALL_TIMEOUT
 }
@@ -814,6 +817,19 @@ mod tests {
                 "{v:?} must not shorten the deadline"
             );
         }
+    }
+
+    /// `glass-android` parses this same variable with a bare `.parse()` — no `.trim()` — so a
+    /// whitespace-padded value is unreadable to the device too. Trimming it here would derive a
+    /// deadline from a boot budget the device itself fell back away from, the two silently
+    /// disagreeing about how long the boot may take.
+    #[test]
+    fn a_whitespace_padded_boot_budget_falls_back_to_the_default_like_glass_android() {
+        let get = |k: &str| (k == "GLASS_EMULATOR_BOOT_TIMEOUT_MS").then(|| " 600000 ".to_string());
+        assert_eq!(
+            start_deadline(android(), &get),
+            Duration::from_millis(BOOT_BUDGET_DEFAULT_MS) + CALL_TIMEOUT
+        );
     }
 
     /// A boot budget smaller than one ordinary call still leaves a full ordinary call's worth of

--- a/crates/glass-mcp/src/smoke/mod.rs
+++ b/crates/glass-mcp/src/smoke/mod.rs
@@ -823,7 +823,12 @@ mod tests {
             row("android").contains("the first row is the default"),
             "{t}"
         );
-        assert!(row("x11").contains("first runnable on `PATH`"), "{t}");
+        for probing in ["x11", "wayland"] {
+            assert!(
+                row(probing).contains("first runnable on `PATH`"),
+                "{probing}: {t}"
+            );
+        }
     }
 
     fn android() -> &'static DrivableBackend {

--- a/crates/glass-mcp/src/smoke/profile.rs
+++ b/crates/glass-mcp/src/smoke/profile.rs
@@ -103,6 +103,8 @@ pub const ANDROID_CANDIDATES: [Candidate; 2] = [
 pub struct Profile {
     pub backend: String,
     pub app: &'static Candidate,
+    /// The backend's whole table, so a failure can name what this run did not try.
+    pub candidates: &'static [Candidate],
     /// How long the launch may take. Larger than every other call's budget only where a launch
     /// may boot a device first.
     pub start_deadline: std::time::Duration,

--- a/crates/glass-mcp/src/smoke/profile.rs
+++ b/crates/glass-mcp/src/smoke/profile.rs
@@ -103,6 +103,9 @@ pub const ANDROID_CANDIDATES: [Candidate; 2] = [
 pub struct Profile {
     pub backend: String,
     pub app: &'static Candidate,
+    /// How long the launch may take. Larger than every other call's budget only where a launch
+    /// may boot a device first.
+    pub start_deadline: std::time::Duration,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/glass-mcp/src/smoke/profile.rs
+++ b/crates/glass-mcp/src/smoke/profile.rs
@@ -72,6 +72,33 @@ pub const WAYLAND_CANDIDATES: [Candidate; 3] = [
     },
 ];
 
+/// Android targets are `package/.Activity` components rather than executables, so `bin` holds the
+/// component and `args` is empty: `am start` launches an activity, and there is no argument vector
+/// to fill. `env` is empty because on android `AppSpec.env` configures the host-side command, never
+/// the launched app — which is forked from zygote and never sees it.
+///
+/// Nothing probes the device, so this is not a fallback chain: `contacts` is what a run drives
+/// unless `--app` says otherwise.
+pub const ANDROID_CANDIDATES: [Candidate; 2] = [
+    // The only stock component found with a directly editable field on its first screen, which is
+    // what the interaction check needs. It opens an unsaved contact draft: nothing saves it, and
+    // the stop check force-stops the package rather than closing a window.
+    Candidate {
+        bin: "com.google.android.contacts/com.android.contacts.activities.CompactContactEditorActivity",
+        args: &[],
+        env: &[],
+        label: "contacts",
+    },
+    // For system images without the Google apps. It launches everywhere and exposes a tree, but
+    // has no editable field, so the interaction check skips rather than passing.
+    Candidate {
+        bin: "com.android.settings/.Settings",
+        args: &[],
+        env: &[],
+        label: "settings",
+    },
+];
+
 #[derive(Debug, Clone)]
 pub struct Profile {
     pub backend: String,

--- a/crates/glass-mcp/src/smoke/profile.rs
+++ b/crates/glass-mcp/src/smoke/profile.rs
@@ -4,7 +4,8 @@ use std::ffi::OsStr;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Candidate {
-    /// Executable to look for on PATH.
+    /// What to launch: an executable name resolved on `PATH`, or — on a backend whose targets live
+    /// on a device — the `package/.Activity` component to start there.
     pub bin: &'static str,
     /// Its arguments. Must open a non-destructive, unsaved surface.
     pub args: &'static [&'static str],
@@ -103,8 +104,10 @@ pub const ANDROID_CANDIDATES: [Candidate; 2] = [
 pub struct Profile {
     pub backend: String,
     pub app: &'static Candidate,
-    /// The backend's whole table, so a failure can name what this run did not try.
-    pub candidates: &'static [Candidate],
+    /// What a failed launch may offer instead, as the labels `--app` accepts. Resolved where the
+    /// backend's resolution policy and search path are both known, so a backend that probes never
+    /// offers a candidate that probe already found absent.
+    pub alternatives: Vec<&'static str>,
     /// How long the launch may take. Larger than every other call's budget only where a launch
     /// may boot a device first.
     pub start_deadline: std::time::Duration,

--- a/crates/glass-mcp/src/smoke/profile.rs
+++ b/crates/glass-mcp/src/smoke/profile.rs
@@ -139,24 +139,49 @@ fn bin_list(candidates: &[Candidate]) -> String {
         .join(", ")
 }
 
-/// Pick the first candidate runnable on `path` — the value of `PATH`, or `None` when the
-/// variable is unset. Taking the search path as a parameter is what lets the probe be tested
-/// against a directory the test controls rather than the host's real environment.
+/// How a backend's target app is chosen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Resolution {
+    /// Probe `PATH` and take the first candidate that resolves.
+    OnPath,
+    /// Take the first candidate as given. The target ships with the device's system image, and
+    /// nothing this process can run says whether this particular one is there — so the table's
+    /// first row is the default and the rest are reachable only through `--app`.
+    Preinstalled,
+}
+
+/// Pick the candidate this backend's policy selects. Under [`Resolution::OnPath`], the first one
+/// runnable on `path` — the value of `PATH`, or `None` when the variable is unset. Taking the
+/// search path as a parameter is what lets the probe be tested against a directory the test
+/// controls rather than the host's real environment.
 pub fn resolve_app(
     candidates: &'static [Candidate],
     path: Option<&OsStr>,
+    how: Resolution,
 ) -> Result<&'static Candidate, NoTargetApp> {
-    let path = path.ok_or(NoTargetApp::NoSearchPath)?;
-    candidates
-        .iter()
-        .find(|c| on_path_in(c.bin, path))
-        .ok_or(NoTargetApp::NoneInstalled)
+    match how {
+        // `first`, not `[0]`: an empty table is a programming error a test catches, not a reason
+        // to panic inside a release binary's smoke run.
+        Resolution::Preinstalled => candidates.first().ok_or(NoTargetApp::NoneInstalled),
+        Resolution::OnPath => {
+            let path = path.ok_or(NoTargetApp::NoSearchPath)?;
+            candidates
+                .iter()
+                .find(|c| on_path_in(c.bin, path))
+                .ok_or(NoTargetApp::NoneInstalled)
+        }
+    }
 }
 
-/// Is this specific candidate runnable, without regard to probe order? What `--app` needs:
-/// the caller has already chosen the candidate and only asks whether it could run.
-pub fn runnable(candidate: &Candidate, path: Option<&OsStr>) -> bool {
-    path.is_some_and(|p| on_path_in(candidate.bin, p))
+/// Is this specific candidate runnable, without regard to probe order? What `--app` needs: the
+/// caller has already chosen the candidate and only asks whether it could run. Under
+/// [`Resolution::Preinstalled`] that question has no answer this process can obtain, and the
+/// honest response is the one that does not invent a failure.
+pub fn runnable(candidate: &Candidate, path: Option<&OsStr>, how: Resolution) -> bool {
+    match how {
+        Resolution::Preinstalled => true,
+        Resolution::OnPath => path.is_some_and(|p| on_path_in(candidate.bin, p)),
+    }
 }
 
 /// Is `bin` runnable as a bare command name on `path`? Delegates to the workspace's one
@@ -316,14 +341,14 @@ mod tests {
     #[test]
     fn resolve_picks_the_first_present_candidate() {
         let (_dir, path) = path_fixture(&["zenity", "xterm"], &[]);
-        let c = resolve_app(&X11_CANDIDATES, Some(&path)).unwrap();
+        let c = resolve_app(&X11_CANDIDATES, Some(&path), Resolution::OnPath).unwrap();
         assert_eq!(c.label, "zenity");
     }
 
     #[test]
     fn resolve_reports_none_installed_when_the_path_holds_no_candidate() {
         let (_dir, path) = path_fixture(&[], &[]);
-        let err = resolve_app(&X11_CANDIDATES, Some(&path)).unwrap_err();
+        let err = resolve_app(&X11_CANDIDATES, Some(&path), Resolution::OnPath).unwrap_err();
         assert_eq!(err, NoTargetApp::NoneInstalled);
     }
 
@@ -333,7 +358,7 @@ mod tests {
     #[test]
     fn a_non_executable_file_is_not_a_candidate() {
         let (_dir, path) = path_fixture(&["xterm"], &["xed"]);
-        let c = resolve_app(&X11_CANDIDATES, Some(&path)).unwrap();
+        let c = resolve_app(&X11_CANDIDATES, Some(&path), Resolution::OnPath).unwrap();
         assert_eq!(
             c.label, "xterm",
             "a mode-644 file named xed must be skipped, not selected"
@@ -346,17 +371,51 @@ mod tests {
         let (_dir, path) = path_fixture(&["zenity"], &[]);
         let zenity = X11_CANDIDATES.iter().find(|c| c.bin == "zenity").unwrap();
         let xterm = X11_CANDIDATES.iter().find(|c| c.bin == "xterm").unwrap();
-        assert!(runnable(zenity, Some(&path)));
-        assert!(!runnable(xterm, Some(&path)));
-        assert!(!runnable(zenity, None), "an unset PATH resolves nothing");
+        assert!(runnable(zenity, Some(&path), Resolution::OnPath));
+        assert!(!runnable(xterm, Some(&path), Resolution::OnPath));
+        assert!(
+            !runnable(zenity, None, Resolution::OnPath),
+            "an unset PATH resolves nothing"
+        );
     }
 
     /// An unset `PATH` is its own case: no amount of installing fixes it, so it must not be
     /// reported as "nothing installed".
     #[test]
     fn an_unset_path_is_not_reported_as_nothing_installed() {
-        let err = resolve_app(&X11_CANDIDATES, None).unwrap_err();
+        let err = resolve_app(&X11_CANDIDATES, None, Resolution::OnPath).unwrap_err();
         assert_eq!(err, NoTargetApp::NoSearchPath);
+    }
+
+    /// Preinstalled resolution answers without consulting `PATH`: on a device backend there is
+    /// nothing on this host to consult, and probing would report a working host as broken.
+    #[test]
+    fn preinstalled_resolution_takes_the_first_row_without_a_search_path() {
+        let c = resolve_app(&X11_CANDIDATES, None, Resolution::Preinstalled)
+            .expect("a preinstalled target does not depend on this host's PATH");
+        assert_eq!(c.label, X11_CANDIDATES[0].label);
+    }
+
+    /// The policy is what decides, not the arguments: the same unset `PATH` that resolves fine
+    /// above is still terminal for a backend that resolves by probing.
+    #[test]
+    fn on_path_resolution_still_needs_a_search_path() {
+        assert_eq!(
+            resolve_app(&X11_CANDIDATES, None, Resolution::OnPath).unwrap_err(),
+            NoTargetApp::NoSearchPath
+        );
+    }
+
+    /// `--app`'s probe asks "could this candidate run here?", which no code in this process can
+    /// answer about a device. Answering `false` would make `--dry-run` report a working host as
+    /// unable to run the app it is about to drive.
+    #[test]
+    fn runnable_is_true_under_preinstalled_even_when_nothing_is_on_path() {
+        let (_dir, path) = path_fixture(&[], &[]);
+        let c = &X11_CANDIDATES[0];
+        assert!(!runnable(c, Some(&path), Resolution::OnPath));
+        assert!(runnable(c, Some(&path), Resolution::Preinstalled));
+        assert!(runnable(c, None, Resolution::Preinstalled));
     }
 
     #[test]
@@ -559,17 +618,18 @@ mod tests {
     /// a `serde_json::Map`, where the later value wins on the wire without anything saying so.
     #[test]
     fn every_candidates_env_is_a_well_formed_map() {
-        for (backend, candidates) in crate::smoke::DRIVABLE {
-            for c in *candidates {
+        for b in crate::smoke::DRIVABLE {
+            for c in b.candidates {
                 let mut seen = std::collections::BTreeSet::new();
                 for (k, v) in c.env {
-                    assert!(!k.is_empty(), "{backend}/{}: empty env key", c.label);
+                    assert!(!k.is_empty(), "{}/{}: empty env key", b.name, c.label);
                     assert!(
                         !v.is_empty(),
-                        "{backend}/{}: empty value for {k:?}",
+                        "{}/{}: empty value for {k:?}",
+                        b.name,
                         c.label
                     );
-                    assert!(seen.insert(k), "{backend}/{}: {k:?} set twice", c.label);
+                    assert!(seen.insert(k), "{}/{}: {k:?} set twice", b.name, c.label);
                 }
             }
         }
@@ -600,7 +660,7 @@ mod tests {
     #[test]
     fn resolve_picks_the_first_present_wayland_candidate() {
         let (_dir, path) = path_fixture(&["zenity", "gnome-text-editor"], &[]);
-        let c = resolve_app(&WAYLAND_CANDIDATES, Some(&path)).unwrap();
+        let c = resolve_app(&WAYLAND_CANDIDATES, Some(&path), Resolution::OnPath).unwrap();
         assert_eq!(c.label, "gnome-text-editor");
     }
 }

--- a/crates/glass-mcp/src/smoke/selfcheck.rs
+++ b/crates/glass-mcp/src/smoke/selfcheck.rs
@@ -6,9 +6,9 @@
 //! substring distinctive to the assertion it targets.
 
 use crate::smoke::checks;
-use crate::smoke::profile::OutlineNode;
+use crate::smoke::profile::{OutlineNode, Profile, X11_CANDIDATES};
 use crate::smoke::report::{CheckOutcome, CheckStatus};
-use crate::smoke::transport::{CallResult, ScriptedTransport};
+use crate::smoke::transport::{CALL_TIMEOUT, CallResult, ScriptedTransport};
 use serde_json::json;
 
 /// One fault-injection scenario: the outcome a check produced against a deliberately wrong
@@ -44,7 +44,7 @@ impl Scenario {
 /// annotated on it: a scenario dropped without this being changed with it is then a length
 /// mismatch the compiler rejects, rather than a self-check that reports success having injected
 /// one fewer. cargo-mutants does not mutate array literals, so no sweep would report that.
-const INJECTED_FAULTS: usize = 5;
+const INJECTED_FAULTS: usize = 6;
 
 /// Faults, and the check that must catch each one — for the reason each is named after.
 pub fn run_self_check() -> Result<String, String> {
@@ -54,6 +54,7 @@ pub fn run_self_check() -> Result<String, String> {
         noop_interaction_scenario(),
         remedyless_error_scenario(),
         dropped_error_message_scenario(),
+        windowless_start_scenario(),
     ];
 
     for s in &scenarios {
@@ -224,6 +225,39 @@ fn dropped_error_message_scenario() -> Scenario {
     }
 }
 
+/// Scenario 6: `glass_start` reports ok for a window with no `height`. `check_start`'s geometry
+/// guard must catch this; its text names the missing field, which no other failure path in that
+/// check produces — a transport error carries the server's own message instead. Deleting the guard
+/// does not go red another way: the detail is then interpolated straight from the response, so the
+/// check reaches a genuine `Pass` on a launch that established no window.
+///
+/// Driven through `check_start` deliberately: it is the check whose whole job is to notice a
+/// broken launch, and no scenario above reaches it.
+fn windowless_start_scenario() -> Scenario {
+    let mut t = ScriptedTransport::new(vec![(
+        "glass_start",
+        Ok(CallResult::ok(
+            "glass_start",
+            json!({ "x": 0, "y": 0, "width": 800 }),
+            &[],
+            0,
+        )),
+    )]);
+    let p = Profile {
+        backend: "x11".to_string(),
+        app: &X11_CANDIDATES[0],
+        // Nothing to offer: an offer is appended only on the failure path, and a scenario whose
+        // detail carried one would no longer be scoped to the guard under test.
+        alternatives: vec![],
+        start_deadline: CALL_TIMEOUT,
+    };
+    Scenario {
+        name: "start reported a window with no height",
+        outcome: checks::check_start(&mut t, &p),
+        expect_detail: "no `height` in its geometry",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -293,7 +327,7 @@ mod tests {
     fn the_success_message_names_how_many_faults_were_injected() {
         assert_eq!(
             run_self_check().expect("the shipped scenarios must all be caught"),
-            "5 injected faults, all caught"
+            "6 injected faults, all caught"
         );
     }
 }

--- a/crates/glass-mcp/src/smoke/transport.rs
+++ b/crates/glass-mcp/src/smoke/transport.rs
@@ -4,6 +4,11 @@
 //! without a display.
 
 use serde_json::Value;
+use std::time::Duration;
+
+/// A server that has not answered in this long is treated as hung. Every call uses it except a
+/// launch that may boot a device first — see the smoke module's `start_deadline`.
+pub const CALL_TIMEOUT: Duration = Duration::from_secs(120);
 
 #[derive(Debug, Clone, Default)]
 pub struct CallResult {
@@ -17,7 +22,17 @@ pub struct CallResult {
 }
 
 pub trait McpTransport {
-    fn call(&mut self, tool: &str, args: Value) -> Result<CallResult, String>;
+    /// Call `tool`, giving the server `deadline` to answer.
+    fn call_with_deadline(
+        &mut self,
+        tool: &str,
+        args: Value,
+        deadline: Duration,
+    ) -> Result<CallResult, String>;
+
+    fn call(&mut self, tool: &str, args: Value) -> Result<CallResult, String> {
+        self.call_with_deadline(tool, args, CALL_TIMEOUT)
+    }
 }
 
 impl CallResult {
@@ -76,6 +91,7 @@ impl CallResult {
 pub struct ScriptedTransport {
     queue: std::collections::VecDeque<(String, Result<CallResult, String>)>,
     calls: Vec<(String, Value)>,
+    deadlines: Vec<(String, Duration)>,
 }
 
 impl ScriptedTransport {
@@ -86,6 +102,7 @@ impl ScriptedTransport {
                 .map(|(t, r)| (t.to_string(), r))
                 .collect(),
             calls: Vec::new(),
+            deadlines: Vec::new(),
         }
     }
 
@@ -107,11 +124,30 @@ impl ScriptedTransport {
         );
         Some(args)
     }
+
+    /// The deadline the one call to `tool` was made with. Same single-call rule as `args_for`:
+    /// answering about the first of several would hand an assertion a green result about the
+    /// wrong call.
+    pub fn deadline_for(&self, tool: &str) -> Option<Duration> {
+        let mut matching = self.deadlines.iter().filter(|(t, _)| t == tool);
+        let (_, d) = matching.next()?;
+        assert!(
+            matching.next().is_none(),
+            "{tool} was called more than once; use calls() to pick the call you mean"
+        );
+        Some(*d)
+    }
 }
 
 impl McpTransport for ScriptedTransport {
-    fn call(&mut self, tool: &str, args: Value) -> Result<CallResult, String> {
+    fn call_with_deadline(
+        &mut self,
+        tool: &str,
+        args: Value,
+        deadline: Duration,
+    ) -> Result<CallResult, String> {
         self.calls.push((tool.to_string(), args));
+        self.deadlines.push((tool.to_string(), deadline));
         match self.queue.pop_front() {
             None => Err(format!("script exhausted; unexpected call to {tool}")),
             Some((expected, r)) if expected == tool => r,

--- a/crates/glass-mcp/tests/common/mod.rs
+++ b/crates/glass-mcp/tests/common/mod.rs
@@ -310,11 +310,8 @@ fn classify(doc: &serde_json::Value) -> HostProbe {
     match status {
         "ok" => HostProbe::Available,
         "warn" | "fail" | "skip" => HostProbe::Absent,
-        // `Some(other)` (rather than `other` alone) keeps this message identical to when this
-        // read `check["status"].as_str()` directly, which is what `sway_probe_tests` still checks.
         other => HostProbe::Broken(format!(
-            "sway >=1.12 check had unrecognized status {:?}: {doc}",
-            Some(other)
+            "sway >=1.12 check had unrecognized status {other:?}: {doc}"
         )),
     }
 }
@@ -337,7 +334,6 @@ fn classify_android(doc: &serde_json::Value) -> HostProbe {
     match device {
         // Attached, or about to boot: the runner inherits glass's auto-boot lifecycle.
         "ok" | "warn" => HostProbe::Available,
-        "skip" => HostProbe::Absent,
         // `fail` is two conditions — nothing to run, and a refusal such as several online devices
         // with no serial chosen. A host whose adb works has android set up, so both are worth
         // reporting; doctor's own detail is the only thing that says which.
@@ -427,7 +423,7 @@ mod sway_probe_tests {
     fn a_status_outside_the_known_set_cannot_be_read_as_an_answer() {
         let why = why_broken(&doctor_reporting("green"));
         assert!(
-            why.contains("unrecognized status Some(\"green\")"),
+            why.contains("unrecognized status \"green\""),
             "must name what it got: {why}"
         );
     }
@@ -545,14 +541,6 @@ mod android_probe_tests {
         }
     }
 
-    #[test]
-    fn a_skipped_device_check_is_absent() {
-        assert!(matches!(
-            classify_android(&doctor_reporting("ok", "skip", "skipped — adb unavailable")),
-            HostProbe::Absent
-        ));
-    }
-
     /// The trap: `fail` covers both "nothing to run" and "several devices, pick one". A host with
     /// adb working has android set up, so a refusal is a problem to report, not a reason to skip
     /// quietly — and the report must carry doctor's own detail, which is the only thing that says
@@ -573,7 +561,13 @@ mod android_probe_tests {
     #[test]
     fn a_device_status_outside_the_known_set_cannot_be_read_as_an_answer() {
         let why = why_broken(&doctor_reporting("ok", "green", "…"));
-        assert!(why.contains("green"), "must name what it got: {why}");
+        // The fuller phrase, not just "green": the fixture document also carries the raw
+        // `"status": "green"` field, so a bare `contains("green")` would pass even if the
+        // extracted status were never read into the message at all.
+        assert!(
+            why.contains("unrecognized status \"green\""),
+            "must name what it got: {why}"
+        );
     }
 
     #[test]

--- a/crates/glass-mcp/tests/common/mod.rs
+++ b/crates/glass-mcp/tests/common/mod.rs
@@ -1,6 +1,6 @@
-//! What the two `#[ignore]`d smoke gates share: the private Xvfb the x11 run needs (the MCP
-//! server connects to an X display at startup), the sway probe the wayland run needs, and the
-//! report readers and assertions both apply to whichever backend they drove.
+//! What the three `#[ignore]`d smoke gates share: the private Xvfb the x11 run needs (the MCP
+//! server connects to an X display at startup), the host probes the wayland and android runs need,
+//! and the report readers and assertions all three apply to whichever backend they drove.
 
 #![allow(dead_code)]
 
@@ -182,14 +182,18 @@ pub fn assert_fixture_checks_pass(json: &serde_json::Value, stdout: &str) {
     }
 }
 
-/// Whether this host has what a gate needs, or why the question could not be answered. A probe
-/// that cannot answer is not a host without the thing: the first must fail the test, the second
-/// must skip it.
+/// Whether this host has what a gate needs, or why it cannot be used. A host that simply lacks the
+/// feature is not the same as one that has it and cannot run it: the first must skip, and the
+/// second — like a probe that could not answer at all — must fail loudly.
 #[derive(Debug)]
 #[must_use]
 pub enum HostProbe {
     Available,
+    /// This host does not have the feature the gate drives, so there is nothing here to report.
     Absent,
+    /// Either the probe could not answer, or this host has the feature and glass will not use it.
+    /// Neither is a host to skip: the first would pass off an unasked question as an absent
+    /// feature, the second a setup gap the operator can act on.
     Broken(String),
 }
 
@@ -216,7 +220,9 @@ impl HostProbe {
                 eprintln!("no {what}; skipping");
                 false
             }
-            Self::Broken(why) => panic!("cannot tell whether this host can run the gate: {why}"),
+            Self::Broken(why) => {
+                panic!("the gate cannot run here, and this host is not one to skip: {why}")
+            }
         }
     }
 }
@@ -316,8 +322,9 @@ fn classify(doc: &serde_json::Value) -> HostProbe {
     }
 }
 
-/// Read a `doctor --json` document's verdict on android. Split from running the binary because
-/// the ways the document can be unreadable are what needs testing, and none of them need a device.
+/// Read a `doctor --json` document's verdict on android: can the gate run here, is this simply a
+/// host without android, or is it one that has android and will not run it? Split from running the
+/// binary because those readings are what needs testing, and none of them need a device.
 fn classify_android(doc: &serde_json::Value) -> HostProbe {
     let (adb, _) = match check_status(doc, "android", "adb") {
         Ok(v) => v,
@@ -334,12 +341,22 @@ fn classify_android(doc: &serde_json::Value) -> HostProbe {
     match device {
         // Attached, or about to boot: the runner inherits glass's auto-boot lifecycle.
         "ok" | "warn" => HostProbe::Available,
-        // `fail` is two conditions — nothing to run, and a refusal such as several online devices
-        // with no serial chosen. A host whose adb works has android set up, so both are worth
-        // reporting; doctor's own detail is the only thing that says which.
-        "fail" => HostProbe::Broken(format!(
-            "glass will not use any device on this host: {detail}"
-        )),
+        // `fail` is two conditions — no device and nothing to boot, and a refusal such as several
+        // online devices with no serial chosen. The `emulator` check is what tells them apart:
+        // doctor reports `device` as `warn` (will boot) whenever an AVD exists, so a `fail` beside
+        // AVDs is a refusal, and a `fail` without them is a host with nothing to run.
+        "fail" => match check_status(doc, "android", "emulator") {
+            Ok(("ok", _)) => HostProbe::Broken(format!(
+                "glass will not use any device on this host: {detail}"
+            )),
+            // Every non-`ok` verdict means no AVD glass could boot — no emulator binary, or none
+            // listed. With no device either, this host is not set up for android at all.
+            Ok(("warn" | "fail" | "skip", _)) => HostProbe::Absent,
+            Ok((other, _)) => HostProbe::Broken(format!(
+                "the android emulator check had unrecognized status {other:?}: {doc}"
+            )),
+            Err(why) => HostProbe::Broken(why),
+        },
         other => HostProbe::Broken(format!(
             "the android device check had unrecognized status {other:?}: {doc}"
         )),
@@ -488,16 +505,22 @@ mod android_probe_tests {
     use super::*;
     use serde_json::json;
 
-    /// A `doctor --json` document shaped like the real one's android section. A shape that
-    /// drifted from doctor's own would make every host `Broken`, which panics — so this fixture
-    /// cannot rot quietly.
-    fn doctor_reporting(adb: &str, device: &str, device_detail: &str) -> serde_json::Value {
+    /// A `doctor --json` document shaped like the real one's android section, in doctor's own
+    /// check order. A shape that drifted from doctor's own would make every host `Broken`, which
+    /// panics — so this fixture cannot rot quietly.
+    fn doctor_reporting(
+        adb: &str,
+        emulator: &str,
+        device: &str,
+        device_detail: &str,
+    ) -> serde_json::Value {
         json!({
             "sections": [{
                 "title": "android",
                 "backend": "android",
                 "checks": [
                     { "name": "adb", "status": adb, "detail": "adb at …" },
+                    { "name": "emulator", "status": emulator, "detail": "emulator at …" },
                     { "name": "device", "status": device, "detail": device_detail },
                     { "name": "screencap", "status": "ok", "detail": "…" },
                 ],
@@ -519,7 +542,7 @@ mod android_probe_tests {
         for device in ["ok", "warn"] {
             assert!(
                 matches!(
-                    classify_android(&doctor_reporting("ok", device, "…")),
+                    classify_android(&doctor_reporting("ok", "ok", device, "…")),
                     HostProbe::Available
                 ),
                 "device {device:?} must read as a host that can run"
@@ -533,7 +556,7 @@ mod android_probe_tests {
         for device in ["skip", "fail", "ok"] {
             assert!(
                 matches!(
-                    classify_android(&doctor_reporting("fail", device, "…")),
+                    classify_android(&doctor_reporting("fail", "ok", device, "…")),
                     HostProbe::Absent
                 ),
                 "no adb must read as absent even when device says {device:?}"
@@ -541,13 +564,35 @@ mod android_probe_tests {
         }
     }
 
-    /// The trap: `fail` covers both "nothing to run" and "several devices, pick one". A host with
-    /// adb working has android set up, so a refusal is a problem to report, not a reason to skip
-    /// quietly — and the report must carry doctor's own detail, which is the only thing that says
-    /// which of the two it was.
+    /// The ordinary contributor: a distro-packaged `adb`, no phone and no AVD. Nothing here is
+    /// set up for android and nothing is misconfigured, so this must skip — the same shape as a
+    /// host with no sway — rather than fail a gate the developer never asked to run.
     #[test]
-    fn a_failing_device_check_on_a_host_with_adb_is_reported_not_skipped() {
+    fn a_host_with_adb_but_nothing_to_run_is_absent() {
+        for emulator in ["warn", "fail", "skip"] {
+            assert!(
+                matches!(
+                    classify_android(&doctor_reporting(
+                        "ok",
+                        emulator,
+                        "fail",
+                        "no online device and no AVD to boot",
+                    )),
+                    HostProbe::Absent
+                ),
+                "emulator {emulator:?} means no AVD to boot, so this host has nothing to run"
+            );
+        }
+    }
+
+    /// The other half of a failing `device` check: an AVD exists, so doctor would have said "will
+    /// boot" had that been the whole story — the failure is a refusal. That is a host with android
+    /// set up, which is worth reporting rather than skipping quietly, and doctor's own detail is
+    /// the only thing that says what glass refused over.
+    #[test]
+    fn a_refusal_on_a_host_with_an_avd_is_reported_not_skipped() {
         let why = why_broken(&doctor_reporting(
+            "ok",
             "ok",
             "fail",
             "2 online devices; set GLASS_ANDROID_SERIAL to one of: [emulator-5554, emulator-5556]",
@@ -560,7 +605,7 @@ mod android_probe_tests {
 
     #[test]
     fn a_device_status_outside_the_known_set_cannot_be_read_as_an_answer() {
-        let why = why_broken(&doctor_reporting("ok", "green", "…"));
+        let why = why_broken(&doctor_reporting("ok", "ok", "green", "…"));
         // The fuller phrase, not just "green": the fixture document also carries the raw
         // `"status": "green"` field, so a bare `contains("green")` would pass even if the
         // extracted status were never read into the message at all.
@@ -568,6 +613,33 @@ mod android_probe_tests {
             why.contains("unrecognized status \"green\""),
             "must name what it got: {why}"
         );
+    }
+
+    /// The emulator check is what decides skip-or-report, so a verdict nobody mapped cannot be
+    /// guessed at in either direction.
+    #[test]
+    fn an_emulator_status_outside_the_known_set_cannot_be_read_as_an_answer() {
+        let why = why_broken(&doctor_reporting("ok", "green", "fail", "…"));
+        assert!(
+            why.contains("emulator check had unrecognized status \"green\""),
+            "must name the check and what it got: {why}"
+        );
+    }
+
+    /// Without the emulator check there is nothing to tell a refusal from an empty host, and
+    /// guessing either way is worse than saying so.
+    #[test]
+    fn an_android_section_with_no_emulator_check_cannot_be_read_as_an_answer() {
+        let why = why_broken(&json!({
+            "sections": [{
+                "title": "android",
+                "checks": [
+                    { "name": "adb", "status": "ok", "detail": "…" },
+                    { "name": "device", "status": "fail", "detail": "…" },
+                ],
+            }],
+        }));
+        assert!(why.contains("emulator"), "must name the check: {why}");
     }
 
     #[test]

--- a/crates/glass-mcp/tests/common/mod.rs
+++ b/crates/glass-mcp/tests/common/mod.rs
@@ -182,12 +182,12 @@ pub fn assert_fixture_checks_pass(json: &serde_json::Value, stdout: &str) {
     }
 }
 
-/// Whether this host has a sway the Wayland backend can spawn, or why the question could not be
-/// answered. A probe that cannot answer is not a host without sway: the first must fail the
-/// test, the second must skip it.
+/// Whether this host has what a gate needs, or why the question could not be answered. A probe
+/// that cannot answer is not a host without the thing: the first must fail the test, the second
+/// must skip it.
 #[derive(Debug)]
 #[must_use]
-pub enum SwayProbe {
+pub enum HostProbe {
     Available,
     Absent,
     Broken(String),
@@ -197,39 +197,67 @@ pub enum SwayProbe {
 /// green wayland gate always means the gate ran, and a developer laptop leaves it unset and skips.
 pub const REQUIRE_WAYLAND: &str = "GLASS_SMOKE_REQUIRE_WAYLAND";
 
-impl SwayProbe {
+/// Set in the environment to make an absent android host a failure rather than a skip, matching
+/// [`REQUIRE_WAYLAND`].
+pub const REQUIRE_ANDROID: &str = "GLASS_SMOKE_REQUIRE_ANDROID";
+
+impl HostProbe {
     /// Whether the gate can run, panicking rather than returning `false` for every answer a skip
-    /// would misreport as a pass: a probe that could not answer, and — where [`REQUIRE_WAYLAND`]
-    /// demands a real run — a host with no sway at all.
+    /// would misreport as a pass: a probe that could not answer, and — where `require_var`
+    /// demands a real run — a host that lacks what the gate needs.
     #[must_use]
-    pub fn can_run(self) -> bool {
+    pub fn can_run(self, require_var: &str, what: &str) -> bool {
         match self {
             Self::Available => true,
-            Self::Absent if std::env::var_os(REQUIRE_WAYLAND).is_some() => panic!(
-                "{REQUIRE_WAYLAND} is set, so this gate must run, but no glass-discoverable \
-                 sway >=1.12 was found for the Wayland backend to spawn"
-            ),
+            Self::Absent if std::env::var_os(require_var).is_some() => {
+                panic!("{require_var} is set, so this gate must run, but this host has no {what}")
+            }
             Self::Absent => {
-                eprintln!("no glass-discoverable sway >=1.12; skipping");
+                eprintln!("no {what}; skipping");
                 false
             }
-            Self::Broken(why) => panic!("cannot tell whether this host has sway: {why}"),
+            Self::Broken(why) => panic!("cannot tell whether this host can run the gate: {why}"),
         }
     }
 }
 
 /// Does this host have a sway the Wayland backend can spawn? Asks the shipped binary's own probe
 /// rather than re-implementing discovery, so the guard and the backend cannot disagree.
-pub fn sway_probe(server: &str) -> SwayProbe {
+pub fn sway_probe(server: &str) -> HostProbe {
     let out = match Command::new(server).args(["doctor", "--json"]).output() {
         Ok(out) => out,
-        Err(e) => return SwayProbe::Broken(format!("could not run {server} doctor --json: {e}")),
+        Err(e) => return HostProbe::Broken(format!("could not run {server} doctor --json: {e}")),
     };
     match serde_json::from_slice(&out.stdout) {
         Ok(json) => classify(&json),
         // A doctor that died before printing leaves an empty stdout, so its status and stderr
         // are the only cause there is to report.
-        Err(e) => SwayProbe::Broken(format!(
+        Err(e) => HostProbe::Broken(format!(
+            "{server} doctor --json printed no readable JSON ({e}); {}, stdout: {:?}, \
+             stderr tail: {}",
+            out.status,
+            String::from_utf8_lossy(&out.stdout),
+            tail(&out.stderr),
+        )),
+    }
+}
+
+/// Does this host have an android device the backend can drive? Runs doctor with
+/// `GLASS_BACKEND=android`, because doctor softens an inactive android section's failures to
+/// warnings — a `device` check that says `fail` would otherwise arrive as `warn` and read as
+/// "will boot an AVD".
+pub fn android_probe(server: &str) -> HostProbe {
+    let out = match Command::new(server)
+        .args(["doctor", "--json"])
+        .env("GLASS_BACKEND", "android")
+        .output()
+    {
+        Ok(out) => out,
+        Err(e) => return HostProbe::Broken(format!("could not run {server} doctor --json: {e}")),
+    };
+    match serde_json::from_slice(&out.stdout) {
+        Ok(json) => classify_android(&json),
+        Err(e) => HostProbe::Broken(format!(
             "{server} doctor --json printed no readable JSON ({e}); {}, stdout: {:?}, \
              stderr tail: {}",
             out.status,
@@ -246,34 +274,78 @@ fn tail(stream: &[u8]) -> String {
     lines[lines.len().saturating_sub(5)..].join(" | ")
 }
 
-/// Read a `doctor --json` document's verdict on sway. Split from running the binary because the
-/// six ways the document can be unreadable are what needs testing, and none of them need a host.
-fn classify(doctor_json: &serde_json::Value) -> SwayProbe {
-    let Some(sections) = doctor_json["sections"].as_array() else {
-        return SwayProbe::Broken(format!(
-            "doctor --json had no \"sections\" array: {doctor_json}"
-        ));
+/// One check's status from a `doctor --json` document, or why the document could not answer.
+fn check_status<'a>(
+    doc: &'a serde_json::Value,
+    section: &str,
+    check: &str,
+) -> Result<(&'a str, &'a str), String> {
+    let Some(sections) = doc["sections"].as_array() else {
+        return Err(format!("doctor --json had no \"sections\" array: {doc}"));
     };
-    let Some(wayland) = sections.iter().find(|s| s["title"] == "wayland") else {
-        return SwayProbe::Broken(format!(
-            "doctor --json had no \"wayland\" section: {doctor_json}"
-        ));
+    let Some(s) = sections.iter().find(|s| s["title"] == section) else {
+        return Err(format!("doctor --json had no {section:?} section: {doc}"));
     };
-    let Some(check) = wayland["checks"]
+    let Some(c) = s["checks"]
         .as_array()
         .into_iter()
         .flatten()
-        .find(|c| c["name"] == "sway >=1.12")
+        .find(|c| c["name"] == check)
     else {
-        return SwayProbe::Broken(format!(
-            "wayland section had no \"sway >=1.12\" check: {wayland}"
-        ));
+        return Err(format!("{section} section had no {check:?} check: {s}"));
     };
-    match check["status"].as_str() {
-        Some("ok") => SwayProbe::Available,
-        Some("warn" | "fail" | "skip") => SwayProbe::Absent,
-        other => SwayProbe::Broken(format!(
-            "sway >=1.12 check had unrecognized status {other:?}: {wayland}"
+    let status = c["status"]
+        .as_str()
+        .ok_or_else(|| format!("{check:?} check carried no status string: {c}"))?;
+    Ok((status, c["detail"].as_str().unwrap_or_default()))
+}
+
+/// Read a `doctor --json` document's verdict on sway. Split from running the binary because the
+/// six ways the document can be unreadable are what needs testing, and none of them need a host.
+fn classify(doc: &serde_json::Value) -> HostProbe {
+    let (status, _) = match check_status(doc, "wayland", "sway >=1.12") {
+        Ok(v) => v,
+        Err(why) => return HostProbe::Broken(why),
+    };
+    match status {
+        "ok" => HostProbe::Available,
+        "warn" | "fail" | "skip" => HostProbe::Absent,
+        // `Some(other)` (rather than `other` alone) keeps this message identical to when this
+        // read `check["status"].as_str()` directly, which is what `sway_probe_tests` still checks.
+        other => HostProbe::Broken(format!(
+            "sway >=1.12 check had unrecognized status {:?}: {doc}",
+            Some(other)
+        )),
+    }
+}
+
+/// Read a `doctor --json` document's verdict on android. Split from running the binary because
+/// the ways the document can be unreadable are what needs testing, and none of them need a device.
+fn classify_android(doc: &serde_json::Value) -> HostProbe {
+    let (adb, _) = match check_status(doc, "android", "adb") {
+        Ok(v) => v,
+        Err(why) => return HostProbe::Broken(why),
+    };
+    // No adb is a host with no android SDK: nothing to report, nothing to fix for this gate.
+    if adb != "ok" {
+        return HostProbe::Absent;
+    }
+    let (device, detail) = match check_status(doc, "android", "device") {
+        Ok(v) => v,
+        Err(why) => return HostProbe::Broken(why),
+    };
+    match device {
+        // Attached, or about to boot: the runner inherits glass's auto-boot lifecycle.
+        "ok" | "warn" => HostProbe::Available,
+        "skip" => HostProbe::Absent,
+        // `fail` is two conditions — nothing to run, and a refusal such as several online devices
+        // with no serial chosen. A host whose adb works has android set up, so both are worth
+        // reporting; doctor's own detail is the only thing that says which.
+        "fail" => HostProbe::Broken(format!(
+            "glass will not use any device on this host: {detail}"
+        )),
+        other => HostProbe::Broken(format!(
+            "the android device check had unrecognized status {other:?}: {doc}"
         )),
     }
 }
@@ -325,7 +397,7 @@ mod sway_probe_tests {
 
     fn why_broken(json: &serde_json::Value) -> String {
         match classify(json) {
-            SwayProbe::Broken(why) => why,
+            HostProbe::Broken(why) => why,
             other => panic!("expected Broken, got {other:?}"),
         }
     }
@@ -334,7 +406,7 @@ mod sway_probe_tests {
     fn an_ok_sway_check_means_the_gate_can_run() {
         assert!(matches!(
             classify(&doctor_reporting("ok")),
-            SwayProbe::Available
+            HostProbe::Available
         ));
     }
 
@@ -345,7 +417,7 @@ mod sway_probe_tests {
     fn every_non_ok_sway_verdict_means_the_host_has_no_sway() {
         for status in ["warn", "fail", "skip"] {
             assert!(
-                matches!(classify(&doctor_reporting(status)), SwayProbe::Absent),
+                matches!(classify(&doctor_reporting(status)), HostProbe::Absent),
                 "status {status:?} must read as a host without sway"
             );
         }
@@ -390,7 +462,7 @@ mod sway_probe_tests {
         .expect("write");
         std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755)).expect("chmod");
         let why = match sway_probe(fake.to_str().expect("utf-8 path")) {
-            SwayProbe::Broken(why) => why,
+            HostProbe::Broken(why) => why,
             other => panic!("expected Broken, got {other:?}"),
         };
         assert!(
@@ -412,5 +484,112 @@ mod sway_probe_tests {
             }],
         }));
         assert!(why.contains("sway >=1.12"), "must name the check: {why}");
+    }
+}
+
+#[cfg(test)]
+mod android_probe_tests {
+    use super::*;
+    use serde_json::json;
+
+    /// A `doctor --json` document shaped like the real one's android section. A shape that
+    /// drifted from doctor's own would make every host `Broken`, which panics — so this fixture
+    /// cannot rot quietly.
+    fn doctor_reporting(adb: &str, device: &str, device_detail: &str) -> serde_json::Value {
+        json!({
+            "sections": [{
+                "title": "android",
+                "backend": "android",
+                "checks": [
+                    { "name": "adb", "status": adb, "detail": "adb at …" },
+                    { "name": "device", "status": device, "detail": device_detail },
+                    { "name": "screencap", "status": "ok", "detail": "…" },
+                ],
+            }],
+        })
+    }
+
+    fn why_broken(json: &serde_json::Value) -> String {
+        match classify_android(json) {
+            HostProbe::Broken(why) => why,
+            other => panic!("expected Broken, got {other:?}"),
+        }
+    }
+
+    /// Both verdicts a healthy host can reach: attached to a device, or about to boot one. The
+    /// runner inherits glass's auto-boot lifecycle, so "will boot" is a host that can run.
+    #[test]
+    fn an_attached_or_bootable_device_means_the_gate_can_run() {
+        for device in ["ok", "warn"] {
+            assert!(
+                matches!(
+                    classify_android(&doctor_reporting("ok", device, "…")),
+                    HostProbe::Available
+                ),
+                "device {device:?} must read as a host that can run"
+            );
+        }
+    }
+
+    /// No adb is a host without android set up — skip, do not fail.
+    #[test]
+    fn a_host_without_adb_is_absent_whatever_the_device_check_says() {
+        for device in ["skip", "fail", "ok"] {
+            assert!(
+                matches!(
+                    classify_android(&doctor_reporting("fail", device, "…")),
+                    HostProbe::Absent
+                ),
+                "no adb must read as absent even when device says {device:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_skipped_device_check_is_absent() {
+        assert!(matches!(
+            classify_android(&doctor_reporting("ok", "skip", "skipped — adb unavailable")),
+            HostProbe::Absent
+        ));
+    }
+
+    /// The trap: `fail` covers both "nothing to run" and "several devices, pick one". A host with
+    /// adb working has android set up, so a refusal is a problem to report, not a reason to skip
+    /// quietly — and the report must carry doctor's own detail, which is the only thing that says
+    /// which of the two it was.
+    #[test]
+    fn a_failing_device_check_on_a_host_with_adb_is_reported_not_skipped() {
+        let why = why_broken(&doctor_reporting(
+            "ok",
+            "fail",
+            "2 online devices; set GLASS_ANDROID_SERIAL to one of: [emulator-5554, emulator-5556]",
+        ));
+        assert!(
+            why.contains("GLASS_ANDROID_SERIAL"),
+            "must carry doctor's own detail: {why}"
+        );
+    }
+
+    #[test]
+    fn a_device_status_outside_the_known_set_cannot_be_read_as_an_answer() {
+        let why = why_broken(&doctor_reporting("ok", "green", "…"));
+        assert!(why.contains("green"), "must name what it got: {why}");
+    }
+
+    #[test]
+    fn a_document_with_no_android_section_cannot_be_read_as_an_answer() {
+        let why = why_broken(&json!({ "sections": [{ "title": "x11", "checks": [] }] }));
+        assert!(why.contains("android"), "must name what was missing: {why}");
+    }
+
+    #[test]
+    fn an_android_section_with_no_device_check_cannot_be_read_as_an_answer() {
+        let why = why_broken(&json!({
+            "sections": [{
+                "title": "android",
+                "checks": [{ "name": "adb", "status": "ok", "detail": "…" }],
+            }],
+        }));
+        assert!(why.contains("device"), "must name the check: {why}");
     }
 }

--- a/crates/glass-mcp/tests/common/mod.rs
+++ b/crates/glass-mcp/tests/common/mod.rs
@@ -189,7 +189,8 @@ pub fn assert_fixture_checks_pass(json: &serde_json::Value, stdout: &str) {
 #[must_use]
 pub enum HostProbe {
     Available,
-    /// This host does not have the feature the gate drives, so there is nothing here to report.
+    /// The probe found no way for this gate to run here. Skipping is the honest answer to that;
+    /// where a run is mandatory, the `require_*` variable turns the skip into a failure.
     Absent,
     /// Either the probe could not answer, or this host has the feature and glass will not use it.
     /// Neither is a host to skip: the first would pass off an unasked question as an absent
@@ -208,7 +209,7 @@ pub const REQUIRE_ANDROID: &str = "GLASS_SMOKE_REQUIRE_ANDROID";
 impl HostProbe {
     /// Whether the gate can run, panicking rather than returning `false` for every answer a skip
     /// would misreport as a pass: a probe that could not answer, and — where `require_var`
-    /// demands a real run — a host that lacks what the gate needs.
+    /// demands a real run — a host the probe found no way to run on.
     #[must_use]
     pub fn can_run(self, require_var: &str, what: &str) -> bool {
         match self {
@@ -322,9 +323,9 @@ fn classify(doc: &serde_json::Value) -> HostProbe {
     }
 }
 
-/// Read a `doctor --json` document's verdict on android: can the gate run here, is this simply a
-/// host without android, or is it one that has android and will not run it? Split from running the
-/// binary because those readings are what needs testing, and none of them need a device.
+/// Read a `doctor --json` document's verdict on android: can the gate run here, did the probe find
+/// no way to get a device, or does this host have an AVD and refuse to use one? Split from running
+/// the binary because those readings are what needs testing, and none of them need a device.
 fn classify_android(doc: &serde_json::Value) -> HostProbe {
     let (adb, _) = match check_status(doc, "android", "adb") {
         Ok(v) => v,
@@ -342,15 +343,17 @@ fn classify_android(doc: &serde_json::Value) -> HostProbe {
         // Attached, or about to boot: the runner inherits glass's auto-boot lifecycle.
         "ok" | "warn" => HostProbe::Available,
         // `fail` is two conditions — no device and nothing to boot, and a refusal such as several
-        // online devices with no serial chosen. The `emulator` check is what tells them apart:
-        // doctor reports `device` as `warn` (will boot) whenever an AVD exists, so a `fail` beside
-        // AVDs is a refusal, and a `fail` without them is a host with nothing to run.
+        // online devices with no serial chosen. The `emulator` check is the only signal that
+        // separates them: doctor reports `device` as `warn` (will boot) whenever an AVD exists, so
+        // a `fail` beside AVDs is a refusal.
         "fail" => match check_status(doc, "android", "emulator") {
             Ok(("ok", _)) => HostProbe::Broken(format!(
                 "glass will not use any device on this host: {detail}"
             )),
-            // Every non-`ok` verdict means no AVD glass could boot — no emulator binary, or none
-            // listed. With no device either, this host is not set up for android at all.
+            // Every non-`ok` verdict means no AVD to fall back on — no emulator binary, or none
+            // listed. Usually a host with no android set up; a refusal on a host with devices
+            // attached but no AVDs is indistinguishable from that in what doctor exposes, so it
+            // skips too. `REQUIRE_ANDROID` is what makes that safe where a run is mandatory.
             Ok(("warn" | "fail" | "skip", _)) => HostProbe::Absent,
             Ok((other, _)) => HostProbe::Broken(format!(
                 "the android emulator check had unrecognized status {other:?}: {doc}"

--- a/crates/glass-mcp/tests/common/mod.rs
+++ b/crates/glass-mcp/tests/common/mod.rs
@@ -508,9 +508,12 @@ mod android_probe_tests {
     use super::*;
     use serde_json::json;
 
-    /// A `doctor --json` document shaped like the real one's android section, in doctor's own
-    /// check order. A shape that drifted from doctor's own would make every host `Broken`, which
-    /// panics — so this fixture cannot rot quietly.
+    /// A `doctor --json` document shaped like the real one's android section: all seven checks
+    /// doctor always emits, in its own order. The four this classifier does not read carry what a
+    /// plain (non-`--deep`) run produces — optional companions and unrequested deep probes all
+    /// skip. A shape that drifted from doctor's own would make every host `Broken`, which panics,
+    /// so this fixture cannot rot quietly; holding only the checks read today would instead answer
+    /// a classifier that reaches for a fifth with a document doctor never emits.
     fn doctor_reporting(
         adb: &str,
         emulator: &str,
@@ -525,7 +528,10 @@ mod android_probe_tests {
                     { "name": "adb", "status": adb, "detail": "adb at …" },
                     { "name": "emulator", "status": emulator, "detail": "emulator at …" },
                     { "name": "device", "status": device, "detail": device_detail },
-                    { "name": "screencap", "status": "ok", "detail": "…" },
+                    { "name": "agent", "status": "skip", "detail": "not configured …" },
+                    { "name": "a11y-service", "status": "skip", "detail": "not configured …" },
+                    { "name": "screencap", "status": "skip", "detail": "…" },
+                    { "name": "uiautomator", "status": "skip", "detail": "…" },
                 ],
             }],
         })

--- a/crates/glass-mcp/tests/smoke_android.rs
+++ b/crates/glass-mcp/tests/smoke_android.rs
@@ -13,10 +13,10 @@ const SERVER: &str = env!("CARGO_BIN_EXE_glass-mcp");
 fn smoke_android_passes_against_a_stock_app() {
     // The backend attaches to an online device or boots the configured AVD, so there is nothing
     // to start here — but a host with no android at all must skip rather than report a failure
-    // it cannot act on.
+    // it cannot act on. A host that has android and will not run it is reported, not skipped.
     if !android_probe(SERVER).can_run(
         REQUIRE_ANDROID,
-        "adb-reachable android device or AVD to boot",
+        "android setup glass can drive — adb, plus an online device or an AVD to boot",
     ) {
         return;
     }

--- a/crates/glass-mcp/tests/smoke_android.rs
+++ b/crates/glass-mcp/tests/smoke_android.rs
@@ -11,12 +11,12 @@ const SERVER: &str = env!("CARGO_BIN_EXE_glass-mcp");
 #[test]
 #[ignore = "requires an adb-reachable android device or an AVD to boot; run via: cargo test -p glass-mcp --test smoke_android -- --ignored"]
 fn smoke_android_passes_against_a_stock_app() {
-    // The backend attaches to an online device or boots the configured AVD, so there is nothing
-    // to start here — but a host with no android at all must skip rather than report a failure
-    // it cannot act on. A host that has android and will not run it is reported, not skipped.
+    // The backend attaches to an online device or boots the configured AVD, so there is nothing to
+    // start here — but a host the probe found no way to get a device on must skip rather than
+    // report a failure it cannot act on. A host with an AVD that glass refuses to use is reported.
     if !android_probe(SERVER).can_run(
         REQUIRE_ANDROID,
-        "android setup glass can drive — adb, plus an online device or an AVD to boot",
+        "device glass will use, and no AVD it would boot instead",
     ) {
         return;
     }

--- a/crates/glass-mcp/tests/smoke_android.rs
+++ b/crates/glass-mcp/tests/smoke_android.rs
@@ -1,0 +1,24 @@
+//! End-to-end: the shipped `smoke` subcommand against a stock app under the android backend, on a
+//! live device. #[ignore]d (needs an adb-reachable device or an AVD to boot); run via:
+//!   cargo test -p glass-mcp --test smoke_android -- --ignored
+
+mod common;
+
+use common::{REQUIRE_ANDROID, android_probe, assert_smoke_gate};
+
+const SERVER: &str = env!("CARGO_BIN_EXE_glass-mcp");
+
+#[test]
+#[ignore = "requires an adb-reachable android device or an AVD to boot; run via: cargo test -p glass-mcp --test smoke_android -- --ignored"]
+fn smoke_android_passes_against_a_stock_app() {
+    // The backend attaches to an online device or boots the configured AVD, so there is nothing
+    // to start here — but a host with no android at all must skip rather than report a failure
+    // it cannot act on.
+    if !android_probe(SERVER).can_run(
+        REQUIRE_ANDROID,
+        "adb-reachable android device or AVD to boot",
+    ) {
+        return;
+    }
+    assert_smoke_gate(SERVER, "android", &[]);
+}

--- a/crates/glass-mcp/tests/smoke_wayland.rs
+++ b/crates/glass-mcp/tests/smoke_wayland.rs
@@ -4,7 +4,7 @@
 
 mod common;
 
-use common::{assert_smoke_gate, sway_probe};
+use common::{REQUIRE_WAYLAND, assert_smoke_gate, sway_probe};
 
 const SERVER: &str = env!("CARGO_BIN_EXE_glass-mcp");
 
@@ -13,7 +13,7 @@ const SERVER: &str = env!("CARGO_BIN_EXE_glass-mcp");
 fn smoke_wayland_passes_against_a_real_app() {
     // The backend spawns its own compositor, so there is nothing to start here — but a host
     // without sway must skip rather than report a failure it cannot act on.
-    if !sway_probe(SERVER).can_run() {
+    if !sway_probe(SERVER).can_run(REQUIRE_WAYLAND, "glass-discoverable sway >=1.12") {
         return;
     }
     assert_smoke_gate(SERVER, "wayland", &[]);

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -68,16 +68,19 @@ glass's own MCP tools against a real app and report whether this build works end
 the statuses, and the report's fields are described in
 [smoke checks and report](smoke.md).
 
-- `--backend <name>` — backend to exercise. The smoke runner drives `x11`, which is the default, and
-  `wayland`; the candidates each one probes are listed in [smoke checks and report](smoke.md#target-apps),
-  and a `wayland` run additionally needs a discoverable sway ≥ 1.12 to launch the app into.
+- `--backend <name>` — backend to exercise. The smoke runner drives `x11` (the default), `wayland`
+  and `android`; each backend's candidates, and how it chooses among them, are listed in
+  [smoke checks and report](smoke.md#target-apps), and a `wayland` run additionally needs a
+  discoverable sway ≥ 1.12 to launch the app into.
   Also sets `GLASS_BACKEND` for the server the run spawns, overriding any ambient value, so
   the session and `glass_doctor`'s verdict always agree on which backend is under test.
 - `--report <path>` — also write the JSON report to `path` (the text report always goes to stdout).
-- `--app <name>` — force a specific candidate app instead of probing for the first one present. The
-  name must be one of the backend's candidates; a name that is not is a usage error. A real run does
-  not check the named binary for presence, so naming an app that is not installed fails at the
-  `start` check; a `--dry-run` does check, and marks the plan unavailable.
+- `--app <name>` — force a specific candidate app instead of the one the backend would choose on its
+  own. The name must be one of the backend's candidates; a name that is not is a usage error. A real
+  run does not check the named app for presence, so naming one that is not there fails at the
+  `start` check. Under `--dry-run`, `x11` and `wayland` do check `PATH` and mark the plan unavailable
+  when the named app is not on it; nothing on the host can check an `android` candidate, so its
+  `--dry-run` always accepts the name.
 - `--dry-run` — print the plan and exit without spawning a server, launching an app, or calling a
   tool. Every check is a `skip`, the heading reads `PASS (plan only)`, and the exit code is 0. With
   `--report`, the plan is written as JSON like any other run. Unlike a real run, this does not

--- a/docs/reference/smoke.md
+++ b/docs/reference/smoke.md
@@ -41,10 +41,13 @@ A `--backend wayland` run also needs a discoverable sway ≥ 1.12 — the backen
 headless one per session, and [Set up Linux](../how-to/setup-linux.md#wayland-sway) covers where it
 looks. Without one, check 1 (`start`) fails: there is no compositor to launch the app into.
 
-An `android` run needs a reachable `adb` and either an online device or an AVD glass can boot —
-`glass-mcp doctor` reports both under `android`. Because nothing probes the device, a component
-that is not installed on the image under test fails check 1 (`start`) with the launch error the
-device reported; the failure names the other candidates and how to select one.
+An `android` run needs a reachable `adb` and either an online device or an AVD glass can boot.
+`GLASS_BACKEND=android glass-mcp doctor` reports both under `android` as the run will meet them.
+Under any other backend, doctor softens that section's failures to advisory warnings — they are not
+required for the backend it is grading — so a host with no device and no AVD reads there as a
+warning rather than a failure, and the exit code stays 0. Because nothing probes the device, a
+component that is not installed on the image under test fails check 1 (`start`) with the launch
+error the device reported; the failure names the other candidates and how to select one.
 
 ## Checks
 

--- a/docs/reference/smoke.md
+++ b/docs/reference/smoke.md
@@ -16,15 +16,20 @@ server is given `GLASS_BACKEND` set to the backend under test, overriding any am
 
 ## Target apps
 
-A real run drives a stock app installed on the host. Each backend has a candidate list; the run
-probes it in order and takes the first one runnable on `PATH`, recording the choice in the report's
-`app` field. `--app <name>` selects a specific candidate instead.
+A real run drives a stock app, and each backend has a candidate list it chooses from — recording
+the choice in the report's `app` field. How it chooses depends on where the app lives. On `x11`
+and `wayland` the candidates are executables, so the run probes `PATH` and takes the first one
+installed. On `android` the candidate is a `package/.Activity` component on the device, which
+nothing on the host can see, so the run takes the first row as given and never probes: the list is
+a set of choices, not a fallback chain. `--app <name>` selects a different candidate on any
+backend.
 
 <!-- BEGIN GENERATED: smoke-candidates -->
-| Backend | Candidates, in probe order |
-|---|---|
-| `x11` | `xed`, `gnome-text-editor`, `zenity`, `xterm` |
-| `wayland` | `xed`, `gnome-text-editor`, `zenity` |
+| Backend | Chosen by | Candidates, in order |
+|---|---|---|
+| `x11` | first runnable on `PATH` | `xed`, `gnome-text-editor`, `zenity`, `xterm` |
+| `wayland` | first runnable on `PATH` | `xed`, `gnome-text-editor`, `zenity` |
+| `android` | preinstalled; the first row is the default, the rest need `--app` | `contacts` (`com.google.android.contacts/com.android.contacts.activities.CompactContactEditorActivity`), `settings` (`com.android.settings/.Settings`) |
 <!-- END GENERATED: smoke-candidates -->
 
 A wayland run launches its target with `GDK_BACKEND=wayland`, so a toolkit that cannot use the
@@ -35,6 +40,11 @@ wayland candidate.
 A `--backend wayland` run also needs a discoverable sway ≥ 1.12 — the backend spawns a private
 headless one per session, and [Set up Linux](../how-to/setup-linux.md#wayland-sway) covers where it
 looks. Without one, check 1 (`start`) fails: there is no compositor to launch the app into.
+
+An `android` run needs a reachable `adb` and either an online device or an AVD glass can boot —
+`glass-mcp doctor` reports both under `android`. Because nothing probes the device, a component
+that is not installed on the image under test fails check 1 (`start`) with the launch error the
+device reported; the failure names the other candidates and how to select one.
 
 ## Checks
 


### PR DESCRIPTION
`glass-mcp smoke` drove x11 and wayland. This adds android.

Android breaks every assumption the runner was built on: its target is a `package/.Activity`
component on a device rather than an executable on `$PATH`, nothing on the host can see whether
that component is installed, and a launch may boot an emulator first. So four things changed
alongside the new backend row.

**Target resolution became an explicit policy.** `Resolution::OnPath` probes `PATH` as before;
`Resolution::Preinstalled` takes the table's first row as given. The consequence is worth stating
plainly: without a probe, a candidate list is not a fallback chain. `contacts` is what an android
run drives; `settings` is reachable only through `--app`, and exists for images without the Google
apps (it has no editable field, so check 5 skips rather than passing).

**The launch deadline is derived, not chosen.** The shared call timeout is 120s and glass's own
`GLASS_EMULATOR_BOOT_TIMEOUT_MS` defaults to 120000, so a cold-boot launch had the same client-side
and device-side budget — anything spent launching after the boot pushed it over, and the client gave
up first, reporting its own deadline as a launch failure. A launch that may boot a device now gets
`boot_budget + CALL_TIMEOUT`: the device's whole budget, plus one ordinary call's worth on top. The
default is read from `glass-android`'s own constant, so the two cannot drift.

**A failed launch names the candidates it did not try.** Since nothing probed the device, check 1 is
the only place an operator learns what else the backend could have driven. On a probing backend the
offer lists only what is actually installed — the earlier rows the probe skipped are known-absent
and naming them would send the operator back to a run that cannot work.

**The gate's host probe distinguishes three answers, not two.** `Available`, `Absent`, and `Broken`:
a probe that cannot answer is not a host without the feature. It runs `doctor --json` with
`GLASS_BACKEND=android`, because doctor softens an inactive backend's failures to warnings — a
`device` check that says `fail` would otherwise arrive as `warn` and read as "will boot an AVD".

## Verified on a device

Not CI-verifiable, so it was run by hand against an emulator and the output recorded:

- the `#[ignore]`d gate: 8/8 `pass`
- `interaction` detail `element #34 took the value; pixel path ok` — the empty confirmation clause
  means the same element id both received the write and reported it back, which is the strongest of
  the three outcomes that check can report
- `--app settings`: 7 `pass` + `interaction` `skip`, exit 0 — the honest degrade, not a failure
- a forced full cold boot (`-no-snapshot-load`, no device online): 8/8 `pass`, 34.5s for boot plus
  launch plus every check
- `--dry-run`: 8 `skip` rows, `contacts` named, no device contacted

## Two limits, stated rather than implied

**The derived deadline's arithmetic is proven only by unit tests.** A real full boot on the machine
used here takes ~25s, so the on-device run cannot discriminate the derived deadline from any flat
generous budget. What it proves is the path — no device, glass boots the AVD, the app launches, all
eight checks pass. The arithmetic rests on the unit tests, which do distinguish it.

**There is no android CI job, and this does not add one.** Nothing about the android runtime path
gates a PR; the gate is `#[ignore]`d and run by hand or by a release orchestrator. The code that
CI *can* reach — resolution policy, deadline arithmetic, the offer, the probe classification — is
covered by the mutation gate over `crates/glass-mcp/src/smoke/`.

## Also here

`--self-check` gains a sixth injected fault covering check 1, which had none. A malformed
`GLASS_EMULATOR_BOOT_TIMEOUT_MS` now says so on stderr instead of silently falling back — the value
used is still exactly what `glass-android` derives, but an operator who raised the budget for a slow
host is told when it was ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
