### PR TITLE
ci: name the mutation gate after what it gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,7 @@ jobs:
   # A matrix job's checks are named per shard, so the branch ruleset has nothing stable
   # to require. This one has a fixed name and fails if any shard did.
   mutants-gate:
-    name: Mutation gate (smoke)
+    name: Mutation gate (glass-core)
     runs-on: ubuntu-latest
     needs: mutants
     if: always()


### PR DESCRIPTION
The aggregate `mutants-gate` job kept its old name after the gate was re-pointed at `glass-core` in #243, so the one check with a stable name — the one a branch ruleset can require — still read `Mutation gate (smoke)`. The eight per-shard checks were already renamed.

**Action needed after merge:** add `Mutation gate (glass-core)` as a required status check on the master ruleset. The old `Mutation gate (smoke)` context has already been removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)