### PR TITLE
ci: make the weekly mutation sweep informational

### DIFF
--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -34,6 +34,10 @@ jobs:
           tool: cargo-mutants,cargo-nextest
       - name: Sweep
         # nextest runs each test in its own process, so slow tests overlap rather than sum.
+        # Informational until glass-core's pre-existing survivors are cleared (343 as of
+        # 2026-07-28); a permanently-red check is one nobody reads. The per-PR --in-diff gate
+        # blocks, so new and changed code is still covered.
+        continue-on-error: true
         run: |
           scripts/mutants.sh "$RUNNER_TEMP/mutants" \
             --test-tool nextest \


### PR DESCRIPTION
A local full sweep of `glass-core` — the gate's new target since #243 — returned:

| | |
|---|---|
| generated | 1588 |
| caught | 1138 |
| **missed** | **343** |
| timeout | 8 |
| unviable | 99 |

So the glob genuinely generates mutants, which the removal PR could not show (it touched no glass-core file, so every shard skipped).

But 343 survivors means the weekly full sweep would fail every run. `glass-core` had never been under a mutation gate — the module the gate previously targeted was hardened to zero over a dedicated increment, and I re-pointed it without measuring the new target first.

**The per-PR gate is unaffected and still blocks.** It is `--in-diff` scoped, so it only mutates lines a PR touches; pre-existing survivors cannot hide a regression in new code.

The 8 timeouts are `+=` → `*=` inside pixel-conversion loops and `>` → `<` in `LogBuffer::push` — mutants that make loops effectively non-terminating, so timing out is the right outcome rather than a defect.

## The backlog, for whoever picks it up

| file | survivors |
|---|---|
| `diff.rs` | 107 |
| `marks.rs` | 64 |
| `accessibility.rs` | 62 |
| `session/a11y.rs` | 44 |
| `session/wait.rs` | 26 |

Mostly arithmetic operator swaps. Not all are equally valuable, but some are: swapping the `+` in `rgb2y` survives, meaning no test pins the luma values that decide `glass_diff`'s `changed_pct` — a number agents branch on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)