### PR TITLE
test(session/wait): clear the scroll geometry of surviving mutants

### DIFF
--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -31,6 +31,7 @@ pub(crate) struct FakePlatform {
     started: bool,
     capture_log: Arc<Mutex<Vec<Option<Region>>>>,
     click_log: Arc<Mutex<Vec<(i32, i32)>>>,
+    log_batches: std::collections::VecDeque<Vec<(Stream, String)>>,
     key_log: Arc<Mutex<Vec<KeyEvent>>>,
     scroll_log: Arc<Mutex<Vec<PointerEvent>>>,
     drag_log: Arc<Mutex<Vec<PointerEvent>>>,
@@ -108,6 +109,16 @@ impl FakePlatform {
     }
     pub(crate) fn with_logs(mut self, logs: Vec<(Stream, &str)>) -> Self {
         self.pending_logs = logs.into_iter().map(|(s, t)| (s, t.to_string())).collect();
+        self
+    }
+    /// One batch per drain, in order, so a line can be made to arrive on a chosen pump rather
+    /// than all at once. `start` pumps before any wait begins, so staging a line for a later
+    /// drain is the only way to have it land after a call has taken its starting cursor.
+    pub(crate) fn with_log_batches(mut self, batches: Vec<Vec<(Stream, &str)>>) -> Self {
+        self.log_batches = batches
+            .into_iter()
+            .map(|b| b.into_iter().map(|(s, t)| (s, t.to_string())).collect())
+            .collect();
         self
     }
     pub(crate) fn with_windows(mut self, windows: Vec<WindowInfo>) -> Self {
@@ -261,6 +272,9 @@ impl Platform for FakePlatform {
         Ok(self.geometry.clone())
     }
     fn drain_logs(&mut self) -> Vec<(Stream, String)> {
+        if let Some(batch) = self.log_batches.pop_front() {
+            return batch;
+        }
         std::mem::take(&mut self.pending_logs)
     }
     fn get_clipboard(&mut self) -> Result<String> {

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -1326,6 +1326,100 @@ mod tests {
         assert!(out.element.unwrap().bounds.is_none());
     }
 
+    /// `reversed` says whether the match came from the second, opposite sweep. Every existing
+    /// case returns through the tail, which hardcodes `true`, so the flag is only observable
+    /// from a return *inside* the loop — here, a match on the first direction.
+    #[test]
+    fn scroll_to_element_reports_not_reversed_when_found_on_the_first_sweep() {
+        let absent = tree_with(100, 100, vec![]);
+        let realized = tree_with(
+            100,
+            100,
+            vec![AxNode {
+                name: Some("Ghost".into()),
+                ..ax_node(1, AxRole::Button, None, vec![])
+            }],
+        );
+        let mut g = glass_with_a11y_seq(FakePlatform::new(100, 100), vec![absent, realized]);
+        g.start(&spec()).unwrap();
+        let out = g
+            .scroll_to_element(&ScrollToElementParams {
+                name: Some("Ghost".into()),
+                role: None,
+                value_contains: None,
+                direction: Some(ScrollDirection::Down),
+                anchor: None,
+                step: SCROLL_TO_DEFAULT_STEP,
+                timeout_ms: SCROLL_TO_DEFAULT_TIMEOUT_MS,
+            })
+            .unwrap();
+        assert!(out.matched);
+        assert!(
+            !out.reversed,
+            "found on the primary sweep, so the opposite one never ran"
+        );
+    }
+
+    /// Either bound ends the sweep on its own. A zero timeout is spent before the first step,
+    /// so nothing is scrolled — which a conjunction of the two bounds would not honour, since
+    /// the step count is still far below its cap.
+    #[test]
+    fn scroll_to_element_stops_on_the_timeout_alone() {
+        let mut g = glass_with_a11y(FakePlatform::new(100, 100), fake_tree());
+        g.start(&spec()).unwrap();
+        let out = g
+            .scroll_to_element(&ScrollToElementParams {
+                name: Some("Ghost".into()),
+                role: None,
+                value_contains: None,
+                direction: Some(ScrollDirection::Down),
+                anchor: None,
+                step: SCROLL_TO_DEFAULT_STEP,
+                timeout_ms: 0,
+            })
+            .unwrap();
+        assert!(!out.matched);
+        assert_eq!(out.steps, 0, "the timeout is spent before the first scroll");
+        assert!(!out.reversed, "it gave up on the primary sweep");
+    }
+
+    /// The anchor is clamped to the last addressable pixel, so an element whose centre lies
+    /// past the window edge still yields a point inside it.
+    #[test]
+    fn scroll_anchor_clamps_to_the_last_pixel_inside_the_window() {
+        let past = AxRect {
+            x: 300,
+            y: 300,
+            width: 40,
+            height: 40,
+        };
+        // Horizontal sweep anchors x at the window centre and y on the element's row.
+        assert_eq!(
+            scroll_anchor(ScrollDirection::Right, Some(past), 100, 100),
+            (50, 99)
+        );
+        // Vertical sweep anchors y at the centre and x on the element's column.
+        assert_eq!(
+            scroll_anchor(ScrollDirection::Down, Some(past), 100, 100),
+            (99, 50)
+        );
+        // Negative centres clamp up to zero on the same axis.
+        let before = AxRect {
+            x: -300,
+            y: -300,
+            width: 40,
+            height: 40,
+        };
+        assert_eq!(
+            scroll_anchor(ScrollDirection::Right, Some(before), 100, 100),
+            (50, 0)
+        );
+        assert_eq!(
+            scroll_anchor(ScrollDirection::Down, Some(before), 100, 100),
+            (0, 50)
+        );
+    }
+
     #[test]
     fn scroll_to_element_absent_with_omitted_direction_defaults_to_down() {
         // Omitted direction + a target never in the tree: inference has nothing to go
@@ -1992,6 +2086,98 @@ mod tests {
         assert_eq!(Up.as_str(), "up");
         assert_eq!(Left.as_str(), "left");
         assert_eq!(Right.as_str(), "right");
+    }
+
+    /// The overflow magnitudes decide which edge wins, and each is built from its own
+    /// arithmetic. The existing tie-break is 2001 against 501, where a term being off by one
+    /// changes nothing — these put the two candidates exactly one apart, so any single altered
+    /// operand flips the answer. `max_by_key` keeps the *last* maximum, so a tie hands it to
+    /// the later direction in the table.
+    #[test]
+    fn offscreen_direction_tie_breaks_on_a_single_pixel() {
+        let at = |x: i32, y: i32| AxRect {
+            x,
+            y,
+            width: 10,
+            height: 10,
+        };
+        // Right 11 vs Down 10.
+        assert_eq!(
+            offscreen_direction(at(110, 109), 100, 100),
+            Some(ScrollDirection::Right)
+        );
+        // Left 11 vs Up 10.
+        assert_eq!(
+            offscreen_direction(at(-20, -19), 100, 100),
+            Some(ScrollDirection::Left)
+        );
+        // Right 11 vs Up 10.
+        assert_eq!(
+            offscreen_direction(at(110, -19), 100, 100),
+            Some(ScrollDirection::Right)
+        );
+        // Left 11 vs Down 10.
+        assert_eq!(
+            offscreen_direction(at(-20, 109), 100, 100),
+            Some(ScrollDirection::Left)
+        );
+        // And the other way round on each pair, so "always the first row" is wrong too.
+        assert_eq!(
+            offscreen_direction(at(109, 110), 100, 100),
+            Some(ScrollDirection::Down)
+        );
+        assert_eq!(
+            offscreen_direction(at(-19, -20), 100, 100),
+            Some(ScrollDirection::Up)
+        );
+
+        // Exact ties. Because the last maximum wins, a later row keeps a tie — so a later row
+        // losing one pixel is only visible from a tie, never from a margin it already leads by.
+        assert_eq!(
+            offscreen_direction(at(110, 110), 100, 100),
+            Some(ScrollDirection::Down),
+            "Right and Down both overflow by 11; the later row keeps the tie"
+        );
+        assert_eq!(
+            offscreen_direction(at(110, -20), 100, 100),
+            Some(ScrollDirection::Up),
+            "Right and Up both overflow by 11; the later row keeps the tie"
+        );
+    }
+
+    /// Each edge is half-open in its own direction: touching it is still on-screen, one past it
+    /// is not.
+    #[test]
+    fn offscreen_direction_boundaries_are_exact() {
+        let at = |x: i32, y: i32| AxRect {
+            x,
+            y,
+            width: 10,
+            height: 10,
+        };
+        // x == win_w is off; one less still intersects.
+        assert_eq!(
+            offscreen_direction(at(100, 50), 100, 100),
+            Some(ScrollDirection::Right)
+        );
+        assert_eq!(offscreen_direction(at(99, 50), 100, 100), None);
+        // x + w == 0 is off; one more still intersects.
+        assert_eq!(
+            offscreen_direction(at(-10, 50), 100, 100),
+            Some(ScrollDirection::Left)
+        );
+        assert_eq!(offscreen_direction(at(-9, 50), 100, 100), None);
+        // Same on the vertical axis, including the Up case the older test omits.
+        assert_eq!(
+            offscreen_direction(at(50, 100), 100, 100),
+            Some(ScrollDirection::Down)
+        );
+        assert_eq!(offscreen_direction(at(50, 99), 100, 100), None);
+        assert_eq!(
+            offscreen_direction(at(50, -10), 100, 100),
+            Some(ScrollDirection::Up)
+        );
+        assert_eq!(offscreen_direction(at(50, -9), 100, 100), None);
     }
 
     #[test]

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -1997,6 +1997,37 @@ mod tests {
         assert_eq!(o.cursor, line.seq + 1);
     }
 
+    /// The note means "this was already in the buffer *before* your call", and its advice —
+    /// pass cursor:0 — is only right for such a line. One that arrives after the wait has taken
+    /// its starting cursor sits at or past it, and must not be described that way. The empty
+    /// batches put the line on the pump that happens after the poll gives up.
+    #[test]
+    fn wait_for_log_does_not_report_a_line_that_arrived_during_the_call() {
+        let platform = FakePlatform::new(10, 10).with_log_batches(vec![
+            vec![],
+            vec![],
+            vec![],
+            vec![(Stream::Stdout, "arrived during the wait")],
+        ]);
+        let mut g = glass_with(platform);
+        g.start(&spec()).unwrap();
+        let o = g
+            .wait_for_log(&WaitLogParams {
+                contains: "arrived during the wait".into(),
+                stream: None,
+                cursor: None,
+                interval_ms: 0,
+                timeout_ms: 0,
+            })
+            .unwrap();
+        assert!(!o.matched, "the poll gave up before the line landed");
+        assert!(
+            o.note.is_none(),
+            "the line arrived during the call, so it was not buffered beforehand: {:?}",
+            o.note
+        );
+    }
+
     #[test]
     fn wait_for_log_default_cursor_skips_old_lines_and_times_out() {
         // The line already in the buffer is "old" (before the default start cursor),


### PR DESCRIPTION
The last file of the `glass-core` mutation backlog (#243), after `diff.rs` (#248), `marks.rs` (#249), `accessibility.rs` (#250) and `session/a11y.rs` (#251). **26 survivors**, 19 of them in `offscreen_direction`'s overflow arithmetic.

With this, **all 343** survivors `glass-core` carried when the gate was re-pointed at it are cleared.

## Margins a single operand cannot close

The overflow magnitudes are only ever observable through `max_by_key`, and the existing tie-break is **2001 against 501** — no single altered operand changes that outcome. The new cases put two candidates **exactly one apart**, in both directions, across all four edge pairings.

## Two needed an exact tie instead

`max_by_key` keeps the **last** maximum, so a later row in the table wins ties. Reducing `Down` or `Up` by one therefore still leaves them ahead of any margin they already led by — and they are mutually exclusive with each other, so they can only ever be compared against an *earlier* row.

Only an exact tie makes the missing pixel decide: `Right 11` against `Down 11` goes to `Down`, and losing the `+1` hands it back to `Right`.

## Unobservable through the existing tests

`scroll_to_element`'s `reversed` flag is set per sweep, but every existing test returns through the function's tail — which **hardcodes `true`**. Assertions on `out.reversed` were reading a constant, not the variable. The new test matches on the first sweep, where the in-loop return carries it.

The timeout and step-count bounds each end the sweep on their own, and nothing exercised the timeout alone. `scroll_anchor`'s clamps had no case where the element's centre lay outside the window.

## The last survivor, and a correction

`wait_for_log`'s `l.seq < start_cursor` needs a line landing at **exactly** the starting cursor. I first reported that the fake could not stage it and left it for CI to confirm. That was wrong — it could, with one change.

`drain_logs` handed over everything pending on the first call, and `start` pumps before any wait begins, so a staged line was always old by then. Batched delivery — one batch per drain — puts the line on a chosen pump; three empty batches place it on the pump that runs after the poll gives up, the only moment it can land at the starting cursor. All three comparison mutants now fail: `<=`, `>` and `==`.

**That guard is not redundant**, which is worth recording because four other branches in this backlog were. A poll that timed out proves no match existed *while it was looking*, but the `pump` after it can still admit one — and that line is not old. The right answer was a better fixture, not a deleted branch.

## Verified by mutation, not by coverage

26 mutations applied by hand, run, then reverted — the full operator cross-product over the four magnitude expressions, both edge predicates per direction, `max_by_key` itself, the `reversed` flag, the bail condition, both anchor clamps, and all three comparisons on the cursor guard.

## Follow-up

The `continue-on-error` added to the weekly sweep in #247 exists only because this backlog made it permanently red. That reason is now gone and it should come off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)