### PR TITLE
ci: let the weekly mutation sweep fail again

### DIFF
--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -34,10 +34,6 @@ jobs:
           tool: cargo-mutants,cargo-nextest
       - name: Sweep
         # nextest runs each test in its own process, so slow tests overlap rather than sum.
-        # Informational until glass-core's pre-existing survivors are cleared (343 as of
-        # 2026-07-28); a permanently-red check is one nobody reads. The per-PR --in-diff gate
-        # blocks, so new and changed code is still covered.
-        continue-on-error: true
         run: |
           scripts/mutants.sh "$RUNNER_TEMP/mutants" \
             --test-tool nextest \


### PR DESCRIPTION
`continue-on-error: true` came in with #247 for one reason, stated in the comment it carried: `glass-core` held 343 survivors from before the gate pointed at it, and a check that is red every week is a check nobody reads.

That backlog is gone — #248 (`diff.rs`), #249 (`marks.rs`), #250 (`accessibility.rs`), #251 (`session/a11y.rs`), #252 (`session/wait.rs`). A red sweep now means a real survivor, so it should block again.

The nextest comment above it is unrelated and stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)