### PR TITLE
fix(android): report the failed uiautomator dump, and wait for it on a cold device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,15 @@ internal refactors, CI, or test-only changes.
   Android paths have no such live check.
 
 ### Fixed
+- Android: `glass_a11y_snapshot` no longer fails on the first call against a device that has just
+  booted, and a dump that does fail now says why. A device reaches `sys.boot_completed` — all
+  `glass_start` waits for — several seconds before `uiautomator` can produce a dump, so the first
+  snapshot now waits for it (up to 30s, once per session; later snapshots do not wait). When a dump
+  genuinely fails, the error names the dump and quotes its own reason —
+  `uiautomator dump did not write /sdcard/glass_dump.xml: ERROR: null root node returned by
+  UiTestAutomationBridge.` — where it used to report the unrelated read of the file the dump had
+  never written (`cat: /sdcard/glass_dump.xml: No such file or directory`). `glass_doctor --deep`
+  keeps its single attempt, so it still reports whether the device can dump right now.
 - Linux (`backend: "wayland"`): glass now recovers a window an X11 app opened that the compositor
   never surfaced. Under load, a window the app maps can reach the compositor's Xwayland server and
   never reach the compositor itself — sway has no view for it, so `glass_list_windows` leaves it

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -15,16 +15,14 @@ use crate::target::{choose_serial, parse_devices};
 const DUMP_PATH: &str = "/sdcard/glass_dump.xml";
 
 /// How long the *first* snapshot of a session waits for `uiautomator` to become able to
-/// dump. A device reaches `sys.boot_completed` — all the platform waits for before
-/// reporting the app up — several seconds before the dump can serve one, so a snapshot
-/// taken right after a cold boot would otherwise fail on a device that is merely still
-/// starting. Later snapshots do not wait: once a dump has succeeded the readiness
-/// question is settled, and waiting again would blow the budget of a caller like
-/// `wait_for_element`, whose own poll runs a snapshot per tick.
+/// dump: a device reaches `sys.boot_completed` — all the platform waits for before
+/// reporting the app up — several seconds before the dump can serve one. Later snapshots
+/// must not wait, or a caller like `wait_for_element`, which runs a snapshot per tick
+/// inside its own budget, would be held long past it.
 const DUMP_READY_TIMEOUT_MS: u64 = 30_000;
 const DUMP_POLL_INTERVAL_MS: u64 = 1_000;
 
-/// Runs one adb command and returns its `(stdout, stderr)`. The seam that lets the dump
+/// Runs one adb command and returns its `(stdout, stderr)` — the seam that lets the dump
 /// sequence be driven by a fake instead of a device.
 type AdbRunner<'a> = dyn FnMut(&[&str]) -> Result<(String, String)> + 'a;
 
@@ -37,16 +35,16 @@ pub(crate) fn adb_runner(adb: &Adb) -> impl FnMut(&[&str]) -> Result<(String, St
 ///
 /// `uiautomator dump` exits 0 even when it fails and reports the reason on stderr, so
 /// neither its exit status nor its stdout can be trusted; the file it was asked to write
-/// is the only reliable success signal. Any stale file is removed first, so a previous
-/// run's tree cannot stand in for one this dump never wrote.
+/// is the only reliable success signal. A stale file is removed first, best-effort, so a
+/// previous run's tree does not stand in for one this dump never wrote.
 pub(crate) fn dump_once(run: &mut AdbRunner<'_>, path: &str) -> Result<String> {
     let _ = run(&["shell", "rm", "-f", path]);
     let (_, stderr) = run(&["shell", "uiautomator", "dump", path])?;
     match run(&["shell", "cat", path]) {
         Ok((xml, _)) => Ok(xml),
-        // The dump explained itself on stderr, so that is why there is no file to read and
-        // is the diagnosis worth reporting — naming the dump, not the read that came up
-        // empty. Its stdout is never the reason: it carries only the success line.
+        // The dump explained itself on stderr: that is why there is no file, and it names
+        // the dump rather than the read that came up empty. Its stdout is never the reason
+        // — it carries only the success line.
         Err(_) if !stderr.trim().is_empty() => Err(GlassError::AccessibilityUnavailable(format!(
             "uiautomator dump did not write {path}: {}",
             stderr.trim()

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -14,42 +14,80 @@ use crate::target::{choose_serial, parse_devices};
 
 const DUMP_PATH: &str = "/sdcard/glass_dump.xml";
 
-/// How long a snapshot keeps retrying the dump. A device reports `sys.boot_completed` —
-/// all the platform waits for before reporting the app up — several seconds before
-/// `uiautomator` can serve a dump, so a snapshot taken right after a cold boot would
-/// otherwise fail on a device that is merely still starting.
+/// How long the *first* snapshot of a session waits for `uiautomator` to become able to
+/// dump. A device reaches `sys.boot_completed` — all the platform waits for before
+/// reporting the app up — several seconds before the dump can serve one, so a snapshot
+/// taken right after a cold boot would otherwise fail on a device that is merely still
+/// starting. Later snapshots do not wait: once a dump has succeeded the readiness
+/// question is settled, and waiting again would blow the budget of a caller like
+/// `wait_for_element`, whose own poll runs a snapshot per tick.
 const DUMP_READY_TIMEOUT_MS: u64 = 30_000;
-const DUMP_POLL_INTERVAL_MS: u64 = 500;
+const DUMP_POLL_INTERVAL_MS: u64 = 1_000;
+
+/// Runs one adb command and returns its `(stdout, stderr)`. The seam that lets the dump
+/// sequence be driven by a fake instead of a device.
+type AdbRunner<'a> = dyn FnMut(&[&str]) -> Result<(String, String)> + 'a;
+
+/// Bind a runner to a real device.
+pub(crate) fn adb_runner(adb: &Adb) -> impl FnMut(&[&str]) -> Result<(String, String)> + '_ {
+    move |argv| adb.run_streams(argv.iter().copied())
+}
 
 /// One `uiautomator dump`, returning the XML it wrote.
 ///
 /// `uiautomator dump` exits 0 even when it fails and reports the reason on stderr, so
 /// neither its exit status nor its stdout can be trusted; the file it was asked to write
-/// — removed first, so a previous run's tree cannot stand in for it — is the only
-/// reliable success signal.
-pub(crate) fn dump_once(adb: &Adb, path: &str) -> Result<String> {
-    let _ = adb.run(["shell", "rm", "-f", path]);
-    let (out, err) = adb.run_streams(["shell", "uiautomator", "dump", path])?;
-    adb.run(["shell", "cat", path])
-        .map_err(|read_err| dump_failed(path, &out, &err, &read_err))
+/// is the only reliable success signal. Any stale file is removed first, so a previous
+/// run's tree cannot stand in for one this dump never wrote.
+pub(crate) fn dump_once(run: &mut AdbRunner<'_>, path: &str) -> Result<String> {
+    let _ = run(&["shell", "rm", "-f", path]);
+    let (_, stderr) = run(&["shell", "uiautomator", "dump", path])?;
+    match run(&["shell", "cat", path]) {
+        Ok((xml, _)) => Ok(xml),
+        // The dump explained itself on stderr, so that is why there is no file to read and
+        // is the diagnosis worth reporting — naming the dump, not the read that came up
+        // empty. Its stdout is never the reason: it carries only the success line.
+        Err(_) if !stderr.trim().is_empty() => Err(GlassError::AccessibilityUnavailable(format!(
+            "uiautomator dump did not write {path}: {}",
+            stderr.trim()
+        ))),
+        // A dump that said nothing leaves the read as the only evidence, and a read that
+        // fails on its own is about the device rather than a dump yet to become possible.
+        Err(e) => Err(e),
+    }
 }
 
-/// The error for a dump that wrote no file: it names the dump rather than the read that
-/// came up empty, and quotes uiautomator's own diagnosis in preference to ours. Pure, so
-/// the cold-device signature is tested without a device.
-fn dump_failed(path: &str, stdout: &str, stderr: &str, read_err: &GlassError) -> GlassError {
-    let why = [stderr, stdout]
-        .into_iter()
-        .map(str::trim)
-        .find(|s| !s.is_empty())
-        .map_or_else(|| read_err.to_string(), str::to_string);
-    GlassError::AccessibilityUnavailable(format!("uiautomator dump did not write {path}: {why}"))
+/// Dump, retrying while `uiautomator` reports it cannot serve one yet, up to `budget`.
+///
+/// Only that one failure resolves by waiting: an adb or device error is returned at once,
+/// so a device that has gone away is not retried for the whole budget.
+fn dump_until_ready(
+    run: &mut AdbRunner<'_>,
+    path: &str,
+    budget: Duration,
+    interval: Duration,
+) -> Result<String> {
+    let deadline = Instant::now() + budget;
+    loop {
+        match dump_once(run, path) {
+            Ok(xml) => return Ok(xml),
+            Err(e) => {
+                let retryable = matches!(e, GlassError::AccessibilityUnavailable(_));
+                if !retryable || Instant::now() >= deadline {
+                    return Err(e);
+                }
+                std::thread::sleep(interval);
+            }
+        }
+    }
 }
 
 /// Reads the active window's accessibility tree via `uiautomator`.
 pub struct AndroidA11y {
     adb: Adb,
     resolved: bool,
+    /// Set once a dump has succeeded, after which snapshots stop waiting for readiness.
+    warmed: bool,
 }
 
 impl AndroidA11y {
@@ -57,6 +95,7 @@ impl AndroidA11y {
         Self {
             adb: Adb::from_env(),
             resolved: false,
+            warmed: false,
         }
     }
 
@@ -66,6 +105,7 @@ impl AndroidA11y {
         Self {
             adb,
             resolved: true,
+            warmed: false,
         }
     }
 
@@ -124,14 +164,18 @@ impl Accessibility for AndroidA11y {
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
         let window = ctx.window.clone();
         let adb = self.ensure_adb()?;
-        let deadline = Instant::now() + Duration::from_millis(DUMP_READY_TIMEOUT_MS);
-        let xml = loop {
-            match dump_once(&adb, DUMP_PATH) {
-                Ok(xml) => break xml,
-                Err(e) if Instant::now() >= deadline => return Err(e),
-                Err(_) => std::thread::sleep(Duration::from_millis(DUMP_POLL_INTERVAL_MS)),
-            }
+        let budget = if self.warmed {
+            Duration::ZERO
+        } else {
+            Duration::from_millis(DUMP_READY_TIMEOUT_MS)
         };
+        let xml = dump_until_ready(
+            &mut adb_runner(&adb),
+            DUMP_PATH,
+            budget,
+            Duration::from_millis(DUMP_POLL_INTERVAL_MS),
+        )?;
+        self.warmed = true;
         build_tree(&xml, &window, ctx.limits)
     }
 
@@ -169,68 +213,150 @@ impl Accessibility for AndroidA11y {
 
 #[cfg(test)]
 mod tests {
-    use super::{dump_failed, locate_editable_target};
+    use super::{dump_once, dump_until_ready, locate_editable_target};
     use glass_core::accessibility::{AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree};
-    use glass_core::{GlassError, WindowGeometry};
+    use glass_core::{GlassError, Result, WindowGeometry};
+    use std::time::Duration;
+
+    const PATH: &str = "/sdcard/glass_dump.xml";
+    const XML: &str = "<?xml version='1.0'?><hierarchy rotation=\"0\"></hierarchy>";
 
     /// What `uiautomator dump` writes to stderr on a device that has booted but whose
-    /// accessibility bridge is not serving yet — captured from a cold emulator.
+    /// accessibility bridge is not serving yet — captured from a cold emulator, where the
+    /// dump also exits 0 and prints nothing on stdout.
     const NOT_READY: &str = "ERROR: null root node returned by UiTestAutomationBridge.";
 
-    /// What the read of the unwritten file reports, and what the old code surfaced.
+    /// What `uiautomator dump` prints on stdout when it succeeds (typo upstream's).
+    const DUMPED: &str = "UI hierchary dumped to: /sdcard/glass_dump.xml";
+
+    /// The `cat` of a file the dump never wrote — the error the old code surfaced in place
+    /// of the dump's own.
     fn read_err() -> GlassError {
-        GlassError::Backend(
-            "`adb -s emulator-5554 shell cat /sdcard/glass_dump.xml` failed: \
-             cat: /sdcard/glass_dump.xml: No such file or directory"
-                .into(),
-        )
+        GlassError::Backend(format!(
+            "`adb shell cat {PATH}` failed: cat: {PATH}: No such file"
+        ))
+    }
+
+    /// An adb whose `uiautomator dump` fails as a cold device's does for `cold` attempts,
+    /// then succeeds. Records every command it is given.
+    fn fake(cold: usize) -> impl FnMut(&[&str]) -> Result<(String, String)> {
+        let mut dumps = 0;
+        let mut wrote = false;
+        move |argv: &[&str]| match argv {
+            ["shell", "rm", "-f", _] => {
+                wrote = false;
+                Ok((String::new(), String::new()))
+            }
+            ["shell", "uiautomator", "dump", _] => {
+                dumps += 1;
+                if dumps > cold {
+                    wrote = true;
+                    Ok((DUMPED.to_string(), String::new()))
+                } else {
+                    // Exit 0, nothing on stdout, the diagnosis on stderr.
+                    Ok((String::new(), format!("{NOT_READY}\n")))
+                }
+            }
+            ["shell", "cat", _] if wrote => Ok((XML.to_string(), String::new())),
+            ["shell", "cat", _] => Err(read_err()),
+            other => panic!("unexpected adb command: {other:?}"),
+        }
     }
 
     #[test]
-    fn dump_failure_names_the_dump_not_the_read() {
-        let e = dump_failed("/sdcard/glass_dump.xml", "", NOT_READY, &read_err());
+    fn dump_reports_the_dump_that_wrote_nothing_not_the_read_that_found_nothing() {
+        let mut run = fake(1);
+        let e = dump_once(&mut run, PATH).unwrap_err();
         let msg = e.to_string();
         assert!(
-            msg.contains("uiautomator dump did not write /sdcard/glass_dump.xml"),
+            msg.contains(&format!("uiautomator dump did not write {PATH}")),
             "must name the step that should have written the file: {msg}"
         );
         assert!(
-            !msg.contains("cat:"),
-            "must not send the reader to the missing file instead of the dump: {msg}"
+            msg.contains(NOT_READY),
+            "must quote uiautomator's own diagnosis: {msg}"
         );
-    }
-
-    #[test]
-    fn dump_failure_quotes_uiautomators_own_diagnosis() {
-        let e = dump_failed("/sdcard/glass_dump.xml", "", NOT_READY, &read_err());
-        assert!(e.to_string().contains(NOT_READY), "{e}");
-        assert!(matches!(e, GlassError::AccessibilityUnavailable(_)));
-    }
-
-    #[test]
-    fn dump_failure_prefers_stderr_over_stdout() {
-        // The failing dump leaves stdout empty, but a version that also chatters on stdout
-        // must not bury the diagnosis.
-        let e = dump_failed(
-            "/p.xml",
-            "UI hierchary dumped to: /p.xml",
-            NOT_READY,
-            &read_err(),
-        );
-        let msg = e.to_string();
-        assert!(msg.contains(NOT_READY), "{msg}");
         assert!(
-            !msg.contains("hierchary"),
-            "the success chatter is not the reason: {msg}"
+            !msg.contains("cat:"),
+            "must not send the reader to the missing file: {msg}"
         );
     }
 
     #[test]
-    fn dump_failure_falls_back_to_the_read_error_when_the_dump_said_nothing() {
-        // A dump that says nothing on either stream leaves the read as the only evidence,
-        // so a silent failure still reports something a reader can act on.
-        let e = dump_failed("/p.xml", "  ", "\n", &read_err());
-        assert!(e.to_string().contains("No such file or directory"), "{e}");
+    fn dump_clears_a_stale_file_before_dumping() {
+        let mut seen: Vec<String> = Vec::new();
+        let mut run = |argv: &[&str]| -> Result<(String, String)> {
+            seen.push(argv.join(" "));
+            match argv {
+                ["shell", "cat", _] => Ok((XML.to_string(), String::new())),
+                _ => Ok((String::new(), String::new())),
+            }
+        };
+        dump_once(&mut run, PATH).unwrap();
+        assert_eq!(
+            seen,
+            vec![
+                format!("shell rm -f {PATH}"),
+                format!("shell uiautomator dump {PATH}"),
+                format!("shell cat {PATH}"),
+            ],
+            "a stale tree must not be able to stand in for a dump that never ran"
+        );
+    }
+
+    #[test]
+    fn a_read_failure_the_dump_did_not_explain_is_returned_as_it_stands() {
+        // The dump succeeded and said so; the read then failed on its own. Blaming the dump
+        // here would repeat the misattribution this fix exists to remove.
+        let mut run = |argv: &[&str]| -> Result<(String, String)> {
+            match argv {
+                ["shell", "cat", _] => Err(read_err()),
+                _ => Ok((DUMPED.to_string(), String::new())),
+            }
+        };
+        let e = dump_once(&mut run, PATH).unwrap_err();
+        assert!(matches!(e, GlassError::Backend(_)), "{e}");
+        assert!(!e.to_string().contains("did not write"), "{e}");
+    }
+
+    #[test]
+    fn a_dump_that_is_not_ready_yet_is_retried_until_it_is() {
+        let mut run = fake(3);
+        let xml = dump_until_ready(&mut run, PATH, Duration::from_secs(30), Duration::ZERO)
+            .expect("a device that becomes ready within the budget must produce a tree");
+        assert_eq!(xml, XML);
+    }
+
+    #[test]
+    fn a_dump_that_never_becomes_ready_fails_with_the_last_reason() {
+        let mut run = fake(usize::MAX);
+        let e = dump_until_ready(&mut run, PATH, Duration::ZERO, Duration::ZERO).unwrap_err();
+        assert!(e.to_string().contains(NOT_READY), "{e}");
+    }
+
+    #[test]
+    fn an_adb_failure_is_not_retried() {
+        // A device that has gone away will not come back by waiting, and a caller polling
+        // with its own timeout must not be held past it.
+        let mut attempts = 0;
+        let mut run = |argv: &[&str]| -> Result<(String, String)> {
+            match argv {
+                ["shell", "uiautomator", "dump", _] => {
+                    attempts += 1;
+                    Err(GlassError::Backend(
+                        "device 'emulator-5554' not found".into(),
+                    ))
+                }
+                _ => Ok((String::new(), String::new())),
+            }
+        };
+        let e =
+            dump_until_ready(&mut run, PATH, Duration::from_secs(30), Duration::ZERO).unwrap_err();
+        assert!(matches!(e, GlassError::Backend(_)), "{e}");
+        assert_eq!(
+            attempts, 1,
+            "must not wait out the budget on a device error"
+        );
     }
 
     const WIN: WindowGeometry = WindowGeometry {

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -2,15 +2,49 @@
 //! over adb and maps the result via `crate::axmap`. Resolves its own device
 //! lazily, since the `Accessibility` trait is handed only an `AxContext`.
 
+use std::time::{Duration, Instant};
+
 use glass_core::accessibility::{Accessibility, AxContext, AxTarget, AxTree};
 use glass_core::{GlassError, KeyEvent, MouseButton, PointerEvent, Result, WindowGeometry};
 
 use crate::adb::Adb;
-use crate::axmap::{build_tree, check_dump_status};
+use crate::axmap::build_tree;
 use crate::input::{key_commands, pointer_commands};
 use crate::target::{choose_serial, parse_devices};
 
 const DUMP_PATH: &str = "/sdcard/glass_dump.xml";
+
+/// How long a snapshot keeps retrying the dump. A device reports `sys.boot_completed` —
+/// all the platform waits for before reporting the app up — several seconds before
+/// `uiautomator` can serve a dump, so a snapshot taken right after a cold boot would
+/// otherwise fail on a device that is merely still starting.
+const DUMP_READY_TIMEOUT_MS: u64 = 30_000;
+const DUMP_POLL_INTERVAL_MS: u64 = 500;
+
+/// One `uiautomator dump`, returning the XML it wrote.
+///
+/// `uiautomator dump` exits 0 even when it fails and reports the reason on stderr, so
+/// neither its exit status nor its stdout can be trusted; the file it was asked to write
+/// — removed first, so a previous run's tree cannot stand in for it — is the only
+/// reliable success signal.
+pub(crate) fn dump_once(adb: &Adb, path: &str) -> Result<String> {
+    let _ = adb.run(["shell", "rm", "-f", path]);
+    let (out, err) = adb.run_streams(["shell", "uiautomator", "dump", path])?;
+    adb.run(["shell", "cat", path])
+        .map_err(|read_err| dump_failed(path, &out, &err, &read_err))
+}
+
+/// The error for a dump that wrote no file: it names the dump rather than the read that
+/// came up empty, and quotes uiautomator's own diagnosis in preference to ours. Pure, so
+/// the cold-device signature is tested without a device.
+fn dump_failed(path: &str, stdout: &str, stderr: &str, read_err: &GlassError) -> GlassError {
+    let why = [stderr, stdout]
+        .into_iter()
+        .map(str::trim)
+        .find(|s| !s.is_empty())
+        .map_or_else(|| read_err.to_string(), str::to_string);
+    GlassError::AccessibilityUnavailable(format!("uiautomator dump did not write {path}: {why}"))
+}
 
 /// Reads the active window's accessibility tree via `uiautomator`.
 pub struct AndroidA11y {
@@ -90,11 +124,14 @@ impl Accessibility for AndroidA11y {
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
         let window = ctx.window.clone();
         let adb = self.ensure_adb()?;
-        // Remove any stale dump so a dump that fails to (re)write can't yield a prior tree.
-        let _ = adb.run(["shell", "rm", "-f", DUMP_PATH]);
-        let status = adb.run(["shell", "uiautomator", "dump", DUMP_PATH])?;
-        check_dump_status(&status)?;
-        let xml = adb.run(["shell", "cat", DUMP_PATH])?;
+        let deadline = Instant::now() + Duration::from_millis(DUMP_READY_TIMEOUT_MS);
+        let xml = loop {
+            match dump_once(&adb, DUMP_PATH) {
+                Ok(xml) => break xml,
+                Err(e) if Instant::now() >= deadline => return Err(e),
+                Err(_) => std::thread::sleep(Duration::from_millis(DUMP_POLL_INTERVAL_MS)),
+            }
+        };
         build_tree(&xml, &window, ctx.limits)
     }
 
@@ -132,9 +169,69 @@ impl Accessibility for AndroidA11y {
 
 #[cfg(test)]
 mod tests {
-    use super::locate_editable_target;
+    use super::{dump_failed, locate_editable_target};
     use glass_core::accessibility::{AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree};
     use glass_core::{GlassError, WindowGeometry};
+
+    /// What `uiautomator dump` writes to stderr on a device that has booted but whose
+    /// accessibility bridge is not serving yet — captured from a cold emulator.
+    const NOT_READY: &str = "ERROR: null root node returned by UiTestAutomationBridge.";
+
+    /// What the read of the unwritten file reports, and what the old code surfaced.
+    fn read_err() -> GlassError {
+        GlassError::Backend(
+            "`adb -s emulator-5554 shell cat /sdcard/glass_dump.xml` failed: \
+             cat: /sdcard/glass_dump.xml: No such file or directory"
+                .into(),
+        )
+    }
+
+    #[test]
+    fn dump_failure_names_the_dump_not_the_read() {
+        let e = dump_failed("/sdcard/glass_dump.xml", "", NOT_READY, &read_err());
+        let msg = e.to_string();
+        assert!(
+            msg.contains("uiautomator dump did not write /sdcard/glass_dump.xml"),
+            "must name the step that should have written the file: {msg}"
+        );
+        assert!(
+            !msg.contains("cat:"),
+            "must not send the reader to the missing file instead of the dump: {msg}"
+        );
+    }
+
+    #[test]
+    fn dump_failure_quotes_uiautomators_own_diagnosis() {
+        let e = dump_failed("/sdcard/glass_dump.xml", "", NOT_READY, &read_err());
+        assert!(e.to_string().contains(NOT_READY), "{e}");
+        assert!(matches!(e, GlassError::AccessibilityUnavailable(_)));
+    }
+
+    #[test]
+    fn dump_failure_prefers_stderr_over_stdout() {
+        // The failing dump leaves stdout empty, but a version that also chatters on stdout
+        // must not bury the diagnosis.
+        let e = dump_failed(
+            "/p.xml",
+            "UI hierchary dumped to: /p.xml",
+            NOT_READY,
+            &read_err(),
+        );
+        let msg = e.to_string();
+        assert!(msg.contains(NOT_READY), "{msg}");
+        assert!(
+            !msg.contains("hierchary"),
+            "the success chatter is not the reason: {msg}"
+        );
+    }
+
+    #[test]
+    fn dump_failure_falls_back_to_the_read_error_when_the_dump_said_nothing() {
+        // A dump that says nothing on either stream leaves the read as the only evidence,
+        // so a silent failure still reports something a reader can act on.
+        let e = dump_failed("/p.xml", "  ", "\n", &read_err());
+        assert!(e.to_string().contains("No such file or directory"), "{e}");
+    }
 
     const WIN: WindowGeometry = WindowGeometry {
         x: 0,

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -41,12 +41,22 @@ impl Adb {
     where
         I: IntoIterator<Item = &'a str>,
     {
-        let argv = build_argv(
-            self.serial.as_deref(),
-            &args.into_iter().collect::<Vec<_>>(),
-        );
-        let out = self.spawn(&argv)?;
-        decode_text(&self.bin, &argv, out)
+        let out = self.output(args)?;
+        Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+    }
+
+    /// Run adb capturing stdout *and* stderr. For a command whose exit status does not
+    /// signal success — `uiautomator dump` exits 0 when it fails, and explains itself on
+    /// stderr — the caller has to judge the outcome from the streams itself.
+    pub fn run_streams<'a, I>(&self, args: I) -> Result<(String, String)>
+    where
+        I: IntoIterator<Item = &'a str>,
+    {
+        let out = self.output(args)?;
+        Ok((
+            String::from_utf8_lossy(&out.stdout).into_owned(),
+            String::from_utf8_lossy(&out.stderr).into_owned(),
+        ))
     }
 
     /// Run adb capturing raw stdout bytes (e.g. `exec-out screencap`).
@@ -54,23 +64,28 @@ impl Adb {
     where
         I: IntoIterator<Item = &'a str>,
     {
+        Ok(self.output(args)?.stdout)
+    }
+
+    /// Run adb and return the completed process, erroring on spawn failure or non-zero
+    /// exit so every caller reports those two the same way.
+    fn output<'a, I>(&self, args: I) -> Result<Output>
+    where
+        I: IntoIterator<Item = &'a str>,
+    {
         let argv = build_argv(
             self.serial.as_deref(),
             &args.into_iter().collect::<Vec<_>>(),
         );
-        let out = self.spawn(&argv)?;
+        let out = Command::new(&self.bin)
+            .args(&argv)
+            .output()
+            .map_err(|e| GlassError::Backend(format!("failed to run `{}`: {e}", self.bin)))?;
         if out.status.success() {
-            Ok(out.stdout)
+            Ok(out)
         } else {
             Err(exit_error(&self.bin, &argv, &out))
         }
-    }
-
-    fn spawn(&self, argv: &[String]) -> Result<Output> {
-        Command::new(&self.bin)
-            .args(argv)
-            .output()
-            .map_err(|e| GlassError::Backend(format!("failed to run `{}`: {e}", self.bin)))
     }
 }
 
@@ -84,14 +99,6 @@ pub(crate) fn build_argv(serial: Option<&str>, args: &[&str]) -> Vec<String> {
     }
     v.extend(args.iter().map(|a| a.to_string()));
     v
-}
-
-fn decode_text(bin: &str, argv: &[String], out: Output) -> Result<String> {
-    if out.status.success() {
-        Ok(String::from_utf8_lossy(&out.stdout).into_owned())
-    } else {
-        Err(exit_error(bin, argv, &out))
-    }
 }
 
 fn exit_error(bin: &str, argv: &[String], out: &Output) -> GlassError {

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -87,17 +87,6 @@ pub fn parse_bounds(s: &str, window: &WindowGeometry) -> Option<AxRect> {
     })
 }
 
-/// Surface the `uiautomator dump` idle-state / error failure mode loudly.
-pub fn check_dump_status(stdout: &str) -> Result<()> {
-    if stdout.contains("ERROR") || stdout.contains("could not get idle state") {
-        return Err(GlassError::AccessibilityUnavailable(format!(
-            "uiautomator dump failed: {}",
-            stdout.trim()
-        )));
-    }
-    Ok(())
-}
-
 /// Parse uiautomator XML into an `AxTree`. Ids are left unset (the caller runs
 /// `AxTree::assign_ids`). The hierarchy is wrapped in a synthetic `Window` root
 /// sized to the app window.
@@ -299,13 +288,6 @@ mod tests {
         let r = parse_bounds("[40,100][300,160]", &win).unwrap();
         assert_eq!((r.x, r.y, r.width, r.height), (40, 37, 260, 60));
         assert!(parse_bounds("garbage", &win).is_none());
-    }
-
-    #[test]
-    fn dump_status_detects_idle_failure() {
-        assert!(check_dump_status("UI hierchary dumped to: /sdcard/glass_dump.xml").is_ok());
-        let err = check_dump_status("ERROR: could not get idle state!").unwrap_err();
-        assert!(matches!(err, GlassError::AccessibilityUnavailable(_)));
     }
 
     #[test]

--- a/crates/glass-android/src/doctor.rs
+++ b/crates/glass-android/src/doctor.rs
@@ -6,9 +6,9 @@
 
 use glass_core::{Check, CheckStatus};
 
+use crate::a11y::dump_once;
 use crate::adb::Adb;
 use crate::avd::{Action, Lifecycle, decide, parse_list_avds, resolve_emulator_bin};
-use crate::axmap::check_dump_status;
 use crate::target::{Device, parse_devices};
 
 /// Skip detail the deep-capture checks (`screencap`, `uiautomator`) emit when `--deep`
@@ -217,16 +217,10 @@ fn deep_probe(adb: &Adb, serial: &str) -> DeepProbe {
         Err(e) => Err(e.to_string()),
     };
 
-    // Remove any stale dump so a failed `uiautomator dump` can't yield a false positive
-    // from a prior run's file; validate the dump command's own status (parity with
-    // AndroidA11y) before trusting the cat'd XML.
-    let _ = dev.run(["shell", "rm", "-f", DUMP_PATH]);
-    let uiautomator = match dev
-        .run(["shell", "uiautomator", "dump", DUMP_PATH])
-        .and_then(|status| {
-            check_dump_status(&status)?;
-            dev.run(["shell", "cat", DUMP_PATH])
-        }) {
+    // Deliberately one attempt, where AndroidA11y retries: doctor reports what the device
+    // can do now, and a dump that only succeeds after a wait is what this check exists to
+    // reveal.
+    let uiautomator = match dump_once(&dev, DUMP_PATH) {
         Ok(xml) if xml.contains("<hierarchy") => Ok("a11y dump OK".to_string()),
         Ok(_) => Err("uiautomator dump produced no hierarchy".to_string()),
         Err(e) => Err(e.to_string()),

--- a/crates/glass-android/src/doctor.rs
+++ b/crates/glass-android/src/doctor.rs
@@ -6,7 +6,7 @@
 
 use glass_core::{Check, CheckStatus};
 
-use crate::a11y::dump_once;
+use crate::a11y::{adb_runner, dump_once};
 use crate::adb::Adb;
 use crate::avd::{Action, Lifecycle, decide, parse_list_avds, resolve_emulator_bin};
 use crate::target::{Device, parse_devices};
@@ -220,7 +220,7 @@ fn deep_probe(adb: &Adb, serial: &str) -> DeepProbe {
     // Deliberately one attempt, where AndroidA11y retries: doctor reports what the device
     // can do now, and a dump that only succeeds after a wait is what this check exists to
     // reveal.
-    let uiautomator = match dump_once(&dev, DUMP_PATH) {
+    let uiautomator = match dump_once(&mut adb_runner(&dev), DUMP_PATH) {
         Ok(xml) if xml.contains("<hierarchy") => Ok("a11y dump OK".to_string()),
         Ok(_) => Err("uiautomator dump produced no hierarchy".to_string()),
         Err(e) => Err(e.to_string()),


### PR DESCRIPTION
Closes #245.

`glass_a11y_snapshot` failed on the first call against a freshly booted emulator and passed on the second, blaming a step that was not at fault:

```
cat: /sdcard/glass_dump.xml: No such file or directory
```

## The guard was reading a stream that could never carry the failure

Measured on a cold emulator, one second apart:

```
dt=5s  rc=0  stdout=[]  stderr=[ERROR: null root node returned by UiTestAutomationBridge.]
dt=9s  rc=0  stdout=[UI hierchary dumped to: /sdcard/probe_dump.xml]   head=[<?xml …<hierarchy]
```

A failing `uiautomator dump` **exits 0** and writes its diagnosis to **stderr**. `Adb::run` returns stdout alone — it reads stderr only to build the error for a non-zero exit — so `check_dump_status(stdout)` was handed an empty string every time. Its `"ERROR"` substring was in the output all along, on the stream nobody passed it. The failure then surfaced one step later, at the `cat` of a file that was never written.

So the old check could not have caught this, and no wording of it would have: the reliable signal is neither the exit status (always 0) nor a message whose wording is uiautomator's to change, but **the file it was asked to write**. That is also what the caller actually needs. `Adb::run_streams` keeps stderr so the error can quote the real reason:

```
uiautomator dump did not write /sdcard/glass_dump.xml:
ERROR: null root node returned by UiTestAutomationBridge.
```

## The wait

A device reaches `sys.boot_completed` — all `glass_start` waits for — several seconds before uiautomator can serve a dump. The first snapshot of a session now polls to a 30s deadline; later ones do not wait, because once a dump has succeeded the readiness question is settled.

That last part matters more than it looks: `wait_for_element` runs a snapshot per tick inside its own `poll_until`, whose contract is that a tick error aborts. An unconditional 30s inner wait would let a caller asking for 2s wait 30. For the same reason **only** "the dump ran and wrote nothing" is retried — an adb or device error is returned at once, since a device that has gone away does not come back by waiting.

`glass_doctor --deep` deliberately keeps its single attempt: a dump that only works after a wait is exactly what that check exists to reveal. It picks up the better message for free, and now shares the dump sequence rather than mirroring it.

## Verified with the mechanism switched off, then on

Both on a cold-booted emulator, through the real MCP path, using the driver that found the bug:

| deadline | first run against a cold AVD |
|---|---|
| `0` | FAIL at check 4 — `uiautomator dump did not write …: ERROR: null root node …` |
| `30s` | **8/8 PASS** |

The failing leg is what makes the passing one mean anything: it proves the cold window was open during that boot, so the green is the retry working rather than a lucky start. Re-run after the review rework, since the retry predicate changed.

## Tests

The dump sequence runs against a fake adb, so what the fix actually does is pinned in CI rather than only on a device: a not-ready dump is retried until it succeeds, the stale file is cleared first, exhausting the budget reports the last reason, and an adb error is not retried at all.

Three of the six fail against the old code; the other three are guards against regressions the review found in the first cut of this fix — including one where preferring the dump's stdout would have made a vanished device report `did not write <path>: UI hierchary dumped to: <path>`, the same misattribution this PR removes. Stdout is no longer consulted.

## Also here

`Adb`'s three run methods (`run`, `run_streams`, `run_bytes`) now share one private `output` helper. Adding the third stream-capturing method would otherwise have been the third copy of the same spawn-and-check block; behaviour is unchanged for all three.

## Not fixed here

The sibling iOS first-run failure (#246) has the same cold-start signature through a different mechanism, and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)