### PR TITLE
fix(ios): take the display scale from the target, not the app's tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,14 @@ internal refactors, CI, or test-only changes.
   Android paths have no such live check.
 
 ### Fixed
+- iOS: `glass_start` now reads the display scale from the Simulator rather than from the app's
+  accessibility tree, so a launch no longer depends on the app having rendered. The scale is a
+  property of the device (`idb describe` reports it before any app runs), but glass derived it by
+  dividing the capture's pixel width by the accessibility root's point width — a value that is
+  absent for around two seconds after launch, against a retry budget of about half a second. A
+  launch that lost that race failed with `could not determine the iOS display scale from the
+  accessibility tree` and left no session, and the retry loop it needed is gone with the
+  dependency.
 - Android: `glass_a11y_snapshot` no longer fails on the first call against a device that has just
   booted, and a dump that does fail now says why. A device reaches `sys.boot_completed` — all
   `glass_start` waits for — several seconds before `uiautomator` can produce a dump, so the first

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -3,7 +3,7 @@
 //! against a stale id landing on a different element), focuses it, clears it, and
 //! types the new text via synthetic HID input.
 use glass_core::accessibility::{Accessibility, AxContext, AxRect, AxTarget, AxTree};
-use glass_core::{GlassError, KeyEvent, MouseButton, PointerEvent, Result, WindowGeometry};
+use glass_core::{GlassError, KeyEvent, MouseButton, PointerEvent, Result};
 
 use crate::axmap;
 use crate::idb::client::IdbClient;
@@ -13,35 +13,32 @@ use crate::injector::IdbInjector;
 /// Simulator, over idb's `accessibility_info` and HID RPCs.
 pub struct IosA11y {
     client: IdbClient,
-    /// The target's own scale, fetched on first need and kept: it is a property of the
-    /// device, so unlike the tree's it does not change between snapshots.
-    device_scale: std::cell::Cell<Option<f64>>,
-}
-
-/// The point→pixel scale for a describe response: the capture window's pixel width over
-/// the describe root's logical-point width. Preferred over the device's own scale because
-/// the tree's frames are in exactly these points, so it stays right even where the two
-/// disagree. Computed per describe rather than cached, since the tree it divides is too.
-/// `None` if the tree carries no positive root width — the caller falls back then.
-fn scale_from(json: &str, window: &WindowGeometry) -> Option<f64> {
-    axmap::scale_from_width(json, window.width)
+    /// The target's scale, fetched on first need and kept: a property of the device, so it
+    /// does not change between snapshots.
+    scale: Option<f64>,
 }
 
 impl IosA11y {
     pub(crate) fn new(client: IdbClient) -> Self {
         IosA11y {
             client,
-            device_scale: std::cell::Cell::new(None),
+            scale: None,
         }
     }
 
-    /// The target's point→pixel scale, for when the tree carries no root width to divide.
-    fn device_scale(&self) -> Result<f64> {
-        if let Some(scale) = self.device_scale.get() {
+    /// The target's point→pixel scale, from the device rather than from the tree.
+    ///
+    /// Not the tree's own `capture width / root point width`: that divides by the widest
+    /// *top-level* element, which equals the screen only when one spans it, and it is
+    /// unavailable at all for the second or so an app takes to render. The platform's
+    /// injector converts with the device's scale, so a reader using a different one would
+    /// report bounds that tap somewhere else.
+    fn scale(&mut self) -> Result<f64> {
+        if let Some(scale) = self.scale {
             return Ok(scale);
         }
         let scale = crate::platform::checked_scale(self.client.describe()?.density)?;
-        self.device_scale.set(Some(scale));
+        self.scale = Some(scale);
         Ok(scale)
     }
 
@@ -49,16 +46,9 @@ impl IosA11y {
     /// scale from `ctx.window` (pixels, valid once the app has started) and the describe
     /// root's point width, and map the id-assigned tree. Returns the tree and the scale,
     /// since `set_value` needs the same scale to place synthetic input.
-    fn describe(&self, ctx: &AxContext) -> Result<(AxTree, f64)> {
+    fn describe(&mut self, ctx: &AxContext) -> Result<(AxTree, f64)> {
+        let scale = self.scale()?;
         let json = self.client.describe_all()?;
-        // An app mid-launch reports a tree with no root width for a second or two. Falling
-        // back to the device's scale rather than erroring lets that arrive as an empty tree,
-        // which `wait_for_element` can poll through — an error would abort its poll, since
-        // `poll_until` treats a tick error as fatal.
-        let scale = match scale_from(&json, &ctx.window) {
-            Some(scale) => scale,
-            None => self.device_scale()?,
-        };
         let mut tree = axmap::build_tree(&json, scale, &ctx.window, ctx.limits)?;
         tree.assign_ids();
         Ok((tree, scale))
@@ -159,28 +149,6 @@ mod tests {
         let mut t = AxTree::new(root);
         t.assign_ids();
         t
-    }
-
-    fn window_px(width: u32) -> WindowGeometry {
-        WindowGeometry {
-            x: 0,
-            y: 0,
-            width,
-            height: 2622,
-        }
-    }
-
-    #[test]
-    fn scale_from_divides_window_pixels_by_root_point_width() {
-        // A 1206px-wide capture over a 402pt describe root is the ×3 backing scale — the
-        // real value this reader must recover per call, not the provisional 1.0.
-        let json = r#"[{"frame":{"width":402}}]"#;
-        assert_eq!(scale_from(json, &window_px(1206)), Some(3.0));
-    }
-
-    #[test]
-    fn scale_from_is_none_without_a_root_point_width() {
-        assert_eq!(scale_from("[]", &window_px(1206)), None);
     }
 
     #[test]

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -13,21 +13,36 @@ use crate::injector::IdbInjector;
 /// Simulator, over idb's `accessibility_info` and HID RPCs.
 pub struct IosA11y {
     client: IdbClient,
+    /// The target's own scale, fetched on first need and kept: it is a property of the
+    /// device, so unlike the tree's it does not change between snapshots.
+    device_scale: std::cell::Cell<Option<f64>>,
 }
 
 /// The point→pixel scale for a describe response: the capture window's pixel width over
-/// the describe root's logical-point width. Computed per describe rather than cached,
-/// because this reader is built before the app launches — when the real scale is still
-/// unknown — so a scale frozen at construction would be wrong. `None` if the tree carries
-/// no positive root width. Delegates to [`axmap::scale_from_width`] so the reader and the
-/// platform's scale discovery compute the ratio one way.
+/// the describe root's logical-point width. Preferred over the device's own scale because
+/// the tree's frames are in exactly these points, so it stays right even where the two
+/// disagree. Computed per describe rather than cached, since the tree it divides is too.
+/// `None` if the tree carries no positive root width — the caller falls back then.
 fn scale_from(json: &str, window: &WindowGeometry) -> Option<f64> {
     axmap::scale_from_width(json, window.width)
 }
 
 impl IosA11y {
     pub(crate) fn new(client: IdbClient) -> Self {
-        IosA11y { client }
+        IosA11y {
+            client,
+            device_scale: std::cell::Cell::new(None),
+        }
+    }
+
+    /// The target's point→pixel scale, for when the tree carries no root width to divide.
+    fn device_scale(&self) -> Result<f64> {
+        if let Some(scale) = self.device_scale.get() {
+            return Ok(scale);
+        }
+        let scale = crate::platform::checked_scale(self.client.describe()?.density)?;
+        self.device_scale.set(Some(scale));
+        Ok(scale)
     }
 
     /// One describe round-trip: fetch the accessibility JSON, derive the point→pixel
@@ -36,11 +51,14 @@ impl IosA11y {
     /// since `set_value` needs the same scale to place synthetic input.
     fn describe(&self, ctx: &AxContext) -> Result<(AxTree, f64)> {
         let json = self.client.describe_all()?;
-        let scale = scale_from(&json, &ctx.window).ok_or_else(|| {
-            GlassError::Backend(
-                "could not determine the iOS accessibility scale from the tree".into(),
-            )
-        })?;
+        // An app mid-launch reports a tree with no root width for a second or two. Falling
+        // back to the device's scale rather than erroring lets that arrive as an empty tree,
+        // which `wait_for_element` can poll through — an error would abort its poll, since
+        // `poll_until` treats a tick error as fatal.
+        let scale = match scale_from(&json, &ctx.window) {
+            Some(scale) => scale,
+            None => self.device_scale()?,
+        };
         let mut tree = axmap::build_tree(&json, scale, &ctx.window, ctx.limits)?;
         tree.assign_ids();
         Ok((tree, scale))

--- a/crates/glass-ios/src/axmap.rs
+++ b/crates/glass-ios/src/axmap.rs
@@ -137,42 +137,6 @@ pub fn build_tree(
     Ok(tree)
 }
 
-/// The widest top-level element's logical-point width from idb's nested
-/// `accessibility_info` JSON — the describe root's `frame.width`. This is the point
-/// counterpart to the capture frame's pixel width, so dividing the two yields the
-/// device's point→pixel scale (`scale = pixel_width / point_width`).
-///
-/// Reads the structured `frame` object, matching [`build_tree`]: the sibling `AXFrame`
-/// is a stringified CGRect, not a number, so it is deliberately ignored. Returns `None`
-/// when the JSON does not parse, carries no top-level element, or no element has a
-/// numeric `frame.width` — the caller treats that as "scale undetermined" rather than
-/// assuming a default.
-pub fn root_point_width(json: &str) -> Option<f64> {
-    fn frame_width(n: &Value) -> Option<f64> {
-        n.get("frame")?.get("width")?.as_f64()
-    }
-    let v: Value = serde_json::from_str(json).ok()?;
-    match v {
-        Value::Array(a) => a.iter().filter_map(frame_width).reduce(f64::max),
-        obj @ Value::Object(_) => frame_width(&obj),
-        _ => None,
-    }
-}
-
-/// The device's point→pixel scale for a describe response: the capture's pixel width
-/// (`frame_px_width`) over the describe root's logical-point width (from
-/// [`root_point_width`]), i.e. `scale = frame_px_width / root_point_width`.
-///
-/// Returns `None` when the tree carries no *positive* root width — a non-positive width
-/// can't yield a usable scale, so callers treat `None` as "scale undetermined" rather
-/// than dividing by it. Shared by the accessibility reader and the platform's scale
-/// discovery so both compute the ratio one way.
-pub fn scale_from_width(json: &str, frame_px_width: u32) -> Option<f64> {
-    root_point_width(json)
-        .filter(|w| *w > 0.0)
-        .map(|pt| f64::from(frame_px_width) / pt)
-}
-
 /// iOS `(checkable, checked)` from the normalized role and idb's `AXValue` string. A UISwitch
 /// reports role AXCheckBox/AXSwitch/AXToggle with AXValue "0"/"1". Claims `checkable` ONLY for a
 /// determinate "0"/"1" on a checkable role (the #170 invariant); anything else → (false, false).
@@ -341,6 +305,16 @@ mod tests {
     }
 
     #[test]
+    fn an_empty_tree_maps_to_an_empty_window_rather_than_an_error() {
+        // What an app reports for the second or so it takes to render. `IosA11y` relies on
+        // this arriving as an empty tree: an error here would abort `wait_for_element`'s
+        // poll, which treats a tick error as fatal, so an agent could not wait it out.
+        let tree = build_tree("[]", 3.0, &win(), WalkLimits::DEFAULT)
+            .expect("an unrendered app is an empty tree, not a failure");
+        assert!(tree.root.children.is_empty());
+    }
+
+    #[test]
     fn build_tree_wraps_elements_in_a_window_root_sized_to_geometry() {
         let tree = built();
         assert_eq!(tree.root.role, AxRole::Window);
@@ -448,58 +422,6 @@ mod tests {
         // A bare scalar is neither an element object nor an array of elements.
         let err = build_tree("42", SCALE, &win(), WalkLimits::DEFAULT).unwrap_err();
         assert!(matches!(err, GlassError::AccessibilityUnavailable(_)));
-    }
-
-    #[test]
-    fn root_point_width_reads_widest_frame() {
-        let j = r#"[{"frame":{"x":0,"y":0,"width":402,"height":874}}]"#;
-        assert_eq!(root_point_width(j), Some(402.0));
-    }
-
-    #[test]
-    fn root_point_width_picks_the_widest_top_level_element() {
-        let j = r#"[{"frame":{"width":320}},{"frame":{"width":402}}]"#;
-        assert_eq!(root_point_width(j), Some(402.0));
-    }
-
-    #[test]
-    fn root_point_width_reads_a_single_object_root() {
-        let j = r#"{"frame":{"width":390}}"#;
-        assert_eq!(root_point_width(j), Some(390.0));
-    }
-
-    #[test]
-    fn root_point_width_is_none_without_a_numeric_frame_width() {
-        // `AXFrame` is a stringified CGRect, not a number, and there is no structured
-        // `frame` here — so there is no usable width to read.
-        let j = r#"[{"AXFrame":"{{0, 0}, {402, 874}}"}]"#;
-        assert_eq!(root_point_width(j), None);
-    }
-
-    #[test]
-    fn root_point_width_is_none_on_malformed_json() {
-        assert_eq!(root_point_width("not json"), None);
-    }
-
-    #[test]
-    fn root_point_width_matches_the_fixture_application_width() {
-        // The real describe-all fixture's application root is 402 logical points wide.
-        assert_eq!(root_point_width(FIXTURE), Some(402.0));
-    }
-
-    #[test]
-    fn scale_from_width_divides_pixels_by_root_point_width() {
-        // 1206px capture over a 402pt describe root is the ×3 backing scale.
-        let json = r#"[{"frame":{"width":402}}]"#;
-        assert_eq!(scale_from_width(json, 1206), Some(3.0));
-    }
-
-    #[test]
-    fn scale_from_width_is_none_without_a_positive_root_width() {
-        // No usable width (empty tree) and a non-positive width both yield None, so no
-        // caller ever divides by a zero-or-negative point width.
-        assert_eq!(scale_from_width("[]", 1206), None);
-        assert_eq!(scale_from_width(r#"[{"frame":{"width":0}}]"#, 1206), None);
     }
 
     #[test]

--- a/crates/glass-ios/src/idb/client.rs
+++ b/crates/glass-ios/src/idb/client.rs
@@ -212,18 +212,20 @@ impl IdbClient {
 
 #[cfg(test)]
 mod tests {
-    /// glass drives input at two scales that must agree: the target's density, used at launch
-    /// because it is known before the app renders (#246), and the ratio the live accessibility
-    /// tree implies. Do not assert the density against idb's own `width_points` instead — idb
-    /// derives that field *from* the density, so such a check cannot fail.
+
+    use super::*;
+
+    /// The scale glass drives every tap at comes from this RPC (`platform::discover_scale`),
+    /// so a target that stops reporting a usable density silently breaks input placement.
+    /// That the value is *correct* is proved end-to-end by `tests/drive_integration.rs`,
+    /// which taps elements by their accessibility bounds and asserts the app responded.
     ///
     /// ```sh
-    /// GLASS_IOS_UDID=<udid> cargo test -p glass-ios --lib density_matches -- --ignored --nocapture
+    /// GLASS_IOS_UDID=<udid> cargo test -p glass-ios --lib describe_reports -- --ignored --nocapture
     /// ```
     #[test]
     #[ignore = "on-box only: needs a macOS host with a booted iOS Simulator and idb_companion"]
-    fn density_matches_the_scale_the_live_tree_implies() {
-        use std::time::{Duration, Instant};
+    fn describe_reports_a_usable_density_with_no_app_running() {
         let udid = std::env::var("GLASS_IOS_UDID").expect("set GLASS_IOS_UDID to a booted sim");
         let companion =
             crate::idb::companion::IdbCompanion::spawn(&udid).expect("idb_companion must start");
@@ -233,45 +235,16 @@ mod tests {
         let d = client
             .describe()
             .expect("describe must report screen dimensions");
+        println!(
+            "pixels {}x{}, points {}x{}, density {}",
+            d.width, d.height, d.width_points, d.height_points, d.density
+        );
         assert!(
             d.density.is_finite() && d.density > 0.0,
             "a target reporting no usable density leaves glass unable to place input: {}",
             d.density
         );
-
-        // A stock app, so this needs nothing installed; the tree has no root width until
-        // something is drawn.
-        let out = std::process::Command::new("xcrun")
-            .args(["simctl", "launch", &udid, "com.apple.Preferences"])
-            .output()
-            .expect("xcrun simctl launch must run");
-        assert!(
-            out.status.success(),
-            "the comparison is meaningless if the app never launched: {}",
-            String::from_utf8_lossy(&out.stderr).trim()
-        );
-
-        let deadline = Instant::now() + Duration::from_secs(20);
-        let live = loop {
-            let json = client.describe_all().expect("describe_all must work");
-            if let Some(scale) = crate::axmap::scale_from_width(&json, d.width as u32) {
-                break scale;
-            }
-            assert!(
-                Instant::now() < deadline,
-                "the tree never carried a root width"
-            );
-            std::thread::sleep(Duration::from_millis(100));
-        };
-
-        assert_eq!(
-            d.density, live,
-            "the device's density and the live tree's ratio are the two scales glass drives \
-             input at; a disagreement places taps at the wrong point"
-        );
     }
-
-    use super::*;
 
     #[test]
     fn map_timed_folds_an_elapsed_deadline_into_a_backend_timeout() {

--- a/crates/glass-ios/src/idb/client.rs
+++ b/crates/glass-ios/src/idb/client.rs
@@ -157,6 +157,28 @@ impl IdbClient {
         Ok(resp.into_inner().json)
     }
 
+    /// Describe the target itself: its screen's pixel size, logical-point size and density.
+    /// These are properties of the device, so unlike [`describe_all`](Self::describe_all)
+    /// they are available before the app under test has rendered anything.
+    pub fn describe(&self) -> Result<proto::ScreenDimensions> {
+        self.ensure_off_runtime("idb describe")?;
+        let mut client = self.client.clone();
+        let outcome = self.rt.block_on(async move {
+            tokio::time::timeout(
+                RPC_TIMEOUT,
+                client.describe(proto::TargetDescriptionRequest {
+                    fetch_diagnostics: false,
+                }),
+            )
+            .await
+        });
+        let resp = map_timed("idb describe", RPC_TIMEOUT, outcome)?;
+        resp.into_inner()
+            .target_description
+            .and_then(|t| t.screen_dimensions)
+            .ok_or_else(|| GlassError::Backend("idb describe returned no screen dimensions".into()))
+    }
+
     /// Send one HID event stream (client-streaming `hid`). A tap is two events
     /// (touch DOWN, touch UP); a chord is modifier + key down/up pairs.
     pub fn hid(&self, events: Vec<proto::HidEvent>) -> Result<()> {
@@ -190,6 +212,46 @@ impl IdbClient {
 
 #[cfg(test)]
 mod tests {
+    /// The scale glass drives input at comes from this RPC (see `platform::discover_scale`),
+    /// so this checks the target reports one at all and that it is the screen's own pixel/point
+    /// ratio rather than some unrelated field. Needs no app launched — which is the point:
+    /// the value is a property of the device, available before anything has rendered (#246).
+    ///
+    /// ```sh
+    /// GLASS_IOS_UDID=<udid> cargo test -p glass-ios --lib describe_reports -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "on-box only: needs a macOS host with a booted iOS Simulator and idb_companion"]
+    fn describe_reports_a_density_that_is_the_screens_pixel_to_point_ratio() {
+        let udid = std::env::var("GLASS_IOS_UDID").expect("set GLASS_IOS_UDID to a booted sim");
+        let companion =
+            crate::idb::companion::IdbCompanion::spawn(&udid).expect("idb_companion must start");
+        let client =
+            IdbClient::connect(companion.socket()).expect("companion must accept a client");
+
+        let d = client
+            .describe()
+            .expect("describe must report screen dimensions");
+        println!(
+            "pixels {}x{}, points {}x{}, density {}",
+            d.width, d.height, d.width_points, d.height_points, d.density
+        );
+        assert!(
+            d.density.is_finite() && d.density > 0.0,
+            "a target that reports no usable density leaves glass unable to place input: {}",
+            d.density
+        );
+        assert!(
+            d.width_points > 0,
+            "a screen with no point width cannot be cross-checked"
+        );
+        assert_eq!(
+            d.density,
+            d.width as f64 / d.width_points as f64,
+            "density must be the screen's own pixel/point ratio"
+        );
+    }
+
     use super::*;
 
     #[test]

--- a/crates/glass-ios/src/idb/client.rs
+++ b/crates/glass-ios/src/idb/client.rs
@@ -212,17 +212,20 @@ impl IdbClient {
 
 #[cfg(test)]
 mod tests {
-    /// The scale glass drives input at comes from this RPC (see `platform::discover_scale`),
-    /// so this checks the target reports one at all and that it is the screen's own pixel/point
-    /// ratio rather than some unrelated field. Needs no app launched — which is the point:
-    /// the value is a property of the device, available before anything has rendered (#246).
+    /// glass drives input at two scales that must agree: the target's density, which
+    /// `platform::discover_scale` uses at launch because it is available before the app
+    /// renders (#246), and the ratio the live accessibility tree implies, which `IosA11y`
+    /// prefers because the tree's frames are in exactly those points. Asserting the density
+    /// against idb's own `width_points` would prove nothing — idb derives that field *from*
+    /// the density — so this compares it against the live tree instead.
     ///
     /// ```sh
-    /// GLASS_IOS_UDID=<udid> cargo test -p glass-ios --lib describe_reports -- --ignored --nocapture
+    /// GLASS_IOS_UDID=<udid> cargo test -p glass-ios --lib density_matches -- --ignored --nocapture
     /// ```
     #[test]
     #[ignore = "on-box only: needs a macOS host with a booted iOS Simulator and idb_companion"]
-    fn describe_reports_a_density_that_is_the_screens_pixel_to_point_ratio() {
+    fn density_matches_the_scale_the_live_tree_implies() {
+        use std::time::{Duration, Instant};
         let udid = std::env::var("GLASS_IOS_UDID").expect("set GLASS_IOS_UDID to a booted sim");
         let companion =
             crate::idb::companion::IdbCompanion::spawn(&udid).expect("idb_companion must start");
@@ -232,23 +235,41 @@ mod tests {
         let d = client
             .describe()
             .expect("describe must report screen dimensions");
-        println!(
-            "pixels {}x{}, points {}x{}, density {}",
-            d.width, d.height, d.width_points, d.height_points, d.density
-        );
         assert!(
             d.density.is_finite() && d.density > 0.0,
-            "a target that reports no usable density leaves glass unable to place input: {}",
+            "a target reporting no usable density leaves glass unable to place input: {}",
             d.density
         );
+
+        // A stock app, so this needs nothing installed; the tree has no root width until
+        // something is drawn.
+        let out = std::process::Command::new("xcrun")
+            .args(["simctl", "launch", &udid, "com.apple.Preferences"])
+            .output()
+            .expect("xcrun simctl launch must run");
         assert!(
-            d.width_points > 0,
-            "a screen with no point width cannot be cross-checked"
+            out.status.success(),
+            "the comparison is meaningless if the app never launched: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
         );
+
+        let deadline = Instant::now() + Duration::from_secs(20);
+        let live = loop {
+            let json = client.describe_all().expect("describe_all must work");
+            if let Some(scale) = crate::axmap::scale_from_width(&json, d.width as u32) {
+                break scale;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "the tree never carried a root width"
+            );
+            std::thread::sleep(Duration::from_millis(100));
+        };
+
         assert_eq!(
-            d.density,
-            d.width as f64 / d.width_points as f64,
-            "density must be the screen's own pixel/point ratio"
+            d.density, live,
+            "the device's density and the live tree's ratio are the two scales glass drives \
+             input at; a disagreement places taps at the wrong point"
         );
     }
 

--- a/crates/glass-ios/src/idb/client.rs
+++ b/crates/glass-ios/src/idb/client.rs
@@ -212,12 +212,10 @@ impl IdbClient {
 
 #[cfg(test)]
 mod tests {
-    /// glass drives input at two scales that must agree: the target's density, which
-    /// `platform::discover_scale` uses at launch because it is available before the app
-    /// renders (#246), and the ratio the live accessibility tree implies, which `IosA11y`
-    /// prefers because the tree's frames are in exactly those points. Asserting the density
-    /// against idb's own `width_points` would prove nothing — idb derives that field *from*
-    /// the density — so this compares it against the live tree instead.
+    /// glass drives input at two scales that must agree: the target's density, used at launch
+    /// because it is known before the app renders (#246), and the ratio the live accessibility
+    /// tree implies. Do not assert the density against idb's own `width_points` instead — idb
+    /// derives that field *from* the density, so such a check cannot fail.
     ///
     /// ```sh
     /// GLASS_IOS_UDID=<udid> cargo test -p glass-ios --lib density_matches -- --ignored --nocapture

--- a/crates/glass-ios/src/injector/mod.rs
+++ b/crates/glass-ios/src/injector/mod.rs
@@ -72,10 +72,10 @@ fn key(code: u16, down: bool) -> proto::HidEvent {
 
 impl IdbInjector {
     /// Build an injector for a device whose point→pixel scale is `scale`. `scale` must be
-    /// finite and positive — it is a divisor for every coordinate, and callers only reach
-    /// here with a scale derived from a positive root width (see `axmap::scale_from_width`),
-    /// so the `debug_assert` documents that precondition and catches a future regression in
-    /// debug builds.
+    /// finite and positive — it is a divisor for every coordinate, and both callers reach here
+    /// through a check that guarantees it (`platform::checked_scale`, or a positive root width
+    /// via `axmap::scale_from_width`), so the `debug_assert` documents that precondition and
+    /// catches a future regression in debug builds.
     pub(crate) fn new(scale: f64) -> Self {
         debug_assert!(
             scale.is_finite() && scale > 0.0,

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -120,9 +120,8 @@ const LAUNCH_FAILURE_LOG_LINES: usize = 4;
 ///
 /// Measured on a Simulator: an app that rejects a launch argument and calls `fatalError`
 /// disappears from `ps` about 465 ms after `simctl launch` returns, repeatably. The window is set
-/// above that so the check is not a race, and it is spent rather than assumed — the work between
-/// launch and check (a screenshot, and scale discovery when a driver is present) usually covers
-/// it, but that is a property of neighbouring code, and an observe-only launch skips half of it.
+/// above that so the check is not a race, and it is spent rather than assumed: the work between
+/// launch and check is a screenshot and one scale RPC, which does not reliably cover it.
 ///
 /// A window can only ever bound "died at startup"; an app that exits later is a running app that
 /// stopped, which the next operation reports.
@@ -346,10 +345,12 @@ const LOG_STREAM_READY_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Discover the device's point→pixel scale, which idb reports for the *target* — so it is
 /// known before the app has drawn anything, unlike the accessibility tree this used to derive
-/// it from. Taken as the screen's density rather than divided out of its own pixel and point
-/// widths, because a density does not swap axes when the device rotates. It never falls back
-/// to a placeholder: an undetermined scale would place every tap at the wrong point, so the
-/// failure surfaces as an error and the caller leaves the session unstarted.
+/// it from. idb derives the screen's point width from this same density, so dividing those
+/// two out again would be the same number by construction, not a second opinion — where a
+/// real second opinion exists, the accessibility tree's own ratio, `IosA11y` prefers it. It
+/// never falls back to a placeholder: an undetermined scale would place every tap at the
+/// wrong point, so the failure surfaces as an error and the caller leaves the session
+/// unstarted.
 fn discover_scale(client: &IdbClient) -> Result<f64> {
     checked_scale(client.describe()?.density)
 }
@@ -357,7 +358,7 @@ fn discover_scale(client: &IdbClient) -> Result<f64> {
 /// Reject a density that cannot be a scale. Separated from the RPC so this is testable
 /// without a simulator, and kept because idb's field is a plain `double`: a zero from a
 /// target that failed to report one would otherwise divide every tap to infinity.
-fn checked_scale(density: f64) -> Result<f64> {
+pub(crate) fn checked_scale(density: f64) -> Result<f64> {
     if !density.is_finite() || density <= 0.0 {
         return Err(GlassError::Backend(format!(
             "could not determine the iOS display scale: idb reported a screen density of \
@@ -692,11 +693,11 @@ mod tests {
         // Guessing here would place every tap at the wrong point, so it is an error and the
         // caller leaves the session unstarted rather than driven at a wrong scale.
         for bad in [0.0, -1.0, f64::NAN, f64::INFINITY] {
-            let err = checked_scale(bad).expect_err("{bad} cannot be a scale");
-            assert!(
-                matches!(&err, GlassError::Backend(m) if m.contains("display scale")),
-                "{err}"
-            );
+            let err = match checked_scale(bad) {
+                Ok(scale) => panic!("{bad} must be rejected, was accepted as scale {scale}"),
+                Err(e) => e.to_string(),
+            };
+            assert!(err.contains("display scale"), "{err}");
         }
     }
 }

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -121,7 +121,8 @@ const LAUNCH_FAILURE_LOG_LINES: usize = 4;
 /// Measured on a Simulator: an app that rejects a launch argument and calls `fatalError`
 /// disappears from `ps` about 465 ms after `simctl launch` returns, repeatably. The window is set
 /// above that so the check is not a race, and it is spent rather than assumed: the work between
-/// launch and check is a screenshot and one scale RPC, which does not reliably cover it.
+/// launch and check is a screenshot, plus one scale RPC when a driver is present, which does not
+/// reliably cover it.
 ///
 /// A window can only ever bound "died at startup"; an app that exits later is a running app that
 /// stopped, which the next operation reports.
@@ -464,11 +465,10 @@ impl Platform for IosPlatform {
         };
         // With a driver present, learn the point→pixel scale and build the injector at it
         // before reporting the app as running, so no tap is ever issued at an unverified
-        // scale (`describe` reports point frames while the screenshot is in pixels; their
-        // ratio is the scale). On scale-discovery failure the app is left unregistered (no
-        // active session) rather than driven at a wrong scale. In observe-only mode (no
-        // companion) there is no injector — input is unsupported — but geometry is still
-        // reported so capture/logs/clipboard work.
+        // scale. On scale-discovery failure the app is left unregistered (no active session)
+        // rather than driven at a wrong scale. In observe-only mode (no companion) there is
+        // no injector — input is unsupported — but geometry is still reported so
+        // capture/logs/clipboard work.
         let injector = match &self.driver {
             Some(driver) => Some(IdbInjector::new(discover_scale(&driver.client)?)),
             None => None,
@@ -693,9 +693,12 @@ mod tests {
         for bad in [0.0, -1.0, f64::NAN, f64::INFINITY] {
             let err = match checked_scale(bad) {
                 Ok(scale) => panic!("{bad} must be rejected, was accepted as scale {scale}"),
-                Err(e) => e.to_string(),
+                Err(e) => e,
             };
-            assert!(err.contains("display scale"), "{err}");
+            assert!(
+                matches!(&err, GlassError::Backend(m) if m.contains("display scale")),
+                "{err}"
+            );
         }
     }
 }

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -345,19 +345,17 @@ const LOG_STREAM_READY_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Discover the device's point→pixel scale, which idb reports for the *target* — so it is
 /// known before the app has drawn anything, unlike the accessibility tree this used to derive
-/// it from. idb derives the screen's point width from this same density, so dividing those
-/// two out again would be the same number by construction, not a second opinion — where a
-/// real second opinion exists, the accessibility tree's own ratio, `IosA11y` prefers it. It
-/// never falls back to a placeholder: an undetermined scale would place every tap at the
-/// wrong point, so the failure surfaces as an error and the caller leaves the session
-/// unstarted.
+/// it from. `IosA11y` prefers the tree's own ratio where it has one, that being the only
+/// independent second opinion: idb derives the screen's point width from this same density.
+/// It never falls back to a placeholder — an undetermined scale would place every tap at the
+/// wrong point, so the failure surfaces as an error and the session is left unstarted.
 fn discover_scale(client: &IdbClient) -> Result<f64> {
     checked_scale(client.describe()?.density)
 }
 
-/// Reject a density that cannot be a scale. Separated from the RPC so this is testable
-/// without a simulator, and kept because idb's field is a plain `double`: a zero from a
-/// target that failed to report one would otherwise divide every tap to infinity.
+/// Reject a density that cannot be a scale: idb's field is a plain `double`, and a zero from
+/// a target that failed to report one would divide every tap to infinity. Split from the RPC
+/// so it is testable without a simulator.
 pub(crate) fn checked_scale(density: f64) -> Result<f64> {
     if !density.is_finite() || density <= 0.0 {
         return Err(GlassError::Backend(format!(
@@ -691,7 +689,7 @@ mod tests {
     #[test]
     fn a_density_that_cannot_be_a_scale_is_rejected() {
         // Guessing here would place every tap at the wrong point, so it is an error and the
-        // caller leaves the session unstarted rather than driven at a wrong scale.
+        // caller leaves the session unstarted.
         for bad in [0.0, -1.0, f64::NAN, f64::INFINITY] {
             let err = match checked_scale(bad) {
                 Ok(scale) => panic!("{bad} must be rejected, was accepted as scale {scale}"),

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -344,59 +344,27 @@ impl IosPlatform {
 /// failed stream so launch is never blocked for long.
 const LOG_STREAM_READY_TIMEOUT: Duration = Duration::from_secs(2);
 
-/// How many times [`retry_for_scale`] polls for a positive scale before giving up.
-const SCALE_ATTEMPTS: usize = 3;
-/// How long [`retry_for_scale`] waits between polls while the tree is still empty.
-const SCALE_RETRY_DELAY: Duration = Duration::from_millis(200);
-
-/// Poll `next_scale` up to [`SCALE_ATTEMPTS`] times, `delay` apart, for the device's
-/// point→pixel scale. Each outcome is handled distinctly:
-///
-/// - `Ok(Some(scale))` — discovered; returned immediately.
-/// - `Ok(None)` — the tree parsed but has no positive root width yet (the app may still be
-///   rendering). This is the transient case worth retrying.
-/// - `Err(e)` — a real describe/RPC failure (dead transport, unparseable JSON, a timeout).
-///   Retrying can't help and a per-attempt timeout would cost the full deadline each try, so
-///   it is surfaced at once, wrapped with its cause.
-///
-/// If every attempt yields `Ok(None)`, the give-up error names the still-unrendered tree.
-/// `delay` is a parameter (rather than the [`SCALE_RETRY_DELAY`] constant inline) purely so
-/// tests can drive the loop with no sleeps.
-fn retry_for_scale(
-    delay: Duration,
-    mut next_scale: impl FnMut() -> Result<Option<f64>>,
-) -> Result<f64> {
-    for attempt in 0..SCALE_ATTEMPTS {
-        match next_scale() {
-            Ok(Some(scale)) => return Ok(scale),
-            Ok(None) => {}
-            Err(e) => {
-                return Err(GlassError::Backend(format!(
-                    "could not determine the iOS display scale; last describe error: {e}"
-                )));
-            }
-        }
-        if attempt + 1 < SCALE_ATTEMPTS {
-            std::thread::sleep(delay);
-        }
-    }
-    Err(GlassError::Backend(
-        "could not determine the iOS display scale from the accessibility tree; \
-         the app may not have finished rendering"
-            .into(),
-    ))
-}
-
-/// Discover the device's point→pixel scale by dividing the capture's pixel width by the
-/// accessibility root's logical-point width. `describe` can briefly lag a launch, so the
-/// retry loop in [`retry_for_scale`] tolerates a transient empty tree. It never falls back
+/// Discover the device's point→pixel scale, which idb reports for the *target* — so it is
+/// known before the app has drawn anything, unlike the accessibility tree this used to derive
+/// it from. Taken as the screen's density rather than divided out of its own pixel and point
+/// widths, because a density does not swap axes when the device rotates. It never falls back
 /// to a placeholder: an undetermined scale would place every tap at the wrong point, so the
 /// failure surfaces as an error and the caller leaves the session unstarted.
-fn discover_scale(client: &IdbClient, frame_px_width: u32) -> Result<f64> {
-    retry_for_scale(SCALE_RETRY_DELAY, || {
-        let json = client.describe_all()?;
-        Ok(crate::axmap::scale_from_width(&json, frame_px_width))
-    })
+fn discover_scale(client: &IdbClient) -> Result<f64> {
+    checked_scale(client.describe()?.density)
+}
+
+/// Reject a density that cannot be a scale. Separated from the RPC so this is testable
+/// without a simulator, and kept because idb's field is a plain `double`: a zero from a
+/// target that failed to report one would otherwise divide every tap to infinity.
+fn checked_scale(density: f64) -> Result<f64> {
+    if !density.is_finite() || density <= 0.0 {
+        return Err(GlassError::Backend(format!(
+            "could not determine the iOS display scale: idb reported a screen density of \
+             {density}"
+        )));
+    }
+    Ok(density)
 }
 
 impl Platform for IosPlatform {
@@ -503,10 +471,7 @@ impl Platform for IosPlatform {
         // companion) there is no injector — input is unsupported — but geometry is still
         // reported so capture/logs/clipboard work.
         let injector = match &self.driver {
-            Some(driver) => Some(IdbInjector::new(discover_scale(
-                &driver.client,
-                frame.width,
-            )?)),
+            Some(driver) => Some(IdbInjector::new(discover_scale(&driver.client)?)),
             None => None,
         };
         // Everything above would look identical for an app that died on launch: `simctl launch`
@@ -717,53 +682,22 @@ mod tests {
     }
 
     #[test]
-    fn retry_for_scale_returns_the_first_positive_scale() {
-        // Empty tree twice (still rendering), then a real scale on the third poll: it must
-        // keep trying and return that scale — the `describe`-lags-a-launch case.
-        let calls = std::cell::Cell::new(0usize);
-        let scale = retry_for_scale(Duration::ZERO, || {
-            let n = calls.get();
-            calls.set(n + 1);
-            Ok(if n < 2 { None } else { Some(3.0) })
-        })
-        .expect("scale should be discovered on the third poll");
-        assert_eq!(scale, 3.0);
-        assert_eq!(calls.get(), 3, "should have polled exactly three times");
+    fn a_reported_density_is_the_scale() {
+        // 3x is what the Simulator reports for an iPhone 17.
+        assert_eq!(checked_scale(3.0).unwrap(), 3.0);
     }
 
     #[test]
-    fn retry_for_scale_gives_up_after_the_last_attempt() {
-        // A tree that never gains a width: after exhausting every attempt, give up with the
-        // still-rendering error rather than looping forever or inventing a scale.
-        let calls = std::cell::Cell::new(0usize);
-        let err = retry_for_scale(Duration::ZERO, || {
-            calls.set(calls.get() + 1);
-            Ok(None)
-        })
-        .expect_err("an always-empty tree must give up, not succeed");
-        assert_eq!(calls.get(), SCALE_ATTEMPTS, "should exhaust every attempt");
-        assert!(
-            matches!(&err, GlassError::Backend(m) if m.contains("finished rendering")),
-            "give-up error should name the unrendered tree: {err:?}"
-        );
-    }
-
-    #[test]
-    fn retry_for_scale_surfaces_a_describe_error_without_retrying() {
-        // A hard describe/RPC failure can't be fixed by waiting, so it must surface on the
-        // first poll with its cause — never retried (retrying would cost a full deadline).
-        let calls = std::cell::Cell::new(0usize);
-        let err = retry_for_scale(Duration::ZERO, || {
-            calls.set(calls.get() + 1);
-            Err(GlassError::Backend("dead transport".into()))
-        })
-        .expect_err("a describe error must surface, not be retried");
-        assert_eq!(calls.get(), 1, "a hard error must not be retried");
-        assert!(
-            matches!(&err, GlassError::Backend(m)
-                if m.contains("last describe error") && m.contains("dead transport")),
-            "error should wrap the describe cause: {err:?}"
-        );
+    fn a_density_that_cannot_be_a_scale_is_rejected() {
+        // Guessing here would place every tap at the wrong point, so it is an error and the
+        // caller leaves the session unstarted rather than driven at a wrong scale.
+        for bad in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            let err = checked_scale(bad).expect_err("{bad} cannot be a scale");
+            assert!(
+                matches!(&err, GlassError::Backend(m) if m.contains("display scale")),
+                "{err}"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
Refs #246 — please read **What this does and does not prove** before merging.

`glass_start` derived the point→pixel scale — what `IdbInjector` uses to turn capture pixels into the points idb expects — from the app's accessibility tree, so a launch depended on the app having rendered. When it hadn't, the launch failed and left no session:

```
could not determine the iOS display scale from the accessibility tree;
the app may not have finished rendering
```

## The scale was never the app's to report

It is a property of the device, and idb reports it for the *target*. Measured on a booted Simulator with the launch's exit status checked:

| source | when it answers |
|---|---|
| `idb describe` → `density: 3` | before any app is running, on a still-booting Simulator |
| accessibility root point width | **1.88 s** after `simctl launch` |

The old retry was 3 attempts 200 ms apart — about a third of that gap, closed only by whatever incidental work sat between launch and the check. It existed to wait for a value that was never the right source, so it goes with the dependency.

## What the tree ratio actually was

Worth stating, because it is why this PR ends up deleting the old source rather than keeping it as a second opinion. `scale_from_width` divided the capture's pixel width by the widest **top-level element's** point width — not the screen's. That equals the device's scale only when some top-level element happens to span the capture.

On master that never mattered: scale discovery and the a11y reader called the *same* function, so the pixel bounds the reader reported and the points the injector converted them back into used one factor, and taps landed. My first cut sourced only the launch scale from the device and left the reader on the tree — and `click_element` joins them, reading pixel bounds from the cached tree and sending them through the platform injector. Tree at `R`, injector at `D`, every element tap lands at `pt × R/D`. Review caught it; on a device whose widest top-level element is 300 pt, that is a 34% displacement.

So both sides now take the device's scale, and `root_point_width`/`scale_from_width` are deleted rather than demoted — 88 lines. Their layout dependence is precisely what made a second source unsafe.

## What this does and does not prove

**Does not:** I could not reproduce #246 on demand. The master binary passed 6/6 cold-boot smoke runs including at load average 26–127, and disabling the intermediate a11y fallback still left `drive_integration` green. Both windows stayed shut on this box.

**Does:** the two measurements above, and that taps land correctly with one scale — `drive_integration` taps elements by their accessibility bounds and asserts the app responded, run on box after the change. The case for merging is that the dependency is gone by construction.

**No regression:** smoke 8/8 on two cold boots, `drive_integration` green, full workspace suite green.

## Tests

- `checked_scale`'s rejection of a degenerate density, shown to fail when the check is removed (it names the input that got through).
- `build_tree("[]")` yields an empty window rather than an error — the invariant that lets `wait_for_element` poll through a still-rendering app. Shown to fail when `build_tree` errors instead.
- On box: that idb reports a usable density at all, which is what this crate needs from it. An earlier version asserted density against idb's `width_points`, which idb derives *from* density, so it could not fail; the version after that polled for a tree root the home screen always publishes, so its loop never iterated.

## Known follow-up, not in this PR

`glass_start` returns before the app has rendered, so a snapshot in that ~1–2 s window returns an empty tree and picks up glass-core's generic *"this app may publish no accessibility tree — drive it by pixels"* hint, which is wrong advice for an app that is merely still drawing. Master masked this by blocking in scale discovery. A bounded, non-fatal settle in `start_app` would fix it, but that is a new product behaviour rather than part of this fix, so it is flagged rather than folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)