### PR TITLE
docs(ios): correct a doc left describing the removed scale derivation

### DIFF
--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -42,10 +42,9 @@ impl IosA11y {
         Ok(scale)
     }
 
-    /// One describe round-trip: fetch the accessibility JSON, derive the point→pixel
-    /// scale from `ctx.window` (pixels, valid once the app has started) and the describe
-    /// root's point width, and map the id-assigned tree. Returns the tree and the scale,
-    /// since `set_value` needs the same scale to place synthetic input.
+    /// One describe round-trip: fetch the accessibility JSON and map the id-assigned tree at
+    /// the target's scale. Returns the scale alongside it, since `set_value` places synthetic
+    /// input at the same one.
     fn describe(&mut self, ctx: &AxContext) -> Result<(AxTree, f64)> {
         let scale = self.scale()?;
         let json = self.client.describe_all()?;


### PR DESCRIPTION
Leftover from #255. `IosA11y::describe`'s doc still said it derives the point→pixel scale "from `ctx.window` (pixels, valid once the app has started) and the describe root's point width" — which is precisely the mechanism #255 removed, and the one whose layout dependence made it wrong to keep.

A comment that describes a removed mechanism is worse than none: the next reader would conclude the tree still drives the scale.

Comment-only; verified as such (`git diff -U0` contains no non-comment line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)