### PR TITLE
fix(macos): ship a README in the release .zip and .dmg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,8 +295,16 @@ jobs:
           tag="${GITHUB_REF_NAME}"
           name="glass-mcp-${tag}-universal-apple-darwin"
           mkdir -p dist
-          # ditto (not zip) preserves the bundle layout + signature.
-          ditto -c -k --keepParent target/macos-app/GlassMcp.app "dist/${name}.zip"
+          # The README sits beside the bundle, never inside it: a file added within
+          # GlassMcp.app would invalidate its signature and its notarization.
+          stage="$(mktemp -d)"
+          # ditto (not cp -R) is the guaranteed-faithful copy for a signed bundle.
+          ditto target/macos-app/GlassMcp.app "$stage/GlassMcp.app"
+          cp packaging/README-macos.md "$stage/README.md"
+          # Archive the staging directory's *contents* (no --keepParent), so the app stays at
+          # the root of the zip next to the README rather than nested under a folder.
+          ditto -c -k "$stage" "dist/${name}.zip"
+          rm -rf "$stage"
           ( cd dist && for f in *.zip *.dmg; do shasum -a 256 "$f" > "$f.sha256"; done )
 
       - name: Attest build provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,13 +298,14 @@ jobs:
           # The README sits beside the bundle, never inside it: a file added within
           # GlassMcp.app would invalidate its signature and its notarization.
           stage="$(mktemp -d)"
-          # ditto (not cp -R) is the guaranteed-faithful copy for a signed bundle.
+          trap 'rm -rf "$stage"' EXIT
+          # ditto (not cp -R) is the guaranteed-faithful copy for a signed bundle — the same
+          # copy make-dmg.sh already makes of the stapled app, so the ticket survives it too.
           ditto target/macos-app/GlassMcp.app "$stage/GlassMcp.app"
           cp packaging/README-macos.md "$stage/README.md"
           # Archive the staging directory's *contents* (no --keepParent), so the app stays at
           # the root of the zip next to the README rather than nested under a folder.
           ditto -c -k "$stage" "dist/${name}.zip"
-          rm -rf "$stage"
           ( cd dist && for f in *.zip *.dmg; do shasum -a 256 "$f" > "$f.sha256"; done )
 
       - name: Attest build provenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,11 @@ internal refactors, CI, or test-only changes.
   Android paths have no such live check.
 
 ### Fixed
+- macOS: the release `.zip` and `.dmg` now carry a `README.md`, as every other platform's artifact
+  already did. It covers the drag-to-`/Applications` install, the two permission grants (including
+  that granting Screen Recording relaunches the app), and the `http://127.0.0.1:7300/` endpoint —
+  the platform with the most first-run setup was the one shipping none of it. The file sits beside
+  `GlassMcp.app` rather than inside it, so the bundle's signature and notarization are untouched.
 - iOS: `glass_start` now reads the display scale from the Simulator rather than from the app's
   accessibility tree, so a launch no longer depends on the app having rendered. The scale is a
   property of the device (`idb describe` reports it before any app runs), but glass derived it by

--- a/crates/glass-mcp/tests/bundled_readme_links.rs
+++ b/crates/glass-mcp/tests/bundled_readme_links.rs
@@ -1,5 +1,5 @@
 //! Guard: the per-platform READMEs bundled INTO the release archives
-//! (`packaging/README-{gnu,musl,windows}.md`) ship standalone — `release.yml` puts only the
+//! (`packaging/README-{gnu,musl,windows,macos}.md`) ship standalone — `release.yml` puts only the
 //! binary and that one file (renamed `README.md`) in each tarball/zip, no other repo files. So
 //! every inline link in them must be an ABSOLUTE URL (or an in-page anchor): a repo-relative link
 //! like `../docs/…` or a sibling `README-windows.md` resolves on GitHub but is broken the moment a
@@ -21,6 +21,7 @@ const BUNDLED: &[&str] = &[
     "packaging/README-gnu.md",
     "packaging/README-musl.md",
     "packaging/README-windows.md",
+    "packaging/README-macos.md",
 ];
 
 /// Every inline link / image target `](target)` in the markdown, target read up to the first `)`.

--- a/crates/glass-mcp/tests/bundled_readme_links.rs
+++ b/crates/glass-mcp/tests/bundled_readme_links.rs
@@ -1,6 +1,7 @@
 //! Guard: the per-platform READMEs bundled INTO the release archives
 //! (`packaging/README-{gnu,musl,windows,macos}.md`) ship standalone — `release.yml` puts only the
-//! binary and that one file (renamed `README.md`) in each tarball/zip, no other repo files. So
+//! binary (on macOS, the `GlassMcp.app` bundle) and that one file, renamed `README.md`, in each
+//! tarball/zip/dmg, and no other repo files. So
 //! every inline link in them must be an ABSOLUTE URL (or an in-page anchor): a repo-relative link
 //! like `../docs/…` or a sibling `README-windows.md` resolves on GitHub but is broken the moment a
 //! user extracts the archive. This test also forbids the exact stale claims a past drift shipped

--- a/docs/how-to/setup-macos.md
+++ b/docs/how-to/setup-macos.md
@@ -14,12 +14,13 @@ macOS opens it without a Gatekeeper detour, and first-run is a double-click:
 1. **Download** the `.dmg` from Releases and open it.
 2. **Drag `GlassMcp.app` to `/Applications`.**
 3. **Double-click `GlassMcp.app`.** A **permission checklist window** appears, listing **Accessibility**
-   and **Screen Recording**, each with a ✓/○ status and its own **Open Settings** button.
-4. Click **Open Settings** for each permission, **one at a time**. It adds `GlassMcp.app` to that
-   permission's pane under **System Settings → Privacy & Security** and opens the pane so you can turn
-   it on. Because the app is asking for *itself*, the grant lands on `GlassMcp.app` directly — no manual
-   `＋`-add needed. Granting **Screen Recording relaunches `GlassMcp.app` automatically** (macOS quits
-   and reopens it to pick up the grant) — that relaunch is expected, not an error. If you grant the two
+   and **Screen Recording**, each with a ✓/○ status and its own **Request…** button.
+4. Click **Request…** for each permission, **one at a time**. macOS raises its own consent prompt,
+   whose **Open System Settings** button navigates to that permission's pane under **System Settings →
+   Privacy & Security**. Because the app is asking for *itself*, `GlassMcp.app` is already listed there
+   — no manual `＋`-add needed. glass deliberately does not force the pane open itself, which fought
+   the system's own prompt. Granting **Screen Recording needs `GlassMcp.app` to restart** — macOS
+   offers **Quit & Reopen** — and that restart is expected, not an error. If you grant the two
    out of order, or a grant made elsewhere doesn't show up, click **Re-check**. Grants are **one-time**:
    keyed to the app's signed identity, they survive restarts and updates (see
    [the permission model](../explanation/macos-permissions.md)).

--- a/packaging/README-macos.md
+++ b/packaging/README-macos.md
@@ -5,7 +5,8 @@ launches an app, screenshots what's on screen, clicks and types into it, reads i
 logs, and detects visual changes — so the agent can build and debug a GUI on its own
 instead of asking you "does this look right?".
 
-This is the **macOS universal** build (Apple Silicon and Intel), signed and notarized.
+This is the **macOS universal** build, signed and notarized. It carries both
+architectures, though only Apple Silicon is tested — Intel Macs aren't yet verified.
 See the project README for the full picture:
 <https://github.com/fixed-width/glass>.
 The full macOS guide is
@@ -15,12 +16,14 @@ The full macOS guide is
 
 ## 1. System requirements
 
-macOS 14 or later. Nothing else to install — capture, input and the accessibility tree
-all use built-in macOS APIs.
+macOS 14 or later. Nothing else to install — capture, input, the accessibility tree and
+the Seatbelt sandbox that launched apps run under are all built into macOS.
 
 ## 2. Install
 
-Drag **`GlassMcp.app`** to **`/Applications`**, then double-click it.
+Drag **`GlassMcp.app`** to **`/Applications`**, then double-click it. macOS may first
+ask you to confirm an app downloaded from the internet — that is the quarantine prompt
+every download gets, not a permission request.
 
 Unlike the Linux and Windows builds, this one is a **GUI app, not a command-line
 binary**: macOS grants screen and input access to an application's signed identity, so
@@ -29,17 +32,19 @@ glass ships as one.
 ## 3. Grant the two permissions
 
 On first launch a **permission checklist** appears, listing **Accessibility** and
-**Screen Recording**. Click **Open Settings** next to each, one at a time, and turn it
-on — the app asks on its own behalf, so the grant lands on `GlassMcp.app` with nothing
-to add by hand.
+**Screen Recording**. Click **Request…** next to each, one at a time. macOS raises its
+own consent prompt — use the **Open System Settings** button on it to reach the pane and
+turn the permission on. The app asks on its own behalf, so it is already listed there
+with nothing to add by hand.
 
-**Granting Screen Recording relaunches the app.** macOS quits and reopens it so the
-grant takes effect; that relaunch is expected, not a failure. If a grant doesn't show
-up, click **Re-check**.
+**Granting Screen Recording needs the app to restart.** macOS offers **Quit & Reopen**;
+accept it, so the grant takes effect. That restart is expected, not a failure. If a
+grant doesn't show up, click **Re-check**.
 
 Once both are on, the checklist is replaced by a **`glass ●`** menu-bar item and glass
-starts serving. The grants are one-time — they survive restarts and updates. Why they
-behave this way is in
+starts serving. It also installs a LaunchAgent, so it **starts again at every login** —
+**Quit glass** or **Uninstall glass…** from that menu are how you stop it. The grants
+are one-time and survive restarts and updates. Why they behave this way is in
 [docs/explanation/macos-permissions.md](https://github.com/fixed-width/glass/blob/master/docs/explanation/macos-permissions.md).
 
 ## 4. Connect your agent (MCP over HTTP)
@@ -49,15 +54,20 @@ spawned by the agent the way the Linux and Windows binaries do. Point your clien
 that URL; loopback needs no token. See
 [docs/how-to/connect-an-agent.md](https://github.com/fixed-width/glass/blob/master/docs/how-to/connect-an-agent.md#over-http).
 
-Copy the endpoint straight from the **`glass ●`** menu with **Copy endpoint**.
+The **`glass ●`** menu also has **Copy endpoint**, **Restart** (after a fresh grant),
+**Quit glass**, and **Uninstall glass…**.
 
 ## 5. Check it works
 
 Ask your agent something like:
 
-> "Use glass to launch `/System/Applications/Font Book.app` and take a screenshot."
+> "Use glass to launch `/System/Applications/Font Book.app` with `sandbox` set to `off`
+> and take a screenshot."
 
-You should get back an image of the app. The tools it now has include `glass_start`,
+You should get back an image of the app. **Apple's own apps need `sandbox: "off"`**:
+macOS requires them to be started through LaunchServices, which glass cannot then place
+under Seatbelt, so a contained launch of one fails rather than running it unconfined.
+Apps you are developing take the default and stay contained. The tools it now has include `glass_start`,
 `glass_screenshot`, `glass_click`, `glass_type`, `glass_wait_stable`, `glass_diff`,
 `glass_logs`, `glass_a11y_snapshot`, `glass_click_element`, and `glass_doctor`.
 

--- a/packaging/README-macos.md
+++ b/packaging/README-macos.md
@@ -1,0 +1,87 @@
+# glass — macOS (universal)
+
+**glass** is an MCP server that lets an AI coding agent drive native GUI apps: it
+launches an app, screenshots what's on screen, clicks and types into it, reads its
+logs, and detects visual changes — so the agent can build and debug a GUI on its own
+instead of asking you "does this look right?".
+
+This is the **macOS universal** build (Apple Silicon and Intel), signed and notarized.
+See the project README for the full picture:
+<https://github.com/fixed-width/glass>.
+The full macOS guide is
+[docs/how-to/setup-macos.md](https://github.com/fixed-width/glass/blob/master/docs/how-to/setup-macos.md).
+
+---
+
+## 1. System requirements
+
+macOS 14 or later. Nothing else to install — capture, input and the accessibility tree
+all use built-in macOS APIs.
+
+## 2. Install
+
+Drag **`GlassMcp.app`** to **`/Applications`**, then double-click it.
+
+Unlike the Linux and Windows builds, this one is a **GUI app, not a command-line
+binary**: macOS grants screen and input access to an application's signed identity, so
+glass ships as one.
+
+## 3. Grant the two permissions
+
+On first launch a **permission checklist** appears, listing **Accessibility** and
+**Screen Recording**. Click **Open Settings** next to each, one at a time, and turn it
+on — the app asks on its own behalf, so the grant lands on `GlassMcp.app` with nothing
+to add by hand.
+
+**Granting Screen Recording relaunches the app.** macOS quits and reopens it so the
+grant takes effect; that relaunch is expected, not a failure. If a grant doesn't show
+up, click **Re-check**.
+
+Once both are on, the checklist is replaced by a **`glass ●`** menu-bar item and glass
+starts serving. The grants are one-time — they survive restarts and updates. Why they
+behave this way is in
+[docs/explanation/macos-permissions.md](https://github.com/fixed-width/glass/blob/master/docs/explanation/macos-permissions.md).
+
+## 4. Connect your agent (MCP over HTTP)
+
+The macOS app serves over HTTP at **`http://127.0.0.1:7300/`** — it does not need to be
+spawned by the agent the way the Linux and Windows binaries do. Point your client at
+that URL; loopback needs no token. See
+[docs/how-to/connect-an-agent.md](https://github.com/fixed-width/glass/blob/master/docs/how-to/connect-an-agent.md#over-http).
+
+Copy the endpoint straight from the **`glass ●`** menu with **Copy endpoint**.
+
+## 5. Check it works
+
+Ask your agent something like:
+
+> "Use glass to launch `/System/Applications/Font Book.app` and take a screenshot."
+
+You should get back an image of the app. The tools it now has include `glass_start`,
+`glass_screenshot`, `glass_click`, `glass_type`, `glass_wait_stable`, `glass_diff`,
+`glass_logs`, `glass_a11y_snapshot`, `glass_click_element`, and `glass_doctor`.
+
+glass captures the real desktop, so a sleeping or locked display has nothing to grab.
+On a Mac you aren't sitting at, hold it awake: `caffeinate -d -i -s &`.
+
+## 6. Optional: the `glass-mcp` CLI on your `$PATH`
+
+The binary lives inside the bundle and isn't needed for MCP, but it's useful from a
+terminal — `glass-mcp status` and `glass-mcp doctor`:
+
+```bash
+sudo ln -s /Applications/GlassMcp.app/Contents/MacOS/glass-mcp /usr/local/bin/glass-mcp
+```
+
+## Uninstall
+
+**Uninstall glass…** from the **`glass ●`** menu (or `glass-mcp uninstall`) stops glass
+starting at login and quits it. Neither touches the bundle — drag `GlassMcp.app` to the
+Trash to finish.
+
+---
+
+## Problems?
+
+`glass-mcp doctor` diagnoses most setup issues and prints a remedy for each failed
+check. Bug reports and questions: <https://github.com/fixed-width/glass/issues>.

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -78,7 +78,9 @@ Tagging `v*` runs the `macos` job in [`.github/workflows/release.yml`](../../.gi
 which builds a **universal2** (`arm64` + `x86_64`) `GlassMcp.app`, Developer-ID-signs it
 (hardened runtime + secure timestamp, nested clip-shim dylib included), notarizes and
 staples it via `xcrun notarytool` + `stapler`, and uploads
-`glass-mcp-<tag>-universal-apple-darwin.zip` to the GitHub Release.
+`glass-mcp-<tag>-universal-apple-darwin.{zip,dmg}` (each with a `.sha256`) to the GitHub
+Release. Both carry `../README-macos.md` as `README.md` beside the bundle — never inside
+it, which would break the signature.
 
 The job **skips cleanly** (no failure) until these repository secrets are set, so releases
 still publish the Linux/Windows artifacts before macOS signing is available:

--- a/packaging/macos/make-dmg.sh
+++ b/packaging/macos/make-dmg.sh
@@ -27,8 +27,9 @@ trap 'rm -rf "$staging"' EXIT
 # ditto (not cp -R) is the guaranteed-faithful copy for a signed bundle — it preserves the
 # bundle layout + code signature, matching release.yml's Package step.
 ditto "$app" "$staging/$(basename "$app")"
-# Beside the bundle, never inside it: a file added within the .app would invalidate its
-# signature. Resolved from this script's own location so callers need not pass it.
+# Beside the bundle, never inside it — a file added within the .app would invalidate its
+# signature — and resolved from this script's own location rather than passed in, so no
+# caller can pass the wrong one.
 readme="$(cd "$(dirname "$0")/.." && pwd)/README-macos.md"
 [ -f "$readme" ] || { echo "error: README not found: $readme" >&2; exit 1; }
 cp "$readme" "$staging/README.md"

--- a/packaging/macos/make-dmg.sh
+++ b/packaging/macos/make-dmg.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Build a drag-install .dmg around a signed GlassMcp.app: stage the app + an /Applications symlink,
-# then hdiutil a compressed read-only image. Sign/notarize/staple happen separately (notarize.sh).
+# Build a drag-install .dmg around a signed GlassMcp.app: stage the app, a README and an
+# /Applications symlink, then hdiutil a compressed read-only image. Sign/notarize/staple happen
+# separately (notarize.sh).
 #
 #   ./packaging/macos/make-dmg.sh --app <path.app> --out <dir> --version <X.Y.Z>
 set -euo pipefail
@@ -26,6 +27,11 @@ trap 'rm -rf "$staging"' EXIT
 # ditto (not cp -R) is the guaranteed-faithful copy for a signed bundle — it preserves the
 # bundle layout + code signature, matching release.yml's Package step.
 ditto "$app" "$staging/$(basename "$app")"
+# Beside the bundle, never inside it: a file added within the .app would invalidate its
+# signature. Resolved from this script's own location so callers need not pass it.
+readme="$(cd "$(dirname "$0")/.." && pwd)/README-macos.md"
+[ -f "$readme" ] || { echo "error: README not found: $readme" >&2; exit 1; }
+cp "$readme" "$staging/README.md"
 ln -s /Applications "$staging/Applications"
 dmg="$out/${name}.dmg"
 rm -f "$dmg"


### PR DESCRIPTION
Closes #242.

Every platform's release artifact bundles per-platform first-run instructions except macOS, which shipped none — on the one platform that cannot do anything until two permissions are granted. A user who unzipped it got an app bundle and nothing else.

## Beside the bundle, not inside it

This is the constraint the packaging is built around, and it is not a style preference. Copying the README into the bundle root:

```
GlassMcp.app: unsealed contents present in the bundle root
```

That would cost the artifact its signature and its notarization. So the zip stages the app and the README into a directory and archives its **contents** (`ditto -c -k` without `--keepParent`), leaving the app at the archive root next to the README rather than nested a level down — the same flat shape the Windows artifact has. `make-dmg.sh` stages the README next to the `/Applications` symlink it already creates.

## Verified on macOS

Against an ad-hoc-signed stub bundle, so no signing material is needed to re-run it:

| | |
|---|---|
| zip top level | `GlassMcp.app  README.md` |
| inside the bundle | nothing added |
| `codesign --verify --strict` on the extracted app | passes |
| dmg contents | `Applications  GlassMcp.app  README.md` |
| `codesign --verify --strict` on the mounted image | passes |
| negative control — README **inside** the bundle | fails, `unsealed contents present in the bundle root` |

The link guard that keeps bundled READMEs free of repo-relative links now covers the new file; confirmed by making one link relative and watching it fail.

## Four corrections review caught in the prose

Worth listing, because each would have misdirected a real user:

- **The first-run example named a system app without `sandbox: "off"`.** macOS makes Apple platform code start through LaunchServices, which glass then cannot place under Seatbelt, so a contained launch is refused — and the direct spawn it attempts first is documented to leave a crash report and a "quit unexpectedly" dialog for most stock apps. glass's own smoke profile has always passed `sandbox: "off"` here; the README dropped it.
- **The checklist button is `Request…`, not "Open Settings"**, and glass deliberately does not open the pane — `onboarding.rs` records that forcing Settings open fought macOS's own consent prompt, which is what carries that button. The Screen Recording grant is a **Quit & Reopen** prompt the user accepts, not an automatic relaunch.
- **"Apple Silicon and Intel"** dropped the qualifier the repo carries everywhere else: the binary is universal, Intel is not verified.
- **The LaunchAgent went unmentioned** — glass starts again at every login, which is material for a tool holding Screen Recording and Accessibility, and which the uninstall section already assumed the reader knew.

The first two came from `docs/how-to/setup-macos.md`, which had the same drift; it is corrected alongside.

## Also

The maintainer-facing `packaging/macos/README.md` and the link guard's module doc both described the macOS artifact as a zip carrying only a binary. Both now describe what actually ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)