### PR TITLE
feat(a11y): give every node a description, and source it on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ internal refactors, CI, or test-only changes.
 ## [Unreleased]
 
 ### Added
+- Accessibility elements can now carry a second label. `glass_a11y_snapshot` renders it as
+  `desc="…"` after the name — an icon-only button that used to reach you as a role and a
+  rectangle now says what it is — and the `glass_a11y_marks` legend labels an unnamed element
+  from it, spelled `desc="…"` there too. `glass_wait_for_element` and `glass_scroll_to_element`
+  report it on the element they matched. It is display-only: both tools still select on `name`.
+  Only the AT-SPI (Linux) reader sources the field today, so `desc` does not appear on Windows,
+  macOS, Android or iOS yet.
 - `glass_start` on the iOS Simulator passes an app's launch arguments through: everything after
   the `.app` path or bundle id in `run` reaches the app as its own arguments, joined
   (`--tab=value`) and separated (`--tab value`) forms alike, so an app whose behaviour is

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -11,7 +11,7 @@ use atspi::proxy::component::ComponentProxy;
 use atspi_common::{CoordType, ObjectRefOwned};
 use glass_core::{
     Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget, AxTree, GlassError, Result,
-    TruncationLimit, WalkBudget,
+    TruncationLimit, WalkBudget, normalize_description,
 };
 
 use crate::mapping::{map_role, map_states};
@@ -375,17 +375,18 @@ async fn walk(
     budget: &mut WalkBudget,
 ) -> Result<AxNode> {
     budget.visit();
-    // Issue the six independent per-node reads concurrently on the shared connection and await
-    // the slowest, instead of paying six sequential D-Bus round-trips (~6x the per-node latency).
-    // zbus multiplexes concurrent method calls over one connection. Traversal order, `budget`
-    // accounting, the child-gate, and child recursion below are all unchanged, so node ids stay
-    // in lockstep with `find_nth`. On the error path `join!` completes all six before we bail
-    // (vs. short-circuiting) — the result is identical, at the cost of a few reads on a snapshot
-    // that was already failing.
-    let (role_res, raw_role_res, name_res, state_res, bounds, child_refs_res) = tokio::join!(
+    // Issue the seven independent per-node reads concurrently on the shared connection and await
+    // the slowest, instead of paying seven sequential D-Bus round-trips (~7x the per-node
+    // latency). zbus multiplexes concurrent method calls over one connection. Traversal order,
+    // `budget` accounting, the child-gate, and child recursion below are all unchanged, so node
+    // ids stay in lockstep with `find_nth`. On the error path `join!` completes all seven before
+    // we bail (vs. short-circuiting) — the result is identical, at the cost of a few reads on a
+    // snapshot that was already failing.
+    let (role_res, raw_role_res, name_res, description_res, state_res, bounds, child_refs_res) = tokio::join!(
         proxy.get_role(),
         proxy.get_role_name(),
         proxy.name(),
+        proxy.description(),
         proxy.get_state(),
         extents(proxy, conn),
         proxy.get_children(),
@@ -393,6 +394,7 @@ async fn walk(
     let role = role_res.map_err(bus_err)?;
     let raw_role = raw_role_res.unwrap_or_default();
     let name = nonempty(name_res.unwrap_or_default());
+    let description = normalize_description(&description_res.unwrap_or_default(), name.as_deref());
     let states = map_states(&state_res.map_err(bus_err)?);
 
     let mut children = Vec::new();
@@ -427,7 +429,7 @@ async fn walk(
         role: map_role(role),
         raw_role,
         name,
-        description: None,
+        description,
         value,
         states,
         bounds,

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -427,6 +427,7 @@ async fn walk(
         role: map_role(role),
         raw_role,
         name,
+        description: None,
         value,
         states,
         bounds,

--- a/crates/glass-a11y-linux/tests/fixtures/a11y_fixture.py
+++ b/crates/glass-a11y-linux/tests/fixtures/a11y_fixture.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Minimal GTK4 app with a known accessibility tree, for glass-a11y-linux tests.
 Window "Glass A11y Fixture" containing a Label "Ready", a Button "Save", a
+Button "Bold" (AT-SPI description "Bold text", distinct from its name), a
 CheckButton "Enable", an Entry "Field" (initial text "hello"), a SpinButton
 "Amount" (initial value 1), a DropDown "Company" (Acme/Globex/Initech), a
 Switch "Active" (off), a virtualized GtkListView of 80 rows ("Row 000".."Row
@@ -32,6 +33,10 @@ class FixtureApp(Gtk.Application):
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
         box.append(Gtk.Label(label="Ready"))
         box.append(Gtk.Button(label="Save"))
+        bold = Gtk.Button(label="Bold")
+        # update_property(DESCRIPTION) populates AT-SPI Description (verified on the bus).
+        bold.update_property([Gtk.AccessibleProperty.DESCRIPTION], ["Bold text"])
+        box.append(bold)
         box.append(Gtk.CheckButton(label="Enable"))
         entry = Gtk.Entry()
         entry.set_text("hello")

--- a/crates/glass-a11y-linux/tests/fixtures/a11y_fixture.py
+++ b/crates/glass-a11y-linux/tests/fixtures/a11y_fixture.py
@@ -2,6 +2,7 @@
 """Minimal GTK4 app with a known accessibility tree, for glass-a11y-linux tests.
 Window "Glass A11y Fixture" containing a Label "Ready", a Button "Save", a
 Button "Bold" (AT-SPI description "Bold text", distinct from its name), a
+Button "Italic" (AT-SPI description "Italic", the SAME string as its name), a
 CheckButton "Enable", an Entry "Field" (initial text "hello"), a SpinButton
 "Amount" (initial value 1), a DropDown "Company" (Acme/Globex/Initech), a
 Switch "Active" (off), a virtualized GtkListView of 80 rows ("Row 000".."Row
@@ -37,6 +38,11 @@ class FixtureApp(Gtk.Application):
         # update_property(DESCRIPTION) populates AT-SPI Description (verified on the bus).
         bold.update_property([Gtk.AccessibleProperty.DESCRIPTION], ["Bold text"])
         box.append(bold)
+        italic = Gtk.Button(label="Italic")
+        # Description == name, the case normalize_description drops: toolkits routinely
+        # report one label in both fields, and the outline must not print it twice.
+        italic.update_property([Gtk.AccessibleProperty.DESCRIPTION], ["Italic"])
+        box.append(italic)
         box.append(Gtk.CheckButton(label="Enable"))
         entry = Gtk.Entry()
         entry.set_text("hello")

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -462,6 +462,27 @@ fn launch_fixture() -> Glass {
     glass
 }
 
+/// Both assertions in one launch: the AT-SPI bus is shared per process and the suite runs
+/// single-threaded, so a second fixture launch costs ~3s for nothing.
+#[test]
+#[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
+fn snapshot_reads_a_widget_description() {
+    let mut glass = launch_fixture();
+    let tree = glass.a11y_snapshot(None).expect("snapshot");
+
+    let bold = find_node(&tree.root, "Bold").expect("Bold button");
+    assert_eq!(bold.description.as_deref(), Some("Bold text"));
+    // The description must not have displaced the name.
+    assert_eq!(bold.name.as_deref(), Some("Bold"));
+
+    // A widget the fixture gives no description reports None, not an empty string — so a
+    // reader that returned "" for everything could not pass the test above by accident.
+    let save = find_node(&tree.root, "Save").expect("Save button");
+    assert_eq!(save.description, None);
+
+    glass.stop().expect("stop");
+}
+
 /// The GTK fixture's Switch "Active" exposes an AT-SPI activation action ("toggle") —
 /// click_element must take the native path and actually toggle it.
 ///

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -159,9 +159,8 @@ fn snapshot_covers_the_declared_linux_roles() {
         "{}",
         description_census_report("fixture", &tree, DescriptionSourcing::Sourced)
     );
-    // The suite passes no --nocapture, so the block above is invisible on a pass. The fixture
-    // has described widgets, so assert on the count too — a reader that regressed to `None`
-    // everywhere would still print a plausible-looking zero.
+    // The suite passes no --nocapture, so the block above is invisible on a pass and a reader
+    // regressed to `None` everywhere would print a plausible-looking zero unchallenged.
     assert!(
         description_census(&tree).described() >= 1,
         "the fixture's described widgets must reach the census"
@@ -466,9 +465,8 @@ fn launch_fixture() -> Glass {
 }
 
 /// Every description case in one launch: the AT-SPI bus is shared per process and the suite
-/// runs single-threaded, so a second fixture launch costs ~3s for nothing. `stop()` comes
-/// before the asserts — glass-core has no `Drop`, so a failing assert would otherwise leak
-/// the GTK4 fixture into the rest of the suite.
+/// runs single-threaded, so a second launch costs ~3s for nothing. `stop()` precedes the
+/// asserts because glass-core has no `Drop` — a failing assert would leak the GTK4 fixture.
 #[test]
 #[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
 fn snapshot_reads_a_widget_description() {
@@ -486,10 +484,8 @@ fn snapshot_reads_a_widget_description() {
     let save = find_node(&tree.root, "Save").expect("Save button");
     assert_eq!(save.description, None);
 
-    // The fixture gives Italic a description equal to its name — the case
-    // normalize_description exists for, and the one a reader that passed the wrong `name`
-    // (or skipped the helper) would get wrong, doubling the label on every line of a
-    // toolkit that reports both fields.
+    // Italic's description equals its name — the clause normalize_description exists for, and
+    // the one a reader passing the wrong `name` gets wrong, doubling the label on every line.
     let italic = find_node(&tree.root, "Italic").expect("Italic button");
     assert_eq!(italic.description, None);
 }

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -465,13 +465,16 @@ fn launch_fixture() -> Glass {
     glass
 }
 
-/// Both assertions in one launch: the AT-SPI bus is shared per process and the suite runs
-/// single-threaded, so a second fixture launch costs ~3s for nothing.
+/// Every description case in one launch: the AT-SPI bus is shared per process and the suite
+/// runs single-threaded, so a second fixture launch costs ~3s for nothing. `stop()` comes
+/// before the asserts — glass-core has no `Drop`, so a failing assert would otherwise leak
+/// the GTK4 fixture into the rest of the suite.
 #[test]
 #[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
 fn snapshot_reads_a_widget_description() {
     let mut glass = launch_fixture();
     let tree = glass.a11y_snapshot(None).expect("snapshot");
+    glass.stop().expect("stop");
 
     let bold = find_node(&tree.root, "Bold").expect("Bold button");
     assert_eq!(bold.description.as_deref(), Some("Bold text"));
@@ -483,7 +486,12 @@ fn snapshot_reads_a_widget_description() {
     let save = find_node(&tree.root, "Save").expect("Save button");
     assert_eq!(save.description, None);
 
-    glass.stop().expect("stop");
+    // The fixture gives Italic a description equal to its name — the case
+    // normalize_description exists for, and the one a reader that passed the wrong `name`
+    // (or skipped the helper) would get wrong, doubling the label on every line of a
+    // toolkit that reports both fields.
+    let italic = find_node(&tree.root, "Italic").expect("Italic button");
+    assert_eq!(italic.description, None);
 }
 
 /// The GTK fixture's Switch "Active" exposes an AT-SPI activation action ("toggle") —

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -140,7 +140,7 @@ fn snapshot_finds_gtk_widgets() {
 #[test]
 #[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
 fn snapshot_covers_the_declared_linux_roles() {
-    use glass_core::{AxRole, role_histogram};
+    use glass_core::{AxRole, description_census, role_histogram};
 
     let mut glass = glass_x11_with_a11y();
     glass.start(&fixture_spec()).expect("start fixture");
@@ -151,6 +151,19 @@ fn snapshot_covers_the_declared_linux_roles() {
     glass.stop().expect("stop");
 
     let seen: Vec<AxRole> = role_histogram(&tree).into_iter().map(|t| t.role).collect();
+
+    let census = description_census(&tree);
+    println!(
+        "fixture: {} of {} nodes described",
+        census.described, census.nodes
+    );
+    for sample in &census.samples {
+        println!(
+            "  {} name={:?} desc={:?}",
+            sample.raw_role, sample.name, sample.description
+        );
+    }
+
     // A GTK4 Entry reports AT-SPI `Text`, so the fixture's text input is a `TextArea`, not a
     // `TextField` — see the existing note on the set_value tests in this file.
     for expected in [

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -140,7 +140,9 @@ fn snapshot_finds_gtk_widgets() {
 #[test]
 #[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
 fn snapshot_covers_the_declared_linux_roles() {
-    use glass_core::{AxRole, description_census, role_histogram};
+    use glass_core::{
+        AxRole, DescriptionSourcing, description_census, description_census_report, role_histogram,
+    };
 
     let mut glass = glass_x11_with_a11y();
     glass.start(&fixture_spec()).expect("start fixture");
@@ -152,17 +154,18 @@ fn snapshot_covers_the_declared_linux_roles() {
 
     let seen: Vec<AxRole> = role_histogram(&tree).into_iter().map(|t| t.role).collect();
 
-    let census = description_census(&tree);
-    println!(
-        "fixture: {} of {} nodes described",
-        census.described, census.nodes
+    // `Sourced`: this reader reads AT-SPI's Description, so the count is about the fixture.
+    print!(
+        "{}",
+        description_census_report("fixture", &tree, DescriptionSourcing::Sourced)
     );
-    for sample in &census.samples {
-        println!(
-            "  {} name={:?} desc={:?}",
-            sample.raw_role, sample.name, sample.description
-        );
-    }
+    // The suite passes no --nocapture, so the block above is invisible on a pass. The fixture
+    // has described widgets, so assert on the count too — a reader that regressed to `None`
+    // everywhere would still print a plausible-looking zero.
+    assert!(
+        description_census(&tree).described() >= 1,
+        "the fixture's described widgets must reach the census"
+    );
 
     // A GTK4 Entry reports AT-SPI `Text`, so the fixture's text input is a `TextArea`, not a
     // `TextField` — see the existing note on the set_value tests in this file.

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -424,7 +424,9 @@ fn walk(
         role,
         raw_role,
         name,
-        // This reader does not read the platform's description yet.
+        // `AXDescription` is already read above as the name fallback, so reading it here
+        // would normalize away as a duplicate of `name`. `AXHelp` — the tooltip — is the
+        // secondary label this reader does not read yet.
         description: None,
         value,
         states,

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -424,6 +424,8 @@ fn walk(
         role,
         raw_role,
         name,
+        // This reader does not read the platform's description yet.
+        description: None,
         value,
         states,
         bounds,

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -424,9 +424,8 @@ fn walk(
         role,
         raw_role,
         name,
-        // `AXDescription` is already read above as the name fallback, so reading it here
-        // would normalize away as a duplicate of `name`. `AXHelp` — the tooltip — is the
-        // secondary label this reader does not read yet.
+        // `AXDescription` is already read above as the name fallback, so reading it here would
+        // normalize away as a duplicate; `AXHelp` (the tooltip) is the unread secondary label.
         description: None,
         value,
         states,

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -192,7 +192,8 @@ fn walk(
         role: crate::mapping::map_role(ct_id, facts.checkable),
         raw_role,
         name,
-        // This reader does not read the platform's description yet.
+        // This reader reads neither of UIA's secondary labels yet: `HelpText` (the tooltip)
+        // and `FullDescription`.
         description: None,
         value,
         states,

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -192,6 +192,8 @@ fn walk(
         role: crate::mapping::map_role(ct_id, facts.checkable),
         raw_role,
         name,
+        // This reader does not read the platform's description yet.
+        description: None,
         value,
         states,
         bounds,

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -377,6 +377,7 @@ mod tests {
             role,
             raw_role: String::new(),
             name: name.map(Into::into),
+            description: None,
             value: None,
             states: AxStates {
                 editable,

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -96,9 +96,9 @@ fn json_to_node(
         // name: the element's own text label, falling back to content-description.
         // value: editable text content only (content-description is not user-entered text).
         name: text.or(desc).map(str::to_string),
-        // The content-description is Android's secondary label and is already read above,
-        // as the `name` fallback. The node's hint and state-description are the ones left
-        // unread: the on-device service's node JSON carries neither.
+        // The content-description is Android's secondary label and is already read above as
+        // the `name` fallback; the unread ones are the node's hint and state-description,
+        // which the on-device service's node JSON does not carry.
         description: None,
         value: text.map(str::to_string),
         states: AxStates {

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -96,6 +96,8 @@ fn json_to_node(
         // name: the element's own text label, falling back to content-description.
         // value: editable text content only (content-description is not user-entered text).
         name: text.or(desc).map(str::to_string),
+        // This reader does not read the platform's description yet.
+        description: None,
         value: text.map(str::to_string),
         states: AxStates {
             enabled: flag("enabled"),

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -96,7 +96,9 @@ fn json_to_node(
         // name: the element's own text label, falling back to content-description.
         // value: editable text content only (content-description is not user-entered text).
         name: text.or(desc).map(str::to_string),
-        // This reader does not read the platform's description yet.
+        // The content-description is Android's secondary label and is already read above,
+        // as the `name` fallback. The node's hint and state-description are the ones left
+        // unread: the on-device service's node JSON carries neither.
         description: None,
         value: text.map(str::to_string),
         states: AxStates {

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -210,9 +210,9 @@ fn map_node(
         role,
         raw_role: class.to_string(),
         name,
-        // `content-desc` is Android's secondary label and is already read above, as the
-        // preferred `name`. The hint and state-description are unread: a `uiautomator`
-        // dump exposes neither as an attribute.
+        // `content-desc` is Android's secondary label and is already read above as the
+        // preferred `name`; the hint and state-description are unread, and a `uiautomator`
+        // dump exposes neither as an attribute anyway.
         description: None,
         value,
         states,

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -210,7 +210,9 @@ fn map_node(
         role,
         raw_role: class.to_string(),
         name,
-        // This reader does not read the platform's description yet.
+        // `content-desc` is Android's secondary label and is already read above, as the
+        // preferred `name`. The hint and state-description are unread: a `uiautomator`
+        // dump exposes neither as an attribute.
         description: None,
         value,
         states,

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -124,6 +124,7 @@ pub fn build_tree(xml: &str, window: &WindowGeometry, limits: WalkLimits) -> Res
         role: AxRole::Window,
         raw_role: "hierarchy".into(),
         name: None,
+        description: None,
         value: None,
         states: AxStates::default(),
         bounds: Some(AxRect {
@@ -209,6 +210,8 @@ fn map_node(
         role,
         raw_role: class.to_string(),
         name,
+        // This reader does not read the platform's description yet.
+        description: None,
         value,
         states,
         bounds: parse_bounds(attr("bounds"), window),

--- a/crates/glass-android/tests/role_probe.rs
+++ b/crates/glass-android/tests/role_probe.rs
@@ -38,7 +38,8 @@ use glass_android::{
 };
 use glass_core::accessibility::{Accessibility, AxContext, WalkLimits};
 use glass_core::{
-    AppSpec, AxRole, AxTree, Platform, SandboxLevel, description_census, role_histogram,
+    AppSpec, AxRole, AxTree, DescriptionSourcing, Platform, SandboxLevel,
+    description_census_report, role_histogram,
 };
 
 /// Comma-separated `package/activity` components to probe, e.g.
@@ -180,22 +181,6 @@ fn print_role_histogram(label: &str, tree: &AxTree) {
     }
 }
 
-/// Print `description_census(tree)`: how many nodes carry a description, and a sample of
-/// which ones — the evidence for whether this platform's secondary label is worth wiring up.
-fn print_description_census(label: &str, tree: &AxTree) {
-    let census = description_census(tree);
-    println!(
-        "{label}: {} of {} nodes described",
-        census.described, census.nodes
-    );
-    for sample in &census.samples {
-        println!(
-            "  {} name={:?} desc={:?}",
-            sample.raw_role, sample.name, sample.description
-        );
-    }
-}
-
 /// The components named by [`PROBE_APPS_VAR`], or `None` when the variable is unset or names
 /// nothing — the caller prints what to set and returns without probing.
 fn probe_targets() -> Option<Vec<String>> {
@@ -279,7 +264,12 @@ fn uiautomator_role_histogram_probe() {
             .unwrap_or_else(|e| panic!("snapshot({component}): {e}"));
         tree.assign_ids();
         print_role_histogram(component, &tree);
-        print_description_census(component, &tree);
+        // `Unsourced`: neither Android reader sources the field, so the count is 0 for
+        // every app — flip this when one reads the hint / state-description.
+        print!(
+            "{}",
+            description_census_report(component, &tree, DescriptionSourcing::Unsourced)
+        );
         violations.extend(thin_tree_violation(component, &tree));
         violations.extend(mapped_class_violations(component, &tree));
 
@@ -345,7 +335,10 @@ fn service_role_histogram_probe() {
         tree.assign_ids();
         let label = format!("{component} (service)");
         print_role_histogram(&label, &tree);
-        print_description_census(&label, &tree);
+        print!(
+            "{}",
+            description_census_report(&label, &tree, DescriptionSourcing::Unsourced)
+        );
         violations.extend(thin_tree_violation(&label, &tree));
         violations.extend(mapped_class_violations(&label, &tree));
 

--- a/crates/glass-android/tests/role_probe.rs
+++ b/crates/glass-android/tests/role_probe.rs
@@ -37,7 +37,9 @@ use glass_android::{
     A11yServiceRegistry, AgentRegistry, AndroidA11y, AndroidPlatform, EmulatorRegistry, ServiceA11y,
 };
 use glass_core::accessibility::{Accessibility, AxContext, WalkLimits};
-use glass_core::{AppSpec, AxRole, AxTree, Platform, SandboxLevel, role_histogram};
+use glass_core::{
+    AppSpec, AxRole, AxTree, Platform, SandboxLevel, description_census, role_histogram,
+};
 
 /// Comma-separated `package/activity` components to probe, e.g.
 /// `com.android.settings/.Settings`. Each element is exactly what `AppSpec::run`'s first
@@ -178,6 +180,22 @@ fn print_role_histogram(label: &str, tree: &AxTree) {
     }
 }
 
+/// Print `description_census(tree)`: how many nodes carry a description, and a sample of
+/// which ones — the evidence for whether this platform's secondary label is worth wiring up.
+fn print_description_census(label: &str, tree: &AxTree) {
+    let census = description_census(tree);
+    println!(
+        "{label}: {} of {} nodes described",
+        census.described, census.nodes
+    );
+    for sample in &census.samples {
+        println!(
+            "  {} name={:?} desc={:?}",
+            sample.raw_role, sample.name, sample.description
+        );
+    }
+}
+
 /// The components named by [`PROBE_APPS_VAR`], or `None` when the variable is unset or names
 /// nothing — the caller prints what to set and returns without probing.
 fn probe_targets() -> Option<Vec<String>> {
@@ -261,6 +279,7 @@ fn uiautomator_role_histogram_probe() {
             .unwrap_or_else(|e| panic!("snapshot({component}): {e}"));
         tree.assign_ids();
         print_role_histogram(component, &tree);
+        print_description_census(component, &tree);
         violations.extend(thin_tree_violation(component, &tree));
         violations.extend(mapped_class_violations(component, &tree));
 
@@ -326,6 +345,7 @@ fn service_role_histogram_probe() {
         tree.assign_ids();
         let label = format!("{component} (service)");
         print_role_histogram(&label, &tree);
+        print_description_census(&label, &tree);
         violations.extend(thin_tree_violation(&label, &tree));
         violations.extend(mapped_class_violations(&label, &tree));
 

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -815,6 +815,9 @@ pub struct ElementInfo {
     pub id: AxNodeId,
     pub role: AxRole,
     pub name: Option<String>,
+    /// Carried so an element the outline labels `desc="…"` still has a label here. Reported
+    /// only — the selector matched on `name`.
+    pub description: Option<String>,
     pub value: Option<String>,
     pub bounds: Option<AxRect>,
     pub states: AxStates,
@@ -827,6 +830,7 @@ impl ElementInfo {
             id: n.id,
             role: n.role,
             name: n.name.clone(),
+            description: n.description.clone(),
             value: n.value.clone(),
             bounds: n.bounds,
             states: n.states,

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -552,9 +552,9 @@ impl AxTree {
         walk(&self.root, id)
     }
 
-    /// Render a compact indented outline, one line per node:
-    /// `#<id> <Role> "<name>" (<x>,<y> <w>x<h>) [<states>]` — name/bounds/states
-    /// elided when absent. Two spaces of indent per depth level.
+    /// Render a compact indented outline, one line per node, in `outline::write_line`'s format —
+    /// the single definition of it, shared with [`crate::outline::render_compact`]. This render
+    /// differs only in keeping every node: nothing is collapsed.
     ///
     /// Pure tree text — no truncation notice is appended here. Keeping this render pure
     /// means `scroll_to_element`'s saturation check (which diffs consecutive `to_outline`

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -2246,8 +2246,11 @@ mod tests {
         assert_eq!(normalize_description("   ", None), None);
         // A description identical to the name would print the same label twice per line.
         assert_eq!(normalize_description("Save", Some("Save")), None);
-        // Equality is judged after trimming, so surrounding whitespace cannot smuggle a duplicate in.
+        // Both sides are trimmed before the comparison, so surrounding whitespace cannot
+        // smuggle a duplicate in from either. The name side is reachable: the readers'
+        // `nonempty` helper does not trim, so a name can arrive as `Some("Save ")`.
         assert_eq!(normalize_description("  Save  ", Some("Save")), None);
+        assert_eq!(normalize_description("Save", Some("  Save  ")), None);
     }
 
     #[test]

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -815,8 +815,8 @@ pub struct ElementInfo {
     pub id: AxNodeId,
     pub role: AxRole,
     pub name: Option<String>,
-    /// Carried so an element the outline labels `desc="…"` still has a label here. Reported
-    /// only — the selector matched on `name`.
+    /// Carried so an element the outline labels `desc="…"` still has a label here; reported
+    /// only, since the selector matched on `name`.
     pub description: Option<String>,
     pub value: Option<String>,
     pub bounds: Option<AxRect>,
@@ -2246,9 +2246,8 @@ mod tests {
         assert_eq!(normalize_description("   ", None), None);
         // A description identical to the name would print the same label twice per line.
         assert_eq!(normalize_description("Save", Some("Save")), None);
-        // Both sides are trimmed before the comparison, so surrounding whitespace cannot
-        // smuggle a duplicate in from either. The name side is reachable: the readers'
-        // `nonempty` helper does not trim, so a name can arrive as `Some("Save ")`.
+        // Both sides are trimmed, and the name side is reachable: the readers' `nonempty`
+        // helper does not trim, so a name can arrive as `Some("Save ")`.
         assert_eq!(normalize_description("  Save  ", Some("Save")), None);
         assert_eq!(normalize_description("Save", Some("  Save  ")), None);
     }

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -305,10 +305,26 @@ pub struct AxNode {
     /// The backend's native role string — the escape hatch for unmapped roles.
     pub raw_role: String,
     pub name: Option<String>,
+    /// A secondary human label the platform exposes separately from `name`: help/tooltip text
+    /// on desktop, or the human label where `name` is a developer-assigned id. Kept out of
+    /// `name` because `name` is half the [`AxTarget`] fingerprint `set_value` re-walks against
+    /// and has to stay stable.
+    pub description: Option<String>,
     pub value: Option<String>,
     pub states: AxStates,
     pub bounds: Option<AxRect>,
     pub children: Vec<AxNode>,
+}
+
+/// A node's description, or `None` when it would add nothing: empty, whitespace-only, or the
+/// same string as `name` (platforms routinely report both fields with one label in them).
+/// Every backend normalizes through this so the rule cannot drift per-platform.
+pub fn normalize_description(raw: &str, name: Option<&str>) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || Some(trimmed) == name.map(str::trim) {
+        return None;
+    }
+    Some(trimmed.to_string())
 }
 
 /// Bounds on how much of an app's accessibility tree a backend walks. Shared by every OS
@@ -1616,6 +1632,7 @@ mod tests {
             role,
             raw_role: format!("{role:?}").to_lowercase(),
             name: Some(name.into()),
+            description: None,
             value: None,
             states: AxStates::default(),
             bounds: None,
@@ -1656,6 +1673,7 @@ mod tests {
             role: AxRole::Window,
             raw_role: "frame".into(),
             name: Some("Settings".into()),
+            description: None,
             value: None,
             states: AxStates::default(),
             bounds: Some(AxRect {
@@ -1813,6 +1831,7 @@ mod tests {
             role: AxRole::Window,
             raw_role: "frame".into(),
             name: Some("App".into()),
+            description: None,
             value: None,
             states: AxStates::default(),
             bounds: None,
@@ -1851,6 +1870,7 @@ mod tests {
             role: AxRole::Group,
             raw_role: "panel".into(),
             name: None,
+            description: None,
             value: None,
             states: AxStates {
                 focusable: true,
@@ -1865,6 +1885,7 @@ mod tests {
             role: AxRole::Window,
             raw_role: "frame".into(),
             name: Some("App".into()),
+            description: None,
             value: None,
             states: AxStates::default(),
             bounds: None,
@@ -2212,5 +2233,34 @@ mod tests {
         };
         assert_eq!(p.label(), "pointer");
         assert_eq!(p.native_fallback(), Some("reason"));
+    }
+
+    #[test]
+    fn normalize_description_drops_what_adds_nothing() {
+        // Empty and whitespace-only are "the platform exposed no description".
+        assert_eq!(normalize_description("", None), None);
+        assert_eq!(normalize_description("   ", None), None);
+        // A description identical to the name would print the same label twice per line.
+        assert_eq!(normalize_description("Save", Some("Save")), None);
+        // Equality is judged after trimming, so surrounding whitespace cannot smuggle a duplicate in.
+        assert_eq!(normalize_description("  Save  ", Some("Save")), None);
+    }
+
+    #[test]
+    fn normalize_description_keeps_an_informative_value() {
+        assert_eq!(
+            normalize_description("  Saves and closes  ", Some("Save")),
+            Some("Saves and closes".to_string())
+        );
+        // With no name, any non-empty description is the only label the node has.
+        assert_eq!(
+            normalize_description("Bold", None),
+            Some("Bold".to_string())
+        );
+        // Case and inner spacing are the platform's; only exact duplicates are dropped.
+        assert_eq!(
+            normalize_description("save", Some("Save")),
+            Some("save".to_string())
+        );
     }
 }

--- a/crates/glass-core/src/description_census.rs
+++ b/crates/glass-core/src/description_census.rs
@@ -72,9 +72,9 @@ pub fn description_census(tree: &AxTree) -> DescriptionCensus {
 /// The census as a printable block: one summary line, then one line per sample. Returns a
 /// `String` rather than printing so a caller that saves a report can fold it in.
 ///
-/// `sourcing` decides whether a zero is a finding about the app or about glass, and says
-/// which on the summary line — a reader that leaves the field `None` counts zero on every
-/// app, and an unqualified "0 of 412 nodes described" reads as the opposite of that.
+/// `sourcing` says on the summary line which kind of zero this is: a reader that leaves the
+/// field `None` counts zero on every app, which unqualified reads as a finding about the
+/// platform.
 pub fn description_census_report(
     label: &str,
     tree: &AxTree,

--- a/crates/glass-core/src/description_census.rs
+++ b/crates/glass-core/src/description_census.rs
@@ -1,10 +1,15 @@
 //! Tally an accessibility tree by whether its nodes carry a description — the evidence
 //! behind whether a platform's secondary label is worth wiring up.
 //!
-//! [`AxNode::description`] exists on every backend, but nothing sources it until that
-//! backend's own PR lands; until then every tree reports zero. Counting how many of a real
-//! app's nodes actually carry one turns "does this app's UI have descriptions" into a number
-//! a probe run prints, rather than a guess from documentation.
+//! Counting how many of a real app's nodes carry one turns "does this app's UI have
+//! descriptions" into a number a probe run prints, rather than a guess from documentation.
+//!
+//! [`AxNode::description`] exists on every backend, but a reader that leaves it `None` makes
+//! the count zero by construction, for every app — a fact about glass, not about the platform.
+//! Only a caller knows which of the two it has, so [`description_census_report`] takes a
+//! [`DescriptionSourcing`] and prints it beside the number.
+
+use std::fmt::Write as _;
 
 use crate::accessibility::{AxNode, AxTree};
 
@@ -24,22 +29,34 @@ pub struct DescribedSample {
 pub struct DescriptionCensus {
     /// Total nodes walked.
     pub nodes: usize,
-    /// Nodes whose `description` is `Some`.
-    pub described: usize,
     /// One [`DescribedSample`] per described node.
     pub samples: Vec<DescribedSample>,
+}
+
+impl DescriptionCensus {
+    /// Nodes whose `description` is `Some`. Derived from [`Self::samples`], which holds one
+    /// entry per described node, so the two cannot disagree.
+    pub fn described(&self) -> usize {
+        self.samples.len()
+    }
+}
+
+/// Whether the reader that produced a tree sources [`AxNode::description`] at all.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DescriptionSourcing {
+    /// The reader reads its platform's secondary label, so the count describes the app.
+    Sourced,
+    /// The reader leaves `description: None`, so the count is 0 for every app.
+    Unsourced,
 }
 
 /// Walk every node once, counting the tree and sampling every description found.
 ///
 /// Samples sort by `description`, then `raw_role`, then `name` — a total order, so two runs
 /// of the same app diff cleanly, mirroring why [`crate::role_histogram`] sorts totally.
-/// `described == 0` is itself the finding a probe run is after: it means this platform's
-/// tree carries no descriptions yet, not that the walk found nothing.
 pub fn description_census(tree: &AxTree) -> DescriptionCensus {
     let mut census = DescriptionCensus {
         nodes: 0,
-        described: 0,
         samples: Vec::new(),
     };
     visit(&tree.root, &mut census);
@@ -52,10 +69,44 @@ pub fn description_census(tree: &AxTree) -> DescriptionCensus {
     census
 }
 
+/// The census as a printable block: one summary line, then one line per sample. Returns a
+/// `String` rather than printing so a caller that saves a report can fold it in.
+///
+/// `sourcing` decides whether a zero is a finding about the app or about glass, and says
+/// which on the summary line — a reader that leaves the field `None` counts zero on every
+/// app, and an unqualified "0 of 412 nodes described" reads as the opposite of that.
+pub fn description_census_report(
+    label: &str,
+    tree: &AxTree,
+    sourcing: DescriptionSourcing,
+) -> String {
+    let census = description_census(tree);
+    let caveat = match sourcing {
+        DescriptionSourcing::Sourced => "",
+        DescriptionSourcing::Unsourced => {
+            " (this backend's reader leaves description: None, so the count is 0 whatever the app exposes)"
+        }
+    };
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "{label}: {} of {} nodes described{caveat}",
+        census.described(),
+        census.nodes
+    );
+    for sample in &census.samples {
+        let _ = writeln!(
+            out,
+            "  {} name={:?} desc={:?}",
+            sample.raw_role, sample.name, sample.description
+        );
+    }
+    out
+}
+
 fn visit(node: &AxNode, census: &mut DescriptionCensus) {
     census.nodes += 1;
     if let Some(description) = &node.description {
-        census.described += 1;
         census.samples.push(DescribedSample {
             raw_role: node.raw_role.clone(),
             name: node.name.clone(),
@@ -102,15 +153,20 @@ mod tests {
 
     #[test]
     fn census_counts_described_nodes_and_samples_them() {
+        // The described toggle sits UNDER an undescribed wrapper, not beside it: in a real
+        // app the described widgets are levels down, so a walk that never recursed would
+        // report zero there while passing a flat fixture.
+        let mut wrapper = described("filler", None, None);
+        wrapper.children = vec![described("toggle button", None, Some("Bold"))];
         let tree = tree_of(vec![
             described("push button", Some("Save"), Some("Saves and closes")),
             described("push button", Some("Open"), None),
-            described("toggle button", None, Some("Bold")),
+            wrapper,
         ]);
         let census = description_census(&tree);
         // The root the helper wraps these in counts too, and carries no description.
-        assert_eq!(census.nodes, 4);
-        assert_eq!(census.described, 2);
+        assert_eq!(census.nodes, 5);
+        assert_eq!(census.described(), 2);
         assert_eq!(
             census
                 .samples
@@ -151,10 +207,31 @@ mod tests {
     fn census_of_a_tree_with_no_descriptions_is_empty_not_absent() {
         let census =
             description_census(&tree_of(vec![described("push button", Some("Save"), None)]));
-        assert_eq!(census.described, 0);
+        assert_eq!(census.described(), 0);
         assert!(census.samples.is_empty());
         // A run that read a real tree and found nothing is a finding; it must be
         // distinguishable from a run that read nothing at all.
         assert_eq!(census.nodes, 2);
+    }
+
+    #[test]
+    fn a_report_over_an_unsourced_reader_says_the_zero_is_not_an_observation() {
+        let tree = tree_of(vec![described("push button", Some("Save"), None)]);
+        let report = description_census_report("app", &tree, DescriptionSourcing::Unsourced);
+        assert!(
+            report.starts_with("app: 0 of 2 nodes described ("),
+            "the qualifier must sit on the number's own line: {report}"
+        );
+        assert!(report.contains("description: None"), "{report}");
+    }
+
+    #[test]
+    fn a_report_over_a_sourcing_reader_is_the_bare_count_and_its_samples() {
+        let tree = tree_of(vec![described("push button", Some("Save"), Some("Saves"))]);
+        let report = description_census_report("app", &tree, DescriptionSourcing::Sourced);
+        assert_eq!(
+            report,
+            "app: 1 of 2 nodes described\n  push button name=Some(\"Save\") desc=\"Saves\"\n"
+        );
     }
 }

--- a/crates/glass-core/src/description_census.rs
+++ b/crates/glass-core/src/description_census.rs
@@ -1,0 +1,132 @@
+//! Tally an accessibility tree by whether its nodes carry a description — the evidence
+//! behind whether a platform's secondary label is worth wiring up.
+//!
+//! [`AxNode::description`] exists on every backend, but nothing sources it until that
+//! backend's own PR lands; until then every tree reports zero. Counting how many of a real
+//! app's nodes actually carry one turns "does this app's UI have descriptions" into a number
+//! a probe run prints, rather than a guess from documentation.
+
+use crate::accessibility::{AxNode, AxTree};
+
+/// One described node a probe run wants to see, not just count.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DescribedSample {
+    /// The backend's native role string, as carried in [`AxNode::raw_role`].
+    pub raw_role: String,
+    pub name: Option<String>,
+    pub description: String,
+}
+
+/// How many of a tree's nodes carry a description, and a sample of which ones.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DescriptionCensus {
+    /// Total nodes walked.
+    pub nodes: usize,
+    /// Nodes whose `description` is `Some`.
+    pub described: usize,
+    /// One [`DescribedSample`] per described node.
+    pub samples: Vec<DescribedSample>,
+}
+
+/// Walk every node once, counting the tree and sampling every description found.
+///
+/// Samples sort by `description`, then `raw_role`, then `name` — a total order, so two runs
+/// of the same app diff cleanly, mirroring why [`crate::role_histogram`] sorts totally.
+/// `described == 0` is itself the finding a probe run is after: it means this platform's
+/// tree carries no descriptions yet, not that the walk found nothing.
+pub fn description_census(tree: &AxTree) -> DescriptionCensus {
+    let mut census = DescriptionCensus {
+        nodes: 0,
+        described: 0,
+        samples: Vec::new(),
+    };
+    visit(&tree.root, &mut census);
+    census.samples.sort_by(|a, b| {
+        a.description
+            .cmp(&b.description)
+            .then(a.raw_role.cmp(&b.raw_role))
+            .then(a.name.cmp(&b.name))
+    });
+    census
+}
+
+fn visit(node: &AxNode, census: &mut DescriptionCensus) {
+    census.nodes += 1;
+    if let Some(description) = &node.description {
+        census.described += 1;
+        census.samples.push(DescribedSample {
+            raw_role: node.raw_role.clone(),
+            name: node.name.clone(),
+            description: description.clone(),
+        });
+    }
+    for child in &node.children {
+        visit(child, census);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::accessibility::{AxNodeId, AxRole, AxStates};
+
+    fn described(raw_role: &str, name: Option<&str>, description: Option<&str>) -> AxNode {
+        AxNode {
+            id: AxNodeId(0),
+            role: AxRole::Other,
+            raw_role: raw_role.to_string(),
+            name: name.map(str::to_string),
+            description: description.map(str::to_string),
+            value: None,
+            states: AxStates::default(),
+            bounds: None,
+            children: Vec::new(),
+        }
+    }
+
+    fn tree_of(children: Vec<AxNode>) -> AxTree {
+        AxTree::new(AxNode {
+            id: AxNodeId(0),
+            role: AxRole::Window,
+            raw_role: "root".to_string(),
+            name: None,
+            description: None,
+            value: None,
+            states: AxStates::default(),
+            bounds: None,
+            children,
+        })
+    }
+
+    #[test]
+    fn census_counts_described_nodes_and_samples_them() {
+        let tree = tree_of(vec![
+            described("push button", Some("Save"), Some("Saves and closes")),
+            described("push button", Some("Open"), None),
+            described("toggle button", None, Some("Bold")),
+        ]);
+        let census = description_census(&tree);
+        // The root the helper wraps these in counts too, and carries no description.
+        assert_eq!(census.nodes, 4);
+        assert_eq!(census.described, 2);
+        assert_eq!(
+            census
+                .samples
+                .iter()
+                .map(|s| s.description.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Bold", "Saves and closes"]
+        );
+    }
+
+    #[test]
+    fn census_of_a_tree_with_no_descriptions_is_empty_not_absent() {
+        let census =
+            description_census(&tree_of(vec![described("push button", Some("Save"), None)]));
+        assert_eq!(census.described, 0);
+        assert!(census.samples.is_empty());
+        // A run that read a real tree and found nothing is a finding; it must be
+        // distinguishable from a run that read nothing at all.
+        assert_eq!(census.nodes, 2);
+    }
+}

--- a/crates/glass-core/src/description_census.rs
+++ b/crates/glass-core/src/description_census.rs
@@ -13,7 +13,9 @@ use crate::accessibility::{AxNode, AxTree};
 pub struct DescribedSample {
     /// The backend's native role string, as carried in [`AxNode::raw_role`].
     pub raw_role: String,
+    /// The node's name, alongside the description.
     pub name: Option<String>,
+    /// The node's description — the reason this sample exists.
     pub description: String,
 }
 
@@ -116,6 +118,32 @@ mod tests {
                 .map(|s| s.description.as_str())
                 .collect::<Vec<_>>(),
             vec!["Bold", "Saves and closes"]
+        );
+    }
+
+    #[test]
+    fn census_orders_ties_by_raw_role_then_name() {
+        // Same description on every node (plausible: several "OK" controls on one screen), so
+        // this pins both tie-break clauses: `raw_role` separates "checkbox" from "push button",
+        // then `name` separates the two "push button" samples from each other.
+        let tree = tree_of(vec![
+            described("push button", Some("Zeta"), Some("OK")),
+            described("checkbox", Some("Enable"), Some("OK")),
+            described("push button", Some("Alpha"), Some("OK")),
+        ]);
+        let census = description_census(&tree);
+        let order: Vec<(&str, Option<&str>)> = census
+            .samples
+            .iter()
+            .map(|s| (s.raw_role.as_str(), s.name.as_deref()))
+            .collect();
+        assert_eq!(
+            order,
+            vec![
+                ("checkbox", Some("Enable")),
+                ("push button", Some("Alpha")),
+                ("push button", Some("Zeta")),
+            ]
         );
     }
 

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -72,7 +72,7 @@ pub mod accessibility;
 pub use accessibility::{
     Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree,
     ClickMethod, ElementCondition, ElementInfo, ElementMatch, MAX_DEPTH, MAX_NODES, MAX_SIBLINGS,
-    Truncation, TruncationLimit, WalkBudget, WalkLimits, element_match,
+    Truncation, TruncationLimit, WalkBudget, WalkLimits, element_match, normalize_description,
 };
 
 pub mod marks;

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -86,7 +86,10 @@ pub mod role_histogram;
 pub use role_histogram::{RoleTally, role_histogram};
 
 pub mod description_census;
-pub use description_census::{DescribedSample, DescriptionCensus, description_census};
+pub use description_census::{
+    DescribedSample, DescriptionCensus, DescriptionSourcing, description_census,
+    description_census_report,
+};
 
 pub mod audit;
 pub use audit::{Actuation, ActuationContext, AuditOutcome, AuditSink, ElementRef, WindowRef};

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -85,6 +85,9 @@ pub mod role_support;
 pub mod role_histogram;
 pub use role_histogram::{RoleTally, role_histogram};
 
+pub mod description_census;
+pub use description_census::{DescribedSample, DescriptionCensus, description_census};
+
 pub mod audit;
 pub use audit::{Actuation, ActuationContext, AuditOutcome, AuditSink, ElementRef, WindowRef};
 

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -76,7 +76,7 @@ pub use accessibility::{
 };
 
 pub mod marks;
-pub use marks::Mark;
+pub use marks::{Mark, MarkLabel};
 
 pub mod outline;
 

--- a/crates/glass-core/src/marks.rs
+++ b/crates/glass-core/src/marks.rs
@@ -14,7 +14,18 @@ use crate::frame::Frame;
 pub struct Mark {
     pub id: AxNodeId,
     pub role: AxRole,
-    pub name: Option<String>,
+    /// The node's name, or its description when the node has no name — an icon-only
+    /// control's only label. `None` when it has neither.
+    pub label: Option<MarkLabel>,
+}
+
+/// A mark's label and which field it came from. Selectors match on `name` only, so a legend
+/// that printed a description in the same quoted slot as a name would invite a `name:` query
+/// that can never match; the renderer keeps them apart.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MarkLabel {
+    Name(String),
+    Description(String),
 }
 
 const SCALE: i32 = 2; // integer upscale of the 3x5 font cells
@@ -61,7 +72,11 @@ fn collect(node: &AxNode, frame: &mut Frame, legend: &mut Vec<Mark>) {
             role: node.role,
             // An icon-only control is exactly the mark that has no name; its description is
             // the only label the legend can show.
-            name: node.name.clone().or_else(|| node.description.clone()),
+            label: match (&node.name, &node.description) {
+                (Some(name), _) => Some(MarkLabel::Name(name.clone())),
+                (None, Some(description)) => Some(MarkLabel::Description(description.clone())),
+                (None, None) => None,
+            },
         });
     }
     for child in &node.children {
@@ -269,7 +284,9 @@ mod tests {
         b.name = None;
         b.description = Some("Bold".into());
         let (_, legend) = render(&Frame::solid(100, 100, [0, 0, 0, 255]), &tree_of(b));
-        assert_eq!(legend[0].name.as_deref(), Some("Bold"));
+        // Description, not Name: the legend renders the two differently because only a name
+        // is matchable by a selector.
+        assert_eq!(legend[0].label, Some(MarkLabel::Description("Bold".into())));
     }
 
     #[test]
@@ -287,7 +304,25 @@ mod tests {
         );
         b.description = Some("Saves and closes".into());
         let (_, legend) = render(&Frame::solid(100, 100, [0, 0, 0, 255]), &tree_of(b));
-        assert_eq!(legend[0].name.as_deref(), Some("Save"));
+        assert_eq!(legend[0].label, Some(MarkLabel::Name("Save".into())));
+    }
+
+    #[test]
+    fn a_mark_with_neither_name_nor_description_has_no_label() {
+        let mut b = node(
+            0,
+            AxRole::Button,
+            "",
+            Some(AxRect {
+                x: 10,
+                y: 10,
+                width: 20,
+                height: 16,
+            }),
+        );
+        b.name = None;
+        let (_, legend) = render(&Frame::solid(100, 100, [0, 0, 0, 255]), &tree_of(b));
+        assert_eq!(legend[0].label, None);
     }
 
     #[test]
@@ -306,7 +341,7 @@ mod tests {
         assert_eq!(legend.len(), 1);
         assert_eq!(legend[0].id, AxNodeId(1));
         assert_eq!(legend[0].role, AxRole::Button);
-        assert_eq!(legend[0].name.as_deref(), Some("Save"));
+        assert_eq!(legend[0].label, Some(MarkLabel::Name("Save".into())));
         assert_eq!(px(&out, 10, 10), OUTLINE);
         assert_eq!(px(&out, 10, 40), [0, 0, 0, 255]);
     }

--- a/crates/glass-core/src/marks.rs
+++ b/crates/glass-core/src/marks.rs
@@ -59,7 +59,9 @@ fn collect(node: &AxNode, frame: &mut Frame, legend: &mut Vec<Mark>) {
         legend.push(Mark {
             id: node.id,
             role: node.role,
-            name: node.name.clone(),
+            // An icon-only control is exactly the mark that has no name; its description is
+            // the only label the legend can show.
+            name: node.name.clone().or_else(|| node.description.clone()),
         });
     }
     for child in &node.children {
@@ -228,6 +230,64 @@ mod tests {
         let mut t = AxTree::new(root);
         t.assign_ids();
         t
+    }
+
+    /// A Window containing exactly `child`, ids assigned.
+    fn tree_of(child: AxNode) -> AxTree {
+        let root = AxNode {
+            children: vec![child],
+            ..node(
+                0,
+                AxRole::Window,
+                "Win",
+                Some(AxRect {
+                    x: 0,
+                    y: 0,
+                    width: 100,
+                    height: 100,
+                }),
+            )
+        };
+        let mut t = AxTree::new(root);
+        t.assign_ids();
+        t
+    }
+
+    #[test]
+    fn an_unnamed_mark_takes_its_label_from_the_description() {
+        let mut b = node(
+            0,
+            AxRole::Button,
+            "",
+            Some(AxRect {
+                x: 10,
+                y: 10,
+                width: 20,
+                height: 16,
+            }),
+        );
+        b.name = None;
+        b.description = Some("Bold".into());
+        let (_, legend) = render(&Frame::solid(100, 100, [0, 0, 0, 255]), &tree_of(b));
+        assert_eq!(legend[0].name.as_deref(), Some("Bold"));
+    }
+
+    #[test]
+    fn a_named_mark_keeps_its_name() {
+        let mut b = node(
+            0,
+            AxRole::Button,
+            "Save",
+            Some(AxRect {
+                x: 10,
+                y: 10,
+                width: 20,
+                height: 16,
+            }),
+        );
+        b.description = Some("Saves and closes".into());
+        let (_, legend) = render(&Frame::solid(100, 100, [0, 0, 0, 255]), &tree_of(b));
+        assert_eq!(legend[0].name.as_deref(), Some("Save"));
     }
 
     #[test]

--- a/crates/glass-core/src/marks.rs
+++ b/crates/glass-core/src/marks.rs
@@ -177,6 +177,7 @@ mod tests {
             role,
             raw_role: String::new(),
             name: Some(name.into()),
+            description: None,
             value: None,
             states: Default::default(),
             bounds,
@@ -213,6 +214,7 @@ mod tests {
             role: AxRole::Window,
             raw_role: "frame".into(),
             name: Some("Win".into()),
+            description: None,
             value: None,
             states: Default::default(),
             bounds: Some(AxRect {

--- a/crates/glass-core/src/outline.rs
+++ b/crates/glass-core/src/outline.rs
@@ -359,6 +359,22 @@ mod tests {
     }
 
     #[test]
+    fn a_description_is_escaped_and_stays_on_one_line() {
+        // App-controlled text: a raw newline would split one node across two lines and break
+        // the one-node-per-line contract the outline diff and the id lookups rely on.
+        let out = render_compact(&tree_of(described(
+            AxRole::Button,
+            None,
+            "say \"hi\"\nthen go",
+        )));
+        assert!(
+            out.contains(r#"desc="say \"hi\"\nthen go""#),
+            "quote and newline must be escaped: {out}"
+        );
+        assert_eq!(out.lines().count(), 2, "Window + Button only: {out}");
+    }
+
+    #[test]
     fn a_node_without_a_description_renders_exactly_as_before() {
         let out = render_compact(&tree_of(node(AxRole::Button, Some("Save"))));
         assert!(!out.contains("desc="), "unexpected line: {out}");

--- a/crates/glass-core/src/outline.rs
+++ b/crates/glass-core/src/outline.rs
@@ -28,10 +28,13 @@ use crate::accessibility::{AxNode, AxRole, AxTree};
 /// - a **focusable** container is actable: Jetpack Compose surfaces a real button as a
 ///   clickable `Group` with the role lost (see `accessibility::element_match`), so eliding
 ///   it would hide a button that is still clickable — invisible but addressable;
+/// - a **described** container is labelled: a description is the only label a node with no
+///   name has, so eliding it drops the one thing that says what the container is;
 /// - a multi-child container conveys grouping; a single-child one does not.
 fn is_scaffolding(node: &AxNode) -> bool {
     matches!(node.role, AxRole::Group | AxRole::Other)
         && node.name.is_none()
+        && node.description.is_none()
         && node.value.is_none()
         && !node.states.focusable
         && node.children.len() == 1
@@ -201,6 +204,18 @@ mod tests {
         assert!(
             render_compact(&tree_of(g)).contains("Group"),
             "a focusable Group is actable and must never be elided"
+        );
+    }
+
+    #[test]
+    fn a_described_group_is_kept() {
+        // A toolkit can put a description on any container (GTK4 accepts DESCRIPTION on a
+        // plain Gtk.Box), and there it is the container's only label.
+        let mut g = described(AxRole::Group, None, "Formatting");
+        g.children = vec![node(AxRole::Button, Some("Save"))];
+        assert!(
+            render_compact(&tree_of(g)).contains(r#"Group desc="Formatting""#),
+            "a description is the only label an unnamed container has"
         );
     }
 

--- a/crates/glass-core/src/outline.rs
+++ b/crates/glass-core/src/outline.rs
@@ -37,8 +37,9 @@ fn is_scaffolding(node: &AxNode) -> bool {
         && node.children.len() == 1
 }
 
-/// Write one node's line: `#<id> <Role> "<name>" (<x>,<y> <w>x<h>) [<states>]`, name/bounds/
-/// states elided when absent, two spaces of indent per depth level.
+/// Write one node's line: `#<id> <Role> "<name>" desc="<description>" (<x>,<y> <w>x<h>)
+/// [<states>]`, name/description/bounds/states elided when absent, two spaces of indent per
+/// depth level.
 ///
 /// A node glass has no role mapping for renders as `Other(<native token>)` — the AT-SPI role,
 /// UIA control-type name, AX role string, Android widget class or iOS role string the backend
@@ -57,6 +58,9 @@ pub(crate) fn write_line(node: &AxNode, depth: usize, out: &mut String) {
     }
     if let Some(name) = &node.name {
         let _ = write!(out, " {name:?}");
+    }
+    if let Some(description) = &node.description {
+        let _ = write!(out, " desc={description:?}");
     }
     if let Some(b) = &node.bounds {
         let _ = write!(out, " ({},{} {}x{})", b.x, b.y, b.width, b.height);
@@ -120,6 +124,14 @@ mod tests {
             states: AxStates::default(),
             bounds: None,
             children: vec![],
+        }
+    }
+
+    /// `node`, plus a description.
+    fn described(role: AxRole, name: Option<&str>, description: &str) -> AxNode {
+        AxNode {
+            description: Some(description.into()),
+            ..node(role, name)
         }
     }
 
@@ -304,6 +316,45 @@ mod tests {
         n.raw_role = "AXDisclosureTriangle".into();
         let t = tree_of(n);
         assert_eq!(render_compact(&t), t.to_outline());
+    }
+
+    #[test]
+    fn a_description_renders_between_the_name_and_the_bounds() {
+        let mut n = described(AxRole::Button, Some("Save"), "Saves and closes the sheet");
+        n.bounds = Some(AxRect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 24,
+        });
+        let out = render_compact(&tree_of(n));
+        assert!(
+            out.contains(r#"Button "Save" desc="Saves and closes the sheet" (0,0 80x24)"#),
+            "unexpected line: {out}"
+        );
+    }
+
+    #[test]
+    fn an_unnamed_element_still_renders_its_description() {
+        let out = render_compact(&tree_of(described(AxRole::Button, None, "Bold")));
+        assert!(
+            out.contains(r#"Button desc="Bold""#),
+            "unexpected line: {out}"
+        );
+    }
+
+    #[test]
+    fn a_node_without_a_description_renders_exactly_as_before() {
+        let out = render_compact(&tree_of(node(AxRole::Button, Some("Save"))));
+        assert!(!out.contains("desc="), "unexpected line: {out}");
+    }
+
+    #[test]
+    fn to_outline_renders_the_description_too() {
+        // Both renders share write_line; this pins that they cannot drift on this field.
+        let t = tree_of(described(AxRole::Button, Some("Save"), "Saves and closes"));
+        assert_eq!(t.to_outline(), render_compact(&t));
+        assert!(t.to_outline().contains(r#"desc="Saves and closes""#));
     }
 
     #[test]

--- a/crates/glass-core/src/outline.rs
+++ b/crates/glass-core/src/outline.rs
@@ -115,6 +115,7 @@ mod tests {
             role,
             raw_role: String::new(),
             name: name.map(Into::into),
+            description: None,
             value: None,
             states: AxStates::default(),
             bounds: None,

--- a/crates/glass-core/src/role_histogram.rs
+++ b/crates/glass-core/src/role_histogram.rs
@@ -68,6 +68,7 @@ mod tests {
             role,
             raw_role: raw.to_string(),
             name: None,
+            description: None,
             value: None,
             states: AxStates::default(),
             bounds: None,

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -1470,6 +1470,7 @@ mod tests {
             role: AxRole::Window,
             raw_role: "window".into(),
             name: None,
+            description: None,
             value: None,
             states: AxStates::default(),
             bounds: Some(AxRect {
@@ -1483,6 +1484,7 @@ mod tests {
                 role: AxRole::Button,
                 raw_role: "button".into(),
                 name: Some("5".into()),
+                description: None,
                 value: None,
                 states: AxStates::default(),
                 bounds: Some(bounds),
@@ -1594,6 +1596,7 @@ mod tests {
             role: AxRole::Label,
             raw_role: "label".into(),
             name: Some("nobounds".into()),
+            description: None,
             value: None,
             states: AxStates::default(),
             bounds: None,
@@ -1718,6 +1721,7 @@ mod tests {
             role: AxRole::Button,
             raw_role: "button".into(),
             name: Some("hidden".into()),
+            description: None,
             value: None,
             states: AxStates::default(),
             bounds: None,
@@ -1741,6 +1745,7 @@ mod tests {
             role: AxRole::Button,
             raw_role: "button".into(),
             name: Some("hidden".into()),
+            description: None,
             value: None,
             states: AxStates::default(),
             bounds: None,
@@ -1820,6 +1825,7 @@ mod tests {
             role,
             raw_role: name.into(),
             name: Some(name.into()),
+            description: None,
             value: None,
             states: AxStates {
                 checkable,
@@ -1833,6 +1839,7 @@ mod tests {
             role: AxRole::Window,
             raw_role: "window".into(),
             name: None,
+            description: None,
             value: None,
             states: AxStates::default(),
             bounds: Some(AxRect {
@@ -1922,6 +1929,7 @@ mod tests {
             role: AxRole::Window,
             raw_role: "window".into(),
             name: None,
+            description: None,
             value: None,
             states: AxStates::default(),
             bounds: Some(AxRect {
@@ -1935,6 +1943,7 @@ mod tests {
                 role: AxRole::CheckBox,
                 raw_role: "checkbox".into(),
                 name: Some("labeled".into()),
+                description: None,
                 value: None,
                 states: AxStates {
                     checkable: true,
@@ -1973,6 +1982,7 @@ mod tests {
             role: AxRole::Window,
             raw_role: "window".into(),
             name: None,
+            description: None,
             value: None,
             states: AxStates::default(),
             bounds: Some(AxRect {
@@ -1986,6 +1996,7 @@ mod tests {
                 role: AxRole::CheckBox,
                 raw_role: "checkbox".into(),
                 name: Some("tight".into()),
+                description: None,
                 value: None,
                 states: AxStates {
                     checkable: true,
@@ -2244,6 +2255,7 @@ mod tests {
             role: AxRole::ListItem,
             raw_role: "list item".into(),
             name: Some("Globex".into()),
+            description: None,
             value: None,
             states: AxStates::default(),
             bounds: Some(AxRect {
@@ -2259,6 +2271,7 @@ mod tests {
             role: AxRole::Window,
             raw_role: "frame".into(),
             name: Some("Win".into()),
+            description: None,
             value: None,
             states: AxStates::default(),
             bounds: Some(AxRect {
@@ -2723,6 +2736,7 @@ mod tests {
             role: AxRole::CheckBox,
             raw_role: "switch".into(),
             name: Some("Sw".into()),
+            description: None,
             value: None,
             states: AxStates {
                 checkable: true,
@@ -2742,6 +2756,7 @@ mod tests {
             role: AxRole::Window,
             raw_role: "frame".into(),
             name: Some("Win".into()),
+            description: None,
             value: None,
             states: AxStates::default(),
             bounds: Some(AxRect {
@@ -2885,6 +2900,7 @@ mod tests {
             role: AxRole::CheckBox,
             raw_role: "switch".into(),
             name: Some("Sw".into()),
+            description: None,
             value: None,
             states: AxStates {
                 checkable: true,
@@ -2906,6 +2922,7 @@ mod tests {
             role: AxRole::Window,
             raw_role: "frame".into(),
             name: Some("Win".into()),
+            description: None,
             value: None,
             states: AxStates::default(),
             bounds: Some(AxRect {

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -373,6 +373,7 @@ pub(crate) fn fake_tree() -> AxTree {
         role: AxRole::Button,
         raw_role: "push button".into(),
         name: Some("Save".into()),
+        description: None,
         value: None,
         states: AxStates::default(),
         bounds: Some(AxRect {
@@ -388,6 +389,7 @@ pub(crate) fn fake_tree() -> AxTree {
         role: AxRole::Window,
         raw_role: "frame".into(),
         name: Some("Win".into()),
+        description: None,
         value: None,
         states: AxStates::default(),
         bounds: Some(AxRect {
@@ -432,6 +434,7 @@ pub(crate) fn ax_node(
         role,
         raw_role: format!("{role:?}"),
         name: None,
+        description: None,
         value: None,
         states: AxStates::default(),
         bounds,
@@ -593,6 +596,7 @@ pub(crate) fn tree_with(win_w: u32, win_h: u32, children: Vec<AxNode>) -> AxTree
         role: AxRole::Window,
         raw_role: "frame".into(),
         name: Some("Win".into()),
+        description: None,
         value: None,
         states: AxStates::default(),
         bounds: Some(AxRect {
@@ -648,6 +652,7 @@ pub(crate) fn fake_tree_with_popover_option() -> AxTree {
         role: AxRole::ListItem,
         raw_role: "list item".into(),
         name: Some("Globex".into()),
+        description: None,
         value: None,
         states: AxStates::default(),
         bounds: Some(AxRect {
@@ -663,6 +668,7 @@ pub(crate) fn fake_tree_with_popover_option() -> AxTree {
         role: AxRole::List,
         raw_role: "list".into(),
         name: None,
+        description: None,
         value: None,
         states: AxStates::default(),
         bounds: Some(AxRect {
@@ -678,6 +684,7 @@ pub(crate) fn fake_tree_with_popover_option() -> AxTree {
         role: AxRole::Window,
         raw_role: "frame".into(),
         name: Some("Win".into()),
+        description: None,
         value: None,
         states: AxStates::default(),
         bounds: Some(AxRect {

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -119,6 +119,7 @@ mod tests {
             role,
             raw_role: String::new(),
             name: Some(name.into()),
+            description: None,
             value: None,
             states: AxStates {
                 editable: true,
@@ -135,6 +136,7 @@ mod tests {
             role: AxRole::Window,
             raw_role: "AXWindow".into(),
             name: None,
+            description: None,
             value: None,
             states: AxStates::default(),
             bounds: Some(AxRect {

--- a/crates/glass-ios/src/axmap.rs
+++ b/crates/glass-ios/src/axmap.rs
@@ -233,7 +233,9 @@ fn map_node(n: &Value, scale: f64, depth: usize, budget: &mut WalkBudget) -> AxN
         role,
         raw_role: ax_type,
         name,
-        // This reader does not read the platform's description yet.
+        // `AXLabel` — the human label behind the stable `AXUniqueId` this reader prefers for
+        // `name`, exactly the split `AxNode::description` exists for — is already read above,
+        // into `name` or `value`. `accessibilityHint` is the unread one.
         description: None,
         value,
         states,

--- a/crates/glass-ios/src/axmap.rs
+++ b/crates/glass-ios/src/axmap.rs
@@ -122,6 +122,7 @@ pub fn build_tree(
         role: AxRole::Window,
         raw_role: "AXWindow".into(),
         name: None,
+        description: None,
         value: None,
         states: AxStates::default(),
         bounds: Some(AxRect {
@@ -232,6 +233,8 @@ fn map_node(n: &Value, scale: f64, depth: usize, budget: &mut WalkBudget) -> AxN
         role,
         raw_role: ax_type,
         name,
+        // This reader does not read the platform's description yet.
+        description: None,
         value,
         states,
         bounds,

--- a/crates/glass-ios/src/axmap.rs
+++ b/crates/glass-ios/src/axmap.rs
@@ -234,8 +234,8 @@ fn map_node(n: &Value, scale: f64, depth: usize, budget: &mut WalkBudget) -> AxN
         raw_role: ax_type,
         name,
         // `AXLabel` — the human label behind the stable `AXUniqueId` this reader prefers for
-        // `name`, exactly the split `AxNode::description` exists for — is already read above,
-        // into `name` or `value`. `accessibilityHint` is the unread one.
+        // `name`, exactly the split `AxNode::description` exists for — is already read above
+        // into `name` or `value`; `accessibilityHint` is the unread one.
         description: None,
         value,
         states,

--- a/crates/glass-ios/tests/role_probe.rs
+++ b/crates/glass-ios/tests/role_probe.rs
@@ -29,7 +29,9 @@ use std::time::Duration;
 
 use glass_core::Accessibility; // the trait must be in scope to call `snapshot` on the boxed reader
 use glass_core::accessibility::{AxContext, WalkLimits};
-use glass_core::{AppSpec, AxRole, AxTree, Platform, SandboxLevel, role_histogram};
+use glass_core::{
+    AppSpec, AxRole, AxTree, Platform, SandboxLevel, description_census, role_histogram,
+};
 use glass_ios::{IosPlatform, SimulatorRegistry};
 
 /// Comma-separated bundle ids or `.app` paths to probe, e.g. `com.apple.Preferences`. Unset
@@ -168,6 +170,22 @@ fn print_role_histogram(label: &str, tree: &AxTree) {
     }
 }
 
+/// Print `description_census(tree)`: how many nodes carry a description, and a sample of
+/// which ones — the evidence for whether this platform's secondary label is worth wiring up.
+fn print_description_census(label: &str, tree: &AxTree) {
+    let census = description_census(tree);
+    println!(
+        "{label}: {} of {} nodes described",
+        census.described, census.nodes
+    );
+    for sample in &census.samples {
+        println!(
+            "  {} name={:?} desc={:?}",
+            sample.raw_role, sample.name, sample.description
+        );
+    }
+}
+
 #[test]
 #[ignore = "on-box only: needs a macOS host with a booted iOS Simulator + idb_companion, and \
             GLASS_A11Y_PROBE_APPS naming bundle ids or .app paths"]
@@ -225,6 +243,7 @@ fn role_histogram_probe() {
             .unwrap_or_else(|e| panic!("snapshot({target}): {e}"));
         tree.assign_ids();
         print_role_histogram(target, &tree);
+        print_description_census(target, &tree);
         violations.extend(thin_tree_violation(target, &tree));
         violations.extend(mapped_token_violations(target, &tree));
 

--- a/crates/glass-ios/tests/role_probe.rs
+++ b/crates/glass-ios/tests/role_probe.rs
@@ -30,7 +30,8 @@ use std::time::Duration;
 use glass_core::Accessibility; // the trait must be in scope to call `snapshot` on the boxed reader
 use glass_core::accessibility::{AxContext, WalkLimits};
 use glass_core::{
-    AppSpec, AxRole, AxTree, Platform, SandboxLevel, description_census, role_histogram,
+    AppSpec, AxRole, AxTree, DescriptionSourcing, Platform, SandboxLevel,
+    description_census_report, role_histogram,
 };
 use glass_ios::{IosPlatform, SimulatorRegistry};
 
@@ -170,22 +171,6 @@ fn print_role_histogram(label: &str, tree: &AxTree) {
     }
 }
 
-/// Print `description_census(tree)`: how many nodes carry a description, and a sample of
-/// which ones — the evidence for whether this platform's secondary label is worth wiring up.
-fn print_description_census(label: &str, tree: &AxTree) {
-    let census = description_census(tree);
-    println!(
-        "{label}: {} of {} nodes described",
-        census.described, census.nodes
-    );
-    for sample in &census.samples {
-        println!(
-            "  {} name={:?} desc={:?}",
-            sample.raw_role, sample.name, sample.description
-        );
-    }
-}
-
 #[test]
 #[ignore = "on-box only: needs a macOS host with a booted iOS Simulator + idb_companion, and \
             GLASS_A11Y_PROBE_APPS naming bundle ids or .app paths"]
@@ -243,7 +228,12 @@ fn role_histogram_probe() {
             .unwrap_or_else(|e| panic!("snapshot({target}): {e}"));
         tree.assign_ids();
         print_role_histogram(target, &tree);
-        print_description_census(target, &tree);
+        // `Unsourced`: this reader leaves `description: None`, so the count is 0 for every
+        // app — flip this when it reads accessibilityHint.
+        print!(
+            "{}",
+            description_census_report(target, &tree, DescriptionSourcing::Unsourced)
+        );
         violations.extend(thin_tree_violation(target, &tree));
         violations.extend(mapped_token_violations(target, &tree));
 

--- a/crates/glass-macos/tests/a11y.rs
+++ b/crates/glass-macos/tests/a11y.rs
@@ -81,9 +81,9 @@ mod macos_main {
     ];
 
     /// Pre-order search for the first `TextField` node — the fixture's editable "Note" field.
-    /// Separate from the [`NEEDLES`] outline check because `to_outline` only ever renders
-    /// `name`; this reaches `AxNode::value` directly to prove content is read independently of
-    /// the (stable) label.
+    /// Separate from the [`NEEDLES`] outline check because `to_outline` renders labels (`name`,
+    /// plus `desc` where a reader sources one) and never `value`; this reaches `AxNode::value`
+    /// directly to prove content is read independently of the (stable) label.
     fn find_text_field(node: &AxNode) -> Option<&AxNode> {
         if node.role == AxRole::TextField {
             return Some(node);

--- a/crates/glass-macos/tests/a11y.rs
+++ b/crates/glass-macos/tests/a11y.rs
@@ -69,8 +69,8 @@ mod macos_main {
     const CLICK_SETTLE: Duration = Duration::from_millis(400);
 
     /// The four elements the fixture exposes, asserted as substrings of the tree outline.
-    /// `to_outline` renders each node as `#<id> <Role> "<name>" ...`, using only `name` (never
-    /// `value`) — so the editable field's stable label (`setAccessibilityLabel("Note")`,
+    /// `to_outline` renders each node as `#<id> <Role> "<name>" ...`, rendering `name` and never
+    /// `value` — so the editable field's stable label (`setAccessibilityLabel("Note")`,
     /// surfaced as `AXDescription`) is what appears here, not its volatile content ("hello").
     /// The content is checked separately, via [`find_text_field`], against `AxNode::value`.
     const NEEDLES: [&str; 4] = [

--- a/crates/glass-macos/tests/role_probe.rs
+++ b/crates/glass-macos/tests/role_probe.rs
@@ -43,8 +43,8 @@ mod macos_main {
 
     use glass_a11y_macos::MacosA11y;
     use glass_core::{
-        Accessibility, AppSpec, AxContext, AxRole, AxTree, Platform, SandboxLevel, WalkLimits,
-        description_census, role_histogram,
+        Accessibility, AppSpec, AxContext, AxRole, AxTree, DescriptionSourcing, Platform,
+        SandboxLevel, WalkLimits, description_census_report, role_histogram,
     };
     use glass_macos::MacosPlatform;
 
@@ -133,22 +133,6 @@ mod macos_main {
         }
     }
 
-    /// Print `description_census(tree)`: how many nodes carry a description, and a sample of
-    /// which ones — the evidence for whether this platform's secondary label is worth wiring up.
-    fn print_description_census(label: &str, tree: &AxTree) {
-        let census = description_census(tree);
-        println!(
-            "{label}: {} of {} nodes described",
-            census.described, census.nodes
-        );
-        for sample in &census.samples {
-            println!(
-                "  {} name={:?} desc={:?}",
-                sample.raw_role, sample.name, sample.description
-            );
-        }
-    }
-
     /// Run `body`, then always call `platform.stop_app()` afterward regardless of whether
     /// `body` succeeded — mirrors `tests/bundle_launch.rs`'s identically-named helper.
     fn with_stop_app<T>(
@@ -223,7 +207,12 @@ mod macos_main {
             // of how big the tree actually was.
             tree.assign_ids();
             print_role_histogram(run0, &tree);
-            print_description_census(run0, &tree);
+            // `Unsourced`: this reader leaves `description: None`, so the count is 0 for
+            // every app — flip this when it reads AXHelp.
+            print!(
+                "{}",
+                description_census_report(run0, &tree, DescriptionSourcing::Unsourced)
+            );
             // Checked after the histogram is printed, so the evidence that explains a failure
             // is already in the output when the failure is reported.
             let violations = mapped_token_violations(run0, &tree);

--- a/crates/glass-macos/tests/role_probe.rs
+++ b/crates/glass-macos/tests/role_probe.rs
@@ -44,7 +44,7 @@ mod macos_main {
     use glass_a11y_macos::MacosA11y;
     use glass_core::{
         Accessibility, AppSpec, AxContext, AxRole, AxTree, Platform, SandboxLevel, WalkLimits,
-        role_histogram,
+        description_census, role_histogram,
     };
     use glass_macos::MacosPlatform;
 
@@ -133,6 +133,22 @@ mod macos_main {
         }
     }
 
+    /// Print `description_census(tree)`: how many nodes carry a description, and a sample of
+    /// which ones — the evidence for whether this platform's secondary label is worth wiring up.
+    fn print_description_census(label: &str, tree: &AxTree) {
+        let census = description_census(tree);
+        println!(
+            "{label}: {} of {} nodes described",
+            census.described, census.nodes
+        );
+        for sample in &census.samples {
+            println!(
+                "  {} name={:?} desc={:?}",
+                sample.raw_role, sample.name, sample.description
+            );
+        }
+    }
+
     /// Run `body`, then always call `platform.stop_app()` afterward regardless of whether
     /// `body` succeeded — mirrors `tests/bundle_launch.rs`'s identically-named helper.
     fn with_stop_app<T>(
@@ -207,6 +223,7 @@ mod macos_main {
             // of how big the tree actually was.
             tree.assign_ids();
             print_role_histogram(run0, &tree);
+            print_description_census(run0, &tree);
             // Checked after the histogram is printed, so the evidence that explains a failure
             // is already in the output when the failure is reported.
             let violations = mapped_token_violations(run0, &tree);

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -431,7 +431,9 @@ impl GlassServer {
     #[tool(
         description = "Screenshot of the active window with a numbered box drawn on each \
                        interactable element (Set-of-Mark) — returns the annotated image plus a \
-                       text legend (`#<id> <Role> \"<name>\"`). Pick an element visually, then \
+                       text legend (`#<id> <Role> \"<name>\"`, or `#<id> <Role> \
+                       desc=\"<description>\"` for an element that has only a description). \
+                       Pick an element visually, then \
                        click it with glass_click_element using its #id (same ids as \
                        glass_a11y_snapshot). Chips sit just outside each element so small icon \
                        buttons stay visible. The box is only as precise as the toolkit's \

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -373,8 +373,11 @@ impl GlassServer {
                        elements: role, name, description, window-relative bounds) as compact \
                        text — deterministic, low-token element addressing alongside \
                        screenshots. Each line is `#<id> <Role> \"<name>\" desc=\"<description>\" \
-                       (x,y wxh) [states]`, with desc present only when the platform exposes a \
-                       secondary label distinct from the name; pass an #id to \
+                       (x,y wxh) [states]`. desc appears only where glass's reader for the \
+                       running backend sources the platform's secondary label — not all of \
+                       them do yet — and it differs from the name; it is display-only, since \
+                       glass_wait_for_element and glass_scroll_to_element select on name, not \
+                       description. Pass an #id to \
                        glass_click_element. Errors if the backend or app exposes no \
                        accessibility tree (e.g. a canvas/black-box app) — fall back to \
                        glass_screenshot then. Optional max_nodes: raise the element cap, or 0 \
@@ -556,7 +559,8 @@ const SERVER_INSTRUCTIONS: &str = "glass gives you a build → see → interact 
      glass_start launches the app and captures its logs (glass_logs for stdout/stderr).\n\n\
      SEE AND ADDRESS THE UI CHEAPLY FIRST — the low-token default. When the app exposes \
      an accessibility tree, glass_a11y_snapshot returns its elements as TEXT (#id, role, \
-     name, description, window-relative bounds) — deterministic, no image tokens. Address \
+     name, window-relative bounds, and a description where the running backend's reader \
+     sources one) — deterministic, no image tokens. Address \
      elements by #id: glass_click_element clicks one, glass_set_value writes an editable element's \
      value, and glass_wait_for_element blocks until an element reaches a state (e.g. Save \
      becomes enabled). Prefer this over screenshots and pixel-hunting whenever it works.\n\n\

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -370,10 +370,12 @@ impl GlassServer {
 
     #[tool(
         description = "Capture the active window's accessibility tree (semantic \
-                       elements: role, name, window-relative bounds) as compact text — \
-                       deterministic, low-token element addressing alongside screenshots. \
-                       Each line is `#<id> <Role> \"<name>\" (x,y wxh) [states]`; pass an \
-                       #id to glass_click_element. Errors if the backend or app exposes no \
+                       elements: role, name, description, window-relative bounds) as compact \
+                       text — deterministic, low-token element addressing alongside \
+                       screenshots. Each line is `#<id> <Role> \"<name>\" desc=\"<description>\" \
+                       (x,y wxh) [states]`, with desc present only when the platform exposes a \
+                       secondary label distinct from the name; pass an #id to \
+                       glass_click_element. Errors if the backend or app exposes no \
                        accessibility tree (e.g. a canvas/black-box app) — fall back to \
                        glass_screenshot then. Optional max_nodes: raise the element cap, or 0 \
                        to remove the element-count limit (default caps protect the token budget)."
@@ -552,8 +554,8 @@ const SERVER_INSTRUCTIONS: &str = "glass gives you a build → see → interact 
      glass_start launches the app and captures its logs (glass_logs for stdout/stderr).\n\n\
      SEE AND ADDRESS THE UI CHEAPLY FIRST — the low-token default. When the app exposes \
      an accessibility tree, glass_a11y_snapshot returns its elements as TEXT (#id, role, \
-     name, window-relative bounds) — deterministic, no image tokens. Address elements by \
-     #id: glass_click_element clicks one, glass_set_value writes an editable element's \
+     name, description, window-relative bounds) — deterministic, no image tokens. Address \
+     elements by #id: glass_click_element clicks one, glass_set_value writes an editable element's \
      value, and glass_wait_for_element blocks until an element reaches a state (e.g. Save \
      becomes enabled). Prefer this over screenshots and pixel-hunting whenever it works.\n\n\
      PIXELS ARE THE FALLBACK — for a canvas/black-box app with no tree (glass_a11y_snapshot \

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -726,6 +726,7 @@ pub(crate) mod testutil {
             role: AxRole::Button,
             raw_role: "push button".into(),
             name: Some("Save".into()),
+            description: None,
             value: None,
             states: AxStates {
                 focusable: true,
@@ -745,6 +746,7 @@ pub(crate) mod testutil {
             role: AxRole::Window,
             raw_role: "frame".into(),
             name: Some("Win".into()),
+            description: None,
             value: None,
             states: AxStates::default(),
             bounds: Some(AxRect {
@@ -765,6 +767,7 @@ pub(crate) mod testutil {
             role: AxRole::Window,
             raw_role: "frame".into(),
             name: Some("Win".into()),
+            description: None,
             value: None,
             states: AxStates::default(),
             bounds: Some(AxRect {

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -6,8 +6,8 @@
 use std::path::PathBuf;
 
 use glass_core::{
-    AppSpec, AxNodeId, Glass, MouseButton, WindowGeometry, WindowHint, WindowId, WindowOp,
-    frame_to_webp,
+    AppSpec, AxNodeId, Glass, MarkLabel, MouseButton, WindowGeometry, WindowHint, WindowId,
+    WindowOp, frame_to_webp,
 };
 use serde_json::json;
 
@@ -435,8 +435,12 @@ pub fn a11y_marks(glass: &mut Glass) -> ToolResult {
     } else {
         marks
             .iter()
-            .map(|m| match &m.name {
-                Some(name) => format!("#{} {:?} {name:?}", m.id.0, m.role),
+            // Same spelling as the outline's line: a quoted bare label is the accessible
+            // name a `name:` selector matches, `desc="…"` is a description and matches
+            // nothing.
+            .map(|m| match &m.label {
+                Some(MarkLabel::Name(name)) => format!("#{} {:?} {name:?}", m.id.0, m.role),
+                Some(MarkLabel::Description(d)) => format!("#{} {:?} desc={d:?}", m.id.0, m.role),
                 None => format!("#{} {:?}", m.id.0, m.role),
             })
             .collect::<Vec<_>>()
@@ -1391,6 +1395,51 @@ mod tests {
             OutContent::Text(t) => assert!(t.contains("#1 Button \"Save\""), "legend: {t}"),
             _ => panic!("expected legend text"),
         }
+    }
+
+    #[test]
+    fn a11y_marks_legend_spells_a_description_apart_from_a_name() {
+        use glass_core::{AxRect, Frame};
+        let mut tree = fake_tree();
+        let mut icon = tree.root.children[0].clone();
+        icon.name = None;
+        icon.description = Some("Bold".into());
+        icon.bounds = Some(AxRect {
+            x: 40,
+            y: 10,
+            width: 20,
+            height: 20,
+        });
+        tree.root.children.push(icon);
+        let platform =
+            FakePlatform::new(100, 100).with_frames(vec![Frame::solid(100, 100, [0, 0, 0, 255])]);
+        let mut g = glass_with_a11y(platform, tree);
+        g.start(&AppSpec {
+            build: None,
+            run: vec!["x".into()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 1,
+            sandbox: SandboxLevel::Off,
+            a11y: false,
+        })
+        .unwrap();
+        let out = a11y_marks(&mut g).unwrap();
+        let OutContent::Text(legend) = &out.0[2] else {
+            panic!("expected legend text")
+        };
+        // A real name rides in the quoted slot a `name:` selector matches; a description
+        // rides in `desc="…"`, exactly as the outline spells it.
+        assert!(legend.contains("#1 Button \"Save\""), "legend: {legend}");
+        assert!(
+            legend.contains("#2 Button desc=\"Bold\""),
+            "legend: {legend}"
+        );
+        assert!(
+            !legend.contains("Button \"Bold\""),
+            "a description must never render as a name: {legend}"
+        );
     }
 
     #[test]

--- a/crates/glass-mcp/src/tools/wait.rs
+++ b/crates/glass-mcp/src/tools/wait.rs
@@ -325,6 +325,7 @@ mod tests {
             role: AxRole::Button,
             raw_role: "push button".into(),
             name: Some("Save".into()),
+            description: None,
             value: None,
             states: AxStates {
                 focusable: true,
@@ -344,6 +345,7 @@ mod tests {
             role: AxRole::Window,
             raw_role: "frame".into(),
             name: Some("Win".into()),
+            description: None,
             value: None,
             states: AxStates::default(),
             bounds: Some(AxRect {

--- a/crates/glass-mcp/src/tools/wait.rs
+++ b/crates/glass-mcp/src/tools/wait.rs
@@ -45,8 +45,8 @@ pub fn wait_for_element(glass: &mut Glass, a: &WaitForElementArgs) -> ToolResult
 }
 
 /// The matched a11y element as an untrusted sibling block (empty when nothing
-/// matched). Its `name`/`value` are app-controlled, so they must never ride in the
-/// trusted `result` envelope.
+/// matched). Its `name`/`description`/`value` are app-controlled, so they must never ride in
+/// the trusted `result` envelope.
 fn element_sibling(element: Option<glass_core::ElementInfo>) -> Vec<OutContent> {
     match element {
         Some(e) => {
@@ -54,6 +54,9 @@ fn element_sibling(element: Option<glass_core::ElementInfo>) -> Vec<OutContent> 
                 "id": e.id.0,
                 "role": format!("{:?}", e.role),
                 "name": e.name,
+                // An icon-only element's only label; without it the block that reports the
+                // match carries no label at all for a node the outline labels desc="…".
+                "description": e.description,
                 "value": e.value,
                 "bounds": e.bounds.map(|b| json!({ "x": b.x, "y": b.y, "width": b.width, "height": b.height })),
                 "states": e.states.active(),
@@ -395,6 +398,26 @@ mod tests {
             }
             _ => panic!("expected text"),
         }
+    }
+
+    #[test]
+    fn a_matched_element_reports_its_description() {
+        // An icon-only control has no name, so without `description` the match block would
+        // carry no label at all for a node the outline shows as `desc="Bold"`.
+        let mut tree = fake_tree();
+        tree.root.children[0].name = None;
+        tree.root.children[0].description = Some("Bold".into());
+        let mut g = started_a11y_with(tree);
+        let mut a = elem_args();
+        a.role = Some("Button".into());
+        let out = wait_for_element(&mut g, &a).unwrap();
+        let OutContent::Text(sibling) = &out.0[1] else {
+            panic!("expected untrusted element sibling")
+        };
+        assert!(
+            sibling.contains("\"description\":\"Bold\""),
+            "the element's only label must be reported: {sibling}"
+        );
     }
 
     fn started_a11y_with(tree: AxTree) -> Glass {

--- a/crates/glass-testapp/tests/common/mcp_cost.rs
+++ b/crates/glass-testapp/tests/common/mcp_cost.rs
@@ -472,8 +472,9 @@ pub async fn run_arm_a(client: &Peer<RoleClient>) -> ArmReport {
 }
 
 /// `(x, y, w, h)` for node #id, parsed from its outline line's `(x,y wxh)` field. Uses the
-/// LAST `(...)` group on the line, not the first: a widget's quoted name precedes its
-/// bounds and can itself contain a literal `(` (e.g. a button named "Apply (default)"), so
+/// LAST `(...)` group on the line, not the first: a widget's quoted name and quoted `desc`
+/// both precede the bounds and can contain a literal `(` (e.g. a button named "Apply
+/// (default)"), so
 /// `rfind` is required — the bounds are always the final parenthesized group (states after
 /// them use `[...]`, not parens).
 pub fn parse_bounds(outline: &str, id: u32) -> Option<(i64, i64, u32, u32)> {

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -16,7 +16,7 @@ use glass_a11y_windows::WindowsA11y;
 use glass_core::{
     Accessibility, AppSpec, AxContext, AxNode, AxRole, AxTarget, AxTree, Backend, BaselineStore,
     Glass, GlassError, KeyEvent, Modifier, MouseButton, Platform, PlatformFactory, PointerEvent,
-    WalkLimits, WindowGeometry, WindowHint, WindowOp, role_histogram,
+    WalkLimits, WindowGeometry, WindowHint, WindowOp, description_census, role_histogram,
 };
 use glass_windows::WindowsPlatform;
 
@@ -1134,6 +1134,28 @@ fn render_role_histogram(label: &str, tree: &AxTree) -> String {
     out
 }
 
+/// Render `description_census(tree)` in the same block-returning style as
+/// [`render_role_histogram`], so [`probe_role_histogram`] can fold it into the same
+/// printed/saved report.
+fn render_description_census(label: &str, tree: &AxTree) -> String {
+    use std::fmt::Write as _;
+    let census = description_census(tree);
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "{label}: {} of {} nodes described",
+        census.described, census.nodes
+    );
+    for sample in &census.samples {
+        let _ = writeln!(
+            out,
+            "  {} name={:?} desc={:?}",
+            sample.raw_role, sample.name, sample.description
+        );
+    }
+    out
+}
+
 /// UIA control-type names glass maps to a role, and that a probed app has actually been seen to
 /// emit. A histogram bucket carrying one of these must not come back [`AxRole::Other`]: the
 /// token reached the reader, so a mapped role is the only correct outcome, and `Other` would
@@ -1216,6 +1238,10 @@ fn probe_role_histogram(label: &str, spec: &AppSpec, report: &mut String) -> Vec
     let block = render_role_histogram(label, &tree);
     print!("{block}");
     report.push_str(&block);
+
+    let census_block = render_description_census(label, &tree);
+    print!("{census_block}");
+    report.push_str(&census_block);
 
     // Collect toggle-capable non-checkbox/radio nodes (evidence for ToggleButton row parity).
     let mut candidates = Vec::new();

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -15,8 +15,9 @@ use std::time::Duration;
 use glass_a11y_windows::WindowsA11y;
 use glass_core::{
     Accessibility, AppSpec, AxContext, AxNode, AxRole, AxTarget, AxTree, Backend, BaselineStore,
-    Glass, GlassError, KeyEvent, Modifier, MouseButton, Platform, PlatformFactory, PointerEvent,
-    WalkLimits, WindowGeometry, WindowHint, WindowOp, description_census, role_histogram,
+    DescriptionSourcing, Glass, GlassError, KeyEvent, Modifier, MouseButton, Platform,
+    PlatformFactory, PointerEvent, WalkLimits, WindowGeometry, WindowHint, WindowOp,
+    description_census_report, role_histogram,
 };
 use glass_windows::WindowsPlatform;
 
@@ -1134,28 +1135,6 @@ fn render_role_histogram(label: &str, tree: &AxTree) -> String {
     out
 }
 
-/// Render `description_census(tree)` in the same block-returning style as
-/// [`render_role_histogram`], so [`probe_role_histogram`] can fold it into the same
-/// printed/saved report.
-fn render_description_census(label: &str, tree: &AxTree) -> String {
-    use std::fmt::Write as _;
-    let census = description_census(tree);
-    let mut out = String::new();
-    let _ = writeln!(
-        out,
-        "{label}: {} of {} nodes described",
-        census.described, census.nodes
-    );
-    for sample in &census.samples {
-        let _ = writeln!(
-            out,
-            "  {} name={:?} desc={:?}",
-            sample.raw_role, sample.name, sample.description
-        );
-    }
-    out
-}
-
 /// UIA control-type names glass maps to a role, and that a probed app has actually been seen to
 /// emit. A histogram bucket carrying one of these must not come back [`AxRole::Other`]: the
 /// token reached the reader, so a mapped role is the only correct outcome, and `Other` would
@@ -1239,7 +1218,9 @@ fn probe_role_histogram(label: &str, spec: &AppSpec, report: &mut String) -> Vec
     print!("{block}");
     report.push_str(&block);
 
-    let census_block = render_description_census(label, &tree);
+    // `Unsourced`: this reader leaves `description: None`, so the count is 0 for every app —
+    // flip this when it reads HelpText/FullDescription.
+    let census_block = description_census_report(label, &tree, DescriptionSourcing::Unsourced);
     print!("{census_block}");
     report.push_str(&census_block);
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -230,9 +230,9 @@ no accessibility tree.
 - `interval_ms` (integer, default 200) — poll interval (one a11y snapshot per tick).
 - `timeout_ms` (integer, default 10000) — returns `{matched:false}` on timeout.
 
-Returns `{matched, elapsed_ms}`. On a match, the matched element (`{id, role, name, value, bounds,
-states}`) rides as an untrusted sibling text block, since its `name`/`value` are app-controlled; its
-`id` is usable with `glass_click_element`. No sibling on timeout.
+Returns `{matched, elapsed_ms}`. On a match, the matched element (`{id, role, name, description,
+value, bounds, states}`) rides as an untrusted sibling text block, since its `name`/`description`/
+`value` are app-controlled; its `id` is usable with `glass_click_element`. No sibling on timeout.
 
 ### `glass_wait_for_region`
 
@@ -456,9 +456,14 @@ reads the Simulator's accessibility tree over `idb_companion` (install it — se
 Capture the active window's accessibility tree as compact text. Returns `{}`; the tree itself
 rides as an untrusted sibling text block, one line per element:
 `#<id> <Role> "<name>" desc="<description>" (x,y wxh) [states]`; pass an `#id` to
-`glass_click_element`. `desc="…"` appears only when the platform exposes a secondary label that
-differs from the name — help or tooltip text on desktop, or the human-readable label where the
-name is a developer-assigned id — and is omitted otherwise. An element whose platform role glass
+`glass_click_element`. `desc="…"` carries a secondary label the platform exposes separately from
+the name — help or tooltip text, or the human-readable label where the name is a
+developer-assigned id. It appears only where glass's reader sources that label, which today is the
+AT-SPI (Linux) reader alone; the UI Automation, AX, `uiautomator` and `idb` readers do not read
+their platform's secondary label yet, so `desc` never appears there no matter what the app
+exposes. It is also omitted when the description duplicates the name. **`desc` is display-only:
+`glass_wait_for_element` and `glass_scroll_to_element` select on `name`, never on the
+description.** An element whose platform role glass
 has no mapping for renders as `Other(<native token>)` — e.g.
 `#4 Other(AXDisclosureTriangle) "Details" [enabled]` — so the platform's own token is still
 visible; a bare `Other` means the platform named no token at all.
@@ -531,9 +536,9 @@ Errors if the app exposes no accessibility tree.
 - `timeout_ms` (integer, default 20000) — returns `{matched:false}` on timeout.
 
 Returns `{matched, elapsed_ms, scrolled{steps, reversed, direction}}` — `direction` is the resolved
-(possibly inferred) sweep direction. On a match, the matched element (`{id, role, name, value, bounds,
-states}`) rides as an untrusted sibling text block, since its `name`/`value` are app-controlled; its
-`id` is usable with `glass_click_element`. No sibling on timeout.
+(possibly inferred) sweep direction. On a match, the matched element (`{id, role, name, description,
+value, bounds, states}`) rides as an untrusted sibling text block, since its `name`/`description`/
+`value` are app-controlled; its `id` is usable with `glass_click_element`. No sibling on timeout.
 
 ## Clipboard
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -455,8 +455,11 @@ reads the Simulator's accessibility tree over `idb_companion` (install it — se
 
 Capture the active window's accessibility tree as compact text. Returns `{}`; the tree itself
 rides as an untrusted sibling text block, one line per element:
-`#<id> <Role> "<name>" (x,y wxh) [states]`; pass an `#id` to `glass_click_element`. An element
-whose platform role glass has no mapping for renders as `Other(<native token>)` — e.g.
+`#<id> <Role> "<name>" desc="<description>" (x,y wxh) [states]`; pass an `#id` to
+`glass_click_element`. `desc="…"` appears only when the platform exposes a secondary label that
+differs from the name — help or tooltip text on desktop, or the human-readable label where the
+name is a developer-assigned id — and is omitted otherwise. An element whose platform role glass
+has no mapping for renders as `Other(<native token>)` — e.g.
 `#4 Other(AXDisclosureTriangle) "Details" [enabled]` — so the platform's own token is still
 visible; a bare `Other` means the platform named no token at all.
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -480,11 +480,13 @@ what each backend can produce.
 
 Screenshot of the active window with a numbered Set-of-Mark box on each interactable element, plus a
 text legend (`#<id> <Role> "<name>"`). An element with no name but a description is labelled from it
-and rendered as `#<id> <Role> desc="<description>"`, the same spelling the snapshot outline uses —
-so the legend never shows a description where a matchable `name` would be. No parameters. Returns `{count}` — the number of marked
-elements; the image and the legend text follow as siblings (the legend untrusted-wrapped), per the
-image ordering above. Same ids as `glass_a11y_snapshot`. The box is only as precise as the toolkit's
-a11y geometry (can drift ~10–20px), but the `#id` and the click are exact.
+and rendered as `#<id> <Role> desc="<description>"`, the same spelling the snapshot outline uses, so
+the legend never shows a description where a matchable `name` would be.
+
+No parameters. Returns `{count}` — the number of marked elements; the image and the legend text
+follow as siblings (the legend untrusted-wrapped), per the image ordering above. Same ids as
+`glass_a11y_snapshot`. The box is only as precise as the toolkit's a11y geometry (can drift
+~10–20px), but the `#id` and the click are exact.
 
 ### `glass_click_element`
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -474,7 +474,9 @@ what each backend can produce.
 ### `glass_a11y_marks`
 
 Screenshot of the active window with a numbered Set-of-Mark box on each interactable element, plus a
-text legend (`#<id> <Role> "<name>"`). No parameters. Returns `{count}` — the number of marked
+text legend (`#<id> <Role> "<name>"`). An element with no name but a description is labelled from it
+and rendered as `#<id> <Role> desc="<description>"`, the same spelling the snapshot outline uses —
+so the legend never shows a description where a matchable `name` would be. No parameters. Returns `{count}` — the number of marked
 elements; the image and the legend text follow as siblings (the legend untrusted-wrapped), per the
 image ordering above. Same ids as `glass_a11y_snapshot`. The box is only as precise as the toolkit's
 a11y geometry (can drift ~10–20px), but the `#id` and the click are exact.


### PR DESCRIPTION
An icon-only button reaches an agent today as `#13 Button (84,0 24x24) [focusable]` — a role, a
rectangle, and nothing to decide with. Every platform exposes a second human label for exactly that
case, and glass read none of them. Two backends were worse than not reading it: iOS takes `name` from
`AXUniqueId` when present, so a labelled element gives up `"Bold Text"` in favour of the developer id
`"boldText"`; macOS takes `AXTitle` else `AXDescription`, so a titled node drops its description. The
id and the title have to keep the name — `name` is half the `AxTarget` fingerprint `set_value`
re-walks against — so the label needs its own field.

This adds that field and sources it on Linux. Windows, macOS, Android and iOS are later PRs.

## What's here

- **`AxNode.description`**, with one shared rule in `glass_core::normalize_description`: trim, then
  `None` for empty or for a value equal to the trimmed name. Platforms routinely report both fields
  with one label in them, and without that clause every line of such a tree would read
  `Button "Save" desc="Save"`.
- **Outline render** — `#12 Button "Save" desc="Saves and closes the sheet" (0,0 80x24) [focusable]`.
  Spelled `desc="…"` rather than a bare sigil because the outline is read cold by an agent that has
  not read the reference. `write_line` is shared, so `to_outline` and `render_compact` cannot drift.
- **Marks legend** — an icon-only control is exactly the mark that has no name, so the legend falls
  back to the description. It renders as `desc="Bold"`, never in the `"name"` slot: selectors match
  on `name`, and a description shown as a name would produce a call that can never match.
- **`description_census`** — a tally probe runs print, so the later per-platform PRs decide from
  evidence. On a backend whose reader does not source the field yet, the printed line says so, so a
  zero cannot be misread as an observation about the platform.
- **Linux AT-SPI backend** sources it as a seventh arm on the per-node concurrent read batch.

## The cost, measured

The read was predicted free — it joins an existing `tokio::join!`, and a concurrent batch is bounded
by its slowest call. **It is not free.** On the 1500-node bench fixture, 12 interleaved runs per
condition:

| | mean | sd |
|---|---|---|
| before | 659 ms | 23 |
| after | 721 ms | 37 |

**+9.3% (61 ms), Welch t = 4.86, df = 18.3.** Not noise. The batch is only partly parallel
server-side — one zbus connection, the app servicing calls on a single main loop — the same ceiling
that made the original concurrency work land at ~1.9x rather than the projected ~6x.

61 ms per full-depth snapshot buys the only descriptor an icon-only control has, so this ships the
unconditional read. Narrowing by role stays available if that trade ever looks wrong.

## Verification

`cargo fmt --check`, `clippy --workspace --all-targets -D warnings`, `cargo test --workspace`,
`./scripts/test-a11y.sh` (27/27, including the new live description tests), `./scripts/test-x11.sh`,
and `cargo check -p glass-windows --tests --target x86_64-pc-windows-gnu`.

The GTK fixture's description was proven to reach the accessibility bus with an independent
PyGObject AT-SPI client before any Rust asserted on it — glass's own reader could not be the oracle
for a field it did not yet read.

The macOS files touched here are comment-only edits and could not be compiled on the Linux host;
Android, iOS and Windows probe harnesses all compile here.

## Deliberately not in this PR

- `description` does not enter `AxTarget::matches`, the `set_value` fingerprint, or the
  `role:`/`name:` selectors. It is display-only, and the tool description says so.
- No length cap on a description in the outline. `name` is uncapped too; a policy for app-controlled
  string length affects both and wants its own decision.
- Normalization is enforced by every backend calling the shared function, not by the type or by a
  central pass at the tree seam. Worth revisiting when the second backend lands.
- The census `samples` list is unbounded, and the "this reader does not source it" markers at the
  four probe sites are hand-maintained.

## Follow-up filed

The two Android readers disagree on name precedence — the accessibility service does
`text.or(desc)`, uiautomator does `content-desc.or(text)` — so the same app yields a different
`name` depending on which reader ran, and `name` is half the fingerprint. Recorded rather than fixed
here, because changing either precedence moves fingerprints and deserves its own verification.
