### PR TITLE
a11y: source the description field on Windows and macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ internal refactors, CI, or test-only changes.
   from it, spelled `desc="…"` there too. `glass_wait_for_element` and `glass_scroll_to_element`
   report it on the element they matched. It is display-only: both tools still select on `name`.
   The Linux, Windows and macOS readers source the field — AT-SPI `Description`, UI Automation
-  `HelpText`, and AX `AXHelp` respectively — so `desc` does not appear on Android or iOS yet.
+  `HelpText`, and AX `AXHelp` respectively. The Android and iOS readers do not read their
+  platform's secondary label yet, so `desc` does not appear there.
 - `glass_start` on the iOS Simulator passes an app's launch arguments through: everything after
   the `.app` path or bundle id in `run` reaches the app as its own arguments, joined
   (`--tab=value`) and separated (`--tab value`) forms alike, so an app whose behaviour is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ internal refactors, CI, or test-only changes.
   rectangle now says what it is — and the `glass_a11y_marks` legend labels an unnamed element
   from it, spelled `desc="…"` there too. `glass_wait_for_element` and `glass_scroll_to_element`
   report it on the element they matched. It is display-only: both tools still select on `name`.
-  Only the AT-SPI (Linux) reader sources the field today, so `desc` does not appear on Windows,
-  macOS, Android or iOS yet.
+  The Linux, Windows and macOS readers source the field — AT-SPI `Description`, UI Automation
+  `HelpText`, and AX `AXHelp` respectively — so `desc` does not appear on Android or iOS yet.
 - `glass_start` on the iOS Simulator passes an app's launch arguments through: everything after
   the `.app` path or bundle id in `run` reaches the app as its own arguments, joined
   (`--tab=value`) and separated (`--tab value`) forms alike, so an app whose behaviour is

--- a/crates/glass-a11y-macos/src/ffi.rs
+++ b/crates/glass-a11y-macos/src/ffi.rs
@@ -47,6 +47,7 @@ pub(crate) mod attr {
     pub(crate) const ROLE_DESCRIPTION: &str = "AXRoleDescription";
     pub(crate) const TITLE: &str = "AXTitle";
     pub(crate) const DESCRIPTION: &str = "AXDescription";
+    pub(crate) const HELP: &str = "AXHelp";
     pub(crate) const CHILDREN: &str = "AXChildren";
     pub(crate) const WINDOWS: &str = "AXWindows";
     pub(crate) const POSITION: &str = "AXPosition";

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -20,7 +20,7 @@ use glass_core::coords::pixel_geometry_from_content_rect;
 use glass_core::platform::WindowGeometry;
 use glass_core::{
     Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxTarget, AxTree, GlassError,
-    Result, TruncationLimit, WalkBudget,
+    Result, TruncationLimit, WalkBudget, normalize_description,
 };
 use objc2_application_services::AXUIElement;
 use objc2_core_foundation::CFRetained;
@@ -368,8 +368,20 @@ fn walk(
     // Name = title, else description — both stable labels (e.g. `setAccessibilityLabel`
     // surfaces as `AXDescription`). Never fold in `AXValue`: it's volatile content, and a
     // node's name must stay stable for the `AxTarget` fingerprint `set_value` relies on.
-    let name = ffi::attribute_string(el, attr::TITLE)
-        .or_else(|| ffi::attribute_string(el, attr::DESCRIPTION));
+    let title = ffi::attribute_string(el, attr::TITLE);
+    let titled = title.is_some();
+    let name = title.or_else(|| ffi::attribute_string(el, attr::DESCRIPTION));
+    // `AXHelp` (the tooltip), else `AXDescription` — but only where `AXTitle` already took the
+    // name, since otherwise `AXDescription` IS the name and would normalize away as a duplicate.
+    // So `AXDescription` costs at most one read per node either way: as the name fallback when
+    // there is no title, here when there is.
+    let description = ffi::attribute_string(el, attr::HELP)
+        .or_else(|| {
+            titled
+                .then(|| ffi::attribute_string(el, attr::DESCRIPTION))
+                .flatten()
+        })
+        .and_then(|raw| normalize_description(&raw, name.as_deref()));
     let value = ffi::attribute_string(el, attr::VALUE);
     let bounds = window_relative_rect(el, scale, win);
     let states = mapping::map_states(&gather_states(el, role));
@@ -424,9 +436,7 @@ fn walk(
         role,
         raw_role,
         name,
-        // `AXDescription` is already read above as the name fallback, so reading it here would
-        // normalize away as a duplicate; `AXHelp` (the tooltip) is the unread secondary label.
-        description: None,
+        description,
         value,
         states,
         bounds,

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -168,9 +168,7 @@ impl Accessibility for MacosA11y {
         // Same fingerprint gate as set_value: role + name + bounds.
         let ax_role = ffi::attribute_string(&el, attr::ROLE).unwrap_or_default();
         let role = mapping::map_role(&ax_role, read_subrole(&el, &ax_role).as_deref());
-        // Same two reads, in the same order, that `walk` derived this element's `name` from —
-        // through the same helper, so a fingerprint can never be computed from a differently-read
-        // name and reject an element that never moved.
+        // `name` derived exactly as in `walk` and `set_value` — see there.
         let name = read_label(&el, attr::TITLE).or_else(|| read_label(&el, attr::DESCRIPTION));
         let bounds = window_relative_rect(&el, scale, &ctx.window);
         if !target.matches(role, name.as_deref())

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -402,8 +402,10 @@ fn walk(
     // Which attribute is left to describe the node therefore depends on which one named it, so
     // both labels are decided in one place. `AXDescription` costs at most one read per node
     // either way: as the name when there is no title, as the description only when there IS a
-    // title and no `AXHelp` — where the title took the name, so a description read cannot
-    // normalize away as a duplicate of it.
+    // title and no `AXHelp` — worth reading there, unlike the untitled case where
+    // `AXDescription` IS the name and could only ever normalize away as a duplicate of it. (A
+    // titled node whose title and description hold the same string still normalizes away; that
+    // is the value check doing its job, not a wasted branch.)
     let (name, secondary) = match read_label(el, attr::TITLE) {
         Some(title) => (
             Some(title),

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -305,13 +305,12 @@ fn select_window(
 /// present-but-empty value, so `name` keeps the value it had before this reader sourced a
 /// description.
 ///
-/// The checked form earns its keep for the same reason [`read_subrole`] uses it: the direct read
-/// folds a genuine failure into the same `None` as a legitimately-absent attribute, and most nodes
-/// legitimately lack `AXHelp` — which is what would make the dishonest `None`s undetectable. A
-/// failure still degrades to `None`, since one unreadable attribute must not fail a whole snapshot,
-/// but it logs first. `AXTitle` earns it twice over: it decides `name`, half the `AxTarget`
-/// fingerprint `set_value` re-walks against, and (here) which attribute is free to be the
-/// description.
+/// Checked for [`read_subrole`]'s reason: the direct read folds a genuine failure into the same
+/// `None` as an absent attribute, and since most nodes legitimately lack `AXHelp`, the dishonest
+/// `None`s would be undetectable. A failure still degrades to `None` — one unreadable attribute
+/// must not fail a snapshot — but it logs first. `AXTitle` earns it twice over: it decides `name`,
+/// half the `AxTarget` fingerprint `set_value` re-walks against, and which attribute is left to
+/// describe the node.
 fn read_label(el: &AXUIElement, attr_name: &str) -> Option<String> {
     match ffi::attribute_string_checked(el, attr_name) {
         Ok(text) => text.filter(|t| !t.is_empty()),
@@ -404,8 +403,8 @@ fn walk(
     // either way: as the name when there is no title, as the description only when there IS a
     // title and no `AXHelp` — worth reading there, unlike the untitled case where
     // `AXDescription` IS the name and could only ever normalize away as a duplicate of it. (A
-    // titled node whose title and description hold the same string still normalizes away; that
-    // is the value check doing its job, not a wasted branch.)
+    // titled node whose title and description hold the same string still normalizes away — the
+    // value check, not the branch, is what drops it.)
     let (name, secondary) = match read_label(el, attr::TITLE) {
         Some(title) => (
             Some(title),

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -106,8 +106,10 @@ impl Accessibility for MacosA11y {
         // and it is rejected here rather than silently overwritten.
         let ax_role = ffi::attribute_string(&el, attr::ROLE).unwrap_or_default();
         let role = mapping::map_role(&ax_role, read_subrole(&el, &ax_role).as_deref());
-        let name = ffi::attribute_string(&el, attr::TITLE)
-            .or_else(|| ffi::attribute_string(&el, attr::DESCRIPTION));
+        // Same two reads, in the same order, that `walk` derived this element's `name` from —
+        // through the same helper, so a fingerprint can never be computed from a differently-read
+        // name and reject an element that never moved.
+        let name = read_label(&el, attr::TITLE).or_else(|| read_label(&el, attr::DESCRIPTION));
         let bounds = window_relative_rect(&el, scale, &ctx.window);
         if !target.matches(role, name.as_deref())
             || !target.bounds_consistent(bounds, SET_VALUE_BOUNDS_TOL)
@@ -166,8 +168,10 @@ impl Accessibility for MacosA11y {
         // Same fingerprint gate as set_value: role + name + bounds.
         let ax_role = ffi::attribute_string(&el, attr::ROLE).unwrap_or_default();
         let role = mapping::map_role(&ax_role, read_subrole(&el, &ax_role).as_deref());
-        let name = ffi::attribute_string(&el, attr::TITLE)
-            .or_else(|| ffi::attribute_string(&el, attr::DESCRIPTION));
+        // Same two reads, in the same order, that `walk` derived this element's `name` from —
+        // through the same helper, so a fingerprint can never be computed from a differently-read
+        // name and reject an element that never moved.
+        let name = read_label(&el, attr::TITLE).or_else(|| read_label(&el, attr::DESCRIPTION));
         let bounds = window_relative_rect(&el, scale, &ctx.window);
         if !target.matches(role, name.as_deref())
             || !target.bounds_consistent(bounds, SET_VALUE_BOUNDS_TOL)
@@ -295,6 +299,32 @@ fn select_window(
     best.map(|(_, w, scale)| (w, scale))
 }
 
+/// One of the label attributes a node's `name`/`description` come from (`AXTitle`,
+/// `AXDescription`, `AXHelp`), read through the *error-aware* [`ffi::attribute_string_checked`]
+/// and then folded to `None` when empty — exactly what [`ffi::attribute_string`] returns for a
+/// present-but-empty value, so `name` keeps the value it had before this reader sourced a
+/// description.
+///
+/// The checked form earns its keep for the same reason [`read_subrole`] uses it: the direct read
+/// folds a genuine failure into the same `None` as a legitimately-absent attribute, and most nodes
+/// legitimately lack `AXHelp` — which is what would make the dishonest `None`s undetectable. A
+/// failure still degrades to `None`, since one unreadable attribute must not fail a whole snapshot,
+/// but it logs first. `AXTitle` earns it twice over: it decides `name`, half the `AxTarget`
+/// fingerprint `set_value` re-walks against, and (here) which attribute is free to be the
+/// description.
+fn read_label(el: &AXUIElement, attr_name: &str) -> Option<String> {
+    match ffi::attribute_string_checked(el, attr_name) {
+        Ok(text) => text.filter(|t| !t.is_empty()),
+        Err(err) => {
+            eprintln!(
+                "glass-a11y-macos: {attr_name} read failed: {err}; treating the element as \
+                 having no {attr_name}"
+            );
+            None
+        }
+    }
+}
+
 /// `el`'s `AXSubrole`, but only for the base roles whose subrole actually changes the mapped
 /// role ([`mapping::subrole_matters`]) — every other node skips the AX IPC round-trip and gets
 /// `None`.
@@ -368,20 +398,23 @@ fn walk(
     // Name = title, else description — both stable labels (e.g. `setAccessibilityLabel`
     // surfaces as `AXDescription`). Never fold in `AXValue`: it's volatile content, and a
     // node's name must stay stable for the `AxTarget` fingerprint `set_value` relies on.
-    let title = ffi::attribute_string(el, attr::TITLE);
-    let titled = title.is_some();
-    let name = title.or_else(|| ffi::attribute_string(el, attr::DESCRIPTION));
-    // `AXHelp` (the tooltip), else `AXDescription` — but only where `AXTitle` already took the
-    // name, since otherwise `AXDescription` IS the name and would normalize away as a duplicate.
-    // So `AXDescription` costs at most one read per node either way: as the name fallback when
-    // there is no title, here when there is.
-    let description = ffi::attribute_string(el, attr::HELP)
-        .or_else(|| {
-            titled
-                .then(|| ffi::attribute_string(el, attr::DESCRIPTION))
-                .flatten()
-        })
-        .and_then(|raw| normalize_description(&raw, name.as_deref()));
+    //
+    // Which attribute is left to describe the node therefore depends on which one named it, so
+    // both labels are decided in one place. `AXDescription` costs at most one read per node
+    // either way: as the name when there is no title, as the description only when there IS a
+    // title and no `AXHelp` — where the title took the name, so a description read cannot
+    // normalize away as a duplicate of it.
+    let (name, secondary) = match read_label(el, attr::TITLE) {
+        Some(title) => (
+            Some(title),
+            read_label(el, attr::HELP).or_else(|| read_label(el, attr::DESCRIPTION)),
+        ),
+        None => (
+            read_label(el, attr::DESCRIPTION),
+            read_label(el, attr::HELP),
+        ),
+    };
+    let description = secondary.and_then(|raw| normalize_description(&raw, name.as_deref()));
     let value = ffi::attribute_string(el, attr::VALUE);
     let bounds = window_relative_rect(el, scale, win);
     let states = mapping::map_states(&gather_states(el, role));

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -149,12 +149,7 @@ fn walk(
         .map(str::to_string)
         .unwrap_or_else(|| format!("UIA:{ct_id}"));
     let name = nonempty(el.get_name().unwrap_or_default());
-    // UIA's secondary label is `HelpText`, the tooltip — one more cross-process round-trip per
-    // node, which the probe harness's cost block measures. `FullDescription` is UIA's other
-    // secondary label; `uiautomation` 0.25 exposes no accessor for it (only
-    // `UIProperty::FullDescription` through `get_property_value`).
-    let description =
-        normalize_description(&el.get_help_text().unwrap_or_default(), name.as_deref());
+    let description = normalize_description(&help_text(el, ct_id), name.as_deref());
     let bounds = window_relative_bounds(el, origin);
     let (facts, value) = gather(el, ct_id);
     let states = crate::mapping::map_states(&facts);
@@ -310,6 +305,30 @@ fn gather(el: &UIElement, ct_id: u32) -> (crate::mapping::StateFacts, Option<Str
         checkable,
     };
     (facts, value)
+}
+
+/// `el`'s UIA `HelpText` — the tooltip, and the secondary label the outline renders as
+/// `desc="…"`. Costs one cross-process property read per node.
+///
+/// A failed read degrades to no description, since one unreadable property must not fail a whole
+/// snapshot, but it logs first (the treatment [`toggle_pattern`] already gives its own failures).
+/// It matters more here than the `.ok()` on a pattern probe: `CurrentHelpText` answers an *unset*
+/// property with an empty string, so every `Err` is a genuine COM failure — a stale element, a hung
+/// or disconnected provider, a denied cross-integrity read — never "the app set no help text". The
+/// two must not reach the outline looking alike.
+///
+/// `FullDescription` is UIA's other secondary label; `uiautomation` 0.25 exposes no accessor for it
+/// (only `UIProperty::FullDescription` through `get_property_value`), and no probed app was
+/// observed carrying one.
+fn help_text(el: &UIElement, ct_id: u32) -> String {
+    el.get_help_text().unwrap_or_else(|e| {
+        eprintln!(
+            "glass-a11y-windows: HelpText read failed on control type {ct_id} \
+             (HRESULT {:#010x}: {e}); treating the element as having no description",
+            e.code()
+        );
+        String::new()
+    })
 }
 
 /// UIA `BoundingRectangle` (screen) → window-relative `AxRect`, or `None` for zero-area.

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 
 use glass_core::{
     Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget, AxTree, GlassError, Result,
-    TruncationLimit, WalkBudget,
+    TruncationLimit, WalkBudget, normalize_description,
 };
 use uiautomation::patterns::{
     UIExpandCollapsePattern, UIInvokePattern, UIRangeValuePattern, UISelectionItemPattern,
@@ -149,6 +149,12 @@ fn walk(
         .map(str::to_string)
         .unwrap_or_else(|| format!("UIA:{ct_id}"));
     let name = nonempty(el.get_name().unwrap_or_default());
+    // UIA's secondary label is `HelpText`, the tooltip — one more cross-process round-trip per
+    // node, which the probe harness's cost block measures. `FullDescription` is UIA's other
+    // secondary label; `uiautomation` 0.25 exposes no accessor for it (only
+    // `UIProperty::FullDescription` through `get_property_value`).
+    let description =
+        normalize_description(&el.get_help_text().unwrap_or_default(), name.as_deref());
     let bounds = window_relative_bounds(el, origin);
     let (facts, value) = gather(el, ct_id);
     let states = crate::mapping::map_states(&facts);
@@ -192,9 +198,7 @@ fn walk(
         role: crate::mapping::map_role(ct_id, facts.checkable),
         raw_role,
         name,
-        // This reader reads neither of UIA's secondary labels yet: `HelpText` (the tooltip)
-        // and `FullDescription`.
-        description: None,
+        description,
         value,
         states,
         bounds,

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -314,8 +314,7 @@ fn gather(el: &UIElement, ct_id: u32) -> (crate::mapping::StateFacts, Option<Str
 /// snapshot, but it logs first (the treatment [`toggle_pattern`] already gives its own failures).
 /// It matters more here than the `.ok()` on a pattern probe: `CurrentHelpText` answers an *unset*
 /// property with an empty string, so every `Err` is a genuine COM failure — a stale element, a hung
-/// or disconnected provider, a denied cross-integrity read — never "the app set no help text". The
-/// two must not reach the outline looking alike.
+/// or disconnected provider, a denied cross-integrity read — never "the app set no help text".
 ///
 /// `FullDescription` is UIA's other secondary label; `uiautomation` 0.25 exposes no accessor for it
 /// (only `UIProperty::FullDescription` through `get_property_value`), and no probed app was

--- a/crates/glass-macos/fixture/a11y_fixture.swift
+++ b/crates/glass-macos/fixture/a11y_fixture.swift
@@ -1,7 +1,7 @@
 // a11y_fixture.swift — glass-macos accessibility-tree test fixture.
 //
-// A minimal Cocoa app whose window exposes a real NSAccessibility tree with four named
-// controls, for the macOS a11y reader's on-box tests to drive by name:
+// A minimal Cocoa app whose window exposes a real NSAccessibility tree with five controls, for
+// the macOS a11y reader's on-box tests to drive by name:
 //
 //   - an NSButton titled "Save" — prints `SAVE_CLICKED` to stdout (flushed) when its action
 //     fires, so both the bounds-agreement test (a real pointer click) and the native-invoke
@@ -16,13 +16,16 @@
 //     action, so the native-invoke test can confirm it is rejected as `AxActionUnavailable`
 //     rather than silently doing nothing.
 //
-// Each control sets an explicit `accessibilityLabel` so the reader can find it by name
-// regardless of its visible title/string value. Three also set `accessibilityHelp` (or a title
-// distinct from the label) to pin the reader's secondary-label rule: "Save" carries help text
-// distinct from its name, "Status" carries help identical to its name (which must be dropped, not
-// printed twice), and "Bold" carries neither help nor a matching title. Sibling to `quadrants.swift` (the
-// capture/input fixture) in this same directory; kept separate because it exercises a
-// different concern (accessibility-tree contents, not pixels or raw input events).
+// Every control sets an explicit `accessibilityLabel` so the reader can find it by name
+// regardless of its visible title/string value — with one deliberate exception: "Bold"'s label
+// differs from its title, so the reader names it from `AXTitle` and the label becomes its
+// description. That, plus two `accessibilityHelp` settings, is what pins the reader's
+// secondary-label rule: "Save" carries help text distinct from its name, and "Status" carries help
+// identical to its name, which must be dropped rather than printed twice.
+//
+// Sibling to `quadrants.swift` (the capture/input fixture) in this same directory; kept separate
+// because it exercises a different concern (accessibility-tree contents, not pixels or raw input
+// events).
 //
 // Build: swiftc -parse-as-library a11y_fixture.swift -o a11y_fixture
 //   (`-parse-as-library` is required because this file uses a top-level `@main` type

--- a/crates/glass-macos/fixture/a11y_fixture.swift
+++ b/crates/glass-macos/fixture/a11y_fixture.swift
@@ -17,11 +17,10 @@
 //     rather than silently doing nothing.
 //
 // Every control sets an explicit `accessibilityLabel` so the reader can find it by name
-// regardless of its visible title/string value — with one deliberate exception: "Bold"'s label
-// differs from its title, so the reader names it from `AXTitle` and the label becomes its
-// description. That, plus two `accessibilityHelp` settings, is what pins the reader's
-// secondary-label rule: "Save" carries help text distinct from its name, and "Status" carries help
-// identical to its name, which must be dropped rather than printed twice.
+// regardless of its visible title/string value — except "Bold", named by its title as above. That
+// exception plus two `accessibilityHelp` settings are what pin the reader's secondary-label rule:
+// "Save" carries help distinct from its name, and "Status" carries help identical to its name,
+// which must be dropped rather than printed twice.
 //
 // Sibling to `quadrants.swift` (the capture/input fixture) in this same directory; kept separate
 // because it exercises a different concern (accessibility-tree contents, not pixels or raw input

--- a/crates/glass-macos/fixture/a11y_fixture.swift
+++ b/crates/glass-macos/fixture/a11y_fixture.swift
@@ -9,13 +9,18 @@
 //     NSButton runs the identical target/action as a real click, so one marker line proves
 //     both paths reach the real handler — no separate "invoke" marker needed.
 //   - an NSButton checkbox labelled "Enable".
+//   - an NSButton titled "Bold" whose accessibility label differs from its title, so the
+//     reader's `AXTitle` names it and its `AXDescription` becomes its description.
 //   - an editable NSTextField labelled "Note", initial value "hello".
 //   - a non-editable, non-interactive NSTextField label ("Status") — exposes no AXPress
 //     action, so the native-invoke test can confirm it is rejected as `AxActionUnavailable`
 //     rather than silently doing nothing.
 //
 // Each control sets an explicit `accessibilityLabel` so the reader can find it by name
-// regardless of its visible title/string value. Sibling to `quadrants.swift` (the
+// regardless of its visible title/string value. Three also set `accessibilityHelp` (or a title
+// distinct from the label) to pin the reader's secondary-label rule: "Save" carries help text
+// distinct from its name, "Status" carries help identical to its name (which must be dropped, not
+// printed twice), and "Bold" carries neither help nor a matching title. Sibling to `quadrants.swift` (the
 // capture/input fixture) in this same directory; kept separate because it exercises a
 // different concern (accessibility-tree contents, not pixels or raw input events).
 //
@@ -35,10 +40,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let save = NSButton(title: "Save", target: self, action: #selector(onSave))
         save.frame = NSRect(x: 20, y: 140, width: 80, height: 32)
         save.setAccessibilityLabel("Save")
+        // Distinct from the label, so the reader's `description` must come from `AXHelp`
+        // specifically — a count of described nodes cannot say which attribute produced them.
+        save.setAccessibilityHelp("Saves and closes the sheet")
 
         let enable = NSButton(checkboxWithTitle: "Enable", target: nil, action: nil)
         enable.frame = NSRect(x: 20, y: 100, width: 120, height: 24)
         enable.setAccessibilityLabel("Enable")
+
+        // Title and label deliberately differ and no help text is set, so `AXTitle` supplies the
+        // name and `AXDescription` is left to be the description — the reader's titled branch,
+        // which no other control here exercises.
+        let bold = NSButton(title: "Bold", target: nil, action: nil)
+        bold.frame = NSRect(x: 160, y: 140, width: 80, height: 32)
+        bold.setAccessibilityLabel("Bold text style")
 
         let note = NSTextField(string: "hello")
         note.frame = NSRect(x: 20, y: 60, width: 200, height: 24)
@@ -51,10 +66,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let status = NSTextField(labelWithString: "ready")
         status.frame = NSRect(x: 20, y: 20, width: 120, height: 20)
         status.setAccessibilityLabel("Status")
+        // Help text identical to the label, so the reader must drop it rather than print the
+        // same string twice on one outline line.
+        status.setAccessibilityHelp("Status")
 
         let contentView = NSView(frame: window.contentView!.bounds)
         contentView.addSubview(save)
         contentView.addSubview(enable)
+        contentView.addSubview(bold)
         contentView.addSubview(note)
         contentView.addSubview(status)
         window.contentView = contentView

--- a/crates/glass-macos/tests/a11y.rs
+++ b/crates/glass-macos/tests/a11y.rs
@@ -2,8 +2,11 @@
 //! the whole `glass-a11y-macos` snapshot + set_value + invoke path (`MacosPlatform::start_app`
 //! -> `AxContext` -> `MacosA11y::snapshot`/`set_value`/`invoke` -> AXUIElement walk ->
 //! `AxTree`), driven against the `a11y_fixture` Cocoa app (a "Save" button, an "Enable"
-//! checkbox, an editable "Note" field — labeled "Note" via `setAccessibilityLabel`, holding
-//! the content "hello" — and a non-interactive "Status" label). After the snapshot checks,
+//! checkbox, a "Bold" button whose accessibility label differs from its title, an editable
+//! "Note" field — labeled "Note" via `setAccessibilityLabel`, holding the content "hello" —
+//! and a non-interactive "Status" label). Four of them carry a deliberate `AXHelp`/`AXTitle`
+//! arrangement, so the snapshot checks pin which attribute the reader's `description` comes
+//! from. After the snapshot checks,
 //! it round-trips `set_value` on the "Note" field ("hello" -> "world") and confirms the
 //! non-editable "Save" button rejects a write with `AxElementNotEditable`.
 //!
@@ -68,7 +71,7 @@ mod macos_main {
     /// reader before we drain.
     const CLICK_SETTLE: Duration = Duration::from_millis(400);
 
-    /// The four elements the fixture exposes, asserted as substrings of the tree outline.
+    /// Four of the fixture's element lines, asserted as substrings of the tree outline.
     /// `to_outline` renders each node as `#<id> <Role> "<name>" ...`, rendering `name` and never
     /// `value` — so the editable field's stable label (`setAccessibilityLabel("Note")`,
     /// surfaced as `AXDescription`) is what appears here, not its volatile content ("hello").

--- a/crates/glass-macos/tests/a11y.rs
+++ b/crates/glass-macos/tests/a11y.rs
@@ -239,6 +239,31 @@ mod macos_main {
             ));
         }
 
+        // The secondary label, one case per rule. The census a probe run prints can only say that
+        // *something* arrived; these say which attribute produced it, and that the two cases which
+        // must produce nothing do.
+        for (name, want) in [
+            // `AXHelp`, distinct from the name.
+            ("Save", Some("Saves and closes the sheet")),
+            // `AXTitle` named it, so `AXDescription` is free to describe it.
+            ("Bold", Some("Bold text style")),
+            // Labelled but untitled: `AXDescription` IS the name, and must not be repeated.
+            ("Note", None),
+            // `AXHelp` identical to the name: dropped, not printed twice.
+            ("Status", None),
+        ] {
+            let node = match find_by_name(&tree.root, name) {
+                Some(n) => n,
+                None => return Err(format!("no {name:?} node in tree:\n{outline}")),
+            };
+            if node.description.as_deref() != want {
+                return Err(format!(
+                    "{name:?} description = {:?}, want {want:?}:\n{outline}",
+                    node.description
+                ));
+            }
+        }
+
         // The outline only proves `name`; confirm `value` is read separately, straight off
         // the field's content — not folded into `name` (that was the bug this test guards).
         let field = match find_text_field(&tree.root) {

--- a/crates/glass-macos/tests/role_probe.rs
+++ b/crates/glass-macos/tests/role_probe.rs
@@ -142,10 +142,9 @@ mod macos_main {
     ///
     /// Repeating inside one launch leaves app *startup* out of the number, but each sample is
     /// still a whole `snapshot` call — the Accessibility-grant gate and the `AXWindows` resolve,
-    /// and then the walk. So the absolute figure is not walk time, and only the *difference*
-    /// between two runs of this block is attributable to a change in what the walk reads per node
-    /// (glass's `description`). A per-node figure is that difference over the node count in the
-    /// histogram header above, never the mean over it.
+    /// then the walk — so only the *difference* between two runs of this block is attributable to a
+    /// change in what the walk reads per node (glass's `description`). A per-node figure is that
+    /// difference over the node count in the histogram header above, never the mean over it.
     ///
     /// Never asserted and never fatal: a latency bound would flake on a loaded box, and a snapshot
     /// that fails here must not cost this app its role-parity check or the later apps their runs.

--- a/crates/glass-macos/tests/role_probe.rs
+++ b/crates/glass-macos/tests/role_probe.rs
@@ -39,7 +39,7 @@ fn main() {
 
 #[cfg(target_os = "macos")]
 mod macos_main {
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     use glass_a11y_macos::MacosA11y;
     use glass_core::{
@@ -133,6 +133,44 @@ mod macos_main {
         }
     }
 
+    /// Snapshot repeats behind one launch in [`print_snapshot_cost`]. Enough samples that one
+    /// slow outlier doesn't set the mean, few enough that several probed apps stay inside the
+    /// granted run (mirrors the Windows probe's constant of the same name).
+    const COST_REPEATS: usize = 10;
+
+    /// Re-snapshot the already-launched app [`COST_REPEATS`] times and print each walk's
+    /// wall-clock. Repeating inside one launch leaves app startup out of the number, so what
+    /// remains is the walk — the cost a per-node read (glass's `description`) adds to. Printed,
+    /// never asserted: a latency bound would flake on a loaded box.
+    fn print_snapshot_cost(
+        label: &str,
+        a11y: &mut MacosA11y,
+        ctx: &AxContext,
+    ) -> Result<(), String> {
+        let mut samples = Vec::with_capacity(COST_REPEATS);
+        for _ in 0..COST_REPEATS {
+            let started = Instant::now();
+            let tree = a11y
+                .snapshot(ctx)
+                .map_err(|e| format!("{label}: snapshot failed during the cost repeats: {e}"))?;
+            samples.push(started.elapsed().as_secs_f64() * 1000.0);
+            // The tree is read, not dropped unexamined, so no future laziness can move walk
+            // work out from under the timer.
+            std::hint::black_box(tree.root.children.len());
+        }
+        let mean = samples.iter().sum::<f64>() / samples.len() as f64;
+        println!(
+            "  snapshot cost over {} repeats (mean {mean:.0}ms): {}",
+            samples.len(),
+            samples
+                .iter()
+                .map(|ms| format!("{ms:.0}ms"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        Ok(())
+    }
+
     /// Run `body`, then always call `platform.stop_app()` afterward regardless of whether
     /// `body` succeeded — mirrors `tests/bundle_launch.rs`'s identically-named helper.
     fn with_stop_app<T>(
@@ -213,6 +251,7 @@ mod macos_main {
                 "{}",
                 description_census_report(run0, &tree, DescriptionSourcing::Unsourced)
             );
+            print_snapshot_cost(run0, &mut a11y, &ctx)?;
             // Checked after the histogram is printed, so the evidence that explains a failure
             // is already in the output when the failure is reported.
             let violations = mapped_token_violations(run0, &tree);

--- a/crates/glass-macos/tests/role_probe.rs
+++ b/crates/glass-macos/tests/role_probe.rs
@@ -144,8 +144,8 @@ mod macos_main {
     /// still a whole `snapshot` call — the Accessibility-grant gate and the `AXWindows` resolve,
     /// and then the walk. So the absolute figure is not walk time, and only the *difference*
     /// between two runs of this block is attributable to a change in what the walk reads per node
-    /// (glass's `description`). To get a per-node figure, divide that difference by the node count
-    /// in the histogram header above; dividing the mean itself by it means nothing.
+    /// (glass's `description`). A per-node figure is that difference over the node count in the
+    /// histogram header above, never the mean over it.
     ///
     /// Never asserted and never fatal: a latency bound would flake on a loaded box, and a snapshot
     /// that fails here must not cost this app its role-parity check or the later apps their runs.

--- a/crates/glass-macos/tests/role_probe.rs
+++ b/crates/glass-macos/tests/role_probe.rs
@@ -144,8 +144,8 @@ mod macos_main {
     /// still a whole `snapshot` call — the Accessibility-grant gate and the `AXWindows` resolve,
     /// and then the walk. So the absolute figure is not walk time, and only the *difference*
     /// between two runs of this block is attributable to a change in what the walk reads per node
-    /// (glass's `description`). Divide by the node count in the histogram header above, not into
-    /// the mean.
+    /// (glass's `description`). To get a per-node figure, divide that difference by the node count
+    /// in the histogram header above; dividing the mean itself by it means nothing.
     ///
     /// Never asserted and never fatal: a latency bound would flake on a loaded box, and a snapshot
     /// that fails here must not cost this app its role-parity check or the later apps their runs.
@@ -223,6 +223,9 @@ mod macos_main {
     /// that one check the histogram's contents are never asserted; reading the printed output
     /// to decide which `Gap` cell in `glass_core::role_support::ROLE_SUPPORT` a real native
     /// token now justifies filling is the human's job.
+    /// `Ok` carries how many of this app's nodes the reader gave a description — an observation
+    /// per app (an app with no `AXHelp` is a legitimate zero), summed by [`run`] so a whole run
+    /// of zeros can be challenged there.
     fn probe_one(run0: &str) -> Result<usize, String> {
         println!("\n--- launching {run0} ---");
         let mut platform =

--- a/crates/glass-macos/tests/role_probe.rs
+++ b/crates/glass-macos/tests/role_probe.rs
@@ -245,11 +245,11 @@ mod macos_main {
             // of how big the tree actually was.
             tree.assign_ids();
             print_role_histogram(run0, &tree);
-            // `Unsourced`: this reader leaves `description: None`, so the count is 0 for
-            // every app — flip this when it reads AXHelp.
+            // `Sourced`: this reader reads `AXHelp` (else `AXDescription` where `AXTitle` took
+            // the name), so a zero here is a fact about the app.
             print!(
                 "{}",
-                description_census_report(run0, &tree, DescriptionSourcing::Unsourced)
+                description_census_report(run0, &tree, DescriptionSourcing::Sourced)
             );
             print_snapshot_cost(run0, &mut a11y, &ctx)?;
             // Checked after the histogram is printed, so the evidence that explains a failure

--- a/crates/glass-macos/tests/role_probe.rs
+++ b/crates/glass-macos/tests/role_probe.rs
@@ -44,7 +44,7 @@ mod macos_main {
     use glass_a11y_macos::MacosA11y;
     use glass_core::{
         Accessibility, AppSpec, AxContext, AxRole, AxTree, DescriptionSourcing, Platform,
-        SandboxLevel, WalkLimits, description_census_report, role_histogram,
+        SandboxLevel, WalkLimits, description_census, description_census_report, role_histogram,
     };
     use glass_macos::MacosPlatform;
 
@@ -133,42 +133,63 @@ mod macos_main {
         }
     }
 
-    /// Snapshot repeats behind one launch in [`print_snapshot_cost`]. Enough samples that one
-    /// slow outlier doesn't set the mean, few enough that several probed apps stay inside the
-    /// granted run (mirrors the Windows probe's constant of the same name).
+    /// Extra snapshots [`print_snapshot_cost`] takes of each probed app. Every sample is printed
+    /// beside the mean, so a single slow outlier is visible rather than hidden in the average.
     const COST_REPEATS: usize = 10;
 
-    /// Re-snapshot the already-launched app [`COST_REPEATS`] times and print each walk's
-    /// wall-clock. Repeating inside one launch leaves app startup out of the number, so what
-    /// remains is the walk — the cost a per-node read (glass's `description`) adds to. Printed,
-    /// never asserted: a latency bound would flake on a loaded box.
-    fn print_snapshot_cost(
-        label: &str,
-        a11y: &mut MacosA11y,
-        ctx: &AxContext,
-    ) -> Result<(), String> {
+    /// Re-snapshot the already-launched app [`COST_REPEATS`] times and print each sample's
+    /// wall-clock.
+    ///
+    /// Repeating inside one launch leaves app *startup* out of the number, but each sample is
+    /// still a whole `snapshot` call — the Accessibility-grant gate and the `AXWindows` resolve,
+    /// and then the walk. So the absolute figure is not walk time, and only the *difference*
+    /// between two runs of this block is attributable to a change in what the walk reads per node
+    /// (glass's `description`). Divide by the node count in the histogram header above, not into
+    /// the mean.
+    ///
+    /// Never asserted and never fatal: a latency bound would flake on a loaded box, and a snapshot
+    /// that fails here must not cost this app its role-parity check or the later apps their runs.
+    /// Twin of `render_snapshot_cost` in `glass-windows/tests/onbox.rs` — keep the two in step.
+    fn print_snapshot_cost(a11y: &mut MacosA11y, ctx: &AxContext) {
         let mut samples = Vec::with_capacity(COST_REPEATS);
-        for _ in 0..COST_REPEATS {
+        for repeat in 0..COST_REPEATS {
             let started = Instant::now();
-            let tree = a11y
-                .snapshot(ctx)
-                .map_err(|e| format!("{label}: snapshot failed during the cost repeats: {e}"))?;
-            samples.push(started.elapsed().as_secs_f64() * 1000.0);
-            // The tree is read, not dropped unexamined, so no future laziness can move walk
-            // work out from under the timer.
-            std::hint::black_box(tree.root.children.len());
+            match a11y.snapshot(ctx) {
+                Ok(tree) => {
+                    // Inside the timed window, so no future laziness could move walk work out
+                    // from under the timer.
+                    std::hint::black_box(&tree);
+                    samples.push(started.elapsed().as_secs_f64() * 1000.0);
+                }
+                // The samples taken so far go out with the error: "the first one failed" and
+                // "they grew from 40ms to 900ms and then failed" are different findings.
+                Err(e) => {
+                    println!(
+                        "  snapshot cost: repeat {repeat} of {COST_REPEATS} FAILED: {e}\n  \
+                         samples before it: {}",
+                        render_cost_samples(&samples)
+                    );
+                    return;
+                }
+            }
         }
         let mean = samples.iter().sum::<f64>() / samples.len() as f64;
         println!(
-            "  snapshot cost over {} repeats (mean {mean:.0}ms): {}",
-            samples.len(),
-            samples
-                .iter()
-                .map(|ms| format!("{ms:.0}ms"))
-                .collect::<Vec<_>>()
-                .join(", ")
+            "  snapshot cost over {COST_REPEATS} snapshots (mean {mean:.0}ms): {}",
+            render_cost_samples(&samples)
         );
-        Ok(())
+    }
+
+    /// Cost samples as `19ms, 20ms, …`, or `(none)` when the first snapshot failed.
+    fn render_cost_samples(samples: &[f64]) -> String {
+        if samples.is_empty() {
+            return "(none)".to_string();
+        }
+        samples
+            .iter()
+            .map(|ms| format!("{ms:.0}ms"))
+            .collect::<Vec<_>>()
+            .join(", ")
     }
 
     /// Run `body`, then always call `platform.stop_app()` afterward regardless of whether
@@ -202,7 +223,7 @@ mod macos_main {
     /// that one check the histogram's contents are never asserted; reading the printed output
     /// to decide which `Gap` cell in `glass_core::role_support::ROLE_SUPPORT` a real native
     /// token now justifies filling is the human's job.
-    fn probe_one(run0: &str) -> Result<(), String> {
+    fn probe_one(run0: &str) -> Result<usize, String> {
         println!("\n--- launching {run0} ---");
         let mut platform =
             MacosPlatform::new().map_err(|e| format!("MacosPlatform::new() for {run0}: {e}"))?;
@@ -246,17 +267,18 @@ mod macos_main {
             tree.assign_ids();
             print_role_histogram(run0, &tree);
             // `Sourced`: this reader reads `AXHelp` (else `AXDescription` where `AXTitle` took
-            // the name), so a zero here is a fact about the app.
+            // the name), so a zero here is a fact about the app — modulo a read that failed,
+            // which `read_label` logs rather than counting.
             print!(
                 "{}",
                 description_census_report(run0, &tree, DescriptionSourcing::Sourced)
             );
-            print_snapshot_cost(run0, &mut a11y, &ctx)?;
+            print_snapshot_cost(&mut a11y, &ctx);
             // Checked after the histogram is printed, so the evidence that explains a failure
             // is already in the output when the failure is reported.
             let violations = mapped_token_violations(run0, &tree);
             if violations.is_empty() {
-                Ok(())
+                Ok(description_census(&tree).described())
             } else {
                 Err(violations.join("\n"))
             }
@@ -286,14 +308,28 @@ mod macos_main {
         }
 
         let mut failures = Vec::new();
+        let mut described = 0usize;
         for run0 in targets {
-            if let Err(e) = probe_one(run0) {
-                failures.push(e);
+            match probe_one(run0) {
+                Ok(n) => described += n,
+                Err(e) => failures.push(e),
             }
         }
 
         if !failures.is_empty() {
             fail(failures.join("\n\n"));
+        }
+        // Not a failure: which apps carry `AXHelp` is up to the apps, and the caller chooses them
+        // (System Settings really does report none). But the census now prints without a caveat,
+        // so a reader regressed to `description: None` would print a plausible zero for every app
+        // and this probe would pass silently. Say it once, at the end, where a whole-run zero is
+        // visible as one claim rather than N app facts.
+        if described == 0 {
+            println!(
+                "\nNOTE: no app in this run reported a single described node — either these apps \
+                 carry no AXHelp, or the reader stopped sourcing it (see read_label in \
+                 glass-a11y-macos)"
+            );
         }
         println!("\nROLE_PROBE_PASS");
         std::process::exit(0);

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -17,7 +17,7 @@ use glass_core::{
     Accessibility, AppSpec, AxContext, AxNode, AxRole, AxTarget, AxTree, Backend, BaselineStore,
     DescriptionSourcing, Glass, GlassError, KeyEvent, Modifier, MouseButton, Platform,
     PlatformFactory, PointerEvent, WalkLimits, WindowGeometry, WindowHint, WindowOp,
-    description_census_report, role_histogram,
+    description_census, description_census_report, role_histogram,
 };
 use glass_windows::WindowsPlatform;
 
@@ -1135,40 +1135,66 @@ fn render_role_histogram(label: &str, tree: &AxTree) -> String {
     out
 }
 
-/// Snapshot repeats behind one launch in [`render_snapshot_cost`]. Enough samples that one slow
-/// outlier doesn't set the mean, few enough that four probed apps stay inside the on-box run.
+/// Set to any value to make [`probe_role_histogram`] print the snapshot-cost block. Off by
+/// default — see the gate's own comment at the call site.
+const COST_ENV: &str = "GLASS_PROBE_COST";
+
+/// Extra snapshots [`render_snapshot_cost`] takes of each probed app. Every sample is printed
+/// beside the mean, so a single slow outlier is visible rather than hidden in the average.
 const COST_REPEATS: usize = 10;
 
-/// Re-snapshot the already-launched app [`COST_REPEATS`] times and render each walk's wall-clock.
-/// Repeating inside one launch leaves app startup out of the number, so what remains is the walk —
-/// the cost a per-node read (glass's `description`) adds to. Printed, never asserted: a latency
-/// bound would flake on a loaded box.
-fn render_snapshot_cost(label: &str, a11y: &mut WindowsA11y, ctx: &AxContext) -> String {
-    use std::fmt::Write as _;
+/// Re-snapshot the already-launched app [`COST_REPEATS`] times and render each sample's
+/// wall-clock.
+///
+/// Repeating inside one launch leaves app *startup* out of the number, but each sample is still a
+/// whole `snapshot` call — a fresh thread, COM initialization and the window lookup, and then the
+/// walk. So the absolute figure is not walk time, and only the *difference* between two runs of
+/// this block is attributable to a change in what the walk reads per node (glass's `description`).
+/// Divide by the node count in the histogram header above, not into the mean.
+///
+/// Never asserted and never fatal: a latency bound would flake on a loaded box, and a snapshot that
+/// fails here must not strand the window the caller is about to close, cost the later probes their
+/// evidence, or skip the artifacts write. Twin of `print_snapshot_cost` in
+/// `glass-macos/tests/role_probe.rs` — keep the two in step.
+fn render_snapshot_cost(a11y: &mut WindowsA11y, ctx: &AxContext) -> String {
     let mut samples = Vec::with_capacity(COST_REPEATS);
-    for _ in 0..COST_REPEATS {
+    for repeat in 0..COST_REPEATS {
         let started = Instant::now();
-        let tree = a11y
-            .snapshot(ctx)
-            .unwrap_or_else(|e| panic!("{label}: snapshot failed during the cost repeats: {e}"));
-        samples.push(started.elapsed().as_secs_f64() * 1000.0);
-        // The tree is read, not dropped unexamined, so no future laziness can move walk work
-        // out from under the timer.
-        std::hint::black_box(tree.count);
+        match a11y.snapshot(ctx) {
+            Ok(tree) => {
+                // Inside the timed window, so no future laziness could move walk work out from
+                // under the timer.
+                std::hint::black_box(&tree);
+                samples.push(started.elapsed().as_secs_f64() * 1000.0);
+            }
+            // The samples taken so far go out with the error: "the first one failed" and
+            // "they grew from 40ms to 900ms and then failed" are different findings.
+            Err(e) => {
+                return format!(
+                    "  snapshot cost: repeat {repeat} of {COST_REPEATS} FAILED: {e}\n  \
+                     samples before it: {}\n",
+                    render_cost_samples(&samples)
+                );
+            }
+        }
     }
     let mean = samples.iter().sum::<f64>() / samples.len() as f64;
-    let mut out = String::new();
-    let _ = writeln!(
-        out,
-        "  snapshot cost over {} repeats (mean {mean:.0}ms): {}",
-        samples.len(),
-        samples
-            .iter()
-            .map(|ms| format!("{ms:.0}ms"))
-            .collect::<Vec<_>>()
-            .join(", ")
-    );
-    out
+    format!(
+        "  snapshot cost over {COST_REPEATS} snapshots (mean {mean:.0}ms): {}\n",
+        render_cost_samples(&samples)
+    )
+}
+
+/// Cost samples as `19ms, 20ms, …`, or `(none)` when the first snapshot failed.
+fn render_cost_samples(samples: &[f64]) -> String {
+    if samples.is_empty() {
+        return "(none)".to_string();
+    }
+    samples
+        .iter()
+        .map(|ms| format!("{ms:.0}ms"))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// UIA control-type names glass maps to a role, and that a probed app has actually been seen to
@@ -1230,8 +1256,19 @@ fn close_adopted_window(raw: Option<i64>) {
 /// is saved. Beyond that one check the histogram's contents are never asserted; reading it to
 /// decide which `Gap` cell in `glass_core::role_support::ROLE_SUPPORT` a real native token now
 /// justifies filling is the human's job.
+/// What [`probe_role_histogram`] hands back for the caller to assert on once every app has been
+/// probed and the report written.
+struct ProbeOutcome {
+    /// See [`mapped_token_violations`].
+    violations: Vec<String>,
+    /// Nodes whose `description` the reader sourced. Per-app this is an observation, not a
+    /// requirement — an app carrying no tooltips is a legitimate zero — but a run in which NO app
+    /// reports one means the reader stopped sourcing the field, which the caller does assert on.
+    described: usize,
+}
+
 #[must_use]
-fn probe_role_histogram(label: &str, spec: &AppSpec, report: &mut String) -> Vec<String> {
+fn probe_role_histogram(label: &str, spec: &AppSpec, report: &mut String) -> ProbeOutcome {
     let mut p = WindowsPlatform::new().expect("WindowsPlatform::new");
     let geo = p
         .start_app(spec)
@@ -1254,14 +1291,21 @@ fn probe_role_histogram(label: &str, spec: &AppSpec, report: &mut String) -> Vec
     print!("{block}");
     report.push_str(&block);
 
-    // `Sourced`: this reader reads UIA `HelpText`, so a zero here is a fact about the app.
+    // `Sourced`: this reader reads UIA `HelpText`, so a zero here is a fact about the app —
+    // modulo a read that failed, which `help_text` logs rather than counting.
     let census_block = description_census_report(label, &tree, DescriptionSourcing::Sourced);
     print!("{census_block}");
     report.push_str(&census_block);
+    let described = description_census(&tree).described();
 
-    let cost_block = render_snapshot_cost(label, &mut a11y, &ctx);
-    print!("{cost_block}");
-    report.push_str(&cost_block);
+    // Off by default: the cost block adds `COST_REPEATS` full-tree walks per app to a run the
+    // bridge caps at 300s, and the number it produces answers a question (what does a per-node
+    // read cost?) that is asked when something changes, not on every evidence run.
+    if std::env::var_os(COST_ENV).is_some() {
+        let cost_block = render_snapshot_cost(&mut a11y, &ctx);
+        print!("{cost_block}");
+        report.push_str(&cost_block);
+    }
 
     // Collect toggle-capable non-checkbox/radio nodes (evidence for ToggleButton row parity).
     let mut candidates = Vec::new();
@@ -1306,7 +1350,10 @@ fn probe_role_histogram(label: &str, spec: &AppSpec, report: &mut String) -> Vec
         print!("{line}");
         report.push_str(&line);
     }
-    violations
+    ProbeOutcome {
+        violations,
+        described,
+    }
 }
 
 /// The evidence step behind the Windows half of the accessibility role-parity work: launch a
@@ -1362,26 +1409,17 @@ fn onbox_role_histogram_probe() {
 
     let mut report = String::new();
     let mut violations = Vec::new();
-    violations.extend(probe_role_histogram(
-        "charmap.exe (Character Map)",
-        &charmap_spec(),
-        &mut report,
-    ));
-    violations.extend(probe_role_histogram(
-        "notepad.exe (Notepad)",
-        &notepad_spec(),
-        &mut report,
-    ));
-    violations.extend(probe_role_histogram(
-        "taskmgr.exe (Task Manager)",
-        &taskmgr_spec(),
-        &mut report,
-    ));
-    violations.extend(probe_role_histogram(
-        "explorer.exe (File Explorer)",
-        &explorer_spec(),
-        &mut report,
-    ));
+    let mut described = 0usize;
+    for (label, spec) in [
+        ("charmap.exe (Character Map)", charmap_spec()),
+        ("notepad.exe (Notepad)", notepad_spec()),
+        ("taskmgr.exe (Task Manager)", taskmgr_spec()),
+        ("explorer.exe (File Explorer)", explorer_spec()),
+    ] {
+        let outcome = probe_role_histogram(label, &spec, &mut report);
+        violations.extend(outcome.violations);
+        described += outcome.described;
+    }
     save_report("role-histogram-windows.txt", &report);
     // Fail last, after every app has been probed and the artifacts file written: the histograms
     // are the evidence a violation has to be read against.
@@ -1389,5 +1427,15 @@ fn onbox_role_histogram_probe() {
         violations.is_empty(),
         "a token glass maps came back unmapped:\n{}",
         violations.join("\n")
+    );
+    // The census prints without a caveat now that this reader sources the field, so a reader
+    // regressed to `description: None` would print a plausible zero for every app and pass. Some
+    // app in this set must report one: File Explorer's toolbar buttons and Task Manager's column
+    // headers both carry HelpText. Deliberately NOT per-app — an app with no tooltips is a real
+    // observation, not a failure.
+    assert!(
+        described >= 1,
+        "no probed app reported a single described node: either every app lost its HelpText, or \
+         the reader stopped sourcing it"
     );
 }

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -10,7 +10,7 @@
 #![allow(unsafe_code)]
 
 use std::sync::Mutex;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use glass_a11y_windows::WindowsA11y;
 use glass_core::{
@@ -1135,6 +1135,42 @@ fn render_role_histogram(label: &str, tree: &AxTree) -> String {
     out
 }
 
+/// Snapshot repeats behind one launch in [`render_snapshot_cost`]. Enough samples that one slow
+/// outlier doesn't set the mean, few enough that four probed apps stay inside the on-box run.
+const COST_REPEATS: usize = 10;
+
+/// Re-snapshot the already-launched app [`COST_REPEATS`] times and render each walk's wall-clock.
+/// Repeating inside one launch leaves app startup out of the number, so what remains is the walk —
+/// the cost a per-node read (glass's `description`) adds to. Printed, never asserted: a latency
+/// bound would flake on a loaded box.
+fn render_snapshot_cost(label: &str, a11y: &mut WindowsA11y, ctx: &AxContext) -> String {
+    use std::fmt::Write as _;
+    let mut samples = Vec::with_capacity(COST_REPEATS);
+    for _ in 0..COST_REPEATS {
+        let started = Instant::now();
+        let tree = a11y
+            .snapshot(ctx)
+            .unwrap_or_else(|e| panic!("{label}: snapshot failed during the cost repeats: {e}"));
+        samples.push(started.elapsed().as_secs_f64() * 1000.0);
+        // The tree is read, not dropped unexamined, so no future laziness can move walk work
+        // out from under the timer.
+        std::hint::black_box(tree.count);
+    }
+    let mean = samples.iter().sum::<f64>() / samples.len() as f64;
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "  snapshot cost over {} repeats (mean {mean:.0}ms): {}",
+        samples.len(),
+        samples
+            .iter()
+            .map(|ms| format!("{ms:.0}ms"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    out
+}
+
 /// UIA control-type names glass maps to a role, and that a probed app has actually been seen to
 /// emit. A histogram bucket carrying one of these must not come back [`AxRole::Other`]: the
 /// token reached the reader, so a mapped role is the only correct outcome, and `Other` would
@@ -1223,6 +1259,10 @@ fn probe_role_histogram(label: &str, spec: &AppSpec, report: &mut String) -> Vec
     let census_block = description_census_report(label, &tree, DescriptionSourcing::Unsourced);
     print!("{census_block}");
     report.push_str(&census_block);
+
+    let cost_block = render_snapshot_cost(label, &mut a11y, &ctx);
+    print!("{cost_block}");
+    report.push_str(&cost_block);
 
     // Collect toggle-capable non-checkbox/radio nodes (evidence for ToggleButton row parity).
     let mut candidates = Vec::new();

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -1254,9 +1254,8 @@ fn probe_role_histogram(label: &str, spec: &AppSpec, report: &mut String) -> Vec
     print!("{block}");
     report.push_str(&block);
 
-    // `Unsourced`: this reader leaves `description: None`, so the count is 0 for every app —
-    // flip this when it reads HelpText/FullDescription.
-    let census_block = description_census_report(label, &tree, DescriptionSourcing::Unsourced);
+    // `Sourced`: this reader reads UIA `HelpText`, so a zero here is a fact about the app.
+    let census_block = description_census_report(label, &tree, DescriptionSourcing::Sourced);
     print!("{census_block}");
     report.push_str(&census_block);
 

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -1146,8 +1146,8 @@ const COST_REPEATS: usize = 10;
 /// whole `snapshot` call — a fresh thread, COM initialization and the window lookup, and then the
 /// walk. So the absolute figure is not walk time, and only the *difference* between two runs of
 /// this block is attributable to a change in what the walk reads per node (glass's `description`).
-/// To get a per-node figure, divide that difference by the node count in the histogram header
-/// above; dividing the mean itself by it means nothing.
+/// A per-node figure is that difference over the node count in the histogram header above, never
+/// the mean over it.
 ///
 /// Never asserted and never fatal: a latency bound would flake on a loaded box, and a snapshot that
 /// fails here must not strand the window the caller is about to close, cost the later probes their

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -1146,7 +1146,8 @@ const COST_REPEATS: usize = 10;
 /// whole `snapshot` call — a fresh thread, COM initialization and the window lookup, and then the
 /// walk. So the absolute figure is not walk time, and only the *difference* between two runs of
 /// this block is attributable to a change in what the walk reads per node (glass's `description`).
-/// Divide by the node count in the histogram header above, not into the mean.
+/// To get a per-node figure, divide that difference by the node count in the histogram header
+/// above; dividing the mean itself by it means nothing.
 ///
 /// Never asserted and never fatal: a latency bound would flake on a loaded box, and a snapshot that
 /// fails here must not strand the window the caller is about to close, cost the later probes their
@@ -1243,15 +1244,6 @@ fn close_adopted_window(raw: Option<i64>) {
     }
 }
 
-/// Launch `spec`, snapshot its accessibility tree with the node cap lifted (so a big app's
-/// tree is never truncated mid-probe — depth/siblings keep their generous structural-rail
-/// defaults regardless; see [`WalkLimits::from_max_nodes`]), print its role histogram, append
-/// it to `report`, then stop the app. Panics — failing the test — only when the app can't be
-/// launched or a snapshot can't be taken at all: a real breakage, never merely an unexpected
-/// role. Returns any [`mapped_token_violations`], which the caller fails on *after* the report
-/// is saved. Beyond that one check the histogram's contents are never asserted; reading it to
-/// decide which `Gap` cell in `glass_core::role_support::ROLE_SUPPORT` a real native token now
-/// justifies filling is the human's job.
 /// What [`probe_role_histogram`] hands back for the caller to assert on once every app has been
 /// probed and the report written.
 struct ProbeOutcome {
@@ -1263,6 +1255,16 @@ struct ProbeOutcome {
     described: usize,
 }
 
+/// Launch `spec`, snapshot its accessibility tree with the node cap lifted (so a big app's
+/// tree is never truncated mid-probe — depth/siblings keep their generous structural-rail
+/// defaults regardless; see [`WalkLimits::from_max_nodes`]), print its role histogram, append
+/// it to `report`, then stop the app. Panics — failing the test — only when the app can't be
+/// launched or its FIRST snapshot can't be taken at all: a real breakage, never merely an
+/// unexpected role. A snapshot that fails later, inside [`render_snapshot_cost`]'s repeats, is
+/// reported in the block and not fatal. Returns the [`ProbeOutcome`] the caller asserts on *after*
+/// the report is saved. Beyond those checks the histogram's contents are never asserted; reading it
+/// to decide which `Gap` cell in `glass_core::role_support::ROLE_SUPPORT` a real native token now
+/// justifies filling is the human's job.
 #[must_use]
 fn probe_role_histogram(label: &str, spec: &AppSpec, report: &mut String) -> ProbeOutcome {
     let mut p = WindowsPlatform::new().expect("WindowsPlatform::new");

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -1143,11 +1143,10 @@ const COST_REPEATS: usize = 10;
 /// wall-clock.
 ///
 /// Repeating inside one launch leaves app *startup* out of the number, but each sample is still a
-/// whole `snapshot` call — a fresh thread, COM initialization and the window lookup, and then the
-/// walk. So the absolute figure is not walk time, and only the *difference* between two runs of
-/// this block is attributable to a change in what the walk reads per node (glass's `description`).
-/// A per-node figure is that difference over the node count in the histogram header above, never
-/// the mean over it.
+/// whole `snapshot` call — a fresh thread, COM initialization and the window lookup, then the walk —
+/// so only the *difference* between two runs of this block is attributable to a change in what the
+/// walk reads per node (glass's `description`). A per-node figure is that difference over the node
+/// count in the histogram header above, never the mean over it.
 ///
 /// Never asserted and never fatal: a latency bound would flake on a loaded box, and a snapshot that
 /// fails here must not strand the window the caller is about to close, cost the later probes their

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -1135,10 +1135,6 @@ fn render_role_histogram(label: &str, tree: &AxTree) -> String {
     out
 }
 
-/// Set to any value to make [`probe_role_histogram`] print the snapshot-cost block. Off by
-/// default — see the gate's own comment at the call site.
-const COST_ENV: &str = "GLASS_PROBE_COST";
-
 /// Extra snapshots [`render_snapshot_cost`] takes of each probed app. Every sample is printed
 /// beside the mean, so a single slow outlier is visible rather than hidden in the average.
 const COST_REPEATS: usize = 10;
@@ -1298,14 +1294,12 @@ fn probe_role_histogram(label: &str, spec: &AppSpec, report: &mut String) -> Pro
     report.push_str(&census_block);
     let described = description_census(&tree).described();
 
-    // Off by default: the cost block adds `COST_REPEATS` full-tree walks per app to a run the
-    // bridge caps at 300s, and the number it produces answers a question (what does a per-node
-    // read cost?) that is asked when something changes, not on every evidence run.
-    if std::env::var_os(COST_ENV).is_some() {
-        let cost_block = render_snapshot_cost(&mut a11y, &ctx);
-        print!("{cost_block}");
-        report.push_str(&cost_block);
-    }
+    // `COST_REPEATS` extra walks per app cost ~3s across this probe's four apps (measured on
+    // box), well inside the 300s the bridge allows a run, so the block is unconditional rather
+    // than behind a flag the bridge has no way to pass through.
+    let cost_block = render_snapshot_cost(&mut a11y, &ctx);
+    print!("{cost_block}");
+    report.push_str(&cost_block);
 
     // Collect toggle-capable non-checkbox/radio nodes (evidence for ToggleButton row parity).
     let mut candidates = Vec::new();

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -458,10 +458,11 @@ rides as an untrusted sibling text block, one line per element:
 `#<id> <Role> "<name>" desc="<description>" (x,y wxh) [states]`; pass an `#id` to
 `glass_click_element`. `desc="…"` carries a secondary label the platform exposes separately from
 the name — help or tooltip text, or the human-readable label where the name is a
-developer-assigned id. It appears only where glass's reader sources that label, which today is the
-AT-SPI (Linux) reader alone; the UI Automation, AX, `uiautomator` and `idb` readers do not read
-their platform's secondary label yet, so `desc` never appears there no matter what the app
-exposes. It is also omitted when the description duplicates the name. **`desc` is display-only:
+developer-assigned id. It appears only where glass's reader sources that label: the AT-SPI (Linux)
+reader reads AT-SPI `Description`, the UI Automation (Windows) reader reads `HelpText`, and the AX
+(macOS) reader reads `AXHelp` (plus `AXDescription` where `AXTitle` already supplied the name). The
+`uiautomator` (Android) and `idb` (iOS) readers do not read their platform's secondary label yet, so
+`desc` never appears there no matter what the app exposes. It is also omitted when the description duplicates the name. **`desc` is display-only:
 `glass_wait_for_element` and `glass_scroll_to_element` select on `name`, never on the
 description.** An element whose platform role glass
 has no mapping for renders as `Other(<native token>)` — e.g.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -460,12 +460,12 @@ rides as an untrusted sibling text block, one line per element:
 the name — help or tooltip text, or the human-readable label where the name is a
 developer-assigned id. It appears only where glass's reader sources that label: the AT-SPI (Linux)
 reader reads AT-SPI `Description`, the UI Automation (Windows) reader reads `HelpText`, and the AX
-(macOS) reader reads `AXHelp` (plus `AXDescription` where `AXTitle` already supplied the name). The
-`uiautomator` (Android) and `idb` (iOS) readers do not read their platform's secondary label yet, so
-`desc` never appears there no matter what the app exposes. It is also omitted when the description duplicates the name. **`desc` is display-only:
-`glass_wait_for_element` and `glass_scroll_to_element` select on `name`, never on the
-description.** An element whose platform role glass
-has no mapping for renders as `Other(<native token>)` — e.g.
+(macOS) reader reads `AXHelp`, else `AXDescription` where `AXTitle` already supplied the name. The
+Android readers and the `idb` (iOS) reader do not read their platform's secondary label yet, so
+`desc` never appears there no matter what the app exposes. It is also omitted when the description
+duplicates the name. **`desc` is display-only: `glass_wait_for_element` and
+`glass_scroll_to_element` select on `name`, never on the description.** An element whose platform
+role glass has no mapping for renders as `Other(<native token>)` — e.g.
 `#4 Other(AXDisclosureTriangle) "Details" [enabled]` — so the platform's own token is still
 visible; a bare `Other` means the platform named no token at all.
 


### PR DESCRIPTION
PR2 of the `AxNode.description` arc (PR1 was #259): the Windows and macOS accessibility readers
now source the platform's secondary label, so an icon-only control reaches an agent as something
other than a role and a rectangle.

- **Windows** reads UIA `HelpText`.
- **macOS** reads `AXHelp`, else `AXDescription` where `AXTitle` already supplied the name —
  because `AXDescription` *is* the name otherwise, and the shared normalizer would drop it as a
  duplicate. `AXDescription` still costs at most one read per node.

`name` is unchanged on every node on both platforms, which matters more than it looks: `name` is
half the `AxTarget` fingerprint `set_value` re-walks against, and every `role:`/`name:` selector
keys on it. `find_nth` is untouched on both readers, and `description` stays out of the fingerprint
and the selectors — it is display-only, as the tool description says.

Android and iOS remain unsourced; that is PR3.

## Probe evidence

Each arm ships only for a token a probe actually observed, on real hardware.

**Windows** (`onbox_role_histogram_probe`, four stock apps):

| app | described | sample |
|---|---|---|
| File Explorer | 7 / 133 | `Button name="Copy" desc="Copy the selected items to the Clipboard."` |
| Task Manager | 2 / 66 | `HeaderItem name="CPU 0%. Press Enter to change sorting." desc="Total processor utilization across all cores"` |
| charmap | 0 / 26 | observed negative |
| Notepad | 0 / 36 | observed negative |

`FullDescription` — UIA's other secondary label — stays unwired: `HelpText` answered the question,
and `uiautomation` 0.25 exposes no accessor for it anyway.

**macOS** (`role_probe`, granted run):

| app | described | sample |
|---|---|---|
| TextEdit | 16 / 46 | `AXCheckBox name="bold" desc="Bold text"`, and the motivating case — `AXButton name=None desc="this button also has an action to zoom the window"` |
| Calculator | 2 / 35 | `AXButton name="Change Sign" desc="Change sign of a value"` |
| System Settings | 0 / 130 | observed negative (SwiftUI exposes no `AXHelp` there) |

## Cost, measured not predicted

Interleaved A/B — the two builds alternated, never blocked, because a blocked 3-vs-3 design produced
a false "within noise" conclusion in PR1. Each figure is a whole `snapshot` call, so only the
*difference* is attributable to the new per-node read.

**Windows**, n=30 per side per app, three alternating rounds:

| app (nodes) | before | after | delta | Welch t |
|---|---|---|---|---|
| charmap (26) | 18.7ms sd 0.6 | 19.7ms sd 0.7 | +0.9ms (+5.0%) | 5.80 |
| Notepad (36) | 27.2ms sd 1.3 | 28.2ms sd 1.1 | +1.1ms (+3.9%) | 3.44 |
| Task Manager (66) | 67.7ms sd 31.1 | 71.5ms sd 32.2 | +3.8ms (+5.6%) | 0.46 |
| File Explorer (133) | 116.4ms sd 4.0 | 120.7ms sd 2.4 | +4.3ms (+3.7%) | 5.10 |

Task Manager's low `t` is one ~160ms outlier per side inflating both sd's; its medians move
55.5 → 60.0, in line with the rest. About 32µs per node.

**macOS**: TextEdit (46 nodes) 12.4ms → 13.3ms, +0.9ms (+7.0%), t=1.33, medians both 12.0.
System Settings (130 nodes) 59.3ms → 61.6ms, +2.4ms (+4.0%), t=0.45; dropping each run's two
warm-up snapshots, 52.8ms → 54.3ms, +1.6ms (+3.0%), t=1.40. Not statistically resolved at n=20,
but the direction and magnitude match Windows (~12–20µs/node), and the decision it informs —
whether to read the descriptor only on roles likely to carry one — is "no" at either bound, so the
spec's role-narrowing fallback stays unused.

Linux, for comparison, measured +9.3% in PR1.

## Both controls shown to fail

A test that only passes proves nothing about whether it can catch anything.

- Windows: with the reader arm disabled, all four apps report 0 described and the run goes red on
  the new assertion. It asserts the union across the four apps, deliberately not per-app — an app
  with no tooltips is a real observation, not a failure. macOS, whose app list is caller-supplied,
  prints a challenge line instead of asserting.
- macOS: with the arm disabled, the fixture case fails —
  `FAIL: "Save" description = None, want Some("Saves and closes the sheet")`.

The macOS fixture gained four discriminating cases: help distinct from the name, a titled control
described by its `AXDescription`, a labelled-but-untitled control that must report nothing, and help
identical to the name. A census count can only say *something* arrived; these say which attribute
produced it.

## What the pre-merge panel changed

Five lenses ran before this PR opened; the substantive findings were not cosmetic.

- **A failed read was invisible.** It rendered identically to an app exposing no label. On Windows
  that is the clearer defect — UIA answers an *unset* property with an empty string, so every `Err`
  from `get_help_text` is a genuine COM failure (stale element, hung provider, denied
  cross-integrity read). Both readers now log before degrading to `None`, the treatment
  `toggle_pattern` and `read_subrole` already give their own failures. macOS routes its label reads
  through the error-aware `attribute_string_checked`, including both fingerprint sites, so a
  fingerprint can never be computed from a differently-read name.
- **The cost block misdescribed itself.** Its comment claimed the measured interval was the walk;
  the timer wraps a whole `snapshot`, including a fresh thread and COM init on Windows and the grant
  gate plus window resolve on macOS. It also placed `black_box` *after* `elapsed()`, outside the
  window it existed to protect.
- **The cost loop could abort the probe.** A failed repeat panicked, stranding the adopted window,
  skipping three later apps and the artifacts write. Now non-fatal, printing the samples it had.
- **Docs were wrong in a way a reader would act on:** `tools.md` said macOS reads `AXHelp` "plus"
  `AXDescription` where the code short-circuits with `else`, and named one of Android's two readers.

## Verification

- Local: `cargo fmt --check`, `clippy --workspace --all-targets -D warnings`, `cargo test
  --workspace`, `clippy --target x86_64-pc-windows-gnu`, `scripts/test-a11y.sh` (27 + 5 green).
- mini (macOS 26.5.2, arm64): `fmt --check`, clippy for both macOS crates, unit tests, and the
  granted a11y suite — `A11Y_SETVALUE_PASS` / `A11Y_INVOKE_PASS` / `A11Y_BOUNDS_PASS` /
  `A11Y_SNAPSHOT_PASS` with all four description cases.
- lotus (Windows): `onbox_role_histogram_probe` green through the session-1 bridge.

## Deliberately not here

- **A pure `mapping::labels()` seam** that would put the macOS precedence under test on a Linux dev
  box. Worth doing: the `titled` gate is behaviourally invisible — remove it and the output is
  identical, only the per-node read count changes — so no output-based test on any hardware can
  protect it. Follow-up.
- **Flaky macOS window adoption**, pre-existing and unrelated: one run adopted a 468x101 window for
  Calculator and failed selection (`candidates: [ax=(510,497,230,408) scale=2 dx=540 dy=590]`),
  while the surrounding runs adopted 230x408 correctly. Its own issue.
- A mock `UIElement`/`AXUIElement`. It would only show that a stub's attributes flow through the
  stub's own precedence — it cannot catch a mistyped `"AXHelp"` or tell you what AppKit exposes.
