### PR TITLE
mobile: bound every one-shot adb, simctl, emulator, plutil and ps call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,15 @@ internal refactors, CI, or test-only changes.
 
 ### Fixed
 - An Android or iOS Simulator command that stops answering no longer hangs the tool it was
-  serving. Every one-shot call glass makes to `adb`, `xcrun simctl`, `plutil` or `ps` now has a
-  deadline sized for what that call does — a full accessibility dump gets longer than a tap, and
-  waiting out a simulator boot gets longer still — and a call that exceeds it comes back as an
-  error naming the operation, how long it waited, anything the tool managed to say first, and what
-  to try (for `adb`, `adb kill-server`). Log streaming is unaffected: it is meant to run until you
-  stop it.
+  serving. Every one-shot call glass makes to `adb`, `emulator`, `xcrun simctl`, `plutil` or `ps`
+  now has a deadline sized for what that call does — a full accessibility dump gets longer than a
+  tap, an app install longer still, and waiting out a simulator boot longest of all — and a call
+  that exceeds it comes back as an error naming the operation, how long it waited, anything the
+  tool managed to say first, and what to try (for `adb`, `adb kill-server`). Log streaming is
+  unaffected: it is meant to run until you stop it.
+- A command that exits while something it started still holds its output pipe no longer returns
+  the partial output as though it were complete; it reports that the output may be truncated. A
+  short read of an accessibility or window dump used to parse as a smaller screen.
 
 ### Added
 - Accessibility elements can now carry a second label. `glass_a11y_snapshot` renders it as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+### Fixed
+- An Android or iOS Simulator command that stops answering no longer hangs the tool it was
+  serving. Every one-shot call glass makes to `adb`, `xcrun simctl`, `plutil` or `ps` now has a
+  deadline sized for what that call does — a full accessibility dump gets longer than a tap, and
+  waiting out a simulator boot gets longer still — and a call that exceeds it comes back as an
+  error naming the operation, how long it waited, anything the tool managed to say first, and what
+  to try (for `adb`, `adb kill-server`). Log streaming is unaffected: it is meant to run until you
+  stop it.
+
 ### Added
 - Accessibility elements can now carry a second label. `glass_a11y_snapshot` renders it as
   `desc="…"` after the name — an icon-only button that used to reach you as a role and a

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -16,7 +16,8 @@ pub enum AdbOp {
     Dump,
     /// `exec-out screencap` — encodes a full-resolution frame.
     Screencap,
-    /// `install` / `push` — copies and verifies a file over the wire.
+    /// `install` / `push` / `pull` / `uninstall` — moves a file over the wire, and an install also
+    /// verifies it on device.
     Transfer,
     /// Everything else: `shell`, `input`, `am start`, `devices`, `forward`, `getprop`.
     Shell,
@@ -233,8 +234,7 @@ mod tests {
 
     #[test]
     fn a_dump_gets_the_longest_budget_of_the_interactive_calls() {
-        // The slowest healthy call decides its own deadline; a single per-backend budget would
-        // have to be sized for it and would then let a wedged `input` hang exactly as long.
+        // Ordering is the invariant here; the values themselves are calibrated on device.
         assert!(AdbOp::Dump.budget() > AdbOp::Shell.budget());
         assert!(AdbOp::Transfer.budget() > AdbOp::Dump.budget());
         assert!(AdbOp::Shell.budget() >= Duration::from_secs(10));

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -12,14 +12,19 @@ use glass_core::{GlassError, Result, run_bounded};
 /// that fires on a loaded-but-working device is worse than the hang it replaces.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AdbOp {
-    /// `uiautomator dump` — walks the whole view tree on device.
+    /// `uiautomator dump`, and the `cat` that reads the tree it wrote — the two halves of one
+    /// snapshot, so they share a deadline rather than the read-back inheriting a tap's.
     Dump,
     /// `exec-out screencap` — encodes a full-resolution frame.
     Screencap,
     /// `install` / `push` / `pull` / `uninstall` — moves a file over the wire, and an install also
     /// verifies it on device.
     Transfer,
-    /// Everything else: `shell`, `input`, `am start`, `devices`, `forward`, `getprop`.
+    /// `am start -W`, which blocks until the activity is up. A first launch after an install pays
+    /// for ART compiling and a cold page cache, so it is nothing like the tap it would otherwise
+    /// share a budget with.
+    Launch,
+    /// Everything else: `input`, `dumpsys`, `devices`, `forward`, `getprop`, `pidof`.
     Shell,
 }
 
@@ -30,6 +35,7 @@ impl AdbOp {
             Self::Dump => Duration::from_secs(20),
             Self::Screencap => Duration::from_secs(15),
             Self::Transfer => Duration::from_secs(120),
+            Self::Launch => Duration::from_secs(60),
             Self::Shell => Duration::from_secs(10),
         }
     }
@@ -37,20 +43,23 @@ impl AdbOp {
     /// Classify an adb argv, so no call site has to pass its own budget and none can pick a longer
     /// one than its work needs. An unrecognized call is [`AdbOp::Shell`] — the SHORT budget, so a
     /// future caller that forgets to extend this fails fast rather than hanging for two minutes.
+    ///
+    /// Matched by POSITION, never by scanning the argv for a substring: arguments carry
+    /// caller-supplied data — an APK path from `AppSpec.run`, a package name, text a `glass_type`
+    /// sends — and a path like `~/uiautomator-samples/app.apk` would otherwise classify an install
+    /// as a dump and kill it at 20s instead of 120s, blaming the wrong operation as it went.
+    ///
+    /// `args` is what the caller passed, before [`build_argv`] prefixes `-s <serial>`, so `args[0]`
+    /// is always the subcommand.
     pub fn for_args(args: &[&str]) -> Self {
-        if args.iter().any(|a| a.contains("uiautomator")) {
-            Self::Dump
-        } else if args.iter().any(|a| a.contains("screencap")) {
-            Self::Screencap
-        } else if args.iter().any(|a| {
-            matches!(
-                *a,
-                "install" | "install-multiple" | "push" | "pull" | "uninstall"
-            )
-        }) {
-            Self::Transfer
-        } else {
-            Self::Shell
+        match (args.first().copied(), args.get(1).copied()) {
+            (Some("install" | "install-multiple" | "push" | "pull" | "uninstall"), _) => {
+                Self::Transfer
+            }
+            (Some("shell"), Some("uiautomator" | "cat")) => Self::Dump,
+            (Some("exec-out" | "shell"), Some("screencap")) => Self::Screencap,
+            (Some("shell"), Some("am")) => Self::Launch,
+            _ => Self::Shell,
         }
     }
 
@@ -60,6 +69,7 @@ impl AdbOp {
             Self::Dump => "adb:uiautomator dump",
             Self::Screencap => "adb:screencap",
             Self::Transfer => "adb:file transfer",
+            Self::Launch => "adb:am start",
             Self::Shell => "adb:shell",
         }
     }
@@ -143,19 +153,27 @@ impl Adb {
         cmd.args(&argv);
         // A wedged adb server answers nothing at all, and the fix is one command — so the remedy
         // rides in the error the caller sees rather than in a log line nobody reads.
-        // Extend the message rather than wrapping the error: nesting one `Backend` inside another
-        // makes `Display` print its prefix twice, and this text is read by an agent.
-        let out = run_bounded(&mut cmd, op.budget(), op.label()).map_err(|e| match e {
-            GlassError::Backend(msg) => GlassError::Backend(format!(
-                "{msg}; if this repeats, run `adb kill-server` and retry"
-            )),
-            other => other,
-        })?;
+        let out = run_bounded(&mut cmd, op.budget(), op.label()).map_err(with_adb_hint)?;
         if out.status.success() {
             Ok(out)
         } else {
             Err(exit_error(&self.bin, &argv, &out))
         }
+    }
+}
+
+/// Add adb's one-command remedy to a TIMEOUT, and nothing else.
+///
+/// Extends the message rather than wrapping the error: nesting one `Backend` inside another makes
+/// `Display` print its prefix twice, and an agent reads this text. Gated on the timeout because the
+/// other failure is a spawn failure — a missing or mis-resolved binary, the most common Android
+/// setup problem — where `adb kill-server` is advice for a binary that is not there.
+fn with_adb_hint(e: GlassError) -> GlassError {
+    match e {
+        GlassError::Backend(msg) if msg.contains("no answer within") => GlassError::Backend(
+            format!("{msg}; if this repeats, run `adb kill-server` and retry"),
+        ),
+        other => other,
     }
 }
 
@@ -181,7 +199,8 @@ fn exit_error(bin: &str, argv: &[String], out: &Output) -> GlassError {
 
 #[cfg(test)]
 mod tests {
-    use super::AdbOp;
+    use super::{Adb, AdbOp, build_argv, with_adb_hint};
+    use glass_core::GlassError;
     use std::time::Duration;
 
     /// Live proof that a wedged adb call ends instead of hanging. Ignored by default:
@@ -196,7 +215,7 @@ mod tests {
     #[test]
     #[ignore = "requires a booted AVD + GLASS_ADB"]
     fn a_shell_call_that_never_answers_dies_at_its_budget() {
-        let adb = super::Adb::from_env();
+        let adb = Adb::from_env();
         let budget = AdbOp::Shell.budget();
 
         let started = std::time::Instant::now();
@@ -259,8 +278,17 @@ mod tests {
                 vec!["uninstall", "tech.fixedwidth.glass.a11y"],
                 AdbOp::Transfer,
             ),
+            (vec!["shell", "cat", "/sdcard/glass_dump.xml"], AdbOp::Dump),
             (vec!["shell", "input", "tap", "10", "20"], AdbOp::Shell),
-            (vec!["shell", "am", "start", "-n", "pkg/.Act"], AdbOp::Shell),
+            (
+                vec!["shell", "am", "start", "-W", "-n", "pkg/.Act"],
+                AdbOp::Launch,
+            ),
+            (
+                vec!["shell", "rm", "-f", "/sdcard/glass_dump.xml"],
+                AdbOp::Shell,
+            ),
+            (vec!["shell", "pidof", "com.example.app"], AdbOp::Shell),
             (vec!["shell", "dumpsys", "window", "windows"], AdbOp::Shell),
             (vec!["devices"], AdbOp::Shell),
             (
@@ -276,13 +304,65 @@ mod tests {
     }
 
     #[test]
+    fn caller_supplied_data_cannot_choose_a_budget() {
+        // Each of these carries a word the classifier used to scan for anywhere in the argv. The
+        // install pair is the harmful direction: a 120s transfer cut to 20s and killed mid-flight,
+        // blamed on `adb:uiautomator dump`. The rest merely lengthened a tap's deadline.
+        for (argv, want) in [
+            (
+                vec!["install", "-r", "-t", "/home/u/uiautomator-samples/app.apk"],
+                AdbOp::Transfer,
+            ),
+            (
+                vec![
+                    "push",
+                    "/tmp/screencap-tools/agent.jar",
+                    "/data/local/tmp/agent.jar",
+                ],
+                AdbOp::Transfer,
+            ),
+            (vec!["shell", "input text 'uiautomator'"], AdbOp::Shell),
+            (
+                vec!["shell", "pidof", "com.example.uiautomator"],
+                AdbOp::Shell,
+            ),
+        ] {
+            assert_eq!(AdbOp::for_args(&argv), want, "argv {argv:?}");
+        }
+    }
+
+    #[test]
+    fn only_a_timeout_gets_the_kill_server_remedy() {
+        // A spawn failure means adb is missing or mis-resolved — the most common Android setup
+        // problem — and telling an agent to run `adb kill-server` sends it at a binary that is not
+        // there, in place of the path that would have identified the real fault.
+        let spawn = with_adb_hint(GlassError::Backend(
+            "adb:shell: failed to start: No such file or directory (os error 2)".into(),
+        ));
+        assert!(!spawn.to_string().contains("kill-server"), "{spawn}");
+
+        let timeout = with_adb_hint(GlassError::Backend(
+            "adb:shell: no answer within 10s, so the process was killed".into(),
+        ));
+        assert!(timeout.to_string().contains("adb kill-server"), "{timeout}");
+        // Extending the message must not wrap one Backend in another: Display prints its prefix
+        // per layer, and "backend error: backend error: ..." is what an agent would read.
+        assert_eq!(timeout.to_string().matches("backend error").count(), 1);
+    }
+
+    #[test]
+    fn a_launch_is_not_billed_as_a_tap() {
+        // `am start -W` blocks until the activity is up; a cold first launch after an install runs
+        // for seconds while ART compiles, so sharing the tap budget failed healthy launches.
+        assert!(AdbOp::Launch.budget() > AdbOp::Shell.budget());
+    }
+
+    #[test]
     fn an_unrecognized_call_takes_the_short_budget_not_a_generous_one() {
         // Fail fast beats hanging for two minutes when a future caller forgets to extend the
         // classifier.
         assert_eq!(AdbOp::for_args(&["some-future-subcommand"]), AdbOp::Shell);
     }
-
-    use super::build_argv;
 
     #[test]
     fn argv_without_serial_is_passthrough() {

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -1,6 +1,68 @@
 use std::process::{Command, Output};
+use std::time::Duration;
 
-use glass_core::{GlassError, Result};
+use glass_core::{GlassError, Result, run_bounded};
+
+/// What an adb invocation is doing, which is what decides how long it may take.
+///
+/// One deadline for the whole backend would have to accommodate the slowest healthy call — a full
+/// `uiautomator dump`, or an APK install — and would then let a wedged `input` hang just as long.
+///
+/// Budgets are ~4x the slowest healthy run measured on the dogfood AVD, floored at 10s: a budget
+/// that fires on a loaded-but-working device is worse than the hang it replaces.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AdbOp {
+    /// `uiautomator dump` — walks the whole view tree on device.
+    Dump,
+    /// `exec-out screencap` — encodes a full-resolution frame.
+    Screencap,
+    /// `install` / `push` — copies and verifies a file over the wire.
+    Transfer,
+    /// Everything else: `shell`, `input`, `am start`, `devices`, `forward`, `getprop`.
+    Shell,
+}
+
+impl AdbOp {
+    /// The deadline for this kind of call.
+    pub fn budget(self) -> Duration {
+        match self {
+            Self::Dump => Duration::from_secs(20),
+            Self::Screencap => Duration::from_secs(15),
+            Self::Transfer => Duration::from_secs(120),
+            Self::Shell => Duration::from_secs(10),
+        }
+    }
+
+    /// Classify an adb argv, so no call site has to pass its own budget and none can pick a longer
+    /// one than its work needs. An unrecognized call is [`AdbOp::Shell`] — the SHORT budget, so a
+    /// future caller that forgets to extend this fails fast rather than hanging for two minutes.
+    pub fn for_args(args: &[&str]) -> Self {
+        if args.iter().any(|a| a.contains("uiautomator")) {
+            Self::Dump
+        } else if args.iter().any(|a| a.contains("screencap")) {
+            Self::Screencap
+        } else if args.iter().any(|a| {
+            matches!(
+                *a,
+                "install" | "install-multiple" | "push" | "pull" | "uninstall"
+            )
+        }) {
+            Self::Transfer
+        } else {
+            Self::Shell
+        }
+    }
+
+    /// Operation name for the timeout error, prefixed so a reader knows which tool hung.
+    fn label(self) -> &'static str {
+        match self {
+            Self::Dump => "adb:uiautomator dump",
+            Self::Screencap => "adb:screencap",
+            Self::Transfer => "adb:file transfer",
+            Self::Shell => "adb:shell",
+        }
+    }
+}
 
 /// A thin wrapper over the `adb` binary, targeting one device serial.
 #[derive(Clone, Debug)]
@@ -73,14 +135,18 @@ impl Adb {
     where
         I: IntoIterator<Item = &'a str>,
     {
-        let argv = build_argv(
-            self.serial.as_deref(),
-            &args.into_iter().collect::<Vec<_>>(),
-        );
-        let out = Command::new(&self.bin)
-            .args(&argv)
-            .output()
-            .map_err(|e| GlassError::Backend(format!("failed to run `{}`: {e}", self.bin)))?;
+        let args: Vec<&str> = args.into_iter().collect();
+        let op = AdbOp::for_args(&args);
+        let argv = build_argv(self.serial.as_deref(), &args);
+        let mut cmd = Command::new(&self.bin);
+        cmd.args(&argv);
+        // A wedged adb server answers nothing at all, and the fix is one command — so the remedy
+        // rides in the error the caller sees rather than in a log line nobody reads.
+        let out = run_bounded(&mut cmd, op.budget(), op.label()).map_err(|e| {
+            GlassError::Backend(format!(
+                "{e}; if this repeats, run `adb kill-server` and retry"
+            ))
+        })?;
         if out.status.success() {
             Ok(out)
         } else {
@@ -111,6 +177,60 @@ fn exit_error(bin: &str, argv: &[String], out: &Output) -> GlassError {
 
 #[cfg(test)]
 mod tests {
+    use super::AdbOp;
+    use std::time::Duration;
+
+    #[test]
+    fn a_dump_gets_the_longest_budget_of_the_interactive_calls() {
+        // The slowest healthy call decides its own deadline; a single per-backend budget would
+        // have to be sized for it and would then let a wedged `input` hang exactly as long.
+        assert!(AdbOp::Dump.budget() > AdbOp::Shell.budget());
+        assert!(AdbOp::Transfer.budget() > AdbOp::Dump.budget());
+        assert!(AdbOp::Shell.budget() >= Duration::from_secs(10));
+    }
+
+    #[test]
+    fn every_argv_this_crate_actually_runs_classifies_as_intended() {
+        // The real argvs, taken from the call sites, so a refactor that renames a subcommand is
+        // caught here rather than by a call silently dropping to the short budget.
+        for (argv, want) in [
+            (
+                vec!["shell", "uiautomator", "dump", "/sdcard/glass_dump.xml"],
+                AdbOp::Dump,
+            ),
+            (vec!["exec-out", "screencap"], AdbOp::Screencap),
+            (vec!["install", "-r", "/tmp/app.apk"], AdbOp::Transfer),
+            (
+                vec!["push", "/tmp/agent.jar", "/data/local/tmp/agent.jar"],
+                AdbOp::Transfer,
+            ),
+            (
+                vec!["uninstall", "tech.fixedwidth.glass.a11y"],
+                AdbOp::Transfer,
+            ),
+            (vec!["shell", "input", "tap", "10", "20"], AdbOp::Shell),
+            (vec!["shell", "am", "start", "-n", "pkg/.Act"], AdbOp::Shell),
+            (vec!["shell", "dumpsys", "window", "windows"], AdbOp::Shell),
+            (vec!["devices"], AdbOp::Shell),
+            (
+                vec!["forward", "tcp:0", "localabstract:glass"],
+                AdbOp::Shell,
+            ),
+            (vec!["shell", "getprop", "sys.boot_completed"], AdbOp::Shell),
+            (vec!["emu", "kill"], AdbOp::Shell),
+            (vec!["version"], AdbOp::Shell),
+        ] {
+            assert_eq!(AdbOp::for_args(&argv), want, "argv {argv:?}");
+        }
+    }
+
+    #[test]
+    fn an_unrecognized_call_takes_the_short_budget_not_a_generous_one() {
+        // Fail fast beats hanging for two minutes when a future caller forgets to extend the
+        // classifier.
+        assert_eq!(AdbOp::for_args(&["some-future-subcommand"]), AdbOp::Shell);
+    }
+
     use super::build_argv;
 
     #[test]

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -142,10 +142,13 @@ impl Adb {
         cmd.args(&argv);
         // A wedged adb server answers nothing at all, and the fix is one command — so the remedy
         // rides in the error the caller sees rather than in a log line nobody reads.
-        let out = run_bounded(&mut cmd, op.budget(), op.label()).map_err(|e| {
-            GlassError::Backend(format!(
-                "{e}; if this repeats, run `adb kill-server` and retry"
-            ))
+        // Extend the message rather than wrapping the error: nesting one `Backend` inside another
+        // makes `Display` print its prefix twice, and this text is read by an agent.
+        let out = run_bounded(&mut cmd, op.budget(), op.label()).map_err(|e| match e {
+            GlassError::Backend(msg) => GlassError::Backend(format!(
+                "{msg}; if this repeats, run `adb kill-server` and retry"
+            )),
+            other => other,
         })?;
         if out.status.success() {
             Ok(out)
@@ -179,6 +182,54 @@ fn exit_error(bin: &str, argv: &[String], out: &Output) -> GlassError {
 mod tests {
     use super::AdbOp;
     use std::time::Duration;
+
+    /// Live proof that a wedged adb call ends instead of hanging. Ignored by default:
+    ///   GLASS_ADB=$HOME/android-sdk/platform-tools/adb \
+    ///     cargo test -p glass-android --lib -- --ignored --nocapture a_shell_call
+    ///
+    /// The budget tests above cover which deadline a call gets, and `glass_core::bounded`'s cover
+    /// the mechanism against a local `sh`. Neither exercises what actually failed before this
+    /// existed: a real `adb` call that never answers. It lives in-crate rather than in
+    /// `tests/*_loop.rs` because `adb` is a private module, and a test is not a reason to widen the
+    /// crate's public surface.
+    #[test]
+    #[ignore = "requires a booted AVD + GLASS_ADB"]
+    fn a_shell_call_that_never_answers_dies_at_its_budget() {
+        let adb = super::Adb::from_env();
+        let budget = AdbOp::Shell.budget();
+
+        let started = std::time::Instant::now();
+        // Ten times the budget, so "it returned because the command finished" is no explanation.
+        let err = adb
+            .run(["shell", "sleep", "100"])
+            .expect_err("a call that outlives its budget must fail, not return");
+        let waited = started.elapsed();
+        println!("waited {waited:?} against a {budget:?} budget; error: {err}");
+
+        assert!(
+            waited < budget + Duration::from_secs(5),
+            "waited {waited:?}, past the {budget:?} budget — the bound did not fire"
+        );
+        let msg = err.to_string();
+        // Whoever reads this has to learn which call hung and what to do about it.
+        assert!(msg.contains("adb:shell"), "must name the operation: {msg}");
+        assert!(
+            msg.contains("adb kill-server"),
+            "must carry the remedy: {msg}"
+        );
+        // Extending the message must not wrap one Backend error in another: Display prints its
+        // prefix per layer, and "backend error: backend error: ..." is what an agent would read.
+        assert_eq!(
+            msg.matches("backend error").count(),
+            1,
+            "the error prefix must appear once: {msg}"
+        );
+
+        // The next call still works, so the timeout killed the child rather than leaving the
+        // connection wedged behind it.
+        let devices = adb.run(["devices"]).expect("adb usable after a timeout");
+        assert!(devices.contains("List of devices"), "{devices}");
+    }
 
     #[test]
     fn a_dump_gets_the_longest_budget_of_the_interactive_calls() {

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -1,7 +1,7 @@
 use std::process::{Command, Output};
 use std::time::Duration;
 
-use glass_core::{GlassError, Result, run_bounded};
+use glass_core::{GlassError, Result, TIMED_OUT, run_bounded};
 
 /// What an adb invocation is doing, which is what decides how long it may take.
 ///
@@ -22,7 +22,8 @@ pub enum AdbOp {
     Transfer,
     /// `am start -W`, which blocks until the activity is up. A first launch after an install pays
     /// for ART compiling and a cold page cache, so it is nothing like the tap it would otherwise
-    /// share a budget with.
+    /// share a budget with. `am` alone is NOT this: `am force-stop` runs during teardown, inside
+    /// `glass_core::TEARDOWN_BUDGET`, and must keep the short deadline.
     Launch,
     /// Everything else: `input`, `dumpsys`, `devices`, `forward`, `getprop`, `pidof`.
     Shell,
@@ -58,7 +59,7 @@ impl AdbOp {
             }
             (Some("shell"), Some("uiautomator" | "cat")) => Self::Dump,
             (Some("exec-out" | "shell"), Some("screencap")) => Self::Screencap,
-            (Some("shell"), Some("am")) => Self::Launch,
+            (Some("shell"), Some("am")) if args.get(2) == Some(&"start") => Self::Launch,
             _ => Self::Shell,
         }
     }
@@ -170,9 +171,9 @@ impl Adb {
 /// setup problem — where `adb kill-server` is advice for a binary that is not there.
 fn with_adb_hint(e: GlassError) -> GlassError {
     match e {
-        GlassError::Backend(msg) if msg.contains("no answer within") => GlassError::Backend(
-            format!("{msg}; if this repeats, run `adb kill-server` and retry"),
-        ),
+        GlassError::Backend(msg) if msg.contains(TIMED_OUT) => GlassError::Backend(format!(
+            "{msg}; if this repeats, run `adb kill-server` and retry"
+        )),
         other => other,
     }
 }
@@ -341,9 +342,15 @@ mod tests {
         ));
         assert!(!spawn.to_string().contains("kill-server"), "{spawn}");
 
-        let timeout = with_adb_hint(GlassError::Backend(
-            "adb:shell: no answer within 10s, so the process was killed".into(),
-        ));
+        // Built by running a real timeout rather than typed here: the gate keys on wording that
+        // `glass-core` owns, so a fixture repeating that wording could not notice it drifting.
+        let real_timeout = glass_core::run_bounded(
+            std::process::Command::new("/bin/sh").args(["-c", "sleep 30"]),
+            std::time::Duration::from_millis(200),
+            "adb:shell",
+        )
+        .expect_err("must time out");
+        let timeout = with_adb_hint(real_timeout);
         assert!(timeout.to_string().contains("adb kill-server"), "{timeout}");
         // Extending the message must not wrap one Backend in another: Display prints its prefix
         // per layer, and "backend error: backend error: ..." is what an agent would read.

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -334,9 +334,7 @@ mod tests {
 
     #[test]
     fn only_a_timeout_gets_the_kill_server_remedy() {
-        // A spawn failure means adb is missing or mis-resolved — the most common Android setup
-        // problem — and telling an agent to run `adb kill-server` sends it at a binary that is not
-        // there, in place of the path that would have identified the real fault.
+        // The spawn case must stay bare: `with_adb_hint`'s doc says why.
         let spawn = with_adb_hint(GlassError::Backend(
             "adb:shell: failed to start: No such file or directory (os error 2)".into(),
         ));
@@ -359,8 +357,7 @@ mod tests {
 
     #[test]
     fn a_launch_is_not_billed_as_a_tap() {
-        // `am start -W` blocks until the activity is up; a cold first launch after an install runs
-        // for seconds while ART compiles, so sharing the tap budget failed healthy launches.
+        // Ordering only; the variant doc explains why a launch is not a tap.
         assert!(AdbOp::Launch.budget() > AdbOp::Shell.budget());
     }
 

--- a/crates/glass-android/src/avd.rs
+++ b/crates/glass-android/src/avd.rs
@@ -242,7 +242,10 @@ pub fn boot_avd(base: &Adb, get: &dyn Fn(&str) -> Option<String>) -> Result<Stri
                 err.trim()
             )));
         }
-        let online = crate::target::parse_devices(&base.run(["devices"])?);
+        // Tolerant, like the `getprop` below it: this polls every 500ms inside the boot deadline, so
+        // one slow `devices` call is a hiccup, not a reason to abandon a boot — and propagating here
+        // would skip the deadline branch that kills the emulator, leaving it holding the AVD lock.
+        let online = crate::target::parse_devices(&base.run(["devices"]).unwrap_or_default());
         if let Some(serial) = new_serial(&before, &online) {
             let adb = base.with_serial(serial.clone());
             if adb
@@ -272,11 +275,15 @@ pub fn boot_avd(base: &Adb, get: &dyn Fn(&str) -> Option<String>) -> Result<Stri
     }
 }
 
+/// Deadline for `emulator -list-avds`. It reads the AVD directory and prints names — a fast local
+/// query — but a broken SDK can wedge the binary, and this runs first on the `glass_start` boot
+/// path, so an unbounded call here hangs a launch before anything else happens.
+pub(crate) const EMULATOR_LIST_BUDGET: Duration = Duration::from_secs(15);
+
 fn run_emulator_list(bin: &str) -> Result<String> {
-    let out = Command::new(bin)
-        .arg("-list-avds")
-        .output()
-        .map_err(|e| GlassError::Backend(format!("failed to run `{bin} -list-avds`: {e}")))?;
+    let mut cmd = Command::new(bin);
+    cmd.arg("-list-avds");
+    let out = glass_core::run_bounded(&mut cmd, EMULATOR_LIST_BUDGET, "emulator:-list-avds")?;
     Ok(String::from_utf8_lossy(&out.stdout).into_owned())
 }
 

--- a/crates/glass-android/src/doctor.rs
+++ b/crates/glass-android/src/doctor.rs
@@ -189,13 +189,20 @@ fn first_line(s: &str) -> String {
     s.lines().next().unwrap_or("").trim().to_string()
 }
 
-/// `<bin> -list-avds`: `None` on spawn failure (binary absent), else the parsed names.
+/// `<bin> -list-avds`: `None` on spawn failure (binary absent) or a timeout, else the parsed names.
+///
+/// Bounded like the boot path's copy of this call: a doctor that hangs on a wedged tool reports
+/// nothing at all, which is the one thing it must never do.
 fn list_avds(bin: &str) -> Option<Vec<String>> {
-    std::process::Command::new(bin)
-        .arg("-list-avds")
-        .output()
-        .ok()
-        .map(|o| parse_list_avds(&String::from_utf8_lossy(&o.stdout)))
+    let mut cmd = std::process::Command::new(bin);
+    cmd.arg("-list-avds");
+    glass_core::run_bounded(
+        &mut cmd,
+        crate::avd::EMULATOR_LIST_BUDGET,
+        "emulator:-list-avds",
+    )
+    .ok()
+    .map(|o| parse_list_avds(&String::from_utf8_lossy(&o.stdout)))
 }
 
 /// Deep probe one online device: capture a frame (validated via the real decoder) and

--- a/crates/glass-android/src/doctor.rs
+++ b/crates/glass-android/src/doctor.rs
@@ -189,10 +189,12 @@ fn first_line(s: &str) -> String {
     s.lines().next().unwrap_or("").trim().to_string()
 }
 
-/// `<bin> -list-avds`: `None` on spawn failure (binary absent) or a timeout, else the parsed names.
+/// `<bin> -list-avds`: `None` when the binary could not be run to an answer, else the parsed names.
 ///
 /// Bounded like the boot path's copy of this call: a doctor that hangs on a wedged tool reports
-/// nothing at all, which is the one thing it must never do.
+/// nothing at all, which is the one thing it must never do. A timeout still collapses into the same
+/// `None` as an absent binary — the caller renders that as "not found", which is then the wrong
+/// remedy — so it is logged, the way the iOS doctor logs its probes.
 fn list_avds(bin: &str) -> Option<Vec<String>> {
     let mut cmd = std::process::Command::new(bin);
     cmd.arg("-list-avds");
@@ -201,6 +203,7 @@ fn list_avds(bin: &str) -> Option<Vec<String>> {
         crate::avd::EMULATOR_LIST_BUDGET,
         "emulator:-list-avds",
     )
+    .inspect_err(|e| eprintln!("glass-android doctor: {e}"))
     .ok()
     .map(|o| parse_list_avds(&String::from_utf8_lossy(&o.stdout)))
 }

--- a/crates/glass-core/src/bounded.rs
+++ b/crates/glass-core/src/bounded.rs
@@ -6,7 +6,7 @@
 //! use. A long-lived child — a log tail, an emulator, the on-device agent — is NOT this: those use
 //! `Command::spawn` directly and are meant to outlive the call that started them.
 
-use std::io::Read;
+use std::io::{Read, Write};
 use std::process::{Child, Command, Output, Stdio};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
@@ -14,16 +14,29 @@ use std::time::{Duration, Instant};
 
 use crate::{GlassError, Result};
 
-/// How often the parent checks whether the child has exited while waiting out its budget.
+/// Longest gap between checks on a child that has not exited yet. The wait starts far tighter and
+/// backs off to this, so a one-shot that answers in a millisecond is not billed a full tick while
+/// waiting out a three-minute boot still costs only a handful of wakeups.
 const POLL: Duration = Duration::from_millis(20);
 
-/// How long to let a drain thread finish reading after the child has exited, before taking what it
-/// has. Normally instant — the pipe closes with the child — but a grandchild that inherited the
-/// write end keeps it open, and no output is worth stalling a completed call for.
+/// First gap between checks, doubled up to [`POLL`].
+const POLL_START: Duration = Duration::from_millis(1);
+
+/// How long to let a drain thread reach EOF after the child has exited. Normally instant — the pipe
+/// closes with the child — but a grandchild that inherited the write end keeps it open, and no
+/// output is worth stalling a completed call for.
 const DRAIN_SETTLE: Duration = Duration::from_millis(200);
 
-/// Bytes read from one of the child's pipes, shared with the thread still reading it.
-type Drained = Arc<Mutex<Vec<u8>>>;
+/// How long to wait for a killed child to leave the process table. Bounded rather than a plain
+/// `wait()`: SIGKILL only lands when the child next leaves the kernel, so a process stuck in an
+/// uninterruptible syscall — the very failure this module exists for — would otherwise strand a
+/// caller who has already spent their whole budget. A stray zombie is the cheaper outcome.
+const KILL_REAP: Duration = Duration::from_millis(500);
+
+/// Most output one call may buffer, so a drain thread left reading a pipe some grandchild still
+/// holds cannot grow without bound. Far past any real one-shot's output — a full `uiautomator dump`
+/// of a deep tree is a few hundred KiB.
+const MAX_CAPTURE: usize = 64 * 1024 * 1024;
 
 /// Run `cmd` to completion, or kill it and fail once `budget` elapses.
 ///
@@ -35,78 +48,205 @@ type Drained = Arc<Mutex<Vec<u8>>>;
 /// Both pipes are drained on their own threads: a child that fills a pipe buffer while the parent
 /// waits blocks in `write` and never exits, putting the deadline itself out of reach.
 pub fn run_bounded(cmd: &mut Command, budget: Duration, op: &str) -> Result<Output> {
+    run_bounded_inner(cmd, budget, op, None)
+}
+
+/// [`run_bounded`], but writing `stdin` to the child first.
+///
+/// The write happens on its own thread for the same reason the reads do: a tool that answers before
+/// consuming all of its input leaves the parent blocked in `write`, with the deadline out of reach.
+/// `simctl pbcopy` is the caller — it takes the clipboard text on stdin, so it cannot go through the
+/// plain runner, which closes stdin.
+pub fn run_bounded_with_stdin(
+    cmd: &mut Command,
+    budget: Duration,
+    op: &str,
+    stdin: &[u8],
+) -> Result<Output> {
+    run_bounded_inner(cmd, budget, op, Some(stdin.to_vec()))
+}
+
+fn run_bounded_inner(
+    cmd: &mut Command,
+    budget: Duration,
+    op: &str,
+    stdin: Option<Vec<u8>>,
+) -> Result<Output> {
     let mut child = cmd
-        .stdin(Stdio::null())
+        .stdin(if stdin.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| GlassError::Backend(format!("{op}: failed to start: {e}")))?;
 
-    let (stdout, out_thread) = drain(child.stdout.take());
-    let (stderr, err_thread) = drain(child.stderr.take());
+    if let Some(bytes) = stdin {
+        // Best-effort and detached: a child that never reads its stdin must not block the parent,
+        // and whatever it does read it reads before it exits, which the deadline already covers.
+        if let Some(mut pipe) = child.stdin.take() {
+            std::thread::spawn(move || {
+                let _ = pipe.write_all(&bytes);
+            });
+        }
+    }
+
+    let stdout = Pipe::drain(child.stdout.take());
+    let stderr = Pipe::drain(child.stderr.take());
 
     let deadline = Instant::now() + budget;
+    let mut wait = POLL_START;
     let status = loop {
         match child.try_wait() {
             Ok(Some(status)) => break status,
             Ok(None) => {}
-            Err(e) => return Err(GlassError::Backend(format!("{op}: wait failed: {e}"))),
+            // The one exit that would otherwise leave the child running with no deadline at all —
+            // `Child::drop` neither kills nor reaps.
+            Err(e) => {
+                let killed = kill_and_reap(&mut child);
+                return Err(GlassError::Backend(format!(
+                    "{op}: could not check whether the process had exited: {e}{}",
+                    if killed {
+                        "; it was killed"
+                    } else {
+                        "; it may still be running"
+                    }
+                )));
+            }
         }
         if Instant::now() >= deadline {
-            return Err(timed_out(&mut child, op, budget, &stdout, &stderr));
+            return Err(timed_out(&mut child, op, budget, stdout, stderr));
         }
-        std::thread::sleep(POLL);
+        std::thread::sleep(wait);
+        wait = (wait * 2).min(POLL);
     };
 
-    settle(out_thread);
-    settle(err_thread);
+    // One deadline for both pipes, so a finished call is never stalled twice over.
+    let settled_by = Instant::now() + DRAIN_SETTLE;
+    let (out_bytes, out_done) = stdout.take(settled_by);
+    let (err_bytes, err_done) = stderr.take(settled_by);
+    // A short read must never pass for a complete answer: `dumpsys window windows` is parsed by a
+    // tolerant line scanner that would read a truncated dump as a shorter window list, and glass
+    // would then report the wrong geometry. `Command::output` cannot produce this — it reads to EOF
+    // — so failing here keeps the contract callers already had.
+    if !out_done || !err_done {
+        return Err(GlassError::Backend(format!(
+            "{op}: exited {status} but its output was still arriving {DRAIN_SETTLE:?} later \
+             (something inherited its pipe), so the {} bytes read may be incomplete",
+            out_bytes.len() + err_bytes.len()
+        )));
+    }
+
     Ok(Output {
         status,
-        stdout: taken(&stdout),
-        stderr: taken(&stderr),
+        stdout: out_bytes,
+        stderr: err_bytes,
     })
 }
 
-/// Read a pipe on its own thread, appending each chunk to a buffer the caller can read at any time.
-///
-/// Chunked rather than `read_to_end` so a timeout can report what the child had already said: a
-/// killed child does not necessarily close the pipe — `sh -c "...; sleep 30"` leaves `sleep`
-/// holding the write end, and `adb` likewise spawns subprocesses — so a thread blocked in
-/// `read_to_end` would still be waiting for EOF with the bytes stuck in its local buffer.
-fn drain<R: Read + Send + 'static>(pipe: Option<R>) -> (Drained, Option<JoinHandle<()>>) {
-    let buf: Drained = Arc::new(Mutex::new(Vec::new()));
-    let Some(mut pipe) = pipe else {
-        return (buf, None);
-    };
-    let sink = Arc::clone(&buf);
-    let handle = std::thread::spawn(move || {
-        let mut chunk = [0u8; 8192];
-        while let Ok(n) = pipe.read(&mut chunk) {
-            if n == 0 {
-                break;
-            }
-            if let Ok(mut sink) = sink.lock() {
-                sink.extend_from_slice(&chunk[..n]);
-            }
-        }
-    });
-    (buf, Some(handle))
+/// One of the child's pipes, read on its own thread.
+struct Pipe {
+    buf: Arc<Mutex<Vec<u8>>>,
+    /// Set once the thread has read to EOF, so a caller can tell a complete answer from one it gave
+    /// up waiting for.
+    done: Arc<Mutex<bool>>,
+    thread: Option<JoinHandle<()>>,
 }
 
-/// Wait briefly for a drain thread to reach EOF, so a completed call reports its whole output.
-/// Bounded by [`DRAIN_SETTLE`]: a grandchild holding the pipe open must not strand the caller.
-fn settle(handle: Option<JoinHandle<()>>) {
-    let Some(handle) = handle else { return };
-    let deadline = Instant::now() + DRAIN_SETTLE;
-    while !handle.is_finished() && Instant::now() < deadline {
+impl Pipe {
+    /// Start reading `pipe` on a new thread, appending each chunk to a buffer readable at any time.
+    ///
+    /// Chunked rather than `read_to_end` so a timeout can report what the child had already said: a
+    /// killed child does not necessarily close the pipe — `sh -c "...; sleep 30"` leaves `sleep`
+    /// holding the write end, and `adb` likewise spawns subprocesses — so a thread blocked in
+    /// `read_to_end` would still be waiting for EOF with the bytes stuck in its local buffer.
+    fn drain<R: Read + Send + 'static>(pipe: Option<R>) -> Self {
+        let buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let done = Arc::new(Mutex::new(false));
+        let Some(mut pipe) = pipe else {
+            // No pipe is a complete read of nothing, not an abandoned one.
+            *done.lock().expect("fresh mutex") = true;
+            return Self {
+                buf,
+                done,
+                thread: None,
+            };
+        };
+        let sink = Arc::clone(&buf);
+        let finished = Arc::clone(&done);
+        let thread = std::thread::spawn(move || {
+            let mut chunk = [0u8; 8192];
+            loop {
+                match pipe.read(&mut chunk) {
+                    Ok(0) => {
+                        if let Ok(mut finished) = finished.lock() {
+                            *finished = true;
+                        }
+                        break;
+                    }
+                    Ok(n) => {
+                        let Ok(mut sink) = sink.lock() else { break };
+                        if sink.len() + n > MAX_CAPTURE {
+                            break;
+                        }
+                        sink.extend_from_slice(&chunk[..n]);
+                    }
+                    // A signal interrupting the read is not end of stream; `read_to_end` retries
+                    // this for you, a bare `read` does not, and glass-mcp installs signal handlers.
+                    Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                    Err(_) => break,
+                }
+            }
+        });
+        Self {
+            buf,
+            done,
+            thread: Some(thread),
+        }
+    }
+
+    /// Everything read so far, and whether the pipe reached EOF. Waits until `settled_by` for the
+    /// thread to finish first, so a completed call reports its whole output; a grandchild holding
+    /// the pipe open must not strand the caller.
+    fn take(self, settled_by: Instant) -> (Vec<u8>, bool) {
+        poll_until(settled_by, || {
+            self.thread.as_ref().is_none_or(JoinHandle::is_finished)
+        });
+        let bytes = self
+            .buf
+            .lock()
+            .map(|mut b| std::mem::take(&mut *b))
+            .unwrap_or_default();
+        // A lock we cannot read is not evidence of a complete read.
+        let done = self.done.lock().map(|d| *d).unwrap_or(false);
+        (bytes, done)
+    }
+
+    /// Everything read so far, without waiting — for a timeout report, where partial output is the
+    /// point.
+    fn snapshot(&self) -> Vec<u8> {
+        self.buf.lock().map(|b| b.clone()).unwrap_or_default()
+    }
+}
+
+/// Sleep in [`POLL`] steps until `ready` answers true or `deadline` passes.
+fn poll_until(deadline: Instant, mut ready: impl FnMut() -> bool) {
+    while !ready() && Instant::now() < deadline {
         std::thread::sleep(POLL);
     }
 }
 
-/// Whatever a drain thread has collected so far. A poisoned lock reads as empty — one unreadable
-/// buffer must not turn a real timeout into a panic.
-fn taken(buf: &Drained) -> Vec<u8> {
-    buf.lock().map(|b| b.clone()).unwrap_or_default()
+/// Kill a child and wait briefly for it to leave the process table. `true` if it did.
+fn kill_and_reap(child: &mut Child) -> bool {
+    let _ = child.kill();
+    let mut reaped = false;
+    poll_until(Instant::now() + KILL_REAP, || {
+        reaped = matches!(child.try_wait(), Ok(Some(_)));
+        reaped
+    });
+    reaped
 }
 
 /// Kill the child and describe the timeout, including whatever it managed to say first — a partial
@@ -115,24 +255,35 @@ fn timed_out(
     child: &mut Child,
     op: &str,
     budget: Duration,
-    stdout: &Drained,
-    stderr: &Drained,
+    stdout: Pipe,
+    stderr: Pipe,
 ) -> GlassError {
-    let _ = child.kill();
-    let _ = child.wait();
-    let out = String::from_utf8_lossy(&taken(stdout)).trim().to_string();
-    let err = String::from_utf8_lossy(&taken(stderr)).trim().to_string();
-    let said = match (out.is_empty(), err.is_empty()) {
-        (true, true) => "it produced no output before the kill".to_string(),
-        (false, true) => format!("stdout before the kill: {out}"),
-        (true, false) => format!("stderr before the kill: {err}"),
-        (false, false) => format!("before the kill — stdout: {out}; stderr: {err}"),
+    let reaped = kill_and_reap(child);
+    let out = String::from_utf8_lossy(&stdout.snapshot())
+        .trim()
+        .to_string();
+    let err = String::from_utf8_lossy(&stderr.snapshot())
+        .trim()
+        .to_string();
+    let mut said: Vec<String> = Vec::new();
+    if !out.is_empty() {
+        said.push(format!("stdout: {out}"));
+    }
+    if !err.is_empty() {
+        said.push(format!("stderr: {err}"));
+    }
+    let said = if said.is_empty() {
+        "it produced no output before the kill".to_string()
+    } else {
+        format!("before the kill — {}", said.join("; "))
     };
-    GlassError::Backend(format!(
-        "{op}: no answer within {budget:?}, so the process was killed; {said}"
-    ))
+    let fate = if reaped {
+        "so the process was killed"
+    } else {
+        "so the process was killed, though it had not exited yet (it may be stuck in the kernel)"
+    };
+    GlassError::Backend(format!("{op}: no answer within {budget:?}, {fate}; {said}"))
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -171,19 +322,6 @@ mod tests {
     }
 
     #[test]
-    fn output_larger_than_a_pipe_buffer_still_completes() {
-        // 1 MiB, well past the ~64 KiB a pipe holds: a parent that waits without draining
-        // deadlocks here, and the deadline never fires because the child never exits.
-        let out = run_bounded(
-            Command::new("/bin/sh").args(["-c", "yes ABCDEFGH | head -c 1048576"]),
-            Duration::from_secs(20),
-            "test:flood",
-        )
-        .expect("a draining implementation completes");
-        assert_eq!(out.stdout.len(), 1_048_576);
-    }
-
-    #[test]
     fn a_nonzero_exit_is_returned_not_reported_as_a_timeout() {
         let out = run_bounded(
             Command::new("/bin/sh").args(["-c", "exit 3"]),
@@ -216,6 +354,103 @@ mod tests {
         )
         .expect_err("must time out");
         assert!(err.to_string().contains("partial-tree"), "{err}");
+    }
+
+    #[test]
+    fn a_pipe_still_open_after_the_child_exits_ends_promptly_as_an_error() {
+        // A grandchild that inherited the write end keeps the pipe open after the child exits, so
+        // EOF may never come. Two things must hold, and they pull against each other: the call must
+        // not stall waiting for EOF, and it must not pass off what arrived as the whole answer —
+        // `dumpsys window windows` is parsed by a tolerant line scanner that would read a truncated
+        // dump as a shorter window list, and glass would report the wrong geometry from it.
+        //
+        // The parent cannot tell "the grandchild will write nothing more" from "the grandchild is
+        // about to write", so both settle out as this error rather than a short success.
+        let started = Instant::now();
+        let err = run_bounded(
+            Command::new("/bin/sh").args([
+                "-c",
+                "printf head; { sleep 1; printf tail-written-late; } &",
+            ]),
+            Duration::from_secs(20),
+            "test:late-writer",
+        )
+        .expect_err("an incomplete read must not pass for success");
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "waited {:?} — a finished call must not wait out a grandchild",
+            started.elapsed()
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("test:late-writer"), "{msg}");
+        assert!(msg.contains("may be incomplete"), "{msg}");
+    }
+
+    #[test]
+    fn a_flood_on_either_pipe_completes() {
+        // 1 MiB down each stream: draining only stdout would deadlock on a stderr-heavy child.
+        let out = run_bounded(
+            Command::new("/bin/sh").args([
+                "-c",
+                "yes A | head -c 1048576; yes B | head -c 1048576 1>&2",
+            ]),
+            Duration::from_secs(30),
+            "test:both-floods",
+        )
+        .expect("both pipes drained");
+        assert_eq!(out.stdout.len(), 1_048_576);
+        assert_eq!(out.stderr.len(), 1_048_576);
+    }
+
+    #[test]
+    fn a_killed_child_is_reaped_not_left_a_zombie() {
+        // `Child::drop` does not reap on Unix, and glass-mcp is long-lived, so a timeout that
+        // skipped the wait would leak a zombie per hung call. The pid rides out in the error.
+        let err = run_bounded(
+            Command::new("/bin/sh").args(["-c", "printf $$; sleep 30"]),
+            Duration::from_millis(300),
+            "test:reap",
+        )
+        .expect_err("must time out");
+        let msg = err.to_string();
+        let pid: i32 = msg
+            .split("stdout: ")
+            .nth(1)
+            .and_then(|rest| rest.split(|c: char| !c.is_ascii_digit()).next())
+            .and_then(|digits| digits.parse().ok())
+            .unwrap_or_else(|| panic!("no pid in {msg}"));
+        // `kill -0` fails once the process is gone, including as a zombie's parent has reaped it.
+        let alive = Command::new("/bin/kill")
+            .args(["-0", &pid.to_string()])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        assert!(!alive, "pid {pid} still exists — the child was not reaped");
+    }
+
+    #[test]
+    fn stdin_is_written_to_the_child() {
+        let out = run_bounded_with_stdin(
+            &mut Command::new("/bin/cat"),
+            Duration::from_secs(10),
+            "test:stdin",
+            b"clipboard text",
+        )
+        .expect("cat echoes its stdin");
+        assert_eq!(String::from_utf8_lossy(&out.stdout), "clipboard text");
+    }
+
+    #[test]
+    fn a_child_that_ignores_its_stdin_still_returns() {
+        // A tool that answers without consuming its input would block a parent that wrote inline.
+        let out = run_bounded_with_stdin(
+            Command::new("/bin/sh").args(["-c", "printf done"]),
+            Duration::from_secs(10),
+            "test:stdin-ignored",
+            &vec![b'x'; 1024 * 1024],
+        )
+        .expect("must not block on an unread stdin");
+        assert_eq!(String::from_utf8_lossy(&out.stdout), "done");
     }
 
     #[test]

--- a/crates/glass-core/src/bounded.rs
+++ b/crates/glass-core/src/bounded.rs
@@ -1,0 +1,231 @@
+//! Run a one-shot child process under a deadline.
+//!
+//! Every backend that drives an external tool (`adb`, `xcrun simctl`, `plutil`) needs the same
+//! thing: the tool answers quickly, or it has hung and must not hang the agent's call with it.
+//! `std::process` offers no wait-with-a-deadline, so this module supplies the one shape they all
+//! use. A long-lived child — a log tail, an emulator, the on-device agent — is NOT this: those use
+//! `Command::spawn` directly and are meant to outlive the call that started them.
+
+use std::io::Read;
+use std::process::{Child, Command, Output, Stdio};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use crate::{GlassError, Result};
+
+/// How often the parent checks whether the child has exited while waiting out its budget.
+const POLL: Duration = Duration::from_millis(20);
+
+/// How long to let a drain thread finish reading after the child has exited, before taking what it
+/// has. Normally instant — the pipe closes with the child — but a grandchild that inherited the
+/// write end keeps it open, and no output is worth stalling a completed call for.
+const DRAIN_SETTLE: Duration = Duration::from_millis(200);
+
+/// Bytes read from one of the child's pipes, shared with the thread still reading it.
+type Drained = Arc<Mutex<Vec<u8>>>;
+
+/// Run `cmd` to completion, or kill it and fail once `budget` elapses.
+///
+/// `op` names the operation in the error (`"adb:uiautomator dump"`), so a timeout says which call
+/// hung rather than merely which binary. A non-zero exit is NOT an error here: the returned
+/// [`Output`] carries it exactly as [`Command::output`] would, leaving each caller's own exit
+/// handling untouched.
+///
+/// Both pipes are drained on their own threads: a child that fills a pipe buffer while the parent
+/// waits blocks in `write` and never exits, putting the deadline itself out of reach.
+pub fn run_bounded(cmd: &mut Command, budget: Duration, op: &str) -> Result<Output> {
+    let mut child = cmd
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| GlassError::Backend(format!("{op}: failed to start: {e}")))?;
+
+    let (stdout, out_thread) = drain(child.stdout.take());
+    let (stderr, err_thread) = drain(child.stderr.take());
+
+    let deadline = Instant::now() + budget;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {}
+            Err(e) => return Err(GlassError::Backend(format!("{op}: wait failed: {e}"))),
+        }
+        if Instant::now() >= deadline {
+            return Err(timed_out(&mut child, op, budget, &stdout, &stderr));
+        }
+        std::thread::sleep(POLL);
+    };
+
+    settle(out_thread);
+    settle(err_thread);
+    Ok(Output {
+        status,
+        stdout: taken(&stdout),
+        stderr: taken(&stderr),
+    })
+}
+
+/// Read a pipe on its own thread, appending each chunk to a buffer the caller can read at any time.
+///
+/// Chunked rather than `read_to_end` so a timeout can report what the child had already said: a
+/// killed child does not necessarily close the pipe — `sh -c "...; sleep 30"` leaves `sleep`
+/// holding the write end, and `adb` likewise spawns subprocesses — so a thread blocked in
+/// `read_to_end` would still be waiting for EOF with the bytes stuck in its local buffer.
+fn drain<R: Read + Send + 'static>(pipe: Option<R>) -> (Drained, Option<JoinHandle<()>>) {
+    let buf: Drained = Arc::new(Mutex::new(Vec::new()));
+    let Some(mut pipe) = pipe else {
+        return (buf, None);
+    };
+    let sink = Arc::clone(&buf);
+    let handle = std::thread::spawn(move || {
+        let mut chunk = [0u8; 8192];
+        while let Ok(n) = pipe.read(&mut chunk) {
+            if n == 0 {
+                break;
+            }
+            if let Ok(mut sink) = sink.lock() {
+                sink.extend_from_slice(&chunk[..n]);
+            }
+        }
+    });
+    (buf, Some(handle))
+}
+
+/// Wait briefly for a drain thread to reach EOF, so a completed call reports its whole output.
+/// Bounded by [`DRAIN_SETTLE`]: a grandchild holding the pipe open must not strand the caller.
+fn settle(handle: Option<JoinHandle<()>>) {
+    let Some(handle) = handle else { return };
+    let deadline = Instant::now() + DRAIN_SETTLE;
+    while !handle.is_finished() && Instant::now() < deadline {
+        std::thread::sleep(POLL);
+    }
+}
+
+/// Whatever a drain thread has collected so far. A poisoned lock reads as empty — one unreadable
+/// buffer must not turn a real timeout into a panic.
+fn taken(buf: &Drained) -> Vec<u8> {
+    buf.lock().map(|b| b.clone()).unwrap_or_default()
+}
+
+/// Kill the child and describe the timeout, including whatever it managed to say first — a partial
+/// `uiautomator dump` tells a reader more about the hang than silence does.
+fn timed_out(
+    child: &mut Child,
+    op: &str,
+    budget: Duration,
+    stdout: &Drained,
+    stderr: &Drained,
+) -> GlassError {
+    let _ = child.kill();
+    let _ = child.wait();
+    let out = String::from_utf8_lossy(&taken(stdout)).trim().to_string();
+    let err = String::from_utf8_lossy(&taken(stderr)).trim().to_string();
+    let said = match (out.is_empty(), err.is_empty()) {
+        (true, true) => "it produced no output before the kill".to_string(),
+        (false, true) => format!("stdout before the kill: {out}"),
+        (true, false) => format!("stderr before the kill: {err}"),
+        (false, false) => format!("before the kill — stdout: {out}; stderr: {err}"),
+    };
+    GlassError::Backend(format!(
+        "{op}: no answer within {budget:?}, so the process was killed; {said}"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+    use std::time::Duration;
+
+    #[test]
+    fn a_fast_command_returns_its_output() {
+        let out = run_bounded(
+            Command::new("/bin/sh").args(["-c", "printf ready"]),
+            Duration::from_secs(10),
+            "test:fast",
+        )
+        .expect("fast command");
+        assert_eq!(String::from_utf8_lossy(&out.stdout), "ready");
+    }
+
+    #[test]
+    fn a_command_that_outlives_its_budget_is_killed_and_named() {
+        let started = std::time::Instant::now();
+        let err = run_bounded(
+            Command::new("/bin/sh").args(["-c", "sleep 30"]),
+            Duration::from_millis(300),
+            "test:hang",
+        )
+        .expect_err("must not wait out a hung child");
+        // The budget is enforced, not merely documented.
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "waited {:?}",
+            started.elapsed()
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("test:hang"), "{msg}");
+        assert!(msg.contains("300ms"), "{msg}");
+    }
+
+    #[test]
+    fn output_larger_than_a_pipe_buffer_still_completes() {
+        // 1 MiB, well past the ~64 KiB a pipe holds: a parent that waits without draining
+        // deadlocks here, and the deadline never fires because the child never exits.
+        let out = run_bounded(
+            Command::new("/bin/sh").args(["-c", "yes ABCDEFGH | head -c 1048576"]),
+            Duration::from_secs(20),
+            "test:flood",
+        )
+        .expect("a draining implementation completes");
+        assert_eq!(out.stdout.len(), 1_048_576);
+    }
+
+    #[test]
+    fn a_nonzero_exit_is_returned_not_reported_as_a_timeout() {
+        let out = run_bounded(
+            Command::new("/bin/sh").args(["-c", "exit 3"]),
+            Duration::from_secs(10),
+            "test:exit",
+        )
+        .expect("a failing command still yields its Output");
+        assert_eq!(out.status.code(), Some(3));
+    }
+
+    #[test]
+    fn stderr_is_captured_alongside_stdout() {
+        let out = run_bounded(
+            Command::new("/bin/sh").args(["-c", "printf out; printf err 1>&2"]),
+            Duration::from_secs(10),
+            "test:streams",
+        )
+        .expect("both streams");
+        assert_eq!(String::from_utf8_lossy(&out.stdout), "out");
+        assert_eq!(String::from_utf8_lossy(&out.stderr), "err");
+    }
+
+    #[test]
+    fn what_a_hung_child_said_before_the_kill_rides_in_the_error() {
+        // A partial `uiautomator dump` says more about a hang than silence does.
+        let err = run_bounded(
+            Command::new("/bin/sh").args(["-c", "printf partial-tree; sleep 30"]),
+            Duration::from_millis(300),
+            "test:partial",
+        )
+        .expect_err("must time out");
+        assert!(err.to_string().contains("partial-tree"), "{err}");
+    }
+
+    #[test]
+    fn a_missing_program_is_a_spawn_error_naming_the_operation() {
+        let err = run_bounded(
+            &mut Command::new("/nonexistent/glass-test-binary"),
+            Duration::from_secs(10),
+            "test:spawn",
+        )
+        .expect_err("spawn must fail");
+        assert!(err.to_string().contains("test:spawn"), "{err}");
+    }
+}

--- a/crates/glass-core/src/bounded.rs
+++ b/crates/glass-core/src/bounded.rs
@@ -27,8 +27,8 @@ const POLL: Duration = Duration::from_millis(20);
 const POLL_START: Duration = Duration::from_millis(1);
 
 /// How long to let a drain thread reach EOF after the child has exited. Normally instant — the pipe
-/// closes with the child — but a grandchild that inherited the write end keeps it open, and no
-/// output is worth stalling a completed call for.
+/// closes with the child — but something the child started may hold it open, and the call ends as
+/// an error rather than stalling for it.
 const DRAIN_SETTLE: Duration = Duration::from_millis(200);
 
 /// How long to wait for a killed child to leave the process table. Bounded rather than a plain
@@ -38,8 +38,8 @@ const DRAIN_SETTLE: Duration = Duration::from_millis(200);
 const KILL_REAP: Duration = Duration::from_millis(500);
 
 /// Most output ONE PIPE may buffer, so a drain thread left reading a pipe something else still
-/// holds cannot grow without bound. Far past any real one-shot's output — a full `uiautomator dump`
-/// of a deep tree is a few hundred KiB.
+/// holds cannot grow without bound. Far past any real one-shot's output: measured on the dogfood
+/// AVD, a `uiautomator dump` is ~12KB and the largest, `exec-out screencap`, is ~10MB.
 const MAX_CAPTURE: usize = 64 * 1024 * 1024;
 
 /// Run `cmd` to completion, or kill it and fail once `budget` elapses.
@@ -383,14 +383,10 @@ mod tests {
 
     #[test]
     fn a_pipe_still_open_after_the_child_exits_ends_promptly_as_an_error() {
-        // A grandchild that inherited the write end keeps the pipe open after the child exits, so
-        // EOF may never come. Two things must hold, and they pull against each other: the call must
-        // not stall waiting for EOF, and it must not pass off what arrived as the whole answer —
-        // `dumpsys window windows` is parsed by a tolerant line scanner that would read a truncated
-        // dump as a shorter window list, and glass would report the wrong geometry from it.
-        //
-        // The parent cannot tell "the grandchild will write nothing more" from "the grandchild is
-        // about to write", so both settle out as this error rather than a short success.
+        // Two properties that pull against each other: the call must not stall waiting for an EOF
+        // that may never come, and it must not pass off what arrived as the whole answer. The
+        // parent cannot tell "the grandchild will write nothing more" from "it is about to write",
+        // so both settle out as this error.
         let started = Instant::now();
         let err = run_bounded(
             Command::new("/bin/sh").args([

--- a/crates/glass-core/src/bounded.rs
+++ b/crates/glass-core/src/bounded.rs
@@ -14,9 +14,13 @@ use std::time::{Duration, Instant};
 
 use crate::{GlassError, Result};
 
+/// The phrase a timeout error carries, so a caller can recognise one without matching on prose it
+/// does not own — `glass-android` offers `adb kill-server` for a timeout and for nothing else.
+pub const TIMED_OUT: &str = "no answer within";
+
 /// Longest gap between checks on a child that has not exited yet. The wait starts far tighter and
-/// backs off to this, so a one-shot that answers in a millisecond is not billed a full tick while
-/// waiting out a three-minute boot still costs only a handful of wakeups.
+/// backs off to this, so a one-shot that answers in a millisecond is not billed a full tick and a
+/// long wait settles to one wakeup every 20ms.
 const POLL: Duration = Duration::from_millis(20);
 
 /// First gap between checks, doubled up to [`POLL`].
@@ -33,7 +37,7 @@ const DRAIN_SETTLE: Duration = Duration::from_millis(200);
 /// caller who has already spent their whole budget. A stray zombie is the cheaper outcome.
 const KILL_REAP: Duration = Duration::from_millis(500);
 
-/// Most output one call may buffer, so a drain thread left reading a pipe some grandchild still
+/// Most output ONE PIPE may buffer, so a drain thread left reading a pipe something else still
 /// holds cannot grow without bound. Far past any real one-shot's output — a full `uiautomator dump`
 /// of a deep tree is a few hundred KiB.
 const MAX_CAPTURE: usize = 64 * 1024 * 1024;
@@ -83,14 +87,22 @@ fn run_bounded_inner(
         .spawn()
         .map_err(|e| GlassError::Backend(format!("{op}: failed to start: {e}")))?;
 
-    if let Some(bytes) = stdin {
-        // Best-effort and detached: a child that never reads its stdin must not block the parent,
-        // and whatever it does read it reads before it exits, which the deadline already covers.
-        if let Some(mut pipe) = child.stdin.take() {
-            std::thread::spawn(move || {
-                let _ = pipe.write_all(&bytes);
-            });
-        }
+    // Written on its own thread: a child that answers without consuming its input would otherwise
+    // leave the parent blocked in `write` with the deadline out of reach. The outcome is shared
+    // back, because a payload that only partly landed is the same silent truncation as a partial
+    // read — `pbcopy` would report a clipboard it never fully received.
+    let wrote: Arc<Mutex<Option<std::io::Error>>> = Arc::new(Mutex::new(None));
+    if let Some(bytes) = stdin
+        && let Some(mut pipe) = child.stdin.take()
+    {
+        let outcome = Arc::clone(&wrote);
+        std::thread::spawn(move || {
+            if let Err(e) = pipe.write_all(&bytes)
+                && let Ok(mut outcome) = outcome.lock()
+            {
+                *outcome = Some(e);
+            }
+        });
     }
 
     let stdout = Pipe::drain(child.stdout.take());
@@ -131,10 +143,17 @@ fn run_bounded_inner(
     // tolerant line scanner that would read a truncated dump as a shorter window list, and glass
     // would then report the wrong geometry. `Command::output` cannot produce this — it reads to EOF
     // — so failing here keeps the contract callers already had.
+    if let Ok(mut wrote) = wrote.lock()
+        && let Some(e) = wrote.take()
+    {
+        return Err(GlassError::Backend(format!(
+            "{op}: could not write all of its input ({e}), so it acted on a partial payload"
+        )));
+    }
     if !out_done || !err_done {
         return Err(GlassError::Backend(format!(
-            "{op}: exited {status} but its output was still arriving {DRAIN_SETTLE:?} later \
-             (something inherited its pipe), so the {} bytes read may be incomplete",
+            "{op}: exited, but its output pipe had not reached end-of-file {DRAIN_SETTLE:?} \
+             later (something it started may still hold it), so the {} bytes read may be incomplete",
             out_bytes.len() + err_bytes.len()
         )));
     }
@@ -249,16 +268,9 @@ fn kill_and_reap(child: &mut Child) -> bool {
     reaped
 }
 
-/// Kill the child and describe the timeout, including whatever it managed to say first — a partial
-/// `uiautomator dump` tells a reader more about the hang than silence does.
-fn timed_out(
-    child: &mut Child,
-    op: &str,
-    budget: Duration,
-    stdout: Pipe,
-    stderr: Pipe,
-) -> GlassError {
-    let reaped = kill_and_reap(child);
+/// Whatever the child managed to say before it was killed — a partial `uiautomator dump` tells a
+/// reader more about a hang than silence does.
+fn said_before_the_kill(stdout: &Pipe, stderr: &Pipe) -> String {
     let out = String::from_utf8_lossy(&stdout.snapshot())
         .trim()
         .to_string();
@@ -272,17 +284,30 @@ fn timed_out(
     if !err.is_empty() {
         said.push(format!("stderr: {err}"));
     }
-    let said = if said.is_empty() {
+    if said.is_empty() {
         "it produced no output before the kill".to_string()
     } else {
         format!("before the kill — {}", said.join("; "))
-    };
+    }
+}
+
+/// Kill the child and describe the timeout, including whatever it managed to say first — a partial
+/// `uiautomator dump` tells a reader more about the hang than silence does.
+fn timed_out(
+    child: &mut Child,
+    op: &str,
+    budget: Duration,
+    stdout: Pipe,
+    stderr: Pipe,
+) -> GlassError {
+    let reaped = kill_and_reap(child);
+    let said = said_before_the_kill(&stdout, &stderr);
     let fate = if reaped {
         "so the process was killed"
     } else {
         "so the process was killed, though it had not exited yet (it may be stuck in the kernel)"
     };
-    GlassError::Backend(format!("{op}: no answer within {budget:?}, {fate}; {said}"))
+    GlassError::Backend(format!("{op}: {TIMED_OUT} {budget:?}, {fate}; {said}"))
 }
 #[cfg(test)]
 mod tests {
@@ -422,6 +447,7 @@ mod tests {
         // `kill -0` fails once the process is gone, including as a zombie's parent has reaped it.
         let alive = Command::new("/bin/kill")
             .args(["-0", &pid.to_string()])
+            .stderr(Stdio::null())
             .status()
             .map(|s| s.success())
             .unwrap_or(false);
@@ -441,16 +467,28 @@ mod tests {
     }
 
     #[test]
-    fn a_child_that_ignores_its_stdin_still_returns() {
-        // A tool that answers without consuming its input would block a parent that wrote inline.
-        let out = run_bounded_with_stdin(
+    fn a_child_that_ignores_its_stdin_ends_promptly_and_says_the_payload_did_not_land() {
+        // Two properties, and the first is why the write is on a thread at all: a tool that answers
+        // without reading its input must not leave the parent blocked in `write`. The second is
+        // that the payload going nowhere is reported — `pbcopy` exits 0 whether or not it received
+        // the whole clipboard, so silence here would be a clipboard glass claims it set.
+        let started = Instant::now();
+        let err = run_bounded_with_stdin(
             Command::new("/bin/sh").args(["-c", "printf done"]),
             Duration::from_secs(10),
             "test:stdin-ignored",
-            &vec![b'x'; 1024 * 1024],
+            &vec![b'x'; 4 * 1024 * 1024],
         )
-        .expect("must not block on an unread stdin");
-        assert_eq!(String::from_utf8_lossy(&out.stdout), "done");
+        .expect_err("an unwritten payload must not pass silently");
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "waited {:?} — the write must not block the call",
+            started.elapsed()
+        );
+        assert!(
+            err.to_string().contains("partial payload"),
+            "must say the input did not land: {err}"
+        );
     }
 
     #[test]

--- a/crates/glass-core/src/bounded.rs
+++ b/crates/glass-core/src/bounded.rs
@@ -128,7 +128,7 @@ fn run_bounded_inner(
                 )));
             }
         }
-        if Instant::now() >= deadline {
+        if deadline_passed(Instant::now(), deadline) {
             return Err(timed_out(&mut child, op, budget, stdout, stderr));
         }
         std::thread::sleep(wait);
@@ -207,7 +207,7 @@ impl Pipe {
                     }
                     Ok(n) => {
                         let Ok(mut sink) = sink.lock() else { break };
-                        if sink.len() + n > MAX_CAPTURE {
+                        if would_exceed_capture(sink.len(), n) {
                             break;
                         }
                         sink.extend_from_slice(&chunk[..n]);
@@ -250,9 +250,20 @@ impl Pipe {
     }
 }
 
+/// Whether appending `n` more bytes to a buffer of `len` would pass [`MAX_CAPTURE`].
+fn would_exceed_capture(len: usize, n: usize) -> bool {
+    len + n > MAX_CAPTURE
+}
+
+/// Whether `deadline` has arrived. Its own function so the boundary — a deadline exactly reached
+/// counts as passed — is pinned by a test rather than by an inequality no timing test can pin.
+fn deadline_passed(now: Instant, deadline: Instant) -> bool {
+    now >= deadline
+}
+
 /// Sleep in [`POLL`] steps until `ready` answers true or `deadline` passes.
 fn poll_until(deadline: Instant, mut ready: impl FnMut() -> bool) {
-    while !ready() && Instant::now() < deadline {
+    while !ready() && !deadline_passed(Instant::now(), deadline) {
         std::thread::sleep(POLL);
     }
 }
@@ -484,6 +495,87 @@ mod tests {
         assert!(
             err.to_string().contains("partial payload"),
             "must say the input did not land: {err}"
+        );
+    }
+
+    #[test]
+    fn the_capture_cap_holds_the_largest_real_payload_and_stops_just_past_itself() {
+        // The cap exists to bound an abandoned drain thread, so it has to clear the biggest thing a
+        // one-shot really produces — a ~10MB `exec-out screencap` — by a wide margin.
+        // A const block, per clippy: the cap is a constant, so this is a compile-time claim. Under
+        // a mutation that shrinks it the crate stops compiling, which the gate counts too.
+        const { assert!(MAX_CAPTURE >= 10 * 1024 * 1024) };
+        // Exactly at the cap is still allowed; one byte past it is not.
+        assert!(!would_exceed_capture(MAX_CAPTURE, 0));
+        assert!(!would_exceed_capture(MAX_CAPTURE - 1, 1));
+        assert!(would_exceed_capture(MAX_CAPTURE, 1));
+    }
+
+    #[test]
+    fn a_deadline_exactly_reached_counts_as_passed() {
+        // The boundary no timing test can reach: waiting one more round at the deadline would mean
+        // a budget that is always at least one poll longer than it says.
+        let t = Instant::now();
+        assert!(deadline_passed(t, t));
+        assert!(deadline_passed(t + Duration::from_millis(1), t));
+        assert!(!deadline_passed(t, t + Duration::from_millis(1)));
+    }
+
+    #[test]
+    fn an_interrupted_read_resumes_instead_of_ending_the_stream() {
+        // EINTR is not end of stream: `read_to_end` retries it for you, a bare `read` does not, and
+        // glass-mcp installs signal handlers. Treating it as EOF would silently truncate.
+        struct Interrupts {
+            reads: usize,
+        }
+        impl Read for Interrupts {
+            fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+                self.reads += 1;
+                match self.reads {
+                    1 => Err(std::io::Error::from(std::io::ErrorKind::Interrupted)),
+                    2 => {
+                        buf[..5].copy_from_slice(b"after");
+                        Ok(5)
+                    }
+                    _ => Ok(0),
+                }
+            }
+        }
+        let pipe = Pipe::drain(Some(Interrupts { reads: 0 }));
+        let (bytes, done) = pipe.take(Instant::now() + Duration::from_secs(5));
+        assert_eq!(String::from_utf8_lossy(&bytes), "after");
+        assert!(done, "the reader reached EOF, so the read is complete");
+    }
+
+    #[test]
+    fn one_pipe_left_open_is_enough_to_report_an_incomplete_read() {
+        // stderr closes with the child; only stdout stays held. A check that demanded BOTH pipes be
+        // incomplete would call this a clean, complete answer.
+        let err = run_bounded(
+            Command::new("/bin/sh")
+                .args(["-c", "printf head; { sleep 1; printf tail; } 2>/dev/null &"]),
+            Duration::from_secs(20),
+            "test:one-pipe",
+        )
+        .expect_err("one unfinished pipe is an incomplete read");
+        assert!(err.to_string().contains("may be incomplete"), "{err}");
+    }
+
+    #[test]
+    fn a_hung_child_that_only_wrote_to_stderr_is_quoted_too() {
+        // The stdout branch is covered above; without this, deleting the emptiness check on the
+        // stderr branch goes unnoticed.
+        let err = run_bounded(
+            Command::new("/bin/sh").args(["-c", "printf complaining 1>&2; sleep 30"]),
+            Duration::from_millis(300),
+            "test:stderr-only",
+        )
+        .expect_err("must time out");
+        let msg = err.to_string();
+        assert!(msg.contains("stderr: complaining"), "{msg}");
+        assert!(
+            !msg.contains("stdout:"),
+            "nothing was written to stdout: {msg}"
         );
     }
 

--- a/crates/glass-core/src/bounded.rs
+++ b/crates/glass-core/src/bounded.rs
@@ -132,7 +132,7 @@ fn run_bounded_inner(
             return Err(timed_out(&mut child, op, budget, stdout, stderr));
         }
         std::thread::sleep(wait);
-        wait = (wait * 2).min(POLL);
+        wait = next_wait(wait);
     };
 
     // One deadline for both pipes, so a finished call is never stalled twice over.
@@ -250,6 +250,13 @@ impl Pipe {
     }
 }
 
+/// The next gap between checks: double, capped at [`POLL`]. Its own function so the growth is
+/// pinned by a test — an arithmetic slip here only changes how often the parent wakes, which no
+/// behavioural test can see.
+fn next_wait(previous: Duration) -> Duration {
+    (previous * 2).min(POLL)
+}
+
 /// Whether appending `n` more bytes to a buffer of `len` would pass [`MAX_CAPTURE`].
 fn would_exceed_capture(len: usize, n: usize) -> bool {
     len + n > MAX_CAPTURE
@@ -322,11 +329,19 @@ fn timed_out(
 }
 #[cfg(test)]
 mod tests {
+    //! The tests that drive a real child use `/bin/sh` and friends, so they are `cfg(unix)`: this
+    //! module runs on Windows too — `glass-android` shells out to `adb` from any host — and a
+    //! hardcoded `/bin/sh` there fails with "the system cannot find the path specified" rather than
+    //! testing anything. What stays portable is everything that needs no process: the capture cap,
+    //! the deadline boundary, the backoff, and the pipe-drain behaviour, which takes any `Read`.
+
     use super::*;
+    #[cfg(unix)]
     use std::process::Command;
     use std::time::Duration;
 
     #[test]
+    #[cfg(unix)]
     fn a_fast_command_returns_its_output() {
         let out = run_bounded(
             Command::new("/bin/sh").args(["-c", "printf ready"]),
@@ -338,6 +353,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn a_command_that_outlives_its_budget_is_killed_and_named() {
         let started = std::time::Instant::now();
         let err = run_bounded(
@@ -358,6 +374,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn a_nonzero_exit_is_returned_not_reported_as_a_timeout() {
         let out = run_bounded(
             Command::new("/bin/sh").args(["-c", "exit 3"]),
@@ -369,6 +386,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn stderr_is_captured_alongside_stdout() {
         let out = run_bounded(
             Command::new("/bin/sh").args(["-c", "printf out; printf err 1>&2"]),
@@ -381,6 +399,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn what_a_hung_child_said_before_the_kill_rides_in_the_error() {
         // A partial `uiautomator dump` says more about a hang than silence does.
         let err = run_bounded(
@@ -393,6 +412,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn a_pipe_still_open_after_the_child_exits_ends_promptly_as_an_error() {
         // Two properties that pull against each other: the call must not stall waiting for an EOF
         // that may never come, and it must not pass off what arrived as the whole answer. The
@@ -419,6 +439,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn a_flood_on_either_pipe_completes() {
         // 1 MiB down each stream: draining only stdout would deadlock on a stderr-heavy child.
         let out = run_bounded(
@@ -435,6 +456,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn a_killed_child_is_reaped_not_left_a_zombie() {
         // `Child::drop` does not reap on Unix, and glass-mcp is long-lived, so a timeout that
         // skipped the wait would leak a zombie per hung call. The pid rides out in the error.
@@ -462,6 +484,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn stdin_is_written_to_the_child() {
         let out = run_bounded_with_stdin(
             &mut Command::new("/bin/cat"),
@@ -474,6 +497,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn a_child_that_ignores_its_stdin_ends_promptly_and_says_the_payload_did_not_land() {
         // Two properties, and the first is why the write is on a thread at all: a tool that answers
         // without reading its input must not leave the parent blocked in `write`. The second is
@@ -548,6 +572,45 @@ mod tests {
     }
 
     #[test]
+    fn any_other_read_error_ends_the_stream_and_is_not_a_complete_read() {
+        // Only EINTR resumes. Resuming past a real error would walk on to the next read and call
+        // whatever it found a finished stream — the truncation this module refuses to return.
+        struct Broken {
+            reads: usize,
+        }
+        impl Read for Broken {
+            fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+                self.reads += 1;
+                match self.reads {
+                    1 => Err(std::io::Error::other("device disappeared")),
+                    _ => Ok(0),
+                }
+            }
+        }
+        let pipe = Pipe::drain(Some(Broken { reads: 0 }));
+        let (bytes, done) = pipe.take(Instant::now() + Duration::from_secs(5));
+        assert!(bytes.is_empty(), "{bytes:?}");
+        assert!(!done, "a broken read is not an end-of-file");
+    }
+
+    #[test]
+    fn the_wait_between_checks_doubles_up_to_the_cap() {
+        // A one-shot answering in a millisecond must not be billed a full tick, and a long wait
+        // must settle to a steady cadence rather than spinning.
+        assert_eq!(
+            next_wait(Duration::from_millis(1)),
+            Duration::from_millis(2)
+        );
+        assert_eq!(
+            next_wait(Duration::from_millis(8)),
+            Duration::from_millis(16)
+        );
+        assert_eq!(next_wait(Duration::from_millis(16)), POLL);
+        assert_eq!(next_wait(POLL), POLL);
+    }
+
+    #[test]
+    #[cfg(unix)]
     fn one_pipe_left_open_is_enough_to_report_an_incomplete_read() {
         // stderr closes with the child; only stdout stays held. A check that demanded BOTH pipes be
         // incomplete would call this a clean, complete answer.
@@ -562,6 +625,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn a_hung_child_that_only_wrote_to_stderr_is_quoted_too() {
         // The stdout branch is covered above; without this, deleting the emptiness check on the
         // stderr branch goes unnoticed.
@@ -580,6 +644,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn a_missing_program_is_a_spawn_error_naming_the_operation() {
         let err = run_bounded(
             &mut Command::new("/nonexistent/glass-test-binary"),

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -13,7 +13,7 @@ pub mod toolpath;
 pub use toolpath::tool_path;
 
 pub mod bounded;
-pub use bounded::{run_bounded, run_bounded_with_stdin};
+pub use bounded::{TIMED_OUT, run_bounded, run_bounded_with_stdin};
 
 pub mod frame;
 pub use frame::{Frame, Region};

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -12,6 +12,9 @@ pub use error::{GlassError, Result};
 pub mod toolpath;
 pub use toolpath::tool_path;
 
+pub mod bounded;
+pub use bounded::run_bounded;
+
 pub mod frame;
 pub use frame::{Frame, Region};
 

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -13,7 +13,7 @@ pub mod toolpath;
 pub use toolpath::tool_path;
 
 pub mod bounded;
-pub use bounded::run_bounded;
+pub use bounded::{run_bounded, run_bounded_with_stdin};
 
 pub mod frame;
 pub use frame::{Frame, Region};

--- a/crates/glass-ios/src/doctor.rs
+++ b/crates/glass-ios/src/doctor.rs
@@ -100,14 +100,14 @@ fn device_check(p: &Probe) -> Check {
     }
 }
 
+/// Deadline for each doctor probe. Doctor reports on the host rather than driving it, so every
+/// probe here is a fast query; a tool that does not answer in this long is itself the finding.
+const PROBE_BUDGET: Duration = Duration::from_secs(10);
+
 /// Build the iOS doctor checks by probing the host with real `xcrun`/`xcode-select`
 /// calls. Best-effort: a missing tool simply makes the corresponding check report
 /// not-ok with a remedy, rather than failing this function. `_deep` is accepted for
 /// signature parity with the other backends' doctors; iOS has no expensive deep probe.
-/// Deadline for each doctor probe. Doctor reports on the host rather than driving it, so every
-/// probe here is a fast query; a tool that does not answer in this long is itself the finding.
-const PROBE_BUDGET: std::time::Duration = std::time::Duration::from_secs(10);
-
 pub fn checks(_deep: bool) -> Vec<Check> {
     // Bounded like every other one-shot: doctor's job is to report, and a doctor that hangs on a
     // wedged tool reports nothing at all. A timeout lands in the same `None` as a missing tool,
@@ -115,14 +115,20 @@ pub fn checks(_deep: bool) -> Vec<Check> {
     let mut xcode_select = Command::new("xcode-select");
     xcode_select.arg("-p");
     let xcode_dir = glass_core::run_bounded(&mut xcode_select, PROBE_BUDGET, "xcode-select:-p")
+        .inspect_err(|e| eprintln!("glass-ios doctor: {e}"))
         .ok()
         .filter(|o| o.status.success())
         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
 
+    // Labelled per probe, not "doctor probe": a timeout has to say whether `help`, `list runtimes`
+    // or `list devices` hung. The error is logged rather than dropped, because `.ok()` folds a
+    // timeout into the same `None` as a missing tool, and the resulting check then recommends
+    // installing Xcode to someone whose Xcode is fine but whose CoreSimulator is wedged.
     let simctl_out = |args: &[&str]| {
         let mut cmd = Command::new("xcrun");
         cmd.args(args);
-        glass_core::run_bounded(&mut cmd, PROBE_BUDGET, "xcrun:doctor probe")
+        glass_core::run_bounded(&mut cmd, PROBE_BUDGET, &format!("xcrun:{}", args.join(" ")))
+            .inspect_err(|e| eprintln!("glass-ios doctor: {e}"))
             .ok()
             .filter(|o| o.status.success())
             .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())

--- a/crates/glass-ios/src/doctor.rs
+++ b/crates/glass-ios/src/doctor.rs
@@ -104,18 +104,25 @@ fn device_check(p: &Probe) -> Check {
 /// calls. Best-effort: a missing tool simply makes the corresponding check report
 /// not-ok with a remedy, rather than failing this function. `_deep` is accepted for
 /// signature parity with the other backends' doctors; iOS has no expensive deep probe.
+/// Deadline for each doctor probe. Doctor reports on the host rather than driving it, so every
+/// probe here is a fast query; a tool that does not answer in this long is itself the finding.
+const PROBE_BUDGET: std::time::Duration = std::time::Duration::from_secs(10);
+
 pub fn checks(_deep: bool) -> Vec<Check> {
-    let xcode_dir = Command::new("xcode-select")
-        .arg("-p")
-        .output()
+    // Bounded like every other one-shot: doctor's job is to report, and a doctor that hangs on a
+    // wedged tool reports nothing at all. A timeout lands in the same `None` as a missing tool,
+    // so the check still says not-ok with its remedy.
+    let mut xcode_select = Command::new("xcode-select");
+    xcode_select.arg("-p");
+    let xcode_dir = glass_core::run_bounded(&mut xcode_select, PROBE_BUDGET, "xcode-select:-p")
         .ok()
         .filter(|o| o.status.success())
         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
 
     let simctl_out = |args: &[&str]| {
-        Command::new("xcrun")
-            .args(args)
-            .output()
+        let mut cmd = Command::new("xcrun");
+        cmd.args(args);
+        glass_core::run_bounded(&mut cmd, PROBE_BUDGET, "xcrun:doctor probe")
             .ok()
             .filter(|o| o.status.success())
             .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -1,8 +1,7 @@
 //! `IosPlatform`: the `glass_core::Platform` implementation that drives a single
 //! foreground app on an iOS Simulator over `xcrun simctl`.
 
-use std::io::Write;
-use std::process::{Command, Stdio};
+use std::process::Command;
 use std::time::{Duration, Instant};
 
 use glass_core::{
@@ -197,7 +196,15 @@ fn pid_is_running(pid: u32) -> bool {
             );
             true
         }
-        Err(_) => true,
+        // Its sibling above logs before failing open; a `ps` that did not answer in ten seconds on
+        // a healthy host is at least as worth saying out loud as one that printed to stderr.
+        Err(e) => {
+            eprintln!(
+                "glass-ios: could not check whether the app is still running ({e}); \
+                 treating it as running"
+            );
+            true
+        }
     }
 }
 
@@ -582,34 +589,22 @@ impl Platform for IosPlatform {
 
     fn set_clipboard(&mut self, text: &str) -> Result<()> {
         self.running()?;
-        // `simctl pbcopy` reads the clipboard text from stdin, so it needs a piped child
-        // rather than the `Simctl::run` one-shot-output helper.
-        let mut child = Command::new(self.target.simctl().program())
-            .args(
-                self.target
-                    .simctl()
-                    .full_args(&["pbcopy", self.target.udid()]),
-            )
-            .stdin(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .map_err(|e| GlassError::Backend(format!("pbcopy: {e}")))?;
-        let mut stdin = child
-            .stdin
-            .take()
-            .ok_or_else(|| GlassError::Backend("pbcopy: failed to open stdin".into()))?;
-        if let Err(e) = stdin.write_all(text.as_bytes()) {
-            // Reap the child before returning so it doesn't outlive us as a zombie; its exit
-            // status doesn't matter here since we're already reporting the write failure.
-            let _ = child.wait();
-            return Err(GlassError::Backend(format!("pbcopy write: {e}")));
-        }
-        // Close our end so `pbcopy` sees EOF and exits; holding it open past this point
-        // would deadlock the `wait_with_output()` below.
-        drop(stdin);
-        let out = child
-            .wait_with_output()
-            .map_err(|e| GlassError::Backend(format!("pbcopy wait: {e}")))?;
+        // `simctl pbcopy` takes the clipboard text on stdin, so it cannot go through `Simctl::run`,
+        // which closes stdin — but it is a one-shot `simctl` call like any other and gets the same
+        // deadline. The runner writes stdin on its own thread, so a `pbcopy` that exits without
+        // reading everything cannot leave this blocked in `write`.
+        let mut cmd = Command::new(self.target.simctl().program());
+        cmd.args(
+            self.target
+                .simctl()
+                .full_args(&["pbcopy", self.target.udid()]),
+        );
+        let out = glass_core::run_bounded_with_stdin(
+            &mut cmd,
+            crate::simctl::SimctlOp::Query.budget(),
+            "simctl:pbcopy",
+            text.as_bytes(),
+        )?;
         if out.status.success() {
             Ok(())
         } else {

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -173,10 +173,11 @@ fn launch_stderr_tail(simctl: &Simctl, udid: &str) -> Option<String> {
 fn pid_is_running(pid: u32) -> bool {
     // Absolute path: `ps` resolved through `PATH` could be a shim whose non-zero exit would be
     // read below as "the app died", turning a healthy launch into a confident false report.
-    match Command::new("/bin/ps")
-        .args(["-p", &pid.to_string(), "-o", "state="])
-        .output()
-    {
+    let mut cmd = Command::new("/bin/ps");
+    cmd.args(["-p", &pid.to_string(), "-o", "state="]);
+    // A timeout here reads the same as `ps` being missing: not knowable, so not evidence the app
+    // died (see this function's doc). Bounded so a wedged `ps` cannot hold up a launch.
+    match glass_core::run_bounded(&mut cmd, std::time::Duration::from_secs(10), "ps:pid-state") {
         // A process that has exited but not yet been reaped is still listed, in state `Z`. That
         // is a real window here — the app's parent is `launchd_sim`, not this process — and a
         // zombie is a dead app, so the state is read rather than just the exit status.
@@ -235,10 +236,13 @@ pub(crate) fn bundle_id_from_run(run: &[String]) -> Result<(Option<String>, Stri
         .ok_or_else(|| GlassError::Backend("cannot start app: run command is empty".into()))?;
     if looks_like_app_path(first) {
         let plist = format!("{first}/Info.plist");
-        let out = Command::new("plutil")
-            .args(["-extract", "CFBundleIdentifier", "raw", "-o", "-", &plist])
-            .output()
-            .map_err(|e| GlassError::Backend(format!("plutil: {e}")))?;
+        let mut cmd = Command::new("plutil");
+        cmd.args(["-extract", "CFBundleIdentifier", "raw", "-o", "-", &plist]);
+        let out = glass_core::run_bounded(
+            &mut cmd,
+            std::time::Duration::from_secs(10),
+            "plutil:CFBundleIdentifier",
+        )?;
         if !out.status.success() {
             return Err(GlassError::Backend(format!(
                 "could not read CFBundleIdentifier from {plist}: {}",
@@ -427,9 +431,13 @@ impl Platform for IosPlatform {
         for (k, v) in &spec.env {
             launch.env(format!("SIMCTL_CHILD_{k}"), v);
         }
-        let out = launch
-            .output()
-            .map_err(|e| GlassError::Backend(format!("simctl launch: {e}")))?;
+        // Bounded like every other simctl call, but spelled out here because this one cannot go
+        // through `Simctl::run`: it needs `SIMCTL_CHILD_*` in the child's environment.
+        let out = glass_core::run_bounded(
+            &mut launch,
+            crate::simctl::SimctlOp::Lifecycle.budget(),
+            "simctl:launch",
+        )?;
         if !out.status.success() {
             return Err(GlassError::Backend(format!(
                 "simctl launch failed: {}",

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -599,12 +599,11 @@ impl Platform for IosPlatform {
                 .simctl()
                 .full_args(&["pbcopy", self.target.udid()]),
         );
-        let out = glass_core::run_bounded_with_stdin(
-            &mut cmd,
-            crate::simctl::SimctlOp::Query.budget(),
-            "simctl:pbcopy",
-            text.as_bytes(),
-        )?;
+        // Budget and label from the classifier, like every other simctl call — this site only
+        // exists apart because the payload goes on stdin, not because it is special.
+        let op = crate::simctl::SimctlOp::for_sub(&["pbcopy"]);
+        let out =
+            glass_core::run_bounded_with_stdin(&mut cmd, op.budget(), op.label(), text.as_bytes())?;
         if out.status.success() {
             Ok(())
         } else {

--- a/crates/glass-ios/src/simctl.rs
+++ b/crates/glass-ios/src/simctl.rs
@@ -1,6 +1,60 @@
 use std::process::Command;
+use std::time::Duration;
 
-use glass_core::{GlassError, Result};
+use glass_core::{GlassError, Result, run_bounded};
+
+/// What a `simctl` invocation is doing, which is what decides how long it may take.
+///
+/// `BootStatus` is the outlier: `simctl bootstatus <udid> -b` blocks *by design* until the
+/// simulator finishes booting — minutes on a cold machine — so it is bounded generously rather
+/// than left unbounded, because a boot that never completes must still end as an error.
+///
+/// Budgets are ~4x the slowest healthy run measured on the dogfood simulator, floored at 10s.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SimctlOp {
+    /// `bootstatus -b` — waits out the whole boot.
+    BootStatus,
+    /// `launch` / `install` / `boot` / `shutdown` — device lifecycle.
+    Lifecycle,
+    /// `io <udid> screenshot` — encodes a frame.
+    Screenshot,
+    /// Everything else: `list`, `pbpaste`, `terminate`, `spawn`.
+    Query,
+}
+
+impl SimctlOp {
+    /// The deadline for this kind of call.
+    pub fn budget(self) -> Duration {
+        match self {
+            Self::BootStatus => Duration::from_secs(180),
+            Self::Lifecycle => Duration::from_secs(60),
+            Self::Screenshot => Duration::from_secs(15),
+            Self::Query => Duration::from_secs(10),
+        }
+    }
+
+    /// Classify a `simctl` subcommand argv, so no call site passes its own budget and none can pick
+    /// a longer one than its work needs. An unrecognized call is [`SimctlOp::Query`] — the SHORT
+    /// budget, so a future caller that forgets to extend this fails fast.
+    pub fn for_sub(sub: &[&str]) -> Self {
+        match sub.first().copied() {
+            Some("bootstatus") => Self::BootStatus,
+            Some("launch" | "install" | "boot" | "shutdown" | "erase") => Self::Lifecycle,
+            Some("io") => Self::Screenshot,
+            _ => Self::Query,
+        }
+    }
+
+    /// Operation name for the timeout error, prefixed so a reader knows which tool hung.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::BootStatus => "simctl:bootstatus",
+            Self::Lifecycle => "simctl:lifecycle",
+            Self::Screenshot => "simctl:io screenshot",
+            Self::Query => "simctl:query",
+        }
+    }
+}
 
 /// A stateless `xcrun simctl <argv>` runner. Every call site passes the target device's UDID
 /// positionally in `sub` (matching how `simctl` itself takes it), so this holds no per-device
@@ -32,10 +86,10 @@ impl Simctl {
     }
 
     fn output(&self, sub: &[&str]) -> Result<Vec<u8>> {
-        let out = Command::new(self.program())
-            .args(self.full_args(sub))
-            .output()
-            .map_err(|e| GlassError::Backend(format!("failed to run xcrun simctl: {e}")))?;
+        let op = SimctlOp::for_sub(sub);
+        let mut cmd = Command::new(self.program());
+        cmd.args(self.full_args(sub));
+        let out = run_bounded(&mut cmd, op.budget(), op.label())?;
         if !out.status.success() {
             return Err(GlassError::Backend(format!(
                 "simctl {:?} failed: {}",
@@ -50,6 +104,47 @@ impl Simctl {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn bootstatus_may_take_far_longer_than_any_ordinary_call() {
+        // `simctl bootstatus <udid> -b` blocks until the simulator finishes booting — minutes on a
+        // cold machine — so it cannot share a deadline sized for a query.
+        assert!(SimctlOp::BootStatus.budget() >= Duration::from_secs(180));
+        assert!(SimctlOp::Query.budget() < SimctlOp::Lifecycle.budget());
+        assert!(SimctlOp::Query.budget() >= Duration::from_secs(10));
+    }
+
+    #[test]
+    fn every_sub_this_crate_actually_runs_classifies_as_intended() {
+        // The real argvs, taken from the call sites, so renaming a subcommand is caught here
+        // rather than by a call silently dropping to the short budget.
+        for (sub, want) in [
+            (vec!["bootstatus", "UDID", "-b"], SimctlOp::BootStatus),
+            (
+                vec!["launch", "UDID", "com.example.app"],
+                SimctlOp::Lifecycle,
+            ),
+            (vec!["install", "UDID", "/tmp/App.app"], SimctlOp::Lifecycle),
+            (vec!["shutdown", "UDID"], SimctlOp::Lifecycle),
+            (
+                vec!["io", "UDID", "screenshot", "/tmp/f.png"],
+                SimctlOp::Screenshot,
+            ),
+            (vec!["list", "devices", "-j"], SimctlOp::Query),
+            (vec!["pbpaste", "UDID"], SimctlOp::Query),
+            (
+                vec!["terminate", "UDID", "com.example.app"],
+                SimctlOp::Query,
+            ),
+        ] {
+            assert_eq!(SimctlOp::for_sub(&sub), want, "sub {sub:?}");
+        }
+    }
+
+    #[test]
+    fn an_unrecognized_sub_takes_the_short_budget_not_a_generous_one() {
+        assert_eq!(SimctlOp::for_sub(&["some-future-sub"]), SimctlOp::Query);
+    }
 
     #[test]
     fn program_is_xcrun_with_simctl_first_arg() {

--- a/crates/glass-ios/src/simctl.rs
+++ b/crates/glass-ios/src/simctl.rs
@@ -14,8 +14,11 @@ use glass_core::{GlassError, Result, run_bounded};
 pub enum SimctlOp {
     /// `bootstatus -b` — waits out the whole boot.
     BootStatus,
-    /// `launch` / `install` / `boot` / `shutdown` — device lifecycle.
+    /// `launch` / `boot` / `shutdown` — device lifecycle.
     Lifecycle,
+    /// `install` — copies an `.app` into the simulator and registers it. Payload-sized, like
+    /// Android's `Transfer`, and unlike the rest of the lifecycle verbs.
+    Install,
     /// `io <udid> screenshot` — encodes a frame.
     Screenshot,
     /// Everything else: `list`, `pbpaste`, `terminate`, `spawn`.
@@ -28,6 +31,7 @@ impl SimctlOp {
         match self {
             Self::BootStatus => Duration::from_secs(180),
             Self::Lifecycle => Duration::from_secs(60),
+            Self::Install => Duration::from_secs(120),
             Self::Screenshot => Duration::from_secs(15),
             Self::Query => Duration::from_secs(10),
         }
@@ -39,7 +43,8 @@ impl SimctlOp {
     pub fn for_sub(sub: &[&str]) -> Self {
         match sub.first().copied() {
             Some("bootstatus") => Self::BootStatus,
-            Some("launch" | "install" | "boot" | "shutdown" | "erase") => Self::Lifecycle,
+            Some("install") => Self::Install,
+            Some("launch" | "boot" | "shutdown" | "erase") => Self::Lifecycle,
             Some("io") => Self::Screenshot,
             _ => Self::Query,
         }
@@ -50,6 +55,7 @@ impl SimctlOp {
         match self {
             Self::BootStatus => "simctl:bootstatus",
             Self::Lifecycle => "simctl:lifecycle",
+            Self::Install => "simctl:install",
             Self::Screenshot => "simctl:io screenshot",
             Self::Query => "simctl:query",
         }
@@ -161,7 +167,7 @@ mod tests {
                 vec!["launch", "UDID", "com.example.app"],
                 SimctlOp::Lifecycle,
             ),
-            (vec!["install", "UDID", "/tmp/App.app"], SimctlOp::Lifecycle),
+            (vec!["install", "UDID", "/tmp/App.app"], SimctlOp::Install),
             (vec!["shutdown", "UDID"], SimctlOp::Lifecycle),
             (
                 vec!["io", "UDID", "screenshot", "/tmp/f.png"],

--- a/crates/glass-ios/src/simctl.rs
+++ b/crates/glass-ios/src/simctl.rs
@@ -109,8 +109,8 @@ mod tests {
     ///   GLASS_IOS_UDID=<booted udid> \
     ///     cargo test -p glass-ios --lib -- --ignored --nocapture a_spawned_command
     ///
-    /// `simctl spawn <udid> sleep` is a real call into a real simulator that never answers, which
-    /// is what the budget tests above cannot exercise. In-crate because `simctl` is a private
+    /// `simctl spawn <udid> /bin/sleep` is a real call into a real simulator that never answers,
+    /// which is what the budget tests above cannot exercise. In-crate because `simctl` is a private
     /// module, and a test is not a reason to widen the crate's public surface.
     #[test]
     #[ignore = "requires a booted simulator + GLASS_IOS_UDID"]
@@ -144,8 +144,8 @@ mod tests {
 
     #[test]
     fn bootstatus_may_take_far_longer_than_any_ordinary_call() {
-        // `simctl bootstatus <udid> -b` blocks until the simulator finishes booting — minutes on a
-        // cold machine — so it cannot share a deadline sized for a query.
+        // Pins what the enum doc explains, so a later edit cannot quietly fold BootStatus into
+        // the generic budget.
         assert!(SimctlOp::BootStatus.budget() >= Duration::from_secs(180));
         assert!(SimctlOp::Query.budget() < SimctlOp::Lifecycle.budget());
         assert!(SimctlOp::Query.budget() >= Duration::from_secs(10));

--- a/crates/glass-ios/src/simctl.rs
+++ b/crates/glass-ios/src/simctl.rs
@@ -105,6 +105,43 @@ impl Simctl {
 mod tests {
     use super::*;
 
+    /// Live proof that a wedged simctl call ends instead of hanging. Ignored by default:
+    ///   GLASS_IOS_UDID=<booted udid> \
+    ///     cargo test -p glass-ios --lib -- --ignored --nocapture a_spawned_command
+    ///
+    /// `simctl spawn <udid> sleep` is a real call into a real simulator that never answers, which
+    /// is what the budget tests above cannot exercise. In-crate because `simctl` is a private
+    /// module, and a test is not a reason to widen the crate's public surface.
+    #[test]
+    #[ignore = "requires a booted simulator + GLASS_IOS_UDID"]
+    fn a_spawned_command_that_never_answers_dies_at_its_budget() {
+        let udid = std::env::var("GLASS_IOS_UDID").expect("GLASS_IOS_UDID");
+        let budget = SimctlOp::Query.budget();
+
+        let started = std::time::Instant::now();
+        let err = Simctl::new()
+            // Absolute path: `spawn` runs the binary INSIDE the simulator, where a bare `sleep`
+            // is not on the path and fails instantly with ENOENT rather than hanging.
+            .run(&["spawn", &udid, "/bin/sleep", "100"])
+            .expect_err("a call that outlives its budget must fail, not return");
+        let waited = started.elapsed();
+        println!("waited {waited:?} against a {budget:?} budget; error: {err}");
+
+        assert!(
+            waited < budget + Duration::from_secs(5),
+            "waited {waited:?}, past the {budget:?} budget — the bound did not fire"
+        );
+        assert!(
+            err.to_string().contains("simctl:query"),
+            "must name the operation: {err}"
+        );
+        // The next call still works: the timeout killed the child, it did not wedge simctl.
+        let listed = Simctl::new()
+            .run(&["list", "devices"])
+            .expect("still usable");
+        assert!(listed.contains("Devices"), "{listed}");
+    }
+
     #[test]
     fn bootstatus_may_take_far_longer_than_any_ordinary_call() {
         // `simctl bootstatus <udid> -b` blocks until the simulator finishes booting — minutes on a

--- a/crates/glass-ios/src/simctl.rs
+++ b/crates/glass-ios/src/simctl.rs
@@ -21,7 +21,7 @@ pub enum SimctlOp {
     Install,
     /// `io <udid> screenshot` — encodes a frame.
     Screenshot,
-    /// Everything else: `list`, `pbpaste`, `terminate`, `spawn`.
+    /// Everything else: `list`, `pbcopy`, `pbpaste`, `terminate`, `spawn`.
     Query,
 }
 
@@ -175,6 +175,7 @@ mod tests {
             ),
             (vec!["list", "devices", "-j"], SimctlOp::Query),
             (vec!["pbpaste", "UDID"], SimctlOp::Query),
+            (vec!["pbcopy", "UDID"], SimctlOp::Query),
             (
                 vec!["terminate", "UDID", "com.example.app"],
                 SimctlOp::Query,


### PR DESCRIPTION
Item 2 of the cross-backend accessibility audit, first of three PRs: no one-shot external-tool call
in the mobile backends can hang the tool it is serving.

Before this, every `adb`, `xcrun simctl`, `plutil`, `ps` and `emulator` invocation ran through
`Command::output()`, which waits forever. A wedged device or simulator hung the MCP call with no
deadline and no diagnosis.

## What lands

`glass_core::run_bounded(cmd, budget, op)` spawns the child, drains both pipes on threads, waits to
a deadline, and on expiry kills that exact child and returns an error naming the operation, the
budget, whatever the child had already said, and what to try. `run_bounded_with_stdin` is the same
for a call whose payload arrives on stdin. No new dependency — `wait-timeout` would carry weight for
about forty lines of `std`.

Budgets come from `AdbOp` / `SimctlOp`, which classify the argv centrally, so none of the ~50 call
sites picks its own and an unrecognised call takes the **short** budget — a future caller who
forgets to extend the classifier fails fast instead of hanging for two minutes.

Streaming stays unbounded, deliberately: `logcat`, `log stream`, the on-device agent and the
emulator are tails, not calls.

## Budgets, measured on the dogfood devices

Each is ≈4× the slowest healthy run, floored at 10s — a budget that fires on a loaded-but-working
device is worse than the hang it replaces.

| AVD (Pixel_8) | slowest healthy | budget |
|---|---|---|
| `uiautomator dump` | 2266ms | 20s |
| `exec-out screencap` | 230ms | 15s |
| `am start -W` | 703ms | 60s |
| `input tap` / `dumpsys` | 32ms | 10s |
| `install` / `push` | not measured — see below | 120s |

| Simulator (iOS 26.5) | slowest healthy | budget |
|---|---|---|
| `list devices -j` | 85ms | 10s |
| `io screenshot` | 281ms | 15s |
| boot + `bootstatus -b` | 3990ms | 180s |

`Transfer` (120s) and `SimctlOp::Install` rest on install semantics rather than a measurement: an
8 MiB push measures ~26ms, but that is emulator-local and says nothing about a real install, which
also verifies and dexopts. Stated here rather than left implied by the "4×" rule above.

## Verified on hardware, not just compiled

- **A real hang, induced per backend**: an `adb` call died at 10.01s naming `adb:shell` with its
  remedy, a `simctl` call at 10.03s naming `simctl:query` — and the next call worked both times, so
  the timeout killed the child rather than wedging the connection.
- **The real payloads through the completeness check**: a **10,368,016-byte** `screencap` and a
  12,634-byte `uiautomator dump`, plus the `see`, `a11y`, `window` and `doctor` device loops.
- **The rewritten `pbcopy` path**: a clipboard round trip written through the bounded stdin runner
  and read back with `pbpaste` on a booted simulator.
- Locally: `fmt`, workspace `clippy` and tests, the scoped Windows cross-target clippy,
  `scripts/test-x11.sh` and `scripts/test-a11y.sh`. On mini: `glass-ios` clippy and 149 tests.

## What the pre-merge panel changed

Five lenses, then a scoped re-review. The defects were not cosmetic:

- **A short read passed for a complete answer.** When a child exits while something it started still
  holds the write end, the drain never reaches EOF — the runner returned the partial bytes with a
  zero exit status. `dumpsys window windows` is parsed by a tolerant line scanner, so a truncated
  dump read as a *smaller window list* and glass would have reported wrong geometry for every
  coordinate after it. `Command::output()` cannot do this, because it reads to EOF. Pipes now track
  EOF and an incomplete read is an error.
- **Caller data could choose a budget.** The classifier scanned every argument for substrings, so an
  APK path containing `uiautomator` — plausible for this audience — turned a 120s install into a 20s
  dump budget, killing a healthy install mid-flight and blaming the wrong operation. Positional now.
- **`am start -W` sat in the 10s tap bucket.** It blocks until the activity is up, so a cold first
  launch would have failed while healthy — a false negative on the primary happy path.
- **Three one-shots were never wired**, two of them listed in this change's own plan: `emulator
  -list-avds` on the `glass_start` boot path and in the Android doctor, and `simctl pbcopy`, which
  the runner structurally could not serve because it closed stdin.
- Plus: the `try_wait` error arm abandoned the child (no kill, no reap); the post-kill `wait()` was
  unbounded, so a process stuck in the kernel could strand a caller *inside* the timeout handler;
  `EINTR` ended a drain as though it were EOF; the `adb kill-server` remedy was appended to spawn
  failures, advising an agent to run a binary that is not there; a timed-out `devices` poll aborted
  a boot and skipped the branch that kills the emulator, leaving it holding the AVD lock; the iOS
  doctor folded a timeout into "tool missing" and told users to install the Xcode they already have;
  and the 20ms poll floor cost ~20ms on every call, now a 1ms backoff.

The re-review then caught two regressions the first fix wave introduced: `am force-stop` fell into
the new `Launch` bucket, raising a teardown call's ceiling to 60s inside a 3s `TEARDOWN_BUDGET`; and
a partial *stdin* write was as silent as the read it had just fixed.

## What CI found after the panel

Two rounds of the glass-core mutation gate turned up **eight** surviving mutants, every one a
property claimed in a comment but never pinned by a test. The two that mattered most were the
completeness check demanding *both* pipes be incomplete rather than either — so a child holding only
stdout open would still have returned a short read as success, the very bug the check exists to
stop — and the EINTR guard, which could be replaced with `true` unnoticed because no test fed the
drain a non-Interrupted error. Two others needed a pure seam before any test could reach them: the
capture cap's boundary and the deadline comparison, where "exactly at the deadline" is unreachable
by timing. Each mutation was hand-applied and confirmed to turn the suite red, since local mutation runs are
blocked on the dev machine.

The Windows leg also went red on all twelve bounded tests, which hardcoded `/bin/sh`. glass-core is
platform-agnostic and `glass-android` drives `adb` from any host, so this module does run on Windows.
The process-driving tests are now `cfg(unix)`; the five that need no process — the cap, the deadline,
the backoff, and both drain behaviours, which take any `Read` — still run everywhere.

## Known interactions, not fixed here

- `dump_until_ready`'s own 30s budget can be overrun by the inner budgets it now contains
  (`rm` + `dump` + `cat`), since it checks its deadline between attempts rather than between steps.
- Killing the adb client leaves a device-side `uiautomator dump` running, so an abandoned dump can
  write the file a later attempt reads. A per-attempt dump path would close it.

Both are consequences of introducing a kill where there was none, and belong in their own change
rather than this one.
