### PR TITLE
fix: report a set_value that did not take on the backends that type it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,15 @@ internal refactors, CI, or test-only changes.
 ## [Unreleased]
 
 ### Fixed
-- `glass_set_value` on Android and the iOS Simulator now tells you when a write did not take. It
-  used to tap the element, clear it, type, and report success without ever looking again — so a
-  read-only field, a tap that landed slightly off, or a keyboard that swallowed the text all came
-  back as `ok`, and everything you asserted afterwards was against a screen that never changed. It
-  now reads the element back once and reports the write as not applied when the value did not
-  change. The other backends already did this.
+- `glass_set_value` now tells you when a write did not take on Android (without the on-device
+  accessibility service) and on the iOS Simulator. Those two backends tap the element, clear it and
+  type — and used to report success without ever looking again, so a tap that landed slightly off, a
+  field that rejected the input, or a dropped keystroke all came back as `ok`, and everything you
+  asserted afterwards was against a screen that never changed. They now read the element back and
+  require it to hold exactly what you asked for. A field that reformats what it is given (a phone
+  number becoming `(123) 456-7890`) is reported as not applied even though the text arrived: read the
+  element to see what it holds. Windows and macOS already read the value back, and Android's
+  on-device service reader already did too; the Linux reader still trusts the toolkit's own answer.
 - An Android or iOS Simulator command that stops answering no longer hangs the tool it was
   serving. Every one-shot call glass makes to `adb`, `emulator`, `xcrun simctl`, `plutil` or `ps`
   now has a deadline sized for what that call does — a full accessibility dump gets longer than a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ internal refactors, CI, or test-only changes.
 ## [Unreleased]
 
 ### Fixed
+- `glass_set_value` on Android and the iOS Simulator now tells you when a write did not take. It
+  used to tap the element, clear it, type, and report success without ever looking again — so a
+  read-only field, a tap that landed slightly off, or a keyboard that swallowed the text all came
+  back as `ok`, and everything you asserted afterwards was against a screen that never changed. It
+  now reads the element back once and reports the write as not applied when the value did not
+  change. The other backends already did this.
 - An Android or iOS Simulator command that stops answering no longer hangs the tool it was
   serving. Every one-shot call glass makes to `adb`, `emulator`, `xcrun simctl`, `plutil` or `ps`
   now has a deadline sized for what that call does — a full accessibility dump gets longer than a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,11 @@ internal refactors, CI, or test-only changes.
   asserted afterwards was against a screen that never changed. They now read the element back and
   require it to hold exactly what you asked for. A field that reformats what it is given (a phone
   number becoming `(123) 456-7890`) is reported as not applied even though the text arrived: read the
-  element to see what it holds. Windows and macOS already read the value back, and Android's
-  on-device service reader already did too; the Linux reader still trusts the toolkit's own answer.
+  element to see what it holds. Clearing a field is judged its own way — it has to read back empty —
+  so on a platform that reports an emptied field's placeholder as its text (Android does), a clear
+  that worked is also reported as not applied. Windows and macOS already read the value back, and
+  Android's on-device service reader already did too; the Linux reader still trusts the toolkit's own
+  answer.
 - An Android or iOS Simulator command that stops answering no longer hangs the tool it was
   serving. Every one-shot call glass makes to `adb`, `emulator`, `xcrun simctl`, `plutil` or `ps`
   now has a deadline sized for what that call does — a full accessibility dump gets longer than a

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -20,7 +20,7 @@ use glass_core::coords::pixel_geometry_from_content_rect;
 use glass_core::platform::WindowGeometry;
 use glass_core::{
     Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxTarget, AxTree, GlassError,
-    Result, TruncationLimit, WalkBudget, normalize_description,
+    Result, TruncationLimit, WalkBudget, normalize_description, read_back_confirms,
 };
 use objc2_application_services::AXUIElement;
 use objc2_core_foundation::CFRetained;
@@ -604,37 +604,11 @@ fn gather_states(el: &AXUIElement, role: AxRole) -> AxStateFacts {
     }
 }
 
-/// Whether a `set_value` write actually took, judged from the value read back. Some
-/// read-only-in-practice editables accept the AX write without an `AXError` but never change
-/// `AXValue` (a misleading success); a real set changes the value, possibly to a reformatted
-/// string. So it took iff the read-back equals the request OR differs from the pre-set
-/// value. Mirrors the Windows reader's `set_value_took`.
-fn set_value_took(before: &str, after: &str, requested: &str) -> bool {
-    after == requested || after != before
-}
-
-/// Whether a read-back poll can *confirm* a `set_value` write took. `read_back` is the value
-/// read after the write (`None` if that read failed or the attribute was absent); `before` is
-/// the pre-write baseline (`None` if the pre-read failed/was absent — baseline unknown).
-/// Confirms only when it can prove the write landed: a `None` read-back is inconclusive and
-/// never confirms; with a known baseline it delegates to [`set_value_took`]; with an unknown
-/// baseline only an exact match with the request confirms — "changed from before" is meaningless
-/// without a trustworthy baseline. Mirrors the Windows reader.
-fn read_back_confirms(read_back: Option<&str>, before: Option<&str>, requested: &str) -> bool {
-    match (read_back, before) {
-        (None, _) => false,
-        (Some(after), Some(before)) => set_value_took(before, after, requested),
-        (Some(after), None) => after == requested,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use glass_core::{MAX_DEPTH, MAX_NODES};
 
-    use super::{
-        TruncationLimit, WalkBudget, may_explore_children, read_back_confirms, set_value_took,
-    };
+    use super::{TruncationLimit, WalkBudget, may_explore_children};
 
     #[test]
     fn below_the_caps_children_may_be_explored_and_nothing_is_recorded() {
@@ -677,54 +651,5 @@ mod tests {
             budget.truncation().map(|t| t.limit),
             Some(TruncationLimit::Depth)
         );
-    }
-
-    #[test]
-    fn noop_is_not_taken() {
-        // A read-only editable: value unchanged AND not the requested text.
-        assert!(!set_value_took("hello", "hello", "world"));
-    }
-
-    #[test]
-    fn exact_match_took() {
-        assert!(set_value_took("hello", "world", "world"));
-    }
-
-    #[test]
-    fn reformatted_change_took() {
-        // The AX field may normalize the written text — changed from before, so it took.
-        assert!(set_value_took("0", "0.0", "0"));
-    }
-
-    #[test]
-    fn setting_current_value_is_taken() {
-        // Edge case: requesting the value it already holds → equals request → taken.
-        assert!(set_value_took("world", "world", "world"));
-    }
-
-    #[test]
-    fn read_back_rejects_a_failed_post_read() {
-        // A failed/absent post-write read (None) is inconclusive — never a false success.
-        assert!(!read_back_confirms(None, Some("hello"), "world"));
-    }
-
-    #[test]
-    fn read_back_confirms_change_against_known_baseline() {
-        // Known baseline + value changed from it → took (delegates to set_value_took).
-        assert!(read_back_confirms(Some("0.0"), Some("0"), "0"));
-    }
-
-    #[test]
-    fn read_back_rejects_unconfirmable_change_when_baseline_unknown() {
-        // Regression: pre-fix a failed pre-read defaulted to "", so a no-op that reads back its
-        // real (non-empty) value looked "changed" → false success. An unknown baseline must not
-        // confirm a mere difference; only an exact match can.
-        assert!(!read_back_confirms(Some("hello"), None, "world"));
-    }
-
-    #[test]
-    fn read_back_confirms_exact_match_when_baseline_unknown() {
-        // Unknown baseline, but the read-back equals the request → definitively took.
-        assert!(read_back_confirms(Some("world"), None, "world"));
     }
 }

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 
 use glass_core::{
     Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget, AxTree, GlassError, Result,
-    TruncationLimit, WalkBudget, normalize_description,
+    TruncationLimit, WalkBudget, normalize_description, read_back_confirms,
 };
 use uiautomation::patterns::{
     UIExpandCollapsePattern, UIInvokePattern, UIRangeValuePattern, UISelectionItemPattern,
@@ -567,36 +567,6 @@ fn find_nth(
     None
 }
 
-/// Whether a `set_value` write actually took, judged from the value read back. egui-style
-/// read-only editables (`TextEdit`) accept UIA `SetValue` without error but never change the
-/// buffer — a misleading success; a real set (`Slider`/`DragValue`) changes the value, possibly
-/// to a reformatted string. So it took iff the read-back equals the request OR differs from the
-/// pre-set value.
-pub(crate) fn set_value_took(before: &str, after: &str, requested: &str) -> bool {
-    after == requested || after != before
-}
-
-/// Whether a read-back poll can *confirm* a `set_value` write took. `read_back` is the value
-/// read after the write (`None` if that read failed); `before` is the pre-write baseline
-/// (`None` if the pre-read failed — baseline unknown). Confirms only when it can prove the
-/// write landed:
-/// - a failed post-write read (`read_back == None`) is inconclusive → never confirms (the
-///   caller keeps polling to its deadline, then reports `AxValueNotApplied`);
-/// - with a known baseline, delegates to [`set_value_took`] (equals request, or changed from it);
-/// - with an unknown baseline, only an exact match with the request confirms — "changed from
-///   before" is meaningless without a trustworthy baseline.
-///
-/// This is the honesty guard against a *failed read* masquerading as a change: the pre-fix loop
-/// collapsed both reads to `""` via `unwrap_or_default()`, so a failed read looked like a value
-/// that "differs from before" and reported false success. Mirrors the macOS reader.
-fn read_back_confirms(read_back: Option<&str>, before: Option<&str>, requested: &str) -> bool {
-    match (read_back, before) {
-        (None, _) => false,
-        (Some(after), Some(before)) => set_value_took(before, after, requested),
-        (Some(after), None) => after == requested,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -643,47 +613,5 @@ mod tests {
             budget.truncation().map(|t| t.limit),
             Some(TruncationLimit::Depth)
         );
-    }
-
-    #[test]
-    fn noop_is_not_taken() {
-        // read-only TextEdit: value unchanged AND not the requested text.
-        assert!(!set_value_took("#000000", "#000000", "#12AA34"));
-    }
-    #[test]
-    fn exact_match_took() {
-        assert!(set_value_took("#000000", "#12AA34", "#12AA34"));
-    }
-    #[test]
-    fn reformatted_numeric_change_took() {
-        // a slider set to "50" may read back "50.0" — changed from before, so it took.
-        assert!(set_value_took("0", "50.0", "50"));
-    }
-    #[test]
-    fn setting_current_value_is_taken() {
-        // edge: requesting the value it already holds → equals request → taken (acceptable).
-        assert!(set_value_took("50", "50", "50"));
-    }
-    #[test]
-    fn read_back_rejects_a_failed_post_read() {
-        // A failed post-write read (None) is inconclusive — never a false success.
-        assert!(!read_back_confirms(None, Some("hello"), "world"));
-    }
-    #[test]
-    fn read_back_confirms_change_against_known_baseline() {
-        // Known baseline + value changed from it → took (delegates to set_value_took).
-        assert!(read_back_confirms(Some("50.0"), Some("0"), "50"));
-    }
-    #[test]
-    fn read_back_rejects_unconfirmable_change_when_baseline_unknown() {
-        // Regression: pre-fix a failed pre-read defaulted to "", so a no-op that reads back its
-        // real (non-empty) value looked "changed" → false success. An unknown baseline must not
-        // confirm a mere difference; only an exact match can.
-        assert!(!read_back_confirms(Some("hello"), None, "world"));
-    }
-    #[test]
-    fn read_back_confirms_exact_match_when_baseline_unknown() {
-        // Unknown baseline, but the read-back equals the request → definitively took.
-        assert!(read_back_confirms(Some("world"), None, "world"));
     }
 }

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -84,13 +84,12 @@ fn dump_until_ready(
 }
 
 /// Judge a typed `set_value` from a tree read back after it. `Ok(())` only when the field holds
-/// exactly what was asked for — except for a clear, which `glass_core::typed_clear_landed` judges
-/// differently because an emptied field may report its hint as its value.
+/// exactly what was asked for, or — for a clear — reads back empty.
 ///
 /// Exact match, not "changed from before": tap-and-type is not atomic, so a dropped key or an input
 /// filter leaves the field holding something that is neither the request nor the old value, and
 /// calling that success is the failure this check exists to prevent. `glass_core::typed_text_landed`
-/// carries the rule and the cost of it.
+/// and `glass_core::typed_clear_landed` carry the rules and the cost of them.
 ///
 /// The element is re-resolved by its pre-order id, which the write can perturb if the tap changes
 /// what is on screen. Raising the soft keyboard does not: measured on the dogfood AVD with
@@ -99,23 +98,26 @@ fn dump_until_ready(
 /// window — does shift them, so a mismatch is [`GlassError::AxElementChanged`] ("re-snapshot")
 /// rather than a claim about the write.
 ///
-/// The node must also still be editable: an editable's name comes from `content-desc` alone, so most
-/// have none, and role+name alone would let a nameless neighbour that inherited the id be judged
-/// instead.
-fn verify_write(
-    after_tree: &AxTree,
-    target: &AxTarget,
-    before: Option<&str>,
-    text: &str,
-) -> Result<()> {
+/// Role and name are checked but bounds deliberately are not, unlike the pre-write
+/// [`locate_editable_target`]: the IME reflows the layout under the field it is typing into, so a
+/// moved-but-correct element is the normal case here.
+///
+/// The node must also still be editable, which excludes a non-editable neighbour that inherited the
+/// id — but not a second nameless editable, since an editable's name comes from `content-desc` alone
+/// and `AxTarget::matches` compares `None` to `None`. The exact-value requirement is what covers
+/// that case.
+fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()> {
     let Some(node) = after_tree.find(target.id) else {
         // A tree cut short by the node cap explains an absent element better than "it moved" does.
         return Err(match &after_tree.truncated {
+            // `Truncation::notice()` is written to close a rendered outline — a leading ellipsis
+            // and its own pixel-fallback advice — so this states the cap itself instead.
             Some(t) => GlassError::AccessibilityUnavailable(format!(
                 "set_value: the text was typed, but the read-back could not find element {} \
-                 because the tree was truncated ({}); re-snapshot rather than retyping",
+                 because the tree was truncated at {} {}; re-snapshot rather than retyping",
                 target.id.0,
-                t.notice()
+                t.limit_value,
+                t.limit.label(),
             )),
             None => GlassError::AxElementChanged(target.id.0),
         });
@@ -123,10 +125,8 @@ fn verify_write(
     if !target.matches(node.role, node.name.as_deref()) || !node.states.editable {
         return Err(GlassError::AxElementChanged(target.id.0));
     }
-    // A clear is judged differently, because an emptied field may report its hint as its value —
-    // see `typed_clear_landed`.
     let landed = if text.is_empty() {
-        typed_clear_landed(node.value.as_deref(), before)
+        typed_clear_landed(node.value.as_deref())
     } else {
         typed_text_landed(node.value.as_deref(), text)
     };
@@ -147,6 +147,12 @@ const VERIFY_ATTEMPTS: usize = 3;
 /// keystroke and small next to the `uiautomator dump` that follows it.
 const VERIFY_SETTLE_MS: u64 = 300;
 
+/// Readiness budget for one post-write read-back. Do NOT reuse [`DUMP_READY_TIMEOUT_MS`] here: that
+/// is the once-per-session cold-boot budget, and at [`VERIFY_ATTEMPTS`] attempts it would let a
+/// routine write hold the single-threaded tool loop for a minute and a half. What this waits out is
+/// an IME animation, which takes hundreds of milliseconds.
+const VERIFY_READY_BUDGET_MS: u64 = 2_000;
+
 /// Reads the active window's accessibility tree via `uiautomator`.
 pub struct AndroidA11y {
     adb: Adb,
@@ -162,6 +168,24 @@ impl AndroidA11y {
             resolved: false,
             warmed: false,
         }
+    }
+
+    /// One dump, retrying a not-ready device for up to `budget`.
+    ///
+    /// Split out of [`Accessibility::snapshot`] so a caller that knows the UI is mid-flux can ask
+    /// for retries even on a warmed reader: `snapshot` gives a warmed reader no budget, which is
+    /// right for a `wait_for_element` tick and wrong immediately after typing.
+    fn snapshot_with_budget(&mut self, ctx: &AxContext, budget: Duration) -> Result<AxTree> {
+        let window = ctx.window.clone();
+        let adb = self.ensure_adb()?;
+        let xml = dump_until_ready(
+            &mut adb_runner(&adb),
+            DUMP_PATH,
+            budget,
+            Duration::from_millis(DUMP_POLL_INTERVAL_MS),
+        )?;
+        self.warmed = true;
+        build_tree(&xml, &window, ctx.limits)
     }
 
     /// Bind directly to an already-resolved (serial-bound) adb client. Used in production so
@@ -225,26 +249,6 @@ fn locate_editable_target(
         .ok_or(GlassError::AxElementNotClickable(target.id.0))
 }
 
-impl AndroidA11y {
-    /// One dump, retrying a not-ready device for up to `budget`.
-    ///
-    /// Split out of [`Accessibility::snapshot`] so a caller that knows the UI is mid-flux can ask
-    /// for retries even on a warmed reader: `snapshot` gives a warmed reader no budget, which is
-    /// right for a `wait_for_element` tick and wrong immediately after typing.
-    fn snapshot_with_budget(&mut self, ctx: &AxContext, budget: Duration) -> Result<AxTree> {
-        let window = ctx.window.clone();
-        let adb = self.ensure_adb()?;
-        let xml = dump_until_ready(
-            &mut adb_runner(&adb),
-            DUMP_PATH,
-            budget,
-            Duration::from_millis(DUMP_POLL_INTERVAL_MS),
-        )?;
-        self.warmed = true;
-        build_tree(&xml, &window, ctx.limits)
-    }
-}
-
 impl Accessibility for AndroidA11y {
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
         let budget = if self.warmed {
@@ -261,9 +265,6 @@ impl Accessibility for AndroidA11y {
         let mut tree = self.snapshot(ctx)?;
         tree.assign_ids();
         let (cx, cy) = locate_editable_target(&tree, target, &window)?;
-        // Needed only to judge a clear: an emptied field may report its hint, so the evidence a
-        // clear landed is that the value changed from this.
-        let before = tree.find(target.id).and_then(|n| n.value.clone());
 
         let adb = self.ensure_adb()?;
         // Tap to focus, select-all, delete, type — reusing the P2 input builders.
@@ -288,17 +289,17 @@ impl Accessibility for AndroidA11y {
         }
 
         // Each read-back is a whole `uiautomator dump` — measured at ~2.3s on the dogfood AVD — so
-        // this reads once and only retries while unconfirmed, rather than polling on every write.
+        // this reads once and retries only the one verdict a later read can overturn.
         //
         // A failure of this read is NOT a failure of the write — the field has already been cleared
         // and typed into — so it says so, because a caller that retries blindly types twice. The
-        // readiness budget is deliberately non-zero even on a warmed reader: the IME and any
-        // suggestion strip are still animating, which is exactly when a dump comes back not-ready.
+        // readiness budget is non-zero even on a warmed reader: the IME and any suggestion strip are
+        // still animating, which is exactly when a dump comes back not-ready.
         let mut last = None;
-        for attempt in 0..VERIFY_ATTEMPTS {
+        for _ in 0..VERIFY_ATTEMPTS {
             std::thread::sleep(Duration::from_millis(VERIFY_SETTLE_MS));
             let mut after = self
-                .snapshot_with_budget(ctx, Duration::from_millis(DUMP_READY_TIMEOUT_MS))
+                .snapshot_with_budget(ctx, Duration::from_millis(VERIFY_READY_BUDGET_MS))
                 .map_err(|e| {
                     GlassError::AccessibilityUnavailable(format!(
                         "set_value: the text was typed, but reading the element back failed: {e}; \
@@ -306,12 +307,12 @@ impl Accessibility for AndroidA11y {
                     ))
                 })?;
             after.assign_ids();
-            match verify_write(&after, target, before.as_deref(), text) {
+            match verify_write(&after, target, text) {
                 Ok(()) => return Ok(()),
-                Err(e) => {
-                    let _ = attempt;
-                    last = Some(e);
-                }
+                // Only a not-applied verdict can change on a later read: drift and truncation are
+                // structural, and re-dumping for them costs seconds to reach the same answer.
+                Err(e @ GlassError::AxValueNotApplied(_)) => last = Some(e),
+                Err(e) => return Err(e),
             }
         }
         Err(last.unwrap_or(GlassError::AxValueNotApplied(target.id.0)))
@@ -521,7 +522,7 @@ mod tests {
     fn a_write_that_landed_is_reported_as_success() {
         let after = tree_holding(Some("world"));
         let t = target(0, Some("Search"), Some(BOUNDS));
-        assert!(verify_write(&after, &t, Some("hello"), "world").is_ok());
+        assert!(verify_write(&after, &t, "world").is_ok());
     }
 
     #[test]
@@ -530,7 +531,21 @@ mod tests {
         // `set_value(id, "")` fail every time — which is what it did before this was fixed.
         let after = tree_holding(None);
         let t = target(0, Some("Search"), Some(BOUNDS));
-        assert!(verify_write(&after, &t, Some("hello"), "").is_ok());
+        assert!(verify_write(&after, &t, "").is_ok());
+    }
+
+    #[test]
+    fn a_cleared_field_reporting_its_hint_reads_as_not_applied() {
+        // The cost of judging a clear by "reads back empty", pinned as a decision: this device does
+        // empty the field and `uiautomator` does report the hint as its text. Accepting "the value
+        // changed" instead would accept a clear that never fired on any field that reformats when it
+        // takes focus, which is the false success this check exists to prevent.
+        let after = tree_holding(Some("Search settings"));
+        let t = target(0, Some("Search"), Some(BOUNDS));
+        assert!(matches!(
+            verify_write(&after, &t, ""),
+            Err(GlassError::AxValueNotApplied(0))
+        ));
     }
 
     #[test]
@@ -539,7 +554,7 @@ mod tests {
         let after = tree_holding(Some("hello"));
         let t = target(0, Some("Search"), Some(BOUNDS));
         assert!(matches!(
-            verify_write(&after, &t, Some("hello"), "world"),
+            verify_write(&after, &t, "world"),
             Err(GlassError::AxValueNotApplied(0))
         ));
     }
@@ -550,7 +565,7 @@ mod tests {
         let after = tree_holding(Some("worl"));
         let t = target(0, Some("Search"), Some(BOUNDS));
         assert!(matches!(
-            verify_write(&after, &t, Some("hello"), "world"),
+            verify_write(&after, &t, "world"),
             Err(GlassError::AxValueNotApplied(0))
         ));
     }
@@ -563,7 +578,7 @@ mod tests {
         let after = tree_holding(Some("(123) 456-7890"));
         let t = target(0, Some("Search"), Some(BOUNDS));
         assert!(matches!(
-            verify_write(&after, &t, Some("hello"), "1234567890"),
+            verify_write(&after, &t, "1234567890"),
             Err(GlassError::AxValueNotApplied(0))
         ));
     }
@@ -575,20 +590,20 @@ mod tests {
         let after = tree_holding(Some("world"));
         let t = target(0, Some("A different field"), Some(BOUNDS));
         assert!(matches!(
-            verify_write(&after, &t, Some("hello"), "world"),
+            verify_write(&after, &t, "world"),
             Err(GlassError::AxElementChanged(0))
         ));
     }
 
     #[test]
     fn a_non_editable_node_at_the_id_is_reported_as_changed() {
-        // An editable's name comes from `content-desc` alone, so most have none and role+name alone
-        // would let any nameless TextField-shaped neighbour that inherited the id be judged instead.
+        // Excludes a non-editable neighbour that inherited the id — a label, or a container the
+        // walk shifted into place.
         let mut after = tree_holding(Some("world"));
         after.root.states.editable = false;
         let t = target(0, Some("Search"), Some(BOUNDS));
         assert!(matches!(
-            verify_write(&after, &t, Some("hello"), "world"),
+            verify_write(&after, &t, "world"),
             Err(GlassError::AxElementChanged(0))
         ));
     }
@@ -598,7 +613,7 @@ mod tests {
         let after = tree_holding(Some("world"));
         let t = target(7, Some("Search"), Some(BOUNDS));
         assert!(matches!(
-            verify_write(&after, &t, Some("hello"), "world"),
+            verify_write(&after, &t, "world"),
             Err(GlassError::AxElementChanged(7))
         ));
     }
@@ -615,7 +630,7 @@ mod tests {
         });
         let t = target(7, Some("Search"), Some(BOUNDS));
         assert!(matches!(
-            verify_write(&after, &t, Some("hello"), "world"),
+            verify_write(&after, &t, "world"),
             Err(GlassError::AccessibilityUnavailable(_))
         ));
     }

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -244,8 +244,7 @@ impl Accessibility for AndroidA11y {
         }
 
         // Read back once, not in a loop: a re-read here is a whole `uiautomator dump` (~2s on the
-        // dogfood AVD), so polling would cost seconds per write. The settle is the beat the toolkit
-        // needs to commit the text — small next to the dump that follows it.
+        // dogfood AVD), so polling would cost seconds per write.
         std::thread::sleep(Duration::from_millis(VERIFY_SETTLE_MS));
         let mut after = self.snapshot(ctx)?;
         after.assign_ids();
@@ -461,8 +460,7 @@ mod tests {
 
     #[test]
     fn a_field_that_never_changed_is_not_a_successful_write() {
-        // The tap missed, the field is read-only, or the keyboard swallowed the text. Reporting Ok
-        // here tells an agent the field holds text it does not hold.
+        // The case `verify_write`'s doc is about: nothing changed, so nothing is confirmed.
         let after = tree_holding(Some("hello"));
         let t = target(0, Some("Search"), Some(BOUNDS));
         assert!(matches!(

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -84,7 +84,8 @@ fn dump_until_ready(
 }
 
 /// Judge a typed `set_value` from a tree read back after it. `Ok(())` only when the field holds
-/// exactly what was asked for.
+/// exactly what was asked for — except for a clear, which `glass_core::typed_clear_landed` judges
+/// differently because an emptied field may report its hint as its value.
 ///
 /// Exact match, not "changed from before": tap-and-type is not atomic, so a dropped key or an input
 /// filter leaves the field holding something that is neither the request nor the old value, and
@@ -545,9 +546,7 @@ mod tests {
 
     #[test]
     fn a_partly_typed_write_is_not_a_successful_write() {
-        // A dropped keystroke leaves text that is neither the request nor the old value. Accepting
-        // "changed from before" would call this success and send an agent on to assert against a
-        // field holding "worl" — which is the whole failure this check exists to prevent.
+        // The reason the rule is an exact match; `typed_text_landed` carries the argument.
         let after = tree_holding(Some("worl"));
         let t = target(0, Some("Search"), Some(BOUNDS));
         assert!(matches!(

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -5,7 +5,9 @@
 use std::time::{Duration, Instant};
 
 use glass_core::accessibility::{Accessibility, AxContext, AxTarget, AxTree};
-use glass_core::{GlassError, KeyEvent, MouseButton, PointerEvent, Result, WindowGeometry};
+use glass_core::{
+    GlassError, KeyEvent, MouseButton, PointerEvent, Result, WindowGeometry, read_back_confirms,
+};
 
 use crate::adb::Adb;
 use crate::axmap::build_tree;
@@ -79,6 +81,38 @@ fn dump_until_ready(
         }
     }
 }
+
+/// Judge a `set_value` write from a tree read back after it, against the value the target held
+/// before. `Ok(())` only when the read-back proves the write landed.
+///
+/// A tap-and-type can miss: the field may be read-only, the keyboard may swallow the text, or the
+/// tap may land on a neighbour. Reporting success then tells an agent a field holds text it does
+/// not hold, and every later assertion is made against a screen that never changed.
+///
+/// A target that is no longer at that id is [`GlassError::AxElementChanged`], not
+/// `AxValueNotApplied`: the write may well have landed, on something that then moved.
+fn verify_write(
+    after_tree: &AxTree,
+    target: &AxTarget,
+    before: Option<&str>,
+    text: &str,
+) -> Result<()> {
+    let node = after_tree
+        .find(target.id)
+        .ok_or(GlassError::AxElementChanged(target.id.0))?;
+    if !target.matches(node.role, node.name.as_deref()) {
+        return Err(GlassError::AxElementChanged(target.id.0));
+    }
+    if read_back_confirms(node.value.as_deref(), before, text) {
+        Ok(())
+    } else {
+        Err(GlassError::AxValueNotApplied(target.id.0))
+    }
+}
+
+/// How long to let the toolkit commit typed text before reading it back. Generous relative to a
+/// keystroke and small next to the `uiautomator dump` that follows it.
+const VERIFY_SETTLE_MS: u64 = 300;
 
 /// Reads the active window's accessibility tree via `uiautomator`.
 pub struct AndroidA11y {
@@ -183,6 +217,9 @@ impl Accessibility for AndroidA11y {
         let mut tree = self.snapshot(ctx)?;
         tree.assign_ids();
         let (cx, cy) = locate_editable_target(&tree, target, &window)?;
+        // The baseline for the read-back, taken from the snapshot that located the target rather
+        // than from a read of its own.
+        let before = tree.find(target.id).and_then(|n| n.value.clone());
 
         let adb = self.ensure_adb()?;
         // Tap to focus, select-all, delete, type — reusing the P2 input builders.
@@ -205,13 +242,20 @@ impl Accessibility for AndroidA11y {
                 adb.run(argv.iter().map(String::as_str))?;
             }
         }
-        Ok(())
+
+        // Read back once, not in a loop: a re-read here is a whole `uiautomator dump` (~2s on the
+        // dogfood AVD), so polling would cost seconds per write. The settle is the beat the toolkit
+        // needs to commit the text — small next to the dump that follows it.
+        std::thread::sleep(Duration::from_millis(VERIFY_SETTLE_MS));
+        let mut after = self.snapshot(ctx)?;
+        after.assign_ids();
+        verify_write(&after, target, before.as_deref(), text)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{dump_once, dump_until_ready, locate_editable_target};
+    use super::{dump_once, dump_until_ready, locate_editable_target, verify_write};
     use glass_core::accessibility::{AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree};
     use glass_core::{GlassError, Result, WindowGeometry};
     use std::time::Duration;
@@ -391,6 +435,14 @@ mod tests {
         t
     }
 
+    /// The same single-node tree, holding `value` — what a read-back sees.
+    fn tree_holding(value: Option<&str>) -> AxTree {
+        let mut t = tree(AxRole::TextField, Some("Search"), Some(BOUNDS), true);
+        t.root.value = value.map(Into::into);
+        t.assign_ids();
+        t
+    }
+
     fn target(id: u32, name: Option<&str>, bounds: Option<AxRect>) -> AxTarget {
         AxTarget {
             id: AxNodeId(id),
@@ -398,6 +450,56 @@ mod tests {
             name: name.map(Into::into),
             bounds,
         }
+    }
+
+    #[test]
+    fn a_write_that_landed_is_reported_as_success() {
+        let after = tree_holding(Some("world"));
+        let t = target(0, Some("Search"), Some(BOUNDS));
+        assert!(verify_write(&after, &t, Some("hello"), "world").is_ok());
+    }
+
+    #[test]
+    fn a_field_that_never_changed_is_not_a_successful_write() {
+        // The tap missed, the field is read-only, or the keyboard swallowed the text. Reporting Ok
+        // here tells an agent the field holds text it does not hold.
+        let after = tree_holding(Some("hello"));
+        let t = target(0, Some("Search"), Some(BOUNDS));
+        assert!(matches!(
+            verify_write(&after, &t, Some("hello"), "world"),
+            Err(GlassError::AxValueNotApplied(0))
+        ));
+    }
+
+    #[test]
+    fn a_reformatted_value_still_counts_as_landed() {
+        // A field may normalize what was typed; changed from the baseline is enough.
+        let after = tree_holding(Some("50.0"));
+        let t = target(0, Some("Search"), Some(BOUNDS));
+        assert!(verify_write(&after, &t, Some("0"), "50").is_ok());
+    }
+
+    #[test]
+    fn a_target_that_moved_is_reported_as_changed_not_as_a_failed_write() {
+        // The write may well have landed — on something that then moved. Saying "not applied"
+        // would send an agent to retype into whatever now sits at that id.
+        let after = tree_holding(Some("world"));
+        let t = target(0, Some("A different field"), Some(BOUNDS));
+        assert!(matches!(
+            verify_write(&after, &t, Some("hello"), "world"),
+            Err(GlassError::AxElementChanged(0))
+        ));
+    }
+
+    #[test]
+    fn a_target_missing_from_the_read_back_is_reported_as_changed() {
+        let mut after = tree_holding(Some("world"));
+        after.root.children.clear();
+        let t = target(7, Some("Search"), Some(BOUNDS));
+        assert!(matches!(
+            verify_write(&after, &t, Some("hello"), "world"),
+            Err(GlassError::AxElementChanged(7))
+        ));
     }
 
     #[test]

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -6,7 +6,8 @@ use std::time::{Duration, Instant};
 
 use glass_core::accessibility::{Accessibility, AxContext, AxTarget, AxTree};
 use glass_core::{
-    GlassError, KeyEvent, MouseButton, PointerEvent, Result, WindowGeometry, read_back_confirms,
+    GlassError, KeyEvent, MouseButton, PointerEvent, Result, WindowGeometry, typed_clear_landed,
+    typed_text_landed,
 };
 
 use crate::adb::Adb;
@@ -82,33 +83,64 @@ fn dump_until_ready(
     }
 }
 
-/// Judge a `set_value` write from a tree read back after it, against the value the target held
-/// before. `Ok(())` only when the read-back proves the write landed.
+/// Judge a typed `set_value` from a tree read back after it. `Ok(())` only when the field holds
+/// exactly what was asked for.
 ///
-/// A tap-and-type can miss: the field may be read-only, the keyboard may swallow the text, or the
-/// tap may land on a neighbour. Reporting success then tells an agent a field holds text it does
-/// not hold, and every later assertion is made against a screen that never changed.
+/// Exact match, not "changed from before": tap-and-type is not atomic, so a dropped key or an input
+/// filter leaves the field holding something that is neither the request nor the old value, and
+/// calling that success is the failure this check exists to prevent. `glass_core::typed_text_landed`
+/// carries the rule and the cost of it.
 ///
-/// A target that is no longer at that id is [`GlassError::AxElementChanged`], not
-/// `AxValueNotApplied`: the write may well have landed, on something that then moved.
+/// The element is re-resolved by its pre-order id, which the write can perturb if the tap changes
+/// what is on screen. Raising the soft keyboard does not: measured on the dogfood AVD with
+/// `mInputShown=true`, `uiautomator dump` emits the focused window only and no IME window, so the
+/// keyboard cannot shift ids. A tap that navigates — Settings' search entry opens a different
+/// window — does shift them, so a mismatch is [`GlassError::AxElementChanged`] ("re-snapshot")
+/// rather than a claim about the write.
+///
+/// The node must also still be editable: an editable's name comes from `content-desc` alone, so most
+/// have none, and role+name alone would let a nameless neighbour that inherited the id be judged
+/// instead.
 fn verify_write(
     after_tree: &AxTree,
     target: &AxTarget,
     before: Option<&str>,
     text: &str,
 ) -> Result<()> {
-    let node = after_tree
-        .find(target.id)
-        .ok_or(GlassError::AxElementChanged(target.id.0))?;
-    if !target.matches(node.role, node.name.as_deref()) {
+    let Some(node) = after_tree.find(target.id) else {
+        // A tree cut short by the node cap explains an absent element better than "it moved" does.
+        return Err(match &after_tree.truncated {
+            Some(t) => GlassError::AccessibilityUnavailable(format!(
+                "set_value: the text was typed, but the read-back could not find element {} \
+                 because the tree was truncated ({}); re-snapshot rather than retyping",
+                target.id.0,
+                t.notice()
+            )),
+            None => GlassError::AxElementChanged(target.id.0),
+        });
+    };
+    if !target.matches(node.role, node.name.as_deref()) || !node.states.editable {
         return Err(GlassError::AxElementChanged(target.id.0));
     }
-    if read_back_confirms(node.value.as_deref(), before, text) {
+    // A clear is judged differently, because an emptied field may report its hint as its value —
+    // see `typed_clear_landed`.
+    let landed = if text.is_empty() {
+        typed_clear_landed(node.value.as_deref(), before)
+    } else {
+        typed_text_landed(node.value.as_deref(), text)
+    };
+    if landed {
         Ok(())
     } else {
         Err(GlassError::AxValueNotApplied(target.id.0))
     }
 }
+
+/// How many times to read the element back before reporting the write as not applied. A landed
+/// write confirms on the first read and pays for one; the retries exist for a field that commits a
+/// frame or two later — a Compose recompose, a debounced handler — which the on-device service
+/// reader polls two whole seconds for.
+const VERIFY_ATTEMPTS: usize = 3;
 
 /// How long to let the toolkit commit typed text before reading it back. Generous relative to a
 /// keystroke and small next to the `uiautomator dump` that follows it.
@@ -192,15 +224,15 @@ fn locate_editable_target(
         .ok_or(GlassError::AxElementNotClickable(target.id.0))
 }
 
-impl Accessibility for AndroidA11y {
-    fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
+impl AndroidA11y {
+    /// One dump, retrying a not-ready device for up to `budget`.
+    ///
+    /// Split out of [`Accessibility::snapshot`] so a caller that knows the UI is mid-flux can ask
+    /// for retries even on a warmed reader: `snapshot` gives a warmed reader no budget, which is
+    /// right for a `wait_for_element` tick and wrong immediately after typing.
+    fn snapshot_with_budget(&mut self, ctx: &AxContext, budget: Duration) -> Result<AxTree> {
         let window = ctx.window.clone();
         let adb = self.ensure_adb()?;
-        let budget = if self.warmed {
-            Duration::ZERO
-        } else {
-            Duration::from_millis(DUMP_READY_TIMEOUT_MS)
-        };
         let xml = dump_until_ready(
             &mut adb_runner(&adb),
             DUMP_PATH,
@@ -210,6 +242,17 @@ impl Accessibility for AndroidA11y {
         self.warmed = true;
         build_tree(&xml, &window, ctx.limits)
     }
+}
+
+impl Accessibility for AndroidA11y {
+    fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
+        let budget = if self.warmed {
+            Duration::ZERO
+        } else {
+            Duration::from_millis(DUMP_READY_TIMEOUT_MS)
+        };
+        self.snapshot_with_budget(ctx, budget)
+    }
 
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
         let window = ctx.window.clone();
@@ -217,8 +260,8 @@ impl Accessibility for AndroidA11y {
         let mut tree = self.snapshot(ctx)?;
         tree.assign_ids();
         let (cx, cy) = locate_editable_target(&tree, target, &window)?;
-        // The baseline for the read-back, taken from the snapshot that located the target rather
-        // than from a read of its own.
+        // Needed only to judge a clear: an emptied field may report its hint, so the evidence a
+        // clear landed is that the value changed from this.
         let before = tree.find(target.id).and_then(|n| n.value.clone());
 
         let adb = self.ensure_adb()?;
@@ -243,12 +286,34 @@ impl Accessibility for AndroidA11y {
             }
         }
 
-        // Read back once, not in a loop: a re-read here is a whole `uiautomator dump` (~2s on the
-        // dogfood AVD), so polling would cost seconds per write.
-        std::thread::sleep(Duration::from_millis(VERIFY_SETTLE_MS));
-        let mut after = self.snapshot(ctx)?;
-        after.assign_ids();
-        verify_write(&after, target, before.as_deref(), text)
+        // Each read-back is a whole `uiautomator dump` — measured at ~2.3s on the dogfood AVD — so
+        // this reads once and only retries while unconfirmed, rather than polling on every write.
+        //
+        // A failure of this read is NOT a failure of the write — the field has already been cleared
+        // and typed into — so it says so, because a caller that retries blindly types twice. The
+        // readiness budget is deliberately non-zero even on a warmed reader: the IME and any
+        // suggestion strip are still animating, which is exactly when a dump comes back not-ready.
+        let mut last = None;
+        for attempt in 0..VERIFY_ATTEMPTS {
+            std::thread::sleep(Duration::from_millis(VERIFY_SETTLE_MS));
+            let mut after = self
+                .snapshot_with_budget(ctx, Duration::from_millis(DUMP_READY_TIMEOUT_MS))
+                .map_err(|e| {
+                    GlassError::AccessibilityUnavailable(format!(
+                        "set_value: the text was typed, but reading the element back failed: {e}; \
+                         re-snapshot to see whether it landed rather than retyping"
+                    ))
+                })?;
+            after.assign_ids();
+            match verify_write(&after, target, before.as_deref(), text) {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    let _ = attempt;
+                    last = Some(e);
+                }
+            }
+        }
+        Err(last.unwrap_or(GlassError::AxValueNotApplied(target.id.0)))
     }
 }
 
@@ -459,8 +524,17 @@ mod tests {
     }
 
     #[test]
+    fn clearing_a_field_is_a_write_that_can_succeed() {
+        // An empty field reports no value at all, so a rule that read `None` as "unknown" made
+        // `set_value(id, "")` fail every time — which is what it did before this was fixed.
+        let after = tree_holding(None);
+        let t = target(0, Some("Search"), Some(BOUNDS));
+        assert!(verify_write(&after, &t, Some("hello"), "").is_ok());
+    }
+
+    #[test]
     fn a_field_that_never_changed_is_not_a_successful_write() {
-        // The case `verify_write`'s doc is about: nothing changed, so nothing is confirmed.
+        // The case `verify_write`'s doc is about: the field still holds the old text.
         let after = tree_holding(Some("hello"));
         let t = target(0, Some("Search"), Some(BOUNDS));
         assert!(matches!(
@@ -470,11 +544,29 @@ mod tests {
     }
 
     #[test]
-    fn a_reformatted_value_still_counts_as_landed() {
-        // A field may normalize what was typed; changed from the baseline is enough.
-        let after = tree_holding(Some("50.0"));
+    fn a_partly_typed_write_is_not_a_successful_write() {
+        // A dropped keystroke leaves text that is neither the request nor the old value. Accepting
+        // "changed from before" would call this success and send an agent on to assert against a
+        // field holding "worl" — which is the whole failure this check exists to prevent.
+        let after = tree_holding(Some("worl"));
         let t = target(0, Some("Search"), Some(BOUNDS));
-        assert!(verify_write(&after, &t, Some("0"), "50").is_ok());
+        assert!(matches!(
+            verify_write(&after, &t, Some("hello"), "world"),
+            Err(GlassError::AxValueNotApplied(0))
+        ));
+    }
+
+    #[test]
+    fn a_field_that_reformats_what_it_was_given_reports_not_applied() {
+        // The cost of the strictness, pinned so it is a decision rather than a surprise: a mask that
+        // turns "1234567890" into "(123) 456-7890" reads as not applied. An agent can re-read the
+        // tree and see the value; a false success would have it asserting against the wrong text.
+        let after = tree_holding(Some("(123) 456-7890"));
+        let t = target(0, Some("Search"), Some(BOUNDS));
+        assert!(matches!(
+            verify_write(&after, &t, Some("hello"), "1234567890"),
+            Err(GlassError::AxValueNotApplied(0))
+        ));
     }
 
     #[test]
@@ -490,13 +582,42 @@ mod tests {
     }
 
     #[test]
-    fn a_target_missing_from_the_read_back_is_reported_as_changed() {
+    fn a_non_editable_node_at_the_id_is_reported_as_changed() {
+        // An editable's name comes from `content-desc` alone, so most have none and role+name alone
+        // would let any nameless TextField-shaped neighbour that inherited the id be judged instead.
         let mut after = tree_holding(Some("world"));
-        after.root.children.clear();
+        after.root.states.editable = false;
+        let t = target(0, Some("Search"), Some(BOUNDS));
+        assert!(matches!(
+            verify_write(&after, &t, Some("hello"), "world"),
+            Err(GlassError::AxElementChanged(0))
+        ));
+    }
+
+    #[test]
+    fn a_target_missing_from_the_read_back_is_reported_as_changed() {
+        let after = tree_holding(Some("world"));
         let t = target(7, Some("Search"), Some(BOUNDS));
         assert!(matches!(
             verify_write(&after, &t, Some("hello"), "world"),
             Err(GlassError::AxElementChanged(7))
+        ));
+    }
+
+    #[test]
+    fn a_truncated_read_back_says_so_rather_than_blaming_drift() {
+        // The tree carries the reason the element is absent; reporting "it moved" would throw away
+        // the one fact that explains it.
+        let mut after = tree_holding(Some("world"));
+        after.truncated = Some(glass_core::accessibility::Truncation {
+            limit: glass_core::accessibility::TruncationLimit::Nodes,
+            limit_value: 1,
+            nodes_walked: 1,
+        });
+        let t = target(7, Some("Search"), Some(BOUNDS));
+        assert!(matches!(
+            verify_write(&after, &t, Some("hello"), "world"),
+            Err(GlassError::AccessibilityUnavailable(_))
         ));
     }
 

--- a/crates/glass-android/tests/a11y_loop.rs
+++ b/crates/glass-android/tests/a11y_loop.rs
@@ -1,11 +1,15 @@
 //! Live accessibility verification against a running AVD. Ignored by default:
 //!   GLASS_ADB=$HOME/android-sdk/platform-tools/adb \
-//!     cargo test -p glass-android --test a11y_loop -- --ignored --nocapture
+//!     cargo test -p glass-android --test a11y_loop -- --ignored --nocapture --test-threads=1
+//!
+//! `--test-threads=1` is required, not tidiness: both tests drive Settings on the one attached
+//! device, so in parallel each tears down the app the other is mid-interaction with.
 //!
 //! Launches com.android.settings, snapshots its a11y tree, and asserts the tree
 //! is non-trivial and carries named, role-typed elements. A second test writes into a real
-//! `EditText` and checks that a landed write is confirmed against the live field — including a
-//! clear, which this platform reports by showing the field's hint rather than an empty value.
+//! `EditText` and checks that a landed write is confirmed against the live field — and that a
+//! clear cannot be confirmed here at all, because this platform reports the emptied field's hint
+//! as its text.
 
 use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, WalkLimits};
 use glass_core::{AppSpec, GlassError, MouseButton, Platform, PointerEvent, SandboxLevel};
@@ -142,15 +146,13 @@ fn set_value_reports_whether_the_write_landed() {
         "field holds {held:?} after the write"
     );
 
-    // Clearing the field, which no other test exercises on a device and which is where the first two
-    // versions of this check were wrong: a rule that read an absent value as "the read failed"
-    // reported every clear as a failure, and a rule that demanded the field read back empty failed
-    // here too, because this field reports its hint instead (see the assertion below).
+    // Clearing the field, on the device whose behaviour decided the rule: an emptied Android
+    // `EditText` reports its *hint* as its text and `uiautomator` exposes no hint attribute, so a
+    // clear cannot be confirmed here at all — the deliberate cost of judging one by "reads back
+    // empty". What the device still has to show is that the text went.
     //
-    // The target is re-located first, deliberately: typing into Settings' search renders a results
-    // list, which shifts every pre-order id after it, so the target captured before the write is
-    // stale by now — and `set_value` says so (`AxElementChanged`) rather than writing to whatever
-    // inherited the id. Re-locating is what an agent does after a write that changes the screen.
+    // The target is re-located first: typing into Settings' search renders a results list, so the
+    // screen the pre-write target was captured against is gone.
     let mut before_clear = a11y.snapshot(&ctx).expect("snapshot before the clear");
     before_clear.assign_ids();
     let field = find(&before_clear.root, &|n| n.states.editable).expect("the field is still there");
@@ -160,18 +162,21 @@ fn set_value_reports_whether_the_write_landed() {
         name: field.name.clone(),
         bounds: field.bounds,
     };
-    a11y.set_value(&ctx, &target, "")
-        .expect("clearing a field is a write that can succeed");
+    match a11y.set_value(&ctx, &target, "") {
+        Err(GlassError::AxValueNotApplied(_)) => {}
+        other => panic!("a field that reports its hint cannot confirm a clear: {other:?}"),
+    }
     let mut cleared = a11y.snapshot(&ctx).expect("snapshot after clear");
     cleared.assign_ids();
-    let left = cleared
-        .find(target.id)
-        .and_then(|n| n.value.clone())
-        .unwrap_or_default();
-    // Not `is_empty()`: an emptied Android `EditText` reports its *hint* as its text, and
-    // `uiautomator` exposes no separate hint attribute — which is exactly why a clear is judged by
-    // the value changing rather than by it reading back empty.
-    assert_ne!(left, "glass", "the field still holds what was typed");
+    // Found by what it is, not by an id the clear may have shifted, so this cannot pass by failing
+    // to look.
+    let field = find(&cleared.root, &|n| n.states.editable)
+        .expect("the field is still there after the clear");
+    assert_ne!(
+        field.value.as_deref(),
+        Some("glass"),
+        "the typed text is gone from the field"
+    );
 
     // A stale target is refused before anything is typed — the pre-write fingerprint check, which
     // predates the read-back. Kept as a regression guard, not as evidence about the read-back.

--- a/crates/glass-android/tests/a11y_loop.rs
+++ b/crates/glass-android/tests/a11y_loop.rs
@@ -3,10 +3,11 @@
 //!     cargo test -p glass-android --test a11y_loop -- --ignored --nocapture
 //!
 //! Launches com.android.settings, snapshots its a11y tree, and asserts the tree
-//! is non-trivial and carries named, role-typed elements.
+//! is non-trivial and carries named, role-typed elements. A second test writes into a real
+//! `EditText` and checks that `set_value` only claims success when the write actually landed.
 
-use glass_core::accessibility::{Accessibility, AxContext, WalkLimits};
-use glass_core::{AppSpec, Platform, SandboxLevel};
+use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, WalkLimits};
+use glass_core::{AppSpec, GlassError, MouseButton, Platform, PointerEvent, SandboxLevel};
 
 fn settings_spec() -> AppSpec {
     AppSpec {
@@ -59,4 +60,100 @@ fn snapshot_has_named_role_typed_nodes() {
     platform.stop_app().expect("stop");
     drop(platform); // close the platform's agent connection (if any) first
     agents.shutdown(); // tear down a launched agent — these tests must not leak it
+}
+
+/// Depth-first search for the first node satisfying `want`.
+fn find<'a>(node: &'a AxNode, want: &dyn Fn(&AxNode) -> bool) -> Option<&'a AxNode> {
+    if want(node) {
+        return Some(node);
+    }
+    node.children.iter().find_map(|c| find(c, want))
+}
+
+/// A real write into a real field, and a real write that cannot land.
+///
+/// Settings has no editable field until its search entry is tapped, so the test taps it first and
+/// then drives `set_value` against the `EditText` that appears — which is the point: this exercises
+/// the tap-clear-type path on a live toolkit, where the read-back has to come from `uiautomator`'s
+/// own view of the field rather than from anything glass remembers writing.
+#[test]
+#[ignore = "requires a booted AVD + GLASS_ANDROID_SERIAL/GLASS_ADB"]
+fn set_value_reports_whether_the_write_landed() {
+    let agents = glass_android::AgentRegistry::new();
+    let mut platform =
+        glass_android::AndroidPlatform::from_env(&glass_android::EmulatorRegistry::new(), &agents)
+            .expect("attach");
+    let window = platform
+        .start_app(&settings_spec())
+        .expect("launch settings");
+    std::thread::sleep(std::time::Duration::from_millis(1200));
+
+    let ctx = AxContext {
+        pids: platform.app_pids(),
+        window: window.clone(),
+        window_handle: None,
+        a11y_bus_addr: None,
+        limits: WalkLimits::DEFAULT,
+    };
+    let mut a11y = glass_android::AndroidA11y::new();
+
+    // Tap the search entry so Settings puts up its EditText.
+    let mut tree = a11y.snapshot(&ctx).expect("snapshot");
+    tree.assign_ids();
+    let search = find(&tree.root, &|n| {
+        n.name.as_deref().is_some_and(|s| s.contains("Search"))
+    })
+    .and_then(|n| n.bounds)
+    .and_then(|b| b.clamped_center(window.width, window.height))
+    .expect("Settings shows a search entry");
+    platform
+        .send_pointer(&PointerEvent::Click {
+            x: search.0,
+            y: search.1,
+            button: MouseButton::Left,
+            count: 1,
+            modifiers: vec![],
+        })
+        .expect("tap search");
+    std::thread::sleep(std::time::Duration::from_millis(1500));
+
+    let mut tree = a11y.snapshot(&ctx).expect("re-snapshot");
+    tree.assign_ids();
+    let field = find(&tree.root, &|n| n.states.editable).expect("an editable field after the tap");
+    let target = AxTarget {
+        id: field.id,
+        role: field.role,
+        name: field.name.clone(),
+        bounds: field.bounds,
+    };
+
+    // A write that lands: reported Ok, and the field really holds it afterwards.
+    a11y.set_value(&ctx, &target, "glass")
+        .expect("a real write into a real field must succeed");
+    let mut after = a11y.snapshot(&ctx).expect("snapshot after write");
+    after.assign_ids();
+    let held = find(&after.root, &|n| n.states.editable)
+        .and_then(|n| n.value.clone())
+        .unwrap_or_default();
+    assert!(
+        held.contains("glass"),
+        "field holds {held:?} after the write"
+    );
+
+    // A write that cannot land: the id names a node that is not the field any more. Before this
+    // change every one of these returned Ok.
+    let stale = AxTarget {
+        id: target.id,
+        role: target.role,
+        name: Some("not the field that is there".into()),
+        bounds: target.bounds,
+    };
+    match a11y.set_value(&ctx, &stale, "ignored") {
+        Err(GlassError::AxElementChanged(_)) | Err(GlassError::AxElementNotFound(_)) => {}
+        other => panic!("a stale target must not report success: {other:?}"),
+    }
+
+    platform.stop_app().expect("stop");
+    drop(platform);
+    agents.shutdown();
 }

--- a/crates/glass-android/tests/a11y_loop.rs
+++ b/crates/glass-android/tests/a11y_loop.rs
@@ -4,7 +4,8 @@
 //!
 //! Launches com.android.settings, snapshots its a11y tree, and asserts the tree
 //! is non-trivial and carries named, role-typed elements. A second test writes into a real
-//! `EditText` and checks that `set_value` only claims success when the write actually landed.
+//! `EditText` and checks that a landed write is confirmed against the live field — including a
+//! clear, which the read-back rule has to treat as a value rather than as a failed read.
 
 use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, WalkLimits};
 use glass_core::{AppSpec, GlassError, MouseButton, Platform, PointerEvent, SandboxLevel};
@@ -70,7 +71,7 @@ fn find<'a>(node: &'a AxNode, want: &dyn Fn(&AxNode) -> bool) -> Option<&'a AxNo
     node.children.iter().find_map(|c| find(c, want))
 }
 
-/// A real write into a real field, and a real write that cannot land.
+/// A real write into a real field, and a real clear of it.
 ///
 /// Settings has no editable field until its search entry is tapped, so the test taps it first and
 /// then drives `set_value` against the `EditText` that appears — which is the point: this exercises
@@ -127,12 +128,13 @@ fn set_value_reports_whether_the_write_landed() {
         bounds: field.bounds,
     };
 
-    // A write that lands: reported Ok, and the field really holds it afterwards.
+    // A write that lands: reported Ok, and the node at that id really holds it afterwards.
     a11y.set_value(&ctx, &target, "glass")
         .expect("a real write into a real field must succeed");
     let mut after = a11y.snapshot(&ctx).expect("snapshot after write");
     after.assign_ids();
-    let held = find(&after.root, &|n| n.states.editable)
+    let held = after
+        .find(target.id)
         .and_then(|n| n.value.clone())
         .unwrap_or_default();
     assert!(
@@ -140,8 +142,38 @@ fn set_value_reports_whether_the_write_landed() {
         "field holds {held:?} after the write"
     );
 
-    // A write that cannot land: the id names a node that is not the field any more. Before this
-    // change every one of these returned Ok.
+    // Clearing the field: the read-back sees no value at all, which the rule has to read as "empty"
+    // rather than "the read failed" — otherwise this reports failure for a clear that worked. Nothing
+    // else on device exercises that, and it is where the first version of this check was wrong.
+    //
+    // The target is re-located first, deliberately: typing into Settings' search renders a results
+    // list, which shifts every pre-order id after it, so the target captured before the write is
+    // stale by now — and `set_value` says so (`AxElementChanged`) rather than writing to whatever
+    // inherited the id. Re-locating is what an agent does after a write that changes the screen.
+    let mut before_clear = a11y.snapshot(&ctx).expect("snapshot before the clear");
+    before_clear.assign_ids();
+    let field = find(&before_clear.root, &|n| n.states.editable).expect("the field is still there");
+    let target = AxTarget {
+        id: field.id,
+        role: field.role,
+        name: field.name.clone(),
+        bounds: field.bounds,
+    };
+    a11y.set_value(&ctx, &target, "")
+        .expect("clearing a field is a write that can succeed");
+    let mut cleared = a11y.snapshot(&ctx).expect("snapshot after clear");
+    cleared.assign_ids();
+    let left = cleared
+        .find(target.id)
+        .and_then(|n| n.value.clone())
+        .unwrap_or_default();
+    // Not `is_empty()`: an emptied Android `EditText` reports its *hint* as its text, and
+    // `uiautomator` exposes no separate hint attribute — which is exactly why a clear is judged by
+    // the value changing rather than by it reading back empty.
+    assert_ne!(left, "glass", "the field still holds what was typed");
+
+    // A stale target is refused before anything is typed — the pre-write fingerprint check, which
+    // predates the read-back. Kept as a regression guard, not as evidence about the read-back.
     let stale = AxTarget {
         id: target.id,
         role: target.role,

--- a/crates/glass-android/tests/a11y_loop.rs
+++ b/crates/glass-android/tests/a11y_loop.rs
@@ -5,7 +5,7 @@
 //! Launches com.android.settings, snapshots its a11y tree, and asserts the tree
 //! is non-trivial and carries named, role-typed elements. A second test writes into a real
 //! `EditText` and checks that a landed write is confirmed against the live field — including a
-//! clear, which the read-back rule has to treat as a value rather than as a failed read.
+//! clear, which this platform reports by showing the field's hint rather than an empty value.
 
 use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, WalkLimits};
 use glass_core::{AppSpec, GlassError, MouseButton, Platform, PointerEvent, SandboxLevel};
@@ -128,7 +128,7 @@ fn set_value_reports_whether_the_write_landed() {
         bounds: field.bounds,
     };
 
-    // A write that lands: reported Ok, and the node at that id really holds it afterwards.
+    // A write that lands: reported Ok, and the node at that id holds it afterwards.
     a11y.set_value(&ctx, &target, "glass")
         .expect("a real write into a real field must succeed");
     let mut after = a11y.snapshot(&ctx).expect("snapshot after write");
@@ -142,9 +142,10 @@ fn set_value_reports_whether_the_write_landed() {
         "field holds {held:?} after the write"
     );
 
-    // Clearing the field: the read-back sees no value at all, which the rule has to read as "empty"
-    // rather than "the read failed" — otherwise this reports failure for a clear that worked. Nothing
-    // else on device exercises that, and it is where the first version of this check was wrong.
+    // Clearing the field, which no other test exercises on a device and which is where the first two
+    // versions of this check were wrong: a rule that read an absent value as "the read failed"
+    // reported every clear as a failure, and a rule that demanded the field read back empty failed
+    // here too, because this field reports its hint instead (see the assertion below).
     //
     // The target is re-located first, deliberately: typing into Settings' search renders a results
     // list, which shifts every pre-order id after it, so the target captured before the write is

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -396,8 +396,8 @@ pub enum TruncationLimit {
 }
 
 impl TruncationLimit {
-    /// Human-readable unit for the disclosure notice.
-    fn label(self) -> &'static str {
+    /// Human-readable unit for a disclosure notice: pairs with [`Truncation::limit_value`].
+    pub fn label(self) -> &'static str {
         match self {
             TruncationLimit::Nodes => "nodes",
             TruncationLimit::Depth => "levels deep",

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -94,7 +94,10 @@ pub enum GlassError {
     AxElementChanged(u32),
 
     #[error(
-        "set_value on element #{0} reported success but the value did not change (read-only a11y projection — use keystrokes)"
+        "set_value on element #{0} did not take — the element does not hold the requested value. On \
+         a desktop backend this usually means a read-only accessibility projection, so try \
+         keystrokes; on Android or the iOS Simulator the write already IS keystrokes, so the tap may \
+         have missed or the field rejected the input — re-snapshot to see what it holds"
     )]
     AxValueNotApplied(u32),
 

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -15,6 +15,9 @@ pub use toolpath::tool_path;
 pub mod bounded;
 pub use bounded::{TIMED_OUT, run_bounded, run_bounded_with_stdin};
 
+pub mod set_value;
+pub use set_value::{read_back_confirms, set_value_took};
+
 pub mod frame;
 pub use frame::{Frame, Region};
 

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -16,7 +16,7 @@ pub mod bounded;
 pub use bounded::{TIMED_OUT, run_bounded, run_bounded_with_stdin};
 
 pub mod set_value;
-pub use set_value::{read_back_confirms, set_value_took};
+pub use set_value::{read_back_confirms, typed_clear_landed, typed_text_landed};
 
 pub mod frame;
 pub use frame::{Frame, Region};

--- a/crates/glass-core/src/set_value.rs
+++ b/crates/glass-core/src/set_value.rs
@@ -60,7 +60,7 @@ pub fn read_back_confirms(read_back: Option<&str>, before: Option<&str>, request
 /// was there before.
 ///
 /// `read_back` is `None` when the element reports no value, which for a text field means it is
-/// empty — every mobile reader maps an empty value away — so it compares as `""`.
+/// empty — the `uiautomator` and `idb` mappers both drop an empty value — so it compares as `""`.
 ///
 /// The cost of the strictness: a field that reformats what it is given (a phone number becoming
 /// `"(123) 456-7890"`) reports the write as not applied even though it landed. That is the safer
@@ -72,22 +72,18 @@ pub fn typed_text_landed(read_back: Option<&str>, requested: &str) -> bool {
     read_back.unwrap_or("") == requested
 }
 
-/// Whether a *clear* — a typed write of `""` — landed, judged from the value read back and the value
-/// the field held before.
+/// Whether a *clear* — a typed write of `""` — landed, judged from the value read back.
 ///
-/// A clear cannot be judged by comparing the read-back to `""`, because a platform may report an
-/// empty field's *hint* as its value: measured on the dogfood AVD, `uiautomator dump` gives an empty
-/// `EditText` `text="Search settings"`, its placeholder, and exposes no separate hint attribute, so
-/// an empty hinted field is indistinguishable from one holding that text. Comparing to `""` would
-/// report every clear of a hinted field as not applied.
+/// Empty only. Do not weaken this to "empty, or the value changed": the tap that begins a clear can
+/// itself change a field that reformats on focus — a currency field showing `"$1,234.00"` unfocused
+/// and `"1234.00"` while editing — so "changed" would confirm a clear whose delete never fired.
 ///
-/// So a clear is confirmed when the field reads back empty, or when its value changed at all — which
-/// on a hinted field is the hint reappearing. The weaker rule is confined to this case: for a clear
-/// there is nothing else to compare against, and a clear that did not fire leaves the value exactly
-/// as it was.
-pub fn typed_clear_landed(read_back: Option<&str>, before: Option<&str>) -> bool {
-    let after = read_back.unwrap_or("");
-    after.is_empty() || Some(after) != before
+/// The cost is a false *failure*: on the dogfood AVD an emptied `EditText` reports its placeholder as
+/// its text (`text="Search settings"`, and `uiautomator` exposes no separate hint attribute), so a
+/// clear that worked reads as not applied. An agent can read the element and see the placeholder; the
+/// other direction would have it believing an unchanged field was cleared.
+pub fn typed_clear_landed(read_back: Option<&str>) -> bool {
+    read_back.unwrap_or("").is_empty()
 }
 
 #[cfg(test)]
@@ -127,15 +123,14 @@ mod tests {
     }
 
     #[test]
-    fn a_clear_is_confirmed_by_an_empty_field_or_by_the_value_changing() {
-        // Empty is the obvious case.
-        assert!(typed_clear_landed(None, Some("hello")));
-        assert!(typed_clear_landed(Some(""), Some("hello")));
-        // The hint case, which is why this rule is not "reads back empty": an emptied Android
-        // EditText reports its placeholder, so the evidence is that the value changed.
-        assert!(typed_clear_landed(Some("Search settings"), Some("glass")));
-        // A clear that did not fire leaves the value exactly as it was.
-        assert!(!typed_clear_landed(Some("glass"), Some("glass")));
+    fn a_clear_is_confirmed_only_by_an_empty_field() {
+        assert!(typed_clear_landed(None));
+        assert!(typed_clear_landed(Some("")));
+        // A clear that did not fire.
+        assert!(!typed_clear_landed(Some("glass")));
+        // The cost, pinned as a decision: a platform that reports an emptied field's placeholder
+        // reads as not applied.
+        assert!(!typed_clear_landed(Some("Search settings")));
     }
 
     #[test]

--- a/crates/glass-core/src/set_value.rs
+++ b/crates/glass-core/src/set_value.rs
@@ -6,8 +6,8 @@
 //! same; a tap-and-type on a mobile field can land somewhere else entirely. Reporting `Ok` on any
 //! of those is a false success — the agent believes a field holds text it does not hold.
 //!
-//! So the judgement lives here, once, rather than in each reader: three of them had already grown
-//! their own copy of it.
+//! So the judgement lives here rather than in each reader: the macOS and Windows readers had each
+//! grown their own copy, and the two mobile backends were about to need it too.
 
 /// Whether a `set_value` write took, judged from the value read back.
 ///

--- a/crates/glass-core/src/set_value.rs
+++ b/crates/glass-core/src/set_value.rs
@@ -1,0 +1,93 @@
+//! Judging whether a `set_value` write actually took, from the value read back afterwards.
+//!
+//! Every backend that writes a value faces the same problem: the platform can accept the write
+//! without error and change nothing. A UIA `SetValue` on an egui read-only `TextEdit` returns
+//! success and leaves the buffer alone; an AX write to a read-only-in-practice editable does the
+//! same; a tap-and-type on a mobile field can land somewhere else entirely. Reporting `Ok` on any
+//! of those is a false success — the agent believes a field holds text it does not hold.
+//!
+//! So the judgement lives here, once, rather than in each reader: three of them had already grown
+//! their own copy of it.
+
+/// Whether a `set_value` write took, judged from the value read back.
+///
+/// It took iff the read-back equals the request OR differs from the pre-set value. The second half
+/// matters because a real write may be reformatted on the way in — a slider set to `"50"` reads
+/// back `"50.0"` — while a write that silently did nothing reads back exactly what was there
+/// before.
+pub fn set_value_took(before: &str, after: &str, requested: &str) -> bool {
+    after == requested || after != before
+}
+
+/// Whether a read-back can *confirm* the write took. `read_back` is the value read afterwards
+/// (`None` when that read failed or the value was absent); `before` is the pre-write baseline
+/// (`None` when that read failed — the baseline is unknown).
+///
+/// Confirms only when it can prove the write landed:
+/// - a failed post-write read is inconclusive and never confirms;
+/// - with a known baseline it delegates to [`set_value_took`];
+/// - with an unknown baseline only an exact match with the request confirms, because "differs from
+///   before" means nothing without a baseline to differ from.
+///
+/// That last rule is the guard against a *failed read* passing for a change: a reader that collapsed
+/// both reads to `""` once reported false success for exactly that reason.
+pub fn read_back_confirms(read_back: Option<&str>, before: Option<&str>, requested: &str) -> bool {
+    match (read_back, before) {
+        (None, _) => false,
+        (Some(after), Some(before)) => set_value_took(before, after, requested),
+        (Some(after), None) => after == requested,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_write_that_changed_nothing_did_not_take() {
+        // A read-only editable that accepts the write and keeps its value.
+        assert!(!set_value_took("#000000", "#000000", "#12AA34"));
+    }
+
+    #[test]
+    fn a_read_back_equal_to_the_request_took() {
+        assert!(set_value_took("#000000", "#12AA34", "#12AA34"));
+    }
+
+    #[test]
+    fn a_reformatted_value_still_took() {
+        // A slider set to "50" may read back "50.0" — changed from before, so it landed.
+        assert!(set_value_took("0", "50.0", "50"));
+    }
+
+    #[test]
+    fn writing_the_value_it_already_holds_counts_as_taken() {
+        // Nothing can distinguish this from a no-op, and reporting failure for a write that asked
+        // for the value already present would be the more misleading answer.
+        assert!(set_value_took("50", "50", "50"));
+    }
+
+    #[test]
+    fn a_failed_post_read_never_confirms() {
+        // Inconclusive is not success: the caller reports `AxValueNotApplied` rather than guess.
+        assert!(!read_back_confirms(None, Some("hello"), "world"));
+    }
+
+    #[test]
+    fn a_change_from_a_known_baseline_confirms() {
+        assert!(read_back_confirms(Some("50.0"), Some("0"), "50"));
+        assert!(read_back_confirms(Some("0.0"), Some("0"), "0"));
+    }
+
+    #[test]
+    fn a_mere_difference_cannot_confirm_when_the_baseline_is_unknown() {
+        // The regression this rule exists for: a failed pre-read defaulting to "" made a no-op that
+        // reads back its real value look "changed", and the write was reported as successful.
+        assert!(!read_back_confirms(Some("hello"), None, "world"));
+    }
+
+    #[test]
+    fn an_exact_match_confirms_even_with_an_unknown_baseline() {
+        assert!(read_back_confirms(Some("world"), None, "world"));
+    }
+}

--- a/crates/glass-core/src/set_value.rs
+++ b/crates/glass-core/src/set_value.rs
@@ -6,8 +6,22 @@
 //! same; a tap-and-type on a mobile field can land somewhere else entirely. Reporting `Ok` on any
 //! of those is a false success — the agent believes a field holds text it does not hold.
 //!
-//! So the judgement lives here rather than in each reader: the macOS and Windows readers had each
-//! grown their own copy, and the two mobile backends were about to need it too.
+//! Two rules live here, because two kinds of write need different evidence.
+//!
+//! An *atomic platform write* (UIA `SetValue`, AX `AXValue`) either happens or does not, and may be
+//! reformatted on the way in — a slider set to `"50"` reads back `"50.0"`. So a value that merely
+//! differs from the old one is evidence it landed: [`read_back_confirms`]. The macOS and Windows
+//! readers had each grown their own copy of that rule; it is theirs.
+//!
+//! A *typed write* (tap, select-all, delete, type) is not atomic. A dropped key, a `maxLength`, an
+//! input filter or autocorrect all leave the field holding something that is neither the request nor
+//! the old value, and calling that success is the very failure this module exists to prevent. So a
+//! typed write must read back exactly what was asked: [`typed_text_landed`]. Android's on-device
+//! service reader reached the same conclusion independently (`a11y_service.rs`).
+//!
+//! Two write paths deliberately do not use either rule: the AT-SPI (Linux) reader trusts the
+//! toolkit's own `set_text_contents` answer without reading back, and Android's service reader keeps
+//! its own exact-match loop.
 
 /// Whether a `set_value` write took, judged from the value read back.
 ///
@@ -15,7 +29,7 @@
 /// matters because a real write may be reformatted on the way in — a slider set to `"50"` reads
 /// back `"50.0"` — while a write that silently did nothing reads back exactly what was there
 /// before.
-pub fn set_value_took(before: &str, after: &str, requested: &str) -> bool {
+fn set_value_took(before: &str, after: &str, requested: &str) -> bool {
     after == requested || after != before
 }
 
@@ -37,6 +51,43 @@ pub fn read_back_confirms(read_back: Option<&str>, before: Option<&str>, request
         (Some(after), Some(before)) => set_value_took(before, after, requested),
         (Some(after), None) => after == requested,
     }
+}
+
+/// Whether a *typed* write landed, judged from the value read back.
+///
+/// Exact match, unlike [`read_back_confirms`]: keystrokes can land partially, and a field holding
+/// `"worl"` after `"world"` was typed has not received the write, even though it differs from what
+/// was there before.
+///
+/// `read_back` is `None` when the element reports no value, which for a text field means it is
+/// empty — every mobile reader maps an empty value away — so it compares as `""`.
+///
+/// The cost of the strictness: a field that reformats what it is given (a phone number becoming
+/// `"(123) 456-7890"`) reports the write as not applied even though it landed. That is the safer
+/// direction — an agent can re-read the tree and see the value, whereas a false success has it
+/// asserting against a screen that never changed.
+///
+/// Not for a clear: see [`typed_clear_landed`].
+pub fn typed_text_landed(read_back: Option<&str>, requested: &str) -> bool {
+    read_back.unwrap_or("") == requested
+}
+
+/// Whether a *clear* — a typed write of `""` — landed, judged from the value read back and the value
+/// the field held before.
+///
+/// A clear cannot be judged by comparing the read-back to `""`, because a platform may report an
+/// empty field's *hint* as its value: measured on the dogfood AVD, `uiautomator dump` gives an empty
+/// `EditText` `text="Search settings"`, its placeholder, and exposes no separate hint attribute, so
+/// an empty hinted field is indistinguishable from one holding that text. Comparing to `""` would
+/// report every clear of a hinted field as not applied.
+///
+/// So a clear is confirmed when the field reads back empty, or when its value changed at all — which
+/// on a hinted field is the hint reappearing. The weaker rule is confined to this case: for a clear
+/// there is nothing else to compare against, and a clear that did not fire leaves the value exactly
+/// as it was.
+pub fn typed_clear_landed(read_back: Option<&str>, before: Option<&str>) -> bool {
+    let after = read_back.unwrap_or("");
+    after.is_empty() || Some(after) != before
 }
 
 #[cfg(test)]
@@ -65,6 +116,39 @@ mod tests {
         // Nothing can distinguish this from a no-op, and reporting failure for a write that asked
         // for the value already present would be the more misleading answer.
         assert!(set_value_took("50", "50", "50"));
+    }
+
+    #[test]
+    fn a_typed_write_must_read_back_exactly() {
+        assert!(typed_text_landed(Some("world"), "world"));
+        // A dropped keystroke: differs from the old value, but the write did not land.
+        assert!(!typed_text_landed(Some("worl"), "world"));
+        assert!(!typed_text_landed(Some("hello"), "world"));
+    }
+
+    #[test]
+    fn a_clear_is_confirmed_by_an_empty_field_or_by_the_value_changing() {
+        // Empty is the obvious case.
+        assert!(typed_clear_landed(None, Some("hello")));
+        assert!(typed_clear_landed(Some(""), Some("hello")));
+        // The hint case, which is why this rule is not "reads back empty": an emptied Android
+        // EditText reports its placeholder, so the evidence is that the value changed.
+        assert!(typed_clear_landed(Some("Search settings"), Some("glass")));
+        // A clear that did not fire leaves the value exactly as it was.
+        assert!(!typed_clear_landed(Some("glass"), Some("glass")));
+    }
+
+    #[test]
+    fn a_typed_write_of_text_still_needs_an_exact_match() {
+        assert!(typed_text_landed(None, ""));
+        assert!(!typed_text_landed(None, "world"));
+    }
+
+    #[test]
+    fn an_unchanged_value_does_not_confirm_an_atomic_write() {
+        // The arm with no false case before: a read-back equal to the baseline and unequal to the
+        // request is the no-op this predicate exists to catch.
+        assert!(!read_back_confirms(Some("hello"), Some("hello"), "world"));
     }
 
     #[test]

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -84,43 +84,52 @@ fn verify(tree: &AxTree, target: &AxTarget) -> Result<AxRect> {
         .ok_or_else(|| GlassError::Backend("a11y set_value: element has no bounds".into()))
 }
 
-/// How long to let the app commit typed text before each read-back attempt. The device test's own
-/// helper allows up to twelve 300ms-spaced describes for a typed value to become observable, so one
-/// read at 300ms is not on its own enough — hence [`VERIFY_ATTEMPTS`].
+/// How long to let the app commit typed text before each read-back attempt. Generous next to a
+/// keystroke and small next to the `describe` that follows it.
 const VERIFY_SETTLE: Duration = Duration::from_millis(300);
 
 /// How many times to read the element back before reporting the write as not applied. A landed write
-/// confirms on the first attempt.
+/// confirms on the first attempt and pays for one describe; the retries cover a field that commits a
+/// frame or two later.
 const VERIFY_ATTEMPTS: usize = 3;
 
 /// Judge a typed `set_value` from a tree described after it. `Ok(())` only when the field holds
-/// exactly what was asked for.
+/// exactly what was asked for, or — for a clear — reads back empty.
 ///
 /// Exact match, not "changed from before": tap-and-type is not atomic, so a dropped key or a field
 /// that filters input leaves something that is neither the request nor the old value, and calling
-/// that success is the failure this check exists to prevent. `glass_core::typed_text_landed` carries
-/// the rule and the cost of it. Twin of `verify_write` in `glass-android/src/a11y.rs` — keep the two
-/// in step.
+/// that success is the failure this check exists to prevent. `glass_core::typed_text_landed` and
+/// `glass_core::typed_clear_landed` carry the rules and the cost of them. Twin of `verify_write` in
+/// `glass-android/src/a11y.rs` — keep the two in step.
 ///
 /// The element is re-resolved by its pre-order id, which the write itself can perturb (the keyboard
 /// appears between the two describes), so a mismatch is [`GlassError::AxElementChanged`] —
-/// "re-snapshot" — rather than a claim about the write.
-fn verify_write(
-    after_tree: &AxTree,
-    target: &AxTarget,
-    before: Option<&str>,
-    text: &str,
-) -> Result<()> {
-    let node = after_tree
-        .find(target.id)
-        .ok_or(GlassError::AxElementChanged(target.id.0))?;
+/// "re-snapshot" — rather than a claim about the write. A tree cut short by the walk caps explains an
+/// absent element better than drift does, so that case says so instead.
+///
+/// The node must also still be editable: for a non-editable node `axmap` puts the element's AXLabel
+/// in `value`, so a label that changed inside the settle window would otherwise read as a successful
+/// write into a Label.
+fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()> {
+    let Some(node) = after_tree.find(target.id) else {
+        return Err(match &after_tree.truncated {
+            // `Truncation::notice()` is written to close a rendered outline — a leading ellipsis and
+            // its own pixel-fallback advice — so this states the cap itself instead.
+            Some(t) => GlassError::AccessibilityUnavailable(format!(
+                "a11y set_value: the text was typed, but the read-back could not find element {} \
+                 because the tree was truncated at {} {}; re-snapshot rather than retyping",
+                target.id.0,
+                t.limit_value,
+                t.limit.label(),
+            )),
+            None => GlassError::AxElementChanged(target.id.0),
+        });
+    };
     if !target.matches(node.role, node.name.as_deref()) || !node.states.editable {
         return Err(GlassError::AxElementChanged(target.id.0));
     }
-    // A clear is judged differently, because an emptied field may report its hint as its value —
-    // see `typed_clear_landed`.
     let landed = if text.is_empty() {
-        typed_clear_landed(node.value.as_deref(), before)
+        typed_clear_landed(node.value.as_deref())
     } else {
         typed_text_landed(node.value.as_deref(), text)
     };
@@ -141,8 +150,6 @@ impl Accessibility for IosA11y {
         // the ids here are final, not walked again.
         let (tree, scale) = self.describe(ctx)?;
         let bounds = verify(&tree, target)?;
-        // Needed only to judge a clear — see `typed_clear_landed`.
-        let before = tree.find(target.id).and_then(|n| n.value.clone());
         let (cx, cy) = bounds
             .clamped_center(ctx.window.width, ctx.window.height)
             .ok_or_else(|| GlassError::Backend("a11y set_value: element not on screen".into()))?;
@@ -166,8 +173,6 @@ impl Accessibility for IosA11y {
 
         // A failure of this read is not a failure of the write — the field has already been cleared
         // and typed into — so it says so rather than letting a caller retry blindly and type twice.
-        // Re-read up to `VERIFY_ATTEMPTS` times, but only while unconfirmed: a landed write pays for
-        // one describe, and a field that commits a frame later still gets seen.
         let mut last = None;
         for _ in 0..VERIFY_ATTEMPTS {
             std::thread::sleep(VERIFY_SETTLE);
@@ -177,9 +182,12 @@ impl Accessibility for IosA11y {
                      re-snapshot to see whether it landed rather than retyping"
                 ))
             })?;
-            match verify_write(&after, target, before.as_deref(), text) {
+            match verify_write(&after, target, text) {
                 Ok(()) => return Ok(()),
-                Err(e) => last = Some(e),
+                // Only a not-applied verdict can change on a later describe: drift and truncation
+                // are structural, so re-describing for them reaches the same answer more slowly.
+                Err(e @ GlassError::AxValueNotApplied(_)) => last = Some(e),
+                Err(e) => return Err(e),
             }
         }
         Err(last.unwrap_or(GlassError::AxValueNotApplied(target.id.0)))
@@ -257,7 +265,7 @@ mod tests {
     #[test]
     fn a_write_that_landed_is_reported_as_success() {
         let after = tree_with_value(Some("world"));
-        assert!(verify_write(&after, &matching_target(), Some("hello"), "world").is_ok());
+        assert!(verify_write(&after, &matching_target(), "world").is_ok());
     }
 
     #[test]
@@ -265,14 +273,44 @@ mod tests {
         // An empty field reports no value at all, so a rule that read `None` as "unknown" made
         // `set_value(id, "")` fail every time.
         let after = tree_with_value(None);
-        assert!(verify_write(&after, &matching_target(), Some("hello"), "").is_ok());
+        assert!(verify_write(&after, &matching_target(), "").is_ok());
+    }
+
+    #[test]
+    fn a_cleared_field_still_reporting_text_reads_as_not_applied() {
+        // A clear is judged by "reads back empty", not by "the value changed": the tap that begins
+        // the clear can itself change a field that reformats on focus, and accepting that would
+        // confirm a clear whose delete never fired.
+        let after = tree_with_value(Some("Search settings"));
+        assert!(matches!(
+            verify_write(&after, &matching_target(), ""),
+            Err(GlassError::AxValueNotApplied(_))
+        ));
+    }
+
+    #[test]
+    fn a_truncated_read_back_says_so_rather_than_blaming_drift() {
+        // The iOS tree carries the same truncation record Android's does; reporting "it moved" would
+        // throw away the one fact that explains the absence.
+        let mut after = tree_with_value(Some("world"));
+        after.truncated = Some(glass_core::accessibility::Truncation {
+            limit: glass_core::accessibility::TruncationLimit::Nodes,
+            limit_value: 1,
+            nodes_walked: 1,
+        });
+        let mut t = matching_target();
+        t.id = AxNodeId(99);
+        assert!(matches!(
+            verify_write(&after, &t, "world"),
+            Err(GlassError::AccessibilityUnavailable(_))
+        ));
     }
 
     #[test]
     fn a_field_that_never_changed_is_not_a_successful_write() {
         let after = tree_with_value(Some("hello"));
         assert!(matches!(
-            verify_write(&after, &matching_target(), Some("hello"), "world"),
+            verify_write(&after, &matching_target(), "world"),
             Err(GlassError::AxValueNotApplied(1))
         ));
     }
@@ -283,7 +321,7 @@ mod tests {
         // called it success.
         let after = tree_with_value(Some("worl"));
         assert!(matches!(
-            verify_write(&after, &matching_target(), Some("hello"), "world"),
+            verify_write(&after, &matching_target(), "world"),
             Err(GlassError::AxValueNotApplied(1))
         ));
     }
@@ -294,7 +332,7 @@ mod tests {
         let mut t = matching_target();
         t.name = Some("A different field".into());
         assert!(matches!(
-            verify_write(&after, &t, Some("hello"), "world"),
+            verify_write(&after, &t, "world"),
             Err(GlassError::AxElementChanged(1))
         ));
     }
@@ -306,7 +344,7 @@ mod tests {
         let mut after = tree_with_value(Some("world"));
         after.root.children[0].states.editable = false;
         assert!(matches!(
-            verify_write(&after, &matching_target(), Some("hello"), "world"),
+            verify_write(&after, &matching_target(), "world"),
             Err(GlassError::AxElementChanged(1))
         ));
     }
@@ -317,7 +355,7 @@ mod tests {
         let mut t = matching_target();
         t.id = AxNodeId(9);
         assert!(matches!(
-            verify_write(&after, &t, Some("hello"), "world"),
+            verify_write(&after, &t, "world"),
             Err(GlassError::AxElementChanged(9))
         ));
     }

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -1,11 +1,13 @@
 //! iOS accessibility reader over idb's `accessibility_info`. Snapshot maps the
 //! nested JSON to an AxTree; set_value re-verifies the target element (guarding
 //! against a stale id landing on a different element), focuses it, clears it, and
-//! types the new text via synthetic HID input.
+//! types the new text via synthetic HID input, then reads the element back and reports the write as not applied if it does not hold it.
 use glass_core::accessibility::{Accessibility, AxContext, AxRect, AxTarget, AxTree};
 use std::time::Duration;
 
-use glass_core::{GlassError, KeyEvent, MouseButton, PointerEvent, Result, read_back_confirms};
+use glass_core::{
+    GlassError, KeyEvent, MouseButton, PointerEvent, Result, typed_clear_landed, typed_text_landed,
+};
 
 use crate::axmap;
 use crate::idb::client::IdbClient;
@@ -72,21 +74,37 @@ fn verify(tree: &AxTree, target: &AxTarget) -> Result<AxRect> {
             "a11y set_value: element moved since the snapshot; re-snapshot".into(),
         ));
     }
+    // Android and macOS gate on this and iOS did not, which mattered once the write is checked: for
+    // a non-editable node `axmap` puts the element's AXLabel in `value`, so a label that changed for
+    // any reason inside the settle window would have read as a successful write into a Label.
+    if !node.states.editable {
+        return Err(GlassError::AxElementNotEditable(target.id.0));
+    }
     node.bounds
         .ok_or_else(|| GlassError::Backend("a11y set_value: element has no bounds".into()))
 }
 
-/// How long to let the app commit typed text before reading it back. Generous next to a keystroke,
-/// small next to the `describe` that follows it.
+/// How long to let the app commit typed text before each read-back attempt. The device test's own
+/// helper allows up to twelve 300ms-spaced describes for a typed value to become observable, so one
+/// read at 300ms is not on its own enough — hence [`VERIFY_ATTEMPTS`].
 const VERIFY_SETTLE: Duration = Duration::from_millis(300);
 
-/// Judge a `set_value` write from a tree described after it, against the value the target held
-/// before. `Ok(())` only when the read-back proves the write landed.
+/// How many times to read the element back before reporting the write as not applied. A landed write
+/// confirms on the first attempt.
+const VERIFY_ATTEMPTS: usize = 3;
+
+/// Judge a typed `set_value` from a tree described after it. `Ok(())` only when the field holds
+/// exactly what was asked for.
 ///
-/// A tap-and-type can miss: the field may reject input, the keyboard may not have come up, or the
-/// tap may land on a neighbour. Reporting success then tells an agent a field holds text it does
-/// not hold. A target no longer at that id is [`GlassError::AxElementChanged`], since the write may
-/// have landed on something that then moved.
+/// Exact match, not "changed from before": tap-and-type is not atomic, so a dropped key or a field
+/// that filters input leaves something that is neither the request nor the old value, and calling
+/// that success is the failure this check exists to prevent. `glass_core::typed_text_landed` carries
+/// the rule and the cost of it. Twin of `verify_write` in `glass-android/src/a11y.rs` — keep the two
+/// in step.
+///
+/// The element is re-resolved by its pre-order id, which the write itself can perturb (the keyboard
+/// appears between the two describes), so a mismatch is [`GlassError::AxElementChanged`] —
+/// "re-snapshot" — rather than a claim about the write.
 fn verify_write(
     after_tree: &AxTree,
     target: &AxTarget,
@@ -96,10 +114,17 @@ fn verify_write(
     let node = after_tree
         .find(target.id)
         .ok_or(GlassError::AxElementChanged(target.id.0))?;
-    if !target.matches(node.role, node.name.as_deref()) {
+    if !target.matches(node.role, node.name.as_deref()) || !node.states.editable {
         return Err(GlassError::AxElementChanged(target.id.0));
     }
-    if read_back_confirms(node.value.as_deref(), before, text) {
+    // A clear is judged differently, because an emptied field may report its hint as its value —
+    // see `typed_clear_landed`.
+    let landed = if text.is_empty() {
+        typed_clear_landed(node.value.as_deref(), before)
+    } else {
+        typed_text_landed(node.value.as_deref(), text)
+    };
+    if landed {
         Ok(())
     } else {
         Err(GlassError::AxValueNotApplied(target.id.0))
@@ -116,7 +141,7 @@ impl Accessibility for IosA11y {
         // the ids here are final, not walked again.
         let (tree, scale) = self.describe(ctx)?;
         let bounds = verify(&tree, target)?;
-        // The baseline for the read-back, from the describe that already located the target.
+        // Needed only to judge a clear — see `typed_clear_landed`.
         let before = tree.find(target.id).and_then(|n| n.value.clone());
         let (cx, cy) = bounds
             .clamped_center(ctx.window.width, ctx.window.height)
@@ -139,10 +164,25 @@ impl Accessibility for IosA11y {
         self.client
             .hid(injector.key_events(&KeyEvent::Text(text.to_string()))?)?;
 
-        // Read back once, not in a loop: a re-read is a whole `describe` round trip through idb.
-        std::thread::sleep(VERIFY_SETTLE);
-        let (after, _) = self.describe(ctx)?;
-        verify_write(&after, target, before.as_deref(), text)
+        // A failure of this read is not a failure of the write — the field has already been cleared
+        // and typed into — so it says so rather than letting a caller retry blindly and type twice.
+        // Re-read up to `VERIFY_ATTEMPTS` times, but only while unconfirmed: a landed write pays for
+        // one describe, and a field that commits a frame later still gets seen.
+        let mut last = None;
+        for _ in 0..VERIFY_ATTEMPTS {
+            std::thread::sleep(VERIFY_SETTLE);
+            let (after, _) = self.describe(ctx).map_err(|e| {
+                GlassError::Backend(format!(
+                    "a11y set_value: the text was typed, but reading the element back failed: {e}; \
+                     re-snapshot to see whether it landed rather than retyping"
+                ))
+            })?;
+            match verify_write(&after, target, before.as_deref(), text) {
+                Ok(()) => return Ok(()),
+                Err(e) => last = Some(e),
+            }
+        }
+        Err(last.unwrap_or(GlassError::AxValueNotApplied(target.id.0)))
     }
 }
 
@@ -217,17 +257,34 @@ mod tests {
     #[test]
     fn a_write_that_landed_is_reported_as_success() {
         let after = tree_with_value(Some("world"));
-        let t = matching_target();
-        assert!(verify_write(&after, &t, Some("hello"), "world").is_ok());
+        assert!(verify_write(&after, &matching_target(), Some("hello"), "world").is_ok());
+    }
+
+    #[test]
+    fn clearing_a_field_is_a_write_that_can_succeed() {
+        // An empty field reports no value at all, so a rule that read `None` as "unknown" made
+        // `set_value(id, "")` fail every time.
+        let after = tree_with_value(None);
+        assert!(verify_write(&after, &matching_target(), Some("hello"), "").is_ok());
     }
 
     #[test]
     fn a_field_that_never_changed_is_not_a_successful_write() {
         let after = tree_with_value(Some("hello"));
-        let t = matching_target();
         assert!(matches!(
-            verify_write(&after, &t, Some("hello"), "world"),
-            Err(GlassError::AxValueNotApplied(_))
+            verify_write(&after, &matching_target(), Some("hello"), "world"),
+            Err(GlassError::AxValueNotApplied(1))
+        ));
+    }
+
+    #[test]
+    fn a_partly_typed_write_is_not_a_successful_write() {
+        // A dropped keystroke: differs from the old value, so "changed from before" would have
+        // called it success.
+        let after = tree_with_value(Some("worl"));
+        assert!(matches!(
+            verify_write(&after, &matching_target(), Some("hello"), "world"),
+            Err(GlassError::AxValueNotApplied(1))
         ));
     }
 
@@ -238,7 +295,30 @@ mod tests {
         t.name = Some("A different field".into());
         assert!(matches!(
             verify_write(&after, &t, Some("hello"), "world"),
-            Err(GlassError::AxElementChanged(_))
+            Err(GlassError::AxElementChanged(1))
+        ));
+    }
+
+    #[test]
+    fn a_non_editable_node_at_the_id_is_reported_as_changed() {
+        // For a non-editable node this reader puts the element's AXLabel in `value`, so without the
+        // editable gate a label that changed inside the settle window read as a successful write.
+        let mut after = tree_with_value(Some("world"));
+        after.root.children[0].states.editable = false;
+        assert!(matches!(
+            verify_write(&after, &matching_target(), Some("hello"), "world"),
+            Err(GlassError::AxElementChanged(1))
+        ));
+    }
+
+    #[test]
+    fn a_target_missing_from_the_read_back_is_reported_as_changed() {
+        let after = tree_with_value(Some("world"));
+        let mut t = matching_target();
+        t.id = AxNodeId(9);
+        assert!(matches!(
+            verify_write(&after, &t, Some("hello"), "world"),
+            Err(GlassError::AxElementChanged(9))
         ));
     }
 

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -3,7 +3,9 @@
 //! against a stale id landing on a different element), focuses it, clears it, and
 //! types the new text via synthetic HID input.
 use glass_core::accessibility::{Accessibility, AxContext, AxRect, AxTarget, AxTree};
-use glass_core::{GlassError, KeyEvent, MouseButton, PointerEvent, Result};
+use std::time::Duration;
+
+use glass_core::{GlassError, KeyEvent, MouseButton, PointerEvent, Result, read_back_confirms};
 
 use crate::axmap;
 use crate::idb::client::IdbClient;
@@ -74,6 +76,36 @@ fn verify(tree: &AxTree, target: &AxTarget) -> Result<AxRect> {
         .ok_or_else(|| GlassError::Backend("a11y set_value: element has no bounds".into()))
 }
 
+/// How long to let the app commit typed text before reading it back. Generous next to a keystroke,
+/// small next to the `describe` that follows it.
+const VERIFY_SETTLE: Duration = Duration::from_millis(300);
+
+/// Judge a `set_value` write from a tree described after it, against the value the target held
+/// before. `Ok(())` only when the read-back proves the write landed.
+///
+/// A tap-and-type can miss: the field may reject input, the keyboard may not have come up, or the
+/// tap may land on a neighbour. Reporting success then tells an agent a field holds text it does
+/// not hold. A target no longer at that id is [`GlassError::AxElementChanged`], since the write may
+/// have landed on something that then moved.
+fn verify_write(
+    after_tree: &AxTree,
+    target: &AxTarget,
+    before: Option<&str>,
+    text: &str,
+) -> Result<()> {
+    let node = after_tree
+        .find(target.id)
+        .ok_or(GlassError::AxElementChanged(target.id.0))?;
+    if !target.matches(node.role, node.name.as_deref()) {
+        return Err(GlassError::AxElementChanged(target.id.0));
+    }
+    if read_back_confirms(node.value.as_deref(), before, text) {
+        Ok(())
+    } else {
+        Err(GlassError::AxValueNotApplied(target.id.0))
+    }
+}
+
 impl Accessibility for IosA11y {
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
         Ok(self.describe(ctx)?.0)
@@ -84,6 +116,8 @@ impl Accessibility for IosA11y {
         // the ids here are final, not walked again.
         let (tree, scale) = self.describe(ctx)?;
         let bounds = verify(&tree, target)?;
+        // The baseline for the read-back, from the describe that already located the target.
+        let before = tree.find(target.id).and_then(|n| n.value.clone());
         let (cx, cy) = bounds
             .clamped_center(ctx.window.width, ctx.window.height)
             .ok_or_else(|| GlassError::Backend("a11y set_value: element not on screen".into()))?;
@@ -104,7 +138,11 @@ impl Accessibility for IosA11y {
             .hid(injector.key_events(&KeyEvent::Chord("Delete".into()))?)?;
         self.client
             .hid(injector.key_events(&KeyEvent::Text(text.to_string()))?)?;
-        Ok(())
+
+        // Read back once, not in a loop: a re-read is a whole `describe` round trip through idb.
+        std::thread::sleep(VERIFY_SETTLE);
+        let (after, _) = self.describe(ctx)?;
+        verify_write(&after, target, before.as_deref(), text)
     }
 }
 
@@ -150,6 +188,58 @@ mod tests {
         let mut t = AxTree::new(root);
         t.assign_ids();
         t
+    }
+
+    const FIELD: AxRect = AxRect {
+        x: 10,
+        y: 20,
+        width: 100,
+        height: 40,
+    };
+
+    /// The one-field tree a read-back sees, holding `value`.
+    fn tree_with_value(value: Option<&str>) -> AxTree {
+        let mut field = leaf(0, AxRole::TextField, "Note", FIELD);
+        field.value = value.map(Into::into);
+        tree_with(field)
+    }
+
+    /// A target matching that field as the snapshot before the write saw it.
+    fn matching_target() -> AxTarget {
+        AxTarget {
+            id: AxNodeId(1),
+            role: AxRole::TextField,
+            name: Some("Note".into()),
+            bounds: Some(FIELD),
+        }
+    }
+
+    #[test]
+    fn a_write_that_landed_is_reported_as_success() {
+        let after = tree_with_value(Some("world"));
+        let t = matching_target();
+        assert!(verify_write(&after, &t, Some("hello"), "world").is_ok());
+    }
+
+    #[test]
+    fn a_field_that_never_changed_is_not_a_successful_write() {
+        let after = tree_with_value(Some("hello"));
+        let t = matching_target();
+        assert!(matches!(
+            verify_write(&after, &t, Some("hello"), "world"),
+            Err(GlassError::AxValueNotApplied(_))
+        ));
+    }
+
+    #[test]
+    fn a_target_that_moved_is_reported_as_changed_not_as_a_failed_write() {
+        let after = tree_with_value(Some("world"));
+        let mut t = matching_target();
+        t.name = Some("A different field".into());
+        assert!(matches!(
+            verify_write(&after, &t, Some("hello"), "world"),
+            Err(GlassError::AxElementChanged(_))
+        ));
     }
 
     #[test]

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -417,9 +417,10 @@ impl GlassServer {
     #[tool(
         description = "Set an editable element's value — pick the element's #id from \
                        glass_a11y_snapshot. Where the platform can write the value directly this is \
-                       instant and takes no keystrokes; on a mobile backend it taps the element, \
-                       clears it and types, then reads the element back to confirm, which costs an \
-                       extra accessibility read. Errors if the element isn't editable, if it changed \
+                       instant and takes no keystrokes; where it has to be typed, glass taps the \
+                       element, clears it and types, then reads the element back to confirm — up to \
+                       three accessibility reads, since a field may commit a frame or two later. \
+                       Errors if the element isn't editable, if it changed \
                        since the snapshot (re-snapshot), if the element does not hold the requested \
                        value afterwards, or if the app exposes no accessibility tree. \
                        Optional `return`: \"snapshot\" settles the UI then folds a fresh a11y \

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -415,10 +415,13 @@ impl GlassServer {
     }
 
     #[tool(
-        description = "Set an editable element's value directly via accessibility (instant, no \
-                       keystrokes) — pick the element's #id from glass_a11y_snapshot. Errors if the \
-                       element isn't editable, if it changed since the snapshot (re-snapshot), or if \
-                       the app exposes no accessibility tree. \
+        description = "Set an editable element's value — pick the element's #id from \
+                       glass_a11y_snapshot. Where the platform can write the value directly this is \
+                       instant and takes no keystrokes; on a mobile backend it taps the element, \
+                       clears it and types, then reads the element back to confirm, which costs an \
+                       extra accessibility read. Errors if the element isn't editable, if it changed \
+                       since the snapshot (re-snapshot), if the element does not hold the requested \
+                       value afterwards, or if the app exposes no accessibility tree. \
                        Optional `return`: \"snapshot\" settles the UI then folds a fresh a11y \
                        tree into the result (and refreshes the snapshot cache); \"settle\" waits \
                        for the UI to stop \

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -503,8 +503,13 @@ Returns `{id}` — the `#id` you clicked — plus `observed: {settled, saw_motio
 
 ### `glass_set_value`
 
-Set an editable element's value directly via accessibility (instant, no keystrokes). Errors if the
-element isn't editable, changed since the snapshot, or the app exposes no accessibility tree.
+Where the platform can write the value directly this is instant and takes no keystrokes. On a mobile
+backend (Android without the on-device accessibility service, and the iOS Simulator) it taps the
+element, clears it and types, then reads the element back to confirm — up to three reads, since a
+field may commit a frame or two later. Errors if the element isn't editable, changed since the
+snapshot, does not hold the requested value afterwards, or the app exposes no accessibility tree. A
+field that reformats what it is given, and a cleared field that reports its placeholder as its text,
+both read as not applied even though the text arrived — read the element to see what it holds.
 
 - `id` (integer, **required**) — the element's `#id`.
 - `text` (string, **required**) — the value to set.


### PR DESCRIPTION
`glass_set_value` on the two backends that have to *type* a value — Android without the on-device
accessibility service, and the iOS Simulator — tapped the element, cleared it, typed, and returned
`Ok(())` without ever looking again. A tap that landed slightly off, a field that rejected the input,
a dropped keystroke: all came back as success, and everything the agent asserted afterwards was
against a screen that never changed. Windows, macOS and Android's on-device service reader already
read the value back; these two now do too.

## The rule, and why it is not the one the other backends use

An *atomic platform write* (UIA `SetValue`, AX `AXValue`) either happens or does not, and may be
reformatted on the way in — a slider set to `"50"` reads back `"50.0"`. So "the value changed" is
evidence it landed. That judgement had grown its own copy in the macOS reader and another in the
Windows reader; it moves to `glass_core::read_back_confirms` and both now call it.

A *typed write* is not atomic. A dropped key leaves `"worl"` after `"world"` was typed — neither the
request nor the old value — so "changed" would call that a success. `typed_text_landed` requires an
exact match. The cost, pinned by a test rather than left to be discovered: a field that reformats what
it is given (`"1234567890"` becoming `"(123) 456-7890"`) reads as not applied even though the text
arrived. That is the recoverable direction — the agent can read the element and see the value.

A *clear* gets its own rule again, and this is where the device changed the design. On the dogfood AVD
an emptied `EditText` reports its **placeholder** as its text (`text="Search settings"`), and
`uiautomator` exposes no separate hint attribute, so nothing distinguishes "cleared" from "still full"
by value alone. The tempting rule — empty, or the value changed at all — is wrong: the tap that begins
a clear can itself change a field that reformats on focus, which would confirm a clear whose delete
never fired. `typed_clear_landed` therefore requires an empty read-back, which makes a clear
*unconfirmable* on a platform that reports a placeholder. The device test pins that as a decision:
`set_value(id, "")` on Settings' search field returns `AxValueNotApplied`, and the field is separately
shown no longer to hold the typed text.

## Cost

One extra read per write on those two backends: ~2.6s on the AVD (300ms settle + a ~2.3s
`uiautomator dump`), ~1s on the Simulator. A landed write confirms on the first read. Up to three
reads before reporting not-applied, for a field that commits a frame or two later — and only that
verdict is retried, since drift and truncation cannot change on a re-read.

## Verification

- Local: `cargo fmt --check`, workspace clippy, `cargo test --workspace` (72 suites), Windows
  cross-target clippy, `scripts/test-x11.sh`, `scripts/test-a11y.sh`.
- Android AVD: both `a11y_loop` device tests, serially — a real write into Settings' live `EditText`,
  the clear characterized above, and a stale target refused.
- macOS/iOS on an arm64 host: clippy + tests for `glass-ios`, `glass-a11y-macos`, `glass-macos`,
  `glass-core`; the `drive_integration` device test against a booted iPhone 17 Pro simulator.
- Every new assertion was shown to fail with its mechanism removed.

A second review pass over the first fix wave caught two defects the wave itself introduced: it had
given the read-back the once-per-session cold-boot budget (a 91s worst case on the thread every glass
tool shares), and its clear rule was the "changed" rule described above. Both are fixed here; the
last commit is that pass.
