### PR TITLE
fix: make glass doctor measure the accessibility reader and the iOS target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,14 +19,16 @@ internal refactors, CI, or test-only changes.
 ### Fixed
 - `glass doctor`'s macOS accessibility line now reports a real reading instead of assuming one. It
   used to say the reader was available whatever the accessibility API was doing, so the one case you
-  need it for — the reader is not answering — showed green. It now makes a system-wide accessibility
-  read and reports what happened, with the error code: a process that is not trusted and a host that
-  withholds its accessibility trees (a locked screen does this) are different lines with different
-  remedies.
-- `glass doctor`'s iOS device line now says whether a simulator is *booted*. It reported how many
-  were available, which reads as ready when nothing is running and every iOS call is about to fail.
-  It names the booted one — the same one a driving call would attach to — and warns with a remedy
-  when there is none. The doctor still boots nothing.
+  need it for — the reader is not answering — showed green. It now reads one attribute off the
+  system-wide accessibility element and reports what happened, with the error code. macOS gives the
+  same code for several causes, so the line names the one that applies: not trusted, a locked
+  session, assistive access switched off, or a stack that stopped answering — each with its own
+  remedy. A locked session is a warning rather than a failure, since it is not something to fix.
+- `glass doctor`'s iOS device line now reports which simulator glass would drive. It listed how many
+  were available and nothing more. Nothing booted is fine and says so — glass boots one at start —
+  but a `GLASS_IOS_UDID` that names a simulator which is *not* booted is now a failure, because glass
+  attaches to a pinned device without booting it and every call would fail against a dead target. A
+  device listing that cannot be read says that, rather than reporting it as nothing booted.
 - `glass_set_value` now tells you when a write did not take on Android (without the on-device
   accessibility service) and on the iOS Simulator. Those two backends tap the element, clear it and
   type — and used to report success without ever looking again, so a tap that landed slightly off, a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ internal refactors, CI, or test-only changes.
 ## [Unreleased]
 
 ### Fixed
+- `glass doctor`'s macOS accessibility line now reports a real reading instead of assuming one. It
+  used to say the reader was available whatever the accessibility API was doing, so the one case you
+  need it for — the reader is not answering — showed green. It now makes a system-wide accessibility
+  read and reports what happened, with the error code: a process that is not trusted and a host that
+  withholds its accessibility trees (a locked screen does this) are different lines with different
+  remedies.
+- `glass doctor`'s iOS device line now says whether a simulator is *booted*. It reported how many
+  were available, which reads as ready when nothing is running and every iOS call is about to fail.
+  It names the booted one — the same one a driving call would attach to — and warns with a remedy
+  when there is none. The doctor still boots nothing.
 - `glass_set_value` now tells you when a write did not take on Android (without the on-device
   accessibility service) and on the iOS Simulator. Those two backends tap the element, clear it and
   type — and used to report success without ever looking again, so a tap that landed slightly off, a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,18 @@ internal refactors, CI, or test-only changes.
   need it for — the reader is not answering — showed green. It now reads one attribute off the
   system-wide accessibility element and reports what happened, with the error code. macOS gives the
   same code for several causes, so the line names the one that applies: not trusted, a locked
-  session, assistive access switched off, or a stack that stopped answering — each with its own
-  remedy. A locked session is a warning rather than a failure, since it is not something to fix.
-- `glass doctor`'s iOS device line now reports which simulator glass would drive. It listed how many
-  were available and nothing more. Nothing booted is fine and says so — glass boots one at start —
-  but a `GLASS_IOS_UDID` that names a simulator which is *not* booted is now a failure, because glass
-  attaches to a pinned device without booting it and every call would fail against a dead target. A
-  device listing that cannot be read says that, rather than reporting it as nothing booted.
+  session, nobody logged in at the console, assistive access switched off, or a stack that stopped
+  answering — each with its own remedy. A locked or logged-out session is a warning rather than a
+  failure, since neither is a broken install.
+- `glass doctor`'s iOS device line now reports which simulator glass would drive, by running the same
+  resolution `glass_start` runs. It listed how many were available and nothing more. Nothing booted
+  is fine and says so — glass boots one at start — and an iPad-only host is no longer reported as
+  having no device, since glass drives any iOS simulator. What is now reported as a failure is what
+  the start path will not fix for you: a `GLASS_IOS_UDID` that names a simulator which is not booted,
+  or is not on this host, or is not an iOS simulator at all (glass attaches to a pinned device
+  without booting or checking it, so every call would fail against it), and a `GLASS_IOS_DEVICE` that
+  matches nothing here — each with the remedy that fits. A device listing that cannot be read says
+  that, rather than reporting it as nothing booted.
 - `glass_set_value` now tells you when a write did not take on Android (without the on-device
   accessibility service) and on the iOS Simulator. Those two backends tap the element, clear it and
   type — and used to report success without ever looking again, so a tap that landed slightly off, a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,10 @@ internal refactors, CI, or test-only changes.
   used to say the reader was available whatever the accessibility API was doing, so the one case you
   need it for — the reader is not answering — showed green. It now reads one attribute off the
   system-wide accessibility element and reports what happened, with the error code. macOS gives the
-  same code for several causes, so the line names the one that applies: not trusted, a locked
-  session, nobody logged in at the console, assistive access switched off, or a stack that stopped
-  answering — each with its own remedy. A locked or logged-out session is a warning rather than a
-  failure, since neither is a broken install.
+  same code for several causes, so the line names the one that applies: not trusted, nobody logged in
+  at the console, assistive access switched off, or a binary that was never granted despite the
+  system reporting it as trusted — each with its own remedy. A logged-out console is a warning rather
+  than a failure, since it is not a broken install.
 - `glass doctor`'s iOS device line now reports which simulator glass would drive, by running the same
   resolution `glass_start` runs. It listed how many were available and nothing more. Nothing booted
   is fine and says so — glass boots one at start — and an iPad-only host is no longer reported as

--- a/crates/glass-a11y-macos/src/doctor.rs
+++ b/crates/glass-a11y-macos/src/doctor.rs
@@ -1,110 +1,156 @@
 //! Environment checks for the macOS accessibility backend ("glass doctor"). The pure
-//! `a11y_checks` maps a gathered probe to `Check`s and is unit-tested on any host; `probe`
-//! makes the one real AX call, on macOS only.
+//! `a11y_checks` maps gathered facts to `Check`s and is unit-tested on any host; `probe` makes the
+//! one real AX call, on macOS only.
 
 use glass_core::{Check, CheckStatus};
 
+/// The attribute the doctor reads off the system-wide element.
+///
+/// Do not swap this for a cheaper one. It is *trust-gated*: an untrusted process reading it gets
+/// `CannotComplete`, while `AXRole` on the same element answers `Success` (surveyed on macOS 26.5).
+/// So this attribute fails exactly when the reader would fail, and a "simpler" one would report
+/// green to a process that cannot read a single tree — the fabrication this module exists to remove.
+pub const PROBE_ATTRIBUTE: &str = "AXFocusedApplication";
+
+/// `kAXErrorAPIDisabled`: assistive access is off for this process.
+const API_DISABLED: i32 = -25211;
+/// `kAXErrorCannotComplete`: the call was not answered.
+const CANNOT_COMPLETE: i32 = -25204;
+/// `kAXErrorNoValue`: the attribute exists but holds nothing.
+const NO_VALUE: i32 = -25212;
+
 /// What one system-wide accessibility read did.
 ///
-/// The question is whether the AX stack *answered*, not what it answered: an absent attribute is a
-/// definite reply and counts as healthy, while `DidNotComplete` means the API refused to talk.
+/// The question is whether the AX stack *answered*, not what it answered.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SystemWideProbe {
     Answered,
-    /// The call returned "this element has no such attribute" — no application is focused. The
-    /// stack answered, so the reader works.
-    AttributeAbsent,
-    /// `kAXErrorAPIDisabled` (-25211): the API is not available to this process.
+    /// `kAXErrorNoValue`: the read was answered with "nothing here" — for [`PROBE_ATTRIBUTE`], no
+    /// application is frontmost. A definite reply, so the stack is up.
+    NothingFocused,
+    /// `kAXErrorAPIDisabled`.
     ApiDisabled,
-    /// `kAXErrorCannotComplete` (-25204): the API did not answer.
+    /// `kAXErrorCannotComplete`. Ambiguous on its own: an untrusted process gets this, and so does a
+    /// trusted one whose read is not answered — which is why [`a11y_checks`] takes the grant.
     DidNotComplete,
+    /// Any other `AXError`, carrying the raw code so a field report names it. Includes
+    /// `kAXErrorAttributeUnsupported` (-25205), which for [`PROBE_ATTRIBUTE`] means the system-wide
+    /// element is not behaving as a working macOS does — not a healthy absence.
     Failed(i32),
 }
 
-/// `kAXErrorAPIDisabled`, quoted in the check so the reader can search for it.
-const API_DISABLED: i32 = -25211;
-/// `kAXErrorCannotComplete`.
-const CANNOT_COMPLETE: i32 = -25204;
+impl SystemWideProbe {
+    /// Classify a raw `AXError` code. Lives here rather than beside the FFI call so it is compiled
+    /// and tested on every host, not only on macOS.
+    pub fn from_ax_code(code: i32) -> Self {
+        match code {
+            0 => Self::Answered,
+            NO_VALUE => Self::NothingFocused,
+            API_DISABLED => Self::ApiDisabled,
+            CANNOT_COMPLETE => Self::DidNotComplete,
+            other => Self::Failed(other),
+        }
+    }
+}
 
-/// Map a system-wide read to the `a11y reader` check, disambiguated by whether this process holds
-/// the Accessibility grant.
+/// Points at the grant check rather than repeating its remedy, so an untrusted process is one cause
+/// with one thing to do.
+const GRANT_REMEDY: &str = "grant Accessibility to this binary — see the check below";
+
+/// Map a system-wide read to the `a11y reader` check.
 ///
-/// The grant is needed because macOS reports both causes with the same code: measured on macOS 26.5,
-/// an *untrusted* process reading `AXFocusedApplication` off the system-wide element gets
-/// `kAXErrorCannotComplete` (-25204), the same code a trusted process gets when the host is
-/// withholding its trees — which is what a locked screen does (measured 2026-07-29). Reporting one
-/// remedy for both would send half the readers to the wrong fix, and the grant bit is already
-/// gathered, so the two are told apart here rather than left to the operator.
+/// Takes two facts the caller has already gathered because the probe alone cannot be read
+/// correctly. `accessibility_granted`: an untrusted process gets `CannotComplete` (measured on
+/// macOS 26.5), the same code a trusted process gets when its read is not answered.
+/// `session_locked`: a locked console session is a known cause of accessibility calls misbehaving
+/// (`glass-macos`'s input tests record synthetic events being dropped while
+/// `CGSSessionScreenIsLocked` is set), and the aggregator already reads the real lock state — so
+/// this says the screen is locked when it *is*, rather than inferring it from an error code and
+/// contradicting the `display awake` check printed beside it.
 ///
-/// The grant still gets its own check beside this one: this line answers "did the API respond", that
+/// The grant keeps its own check next to this one: this line answers "did the API respond", that
 /// one answers "is this binary trusted".
-pub fn a11y_checks(probe: SystemWideProbe, accessibility_granted: bool) -> Vec<Check> {
+pub fn a11y_checks(
+    probe: SystemWideProbe,
+    accessibility_granted: bool,
+    session_locked: bool,
+) -> Vec<Check> {
+    let ok = |detail: &str| Check::new("a11y reader", CheckStatus::Ok, detail);
+    let fail = |detail: String, remedy: &str| {
+        Check::new("a11y reader", CheckStatus::Fail, detail).with_remedy(remedy)
+    };
+
+    // An untrusted process cannot read a tree whatever the probe said, so no probe outcome may
+    // report this line green: a green reader line above a red grant line is the contradiction the
+    // hardcoded `Ok` used to print.
+    if !accessibility_granted {
+        return vec![fail(
+            format!(
+                "this process is not trusted, so glass_a11y_snapshot / glass_a11y_marks / \
+                 glass_click_element / glass_set_value will fail (system-wide read: {})",
+                describe(probe)
+            ),
+            GRANT_REMEDY,
+        )];
+    }
+
     vec![match probe {
-        SystemWideProbe::Answered => Check::new(
+        SystemWideProbe::Answered => ok("AXUIElement reader answered a system-wide read"),
+        SystemWideProbe::NothingFocused => {
+            ok("AXUIElement reader answered a system-wide read (no application is frontmost)")
+        }
+        // Locked first: it explains every failing code below it, and it is measured rather than
+        // guessed, so an operator is never sent to log out over a screen they can just unlock.
+        p if session_locked => Check::new(
             "a11y reader",
-            CheckStatus::Ok,
-            "AXUIElement reader answered a system-wide read",
-        ),
-        SystemWideProbe::AttributeAbsent => Check::new(
-            "a11y reader",
-            CheckStatus::Ok,
-            "AXUIElement reader answered a system-wide read (nothing is focused right now)",
-        ),
-        SystemWideProbe::ApiDisabled => Check::new(
-            "a11y reader",
-            CheckStatus::Fail,
+            CheckStatus::Warn,
             format!(
-                "the accessibility API is disabled for this process (AXError {API_DISABLED}) — \
-                 glass_a11y_snapshot / glass_a11y_marks / glass_click_element / glass_set_value \
-                 will fail"
+                "the console session is locked, and the system-wide read did not succeed ({}) — \
+                 accessibility is unreliable while locked",
+                describe(p)
             ),
         )
-        .with_remedy(GRANT_REMEDY),
-        SystemWideProbe::DidNotComplete if !accessibility_granted => Check::new(
-            "a11y reader",
-            CheckStatus::Fail,
+        .with_remedy("unlock the session and re-run (see the `display awake` check)"),
+        SystemWideProbe::ApiDisabled => fail(
+            format!(
+                "assistive access is off for this process (AXError {API_DISABLED}), so the \
+                 accessibility tools will fail"
+            ),
+            "enable assistive access for this binary in System Settings > Privacy & Security > \
+             Accessibility, then restart it",
+        ),
+        SystemWideProbe::DidNotComplete => fail(
             format!(
                 "the accessibility API did not answer (AXError {CANNOT_COMPLETE}) — this process is \
-                 not trusted, which is what that code means for a binary without the Accessibility \
-                 grant"
+                 trusted and the session is unlocked, so the accessibility stack is not responding"
             ),
-        )
-        .with_remedy(GRANT_REMEDY),
-        SystemWideProbe::DidNotComplete => Check::new(
-            "a11y reader",
-            CheckStatus::Fail,
-            format!(
-                "the accessibility API did not answer (AXError {CANNOT_COMPLETE}) — this process is \
-                 trusted, so the host is withholding its accessibility trees: a locked screen does \
-                 this, as does a wedged accessibility stack"
-            ),
-        )
-        .with_remedy("unlock the screen and re-run; if it was already unlocked, log out and back in"),
-        SystemWideProbe::Failed(code) => Check::new(
-            "a11y reader",
-            CheckStatus::Fail,
+            "log out and back in; if it persists, report this with the `glass doctor` output",
+        ),
+        SystemWideProbe::Failed(code) => fail(
             format!("system-wide accessibility read failed (AXError {code})"),
+            "log out and back in; if it persists, report this AXError code with the `glass doctor` \
+             output",
         ),
     }]
 }
 
-/// Points at the grant check rather than repeating its remedy, so an ungranted process is one cause
-/// with one thing to do.
-const GRANT_REMEDY: &str = "grant Accessibility to this binary — see the check below";
+/// The probe outcome in a half-sentence, for details that report it as evidence rather than as the
+/// finding itself.
+fn describe(probe: SystemWideProbe) -> String {
+    match probe {
+        SystemWideProbe::Answered => "answered".into(),
+        SystemWideProbe::NothingFocused => format!("AXError {NO_VALUE}, nothing frontmost"),
+        SystemWideProbe::ApiDisabled => format!("AXError {API_DISABLED}"),
+        SystemWideProbe::DidNotComplete => format!("AXError {CANNOT_COMPLETE}"),
+        SystemWideProbe::Failed(code) => format!("AXError {code}"),
+    }
+}
 
-/// Probe whether the AXUIElement reader is answering — one `AXUIElementCopyAttributeValue` against
-/// the system-wide element, which needs no target application and mutates nothing — and report it
-/// beside `accessibility_granted`, which the caller has already gathered.
+/// One `AXUIElementCopyAttributeValue` of [`PROBE_ATTRIBUTE`] against the system-wide element: no
+/// target application, no mutation, and bounded by an explicit AX messaging timeout.
 ///
 /// macOS-only on purpose, with no off-macOS stub: a stub would have to invent an answer, which is
 /// the fabrication this module exists to remove. Host unit tests drive [`a11y_checks`] directly.
-#[cfg(target_os = "macos")]
-pub fn checks(accessibility_granted: bool) -> Vec<Check> {
-    a11y_checks(probe(), accessibility_granted)
-}
-
-/// The gathered probe on its own, for an aggregator that assembles this line beside checks of its
-/// own (`glass-mcp` pairs it with the Accessibility grant).
 #[cfg(target_os = "macos")]
 pub fn probe() -> SystemWideProbe {
     crate::ffi::probe_system_wide()
@@ -114,86 +160,169 @@ pub fn probe() -> SystemWideProbe {
 mod tests {
     use super::*;
 
+    fn reader(probe: SystemWideProbe, granted: bool, locked: bool) -> Check {
+        a11y_checks(probe, granted, locked).remove(0)
+    }
+
+    const EVERY_PROBE: [SystemWideProbe; 5] = [
+        SystemWideProbe::Answered,
+        SystemWideProbe::NothingFocused,
+        SystemWideProbe::ApiDisabled,
+        SystemWideProbe::DidNotComplete,
+        SystemWideProbe::Failed(-25200),
+    ];
+
+    #[test]
+    fn the_probe_attribute_is_the_trust_gated_one() {
+        // The whole check rests on this string: `AXRole` answers for an untrusted process, so
+        // swapping to it would report green to a process that cannot read a tree.
+        assert_eq!(PROBE_ATTRIBUTE, "AXFocusedApplication");
+    }
+
+    #[test]
+    fn every_ax_code_classifies_to_its_own_outcome() {
+        assert_eq!(SystemWideProbe::from_ax_code(0), SystemWideProbe::Answered);
+        assert_eq!(
+            SystemWideProbe::from_ax_code(NO_VALUE),
+            SystemWideProbe::NothingFocused
+        );
+        assert_eq!(
+            SystemWideProbe::from_ax_code(API_DISABLED),
+            SystemWideProbe::ApiDisabled
+        );
+        assert_eq!(
+            SystemWideProbe::from_ax_code(CANNOT_COMPLETE),
+            SystemWideProbe::DidNotComplete
+        );
+        assert_eq!(
+            SystemWideProbe::from_ax_code(-25200),
+            SystemWideProbe::Failed(-25200)
+        );
+    }
+
+    #[test]
+    fn an_unsupported_attribute_is_not_treated_as_a_healthy_absence() {
+        // -25205 means the system-wide element does not carry the attribute at all, which a working
+        // macOS never reports for `AXFocusedApplication` — unlike -25212, which means "nothing is
+        // frontmost". Folding the two (the tree walk's `is_absent_error` does) would report a
+        // malformed AX stack as healthy.
+        assert_eq!(
+            SystemWideProbe::from_ax_code(-25205),
+            SystemWideProbe::Failed(-25205)
+        );
+        assert_eq!(
+            reader(SystemWideProbe::from_ax_code(-25205), true, false).status,
+            CheckStatus::Fail
+        );
+    }
+
     #[test]
     fn an_answering_ax_stack_is_ok() {
         assert_eq!(
-            a11y_checks(SystemWideProbe::Answered, true)[0].status,
+            reader(SystemWideProbe::Answered, true, false).status,
             CheckStatus::Ok
         );
     }
 
     #[test]
-    fn an_absent_attribute_still_proves_the_stack_answered() {
-        // No focused application is a legitimate answer, not a broken stack: the call returned a
-        // definite "no such attribute" rather than refusing to talk.
-        assert_eq!(
-            a11y_checks(SystemWideProbe::AttributeAbsent, true)[0].status,
-            CheckStatus::Ok
+    fn nothing_frontmost_still_proves_the_stack_answered() {
+        let c = reader(SystemWideProbe::NothingFocused, true, false);
+        assert_eq!(c.status, CheckStatus::Ok);
+        // The detail is the arm's whole point: collapsing it into `Answered` would lose the reason
+        // the read came back empty.
+        assert!(c.detail.contains("frontmost"), "{}", c.detail);
+    }
+
+    #[test]
+    fn an_untrusted_process_never_reports_a_green_reader() {
+        // The probe cannot rescue an untrusted process: it holds no grant, so no tree read can
+        // succeed whatever the system-wide element answered.
+        for p in EVERY_PROBE {
+            let c = reader(p, false, false);
+            assert_eq!(c.status, CheckStatus::Fail, "{p:?} -> {c:?}");
+            assert_eq!(c.remedy.as_deref(), Some(GRANT_REMEDY), "{p:?}");
+        }
+    }
+
+    #[test]
+    fn a_locked_session_is_a_warning_naming_the_lock_not_a_failure() {
+        // Transient and not a configuration defect: failing here would exit(1) on a Mac driving
+        // another backend with its screen locked. The lock is read, not inferred from the code.
+        let c = reader(SystemWideProbe::DidNotComplete, true, true);
+        assert_eq!(c.status, CheckStatus::Warn);
+        assert!(c.detail.contains("locked"), "{}", c.detail);
+        assert!(
+            c.remedy.as_deref().unwrap().contains("unlock"),
+            "{:?}",
+            c.remedy
         );
     }
 
     #[test]
-    fn a_disabled_api_fails_and_carries_the_error_code() {
-        let c = &a11y_checks(SystemWideProbe::ApiDisabled, false)[0];
+    fn an_unlocked_trusted_process_that_gets_no_answer_blames_the_stack() {
+        // Same AXError, three causes; with the grant held and the session unlocked, the remaining
+        // one is the stack. Sending this operator to unlock an unlocked screen — or to a grant they
+        // already hold — is the diagnostic failing at its one job.
+        let c = reader(SystemWideProbe::DidNotComplete, true, false);
         assert_eq!(c.status, CheckStatus::Fail);
         assert!(
-            c.detail.contains("-25211"),
-            "detail must carry the AXError code: {}",
+            !c.detail.to_lowercase().contains("not trusted"),
+            "{}",
             c.detail
         );
+        assert!(
+            c.detail.contains(&CANNOT_COMPLETE.to_string()),
+            "{}",
+            c.detail
+        );
+        assert_ne!(c.remedy.as_deref(), Some(GRANT_REMEDY));
     }
 
     #[test]
-    fn a_trusted_process_that_gets_no_answer_names_the_locked_screen() {
-        // The failure that cost an hour on 2026-07-29: the AX stack was fine and the screen was
-        // locked, and nothing in the diagnostic said so.
-        let c = &a11y_checks(SystemWideProbe::DidNotComplete, true)[0];
+    fn a_granted_process_with_assistive_access_off_is_not_sent_to_the_grant_check() {
+        // The grant line beside this one reads "granted", so pointing at it would be a dead end.
+        let c = reader(SystemWideProbe::ApiDisabled, true, false);
         assert_eq!(c.status, CheckStatus::Fail);
-        assert!(
-            c.detail.to_lowercase().contains("locked"),
-            "detail must name the locked screen: {}",
-            c.detail
-        );
-    }
-
-    #[test]
-    fn an_untrusted_process_that_gets_no_answer_names_the_grant_instead() {
-        // Same AXError, different cause: macOS 26.5 gives an ungranted binary -25204 too (measured
-        // against the real API from an ungranted test binary). Sending that reader to unlock an
-        // already-unlocked screen is the diagnostic failing at its one job.
-        let c = &a11y_checks(SystemWideProbe::DidNotComplete, false)[0];
-        assert_eq!(c.status, CheckStatus::Fail);
-        assert!(
-            !c.detail.to_lowercase().contains("locked"),
-            "an ungranted process must not be told about the screen: {}",
-            c.detail
-        );
-        assert_eq!(c.remedy.as_deref(), Some(GRANT_REMEDY));
+        assert_ne!(c.remedy.as_deref(), Some(GRANT_REMEDY));
+        assert!(c.detail.contains(&API_DISABLED.to_string()), "{}", c.detail);
     }
 
     #[test]
     fn an_unrecognized_error_still_reports_its_code() {
-        let c = &a11y_checks(SystemWideProbe::Failed(-25200), true)[0];
+        let c = reader(SystemWideProbe::Failed(-25208), true, false);
         assert_eq!(c.status, CheckStatus::Fail);
-        assert!(c.detail.contains("-25200"), "detail: {}", c.detail);
+        assert!(c.detail.contains("-25208"), "{}", c.detail);
     }
 
     #[test]
-    fn no_variant_reports_the_grant() {
-        // The grant is a separate check with a separate remedy; collapsing the two is what made the
-        // old hardcoded line useless.
-        for p in [
-            SystemWideProbe::Answered,
-            SystemWideProbe::AttributeAbsent,
-            SystemWideProbe::ApiDisabled,
-            SystemWideProbe::DidNotComplete,
-            SystemWideProbe::Failed(-1),
-        ] {
-            let c = &a11y_checks(p, false)[0];
+    fn no_check_this_module_emits_is_a_dead_end() {
+        // `CheckStatus::Fail` is documented as carrying a remedy; a red line with no next step is
+        // worst exactly where the operator knows least.
+        for p in EVERY_PROBE {
+            for granted in [true, false] {
+                for locked in [true, false] {
+                    let c = reader(p, granted, locked);
+                    if c.status != CheckStatus::Ok {
+                        assert!(
+                            c.remedy.is_some(),
+                            "{p:?} granted={granted} locked={locked} -> {c:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn the_reader_line_never_duplicates_the_grant_lines_remedy_text() {
+        // The grant check owns the System Settings pane; this line points at it instead, so an
+        // untrusted operator is given one thing to do rather than two.
+        for p in EVERY_PROBE {
+            let c = reader(p, false, false);
             assert!(
-                !c.detail.contains("System Settings"),
-                "the reader line must not duplicate the grant line's remedy: {}",
-                c.detail
+                !c.remedy.as_deref().unwrap().contains("System Settings"),
+                "{p:?} -> {:?}",
+                c.remedy
             );
         }
     }

--- a/crates/glass-a11y-macos/src/doctor.rs
+++ b/crates/glass-a11y-macos/src/doctor.rs
@@ -53,6 +53,18 @@ impl SystemWideProbe {
     }
 }
 
+/// The console session's state, as the aggregator reads it. Mirrors `glass_macos::SessionState`
+/// without depending on it: this crate maps outcomes to text, and the platform crate owns the read.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConsoleSession {
+    Unlocked,
+    Locked,
+    /// Nobody is logged in at the console. Distinct from locked: unlocking is not the remedy, and
+    /// telling this operator the session is unlocked is a falsehood the report contradicts two
+    /// lines further up.
+    NoSession,
+}
+
 /// Points at the grant check rather than repeating its remedy, so an untrusted process is one cause
 /// with one thing to do.
 const GRANT_REMEDY: &str = "grant Accessibility to this binary — see the check below";
@@ -62,18 +74,19 @@ const GRANT_REMEDY: &str = "grant Accessibility to this binary — see the check
 /// Takes two facts the caller has already gathered because the probe alone cannot be read
 /// correctly. `accessibility_granted`: an untrusted process gets `CannotComplete` (measured on
 /// macOS 26.5), the same code a trusted process gets when its read is not answered.
-/// `session_locked`: a locked console session is a known cause of accessibility calls misbehaving
-/// (`glass-macos`'s input tests record synthetic events being dropped while
-/// `CGSSessionScreenIsLocked` is set), and the aggregator already reads the real lock state — so
-/// this says the screen is locked when it *is*, rather than inferring it from an error code and
-/// contradicting the `display awake` check printed beside it.
+/// `session`: an unanswered read means something different with nobody at the console, and the
+/// aggregator already reads the real state — so this reports the session it *is* in rather than
+/// inferring one from an error code and contradicting the `display awake` check printed beside it.
+/// Whether a locked session actually produces this code is not established (`glass-macos`'s input
+/// tests record locked-session AX *writes* reporting success), which is why the session only
+/// qualifies the ambiguous code rather than explaining every failure.
 ///
 /// The grant keeps its own check next to this one: this line answers "did the API respond", that
 /// one answers "is this binary trusted".
 pub fn a11y_checks(
     probe: SystemWideProbe,
     accessibility_granted: bool,
-    session_locked: bool,
+    session: ConsoleSession,
 ) -> Vec<Check> {
     let ok = |detail: &str| Check::new("a11y reader", CheckStatus::Ok, detail);
     let fail = |detail: String, remedy: &str| {
@@ -99,18 +112,29 @@ pub fn a11y_checks(
         SystemWideProbe::NothingFocused => {
             ok("AXUIElement reader answered a system-wide read (no application is frontmost)")
         }
-        // Locked first: it explains every failing code below it, and it is measured rather than
-        // guessed, so an operator is never sent to log out over a screen they can just unlock.
-        p if session_locked => Check::new(
+        // Only the ambiguous code defers to the session: `ApiDisabled` and an unrecognised code
+        // mean what they mean whether or not anyone is at the console, and letting the session
+        // swallow them would downgrade a real defect to "unlock your screen".
+        SystemWideProbe::DidNotComplete if session != ConsoleSession::Unlocked => Check::new(
             "a11y reader",
             CheckStatus::Warn,
-            format!(
-                "the console session is locked, and the system-wide read did not succeed ({}) — \
-                 accessibility is unreliable while locked",
-                describe(p)
-            ),
+            match session {
+                ConsoleSession::Locked => format!(
+                    "the system-wide read was not answered (AXError {CANNOT_COMPLETE}) and the \
+                     console session is locked"
+                ),
+                _ => format!(
+                    "the system-wide read was not answered (AXError {CANNOT_COMPLETE}) and no \
+                     account is logged in at the console"
+                ),
+            },
         )
-        .with_remedy("unlock the session and re-run (see the `display awake` check)"),
+        .with_remedy(match session {
+            ConsoleSession::Locked => {
+                "unlock the session and re-run (see the `display awake` check)"
+            }
+            _ => "log in at the console and re-run (see the `display awake` check)",
+        }),
         SystemWideProbe::ApiDisabled => fail(
             format!(
                 "assistive access is off for this process (AXError {API_DISABLED}), so the \
@@ -122,7 +146,8 @@ pub fn a11y_checks(
         SystemWideProbe::DidNotComplete => fail(
             format!(
                 "the accessibility API did not answer (AXError {CANNOT_COMPLETE}) — this process is \
-                 trusted and the session is unlocked, so the accessibility stack is not responding"
+                 trusted and someone is logged in at an unlocked console, so the accessibility \
+                 stack is not responding"
             ),
             "log out and back in; if it persists, report this with the `glass doctor` output",
         ),
@@ -160,9 +185,15 @@ pub fn probe() -> SystemWideProbe {
 mod tests {
     use super::*;
 
-    fn reader(probe: SystemWideProbe, granted: bool, locked: bool) -> Check {
-        a11y_checks(probe, granted, locked).remove(0)
+    fn reader(probe: SystemWideProbe, granted: bool, session: ConsoleSession) -> Check {
+        a11y_checks(probe, granted, session).remove(0)
     }
+
+    const EVERY_SESSION: [ConsoleSession; 3] = [
+        ConsoleSession::Unlocked,
+        ConsoleSession::Locked,
+        ConsoleSession::NoSession,
+    ];
 
     const EVERY_PROBE: [SystemWideProbe; 5] = [
         SystemWideProbe::Answered,
@@ -211,7 +242,12 @@ mod tests {
             SystemWideProbe::Failed(-25205)
         );
         assert_eq!(
-            reader(SystemWideProbe::from_ax_code(-25205), true, false).status,
+            reader(
+                SystemWideProbe::from_ax_code(-25205),
+                true,
+                ConsoleSession::Unlocked
+            )
+            .status,
             CheckStatus::Fail
         );
     }
@@ -219,14 +255,18 @@ mod tests {
     #[test]
     fn an_answering_ax_stack_is_ok() {
         assert_eq!(
-            reader(SystemWideProbe::Answered, true, false).status,
+            reader(SystemWideProbe::Answered, true, ConsoleSession::Unlocked).status,
             CheckStatus::Ok
         );
     }
 
     #[test]
     fn nothing_frontmost_still_proves_the_stack_answered() {
-        let c = reader(SystemWideProbe::NothingFocused, true, false);
+        let c = reader(
+            SystemWideProbe::NothingFocused,
+            true,
+            ConsoleSession::Unlocked,
+        );
         assert_eq!(c.status, CheckStatus::Ok);
         // The detail is the arm's whole point: collapsing it into `Answered` would lose the reason
         // the read came back empty.
@@ -238,9 +278,49 @@ mod tests {
         // The probe cannot rescue an untrusted process: it holds no grant, so no tree read can
         // succeed whatever the system-wide element answered.
         for p in EVERY_PROBE {
-            let c = reader(p, false, false);
+            let c = reader(p, false, ConsoleSession::Unlocked);
             assert_eq!(c.status, CheckStatus::Fail, "{p:?} -> {c:?}");
             assert_eq!(c.remedy.as_deref(), Some(GRANT_REMEDY), "{p:?}");
+        }
+    }
+
+    #[test]
+    fn a_console_with_nobody_logged_in_is_not_told_the_session_is_unlocked() {
+        // `NoSession` used to fold into "unlocked", so the line asserted the opposite of the
+        // `display awake` check printed beside it and told a logged-out operator to log out.
+        let c = reader(
+            SystemWideProbe::DidNotComplete,
+            true,
+            ConsoleSession::NoSession,
+        );
+        assert_eq!(c.status, CheckStatus::Warn);
+        assert!(c.detail.contains("no account is logged in"), "{}", c.detail);
+        assert!(
+            c.remedy
+                .as_deref()
+                .unwrap()
+                .contains("log in at the console"),
+            "{:?}",
+            c.remedy
+        );
+    }
+
+    #[test]
+    fn a_session_state_never_downgrades_a_defect_it_does_not_explain() {
+        // The session only qualifies the ambiguous code. An unlocked-session defect stays a defect
+        // when the screen happens to be locked — otherwise a rebuilt binary with assistive access
+        // off reads as "unlock your screen" and the doctor exits 0.
+        for session in EVERY_SESSION {
+            for p in [
+                SystemWideProbe::ApiDisabled,
+                SystemWideProbe::Failed(-25208),
+            ] {
+                assert_eq!(
+                    reader(p, true, session).status,
+                    CheckStatus::Fail,
+                    "{p:?} {session:?}"
+                );
+            }
         }
     }
 
@@ -248,7 +328,11 @@ mod tests {
     fn a_locked_session_is_a_warning_naming_the_lock_not_a_failure() {
         // Transient and not a configuration defect: failing here would exit(1) on a Mac driving
         // another backend with its screen locked. The lock is read, not inferred from the code.
-        let c = reader(SystemWideProbe::DidNotComplete, true, true);
+        let c = reader(
+            SystemWideProbe::DidNotComplete,
+            true,
+            ConsoleSession::Locked,
+        );
         assert_eq!(c.status, CheckStatus::Warn);
         assert!(c.detail.contains("locked"), "{}", c.detail);
         assert!(
@@ -263,7 +347,11 @@ mod tests {
         // Same AXError, three causes; with the grant held and the session unlocked, the remaining
         // one is the stack. Sending this operator to unlock an unlocked screen — or to a grant they
         // already hold — is the diagnostic failing at its one job.
-        let c = reader(SystemWideProbe::DidNotComplete, true, false);
+        let c = reader(
+            SystemWideProbe::DidNotComplete,
+            true,
+            ConsoleSession::Unlocked,
+        );
         assert_eq!(c.status, CheckStatus::Fail);
         assert!(
             !c.detail.to_lowercase().contains("not trusted"),
@@ -281,7 +369,7 @@ mod tests {
     #[test]
     fn a_granted_process_with_assistive_access_off_is_not_sent_to_the_grant_check() {
         // The grant line beside this one reads "granted", so pointing at it would be a dead end.
-        let c = reader(SystemWideProbe::ApiDisabled, true, false);
+        let c = reader(SystemWideProbe::ApiDisabled, true, ConsoleSession::Unlocked);
         assert_eq!(c.status, CheckStatus::Fail);
         assert_ne!(c.remedy.as_deref(), Some(GRANT_REMEDY));
         assert!(c.detail.contains(&API_DISABLED.to_string()), "{}", c.detail);
@@ -289,7 +377,11 @@ mod tests {
 
     #[test]
     fn an_unrecognized_error_still_reports_its_code() {
-        let c = reader(SystemWideProbe::Failed(-25208), true, false);
+        let c = reader(
+            SystemWideProbe::Failed(-25208),
+            true,
+            ConsoleSession::Unlocked,
+        );
         assert_eq!(c.status, CheckStatus::Fail);
         assert!(c.detail.contains("-25208"), "{}", c.detail);
     }
@@ -300,12 +392,12 @@ mod tests {
         // worst exactly where the operator knows least.
         for p in EVERY_PROBE {
             for granted in [true, false] {
-                for locked in [true, false] {
-                    let c = reader(p, granted, locked);
+                for session in EVERY_SESSION {
+                    let c = reader(p, granted, session);
                     if c.status != CheckStatus::Ok {
                         assert!(
                             c.remedy.is_some(),
-                            "{p:?} granted={granted} locked={locked} -> {c:?}"
+                            "{p:?} granted={granted} session={session:?} -> {c:?}"
                         );
                     }
                 }
@@ -314,16 +406,16 @@ mod tests {
     }
 
     #[test]
-    fn the_reader_line_never_duplicates_the_grant_lines_remedy_text() {
+    fn an_untrusted_process_is_pointed_at_the_grant_check_not_at_a_second_copy_of_it() {
         // The grant check owns the System Settings pane; this line points at it instead, so an
-        // untrusted operator is given one thing to do rather than two.
+        // untrusted operator is given one thing to do rather than two. (A *granted* process whose
+        // assistive access is off is a different case: the grant line reads green there, so that
+        // arm names the pane itself.)
         for p in EVERY_PROBE {
-            let c = reader(p, false, false);
-            assert!(
-                !c.remedy.as_deref().unwrap().contains("System Settings"),
-                "{p:?} -> {:?}",
-                c.remedy
-            );
+            for session in EVERY_SESSION {
+                let c = reader(p, false, session);
+                assert_eq!(c.remedy.as_deref(), Some(GRANT_REMEDY), "{p:?} {session:?}");
+            }
         }
     }
 }

--- a/crates/glass-a11y-macos/src/doctor.rs
+++ b/crates/glass-a11y-macos/src/doctor.rs
@@ -6,11 +6,9 @@ use glass_core::{Check, CheckStatus};
 
 /// The attribute the doctor reads off the system-wide element.
 ///
-/// Do not swap this for a cheaper one. It is *access-gated*: a binary macOS will not let read the
-/// accessibility tree gets `CannotComplete` from it, while `AXRole` on the same element answers
-/// `Success` (surveyed on macOS 26.5). So this attribute fails exactly when the reader would fail,
-/// and a "simpler" one would report green to a process that cannot read a single tree — the
-/// fabrication this module exists to remove.
+/// Do not swap this for a cheaper one: it is *access-gated*, so a binary macOS will not let read the
+/// tree gets `CannotComplete` from it while `AXRole` on the same element answers `Success` (surveyed
+/// on macOS 26.5) — a simpler attribute reports green to a process that cannot read anything.
 pub const PROBE_ATTRIBUTE: &str = "AXFocusedApplication";
 
 /// `kAXErrorAPIDisabled`: assistive access is off for this process.
@@ -58,18 +56,17 @@ impl SystemWideProbe {
 /// The console session's state, as the aggregator reads it. Mirrors `glass_macos::SessionState`
 /// without depending on it: this crate maps outcomes to text, and the platform crate owns the read.
 ///
-/// A *locked* session is deliberately not distinguished from an unlocked one here. Measured on
-/// macOS 26.5 by locking a host mid-probe: with `CGSSessionScreenIsLocked` set, the system-wide
-/// read still answers `Success`, so a lock never produces the code this would have qualified. The
-/// lock's real consequence — capture and input are suppressed — is reported by the `display awake`
-/// check, and repeating it here would be a second copy of one fact.
+/// A *locked* session is deliberately not distinguished from an unlocked one: measured on macOS 26.5
+/// by locking a host mid-probe, the system-wide read still answers `Success` with
+/// `CGSSessionScreenIsLocked` set, so a lock never produces the code it would have qualified. The
+/// lock's real consequence — capture and input suppressed — is the `display awake` check's to report.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ConsoleSession {
     /// Somebody is logged in at the console, locked or not.
     LoggedIn,
-    /// Nobody is logged in at the console. Unmeasured against this probe, unlike the locked case:
-    /// kept because if it *does* produce an unanswered read, "log in at the console" is the only
-    /// remedy that helps, and the alternative message would blame the binary's grant.
+    /// Nobody is logged in at the console — unmeasured against this probe, unlike the locked case,
+    /// and kept because if it does produce an unanswered read, logging in is the only remedy that
+    /// helps.
     NoSession,
 }
 
@@ -77,26 +74,16 @@ pub enum ConsoleSession {
 /// with one thing to do.
 const GRANT_REMEDY: &str = "grant Accessibility to this binary — see the check below";
 
-/// Map a system-wide read to the `a11y reader` check.
+/// Map a system-wide read to the `a11y reader` check, using two facts the caller has already
+/// gathered because the probe cannot be read correctly alone.
 ///
-/// Takes two facts the caller has already gathered because the probe alone cannot be read
-/// correctly. `accessibility_granted`: a denied process gets `CannotComplete` (measured on macOS
-/// 26.5), the same code a process gets when its read is genuinely not answered.
+/// `accessibility_granted` narrows the causes of `CannotComplete` without settling them: measured on
+/// one host at one moment, `glass-mcp` read the system-wide element successfully while another
+/// binary got that code **with `AXIsProcessTrusted` reporting it as trusted**, so a `true` grant bit
+/// does not mean this binary may read.
 ///
-/// The grant narrows the causes; it does not settle them. Measured on the same host at the same
-/// moment: `glass-mcp` read the system-wide element successfully while another binary got
-/// `CannotComplete` **with `AXIsProcessTrusted` reporting it as trusted**. So a `true` grant bit does
-/// not mean this binary may read, and the trusted-and-unlocked arm below says so rather than
-/// blaming the accessibility stack.
-///
-/// `session`: an unanswered read means something different with nobody at the console, and the
-/// aggregator already reads the real state — so this reports the session it *is* in rather than
-/// inferring one from an error code and contradicting the `display awake` check printed beside it.
-/// A locked session is not one of the causes: it was measured not to produce this code (see
-/// [`ConsoleSession`]).
-///
-/// The grant keeps its own check next to this one: this line answers "did the API respond", that
-/// one answers "is this binary trusted".
+/// `session` distinguishes nobody-at-the-console, where the remedy is to log in rather than to
+/// check a grant. A locked session is not a cause at all — see [`ConsoleSession`].
 pub fn a11y_checks(
     probe: SystemWideProbe,
     accessibility_granted: bool,

--- a/crates/glass-a11y-macos/src/doctor.rs
+++ b/crates/glass-a11y-macos/src/doctor.rs
@@ -26,13 +26,19 @@ const API_DISABLED: i32 = -25211;
 /// `kAXErrorCannotComplete`.
 const CANNOT_COMPLETE: i32 = -25204;
 
-/// Map a system-wide read to the `a11y reader` check.
+/// Map a system-wide read to the `a11y reader` check, disambiguated by whether this process holds
+/// the Accessibility grant.
 ///
-/// Deliberately says nothing about the Accessibility grant — that is its own check, with its own
-/// remedy. This one answers "did the API respond", which a granted process can still fail: with
-/// `CGSSessionScreenIsLocked` set, every AX tree on the host is withheld (measured 2026-07-29), and
-/// a diagnostic that reports only "failed" sends the reader hunting for a bug in glass.
-pub fn a11y_checks(probe: SystemWideProbe) -> Vec<Check> {
+/// The grant is needed because macOS reports both causes with the same code: measured on macOS 26.5,
+/// an *untrusted* process reading `AXFocusedApplication` off the system-wide element gets
+/// `kAXErrorCannotComplete` (-25204), the same code a trusted process gets when the host is
+/// withholding its trees — which is what a locked screen does (measured 2026-07-29). Reporting one
+/// remedy for both would send half the readers to the wrong fix, and the grant bit is already
+/// gathered, so the two are told apart here rather than left to the operator.
+///
+/// The grant still gets its own check beside this one: this line answers "did the API respond", that
+/// one answers "is this binary trusted".
+pub fn a11y_checks(probe: SystemWideProbe, accessibility_granted: bool) -> Vec<Check> {
     vec![match probe {
         SystemWideProbe::Answered => Check::new(
             "a11y reader",
@@ -53,19 +59,27 @@ pub fn a11y_checks(probe: SystemWideProbe) -> Vec<Check> {
                  will fail"
             ),
         )
-        .with_remedy("grant Accessibility to this binary — see the check below"),
+        .with_remedy(GRANT_REMEDY),
+        SystemWideProbe::DidNotComplete if !accessibility_granted => Check::new(
+            "a11y reader",
+            CheckStatus::Fail,
+            format!(
+                "the accessibility API did not answer (AXError {CANNOT_COMPLETE}) — this process is \
+                 not trusted, which is what that code means for a binary without the Accessibility \
+                 grant"
+            ),
+        )
+        .with_remedy(GRANT_REMEDY),
         SystemWideProbe::DidNotComplete => Check::new(
             "a11y reader",
             CheckStatus::Fail,
             format!(
-                "the accessibility API did not answer (AXError {CANNOT_COMPLETE}) — a locked \
-                 screen withholds every accessibility tree on the host, as does a wedged \
-                 accessibility stack"
+                "the accessibility API did not answer (AXError {CANNOT_COMPLETE}) — this process is \
+                 trusted, so the host is withholding its accessibility trees: a locked screen does \
+                 this, as does a wedged accessibility stack"
             ),
         )
-        .with_remedy(
-            "unlock the screen and re-run; if it was already unlocked, log out and back in",
-        ),
+        .with_remedy("unlock the screen and re-run; if it was already unlocked, log out and back in"),
         SystemWideProbe::Failed(code) => Check::new(
             "a11y reader",
             CheckStatus::Fail,
@@ -74,14 +88,19 @@ pub fn a11y_checks(probe: SystemWideProbe) -> Vec<Check> {
     }]
 }
 
-/// Probe whether the AXUIElement reader is answering: one `AXUIElementCopyAttributeValue` against
-/// the system-wide element, which needs no target application and mutates nothing.
+/// Points at the grant check rather than repeating its remedy, so an ungranted process is one cause
+/// with one thing to do.
+const GRANT_REMEDY: &str = "grant Accessibility to this binary — see the check below";
+
+/// Probe whether the AXUIElement reader is answering — one `AXUIElementCopyAttributeValue` against
+/// the system-wide element, which needs no target application and mutates nothing — and report it
+/// beside `accessibility_granted`, which the caller has already gathered.
 ///
 /// macOS-only on purpose, with no off-macOS stub: a stub would have to invent an answer, which is
 /// the fabrication this module exists to remove. Host unit tests drive [`a11y_checks`] directly.
 #[cfg(target_os = "macos")]
-pub fn checks() -> Vec<Check> {
-    a11y_checks(probe())
+pub fn checks(accessibility_granted: bool) -> Vec<Check> {
+    a11y_checks(probe(), accessibility_granted)
 }
 
 /// The gathered probe on its own, for an aggregator that assembles this line beside checks of its
@@ -98,7 +117,7 @@ mod tests {
     #[test]
     fn an_answering_ax_stack_is_ok() {
         assert_eq!(
-            a11y_checks(SystemWideProbe::Answered)[0].status,
+            a11y_checks(SystemWideProbe::Answered, true)[0].status,
             CheckStatus::Ok
         );
     }
@@ -108,14 +127,14 @@ mod tests {
         // No focused application is a legitimate answer, not a broken stack: the call returned a
         // definite "no such attribute" rather than refusing to talk.
         assert_eq!(
-            a11y_checks(SystemWideProbe::AttributeAbsent)[0].status,
+            a11y_checks(SystemWideProbe::AttributeAbsent, true)[0].status,
             CheckStatus::Ok
         );
     }
 
     #[test]
     fn a_disabled_api_fails_and_carries_the_error_code() {
-        let c = &a11y_checks(SystemWideProbe::ApiDisabled)[0];
+        let c = &a11y_checks(SystemWideProbe::ApiDisabled, false)[0];
         assert_eq!(c.status, CheckStatus::Fail);
         assert!(
             c.detail.contains("-25211"),
@@ -125,10 +144,10 @@ mod tests {
     }
 
     #[test]
-    fn a_stack_that_did_not_answer_names_the_locked_screen() {
+    fn a_trusted_process_that_gets_no_answer_names_the_locked_screen() {
         // The failure that cost an hour on 2026-07-29: the AX stack was fine and the screen was
         // locked, and nothing in the diagnostic said so.
-        let c = &a11y_checks(SystemWideProbe::DidNotComplete)[0];
+        let c = &a11y_checks(SystemWideProbe::DidNotComplete, true)[0];
         assert_eq!(c.status, CheckStatus::Fail);
         assert!(
             c.detail.to_lowercase().contains("locked"),
@@ -138,8 +157,23 @@ mod tests {
     }
 
     #[test]
+    fn an_untrusted_process_that_gets_no_answer_names_the_grant_instead() {
+        // Same AXError, different cause: macOS 26.5 gives an ungranted binary -25204 too (measured
+        // against the real API from an ungranted test binary). Sending that reader to unlock an
+        // already-unlocked screen is the diagnostic failing at its one job.
+        let c = &a11y_checks(SystemWideProbe::DidNotComplete, false)[0];
+        assert_eq!(c.status, CheckStatus::Fail);
+        assert!(
+            !c.detail.to_lowercase().contains("locked"),
+            "an ungranted process must not be told about the screen: {}",
+            c.detail
+        );
+        assert_eq!(c.remedy.as_deref(), Some(GRANT_REMEDY));
+    }
+
+    #[test]
     fn an_unrecognized_error_still_reports_its_code() {
-        let c = &a11y_checks(SystemWideProbe::Failed(-25200))[0];
+        let c = &a11y_checks(SystemWideProbe::Failed(-25200), true)[0];
         assert_eq!(c.status, CheckStatus::Fail);
         assert!(c.detail.contains("-25200"), "detail: {}", c.detail);
     }
@@ -155,7 +189,7 @@ mod tests {
             SystemWideProbe::DidNotComplete,
             SystemWideProbe::Failed(-1),
         ] {
-            let c = &a11y_checks(p)[0];
+            let c = &a11y_checks(p, false)[0];
             assert!(
                 !c.detail.contains("System Settings"),
                 "the reader line must not duplicate the grant line's remedy: {}",

--- a/crates/glass-a11y-macos/src/doctor.rs
+++ b/crates/glass-a11y-macos/src/doctor.rs
@@ -60,8 +60,8 @@ pub enum ConsoleSession {
     Unlocked,
     Locked,
     /// Nobody is logged in at the console. Distinct from locked: unlocking is not the remedy, and
-    /// telling this operator the session is unlocked is a falsehood the report contradicts two
-    /// lines further up.
+    /// telling this operator the session is unlocked contradicts the `display awake` check the same
+    /// report prints.
     NoSession,
 }
 
@@ -123,7 +123,7 @@ pub fn a11y_checks(
                     "the system-wide read was not answered (AXError {CANNOT_COMPLETE}) and the \
                      console session is locked"
                 ),
-                _ => format!(
+                ConsoleSession::NoSession | ConsoleSession::Unlocked => format!(
                     "the system-wide read was not answered (AXError {CANNOT_COMPLETE}) and no \
                      account is logged in at the console"
                 ),
@@ -133,15 +133,19 @@ pub fn a11y_checks(
             ConsoleSession::Locked => {
                 "unlock the session and re-run (see the `display awake` check)"
             }
-            _ => "log in at the console and re-run (see the `display awake` check)",
+            ConsoleSession::NoSession | ConsoleSession::Unlocked => {
+                "log in at the console and re-run (see the `display awake` check)"
+            }
         }),
+        // Reached only with the grant held, so "go and grant it" would send the operator to a pane
+        // where the box is already ticked. A stale TCC record is the case that produces this.
         SystemWideProbe::ApiDisabled => fail(
             format!(
-                "assistive access is off for this process (AXError {API_DISABLED}), so the \
-                 accessibility tools will fail"
+                "assistive access is off for this process (AXError {API_DISABLED}) even though it \
+                 holds the Accessibility grant, so the accessibility tools will fail"
             ),
-            "enable assistive access for this binary in System Settings > Privacy & Security > \
-             Accessibility, then restart it",
+            "remove this binary from System Settings > Privacy & Security > Accessibility, add it \
+             again, and restart it",
         ),
         SystemWideProbe::DidNotComplete => fail(
             format!(
@@ -276,11 +280,14 @@ mod tests {
     #[test]
     fn an_untrusted_process_never_reports_a_green_reader() {
         // The probe cannot rescue an untrusted process: it holds no grant, so no tree read can
-        // succeed whatever the system-wide element answered.
+        // succeed whatever the system-wide element answered. The remedy points at the grant check
+        // rather than repeating its System Settings text, so there is one thing to do, not two.
         for p in EVERY_PROBE {
-            let c = reader(p, false, ConsoleSession::Unlocked);
-            assert_eq!(c.status, CheckStatus::Fail, "{p:?} -> {c:?}");
-            assert_eq!(c.remedy.as_deref(), Some(GRANT_REMEDY), "{p:?}");
+            for session in EVERY_SESSION {
+                let c = reader(p, false, session);
+                assert_eq!(c.status, CheckStatus::Fail, "{p:?} {session:?} -> {c:?}");
+                assert_eq!(c.remedy.as_deref(), Some(GRANT_REMEDY), "{p:?} {session:?}");
+            }
         }
     }
 
@@ -401,20 +408,6 @@ mod tests {
                         );
                     }
                 }
-            }
-        }
-    }
-
-    #[test]
-    fn an_untrusted_process_is_pointed_at_the_grant_check_not_at_a_second_copy_of_it() {
-        // The grant check owns the System Settings pane; this line points at it instead, so an
-        // untrusted operator is given one thing to do rather than two. (A *granted* process whose
-        // assistive access is off is a different case: the grant line reads green there, so that
-        // arm names the pane itself.)
-        for p in EVERY_PROBE {
-            for session in EVERY_SESSION {
-                let c = reader(p, false, session);
-                assert_eq!(c.remedy.as_deref(), Some(GRANT_REMEDY), "{p:?} {session:?}");
             }
         }
     }

--- a/crates/glass-a11y-macos/src/doctor.rs
+++ b/crates/glass-a11y-macos/src/doctor.rs
@@ -1,5 +1,5 @@
 //! Environment checks for the macOS accessibility backend ("glass doctor"). The pure
-//! `a11y_checks` maps a gathered probe to `Check`s and is unit-tested on any host; `gather`
+//! `a11y_checks` maps a gathered probe to `Check`s and is unit-tested on any host; `probe`
 //! makes the one real AX call, on macOS only.
 
 use glass_core::{Check, CheckStatus};
@@ -81,7 +81,14 @@ pub fn a11y_checks(probe: SystemWideProbe) -> Vec<Check> {
 /// the fabrication this module exists to remove. Host unit tests drive [`a11y_checks`] directly.
 #[cfg(target_os = "macos")]
 pub fn checks() -> Vec<Check> {
-    a11y_checks(crate::ffi::probe_system_wide())
+    a11y_checks(probe())
+}
+
+/// The gathered probe on its own, for an aggregator that assembles this line beside checks of its
+/// own (`glass-mcp` pairs it with the Accessibility grant).
+#[cfg(target_os = "macos")]
+pub fn probe() -> SystemWideProbe {
+    crate::ffi::probe_system_wide()
 }
 
 #[cfg(test)]

--- a/crates/glass-a11y-macos/src/doctor.rs
+++ b/crates/glass-a11y-macos/src/doctor.rs
@@ -1,0 +1,159 @@
+//! Environment checks for the macOS accessibility backend ("glass doctor"). The pure
+//! `a11y_checks` maps a gathered probe to `Check`s and is unit-tested on any host; `gather`
+//! makes the one real AX call, on macOS only.
+
+use glass_core::{Check, CheckStatus};
+
+/// What one system-wide accessibility read did.
+///
+/// The question is whether the AX stack *answered*, not what it answered: an absent attribute is a
+/// definite reply and counts as healthy, while `DidNotComplete` means the API refused to talk.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SystemWideProbe {
+    Answered,
+    /// The call returned "this element has no such attribute" — no application is focused. The
+    /// stack answered, so the reader works.
+    AttributeAbsent,
+    /// `kAXErrorAPIDisabled` (-25211): the API is not available to this process.
+    ApiDisabled,
+    /// `kAXErrorCannotComplete` (-25204): the API did not answer.
+    DidNotComplete,
+    Failed(i32),
+}
+
+/// `kAXErrorAPIDisabled`, quoted in the check so the reader can search for it.
+const API_DISABLED: i32 = -25211;
+/// `kAXErrorCannotComplete`.
+const CANNOT_COMPLETE: i32 = -25204;
+
+/// Map a system-wide read to the `a11y reader` check.
+///
+/// Deliberately says nothing about the Accessibility grant — that is its own check, with its own
+/// remedy. This one answers "did the API respond", which a granted process can still fail: with
+/// `CGSSessionScreenIsLocked` set, every AX tree on the host is withheld (measured 2026-07-29), and
+/// a diagnostic that reports only "failed" sends the reader hunting for a bug in glass.
+pub fn a11y_checks(probe: SystemWideProbe) -> Vec<Check> {
+    vec![match probe {
+        SystemWideProbe::Answered => Check::new(
+            "a11y reader",
+            CheckStatus::Ok,
+            "AXUIElement reader answered a system-wide read",
+        ),
+        SystemWideProbe::AttributeAbsent => Check::new(
+            "a11y reader",
+            CheckStatus::Ok,
+            "AXUIElement reader answered a system-wide read (nothing is focused right now)",
+        ),
+        SystemWideProbe::ApiDisabled => Check::new(
+            "a11y reader",
+            CheckStatus::Fail,
+            format!(
+                "the accessibility API is disabled for this process (AXError {API_DISABLED}) — \
+                 glass_a11y_snapshot / glass_a11y_marks / glass_click_element / glass_set_value \
+                 will fail"
+            ),
+        )
+        .with_remedy("grant Accessibility to this binary — see the check below"),
+        SystemWideProbe::DidNotComplete => Check::new(
+            "a11y reader",
+            CheckStatus::Fail,
+            format!(
+                "the accessibility API did not answer (AXError {CANNOT_COMPLETE}) — a locked \
+                 screen withholds every accessibility tree on the host, as does a wedged \
+                 accessibility stack"
+            ),
+        )
+        .with_remedy(
+            "unlock the screen and re-run; if it was already unlocked, log out and back in",
+        ),
+        SystemWideProbe::Failed(code) => Check::new(
+            "a11y reader",
+            CheckStatus::Fail,
+            format!("system-wide accessibility read failed (AXError {code})"),
+        ),
+    }]
+}
+
+/// Probe whether the AXUIElement reader is answering: one `AXUIElementCopyAttributeValue` against
+/// the system-wide element, which needs no target application and mutates nothing.
+///
+/// macOS-only on purpose, with no off-macOS stub: a stub would have to invent an answer, which is
+/// the fabrication this module exists to remove. Host unit tests drive [`a11y_checks`] directly.
+#[cfg(target_os = "macos")]
+pub fn checks() -> Vec<Check> {
+    a11y_checks(crate::ffi::probe_system_wide())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_answering_ax_stack_is_ok() {
+        assert_eq!(
+            a11y_checks(SystemWideProbe::Answered)[0].status,
+            CheckStatus::Ok
+        );
+    }
+
+    #[test]
+    fn an_absent_attribute_still_proves_the_stack_answered() {
+        // No focused application is a legitimate answer, not a broken stack: the call returned a
+        // definite "no such attribute" rather than refusing to talk.
+        assert_eq!(
+            a11y_checks(SystemWideProbe::AttributeAbsent)[0].status,
+            CheckStatus::Ok
+        );
+    }
+
+    #[test]
+    fn a_disabled_api_fails_and_carries_the_error_code() {
+        let c = &a11y_checks(SystemWideProbe::ApiDisabled)[0];
+        assert_eq!(c.status, CheckStatus::Fail);
+        assert!(
+            c.detail.contains("-25211"),
+            "detail must carry the AXError code: {}",
+            c.detail
+        );
+    }
+
+    #[test]
+    fn a_stack_that_did_not_answer_names_the_locked_screen() {
+        // The failure that cost an hour on 2026-07-29: the AX stack was fine and the screen was
+        // locked, and nothing in the diagnostic said so.
+        let c = &a11y_checks(SystemWideProbe::DidNotComplete)[0];
+        assert_eq!(c.status, CheckStatus::Fail);
+        assert!(
+            c.detail.to_lowercase().contains("locked"),
+            "detail must name the locked screen: {}",
+            c.detail
+        );
+    }
+
+    #[test]
+    fn an_unrecognized_error_still_reports_its_code() {
+        let c = &a11y_checks(SystemWideProbe::Failed(-25200))[0];
+        assert_eq!(c.status, CheckStatus::Fail);
+        assert!(c.detail.contains("-25200"), "detail: {}", c.detail);
+    }
+
+    #[test]
+    fn no_variant_reports_the_grant() {
+        // The grant is a separate check with a separate remedy; collapsing the two is what made the
+        // old hardcoded line useless.
+        for p in [
+            SystemWideProbe::Answered,
+            SystemWideProbe::AttributeAbsent,
+            SystemWideProbe::ApiDisabled,
+            SystemWideProbe::DidNotComplete,
+            SystemWideProbe::Failed(-1),
+        ] {
+            let c = &a11y_checks(p)[0];
+            assert!(
+                !c.detail.contains("System Settings"),
+                "the reader line must not duplicate the grant line's remedy: {}",
+                c.detail
+            );
+        }
+    }
+}

--- a/crates/glass-a11y-macos/src/doctor.rs
+++ b/crates/glass-a11y-macos/src/doctor.rs
@@ -6,10 +6,11 @@ use glass_core::{Check, CheckStatus};
 
 /// The attribute the doctor reads off the system-wide element.
 ///
-/// Do not swap this for a cheaper one. It is *trust-gated*: an untrusted process reading it gets
-/// `CannotComplete`, while `AXRole` on the same element answers `Success` (surveyed on macOS 26.5).
-/// So this attribute fails exactly when the reader would fail, and a "simpler" one would report
-/// green to a process that cannot read a single tree — the fabrication this module exists to remove.
+/// Do not swap this for a cheaper one. It is *access-gated*: a binary macOS will not let read the
+/// accessibility tree gets `CannotComplete` from it, while `AXRole` on the same element answers
+/// `Success` (surveyed on macOS 26.5). So this attribute fails exactly when the reader would fail,
+/// and a "simpler" one would report green to a process that cannot read a single tree — the
+/// fabrication this module exists to remove.
 pub const PROBE_ATTRIBUTE: &str = "AXFocusedApplication";
 
 /// `kAXErrorAPIDisabled`: assistive access is off for this process.
@@ -30,8 +31,9 @@ pub enum SystemWideProbe {
     NothingFocused,
     /// `kAXErrorAPIDisabled`.
     ApiDisabled,
-    /// `kAXErrorCannotComplete`. Ambiguous on its own: an untrusted process gets this, and so does a
-    /// trusted one whose read is not answered — which is why [`a11y_checks`] takes the grant.
+    /// `kAXErrorCannotComplete`. Ambiguous on its own: a binary macOS denies gets this, and so does
+    /// one whose read is genuinely not answered — and `AXIsProcessTrusted` does not separate them
+    /// (see [`a11y_checks`]).
     DidNotComplete,
     /// Any other `AXError`, carrying the raw code so a field report names it. Includes
     /// `kAXErrorAttributeUnsupported` (-25205), which for [`PROBE_ATTRIBUTE`] means the system-wide
@@ -55,13 +57,19 @@ impl SystemWideProbe {
 
 /// The console session's state, as the aggregator reads it. Mirrors `glass_macos::SessionState`
 /// without depending on it: this crate maps outcomes to text, and the platform crate owns the read.
+///
+/// A *locked* session is deliberately not distinguished from an unlocked one here. Measured on
+/// macOS 26.5 by locking a host mid-probe: with `CGSSessionScreenIsLocked` set, the system-wide
+/// read still answers `Success`, so a lock never produces the code this would have qualified. The
+/// lock's real consequence — capture and input are suppressed — is reported by the `display awake`
+/// check, and repeating it here would be a second copy of one fact.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ConsoleSession {
-    Unlocked,
-    Locked,
-    /// Nobody is logged in at the console. Distinct from locked: unlocking is not the remedy, and
-    /// telling this operator the session is unlocked contradicts the `display awake` check the same
-    /// report prints.
+    /// Somebody is logged in at the console, locked or not.
+    LoggedIn,
+    /// Nobody is logged in at the console. Unmeasured against this probe, unlike the locked case:
+    /// kept because if it *does* produce an unanswered read, "log in at the console" is the only
+    /// remedy that helps, and the alternative message would blame the binary's grant.
     NoSession,
 }
 
@@ -72,14 +80,20 @@ const GRANT_REMEDY: &str = "grant Accessibility to this binary — see the check
 /// Map a system-wide read to the `a11y reader` check.
 ///
 /// Takes two facts the caller has already gathered because the probe alone cannot be read
-/// correctly. `accessibility_granted`: an untrusted process gets `CannotComplete` (measured on
-/// macOS 26.5), the same code a trusted process gets when its read is not answered.
+/// correctly. `accessibility_granted`: a denied process gets `CannotComplete` (measured on macOS
+/// 26.5), the same code a process gets when its read is genuinely not answered.
+///
+/// The grant narrows the causes; it does not settle them. Measured on the same host at the same
+/// moment: `glass-mcp` read the system-wide element successfully while another binary got
+/// `CannotComplete` **with `AXIsProcessTrusted` reporting it as trusted**. So a `true` grant bit does
+/// not mean this binary may read, and the trusted-and-unlocked arm below says so rather than
+/// blaming the accessibility stack.
+///
 /// `session`: an unanswered read means something different with nobody at the console, and the
 /// aggregator already reads the real state — so this reports the session it *is* in rather than
 /// inferring one from an error code and contradicting the `display awake` check printed beside it.
-/// Whether a locked session actually produces this code is not established (`glass-macos`'s input
-/// tests record locked-session AX *writes* reporting success), which is why the session only
-/// qualifies the ambiguous code rather than explaining every failure.
+/// A locked session is not one of the causes: it was measured not to produce this code (see
+/// [`ConsoleSession`]).
 ///
 /// The grant keeps its own check next to this one: this line answers "did the API respond", that
 /// one answers "is this binary trusted".
@@ -112,31 +126,17 @@ pub fn a11y_checks(
         SystemWideProbe::NothingFocused => {
             ok("AXUIElement reader answered a system-wide read (no application is frontmost)")
         }
-        // Only the ambiguous code defers to the session: `ApiDisabled` and an unrecognised code
-        // mean what they mean whether or not anyone is at the console, and letting the session
-        // swallow them would downgrade a real defect to "unlock your screen".
-        SystemWideProbe::DidNotComplete if session != ConsoleSession::Unlocked => Check::new(
+        // Only the ambiguous code defers to the session, and only for the one session state that
+        // could plausibly cause it: nobody at the console is not a defect to fix, so it warns.
+        SystemWideProbe::DidNotComplete if session == ConsoleSession::NoSession => Check::new(
             "a11y reader",
             CheckStatus::Warn,
-            match session {
-                ConsoleSession::Locked => format!(
-                    "the system-wide read was not answered (AXError {CANNOT_COMPLETE}) and the \
-                     console session is locked"
-                ),
-                ConsoleSession::NoSession | ConsoleSession::Unlocked => format!(
-                    "the system-wide read was not answered (AXError {CANNOT_COMPLETE}) and no \
-                     account is logged in at the console"
-                ),
-            },
+            format!(
+                "the system-wide read was not answered (AXError {CANNOT_COMPLETE}) and no account \
+                 is logged in at the console"
+            ),
         )
-        .with_remedy(match session {
-            ConsoleSession::Locked => {
-                "unlock the session and re-run (see the `display awake` check)"
-            }
-            ConsoleSession::NoSession | ConsoleSession::Unlocked => {
-                "log in at the console and re-run (see the `display awake` check)"
-            }
-        }),
+        .with_remedy("log in at the console and re-run (see the `display awake` check)"),
         // Reached only with the grant held, so "go and grant it" would send the operator to a pane
         // where the box is already ticked. A stale TCC record is the case that produces this.
         SystemWideProbe::ApiDisabled => fail(
@@ -149,11 +149,13 @@ pub fn a11y_checks(
         ),
         SystemWideProbe::DidNotComplete => fail(
             format!(
-                "the accessibility API did not answer (AXError {CANNOT_COMPLETE}) — this process is \
-                 trusted and someone is logged in at an unlocked console, so the accessibility \
-                 stack is not responding"
+                "the accessibility API did not answer (AXError {CANNOT_COMPLETE}) even though this \
+                 process reports as trusted — macOS reports trust for a binary whose reads it still \
+                 denies, so the likeliest cause is that this exact binary was never granted"
             ),
-            "log out and back in; if it persists, report this with the `glass doctor` output",
+            "grant Accessibility to the binary you are actually running — a rebuild at another path \
+             or under another name is a different binary to macOS — and restart it; if it already \
+             holds the grant, log out and back in",
         ),
         SystemWideProbe::Failed(code) => fail(
             format!("system-wide accessibility read failed (AXError {code})"),
@@ -193,11 +195,8 @@ mod tests {
         a11y_checks(probe, granted, session).remove(0)
     }
 
-    const EVERY_SESSION: [ConsoleSession; 3] = [
-        ConsoleSession::Unlocked,
-        ConsoleSession::Locked,
-        ConsoleSession::NoSession,
-    ];
+    const EVERY_SESSION: [ConsoleSession; 2] =
+        [ConsoleSession::LoggedIn, ConsoleSession::NoSession];
 
     const EVERY_PROBE: [SystemWideProbe; 5] = [
         SystemWideProbe::Answered,
@@ -249,7 +248,7 @@ mod tests {
             reader(
                 SystemWideProbe::from_ax_code(-25205),
                 true,
-                ConsoleSession::Unlocked
+                ConsoleSession::LoggedIn
             )
             .status,
             CheckStatus::Fail
@@ -259,7 +258,7 @@ mod tests {
     #[test]
     fn an_answering_ax_stack_is_ok() {
         assert_eq!(
-            reader(SystemWideProbe::Answered, true, ConsoleSession::Unlocked).status,
+            reader(SystemWideProbe::Answered, true, ConsoleSession::LoggedIn).status,
             CheckStatus::Ok
         );
     }
@@ -269,7 +268,7 @@ mod tests {
         let c = reader(
             SystemWideProbe::NothingFocused,
             true,
-            ConsoleSession::Unlocked,
+            ConsoleSession::LoggedIn,
         );
         assert_eq!(c.status, CheckStatus::Ok);
         // The detail is the arm's whole point: collapsing it into `Answered` would lose the reason
@@ -332,21 +331,11 @@ mod tests {
     }
 
     #[test]
-    fn a_locked_session_is_a_warning_naming_the_lock_not_a_failure() {
-        // Transient and not a configuration defect: failing here would exit(1) on a Mac driving
-        // another backend with its screen locked. The lock is read, not inferred from the code.
-        let c = reader(
-            SystemWideProbe::DidNotComplete,
-            true,
-            ConsoleSession::Locked,
-        );
-        assert_eq!(c.status, CheckStatus::Warn);
-        assert!(c.detail.contains("locked"), "{}", c.detail);
-        assert!(
-            c.remedy.as_deref().unwrap().contains("unlock"),
-            "{:?}",
-            c.remedy
-        );
+    fn a_locked_console_is_not_a_case_this_check_reports_on() {
+        // Measured by locking a macOS 26.5 host mid-probe: the system-wide read still answered, so
+        // there is no locked-session outcome to report here. `display awake` carries the lock.
+        let c = reader(SystemWideProbe::Answered, true, ConsoleSession::LoggedIn);
+        assert_eq!(c.status, CheckStatus::Ok);
     }
 
     #[test]
@@ -357,7 +346,7 @@ mod tests {
         let c = reader(
             SystemWideProbe::DidNotComplete,
             true,
-            ConsoleSession::Unlocked,
+            ConsoleSession::LoggedIn,
         );
         assert_eq!(c.status, CheckStatus::Fail);
         assert!(
@@ -376,7 +365,7 @@ mod tests {
     #[test]
     fn a_granted_process_with_assistive_access_off_is_not_sent_to_the_grant_check() {
         // The grant line beside this one reads "granted", so pointing at it would be a dead end.
-        let c = reader(SystemWideProbe::ApiDisabled, true, ConsoleSession::Unlocked);
+        let c = reader(SystemWideProbe::ApiDisabled, true, ConsoleSession::LoggedIn);
         assert_eq!(c.status, CheckStatus::Fail);
         assert_ne!(c.remedy.as_deref(), Some(GRANT_REMEDY));
         assert!(c.detail.contains(&API_DISABLED.to_string()), "{}", c.detail);
@@ -387,7 +376,7 @@ mod tests {
         let c = reader(
             SystemWideProbe::Failed(-25208),
             true,
-            ConsoleSession::Unlocked,
+            ConsoleSession::LoggedIn,
         );
         assert_eq!(c.status, CheckStatus::Fail);
         assert!(c.detail.contains("-25208"), "{}", c.detail);

--- a/crates/glass-a11y-macos/src/ffi.rs
+++ b/crates/glass-a11y-macos/src/ffi.rs
@@ -156,8 +156,9 @@ pub(crate) fn probe_system_wide() -> SystemWideProbe {
     probe_system_wide_attr(crate::doctor::PROBE_ATTRIBUTE)
 }
 
-/// How long one doctor AX read may wait. Generous for a system-wide attribute read, which answers
-/// in microseconds on a healthy host.
+/// How long one doctor AX read may wait before the API gives up. A system-wide
+/// `AXFocusedApplication` read is forwarded to the frontmost application, so this has to allow for
+/// a busy-but-healthy app, not just for the round trip.
 const PROBE_TIMEOUT_SECS: f32 = 2.0;
 
 /// [`probe_system_wide`] with the attribute as a seam, so a live test can drive the classifier with
@@ -167,19 +168,29 @@ fn probe_system_wide_attr(attr_name: &str) -> SystemWideProbe {
     // SAFETY: `AXUIElementCreateSystemWide` takes no arguments and never returns NULL per Apple's
     // documented contract (the binding itself `.expect()`s on this).
     let el = unsafe { AXUIElement::new_system_wide() };
+    // Setting a timeout on the *system-wide* object sets it globally for the process (Apple's
+    // documented behaviour), so this would otherwise cap every later glass_a11y_snapshot in the
+    // server — a diagnostic changing what the product does. It is restored below.
+    //
     // SAFETY: `el` is a live `AXUIElement`; the call takes a plain timeout with no aliasing or
-    // lifetime preconditions. Its own failure is not reported: a timeout that could not be set
-    // leaves the system default in place, which is a slower probe, not a wrong one.
+    // lifetime preconditions. A timeout that could not be set leaves the system default in place:
+    // the probe is then bounded only by that default, which is the pre-existing behaviour.
     let _ = unsafe { el.set_messaging_timeout(PROBE_TIMEOUT_SECS) };
     let attr = CFString::from_str(attr_name);
     let mut raw: *const CFType = std::ptr::null();
     // SAFETY: `el` is a live `AXUIElement`; `raw` is a valid local out-param slot matching
     // `AXUIElementCopyAttributeValue`'s documented signature (mirrors `copy_attribute_checked`).
     let err = unsafe { el.copy_attribute_value(&attr, NonNull::from(&mut raw)) };
-    if let Some(nn) = NonNull::new(raw.cast_mut()) {
+    // SAFETY: as above; 0 restores the process-global default, leaving the AX subsystem as the
+    // probe found it.
+    let _ = unsafe { el.set_messaging_timeout(0.0) };
+    if err == AXError::Success
+        && let Some(nn) = NonNull::new(raw.cast_mut())
+    {
         // SAFETY: on `Success` the Copy call returned an already-retained (+1) value per Core
         // Foundation's Copy/Create rule; taking ownership here releases it at end of scope rather
-        // than leaking the frontmost application element on every doctor run.
+        // than leaking the frontmost application element on every doctor run. Only on `Success`:
+        // on any other code the out-param is not ours to release.
         drop(unsafe { CFRetained::from_raw(nn) });
     }
     // A `Success` with a null value is `Answered` here, though `copy_attribute_checked` calls the
@@ -422,9 +433,10 @@ mod tests {
         );
     }
 
-    /// Live: the surveyed fact the probe attribute is chosen for — `AXRole` answers where
-    /// `AXFocusedApplication` may not — so a maintainer swapping the attribute has something that
-    /// fails rather than a comment.
+    /// Live: `AXRole` answers on the system-wide element. Half of the reason
+    /// [`crate::doctor::PROBE_ATTRIBUTE`] is not `AXRole`; the other half — that an *untrusted*
+    /// process still gets an answer from it — needs an untrusted process and is not asserted
+    /// anywhere.
     #[test]
     #[ignore = "needs a macOS GUI session (run by scripts/test-macos-a11y.sh)"]
     fn axrole_answers_on_the_system_wide_element() {
@@ -432,6 +444,30 @@ mod tests {
             probe_system_wide_attr("AXRole"),
             SystemWideProbe::Answered,
             "if this fails, the reason PROBE_ATTRIBUTE is AXFocusedApplication no longer holds"
+        );
+    }
+
+    /// The doctor hand-copies these codes so its classifier compiles on any host; nothing else
+    /// keeps them equal to the binding's, and a one-digit slip would silently reclassify a disabled
+    /// API as an unrecognised failure.
+    #[test]
+    fn the_doctors_ax_codes_match_the_binding() {
+        use crate::doctor::SystemWideProbe;
+        assert_eq!(
+            SystemWideProbe::from_ax_code(AXError::APIDisabled.0),
+            SystemWideProbe::ApiDisabled
+        );
+        assert_eq!(
+            SystemWideProbe::from_ax_code(AXError::CannotComplete.0),
+            SystemWideProbe::DidNotComplete
+        );
+        assert_eq!(
+            SystemWideProbe::from_ax_code(AXError::NoValue.0),
+            SystemWideProbe::NothingFocused
+        );
+        assert_eq!(
+            SystemWideProbe::from_ax_code(AXError::Success.0),
+            SystemWideProbe::Answered
         );
     }
 

--- a/crates/glass-a11y-macos/src/ffi.rs
+++ b/crates/glass-a11y-macos/src/ffi.rs
@@ -144,48 +144,47 @@ fn copy_attribute_checked(el: &AXUIElement, attr_name: &str) -> Result<Option<CF
 
 /// One system-wide accessibility read, for the doctor: does the AX API answer at all?
 ///
-/// Reads `AXFocusedApplication` off `AXUIElementCreateSystemWide` and throws the value away — the
-/// question is whether the call was *answered*, not what is focused — so it needs no target
-/// application and mutates nothing. It cannot go through [`copy_attribute_checked`], which folds
-/// every real failure into one error string; the doctor reports the code.
+/// Reads [`SystemWideProbe`]'s probe attribute and throws the value away — the question is whether
+/// the call was *answered*, not what is focused — so it needs no target application and mutates
+/// nothing. It cannot go through [`copy_attribute_checked`], which returns a `GlassError` and
+/// discards the `AXError` discriminant the doctor classifies on.
+///
+/// Bounded by an explicit messaging timeout: an AX read is synchronous IPC to another process, and
+/// "the accessibility stack is wedged" — the headline condition this probe exists to catch — is
+/// exactly the case that blocks. A doctor that hangs reports nothing at all.
 pub(crate) fn probe_system_wide() -> SystemWideProbe {
-    // `AXFocusedApplication`, not a cheaper attribute, because it is *trust-gated*: surveyed on the
-    // dogfood mini, an untrusted process reading it off the system-wide element gets
-    // `CannotComplete` while `AXRole` on the same element answers `Success`. So this attribute fails
-    // exactly when the reader would fail, and a "simpler" one would report green to a process that
-    // cannot read a single tree.
-    probe_system_wide_attr("AXFocusedApplication")
+    probe_system_wide_attr(crate::doctor::PROBE_ATTRIBUTE)
 }
 
+/// How long one doctor AX read may wait. Generous for a system-wide attribute read, which answers
+/// in microseconds on a healthy host.
+const PROBE_TIMEOUT_SECS: f32 = 2.0;
+
 /// [`probe_system_wide`] with the attribute as a seam, so a live test can drive the classifier with
-/// an attribute the system-wide element definitely lacks and see a non-`Success` code come back from
-/// the real API rather than from a fixture.
+/// an attribute the system-wide element does not carry and see a real non-`Success` code come back
+/// from the API rather than from a fixture.
 fn probe_system_wide_attr(attr_name: &str) -> SystemWideProbe {
     // SAFETY: `AXUIElementCreateSystemWide` takes no arguments and never returns NULL per Apple's
     // documented contract (the binding itself `.expect()`s on this).
     let el = unsafe { AXUIElement::new_system_wide() };
+    // SAFETY: `el` is a live `AXUIElement`; the call takes a plain timeout with no aliasing or
+    // lifetime preconditions. Its own failure is not reported: a timeout that could not be set
+    // leaves the system default in place, which is a slower probe, not a wrong one.
+    let _ = unsafe { el.set_messaging_timeout(PROBE_TIMEOUT_SECS) };
     let attr = CFString::from_str(attr_name);
     let mut raw: *const CFType = std::ptr::null();
     // SAFETY: `el` is a live `AXUIElement`; `raw` is a valid local out-param slot matching
     // `AXUIElementCopyAttributeValue`'s documented signature (mirrors `copy_attribute_checked`).
     let err = unsafe { el.copy_attribute_value(&attr, NonNull::from(&mut raw)) };
-    if err == AXError::Success {
-        if let Some(nn) = NonNull::new(raw.cast_mut()) {
-            // SAFETY: the Copy call returned an already-retained (+1) value per Core Foundation's
-            // Copy/Create rule; taking ownership here releases it at end of scope rather than
-            // leaking the focused application element on every doctor run.
-            drop(unsafe { CFRetained::from_raw(nn) });
-        }
-        return SystemWideProbe::Answered;
+    if let Some(nn) = NonNull::new(raw.cast_mut()) {
+        // SAFETY: on `Success` the Copy call returned an already-retained (+1) value per Core
+        // Foundation's Copy/Create rule; taking ownership here releases it at end of scope rather
+        // than leaking the frontmost application element on every doctor run.
+        drop(unsafe { CFRetained::from_raw(nn) });
     }
-    if is_absent_error(err) {
-        return SystemWideProbe::AttributeAbsent;
-    }
-    match err {
-        AXError::APIDisabled => SystemWideProbe::ApiDisabled,
-        AXError::CannotComplete => SystemWideProbe::DidNotComplete,
-        other => SystemWideProbe::Failed(other.0),
-    }
+    // A `Success` with a null value is `Answered` here, though `copy_attribute_checked` calls the
+    // same pair a backend error: this probe asks whether the call was answered, and it was.
+    SystemWideProbe::from_ax_code(err.0)
 }
 
 /// Read `el`'s `attr_name` as a `String`, or `None` when the attribute is absent, isn't a
@@ -407,18 +406,32 @@ mod tests {
     use crate::doctor::SystemWideProbe;
     use objc2_application_services::AXError;
 
-    // There is deliberately no live "healthy host answers" test: on the dogfood mini this harness
-    // gets `CannotComplete` while `glass-mcp doctor` answers, on the same host in the same session,
-    // so the assertion would encode which binaries that host happens to trust.
+    // There is deliberately no live "the probe answers" test: on a granted process it answers and
+    // on an untrusted one it does not, so the assertion would encode which binaries the running
+    // host happens to trust. The classification it feeds is unit-tested in `doctor`, on any host.
 
-    /// Live: a real non-`Success` `AXError` reaches the classifier and is named, rather than every
-    /// outcome collapsing to the healthy one — which is the defect this whole check replaces.
+    /// Live: a real `AXError` from the API reaches the classifier and is told apart from `Answered`.
+    /// Needs a GUI session; whether it needs the Accessibility grant is untested — an attribute the
+    /// element does not carry is not trust-gated on the evidence this crate has.
     #[test]
-    #[ignore = "needs a macOS GUI session with Accessibility granted to this process"]
-    fn an_attribute_the_element_lacks_classifies_as_absent() {
-        assert_eq!(
+    #[ignore = "needs a macOS GUI session (run by scripts/test-macos-a11y.sh)"]
+    fn an_attribute_the_element_lacks_is_not_reported_as_answered() {
+        assert_ne!(
             probe_system_wide_attr("AXNoSuchAttributeGlassDoctorProbe"),
-            SystemWideProbe::AttributeAbsent
+            SystemWideProbe::Answered
+        );
+    }
+
+    /// Live: the surveyed fact the probe attribute is chosen for — `AXRole` answers where
+    /// `AXFocusedApplication` may not — so a maintainer swapping the attribute has something that
+    /// fails rather than a comment.
+    #[test]
+    #[ignore = "needs a macOS GUI session (run by scripts/test-macos-a11y.sh)"]
+    fn axrole_answers_on_the_system_wide_element() {
+        assert_eq!(
+            probe_system_wide_attr("AXRole"),
+            SystemWideProbe::Answered,
+            "if this fails, the reason PROBE_ATTRIBUTE is AXFocusedApplication no longer holds"
         );
     }
 

--- a/crates/glass-a11y-macos/src/ffi.rs
+++ b/crates/glass-a11y-macos/src/ffi.rs
@@ -150,10 +150,22 @@ fn copy_attribute_checked(el: &AXUIElement, attr_name: &str) -> Result<Option<CF
 /// every real failure into one error string: the doctor has to tell `APIDisabled` (not trusted)
 /// from `CannotComplete` (the stack did not answer, which is what a locked screen looks like).
 pub(crate) fn probe_system_wide() -> SystemWideProbe {
+    // `AXFocusedApplication`, not a cheaper attribute, because it is *trust-gated*: surveyed on the
+    // dogfood mini, an untrusted process reading it off the system-wide element gets
+    // `CannotComplete` while `AXRole` on the same element answers `Success`. So this attribute fails
+    // exactly when the reader would fail, and a "simpler" one would report green to a process that
+    // cannot read a single tree.
+    probe_system_wide_attr("AXFocusedApplication")
+}
+
+/// [`probe_system_wide`] with the attribute as a seam, so a live test can drive the classifier with
+/// an attribute the system-wide element definitely lacks and see a non-`Success` code come back from
+/// the real API rather than from a fixture.
+fn probe_system_wide_attr(attr_name: &str) -> SystemWideProbe {
     // SAFETY: `AXUIElementCreateSystemWide` takes no arguments and never returns NULL per Apple's
     // documented contract (the binding itself `.expect()`s on this).
     let el = unsafe { AXUIElement::new_system_wide() };
-    let attr = CFString::from_str("AXFocusedApplication");
+    let attr = CFString::from_str(attr_name);
     let mut raw: *const CFType = std::ptr::null();
     // SAFETY: `el` is a live `AXUIElement`; `raw` is a valid local out-param slot matching
     // `AXUIElementCopyAttributeValue`'s documented signature (mirrors `copy_attribute_checked`).
@@ -392,8 +404,25 @@ fn ax_err(context: &str, err: AXError) -> GlassError {
 
 #[cfg(test)]
 mod tests {
-    use super::is_absent_error;
+    use super::{is_absent_error, probe_system_wide_attr};
+    use crate::doctor::SystemWideProbe;
     use objc2_application_services::AXError;
+
+    // There is deliberately no live "healthy host answers" test: the Accessibility grant attaches
+    // to the binary, and a `cargo test` binary is never granted one — measured on the dogfood mini,
+    // where `glass-mcp doctor` answered and this harness got CannotComplete on the same host in the
+    // same session. That measurement is also why the doctor disambiguates -25204 with the grant bit.
+
+    /// Live: a real non-`Success` `AXError` reaches the classifier and is named, rather than every
+    /// outcome collapsing to the healthy one — which is the defect this whole check replaces.
+    #[test]
+    #[ignore = "needs a macOS GUI session with Accessibility granted to this process"]
+    fn an_attribute_the_element_lacks_classifies_as_absent() {
+        assert_eq!(
+            probe_system_wide_attr("AXNoSuchAttributeGlassDoctorProbe"),
+            SystemWideProbe::AttributeAbsent
+        );
+    }
 
     #[test]
     fn absent_ax_errors_classified_as_absent() {

--- a/crates/glass-a11y-macos/src/ffi.rs
+++ b/crates/glass-a11y-macos/src/ffi.rs
@@ -147,8 +147,7 @@ fn copy_attribute_checked(el: &AXUIElement, attr_name: &str) -> Result<Option<CF
 /// Reads `AXFocusedApplication` off `AXUIElementCreateSystemWide` and throws the value away — the
 /// question is whether the call was *answered*, not what is focused — so it needs no target
 /// application and mutates nothing. It cannot go through [`copy_attribute_checked`], which folds
-/// every real failure into one error string: the doctor has to tell `APIDisabled` (not trusted)
-/// from `CannotComplete` (the stack did not answer, which is what a locked screen looks like).
+/// every real failure into one error string; the doctor reports the code.
 pub(crate) fn probe_system_wide() -> SystemWideProbe {
     // `AXFocusedApplication`, not a cheaper attribute, because it is *trust-gated*: surveyed on the
     // dogfood mini, an untrusted process reading it off the system-wide element gets
@@ -408,10 +407,9 @@ mod tests {
     use crate::doctor::SystemWideProbe;
     use objc2_application_services::AXError;
 
-    // There is deliberately no live "healthy host answers" test: the Accessibility grant attaches
-    // to the binary, and a `cargo test` binary is never granted one — measured on the dogfood mini,
-    // where `glass-mcp doctor` answered and this harness got CannotComplete on the same host in the
-    // same session. That measurement is also why the doctor disambiguates -25204 with the grant bit.
+    // There is deliberately no live "healthy host answers" test: on the dogfood mini this harness
+    // gets `CannotComplete` while `glass-mcp doctor` answers, on the same host in the same session,
+    // so the assertion would encode which binaries that host happens to trust.
 
     /// Live: a real non-`Success` `AXError` reaches the classifier and is named, rather than every
     /// outcome collapsing to the healthy one — which is the defect this whole check replaces.

--- a/crates/glass-a11y-macos/src/ffi.rs
+++ b/crates/glass-a11y-macos/src/ffi.rs
@@ -156,10 +156,32 @@ pub(crate) fn probe_system_wide() -> SystemWideProbe {
     probe_system_wide_attr(crate::doctor::PROBE_ATTRIBUTE)
 }
 
-/// How long one doctor AX read may wait before the API gives up. A system-wide
-/// `AXFocusedApplication` read is forwarded to the frontmost application, so this has to allow for
-/// a busy-but-healthy app, not just for the round trip.
+/// How long one doctor AX read may wait before the API gives up — chosen to leave room for a busy
+/// frontmost application rather than measured against one.
 const PROBE_TIMEOUT_SECS: f32 = 2.0;
+
+/// The process-global AX messaging timeout, restored on drop.
+///
+/// A guard rather than a pair of calls so an unwind between them cannot leave the whole server
+/// running with the probe's short bound.
+struct ProbeTimeout<'a>(&'a AXUIElement);
+
+impl<'a> ProbeTimeout<'a> {
+    fn set(el: &'a AXUIElement) -> Self {
+        // SAFETY: `el` is a live `AXUIElement`; the call takes a plain timeout with no aliasing or
+        // lifetime preconditions. A timeout that could not be set leaves the system default in
+        // place: the probe is then bounded only by that default, as it was before.
+        let _ = unsafe { el.set_messaging_timeout(PROBE_TIMEOUT_SECS) };
+        Self(el)
+    }
+}
+
+impl Drop for ProbeTimeout<'_> {
+    fn drop(&mut self) {
+        // SAFETY: as in `set`; 0 on the system-wide object restores the documented default.
+        let _ = unsafe { self.0.set_messaging_timeout(0.0) };
+    }
+}
 
 /// [`probe_system_wide`] with the attribute as a seam, so a live test can drive the classifier with
 /// an attribute the system-wide element does not carry and see a real non-`Success` code come back
@@ -169,21 +191,18 @@ fn probe_system_wide_attr(attr_name: &str) -> SystemWideProbe {
     // documented contract (the binding itself `.expect()`s on this).
     let el = unsafe { AXUIElement::new_system_wide() };
     // Setting a timeout on the *system-wide* object sets it globally for the process (Apple's
-    // documented behaviour), so this would otherwise cap every later glass_a11y_snapshot in the
-    // server — a diagnostic changing what the product does. It is restored below.
-    //
-    // SAFETY: `el` is a live `AXUIElement`; the call takes a plain timeout with no aliasing or
-    // lifetime preconditions. A timeout that could not be set leaves the system default in place:
-    // the probe is then bounded only by that default, which is the pre-existing behaviour.
-    let _ = unsafe { el.set_messaging_timeout(PROBE_TIMEOUT_SECS) };
+    // documented behaviour), so the bound is restored the moment the read returns — otherwise one
+    // `glass_doctor` call would cap every later a11y read in the server, a diagnostic changing what
+    // the product does. `glass_doctor` does not run on the serialized platform thread, so an a11y
+    // read *concurrent* with the probe still sees the cap; that window is one attribute read long,
+    // where the alternative is an unbounded doctor.
+    let _timeout = ProbeTimeout::set(&el);
     let attr = CFString::from_str(attr_name);
     let mut raw: *const CFType = std::ptr::null();
     // SAFETY: `el` is a live `AXUIElement`; `raw` is a valid local out-param slot matching
     // `AXUIElementCopyAttributeValue`'s documented signature (mirrors `copy_attribute_checked`).
     let err = unsafe { el.copy_attribute_value(&attr, NonNull::from(&mut raw)) };
-    // SAFETY: as above; 0 restores the process-global default, leaving the AX subsystem as the
-    // probe found it.
-    let _ = unsafe { el.set_messaging_timeout(0.0) };
+    drop(_timeout);
     if err == AXError::Success
         && let Some(nn) = NonNull::new(raw.cast_mut())
     {
@@ -425,7 +444,7 @@ mod tests {
     /// Needs a GUI session; whether it needs the Accessibility grant is untested — an attribute the
     /// element does not carry is not trust-gated on the evidence this crate has.
     #[test]
-    #[ignore = "needs a macOS GUI session (run by scripts/test-macos-a11y.sh)"]
+    #[ignore = "needs a macOS GUI session; CI has none, so run it on a dev Mac: cargo test -p glass-a11y-macos --lib ffi::tests -- --ignored"]
     fn an_attribute_the_element_lacks_is_not_reported_as_answered() {
         assert_ne!(
             probe_system_wide_attr("AXNoSuchAttributeGlassDoctorProbe"),
@@ -438,7 +457,7 @@ mod tests {
     /// process still gets an answer from it — needs an untrusted process and is not asserted
     /// anywhere.
     #[test]
-    #[ignore = "needs a macOS GUI session (run by scripts/test-macos-a11y.sh)"]
+    #[ignore = "needs a macOS GUI session; CI has none, so run it on a dev Mac: cargo test -p glass-a11y-macos --lib ffi::tests -- --ignored"]
     fn axrole_answers_on_the_system_wide_element() {
         assert_eq!(
             probe_system_wide_attr("AXRole"),

--- a/crates/glass-a11y-macos/src/ffi.rs
+++ b/crates/glass-a11y-macos/src/ffi.rs
@@ -28,6 +28,7 @@
 
 use std::ptr::NonNull;
 
+use crate::doctor::SystemWideProbe;
 use objc2_application_services::{AXError, AXUIElement, AXValue, AXValueType};
 use objc2_core_foundation::{
     CFArray, CFBoolean, CFNumber, CFNumberType, CFRetained, CFString, CFType, CGPoint, CGSize,
@@ -139,6 +140,41 @@ fn copy_attribute_checked(el: &AXUIElement, attr_name: &str) -> Result<Option<CF
     // ownership rule — an already-retained (+1) `CFTypeRef` on success — so
     // `CFRetained::from_raw` takes ownership without an extra retain (mirrors `axwindow`).
     Ok(Some(unsafe { CFRetained::from_raw(nn) }))
+}
+
+/// One system-wide accessibility read, for the doctor: does the AX API answer at all?
+///
+/// Reads `AXFocusedApplication` off `AXUIElementCreateSystemWide` and throws the value away — the
+/// question is whether the call was *answered*, not what is focused — so it needs no target
+/// application and mutates nothing. It cannot go through [`copy_attribute_checked`], which folds
+/// every real failure into one error string: the doctor has to tell `APIDisabled` (not trusted)
+/// from `CannotComplete` (the stack did not answer, which is what a locked screen looks like).
+pub(crate) fn probe_system_wide() -> SystemWideProbe {
+    // SAFETY: `AXUIElementCreateSystemWide` takes no arguments and never returns NULL per Apple's
+    // documented contract (the binding itself `.expect()`s on this).
+    let el = unsafe { AXUIElement::new_system_wide() };
+    let attr = CFString::from_str("AXFocusedApplication");
+    let mut raw: *const CFType = std::ptr::null();
+    // SAFETY: `el` is a live `AXUIElement`; `raw` is a valid local out-param slot matching
+    // `AXUIElementCopyAttributeValue`'s documented signature (mirrors `copy_attribute_checked`).
+    let err = unsafe { el.copy_attribute_value(&attr, NonNull::from(&mut raw)) };
+    if err == AXError::Success {
+        if let Some(nn) = NonNull::new(raw.cast_mut()) {
+            // SAFETY: the Copy call returned an already-retained (+1) value per Core Foundation's
+            // Copy/Create rule; taking ownership here releases it at end of scope rather than
+            // leaking the focused application element on every doctor run.
+            drop(unsafe { CFRetained::from_raw(nn) });
+        }
+        return SystemWideProbe::Answered;
+    }
+    if is_absent_error(err) {
+        return SystemWideProbe::AttributeAbsent;
+    }
+    match err {
+        AXError::APIDisabled => SystemWideProbe::ApiDisabled,
+        AXError::CannotComplete => SystemWideProbe::DidNotComplete,
+        other => SystemWideProbe::Failed(other.0),
+    }
 }
 
 /// Read `el`'s `attr_name` as a `String`, or `None` when the attribute is absent, isn't a

--- a/crates/glass-a11y-macos/src/lib.rs
+++ b/crates/glass-a11y-macos/src/lib.rs
@@ -5,6 +5,7 @@
 // `mapping` module stays `unsafe`-free by convention.
 #![allow(unsafe_code)]
 
+pub mod doctor; // pure probe->Check mapping (cross-platform) + the macOS-only AX probe
 pub mod mapping; // pure AX->normalized mapping — cross-platform, unit-tested on any host
 
 // The cfg(macos) AXUIElement reader: `ffi` holds every `unsafe` AX read primitive, `reader`

--- a/crates/glass-ios/src/doctor.rs
+++ b/crates/glass-ios/src/doctor.rs
@@ -26,6 +26,9 @@ pub struct Probe<'a> {
     pub runtimes: &'a [String],
     /// iPhone simulator lines from `xcrun simctl list devices available`.
     pub iphones: &'a [String],
+    /// Name of an already-booted iOS simulator, if any. Everything glass does on iOS needs a booted
+    /// target, and booting one is not the doctor's business.
+    pub booted: Option<&'a str>,
 }
 
 const INSTALL_XCODE_REMEDY: &str =
@@ -87,16 +90,27 @@ fn runtime_check(p: &Probe) -> Check {
 }
 
 fn device_check(p: &Probe) -> Check {
-    if p.iphones.is_empty() {
-        Check::new("device", CheckStatus::Fail, "no iPhone simulator available").with_remedy(
-            "create one in Xcode (Window > Devices and Simulators) or with `xcrun simctl create`",
+    match (p.iphones.is_empty(), p.booted) {
+        (true, _) => Check::new("device", CheckStatus::Fail, "no iPhone simulator available")
+            .with_remedy(
+                "create one in Xcode (Window > Devices and Simulators) or with `xcrun simctl create`",
+            ),
+        // Available is not driveable: every iOS tool needs a *booted* target, so a host with twelve
+        // simulators and none booted used to read green and then fail on the first call.
+        (false, None) => Check::new(
+            "device",
+            CheckStatus::Warn,
+            format!(
+                "{} iPhone simulator(s) available, none booted",
+                p.iphones.len()
+            ),
         )
-    } else {
-        Check::new(
+        .with_remedy("boot one with `xcrun simctl boot <udid>` (glass does not boot it for you here)"),
+        (false, Some(name)) => Check::new(
             "device",
             CheckStatus::Ok,
-            format!("{} iPhone simulator(s) available", p.iphones.len()),
-        )
+            format!("{} available, booted: {name}", p.iphones.len()),
+        ),
     }
 }
 
@@ -148,11 +162,18 @@ pub fn checks(_deep: bool) -> Vec<Check> {
         .map(|l| l.trim().to_string())
         .collect();
 
+    // The same listing `booted_udid` reads, by name rather than udid: a name is what the operator
+    // sees in Xcode. Nothing here boots anything — doctor reports on the host, it does not change it.
+    let booted = simctl_out(&["simctl", "list", "devices", "available", "--json"])
+        .and_then(|json| parse_devices(&json).ok())
+        .and_then(|devices| booted_name(&devices));
+
     build_checks(&Probe {
         xcode_dir,
         simctl_ok,
         runtimes: &runtimes,
         iphones: &iphones,
+        booted: booted.as_deref(),
     })
 }
 
@@ -299,6 +320,16 @@ fn booted_udid() -> Option<String> {
     booted_from(&parse_devices(&list).ok()?)
 }
 
+/// Name of an already-booted iOS simulator, chosen the same way [`booted_from`] chooses its udid so
+/// the reported device is the one a driving call would attach to.
+fn booted_name(devices: &[SimDevice]) -> Option<String> {
+    let udid = booted_from(devices)?;
+    devices
+        .iter()
+        .find(|d| d.udid == udid)
+        .map(|d| d.name.clone())
+}
+
 /// Pure booted-sim selection: `resolve(_, None, None)` returns `Attach` iff an iOS sim is
 /// already booted, so `Attach` is exactly "spawn against it without booting"; `Boot`/`Error`
 /// mean nothing is booted. The testable seam for [`booted_udid`].
@@ -355,6 +386,60 @@ mod tests {
     }
 
     #[test]
+    fn simulators_available_but_none_booted_is_not_green() {
+        // The gap this closes: everything glass does on iOS needs a booted target, so reporting
+        // "12 iPhone simulator(s) available" as Ok sent an operator into a run that could not work.
+        let runtimes = vec!["iOS 26.5".to_string()];
+        let iphones = vec!["iPhone 17".to_string(), "iPhone 17 Pro".to_string()];
+        let p = Probe {
+            xcode_dir: Some("/Applications/Xcode.app/Contents/Developer".into()),
+            simctl_ok: true,
+            runtimes: &runtimes,
+            iphones: &iphones,
+            booted: None,
+        };
+        let device = build_checks(&p)
+            .into_iter()
+            .find(|c| c.name == "device")
+            .unwrap();
+        assert_eq!(device.status, CheckStatus::Warn);
+        assert!(
+            device.remedy.as_deref().unwrap().contains("simctl boot"),
+            "{:?}",
+            device.remedy
+        );
+    }
+
+    #[test]
+    fn a_booted_simulator_is_named_so_the_operator_knows_which_one() {
+        let runtimes = vec!["iOS 26.5".to_string()];
+        let iphones = vec!["iPhone 17".to_string(), "iPhone 17 Pro".to_string()];
+        let p = Probe {
+            xcode_dir: Some("/Applications/Xcode.app/Contents/Developer".into()),
+            simctl_ok: true,
+            runtimes: &runtimes,
+            iphones: &iphones,
+            booted: Some("iPhone 17 Pro"),
+        };
+        let device = build_checks(&p)
+            .into_iter()
+            .find(|c| c.name == "device")
+            .unwrap();
+        assert_eq!(device.status, CheckStatus::Ok);
+        assert!(device.detail.contains("iPhone 17 Pro"), "{}", device.detail);
+    }
+
+    #[test]
+    fn booted_name_reports_the_device_a_driving_call_would_attach_to() {
+        let devices = vec![
+            dev("AAA", "iPhone 17", "Shutdown"),
+            dev("BBB", "iPhone 17 Pro", "Booted"),
+        ];
+        assert_eq!(booted_name(&devices), Some("iPhone 17 Pro".to_string()));
+        assert_eq!(booted_name(&devices[..1]), None);
+    }
+
+    #[test]
     fn all_green_when_fully_configured() {
         let runtimes = vec!["iOS 26.5".to_string()];
         let iphones = vec!["iPhone 17".to_string()];
@@ -363,6 +448,7 @@ mod tests {
             simctl_ok: true,
             runtimes: &runtimes,
             iphones: &iphones,
+            booted: Some("iPhone 17"),
         };
         let cs = build_checks(&p);
         assert!(cs.iter().all(|c| c.status == CheckStatus::Ok), "{cs:?}");
@@ -375,6 +461,7 @@ mod tests {
             simctl_ok: false,
             runtimes: &[],
             iphones: &[],
+            booted: None,
         };
         let cs = build_checks(&p);
         let xcode = cs.iter().find(|c| c.name == "xcode").unwrap();
@@ -399,6 +486,7 @@ mod tests {
             simctl_ok: false,
             runtimes: &[],
             iphones: &[],
+            booted: None,
         };
         let cs = build_checks(&p);
         let xcode = cs.iter().find(|c| c.name == "xcode").unwrap();
@@ -417,6 +505,7 @@ mod tests {
             simctl_ok: true,
             runtimes: &[],
             iphones: &[],
+            booted: None,
         };
         let cs = build_checks(&p);
         assert_eq!(

--- a/crates/glass-ios/src/doctor.rs
+++ b/crates/glass-ios/src/doctor.rs
@@ -1,6 +1,6 @@
 //! `glass doctor` checks for the iOS Simulator backend: is a full Xcode install active,
-//! does `xcrun simctl` work, is at least one iOS runtime downloaded, is an iPhone simulator
-//! available to run apps on, and will the target glass resolves at start actually be driveable?
+//! does `xcrun simctl` work, is at least one iOS runtime downloaded, and is the target glass would
+//! resolve at start actually driveable?
 //!
 //! Pure `build_checks(&Probe)` over observed state, plus the thin subprocess-probing
 //! `checks(deep)` entry point the aggregator calls.
@@ -46,8 +46,12 @@ pub enum TargetFacts {
     /// `GLASS_IOS_UDID` names a device that is present but not booted. glass attaches to a pinned
     /// udid *without* booting it, so this is the one state the start path will not fix for you.
     PinnedNotBooted(String),
-    /// Resolution failed outright — no available simulator, or `GLASS_IOS_DEVICE` names none.
-    Unresolvable(String),
+    /// `GLASS_IOS_UDID` names a booted device that is not an iOS simulator. glass attaches to it —
+    /// `resolve` does not filter a pinned udid by runtime — and every iOS call then fails.
+    PinnedNotIos { udid: String, name: String },
+    /// Resolution failed outright. `named` records whether a `GLASS_IOS_DEVICE` preference was in
+    /// play, because that changes the remedy from "create a simulator" to "fix the variable".
+    Unresolvable { why: String, named: bool },
     /// The listing could not be read, carrying why.
     Unknown(String),
 }
@@ -118,9 +122,9 @@ fn device_check(p: &Probe) -> Check {
         TargetFacts::WillBoot { name, available } => ok(format!(
             "{available} iOS simulator(s) available, none booted (glass boots {name} at start)"
         )),
-        TargetFacts::Attaching { name, available } => {
-            ok(format!("{available} iOS simulator(s) available, booted: {name}"))
-        }
+        TargetFacts::Attaching { name, available } => ok(format!(
+            "{available} iOS simulator(s) available, booted: {name}"
+        )),
         TargetFacts::PinnedNotBooted(udid) => Check::new(
             "device",
             CheckStatus::Fail,
@@ -134,6 +138,15 @@ fn device_check(p: &Probe) -> Check {
         )),
         // Distinct from not-booted: `simctl boot` on a udid the listing does not carry answers
         // "Invalid device", so the remedy has to be a different one.
+        TargetFacts::PinnedNotIos { udid, name } => Check::new(
+            "device",
+            CheckStatus::Fail,
+            format!(
+                "GLASS_IOS_UDID pins {udid} ({name}), which is not an iOS simulator — glass would \
+                 attach to it and every iOS call would fail"
+            ),
+        )
+        .with_remedy("pin an iOS simulator's udid, or unset GLASS_IOS_UDID and let glass pick"),
         TargetFacts::PinnedMissing(udid) => Check::new(
             "device",
             CheckStatus::Fail,
@@ -142,14 +155,26 @@ fn device_check(p: &Probe) -> Check {
         .with_remedy(
             "check the udid against `xcrun simctl list devices available`, or unset GLASS_IOS_UDID",
         ),
-        TargetFacts::Unresolvable(why) => Check::new("device", CheckStatus::Fail, why.clone())
-            .with_remedy(
-                "create one in Xcode (Window > Devices and Simulators) or with `xcrun simctl create`",
-            ),
-        TargetFacts::Unknown(cause) => {
-            Check::new("device", CheckStatus::Warn, format!("could not tell what glass would drive: {cause}"))
-                .with_remedy("run `xcrun simctl list devices available --json` and check it parses")
-        }
+        // Two different failures share `Resolve::Error`: the host has nothing, or the operator's
+        // `GLASS_IOS_DEVICE` matches nothing it has. Telling the second one to create a simulator
+        // hides the variable that actually decided it.
+        TargetFacts::Unresolvable { why, named } => Check::new(
+            "device",
+            CheckStatus::Fail,
+            why.clone(),
+        )
+        .with_remedy(if *named {
+            "correct GLASS_IOS_DEVICE to a simulator this host has, or unset it and let glass \
+                 pick"
+        } else {
+            "create one in Xcode (Window > Devices and Simulators) or with `xcrun simctl create`"
+        }),
+        TargetFacts::Unknown(cause) => Check::new(
+            "device",
+            CheckStatus::Warn,
+            format!("could not tell what glass would drive: {cause}"),
+        )
+        .with_remedy("run `xcrun simctl list devices available --json` and check it parses"),
     }
 }
 
@@ -385,6 +410,10 @@ fn target_from(
             // picks from the listing itself.
             None => TargetFacts::PinnedMissing(udid),
             Some(d) if d.state != "Booted" => TargetFacts::PinnedNotBooted(udid),
+            Some(d) if !d.runtime.contains("iOS") => TargetFacts::PinnedNotIos {
+                udid,
+                name: d.name.clone(),
+            },
             Some(d) => TargetFacts::Attaching {
                 name: d.name.clone(),
                 available,
@@ -397,14 +426,20 @@ fn target_from(
                 .map_or(udid, |d| d.name.clone()),
             available,
         },
-        Resolve::Error(why) => TargetFacts::Unresolvable(why),
+        Resolve::Error(why) => TargetFacts::Unresolvable {
+            why,
+            named: want_name.is_some(),
+        },
     }
 }
 
-/// A device a driving call could use: available, and on an iOS runtime (a watchOS or tvOS simulator
-/// is never a target). Mirrors the filter `resolve` selects with.
+/// A device a driving call could use: on an iOS runtime (a watchOS or tvOS simulator is never a
+/// boot candidate), and either offered by the listing or already booted.
+///
+/// The booted half matters: `resolve` attaches to a booted device without consulting `is_available`,
+/// so counting only available ones let the line read "0 iOS simulator(s) available, booted: X".
 fn ios_target(d: &SimDevice) -> bool {
-    d.is_available && d.runtime.contains("iOS")
+    d.runtime.contains("iOS") && (d.is_available || d.state == "Booted")
 }
 
 /// Pure booted-sim selection: `resolve(_, None, None)` returns `Attach` iff an iOS sim is
@@ -583,6 +618,79 @@ mod tests {
     }
 
     #[test]
+    fn a_pinned_udid_reaches_the_resolution_from_the_environment() {
+        // Proven missing by mutation: dropping the udid on the way through `gather_target` left the
+        // whole suite green while the doctor reported a green line for a host whose pinned target is
+        // a shut-down device — the dead-target case this check exists for.
+        let json = r#"{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-26-5":[
+            {"udid":"AAA","name":"iPhone 17","state":"Shutdown","isAvailable":true},
+            {"udid":"BBB","name":"iPhone 17 Pro","state":"Booted","isAvailable":true}]}}"#;
+        let facts = gather_target(&|_| Some(json.to_string()), &|k| {
+            (k == "GLASS_IOS_UDID").then(|| "AAA".to_string())
+        });
+        assert_eq!(facts, TargetFacts::PinnedNotBooted("AAA".into()));
+    }
+
+    #[test]
+    fn a_name_preference_that_matches_nothing_is_remedied_by_fixing_the_variable() {
+        // Not "create a simulator in Xcode": this host has one, and the operator's own variable is
+        // what ruled it out.
+        let c = device_line(&TargetFacts::Unresolvable {
+            why: "no available simulator named \"iPhone 16\"".into(),
+            named: true,
+        });
+        assert_eq!(c.status, CheckStatus::Fail);
+        assert!(
+            c.remedy.as_deref().unwrap().contains("GLASS_IOS_DEVICE"),
+            "{:?}",
+            c.remedy
+        );
+    }
+
+    #[test]
+    fn a_pinned_udid_on_a_non_ios_runtime_is_caught_before_it_is_driven() {
+        // `resolve` returns a pinned udid whatever its runtime, so glass would attach to a watch and
+        // every iOS call would fail against it.
+        let devices = vec![dev_on(
+            "WATCH",
+            "Apple Watch Series 10",
+            "Booted",
+            "com.apple.CoreSimulator.SimRuntime.watchOS-10-4",
+        )];
+        assert_eq!(
+            target_from(&devices, Some("WATCH"), None),
+            TargetFacts::PinnedNotIos {
+                udid: "WATCH".into(),
+                name: "Apple Watch Series 10".into(),
+            }
+        );
+        assert_eq!(
+            device_line(&target_from(&devices, Some("WATCH"), None)).status,
+            CheckStatus::Fail
+        );
+    }
+
+    #[test]
+    fn the_count_never_contradicts_the_device_it_names() {
+        // `resolve` attaches to a booted device without consulting `is_available`, so a listing that
+        // omits the availability key used to render "0 iOS simulator(s) available, booted: X".
+        let devices = vec![SimDevice {
+            udid: "AAA".into(),
+            name: "iPhone 17".into(),
+            state: "Booted".into(),
+            runtime: "com.apple.CoreSimulator.SimRuntime.iOS-26-5".into(),
+            is_available: false,
+        }];
+        assert_eq!(
+            target_from(&devices, None, None),
+            TargetFacts::Attaching {
+                name: "iPhone 17".into(),
+                available: 1,
+            }
+        );
+    }
+
+    #[test]
     fn a_pin_is_missing_when_the_listing_does_not_carry_it() {
         let devices = vec![dev("BBB", "iPhone 17 Pro", "Booted")];
         assert_eq!(
@@ -606,7 +714,7 @@ mod tests {
         let devices = vec![dev("AAA", "iPhone 17", "Shutdown")];
         let facts = target_from(&devices, None, Some("iPhone 16"));
         assert!(
-            matches!(&facts, TargetFacts::Unresolvable(why) if why.contains("iPhone 16")),
+            matches!(&facts, TargetFacts::Unresolvable { why, named: true } if why.contains("iPhone 16")),
             "{facts:?}"
         );
     }
@@ -637,7 +745,7 @@ mod tests {
             (k == "GLASS_IOS_DEVICE").then(|| "iPhone 16".to_string())
         });
         assert!(
-            matches!(&facts, TargetFacts::Unresolvable(why) if why.contains("iPhone 16")),
+            matches!(&facts, TargetFacts::Unresolvable { why, named: true } if why.contains("iPhone 16")),
             "{facts:?}"
         );
     }
@@ -678,7 +786,10 @@ mod tests {
             xcode_dir: Some("/Library/Developer/CommandLineTools".into()),
             simctl_ok: false,
             runtimes: &[],
-            target: &TargetFacts::Unresolvable("no available iPhone simulator found".into()),
+            target: &TargetFacts::Unresolvable {
+                why: "no available iPhone simulator found".into(),
+                named: false,
+            },
         };
         let cs = build_checks(&p);
         let xcode = cs.iter().find(|c| c.name == "xcode").unwrap();
@@ -702,7 +813,10 @@ mod tests {
             xcode_dir: None,
             simctl_ok: false,
             runtimes: &[],
-            target: &TargetFacts::Unresolvable("no available iPhone simulator found".into()),
+            target: &TargetFacts::Unresolvable {
+                why: "no available iPhone simulator found".into(),
+                named: false,
+            },
         };
         let cs = build_checks(&p);
         let xcode = cs.iter().find(|c| c.name == "xcode").unwrap();
@@ -720,7 +834,10 @@ mod tests {
             xcode_dir: Some("/Applications/Xcode.app/Contents/Developer".into()),
             simctl_ok: true,
             runtimes: &[],
-            target: &TargetFacts::Unresolvable("no available iPhone simulator found".into()),
+            target: &TargetFacts::Unresolvable {
+                why: "no available iPhone simulator found".into(),
+                named: false,
+            },
         };
         let cs = build_checks(&p);
         assert_eq!(

--- a/crates/glass-ios/src/doctor.rs
+++ b/crates/glass-ios/src/doctor.rs
@@ -25,29 +25,29 @@ pub struct Probe<'a> {
     pub simctl_ok: bool,
     /// iOS runtime lines from `xcrun simctl list runtimes`.
     pub runtimes: &'a [String],
-    /// iPhone simulator lines from `xcrun simctl list devices available`.
-    pub iphones: &'a [String],
     /// What the device listing said about the target glass would drive.
     pub target: &'a TargetFacts,
 }
 
 /// What the doctor could learn about the simulator glass would drive at start.
 ///
-/// Three-valued on purpose: a listing that failed is not a host with nothing booted, and reporting
-/// one as the other is how a diagnostic sends an operator to fix something that is not broken.
+/// Every arm is the outcome of running the *real* resolution the start path runs
+/// ([`crate::device::resolve`] with the same `GLASS_IOS_UDID` / `GLASS_IOS_DEVICE` preferences), so
+/// the doctor reports what would happen rather than a proxy for it. A listing that could not be read
+/// is its own arm: reporting it as "nothing booted" is a remedy the operator cannot follow to green.
 #[derive(Debug, PartialEq, Eq)]
 pub enum TargetFacts {
-    /// The listing was read.
-    Known {
-        /// Name of an already-booted iOS-family simulator (an iPad counts — `resolve` drives any
-        /// iOS-family device, and only *prefers* an iPhone), if any.
-        booted: Option<String>,
-        /// `GLASS_IOS_UDID`, when set: glass attaches to that udid **without booting it**, so a
-        /// shut-down one makes every call fail against a dead target.
-        pinned_udid: Option<String>,
-        /// Whether `pinned_udid` names a device the listing reports as booted.
-        pinned_is_booted: bool,
-    },
+    /// A booted device glass would attach to, and how many iOS-family simulators are available.
+    Attaching { name: String, available: usize },
+    /// Nothing booted; glass boots this one at start.
+    WillBoot { name: String, available: usize },
+    /// `GLASS_IOS_UDID` names a device the listing does not contain.
+    PinnedMissing(String),
+    /// `GLASS_IOS_UDID` names a device that is present but not booted. glass attaches to a pinned
+    /// udid *without* booting it, so this is the one state the start path will not fix for you.
+    PinnedNotBooted(String),
+    /// Resolution failed outright — no available simulator, or `GLASS_IOS_DEVICE` names none.
+    Unresolvable(String),
     /// The listing could not be read, carrying why.
     Unknown(String),
 }
@@ -111,36 +111,17 @@ fn runtime_check(p: &Probe) -> Check {
 }
 
 fn device_check(p: &Probe) -> Check {
-    if p.iphones.is_empty() {
-        return Check::new("device", CheckStatus::Fail, "no iPhone simulator available").with_remedy(
-            "create one in Xcode (Window > Devices and Simulators) or with `xcrun simctl create`",
-        );
-    }
-    let n = p.iphones.len();
+    let ok = |detail: String| Check::new("device", CheckStatus::Ok, detail);
     match p.target {
         // Nothing booted is the ordinary cold state, not a finding: `SimTarget::from_env` boots one
         // with `bootstatus -b` at start. Warning here would prescribe a command glass runs itself.
-        TargetFacts::Known {
-            pinned_udid: None,
-            booted,
-            ..
-        } => Check::new(
-            "device",
-            CheckStatus::Ok,
-            match booted {
-                Some(name) => format!("{n} iPhone simulator(s) available, booted: {name}"),
-                None => format!(
-                    "{n} iPhone simulator(s) available, none booted (glass boots one at start)"
-                ),
-            },
-        ),
-        // A pinned udid is the one case the start path will not boot for you: `resolve` returns it
-        // unconditionally, so a shut-down one is a dead target and every call fails against it.
-        TargetFacts::Known {
-            pinned_udid: Some(udid),
-            pinned_is_booted: false,
-            ..
-        } => Check::new(
+        TargetFacts::WillBoot { name, available } => ok(format!(
+            "{available} iOS simulator(s) available, none booted (glass boots {name} at start)"
+        )),
+        TargetFacts::Attaching { name, available } => {
+            ok(format!("{available} iOS simulator(s) available, booted: {name}"))
+        }
+        TargetFacts::PinnedNotBooted(udid) => Check::new(
             "device",
             CheckStatus::Fail,
             format!(
@@ -151,22 +132,24 @@ fn device_check(p: &Probe) -> Check {
         .with_remedy(format!(
             "boot it with `xcrun simctl boot {udid}`, or unset GLASS_IOS_UDID and let glass pick"
         )),
-        TargetFacts::Known {
-            pinned_udid: Some(udid),
-            ..
-        } => Check::new(
+        // Distinct from not-booted: `simctl boot` on a udid the listing does not carry answers
+        // "Invalid device", so the remedy has to be a different one.
+        TargetFacts::PinnedMissing(udid) => Check::new(
             "device",
-            CheckStatus::Ok,
-            format!(
-                "{n} iPhone simulator(s) available; GLASS_IOS_UDID pins {udid}, which is booted"
-            ),
-        ),
-        TargetFacts::Unknown(cause) => Check::new(
-            "device",
-            CheckStatus::Warn,
-            format!("{n} iPhone simulator(s) available; could not tell what is booted: {cause}"),
+            CheckStatus::Fail,
+            format!("GLASS_IOS_UDID pins {udid}, which this host has no simulator for"),
         )
-        .with_remedy("run `xcrun simctl list devices available --json` and check it parses"),
+        .with_remedy(
+            "check the udid against `xcrun simctl list devices available`, or unset GLASS_IOS_UDID",
+        ),
+        TargetFacts::Unresolvable(why) => Check::new("device", CheckStatus::Fail, why.clone())
+            .with_remedy(
+                "create one in Xcode (Window > Devices and Simulators) or with `xcrun simctl create`",
+            ),
+        TargetFacts::Unknown(cause) => {
+            Check::new("device", CheckStatus::Warn, format!("could not tell what glass would drive: {cause}"))
+                .with_remedy("run `xcrun simctl list devices available --json` and check it parses")
+        }
     }
 }
 
@@ -211,20 +194,12 @@ pub fn checks(_deep: bool) -> Vec<Check> {
         .filter(|l| l.contains("iOS"))
         .map(|l| l.trim().to_string())
         .collect();
-    let iphones: Vec<String> = simctl_out(&["simctl", "list", "devices", "available"])
-        .unwrap_or_default()
-        .lines()
-        .filter(|l| l.contains("iPhone"))
-        .map(|l| l.trim().to_string())
-        .collect();
-
     let target = gather_target(&simctl_out, &|k| std::env::var(k).ok());
 
     build_checks(&Probe {
         xcode_dir,
         simctl_ok,
         runtimes: &runtimes,
-        iphones: &iphones,
         target: &target,
     })
 }
@@ -374,43 +349,62 @@ fn booted_udid() -> Option<String> {
 
 /// Read the device listing once and answer what the start path would do with it.
 ///
-/// Every failure to read it becomes [`TargetFacts::Unknown`] carrying the cause, rather than the
-/// `None` that means "nothing is booted": a timed-out or unparseable listing reported as "none
-/// booted" is a remedy the operator cannot follow to green.
+/// One listing, not two: a second `simctl` call is a second thing that can fail, and when both fail
+/// the doctor has to describe the failure rather than infer an empty host from it.
 fn gather_target(
     simctl_out: &dyn Fn(&[&str]) -> Option<String>,
     env: &dyn Fn(&str) -> Option<String>,
 ) -> TargetFacts {
-    let Some(json) = simctl_out(&["simctl", "list", "devices", "available", "--json"]) else {
-        return TargetFacts::Unknown("`xcrun simctl list devices --json` did not answer".into());
+    let args = ["simctl", "list", "devices", "available", "--json"];
+    let Some(json) = simctl_out(&args) else {
+        return TargetFacts::Unknown(format!("`xcrun {}` did not answer", args.join(" ")));
     };
     match parse_devices(&json) {
-        Ok(devices) => target_from(&devices, wants(env).0),
+        Ok(devices) => {
+            let (udid, name, _) = wants(env);
+            target_from(&devices, udid.as_deref(), name.as_deref())
+        }
         Err(e) => TargetFacts::Unknown(e.to_string()),
     }
 }
 
-/// The pure half of [`gather_target`]: what the listing says about the target glass would drive.
-fn target_from(devices: &[SimDevice], pinned_udid: Option<String>) -> TargetFacts {
-    let booted = booted_name(devices);
-    let pinned_is_booted = pinned_udid
-        .as_deref()
-        .is_some_and(|u| devices.iter().any(|d| d.udid == u && d.state == "Booted"));
-    TargetFacts::Known {
-        booted,
-        pinned_udid,
-        pinned_is_booted,
+/// The pure half of [`gather_target`]: run the start path's own resolution and describe its outcome.
+///
+/// Both preferences are passed, because both change what a driving call does: `GLASS_IOS_DEVICE`
+/// naming a simulator this host lacks makes `glass_start` fail outright, which the doctor should say
+/// rather than report a green line about some other device.
+fn target_from(
+    devices: &[SimDevice],
+    want_udid: Option<&str>,
+    want_name: Option<&str>,
+) -> TargetFacts {
+    let available = devices.iter().filter(|d| ios_target(d)).count();
+    match resolve(devices, want_udid, want_name) {
+        Resolve::Attach(udid) => match devices.iter().find(|d| d.udid == udid) {
+            // Only a pinned udid can name something the listing does not carry: the unpinned path
+            // picks from the listing itself.
+            None => TargetFacts::PinnedMissing(udid),
+            Some(d) if d.state != "Booted" => TargetFacts::PinnedNotBooted(udid),
+            Some(d) => TargetFacts::Attaching {
+                name: d.name.clone(),
+                available,
+            },
+        },
+        Resolve::Boot(udid) => TargetFacts::WillBoot {
+            name: devices
+                .iter()
+                .find(|d| d.udid == udid)
+                .map_or(udid, |d| d.name.clone()),
+            available,
+        },
+        Resolve::Error(why) => TargetFacts::Unresolvable(why),
     }
 }
 
-/// Name of the already-booted simulator [`booted_from`] would attach to — the same selection a
-/// driving call makes when `GLASS_IOS_UDID` is unset (a pinned udid bypasses this entirely).
-fn booted_name(devices: &[SimDevice]) -> Option<String> {
-    let udid = booted_from(devices)?;
-    devices
-        .iter()
-        .find(|d| d.udid == udid)
-        .map(|d| d.name.clone())
+/// A device a driving call could use: available, and on an iOS runtime (a watchOS or tvOS simulator
+/// is never a target). Mirrors the filter `resolve` selects with.
+fn ios_target(d: &SimDevice) -> bool {
+    d.is_available && d.runtime.contains("iOS")
 }
 
 /// Pure booted-sim selection: `resolve(_, None, None)` returns `Attach` iff an iOS sim is
@@ -477,23 +471,12 @@ mod tests {
         assert_eq!(booted_from(&devices), None);
     }
 
-    /// A read listing, with an optional booted device and an optional `GLASS_IOS_UDID` pin.
-    fn known(booted: Option<&str>, pinned: Option<(&str, bool)>) -> TargetFacts {
-        TargetFacts::Known {
-            booted: booted.map(Into::into),
-            pinned_udid: pinned.map(|(u, _)| u.to_string()),
-            pinned_is_booted: pinned.is_some_and(|(_, b)| b),
-        }
-    }
-
     fn device_line(target: &TargetFacts) -> Check {
         let runtimes = vec!["iOS 26.5".to_string()];
-        let iphones = vec!["iPhone 17".to_string(), "iPhone 17 Pro".to_string()];
         let p = Probe {
             xcode_dir: Some("/Applications/Xcode.app/Contents/Developer".into()),
             simctl_ok: true,
             runtimes: &runtimes,
-            iphones: &iphones,
             target,
         };
         build_checks(&p)
@@ -506,37 +489,44 @@ mod tests {
     fn nothing_booted_is_not_a_finding_because_glass_boots_one_at_start() {
         // `SimTarget::from_env` runs `bootstatus -b` when nothing is booted, so warning here would
         // prescribe a command glass runs itself, on a host with nothing wrong with it.
-        let c = device_line(&known(None, None));
+        let c = device_line(&TargetFacts::WillBoot {
+            name: "iPhone 17".into(),
+            available: 5,
+        });
         assert_eq!(c.status, CheckStatus::Ok);
-        assert!(c.detail.contains("boots one at start"), "{}", c.detail);
-    }
-
-    #[test]
-    fn a_booted_simulator_is_named_so_the_operator_knows_which_one() {
-        let c = device_line(&known(Some("iPhone 17 Pro"), None));
-        assert_eq!(c.status, CheckStatus::Ok);
-        assert!(c.detail.contains("iPhone 17 Pro"), "{}", c.detail);
+        assert!(
+            c.detail.contains("boots iPhone 17 at start"),
+            "{}",
+            c.detail
+        );
     }
 
     #[test]
     fn a_pinned_udid_that_is_not_booted_is_the_one_state_start_will_not_fix() {
         // `resolve` returns a pinned udid without checking its state and without booting it, so
         // glass attaches to a dead target and every later call fails against it.
-        let c = device_line(&known(Some("iPhone 17 Pro"), Some(("DEAD-UDID", false))));
+        let c = device_line(&TargetFacts::PinnedNotBooted("DEAD-UDID".into()));
         assert_eq!(c.status, CheckStatus::Fail);
-        assert!(c.detail.contains("DEAD-UDID"), "{}", c.detail);
         assert!(
-            c.remedy.as_deref().unwrap().contains("GLASS_IOS_UDID"),
+            c.remedy
+                .as_deref()
+                .unwrap()
+                .contains("simctl boot DEAD-UDID"),
             "{:?}",
             c.remedy
         );
     }
 
     #[test]
-    fn a_pinned_udid_that_is_booted_is_reported_not_warned_about() {
-        let c = device_line(&known(None, Some(("LIVE-UDID", true))));
-        assert_eq!(c.status, CheckStatus::Ok);
-        assert!(c.detail.contains("LIVE-UDID"), "{}", c.detail);
+    fn a_pinned_udid_the_host_lacks_is_not_told_to_boot_it() {
+        // `simctl boot` on an unknown udid answers "Invalid device", so this needs its own remedy.
+        let c = device_line(&TargetFacts::PinnedMissing("GHOST".into()));
+        assert_eq!(c.status, CheckStatus::Fail);
+        assert!(
+            !c.remedy.as_deref().unwrap().contains("simctl boot"),
+            "{:?}",
+            c.remedy
+        );
     }
 
     #[test]
@@ -556,9 +546,9 @@ mod tests {
     }
 
     #[test]
-    fn booted_name_reports_the_device_a_driving_call_would_attach_to() {
-        // Two booted devices and a non-iOS one: a naive "first booted" pick names the watch or the
-        // wrong simulator, which is not what `resolve` — and so a driving call — would attach to.
+    fn the_reported_device_is_the_one_a_driving_call_would_attach_to() {
+        // Two booted devices and a booted watch: a naive "first booted" pick names the watch or the
+        // wrong simulator, neither of which is what `resolve` — and so a driving call — attaches to.
         let devices = vec![
             dev_on(
                 "WATCH",
@@ -569,53 +559,114 @@ mod tests {
             dev("IPAD", "iPad Pro 13-inch", "Booted"),
             dev("PHONE", "iPhone 17 Pro", "Booted"),
         ];
-        assert_eq!(booted_name(&devices), Some("iPhone 17 Pro".to_string()));
-        // A booted watch is not a target: nothing iOS-family is booted here.
-        assert_eq!(booted_name(&devices[..1]), None);
-    }
-
-    #[test]
-    fn a_pin_is_only_booted_when_the_listing_says_that_exact_udid_is() {
-        let devices = vec![
-            dev("AAA", "iPhone 17", "Shutdown"),
-            dev("BBB", "iPhone 17 Pro", "Booted"),
-        ];
         assert_eq!(
-            target_from(&devices, Some("AAA".into())),
-            known(Some("iPhone 17 Pro"), Some(("AAA", false)))
-        );
-        assert_eq!(
-            target_from(&devices, Some("BBB".into())),
-            known(Some("iPhone 17 Pro"), Some(("BBB", true)))
+            target_from(&devices, None, None),
+            TargetFacts::Attaching {
+                name: "iPhone 17 Pro".into(),
+                available: 2,
+            }
         );
     }
 
     #[test]
-    fn a_listing_that_does_not_answer_is_unknown_not_empty() {
+    fn an_ipad_only_host_is_driveable_and_reported_so() {
+        // `resolve` drives any iOS-family device and only *prefers* an iPhone, so failing an
+        // iPad-only host with "no iPhone simulator available" would report a working host as broken.
+        let devices = vec![dev("IPAD", "iPad Pro 13-inch", "Shutdown")];
+        assert_eq!(
+            target_from(&devices, None, None),
+            TargetFacts::WillBoot {
+                name: "iPad Pro 13-inch".into(),
+                available: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn a_pin_is_missing_when_the_listing_does_not_carry_it() {
+        let devices = vec![dev("BBB", "iPhone 17 Pro", "Booted")];
+        assert_eq!(
+            target_from(&devices, Some("TYPO"), None),
+            TargetFacts::PinnedMissing("TYPO".into())
+        );
+        assert_eq!(
+            target_from(&devices, Some("BBB"), None),
+            TargetFacts::Attaching {
+                name: "iPhone 17 Pro".into(),
+                available: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn a_device_name_that_matches_nothing_is_reported_not_ignored() {
+        // `GLASS_IOS_DEVICE` changes what a driving call resolves: a name this host lacks makes
+        // `glass_start` fail outright, so reading only the udid preference would report a green
+        // line about a device glass would never attach to.
+        let devices = vec![dev("AAA", "iPhone 17", "Shutdown")];
+        let facts = target_from(&devices, None, Some("iPhone 16"));
+        assert!(
+            matches!(&facts, TargetFacts::Unresolvable(why) if why.contains("iPhone 16")),
+            "{facts:?}"
+        );
+    }
+
+    #[test]
+    fn a_listing_that_does_not_answer_names_the_command_that_did_not_answer() {
         let facts = gather_target(&|_| None, &|_| None);
-        assert!(matches!(facts, TargetFacts::Unknown(_)), "{facts:?}");
+        match facts {
+            TargetFacts::Unknown(cause) => {
+                assert!(
+                    cause.contains("simctl list devices available --json"),
+                    "{cause}"
+                )
+            }
+            other => panic!("expected Unknown, got {other:?}"),
+        }
     }
 
     #[test]
-    fn a_read_listing_carries_the_pin_from_the_environment() {
+    fn a_read_listing_carries_both_preferences_from_the_environment() {
+        // Shut down, deliberately: `resolve` answers from the booted devices before it consults
+        // `GLASS_IOS_DEVICE`, so the name preference only changes the outcome when nothing is
+        // booted — and a fixture with a booted device would pass whether or not the doctor read
+        // the variable at all.
         let json = r#"{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-26-5":[
-            {"udid":"BBB","name":"iPhone 17 Pro","state":"Booted","isAvailable":true}]}}"#;
+            {"udid":"BBB","name":"iPhone 17 Pro","state":"Shutdown","isAvailable":true}]}}"#;
         let facts = gather_target(&|_| Some(json.to_string()), &|k| {
-            (k == "GLASS_IOS_UDID").then(|| "BBB".to_string())
+            (k == "GLASS_IOS_DEVICE").then(|| "iPhone 16".to_string())
         });
-        assert_eq!(facts, known(Some("iPhone 17 Pro"), Some(("BBB", true))));
+        assert!(
+            matches!(&facts, TargetFacts::Unresolvable(why) if why.contains("iPhone 16")),
+            "{facts:?}"
+        );
+    }
+
+    #[test]
+    fn a_booted_device_wins_over_a_name_preference_that_matches_nothing() {
+        // Measured from `resolve`: the booted branch ignores `want_name` entirely. Pinned here so
+        // the doctor's "what would a driving call do" claim stays true if that ordering changes.
+        let devices = vec![dev("BBB", "iPhone 17 Pro", "Booted")];
+        assert_eq!(
+            target_from(&devices, None, Some("iPhone 16")),
+            TargetFacts::Attaching {
+                name: "iPhone 17 Pro".into(),
+                available: 1,
+            }
+        );
     }
 
     #[test]
     fn all_green_when_fully_configured() {
         let runtimes = vec!["iOS 26.5".to_string()];
-        let iphones = vec!["iPhone 17".to_string()];
         let p = Probe {
             xcode_dir: Some("/Applications/Xcode.app/Contents/Developer".into()),
             simctl_ok: true,
             runtimes: &runtimes,
-            iphones: &iphones,
-            target: &known(Some("iPhone 17"), None),
+            target: &TargetFacts::Attaching {
+                name: "iPhone 17".into(),
+                available: 1,
+            },
         };
         let cs = build_checks(&p);
         assert!(cs.iter().all(|c| c.status == CheckStatus::Ok), "{cs:?}");
@@ -627,8 +678,7 @@ mod tests {
             xcode_dir: Some("/Library/Developer/CommandLineTools".into()),
             simctl_ok: false,
             runtimes: &[],
-            iphones: &[],
-            target: &known(None, None),
+            target: &TargetFacts::Unresolvable("no available iPhone simulator found".into()),
         };
         let cs = build_checks(&p);
         let xcode = cs.iter().find(|c| c.name == "xcode").unwrap();
@@ -652,8 +702,7 @@ mod tests {
             xcode_dir: None,
             simctl_ok: false,
             runtimes: &[],
-            iphones: &[],
-            target: &known(None, None),
+            target: &TargetFacts::Unresolvable("no available iPhone simulator found".into()),
         };
         let cs = build_checks(&p);
         let xcode = cs.iter().find(|c| c.name == "xcode").unwrap();
@@ -671,8 +720,7 @@ mod tests {
             xcode_dir: Some("/Applications/Xcode.app/Contents/Developer".into()),
             simctl_ok: true,
             runtimes: &[],
-            iphones: &[],
-            target: &known(None, None),
+            target: &TargetFacts::Unresolvable("no available iPhone simulator found".into()),
         };
         let cs = build_checks(&p);
         assert_eq!(

--- a/crates/glass-ios/src/doctor.rs
+++ b/crates/glass-ios/src/doctor.rs
@@ -1,6 +1,6 @@
 //! `glass doctor` checks for the iOS Simulator backend: is a full Xcode install active,
-//! does `xcrun simctl` work, is at least one iOS runtime downloaded, and is an iPhone
-//! simulator available to run apps on?
+//! does `xcrun simctl` work, is at least one iOS runtime downloaded, is an iPhone simulator
+//! available to run apps on, and will the target glass resolves at start actually be driveable?
 //!
 //! Pure `build_checks(&Probe)` over observed state, plus the thin subprocess-probing
 //! `checks(deep)` entry point the aggregator calls.
@@ -14,9 +14,10 @@ use glass_core::{Check, CheckStatus, GlassError};
 use crate::device::{Resolve, SimDevice, parse_devices, resolve};
 use crate::idb::companion::{IdbCompanion, companion_bin, companion_present_with};
 use crate::simctl::Simctl;
+use crate::target::wants;
 
-/// Observed host state for the iOS doctor checks. Captured by `run`, consumed by the
-/// pure `checks` so all branch logic is unit-testable without subprocesses.
+/// Observed host state for the iOS doctor checks. Captured by [`checks`], consumed by the pure
+/// [`build_checks`] so all branch logic is unit-testable without subprocesses.
 pub struct Probe<'a> {
     /// `xcode-select -p` output: the active developer directory, if any.
     pub xcode_dir: Option<String>,
@@ -26,9 +27,29 @@ pub struct Probe<'a> {
     pub runtimes: &'a [String],
     /// iPhone simulator lines from `xcrun simctl list devices available`.
     pub iphones: &'a [String],
-    /// Name of an already-booted iOS simulator, if any. Everything glass does on iOS needs a booted
-    /// target, and booting one is not the doctor's business.
-    pub booted: Option<&'a str>,
+    /// What the device listing said about the target glass would drive.
+    pub target: &'a TargetFacts,
+}
+
+/// What the doctor could learn about the simulator glass would drive at start.
+///
+/// Three-valued on purpose: a listing that failed is not a host with nothing booted, and reporting
+/// one as the other is how a diagnostic sends an operator to fix something that is not broken.
+#[derive(Debug, PartialEq, Eq)]
+pub enum TargetFacts {
+    /// The listing was read.
+    Known {
+        /// Name of an already-booted iOS-family simulator (an iPad counts — `resolve` drives any
+        /// iOS-family device, and only *prefers* an iPhone), if any.
+        booted: Option<String>,
+        /// `GLASS_IOS_UDID`, when set: glass attaches to that udid **without booting it**, so a
+        /// shut-down one makes every call fail against a dead target.
+        pinned_udid: Option<String>,
+        /// Whether `pinned_udid` names a device the listing reports as booted.
+        pinned_is_booted: bool,
+    },
+    /// The listing could not be read, carrying why.
+    Unknown(String),
 }
 
 const INSTALL_XCODE_REMEDY: &str =
@@ -90,27 +111,62 @@ fn runtime_check(p: &Probe) -> Check {
 }
 
 fn device_check(p: &Probe) -> Check {
-    match (p.iphones.is_empty(), p.booted) {
-        (true, _) => Check::new("device", CheckStatus::Fail, "no iPhone simulator available")
-            .with_remedy(
-                "create one in Xcode (Window > Devices and Simulators) or with `xcrun simctl create`",
-            ),
-        // Available is not driveable: every iOS tool needs a *booted* target, so a host with twelve
-        // simulators and none booted used to read green and then fail on the first call.
-        (false, None) => Check::new(
-            "device",
-            CheckStatus::Warn,
-            format!(
-                "{} iPhone simulator(s) available, none booted",
-                p.iphones.len()
-            ),
-        )
-        .with_remedy("boot one with `xcrun simctl boot <udid>` (glass does not boot it for you here)"),
-        (false, Some(name)) => Check::new(
+    if p.iphones.is_empty() {
+        return Check::new("device", CheckStatus::Fail, "no iPhone simulator available").with_remedy(
+            "create one in Xcode (Window > Devices and Simulators) or with `xcrun simctl create`",
+        );
+    }
+    let n = p.iphones.len();
+    match p.target {
+        // Nothing booted is the ordinary cold state, not a finding: `SimTarget::from_env` boots one
+        // with `bootstatus -b` at start. Warning here would prescribe a command glass runs itself.
+        TargetFacts::Known {
+            pinned_udid: None,
+            booted,
+            ..
+        } => Check::new(
             "device",
             CheckStatus::Ok,
-            format!("{} available, booted: {name}", p.iphones.len()),
+            match booted {
+                Some(name) => format!("{n} iPhone simulator(s) available, booted: {name}"),
+                None => format!(
+                    "{n} iPhone simulator(s) available, none booted (glass boots one at start)"
+                ),
+            },
         ),
+        // A pinned udid is the one case the start path will not boot for you: `resolve` returns it
+        // unconditionally, so a shut-down one is a dead target and every call fails against it.
+        TargetFacts::Known {
+            pinned_udid: Some(udid),
+            pinned_is_booted: false,
+            ..
+        } => Check::new(
+            "device",
+            CheckStatus::Fail,
+            format!(
+                "GLASS_IOS_UDID pins {udid}, which is not booted — glass attaches to a pinned udid \
+                 without booting it, so every call would fail against a dead target"
+            ),
+        )
+        .with_remedy(format!(
+            "boot it with `xcrun simctl boot {udid}`, or unset GLASS_IOS_UDID and let glass pick"
+        )),
+        TargetFacts::Known {
+            pinned_udid: Some(udid),
+            ..
+        } => Check::new(
+            "device",
+            CheckStatus::Ok,
+            format!(
+                "{n} iPhone simulator(s) available; GLASS_IOS_UDID pins {udid}, which is booted"
+            ),
+        ),
+        TargetFacts::Unknown(cause) => Check::new(
+            "device",
+            CheckStatus::Warn,
+            format!("{n} iPhone simulator(s) available; could not tell what is booted: {cause}"),
+        )
+        .with_remedy("run `xcrun simctl list devices available --json` and check it parses"),
     }
 }
 
@@ -162,18 +218,14 @@ pub fn checks(_deep: bool) -> Vec<Check> {
         .map(|l| l.trim().to_string())
         .collect();
 
-    // The same listing `booted_udid` reads, by name rather than udid: a name is what the operator
-    // sees in Xcode. Nothing here boots anything — doctor reports on the host, it does not change it.
-    let booted = simctl_out(&["simctl", "list", "devices", "available", "--json"])
-        .and_then(|json| parse_devices(&json).ok())
-        .and_then(|devices| booted_name(&devices));
+    let target = gather_target(&simctl_out, &|k| std::env::var(k).ok());
 
     build_checks(&Probe {
         xcode_dir,
         simctl_ok,
         runtimes: &runtimes,
         iphones: &iphones,
-        booted: booted.as_deref(),
+        target: &target,
     })
 }
 
@@ -320,8 +372,39 @@ fn booted_udid() -> Option<String> {
     booted_from(&parse_devices(&list).ok()?)
 }
 
-/// Name of an already-booted iOS simulator, chosen the same way [`booted_from`] chooses its udid so
-/// the reported device is the one a driving call would attach to.
+/// Read the device listing once and answer what the start path would do with it.
+///
+/// Every failure to read it becomes [`TargetFacts::Unknown`] carrying the cause, rather than the
+/// `None` that means "nothing is booted": a timed-out or unparseable listing reported as "none
+/// booted" is a remedy the operator cannot follow to green.
+fn gather_target(
+    simctl_out: &dyn Fn(&[&str]) -> Option<String>,
+    env: &dyn Fn(&str) -> Option<String>,
+) -> TargetFacts {
+    let Some(json) = simctl_out(&["simctl", "list", "devices", "available", "--json"]) else {
+        return TargetFacts::Unknown("`xcrun simctl list devices --json` did not answer".into());
+    };
+    match parse_devices(&json) {
+        Ok(devices) => target_from(&devices, wants(env).0),
+        Err(e) => TargetFacts::Unknown(e.to_string()),
+    }
+}
+
+/// The pure half of [`gather_target`]: what the listing says about the target glass would drive.
+fn target_from(devices: &[SimDevice], pinned_udid: Option<String>) -> TargetFacts {
+    let booted = booted_name(devices);
+    let pinned_is_booted = pinned_udid
+        .as_deref()
+        .is_some_and(|u| devices.iter().any(|d| d.udid == u && d.state == "Booted"));
+    TargetFacts::Known {
+        booted,
+        pinned_udid,
+        pinned_is_booted,
+    }
+}
+
+/// Name of the already-booted simulator [`booted_from`] would attach to — the same selection a
+/// driving call makes when `GLASS_IOS_UDID` is unset (a pinned udid bypasses this entirely).
 fn booted_name(devices: &[SimDevice]) -> Option<String> {
     let udid = booted_from(devices)?;
     devices
@@ -358,11 +441,20 @@ mod tests {
     }
 
     fn dev(udid: &str, name: &str, state: &str) -> SimDevice {
+        dev_on(
+            udid,
+            name,
+            state,
+            "com.apple.CoreSimulator.SimRuntime.iOS-26-5",
+        )
+    }
+
+    fn dev_on(udid: &str, name: &str, state: &str, runtime: &str) -> SimDevice {
         SimDevice {
             udid: udid.into(),
             name: name.into(),
             state: state.into(),
-            runtime: "com.apple.CoreSimulator.SimRuntime.iOS-26-5".into(),
+            runtime: runtime.into(),
             is_available: true,
         }
     }
@@ -385,10 +477,16 @@ mod tests {
         assert_eq!(booted_from(&devices), None);
     }
 
-    #[test]
-    fn simulators_available_but_none_booted_is_not_green() {
-        // The gap this closes: everything glass does on iOS needs a booted target, so reporting
-        // "12 iPhone simulator(s) available" as Ok sent an operator into a run that could not work.
+    /// A read listing, with an optional booted device and an optional `GLASS_IOS_UDID` pin.
+    fn known(booted: Option<&str>, pinned: Option<(&str, bool)>) -> TargetFacts {
+        TargetFacts::Known {
+            booted: booted.map(Into::into),
+            pinned_udid: pinned.map(|(u, _)| u.to_string()),
+            pinned_is_booted: pinned.is_some_and(|(_, b)| b),
+        }
+    }
+
+    fn device_line(target: &TargetFacts) -> Check {
         let runtimes = vec!["iOS 26.5".to_string()];
         let iphones = vec!["iPhone 17".to_string(), "iPhone 17 Pro".to_string()];
         let p = Probe {
@@ -396,47 +494,116 @@ mod tests {
             simctl_ok: true,
             runtimes: &runtimes,
             iphones: &iphones,
-            booted: None,
+            target,
         };
-        let device = build_checks(&p)
+        build_checks(&p)
             .into_iter()
             .find(|c| c.name == "device")
-            .unwrap();
-        assert_eq!(device.status, CheckStatus::Warn);
-        assert!(
-            device.remedy.as_deref().unwrap().contains("simctl boot"),
-            "{:?}",
-            device.remedy
-        );
+            .unwrap()
+    }
+
+    #[test]
+    fn nothing_booted_is_not_a_finding_because_glass_boots_one_at_start() {
+        // `SimTarget::from_env` runs `bootstatus -b` when nothing is booted, so warning here would
+        // prescribe a command glass runs itself, on a host with nothing wrong with it.
+        let c = device_line(&known(None, None));
+        assert_eq!(c.status, CheckStatus::Ok);
+        assert!(c.detail.contains("boots one at start"), "{}", c.detail);
     }
 
     #[test]
     fn a_booted_simulator_is_named_so_the_operator_knows_which_one() {
-        let runtimes = vec!["iOS 26.5".to_string()];
-        let iphones = vec!["iPhone 17".to_string(), "iPhone 17 Pro".to_string()];
-        let p = Probe {
-            xcode_dir: Some("/Applications/Xcode.app/Contents/Developer".into()),
-            simctl_ok: true,
-            runtimes: &runtimes,
-            iphones: &iphones,
-            booted: Some("iPhone 17 Pro"),
-        };
-        let device = build_checks(&p)
-            .into_iter()
-            .find(|c| c.name == "device")
-            .unwrap();
-        assert_eq!(device.status, CheckStatus::Ok);
-        assert!(device.detail.contains("iPhone 17 Pro"), "{}", device.detail);
+        let c = device_line(&known(Some("iPhone 17 Pro"), None));
+        assert_eq!(c.status, CheckStatus::Ok);
+        assert!(c.detail.contains("iPhone 17 Pro"), "{}", c.detail);
+    }
+
+    #[test]
+    fn a_pinned_udid_that_is_not_booted_is_the_one_state_start_will_not_fix() {
+        // `resolve` returns a pinned udid without checking its state and without booting it, so
+        // glass attaches to a dead target and every later call fails against it.
+        let c = device_line(&known(Some("iPhone 17 Pro"), Some(("DEAD-UDID", false))));
+        assert_eq!(c.status, CheckStatus::Fail);
+        assert!(c.detail.contains("DEAD-UDID"), "{}", c.detail);
+        assert!(
+            c.remedy.as_deref().unwrap().contains("GLASS_IOS_UDID"),
+            "{:?}",
+            c.remedy
+        );
+    }
+
+    #[test]
+    fn a_pinned_udid_that_is_booted_is_reported_not_warned_about() {
+        let c = device_line(&known(None, Some(("LIVE-UDID", true))));
+        assert_eq!(c.status, CheckStatus::Ok);
+        assert!(c.detail.contains("LIVE-UDID"), "{}", c.detail);
+    }
+
+    #[test]
+    fn a_listing_that_could_not_be_read_says_so_instead_of_none_booted() {
+        // The failure this shape exists to prevent: a timed-out or unparseable listing reported as
+        // "nothing booted" is a remedy the operator cannot follow to green.
+        let c = device_line(&TargetFacts::Unknown(
+            "simctl list JSON parse failed: eof".into(),
+        ));
+        assert_eq!(c.status, CheckStatus::Warn);
+        assert!(c.detail.contains("parse failed"), "{}", c.detail);
+        assert!(
+            !c.remedy.as_deref().unwrap().contains("simctl boot"),
+            "must not prescribe booting: {:?}",
+            c.remedy
+        );
     }
 
     #[test]
     fn booted_name_reports_the_device_a_driving_call_would_attach_to() {
+        // Two booted devices and a non-iOS one: a naive "first booted" pick names the watch or the
+        // wrong simulator, which is not what `resolve` — and so a driving call — would attach to.
+        let devices = vec![
+            dev_on(
+                "WATCH",
+                "Apple Watch Series 10",
+                "Booted",
+                "com.apple.CoreSimulator.SimRuntime.watchOS-10-4",
+            ),
+            dev("IPAD", "iPad Pro 13-inch", "Booted"),
+            dev("PHONE", "iPhone 17 Pro", "Booted"),
+        ];
+        assert_eq!(booted_name(&devices), Some("iPhone 17 Pro".to_string()));
+        // A booted watch is not a target: nothing iOS-family is booted here.
+        assert_eq!(booted_name(&devices[..1]), None);
+    }
+
+    #[test]
+    fn a_pin_is_only_booted_when_the_listing_says_that_exact_udid_is() {
         let devices = vec![
             dev("AAA", "iPhone 17", "Shutdown"),
             dev("BBB", "iPhone 17 Pro", "Booted"),
         ];
-        assert_eq!(booted_name(&devices), Some("iPhone 17 Pro".to_string()));
-        assert_eq!(booted_name(&devices[..1]), None);
+        assert_eq!(
+            target_from(&devices, Some("AAA".into())),
+            known(Some("iPhone 17 Pro"), Some(("AAA", false)))
+        );
+        assert_eq!(
+            target_from(&devices, Some("BBB".into())),
+            known(Some("iPhone 17 Pro"), Some(("BBB", true)))
+        );
+    }
+
+    #[test]
+    fn a_listing_that_does_not_answer_is_unknown_not_empty() {
+        let facts = gather_target(&|_| None, &|_| None);
+        assert!(matches!(facts, TargetFacts::Unknown(_)), "{facts:?}");
+    }
+
+    #[test]
+    fn a_read_listing_carries_the_pin_from_the_environment() {
+        let json = r#"{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-26-5":[
+            {"udid":"BBB","name":"iPhone 17 Pro","state":"Booted","isAvailable":true}]}}"#;
+        let facts = gather_target(&|_| Some(json.to_string()), &|k| {
+            (k == "GLASS_IOS_UDID").then(|| "BBB".to_string())
+        });
+        assert_eq!(facts, known(Some("iPhone 17 Pro"), Some(("BBB", true))));
     }
 
     #[test]
@@ -448,7 +615,7 @@ mod tests {
             simctl_ok: true,
             runtimes: &runtimes,
             iphones: &iphones,
-            booted: Some("iPhone 17"),
+            target: &known(Some("iPhone 17"), None),
         };
         let cs = build_checks(&p);
         assert!(cs.iter().all(|c| c.status == CheckStatus::Ok), "{cs:?}");
@@ -461,7 +628,7 @@ mod tests {
             simctl_ok: false,
             runtimes: &[],
             iphones: &[],
-            booted: None,
+            target: &known(None, None),
         };
         let cs = build_checks(&p);
         let xcode = cs.iter().find(|c| c.name == "xcode").unwrap();
@@ -486,7 +653,7 @@ mod tests {
             simctl_ok: false,
             runtimes: &[],
             iphones: &[],
-            booted: None,
+            target: &known(None, None),
         };
         let cs = build_checks(&p);
         let xcode = cs.iter().find(|c| c.name == "xcode").unwrap();
@@ -505,7 +672,7 @@ mod tests {
             simctl_ok: true,
             runtimes: &[],
             iphones: &[],
-            booted: None,
+            target: &known(None, None),
         };
         let cs = build_checks(&p);
         assert_eq!(

--- a/crates/glass-ios/src/doctor.rs
+++ b/crates/glass-ios/src/doctor.rs
@@ -31,10 +31,9 @@ pub struct Probe<'a> {
 
 /// What the doctor could learn about the simulator glass would drive at start.
 ///
-/// Every arm is the outcome of running the *real* resolution the start path runs
-/// ([`crate::device::resolve`] with the same `GLASS_IOS_UDID` / `GLASS_IOS_DEVICE` preferences), so
-/// the doctor reports what would happen rather than a proxy for it. A listing that could not be read
-/// is its own arm: reporting it as "nothing booted" is a remedy the operator cannot follow to green.
+/// Every arm is the outcome of the *real* resolution the start path runs ([`crate::device::resolve`],
+/// with the same `GLASS_IOS_UDID` / `GLASS_IOS_DEVICE` preferences). A listing that could not be read
+/// is its own arm: reported as "nothing booted", it is a remedy the operator cannot follow to green.
 #[derive(Debug, PartialEq, Eq)]
 pub enum TargetFacts {
     /// A booted device glass would attach to, and how many iOS-family simulators are available.
@@ -374,8 +373,8 @@ fn booted_udid() -> Option<String> {
 
 /// Read the device listing once and answer what the start path would do with it.
 ///
-/// One listing, not two: a second `simctl` call is a second thing that can fail, and when both fail
-/// the doctor has to describe the failure rather than infer an empty host from it.
+/// One listing, not two: a second `simctl` call is a second thing that can fail, and a failed
+/// listing has to be described rather than read as an empty host.
 fn gather_target(
     simctl_out: &dyn Fn(&[&str]) -> Option<String>,
     env: &dyn Fn(&str) -> Option<String>,
@@ -395,9 +394,8 @@ fn gather_target(
 
 /// The pure half of [`gather_target`]: run the start path's own resolution and describe its outcome.
 ///
-/// Both preferences are passed, because both change what a driving call does: `GLASS_IOS_DEVICE`
-/// naming a simulator this host lacks makes `glass_start` fail outright, which the doctor should say
-/// rather than report a green line about some other device.
+/// Both preferences are passed because both change what a driving call does — `GLASS_IOS_DEVICE`
+/// naming a simulator this host lacks makes `glass_start` fail outright.
 fn target_from(
     devices: &[SimDevice],
     want_udid: Option<&str>,

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -218,7 +218,10 @@ fn diagnose_inner(deep: bool, audit: Option<&crate::audit::AuditReport>) -> Diag
         sections.push(Section::new(
             "accessibility (macos)",
             None,
-            macos_a11y_checks(glass_macos::accessibility_granted()),
+            macos_a11y_checks(
+                glass_macos::accessibility_granted(),
+                glass_a11y_macos::doctor::probe(),
+            ),
         ));
     }
 
@@ -519,35 +522,33 @@ fn macos_checks(resolved_backend: &str) -> Vec<Check> {
     )
 }
 
-/// The "accessibility (macos)" section: the `glass-a11y-macos` reader (AXUIElement) is a
-/// system framework, not an optional install like Linux's AT-SPI daemon or a service that
-/// needs spinning up — so it's always present in a macOS build, and the only real
-/// precondition left to report is the Accessibility TCC grant itself. Pure — takes the
-/// already-gathered grant fact, makes no OS calls — so it's unit-tested without needing a
-/// real grant, mirroring `glass_a11y_linux::doctor::a11y_checks`/
-/// `glass_a11y_windows::doctor::a11y_checks`.
+/// The "accessibility (macos)" section: the reader line comes from a real system-wide AX read
+/// (`glass_a11y_macos::doctor`), and the Accessibility TCC grant is reported beside it.
+///
+/// The two answer different questions and keep different remedies: the reader line says whether the
+/// AX API responded at all — which a *granted* process still fails against a locked screen — and the
+/// grant line says whether this binary is trusted. Pure: it takes both facts already gathered, so
+/// it is unit-tested without a grant or a live AX stack, mirroring
+/// `glass_a11y_linux::doctor::a11y_checks`/`glass_a11y_windows::doctor::a11y_checks`.
 #[cfg(target_os = "macos")]
-fn macos_a11y_checks(accessibility_granted: bool) -> Vec<Check> {
-    vec![
+fn macos_a11y_checks(
+    accessibility_granted: bool,
+    probe: glass_a11y_macos::doctor::SystemWideProbe,
+) -> Vec<Check> {
+    let mut checks = glass_a11y_macos::doctor::a11y_checks(probe);
+    checks.push(if accessibility_granted {
+        Check::new("Accessibility", CheckStatus::Ok, "granted")
+    } else {
         Check::new(
-            "a11y reader",
-            CheckStatus::Ok,
-            "AXUIElement reader available — glass_a11y_snapshot / glass_a11y_marks / \
-             glass_click_element / glass_set_value will work once Accessibility is granted (see below)",
-        ),
-        if accessibility_granted {
-            Check::new("Accessibility", CheckStatus::Ok, "granted")
-        } else {
-            Check::new(
-                "Accessibility",
-                CheckStatus::Fail,
-                "not granted — glass_a11y_snapshot / glass_a11y_marks / glass_click_element / \
-                 glass_set_value will fail with a permission error",
-            )
-            .with_remedy(glass_macos::accessibility_remedy())
-            .with_remedy_action(format!("open {}", glass_macos::accessibility_pane_url()))
-        },
-    ]
+            "Accessibility",
+            CheckStatus::Fail,
+            "not granted — glass_a11y_snapshot / glass_a11y_marks / glass_click_element / \
+             glass_set_value will fail with a permission error",
+        )
+        .with_remedy(glass_macos::accessibility_remedy())
+        .with_remedy_action(format!("open {}", glass_macos::accessibility_pane_url()))
+    });
+    checks
 }
 
 #[cfg(test)]
@@ -1112,18 +1113,34 @@ mod tests {
         }
 
         #[test]
-        fn a11y_reader_is_always_reported_present() {
-            // The AXUIElement reader is a system framework compiled unconditionally into
-            // a macOS build — unlike Linux's AT-SPI daemon, there's no "not installed"
-            // state to detect, so this line is always Ok regardless of the grant.
-            let checks = macos_a11y_checks(false);
-            let reader = checks.iter().find(|c| c.name == "a11y reader").unwrap();
-            assert_eq!(reader.status, CheckStatus::Ok);
+        fn the_reader_line_reports_the_probe_not_a_constant() {
+            // The defect this replaced: the line was `Ok` whatever the AX stack was doing, so the
+            // one case an operator needs it for — the reader is not answering — read green.
+            use glass_a11y_macos::doctor::SystemWideProbe;
+            let answered = macos_a11y_checks(true, SystemWideProbe::Answered);
+            let refused = macos_a11y_checks(true, SystemWideProbe::DidNotComplete);
+            assert_eq!(
+                answered
+                    .iter()
+                    .find(|c| c.name == "a11y reader")
+                    .unwrap()
+                    .status,
+                CheckStatus::Ok
+            );
+            assert_eq!(
+                refused
+                    .iter()
+                    .find(|c| c.name == "a11y reader")
+                    .unwrap()
+                    .status,
+                CheckStatus::Fail
+            );
         }
 
         #[test]
-        fn a11y_granted_is_all_ok() {
-            let checks = macos_a11y_checks(true);
+        fn a_granted_process_whose_ax_stack_answers_is_all_ok() {
+            use glass_a11y_macos::doctor::SystemWideProbe;
+            let checks = macos_a11y_checks(true, SystemWideProbe::Answered);
             assert!(
                 checks.iter().all(|c| c.status == CheckStatus::Ok),
                 "{checks:?}"
@@ -1131,8 +1148,27 @@ mod tests {
         }
 
         #[test]
+        fn an_ungranted_process_gets_one_remedy_per_question() {
+            // Ungranted + APIDisabled is one cause with two symptoms. The grant line owns the
+            // System Settings remedy; the reader line points at it rather than repeating it, so the
+            // operator is not given two things to do.
+            use glass_a11y_macos::doctor::SystemWideProbe;
+            let checks = macos_a11y_checks(false, SystemWideProbe::ApiDisabled);
+            let reader = checks.iter().find(|c| c.name == "a11y reader").unwrap();
+            let grant = checks.iter().find(|c| c.name == "Accessibility").unwrap();
+            assert_eq!(
+                grant.remedy.as_deref(),
+                Some(glass_macos::accessibility_remedy())
+            );
+            assert_ne!(reader.remedy, grant.remedy);
+        }
+
+        #[test]
         fn a11y_not_granted_fails_with_the_shared_remedy() {
-            let checks = macos_a11y_checks(false);
+            let checks = macos_a11y_checks(
+                false,
+                glass_a11y_macos::doctor::SystemWideProbe::ApiDisabled,
+            );
             let c = checks.iter().find(|c| c.name == "Accessibility").unwrap();
             assert_eq!(c.status, CheckStatus::Fail);
             // Same remedy string as the "macos" section's own Accessibility check — no
@@ -1145,7 +1181,10 @@ mod tests {
 
         #[test]
         fn a11y_not_granted_points_at_the_accessibility_pane() {
-            let checks = macos_a11y_checks(false);
+            let checks = macos_a11y_checks(
+                false,
+                glass_a11y_macos::doctor::SystemWideProbe::ApiDisabled,
+            );
             let c = checks.iter().find(|c| c.name == "Accessibility").unwrap();
             // Same pane URL as the "macos" section's own Accessibility check — kept in
             // sync for the same reason as the shared remedy string above.

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -221,7 +221,7 @@ fn diagnose_inner(deep: bool, audit: Option<&crate::audit::AuditReport>) -> Diag
             macos_a11y_checks(
                 glass_a11y_macos::doctor::probe(),
                 glass_macos::accessibility_granted(),
-                glass_macos::session_state() == glass_macos::SessionState::Locked,
+                console_session(glass_macos::session_state()),
             ),
         ));
     }
@@ -523,6 +523,19 @@ fn macos_checks(resolved_backend: &str) -> Vec<Check> {
     )
 }
 
+/// Translate the platform crate's session read into the a11y reader's vocabulary. Nobody at the
+/// console is not the same as a locked screen: unlocking is not the remedy, and the reader line
+/// would otherwise assert "unlocked" two lines under a `display awake` check saying the opposite.
+#[cfg(target_os = "macos")]
+fn console_session(state: glass_macos::SessionState) -> glass_a11y_macos::doctor::ConsoleSession {
+    use glass_a11y_macos::doctor::ConsoleSession;
+    match state {
+        glass_macos::SessionState::Unlocked => ConsoleSession::Unlocked,
+        glass_macos::SessionState::Locked => ConsoleSession::Locked,
+        glass_macos::SessionState::NoSession => ConsoleSession::NoSession,
+    }
+}
+
 /// The "accessibility (macos)" section: the reader line, from a real system-wide AX read, and the
 /// Accessibility TCC grant beside it.
 ///
@@ -537,10 +550,9 @@ fn macos_checks(resolved_backend: &str) -> Vec<Check> {
 fn macos_a11y_checks(
     probe: glass_a11y_macos::doctor::SystemWideProbe,
     accessibility_granted: bool,
-    session_locked: bool,
+    session: glass_a11y_macos::doctor::ConsoleSession,
 ) -> Vec<Check> {
-    let mut checks =
-        glass_a11y_macos::doctor::a11y_checks(probe, accessibility_granted, session_locked);
+    let mut checks = glass_a11y_macos::doctor::a11y_checks(probe, accessibility_granted, session);
     checks.push(if accessibility_granted {
         Check::new("Accessibility", CheckStatus::Ok, "granted")
     } else {
@@ -1121,9 +1133,14 @@ mod tests {
         fn the_reader_line_reports_the_probe_not_a_constant() {
             // The defect this replaced: the line was `Ok` whatever the AX stack was doing, so the
             // one case an operator needs it for — the reader is not answering — read green.
-            use glass_a11y_macos::doctor::SystemWideProbe;
-            let answered = macos_a11y_checks(SystemWideProbe::Answered, true, false);
-            let refused = macos_a11y_checks(SystemWideProbe::DidNotComplete, true, false);
+            use glass_a11y_macos::doctor::{ConsoleSession, SystemWideProbe};
+            let answered =
+                macos_a11y_checks(SystemWideProbe::Answered, true, ConsoleSession::Unlocked);
+            let refused = macos_a11y_checks(
+                SystemWideProbe::DidNotComplete,
+                true,
+                ConsoleSession::Unlocked,
+            );
             assert_eq!(
                 answered
                     .iter()
@@ -1144,8 +1161,9 @@ mod tests {
 
         #[test]
         fn a_granted_process_whose_ax_stack_answers_is_all_ok() {
-            use glass_a11y_macos::doctor::SystemWideProbe;
-            let checks = macos_a11y_checks(SystemWideProbe::Answered, true, false);
+            use glass_a11y_macos::doctor::{ConsoleSession, SystemWideProbe};
+            let checks =
+                macos_a11y_checks(SystemWideProbe::Answered, true, ConsoleSession::Unlocked);
             assert!(
                 checks.iter().all(|c| c.status == CheckStatus::Ok),
                 "{checks:?}"
@@ -1156,8 +1174,12 @@ mod tests {
         fn an_ungranted_process_gets_one_remedy_per_question() {
             // The grant line owns the System Settings remedy; the reader line points at it rather
             // than repeating it, so the operator is given one thing to do rather than two.
-            use glass_a11y_macos::doctor::SystemWideProbe;
-            let checks = macos_a11y_checks(SystemWideProbe::DidNotComplete, false, false);
+            use glass_a11y_macos::doctor::{ConsoleSession, SystemWideProbe};
+            let checks = macos_a11y_checks(
+                SystemWideProbe::DidNotComplete,
+                false,
+                ConsoleSession::Unlocked,
+            );
             let reader = checks.iter().find(|c| c.name == "a11y reader").unwrap();
             let grant = checks.iter().find(|c| c.name == "Accessibility").unwrap();
             assert_eq!(
@@ -1180,9 +1202,13 @@ mod tests {
         fn a_locked_session_does_not_fail_the_whole_run() {
             // This section is always critical (`backend: None`), so a `Fail` here exits non-zero
             // even for someone driving android on a Mac. A locked screen is transient and not a
-            // configuration defect, so it warns.
-            use glass_a11y_macos::doctor::SystemWideProbe;
-            let checks = macos_a11y_checks(SystemWideProbe::DidNotComplete, true, true);
+            // configuration defect, so it warns — asserted here rather than left to the comment.
+            use glass_a11y_macos::doctor::{ConsoleSession, SystemWideProbe};
+            let checks = macos_a11y_checks(
+                SystemWideProbe::DidNotComplete,
+                true,
+                ConsoleSession::Locked,
+            );
             let reader = checks.iter().find(|c| c.name == "a11y reader").unwrap();
             assert_eq!(reader.status, CheckStatus::Warn);
         }
@@ -1192,7 +1218,7 @@ mod tests {
             let checks = macos_a11y_checks(
                 glass_a11y_macos::doctor::SystemWideProbe::ApiDisabled,
                 false,
-                false,
+                glass_a11y_macos::doctor::ConsoleSession::Unlocked,
             );
             let c = checks.iter().find(|c| c.name == "Accessibility").unwrap();
             assert_eq!(c.status, CheckStatus::Fail);
@@ -1209,7 +1235,7 @@ mod tests {
             let checks = macos_a11y_checks(
                 glass_a11y_macos::doctor::SystemWideProbe::ApiDisabled,
                 false,
-                false,
+                glass_a11y_macos::doctor::ConsoleSession::Unlocked,
             );
             let c = checks.iter().find(|c| c.name == "Accessibility").unwrap();
             // Same pane URL as the "macos" section's own Accessibility check — kept in

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -523,15 +523,17 @@ fn macos_checks(resolved_backend: &str) -> Vec<Check> {
     )
 }
 
-/// Translate the platform crate's session read into the a11y reader's vocabulary. Nobody at the
-/// console is not the same as a locked screen: unlocking is not the remedy, and the reader line
-/// would otherwise assert "unlocked" two lines under a `display awake` check saying the opposite.
+/// Translate the platform crate's session read into the a11y reader's vocabulary.
+///
+/// Locked collapses into `LoggedIn`: a locked session was measured not to change what the probe
+/// returns, and the lock's real consequence is already the `display awake` check's to report.
 #[cfg(target_os = "macos")]
 fn console_session(state: glass_macos::SessionState) -> glass_a11y_macos::doctor::ConsoleSession {
     use glass_a11y_macos::doctor::ConsoleSession;
     match state {
-        glass_macos::SessionState::Unlocked => ConsoleSession::Unlocked,
-        glass_macos::SessionState::Locked => ConsoleSession::Locked,
+        glass_macos::SessionState::Unlocked | glass_macos::SessionState::Locked => {
+            ConsoleSession::LoggedIn
+        }
         glass_macos::SessionState::NoSession => ConsoleSession::NoSession,
     }
 }
@@ -1135,11 +1137,11 @@ mod tests {
             // one case an operator needs it for — the reader is not answering — read green.
             use glass_a11y_macos::doctor::{ConsoleSession, SystemWideProbe};
             let answered =
-                macos_a11y_checks(SystemWideProbe::Answered, true, ConsoleSession::Unlocked);
+                macos_a11y_checks(SystemWideProbe::Answered, true, ConsoleSession::LoggedIn);
             let refused = macos_a11y_checks(
                 SystemWideProbe::DidNotComplete,
                 true,
-                ConsoleSession::Unlocked,
+                ConsoleSession::LoggedIn,
             );
             assert_eq!(
                 answered
@@ -1163,7 +1165,7 @@ mod tests {
         fn a_granted_process_whose_ax_stack_answers_is_all_ok() {
             use glass_a11y_macos::doctor::{ConsoleSession, SystemWideProbe};
             let checks =
-                macos_a11y_checks(SystemWideProbe::Answered, true, ConsoleSession::Unlocked);
+                macos_a11y_checks(SystemWideProbe::Answered, true, ConsoleSession::LoggedIn);
             assert!(
                 checks.iter().all(|c| c.status == CheckStatus::Ok),
                 "{checks:?}"
@@ -1178,7 +1180,7 @@ mod tests {
             let checks = macos_a11y_checks(
                 SystemWideProbe::DidNotComplete,
                 false,
-                ConsoleSession::Unlocked,
+                ConsoleSession::LoggedIn,
             );
             let reader = checks.iter().find(|c| c.name == "a11y reader").unwrap();
             let grant = checks.iter().find(|c| c.name == "Accessibility").unwrap();
@@ -1206,11 +1208,13 @@ mod tests {
             use glass_a11y_macos::doctor::ConsoleSession;
             assert_eq!(
                 console_session(glass_macos::SessionState::Unlocked),
-                ConsoleSession::Unlocked
+                ConsoleSession::LoggedIn
             );
+            // Measured: a locked session does not change what the probe returns, so it maps to the
+            // same vocabulary as unlocked and the lock is reported by `display awake` alone.
             assert_eq!(
                 console_session(glass_macos::SessionState::Locked),
-                ConsoleSession::Locked
+                ConsoleSession::LoggedIn
             );
             assert_eq!(
                 console_session(glass_macos::SessionState::NoSession),
@@ -1219,15 +1223,15 @@ mod tests {
         }
 
         #[test]
-        fn a_locked_session_does_not_fail_the_whole_run() {
+        fn a_console_with_nobody_logged_in_does_not_fail_the_whole_run() {
             // This section is always critical (`backend: None`), so a `Fail` here exits non-zero
-            // even for someone driving android on a Mac. A locked screen is transient and not a
-            // configuration defect, so it warns — asserted here rather than left to the comment.
+            // even for someone driving android on a Mac. Nobody at the console is not a broken
+            // install, so it warns — asserted here rather than left to the comment.
             use glass_a11y_macos::doctor::{ConsoleSession, SystemWideProbe};
             let checks = macos_a11y_checks(
                 SystemWideProbe::DidNotComplete,
                 true,
-                ConsoleSession::Locked,
+                ConsoleSession::NoSession,
             );
             let reader = checks.iter().find(|c| c.name == "a11y reader").unwrap();
             assert_eq!(reader.status, CheckStatus::Warn);
@@ -1238,7 +1242,7 @@ mod tests {
             let checks = macos_a11y_checks(
                 glass_a11y_macos::doctor::SystemWideProbe::ApiDisabled,
                 false,
-                glass_a11y_macos::doctor::ConsoleSession::Unlocked,
+                glass_a11y_macos::doctor::ConsoleSession::LoggedIn,
             );
             let c = checks.iter().find(|c| c.name == "Accessibility").unwrap();
             assert_eq!(c.status, CheckStatus::Fail);
@@ -1255,7 +1259,7 @@ mod tests {
             let checks = macos_a11y_checks(
                 glass_a11y_macos::doctor::SystemWideProbe::ApiDisabled,
                 false,
-                glass_a11y_macos::doctor::ConsoleSession::Unlocked,
+                glass_a11y_macos::doctor::ConsoleSession::LoggedIn,
             );
             let c = checks.iter().find(|c| c.name == "Accessibility").unwrap();
             // Same pane URL as the "macos" section's own Accessibility check — kept in

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -219,8 +219,9 @@ fn diagnose_inner(deep: bool, audit: Option<&crate::audit::AuditReport>) -> Diag
             "accessibility (macos)",
             None,
             macos_a11y_checks(
-                glass_macos::accessibility_granted(),
                 glass_a11y_macos::doctor::probe(),
+                glass_macos::accessibility_granted(),
+                glass_macos::session_state() == glass_macos::SessionState::Locked,
             ),
         ));
     }
@@ -522,20 +523,24 @@ fn macos_checks(resolved_backend: &str) -> Vec<Check> {
     )
 }
 
-/// The "accessibility (macos)" section: the reader line comes from a real system-wide AX read
-/// (`glass_a11y_macos::doctor`), and the Accessibility TCC grant is reported beside it.
+/// The "accessibility (macos)" section: the reader line, from a real system-wide AX read, and the
+/// Accessibility TCC grant beside it.
 ///
 /// The two answer different questions and keep different remedies: the reader line says whether the
-/// AX API responded at all — which a *granted* process still fails against a locked screen — and the
-/// grant line says whether this binary is trusted. Pure: it takes both facts already gathered, so
-/// it is unit-tested without a grant or a live AX stack, mirroring
-/// `glass_a11y_linux::doctor::a11y_checks`/`glass_a11y_windows::doctor::a11y_checks`.
+/// API responded — which a *trusted* process still fails when the accessibility stack is not
+/// answering — and the grant line says whether this binary is trusted. Pure: it takes the three
+/// facts already gathered, so it is unit-tested without a grant, a lock, or a live AX stack,
+/// mirroring `glass_a11y_linux::doctor::a11y_checks`/`glass_a11y_windows::doctor::a11y_checks`.
+///
+/// Argument order matches `glass_a11y_macos::doctor::a11y_checks`, which it delegates to.
 #[cfg(target_os = "macos")]
 fn macos_a11y_checks(
-    accessibility_granted: bool,
     probe: glass_a11y_macos::doctor::SystemWideProbe,
+    accessibility_granted: bool,
+    session_locked: bool,
 ) -> Vec<Check> {
-    let mut checks = glass_a11y_macos::doctor::a11y_checks(probe, accessibility_granted);
+    let mut checks =
+        glass_a11y_macos::doctor::a11y_checks(probe, accessibility_granted, session_locked);
     checks.push(if accessibility_granted {
         Check::new("Accessibility", CheckStatus::Ok, "granted")
     } else {
@@ -1117,8 +1122,8 @@ mod tests {
             // The defect this replaced: the line was `Ok` whatever the AX stack was doing, so the
             // one case an operator needs it for — the reader is not answering — read green.
             use glass_a11y_macos::doctor::SystemWideProbe;
-            let answered = macos_a11y_checks(true, SystemWideProbe::Answered);
-            let refused = macos_a11y_checks(true, SystemWideProbe::DidNotComplete);
+            let answered = macos_a11y_checks(SystemWideProbe::Answered, true, false);
+            let refused = macos_a11y_checks(SystemWideProbe::DidNotComplete, true, false);
             assert_eq!(
                 answered
                     .iter()
@@ -1140,7 +1145,7 @@ mod tests {
         #[test]
         fn a_granted_process_whose_ax_stack_answers_is_all_ok() {
             use glass_a11y_macos::doctor::SystemWideProbe;
-            let checks = macos_a11y_checks(true, SystemWideProbe::Answered);
+            let checks = macos_a11y_checks(SystemWideProbe::Answered, true, false);
             assert!(
                 checks.iter().all(|c| c.status == CheckStatus::Ok),
                 "{checks:?}"
@@ -1149,25 +1154,45 @@ mod tests {
 
         #[test]
         fn an_ungranted_process_gets_one_remedy_per_question() {
-            // Ungranted + APIDisabled is one cause with two symptoms. The grant line owns the
-            // System Settings remedy; the reader line points at it rather than repeating it, so the
-            // operator is not given two things to do.
+            // The grant line owns the System Settings remedy; the reader line points at it rather
+            // than repeating it, so the operator is given one thing to do rather than two.
             use glass_a11y_macos::doctor::SystemWideProbe;
-            let checks = macos_a11y_checks(false, SystemWideProbe::ApiDisabled);
+            let checks = macos_a11y_checks(SystemWideProbe::DidNotComplete, false, false);
             let reader = checks.iter().find(|c| c.name == "a11y reader").unwrap();
             let grant = checks.iter().find(|c| c.name == "Accessibility").unwrap();
             assert_eq!(
                 grant.remedy.as_deref(),
                 Some(glass_macos::accessibility_remedy())
             );
-            assert_ne!(reader.remedy, grant.remedy);
+            // Not `assert_ne!` on the two Options: that passes when the reader line has no remedy
+            // at all, which is the dead end this is meant to rule out.
+            let reader_remedy = reader
+                .remedy
+                .as_deref()
+                .expect("the reader line needs a remedy");
+            assert!(
+                reader_remedy.contains("see the check below"),
+                "{reader_remedy}"
+            );
+        }
+
+        #[test]
+        fn a_locked_session_does_not_fail_the_whole_run() {
+            // This section is always critical (`backend: None`), so a `Fail` here exits non-zero
+            // even for someone driving android on a Mac. A locked screen is transient and not a
+            // configuration defect, so it warns.
+            use glass_a11y_macos::doctor::SystemWideProbe;
+            let checks = macos_a11y_checks(SystemWideProbe::DidNotComplete, true, true);
+            let reader = checks.iter().find(|c| c.name == "a11y reader").unwrap();
+            assert_eq!(reader.status, CheckStatus::Warn);
         }
 
         #[test]
         fn a11y_not_granted_fails_with_the_shared_remedy() {
             let checks = macos_a11y_checks(
-                false,
                 glass_a11y_macos::doctor::SystemWideProbe::ApiDisabled,
+                false,
+                false,
             );
             let c = checks.iter().find(|c| c.name == "Accessibility").unwrap();
             assert_eq!(c.status, CheckStatus::Fail);
@@ -1182,8 +1207,9 @@ mod tests {
         #[test]
         fn a11y_not_granted_points_at_the_accessibility_pane() {
             let checks = macos_a11y_checks(
-                false,
                 glass_a11y_macos::doctor::SystemWideProbe::ApiDisabled,
+                false,
+                false,
             );
             let c = checks.iter().find(|c| c.name == "Accessibility").unwrap();
             // Same pane URL as the "macos" section's own Accessibility check — kept in

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -1199,6 +1199,26 @@ mod tests {
         }
 
         #[test]
+        fn each_session_state_maps_to_its_own_console_meaning() {
+            // The only untested line the a11y wiring added. Swapping two arms compiles and keeps the
+            // workspace green, while telling a locked-screen operator to log in — the contradiction
+            // with `display awake` that three-valuing this was meant to remove.
+            use glass_a11y_macos::doctor::ConsoleSession;
+            assert_eq!(
+                console_session(glass_macos::SessionState::Unlocked),
+                ConsoleSession::Unlocked
+            );
+            assert_eq!(
+                console_session(glass_macos::SessionState::Locked),
+                ConsoleSession::Locked
+            );
+            assert_eq!(
+                console_session(glass_macos::SessionState::NoSession),
+                ConsoleSession::NoSession
+            );
+        }
+
+        #[test]
         fn a_locked_session_does_not_fail_the_whole_run() {
             // This section is always critical (`backend: None`), so a `Fail` here exits non-zero
             // even for someone driving android on a Mac. A locked screen is transient and not a

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -535,7 +535,7 @@ fn macos_a11y_checks(
     accessibility_granted: bool,
     probe: glass_a11y_macos::doctor::SystemWideProbe,
 ) -> Vec<Check> {
-    let mut checks = glass_a11y_macos::doctor::a11y_checks(probe);
+    let mut checks = glass_a11y_macos::doctor::a11y_checks(probe, accessibility_granted);
     checks.push(if accessibility_granted {
         Check::new("Accessibility", CheckStatus::Ok, "granted")
     } else {

--- a/docs/how-to/setup-ios.md
+++ b/docs/how-to/setup-ios.md
@@ -133,10 +133,10 @@ reads the pasteboard over `simctl`, not through an in-app `UIPasteboard` read, s
 GLASS_BACKEND=ios glass-mcp doctor
 ```
 
-Reports whether full Xcode is active, `simctl` works, an iOS runtime is downloaded, an iPhone
-simulator is available (and which one, if any, is already booted — glass boots one itself at start
-unless `GLASS_IOS_UDID` pins a specific device), and `idb_companion` is installed (for input +
-accessibility) — each failing
+Reports whether full Xcode is active, `simctl` works, an iOS runtime is downloaded, which simulator
+glass would drive (it boots one itself at start unless `GLASS_IOS_UDID` pins a specific device — a
+pin that is not booted is reported as a failure, since glass attaches to it without booting), and
+whether `idb_companion` is installed (for input + accessibility) — each failing
 check comes with its own remedy (the commands above). The `[ios]` section (including the
 `idb_companion` line) also appears when iOS is driven per-call from a server whose default backend is
 macOS; there an absent `idb_companion` is shown as an advisory warning rather than a failure, since it

--- a/docs/how-to/setup-ios.md
+++ b/docs/how-to/setup-ios.md
@@ -134,7 +134,9 @@ GLASS_BACKEND=ios glass-mcp doctor
 ```
 
 Reports whether full Xcode is active, `simctl` works, an iOS runtime is downloaded, an iPhone
-simulator is available, and `idb_companion` is installed (for input + accessibility) — each failing
+simulator is available (and which one, if any, is already booted — glass boots one itself at start
+unless `GLASS_IOS_UDID` pins a specific device), and `idb_companion` is installed (for input +
+accessibility) — each failing
 check comes with its own remedy (the commands above). The `[ios]` section (including the
 `idb_companion` line) also appears when iOS is driven per-call from a server whose default backend is
 macOS; there an absent `idb_companion` is shown as an advisory warning rather than a failure, since it

--- a/scripts/test-macos-a11y.sh
+++ b/scripts/test-macos-a11y.sh
@@ -45,11 +45,11 @@ cargo test -p glass-macos --test a11y --no-run
 # pre-builds one so the granted process doesn't need a writable `$TMPDIR` / working
 # `swiftc` invocation in that context. No machine-specific paths are hardcoded here; the
 # out-of-band recipe supplies them at run time.
-# The a11y *doctor* probe is a different matter: reading one attribute off the system-wide
-# element needs a GUI session but no TCC grant, so its `#[ignore]`d live tests can run right
-# here rather than out-of-band. They are what keeps `glass doctor`'s accessibility line from
-# drifting back into a claim nothing measures.
-echo "test-macos-a11y.sh: running the doctor's live system-wide probe tests…"
-cargo test -p glass-a11y-macos --lib ffi::tests -- --ignored --test-threads=1
-
-echo "test-macos-a11y.sh: OK (compile/link, plus the live doctor probe; the granted a11y run happens out-of-band — see comments above)."
+# The a11y *doctor* probe has live tests too (`glass-a11y-macos`, `ffi::tests`, `#[ignore]`d).
+# They need no TCC grant — only a WindowServer session, which this CI runner does not have —
+# so they stay out-of-band like the granted run above:
+#
+#   cargo test -p glass-a11y-macos --lib ffi::tests -- --ignored --test-threads=1
+#
+# Run them on a dev Mac when changing what `glass doctor` reads off the system-wide element.
+echo "test-macos-a11y.sh: OK (compile/link only — the granted run and the live doctor probe happen out-of-band; see comments above)."

--- a/scripts/test-macos-a11y.sh
+++ b/scripts/test-macos-a11y.sh
@@ -45,4 +45,11 @@ cargo test -p glass-macos --test a11y --no-run
 # pre-builds one so the granted process doesn't need a writable `$TMPDIR` / working
 # `swiftc` invocation in that context. No machine-specific paths are hardcoded here; the
 # out-of-band recipe supplies them at run time.
-echo "test-macos-a11y.sh: OK (compile/link only — the granted run happens out-of-band; see comments above)."
+# The a11y *doctor* probe is a different matter: reading one attribute off the system-wide
+# element needs a GUI session but no TCC grant, so its `#[ignore]`d live tests can run right
+# here rather than out-of-band. They are what keeps `glass doctor`'s accessibility line from
+# drifting back into a claim nothing measures.
+echo "test-macos-a11y.sh: running the doctor's live system-wide probe tests…"
+cargo test -p glass-a11y-macos --lib ffi::tests -- --ignored --test-threads=1
+
+echo "test-macos-a11y.sh: OK (compile/link, plus the live doctor probe; the granted a11y run happens out-of-band — see comments above)."


### PR DESCRIPTION
`glass doctor` had a check that could not fail. The macOS `a11y reader` line was a hardcoded
`CheckStatus::Ok` with prose, so the one condition an operator consults it for — the accessibility
reader is not answering — reported green. The iOS `device` line counted simulators that *exist*,
which says nothing about the one glass would actually drive.

## macOS: read the API, then say what it answered

One `AXUIElementCopyAttributeValue` of `AXFocusedApplication` against the system-wide element. No
target application, no mutation, and it exercises the same AX path the reader uses.

The attribute is load-bearing and the code says so: it is *trust-gated*. An untrusted process gets
`kAXErrorCannotComplete` from it, while `AXRole` on the same element answers `Success` — so a cheaper
attribute would report green to a process that cannot read a single tree. There is an `#[ignore]`d
live test pinning the `AXRole` half.

macOS returns one code for several causes, so the line takes the two facts the aggregator has already
gathered — the Accessibility grant and the console session — and names the cause that applies:

| State | Line |
|---|---|
| Not trusted | Fail, pointing at the grant check rather than repeating its remedy |
| Trusted, nobody logged in at the console | Warn — not a broken install |
| Assistive access off despite the grant | Fail, remedy = re-add the binary (a stale TCC record) |
| Trusted, someone logged in, no answer | Fail — this binary was never granted, whatever the trust bit says |
| Unrecognised `AXError` | Fail, carrying the code, with a remedy |

Two constraints shaped this. The session only qualifies the *ambiguous* code: letting it explain the
others downgraded a real defect to "unlock your screen". And every `Fail` carries a remedy, which
`CheckStatus::Fail`'s own doc requires and a test now enforces over all 30 combinations.

The read is bounded by an AX messaging timeout, restored on drop. Setting it on the system-wide
element sets it *process-wide*, so leaving it applied would have capped every later
`glass_a11y_snapshot` in the server — a diagnostic changing what the product does.

## iOS: report the resolution, not a proxy for it

The check now runs `device::resolve` — the same call `SimTarget::from_env` makes at start — and
reports its outcome. That corrected a false premise: **glass boots a simulator itself**
(`bootstatus -b`), so "none booted" is the ordinary cold state and warning about it prescribed a
command glass runs for you. It is `Ok` and says so.

What is now caught is what the start path will *not* fix, because `resolve` returns a pinned
`GLASS_IOS_UDID` without booting or checking it: a pin that is not booted, not present on this host,
or not an iOS simulator at all — each with the remedy that fits, since `simctl boot` on an unknown
udid answers "Invalid device". A `GLASS_IOS_DEVICE` matching nothing is reported against the variable
rather than "create a simulator in Xcode". An iPad-only host is no longer called deviceless. A
listing that cannot be read says that, instead of collapsing into "nothing booted".

## Verification

- Local: `cargo fmt --check`, workspace clippy, `cargo test --workspace` (72 suites).
- On an arm64 Mac: clippy + tests for `glass-mcp`, `glass-a11y-macos`, `glass-ios`; the `#[ignore]`d
  live probe tests; and `glass doctor` itself for the healthy macOS line and all four iOS states.
- The classifier moved out of the FFI module so it compiles and is tested on every host, with a
  macOS-side test tying its hand-copied `AXError` codes back to the binding.

Three review waves ran over this branch. The first two fixed defects the panel found *and introduced
worse ones* — a process-global timeout left applied, live tests wired into a CI leg whose runner has
no WindowServer session, and `NoSession` folded into "unlocked" so a logged-out Mac was told its
session was unlocked. Each was caught by re-review before it shipped, and two of the last round's
gaps were proven by mutation rather than argued.

Two facts were measured on a dogfood Mac rather than assumed, and both changed the code:

**A locked session does not affect this probe.** Locking the host mid-sample, the reader line kept
answering while `display awake` flipped to its warning:

```
09:10:51 | ✓ display awake: session unlocked                 | ✓ a11y reader: answered a system-wide read
09:10:56 | ⚠ display awake: console session is locked/asleep | ✓ a11y reader: answered a system-wide read
```

So the locked-session arm this branch carried for two rounds could never fire, and it is gone. The
lock's real consequence stays with `display awake`, which already reports it.

**`AXIsProcessTrusted` does not track whether this binary may read.** On the same host at the same
moment, `glass-mcp` read the system-wide element successfully while another binary got
`CannotComplete` *with the trust bit reporting it as trusted*. The check's "trusted and unlocked, so
the stack is not responding" arm was therefore the wrong diagnosis with an unfollowable remedy; it
now names the likely cause instead — this exact binary was never granted, since a rebuild at another
path or under another name is a different binary to macOS.
