### PR TITLE
perf: stop re-walking the tree while a wait waits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y \
             xwayland libegl1 libgl1 libgles2 libgbm1 libdrm2 libegl-mesa0 libgl1-mesa-dri bubblewrap \
-            zenity at-spi2-core
+            zenity at-spi2-core xvfb python3-gi gir1.2-gtk-4.0
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
       - name: Fetch prebuilt sway bundle
         run: |
@@ -125,6 +125,9 @@ jobs:
             | tar -C ~/.local/share/glass/sway -xz
           ~/.local/share/glass/sway/bin/sway --version
       - run: ./scripts/test-wayland.sh
+      # The a11y suite's Wayland launch tests, which need this job's sway: the X11 job runs the
+      # other 25 and names these as skipped.
+      - run: ./scripts/test-a11y.sh wayland_a11y
 
   macos:
     name: macOS (build · clippy · test)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,10 @@ jobs:
           sudo apt-get update && sudo apt-get install -y xvfb bubblewrap python3-gi gir1.2-gtk-4.0 zenity at-spi2-core
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
       - run: ./scripts/test-x11.sh
+      # The AT-SPI suite owns every Linux accessibility fact the repo asserts — which role a GTK
+      # switch arrives as, and whether an event subscription actually stops a wait re-walking.
+      # It needs no dependency this job does not already install, and was simply never wired in.
+      - run: ./scripts/test-a11y.sh
 
   wayland:
     name: Wayland integration (sway)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,32 @@ jobs:
           sudo apt-get update && sudo apt-get install -y xvfb bubblewrap python3-gi gir1.2-gtk-4.0 zenity at-spi2-core
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
       - run: ./scripts/test-x11.sh
-      # The AT-SPI suite owns every Linux accessibility fact the repo asserts — which role a GTK
-      # switch arrives as, and whether an event subscription actually stops a wait re-walking.
-      # It needs no dependency this job does not already install, and was simply never wired in.
+
+  a11y:
+    name: AT-SPI integration (a11y)
+    runs-on: ubuntu-latest
+    # Its own job rather than a step on the X11 one: the suite takes ~2 minutes, which is the
+    # length of that job again, and every integration job runs in parallel. The three
+    # `wayland_a11y_*` tests need a sway this job does not fetch, so they run on the Wayland job
+    # and this one names them as skipped.
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Install pinned toolchain
+        run: rustup show
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: .
+      - name: Install system deps
+        # The suite launches a real GTK4 app (python3-gi + gir1.2-gtk-4.0) under an X server it
+        # starts itself, against glass's own private bus + AT-SPI registry (at-spi2-core).
+        # bubblewrap, and the AppArmor knob Ubuntu 24.04 restricts it with, are for the four tests
+        # that read the tree from inside a sandbox.
+        run: |
+          sudo apt-get update && sudo apt-get install -y xvfb bubblewrap python3-gi gir1.2-gtk-4.0 at-spi2-core
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+      # This suite owns every Linux accessibility fact the repo asserts — which role a GTK switch
+      # arrives as, whether an event subscription actually stops a wait re-walking — and until now
+      # ran nowhere but a developer's machine.
       - run: ./scripts/test-a11y.sh
 
   wayland:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@ internal refactors, CI, or test-only changes.
 ### Changed
 - On Linux, `glass_wait_for_element` no longer re-reads the whole accessibility tree on a timer.
   Where the platform can say whether anything changed, a wait for something that has not happened
-  yet now reads the tree once instead of once per interval — measured against the GTK test fixture,
-  1 read for a 3-second wait where it previously took 22. It still re-reads about once a second
-  regardless, so a change the platform does not announce costs latency rather than a wrong answer.
+  yet now reads the tree when something changes instead of once per interval — measured against the
+  GTK test fixture, 3 reads for a 3-second wait where it previously took 22. It re-reads about once
+  a second regardless, so a change the platform does not announce costs latency, not a wrong answer.
   Every other backend polls exactly as before, and so does Linux if the subscription cannot be
   established or stops delivering.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+### Changed
+- `glass_wait_for_element` no longer re-reads the whole accessibility tree on a timer while it
+  waits. On Linux, where the platform can say whether anything changed, a wait that is waiting for
+  something which has not happened yet now reads the tree once instead of once per interval —
+  measured against a real app, 1 read for a 3-second wait where it previously took 22. Results are
+  unchanged; only the cost is. Every other backend polls exactly as before, and so does Linux if the
+  subscription cannot be established or stops delivering.
+
 ### Fixed
 - A switch now reports the same role on Windows, macOS, Android and iOS. `glass_a11y_snapshot`
   called one a `CheckBox` on iOS, and a `Button` or a `CheckBox` on macOS depending on which toolkit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,13 @@ internal refactors, CI, or test-only changes.
 ## [Unreleased]
 
 ### Changed
-- `glass_wait_for_element` no longer re-reads the whole accessibility tree on a timer while it
-  waits. On Linux, where the platform can say whether anything changed, a wait that is waiting for
-  something which has not happened yet now reads the tree once instead of once per interval —
-  measured against a real app, 1 read for a 3-second wait where it previously took 22. Results are
-  unchanged; only the cost is. Every other backend polls exactly as before, and so does Linux if the
-  subscription cannot be established or stops delivering.
+- On Linux, `glass_wait_for_element` no longer re-reads the whole accessibility tree on a timer.
+  Where the platform can say whether anything changed, a wait for something that has not happened
+  yet now reads the tree once instead of once per interval — measured against the GTK test fixture,
+  1 read for a 3-second wait where it previously took 22. It still re-reads about once a second
+  regardless, so a change the platform does not announce costs latency rather than a wrong answer.
+  Every other backend polls exactly as before, and so does Linux if the subscription cannot be
+  established or stops delivering.
 
 ### Fixed
 - A switch now reports the same role on Windows, macOS, Android and iOS. `glass_a11y_snapshot`

--- a/crates/glass-a11y-linux/src/events.rs
+++ b/crates/glass-a11y-linux/src/events.rs
@@ -12,19 +12,13 @@ use std::time::Duration;
 use atspi::connection::AccessibilityConnection;
 use glass_core::{AxContext, ChangeSignal, ChangeWait};
 
-/// Whether an event from `emitter` concerns the app glass is driving.
-///
-/// Compares the D-Bus unique name (`:1.15`) that owns the emitting object against the app's own.
-/// Pure so the rule can be tested without a bus — the only part of this file that can be.
+/// Whether an event from `emitter` concerns the app glass is driving — a unique-name match
+/// (`:1.15`), and the only part of this file testable without a bus.
 pub(crate) fn concerns_app(app_bus_name: &str, emitter_bus_name: &str) -> bool {
     !app_bus_name.is_empty() && app_bus_name == emitter_bus_name
 }
 
 /// A [`ChangeSignal`] fed by an AT-SPI event stream running on its own thread.
-///
-/// Reports [`ChangeWait::Unusable`] once the stream ends — a subscription that has stopped
-/// delivering must not read as a permanently quiet app, or the wait it feeds would stop looking at
-/// the tree and never see what it is waiting for.
 pub(crate) struct AtspiChanges {
     rx: Receiver<()>,
     live: bool,
@@ -78,8 +72,8 @@ pub(crate) fn subscribe(ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
     }
 }
 
-/// How long to wait for the registry to accept the subscription. Generous next to a walk (~732ms
-/// on a 1500-node tree) and bounded, because failing to subscribe must cost a poll, not a hang.
+/// How long to wait for the registry to accept the subscription — bounded, because failing to
+/// subscribe must cost a poll, not a hang.
 const SUBSCRIBE_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Register for object events and forward the ones this app emitted.

--- a/crates/glass-a11y-linux/src/events.rs
+++ b/crates/glass-a11y-linux/src/events.rs
@@ -1,11 +1,17 @@
 //! AT-SPI change notifications, so a wait stops re-walking a tree that has not changed.
 //!
-//! The stream this subscribes to is **session-wide**: every accessible application on the bus
-//! emits onto it, each event carrying its emitter's unique bus name. Probed on 2026-07-30, a
-//! subscription taken while driving one app received events from unrelated desktop applications.
-//! So the filter below is not an optimization — without it a wait would wake on every unrelated
-//! desktop change, which is worse than the polling it replaces.
+//! The stream carries every app registered on the bus it is taken from, not just the one being
+//! driven — each event names its emitter's unique bus name. So the events are filtered, and
+//! filtered to a *set* of names: a walk crosses process boundaries (each child is proxied at its
+//! own name), so an app embedding an out-of-process view publishes part of its tree from a second
+//! connection, and matching one name would walk that subtree while dropping its events.
+//!
+//! (A probe on 2026-07-30 watched a *host* session bus and saw unrelated desktop applications on
+//! it. glass reads its own private bus, where that does not apply — the multi-process case above
+//! is what the filter is really for.)
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, RecvTimeoutError, SyncSender, sync_channel};
 use std::time::Duration;
 
@@ -13,15 +19,26 @@ use atspi::connection::AccessibilityConnection;
 use glass_core::{AxContext, ChangeSignal, ChangeWait};
 
 /// Whether an event from `emitter` concerns the app glass is driving — a unique-name match
-/// (`:1.15`), and the only part of this file testable without a bus.
-pub(crate) fn concerns_app(app_bus_name: &str, emitter_bus_name: &str) -> bool {
-    !app_bus_name.is_empty() && app_bus_name == emitter_bus_name
+/// (`:1.15`) against every connection the app publishes from.
+pub(crate) fn concerns_app(app_bus_names: &[String], emitter_bus_name: &str) -> bool {
+    app_bus_names.iter().any(|n| n == emitter_bus_name)
 }
 
 /// A [`ChangeSignal`] fed by an AT-SPI event stream running on its own thread.
 pub(crate) struct AtspiChanges {
     rx: Receiver<()>,
     live: bool,
+    /// Cleared on drop to stop the pump. Without it the pump owns its own connection, so its
+    /// stream never ends and the thread — with a tokio runtime, a bus connection and a registry
+    /// registration that makes every app on the desktop forward object events — would outlive
+    /// every wait that created one.
+    running: Arc<AtomicBool>,
+}
+
+impl Drop for AtspiChanges {
+    fn drop(&mut self) {
+        self.running.store(false, Ordering::Relaxed);
+    }
 }
 
 impl ChangeSignal for AtspiChanges {
@@ -53,6 +70,8 @@ pub(crate) fn subscribe(ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
     // already carries that fact, so a chatty app cannot grow an unbounded backlog here.
     let (tx, rx) = sync_channel(1);
     let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+    let running = Arc::new(AtomicBool::new(true));
+    let pump_running = running.clone();
     std::thread::spawn(move || {
         let Ok(rt) = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -61,23 +80,38 @@ pub(crate) fn subscribe(ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
             let _ = ready_tx.send(false);
             return;
         };
-        rt.block_on(pump(&ctx, tx, ready_tx));
+        rt.block_on(pump(&ctx, tx, ready_tx, pump_running));
     });
     // Wait for the subscription to be established before returning: a caller reads the tree the
     // moment it gets a signal back, and a change landing before the match rule is in place would
     // be lost.
     match ready_rx.recv_timeout(SUBSCRIBE_TIMEOUT) {
-        Ok(true) => Some(Box::new(AtspiChanges { rx, live: true })),
-        _ => None,
+        Ok(true) => Some(Box::new(AtspiChanges {
+            rx,
+            live: true,
+            running,
+        })),
+        // Including the timeout: the pump may still be starting, and nothing else would ever tell
+        // it to stop.
+        _ => {
+            running.store(false, Ordering::Relaxed);
+            None
+        }
     }
 }
 
-/// How long to wait for the registry to accept the subscription — bounded, because failing to
+/// How long to wait for the registry to accept the subscription: a registry round-trip plus one
+/// `GetConnectionUnixProcessID` per registered app, so generous — but bounded, because failing to
 /// subscribe must cost a poll, not a hang.
 const SUBSCRIBE_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Register for object events and forward the ones this app emitted.
-async fn pump(ctx: &AxContext, tx: SyncSender<()>, ready: std::sync::mpsc::Sender<bool>) {
+async fn pump(
+    ctx: &AxContext,
+    tx: SyncSender<()>,
+    ready: std::sync::mpsc::Sender<bool>,
+    running: Arc<AtomicBool>,
+) {
     let Some(addr) = ctx.a11y_bus_addr.as_deref() else {
         let _ = ready.send(false);
         return;
@@ -98,38 +132,73 @@ async fn pump(ctx: &AxContext, tx: SyncSender<()>, ready: std::sync::mpsc::Sende
         let _ = ready.send(false);
         return;
     }
-    let app_bus_name = match crate::reader::app_bus_name(ctx, &conn).await {
-        Some(name) => name,
-        None => {
-            let _ = ready.send(false);
-            return;
-        }
-    };
-    let _ = ready.send(true);
+    let app_bus_names = crate::reader::app_bus_names(ctx, &conn).await;
+    if app_bus_names.is_empty() {
+        let _ = ready.send(false);
+        return;
+    }
 
+    // The stream is attached *before* the handshake, not after: until `event_stream` runs there is
+    // no active receiver on the connection, and zbus drops messages that arrive with none. The
+    // match rule alone does not hold them — which is the race the handshake exists to close.
     let stream = conn.event_stream();
     let mut stream = std::pin::pin!(stream);
-    loop {
-        let next = std::future::poll_fn(|cx| {
-            zbus::export::futures_core::Stream::poll_next(stream.as_mut(), cx)
-        })
+    let _ = ready.send(true);
+    let mut consecutive_errors = 0u32;
+    while running.load(Ordering::Relaxed) {
+        // Bounded, so a dropped signal is noticed on a quiet app too: the stream itself never ends
+        // while this task owns the connection, so without a timeout the thread would park in
+        // `poll_next` forever waiting for an event that may never come.
+        let next = tokio::time::timeout(
+            SHUTDOWN_CHECK,
+            std::future::poll_fn(|cx| {
+                zbus::export::futures_core::Stream::poll_next(stream.as_mut(), cx)
+            }),
+        )
         .await;
         match next {
             // Only this app's events. `tx` full means an unread change is already queued, which
             // says the same thing, so dropping this one loses nothing.
-            Some(Ok(ev)) => {
-                if emitter_bus_name(&ev).is_some_and(|n| concerns_app(&app_bus_name, &n)) {
-                    let _ = tx.try_send(());
+            Ok(Some(Ok(ev))) => {
+                consecutive_errors = 0;
+                if emitter_bus_name(&ev).is_some_and(|n| concerns_app(&app_bus_names, &n))
+                    && tx
+                        .try_send(())
+                        .is_err_and(|e| matches!(e, std::sync::mpsc::TrySendError::Disconnected(_)))
+                {
+                    return; // the wait that subscribed is over
                 }
             }
-            // A transport error is not the end of the stream; keep listening.
-            Some(Err(_)) => {}
+            // Whether a decode failure ends the stream is not established here, so neither
+            // assumption is made: one is tolerated, a run of them is treated as a stream that is
+            // not coming back rather than spun on at full tilt.
+            Ok(Some(Err(_))) => {
+                consecutive_errors += 1;
+                if consecutive_errors >= MAX_CONSECUTIVE_ERRORS {
+                    return;
+                }
+            }
             // The stream ended: dropping `tx` disconnects the receiver, which is how the signal
             // learns to report `Unusable` rather than looking quiet forever.
-            None => return,
+            Ok(None) => return,
+            // No event within the shutdown check — loop and re-test `running`.
+            Err(_) => {}
         }
     }
+    // Leaving the registration behind would keep every app on the desktop forwarding object
+    // events to a bus nobody reads.
+    let _ = conn
+        .deregister_event::<atspi_common::events::ObjectEvents>()
+        .await;
 }
+
+/// How long the pump waits for an event before re-checking whether its signal still exists. Short
+/// enough that a dropped signal frees the thread promptly, long enough not to spin.
+const SHUTDOWN_CHECK: Duration = Duration::from_millis(250);
+
+/// Consecutive stream errors before the pump gives up. One is a decode failure; a run of them is a
+/// transport that is not coming back, and retrying it forever would burn a core.
+const MAX_CONSECUTIVE_ERRORS: u32 = 20;
 
 /// The unique bus name that emitted `ev`. Object events are the only kind subscribed to, so any
 /// other kind is not this app's business.
@@ -149,14 +218,23 @@ mod tests {
     fn only_this_apps_events_count() {
         // The stream carries the whole session: unrelated desktop applications emit onto it, so an
         // unfiltered wait would wake on a clock tick in another window.
-        assert!(concerns_app(":1.15", ":1.15"));
-        assert!(!concerns_app(":1.15", ":1.42"));
+        let app = vec![":1.15".to_string()];
+        assert!(concerns_app(&app, ":1.15"));
+        assert!(!concerns_app(&app, ":1.42"));
     }
 
     #[test]
-    fn an_unknown_app_name_matches_nothing() {
+    fn a_second_process_of_the_same_app_counts_too() {
+        // A walk crosses process boundaries — an embedded view publishes its subtree from its own
+        // connection — so filtering on one name would walk that subtree and drop its events.
+        let app = vec![":1.15".to_string(), ":1.42".to_string()];
+        assert!(concerns_app(&app, ":1.42"));
+        assert!(!concerns_app(&app, ":1.99"));
+    }
+
+    #[test]
+    fn an_unresolved_app_matches_nothing() {
         // Failing open here would make every desktop event look like ours.
-        assert!(!concerns_app("", ""));
-        assert!(!concerns_app("", ":1.15"));
+        assert!(!concerns_app(&[], ":1.15"));
     }
 }

--- a/crates/glass-a11y-linux/src/events.rs
+++ b/crates/glass-a11y-linux/src/events.rs
@@ -1,0 +1,168 @@
+//! AT-SPI change notifications, so a wait stops re-walking a tree that has not changed.
+//!
+//! The stream this subscribes to is **session-wide**: every accessible application on the bus
+//! emits onto it, each event carrying its emitter's unique bus name. Probed on 2026-07-30, a
+//! subscription taken while driving one app received events from unrelated desktop applications.
+//! So the filter below is not an optimization — without it a wait would wake on every unrelated
+//! desktop change, which is worse than the polling it replaces.
+
+use std::sync::mpsc::{Receiver, RecvTimeoutError, SyncSender, sync_channel};
+use std::time::Duration;
+
+use atspi::connection::AccessibilityConnection;
+use glass_core::{AxContext, ChangeSignal, ChangeWait};
+
+/// Whether an event from `emitter` concerns the app glass is driving.
+///
+/// Compares the D-Bus unique name (`:1.15`) that owns the emitting object against the app's own.
+/// Pure so the rule can be tested without a bus — the only part of this file that can be.
+pub(crate) fn concerns_app(app_bus_name: &str, emitter_bus_name: &str) -> bool {
+    !app_bus_name.is_empty() && app_bus_name == emitter_bus_name
+}
+
+/// A [`ChangeSignal`] fed by an AT-SPI event stream running on its own thread.
+///
+/// Reports [`ChangeWait::Unusable`] once the stream ends — a subscription that has stopped
+/// delivering must not read as a permanently quiet app, or the wait it feeds would stop looking at
+/// the tree and never see what it is waiting for.
+pub(crate) struct AtspiChanges {
+    rx: Receiver<()>,
+    live: bool,
+}
+
+impl ChangeSignal for AtspiChanges {
+    fn wait(&mut self, timeout: Duration) -> ChangeWait {
+        if !self.live {
+            return ChangeWait::Unusable;
+        }
+        match self.rx.recv_timeout(timeout) {
+            Ok(()) => {
+                // Drain whatever else arrived: a burst of events is one reason to re-read, not
+                // one re-read each.
+                while self.rx.try_recv().is_ok() {}
+                ChangeWait::Changed
+            }
+            Err(RecvTimeoutError::Timeout) => ChangeWait::Quiet,
+            Err(RecvTimeoutError::Disconnected) => {
+                self.live = false;
+                ChangeWait::Unusable
+            }
+        }
+    }
+}
+
+/// Subscribe to changes for the app in `ctx`, or `None` if no subscription could be established —
+/// the caller then polls exactly as it did before.
+pub(crate) fn subscribe(ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
+    let ctx = ctx.clone();
+    // Capacity 1: the receiver only needs to learn that *something* changed, and a full channel
+    // already carries that fact, so a chatty app cannot grow an unbounded backlog here.
+    let (tx, rx) = sync_channel(1);
+    let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let Ok(rt) = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        else {
+            let _ = ready_tx.send(false);
+            return;
+        };
+        rt.block_on(pump(&ctx, tx, ready_tx));
+    });
+    // Wait for the subscription to be established before returning: a caller reads the tree the
+    // moment it gets a signal back, and a change landing before the match rule is in place would
+    // be lost.
+    match ready_rx.recv_timeout(SUBSCRIBE_TIMEOUT) {
+        Ok(true) => Some(Box::new(AtspiChanges { rx, live: true })),
+        _ => None,
+    }
+}
+
+/// How long to wait for the registry to accept the subscription. Generous next to a walk (~732ms
+/// on a 1500-node tree) and bounded, because failing to subscribe must cost a poll, not a hang.
+const SUBSCRIBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Register for object events and forward the ones this app emitted.
+async fn pump(ctx: &AxContext, tx: SyncSender<()>, ready: std::sync::mpsc::Sender<bool>) {
+    let Some(addr) = ctx.a11y_bus_addr.as_deref() else {
+        let _ = ready.send(false);
+        return;
+    };
+    let Ok(parsed) = addr.try_into() else {
+        let _ = ready.send(false);
+        return;
+    };
+    let Ok(conn) = AccessibilityConnection::from_address(parsed).await else {
+        let _ = ready.send(false);
+        return;
+    };
+    if conn
+        .register_event::<atspi_common::events::ObjectEvents>()
+        .await
+        .is_err()
+    {
+        let _ = ready.send(false);
+        return;
+    }
+    let app_bus_name = match crate::reader::app_bus_name(ctx, &conn).await {
+        Some(name) => name,
+        None => {
+            let _ = ready.send(false);
+            return;
+        }
+    };
+    let _ = ready.send(true);
+
+    let stream = conn.event_stream();
+    let mut stream = std::pin::pin!(stream);
+    loop {
+        let next = std::future::poll_fn(|cx| {
+            zbus::export::futures_core::Stream::poll_next(stream.as_mut(), cx)
+        })
+        .await;
+        match next {
+            // Only this app's events. `tx` full means an unread change is already queued, which
+            // says the same thing, so dropping this one loses nothing.
+            Some(Ok(ev)) => {
+                if emitter_bus_name(&ev).is_some_and(|n| concerns_app(&app_bus_name, &n)) {
+                    let _ = tx.try_send(());
+                }
+            }
+            // A transport error is not the end of the stream; keep listening.
+            Some(Err(_)) => {}
+            // The stream ended: dropping `tx` disconnects the receiver, which is how the signal
+            // learns to report `Unusable` rather than looking quiet forever.
+            None => return,
+        }
+    }
+}
+
+/// The unique bus name that emitted `ev`. Object events are the only kind subscribed to, so any
+/// other kind is not this app's business.
+fn emitter_bus_name(ev: &atspi::Event) -> Option<String> {
+    use atspi_common::EventProperties;
+    match ev {
+        atspi::Event::Object(o) => Some(o.sender().to_string()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_this_apps_events_count() {
+        // The stream carries the whole session: unrelated desktop applications emit onto it, so an
+        // unfiltered wait would wake on a clock tick in another window.
+        assert!(concerns_app(":1.15", ":1.15"));
+        assert!(!concerns_app(":1.15", ":1.42"));
+    }
+
+    #[test]
+    fn an_unknown_app_name_matches_nothing() {
+        // Failing open here would make every desktop event look like ours.
+        assert!(!concerns_app("", ""));
+        assert!(!concerns_app("", ":1.15"));
+    }
+}

--- a/crates/glass-a11y-linux/src/events.rs
+++ b/crates/glass-a11y-linux/src/events.rs
@@ -1,14 +1,11 @@
 //! AT-SPI change notifications, so a wait stops re-walking a tree that has not changed.
 //!
-//! The stream carries every app registered on the bus it is taken from, not just the one being
-//! driven — each event names its emitter's unique bus name. So the events are filtered, and
-//! filtered to a *set* of names: a walk crosses process boundaries (each child is proxied at its
-//! own name), so an app embedding an out-of-process view publishes part of its tree from a second
-//! connection, and matching one name would walk that subtree while dropping its events.
+//! The stream carries every app registered on the bus it is taken from, each event naming its
+//! emitter's unique bus name, so events are filtered to the *set* of names the app publishes from
+//! (see [`crate::reader::app_bus_names`] for why a set).
 //!
 //! (A probe on 2026-07-30 watched a *host* session bus and saw unrelated desktop applications on
-//! it. glass reads its own private bus, where that does not apply — the multi-process case above
-//! is what the filter is really for.)
+//! it; glass reads its own private bus, so the multi-process case is what the filter is for.)
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -155,13 +152,9 @@ async fn pump(
         let _ = ready.send(true);
         forward(&mut stream, &tx, &app_bus_names, &running).await;
     }
-    // Outside the block, so the stream is dropped first: it is no longer polled, and zbus's message
-    // channel is bounded and does not overflow, so a burst arriving during these round-trips would
-    // stall delivery of their own replies and park this thread forever — reinstating the leak the
-    // shutdown exists to remove. Bounded for the same reason.
-    //
-    // Leaving the registration behind would keep every app on the bus forwarding object events to
-    // a listener nobody reads.
+    // Drop the stream first, and bound this: zbus's message channel does not overflow, so a burst
+    // arriving while nothing polls it would stall the replies to these round-trips and park the
+    // thread here — the same leak, at the one place that exists to close it.
     let _ = tokio::time::timeout(
         DEREGISTER_TIMEOUT,
         conn.deregister_event::<atspi_common::events::ObjectEvents>(),
@@ -171,9 +164,8 @@ async fn pump(
 
 /// Forward this app's events until the signal is dropped, the stream ends, or it stops parsing.
 ///
-/// Split out so every way of leaving it returns to one caller: the deregister below used to be
-/// reachable from only one of four exits, so the common end-of-wait path — an event arriving after
-/// the signal was dropped — left the registration behind.
+/// Do not inline this back into the pump: with the loop written there, the deregister was reachable
+/// from one of four exits, and the common end-of-wait path was not it.
 async fn forward(
     stream: &mut std::pin::Pin<
         &mut impl futures_core::Stream<Item = Result<atspi::Event, atspi::AtspiError>>,

--- a/crates/glass-a11y-linux/src/events.rs
+++ b/crates/glass-a11y-linux/src/events.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 
 use atspi::connection::AccessibilityConnection;
 use glass_core::{AxContext, ChangeSignal, ChangeWait};
+use zbus::export::futures_core;
 
 /// Whether an event from `emitter` concerns the app glass is driving — a unique-name match
 /// (`:1.15`) against every connection the app publishes from.
@@ -112,6 +113,13 @@ async fn pump(
     ready: std::sync::mpsc::Sender<bool>,
     running: Arc<AtomicBool>,
 ) {
+    // No pid hint means `app_matches` accepts every app on the registry, so the filter below would
+    // pass everything and the wait would re-read on any app's event — polling, with a subscription's
+    // cost on top. Declining is the same behaviour it has today, for less.
+    if ctx.pids.is_empty() {
+        let _ = ready.send(false);
+        return;
+    }
     let Some(addr) = ctx.a11y_bus_addr.as_deref() else {
         let _ = ready.send(false);
         return;
@@ -141,9 +149,39 @@ async fn pump(
     // The stream is attached *before* the handshake, not after: until `event_stream` runs there is
     // no active receiver on the connection, and zbus drops messages that arrive with none. The
     // match rule alone does not hold them — which is the race the handshake exists to close.
-    let stream = conn.event_stream();
-    let mut stream = std::pin::pin!(stream);
-    let _ = ready.send(true);
+    {
+        let stream = conn.event_stream();
+        let mut stream = std::pin::pin!(stream);
+        let _ = ready.send(true);
+        forward(&mut stream, &tx, &app_bus_names, &running).await;
+    }
+    // Outside the block, so the stream is dropped first: it is no longer polled, and zbus's message
+    // channel is bounded and does not overflow, so a burst arriving during these round-trips would
+    // stall delivery of their own replies and park this thread forever — reinstating the leak the
+    // shutdown exists to remove. Bounded for the same reason.
+    //
+    // Leaving the registration behind would keep every app on the bus forwarding object events to
+    // a listener nobody reads.
+    let _ = tokio::time::timeout(
+        DEREGISTER_TIMEOUT,
+        conn.deregister_event::<atspi_common::events::ObjectEvents>(),
+    )
+    .await;
+}
+
+/// Forward this app's events until the signal is dropped, the stream ends, or it stops parsing.
+///
+/// Split out so every way of leaving it returns to one caller: the deregister below used to be
+/// reachable from only one of four exits, so the common end-of-wait path — an event arriving after
+/// the signal was dropped — left the registration behind.
+async fn forward(
+    stream: &mut std::pin::Pin<
+        &mut impl futures_core::Stream<Item = Result<atspi::Event, atspi::AtspiError>>,
+    >,
+    tx: &SyncSender<()>,
+    app_bus_names: &[String],
+    running: &AtomicBool,
+) {
     let mut consecutive_errors = 0u32;
     while running.load(Ordering::Relaxed) {
         // Bounded, so a dropped signal is noticed on a quiet app too: the stream itself never ends
@@ -151,9 +189,7 @@ async fn pump(
         // `poll_next` forever waiting for an event that may never come.
         let next = tokio::time::timeout(
             SHUTDOWN_CHECK,
-            std::future::poll_fn(|cx| {
-                zbus::export::futures_core::Stream::poll_next(stream.as_mut(), cx)
-            }),
+            std::future::poll_fn(|cx| futures_core::Stream::poll_next(stream.as_mut(), cx)),
         )
         .await;
         match next {
@@ -161,7 +197,7 @@ async fn pump(
             // says the same thing, so dropping this one loses nothing.
             Ok(Some(Ok(ev))) => {
                 consecutive_errors = 0;
-                if emitter_bus_name(&ev).is_some_and(|n| concerns_app(&app_bus_names, &n))
+                if emitter_bus_name(&ev).is_some_and(|n| concerns_app(app_bus_names, &n))
                     && tx
                         .try_send(())
                         .is_err_and(|e| matches!(e, std::sync::mpsc::TrySendError::Disconnected(_)))
@@ -185,12 +221,11 @@ async fn pump(
             Err(_) => {}
         }
     }
-    // Leaving the registration behind would keep every app on the desktop forwarding object
-    // events to a bus nobody reads.
-    let _ = conn
-        .deregister_event::<atspi_common::events::ObjectEvents>()
-        .await;
 }
+
+/// How long to wait for the registry to accept the unsubscribe. Bounded because a hung teardown is
+/// the leak again, wearing a different hat.
+const DEREGISTER_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// How long the pump waits for an event before re-checking whether its signal still exists. Short
 /// enough that a dropped signal frees the thread promptly, long enough not to spin.
@@ -216,8 +251,7 @@ mod tests {
 
     #[test]
     fn only_this_apps_events_count() {
-        // The stream carries the whole session: unrelated desktop applications emit onto it, so an
-        // unfiltered wait would wake on a clock tick in another window.
+        // The bus carries every registered app, so an unfiltered wait would wake on another one.
         let app = vec![":1.15".to_string()];
         assert!(concerns_app(&app, ":1.15"));
         assert!(!concerns_app(&app, ":1.42"));

--- a/crates/glass-a11y-linux/src/lib.rs
+++ b/crates/glass-a11y-linux/src/lib.rs
@@ -3,6 +3,7 @@
 //! per-OS `Accessibility` seam (orthogonal to the display `Platform` seam); the
 //! same impl serves both the X11 and Wayland display backends.
 
+mod events;
 mod mapping;
 mod reader;
 

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -29,6 +29,10 @@ impl LinuxA11y {
 }
 
 impl Accessibility for LinuxA11y {
+    fn subscribe_changes(&mut self, ctx: &AxContext) -> Option<Box<dyn glass_core::ChangeSignal>> {
+        crate::events::subscribe(ctx)
+    }
+
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
         let ctx = ctx.clone();
         let (tx, rx) = mpsc::channel();
@@ -345,6 +349,23 @@ async fn find_nth(
 /// signal: the app matches when its owning pid is in `ctx.pids` (the launched app's PID
 /// set — root + enumerable descendants). An empty set (no pid hint, e.g. a backend that
 /// can't enumerate) accepts the first app (refine later).
+/// The unique D-Bus name of the app in `ctx` — the key the event filter matches on, resolved the
+/// same way [`find_app`] resolves the app itself so a subscription and a walk cannot disagree
+/// about which application they are about.
+pub(crate) async fn app_bus_name(
+    ctx: &AxContext,
+    conn: &AccessibilityConnection,
+) -> Option<String> {
+    let zbus_conn = conn.connection().clone();
+    let root = conn.root_accessible_on_registry().await.ok()?;
+    for app_ref in root.get_children().await.ok()? {
+        if app_matches(&app_ref, ctx, &zbus_conn).await {
+            return app_ref.name().map(|n| n.to_string());
+        }
+    }
+    None
+}
+
 async fn app_matches(app_ref: &ObjectRefOwned, ctx: &AxContext, conn: &zbus::Connection) -> bool {
     if ctx.pids.is_empty() {
         return true; // no pid hint: accept the first app (refine by geometry/title elsewhere)

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -345,27 +345,36 @@ async fn find_nth(
     Ok(None)
 }
 
+/// Every unique D-Bus name belonging to the app in `ctx` — the keys the event filter matches on.
+///
+/// A set, not one name: a walk crosses process boundaries (each child is proxied at *its own* bus
+/// name), so an app that embeds an out-of-process view publishes part of its tree from a second
+/// connection. Filtering on one name would walk that subtree while dropping every event it emits.
+/// Matched by pid, the same rule [`find_app`] applies — though not at the same moment: this
+/// resolves once when the subscription is taken, and a walk re-resolves each time.
+pub(crate) async fn app_bus_names(ctx: &AxContext, conn: &AccessibilityConnection) -> Vec<String> {
+    let zbus_conn = conn.connection().clone();
+    let Ok(root) = conn.root_accessible_on_registry().await else {
+        return Vec::new();
+    };
+    let Ok(children) = root.get_children().await else {
+        return Vec::new();
+    };
+    let mut names = Vec::new();
+    for app_ref in children {
+        if app_matches(&app_ref, ctx, &zbus_conn).await
+            && let Some(name) = app_ref.name()
+        {
+            names.push(name.to_string());
+        }
+    }
+    names
+}
+
 /// Does this AT-SPI application belong to the launched process? PID is the reliable
 /// signal: the app matches when its owning pid is in `ctx.pids` (the launched app's PID
 /// set — root + enumerable descendants). An empty set (no pid hint, e.g. a backend that
 /// can't enumerate) accepts the first app (refine later).
-/// The unique D-Bus name of the app in `ctx` — the key the event filter matches on, resolved the
-/// same way [`find_app`] resolves the app itself so a subscription and a walk cannot disagree
-/// about which application they are about.
-pub(crate) async fn app_bus_name(
-    ctx: &AxContext,
-    conn: &AccessibilityConnection,
-) -> Option<String> {
-    let zbus_conn = conn.connection().clone();
-    let root = conn.root_accessible_on_registry().await.ok()?;
-    for app_ref in root.get_children().await.ok()? {
-        if app_matches(&app_ref, ctx, &zbus_conn).await {
-            return app_ref.name().map(|n| n.to_string());
-        }
-    }
-    None
-}
-
 async fn app_matches(app_ref: &ObjectRefOwned, ctx: &AxContext, conn: &zbus::Connection) -> bool {
     if ctx.pids.is_empty() {
         return true; // no pid hint: accept the first app (refine by geometry/title elsewhere)

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -1203,13 +1203,12 @@ fn a_quiet_wait_stops_re_walking_the_tree() {
     glass.stop().expect("stop");
 
     // Logged: the number is the point of the change.
-    eprintln!("quiet 3s wait at 100ms: {walked} walks (polling would be ~30)");
+    eprintln!("quiet 3s wait at 100ms: {walked} walks (polling took 22)");
     assert!(!out.matched, "the element must not exist");
     // See `Counting`: without this the test could measure polling and pass.
     assert!(subscribed > 0, "no subscription was established");
-    // Polling at 100ms over 3s would walk ~30 times, and the fixture is quiet.
-    // Three: one at the start, plus the forced re-read the quiet ceiling makes about once a
-    // second. Polling the same wait takes ~30.
+    // One read at the start plus the ceiling's forced re-read about once a second — 3 measured,
+    // against 22 for the same wait polling.
     assert!(
         walked <= 5,
         "a quiet 3s wait walked {walked} times; the subscription is not suppressing walks"

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -6,12 +6,11 @@
 
 use glass_core::{AppSpec, Backend, BaselineStore, Glass, PlatformFactory, WindowHint};
 
-/// Counts the walks a session performs, so a test can assert what an event subscription is *for*
-/// — wall-clock cannot tell a wait that waited efficiently from one that walked slowly.
+/// Counts the walks a session performs — wall-clock cannot tell a wait that waited efficiently
+/// from one that walked slowly.
 ///
-/// Forwards every trait method. A forgotten forward would silently disable the subscription and
-/// leave the test measuring the polling it was written to replace, which is why the walk-saving
-/// test asserts the wrapper still yields a signal.
+/// Forwards every trait method; `subscribe_changes` has a default body, so a forgotten forward
+/// would compile and silently disable what the test measures.
 struct Counting<A> {
     inner: A,
     walks: std::sync::Arc<std::sync::atomic::AtomicUsize>,
@@ -1203,16 +1202,16 @@ fn a_quiet_wait_stops_re_walking_the_tree() {
     let subscribed = signals.load(std::sync::atomic::Ordering::Relaxed);
     glass.stop().expect("stop");
 
-    // Logged like the bench walk's timing: the number is the point of the change, and a reader
-    // of CI output should not have to re-derive it.
+    // Logged: the number is the point of the change.
     eprintln!("quiet 3s wait at 100ms: {walked} walks (polling would be ~30)");
     assert!(!out.matched, "the element must not exist");
-    // The wrapper forwards `subscribe_changes`: without this the test would silently measure the
-    // polling it exists to replace.
+    // See `Counting`: without this the test could measure polling and pass.
     assert!(subscribed > 0, "no subscription was established");
     // Polling at 100ms over 3s would walk ~30 times, and the fixture is quiet.
+    // Three: one at the start, plus the forced re-read the quiet ceiling makes about once a
+    // second. Polling the same wait takes ~30.
     assert!(
-        walked <= 3,
+        walked <= 5,
         "a quiet 3s wait walked {walked} times; the subscription is not suppressing walks"
     );
 }

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -6,6 +6,81 @@
 
 use glass_core::{AppSpec, Backend, BaselineStore, Glass, PlatformFactory, WindowHint};
 
+/// Counts the walks a session performs, so a test can assert what an event subscription is *for*
+/// — wall-clock cannot tell a wait that waited efficiently from one that walked slowly.
+///
+/// Forwards every trait method. A forgotten forward would silently disable the subscription and
+/// leave the test measuring the polling it was written to replace, which is why the walk-saving
+/// test asserts the wrapper still yields a signal.
+struct Counting<A> {
+    inner: A,
+    walks: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    signals: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+}
+
+impl<A: glass_core::Accessibility> glass_core::Accessibility for Counting<A> {
+    fn snapshot(&mut self, ctx: &glass_core::AxContext) -> glass_core::Result<glass_core::AxTree> {
+        self.walks
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.inner.snapshot(ctx)
+    }
+    fn subscribe_changes(
+        &mut self,
+        ctx: &glass_core::AxContext,
+    ) -> Option<Box<dyn glass_core::ChangeSignal>> {
+        let s = self.inner.subscribe_changes(ctx);
+        if s.is_some() {
+            self.signals
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+        s
+    }
+    fn set_value(
+        &mut self,
+        ctx: &glass_core::AxContext,
+        target: &glass_core::AxTarget,
+        text: &str,
+    ) -> glass_core::Result<()> {
+        self.inner.set_value(ctx, target, text)
+    }
+    fn invoke(
+        &mut self,
+        ctx: &glass_core::AxContext,
+        target: &glass_core::AxTarget,
+    ) -> glass_core::Result<()> {
+        self.inner.invoke(ctx, target)
+    }
+}
+
+/// A session whose reader counts walks and subscriptions.
+fn glass_counting() -> (
+    Glass,
+    std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    std::sync::Arc<std::sync::atomic::AtomicUsize>,
+) {
+    let walks = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let signals = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let (w, sg) = (walks.clone(), signals.clone());
+    let factory: PlatformFactory = Box::new(move |_backend| {
+        Ok(Backend {
+            platform: Box::new(glass_x11::X11Platform::from_env()?),
+            accessibility: Some(Box::new(Counting {
+                inner: glass_a11y_linux::LinuxA11y::new(),
+                walks: w.clone(),
+                signals: sg.clone(),
+            })),
+        })
+    });
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().join("baselines");
+    std::mem::forget(dir);
+    (
+        Glass::new(factory, "x11".into(), BaselineStore::new(root), 100),
+        walks,
+        signals,
+    )
+}
+
 fn glass_x11_with_a11y() -> Glass {
     let factory: PlatformFactory = Box::new(|_backend| {
         Ok(Backend {
@@ -1098,5 +1173,46 @@ fn stopping_an_a11y_launch_finishes_inside_the_teardown_budget() {
         "tearing down an a11y launch (ask + signal ladder + private bus) must fit in the {:?} \
          glass-mcp allows teardown; this took {elapsed:?}",
         glass_core::TEARDOWN_BUDGET
+    );
+}
+
+/// The point of the event subscription, measured against a real app: a wait for something that
+/// never happens must stop re-reading the tree.
+///
+/// Counted rather than timed — a wait that walked slowly and a wait that waited efficiently take
+/// the same wall-clock, and only the walk count tells them apart.
+#[test]
+#[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
+fn a_quiet_wait_stops_re_walking_the_tree() {
+    let (mut glass, walks, signals) = glass_counting();
+    glass.start(&fixture_spec()).expect("launch");
+    std::thread::sleep(std::time::Duration::from_millis(3_000));
+
+    walks.store(0, std::sync::atomic::Ordering::Relaxed);
+    let out = glass
+        .wait_for_element(&glass_core::WaitElementParams {
+            name: Some("no such element in this fixture".into()),
+            role: None,
+            value_contains: None,
+            condition: glass_core::ElementCondition::Appears,
+            interval_ms: 100,
+            timeout_ms: 3_000,
+        })
+        .expect("wait");
+    let walked = walks.load(std::sync::atomic::Ordering::Relaxed);
+    let subscribed = signals.load(std::sync::atomic::Ordering::Relaxed);
+    glass.stop().expect("stop");
+
+    // Logged like the bench walk's timing: the number is the point of the change, and a reader
+    // of CI output should not have to re-derive it.
+    eprintln!("quiet 3s wait at 100ms: {walked} walks (polling would be ~30)");
+    assert!(!out.matched, "the element must not exist");
+    // The wrapper forwards `subscribe_changes`: without this the test would silently measure the
+    // polling it exists to replace.
+    assert!(subscribed > 0, "no subscription was established");
+    // Polling at 100ms over 3s would walk ~30 times, and the fixture is quiet.
+    assert!(
+        walked <= 3,
+        "a quiet 3s wait walked {walked} times; the subscription is not suppressing walks"
     );
 }

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -664,19 +664,15 @@ impl AxTarget {
     }
 }
 
-/// The OS accessibility seam — one impl per OS. Object-safe; the session stores
-/// it boxed as `Send` (the `Send` bound lives at the storage site, not on the
-/// trait). Distinct from `Platform`: accessibility varies per-OS, not per-
-/// display-server.
 /// A backend's notification that the app's accessibility tree may have changed.
 ///
-/// Exists so a wait can stop re-reading the whole tree on a timer: on a large tree a walk costs far
-/// more than the poll interval it is nominally paced by (measured on AT-SPI: 732ms for 1500 nodes
-/// against a 100ms interval), so a wait for something that has not happened yet spends its whole
-/// budget re-reading an unchanged tree.
+/// Exists so a wait can stop re-reading the whole tree on a timer. A walk is not free and grows
+/// with the tree — measured on AT-SPI, 36ms for a small fixture and 732ms at the 1500-node cap —
+/// so a wait for something that has not happened yet spends its whole budget re-reading a tree
+/// that did not change.
 ///
-/// Public and object-safe on purpose: a caller has to be able to write a fake — the case worth
-/// pinning is a signal that fires *constantly*, which must not turn a poll loop into a spin.
+/// Public and object-safe because it crosses the `Accessibility` seam, which backends implement
+/// out-of-crate.
 pub trait ChangeSignal: Send {
     /// Block until a change arrives or `timeout` elapses.
     ///
@@ -702,6 +698,10 @@ pub enum ChangeWait {
     Unusable,
 }
 
+/// The OS accessibility seam — one impl per OS. Object-safe; the session stores
+/// it boxed as `Send` (the `Send` bound lives at the storage site, not on the
+/// trait). Distinct from `Platform`: accessibility varies per-OS, not per-
+/// display-server.
 pub trait Accessibility {
     /// Snapshot the active window's accessibility subtree, normalized and in
     /// window-relative coordinates. Node ids are assigned by the caller
@@ -710,12 +710,15 @@ pub trait Accessibility {
 
     /// Subscribe to change notifications for the app described by `ctx`.
     ///
-    /// `None` — the default — means this backend has no event stream, and its callers keep polling
-    /// exactly as they did before. Two backends can never implement it: Android's `uiautomator`
-    /// reader is a dump per call, and iOS's is an `idb describe` per call.
+    /// `None` — the default — means this reader has no event stream, and its callers keep polling
+    /// exactly as they did before. Two readers cannot have one as built: Android's `uiautomator`
+    /// reader is a dump per call and iOS's is an `idb describe` per call. Android's *other* reader,
+    /// the on-device accessibility service, is driven by events and is the natural next one.
     ///
-    /// The subscription must be established *before* the caller's first read, or a change landing
-    /// between the two is lost and the caller waits out an interval on a tree that already matches.
+    /// Subscribe before the first read, not after: a change that lands after a read but before the
+    /// subscription is announced to nobody, and the caller then waits out its *entire* budget on a
+    /// condition that already holds. (A change between subscribing and reading is safe — the read
+    /// sees it.)
     fn subscribe_changes(&mut self, _ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
         None
     }

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -668,11 +668,40 @@ impl AxTarget {
 /// it boxed as `Send` (the `Send` bound lives at the storage site, not on the
 /// trait). Distinct from `Platform`: accessibility varies per-OS, not per-
 /// display-server.
+/// A backend's notification that the app's accessibility tree may have changed.
+///
+/// Exists so a wait can stop re-reading the whole tree on a timer: on a large tree a walk costs far
+/// more than the poll interval it is nominally paced by (measured on AT-SPI: 732ms for 1500 nodes
+/// against a 100ms interval), so a wait for something that has not happened yet spends its whole
+/// budget re-reading an unchanged tree.
+///
+/// Public and object-safe on purpose: a caller has to be able to write a fake — the case worth
+/// pinning is a signal that fires *constantly*, which must not turn a poll loop into a spin.
+pub trait ChangeSignal: Send {
+    /// Block until a change arrives or `timeout` elapses. `true` means a change arrived, `false`
+    /// means the wait timed out — including permanently, if the subscription died. An
+    /// implementation must never block past `timeout`: the caller's deadline is the only thing
+    /// standing between a dead subscription and a hung wait.
+    fn wait(&mut self, timeout: std::time::Duration) -> bool;
+}
+
 pub trait Accessibility {
     /// Snapshot the active window's accessibility subtree, normalized and in
     /// window-relative coordinates. Node ids are assigned by the caller
     /// afterward via [`AxTree::assign_ids`]; the backend need not set them.
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree>;
+
+    /// Subscribe to change notifications for the app described by `ctx`.
+    ///
+    /// `None` — the default — means this backend has no event stream, and its callers keep polling
+    /// exactly as they did before. Two backends can never implement it: Android's `uiautomator`
+    /// reader is a dump per call, and iOS's is an `idb describe` per call.
+    ///
+    /// The subscription must be established *before* the caller's first read, or a change landing
+    /// between the two is lost and the caller waits out an interval on a tree that already matches.
+    fn subscribe_changes(&mut self, _ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
+        None
+    }
 
     /// Set the editable element identified by `target` to `text`. The backend
     /// re-walks pre-order to `target.id`, verifies role+name, then sets via the

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -676,8 +676,10 @@ impl AxTarget {
 pub trait ChangeSignal: Send {
     /// Block until a change arrives or `timeout` elapses.
     ///
-    /// Must never block past `timeout`: the caller's deadline is the only thing standing between a
-    /// subscription that stopped delivering and a hung wait.
+    /// Must never block past `timeout`, and must actually block for it when there is nothing to
+    /// report: the deadline is the only thing standing between a subscription that stopped
+    /// delivering and a hung wait, and an implementation that returns instantly every time turns
+    /// the caller's poll loop into a spin.
     fn wait(&mut self, timeout: std::time::Duration) -> ChangeWait;
 }
 

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -678,11 +678,28 @@ impl AxTarget {
 /// Public and object-safe on purpose: a caller has to be able to write a fake — the case worth
 /// pinning is a signal that fires *constantly*, which must not turn a poll loop into a spin.
 pub trait ChangeSignal: Send {
-    /// Block until a change arrives or `timeout` elapses. `true` means a change arrived, `false`
-    /// means the wait timed out — including permanently, if the subscription died. An
-    /// implementation must never block past `timeout`: the caller's deadline is the only thing
-    /// standing between a dead subscription and a hung wait.
-    fn wait(&mut self, timeout: std::time::Duration) -> bool;
+    /// Block until a change arrives or `timeout` elapses.
+    ///
+    /// Must never block past `timeout`: the caller's deadline is the only thing standing between a
+    /// subscription that stopped delivering and a hung wait.
+    fn wait(&mut self, timeout: std::time::Duration) -> ChangeWait;
+}
+
+/// What a [`ChangeSignal`] learned while waiting.
+///
+/// `Quiet` and `Unusable` are separate answers because a caller does opposite things with them: on
+/// `Quiet` it can skip re-reading the tree, which is the entire saving; on `Unusable` it must go
+/// back to re-reading on the interval, because a signal that can no longer tell would otherwise
+/// look like a permanently quiet app and the wait would never notice the state it is waiting for.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChangeWait {
+    /// Something changed — read the tree.
+    Changed,
+    /// Nothing changed within the timeout, and the signal is still trustworthy.
+    Quiet,
+    /// The subscription can no longer report changes (the stream ended, the bus dropped). The
+    /// caller must stop trusting it and resume polling.
+    Unusable,
 }
 
 pub trait Accessibility {

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -77,8 +77,9 @@ pub use platform::{
 pub mod accessibility;
 pub use accessibility::{
     Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree,
-    ClickMethod, ElementCondition, ElementInfo, ElementMatch, MAX_DEPTH, MAX_NODES, MAX_SIBLINGS,
-    Truncation, TruncationLimit, WalkBudget, WalkLimits, element_match, normalize_description,
+    ChangeSignal, ChangeWait, ClickMethod, ElementCondition, ElementInfo, ElementMatch, MAX_DEPTH,
+    MAX_NODES, MAX_SIBLINGS, Truncation, TruncationLimit, WalkBudget, WalkLimits, element_match,
+    normalize_description,
 };
 
 pub mod marks;

--- a/crates/glass-core/src/poll.rs
+++ b/crates/glass-core/src/poll.rs
@@ -33,10 +33,9 @@ pub fn poll_until<T>(
 
 /// [`poll_until`] with the wait between ticks supplied by the caller, and the power to skip a tick.
 ///
-/// `pause` is handed the interval and answers whether the next tick is worth running. A caller that
-/// can be *told* nothing changed — an accessibility event stream, say — returns `false`, and the
-/// loop waits again instead of redoing work whose answer cannot have changed. Returning `true`
-/// reproduces a plain sleep-and-retry.
+/// `pause` is handed the interval and answers whether the next tick is worth running: `false` from
+/// a caller that can be *told* nothing changed skips work whose answer cannot have changed, and
+/// `true` reproduces a plain sleep-and-retry.
 ///
 /// The deadline is checked every iteration, tick or no tick, so a `pause` that always says "skip"
 /// still ends the loop on time; and a `pause` that never blocks spins only until the deadline.

--- a/crates/glass-core/src/poll.rs
+++ b/crates/glass-core/src/poll.rs
@@ -40,6 +40,10 @@ pub fn poll_until<T>(
 ///
 /// The deadline is checked every iteration, tick or no tick, so a `pause` that always says "skip"
 /// still ends the loop on time; and a `pause` that never blocks spins only until the deadline.
+///
+/// `pause` is called even when `interval_ms` is 0 — sleeping for zero is what the default does, and
+/// a caller whose pause can *skip* must decide for itself whether a zero interval leaves it
+/// anything to wait for.
 pub fn poll_until_with_pause<T>(
     interval_ms: u64,
     timeout_ms: u64,
@@ -61,11 +65,7 @@ pub fn poll_until_with_pause<T>(
                 elapsed_ms: start.elapsed().as_millis() as u64,
             });
         }
-        run_tick = if interval_ms > 0 {
-            pause(Duration::from_millis(interval_ms))
-        } else {
-            true
-        };
+        run_tick = pause(Duration::from_millis(interval_ms));
     }
 }
 

--- a/crates/glass-core/src/poll.rs
+++ b/crates/glass-core/src/poll.rs
@@ -20,25 +20,36 @@ pub fn poll_until<T>(
     timeout_ms: u64,
     tick: impl FnMut() -> Result<Option<T>>,
 ) -> Result<PollOutcome<T>> {
-    poll_until_with_pause(interval_ms, timeout_ms, std::thread::sleep, tick)
+    poll_until_with_pause(
+        interval_ms,
+        timeout_ms,
+        |d| {
+            std::thread::sleep(d);
+            true
+        },
+        tick,
+    )
 }
 
-/// [`poll_until`] with the wait between ticks supplied by the caller.
+/// [`poll_until`] with the wait between ticks supplied by the caller, and the power to skip a tick.
 ///
-/// `pause` is handed the interval and may return early — a caller that can be *told* the state
-/// changed (an accessibility event, say) uses it to wake immediately instead of sleeping out an
-/// interval that no longer means anything. Returning early only skips the wait: the deadline still
-/// governs, so a `pause` that never blocks turns the loop into a spin bounded by `timeout_ms`
-/// rather than an unbounded one.
+/// `pause` is handed the interval and answers whether the next tick is worth running. A caller that
+/// can be *told* nothing changed — an accessibility event stream, say — returns `false`, and the
+/// loop waits again instead of redoing work whose answer cannot have changed. Returning `true`
+/// reproduces a plain sleep-and-retry.
+///
+/// The deadline is checked every iteration, tick or no tick, so a `pause` that always says "skip"
+/// still ends the loop on time; and a `pause` that never blocks spins only until the deadline.
 pub fn poll_until_with_pause<T>(
     interval_ms: u64,
     timeout_ms: u64,
-    mut pause: impl FnMut(Duration),
+    mut pause: impl FnMut(Duration) -> bool,
     mut tick: impl FnMut() -> Result<Option<T>>,
 ) -> Result<PollOutcome<T>> {
     let start = Instant::now();
+    let mut run_tick = true;
     loop {
-        if let Some(v) = tick()? {
+        if run_tick && let Some(v) = tick()? {
             return Ok(PollOutcome {
                 value: Some(v),
                 elapsed_ms: start.elapsed().as_millis() as u64,
@@ -50,9 +61,11 @@ pub fn poll_until_with_pause<T>(
                 elapsed_ms: start.elapsed().as_millis() as u64,
             });
         }
-        if interval_ms > 0 {
-            pause(Duration::from_millis(interval_ms));
-        }
+        run_tick = if interval_ms > 0 {
+            pause(Duration::from_millis(interval_ms))
+        } else {
+            true
+        };
     }
 }
 
@@ -68,7 +81,10 @@ mod tests {
         poll_until_with_pause(
             5,
             5_000,
-            |_| paused.set(paused.get() + 1),
+            |_| {
+                paused.set(paused.get() + 1);
+                true
+            },
             || {
                 ticks += 1;
                 Ok(if ticks == 3 { Some(()) } else { None })
@@ -84,7 +100,7 @@ mod tests {
     fn a_pause_that_returns_early_still_honours_the_deadline() {
         // A signal that fires constantly must bound the loop, not spin it forever.
         let started = Instant::now();
-        let out = poll_until_with_pause(10, 40, |_| {}, || Ok(None::<()>)).unwrap();
+        let out = poll_until_with_pause(10, 40, |_| true, || Ok(None::<()>)).unwrap();
         assert!(out.value.is_none());
         assert!(started.elapsed() >= Duration::from_millis(40));
     }

--- a/crates/glass-core/src/poll.rs
+++ b/crates/glass-core/src/poll.rs
@@ -18,6 +18,22 @@ pub struct PollOutcome<T> {
 pub fn poll_until<T>(
     interval_ms: u64,
     timeout_ms: u64,
+    tick: impl FnMut() -> Result<Option<T>>,
+) -> Result<PollOutcome<T>> {
+    poll_until_with_pause(interval_ms, timeout_ms, std::thread::sleep, tick)
+}
+
+/// [`poll_until`] with the wait between ticks supplied by the caller.
+///
+/// `pause` is handed the interval and may return early — a caller that can be *told* the state
+/// changed (an accessibility event, say) uses it to wake immediately instead of sleeping out an
+/// interval that no longer means anything. Returning early only skips the wait: the deadline still
+/// governs, so a `pause` that never blocks turns the loop into a spin bounded by `timeout_ms`
+/// rather than an unbounded one.
+pub fn poll_until_with_pause<T>(
+    interval_ms: u64,
+    timeout_ms: u64,
+    mut pause: impl FnMut(Duration),
     mut tick: impl FnMut() -> Result<Option<T>>,
 ) -> Result<PollOutcome<T>> {
     let start = Instant::now();
@@ -35,7 +51,7 @@ pub fn poll_until<T>(
             });
         }
         if interval_ms > 0 {
-            std::thread::sleep(Duration::from_millis(interval_ms));
+            pause(Duration::from_millis(interval_ms));
         }
     }
 }
@@ -44,6 +60,34 @@ pub fn poll_until<T>(
 mod tests {
     use super::*;
     use crate::error::GlassError;
+
+    #[test]
+    fn the_pause_hook_replaces_the_sleep() {
+        let paused = std::cell::Cell::new(0);
+        let mut ticks = 0;
+        poll_until_with_pause(
+            5,
+            5_000,
+            |_| paused.set(paused.get() + 1),
+            || {
+                ticks += 1;
+                Ok(if ticks == 3 { Some(()) } else { None })
+            },
+        )
+        .unwrap();
+        // Two unsatisfied ticks, so two pauses — and no sleep of the loop's own, which is what
+        // lets a caller wake on an event instead of waiting out an interval.
+        assert_eq!(paused.get(), 2);
+    }
+
+    #[test]
+    fn a_pause_that_returns_early_still_honours_the_deadline() {
+        // A signal that fires constantly must bound the loop, not spin it forever.
+        let started = Instant::now();
+        let out = poll_until_with_pause(10, 40, |_| {}, || Ok(None::<()>)).unwrap();
+        assert!(out.value.is_none());
+        assert!(started.elapsed() >= Duration::from_millis(40));
+    }
 
     #[test]
     fn returns_value_when_satisfied_immediately() {

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -36,10 +36,6 @@ impl Glass {
         self.snapshot_at_current_limits()
     }
 
-    /// Re-snapshot the active window reusing the limits the last user snapshot set — it does NOT
-    /// reset them. Used by compound operations (the `return:"snapshot"` fold, `wait_for_element`,
-    /// and the scroll/combo/toggle loops) so an agent working in a raised-cap tree keeps that
-    /// id-space instead of silently reverting to the default cap on the next internal snapshot.
     /// Subscribe to the backend's change notifications for the active app, if it has any.
     ///
     /// Callers hold the returned signal in a local, never in the session: a poll loop's tick
@@ -47,6 +43,10 @@ impl Glass {
     /// pause between ticks.
     pub(crate) fn subscribe_a11y_changes(&mut self) -> Option<Box<dyn ChangeSignal>> {
         let s = self.active_mut().ok()?;
+        // Reader check first, like `snapshot_at_current_limits`: the accessors below are platform
+        // round-trips (`app_pids` shells out to `adb` on Android), and a backend with no reader —
+        // or one taking the default `None` — must not pay them for a subscription it cannot have.
+        s.accessibility.as_ref()?;
         // The cached geometry, deliberately: subscribing must not depend on a window round-trip
         // that can fail, because failing to subscribe has to degrade to polling rather than to an
         // error. The reader only needs enough context to identify the app.
@@ -60,6 +60,10 @@ impl Glass {
         s.accessibility.as_mut()?.subscribe_changes(&ctx)
     }
 
+    /// Re-snapshot the active window reusing the limits the last user snapshot set — it does NOT
+    /// reset them. Used by compound operations (the `return:"snapshot"` fold, `wait_for_element`,
+    /// and the scroll/combo/toggle loops) so an agent working in a raised-cap tree keeps that
+    /// id-space instead of silently reverting to the default cap on the next internal snapshot.
     pub fn a11y_resnapshot(&mut self) -> Result<AxTree> {
         self.snapshot_at_current_limits()
     }
@@ -415,10 +419,9 @@ impl Glass {
                 return Ok(()); // truthful no-op, no actuation
             }
             self.click_element_inner(id)?; // the toggle actuation (a swipe for a row-shaped control)
-            // Deliberately not event-gated, unlike `wait_for_element`: this poll waits on a change
-            // it just caused and usually sees it on the first or second read, while establishing a
-            // subscription costs a round-trip of its own — paid on every `set_value`, to save reads
-            // this loop rarely takes.
+            // Not event-gated, and cannot be: this branch runs only on a backend that frames a
+            // switch as its whole row, which today is iOS alone — a reader with no event stream to
+            // subscribe to.
             let outcome = crate::poll::poll_until(
                 TOGGLE_VERIFY_INTERVAL_MS,
                 TOGGLE_VERIFY_TIMEOUT_MS,

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -44,8 +44,10 @@ impl Glass {
     pub(crate) fn subscribe_a11y_changes(&mut self) -> Option<Box<dyn ChangeSignal>> {
         let s = self.active_mut().ok()?;
         // Reader check first, like `snapshot_at_current_limits`: the accessors below are platform
-        // round-trips (`app_pids` shells out to `adb` on Android), and a backend with no reader —
-        // or one taking the default `None` — must not pay them for a subscription it cannot have.
+        // round-trips (`app_pids` shells out to `adb` on Android), and a backend with no reader at
+        // all must not pay them for a subscription it cannot have. A reader that has one but takes
+        // the default `None` still pays — once per wait, inside the caller's budget, because
+        // nothing short of asking it can tell.
         s.accessibility.as_ref()?;
         // The cached geometry, deliberately: subscribing must not depend on a window round-trip
         // that can fail, because failing to subscribe has to degrade to polling rather than to an

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -415,6 +415,10 @@ impl Glass {
                 return Ok(()); // truthful no-op, no actuation
             }
             self.click_element_inner(id)?; // the toggle actuation (a swipe for a row-shaped control)
+            // Deliberately not event-gated, unlike `wait_for_element`: this poll waits on a change
+            // it just caused and usually sees it on the first or second read, while establishing a
+            // subscription costs a round-trip of its own — paid on every `set_value`, to save reads
+            // this loop rarely takes.
             let outcome = crate::poll::poll_until(
                 TOGGLE_VERIFY_INTERVAL_MS,
                 TOGGLE_VERIFY_TIMEOUT_MS,

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -44,10 +44,9 @@ impl Glass {
     pub(crate) fn subscribe_a11y_changes(&mut self) -> Option<Box<dyn ChangeSignal>> {
         let s = self.active_mut().ok()?;
         // Reader check first, like `snapshot_at_current_limits`: the accessors below are platform
-        // round-trips (`app_pids` shells out to `adb` on Android), and a backend with no reader at
-        // all must not pay them for a subscription it cannot have. A reader that has one but takes
-        // the default `None` still pays — once per wait, inside the caller's budget, because
-        // nothing short of asking it can tell.
+        // round-trips (`app_pids` shells out to `adb` on Android). A reader that has no event
+        // stream still pays them once per wait, inside the caller's budget — nothing short of
+        // asking it can tell.
         s.accessibility.as_ref()?;
         // The cached geometry, deliberately: subscribing must not depend on a window round-trip
         // that can fail, because failing to subscribe has to degrade to polling rather than to an

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -40,6 +40,26 @@ impl Glass {
     /// reset them. Used by compound operations (the `return:"snapshot"` fold, `wait_for_element`,
     /// and the scroll/combo/toggle loops) so an agent working in a raised-cap tree keeps that
     /// id-space instead of silently reverting to the default cap on the next internal snapshot.
+    /// Subscribe to the backend's change notifications for the active app, if it has any.
+    ///
+    /// Callers hold the returned signal in a local, never in the session: a poll loop's tick
+    /// closure borrows `self` mutably, so a signal stored here could not be waited on from the
+    /// pause between ticks.
+    pub(crate) fn subscribe_a11y_changes(&mut self) -> Option<Box<dyn ChangeSignal>> {
+        let s = self.active_mut().ok()?;
+        // The cached geometry, deliberately: subscribing must not depend on a window round-trip
+        // that can fail, because failing to subscribe has to degrade to polling rather than to an
+        // error. The reader only needs enough context to identify the app.
+        let ctx = AxContext {
+            pids: s.platform.app_pids(),
+            window: s.geometry.clone(),
+            window_handle: s.platform.active_window_handle(),
+            a11y_bus_addr: s.platform.a11y_bus_addr(),
+            limits: s.a11y_limits,
+        };
+        s.accessibility.as_mut()?.subscribe_changes(&ctx)
+    }
+
     pub fn a11y_resnapshot(&mut self) -> Result<AxTree> {
         self.snapshot_at_current_limits()
     }

--- a/crates/glass-core/src/session/mod.rs
+++ b/crates/glass-core/src/session/mod.rs
@@ -2,8 +2,9 @@
 //! its operations are grouped into submodules (each adds an `impl Glass` block).
 
 use crate::accessibility::{
-    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxTarget, AxTree, ClickMethod,
-    ElementCondition, ElementInfo, ElementMatch, WalkLimits, element_match,
+    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxTarget, AxTree, ChangeSignal,
+    ChangeWait, ClickMethod, ElementCondition, ElementInfo, ElementMatch, WalkLimits,
+    element_match,
 };
 use crate::baseline::BaselineStore;
 use crate::diff::{

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -636,6 +636,20 @@ impl ChangeSignal for DeadSignal {
     }
 }
 
+/// A signal that reports one change, then goes quiet — an app that does the thing being waited
+/// for and then settles, which is the shape of every wait that succeeds.
+pub(crate) struct SignalsOnce(pub(crate) bool);
+impl ChangeSignal for SignalsOnce {
+    fn wait(&mut self, timeout: Duration) -> ChangeWait {
+        if self.0 {
+            self.0 = false;
+            return ChangeWait::Changed;
+        }
+        std::thread::sleep(timeout);
+        ChangeWait::Quiet
+    }
+}
+
 /// A signal that always reports a change immediately — a chatty app.
 pub(crate) struct AlwaysSignals;
 impl ChangeSignal for AlwaysSignals {

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -544,6 +544,9 @@ pub(crate) struct SeqAccessibility {
     walks: Arc<AtomicUsize>,
     /// What `subscribe_changes` hands back — `None` models every backend without an event stream.
     signal: Option<fn() -> Box<dyn ChangeSignal>>,
+    /// How many times a subscription was asked for. A wait that subscribes when it cannot use the
+    /// signal pays a round-trip for nothing.
+    subscribes: Arc<AtomicUsize>,
 }
 
 impl Accessibility for SeqAccessibility {
@@ -554,6 +557,7 @@ impl Accessibility for SeqAccessibility {
         Ok(t)
     }
     fn subscribe_changes(&mut self, _ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
+        self.subscribes.fetch_add(1, Ordering::Relaxed);
         self.signal.map(|make| make())
     }
     fn set_value(&mut self, _ctx: &AxContext, _t: &AxTarget, _s: &str) -> Result<()> {
@@ -590,6 +594,7 @@ pub(crate) fn glass_with_a11y_seq_invoke(
             invoke_log: invoke_log.clone(),
             walks: Arc::new(AtomicUsize::new(0)),
             signal: None,
+            subscribes: Arc::new(AtomicUsize::new(0)),
         }),
     );
     (g, invoke_log)
@@ -604,7 +609,18 @@ pub(crate) fn glass_with_a11y_counted(
     trees: Vec<AxTree>,
     signal: Option<fn() -> Box<dyn ChangeSignal>>,
 ) -> (Glass, Arc<AtomicUsize>) {
+    let (g, walks, _) = glass_with_a11y_counted_subs(platform, trees, signal);
+    (g, walks)
+}
+
+/// [`glass_with_a11y_counted`], also reporting how many times a subscription was requested.
+pub(crate) fn glass_with_a11y_counted_subs(
+    platform: FakePlatform,
+    trees: Vec<AxTree>,
+    signal: Option<fn() -> Box<dyn ChangeSignal>>,
+) -> (Glass, Arc<AtomicUsize>, Arc<AtomicUsize>) {
     let walks = Arc::new(AtomicUsize::new(0));
+    let subscribes = Arc::new(AtomicUsize::new(0));
     let g = glass_with_backend(
         platform,
         Box::new(SeqAccessibility {
@@ -614,9 +630,10 @@ pub(crate) fn glass_with_a11y_counted(
             invoke_log: Arc::new(Mutex::new(Vec::new())),
             walks: walks.clone(),
             signal,
+            subscribes: subscribes.clone(),
         }),
     );
-    (g, walks)
+    (g, walks, subscribes)
 }
 
 /// A signal that never reports a change — a quiet UI.
@@ -646,6 +663,30 @@ impl ChangeSignal for SignalsOnce {
             return ChangeWait::Changed;
         }
         std::thread::sleep(timeout);
+        ChangeWait::Quiet
+    }
+}
+
+/// A signal that reports a change partway through each wait — a chatty app whose events arrive
+/// mid-interval, which is what makes the caller's pacing arithmetic observable.
+pub(crate) struct ChangesMidInterval;
+impl ChangeSignal for ChangesMidInterval {
+    fn wait(&mut self, timeout: Duration) -> ChangeWait {
+        std::thread::sleep(timeout / 2);
+        ChangeWait::Changed
+    }
+}
+
+/// A signal that answers `Quiet` without blocking for the timeout — an implementation that keeps
+/// half of [`ChangeSignal::wait`]'s contract. The loop must survive it; counted, because the
+/// failure is CPU burn, which nothing else here would notice.
+pub(crate) struct QuietWithoutBlocking;
+
+pub(crate) static QUIET_WITHOUT_BLOCKING_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+impl ChangeSignal for QuietWithoutBlocking {
+    fn wait(&mut self, _timeout: Duration) -> ChangeWait {
+        QUIET_WITHOUT_BLOCKING_CALLS.fetch_add(1, Ordering::Relaxed);
         ChangeWait::Quiet
     }
 }

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -619,8 +619,7 @@ pub(crate) fn glass_with_a11y_counted(
     (g, walks)
 }
 
-/// A signal that never reports a change — a quiet UI, where the whole point is that the wait
-/// stops re-walking.
+/// A signal that never reports a change — a quiet UI.
 pub(crate) struct NeverSignals;
 impl ChangeSignal for NeverSignals {
     fn wait(&mut self, timeout: Duration) -> ChangeWait {
@@ -629,8 +628,7 @@ impl ChangeSignal for NeverSignals {
     }
 }
 
-/// A signal that stops working immediately — the case that must degrade to polling rather than to
-/// a wait that never looks again.
+/// A signal that stops working immediately.
 pub(crate) struct DeadSignal;
 impl ChangeSignal for DeadSignal {
     fn wait(&mut self, _timeout: Duration) -> ChangeWait {
@@ -638,8 +636,7 @@ impl ChangeSignal for DeadSignal {
     }
 }
 
-/// A signal that always reports a change immediately — a chatty app. The loop must stay bounded by
-/// its deadline rather than spinning on it.
+/// A signal that always reports a change immediately — a chatty app.
 pub(crate) struct AlwaysSignals;
 impl ChangeSignal for AlwaysSignals {
     fn wait(&mut self, _timeout: Duration) -> ChangeWait {

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -4,11 +4,12 @@
 
 pub(crate) use super::*;
 pub(crate) use crate::accessibility::{
-    AxNode, AxRect, AxRole, AxStates, AxTarget, ElementCondition,
+    AxNode, AxRect, AxRole, AxStates, AxTarget, ChangeSignal, ChangeWait, ElementCondition,
 };
 pub(crate) use crate::audit::{Actuation, ActuationContext, AuditOutcome, AuditSink};
 pub(crate) use crate::platform::{SandboxLevel, Segment};
 pub(crate) use std::collections::VecDeque;
+pub(crate) use std::sync::atomic::{AtomicUsize, Ordering};
 pub(crate) use std::sync::{Arc, Mutex};
 pub(crate) use std::time::Duration;
 
@@ -538,13 +539,22 @@ pub(crate) struct SeqAccessibility {
     idx: usize,
     invoke_behavior: InvokeBehavior,
     invoke_log: Arc<Mutex<Vec<AxTarget>>>,
+    /// How many walks this backend was asked for. Wall-clock cannot tell a wait that waited
+    /// efficiently from one that walked slowly; the count can.
+    walks: Arc<AtomicUsize>,
+    /// What `subscribe_changes` hands back — `None` models every backend without an event stream.
+    signal: Option<fn() -> Box<dyn ChangeSignal>>,
 }
 
 impl Accessibility for SeqAccessibility {
     fn snapshot(&mut self, _ctx: &AxContext) -> Result<AxTree> {
+        self.walks.fetch_add(1, Ordering::Relaxed);
         let t = self.trees[self.idx.min(self.trees.len() - 1)].clone();
         self.idx += 1;
         Ok(t)
+    }
+    fn subscribe_changes(&mut self, _ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
+        self.signal.map(|make| make())
     }
     fn set_value(&mut self, _ctx: &AxContext, _t: &AxTarget, _s: &str) -> Result<()> {
         Ok(())
@@ -578,9 +588,63 @@ pub(crate) fn glass_with_a11y_seq_invoke(
             idx: 0,
             invoke_behavior: behavior,
             invoke_log: invoke_log.clone(),
+            walks: Arc::new(AtomicUsize::new(0)),
+            signal: None,
         }),
     );
     (g, invoke_log)
+}
+
+/// A session whose accessibility backend counts walks and hands out `signal`.
+///
+/// `signal` is a constructor rather than a value because `subscribe_changes` may be called more
+/// than once in a session's life; `None` models a backend with no event stream at all.
+pub(crate) fn glass_with_a11y_counted(
+    platform: FakePlatform,
+    trees: Vec<AxTree>,
+    signal: Option<fn() -> Box<dyn ChangeSignal>>,
+) -> (Glass, Arc<AtomicUsize>) {
+    let walks = Arc::new(AtomicUsize::new(0));
+    let g = glass_with_backend(
+        platform,
+        Box::new(SeqAccessibility {
+            trees,
+            idx: 0,
+            invoke_behavior: InvokeBehavior::Unsupported,
+            invoke_log: Arc::new(Mutex::new(Vec::new())),
+            walks: walks.clone(),
+            signal,
+        }),
+    );
+    (g, walks)
+}
+
+/// A signal that never reports a change — a quiet UI, where the whole point is that the wait
+/// stops re-walking.
+pub(crate) struct NeverSignals;
+impl ChangeSignal for NeverSignals {
+    fn wait(&mut self, timeout: Duration) -> ChangeWait {
+        std::thread::sleep(timeout);
+        ChangeWait::Quiet
+    }
+}
+
+/// A signal that stops working immediately — the case that must degrade to polling rather than to
+/// a wait that never looks again.
+pub(crate) struct DeadSignal;
+impl ChangeSignal for DeadSignal {
+    fn wait(&mut self, _timeout: Duration) -> ChangeWait {
+        ChangeWait::Unusable
+    }
+}
+
+/// A signal that always reports a change immediately — a chatty app. The loop must stay bounded by
+/// its deadline rather than spinning on it.
+pub(crate) struct AlwaysSignals;
+impl ChangeSignal for AlwaysSignals {
+    fn wait(&mut self, _timeout: Duration) -> ChangeWait {
+        ChangeWait::Changed
+    }
 }
 
 pub(crate) fn named_node(id: u32, role: AxRole, name: &str, bounds: AxRect) -> AxNode {

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -370,21 +370,47 @@ impl Glass {
     /// the backend has no accessibility reader (the first snapshot fails).
     pub fn wait_for_element(&mut self, params: &WaitElementParams) -> Result<WaitElementOutcome> {
         self.require_active()?; // fail fast; a11y_snapshot rechecks inside the loop
-        let outcome = crate::poll::poll_until(params.interval_ms, params.timeout_ms, || {
-            let tree = self.a11y_resnapshot()?; // fresh snapshot; assigns ids, caches, pumps
-            Ok(
-                match element_match(
-                    &tree,
-                    params.name.as_deref(),
-                    params.role,
-                    params.value_contains.as_deref(),
-                    params.condition,
-                ) {
-                    ElementMatch::Satisfied(node) => Some(node.map(ElementInfo::from_node)),
-                    ElementMatch::Pending => None,
+        // Subscribed before the first walk: a change landing between the two would otherwise be
+        // lost, and the wait would sleep out an interval on a tree that already matches.
+        let mut signal = self.subscribe_a11y_changes();
+        let outcome = crate::poll::poll_until_with_pause(
+            params.interval_ms,
+            params.timeout_ms,
+            // A backend that can say "nothing changed" saves the walk; one that cannot sleeps
+            // exactly as before. Either way the interval bounds the wait, so a subscription that
+            // dies silently costs latency, never a hang.
+            |d| match signal.as_mut() {
+                Some(s) => match s.wait(d) {
+                    ChangeWait::Changed => true,
+                    ChangeWait::Quiet => false,
+                    // A signal that can no longer tell must not look like a permanently quiet app,
+                    // or the wait would stop reading the tree and never see what it waits for.
+                    ChangeWait::Unusable => {
+                        signal = None;
+                        true
+                    }
                 },
-            )
-        })?;
+                None => {
+                    std::thread::sleep(d);
+                    true
+                }
+            },
+            || {
+                let tree = self.a11y_resnapshot()?; // fresh snapshot; assigns ids, caches, pumps
+                Ok(
+                    match element_match(
+                        &tree,
+                        params.name.as_deref(),
+                        params.role,
+                        params.value_contains.as_deref(),
+                        params.condition,
+                    ) {
+                        ElementMatch::Satisfied(node) => Some(node.map(ElementInfo::from_node)),
+                        ElementMatch::Pending => None,
+                    },
+                )
+            },
+        )?;
         Ok(WaitElementOutcome {
             matched: outcome.value.is_some(),
             element: outcome.value.flatten(),
@@ -1153,6 +1179,91 @@ mod tests {
         let e = o.element.expect("matched element");
         assert_eq!(e.id, AxNodeId(1));
         assert_eq!(e.name.as_deref(), Some("Save"));
+    }
+
+    /// A condition the fixed fake tree never satisfies, so the wait runs its full budget.
+    fn never_matches(interval_ms: u64, timeout_ms: u64) -> WaitElementParams {
+        WaitElementParams {
+            name: Some("Save".into()),
+            role: None,
+            value_contains: None,
+            condition: ElementCondition::Checked,
+            interval_ms,
+            timeout_ms,
+        }
+    }
+
+    #[test]
+    fn a_quiet_wait_walks_once() {
+        // The point of the change: told nothing changed, the wait must not re-read the tree. On a
+        // real backend each of those reads is a full walk — 732ms on a 1500-node AT-SPI tree.
+        let (mut g, walks) = glass_with_a11y_counted(
+            FakePlatform::new(100, 100),
+            vec![fake_tree_enabled()],
+            Some(|| Box::new(NeverSignals) as Box<dyn ChangeSignal>),
+        );
+        g.start(&spec()).unwrap();
+
+        let o = g.wait_for_element(&never_matches(20, 120)).unwrap();
+
+        assert!(!o.matched);
+        assert_eq!(walks.load(Ordering::Relaxed), 1, "a quiet wait re-walked");
+    }
+
+    #[test]
+    fn a_signal_that_never_stops_firing_stays_bounded_by_the_deadline() {
+        // A chatty app must not turn the loop into a spin: the pause may return early, but the
+        // deadline still governs, so the walk count stays in the same order as the interval allows.
+        let (mut g, walks) = glass_with_a11y_counted(
+            FakePlatform::new(100, 100),
+            vec![fake_tree_enabled()],
+            Some(|| Box::new(AlwaysSignals) as Box<dyn ChangeSignal>),
+        );
+        g.start(&spec()).unwrap();
+
+        let o = g.wait_for_element(&never_matches(20, 60)).unwrap();
+
+        assert!(!o.matched);
+        let n = walks.load(Ordering::Relaxed);
+        assert!(n > 1, "an always-firing signal should re-walk; walked {n}");
+    }
+
+    #[test]
+    fn a_signal_that_stops_working_falls_back_to_polling() {
+        // The failure that would be invisible: a dead subscription reports no changes, which is
+        // indistinguishable from a quiet app unless it says so — and a wait that believed it would
+        // stop reading the tree and never see what it is waiting for.
+        let (mut g, walks) = glass_with_a11y_counted(
+            FakePlatform::new(100, 100),
+            vec![fake_tree_enabled()],
+            Some(|| Box::new(DeadSignal) as Box<dyn ChangeSignal>),
+        );
+        g.start(&spec()).unwrap();
+
+        let o = g.wait_for_element(&never_matches(20, 80)).unwrap();
+
+        assert!(!o.matched);
+        assert!(
+            walks.load(Ordering::Relaxed) > 1,
+            "a dead signal must degrade to polling, not to silence"
+        );
+    }
+
+    #[test]
+    fn a_backend_without_a_signal_polls_exactly_as_before() {
+        // Every backend but one has no event stream, and two never can. Their waits must keep the
+        // behaviour they had: re-walk each interval.
+        let (mut g, walks) =
+            glass_with_a11y_counted(FakePlatform::new(100, 100), vec![fake_tree_enabled()], None);
+        g.start(&spec()).unwrap();
+
+        let o = g.wait_for_element(&never_matches(10, 80)).unwrap();
+
+        assert!(!o.matched);
+        assert!(
+            walks.load(Ordering::Relaxed) > 1,
+            "a backend with no signal stopped polling"
+        );
     }
 
     #[test]

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -2,7 +2,7 @@
 //! and the wait/scroll parameter and outcome types.
 use super::*;
 
-/// How many consecutive "nothing changed" answers to accept before reading the tree anyway.
+/// How many "nothing changed" answers to accept before reading the tree anyway.
 ///
 /// A signal reports the change classes it subscribed to, from the senders it resolved; anything
 /// outside that would otherwise let a wait answer "not matched" without ever looking again — a
@@ -397,7 +397,7 @@ impl Glass {
         let remaining = params
             .timeout_ms
             .saturating_sub(started.elapsed().as_millis() as u64);
-        let mut quiet_runs = 0u32;
+        let mut quiet_budget = QUIET_RUNS_BEFORE_REREAD;
         let outcome = crate::poll::poll_until_with_pause(
             params.interval_ms,
             remaining,
@@ -405,29 +405,17 @@ impl Glass {
             // exactly as before.
             |d| {
                 let paused_at = std::time::Instant::now();
-                match signal.as_mut() {
+                let read_now = match signal.as_mut() {
                     Some(s) => match s.wait(d) {
-                        ChangeWait::Changed => {
-                            quiet_runs = 0;
-                            // Wake early, but never walk sooner than one interval after the last one.
-                            // A chatty app (spinner, clock, progress bar) would otherwise drive
-                            // back-to-back walks with no gap, hammering the same bus the app is trying
-                            // to serve: the interval is a contract with the app under test, not just a
-                            // sleep the caller wanted skipped.
-                            let spent = paused_at.elapsed();
-                            if spent < d {
-                                std::thread::sleep(d - spent);
-                            }
-                            true
-                        }
+                        ChangeWait::Changed => true,
                         // Re-read anyway now and then. The signal reports the change classes it
-                        // subscribed to, from the sender it resolved; anything outside that would
+                        // subscribed to, from the senders it resolved; anything outside that would
                         // otherwise make the wait answer "not matched" without ever looking — turning
                         // a cost optimization into a wrong result.
                         ChangeWait::Quiet => {
-                            quiet_runs += 1;
-                            if quiet_runs >= QUIET_RUNS_BEFORE_REREAD {
-                                quiet_runs = 0;
+                            quiet_budget = quiet_budget.saturating_sub(1);
+                            if quiet_budget == 0 {
+                                quiet_budget = QUIET_RUNS_BEFORE_REREAD;
                                 true
                             } else {
                                 false
@@ -439,11 +427,14 @@ impl Glass {
                             true
                         }
                     },
-                    None => {
-                        std::thread::sleep(d);
-                        true
-                    }
-                }
+                    None => true,
+                };
+                // One interval between reads, whatever woke us. A chatty app (spinner, clock,
+                // progress bar) would otherwise drive back-to-back walks with no gap, hammering the
+                // same bus the app is trying to serve — and a signal that returns early without
+                // blocking, which nothing here can enforce, would spin this loop at full tilt.
+                std::thread::sleep(d.saturating_sub(paused_at.elapsed()));
+                read_now
             },
             || {
                 let tree = self.a11y_resnapshot()?; // fresh snapshot; assigns ids, caches, pumps
@@ -1267,6 +1258,26 @@ mod tests {
     }
 
     #[test]
+    fn a_signal_that_never_blocks_does_not_spin_the_loop() {
+        // `wait` must block for the timeout it is handed, and nothing in the seam can enforce that,
+        // so the loop paces itself: a signal that answers instantly would otherwise turn a 200ms
+        // wait into 200ms of a pegged core.
+        QUIET_WITHOUT_BLOCKING_CALLS.store(0, Ordering::Relaxed);
+        let (mut g, _walks) = glass_with_a11y_counted(
+            FakePlatform::new(100, 100),
+            vec![fake_tree_enabled()],
+            Some(|| Box::new(QuietWithoutBlocking) as Box<dyn ChangeSignal>),
+        );
+        g.start(&spec()).unwrap();
+
+        let _ = g.wait_for_element(&never_matches(20, 200)).unwrap();
+
+        // Ten intervals fit in the budget; a spin runs to thousands.
+        let calls = QUIET_WITHOUT_BLOCKING_CALLS.load(Ordering::Relaxed);
+        assert!(calls <= 40, "the loop spun: {calls} pauses in ten intervals");
+    }
+
+    #[test]
     fn a_change_wakes_the_wait_and_it_finds_the_element() {
         // The contract, which every other test here leaves untested: they all wait for something
         // that never matches, so they would pass on a wait that skipped every read forever.
@@ -1306,16 +1317,85 @@ mod tests {
         );
         g.start(&spec()).unwrap();
 
-        let o = g.wait_for_element(&never_matches(20, 100)).unwrap();
+        let o = g.wait_for_element(&never_matches(20, 200)).unwrap();
 
         assert!(!o.matched);
         let n = walks.load(Ordering::Relaxed);
-        assert!(n > 1, "an always-firing signal should re-walk; walked {n}");
-        // And no faster than polling would: waking early must not remove the interval's ceiling,
-        // or a chatty app turns every wait into back-to-back walks against the app's own bus.
+        // A band, not a ceiling. Too many: waking early removed the interval's pacing, and a
+        // chatty app drives back-to-back walks against the bus it is trying to serve. Too few: the
+        // pacing over-sleeps, making the wake slower than the polling it replaced.
         assert!(
-            n <= 100 / 20 + 2,
-            "a chatty app drove {n} walks in 100ms at a 20ms interval"
+            (7..=12).contains(&n),
+            "a chatty app drove {n} walks in 200ms at a 20ms interval"
+        );
+    }
+
+    #[test]
+    fn a_long_quiet_wait_reads_anyway_now_and_then() {
+        // The ceiling: a signal reports only what it subscribed to, so believing "quiet" forever
+        // would let a wait answer "not matched" without ever looking again. 25 intervals is two
+        // ceilings, so two forced reads on top of the first.
+        let (mut g, walks) = glass_with_a11y_counted(
+            FakePlatform::new(100, 100),
+            vec![fake_tree_enabled()],
+            Some(|| Box::new(NeverSignals) as Box<dyn ChangeSignal>),
+        );
+        g.start(&spec()).unwrap();
+
+        let o = g.wait_for_element(&never_matches(10, 250)).unwrap();
+
+        assert!(!o.matched);
+        let n = walks.load(Ordering::Relaxed);
+        assert!(
+            (2..=5).contains(&n),
+            "a quiet 250ms wait at a 10ms interval read {n} times; the ceiling is not firing"
+        );
+    }
+
+    #[test]
+    fn an_interval_of_zero_does_not_subscribe() {
+        // With no pause there is nothing a signal could save, and subscribing is a round-trip of
+        // its own — paid, on a real backend, out of the caller's budget.
+        let (mut g, walks, subscribes) = glass_with_a11y_counted_subs(
+            FakePlatform::new(100, 100),
+            vec![fake_tree_enabled()],
+            Some(|| Box::new(NeverSignals) as Box<dyn ChangeSignal>),
+        );
+        g.start(&spec()).unwrap();
+
+        let o = g.wait_for_element(&never_matches(0, 30)).unwrap();
+
+        assert!(!o.matched);
+        assert_eq!(
+            subscribes.load(Ordering::Relaxed),
+            0,
+            "subscribed for nothing"
+        );
+        assert!(
+            walks.load(Ordering::Relaxed) > 1,
+            "an interval of 0 must keep re-reading"
+        );
+    }
+
+    #[test]
+    fn a_change_arriving_mid_interval_still_paces_the_next_read() {
+        // The pacing is "wake early, but no sooner than one interval after the last read". A signal
+        // whose change lands halfway through is what tells the two arithmetics apart: sleeping the
+        // *remainder* keeps one read per interval, sleeping the elapsed time again halves the rate.
+        let (mut g, walks) = glass_with_a11y_counted(
+            FakePlatform::new(100, 100),
+            vec![fake_tree_enabled()],
+            Some(|| Box::new(ChangesMidInterval) as Box<dyn ChangeSignal>),
+        );
+        g.start(&spec()).unwrap();
+
+        let o = g.wait_for_element(&never_matches(20, 200)).unwrap();
+
+        assert!(!o.matched);
+        let n = walks.load(Ordering::Relaxed);
+        assert!(
+            (7..=12).contains(&n),
+            "a mid-interval change drove {n} walks in 200ms at a 20ms interval"
         );
     }
 

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -2,6 +2,14 @@
 //! and the wait/scroll parameter and outcome types.
 use super::*;
 
+/// How many consecutive "nothing changed" answers to accept before reading the tree anyway.
+///
+/// A signal reports the change classes it subscribed to, from the senders it resolved; anything
+/// outside that would otherwise let a wait answer "not matched" without ever looking again — a
+/// wrong result rather than a slow one. This bounds that to added latency: at the default 100ms
+/// interval, one re-read per second no matter what the platform does or does not announce.
+const QUIET_RUNS_BEFORE_REREAD: u32 = 10;
+
 /// Parameters for [`Glass::wait_stable`].
 #[derive(Clone, Debug)]
 pub struct WaitStableParams {
@@ -308,9 +316,10 @@ pub struct WaitLogOutcome {
 }
 
 impl Glass {
-    /// Not event-gated: this waits on *pixels* settling, and an accessibility event says nothing
-    /// about whether the frame stopped changing (an animation emits no a11y events; a tree change
-    /// may not move a pixel).
+    /// Wait until the screen stops changing.
+    ///
+    /// Not event-gated, and must not be: this waits on *pixels* settling, and an accessibility
+    /// event says nothing about that — an animation emits none, and a tree change may move none.
     pub fn wait_stable(&mut self, params: &WaitStableParams) -> Result<WaitStableOutcome> {
         let active = self.require_active()?;
         // The active window's cached geometry only bounds a stability_region when
@@ -373,27 +382,67 @@ impl Glass {
     /// the backend has no accessibility reader (the first snapshot fails).
     pub fn wait_for_element(&mut self, params: &WaitElementParams) -> Result<WaitElementOutcome> {
         self.require_active()?; // fail fast; a11y_snapshot rechecks inside the loop
-        // Subscribed before the first walk: a change landing between the two would otherwise be
-        // lost, and the wait would sleep out an interval on a tree that already matches.
-        let mut signal = self.subscribe_a11y_changes();
+        let started = std::time::Instant::now();
+        // Before the first walk, not after: a change landing in that gap is announced to nobody,
+        // and the wait then burns its whole budget on a condition that already holds.
+        //
+        // An interval of 0 means "re-read as fast as you can", which never pauses — so there is
+        // nothing for a signal to save, and subscribing would only cost a round-trip.
+        let mut signal = (params.interval_ms > 0)
+            .then(|| self.subscribe_a11y_changes())
+            .flatten();
+        // Subscribing costs a round-trip of its own, and it is the caller's budget it spends: a
+        // wait told to give up after 500ms must not take longer because establishing a
+        // subscription was slow.
+        let remaining = params
+            .timeout_ms
+            .saturating_sub(started.elapsed().as_millis() as u64);
+        let mut quiet_runs = 0u32;
         let outcome = crate::poll::poll_until_with_pause(
             params.interval_ms,
-            params.timeout_ms,
+            remaining,
             // A backend that can say "nothing changed" saves the walk; one that cannot sleeps
             // exactly as before.
-            |d| match signal.as_mut() {
-                Some(s) => match s.wait(d) {
-                    ChangeWait::Changed => true,
-                    ChangeWait::Quiet => false,
-                    // See `ChangeWait`: an unusable signal must not read as a quiet one.
-                    ChangeWait::Unusable => {
-                        signal = None;
+            |d| {
+                let paused_at = std::time::Instant::now();
+                match signal.as_mut() {
+                    Some(s) => match s.wait(d) {
+                        ChangeWait::Changed => {
+                            quiet_runs = 0;
+                            // Wake early, but never walk sooner than one interval after the last one.
+                            // A chatty app (spinner, clock, progress bar) would otherwise drive
+                            // back-to-back walks with no gap, hammering the same bus the app is trying
+                            // to serve: the interval is a contract with the app under test, not just a
+                            // sleep the caller wanted skipped.
+                            let spent = paused_at.elapsed();
+                            if spent < d {
+                                std::thread::sleep(d - spent);
+                            }
+                            true
+                        }
+                        // Re-read anyway now and then. The signal reports the change classes it
+                        // subscribed to, from the sender it resolved; anything outside that would
+                        // otherwise make the wait answer "not matched" without ever looking — turning
+                        // a cost optimization into a wrong result.
+                        ChangeWait::Quiet => {
+                            quiet_runs += 1;
+                            if quiet_runs >= QUIET_RUNS_BEFORE_REREAD {
+                                quiet_runs = 0;
+                                true
+                            } else {
+                                false
+                            }
+                        }
+                        // See `ChangeWait`: an unusable signal must not read as a quiet one.
+                        ChangeWait::Unusable => {
+                            signal = None;
+                            true
+                        }
+                    },
+                    None => {
+                        std::thread::sleep(d);
                         true
                     }
-                },
-                None => {
-                    std::thread::sleep(d);
-                    true
                 }
             },
             || {
@@ -415,7 +464,9 @@ impl Glass {
         Ok(WaitElementOutcome {
             matched: outcome.value.is_some(),
             element: outcome.value.flatten(),
-            elapsed_ms: outcome.elapsed_ms,
+            // From before the subscription, not from the poll loop: the agent is told how long the
+            // call took, and the subscribe is part of it.
+            elapsed_ms: started.elapsed().as_millis() as u64,
         })
     }
 
@@ -643,8 +694,9 @@ impl Glass {
     /// scanning from `cursor` (default: the buffer end at call start, so only new
     /// lines count). Returns the matched line and a resume cursor; on timeout
     /// returns `{matched:false}` with the current end cursor.
-    /// Not event-gated: each tick reads the in-process log buffer, which costs nothing to re-read
-    /// — there is no walk here to save.
+    /// Not event-gated, and must not be: an app writes to stdout without emitting any accessibility
+    /// event — a canvas app emits none at all — so a gated loop would miss lines for a whole
+    /// timeout.
     pub fn wait_for_log(&mut self, params: &WaitLogParams) -> Result<WaitLogOutcome> {
         let start_cursor = {
             let s = self.active_mut()?;
@@ -1215,6 +1267,35 @@ mod tests {
     }
 
     #[test]
+    fn a_change_wakes_the_wait_and_it_finds_the_element() {
+        // The contract, which every other test here leaves untested: they all wait for something
+        // that never matches, so they would pass on a wait that skipped every read forever.
+        let (mut g, walks) = glass_with_a11y_counted(
+            FakePlatform::new(100, 100),
+            vec![fake_tree(), fake_tree_enabled()],
+            Some(|| Box::new(SignalsOnce(true)) as Box<dyn ChangeSignal>),
+        );
+        g.start(&spec()).unwrap();
+
+        let o = g
+            .wait_for_element(&WaitElementParams {
+                name: Some("Save".into()),
+                role: None,
+                value_contains: None,
+                condition: ElementCondition::Enabled,
+                // Shorter than the quiet ceiling (10 intervals): otherwise a wait that ignored the
+                // change entirely would still match on the forced re-read, and this test would
+                // pass without the wake it exists to prove.
+                interval_ms: 20,
+                timeout_ms: 120,
+            })
+            .unwrap();
+
+        assert!(o.matched, "the change was announced but never read");
+        assert_eq!(walks.load(Ordering::Relaxed), 2, "one read per state");
+    }
+
+    #[test]
     fn a_signal_that_never_stops_firing_stays_bounded_by_the_deadline() {
         // A chatty app must not turn the loop into a spin: the pause may return early, but the
         // deadline still governs, so the walk count stays in the same order as the interval allows.
@@ -1225,11 +1306,17 @@ mod tests {
         );
         g.start(&spec()).unwrap();
 
-        let o = g.wait_for_element(&never_matches(20, 60)).unwrap();
+        let o = g.wait_for_element(&never_matches(20, 100)).unwrap();
 
         assert!(!o.matched);
         let n = walks.load(Ordering::Relaxed);
         assert!(n > 1, "an always-firing signal should re-walk; walked {n}");
+        // And no faster than polling would: waking early must not remove the interval's ceiling,
+        // or a chatty app turns every wait into back-to-back walks against the app's own bus.
+        assert!(
+            n <= 100 / 20 + 2,
+            "a chatty app drove {n} walks in 100ms at a 20ms interval"
+        );
     }
 
     #[test]

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -380,14 +380,12 @@ impl Glass {
             params.interval_ms,
             params.timeout_ms,
             // A backend that can say "nothing changed" saves the walk; one that cannot sleeps
-            // exactly as before. Either way the interval bounds the wait, so a subscription that
-            // dies silently costs latency, never a hang.
+            // exactly as before.
             |d| match signal.as_mut() {
                 Some(s) => match s.wait(d) {
                     ChangeWait::Changed => true,
                     ChangeWait::Quiet => false,
-                    // A signal that can no longer tell must not look like a permanently quiet app,
-                    // or the wait would stop reading the tree and never see what it waits for.
+                    // See `ChangeWait`: an unusable signal must not read as a quiet one.
                     ChangeWait::Unusable => {
                         signal = None;
                         true
@@ -1202,8 +1200,7 @@ mod tests {
 
     #[test]
     fn a_quiet_wait_walks_once() {
-        // The point of the change: told nothing changed, the wait must not re-read the tree. On a
-        // real backend each of those reads is a full walk — 732ms on a 1500-node AT-SPI tree.
+        // The point of the change: told nothing changed, the wait must not re-read the tree.
         let (mut g, walks) = glass_with_a11y_counted(
             FakePlatform::new(100, 100),
             vec![fake_tree_enabled()],
@@ -1238,8 +1235,7 @@ mod tests {
     #[test]
     fn a_signal_that_stops_working_falls_back_to_polling() {
         // The failure that would be invisible: a dead subscription reports no changes, which is
-        // indistinguishable from a quiet app unless it says so — and a wait that believed it would
-        // stop reading the tree and never see what it is waiting for.
+        // indistinguishable from a quiet app unless it says so.
         let (mut g, walks) = glass_with_a11y_counted(
             FakePlatform::new(100, 100),
             vec![fake_tree_enabled()],

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -308,6 +308,9 @@ pub struct WaitLogOutcome {
 }
 
 impl Glass {
+    /// Not event-gated: this waits on *pixels* settling, and an accessibility event says nothing
+    /// about whether the frame stopped changing (an animation emits no a11y events; a tree change
+    /// may not move a pixel).
     pub fn wait_stable(&mut self, params: &WaitStableParams) -> Result<WaitStableOutcome> {
         let active = self.require_active()?;
         // The active window's cached geometry only bounds a stability_region when
@@ -570,6 +573,8 @@ impl Glass {
     /// crop to a stable `region` to avoid this. `ignore` excludes window-relative
     /// sub-rectangles from every comparison — pixels there never count toward
     /// `changed`/`matches` (see `WaitRegionParams::ignore`).
+    /// Not event-gated, for the same reason as [`Glass::wait_stable`]: the subject is a captured
+    /// region, not the accessibility tree.
     pub fn wait_for_region(&mut self, params: &WaitRegionParams) -> Result<WaitRegionOutcome> {
         let active = self.require_active()?;
         // As in `wait_stable`: the active window's cached geometry only bounds
@@ -640,6 +645,8 @@ impl Glass {
     /// scanning from `cursor` (default: the buffer end at call start, so only new
     /// lines count). Returns the matched line and a resume cursor; on timeout
     /// returns `{matched:false}` with the current end cursor.
+    /// Not event-gated: each tick reads the in-process log buffer, which costs nothing to re-read
+    /// — there is no walk here to save.
     pub fn wait_for_log(&mut self, params: &WaitLogParams) -> Result<WaitLogOutcome> {
         let start_cursor = {
             let s = self.active_mut()?;

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -401,17 +401,12 @@ impl Glass {
         let outcome = crate::poll::poll_until_with_pause(
             params.interval_ms,
             remaining,
-            // A backend that can say "nothing changed" saves the walk; one that cannot sleeps
-            // exactly as before.
             |d| {
                 let paused_at = std::time::Instant::now();
                 let read_now = match signal.as_mut() {
                     Some(s) => match s.wait(d) {
                         ChangeWait::Changed => true,
-                        // Re-read anyway now and then. The signal reports the change classes it
-                        // subscribed to, from the senders it resolved; anything outside that would
-                        // otherwise make the wait answer "not matched" without ever looking — turning
-                        // a cost optimization into a wrong result.
+                        // Read anyway now and then — see `QUIET_RUNS_BEFORE_REREAD`.
                         ChangeWait::Quiet => {
                             quiet_budget = quiet_budget.saturating_sub(1);
                             if quiet_budget == 0 {
@@ -1274,7 +1269,10 @@ mod tests {
 
         // Ten intervals fit in the budget; a spin runs to thousands.
         let calls = QUIET_WITHOUT_BLOCKING_CALLS.load(Ordering::Relaxed);
-        assert!(calls <= 40, "the loop spun: {calls} pauses in ten intervals");
+        assert!(
+            calls <= 40,
+            "the loop spun: {calls} pauses in ten intervals"
+        );
     }
 
     #[test]
@@ -1308,8 +1306,6 @@ mod tests {
 
     #[test]
     fn a_signal_that_never_stops_firing_stays_bounded_by_the_deadline() {
-        // A chatty app must not turn the loop into a spin: the pause may return early, but the
-        // deadline still governs, so the walk count stays in the same order as the interval allows.
         let (mut g, walks) = glass_with_a11y_counted(
             FakePlatform::new(100, 100),
             vec![fake_tree_enabled()],
@@ -1332,9 +1328,8 @@ mod tests {
 
     #[test]
     fn a_long_quiet_wait_reads_anyway_now_and_then() {
-        // The ceiling: a signal reports only what it subscribed to, so believing "quiet" forever
-        // would let a wait answer "not matched" without ever looking again. 25 intervals is two
-        // ceilings, so two forced reads on top of the first.
+        // 25 intervals is two `QUIET_RUNS_BEFORE_REREAD` ceilings, so two forced reads on top of
+        // the first.
         let (mut g, walks) = glass_with_a11y_counted(
             FakePlatform::new(100, 100),
             vec![fake_tree_enabled()],

--- a/scripts/test-a11y.sh
+++ b/scripts/test-a11y.sh
@@ -29,6 +29,16 @@ fi
 
 TEST_FILTER="${1:-}"
 
+# Three of these tests drive the app under Wayland, so they need the same sway >=1.12
+# scripts/test-wayland.sh does. Named, not silently dropped: a run that says nothing about them
+# reads as "the suite passed" when a quarter of the launch paths never ran.
+SKIP_ARGS=()
+SWAY_BUNDLE="${XDG_DATA_HOME:-$HOME/.local/share}/glass/sway/bin/sway"
+if [ ! -x "$SWAY_BUNDLE" ] && ! { command -v sway >/dev/null 2>&1 && sway --version 2>/dev/null | grep -qE 'version 1\.(1[2-9]|[2-9][0-9])'; }; then
+    echo "test-a11y: no glass-discoverable sway >=1.12 — skipping the wayland_a11y_* tests."
+    SKIP_ARGS=(--skip wayland_a11y)
+fi
+
 # Hermetic isolation: run the whole suite under a throwaway XDG_RUNTIME_DIR. AT-SPI derives its
 # socket dir from XDG_RUNTIME_DIR, so any at-spi-bus-launcher these tests spawn — through glass's
 # PrivateBus (which already overrides it) OR any other path — writes to this throwaway, NEVER the
@@ -46,4 +56,4 @@ export XDG_RUNTIME_DIR="$A11Y_TEST_RUNTIME"
 # org.a11y.Status.ScreenReaderEnabled advertisement that accesskit-based apps gate on) run
 # under the same throwaway XDG_RUNTIME_DIR isolation.
 cargo test -p glass-dbus-linux --lib -- --ignored --test-threads=1 "$TEST_FILTER"
-cargo test -p glass-a11y-linux --test integration -- --ignored --test-threads=1 "$TEST_FILTER"
+cargo test -p glass-a11y-linux --test integration -- --ignored --test-threads=1 "${SKIP_ARGS[@]}" "$TEST_FILTER"


### PR DESCRIPTION
`glass_wait_for_element` re-read the entire accessibility tree on every poll tick. The interval it is
nominally paced by is fiction on a large tree: a walk of the 1500-node cap measures 732ms against a
100ms default, so a wait for something that has not happened yet spent its whole budget re-reading a
tree that did not change.

## What changed

A `ChangeSignal` seam in `glass-core`, defaulted to `None` so every backend but one is untouched, and
an AT-SPI implementation on Linux. `poll_until`'s pause can now skip a tick rather than only delay it.

Measured on box against the GTK fixture — a quiet 3-second wait at a 100ms interval:

| | walks |
|---|---|
| polling (before) | 22 |
| event-gated | **3** |

Three, not one, because a quiet answer is only believed so far — see below.

## Why `Quiet` is not trusted indefinitely

A subscription reports the change classes it registered for, from the senders it resolved. Anything
outside that would let a wait answer `matched: false` without ever looking again — turning a cost
optimization into a wrong result, which is the one thing it must not do. So the loop re-reads anyway
every ten intervals. That bounds anything the platform does not announce to latency instead of a
wrong answer, and costs two extra walks out of the twenty-two saved.

## Things the review panel caught that were wrong

Worth listing, because they were not obvious:

- **The pump leaked.** It owned its own connection, so its stream never ended, and dropping the
  signal told it nothing. Every wait left behind a thread, a runtime, a bus connection and a registry
  registration — and that registration makes every app on the bus forward events, so a long session
  would have made its own walks slower.
- **The filter did not match how a walk works.** A walk crosses process boundaries (each child is
  proxied at its own bus name), so an app embedding an out-of-process view had its subtree walked
  while every event it emitted was dropped. It now matches every connection in the app's process set.
- **The stream was attached after the readiness handshake**, so events in that window were dropped
  for want of a receiver — the exact race the handshake exists to close.
- **Subscribing sat outside the wait's budget**, so a 500ms wait could take 2.5s and report 500ms.
- **Waking early removed the interval's ceiling**, so a chatty app drove back-to-back walks against
  the bus it was trying to serve.
- **Every test waited for something that never matched**, so all of them would have passed on a wait
  that skipped every read forever.

And, from the re-review of that fix wave:

- **The leak fix was reachable from one of the pump's four exits** — not the common one, an event
  arriving after the signal was dropped. The loop is now a function whose every return lands at the
  same caller.
- **The unsubscribe could hang where the leak used to be**: zbus's message channel does not
  overflow, so round-trips issued while a burst sits undelivered would stall on their own replies.
  The stream is dropped first, and the call is bounded.
- **Only a change paced the loop**, so a signal that answered "quiet" without blocking — half the
  seam's contract, and nothing can enforce it — would have spun a core for the whole wait. Pacing
  now covers every pause, pinned by a test that counts them.
- **A wait with no pid hint subscribed to the whole bus**: `app_matches` accepts every app in that
  case, so the filter passed everything. It now declines and polls, which is what it did before.

## Scope

Only one of glass's five poll loops reads the a11y tree on a timer. `wait_stable` and
`wait_for_region` wait on pixels, `wait_for_log` on an in-process buffer — gating either would make
them miss what they watch, not merely re-read less — and `set_value`'s toggle verify runs only on a
backend with no event stream. Each says so where someone would go to wire it up.

## Verification

- Local: `cargo fmt --check`, workspace clippy, `cargo test --workspace` (72 suites),
  `scripts/test-a11y.sh` (28 tests).
- On box: the walk counts above, through a decorator that also asserts a subscription was
  established — otherwise the test could measure the polling it exists to replace and pass.
- Every new assertion was shown to fail with its mechanism removed.
- **This PR also wires `scripts/test-a11y.sh` into CI**, as its own parallel job — it owns every
  Linux accessibility fact this repo asserts and ran nowhere but a developer's machine. Its own job
  because the suite takes about two minutes, which is the X11 job's whole length again, and the
  integration jobs run in parallel. The three tests that drive the fixture under Wayland need sway,
  so they run on the Wayland job; the a11y job names them as skipped rather than passing quietly
  without them.

  `AT-SPI integration (a11y)` is a new check name, so it is not in the master ruleset's required
  list — worth adding there if it should block merges.

