### PR TITLE
docs(mcp): describe every tool parameter, and the six thinnest tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ internal refactors, CI, or test-only changes.
   behaviour a caller cannot see from the type — `glass_baseline_save` overwrites an existing
   name silently, `glass_type` types into whatever already has focus, and `glass_start`'s
   `timeout_ms` bounds waiting for the window, not the `build` step.
+- `glass_type`, `glass_key`, `glass_drag`, `glass_stop`, `glass_baseline_save` and `glass_logs`
+  now describe what they do to the app and when to reach for them rather than a sibling tool.
+  Each states the consequence a caller would otherwise learn by trial: `glass_type` does not
+  focus a field and a newline in its text does not press Return, `glass_drag` refuses a path
+  with any endpoint outside the window, `glass_stop` discards the captured logs and element ids,
+  `glass_baseline_save` replaces an existing name silently, and `glass_logs` returns whatever
+  has accumulated without waiting (`glass_wait_for_log` is the blocking one).
 
 ### Changed
 - On Linux, `glass_wait_for_element` no longer re-reads the whole accessibility tree on a timer.
@@ -35,6 +42,9 @@ internal refactors, CI, or test-only changes.
   established or stops delivering.
 
 ### Fixed
+- The tool reference said a negative input coordinate addressed a point off the window's
+  top-left edge. It is rejected, like any other point outside the window, before the backend
+  sees it; the reference now says so and a test covers the negative case.
 - A switch now reports the same role on Windows, macOS, Android and iOS. `glass_a11y_snapshot`
   called one a `CheckBox` on iOS, and a `Button` or a `CheckBox` on macOS depending on which toolkit
   drew it, so a `role:"ToggleButton"` selector that worked on one machine silently matched nothing on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+### Added
+- Every tool parameter now carries a description in the advertised MCP schema, so an agent can
+  read a parameter's meaning without inferring it from the name. The additions cover the
+  coordinate space (window-relative everywhere except `glass_window`'s `move`, which positions
+  the window on screen), the defaults for click count, drag/settle timing and log paging, and
+  behaviour a caller cannot see from the type — `glass_baseline_save` overwrites an existing
+  name silently, `glass_type` types into whatever already has focus, and `glass_start`'s
+  `timeout_ms` bounds waiting for the window, not the `build` step.
+
 ### Changed
 - On Linux, `glass_wait_for_element` no longer re-reads the whole accessibility tree on a timer.
   Where the platform can say whether anything changed, a wait for something that has not happened

--- a/crates/glass-core/src/session/input.rs
+++ b/crates/glass-core/src/session/input.rs
@@ -104,6 +104,23 @@ mod tests {
     }
 
     #[test]
+    fn negative_pointer_coordinate_is_rejected() {
+        let mut g = glass_with(FakePlatform::new(10, 10));
+        g.start(&spec()).unwrap();
+        let err = g.pointer(&PointerEvent::Click {
+            x: -1,
+            y: 5,
+            button: crate::platform::MouseButton::Left,
+            count: 1,
+            modifiers: vec![],
+        });
+        assert!(matches!(
+            err.unwrap_err(),
+            GlassError::CoordOutOfBounds { .. }
+        ));
+    }
+
+    #[test]
     fn gesture_out_of_bounds_segment_is_rejected() {
         let mut g = glass_with(FakePlatform::new(100, 80));
         g.start(&spec()).unwrap();

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -7,9 +7,13 @@ use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct RegionArgs {
+    /// Left edge in pixels, window-relative — 0 is the window's left edge, not the screen's.
     pub x: u32,
+    /// Top edge in pixels, window-relative — 0 is the window's top edge, not the screen's.
     pub y: u32,
+    /// Width in pixels, extending right from `x`.
     pub width: u32,
+    /// Height in pixels, extending down from `y`.
     pub height: u32,
 }
 
@@ -72,6 +76,8 @@ pub struct StartArgs {
     /// An operator-set floor (`GLASS_SANDBOX_FLOOR`) may raise an omitted level, and
     /// refuses an explicit level requested below it.
     pub sandbox: Option<String>,
+    /// Working directory for both `build` and the launched app; omit to inherit the
+    /// server's own.
     pub cwd: Option<String>,
     /// Extra environment variables, as a `{ "KEY": "VALUE" }` object. They reach the launched app
     /// on the desktop backends and on `ios`; on `android` they configure the `build` command on
@@ -84,6 +90,8 @@ pub struct StartArgs {
     /// an unrelated process. Omit to take the first window owned by the launched
     /// process or a descendant it can follow.
     pub window_hint: Option<WindowHintArgs>,
+    /// How long to wait for the app's window to appear before failing the launch
+    /// (default 10000ms). Does not bound `build`.
     pub timeout_ms: Option<u64>,
     /// Spawn a private accessibility (AT-SPI) bus so `glass_a11y_snapshot` / `marks` /
     /// `set_value` / `click_element` / `wait_for_element` work against this app. **On by
@@ -99,9 +107,16 @@ pub struct StartArgs {
 pub struct WindowArgs {
     /// One of: "focus", "resize", "move", "geometry".
     pub op: String,
+    /// New left edge for `op: "move"`, required there and ignored otherwise. Screen
+    /// coordinates — the one place in this API that is not window-relative, since a
+    /// window cannot be positioned relative to itself.
     pub x: Option<i32>,
+    /// New top edge for `op: "move"`, required there and ignored otherwise. Screen
+    /// coordinates; see `x`.
     pub y: Option<i32>,
+    /// New width in pixels for `op: "resize"`, required there and ignored otherwise.
     pub width: Option<u32>,
+    /// New height in pixels for `op: "resize"`, required there and ignored otherwise.
     pub height: Option<u32>,
 }
 
@@ -161,10 +176,13 @@ pub struct A11ySnapshotArgs {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ClickArgs {
+    /// Click point x, window-relative — 0 is the window's left edge, not the screen's.
     pub x: i32,
+    /// Click point y, window-relative — 0 is the window's top edge, not the screen's.
     pub y: i32,
     /// "left" (default), "right", or "middle".
     pub button: Option<String>,
+    /// Consecutive clicks at this point (default 1); pass 2 for a double-click.
     pub count: Option<u32>,
     /// Modifier keys to hold during the action, e.g. ["ctrl"] or ["ctrl","shift"] for multi/range-select.
     pub modifiers: Option<Vec<String>>,
@@ -172,16 +190,23 @@ pub struct ClickArgs {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct MoveArgs {
+    /// Destination x, window-relative — 0 is the window's left edge, not the screen's.
     pub x: i32,
+    /// Destination y, window-relative — 0 is the window's top edge, not the screen's.
     pub y: i32,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct DragArgs {
+    /// Press-point x, window-relative — 0 is the window's left edge, not the screen's.
     pub x1: i32,
+    /// Press-point y, window-relative — 0 is the window's top edge, not the screen's.
     pub y1: i32,
+    /// Release-point x, window-relative.
     pub x2: i32,
+    /// Release-point y, window-relative.
     pub y2: i32,
+    /// Button held for the drag: "left" (default), "right", or "middle".
     pub button: Option<String>,
     /// Modifier keys to hold during the action, e.g. ["ctrl"] or ["ctrl","shift"] for multi/range-select.
     pub modifiers: Option<Vec<String>>,
@@ -201,7 +226,9 @@ pub struct PointerArgs {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct PointArg {
+    /// Window-relative x — 0 is the window's left edge, not the screen's.
     pub x: i32,
+    /// Window-relative y — 0 is the window's top edge, not the screen's.
     pub y: i32,
 }
 
@@ -216,7 +243,10 @@ pub struct GestureArgs {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ScrollArgs {
+    /// Pointer x the wheel is aimed at, window-relative — apps scroll the container
+    /// under this point, so it selects which pane moves.
     pub x: i32,
+    /// Pointer y the wheel is aimed at, window-relative. See `x`.
     pub y: i32,
     /// Horizontal scroll in **wheel notches** (discrete clicks — small integers like 1–5, NOT
     /// pixels). Positive `dx` sends wheel-right, negative wheel-left; glass clicks `|dx|` times.
@@ -231,6 +261,9 @@ pub struct ScrollArgs {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct TypeArgs {
+    /// Text to type into whatever currently has keyboard focus — this tool does not
+    /// focus a field, so click or `glass_click_element` one first. Sent as synthetic
+    /// key events, not pasted, so an app's per-keystroke handlers run.
     pub text: String,
     /// Optional observe folded into the result: "snapshot" (wait for the UI to settle, then
     /// fold a fresh a11y tree, also refreshing the snapshot cache), "settle" (wait for the UI
@@ -254,9 +287,17 @@ pub struct ClipboardSetArgs {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct WaitStableArgs {
+    /// How long to wait between capture ticks (default 100ms).
     pub interval_ms: Option<u64>,
+    /// Consecutive unchanged frames required before the UI counts as settled
+    /// (default 3). Raise it for an app that pauses mid-animation.
     pub settle_frames: Option<u32>,
+    /// Per-channel difference (0–255) two frames may have and still count as
+    /// unchanged (default 0, exact match). Raise it for a backend with dithering
+    /// or compression noise.
     pub tolerance: Option<u8>,
+    /// Give up after this long (default 5000ms); returns `{settled:false}` rather
+    /// than erroring.
     pub timeout_ms: Option<u64>,
     /// Optional window-relative sub-rectangle for the returned frame.
     pub region: Option<RegionArgs>,
@@ -388,6 +429,9 @@ pub struct WaitForLogArgs {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct BaselineSaveArgs {
+    /// Name to file this baseline under, reused by `glass_diff` and
+    /// `glass_wait_for_region`. ASCII letters, digits, `-` and `_` only; saving over
+    /// an existing name replaces it without warning.
     pub name: String,
 }
 
@@ -409,6 +453,8 @@ pub struct CapabilitiesArgs {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct DiffArgs {
+    /// Name of a baseline saved by `glass_baseline_save`; an unsaved name errors
+    /// rather than reporting no change.
     pub name: String,
     /// `"perceptual"` (default) or `"exact"`.
     pub mode: Option<String>,
@@ -435,10 +481,16 @@ pub struct DiffArgs {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct LogsArgs {
+    /// Resume point — the `cursor` a previous call returned, to read only what has
+    /// been logged since. Omit to read from the oldest buffered line.
     pub cursor: Option<u64>,
+    /// Cap on lines returned (default 200); the returned `cursor` resumes at the
+    /// first line left unread, so a capped read is not a lost one.
     pub max_lines: Option<u32>,
     /// "stdout", "stderr", or "both" (default).
     pub stream: Option<String>,
+    /// Return only lines containing this substring (case-sensitive). Filtering
+    /// happens server-side, so it narrows what the cap applies to.
     pub contains: Option<String>,
 }
 
@@ -459,10 +511,18 @@ pub enum Action {
 /// A mid-sequence or terminal settle — the `wait_stable` knobs, no image/return.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SettleArgs {
+    /// How long to wait between capture ticks (default 100ms).
     pub interval_ms: Option<u64>,
+    /// Consecutive unchanged frames required before the UI counts as settled (default 3).
     pub settle_frames: Option<u32>,
+    /// Per-channel difference (0–255) two frames may have and still count as
+    /// unchanged (default 0, exact match).
     pub tolerance: Option<u8>,
+    /// Give up after this long (default 5000ms); the sequence continues rather than
+    /// failing.
     pub timeout_ms: Option<u64>,
+    /// Window-relative sub-rectangle to watch for settling; when set, changes outside
+    /// it are ignored.
     pub stability_region: Option<RegionArgs>,
     /// Window-relative rectangles to exclude from the settle comparison. Use for
     /// perpetually animating content — a blinking text caret, a clock, a
@@ -479,15 +539,25 @@ pub struct SettleArgs {
 /// `include_image`) returns an image.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ThenArgs {
+    /// Wait for the UI to stop changing first. Set this whenever `diff` or
+    /// `screenshot` follows, or they observe a half-drawn frame.
     pub settle: Option<SettleArgs>,
+    /// Compare against a saved baseline and return change stats as text.
     pub diff: Option<DiffArgs>,
+    /// Capture the window as an image — the only field here that always spends image
+    /// tokens; prefer `diff` when you just need to know whether something changed.
     pub screenshot: Option<ScreenshotArgs>,
 }
 
 /// Arguments for `glass_do`: an ordered, non-empty action sequence + optional observe.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct DoArgs {
+    /// Actions to run in order; must be non-empty. Fail-fast — the first failing
+    /// action aborts the rest and reports its index, so a partial sequence may
+    /// already have landed.
     pub actions: Vec<Action>,
+    /// Optional observe run once after the last action, in the order settle → diff
+    /// → screenshot.
     pub then: Option<ThenArgs>,
 }
 

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -148,7 +148,12 @@ impl GlassServer {
     #[tool(
         description = "Stop the running app and end the session. The app is asked to close first, \
                        so it saves state and starts clean next time; one that will not close is \
-                       terminated, which takes a moment longer."
+                       terminated, which takes a moment longer. Ends everything session-scoped: \
+                       captured logs and a11y element ids are gone afterwards, so read what you \
+                       need first (saved baselines outlive it, until the server exits). There is \
+                       no resume — only glass_start runs the app again, as a fresh session. Not \
+                       needed between steps of a task; one session can be driven for as long as \
+                       you need it, and errors if no session is running."
     )]
     async fn glass_stop(&self) -> Result<CallToolResult, McpError> {
         self.run(tools::stop).await
@@ -203,7 +208,16 @@ impl GlassServer {
     }
 
     #[tool(
-        description = "Drag with a button held from (x1,y1) to (x2,y2) — window-relative coordinates. Optional modifiers held during the action, e.g. [\"ctrl\"] or [\"ctrl\",\"shift\"] for multi/range-select."
+        description = "Drag with a button held from (x1,y1) to (x2,y2) — window-relative \
+                       coordinates, so 0,0 is the window's top-left, not the screen's. Presses \
+                       at the start point, moves across in steps over `duration_ms`, and releases \
+                       at the end; the button is left (`button` overrides) and optional modifiers \
+                       are held throughout, e.g. [\"ctrl\"] or [\"ctrl\",\"shift\"] for \
+                       multi/range-select. Either endpoint outside the window is refused with an \
+                       error giving the window size, so a drag never lands somewhere you did not \
+                       aim. Use this for a single pointer — selecting text, moving an item, \
+                       resizing a pane; glass_gesture is the multi-touch equivalent (2+ pointers, \
+                       for pinch/rotate), and glass_click is the press-and-release-in-place case."
     )]
     async fn glass_drag(
         &self,
@@ -237,11 +251,21 @@ impl GlassServer {
         self.run(move |g| tools::gesture(g, &a)).await
     }
 
-    #[tool(description = "Type a string of text into the focused window. \
+    #[tool(
+        description = "Type a string of text into the focused window. Does not focus anything \
+                       itself — click the field first (glass_click_element, or glass_click), or \
+                       the text goes wherever focus already was. Sent as individual keystrokes, \
+                       not a paste, so per-key handlers, autocomplete and validation all run; a \
+                       newline in `text` does not press Return, so send that as a separate \
+                       glass_key. Prefer glass_set_value for a field the a11y tree exposes: it \
+                       addresses the field directly and reports whether the value landed, where \
+                       this types wherever the cursor already sits and cannot tell you what it \
+                       hit. \
                        Optional `return`: \"snapshot\" settles the UI then folds a fresh a11y \
                        tree into the result (and refreshes the snapshot cache); \"settle\" waits \
                        for the UI to stop changing (text-only); omit or \"none\" for no observe \
-                       (default).")]
+                       (default)."
+    )]
     async fn glass_type(
         &self,
         Parameters(a): Parameters<TypeArgs>,
@@ -249,7 +273,18 @@ impl GlassServer {
         self.run(move |g| tools::type_text(g, &a)).await
     }
 
-    #[tool(description = "Press a key chord like 'ctrl+s', 'Return', 'alt+F4'.")]
+    #[tool(
+        description = "Press a key chord like 'ctrl+s', 'Return', 'alt+F4'. One key with any \
+                       number of modifiers, joined by '+': the last token is the key, every \
+                       earlier one a modifier (ctrl, shift, alt, super — `cmd`, `win` and `meta` \
+                       are accepted names for super, and all of them are case-insensitive). The \
+                       key is a named key such as Return, Escape, Tab, Delete, an arrow or F1-F12, \
+                       or a single printable ASCII character. An unrecognised modifier or \
+                       key name is rejected with an error naming the token, so nothing is \
+                       half-pressed; modifiers are released again when the chord completes. Use \
+                       this for shortcuts and named keys — glass_type is for literal text and \
+                       cannot express either."
+    )]
     async fn glass_key(
         &self,
         Parameters(a): Parameters<KeyArgs>,
@@ -278,7 +313,17 @@ impl GlassServer {
         self.run(move |g| tools::clipboard_set(g, &a)).await
     }
 
-    #[tool(description = "Save the current frame as a named visual baseline.")]
+    #[tool(
+        description = "Save the current frame as a named visual baseline — a reference image \
+                       glass_diff and glass_wait_for_region later compare against, so you can ask \
+                       what changed without spending image tokens on a before-and-after pair. \
+                       Captures the whole window at call time (not a saved region), so settle the \
+                       UI first if something is still animating. Saving over an existing name \
+                       replaces it silently; baselines live outside the app under a per-server \
+                       directory and last until the server exits, surviving glass_stop. Use this \
+                       plus glass_diff to detect change; use glass_screenshot when you actually \
+                       need to look at the pixels."
+    )]
     async fn glass_baseline_save(
         &self,
         Parameters(a): Parameters<BaselineSaveArgs>,
@@ -453,7 +498,18 @@ impl GlassServer {
         self.run(tools::a11y_marks).await
     }
 
-    #[tool(description = "Read captured stdout/stderr log lines with a resumable cursor.")]
+    #[tool(
+        description = "Read captured stdout/stderr log lines with a resumable cursor. glass_start \
+                       captures the app's output from launch; this returns what has accumulated \
+                       and a `cursor` to pass back next time, so a loop reads each line once. \
+                       Returns immediately with whatever is there, including nothing at all — it \
+                       does not wait, so use glass_wait_for_log when you want to block until a \
+                       line appears (starting up, finishing work). Filter server-side with \
+                       `stream` and `contains` rather than reading everything and scanning it \
+                       yourself. The buffer keeps the most recent lines and drops the oldest, so \
+                       a chatty app can age out lines you never read; the lines are the app's own \
+                       output and are returned marked as untrusted."
+    )]
     async fn glass_logs(
         &self,
         Parameters(a): Parameters<LogsArgs>,

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -68,8 +68,10 @@ ids are in [Conventions](#conventions) above):
   `window_id` param — are `u64`, carrying the platform's own window handle.
 - **Input coordinates** — `x`/`y` (and `x1,y1,x2,y2`, and gesture `from`/`to`) on
   `glass_click`/`glass_move`/`glass_drag`/`glass_scroll`/`glass_gesture` — are signed `i32`,
-  window-relative. A negative value addresses a point off the window's top-left edge rather than
-  being rejected.
+  window-relative. The type is signed, but the accepted range is not: a point outside the window,
+  negative or past its width/height, is rejected with `CoordOutOfBounds` naming the window size,
+  before the backend sees it. For a drag or gesture, *every* endpoint is checked, so a partly
+  out-of-range path is refused rather than clipped.
 - **Region coordinates** — `region`/`stability_region`/the rects inside `ignore`
   (`x,y,width,height`), wherever a tool accepts one — are unsigned `u32`; they can never be
   negative.


### PR DESCRIPTION
## What

The MCP schema was the thinnest part of glass's agent-facing surface. Roughly a third of tool parameters reached the agent as a bare name and type, and six tools described themselves in a sentence that mostly restated their own name.

### Parameters

Every parameter now carries a one-line description, each fact read out of the implementation:

- **Coordinate space** on every pointer tool — and that `glass_window`'s `move` is the single place taking screen coordinates, since a window cannot be positioned relative to itself.
- **Defaults**: click `count` 1, drag 200ms, settle 100ms/3 frames/tolerance 0/5000ms, logs 200 lines, start 10000ms.
- **Behaviour invisible in the type**: `glass_start`'s `timeout_ms` bounds waiting for the window and not the `build` step; the baseline name charset is `[A-Za-z0-9_-]` and saving over a name replaces it; `glass_do` is fail-fast, so a partial sequence may already have landed.

### Tool descriptions

`glass_type`, `glass_key`, `glass_drag`, `glass_stop`, `glass_baseline_save` and `glass_logs` now state the effect on the app, the consequence a caller would otherwise learn by trial, and which sibling to use instead:

| Tool | Consequence now stated | Sibling named |
|---|---|---|
| `glass_type` | does not focus a field; keystrokes not a paste; a newline does not press Return | `glass_set_value` |
| `glass_key` | chord grammar and modifier aliases; an unrecognised token rejects the whole chord | `glass_type` |
| `glass_drag` | coordinate origin, default button, any endpoint outside the window is refused | `glass_gesture`, `glass_click` |
| `glass_stop` | logs and element ids go with the session; only `glass_start` returns | — |
| `glass_baseline_save` | what a baseline is, where it lives, silent overwrite | `glass_screenshot` |
| `glass_logs` | never blocks; buffer ages out the oldest lines | `glass_wait_for_log` |

## A wrong claim this turned up

Sourcing each fact from the implementation rather than from the existing prose surfaced an error in the tool reference. It said:

> A negative value addresses a point off the window's top-left edge rather than being rejected.

`check_bounds` rejects it — `x < 0 || y < 0 || x >= w || y >= h` — before the backend sees the event. The existing test only covered the past-the-far-edge case (`x: 10` in a 10-wide window), so the negative branch was untested and the doc drifted. This adds `negative_pointer_coordinate_is_rejected` and corrects the reference.

The new test was checked in both directions: green with `x: -1`, and red when flipped to a valid `x: 1`, so it fails if the rejection is ever removed.

## Verification

Drove `tools/list` over stdio against the built server and inspected the advertised schema:

- **103 parameters described, 0 undescribed**, across all 30 tools including nested `$defs`.
- All six rewritten descriptions present, 563-802 chars each (from 47-300).
- The coverage query was itself checked against a fixture containing one undescribed parameter, to confirm it reports gaps rather than matching nothing.

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (72 suites) all clean.

Claims verified in source before writing them: the build step is untimed in all six backends; `tolerance` is a per-channel byte compare; a settle timeout inside `glass_do` proceeds rather than failing; drag motion is interpolated across waypoints with a dwell before release; baselines are per-pid and survive `glass_stop`; no backend maps `\n` to Return; iOS's `set_value` is a tap+type delegate, so the description avoids claiming it replaces existing content.