### PR TITLE
a11y(android): one name rule for both readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+### Fixed
+- Android's `set_value` now refuses a write whose target has drifted in value, not just in role,
+  name or bounds. A re-walk that lands on a same-role, same-name, same-rect element holding
+  *different* data — a recycled list row reusing the same view is the case this closes — is now
+  rejected as changed since the snapshot rather than written to. An editable element with no
+  content description and no resource id has no name at all, so role plus an 8px bounds match used
+  to be the whole fingerprint a write re-walked against. The value only discriminates where there
+  was one to capture: rows of *empty* fields share a role, a name, a rect and no value alike, so a
+  write can still land on the wrong one of those — re-snapshot before writing into a list that has
+  scrolled.
+
 ### Changed
 - Both Android readers now name an element the same way. The same control used to answer
   differently depending on which reader was running — `uiautomator` and the on-device
@@ -29,23 +40,29 @@ internal refactors, CI, or test-only changes.
   to name a filled text field by its own contents, so its name changed with the field's contents
   from one snapshot read to the next.
 
-  Two losses to know about, both on the accessibility-service reader. An *empty* text field that
-  has a hint but no content description used to be named by that hint — Android reports a hint
-  through the same `text` attribute a filled field uses, so an empty field's hint arrived
-  indistinguishable from typed content — and it is now unnamed. That naming was never
-  dependable: it held only while the field was empty and became the typed content the moment
-  anything was entered, so it was not a stable selector either way. Carrying Android's hint as
-  its own field is a separate change, not part of this one.
+  An editable element with no content description — including an empty field named only by its
+  hint — now falls back to the leaf of its view resource id rather than staying unnamed: plain
+  text, not the package-qualified form Android reports, and shared by every other view built from
+  the same layout, so treat it as a label of last resort, not a selector to rely on.
+  Verified on device: Settings' search box reads `open_search_view_edit_text` identically from
+  both readers. The on-device companion separately carries the field's hint into its
+  `description`, so an agent sees `desc="Search settings"` there even when nothing names the field
+  at all — verified on the role fixture's added `EditText`, which has a hint and neither a content
+  description nor a resource id: it renders as `TextField desc="Search settings"` through the
+  companion. `uiautomator` cannot supply that description at all — its dump carries no hint
+  attribute — so a text field's `desc` is richer through the companion than through `uiautomator`.
+  Both the id fallback and the hint on the accessibility-service reader need the updated on-device
+  companion.
 
-  And an element that is not editable — a label, a button, a check box — no longer reports a
-  `value`; that reader used to copy the element's own text there as well as into `name`. Since a
-  `value_contains` filter matches only an element that has a value, `value_contains` against a
-  non-editable element under this reader now never matches, so a `glass_wait_for_element` written
-  that way waits out its whole timeout and answers `{matched:false}`. Match those elements on
-  `name` instead. It also retires an escape hatch worth naming: a Jetpack Compose button surfaces
-  as a clickable `Group`, and `role:"Button"` plus `value_contains:"Submit"` used to reach it —
-  use `role:"Button"` with `name:"Submit"`, which reaches it the same way. `uiautomator` never
-  matched this way, so a selector written against that reader is unaffected.
+  One selector detail changes with it, though nothing becomes unreachable. On the
+  accessibility-service reader an element that is not editable — a label, a button, a check box —
+  no longer reports a `value`; that reader used to copy the element's own text there as well as
+  into `name`. A `value_contains` filter aimed at such an element therefore stops matching, and
+  `glass_wait_for_element` waits out its timeout. Match on `name` instead: it is a substring
+  filter too, and that text was always in `name` as well, so every selector has an equivalent —
+  including `role:"Button"` with `name:"Submit"`, which reaches a Jetpack Compose button surfacing
+  as a clickable `Group` exactly as the `value_contains` form did. `uiautomator` never reported a
+  value there, so a selector written against that reader is unaffected.
 
 ### Added
 - Every tool parameter now carries a description in the advertised MCP schema, so an agent can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,26 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+### Changed
+- Both Android readers now name an element the same way. The same control used to answer
+  differently depending on which reader was running — `uiautomator` and the on-device
+  accessibility-service reader disagreed on which label became the `name` — so a `name:`
+  selector learned under one could silently miss under the other, with nothing to say why. A
+  control with both a visible label and a content description is now named by the visible
+  label, the one actually on screen: verified on device, the role fixture's button reads
+  `Button "Save" desc="Save changes"` through both readers, where the two strings used to be
+  swapped between them. An editable element is named by its content
+  description and never by what has been typed into it; the accessibility-service reader used
+  to name a filled text field by its own contents, so its name changed on every keystroke.
+
+  One loss to know about: on the accessibility-service reader, an *empty* text field that has a
+  hint but no content description used to be named by that hint — Android reports a hint through
+  the same `text` attribute a filled field uses, so an empty field's hint arrived
+  indistinguishable from typed content — and it is now unnamed. That naming was never
+  dependable: it held only while the field was empty and became the typed content the moment
+  anything was entered, so it was not a stable selector either way. Carrying Android's hint as
+  its own field is the real fix, and is not part of this change.
+
 ### Added
 - Every tool parameter now carries a description in the advertised MCP schema, so an agent can
   read a parameter's meaning without inferring it from the name. The additions cover the
@@ -107,9 +127,7 @@ internal refactors, CI, or test-only changes.
   value; and the iOS reader reads the element's accessibility hint, falling back to the label an
   editable element's identifier displaced. On Android a description needs one node to carry two
   distinct labels and most controls carry only one, so expect `desc` to be absent on most Android
-  nodes. The two Android readers also disagree on which label is the name: `uiautomator` prefers
-  content-description, the on-device accessibility-service reader prefers text, so the same
-  control can report `name` and `desc` swapped depending on which reader is running.
+  nodes.
 - `glass_start` on the iOS Simulator passes an app's launch arguments through: everything after
   the `.app` path or bundle id in `run` reaches the app as its own arguments, joined
   (`--tab=value`) and separated (`--tab value`) forms alike, so an app whose behaviour is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,13 +29,23 @@ internal refactors, CI, or test-only changes.
   to name a filled text field by its own contents, so its name changed with the field's contents
   from one snapshot read to the next.
 
-  One loss to know about: on the accessibility-service reader, an *empty* text field that has a
-  hint but no content description used to be named by that hint — Android reports a hint through
-  the same `text` attribute a filled field uses, so an empty field's hint arrived
+  Two losses to know about, both on the accessibility-service reader. An *empty* text field that
+  has a hint but no content description used to be named by that hint — Android reports a hint
+  through the same `text` attribute a filled field uses, so an empty field's hint arrived
   indistinguishable from typed content — and it is now unnamed. That naming was never
   dependable: it held only while the field was empty and became the typed content the moment
   anything was entered, so it was not a stable selector either way. Carrying Android's hint as
   its own field is a separate change, not part of this one.
+
+  And an element that is not editable — a label, a button, a check box — no longer reports a
+  `value`; that reader used to copy the element's own text there as well as into `name`. Since a
+  `value_contains` filter matches only an element that has a value, `value_contains` against a
+  non-editable element under this reader now never matches, so a `glass_wait_for_element` written
+  that way waits out its whole timeout and answers `{matched:false}`. Match those elements on
+  `name` instead. It also retires an escape hatch worth naming: a Jetpack Compose button surfaces
+  as a clickable `Group`, and `role:"Button"` plus `value_contains:"Submit"` used to reach it —
+  use `role:"Button"` with `name:"Submit"`, which reaches it the same way. `uiautomator` never
+  matched this way, so a selector written against that reader is unaffected.
 
 ### Added
 - Every tool parameter now carries a description in the advertised MCP schema, so an agent can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ internal refactors, CI, or test-only changes.
   `Button "Save" desc="Save changes"` through both readers, where the two strings used to be
   swapped between them. An editable element is named by its content
   description and never by what has been typed into it; the accessibility-service reader used
-  to name a filled text field by its own contents, so its name changed on every keystroke.
+  to name a filled text field by its own contents, so its name changed with the field's contents
+  from one snapshot read to the next.
 
   One loss to know about: on the accessibility-service reader, an *empty* text field that has a
   hint but no content description used to be named by that hint — Android reports a hint through
@@ -34,7 +35,7 @@ internal refactors, CI, or test-only changes.
   indistinguishable from typed content — and it is now unnamed. That naming was never
   dependable: it held only while the field was empty and became the typed content the moment
   anything was entered, so it was not a stable selector either way. Carrying Android's hint as
-  its own field is the real fix, and is not part of this change.
+  its own field is a separate change, not part of this one.
 
 ### Added
 - Every tool parameter now carries a description in the advertised MCP schema, so an agent can

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -225,17 +225,20 @@ impl Default for AndroidA11y {
 
 /// Re-resolve `target` in an already-numbered `tree` and return the node only if it is still the
 /// element that was addressed and still editable. Errors specifically when the target is gone
-/// (`AxElementNotFound`), has drifted in role/name/bounds (`AxElementChanged`), or is not editable
-/// (`AxElementNotEditable`).
+/// (`AxElementNotFound`), has drifted in role/name/bounds/value (`AxElementChanged`), or is not
+/// editable (`AxElementNotEditable`).
 ///
 /// Both Android readers' `set_value` guards route through this — the check that stops a write
 /// landing on whatever inherited the id between the snapshot the caller read and the one the write
-/// acts on. Pure (no device I/O), so it is testable without a device.
+/// acts on. A recycled `RecyclerView` row is the motivating case for comparing `value` too — see
+/// `AxTarget::value`'s doc. Pure (no device I/O), so it is testable without a device.
 pub(crate) fn editable_target<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&'a AxNode> {
     let node = tree
         .find(target.id)
         .ok_or(GlassError::AxElementNotFound(target.id.0))?;
-    if !target.matches(node.role, node.name.as_deref()) || !target.bounds_consistent(node.bounds, 8)
+    if !target.matches(node.role, node.name.as_deref())
+        || !target.bounds_consistent(node.bounds, 8)
+        || !target.value_consistent(node.value.as_deref())
     {
         return Err(GlassError::AxElementChanged(target.id.0));
     }
@@ -331,7 +334,9 @@ impl Accessibility for AndroidA11y {
 
 #[cfg(test)]
 mod tests {
-    use super::{dump_once, dump_until_ready, locate_editable_target, verify_write};
+    use super::{
+        dump_once, dump_until_ready, editable_target, locate_editable_target, verify_write,
+    };
     use glass_core::accessibility::{AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree};
     use glass_core::{GlassError, Result, WindowGeometry};
     use std::time::Duration;
@@ -519,12 +524,22 @@ mod tests {
         t
     }
 
+    /// Like `tree`, but also holding `value` — see `editable_target`'s doc for why that's part of
+    /// the fingerprint too. Always at `BOUNDS`, always editable.
+    fn tree_with_value(role: AxRole, name: Option<&str>, value: Option<&str>) -> AxTree {
+        let mut t = tree(role, name, Some(BOUNDS), true);
+        t.root.value = value.map(Into::into);
+        t.assign_ids();
+        t
+    }
+
     fn target(id: u32, name: Option<&str>, bounds: Option<AxRect>) -> AxTarget {
         AxTarget {
             id: AxNodeId(id),
             role: AxRole::TextField,
             name: name.map(Into::into),
             bounds,
+            value: None,
         }
     }
 
@@ -682,6 +697,71 @@ mod tests {
             locate_editable_target(&t, &target(0, Some("Search"), Some(moved)), &WIN),
             Err(GlassError::AxElementChanged(0))
         ));
+    }
+
+    #[test]
+    fn a_target_whose_value_moved_is_rejected() {
+        // The recycled-row case `editable_target`'s doc names: role, name and rect match here too.
+        let tree = tree_with_value(AxRole::TextField, Some("row_title"), Some("Zara"));
+        let target = AxTarget {
+            id: AxNodeId(0),
+            role: AxRole::TextField,
+            name: Some("row_title".into()),
+            bounds: tree.root.bounds,
+            value: Some("Alice".into()),
+        };
+        assert!(matches!(
+            editable_target(&tree, &target),
+            Err(GlassError::AxElementChanged(0))
+        ));
+    }
+
+    #[test]
+    fn a_target_with_no_captured_value_still_passes() {
+        // The `None`-must-not-gate case from the comment on `editable_target`'s value check.
+        let tree = tree_with_value(AxRole::TextField, Some("row_title"), Some("Alice"));
+        let target = AxTarget {
+            id: AxNodeId(0),
+            role: AxRole::TextField,
+            name: Some("row_title".into()),
+            bounds: tree.root.bounds,
+            value: None,
+        };
+        assert!(editable_target(&tree, &target).is_ok());
+    }
+
+    #[test]
+    fn a_target_whose_value_vanished_is_rejected() {
+        // Android reports an emptied field as no value at all, so this is the shape a row that
+        // recycled from filled to empty arrives in — a real change, not a missing observation.
+        let tree = tree_with_value(AxRole::TextField, Some("row_title"), None);
+        let target = AxTarget {
+            id: AxNodeId(0),
+            role: AxRole::TextField,
+            name: Some("row_title".into()),
+            bounds: tree.root.bounds,
+            value: Some("Alice".into()),
+        };
+        assert!(matches!(
+            editable_target(&tree, &target),
+            Err(GlassError::AxElementChanged(0))
+        ));
+    }
+
+    #[test]
+    fn a_target_whose_value_still_matches_passes() {
+        // Every other target helper here captures `None`, so "reject whenever a value was
+        // captured" would pass all of them too — this is the one case that actually needs the
+        // comparison, not just the presence check.
+        let tree = tree_with_value(AxRole::TextField, Some("row_title"), Some("Alice"));
+        let target = AxTarget {
+            id: AxNodeId(0),
+            role: AxRole::TextField,
+            name: Some("row_title".into()),
+            bounds: tree.root.bounds,
+            value: Some("Alice".into()),
+        };
+        assert!(editable_target(&tree, &target).is_ok());
     }
 
     #[test]

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -4,7 +4,7 @@
 
 use std::time::{Duration, Instant};
 
-use glass_core::accessibility::{Accessibility, AxContext, AxTarget, AxTree};
+use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, AxTree};
 use glass_core::{
     GlassError, KeyEvent, MouseButton, PointerEvent, Result, WindowGeometry, typed_clear_landed,
     typed_text_landed,
@@ -223,17 +223,15 @@ impl Default for AndroidA11y {
     }
 }
 
-/// Locate `target` in an already-numbered `tree` and return the window-relative tap point for
-/// editing it. Errors specifically when the target is gone (`AxElementNotFound`), has drifted in
-/// role/name/bounds (`AxElementChanged`), is not editable (`AxElementNotEditable`), or has no
-/// clickable on-screen center (`AxElementNotClickable`). Pure (no device I/O) so `set_value`'s
-/// re-validation — the guard that stops it typing into the wrong element after a re-snapshot — is
-/// testable without a device.
-fn locate_editable_target(
-    tree: &AxTree,
-    target: &AxTarget,
-    window: &WindowGeometry,
-) -> Result<(i32, i32)> {
+/// Re-resolve `target` in an already-numbered `tree` and return the node only if it is still the
+/// element that was addressed and still editable. Errors specifically when the target is gone
+/// (`AxElementNotFound`), has drifted in role/name/bounds (`AxElementChanged`), or is not editable
+/// (`AxElementNotEditable`).
+///
+/// Both Android readers' `set_value` guards route through this — the check that stops a write
+/// landing on whatever inherited the id between the snapshot the caller read and the one the write
+/// acts on. Pure (no device I/O), so it is testable without a device.
+pub(crate) fn editable_target<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&'a AxNode> {
     let node = tree
         .find(target.id)
         .ok_or(GlassError::AxElementNotFound(target.id.0))?;
@@ -244,7 +242,19 @@ fn locate_editable_target(
     if !node.states.editable {
         return Err(GlassError::AxElementNotEditable(target.id.0));
     }
-    node.bounds
+    Ok(node)
+}
+
+/// [`editable_target`], plus the window-relative tap point for editing it — the extra step the
+/// `uiautomator` reader needs, because it edits by tapping where the on-device service can act on
+/// the node directly. Errors `AxElementNotClickable` when the element has no on-screen center.
+fn locate_editable_target(
+    tree: &AxTree,
+    target: &AxTarget,
+    window: &WindowGeometry,
+) -> Result<(i32, i32)> {
+    editable_target(tree, target)?
+        .bounds
         .and_then(|b| b.clamped_center(window.width, window.height))
         .ok_or(GlassError::AxElementNotClickable(target.id.0))
 }

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -8,12 +8,12 @@ use serde_json::{Value, json};
 
 use glass_core::accessibility::{
     Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree,
-    TruncationLimit, WalkBudget, WalkLimits, normalize_description,
+    TruncationLimit, WalkBudget, WalkLimits,
 };
 use glass_core::platform::WindowGeometry;
 use glass_core::{GlassError, Result};
 
-use crate::axmap::class_to_role;
+use crate::axmap::{class_to_role, labels};
 use crate::conn::Conn;
 
 /// Map one device `tree` JSON node (+descendants) into an `AxNode`, converting screen bounds to
@@ -34,12 +34,12 @@ fn json_to_node(
 ) -> Result<AxNode> {
     budget.visit();
     let cls = v.get("class").and_then(Value::as_str).unwrap_or("");
-    // No host-side filter: device agent drops empty text/desc. Were that to change,
-    // empty `text` would win the name. Filtering here would change name, so it stays
-    // device-side (key to selectors, set_value).
+    let flag = |k: &str| v.get(k).and_then(Value::as_bool).unwrap_or(false);
+    // No host-side filter: device agent drops empty text/desc, so this reader needs no
+    // non_empty like the uiautomator reader's XML dump.
     let text = v.get("text").and_then(Value::as_str);
     let desc = v.get("desc").and_then(Value::as_str);
-    let name = text.or(desc);
+    let (name, value, description) = labels(text, desc, flag("editable"));
     let b = v
         .get("bounds")
         .ok_or_else(|| GlassError::AccessibilityUnavailable("node missing bounds".into()))?;
@@ -59,7 +59,6 @@ fn json_to_node(
             .clamp(0, i64::from(u32::MAX)) as u32
     };
     let (x, y, w, h) = (bi("x"), bi("y"), bu("w"), bu("h"));
-    let flag = |k: &str| v.get(k).and_then(Value::as_bool).unwrap_or(false);
     // Recursion is bounded by `budget` (depth, node count, siblings per level), so a
     // pathologically deep or wide device tree cannot blow the stack or the token budget.
     // The child array is resolved before either bound is consulted: a childless node must
@@ -97,13 +96,10 @@ fn json_to_node(
         id: AxNodeId(0),
         role: class_to_role(cls),
         raw_role: cls.to_string(),
-        // name: the element's own text label, falling back to content-description.
-        // value: editable text content only (content-description is not user-entered text).
-        name: name.map(str::to_string),
-        // The content-description a `text` label displaced; with no `text` the desc IS the name.
+        name,
         // Hint and state-description stay unread — the device protocol carries neither.
-        description: desc.and_then(|d| normalize_description(d, name)),
-        value: text.map(str::to_string),
+        description,
+        value,
         states: AxStates {
             enabled: flag("enabled"),
             editable: flag("editable"),
@@ -497,7 +493,7 @@ mod tests {
             "bounds": {"x": 0, "y": 100, "w": 1080, "h": 2300},
             "editable": false, "clickable": false, "enabled": true, "scrollable": false,
             "children": [
-                {"ref": 1, "class": "android.widget.EditText", "text": "Email",
+                {"ref": 1, "class": "android.widget.EditText", "text": "joe@x.com", "desc": "Email",
                  "bounds": {"x": 40, "y": 200, "w": 600, "h": 120},
                  "editable": true, "clickable": true, "enabled": true, "scrollable": false},
                 {"ref": 2, "class": "android.widget.Button", "desc": "Save",
@@ -510,7 +506,8 @@ mod tests {
         assert_eq!(t.count, 3);
         let email = t.find(AxNodeId(1)).unwrap();
         assert_eq!(email.role, AxRole::TextField);
-        assert_eq!(email.name.as_deref(), Some("Email"));
+        assert_eq!(email.name.as_deref(), Some("Email")); // editable: name follows desc, not text
+        assert_eq!(email.value.as_deref(), Some("joe@x.com"));
         assert!(email.states.editable);
         assert_eq!(email.bounds.unwrap().y, 100); // window-relative: 200 - win.y 100
         let save = t.find(AxNodeId(2)).unwrap();
@@ -708,10 +705,13 @@ mod tests {
     #[test]
     fn the_content_description_a_text_displaced_becomes_the_description() {
         let node = mapped(Some("Save"), Some("Save changes"));
-        // `text` wins the name on this reader — the opposite of the uiautomator reader, which is
-        // glass#260 and is NOT changed here.
+        // Non-editable: `text` wins the name here too, unchanged by glass#260.
         assert_eq!(node.name.as_deref(), Some("Save"));
         assert_eq!(node.description.as_deref(), Some("Save changes"));
+        assert_eq!(
+            node.value, None,
+            "a Button's text is not user-entered content"
+        );
     }
 
     #[test]
@@ -735,11 +735,21 @@ mod tests {
     }
 
     #[test]
-    fn an_editable_nodes_desc_is_still_its_description() {
-        // Deliberately ungated, unlike the uiautomator reader: there the editable node's `text`
-        // is only the value, here it is the name too, so the displaced `desc` is the one label
-        // left with nowhere else to go.
+    fn an_editable_node_is_named_by_its_content_description_not_its_text() {
+        // This reader used to name an editable node by `text`, so a filled field's name
+        // changed on every keystroke and could not be selected against.
         let node = mapped_editable(Some("joe@x.com"), Some("Email"));
-        assert_eq!(node.description.as_deref(), Some("Email"));
+        assert_eq!(node.name.as_deref(), Some("Email"));
+        assert_eq!(node.value.as_deref(), Some("joe@x.com"));
+        assert_eq!(node.description, None);
+    }
+
+    #[test]
+    fn a_non_editable_nodes_text_is_its_name_and_not_also_its_value() {
+        // This reader used to copy a label into `value` too, so a Label reported the same
+        // string twice.
+        let node = mapped(Some("Settings"), None);
+        assert_eq!(node.name.as_deref(), Some("Settings"));
+        assert_eq!(node.value, None);
     }
 }

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -13,7 +13,7 @@ use glass_core::accessibility::{
 use glass_core::platform::WindowGeometry;
 use glass_core::{GlassError, Result};
 
-use crate::axmap::{class_to_role, labels};
+use crate::axmap::{LabelInputs, class_to_role, labels};
 use crate::conn::Conn;
 
 /// Map one device `tree` JSON node (+descendants) into an `AxNode`, converting screen bounds to
@@ -39,7 +39,17 @@ fn json_to_node(
     // `None` here; `labels` judges a blank one absent either way.
     let text = v.get("text").and_then(Value::as_str);
     let desc = v.get("desc").and_then(Value::as_str);
-    let (name, value, description) = labels(text, desc, flag("editable"));
+    // Both keys are absent (not null) on an older companion; `get` returns `None` either way, so
+    // no version check is needed to stay compatible with it.
+    let resource_id = v.get("resource_id").and_then(Value::as_str);
+    let hint = v.get("hint").and_then(Value::as_str);
+    let (name, value, description) = labels(LabelInputs {
+        text,
+        desc,
+        resource_id,
+        hint,
+        editable: flag("editable"),
+    });
     let b = v
         .get("bounds")
         .ok_or_else(|| GlassError::AccessibilityUnavailable("node missing bounds".into()))?;
@@ -97,7 +107,7 @@ fn json_to_node(
         role: class_to_role(cls),
         raw_role: cls.to_string(),
         name,
-        // Hint and state-description stay unread — the device protocol carries neither.
+        // State-description stays unread — the device protocol doesn't carry it.
         description,
         value,
         states: AxStates {
@@ -677,7 +687,12 @@ mod tests {
         assert_eq!((b.x, b.y), (-5, -90)); // window-relative: x -5-0, y 10-100
     }
 
-    fn node_json(text: Option<&str>, desc: Option<&str>) -> Value {
+    fn node_json(
+        text: Option<&str>,
+        desc: Option<&str>,
+        resource_id: Option<&str>,
+        hint: Option<&str>,
+    ) -> Value {
         let mut v = json!({
             "class": "android.widget.Button",
             "bounds": {"x": 0, "y": 100, "w": 10, "h": 10},
@@ -689,19 +704,43 @@ mod tests {
         if let Some(d) = desc {
             v["desc"] = json!(d);
         }
+        if let Some(r) = resource_id {
+            v["resource_id"] = json!(r);
+        }
+        if let Some(h) = hint {
+            v["hint"] = json!(h);
+        }
         v
     }
 
     fn mapped(text: Option<&str>, desc: Option<&str>) -> AxNode {
         let mut budget = WalkBudget::new();
-        json_to_node(&node_json(text, desc), &win(), 0, &mut budget).expect("maps")
+        json_to_node(&node_json(text, desc, None, None), &win(), 0, &mut budget).expect("maps")
     }
 
-    /// [`mapped`], for an editable field rather than a button.
+    /// [`mapped`], for an editable field; omits `resource_id`/`hint`, the shape an older
+    /// companion sends.
     fn mapped_editable(text: Option<&str>, desc: Option<&str>) -> AxNode {
-        let mut v = node_json(text, desc);
+        let mut v = node_json(text, desc, None, None);
         v["class"] = json!("android.widget.EditText");
         v["editable"] = json!(true);
+        let mut budget = WalkBudget::new();
+        json_to_node(&v, &win(), 0, &mut budget).expect("maps")
+    }
+
+    /// [`mapped_editable`], additionally setting `resource_id` and `hint`.
+    fn mapped_full(
+        text: Option<&str>,
+        desc: Option<&str>,
+        resource_id: Option<&str>,
+        hint: Option<&str>,
+        editable: bool,
+    ) -> AxNode {
+        let mut v = node_json(text, desc, resource_id, hint);
+        if editable {
+            v["class"] = json!("android.widget.EditText");
+            v["editable"] = json!(true);
+        }
         let mut budget = WalkBudget::new();
         json_to_node(&v, &win(), 0, &mut budget).expect("maps")
     }
@@ -749,11 +788,11 @@ mod tests {
     }
 
     #[test]
-    fn an_editable_node_with_no_desc_is_unnamed_not_named_by_its_contents() {
-        // The device omits the key entirely for a field with no content description. Falling
-        // back to `text` would name the field by what has been typed into it, moving the name —
-        // and the fingerprint `set_value` re-walks against — on every keystroke; unnamed is the
-        // honest reading.
+    fn an_editable_node_with_no_desc_and_no_id_is_unnamed_not_named_by_its_contents() {
+        // The device omits the key entirely for a field with no content description, and
+        // `mapped_editable` omits `resource_id` too, so nothing is left to fall back to. Naming it
+        // by `text` would move the name — and the fingerprint `set_value` re-walks against — on
+        // every keystroke, so unnamed is the honest reading.
         let node = mapped_editable(Some("joe@x.com"), None);
         assert_eq!(node.name, None);
         assert_eq!(node.value.as_deref(), Some("joe@x.com"));
@@ -766,5 +805,48 @@ mod tests {
         let node = mapped(Some("Settings"), None);
         assert_eq!(node.name.as_deref(), Some("Settings"));
         assert_eq!(node.value, None);
+    }
+
+    #[test]
+    fn an_editable_node_with_no_desc_is_named_by_its_view_id() {
+        let node = mapped_full(
+            Some("joe@x.com"),
+            None,
+            Some("com.x:id/email_field"),
+            None,
+            true,
+        );
+        assert_eq!(node.name.as_deref(), Some("email_field"));
+        assert_eq!(node.value.as_deref(), Some("joe@x.com"));
+    }
+
+    #[test]
+    fn an_editable_nodes_hint_becomes_its_description() {
+        let node = mapped_full(
+            None,
+            None,
+            Some("com.x:id/q"),
+            Some("Search settings"),
+            true,
+        );
+        assert_eq!(node.name.as_deref(), Some("q"));
+        assert_eq!(node.description.as_deref(), Some("Search settings"));
+    }
+
+    #[test]
+    fn an_editable_nodes_name_is_the_desc_not_the_raw_resource_id() {
+        // The only fixture here with both `desc` and `resource_id` present, so it is what
+        // pins the precedence between them. (`LabelInputs`'s named fields, not this test, are
+        // what stop the call site transposing the two.) The older-companion path (neither key
+        // sent) needs no dedicated test — every fixture above that omits them already
+        // exercises it.
+        let node = mapped_full(
+            Some("joe@x.com"),
+            Some("Email"),
+            Some("com.x:id/email_field"),
+            None,
+            true,
+        );
+        assert_eq!(node.name.as_deref(), Some("Email"));
     }
 }

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -35,8 +35,9 @@ fn json_to_node(
     budget.visit();
     let cls = v.get("class").and_then(Value::as_str).unwrap_or("");
     let flag = |k: &str| v.get(k).and_then(Value::as_bool).unwrap_or(false);
-    // No host-side filter: device agent drops empty text/desc, so this reader needs no
-    // non_empty like the uiautomator reader's XML dump.
+    // No host-side filter: device agent drops empty text/desc, so this reader skips the
+    // `non_empty` guard the uiautomator reader needs — were that to change, an empty `text`
+    // would win the name over `desc` on a non-editable node.
     let text = v.get("text").and_then(Value::as_str);
     let desc = v.get("desc").and_then(Value::as_str);
     let (name, value, description) = labels(text, desc, flag("editable"));
@@ -736,8 +737,8 @@ mod tests {
 
     #[test]
     fn an_editable_node_is_named_by_its_content_description_not_its_text() {
-        // This reader used to name an editable node by `text`, so a filled field's name
-        // changed on every keystroke and could not be selected against.
+        // This reader used to name an editable node by `text` too (see `labels`'s doc for why
+        // that breaks selectors).
         let node = mapped_editable(Some("joe@x.com"), Some("Email"));
         assert_eq!(node.name.as_deref(), Some("Email"));
         assert_eq!(node.value.as_deref(), Some("joe@x.com"));

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -35,9 +35,8 @@ fn json_to_node(
     budget.visit();
     let cls = v.get("class").and_then(Value::as_str).unwrap_or("");
     let flag = |k: &str| v.get(k).and_then(Value::as_bool).unwrap_or(false);
-    // No host-side filter: device agent drops empty text/desc, so this reader skips the
-    // `non_empty` guard the uiautomator reader needs — were that to change, an empty `text`
-    // would win the name over `desc` on a non-editable node.
+    // The device agent omits an empty text/desc rather than sending `""`, so both arrive as
+    // `None` here; `labels` judges a blank one absent either way.
     let text = v.get("text").and_then(Value::as_str);
     let desc = v.get("desc").and_then(Value::as_str);
     let (name, value, description) = labels(text, desc, flag("editable"));
@@ -743,6 +742,17 @@ mod tests {
         assert_eq!(node.name.as_deref(), Some("Email"));
         assert_eq!(node.value.as_deref(), Some("joe@x.com"));
         assert_eq!(node.description, None);
+    }
+
+    #[test]
+    fn an_editable_node_with_no_desc_is_unnamed_not_named_by_its_contents() {
+        // The device omits the key entirely for a field with no content description. Falling
+        // back to `text` would name the field by what has been typed into it, moving the name —
+        // and the fingerprint `set_value` re-walks against — on every keystroke; unnamed is the
+        // honest reading.
+        let node = mapped_editable(Some("joe@x.com"), None);
+        assert_eq!(node.name, None);
+        assert_eq!(node.value.as_deref(), Some("joe@x.com"));
     }
 
     #[test]

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -219,24 +219,14 @@ impl Accessibility for ServiceA11y {
     }
 
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
-        // Guard: re-snapshot and verify the ref still points at the same editable element
-        // (role+name+bounds) before acting — the same drift protection as AndroidA11y::set_value.
+        // Guard: re-snapshot and verify the ref still points at the same editable element before
+        // acting. Shared with `AndroidA11y::set_value`, so both readers refuse the same drift.
         let tree = {
             let mut t = self.snapshot(ctx)?;
             t.assign_ids();
             t
         };
-        let node = tree
-            .find(target.id)
-            .ok_or(GlassError::AxElementNotFound(target.id.0))?;
-        if !target.matches(node.role, node.name.as_deref())
-            || !target.bounds_consistent(node.bounds, 8)
-        {
-            return Err(GlassError::AxElementChanged(target.id.0));
-        }
-        if !node.states.editable {
-            return Err(GlassError::AxElementNotEditable(target.id.0));
-        }
+        crate::a11y::editable_target(&tree, target)?;
         self.client.action(target.id.0, "set_text", Some(text))?;
         // Verify the value actually took. ACTION_SET_TEXT returns success but silently no-ops when
         // *replacing* existing text in a Compose field, so a bare Ok could lie (glass forbids silent

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -236,10 +236,24 @@ impl Accessibility for ServiceA11y {
         loop {
             let mut after = self.snapshot(ctx)?;
             after.assign_ids();
-            let got = after.find(target.id).and_then(|n| n.value.clone());
+            let node = after.find(target.id);
+            let got = node.and_then(|n| n.value.clone());
             // An empty field reports no value (None), not Some(""), so compare against "".
             if got.as_deref().unwrap_or("") == text {
                 return Ok(());
+            }
+            // A field that has stopped reporting `editable` — a submit collapsing it to a display
+            // row, focus lost — also reports no value, which reads exactly like a write that never
+            // landed. Spending the rest of the budget to then blame the write would send the
+            // caller to clear a field that is already correct and to switch backends for nothing.
+            // `AndroidA11y`'s `verify_write` re-checks the same flag for the same reason.
+            if node.is_some_and(|n| !n.states.editable) {
+                return Err(GlassError::AccessibilityUnavailable(format!(
+                    "set_value on element {} was sent, but the element no longer reports itself \
+                     editable, so its value cannot be read back; re-snapshot to see what it holds \
+                     rather than retyping",
+                    target.id.0
+                )));
             }
             if std::time::Instant::now() >= deadline {
                 return Err(GlassError::Backend(format!(

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -226,6 +226,20 @@ fn map_node(
 /// naming it by that text would move the name (and the role+name fingerprint) on every keystroke,
 /// so no `name:` selector could hold, and the content description is the only label left.
 ///
+/// That exception trades one failure for a smaller one. A text field with no content description
+/// is now unnamed, so role plus an 8px bounds match is the whole fingerprint `set_value` re-walks
+/// against. It removes a false *rejection* — the old service-reader name moved whenever the field's
+/// contents did, so a write could be refused for drift that never happened — at the cost of weaker
+/// discrimination against an in-place replacement, a recycled list row or a dialog reusing the
+/// rect. The weaker case stays bounded: `json_to_node` errors on a node with no bounds, so there is
+/// always a rect to compare.
+///
+/// A label with no non-whitespace content counts as absent. Left in place it would occupy the
+/// matchable `name` slot, where no `name:` selector reaches it and nothing falls back to the
+/// description — the judgement [`normalize_description`] already makes about its own candidate.
+/// Only the decision reads the trimmed form; a name that survives it is stored as the platform
+/// gave it.
+///
 /// `editable` is the caller's to decide: the on-device service reads an authoritative flag, while
 /// a `uiautomator` dump carries no such attribute and infers it from the widget class.
 pub(crate) fn labels(
@@ -233,22 +247,32 @@ pub(crate) fn labels(
     desc: Option<&str>,
     editable: bool,
 ) -> (Option<String>, Option<String>, Option<String>) {
+    fn labelled(s: &&str) -> bool {
+        !s.trim().is_empty()
+    }
+    let text_label = text.filter(labelled);
+    let desc_label = desc.filter(labelled);
     if editable {
         return (
-            desc.map(str::to_string),
+            desc_label.map(str::to_string),
+            // Verbatim, unlike the labels: whitespace a user typed is content, not a blank label.
             text.map(str::to_string),
             // The text is already the value; repeating it would print the same string twice.
             None,
         );
     }
-    let name = text.or(desc);
+    let name = text_label.or(desc_label);
     (
         name.map(str::to_string),
         None,
-        desc.and_then(|d| normalize_description(d, name)),
+        desc_label.and_then(|d| normalize_description(d, name)),
     )
 }
 
+/// Absent attribute and empty attribute are the same thing to `uiautomator`, which emits
+/// `text=""` on every node that has none. Kept even though [`labels`] judges the *name* itself,
+/// because it is also what keeps an empty field's `value` `None` rather than `Some("")` — the
+/// shape `typed_clear_landed` and a `value_contains` filter both read.
 fn non_empty(s: &str) -> Option<String> {
     if s.is_empty() {
         None
@@ -572,6 +596,41 @@ mod tests {
         assert_eq!(label.description, None);
     }
 
+    /// A `<hierarchy>` of one `EditText` carrying `text` and `content-desc` verbatim — the
+    /// attributes are always present in a dump, so `""` is how the device says "absent".
+    fn edit_text_xml(text: &str, content_desc: &str) -> String {
+        format!(
+            "<?xml version='1.0'?><hierarchy rotation=\"0\">\
+             <node index=\"0\" text=\"{text}\" class=\"android.widget.EditText\" \
+             content-desc=\"{content_desc}\" enabled=\"true\" focusable=\"true\" focused=\"true\" \
+             selected=\"false\" checkable=\"false\" checked=\"false\" password=\"false\" \
+             bounds=\"[0,0][100,50]\" /></hierarchy>"
+        )
+    }
+
+    #[test]
+    fn an_editable_node_with_an_empty_content_desc_is_unnamed_not_named_by_its_contents() {
+        // `content-desc=""` is what a device sends for a field with no description, and an
+        // unnamed field is the honest reading: naming it by `text` would move the name — and the
+        // fingerprint `set_value` re-walks against — on every keystroke.
+        let xml = edit_text_xml("joe@x.com", "");
+        let tree = build_tree(&xml, &win(), WalkLimits::DEFAULT).unwrap();
+        let field = &tree.root.children[0];
+        assert_eq!(field.name, None);
+        assert_eq!(field.value.as_deref(), Some("joe@x.com"));
+    }
+
+    #[test]
+    fn an_empty_editable_node_reports_no_value_rather_than_an_empty_one() {
+        // `typed_clear_landed` and a `value_contains` filter both read "empty" as no value at
+        // all, so `text=""` must not surface as `Some("")`.
+        let xml = edit_text_xml("", "Email");
+        let tree = build_tree(&xml, &win(), WalkLimits::DEFAULT).unwrap();
+        let field = &tree.root.children[0];
+        assert_eq!(field.name.as_deref(), Some("Email"));
+        assert_eq!(field.value, None);
+    }
+
     #[test]
     fn a_text_identical_to_the_content_desc_is_not_a_description() {
         let xml = concat!(
@@ -632,6 +691,21 @@ mod tests {
             // Neither label.
             (None, None, false, None, None, None),
             (None, None, true, None, None, None),
+            // A label of pure whitespace is no label: it must not take the name slot, where no
+            // `name:` selector could reach it and the description would never stand in.
+            (
+                Some(" "),
+                Some("Save changes"),
+                false,
+                Some("Save changes"),
+                None,
+                None,
+            ),
+            (Some(" "), None, false, None, None, None),
+            // The empty content-desc a device really sends for "no description". `Some("")` in
+            // the name slot is worse than `None`: it matches every other empty-named node.
+            (Some("hi"), Some(""), true, None, Some("hi"), None),
+            (Some("hi"), Some("  "), true, None, Some("hi"), None),
         ];
         for &(text, desc, editable, name, value, description) in cases {
             assert_eq!(

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -222,8 +222,9 @@ fn map_node(
 ///
 /// Both Android readers route through this, so the precedence is one decision with one test suite
 /// rather than a per-reader choice that can drift apart — which is what it had done. The visible
-/// text is the name; an editable node is the exception, because there the text is the user's
-/// content and the content description is the only label left.
+/// text is the name; an editable node is the exception, because its text is what the user typed —
+/// naming it by that text would move the name (and the role+name fingerprint) on every keystroke,
+/// so no `name:` selector could hold, and the content description is the only label left.
 ///
 /// `editable` is the caller's to decide: the on-device service reads an authoritative flag, while
 /// a `uiautomator` dump carries no such attribute and infers it from the widget class.
@@ -647,9 +648,8 @@ mod tests {
 
     #[test]
     fn an_editable_node_is_never_named_by_what_was_typed_into_it() {
-        // The case that decides the editable branch: `name` must not follow the content, or a
-        // `name:` selector cannot address a filled field and the role+name fingerprint moves
-        // every time the value does.
+        // The case the editable branch exists for (see `labels`'s doc): name must not track
+        // the typed value.
         let (before, _, _) = labels(Some("jo"), Some("Email"), true);
         let (after, _, _) = labels(Some("joe@x.com"), Some("Email"), true);
         assert_eq!(before, after);

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -226,13 +226,10 @@ fn map_node(
 /// naming it by that text would move the name (and the role+name fingerprint) on every keystroke,
 /// so no `name:` selector could hold, and the content description is the only label left.
 ///
-/// That exception trades one failure for a smaller one. A text field with no content description
-/// is now unnamed, so role plus an 8px bounds match is the whole fingerprint `set_value` re-walks
-/// against. It removes a false *rejection* — the old service-reader name moved whenever the field's
-/// contents did, so a write could be refused for drift that never happened — at the cost of weaker
-/// discrimination against an in-place replacement, a recycled list row or a dialog reusing the
-/// rect. The weaker case stays bounded: `json_to_node` errors on a node with no bounds, so there is
-/// always a rect to compare.
+/// A text field with no content description is unnamed, so role plus an 8px bounds match is the
+/// whole fingerprint `set_value` re-walks against — weaker discrimination against an in-place
+/// replacement, a recycled list row, or a dialog reusing the rect. `json_to_node` errors on a node
+/// with no bounds, so that rect is always there to compare.
 ///
 /// A label with no non-whitespace content counts as absent. Left in place it would occupy the
 /// matchable `name` slot, where no `name:` selector reaches it and nothing falls back to the

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -155,17 +155,7 @@ fn map_node(
     let editable = role == AxRole::TextField || boolean("password");
     let content_desc = non_empty(attr("content-desc"));
     let text = non_empty(attr("text"));
-    let name = content_desc.or_else(|| if editable { None } else { text.clone() });
-    // An editable node's `text` is its value, so it is already surfaced. A non-editable node's
-    // `text` is either the name (no content-desc) or dropped outright, and the dropped case is
-    // what this recovers.
-    let description = if editable {
-        None
-    } else {
-        text.as_deref()
-            .and_then(|t| normalize_description(t, name.as_deref()))
-    };
-    let value = if editable { text } else { None };
+    let (name, value, description) = labels(text.as_deref(), content_desc.as_deref(), editable);
     let states = AxStates {
         focused: boolean("focused"),
         focusable: boolean("focusable"),
@@ -237,7 +227,6 @@ fn map_node(
 ///
 /// `editable` is the caller's to decide: the on-device service reads an authoritative flag, while
 /// a `uiautomator` dump carries no such attribute and infers it from the widget class.
-#[allow(dead_code)] // temporary: used only by tests until the next change wires up a caller
 pub(crate) fn labels(
     text: Option<&str>,
     desc: Option<&str>,
@@ -544,13 +533,13 @@ mod tests {
     );
 
     #[test]
-    fn the_text_a_content_desc_displaced_becomes_the_description() {
+    fn the_content_desc_a_visible_text_displaced_becomes_the_description() {
         let tree = build_tree(BOTH_LABELS_XML, &win(), WalkLimits::DEFAULT).unwrap();
         let button = &tree.root.children[0];
-        // `content-desc` wins the name here (that precedence is glass#260's subject and is NOT
-        // changed by this test), so `text` is the label that would otherwise be dropped.
-        assert_eq!(button.name.as_deref(), Some("Save changes"));
-        assert_eq!(button.description.as_deref(), Some("Save"));
+        // Visible text wins the name (glass#260); `content-desc` is the label that would
+        // otherwise be dropped.
+        assert_eq!(button.name.as_deref(), Some("Save"));
+        assert_eq!(button.description.as_deref(), Some("Save changes"));
     }
 
     #[test]

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -228,6 +228,37 @@ fn map_node(
     }
 }
 
+/// The three label fields, from the two labels Android exposes plus whether the node is editable.
+///
+/// Both Android readers route through this, so the precedence is one decision with one test suite
+/// rather than a per-reader choice that can drift apart — which is what it had done. The visible
+/// text is the name; an editable node is the exception, because there the text is the user's
+/// content and the content description is the only label left.
+///
+/// `editable` is the caller's to decide: the on-device service reads an authoritative flag, while
+/// a `uiautomator` dump carries no such attribute and infers it from the widget class.
+#[allow(dead_code)] // temporary: used only by tests until the next change wires up a caller
+pub(crate) fn labels(
+    text: Option<&str>,
+    desc: Option<&str>,
+    editable: bool,
+) -> (Option<String>, Option<String>, Option<String>) {
+    if editable {
+        return (
+            desc.map(str::to_string),
+            text.map(str::to_string),
+            // The text is already the value; repeating it would print the same string twice.
+            None,
+        );
+    }
+    let name = text.or(desc);
+    (
+        name.map(str::to_string),
+        None,
+        desc.and_then(|d| normalize_description(d, name)),
+    )
+}
+
 fn non_empty(s: &str) -> Option<String> {
     if s.is_empty() {
         None
@@ -563,6 +594,77 @@ mod tests {
         );
         let tree = build_tree(xml, &win(), WalkLimits::DEFAULT).unwrap();
         assert_eq!(tree.root.children[0].description, None);
+    }
+
+    /// Every combination of the two labels and the editable flag, with the rule stated once.
+    /// `desc` differs from `text` except where the case is about them matching.
+    #[test]
+    #[expect(
+        clippy::type_complexity,
+        reason = "one-off table type, not worth naming"
+    )]
+    fn labels_follow_one_rule_for_both_readers() {
+        // (text, desc, editable) -> (name, value, description)
+        let cases: &[(
+            Option<&str>,
+            Option<&str>,
+            bool,
+            Option<&str>,
+            Option<&str>,
+            Option<&str>,
+        )] = &[
+            // Non-editable: the visible text is the name, the content-description is the extra.
+            (
+                Some("Save"),
+                Some("Save changes"),
+                false,
+                Some("Save"),
+                None,
+                Some("Save changes"),
+            ),
+            // No text: the content-description IS the name, so it must not print twice.
+            (None, Some("Bold"), false, Some("Bold"), None, None),
+            // No content-description: nothing to add.
+            (Some("Settings"), None, false, Some("Settings"), None, None),
+            // Both, identical: one label, printed once.
+            (Some("Save"), Some("Save"), false, Some("Save"), None, None),
+            // Editable: the text is the user's content, so the description is the label.
+            (
+                Some("joe@x.com"),
+                Some("Email"),
+                true,
+                Some("Email"),
+                Some("joe@x.com"),
+                None,
+            ),
+            // Editable with no content-description: honestly unnamed, never named by its content.
+            (Some("joe@x.com"), None, true, None, Some("joe@x.com"), None),
+            // Neither label.
+            (None, None, false, None, None, None),
+            (None, None, true, None, None, None),
+        ];
+        for &(text, desc, editable, name, value, description) in cases {
+            assert_eq!(
+                labels(text, desc, editable),
+                (
+                    name.map(str::to_string),
+                    value.map(str::to_string),
+                    description.map(str::to_string)
+                ),
+                "labels({text:?}, {desc:?}, editable={editable})"
+            );
+        }
+    }
+
+    #[test]
+    fn an_editable_node_is_never_named_by_what_was_typed_into_it() {
+        // The case that decides the editable branch: `name` must not follow the content, or a
+        // `name:` selector cannot address a filled field and the role+name fingerprint moves
+        // every time the value does.
+        let (before, _, _) = labels(Some("jo"), Some("Email"), true);
+        let (after, _, _) = labels(Some("joe@x.com"), Some("Email"), true);
+        assert_eq!(before, after);
+        assert_eq!(before.as_deref(), Some("Email"));
     }
 
     #[test]

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -308,6 +308,11 @@ mod tests {
         "<node index=\"2\" text=\"\" class=\"android.widget.Button\" package=\"com.x\" ",
         "content-desc=\"Save\" enabled=\"true\" focusable=\"true\" focused=\"false\" selected=\"false\" ",
         "checkable=\"false\" checked=\"false\" password=\"false\" bounds=\"[40,300][1040,380]\" />",
+        // A masked field whose class is in no table — the case `password` is the only signal for.
+        "<node index=\"3\" text=\"hunter2\" class=\"com.example.SecureField\" package=\"com.x\" ",
+        "content-desc=\"Password\" enabled=\"true\" focusable=\"true\" focused=\"false\" ",
+        "selected=\"false\" checkable=\"false\" checked=\"false\" password=\"true\" ",
+        "bounds=\"[40,400][1040,480]\" />",
         "</node></hierarchy>",
     );
 
@@ -374,7 +379,7 @@ mod tests {
         let frame = &tree.root.children[0];
         assert_eq!(frame.role, AxRole::Group);
         let kids = &frame.children;
-        assert_eq!(kids.len(), 3);
+        assert_eq!(kids.len(), 4);
         assert_eq!(
             (kids[0].role, kids[0].name.as_deref()),
             (AxRole::Label, Some("Settings"))
@@ -388,6 +393,19 @@ mod tests {
             (AxRole::Button, Some("Save"))
         );
         assert_eq!(kids[2].bounds.unwrap().width, 1000);
+    }
+
+    #[test]
+    fn a_password_node_is_editable_whatever_its_class() {
+        // `password="true"` is the only editable signal for a masked field whose class is in no
+        // table. Without it the node is non-editable, and a non-editable node is named by its
+        // text — so the name would become the field's own masked contents.
+        let tree = build_tree(XML, &win(), WalkLimits::DEFAULT).unwrap();
+        let secure = &tree.root.children[0].children[3];
+        assert_eq!(secure.role, AxRole::Other, "class is deliberately unmapped");
+        assert!(secure.states.editable, "password=true must imply editable");
+        assert_eq!(secure.name.as_deref(), Some("Password"));
+        assert_eq!(secure.value.as_deref(), Some("hunter2"));
     }
 
     /// A `<hierarchy>` with `n` flat top-level `<node>` elements, each a distinctly-named Button.

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -717,6 +717,16 @@ mod tests {
                 None,
             ),
             (Some(" "), None, false, None, None, None),
+            // Editable's value keeps whitespace: a caller can legitimately set a field to
+            // spaces, and read-back compares exactly.
+            (
+                Some("  "),
+                Some("Email"),
+                true,
+                Some("Email"),
+                Some("  "),
+                None,
+            ),
             // The empty content-desc a device really sends for "no description". `Some("")` in
             // the name slot is worse than `None`: it matches every other empty-named node.
             (Some("hi"), Some(""), true, None, Some("hi"), None),

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -68,6 +68,14 @@ pub fn class_to_role(class: &str) -> AxRole {
     AxRole::Other
 }
 
+/// `com.example:id/search_src_text` → `search_src_text`. The package-qualified form is noise in an
+/// outline; the bare leaf is still not unique within an app's tree — see [`labels`]'s doc for why
+/// it is only a label of last resort. The leaf can be blank where the whole id was not
+/// (`com.x:id/`), so callers judge it after taking it, not before.
+fn id_leaf(id: &str) -> &str {
+    id.rsplit('/').next().unwrap_or(id)
+}
+
 /// Parse uiautomator `bounds="[l,t][r,b]"` (screen-absolute) into a window-relative `AxRect`.
 pub fn parse_bounds(s: &str, window: &WindowGeometry) -> Option<AxRect> {
     let s = s.trim().strip_prefix('[')?;
@@ -155,7 +163,15 @@ fn map_node(
     let editable = role == AxRole::TextField || boolean("password");
     let content_desc = non_empty(attr("content-desc"));
     let text = non_empty(attr("text"));
-    let (name, value, description) = labels(text.as_deref(), content_desc.as_deref(), editable);
+    let resource_id = non_empty(attr("resource-id"));
+    let (name, value, description) = labels(LabelInputs {
+        text: text.as_deref(),
+        desc: content_desc.as_deref(),
+        resource_id: resource_id.as_deref(),
+        // A uiautomator dump carries no hint attribute — verified absent on API 34.
+        hint: None,
+        editable,
+    });
     let states = AxStates {
         focused: boolean("focused"),
         focusable: boolean("focusable"),
@@ -218,46 +234,83 @@ fn map_node(
     }
 }
 
-/// The three label fields, from the two labels Android exposes plus whether the node is editable.
+/// What a reader read off one node, for [`labels`] to judge.
+///
+/// A struct rather than four interchangeable `Option<&str>` parameters: transposing two of those
+/// is not a type error, and the result is a plausible-looking *wrong* name (the unleafed id in the
+/// name slot) that no test outside a dedicated one would catch.
+pub(crate) struct LabelInputs<'a> {
+    /// The element's visible text — for an editable node, what the user typed.
+    pub(crate) text: Option<&'a str>,
+    /// Its content description.
+    pub(crate) desc: Option<&'a str>,
+    /// Its view resource id, package-qualified as the platform reports it.
+    pub(crate) resource_id: Option<&'a str>,
+    /// Its hint (placeholder text). Always `None` from `uiautomator`, whose dump carries no such
+    /// attribute.
+    pub(crate) hint: Option<&'a str>,
+    /// Whether the node is editable. The caller's to decide: the on-device service reads an
+    /// authoritative flag, while a `uiautomator` dump infers it from the widget class.
+    pub(crate) editable: bool,
+}
+
+/// The three label fields — name, value, description — from what a reader read off the node.
 ///
 /// Both Android readers route through this, so the precedence is one decision with one test suite
 /// rather than a per-reader choice that can drift apart — which is what it had done. The visible
 /// text is the name; an editable node is the exception, because its text is what the user typed —
 /// naming it by that text would move the name (and the role+name fingerprint) on every keystroke,
-/// so no `name:` selector could hold, and the content description is the only label left.
+/// so no `name:` selector could hold, and the content description — or, failing that, the
+/// resource id — is the label left.
 ///
-/// A text field with no content description is unnamed, so role plus an 8px bounds match is the
-/// whole fingerprint `set_value` re-walks against — weaker discrimination against an in-place
-/// replacement, a recycled list row, or a dialog reusing the rect. `json_to_node` errors on a node
-/// with no bounds, so that rect is always there to compare.
+/// A text field with no content description falls back to its resource id — not unique in a tree
+/// (ten rows from one layout can all carry `row_title`), so it is a label of last resort rather
+/// than an identifier. Only when both are absent does the node stay unnamed; role, bounds, and —
+/// since `editable_target` also compares `AxTarget::value` — the field's own text are then the
+/// whole fingerprint `set_value` re-walks against. `json_to_node` errors on a node with no bounds,
+/// so that rect is always there to compare.
 ///
-/// A label with no non-whitespace content counts as absent. Left in place it would occupy the
-/// matchable `name` slot, where no `name:` selector reaches it and nothing falls back to the
-/// description — the judgement [`normalize_description`] already makes about its own candidate.
-/// Only the decision reads the trimmed form; a name that survives it is stored as the platform
-/// gave it.
+/// The hint (Android's placeholder text for an empty field) becomes the `description`, never the
+/// `name` — `uiautomator` cannot see a hint at all, so a hint-derived name would exist on one
+/// reader but not the other.
 ///
-/// `editable` is the caller's to decide: the on-device service reads an authoritative flag, while
-/// a `uiautomator` dump carries no such attribute and infers it from the widget class.
-pub(crate) fn labels(
-    text: Option<&str>,
-    desc: Option<&str>,
-    editable: bool,
-) -> (Option<String>, Option<String>, Option<String>) {
+/// A label, resource id, or hint with no non-whitespace content counts as absent. Left in place it
+/// would occupy the matchable `name` slot, where no `name:` selector reaches it and nothing falls
+/// back to the description — the judgement [`normalize_description`] already makes about its own
+/// candidate. The id is judged *after* its leaf is taken, so a `com.x:id/` with nothing behind the
+/// slash is absent too. Only the decision reads the trimmed form; a name that survives it is
+/// stored as the platform gave it.
+pub(crate) fn labels(inputs: LabelInputs<'_>) -> (Option<String>, Option<String>, Option<String>) {
     fn labelled(s: &&str) -> bool {
         !s.trim().is_empty()
     }
+    let LabelInputs {
+        text,
+        desc,
+        resource_id,
+        hint,
+        editable,
+    } = inputs;
     let text_label = text.filter(labelled);
     let desc_label = desc.filter(labelled);
     if editable {
+        // Bound before the tuple: the hint is judged against the name that was actually chosen,
+        // so a hint repeating it drops, exactly as a description does on the other arm.
+        let name = desc_label
+            .or_else(|| resource_id.map(id_leaf).filter(labelled))
+            .map(str::to_string);
+        let description = hint
+            .filter(labelled)
+            .and_then(|h| normalize_description(h, name.as_deref()));
         return (
-            desc_label.map(str::to_string),
+            name,
             // Verbatim, unlike the labels: whitespace a user typed is content, not a blank label.
             text.map(str::to_string),
-            // The text is already the value; repeating it would print the same string twice.
-            None,
+            description,
         );
     }
+    // No resource-id fallback here: giving every container a name too would stop
+    // `outline::is_scaffolding` collapsing them, inflating every snapshot.
     let name = text_label.or(desc_label);
     (
         name.map(str::to_string),
@@ -624,10 +677,11 @@ mod tests {
     }
 
     #[test]
-    fn an_editable_node_with_an_empty_content_desc_is_unnamed_not_named_by_its_contents() {
-        // `content-desc=""` is what a device sends for a field with no description, and an
-        // unnamed field is the honest reading: naming it by `text` would move the name — and the
-        // fingerprint `set_value` re-walks against — on every keystroke.
+    fn an_editable_node_with_no_desc_and_no_id_is_unnamed_not_named_by_its_contents() {
+        // `content-desc=""` is what a device sends for a field with no description, and
+        // `edit_text_xml` emits no `resource-id`, so nothing is left to fall back to: naming it by
+        // `text` would move the name — and the fingerprint `set_value` re-walks against — on every
+        // keystroke, so unnamed is the honest reading.
         let xml = edit_text_xml("joe@x.com", "");
         let tree = build_tree(&xml, &win(), WalkLimits::DEFAULT).unwrap();
         let field = &tree.root.children[0];
@@ -647,6 +701,24 @@ mod tests {
     }
 
     #[test]
+    fn an_editable_node_with_no_content_desc_is_named_by_its_view_id() {
+        let xml = concat!(
+            "<?xml version='1.0'?><hierarchy rotation=\"0\">",
+            "<node index=\"0\" text=\"wifi\" resource-id=\"com.android.settings:id/search_src_text\" ",
+            "class=\"android.widget.EditText\" content-desc=\"\" enabled=\"true\" focusable=\"true\" ",
+            "focused=\"false\" selected=\"false\" checkable=\"false\" checked=\"false\" ",
+            "password=\"false\" bounds=\"[0,0][100,50]\" />",
+            "</hierarchy>",
+        );
+        let tree = build_tree(xml, &win(), WalkLimits::DEFAULT).unwrap();
+        let field = &tree.root.children[0];
+        assert_eq!(field.name.as_deref(), Some("search_src_text"));
+        assert_eq!(field.value.as_deref(), Some("wifi"));
+        // uiautomator carries no hint, so there is nothing to describe.
+        assert_eq!(field.description, None);
+    }
+
+    #[test]
     fn a_text_identical_to_the_content_desc_is_not_a_description() {
         let xml = concat!(
             "<?xml version='1.0'?><hierarchy rotation=\"0\">",
@@ -660,16 +732,19 @@ mod tests {
         assert_eq!(tree.root.children[0].description, None);
     }
 
-    /// Every combination of the two labels and the editable flag, with the rule stated once.
-    /// `desc` differs from `text` except where the case is about them matching.
+    /// Every combination of the two labels, the resource id, the hint, and the editable flag,
+    /// with the rule stated once. `desc` differs from `text` except where the case is about them
+    /// matching.
     #[test]
     #[expect(
         clippy::type_complexity,
         reason = "one-off table type, not worth naming"
     )]
     fn labels_follow_one_rule_for_both_readers() {
-        // (text, desc, editable) -> (name, value, description)
+        // (text, desc, resource_id, hint, editable) -> (name, value, description)
         let cases: &[(
+            Option<&str>,
+            Option<&str>,
             Option<&str>,
             Option<&str>,
             bool,
@@ -681,47 +756,92 @@ mod tests {
             (
                 Some("Save"),
                 Some("Save changes"),
+                None,
+                None,
                 false,
                 Some("Save"),
                 None,
                 Some("Save changes"),
             ),
             // No text: the content-description IS the name, so it must not print twice.
-            (None, Some("Bold"), false, Some("Bold"), None, None),
+            (
+                None,
+                Some("Bold"),
+                None,
+                None,
+                false,
+                Some("Bold"),
+                None,
+                None,
+            ),
             // No content-description: nothing to add.
-            (Some("Settings"), None, false, Some("Settings"), None, None),
+            (
+                Some("Settings"),
+                None,
+                None,
+                None,
+                false,
+                Some("Settings"),
+                None,
+                None,
+            ),
             // Both, identical: one label, printed once.
-            (Some("Save"), Some("Save"), false, Some("Save"), None, None),
+            (
+                Some("Save"),
+                Some("Save"),
+                None,
+                None,
+                false,
+                Some("Save"),
+                None,
+                None,
+            ),
             // Editable: the text is the user's content, so the description is the label.
             (
                 Some("joe@x.com"),
                 Some("Email"),
+                None,
+                None,
                 true,
                 Some("Email"),
                 Some("joe@x.com"),
                 None,
             ),
-            // Editable with no content-description: honestly unnamed, never named by its content.
-            (Some("joe@x.com"), None, true, None, Some("joe@x.com"), None),
+            // Editable with no content-description or resource id: honestly unnamed, never named
+            // by its content.
+            (
+                Some("joe@x.com"),
+                None,
+                None,
+                None,
+                true,
+                None,
+                Some("joe@x.com"),
+                None,
+            ),
             // Neither label.
-            (None, None, false, None, None, None),
-            (None, None, true, None, None, None),
+            (None, None, None, None, false, None, None, None),
+            (None, None, None, None, true, None, None, None),
             // A label of pure whitespace is no label: it must not take the name slot, where no
             // `name:` selector could reach it and the description would never stand in.
             (
                 Some(" "),
                 Some("Save changes"),
+                None,
+                None,
                 false,
                 Some("Save changes"),
                 None,
                 None,
             ),
-            (Some(" "), None, false, None, None, None),
+            (Some(" "), None, None, None, false, None, None, None),
             // Editable's value keeps whitespace: a caller can legitimately set a field to
             // spaces, and read-back compares exactly.
             (
                 Some("  "),
                 Some("Email"),
+                None,
+                None,
                 true,
                 Some("Email"),
                 Some("  "),
@@ -729,18 +849,144 @@ mod tests {
             ),
             // The empty content-desc a device really sends for "no description". `Some("")` in
             // the name slot is worse than `None`: it matches every other empty-named node.
-            (Some("hi"), Some(""), true, None, Some("hi"), None),
-            (Some("hi"), Some("  "), true, None, Some("hi"), None),
+            (
+                Some("hi"),
+                Some(""),
+                None,
+                None,
+                true,
+                None,
+                Some("hi"),
+                None,
+            ),
+            (
+                Some("hi"),
+                Some("  "),
+                None,
+                None,
+                true,
+                None,
+                Some("hi"),
+                None,
+            ),
+            // Editable, no content description: the resource id names it rather than nothing.
+            // Package-qualified, as the platform actually emits it: the leaf is the name, not
+            // the qualified string.
+            (
+                Some("wifi"),
+                None,
+                Some("com.android.settings:id/search_src_text"),
+                None,
+                true,
+                Some("search_src_text"),
+                Some("wifi"),
+                None,
+            ),
+            // A content description still wins the name; the id is only a fallback.
+            (
+                Some("wifi"),
+                Some("Email"),
+                Some("com.android.settings:id/search_src_text"),
+                None,
+                true,
+                Some("Email"),
+                Some("wifi"),
+                None,
+            ),
+            // The hint is the description, and does not touch the name.
+            (
+                Some("wifi"),
+                None,
+                Some("com.android.settings:id/search_src_text"),
+                Some("Search settings"),
+                true,
+                Some("search_src_text"),
+                Some("wifi"),
+                Some("Search settings"),
+            ),
+            // A hint equal to the name adds nothing.
+            (
+                None,
+                None,
+                Some("com.x:id/Search"),
+                Some("Search"),
+                true,
+                Some("Search"),
+                None,
+                None,
+            ),
+            // Non-editable is untouched by either new input.
+            (
+                Some("Save"),
+                Some("Save changes"),
+                Some("save_btn"),
+                Some("ignored"),
+                false,
+                Some("Save"),
+                None,
+                Some("Save changes"),
+            ),
+            // Neither label nor id: still honestly unnamed.
+            (
+                Some("wifi"),
+                None,
+                None,
+                None,
+                true,
+                None,
+                Some("wifi"),
+                None,
+            ),
+            // Non-editable with an id and no labels at all: the fallback is editable-only, so
+            // this stays unnamed rather than picking up the id.
+            (
+                None,
+                None,
+                Some("com.x:id/save_btn"),
+                None,
+                false,
+                None,
+                None,
+                None,
+            ),
+            // An id with nothing behind the slash: the leaf, not the qualified string, is what
+            // has to be non-blank, or `Some("")` takes the matchable name slot.
+            (
+                Some("wifi"),
+                None,
+                Some("com.x:id/"),
+                None,
+                true,
+                None,
+                Some("wifi"),
+                None,
+            ),
+            (
+                Some("wifi"),
+                None,
+                Some("com.x:id/   "),
+                None,
+                true,
+                None,
+                Some("wifi"),
+                None,
+            ),
         ];
-        for &(text, desc, editable, name, value, description) in cases {
+        for &(text, desc, resource_id, hint, editable, name, value, description) in cases {
             assert_eq!(
-                labels(text, desc, editable),
+                labels(LabelInputs {
+                    text,
+                    desc,
+                    resource_id,
+                    hint,
+                    editable
+                }),
                 (
                     name.map(str::to_string),
                     value.map(str::to_string),
                     description.map(str::to_string)
                 ),
-                "labels({text:?}, {desc:?}, editable={editable})"
+                "labels({text:?}, {desc:?}, {resource_id:?}, {hint:?}, editable={editable})"
             );
         }
     }
@@ -749,8 +995,17 @@ mod tests {
     fn an_editable_node_is_never_named_by_what_was_typed_into_it() {
         // The case the editable branch exists for (see `labels`'s doc): name must not track
         // the typed value.
-        let (before, _, _) = labels(Some("jo"), Some("Email"), true);
-        let (after, _, _) = labels(Some("joe@x.com"), Some("Email"), true);
+        let typed = |text| {
+            labels(LabelInputs {
+                text: Some(text),
+                desc: Some("Email"),
+                resource_id: None,
+                hint: None,
+                editable: true,
+            })
+        };
+        let (before, _, _) = typed("jo");
+        let (after, _, _) = typed("joe@x.com");
         assert_eq!(before, after);
         assert_eq!(before.as_deref(), Some("Email"));
     }

--- a/crates/glass-android/tests/a11y_loop.rs
+++ b/crates/glass-android/tests/a11y_loop.rs
@@ -130,6 +130,7 @@ fn set_value_reports_whether_the_write_landed() {
         role: field.role,
         name: field.name.clone(),
         bounds: field.bounds,
+        value: field.value.clone(),
     };
 
     // A write that lands: reported Ok, and the node at that id holds it afterwards.
@@ -161,6 +162,7 @@ fn set_value_reports_whether_the_write_landed() {
         role: field.role,
         name: field.name.clone(),
         bounds: field.bounds,
+        value: field.value.clone(),
     };
     match a11y.set_value(&ctx, &target, "") {
         Err(GlassError::AxValueNotApplied(_)) => {}
@@ -185,6 +187,7 @@ fn set_value_reports_whether_the_write_landed() {
         role: target.role,
         name: Some("not the field that is there".into()),
         bounds: target.bounds,
+        value: target.value.clone(),
     };
     match a11y.set_value(&ctx, &stale, "ignored") {
         Err(GlassError::AxElementChanged(_)) | Err(GlassError::AxElementNotFound(_)) => {}

--- a/crates/glass-android/tests/a11y_service_loop.rs
+++ b/crates/glass-android/tests/a11y_service_loop.rs
@@ -69,6 +69,7 @@ fn a11y_service_snapshot_and_actions() {
             role: node.role,
             name: node.name.clone(),
             bounds: node.bounds,
+            value: node.value.clone(),
         };
         a11y.set_value(&ctx, &target, "viaA11y")
             .expect("set_value via ACTION_SET_TEXT");

--- a/crates/glass-android/tests/role_probe.rs
+++ b/crates/glass-android/tests/role_probe.rs
@@ -285,7 +285,7 @@ fn uiautomator_role_histogram_probe() {
         println!(
             "\nNOTE: no app in this run reported a single described node — either these apps \
              give every element one label, or the reader stopped sourcing it (see the \
-             `description` binding in axmap::map_node / a11y_service::json_to_node)"
+             `description` binding in axmap::labels, which both readers route through)"
         );
     }
     assert!(violations.is_empty(), "{}", violations.join("\n"));
@@ -365,7 +365,7 @@ fn service_role_histogram_probe() {
         println!(
             "\nNOTE: no app in this run reported a single described node — either these apps \
              give every element one label, or the reader stopped sourcing it (see the \
-             `description` binding in axmap::map_node / a11y_service::json_to_node)"
+             `description` binding in axmap::labels, which both readers route through)"
         );
     }
     // `_restore` puts the device's accessibility settings back as it drops, after this

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -553,6 +553,18 @@ impl AxTree {
         walk(&self.root, id)
     }
 
+    /// [`Self::find`], mutably — for patching a field of a cached node in place rather than
+    /// re-walking the whole tree.
+    pub fn find_mut(&mut self, id: AxNodeId) -> Option<&mut AxNode> {
+        fn walk(node: &mut AxNode, id: AxNodeId) -> Option<&mut AxNode> {
+            if node.id == id {
+                return Some(node);
+            }
+            node.children.iter_mut().find_map(|c| walk(c, id))
+        }
+        walk(&mut self.root, id)
+    }
+
     /// Render a compact indented outline, one line per node, in `outline::write_line`'s format —
     /// the single definition of it, shared with [`crate::outline::render_compact`]. This render
     /// differs only in keeping every node: nothing is collapsed.
@@ -623,11 +635,12 @@ pub struct AxContext {
 }
 
 /// A fingerprint identifying the element a value-set targets: its synthetic id
-/// (pre-order index), the role/name the caller saw in the snapshot, and the
-/// element's window-relative bounds when known. The backend re-walks to the id
-/// and verifies role+name (and bounds, when present) so a stale id — or tree
-/// drift that lands a *different* same-role+name element on the id — errors
-/// rather than overwriting the wrong element.
+/// (pre-order index), the role/name the caller saw in the snapshot, the
+/// element's window-relative bounds when known, and the value it held. The
+/// backend re-walks to the id and verifies role+name (and bounds, when present;
+/// on Android the value too) so a stale id — or tree drift that lands a
+/// *different* same-role+name element on the id — errors rather than
+/// overwriting the wrong element.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AxTarget {
     pub id: AxNodeId,
@@ -638,6 +651,18 @@ pub struct AxTarget {
     /// same-role+name element if the tree drifted, and that element sits
     /// elsewhere — see [`Self::bounds_consistent`].
     pub bounds: Option<AxRect>,
+    /// The element's value at snapshot time, when it had one. Captured on every backend, but
+    /// compared only by Android's `set_value` guard (`editable_target`), where a recycled list
+    /// row reuses the same view — role, name and rect all identical, only this different. The
+    /// other backends carry it without reading it; see [`Self::value_consistent`].
+    ///
+    /// After a successful write the session cache patches this to the text that was requested —
+    /// an exact fact only on a typed-write backend (Android/iOS, verified by
+    /// `typed_text_landed`/`typed_clear_landed`). An atomic-write backend (Windows/macOS) may
+    /// have reformatted the value instead (`read_back_confirms`), and Linux's AT-SPI writer
+    /// doesn't read back at all, so on those a future consumer should treat this as a best
+    /// available label, not a proven one.
+    pub value: Option<String>,
 }
 
 impl AxTarget {
@@ -662,6 +687,15 @@ impl AxTarget {
                     && (i64::from(a.height) - i64::from(b.height)).abs() <= tol
             }
         }
+    }
+
+    /// Whether a reached element's value `got` is consistent with the value captured for this
+    /// target. `true` when none was captured: a captured `None` says the element held no value
+    /// then, not which element it was, so gating on it would make every element that never held
+    /// one unwritable. A live `None` against a captured value still rejects — Android reports an
+    /// emptied field as no value at all, which is a real change, not a missing observation.
+    pub fn value_consistent(&self, got: Option<&str>) -> bool {
+        self.value.is_none() || self.value.as_deref() == got
     }
 }
 
@@ -1050,6 +1084,7 @@ mod tests {
             role: AxRole::TextField,
             name: None,
             bounds: None,
+            value: None,
         };
         let ctx = AxContext {
             pids: vec![],
@@ -1197,6 +1232,7 @@ mod tests {
             role: AxRole::Button,
             name: None,
             bounds,
+            value: None,
         };
         let t = target(Some(want));
 
@@ -1401,6 +1437,7 @@ mod tests {
             role: AxRole::TextField,
             name: Some("Email".into()),
             bounds: None,
+            value: None,
         };
         assert!(t.matches(AxRole::TextField, Some("Email")));
         assert!(!t.matches(AxRole::Button, Some("Email")), "role must match");
@@ -1418,6 +1455,7 @@ mod tests {
             role: AxRole::TextField,
             name: None,
             bounds: None,
+            value: None,
         };
         assert!(
             t_unnamed.matches(AxRole::TextField, None),
@@ -1442,6 +1480,7 @@ mod tests {
             role: AxRole::TextField,
             name: None,
             bounds: Some(r),
+            value: None,
         };
         // Exact and within-tolerance bounds pass.
         assert!(t.bounds_consistent(Some(r), 8));
@@ -1475,9 +1514,31 @@ mod tests {
             role: AxRole::TextField,
             name: None,
             bounds: None,
+            value: None,
         };
         assert!(t_nofp.bounds_consistent(Some(r), 8));
         assert!(t_nofp.bounds_consistent(None, 8));
+    }
+
+    #[test]
+    fn ax_target_value_consistent_rejects_an_element_holding_other_data() {
+        let with_value = |value: Option<&str>| AxTarget {
+            id: AxNodeId(3),
+            role: AxRole::TextField,
+            name: None,
+            bounds: None,
+            value: value.map(Into::into),
+        };
+        let t = with_value(Some("Alice"));
+        assert!(t.value_consistent(Some("Alice")));
+        // A recycled row: same role, name and rect, different data → rejected.
+        assert!(!t.value_consistent(Some("Zara")));
+        // An emptied field reports no value at all, which is still a change.
+        assert!(!t.value_consistent(None));
+        // Nothing captured → nothing to verify, accept, or every element that never held a
+        // value would be unwritable.
+        assert!(with_value(None).value_consistent(Some("Alice")));
+        assert!(with_value(None).value_consistent(None));
     }
 
     #[test]
@@ -1759,6 +1820,25 @@ mod tests {
         t.assign_ids();
         assert_eq!(t.find(AxNodeId(1)).unwrap().name.as_deref(), Some("Save"));
         assert!(t.find(AxNodeId(99)).is_none());
+    }
+
+    #[test]
+    fn find_mut_patches_the_node_in_place_without_touching_the_rest() {
+        let mut t = sample_tree();
+        t.assign_ids();
+        t.find_mut(AxNodeId(2)).unwrap().value = Some("sibling".into());
+        t.find_mut(AxNodeId(1)).unwrap().value = Some("patched".into());
+        assert_eq!(
+            t.find(AxNodeId(1)).unwrap().value.as_deref(),
+            Some("patched")
+        );
+        // "the rest": the sibling keeps its own value, so a patch reaching past the one id it was
+        // handed is caught rather than named away.
+        assert_eq!(
+            t.find(AxNodeId(2)).unwrap().value.as_deref(),
+            Some("sibling")
+        );
+        assert!(t.find_mut(AxNodeId(99)).is_none());
     }
 
     #[test]
@@ -2273,6 +2353,7 @@ mod tests {
             role: AxRole::Button,
             name: None,
             bounds: None,
+            value: None,
         };
         assert!(matches!(
             NoInvoke.invoke(&ctx, &target),

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -160,6 +160,25 @@ impl GlassError {
         )
     }
 
+    /// Whether a failed value-write is **proven** to have gone out before failing — the only case
+    /// where the session's captured value is stale and must be dropped. True for the read-back
+    /// verdict [`GlassError::AxValueNotApplied`], raised only after a write was dispatched; false
+    /// for everything else, including variants added later.
+    ///
+    /// Same "did anything dispatch?" question as [`Self::invoke_fallback_eligible`], but decided by
+    /// an allowlist, because the two mistakes are not symmetric. Keeping the value can only make
+    /// the guard reject more — an `AxElementChanged` whose own message tells the caller to
+    /// re-snapshot, recoverable. Dropping it can only make the guard accept more, and what it then
+    /// accepts is a write onto the wrong element, reported as `Ok`.
+    ///
+    /// Some verdicts cannot be classified at all: Android raises `Backend` and
+    /// `AccessibilityUnavailable` on *both* sides of the dispatch — its pre-write re-snapshot and
+    /// adb handshake fail the same way its post-write read-back does — so no variant-level split
+    /// separates them, and the recoverable answer has to win.
+    pub fn set_value_failed_after_writing(&self) -> bool {
+        matches!(self, GlassError::AxValueNotApplied(_))
+    }
+
     /// Runtime "this operation is unsupported on the active backend" error, worded
     /// consistently.
     ///
@@ -303,6 +322,26 @@ mod tests {
             GlassError::Backend("bus died".into()),
         ] {
             assert!(!e.invoke_fallback_eligible(), "{e}");
+        }
+    }
+
+    #[test]
+    fn only_a_proven_post_dispatch_verdict_invalidates_the_captured_value() {
+        // The read-back verdict is reached only after the write went out.
+        assert!(GlassError::AxValueNotApplied(3).set_value_failed_after_writing());
+        // Everything else keeps the captured value: the pre-dispatch rejections, the transport
+        // errors raised on either side of the dispatch, and any variant not named (the wildcard).
+        for e in [
+            GlassError::AxElementNotFound(3),
+            GlassError::AxElementChanged(3),
+            GlassError::AxElementNotEditable(3),
+            GlassError::AxElementNotClickable(3),
+            GlassError::AxUnsupported,
+            GlassError::AccessibilityUnavailable("uiautomator dump not ready".into()),
+            GlassError::Backend("adb died".into()),
+            GlassError::Timeout(10),
+        ] {
+            assert!(!e.set_value_failed_after_writing(), "{e}");
         }
     }
 

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -305,6 +305,7 @@ impl Glass {
                 role: node.role,
                 name: node.name.clone(),
                 bounds: node.bounds,
+                value: node.value.clone(),
             };
             let ctx = AxContext {
                 pids: s.platform.app_pids(),
@@ -370,6 +371,7 @@ impl Glass {
                 role: node.role,
                 name: node.name.clone(),
                 bounds: node.bounds,
+                value: node.value.clone(),
             };
             let ctx = AxContext {
                 pids: s.platform.app_pids(),
@@ -384,6 +386,9 @@ impl Glass {
         // interface only moves the popup's *preview* selection, and the model commits
         // only on row activation (Enter/click). So drive it like a person does —
         // open it, keyboard-navigate to the option, and press Enter.
+        //
+        // No cache patch on this path: every `Ok` it returns either actuated nothing or followed
+        // an `a11y_resnapshot`, which replaces `last_ax` wholesale — a fresher fact than a patch.
         if target.role == AxRole::ComboBox {
             return self.set_combo_value(id, &target, text);
         }
@@ -419,6 +424,8 @@ impl Glass {
             if st.checked == want {
                 return Ok(()); // truthful no-op, no actuation
             }
+            // No cache patch here either, for the combo path's reason: the verify poll below
+            // re-snapshots, so `last_ax` holds the tree that observed the toggle.
             self.click_element_inner(id)?; // the toggle actuation (a swipe for a row-shaped control)
             // Not event-gated, and cannot be: this branch runs only on a backend that frames a
             // switch as its whole row, which today is iOS alone — a reader with no event stream to
@@ -440,10 +447,30 @@ impl Glass {
             };
         }
         let s = self.active_mut()?;
-        s.accessibility
+        let result = s
+            .accessibility
             .as_mut()
             .ok_or(GlassError::AxUnsupported)?
-            .set_value(&ctx, &target, text)?;
+            .set_value(&ctx, &target, text);
+        if let Err(e) = result {
+            // A failure after dispatch doesn't mean the field is unchanged — Android types before
+            // it verifies, so a partial type or the AVD's documented placeholder-on-clear can
+            // still have altered it. Invalidate (not gate) so a retry with no intervening snapshot
+            // isn't rejected as drift; every other failure keeps its value, for the asymmetry
+            // `set_value_failed_after_writing` documents.
+            if e.set_value_failed_after_writing()
+                && let Some(node) = s.last_ax.as_mut().and_then(|t| t.find_mut(id))
+            {
+                node.value = None;
+            }
+            return Err(e);
+        }
+        // `Ok`'s guarantee varies by backend — see `AxTarget::value`'s doc — but patching to the
+        // requested text still beats leaving the pre-write value, which is definitely stale, not
+        // just possibly imprecise. Patch by id; a re-snapshot would cost a whole walk for one field.
+        if let Some(node) = s.last_ax.as_mut().and_then(|t| t.find_mut(id)) {
+            node.value = (!text.is_empty()).then(|| text.to_string());
+        }
         s.pump();
         Ok(())
     }
@@ -2693,9 +2720,261 @@ mod tests {
                     width: 20,
                     height: 20
                 }),
+                value: None,
             }
         );
         assert_eq!(calls[0].1, "hello");
+    }
+
+    /// A one-node tree whose root is an editable field holding `value` — the shape the cache
+    /// tests need, since `set_value` targets the node the snapshot cached.
+    fn editable_field_tree(value: Option<&str>) -> AxTree {
+        AxTree::new(AxNode {
+            id: AxNodeId(0),
+            role: AxRole::TextField,
+            raw_role: "text field".into(),
+            name: Some("Name".into()),
+            description: None,
+            value: value.map(Into::into),
+            states: AxStates {
+                editable: true,
+                ..Default::default()
+            },
+            bounds: Some(rect(0, 0, 50, 20)),
+            children: vec![],
+        })
+    }
+
+    /// A started, snapshotted session over `accessibility` — ready for the `set_value` call the
+    /// test is actually about.
+    fn glass_ready_for_set_value(accessibility: Box<dyn Accessibility + Send>) -> Glass {
+        let mut g = glass_with_backend(FakePlatform::new(100, 100), accessibility);
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot(None).unwrap();
+        g
+    }
+
+    /// [`FakeAccessibility`] over `tree`, logging its writes to `set_log`.
+    fn logging_a11y(
+        tree: AxTree,
+        set_log: Arc<Mutex<Vec<(AxTarget, String)>>>,
+    ) -> FakeAccessibility {
+        FakeAccessibility {
+            tree,
+            set_log,
+            set_fail: false,
+            ctx_log: Arc::new(Mutex::new(None)),
+            invoke_behavior: InvokeBehavior::Unsupported,
+            invoke_log: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    #[test]
+    fn set_value_patches_last_ax_so_a_retry_carries_the_written_value() {
+        // Same mock harness as `set_value_passes_target_and_text_to_backend`: asserting on
+        // `set_log` proves the cache patch directly. The real drift guard lives in
+        // `editable_target` (glass-android), not here, so this doesn't reimplement it.
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let mut g = glass_ready_for_set_value(Box::new(logging_a11y(
+            editable_field_tree(Some("orig")),
+            log.clone(),
+        )));
+
+        g.set_value(AxNodeId(0), "a").unwrap();
+        g.set_value(AxNodeId(0), "b").unwrap(); // no intervening snapshot
+
+        let calls = log.lock().unwrap();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(
+            calls[1].0.value,
+            Some("a".into()),
+            "the second call's target must carry what the first call wrote, not the pre-write \
+             snapshot value"
+        );
+    }
+
+    #[test]
+    fn set_value_patches_a_cleared_field_to_no_value_at_all() {
+        // Android reports an emptied field as no value rather than `Some("")`, so caching the
+        // empty string after a successful clear would make `set_value(id, "")` then
+        // `set_value(id, "text")` — ordinary agent sequencing — look like drift on the second.
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let mut g = glass_ready_for_set_value(Box::new(logging_a11y(
+            editable_field_tree(Some("orig")),
+            log.clone(),
+        )));
+
+        g.set_value(AxNodeId(0), "").unwrap();
+        g.set_value(AxNodeId(0), "text").unwrap(); // no intervening snapshot
+
+        assert_eq!(
+            log.lock().unwrap()[1].0.value,
+            None,
+            "a cleared field caches as no value, the shape the reader would report"
+        );
+    }
+
+    /// An `Accessibility` whose `set_value` fails the first call and succeeds every one after,
+    /// logging successful calls like `FakeAccessibility`. `FakeAccessibility::set_fail` is a
+    /// fixed knob, not a script, and this needs to vary across one session's two calls — kept
+    /// local since only one test needs it.
+    struct FlakyOnceAccessibility {
+        tree: AxTree,
+        failed_once: bool,
+        set_log: Arc<Mutex<Vec<(AxTarget, String)>>>,
+    }
+
+    impl Accessibility for FlakyOnceAccessibility {
+        fn snapshot(&mut self, _ctx: &AxContext) -> Result<AxTree> {
+            Ok(self.tree.clone())
+        }
+        fn set_value(&mut self, _ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
+            if !self.failed_once {
+                self.failed_once = true;
+                return Err(GlassError::AxValueNotApplied(target.id.0));
+            }
+            self.set_log
+                .lock()
+                .unwrap()
+                .push((target.clone(), text.to_string()));
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn set_value_invalidates_the_cached_value_after_a_write_that_may_have_landed() {
+        // `AxValueNotApplied` is raised after the keystrokes went out — the AVD false-failure
+        // `typed_clear_landed` documents (an emptied field reporting its placeholder) is one — so
+        // the cached value is no longer a fact and must not gate the retry.
+        let set_log = Arc::new(Mutex::new(Vec::new()));
+        let mut g = glass_ready_for_set_value(Box::new(FlakyOnceAccessibility {
+            tree: editable_field_tree(Some("orig")),
+            failed_once: false,
+            set_log: set_log.clone(),
+        }));
+
+        assert!(
+            g.set_value(AxNodeId(0), "a").is_err(),
+            "first write is scripted to fail"
+        );
+        g.set_value(AxNodeId(0), "a").unwrap(); // retry, no intervening snapshot
+
+        assert_eq!(
+            set_log.lock().unwrap()[0].0.value,
+            None,
+            "the retry's target must not carry the stale pre-failure value"
+        );
+    }
+
+    /// An `Accessibility` that guards its write on the target's value the way Android's
+    /// `editable_target` does — over the same [`AxTarget::value_consistent`], so this scripts the
+    /// guard rather than reimplementing it. `held` is what the live element reads.
+    struct GuardedAccessibility {
+        tree: AxTree,
+        held: Option<String>,
+        set_log: Arc<Mutex<Vec<(AxTarget, String)>>>,
+    }
+
+    impl Accessibility for GuardedAccessibility {
+        fn snapshot(&mut self, _ctx: &AxContext) -> Result<AxTree> {
+            Ok(self.tree.clone())
+        }
+        fn set_value(&mut self, _ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
+            if !target.value_consistent(self.held.as_deref()) {
+                return Err(GlassError::AxElementChanged(target.id.0));
+            }
+            self.held = Some(text.to_string());
+            self.set_log
+                .lock()
+                .unwrap()
+                .push((target.clone(), text.to_string()));
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn a_write_rejected_before_dispatch_keeps_the_fingerprint_that_rejected_it() {
+        // The recycled-row case: the snapshot read "Alice", the row now holds "Zara", and the
+        // guard rejects. An agent retries without re-snapshotting — blanking the cached value on
+        // that rejection would send the retry in with no value to compare, skipping the guard and
+        // writing to the wrong row.
+        let set_log = Arc::new(Mutex::new(Vec::new()));
+        let mut g = glass_ready_for_set_value(Box::new(GuardedAccessibility {
+            tree: editable_field_tree(Some("Alice")),
+            held: Some("Zara".into()),
+            set_log: set_log.clone(),
+        }));
+
+        for attempt in ["first", "retry"] {
+            assert!(
+                matches!(
+                    g.set_value(AxNodeId(0), "x"),
+                    Err(GlassError::AxElementChanged(0))
+                ),
+                "the {attempt} must be rejected as drift"
+            );
+        }
+        assert!(
+            set_log.lock().unwrap().is_empty(),
+            "no write may land on the drifted row"
+        );
+    }
+
+    /// [`GuardedAccessibility`] whose first call fails before dispatching anything — the shape of
+    /// Android's `set_value`, which re-snapshots and reaches for adb before it taps.
+    struct PreDispatchFailureThenGuarded {
+        first_failure: Option<GlassError>,
+        guarded: GuardedAccessibility,
+    }
+
+    impl Accessibility for PreDispatchFailureThenGuarded {
+        fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
+            self.guarded.snapshot(ctx)
+        }
+        fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
+            match self.first_failure.take() {
+                Some(e) => Err(e),
+                None => self.guarded.set_value(ctx, target, text),
+            }
+        }
+    }
+
+    #[test]
+    fn a_pre_dispatch_transport_failure_keeps_the_value_that_guards_the_retry() {
+        // A not-ready `uiautomator dump` or an adb hiccup fails the guard's own re-snapshot, before
+        // anything is typed — as `Backend` or `AccessibilityUnavailable`, the same variants that
+        // post-dispatch failures use, so neither can be classified by variant. The captured value
+        // is still a fact here; blanking it would let the retry write to the recycled row.
+        for failure in [
+            GlassError::Backend("uiautomator dump not ready".into()),
+            GlassError::AccessibilityUnavailable("adb: device offline".into()),
+        ] {
+            let set_log = Arc::new(Mutex::new(Vec::new()));
+            let mut g = glass_ready_for_set_value(Box::new(PreDispatchFailureThenGuarded {
+                first_failure: Some(failure),
+                guarded: GuardedAccessibility {
+                    tree: editable_field_tree(Some("Alice")),
+                    held: Some("Zara".into()), // the row recycled under the snapshot
+                    set_log: set_log.clone(),
+                },
+            }));
+
+            assert!(
+                g.set_value(AxNodeId(0), "x").is_err(),
+                "first write is scripted to fail before dispatch"
+            );
+            assert!(
+                matches!(
+                    g.set_value(AxNodeId(0), "x"),
+                    Err(GlassError::AxElementChanged(0))
+                ),
+                "the retry must still be guarded by the captured value"
+            );
+            assert!(
+                set_log.lock().unwrap().is_empty(),
+                "no write may land on the drifted row"
+            );
+        }
     }
 
     #[test]

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -460,8 +460,9 @@ pub(crate) fn glass_with(platform: FakePlatform) -> Glass {
 }
 
 /// Shared `Glass`-construction boilerplate for the a11y builders: a one-shot
-/// factory yielding a `Backend` over `platform` + `accessibility`.
-fn glass_with_backend(
+/// factory yielding a `Backend` over `platform` + `accessibility`. Public to the crate's tests
+/// so one that scripts its own `Accessibility` doesn't have to restate the factory.
+pub(crate) fn glass_with_backend(
     platform: FakePlatform,
     accessibility: Box<dyn Accessibility + Send>,
 ) -> Glass {

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -259,6 +259,7 @@ mod tests {
             role: AxRole::TextField,
             name: Some("Note".into()),
             bounds: Some(FIELD),
+            value: None,
         }
     }
 
@@ -374,6 +375,7 @@ mod tests {
             role: AxRole::TextField,
             name: Some("inputField".into()),
             bounds: Some(r),
+            value: None,
         };
         assert_eq!(verify(&tree, &target).unwrap(), r);
     }
@@ -392,6 +394,7 @@ mod tests {
             role: AxRole::TextField,
             name: Some("inputField".into()),
             bounds: Some(r),
+            value: None,
         };
         assert!(verify(&tree, &target).is_err());
     }
@@ -411,6 +414,7 @@ mod tests {
             role: AxRole::TextField,
             name: Some("inputField".into()),
             bounds: Some(r),
+            value: None,
         };
         // Pin the variant: an unresolved id must report AxElementNotFound (naming the id),
         // not the generic AxUnsupported — both are `Err`, so `.is_err()` alone wouldn't guard it.
@@ -441,6 +445,7 @@ mod tests {
                 width: 100,
                 height: 30,
             }),
+            value: None,
         };
         assert!(verify(&tree, &target).is_err());
     }

--- a/crates/glass-ios/tests/drive_integration.rs
+++ b/crates/glass-ios/tests/drive_integration.rs
@@ -202,6 +202,7 @@ fn drive_fixture_snapshot_tap_and_type_end_to_end() {
         role: field.role,
         name: field.name.clone(),
         bounds: field.bounds,
+        value: field.value.clone(),
     };
     a11y.set_value(&ctx, &target, "world")
         .expect("set_value: clear then type");

--- a/crates/glass-macos/tests/a11y.rs
+++ b/crates/glass-macos/tests/a11y.rs
@@ -296,6 +296,7 @@ mod macos_main {
             role: note.role,
             name: note.name.clone(),
             bounds: note.bounds,
+            value: note.value.clone(),
         };
         try_expect(
             a11y.set_value(&ctx, &note_tgt, "world"),
@@ -326,6 +327,7 @@ mod macos_main {
             role: save.role,
             name: save.name.clone(),
             bounds: save.bounds,
+            value: save.value.clone(),
         };
         match a11y.set_value(&ctx, &save_tgt, "x") {
             Err(GlassError::AxElementNotEditable(_)) => {}
@@ -362,6 +364,7 @@ mod macos_main {
             role: status.role,
             name: status.name.clone(),
             bounds: status.bounds,
+            value: status.value.clone(),
         };
         match a11y.invoke(&ctx, &status_tgt) {
             Err(GlassError::AxActionUnavailable(_)) => {}

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -773,6 +773,7 @@ fn onbox_a11y_set_value() {
         role: field.role,
         name: field.name.clone(),
         bounds: field.bounds,
+        value: field.value.clone(),
     };
 
     const NEW: &str = "GLASSVALUE";
@@ -798,6 +799,7 @@ fn onbox_a11y_set_value() {
         role: b.role,
         name: b.name.clone(),
         bounds: b.bounds,
+        value: b.value.clone(),
     };
     assert!(
         matches!(
@@ -843,6 +845,7 @@ fn onbox_egui_set_value_honesty() {
         role: field.role,
         name: field.name.clone(),
         bounds: field.bounds,
+        value: field.value.clone(),
     };
     assert!(
         matches!(

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -468,24 +468,44 @@ developer-assigned id. It appears only where glass's reader sources that label: 
 reader reads AT-SPI `Description`, the UI Automation (Windows) reader reads `HelpText`, the AX
 (macOS) reader reads `AXHelp`, else `AXDescription` where `AXTitle` already supplied the name, the
 Android readers read whichever of the element's text and content-description did not become the
-name or the value, and the `idb` (iOS) reader reads the element's hint, falling back to the label
-an editable element's identifier displaced. It is omitted when the description duplicates the name.
+name or the value, the on-device companion additionally supplies an editable element's hint where
+that leaves it undescribed, and the `idb` (iOS) reader reads the element's hint, falling back to
+the label an editable element's identifier displaced. It is omitted when the description duplicates
+the name.
 **`desc` is display-only: `glass_wait_for_element` and `glass_scroll_to_element` select on `name`,
 never on the description.**
 
-On **Android** a description needs one node to carry both of its labels, and most controls carry
-only one — across four stock apps, only one node in roughly three hundred had both — so expect
-`desc` to be absent on most Android nodes, not routinely present. The other readers take it from a
-separate descriptor field, so there a node with a single label can still carry one.
+On **Android** a description drawn from the element's own two labels needs one node to carry both,
+and most controls carry only one — across four stock apps, only one node in roughly three hundred
+had both — so on a non-editable element expect `desc` to be absent, not routinely present. An
+editable element read through the on-device companion is the exception: its hint is a source of its
+own (below), needing no second label. The other readers take the description from a separate
+descriptor field, so there a node with a single label can still carry one.
 
 Both Android readers name a control the same way: the visible text is the `name`, or the
 content-description where there is no text — except on an editable element, where the text is
-already the `value` and the content-description is the `name` instead.
+already the `value` and the content-description is the `name` instead. A filled field's name does
+not change as its text changes, on either reader.
 
 One consequence of that rule: two controls that differ only in their content-description — "Save
 draft" and "Save and close", both reading `Save` on screen — now share a `name`, and a `name:`
 selector picks the first of them in tree order without reporting that a second matched. Where two
 controls read alike, address the one you want by its `id` from a snapshot.
+
+An editable element with no content description falls back to the leaf of its view resource id
+rather than staying unnamed — `open_search_view_edit_text`, not the package-qualified
+`com.android.settings:id/open_search_view_edit_text`. Settings' search box, for example, reads that
+name identically from both readers. Treat the id as a label of last resort: a resource id is not
+unique within a tree — ten rows built from one layout can all carry the same one — so it tells
+this element apart from unrelated ones, not from its own kind.
+
+The on-device companion adds a second source of `desc` for an editable element: its hint
+(Android's placeholder text) becomes the description. That source is companion-only — a
+`uiautomator` dump carries no hint attribute at all, so `uiautomator` never supplies one — so a
+text field's `desc` is richer through the companion than through `uiautomator`. A field with a
+hint but no content description and no resource id has nothing left to name it, so it stays
+unnamed but described, rendering as `#35 TextField desc="Search settings"`, which
+`glass_a11y_marks` labels from that description (see below).
 
 An element whose platform role glass has no mapping for renders as `Other(<native token>)` — e.g.
 `#4 Other(AXDisclosureTriangle) "Details" [enabled]` — so the platform's own token is still

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -228,7 +228,10 @@ no accessibility tree.
   `checked`, `unchecked`, `selected`, `unselected`, `expanded`, `collapsed`, `focused`, `visible`,
   `hidden`.
 - `value_contains` (string) — additionally require the matched element's value to contain this
-  substring; not a standalone selector (`name` and/or `role` still required).
+  substring; not a standalone selector (`name` and/or `role` still required). Only an element that
+  reports a value can match one: on Android's on-device accessibility-service reader that is the
+  editable elements alone, so filter a label, button or check box there on `name` instead — a
+  `value_contains` against one waits out the whole timeout and returns `{matched:false}`.
 - `interval_ms` (integer, default 200) — poll interval (one a11y snapshot per tick).
 - `timeout_ms` (integer, default 10000) — returns `{matched:false}` on timeout.
 
@@ -478,6 +481,11 @@ Both Android readers name a control the same way: the visible text is the `name`
 content-description where there is no text — except on an editable element, where the text is
 already the `value` and the content-description is the `name` instead.
 
+One consequence of that rule: two controls that differ only in their content-description — "Save
+draft" and "Save and close", both reading `Save` on screen — now share a `name`, and a `name:`
+selector picks the first of them in tree order without reporting that a second matched. Where two
+controls read alike, address the one you want by its `id` from a snapshot.
+
 An element whose platform role glass has no mapping for renders as `Other(<native token>)` — e.g.
 `#4 Other(AXDisclosureTriangle) "Details" [enabled]` — so the platform's own token is still
 visible; a bare `Other` means the platform named no token at all.
@@ -543,7 +551,9 @@ Errors if the app exposes no accessibility tree.
   is required.
 - `role` (string) — role filter, e.g. `"ListItem"`, `"Button"` (selector).
 - `value_contains` (string) — additionally require the matched element's value to contain this
-  substring; not a standalone selector.
+  substring; not a standalone selector. Only an element that reports a value can match one: on
+  Android's on-device accessibility-service reader that is the editable elements alone, so filter
+  a label, button or check box there on `name` instead.
 - `direction` (string) — `"up"`/`"down"` (vertical) or `"left"`/`"right"` (horizontal). **Omit
   to infer** the direction from the target's off-screen position (e.g. an item at `x ≥ width`
   scrolls right); inference falls back to a vertical `down`→`up` sweep when the target isn't in

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -229,9 +229,10 @@ no accessibility tree.
   `hidden`.
 - `value_contains` (string) — additionally require the matched element's value to contain this
   substring; not a standalone selector (`name` and/or `role` still required). Only an element that
-  reports a value can match one: on Android's on-device accessibility-service reader that is the
-  editable elements alone, so filter a label, button or check box there on `name` instead — a
-  `value_contains` against one waits out the whole timeout and returns `{matched:false}`.
+  reports a value can match one: on Android that is the editable elements alone (a change for the
+  on-device accessibility-service reader), so filter a label, button or check box there on `name`
+  instead — a `value_contains` against one waits out the whole timeout and returns
+  `{matched:false}`.
 - `interval_ms` (integer, default 200) — poll interval (one a11y snapshot per tick).
 - `timeout_ms` (integer, default 10000) — returns `{matched:false}` on timeout.
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -474,9 +474,9 @@ only one — across four stock apps, only one node in roughly three hundred had 
 `desc` to be absent on most Android nodes, not routinely present. The other readers take it from a
 separate descriptor field, so there a node with a single label can still carry one.
 
-Both Android readers name a control the same way: the visible text is the `name`, except on an
-editable element, where the text is already the `value` and the content-description is the `name`
-instead.
+Both Android readers name a control the same way: the visible text is the `name`, or the
+content-description where there is no text — except on an editable element, where the text is
+already the `value` and the content-description is the `name` instead.
 
 An element whose platform role glass has no mapping for renders as `Other(<native token>)` — e.g.
 `#4 Other(AXDisclosureTriangle) "Details" [enabled]` — so the platform's own token is still

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -474,12 +474,9 @@ only one — across four stock apps, only one node in roughly three hundred had 
 `desc` to be absent on most Android nodes, not routinely present. The other readers take it from a
 separate descriptor field, so there a node with a single label can still carry one.
 
-The two Android readers also disagree on which label becomes the `name`: `uiautomator` prefers the
-content-description, the on-device accessibility-service reader prefers the text, so the same
-control can report `name` and `desc` swapped depending on which reader is running. Because
-selection is on `name` only, a `name:` selector learned under one Android reader can silently miss
-under the other — re-read the snapshot after switching readers rather than carrying a selector
-across them.
+Both Android readers name a control the same way: the visible text is the `name`, except on an
+editable element, where the text is already the `value` and the content-description is the `name`
+instead.
 
 An element whose platform role glass has no mapping for renders as `Other(<native token>)` — e.g.
 `#4 Other(AXDisclosureTriangle) "Details" [enabled]` — so the platform's own token is still

--- a/examples/android-role-fixture/README.md
+++ b/examples/android-role-fixture/README.md
@@ -20,8 +20,10 @@ guarantee. Re-run it rather than trusting it; the read step below prints the API
 | `PopupMenu` (button) | `android.widget.ListView`, entries `LinearLayout`/`RelativeLayout` |
 | `AlertDialog` (button) | `FrameLayout`/`LinearLayout` panels under `android:id/parentPanel` |
 | `Button` with `text` + a different `contentDescription` | `android.widget.Button`; both readers name it by its `text` and carry the `contentDescription` as `desc="…"` |
+| `EditText` with a hint, no `contentDescription`, no resource id | `android.widget.EditText`; unnamed, and through the on-device companion the hint is the description — read as `#35 TextField desc="Search settings"`, which `glass_a11y_marks` labels from that description. `uiautomator` sees no hint, so there it is unnamed and undescribed |
 
-The last two need a tap. Each opens as the topmost window, so dump it separately.
+`PopupMenu` and `AlertDialog` each need a tap. Each opens as the topmost window, so dump it
+separately.
 
 A subclass inherits the accessibility class name of the framework class it extends unless it
 overrides `getAccessibilityClassName()` — which is why the toolbar arrives as `ViewGroup`, and why

--- a/examples/android-role-fixture/README.md
+++ b/examples/android-role-fixture/README.md
@@ -19,7 +19,7 @@ guarantee. Re-run it rather than trusting it; the read step below prints the API
 | `ProgressBar` | itself |
 | `PopupMenu` (button) | `android.widget.ListView`, entries `LinearLayout`/`RelativeLayout` |
 | `AlertDialog` (button) | `FrameLayout`/`LinearLayout` panels under `android:id/parentPanel` |
-| `Button` with `text` + a different `contentDescription` | `android.widget.Button`; the label each reader doesn't pick for `name` is what `desc="…"` carries |
+| `Button` with `text` + a different `contentDescription` | `android.widget.Button`; both readers name it by its `text` and carry the `contentDescription` as `desc="…"` |
 
 The last two need a tap. Each opens as the topmost window, so dump it separately.
 

--- a/examples/android-role-fixture/src/tech/fixedwidth/glassrolefixture/MainActivity.java
+++ b/examples/android-role-fixture/src/tech/fixedwidth/glassrolefixture/MainActivity.java
@@ -91,10 +91,8 @@ public class MainActivity extends Activity {
         root.addView(menuButton(), matchWrap());
         root.addView(dialogButton(), matchWrap());
 
-        // Both Android readers take a name from one of these two labels and now surface the
-        // other as `description` — uiautomator prefers content-desc, the accessibility service
-        // prefers text — so one control whose two labels differ is the positive control for it
-        // on both.
+        // Both readers name this by its visible text and surface the content-description as
+        // `description` — the positive control proving the two readers agree on precedence.
         Button described = new Button(this);
         described.setText("Save");
         described.setContentDescription("Save changes");

--- a/examples/android-role-fixture/src/tech/fixedwidth/glassrolefixture/MainActivity.java
+++ b/examples/android-role-fixture/src/tech/fixedwidth/glassrolefixture/MainActivity.java
@@ -8,6 +8,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
+import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.GridView;
 import android.widget.LinearLayout;
@@ -97,6 +98,13 @@ public class MainActivity extends Activity {
         described.setText("Save");
         described.setContentDescription("Save changes");
         root.addView(described, matchWrap());
+
+        // A hint and nothing else: no content description, and no resource name (this fixture has
+        // no resources file), so it stays unnamed. Through the on-device service its hint arrives
+        // as the description, which makes it the one control that renders desc= with no name.
+        EditText hinted = new EditText(this);
+        hinted.setHint("Search settings");
+        root.addView(hinted, matchWrap());
 
         ScrollView scroller = new ScrollView(this);
         scroller.addView(root);


### PR DESCRIPTION
Closes #260.

glass's two Android accessibility readers chose a node's `name` in opposite order, so the same control answered differently depending on which one was running — and since `name` is half the `AxTarget` fingerprint that `set_value` re-walks against, and what every `name:` selector matches, a script that worked through one reader could silently miss through the other.

Both now route through one helper. The visible text is the name; an editable element is the exception, because there the text is the user's content rather than a label.

| Node | `name` | `value` | `description` |
|---|---|---|---|
| editable | content description | the text | — |
| non-editable | the visible text, else the content description | — | the content description the text displaced |

## Verified on device

The role fixture's `Button` carries `text="Save"` and `contentDescription="Save changes"`. It used to report the two strings **swapped** between the readers — that swap is the bug. Through a freshly built `glass-mcp` against the AVD (API 34), both readers now:

```
uiautomator:      #46 Button "Save" desc="Save changes" (0,2324 1080x13) [focusable,enabled,visible]
android-service:  #34 Button "Save" desc="Save changes" (0,2377 1080x13) [focusable,enabled,visible]
```

The differing ids and y-offsets are the useful part: they show two genuinely distinct reader paths, not one run captured twice.

Also checked on device: a text field with content is no longer named by what was typed into it.

## Three behaviours changed

- **`uiautomator`** names a non-editable node by its visible text rather than its content description.
- **The accessibility-service reader** gains the editable gate. A filled text field used to be named by its own contents, so its name moved as the value did.
- **The accessibility-service reader** stops copying a non-editable node's text into `value` as well as `name`.

## What it costs, stated plainly

**A hint-only text field is now unnamed.** Android returns a hint through the same `text` attribute when an `EditText` is empty, so the service reader's old `text.or(desc)` named such a field by its hint — by accident, through the text path. On device it now renders as a bare `#16 TextField (126,149 954x126) [...]`.

That naming was never dependable: it held only while the field was empty and became the typed content the moment anything was entered. Carrying Android's `hintText` as its own field is the real fix and is filed separately.

**`value_contains` can no longer match a non-editable element** on the accessibility-service reader, since those no longer report a value. Documented beside the filter in `tools.md` rather than left to be discovered by a timeout.

**A `name:` selector can now be ambiguous.** Two controls that differed only by content description can share a visible label. Lookup returns the first match with no ambiguity signal — inherent to the rule, and noted in the docs.

**`set_value`'s fingerprint is weaker on unnamed fields.** With `name = None`, role plus an 8px bounds match carries it. That removes a false *rejection* — the old service-reader name moved whenever the field's contents did — at the cost of weaker discrimination against in-place replacement, such as a recycled list row. It is bounded, because a node with unreadable bounds errors the snapshot outright, so there is always a rect to compare. Recorded in the helper's doc; a durable fix is filed separately.

## Review

Five review lenses ran before this PR. They found no critical defects and ten other things, all fixed here:

- A **blank string could occupy the matchable name slot** — `text=" "` beat a real content description, rendering `#7 Button " " desc="Save changes"` with every `name:` selector missing and the marks legend declining to fall back, because the name was `Some`. The name path and `normalize_description` disagreed about the same string; the helper now rejects blank candidates the same way.
- The **post-write poll could misreport a landed write** as a failure with advice to clear a field that was already correct.
- The **service reader's `set_value` guard was a hand-copy** of a tested one; the validation is now shared, and a review confirmed the extraction is condition-for-condition and error-variant-for-error-variant identical.
- **Four mutations survived the whole suite** and now do not — including the `.or(text)` fallback someone would reach for after reading the hint-loss note above, which would silently reinstate the defect this PR removes.

Every test added or changed here was shown to fail against a deliberate mutation of the implementation before being accepted.

## Known gaps, not addressed here

`ServiceA11y::set_value` still has no local test — deleting its guard outright leaves the suite green. It is a hand-verified path with an `#[ignore]`d device test, and closing it needs a loopback fake for the device socket. A node that vanishes from the tree also still burns the full post-write poll rather than saying so.
