### PR TITLE
a11y(android): a name for every field, and a guard that can tell elements apart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@ internal refactors, CI, or test-only changes.
   *different* data — a recycled list row reusing the same view is the case this closes — is now
   rejected as changed since the snapshot rather than written to. An editable element with no
   content description and no resource id has no name at all, so role plus an 8px bounds match used
-  to be the whole fingerprint a write re-walked against.
+  to be the whole fingerprint a write re-walked against. The value only discriminates where there
+  was one to capture: rows of *empty* fields share a role, a name, a rect and no value alike, so a
+  write can still land on the wrong one of those — re-snapshot before writing into a list that has
+  scrolled.
 
 ### Changed
 - Both Android readers now name an element the same way. The same control used to answer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,16 +54,15 @@ internal refactors, CI, or test-only changes.
   Both the id fallback and the hint on the accessibility-service reader need the updated on-device
   companion.
 
-  One loss remains, on the accessibility-service reader: an element that is not editable — a
-  label, a button, a check box — no longer reports a `value`; that reader used to copy the
-  element's own text there as well as into `name`. Since a `value_contains` filter matches only an
-  element that has a value, `value_contains` against a non-editable element under this reader now
-  never matches, so a `glass_wait_for_element` written
-  that way waits out its whole timeout and answers `{matched:false}`. Match those elements on
-  `name` instead. It also retires an escape hatch worth naming: a Jetpack Compose button surfaces
-  as a clickable `Group`, and `role:"Button"` plus `value_contains:"Submit"` used to reach it —
-  use `role:"Button"` with `name:"Submit"`, which reaches it the same way. `uiautomator` never
-  matched this way, so a selector written against that reader is unaffected.
+  One selector detail changes with it, though nothing becomes unreachable. On the
+  accessibility-service reader an element that is not editable — a label, a button, a check box —
+  no longer reports a `value`; that reader used to copy the element's own text there as well as
+  into `name`. A `value_contains` filter aimed at such an element therefore stops matching, and
+  `glass_wait_for_element` waits out its timeout. Match on `name` instead: it is a substring
+  filter too, and that text was always in `name` as well, so every selector has an equivalent —
+  including `role:"Button"` with `name:"Submit"`, which reaches a Jetpack Compose button surfacing
+  as a clickable `Group` exactly as the `value_contains` form did. `uiautomator` never reported a
+  value there, so a selector written against that reader is unaffected.
 
 ### Added
 - Every tool parameter now carries a description in the advertised MCP schema, so an agent can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+### Fixed
+- `glass_set_value`, and the native-invoke path `glass_click_element` prefers before falling back
+  to a synthesized pointer click, now also fingerprint the target's value, not just its role, name
+  and bounds. A re-walk that lands on a same-role, same-name, same-rect element holding *different*
+  data — a recycled list row reusing the same view is the case this closes — is now rejected as
+  changed since the snapshot instead of being written to or actuated. The gap was widest on
+  Android: an editable element with no content description and no resource id has no name at all,
+  so role plus an 8px bounds match used to be the whole fingerprint a write re-walked against.
+
 ### Changed
 - Both Android readers now name an element the same way. The same control used to answer
   differently depending on which reader was running — `uiautomator` and the on-device
@@ -29,18 +38,31 @@ internal refactors, CI, or test-only changes.
   to name a filled text field by its own contents, so its name changed with the field's contents
   from one snapshot read to the next.
 
-  Two losses to know about, both on the accessibility-service reader. An *empty* text field that
-  has a hint but no content description used to be named by that hint — Android reports a hint
-  through the same `text` attribute a filled field uses, so an empty field's hint arrived
-  indistinguishable from typed content — and it is now unnamed. That naming was never
-  dependable: it held only while the field was empty and became the typed content the moment
-  anything was entered, so it was not a stable selector either way. Carrying Android's hint as
-  its own field is a separate change, not part of this one.
+  An editable element with no content description — including an empty field named only by its
+  hint — now falls back to the leaf of its view resource id rather than staying unnamed: plain
+  text, not the package-qualified form Android reports, and shared by every other view built from
+  the same layout, so treat it as a label of last resort, not a selector to rely on.
+  Verified on device: Settings' search box reads `open_search_view_edit_text` identically from
+  both readers. The on-device companion separately carries the field's hint into its
+  `description`, so an agent sees `desc="Search settings"` there even when nothing names the field
+  at all — verified on the role fixture's added `EditText`, which has a hint and neither a content
+  description nor a resource id: it renders as `TextField desc="Search settings"` through the
+  companion. `uiautomator` cannot supply that description at all — its dump carries no hint
+  attribute — so a text field's `desc` is richer through the companion than through `uiautomator`.
 
-  And an element that is not editable — a label, a button, a check box — no longer reports a
-  `value`; that reader used to copy the element's own text there as well as into `name`. Since a
-  `value_contains` filter matches only an element that has a value, `value_contains` against a
-  non-editable element under this reader now never matches, so a `glass_wait_for_element` written
+  The id fallback opens a gap of its own for anyone still running the companion released before
+  this change. `uiautomator` reads a resource id from its own dump and names such a field
+  immediately; the accessibility-service reader depends on the companion for one, and the old
+  companion never sent it, so it still leaves the field unnamed. The trigger — editable, carries a
+  resource id, no content description — is most stock text fields, not an edge case, and it
+  resolves once the companion is updated. Nothing that matched before stops matching: this only
+  adds a name where the service reader previously had none.
+
+  One loss remains, on the accessibility-service reader: an element that is not editable — a
+  label, a button, a check box — no longer reports a `value`; that reader used to copy the
+  element's own text there as well as into `name`. Since a `value_contains` filter matches only an
+  element that has a value, `value_contains` against a non-editable element under this reader now
+  never matches, so a `glass_wait_for_element` written
   that way waits out its whole timeout and answers `{matched:false}`. Match those elements on
   `name` instead. It also retires an escape hatch worth naming: a Jetpack Compose button surfaces
   as a clickable `Group`, and `role:"Button"` plus `value_contains:"Submit"` used to reach it —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,12 @@ internal refactors, CI, or test-only changes.
 ## [Unreleased]
 
 ### Fixed
-- `glass_set_value`, and the native-invoke path `glass_click_element` prefers before falling back
-  to a synthesized pointer click, now also fingerprint the target's value, not just its role, name
-  and bounds. A re-walk that lands on a same-role, same-name, same-rect element holding *different*
-  data — a recycled list row reusing the same view is the case this closes — is now rejected as
-  changed since the snapshot instead of being written to or actuated. The gap was widest on
-  Android: an editable element with no content description and no resource id has no name at all,
-  so role plus an 8px bounds match used to be the whole fingerprint a write re-walked against.
+- Android's `set_value` now refuses a write whose target has drifted in value, not just in role,
+  name or bounds. A re-walk that lands on a same-role, same-name, same-rect element holding
+  *different* data — a recycled list row reusing the same view is the case this closes — is now
+  rejected as changed since the snapshot rather than written to. An editable element with no
+  content description and no resource id has no name at all, so role plus an 8px bounds match used
+  to be the whole fingerprint a write re-walked against.
 
 ### Changed
 - Both Android readers now name an element the same way. The same control used to answer
@@ -49,14 +48,8 @@ internal refactors, CI, or test-only changes.
   description nor a resource id: it renders as `TextField desc="Search settings"` through the
   companion. `uiautomator` cannot supply that description at all — its dump carries no hint
   attribute — so a text field's `desc` is richer through the companion than through `uiautomator`.
-
-  The id fallback opens a gap of its own for anyone still running the companion released before
-  this change. `uiautomator` reads a resource id from its own dump and names such a field
-  immediately; the accessibility-service reader depends on the companion for one, and the old
-  companion never sent it, so it still leaves the field unnamed. The trigger — editable, carries a
-  resource id, no content description — is most stock text fields, not an edge case, and it
-  resolves once the companion is updated. Nothing that matched before stops matching: this only
-  adds a name where the service reader previously had none.
+  Both the id fallback and the hint on the accessibility-service reader need the updated on-device
+  companion.
 
   One loss remains, on the accessibility-service reader: an element that is not editable — a
   label, a button, a check box — no longer reports a `value`; that reader used to copy the

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -225,18 +225,25 @@ impl Default for AndroidA11y {
 
 /// Re-resolve `target` in an already-numbered `tree` and return the node only if it is still the
 /// element that was addressed and still editable. Errors specifically when the target is gone
-/// (`AxElementNotFound`), has drifted in role/name/bounds (`AxElementChanged`), or is not editable
-/// (`AxElementNotEditable`).
+/// (`AxElementNotFound`), has drifted in role/name/bounds/value (`AxElementChanged`), or is not
+/// editable (`AxElementNotEditable`).
 ///
 /// Both Android readers' `set_value` guards route through this — the check that stops a write
 /// landing on whatever inherited the id between the snapshot the caller read and the one the write
-/// acts on. Pure (no device I/O), so it is testable without a device.
+/// acts on. A recycled `RecyclerView` row keeps role, name and rect unchanged and only its data
+/// differs, which is why a captured value is checked too. Pure (no device I/O), so it is testable
+/// without a device.
 pub(crate) fn editable_target<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&'a AxNode> {
     let node = tree
         .find(target.id)
         .ok_or(GlassError::AxElementNotFound(target.id.0))?;
     if !target.matches(node.role, node.name.as_deref()) || !target.bounds_consistent(node.bounds, 8)
     {
+        return Err(GlassError::AxElementChanged(target.id.0));
+    }
+    // A captured `None` says nothing about identity and must not gate, or every element that
+    // never had a value becomes unwritable.
+    if target.value.is_some() && target.value.as_deref() != node.value.as_deref() {
         return Err(GlassError::AxElementChanged(target.id.0));
     }
     if !node.states.editable {
@@ -331,7 +338,9 @@ impl Accessibility for AndroidA11y {
 
 #[cfg(test)]
 mod tests {
-    use super::{dump_once, dump_until_ready, locate_editable_target, verify_write};
+    use super::{
+        dump_once, dump_until_ready, editable_target, locate_editable_target, verify_write,
+    };
     use glass_core::accessibility::{AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree};
     use glass_core::{GlassError, Result, WindowGeometry};
     use std::time::Duration;
@@ -519,6 +528,15 @@ mod tests {
         t
     }
 
+    /// Like `tree`, but also holding `value` — the fingerprint a recycled row needs, since its
+    /// role, name and bounds are reused unchanged. Always at `BOUNDS`, always editable.
+    fn tree_with_value(role: AxRole, name: Option<&str>, value: Option<&str>) -> AxTree {
+        let mut t = tree(role, name, Some(BOUNDS), true);
+        t.root.value = value.map(Into::into);
+        t.assign_ids();
+        t
+    }
+
     fn target(id: u32, name: Option<&str>, bounds: Option<AxRect>) -> AxTarget {
         AxTarget {
             id: AxNodeId(id),
@@ -683,6 +701,39 @@ mod tests {
             locate_editable_target(&t, &target(0, Some("Search"), Some(moved)), &WIN),
             Err(GlassError::AxElementChanged(0))
         ));
+    }
+
+    #[test]
+    fn a_target_whose_value_moved_is_rejected() {
+        // A recycled row reuses the view, so role, name and rect are all identical and only the
+        // data differs — the value is the one thing that can catch it.
+        let tree = tree_with_value(AxRole::TextField, Some("row_title"), Some("Zara"));
+        let target = AxTarget {
+            id: AxNodeId(0),
+            role: AxRole::TextField,
+            name: Some("row_title".into()),
+            bounds: tree.root.bounds,
+            value: Some("Alice".into()),
+        };
+        assert!(matches!(
+            editable_target(&tree, &target),
+            Err(GlassError::AxElementChanged(0))
+        ));
+    }
+
+    #[test]
+    fn a_target_with_no_captured_value_still_passes() {
+        // A `None` at snapshot time says nothing about identity, so it must not gate. Without
+        // this, every element that had no value became un-writable.
+        let tree = tree_with_value(AxRole::TextField, Some("row_title"), Some("Alice"));
+        let target = AxTarget {
+            id: AxNodeId(0),
+            role: AxRole::TextField,
+            name: Some("row_title".into()),
+            bounds: tree.root.bounds,
+            value: None,
+        };
+        assert!(editable_target(&tree, &target).is_ok());
     }
 
     #[test]

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -230,9 +230,8 @@ impl Default for AndroidA11y {
 ///
 /// Both Android readers' `set_value` guards route through this — the check that stops a write
 /// landing on whatever inherited the id between the snapshot the caller read and the one the write
-/// acts on. A recycled `RecyclerView` row keeps role, name and rect unchanged and only its data
-/// differs, which is why a captured value is checked too. Pure (no device I/O), so it is testable
-/// without a device.
+/// acts on. A recycled `RecyclerView` row is the motivating case for comparing `value` too — see
+/// `AxTarget::value`'s doc. Pure (no device I/O), so it is testable without a device.
 pub(crate) fn editable_target<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&'a AxNode> {
     let node = tree
         .find(target.id)
@@ -528,8 +527,8 @@ mod tests {
         t
     }
 
-    /// Like `tree`, but also holding `value` — the fingerprint a recycled row needs, since its
-    /// role, name and bounds are reused unchanged. Always at `BOUNDS`, always editable.
+    /// Like `tree`, but also holding `value` — see `editable_target`'s doc for why that's part of
+    /// the fingerprint too. Always at `BOUNDS`, always editable.
     fn tree_with_value(role: AxRole, name: Option<&str>, value: Option<&str>) -> AxTree {
         let mut t = tree(role, name, Some(BOUNDS), true);
         t.root.value = value.map(Into::into);
@@ -705,8 +704,7 @@ mod tests {
 
     #[test]
     fn a_target_whose_value_moved_is_rejected() {
-        // A recycled row reuses the view, so role, name and rect are all identical and only the
-        // data differs — the value is the one thing that can catch it.
+        // The recycled-row case `editable_target`'s doc names: role, name and rect match here too.
         let tree = tree_with_value(AxRole::TextField, Some("row_title"), Some("Zara"));
         let target = AxTarget {
             id: AxNodeId(0),
@@ -723,8 +721,7 @@ mod tests {
 
     #[test]
     fn a_target_with_no_captured_value_still_passes() {
-        // A `None` at snapshot time says nothing about identity, so it must not gate. Without
-        // this, every element that had no value became un-writable.
+        // The `None`-must-not-gate case from the comment on `editable_target`'s value check.
         let tree = tree_with_value(AxRole::TextField, Some("row_title"), Some("Alice"));
         let target = AxTarget {
             id: AxNodeId(0),

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -525,6 +525,7 @@ mod tests {
             role: AxRole::TextField,
             name: name.map(Into::into),
             bounds,
+            value: None,
         }
     }
 

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -737,6 +737,22 @@ mod tests {
     }
 
     #[test]
+    fn a_target_whose_value_still_matches_passes() {
+        // Every other target helper here captures `None`, so "reject whenever a value was
+        // captured" would pass all of them too — this is the one case that actually needs the
+        // comparison, not just the presence check.
+        let tree = tree_with_value(AxRole::TextField, Some("row_title"), Some("Alice"));
+        let target = AxTarget {
+            id: AxNodeId(0),
+            role: AxRole::TextField,
+            name: Some("row_title".into()),
+            bounds: tree.root.bounds,
+            value: Some("Alice".into()),
+        };
+        assert!(editable_target(&tree, &target).is_ok());
+    }
+
+    #[test]
     fn non_editable_target_is_element_not_editable() {
         let t = tree(AxRole::TextField, Some("Search"), Some(BOUNDS), false);
         assert!(matches!(

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -236,13 +236,10 @@ pub(crate) fn editable_target<'a>(tree: &'a AxTree, target: &AxTarget) -> Result
     let node = tree
         .find(target.id)
         .ok_or(GlassError::AxElementNotFound(target.id.0))?;
-    if !target.matches(node.role, node.name.as_deref()) || !target.bounds_consistent(node.bounds, 8)
+    if !target.matches(node.role, node.name.as_deref())
+        || !target.bounds_consistent(node.bounds, 8)
+        || !target.value_consistent(node.value.as_deref())
     {
-        return Err(GlassError::AxElementChanged(target.id.0));
-    }
-    // A captured `None` says nothing about identity and must not gate, or every element that
-    // never had a value becomes unwritable.
-    if target.value.is_some() && target.value.as_deref() != node.value.as_deref() {
         return Err(GlassError::AxElementChanged(target.id.0));
     }
     if !node.states.editable {
@@ -731,6 +728,24 @@ mod tests {
             value: None,
         };
         assert!(editable_target(&tree, &target).is_ok());
+    }
+
+    #[test]
+    fn a_target_whose_value_vanished_is_rejected() {
+        // Android reports an emptied field as no value at all, so this is the shape a row that
+        // recycled from filled to empty arrives in — a real change, not a missing observation.
+        let tree = tree_with_value(AxRole::TextField, Some("row_title"), None);
+        let target = AxTarget {
+            id: AxNodeId(0),
+            role: AxRole::TextField,
+            name: Some("row_title".into()),
+            bounds: tree.root.bounds,
+            value: Some("Alice".into()),
+        };
+        assert!(matches!(
+            editable_target(&tree, &target),
+            Err(GlassError::AxElementChanged(0))
+        ));
     }
 
     #[test]

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -828,11 +828,19 @@ mod tests {
     }
 
     #[test]
-    fn a_node_from_an_older_companion_carries_neither_field() {
-        // The released APK sends neither key; mapping must succeed unchanged, not error.
-        let node = mapped_editable(Some("joe@x.com"), Some("Email"));
+    fn an_editable_nodes_name_is_the_desc_not_the_raw_resource_id() {
+        // Pins the `labels` call site's argument order: only this test has both `desc` and
+        // `resource_id` present, so a swap of the two would otherwise name the field by the
+        // unleafed id and nothing would catch it. The older-companion path (neither key
+        // sent) needs no dedicated test — every fixture above that omits them already
+        // exercises it.
+        let node = mapped_full(
+            Some("joe@x.com"),
+            Some("Email"),
+            Some("com.x:id/email_field"),
+            None,
+            true,
+        );
         assert_eq!(node.name.as_deref(), Some("Email"));
-        assert_eq!(node.value.as_deref(), Some("joe@x.com"));
-        assert_eq!(node.description, None);
     }
 }

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -39,7 +39,7 @@ fn json_to_node(
     // `None` here; `labels` judges a blank one absent either way.
     let text = v.get("text").and_then(Value::as_str);
     let desc = v.get("desc").and_then(Value::as_str);
-    let (name, value, description) = labels(text, desc, flag("editable"));
+    let (name, value, description) = labels(text, desc, None, None, flag("editable"));
     let b = v
         .get("bounds")
         .ok_or_else(|| GlassError::AccessibilityUnavailable("node missing bounds".into()))?;

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -13,7 +13,7 @@ use glass_core::accessibility::{
 use glass_core::platform::WindowGeometry;
 use glass_core::{GlassError, Result};
 
-use crate::axmap::{class_to_role, labels};
+use crate::axmap::{LabelInputs, class_to_role, labels};
 use crate::conn::Conn;
 
 /// Map one device `tree` JSON node (+descendants) into an `AxNode`, converting screen bounds to
@@ -43,7 +43,13 @@ fn json_to_node(
     // no version check is needed to stay compatible with it.
     let resource_id = v.get("resource_id").and_then(Value::as_str);
     let hint = v.get("hint").and_then(Value::as_str);
-    let (name, value, description) = labels(text, desc, resource_id, hint, flag("editable"));
+    let (name, value, description) = labels(LabelInputs {
+        text,
+        desc,
+        resource_id,
+        hint,
+        editable: flag("editable"),
+    });
     let b = v
         .get("bounds")
         .ok_or_else(|| GlassError::AccessibilityUnavailable("node missing bounds".into()))?;
@@ -782,11 +788,11 @@ mod tests {
     }
 
     #[test]
-    fn an_editable_node_with_no_desc_is_unnamed_not_named_by_its_contents() {
-        // The device omits the key entirely for a field with no content description. Falling
-        // back to `text` would name the field by what has been typed into it, moving the name —
-        // and the fingerprint `set_value` re-walks against — on every keystroke; unnamed is the
-        // honest reading.
+    fn an_editable_node_with_no_desc_and_no_id_is_unnamed_not_named_by_its_contents() {
+        // The device omits the key entirely for a field with no content description, and
+        // `mapped_editable` omits `resource_id` too, so nothing is left to fall back to. Naming it
+        // by `text` would move the name — and the fingerprint `set_value` re-walks against — on
+        // every keystroke, so unnamed is the honest reading.
         let node = mapped_editable(Some("joe@x.com"), None);
         assert_eq!(node.name, None);
         assert_eq!(node.value.as_deref(), Some("joe@x.com"));
@@ -829,9 +835,9 @@ mod tests {
 
     #[test]
     fn an_editable_nodes_name_is_the_desc_not_the_raw_resource_id() {
-        // Pins the `labels` call site's argument order: only this test has both `desc` and
-        // `resource_id` present, so a swap of the two would otherwise name the field by the
-        // unleafed id and nothing would catch it. The older-companion path (neither key
+        // The only fixture here with both `desc` and `resource_id` present, so it is what
+        // pins the precedence between them. (`LabelInputs`'s named fields, not this test, are
+        // what stop the call site transposing the two.) The older-companion path (neither key
         // sent) needs no dedicated test — every fixture above that omits them already
         // exercises it.
         let node = mapped_full(

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -39,7 +39,11 @@ fn json_to_node(
     // `None` here; `labels` judges a blank one absent either way.
     let text = v.get("text").and_then(Value::as_str);
     let desc = v.get("desc").and_then(Value::as_str);
-    let (name, value, description) = labels(text, desc, None, None, flag("editable"));
+    // Both keys are absent (not null) on an older companion; `get` returns `None` either way, so
+    // no version check is needed to stay compatible with it.
+    let resource_id = v.get("resource_id").and_then(Value::as_str);
+    let hint = v.get("hint").and_then(Value::as_str);
+    let (name, value, description) = labels(text, desc, resource_id, hint, flag("editable"));
     let b = v
         .get("bounds")
         .ok_or_else(|| GlassError::AccessibilityUnavailable("node missing bounds".into()))?;
@@ -97,7 +101,7 @@ fn json_to_node(
         role: class_to_role(cls),
         raw_role: cls.to_string(),
         name,
-        // Hint and state-description stay unread — the device protocol carries neither.
+        // State-description stays unread — the device protocol doesn't carry it.
         description,
         value,
         states: AxStates {
@@ -677,7 +681,12 @@ mod tests {
         assert_eq!((b.x, b.y), (-5, -90)); // window-relative: x -5-0, y 10-100
     }
 
-    fn node_json(text: Option<&str>, desc: Option<&str>) -> Value {
+    fn node_json(
+        text: Option<&str>,
+        desc: Option<&str>,
+        resource_id: Option<&str>,
+        hint: Option<&str>,
+    ) -> Value {
         let mut v = json!({
             "class": "android.widget.Button",
             "bounds": {"x": 0, "y": 100, "w": 10, "h": 10},
@@ -689,19 +698,43 @@ mod tests {
         if let Some(d) = desc {
             v["desc"] = json!(d);
         }
+        if let Some(r) = resource_id {
+            v["resource_id"] = json!(r);
+        }
+        if let Some(h) = hint {
+            v["hint"] = json!(h);
+        }
         v
     }
 
     fn mapped(text: Option<&str>, desc: Option<&str>) -> AxNode {
         let mut budget = WalkBudget::new();
-        json_to_node(&node_json(text, desc), &win(), 0, &mut budget).expect("maps")
+        json_to_node(&node_json(text, desc, None, None), &win(), 0, &mut budget).expect("maps")
     }
 
-    /// [`mapped`], for an editable field rather than a button.
+    /// [`mapped`], for an editable field; omits `resource_id`/`hint`, the shape an older
+    /// companion sends.
     fn mapped_editable(text: Option<&str>, desc: Option<&str>) -> AxNode {
-        let mut v = node_json(text, desc);
+        let mut v = node_json(text, desc, None, None);
         v["class"] = json!("android.widget.EditText");
         v["editable"] = json!(true);
+        let mut budget = WalkBudget::new();
+        json_to_node(&v, &win(), 0, &mut budget).expect("maps")
+    }
+
+    /// [`mapped_editable`], additionally setting `resource_id` and `hint`.
+    fn mapped_full(
+        text: Option<&str>,
+        desc: Option<&str>,
+        resource_id: Option<&str>,
+        hint: Option<&str>,
+        editable: bool,
+    ) -> AxNode {
+        let mut v = node_json(text, desc, resource_id, hint);
+        if editable {
+            v["class"] = json!("android.widget.EditText");
+            v["editable"] = json!(true);
+        }
         let mut budget = WalkBudget::new();
         json_to_node(&v, &win(), 0, &mut budget).expect("maps")
     }
@@ -766,5 +799,40 @@ mod tests {
         let node = mapped(Some("Settings"), None);
         assert_eq!(node.name.as_deref(), Some("Settings"));
         assert_eq!(node.value, None);
+    }
+
+    #[test]
+    fn an_editable_node_with_no_desc_is_named_by_its_view_id() {
+        let node = mapped_full(
+            Some("joe@x.com"),
+            None,
+            Some("com.x:id/email_field"),
+            None,
+            true,
+        );
+        assert_eq!(node.name.as_deref(), Some("email_field"));
+        assert_eq!(node.value.as_deref(), Some("joe@x.com"));
+    }
+
+    #[test]
+    fn an_editable_nodes_hint_becomes_its_description() {
+        let node = mapped_full(
+            None,
+            None,
+            Some("com.x:id/q"),
+            Some("Search settings"),
+            true,
+        );
+        assert_eq!(node.name.as_deref(), Some("q"));
+        assert_eq!(node.description.as_deref(), Some("Search settings"));
+    }
+
+    #[test]
+    fn a_node_from_an_older_companion_carries_neither_field() {
+        // The released APK sends neither key; mapping must succeed unchanged, not error.
+        let node = mapped_editable(Some("joe@x.com"), Some("Email"));
+        assert_eq!(node.name.as_deref(), Some("Email"));
+        assert_eq!(node.value.as_deref(), Some("joe@x.com"));
+        assert_eq!(node.description, None);
     }
 }

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -161,10 +161,12 @@ fn map_node(
     let editable = role == AxRole::TextField || boolean("password");
     let content_desc = non_empty(attr("content-desc"));
     let text = non_empty(attr("text"));
+    let resource_id = non_empty(attr("resource-id"));
     let (name, value, description) = labels(
         text.as_deref(),
         content_desc.as_deref(),
-        None,
+        resource_id.as_deref(),
+        // A uiautomator dump carries no hint attribute — verified absent on API 34.
         None,
         editable,
     );
@@ -673,6 +675,24 @@ mod tests {
         let field = &tree.root.children[0];
         assert_eq!(field.name.as_deref(), Some("Email"));
         assert_eq!(field.value, None);
+    }
+
+    #[test]
+    fn an_editable_node_with_no_content_desc_is_named_by_its_view_id() {
+        let xml = concat!(
+            "<?xml version='1.0'?><hierarchy rotation=\"0\">",
+            "<node index=\"0\" text=\"wifi\" resource-id=\"com.android.settings:id/search_src_text\" ",
+            "class=\"android.widget.EditText\" content-desc=\"\" enabled=\"true\" focusable=\"true\" ",
+            "focused=\"false\" selected=\"false\" checkable=\"false\" checked=\"false\" ",
+            "password=\"false\" bounds=\"[0,0][100,50]\" />",
+            "</hierarchy>",
+        );
+        let tree = build_tree(xml, &win(), WalkLimits::DEFAULT).unwrap();
+        let field = &tree.root.children[0];
+        assert_eq!(field.name.as_deref(), Some("search_src_text"));
+        assert_eq!(field.value.as_deref(), Some("wifi"));
+        // uiautomator carries no hint, so there is nothing to describe.
+        assert_eq!(field.description, None);
     }
 
     #[test]

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -69,7 +69,8 @@ pub fn class_to_role(class: &str) -> AxRole {
 }
 
 /// `com.example:id/search_src_text` → `search_src_text`. The package-qualified form is noise in an
-/// outline, and within one app's tree the leaf is what distinguishes one view from another.
+/// outline; the bare leaf is still not unique within an app's tree — see `labels`'s doc for why
+/// it is only a label of last resort.
 fn id_leaf(id: &str) -> String {
     id.rsplit('/').next().unwrap_or(id).to_string()
 }
@@ -244,10 +245,10 @@ fn map_node(
 ///
 /// A text field with no content description falls back to its resource id — not unique in a tree
 /// (ten rows from one layout can all carry `row_title`), so it is a label of last resort rather
-/// than an identifier. Only when both are absent does the node stay unnamed, leaving role plus an
-/// 8px bounds match as the whole fingerprint `set_value` re-walks against — weaker discrimination
-/// against an in-place replacement, a recycled list row, or a dialog reusing the rect.
-/// `json_to_node` errors on a node with no bounds, so that rect is always there to compare.
+/// than an identifier. Only when both are absent does the node stay unnamed; role, bounds, and —
+/// since `editable_target` also compares `AxTarget::value` — the field's own text are then the
+/// whole fingerprint `set_value` re-walks against. `json_to_node` errors on a node with no bounds,
+/// so that rect is always there to compare.
 ///
 /// The hint (Android's placeholder text for an empty field) becomes the `description`, never the
 /// `name` — `uiautomator` cannot see a hint at all, so a hint-derived name would exist on one
@@ -289,6 +290,8 @@ pub(crate) fn labels(
             description,
         );
     }
+    // No resource-id fallback here: giving every container a name too would stop
+    // `outline::is_scaffolding` collapsing them, inflating every snapshot.
     let name = text_label.or(desc_label);
     (
         name.map(str::to_string),

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -827,10 +827,12 @@ mod tests {
                 None,
             ),
             // Editable, no content description: the resource id names it rather than nothing.
+            // Package-qualified, as the platform actually emits it: the leaf is the name, not
+            // the qualified string.
             (
                 Some("wifi"),
                 None,
-                Some("search_src_text"),
+                Some("com.android.settings:id/search_src_text"),
                 None,
                 true,
                 Some("search_src_text"),
@@ -841,7 +843,7 @@ mod tests {
             (
                 Some("wifi"),
                 Some("Email"),
-                Some("search_src_text"),
+                Some("com.android.settings:id/search_src_text"),
                 None,
                 true,
                 Some("Email"),
@@ -852,7 +854,7 @@ mod tests {
             (
                 Some("wifi"),
                 None,
-                Some("search_src_text"),
+                Some("com.android.settings:id/search_src_text"),
                 Some("Search settings"),
                 true,
                 Some("search_src_text"),
@@ -863,7 +865,7 @@ mod tests {
             (
                 None,
                 None,
-                Some("Search"),
+                Some("com.x:id/Search"),
                 Some("Search"),
                 true,
                 Some("Search"),
@@ -890,6 +892,18 @@ mod tests {
                 true,
                 None,
                 Some("wifi"),
+                None,
+            ),
+            // Non-editable with an id and no labels at all: the fallback is editable-only, so
+            // this stays unnamed rather than picking up the id.
+            (
+                None,
+                None,
+                Some("com.x:id/save_btn"),
+                None,
+                false,
+                None,
+                None,
                 None,
             ),
         ];

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -68,6 +68,12 @@ pub fn class_to_role(class: &str) -> AxRole {
     AxRole::Other
 }
 
+/// `com.example:id/search_src_text` → `search_src_text`. The package-qualified form is noise in an
+/// outline, and within one app's tree the leaf is what distinguishes one view from another.
+fn id_leaf(id: &str) -> String {
+    id.rsplit('/').next().unwrap_or(id).to_string()
+}
+
 /// Parse uiautomator `bounds="[l,t][r,b]"` (screen-absolute) into a window-relative `AxRect`.
 pub fn parse_bounds(s: &str, window: &WindowGeometry) -> Option<AxRect> {
     let s = s.trim().strip_prefix('[')?;
@@ -155,7 +161,13 @@ fn map_node(
     let editable = role == AxRole::TextField || boolean("password");
     let content_desc = non_empty(attr("content-desc"));
     let text = non_empty(attr("text"));
-    let (name, value, description) = labels(text.as_deref(), content_desc.as_deref(), editable);
+    let (name, value, description) = labels(
+        text.as_deref(),
+        content_desc.as_deref(),
+        None,
+        None,
+        editable,
+    );
     let states = AxStates {
         focused: boolean("focused"),
         focusable: boolean("focusable"),
@@ -218,30 +230,40 @@ fn map_node(
     }
 }
 
-/// The three label fields, from the two labels Android exposes plus whether the node is editable.
+/// The three label fields, from the two labels Android exposes, the view's resource id, its
+/// hint, and whether the node is editable.
 ///
 /// Both Android readers route through this, so the precedence is one decision with one test suite
 /// rather than a per-reader choice that can drift apart — which is what it had done. The visible
 /// text is the name; an editable node is the exception, because its text is what the user typed —
 /// naming it by that text would move the name (and the role+name fingerprint) on every keystroke,
-/// so no `name:` selector could hold, and the content description is the only label left.
+/// so no `name:` selector could hold, and the content description — or, failing that, the
+/// resource id — is the label left.
 ///
-/// A text field with no content description is unnamed, so role plus an 8px bounds match is the
-/// whole fingerprint `set_value` re-walks against — weaker discrimination against an in-place
-/// replacement, a recycled list row, or a dialog reusing the rect. `json_to_node` errors on a node
-/// with no bounds, so that rect is always there to compare.
+/// A text field with no content description falls back to its resource id — not unique in a tree
+/// (ten rows from one layout can all carry `row_title`), so it is a label of last resort rather
+/// than an identifier. Only when both are absent does the node stay unnamed, leaving role plus an
+/// 8px bounds match as the whole fingerprint `set_value` re-walks against — weaker discrimination
+/// against an in-place replacement, a recycled list row, or a dialog reusing the rect.
+/// `json_to_node` errors on a node with no bounds, so that rect is always there to compare.
 ///
-/// A label with no non-whitespace content counts as absent. Left in place it would occupy the
-/// matchable `name` slot, where no `name:` selector reaches it and nothing falls back to the
-/// description — the judgement [`normalize_description`] already makes about its own candidate.
-/// Only the decision reads the trimmed form; a name that survives it is stored as the platform
-/// gave it.
+/// The hint (Android's placeholder text for an empty field) becomes the `description`, never the
+/// `name` — `uiautomator` cannot see a hint at all, so a hint-derived name would exist on one
+/// reader but not the other.
+///
+/// A label, resource id, or hint with no non-whitespace content counts as absent. Left in place it
+/// would occupy the matchable `name` slot, where no `name:` selector reaches it and nothing falls
+/// back to the description — the judgement [`normalize_description`] already makes about its own
+/// candidate. Only the decision reads the trimmed form; a name that survives it is stored as the
+/// platform gave it.
 ///
 /// `editable` is the caller's to decide: the on-device service reads an authoritative flag, while
 /// a `uiautomator` dump carries no such attribute and infers it from the widget class.
 pub(crate) fn labels(
     text: Option<&str>,
     desc: Option<&str>,
+    resource_id: Option<&str>,
+    hint: Option<&str>,
     editable: bool,
 ) -> (Option<String>, Option<String>, Option<String>) {
     fn labelled(s: &&str) -> bool {
@@ -250,12 +272,19 @@ pub(crate) fn labels(
     let text_label = text.filter(labelled);
     let desc_label = desc.filter(labelled);
     if editable {
+        // Bound before the tuple: the hint is judged against the name that was actually chosen,
+        // so a hint repeating it drops, exactly as a description does on the other arm.
+        let name = desc_label
+            .map(str::to_string)
+            .or_else(|| resource_id.filter(labelled).map(id_leaf));
+        let description = hint
+            .filter(labelled)
+            .and_then(|h| normalize_description(h, name.as_deref()));
         return (
-            desc_label.map(str::to_string),
+            name,
             // Verbatim, unlike the labels: whitespace a user typed is content, not a blank label.
             text.map(str::to_string),
-            // The text is already the value; repeating it would print the same string twice.
-            None,
+            description,
         );
     }
     let name = text_label.or(desc_label);
@@ -660,16 +689,19 @@ mod tests {
         assert_eq!(tree.root.children[0].description, None);
     }
 
-    /// Every combination of the two labels and the editable flag, with the rule stated once.
-    /// `desc` differs from `text` except where the case is about them matching.
+    /// Every combination of the two labels, the resource id, the hint, and the editable flag,
+    /// with the rule stated once. `desc` differs from `text` except where the case is about them
+    /// matching.
     #[test]
     #[expect(
         clippy::type_complexity,
         reason = "one-off table type, not worth naming"
     )]
     fn labels_follow_one_rule_for_both_readers() {
-        // (text, desc, editable) -> (name, value, description)
+        // (text, desc, resource_id, hint, editable) -> (name, value, description)
         let cases: &[(
+            Option<&str>,
+            Option<&str>,
             Option<&str>,
             Option<&str>,
             bool,
@@ -681,47 +713,92 @@ mod tests {
             (
                 Some("Save"),
                 Some("Save changes"),
+                None,
+                None,
                 false,
                 Some("Save"),
                 None,
                 Some("Save changes"),
             ),
             // No text: the content-description IS the name, so it must not print twice.
-            (None, Some("Bold"), false, Some("Bold"), None, None),
+            (
+                None,
+                Some("Bold"),
+                None,
+                None,
+                false,
+                Some("Bold"),
+                None,
+                None,
+            ),
             // No content-description: nothing to add.
-            (Some("Settings"), None, false, Some("Settings"), None, None),
+            (
+                Some("Settings"),
+                None,
+                None,
+                None,
+                false,
+                Some("Settings"),
+                None,
+                None,
+            ),
             // Both, identical: one label, printed once.
-            (Some("Save"), Some("Save"), false, Some("Save"), None, None),
+            (
+                Some("Save"),
+                Some("Save"),
+                None,
+                None,
+                false,
+                Some("Save"),
+                None,
+                None,
+            ),
             // Editable: the text is the user's content, so the description is the label.
             (
                 Some("joe@x.com"),
                 Some("Email"),
+                None,
+                None,
                 true,
                 Some("Email"),
                 Some("joe@x.com"),
                 None,
             ),
-            // Editable with no content-description: honestly unnamed, never named by its content.
-            (Some("joe@x.com"), None, true, None, Some("joe@x.com"), None),
+            // Editable with no content-description or resource id: honestly unnamed, never named
+            // by its content.
+            (
+                Some("joe@x.com"),
+                None,
+                None,
+                None,
+                true,
+                None,
+                Some("joe@x.com"),
+                None,
+            ),
             // Neither label.
-            (None, None, false, None, None, None),
-            (None, None, true, None, None, None),
+            (None, None, None, None, false, None, None, None),
+            (None, None, None, None, true, None, None, None),
             // A label of pure whitespace is no label: it must not take the name slot, where no
             // `name:` selector could reach it and the description would never stand in.
             (
                 Some(" "),
                 Some("Save changes"),
+                None,
+                None,
                 false,
                 Some("Save changes"),
                 None,
                 None,
             ),
-            (Some(" "), None, false, None, None, None),
+            (Some(" "), None, None, None, false, None, None, None),
             // Editable's value keeps whitespace: a caller can legitimately set a field to
             // spaces, and read-back compares exactly.
             (
                 Some("  "),
                 Some("Email"),
+                None,
+                None,
                 true,
                 Some("Email"),
                 Some("  "),
@@ -729,18 +806,102 @@ mod tests {
             ),
             // The empty content-desc a device really sends for "no description". `Some("")` in
             // the name slot is worse than `None`: it matches every other empty-named node.
-            (Some("hi"), Some(""), true, None, Some("hi"), None),
-            (Some("hi"), Some("  "), true, None, Some("hi"), None),
+            (
+                Some("hi"),
+                Some(""),
+                None,
+                None,
+                true,
+                None,
+                Some("hi"),
+                None,
+            ),
+            (
+                Some("hi"),
+                Some("  "),
+                None,
+                None,
+                true,
+                None,
+                Some("hi"),
+                None,
+            ),
+            // Editable, no content description: the resource id names it rather than nothing.
+            (
+                Some("wifi"),
+                None,
+                Some("search_src_text"),
+                None,
+                true,
+                Some("search_src_text"),
+                Some("wifi"),
+                None,
+            ),
+            // A content description still wins the name; the id is only a fallback.
+            (
+                Some("wifi"),
+                Some("Email"),
+                Some("search_src_text"),
+                None,
+                true,
+                Some("Email"),
+                Some("wifi"),
+                None,
+            ),
+            // The hint is the description, and does not touch the name.
+            (
+                Some("wifi"),
+                None,
+                Some("search_src_text"),
+                Some("Search settings"),
+                true,
+                Some("search_src_text"),
+                Some("wifi"),
+                Some("Search settings"),
+            ),
+            // A hint equal to the name adds nothing.
+            (
+                None,
+                None,
+                Some("Search"),
+                Some("Search"),
+                true,
+                Some("Search"),
+                None,
+                None,
+            ),
+            // Non-editable is untouched by either new input.
+            (
+                Some("Save"),
+                Some("Save changes"),
+                Some("save_btn"),
+                Some("ignored"),
+                false,
+                Some("Save"),
+                None,
+                Some("Save changes"),
+            ),
+            // Neither label nor id: still honestly unnamed.
+            (
+                Some("wifi"),
+                None,
+                None,
+                None,
+                true,
+                None,
+                Some("wifi"),
+                None,
+            ),
         ];
-        for &(text, desc, editable, name, value, description) in cases {
+        for &(text, desc, resource_id, hint, editable, name, value, description) in cases {
             assert_eq!(
-                labels(text, desc, editable),
+                labels(text, desc, resource_id, hint, editable),
                 (
                     name.map(str::to_string),
                     value.map(str::to_string),
                     description.map(str::to_string)
                 ),
-                "labels({text:?}, {desc:?}, editable={editable})"
+                "labels({text:?}, {desc:?}, {resource_id:?}, {hint:?}, editable={editable})"
             );
         }
     }
@@ -749,8 +910,8 @@ mod tests {
     fn an_editable_node_is_never_named_by_what_was_typed_into_it() {
         // The case the editable branch exists for (see `labels`'s doc): name must not track
         // the typed value.
-        let (before, _, _) = labels(Some("jo"), Some("Email"), true);
-        let (after, _, _) = labels(Some("joe@x.com"), Some("Email"), true);
+        let (before, _, _) = labels(Some("jo"), Some("Email"), None, None, true);
+        let (after, _, _) = labels(Some("joe@x.com"), Some("Email"), None, None, true);
         assert_eq!(before, after);
         assert_eq!(before.as_deref(), Some("Email"));
     }

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -69,10 +69,11 @@ pub fn class_to_role(class: &str) -> AxRole {
 }
 
 /// `com.example:id/search_src_text` → `search_src_text`. The package-qualified form is noise in an
-/// outline; the bare leaf is still not unique within an app's tree — see `labels`'s doc for why
-/// it is only a label of last resort.
-fn id_leaf(id: &str) -> String {
-    id.rsplit('/').next().unwrap_or(id).to_string()
+/// outline; the bare leaf is still not unique within an app's tree — see [`labels`]'s doc for why
+/// it is only a label of last resort. The leaf can be blank where the whole id was not
+/// (`com.x:id/`), so callers judge it after taking it, not before.
+fn id_leaf(id: &str) -> &str {
+    id.rsplit('/').next().unwrap_or(id)
 }
 
 /// Parse uiautomator `bounds="[l,t][r,b]"` (screen-absolute) into a window-relative `AxRect`.
@@ -163,14 +164,14 @@ fn map_node(
     let content_desc = non_empty(attr("content-desc"));
     let text = non_empty(attr("text"));
     let resource_id = non_empty(attr("resource-id"));
-    let (name, value, description) = labels(
-        text.as_deref(),
-        content_desc.as_deref(),
-        resource_id.as_deref(),
+    let (name, value, description) = labels(LabelInputs {
+        text: text.as_deref(),
+        desc: content_desc.as_deref(),
+        resource_id: resource_id.as_deref(),
         // A uiautomator dump carries no hint attribute — verified absent on API 34.
-        None,
+        hint: None,
         editable,
-    );
+    });
     let states = AxStates {
         focused: boolean("focused"),
         focusable: boolean("focusable"),
@@ -233,8 +234,27 @@ fn map_node(
     }
 }
 
-/// The three label fields, from the two labels Android exposes, the view's resource id, its
-/// hint, and whether the node is editable.
+/// What a reader read off one node, for [`labels`] to judge.
+///
+/// A struct rather than four interchangeable `Option<&str>` parameters: transposing two of those
+/// is not a type error, and the result is a plausible-looking *wrong* name (the unleafed id in the
+/// name slot) that no test outside a dedicated one would catch.
+pub(crate) struct LabelInputs<'a> {
+    /// The element's visible text — for an editable node, what the user typed.
+    pub(crate) text: Option<&'a str>,
+    /// Its content description.
+    pub(crate) desc: Option<&'a str>,
+    /// Its view resource id, package-qualified as the platform reports it.
+    pub(crate) resource_id: Option<&'a str>,
+    /// Its hint (placeholder text). Always `None` from `uiautomator`, whose dump carries no such
+    /// attribute.
+    pub(crate) hint: Option<&'a str>,
+    /// Whether the node is editable. The caller's to decide: the on-device service reads an
+    /// authoritative flag, while a `uiautomator` dump infers it from the widget class.
+    pub(crate) editable: bool,
+}
+
+/// The three label fields — name, value, description — from what a reader read off the node.
 ///
 /// Both Android readers route through this, so the precedence is one decision with one test suite
 /// rather than a per-reader choice that can drift apart — which is what it had done. The visible
@@ -257,29 +277,28 @@ fn map_node(
 /// A label, resource id, or hint with no non-whitespace content counts as absent. Left in place it
 /// would occupy the matchable `name` slot, where no `name:` selector reaches it and nothing falls
 /// back to the description — the judgement [`normalize_description`] already makes about its own
-/// candidate. Only the decision reads the trimmed form; a name that survives it is stored as the
-/// platform gave it.
-///
-/// `editable` is the caller's to decide: the on-device service reads an authoritative flag, while
-/// a `uiautomator` dump carries no such attribute and infers it from the widget class.
-pub(crate) fn labels(
-    text: Option<&str>,
-    desc: Option<&str>,
-    resource_id: Option<&str>,
-    hint: Option<&str>,
-    editable: bool,
-) -> (Option<String>, Option<String>, Option<String>) {
+/// candidate. The id is judged *after* its leaf is taken, so a `com.x:id/` with nothing behind the
+/// slash is absent too. Only the decision reads the trimmed form; a name that survives it is
+/// stored as the platform gave it.
+pub(crate) fn labels(inputs: LabelInputs<'_>) -> (Option<String>, Option<String>, Option<String>) {
     fn labelled(s: &&str) -> bool {
         !s.trim().is_empty()
     }
+    let LabelInputs {
+        text,
+        desc,
+        resource_id,
+        hint,
+        editable,
+    } = inputs;
     let text_label = text.filter(labelled);
     let desc_label = desc.filter(labelled);
     if editable {
         // Bound before the tuple: the hint is judged against the name that was actually chosen,
         // so a hint repeating it drops, exactly as a description does on the other arm.
         let name = desc_label
-            .map(str::to_string)
-            .or_else(|| resource_id.filter(labelled).map(id_leaf));
+            .or_else(|| resource_id.map(id_leaf).filter(labelled))
+            .map(str::to_string);
         let description = hint
             .filter(labelled)
             .and_then(|h| normalize_description(h, name.as_deref()));
@@ -658,10 +677,11 @@ mod tests {
     }
 
     #[test]
-    fn an_editable_node_with_an_empty_content_desc_is_unnamed_not_named_by_its_contents() {
-        // `content-desc=""` is what a device sends for a field with no description, and an
-        // unnamed field is the honest reading: naming it by `text` would move the name — and the
-        // fingerprint `set_value` re-walks against — on every keystroke.
+    fn an_editable_node_with_no_desc_and_no_id_is_unnamed_not_named_by_its_contents() {
+        // `content-desc=""` is what a device sends for a field with no description, and
+        // `edit_text_xml` emits no `resource-id`, so nothing is left to fall back to: naming it by
+        // `text` would move the name — and the fingerprint `set_value` re-walks against — on every
+        // keystroke, so unnamed is the honest reading.
         let xml = edit_text_xml("joe@x.com", "");
         let tree = build_tree(&xml, &win(), WalkLimits::DEFAULT).unwrap();
         let field = &tree.root.children[0];
@@ -929,10 +949,38 @@ mod tests {
                 None,
                 None,
             ),
+            // An id with nothing behind the slash: the leaf, not the qualified string, is what
+            // has to be non-blank, or `Some("")` takes the matchable name slot.
+            (
+                Some("wifi"),
+                None,
+                Some("com.x:id/"),
+                None,
+                true,
+                None,
+                Some("wifi"),
+                None,
+            ),
+            (
+                Some("wifi"),
+                None,
+                Some("com.x:id/   "),
+                None,
+                true,
+                None,
+                Some("wifi"),
+                None,
+            ),
         ];
         for &(text, desc, resource_id, hint, editable, name, value, description) in cases {
             assert_eq!(
-                labels(text, desc, resource_id, hint, editable),
+                labels(LabelInputs {
+                    text,
+                    desc,
+                    resource_id,
+                    hint,
+                    editable
+                }),
                 (
                     name.map(str::to_string),
                     value.map(str::to_string),
@@ -947,8 +995,17 @@ mod tests {
     fn an_editable_node_is_never_named_by_what_was_typed_into_it() {
         // The case the editable branch exists for (see `labels`'s doc): name must not track
         // the typed value.
-        let (before, _, _) = labels(Some("jo"), Some("Email"), None, None, true);
-        let (after, _, _) = labels(Some("joe@x.com"), Some("Email"), None, None, true);
+        let typed = |text| {
+            labels(LabelInputs {
+                text: Some(text),
+                desc: Some("Email"),
+                resource_id: None,
+                hint: None,
+                editable: true,
+            })
+        };
+        let (before, _, _) = typed("jo");
+        let (after, _, _) = typed("joe@x.com");
         assert_eq!(before, after);
         assert_eq!(before.as_deref(), Some("Email"));
     }

--- a/crates/glass-android/tests/a11y_loop.rs
+++ b/crates/glass-android/tests/a11y_loop.rs
@@ -130,6 +130,7 @@ fn set_value_reports_whether_the_write_landed() {
         role: field.role,
         name: field.name.clone(),
         bounds: field.bounds,
+        value: field.value.clone(),
     };
 
     // A write that lands: reported Ok, and the node at that id holds it afterwards.
@@ -161,6 +162,7 @@ fn set_value_reports_whether_the_write_landed() {
         role: field.role,
         name: field.name.clone(),
         bounds: field.bounds,
+        value: field.value.clone(),
     };
     match a11y.set_value(&ctx, &target, "") {
         Err(GlassError::AxValueNotApplied(_)) => {}
@@ -185,6 +187,7 @@ fn set_value_reports_whether_the_write_landed() {
         role: target.role,
         name: Some("not the field that is there".into()),
         bounds: target.bounds,
+        value: target.value.clone(),
     };
     match a11y.set_value(&ctx, &stale, "ignored") {
         Err(GlassError::AxElementChanged(_)) | Err(GlassError::AxElementNotFound(_)) => {}

--- a/crates/glass-android/tests/a11y_service_loop.rs
+++ b/crates/glass-android/tests/a11y_service_loop.rs
@@ -69,6 +69,7 @@ fn a11y_service_snapshot_and_actions() {
             role: node.role,
             name: node.name.clone(),
             bounds: node.bounds,
+            value: node.value.clone(),
         };
         a11y.set_value(&ctx, &target, "viaA11y")
             .expect("set_value via ACTION_SET_TEXT");

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -654,6 +654,13 @@ pub struct AxTarget {
     /// `set_value` path uses it to notice that a re-walk landed on a different element holding
     /// different data — a recycled list row reuses the same view, so its role, name and rect are
     /// all identical and only this differs.
+    ///
+    /// After a write, the session cache patches this to the text that was requested — an exact
+    /// fact only on a typed-write backend (Android/iOS, verified by
+    /// `typed_text_landed`/`typed_clear_landed`). An atomic-write backend (Windows/macOS) may
+    /// have reformatted the value instead (`read_back_confirms`), and Linux's AT-SPI writer
+    /// doesn't read back at all, so on those a future consumer should treat this as a best
+    /// available label, not a proven one.
     pub value: Option<String>,
 }
 

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -553,6 +553,18 @@ impl AxTree {
         walk(&self.root, id)
     }
 
+    /// [`Self::find`], mutably — for patching a field of a cached node in place rather than
+    /// re-walking the whole tree.
+    pub fn find_mut(&mut self, id: AxNodeId) -> Option<&mut AxNode> {
+        fn walk(node: &mut AxNode, id: AxNodeId) -> Option<&mut AxNode> {
+            if node.id == id {
+                return Some(node);
+            }
+            node.children.iter_mut().find_map(|c| walk(c, id))
+        }
+        walk(&mut self.root, id)
+    }
+
     /// Render a compact indented outline, one line per node, in `outline::write_line`'s format —
     /// the single definition of it, shared with [`crate::outline::render_compact`]. This render
     /// differs only in keeping every node: nothing is collapsed.
@@ -1770,6 +1782,18 @@ mod tests {
         t.assign_ids();
         assert_eq!(t.find(AxNodeId(1)).unwrap().name.as_deref(), Some("Save"));
         assert!(t.find(AxNodeId(99)).is_none());
+    }
+
+    #[test]
+    fn find_mut_patches_the_node_in_place_without_touching_the_rest() {
+        let mut t = sample_tree();
+        t.assign_ids();
+        t.find_mut(AxNodeId(1)).unwrap().value = Some("patched".into());
+        assert_eq!(
+            t.find(AxNodeId(1)).unwrap().value.as_deref(),
+            Some("patched")
+        );
+        assert!(t.find_mut(AxNodeId(99)).is_none());
     }
 
     #[test]

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -635,11 +635,12 @@ pub struct AxContext {
 }
 
 /// A fingerprint identifying the element a value-set targets: its synthetic id
-/// (pre-order index), the role/name the caller saw in the snapshot, and the
-/// element's window-relative bounds when known. The backend re-walks to the id
-/// and verifies role+name (and bounds, when present) so a stale id — or tree
-/// drift that lands a *different* same-role+name element on the id — errors
-/// rather than overwriting the wrong element.
+/// (pre-order index), the role/name the caller saw in the snapshot, the
+/// element's window-relative bounds when known, and the value it held. The
+/// backend re-walks to the id and verifies role+name (and bounds, when present;
+/// on Android the value too) so a stale id — or tree drift that lands a
+/// *different* same-role+name element on the id — errors rather than
+/// overwriting the wrong element.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AxTarget {
     pub id: AxNodeId,
@@ -650,13 +651,13 @@ pub struct AxTarget {
     /// same-role+name element if the tree drifted, and that element sits
     /// elsewhere — see [`Self::bounds_consistent`].
     pub bounds: Option<AxRect>,
-    /// The element's value at snapshot time, when it had one. Captured on every backend; the
-    /// `set_value` path uses it to notice that a re-walk landed on a different element holding
-    /// different data — a recycled list row reuses the same view, so its role, name and rect are
-    /// all identical and only this differs.
+    /// The element's value at snapshot time, when it had one. Captured on every backend, but
+    /// compared only by Android's `set_value` guard (`editable_target`), where a recycled list
+    /// row reuses the same view — role, name and rect all identical, only this different. The
+    /// other backends carry it without reading it; see [`Self::value_consistent`].
     ///
-    /// After a write, the session cache patches this to the text that was requested — an exact
-    /// fact only on a typed-write backend (Android/iOS, verified by
+    /// After a successful write the session cache patches this to the text that was requested —
+    /// an exact fact only on a typed-write backend (Android/iOS, verified by
     /// `typed_text_landed`/`typed_clear_landed`). An atomic-write backend (Windows/macOS) may
     /// have reformatted the value instead (`read_back_confirms`), and Linux's AT-SPI writer
     /// doesn't read back at all, so on those a future consumer should treat this as a best
@@ -686,6 +687,15 @@ impl AxTarget {
                     && (i64::from(a.height) - i64::from(b.height)).abs() <= tol
             }
         }
+    }
+
+    /// Whether a reached element's value `got` is consistent with the value captured for this
+    /// target. `true` when none was captured: a captured `None` says the element held no value
+    /// then, not which element it was, so gating on it would make every element that never held
+    /// one unwritable. A live `None` against a captured value still rejects — Android reports an
+    /// emptied field as no value at all, which is a real change, not a missing observation.
+    pub fn value_consistent(&self, got: Option<&str>) -> bool {
+        self.value.is_none() || self.value.as_deref() == got
     }
 }
 
@@ -1511,6 +1521,27 @@ mod tests {
     }
 
     #[test]
+    fn ax_target_value_consistent_rejects_an_element_holding_other_data() {
+        let with_value = |value: Option<&str>| AxTarget {
+            id: AxNodeId(3),
+            role: AxRole::TextField,
+            name: None,
+            bounds: None,
+            value: value.map(Into::into),
+        };
+        let t = with_value(Some("Alice"));
+        assert!(t.value_consistent(Some("Alice")));
+        // A recycled row: same role, name and rect, different data → rejected.
+        assert!(!t.value_consistent(Some("Zara")));
+        // An emptied field reports no value at all, which is still a change.
+        assert!(!t.value_consistent(None));
+        // Nothing captured → nothing to verify, accept, or every element that never held a
+        // value would be unwritable.
+        assert!(with_value(None).value_consistent(Some("Alice")));
+        assert!(with_value(None).value_consistent(None));
+    }
+
+    #[test]
     fn clamped_center_is_in_bounds() {
         let r = AxRect {
             x: 10,
@@ -1795,10 +1826,17 @@ mod tests {
     fn find_mut_patches_the_node_in_place_without_touching_the_rest() {
         let mut t = sample_tree();
         t.assign_ids();
+        t.find_mut(AxNodeId(2)).unwrap().value = Some("sibling".into());
         t.find_mut(AxNodeId(1)).unwrap().value = Some("patched".into());
         assert_eq!(
             t.find(AxNodeId(1)).unwrap().value.as_deref(),
             Some("patched")
+        );
+        // "the rest": the sibling keeps its own value, so a patch reaching past the one id it was
+        // handed is caught rather than named away.
+        assert_eq!(
+            t.find(AxNodeId(2)).unwrap().value.as_deref(),
+            Some("sibling")
         );
         assert!(t.find_mut(AxNodeId(99)).is_none());
     }

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -638,6 +638,11 @@ pub struct AxTarget {
     /// same-role+name element if the tree drifted, and that element sits
     /// elsewhere — see [`Self::bounds_consistent`].
     pub bounds: Option<AxRect>,
+    /// The element's value at snapshot time, when it had one. Captured on every backend; the
+    /// `set_value` path uses it to notice that a re-walk landed on a different element holding
+    /// different data — a recycled list row reuses the same view, so its role, name and rect are
+    /// all identical and only this differs.
+    pub value: Option<String>,
 }
 
 impl AxTarget {
@@ -1050,6 +1055,7 @@ mod tests {
             role: AxRole::TextField,
             name: None,
             bounds: None,
+            value: None,
         };
         let ctx = AxContext {
             pids: vec![],
@@ -1197,6 +1203,7 @@ mod tests {
             role: AxRole::Button,
             name: None,
             bounds,
+            value: None,
         };
         let t = target(Some(want));
 
@@ -1401,6 +1408,7 @@ mod tests {
             role: AxRole::TextField,
             name: Some("Email".into()),
             bounds: None,
+            value: None,
         };
         assert!(t.matches(AxRole::TextField, Some("Email")));
         assert!(!t.matches(AxRole::Button, Some("Email")), "role must match");
@@ -1418,6 +1426,7 @@ mod tests {
             role: AxRole::TextField,
             name: None,
             bounds: None,
+            value: None,
         };
         assert!(
             t_unnamed.matches(AxRole::TextField, None),
@@ -1442,6 +1451,7 @@ mod tests {
             role: AxRole::TextField,
             name: None,
             bounds: Some(r),
+            value: None,
         };
         // Exact and within-tolerance bounds pass.
         assert!(t.bounds_consistent(Some(r), 8));
@@ -1475,6 +1485,7 @@ mod tests {
             role: AxRole::TextField,
             name: None,
             bounds: None,
+            value: None,
         };
         assert!(t_nofp.bounds_consistent(Some(r), 8));
         assert!(t_nofp.bounds_consistent(None, 8));
@@ -2273,6 +2284,7 @@ mod tests {
             role: AxRole::Button,
             name: None,
             bounds: None,
+            value: None,
         };
         assert!(matches!(
             NoInvoke.invoke(&ctx, &target),

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -160,6 +160,28 @@ impl GlassError {
         )
     }
 
+    /// Whether a failed value-write may already have altered the element. False only for the
+    /// verdicts a backend reaches **before dispatching anything**: the id resolved to nothing
+    /// ([`GlassError::AxElementNotFound`]), the element on it was not the one addressed
+    /// ([`GlassError::AxElementChanged`]), or it cannot be written or tapped at all
+    /// ([`GlassError::AxElementNotEditable`], [`GlassError::AxElementNotClickable`]).
+    ///
+    /// Same "did anything dispatch?" split as [`Self::invoke_fallback_eligible`], with the
+    /// polarity flipped because the safe answer is the opposite one: the session drops its cached
+    /// value when this is true, so the wildcard must read "may have written" until a variant is
+    /// proven otherwise. Answering `false` for an error raised *after* the keystrokes went out
+    /// would leave the session fingerprinting the next write against a value the field no longer
+    /// holds.
+    pub fn set_value_may_have_written(&self) -> bool {
+        !matches!(
+            self,
+            GlassError::AxElementNotFound(_)
+                | GlassError::AxElementChanged(_)
+                | GlassError::AxElementNotEditable(_)
+                | GlassError::AxElementNotClickable(_)
+        )
+    }
+
     /// Runtime "this operation is unsupported on the active backend" error, worded
     /// consistently.
     ///
@@ -303,6 +325,29 @@ mod tests {
             GlassError::Backend("bus died".into()),
         ] {
             assert!(!e.invoke_fallback_eligible(), "{e}");
+        }
+    }
+
+    #[test]
+    fn a_write_may_have_landed_unless_it_was_rejected_before_dispatch() {
+        // Rejected before anything was typed: the field still reads as the snapshot saw it.
+        for e in [
+            GlassError::AxElementNotFound(3),
+            GlassError::AxElementChanged(3),
+            GlassError::AxElementNotEditable(3),
+            GlassError::AxElementNotClickable(3),
+        ] {
+            assert!(!e.set_value_may_have_written(), "{e}");
+        }
+        // Everything else, including a post-write verdict, an ambiguous transport error, and any
+        // variant not named at all (the wildcard).
+        for e in [
+            GlassError::AxValueNotApplied(3),
+            GlassError::AccessibilityUnavailable("set_value timed out".into()),
+            GlassError::Backend("adb died".into()),
+            GlassError::Timeout(10),
+        ] {
+            assert!(e.set_value_may_have_written(), "{e}");
         }
     }
 

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -160,26 +160,23 @@ impl GlassError {
         )
     }
 
-    /// Whether a failed value-write may already have altered the element. False only for the
-    /// verdicts a backend reaches **before dispatching anything**: the id resolved to nothing
-    /// ([`GlassError::AxElementNotFound`]), the element on it was not the one addressed
-    /// ([`GlassError::AxElementChanged`]), or it cannot be written or tapped at all
-    /// ([`GlassError::AxElementNotEditable`], [`GlassError::AxElementNotClickable`]).
+    /// Whether a failed value-write is **proven** to have gone out before failing — the only case
+    /// where the session's captured value is stale and must be dropped. True for the read-back
+    /// verdict [`GlassError::AxValueNotApplied`], raised only after a write was dispatched; false
+    /// for everything else, including variants added later.
     ///
-    /// Same "did anything dispatch?" split as [`Self::invoke_fallback_eligible`], with the
-    /// polarity flipped because the safe answer is the opposite one: the session drops its cached
-    /// value when this is true, so the wildcard must read "may have written" until a variant is
-    /// proven otherwise. Answering `false` for an error raised *after* the keystrokes went out
-    /// would leave the session fingerprinting the next write against a value the field no longer
-    /// holds.
-    pub fn set_value_may_have_written(&self) -> bool {
-        !matches!(
-            self,
-            GlassError::AxElementNotFound(_)
-                | GlassError::AxElementChanged(_)
-                | GlassError::AxElementNotEditable(_)
-                | GlassError::AxElementNotClickable(_)
-        )
+    /// Same "did anything dispatch?" question as [`Self::invoke_fallback_eligible`], but decided by
+    /// an allowlist, because the two mistakes are not symmetric. Keeping the value can only make
+    /// the guard reject more — an `AxElementChanged` whose own message tells the caller to
+    /// re-snapshot, recoverable. Dropping it can only make the guard accept more, and what it then
+    /// accepts is a write onto the wrong element, reported as `Ok`.
+    ///
+    /// Some verdicts cannot be classified at all: Android raises `Backend` and
+    /// `AccessibilityUnavailable` on *both* sides of the dispatch — its pre-write re-snapshot and
+    /// adb handshake fail the same way its post-write read-back does — so no variant-level split
+    /// separates them, and the recoverable answer has to win.
+    pub fn set_value_failed_after_writing(&self) -> bool {
+        matches!(self, GlassError::AxValueNotApplied(_))
     }
 
     /// Runtime "this operation is unsupported on the active backend" error, worded
@@ -329,25 +326,22 @@ mod tests {
     }
 
     #[test]
-    fn a_write_may_have_landed_unless_it_was_rejected_before_dispatch() {
-        // Rejected before anything was typed: the field still reads as the snapshot saw it.
+    fn only_a_proven_post_dispatch_verdict_invalidates_the_captured_value() {
+        // The read-back verdict is reached only after the write went out.
+        assert!(GlassError::AxValueNotApplied(3).set_value_failed_after_writing());
+        // Everything else keeps the captured value: the pre-dispatch rejections, the transport
+        // errors raised on either side of the dispatch, and any variant not named (the wildcard).
         for e in [
             GlassError::AxElementNotFound(3),
             GlassError::AxElementChanged(3),
             GlassError::AxElementNotEditable(3),
             GlassError::AxElementNotClickable(3),
-        ] {
-            assert!(!e.set_value_may_have_written(), "{e}");
-        }
-        // Everything else, including a post-write verdict, an ambiguous transport error, and any
-        // variant not named at all (the wildcard).
-        for e in [
-            GlassError::AxValueNotApplied(3),
-            GlassError::AccessibilityUnavailable("set_value timed out".into()),
+            GlassError::AxUnsupported,
+            GlassError::AccessibilityUnavailable("uiautomator dump not ready".into()),
             GlassError::Backend("adb died".into()),
             GlassError::Timeout(10),
         ] {
-            assert!(e.set_value_may_have_written(), "{e}");
+            assert!(!e.set_value_failed_after_writing(), "{e}");
         }
     }
 

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -446,6 +446,12 @@ impl Glass {
             .as_mut()
             .ok_or(GlassError::AxUnsupported)?
             .set_value(&ctx, &target, text)?;
+        // `Ok` means the write was read back and confirmed (#267/#272): the cache is corrected
+        // to a known fact, not a hoped one. Patch by id — re-snapshotting costs a whole walk
+        // for one field. Empty normalizes to `None`, matching a cleared field's read-back.
+        if let Some(node) = s.last_ax.as_mut().and_then(|t| t.find_mut(id)) {
+            node.value = (!text.is_empty()).then(|| text.to_string());
+        }
         s.pump();
         Ok(())
     }
@@ -2699,6 +2705,37 @@ mod tests {
             }
         );
         assert_eq!(calls[0].1, "hello");
+    }
+
+    #[test]
+    fn set_value_patches_last_ax_so_a_same_element_rewrite_is_not_rejected_as_drifted() {
+        // Without the patch, the second call's stale `target.value` ("orig") is rejected as
+        // drift by the fake's value-fingerprint guard. No intervening snapshot — that would
+        // refresh the cache and mask the bug.
+        let root = AxNode {
+            id: AxNodeId(0),
+            role: AxRole::TextField,
+            raw_role: "text field".into(),
+            name: Some("Name".into()),
+            description: None,
+            value: Some("orig".into()),
+            states: AxStates {
+                editable: true,
+                ..Default::default()
+            },
+            bounds: Some(AxRect {
+                x: 0,
+                y: 0,
+                width: 50,
+                height: 20,
+            }),
+            children: vec![],
+        };
+        let mut g = glass_with_a11y(FakePlatform::new(100, 100), AxTree::new(root));
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot(None).unwrap();
+        g.set_value(AxNodeId(0), "a").unwrap();
+        g.set_value(AxNodeId(0), "b").unwrap();
     }
 
     #[test]

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -442,13 +442,24 @@ impl Glass {
             };
         }
         let s = self.active_mut()?;
-        s.accessibility
+        let result = s
+            .accessibility
             .as_mut()
             .ok_or(GlassError::AxUnsupported)?
-            .set_value(&ctx, &target, text)?;
-        // `Ok` means the write was read back and confirmed (#267/#272): the cache is corrected
-        // to a known fact, not a hoped one. Patch by id — re-snapshotting costs a whole walk
-        // for one field. Empty normalizes to `None`, matching a cleared field's read-back.
+            .set_value(&ctx, &target, text);
+        if let Err(e) = result {
+            // A reported failure doesn't mean the field is unchanged — Android types before it
+            // verifies, so a partial type or the AVD's documented placeholder-on-clear can still
+            // have altered it. Invalidate (not gate) so a retry with no intervening snapshot
+            // isn't rejected as drift.
+            if let Some(node) = s.last_ax.as_mut().and_then(|t| t.find_mut(id)) {
+                node.value = None;
+            }
+            return Err(e);
+        }
+        // `Ok`'s guarantee varies by backend — see `AxTarget::value`'s doc — but patching to the
+        // requested text still beats leaving the pre-write value, which is definitely stale, not
+        // just possibly imprecise. Patch by id; a re-snapshot would cost a whole walk for one field.
         if let Some(node) = s.last_ax.as_mut().and_then(|t| t.find_mut(id)) {
             node.value = (!text.is_empty()).then(|| text.to_string());
         }
@@ -2708,10 +2719,14 @@ mod tests {
     }
 
     #[test]
-    fn set_value_patches_last_ax_so_a_same_element_rewrite_is_not_rejected_as_drifted() {
-        // Without the patch, the second call's stale `target.value` ("orig") is rejected as
-        // drift by the fake's value-fingerprint guard. No intervening snapshot — that would
-        // refresh the cache and mask the bug.
+    fn set_value_patches_last_ax_so_a_retry_carries_the_written_value() {
+        // Same mock harness as `set_value_passes_target_and_text_to_backend`: asserting on
+        // `set_log` proves the cache patch directly. The real drift guard lives in
+        // `editable_target` (glass-android), not here, so this doesn't reimplement it.
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let dir = tempfile::tempdir().unwrap();
+        let baselines = dir.path().join("baselines");
+        std::mem::forget(dir);
         let root = AxNode {
             id: AxNodeId(0),
             role: AxRole::TextField,
@@ -2731,11 +2746,121 @@ mod tests {
             }),
             children: vec![],
         };
-        let mut g = glass_with_a11y(FakePlatform::new(100, 100), AxTree::new(root));
+        let mut held: Option<Backend> = Some(Backend {
+            platform: Box::new(FakePlatform::new(100, 100)),
+            accessibility: Some(Box::new(FakeAccessibility {
+                tree: AxTree::new(root),
+                set_log: log.clone(),
+                set_fail: false,
+                ctx_log: Arc::new(Mutex::new(None)),
+                invoke_behavior: InvokeBehavior::Unsupported,
+                invoke_log: Arc::new(Mutex::new(Vec::new())),
+            })),
+        });
+        let factory: PlatformFactory = Box::new(move |_b| {
+            held.take()
+                .ok_or_else(|| GlassError::Backend("twice".into()))
+        });
+        let mut g = Glass::new(factory, "x11".into(), BaselineStore::new(baselines), 100);
         g.start(&spec()).unwrap();
         g.a11y_snapshot(None).unwrap();
+
         g.set_value(AxNodeId(0), "a").unwrap();
-        g.set_value(AxNodeId(0), "b").unwrap();
+        g.set_value(AxNodeId(0), "b").unwrap(); // no intervening snapshot
+
+        let calls = log.lock().unwrap();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(
+            calls[1].0.value,
+            Some("a".into()),
+            "the second call's target must carry what the first call wrote, not the pre-write \
+             snapshot value"
+        );
+    }
+
+    /// An `Accessibility` whose `set_value` fails the first call and succeeds every one after,
+    /// logging successful calls like `FakeAccessibility`. `FakeAccessibility::set_fail` is a
+    /// fixed knob, not a script, and this needs to vary across one session's two calls — kept
+    /// local since only one test needs it.
+    struct FlakyOnceAccessibility {
+        tree: AxTree,
+        failed_once: bool,
+        set_log: Arc<Mutex<Vec<(AxTarget, String)>>>,
+    }
+
+    impl Accessibility for FlakyOnceAccessibility {
+        fn snapshot(&mut self, _ctx: &AxContext) -> Result<AxTree> {
+            Ok(self.tree.clone())
+        }
+        fn set_value(&mut self, _ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
+            if !self.failed_once {
+                self.failed_once = true;
+                return Err(GlassError::AxValueNotApplied(target.id.0));
+            }
+            self.set_log
+                .lock()
+                .unwrap()
+                .push((target.clone(), text.to_string()));
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn set_value_invalidates_the_cached_value_after_a_failed_write() {
+        // Android types before it verifies (`typed_clear_landed`'s documented AVD false-failure:
+        // an emptied field reporting its placeholder), so a reported failure can still have
+        // changed the field. The stale pre-write value must not survive it, or a retry with no
+        // intervening snapshot would carry a value `editable_target` could reject as drift.
+        let dir = tempfile::tempdir().unwrap();
+        let baselines = dir.path().join("baselines");
+        std::mem::forget(dir);
+        let root = AxNode {
+            id: AxNodeId(0),
+            role: AxRole::TextField,
+            raw_role: "text field".into(),
+            name: Some("Name".into()),
+            description: None,
+            value: Some("orig".into()),
+            states: AxStates {
+                editable: true,
+                ..Default::default()
+            },
+            bounds: Some(AxRect {
+                x: 0,
+                y: 0,
+                width: 50,
+                height: 20,
+            }),
+            children: vec![],
+        };
+        let set_log = Arc::new(Mutex::new(Vec::new()));
+        let mut held: Option<Backend> = Some(Backend {
+            platform: Box::new(FakePlatform::new(100, 100)),
+            accessibility: Some(Box::new(FlakyOnceAccessibility {
+                tree: AxTree::new(root),
+                failed_once: false,
+                set_log: set_log.clone(),
+            })),
+        });
+        let factory: PlatformFactory = Box::new(move |_b| {
+            held.take()
+                .ok_or_else(|| GlassError::Backend("twice".into()))
+        });
+        let mut g = Glass::new(factory, "x11".into(), BaselineStore::new(baselines), 100);
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot(None).unwrap();
+
+        assert!(
+            g.set_value(AxNodeId(0), "a").is_err(),
+            "first write is scripted to fail"
+        );
+        g.set_value(AxNodeId(0), "a").unwrap(); // retry, no intervening snapshot
+
+        assert_eq!(
+            set_log.lock().unwrap()[0].0.value,
+            None,
+            "the retry's target must not carry the stale pre-failure value"
+        );
     }
 
     #[test]

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -2807,10 +2807,9 @@ mod tests {
 
     #[test]
     fn set_value_invalidates_the_cached_value_after_a_failed_write() {
-        // Android types before it verifies (`typed_clear_landed`'s documented AVD false-failure:
-        // an emptied field reporting its placeholder), so a reported failure can still have
-        // changed the field. The stale pre-write value must not survive it, or a retry with no
-        // intervening snapshot would carry a value `editable_target` could reject as drift.
+        // The AVD false-failure `typed_clear_landed` documents (an emptied field reporting its
+        // placeholder) is why `Glass::set_value` invalidates rather than gates on failure — see
+        // its comment. This exercises that path through a real retry.
         let dir = tempfile::tempdir().unwrap();
         let baselines = dir.path().join("baselines");
         std::mem::forget(dir);

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -386,6 +386,9 @@ impl Glass {
         // interface only moves the popup's *preview* selection, and the model commits
         // only on row activation (Enter/click). So drive it like a person does —
         // open it, keyboard-navigate to the option, and press Enter.
+        //
+        // No cache patch on this path: every `Ok` it returns either actuated nothing or followed
+        // an `a11y_resnapshot`, which replaces `last_ax` wholesale — a fresher fact than a patch.
         if target.role == AxRole::ComboBox {
             return self.set_combo_value(id, &target, text);
         }
@@ -421,6 +424,8 @@ impl Glass {
             if st.checked == want {
                 return Ok(()); // truthful no-op, no actuation
             }
+            // No cache patch here either, for the combo path's reason: the verify poll below
+            // re-snapshots, so `last_ax` holds the tree that observed the toggle.
             self.click_element_inner(id)?; // the toggle actuation (a swipe for a row-shaped control)
             // Not event-gated, and cannot be: this branch runs only on a backend that frames a
             // switch as its whole row, which today is iOS alone — a reader with no event stream to
@@ -448,11 +453,15 @@ impl Glass {
             .ok_or(GlassError::AxUnsupported)?
             .set_value(&ctx, &target, text);
         if let Err(e) = result {
-            // A reported failure doesn't mean the field is unchanged — Android types before it
-            // verifies, so a partial type or the AVD's documented placeholder-on-clear can still
-            // have altered it. Invalidate (not gate) so a retry with no intervening snapshot
-            // isn't rejected as drift.
-            if let Some(node) = s.last_ax.as_mut().and_then(|t| t.find_mut(id)) {
+            // A failure after dispatch doesn't mean the field is unchanged — Android types before
+            // it verifies, so a partial type or the AVD's documented placeholder-on-clear can
+            // still have altered it. Invalidate (not gate) so a retry with no intervening snapshot
+            // isn't rejected as drift. A rejection from *before* dispatch keeps its value: that
+            // verdict is the guard working, and blanking the fingerprint would disarm it on the
+            // very retry it invites.
+            if e.set_value_may_have_written()
+                && let Some(node) = s.last_ax.as_mut().and_then(|t| t.find_mut(id))
+            {
                 node.value = None;
             }
             return Err(e);
@@ -2718,52 +2727,59 @@ mod tests {
         assert_eq!(calls[0].1, "hello");
     }
 
+    /// A one-node tree whose root is an editable field holding `value` — the shape the cache
+    /// tests need, since `set_value` targets the node the snapshot cached.
+    fn editable_field_tree(value: Option<&str>) -> AxTree {
+        AxTree::new(AxNode {
+            id: AxNodeId(0),
+            role: AxRole::TextField,
+            raw_role: "text field".into(),
+            name: Some("Name".into()),
+            description: None,
+            value: value.map(Into::into),
+            states: AxStates {
+                editable: true,
+                ..Default::default()
+            },
+            bounds: Some(rect(0, 0, 50, 20)),
+            children: vec![],
+        })
+    }
+
+    /// A started, snapshotted session over `accessibility` — ready for the `set_value` call the
+    /// test is actually about.
+    fn glass_ready_for_set_value(accessibility: Box<dyn Accessibility + Send>) -> Glass {
+        let mut g = glass_with_backend(FakePlatform::new(100, 100), accessibility);
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot(None).unwrap();
+        g
+    }
+
+    /// [`FakeAccessibility`] over `tree`, logging its writes to `set_log`.
+    fn logging_a11y(
+        tree: AxTree,
+        set_log: Arc<Mutex<Vec<(AxTarget, String)>>>,
+    ) -> FakeAccessibility {
+        FakeAccessibility {
+            tree,
+            set_log,
+            set_fail: false,
+            ctx_log: Arc::new(Mutex::new(None)),
+            invoke_behavior: InvokeBehavior::Unsupported,
+            invoke_log: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
     #[test]
     fn set_value_patches_last_ax_so_a_retry_carries_the_written_value() {
         // Same mock harness as `set_value_passes_target_and_text_to_backend`: asserting on
         // `set_log` proves the cache patch directly. The real drift guard lives in
         // `editable_target` (glass-android), not here, so this doesn't reimplement it.
         let log = Arc::new(Mutex::new(Vec::new()));
-        let dir = tempfile::tempdir().unwrap();
-        let baselines = dir.path().join("baselines");
-        std::mem::forget(dir);
-        let root = AxNode {
-            id: AxNodeId(0),
-            role: AxRole::TextField,
-            raw_role: "text field".into(),
-            name: Some("Name".into()),
-            description: None,
-            value: Some("orig".into()),
-            states: AxStates {
-                editable: true,
-                ..Default::default()
-            },
-            bounds: Some(AxRect {
-                x: 0,
-                y: 0,
-                width: 50,
-                height: 20,
-            }),
-            children: vec![],
-        };
-        let mut held: Option<Backend> = Some(Backend {
-            platform: Box::new(FakePlatform::new(100, 100)),
-            accessibility: Some(Box::new(FakeAccessibility {
-                tree: AxTree::new(root),
-                set_log: log.clone(),
-                set_fail: false,
-                ctx_log: Arc::new(Mutex::new(None)),
-                invoke_behavior: InvokeBehavior::Unsupported,
-                invoke_log: Arc::new(Mutex::new(Vec::new())),
-            })),
-        });
-        let factory: PlatformFactory = Box::new(move |_b| {
-            held.take()
-                .ok_or_else(|| GlassError::Backend("twice".into()))
-        });
-        let mut g = Glass::new(factory, "x11".into(), BaselineStore::new(baselines), 100);
-        g.start(&spec()).unwrap();
-        g.a11y_snapshot(None).unwrap();
+        let mut g = glass_ready_for_set_value(Box::new(logging_a11y(
+            editable_field_tree(Some("orig")),
+            log.clone(),
+        )));
 
         g.set_value(AxNodeId(0), "a").unwrap();
         g.set_value(AxNodeId(0), "b").unwrap(); // no intervening snapshot
@@ -2775,6 +2791,27 @@ mod tests {
             Some("a".into()),
             "the second call's target must carry what the first call wrote, not the pre-write \
              snapshot value"
+        );
+    }
+
+    #[test]
+    fn set_value_patches_a_cleared_field_to_no_value_at_all() {
+        // Android reports an emptied field as no value rather than `Some("")`, so caching the
+        // empty string after a successful clear would make `set_value(id, "")` then
+        // `set_value(id, "text")` — ordinary agent sequencing — look like drift on the second.
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let mut g = glass_ready_for_set_value(Box::new(logging_a11y(
+            editable_field_tree(Some("orig")),
+            log.clone(),
+        )));
+
+        g.set_value(AxNodeId(0), "").unwrap();
+        g.set_value(AxNodeId(0), "text").unwrap(); // no intervening snapshot
+
+        assert_eq!(
+            log.lock().unwrap()[1].0.value,
+            None,
+            "a cleared field caches as no value, the shape the reader would report"
         );
     }
 
@@ -2806,48 +2843,16 @@ mod tests {
     }
 
     #[test]
-    fn set_value_invalidates_the_cached_value_after_a_failed_write() {
-        // The AVD false-failure `typed_clear_landed` documents (an emptied field reporting its
-        // placeholder) is why `Glass::set_value` invalidates rather than gates on failure — see
-        // its comment. This exercises that path through a real retry.
-        let dir = tempfile::tempdir().unwrap();
-        let baselines = dir.path().join("baselines");
-        std::mem::forget(dir);
-        let root = AxNode {
-            id: AxNodeId(0),
-            role: AxRole::TextField,
-            raw_role: "text field".into(),
-            name: Some("Name".into()),
-            description: None,
-            value: Some("orig".into()),
-            states: AxStates {
-                editable: true,
-                ..Default::default()
-            },
-            bounds: Some(AxRect {
-                x: 0,
-                y: 0,
-                width: 50,
-                height: 20,
-            }),
-            children: vec![],
-        };
+    fn set_value_invalidates_the_cached_value_after_a_write_that_may_have_landed() {
+        // `AxValueNotApplied` is raised after the keystrokes went out — the AVD false-failure
+        // `typed_clear_landed` documents (an emptied field reporting its placeholder) is one — so
+        // the cached value is no longer a fact and must not gate the retry.
         let set_log = Arc::new(Mutex::new(Vec::new()));
-        let mut held: Option<Backend> = Some(Backend {
-            platform: Box::new(FakePlatform::new(100, 100)),
-            accessibility: Some(Box::new(FlakyOnceAccessibility {
-                tree: AxTree::new(root),
-                failed_once: false,
-                set_log: set_log.clone(),
-            })),
-        });
-        let factory: PlatformFactory = Box::new(move |_b| {
-            held.take()
-                .ok_or_else(|| GlassError::Backend("twice".into()))
-        });
-        let mut g = Glass::new(factory, "x11".into(), BaselineStore::new(baselines), 100);
-        g.start(&spec()).unwrap();
-        g.a11y_snapshot(None).unwrap();
+        let mut g = glass_ready_for_set_value(Box::new(FlakyOnceAccessibility {
+            tree: editable_field_tree(Some("orig")),
+            failed_once: false,
+            set_log: set_log.clone(),
+        }));
 
         assert!(
             g.set_value(AxNodeId(0), "a").is_err(),
@@ -2859,6 +2864,60 @@ mod tests {
             set_log.lock().unwrap()[0].0.value,
             None,
             "the retry's target must not carry the stale pre-failure value"
+        );
+    }
+
+    /// An `Accessibility` that guards its write on the target's value the way Android's
+    /// `editable_target` does — over the same [`AxTarget::value_consistent`], so this scripts the
+    /// guard rather than reimplementing it. `held` is what the live element reads.
+    struct GuardedAccessibility {
+        tree: AxTree,
+        held: Option<String>,
+        set_log: Arc<Mutex<Vec<(AxTarget, String)>>>,
+    }
+
+    impl Accessibility for GuardedAccessibility {
+        fn snapshot(&mut self, _ctx: &AxContext) -> Result<AxTree> {
+            Ok(self.tree.clone())
+        }
+        fn set_value(&mut self, _ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
+            if !target.value_consistent(self.held.as_deref()) {
+                return Err(GlassError::AxElementChanged(target.id.0));
+            }
+            self.held = Some(text.to_string());
+            self.set_log
+                .lock()
+                .unwrap()
+                .push((target.clone(), text.to_string()));
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn a_write_rejected_before_dispatch_keeps_the_fingerprint_that_rejected_it() {
+        // The recycled-row case: the snapshot read "Alice", the row now holds "Zara", and the
+        // guard rejects. An agent retries without re-snapshotting — blanking the cached value on
+        // that rejection would send the retry in with no value to compare, skipping the guard and
+        // writing to the wrong row.
+        let set_log = Arc::new(Mutex::new(Vec::new()));
+        let mut g = glass_ready_for_set_value(Box::new(GuardedAccessibility {
+            tree: editable_field_tree(Some("Alice")),
+            held: Some("Zara".into()),
+            set_log: set_log.clone(),
+        }));
+
+        for attempt in ["first", "retry"] {
+            assert!(
+                matches!(
+                    g.set_value(AxNodeId(0), "x"),
+                    Err(GlassError::AxElementChanged(0))
+                ),
+                "the {attempt} must be rejected as drift"
+            );
+        }
+        assert!(
+            set_log.lock().unwrap().is_empty(),
+            "no write may land on the drifted row"
         );
     }
 

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -305,6 +305,7 @@ impl Glass {
                 role: node.role,
                 name: node.name.clone(),
                 bounds: node.bounds,
+                value: node.value.clone(),
             };
             let ctx = AxContext {
                 pids: s.platform.app_pids(),
@@ -370,6 +371,7 @@ impl Glass {
                 role: node.role,
                 name: node.name.clone(),
                 bounds: node.bounds,
+                value: node.value.clone(),
             };
             let ctx = AxContext {
                 pids: s.platform.app_pids(),
@@ -2693,6 +2695,7 @@ mod tests {
                     width: 20,
                     height: 20
                 }),
+                value: None,
             }
         );
         assert_eq!(calls[0].1, "hello");

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -456,10 +456,9 @@ impl Glass {
             // A failure after dispatch doesn't mean the field is unchanged — Android types before
             // it verifies, so a partial type or the AVD's documented placeholder-on-clear can
             // still have altered it. Invalidate (not gate) so a retry with no intervening snapshot
-            // isn't rejected as drift. A rejection from *before* dispatch keeps its value: that
-            // verdict is the guard working, and blanking the fingerprint would disarm it on the
-            // very retry it invites.
-            if e.set_value_may_have_written()
+            // isn't rejected as drift; every other failure keeps its value, for the asymmetry
+            // `set_value_failed_after_writing` documents.
+            if e.set_value_failed_after_writing()
                 && let Some(node) = s.last_ax.as_mut().and_then(|t| t.find_mut(id))
             {
                 node.value = None;
@@ -2919,6 +2918,63 @@ mod tests {
             set_log.lock().unwrap().is_empty(),
             "no write may land on the drifted row"
         );
+    }
+
+    /// [`GuardedAccessibility`] whose first call fails before dispatching anything — the shape of
+    /// Android's `set_value`, which re-snapshots and reaches for adb before it taps.
+    struct PreDispatchFailureThenGuarded {
+        first_failure: Option<GlassError>,
+        guarded: GuardedAccessibility,
+    }
+
+    impl Accessibility for PreDispatchFailureThenGuarded {
+        fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
+            self.guarded.snapshot(ctx)
+        }
+        fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
+            match self.first_failure.take() {
+                Some(e) => Err(e),
+                None => self.guarded.set_value(ctx, target, text),
+            }
+        }
+    }
+
+    #[test]
+    fn a_pre_dispatch_transport_failure_keeps_the_value_that_guards_the_retry() {
+        // A not-ready `uiautomator dump` or an adb hiccup fails the guard's own re-snapshot, before
+        // anything is typed — as `Backend` or `AccessibilityUnavailable`, the same variants that
+        // post-dispatch failures use, so neither can be classified by variant. The captured value
+        // is still a fact here; blanking it would let the retry write to the recycled row.
+        for failure in [
+            GlassError::Backend("uiautomator dump not ready".into()),
+            GlassError::AccessibilityUnavailable("adb: device offline".into()),
+        ] {
+            let set_log = Arc::new(Mutex::new(Vec::new()));
+            let mut g = glass_ready_for_set_value(Box::new(PreDispatchFailureThenGuarded {
+                first_failure: Some(failure),
+                guarded: GuardedAccessibility {
+                    tree: editable_field_tree(Some("Alice")),
+                    held: Some("Zara".into()), // the row recycled under the snapshot
+                    set_log: set_log.clone(),
+                },
+            }));
+
+            assert!(
+                g.set_value(AxNodeId(0), "x").is_err(),
+                "first write is scripted to fail before dispatch"
+            );
+            assert!(
+                matches!(
+                    g.set_value(AxNodeId(0), "x"),
+                    Err(GlassError::AxElementChanged(0))
+                ),
+                "the retry must still be guarded by the captured value"
+            );
+            assert!(
+                set_log.lock().unwrap().is_empty(),
+                "no write may land on the drifted row"
+            );
+        }
     }
 
     #[test]

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -460,8 +460,9 @@ pub(crate) fn glass_with(platform: FakePlatform) -> Glass {
 }
 
 /// Shared `Glass`-construction boilerplate for the a11y builders: a one-shot
-/// factory yielding a `Backend` over `platform` + `accessibility`.
-fn glass_with_backend(
+/// factory yielding a `Backend` over `platform` + `accessibility`. Public to the crate's tests
+/// so one that scripts its own `Accessibility` doesn't have to restate the factory.
+pub(crate) fn glass_with_backend(
     platform: FakePlatform,
     accessibility: Box<dyn Accessibility + Send>,
 ) -> Glass {

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -355,6 +355,17 @@ impl Accessibility for FakeAccessibility {
         if self.set_fail {
             return Err(GlassError::AxElementNotEditable(target.id.0));
         }
+        // Models the value-fingerprint guard a real backend runs (`editable_target` in
+        // glass-android) — the only way to make a stale `last_ax` cache observable without a
+        // device.
+        if let Some(want) = &target.value
+            && self.tree.find(target.id).and_then(|n| n.value.as_deref()) != Some(want.as_str())
+        {
+            return Err(GlassError::AxElementChanged(target.id.0));
+        }
+        if let Some(node) = self.tree.find_mut(target.id) {
+            node.value = (!text.is_empty()).then(|| text.to_string());
+        }
         self.set_log
             .lock()
             .unwrap()

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -355,17 +355,6 @@ impl Accessibility for FakeAccessibility {
         if self.set_fail {
             return Err(GlassError::AxElementNotEditable(target.id.0));
         }
-        // Models the value-fingerprint guard a real backend runs (`editable_target` in
-        // glass-android) — the only way to make a stale `last_ax` cache observable without a
-        // device.
-        if let Some(want) = &target.value
-            && self.tree.find(target.id).and_then(|n| n.value.as_deref()) != Some(want.as_str())
-        {
-            return Err(GlassError::AxElementChanged(target.id.0));
-        }
-        if let Some(node) = self.tree.find_mut(target.id) {
-            node.value = (!text.is_empty()).then(|| text.to_string());
-        }
         self.set_log
             .lock()
             .unwrap()

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -259,6 +259,7 @@ mod tests {
             role: AxRole::TextField,
             name: Some("Note".into()),
             bounds: Some(FIELD),
+            value: None,
         }
     }
 
@@ -374,6 +375,7 @@ mod tests {
             role: AxRole::TextField,
             name: Some("inputField".into()),
             bounds: Some(r),
+            value: None,
         };
         assert_eq!(verify(&tree, &target).unwrap(), r);
     }
@@ -392,6 +394,7 @@ mod tests {
             role: AxRole::TextField,
             name: Some("inputField".into()),
             bounds: Some(r),
+            value: None,
         };
         assert!(verify(&tree, &target).is_err());
     }
@@ -411,6 +414,7 @@ mod tests {
             role: AxRole::TextField,
             name: Some("inputField".into()),
             bounds: Some(r),
+            value: None,
         };
         // Pin the variant: an unresolved id must report AxElementNotFound (naming the id),
         // not the generic AxUnsupported — both are `Err`, so `.is_err()` alone wouldn't guard it.
@@ -441,6 +445,7 @@ mod tests {
                 width: 100,
                 height: 30,
             }),
+            value: None,
         };
         assert!(verify(&tree, &target).is_err());
     }

--- a/crates/glass-ios/tests/drive_integration.rs
+++ b/crates/glass-ios/tests/drive_integration.rs
@@ -202,6 +202,7 @@ fn drive_fixture_snapshot_tap_and_type_end_to_end() {
         role: field.role,
         name: field.name.clone(),
         bounds: field.bounds,
+        value: field.value.clone(),
     };
     a11y.set_value(&ctx, &target, "world")
         .expect("set_value: clear then type");

--- a/crates/glass-macos/tests/a11y.rs
+++ b/crates/glass-macos/tests/a11y.rs
@@ -296,6 +296,7 @@ mod macos_main {
             role: note.role,
             name: note.name.clone(),
             bounds: note.bounds,
+            value: note.value.clone(),
         };
         try_expect(
             a11y.set_value(&ctx, &note_tgt, "world"),
@@ -326,6 +327,7 @@ mod macos_main {
             role: save.role,
             name: save.name.clone(),
             bounds: save.bounds,
+            value: save.value.clone(),
         };
         match a11y.set_value(&ctx, &save_tgt, "x") {
             Err(GlassError::AxElementNotEditable(_)) => {}
@@ -362,6 +364,7 @@ mod macos_main {
             role: status.role,
             name: status.name.clone(),
             bounds: status.bounds,
+            value: status.value.clone(),
         };
         match a11y.invoke(&ctx, &status_tgt) {
             Err(GlassError::AxActionUnavailable(_)) => {}

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -773,6 +773,7 @@ fn onbox_a11y_set_value() {
         role: field.role,
         name: field.name.clone(),
         bounds: field.bounds,
+        value: field.value.clone(),
     };
 
     const NEW: &str = "GLASSVALUE";
@@ -798,6 +799,7 @@ fn onbox_a11y_set_value() {
         role: b.role,
         name: b.name.clone(),
         bounds: b.bounds,
+        value: b.value.clone(),
     };
     assert!(
         matches!(
@@ -843,6 +845,7 @@ fn onbox_egui_set_value_honesty() {
         role: field.role,
         name: field.name.clone(),
         bounds: field.bounds,
+        value: field.value.clone(),
     };
     assert!(
         matches!(

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -480,18 +480,10 @@ only one — across four stock apps, only one node in roughly three hundred had 
 `desc` to be absent on most Android nodes, not routinely present. The other readers take it from a
 separate descriptor field, so there a node with a single label can still carry one.
 
-The on-device companion adds a second source of `desc` for an editable element: its hint
-(Android's placeholder text) becomes the description. That source is companion-only — a
-`uiautomator` dump carries no hint attribute at all, so `uiautomator` never supplies one — so a
-text field's `desc` is richer through the companion than through `uiautomator`. A field with a
-hint but no content description and no resource id has nothing left to name it, so it stays
-unnamed but described: verified rendering as `#35 TextField desc="Search settings"`, which
-`glass_a11y_marks` labels from that description (see below).
-
 Both Android readers name a control the same way: the visible text is the `name`, or the
 content-description where there is no text — except on an editable element, where the text is
-already the `value` and the content-description is the `name` instead — verified on device, a
-filled field's name does not change as its text changes, on either reader.
+already the `value` and the content-description is the `name` instead. A filled field's name does
+not change as its text changes, on either reader.
 
 One consequence of that rule: two controls that differ only in their content-description — "Save
 draft" and "Save and close", both reading `Save` on screen — now share a `name`, and a `name:`
@@ -500,18 +492,18 @@ controls read alike, address the one you want by its `id` from a snapshot.
 
 An editable element with no content description falls back to the leaf of its view resource id
 rather than staying unnamed — `open_search_view_edit_text`, not the package-qualified
-`com.android.settings:id/open_search_view_edit_text` — verified on the emulator (API 34): Settings'
-search box reads that name identically from both readers. Treat the id as a label of last resort: a
-resource id is not unique within a tree — ten rows built from one layout can all carry the same
-one — so it tells this element apart from unrelated ones, not from its own kind.
+`com.android.settings:id/open_search_view_edit_text`. Settings' search box, for example, reads that
+name identically from both readers. Treat the id as a label of last resort: a resource id is not
+unique within a tree — ten rows built from one layout can all carry the same one — so it tells
+this element apart from unrelated ones, not from its own kind.
 
-This id fallback opens a gap between the two readers for anyone still running a previously
-released on-device companion. `uiautomator` reads the resource id straight from its own dump, so
-it names such an element immediately; the old companion never sent a resource id, so the
-accessibility-service reader leaves the same element unnamed until the companion is updated. The
-trigger — editable, carries a resource id, no content description — is most stock text fields, not
-an exotic case. Nothing that matched before stops matching: this only adds a name where the
-service reader previously had none.
+The on-device companion adds a second source of `desc` for an editable element: its hint
+(Android's placeholder text) becomes the description. That source is companion-only — a
+`uiautomator` dump carries no hint attribute at all, so `uiautomator` never supplies one — so a
+text field's `desc` is richer through the companion than through `uiautomator`. A field with a
+hint but no content description and no resource id has nothing left to name it, so it stays
+unnamed but described, rendering as `#35 TextField desc="Search settings"`, which
+`glass_a11y_marks` labels from that description (see below).
 
 An element whose platform role glass has no mapping for renders as `Other(<native token>)` — e.g.
 `#4 Other(AXDisclosureTriangle) "Details" [enabled]` — so the platform's own token is still

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -475,10 +475,12 @@ the name.
 **`desc` is display-only: `glass_wait_for_element` and `glass_scroll_to_element` select on `name`,
 never on the description.**
 
-On **Android** a description needs one node to carry both of its labels, and most controls carry
-only one — across four stock apps, only one node in roughly three hundred had both — so expect
-`desc` to be absent on most Android nodes, not routinely present. The other readers take it from a
-separate descriptor field, so there a node with a single label can still carry one.
+On **Android** a description drawn from the element's own two labels needs one node to carry both,
+and most controls carry only one — across four stock apps, only one node in roughly three hundred
+had both — so on a non-editable element expect `desc` to be absent, not routinely present. An
+editable element read through the on-device companion is the exception: its hint is a source of its
+own (below), needing no second label. The other readers take the description from a separate
+descriptor field, so there a node with a single label can still carry one.
 
 Both Android readers name a control the same way: the visible text is the `name`, or the
 content-description where there is no text — except on an editable element, where the text is

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -468,8 +468,10 @@ developer-assigned id. It appears only where glass's reader sources that label: 
 reader reads AT-SPI `Description`, the UI Automation (Windows) reader reads `HelpText`, the AX
 (macOS) reader reads `AXHelp`, else `AXDescription` where `AXTitle` already supplied the name, the
 Android readers read whichever of the element's text and content-description did not become the
-name or the value, and the `idb` (iOS) reader reads the element's hint, falling back to the label
-an editable element's identifier displaced. It is omitted when the description duplicates the name.
+name or the value, the on-device companion additionally supplies an editable element's hint where
+that leaves it undescribed, and the `idb` (iOS) reader reads the element's hint, falling back to
+the label an editable element's identifier displaced. It is omitted when the description duplicates
+the name.
 **`desc` is display-only: `glass_wait_for_element` and `glass_scroll_to_element` select on `name`,
 never on the description.**
 
@@ -478,14 +480,38 @@ only one — across four stock apps, only one node in roughly three hundred had 
 `desc` to be absent on most Android nodes, not routinely present. The other readers take it from a
 separate descriptor field, so there a node with a single label can still carry one.
 
+The on-device companion adds a second source of `desc` for an editable element: its hint
+(Android's placeholder text) becomes the description. That source is companion-only — a
+`uiautomator` dump carries no hint attribute at all, so `uiautomator` never supplies one — so a
+text field's `desc` is richer through the companion than through `uiautomator`. A field with a
+hint but no content description and no resource id has nothing left to name it, so it stays
+unnamed but described: verified rendering as `#35 TextField desc="Search settings"`, which
+`glass_a11y_marks` labels from that description (see below).
+
 Both Android readers name a control the same way: the visible text is the `name`, or the
 content-description where there is no text — except on an editable element, where the text is
-already the `value` and the content-description is the `name` instead.
+already the `value` and the content-description is the `name` instead — verified on device, a
+filled field's name does not change as its text changes, on either reader.
 
 One consequence of that rule: two controls that differ only in their content-description — "Save
 draft" and "Save and close", both reading `Save` on screen — now share a `name`, and a `name:`
 selector picks the first of them in tree order without reporting that a second matched. Where two
 controls read alike, address the one you want by its `id` from a snapshot.
+
+An editable element with no content description falls back to the leaf of its view resource id
+rather than staying unnamed — `open_search_view_edit_text`, not the package-qualified
+`com.android.settings:id/open_search_view_edit_text` — verified on the emulator (API 34): Settings'
+search box reads that name identically from both readers. Treat the id as a label of last resort: a
+resource id is not unique within a tree — ten rows built from one layout can all carry the same
+one — so it tells this element apart from unrelated ones, not from its own kind.
+
+This id fallback opens a gap between the two readers for anyone still running a previously
+released on-device companion. `uiautomator` reads the resource id straight from its own dump, so
+it names such an element immediately; the old companion never sent a resource id, so the
+accessibility-service reader leaves the same element unnamed until the companion is updated. The
+trigger — editable, carries a resource id, no content description — is most stock text fields, not
+an exotic case. Nothing that matched before stops matching: this only adds a name where the
+service reader previously had none.
 
 An element whose platform role glass has no mapping for renders as `Other(<native token>)` — e.g.
 `#4 Other(AXDisclosureTriangle) "Details" [enabled]` — so the platform's own token is still

--- a/examples/android-role-fixture/README.md
+++ b/examples/android-role-fixture/README.md
@@ -20,9 +20,10 @@ guarantee. Re-run it rather than trusting it; the read step below prints the API
 | `PopupMenu` (button) | `android.widget.ListView`, entries `LinearLayout`/`RelativeLayout` |
 | `AlertDialog` (button) | `FrameLayout`/`LinearLayout` panels under `android:id/parentPanel` |
 | `Button` with `text` + a different `contentDescription` | `android.widget.Button`; both readers name it by its `text` and carry the `contentDescription` as `desc="…"` |
-| `EditText` with a hint, no `contentDescription`, no resource id | unnamed; reading not yet taken — fill in once the on-device companion has been run against it |
+| `EditText` with a hint, no `contentDescription`, no resource id | `android.widget.EditText`; unnamed, and through the on-device companion the hint is the description — read as `#35 TextField desc="Search settings"`, which `glass_a11y_marks` labels from that description. `uiautomator` sees no hint, so there it is unnamed and undescribed |
 
-The last two need a tap. Each opens as the topmost window, so dump it separately.
+`PopupMenu` and `AlertDialog` each need a tap. Each opens as the topmost window, so dump it
+separately.
 
 A subclass inherits the accessibility class name of the framework class it extends unless it
 overrides `getAccessibilityClassName()` — which is why the toolbar arrives as `ViewGroup`, and why

--- a/examples/android-role-fixture/README.md
+++ b/examples/android-role-fixture/README.md
@@ -20,6 +20,7 @@ guarantee. Re-run it rather than trusting it; the read step below prints the API
 | `PopupMenu` (button) | `android.widget.ListView`, entries `LinearLayout`/`RelativeLayout` |
 | `AlertDialog` (button) | `FrameLayout`/`LinearLayout` panels under `android:id/parentPanel` |
 | `Button` with `text` + a different `contentDescription` | `android.widget.Button`; both readers name it by its `text` and carry the `contentDescription` as `desc="…"` |
+| `EditText` with a hint, no `contentDescription`, no resource id | unnamed; reading not yet taken — fill in once the on-device companion has been run against it |
 
 The last two need a tap. Each opens as the topmost window, so dump it separately.
 

--- a/examples/android-role-fixture/src/tech/fixedwidth/glassrolefixture/MainActivity.java
+++ b/examples/android-role-fixture/src/tech/fixedwidth/glassrolefixture/MainActivity.java
@@ -8,6 +8,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
+import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.GridView;
 import android.widget.LinearLayout;
@@ -97,6 +98,13 @@ public class MainActivity extends Activity {
         described.setText("Save");
         described.setContentDescription("Save changes");
         root.addView(described, matchWrap());
+
+        // A hint and nothing else: no content description, and no resource name (this fixture has
+        // no resources file), so it stays unnamed. Through the on-device service its hint arrives
+        // as the description, which makes it the one control that renders desc= with no name.
+        EditText hinted = new EditText(this);
+        hinted.setHint("Search settings");
+        root.addView(hinted, matchWrap());
 
         ScrollView scroller = new ScrollView(this);
         scroller.addView(root);


### PR DESCRIPTION
Targets `fix/android-name-precedence` (#274), not master — that branch does not go to master until this lands, because these are the two regressions it introduced. Closes #275 and #276.

## What changed

| Node | `name` | `value` | `description` |
|---|---|---|---|
| editable | content description, else **the resource-id leaf** | the text | the **hint**, where the reader has one |
| non-editable | the visible text, else the content description | — | the content description the text displaced |

An editable element always has a name now. The hint is a `description` and never a name, because a `uiautomator` dump has no hint attribute at all — a hint-derived name would split the two readers, which is the thing #274 exists to have stopped.

The on-device companion gains two optional fields (`resource_id`, `hint`) in a separate repo. An older installed companion sends neither; the reader is absent-tolerant by construction, with no version check.

`AxTarget` also gained a `value`, captured at snapshot time. Android's `set_value` guard compares it before writing.

## Verified on device

API 34, both companion APKs, a freshly built server.

- Settings' search box reads `open_search_view_edit_text` **identically from both readers** — the resource id, as its leaf.
- A field with content is still not named by that content: typing changed nothing.
- The fixture's hinted field renders `#35 TextField desc="Search settings"` — **unnamed but described**, and `glass_a11y_marks` labels it from that description. That fallback shipped long ago with nothing in any fixture able to reach it; this is the first time it has been seen on a real screen.
- #274's own check still holds: `Button "Save" desc="Save changes"` identically through both readers.

## Why the guard needed a value

No identifier Android exposes can tell a recycled `RecyclerView` row from the row it replaced — the view is reused, so its resource id, role and rect are all identical and only the data differs. A `stable_id` on `AxTarget` would not have discriminated it. The data does, and the guard runs before the write, when a legitimate target still holds what the snapshot saw.

That required two supporting pieces:

- The session cache is **patched** after a successful write, or `set_value(id, "a")` then `set_value(id, "b")` would fail the second time against a stale value.
- It is **invalidated** after a failure where the write may already have landed — Android types before it verifies.

## What the review changed

Five lenses ran before this PR. The most consequential finding was in the invalidation above: it originally fired on *every* error, including the `AxElementChanged` the guard itself raises before anything is typed. That turned a detected drift into a silent wrong write — reject, blank the fingerprint, retry unguarded, land on the wrong row, report `Ok`. Two lenses found it independently.

The first fix bounded it with a "did the write dispatch?" predicate, but defaulted the unlisted case to *invalidate*. A re-review showed that was still backwards and reproduced a wrong write through it: the guard's own pre-dispatch re-snapshot fails as `Backend` or `AccessibilityUnavailable` — a not-ready dump, an adb hiccup — and those same variants are also raised post-dispatch, so no variant-level split can classify them.

The default is now **preserve**, with `AxValueNotApplied` the sole allowlisted post-dispatch verdict. The asymmetry is the reason and it is recorded in the code: preserving can only make the guard reject more, which is recoverable and whose error already says re-snapshot; blanking can only make it accept more, and what it accepts is a write onto the wrong element.

The panel also produced: a named-field struct for the label inputs, after five interchangeable parameters had already caused one swap that a single hand-added test caught rather than the type system; `AxTarget::value_consistent` extracted beside its existing sibling `bounds_consistent`; a blank resource id no longer able to occupy the matchable name slot; and four unpinned behaviours given tests, each shown to fail under a deliberate mutation before being accepted.

## Known limits

- A resource id is **not unique** in a tree — ten rows from one layout share it. It is a label of last resort, not an identifier.
- The guard discriminates a recycled row only when the row's field was **non-empty** at snapshot. A list of empty inputs shares an id, a rect and a `None` value, and nothing tells them apart.
- The value check can reject a legitimate target when a field's value moves on its own between snapshot and write. That is the recoverable direction, and the error already says re-snapshot.
