### PR TITLE
a11y-windows: event-gated waits over UI Automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,12 @@ internal refactors, CI, or test-only changes.
 - On Windows, `glass_wait_for_element` no longer re-reads the whole accessibility tree on a timer.
   Where UI Automation announces a property change, a wait for something that has not happened yet
   now reads the tree when something changes instead of once per interval — measured on hardware at
-  `interval_ms: 100`, 3 walks for a 3-second wait where it previously took 22. It still re-reads
-  every tenth interval regardless — about every two seconds at the default `interval_ms` of 200 —
-  so a change the platform does not announce costs latency, not a wrong answer. That matters most
-  for `condition: "enabled"`: of the two providers measured, a WinForms app never announced a
-  control becoming enabled and a WPF one did. Every other backend polls exactly as before, and so
-  does Windows if the subscription cannot be established or stops delivering.
+  `interval_ms: 100`, 4 walks for a 3-second wait where it previously took 24. It still re-reads
+  once a second regardless, and once more before reporting nothing found, so a change the platform
+  does not announce costs latency, not a wrong answer. That matters most for `condition: "enabled"`:
+  of the two providers measured, a WinForms app never announced a control becoming enabled and a
+  WPF one did. Every other backend polls exactly as before, and so does Windows if the subscription
+  cannot be established or stops delivering.
 
 ### Fixed
 - A `glass_wait_for_element` shorter than a second could report an element absent that was on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,13 @@ internal refactors, CI, or test-only changes.
 ### Changed
 - On Windows, `glass_wait_for_element` no longer re-reads the whole accessibility tree on a timer.
   Where UI Automation announces a property change, a wait for something that has not happened yet
-  now reads the tree when something changes instead of once per interval — measured on hardware, 3
-  walks for a 3-second wait where it previously took 22. It re-reads about once a second regardless,
-  so a change the platform does not announce costs latency, not a wrong answer — which matters most
-  for `condition: "enabled"`, because a WinForms app reaches UI Automation through the legacy MSAA
-  bridge, which never announces a control becoming enabled. Every other backend polls exactly as
-  before, and so does Windows if the subscription cannot be established or stops delivering.
+  now reads the tree when something changes instead of once per interval — measured on hardware at
+  `interval_ms: 100`, 3 walks for a 3-second wait where it previously took 22. It still re-reads
+  every tenth interval regardless — about every two seconds at the default `interval_ms` of 200 —
+  so a change the platform does not announce costs latency, not a wrong answer. That matters most
+  for `condition: "enabled"`: of the two providers measured, a WinForms app never announced a
+  control becoming enabled and a WPF one did. Every other backend polls exactly as before, and so
+  does Windows if the subscription cannot be established or stops delivering.
 
 ### Fixed
 - A `glass_wait_for_element` shorter than a second could report an element absent that was on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ internal refactors, CI, or test-only changes.
   the end of many waits. Such a wait answered from the single read it took before the change it was
   waiting for. It now reads once more before reporting nothing found, whatever its length, and the
   once-a-second floor no longer moves with `interval_ms`. Affects every backend that can subscribe
-  to change notifications, which today is Linux.
+  to change notifications.
 - Android's `set_value` now refuses a write whose target has drifted in value, not just in role,
   name or bounds. A re-walk that lands on a same-role, same-name, same-rect element holding
   *different* data — a recycled list row reusing the same view is the case this closes — is now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+### Changed
+- On Windows, `glass_wait_for_element` no longer re-reads the whole accessibility tree on a timer.
+  Where UI Automation announces a property change, a wait for something that has not happened yet
+  now reads the tree when something changes instead of once per interval — measured on hardware, 3
+  walks for a 3-second wait where it previously took 22. It re-reads about once a second regardless,
+  so a change the platform does not announce costs latency, not a wrong answer — which matters most
+  for `condition: "enabled"`, because a WinForms app reaches UI Automation through the legacy MSAA
+  bridge, which never announces a control becoming enabled. Every other backend polls exactly as
+  before, and so does Windows if the subscription cannot be established or stops delivering.
+
 ### Fixed
 - A `glass_wait_for_element` shorter than a second could report an element absent that was on
   screen. Where the platform announces changes, the wait skips reads it has been told are pointless

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,6 +1059,7 @@ version = "0.0.0"
 dependencies = [
  "glass-core",
  "uiautomation",
+ "windows",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,11 @@ publish = false
 # (clippy's `lint_groups_priority` otherwise flags the ambiguous same-priority ordering).
 future_incompatible = { level = "warn", priority = -1 }
 nonstandard_style = { level = "deny", priority = -1 }
-# Enforce the CLAUDE.md "avoid unsafe" invariant: pure crates carry no `unsafe` at all. The six
-# FFI backends (glass-macos/-windows/-clip-hook/-a11y-macos/-sandbox-macos/-clip-shim-macos) opt
-# back in per-target with a documented `#![allow(unsafe_code)]`; every site has a `// SAFETY:`.
+# Enforce the CLAUDE.md "avoid unsafe" invariant: `unsafe` is denied everywhere unless a target
+# opts back in explicitly, and every site carries a `// SAFETY:`. The FFI backends opt in crate-wide
+# with a documented `#![allow(unsafe_code)]` (glass-macos/-windows/-clip-hook/-a11y-macos/
+# -sandbox-macos/-clip-shim-macos); glass-dbus-linux and glass-a11y-windows opt in on the one item
+# that needs it, which is the narrower form to prefer.
 unsafe_code = "deny"
 
 [workspace.lints.clippy]

--- a/crates/glass-a11y-windows/Cargo.toml
+++ b/crates/glass-a11y-windows/Cargo.toml
@@ -13,6 +13,13 @@ glass-core.workspace = true
 # `event` for the change subscription in `events.rs`; `uiautomation` gates its event handler
 # types behind it. No new crate, and it resolves against the existing lockfile.
 uiautomation = { version = "0.25", features = ["process", "event"] }
+# `IUIAutomation2::SetTransactionTimeout`, to bound every cross-process call the subscription
+# makes (registration, the liveness probe, teardown) — `uiautomation` doesn't expose it, but
+# `UIAutomation: AsRef<IUIAutomation>` reaches the raw interface to cast up from. Already a
+# workspace dependency at this version (glass-windows, glass-clip-hook), and `uiautomation` itself
+# already requests `Win32_UI_Accessibility` transitively, so this is a dependency line, not a
+# feature or version change to the resolved graph.
+windows = { version = "0.62", features = ["Win32_UI_Accessibility"] }
 
 [lints]
 workspace = true

--- a/crates/glass-a11y-windows/Cargo.toml
+++ b/crates/glass-a11y-windows/Cargo.toml
@@ -14,12 +14,13 @@ glass-core.workspace = true
 # types behind it. No new crate, and it resolves against the existing lockfile.
 uiautomation = { version = "0.25", features = ["process", "event"] }
 # `IUIAutomation2::SetTransactionTimeout`, to bound every cross-process call the subscription
-# makes (registration, the liveness probe, teardown) — `uiautomation` doesn't expose it, but
-# `UIAutomation: AsRef<IUIAutomation>` reaches the raw interface to cast up from. Already a
-# workspace dependency at this version (glass-windows, glass-clip-hook), and `uiautomation` itself
-# already requests `Win32_UI_Accessibility` transitively, so this is a dependency line, not a
-# feature or version change to the resolved graph.
-windows = { version = "0.62", features = ["Win32_UI_Accessibility"] }
+# makes (registration, the liveness probe, teardown). `uiautomation` exposes neither that
+# interface nor the `CUIAutomation8` coclass that implements it, so `events.rs` creates its own
+# automation object — hence `Win32_System_Com` for `CoInitializeEx`/`CoCreateInstance` alongside
+# `Win32_UI_Accessibility`. Already a workspace dependency at this version (glass-windows,
+# glass-clip-hook), and `uiautomation` itself already requests both of these features
+# transitively, so this is a dependency line, not a version change to the resolved graph.
+windows = { version = "0.62", features = ["Win32_UI_Accessibility", "Win32_System_Com"] }
 
 [lints]
 workspace = true

--- a/crates/glass-a11y-windows/Cargo.toml
+++ b/crates/glass-a11y-windows/Cargo.toml
@@ -10,16 +10,11 @@ publish = false
 glass-core.workspace = true
 
 [target.'cfg(windows)'.dependencies]
-# `event` for the change subscription in `events.rs`; `uiautomation` gates its event handler
-# types behind it. No new crate, and it resolves against the existing lockfile.
+# `event` gates the event-handler types `events.rs` registers.
 uiautomation = { version = "0.25", features = ["process", "event"] }
-# `IUIAutomation2::SetTransactionTimeout`, to bound every cross-process call the subscription
-# makes (registration, the liveness probe, teardown). `uiautomation` exposes neither that
-# interface nor the `CUIAutomation8` coclass that implements it, so `events.rs` creates its own
-# automation object — hence `Win32_System_Com` for `CoInitializeEx`/`CoCreateInstance` alongside
-# `Win32_UI_Accessibility`. Already a workspace dependency at this version (glass-windows,
-# glass-clip-hook), and `uiautomation` itself already requests both of these features
-# transitively, so this is a dependency line, not a version change to the resolved graph.
+# For `IUIAutomation2::SetTransactionTimeout`, which bounds the subscription's cross-process
+# calls: `uiautomation` exposes neither that interface nor the `CUIAutomation8` coclass behind
+# it, so `events.rs` builds its own automation object — hence `Win32_System_Com` as well.
 windows = { version = "0.62", features = ["Win32_UI_Accessibility", "Win32_System_Com"] }
 
 [lints]

--- a/crates/glass-a11y-windows/Cargo.toml
+++ b/crates/glass-a11y-windows/Cargo.toml
@@ -10,7 +10,9 @@ publish = false
 glass-core.workspace = true
 
 [target.'cfg(windows)'.dependencies]
-uiautomation = { version = "0.25", features = ["process"] }
+# `event` for the change subscription in `events.rs`; `uiautomation` gates its event handler
+# types behind it. No new crate, and it resolves against the existing lockfile.
+uiautomation = { version = "0.25", features = ["process", "event"] }
 
 [lints]
 workspace = true

--- a/crates/glass-a11y-windows/src/events.rs
+++ b/crates/glass-a11y-windows/src/events.rs
@@ -174,10 +174,6 @@ impl ChangeSignal for UiaChanges {
 
 /// Subscribe to changes for the window in `ctx`, or `None` if no subscription could be
 /// established — the caller then polls exactly as it did before.
-///
-/// Not yet called: `WindowsA11y::subscribe_changes` wires this in as a follow-up, so nothing in
-/// the crate reaches this (or the rest of the module's production path) until then.
-#[allow(dead_code)]
 pub(crate) fn subscribe(ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
     let ctx = ctx.clone();
     // Capacity 1: the receiver only needs to learn that *something* changed, and a full channel

--- a/crates/glass-a11y-windows/src/events.rs
+++ b/crates/glass-a11y-windows/src/events.rs
@@ -147,19 +147,29 @@ impl CustomPropertyChangedEventHandler for Notify {
     }
 }
 
+/// Whether the pump can still be heard from. Two states rather than a receiver plus a flag, so
+/// "ended, but still holding a channel to read" is a state that cannot be built.
+enum Signaling {
+    Live {
+        rx: Receiver<()>,
+        /// Set while the pump can still deliver, cleared on its way out (see [`ClearOnExit`]). A
+        /// dead pump does not reliably disconnect the channel — UIA holds both senders inside COM
+        /// objects until the two `remove_*` calls succeed, against a window that has usually just
+        /// stopped resolving — so this, not `RecvTimeoutError::Disconnected`, is what tells `wait`
+        /// the pump is gone.
+        alive: Arc<AtomicBool>,
+    },
+    Ended,
+}
+
 /// A [`ChangeSignal`] fed by UIA event handlers registered on a background thread.
 pub(crate) struct UiaChanges {
-    rx: Receiver<()>,
-    live: bool,
+    signaling: Signaling,
     /// Cleared on drop to stop the pump, which is what removes the registrations. Leaked, the
-    /// target app's provider keeps doing work for a subscription nobody holds.
+    /// target app's provider keeps doing work for a subscription nobody holds. Written by this,
+    /// the consumer side, and read by the pump — the opposite direction from `alive`, which is why
+    /// the two are separate flags and neither side reads the one it writes.
     running: Arc<AtomicBool>,
-    /// Set while the pump can still deliver, cleared on its way out (see [`ClearOnExit`]). A dead
-    /// pump does not reliably disconnect the channel — UIA holds both senders inside COM objects
-    /// until the two `remove_*` calls succeed, against a window that has usually just stopped
-    /// resolving — so this, not `RecvTimeoutError::Disconnected`, is what tells `wait` the pump is
-    /// gone.
-    alive: Arc<AtomicBool>,
 }
 
 impl Drop for UiaChanges {
@@ -170,25 +180,28 @@ impl Drop for UiaChanges {
 
 impl ChangeSignal for UiaChanges {
     fn wait(&mut self, timeout: Duration) -> ChangeWait {
-        // Read before the channel: once the pump has gone, a queued message is a stale change and
-        // the caller re-reads on `Unusable` anyway.
-        if !self.live || !self.alive.load(Ordering::Relaxed) {
-            self.live = false;
-            return ChangeWait::Unusable;
+        let outcome = match &self.signaling {
+            Signaling::Ended => ChangeWait::Unusable,
+            // `alive` before the channel: once the pump has gone, a queued message is a stale
+            // change and the caller re-reads on `Unusable` anyway.
+            Signaling::Live { alive, .. } if !alive.load(Ordering::Relaxed) => ChangeWait::Unusable,
+            Signaling::Live { rx, .. } => match rx.recv_timeout(timeout) {
+                Ok(()) => {
+                    // One logical change delivers several events — a control and its text peer, a
+                    // structure event alongside a property event. A burst is one reason to re-read.
+                    while rx.try_recv().is_ok() {}
+                    ChangeWait::Changed
+                }
+                Err(RecvTimeoutError::Timeout) => ChangeWait::Quiet,
+                Err(RecvTimeoutError::Disconnected) => ChangeWait::Unusable,
+            },
+        };
+        if outcome == ChangeWait::Unusable {
+            // Drops the receiver with it, so a signal that has answered `Unusable` once has
+            // nothing left to answer anything else from.
+            self.signaling = Signaling::Ended;
         }
-        match self.rx.recv_timeout(timeout) {
-            Ok(()) => {
-                // One logical change delivers several events — a control and its text peer, a
-                // structure event alongside a property event. A burst is one reason to re-read.
-                while self.rx.try_recv().is_ok() {}
-                ChangeWait::Changed
-            }
-            Err(RecvTimeoutError::Timeout) => ChangeWait::Quiet,
-            Err(RecvTimeoutError::Disconnected) => {
-                self.live = false;
-                ChangeWait::Unusable
-            }
-        }
+        outcome
     }
 }
 
@@ -209,10 +222,8 @@ pub(crate) fn subscribe(ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
     // moment it has a signal, and a change landing before registration would be lost.
     match ready_rx.recv_timeout(SUBSCRIBE_TIMEOUT) {
         Ok(true) => Some(Box::new(UiaChanges {
-            rx,
-            live: true,
+            signaling: Signaling::Live { rx, alive },
             running,
-            alive,
         })),
         // Including the timeout: the pump may still be starting, and nothing else would ever tell
         // it to stop.
@@ -399,15 +410,21 @@ mod tests {
     /// `Quiet` is what licenses a caller to skip re-reading the tree (see `ChangeWait`) — this
     /// pins the case where that licence is actually earned: nothing arrived, and the signal is
     /// still trustworthy.
+    /// Builds the signal the way `subscribe` does, with the pump still running.
+    fn live_changes(rx: Receiver<()>) -> UiaChanges {
+        UiaChanges {
+            signaling: Signaling::Live {
+                rx,
+                alive: Arc::new(AtomicBool::new(true)),
+            },
+            running: Arc::new(AtomicBool::new(true)),
+        }
+    }
+
     #[test]
     fn no_event_within_the_timeout_reports_quiet() {
         let (_tx, rx) = sync_channel(1);
-        let mut changes = UiaChanges {
-            rx,
-            live: true,
-            running: Arc::new(AtomicBool::new(true)),
-            alive: Arc::new(AtomicBool::new(true)),
-        };
+        let mut changes = live_changes(rx);
         assert_eq!(changes.wait(Duration::from_millis(20)), ChangeWait::Quiet);
     }
 
@@ -422,15 +439,13 @@ mod tests {
         tx.send(()).unwrap();
         tx.send(()).unwrap();
         tx.send(()).unwrap();
-        let mut changes = UiaChanges {
-            rx,
-            live: true,
-            running: Arc::new(AtomicBool::new(true)),
-            alive: Arc::new(AtomicBool::new(true)),
-        };
+        let mut changes = live_changes(rx);
         assert_eq!(changes.wait(Duration::from_millis(20)), ChangeWait::Changed);
+        let Signaling::Live { rx, .. } = &changes.signaling else {
+            unreachable!("a delivered change leaves the signal live")
+        };
         assert!(
-            changes.rx.try_recv().is_err(),
+            rx.try_recv().is_err(),
             "a queued event survived the drain, so the next wait would re-report a stale change"
         );
     }
@@ -441,53 +456,29 @@ mod tests {
     fn a_disconnected_channel_reports_unusable() {
         let (tx, rx) = sync_channel::<()>(1);
         drop(tx);
-        let mut changes = UiaChanges {
-            rx,
-            live: true,
-            running: Arc::new(AtomicBool::new(true)),
-            alive: Arc::new(AtomicBool::new(true)),
-        };
+        let mut changes = live_changes(rx);
         assert_eq!(
             changes.wait(Duration::from_millis(20)),
             ChangeWait::Unusable
         );
     }
 
-    /// `live` is the sticky half of the contract: once tripped, `wait` must return `Unusable`
-    /// without consulting the channel again — proven here by leaving a message the channel would
-    /// otherwise happily report as `Changed`.
-    #[test]
-    fn once_live_is_false_wait_reports_unusable_even_with_a_message_pending() {
-        let (tx, rx) = sync_channel(1);
-        tx.send(()).unwrap();
-        let mut changes = UiaChanges {
-            rx,
-            live: false,
-            running: Arc::new(AtomicBool::new(true)),
-            alive: Arc::new(AtomicBool::new(true)),
-        };
-        assert_eq!(
-            changes.wait(Duration::from_millis(20)),
-            ChangeWait::Unusable
-        );
-    }
-
-    /// The same shape for `alive`, which carries the opposite direction: the pump telling the
-    /// signal it has gone. It has to be read *before* the channel, because the channel is the
-    /// unreliable half here — UIA holds both senders inside the registered handlers, so a pump
-    /// that exited because its window stopped resolving can leave them undropped indefinitely,
-    /// and every `wait` would keep reporting `Quiet` for a subscription that will never deliver
-    /// again. A message left pending proves the check is not merely the `Disconnected` arm
-    /// wearing a different name.
+    /// `alive` carries the opposite direction to `running`: the pump telling the signal it has
+    /// gone. It has to be read *before* the channel, because the channel is the unreliable half
+    /// here — UIA holds both senders inside the registered handlers, so a pump that exited because
+    /// its window stopped resolving can leave them undropped indefinitely, and every `wait` would
+    /// keep reporting `Quiet` for a subscription that will never deliver again. A message left
+    /// pending proves the check is not merely the `Disconnected` arm wearing a different name.
     #[test]
     fn once_alive_is_cleared_wait_reports_unusable_even_with_a_message_pending() {
         let (tx, rx) = sync_channel(1);
         tx.send(()).unwrap();
         let mut changes = UiaChanges {
-            rx,
-            live: true,
+            signaling: Signaling::Live {
+                rx,
+                alive: Arc::new(AtomicBool::new(false)),
+            },
             running: Arc::new(AtomicBool::new(true)),
-            alive: Arc::new(AtomicBool::new(false)),
         };
         assert_eq!(
             changes.wait(Duration::from_millis(20)),
@@ -500,13 +491,10 @@ mod tests {
     /// UIA provider — would outlive every wait that created it.
     #[test]
     fn dropping_the_signal_clears_running() {
-        let (_tx, rx) = sync_channel(1);
         let running = Arc::new(AtomicBool::new(true));
         let changes = UiaChanges {
-            rx,
-            live: true,
+            signaling: Signaling::Ended,
             running: running.clone(),
-            alive: Arc::new(AtomicBool::new(true)),
         };
         drop(changes);
         assert!(!running.load(Ordering::Relaxed));

--- a/crates/glass-a11y-windows/src/events.rs
+++ b/crates/glass-a11y-windows/src/events.rs
@@ -59,11 +59,11 @@ fn watched() -> Vec<UIProperty> {
         .filter_map(announcing_property)
         .chain(SELECTOR_PROPERTIES)
     {
-        // Duplicates are the rule here, not the exception — a condition and its inverse share an
-        // announcing property, and a selector property can announce a condition too — and they are
-        // not adjacent, so `Vec::dedup` would leave some behind. Order is not preserved for
-        // anything's sake: this is the set of properties to register, and nothing reads the order
-        // it is built in.
+        // A condition and its inverse are announced by the same property, so duplicates are
+        // routine. Membership rather than `Vec::dedup`, which drops only *adjacent* duplicates and
+        // would therefore depend on the order `ElementCondition::ALL` happens to list conditions
+        // in — an order nothing pins. Order does not matter here either way: this is the set of
+        // properties to register, and nothing reads the sequence it was built in.
         if !watched.contains(&p) {
             watched.push(p);
         }

--- a/crates/glass-a11y-windows/src/events.rs
+++ b/crates/glass-a11y-windows/src/events.rs
@@ -1,11 +1,10 @@
 //! UI Automation change notifications, so a wait stops re-walking a tree that has not changed.
 //!
-//! A subscription owns its thread for its whole life. The reader spawns a thread per snapshot and
-//! lets it die; a registration cannot work that way, because it belongs to the COM apartment the
-//! thread initialized and has to outlive any single read.
+//! A registration belongs to the COM apartment its thread initialized, so the pump thread outlives
+//! any single read — unlike the reader's per-snapshot threads.
 //!
-//! Handlers are invoked by UIA on its own RPC threads, not this one — which is why nothing but a
-//! unit crosses the channel (see [`Notify`]).
+//! Handlers run on UIA's own RPC threads, which is why nothing but a unit crosses the channel
+//! (see [`Notify`]).
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -29,10 +28,9 @@ use crate::mapping::WatchedProperty;
 
 /// The one place [`WatchedProperty`] becomes a `uiautomation` type.
 ///
-/// Exhaustive: a new `WatchedProperty` fails to compile here until it is given a UIA property.
-/// That is all the compiler settles — an arm here is not a registration. What the subscription
-/// actually asks UIA for is [`WatchedProperty::ALL`] (see [`watched`]), and keeping *that* in step
-/// with the conditions is a test's job (`mapping.rs`'s `every_announced_property_is_registered`).
+/// Exhaustive, so a new `WatchedProperty` fails to compile here — but an arm is not a
+/// registration: the subscription asks for [`WatchedProperty::ALL`], kept in step with the
+/// conditions by `mapping.rs`'s `every_announced_property_is_registered`.
 const fn uia_property(p: WatchedProperty) -> UIProperty {
     match p {
         WatchedProperty::Name => UIProperty::Name,
@@ -46,71 +44,57 @@ const fn uia_property(p: WatchedProperty) -> UIProperty {
     }
 }
 
-/// The properties registered on the window — the whole of what this subscription asks UIA for.
-/// Built from [`WatchedProperty::ALL`] rather than listed again, so this function cannot drift
-/// from it. `ALL` is itself hand-written; see its doc for what keeps it complete.
+/// The whole of what this subscription asks UIA for. [`WatchedProperty::ALL`] is hand-written;
+/// see its doc for what keeps it complete.
 fn watched() -> [UIProperty; WatchedProperty::ALL.len()] {
     WatchedProperty::ALL.map(uia_property)
 }
 
-/// How long to wait for the pump to establish both registrations. Registration cost scales with
-/// tree size — measured 38ms + 17ms on a 1500-node window — and it is the *caller's* wait budget
-/// being spent, so this is bounded generously but never unbounded: failing to subscribe must cost
-/// a poll, not a hang. It is a caller-visible ceiling, and a wider one than the Linux reader's 2s:
-/// against a provider that never finishes registering, a `wait_for_element` given `timeout_ms:
-/// 500` returns in about 3s, not 500ms.
+/// How long to wait for the pump to establish both registrations, which cost 38ms + 17ms on a
+/// 1500-node window and scale with tree size. Spent from the caller's budget, so it is a visible
+/// ceiling and a wider one than the Linux reader's 2s: against a provider that never finishes
+/// registering, `timeout_ms: 500` returns in about 3s.
 const SUBSCRIBE_TIMEOUT: Duration = Duration::from_secs(3);
 
-/// The per-call limit `bounded_automation` sets, in milliseconds (the unit
-/// `IUIAutomation2::SetTransactionTimeout` itself takes). UIA's default, measured on a Windows
-/// box, is 20000ms, so this is a deliberate 10x tightening — still generous against the slowest
-/// measured call, registration's 38ms + 17ms on a 1500-node window. It bounds one call, not the
-/// whole prelude: `subscribe`'s handshake makes up to three, so three slow-but-succeeding calls
-/// can still expire `SUBSCRIBE_TIMEOUT` first. That case is benign — `subscribe` returns `None`
-/// and the pump, seeing `running == false`, tears down.
+/// The per-call limit `bounded_automation` sets, in the milliseconds
+/// `IUIAutomation2::SetTransactionTimeout` takes. UIA's default is 20000ms, measured on a Windows
+/// box. It bounds one call, not the prelude: `subscribe`'s handshake makes up to three, so three
+/// slow-but-succeeding calls can still expire `SUBSCRIBE_TIMEOUT` first, which is benign.
 const TRANSACTION_TIMEOUT_MS: u32 = 2_000;
 
 /// How long the pump sleeps between `running` checks — a cadence, not the shutdown bound. A
-/// dropped signal is *observed* within this long plus at most one bounded liveness probe, and
-/// teardown then makes two more bounded calls, so shutdown is bounded by that sum
-/// (`SHUTDOWN_CHECK` + 3 × `TRANSACTION_TIMEOUT_MS` at worst), not by this constant alone.
+/// dropped signal is observed within this long plus at most one bounded liveness probe, and
+/// teardown makes two more, so shutdown is bounded by `SHUTDOWN_CHECK` + 3 ×
+/// `TRANSACTION_TIMEOUT_MS` at worst.
 const SHUTDOWN_CHECK: Duration = Duration::from_millis(250);
 
-/// How often the pump confirms a *quiet* registration is still delivering, by re-resolving the
-/// window. Far slower than `SHUTDOWN_CHECK` on purpose: this is a cross-process call into the
-/// target app's own UIA provider, and running it at shutdown-check cadence would spend on
-/// liveness exactly the cost the subscription exists to avoid — and would gate the shutdown-check
-/// promptness above behind a live call on every tick instead of one every couple of seconds.
-/// Nothing else notices a dead registration — the app exiting, or destroying and recreating its
-/// top-level window, stops events without disconnecting either sender — so without this check
-/// `wait` would report `Quiet` for the caller's entire budget instead of `Unusable`, which
-/// licenses skipping a re-read of a tree that is actually changing. A failed probe ends the pump,
-/// and what reaches `wait` is the pump clearing `alive` on its way out, not the senders: UIA holds
-/// those inside the registered handlers until both `remove_*` calls succeed, which is least likely
-/// exactly when the window has stopped resolving. A registration that has delivered recently skips
-/// this probe entirely (see `Notify::delivered`), so this cadence is only ever spent on a
-/// subscription that has actually gone quiet.
+/// How often the pump confirms a *quiet* registration still delivers, by re-resolving the window.
+/// Far slower than `SHUTDOWN_CHECK` because it is a cross-process call into the target app's own
+/// UIA provider. Nothing else notices a dead registration: the app exiting, or destroying and
+/// recreating its top-level window, stops events without disconnecting either sender, so `wait`
+/// would report `Quiet` for the caller's entire budget instead of `Unusable`. What reaches `wait`
+/// is the pump clearing `alive` on its way out, not the senders — UIA holds those inside the
+/// registered handlers until both `remove_*` calls succeed, which is least likely exactly when the
+/// window has stopped resolving. A registration that delivered recently skips the probe entirely
+/// (see `Notify::delivered`).
 const LIVENESS_CHECK: Duration = Duration::from_secs(2);
 
-/// Both handlers report the same thing — that *something* changed — because that is all the wait
-/// needs; it re-reads the tree itself.
+/// Both handlers report only that *something* changed; the wait re-reads the tree itself.
 ///
-/// A `UIElement` must never be sent through this channel. It is apartment-affine and these
-/// handlers run on UIA's RPC threads, not the pump's. Reporting *what* changed is the obvious
-/// improvement and the one that would break it.
+/// A `UIElement` must never be sent through this channel — it is apartment-affine and these
+/// handlers run on UIA's RPC threads. Reporting *what* changed is the obvious improvement and the
+/// one that would break it.
 struct Notify {
     tx: SyncSender<()>,
-    /// Set whenever a handler fires, so the pump can skip a `LIVENESS_CHECK` probe against a
-    /// subscription that just proved itself alive. Relaxed is enough: this is a hint the pump
-    /// reads on its own cadence, and observing it late costs at most one skipped-then-redone
+    /// Set whenever a handler fires, so the pump skips a `LIVENESS_CHECK` probe against a
+    /// subscription that just proved itself alive. Relaxed suffices — observing it late costs one
     /// probe cycle, never a wrong answer.
     delivered: Arc<AtomicBool>,
 }
 
 impl Notify {
-    /// Shared by both handler impls below, so `delivered` and `tx` stay in lockstep — a change
-    /// that reaches one and not the other would make the liveness probe distrust an app that is
-    /// actually still talking.
+    /// Shared by both handler impls so `delivered` and `tx` stay in lockstep — updating one alone
+    /// would make the liveness probe distrust an app that is still talking.
     fn record_and_forward(&self) {
         self.delivered.store(true, Ordering::Relaxed);
         // A full channel already carries "something changed", so dropping this one loses nothing.
@@ -146,15 +130,14 @@ impl CustomPropertyChangedEventHandler for Notify {
 pub(crate) struct UiaChanges {
     rx: Receiver<()>,
     live: bool,
-    /// Cleared on drop to stop the pump, which is what removes the registrations. Without it the
-    /// target app's UIA provider keeps doing work for a subscription nobody holds — degrading the
-    /// app being driven and glass's own walks through it.
+    /// Cleared on drop to stop the pump, which is what removes the registrations. Leaked, the
+    /// target app's provider keeps doing work for a subscription nobody holds.
     running: Arc<AtomicBool>,
-    /// The other direction: set while the pump can still deliver, cleared by the pump on its way
-    /// out (see [`ClearOnExit`]). A dead pump does not reliably disconnect the channel — both
-    /// senders live inside COM objects UIA holds until the two `remove_*` calls succeed, and those
-    /// calls run against a window that has usually just stopped resolving — so this, not
-    /// `RecvTimeoutError::Disconnected`, is what makes "the pump is gone" reach `wait`.
+    /// Set while the pump can still deliver, cleared on its way out (see [`ClearOnExit`]). A dead
+    /// pump does not reliably disconnect the channel — UIA holds both senders inside COM objects
+    /// until the two `remove_*` calls succeed, against a window that has usually just stopped
+    /// resolving — so this, not `RecvTimeoutError::Disconnected`, is what tells `wait` the pump is
+    /// gone.
     alive: Arc<AtomicBool>,
 }
 
@@ -166,18 +149,16 @@ impl Drop for UiaChanges {
 
 impl ChangeSignal for UiaChanges {
     fn wait(&mut self, timeout: Duration) -> ChangeWait {
-        // `alive` is read like `live`, before the channel: once the pump has gone there is nothing
-        // left to deliver, and a message still queued behind it is a change already stale — the
-        // caller re-reads on `Unusable` anyway, so nothing is lost by not reporting it.
+        // Read before the channel: once the pump has gone, a queued message is a stale change and
+        // the caller re-reads on `Unusable` anyway.
         if !self.live || !self.alive.load(Ordering::Relaxed) {
             self.live = false;
             return ChangeWait::Unusable;
         }
         match self.rx.recv_timeout(timeout) {
             Ok(()) => {
-                // One logical change delivers several events — a control and its text peer, and a
-                // structure event alongside a property event for one insertion. Drain: a burst is
-                // one reason to re-read, not one re-read each.
+                // One logical change delivers several events — a control and its text peer, a
+                // structure event alongside a property event. A burst is one reason to re-read.
                 while self.rx.try_recv().is_ok() {}
                 ChangeWait::Changed
             }
@@ -194,8 +175,8 @@ impl ChangeSignal for UiaChanges {
 /// established — the caller then polls exactly as it did before.
 pub(crate) fn subscribe(ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
     let ctx = ctx.clone();
-    // Capacity 1: the receiver only needs to learn that *something* changed, and a full channel
-    // already says that, so a chatty app cannot grow a backlog here.
+    // Capacity 1: a full channel already says "something changed", so a chatty app grows no
+    // backlog here.
     let (tx, rx) = sync_channel(1);
     let (ready_tx, ready_rx) = std::sync::mpsc::channel();
     let running = Arc::new(AtomicBool::new(true));
@@ -222,17 +203,15 @@ pub(crate) fn subscribe(ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
 }
 
 /// Creates the automation object the pump uses, bounding every cross-process call made through it
-/// — registration, the liveness probe, both teardown calls — at `TRANSACTION_TIMEOUT_MS`. Without
-/// that bound a wedged-but-alive provider (busy, not exited) can hold the pump inside a
+/// at `TRANSACTION_TIMEOUT_MS`. Unbounded, a wedged-but-alive provider holds the pump inside a
 /// synchronous COM call indefinitely, since such a call has no clean cancellation.
 ///
-/// The bound belongs to the object, not to the thread, so the pump must use *this* object for
-/// everything. It cannot come from `UIAutomation::new()`: that creates a `CUIAutomation` instance,
-/// and only the separate `CUIAutomation8` coclass implements `IUIAutomation2`, the interface
-/// carrying the knob (Windows 8.1+, so it exists everywhere glass runs). Casting the former to it
-/// fails with `E_NOINTERFACE`, measured on a Windows box. COM is initialized here rather than by
-/// calling `UIAutomation::new()` for its `CoInitializeEx` side effect, which would leave a second,
-/// unbounded automation object with nothing to do.
+/// The bound belongs to the object, so the pump must use *this* one for everything. It cannot come
+/// from `UIAutomation::new()`: that creates a `CUIAutomation` instance, and only the separate
+/// `CUIAutomation8` coclass implements `IUIAutomation2`, which carries the knob (Windows 8.1+).
+/// Casting the former to it fails with `E_NOINTERFACE`, measured on a Windows box. COM is
+/// initialized here rather than via `UIAutomation::new()`'s side effect, which would leave a
+/// second, unbounded automation object with nothing to do.
 #[allow(unsafe_code)]
 fn bounded_automation() -> windows::core::Result<UIAutomation> {
     // SAFETY: `CoInitializeEx` must run on this thread before `CoCreateInstance`, which this
@@ -276,11 +255,10 @@ fn pump(
     // Whichever way this function ends — a failed prelude, a dropped signal, a failed liveness
     // probe, a panic — `wait` learns the pump is gone. Dropped explicitly before teardown below.
     let alive = ClearOnExit(alive);
-    // Initializes COM (MTA) on this thread, which the registrations below belong to. It is also
-    // the only automation object this function may use: the transaction bound lives on the object,
-    // so a call made through any other one is unbounded. Failing to build it is a subscribe
-    // failure like every other early exit here — that costs the caller a resumed poll, where
-    // continuing unbounded would silently drop the one property this exists to add.
+    // Initializes COM (MTA) on this thread and is the only automation object this function may
+    // use — the transaction bound lives on the object, so a call through any other is unbounded.
+    // Failing to build it is a subscribe failure like every other early exit: that costs the caller
+    // a resumed poll, where continuing unbounded would drop the property this exists to add.
     let Ok(automation) = bounded_automation() else {
         let _ = ready.send(false);
         return;
@@ -329,9 +307,8 @@ fn pump(
     while running.load(Ordering::Relaxed) {
         std::thread::sleep(SHUTDOWN_CHECK);
         if delivered.swap(false, Ordering::Relaxed) {
-            // A handler fired since the last check, so the registration just proved itself
-            // alive — probing it now would be pure cost for zero information. Reset the
-            // cadence from here too, so a continuously busy app is never probed at all.
+            // A handler fired since the last check, so the registration just proved itself alive.
+            // Resetting the cadence here means a continuously busy app is never probed at all.
             last_liveness_check = Instant::now();
             continue;
         }
@@ -339,11 +316,9 @@ fn pump(
             continue;
         }
         last_liveness_check = Instant::now();
-        // Deliberately fails toward `Unusable`, not toward retrying: a transient read failure
-        // here costs the caller one resumed poll, exactly today's behaviour without a
-        // subscription at all. Reporting `Quiet` on the same failure would be silently wrong
-        // instead of merely conservative, so a failed probe ends the pump rather than being
-        // retried — the teardown below still runs on the way out.
+        // Fails toward `Unusable`, not toward retrying: a transient read failure costs the caller
+        // one resumed poll, where reporting `Quiet` on it would be silently wrong. Teardown below
+        // still runs on the way out.
         if crate::reader::find_app_window(&automation, ctx).is_err() {
             break;
         }

--- a/crates/glass-a11y-windows/src/events.rs
+++ b/crates/glass-a11y-windows/src/events.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, RecvTimeoutError, SyncSender, sync_channel};
 use std::time::{Duration, Instant};
 
-use glass_core::{AxContext, ChangeSignal, ChangeWait};
+use glass_core::{AxContext, ChangeSignal, ChangeWait, ElementCondition};
 use uiautomation::events::{
     CustomPropertyChangedEventHandler, CustomStructureChangedEventHandler,
     UIPropertyChangedEventHandler, UIStructureChangeEventHandler,
@@ -24,13 +24,14 @@ use windows::Win32::System::Com::{
 };
 use windows::Win32::UI::Accessibility::{CUIAutomation8, IUIAutomation, IUIAutomation2};
 
-use crate::mapping::WatchedProperty;
+use crate::mapping::{SELECTOR_PROPERTIES, WatchedProperty, announcing_property};
 
 /// The one place [`WatchedProperty`] becomes a `uiautomation` type.
 ///
-/// Exhaustive, so a new `WatchedProperty` fails to compile here — but an arm is not a
-/// registration: the subscription asks for [`WatchedProperty::ALL`], kept in step with the
-/// conditions by `mapping.rs`'s `every_announced_property_is_registered`.
+/// Exhaustive, so a new `WatchedProperty` fails to compile here. An arm names the property that
+/// actually gets registered whenever [`watched`] reaches it, so a mis-paired arm registers the
+/// wrong property; `each_watched_property_converts_to_the_uia_property_with_its_id` is what
+/// catches that.
 const fn uia_property(p: WatchedProperty) -> UIProperty {
     match p {
         WatchedProperty::Name => UIProperty::Name,
@@ -38,16 +39,36 @@ const fn uia_property(p: WatchedProperty) -> UIProperty {
         WatchedProperty::IsEnabled => UIProperty::IsEnabled,
         WatchedProperty::IsOffscreen => UIProperty::IsOffscreen,
         WatchedProperty::Value => UIProperty::ValueValue,
+        WatchedProperty::RangeValue => UIProperty::RangeValueValue,
         WatchedProperty::ExpandCollapseState => UIProperty::ExpandCollapseExpandCollapseState,
         WatchedProperty::SelectionItemIsSelected => UIProperty::SelectionItemIsSelected,
         WatchedProperty::ToggleState => UIProperty::ToggleToggleState,
     }
 }
 
-/// The whole of what this subscription asks UIA for. [`WatchedProperty::ALL`] is hand-written;
-/// see its doc for what keeps it complete.
-fn watched() -> [UIProperty; WatchedProperty::ALL.len()] {
-    WatchedProperty::ALL.map(uia_property)
+/// The whole of what this subscription asks UIA for: the property announcing each
+/// [`ElementCondition`], plus the properties selectors match on ([`SELECTOR_PROPERTIES`]).
+///
+/// Derived rather than hand-listed, so `mapping.rs`'s declarations are the thing that decides what
+/// is registered — a condition whose announcing property is wrong now registers the wrong
+/// property, rather than being a claim no code reads.
+fn watched() -> Vec<UIProperty> {
+    let mut watched: Vec<WatchedProperty> = Vec::new();
+    for p in ElementCondition::ALL
+        .into_iter()
+        .filter_map(announcing_property)
+        .chain(SELECTOR_PROPERTIES)
+    {
+        // Duplicates are the rule here, not the exception — a condition and its inverse share an
+        // announcing property, and a selector property can announce a condition too — and they are
+        // not adjacent, so `Vec::dedup` would leave some behind. Order is not preserved for
+        // anything's sake: this is the set of properties to register, and nothing reads the order
+        // it is built in.
+        if !watched.contains(&p) {
+            watched.push(p);
+        }
+    }
+    watched.into_iter().map(uia_property).collect()
 }
 
 /// How long to wait for the pump to establish both registrations, which cost 38ms + 17ms on a

--- a/crates/glass-a11y-windows/src/events.rs
+++ b/crates/glass-a11y-windows/src/events.rs
@@ -10,7 +10,7 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, RecvTimeoutError, SyncSender, sync_channel};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use glass_core::{AxContext, ChangeSignal, ChangeWait};
 use uiautomation::events::{
@@ -42,7 +42,7 @@ const fn uia_property(p: WatchedProperty) -> UIProperty {
 
 /// The properties registered on the window. Built from [`WatchedProperty::ALL`] rather than
 /// listed again here, so there is no second list to fall out of step.
-fn watched() -> [UIProperty; 8] {
+fn watched() -> [UIProperty; WatchedProperty::ALL.len()] {
     WatchedProperty::ALL.map(uia_property)
 }
 
@@ -55,6 +55,15 @@ const SUBSCRIBE_TIMEOUT: Duration = Duration::from_secs(3);
 /// How long the pump sleeps before re-checking whether its signal still exists. Short enough that
 /// a dropped signal frees the thread and its registrations promptly, long enough not to spin.
 const SHUTDOWN_CHECK: Duration = Duration::from_millis(250);
+
+/// How often the pump confirms the registration is still delivering, by re-resolving the window.
+/// Far slower than `SHUTDOWN_CHECK` on purpose: this is a cross-process call against the app glass
+/// is driving, and running it at shutdown-check cadence would spend on liveness exactly the cost
+/// the subscription exists to avoid. Nothing else notices a dead registration — the app exiting,
+/// or destroying and recreating its top-level window, stops events without disconnecting either
+/// sender — so without this check `wait` would report `Quiet` for the caller's entire budget
+/// instead of `Unusable`, which licenses skipping a re-read of a tree that is actually changing.
+const LIVENESS_CHECK: Duration = Duration::from_secs(2);
 
 /// Both handlers report the same thing — that *something* changed — because that is all the wait
 /// needs; it re-reads the tree itself.
@@ -206,8 +215,21 @@ fn pump(
     }
     let _ = ready.send(true);
 
+    let mut last_liveness_check = Instant::now();
     while running.load(Ordering::Relaxed) {
         std::thread::sleep(SHUTDOWN_CHECK);
+        if last_liveness_check.elapsed() < LIVENESS_CHECK {
+            continue;
+        }
+        last_liveness_check = Instant::now();
+        // Deliberately fails toward `Unusable`, not toward retrying: a transient read failure
+        // here costs the caller one resumed poll, exactly today's behaviour without a
+        // subscription at all. Reporting `Quiet` on the same failure would be silently wrong
+        // instead of merely conservative, so a failed probe ends the pump rather than being
+        // retried — the teardown below still runs on the way out.
+        if crate::reader::find_app_window(&automation, ctx).is_err() {
+            break;
+        }
     }
 
     let _ = automation.remove_structure_changed_event_handler(&window, &structure);
@@ -230,5 +252,93 @@ mod tests {
                 "{p:?} converts to a UIProperty with a different id"
             );
         }
+    }
+
+    /// `Quiet` is what licenses a caller to skip re-reading the tree (see `ChangeWait`) — this
+    /// pins the case where that licence is actually earned: nothing arrived, and the signal is
+    /// still trustworthy.
+    #[test]
+    fn no_event_within_the_timeout_reports_quiet() {
+        let (_tx, rx) = sync_channel(1);
+        let mut changes = UiaChanges {
+            rx,
+            live: true,
+            running: Arc::new(AtomicBool::new(true)),
+        };
+        assert_eq!(changes.wait(Duration::from_millis(20)), ChangeWait::Quiet);
+    }
+
+    /// A burst must cost the caller one re-read, not one per queued event — a control and its
+    /// text peer, say, firing together. The return value alone can't tell a drain from a channel
+    /// that only ever held one message, so this also asserts the channel is empty afterward.
+    #[test]
+    fn a_burst_of_events_reports_changed_once_and_leaves_the_channel_drained() {
+        // Capacity here is a test convenience for simulating several pending events at once;
+        // production bounds the real channel to 1 for an unrelated reason (backlog growth).
+        let (tx, rx) = sync_channel(4);
+        tx.send(()).unwrap();
+        tx.send(()).unwrap();
+        tx.send(()).unwrap();
+        let mut changes = UiaChanges {
+            rx,
+            live: true,
+            running: Arc::new(AtomicBool::new(true)),
+        };
+        assert_eq!(changes.wait(Duration::from_millis(20)), ChangeWait::Changed);
+        assert!(
+            changes.rx.try_recv().is_err(),
+            "a queued event survived the drain, so the next wait would re-report a stale change"
+        );
+    }
+
+    /// The subscription itself ended — the stream, not merely the app, went quiet — so the caller
+    /// must resume polling rather than trust a signal that can no longer speak.
+    #[test]
+    fn a_disconnected_channel_reports_unusable() {
+        let (tx, rx) = sync_channel::<()>(1);
+        drop(tx);
+        let mut changes = UiaChanges {
+            rx,
+            live: true,
+            running: Arc::new(AtomicBool::new(true)),
+        };
+        assert_eq!(
+            changes.wait(Duration::from_millis(20)),
+            ChangeWait::Unusable
+        );
+    }
+
+    /// `live` is the sticky half of the contract: once tripped, `wait` must return `Unusable`
+    /// without consulting the channel again — proven here by leaving a message the channel would
+    /// otherwise happily report as `Changed`.
+    #[test]
+    fn once_live_is_false_wait_reports_unusable_even_with_a_message_pending() {
+        let (tx, rx) = sync_channel(1);
+        tx.send(()).unwrap();
+        let mut changes = UiaChanges {
+            rx,
+            live: false,
+            running: Arc::new(AtomicBool::new(true)),
+        };
+        assert_eq!(
+            changes.wait(Duration::from_millis(20)),
+            ChangeWait::Unusable
+        );
+    }
+
+    /// `running` is the only signal that tells the pump to stop and remove its registrations; if
+    /// `Drop` stopped setting it, the pump — and the registrations it holds on the target app's
+    /// UIA provider — would outlive every wait that created it.
+    #[test]
+    fn dropping_the_signal_clears_running() {
+        let (_tx, rx) = sync_channel(1);
+        let running = Arc::new(AtomicBool::new(true));
+        let changes = UiaChanges {
+            rx,
+            live: true,
+            running: running.clone(),
+        };
+        drop(changes);
+        assert!(!running.load(Ordering::Relaxed));
     }
 }

--- a/crates/glass-a11y-windows/src/events.rs
+++ b/crates/glass-a11y-windows/src/events.rs
@@ -363,8 +363,8 @@ fn register_handlers(
     registered
 }
 
-/// Hold the registrations open until the signal is dropped or the window stops resolving, with
-/// `alive` set for exactly that long and cleared before returning.
+/// Hold the registrations open until the signal is dropped or the window stops resolving, and
+/// clear `alive` before returning however that happens.
 ///
 /// Do not inline this back into the pump: `alive` has to be cleared *before* the caller's two
 /// `remove_*` calls, each a cross-process call bounded at `TRANSACTION_TIMEOUT_MS` that a `wait`
@@ -448,9 +448,6 @@ mod tests {
         assert!(rx.try_recv().is_ok());
     }
 
-    /// `Quiet` is what licenses a caller to skip re-reading the tree (see `ChangeWait`) — this
-    /// pins the case where that licence is actually earned: nothing arrived, and the signal is
-    /// still trustworthy.
     /// The registration order that costs the target application something: the structure handler
     /// is already in place when the property handler is refused, so it has to come back off before
     /// the pump gives up — the caller is told `false` and never comes back to remove it.
@@ -507,6 +504,9 @@ mod tests {
         }
     }
 
+    /// `Quiet` is what licenses a caller to skip re-reading the tree (see `ChangeWait`) — this
+    /// pins the case where that licence is actually earned: nothing arrived, and the signal is
+    /// still trustworthy.
     #[test]
     fn no_event_within_the_timeout_reports_quiet() {
         let (_tx, rx) = sync_channel(1);

--- a/crates/glass-a11y-windows/src/events.rs
+++ b/crates/glass-a11y-windows/src/events.rs
@@ -59,11 +59,10 @@ fn watched() -> Vec<UIProperty> {
         .filter_map(announcing_property)
         .chain(SELECTOR_PROPERTIES)
     {
-        // A condition and its inverse are announced by the same property, so duplicates are
-        // routine. Membership rather than `Vec::dedup`, which drops only *adjacent* duplicates and
-        // would therefore depend on the order `ElementCondition::ALL` happens to list conditions
-        // in — an order nothing pins. Order does not matter here either way: this is the set of
-        // properties to register, and nothing reads the sequence it was built in.
+        // A condition and its inverse share a property, so duplicates are routine. Membership
+        // rather than `Vec::dedup`, which drops only *adjacent* ones and would depend on the order
+        // `ElementCondition::ALL` happens to list conditions in. This is a set to register with;
+        // nothing reads the sequence it was built in.
         if !watched.contains(&p) {
             watched.push(p);
         }
@@ -550,12 +549,9 @@ mod tests {
         );
     }
 
-    /// `alive` carries the opposite direction to `running`: the pump telling the signal it has
-    /// gone. It has to be read *before* the channel, because the channel is the unreliable half
-    /// here — UIA holds both senders inside the registered handlers, so a pump that exited because
-    /// its window stopped resolving can leave them undropped indefinitely, and every `wait` would
-    /// keep reporting `Quiet` for a subscription that will never deliver again. A message left
-    /// pending proves the check is not merely the `Disconnected` arm wearing a different name.
+    /// A message left pending is what proves this check is not merely the `Disconnected` arm
+    /// wearing a different name — see `Signaling::alive` for why the channel is the unreliable
+    /// half.
     #[test]
     fn once_alive_is_cleared_wait_reports_unusable_even_with_a_message_pending() {
         let (tx, rx) = sync_channel(1);

--- a/crates/glass-a11y-windows/src/events.rs
+++ b/crates/glass-a11y-windows/src/events.rs
@@ -284,9 +284,6 @@ fn pump(
     running: &AtomicBool,
     alive: &AtomicBool,
 ) {
-    // Whichever way this function ends — a failed prelude, a dropped signal, a failed liveness
-    // probe, a panic — `wait` learns the pump is gone. Dropped explicitly before teardown below.
-    let alive = ClearOnExit(alive);
     // Initializes COM (MTA) on this thread and is the only automation object this function may
     // use — the transaction bound lives on the object, so a call through any other is unbounded.
     // Failing to build it is a subscribe failure like every other early exit: that costs the caller
@@ -306,35 +303,86 @@ fn pump(
         delivered: delivered.clone(),
     }
     .into();
-    if automation
-        .add_structure_changed_event_handler(&window, TreeScope::Subtree, None, &structure)
-        .is_err()
-    {
-        let _ = ready.send(false);
-        return;
-    }
-
     let property: UIPropertyChangedEventHandler = Notify {
         tx,
         delivered: delivered.clone(),
     }
     .into();
-    if automation
-        .add_property_changed_event_handler(
-            &window,
-            TreeScope::Subtree,
-            None,
-            &property,
-            &watched(),
-        )
-        .is_err()
-    {
-        let _ = automation.remove_structure_changed_event_handler(&window, &structure);
-        let _ = ready.send(false);
+    // Nothing is registered unless this returns true, and nothing stays registered if it does not.
+    if !register_handlers(
+        ready,
+        || {
+            automation
+                .add_structure_changed_event_handler(&window, TreeScope::Subtree, None, &structure)
+                .is_ok()
+        },
+        || {
+            automation
+                .add_property_changed_event_handler(
+                    &window,
+                    TreeScope::Subtree,
+                    None,
+                    &property,
+                    &watched(),
+                )
+                .is_ok()
+        },
+        || {
+            let _ = automation.remove_structure_changed_event_handler(&window, &structure);
+        },
+    ) {
         return;
     }
-    let _ = ready.send(true);
 
+    run_until_stopped(&automation, ctx, running, alive, &delivered);
+    let _ = automation.remove_structure_changed_event_handler(&window, &structure);
+    let _ = automation.remove_property_changed_event_handler(&window, &property);
+}
+
+/// Add both handlers, remove the first if the second is refused, and answer `ready` with the
+/// outcome. `true` means both are registered and the caller owns removing them.
+///
+/// The COM calls arrive as closures so that ordering can be exercised without a provider: the
+/// half-registered case — structure handler in place, property handler refused — is the one that
+/// would leave the target application carrying a handler nobody will ever remove, and it is out of
+/// reach of any test that needs a real window.
+fn register_handlers(
+    ready: &std::sync::mpsc::Sender<bool>,
+    add_structure: impl FnOnce() -> bool,
+    add_property: impl FnOnce() -> bool,
+    remove_structure: impl FnOnce(),
+) -> bool {
+    let registered = if !add_structure() {
+        false
+    } else if !add_property() {
+        remove_structure();
+        false
+    } else {
+        true
+    };
+    let _ = ready.send(registered);
+    registered
+}
+
+/// Hold the registrations open until the signal is dropped or the window stops resolving, with
+/// `alive` set for exactly that long and cleared before returning.
+///
+/// Do not inline this back into the pump: `alive` has to be cleared *before* the caller's two
+/// `remove_*` calls, each a cross-process call bounded at `TRANSACTION_TIMEOUT_MS` that a `wait`
+/// must read as `Unusable` rather than `Quiet`. Written inline, that ordering rested on a single
+/// `drop(alive)` line whose deletion still compiled and broke nothing any test could see. The
+/// Linux pump is split from its loop for the same class of reason (see `glass-a11y-linux`'s
+/// `forward`).
+fn run_until_stopped(
+    automation: &UIAutomation,
+    ctx: &AxContext,
+    running: &AtomicBool,
+    alive: &AtomicBool,
+    delivered: &AtomicBool,
+) {
+    // However this function ends — a dropped signal, a failed liveness probe, a panic — `wait`
+    // learns the pump is gone, and learns it before the caller tears the registrations down.
+    let _alive = ClearOnExit(alive);
     let mut last_liveness_check = Instant::now();
     while running.load(Ordering::Relaxed) {
         std::thread::sleep(SHUTDOWN_CHECK);
@@ -349,18 +397,12 @@ fn pump(
         }
         last_liveness_check = Instant::now();
         // Fails toward `Unusable`, not toward retrying: a transient read failure costs the caller
-        // one resumed poll, where reporting `Quiet` on it would be silently wrong. Teardown below
-        // still runs on the way out.
-        if crate::reader::find_app_window(&automation, ctx).is_err() {
+        // one resumed poll, where reporting `Quiet` on it would be silently wrong. The caller's
+        // teardown still runs on the way out.
+        if crate::reader::find_app_window(automation, ctx).is_err() {
             break;
         }
     }
-
-    // Before the removes, not after: each is a cross-process call bounded at seconds, and a `wait`
-    // running through that window must already read `Unusable` rather than `Quiet`.
-    drop(alive);
-    let _ = automation.remove_structure_changed_event_handler(&window, &structure);
-    let _ = automation.remove_property_changed_event_handler(&window, &property);
 }
 
 #[cfg(test)]
@@ -410,6 +452,51 @@ mod tests {
     /// `Quiet` is what licenses a caller to skip re-reading the tree (see `ChangeWait`) — this
     /// pins the case where that licence is actually earned: nothing arrived, and the signal is
     /// still trustworthy.
+    /// The registration order that costs the target application something: the structure handler
+    /// is already in place when the property handler is refused, so it has to come back off before
+    /// the pump gives up — the caller is told `false` and never comes back to remove it.
+    #[test]
+    fn a_refused_property_handler_takes_the_structure_handler_back_off() {
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+        let removes = std::cell::Cell::new(0);
+        let registered = register_handlers(
+            &ready_tx,
+            || true,
+            || false,
+            || removes.set(removes.get() + 1),
+        );
+        assert!(!registered);
+        assert_eq!(
+            removes.get(),
+            1,
+            "the registered structure handler was left on the target application"
+        );
+        assert_eq!(ready_rx.try_recv(), Ok(false));
+    }
+
+    /// The other two shapes, so the remove above is not simply unconditional: nothing to take off
+    /// when the structure handler is what failed, and nothing taken off when both succeed.
+    #[test]
+    fn nothing_is_removed_unless_exactly_one_handler_registered() {
+        let removes = std::cell::Cell::new(0);
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+        assert!(!register_handlers(
+            &ready_tx,
+            || false,
+            || unreachable!("the property handler must not be added after a failed structure add"),
+            || removes.set(removes.get() + 1),
+        ));
+        assert_eq!(ready_rx.try_recv(), Ok(false));
+        assert!(register_handlers(
+            &ready_tx,
+            || true,
+            || true,
+            || removes.set(removes.get() + 1),
+        ));
+        assert_eq!(ready_rx.try_recv(), Ok(true));
+        assert_eq!(removes.get(), 0);
+    }
+
     /// Builds the signal the way `subscribe` does, with the pump still running.
     fn live_changes(rx: Receiver<()>) -> UiaChanges {
         UiaChanges {

--- a/crates/glass-a11y-windows/src/events.rs
+++ b/crates/glass-a11y-windows/src/events.rs
@@ -29,8 +29,10 @@ use crate::mapping::WatchedProperty;
 
 /// The one place [`WatchedProperty`] becomes a `uiautomation` type.
 ///
-/// Exhaustive: a new `WatchedProperty` fails to compile here until it is given a UIA property to
-/// register, which is what stops a condition naming a property the subscription never asks for.
+/// Exhaustive: a new `WatchedProperty` fails to compile here until it is given a UIA property.
+/// That is all the compiler settles — an arm here is not a registration. What the subscription
+/// actually asks UIA for is [`WatchedProperty::ALL`] (see [`watched`]), and keeping *that* in step
+/// with the conditions is a test's job (`mapping.rs`'s `every_announced_property_is_registered`).
 const fn uia_property(p: WatchedProperty) -> UIProperty {
     match p {
         WatchedProperty::Name => UIProperty::Name,
@@ -44,8 +46,9 @@ const fn uia_property(p: WatchedProperty) -> UIProperty {
     }
 }
 
-/// The properties registered on the window. Built from [`WatchedProperty::ALL`] rather than
-/// listed again here, so there is no second list to fall out of step.
+/// The properties registered on the window — the whole of what this subscription asks UIA for.
+/// Built from [`WatchedProperty::ALL`] rather than listed again, so this function cannot drift
+/// from it. `ALL` is itself hand-written; see its doc for what keeps it complete.
 fn watched() -> [UIProperty; WatchedProperty::ALL.len()] {
     WatchedProperty::ALL.map(uia_property)
 }
@@ -53,7 +56,9 @@ fn watched() -> [UIProperty; WatchedProperty::ALL.len()] {
 /// How long to wait for the pump to establish both registrations. Registration cost scales with
 /// tree size — measured 38ms + 17ms on a 1500-node window — and it is the *caller's* wait budget
 /// being spent, so this is bounded generously but never unbounded: failing to subscribe must cost
-/// a poll, not a hang.
+/// a poll, not a hang. It is a caller-visible ceiling, and a wider one than the Linux reader's 2s:
+/// against a provider that never finishes registering, a `wait_for_element` given `timeout_ms:
+/// 500` returns in about 3s, not 500ms.
 const SUBSCRIBE_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// The per-call limit `bounded_automation` sets, in milliseconds (the unit
@@ -79,9 +84,12 @@ const SHUTDOWN_CHECK: Duration = Duration::from_millis(250);
 /// Nothing else notices a dead registration — the app exiting, or destroying and recreating its
 /// top-level window, stops events without disconnecting either sender — so without this check
 /// `wait` would report `Quiet` for the caller's entire budget instead of `Unusable`, which
-/// licenses skipping a re-read of a tree that is actually changing. A registration that has
-/// delivered recently skips this probe entirely (see `Notify::delivered`), so this cadence is
-/// only ever spent on a subscription that has actually gone quiet.
+/// licenses skipping a re-read of a tree that is actually changing. A failed probe ends the pump,
+/// and what reaches `wait` is the pump clearing `alive` on its way out, not the senders: UIA holds
+/// those inside the registered handlers until both `remove_*` calls succeed, which is least likely
+/// exactly when the window has stopped resolving. A registration that has delivered recently skips
+/// this probe entirely (see `Notify::delivered`), so this cadence is only ever spent on a
+/// subscription that has actually gone quiet.
 const LIVENESS_CHECK: Duration = Duration::from_secs(2);
 
 /// Both handlers report the same thing — that *something* changed — because that is all the wait
@@ -142,6 +150,12 @@ pub(crate) struct UiaChanges {
     /// target app's UIA provider keeps doing work for a subscription nobody holds — degrading the
     /// app being driven and glass's own walks through it.
     running: Arc<AtomicBool>,
+    /// The other direction: set while the pump can still deliver, cleared by the pump on its way
+    /// out (see [`ClearOnExit`]). A dead pump does not reliably disconnect the channel — both
+    /// senders live inside COM objects UIA holds until the two `remove_*` calls succeed, and those
+    /// calls run against a window that has usually just stopped resolving — so this, not
+    /// `RecvTimeoutError::Disconnected`, is what makes "the pump is gone" reach `wait`.
+    alive: Arc<AtomicBool>,
 }
 
 impl Drop for UiaChanges {
@@ -152,7 +166,11 @@ impl Drop for UiaChanges {
 
 impl ChangeSignal for UiaChanges {
     fn wait(&mut self, timeout: Duration) -> ChangeWait {
-        if !self.live {
+        // `alive` is read like `live`, before the channel: once the pump has gone there is nothing
+        // left to deliver, and a message still queued behind it is a change already stale — the
+        // caller re-reads on `Unusable` anyway, so nothing is lost by not reporting it.
+        if !self.live || !self.alive.load(Ordering::Relaxed) {
+            self.live = false;
             return ChangeWait::Unusable;
         }
         match self.rx.recv_timeout(timeout) {
@@ -181,8 +199,10 @@ pub(crate) fn subscribe(ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
     let (tx, rx) = sync_channel(1);
     let (ready_tx, ready_rx) = std::sync::mpsc::channel();
     let running = Arc::new(AtomicBool::new(true));
+    let alive = Arc::new(AtomicBool::new(true));
     let pump_running = running.clone();
-    std::thread::spawn(move || pump(&ctx, tx, &ready_tx, &pump_running));
+    let pump_alive = alive.clone();
+    std::thread::spawn(move || pump(&ctx, tx, &ready_tx, &pump_running, &pump_alive));
     // Wait for the registrations to be in place before returning: the caller reads the tree the
     // moment it has a signal, and a change landing before registration would be lost.
     match ready_rx.recv_timeout(SUBSCRIBE_TIMEOUT) {
@@ -190,6 +210,7 @@ pub(crate) fn subscribe(ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
             rx,
             live: true,
             running,
+            alive,
         })),
         // Including the timeout: the pump may still be starting, and nothing else would ever tell
         // it to stop.
@@ -231,6 +252,15 @@ fn bounded_automation() -> windows::core::Result<UIAutomation> {
     Ok(UIAutomation::from(IUIAutomation::from(automation)))
 }
 
+/// Clears an `AtomicBool` however its scope ends: an early return, a normal one, or a panic.
+struct ClearOnExit<'a>(&'a AtomicBool);
+
+impl Drop for ClearOnExit<'_> {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Relaxed);
+    }
+}
+
 /// Register both handlers on the window and hold them until the signal is dropped.
 ///
 /// Every early return either registered nothing or removes what it registered. A half-registered
@@ -241,7 +271,11 @@ fn pump(
     tx: SyncSender<()>,
     ready: &std::sync::mpsc::Sender<bool>,
     running: &AtomicBool,
+    alive: &AtomicBool,
 ) {
+    // Whichever way this function ends — a failed prelude, a dropped signal, a failed liveness
+    // probe, a panic — `wait` learns the pump is gone. Dropped explicitly before teardown below.
+    let alive = ClearOnExit(alive);
     // Initializes COM (MTA) on this thread, which the registrations below belong to. It is also
     // the only automation object this function may use: the transaction bound lives on the object,
     // so a call made through any other one is unbounded. Failing to build it is a subscribe
@@ -315,6 +349,9 @@ fn pump(
         }
     }
 
+    // Before the removes, not after: each is a cross-process call bounded at seconds, and a `wait`
+    // running through that window must already read `Unusable` rather than `Quiet`.
+    drop(alive);
     let _ = automation.remove_structure_changed_event_handler(&window, &structure);
     let _ = automation.remove_property_changed_event_handler(&window, &property);
 }
@@ -373,6 +410,7 @@ mod tests {
             rx,
             live: true,
             running: Arc::new(AtomicBool::new(true)),
+            alive: Arc::new(AtomicBool::new(true)),
         };
         assert_eq!(changes.wait(Duration::from_millis(20)), ChangeWait::Quiet);
     }
@@ -392,6 +430,7 @@ mod tests {
             rx,
             live: true,
             running: Arc::new(AtomicBool::new(true)),
+            alive: Arc::new(AtomicBool::new(true)),
         };
         assert_eq!(changes.wait(Duration::from_millis(20)), ChangeWait::Changed);
         assert!(
@@ -410,6 +449,7 @@ mod tests {
             rx,
             live: true,
             running: Arc::new(AtomicBool::new(true)),
+            alive: Arc::new(AtomicBool::new(true)),
         };
         assert_eq!(
             changes.wait(Duration::from_millis(20)),
@@ -428,6 +468,30 @@ mod tests {
             rx,
             live: false,
             running: Arc::new(AtomicBool::new(true)),
+            alive: Arc::new(AtomicBool::new(true)),
+        };
+        assert_eq!(
+            changes.wait(Duration::from_millis(20)),
+            ChangeWait::Unusable
+        );
+    }
+
+    /// The same shape for `alive`, which carries the opposite direction: the pump telling the
+    /// signal it has gone. It has to be read *before* the channel, because the channel is the
+    /// unreliable half here — UIA holds both senders inside the registered handlers, so a pump
+    /// that exited because its window stopped resolving can leave them undropped indefinitely,
+    /// and every `wait` would keep reporting `Quiet` for a subscription that will never deliver
+    /// again. A message left pending proves the check is not merely the `Disconnected` arm
+    /// wearing a different name.
+    #[test]
+    fn once_alive_is_cleared_wait_reports_unusable_even_with_a_message_pending() {
+        let (tx, rx) = sync_channel(1);
+        tx.send(()).unwrap();
+        let mut changes = UiaChanges {
+            rx,
+            live: true,
+            running: Arc::new(AtomicBool::new(true)),
+            alive: Arc::new(AtomicBool::new(false)),
         };
         assert_eq!(
             changes.wait(Duration::from_millis(20)),
@@ -446,6 +510,7 @@ mod tests {
             rx,
             live: true,
             running: running.clone(),
+            alive: Arc::new(AtomicBool::new(true)),
         };
         drop(changes);
         assert!(!running.load(Ordering::Relaxed));

--- a/crates/glass-a11y-windows/src/events.rs
+++ b/crates/glass-a11y-windows/src/events.rs
@@ -20,6 +20,8 @@ use uiautomation::events::{
 use uiautomation::types::{StructureChangeType, TreeScope, UIProperty};
 use uiautomation::variants::Variant;
 use uiautomation::{UIAutomation, UIElement};
+use windows::Win32::UI::Accessibility::IUIAutomation2;
+use windows::core::Interface;
 
 use crate::mapping::WatchedProperty;
 
@@ -52,9 +54,17 @@ fn watched() -> [UIProperty; WatchedProperty::ALL.len()] {
 /// a poll, not a hang.
 const SUBSCRIBE_TIMEOUT: Duration = Duration::from_secs(3);
 
-/// How long the pump sleeps before re-checking `running`. Bounds only the quiet case: a provider
-/// wedged mid-call has no clean cancellation, so it can stall both a shutdown and the teardown
-/// behind it past this cadence.
+/// The per-call limit `bound_transaction_timeout` sets on `automation`, in milliseconds (the unit
+/// `IUIAutomation2::SetTransactionTimeout` itself takes). Generous against the slowest measured
+/// call — registration's 38ms + 17ms on a 1500-node window is nowhere near it — and strictly below
+/// `SUBSCRIBE_TIMEOUT` (see the test pinning that), so a provider this slow fails the call it's
+/// waiting on rather than expiring the subscribe handshake first.
+const TRANSACTION_TIMEOUT_MS: u32 = 2_000;
+
+/// How long the pump sleeps before re-checking `running`. A dropped signal frees the thread and
+/// its registrations within this long, full stop: `bound_transaction_timeout` caps every
+/// cross-process call the loop makes at `TRANSACTION_TIMEOUT_MS`, so a wedged-but-alive provider
+/// can no longer hold the pump inside a call past that cap.
 const SHUTDOWN_CHECK: Duration = Duration::from_millis(250);
 
 /// How often the pump confirms a *quiet* registration is still delivering, by re-resolving the
@@ -190,6 +200,20 @@ pub(crate) fn subscribe(ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
     }
 }
 
+/// Bounds every cross-process call `automation` makes from here on — registration, the liveness
+/// probe, and both teardown calls — at `TRANSACTION_TIMEOUT_MS`. Without it a wedged-but-alive
+/// provider (busy, not exited) can hold the pump inside a synchronous COM call indefinitely,
+/// since such a call has no clean cancellation; `IUIAutomation2` is where UIA exposes the knob
+/// (Windows 8.1+, so this succeeds on anything glass supports).
+#[allow(unsafe_code)]
+fn bound_transaction_timeout(automation: &UIAutomation) -> windows::core::Result<()> {
+    let automation2: IUIAutomation2 = automation.as_ref().cast()?;
+    // SAFETY: `SetTransactionTimeout` sets a plain `u32` millisecond value with no other
+    // preconditions and no output to alias; `automation2` is a live `IUIAutomation2` — the
+    // `cast` above already validated the interface pointer via `QueryInterface`.
+    unsafe { automation2.SetTransactionTimeout(TRANSACTION_TIMEOUT_MS) }
+}
+
 /// Register both handlers on the window and hold them until the signal is dropped.
 ///
 /// Every early return either registered nothing or removes what it registered. A half-registered
@@ -206,6 +230,15 @@ fn pump(
         let _ = ready.send(false);
         return;
     };
+    // A failed cast or failed set is treated as a subscribe failure, the same as every other
+    // early exit here: proceeding unbounded would silently discard the one property this
+    // exists to add, and reporting failure only costs the caller a poll — the recoverable
+    // direction (see this function's own doc for why the cast can't actually fail on a
+    // supported OS).
+    if bound_transaction_timeout(&automation).is_err() {
+        let _ = ready.send(false);
+        return;
+    }
     let Ok(window) = crate::reader::find_app_window(&automation, ctx) else {
         let _ = ready.send(false);
         return;
@@ -290,6 +323,17 @@ mod tests {
                 "{p:?} converts to a UIProperty with a different id"
             );
         }
+    }
+
+    /// Inverted, a subscription against a slow-but-alive provider would fail at the (3s)
+    /// subscribe handshake instead of at the (2s) call it's waiting on — the wrong point to fail
+    /// at, since the handshake would then time out with no way to tell "never registered" apart
+    /// from "registering, just slowly". Compares the two constants directly, so — unlike every
+    /// other test here, which at least constructs a `UiaChanges` or `Notify` — it touches no type
+    /// this crate defines at all, though it still only compiles under this file's `cfg(windows)`.
+    #[test]
+    fn transaction_timeout_is_below_the_subscribe_timeout() {
+        assert!(Duration::from_millis(u64::from(TRANSACTION_TIMEOUT_MS)) < SUBSCRIBE_TIMEOUT);
     }
 
     /// The pump's skip decision (`delivered.swap` in its loop) needs a live registration on a

--- a/crates/glass-a11y-windows/src/events.rs
+++ b/crates/glass-a11y-windows/src/events.rs
@@ -52,17 +52,22 @@ fn watched() -> [UIProperty; WatchedProperty::ALL.len()] {
 /// a poll, not a hang.
 const SUBSCRIBE_TIMEOUT: Duration = Duration::from_secs(3);
 
-/// How long the pump sleeps before re-checking whether its signal still exists. Short enough that
-/// a dropped signal frees the thread and its registrations promptly, long enough not to spin.
+/// How long the pump sleeps before re-checking `running`. Bounds only the quiet case: a provider
+/// wedged mid-call has no clean cancellation, so it can stall both a shutdown and the teardown
+/// behind it past this cadence.
 const SHUTDOWN_CHECK: Duration = Duration::from_millis(250);
 
-/// How often the pump confirms the registration is still delivering, by re-resolving the window.
-/// Far slower than `SHUTDOWN_CHECK` on purpose: this is a cross-process call against the app glass
-/// is driving, and running it at shutdown-check cadence would spend on liveness exactly the cost
-/// the subscription exists to avoid. Nothing else notices a dead registration — the app exiting,
-/// or destroying and recreating its top-level window, stops events without disconnecting either
-/// sender — so without this check `wait` would report `Quiet` for the caller's entire budget
-/// instead of `Unusable`, which licenses skipping a re-read of a tree that is actually changing.
+/// How often the pump confirms a *quiet* registration is still delivering, by re-resolving the
+/// window. Far slower than `SHUTDOWN_CHECK` on purpose: this is a cross-process call into the
+/// target app's own UIA provider, and running it at shutdown-check cadence would spend on
+/// liveness exactly the cost the subscription exists to avoid — and would gate the shutdown-check
+/// promptness above behind a live call on every tick instead of one every couple of seconds.
+/// Nothing else notices a dead registration — the app exiting, or destroying and recreating its
+/// top-level window, stops events without disconnecting either sender — so without this check
+/// `wait` would report `Quiet` for the caller's entire budget instead of `Unusable`, which
+/// licenses skipping a re-read of a tree that is actually changing. A registration that has
+/// delivered recently skips this probe entirely (see `Notify::delivered`), so this cadence is
+/// only ever spent on a subscription that has actually gone quiet.
 const LIVENESS_CHECK: Duration = Duration::from_secs(2);
 
 /// Both handlers report the same thing — that *something* changed — because that is all the wait
@@ -71,7 +76,25 @@ const LIVENESS_CHECK: Duration = Duration::from_secs(2);
 /// A `UIElement` must never be sent through this channel. It is apartment-affine and these
 /// handlers run on UIA's RPC threads, not the pump's. Reporting *what* changed is the obvious
 /// improvement and the one that would break it.
-struct Notify(SyncSender<()>);
+struct Notify {
+    tx: SyncSender<()>,
+    /// Set whenever a handler fires, so the pump can skip a `LIVENESS_CHECK` probe against a
+    /// subscription that just proved itself alive. Relaxed is enough: this is a hint the pump
+    /// reads on its own cadence, and observing it late costs at most one skipped-then-redone
+    /// probe cycle, never a wrong answer.
+    delivered: Arc<AtomicBool>,
+}
+
+impl Notify {
+    /// Shared by both handler impls below, so `delivered` and `tx` stay in lockstep — a change
+    /// that reaches one and not the other would make the liveness probe distrust an app that is
+    /// actually still talking.
+    fn record_and_forward(&self) {
+        self.delivered.store(true, Ordering::Relaxed);
+        // A full channel already carries "something changed", so dropping this one loses nothing.
+        let _ = self.tx.try_send(());
+    }
+}
 
 impl CustomStructureChangedEventHandler for Notify {
     fn handle(
@@ -80,8 +103,7 @@ impl CustomStructureChangedEventHandler for Notify {
         _change_type: StructureChangeType,
         _runtime_id: Option<&[i32]>,
     ) -> uiautomation::Result<()> {
-        // A full channel already carries "something changed", so dropping this one loses nothing.
-        let _ = self.0.try_send(());
+        self.record_and_forward();
         Ok(())
     }
 }
@@ -93,7 +115,7 @@ impl CustomPropertyChangedEventHandler for Notify {
         _property: UIProperty,
         _new_value: Variant,
     ) -> uiautomation::Result<()> {
-        let _ = self.0.try_send(());
+        self.record_and_forward();
         Ok(())
     }
 }
@@ -189,7 +211,12 @@ fn pump(
         return;
     };
 
-    let structure: UIStructureChangeEventHandler = Notify(tx.clone()).into();
+    let delivered = Arc::new(AtomicBool::new(false));
+    let structure: UIStructureChangeEventHandler = Notify {
+        tx: tx.clone(),
+        delivered: delivered.clone(),
+    }
+    .into();
     if automation
         .add_structure_changed_event_handler(&window, TreeScope::Subtree, None, &structure)
         .is_err()
@@ -198,7 +225,11 @@ fn pump(
         return;
     }
 
-    let property: UIPropertyChangedEventHandler = Notify(tx).into();
+    let property: UIPropertyChangedEventHandler = Notify {
+        tx,
+        delivered: delivered.clone(),
+    }
+    .into();
     if automation
         .add_property_changed_event_handler(
             &window,
@@ -218,6 +249,13 @@ fn pump(
     let mut last_liveness_check = Instant::now();
     while running.load(Ordering::Relaxed) {
         std::thread::sleep(SHUTDOWN_CHECK);
+        if delivered.swap(false, Ordering::Relaxed) {
+            // A handler fired since the last check, so the registration just proved itself
+            // alive — probing it now would be pure cost for zero information. Reset the
+            // cadence from here too, so a continuously busy app is never probed at all.
+            last_liveness_check = Instant::now();
+            continue;
+        }
         if last_liveness_check.elapsed() < LIVENESS_CHECK {
             continue;
         }
@@ -252,6 +290,23 @@ mod tests {
                 "{p:?} converts to a UIProperty with a different id"
             );
         }
+    }
+
+    /// The pump's skip decision (`delivered.swap` in its loop) needs a live registration on a
+    /// real COM thread to exercise, so it is not unit-testable here — only `Notify` itself is:
+    /// this pins that firing a handler both marks `delivered` (what lets the pump skip a probe)
+    /// and still forwards to `tx` (what `UiaChanges::wait` reads), so neither regresses alone.
+    #[test]
+    fn a_fired_handler_marks_delivered_and_still_forwards() {
+        let (tx, rx) = sync_channel(1);
+        let delivered = Arc::new(AtomicBool::new(false));
+        let notify = Notify {
+            tx,
+            delivered: delivered.clone(),
+        };
+        notify.record_and_forward();
+        assert!(delivered.load(Ordering::Relaxed));
+        assert!(rx.try_recv().is_ok());
     }
 
     /// `Quiet` is what licenses a caller to skip re-reading the tree (see `ChangeWait`) — this

--- a/crates/glass-a11y-windows/src/events.rs
+++ b/crates/glass-a11y-windows/src/events.rs
@@ -20,8 +20,10 @@ use uiautomation::events::{
 use uiautomation::types::{StructureChangeType, TreeScope, UIProperty};
 use uiautomation::variants::Variant;
 use uiautomation::{UIAutomation, UIElement};
-use windows::Win32::UI::Accessibility::IUIAutomation2;
-use windows::core::Interface;
+use windows::Win32::System::Com::{
+    CLSCTX_ALL, COINIT_MULTITHREADED, CoCreateInstance, CoInitializeEx,
+};
+use windows::Win32::UI::Accessibility::{CUIAutomation8, IUIAutomation, IUIAutomation2};
 
 use crate::mapping::WatchedProperty;
 
@@ -54,17 +56,19 @@ fn watched() -> [UIProperty; WatchedProperty::ALL.len()] {
 /// a poll, not a hang.
 const SUBSCRIBE_TIMEOUT: Duration = Duration::from_secs(3);
 
-/// The per-call limit `bound_transaction_timeout` sets on `automation`, in milliseconds (the unit
-/// `IUIAutomation2::SetTransactionTimeout` itself takes). Generous against the slowest measured
-/// call — registration's 38ms + 17ms on a 1500-node window is nowhere near it — and strictly below
-/// `SUBSCRIBE_TIMEOUT` (see the test pinning that), so a provider this slow fails the call it's
-/// waiting on rather than expiring the subscribe handshake first.
+/// The per-call limit `bounded_automation` sets, in milliseconds (the unit
+/// `IUIAutomation2::SetTransactionTimeout` itself takes). UIA's default, measured on a Windows
+/// box, is 20000ms, so this is a deliberate 10x tightening — still generous against the slowest
+/// measured call, registration's 38ms + 17ms on a 1500-node window. It bounds one call, not the
+/// whole prelude: `subscribe`'s handshake makes up to three, so three slow-but-succeeding calls
+/// can still expire `SUBSCRIBE_TIMEOUT` first. That case is benign — `subscribe` returns `None`
+/// and the pump, seeing `running == false`, tears down.
 const TRANSACTION_TIMEOUT_MS: u32 = 2_000;
 
-/// How long the pump sleeps before re-checking `running`. A dropped signal frees the thread and
-/// its registrations within this long, full stop: `bound_transaction_timeout` caps every
-/// cross-process call the loop makes at `TRANSACTION_TIMEOUT_MS`, so a wedged-but-alive provider
-/// can no longer hold the pump inside a call past that cap.
+/// How long the pump sleeps between `running` checks — a cadence, not the shutdown bound. A
+/// dropped signal is *observed* within this long plus at most one bounded liveness probe, and
+/// teardown then makes two more bounded calls, so shutdown is bounded by that sum
+/// (`SHUTDOWN_CHECK` + 3 × `TRANSACTION_TIMEOUT_MS` at worst), not by this constant alone.
 const SHUTDOWN_CHECK: Duration = Duration::from_millis(250);
 
 /// How often the pump confirms a *quiet* registration is still delivering, by re-resolving the
@@ -200,18 +204,35 @@ pub(crate) fn subscribe(ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
     }
 }
 
-/// Bounds every cross-process call `automation` makes from here on — registration, the liveness
-/// probe, and both teardown calls — at `TRANSACTION_TIMEOUT_MS`. Without it a wedged-but-alive
-/// provider (busy, not exited) can hold the pump inside a synchronous COM call indefinitely,
-/// since such a call has no clean cancellation; `IUIAutomation2` is where UIA exposes the knob
-/// (Windows 8.1+, so this succeeds on anything glass supports).
+/// Creates the automation object the pump uses, bounding every cross-process call made through it
+/// — registration, the liveness probe, both teardown calls — at `TRANSACTION_TIMEOUT_MS`. Without
+/// that bound a wedged-but-alive provider (busy, not exited) can hold the pump inside a
+/// synchronous COM call indefinitely, since such a call has no clean cancellation.
+///
+/// The bound belongs to the object, not to the thread, so the pump must use *this* object for
+/// everything. It cannot come from `UIAutomation::new()`: that creates a `CUIAutomation` instance,
+/// and only the separate `CUIAutomation8` coclass implements `IUIAutomation2`, the interface
+/// carrying the knob (Windows 8.1+, so it exists everywhere glass runs). Casting the former to it
+/// fails with `E_NOINTERFACE`, measured on a Windows box. COM is initialized here rather than by
+/// calling `UIAutomation::new()` for its `CoInitializeEx` side effect, which would leave a second,
+/// unbounded automation object with nothing to do.
 #[allow(unsafe_code)]
-fn bound_transaction_timeout(automation: &UIAutomation) -> windows::core::Result<()> {
-    let automation2: IUIAutomation2 = automation.as_ref().cast()?;
-    // SAFETY: `SetTransactionTimeout` sets a plain `u32` millisecond value with no other
-    // preconditions and no output to alias; `automation2` is a live `IUIAutomation2` — the
-    // `cast` above already validated the interface pointer via `QueryInterface`.
-    unsafe { automation2.SetTransactionTimeout(TRANSACTION_TIMEOUT_MS) }
+fn bounded_automation() -> windows::core::Result<UIAutomation> {
+    // SAFETY: `CoInitializeEx` must run on this thread before `CoCreateInstance`, which this
+    // ordering gives; all three take only scalars and `'static` constants and borrow nothing.
+    // `CoCreateInstance` hands back an owned interface pointer that `windows` wraps, so there is
+    // nothing to alias or keep alive across the calls, and `SetTransactionTimeout` sets a plain
+    // `u32` millisecond value on that pointer with no output.
+    let automation = unsafe {
+        // MTA, matching what `UIAutomation::new()` establishes; the registrations belong to it.
+        CoInitializeEx(None, COINIT_MULTITHREADED).ok()?;
+        let automation: IUIAutomation2 = CoCreateInstance(&CUIAutomation8, None, CLSCTX_ALL)?;
+        automation.SetTransactionTimeout(TRANSACTION_TIMEOUT_MS)?;
+        automation
+    };
+    // A static upcast, not a `QueryInterface`: `IUIAutomation2` extends `IUIAutomation`, which is
+    // the interface `uiautomation` wraps and drives.
+    Ok(UIAutomation::from(IUIAutomation::from(automation)))
 }
 
 /// Register both handlers on the window and hold them until the signal is dropped.
@@ -225,20 +246,15 @@ fn pump(
     ready: &std::sync::mpsc::Sender<bool>,
     running: &AtomicBool,
 ) {
-    // Initializes COM (MTA) on this thread; the registrations below belong to it.
-    let Ok(automation) = UIAutomation::new() else {
+    // Initializes COM (MTA) on this thread, which the registrations below belong to. It is also
+    // the only automation object this function may use: the transaction bound lives on the object,
+    // so a call made through any other one is unbounded. Failing to build it is a subscribe
+    // failure like every other early exit here — that costs the caller a resumed poll, where
+    // continuing unbounded would silently drop the one property this exists to add.
+    let Ok(automation) = bounded_automation() else {
         let _ = ready.send(false);
         return;
     };
-    // A failed cast or failed set is treated as a subscribe failure, the same as every other
-    // early exit here: proceeding unbounded would silently discard the one property this
-    // exists to add, and reporting failure only costs the caller a poll — the recoverable
-    // direction (see this function's own doc for why the cast can't actually fail on a
-    // supported OS).
-    if bound_transaction_timeout(&automation).is_err() {
-        let _ = ready.send(false);
-        return;
-    }
     let Ok(window) = crate::reader::find_app_window(&automation, ctx) else {
         let _ = ready.send(false);
         return;
@@ -325,12 +341,10 @@ mod tests {
         }
     }
 
-    /// Inverted, a subscription against a slow-but-alive provider would fail at the (3s)
-    /// subscribe handshake instead of at the (2s) call it's waiting on — the wrong point to fail
-    /// at, since the handshake would then time out with no way to tell "never registered" apart
-    /// from "registering, just slowly". Compares the two constants directly, so — unlike every
-    /// other test here, which at least constructs a `UiaChanges` or `Notify` — it touches no type
-    /// this crate defines at all, though it still only compiles under this file's `cfg(windows)`.
+    /// Keeps the per-call bound meaningful against the handshake budget: inverted, even a single
+    /// slow call would expire the subscribe handshake before reaching its own limit, leaving no
+    /// way to tell "never registered" from "registering, just slowly". Calls in sequence can
+    /// still outrun the handshake — that is the prelude's shape, not something this pins.
     #[test]
     fn transaction_timeout_is_below_the_subscribe_timeout() {
         assert!(Duration::from_millis(u64::from(TRANSACTION_TIMEOUT_MS)) < SUBSCRIBE_TIMEOUT);

--- a/crates/glass-a11y-windows/src/events.rs
+++ b/crates/glass-a11y-windows/src/events.rs
@@ -1,0 +1,234 @@
+//! UI Automation change notifications, so a wait stops re-walking a tree that has not changed.
+//!
+//! A subscription owns its thread for its whole life. The reader spawns a thread per snapshot and
+//! lets it die; a registration cannot work that way, because it belongs to the COM apartment the
+//! thread initialized and has to outlive any single read.
+//!
+//! Handlers are invoked by UIA on its own RPC threads, not this one — which is why nothing but a
+//! unit crosses the channel (see [`Notify`]).
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, SyncSender, sync_channel};
+use std::time::Duration;
+
+use glass_core::{AxContext, ChangeSignal, ChangeWait};
+use uiautomation::events::{
+    CustomPropertyChangedEventHandler, CustomStructureChangedEventHandler,
+    UIPropertyChangedEventHandler, UIStructureChangeEventHandler,
+};
+use uiautomation::types::{StructureChangeType, TreeScope, UIProperty};
+use uiautomation::variants::Variant;
+use uiautomation::{UIAutomation, UIElement};
+
+use crate::mapping::WatchedProperty;
+
+/// The one place [`WatchedProperty`] becomes a `uiautomation` type.
+///
+/// Exhaustive: a new `WatchedProperty` fails to compile here until it is given a UIA property to
+/// register, which is what stops a condition naming a property the subscription never asks for.
+const fn uia_property(p: WatchedProperty) -> UIProperty {
+    match p {
+        WatchedProperty::Name => UIProperty::Name,
+        WatchedProperty::HasKeyboardFocus => UIProperty::HasKeyboardFocus,
+        WatchedProperty::IsEnabled => UIProperty::IsEnabled,
+        WatchedProperty::IsOffscreen => UIProperty::IsOffscreen,
+        WatchedProperty::Value => UIProperty::ValueValue,
+        WatchedProperty::ExpandCollapseState => UIProperty::ExpandCollapseExpandCollapseState,
+        WatchedProperty::SelectionItemIsSelected => UIProperty::SelectionItemIsSelected,
+        WatchedProperty::ToggleState => UIProperty::ToggleToggleState,
+    }
+}
+
+/// The properties registered on the window. Built from [`WatchedProperty::ALL`] rather than
+/// listed again here, so there is no second list to fall out of step.
+fn watched() -> [UIProperty; 8] {
+    WatchedProperty::ALL.map(uia_property)
+}
+
+/// How long to wait for the pump to establish both registrations. Registration cost scales with
+/// tree size — measured 38ms + 17ms on a 1500-node window — and it is the *caller's* wait budget
+/// being spent, so this is bounded generously but never unbounded: failing to subscribe must cost
+/// a poll, not a hang.
+const SUBSCRIBE_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// How long the pump sleeps before re-checking whether its signal still exists. Short enough that
+/// a dropped signal frees the thread and its registrations promptly, long enough not to spin.
+const SHUTDOWN_CHECK: Duration = Duration::from_millis(250);
+
+/// Both handlers report the same thing — that *something* changed — because that is all the wait
+/// needs; it re-reads the tree itself.
+///
+/// A `UIElement` must never be sent through this channel. It is apartment-affine and these
+/// handlers run on UIA's RPC threads, not the pump's. Reporting *what* changed is the obvious
+/// improvement and the one that would break it.
+struct Notify(SyncSender<()>);
+
+impl CustomStructureChangedEventHandler for Notify {
+    fn handle(
+        &self,
+        _sender: &UIElement,
+        _change_type: StructureChangeType,
+        _runtime_id: Option<&[i32]>,
+    ) -> uiautomation::Result<()> {
+        // A full channel already carries "something changed", so dropping this one loses nothing.
+        let _ = self.0.try_send(());
+        Ok(())
+    }
+}
+
+impl CustomPropertyChangedEventHandler for Notify {
+    fn handle(
+        &self,
+        _sender: &UIElement,
+        _property: UIProperty,
+        _new_value: Variant,
+    ) -> uiautomation::Result<()> {
+        let _ = self.0.try_send(());
+        Ok(())
+    }
+}
+
+/// A [`ChangeSignal`] fed by UIA event handlers registered on a background thread.
+pub(crate) struct UiaChanges {
+    rx: Receiver<()>,
+    live: bool,
+    /// Cleared on drop to stop the pump, which is what removes the registrations. Without it the
+    /// target app's UIA provider keeps doing work for a subscription nobody holds — degrading the
+    /// app being driven and glass's own walks through it.
+    running: Arc<AtomicBool>,
+}
+
+impl Drop for UiaChanges {
+    fn drop(&mut self) {
+        self.running.store(false, Ordering::Relaxed);
+    }
+}
+
+impl ChangeSignal for UiaChanges {
+    fn wait(&mut self, timeout: Duration) -> ChangeWait {
+        if !self.live {
+            return ChangeWait::Unusable;
+        }
+        match self.rx.recv_timeout(timeout) {
+            Ok(()) => {
+                // One logical change delivers several events — a control and its text peer, and a
+                // structure event alongside a property event for one insertion. Drain: a burst is
+                // one reason to re-read, not one re-read each.
+                while self.rx.try_recv().is_ok() {}
+                ChangeWait::Changed
+            }
+            Err(RecvTimeoutError::Timeout) => ChangeWait::Quiet,
+            Err(RecvTimeoutError::Disconnected) => {
+                self.live = false;
+                ChangeWait::Unusable
+            }
+        }
+    }
+}
+
+/// Subscribe to changes for the window in `ctx`, or `None` if no subscription could be
+/// established — the caller then polls exactly as it did before.
+///
+/// Not yet called: `WindowsA11y::subscribe_changes` wires this in as a follow-up, so nothing in
+/// the crate reaches this (or the rest of the module's production path) until then.
+#[allow(dead_code)]
+pub(crate) fn subscribe(ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
+    let ctx = ctx.clone();
+    // Capacity 1: the receiver only needs to learn that *something* changed, and a full channel
+    // already says that, so a chatty app cannot grow a backlog here.
+    let (tx, rx) = sync_channel(1);
+    let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+    let running = Arc::new(AtomicBool::new(true));
+    let pump_running = running.clone();
+    std::thread::spawn(move || pump(&ctx, tx, &ready_tx, &pump_running));
+    // Wait for the registrations to be in place before returning: the caller reads the tree the
+    // moment it has a signal, and a change landing before registration would be lost.
+    match ready_rx.recv_timeout(SUBSCRIBE_TIMEOUT) {
+        Ok(true) => Some(Box::new(UiaChanges {
+            rx,
+            live: true,
+            running,
+        })),
+        // Including the timeout: the pump may still be starting, and nothing else would ever tell
+        // it to stop.
+        _ => {
+            running.store(false, Ordering::Relaxed);
+            None
+        }
+    }
+}
+
+/// Register both handlers on the window and hold them until the signal is dropped.
+///
+/// Every early return either registered nothing or removes what it registered. A half-registered
+/// subscription that reports failure is the worst case: the caller polls, and the provider still
+/// pays for the handler nobody will remove.
+fn pump(
+    ctx: &AxContext,
+    tx: SyncSender<()>,
+    ready: &std::sync::mpsc::Sender<bool>,
+    running: &AtomicBool,
+) {
+    // Initializes COM (MTA) on this thread; the registrations below belong to it.
+    let Ok(automation) = UIAutomation::new() else {
+        let _ = ready.send(false);
+        return;
+    };
+    let Ok(window) = crate::reader::find_app_window(&automation, ctx) else {
+        let _ = ready.send(false);
+        return;
+    };
+
+    let structure: UIStructureChangeEventHandler = Notify(tx.clone()).into();
+    if automation
+        .add_structure_changed_event_handler(&window, TreeScope::Subtree, None, &structure)
+        .is_err()
+    {
+        let _ = ready.send(false);
+        return;
+    }
+
+    let property: UIPropertyChangedEventHandler = Notify(tx).into();
+    if automation
+        .add_property_changed_event_handler(
+            &window,
+            TreeScope::Subtree,
+            None,
+            &property,
+            &watched(),
+        )
+        .is_err()
+    {
+        let _ = automation.remove_structure_changed_event_handler(&window, &structure);
+        let _ = ready.send(false);
+        return;
+    }
+    let _ = ready.send(true);
+
+    while running.load(Ordering::Relaxed) {
+        std::thread::sleep(SHUTDOWN_CHECK);
+    }
+
+    let _ = automation.remove_structure_changed_event_handler(&window, &structure);
+    let _ = automation.remove_property_changed_event_handler(&window, &property);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The conversion is exhaustive, so nothing can be *missing* — but an arm can still name the
+    /// wrong `UIProperty`, and `IsOffscreen` reading as `IsEnabled` would silently register the
+    /// wrong thing. Comparing ids is what catches a mis-paired arm.
+    #[test]
+    fn each_watched_property_converts_to_the_uia_property_with_its_id() {
+        for p in WatchedProperty::ALL {
+            assert_eq!(
+                uia_property(p) as i32 as u32,
+                p.id(),
+                "{p:?} converts to a UIProperty with a different id"
+            );
+        }
+    }
+}

--- a/crates/glass-a11y-windows/src/lib.rs
+++ b/crates/glass-a11y-windows/src/lib.rs
@@ -7,6 +7,9 @@ pub mod doctor;
 pub mod mapping; // pure UIA->normalized mapping — cross-platform, host-tested
 
 #[cfg(windows)]
+mod events;
+
+#[cfg(windows)]
 mod reader;
 
 #[cfg(windows)]

--- a/crates/glass-a11y-windows/src/mapping.rs
+++ b/crates/glass-a11y-windows/src/mapping.rs
@@ -147,7 +147,7 @@ pub fn format_range_value(v: f64) -> String {
 /// A closed set rather than raw ids, so [`announcing_property`] and [`SELECTOR_PROPERTIES`] can
 /// only name a property this enum carries; with a bare `u32` they could name any number at all.
 /// Carrying a variant is not what registers it: `events.rs` builds its registration list from
-/// those two declarations, and a variant neither of them names is registered nowhere.
+/// those two declarations, so a variant neither of them names is not registered at all.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum WatchedProperty {
     Name,
@@ -159,12 +159,13 @@ pub enum WatchedProperty {
     /// re-read — latency, not a wrong answer.
     IsEnabled,
     IsOffscreen,
-    /// A node's `value` where it comes from `ValuePattern` — an editable control, a combo box.
+    /// A node's `value` where it comes from `ValuePattern`, which the reader reads for an Edit, a
+    /// ComboBox or a Document.
     Value,
     /// The other source of a node's `value`: the reader reads a ProgressBar/Slider/Spinner
-    /// position from `RangeValuePattern`, which announces its own property, so a
-    /// `value_contains` wait on one of those is woken by this and never by
-    /// [`Value`](WatchedProperty::Value).
+    /// position from `RangeValuePattern`, never from `ValuePattern`, and UIA reports a change to it
+    /// under a property id of its own — so a `value_contains` wait on one of those is woken by this
+    /// and never by [`Value`](WatchedProperty::Value).
     RangeValue,
     ExpandCollapseState,
     SelectionItemIsSelected,

--- a/crates/glass-a11y-windows/src/mapping.rs
+++ b/crates/glass-a11y-windows/src/mapping.rs
@@ -142,12 +142,12 @@ pub fn format_range_value(v: f64) -> String {
     format!("{v}")
 }
 
-/// A UIA property the change subscription registers for.
+/// A UIA property the change subscription can register for.
 ///
-/// A closed set rather than raw ids, so [`announcing_property`] can only name a property this enum
-/// carries; with a bare `u32` it could name any number at all. Having a variant is not enough,
-/// though: it also needs a `UIProperty` arm in `events.rs`, which the compiler requires, and an
-/// entry in [`ALL`](WatchedProperty::ALL), which is the list actually registered.
+/// A closed set rather than raw ids, so [`announcing_property`] and [`SELECTOR_PROPERTIES`] can
+/// only name a property this enum carries; with a bare `u32` they could name any number at all.
+/// Carrying a variant is not what registers it: `events.rs` builds its registration list from
+/// those two declarations, and a variant neither of them names is registered nowhere.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum WatchedProperty {
     Name,
@@ -155,37 +155,47 @@ pub enum WatchedProperty {
     /// Registered even though the WinForms controls probed on-box never sent it, reaching UI
     /// Automation through the legacy MSAA bridge; a WPF window probed the same way does announce
     /// it, so removing the registration would break the provider it already works for. Where it is
-    /// not sent, a `condition: "enabled"` wait falls back to `glass_core`'s
-    /// `QUIET_RUNS_BEFORE_REREAD` forced re-read — latency, not a wrong answer.
+    /// not sent, a `condition: "enabled"` wait falls back to `glass_core`'s once-a-second forced
+    /// re-read — latency, not a wrong answer.
     IsEnabled,
     IsOffscreen,
+    /// A node's `value` where it comes from `ValuePattern` — an editable control, a combo box.
     Value,
+    /// The other source of a node's `value`: the reader reads a ProgressBar/Slider/Spinner
+    /// position from `RangeValuePattern`, which announces its own property, so a
+    /// `value_contains` wait on one of those is woken by this and never by
+    /// [`Value`](WatchedProperty::Value).
+    RangeValue,
     ExpandCollapseState,
     SelectionItemIsSelected,
     ToggleState,
 }
 
 impl WatchedProperty {
-    /// Every variant, in the order the subscription registers them.
+    /// Every variant, for the tests that cross-check this enum against UIA's own property ids.
     ///
-    /// Hand-written, and nothing makes a new variant appear here. Two tests carry that weight:
-    /// `all_lists_every_watched_property_exactly_once` catches an entry dropped or listed twice,
-    /// and `every_announced_property_is_registered` catches a condition announced by a property
-    /// this array omits. A variant no condition names and this array omits is caught by neither,
-    /// and costs nothing, since nothing else reads it.
-    pub const ALL: [WatchedProperty; 8] = [
+    /// Not the registration list — `events.rs` derives that from [`announcing_property`] and
+    /// [`SELECTOR_PROPERTIES`] — and nothing reads its order. Hand-written, and nothing makes a new
+    /// variant appear here, so `all_lists_every_watched_property_exactly_once` catches an entry
+    /// dropped or listed twice; a variant missing from it is one those cross-checks silently stop
+    /// covering.
+    pub const ALL: [WatchedProperty; 9] = [
         WatchedProperty::Name,
         WatchedProperty::HasKeyboardFocus,
         WatchedProperty::IsEnabled,
         WatchedProperty::IsOffscreen,
         WatchedProperty::Value,
+        WatchedProperty::RangeValue,
         WatchedProperty::ExpandCollapseState,
         WatchedProperty::SelectionItemIsSelected,
         WatchedProperty::ToggleState,
     ];
 
-    /// The stable UIA property id. Numeric for the same reason [`CONTROL_TYPES`] is: this module
-    /// compiles on every host, and `uiautomation` is a `cfg(windows)` dependency.
+    /// The stable UIA property id, transcribed here independently of `events.rs`'s `UIProperty`
+    /// arms. Nothing calls this at run time: its only consumers are the tests that pair the two
+    /// tables against each other (see `every_watched_property_has_a_distinct_id`). Numeric for the
+    /// same reason [`CONTROL_TYPES`] is: this module compiles on every host, and `uiautomation` is
+    /// a `cfg(windows)` dependency.
     pub const fn id(self) -> u32 {
         match self {
             WatchedProperty::Name => 30005,
@@ -193,6 +203,7 @@ impl WatchedProperty {
             WatchedProperty::IsEnabled => 30010,
             WatchedProperty::IsOffscreen => 30022,
             WatchedProperty::Value => 30045,
+            WatchedProperty::RangeValue => 30047,
             WatchedProperty::ExpandCollapseState => 30070,
             WatchedProperty::SelectionItemIsSelected => 30079,
             WatchedProperty::ToggleState => 30086,
@@ -200,14 +211,27 @@ impl WatchedProperty {
     }
 }
 
+/// The properties a *selector* matches on, which no [`glass_core::ElementCondition`] names.
+///
+/// `name:` matches the element's name, and `value_contains:` its value — which the reader reads
+/// from either the Value or the RangeValue pattern depending on the control, hence two value
+/// properties (see [`RangeValue`](WatchedProperty::RangeValue)). A wait filtered on one of these
+/// still has to wake when it changes, so `events.rs` registers these alongside the properties
+/// [`announcing_property`] names.
+pub const SELECTOR_PROPERTIES: [WatchedProperty; 3] = [
+    WatchedProperty::Name,
+    WatchedProperty::Value,
+    WatchedProperty::RangeValue,
+];
+
 /// The property whose change announces `condition`, or `None` where a structure change does.
 ///
 /// Exhaustive, so a new [`glass_core::ElementCondition`] fails to compile here rather than quietly
-/// answering `None`. The compiler stops there; that the property named is one the subscription
-/// registers is checked by `every_announced_property_is_registered`. Nothing calls this at run
-/// time — the subscription registers [`WatchedProperty::ALL`] wholesale — so it declares the
-/// correspondence for that check to verify, and getting it wrong only makes a wait slow, which is
-/// the kind of regression that ships.
+/// answering `None`. This is half of what the subscription registers — `events.rs` walks every
+/// condition through this function and adds [`SELECTOR_PROPERTIES`] — so an arm naming the wrong
+/// property registers the wrong property, and waits on that condition then fall back to
+/// `glass_core`'s forced re-read: slow rather than wrong, which is the kind of regression that
+/// ships.
 pub const fn announcing_property(
     condition: glass_core::ElementCondition,
 ) -> Option<WatchedProperty> {
@@ -464,8 +488,10 @@ mod tests {
 
     #[test]
     fn every_watched_property_has_a_distinct_id() {
-        // Only this stops two variants carrying the same id, which would silently drop one from
-        // the registration — the ids are hand-written and the type says nothing about them.
+        // `id()` feeds no registration; it exists to be a second, independent transcription of the
+        // ids `events.rs`'s `uia_property` arms name, which is the only thing that makes the
+        // pairing check there discriminating. Two variants sharing an id would let a swapped arm
+        // satisfy that check — and the ids are hand-written, so nothing else would notice.
         let ids: Vec<u32> = WatchedProperty::ALL.iter().map(|p| p.id()).collect();
         let mut sorted = ids.clone();
         sorted.sort_unstable();
@@ -480,7 +506,7 @@ mod tests {
     /// One slot per [`WatchedProperty`] variant. Deliberately not `WatchedProperty::ALL.len()`:
     /// sizing the check off the array under test lets an entry dropped from the *end* shrink the
     /// check along with it and pass.
-    const WATCHED_COUNT: usize = 8;
+    const WATCHED_COUNT: usize = 9;
 
     /// Adding a [`WatchedProperty`] fails to compile in this match, which forces a decision about
     /// where it sits in [`WatchedProperty::ALL`]. Mirrors `glass_core`'s `condition_index`.
@@ -491,17 +517,18 @@ mod tests {
             WatchedProperty::IsEnabled => 2,
             WatchedProperty::IsOffscreen => 3,
             WatchedProperty::Value => 4,
-            WatchedProperty::ExpandCollapseState => 5,
-            WatchedProperty::SelectionItemIsSelected => 6,
-            WatchedProperty::ToggleState => 7,
+            WatchedProperty::RangeValue => 5,
+            WatchedProperty::ExpandCollapseState => 6,
+            WatchedProperty::SelectionItemIsSelected => 7,
+            WatchedProperty::ToggleState => 8,
         }
     }
 
     #[test]
     fn all_lists_every_watched_property_exactly_once() {
-        // `ALL` is the list `events.rs` hands UIA, and it is hand-written: an entry dropped from
-        // it is a property no wait can be woken by, and an entry listed twice registers one
-        // property twice while hiding whichever entry it displaced.
+        // `ALL` is what drives the id cross-checks below, and it is hand-written: a variant
+        // dropped from it is a variant those checks silently stop covering, and one listed twice
+        // hides whichever entry it displaced.
         let mut seen = [false; WATCHED_COUNT];
         for p in WatchedProperty::ALL {
             let i = watched_index(p);
@@ -515,27 +542,16 @@ mod tests {
     }
 
     #[test]
-    fn every_announced_property_is_registered() {
-        // Nothing in the type system joins `announcing_property` to `WatchedProperty::ALL`: a
-        // condition can name a property the subscription never asks UIA for, and every wait on
-        // that condition then falls back to the forced re-read forever, with nothing failing.
-        for c in glass_core::ElementCondition::ALL {
-            if let Some(p) = announcing_property(c) {
-                assert!(
-                    WatchedProperty::ALL.contains(&p),
-                    "{c:?} is announced by {p:?}, which the subscription never registers"
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn the_selector_properties_are_registered_too() {
+    fn the_selector_properties_cover_name_and_both_value_sources() {
         // `name:` and `value_contains:` are selectors, not conditions, so no `ElementCondition`
-        // names them — but a wait matching on either still has to wake when they change, and
-        // nothing in the type system ties a selector to a property the way a condition is tied.
-        assert!(WatchedProperty::ALL.contains(&WatchedProperty::Name));
-        assert!(WatchedProperty::ALL.contains(&WatchedProperty::Value));
+        // names them: `SELECTOR_PROPERTIES` is the hand-written half of what `events.rs`
+        // registers, and only this says what belongs in it. Two value properties, not one,
+        // because the reader has two sources for a node's `value` — `ValuePattern` for an
+        // editable control, `RangeValuePattern` for a ProgressBar/Slider/Spinner — and
+        // `value_contains` matches whichever one the element carries.
+        assert!(SELECTOR_PROPERTIES.contains(&WatchedProperty::Name));
+        assert!(SELECTOR_PROPERTIES.contains(&WatchedProperty::Value));
+        assert!(SELECTOR_PROPERTIES.contains(&WatchedProperty::RangeValue));
     }
 
     #[test]

--- a/crates/glass-a11y-windows/src/mapping.rs
+++ b/crates/glass-a11y-windows/src/mapping.rs
@@ -142,6 +142,40 @@ pub fn format_range_value(v: f64) -> String {
     format!("{v}")
 }
 
+/// The UIA property ids a change subscription registers for.
+///
+/// Numeric for the same reason [`CONTROL_TYPES`] is: this module compiles on every host, and
+/// `uiautomation` is a `cfg(windows)` dependency. `events.rs` converts them to `UIProperty` and
+/// a test there pins the two lists together.
+pub const WATCHED_PROPERTY_IDS: &[u32] = &[
+    30005, // Name — the `name:` selector
+    30008, // HasKeyboardFocus
+    30010, // IsEnabled
+    30022, // IsOffscreen
+    30045, // ValueValue — the `value_contains:` selector
+    30070, // ExpandCollapseExpandCollapseState
+    30079, // SelectionItemIsSelected
+    30086, // ToggleToggleState
+];
+
+/// The UIA property whose change announces `condition`, or `None` where a structure change does.
+///
+/// Exhaustive by construction: a new [`glass_core::ElementCondition`] fails to compile here. That
+/// is the enforcement — a condition nothing announces does not error, it just makes waits slow,
+/// which is the kind of regression that ships.
+pub const fn announcing_property(condition: glass_core::ElementCondition) -> Option<u32> {
+    use glass_core::ElementCondition as C;
+    match condition {
+        C::Appears | C::Disappears => None,
+        C::Enabled | C::Disabled => Some(30010),
+        C::Checked | C::Unchecked => Some(30086),
+        C::Selected | C::Unselected => Some(30079),
+        C::Expanded | C::Collapsed => Some(30070),
+        C::Focused => Some(30008),
+        C::Visible | C::Hidden => Some(30022),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -379,5 +413,39 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn every_conditions_property_is_one_the_subscription_registers() {
+        for c in glass_core::ElementCondition::ALL {
+            if let Some(id) = announcing_property(c) {
+                assert!(
+                    WATCHED_PROPERTY_IDS.contains(&id),
+                    "{c:?} is announced by property {id}, which the subscription does not register"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_selector_properties_are_registered_too() {
+        // `name:` and `value_contains:` are selectors, not conditions, so no `ElementCondition`
+        // names them — but a wait matching on either still has to wake when they change.
+        assert!(WATCHED_PROPERTY_IDS.contains(&30005), "Name");
+        assert!(WATCHED_PROPERTY_IDS.contains(&30045), "ValueValue");
+    }
+
+    #[test]
+    fn appearing_and_vanishing_are_structural_not_properties() {
+        // The structure-changed handler covers these; claiming a property for them would mean
+        // registering one that never fires for the case.
+        assert_eq!(
+            announcing_property(glass_core::ElementCondition::Appears),
+            None
+        );
+        assert_eq!(
+            announcing_property(glass_core::ElementCondition::Disappears),
+            None
+        );
     }
 }

--- a/crates/glass-a11y-windows/src/mapping.rs
+++ b/crates/glass-a11y-windows/src/mapping.rs
@@ -144,21 +144,18 @@ pub fn format_range_value(v: f64) -> String {
 
 /// A UIA property the change subscription registers for.
 ///
-/// A closed set rather than raw ids, so [`announcing_property`] can only name a property this
-/// enum has a variant for; with a bare `u32` it could name any number at all and nothing would
-/// notice. Two further things have to hold, and having a variant is neither of them: the variant
-/// needs a `UIProperty` arm in `events.rs`, which the compiler requires because that match is
-/// exhaustive, and it needs an entry in [`ALL`](WatchedProperty::ALL), which is the list actually
-/// registered.
+/// A closed set rather than raw ids, so [`announcing_property`] can only name a property this enum
+/// carries; with a bare `u32` it could name any number at all. Having a variant is not enough,
+/// though: it also needs a `UIProperty` arm in `events.rs`, which the compiler requires, and an
+/// entry in [`ALL`](WatchedProperty::ALL), which is the list actually registered.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum WatchedProperty {
     Name,
     HasKeyboardFocus,
-    /// Registered even though the WinForms controls probed on-box never sent it: those reach UI
-    /// Automation through the legacy MSAA bridge, which announced structure and name changes but
-    /// not this one. A WPF window, probed the same way, does announce it — so removing the
-    /// registration to tidy up for WinForms would break the provider it already works for. Where
-    /// it is not sent, a `condition: "enabled"` wait falls back to `glass_core`'s
+    /// Registered even though the WinForms controls probed on-box never sent it, reaching UI
+    /// Automation through the legacy MSAA bridge; a WPF window probed the same way does announce
+    /// it, so removing the registration would break the provider it already works for. Where it is
+    /// not sent, a `condition: "enabled"` wait falls back to `glass_core`'s
     /// `QUIET_RUNS_BEFORE_REREAD` forced re-read — latency, not a wrong answer.
     IsEnabled,
     IsOffscreen,
@@ -174,8 +171,8 @@ impl WatchedProperty {
     /// Hand-written, and nothing makes a new variant appear here. Two tests carry that weight:
     /// `all_lists_every_watched_property_exactly_once` catches an entry dropped or listed twice,
     /// and `every_announced_property_is_registered` catches a condition announced by a property
-    /// this array does not carry. A new variant that no condition names and this array omits is
-    /// caught by neither — and costs nothing, since nothing else reads it.
+    /// this array omits. A variant no condition names and this array omits is caught by neither,
+    /// and costs nothing, since nothing else reads it.
     pub const ALL: [WatchedProperty; 8] = [
         WatchedProperty::Name,
         WatchedProperty::HasKeyboardFocus,
@@ -205,13 +202,12 @@ impl WatchedProperty {
 
 /// The property whose change announces `condition`, or `None` where a structure change does.
 ///
-/// Exhaustive, so a new [`glass_core::ElementCondition`] fails to compile here rather than
-/// quietly answering `None`. The compiler stops there: that the property named is one the
-/// subscription registers is checked by `every_announced_property_is_registered`, because
-/// [`WatchedProperty::ALL`] is a hand-written array. Nothing calls this at run time — the
-/// subscription registers `ALL` wholesale — so it declares the correspondence for that check to
-/// verify. Getting it wrong raises no error at run time either: the wait falls back to the forced
-/// re-read and merely gets slow, which is the kind of regression that ships.
+/// Exhaustive, so a new [`glass_core::ElementCondition`] fails to compile here rather than quietly
+/// answering `None`. The compiler stops there; that the property named is one the subscription
+/// registers is checked by `every_announced_property_is_registered`. Nothing calls this at run
+/// time — the subscription registers [`WatchedProperty::ALL`] wholesale — so it declares the
+/// correspondence for that check to verify, and getting it wrong only makes a wait slow, which is
+/// the kind of regression that ships.
 pub const fn announcing_property(
     condition: glass_core::ElementCondition,
 ) -> Option<WatchedProperty> {

--- a/crates/glass-a11y-windows/src/mapping.rs
+++ b/crates/glass-a11y-windows/src/mapping.rs
@@ -142,37 +142,71 @@ pub fn format_range_value(v: f64) -> String {
     format!("{v}")
 }
 
-/// The UIA property ids a change subscription registers for.
+/// A UIA property the change subscription registers for.
 ///
-/// Numeric for the same reason [`CONTROL_TYPES`] is: this module compiles on every host, and
-/// `uiautomation` is a `cfg(windows)` dependency. `events.rs` converts them to `UIProperty` and
-/// a test there pins the two lists together.
-pub const WATCHED_PROPERTY_IDS: &[u32] = &[
-    30005, // Name — the `name:` selector
-    30008, // HasKeyboardFocus
-    30010, // IsEnabled
-    30022, // IsOffscreen
-    30045, // ValueValue — the `value_contains:` selector
-    30070, // ExpandCollapseExpandCollapseState
-    30079, // SelectionItemIsSelected
-    30086, // ToggleToggleState
-];
+/// A closed set rather than raw ids, so the correspondence cannot rot: [`announcing_property`]
+/// must name one of these, and a condition needing a property the subscription does not register
+/// means adding a variant here — which fails to compile in `events.rs`'s conversion until it is
+/// registered there too. With a bare `u32` a new condition could name any number at all and
+/// nothing would notice.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WatchedProperty {
+    Name,
+    HasKeyboardFocus,
+    IsEnabled,
+    IsOffscreen,
+    Value,
+    ExpandCollapseState,
+    SelectionItemIsSelected,
+    ToggleState,
+}
 
-/// The UIA property whose change announces `condition`, or `None` where a structure change does.
+impl WatchedProperty {
+    /// Every variant, in the order the subscription registers them.
+    pub const ALL: [WatchedProperty; 8] = [
+        WatchedProperty::Name,
+        WatchedProperty::HasKeyboardFocus,
+        WatchedProperty::IsEnabled,
+        WatchedProperty::IsOffscreen,
+        WatchedProperty::Value,
+        WatchedProperty::ExpandCollapseState,
+        WatchedProperty::SelectionItemIsSelected,
+        WatchedProperty::ToggleState,
+    ];
+
+    /// The stable UIA property id. Numeric for the same reason [`CONTROL_TYPES`] is: this module
+    /// compiles on every host, and `uiautomation` is a `cfg(windows)` dependency.
+    pub const fn id(self) -> u32 {
+        match self {
+            WatchedProperty::Name => 30005,
+            WatchedProperty::HasKeyboardFocus => 30008,
+            WatchedProperty::IsEnabled => 30010,
+            WatchedProperty::IsOffscreen => 30022,
+            WatchedProperty::Value => 30045,
+            WatchedProperty::ExpandCollapseState => 30070,
+            WatchedProperty::SelectionItemIsSelected => 30079,
+            WatchedProperty::ToggleState => 30086,
+        }
+    }
+}
+
+/// The property whose change announces `condition`, or `None` where a structure change does.
 ///
 /// Exhaustive by construction: a new [`glass_core::ElementCondition`] fails to compile here. That
 /// is the enforcement — a condition nothing announces does not error, it just makes waits slow,
 /// which is the kind of regression that ships.
-pub const fn announcing_property(condition: glass_core::ElementCondition) -> Option<u32> {
+pub const fn announcing_property(
+    condition: glass_core::ElementCondition,
+) -> Option<WatchedProperty> {
     use glass_core::ElementCondition as C;
     match condition {
         C::Appears | C::Disappears => None,
-        C::Enabled | C::Disabled => Some(30010),
-        C::Checked | C::Unchecked => Some(30086),
-        C::Selected | C::Unselected => Some(30079),
-        C::Expanded | C::Collapsed => Some(30070),
-        C::Focused => Some(30008),
-        C::Visible | C::Hidden => Some(30022),
+        C::Enabled | C::Disabled => Some(WatchedProperty::IsEnabled),
+        C::Checked | C::Unchecked => Some(WatchedProperty::ToggleState),
+        C::Selected | C::Unselected => Some(WatchedProperty::SelectionItemIsSelected),
+        C::Expanded | C::Collapsed => Some(WatchedProperty::ExpandCollapseState),
+        C::Focused => Some(WatchedProperty::HasKeyboardFocus),
+        C::Visible | C::Hidden => Some(WatchedProperty::IsOffscreen),
     }
 }
 
@@ -416,23 +450,27 @@ mod tests {
     }
 
     #[test]
-    fn every_conditions_property_is_one_the_subscription_registers() {
-        for c in glass_core::ElementCondition::ALL {
-            if let Some(id) = announcing_property(c) {
-                assert!(
-                    WATCHED_PROPERTY_IDS.contains(&id),
-                    "{c:?} is announced by property {id}, which the subscription does not register"
-                );
-            }
-        }
+    fn every_watched_property_has_a_distinct_id() {
+        // The type stops a condition naming an unregistered property; only this stops two
+        // variants carrying the same id, which would silently drop one from the registration.
+        let ids: Vec<u32> = WatchedProperty::ALL.iter().map(|p| p.id()).collect();
+        let mut sorted = ids.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(
+            sorted.len(),
+            ids.len(),
+            "two WatchedProperty variants share an id: {ids:?}"
+        );
     }
 
     #[test]
     fn the_selector_properties_are_registered_too() {
         // `name:` and `value_contains:` are selectors, not conditions, so no `ElementCondition`
-        // names them — but a wait matching on either still has to wake when they change.
-        assert!(WATCHED_PROPERTY_IDS.contains(&30005), "Name");
-        assert!(WATCHED_PROPERTY_IDS.contains(&30045), "ValueValue");
+        // names them — but a wait matching on either still has to wake when they change, and
+        // nothing in the type system ties a selector to a property the way a condition is tied.
+        assert!(WatchedProperty::ALL.contains(&WatchedProperty::Name));
+        assert!(WatchedProperty::ALL.contains(&WatchedProperty::Value));
     }
 
     #[test]

--- a/crates/glass-a11y-windows/src/mapping.rs
+++ b/crates/glass-a11y-windows/src/mapping.rs
@@ -153,6 +153,12 @@ pub fn format_range_value(v: f64) -> String {
 pub enum WatchedProperty {
     Name,
     HasKeyboardFocus,
+    /// Registered even though a WinForms app never sends it: those controls reach UI Automation
+    /// through the legacy MSAA bridge, which announces structure and name changes but not this
+    /// one. A native provider (WPF, and anything built on AccessKit) does announce it, so
+    /// removing the registration to tidy up for WinForms would break the apps it already works
+    /// for. Where it is not sent, a `condition: "enabled"` wait falls back to `glass_core`'s
+    /// `QUIET_RUNS_BEFORE_REREAD` forced re-read — latency, not a wrong answer.
     IsEnabled,
     IsOffscreen,
     Value,

--- a/crates/glass-a11y-windows/src/mapping.rs
+++ b/crates/glass-a11y-windows/src/mapping.rs
@@ -144,20 +144,21 @@ pub fn format_range_value(v: f64) -> String {
 
 /// A UIA property the change subscription registers for.
 ///
-/// A closed set rather than raw ids, so the correspondence cannot rot: [`announcing_property`]
-/// must name one of these, and a condition needing a property the subscription does not register
-/// means adding a variant here — which fails to compile in `events.rs`'s conversion until it is
-/// registered there too. With a bare `u32` a new condition could name any number at all and
-/// nothing would notice.
+/// A closed set rather than raw ids, so [`announcing_property`] can only name a property this
+/// enum has a variant for; with a bare `u32` it could name any number at all and nothing would
+/// notice. Two further things have to hold, and having a variant is neither of them: the variant
+/// needs a `UIProperty` arm in `events.rs`, which the compiler requires because that match is
+/// exhaustive, and it needs an entry in [`ALL`](WatchedProperty::ALL), which is the list actually
+/// registered.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum WatchedProperty {
     Name,
     HasKeyboardFocus,
-    /// Registered even though a WinForms app never sends it: those controls reach UI Automation
-    /// through the legacy MSAA bridge, which announces structure and name changes but not this
-    /// one. A native provider (WPF, and anything built on AccessKit) does announce it, so
-    /// removing the registration to tidy up for WinForms would break the apps it already works
-    /// for. Where it is not sent, a `condition: "enabled"` wait falls back to `glass_core`'s
+    /// Registered even though the WinForms controls probed on-box never sent it: those reach UI
+    /// Automation through the legacy MSAA bridge, which announced structure and name changes but
+    /// not this one. A WPF window, probed the same way, does announce it — so removing the
+    /// registration to tidy up for WinForms would break the provider it already works for. Where
+    /// it is not sent, a `condition: "enabled"` wait falls back to `glass_core`'s
     /// `QUIET_RUNS_BEFORE_REREAD` forced re-read — latency, not a wrong answer.
     IsEnabled,
     IsOffscreen,
@@ -169,6 +170,12 @@ pub enum WatchedProperty {
 
 impl WatchedProperty {
     /// Every variant, in the order the subscription registers them.
+    ///
+    /// Hand-written, and nothing makes a new variant appear here. Two tests carry that weight:
+    /// `all_lists_every_watched_property_exactly_once` catches an entry dropped or listed twice,
+    /// and `every_announced_property_is_registered` catches a condition announced by a property
+    /// this array does not carry. A new variant that no condition names and this array omits is
+    /// caught by neither — and costs nothing, since nothing else reads it.
     pub const ALL: [WatchedProperty; 8] = [
         WatchedProperty::Name,
         WatchedProperty::HasKeyboardFocus,
@@ -198,9 +205,13 @@ impl WatchedProperty {
 
 /// The property whose change announces `condition`, or `None` where a structure change does.
 ///
-/// Exhaustive by construction: a new [`glass_core::ElementCondition`] fails to compile here. That
-/// is the enforcement — a condition nothing announces does not error, it just makes waits slow,
-/// which is the kind of regression that ships.
+/// Exhaustive, so a new [`glass_core::ElementCondition`] fails to compile here rather than
+/// quietly answering `None`. The compiler stops there: that the property named is one the
+/// subscription registers is checked by `every_announced_property_is_registered`, because
+/// [`WatchedProperty::ALL`] is a hand-written array. Nothing calls this at run time — the
+/// subscription registers `ALL` wholesale — so it declares the correspondence for that check to
+/// verify. Getting it wrong raises no error at run time either: the wait falls back to the forced
+/// re-read and merely gets slow, which is the kind of regression that ships.
 pub const fn announcing_property(
     condition: glass_core::ElementCondition,
 ) -> Option<WatchedProperty> {
@@ -457,8 +468,8 @@ mod tests {
 
     #[test]
     fn every_watched_property_has_a_distinct_id() {
-        // The type stops a condition naming an unregistered property; only this stops two
-        // variants carrying the same id, which would silently drop one from the registration.
+        // Only this stops two variants carrying the same id, which would silently drop one from
+        // the registration — the ids are hand-written and the type says nothing about them.
         let ids: Vec<u32> = WatchedProperty::ALL.iter().map(|p| p.id()).collect();
         let mut sorted = ids.clone();
         sorted.sort_unstable();
@@ -468,6 +479,58 @@ mod tests {
             ids.len(),
             "two WatchedProperty variants share an id: {ids:?}"
         );
+    }
+
+    /// One slot per [`WatchedProperty`] variant. Deliberately not `WatchedProperty::ALL.len()`:
+    /// sizing the check off the array under test lets an entry dropped from the *end* shrink the
+    /// check along with it and pass.
+    const WATCHED_COUNT: usize = 8;
+
+    /// Adding a [`WatchedProperty`] fails to compile in this match, which forces a decision about
+    /// where it sits in [`WatchedProperty::ALL`]. Mirrors `glass_core`'s `condition_index`.
+    const fn watched_index(p: WatchedProperty) -> usize {
+        match p {
+            WatchedProperty::Name => 0,
+            WatchedProperty::HasKeyboardFocus => 1,
+            WatchedProperty::IsEnabled => 2,
+            WatchedProperty::IsOffscreen => 3,
+            WatchedProperty::Value => 4,
+            WatchedProperty::ExpandCollapseState => 5,
+            WatchedProperty::SelectionItemIsSelected => 6,
+            WatchedProperty::ToggleState => 7,
+        }
+    }
+
+    #[test]
+    fn all_lists_every_watched_property_exactly_once() {
+        // `ALL` is the list `events.rs` hands UIA, and it is hand-written: an entry dropped from
+        // it is a property no wait can be woken by, and an entry listed twice registers one
+        // property twice while hiding whichever entry it displaced.
+        let mut seen = [false; WATCHED_COUNT];
+        for p in WatchedProperty::ALL {
+            let i = watched_index(p);
+            assert!(!seen[i], "{p:?} appears twice in WatchedProperty::ALL");
+            seen[i] = true;
+        }
+        assert!(
+            seen.iter().all(|s| *s),
+            "WatchedProperty::ALL is missing a variant"
+        );
+    }
+
+    #[test]
+    fn every_announced_property_is_registered() {
+        // Nothing in the type system joins `announcing_property` to `WatchedProperty::ALL`: a
+        // condition can name a property the subscription never asks UIA for, and every wait on
+        // that condition then falls back to the forced re-read forever, with nothing failing.
+        for c in glass_core::ElementCondition::ALL {
+            if let Some(p) = announcing_property(c) {
+                assert!(
+                    WatchedProperty::ALL.contains(&p),
+                    "{c:?} is announced by {p:?}, which the subscription never registers"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -120,7 +120,7 @@ fn run_snapshot(ctx: &AxContext) -> Result<AxTree> {
 /// `send_pointer`/`window` operate on — so it never enumerates the desktop or queries a peer app's
 /// UIA provider (a foreign provider that blocks cross-process calls on the worker thread could
 /// otherwise wedge the whole snapshot). `element_from_handle` touches only the target's provider.
-fn find_app_window(automation: &UIAutomation, ctx: &AxContext) -> Result<UIElement> {
+pub(crate) fn find_app_window(automation: &UIAutomation, ctx: &AxContext) -> Result<UIElement> {
     let handle = ctx.window_handle.ok_or_else(|| {
         GlassError::AccessibilityUnavailable(
             "no active window handle in the a11y context (the backend adopted no window)".into(),

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -7,8 +7,8 @@ use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use glass_core::{
-    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget, AxTree, GlassError, Result,
-    TruncationLimit, WalkBudget, normalize_description, read_back_confirms,
+    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget, AxTree, ChangeSignal, GlassError,
+    Result, TruncationLimit, WalkBudget, normalize_description, read_back_confirms,
 };
 use uiautomation::patterns::{
     UIExpandCollapsePattern, UIInvokePattern, UIRangeValuePattern, UISelectionItemPattern,
@@ -55,6 +55,13 @@ impl Accessibility for WindowsA11y {
                 "accessibility snapshot timed out (UIA not responding)".into(),
             )),
         }
+    }
+
+    fn subscribe_changes(&mut self, ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
+        // Unlike `snapshot`/`set_value`/`invoke` above there is no timeout wrapper: the
+        // subscription's own thread is the long-lived one, and `subscribe` already bounds how
+        // long it will wait for the registrations to land.
+        crate::events::subscribe(ctx)
     }
 
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -58,7 +58,7 @@ impl Accessibility for WindowsA11y {
     }
 
     fn subscribe_changes(&mut self, ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
-        // Unlike `snapshot`/`set_value`/`invoke` above there is no timeout wrapper: the
+        // Unlike `snapshot` above and `set_value`/`invoke` below there is no timeout wrapper: the
         // subscription's own thread is the long-lived one, and `subscribe` already bounds how
         // long it will wait for the registrations to land.
         crate::events::subscribe(ctx)

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -842,9 +842,11 @@ pub enum ElementCondition {
 }
 
 impl ElementCondition {
-    /// Every condition a wait can be given. Mirrors [`AxRole::ALL`]; a backend that subscribes
-    /// to change notifications derives its registration list from this, so a condition absent
-    /// here would be one nothing announces.
+    /// Every condition a wait can be given. Mirrors [`AxRole::ALL`]. A backend that subscribes to
+    /// change notifications keeps its own registration list rather than deriving one from this;
+    /// what walks this array is that backend's coverage test — `glass-a11y-windows`'s
+    /// `every_announced_property_is_registered` — so a condition absent here is one that check
+    /// silently skips.
     pub const ALL: [ElementCondition; 13] = [
         ElementCondition::Appears,
         ElementCondition::Disappears,
@@ -2422,9 +2424,16 @@ mod tests {
         );
     }
 
-    /// Adding an `ElementCondition` fails to compile in this match, and the array below must then
-    /// grow to match — which is the point: `ALL` is what the Windows subscription derives its
-    /// registration list from, so a condition missing from it would be silently unwaitable.
+    /// One slot per `ElementCondition`. Deliberately not `ElementCondition::ALL.len()`: sizing the
+    /// check off the array under test lets an entry dropped from the *end* shrink the check along
+    /// with it and pass.
+    const CONDITION_COUNT: usize = 13;
+
+    /// Adding an `ElementCondition` fails to compile in this match, which is where it is given its
+    /// slot in [`ElementCondition::ALL`]. The test below then catches an entry dropped from that
+    /// array or listed twice; nothing can force a *new* condition into it, since no test can
+    /// enumerate an enum. That is worth care because `ALL` is what the Windows a11y crate's
+    /// coverage test iterates, so a condition missing from it is one that check silently skips.
     const fn condition_index(c: ElementCondition) -> usize {
         match c {
             ElementCondition::Appears => 0,
@@ -2445,7 +2454,7 @@ mod tests {
 
     #[test]
     fn all_lists_every_condition_exactly_once() {
-        let mut seen = [false; ElementCondition::ALL.len()];
+        let mut seen = [false; CONDITION_COUNT];
         for c in ElementCondition::ALL {
             let i = condition_index(c);
             assert!(!seen[i], "{c:?} appears twice in ElementCondition::ALL");

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -842,6 +842,25 @@ pub enum ElementCondition {
 }
 
 impl ElementCondition {
+    /// Every condition a wait can be given. Mirrors [`AxRole::ALL`]; a backend that subscribes
+    /// to change notifications derives its registration list from this, so a condition absent
+    /// here would be one nothing announces.
+    pub const ALL: [ElementCondition; 13] = [
+        ElementCondition::Appears,
+        ElementCondition::Disappears,
+        ElementCondition::Enabled,
+        ElementCondition::Disabled,
+        ElementCondition::Checked,
+        ElementCondition::Unchecked,
+        ElementCondition::Selected,
+        ElementCondition::Unselected,
+        ElementCondition::Expanded,
+        ElementCondition::Collapsed,
+        ElementCondition::Focused,
+        ElementCondition::Visible,
+        ElementCondition::Hidden,
+    ];
+
     /// Parse from the condition name (case-insensitive). `None` for unknown.
     pub fn from_name(s: &str) -> Option<ElementCondition> {
         use ElementCondition::*;
@@ -2400,6 +2419,41 @@ mod tests {
         assert_eq!(
             normalize_description("save", Some("Save")),
             Some("save".to_string())
+        );
+    }
+
+    /// Adding an `ElementCondition` fails to compile in this match, and the array below must then
+    /// grow to match — which is the point: `ALL` is what the Windows subscription derives its
+    /// registration list from, so a condition missing from it would be silently unwaitable.
+    const fn condition_index(c: ElementCondition) -> usize {
+        match c {
+            ElementCondition::Appears => 0,
+            ElementCondition::Disappears => 1,
+            ElementCondition::Enabled => 2,
+            ElementCondition::Disabled => 3,
+            ElementCondition::Checked => 4,
+            ElementCondition::Unchecked => 5,
+            ElementCondition::Selected => 6,
+            ElementCondition::Unselected => 7,
+            ElementCondition::Expanded => 8,
+            ElementCondition::Collapsed => 9,
+            ElementCondition::Focused => 10,
+            ElementCondition::Visible => 11,
+            ElementCondition::Hidden => 12,
+        }
+    }
+
+    #[test]
+    fn all_lists_every_condition_exactly_once() {
+        let mut seen = [false; 13];
+        for c in ElementCondition::ALL {
+            let i = condition_index(c);
+            assert!(!seen[i], "{c:?} appears twice in ElementCondition::ALL");
+            seen[i] = true;
+        }
+        assert!(
+            seen.iter().all(|s| *s),
+            "ElementCondition::ALL is missing a condition"
         );
     }
 }

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -842,10 +842,10 @@ pub enum ElementCondition {
 }
 
 impl ElementCondition {
-    /// Every condition a wait can be given. Mirrors [`AxRole::ALL`]. A backend that subscribes to
-    /// change notifications walks this array to decide what to subscribe to —
-    /// `glass-a11y-windows` builds the set of UIA properties it registers from it — so a condition
-    /// absent here is one no such backend can be woken by, with nothing to fail.
+    /// Every condition a wait can be given. Mirrors [`AxRole::ALL`]. `glass-a11y-windows` walks
+    /// this array to build the set of UIA properties it registers, so a condition absent here is
+    /// one that backend cannot be woken by, with nothing to fail. Not every subscribing backend
+    /// derives its subscription this way — the AT-SPI reader registers by event class instead.
     pub const ALL: [ElementCondition; 13] = [
         ElementCondition::Appears,
         ElementCondition::Disappears,

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -843,10 +843,9 @@ pub enum ElementCondition {
 
 impl ElementCondition {
     /// Every condition a wait can be given. Mirrors [`AxRole::ALL`]. A backend that subscribes to
-    /// change notifications keeps its own registration list rather than deriving one from this;
-    /// what walks this array is that backend's coverage test — `glass-a11y-windows`'s
-    /// `every_announced_property_is_registered` — so a condition absent here is one that check
-    /// silently skips.
+    /// change notifications walks this array to decide what to subscribe to —
+    /// `glass-a11y-windows` builds the set of UIA properties it registers from it — so a condition
+    /// absent here is one no such backend can be woken by, with nothing to fail.
     pub const ALL: [ElementCondition; 13] = [
         ElementCondition::Appears,
         ElementCondition::Disappears,

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -2445,7 +2445,7 @@ mod tests {
 
     #[test]
     fn all_lists_every_condition_exactly_once() {
-        let mut seen = [false; 13];
+        let mut seen = [false; ElementCondition::ALL.len()];
         for c in ElementCondition::ALL {
             let i = condition_index(c);
             assert!(!seen[i], "{c:?} appears twice in ElementCondition::ALL");

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -396,9 +396,11 @@ impl Glass {
         let mut signal = (params.interval_ms > 0)
             .then(|| self.subscribe_a11y_changes())
             .flatten();
-        // Subscribing costs a round-trip of its own, and it is the caller's budget it spends: a
-        // wait told to give up after 500ms must not take longer because establishing a
-        // subscription was slow.
+        // Subscribing costs a round-trip of its own, and it is the caller's budget it spends, so
+        // the poll loop gets what is left rather than the whole of it. That bounds the polling, not
+        // the call: a reader bounds its own handshake in seconds, and by the time this line runs
+        // that time is already gone — a wait told to give up after 500ms can return later than
+        // that, and `elapsed_ms`, measured from before the subscribe, reports it.
         let remaining = params
             .timeout_ms
             .saturating_sub(started.elapsed().as_millis() as u64);

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -396,11 +396,10 @@ impl Glass {
         let mut signal = (params.interval_ms > 0)
             .then(|| self.subscribe_a11y_changes())
             .flatten();
-        // Subscribing costs a round-trip of its own, and it is the caller's budget it spends, so
-        // the poll loop gets what is left rather than the whole of it. That bounds the polling, not
-        // the call: a reader bounds its own handshake in seconds, and by the time this line runs
-        // that time is already gone — a wait told to give up after 500ms can return later than
-        // that, and `elapsed_ms`, measured from before the subscribe, reports it.
+        // Subscribing spends the caller's budget, so the poll loop gets what is left. That bounds
+        // the polling, not the call: a reader bounds its own handshake in seconds, so a wait told
+        // to give up after 500ms can return later than that. `elapsed_ms` is measured from before
+        // the subscribe and reports it.
         let remaining = params
             .timeout_ms
             .saturating_sub(started.elapsed().as_millis() as u64);

--- a/crates/glass-windows/fixture/a11y_fixture.ps1
+++ b/crates/glass-windows/fixture/a11y_fixture.ps1
@@ -1,0 +1,49 @@
+# WinForms accessibility fixture for the on-box Windows tests.
+#
+# WinForms deliberately: those controls reach UI Automation through the legacy MSAA bridge,
+# which raises structure and name changes but never IsEnabled. That is the provider whose
+# behaviour `onbox_a_wait_for_enabled_falls_back_to_the_forced_reread` pins. A WPF or AccessKit
+# fixture is a *native* UIA provider and would announce the transition, proving the opposite.
+#
+# Interpreted on purpose — no build step, matching the Linux fixtures' .py and unlike the macOS
+# .swift, which needs swiftc. Run: powershell.exe -NoProfile -ExecutionPolicy Bypass -File <this>
+#
+# Timeline from launch: the "Save" button starts disabled and becomes enabled at -EnableAfterSec
+# (default 4s), late enough that a wait started after launch is already running when it flips.
+param([int]$EnableAfterSec = 4)
+
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+
+$form = New-Object System.Windows.Forms.Form
+$form.Text = "glass a11y fixture"
+$form.Size = New-Object System.Drawing.Size(400, 200)
+
+$save = New-Object System.Windows.Forms.Button
+$save.Text = "Save"
+$save.Name = "Save"
+$save.Enabled = $false
+$save.Location = New-Object System.Drawing.Point(20, 20)
+$form.Controls.Add($save)
+
+$note = New-Object System.Windows.Forms.TextBox
+$note.Text = "hello"
+$note.Name = "Note"
+$note.AccessibleName = "Note"
+$note.Location = New-Object System.Drawing.Point(20, 60)
+$form.Controls.Add($note)
+
+$script:tick = 0
+$timer = New-Object System.Windows.Forms.Timer
+$timer.Interval = 1000
+$timer.Add_Tick({
+    $script:tick++
+    if ($script:tick -eq $EnableAfterSec) {
+      # Flushed so a test can correlate the flip with its own timeline.
+      Write-Host "FIXTURE_SAVE_ENABLED"
+      $save.Enabled = $true
+    }
+  })
+$timer.Start()
+
+[System.Windows.Forms.Application]::Run($form)

--- a/crates/glass-windows/fixture/a11y_fixture.ps1
+++ b/crates/glass-windows/fixture/a11y_fixture.ps1
@@ -39,8 +39,6 @@ $timer.Interval = 1000
 $timer.Add_Tick({
     $script:tick++
     if ($script:tick -eq $EnableAfterSec) {
-      # Flushed so a test can correlate the flip with its own timeline.
-      Write-Host "FIXTURE_SAVE_ENABLED"
       $save.Enabled = $true
     }
   })

--- a/crates/glass-windows/fixture/a11y_fixture.ps1
+++ b/crates/glass-windows/fixture/a11y_fixture.ps1
@@ -2,8 +2,8 @@
 #
 # WinForms deliberately: those controls reach UI Automation through the legacy MSAA bridge,
 # which raises structure and name changes but never IsEnabled. That is the provider whose
-# behaviour `onbox_a_wait_for_enabled_falls_back_to_the_forced_reread` pins. A WPF or AccessKit
-# fixture is a *native* UIA provider and would announce the transition, proving the opposite.
+# behaviour `onbox_a_wait_for_enabled_falls_back_to_the_forced_reread` pins. A WPF fixture is a
+# *native* UIA provider and does announce the transition, probed the same way — the opposite case.
 #
 # Interpreted on purpose — no build step, matching the Linux fixtures' .py and unlike the macOS
 # .swift, which needs swiftc. Run: powershell.exe -NoProfile -ExecutionPolicy Bypass -File <this>

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -2025,15 +2025,14 @@ fn winforms_fixture_spec() -> AppSpec {
 ///
 /// A WinForms control becoming enabled announces nothing, so this wait cannot be woken by an
 /// event — it can only be rescued by `QUIET_RUNS_BEFORE_REREAD`'s forced re-read. Both halves
-/// matter: that it still matches is the correctness claim, and that it took more than one walk
-/// to get there is what proves the match came from the fallback and not from a notification. If
-/// the second assertion ever starts failing, the bridge began announcing `IsEnabled` and the
-/// disclosure in `events.rs` and the changelog is stale.
+/// matter: that it still matches is the correctness claim; that it took more than one walk rules
+/// out the wait's first read as the source of the match.
 ///
-/// `walked > 1` only proves the match did not come from the wait's first read — an announced
-/// transition and a forced re-read land close enough together in walk count that this assertion
-/// cannot tell them apart. That WinForms never announces `IsEnabled` is established by the
-/// 2026-07-31 on-box probe, not by this test.
+/// `walked > 1` does not, on its own, prove no event fired — an announced transition and a forced
+/// re-read land close enough together in walk count that this assertion cannot tell them apart.
+/// That WinForms never announces `IsEnabled` comes from the 2026-07-31 on-box probe, not from
+/// this test. If this assertion starts failing, the bridge began announcing `IsEnabled` after
+/// all, and the disclosure in `events.rs` and the changelog is stale.
 #[test]
 #[ignore = "on-box only: needs the interactive desktop session"]
 fn onbox_a_wait_for_enabled_falls_back_to_the_forced_reread() {

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -1724,13 +1724,12 @@ fn onbox_a_signal_more_than_halves_a_quiet_walk_count() {
 
 /// A subscription establishes against a real app, and the wait still answers from its first read.
 ///
-/// Deliberately *not* a test that a signal cannot suppress a match, which is a risk it cannot
-/// reach: `glass_core`'s poll loop ticks before it ever pauses (`run_tick` starts true in
-/// `poll_until_with_pause`), so no `ChangeSignal` is consulted before the first walk — and the
-/// element here is already on screen when the wait starts, so that unconditional walk is what
-/// matches. What can fail for a signal-related reason is the subscription never establishing.
-/// A change arriving *after* the first read is the real risk, and
-/// [`onbox_a_wait_wakes_on_a_late_change_from_another_thread`] is what covers it.
+/// Deliberately *not* a test that a signal cannot suppress a match — a risk it cannot reach.
+/// `glass_core`'s poll loop ticks before it ever pauses (`run_tick` starts true in
+/// `poll_until_with_pause`), so no `ChangeSignal` is consulted before the first walk, and the
+/// element here is already on screen. What can still fail for a signal-related reason is the
+/// subscription never establishing. A change arriving *after* the first read is the real risk;
+/// [`onbox_a_wait_wakes_on_a_late_change_from_another_thread`] covers it.
 #[test]
 #[ignore = "on-box only: needs the interactive desktop session"]
 fn onbox_a_subscription_establishes_and_the_first_read_still_answers() {
@@ -1872,12 +1871,11 @@ fn independent_ctx(handle: i64) -> AxContext {
 /// Puts charmap's Advanced-view checkbox back in the state the test found it in, however the test
 /// ends.
 ///
-/// charmap persists that checkbox across launches, so a run that leaves it open changes what every
-/// later charmap launch's tree holds: an open Advanced view adds an Edit, and two other tests in
-/// this file bind to the *first* `TextField` in the tree. Drives the window through its own UIA
-/// reader rather than the test's `Glass`, so it also works while unwinding from a panic — and
-/// every step is best-effort for the same reason: a restore that panicked during a drop would
-/// abort the process and bury the failure that got us here.
+/// charmap persists that checkbox across launches, so a run leaving it open adds an Edit to every
+/// later launch's tree — and two other tests in this file bind to the *first* `TextField`. Drives
+/// the window through its own UIA reader rather than the test's `Glass`, so it works while
+/// unwinding too; every step is best-effort because a panic inside a drop would abort the process
+/// and bury the failure that got us here.
 struct RestoreAdvancedView {
     handle: i64,
     was_checked: bool,

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -1651,11 +1651,12 @@ fn onbox_a_quiet_wait_stops_re_walking_the_tree() {
     assert!(!out.matched, "the element must not exist");
     // See `Counting`: without this the test could measure polling and pass.
     assert!(subscribed > 0, "no subscription was established");
-    // Four reads in a 3s wait, measured: one at the start, `REREAD_AFTER`'s forced re-reads at
-    // ~1s and ~2s, and one more at the deadline before answering "not found". The same wait
-    // without a signal walked 24 times (see `onbox_a_signal_more_than_halves_a_quiet_walk_count`),
-    // which is interval-paced rather than walk-bound — 24 reads in 3s is ~125ms a cycle, the 100ms
-    // interval plus charmap's own ~20ms walk.
+    // Four reads in a 3s wait, measured: one at the start, then `REREAD_AFTER`'s forced re-reads
+    // and the deadline read, whichever of those the timing lands on. The same wait without a
+    // signal walked 24 times (see `onbox_a_signal_more_than_halves_a_quiet_walk_count`) — 24 reads
+    // is 23 cycles, so ~130ms each: the 100ms interval plus charmap's own walk, interval-paced
+    // rather than walk-bound. The deadline read cannot add to that count, since a run with no
+    // signal ticks every interval and so never reaches the deadline having skipped one.
     assert!(
         walked <= 5,
         "a quiet 3s wait walked {walked} times; the subscription is not suppressing walks"

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -2032,7 +2032,8 @@ fn winforms_fixture_spec() -> AppSpec {
 /// re-read land close enough together in walk count that this assertion cannot tell them apart.
 /// That WinForms never announces `IsEnabled` comes from the 2026-07-31 on-box probe, not from
 /// this test. If this assertion starts failing, the bridge began announcing `IsEnabled` after
-/// all, and the disclosure in `events.rs` and the changelog is stale.
+/// all, and the disclosure on `WatchedProperty::IsEnabled` (`glass-a11y-windows/src/mapping.rs`)
+/// and the changelog entry for it are both stale.
 #[test]
 #[ignore = "on-box only: needs the interactive desktop session"]
 fn onbox_a_wait_for_enabled_falls_back_to_the_forced_reread() {
@@ -2073,6 +2074,7 @@ fn onbox_a_wait_for_enabled_falls_back_to_the_forced_reread() {
     assert!(
         walked > 1,
         "the wait matched in {walked} walk(s), so something woke it — the WinForms bridge is \
-         announcing IsEnabled after all, and the disclosure in events.rs is now wrong"
+         announcing IsEnabled after all, and the disclosure on WatchedProperty::IsEnabled is now \
+         wrong"
     );
 }

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -1993,3 +1993,87 @@ fn onbox_a_wait_wakes_on_a_late_change_from_another_thread() {
         out.elapsed_ms
     );
 }
+
+/// The WinForms fixture, whose "Save" button becomes enabled 4s after launch.
+fn winforms_fixture_spec() -> AppSpec {
+    let script = repo_root().join("crates/glass-windows/fixture/a11y_fixture.ps1");
+    AppSpec {
+        build: None,
+        run: vec![
+            "powershell.exe".to_string(),
+            "-NoProfile".to_string(),
+            "-ExecutionPolicy".to_string(),
+            "Bypass".to_string(),
+            "-File".to_string(),
+            script.to_string_lossy().into_owned(),
+        ],
+        cwd: None,
+        env: vec![],
+        // The hint matters here in a way it does not for Notepad: the window belongs to
+        // `powershell.exe`, so pid-set membership alone would also match a console window.
+        window_hint: Some(WindowHint {
+            title: Some("glass a11y fixture".into()),
+            class: None,
+        }),
+        timeout_ms: 15_000,
+        sandbox: glass_core::SandboxLevel::Off,
+        a11y: false,
+    }
+}
+
+/// The documented cost of the `IsEnabled` gap, asserted rather than described.
+///
+/// A WinForms control becoming enabled announces nothing, so this wait cannot be woken by an
+/// event — it can only be rescued by `QUIET_RUNS_BEFORE_REREAD`'s forced re-read. Both halves
+/// matter: that it still matches is the correctness claim, and that it took more than one walk
+/// to get there is what proves the match came from the fallback and not from a notification. If
+/// the second assertion ever starts failing, the bridge began announcing `IsEnabled` and the
+/// disclosure in `events.rs` and the changelog is stale.
+///
+/// `walked > 1` only proves the match did not come from the wait's first read — an announced
+/// transition and a forced re-read land close enough together in walk count that this assertion
+/// cannot tell them apart. That WinForms never announces `IsEnabled` is established by the
+/// 2026-07-31 on-box probe, not by this test.
+#[test]
+#[ignore = "on-box only: needs the interactive desktop session"]
+fn onbox_a_wait_for_enabled_falls_back_to_the_forced_reread() {
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    dpi_aware_once();
+    let (mut glass, walks, signals) = glass_counting(true);
+    glass
+        .start(&winforms_fixture_spec())
+        .expect("start fixture");
+    std::thread::sleep(Duration::from_millis(1200));
+
+    walks.store(0, std::sync::atomic::Ordering::Relaxed);
+    let out = glass
+        .wait_for_element(&glass_core::WaitElementParams {
+            name: Some("Save".into()),
+            role: None,
+            value_contains: None,
+            condition: glass_core::ElementCondition::Enabled,
+            interval_ms: 100,
+            timeout_ms: 10_000,
+        })
+        .expect("wait");
+    let walked = walks.load(std::sync::atomic::Ordering::Relaxed);
+    let subscribed = signals.load(std::sync::atomic::Ordering::Relaxed);
+    let _ = glass.stop();
+
+    eprintln!("wait for Save to enable: {walked} walks");
+    save_report(
+        "onbox-wait-for-enabled-reread.txt",
+        &format!("wait for Save to enable: {walked} walks\n"),
+    );
+    assert!(subscribed > 0, "no subscription was established");
+    assert!(
+        out.matched,
+        "the forced re-read must still find Save enabled; the subscription must not be able to \
+         make a wait miss a change the platform declined to announce"
+    );
+    assert!(
+        walked > 1,
+        "the wait matched in {walked} walk(s), so something woke it — the WinForms bridge is \
+         announcing IsEnabled after all, and the disclosure in events.rs is now wrong"
+    );
+}

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -15,8 +15,8 @@ use std::time::{Duration, Instant};
 use glass_a11y_windows::WindowsA11y;
 use glass_core::{
     Accessibility, AppSpec, AxContext, AxNode, AxRole, AxTarget, AxTree, Backend, BaselineStore,
-    DescriptionSourcing, Glass, GlassError, KeyEvent, Modifier, MouseButton, Platform,
-    PlatformFactory, PointerEvent, WalkLimits, WindowGeometry, WindowHint, WindowOp,
+    ChangeSignal, DescriptionSourcing, Glass, GlassError, KeyEvent, Modifier, MouseButton,
+    Platform, PlatformFactory, PointerEvent, WalkLimits, WindowGeometry, WindowHint, WindowOp,
     description_census, description_census_report, role_histogram,
 };
 use glass_windows::WindowsPlatform;
@@ -1435,5 +1435,243 @@ fn onbox_role_histogram_probe() {
         described >= 1,
         "no probed app reported a single described node: either every app lost its HelpText, or \
          the reader stopped sourcing it"
+    );
+}
+
+/// The subscription must report a change a real UIA provider actually emitted — not merely
+/// establish itself. Sequential on purpose: subscribe, act, then wait. `set_value` on charmap's
+/// Edit field is the same change `onbox_a11y_set_value` already proves lands.
+#[test]
+#[ignore = "on-box only: needs the interactive desktop session"]
+fn onbox_a11y_subscription_reports_a_real_change() {
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    dpi_aware_once();
+    let mut p = WindowsPlatform::new().expect("WindowsPlatform::new");
+    let geo = p.start_app(&charmap_spec()).expect("start charmap");
+    std::thread::sleep(Duration::from_millis(1500));
+
+    let mut a11y = WindowsA11y::new();
+    let ctx = AxContext {
+        pids: p.app_pids(),
+        window: geo.clone(),
+        window_handle: p.active_window_handle(),
+        a11y_bus_addr: None,
+        limits: WalkLimits::DEFAULT,
+    };
+
+    // Before the first read, as the seam requires: a change landing between a read and the
+    // subscription is announced to nobody.
+    let mut signal = a11y
+        .subscribe_changes(&ctx)
+        .expect("UIA subscription must establish against charmap");
+
+    let tree = a11y.snapshot(&ctx).expect("a11y snapshot");
+    let mut field = None;
+    first_role(&tree.root, AxRole::TextField, &mut field);
+    let field = field.expect("charmap must expose a TextField (Edit)");
+    let target = AxTarget {
+        id: field.id,
+        role: field.role,
+        name: field.name.clone(),
+        bounds: field.bounds,
+        value: field.value.clone(),
+    };
+    a11y.set_value(&ctx, &target, "GLASSEVENT")
+        .expect("set_value on the Edit field");
+
+    let verdict = signal.wait(Duration::from_secs(2));
+    let _ = p.stop_app();
+    assert_eq!(
+        verdict,
+        glass_core::ChangeWait::Changed,
+        "a ValueValue change on a real UIA provider must reach the signal"
+    );
+}
+
+/// The other half, and the one the saving depends on: nothing happening must read as `Quiet`,
+/// not as a change. A signal that reports `Changed` on an idle app costs a walk per interval —
+/// polling, with a subscription's price on top.
+#[test]
+#[ignore = "on-box only: needs the interactive desktop session"]
+fn onbox_a11y_subscription_is_quiet_on_an_idle_app() {
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    dpi_aware_once();
+    let mut p = WindowsPlatform::new().expect("WindowsPlatform::new");
+    let geo = p.start_app(&charmap_spec()).expect("start charmap");
+    std::thread::sleep(Duration::from_millis(1500));
+
+    let mut a11y = WindowsA11y::new();
+    let ctx = AxContext {
+        pids: p.app_pids(),
+        window: geo.clone(),
+        window_handle: p.active_window_handle(),
+        a11y_bus_addr: None,
+        limits: WalkLimits::DEFAULT,
+    };
+    let mut signal = a11y
+        .subscribe_changes(&ctx)
+        .expect("UIA subscription must establish against charmap");
+
+    let verdict = signal.wait(Duration::from_millis(800));
+    let _ = p.stop_app();
+    assert_eq!(
+        verdict,
+        glass_core::ChangeWait::Quiet,
+        "an untouched charmap must not report changes"
+    );
+}
+
+/// Counts the walks a session performs. Wall-clock cannot tell a wait that waited efficiently
+/// from one that walked slowly; only the count separates them.
+///
+/// Forwards every trait method. `subscribe_changes` has a default body, so a forgotten forward
+/// would compile and silently disable the thing this measures — hence the counter on it too.
+struct Counting<A> {
+    inner: A,
+    walks: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    signals: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+}
+
+impl<A: Accessibility> Accessibility for Counting<A> {
+    fn snapshot(&mut self, ctx: &AxContext) -> glass_core::Result<glass_core::AxTree> {
+        self.walks
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.inner.snapshot(ctx)
+    }
+    fn subscribe_changes(&mut self, ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
+        let s = self.inner.subscribe_changes(ctx);
+        if s.is_some() {
+            self.signals
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+        s
+    }
+    fn set_value(
+        &mut self,
+        ctx: &AxContext,
+        target: &AxTarget,
+        text: &str,
+    ) -> glass_core::Result<()> {
+        self.inner.set_value(ctx, target, text)
+    }
+    fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> glass_core::Result<()> {
+        self.inner.invoke(ctx, target)
+    }
+}
+
+/// A `Glass` session whose reader counts walks and subscriptions.
+fn glass_counting() -> (
+    Glass,
+    std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    std::sync::Arc<std::sync::atomic::AtomicUsize>,
+) {
+    let walks = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let signals = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let (w, sg) = (walks.clone(), signals.clone());
+    let factory: PlatformFactory = Box::new(move |_backend| {
+        Ok(Backend {
+            platform: Box::new(WindowsPlatform::new()?),
+            accessibility: Some(Box::new(Counting {
+                inner: WindowsA11y::new(),
+                walks: w.clone(),
+                signals: sg.clone(),
+            })),
+        })
+    });
+    let dir = tempfile::tempdir().expect("tempdir for baseline store");
+    let root = dir.path().join("baselines");
+    std::mem::forget(dir);
+    (
+        Glass::new(factory, "windows".into(), BaselineStore::new(root), 100),
+        walks,
+        signals,
+    )
+}
+
+/// The point of the subscription, measured against a real app: a wait for something that never
+/// happens must stop re-reading the tree. A UIA walk is the most expensive of any backend —
+/// 2360ms for 1500 nodes on the dogfood box — so this is where the saving is largest.
+#[test]
+#[ignore = "on-box only: needs the interactive desktop session"]
+fn onbox_a_quiet_wait_stops_re_walking_the_tree() {
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    dpi_aware_once();
+    let (mut glass, walks, signals) = glass_counting();
+    glass.start(&charmap_spec()).expect("start charmap");
+    std::thread::sleep(Duration::from_millis(1500));
+
+    walks.store(0, std::sync::atomic::Ordering::Relaxed);
+    let out = glass
+        .wait_for_element(&glass_core::WaitElementParams {
+            name: Some("no such element in charmap".into()),
+            role: None,
+            value_contains: None,
+            condition: glass_core::ElementCondition::Appears,
+            interval_ms: 100,
+            timeout_ms: 3_000,
+        })
+        .expect("wait");
+    let walked = walks.load(std::sync::atomic::Ordering::Relaxed);
+    let subscribed = signals.load(std::sync::atomic::Ordering::Relaxed);
+    let _ = glass.stop();
+
+    // Logged: the number is the point of the change.
+    eprintln!("quiet 3s wait at 100ms: {walked} walks");
+    assert!(!out.matched, "the element must not exist");
+    // See `Counting`: without this the test could measure polling and pass.
+    assert!(subscribed > 0, "no subscription was established");
+    // One read at the start plus `QUIET_RUNS_BEFORE_REREAD`'s forced re-read about once a
+    // second. The same wait polling takes many more; a UIA walk is slow enough that the
+    // polling count is itself walk-bound rather than interval-bound.
+    assert!(
+        walked <= 5,
+        "a quiet 3s wait walked {walked} times; the subscription is not suppressing walks"
+    );
+}
+
+/// The risk a subscription creates: a wait that no longer matches, because the signal suppressed
+/// the read that would have found the element. Sequential and assumption-free — the element is
+/// already on screen when the wait starts, so the wait must return on its first read.
+#[test]
+#[ignore = "on-box only: needs the interactive desktop session"]
+fn onbox_a_wait_with_a_signal_still_matches() {
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    dpi_aware_once();
+    let (mut glass, walks, signals) = glass_counting();
+    glass.start(&charmap_spec()).expect("start charmap");
+    std::thread::sleep(Duration::from_millis(1500));
+
+    // Read the label out of the tree rather than hardcoding one: charmap's button wording is a
+    // Windows-version detail, and this test is not about the wording.
+    let tree = glass.a11y_snapshot(None).expect("a11y snapshot");
+    let mut button = None;
+    first_role(&tree.root, AxRole::Button, &mut button);
+    let name = button
+        .and_then(|b| b.name.clone())
+        .expect("charmap exposes a named Button");
+
+    walks.store(0, std::sync::atomic::Ordering::Relaxed);
+    let out = glass
+        .wait_for_element(&glass_core::WaitElementParams {
+            name: Some(name.clone()),
+            role: None,
+            value_contains: None,
+            condition: glass_core::ElementCondition::Appears,
+            interval_ms: 100,
+            timeout_ms: 5_000,
+        })
+        .expect("wait");
+    let walked = walks.load(std::sync::atomic::Ordering::Relaxed);
+    let subscribed = signals.load(std::sync::atomic::Ordering::Relaxed);
+    let _ = glass.stop();
+
+    assert!(subscribed > 0, "no subscription was established");
+    assert!(
+        out.matched,
+        "a wait for {name:?}, already on screen, must match"
+    );
+    assert!(
+        walked <= 2,
+        "an already-satisfied wait took {walked} walks; it should return on the first read"
     );
 }

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -1719,12 +1719,18 @@ fn onbox_a_signal_more_than_halves_a_quiet_walk_count() {
     );
 }
 
-/// The risk a subscription creates: a wait that no longer matches, because the signal suppressed
-/// the read that would have found the element. Sequential and assumption-free — the element is
-/// already on screen when the wait starts, so the wait must return on its first read.
+/// A subscription establishes against a real app, and the wait still answers from its first read.
+///
+/// Deliberately *not* a test that a signal cannot suppress a match, which is a risk it cannot
+/// reach: `glass_core`'s poll loop ticks before it ever pauses (`run_tick` starts true in
+/// `poll_until_with_pause`), so no `ChangeSignal` is consulted before the first walk — and the
+/// element here is already on screen when the wait starts, so that unconditional walk is what
+/// matches. What can fail for a signal-related reason is the subscription never establishing.
+/// A change arriving *after* the first read is the real risk, and
+/// [`onbox_a_wait_wakes_on_a_late_change_from_another_thread`] is what covers it.
 #[test]
 #[ignore = "on-box only: needs the interactive desktop session"]
-fn onbox_a_wait_with_a_signal_still_matches() {
+fn onbox_a_subscription_establishes_and_the_first_read_still_answers() {
     let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     dpi_aware_once();
     let (mut glass, walks, signals) = glass_counting(true);
@@ -1822,7 +1828,7 @@ fn find_charmap_window(expected_pid: u32) -> i64 {
 /// Best-effort on-screen geometry for a raw HWND, via the plain window rect — good enough for
 /// `AxContext::window`, which this path only uses for bounds translation inside a snapshot, never
 /// for a click. Deliberately not `glass_windows`'s own DWM-extended `geometry_of`: that function is
-/// crate-private, and reaching for it would mean this "independent" thread borrowing glass's own
+/// crate-private, and reaching for it would mean this "independent" path borrowing glass's own
 /// window code rather than rediscovering the window on its own.
 fn window_rect_geometry(handle: i64) -> WindowGeometry {
     use windows::Win32::Foundation::RECT;
@@ -1844,6 +1850,56 @@ fn window_rect_geometry(handle: i64) -> WindowGeometry {
         y: rect.top,
         width: (rect.right - rect.left).max(0) as u32,
         height: (rect.bottom - rect.top).max(0) as u32,
+    }
+}
+
+/// The `AxContext` an independent UIA reader needs for a raw charmap HWND: no `Glass` state, just
+/// the window and its rect. Shared by the helper thread below and by [`RestoreAdvancedView`],
+/// which both act on the window without going through the `Glass` session under test.
+fn independent_ctx(handle: i64) -> AxContext {
+    AxContext {
+        pids: vec![],
+        window: window_rect_geometry(handle),
+        window_handle: Some(handle),
+        a11y_bus_addr: None,
+        limits: WalkLimits::DEFAULT,
+    }
+}
+
+/// Puts charmap's Advanced-view checkbox back in the state the test found it in, however the test
+/// ends.
+///
+/// charmap persists that checkbox across launches, so a run that leaves it open changes what every
+/// later charmap launch's tree holds: an open Advanced view adds an Edit, and two other tests in
+/// this file bind to the *first* `TextField` in the tree. Drives the window through its own UIA
+/// reader rather than the test's `Glass`, so it also works while unwinding from a panic — and
+/// every step is best-effort for the same reason: a restore that panicked during a drop would
+/// abort the process and bury the failure that got us here.
+struct RestoreAdvancedView {
+    handle: i64,
+    was_checked: bool,
+}
+
+impl Drop for RestoreAdvancedView {
+    fn drop(&mut self) {
+        let ctx = independent_ctx(self.handle);
+        let mut a11y = WindowsA11y::new();
+        let Ok(tree) = a11y.snapshot(&ctx) else {
+            return;
+        };
+        let mut cb = None;
+        first_role_with_bounds(&tree.root, AxRole::CheckBox, &mut cb);
+        let Some(cb) = cb.filter(|cb| cb.states.checked != self.was_checked) else {
+            return;
+        };
+        let target = AxTarget {
+            id: cb.id,
+            role: cb.role,
+            name: cb.name.clone(),
+            bounds: cb.bounds,
+            value: cb.value.clone(),
+        };
+        let _ = a11y.invoke(&ctx, &target);
     }
 }
 
@@ -1876,13 +1932,21 @@ fn onbox_a_wait_wakes_on_a_late_change_from_another_thread() {
     glass.start(&charmap_spec()).expect("start charmap");
     std::thread::sleep(Duration::from_millis(1500));
 
-    // charmap persists the Advanced-view checkbox's state across launches on this box, so
-    // normalize to closed first: the helper thread's job is to open it, and "Search" must not
-    // already be on screen when the timed wait below starts.
+    let pid = newest_charmap_pid().expect("must find the charmap.exe process this test started");
+    let handle = find_charmap_window(pid);
+
+    // charmap persists the Advanced-view checkbox across launches, so normalize to closed first:
+    // the helper thread's job is to open it, and "Search" must not already be on screen when the
+    // timed wait below starts. The guard puts it back — see [`RestoreAdvancedView`] for what a
+    // stray open Advanced view does to the tests that run after this one.
     let tree = glass.a11y_snapshot(None).expect("initial snapshot");
     let mut cb = None;
     first_role_with_bounds(&tree.root, AxRole::CheckBox, &mut cb);
     let cb = cb.expect("charmap exposes the Advanced-view CheckBox");
+    let restore = RestoreAdvancedView {
+        handle,
+        was_checked: cb.states.checked,
+    };
     if cb.states.checked {
         glass
             .click_element(cb.id)
@@ -1890,21 +1954,12 @@ fn onbox_a_wait_wakes_on_a_late_change_from_another_thread() {
         std::thread::sleep(Duration::from_millis(800));
     }
 
-    let pid = newest_charmap_pid().expect("must find the charmap.exe process this test started");
-    let handle = find_charmap_window(pid);
-
     walks.store(0, std::sync::atomic::Ordering::Relaxed);
     signals.store(0, std::sync::atomic::Ordering::Relaxed);
     let helper = std::thread::spawn(move || {
         std::thread::sleep(Duration::from_millis(1400));
         let mut a11y = WindowsA11y::new();
-        let ctx = AxContext {
-            pids: vec![],
-            window: window_rect_geometry(handle),
-            window_handle: Some(handle),
-            a11y_bus_addr: None,
-            limits: WalkLimits::DEFAULT,
-        };
+        let ctx = independent_ctx(handle);
         let tree = a11y.snapshot(&ctx).expect("helper thread's own snapshot");
         let mut cb = None;
         first_role_with_bounds(&tree.root, AxRole::CheckBox, &mut cb);
@@ -1937,6 +1992,10 @@ fn onbox_a_wait_wakes_on_a_late_change_from_another_thread() {
     let walked = walks.load(std::sync::atomic::Ordering::Relaxed);
     let subscribed = signals.load(std::sync::atomic::Ordering::Relaxed);
     let helper_result = helper.join();
+    // Explicitly before `stop`, which the guard's own drop would otherwise run after: restoring
+    // the checkbox means driving charmap's UI, and a stopped charmap has none. On a panic the
+    // guard drops first anyway, since it was declared after `glass`.
+    drop(restore);
     let _ = glass.stop();
 
     helper_result.expect("helper thread must not panic");

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -1660,11 +1660,10 @@ fn onbox_a_quiet_wait_stops_re_walking_the_tree() {
 }
 
 /// `walked <= 5` above bounds a number, not an improvement — a build that always walked 5 times
-/// regardless of the subscription would still pass it. This runs the identical 3s quiet wait
-/// through two sessions that differ in exactly one thing — whether `subscribe_changes`
-/// ever hands back a working signal (see [`Counting::signal_enabled`]) — and asserts the signalled
-/// run beats the polling one by a clear margin. That margin, not the raw walk count, is the number
-/// worth quoting as the saving.
+/// would pass it. This runs the identical 3s quiet wait through two sessions differing in exactly
+/// one thing, whether `subscribe_changes` hands back a working signal (see
+/// [`Counting::signal_enabled`]). That margin, not the raw walk count, is the saving worth
+/// quoting.
 #[test]
 #[ignore = "on-box only: needs the interactive desktop session"]
 fn onbox_a_signal_more_than_halves_a_quiet_walk_count() {
@@ -1798,14 +1797,11 @@ fn newest_charmap_pid() -> Option<u32> {
     String::from_utf8_lossy(&out.stdout).trim().parse().ok()
 }
 
-/// Find the live "Character Map" window AND verify it belongs to `expected_pid` — the pid of the
-/// charmap.exe this test itself started ([`newest_charmap_pid`]), obtained independently of
-/// `Glass`. [`find_window_by_title`] alone binds by title only, exactly like glass's own discovery
-/// does NOT (glass adopts by pid-set/handle); a stale charmap.exe left behind by an earlier test
-/// could otherwise win the title lookup, and the helper thread would toggle the wrong window's
-/// checkbox — read by the main thread's `wait_for_element` as a plain 5s timeout, with nothing in
-/// the failure pointing at a leaked process as the cause. Panics with the mismatched pids named,
-/// rather than let that failure mode reach the caller as an unexplained timeout.
+/// Find the live "Character Map" window and verify it belongs to `expected_pid`, the charmap.exe
+/// this test started ([`newest_charmap_pid`]). [`find_window_by_title`] binds by title alone, so a
+/// stale charmap.exe left by an earlier test could win the lookup and the helper thread would
+/// toggle the wrong window — reaching the caller as an unexplained 5s timeout. Panics with both
+/// pids named instead.
 fn find_charmap_window(expected_pid: u32) -> i64 {
     use windows::Win32::UI::WindowsAndMessaging::GetWindowThreadProcessId;
     let handle = find_window_by_title("Character Map")
@@ -1851,42 +1847,26 @@ fn window_rect_geometry(handle: i64) -> WindowGeometry {
     }
 }
 
-/// The tests above prove correctness without a late change
-/// (`onbox_a_wait_with_a_signal_still_matches`, already on screen) and cost without a match (the
-/// quiet-wait tests), but none of them ever drives `ChangeWait::Changed => true` inside
-/// `Glass::wait_for_element`'s poll loop (`session/wait.rs`) from a change nothing but a real UIA
-/// event produced. This does: the main thread blocks in `wait_for_element` for a control that does
-/// not exist yet; a helper thread — its own `WindowsA11y`, its own `AxContext`, the target window
-/// found and pid-verified independently of the `Glass` session (see [`find_charmap_window`]), so no
-/// `Glass` state crosses threads — sleeps, then actuates charmap's Advanced-view checkbox directly.
-/// Opening it reveals a "Search" [`AxRole::Button`] (confirmed by a one-off on-box probe: closed=26
-/// nodes, open=37; "Search" was the one newly-appeared control with a name unique to itself, unlike
-/// the panel's other new controls, which repeat labels — "Character set", "Group by" — that already
-/// exist elsewhere in charmap's tree).
+/// The only test that drives `ChangeWait::Changed => true` inside `Glass::wait_for_element`'s poll
+/// loop from a change nothing but a real UIA event produced. The main thread blocks waiting for a
+/// control that does not exist yet; a helper thread — its own `WindowsA11y`, its own `AxContext`,
+/// the window pid-verified independently (see [`find_charmap_window`]), so no `Glass` state crosses
+/// threads — sleeps, then actuates charmap's Advanced-view checkbox. Opening it reveals a "Search"
+/// [`AxRole::Button`]: an on-box probe counted 26 nodes closed against 37 open, and "Search" was the
+/// only new control whose name is unique in the tree — the others repeat labels ("Character set",
+/// "Group by") that already appear elsewhere.
 ///
-/// `elapsed_ms` alone does NOT discriminate a working signal from a broken one, and neither does
-/// the walk count alone — each rules out a different broken build:
-/// - No subscription at all (`subscribe_changes` always `None`): every 100ms tick reads regardless
-///   (`wait.rs`'s `None => true` arm), so the change would still be caught at the very next tick —
-///   indistinguishable from a working signal on elapsed time alone, but it walks on EVERY tick
-///   instead of only the initial read + the periodic forced re-reads.
-/// - A subscription that never reports a real event (always `Quiet`): `QUIET_RUNS_BEFORE_REREAD`
-///   (`session/wait.rs`) forces a re-read every ~1000ms at this test's `interval_ms=100`, so the
-///   change would still be caught at the next forced-re-read boundary — indistinguishable from a
-///   working signal on walk count alone (both are low), but it cannot possibly return before that
-///   boundary.
+/// Neither assertion discriminates alone; each rules out a different broken build:
+/// - No subscription (`subscribe_changes` always `None`): every 100ms tick reads regardless, so the
+///   change is caught at the next tick — same elapsed time, but roughly one walk per tick.
+/// - A subscription that never reports an event (always `Quiet`): `QUIET_RUNS_BEFORE_REREAD` forces
+///   a re-read every ~1000ms at `interval_ms=100`, so it cannot return before the next boundary —
+///   same low walk count, but ~2000ms at the earliest.
 ///
-/// So the helper acts at ~1400ms — the middle of the SECOND forced-re-read window (boundaries at
-/// ~1000ms and ~2000ms), not the first: acting near 700ms (as an earlier version of this test did)
-/// put a real-signal result close enough to the first boundary (~1000ms) to leave little margin.
-/// Measured on-box with the helper acting at 1400ms: `matched=true elapsed_ms=1500 walks=3` — 3
-/// walks (the initial read, the ~1000ms forced re-read, and the read the event itself triggers,
-/// matching the quiet-wait tests' own count) and 1500ms elapsed, comfortably below the ~2000ms
-/// floor an always-`Quiet` build would need to reach the same tick and comfortably above what a
-/// no-subscription build's own elapsed time would look like (indistinguishable from this on elapsed
-/// alone, but reached across roughly one walk per 100ms tick — an order of magnitude more). The two
-/// asserts below bound walks between those two shapes and elapsed below the ~2000ms floor —
-/// together, not separately, they rule out both.
+/// Hence the helper acts at ~1400ms, mid-way through the second forced-re-read window (boundaries
+/// ~1000ms and ~2000ms); acting near 700ms left too little margin against the first. Measured
+/// on-box: `matched=true elapsed_ms=1500 walks=3` — the initial read, the ~1000ms forced re-read,
+/// and the read the event triggers.
 #[test]
 #[ignore = "on-box only: needs the interactive desktop session"]
 fn onbox_a_wait_wakes_on_a_late_change_from_another_thread() {
@@ -2027,14 +2007,11 @@ fn winforms_fixture_spec() -> AppSpec {
 /// matter: that it still matches is the correctness claim; that it took more than one walk rules
 /// out the wait's first read as the source of the match.
 ///
-/// `walked > 1` does not, on its own, prove no event fired — an announced transition and a forced
-/// re-read land close enough together in walk count that this assertion cannot tell them apart.
-/// That WinForms never announces `IsEnabled` comes from the 2026-07-31 on-box probe, not from
-/// this test. Nor does a failure say anything about the bridge: `walked > 1` fails only at
-/// `walked == 1`, meaning the wait's very first read already found `Save` enabled — the fixture's
-/// 4s flip landed before the wait began, so start-up overran the sleep above. That is a timing
-/// problem to fix here, not evidence either way: an announced transition would wake the wait at
-/// walk #2 and pass.
+/// `walked > 1` does not prove no event fired — an announced transition and a forced re-read land
+/// too close in walk count to tell apart. That WinForms never announces `IsEnabled` comes from the
+/// on-box probe, not from this test. A failure says nothing about the bridge either: `walked > 1`
+/// fails only at `walked == 1`, meaning the fixture's 4s flip landed before the wait began, which
+/// is a timing problem here — an announced transition would wake the wait at walk #2 and pass.
 #[test]
 #[ignore = "on-box only: needs the interactive desktop session"]
 fn onbox_a_wait_for_enabled_falls_back_to_the_forced_reread() {

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -1613,8 +1613,9 @@ fn glass_counting(
 }
 
 /// The point of the subscription, measured against a real app: a wait for something that never
-/// happens must stop re-reading the tree. A UIA walk is the most expensive of any backend —
-/// 2360ms for 1500 nodes, measured on a Windows box — so this is where the saving is largest.
+/// happens must stop re-reading the tree. What a skipped read is worth scales with the window —
+/// charmap's tree is 26 nodes and walks in ~20ms, where a 1500-node window measured through this
+/// same reader took 2360ms — so the saving counted here is a floor, not a typical case.
 #[test]
 #[ignore = "on-box only: needs the interactive desktop session"]
 fn onbox_a_quiet_wait_stops_re_walking_the_tree() {
@@ -1650,9 +1651,11 @@ fn onbox_a_quiet_wait_stops_re_walking_the_tree() {
     assert!(!out.matched, "the element must not exist");
     // See `Counting`: without this the test could measure polling and pass.
     assert!(subscribed > 0, "no subscription was established");
-    // One read at the start plus `QUIET_RUNS_BEFORE_REREAD`'s forced re-read about once a
-    // second. The same wait polling takes many more; a UIA walk is slow enough that the
-    // polling count is itself walk-bound rather than interval-bound.
+    // Four reads in a 3s wait, measured: one at the start, `REREAD_AFTER`'s forced re-reads at
+    // ~1s and ~2s, and one more at the deadline before answering "not found". The same wait
+    // without a signal walked 24 times (see `onbox_a_signal_more_than_halves_a_quiet_walk_count`),
+    // which is interval-paced rather than walk-bound — 24 reads in 3s is ~125ms a cycle, the 100ms
+    // interval plus charmap's own ~20ms walk.
     assert!(
         walked <= 5,
         "a quiet 3s wait walked {walked} times; the subscription is not suppressing walks"
@@ -1914,14 +1917,15 @@ impl Drop for RestoreAdvancedView {
 ///
 /// Neither assertion discriminates alone; each rules out a different broken build:
 /// - No subscription (`subscribe_changes` always `None`): every 100ms tick reads regardless, so the
-///   change is caught at the next tick — same elapsed time, but roughly one walk per tick.
+///   change is caught at the next tick — same elapsed time, but roughly one walk per tick, which is
+///   what polling costs on a window this small (see `onbox_a_quiet_wait_stops_re_walking_the_tree`).
 /// - A subscription that never reports an event (always `Quiet`): `glass_core`'s `REREAD_AFTER`
 ///   forces a re-read once a second, so it cannot return before the next boundary — same low walk
 ///   count, but ~2000ms at the earliest.
 ///
 /// Hence the helper acts at ~1400ms, mid-way through the second forced-re-read window (boundaries
 /// ~1000ms and ~2000ms); acting near 700ms left too little margin against the first. Measured
-/// on-box: `matched=true elapsed_ms=1500 walks=3` — the initial read, the ~1000ms forced re-read,
+/// on-box: `matched=true elapsed_ms=1501 walks=3` — the initial read, the ~1000ms forced re-read,
 /// and the read the event triggers.
 #[test]
 #[ignore = "on-box only: needs the interactive desktop session"]

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -1771,7 +1771,8 @@ fn onbox_a_wait_with_a_signal_still_matches() {
 /// Pure Win32, independent of any `Platform`/`Glass` instance: the helper thread in
 /// [`onbox_a_wait_wakes_on_a_late_change_from_another_thread`] must share no state with the
 /// `Glass` session it acts on, so it finds the live charmap window itself rather than borrowing
-/// anything glass tracked.
+/// anything glass tracked. Title alone, though: see [`find_charmap_window`] for why a caller
+/// needing the *right* charmap window uses that instead of this directly.
 fn find_window_by_title(title: &str) -> Option<i64> {
     use windows::Win32::UI::WindowsAndMessaging::FindWindowW;
     use windows::core::{HSTRING, PCWSTR};
@@ -1780,6 +1781,47 @@ fn find_window_by_title(title: &str) -> Option<i64> {
     unsafe { FindWindowW(PCWSTR::null(), &HSTRING::from(title)) }
         .ok()
         .map(|h| h.0 as i64)
+}
+
+/// The pid of the most recently started `charmap.exe` process, via a `Get-Process` shell-out (the
+/// same PowerShell-query pattern [`our_edge_count`] already uses elsewhere in this file) —
+/// independent of any `Glass`/`Platform` instance. "Most recent" rather than "the only one": if an
+/// earlier test leaked a `charmap.exe` (a documented, actively-checked-for risk in this file — see
+/// the on-box leak check in the branch's own verification steps), this test's own instance is still
+/// the newest by construction, since it was launched last.
+fn newest_charmap_pid() -> Option<u32> {
+    let ps = "(Get-Process charmap -ErrorAction SilentlyContinue | \
+              Sort-Object StartTime -Descending | Select-Object -First 1).Id";
+    let out = std::process::Command::new("powershell")
+        .args(["-NoProfile", "-Command", ps])
+        .output()
+        .ok()?;
+    String::from_utf8_lossy(&out.stdout).trim().parse().ok()
+}
+
+/// Find the live "Character Map" window AND verify it belongs to `expected_pid` — the pid of the
+/// charmap.exe this test itself started ([`newest_charmap_pid`]), obtained independently of
+/// `Glass`. [`find_window_by_title`] alone binds by title only, exactly like glass's own discovery
+/// does NOT (glass adopts by pid-set/handle); a stale charmap.exe left behind by an earlier test
+/// could otherwise win the title lookup, and the helper thread would toggle the wrong window's
+/// checkbox — read by the main thread's `wait_for_element` as a plain 5s timeout, with nothing in
+/// the failure pointing at a leaked process as the cause. Panics with the mismatched pids named,
+/// rather than let that failure mode reach the caller as an unexplained timeout.
+fn find_charmap_window(expected_pid: u32) -> i64 {
+    use windows::Win32::UI::WindowsAndMessaging::GetWindowThreadProcessId;
+    let handle = find_window_by_title("Character Map")
+        .expect("an independent Win32 lookup must find a live 'Character Map' window");
+    let hwnd = windows::Win32::Foundation::HWND(handle as *mut std::ffi::c_void);
+    let mut owner_pid = 0u32;
+    // SAFETY: writes the owning pid into our stack value; the HWND is only queried, never mutated.
+    unsafe { GetWindowThreadProcessId(hwnd, Some(&mut owner_pid)) };
+    assert_eq!(
+        owner_pid, expected_pid,
+        "the 'Character Map' window found by title belongs to pid {owner_pid}, not {expected_pid} \
+         (the pid this test started) — a stale charmap.exe is likely still running from an earlier \
+         test"
+    );
+    handle
 }
 
 /// Best-effort on-screen geometry for a raw HWND, via the plain window rect — good enough for
@@ -1814,21 +1856,44 @@ fn window_rect_geometry(handle: i64) -> WindowGeometry {
 /// (`onbox_a_wait_with_a_signal_still_matches`, already on screen) and cost without a match
 /// (the quiet-wait tests), but none of them ever drives `ChangeWait::Changed => true` inside
 /// `Glass::wait_for_element`'s poll loop (`session/wait.rs`) from a change nothing but a real UIA
-/// event produced — a build where the signal never actually delivered `Changed` into that loop
-/// passes all three. This closes it: the main thread blocks in `wait_for_element` for a control
-/// that does not exist yet; a helper thread — its own `WindowsA11y`, its own `AxContext`, the
-/// target window found by an independent Win32 title lookup rather than anything the `Glass`
-/// session tracks, so no `Glass` state crosses threads — sleeps briefly, then actuates charmap's
-/// Advanced-view checkbox directly. Opening it reveals a "Search" [`AxRole::Button`] (confirmed by
-/// a one-off on-box probe: closed=26 nodes, open=37; "Search" was the one newly-appeared control
-/// with a name unique to itself, unlike the panel's other new controls, which repeat labels
-/// ("Character set", "Group by") that already exist elsewhere in charmap's tree).
+/// event produced. This does: the main thread blocks in `wait_for_element` for a control that does
+/// not exist yet; a helper thread — its own `WindowsA11y`, its own `AxContext`, the target window
+/// found and pid-verified independently of the `Glass` session (see [`find_charmap_window`]), so no
+/// `Glass` state crosses threads — sleeps, then actuates charmap's Advanced-view checkbox directly.
+/// Opening it reveals a "Search" [`AxRole::Button`] (confirmed by a one-off on-box probe: closed=26
+/// nodes, open=37; "Search" was the one newly-appeared control with a name unique to itself, unlike
+/// the panel's other new controls, which repeat labels — "Character set", "Group by" — that already
+/// exist elsewhere in charmap's tree).
+///
+/// `elapsed_ms` alone does NOT discriminate a working signal from a broken one, and neither does
+/// the walk count alone — each rules out a different broken build:
+/// - No subscription at all (`subscribe_changes` always `None`): every 100ms tick reads regardless
+///   (`wait.rs`'s `None => true` arm), so the change would still be caught at the very next tick —
+///   indistinguishable from a working signal on elapsed time alone, but it walks on EVERY tick
+///   instead of only the initial read + the periodic forced re-reads.
+/// - A subscription that never reports a real event (always `Quiet`): `QUIET_RUNS_BEFORE_REREAD`
+///   (`session/wait.rs`) forces a re-read every ~1000ms at this test's `interval_ms=100`, so the
+///   change would still be caught at the next forced-re-read boundary — indistinguishable from a
+///   working signal on walk count alone (both are low), but it cannot possibly return before that
+///   boundary.
+///
+/// So the helper acts at ~1400ms — the middle of the SECOND forced-re-read window (boundaries at
+/// ~1000ms and ~2000ms), not the first: acting near 700ms (as an earlier version of this test did)
+/// put a real-signal result close enough to the first boundary (~1000ms) to leave little margin.
+/// Measured on-box with the helper acting at 1400ms: `matched=true elapsed_ms=1500 walks=3` — 3
+/// walks (the initial read, the ~1000ms forced re-read, and the read the event itself triggers,
+/// matching the quiet-wait tests' own count) and 1500ms elapsed, comfortably below the ~2000ms
+/// floor an always-`Quiet` build would need to reach the same tick and comfortably above what a
+/// no-subscription build's own elapsed time would look like (indistinguishable from this on elapsed
+/// alone, but reached across roughly one walk per 100ms tick — an order of magnitude more). The two
+/// asserts below bound walks between those two shapes and elapsed below the ~2000ms floor —
+/// together, not separately, they rule out both.
 #[test]
 #[ignore = "on-box only: needs the interactive desktop session"]
 fn onbox_a_wait_wakes_on_a_late_change_from_another_thread() {
     let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     dpi_aware_once();
-    let mut glass = glass_windows_with_a11y();
+    let (mut glass, walks, signals) = glass_counting(true);
     glass.start(&charmap_spec()).expect("start charmap");
     std::thread::sleep(Duration::from_millis(1500));
 
@@ -1846,10 +1911,13 @@ fn onbox_a_wait_wakes_on_a_late_change_from_another_thread() {
         std::thread::sleep(Duration::from_millis(800));
     }
 
-    let handle = find_window_by_title("Character Map")
-        .expect("an independent Win32 lookup must find the live charmap window");
+    let pid = newest_charmap_pid().expect("must find the charmap.exe process this test started");
+    let handle = find_charmap_window(pid);
+
+    walks.store(0, std::sync::atomic::Ordering::Relaxed);
+    signals.store(0, std::sync::atomic::Ordering::Relaxed);
     let helper = std::thread::spawn(move || {
-        std::thread::sleep(Duration::from_millis(700));
+        std::thread::sleep(Duration::from_millis(1400));
         let mut a11y = WindowsA11y::new();
         let ctx = AxContext {
             pids: vec![],
@@ -1873,35 +1941,55 @@ fn onbox_a_wait_wakes_on_a_late_change_from_another_thread() {
             .expect("helper thread opens advanced view");
     });
 
-    let out = glass
-        .wait_for_element(&glass_core::WaitElementParams {
-            name: Some("Search".into()),
-            role: Some(AxRole::Button),
-            value_contains: None,
-            condition: glass_core::ElementCondition::Appears,
-            interval_ms: 100,
-            timeout_ms: 5_000,
-        })
-        .expect("wait");
-    helper.join().expect("helper thread must not panic");
+    // Captured, not unwrapped, before the join: if `wait_for_element` errored, `.expect` below
+    // would panic and unwind — and with the helper still un-joined at that point, its `JoinHandle`
+    // would be dropped while the thread is still doing live Win32/UIA work against this window.
+    // `SERIAL` releases as soon as this test's guard drops on the panic, so the very next on-box
+    // test could start and race the orphaned helper. Joining before any panic-capable call closes
+    // that gap.
+    let wait_result = glass.wait_for_element(&glass_core::WaitElementParams {
+        name: Some("Search".into()),
+        role: Some(AxRole::Button),
+        value_contains: None,
+        condition: glass_core::ElementCondition::Appears,
+        interval_ms: 100,
+        timeout_ms: 5_000,
+    });
+    let walked = walks.load(std::sync::atomic::Ordering::Relaxed);
+    let subscribed = signals.load(std::sync::atomic::Ordering::Relaxed);
+    let helper_result = helper.join();
     let _ = glass.stop();
 
+    helper_result.expect("helper thread must not panic");
+    let out = wait_result.expect("wait");
+
     let line = format!(
-        "late-change wait: matched={} elapsed_ms={}\n",
-        out.matched, out.elapsed_ms
+        "late-change wait: matched={} elapsed_ms={} walks={}\n",
+        out.matched, out.elapsed_ms, walked
     );
     eprint!("{line}");
     save_report("onbox-late-change-wait.txt", &line);
+    assert!(subscribed > 0, "no subscription was established");
     assert!(
         out.matched,
         "the Search button must appear once advanced view opens"
     );
-    // Generous relative to the 5s timeout: a signal-woken wait should return in well under a
-    // second (the helper's own 700ms sleep plus one UIA walk). 3s leaves headroom for box load
-    // while still failing a wait that only ever woke via the timeout.
+    // Rules out "no subscription at all" — see the doc comment above. A polling build would walk
+    // roughly once per 100ms tick over ~1.4s (~14); a working signal walks only the initial read,
+    // the ~1000ms forced re-read, and the event itself (~3, matching the quiet-wait tests' count).
     assert!(
-        out.elapsed_ms < 3_000,
-        "a wait woken by a real UIA change should return well inside the 5s timeout, took {}ms",
+        walked <= 7,
+        "the wait walked {walked} times reaching the change; a live subscription should keep this \
+         near the quiet-wait tests' count (~3), not polling's (~14)"
+    );
+    // Rules out "subscribed but always Quiet" — see the doc comment above. That build cannot answer
+    // before the next forced-re-read boundary at ~2000ms; a working signal answers near the
+    // helper's own 1400ms action instant plus one walk.
+    assert!(
+        out.elapsed_ms < 1_800,
+        "a wait woken by a real UIA change should return near the helper's ~1400ms action instant \
+         (measured on-box: 1500ms), well before the ~2000ms forced-re-read boundary an \
+         always-Quiet signal would need; took {}ms",
         out.elapsed_ms
     );
 }

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -1641,9 +1641,9 @@ fn onbox_a_quiet_wait_stops_re_walking_the_tree() {
     let _ = glass.stop();
 
     // Logged AND saved: `eprintln!` alone is invisible on a pass through the schtasks-bounce
-    // harness (see `probe_role_histogram`'s doc on why it writes `.windows-artifacts` for the
-    // same reason) — save_report is what makes the number reproducible off-box, which is the
-    // entire point of a walk-count test.
+    // harness (see [`artifacts_dir`] for why that is, and why the file is the only way anything
+    // gets out) — save_report is what makes the number reproducible off-box, which is the entire
+    // point of a walk-count test.
     let line = format!("quiet 3s wait at 100ms: {walked} walks\n");
     eprint!("{line}");
     save_report("onbox-walk-count-quiet-wait.txt", &line);
@@ -1915,9 +1915,9 @@ impl Drop for RestoreAdvancedView {
 /// Neither assertion discriminates alone; each rules out a different broken build:
 /// - No subscription (`subscribe_changes` always `None`): every 100ms tick reads regardless, so the
 ///   change is caught at the next tick — same elapsed time, but roughly one walk per tick.
-/// - A subscription that never reports an event (always `Quiet`): `QUIET_RUNS_BEFORE_REREAD` forces
-///   a re-read every ~1000ms at `interval_ms=100`, so it cannot return before the next boundary —
-///   same low walk count, but ~2000ms at the earliest.
+/// - A subscription that never reports an event (always `Quiet`): `glass_core`'s `REREAD_AFTER`
+///   forces a re-read once a second, so it cannot return before the next boundary — same low walk
+///   count, but ~2000ms at the earliest.
 ///
 /// Hence the helper acts at ~1400ms, mid-way through the second forced-re-read window (boundaries
 /// ~1000ms and ~2000ms); acting near 700ms left too little margin against the first. Measured
@@ -2062,9 +2062,9 @@ fn winforms_fixture_spec() -> AppSpec {
 /// The documented cost of the `IsEnabled` gap, asserted rather than described.
 ///
 /// A WinForms control becoming enabled announces nothing, so this wait cannot be woken by an
-/// event — it can only be rescued by `QUIET_RUNS_BEFORE_REREAD`'s forced re-read. Both halves
-/// matter: that it still matches is the correctness claim; that it took more than one walk rules
-/// out the wait's first read as the source of the match.
+/// event — it can only be rescued by `glass_core`'s once-a-second forced re-read (`REREAD_AFTER`).
+/// Both halves matter: that it still matches is the correctness claim; that it took more than one
+/// walk rules out the wait's first read as the source of the match.
 ///
 /// `walked > 1` does not prove no event fired — an announced transition and a forced re-read land
 /// too close in walk count to tell apart. That WinForms never announces `IsEnabled` comes from the

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -1614,7 +1614,7 @@ fn glass_counting(
 
 /// The point of the subscription, measured against a real app: a wait for something that never
 /// happens must stop re-reading the tree. A UIA walk is the most expensive of any backend —
-/// 2360ms for 1500 nodes on the dogfood box — so this is where the saving is largest.
+/// 2360ms for 1500 nodes, measured on a Windows box — so this is where the saving is largest.
 #[test]
 #[ignore = "on-box only: needs the interactive desktop session"]
 fn onbox_a_quiet_wait_stops_re_walking_the_tree() {
@@ -1659,9 +1659,9 @@ fn onbox_a_quiet_wait_stops_re_walking_the_tree() {
     );
 }
 
-/// Finding 1(a): `walked <= 5` above bounds a number, not an improvement — a build that always
-/// walked 5 times regardless of the subscription would still pass it. This runs the identical 3s
-/// quiet wait through two sessions that differ in exactly one thing — whether `subscribe_changes`
+/// `walked <= 5` above bounds a number, not an improvement — a build that always walked 5 times
+/// regardless of the subscription would still pass it. This runs the identical 3s quiet wait
+/// through two sessions that differ in exactly one thing — whether `subscribe_changes`
 /// ever hands back a working signal (see [`Counting::signal_enabled`]) — and asserts the signalled
 /// run beats the polling one by a clear margin. That margin, not the raw walk count, is the number
 /// worth quoting as the saving.
@@ -1786,9 +1786,8 @@ fn find_window_by_title(title: &str) -> Option<i64> {
 /// The pid of the most recently started `charmap.exe` process, via a `Get-Process` shell-out (the
 /// same PowerShell-query pattern [`our_edge_count`] already uses elsewhere in this file) —
 /// independent of any `Glass`/`Platform` instance. "Most recent" rather than "the only one": if an
-/// earlier test leaked a `charmap.exe` (a documented, actively-checked-for risk in this file — see
-/// the on-box leak check in the branch's own verification steps), this test's own instance is still
-/// the newest by construction, since it was launched last.
+/// earlier test leaked a `charmap.exe` — a documented, actively-checked-for risk in this file —
+/// this test's own instance is still the newest by construction, since it was launched last.
 fn newest_charmap_pid() -> Option<u32> {
     let ps = "(Get-Process charmap -ErrorAction SilentlyContinue | \
               Sort-Object StartTime -Descending | Select-Object -First 1).Id";
@@ -1852,9 +1851,9 @@ fn window_rect_geometry(handle: i64) -> WindowGeometry {
     }
 }
 
-/// Finding 1(b): the tests above prove correctness without a late change
-/// (`onbox_a_wait_with_a_signal_still_matches`, already on screen) and cost without a match
-/// (the quiet-wait tests), but none of them ever drives `ChangeWait::Changed => true` inside
+/// The tests above prove correctness without a late change
+/// (`onbox_a_wait_with_a_signal_still_matches`, already on screen) and cost without a match (the
+/// quiet-wait tests), but none of them ever drives `ChangeWait::Changed => true` inside
 /// `Glass::wait_for_element`'s poll loop (`session/wait.rs`) from a change nothing but a real UIA
 /// event produced. This does: the main thread blocks in `wait_for_element` for a control that does
 /// not exist yet; a helper thread — its own `WindowsA11y`, its own `AxContext`, the target window
@@ -2031,9 +2030,11 @@ fn winforms_fixture_spec() -> AppSpec {
 /// `walked > 1` does not, on its own, prove no event fired — an announced transition and a forced
 /// re-read land close enough together in walk count that this assertion cannot tell them apart.
 /// That WinForms never announces `IsEnabled` comes from the 2026-07-31 on-box probe, not from
-/// this test. If this assertion starts failing, the bridge began announcing `IsEnabled` after
-/// all, and the disclosure on `WatchedProperty::IsEnabled` (`glass-a11y-windows/src/mapping.rs`)
-/// and the changelog entry for it are both stale.
+/// this test. Nor does a failure say anything about the bridge: `walked > 1` fails only at
+/// `walked == 1`, meaning the wait's very first read already found `Save` enabled — the fixture's
+/// 4s flip landed before the wait began, so start-up overran the sleep above. That is a timing
+/// problem to fix here, not evidence either way: an announced transition would wake the wait at
+/// walk #2 and pass.
 #[test]
 #[ignore = "on-box only: needs the interactive desktop session"]
 fn onbox_a_wait_for_enabled_falls_back_to_the_forced_reread() {
@@ -2046,6 +2047,7 @@ fn onbox_a_wait_for_enabled_falls_back_to_the_forced_reread() {
     std::thread::sleep(Duration::from_millis(1200));
 
     walks.store(0, std::sync::atomic::Ordering::Relaxed);
+    signals.store(0, std::sync::atomic::Ordering::Relaxed);
     let out = glass
         .wait_for_element(&glass_core::WaitElementParams {
             name: Some("Save".into()),
@@ -2073,8 +2075,8 @@ fn onbox_a_wait_for_enabled_falls_back_to_the_forced_reread() {
     );
     assert!(
         walked > 1,
-        "the wait matched in {walked} walk(s), so something woke it — the WinForms bridge is \
-         announcing IsEnabled after all, and the disclosure on WatchedProperty::IsEnabled is now \
-         wrong"
+        "the wait matched in its first read ({walked} walk), so Save was already enabled when it \
+         started — the fixture's flip beat the wait, and this run measured nothing about the \
+         fallback"
     );
 }

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -1476,6 +1476,17 @@ fn onbox_a11y_subscription_reports_a_real_change() {
         bounds: field.bounds,
         value: field.value.clone(),
     };
+
+    // Discriminating, not just documenting: the channel is open and buffers one item from the
+    // moment of subscription, and the snapshot above is itself a full tree walk — so without this,
+    // a stray event the walk trips on its own subscription could pass the test on a signal that
+    // never actually saw `set_value`'s change.
+    assert_eq!(
+        signal.wait(Duration::from_millis(300)),
+        glass_core::ChangeWait::Quiet,
+        "no change should be pending yet — a real one hasn't been made"
+    );
+
     a11y.set_value(&ctx, &target, "GLASSEVENT")
         .expect("set_value on the Edit field");
 
@@ -1526,10 +1537,16 @@ fn onbox_a11y_subscription_is_quiet_on_an_idle_app() {
 ///
 /// Forwards every trait method. `subscribe_changes` has a default body, so a forgotten forward
 /// would compile and silently disable the thing this measures — hence the counter on it too.
+///
+/// `signal_enabled: false` makes `subscribe_changes` behave like a backend with no event stream
+/// at all — never calling `inner`, so no subscription thread is even started — which is the
+/// baseline [`onbox_a_signal_more_than_halves_a_quiet_walk_count`] compares the live subscription
+/// against: same app, same wait, the only variable is whether a signal was available to lean on.
 struct Counting<A> {
     inner: A,
     walks: std::sync::Arc<std::sync::atomic::AtomicUsize>,
     signals: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    signal_enabled: bool,
 }
 
 impl<A: Accessibility> Accessibility for Counting<A> {
@@ -1539,6 +1556,9 @@ impl<A: Accessibility> Accessibility for Counting<A> {
         self.inner.snapshot(ctx)
     }
     fn subscribe_changes(&mut self, ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
+        if !self.signal_enabled {
+            return None;
+        }
         let s = self.inner.subscribe_changes(ctx);
         if s.is_some() {
             self.signals
@@ -1559,8 +1579,11 @@ impl<A: Accessibility> Accessibility for Counting<A> {
     }
 }
 
-/// A `Glass` session whose reader counts walks and subscriptions.
-fn glass_counting() -> (
+/// A `Glass` session whose reader counts walks and subscriptions. `signal_enabled` gates whether
+/// `subscribe_changes` ever hands back a working signal — see [`Counting`].
+fn glass_counting(
+    signal_enabled: bool,
+) -> (
     Glass,
     std::sync::Arc<std::sync::atomic::AtomicUsize>,
     std::sync::Arc<std::sync::atomic::AtomicUsize>,
@@ -1575,6 +1598,7 @@ fn glass_counting() -> (
                 inner: WindowsA11y::new(),
                 walks: w.clone(),
                 signals: sg.clone(),
+                signal_enabled,
             })),
         })
     });
@@ -1596,11 +1620,12 @@ fn glass_counting() -> (
 fn onbox_a_quiet_wait_stops_re_walking_the_tree() {
     let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     dpi_aware_once();
-    let (mut glass, walks, signals) = glass_counting();
+    let (mut glass, walks, signals) = glass_counting(true);
     glass.start(&charmap_spec()).expect("start charmap");
     std::thread::sleep(Duration::from_millis(1500));
 
     walks.store(0, std::sync::atomic::Ordering::Relaxed);
+    signals.store(0, std::sync::atomic::Ordering::Relaxed);
     let out = glass
         .wait_for_element(&glass_core::WaitElementParams {
             name: Some("no such element in charmap".into()),
@@ -1615,8 +1640,13 @@ fn onbox_a_quiet_wait_stops_re_walking_the_tree() {
     let subscribed = signals.load(std::sync::atomic::Ordering::Relaxed);
     let _ = glass.stop();
 
-    // Logged: the number is the point of the change.
-    eprintln!("quiet 3s wait at 100ms: {walked} walks");
+    // Logged AND saved: `eprintln!` alone is invisible on a pass through the schtasks-bounce
+    // harness (see `probe_role_histogram`'s doc on why it writes `.windows-artifacts` for the
+    // same reason) — save_report is what makes the number reproducible off-box, which is the
+    // entire point of a walk-count test.
+    let line = format!("quiet 3s wait at 100ms: {walked} walks\n");
+    eprint!("{line}");
+    save_report("onbox-walk-count-quiet-wait.txt", &line);
     assert!(!out.matched, "the element must not exist");
     // See `Counting`: without this the test could measure polling and pass.
     assert!(subscribed > 0, "no subscription was established");
@@ -1629,6 +1659,67 @@ fn onbox_a_quiet_wait_stops_re_walking_the_tree() {
     );
 }
 
+/// Finding 1(a): `walked <= 5` above bounds a number, not an improvement — a build that always
+/// walked 5 times regardless of the subscription would still pass it. This runs the identical 3s
+/// quiet wait through two sessions that differ in exactly one thing — whether `subscribe_changes`
+/// ever hands back a working signal (see [`Counting::signal_enabled`]) — and asserts the signalled
+/// run beats the polling one by a clear margin. That margin, not the raw walk count, is the number
+/// worth quoting as the saving.
+#[test]
+#[ignore = "on-box only: needs the interactive desktop session"]
+fn onbox_a_signal_more_than_halves_a_quiet_walk_count() {
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    dpi_aware_once();
+
+    // Local, not a file-level helper: the only two callers are the two arms below, and inlining it
+    // there would drown the one thing that differs between them (`signal_enabled`) in setup noise.
+    fn quiet_wait_walks(signal_enabled: bool) -> (usize, usize) {
+        let (mut glass, walks, signals) = glass_counting(signal_enabled);
+        glass.start(&charmap_spec()).expect("start charmap");
+        std::thread::sleep(Duration::from_millis(1500));
+
+        walks.store(0, std::sync::atomic::Ordering::Relaxed);
+        signals.store(0, std::sync::atomic::Ordering::Relaxed);
+        let out = glass
+            .wait_for_element(&glass_core::WaitElementParams {
+                name: Some("no such element in charmap".into()),
+                role: None,
+                value_contains: None,
+                condition: glass_core::ElementCondition::Appears,
+                interval_ms: 100,
+                timeout_ms: 3_000,
+            })
+            .expect("wait");
+        let walked = walks.load(std::sync::atomic::Ordering::Relaxed);
+        let subscribed = signals.load(std::sync::atomic::Ordering::Relaxed);
+        let _ = glass.stop();
+        assert!(!out.matched, "the element must not exist");
+        (walked, subscribed)
+    }
+
+    let (with_signal, with_subs) = quiet_wait_walks(true);
+    let (without_signal, without_subs) = quiet_wait_walks(false);
+    assert!(
+        with_subs > 0,
+        "the signal-enabled run must have established a subscription"
+    );
+    assert_eq!(
+        without_subs, 0,
+        "the signal-disabled run must never report a subscription — otherwise this isn't \
+         measuring what it claims to"
+    );
+
+    let line =
+        format!("quiet 3s wait: with signal={with_signal} walks, without={without_signal} walks\n");
+    eprint!("{line}");
+    save_report("onbox-walk-count-comparison.txt", &line);
+    assert!(
+        with_signal * 2 < without_signal,
+        "a live subscription must more than halve the walk count: with={with_signal} \
+         without={without_signal}"
+    );
+}
+
 /// The risk a subscription creates: a wait that no longer matches, because the signal suppressed
 /// the read that would have found the element. Sequential and assumption-free — the element is
 /// already on screen when the wait starts, so the wait must return on its first read.
@@ -1637,7 +1728,7 @@ fn onbox_a_quiet_wait_stops_re_walking_the_tree() {
 fn onbox_a_wait_with_a_signal_still_matches() {
     let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
     dpi_aware_once();
-    let (mut glass, walks, signals) = glass_counting();
+    let (mut glass, walks, signals) = glass_counting(true);
     glass.start(&charmap_spec()).expect("start charmap");
     std::thread::sleep(Duration::from_millis(1500));
 
@@ -1651,6 +1742,7 @@ fn onbox_a_wait_with_a_signal_still_matches() {
         .expect("charmap exposes a named Button");
 
     walks.store(0, std::sync::atomic::Ordering::Relaxed);
+    signals.store(0, std::sync::atomic::Ordering::Relaxed);
     let out = glass
         .wait_for_element(&glass_core::WaitElementParams {
             name: Some(name.clone()),
@@ -1673,5 +1765,143 @@ fn onbox_a_wait_with_a_signal_still_matches() {
     assert!(
         walked <= 2,
         "an already-satisfied wait took {walked} walks; it should return on the first read"
+    );
+}
+
+/// Pure Win32, independent of any `Platform`/`Glass` instance: the helper thread in
+/// [`onbox_a_wait_wakes_on_a_late_change_from_another_thread`] must share no state with the
+/// `Glass` session it acts on, so it finds the live charmap window itself rather than borrowing
+/// anything glass tracked.
+fn find_window_by_title(title: &str) -> Option<i64> {
+    use windows::Win32::UI::WindowsAndMessaging::FindWindowW;
+    use windows::core::{HSTRING, PCWSTR};
+    // SAFETY: reads a null-terminated title string and returns the matching top-level HWND (or
+    // an error, treated as "not found"); writes nothing.
+    unsafe { FindWindowW(PCWSTR::null(), &HSTRING::from(title)) }
+        .ok()
+        .map(|h| h.0 as i64)
+}
+
+/// Best-effort on-screen geometry for a raw HWND, via the plain window rect — good enough for
+/// `AxContext::window`, which this path only uses for bounds translation inside a snapshot, never
+/// for a click. Deliberately not `glass_windows`'s own DWM-extended `geometry_of`: that function is
+/// crate-private, and reaching for it would mean this "independent" thread borrowing glass's own
+/// window code rather than rediscovering the window on its own.
+fn window_rect_geometry(handle: i64) -> WindowGeometry {
+    use windows::Win32::Foundation::RECT;
+    use windows::Win32::UI::WindowsAndMessaging::GetWindowRect;
+    let hwnd = windows::Win32::Foundation::HWND(handle as *mut std::ffi::c_void);
+    let mut rect = RECT::default();
+    // SAFETY: writes one RECT into our stack value; the HWND is only queried, never mutated. A
+    // stale/invalid handle just fails, and the zeroed default below is a harmless fallback.
+    if unsafe { GetWindowRect(hwnd, &mut rect) }.is_err() {
+        return WindowGeometry {
+            x: 0,
+            y: 0,
+            width: 0,
+            height: 0,
+        };
+    }
+    WindowGeometry {
+        x: rect.left,
+        y: rect.top,
+        width: (rect.right - rect.left).max(0) as u32,
+        height: (rect.bottom - rect.top).max(0) as u32,
+    }
+}
+
+/// Finding 1(b): the tests above prove correctness without a late change
+/// (`onbox_a_wait_with_a_signal_still_matches`, already on screen) and cost without a match
+/// (the quiet-wait tests), but none of them ever drives `ChangeWait::Changed => true` inside
+/// `Glass::wait_for_element`'s poll loop (`session/wait.rs`) from a change nothing but a real UIA
+/// event produced — a build where the signal never actually delivered `Changed` into that loop
+/// passes all three. This closes it: the main thread blocks in `wait_for_element` for a control
+/// that does not exist yet; a helper thread — its own `WindowsA11y`, its own `AxContext`, the
+/// target window found by an independent Win32 title lookup rather than anything the `Glass`
+/// session tracks, so no `Glass` state crosses threads — sleeps briefly, then actuates charmap's
+/// Advanced-view checkbox directly. Opening it reveals a "Search" [`AxRole::Button`] (confirmed by
+/// a one-off on-box probe: closed=26 nodes, open=37; "Search" was the one newly-appeared control
+/// with a name unique to itself, unlike the panel's other new controls, which repeat labels
+/// ("Character set", "Group by") that already exist elsewhere in charmap's tree).
+#[test]
+#[ignore = "on-box only: needs the interactive desktop session"]
+fn onbox_a_wait_wakes_on_a_late_change_from_another_thread() {
+    let _serial = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+    dpi_aware_once();
+    let mut glass = glass_windows_with_a11y();
+    glass.start(&charmap_spec()).expect("start charmap");
+    std::thread::sleep(Duration::from_millis(1500));
+
+    // charmap persists the Advanced-view checkbox's state across launches on this box, so
+    // normalize to closed first: the helper thread's job is to open it, and "Search" must not
+    // already be on screen when the timed wait below starts.
+    let tree = glass.a11y_snapshot(None).expect("initial snapshot");
+    let mut cb = None;
+    first_role_with_bounds(&tree.root, AxRole::CheckBox, &mut cb);
+    let cb = cb.expect("charmap exposes the Advanced-view CheckBox");
+    if cb.states.checked {
+        glass
+            .click_element(cb.id)
+            .expect("close advanced view to normalize to a known starting state");
+        std::thread::sleep(Duration::from_millis(800));
+    }
+
+    let handle = find_window_by_title("Character Map")
+        .expect("an independent Win32 lookup must find the live charmap window");
+    let helper = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(700));
+        let mut a11y = WindowsA11y::new();
+        let ctx = AxContext {
+            pids: vec![],
+            window: window_rect_geometry(handle),
+            window_handle: Some(handle),
+            a11y_bus_addr: None,
+            limits: WalkLimits::DEFAULT,
+        };
+        let tree = a11y.snapshot(&ctx).expect("helper thread's own snapshot");
+        let mut cb = None;
+        first_role_with_bounds(&tree.root, AxRole::CheckBox, &mut cb);
+        let cb = cb.expect("checkbox still present for the helper thread");
+        let target = AxTarget {
+            id: cb.id,
+            role: cb.role,
+            name: cb.name.clone(),
+            bounds: cb.bounds,
+            value: cb.value.clone(),
+        };
+        a11y.invoke(&ctx, &target)
+            .expect("helper thread opens advanced view");
+    });
+
+    let out = glass
+        .wait_for_element(&glass_core::WaitElementParams {
+            name: Some("Search".into()),
+            role: Some(AxRole::Button),
+            value_contains: None,
+            condition: glass_core::ElementCondition::Appears,
+            interval_ms: 100,
+            timeout_ms: 5_000,
+        })
+        .expect("wait");
+    helper.join().expect("helper thread must not panic");
+    let _ = glass.stop();
+
+    let line = format!(
+        "late-change wait: matched={} elapsed_ms={}\n",
+        out.matched, out.elapsed_ms
+    );
+    eprint!("{line}");
+    save_report("onbox-late-change-wait.txt", &line);
+    assert!(
+        out.matched,
+        "the Search button must appear once advanced view opens"
+    );
+    // Generous relative to the 5s timeout: a signal-woken wait should return in well under a
+    // second (the helper's own 700ms sleep plus one UIA walk). 3s leaves headroom for box load
+    // while still failing a wait that only ever woke via the timeout.
+    assert!(
+        out.elapsed_ms < 3_000,
+        "a wait woken by a real UIA change should return well inside the 5s timeout, took {}ms",
+        out.elapsed_ms
     );
 }


### PR DESCRIPTION
Second backend behind the `ChangeSignal` seam #270 shipped for Linux. On Windows, a `glass_wait_for_element` waiting for something that has not happened yet now reads the tree when UI Automation says something changed, instead of once per interval.

Measured on real Windows hardware, a quiet 3-second wait at a 100ms interval:

```
with the subscription:  3 walks
without:               22 walks
```

## Why Windows was the right backend

The backlog said macOS next, on the premise that its walks were slowest. Both halves of that were probed and are false. Walk cost at the same 1500-node cap, each reader's own per-node property set:

| Backend | 1500 nodes |
|---|---|
| **Windows (UIA)** | **2360ms** |
| Linux (AT-SPI) | 732ms, and already read concurrently |
| macOS (AX) | 210ms |

And the platforms differ in what they will tell you at all. Probed with scratch clients independent of glass's own bindings, so the answers are about the platform rather than our FFI:

| Change | macOS (AppKit) | Windows, WinForms | Windows, WPF |
|---|---|---|---|
| value / name changes | announced | announced | announced |
| **control appears** | **silent** | announced | announced |
| **control becomes enabled** | **silent** | **silent** | announced |

"Appears" and "becomes enabled" are what waits are actually for. macOS announces neither, so event-gating there would buy the quiet-budget reduction while adding up to a second of latency to the common case. Windows announces "appears" everywhere and "becomes enabled" for native providers — and has the walk cost that makes the saving worth having.

## Shape

One `StructureChanged` handler and one `PropertyChanged` handler over eight properties, both registered on the window element at `TreeScope::Subtree` — subtree registration demonstrably covers descendants, so no per-element registration.

The property list is derived from what `ElementCondition` can test rather than chosen: `IsEnabled` for enabled/disabled, `ToggleToggleState` for checked, `IsOffscreen` for visible, and so on, with `Name` and `ValueValue` for the selectors. A new `ElementCondition` fails to compile until it declares which property announces it, and a test checks that property is one the subscription actually registers.

The subscription owns a thread for its whole life, because UIA registrations belong to the COM apartment that created them while the reader's threads die per snapshot. Handlers push a unit into a bounded channel; `ChangeSignal::wait` drains it. Failing to subscribe returns `None` and the caller polls exactly as before.

## The known gap, and its cost

A WinForms app reaches UI Automation through the legacy MSAA bridge, which announced structure and name changes but never `IsEnabled` when probed. So a `condition: "enabled"` wait against one cannot be woken by an event; it falls back to the forced re-read, costing latency rather than a wrong answer. That is disclosed on the `WatchedProperty::IsEnabled` variant and in the changelog, and pinned by an on-box test measuring 4 walks — so it reads as a decision rather than as something to discover.

## Verification

Eleven on-box tests on real Windows hardware, in the interactive session:

- a quiet wait costs 3 walks against 22 with the signal disabled — the identical wait through two sessions differing in one thing
- a real UIA event drives the poll loop: a helper thread reveals a control mid-wait, matched at 1500ms in 3 walks. Neither bound discriminates alone, so both are asserted — walk count rules out a build with no subscription, elapsed rules out one that only ever reports `Quiet`
- the subscription reports a real change and stays quiet on an idle app
- a wait whose element is already present still matches, guarding the regression a subscription makes possible
- the `IsEnabled` fallback still matches, via the forced re-read

Plus 1724 workspace tests, `cargo fmt --check`, workspace clippy, and the `x86_64-pc-windows-gnu` cross-compile gate. The `cfg(windows)` unit tests were also executed under wine (41 against 28 on the host).

The on-box suite was run at `76d44e8`; the only commit after it is a comments-only sweep whose diff was verified to contain no code lines.

## Also here

Windows gains its first accessibility fixture — a WinForms `.ps1`, matching the `.py` Linux already has and the `.swift` on macOS. `glass-core` gains `ElementCondition::ALL`. `uiautomation` gains its `event` feature and `glass-a11y-windows` a `windows` dependency line for `IUIAutomation2::SetTransactionTimeout`, which bounds every cross-process call the subscription makes — no new package enters `Cargo.lock`.

Follow-up filed as #280: a `CacheRequest` bulk fetch takes the same 1500-node walk from 2330ms to 1524ms.

Every other backend polls exactly as before, and so does Windows if the subscription cannot be established or stops delivering.
