### PR TITLE
fix(core): wait for the stdin write's outcome instead of guessing at it

### DIFF
--- a/crates/glass-core/src/bounded.rs
+++ b/crates/glass-core/src/bounded.rs
@@ -8,6 +8,7 @@
 
 use std::io::{Read, Write};
 use std::process::{Child, Command, Output, Stdio};
+use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
@@ -88,22 +89,26 @@ fn run_bounded_inner(
         .map_err(|e| GlassError::Backend(format!("{op}: failed to start: {e}")))?;
 
     // Written on its own thread: a child that answers without consuming its input would otherwise
-    // leave the parent blocked in `write` with the deadline out of reach. The outcome is shared
-    // back, because a payload that only partly landed is the same silent truncation as a partial
-    // read — `pbcopy` would report a clipboard it never fully received.
-    let wrote: Arc<Mutex<Option<std::io::Error>>> = Arc::new(Mutex::new(None));
-    if let Some(bytes) = stdin
+    // leave the parent blocked in `write` with the deadline out of reach. The outcome comes back
+    // over a channel, because a payload that only partly landed is the same silent truncation as a
+    // partial read — `pbcopy` would report a clipboard it never fully received.
+    //
+    // A channel and not a shared cell: nothing joins this thread, so a cell says only what the
+    // writer had recorded by the time the parent happened to look, and "not yet recorded" is
+    // indistinguishable from "wrote everything". The receive below waits for an answer instead.
+    let stdin_len = stdin.as_ref().map_or(0, Vec::len);
+    let wrote = if let Some(bytes) = stdin
         && let Some(mut pipe) = child.stdin.take()
     {
-        let outcome = Arc::clone(&wrote);
+        let (tx, rx) = mpsc::channel();
         std::thread::spawn(move || {
-            if let Err(e) = pipe.write_all(&bytes)
-                && let Ok(mut outcome) = outcome.lock()
-            {
-                *outcome = Some(e);
-            }
+            // `pipe` is owned here, so the write end closes when this returns however it returns.
+            let _ = tx.send(pipe.write_all(&bytes));
         });
-    }
+        Some(rx)
+    } else {
+        None
+    };
 
     let stdout = Pipe::drain(child.stdout.take());
     let stderr = Pipe::drain(child.stderr.take());
@@ -143,12 +148,34 @@ fn run_bounded_inner(
     // tolerant line scanner that would read a truncated dump as a shorter window list, and glass
     // would then report the wrong geometry. `Command::output` cannot produce this — it reads to EOF
     // — so failing here keeps the contract callers already had.
-    if let Ok(mut wrote) = wrote.lock()
-        && let Some(e) = wrote.take()
-    {
-        return Err(GlassError::Backend(format!(
-            "{op}: could not write all of its input ({e}), so it acted on a partial payload"
-        )));
+    //
+    // Bounded by the same `settled_by` as the pipes, and for the same reason: a grandchild holding
+    // the read end keeps the write blocked exactly as it keeps a drain from reaching EOF. A write
+    // still in flight when that expires is reported rather than waited out — the thread stays
+    // parked until the kernel releases it, which a blocking write offers no way to cancel, but the
+    // caller is told its payload's fate is unknown instead of being handed a success.
+    if let Some(rx) = wrote {
+        match rx.recv_timeout(settled_by.saturating_duration_since(Instant::now())) {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                return Err(GlassError::Backend(format!(
+                    "{op}: could not write all of its input ({e}), so it acted on a partial payload"
+                )));
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                return Err(GlassError::Backend(format!(
+                    "{op}: exited, but had not finished writing its {stdin_len} bytes of input \
+                     {DRAIN_SETTLE:?} later (something it started may still hold the pipe), so it \
+                     may have acted on a partial payload"
+                )));
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(GlassError::Backend(format!(
+                    "{op}: the thread writing its input ended without reporting, so whether the \
+                     payload landed is unknown"
+                )));
+            }
+        }
     }
     if !out_done || !err_done {
         return Err(GlassError::Backend(format!(
@@ -519,6 +546,33 @@ mod tests {
         assert!(
             err.to_string().contains("partial payload"),
             "must say the input did not land: {err}"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_write_still_in_flight_when_the_child_exits_is_not_reported_as_landed() {
+        // The sibling test above races: the child exits, and whether the write thread has recorded
+        // its `EPIPE` by the time the parent looks is a matter of scheduling. This one removes the
+        // race. The child exits at once but leaves a grandchild holding the read end, so the write
+        // neither completes nor fails — it is still blocked, and the outcome the parent reads was
+        // never written by anyone. The grandchild's own stdout and stderr go to /dev/null, so both
+        // drains still reach EOF and what is under test is the write, not a held-open output pipe.
+        //
+        // `exec 3<&0` then `<&3` is load-bearing: POSIX gives a background job in a non-interactive
+        // shell its stdin from /dev/null *before* any explicit redirection, so a plain `sleep &`
+        // does not inherit the pipe and the write fails fast with `EPIPE` instead of hanging.
+        let err = run_bounded_with_stdin(
+            Command::new("/bin/sh")
+                .args(["-c", "exec 3<&0; sleep 2 <&3 >/dev/null 2>&1 & printf done"]),
+            Duration::from_secs(10),
+            "test:stdin-in-flight",
+            &vec![b'x'; 4 * 1024 * 1024],
+        )
+        .expect_err("a payload whose fate is unknown must not pass as landed");
+        assert!(
+            err.to_string().contains("had not finished writing"),
+            "must say the write never finished: {err}"
         );
     }
 

--- a/crates/glass-core/src/bounded.rs
+++ b/crates/glass-core/src/bounded.rs
@@ -94,8 +94,8 @@ fn run_bounded_inner(
     // partial read — `pbcopy` would report a clipboard it never fully received.
     //
     // A channel and not a shared cell: nothing joins this thread, so a cell says only what the
-    // writer had recorded by the time the parent happened to look, and "not yet recorded" is
-    // indistinguishable from "wrote everything". The receive below waits for an answer instead.
+    // writer had recorded when the parent looked, and "not yet recorded" reads the same as "wrote
+    // everything".
     let stdin_len = stdin.as_ref().map_or(0, Vec::len);
     let wrote = if let Some(bytes) = stdin
         && let Some(mut pipe) = child.stdin.take()
@@ -151,9 +151,8 @@ fn run_bounded_inner(
     //
     // Bounded by the same `settled_by` as the pipes, and for the same reason: a grandchild holding
     // the read end keeps the write blocked exactly as it keeps a drain from reaching EOF. A write
-    // still in flight when that expires is reported rather than waited out — the thread stays
-    // parked until the kernel releases it, which a blocking write offers no way to cancel, but the
-    // caller is told its payload's fate is unknown instead of being handed a success.
+    // still in flight when that expires is reported rather than waited out; the thread stays parked
+    // until the kernel releases it, which a blocking write offers no way to cancel.
     if let Some(rx) = wrote {
         match rx.recv_timeout(settled_by.saturating_duration_since(Instant::now())) {
             Ok(Ok(())) => {}
@@ -552,12 +551,11 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn a_write_still_in_flight_when_the_child_exits_is_not_reported_as_landed() {
-        // The sibling test above races: the child exits, and whether the write thread has recorded
-        // its `EPIPE` by the time the parent looks is a matter of scheduling. This one removes the
-        // race. The child exits at once but leaves a grandchild holding the read end, so the write
-        // neither completes nor fails — it is still blocked, and the outcome the parent reads was
-        // never written by anyone. The grandchild's own stdout and stderr go to /dev/null, so both
-        // drains still reach EOF and what is under test is the write, not a held-open output pipe.
+        // The sibling test above races: whether the write thread has recorded its `EPIPE` when the
+        // parent looks is a matter of scheduling. Here the child exits at once but leaves a
+        // grandchild holding the read end, so the write is still blocked and no outcome has been
+        // written by anyone. The grandchild's stdout and stderr go to /dev/null, so both drains
+        // reach EOF and what is under test is the write, not a held-open output pipe.
         //
         // `exec 3<&0` then `<&3` is load-bearing: POSIX gives a background job in a non-interactive
         // shell its stdin from /dev/null *before* any explicit redirection, so a plain `sleep &`


### PR DESCRIPTION
`run_bounded_with_stdin` wrote the payload on its own thread and read that thread's outcome from a shared cell without ever joining it. Nothing ordered the two. If the writer had not recorded by the time the parent looked, "not yet recorded" was indistinguishable from "wrote everything", and the call returned `Ok` for a payload that never landed — the silent truncation the mechanism exists to prevent, on a path whose caller sets the clipboard.

The only thing between the child exiting and the read was the 200ms drain-settle window, which exists for the unrelated purpose of letting stdout and stderr reach EOF.

## What changed

The outcome now comes back over a channel the parent waits on, bounded by the same `settled_by` deadline the pipe drains already use — and for the same reason: a grandchild holding the read end blocks the write exactly as it keeps a drain from reaching EOF. A write still in flight when that expires is reported rather than waited out. The thread stays parked until the kernel releases it, which a blocking write offers no way to cancel, but the caller is told its payload's fate is unknown instead of being handed a success.

Three outcomes are now distinguished where there were two: the write failed (unchanged message), the write never finished, and the writing thread ended without reporting.

## The test

The existing `a_child_that_ignores_its_stdin_...` test is a race by construction — whether the writer has recorded its `EPIPE` when the parent looks is a matter of scheduling. It passed 90/90 locally across idle, loaded and single-core runs, and failed three times in one CI run.

The new test removes the race instead of making it rarer. The child exits at once but leaves a grandchild holding the read end, so the write neither completes nor fails; the grandchild's own stdout and stderr go to `/dev/null` so both drains still reach EOF, making the write the only thing under test.

`exec 3<&0` then `<&3` is load-bearing. POSIX gives a background job in a non-interactive shell its stdin from `/dev/null` *before* any explicit redirection, so a plain `sleep &` does not inherit the pipe — the first version of this fixture failed fast with `EPIPE` and proved nothing. Confirmed directly: that form returns in ~2ms, the `<&3` form holds the writer for the full sleep.

Verified red before the fix, for the right reason: `Ok(Output { status: 0, stdout: "done" })` for 4MB that was provably still in flight.

## Why this is worth its own PR

Found while investigating CI on #281, which it blocks. The failure took out four checks from one cause — the workspace test job plus the unmutated baselines of mutation shards 5 and 6, which cascaded to the mutation gate. `bounded.rs` is untouched by that branch.

1719 workspace tests, `cargo fmt --check`, and workspace clippy all clean.
