### PR TITLE
fix(core): a wait shorter than the re-read ceiling could answer from one stale read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ internal refactors, CI, or test-only changes.
 ## [Unreleased]
 
 ### Fixed
+- A `glass_wait_for_element` shorter than a second could report an element absent that was on
+  screen. Where the platform announces changes, the wait skips reads it has been told are pointless
+  and reads anyway once a second in case it was told wrong — but that second was previously counted
+  in polling intervals rather than measured, so at the 200ms default it landed at two seconds, past
+  the end of many waits. Such a wait answered from the single read it took before the change it was
+  waiting for. It now reads once more before reporting nothing found, whatever its length, and the
+  once-a-second floor no longer moves with `interval_ms`. Affects every backend that can subscribe
+  to change notifications, which today is Linux.
 - Android's `set_value` now refuses a write whose target has drifted in value, not just in role,
   name or bounds. A re-walk that lands on a same-role, same-name, same-rect element holding
   *different* data — a recycled list row reusing the same view is the case this closes — is now
@@ -84,8 +92,9 @@ internal refactors, CI, or test-only changes.
 - On Linux, `glass_wait_for_element` no longer re-reads the whole accessibility tree on a timer.
   Where the platform can say whether anything changed, a wait for something that has not happened
   yet now reads the tree when something changes instead of once per interval — measured against the
-  GTK test fixture, 3 reads for a 3-second wait where it previously took 22. It re-reads about once
-  a second regardless, so a change the platform does not announce costs latency, not a wrong answer.
+  GTK test fixture, 4 reads for a 3-second wait where it previously took 22. It re-reads once a
+  second regardless, and always once more before reporting nothing found, so a change the platform
+  does not announce costs latency, not a wrong answer.
   Every other backend polls exactly as before, and so does Linux if the subscription cannot be
   established or stops delivering.
 

--- a/crates/glass-core/src/poll.rs
+++ b/crates/glass-core/src/poll.rs
@@ -59,6 +59,18 @@ pub fn poll_until_with_pause<T>(
             });
         }
         if start.elapsed().as_millis() as u64 >= timeout_ms {
+            // Never answer "not found" on information older than the last pause. A `pause` that
+            // skipped ticks did so because it was told nothing changed, and a caller told wrong —
+            // a platform that declines to announce some change — would otherwise have the loop
+            // report an element absent that has been on screen since before the last pause. One
+            // tick, at a deadline the wait has already spent, is what keeps a skipped tick a cost
+            // saving rather than a wrong answer.
+            if !run_tick && let Some(v) = tick()? {
+                return Ok(PollOutcome {
+                    value: Some(v),
+                    elapsed_ms: start.elapsed().as_millis() as u64,
+                });
+            }
             return Ok(PollOutcome {
                 value: None,
                 elapsed_ms: start.elapsed().as_millis() as u64,
@@ -93,6 +105,32 @@ mod tests {
         // Two unsatisfied ticks, so two pauses — and no sleep of the loop's own, which is what
         // lets a caller wake on an event instead of waiting out an interval.
         assert_eq!(paused.get(), 2);
+    }
+
+    #[test]
+    fn a_loop_that_skipped_its_ticks_looks_once_more_before_answering_no() {
+        // The whole point of a skipped tick is that the caller was *told* nothing changed. A
+        // caller that is told wrong — a platform that declines to announce a change — would
+        // otherwise have the loop report "not found" on information it has not refreshed since
+        // the last pause. One tick at the deadline is what keeps a skip a cost saving rather than
+        // a wrong answer.
+        let mut ticks = 0;
+        let out = poll_until_with_pause(
+            1,
+            30,
+            |_| false, // "nothing changed" — every time, and wrongly
+            || {
+                ticks += 1;
+                // Absent on the first look, present from then on: the change the pause hid.
+                Ok(if ticks > 1 { Some(7) } else { None })
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            out.value,
+            Some(7),
+            "answered from information older than the last pause"
+        );
     }
 
     #[test]

--- a/crates/glass-core/src/poll.rs
+++ b/crates/glass-core/src/poll.rs
@@ -59,12 +59,10 @@ pub fn poll_until_with_pause<T>(
             });
         }
         if start.elapsed().as_millis() as u64 >= timeout_ms {
-            // Never answer "not found" on information older than the last pause. A `pause` that
-            // skipped ticks did so because it was told nothing changed, and a caller told wrong —
-            // a platform that declines to announce some change — would otherwise have the loop
-            // report an element absent that has been on screen since before the last pause. One
-            // tick, at a deadline the wait has already spent, is what keeps a skipped tick a cost
-            // saving rather than a wrong answer.
+            // Never answer "not found" on information older than the last pause: a pause told
+            // "nothing changed" by a platform that declines to announce it would otherwise report
+            // an element absent that is on screen. One tick at an already-spent deadline keeps a
+            // skip a cost saving rather than a wrong answer.
             if !run_tick && let Some(v) = tick()? {
                 return Ok(PollOutcome {
                     value: Some(v),
@@ -109,11 +107,8 @@ mod tests {
 
     #[test]
     fn a_loop_that_skipped_its_ticks_looks_once_more_before_answering_no() {
-        // The whole point of a skipped tick is that the caller was *told* nothing changed. A
-        // caller that is told wrong — a platform that declines to announce a change — would
-        // otherwise have the loop report "not found" on information it has not refreshed since
-        // the last pause. One tick at the deadline is what keeps a skip a cost saving rather than
-        // a wrong answer.
+        // A pause told "nothing changed" by a platform that declines to announce it must not
+        // leave the loop answering from information it has not refreshed since.
         let mut ticks = 0;
         let out = poll_until_with_pause(
             1,

--- a/crates/glass-core/src/poll.rs
+++ b/crates/glass-core/src/poll.rs
@@ -129,6 +129,25 @@ mod tests {
     }
 
     #[test]
+    fn the_deadline_look_is_skipped_when_this_iteration_already_ticked() {
+        // The deadline read exists for information the loop has not refreshed. A loop that just
+        // ticked has, so reading again would bill every ordinary polling caller an extra tick for
+        // nothing.
+        let mut ticks = 0;
+        poll_until_with_pause(
+            0,
+            0, // one tick, then straight to the deadline
+            |_| true,
+            || {
+                ticks += 1;
+                Ok(None::<()>)
+            },
+        )
+        .unwrap();
+        assert_eq!(ticks, 1, "ticked again at a deadline it had just looked at");
+    }
+
+    #[test]
     fn a_pause_that_returns_early_still_honours_the_deadline() {
         // A signal that fires constantly must bound the loop, not spin it forever.
         let started = Instant::now();

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -414,6 +414,19 @@ pub(crate) fn fake_tree_enabled() -> AxTree {
     t
 }
 
+/// [`fake_tree_enabled`] with the button also checked, so a wait on `ElementCondition::Checked`
+/// matches this tree and not that one — the pair is how a test stages a change mid-wait.
+pub(crate) fn fake_tree_checked() -> AxTree {
+    let mut t = fake_tree();
+    t.root.children[0].states = AxStates {
+        enabled: true,
+        checkable: true,
+        checked: true,
+        ..Default::default()
+    };
+    t
+}
+
 pub(crate) fn window_info(id: u64, geometry: WindowGeometry, active: bool) -> WindowInfo {
     WindowInfo {
         id: WindowId(id),

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -9,11 +9,10 @@ use super::*;
 /// wrong result rather than a slow one. This bounds that to added latency, one re-read per second
 /// no matter what the platform does or does not announce.
 ///
-/// Wall-clock, and deliberately not a count of quiet intervals: a count is a ceiling only in units
-/// of `interval_ms`, so it moves with the caller's interval and can sit past the caller's whole
-/// timeout. Ten intervals at the 200ms `glass_wait_for_element` default is two seconds — longer
-/// than many waits ever run, which made the ceiling unreachable for exactly the short waits that
-/// could least afford to answer from one stale read.
+/// Wall-clock, and deliberately not a count of quiet intervals: a count scales with the caller's
+/// `interval_ms` and can sit past the caller's whole timeout — ten at the 200ms
+/// `glass_wait_for_element` default is two seconds, which put the ceiling out of reach of exactly
+/// the short waits that could least afford one stale read.
 const REREAD_AFTER: std::time::Duration = std::time::Duration::from_secs(1);
 
 /// Parameters for [`Glass::wait_stable`].
@@ -1240,10 +1239,8 @@ mod tests {
 
     #[test]
     fn a_quiet_wait_walks_once_and_looks_again_at_the_deadline() {
-        // The point of the change: told nothing changed, the wait must not re-read the tree on the
-        // interval. The second walk is the deadline read — a wait may skip work whose answer it was
-        // told cannot have changed, but it may not answer "not matched" without looking once after
-        // the last thing it was told.
+        // The point of the change: told nothing changed, the wait must not re-read on the
+        // interval. The second walk is the deadline read — see `poll_until_with_pause`.
         let (mut g, walks) = glass_with_a11y_counted(
             FakePlatform::new(100, 100),
             vec![fake_tree_enabled()],
@@ -1337,9 +1334,9 @@ mod tests {
 
     #[test]
     fn a_long_quiet_wait_reads_anyway_now_and_then() {
-        // 2.5s spans two `REREAD_AFTER` ceilings, so two forced reads on top of the first and the
-        // one at the deadline. The interval is deliberately far smaller than the ceiling: a count
-        // of intervals would put the ceiling at 500ms here and read five times.
+        // 2.5s spans two `REREAD_AFTER` ceilings: two forced reads on top of the first and the
+        // deadline's. The interval is far smaller than the ceiling on purpose — a count of
+        // intervals would put it at 500ms here and read five times.
         let (mut g, walks) = glass_with_a11y_counted(
             FakePlatform::new(100, 100),
             vec![fake_tree_enabled()],
@@ -1359,11 +1356,9 @@ mod tests {
 
     #[test]
     fn a_wait_too_short_to_reach_the_ceiling_still_sees_an_unannounced_change() {
-        // The regression this fixes. A platform that declines to announce some change leaves the
-        // wait skipping every tick, and a wait whose whole budget is shorter than `REREAD_AFTER`
-        // never reaches the forced read — so before the deadline read it answered "not matched"
-        // from the single snapshot it took before the change happened. Not a slow answer: a wrong
-        // one, for an element that is on screen.
+        // The regression this fixes: a wait whose whole budget is shorter than `REREAD_AFTER`
+        // never reaches the forced read, so before the deadline read it answered from the single
+        // snapshot it took before the change happened — a wrong answer, for an element on screen.
         let (mut g, walks) = glass_with_a11y_counted(
             FakePlatform::new(100, 100),
             // Absent on the first read, present on every read after it.
@@ -1384,9 +1379,8 @@ mod tests {
 
     #[test]
     fn the_ceiling_is_wall_clock_so_a_wide_interval_does_not_push_it_out() {
-        // A count of quiet intervals scales the ceiling with the caller's interval: ten of the
-        // 200ms `glass_wait_for_element` default is two seconds. Wall-clock, the same wait sees an
-        // unannounced change inside one.
+        // Ten quiet intervals at the 200ms `glass_wait_for_element` default is a two-second
+        // ceiling; wall-clock, the same wait sees an unannounced change inside one.
         let (mut g, _walks) = glass_with_a11y_counted(
             FakePlatform::new(100, 100),
             vec![fake_tree_enabled(), fake_tree_checked()],

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -2,13 +2,19 @@
 //! and the wait/scroll parameter and outcome types.
 use super::*;
 
-/// How many "nothing changed" answers to accept before reading the tree anyway.
+/// How long to go on a signal's word alone before reading the tree anyway.
 ///
 /// A signal reports the change classes it subscribed to, from the senders it resolved; anything
 /// outside that would otherwise let a wait answer "not matched" without ever looking again — a
-/// wrong result rather than a slow one. This bounds that to added latency: at the default 100ms
-/// interval, one re-read per second no matter what the platform does or does not announce.
-const QUIET_RUNS_BEFORE_REREAD: u32 = 10;
+/// wrong result rather than a slow one. This bounds that to added latency, one re-read per second
+/// no matter what the platform does or does not announce.
+///
+/// Wall-clock, and deliberately not a count of quiet intervals: a count is a ceiling only in units
+/// of `interval_ms`, so it moves with the caller's interval and can sit past the caller's whole
+/// timeout. Ten intervals at the 200ms `glass_wait_for_element` default is two seconds — longer
+/// than many waits ever run, which made the ceiling unreachable for exactly the short waits that
+/// could least afford to answer from one stale read.
+const REREAD_AFTER: std::time::Duration = std::time::Duration::from_secs(1);
 
 /// Parameters for [`Glass::wait_stable`].
 #[derive(Clone, Debug)]
@@ -397,7 +403,8 @@ impl Glass {
         let remaining = params
             .timeout_ms
             .saturating_sub(started.elapsed().as_millis() as u64);
-        let mut quiet_budget = QUIET_RUNS_BEFORE_REREAD;
+        // Starts now rather than at the first read: the first tick follows immediately.
+        let mut last_read = std::time::Instant::now();
         let outcome = crate::poll::poll_until_with_pause(
             params.interval_ms,
             remaining,
@@ -406,16 +413,8 @@ impl Glass {
                 let read_now = match signal.as_mut() {
                     Some(s) => match s.wait(d) {
                         ChangeWait::Changed => true,
-                        // Read anyway now and then — see `QUIET_RUNS_BEFORE_REREAD`.
-                        ChangeWait::Quiet => {
-                            quiet_budget = quiet_budget.saturating_sub(1);
-                            if quiet_budget == 0 {
-                                quiet_budget = QUIET_RUNS_BEFORE_REREAD;
-                                true
-                            } else {
-                                false
-                            }
-                        }
+                        // Read anyway now and then — see `REREAD_AFTER`.
+                        ChangeWait::Quiet => last_read.elapsed() >= REREAD_AFTER,
                         // See `ChangeWait`: an unusable signal must not read as a quiet one.
                         ChangeWait::Unusable => {
                             signal = None;
@@ -424,6 +423,9 @@ impl Glass {
                     },
                     None => true,
                 };
+                if read_now {
+                    last_read = std::time::Instant::now();
+                }
                 // One interval between reads, whatever woke us. A chatty app (spinner, clock,
                 // progress bar) would otherwise drive back-to-back walks with no gap, hammering the
                 // same bus the app is trying to serve — and a signal that returns early without
@@ -1237,8 +1239,11 @@ mod tests {
     }
 
     #[test]
-    fn a_quiet_wait_walks_once() {
-        // The point of the change: told nothing changed, the wait must not re-read the tree.
+    fn a_quiet_wait_walks_once_and_looks_again_at_the_deadline() {
+        // The point of the change: told nothing changed, the wait must not re-read the tree on the
+        // interval. The second walk is the deadline read — a wait may skip work whose answer it was
+        // told cannot have changed, but it may not answer "not matched" without looking once after
+        // the last thing it was told.
         let (mut g, walks) = glass_with_a11y_counted(
             FakePlatform::new(100, 100),
             vec![fake_tree_enabled()],
@@ -1249,7 +1254,11 @@ mod tests {
         let o = g.wait_for_element(&never_matches(20, 120)).unwrap();
 
         assert!(!o.matched);
-        assert_eq!(walks.load(Ordering::Relaxed), 1, "a quiet wait re-walked");
+        assert_eq!(
+            walks.load(Ordering::Relaxed),
+            2,
+            "a quiet wait re-walked on the interval"
+        );
     }
 
     #[test]
@@ -1328,8 +1337,9 @@ mod tests {
 
     #[test]
     fn a_long_quiet_wait_reads_anyway_now_and_then() {
-        // 25 intervals is two `QUIET_RUNS_BEFORE_REREAD` ceilings, so two forced reads on top of
-        // the first.
+        // 2.5s spans two `REREAD_AFTER` ceilings, so two forced reads on top of the first and the
+        // one at the deadline. The interval is deliberately far smaller than the ceiling: a count
+        // of intervals would put the ceiling at 500ms here and read five times.
         let (mut g, walks) = glass_with_a11y_counted(
             FakePlatform::new(100, 100),
             vec![fake_tree_enabled()],
@@ -1337,13 +1347,60 @@ mod tests {
         );
         g.start(&spec()).unwrap();
 
-        let o = g.wait_for_element(&never_matches(10, 250)).unwrap();
+        let o = g.wait_for_element(&never_matches(50, 2_500)).unwrap();
 
         assert!(!o.matched);
         let n = walks.load(Ordering::Relaxed);
         assert!(
-            (2..=5).contains(&n),
-            "a quiet 250ms wait at a 10ms interval read {n} times; the ceiling is not firing"
+            (3..=6).contains(&n),
+            "a quiet 2.5s wait at a 50ms interval read {n} times; the ceiling is not firing"
+        );
+    }
+
+    #[test]
+    fn a_wait_too_short_to_reach_the_ceiling_still_sees_an_unannounced_change() {
+        // The regression this fixes. A platform that declines to announce some change leaves the
+        // wait skipping every tick, and a wait whose whole budget is shorter than `REREAD_AFTER`
+        // never reaches the forced read — so before the deadline read it answered "not matched"
+        // from the single snapshot it took before the change happened. Not a slow answer: a wrong
+        // one, for an element that is on screen.
+        let (mut g, walks) = glass_with_a11y_counted(
+            FakePlatform::new(100, 100),
+            // Absent on the first read, present on every read after it.
+            vec![fake_tree_enabled(), fake_tree_checked()],
+            Some(|| Box::new(NeverSignals) as Box<dyn ChangeSignal>),
+        );
+        g.start(&spec()).unwrap();
+
+        // 600ms at a 200ms interval: three intervals, and no ceiling inside the budget.
+        let o = g.wait_for_element(&never_matches(200, 600)).unwrap();
+
+        assert!(
+            o.matched,
+            "answered from one stale read after {} walks",
+            walks.load(Ordering::Relaxed)
+        );
+    }
+
+    #[test]
+    fn the_ceiling_is_wall_clock_so_a_wide_interval_does_not_push_it_out() {
+        // A count of quiet intervals scales the ceiling with the caller's interval: ten of the
+        // 200ms `glass_wait_for_element` default is two seconds. Wall-clock, the same wait sees an
+        // unannounced change inside one.
+        let (mut g, _walks) = glass_with_a11y_counted(
+            FakePlatform::new(100, 100),
+            vec![fake_tree_enabled(), fake_tree_checked()],
+            Some(|| Box::new(NeverSignals) as Box<dyn ChangeSignal>),
+        );
+        g.start(&spec()).unwrap();
+
+        let o = g.wait_for_element(&never_matches(200, 5_000)).unwrap();
+
+        assert!(o.matched);
+        assert!(
+            o.elapsed_ms < 1_500,
+            "took {}ms; an interval-counted ceiling would land near 2000",
+            o.elapsed_ms
         );
     }
 


### PR DESCRIPTION
Two defects with one cause: the ceiling that bounds how long a wait trusts a change signal was a **count of polling intervals** rather than a duration.

## The wrong answer

`QUIET_RUNS_BEFORE_REREAD = 10` fires after ten quiet intervals. At the `glass_wait_for_element` default of `interval_ms: 200`, that is two seconds — longer than many waits ever run.

A wait with `timeout_ms` under the ceiling therefore never reached the forced read *at all*. Trace, at the defaults with a signal that reports `Quiet`:

- t≈0 — read #1, no match. Deadline not reached.
- t=200…1400 — every tick skipped; the budget walks 10→3 and never reaches 0.
- t=1600 — deadline. `matched: false`.

**One read for the whole wait**, and the answer comes from a snapshot taken before the change it was waiting for. Polling did eight. This is not the latency the design accepts — it is a wrong answer for an element that is on screen, and the caller cannot distinguish it from "never happened".

It matters most where a platform declines to announce a change, which is a real and documented case rather than a hypothetical: some UI Automation providers never announce `IsEnabled`, so `condition: "enabled"` waits land exactly here.

## What changed

**The ceiling is wall-clock.** `REREAD_AFTER = 1s`, measured rather than counted, so it no longer moves with the caller's `interval_ms`.

**The poll loop looks once more before answering "not found."** A caller may skip work whose answer it was told cannot have changed; it may not answer from information older than the last thing it was told. That property belongs at the poll layer where the skip happens, not in each caller — `poll_until_with_pause` now runs one tick at the deadline if the last pause skipped one.

The two are complementary. The wall-clock ceiling bounds staleness *during* a wait; the deadline read bounds it at the *end*, including for waits too short to reach any ceiling.

## Tests, red first

- `a_loop_that_skipped_its_ticks_looks_once_more_before_answering_no` — poll layer, a pause that always (wrongly) says "nothing changed".
- `a_wait_too_short_to_reach_the_ceiling_still_sees_an_unannounced_change` — 600ms at a 200ms interval, no ceiling inside the budget, element appearing after the first read.
- `the_ceiling_is_wall_clock_so_a_wide_interval_does_not_push_it_out` — asserts the change is seen inside 1.5s where an interval-counted ceiling lands near 2s.

`a_quiet_wait_walks_once` is renamed and its assertion changed from 1 to 2, because the deadline read is exactly the behaviour this fixes. It was the test most likely to be quietly loosened, so it is worth saying plainly: the contract changed, and the new number is the contract.

## Measured

On the AT-SPI fixture, a quiet 3-second wait at a 100ms interval now costs **4 walks against polling's 22**, up from 3. The extra walk is the deadline read. The Linux changelog entry is corrected from 3 to 4 in this PR rather than left to drift.

Full AT-SPI suite green (28 tests), 1722 workspace tests, `cargo fmt --check` and workspace clippy clean.

## Scope

`glass-core` only, so it applies to every backend that can subscribe to change notifications — today Linux, and Windows in #281, which is where the defect was found.
