### PR TITLE
a11y(android): actuate element clicks through the accessibility service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,13 +59,19 @@ internal refactors, CI, or test-only changes.
   UIKit and SwiftUI equivalents in [`examples/ios-role-fixture/`](examples/ios-role-fixture/) — so
   anyone can read the same trees back.
 - `glass_click_element` now actuates through Android's accessibility action when the optional
-  on-device companion is installed, instead of always synthesizing a tap. It reaches controls a
-  tap cannot — an element scrolled far below the fold actuates in place — and the result's
-  `method` field reports `native-action` for those clicks. A control whose label is a separate
-  element from the control itself, as in Jetpack Compose, resolves to the enclosing control
-  that handles the tap. Clicking a disabled control is now an error rather than a tap that
-  silently does nothing, and a checkbox is only reported clicked once its state is observed to
-  change. The `uiautomator` reader and iOS still use the pointer path and say so.
+  on-device accessibility companion is installed, instead of always synthesizing a tap. It reaches
+  controls a tap cannot — an element scrolled far below the fold actuates in place — and the
+  result's `method` field reports `native-action` for those clicks. A control whose label is a
+  separate element from the control itself, as in Jetpack Compose, resolves to the enclosing
+  control that handles the tap. Clicking a disabled control is now an error rather than a tap that
+  silently does nothing, and a checkbox or switch is only reported clicked once its state is
+  observed to change (a radio button or tab already selected counts as clicked, since re-selecting
+  it is a no-op). The `uiautomator` reader and iOS still use the pointer path and say so.
+- `glass_click_element` now discloses which element it actuated. When the native action fires on a
+  different element than the one you named — a control whose label is a separate element from the
+  control itself — the result and the audit record carry `actuated_id`, so "clicked the Save label"
+  and "clicked the card around it, which navigated away" are no longer indistinguishable
+  afterwards.
 - More elements report a real role instead of `Other`: on Windows, documents; on macOS, outlines
   and their rows, split views and their dividers, scroll areas, headings, and menu buttons; on
   Android, the AndroidX card container, the AppCompat linear layout, the view that hosts a Compose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,14 @@ internal refactors, CI, or test-only changes.
   [`examples/android-role-fixture/`](examples/android-role-fixture/) (builds without Gradle) and the
   UIKit and SwiftUI equivalents in [`examples/ios-role-fixture/`](examples/ios-role-fixture/) — so
   anyone can read the same trees back.
+- `glass_click_element` now actuates through Android's accessibility action when the optional
+  on-device companion is installed, instead of always synthesizing a tap. It reaches controls a
+  tap cannot — an element scrolled far below the fold actuates in place — and the result's
+  `method` field reports `native-action` for those clicks. A control whose label is a separate
+  element from the control itself, as in Jetpack Compose, resolves to the enclosing control
+  that handles the tap. Clicking a disabled control is now an error rather than a tap that
+  silently does nothing, and a checkbox is only reported clicked once its state is observed to
+  change. The `uiautomator` reader and iOS still use the pointer path and say so.
 - More elements report a real role instead of `Other`: on Windows, documents; on macOS, outlines
   and their rows, split views and their dividers, scroll areas, headings, and menu buttons; on
   Android, the AndroidX card container, the AppCompat linear layout, the view that hosts a Compose

--- a/README.md
+++ b/README.md
@@ -77,9 +77,14 @@ Compose, Android resolves to the enclosing control that would have handled the t
 Android's companion-free `uiautomator` reader always use the pointer path. The result's `method`
 field (`native-action`/`pointer`) says which path actually ran for that click, with
 `native_fallback` explaining why when it fell back — the source of truth per click, not the
-backend alone. On the backends that attempt it, the native path re-checks the element against
+backend alone — and `actuated_id` naming the element actually clicked when it isn't the one you
+named. On the backends that attempt it, the native path re-checks the element against
 the live tree, so a click whose element no longer matches errors instead of clicking stale
 coordinates; the pointer-only paths have no such live check.
+
+Clicking a control the tree reports **disabled** is an error on the native path, not a tap that
+silently does nothing — a contract change if you were relying on a click that lands on a greyed-out
+button and reports success.
 
 ## Install at a glance
 

--- a/README.md
+++ b/README.md
@@ -67,16 +67,19 @@ text, so routine checks between screenshots cost no vision tokens. Why the loop 
 [the build → see → interact → debug loop](docs/explanation/the-loop.md).
 
 `glass_click_element` tries the platform's native accessibility action first — AT-SPI `Action` on
-Linux, UI Automation patterns on Windows, `AXPress` on macOS — which actuates elements
-that are occluded or scrolled off-screen and, on macOS, without moving the cursor. Not every
-control exposes one (some toolkit checkbuttons expose no action even on a backend that otherwise
-supports it), so the click falls back to a synthetic pointer click at the element's center when it
-doesn't. iOS and Android always use the pointer path today. The result's `method` field
-(`native-action`/`pointer`) says which path actually ran for that click, with `native_fallback`
-explaining why when it fell back — the source of truth per click, not the backend alone. On those
-three backends the native attempt re-checks the element against the live tree, so a click whose
-element no longer matches errors instead of clicking stale coordinates; the pointer-only iOS and
-Android paths have no such live check.
+Linux, UI Automation patterns on Windows, `AXPress` on macOS, and `ACTION_CLICK` on Android when
+the optional on-device accessibility companion is installed — which actuates elements that are
+occluded or scrolled off-screen and, on macOS, without moving the cursor. Not every control
+exposes one (some toolkit checkbuttons expose no action even on a backend that otherwise
+supports it), so the click falls back to a synthetic pointer click at the element's center when
+it doesn't. Where a control's label is a separate element from the control itself, as in Jetpack
+Compose, Android resolves to the enclosing control that would have handled the tap. iOS and
+Android's companion-free `uiautomator` reader always use the pointer path. The result's `method`
+field (`native-action`/`pointer`) says which path actually ran for that click, with
+`native_fallback` explaining why when it fell back — the source of truth per click, not the
+backend alone. On the backends that attempt it, the native path re-checks the element against
+the live tree, so a click whose element no longer matches errors instead of clicking stale
+coordinates; the pointer-only paths have no such live check.
 
 ## Install at a glance
 

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -66,7 +66,7 @@ impl Accessibility for LinuxA11y {
         }
     }
 
-    fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<()> {
+    fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<Option<AxNodeId>> {
         let ctx = ctx.clone();
         let target = target.clone();
         let (tx, rx) = mpsc::channel();
@@ -74,7 +74,8 @@ impl Accessibility for LinuxA11y {
             let _ = tx.send(run_invoke(&ctx, &target));
         });
         match rx.recv_timeout(SNAPSHOT_TIMEOUT) {
-            Ok(r) => r,
+            // This reader actuates the element it resolved, so it never substitutes another.
+            Ok(r) => r.map(|()| None),
             // The worker thread outlives this timeout, so the action may already have been
             // dispatched — say so. This error is NOT fallback-eligible (see
             // `GlassError::invoke_fallback_eligible`), so no pointer click is layered on top.

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -46,7 +46,7 @@ impl<A: glass_core::Accessibility> glass_core::Accessibility for Counting<A> {
         &mut self,
         ctx: &glass_core::AxContext,
         target: &glass_core::AxTarget,
-    ) -> glass_core::Result<()> {
+    ) -> glass_core::Result<Option<glass_core::AxNodeId>> {
         self.inner.invoke(ctx, target)
     }
 }
@@ -585,7 +585,7 @@ fn click_element_native_invokes_gtk_switch() {
     let method = glass.click_element(switch.id).expect("click");
     assert_eq!(
         method,
-        glass_core::ClickMethod::NativeAction,
+        glass_core::ClickMethod::NativeAction { actuated: None },
         "a GTK Switch exposes an activation action; the native path must take it"
     );
     // The toolkit applies the action on its next main-loop pass — poll briefly.

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -153,7 +153,7 @@ impl Accessibility for MacosA11y {
         }
     }
 
-    fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<()> {
+    fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<Option<AxNodeId>> {
         let (window_el, scale) = resolve_window(ctx)?;
 
         // Start at 0, same numbering rationale as `set_value`. Unlike `set_value` (whose
@@ -184,7 +184,10 @@ impl Accessibility for MacosA11y {
         // generic press with no universal post-state to read back — a checkbox's AXValue, a
         // button's nothing, a menu item's opened menu — so there is nothing to confirm against.
         // Accepted parity gap: a control that accepts AXPress without acting reports success.
-        ffi::perform_action(&el, "AXPress").map_err(|e| GlassError::AxActionFailed(target.id.0, e))
+        // This reader actuates the element it resolved, so it never substitutes another.
+        ffi::perform_action(&el, "AXPress")
+            .map(|()| None)
+            .map_err(|e| GlassError::AxActionFailed(target.id.0, e))
     }
 }
 

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -80,7 +80,7 @@ impl Accessibility for WindowsA11y {
         }
     }
 
-    fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<()> {
+    fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<Option<AxNodeId>> {
         let ctx = ctx.clone();
         let target = target.clone();
         let (tx, rx) = mpsc::channel();
@@ -88,7 +88,8 @@ impl Accessibility for WindowsA11y {
             let _ = tx.send(run_invoke(&ctx, &target));
         });
         match rx.recv_timeout(SNAPSHOT_TIMEOUT) {
-            Ok(r) => r,
+            // This reader actuates the element it resolved, so it never substitutes another.
+            Ok(r) => r.map(|()| None),
             // The worker thread outlives this timeout, so the pattern call may already have
             // been dispatched — say so. This error is NOT fallback-eligible (see
             // `GlassError::invoke_fallback_eligible`), so no pointer click is layered on top.

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -223,9 +223,8 @@ impl Default for AndroidA11y {
     }
 }
 
-/// Find `target.id` and reject a tree that drifted under it. The guard half of
-/// [`editable_target`], shared with the service reader's `invoke`, which needs the same
-/// rejection without the editable check.
+/// Find `target.id` and reject a tree that drifted under it — shared by [`editable_target`]
+/// and the service reader's `invoke`, which needs the same rejection without the editable check.
 pub(crate) fn fingerprinted<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&'a AxNode> {
     let node = tree
         .find(target.id)

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -223,6 +223,22 @@ impl Default for AndroidA11y {
     }
 }
 
+/// Find `target.id` and reject a tree that drifted under it. The guard half of
+/// [`editable_target`], shared with the service reader's `invoke`, which needs the same
+/// rejection without the editable check.
+pub(crate) fn fingerprinted<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&'a AxNode> {
+    let node = tree
+        .find(target.id)
+        .ok_or(GlassError::AxElementNotFound(target.id.0))?;
+    if !target.matches(node.role, node.name.as_deref())
+        || !target.bounds_consistent(node.bounds, 8)
+        || !target.value_consistent(node.value.as_deref())
+    {
+        return Err(GlassError::AxElementChanged(target.id.0));
+    }
+    Ok(node)
+}
+
 /// Re-resolve `target` in an already-numbered `tree` and return the node only if it is still the
 /// element that was addressed and still editable. Errors specifically when the target is gone
 /// (`AxElementNotFound`), has drifted in role/name/bounds/value (`AxElementChanged`), or is not
@@ -233,15 +249,7 @@ impl Default for AndroidA11y {
 /// acts on. A recycled `RecyclerView` row is the motivating case for comparing `value` too — see
 /// `AxTarget::value`'s doc. Pure (no device I/O), so it is testable without a device.
 pub(crate) fn editable_target<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&'a AxNode> {
-    let node = tree
-        .find(target.id)
-        .ok_or(GlassError::AxElementNotFound(target.id.0))?;
-    if !target.matches(node.role, node.name.as_deref())
-        || !target.bounds_consistent(node.bounds, 8)
-        || !target.value_consistent(node.value.as_deref())
-    {
-        return Err(GlassError::AxElementChanged(target.id.0));
-    }
+    let node = fingerprinted(tree, target)?;
     if !node.states.editable {
         return Err(GlassError::AxElementNotEditable(target.id.0));
     }

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -1006,4 +1006,38 @@ mod tests {
         let e = actuable_node(&t, &label).unwrap_err();
         assert!(!e.invoke_fallback_eligible(), "{e}");
     }
+
+    /// Two siblings under the root: the first is clickable and its bounds happen to enclose
+    /// the second, but it does not contain the target in its subtree; the target is the second
+    /// sibling, with no clickable node anywhere in its real ancestry (root nor itself).
+    fn target_follows_a_rejected_clickable_sibling() -> Value {
+        json!({
+            "class": "android.widget.FrameLayout",
+            "bounds": {"x": 0, "y": 100, "w": 1080, "h": 2300},
+            "editable": false, "clickable": false, "enabled": true, "scrollable": false,
+            "children": [
+                {"class": "android.view.View",
+                 "bounds": {"x": 0, "y": 200, "w": 1080, "h": 2000},
+                 "editable": false, "clickable": true, "enabled": true, "scrollable": false,
+                 "children": []},
+                {"class": "android.widget.TextView", "text": "Save",
+                 "bounds": {"x": 40, "y": 1220, "w": 200, "h": 60},
+                 "editable": false, "clickable": false, "enabled": true, "scrollable": false}
+            ]
+        })
+    }
+
+    /// Pins `path_to`'s backtrack: without `out.pop()` restoring the accumulator after the
+    /// first (rejected) sibling, the reverse walk in `actuable_node` would still see that
+    /// sibling's clickable node — whose bounds do enclose the target — as if it were on the
+    /// target's real path, and wrongly return it instead of reporting no actuator exists.
+    #[test]
+    fn a_rejected_earlier_sibling_is_popped_before_trying_the_target_sibling() {
+        let t = built(&target_follows_a_rejected_clickable_sibling());
+        let target = target_for(&t, AxNodeId(2));
+        assert!(matches!(
+            actuable_node(&t, &target),
+            Err(GlassError::AxActionUnavailable(2))
+        ));
+    }
 }

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -14,7 +14,7 @@ use glass_core::platform::WindowGeometry;
 use glass_core::{GlassError, Result};
 
 use crate::axmap::{LabelInputs, class_to_role, labels};
-use crate::conn::Conn;
+use crate::conn::{CallFailure, Conn};
 
 /// Map one device `tree` JSON node (+descendants) into an `AxNode`, converting screen bounds to
 /// window-relative. Ids are left `AxNodeId(0)`; the core's `AxTree::assign_ids` numbers them
@@ -172,93 +172,109 @@ impl ServiceClient {
         })
     }
 
-    /// Run a request, transparently reconnecting once if the socket dropped. The bool is
-    /// `Conn::call`'s: true for a transport failure, false for a refusal the device sent back.
-    fn call(&self, req: Value) -> std::result::Result<Value, (GlassError, bool)> {
+    /// Run a request, reconnecting once and re-sending when `resend` accepts the failure.
+    fn call_with(
+        &self,
+        req: Value,
+        resend: fn(&CallFailure) -> bool,
+    ) -> std::result::Result<Value, CallFailure> {
         let mut conn = self.conn.lock().map_err(|_| {
-            (
-                GlassError::Backend("a11y service client lock poisoned".into()),
-                false,
-            )
+            CallFailure::NotSent(GlassError::Backend(
+                "a11y service client lock poisoned".into(),
+            ))
         })?;
         match conn.call(req.clone()) {
             Ok(v) => Ok(v),
-            Err((e, false)) => Err((e, false)),
-            Err((_, true)) => {
+            Err(f) if resend(&f) => {
                 // The service's accept loop accepts a fresh connection after a drop.
-                *conn = Conn::open(self.port).map_err(|e| (e, true))?;
+                *conn = Conn::open(self.port).map_err(|e| f.with_error(e))?;
                 conn.call(req)
             }
+            Err(f) => Err(f),
         }
+    }
+
+    /// Run a request that can be run twice without consequence, transparently reconnecting
+    /// once if the socket dropped. A dead socket usually surfaces on the *read*, not the
+    /// write, so this covers the ordinary "the service rebound between calls" case.
+    fn call(&self, req: Value) -> std::result::Result<Value, CallFailure> {
+        self.call_with(req, CallFailure::is_transport)
+    }
+
+    /// [`Self::call`] for a side-effecting request: re-send only what provably never went
+    /// out, so a request whose answer was lost is reported rather than run a second time.
+    fn call_once_sent(&self, req: Value) -> std::result::Result<Value, CallFailure> {
+        self.call_with(req, CallFailure::nothing_sent)
     }
 
     fn tree(&self, package: &str) -> Result<Value> {
         let r = self
             .call(json!({"op": "tree", "package": package}))
-            .map_err(|(e, _)| e)?;
+            .map_err(CallFailure::into_error)?;
         r.get("tree")
             .cloned()
             .ok_or_else(|| GlassError::AccessibilityUnavailable("no tree in response".into()))
     }
 
-    /// [`Self::action`], keeping `call`'s transport flag for callers that must not retry a
-    /// possibly-dispatched action by another route.
-    fn action_result(
-        &self,
-        ref_id: u32,
-        action: &str,
-        text: Option<&str>,
-    ) -> std::result::Result<(), (GlassError, bool)> {
-        let mut req = json!({"op": "action", "ref": ref_id, "action": action});
-        if let Some(t) = text {
-            req["text"] = json!(t);
-        }
-        self.call(req).map(|_| ())
+    /// Fire `ACTION_CLICK` on device node `ref_id`. Never re-sent once delivered; the failure
+    /// keeps its delivery classification so the caller can say what it does and does not know.
+    fn click(&self, ref_id: u32) -> std::result::Result<(), CallFailure> {
+        self.call_once_sent(json!({"op": "action", "ref": ref_id, "action": "click"}))
+            .map(|_| ())
     }
 
-    fn action(&self, ref_id: u32, action: &str, text: Option<&str>) -> Result<()> {
-        self.action_result(ref_id, action, text).map_err(|(e, _)| e)
+    /// Fire `ACTION_SET_TEXT` on device node `ref_id`. Idempotent — the same text written
+    /// twice leaves the same field contents — so this takes the reconnecting path.
+    fn set_text(&self, ref_id: u32, text: &str) -> Result<()> {
+        self.call(json!({"op": "action", "ref": ref_id, "action": "set_text", "text": text}))
+            .map(|_| ())
+            .map_err(CallFailure::into_error)
     }
 
     pub fn ping(&self) -> Result<()> {
         self.call(json!({"op": "ping"}))
             .map(|_| ())
-            .map_err(|(e, _)| e)
+            .map_err(CallFailure::into_error)
     }
 }
+
+/// How long `invoke` waits for an actuated control's `checked` state to reach the tree.
+const CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+const CHECK_POLL: std::time::Duration = std::time::Duration::from_millis(150);
 
 /// The Accessibility reader backed by the on-device service. `package` is the target app.
 pub struct ServiceA11y {
     client: ServiceClient,
     package: String,
+    /// How long [`Self::wait_for_check`] polls; [`CHECK_TIMEOUT`] outside tests.
+    check_timeout: std::time::Duration,
 }
 
 impl ServiceA11y {
     pub fn new(client: ServiceClient, package: String) -> Self {
-        Self { client, package }
+        Self {
+            client,
+            package,
+            check_timeout: CHECK_TIMEOUT,
+        }
     }
 
-    /// Poll until `chosen`'s `checked` leaves `was` — a Compose recompose reaches the tree a
-    /// beat after the action, so acknowledgement is not proof; `set_value` polls for the same
-    /// reason.
-    fn wait_for_flip(
-        &mut self,
-        ctx: &AxContext,
-        target: u32,
-        chosen: AxNodeId,
-        was: bool,
-    ) -> Result<()> {
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    /// Poll until the actuated control reports `checked == want`. The toolkit's UI update
+    /// reaches the accessibility tree a beat after the action, so an acknowledgement is not
+    /// proof; `set_value` polls for the same reason.
+    fn wait_for_check(&mut self, ctx: &AxContext, plan: &InvokePlan, want: bool) -> Result<()> {
+        let deadline = std::time::Instant::now() + self.check_timeout;
         loop {
             let mut after = self.snapshot(ctx)?;
             after.assign_ids();
-            if after.find(chosen).is_some_and(|n| n.states.checked != was) {
+            let seen = check_state(&after, &plan.actuated);
+            if seen == CheckState::Reached(want) {
                 return Ok(());
             }
             if std::time::Instant::now() >= deadline {
-                return Err(flip_timeout(target, chosen, was));
+                return Err(check_timeout(plan.target.0, &plan.actuated, want, seen));
             }
-            std::thread::sleep(std::time::Duration::from_millis(150));
+            std::thread::sleep(CHECK_POLL);
         }
     }
 }
@@ -278,7 +294,7 @@ impl Accessibility for ServiceA11y {
             t
         };
         crate::a11y::editable_target(&tree, target)?;
-        self.client.action(target.id.0, "set_text", Some(text))?;
+        self.client.set_text(target.id.0, text)?;
         // Verify the value actually took. ACTION_SET_TEXT returns success but silently no-ops when
         // *replacing* existing text in a Compose field, so a bare Ok could lie (glass forbids silent
         // fallbacks). The set is async (Compose recompose → a11y update), so poll briefly for the
@@ -324,17 +340,12 @@ impl Accessibility for ServiceA11y {
             t.assign_ids();
             t
         };
-        let node = actuable_node(&tree, target)?;
-        let chosen = node.id;
-        if !node.states.enabled {
-            return Err(disabled_error(target.id.0, chosen));
-        }
-        let (checkable, was) = (node.states.checkable, node.states.checked);
+        let plan = invoke_plan(&tree, target)?;
         self.client
-            .action_result(chosen.0, "click", None)
-            .map_err(|(e, transport)| action_error(target.id.0, &e, transport))?;
-        if checkable {
-            return self.wait_for_flip(ctx, target.id.0, chosen, was);
+            .click(plan.actuated.id.0)
+            .map_err(|f| action_error(target.id.0, f))?;
+        if let Some(want) = plan.want_checked {
+            self.wait_for_check(ctx, &plan, want)?;
         }
         Ok(())
     }
@@ -533,14 +544,109 @@ pub(crate) fn wait_for_service(port: u16) -> Result<ServiceClient> {
     }
 }
 
+/// One node's identity, captured when it is actuated so the state read back after the click
+/// can be confirmed to be that same control. An `AxNodeId` is a positional pre-order index
+/// re-derived per snapshot, so an id alone can resolve to a different node in the next tree.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Actuated {
+    id: AxNodeId,
+    role: AxRole,
+    name: Option<String>,
+}
+
+/// What an `invoke` must do, decided from one tree before any device I/O.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct InvokePlan {
+    /// The element the caller named.
+    target: AxNodeId,
+    /// The node the click is sent to — the target, or the control the climb resolved to.
+    actuated: Actuated,
+    /// `Some(want)` when the actuated control must be read back reporting `checked == want`.
+    want_checked: Option<bool>,
+}
+
+/// Whether clicking a control of this role must move its `checked` state. A checkbox or a
+/// switch toggles. A radio button or a tab selects, and clicking the one already selected
+/// leaves it selected — a correct no-op, not a click that failed.
+fn toggles(role: AxRole) -> bool {
+    matches!(role, AxRole::CheckBox | AxRole::ToggleButton)
+}
+
+/// Decide what an `invoke` does with `target`: which node to actuate, and what the tree must
+/// show afterwards. Pure, so the decision is testable without a device.
+///
+/// The order is load-bearing. The target's own fingerprint and `enabled` are read off the node
+/// the caller named, before the climb: a Compose control omits `ACTION_CLICK` while disabled,
+/// so a climb run first walks straight past it and actuates whatever encloses it.
+fn invoke_plan(tree: &AxTree, target: &AxTarget) -> Result<InvokePlan> {
+    let node = crate::a11y::fingerprinted(tree, target)?;
+    if !node.states.enabled {
+        return Err(disabled_error(target.id.0, target.id));
+    }
+    // Under these caps the kept nodes are no longer a pre-order prefix — the walk drops a
+    // subtree and carries on with later siblings — so a host id no longer equals the device
+    // `ref` it would be sent as, and the click would dispatch to a different device node.
+    // `Nodes` stops the walk outright and keeps the prefix, so it stays actuable.
+    //
+    // Fallback-eligible on purpose: nothing has been dispatched, and the pointer path aims at
+    // this tree's own bounds, which the id/`ref` skew does not touch.
+    if let Some(t) = &tree.truncated
+        && matches!(t.limit, TruncationLimit::Depth | TruncationLimit::Siblings)
+    {
+        return Err(GlassError::AxActionUnavailable(target.id.0));
+    }
+    let chosen = actuable_node(tree, target)?;
+    if !chosen.states.enabled {
+        return Err(disabled_error(target.id.0, chosen.id));
+    }
+    let want = if toggles(chosen.role) {
+        !chosen.states.checked
+    } else {
+        true
+    };
+    Ok(InvokePlan {
+        target: target.id,
+        actuated: Actuated {
+            id: chosen.id,
+            role: chosen.role,
+            name: chosen.name.clone(),
+        },
+        want_checked: (chosen.states.checkable && want != chosen.states.checked).then_some(want),
+    })
+}
+
+/// What a tree read after the click says about the actuated control.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CheckState {
+    /// The control is still there, reporting this `checked`.
+    Reached(bool),
+    /// The id no longer resolves to the checkable control that was actuated.
+    Gone,
+}
+
+/// Read the actuated control's `checked` out of a tree taken after the click.
+///
+/// The id alone is not enough to accept a state change by: it is positional, so a node the
+/// click added above the control shifts every later id, and `checked` reads `false` on any
+/// node that has no checked state at all — between them, an inert label sliding into the id
+/// reads as a flip.
+fn check_state(after: &AxTree, act: &Actuated) -> CheckState {
+    match after.find(act.id) {
+        Some(n) if n.states.checkable && n.role == act.role && n.name == act.name => {
+            CheckState::Reached(n.states.checked)
+        }
+        _ => CheckState::Gone,
+    }
+}
+
 /// The node an `invoke` should actuate on behalf of `target`.
 ///
 /// A Compose button's label and its clickable node are different nodes: the touch-target
 /// carries no name and the named child carries no `ACTION_CLICK`. When the target itself
-/// advertises no click, climb to the nearest node that does and encloses it — the same node a
-/// tap at the target's centre would have been handled by.
+/// advertises no click, climb to the nearest node that does and encloses it. Only the target's
+/// own ancestor chain is walked, so this is the node a tap at the target's centre would reach
+/// short of an overlapping sibling drawn above it.
 fn actuable_node<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&'a AxNode> {
-    crate::a11y::fingerprinted(tree, target)?;
     let mut path = Vec::new();
     if !path_to(&tree.root, target.id, &mut path) {
         return Err(GlassError::AxElementNotFound(target.id.0));
@@ -581,38 +687,53 @@ fn encloses(outer: Option<AxRect>, inner: Option<AxRect>) -> bool {
         && i64::from(o.y) + i64::from(o.height) >= i64::from(i.y) + i64::from(i.height)
 }
 
-/// The error for a target the tree says is disabled. Deliberately not `AxActionUnavailable`:
+/// The error for a control the tree says is disabled. Deliberately not `AxActionUnavailable`:
 /// a pointer click would tap a control that cannot act and report success.
-fn disabled_error(target: u32, chosen: AxNodeId) -> GlassError {
+fn disabled_error(target: u32, disabled: AxNodeId) -> GlassError {
     GlassError::AxActionFailed(
         target,
         format!(
             "element {} is disabled, so its click action was refused; no pointer click was \
              synthesized on top of it",
-            chosen.0
+            disabled.0
         ),
     )
 }
 
-/// Map an `action` failure onto the invoke contract. Neither arm is fallback-eligible: a
-/// refusal may still have reached the toolkit, and a lost answer says nothing either way.
-fn action_error(target: u32, e: &GlassError, transport: bool) -> GlassError {
-    if transport {
-        GlassError::AccessibilityUnavailable(format!("a11y service action call failed: {e}"))
-    } else {
-        GlassError::AxActionFailed(target, e.to_string())
+/// Map a click failure onto the invoke contract. No arm is fallback-eligible: a refusal may
+/// still have reached the toolkit, and a lost answer says nothing either way.
+fn action_error(target: u32, f: CallFailure) -> GlassError {
+    match f {
+        CallFailure::NotSent(e) => GlassError::AccessibilityUnavailable(format!(
+            "the click on element {target} could not be sent: {e}"
+        )),
+        // Non-fallback-eligible is not enough here: the message has to stop a human or an
+        // agent re-clicking by hand what may already have actuated.
+        CallFailure::AnswerLost(e) => GlassError::AccessibilityUnavailable(format!(
+            "the click on element {target} was sent but its result was lost ({e}); it may or \
+             may not have actuated — re-snapshot to see the app's state rather than clicking \
+             again"
+        )),
+        CallFailure::Refused(e) => GlassError::AxActionFailed(target, e.to_string()),
     }
 }
 
-/// The error for a toggle whose action was acknowledged but whose state never moved.
-fn flip_timeout(target: u32, chosen: AxNodeId, was: bool) -> GlassError {
+/// The error for a control whose click was accepted but whose state never reached `want`.
+fn check_timeout(target: u32, act: &Actuated, want: bool, seen: CheckState) -> GlassError {
+    let id = act.id.0;
+    let detail = match seen {
+        CheckState::Reached(state) => format!(
+            "its checked state stayed {state} instead of becoming {want}; the control did not \
+             take the click"
+        ),
+        CheckState::Gone => "it is no longer the control that was clicked, so the click could \
+             not be confirmed; a control that disappears or is replaced after an accepted click \
+             has usually acted — re-snapshot to see the app's state rather than clicking again"
+            .to_string(),
+    };
     GlassError::AxActionFailed(
         target,
-        format!(
-            "the click action on element {} was accepted but its checked state stayed {was}; \
-             the control did not toggle",
-            chosen.0
-        ),
+        format!("the click action on element {id} was accepted but {detail}"),
     )
 }
 
@@ -621,6 +742,7 @@ mod tests {
     use super::*;
     use glass_core::accessibility::AxRole;
     use serde_json::json;
+    use std::io::{BufRead, Write};
 
     fn win() -> WindowGeometry {
         WindowGeometry {
@@ -1043,9 +1165,11 @@ mod tests {
 
     #[test]
     fn a_target_that_advertises_a_click_is_actuated_directly() {
-        let t = built(&compose_like());
-        let btn = target_for(&t, AxNodeId(1));
-        assert_eq!(actuable_node(&t, &btn).unwrap().id, AxNodeId(1));
+        // Inside a clickable card, so "the target itself" is distinguishable from "something
+        // enclosing it that also advertises a click".
+        let t = built(&nested_clickables());
+        let btn = target_for(&t, AxNodeId(2));
+        assert_eq!(actuable_node(&t, &btn).unwrap().id, AxNodeId(2));
     }
 
     #[test]
@@ -1089,7 +1213,7 @@ mod tests {
         let mut label = target_for(&t, AxNodeId(2));
         label.name = Some("Send".into());
         assert!(matches!(
-            actuable_node(&t, &label),
+            invoke_plan(&t, &label),
             Err(GlassError::AxElementChanged(2))
         ));
     }
@@ -1099,7 +1223,7 @@ mod tests {
         let t = built(&compose_like());
         let mut label = target_for(&t, AxNodeId(2));
         label.name = Some("Send".into());
-        let e = actuable_node(&t, &label).unwrap_err();
+        let e = invoke_plan(&t, &label).unwrap_err();
         assert!(!e.invoke_fallback_eligible(), "{e}");
     }
 
@@ -1148,28 +1272,531 @@ mod tests {
     }
 
     #[test]
-    fn a_device_refusal_is_not_fallback_eligible() {
+    fn a_device_refusal_is_a_failed_action_not_a_lost_answer() {
         // The device answered and refused. The call may have reached the toolkit, so a pointer
         // click on top of it could actuate the control twice.
         let inner = GlassError::Backend("agent: ACTION_CLICK refused".into());
-        let e = action_error(2, &inner, false);
+        let e = action_error(2, CallFailure::Refused(inner));
+        assert!(matches!(e, GlassError::AxActionFailed(2, _)), "{e}");
         assert!(!e.invoke_fallback_eligible(), "{e}");
         assert!(e.to_string().contains("ACTION_CLICK refused"), "{e}");
     }
 
     #[test]
-    fn a_transport_failure_is_not_fallback_eligible_either() {
+    fn a_click_that_never_went_out_is_a_transport_error_not_a_refusal() {
         let inner = GlassError::Backend("agent write: broken pipe".into());
-        let e = action_error(2, &inner, true);
+        let e = action_error(2, CallFailure::NotSent(inner));
+        assert!(matches!(e, GlassError::AccessibilityUnavailable(_)), "{e}");
         assert!(!e.invoke_fallback_eligible(), "{e}");
     }
 
     #[test]
+    fn a_click_whose_answer_was_lost_says_it_may_already_have_actuated() {
+        let inner = GlassError::Backend("agent closed the connection".into());
+        let e = action_error(2, CallFailure::AnswerLost(inner));
+        assert!(matches!(e, GlassError::AccessibilityUnavailable(_)), "{e}");
+        assert!(!e.invoke_fallback_eligible(), "{e}");
+        // Refusing to fall back is only half of it: the message has to stop a human or an
+        // agent clicking again by hand.
+        let m = e.to_string();
+        assert!(m.contains("was sent"), "{m}");
+        assert!(m.contains("may or may not have actuated"), "{m}");
+        assert!(m.contains("re-snapshot"), "{m}");
+    }
+
+    fn actuated(id: u32, role: AxRole, name: &str) -> Actuated {
+        Actuated {
+            id: AxNodeId(id),
+            role,
+            name: Some(name.into()),
+        }
+    }
+
+    #[test]
     fn a_toggle_that_never_flipped_is_a_failure_not_a_missing_action() {
-        let e = flip_timeout(2, AxNodeId(1), false);
+        let act = actuated(1, AxRole::CheckBox, "Agree");
+        let e = check_timeout(2, &act, true, CheckState::Reached(false));
+        assert!(matches!(e, GlassError::AxActionFailed(2, _)), "{e}");
         assert!(!e.invoke_fallback_eligible(), "{e}");
         // The distinction that matters to a caller: the action WAS accepted.
         assert!(e.to_string().contains("accepted"), "{e}");
-        assert!(e.to_string().contains("did not toggle"), "{e}");
+        assert!(e.to_string().contains("stayed false"), "{e}");
+    }
+
+    #[test]
+    fn a_control_that_vanished_after_the_click_is_not_reported_as_never_moving() {
+        // A checkable row that navigates, a toggle in a dismissing dialog: the state was never
+        // read back at all, and "it stayed <was>" would be an actively wrong diagnosis of a
+        // click that worked — one that invites the retry that actuates twice.
+        let act = actuated(1, AxRole::CheckBox, "Agree");
+        let e = check_timeout(2, &act, true, CheckState::Gone);
+        let m = e.to_string();
+        assert!(!m.contains("stayed"), "no state was read to report: {m}");
+        assert!(m.contains("has usually acted"), "{m}");
+        assert!(m.contains("re-snapshot"), "{m}");
+        assert!(!e.invoke_fallback_eligible(), "{e}");
+    }
+
+    /// A tree taken after the click, holding `nodes` under the root.
+    fn after_tree(nodes: Vec<Value>) -> AxTree {
+        built(&json!({
+            "class": "android.widget.FrameLayout",
+            "bounds": {"x": 0, "y": 100, "w": 1080, "h": 2300},
+            "enabled": true,
+            "children": nodes
+        }))
+    }
+
+    fn checkable_json(class: &str, name: &str, checked: bool) -> Value {
+        json!({
+            "class": class, "text": name,
+            "bounds": {"x": 40, "y": 200, "w": 200, "h": 100},
+            "clickable": true, "enabled": true, "checkable": true, "checked": checked
+        })
+    }
+
+    #[test]
+    fn the_actuated_control_reports_the_state_it_reads_back() {
+        let after = after_tree(vec![checkable_json(
+            "android.widget.CheckBox",
+            "Agree",
+            true,
+        )]);
+        let act = actuated(1, AxRole::CheckBox, "Agree");
+        assert_eq!(check_state(&after, &act), CheckState::Reached(true));
+    }
+
+    #[test]
+    fn a_node_that_inherited_the_id_does_not_count_as_the_flip() {
+        // The app rejected the change and showed an error line above the control, so the tree
+        // gained a node and every later id shifted. Id 1 is now an inert label, whose `checked`
+        // reads false on any node — which a bare `checked != was` reads as an unchecking.
+        let after = after_tree(vec![
+            json!({
+                "class": "android.widget.TextView", "text": "You must agree first",
+                "bounds": {"x": 40, "y": 150, "w": 400, "h": 40}, "enabled": true
+            }),
+            checkable_json("android.widget.CheckBox", "Agree", true),
+        ]);
+        let act = actuated(1, AxRole::CheckBox, "Agree");
+        assert_eq!(check_state(&after, &act), CheckState::Gone);
+    }
+
+    #[test]
+    fn a_different_control_at_the_same_id_does_not_count_as_the_flip() {
+        // Same id, still checkable, still a CheckBox — only the name says it is a different
+        // control, which is exactly the case a bare id match cannot see.
+        let after = after_tree(vec![checkable_json(
+            "android.widget.CheckBox",
+            "Subscribe",
+            false,
+        )]);
+        let act = actuated(1, AxRole::CheckBox, "Agree");
+        assert_eq!(check_state(&after, &act), CheckState::Gone);
+    }
+
+    /// A clickable card wrapping a clickable button wrapping its label — nested clickables are
+    /// the Android norm (a row that opens a detail view, holding a button that deletes).
+    fn nested_clickables() -> Value {
+        json!({
+            "class": "android.widget.FrameLayout",
+            "bounds": {"x": 0, "y": 100, "w": 1080, "h": 2300},
+            "clickable": false, "enabled": true,
+            "children": [
+                {"class": "androidx.cardview.widget.CardView",
+                 "bounds": {"x": 40, "y": 400, "w": 900, "h": 300},
+                 "clickable": true, "enabled": true,
+                 "children": [
+                    {"class": "android.widget.Button",
+                     "bounds": {"x": 60, "y": 440, "w": 300, "h": 120},
+                     "clickable": true, "enabled": true,
+                     "children": [
+                        {"class": "android.widget.TextView", "text": "Delete",
+                         "bounds": {"x": 80, "y": 470, "w": 100, "h": 50},
+                         "clickable": false, "enabled": true}
+                     ]}
+                 ]}
+            ]
+        })
+    }
+
+    #[test]
+    fn a_label_climbs_to_the_nearest_clickable_ancestor_not_the_outermost() {
+        // Both the card and the button enclose the label and both advertise a click. Climbing
+        // to the card actuates "open detail" where the caller asked for "delete".
+        let t = built(&nested_clickables());
+        let label = target_for(&t, AxNodeId(3));
+        assert_eq!(label.name.as_deref(), Some("Delete"));
+        assert_eq!(
+            actuable_node(&t, &label).unwrap().id,
+            AxNodeId(2),
+            "the enclosing Button, not the Card around it"
+        );
+    }
+
+    /// A disabled control that advertises no click of its own, inside a clickable card. This is
+    /// the Compose shape: the accessibility delegate omits `ACTION_CLICK` while a control is
+    /// disabled, so nothing but the node's own `enabled` flag says to refuse.
+    fn disabled_inside_a_clickable_card() -> Value {
+        let mut v = nested_clickables();
+        v["children"][0]["children"][0]["clickable"] = json!(false);
+        v["children"][0]["children"][0]["enabled"] = json!(false);
+        v
+    }
+
+    #[test]
+    fn a_disabled_target_is_refused_even_when_something_around_it_is_clickable() {
+        let t = built(&disabled_inside_a_clickable_card());
+        let e = invoke_plan(&t, &target_for(&t, AxNodeId(2))).unwrap_err();
+        assert!(matches!(e, GlassError::AxActionFailed(2, _)), "{e}");
+        assert!(e.to_string().contains("disabled"), "{e}");
+        assert!(
+            !e.invoke_fallback_eligible(),
+            "a pointer click would tap a control that cannot act: {e}"
+        );
+    }
+
+    #[test]
+    fn a_disabled_control_the_climb_resolved_to_is_refused_as_well() {
+        // The target itself is fine; what would actually be actuated is not.
+        let mut v = nested_clickables();
+        v["children"][0]["children"][0]["clickable"] = json!(false);
+        v["children"][0]["enabled"] = json!(false);
+        let t = built(&v);
+        let e = invoke_plan(&t, &target_for(&t, AxNodeId(3))).unwrap_err();
+        assert!(e.to_string().contains("element 1 is disabled"), "{e}");
+        assert!(!e.invoke_fallback_eligible(), "{e}");
+    }
+
+    #[test]
+    fn a_disabled_target_with_nothing_clickable_around_it_is_refused_too() {
+        // With no clickable ancestor the climb ends in `AxActionUnavailable`, which IS
+        // fallback-eligible — so reaching it taps the disabled control's centre and reports ok.
+        let mut v = disabled_inside_a_clickable_card();
+        v["children"][0]["clickable"] = json!(false);
+        let t = built(&v);
+        let e = invoke_plan(&t, &target_for(&t, AxNodeId(2))).unwrap_err();
+        assert!(e.to_string().contains("disabled"), "{e}");
+        assert!(!e.invoke_fallback_eligible(), "{e}");
+    }
+
+    /// A device tree whose only child is a checkable control of `class`, in `checked` state.
+    fn one_checkable(class: &str, checked: bool) -> Value {
+        json!({
+            "class": "android.widget.FrameLayout",
+            "bounds": {"x": 0, "y": 100, "w": 1080, "h": 2300},
+            "enabled": true,
+            "children": [checkable_json(class, "Agree", checked)]
+        })
+    }
+
+    fn selection_tree(class: &str, checked: bool) -> AxTree {
+        built(&one_checkable(class, checked))
+    }
+
+    #[test]
+    fn re_clicking_a_selected_radio_button_asks_for_no_state_change() {
+        // A radio button that is already selected stays selected: the click is a correct no-op,
+        // so waiting for a flip would fail a click on a UI already in the requested state.
+        let t = selection_tree("android.widget.RadioButton", true);
+        let plan = invoke_plan(&t, &target_for(&t, AxNodeId(1))).unwrap();
+        assert_eq!(plan.want_checked, None);
+    }
+
+    #[test]
+    fn clicking_an_unselected_radio_button_asks_for_it_to_end_selected() {
+        let t = selection_tree("android.widget.RadioButton", false);
+        let plan = invoke_plan(&t, &target_for(&t, AxNodeId(1))).unwrap();
+        assert_eq!(plan.want_checked, Some(true));
+    }
+
+    #[test]
+    fn clicking_a_checkbox_asks_for_its_state_to_move_either_way() {
+        for was in [false, true] {
+            let t = selection_tree("android.widget.CheckBox", was);
+            let plan = invoke_plan(&t, &target_for(&t, AxNodeId(1))).unwrap();
+            assert_eq!(plan.want_checked, Some(!was), "checked was {was}");
+        }
+    }
+
+    #[test]
+    fn clicking_a_switch_asks_for_its_state_to_move_either_way() {
+        for was in [false, true] {
+            let t = selection_tree("android.widget.Switch", was);
+            let plan = invoke_plan(&t, &target_for(&t, AxNodeId(1))).unwrap();
+            assert_eq!(plan.want_checked, Some(!was), "checked was {was}");
+        }
+    }
+
+    #[test]
+    fn a_plain_button_has_no_state_to_wait_for() {
+        let t = built(&compose_like());
+        let plan = invoke_plan(&t, &target_for(&t, AxNodeId(2))).unwrap();
+        assert_eq!(plan.want_checked, None);
+    }
+
+    #[test]
+    fn the_plan_actuates_the_ancestor_the_climb_resolved_to() {
+        let t = built(&compose_like());
+        let plan = invoke_plan(&t, &target_for(&t, AxNodeId(2))).unwrap();
+        assert_eq!(plan.actuated.id, AxNodeId(1));
+    }
+
+    #[test]
+    fn a_target_that_can_act_is_its_own_actuator() {
+        let t = built(&nested_clickables());
+        let plan = invoke_plan(&t, &target_for(&t, AxNodeId(2))).unwrap();
+        assert_eq!(plan.actuated.id, AxNodeId(2));
+    }
+
+    /// The compose fixture read back under `limits` — small caps make the walk report the
+    /// truncation a huge device tree would.
+    fn truncated_compose(limits: WalkLimits) -> AxTree {
+        let mut t = tree_from_json(&compose_like(), &win(), limits).expect("maps");
+        t.assign_ids();
+        t
+    }
+
+    #[test]
+    fn a_depth_truncated_tree_does_not_actuate_natively() {
+        // The depth cap drops a node's children and carries on with later siblings, so the
+        // kept set is no longer a pre-order prefix and a host id no longer equals the device
+        // `ref` the click would be sent as.
+        let t = truncated_compose(WalkLimits {
+            depth: 1,
+            ..WalkLimits::DEFAULT
+        });
+        assert_eq!(t.truncated.map(|x| x.limit), Some(TruncationLimit::Depth));
+        let e = invoke_plan(&t, &target_for(&t, AxNodeId(1))).unwrap_err();
+        assert!(matches!(e, GlassError::AxActionUnavailable(1)), "{e}");
+        // Nothing was dispatched and the pointer path aims at this tree's own bounds, so the
+        // click still lands — as a disclosed pointer click.
+        assert!(e.invoke_fallback_eligible(), "{e}");
+    }
+
+    #[test]
+    fn a_sibling_truncated_tree_does_not_actuate_natively() {
+        let mut v = compose_like();
+        v["children"].as_array_mut().unwrap().push(
+            json!({"class": "android.widget.TextView", "text": "Cancel",
+                         "bounds": {"x": 60, "y": 700, "w": 210, "h": 130},
+                         "clickable": false, "enabled": true}),
+        );
+        let mut t = tree_from_json(
+            &v,
+            &win(),
+            WalkLimits {
+                siblings: 1,
+                ..WalkLimits::DEFAULT
+            },
+        )
+        .expect("maps");
+        t.assign_ids();
+        assert_eq!(
+            t.truncated.map(|x| x.limit),
+            Some(TruncationLimit::Siblings)
+        );
+        let e = invoke_plan(&t, &target_for(&t, AxNodeId(1))).unwrap_err();
+        assert!(matches!(e, GlassError::AxActionUnavailable(1)), "{e}");
+    }
+
+    #[test]
+    fn a_node_capped_tree_still_actuates_natively() {
+        // The node cap stops the walk outright, so what it kept IS a pre-order prefix and every
+        // surviving id still equals its device `ref`.
+        let t = truncated_compose(WalkLimits {
+            nodes: 2,
+            ..WalkLimits::DEFAULT
+        });
+        assert_eq!(t.truncated.map(|x| x.limit), Some(TruncationLimit::Nodes));
+        assert_eq!(
+            invoke_plan(&t, &target_for(&t, AxNodeId(1)))
+                .unwrap()
+                .actuated
+                .id,
+            AxNodeId(1)
+        );
+    }
+
+    /// How the fake device answers an `action` request.
+    #[derive(Clone, Copy)]
+    enum OnAction {
+        Ok,
+        /// Read the request, then drop the socket without answering — the shape of an answer
+        /// lost to a read timeout, a rebinding service or a reset `adb forward` tunnel.
+        DropWithoutAnswering,
+    }
+
+    /// A fake on-device service on a local TCP listener: serves `tree` from a script (the last
+    /// entry repeating) and records every request, tagged with the connection it arrived on so
+    /// a re-send after a reconnect is visible in the log.
+    fn fake_service(trees: Vec<Value>, on_action: OnAction) -> (u16, Arc<Mutex<Vec<String>>>) {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        let ops: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let log = Arc::clone(&ops);
+        std::thread::spawn(move || {
+            let mut conn = 0;
+            let mut served = 0usize;
+            while let Ok((sock, _)) = listener.accept() {
+                conn += 1;
+                let Ok(mut w) = sock.try_clone() else { break };
+                let mut r = std::io::BufReader::new(sock);
+                if writeln!(w, r#"{{"hello":{{"proto":1}}}}"#)
+                    .and_then(|()| w.flush())
+                    .is_err()
+                {
+                    break;
+                }
+                loop {
+                    let mut line = String::new();
+                    if !matches!(r.read_line(&mut line), Ok(n) if n > 0) {
+                        break;
+                    }
+                    let req: Value = serde_json::from_str(&line).expect("request is json");
+                    let id = req["id"].clone();
+                    let reply = match req["op"].as_str().unwrap_or_default() {
+                        "tree" => {
+                            log.lock().unwrap().push(format!("conn{conn}:tree"));
+                            let t = trees[served.min(trees.len() - 1)].clone();
+                            served += 1;
+                            json!({"id": id, "ok": true, "tree": t})
+                        }
+                        "action" => {
+                            log.lock().unwrap().push(format!(
+                                "conn{conn}:{} ref={}",
+                                req["action"].as_str().unwrap_or_default(),
+                                req["ref"]
+                            ));
+                            match on_action {
+                                OnAction::Ok => json!({"id": id, "ok": true}),
+                                OnAction::DropWithoutAnswering => break,
+                            }
+                        }
+                        _ => json!({"id": id, "ok": true}),
+                    };
+                    if writeln!(w, "{reply}").and_then(|()| w.flush()).is_err() {
+                        break;
+                    }
+                }
+            }
+        });
+        (port, ops)
+    }
+
+    /// A reader wired to a fake device. `check_timeout` is passed explicitly so a test that
+    /// must watch a state check time out does not wait out the production budget;
+    /// `Duration::ZERO` makes it read the tree back exactly once.
+    fn reader(port: u16, check_timeout: std::time::Duration) -> ServiceA11y {
+        let client = ServiceClient::connect(port).expect("connect to the fake service");
+        let mut a = ServiceA11y::new(client, String::new());
+        a.check_timeout = check_timeout;
+        a
+    }
+
+    fn ctx() -> AxContext {
+        AxContext {
+            pids: vec![],
+            window: win(),
+            window_handle: None,
+            a11y_bus_addr: None,
+            limits: WalkLimits::DEFAULT,
+        }
+    }
+
+    fn ops_of(ops: &Arc<Mutex<Vec<String>>>) -> Vec<String> {
+        ops.lock().unwrap().clone()
+    }
+
+    #[test]
+    fn a_click_whose_answer_was_lost_is_not_re_sent() {
+        // The write landed and the response did not come back. Re-sending on a fresh socket —
+        // what a transparent reconnect does — dispatches a second ACTION_CLICK and reports one
+        // successful native click.
+        let (port, ops) = fake_service(vec![compose_like()], OnAction::DropWithoutAnswering);
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let t = built(&compose_like());
+        let e = a
+            .invoke(&ctx(), &target_for(&t, AxNodeId(2)))
+            .expect_err("a lost answer is not a success");
+        assert!(!e.invoke_fallback_eligible(), "{e}");
+        assert!(
+            e.to_string().contains("may or may not have actuated"),
+            "{e}"
+        );
+        assert_eq!(
+            ops_of(&ops),
+            vec!["conn1:tree".to_string(), "conn1:click ref=1".to_string()],
+            "exactly one click frame, on the one connection"
+        );
+    }
+
+    #[test]
+    fn the_click_is_sent_to_the_node_the_climb_resolved_to() {
+        // Sending the caller's own id would click the label, which handles nothing — the climb
+        // would be decorative and every Compose click a no-op reported as success.
+        let (port, ops) = fake_service(vec![compose_like()], OnAction::Ok);
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let t = built(&compose_like());
+        a.invoke(&ctx(), &target_for(&t, AxNodeId(2)))
+            .expect("clicks");
+        assert_eq!(
+            ops_of(&ops),
+            vec!["conn1:tree".to_string(), "conn1:click ref=1".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_disabled_target_sends_no_click_at_all() {
+        let json = disabled_inside_a_clickable_card();
+        let (port, ops) = fake_service(vec![json.clone()], OnAction::Ok);
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let t = built(&json);
+        let e = a
+            .invoke(&ctx(), &target_for(&t, AxNodeId(2)))
+            .expect_err("a disabled control must not report success");
+        assert!(e.to_string().contains("disabled"), "{e}");
+        assert_eq!(
+            ops_of(&ops),
+            vec!["conn1:tree".to_string()],
+            "the refusal must happen before anything is dispatched"
+        );
+    }
+
+    #[test]
+    fn a_toggle_whose_state_never_moves_is_reported_failed() {
+        let stuck = one_checkable("android.widget.CheckBox", false);
+        let (port, ops) = fake_service(vec![stuck.clone()], OnAction::Ok);
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let t = built(&stuck);
+        let e = a
+            .invoke(&ctx(), &target_for(&t, AxNodeId(1)))
+            .expect_err("an acknowledged action that changed nothing is not a click");
+        assert!(e.to_string().contains("accepted"), "{e}");
+        assert!(!e.invoke_fallback_eligible(), "{e}");
+        assert_eq!(
+            ops_of(&ops),
+            vec![
+                "conn1:tree".to_string(),
+                "conn1:click ref=1".to_string(),
+                "conn1:tree".to_string()
+            ],
+            "the click went out and the state was read back"
+        );
+    }
+
+    #[test]
+    fn a_toggle_that_flips_is_reported_clicked() {
+        let (port, _) = fake_service(
+            vec![
+                one_checkable("android.widget.CheckBox", false),
+                one_checkable("android.widget.CheckBox", true),
+            ],
+            OnAction::Ok,
+        );
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let t = built(&one_checkable("android.widget.CheckBox", false));
+        a.invoke(&ctx(), &target_for(&t, AxNodeId(1)))
+            .expect("clicks");
     }
 }

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -587,19 +587,21 @@ fn invoke_plan(tree: &AxTree, target: &AxTarget) -> Result<InvokePlan> {
     if !node.states.enabled {
         return Err(disabled_error(target.id.0, target.id));
     }
+    let chosen = actuable_node(tree, target)?;
+    if !chosen.states.enabled {
+        return Err(disabled_error(target.id.0, chosen.id));
+    }
     // Under these caps the kept nodes are no longer a pre-order prefix — the walk drops a
     // subtree and carries on with later siblings — so a host id no longer equals the device
     // `ref` it would be sent as. `Nodes` stops the walk outright and keeps the prefix.
     // Fallback-eligible on purpose: nothing was dispatched, and the pointer path aims at this
-    // tree's own bounds, which the id/`ref` skew does not touch.
+    // tree's own bounds, which the id/`ref` skew does not touch. It must therefore stay below
+    // both `enabled` refusals — reached first, it hands a disabled control to the pointer
+    // path; the climb above it only reads this tree.
     if let Some(t) = &tree.truncated
         && matches!(t.limit, TruncationLimit::Depth | TruncationLimit::Siblings)
     {
         return Err(GlassError::AxActionUnavailable(target.id.0));
-    }
-    let chosen = actuable_node(tree, target)?;
-    if !chosen.states.enabled {
-        return Err(disabled_error(target.id.0, chosen.id));
     }
     let want = if toggles(chosen.role) {
         !chosen.states.checked
@@ -1461,6 +1463,38 @@ mod tests {
         v["children"][0]["children"][0]["clickable"] = json!(false);
         v["children"][0]["enabled"] = json!(false);
         let t = built(&v);
+        let e = invoke_plan(&t, &target_for(&t, AxNodeId(3))).unwrap_err();
+        assert!(e.to_string().contains("element 1 is disabled"), "{e}");
+        assert!(!e.invoke_fallback_eligible(), "{e}");
+    }
+
+    #[test]
+    fn a_disabled_control_is_refused_before_a_truncated_tree_can_fall_back() {
+        // Same shape as the test above, in a truncated tree. `AxActionUnavailable` is
+        // fallback-eligible, so a truncation guard reached before the climb's `enabled` check
+        // taps the disabled control's centre and reports ok.
+        let mut v = nested_clickables();
+        v["children"][0]["children"][0]["clickable"] = json!(false);
+        v["children"][0]["enabled"] = json!(false);
+        v["children"].as_array_mut().expect("root children").push(
+            json!({"class": "android.widget.TextView", "text": "Cancel",
+                         "bounds": {"x": 40, "y": 800, "w": 200, "h": 60},
+                         "clickable": false, "enabled": true}),
+        );
+        let mut t = tree_from_json(
+            &v,
+            &win(),
+            WalkLimits {
+                siblings: 1,
+                ..WalkLimits::DEFAULT
+            },
+        )
+        .expect("maps");
+        t.assign_ids();
+        assert_eq!(
+            t.truncated.map(|x| x.limit),
+            Some(TruncationLimit::Siblings)
+        );
         let e = invoke_plan(&t, &target_for(&t, AxNodeId(3))).unwrap_err();
         assert!(e.to_string().contains("element 1 is disabled"), "{e}");
         assert!(!e.invoke_fallback_eligible(), "{e}");

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -547,7 +547,7 @@ pub(crate) fn wait_for_service(port: u16) -> Result<ServiceClient> {
 /// One node's identity, captured when it is actuated so the state read back after the click
 /// can be confirmed to be that same control. An `AxNodeId` is a positional pre-order index
 /// re-derived per snapshot, so an id alone can resolve to a different node in the next tree.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug)]
 struct Actuated {
     id: AxNodeId,
     role: AxRole,
@@ -555,7 +555,7 @@ struct Actuated {
 }
 
 /// What an `invoke` must do, decided from one tree before any device I/O.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug)]
 struct InvokePlan {
     /// The element the caller named.
     target: AxNodeId,

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -597,7 +597,7 @@ fn invoke_plan(tree: &AxTree, target: &AxTarget) -> Result<InvokePlan> {
     // Fallback-eligible on purpose: nothing was dispatched, and the pointer path aims at this
     // tree's own bounds, which the id/`ref` skew does not touch. It must therefore stay below
     // both `enabled` refusals — reached first, it hands a disabled control to the pointer
-    // path; the climb above it only reads this tree.
+    // path.
     if let Some(t) = &tree.truncated
         && matches!(t.limit, TruncationLimit::Depth | TruncationLimit::Siblings)
     {

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -334,7 +334,7 @@ impl Accessibility for ServiceA11y {
         }
     }
 
-    fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<()> {
+    fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<Option<AxNodeId>> {
         let tree = {
             let mut t = self.snapshot(ctx)?;
             t.assign_ids();
@@ -347,7 +347,7 @@ impl Accessibility for ServiceA11y {
         if let Some(want) = plan.want_checked {
             self.wait_for_check(ctx, &plan, want)?;
         }
-        Ok(())
+        Ok(plan.substituted())
     }
 }
 
@@ -563,6 +563,13 @@ struct InvokePlan {
     actuated: Actuated,
     /// `Some(want)` when the actuated control must be read back reporting `checked == want`.
     want_checked: Option<bool>,
+}
+
+impl InvokePlan {
+    /// The actuated node, when it is not the one the caller named.
+    fn substituted(&self) -> Option<AxNodeId> {
+        (self.actuated.id != self.target).then_some(self.actuated.id)
+    }
 }
 
 /// Whether clicking a control of this role must move its `checked` state. A checkbox or a
@@ -1536,17 +1543,19 @@ mod tests {
     }
 
     #[test]
-    fn the_plan_actuates_the_ancestor_the_climb_resolved_to() {
+    fn the_plan_actuates_the_climbed_ancestor_and_reports_the_substitution() {
         let t = built(&compose_like());
         let plan = invoke_plan(&t, &target_for(&t, AxNodeId(2))).unwrap();
         assert_eq!(plan.actuated.id, AxNodeId(1));
+        assert_eq!(plan.substituted(), Some(AxNodeId(1)));
     }
 
     #[test]
-    fn a_target_that_can_act_is_its_own_actuator() {
+    fn a_target_actuated_in_its_own_right_substitutes_nothing() {
         let t = built(&nested_clickables());
         let plan = invoke_plan(&t, &target_for(&t, AxNodeId(2))).unwrap();
         assert_eq!(plan.actuated.id, AxNodeId(2));
+        assert_eq!(plan.substituted(), None);
     }
 
     /// The compose fixture read back under `limits` — small caps make the walk report the
@@ -1738,8 +1747,10 @@ mod tests {
         let (port, ops) = fake_service(vec![compose_like()], OnAction::Ok);
         let mut a = reader(port, std::time::Duration::ZERO);
         let t = built(&compose_like());
-        a.invoke(&ctx(), &target_for(&t, AxNodeId(2)))
+        let substituted = a
+            .invoke(&ctx(), &target_for(&t, AxNodeId(2)))
             .expect("clicks");
+        assert_eq!(substituted, Some(AxNodeId(1)), "the climb is disclosed");
         assert_eq!(
             ops_of(&ops),
             vec!["conn1:tree".to_string(), "conn1:click ref=1".to_string()]
@@ -1796,7 +1807,11 @@ mod tests {
         );
         let mut a = reader(port, std::time::Duration::ZERO);
         let t = built(&one_checkable("android.widget.CheckBox", false));
-        a.invoke(&ctx(), &target_for(&t, AxNodeId(1)))
-            .expect("clicks");
+        assert_eq!(
+            a.invoke(&ctx(), &target_for(&t, AxNodeId(1)))
+                .expect("clicks"),
+            None,
+            "the target actuated itself, so nothing was substituted"
+        );
     }
 }

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -172,32 +172,44 @@ impl ServiceClient {
         })
     }
 
-    /// Run a request, transparently reconnecting once if the socket dropped.
-    /// Mirrors `AgentClient::call`: lock, try, reconnect on `(e, true)`, retry.
-    fn call(&self, req: Value) -> Result<Value> {
-        let mut conn = self
-            .conn
-            .lock()
-            .map_err(|_| GlassError::Backend("a11y service client lock poisoned".into()))?;
+    /// Run a request, transparently reconnecting once if the socket dropped. The bool in the
+    /// error is `Conn::call`'s: true when the failure was transport rather than a refusal the
+    /// device sent back.
+    fn call(&self, req: Value) -> std::result::Result<Value, (GlassError, bool)> {
+        let mut conn = self.conn.lock().map_err(|_| {
+            (
+                GlassError::Backend("a11y service client lock poisoned".into()),
+                false,
+            )
+        })?;
         match conn.call(req.clone()) {
             Ok(v) => Ok(v),
-            Err((e, false)) => Err(e),
+            Err((e, false)) => Err((e, false)),
             Err((_, true)) => {
                 // The service's accept loop accepts a fresh connection after a drop.
-                *conn = Conn::open(self.port)?;
-                conn.call(req).map_err(|(e, _)| e)
+                *conn = Conn::open(self.port).map_err(|e| (e, true))?;
+                conn.call(req)
             }
         }
     }
 
     fn tree(&self, package: &str) -> Result<Value> {
-        let r = self.call(json!({"op": "tree", "package": package}))?;
+        let r = self
+            .call(json!({"op": "tree", "package": package}))
+            .map_err(|(e, _)| e)?;
         r.get("tree")
             .cloned()
             .ok_or_else(|| GlassError::AccessibilityUnavailable("no tree in response".into()))
     }
 
-    fn action(&self, ref_id: u32, action: &str, text: Option<&str>) -> Result<()> {
+    /// [`Self::action`], keeping `call`'s transport flag for callers that must not retry a
+    /// possibly-dispatched action by another route.
+    fn action_result(
+        &self,
+        ref_id: u32,
+        action: &str,
+        text: Option<&str>,
+    ) -> std::result::Result<(), (GlassError, bool)> {
         let mut req = json!({"op": "action", "ref": ref_id, "action": action});
         if let Some(t) = text {
             req["text"] = json!(t);
@@ -205,8 +217,14 @@ impl ServiceClient {
         self.call(req).map(|_| ())
     }
 
+    fn action(&self, ref_id: u32, action: &str, text: Option<&str>) -> Result<()> {
+        self.action_result(ref_id, action, text).map_err(|(e, _)| e)
+    }
+
     pub fn ping(&self) -> Result<()> {
-        self.call(json!({"op": "ping"})).map(|_| ())
+        self.call(json!({"op": "ping"}))
+            .map(|_| ())
+            .map_err(|(e, _)| e)
     }
 }
 
@@ -275,6 +293,22 @@ impl Accessibility for ServiceA11y {
             }
             std::thread::sleep(std::time::Duration::from_millis(150));
         }
+    }
+
+    fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<()> {
+        let tree = {
+            let mut t = self.snapshot(ctx)?;
+            t.assign_ids();
+            t
+        };
+        let node = actuable_node(&tree, target)?;
+        let chosen = node.id;
+        if !node.states.enabled {
+            return Err(disabled_error(target.id.0, chosen));
+        }
+        self.client
+            .action_result(chosen.0, "click", None)
+            .map_err(|(e, transport)| action_error(target.id.0, &e, transport))
     }
 }
 
@@ -477,7 +511,6 @@ pub(crate) fn wait_for_service(port: u16) -> Result<ServiceClient> {
 /// carries no name and the named child carries no `ACTION_CLICK`. When the target itself
 /// advertises no click, climb to the nearest node that does and encloses it — the same node a
 /// tap at the target's centre would have been handled by.
-#[cfg_attr(not(test), allow(dead_code))]
 fn actuable_node<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&'a AxNode> {
     crate::a11y::fingerprinted(tree, target)?;
     let mut path = Vec::new();
@@ -518,6 +551,29 @@ fn encloses(outer: Option<AxRect>, inner: Option<AxRect>) -> bool {
         && i64::from(o.y) <= i64::from(i.y)
         && i64::from(o.x) + i64::from(o.width) >= i64::from(i.x) + i64::from(i.width)
         && i64::from(o.y) + i64::from(o.height) >= i64::from(i.y) + i64::from(i.height)
+}
+
+/// The error for a target the tree says is disabled. Deliberately not `AxActionUnavailable`:
+/// a pointer click would tap a control that cannot act and report success.
+fn disabled_error(target: u32, chosen: AxNodeId) -> GlassError {
+    GlassError::AxActionFailed(
+        target,
+        format!(
+            "element {} is disabled, so its click action was refused; no pointer click was \
+             synthesized on top of it",
+            chosen.0
+        ),
+    )
+}
+
+/// Map an `action` failure onto the invoke contract. Neither arm is fallback-eligible: a
+/// refusal may still have reached the toolkit, and a lost answer says nothing either way.
+fn action_error(target: u32, e: &GlassError, transport: bool) -> GlassError {
+    if transport {
+        GlassError::AccessibilityUnavailable(format!("a11y service action call failed: {e}"))
+    } else {
+        GlassError::AxActionFailed(target, e.to_string())
+    }
 }
 
 #[cfg(test)]
@@ -1039,5 +1095,32 @@ mod tests {
             actuable_node(&t, &target),
             Err(GlassError::AxActionUnavailable(2))
         ));
+    }
+
+    #[test]
+    fn a_disabled_target_errors_instead_of_falling_back_to_a_pointer_click() {
+        let e = disabled_error(2, AxNodeId(1));
+        assert!(!e.invoke_fallback_eligible(), "{e}");
+        assert!(
+            e.to_string().contains("disabled"),
+            "the message must say why: {e}"
+        );
+    }
+
+    #[test]
+    fn a_device_refusal_is_not_fallback_eligible() {
+        // The device answered and refused. The call may have reached the toolkit, so a pointer
+        // click on top of it could actuate the control twice.
+        let inner = GlassError::Backend("agent: ACTION_CLICK refused".into());
+        let e = action_error(2, &inner, false);
+        assert!(!e.invoke_fallback_eligible(), "{e}");
+        assert!(e.to_string().contains("ACTION_CLICK refused"), "{e}");
+    }
+
+    #[test]
+    fn a_transport_failure_is_not_fallback_eligible_either() {
+        let inner = GlassError::Backend("agent write: broken pipe".into());
+        let e = action_error(2, &inner, true);
+        assert!(!e.invoke_fallback_eligible(), "{e}");
     }
 }

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -195,14 +195,12 @@ impl ServiceClient {
     }
 
     /// Run a request that can be run twice without consequence, transparently reconnecting
-    /// once if the socket dropped. A dead socket usually surfaces on the *read*, not the
-    /// write, so this covers the ordinary "the service rebound between calls" case.
+    /// once if the socket dropped. A dead socket usually surfaces on the *read*, not the write.
     fn call(&self, req: Value) -> std::result::Result<Value, CallFailure> {
         self.call_with(req, CallFailure::is_transport)
     }
 
-    /// [`Self::call`] for a side-effecting request: re-send only what provably never went
-    /// out, so a request whose answer was lost is reported rather than run a second time.
+    /// [`Self::call`] for a side-effecting request: re-send only what provably never went out.
     fn call_once_sent(&self, req: Value) -> std::result::Result<Value, CallFailure> {
         self.call_with(req, CallFailure::nothing_sent)
     }
@@ -217,14 +215,14 @@ impl ServiceClient {
     }
 
     /// Fire `ACTION_CLICK` on device node `ref_id`. Never re-sent once delivered; the failure
-    /// keeps its delivery classification so the caller can say what it does and does not know.
+    /// keeps its delivery classification.
     fn click(&self, ref_id: u32) -> std::result::Result<(), CallFailure> {
         self.call_once_sent(json!({"op": "action", "ref": ref_id, "action": "click"}))
             .map(|_| ())
     }
 
-    /// Fire `ACTION_SET_TEXT` on device node `ref_id`. Idempotent — the same text written
-    /// twice leaves the same field contents — so this takes the reconnecting path.
+    /// Fire `ACTION_SET_TEXT` on device node `ref_id`. Idempotent, so this takes the
+    /// reconnecting path.
     fn set_text(&self, ref_id: u32, text: &str) -> Result<()> {
         self.call(json!({"op": "action", "ref": ref_id, "action": "set_text", "text": text}))
             .map(|_| ())
@@ -260,8 +258,8 @@ impl ServiceA11y {
     }
 
     /// Poll until the actuated control reports `checked == want`. The toolkit's UI update
-    /// reaches the accessibility tree a beat after the action, so an acknowledgement is not
-    /// proof; `set_value` polls for the same reason.
+    /// reaches the accessibility tree a beat after the action; `set_value` polls for the same
+    /// reason.
     fn wait_for_check(&mut self, ctx: &AxContext, plan: &InvokePlan, want: bool) -> Result<()> {
         let deadline = std::time::Instant::now() + self.check_timeout;
         loop {
@@ -544,9 +542,9 @@ pub(crate) fn wait_for_service(port: u16) -> Result<ServiceClient> {
     }
 }
 
-/// One node's identity, captured when it is actuated so the state read back after the click
-/// can be confirmed to be that same control. An `AxNodeId` is a positional pre-order index
-/// re-derived per snapshot, so an id alone can resolve to a different node in the next tree.
+/// One node's identity, captured at actuation so a state read back after the click can be
+/// confirmed to be that same control. An `AxNodeId` is a positional pre-order index re-derived
+/// per snapshot, so an id alone can land on a different node in the next tree.
 #[derive(Debug)]
 struct Actuated {
     id: AxNodeId,
@@ -573,8 +571,8 @@ impl InvokePlan {
 }
 
 /// Whether clicking a control of this role must move its `checked` state. A checkbox or a
-/// switch toggles. A radio button or a tab selects, and clicking the one already selected
-/// leaves it selected — a correct no-op, not a click that failed.
+/// switch toggles; a radio button or a tab selects, and clicking the one already selected
+/// leaves it selected.
 fn toggles(role: AxRole) -> bool {
     matches!(role, AxRole::CheckBox | AxRole::ToggleButton)
 }
@@ -582,9 +580,8 @@ fn toggles(role: AxRole) -> bool {
 /// Decide what an `invoke` does with `target`: which node to actuate, and what the tree must
 /// show afterwards. Pure, so the decision is testable without a device.
 ///
-/// The order is load-bearing. The target's own fingerprint and `enabled` are read off the node
-/// the caller named, before the climb: a Compose control omits `ACTION_CLICK` while disabled,
-/// so a climb run first walks straight past it and actuates whatever encloses it.
+/// The order is load-bearing: a Compose control omits `ACTION_CLICK` while disabled, so a climb
+/// run before the target's own `enabled` check walks past it and actuates whatever encloses it.
 fn invoke_plan(tree: &AxTree, target: &AxTarget) -> Result<InvokePlan> {
     let node = crate::a11y::fingerprinted(tree, target)?;
     if !node.states.enabled {
@@ -592,11 +589,9 @@ fn invoke_plan(tree: &AxTree, target: &AxTarget) -> Result<InvokePlan> {
     }
     // Under these caps the kept nodes are no longer a pre-order prefix — the walk drops a
     // subtree and carries on with later siblings — so a host id no longer equals the device
-    // `ref` it would be sent as, and the click would dispatch to a different device node.
-    // `Nodes` stops the walk outright and keeps the prefix, so it stays actuable.
-    //
-    // Fallback-eligible on purpose: nothing has been dispatched, and the pointer path aims at
-    // this tree's own bounds, which the id/`ref` skew does not touch.
+    // `ref` it would be sent as. `Nodes` stops the walk outright and keeps the prefix.
+    // Fallback-eligible on purpose: nothing was dispatched, and the pointer path aims at this
+    // tree's own bounds, which the id/`ref` skew does not touch.
     if let Some(t) = &tree.truncated
         && matches!(t.limit, TruncationLimit::Depth | TruncationLimit::Siblings)
     {
@@ -633,10 +628,9 @@ enum CheckState {
 
 /// Read the actuated control's `checked` out of a tree taken after the click.
 ///
-/// The id alone is not enough to accept a state change by: it is positional, so a node the
-/// click added above the control shifts every later id, and `checked` reads `false` on any
-/// node that has no checked state at all — between them, an inert label sliding into the id
-/// reads as a flip.
+/// The id alone cannot accept a state change: it is positional, so a node the click added above
+/// the control shifts every later id, and `checked` reads `false` on any node with no checked
+/// state — between them, an inert label sliding into the id reads as a flip.
 fn check_state(after: &AxTree, act: &Actuated) -> CheckState {
     match after.find(act.id) {
         Some(n) if n.states.checkable && n.role == act.role && n.name == act.name => {
@@ -650,9 +644,8 @@ fn check_state(after: &AxTree, act: &Actuated) -> CheckState {
 ///
 /// A Compose button's label and its clickable node are different nodes: the touch-target
 /// carries no name and the named child carries no `ACTION_CLICK`. When the target itself
-/// advertises no click, climb to the nearest node that does and encloses it. Only the target's
-/// own ancestor chain is walked, so this is the node a tap at the target's centre would reach
-/// short of an overlapping sibling drawn above it.
+/// advertises no click, climb to the nearest node that does and encloses it. Only the ancestor
+/// chain is walked, so an overlapping sibling drawn above the target could still take a real tap.
 fn actuable_node<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&'a AxNode> {
     let mut path = Vec::new();
     if !path_to(&tree.root, target.id, &mut path) {
@@ -714,8 +707,8 @@ fn action_error(target: u32, f: CallFailure) -> GlassError {
         CallFailure::NotSent(e) => GlassError::AccessibilityUnavailable(format!(
             "the click on element {target} could not be sent: {e}"
         )),
-        // Non-fallback-eligible is not enough here: the message has to stop a human or an
-        // agent re-clicking by hand what may already have actuated.
+        // Non-fallback-eligible only stops glass re-clicking; the message has to stop a human
+        // or an agent doing it by hand.
         CallFailure::AnswerLost(e) => GlassError::AccessibilityUnavailable(format!(
             "the click on element {target} was sent but its result was lost ({e}); it may or \
              may not have actuated — re-snapshot to see the app's state rather than clicking \
@@ -1303,8 +1296,7 @@ mod tests {
         let e = action_error(2, CallFailure::AnswerLost(inner));
         assert!(matches!(e, GlassError::AccessibilityUnavailable(_)), "{e}");
         assert!(!e.invoke_fallback_eligible(), "{e}");
-        // Refusing to fall back is only half of it: the message has to stop a human or an
-        // agent clicking again by hand.
+        // Refusing to fall back is only half of it — the message has to stop a hand-retry.
         let m = e.to_string();
         assert!(m.contains("was sent"), "{m}");
         assert!(m.contains("may or may not have actuated"), "{m}");
@@ -1332,9 +1324,9 @@ mod tests {
 
     #[test]
     fn a_control_that_vanished_after_the_click_is_not_reported_as_never_moving() {
-        // A checkable row that navigates, a toggle in a dismissing dialog: the state was never
-        // read back at all, and "it stayed <was>" would be an actively wrong diagnosis of a
-        // click that worked — one that invites the retry that actuates twice.
+        // A checkable row that navigates, a toggle in a dismissing dialog: "it stayed <was>"
+        // would be a wrong diagnosis of a click that worked, inviting the retry that actuates
+        // twice.
         let act = actuated(1, AxRole::CheckBox, "Agree");
         let e = check_timeout(2, &act, true, CheckState::Gone);
         let m = e.to_string();
@@ -1375,9 +1367,9 @@ mod tests {
 
     #[test]
     fn a_node_that_inherited_the_id_does_not_count_as_the_flip() {
-        // The app rejected the change and showed an error line above the control, so the tree
-        // gained a node and every later id shifted. Id 1 is now an inert label, whose `checked`
-        // reads false on any node — which a bare `checked != was` reads as an unchecking.
+        // The app rejected the change and showed an error line above the control, so every
+        // later id shifted. Id 1 is now an inert label, whose `checked` reads false — which a
+        // bare `checked != was` reads as an unchecking.
         let after = after_tree(vec![
             json!({
                 "class": "android.widget.TextView", "text": "You must agree first",
@@ -1429,8 +1421,7 @@ mod tests {
 
     #[test]
     fn a_label_climbs_to_the_nearest_clickable_ancestor_not_the_outermost() {
-        // Both the card and the button enclose the label and both advertise a click. Climbing
-        // to the card actuates "open detail" where the caller asked for "delete".
+        // Climbing to the card actuates "open detail" where the caller asked for "delete".
         let t = built(&nested_clickables());
         let label = target_for(&t, AxNodeId(3));
         assert_eq!(label.name.as_deref(), Some("Delete"));
@@ -1441,9 +1432,9 @@ mod tests {
         );
     }
 
-    /// A disabled control that advertises no click of its own, inside a clickable card. This is
-    /// the Compose shape: the accessibility delegate omits `ACTION_CLICK` while a control is
-    /// disabled, so nothing but the node's own `enabled` flag says to refuse.
+    /// A disabled control that advertises no click of its own, inside a clickable card — the
+    /// Compose shape, where the delegate omits `ACTION_CLICK` while a control is disabled, so
+    /// nothing but the node's own `enabled` flag says to refuse.
     fn disabled_inside_a_clickable_card() -> Value {
         let mut v = nested_clickables();
         v["children"][0]["children"][0]["clickable"] = json!(false);
@@ -1503,8 +1494,8 @@ mod tests {
 
     #[test]
     fn re_clicking_a_selected_radio_button_asks_for_no_state_change() {
-        // A radio button that is already selected stays selected: the click is a correct no-op,
-        // so waiting for a flip would fail a click on a UI already in the requested state.
+        // A radio button already selected stays selected, so waiting for a flip fails a click
+        // on a UI already in the requested state.
         let t = selection_tree("android.widget.RadioButton", true);
         let plan = invoke_plan(&t, &target_for(&t, AxNodeId(1))).unwrap();
         assert_eq!(plan.want_checked, None);
@@ -1568,9 +1559,8 @@ mod tests {
 
     #[test]
     fn a_depth_truncated_tree_does_not_actuate_natively() {
-        // The depth cap drops a node's children and carries on with later siblings, so the
-        // kept set is no longer a pre-order prefix and a host id no longer equals the device
-        // `ref` the click would be sent as.
+        // The depth cap drops a node's children and carries on with later siblings, so the kept
+        // set is no longer a pre-order prefix.
         let t = truncated_compose(WalkLimits {
             depth: 1,
             ..WalkLimits::DEFAULT
@@ -1579,7 +1569,7 @@ mod tests {
         let e = invoke_plan(&t, &target_for(&t, AxNodeId(1))).unwrap_err();
         assert!(matches!(e, GlassError::AxActionUnavailable(1)), "{e}");
         // Nothing was dispatched and the pointer path aims at this tree's own bounds, so the
-        // click still lands — as a disclosed pointer click.
+        // click still lands, disclosed as a pointer click.
         assert!(e.invoke_fallback_eligible(), "{e}");
     }
 
@@ -1611,8 +1601,8 @@ mod tests {
 
     #[test]
     fn a_node_capped_tree_still_actuates_natively() {
-        // The node cap stops the walk outright, so what it kept IS a pre-order prefix and every
-        // surviving id still equals its device `ref`.
+        // The node cap stops the walk outright, so every surviving id still equals its device
+        // `ref`.
         let t = truncated_compose(WalkLimits {
             nodes: 2,
             ..WalkLimits::DEFAULT
@@ -1693,9 +1683,9 @@ mod tests {
         (port, ops)
     }
 
-    /// A reader wired to a fake device. `check_timeout` is passed explicitly so a test that
-    /// must watch a state check time out does not wait out the production budget;
-    /// `Duration::ZERO` makes it read the tree back exactly once.
+    /// A reader wired to a fake device. `check_timeout` is passed explicitly so a test watching
+    /// a state check time out does not wait out the production budget; `Duration::ZERO` makes it
+    /// read the tree back exactly once.
     fn reader(port: u16, check_timeout: std::time::Duration) -> ServiceA11y {
         let client = ServiceClient::connect(port).expect("connect to the fake service");
         let mut a = ServiceA11y::new(client, String::new());
@@ -1719,8 +1709,8 @@ mod tests {
 
     #[test]
     fn a_click_whose_answer_was_lost_is_not_re_sent() {
-        // The write landed and the response did not come back. Re-sending on a fresh socket —
-        // what a transparent reconnect does — dispatches a second ACTION_CLICK and reports one
+        // The write landed and the response did not come back. Re-sending on a fresh socket,
+        // as a transparent reconnect does, dispatches a second ACTION_CLICK and reports one
         // successful native click.
         let (port, ops) = fake_service(vec![compose_like()], OnAction::DropWithoutAnswering);
         let mut a = reader(port, std::time::Duration::ZERO);
@@ -1742,8 +1732,8 @@ mod tests {
 
     #[test]
     fn the_click_is_sent_to_the_node_the_climb_resolved_to() {
-        // Sending the caller's own id would click the label, which handles nothing — the climb
-        // would be decorative and every Compose click a no-op reported as success.
+        // Sending the caller's own id would click the label, which handles nothing — every
+        // Compose click a no-op reported as success.
         let (port, ops) = fake_service(vec![compose_like()], OnAction::Ok);
         let mut a = reader(port, std::time::Duration::ZERO);
         let t = built(&compose_like());

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -238,6 +238,30 @@ impl ServiceA11y {
     pub fn new(client: ServiceClient, package: String) -> Self {
         Self { client, package }
     }
+
+    /// Poll until `chosen`'s `checked` leaves `was`. A Compose recompose reaches the
+    /// accessibility tree a beat after the action, so an acknowledgement is not proof the
+    /// control flipped; `set_value` polls for the same reason.
+    fn wait_for_flip(
+        &mut self,
+        ctx: &AxContext,
+        target: u32,
+        chosen: AxNodeId,
+        was: bool,
+    ) -> Result<()> {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            let mut after = self.snapshot(ctx)?;
+            after.assign_ids();
+            if after.find(chosen).is_some_and(|n| n.states.checked != was) {
+                return Ok(());
+            }
+            if std::time::Instant::now() >= deadline {
+                return Err(flip_timeout(target, chosen, was));
+            }
+            std::thread::sleep(std::time::Duration::from_millis(150));
+        }
+    }
 }
 
 impl Accessibility for ServiceA11y {
@@ -306,9 +330,14 @@ impl Accessibility for ServiceA11y {
         if !node.states.enabled {
             return Err(disabled_error(target.id.0, chosen));
         }
+        let (checkable, was) = (node.states.checkable, node.states.checked);
         self.client
             .action_result(chosen.0, "click", None)
-            .map_err(|(e, transport)| action_error(target.id.0, &e, transport))
+            .map_err(|(e, transport)| action_error(target.id.0, &e, transport))?;
+        if checkable {
+            return self.wait_for_flip(ctx, target.id.0, chosen, was);
+        }
+        Ok(())
     }
 }
 
@@ -574,6 +603,18 @@ fn action_error(target: u32, e: &GlassError, transport: bool) -> GlassError {
     } else {
         GlassError::AxActionFailed(target, e.to_string())
     }
+}
+
+/// The error for a toggle whose action was acknowledged but whose state never moved.
+fn flip_timeout(target: u32, chosen: AxNodeId, was: bool) -> GlassError {
+    GlassError::AxActionFailed(
+        target,
+        format!(
+            "the click action on element {} was accepted but its checked state stayed {was}; \
+             the control did not toggle",
+            chosen.0
+        ),
+    )
 }
 
 #[cfg(test)]
@@ -1122,5 +1163,14 @@ mod tests {
         let inner = GlassError::Backend("agent write: broken pipe".into());
         let e = action_error(2, &inner, true);
         assert!(!e.invoke_fallback_eligible(), "{e}");
+    }
+
+    #[test]
+    fn a_toggle_that_never_flipped_is_a_failure_not_a_missing_action() {
+        let e = flip_timeout(2, AxNodeId(1), false);
+        assert!(!e.invoke_fallback_eligible(), "{e}");
+        // The distinction that matters to a caller: the action WAS accepted.
+        assert!(e.to_string().contains("accepted"), "{e}");
+        assert!(e.to_string().contains("did not toggle"), "{e}");
     }
 }

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -471,6 +471,55 @@ pub(crate) fn wait_for_service(port: u16) -> Result<ServiceClient> {
     }
 }
 
+/// The node an `invoke` should actuate on behalf of `target`.
+///
+/// A Compose button's label and its clickable node are different nodes: the touch-target
+/// carries no name and the named child carries no `ACTION_CLICK`. When the target itself
+/// advertises no click, climb to the nearest node that does and encloses it — the same node a
+/// tap at the target's centre would have been handled by.
+#[cfg_attr(not(test), allow(dead_code))]
+fn actuable_node<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&'a AxNode> {
+    crate::a11y::fingerprinted(tree, target)?;
+    let mut path = Vec::new();
+    if !path_to(&tree.root, target.id, &mut path) {
+        return Err(GlassError::AxElementNotFound(target.id.0));
+    }
+    let want = path.last().expect("path_to leaves the target last").bounds;
+    path.iter()
+        .rev()
+        .find(|n| n.states.focusable && (n.id == target.id || encloses(n.bounds, want)))
+        .copied()
+        .ok_or(GlassError::AxActionUnavailable(target.id.0))
+}
+
+/// The root-to-`id` path, inclusive of both ends. False when `id` is not in this subtree,
+/// leaving `out` as it was found.
+fn path_to<'a>(node: &'a AxNode, id: AxNodeId, out: &mut Vec<&'a AxNode>) -> bool {
+    out.push(node);
+    if node.id == id {
+        return true;
+    }
+    for c in &node.children {
+        if path_to(c, id, out) {
+            return true;
+        }
+    }
+    out.pop();
+    false
+}
+
+/// Whether `outer` fully contains `inner`. A node without bounds encloses nothing — the climb
+/// must not reach past a node whose geometry it cannot check.
+fn encloses(outer: Option<AxRect>, inner: Option<AxRect>) -> bool {
+    let (Some(o), Some(i)) = (outer, inner) else {
+        return false;
+    };
+    i64::from(o.x) <= i64::from(i.x)
+        && i64::from(o.y) <= i64::from(i.y)
+        && i64::from(o.x) + i64::from(o.width) >= i64::from(i.x) + i64::from(i.width)
+        && i64::from(o.y) + i64::from(o.height) >= i64::from(i.y) + i64::from(i.height)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -848,5 +897,113 @@ mod tests {
             true,
         );
         assert_eq!(node.name.as_deref(), Some("Email"));
+    }
+
+    /// A device tree shaped like Compose's: the clickable touch-target `View` carries no name,
+    /// and the label that names it is a child.
+    fn compose_like() -> Value {
+        json!({
+            "class": "android.widget.FrameLayout",
+            "bounds": {"x": 0, "y": 100, "w": 1080, "h": 2300},
+            "editable": false, "clickable": false, "enabled": true, "scrollable": false,
+            "children": [
+                {"class": "android.view.View",
+                 "bounds": {"x": 60, "y": 480, "w": 210, "h": 130},
+                 "editable": false, "clickable": true, "enabled": true, "scrollable": false,
+                 "children": [
+                    {"class": "android.widget.TextView", "text": "Save",
+                     "bounds": {"x": 120, "y": 520, "w": 80, "h": 50},
+                     "editable": false, "clickable": false, "enabled": true, "scrollable": false}
+                 ]}
+            ]
+        })
+    }
+
+    fn built(v: &Value) -> AxTree {
+        let mut t = tree_from_json(v, &win(), WalkLimits::DEFAULT).expect("maps");
+        t.assign_ids();
+        t
+    }
+
+    /// The target a caller would hold after selecting `id` from `tree`.
+    fn target_for(tree: &AxTree, id: AxNodeId) -> AxTarget {
+        let n = tree.find(id).expect("node is in the tree");
+        AxTarget {
+            id,
+            role: n.role,
+            name: n.name.clone(),
+            bounds: n.bounds,
+            value: n.value.clone(),
+        }
+    }
+
+    #[test]
+    fn a_named_label_climbs_to_the_clickable_node_that_encloses_it() {
+        let t = built(&compose_like());
+        let label = target_for(&t, AxNodeId(2));
+        assert_eq!(label.name.as_deref(), Some("Save"));
+        assert_eq!(actuable_node(&t, &label).unwrap().id, AxNodeId(1));
+    }
+
+    #[test]
+    fn a_target_that_advertises_a_click_is_actuated_directly() {
+        let t = built(&compose_like());
+        let btn = target_for(&t, AxNodeId(1));
+        assert_eq!(actuable_node(&t, &btn).unwrap().id, AxNodeId(1));
+    }
+
+    #[test]
+    fn a_clickable_ancestor_that_does_not_enclose_the_target_is_not_climbed_to() {
+        // Same shape, but the clickable node's box sits beside its label rather than around
+        // it — the case where a tap at the label's centre would NOT have reached it.
+        let mut v = compose_like();
+        v["children"][0]["bounds"] = json!({"x": 600, "y": 480, "w": 210, "h": 130});
+        let t = built(&v);
+        let label = target_for(&t, AxNodeId(2));
+        assert!(matches!(
+            actuable_node(&t, &label),
+            Err(GlassError::AxActionUnavailable(2))
+        ));
+    }
+
+    #[test]
+    fn a_path_with_no_clickable_node_reports_the_action_unavailable() {
+        let mut v = compose_like();
+        v["children"][0]["clickable"] = json!(false);
+        let t = built(&v);
+        let label = target_for(&t, AxNodeId(2));
+        assert!(matches!(
+            actuable_node(&t, &label),
+            Err(GlassError::AxActionUnavailable(2))
+        ));
+    }
+
+    #[test]
+    fn action_unavailable_is_the_only_resolution_error_that_may_fall_back() {
+        let mut v = compose_like();
+        v["children"][0]["clickable"] = json!(false);
+        let t = built(&v);
+        let e = actuable_node(&t, &target_for(&t, AxNodeId(2))).unwrap_err();
+        assert!(e.invoke_fallback_eligible(), "{e}");
+    }
+
+    #[test]
+    fn a_target_whose_name_drifted_is_rejected_before_any_climb() {
+        let t = built(&compose_like());
+        let mut label = target_for(&t, AxNodeId(2));
+        label.name = Some("Send".into());
+        assert!(matches!(
+            actuable_node(&t, &label),
+            Err(GlassError::AxElementChanged(2))
+        ));
+    }
+
+    #[test]
+    fn a_drifted_target_must_not_fall_back_to_a_pointer_click() {
+        let t = built(&compose_like());
+        let mut label = target_for(&t, AxNodeId(2));
+        label.name = Some("Send".into());
+        let e = actuable_node(&t, &label).unwrap_err();
+        assert!(!e.invoke_fallback_eligible(), "{e}");
     }
 }

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -172,9 +172,8 @@ impl ServiceClient {
         })
     }
 
-    /// Run a request, transparently reconnecting once if the socket dropped. The bool in the
-    /// error is `Conn::call`'s: true when the failure was transport rather than a refusal the
-    /// device sent back.
+    /// Run a request, transparently reconnecting once if the socket dropped. The bool is
+    /// `Conn::call`'s: true for a transport failure, false for a refusal the device sent back.
     fn call(&self, req: Value) -> std::result::Result<Value, (GlassError, bool)> {
         let mut conn = self.conn.lock().map_err(|_| {
             (
@@ -239,9 +238,9 @@ impl ServiceA11y {
         Self { client, package }
     }
 
-    /// Poll until `chosen`'s `checked` leaves `was`. A Compose recompose reaches the
-    /// accessibility tree a beat after the action, so an acknowledgement is not proof the
-    /// control flipped; `set_value` polls for the same reason.
+    /// Poll until `chosen`'s `checked` leaves `was` — a Compose recompose reaches the tree a
+    /// beat after the action, so acknowledgement is not proof; `set_value` polls for the same
+    /// reason.
     fn wait_for_flip(
         &mut self,
         ctx: &AxContext,

--- a/crates/glass-android/src/agent.rs
+++ b/crates/glass-android/src/agent.rs
@@ -10,7 +10,7 @@ use glass_core::{GlassError, Result};
 use serde_json::{Value, json};
 
 use crate::adb::Adb;
-use crate::conn::Conn;
+use crate::conn::{CallFailure, Conn};
 
 /// One absolute-display point in a pointer path (the agent's gesture element).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -42,12 +42,12 @@ impl AgentClient {
             .map_err(|_| GlassError::Backend("agent client lock poisoned".into()))?;
         match conn.call(req.clone()) {
             Ok(v) => Ok(v),
-            Err((e, false)) => Err(e),
-            Err((_, true)) => {
+            Err(f) if f.is_transport() => {
                 // The agent's accept loop accepts a fresh connection after a drop.
                 *conn = Conn::open(self.port)?;
-                conn.call(req).map_err(|(e, _)| e)
+                conn.call(req).map_err(CallFailure::into_error)
             }
+            Err(f) => Err(f.into_error()),
         }
     }
 

--- a/crates/glass-android/src/conn.rs
+++ b/crates/glass-android/src/conn.rs
@@ -13,16 +13,15 @@ use serde_json::{Value, json};
 /// The protocol version this client speaks (must match the agent's hello `proto`).
 pub(crate) const PROTO: i64 = 1;
 
-/// Why one [`Conn::call`] failed, and what it says about delivery. A side-effecting request
-/// may only be re-sent when nothing reached the device: `ACTION_CLICK` is not idempotent, so
-/// re-sending one whose answer was merely lost actuates the control twice.
+/// Why one [`Conn::call`] failed, and what it says about delivery. `ACTION_CLICK` is not
+/// idempotent, so re-sending one whose answer was merely lost actuates the control twice.
 pub(crate) enum CallFailure {
     /// The write failed, so the request never reached the device.
     NotSent(GlassError),
     /// The request went out and no answer came back; it may or may not have run.
     AnswerLost(GlassError),
-    /// The device answered — with a refusal, or with something this client could not read
-    /// as a success. Either way it ran what it was going to run.
+    /// The device answered — with a refusal, or with something this client could not read as
+    /// a success. Either way it ran what it was going to run.
     Refused(GlassError),
 }
 
@@ -44,8 +43,8 @@ impl CallFailure {
         matches!(self, CallFailure::NotSent(_))
     }
 
-    /// This classification carrying `e` instead — for a failure hit while recovering from
-    /// this one, which says no more about delivery than this one already did.
+    /// This classification carrying `e` instead: a failure hit while recovering from this one
+    /// says no more about delivery.
     pub(crate) fn with_error(&self, e: GlassError) -> CallFailure {
         match self {
             CallFailure::NotSent(_) => CallFailure::NotSent(e),

--- a/crates/glass-android/src/conn.rs
+++ b/crates/glass-android/src/conn.rs
@@ -13,6 +13,48 @@ use serde_json::{Value, json};
 /// The protocol version this client speaks (must match the agent's hello `proto`).
 pub(crate) const PROTO: i64 = 1;
 
+/// Why one [`Conn::call`] failed, and what it says about delivery. A side-effecting request
+/// may only be re-sent when nothing reached the device: `ACTION_CLICK` is not idempotent, so
+/// re-sending one whose answer was merely lost actuates the control twice.
+pub(crate) enum CallFailure {
+    /// The write failed, so the request never reached the device.
+    NotSent(GlassError),
+    /// The request went out and no answer came back; it may or may not have run.
+    AnswerLost(GlassError),
+    /// The device answered — with a refusal, or with something this client could not read
+    /// as a success. Either way it ran what it was going to run.
+    Refused(GlassError),
+}
+
+impl CallFailure {
+    /// The error to surface.
+    pub(crate) fn into_error(self) -> GlassError {
+        match self {
+            CallFailure::NotSent(e) | CallFailure::AnswerLost(e) | CallFailure::Refused(e) => e,
+        }
+    }
+
+    /// Whether the socket failed rather than the device answering.
+    pub(crate) fn is_transport(&self) -> bool {
+        matches!(self, CallFailure::NotSent(_) | CallFailure::AnswerLost(_))
+    }
+
+    /// Whether nothing reached the device, so re-sending cannot run the request twice.
+    pub(crate) fn nothing_sent(&self) -> bool {
+        matches!(self, CallFailure::NotSent(_))
+    }
+
+    /// This classification carrying `e` instead — for a failure hit while recovering from
+    /// this one, which says no more about delivery than this one already did.
+    pub(crate) fn with_error(&self, e: GlassError) -> CallFailure {
+        match self {
+            CallFailure::NotSent(_) => CallFailure::NotSent(e),
+            CallFailure::AnswerLost(_) => CallFailure::AnswerLost(e),
+            CallFailure::Refused(_) => CallFailure::Refused(e),
+        }
+    }
+}
+
 /// A live connection to the agent: a framed line reader/writer + a monotonic id.
 pub(crate) struct Conn {
     pub(crate) writer: TcpStream,
@@ -68,12 +110,8 @@ impl Conn {
     }
 
     /// Send one request object (an `id` is injected) and return the response `Value`.
-    /// Returns `(result, io_error)` — `io_error` is true when the failure was a
-    /// transport I/O error (dropped connection) rather than a protocol-level error.
-    pub(crate) fn call(
-        &mut self,
-        mut req: Value,
-    ) -> std::result::Result<Value, (GlassError, bool)> {
+    /// A failure is classified by how far the request got — see [`CallFailure`].
+    pub(crate) fn call(&mut self, mut req: Value) -> std::result::Result<Value, CallFailure> {
         let id = self.next_id;
         self.next_id += 1;
         req["id"] = json!(id);
@@ -82,25 +120,25 @@ impl Conn {
         self.writer
             .write_all(line.as_bytes())
             .and_then(|_| self.writer.flush())
-            .map_err(|e| (GlassError::Backend(format!("agent write: {e}")), true))?;
-        let resp_line = self.read_line().map_err(|e| (e, true))?;
-        let resp: Value = serde_json::from_str(&resp_line)
-            .map_err(|e| (GlassError::Backend(format!("agent resp parse: {e}")), false))?;
+            .map_err(|e| CallFailure::NotSent(GlassError::Backend(format!("agent write: {e}"))))?;
+        let resp_line = self.read_line().map_err(CallFailure::AnswerLost)?;
+        let resp: Value = serde_json::from_str(&resp_line).map_err(|e| {
+            CallFailure::Refused(GlassError::Backend(format!("agent resp parse: {e}")))
+        })?;
         if resp.get("id").and_then(Value::as_i64) != Some(id) {
-            return Err((
-                GlassError::Backend(format!(
-                    "agent response id mismatch (got {:?}, want {id})",
-                    resp.get("id")
-                )),
-                false,
-            ));
+            return Err(CallFailure::Refused(GlassError::Backend(format!(
+                "agent response id mismatch (got {:?}, want {id})",
+                resp.get("id")
+            ))));
         }
         if resp.get("ok").and_then(Value::as_bool) != Some(true) {
             let err = resp
                 .get("error")
                 .and_then(Value::as_str)
                 .unwrap_or("agent error");
-            return Err((GlassError::Backend(format!("agent: {err}")), false));
+            return Err(CallFailure::Refused(GlassError::Backend(format!(
+                "agent: {err}"
+            ))));
         }
         Ok(resp)
     }

--- a/crates/glass-android/tests/a11y_service_loop.rs
+++ b/crates/glass-android/tests/a11y_service_loop.rs
@@ -158,11 +158,9 @@ fn native_invoke_actuates_the_fixture() {
             .expect("counter is present")
     };
 
-    // Poll `read` (a `counter(&mut a11y)` call) until it differs from `before`, instead of
-    // sleeping a fixed settle time and reading once. `invoke` itself already refuses to
-    // guess this timing for a checkable target — `wait_for_flip` polls rather than assumes
-    // a fixed delay — so a non-checkable click's effect on the a11y tree is awaited the
-    // same way here rather than assumed. A timeout is a real failure, not a silent pass.
+    // Poll `read` until it changes instead of sleeping once — `invoke` only waits internally
+    // for a checkable target (`wait_for_flip`), so a plain click's effect on the tree is
+    // awaited here instead. A timeout is a real failure, not a silent pass.
     fn await_change(
         what: &str,
         before: &str,
@@ -185,9 +183,8 @@ fn native_invoke_actuates_the_fixture() {
             std::thread::sleep(std::time::Duration::from_millis(150));
         }
     }
-    // Real headroom over the ~520-580ms this actuation was measured to take on-device — the
-    // poll returns as soon as the value changes, so a generous ceiling costs nothing when it
-    // does.
+    // Measured ~520-580ms on-device; generous is free since the poll returns as soon as the
+    // value changes.
     const AWAIT_DEADLINE: std::time::Duration = std::time::Duration::from_secs(5);
 
     // An enabled classic button actuates.

--- a/crates/glass-android/tests/a11y_service_loop.rs
+++ b/crates/glass-android/tests/a11y_service_loop.rs
@@ -5,15 +5,24 @@
 //!   GLASS_ANDROID_FIXTURE_APK=/path/to/fixture-compose-debug.apk \
 //!     cargo test -p glass-android --test a11y_service_loop -- --ignored --nocapture
 
+use std::sync::Mutex;
+
 use glass_android::{
     A11yServiceRegistry, AgentRegistry, AndroidPlatform, EmulatorRegistry, ServiceA11y,
 };
 use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, WalkLimits};
 use glass_core::{AppSpec, Platform, SandboxLevel, WindowGeometry};
 
+/// Serialize the two tests below: the on-device accessibility service accepts one connection
+/// at a time, and both tests drive whichever activity is currently foreground, so running them
+/// concurrently makes each retarget the other's window. Poison-tolerant so a panicking test
+/// does not wedge the other.
+static DEVICE: Mutex<()> = Mutex::new(());
+
 #[test]
 #[ignore = "requires a booted AVD + GLASS_ADB + GLASS_ANDROID_A11Y_APK"]
 fn a11y_service_snapshot_and_actions() {
+    let _device = DEVICE.lock().unwrap_or_else(|e| e.into_inner());
     let apk = std::env::var("GLASS_ANDROID_A11Y_APK").expect("set GLASS_ANDROID_A11Y_APK");
     // Resolve the device the same way production does, and reuse its serial-bound adb (the
     // `resolved_adb()` accessor) — no bespoke test helper. Launch Settings for an active window.
@@ -90,6 +99,7 @@ fn a11y_service_snapshot_and_actions() {
 #[test]
 #[ignore = "requires a booted AVD + GLASS_ADB + GLASS_ANDROID_A11Y_APK + GLASS_ANDROID_FIXTURE_APK"]
 fn native_invoke_actuates_the_fixture() {
+    let _device = DEVICE.lock().unwrap_or_else(|e| e.into_inner());
     let apk = std::env::var("GLASS_ANDROID_A11Y_APK").expect("set GLASS_ANDROID_A11Y_APK");
     let fixture =
         std::env::var("GLASS_ANDROID_FIXTURE_APK").expect("set GLASS_ANDROID_FIXTURE_APK");

--- a/crates/glass-android/tests/a11y_service_loop.rs
+++ b/crates/glass-android/tests/a11y_service_loop.rs
@@ -1,6 +1,7 @@
 //! Live a11y-service round-trip. Ignored; run with a booted AVD + the built APK:
 //!   GLASS_ADB=$HOME/android-sdk/platform-tools/adb \
 //!   GLASS_ANDROID_A11Y_APK=$HOME/git-sources/fw/glass-android-agent/a11y/build/outputs/apk/debug/a11y-debug.apk \
+//!   GLASS_ANDROID_FIXTURE_APK=$HOME/git-sources/fw/glass-android-agent/fixture-compose/build/outputs/apk/debug/fixture-compose-debug.apk \
 //!     cargo test -p glass-android --test a11y_service_loop -- --ignored --nocapture
 
 use glass_android::{
@@ -82,4 +83,188 @@ fn a11y_service_snapshot_and_actions() {
 
     // Then the controller condition-polls the device to confirm teardown left no enabled service
     // and no forward (don't snapshot immediately — the unbind is async, ~1s; mirror the agent_loop leak check).
+}
+
+/// Native invoke against the fixture. Ignored; run with a booted AVD:
+///   GLASS_ADB=$HOME/android-sdk/platform-tools/adb \
+///   GLASS_ANDROID_A11Y_APK=.../a11y-debug.apk \
+///   GLASS_ANDROID_FIXTURE_APK=.../fixture-compose-debug.apk \
+///     cargo test -p glass-android --test a11y_service_loop -- --ignored --nocapture
+#[test]
+#[ignore = "requires a booted AVD + GLASS_ADB + GLASS_ANDROID_A11Y_APK + GLASS_ANDROID_FIXTURE_APK"]
+fn native_invoke_actuates_the_fixture() {
+    let apk = std::env::var("GLASS_ANDROID_A11Y_APK").expect("set GLASS_ANDROID_A11Y_APK");
+    let fixture =
+        std::env::var("GLASS_ANDROID_FIXTURE_APK").expect("set GLASS_ANDROID_FIXTURE_APK");
+
+    let agents = AgentRegistry::new();
+    let mut p = AndroidPlatform::from_env(&EmulatorRegistry::new(), &agents).expect("attach");
+    let adb = p.resolved_adb();
+    adb.run(["install", "-r", "-g", &fixture])
+        .expect("install fixture");
+
+    let spec = |activity: &str| AppSpec {
+        build: None,
+        run: vec![format!("com.fixedwidth.glassfixture/.{activity}")],
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        timeout_ms: 10_000,
+        sandbox: SandboxLevel::Off,
+        a11y: false,
+    };
+    p.start_app(&spec("InvokeViewFixtureActivity"))
+        .expect("launch view fixture");
+
+    let reg = A11yServiceRegistry::new();
+    let client = reg.ensure(&adb, &apk).expect("install + enable + connect");
+    let mut a11y = ServiceA11y::new(client, String::new());
+    let ctx = AxContext {
+        pids: vec![],
+        window: WindowGeometry {
+            x: 0,
+            y: 0,
+            width: 1080,
+            height: 2400,
+        },
+        window_handle: None,
+        a11y_bus_addr: None,
+        limits: WalkLimits::DEFAULT,
+    };
+
+    fn by_desc<'a>(n: &'a AxNode, desc: &str) -> Option<&'a AxNode> {
+        if n.description.as_deref() == Some(desc) || n.name.as_deref() == Some(desc) {
+            return Some(n);
+        }
+        n.children.iter().find_map(|c| by_desc(c, desc))
+    }
+    fn target(n: &AxNode) -> AxTarget {
+        AxTarget {
+            id: n.id,
+            role: n.role,
+            name: n.name.clone(),
+            bounds: n.bounds,
+            value: n.value.clone(),
+        }
+    }
+    let snap = |a: &mut ServiceA11y| {
+        let mut t = a.snapshot(&ctx).expect("snapshot");
+        t.assign_ids();
+        t
+    };
+    let counter = |a: &mut ServiceA11y| {
+        by_desc(&snap(a).root, "Counter")
+            .and_then(|n| n.name.clone().or_else(|| n.value.clone()))
+            .expect("counter is present")
+    };
+
+    // Poll `read` (a `counter(&mut a11y)` call) until it differs from `before`, instead of
+    // sleeping a fixed settle time and reading once. `invoke` itself already refuses to
+    // guess this timing for a checkable target — `wait_for_flip` polls rather than assumes
+    // a fixed delay — so a non-checkable click's effect on the a11y tree is awaited the
+    // same way here rather than assumed. A timeout is a real failure, not a silent pass.
+    fn await_change(
+        what: &str,
+        before: &str,
+        deadline: std::time::Duration,
+        mut read: impl FnMut() -> String,
+    ) -> String {
+        let start = std::time::Instant::now();
+        loop {
+            let now = read();
+            if now != before {
+                return now;
+            }
+            let elapsed = start.elapsed();
+            if elapsed >= deadline {
+                panic!(
+                    "timed out after {elapsed:?} waiting for {what}; still reads {now:?} \
+                     (started at {before:?})"
+                );
+            }
+            std::thread::sleep(std::time::Duration::from_millis(150));
+        }
+    }
+    // Real headroom over the ~520-580ms this actuation was measured to take on-device — the
+    // poll returns as soon as the value changes, so a generous ceiling costs nothing when it
+    // does.
+    const AWAIT_DEADLINE: std::time::Duration = std::time::Duration::from_secs(5);
+
+    // An enabled classic button actuates.
+    let before = counter(&mut a11y);
+    let t = snap(&mut a11y);
+    let save = target(by_desc(&t.root, "SaveBtn").expect("SaveBtn"));
+    a11y.invoke(&ctx, &save)
+        .expect("native invoke on an enabled button");
+    let after = await_change(
+        "the enabled button's click to register",
+        &before,
+        AWAIT_DEADLINE,
+        || counter(&mut a11y),
+    );
+    assert_ne!(after, before, "the click must actuate");
+
+    // A row far below the fold actuates — the case a pointer tap cannot serve.
+    let t = snap(&mut a11y);
+    let row = target(by_desc(&t.root, "Row250").expect("Row250"));
+    let before = counter(&mut a11y);
+    a11y.invoke(&ctx, &row).expect("native invoke off-screen");
+    let after = await_change(
+        "the off-screen row's click to register",
+        &before,
+        AWAIT_DEADLINE,
+        || counter(&mut a11y),
+    );
+    assert_ne!(after, before, "an off-screen row must actuate");
+    assert!(
+        after.contains("row=250"),
+        "the RIGHT row must actuate, got {after}"
+    );
+
+    // A disabled button errors, and says why.
+    let t = snap(&mut a11y);
+    let gated = target(by_desc(&t.root, "GatedBtn").expect("GatedBtn"));
+    let err = a11y
+        .invoke(&ctx, &gated)
+        .expect_err("a disabled button must not report success");
+    assert!(err.to_string().contains("disabled"), "{err}");
+    assert!(!err.invoke_fallback_eligible(), "must not fall back: {err}");
+
+    // A checkbox flips, and the flip is observed rather than assumed.
+    let t = snap(&mut a11y);
+    let box_node = by_desc(&t.root, "AgreeBox").expect("AgreeBox");
+    let was = box_node.states.checked;
+    let agree = target(box_node);
+    a11y.invoke(&ctx, &agree)
+        .expect("native invoke on a checkbox");
+    let t = snap(&mut a11y);
+    assert_ne!(
+        by_desc(&t.root, "AgreeBox")
+            .expect("AgreeBox")
+            .states
+            .checked,
+        was,
+        "the checkbox must actually toggle"
+    );
+
+    // Compose: the label is not the clickable node, so this exercises the climb.
+    p.start_app(&spec("InvokeComposeFixtureActivity"))
+        .expect("launch compose fixture");
+    std::thread::sleep(std::time::Duration::from_millis(1500));
+    let before = counter(&mut a11y);
+    let t = snap(&mut a11y);
+    let save = target(by_desc(&t.root, "Save").expect("Save label"));
+    a11y.invoke(&ctx, &save)
+        .expect("native invoke via the ancestor climb");
+    let after = await_change(
+        "the climb's click to reach a clickable node",
+        &before,
+        AWAIT_DEADLINE,
+        || counter(&mut a11y),
+    );
+    assert_ne!(after, before, "the climb must reach a clickable node");
+
+    reg.shutdown();
+    p.stop_app().ok();
+    drop(p);
 }

--- a/crates/glass-android/tests/a11y_service_loop.rs
+++ b/crates/glass-android/tests/a11y_service_loop.rs
@@ -255,7 +255,7 @@ fn native_invoke_actuates_the_fixture() {
     // The platform reports the app up before the Compose hierarchy has published its
     // accessibility tree, and the label's bounds keep moving while the activity animates in —
     // `invoke` fingerprints bounds, so waiting for the label to merely exist yields
-    // `AxElementChanged`. Wait for two reads to agree.
+    // `AxElementChanged`.
     let deadline = std::time::Instant::now() + AWAIT_DEADLINE;
     let mut settled = None;
     loop {

--- a/crates/glass-android/tests/a11y_service_loop.rs
+++ b/crates/glass-android/tests/a11y_service_loop.rs
@@ -200,8 +200,8 @@ fn native_invoke_actuates_the_fixture() {
     let t = snap(&mut a11y);
     let row_node = by_desc(&t.root, "Row250").expect("Row250");
     let b = row_node.bounds.expect("the row reports bounds");
-    // Prove the premise rather than trusting the fixture: if the list shrank or the screen grew,
-    // this leg would silently become a second copy of the one above and still pass.
+    // If the list shrank or the screen grew, this leg would silently become a second copy of
+    // the one above and still pass.
     let window_h = i32::try_from(ctx.window.height).expect("window height fits an i32");
     let row_h = i32::try_from(b.height).expect("row height fits an i32");
     assert!(
@@ -253,7 +253,7 @@ fn native_invoke_actuates_the_fixture() {
     p.start_app(&spec("InvokeComposeFixtureActivity"))
         .expect("launch compose fixture");
     // The platform reports the app up before the Compose hierarchy has published its
-    // accessibility tree, so poll for the label instead of sleeping on a guess.
+    // accessibility tree.
     let deadline = std::time::Instant::now() + AWAIT_DEADLINE;
     let t = loop {
         let t = snap(&mut a11y);

--- a/crates/glass-android/tests/a11y_service_loop.rs
+++ b/crates/glass-android/tests/a11y_service_loop.rs
@@ -253,20 +253,25 @@ fn native_invoke_actuates_the_fixture() {
     p.start_app(&spec("InvokeComposeFixtureActivity"))
         .expect("launch compose fixture");
     // The platform reports the app up before the Compose hierarchy has published its
-    // accessibility tree.
+    // accessibility tree, and the label's bounds keep moving while the activity animates in —
+    // `invoke` fingerprints bounds, so waiting for the label to merely exist yields
+    // `AxElementChanged`. Wait for two reads to agree.
     let deadline = std::time::Instant::now() + AWAIT_DEADLINE;
-    let t = loop {
-        let t = snap(&mut a11y);
-        if by_desc(&t.root, "Save").is_some() {
-            break t;
+    let mut settled = None;
+    loop {
+        let bounds = by_desc(&snap(&mut a11y).root, "Save").and_then(|n| n.bounds);
+        if bounds.is_some() && bounds == settled {
+            break;
         }
         assert!(
             std::time::Instant::now() < deadline,
-            "the compose fixture never published a Save label"
+            "the compose fixture never settled on a Save label"
         );
+        settled = bounds;
         std::thread::sleep(std::time::Duration::from_millis(150));
-    };
+    }
     let before = counter(&mut a11y);
+    let t = snap(&mut a11y);
     let save_label = by_desc(&t.root, "Save").expect("Save label");
     let actuated = a11y
         .invoke(&ctx, &target(save_label))

--- a/crates/glass-android/tests/a11y_service_loop.rs
+++ b/crates/glass-android/tests/a11y_service_loop.rs
@@ -1,7 +1,8 @@
-//! Live a11y-service round-trip. Ignored; run with a booted AVD + the built APK:
-//!   GLASS_ADB=$HOME/android-sdk/platform-tools/adb \
-//!   GLASS_ANDROID_A11Y_APK=$HOME/git-sources/fw/glass-android-agent/a11y/build/outputs/apk/debug/a11y-debug.apk \
-//!   GLASS_ANDROID_FIXTURE_APK=$HOME/git-sources/fw/glass-android-agent/fixture-compose/build/outputs/apk/debug/fixture-compose-debug.apk \
+//! Live a11y-service round-trip. Ignored; run with a booted AVD + the built APKs (both come from
+//! the glass-android-agent repo: `./gradlew :a11y:assembleDebug :fixture-compose:assembleDebug`):
+//!   GLASS_ADB=/path/to/platform-tools/adb \
+//!   GLASS_ANDROID_A11Y_APK=/path/to/a11y-debug.apk \
+//!   GLASS_ANDROID_FIXTURE_APK=/path/to/fixture-compose-debug.apk \
 //!     cargo test -p glass-android --test a11y_service_loop -- --ignored --nocapture
 
 use glass_android::{
@@ -85,11 +86,7 @@ fn a11y_service_snapshot_and_actions() {
     // and no forward (don't snapshot immediately — the unbind is async, ~1s; mirror the agent_loop leak check).
 }
 
-/// Native invoke against the fixture. Ignored; run with a booted AVD:
-///   GLASS_ADB=$HOME/android-sdk/platform-tools/adb \
-///   GLASS_ANDROID_A11Y_APK=.../a11y-debug.apk \
-///   GLASS_ANDROID_FIXTURE_APK=.../fixture-compose-debug.apk \
-///     cargo test -p glass-android --test a11y_service_loop -- --ignored --nocapture
+/// Native invoke against the fixture. Ignored; same environment as the test above.
 #[test]
 #[ignore = "requires a booted AVD + GLASS_ADB + GLASS_ANDROID_A11Y_APK + GLASS_ANDROID_FIXTURE_APK"]
 fn native_invoke_actuates_the_fixture() {
@@ -183,8 +180,7 @@ fn native_invoke_actuates_the_fixture() {
             std::thread::sleep(std::time::Duration::from_millis(150));
         }
     }
-    // Measured ~520-580ms on-device; generous is free since the poll returns as soon as the
-    // value changes.
+    // Generous is free: the poll returns as soon as the value changes.
     const AWAIT_DEADLINE: std::time::Duration = std::time::Duration::from_secs(5);
 
     // An enabled classic button actuates.
@@ -193,17 +189,27 @@ fn native_invoke_actuates_the_fixture() {
     let save = target(by_desc(&t.root, "SaveBtn").expect("SaveBtn"));
     a11y.invoke(&ctx, &save)
         .expect("native invoke on an enabled button");
-    let after = await_change(
+    await_change(
         "the enabled button's click to register",
         &before,
         AWAIT_DEADLINE,
         || counter(&mut a11y),
     );
-    assert_ne!(after, before, "the click must actuate");
 
     // A row far below the fold actuates — the case a pointer tap cannot serve.
     let t = snap(&mut a11y);
-    let row = target(by_desc(&t.root, "Row250").expect("Row250"));
+    let row_node = by_desc(&t.root, "Row250").expect("Row250");
+    let b = row_node.bounds.expect("the row reports bounds");
+    // Prove the premise rather than trusting the fixture: if the list shrank or the screen grew,
+    // this leg would silently become a second copy of the one above and still pass.
+    let window_h = i32::try_from(ctx.window.height).expect("window height fits an i32");
+    let row_h = i32::try_from(b.height).expect("row height fits an i32");
+    assert!(
+        b.y >= window_h || b.y + row_h <= 0,
+        "Row250 must lie outside the window for this leg to be about a control a tap cannot \
+         reach; bounds {b:?}, window height {window_h}"
+    );
+    let row = target(row_node);
     let before = counter(&mut a11y);
     a11y.invoke(&ctx, &row).expect("native invoke off-screen");
     let after = await_change(
@@ -212,7 +218,6 @@ fn native_invoke_actuates_the_fixture() {
         AWAIT_DEADLINE,
         || counter(&mut a11y),
     );
-    assert_ne!(after, before, "an off-screen row must actuate");
     assert!(
         after.contains("row=250"),
         "the RIGHT row must actuate, got {after}"
@@ -247,21 +252,42 @@ fn native_invoke_actuates_the_fixture() {
     // Compose: the label is not the clickable node, so this exercises the climb.
     p.start_app(&spec("InvokeComposeFixtureActivity"))
         .expect("launch compose fixture");
-    std::thread::sleep(std::time::Duration::from_millis(1500));
+    // The platform reports the app up before the Compose hierarchy has published its
+    // accessibility tree, so poll for the label instead of sleeping on a guess.
+    let deadline = std::time::Instant::now() + AWAIT_DEADLINE;
+    let t = loop {
+        let t = snap(&mut a11y);
+        if by_desc(&t.root, "Save").is_some() {
+            break t;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the compose fixture never published a Save label"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(150));
+    };
     let before = counter(&mut a11y);
-    let t = snap(&mut a11y);
-    let save = target(by_desc(&t.root, "Save").expect("Save label"));
-    a11y.invoke(&ctx, &save)
-        .expect("native invoke via the ancestor climb");
-    let after = await_change(
+    let save_label = by_desc(&t.root, "Save").expect("Save label");
+    let actuated = a11y
+        .invoke(&ctx, &target(save_label))
+        .expect("native invoke via the ancestor climb")
+        .expect("the climb actuated another node, and the result must name it");
+    assert_ne!(
+        actuated, save_label.id,
+        "the disclosed node is the one that handled the click, not the label asked for"
+    );
+    await_change(
         "the climb's click to reach a clickable node",
         &before,
         AWAIT_DEADLINE,
         || counter(&mut a11y),
     );
-    assert_ne!(after, before, "the climb must reach a clickable node");
 
     reg.shutdown();
     p.stop_app().ok();
     drop(p);
+    // The fixture is glass's to install and glass's to remove: leaving it installed lets device
+    // state accumulate across runs.
+    adb.run(["uninstall", "com.fixedwidth.glassfixture"]).ok();
+    agents.shutdown();
 }

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -773,6 +773,11 @@ pub trait Accessibility {
     /// (role+name, and bounds where its `set_value` does), then fires the
     /// action.
     ///
+    /// Returns the element the action actually fired on, when that is **not**
+    /// `target.id` — a backend whose toolkit carries a control's activation on an
+    /// ancestor of the node that carries its label actuates that ancestor, and the
+    /// caller reports the substitution. `None` means the target itself was actuated.
+    ///
     /// **Error contract.** The caller falls back to a synthetic pointer click for
     /// exactly two outcomes, both meaning *nothing was dispatched*:
     /// [`crate::GlassError::AxUnsupported`] (this backend has no invoke) and
@@ -787,7 +792,7 @@ pub trait Accessibility {
     /// coordinates too.
     ///
     /// Default: unsupported.
-    fn invoke(&mut self, _ctx: &AxContext, _target: &AxTarget) -> Result<()> {
+    fn invoke(&mut self, _ctx: &AxContext, _target: &AxTarget) -> Result<Option<AxNodeId>> {
         Err(crate::error::GlassError::AxUnsupported)
     }
 }
@@ -796,7 +801,9 @@ pub trait Accessibility {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ClickMethod {
     /// The platform's native accessibility action fired; no pointer was synthesized.
-    NativeAction,
+    /// `actuated` names the element the action fired on when it is not the one the
+    /// caller asked for, and is `None` when they are the same element.
+    NativeAction { actuated: Option<AxNodeId> },
     /// The synthetic pointer path ran; `native_fallback` says why the native
     /// action was not used (there is always a reason — invoke is attempted first).
     Pointer { native_fallback: String },
@@ -806,7 +813,7 @@ impl ClickMethod {
     /// Stable label for result payloads and the audit log.
     pub fn label(&self) -> &'static str {
         match self {
-            ClickMethod::NativeAction => "native-action",
+            ClickMethod::NativeAction { .. } => "native-action",
             ClickMethod::Pointer { .. } => "pointer",
         }
     }
@@ -814,8 +821,17 @@ impl ClickMethod {
     /// The fallback reason, when the pointer path ran.
     pub fn native_fallback(&self) -> Option<&str> {
         match self {
-            ClickMethod::NativeAction => None,
+            ClickMethod::NativeAction { .. } => None,
             ClickMethod::Pointer { native_fallback } => Some(native_fallback),
+        }
+    }
+
+    /// The element actuated in the caller's place, when the backend resolved the click
+    /// onto a different one. `None` when the element asked for is the element clicked.
+    pub fn actuated(&self) -> Option<AxNodeId> {
+        match self {
+            ClickMethod::NativeAction { actuated } => *actuated,
+            ClickMethod::Pointer { .. } => None,
         }
     }
 }
@@ -2383,13 +2399,28 @@ mod tests {
 
     #[test]
     fn click_method_labels_and_fallback_access() {
-        assert_eq!(ClickMethod::NativeAction.label(), "native-action");
-        assert_eq!(ClickMethod::NativeAction.native_fallback(), None);
+        let n = ClickMethod::NativeAction { actuated: None };
+        assert_eq!(n.label(), "native-action");
+        assert_eq!(n.native_fallback(), None);
+        assert_eq!(n.actuated(), None);
         let p = ClickMethod::Pointer {
             native_fallback: "reason".into(),
         };
         assert_eq!(p.label(), "pointer");
         assert_eq!(p.native_fallback(), Some("reason"));
+        assert_eq!(p.actuated(), None);
+    }
+
+    #[test]
+    fn a_native_action_on_a_substituted_element_reports_which_one() {
+        // The caller named #4 and the backend actuated the control enclosing it. Reporting
+        // only "native-action" would leave "I clicked the label" and "I clicked the row
+        // around it, which navigated away" indistinguishable afterwards.
+        let m = ClickMethod::NativeAction {
+            actuated: Some(AxNodeId(2)),
+        };
+        assert_eq!(m.actuated(), Some(AxNodeId(2)));
+        assert_eq!(m.label(), "native-action");
     }
 
     #[test]

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -166,7 +166,7 @@ impl Glass {
         // propagates, because clicking on top of a native action that may still land would
         // actuate the control twice while the result claimed only "pointer" ran.
         let native_fallback = match self.try_native_invoke(id) {
-            Ok(()) => return Ok(ClickMethod::NativeAction),
+            Ok(actuated) => return Ok(ClickMethod::NativeAction { actuated }),
             Err(e) if !e.invoke_fallback_eligible() => return Err(e),
             Err(e) => native_fallback_reason(&e),
         };
@@ -272,8 +272,8 @@ impl Glass {
 
     /// One native-invoke attempt: the same fingerprint + context assembly as
     /// `set_value_inner` (over freshly re-read window geometry — see below), then the
-    /// backend's `invoke`.
-    fn try_native_invoke(&mut self, id: AxNodeId) -> Result<()> {
+    /// backend's `invoke`. Passes on the element the backend actuated when it is not `id`.
+    fn try_native_invoke(&mut self, id: AxNodeId) -> Result<Option<AxNodeId>> {
         {
             let s = self.active_mut()?;
             // Reader-presence check up front (mirrors `snapshot_at_current_limits`) so
@@ -317,12 +317,13 @@ impl Glass {
             (target, ctx)
         };
         let s = self.active_mut()?;
-        s.accessibility
+        let actuated = s
+            .accessibility
             .as_mut()
             .ok_or(GlassError::AxUnsupported)?
             .invoke(&ctx, &target)?;
         s.pump();
-        Ok(())
+        Ok(actuated)
     }
 
     /// Set the value/text of element `id` (from the latest `a11y_snapshot`) via the
@@ -1595,7 +1596,7 @@ mod tests {
 
         assert_eq!(
             g.click_element(AxNodeId(1)).unwrap(),
-            ClickMethod::NativeAction
+            ClickMethod::NativeAction { actuated: None }
         );
 
         assert_eq!(invoke_log.lock().unwrap().len(), 1, "the native path ran");
@@ -1676,7 +1677,7 @@ mod tests {
         g.start(&spec()).unwrap();
         g.a11y_snapshot(None).unwrap();
         let method = g.click_element(AxNodeId(1)).unwrap();
-        assert_eq!(method, ClickMethod::NativeAction);
+        assert_eq!(method, ClickMethod::NativeAction { actuated: None });
         assert!(
             clicks.lock().unwrap().is_empty(),
             "no pointer event on the native path"
@@ -1689,6 +1690,26 @@ mod tests {
         assert!(
             log[0].bounds.is_some(),
             "fingerprint carries the snapshot bounds"
+        );
+    }
+
+    #[test]
+    fn click_element_carries_the_element_the_backend_actuated_instead() {
+        // A backend whose toolkit carries the activation on an ancestor of the label clicks
+        // that ancestor. The method has to say so, or the click and its audit record read as
+        // if the caller's own element was the one that fired.
+        let (mut g, _) = glass_with_a11y_invoke(
+            FakePlatform::new(100, 100),
+            fake_tree(),
+            InvokeBehavior::SucceedOnAnother(9),
+        );
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot(None).unwrap();
+        assert_eq!(
+            g.click_element(AxNodeId(1)).unwrap(),
+            ClickMethod::NativeAction {
+                actuated: Some(AxNodeId(9))
+            }
         );
     }
 
@@ -1788,7 +1809,7 @@ mod tests {
         g.a11y_snapshot(None).unwrap();
         assert_eq!(
             g.click_element(AxNodeId(2)).unwrap(),
-            ClickMethod::NativeAction
+            ClickMethod::NativeAction { actuated: None }
         );
     }
 
@@ -2251,7 +2272,7 @@ mod tests {
 
         assert_eq!(
             g.click_element(globex_id).unwrap(),
-            ClickMethod::NativeAction
+            ClickMethod::NativeAction { actuated: None }
         );
 
         assert_eq!(invoke_log.lock().unwrap().len(), 1, "the native path ran");

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -295,6 +295,9 @@ pub(crate) enum InvokeBehavior {
     Unsupported,
     /// Native action fires and reports success.
     Succeed,
+    /// Native action fires on a different element than the one named — the shape of a
+    /// backend whose toolkit carries a control's activation on an ancestor of its label.
+    SucceedOnAnother(u32),
     /// Element exposes no activation action.
     NoAction,
     /// Action fired but the toolkit reported failure.
@@ -309,12 +312,16 @@ fn scripted_invoke(
     behavior: InvokeBehavior,
     log: &Arc<Mutex<Vec<AxTarget>>>,
     target: &AxTarget,
-) -> Result<()> {
+) -> Result<Option<AxNodeId>> {
     match behavior {
         InvokeBehavior::Unsupported => Err(GlassError::AxUnsupported),
         InvokeBehavior::Succeed => {
             log.lock().unwrap().push(target.clone());
-            Ok(())
+            Ok(None)
+        }
+        InvokeBehavior::SucceedOnAnother(actuated) => {
+            log.lock().unwrap().push(target.clone());
+            Ok(Some(AxNodeId(actuated)))
         }
         InvokeBehavior::NoAction => Err(GlassError::AxActionUnavailable(target.id.0)),
         InvokeBehavior::Fail => Err(GlassError::AxActionFailed(
@@ -361,7 +368,7 @@ impl Accessibility for FakeAccessibility {
             .push((target.clone(), text.to_string()));
         Ok(())
     }
-    fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<()> {
+    fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<Option<AxNodeId>> {
         *self.ctx_log.lock().unwrap() = Some(ctx.clone());
         scripted_invoke(self.invoke_behavior, &self.invoke_log, target)
     }
@@ -577,7 +584,7 @@ impl Accessibility for SeqAccessibility {
     fn set_value(&mut self, _ctx: &AxContext, _t: &AxTarget, _s: &str) -> Result<()> {
         Ok(())
     }
-    fn invoke(&mut self, _ctx: &AxContext, target: &AxTarget) -> Result<()> {
+    fn invoke(&mut self, _ctx: &AxContext, target: &AxTarget) -> Result<Option<AxNodeId>> {
         scripted_invoke(self.invoke_behavior, &self.invoke_log, target)
     }
 }

--- a/crates/glass-mcp/src/audit.rs
+++ b/crates/glass-mcp/src/audit.rs
@@ -208,9 +208,8 @@ fn describe(act: &Actuation) -> Option<(&'static str, Value, Option<String>)> {
                     if let Some(reason) = m.native_fallback() {
                         args["native_fallback"] = json!(reason);
                     }
-                    // Which object was actuated, when it is not the one the caller named:
-                    // "clicked the Save label" and "clicked the card around it, which
-                    // navigated away" are otherwise indistinguishable in the record.
+                    // Without this, "clicked the Save label" and "clicked the card around it,
+                    // which navigated away" are indistinguishable in the record.
                     if let Some(actuated) = m.actuated() {
                         args["actuated_id"] = json!(actuated.0);
                     }

--- a/crates/glass-mcp/src/audit.rs
+++ b/crates/glass-mcp/src/audit.rs
@@ -208,6 +208,12 @@ fn describe(act: &Actuation) -> Option<(&'static str, Value, Option<String>)> {
                     if let Some(reason) = m.native_fallback() {
                         args["native_fallback"] = json!(reason);
                     }
+                    // Which object was actuated, when it is not the one the caller named:
+                    // "clicked the Save label" and "clicked the card around it, which
+                    // navigated away" are otherwise indistinguishable in the record.
+                    if let Some(actuated) = m.actuated() {
+                        args["actuated_id"] = json!(actuated.0);
+                    }
                     args
                 }
                 None => json!({}),
@@ -684,7 +690,7 @@ mod tests {
     fn click_element_native_action_records_no_fallback_reason() {
         let buf = Arc::new(Mutex::new(Vec::new()));
         let s = JsonlSink::with_writer(Box::new(Buf(buf.clone())), AuditConfig::default());
-        let method = ClickMethod::NativeAction;
+        let method = ClickMethod::NativeAction { actuated: None };
         s.record(
             &Actuation::ClickElement {
                 element: click_el(),
@@ -700,6 +706,27 @@ mod tests {
             r["args"].get("native_fallback").is_none(),
             "nothing fell back: {r}"
         );
+    }
+
+    #[test]
+    fn click_element_records_the_element_actuated_in_the_targets_place() {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let s = JsonlSink::with_writer(Box::new(Buf(buf.clone())), AuditConfig::default());
+        let method = ClickMethod::NativeAction {
+            actuated: Some(glass_core::AxNodeId(7)),
+        };
+        s.record(
+            &Actuation::ClickElement {
+                element: click_el(),
+                method: Some(&method),
+            },
+            &ActuationContext::default(),
+            &ok(),
+            Duration::from_millis(1),
+        );
+        let r = &lines(&buf)[0];
+        assert_eq!(r["args"]["actuated_id"], 7, "{r}");
+        assert_eq!(r["target"]["element"]["id"], click_el().id, "{r}");
     }
 
     #[test]

--- a/crates/glass-mcp/src/params.rs
+++ b/crates/glass-mcp/src/params.rs
@@ -140,7 +140,9 @@ pub struct ClickElementArgs {
     /// one (works even when the element is occluded or scrolled off-screen), falling
     /// back to a synthetic pointer click at the element's center; the result's
     /// `method` field says which path ran, and `native_fallback` says why when the
-    /// pointer path was used.
+    /// pointer path was used. Where a control's label is a separate element from the
+    /// control itself, the native action fires on the enclosing control and the
+    /// result carries `actuated_id` — the element actually clicked.
     pub id: u32,
     /// Optional observe folded into the result: "snapshot" (wait for the UI to settle, then
     /// fold a fresh a11y tree, also refreshing the snapshot cache), "settle" (wait for the UI

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -439,8 +439,10 @@ impl GlassServer {
                        platform's native accessibility action when the element exposes one — \
                        works even when it's occluded or scrolled off-screen — else falls back \
                        to a synthetic pointer click at the center of its bounds; the result's \
-                       `method` field says which path ran, and `native_fallback` says why when \
-                       the pointer path was used). If the element actually \
+                       `method` field says which path ran, `native_fallback` says why when \
+                       the pointer path was used, and `actuated_id` names the element actually \
+                       clicked when a control's label is a separate element from the control \
+                       itself). If the element actually \
                        renders in a popover owned by a different window than the active one \
                        (e.g. an open dropdown's option row), the click is automatically routed \
                        into that popover window and the previously-active window is restored \

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -403,6 +403,9 @@ pub fn click_element(glass: &mut Glass, a: &ClickElementArgs) -> ToolResult {
     if let Some(reason) = method.native_fallback() {
         result["native_fallback"] = serde_json::json!(reason);
     }
+    if let Some(actuated) = method.actuated() {
+        result["actuated_id"] = serde_json::json!(actuated.0);
+    }
     if let Some(o) = observed {
         result["observed"] = o;
     }
@@ -688,6 +691,8 @@ pub(crate) mod testutil {
         #[default]
         Unsupported,
         Ok,
+        /// The native action fired on a different element than the one named.
+        OkOnAnother(u32),
     }
 
     pub struct FakeAccessibility {
@@ -715,10 +720,11 @@ pub(crate) mod testutil {
                 .push((target.clone(), text.to_string()));
             Ok(())
         }
-        fn invoke(&mut self, _ctx: &AxContext, _target: &AxTarget) -> Result<()> {
+        fn invoke(&mut self, _ctx: &AxContext, _target: &AxTarget) -> Result<Option<AxNodeId>> {
             match self.invoke_outcome {
                 InvokeOutcome::Unsupported => Err(GlassError::AxUnsupported),
-                InvokeOutcome::Ok => Ok(()),
+                InvokeOutcome::Ok => Ok(None),
+                InvokeOutcome::OkOnAnother(id) => Ok(Some(AxNodeId(id))),
             }
         }
     }
@@ -818,6 +824,21 @@ pub(crate) mod testutil {
     /// `click_element`'s native-action path (no pointer event, no fallback disclosed).
     pub fn glass_with_a11y_invoke_ok(platform: FakePlatform, tree: AxTree) -> Glass {
         glass_with_a11y_full(platform, tree, SetOutcome::Ok, InvokeOutcome::Ok)
+    }
+
+    /// [`glass_with_a11y_invoke_ok`] for a backend that actuates element `actuated` when
+    /// asked for another one.
+    pub fn glass_with_a11y_invoke_on_another(
+        platform: FakePlatform,
+        tree: AxTree,
+        actuated: u32,
+    ) -> Glass {
+        glass_with_a11y_full(
+            platform,
+            tree,
+            SetOutcome::Ok,
+            InvokeOutcome::OkOnAnother(actuated),
+        )
     }
 
     fn glass_with_a11y_full(
@@ -1586,6 +1607,67 @@ mod tests {
         assert!(
             v.get("native_fallback").is_none(),
             "no fallback key on the native-action path: {v}"
+        );
+    }
+
+    #[test]
+    fn click_element_names_the_element_it_actuated_instead() {
+        // The backend resolved the click onto a different element. Without this key the
+        // result cannot distinguish "clicked the label" from "clicked the row around it".
+        let mut g = glass_with_a11y_invoke_on_another(FakePlatform::new(100, 100), fake_tree(), 7);
+        g.start(&AppSpec {
+            build: None,
+            run: vec!["x".into()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 1,
+            sandbox: SandboxLevel::Off,
+            a11y: false,
+        })
+        .unwrap();
+        a11y_snapshot(&mut g, &A11ySnapshotArgs { max_nodes: None }).unwrap();
+        let out = click_element(
+            &mut g,
+            &ClickElementArgs {
+                id: 1,
+                return_: None,
+            },
+        )
+        .unwrap();
+        let v = assert_envelope(&out, "glass_click_element");
+        assert_eq!(v["method"], json!("native-action"), "envelope: {v}");
+        assert_eq!(v["id"], json!(1), "envelope: {v}");
+        assert_eq!(v["actuated_id"], json!(7), "envelope: {v}");
+    }
+
+    #[test]
+    fn click_element_omits_actuated_id_when_the_target_itself_was_clicked() {
+        let mut g = glass_with_a11y_invoke_ok(FakePlatform::new(100, 100), fake_tree());
+        g.start(&AppSpec {
+            build: None,
+            run: vec!["x".into()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 1,
+            sandbox: SandboxLevel::Off,
+            a11y: false,
+        })
+        .unwrap();
+        a11y_snapshot(&mut g, &A11ySnapshotArgs { max_nodes: None }).unwrap();
+        let out = click_element(
+            &mut g,
+            &ClickElementArgs {
+                id: 1,
+                return_: None,
+            },
+        )
+        .unwrap();
+        let v = assert_envelope(&out, "glass_click_element");
+        assert!(
+            v.get("actuated_id").is_none(),
+            "nothing was substituted: {v}"
         );
     }
 

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -503,7 +503,7 @@ fn onbox_a11y_snapshot_and_click() {
     let method = glass.click_element(id).expect("click element by id");
     assert_eq!(
         method,
-        glass_core::ClickMethod::NativeAction,
+        glass_core::ClickMethod::NativeAction { actuated: None },
         "a Win32 Button publishes UIA InvokePattern; click_element must take the native path"
     );
     std::thread::sleep(Duration::from_millis(700));
@@ -547,7 +547,7 @@ fn onbox_a11y_native_toggle_checkbox() {
     let method = glass.click_element(id).expect("click element by id");
     assert_eq!(
         method,
-        glass_core::ClickMethod::NativeAction,
+        glass_core::ClickMethod::NativeAction { actuated: None },
         "charmap's Advanced-view checkbox publishes only UIA TogglePattern; click_element must \
          take the native path"
     );
@@ -1574,7 +1574,11 @@ impl<A: Accessibility> Accessibility for Counting<A> {
     ) -> glass_core::Result<()> {
         self.inner.set_value(ctx, target, text)
     }
-    fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> glass_core::Result<()> {
+    fn invoke(
+        &mut self,
+        ctx: &AxContext,
+        target: &AxTarget,
+    ) -> glass_core::Result<Option<glass_core::AxNodeId>> {
         self.inner.invoke(ctx, target)
     }
 }

--- a/docs/how-to/setup-android.md
+++ b/docs/how-to/setup-android.md
@@ -97,9 +97,18 @@ and sets editable fields via the real `ACTION_SET_TEXT`; glass enables it and re
 prior accessibility state on teardown. Without `glass-a11y.apk`, glass uses the `uiautomator` reader.
 Set `GLASS_ANDROID_A11Y=off` to force `uiautomator` even when the APK is present.
 
-The service backs the **accessibility tree + `glass_set_value`**. Element *clicks* stay coordinate taps
-(precise, using the service's bounds) — Android's `ACTION_CLICK` is unreliable on Compose, so glass
-doesn't route clicks through it.
+The service also backs **`glass_click_element`**, which actuates through Android's `ACTION_CLICK`
+instead of tapping the element's centre. That reaches a control scrolled far below the fold or
+covered by something else, and it makes two outcomes honest that a tap cannot:
+
+- Clicking a **disabled** control is an error, not a tap that silently does nothing.
+- A **checkbox or switch** is only reported clicked once its state is read back changed; a radio
+  button or tab that was already selected counts as clicked, since re-selecting it is a no-op.
+
+Where a control's label is a separate element from the control itself — the usual Jetpack Compose
+shape — the action fires on the enclosing control that handles the tap, and the result names it in
+`actuated_id`. Without `glass-a11y.apk` (or with `GLASS_ANDROID_A11Y=off`) clicks stay coordinate
+taps via the `uiautomator` reader.
 
 ### Other locations, and building from source
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -533,15 +533,19 @@ follow as siblings (the legend untrusted-wrapped), per the image ordering above.
 
 ### `glass_click_element`
 
-Click an element by its `#id` (clicks the center of its bounds, via the normal click path).
+Click an element by its `#id`. Tries the platform's native accessibility action first, falling back
+to a synthetic pointer click at the center of the element's bounds.
 
 - `id` (integer, **required**) — the `#id` from the latest snapshot.
 - `return` (string) — `"snapshot"` appends a fresh a11y outline as an untrusted sibling block (and
   refreshes the id cache), `"settle"` folds settle metadata into `result.observed`, or `"none"`
   (default) adds nothing.
 
-Returns `{id}` — the `#id` you clicked — plus `observed: {settled, saw_motion, observed_ms}` when
-`return:"settle"`.
+Returns `{id, method}` — the `#id` you clicked and which path ran (`native-action`/`pointer`) —
+plus `native_fallback` (why the pointer path was used) when it was, `actuated_id` when the native
+action fired on a different element than the one you named (a control whose label is a separate
+element, as in Jetpack Compose, resolves to the enclosing control), and
+`observed: {settled, saw_motion, observed_ms}` when `return:"settle"`.
 
 ### `glass_set_value`
 


### PR DESCRIPTION
`glass_click_element` on Android now actuates through the accessibility service's native `ACTION_CLICK` instead of always synthesizing a pointer tap, when the optional on-device accessibility companion is installed. The `uiautomator` reader and iOS keep the pointer path and disclose that they did.

## What it buys

A control a tap cannot reach now actuates in place — the device test clicks row 250 of 300, far below the fold. Clicks no longer depend on the element being visible or unoccluded.

## Behaviour changes

- **Clicking a disabled control is now an error** rather than a tap that silently does nothing.
- **A checkable control is only reported clicked once its state is observed to change**, not when the device acknowledges the action. Controls that toggle must move; radio buttons and tabs must end selected, so re-clicking a selected one still succeeds.
- **The result names the element actually actuated** when it differs from the one selected. Where a control's label is a separate element from the control itself, as in Jetpack Compose, resolution climbs to the enclosing control that would have handled a tap — `actuated_id` says so, in the result and the audit record.

## Verification

Workspace suite 1770 passing. On-device suite run against an emulator with the companion installed, via the command in its own doc comment.

The host-side tests were written to fail when the behaviour they name is deleted: each was checked red before green, including the four cases where deleting the disabled guard, the state read-back, the resolved-node id, or the read-back predicate previously left the whole suite green.

## Companion

Needs fixed-width/glass-android-agent#8 for the test fixture. No accessibility-service or protocol change, so no companion release and no reinstall.

## Follow-ups filed

#286, #287, #288, #289, #290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)