### PR TITLE
fix(macos): name what adoption chose, and what select_window rejected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -367,6 +367,9 @@ internal refactors, CI, or test-only changes.
   an internal size limit was returned as though it were complete, so a missing element was
   indistinguishable from one that does not exist. All backends now share the same limits and
   disclose when one is reached.
+- macOS: `select_window`'s no-match diagnostic now names each candidate's `AXRole` and the raw
+  `AXError` behind a failed read, and window adoption records which window it took out of what.
+  `WindowNotFound` no longer asserts a timing cause it cannot know.
 
 ## [1.1.0] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -367,9 +367,10 @@ internal refactors, CI, or test-only changes.
   an internal size limit was returned as though it were complete, so a missing element was
   indistinguishable from one that does not exist. All backends now share the same limits and
   disclose when one is reached.
-- macOS: `select_window`'s no-match diagnostic now names each candidate's `AXRole` and the raw
-  `AXError` behind a failed read, and window adoption records which window it took out of what.
-  `WindowNotFound` no longer asserts a timing cause it cannot know.
+- macOS: when the accessibility tree can't resolve the window glass adopted, the diagnostic
+  it prints now names each candidate's `AXRole` and the raw `AXError` behind a failed read, and
+  window adoption itself now records which on-screen window it took out of what else was
+  available. `WindowNotFound` no longer asserts a timing cause it cannot know.
 
 ## [1.1.0] - 2026-07-23
 

--- a/crates/glass-a11y-macos/src/lib.rs
+++ b/crates/glass-a11y-macos/src/lib.rs
@@ -2,7 +2,7 @@
 
 // FFI backend: the AXUIElement reader needs `unsafe`, so this crate opts out of the workspace
 // `unsafe_code = "deny"`; each site carries a `// SAFETY:` note (see CLAUDE.md). The pure
-// `mapping` module stays `unsafe`-free by convention.
+// modules (`doctor`, `mapping`, `select_diagnostic`) stay `unsafe`-free by convention.
 #![allow(unsafe_code)]
 
 pub mod doctor; // pure probe->Check mapping (cross-platform) + the macOS-only AX probe
@@ -11,7 +11,7 @@ pub mod select_diagnostic; // pure select_window candidate-line rendering — cr
 
 // The cfg(macos) AXUIElement reader: `ffi` holds every `unsafe` AX read primitive, `reader`
 // the `unsafe`-free root selection + pre-order walk behind glass-core's `Accessibility`
-// seam. Both are gated off non-macOS, where only the pure `mapping` module above compiles.
+// seam. Both are gated off non-macOS, where only the pure modules above compile.
 #[cfg(target_os = "macos")]
 mod ffi;
 #[cfg(target_os = "macos")]

--- a/crates/glass-a11y-macos/src/lib.rs
+++ b/crates/glass-a11y-macos/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod doctor; // pure probe->Check mapping (cross-platform) + the macOS-only AX probe
 pub mod mapping; // pure AX->normalized mapping — cross-platform, unit-tested on any host
+pub mod select_diagnostic; // pure select_window candidate-line rendering — cross-platform, unit-tested on any host
 
 // The cfg(macos) AXUIElement reader: `ffi` holds every `unsafe` AX read primitive, `reader`
 // the `unsafe`-free root selection + pre-order walk behind glass-core's `Accessibility`

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -27,6 +27,7 @@ use objc2_core_foundation::CFRetained;
 
 use crate::ffi::{self, attr};
 use crate::mapping::{self, AxStateFacts};
+use crate::select_diagnostic::{CandidateOutcome, candidate_line};
 
 /// Per-axis pixel tolerance when matching an `AXWindow`'s origin against the backend's
 /// reported window origin. Same basis as `axwindow.rs`'s geometry-match fallback. Sized for
@@ -236,7 +237,10 @@ fn resolve_window(ctx: &AxContext) -> Result<(CFRetained<AXUIElement>, f64)> {
 /// [`POSITION_TOLERANCE_PX`] of `win`'s origin AND its height is consistent with that scale
 /// (within [`HEIGHT_CONSISTENCY_SLACK_PX`]). Among candidates, the closest origin wins.
 /// `None` when nothing matches (fail closed); logs each candidate's geometry to stderr in
-/// that case so a `WindowNotFound` is diagnosable without re-instrumenting.
+/// that case so a `WindowNotFound` is diagnosable without re-instrumenting — each line also
+/// carries the candidate's role and the `AXError` behind any failed read ([`candidate_line`]),
+/// so a withheld tree (e.g. a locked screen handing back an `AXApplication`) is distinguishable
+/// from a genuine geometry mismatch.
 fn select_window(
     windows: &[CFRetained<AXUIElement>],
     win: &WindowGeometry,
@@ -244,35 +248,68 @@ fn select_window(
     let mut best: Option<(i64, CFRetained<AXUIElement>, f64)> = None;
     let mut diagnostics: Vec<String> = Vec::new();
     for w in windows {
-        let Ok((ax_w, ax_h)) = ffi::ax_size(w) else {
-            diagnostics.push("<AXSize unreadable>".into());
-            continue;
+        // Read first, so a candidate that fails every subsequent read still names what it is:
+        // a withheld tree hands back an `AXApplication` where a window belongs, and that fact
+        // is what identifies the condition (#263).
+        let role = ffi::attribute_string(w, attr::ROLE);
+        let role = role.as_deref();
+        let (ax_w, ax_h) = match ffi::ax_size(w) {
+            Ok(size) => size,
+            Err(e) => {
+                diagnostics.push(candidate_line(
+                    role,
+                    &CandidateOutcome::SizeUnreadable(e.to_string()),
+                ));
+                continue;
+            }
         };
         if ax_w <= 0.0 || ax_h <= 0.0 {
-            diagnostics.push(format!("ax_w={ax_w} ax_h={ax_h} <non-positive size>"));
+            diagnostics.push(candidate_line(
+                role,
+                &CandidateOutcome::NonPositiveSize { ax_w, ax_h },
+            ));
             continue;
         }
         // macOS backing scale is always an integer; snap out the border/content-vs-frame
         // inset noise in the raw width ratio (see doc comment above).
         let scale = (win.width as f64 / ax_w).round().max(1.0);
         if !scale.is_finite() || scale <= 0.0 {
-            diagnostics.push(format!(
-                "ax_w={ax_w} ax_h={ax_h} scale={scale} <invalid scale>"
+            diagnostics.push(candidate_line(
+                role,
+                &CandidateOutcome::InvalidScale { ax_w, ax_h, scale },
             ));
             continue;
         }
-        let Ok((ax_x, ax_y)) = ffi::ax_position(w) else {
-            diagnostics.push(format!(
-                "ax_w={ax_w} ax_h={ax_h} scale={scale} <AXPosition unreadable>"
-            ));
-            continue;
+        let (ax_x, ax_y) = match ffi::ax_position(w) {
+            Ok(pos) => pos,
+            Err(e) => {
+                diagnostics.push(candidate_line(
+                    role,
+                    &CandidateOutcome::PositionUnreadable {
+                        ax_w,
+                        ax_h,
+                        scale,
+                        error: e.to_string(),
+                    },
+                ));
+                continue;
+            }
         };
         // Cast to `i64` before subtracting so `.abs()` can never wrap (`i32::MIN.abs()`
         // panics) — the same no-overflow discipline `axwindow::within_tolerance` follows.
         let dx = ((ax_x * scale).round() as i64 - i64::from(win.x)).abs();
         let dy = ((ax_y * scale).round() as i64 - i64::from(win.y)).abs();
-        diagnostics.push(format!(
-            "ax=({ax_x}, {ax_y}, {ax_w}, {ax_h}) scale={scale} dx={dx} dy={dy}"
+        diagnostics.push(candidate_line(
+            role,
+            &CandidateOutcome::Measured {
+                ax_x,
+                ax_y,
+                ax_w,
+                ax_h,
+                scale,
+                dx,
+                dy,
+            },
         ));
         if dx > POSITION_TOLERANCE_PX || dy > POSITION_TOLERANCE_PX {
             continue;

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -248,9 +248,8 @@ fn select_window(
     let mut best: Option<(i64, CFRetained<AXUIElement>, f64)> = None;
     let mut diagnostics: Vec<String> = Vec::new();
     for w in windows {
-        // Read first, so a candidate that fails every subsequent read still names what it is:
-        // a withheld tree hands back an `AXApplication` where a window belongs, and that fact
-        // is what identifies the condition (#263).
+        // Read first, so a candidate that fails every subsequent read still names what it is
+        // (#263) — see the doc comment above for why that matters.
         let role = ffi::attribute_string(w, attr::ROLE);
         let role = role.as_deref();
         let (ax_w, ax_h) = match ffi::ax_size(w) {

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -330,7 +330,7 @@ fn select_window(
         // exactly how close (or not) each candidate came.
         eprintln!(
             "glass-a11y-macos: select_window found no match for ctx.window={win:?}; candidates: [{}]",
-            diagnostics.join(", ")
+            diagnostics.join("; ")
         );
     }
     best.map(|(_, w, scale)| (w, scale))

--- a/crates/glass-a11y-macos/src/select_diagnostic.rs
+++ b/crates/glass-a11y-macos/src/select_diagnostic.rs
@@ -6,15 +6,19 @@
 //!
 //! The fields are chosen from what a real failure needed and did not have (#263): the
 //! candidate's role, because a withheld tree hands back an `AXApplication` where a window
-//! belongs, and the raw `AXError` behind a failed read, because -25205 names that condition in
-//! one line.
+//! belongs, and the raw `AXError` behind a failed read, which names a genuine AX failure in one
+//! line. `ffi::copy_attribute` classifies `kAXErrorAttributeUnsupported`/`kAXErrorNoValue` as an
+//! absent attribute rather than a failure, so the 2026-07-29 incident's actual code (-25205)
+//! never reaches a diagnostic line — that case is identified by role alone (see
+//! `SizeUnreadable`'s test below).
 
 /// What reading one `AXWindow` candidate produced — one variant per point at which
 /// `select_window` gives up on a candidate, plus the fully-measured case.
 #[derive(Clone, Debug, PartialEq)]
 pub enum CandidateOutcome {
-    /// `AXSize` could not be read. Carries the error's own text, which names the `AXError`
-    /// code (see `ffi::ax_err`).
+    /// `AXSize` could not be read. Carries the error's own text — the `AXError` code for a
+    /// genuine failure (see `ffi::ax_err`), or "attribute not present" with no code for the
+    /// absent-attribute case `ffi::copy_attribute` intercepts before `ax_err` runs.
     SizeUnreadable(String),
     /// `AXSize` read back a zero or negative dimension.
     NonPositiveSize { ax_w: f64, ax_h: f64 },
@@ -41,18 +45,17 @@ pub enum CandidateOutcome {
 }
 
 /// One candidate's diagnostic line. `role` is the candidate's `AXRole`, rendered `?` when it
-/// could not be read — never omitted, so every line has the same leading field to grep for.
+/// could not be read — never omitted, so every line has the same leading field to grep for
+/// (structurally: every arm below builds `detail` only, and `role={role}` is prepended once).
 pub fn candidate_line(role: Option<&str>, outcome: &CandidateOutcome) -> String {
     let role = role.unwrap_or("?");
-    match outcome {
-        CandidateOutcome::SizeUnreadable(error) => {
-            format!("role={role} <AXSize unreadable: {error}>")
-        }
+    let detail = match outcome {
+        CandidateOutcome::SizeUnreadable(error) => format!("<AXSize unreadable: {error}>"),
         CandidateOutcome::NonPositiveSize { ax_w, ax_h } => {
-            format!("role={role} ax_w={ax_w} ax_h={ax_h} <non-positive size>")
+            format!("ax_w={ax_w} ax_h={ax_h} <non-positive size>")
         }
         CandidateOutcome::InvalidScale { ax_w, ax_h, scale } => {
-            format!("role={role} ax_w={ax_w} ax_h={ax_h} scale={scale} <invalid scale>")
+            format!("ax_w={ax_w} ax_h={ax_h} scale={scale} <invalid scale>")
         }
         CandidateOutcome::PositionUnreadable {
             ax_w,
@@ -60,9 +63,7 @@ pub fn candidate_line(role: Option<&str>, outcome: &CandidateOutcome) -> String 
             scale,
             error,
         } => {
-            format!(
-                "role={role} ax_w={ax_w} ax_h={ax_h} scale={scale} <AXPosition unreadable: {error}>"
-            )
+            format!("ax_w={ax_w} ax_h={ax_h} scale={scale} <AXPosition unreadable: {error}>")
         }
         CandidateOutcome::Measured {
             ax_x,
@@ -73,9 +74,10 @@ pub fn candidate_line(role: Option<&str>, outcome: &CandidateOutcome) -> String 
             dx,
             dy,
         } => {
-            format!("role={role} ax=({ax_x}, {ax_y}, {ax_w}, {ax_h}) scale={scale} dx={dx} dy={dy}")
+            format!("ax=({ax_x}, {ax_y}, {ax_w}, {ax_h}) scale={scale} dx={dx} dy={dy}")
         }
-    }
+    };
+    format!("role={role} {detail}")
 }
 
 #[cfg(test)]
@@ -84,20 +86,19 @@ mod tests {
 
     /// The line that cost an hour on 2026-07-29: a locked screen hands back the *application*
     /// element where a window belongs, and `AXSize` fails `kAXErrorAttributeUnsupported`
-    /// (-25205). The error text here is the raw string `select_window` builds from
-    /// `ffi::ax_err`; in production it arrives via `GlassError::Backend`'s `Display`, so the
-    /// live line carries an extra `"backend error: "` prefix
-    /// (`role=AXApplication <AXSize unreadable: backend error: AXSize: AX call failed
-    /// (AXError -25205)>`) — this test only pins the part `candidate_line` itself controls.
+    /// (-25205). `ffi::copy_attribute` classifies that code as an absent attribute rather than
+    /// a failure, so the message it produces is "attribute not present" with no error code —
+    /// role is what actually identifies this case, not the AXError text (contrast
+    /// `an_unreadable_position_keeps_the_ax_error` below, whose fixture is a genuine failure).
     #[test]
-    fn an_unreadable_size_keeps_the_role_and_the_ax_error() {
+    fn an_unreadable_size_from_a_withheld_tree_keeps_the_role_not_an_ax_error_code() {
         let line = candidate_line(
             Some("AXApplication"),
-            &CandidateOutcome::SizeUnreadable("AXSize: AX call failed (AXError -25205)".into()),
+            &CandidateOutcome::SizeUnreadable("AXSize: attribute not present".into()),
         );
         assert_eq!(
             line,
-            "role=AXApplication <AXSize unreadable: AXSize: AX call failed (AXError -25205)>"
+            "role=AXApplication <AXSize unreadable: AXSize: attribute not present>"
         );
     }
 
@@ -144,6 +145,8 @@ mod tests {
         assert_eq!(line, "role=AXWindow ax_w=0 ax_h=12 <non-positive size>");
     }
 
+    /// `candidate_line` renders whatever `scale` it's given; it doesn't distinguish which kind
+    /// of non-finite value `select_window` could actually produce (see the test below for that).
     #[test]
     fn an_invalid_scale_says_so() {
         let line = candidate_line(
@@ -160,7 +163,29 @@ mod tests {
         );
     }
 
-    /// `PositionUnreadable` needs the same AXError-preserving treatment as `SizeUnreadable`.
+    /// The non-finite value `select_window` can actually produce: `.max(1.0)` resolves a NaN
+    /// dividend away (`f64::NAN.max(1.0) == 1.0`), so only an `ax_w` near zero — overflowing
+    /// the division to `Infinity` — reaches `InvalidScale`, never `NaN`.
+    #[test]
+    fn an_invalid_scale_from_a_near_zero_width_says_so() {
+        let line = candidate_line(
+            Some("AXWindow"),
+            &CandidateOutcome::InvalidScale {
+                ax_w: 230.0,
+                ax_h: 408.0,
+                scale: f64::INFINITY,
+            },
+        );
+        assert_eq!(
+            line,
+            "role=AXWindow ax_w=230 ax_h=408 scale=inf <invalid scale>"
+        );
+    }
+
+    /// `PositionUnreadable`'s error text is threaded through the same way `SizeUnreadable`'s is.
+    /// This fixture (-25204, `kAXErrorCannotComplete`) is a genuine failure, not an
+    /// absent-attribute one, so unlike the `SizeUnreadable` test above, its AXError code does
+    /// survive into the line.
     #[test]
     fn an_unreadable_position_keeps_the_ax_error() {
         let line = candidate_line(

--- a/crates/glass-a11y-macos/src/select_diagnostic.rs
+++ b/crates/glass-a11y-macos/src/select_diagnostic.rs
@@ -84,8 +84,7 @@ mod tests {
 
     /// The line that cost an hour on 2026-07-29: a locked screen hands back the *application*
     /// element where a window belongs, and `AXSize` fails `kAXErrorAttributeUnsupported`
-    /// (-25205). Both facts have to survive into the diagnostic, or the log reads as a glass
-    /// regression. The error text here is the raw string `select_window` builds from
+    /// (-25205). The error text here is the raw string `select_window` builds from
     /// `ffi::ax_err`; in production it arrives via `GlassError::Backend`'s `Display`, so the
     /// live line carries an extra `"backend error: "` prefix
     /// (`role=AXApplication <AXSize unreadable: backend error: AXSize: AX call failed
@@ -161,8 +160,7 @@ mod tests {
         );
     }
 
-    /// The `AXPosition` branch drops its error today exactly like the `AXSize` one; it gets the
-    /// same treatment, or the fix only half-lands.
+    /// `PositionUnreadable` needs the same AXError-preserving treatment as `SizeUnreadable`.
     #[test]
     fn an_unreadable_position_keeps_the_ax_error() {
         let line = candidate_line(

--- a/crates/glass-a11y-macos/src/select_diagnostic.rs
+++ b/crates/glass-a11y-macos/src/select_diagnostic.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 //! Rendering for the per-candidate diagnostic `reader::select_window` prints when no `AXWindow`
 //! matched the geometry the display backend reported. Separate from `reader` (which is
 //! `#[cfg(target_os = "macos")]` and needs a live `AXUIElement`) so the format that has to
@@ -84,7 +85,11 @@ mod tests {
     /// The line that cost an hour on 2026-07-29: a locked screen hands back the *application*
     /// element where a window belongs, and `AXSize` fails `kAXErrorAttributeUnsupported`
     /// (-25205). Both facts have to survive into the diagnostic, or the log reads as a glass
-    /// regression.
+    /// regression. The error text here is the raw string `select_window` builds from
+    /// `ffi::ax_err`; in production it arrives via `GlassError::Backend`'s `Display`, so the
+    /// live line carries an extra `"backend error: "` prefix
+    /// (`role=AXApplication <AXSize unreadable: backend error: AXSize: AX call failed
+    /// (AXError -25205)>`) — this test only pins the part `candidate_line` itself controls.
     #[test]
     fn an_unreadable_size_keeps_the_role_and_the_ax_error() {
         let line = candidate_line(

--- a/crates/glass-a11y-macos/src/select_diagnostic.rs
+++ b/crates/glass-a11y-macos/src/select_diagnostic.rs
@@ -1,0 +1,178 @@
+//! Rendering for the per-candidate diagnostic `reader::select_window` prints when no `AXWindow`
+//! matched the geometry the display backend reported. Separate from `reader` (which is
+//! `#[cfg(target_os = "macos")]` and needs a live `AXUIElement`) so the format that has to
+//! survive a debugging session is unit-tested on any host.
+//!
+//! The fields are chosen from what a real failure needed and did not have (#263): the
+//! candidate's role, because a withheld tree hands back an `AXApplication` where a window
+//! belongs, and the raw `AXError` behind a failed read, because -25205 names that condition in
+//! one line.
+
+/// What reading one `AXWindow` candidate produced — one variant per point at which
+/// `select_window` gives up on a candidate, plus the fully-measured case.
+#[derive(Clone, Debug, PartialEq)]
+pub enum CandidateOutcome {
+    /// `AXSize` could not be read. Carries the error's own text, which names the `AXError`
+    /// code (see `ffi::ax_err`).
+    SizeUnreadable(String),
+    /// `AXSize` read back a zero or negative dimension.
+    NonPositiveSize { ax_w: f64, ax_h: f64 },
+    /// The width-derived point→pixel scale was not a usable positive finite number.
+    InvalidScale { ax_w: f64, ax_h: f64, scale: f64 },
+    /// `AXPosition` could not be read. Carries the error's own text, as `SizeUnreadable` does.
+    PositionUnreadable {
+        ax_w: f64,
+        ax_h: f64,
+        scale: f64,
+        error: String,
+    },
+    /// The candidate was measured end-to-end: its scaled origin offsets from the target are
+    /// `dx`/`dy`, in pixels.
+    Measured {
+        ax_x: f64,
+        ax_y: f64,
+        ax_w: f64,
+        ax_h: f64,
+        scale: f64,
+        dx: i64,
+        dy: i64,
+    },
+}
+
+/// One candidate's diagnostic line. `role` is the candidate's `AXRole`, rendered `?` when it
+/// could not be read — never omitted, so every line has the same leading field to grep for.
+pub fn candidate_line(role: Option<&str>, outcome: &CandidateOutcome) -> String {
+    let role = role.unwrap_or("?");
+    match outcome {
+        CandidateOutcome::SizeUnreadable(error) => {
+            format!("role={role} <AXSize unreadable: {error}>")
+        }
+        CandidateOutcome::NonPositiveSize { ax_w, ax_h } => {
+            format!("role={role} ax_w={ax_w} ax_h={ax_h} <non-positive size>")
+        }
+        CandidateOutcome::InvalidScale { ax_w, ax_h, scale } => {
+            format!("role={role} ax_w={ax_w} ax_h={ax_h} scale={scale} <invalid scale>")
+        }
+        CandidateOutcome::PositionUnreadable {
+            ax_w,
+            ax_h,
+            scale,
+            error,
+        } => {
+            format!(
+                "role={role} ax_w={ax_w} ax_h={ax_h} scale={scale} <AXPosition unreadable: {error}>"
+            )
+        }
+        CandidateOutcome::Measured {
+            ax_x,
+            ax_y,
+            ax_w,
+            ax_h,
+            scale,
+            dx,
+            dy,
+        } => {
+            format!("role={role} ax=({ax_x}, {ax_y}, {ax_w}, {ax_h}) scale={scale} dx={dx} dy={dy}")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CandidateOutcome, candidate_line};
+
+    /// The line that cost an hour on 2026-07-29: a locked screen hands back the *application*
+    /// element where a window belongs, and `AXSize` fails `kAXErrorAttributeUnsupported`
+    /// (-25205). Both facts have to survive into the diagnostic, or the log reads as a glass
+    /// regression.
+    #[test]
+    fn an_unreadable_size_keeps_the_role_and_the_ax_error() {
+        let line = candidate_line(
+            Some("AXApplication"),
+            &CandidateOutcome::SizeUnreadable("AXSize: AX call failed (AXError -25205)".into()),
+        );
+        assert_eq!(
+            line,
+            "role=AXApplication <AXSize unreadable: AXSize: AX call failed (AXError -25205)>"
+        );
+    }
+
+    /// A candidate whose role could not be read is still a candidate; it renders `?` rather
+    /// than dropping the field, so every line has the same shape and is greppable.
+    #[test]
+    fn a_missing_role_renders_as_a_question_mark() {
+        let line = candidate_line(None, &CandidateOutcome::SizeUnreadable("boom".into()));
+        assert_eq!(line, "role=? <AXSize unreadable: boom>");
+    }
+
+    /// The measured line keeps the pre-#263 field order and spelling — the format a reader
+    /// comparing today's log against the one pasted in the issue has to recognize — with the
+    /// role prepended.
+    #[test]
+    fn a_measured_candidate_renders_geometry_scale_and_offsets() {
+        let line = candidate_line(
+            Some("AXWindow"),
+            &CandidateOutcome::Measured {
+                ax_x: 510.0,
+                ax_y: 497.0,
+                ax_w: 230.0,
+                ax_h: 408.0,
+                scale: 2.0,
+                dx: 540,
+                dy: 590,
+            },
+        );
+        assert_eq!(
+            line,
+            "role=AXWindow ax=(510, 497, 230, 408) scale=2 dx=540 dy=590"
+        );
+    }
+
+    #[test]
+    fn a_non_positive_size_says_so() {
+        let line = candidate_line(
+            Some("AXWindow"),
+            &CandidateOutcome::NonPositiveSize {
+                ax_w: 0.0,
+                ax_h: 12.0,
+            },
+        );
+        assert_eq!(line, "role=AXWindow ax_w=0 ax_h=12 <non-positive size>");
+    }
+
+    #[test]
+    fn an_invalid_scale_says_so() {
+        let line = candidate_line(
+            Some("AXWindow"),
+            &CandidateOutcome::InvalidScale {
+                ax_w: 230.0,
+                ax_h: 408.0,
+                scale: f64::NAN,
+            },
+        );
+        assert_eq!(
+            line,
+            "role=AXWindow ax_w=230 ax_h=408 scale=NaN <invalid scale>"
+        );
+    }
+
+    /// The `AXPosition` branch drops its error today exactly like the `AXSize` one; it gets the
+    /// same treatment, or the fix only half-lands.
+    #[test]
+    fn an_unreadable_position_keeps_the_ax_error() {
+        let line = candidate_line(
+            Some("AXWindow"),
+            &CandidateOutcome::PositionUnreadable {
+                ax_w: 230.0,
+                ax_h: 408.0,
+                scale: 2.0,
+                error: "AXPosition: AX call failed (AXError -25204)".into(),
+            },
+        );
+        assert_eq!(
+            line,
+            "role=AXWindow ax_w=230 ax_h=408 scale=2 <AXPosition unreadable: AXPosition: AX call \
+             failed (AXError -25204)>"
+        );
+    }
+}

--- a/crates/glass-a11y-macos/src/select_diagnostic.rs
+++ b/crates/glass-a11y-macos/src/select_diagnostic.rs
@@ -8,9 +8,8 @@
 //! candidate's role, because a withheld tree hands back an `AXApplication` where a window
 //! belongs, and the raw `AXError` behind a failed read, which names a genuine AX failure in one
 //! line. `ffi::copy_attribute` classifies `kAXErrorAttributeUnsupported`/`kAXErrorNoValue` as an
-//! absent attribute rather than a failure, so the 2026-07-29 incident's actual code (-25205)
-//! never reaches a diagnostic line — that case is identified by role alone (see
-//! `SizeUnreadable`'s test below).
+//! absent attribute rather than a failure, so that code (-25205) never reaches a diagnostic
+//! line — that case is identified by role alone (see `SizeUnreadable`'s test below).
 
 /// What reading one `AXWindow` candidate produced — one variant per point at which
 /// `select_window` gives up on a candidate, plus the fully-measured case.
@@ -84,21 +83,25 @@ pub fn candidate_line(role: Option<&str>, outcome: &CandidateOutcome) -> String 
 mod tests {
     use super::{CandidateOutcome, candidate_line};
 
-    /// The line that cost an hour on 2026-07-29: a locked screen hands back the *application*
-    /// element where a window belongs, and `AXSize` fails `kAXErrorAttributeUnsupported`
-    /// (-25205). `ffi::copy_attribute` classifies that code as an absent attribute rather than
-    /// a failure, so the message it produces is "attribute not present" with no error code —
-    /// role is what actually identifies this case, not the AXError text (contrast
-    /// `an_unreadable_position_keeps_the_ax_error` below, whose fixture is a genuine failure).
+    /// A locked screen hands back the *application* element where a window belongs, and
+    /// `AXSize` fails `kAXErrorAttributeUnsupported` (-25205). `ffi::copy_attribute` classifies
+    /// that code as an absent attribute rather than a failure, so the message it produces is
+    /// "attribute not present" with no error code — role is what actually identifies this
+    /// case, not the AXError text (contrast `an_unreadable_position_keeps_the_ax_error` below,
+    /// whose fixture is a genuine failure). The fixture carries the `"backend error: "` prefix
+    /// `GlassError::Backend`'s `Display` adds — `select_window` builds this string via
+    /// `e.to_string()` on the `GlassError` `ffi::ax_size` returns, not the inner message alone.
     #[test]
     fn an_unreadable_size_from_a_withheld_tree_keeps_the_role_not_an_ax_error_code() {
         let line = candidate_line(
             Some("AXApplication"),
-            &CandidateOutcome::SizeUnreadable("AXSize: attribute not present".into()),
+            &CandidateOutcome::SizeUnreadable(
+                "backend error: AXSize: attribute not present".into(),
+            ),
         );
         assert_eq!(
             line,
-            "role=AXApplication <AXSize unreadable: AXSize: attribute not present>"
+            "role=AXApplication <AXSize unreadable: backend error: AXSize: attribute not present>"
         );
     }
 
@@ -182,10 +185,10 @@ mod tests {
         );
     }
 
-    /// `PositionUnreadable`'s error text is threaded through the same way `SizeUnreadable`'s is.
-    /// This fixture (-25204, `kAXErrorCannotComplete`) is a genuine failure, not an
-    /// absent-attribute one, so unlike the `SizeUnreadable` test above, its AXError code does
-    /// survive into the line.
+    /// `PositionUnreadable`'s error text is threaded through the same way `SizeUnreadable`'s is,
+    /// `"backend error: "` prefix included. This fixture (-25204, `kAXErrorCannotComplete`) is a
+    /// genuine failure, not an absent-attribute one, so unlike the `SizeUnreadable` test above,
+    /// its AXError code does survive into the line.
     #[test]
     fn an_unreadable_position_keeps_the_ax_error() {
         let line = candidate_line(
@@ -194,13 +197,13 @@ mod tests {
                 ax_w: 230.0,
                 ax_h: 408.0,
                 scale: 2.0,
-                error: "AXPosition: AX call failed (AXError -25204)".into(),
+                error: "backend error: AXPosition: AX call failed (AXError -25204)".into(),
             },
         );
         assert_eq!(
             line,
-            "role=AXWindow ax_w=230 ax_h=408 scale=2 <AXPosition unreadable: AXPosition: AX call \
-             failed (AXError -25204)>"
+            "role=AXWindow ax_w=230 ax_h=408 scale=2 <AXPosition unreadable: backend error: \
+             AXPosition: AX call failed (AXError -25204)>"
         );
     }
 }

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -26,8 +26,14 @@ pub enum GlassError {
     )]
     SandboxedAppExited(Option<i32>),
 
+    /// No window matched. Two causes reach here and the error cannot tell them apart: the app
+    /// genuinely has not opened its window yet, or it has, and the window glass adopted is not
+    /// one of them (#263). Naming only the first sent a real investigation down a timing-race
+    /// path for an hour. The per-candidate detail that does discriminate is printed to stderr
+    /// by the resolver that failed.
     #[error(
-        "window not found — the target app may not have opened its window yet; wait for it to appear and retry"
+        "window not found — the app has no window matching the expected geometry; it may not \
+         have opened its window yet, or the window it opened is not the one glass adopted"
     )]
     WindowNotFound,
 
@@ -244,7 +250,8 @@ mod tests {
         );
         assert_eq!(
             GlassError::WindowNotFound.to_string(),
-            "window not found — the target app may not have opened its window yet; wait for it to appear and retry"
+            "window not found — the app has no window matching the expected geometry; it may not \
+             have opened its window yet, or the window it opened is not the one glass adopted"
         );
     }
 

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -28,8 +28,7 @@ pub enum GlassError {
 
     /// No window matched. Two causes reach here and the error cannot tell them apart: the app
     /// genuinely has not opened its window yet, or it has, and the window glass adopted is not
-    /// one of them (#263). Naming only the first sent a real investigation down a timing-race
-    /// path for an hour. The per-candidate detail that does discriminate is printed to stderr
+    /// one of them (#263). The per-candidate detail that does discriminate is printed to stderr
     /// by the resolver that failed.
     #[error(
         "window not found — the app has no window matching the expected geometry; it may not \

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -27,12 +27,13 @@ pub enum GlassError {
     SandboxedAppExited(Option<i32>),
 
     /// No window matched. Two causes reach here and the error cannot tell them apart: the app
-    /// genuinely has not opened its window yet, or it has, and the window glass adopted is not
-    /// one of them (#263). The per-candidate detail that does discriminate is printed to stderr
-    /// by the resolver that failed.
+    /// may not have opened its window yet, or the window glass is targeting is no longer one of
+    /// its windows — every backend's resolver hits the same ambiguous `Option`/lookup miss
+    /// (#263). On macOS the discriminating per-candidate detail is printed to stderr by the
+    /// resolver that failed; other backends have no equivalent diagnostic yet.
     #[error(
-        "window not found — the app has no window matching the expected geometry; it may not \
-         have opened its window yet, or the window it opened is not the one glass adopted"
+        "window not found — the app may not have opened its window yet, or the window glass is \
+         targeting is no longer one of its windows"
     )]
     WindowNotFound,
 
@@ -249,8 +250,8 @@ mod tests {
         );
         assert_eq!(
             GlassError::WindowNotFound.to_string(),
-            "window not found — the app has no window matching the expected geometry; it may not \
-             have opened its window yet, or the window it opened is not the one glass adopted"
+            "window not found — the app may not have opened its window yet, or the window glass \
+             is targeting is no longer one of its windows"
         );
     }
 

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -61,6 +61,17 @@ harness = false
 name = "role_probe"
 harness = false
 
+# Mac-gated window-adoption PROBE (crates/glass-macos/tests/window_adopt_probe.rs) — not a
+# pass/fail assertion test. Same harness=false main-thread requirement as the targets above
+# (`MacosPlatform::start_app` reaches AppKit's `ffi::app_kit_init()`). Launches the app named
+# by `GLASS_WINDOW_PROBE_APP` repeatedly and prints, per run, the window `start_app` adopted
+# beside every on-screen window the app's pid owns — the evidence needed to identify a window
+# adoption picked that the accessibility reader then could not resolve. With the variable
+# unset it prints what to set and exits 0. See that file's module doc.
+[[test]]
+name = "window_adopt_probe"
+harness = false
+
 [dependencies]
 glass-core.workspace = true
 plist = "1"

--- a/crates/glass-macos/src/adoption_log.rs
+++ b/crates/glass-macos/src/adoption_log.rs
@@ -1,4 +1,5 @@
-//! Rendering for the diagnostic `backend::discover_window` prints when it adopts a window.
+//! Rendering for the diagnostic `backend::discover_window`/`discover_window_pid` print when
+//! they adopt a window.
 //!
 //! Adoption takes the FIRST on-screen `SCWindow` in `SCShareableContent` order owned by the
 //! target pid, and printed nothing about that choice — so a run that adopted a window the
@@ -105,6 +106,18 @@ mod tests {
             line,
             "glass-macos: pid 7 had 1 on-screen window(s) at adoption (first in \
              SCShareableContent order wins): ADOPTED id=101 \"Calculator\" 230x408 @(480,404)"
+        );
+    }
+
+    /// A title is rendered with `{:?}` rather than `{}` so an embedded quote can't be confused
+    /// with the format's own delimiters or the `"; "` join between candidates.
+    #[test]
+    fn a_title_with_a_quote_is_escaped() {
+        let line = adoption_line(7, &[candidate(101, Some("App \"Beta\""), 230, 408, true)]);
+        assert_eq!(
+            line,
+            "glass-macos: pid 7 had 1 on-screen window(s) at adoption (first in \
+             SCShareableContent order wins): ADOPTED id=101 \"App \\\"Beta\\\"\" 230x408 @(480,404)"
         );
     }
 

--- a/crates/glass-macos/src/adoption_log.rs
+++ b/crates/glass-macos/src/adoption_log.rs
@@ -98,8 +98,6 @@ mod tests {
         );
     }
 
-    /// The ordinary case still prints — an adoption that was never ambiguous is exactly the
-    /// baseline a later ambiguous one is read against.
     #[test]
     fn a_single_candidate_still_renders() {
         let line = adoption_line(7, &[candidate(101, Some("Calculator"), 230, 408, true)]);

--- a/crates/glass-macos/src/adoption_log.rs
+++ b/crates/glass-macos/src/adoption_log.rs
@@ -1,0 +1,125 @@
+//! Rendering for the diagnostic `backend::discover_window` prints when it adopts a window.
+//!
+//! Adoption takes the FIRST on-screen `SCWindow` in `SCShareableContent` order owned by the
+//! target pid, and printed nothing about that choice — so a run that adopted a window the
+//! accessibility reader could not resolve (#263) left no record of what else was on offer.
+//! Separate from `scwindow`/`backend` (both `#[cfg(target_os = "macos")]`) so the format is
+//! unit-tested on any host, following `coords`/`clipboard_route`.
+#![forbid(unsafe_code)]
+
+use glass_core::platform::WindowGeometry;
+
+/// One on-screen window the adoption scan considered, as plain owned data — never a live
+/// `SCWindow`, which cannot cross the `SCShareableContent` completion handler's thread
+/// boundary (see `scwindow`'s module doc).
+#[derive(Clone, Debug, PartialEq)]
+pub struct CandidateWindow {
+    /// `SCWindow.windowID()` — the same id `list_windows` hands an agent.
+    pub window_id: u32,
+    /// `SCWindow.title()`; `None` for a borderless/utility window, which is itself a signal
+    /// about what kind of window was adopted.
+    pub title: Option<String>,
+    /// Pixel geometry, same derivation as `WindowMatch::geometry`.
+    pub geometry: WindowGeometry,
+    /// Whether this is the candidate adoption took.
+    pub adopted: bool,
+}
+
+/// The one-line adoption record: how many windows the pid had on screen, in framework order,
+/// with the adopted one marked.
+pub fn adoption_line(pid: i32, candidates: &[CandidateWindow]) -> String {
+    let rendered = if candidates.is_empty() {
+        "(none)".to_string()
+    } else {
+        candidates
+            .iter()
+            .map(render_candidate)
+            .collect::<Vec<_>>()
+            .join("; ")
+    };
+    format!(
+        "glass-macos: pid {pid} had {} on-screen window(s) at adoption (first in \
+         SCShareableContent order wins): {rendered}",
+        candidates.len()
+    )
+}
+
+fn render_candidate(c: &CandidateWindow) -> String {
+    let title = c
+        .title
+        .as_deref()
+        .map_or_else(|| "<untitled>".to_string(), |t| format!("{t:?}"));
+    format!(
+        "{}id={} {title} {}x{} @({},{})",
+        if c.adopted { "ADOPTED " } else { "" },
+        c.window_id,
+        c.geometry.width,
+        c.geometry.height,
+        c.geometry.x,
+        c.geometry.y
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CandidateWindow, adoption_line};
+    use glass_core::platform::WindowGeometry;
+
+    fn candidate(id: u32, title: Option<&str>, w: u32, h: u32, adopted: bool) -> CandidateWindow {
+        CandidateWindow {
+            window_id: id,
+            title: title.map(str::to_string),
+            geometry: WindowGeometry {
+                x: 480,
+                y: 404,
+                width: w,
+                height: h,
+            },
+            adopted,
+        }
+    }
+
+    /// The shape #263 needed and did not have: which window was taken, out of what, in the
+    /// order the framework offered them.
+    #[test]
+    fn two_candidates_render_in_order_with_the_adopted_one_marked() {
+        let line = adoption_line(
+            4321,
+            &[
+                candidate(101, None, 468, 101, true),
+                candidate(102, Some("Calculator"), 230, 408, false),
+            ],
+        );
+        assert_eq!(
+            line,
+            "glass-macos: pid 4321 had 2 on-screen window(s) at adoption (first in \
+             SCShareableContent order wins): ADOPTED id=101 <untitled> 468x101 @(480,404); \
+             id=102 \"Calculator\" 230x408 @(480,404)"
+        );
+    }
+
+    /// The ordinary case still prints — an adoption that was never ambiguous is exactly the
+    /// baseline a later ambiguous one is read against.
+    #[test]
+    fn a_single_candidate_still_renders() {
+        let line = adoption_line(7, &[candidate(101, Some("Calculator"), 230, 408, true)]);
+        assert_eq!(
+            line,
+            "glass-macos: pid 7 had 1 on-screen window(s) at adoption (first in \
+             SCShareableContent order wins): ADOPTED id=101 \"Calculator\" 230x408 @(480,404)"
+        );
+    }
+
+    /// Defensive: the caller only logs after a match, so an empty list should be unreachable.
+    /// It renders a statement rather than an empty bracket, so if it ever does appear the log
+    /// says something true instead of looking truncated.
+    #[test]
+    fn no_candidates_says_so() {
+        let line = adoption_line(7, &[]);
+        assert_eq!(
+            line,
+            "glass-macos: pid 7 had 0 on-screen window(s) at adoption (first in \
+             SCShareableContent order wins): (none)"
+        );
+    }
+}

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -17,6 +17,7 @@ use glass_core::platform::{
 };
 use glass_core::{GlassError, Result};
 
+use crate::adoption_log::adoption_line;
 use crate::axwindow;
 use crate::clipboard_route::ClipboardRoute;
 use crate::coords;
@@ -205,7 +206,14 @@ impl MacosPlatform {
         crate::ffi::app_kit_init();
         let deadline = Instant::now() + Duration::from_millis(timeout_ms.max(1));
         loop {
-            if let Some(m) = crate::scwindow::query_once(&[pid as i32])? {
+            if let Some((m, candidates)) =
+                crate::scwindow::query_once_with_candidates(&[pid as i32])?
+            {
+                // Fail-closed dev-tool diagnostic (stderr only, no behaviour change): adoption
+                // takes the first on-screen window in framework order, and printed nothing
+                // about that choice — so a run that adopted a window the accessibility reader
+                // could not resolve left no record of what else was on offer (#263).
+                eprintln!("{}", adoption_line(pid as i32, &candidates));
                 return Ok(m);
             }
             match child.try_wait() {
@@ -234,7 +242,9 @@ impl MacosPlatform {
         crate::ffi::app_kit_init();
         let deadline = Instant::now() + Duration::from_millis(timeout_ms.max(1));
         loop {
-            if let Some(m) = crate::scwindow::query_once(&[pid])? {
+            if let Some((m, candidates)) = crate::scwindow::query_once_with_candidates(&[pid])? {
+                // Same adoption record as `discover_window` — see there (#263).
+                eprintln!("{}", adoption_line(pid, &candidates));
                 return Ok(m);
             }
             if Instant::now() >= deadline {

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -209,10 +209,7 @@ impl MacosPlatform {
             if let Some((m, candidates)) =
                 crate::scwindow::query_once_with_candidates(&[pid as i32])?
             {
-                // Fail-closed dev-tool diagnostic (stderr only, no behaviour change): adoption
-                // takes the first on-screen window in framework order, and printed nothing
-                // about that choice — so a run that adopted a window the accessibility reader
-                // could not resolve left no record of what else was on offer (#263).
+                // Stderr-only diagnostic, no behaviour change — see adoption_log's module doc (#263).
                 eprintln!("{}", adoption_line(pid as i32, &candidates));
                 return Ok(m);
             }

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -185,19 +185,19 @@ impl MacosPlatform {
         Ok(())
     }
 
-    /// Poll for `child`'s window, alternating a single [`crate::scwindow::query_once`]
-    /// discovery attempt with `child.try_wait()` so a crashed launch fails fast with
-    /// [`GlassError::AppExited`] instead of riding out the whole `timeout_ms` budget
-    /// waiting for a window that will never appear — mirrors
-    /// `glass-x11/src/platform.rs`'s `discover_window`. Can't delegate this to
-    /// `scwindow::find_window_for_pids`: that helper owns its *entire* poll loop
-    /// internally, with no child handle to race against.
+    /// Poll for `child`'s window, alternating a single
+    /// [`crate::scwindow::query_once_with_candidates`] discovery attempt with
+    /// `child.try_wait()` so a crashed launch fails fast with [`GlassError::AppExited`]
+    /// instead of riding out the whole `timeout_ms` budget waiting for a window that will
+    /// never appear — mirrors `glass-x11/src/platform.rs`'s `discover_window`. Can't
+    /// delegate this to `scwindow::find_window_for_pids`: that helper owns its *entire*
+    /// poll loop internally, with no child handle to race against.
     ///
     /// Returns the whole [`crate::scwindow::WindowMatch`] (not just its `geometry`), even
     /// though `start_app` only reads `geometry` from it today — `send_pointer` does its own
     /// independent, fresh `scwindow::find_window_for_pids` resolution per call rather than
     /// reusing anything cached here (see its doc), so this return type is just the natural
-    /// shape of a `query_once` result, not evidence of caching elsewhere.
+    /// shape of a `query_once_with_candidates` result, not evidence of caching elsewhere.
     fn discover_window(
         child: &mut Child,
         pid: u32,
@@ -237,7 +237,8 @@ impl MacosPlatform {
     /// already-running via `ffi::running_pid_for_bundle_id`, or just started via
     /// `ffi::launch_bundle`), so unlike [`discover_window`] there is no local `Child` handle
     /// (`std::process::Child`) to `try_wait` if the adopted app dies before its window
-    /// appears; this loop only re-queries `scwindow::query_once` until `timeout_ms` elapses.
+    /// appears; this loop only re-queries `scwindow::query_once_with_candidates` until
+    /// `timeout_ms` elapses.
     fn discover_window_pid(pid: i32, timeout_ms: u64) -> Result<crate::scwindow::WindowMatch> {
         crate::ffi::app_kit_init();
         let deadline = Instant::now() + Duration::from_millis(timeout_ms.max(1));

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -2,7 +2,8 @@
 //! rendered onto a `CGVirtualDisplay`).
 //!
 //! Like `glass-windows`, the pure logic ([`keymap`], [`coords`], [`clipboard_route`],
-//! [`shim_path`]) is crate-level and unit-tested on any host; the OS-touching
+//! [`shim_path`], [`bundle`], [`adoption_log`]) is crate-level and unit-tested on any host;
+//! the OS-touching
 //! modules and the `MacosPlatform` impl are gated `#[cfg(target_os = "macos")]`. Off macOS
 //! the crate exposes only the pure modules and the [`capabilities`] map (whose `accessibility`
 //! cell is live; every other cell is constant).

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -14,6 +14,7 @@
 
 use glass_core::capability::{CapabilityMap, CapabilityStatus};
 
+pub mod adoption_log; // pure window-adoption diagnostic rendering — cross-platform, host-tested
 pub mod bundle; // pure .app-bundle logic — cross-platform, host-tested
 pub mod clipboard_route; // pure clipboard-routing policy — cross-platform, host-tested
 pub mod coords; // pure window-relative <-> global math — cross-platform, host-tested

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -2,11 +2,10 @@
 //! rendered onto a `CGVirtualDisplay`).
 //!
 //! Like `glass-windows`, the pure logic ([`keymap`], [`coords`], [`clipboard_route`],
-//! [`shim_path`], [`bundle`], [`adoption_log`]) is crate-level and unit-tested on any host;
-//! the OS-touching
-//! modules and the `MacosPlatform` impl are gated `#[cfg(target_os = "macos")]`. Off macOS
-//! the crate exposes only the pure modules and the [`capabilities`] map (whose `accessibility`
-//! cell is live; every other cell is constant).
+//! [`shim_path`], [`bundle`], [`adoption_log`]) is crate-level and unit-tested on any host; the
+//! OS-touching modules and the `MacosPlatform` impl are gated `#[cfg(target_os = "macos")]`. Off
+//! macOS the crate exposes only the pure modules and the [`capabilities`] map (whose
+//! `accessibility` cell is live; every other cell is constant).
 
 // FFI backend: the OS-touching modules need `unsafe`, so this crate opts out of the workspace
 // `unsafe_code = "deny"`; each site carries a `// SAFETY:` note (see CLAUDE.md). The pure

--- a/crates/glass-macos/src/scwindow.rs
+++ b/crates/glass-macos/src/scwindow.rs
@@ -187,8 +187,9 @@ pub(crate) enum Candidates {
 /// summary of every such window in the same order, with the returned one marked adopted.
 ///
 /// One loop for both modes so the hot lookup and the adoption record can never disagree about
-/// what "the target window" means — the same no-drift rule [`find_on_screen_window_by_id`]
-/// follows.
+/// what "the target window" means. [`find_on_screen_window_by_id`] keeps its own separate
+/// loop rather than sharing this one — it matches by `window_id` + pid, not pid alone, so
+/// there's no `Candidates`-style mode to dedup against here.
 pub(crate) fn scan_on_screen_windows(
     content: &SCShareableContent,
     pids: &[i32],
@@ -243,6 +244,12 @@ pub(crate) fn scan_on_screen_windows(
 /// [`scan_on_screen_windows`] without the candidate summary — the per-call lookup
 /// `capture::capture_window` and `query_once` use. Shared by both so the two call sites can't
 /// drift apart on what "the target window" means.
+///
+/// Returns the live `Retained<SCWindow>` itself, against the module's normal "never a
+/// `Retained<SCWindow>`" rule (see the module doc): `capture::capture_window` needs exactly
+/// that, still inside the same completion-handler callback, to build an `SCContentFilter`
+/// from it. `query_once` immediately converts its half of the result to a [`WindowMatch`]
+/// snapshot via [`window_match_from`] instead of holding onto it.
 pub(crate) fn find_on_screen_window(
     content: &SCShareableContent,
     pids: &[i32],
@@ -465,76 +472,32 @@ pub(crate) fn list_app_windows(pids: &[i32]) -> Result<Vec<AppWindow>> {
 /// which retries (or times out) regardless of this cap.
 const QUERY_TIMEOUT: Duration = Duration::from_secs(1);
 
-/// One `SCShareableContent` round trip via the `RcBlock` -> `mpsc` bridge (`ffi.rs`'s
-/// documented pattern): `Ok(Some(_))` on a match, `Ok(None)` if no matching on-screen
-/// window exists yet (the outer poll should retry), `Err` if `SCShareableContent` itself
-/// failed — classified via [`crate::ffi::classify_null_result`] (TCC decline ->
-/// `PermissionDenied`, anything else -> `CaptureFailed`) rather than assumed to always be
-/// a permission decline; not worth retrying either way.
-pub(crate) fn query_once(pids: &[i32]) -> Result<Option<WindowMatch>> {
-    let (tx, rx) = mpsc::channel::<QueryReply>();
-    let pids_owned: Vec<i32> = pids.to_vec();
-
-    // The completion handler does the whole match-or-not decision synchronously inside
-    // the callback (per ffi.rs's async-bridge pattern) and only ever sends `QueryReply`
-    // — plain owned data, `Send` regardless of what ObjC objects were touched to build
-    // it — never a `Retained<SCWindow>` (see module doc).
-    let block = RcBlock::new(
-        move |content_ptr: *mut SCShareableContent, err_ptr: *mut NSError| {
-            if content_ptr.is_null() {
-                let err = crate::ffi::classify_null_result(
-                    err_ptr,
-                    "SCShareableContent completion handler returned null content and null error",
-                );
-                let _ = tx.send(QueryReply::Failed(err));
-                return;
-            }
-            // SAFETY: `content_ptr` was just checked non-null; the framework guarantees it
-            // points to a live `SCShareableContent` for the duration of this callback.
-            let content: &SCShareableContent = unsafe { &*content_ptr };
-
-            let Some((w, pid)) = find_on_screen_window(content, &pids_owned) else {
-                let _ = tx.send(QueryReply::NotFound);
-                return;
-            };
-            let _ = tx.send(QueryReply::Found(window_match_from(&w, pid)));
-        },
-    );
-
-    // SAFETY: `block` matches `getShareableContentExcludingDesktopWindows_onScreenWindowsOnly_completionHandler`'s
-    // documented signature (`*mut SCShareableContent, *mut NSError`, per the generated
-    // binding) — the exact sequence the spike proved end-to-end. The call itself has no
-    // other preconditions.
-    unsafe {
-        SCShareableContent::getShareableContentExcludingDesktopWindows_onScreenWindowsOnly_completionHandler(
-            true, true, &block,
-        );
-    }
-
-    match rx.recv_timeout(QUERY_TIMEOUT) {
-        Ok(QueryReply::Found(m)) => Ok(Some(m)),
-        Ok(QueryReply::NotFound) => Ok(None),
-        Ok(QueryReply::Failed(e)) => Err(e),
-        Err(mpsc::RecvTimeoutError::Timeout) => Ok(None),
-        Err(mpsc::RecvTimeoutError::Disconnected) => Err(GlassError::Backend(
-            "SCShareableContent completion handler was dropped without replying".into(),
-        )),
-    }
-}
-
-/// [`query_once`] for the adoption path: the same single `SCShareableContent` round trip, but
-/// returning the candidate summary alongside the match so `backend::discover_window` can record
-/// what it chose between (#263). No extra query — the candidates come out of the content the
-/// match was already found in.
-pub(crate) fn query_once_with_candidates(
+/// The shared body of [`query_once`] and [`query_once_with_candidates`]: one
+/// `SCShareableContent` round trip via the `RcBlock` -> `mpsc` bridge (`ffi.rs`'s documented
+/// pattern). `Ok(Some(_))` on a match, `Ok(None)` if no matching on-screen window exists yet
+/// (the outer poll should retry), `Err` if `SCShareableContent` itself failed — classified
+/// via [`crate::ffi::classify_null_result`] (TCC decline -> `PermissionDenied`, anything else
+/// -> `CaptureFailed`) rather than assumed to always be a permission decline; not worth
+/// retrying either way. `collect` is forwarded straight to [`scan_on_screen_windows`]:
+/// [`Candidates::Skip`] (`query_once`) gets back an unallocated empty `Vec`, so the hot path
+/// pays nothing for a candidate summary it never uses.
+///
+/// The adopted window's geometry is read once here, from the `WindowMatch` snapshot
+/// ([`window_match_from`]) — not re-derived from the scan's own (separately-read) candidate
+/// entry — so the printed record and the geometry glass goes on to use can't diverge even in
+/// theory (final-review fix, #263): whichever candidate is `adopted` gets its `geometry`
+/// overwritten with the `WindowMatch`'s.
+fn query_once_inner(
     pids: &[i32],
+    collect: Candidates,
 ) -> Result<Option<(WindowMatch, Vec<CandidateWindow>)>> {
     let (tx, rx) = mpsc::channel::<CandidateQueryReply>();
     let pids_owned: Vec<i32> = pids.to_vec();
 
-    // Same async-bridge discipline as `query_once`: the whole decision happens inside the
-    // callback and only plain owned data crosses the channel — never a `Retained<SCWindow>`
-    // (see module doc).
+    // The completion handler does the whole match-or-not decision synchronously inside
+    // the callback (per ffi.rs's async-bridge pattern) and only ever sends
+    // `CandidateQueryReply` — plain owned data, `Send` regardless of what ObjC objects
+    // were touched to build it — never a `Retained<SCWindow>` (see module doc).
     let block = RcBlock::new(
         move |content_ptr: *mut SCShareableContent, err_ptr: *mut NSError| {
             if content_ptr.is_null() {
@@ -549,23 +512,23 @@ pub(crate) fn query_once_with_candidates(
             // points to a live `SCShareableContent` for the duration of this callback.
             let content: &SCShareableContent = unsafe { &*content_ptr };
 
-            let (found, candidates) =
-                scan_on_screen_windows(content, &pids_owned, Candidates::Collect);
+            let (found, mut candidates) = scan_on_screen_windows(content, &pids_owned, collect);
             let Some((w, pid)) = found else {
                 let _ = tx.send(CandidateQueryReply::NotFound);
                 return;
             };
-            let _ = tx.send(CandidateQueryReply::Found(
-                window_match_from(&w, pid),
-                candidates,
-            ));
+            let m = window_match_from(&w, pid);
+            if let Some(adopted) = candidates.iter_mut().find(|c| c.adopted) {
+                adopted.geometry = m.geometry.clone();
+            }
+            let _ = tx.send(CandidateQueryReply::Found(m, candidates));
         },
     );
 
-    // SAFETY: `block` matches
-    // `getShareableContentExcludingDesktopWindows_onScreenWindowsOnly_completionHandler`'s
+    // SAFETY: `block` matches `getShareableContentExcludingDesktopWindows_onScreenWindowsOnly_completionHandler`'s
     // documented signature (`*mut SCShareableContent, *mut NSError`, per the generated
-    // binding) — identical to `query_once`'s call. No other preconditions.
+    // binding) — the exact sequence the spike proved end-to-end. The call itself has no
+    // other preconditions.
     unsafe {
         SCShareableContent::getShareableContentExcludingDesktopWindows_onScreenWindowsOnly_completionHandler(
             true, true, &block,
@@ -583,8 +546,24 @@ pub(crate) fn query_once_with_candidates(
     }
 }
 
-/// [`query_once_with_candidates`]'s channel payload — [`QueryReply`] plus the candidate
-/// summary on the found arm.
+/// [`query_once_inner`] with [`Candidates::Skip`], discarding the (always-empty) candidate
+/// summary — the per-call hot-path lookup [`find_window_for_pids`] polls.
+pub(crate) fn query_once(pids: &[i32]) -> Result<Option<WindowMatch>> {
+    query_once_inner(pids, Candidates::Skip).map(|opt| opt.map(|(m, _)| m))
+}
+
+/// [`query_once_inner`] with [`Candidates::Collect`]: the adoption path's round trip,
+/// returning the candidate summary alongside the match so `backend::discover_window`/
+/// `discover_window_pid` can record what they chose between (#263). No extra query — the
+/// candidates come out of the content the match was already found in.
+pub(crate) fn query_once_with_candidates(
+    pids: &[i32],
+) -> Result<Option<(WindowMatch, Vec<CandidateWindow>)>> {
+    query_once_inner(pids, Candidates::Collect)
+}
+
+/// [`query_once_inner`]'s channel payload — like [`QueryReply`] but carrying the candidate
+/// summary [`scan_on_screen_windows`] collected alongside the match.
 enum CandidateQueryReply {
     Found(WindowMatch, Vec<CandidateWindow>),
     NotFound,

--- a/crates/glass-macos/src/scwindow.rs
+++ b/crates/glass-macos/src/scwindow.rs
@@ -241,15 +241,15 @@ pub(crate) fn scan_on_screen_windows(
     (found, candidates)
 }
 
-/// [`scan_on_screen_windows`] without the candidate summary — the per-call lookup
-/// `capture::capture_window` and `query_once` use. Shared by both so the two call sites can't
-/// drift apart on what "the target window" means.
+/// [`scan_on_screen_windows`] without the candidate summary — `capture::capture_window`'s
+/// per-call lookup (its only caller: `query_once` no longer goes through this function,
+/// it reaches [`scan_on_screen_windows`] directly via `query_once_inner`).
 ///
 /// Returns the live `Retained<SCWindow>` itself, against the module's normal "never a
 /// `Retained<SCWindow>`" rule (see the module doc): `capture::capture_window` needs exactly
 /// that, still inside the same completion-handler callback, to build an `SCContentFilter`
-/// from it. `query_once` immediately converts its half of the result to a [`WindowMatch`]
-/// snapshot via [`window_match_from`] instead of holding onto it.
+/// from it. `query_once_inner` converts its own [`scan_on_screen_windows`] result to a
+/// [`WindowMatch`] snapshot via [`window_match_from`] instead of holding onto it.
 pub(crate) fn find_on_screen_window(
     content: &SCShareableContent,
     pids: &[i32],
@@ -260,8 +260,9 @@ pub(crate) fn find_on_screen_window(
 /// Find the on-screen `SCWindow` in `content.windows()` whose `windowID() == window_id` AND
 /// `owningApplication().processID() ∈ pids`, returning it alongside its owning pid. The
 /// `find_window_by_id`-side counterpart of [`find_on_screen_window`] (which filters by
-/// owning pid alone instead of a specific window + pid set): same on-screen filter as
-/// [`scan_on_screen_windows`]'s loop, so the lookups can't drift on what "on-screen" means.
+/// owning pid alone instead of a specific window + pid set): its own copy of the same
+/// on-screen filter shape as [`scan_on_screen_windows`]'s loop, not a shared call — keeping
+/// the two in sync on what "on-screen" means is a discipline, not something enforced.
 /// The `pids` check (final-review fix 1) is load-bearing, not defensive: `windowID` alone
 /// is not scoped to any particular app, so without it this would match *any* on-screen
 /// window system-wide, letting a stale/foreign `CGWindowID` silently resolve to someone

--- a/crates/glass-macos/src/scwindow.rs
+++ b/crates/glass-macos/src/scwindow.rs
@@ -517,10 +517,8 @@ fn query_once_inner(
                 return;
             };
             let m = window_match_from(&w, pid);
-            // `scan_on_screen_windows` must mark at most one candidate adopted, or `.find`
-            // below silently corrects the wrong one (or none) instead of the one this scan
-            // actually matched.
-            debug_assert!(candidates.iter().filter(|c| c.adopted).count() <= 1);
+            // Safe by construction: `scan_on_screen_windows` sets `adopted = found.is_none()`,
+            // true for at most one candidate, so `.find` below can't correct the wrong one.
             if let Some(adopted) = candidates.iter_mut().find(|c| c.adopted) {
                 adopted.geometry = m.geometry.clone();
             }

--- a/crates/glass-macos/src/scwindow.rs
+++ b/crates/glass-macos/src/scwindow.rs
@@ -53,12 +53,13 @@ use crate::adoption_log::CandidateWindow;
 /// a live `Retained<SCWindow>` across the completion handler's thread boundary (see
 /// module doc).
 // `geometry`/`scale`/`origin_pt` are read by `start_app` (via `backend.rs::discover_window`
-// -> `query_once`) and by `send_pointer`/`capture_frame`/`send_key` (via `backend.rs`'s
-// per-call `find_window_for_pids`/`find_window_by_id` resolution); `window_id` is read by
-// `start_app` too (to seed `MacosPlatform::active_window`, Plan 4 Task 1). `pid` is read by
-// `send_pointer`/`send_key` (via `resolve_active_window`'s per-call resolution) as the
-// CGEvent focus/AX-scoping target, and by every `find_window_by_id` call site's
-// pid-scoping check (Plan 4 final-review fix 1) — every field is read somewhere.
+// -> `query_once_with_candidates`) and by `send_pointer`/`capture_frame`/`send_key` (via
+// `backend.rs`'s per-call `find_window_for_pids`/`find_window_by_id` resolution);
+// `window_id` is read by `start_app` too (to seed `MacosPlatform::active_window`, Plan 4
+// Task 1). `pid` is read by `send_pointer`/`send_key` (via `resolve_active_window`'s
+// per-call resolution) as the CGEvent focus/AX-scoping target, and by every
+// `find_window_by_id` call site's pid-scoping check (Plan 4 final-review fix 1) — every
+// field is read somewhere.
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct WindowMatch {
     /// The owning process's pid — one of the `pids` passed to `find_window_for_pids`.
@@ -116,9 +117,9 @@ pub(crate) struct AppWindow {
 /// matching window appears before `timeout` elapses.
 ///
 /// `MacosPlatform::start_app` still can't use this directly: it runs its own poll loop
-/// (`backend.rs::discover_window`) that alternates a single `query_once` attempt with
-/// `child.try_wait()` so a crashed launch fails fast with `AppExited`, and this function's
-/// self-contained `poll_until` has no child handle to race against. But
+/// (`backend.rs::discover_window`) that alternates a single `query_once_with_candidates`
+/// attempt with `child.try_wait()` so a crashed launch fails fast with `AppExited`, and
+/// this function's self-contained `poll_until` has no child handle to race against. But
 /// `MacosPlatform::send_pointer` does call this directly on every invocation, to
 /// re-resolve the window's current geometry/scale/origin fresh (the window may have moved
 /// or resized since `start_app`, or since the previous `send_pointer` call) — there's no
@@ -252,16 +253,17 @@ pub(crate) fn find_on_screen_window(
 /// Find the on-screen `SCWindow` in `content.windows()` whose `windowID() == window_id` AND
 /// `owningApplication().processID() ∈ pids`, returning it alongside its owning pid. The
 /// `find_window_by_id`-side counterpart of [`find_on_screen_window`] (which filters by
-/// owning pid alone instead of a specific window + pid set): same on-screen filter, same
-/// iteration, so the two lookups can't drift on what "on-screen" means. The `pids` check
-/// (final-review fix 1) is load-bearing, not defensive: `windowID` alone is not scoped to
-/// any particular app, so without it this would match *any* on-screen window system-wide,
-/// letting a stale/foreign `CGWindowID` silently resolve to someone else's window — see
-/// [`find_window_by_id`]'s doc. Used by [`query_once_by_id`] (which then builds a
-/// [`WindowMatch`] snapshot via [`window_match_from`], the same builder [`query_once`] uses)
-/// and by `capture::capture_window_by_id` (which, like `capture_window`, needs the live
-/// `SCWindow` itself, still inside the same completion-handler callback, to build an
-/// `SCContentFilter` — see [`find_on_screen_window`]'s doc).
+/// owning pid alone instead of a specific window + pid set): same on-screen filter as
+/// [`scan_on_screen_windows`]'s loop, so the lookups can't drift on what "on-screen" means.
+/// The `pids` check (final-review fix 1) is load-bearing, not defensive: `windowID` alone
+/// is not scoped to any particular app, so without it this would match *any* on-screen
+/// window system-wide, letting a stale/foreign `CGWindowID` silently resolve to someone
+/// else's window — see [`find_window_by_id`]'s doc. Used by [`query_once_by_id`] (which
+/// then builds a [`WindowMatch`] snapshot via [`window_match_from`], the same builder
+/// [`query_once`] uses) and by `capture::capture_window_by_id` (which, like
+/// `capture_window`, needs the live `SCWindow` itself, still inside the same
+/// completion-handler callback, to build an `SCContentFilter` — see
+/// [`find_on_screen_window`]'s doc).
 pub(crate) fn find_on_screen_window_by_id(
     content: &SCShareableContent,
     window_id: u32,
@@ -273,7 +275,7 @@ pub(crate) fn find_on_screen_window_by_id(
 
     for w in windows.iter() {
         // SAFETY: `w` is a live `SCWindow` yielded by the array; these are plain property
-        // getters with no other preconditions — see `find_on_screen_window`'s identical
+        // getters with no other preconditions — see `scan_on_screen_windows`'s identical
         // SAFETY notes.
         if !unsafe { w.isOnScreen() } {
             continue;
@@ -299,11 +301,11 @@ pub(crate) fn find_on_screen_window_by_id(
 /// Derive a window's pixel geometry, `SCContentFilter` point-to-pixel scale, and POINT
 /// origin from a live `SCWindow` — the `SCContentFilter`/`pointPixelScale`/`contentRect` ->
 /// pixel-`WindowGeometry` conversion `capture::capture_window` also performs for the frame
-/// it produces. Factored out so [`window_match_from`] and [`app_window_from`] can't drift
-/// on how a window becomes a pixel geometry.
+/// it produces. Factored out so [`window_match_from`], [`app_window_from`], and
+/// [`scan_on_screen_windows`] can't drift on how a window becomes a pixel geometry.
 fn window_geometry_and_scale(w: &SCWindow) -> (WindowGeometry, f64, (f64, f64)) {
     // SAFETY: `w` is a live `SCWindow` passed in by a caller that just resolved it from a
-    // live `SCShareableContent.windows()` array (see `find_on_screen_window`/
+    // live `SCShareableContent.windows()` array (see `scan_on_screen_windows`/
     // `find_on_screen_window_by_id`/[`list_app_windows`]); `capture.rs` uses this same
     // initializer on the same kind of live `SCWindow` — no other preconditions.
     let filter =
@@ -323,8 +325,8 @@ fn window_geometry_and_scale(w: &SCWindow) -> (WindowGeometry, f64, (f64, f64)) 
 }
 
 /// Build a [`WindowMatch`] snapshot from a live `SCWindow` + its owning `pid`. Factored out
-/// so [`query_once`] and [`query_once_by_id`] can't drift on how a match becomes a
-/// `WindowMatch`.
+/// so [`query_once`], [`query_once_with_candidates`], and [`query_once_by_id`] can't drift
+/// on how a match becomes a `WindowMatch`.
 fn window_match_from(w: &SCWindow, pid: i32) -> WindowMatch {
     // SAFETY: `w` is live (see `window_geometry_and_scale`'s identical note); a plain
     // property getter with no other preconditions.
@@ -411,7 +413,7 @@ pub(crate) fn list_app_windows(pids: &[i32]) -> Result<Vec<AppWindow>> {
             let mut found = Vec::new();
             for w in windows.iter() {
                 // SAFETY: `w` is a live `SCWindow` yielded by the array; plain property
-                // getters with no other preconditions — see `find_on_screen_window`'s
+                // getters with no other preconditions — see `scan_on_screen_windows`'s
                 // identical notes.
                 if !unsafe { w.isOnScreen() } {
                     continue;
@@ -454,13 +456,13 @@ pub(crate) fn list_app_windows(pids: &[i32]) -> Result<Vec<AppWindow>> {
     }
 }
 
-/// Cap on a single [`query_once`] attempt's wait for its `SCShareableContent` completion
-/// handler. A query resolves in well under a second in the spike's observations, so this
-/// is a wedged-handler backstop, not normal latency; kept small (rather than the old 5s)
-/// so it can't itself eat much of the outer poll loop's `timeout_ms`/deadline budget on a
-/// single bad tick — that budget is owned by the caller (`find_window_for_pids`'s
-/// `poll_until`, or `backend.rs::discover_window`'s own loop), which retries (or times
-/// out) regardless of this cap.
+/// Cap on a single [`query_once`]/[`query_once_with_candidates`] attempt's wait for its
+/// `SCShareableContent` completion handler. A query resolves in well under a second in the
+/// spike's observations, so this is a wedged-handler backstop, not normal latency; kept
+/// small (rather than the old 5s) so it can't itself eat much of the outer poll loop's
+/// `timeout_ms`/deadline budget on a single bad tick — that budget is owned by the caller
+/// (`find_window_for_pids`'s `poll_until`, or `backend.rs::discover_window`'s own loop),
+/// which retries (or times out) regardless of this cap.
 const QUERY_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// One `SCShareableContent` round trip via the `RcBlock` -> `mpsc` bridge (`ffi.rs`'s

--- a/crates/glass-macos/src/scwindow.rs
+++ b/crates/glass-macos/src/scwindow.rs
@@ -268,7 +268,7 @@ pub(crate) fn find_on_screen_window(
 /// window system-wide, letting a stale/foreign `CGWindowID` silently resolve to someone
 /// else's window — see [`find_window_by_id`]'s doc. Used by [`query_once_by_id`] (which
 /// then builds a [`WindowMatch`] snapshot via [`window_match_from`], the same builder
-/// [`query_once`] uses) and by `capture::capture_window_by_id` (which, like
+/// `query_once_inner` uses) and by `capture::capture_window_by_id` (which, like
 /// `capture_window`, needs the live `SCWindow` itself, still inside the same
 /// completion-handler callback, to build an `SCContentFilter` — see
 /// [`find_on_screen_window`]'s doc).

--- a/crates/glass-macos/src/scwindow.rs
+++ b/crates/glass-macos/src/scwindow.rs
@@ -172,10 +172,12 @@ pub(crate) fn find_window_by_id(
 
 /// Whether a scan should also collect a summary of every candidate it saw.
 ///
-/// [`Candidates::Skip`] is the hot path (`capture_window`, `send_pointer`'s per-call
-/// re-resolution): stop at the first match, allocate nothing. [`Candidates::Collect`] is the
-/// once-per-session adoption path, which pays for a full pass so the adoption record can name
-/// what it chose between (#263).
+/// [`Candidates::Skip`] stops at the first match and allocates nothing — `capture_window`'s
+/// and `find_window_for_pids`'s fallback, reached only while `active_window` is unset; once a
+/// session has adopted a window, `capture_frame`/`resolve_active_window` resolve by id via
+/// `find_window_by_id` instead, a separate loop this enum doesn't touch. [`Candidates::Collect`]
+/// is the once-per-session adoption path, which pays for a full pass so the adoption record can
+/// name what it chose between (#263).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum Candidates {
     Skip,
@@ -241,15 +243,11 @@ pub(crate) fn scan_on_screen_windows(
     (found, candidates)
 }
 
-/// [`scan_on_screen_windows`] without the candidate summary — `capture::capture_window`'s
-/// per-call lookup (its only caller: `query_once` no longer goes through this function,
-/// it reaches [`scan_on_screen_windows`] directly via `query_once_inner`).
-///
-/// Returns the live `Retained<SCWindow>` itself, against the module's normal "never a
-/// `Retained<SCWindow>`" rule (see the module doc): `capture::capture_window` needs exactly
-/// that, still inside the same completion-handler callback, to build an `SCContentFilter`
-/// from it. `query_once_inner` converts its own [`scan_on_screen_windows`] result to a
-/// [`WindowMatch`] snapshot via [`window_match_from`] instead of holding onto it.
+/// [`scan_on_screen_windows`] without the candidate summary, for `capture::capture_window`'s
+/// per-call lookup (its only caller). Returns the live `Retained<SCWindow>` itself, against
+/// the module's normal "never a `Retained<SCWindow>`" rule (see the module doc):
+/// `capture::capture_window` needs exactly that, still inside the same completion-handler
+/// callback, to build an `SCContentFilter` from it.
 pub(crate) fn find_on_screen_window(
     content: &SCShareableContent,
     pids: &[i32],
@@ -519,6 +517,10 @@ fn query_once_inner(
                 return;
             };
             let m = window_match_from(&w, pid);
+            // `scan_on_screen_windows` must mark at most one candidate adopted, or `.find`
+            // below silently corrects the wrong one (or none) instead of the one this scan
+            // actually matched.
+            debug_assert!(candidates.iter().filter(|c| c.adopted).count() <= 1);
             if let Some(adopted) = candidates.iter_mut().find(|c| c.adopted) {
                 adopted.geometry = m.geometry.clone();
             }
@@ -653,5 +655,11 @@ mod tests {
     fn list_reply_is_send() {
         fn assert_send<T: Send>() {}
         assert_send::<ListReply>();
+    }
+
+    #[test]
+    fn candidate_query_reply_is_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<CandidateQueryReply>();
     }
 }

--- a/crates/glass-macos/src/scwindow.rs
+++ b/crates/glass-macos/src/scwindow.rs
@@ -47,6 +47,8 @@ use objc2_screen_capture_kit::{
 use glass_core::platform::WindowGeometry;
 use glass_core::{GlassError, Result, poll_until};
 
+use crate::adoption_log::CandidateWindow;
+
 /// A discovered on-screen window: enough to re-find or capture it later without holding
 /// a live `Retained<SCWindow>` across the completion handler's thread boundary (see
 /// module doc).
@@ -167,22 +169,36 @@ pub(crate) fn find_window_by_id(
     outcome.value.ok_or(GlassError::WindowNotFound)
 }
 
+/// Whether a scan should also collect a summary of every candidate it saw.
+///
+/// [`Candidates::Skip`] is the hot path (`capture_window`, `send_pointer`'s per-call
+/// re-resolution): stop at the first match, allocate nothing. [`Candidates::Collect`] is the
+/// once-per-session adoption path, which pays for a full pass so the adoption record can name
+/// what it chose between (#263).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Candidates {
+    Skip,
+    Collect,
+}
+
 /// Find the first on-screen `SCWindow` in `content.windows()` owned by one of `pids`,
-/// returning it alongside its owning pid. Shared by [`query_once`] (which extracts a
-/// [`WindowMatch`] snapshot from the match, since the window itself can't survive the
-/// completion handler's thread boundary — see the module doc) and
-/// `capture::capture_window` (which needs the live `SCWindow` itself, still inside the
-/// same completion-handler callback, to build an `SCContentFilter` from it). Keeping the
-/// filter loop here means the two call sites can't drift apart on what "the target
-/// window" means.
-pub(crate) fn find_on_screen_window(
+/// returning it alongside its owning pid — and, when `collect` is [`Candidates::Collect`], a
+/// summary of every such window in the same order, with the returned one marked adopted.
+///
+/// One loop for both modes so the hot lookup and the adoption record can never disagree about
+/// what "the target window" means — the same no-drift rule [`find_on_screen_window_by_id`]
+/// follows.
+pub(crate) fn scan_on_screen_windows(
     content: &SCShareableContent,
     pids: &[i32],
-) -> Option<(Retained<SCWindow>, i32)> {
+    collect: Candidates,
+) -> (Option<(Retained<SCWindow>, i32)>, Vec<CandidateWindow>) {
     // SAFETY: `windows` is a plain getter on a live `SCShareableContent`; no other
     // preconditions.
     let windows: Retained<NSArray<SCWindow>> = unsafe { content.windows() };
 
+    let mut found: Option<(Retained<SCWindow>, i32)> = None;
+    let mut candidates = Vec::new();
     for w in windows.iter() {
         // SAFETY: `w` is a live `SCWindow` yielded by the array (`NSArray::iter` hands
         // out a fresh, owned `Retained<SCWindow>` per element — see `ffi.rs`'s gotcha
@@ -198,11 +214,39 @@ pub(crate) fn find_on_screen_window(
         };
         // SAFETY: same as above — a plain property getter.
         let pid = unsafe { app.processID() };
-        if pids.contains(&pid) {
-            return Some((w, pid));
+        if !pids.contains(&pid) {
+            continue;
         }
+        let adopted = found.is_none();
+        if adopted {
+            found = Some((w.clone(), pid));
+        }
+        if collect == Candidates::Skip {
+            break;
+        }
+        // SAFETY: `w` is live; `title` is a plain property getter (same read
+        // `app_window_from` performs).
+        let title = unsafe { w.title() }.map(|t| t.to_string());
+        let (geometry, _scale, _origin_pt) = window_geometry_and_scale(&w);
+        candidates.push(CandidateWindow {
+            // SAFETY: `w` is live; a plain property getter.
+            window_id: unsafe { w.windowID() },
+            title,
+            geometry,
+            adopted,
+        });
     }
-    None
+    (found, candidates)
+}
+
+/// [`scan_on_screen_windows`] without the candidate summary — the per-call lookup
+/// `capture::capture_window` and `query_once` use. Shared by both so the two call sites can't
+/// drift apart on what "the target window" means.
+pub(crate) fn find_on_screen_window(
+    content: &SCShareableContent,
+    pids: &[i32],
+) -> Option<(Retained<SCWindow>, i32)> {
+    scan_on_screen_windows(content, pids, Candidates::Skip).0
 }
 
 /// Find the on-screen `SCWindow` in `content.windows()` whose `windowID() == window_id` AND
@@ -474,6 +518,75 @@ pub(crate) fn query_once(pids: &[i32]) -> Result<Option<WindowMatch>> {
             "SCShareableContent completion handler was dropped without replying".into(),
         )),
     }
+}
+
+/// [`query_once`] for the adoption path: the same single `SCShareableContent` round trip, but
+/// returning the candidate summary alongside the match so `backend::discover_window` can record
+/// what it chose between (#263). No extra query — the candidates come out of the content the
+/// match was already found in.
+pub(crate) fn query_once_with_candidates(
+    pids: &[i32],
+) -> Result<Option<(WindowMatch, Vec<CandidateWindow>)>> {
+    let (tx, rx) = mpsc::channel::<CandidateQueryReply>();
+    let pids_owned: Vec<i32> = pids.to_vec();
+
+    // Same async-bridge discipline as `query_once`: the whole decision happens inside the
+    // callback and only plain owned data crosses the channel — never a `Retained<SCWindow>`
+    // (see module doc).
+    let block = RcBlock::new(
+        move |content_ptr: *mut SCShareableContent, err_ptr: *mut NSError| {
+            if content_ptr.is_null() {
+                let err = crate::ffi::classify_null_result(
+                    err_ptr,
+                    "SCShareableContent completion handler returned null content and null error",
+                );
+                let _ = tx.send(CandidateQueryReply::Failed(err));
+                return;
+            }
+            // SAFETY: `content_ptr` was just checked non-null; the framework guarantees it
+            // points to a live `SCShareableContent` for the duration of this callback.
+            let content: &SCShareableContent = unsafe { &*content_ptr };
+
+            let (found, candidates) =
+                scan_on_screen_windows(content, &pids_owned, Candidates::Collect);
+            let Some((w, pid)) = found else {
+                let _ = tx.send(CandidateQueryReply::NotFound);
+                return;
+            };
+            let _ = tx.send(CandidateQueryReply::Found(
+                window_match_from(&w, pid),
+                candidates,
+            ));
+        },
+    );
+
+    // SAFETY: `block` matches
+    // `getShareableContentExcludingDesktopWindows_onScreenWindowsOnly_completionHandler`'s
+    // documented signature (`*mut SCShareableContent, *mut NSError`, per the generated
+    // binding) — identical to `query_once`'s call. No other preconditions.
+    unsafe {
+        SCShareableContent::getShareableContentExcludingDesktopWindows_onScreenWindowsOnly_completionHandler(
+            true, true, &block,
+        );
+    }
+
+    match rx.recv_timeout(QUERY_TIMEOUT) {
+        Ok(CandidateQueryReply::Found(m, candidates)) => Ok(Some((m, candidates))),
+        Ok(CandidateQueryReply::NotFound) => Ok(None),
+        Ok(CandidateQueryReply::Failed(e)) => Err(e),
+        Err(mpsc::RecvTimeoutError::Timeout) => Ok(None),
+        Err(mpsc::RecvTimeoutError::Disconnected) => Err(GlassError::Backend(
+            "SCShareableContent completion handler was dropped without replying".into(),
+        )),
+    }
+}
+
+/// [`query_once_with_candidates`]'s channel payload — [`QueryReply`] plus the candidate
+/// summary on the found arm.
+enum CandidateQueryReply {
+    Found(WindowMatch, Vec<CandidateWindow>),
+    NotFound,
+    Failed(GlassError),
 }
 
 /// [`find_window_by_id`]'s per-attempt round trip — identical shape to [`query_once`] (same

--- a/crates/glass-macos/tests/window_adopt_probe.rs
+++ b/crates/glass-macos/tests/window_adopt_probe.rs
@@ -59,8 +59,8 @@ mod macos_main {
     const DEFAULT_RUNS: usize = 30;
 
     /// How many times to re-enumerate the app's windows after `start_app` returns, and the
-    /// gap between enumerations. Spread across ~1.5s so a window that appears (or vanishes) a
-    /// beat after adoption is still caught — the transient this probe is looking for.
+    /// gap between enumerations. Spread across ~1.25s (5 gaps) so a window that appears (or
+    /// vanishes) a beat after adoption is still caught — the transient this probe is looking for.
     const ENUMERATIONS: usize = 6;
     const ENUMERATION_GAP: Duration = Duration::from_millis(250);
 
@@ -141,16 +141,17 @@ mod macos_main {
                 let windows = platform
                     .list_windows()
                     .map_err(|e| format!("list_windows({run0}): {e}"))?;
-                println!("  t+{}ms: {} window(s)", enumeration * 250, windows.len());
+                println!(
+                    "  t+{}ms: {} window(s)",
+                    enumeration as u128 * ENUMERATION_GAP.as_millis(),
+                    windows.len()
+                );
                 for w in &windows {
-                    let tag = if w.geometry == adopted {
-                        "  == ADOPTED"
-                    } else {
-                        ""
-                    };
+                    let is_adopted = w.geometry == adopted;
+                    matched |= is_adopted;
+                    let tag = if is_adopted { "  == ADOPTED" } else { "" };
                     println!("    {}{tag}", render_window(w));
                 }
-                matched |= windows.iter().any(|w| w.geometry == adopted);
                 if enumeration + 1 < ENUMERATIONS {
                     std::thread::sleep(ENUMERATION_GAP);
                 }

--- a/crates/glass-macos/tests/window_adopt_probe.rs
+++ b/crates/glass-macos/tests/window_adopt_probe.rs
@@ -1,0 +1,214 @@
+//! Window-adoption PROBE for glass#263 — not a pass/fail assertion test. Launches an app
+//! repeatedly and, on each run, prints the window `start_app` adopted alongside every
+//! on-screen window the app's pid actually owns, then reports whether the accessibility
+//! reader could resolve the adopted window at all.
+//!
+//! It exists because `scwindow::find_on_screen_window` adopts the FIRST on-screen `SCWindow`
+//! in `SCShareableContent` order owned by the target pid — no filter on layer, size or title,
+//! and no ordering guarantee from the framework. On 2026-07-29 one run adopted a `468x101`
+//! window that matches no `AXWindow` Calculator owns, and the runs either side of it adopted
+//! the real `230x408` window. This probe's job is to say what that window is, with its title,
+//! rather than leave the next reader guessing.
+//!
+//! Asserts nothing about which window is correct. It fails a run only when an app could not be
+//! launched or enumerated at all — a real breakage, distinct from an app exposing something
+//! unexpected. Same convention as `role_probe.rs`.
+//!
+//! With `GLASS_WINDOW_PROBE_APP` unset (or set but empty), prints what to set and exits 0.
+//!
+//! **`harness = false`** (see `Cargo.toml`'s `[[test]] name = "window_adopt_probe"` entry):
+//! same reason as `capture.rs`/`input.rs`/`windows.rs`/`a11y.rs`/`bundle_launch.rs`/
+//! `role_probe.rs` — `MacosPlatform::start_app` reaches AppKit's `ffi::app_kit_init()`, which
+//! needs the process's TRUE main thread; libtest's per-`#[test]` worker threads can't provide
+//! that, so this file defines its own `fn main()`.
+//!
+//! Needs the same Accessibility (and Screen Recording, for `MacosPlatform::new`'s preflight)
+//! TCC grants as `tests/a11y.rs` — see that file's module doc for how a granted run supplies
+//! them.
+
+#[cfg(not(target_os = "macos"))]
+fn main() {
+    println!("skipped (not macOS)");
+}
+
+#[cfg(target_os = "macos")]
+fn main() {
+    macos_main::run();
+}
+
+#[cfg(target_os = "macos")]
+mod macos_main {
+    use std::time::Duration;
+
+    use glass_a11y_macos::MacosA11y;
+    use glass_core::{
+        Accessibility, AppSpec, AxContext, Platform, SandboxLevel, WalkLimits, WindowInfo,
+    };
+    use glass_macos::MacosPlatform;
+
+    /// The launch command to probe — a `.app` bundle path or a plain executable path, exactly
+    /// what `AppSpec::run`'s first element accepts (see `MacosPlatform::start_app`'s
+    /// bundle-vs-direct-spawn dispatch). Unset (or set but empty) skips the whole probe —
+    /// prints what to set, exits 0 — rather than failing a run that never asked for it.
+    const PROBE_APP_VAR: &str = "GLASS_WINDOW_PROBE_APP";
+
+    /// How many launch/enumerate/stop cycles to run. The adoption this probe hunts was seen
+    /// once across a handful of runs, so the default is high enough to give a rare event a
+    /// chance without needing an argument every time.
+    const PROBE_RUNS_VAR: &str = "GLASS_WINDOW_PROBE_RUNS";
+    const DEFAULT_RUNS: usize = 30;
+
+    /// How many times to re-enumerate the app's windows after `start_app` returns, and the
+    /// gap between enumerations. Spread across ~1.5s so a window that appears (or vanishes) a
+    /// beat after adoption is still caught — the transient this probe is looking for.
+    const ENUMERATIONS: usize = 6;
+    const ENUMERATION_GAP: Duration = Duration::from_millis(250);
+
+    /// Print a clear failure message and exit non-zero — the `harness = false` contract (no
+    /// libtest to format a panic for us). Mirrors the sibling integration tests.
+    fn fail(msg: impl AsRef<str>) -> ! {
+        eprintln!("FAIL: {}", msg.as_ref());
+        std::process::exit(1);
+    }
+
+    /// One window as one line: everything needed to tell a real app window from a transient
+    /// panel — its id, title, pixel geometry, and whether the backend considers it active.
+    fn render_window(w: &WindowInfo) -> String {
+        format!(
+            "id={} {} {}x{} @({},{}){}",
+            w.id.0,
+            w.title
+                .as_deref()
+                .map_or_else(|| "<untitled>".to_string(), |t| format!("{t:?}")),
+            w.geometry.width,
+            w.geometry.height,
+            w.geometry.x,
+            w.geometry.y,
+            if w.active { " ACTIVE" } else { "" }
+        )
+    }
+
+    /// Run `body`, then always call `platform.stop_app()` afterward regardless of whether
+    /// `body` succeeded — mirrors `tests/role_probe.rs`'s identically-named helper.
+    fn with_stop_app<T>(
+        platform: &mut MacosPlatform,
+        label: &str,
+        body: impl FnOnce(&mut MacosPlatform) -> Result<T, String>,
+    ) -> Result<T, String> {
+        let result = body(platform);
+        let stop_result = platform.stop_app();
+        match result {
+            Ok(v) => stop_result
+                .map(|()| v)
+                .map_err(|e| format!("stop_app({label}): {e}")),
+            Err(e) => {
+                if let Err(stop_err) = stop_result {
+                    eprintln!("(additionally) stop_app({label}) failed: {stop_err}");
+                }
+                Err(e)
+            }
+        }
+    }
+
+    /// One launch/enumerate/stop cycle. `Ok(true)` means the adopted geometry matched at least
+    /// one window the app's pid actually owns during the enumeration window; `Ok(false)` is the
+    /// condition this probe hunts. `Err` is a real breakage — the app would not launch, or its
+    /// windows could not be enumerated at all.
+    fn probe_once(run0: &str, run_index: usize) -> Result<bool, String> {
+        let mut platform =
+            MacosPlatform::new().map_err(|e| format!("MacosPlatform::new(): {e}"))?;
+
+        let spec = AppSpec {
+            build: None,
+            run: vec![run0.to_string()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 15_000,
+            sandbox: SandboxLevel::Off,
+            a11y: false,
+        };
+
+        with_stop_app(&mut platform, run0, |platform| {
+            let adopted = platform
+                .start_app(&spec)
+                .map_err(|e| format!("start_app({run0}): {e}"))?;
+            println!("\n===== run {run_index} =====");
+            println!("adopted: {adopted:?}");
+
+            let mut matched = false;
+            for enumeration in 0..ENUMERATIONS {
+                let windows = platform
+                    .list_windows()
+                    .map_err(|e| format!("list_windows({run0}): {e}"))?;
+                println!("  t+{}ms: {} window(s)", enumeration * 250, windows.len());
+                for w in &windows {
+                    let tag = if w.geometry == adopted {
+                        "  == ADOPTED"
+                    } else {
+                        ""
+                    };
+                    println!("    {}{tag}", render_window(w));
+                }
+                matched |= windows.iter().any(|w| w.geometry == adopted);
+                std::thread::sleep(ENUMERATION_GAP);
+            }
+
+            // The symptom the issue reports: whether the reader can resolve the window the
+            // backend adopted. Never fatal — a `WindowNotFound` here is the finding, not a
+            // probe breakage.
+            let ctx = AxContext {
+                pids: platform.app_pids(),
+                window: adopted,
+                window_handle: None,
+                a11y_bus_addr: None,
+                limits: WalkLimits::from_max_nodes(Some(0)),
+            };
+            match MacosA11y::new().snapshot(&ctx) {
+                Ok(_) => println!("  snapshot: ok"),
+                Err(e) => println!("  snapshot: FAILED: {e}"),
+            }
+
+            if !matched {
+                println!("  VERDICT: adopted geometry matched NO window owned by this pid");
+            }
+            Ok(matched)
+        })
+    }
+
+    pub(super) fn run() {
+        let run0 = match std::env::var(PROBE_APP_VAR) {
+            Ok(v) if !v.trim().is_empty() => v.trim().to_string(),
+            _ => {
+                println!(
+                    "skipped: set {PROBE_APP_VAR} to a launch command (a .app bundle path or an \
+                     executable path) to probe, e.g. \
+                     {PROBE_APP_VAR}=/System/Applications/Calculator.app"
+                );
+                std::process::exit(0);
+            }
+        };
+        let runs = std::env::var(PROBE_RUNS_VAR)
+            .ok()
+            .and_then(|v| v.trim().parse::<usize>().ok())
+            .filter(|n| *n > 0)
+            .unwrap_or(DEFAULT_RUNS);
+
+        let mut mismatches = 0usize;
+        let mut failures = Vec::new();
+        for run_index in 1..=runs {
+            match probe_once(&run0, run_index) {
+                Ok(true) => {}
+                Ok(false) => mismatches += 1,
+                Err(e) => failures.push(format!("run {run_index}: {e}")),
+            }
+        }
+
+        if !failures.is_empty() {
+            fail(failures.join("\n\n"));
+        }
+        println!("\n{mismatches} of {runs} run(s) adopted a geometry matching no listed window");
+        println!("WINDOW_ADOPT_PROBE_PASS");
+        std::process::exit(0);
+    }
+}

--- a/crates/glass-macos/tests/window_adopt_probe.rs
+++ b/crates/glass-macos/tests/window_adopt_probe.rs
@@ -3,12 +3,25 @@
 //! on-screen window the app's pid actually owns, then reports whether the accessibility
 //! reader could resolve the adopted window at all.
 //!
-//! It exists because `scwindow::find_on_screen_window` adopts the FIRST on-screen `SCWindow`
-//! in `SCShareableContent` order owned by the target pid — no filter on layer, size or title,
-//! and no ordering guarantee from the framework. On 2026-07-29 one run adopted a `468x101`
-//! window that matches no `AXWindow` Calculator owns, and the runs either side of it adopted
-//! the real `230x408` window. This probe's job is to say what that window is, with its title,
-//! rather than leave the next reader guessing.
+//! It exists because `scwindow::scan_on_screen_windows` (reached via `backend::discover_window`
+//! -> `scwindow::query_once_with_candidates` -> `scwindow::query_once_inner`) adopts the FIRST
+//! on-screen `SCWindow` in `SCShareableContent` order owned by the target pid — no filter on
+//! layer, size or title, and no ordering guarantee from the framework. On 2026-07-29 one run
+//! adopted a `468x101` window that matches no `AXWindow` Calculator owns, and the runs either
+//! side of it adopted the real `230x408` window. This probe's job is to say what that window
+//! is, with its title, rather than leave the next reader guessing.
+//!
+//! **A `.app` bundle already running is adopted, not launched — read this before trusting a
+//! sweep.** `MacosPlatform::start_app`'s bundle branch hands off to `NSWorkspace`/
+//! LaunchServices: if an instance of the app is already running, that instance is adopted and
+//! raised rather than spawned fresh, and `stop_app` deliberately leaves a pre-existing adoptee
+//! running (glass only raised it, so it isn't glass's to kill — see `backend.rs`'s
+//! `Adopted`/`Disposition` doc). A sweep run against an app that's already open therefore
+//! re-adopts the SAME process every run, not N independent launches, and never re-tests a
+//! fresh-launch race. To probe cold launches, quit the target app completely before starting
+//! the sweep and again between sweeps; the per-run pid this probe prints, and the summary's
+//! distinct-pid count, are how to tell a cold-launch sweep from a re-adoption one after the
+//! fact.
 //!
 //! Asserts nothing about which window is correct. It fails a run only when an app could not be
 //! launched or enumerated at all — a real breakage, distinct from an app exposing something
@@ -110,11 +123,20 @@ mod macos_main {
         }
     }
 
-    /// One launch/enumerate/stop cycle. `Ok(true)` means the adopted geometry matched at least
-    /// one window the app's pid actually owns during the enumeration window; `Ok(false)` is the
-    /// condition this probe hunts. `Err` is a real breakage — the app would not launch, or its
-    /// windows could not be enumerated at all.
-    fn probe_once(run0: &str, run_index: usize) -> Result<bool, String> {
+    /// One run's outcome: whether the adopted geometry matched a window the app's pid actually
+    /// owns, whether the accessibility reader could resolve the adopted window at all (#263's
+    /// actual symptom), and the pid `start_app` reported — needed to tell a cold launch from a
+    /// re-adoption of an already-running process (see the module doc's caveat).
+    struct RunOutcome {
+        matched: bool,
+        snapshot_ok: bool,
+        pid: Option<u32>,
+    }
+
+    /// One launch/enumerate/stop cycle. `Err` is a real breakage — the app would not launch, or
+    /// its windows could not be enumerated at all — distinct from either field of `RunOutcome`
+    /// being the unwelcome value, which is a finding, not a probe failure.
+    fn probe_once(run0: &str, run_index: usize) -> Result<RunOutcome, String> {
         let mut platform =
             MacosPlatform::new().map_err(|e| format!("MacosPlatform::new(): {e}"))?;
 
@@ -133,7 +155,12 @@ mod macos_main {
             let adopted = platform
                 .start_app(&spec)
                 .map_err(|e| format!("start_app({run0}): {e}"))?;
+            let pid = platform.app_pids().first().copied();
             println!("\n===== run {run_index} =====");
+            println!(
+                "pid: {}",
+                pid.map_or_else(|| "?".to_string(), |p| p.to_string())
+            );
             println!("adopted: {adopted:?}");
 
             let mut matched = false;
@@ -169,15 +196,25 @@ mod macos_main {
                 // not tree size — cap at 1 node instead of paying for the full tree.
                 limits: WalkLimits::from_max_nodes(Some(1)),
             };
-            match MacosA11y::new().snapshot(&ctx) {
-                Ok(_) => println!("  snapshot: ok"),
-                Err(e) => println!("  snapshot: FAILED: {e}"),
-            }
+            let snapshot_ok = match MacosA11y::new().snapshot(&ctx) {
+                Ok(_) => {
+                    println!("  snapshot: ok");
+                    true
+                }
+                Err(e) => {
+                    println!("  snapshot: FAILED: {e}");
+                    false
+                }
+            };
 
             if !matched {
                 println!("  VERDICT: adopted geometry matched NO window owned by this pid");
             }
-            Ok(matched)
+            Ok(RunOutcome {
+                matched,
+                snapshot_ok,
+                pid,
+            })
         })
     }
 
@@ -200,11 +237,20 @@ mod macos_main {
             .unwrap_or(DEFAULT_RUNS);
 
         let mut mismatches = 0usize;
+        let mut snapshot_failures = 0usize;
+        let mut pids_seen = std::collections::HashSet::new();
         let mut failures = Vec::new();
         for run_index in 1..=runs {
             match probe_once(&run0, run_index) {
-                Ok(true) => {}
-                Ok(false) => mismatches += 1,
+                Ok(outcome) => {
+                    if !outcome.matched {
+                        mismatches += 1;
+                    }
+                    if !outcome.snapshot_ok {
+                        snapshot_failures += 1;
+                    }
+                    pids_seen.extend(outcome.pid);
+                }
                 Err(e) => failures.push(format!("run {run_index}: {e}")),
             }
         }
@@ -212,7 +258,15 @@ mod macos_main {
         if !failures.is_empty() {
             fail(failures.join("\n\n"));
         }
-        println!("\n{mismatches} of {runs} run(s) adopted a geometry matching no listed window");
+        // Both counts and the distinct-pid tally live in one line so a `0 of N` mismatch count
+        // can never be read alone — see the module doc: a low distinct-pid count means most of
+        // `runs` re-adopted the same already-running process rather than launching fresh.
+        println!(
+            "\n{mismatches} of {runs} run(s) adopted a geometry matching no listed window; \
+             {snapshot_failures} of {runs} run(s) failed the accessibility snapshot; \
+             {} distinct pid(s) seen across {runs} run(s)",
+            pids_seen.len()
+        );
         println!("WINDOW_ADOPT_PROBE_PASS");
         std::process::exit(0);
     }

--- a/crates/glass-macos/tests/window_adopt_probe.rs
+++ b/crates/glass-macos/tests/window_adopt_probe.rs
@@ -151,7 +151,9 @@ mod macos_main {
                     println!("    {}{tag}", render_window(w));
                 }
                 matched |= windows.iter().any(|w| w.geometry == adopted);
-                std::thread::sleep(ENUMERATION_GAP);
+                if enumeration + 1 < ENUMERATIONS {
+                    std::thread::sleep(ENUMERATION_GAP);
+                }
             }
 
             // The symptom the issue reports: whether the reader can resolve the window the
@@ -162,7 +164,9 @@ mod macos_main {
                 window: adopted,
                 window_handle: None,
                 a11y_bus_addr: None,
-                limits: WalkLimits::from_max_nodes(Some(0)),
+                // Only Ok/Err is read below, and that outcome turns on root window resolution,
+                // not tree size — cap at 1 node instead of paying for the full tree.
+                limits: WalkLimits::from_max_nodes(Some(1)),
             };
             match MacosA11y::new().snapshot(&ctx) {
                 Ok(_) => println!("  snapshot: ok"),

--- a/crates/glass-macos/tests/window_adopt_probe.rs
+++ b/crates/glass-macos/tests/window_adopt_probe.rs
@@ -3,25 +3,27 @@
 //! on-screen window the app's pid actually owns, then reports whether the accessibility
 //! reader could resolve the adopted window at all.
 //!
-//! It exists because `scwindow::scan_on_screen_windows` (reached via `backend::discover_window`
-//! -> `scwindow::query_once_with_candidates` -> `scwindow::query_once_inner`) adopts the FIRST
+//! It exists because `scwindow::scan_on_screen_windows` (reached via
+//! `backend::discover_window_pid` -> `scwindow::query_once_with_candidates` ->
+//! `scwindow::query_once_inner`) adopts the FIRST
 //! on-screen `SCWindow` in `SCShareableContent` order owned by the target pid — no filter on
 //! layer, size or title, and no ordering guarantee from the framework. On 2026-07-29 one run
 //! adopted a `468x101` window that matches no `AXWindow` Calculator owns, and the runs either
 //! side of it adopted the real `230x408` window. This probe's job is to say what that window
 //! is, with its title, rather than leave the next reader guessing.
 //!
-//! **A `.app` bundle already running is adopted, not launched — read this before trusting a
-//! sweep.** `MacosPlatform::start_app`'s bundle branch hands off to `NSWorkspace`/
-//! LaunchServices: if an instance of the app is already running, that instance is adopted and
-//! raised rather than spawned fresh, and `stop_app` deliberately leaves a pre-existing adoptee
-//! running (glass only raised it, so it isn't glass's to kill — see `backend.rs`'s
-//! `Adopted`/`Disposition` doc). A sweep run against an app that's already open therefore
-//! re-adopts the SAME process every run, not N independent launches, and never re-tests a
-//! fresh-launch race. To probe cold launches, quit the target app completely before starting
-//! the sweep and again between sweeps; the per-run pid this probe prints, and the summary's
-//! distinct-pid count, are how to tell a cold-launch sweep from a re-adoption one after the
-//! fact.
+//! **Whether a `.app` bundle launches fresh or gets adopted depends on the path — read this before
+//! trusting a sweep.** Apple platform code (e.g. Calculator, this probe's own example) hands off
+//! straight to `NSWorkspace`/LaunchServices; a third-party bundle direct-spawns its inner
+//! executable first, reaching LaunchServices only if that spawn exits before a window appears
+//! (`start_bundle`'s doc). Either way, an instance already running at handoff is adopted and
+//! raised, not spawned fresh, and `stop_app` deliberately leaves a pre-existing adoptee running
+//! (glass only raised it, so it isn't glass's to kill — see `backend.rs`'s `Adopted`/`Disposition`
+//! doc). A sweep against an app that's already open can therefore re-adopt the SAME process every
+//! run, not N independent launches, and never re-test a fresh-launch race. To probe cold launches,
+//! quit the target app completely before starting the sweep and again between sweeps; the per-run
+//! pid this probe prints, and the summary's distinct-pid count, are how to tell a cold-launch sweep
+//! from a re-adoption one after the fact.
 //!
 //! Asserts nothing about which window is correct. It fails a run only when an app could not be
 //! launched or enumerated at all — a real breakage, distinct from an app exposing something


### PR DESCRIPTION
## What this closes

Closes #263 item 2 (window-adoption diagnostics) and instruments item 1 (`select_window`'s no-match diagnostic), so a future occurrence of either symptom is diagnosable from stderr instead of costing another investigation.

- **`select_window`'s candidate lines** (`glass-a11y-macos/src/reader.rs`, rendered by the new `select_diagnostic.rs`) now carry each candidate's `AXRole` and the raw `AXError` behind a failed read, not just its geometry.
- **Window adoption** (`glass-macos/src/backend.rs`/`scwindow.rs`, rendered by the new `adoption_log.rs`) now prints which on-screen window it took, out of what else the target pid owned, in the order `SCShareableContent` offered them — from the content the adoption query already holds, so the hot path is unchanged.
- **`WindowNotFound`**'s message no longer asserts a single cause it cannot know, and speaks in terms every backend shares rather than macOS's "adoption" vocabulary (see Review below).
- A new `harness = false` probe, `glass-macos/tests/window_adopt_probe.rs`, launches an app repeatedly and prints the adopted geometry beside every on-screen window the pid actually owns — the tool built to chase down item 1.

## What the probe found

The probe ran 90 times on mini (30× Calculator, 60× TextEdit) and found **no reproduction** of the 2026-07-29 mis-adoption — every run's adopted window matched a real on-screen window owned by the pid.

**That claim needs a caveat this branch's own review caught: none of the 90 runs was a cold launch.** Both apps were already running on mini before either sweep started (Calculator since Wed Jul 29 16:18, TextEdit since 16:19). `MacosPlatform::start_app`'s `.app`-bundle branch hands off to `NSWorkspace`/LaunchServices, which *adopts and raises* an already-running instance rather than spawning one, and `stop_app` deliberately leaves that pre-existing instance running (it isn't glass's to kill). So every run in both sweeps re-adopted the *same* pre-existing process — the Calculator sweep's adoption line is byte-identical across all 30 runs (same pid, same window id 916), and the 60-run TextEdit sweep saw exactly one distinct window id. **The 2026-07-29 mis-adoption happened at a fresh launch, which these 90 runs never re-tested.** The probe (this PR) now prints each run's pid and a distinct-pid count in its summary so a sweep against an already-open app can't be mistaken for 90 independent launches again — see `window_adopt_probe.rs`'s module doc for what an operator must do to force cold launches.

Given that, the plan's conditional adoption-policy change (row 3 in the plan's decision table: only change adoption behavior if the probe reproduces evidence of a bad pick) is still **deliberately not made** — but not on the strength of "no reproduction across 90 runs" anymore. The real reason is that there is still no identified window to filter on: the one incident on record gives no title/layer/size heuristic that distinguishes the bad pick from the good one, so any policy change now would be a guess, cold-launch evidence or not. The probe stays in the tree, now honest about what a re-adoption sweep can and cannot tell you, so the next occurrence gets diagnosed with data.

## Verified on mini (macOS 26.5.2, arm64)

- `./scripts/test-macos-a11y.sh` — exit 0
- `cargo clippy -p glass-macos -p glass-a11y-macos --all-targets -- -D warnings` — clean
- `GLASS_WINDOW_PROBE_APP=/System/Applications/Calculator.app GLASS_WINDOW_PROBE_RUNS=30 cargo test -p glass-macos --test window_adopt_probe` and the same against TextEdit at 60 runs — adoption diagnostic printed in 15/15 sampled runs, 0/90 mismatches
- The granted `tests/a11y.rs` integration suite — 4/4 passed

Evidence: https://github.com/fixed-width/glass/issues/263#issuecomment-5152904402

## Review

Before opening this PR: `rust-best-practices` over every Rust file the branch touched (no additional code-level findings beyond conventions already followed), `terse-comments` (three passes: the whole branch diff, the pr-review-toolkit fix wave, and this last fix), and the `pr-review-toolkit` panel (code-reviewer, comment-analyzer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer, code-simplifier) against the local diff. Every finding was triaged — fixed where it was comment/test-only or provably behavior-preserving (verified: `select_diagnostic.rs`'s pinned-string tests still pass byte-for-byte after refactoring), reported rather than silently applied where a real fix would touch behavior.

The most substantial finding, flagged independently by four of the six reviewers: `WindowNotFound`'s message and doc comment described the macOS multi-candidate-adoption scenario ("the window it opened is not the one glass adopted", "matching the expected geometry") as if it applied everywhere, but `WindowNotFound` is raised by all six backends — most of them (X11, Wayland, Windows, Android, iOS) for reasons that have nothing to do with geometry or "adoption," a concept only macOS's `start_app` discovery has. **Fixed**, since this branch already owns that string (Task 4): both the `#[error]` text and its doc comment now state the two causes in backend-neutral terms (the app may not have opened its window yet, or the window glass is targeting is no longer one of its windows), and the doc explains why the ambiguity is structural to every backend's resolver rather than leaning on the `#263` reference alone. `rg` over the tree confirms nothing else quoted the old wording.

## Gates

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` — all clean on this box. The macOS-only code (`scwindow.rs`, `window_adopt_probe.rs`'s macOS module) additionally cross-checked clean via `cargo clippy --target x86_64-apple-darwin -p glass-macos -p glass-a11y-macos --all-targets -- -D warnings`, since this box can't build glass-macos natively. The pre-existing structural gap that blocks a *workspace-wide* build on macOS (`glass-wayland` → `smithay-client-toolkit` → pinned `rustix 1.1.4` not exporting `pipe_with`/`PipeFlags` for apple targets) is untouched by this branch.

## Final fix wave

A whole-branch review plus one controller-found issue, all addressed:

- The cold-launch gap above (probe now prints per-run pid + a distinct-pid count).
- `probe_once` was aggregating SCWindow self-consistency (`matched`) only; the accessibility-snapshot outcome (#263's actual symptom) was printed per run but never counted. Both signals now flow through a `RunOutcome` and land in the summary line.
- `select_diagnostic.rs`'s `SizeUnreadable`/`PositionUnreadable` fixtures were missing the `"backend error: "` prefix `GlassError::Backend`'s `Display` adds — traced `ffi::ax_size`/`ax_position` through every `GlassError` path they can return and confirmed `select_window` builds the diagnostic string via `e.to_string()`, so the prefix is real; fixtures now match.
- The probe's module doc still credited `find_on_screen_window` with adoption after this branch's own refactor moved it to `scan_on_screen_windows`; renamed and traced the actual call chain.
- The CHANGELOG entry named `select_window`, which collides with the public `glass_select_window` MCP tool; reworded to describe the effect instead of the (private, unrelated) symbol.
- Removed a `debug_assert!` inside the `RcBlock` ScreenCaptureKit invokes on its own queue (`scwindow.rs`) — block2's trampoline is `extern "C"`, so a panic there aborts the process. The invariant it checked is true by construction (`adopted = found.is_none()` in `scan_on_screen_windows`), so the assert added no protection; a comment states the invariant instead.
- `reader.rs`'s no-match diagnostic joined candidate lines with `", "` while each line can itself contain commas; aligned to `adoption_log::adoption_line`'s `"; "`.
- Dropped the "cost an hour"/incident-narration framing from `select_diagnostic.rs`'s comments (the same call this branch already made in `error.rs`), keeping the load-bearing withheld-tree/`AXApplication` technical content.

None of this changes production behavior — comment/test/doc text, one summary-line format change in a `harness = false` probe, and one dead-assert removal. Re-ran all three gates plus the darwin-target clippy after every change; the `terse-comments` skill was run over this wave's diff as its own pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

