### PR TITLE
fix(macos): report the adopted window's settled geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,12 @@ internal refactors, CI, or test-only changes.
   Android paths have no such live check.
 
 ### Fixed
+- On macOS, `glass_start` now reports a window's settled geometry rather than a frame of its
+  opening animation. It used to return whatever geometry it read the instant it found the newly
+  launched window; measured across cold launches, that geometry disagreed with the window's
+  settled size in 11 of 12 runs. It now waits for two consecutive readings to agree before
+  returning. X11 and Wayland were measured and don't race this way, so the fix stays macOS-only;
+  Windows, Android and iOS were not measured.
 - A `glass_wait_for_element` shorter than a second could report an element absent that was on
   screen. Where the platform announces changes, the wait skips reads it has been told are pointless
   and reads anyway once a second in case it was told wrong — but that second was previously counted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,8 +195,9 @@ internal refactors, CI, or test-only changes.
   opening animation. It used to return whatever geometry it read the instant it found the newly
   launched window; measured across cold launches, that geometry disagreed with the window's
   settled size in 11 of 12 runs. It now waits for two consecutive readings to agree before
-  returning. X11 and Wayland were measured and don't race this way, so the fix stays macOS-only;
-  Windows, Android and iOS were not measured.
+  returning. X11 and Wayland were measured against a fixed-size test fixture with no opening
+  animation and didn't race this way there, so the fix stays macOS-only; Windows, Android and iOS
+  were not measured.
 - A `glass_wait_for_element` shorter than a second could report an element absent that was on
   screen. Where the platform announces changes, the wait skips reads it has been told are pointless
   and reads anyway once a second in case it was told wrong — but that second was previously counted

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -23,7 +23,7 @@ use crate::clipboard_route::ClipboardRoute;
 use crate::coords;
 use crate::permissions;
 use crate::process::{self, ClipLaunch, LogSink};
-use crate::settle::{SettleStep, SettleTracker};
+use crate::settle::{SettleOutcome, settle_by_polling};
 
 /// Poll interval between discovery attempts in [`MacosPlatform::discover_window`] —
 /// matches `scwindow::find_window_for_pids`'s own poll cadence
@@ -42,14 +42,19 @@ const WINDOW_RESOLVE_TIMEOUT: Duration = Duration::from_millis(2000);
 
 /// How often to re-read an adopted window's geometry while waiting for it to stop changing, and
 /// how long to keep waiting. macOS reports a window's geometry while it is still opening, so the
-/// reading adoption captured is routinely a frame of the open animation (#263). A window that was
-/// never animating agrees on its second reading and costs one interval; the budget only binds an
-/// app whose window keeps moving.
+/// reading adoption captured is routinely a frame of the open animation (#263). A window that had
+/// already stopped moving needs only one more round trip to confirm it — a `SETTLE_POLL_INTERVAL`
+/// sleep plus one `SCShareableContent` query, ~70-125ms as measured on this branch — but that was
+/// the minority case: 11 of 12 cold launches measured here were still moving at adoption and paid
+/// a second round trip (~140-250ms) before settling. The budget bounds a window that never stops
+/// moving at all (a clock, a video player, an animating splash).
 const SETTLE_POLL_INTERVAL: Duration = Duration::from_millis(25);
 const SETTLE_BUDGET: Duration = Duration::from_millis(500);
-/// Per-poll resolution bound, deliberately far below [`WINDOW_RESOLVE_TIMEOUT`]: a settle poll that
-/// cannot find the window should give the loop its turn back, not spend the whole budget inside one
-/// lookup.
+/// Per-poll resolution bound, deliberately far below [`WINDOW_RESOLVE_TIMEOUT`]: a settle poll
+/// that cannot find the window ends the settle attempt outright rather than retrying (see
+/// [`crate::settle::settle_by_polling`]'s `ReadFailed` handling), so this only bounds how long
+/// that one lookup burns before giving up — not the whole `SETTLE_BUDGET`, which it is
+/// deliberately kept far below.
 const SETTLE_RESOLVE_TIMEOUT: Duration = Duration::from_millis(200);
 
 /// Read-back tolerance (pixels) [`MacosPlatform::window`]'s mutating ops use to decide
@@ -276,10 +281,14 @@ impl MacosPlatform {
     /// pixels off the settled one, and the window `start_app` reports is what
     /// `Glass::start_on_inner` hands the caller and caches as the session's geometry.
     ///
-    /// Never fails the launch. A window that never stops changing (a clock, a video player, an
-    /// animating splash) would otherwise become unlaunchable, so an expired budget returns the
-    /// freshest reading and says so on stderr; likewise a resolve that fails mid-settle, where the
-    /// window was already confirmed present at adoption. Neither path is silent.
+    /// Thin glue over [`settle_by_polling`]: this only builds the per-poll re-resolution closure
+    /// (fixed to `adopted`'s `window_id`/`pid`, since a re-resolved match always carries the same
+    /// two — `find_window_by_id` is what pins them) and turns its [`SettleOutcome`] into the
+    /// stderr disclosure. Never fails the launch: a window that never stops changing (a clock, a
+    /// video player, an animating splash) would otherwise become unlaunchable, so a budget expiry
+    /// reports the freshest reading rather than an error, and likewise a resolve that fails
+    /// mid-settle, where the window was already confirmed present at adoption. Neither path is
+    /// silent.
     ///
     /// Only *when* the geometry is read changes here. Which window was adopted is already decided
     /// by the time this runs.
@@ -287,45 +296,29 @@ impl MacosPlatform {
         pid: i32,
         adopted: crate::scwindow::WindowMatch,
     ) -> crate::scwindow::WindowMatch {
-        let mut tracker = SettleTracker::new();
-        // The adoption reading is the sequence's first element: it is what a settled window has to
-        // agree with for the loop to exit after a single poll.
-        let _ = tracker.observe(adopted.geometry.clone());
-        let mut freshest = adopted;
-        let deadline = Instant::now() + SETTLE_BUDGET;
-        while Instant::now() < deadline {
-            std::thread::sleep(SETTLE_POLL_INTERVAL);
-            let next = match crate::scwindow::find_window_by_id(
+        let window_id = adopted.window_id;
+        let (freshest, outcome) =
+            settle_by_polling(adopted, SETTLE_BUDGET, SETTLE_POLL_INTERVAL, || {
+                crate::scwindow::find_window_by_id(window_id, &[pid], SETTLE_RESOLVE_TIMEOUT)
+            });
+        match outcome {
+            SettleOutcome::Settled => {}
+            SettleOutcome::ReadFailed(e) => eprintln!(
+                "glass-macos: window {} stopped resolving while settling ({e}); reporting the \
+                 last geometry read",
+                freshest.window_id
+            ),
+            SettleOutcome::BudgetExpired => eprintln!(
+                "glass-macos: window {} did not settle within {}ms; reporting {}x{} @({},{}), \
+                 the last geometry read",
                 freshest.window_id,
-                &[pid],
-                SETTLE_RESOLVE_TIMEOUT,
-            ) {
-                Ok(m) => m,
-                Err(e) => {
-                    eprintln!(
-                        "glass-macos: window {} stopped resolving while settling ({e}); \
-                         reporting the last geometry read",
-                        freshest.window_id
-                    );
-                    return freshest;
-                }
-            };
-            let geometry = next.geometry.clone();
-            freshest = next;
-            if let SettleStep::Settled(_) = tracker.observe(geometry) {
-                return freshest;
-            }
+                SETTLE_BUDGET.as_millis(),
+                freshest.geometry.width,
+                freshest.geometry.height,
+                freshest.geometry.x,
+                freshest.geometry.y
+            ),
         }
-        eprintln!(
-            "glass-macos: window {} did not settle within {}ms; reporting {}x{} @({},{}), \
-             the last geometry read",
-            freshest.window_id,
-            SETTLE_BUDGET.as_millis(),
-            freshest.geometry.width,
-            freshest.geometry.height,
-            freshest.geometry.x,
-            freshest.geometry.y
-        );
         freshest
     }
 

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -290,6 +290,14 @@ impl MacosPlatform {
     /// mid-settle, where the window was already confirmed present at adoption. Neither path is
     /// silent.
     ///
+    /// Settles on `geometry` alone, not the whole [`crate::scwindow::WindowMatch`] — `geometry`
+    /// is rounded-to-pixel (`(v * scale).round()`), but `WindowMatch::origin_pt` is the raw
+    /// unrounded point origin it was rounded from, so two readings can agree on `geometry` while
+    /// `origin_pt` keeps drifting inside the same pixel. Comparing the whole match would make
+    /// that drift block settling forever for a window whose on-screen geometry had already
+    /// stopped changing (#263 review). The closure captures every other field of the freshest
+    /// successful read in `freshest` as it goes, so the returned match still carries them.
+    ///
     /// Only *when* the geometry is read changes here. Which window was adopted is already decided
     /// by the time this runs.
     fn settle_window(
@@ -297,10 +305,27 @@ impl MacosPlatform {
         adopted: crate::scwindow::WindowMatch,
     ) -> crate::scwindow::WindowMatch {
         let window_id = adopted.window_id;
-        let (freshest, outcome) =
-            settle_by_polling(adopted, SETTLE_BUDGET, SETTLE_POLL_INTERVAL, || {
-                crate::scwindow::find_window_by_id(window_id, &[pid], SETTLE_RESOLVE_TIMEOUT)
+        let seed_geometry = adopted.geometry.clone();
+        let mut freshest = adopted;
+        let (geometry, outcome) =
+            settle_by_polling(seed_geometry, SETTLE_BUDGET, SETTLE_POLL_INTERVAL, || {
+                // `.map`, not `?`: `?` asks for `E: From<GlassError>` and leaves `E` itself
+                // unconstrained (`settle_by_polling`'s `E` is otherwise only ever produced, never
+                // consumed), which `rustc` can't resolve on its own. `.map` keeps the `Result`'s
+                // error type exactly `GlassError`, pinning `E` without a turbofish.
+                crate::scwindow::find_window_by_id(window_id, &[pid], SETTLE_RESOLVE_TIMEOUT).map(
+                    |m| {
+                        let geometry = m.geometry.clone();
+                        freshest = m;
+                        geometry
+                    },
+                )
             });
+        // `freshest.geometry` already equals `geometry` on every path (both come from the same
+        // read, or neither read ever succeeded and both are still the seed) — stated explicitly
+        // rather than relied upon, and it's what makes `geometry` itself worth naming instead of
+        // discarding.
+        freshest.geometry = geometry;
         match outcome {
             SettleOutcome::Settled => {}
             SettleOutcome::ReadFailed(e) => eprintln!(

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -50,11 +50,13 @@ const WINDOW_RESOLVE_TIMEOUT: Duration = Duration::from_millis(2000);
 /// moving at all (a clock, a video player, an animating splash).
 const SETTLE_POLL_INTERVAL: Duration = Duration::from_millis(25);
 const SETTLE_BUDGET: Duration = Duration::from_millis(500);
-/// Per-poll resolution bound, deliberately far below [`WINDOW_RESOLVE_TIMEOUT`]: a settle poll
-/// that cannot find the window ends the settle attempt outright rather than retrying (see
-/// [`crate::settle::settle_by_polling`]'s `ReadFailed` handling), so this only bounds how long
-/// that one lookup burns before giving up — not the whole `SETTLE_BUDGET`, which it is
-/// deliberately kept far below.
+/// Per-poll resolution bound, deliberately far below [`WINDOW_RESOLVE_TIMEOUT`] (a tenth of it):
+/// a settle poll that cannot find the window ends the settle attempt outright rather than
+/// retrying (see [`crate::settle::settle_by_polling`]'s `ReadFailed` handling), so this only
+/// bounds how long that one lookup burns before giving up. `settle_by_polling` checks its
+/// deadline only between reads, never mid-read, so `SETTLE_BUDGET` is a soft cap: a resolve
+/// that runs close to this full timeout right before the deadline can push actual elapsed time
+/// past `SETTLE_BUDGET` by nearly as much.
 const SETTLE_RESOLVE_TIMEOUT: Duration = Duration::from_millis(200);
 
 /// Read-back tolerance (pixels) [`MacosPlatform::window`]'s mutating ops use to decide
@@ -278,12 +280,12 @@ impl MacosPlatform {
     ///
     /// Adoption reads the window's geometry the moment it finds it, which on macOS is routinely
     /// mid-open-animation — 11 of 12 cold launches measured on 2026-08-01 returned a geometry a few
-    /// pixels off the settled one, and the window `start_app` reports is what
+    /// pixels off the settled one, and the geometry `start_app` reports for it is what
     /// `Glass::start_on_inner` hands the caller and caches as the session's geometry.
     ///
     /// Thin glue over [`settle_by_polling`]: this only builds the per-poll re-resolution closure
-    /// (fixed to `adopted`'s `window_id`/`pid`, since a re-resolved match always carries the same
-    /// two — `find_window_by_id` is what pins them) and turns its [`SettleOutcome`] into the
+    /// (fixed to `window_id` and `pid`, since a re-resolved match always carries the same two —
+    /// `find_window_by_id` is what pins them) and turns its [`SettleOutcome`] into the
     /// stderr disclosure. Never fails the launch: a window that never stops changing (a clock, a
     /// video player, an animating splash) would otherwise become unlaunchable, so a budget expiry
     /// reports the freshest reading rather than an error, and likewise a resolve that fails
@@ -329,9 +331,13 @@ impl MacosPlatform {
         match outcome {
             SettleOutcome::Settled => {}
             SettleOutcome::ReadFailed(e) => eprintln!(
-                "glass-macos: window {} stopped resolving while settling ({e}); reporting the \
-                 last geometry read",
-                freshest.window_id
+                "glass-macos: window {} stopped resolving while settling ({e}); reporting {}x{} \
+                 @({},{}), the last geometry read",
+                freshest.window_id,
+                freshest.geometry.width,
+                freshest.geometry.height,
+                freshest.geometry.x,
+                freshest.geometry.y
             ),
             SettleOutcome::BudgetExpired => eprintln!(
                 "glass-macos: window {} did not settle within {}ms; reporting {}x{} @({},{}), \

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -23,6 +23,7 @@ use crate::clipboard_route::ClipboardRoute;
 use crate::coords;
 use crate::permissions;
 use crate::process::{self, ClipLaunch, LogSink};
+use crate::settle::{SettleStep, SettleTracker};
 
 /// Poll interval between discovery attempts in [`MacosPlatform::discover_window`] —
 /// matches `scwindow::find_window_for_pids`'s own poll cadence
@@ -38,6 +39,18 @@ const DISCOVERY_POLL_INTERVAL: Duration = Duration::from_millis(100);
 /// existed as of the last successful call, so this only needs to cover the ordinary
 /// query-round-trip latency, not a real "is the app even launching" wait.
 const WINDOW_RESOLVE_TIMEOUT: Duration = Duration::from_millis(2000);
+
+/// How often to re-read an adopted window's geometry while waiting for it to stop changing, and
+/// how long to keep waiting. macOS reports a window's geometry while it is still opening, so the
+/// reading adoption captured is routinely a frame of the open animation (#263). A window that was
+/// never animating agrees on its second reading and costs one interval; the budget only binds an
+/// app whose window keeps moving.
+const SETTLE_POLL_INTERVAL: Duration = Duration::from_millis(25);
+const SETTLE_BUDGET: Duration = Duration::from_millis(500);
+/// Per-poll resolution bound, deliberately far below [`WINDOW_RESOLVE_TIMEOUT`]: a settle poll that
+/// cannot find the window should give the loop its turn back, not spend the whole budget inside one
+/// lookup.
+const SETTLE_RESOLVE_TIMEOUT: Duration = Duration::from_millis(200);
 
 /// Read-back tolerance (pixels) [`MacosPlatform::window`]'s mutating ops use to decide
 /// whether a `Move`/`Resize`'s read-back position/size actually matches what was requested
@@ -197,7 +210,9 @@ impl MacosPlatform {
     /// though `start_app` only reads `geometry` from it today — `send_pointer` does its own
     /// independent, fresh `scwindow::find_window_for_pids` resolution per call rather than
     /// reusing anything cached here (see its doc), so this return type is just the natural
-    /// shape of a `query_once_with_candidates` result, not evidence of caching elsewhere.
+    /// shape of a `query_once_with_candidates` result, not evidence of caching elsewhere. The
+    /// match's `geometry` is the settled one — [`Self::settle_window`] re-reads past the
+    /// adoption instant before this returns (#263).
     fn discover_window(
         child: &mut Child,
         pid: u32,
@@ -211,7 +226,7 @@ impl MacosPlatform {
             {
                 // Stderr-only diagnostic, no behaviour change — see adoption_log's module doc (#263).
                 eprintln!("{}", adoption_line(pid as i32, &candidates));
-                return Ok(m);
+                return Ok(Self::settle_window(pid as i32, m));
             }
             match child.try_wait() {
                 Ok(Some(status)) => return Err(GlassError::AppExited(status.code())),
@@ -235,7 +250,8 @@ impl MacosPlatform {
     /// `ffi::launch_bundle`), so unlike [`discover_window`] there is no local `Child` handle
     /// (`std::process::Child`) to `try_wait` if the adopted app dies before its window
     /// appears; this loop only re-queries `scwindow::query_once_with_candidates` until
-    /// `timeout_ms` elapses.
+    /// `timeout_ms` elapses. Like [`discover_window`], the returned match's `geometry` is the
+    /// settled one, not the adoption-instant reading.
     fn discover_window_pid(pid: i32, timeout_ms: u64) -> Result<crate::scwindow::WindowMatch> {
         crate::ffi::app_kit_init();
         let deadline = Instant::now() + Duration::from_millis(timeout_ms.max(1));
@@ -243,13 +259,74 @@ impl MacosPlatform {
             if let Some((m, candidates)) = crate::scwindow::query_once_with_candidates(&[pid])? {
                 // Same adoption record as `discover_window` — see there (#263).
                 eprintln!("{}", adoption_line(pid, &candidates));
-                return Ok(m);
+                return Ok(Self::settle_window(pid, m));
             }
             if Instant::now() >= deadline {
                 return Err(GlassError::Timeout(timeout_ms));
             }
             std::thread::sleep(DISCOVERY_POLL_INTERVAL);
         }
+    }
+
+    /// Re-read `adopted`'s geometry until two consecutive readings agree, and return the match
+    /// carrying that settled geometry.
+    ///
+    /// Adoption reads the window's geometry the moment it finds it, which on macOS is routinely
+    /// mid-open-animation — 10 of 12 cold launches measured on 2026-08-01 returned a geometry a few
+    /// pixels off the settled one, and the window `start_app` reports is what
+    /// `Glass::start_on_inner` hands the caller and caches as the session's geometry.
+    ///
+    /// Never fails the launch. A window that never stops changing (a clock, a video player, an
+    /// animating splash) would otherwise become unlaunchable, so an expired budget returns the
+    /// freshest reading and says so on stderr; likewise a resolve that fails mid-settle, where the
+    /// window was already confirmed present at adoption. Neither path is silent.
+    ///
+    /// Only *when* the geometry is read changes here. Which window was adopted is already decided
+    /// by the time this runs.
+    fn settle_window(
+        pid: i32,
+        adopted: crate::scwindow::WindowMatch,
+    ) -> crate::scwindow::WindowMatch {
+        let mut tracker = SettleTracker::new();
+        // The adoption reading is the sequence's first element: it is what a settled window has to
+        // agree with for the loop to exit after a single poll.
+        let _ = tracker.observe(adopted.geometry.clone());
+        let mut freshest = adopted;
+        let deadline = Instant::now() + SETTLE_BUDGET;
+        while Instant::now() < deadline {
+            std::thread::sleep(SETTLE_POLL_INTERVAL);
+            let next = match crate::scwindow::find_window_by_id(
+                freshest.window_id,
+                &[pid],
+                SETTLE_RESOLVE_TIMEOUT,
+            ) {
+                Ok(m) => m,
+                Err(e) => {
+                    eprintln!(
+                        "glass-macos: window {} stopped resolving while settling ({e}); \
+                         reporting the last geometry read",
+                        freshest.window_id
+                    );
+                    return freshest;
+                }
+            };
+            let geometry = next.geometry.clone();
+            freshest = next;
+            if let SettleStep::Settled(_) = tracker.observe(geometry) {
+                return freshest;
+            }
+        }
+        eprintln!(
+            "glass-macos: window {} did not settle within {}ms; reporting {}x{} @({},{}), \
+             the last geometry read",
+            freshest.window_id,
+            SETTLE_BUDGET.as_millis(),
+            freshest.geometry.width,
+            freshest.geometry.height,
+            freshest.geometry.x,
+            freshest.geometry.y
+        );
+        freshest
     }
 
     /// Resolve the window `capture_frame`/`send_pointer`/`send_key` should target *this*

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -272,7 +272,7 @@ impl MacosPlatform {
     /// carrying that settled geometry.
     ///
     /// Adoption reads the window's geometry the moment it finds it, which on macOS is routinely
-    /// mid-open-animation — 10 of 12 cold launches measured on 2026-08-01 returned a geometry a few
+    /// mid-open-animation — 11 of 12 cold launches measured on 2026-08-01 returned a geometry a few
     /// pixels off the settled one, and the window `start_app` reports is what
     /// `Glass::start_on_inner` hands the caller and caches as the session's geometry.
     ///

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -42,12 +42,15 @@ const WINDOW_RESOLVE_TIMEOUT: Duration = Duration::from_millis(2000);
 
 /// How often to re-read an adopted window's geometry while waiting for it to stop changing, and
 /// how long to keep waiting. macOS reports a window's geometry while it is still opening, so the
-/// reading adoption captured is routinely a frame of the open animation (#263). A window that had
-/// already stopped moving needs only one more round trip to confirm it — a `SETTLE_POLL_INTERVAL`
-/// sleep plus one `SCShareableContent` query, ~70-125ms as measured on this branch — but that was
-/// the minority case: 11 of 12 cold launches measured here were still moving at adoption and paid
-/// a second round trip (~140-250ms) before settling. The budget bounds a window that never stops
-/// moving at all (a clock, a video player, an animating splash).
+/// reading adoption captured is routinely a frame of the open animation (#263). `settle_window`'s
+/// own read is an `SCShareableContent` query; its per-call cost was never isolated here — that
+/// would need an A/B against a build without the settle. The only measured number available is a
+/// different reader's: the probe's dense early-sampling loop (`tests/window_adopt_probe.rs`)
+/// clocked `platform.window(&WindowOp::Geometry)`, an AX read, at ~45-100ms per call. Adding
+/// `SETTLE_POLL_INTERVAL` gives ~70-125ms as arithmetic, not a measurement of this path. A window
+/// still moving at adoption needs at least one further poll before two consecutive readings can
+/// agree — 11 of the 12 cold launches measured for #263 fell into that case. The budget bounds a
+/// window that never stops moving at all (a clock, a video player, an animating splash).
 const SETTLE_POLL_INTERVAL: Duration = Duration::from_millis(25);
 const SETTLE_BUDGET: Duration = Duration::from_millis(500);
 /// Per-poll resolution bound, deliberately far below [`WINDOW_RESOLVE_TIMEOUT`] (a tenth of it):
@@ -323,10 +326,7 @@ impl MacosPlatform {
                     },
                 )
             });
-        // `freshest.geometry` already equals `geometry` on every path (both come from the same
-        // read, or neither read ever succeeded and both are still the seed) — stated explicitly
-        // rather than relied upon, and it's what makes `geometry` itself worth naming instead of
-        // discarding.
+        // No-op on every path: `geometry` and `freshest.geometry` always come from the same read.
         freshest.geometry = geometry;
         match outcome {
             SettleOutcome::Settled => {}

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -19,6 +19,7 @@ pub mod bundle; // pure .app-bundle logic — cross-platform, host-tested
 pub mod clipboard_route; // pure clipboard-routing policy — cross-platform, host-tested
 pub mod coords; // pure window-relative <-> global math — cross-platform, host-tested
 pub mod keymap; // pure ASCII -> (keycode, shift) US map — cross-platform, host-tested
+pub mod settle; // pure settle policy over successive readings — cross-platform, host-tested
 pub mod shim_path; // pure clip-shim dylib path resolution — cross-platform, host-tested
 
 #[cfg(target_os = "macos")]

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -2,10 +2,10 @@
 //! rendered onto a `CGVirtualDisplay`).
 //!
 //! Like `glass-windows`, the pure logic ([`keymap`], [`coords`], [`clipboard_route`],
-//! [`shim_path`], [`bundle`], [`adoption_log`]) is crate-level and unit-tested on any host; the
-//! OS-touching modules and the `MacosPlatform` impl are gated `#[cfg(target_os = "macos")]`. Off
-//! macOS the crate exposes only the pure modules and the [`capabilities`] map (whose
-//! `accessibility` cell is live; every other cell is constant).
+//! [`shim_path`], [`bundle`], [`adoption_log`], [`settle`]) is crate-level and unit-tested on
+//! any host; the OS-touching modules and the `MacosPlatform` impl are gated
+//! `#[cfg(target_os = "macos")]`. Off macOS the crate exposes only the pure modules and the
+//! [`capabilities`] map (whose `accessibility` cell is live; every other cell is constant).
 
 // FFI backend: the OS-touching modules need `unsafe`, so this crate opts out of the workspace
 // `unsafe_code = "deny"`; each site carries a `// SAFETY:` note (see CLAUDE.md). The pure

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -19,7 +19,7 @@ pub mod bundle; // pure .app-bundle logic — cross-platform, host-tested
 pub mod clipboard_route; // pure clipboard-routing policy — cross-platform, host-tested
 pub mod coords; // pure window-relative <-> global math — cross-platform, host-tested
 pub mod keymap; // pure ASCII -> (keycode, shift) US map — cross-platform, host-tested
-pub mod settle; // pure settle policy over successive readings — cross-platform, host-tested
+pub mod settle; // settle policy + poll loop over successive readings — cross-platform, host-tested
 pub mod shim_path; // pure clip-shim dylib path resolution — cross-platform, host-tested
 
 #[cfg(target_os = "macos")]

--- a/crates/glass-macos/src/settle.rs
+++ b/crates/glass-macos/src/settle.rs
@@ -1,4 +1,3 @@
-#![forbid(unsafe_code)]
 //! When a value read repeatedly has stopped changing.
 //!
 //! macOS reports a window's geometry while the window is still opening, so the reading taken at
@@ -8,11 +7,13 @@
 //! one reading. Kept generic and out of the `#[cfg(target_os = "macos")]` modules so the rule is
 //! unit-tested on any host, and so `glass-core` could adopt it if the other backends turn out to
 //! race the same way.
+#![forbid(unsafe_code)]
 
 use std::time::{Duration, Instant};
 
 /// What one more reading tells the caller.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[must_use]
 pub enum SettleStep<T> {
     /// This reading matched the one before it. Stop polling; this is the value.
     Settled(T),
@@ -27,9 +28,17 @@ pub enum SettleStep<T> {
 /// not the likely one. On the macOS backend that motivated this (#263), it was the minority
 /// outcome: 1 of 12 measured cold launches were already stable at adoption; the other 11 needed
 /// further polling before settling.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct SettleTracker<T> {
     previous: Option<T>,
+}
+
+// Hand-written rather than `#[derive(Default)]`: the derive adds a `T: Default` bound to the
+// impl even though `Option<T>` needs none — `previous` defaults to `None` for any `T`.
+impl<T> Default for SettleTracker<T> {
+    fn default() -> Self {
+        Self { previous: None }
+    }
 }
 
 impl<T: Clone + PartialEq> SettleTracker<T> {
@@ -39,11 +48,15 @@ impl<T: Clone + PartialEq> SettleTracker<T> {
 
     /// Record `reading` and report whether it settles the sequence.
     pub fn observe(&mut self, reading: T) -> SettleStep<T> {
-        let settled = self.previous.as_ref() == Some(&reading);
-        self.previous = Some(reading.clone());
-        if settled {
-            SettleStep::Settled(reading)
+        // The clone only happens on the `Settled` path, where the caller needs `reading` back
+        // by value *and* `self.previous` needs to keep its own copy; `Continue` carries no
+        // payload, so that path moves `reading` straight into `self.previous` instead.
+        if self.previous.as_ref() == Some(&reading) {
+            let settled = reading.clone();
+            self.previous = Some(reading);
+            SettleStep::Settled(settled)
         } else {
+            self.previous = Some(reading);
             SettleStep::Continue
         }
     }
@@ -51,6 +64,7 @@ impl<T: Clone + PartialEq> SettleTracker<T> {
 
 /// How a [`settle_by_polling`] call ended.
 #[derive(Debug, PartialEq)]
+#[must_use]
 pub enum SettleOutcome<E> {
     /// Two consecutive readings agreed before `budget` elapsed.
     Settled,
@@ -64,11 +78,20 @@ pub enum SettleOutcome<E> {
 /// readings agree or `budget` elapses. Returns the freshest reading obtained — `seed` itself if
 /// `read` never succeeded — paired with how the poll ended.
 ///
-/// `interval` throttles `read`: a value that never settles is called roughly `budget / interval`
-/// times, so `Duration::ZERO` (or another interval far below `read`'s own cost) busy-spins for
-/// the whole budget rather than pacing the polls — fine for a test with a cheap, instant `read`,
-/// but not the shape a real caller wants. The one production caller today (macOS's
-/// `settle_window`, #263) uses 25ms.
+/// `interval` throttles `read`: a value that never settles is called roughly
+/// `budget / (interval + read's own cost)` times — `interval` alone only bounds the count when
+/// `read` is cheap relative to it, which is true of the tests below (an instant closure) but not
+/// of a real `read` that does I/O. `Duration::ZERO` busy-spins between calls rather than pacing
+/// them — fine for a test with a cheap, instant `read`, but not the shape a real caller wants.
+/// The one production caller today (macOS's `settle_window`, #263) uses 25ms, well under its
+/// own `read`'s cost (a live query), so pacing there comes mostly from the query itself.
+///
+/// `T`'s `PartialEq` decides settlement on the *whole* value — pick a `T` that carries only the
+/// fields that should hold the loop open while they change. A `T` with an extra field that never
+/// repeats (an unrounded coordinate a rounded one was derived from, say) never settles, even once
+/// the fields that actually matter have stopped moving; see the caller-side regression this was
+/// built to close, `settle_window` (`backend.rs`, #263), and this module's own
+/// `a_wide_t_never_settles_while_any_of_its_fields_keeps_drifting` test.
 pub fn settle_by_polling<T, E>(
     seed: T,
     budget: Duration,
@@ -117,7 +140,7 @@ mod tests {
     #[test]
     fn two_equal_readings_settle() {
         let mut t = SettleTracker::new();
-        t.observe(10);
+        let _ = t.observe(10);
         assert_eq!(t.observe(10), SettleStep::Settled(10));
     }
 
@@ -146,8 +169,8 @@ mod tests {
     #[test]
     fn agreement_is_with_the_immediate_predecessor_only() {
         let mut t = SettleTracker::new();
-        t.observe(10);
-        t.observe(20);
+        let _ = t.observe(10);
+        let _ = t.observe(20);
         assert_eq!(t.observe(10), SettleStep::Continue);
     }
 
@@ -224,22 +247,28 @@ mod tests {
         assert_eq!(outcome, SettleOutcome::ReadFailed("window vanished"));
     }
 
-    /// Pins #263's "the predicate silently widened" review finding, at the one seam that is
-    /// actually testable from Linux: `settle_by_polling` compares the *whole* value `read`
-    /// returns, via `T`'s ordinary `PartialEq` — nothing partial, nothing clever. This is exactly
-    /// why `settle_window` (in `backend.rs`, cfg-gated to macOS and unreachable from here) passes
-    /// `WindowGeometry` rather than the wider `WindowMatch`: `WindowMatch::origin_pt` is the raw
-    /// unrounded point origin `geometry` is rounded from, so it can drift forever inside an
-    /// already-settled pixel, and comparing the whole match — as an earlier revision of this
-    /// branch did — would make that drift block settling forever even though the geometry that
-    /// actually matters had already stopped changing. If `settle_by_polling`'s comparison were
-    /// ever narrowed to ignore part of `T` (a plausible "optimization"), a wide `T` like this one
-    /// would start settling despite an unmatched field still drifting, and this test would catch
-    /// it.
-    ///
-    /// `Source` stands in for `WindowMatch`: `pixel` is the field that should decide settlement
-    /// (like `geometry`), `raw` is a volatile field of the wider value that never repeats (like
-    /// `origin_pt`).
+    /// A `read` that fails on its very first call — before any reading past the seed ever
+    /// succeeded — must report the seed itself, per `settle_by_polling`'s own doc ("seed itself
+    /// if `read` never succeeded"). The previous failure test only proves a *later* failure keeps
+    /// the last good reading; this covers the zero-successes case that doc separately promises.
+    #[test]
+    fn a_read_failure_on_the_first_poll_reports_the_seed() {
+        let (value, outcome) =
+            settle_by_polling(42, Duration::from_millis(50), Duration::ZERO, || {
+                Err::<i32, _>("window vanished")
+            });
+        assert_eq!(
+            value, 42,
+            "must report the seed when no read ever succeeded"
+        );
+        assert_eq!(outcome, SettleOutcome::ReadFailed("window vanished"));
+    }
+
+    /// Pins #263's "the predicate silently widened" finding: `settle_by_polling` must compare
+    /// the *whole* `T` via ordinary `PartialEq`, not just a chosen field. `Source` stands in for
+    /// `WindowMatch`: `pixel` is the field that should decide settlement (like `geometry`), `raw`
+    /// is a volatile field that never repeats (like the raw `origin_pt` a rounded `geometry` is
+    /// derived from) — comparing only `pixel` would let this settle despite `raw` still drifting.
     #[test]
     fn a_wide_t_never_settles_while_any_of_its_fields_keeps_drifting() {
         #[derive(Clone, PartialEq)]

--- a/crates/glass-macos/src/settle.rs
+++ b/crates/glass-macos/src/settle.rs
@@ -14,7 +14,7 @@ use std::time::{Duration, Instant};
 /// What one more reading tells the caller.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[must_use]
-pub enum SettleStep<T> {
+pub(crate) enum SettleStep<T> {
     /// This reading matched the one before it. Stop polling; this is the value.
     Settled(T),
     /// No agreement yet. Poll again, until the caller's own budget runs out.
@@ -26,10 +26,10 @@ pub enum SettleStep<T> {
 /// Two samples rather than three or a fixed duration: a value that was already stable when first
 /// read needs only one more reading to confirm it — the cheapest path through this loop, though
 /// not the likely one. On the macOS backend that motivated this (#263), it was the minority
-/// outcome: 1 of 12 measured cold launches were already stable at adoption; the other 11 needed
+/// outcome: 1 of 12 measured cold launches was already stable at adoption; the other 11 needed
 /// further polling before settling.
 #[derive(Clone, Debug)]
-pub struct SettleTracker<T> {
+pub(crate) struct SettleTracker<T> {
     previous: Option<T>,
 }
 
@@ -42,12 +42,12 @@ impl<T> Default for SettleTracker<T> {
 }
 
 impl<T: Clone + PartialEq> SettleTracker<T> {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self { previous: None }
     }
 
     /// Record `reading` and report whether it settles the sequence.
-    pub fn observe(&mut self, reading: T) -> SettleStep<T> {
+    pub(crate) fn observe(&mut self, reading: T) -> SettleStep<T> {
         // The clone only happens on the `Settled` path, where the caller needs `reading` back
         // by value *and* `self.previous` needs to keep its own copy; `Continue` carries no
         // payload, so that path moves `reading` straight into `self.previous` instead.

--- a/crates/glass-macos/src/settle.rs
+++ b/crates/glass-macos/src/settle.rs
@@ -63,6 +63,12 @@ pub enum SettleOutcome<E> {
 /// Poll `read` every `interval`, seeded with `seed` as the first reading, until two consecutive
 /// readings agree or `budget` elapses. Returns the freshest reading obtained — `seed` itself if
 /// `read` never succeeded — paired with how the poll ended.
+///
+/// `interval` throttles `read`: a value that never settles is called roughly `budget / interval`
+/// times, so `Duration::ZERO` (or another interval far below `read`'s own cost) busy-spins for
+/// the whole budget rather than pacing the polls — fine for a test with a cheap, instant `read`,
+/// but not the shape a real caller wants. The one production caller today (macOS's
+/// `settle_window`, #263) uses 25ms.
 pub fn settle_by_polling<T, E>(
     seed: T,
     budget: Duration,
@@ -181,7 +187,7 @@ mod tests {
     fn a_never_repeating_reader_reports_budget_expiry_with_the_freshest_value() {
         let next_value = Cell::new(0);
         let (value, outcome) =
-            settle_by_polling(-1, Duration::from_millis(2), Duration::ZERO, || {
+            settle_by_polling(-1, Duration::from_millis(50), Duration::ZERO, || {
                 next_value.set(next_value.get() + 1);
                 Ok::<i32, &str>(next_value.get())
             });
@@ -216,5 +222,34 @@ mod tests {
         );
         assert_eq!(value, 5);
         assert_eq!(outcome, SettleOutcome::ReadFailed("window vanished"));
+    }
+
+    /// Pins #263's "the predicate silently widened" review finding: `settle_by_polling` settles
+    /// purely on `T`'s `PartialEq`, so `T` itself is part of a caller's contract. `WindowMatch`
+    /// (the type an earlier revision of `settle_window` used as `T`) carries `geometry` — a
+    /// rounded pixel value — alongside `origin_pt`, the raw unrounded point origin `geometry` is
+    /// rounded from; two readings can agree on `geometry` while `origin_pt` keeps drifting inside
+    /// the same pixel forever. `Source` below mirrors just that shape: `pixel` is the value that
+    /// should decide settlement, `raw` stands in for a volatile field of the wider source data
+    /// that never repeats. A caller that narrows `T` to `pixel` alone settles despite `raw`'s
+    /// drift; this is the correction `settle_window` now applies (`T = WindowGeometry`, not
+    /// `WindowMatch`).
+    #[test]
+    fn settling_ignores_drift_in_source_fields_outside_the_compared_value() {
+        #[derive(Clone, PartialEq)]
+        struct Source {
+            pixel: i32,
+            raw: i64,
+        }
+
+        let mut raw = 0;
+        let (value, outcome) =
+            settle_by_polling(510, Duration::from_millis(50), Duration::ZERO, || {
+                raw += 1;
+                let source = Source { pixel: 510, raw };
+                Ok::<i32, &str>(source.pixel)
+            });
+        assert_eq!(value, 510);
+        assert_eq!(outcome, SettleOutcome::Settled);
     }
 }

--- a/crates/glass-macos/src/settle.rs
+++ b/crates/glass-macos/src/settle.rs
@@ -3,9 +3,13 @@
 //!
 //! macOS reports a window's geometry while the window is still opening, so the reading taken at
 //! adoption is routinely a frame of the open animation rather than the window's real size (#263).
-//! The caller polls; this decides when to stop. Kept generic and out of the `#[cfg(target_os =
-//! "macos")]` modules so the rule is unit-tested on any host, and so `glass-core` could adopt it
-//! if the other backends turn out to race the same way.
+//! [`SettleTracker`] decides when a run of readings has stopped changing; [`settle_by_polling`]
+//! owns the poll loop itself (sleeping between reads) so a caller only has to supply how to take
+//! one reading. Kept generic and out of the `#[cfg(target_os = "macos")]` modules so the rule is
+//! unit-tested on any host, and so `glass-core` could adopt it if the other backends turn out to
+//! race the same way.
+
+use std::time::{Duration, Instant};
 
 /// What one more reading tells the caller.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -18,8 +22,11 @@ pub enum SettleStep<T> {
 
 /// Feeds readings in, one at a time, and reports the first time two consecutive readings agree.
 ///
-/// Two samples rather than three or a fixed duration: a window that never animated agrees on its
-/// second reading and costs one extra poll, which is the common case on every launch.
+/// Two samples rather than three or a fixed duration: a value that was already stable when first
+/// read needs only one more reading to confirm it — the cheapest path through this loop, though
+/// not the likely one. On the macOS backend that motivated this (#263), it was the minority
+/// outcome: 1 of 12 measured cold launches were already stable at adoption; the other 11 needed
+/// further polling before settling.
 #[derive(Clone, Debug, Default)]
 pub struct SettleTracker<T> {
     previous: Option<T>,
@@ -42,9 +49,54 @@ impl<T: Clone + PartialEq> SettleTracker<T> {
     }
 }
 
+/// How a [`settle_by_polling`] call ended.
+#[derive(Debug, PartialEq)]
+pub enum SettleOutcome<E> {
+    /// Two consecutive readings agreed before `budget` elapsed.
+    Settled,
+    /// `budget` elapsed with no two consecutive readings agreeing.
+    BudgetExpired,
+    /// `read` returned an error; polling stopped rather than retrying.
+    ReadFailed(E),
+}
+
+/// Poll `read` every `interval`, seeded with `seed` as the first reading, until two consecutive
+/// readings agree or `budget` elapses. Returns the freshest reading obtained — `seed` itself if
+/// `read` never succeeded — paired with how the poll ended.
+pub fn settle_by_polling<T, E>(
+    seed: T,
+    budget: Duration,
+    interval: Duration,
+    mut read: impl FnMut() -> Result<T, E>,
+) -> (T, SettleOutcome<E>)
+where
+    T: Clone + PartialEq,
+{
+    let mut tracker = SettleTracker::new();
+    // The seed is the sequence's first element: it is what a value that was already settled has
+    // to agree with for the loop to exit after a single poll.
+    let _ = tracker.observe(seed.clone());
+    let mut freshest = seed;
+    let deadline = Instant::now() + budget;
+    while Instant::now() < deadline {
+        std::thread::sleep(interval);
+        let next = match read() {
+            Ok(v) => v,
+            Err(e) => return (freshest, SettleOutcome::ReadFailed(e)),
+        };
+        freshest = next.clone();
+        if let SettleStep::Settled(_) = tracker.observe(next) {
+            return (freshest, SettleOutcome::Settled);
+        }
+    }
+    (freshest, SettleOutcome::BudgetExpired)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{SettleStep, SettleTracker};
+    use super::{SettleOutcome, SettleStep, SettleTracker, settle_by_polling};
+    use std::cell::Cell;
+    use std::time::Duration;
 
     /// A single reading can never settle: "settled" means two readings agreed, and there is
     /// nothing yet to agree with.
@@ -54,8 +106,8 @@ mod tests {
         assert_eq!(t.observe(10), SettleStep::Continue);
     }
 
-    /// The ordinary case, and the one that keeps the hot path cheap: a window that was already
-    /// stable settles on its second reading.
+    /// The cheap case (not the typical one — see [`SettleTracker`]'s doc): a window that was
+    /// already stable settles on its second reading.
     #[test]
     fn two_equal_readings_settle() {
         let mut t = SettleTracker::new();
@@ -91,5 +143,78 @@ mod tests {
         t.observe(10);
         t.observe(20);
         assert_eq!(t.observe(10), SettleStep::Continue);
+    }
+
+    /// Guards against the seed silently stopping being the sequence's first element: if it did,
+    /// a reader that only ever confirms the seed would need a second call to settle, and every
+    /// real caller would pay one extra round trip on every launch for nothing.
+    #[test]
+    fn a_reader_confirming_the_seed_settles_after_exactly_one_call() {
+        let calls = Cell::new(0);
+        let (value, outcome) =
+            settle_by_polling(10, Duration::from_millis(50), Duration::ZERO, || {
+                calls.set(calls.get() + 1);
+                Ok::<i32, &str>(10)
+            });
+        assert_eq!(calls.get(), 1);
+        assert_eq!(value, 10);
+        assert_eq!(outcome, SettleOutcome::Settled);
+    }
+
+    /// A changing-then-stable reader must settle on the value the readings actually converged
+    /// to, not the seed and not an intermediate value passed through on the way there.
+    #[test]
+    fn a_changing_then_stable_reader_settles_on_the_later_value() {
+        let mut readings = [10, 20, 20].into_iter();
+        let (value, outcome) =
+            settle_by_polling(1, Duration::from_millis(50), Duration::ZERO, || {
+                Ok::<i32, &str>(readings.next().expect("test provides exactly 3 readings"))
+            });
+        assert_eq!(value, 20);
+        assert_eq!(outcome, SettleOutcome::Settled);
+    }
+
+    /// A reader that never repeats two consecutive values never settles: the budget must expire,
+    /// and what comes back must be the last thing actually read, not the seed it started from —
+    /// a caller with a real budget still wants the freshest information it managed to gather.
+    #[test]
+    fn a_never_repeating_reader_reports_budget_expiry_with_the_freshest_value() {
+        let next_value = Cell::new(0);
+        let (value, outcome) =
+            settle_by_polling(-1, Duration::from_millis(2), Duration::ZERO, || {
+                next_value.set(next_value.get() + 1);
+                Ok::<i32, &str>(next_value.get())
+            });
+        assert_eq!(outcome, SettleOutcome::BudgetExpired);
+        assert_eq!(
+            value,
+            next_value.get(),
+            "must report the last value actually read"
+        );
+        assert_ne!(value, -1, "must not report the seed it started from");
+    }
+
+    /// A `read` failure must end the poll immediately (no retry) and hand back the last good
+    /// reading plus the error — not the seed, and not a silently-swallowed failure that just
+    /// tries again.
+    #[test]
+    fn a_read_failure_ends_the_poll_and_reports_the_last_good_value() {
+        let calls = Cell::new(0);
+        let (value, outcome) =
+            settle_by_polling(0, Duration::from_millis(50), Duration::ZERO, || {
+                calls.set(calls.get() + 1);
+                if calls.get() == 1 {
+                    Ok(5)
+                } else {
+                    Err("window vanished")
+                }
+            });
+        assert_eq!(
+            calls.get(),
+            2,
+            "must stop polling at the first failure, not retry"
+        );
+        assert_eq!(value, 5);
+        assert_eq!(outcome, SettleOutcome::ReadFailed("window vanished"));
     }
 }

--- a/crates/glass-macos/src/settle.rs
+++ b/crates/glass-macos/src/settle.rs
@@ -1,0 +1,95 @@
+#![forbid(unsafe_code)]
+//! When a value read repeatedly has stopped changing.
+//!
+//! macOS reports a window's geometry while the window is still opening, so the reading taken at
+//! adoption is routinely a frame of the open animation rather than the window's real size (#263).
+//! The caller polls; this decides when to stop. Kept generic and out of the `#[cfg(target_os =
+//! "macos")]` modules so the rule is unit-tested on any host, and so `glass-core` could adopt it
+//! if the other backends turn out to race the same way.
+
+/// What one more reading tells the caller.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SettleStep<T> {
+    /// This reading matched the one before it. Stop polling; this is the value.
+    Settled(T),
+    /// No agreement yet. Poll again, until the caller's own budget runs out.
+    Continue,
+}
+
+/// Feeds readings in, one at a time, and reports the first time two consecutive readings agree.
+///
+/// Two samples rather than three or a fixed duration: a window that never animated agrees on its
+/// second reading and costs one extra poll, which is the common case on every launch.
+#[derive(Clone, Debug, Default)]
+pub struct SettleTracker<T> {
+    previous: Option<T>,
+}
+
+impl<T: Clone + PartialEq> SettleTracker<T> {
+    pub fn new() -> Self {
+        Self { previous: None }
+    }
+
+    /// Record `reading` and report whether it settles the sequence.
+    pub fn observe(&mut self, reading: T) -> SettleStep<T> {
+        let settled = self.previous.as_ref() == Some(&reading);
+        self.previous = Some(reading.clone());
+        if settled {
+            SettleStep::Settled(reading)
+        } else {
+            SettleStep::Continue
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SettleStep, SettleTracker};
+
+    /// A single reading can never settle: "settled" means two readings agreed, and there is
+    /// nothing yet to agree with.
+    #[test]
+    fn the_first_reading_never_settles() {
+        let mut t = SettleTracker::new();
+        assert_eq!(t.observe(10), SettleStep::Continue);
+    }
+
+    /// The ordinary case, and the one that keeps the hot path cheap: a window that was already
+    /// stable settles on its second reading.
+    #[test]
+    fn two_equal_readings_settle() {
+        let mut t = SettleTracker::new();
+        t.observe(10);
+        assert_eq!(t.observe(10), SettleStep::Settled(10));
+    }
+
+    /// A window still animating keeps producing new values; only once it stops does a pair
+    /// agree, and the value returned is the one that agreed — not the first reading.
+    #[test]
+    fn a_changing_reading_settles_on_the_later_value() {
+        let mut t = SettleTracker::new();
+        assert_eq!(t.observe(10), SettleStep::Continue);
+        assert_eq!(t.observe(20), SettleStep::Continue);
+        assert_eq!(t.observe(20), SettleStep::Settled(20));
+    }
+
+    /// A window whose geometry oscillates never settles, which is what makes the caller's
+    /// budget load-bearing rather than decorative.
+    #[test]
+    fn alternating_readings_never_settle() {
+        let mut t = SettleTracker::new();
+        for (i, r) in [10, 20, 10, 20, 10].into_iter().enumerate() {
+            assert_eq!(t.observe(r), SettleStep::Continue, "reading {i}");
+        }
+    }
+
+    /// Equality is by value, not by position: a value that recurs after a change still has to
+    /// agree with its immediate predecessor.
+    #[test]
+    fn agreement_is_with_the_immediate_predecessor_only() {
+        let mut t = SettleTracker::new();
+        t.observe(10);
+        t.observe(20);
+        assert_eq!(t.observe(10), SettleStep::Continue);
+    }
+}

--- a/crates/glass-macos/src/settle.rs
+++ b/crates/glass-macos/src/settle.rs
@@ -224,18 +224,24 @@ mod tests {
         assert_eq!(outcome, SettleOutcome::ReadFailed("window vanished"));
     }
 
-    /// Pins #263's "the predicate silently widened" review finding: `settle_by_polling` settles
-    /// purely on `T`'s `PartialEq`, so `T` itself is part of a caller's contract. `WindowMatch`
-    /// (the type an earlier revision of `settle_window` used as `T`) carries `geometry` — a
-    /// rounded pixel value — alongside `origin_pt`, the raw unrounded point origin `geometry` is
-    /// rounded from; two readings can agree on `geometry` while `origin_pt` keeps drifting inside
-    /// the same pixel forever. `Source` below mirrors just that shape: `pixel` is the value that
-    /// should decide settlement, `raw` stands in for a volatile field of the wider source data
-    /// that never repeats. A caller that narrows `T` to `pixel` alone settles despite `raw`'s
-    /// drift; this is the correction `settle_window` now applies (`T = WindowGeometry`, not
-    /// `WindowMatch`).
+    /// Pins #263's "the predicate silently widened" review finding, at the one seam that is
+    /// actually testable from Linux: `settle_by_polling` compares the *whole* value `read`
+    /// returns, via `T`'s ordinary `PartialEq` — nothing partial, nothing clever. This is exactly
+    /// why `settle_window` (in `backend.rs`, cfg-gated to macOS and unreachable from here) passes
+    /// `WindowGeometry` rather than the wider `WindowMatch`: `WindowMatch::origin_pt` is the raw
+    /// unrounded point origin `geometry` is rounded from, so it can drift forever inside an
+    /// already-settled pixel, and comparing the whole match — as an earlier revision of this
+    /// branch did — would make that drift block settling forever even though the geometry that
+    /// actually matters had already stopped changing. If `settle_by_polling`'s comparison were
+    /// ever narrowed to ignore part of `T` (a plausible "optimization"), a wide `T` like this one
+    /// would start settling despite an unmatched field still drifting, and this test would catch
+    /// it.
+    ///
+    /// `Source` stands in for `WindowMatch`: `pixel` is the field that should decide settlement
+    /// (like `geometry`), `raw` is a volatile field of the wider value that never repeats (like
+    /// `origin_pt`).
     #[test]
-    fn settling_ignores_drift_in_source_fields_outside_the_compared_value() {
+    fn a_wide_t_never_settles_while_any_of_its_fields_keeps_drifting() {
         #[derive(Clone, PartialEq)]
         struct Source {
             pixel: i32,
@@ -243,13 +249,20 @@ mod tests {
         }
 
         let mut raw = 0;
-        let (value, outcome) =
-            settle_by_polling(510, Duration::from_millis(50), Duration::ZERO, || {
+        let (_, outcome) = settle_by_polling(
+            Source { pixel: 510, raw },
+            Duration::from_millis(50),
+            Duration::ZERO,
+            || {
                 raw += 1;
-                let source = Source { pixel: 510, raw };
-                Ok::<i32, &str>(source.pixel)
-            });
-        assert_eq!(value, 510);
-        assert_eq!(outcome, SettleOutcome::Settled);
+                Ok::<Source, &str>(Source { pixel: 510, raw })
+            },
+        );
+        assert_eq!(
+            outcome,
+            SettleOutcome::BudgetExpired,
+            "pixel never changed, but raw never repeated either — comparing the whole Source \
+             must never settle"
+        );
     }
 }

--- a/crates/glass-macos/tests/window_adopt_probe.rs
+++ b/crates/glass-macos/tests/window_adopt_probe.rs
@@ -53,11 +53,12 @@ fn main() {
 
 #[cfg(target_os = "macos")]
 mod macos_main {
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     use glass_a11y_macos::MacosA11y;
     use glass_core::{
-        Accessibility, AppSpec, AxContext, Platform, SandboxLevel, WalkLimits, WindowInfo,
+        Accessibility, AppSpec, AxContext, Platform, SandboxLevel, WalkLimits, WindowGeometry,
+        WindowInfo, WindowOp,
     };
     use glass_macos::MacosPlatform;
 
@@ -78,6 +79,15 @@ mod macos_main {
     /// vanishes) a beat after adoption is still caught — the transient this probe is looking for.
     const ENUMERATIONS: usize = 6;
     const ENUMERATION_GAP: Duration = Duration::from_millis(250);
+
+    /// How often, and for how long, to re-read the adopted window's geometry immediately after
+    /// `start_app` returns. macOS reports a window's geometry while it is still opening, so the
+    /// value adoption captured can be a frame of that animation; sampling densely is how the shape
+    /// of the animation becomes visible rather than inferred. 10ms is a floor, not a guarantee —
+    /// each sample is a real `SCShareableContent` round trip, so the printed offsets are what
+    /// actually happened.
+    const EARLY_SAMPLE_INTERVAL: Duration = Duration::from_millis(10);
+    const EARLY_SAMPLE_WINDOW: Duration = Duration::from_millis(300);
 
     /// Print a clear failure message and exit non-zero — the `harness = false` contract (no
     /// libtest to format a panic for us). Mirrors the sibling integration tests.
@@ -135,6 +145,56 @@ mod macos_main {
         pid: Option<u32>,
     }
 
+    /// Re-read the adopted window's geometry every [`EARLY_SAMPLE_INTERVAL`] for
+    /// [`EARLY_SAMPLE_WINDOW`], printing each reading that differs from the one before it, with
+    /// the offset from when sampling began.
+    ///
+    /// Only distinct readings are printed: a settled window produces one line, and an animating
+    /// one produces the shape of its animation instead of thirty identical rows.
+    fn print_early_samples(platform: &mut MacosPlatform, adopted: &WindowGeometry) {
+        let started = Instant::now();
+        let mut last: Option<WindowGeometry> = None;
+        let mut samples = 0usize;
+        println!(
+            "  early samples (adopted: {}x{} @({},{})):",
+            adopted.width, adopted.height, adopted.x, adopted.y
+        );
+        while started.elapsed() < EARLY_SAMPLE_WINDOW {
+            match platform.window(&WindowOp::Geometry) {
+                Ok(g) => {
+                    samples += 1;
+                    if last.as_ref() != Some(&g) {
+                        println!(
+                            "    t+{:>4}ms  {}x{} @({},{})",
+                            started.elapsed().as_millis(),
+                            g.width,
+                            g.height,
+                            g.x,
+                            g.y
+                        );
+                        last = Some(g);
+                    }
+                }
+                // Never fatal: a read that fails mid-animation is itself worth seeing, and this
+                // is a probe, not a gate.
+                Err(e) => println!(
+                    "    t+{:>4}ms  read failed: {e}",
+                    started.elapsed().as_millis()
+                ),
+            }
+            std::thread::sleep(EARLY_SAMPLE_INTERVAL);
+        }
+        let settled_matches_adopted = last.as_ref() == Some(adopted);
+        println!(
+            "    {samples} sample(s); final reading {} the adopted geometry",
+            if settled_matches_adopted {
+                "MATCHES"
+            } else {
+                "DIFFERS from"
+            }
+        );
+    }
+
     /// One launch/enumerate/stop cycle. `Err` is a real breakage — the app would not launch, or
     /// its windows could not be enumerated at all — distinct from either field of `RunOutcome`
     /// being the unwelcome value, which is a finding, not a probe failure.
@@ -164,6 +224,7 @@ mod macos_main {
                 pid.map_or_else(|| "?".to_string(), |p| p.to_string())
             );
             println!("adopted: {adopted:?}");
+            print_early_samples(platform, &adopted);
 
             let mut matched = false;
             for enumeration in 0..ENUMERATIONS {

--- a/crates/glass-macos/tests/window_adopt_probe.rs
+++ b/crates/glass-macos/tests/window_adopt_probe.rs
@@ -139,7 +139,10 @@ mod macos_main {
     /// owns, whether the accessibility reader could resolve the adopted window at all (#263's
     /// actual symptom), the pid `start_app` reported — needed to tell a cold launch from a
     /// re-adoption of an already-running process (see the module doc's caveat) — and how long
-    /// `start_app` itself took, the actual cost of the settle loop this probe exists to justify.
+    /// `start_app` itself took: its total end-to-end wall clock (process launch through
+    /// LaunchServices, first-window creation, `MacosPlatform::new`'s AX/Screen-Recording
+    /// preflight, window discovery, and the settle), launch-dominated rather than the settle's
+    /// own increment — isolating that would need an A/B sweep against a build without it.
     struct RunOutcome {
         matched: bool,
         snapshot_ok: bool,
@@ -338,10 +341,11 @@ mod macos_main {
              {} distinct pid(s) seen across {runs} run(s)",
             pids_seen.len()
         );
-        // The settle loop's wall-clock cost, measured rather than derived from its own
-        // parameters. `start_app_durations` has one entry per successful run — the `fail()`
-        // above exits before reaching here if any run errored — so the division below never
-        // sees a zero-length vec.
+        // `start_app`'s total end-to-end wall clock, launch-dominated — not the settle loop's
+        // own increment; that would need an A/B sweep against a build without it.
+        // `start_app_durations` has one entry per successful run — the `fail()` above exits
+        // before reaching here if any run errored — so the division below never sees a
+        // zero-length vec.
         let min = start_app_durations
             .iter()
             .min()

--- a/crates/glass-macos/tests/window_adopt_probe.rs
+++ b/crates/glass-macos/tests/window_adopt_probe.rs
@@ -84,8 +84,10 @@ mod macos_main {
     /// `start_app` returns. macOS reports a window's geometry while it is still opening, so the
     /// value adoption captured can be a frame of that animation; sampling densely is how the shape
     /// of the animation becomes visible rather than inferred. 10ms is a floor, not a guarantee —
-    /// each sample is a real `SCShareableContent` round trip, so the printed offsets are what
-    /// actually happened.
+    /// each sample is a real round trip (`platform.window(&WindowOp::Geometry)`, an AX read — the
+    /// same reader #263's actual symptom was about, not the `SCShareableContent` path
+    /// `start_app`/`settle_window` themselves poll), so the printed offsets are what actually
+    /// happened.
     const EARLY_SAMPLE_INTERVAL: Duration = Duration::from_millis(10);
     const EARLY_SAMPLE_WINDOW: Duration = Duration::from_millis(300);
 
@@ -140,9 +142,10 @@ mod macos_main {
     /// actual symptom), the pid `start_app` reported — needed to tell a cold launch from a
     /// re-adoption of an already-running process (see the module doc's caveat) — and how long
     /// `start_app` itself took: its total end-to-end wall clock (process launch through
-    /// LaunchServices, first-window creation, `MacosPlatform::new`'s AX/Screen-Recording
-    /// preflight, window discovery, and the settle), launch-dominated rather than the settle's
-    /// own increment — isolating that would need an A/B sweep against a build without it.
+    /// LaunchServices, first-window creation, window discovery, and the settle — `MacosPlatform`
+    /// is already constructed by the time this timer starts, so its own AX/Screen-Recording
+    /// preflight is not part of it), launch-dominated rather than the settle's own increment —
+    /// isolating that would need an A/B sweep against a build without it.
     struct RunOutcome {
         matched: bool,
         snapshot_ok: bool,
@@ -156,6 +159,11 @@ mod macos_main {
     ///
     /// Only distinct readings are printed: a settled window produces one line, and an animating
     /// one produces the shape of its animation instead of thirty identical rows.
+    ///
+    /// The final "MATCHES / DIFFERS from the adopted geometry" line compares an AX-sourced
+    /// reading against `adopted` (SCShareableContent-sourced) — a small, non-animation offset
+    /// between those two readers is possible (see `axwindow.rs`'s `FALLBACK_TOLERANCE_PX`), so a
+    /// `DIFFERS` here is corroborating evidence, not on its own proof that the window kept moving.
     fn print_early_samples(platform: &mut MacosPlatform, adopted: &WindowGeometry) {
         let started = Instant::now();
         let mut last: Option<WindowGeometry> = None;

--- a/crates/glass-macos/tests/window_adopt_probe.rs
+++ b/crates/glass-macos/tests/window_adopt_probe.rs
@@ -74,9 +74,11 @@ mod macos_main {
     const PROBE_RUNS_VAR: &str = "GLASS_WINDOW_PROBE_RUNS";
     const DEFAULT_RUNS: usize = 30;
 
-    /// How many times to re-enumerate the app's windows after `start_app` returns, and the
-    /// gap between enumerations. Spread across ~1.25s (5 gaps) so a window that appears (or
-    /// vanishes) a beat after adoption is still caught — the transient this probe is looking for.
+    /// How many times to re-enumerate the app's windows after `start_app` returns, and the gap
+    /// between enumerations. The first pass runs immediately, before early sampling begins (see
+    /// `EARLY_SAMPLE_WINDOW`) — previously, a transient that appeared and vanished in that gap
+    /// was never enumerated. The remaining `ENUMERATIONS - 1` passes run after early sampling
+    /// ends, `ENUMERATION_GAP` apart, so a transient a beat later is still caught too.
     const ENUMERATIONS: usize = 6;
     const ENUMERATION_GAP: Duration = Duration::from_millis(250);
 
@@ -208,6 +210,34 @@ mod macos_main {
         );
     }
 
+    /// One `list_windows()` call, printed as one line labeled by real elapsed time since
+    /// `series_start`, not by call index — [`print_early_samples`] runs between the first and
+    /// later calls, so an index-derived label understated every call after it by that window's
+    /// real duration.
+    fn enumerate_once(
+        platform: &mut MacosPlatform,
+        run0: &str,
+        adopted: &WindowGeometry,
+        series_start: Instant,
+        matched: &mut bool,
+    ) -> Result<(), String> {
+        let windows = platform
+            .list_windows()
+            .map_err(|e| format!("list_windows({run0}): {e}"))?;
+        println!(
+            "  t+{}ms: {} window(s)",
+            series_start.elapsed().as_millis(),
+            windows.len()
+        );
+        for w in &windows {
+            let is_adopted = &w.geometry == adopted;
+            *matched |= is_adopted;
+            let tag = if is_adopted { "  == ADOPTED" } else { "" };
+            println!("    {}{tag}", render_window(w));
+        }
+        Ok(())
+    }
+
     /// One launch/enumerate/stop cycle. `Err` is a real breakage — the app would not launch, or
     /// its windows could not be enumerated at all — distinct from either field of `RunOutcome`
     /// being the unwelcome value, which is a finding, not a probe failure.
@@ -240,27 +270,20 @@ mod macos_main {
             );
             println!("start_app: {}ms", start_app_elapsed.as_millis());
             println!("adopted: {adopted:?}");
+
+            // t+0 for the enumeration series below — captured at `start_app`'s return, not
+            // derived from a loop index.
+            let series_start = Instant::now();
+            let mut matched = false;
+            // Ahead of early sampling — see `ENUMERATIONS`'s doc for why this pass has to come
+            // first.
+            enumerate_once(platform, run0, &adopted, series_start, &mut matched)?;
+
             print_early_samples(platform, &adopted);
 
-            let mut matched = false;
-            for enumeration in 0..ENUMERATIONS {
-                let windows = platform
-                    .list_windows()
-                    .map_err(|e| format!("list_windows({run0}): {e}"))?;
-                println!(
-                    "  t+{}ms: {} window(s)",
-                    enumeration as u128 * ENUMERATION_GAP.as_millis(),
-                    windows.len()
-                );
-                for w in &windows {
-                    let is_adopted = w.geometry == adopted;
-                    matched |= is_adopted;
-                    let tag = if is_adopted { "  == ADOPTED" } else { "" };
-                    println!("    {}{tag}", render_window(w));
-                }
-                if enumeration + 1 < ENUMERATIONS {
-                    std::thread::sleep(ENUMERATION_GAP);
-                }
+            for _ in 1..ENUMERATIONS {
+                std::thread::sleep(ENUMERATION_GAP);
+                enumerate_once(platform, run0, &adopted, series_start, &mut matched)?;
             }
 
             // The symptom the issue reports: whether the reader can resolve the window the

--- a/crates/glass-macos/tests/window_adopt_probe.rs
+++ b/crates/glass-macos/tests/window_adopt_probe.rs
@@ -137,12 +137,14 @@ mod macos_main {
 
     /// One run's outcome: whether the adopted geometry matched a window the app's pid actually
     /// owns, whether the accessibility reader could resolve the adopted window at all (#263's
-    /// actual symptom), and the pid `start_app` reported — needed to tell a cold launch from a
-    /// re-adoption of an already-running process (see the module doc's caveat).
+    /// actual symptom), the pid `start_app` reported — needed to tell a cold launch from a
+    /// re-adoption of an already-running process (see the module doc's caveat) — and how long
+    /// `start_app` itself took, the actual cost of the settle loop this probe exists to justify.
     struct RunOutcome {
         matched: bool,
         snapshot_ok: bool,
         pid: Option<u32>,
+        start_app: Duration,
     }
 
     /// Re-read the adopted window's geometry every [`EARLY_SAMPLE_INTERVAL`] for
@@ -214,15 +216,18 @@ mod macos_main {
         };
 
         with_stop_app(&mut platform, run0, |platform| {
+            let start_app_began = Instant::now();
             let adopted = platform
                 .start_app(&spec)
                 .map_err(|e| format!("start_app({run0}): {e}"))?;
+            let start_app_elapsed = start_app_began.elapsed();
             let pid = platform.app_pids().first().copied();
             println!("\n===== run {run_index} =====");
             println!(
                 "pid: {}",
                 pid.map_or_else(|| "?".to_string(), |p| p.to_string())
             );
+            println!("start_app: {}ms", start_app_elapsed.as_millis());
             println!("adopted: {adopted:?}");
             print_early_samples(platform, &adopted);
 
@@ -277,6 +282,7 @@ mod macos_main {
                 matched,
                 snapshot_ok,
                 pid,
+                start_app: start_app_elapsed,
             })
         })
     }
@@ -302,6 +308,7 @@ mod macos_main {
         let mut mismatches = 0usize;
         let mut snapshot_failures = 0usize;
         let mut pids_seen = std::collections::HashSet::new();
+        let mut start_app_durations = Vec::new();
         let mut failures = Vec::new();
         for run_index in 1..=runs {
             match probe_once(&run0, run_index) {
@@ -313,6 +320,7 @@ mod macos_main {
                         snapshot_failures += 1;
                     }
                     pids_seen.extend(outcome.pid);
+                    start_app_durations.push(outcome.start_app);
                 }
                 Err(e) => failures.push(format!("run {run_index}: {e}")),
             }
@@ -329,6 +337,32 @@ mod macos_main {
              {snapshot_failures} of {runs} run(s) failed the accessibility snapshot; \
              {} distinct pid(s) seen across {runs} run(s)",
             pids_seen.len()
+        );
+        // The settle loop's wall-clock cost, measured rather than derived from its own
+        // parameters. `start_app_durations` has one entry per successful run — the `fail()`
+        // above exits before reaching here if any run errored — so the division below never
+        // sees a zero-length vec.
+        let min = start_app_durations
+            .iter()
+            .min()
+            .copied()
+            .unwrap_or_default();
+        let max = start_app_durations
+            .iter()
+            .max()
+            .copied()
+            .unwrap_or_default();
+        let mean_ms = start_app_durations
+            .iter()
+            .map(Duration::as_secs_f64)
+            .sum::<f64>()
+            * 1000.0
+            / start_app_durations.len() as f64;
+        println!(
+            "start_app latency: min {}ms, max {}ms, mean {mean_ms:.1}ms across {} run(s)",
+            min.as_millis(),
+            max.as_millis(),
+            start_app_durations.len()
         );
         println!("WINDOW_ADOPT_PROBE_PASS");
         std::process::exit(0);

--- a/crates/glass-testapp/tests/integration.rs
+++ b/crates/glass-testapp/tests/integration.rs
@@ -2001,6 +2001,10 @@ fn geometry_settle_measurement() {
     const RUNS: usize = 20;
     let mut disagreed = 0usize;
     let xvfb = Xvfb::start();
+    // Xvfb resets (and briefly refuses new connections) when its last client disconnects; kept
+    // alive for the whole measurement so the per-run connect/drop below never takes the display
+    // to zero clients and races that reset.
+    let _keepalive = X11Platform::connect(Some(&xvfb.display)).expect("keepalive connect");
     for run in 1..=RUNS {
         // One `Xvfb` for the whole measurement, a fresh platform + launch per run — the fixture is
         // a plain executable, so every iteration is a genuine cold launch.

--- a/crates/glass-testapp/tests/integration.rs
+++ b/crates/glass-testapp/tests/integration.rs
@@ -1996,7 +1996,7 @@ fn sandbox_default_reaches_bare_name_program_on_a_shadowed_path_dir() {
 /// same way decides whether the settle belongs in this backend too or stays macOS-local. Asserts
 /// only that the launches succeeded; the rate is for a human to read.
 #[test]
-#[ignore = "measurement; run via scripts/test-x11.sh geometry_settle_measurement"]
+#[ignore = "measurement; run via scripts/test-x11.sh geometry_settle_measurement --nocapture"]
 fn geometry_settle_measurement() {
     const RUNS: usize = 20;
     let mut disagreed = 0usize;

--- a/crates/glass-testapp/tests/integration.rs
+++ b/crates/glass-testapp/tests/integration.rs
@@ -10,7 +10,7 @@
 mod common;
 
 use common::Xvfb;
-use glass_core::{AppSpec, Platform};
+use glass_core::{AppSpec, Platform, WindowOp};
 use glass_x11::X11Platform;
 
 const TESTAPP: &str = env!("CARGO_BIN_EXE_glass-testapp");
@@ -1987,4 +1987,31 @@ fn sandbox_default_reaches_bare_name_program_on_a_shadowed_path_dir() {
         "never saw READY on stdout (bare-name on a shadowed PATH dir)"
     );
     p.stop_app().unwrap();
+}
+
+/// MEASUREMENT, not an assertion: how often does `start_app`'s returned geometry disagree with a
+/// geometry re-read immediately afterwards?
+///
+/// macOS returns a mid-open-animation reading on most cold launches (#263). Whether X11 races the
+/// same way decides whether the settle belongs in this backend too or stays macOS-local. Asserts
+/// only that the launches succeeded; the rate is for a human to read.
+#[test]
+#[ignore = "measurement; run via scripts/test-x11.sh geometry_settle_measurement"]
+fn geometry_settle_measurement() {
+    const RUNS: usize = 20;
+    let mut disagreed = 0usize;
+    let xvfb = Xvfb::start();
+    for run in 1..=RUNS {
+        // One `Xvfb` for the whole measurement, a fresh platform + launch per run — the fixture is
+        // a plain executable, so every iteration is a genuine cold launch.
+        let mut p = X11Platform::connect(Some(&xvfb.display)).expect("connect");
+        let adopted = p.start_app(&app_spec()).expect("start_app");
+        let reread = p.window(&WindowOp::Geometry).expect("window(Geometry)");
+        if reread != adopted {
+            disagreed += 1;
+            println!("run {run}: adopted {adopted:?} != re-read {reread:?}");
+        }
+        p.stop_app().expect("stop_app");
+    }
+    println!("x11 geometry_settle_measurement: {disagreed} of {RUNS} launches disagreed");
 }

--- a/crates/glass-testapp/tests/integration.rs
+++ b/crates/glass-testapp/tests/integration.rs
@@ -10,7 +10,7 @@
 mod common;
 
 use common::Xvfb;
-use glass_core::{AppSpec, Platform, WindowOp};
+use glass_core::{AppSpec, Platform};
 use glass_x11::X11Platform;
 
 const TESTAPP: &str = env!("CARGO_BIN_EXE_glass-testapp");
@@ -1989,33 +1989,7 @@ fn sandbox_default_reaches_bare_name_program_on_a_shadowed_path_dir() {
     p.stop_app().unwrap();
 }
 
-/// MEASUREMENT, not an assertion: how often does `start_app`'s returned geometry disagree with a
-/// geometry re-read immediately afterwards?
-///
-/// macOS returns a mid-open-animation reading on most cold launches (#263). Whether X11 races the
-/// same way decides whether the settle belongs in this backend too or stays macOS-local. Asserts
-/// only that the launches succeeded; the rate is for a human to read.
-#[test]
-#[ignore = "measurement; run via scripts/test-x11.sh geometry_settle_measurement --nocapture"]
-fn geometry_settle_measurement() {
-    const RUNS: usize = 20;
-    let mut disagreed = 0usize;
-    let xvfb = Xvfb::start();
-    // Xvfb resets (and briefly refuses new connections) when its last client disconnects; kept
-    // alive for the whole measurement so the per-run connect/drop below never takes the display
-    // to zero clients and races that reset.
-    let _keepalive = X11Platform::connect(Some(&xvfb.display)).expect("keepalive connect");
-    for run in 1..=RUNS {
-        // One `Xvfb` for the whole measurement, a fresh platform + launch per run — the fixture is
-        // a plain executable, so every iteration is a genuine cold launch.
-        let mut p = X11Platform::connect(Some(&xvfb.display)).expect("connect");
-        let adopted = p.start_app(&app_spec()).expect("start_app");
-        let reread = p.window(&WindowOp::Geometry).expect("window(Geometry)");
-        if reread != adopted {
-            disagreed += 1;
-            println!("run {run}: adopted {adopted:?} != re-read {reread:?}");
-        }
-        p.stop_app().expect("stop_app");
-    }
-    println!("x11 geometry_settle_measurement: {disagreed} of {RUNS} launches disagreed");
-}
+// geometry_settle_measurement (the #263 X11 launch-race measurement) lives in its own test
+// target, tests/x11_geometry_settle_measurement.rs, run via
+// scripts/x11-geometry-settle-measurement.sh — not part of this file, so its 20 cold launches
+// per run don't ride along with every scripts/test-x11.sh (and so every CI) invocation.

--- a/crates/glass-testapp/tests/wayland.rs
+++ b/crates/glass-testapp/tests/wayland.rs
@@ -1011,3 +1011,31 @@ fn wayland_build_step_runs_before_launch() {
 
 // (Build-step network containment tests removed: the build step is unsandboxed by design —
 // only the launched run is contained.)
+
+/// MEASUREMENT, not an assertion: how often does `start_app`'s returned geometry disagree with a
+/// geometry re-read immediately afterwards?
+///
+/// macOS returns a mid-open-animation reading on most cold launches (#263). Whether Wayland races
+/// the same way decides whether the settle belongs in this backend too or stays macOS-local.
+/// Asserts only that the launches succeeded; the rate is for a human to read.
+#[test]
+#[ignore = "measurement; run via scripts/test-wayland.sh geometry_settle_measurement"]
+fn geometry_settle_measurement() {
+    use glass_core::WindowOp;
+
+    const RUNS: usize = 20;
+    let mut disagreed = 0usize;
+    for run in 1..=RUNS {
+        // A fresh sway compositor + platform + launch per run — the fixture is a plain
+        // executable, so every iteration is a genuine cold launch.
+        let mut p = WaylandPlatform::new().expect("new");
+        let adopted = start(&mut p, &spec(vec![TESTAPP.to_string()], APP_TIMEOUT_MS));
+        let reread = p.window(&WindowOp::Geometry).expect("window(Geometry)");
+        if reread != adopted {
+            disagreed += 1;
+            println!("run {run}: adopted {adopted:?} != re-read {reread:?}");
+        }
+        p.stop_app().expect("stop_app");
+    }
+    println!("wayland geometry_settle_measurement: {disagreed} of {RUNS} launches disagreed");
+}

--- a/crates/glass-testapp/tests/wayland.rs
+++ b/crates/glass-testapp/tests/wayland.rs
@@ -1012,30 +1012,8 @@ fn wayland_build_step_runs_before_launch() {
 // (Build-step network containment tests removed: the build step is unsandboxed by design —
 // only the launched run is contained.)
 
-/// MEASUREMENT, not an assertion: how often does `start_app`'s returned geometry disagree with a
-/// geometry re-read immediately afterwards?
-///
-/// macOS returns a mid-open-animation reading on most cold launches (#263). Whether Wayland races
-/// the same way decides whether the settle belongs in this backend too or stays macOS-local.
-/// Asserts only that the launches succeeded; the rate is for a human to read.
-#[test]
-#[ignore = "measurement; run via scripts/test-wayland.sh geometry_settle_measurement --nocapture"]
-fn geometry_settle_measurement() {
-    use glass_core::WindowOp;
-
-    const RUNS: usize = 20;
-    let mut disagreed = 0usize;
-    for run in 1..=RUNS {
-        // A fresh sway compositor + platform + launch per run — the fixture is a plain
-        // executable, so every iteration is a genuine cold launch.
-        let mut p = WaylandPlatform::new().unwrap();
-        let adopted = start(&mut p, &spec(vec![TESTAPP.to_string()], APP_TIMEOUT_MS));
-        let reread = p.window(&WindowOp::Geometry).unwrap();
-        if reread != adopted {
-            disagreed += 1;
-            println!("run {run}: adopted {adopted:?} != re-read {reread:?}");
-        }
-        p.stop_app().unwrap();
-    }
-    println!("wayland geometry_settle_measurement: {disagreed} of {RUNS} launches disagreed");
-}
+// geometry_settle_measurement (the #263 Wayland launch-race measurement) lives in its own test
+// target, tests/wayland_geometry_settle_measurement.rs, run via
+// scripts/wayland-geometry-settle-measurement.sh — not part of this file, so its 20 cold
+// launches + sway spawns per run don't ride along with every scripts/test-wayland.sh (and so
+// every CI) invocation.

--- a/crates/glass-testapp/tests/wayland.rs
+++ b/crates/glass-testapp/tests/wayland.rs
@@ -1019,7 +1019,7 @@ fn wayland_build_step_runs_before_launch() {
 /// the same way decides whether the settle belongs in this backend too or stays macOS-local.
 /// Asserts only that the launches succeeded; the rate is for a human to read.
 #[test]
-#[ignore = "measurement; run via scripts/test-wayland.sh geometry_settle_measurement"]
+#[ignore = "measurement; run via scripts/test-wayland.sh geometry_settle_measurement --nocapture"]
 fn geometry_settle_measurement() {
     use glass_core::WindowOp;
 
@@ -1028,14 +1028,14 @@ fn geometry_settle_measurement() {
     for run in 1..=RUNS {
         // A fresh sway compositor + platform + launch per run — the fixture is a plain
         // executable, so every iteration is a genuine cold launch.
-        let mut p = WaylandPlatform::new().expect("new");
+        let mut p = WaylandPlatform::new().unwrap();
         let adopted = start(&mut p, &spec(vec![TESTAPP.to_string()], APP_TIMEOUT_MS));
-        let reread = p.window(&WindowOp::Geometry).expect("window(Geometry)");
+        let reread = p.window(&WindowOp::Geometry).unwrap();
         if reread != adopted {
             disagreed += 1;
             println!("run {run}: adopted {adopted:?} != re-read {reread:?}");
         }
-        p.stop_app().expect("stop_app");
+        p.stop_app().unwrap();
     }
     println!("wayland geometry_settle_measurement: {disagreed} of {RUNS} launches disagreed");
 }

--- a/crates/glass-testapp/tests/wayland_geometry_settle_measurement.rs
+++ b/crates/glass-testapp/tests/wayland_geometry_settle_measurement.rs
@@ -1,0 +1,69 @@
+//! MEASUREMENT, not an assertion: how often does Wayland's `start_app` return a geometry that
+//! disagrees with a geometry re-read immediately afterwards? Whether Wayland races the launch
+//! geometry the way the macOS backend does (#263) decides whether the settle belongs here too
+//! or stays macOS-local.
+//!
+//! Its own test target — not `tests/wayland.rs`, which `scripts/test-wayland.sh` runs on every
+//! CI job — so this measurement's 20 extra cold launches + sway spawns per run don't ride along
+//! with output CI discards. Run via `scripts/wayland-geometry-settle-measurement.sh`.
+
+use glass_core::{AppSpec, Platform, WindowOp};
+use glass_wayland::WaylandPlatform;
+
+const TESTAPP: &str = env!("CARGO_BIN_EXE_glass-testapp");
+const APP_TIMEOUT_MS: u64 = 15_000; // start_app: wait this long for sway's socket
+
+fn spec(run: Vec<String>, timeout_ms: u64) -> AppSpec {
+    AppSpec {
+        build: None,
+        run,
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        timeout_ms,
+        sandbox: glass_core::SandboxLevel::Off,
+        a11y: false,
+    }
+}
+
+/// `start_app`, but dump the captured sway/Xwayland/app logs before panicking on failure —
+/// mirrors `tests/wayland.rs`'s identically-named helper.
+fn start(p: &mut WaylandPlatform, spec: &AppSpec) -> glass_core::WindowGeometry {
+    match p.start_app(spec) {
+        Ok(geom) => geom,
+        Err(e) => {
+            eprintln!("\nstart_app failed: {e}\n--- captured sway/Xwayland/app logs ---");
+            for (stream, line) in p.drain_logs() {
+                eprintln!("  [{stream:?}] {line}");
+            }
+            eprintln!("--- end captured logs ---");
+            panic!("start_app failed: {e}");
+        }
+    }
+}
+
+/// macOS returns a mid-open-animation reading on most cold launches (#263). This measurement
+/// uses `glass-testapp`, a fixed 320x240 window with no opening animation, under headless sway —
+/// an environment where such an animation cannot exist. A 0-of-20 result here means Wayland
+/// doesn't hand back a pre-map or stale geometry for a non-animating fixture; it isn't evidence
+/// the backend can't race a real animating app. Asserts only that the launches succeeded; the
+/// rate is for a human to read.
+#[test]
+#[ignore = "measurement; run via scripts/wayland-geometry-settle-measurement.sh"]
+fn geometry_settle_measurement() {
+    const RUNS: usize = 20;
+    let mut disagreed = 0usize;
+    for run in 1..=RUNS {
+        // A fresh sway compositor + platform + launch per run — the fixture is a plain
+        // executable, so every iteration is a genuine cold launch.
+        let mut p = WaylandPlatform::new().unwrap();
+        let adopted = start(&mut p, &spec(vec![TESTAPP.to_string()], APP_TIMEOUT_MS));
+        let reread = p.window(&WindowOp::Geometry).unwrap();
+        if reread != adopted {
+            disagreed += 1;
+            println!("run {run}: adopted {adopted:?} != re-read {reread:?}");
+        }
+        p.stop_app().unwrap();
+    }
+    println!("wayland geometry_settle_measurement: {disagreed} of {RUNS} launches disagreed");
+}

--- a/crates/glass-testapp/tests/x11_geometry_settle_measurement.rs
+++ b/crates/glass-testapp/tests/x11_geometry_settle_measurement.rs
@@ -1,0 +1,60 @@
+//! MEASUREMENT, not an assertion: how often does X11's `start_app` return a geometry that
+//! disagrees with a geometry re-read immediately afterwards? Whether X11 races the launch
+//! geometry the way the macOS backend does (#263) decides whether the settle belongs here too
+//! or stays macOS-local.
+//!
+//! Its own test target — not `tests/integration.rs`, which `scripts/test-x11.sh` runs on every
+//! CI job — so this measurement's 20 extra cold launches per run don't ride along with output CI
+//! discards. Run via `scripts/x11-geometry-settle-measurement.sh`.
+
+mod common;
+
+use common::Xvfb;
+use glass_core::{AppSpec, Platform, WindowOp};
+use glass_x11::X11Platform;
+
+const TESTAPP: &str = env!("CARGO_BIN_EXE_glass-testapp");
+
+fn app_spec() -> AppSpec {
+    AppSpec {
+        build: None,
+        run: vec![TESTAPP.to_string()],
+        cwd: None,
+        env: vec![],
+        window_hint: None,
+        timeout_ms: 5000,
+        sandbox: glass_core::SandboxLevel::Off,
+        a11y: false,
+    }
+}
+
+/// macOS returns a mid-open-animation reading on most cold launches (#263). This measurement
+/// uses `glass-testapp`, a fixed 320x240 window with no opening animation, under headless Xvfb —
+/// an environment where such an animation cannot exist. A 0-of-20 result here means X11 doesn't
+/// hand back a pre-map or stale geometry for a non-animating fixture; it isn't evidence the
+/// backend can't race a real animating app. Asserts only that the launches succeeded; the rate is
+/// for a human to read.
+#[test]
+#[ignore = "measurement; run via scripts/x11-geometry-settle-measurement.sh"]
+fn geometry_settle_measurement() {
+    const RUNS: usize = 20;
+    let mut disagreed = 0usize;
+    let xvfb = Xvfb::start();
+    // Xvfb resets (and briefly refuses new connections) when its last client disconnects; kept
+    // alive for the whole measurement so the per-run connect/drop below never takes the display
+    // to zero clients and races that reset.
+    let _keepalive = X11Platform::connect(Some(&xvfb.display)).expect("keepalive connect");
+    for run in 1..=RUNS {
+        // One `Xvfb` for the whole measurement, a fresh platform + launch per run — the fixture is
+        // a plain executable, so every iteration is a genuine cold launch.
+        let mut p = X11Platform::connect(Some(&xvfb.display)).expect("connect");
+        let adopted = p.start_app(&app_spec()).expect("start_app");
+        let reread = p.window(&WindowOp::Geometry).expect("window(Geometry)");
+        if reread != adopted {
+            disagreed += 1;
+            println!("run {run}: adopted {adopted:?} != re-read {reread:?}");
+        }
+        p.stop_app().expect("stop_app");
+    }
+    println!("x11 geometry_settle_measurement: {disagreed} of {RUNS} launches disagreed");
+}

--- a/scripts/wayland-geometry-settle-measurement.sh
+++ b/scripts/wayland-geometry-settle-measurement.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Measure whether Wayland races the launch geometry the same way macOS does (#263): 20 cold
+# launches under a fresh sway compositor per run, printed disagreement rate. On-demand
+# contributor tooling (the test is #[ignore]d) — NOT part of the per-PR gate, so
+# scripts/test-wayland.sh does not run it. Skips cleanly if no glass-discoverable sway >=1.12
+# is present (build+install via https://github.com/fixed-width/sway-build).
+#
+#   scripts/wayland-geometry-settle-measurement.sh
+set -euo pipefail
+cd "$(dirname "$0")/.."
+SWAY_BUNDLE="${XDG_DATA_HOME:-$HOME/.local/share}/glass/sway/bin/sway"
+if [ ! -x "$SWAY_BUNDLE" ] && ! { command -v sway >/dev/null 2>&1 && sway --version 2>/dev/null | grep -qE 'version 1\.(1[2-9]|[2-9][0-9])'; }; then
+    echo "no glass-discoverable sway >=1.12; build+install via https://github.com/fixed-width/sway-build. Skipping."
+    exit 0
+fi
+exec cargo test -p glass-testapp --test wayland_geometry_settle_measurement -- \
+    --ignored --nocapture --test-threads=1 "$@"

--- a/scripts/x11-geometry-settle-measurement.sh
+++ b/scripts/x11-geometry-settle-measurement.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Measure whether X11 races the launch geometry the same way macOS does (#263): 20 cold
+# launches under Xvfb, printed disagreement rate. On-demand contributor tooling (the test is
+# #[ignore]d) — NOT part of the per-PR gate, so scripts/test-x11.sh does not run it.
+#
+#   scripts/x11-geometry-settle-measurement.sh
+set -euo pipefail
+cd "$(dirname "$0")/.."
+exec cargo test -p glass-testapp --test x11_geometry_settle_measurement -- \
+    --ignored --nocapture --test-threads=1 "$@"


### PR DESCRIPTION
Fixes #263 (item 2 — the settle. Item 1, what explained the original `468x101` phantom
adoption, is a separate, still-open question; see "What's not this PR" below).

## What changed

On macOS, `start_app` used to return whatever window geometry it read at the instant it
adopted the window. `glass_start` cold launches showed this geometry was routinely a frame
of the window's own opening animation, not its settled size. `start_app`/`start_app`'s
internal `discover_window`/`discover_window_pid` now poll the adopted window after finding
it — every 25ms, up to a 500ms budget — until two consecutive geometry readings agree, and
return that settled geometry instead. The policy itself (`SettleTracker`/`settle_by_polling`
in the new `crates/glass-macos/src/settle.rs`) is generic and host-tested on any OS; only the
macOS glue (`settle_window` in `backend.rs`) touches real window state.

A budget expiry or a resolve failure mid-settle never fails the launch — a window that
never stops changing (a clock, a video player, an animating splash) would otherwise become
permanently unlaunchable — so either case reports the freshest geometry read and discloses
via `eprintln!`. Both stderr lines never fired across the measurement runs below.

## Measured before/after (macOS, Calculator, cold launches only — see admissibility note)

| | Before | After |
|---|---|---|
| Disagreement (adopted geometry vs. a re-read) | **11 of 12** | **0 of 12** |
| Distinct pids in the sweep | 12 of 12 | 12 of 12 |

Both sweeps confirmed 12 distinct pids across 12 iterations (via `osascript ... quit` +
`pgrep` polling between runs), so every iteration was a genuine cold launch, not a
re-adoption of an already-running process. Full methodology and per-run data in the task
reports (not part of this PR's diff).

**Latency**: `start_app`'s total end-to-end wall clock, measured with the fix in place
across 8 cold launches: **min 1000ms, max 1204ms, mean ~1104ms**. This is launch-dominated
(process launch via LaunchServices, first-window creation, `MacosPlatform::new`'s
AX/Screen-Recording preflight, window discovery, and the settle, all together) — it does
**not** isolate the settle loop's own marginal cost. An earlier estimate reasoned from the
settle loop's own parameters alone (~65-150ms) turned out not to be comparable to this
total; isolating the settle's true marginal cost would need an A/B sweep against a build
without it, which nobody has run. Do not read this PR as claiming the settle costs ~1.1s —
it doesn't establish that either way.

The budget-expiry and resolve-failure stderr lines never fired across the 20 cold launches
measured for the X11/Wayland sweep below, nor across the macOS sweeps above. The granted
macOS accessibility integration suite (`set_value`/`invoke`/`bounds`/`snapshot`) passed 4/4
after this change, on the same host, exercising `start_app` on a different fixture.

## X11 and Wayland: measured against a non-animating fixture

`geometry_settle_measurement` tests (20 cold launches each — X11 via
`scripts/x11-geometry-settle-measurement.sh`, Wayland via
`scripts/wayland-geometry-settle-measurement.sh`; each its own `glass-testapp` test target so
these extra cold launches don't ride along with `scripts/test-x11.sh`/`test-wayland.sh`, and
so every CI run) compare `start_app`'s returned geometry against an immediate re-read:

- **X11: 0 of 20 disagreed.**
- **Wayland: 0 of 20 disagreed.**

Both sweeps use `glass-testapp`, a fixed 320x240 window with no opening animation, under
headless Xvfb/sway — an environment where such an animation cannot exist. That supports
"these backends don't hand back a pre-map or stale geometry for a non-animating fixture," not
a general claim that neither backend can ever race a real animating app. The decision (keep
the settle macOS-local) stands either way. **Windows, Android and iOS are unmeasured** — this
PR makes no claim about them either way.

## What's not this PR

The original #263 report described an adopted window of `468x101`, and an earlier pass on
this branch hypothesized that was a 2x-Retina full-width/partial-height animation frame.
That hypothesis is **retracted**: it assumed a 2x display, but the machine used for this
branch's dense early-sampling is 1920x1080 at `pointPixelScale` 1.0, where the real window is
`230x408` in both units — so `468` is roughly double the real *width*, not the full width,
and the `scale=2` in the original log was *derived* from that anomalous width (`468/230`
rounds to 2), not independently measured. Dense early-sampling on this branch (a probe
sampling every 10ms for 300ms right after adoption) reproduced the same undershoot-then-
settle signature at a coarser grain — adoption's reading a few px short in both dimensions,
the very next re-read already at the settled value — but did not reproduce a `468`-scale
reading. #263 item 1 (what specifically produced `468x101`) stays open.

## Final review fix wave

A last pass over the branch corrected four more findings:

- `backend.rs`'s `SETTLE_POLL_INTERVAL`/`SETTLE_BUDGET` doc had attributed a round-trip range
  to a measured `SCShareableContent` query; the number actually came from the probe's AX-read
  sampling, and the total was arithmetic (interval + that range), not a stopwatch reading of
  the settle path itself. Corrected the attribution and dropped the unmeasured "second round
  trip" figure in favor of the settle rule's own implication (a window still moving at
  adoption needs at least one further poll).
- The X11/Wayland claim above is now qualified to the fixture it was actually measured
  against.
- `geometry_settle_measurement` (20 cold launches per backend) previously ran inside
  `tests/integration.rs`/`tests/wayland.rs`, so every CI job paid for it with output
  discarded. Moved both to their own test targets + scripts — the same pattern
  `verification_cost.rs`/`verification-cost.sh` already use in this repo.
- `window_adopt_probe.rs`'s early-sampling window opened a 300ms gap before the probe's first
  window enumeration, landing after the transient #263 item 1 is looking for. Added a leading
  enumeration pass and re-based per-pass timestamps on a real `Instant` instead of the loop
  index. macOS-only; verified by the darwin cross-lint and by reading, not by an on-box run.

All gates re-ran clean after this wave, including the X11/Wayland measurements through their
new entry points (rates unchanged: 0 of 20 both).

## Gates

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `CARGO_TARGET_DIR=<fresh scratch> cargo clippy --target x86_64-apple-darwin -p glass-macos -p glass-a11y-macos --all-targets -- -D warnings` — the only compile signal available for `backend.rs`'s macOS-gated changes on a Linux CI/dev host; caught a real `E0282` earlier on this branch.

All pass. Reviewed with `rust-best-practices`, `terse-comments`, and a `pr-review-toolkit`
panel (code-reviewer, comment-analyzer, pr-test-analyzer, silent-failure-hunter,
type-design-analyzer) before opening this PR; findings triaged in the task's own report.

Draft — holding for human review before marking ready.
