### PR TITLE
build: make --workspace work on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,54 +170,20 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: .
-      - run: cargo build  -p glass-macos --locked
-      - run: cargo clippy -p glass-macos --all-targets --locked -- -D warnings
+      # The Linux-only crates gate themselves off macOS (#293), so --workspace resolves
+      # here now and this job no longer maintains a list of macOS crates by hand. Note the
+      # gated crates compile to nothing here: macOS gets a workspace-wide build and lint
+      # gate, not the same test coverage Linux runs.
+      - run: cargo build  --workspace --all-targets --locked
+      - run: cargo clippy --workspace --all-targets --locked -- -D warnings
+      - run: cargo test   --workspace --locked
       - run: ./scripts/test-macos.sh
-      # glass-a11y-macos is the standalone AXUIElement accessibility reader glass-mcp wires
-      # into the macOS backend (make_platform, doctor's "accessibility (macos)" section).
-      # Its pure `mapping` module has no cfg(macos) gate and already builds + unit-tests on
-      # the Linux `check` job's `cargo build/test --workspace` legs; this is the only job
-      # that can build/lint/test the cfg(target_os = "macos") `ffi`/`reader` modules
-      # underneath it (the AXUIElement snapshot/set_value implementation, incl. `reader`'s
-      # `set_value_took` unit tests, which are compiled out everywhere else).
-      - run: cargo build  -p glass-a11y-macos --locked
-      - run: cargo clippy -p glass-a11y-macos --all-targets --locked -- -D warnings
-      - run: cargo test   -p glass-a11y-macos --locked
-      # glass-sandbox-macos is the Seatbelt (sandbox_init) process-containment crate. Its
-      # pure `build_profile` SBPL generator has no cfg(macos) gate and already builds +
-      # unit-tests on the Linux `check` job's `cargo build/test --workspace` legs; this is
-      # the only job that can build/lint/test the cfg(target_os = "macos") `ffi`/`doctor`
-      # modules underneath it. The `glass-macos` `--lib` containment test that actually
-      # spawns a contained process runs via `./scripts/test-macos.sh` above.
-      - run: cargo build  -p glass-sandbox-macos --locked
-      - run: cargo clippy -p glass-sandbox-macos --all-targets --locked -- -D warnings
-      - run: cargo test   -p glass-sandbox-macos --locked
-      # glass-clip-shim-macos is the DYLD_INSERT_LIBRARIES cdylib that swizzles
-      # +[NSPasteboard generalPasteboard] inside a contained app process. It's cdylib-only
-      # (crate-type = ["cdylib"], no rlib), so there's nothing for `cargo test` to run here —
-      # the pure routing logic it's driven by lives in glass-macos::clipboard_route, which
-      # has no cfg(macos) gate and already unit-tests on the Linux `check` job's `cargo test
-      # --workspace` leg. This is the only job that can build/lint the swizzle itself.
-      - run: cargo build  -p glass-clip-shim-macos --all-targets --locked
-      - run: cargo clippy -p glass-clip-shim-macos --all-targets --locked -- -D warnings
       # Compile/link gate for the harness=false `a11y` on-box integration test
       # (crates/glass-macos/tests/a11y.rs) and its Swift fixture — proves both build against
       # this runner's SDK without attempting the granted run (needs the Accessibility/Screen
       # Recording TCC grants and a WindowServer session the runner doesn't have; that
       # happens out-of-band — see the script's own comments and docs/how-to/build-from-source.md).
       - run: ./scripts/test-macos-a11y.sh
-      # glass-mcp is the shipped binary; only this job can build/lint/test/run its
-      # cfg(target_os = "macos") wiring (Cargo.toml's macos dep, lib.rs's "macos" backend
-      # arm + default_backend). `cargo test` here is what actually executes the grants-free
-      # unit tests behind #[cfg(target_os = "macos")] (e.g. doctor's session-state /
-      # backend-resolution tests) — Linux/Windows compile that code out entirely, so this is
-      # the only job that runs it. Capture/input tools still need a granted,
-      # WindowServer-connected session the runner doesn't have, so those stay at
-      # build/lint/headless-boot — the granted checks run on-box (see
-      # docs/how-to/build-from-source.md).
-      - run: cargo build  -p glass-mcp --locked
-      - run: cargo clippy -p glass-mcp --all-targets --locked -- -D warnings
-      - run: cargo test   -p glass-mcp --locked
       - name: glass-mcp doctor sees the macos backend (TCC grants are absent on the runner)
         # `doctor` exits non-zero without the Screen Recording/Accessibility grants, which
         # the runner never has — expected, and NOT gated here (a hard exit-code gate would

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,11 +177,18 @@ jobs:
       - run: cargo build  --workspace --all-targets --locked
       - run: cargo clippy --workspace --all-targets --locked -- -D warnings
       - run: ./scripts/test-macos.sh
-      # Compile/link gate for the harness=false `a11y` on-box integration test
-      # (crates/glass-macos/tests/a11y.rs) and its Swift fixture — proves both build against
-      # this runner's SDK without attempting the granted run (needs the Accessibility/Screen
-      # Recording TCC grants and a WindowServer session the runner doesn't have; that
-      # happens out-of-band — see the script's own comments and docs/how-to/build-from-source.md).
+      # glass-mcp, glass-a11y-macos and glass-sandbox-macos carry cfg(target_os = "macos")
+      # unit tests (e.g. glass-a11y-macos::reader's set_value_took, glass-mcp::doctor's
+      # backend-resolution tests). None of their test targets is harness = false (unlike
+      # glass-macos above), so `cargo test -p` on them runs ungranted exactly as it did
+      # before #293 — this is still the only job that compiles and runs that code at all.
+      - run: cargo test -p glass-mcp -p glass-a11y-macos -p glass-sandbox-macos --locked
+      # Builds the Swift fixture (crates/glass-macos/fixture/a11y_fixture.swift) — the one
+      # thing `cargo build --workspace --all-targets` above doesn't reach — and re-links the
+      # harness=false `a11y` integration test (crates/glass-macos/tests/a11y.rs) as a belt-
+      # and-braces check, without attempting the granted run (needs the Accessibility/Screen
+      # Recording TCC grants and a WindowServer session the runner doesn't have; that happens
+      # out-of-band — see the script's own comments and docs/how-to/build-from-source.md).
       - run: ./scripts/test-macos-a11y.sh
       - name: glass-mcp doctor sees the macos backend (TCC grants are absent on the runner)
         # `doctor` exits non-zero without the Screen Recording/Accessibility grants, which
@@ -211,7 +218,8 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: .
-      # --workspace can't be used: glass-wayland/glass-testapp are Unix-only. Scope to
+      # --workspace can't be used: glass-ios is Unix-only (unconditional std::os::unix /
+      # Permissions::from_mode use) and ungated, unlike the Linux backends (#293). Scope to
       # the Windows crate closure with an explicit -p list (a future Unix-only crate
       # won't get silently pulled, unlike --exclude). --all-targets compiles the
       # glass-windows examples natively.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,10 +155,10 @@ jobs:
   macos:
     name: macOS (build · clippy · test)
     runs-on: macos-14   # arm64 hosted runner
-    # This is the only place cfg(target_os = "macos") code gets built + linted — the Linux
-    # job can't compile it. Capture/input integration tests are #[ignore]d (need a granted,
-    # WindowServer-connected TCC context) and run on-box; the runner covers pure +
-    # macOS unit tests.
+    # This is the only place cfg(target_os = "macos") code gets built + linted + tested — the
+    # Linux job can't compile it. The capture/input/windows/a11y/bundle_launch integration
+    # targets are harness = false and hard-fail without a granted, WindowServer-connected TCC
+    # context, so they run on-box only; the runner covers pure macOS unit tests.
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # rustup auto-installs the pinned toolchain + components from
@@ -170,10 +170,11 @@ jobs:
           workspaces: .
       # The Linux-only crates gate themselves off macOS (#293), so --workspace resolves
       # here now: a workspace-wide build + lint gate, with the gated crates compiling to
-      # nothing. No `cargo test --workspace` here — glass-macos's `harness = false`
-      # integration targets (capture, input, windows, a11y, bundle_launch) hard-fail
-      # without the TCC grants this runner doesn't have; ./scripts/test-macos.sh below
-      # runs `--lib` instead.
+      # nothing. No `cargo test --workspace` here — five of glass-macos's seven
+      # `harness = false` integration targets (capture, input, windows, a11y, bundle_launch)
+      # hard-fail without the TCC grants this runner doesn't have (the other two, role_probe
+      # and window_adopt_probe, exit 0 unconfigured); ./scripts/test-macos.sh below runs
+      # `--lib` instead.
       - run: cargo build  --workspace --all-targets --locked
       - run: cargo clippy --workspace --all-targets --locked -- -D warnings
       - run: ./scripts/test-macos.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,10 +155,8 @@ jobs:
   macos:
     name: macOS (build · clippy · test)
     runs-on: macos-14   # arm64 hosted runner
-    # Only the glass-macos crate is Mac-specific; the rest of the workspace already
-    # builds/tests on the Linux `check` job. This is the only place the
-    # cfg(target_os = "macos") code gets built + linted + tested — the Linux job can't
-    # compile it. Capture/input integration tests are #[ignore]d (need a granted,
+    # This is the only place cfg(target_os = "macos") code gets built + linted — the Linux
+    # job can't compile it. Capture/input integration tests are #[ignore]d (need a granted,
     # WindowServer-connected TCC context) and run on-box; the runner covers pure +
     # macOS unit tests.
     steps:
@@ -171,12 +169,13 @@ jobs:
         with:
           workspaces: .
       # The Linux-only crates gate themselves off macOS (#293), so --workspace resolves
-      # here now and this job no longer maintains a list of macOS crates by hand. Note the
-      # gated crates compile to nothing here: macOS gets a workspace-wide build and lint
-      # gate, not the same test coverage Linux runs.
+      # here now: a workspace-wide build + lint gate, with the gated crates compiling to
+      # nothing. No `cargo test --workspace` here — glass-macos's `harness = false`
+      # integration targets (capture, input, windows, a11y, bundle_launch) hard-fail
+      # without the TCC grants this runner doesn't have; ./scripts/test-macos.sh below
+      # runs `--lib` instead.
       - run: cargo build  --workspace --all-targets --locked
       - run: cargo clippy --workspace --all-targets --locked -- -D warnings
-      - run: cargo test   --workspace --locked
       - run: ./scripts/test-macos.sh
       # Compile/link gate for the harness=false `a11y` on-box integration test
       # (crates/glass-macos/tests/a11y.rs) and its Swift fixture — proves both build against

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,14 @@ internal refactors, CI, or test-only changes.
   live tree, so one that no longer matches the snapshot errors (`element changed;
   re-snapshot`) instead of clicking stale coordinates — the pointer-only iOS and
   Android paths have no such live check.
+- `cargo build --workspace` and `cargo clippy --workspace` now succeed on macOS. The Linux-only
+  backend crates (X11, Wayland, and their AT-SPI/D-Bus/process/sandbox helpers) gate themselves
+  and every one of their dependencies to Linux, instead of failing to build elsewhere — they
+  compile to nothing on macOS. CI's macOS job runs those two commands workspace-wide now, instead
+  of a hand-maintained list of Mac-relevant crates, so it gains a workspace-wide build and lint
+  gate; test coverage there is unchanged, still targeted `cargo test -p` runs and
+  `./scripts/test-macos.sh` rather than `cargo test --workspace`, since several macOS integration
+  tests need permissions CI doesn't grant.
 
 ### Fixed
 - On macOS, `glass_start` now reports a window's settled geometry rather than a frame of its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,14 +189,6 @@ internal refactors, CI, or test-only changes.
   live tree, so one that no longer matches the snapshot errors (`element changed;
   re-snapshot`) instead of clicking stale coordinates — the pointer-only iOS and
   Android paths have no such live check.
-- `cargo build --workspace` and `cargo clippy --workspace` now succeed on macOS. The Linux-only
-  backend crates (X11, Wayland, and their AT-SPI/D-Bus/process/sandbox helpers) gate themselves
-  and every one of their dependencies to Linux, instead of failing to build elsewhere — they
-  compile to nothing on macOS. CI's macOS job runs those two commands workspace-wide now, instead
-  of a hand-maintained list of Mac-relevant crates, so it gains a workspace-wide build and lint
-  gate; test coverage there is unchanged, still targeted `cargo test -p` runs and
-  `./scripts/test-macos.sh` rather than `cargo test --workspace`, since several macOS integration
-  tests need permissions CI doesn't grant.
 
 ### Fixed
 - On macOS, `glass_start` now reports a window's settled geometry rather than a frame of its

--- a/crates/glass-a11y-linux/Cargo.toml
+++ b/crates/glass-a11y-linux/Cargo.toml
@@ -6,14 +6,14 @@ license.workspace = true
 repository.workspace = true
 publish = false
 
-[dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 glass-core.workspace = true
 atspi.workspace = true
 atspi-common.workspace = true
 zbus.workspace = true
 tokio.workspace = true
 
-[dev-dependencies]
+[target.'cfg(target_os = "linux")'.dev-dependencies]
 glass-x11 = { path = "../glass-x11" }
 glass-wayland = { path = "../glass-wayland" }
 tempfile.workspace = true

--- a/crates/glass-a11y-linux/src/lib.rs
+++ b/crates/glass-a11y-linux/src/lib.rs
@@ -3,6 +3,8 @@
 //! per-OS `Accessibility` seam (orthogonal to the display `Platform` seam); the
 //! same impl serves both the X11 and Wayland display backends.
 
+#![cfg(target_os = "linux")]
+
 mod events;
 mod mapping;
 mod reader;

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -4,6 +4,8 @@
 //! registry (no external dbus-run-session / at-spi-bus-launcher needed). The X11
 //! backend self-spawns a private Xvfb for the fixture to render into.
 
+#![cfg(target_os = "linux")]
+
 use glass_core::{AppSpec, Backend, BaselineStore, Glass, PlatformFactory, WindowHint};
 
 /// Counts the walks a session performs — wall-clock cannot tell a wait that waited efficiently

--- a/crates/glass-dbus-linux/Cargo.toml
+++ b/crates/glass-dbus-linux/Cargo.toml
@@ -6,14 +6,14 @@ license.workspace = true
 repository.workspace = true
 publish = false
 
-[dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 glass-core.workspace = true
 glass-proc-linux.workspace = true
 zbus.workspace = true
 tokio.workspace = true
 tempfile.workspace = true
 
-[dev-dependencies]
+[target.'cfg(target_os = "linux")'.dev-dependencies]
 atspi.workspace = true
 
 [lints]

--- a/crates/glass-dbus-linux/src/lib.rs
+++ b/crates/glass-dbus-linux/src/lib.rs
@@ -4,6 +4,8 @@
 //! `at-spi-bus-launcher`, and resolves the a11y-bus address; reaps both on `Drop` (mirrors
 //! `glass-x11`'s `Xvfb`).
 
+#![cfg(target_os = "linux")]
+
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use std::process::{Child, ChildStdout, Command, Stdio};

--- a/crates/glass-dbus-linux/tests/integration.rs
+++ b/crates/glass-dbus-linux/tests/integration.rs
@@ -2,6 +2,8 @@
 //! those tools installed:
 //! `cargo test -p glass-dbus-linux --test integration -- --ignored`.
 
+#![cfg(target_os = "linux")]
+
 use glass_dbus_linux::PrivateBus;
 
 #[test]

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -72,6 +72,15 @@ harness = false
 name = "window_adopt_probe"
 harness = false
 
+# Test-only fixture for process::tests' SandboxLevel::Default tests (crates/glass-macos/
+# src/process.rs): unlike /bin/sh — an Apple platform binary, arm64e-only on Apple Silicon —
+# any Rust-compiled binary is plain arm64, so DYLD_INSERT_LIBRARIES clip-shim injection can
+# actually load into it instead of dyld aborting on the arch mismatch. See
+# src/bin/sandbox_probe.rs and process.rs's `sandbox_probe_path`.
+[[bin]]
+name = "glass-macos-sandbox-probe"
+path = "src/bin/sandbox_probe.rs"
+
 [dependencies]
 glass-core.workspace = true
 plist = "1"

--- a/crates/glass-macos/Cargo.toml
+++ b/crates/glass-macos/Cargo.toml
@@ -73,10 +73,11 @@ name = "window_adopt_probe"
 harness = false
 
 # Test-only fixture for process::tests' SandboxLevel::Default tests (crates/glass-macos/
-# src/process.rs): unlike /bin/sh — an Apple platform binary, arm64e-only on Apple Silicon —
-# any Rust-compiled binary is plain arm64, so DYLD_INSERT_LIBRARIES clip-shim injection can
-# actually load into it instead of dyld aborting on the arch mismatch. See
-# src/bin/sandbox_probe.rs and process.rs's `sandbox_probe_path`.
+# src/process.rs), spawned in place of /bin/sh: dyld treats Apple platform code specially in
+# ways that defeat DYLD_INSERT_LIBRARIES clip-shim injection into it — an arch-mismatch abort
+# on CI, a silent DYLD_* strip on a newer macOS (see src/bin/sandbox_probe.rs's doc for both).
+# A plain cargo-built binary is neither restricted platform code nor arch-mismatched with the
+# shim. See process.rs's `sandbox_probe_path`.
 [[bin]]
 name = "glass-macos-sandbox-probe"
 path = "src/bin/sandbox_probe.rs"

--- a/crates/glass-macos/src/bin/sandbox_probe.rs
+++ b/crates/glass-macos/src/bin/sandbox_probe.rs
@@ -1,0 +1,56 @@
+//! Test-only fixture spawned by `process::tests`' `SandboxLevel::Default` tests (see
+//! `process.rs`'s `sandbox_probe_path`) in place of `/bin/sh`: an Apple platform binary like
+//! `/bin/sh` ships arm64e-only on Apple Silicon, so the arm64 clip shim those tests exercise
+//! can't be `DYLD_INSERT_LIBRARIES`-injected into it (dyld aborts on the arch mismatch before
+//! the process runs at all). Any Rust-compiled binary is plain arm64, so this one loads it
+//! fine, letting the tests exercise the real injection path instead of dodging it.
+//!
+//! Two flags, repeatable, processed in argv order; a bad read never aborts the process (matches
+//! the `cat ... && echo ... || echo ...` shell one-liner this replaces):
+//! - `--print LINE` — write LINE verbatim.
+//! - `--read-env VAR OK FAIL` — write OK if the path named by env var VAR can be read, else FAIL.
+//!
+//! `--read-env` takes an env var NAME, not the path itself: `glass-sandbox-macos::
+//! launch_reallows` re-allows any `run[1..]` argv token that is itself an absolute, existing
+//! path, on the assumption that a launched script needs to read a path passed as its own
+//! argument. One of these tests' paths is the exact file the sandbox must be proving it
+//! DENIES — putting it in argv would re-allow the very thing under test. Env vars aren't argv,
+//! so `spec.env` can carry the real paths without tripping that logic.
+
+use std::io::Write;
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--print" => {
+                let line = args
+                    .get(i + 1)
+                    .unwrap_or_else(|| panic!("sandbox-probe: --print needs a LINE argument"));
+                println!("{line}");
+                i += 2;
+            }
+            "--read-env" => {
+                let var = args
+                    .get(i + 1)
+                    .unwrap_or_else(|| panic!("sandbox-probe: --read-env needs a VAR argument"));
+                let ok = args
+                    .get(i + 2)
+                    .unwrap_or_else(|| panic!("sandbox-probe: --read-env needs an OK marker"));
+                let fail = args
+                    .get(i + 3)
+                    .unwrap_or_else(|| panic!("sandbox-probe: --read-env needs a FAIL marker"));
+                let path = std::env::var(var)
+                    .unwrap_or_else(|_| panic!("sandbox-probe: env var {var} is not set"));
+                match std::fs::read(path) {
+                    Ok(_) => println!("{ok}"),
+                    Err(_) => println!("{fail}"),
+                }
+                i += 4;
+            }
+            other => panic!("sandbox-probe: unrecognized argument {other:?}"),
+        }
+    }
+    let _ = std::io::stdout().flush();
+}

--- a/crates/glass-macos/src/bin/sandbox_probe.rs
+++ b/crates/glass-macos/src/bin/sandbox_probe.rs
@@ -1,9 +1,13 @@
 //! Test-only fixture spawned by `process::tests`' `SandboxLevel::Default` tests (see
-//! `process.rs`'s `sandbox_probe_path`) in place of `/bin/sh`: an Apple platform binary like
-//! `/bin/sh` ships arm64e-only on Apple Silicon, so the arm64 clip shim those tests exercise
-//! can't be `DYLD_INSERT_LIBRARIES`-injected into it (dyld aborts on the arch mismatch before
-//! the process runs at all). Any Rust-compiled binary is plain arm64, so this one loads it
-//! fine, letting the tests exercise the real injection path instead of dodging it.
+//! `process.rs`'s `sandbox_probe_path`) in place of `/bin/sh`. `/bin/sh` is Apple platform
+//! code, and dyld treats that specially in two ways observed directly on different macOS
+//! versions: CI (macos-14) hard-aborts the child on an arm64/arm64e architecture mismatch when
+//! it attempts to inject the arm64 clip shim into arm64e `/bin/sh`; a newer host (Darwin 25.5)
+//! instead silently drops every `DYLD_*` env var for platform code before even attempting the
+//! load, so injection never happens at all. A plain cargo-built binary sidesteps both: it isn't
+//! restricted platform code, so `DYLD_INSERT_LIBRARIES` is honored, and it's built for whatever
+//! architecture this cargo invocation targets, matching the shim by construction — not just
+//! "arm64", so this also works on an Intel Mac.
 //!
 //! Two flags, repeatable, processed in argv order; a bad read never aborts the process (matches
 //! the `cat ... && echo ... || echo ...` shell one-liner this replaces):
@@ -17,8 +21,6 @@
 //! DENIES — putting it in argv would re-allow the very thing under test. Env vars aren't argv,
 //! so `spec.env` can carry the real paths without tripping that logic.
 
-use std::io::Write;
-
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
     let mut i = 0;
@@ -27,30 +29,32 @@ fn main() {
             "--print" => {
                 let line = args
                     .get(i + 1)
-                    .unwrap_or_else(|| panic!("sandbox-probe: --print needs a LINE argument"));
+                    .expect("sandbox-probe: --print needs a LINE argument");
                 println!("{line}");
                 i += 2;
             }
             "--read-env" => {
                 let var = args
                     .get(i + 1)
-                    .unwrap_or_else(|| panic!("sandbox-probe: --read-env needs a VAR argument"));
+                    .expect("sandbox-probe: --read-env needs a VAR argument");
                 let ok = args
                     .get(i + 2)
-                    .unwrap_or_else(|| panic!("sandbox-probe: --read-env needs an OK marker"));
+                    .expect("sandbox-probe: --read-env needs an OK marker");
                 let fail = args
                     .get(i + 3)
-                    .unwrap_or_else(|| panic!("sandbox-probe: --read-env needs a FAIL marker"));
+                    .expect("sandbox-probe: --read-env needs a FAIL marker");
                 let path = std::env::var(var)
                     .unwrap_or_else(|_| panic!("sandbox-probe: env var {var} is not set"));
-                match std::fs::read(path) {
-                    Ok(_) => println!("{ok}"),
-                    Err(_) => println!("{fail}"),
+                // `File::open` alone trips the same Seatbelt read check as a full read, without
+                // pulling in a multi-megabyte file like `/usr/lib/dyld` just to discard it.
+                if std::fs::File::open(path).is_ok() {
+                    println!("{ok}");
+                } else {
+                    println!("{fail}");
                 }
                 i += 4;
             }
             other => panic!("sandbox-probe: unrecognized argument {other:?}"),
         }
     }
-    let _ = std::io::stdout().flush();
 }

--- a/crates/glass-macos/src/process.rs
+++ b/crates/glass-macos/src/process.rs
@@ -457,6 +457,33 @@ mod tests {
         Arc::new(Mutex::new(Vec::new()))
     }
 
+    /// Path to the `glass-macos-sandbox-probe` fixture (see `src/bin/sandbox_probe.rs`) that
+    /// the `SandboxLevel::Default` tests below spawn in place of `/bin/sh`. Located the same
+    /// way `shim_dylib_path_with` locates the clip shim: `cargo test`'s own binary lives at
+    /// `target/<profile>/deps/<hash>`, one directory below where `cargo build --all-targets`
+    /// places a plain `[[bin]]` target's unhashed copy. `scripts/test-macos.sh` builds this
+    /// fixture first, so it's never missing under the sanctioned entry point. Panics (never
+    /// skips) if it somehow still is — these tests must not silently pass without exercising
+    /// the containment they assert.
+    fn sandbox_probe_path() -> PathBuf {
+        const PROBE_BIN_NAME: &str = "glass-macos-sandbox-probe";
+        let exe_dir = std::env::current_exe()
+            .expect("read current_exe")
+            .parent()
+            .expect("current_exe has a parent dir")
+            .to_path_buf();
+        let probe = exe_dir
+            .parent()
+            .expect("exe_dir has a parent dir")
+            .join(PROBE_BIN_NAME);
+        assert!(
+            probe.is_file(),
+            "{probe:?} not built; run `cargo build -p glass-macos --bin {PROBE_BIN_NAME}` \
+             first (scripts/test-macos.sh does this automatically)"
+        );
+        probe
+    }
+
     #[test]
     #[cfg(target_os = "macos")]
     fn default_sandbox_runs_but_contains_filesystem() {
@@ -468,7 +495,7 @@ mod tests {
         //
         // Both the probe and the secret are files that provably exist (rather than relying on a
         // fixed name like `.ssh/known_hosts`, which may not exist on a fresh CI runner) so a
-        // `cat` failure can only mean the sandbox denied it, never that the path was absent.
+        // failed read can only mean the sandbox denied it, never that the path was absent.
         let home = std::env::var("HOME").expect("HOME must be set");
         let proj =
             std::path::Path::new(&home).join(format!("glass-sbx-cwd-{}", std::process::id()));
@@ -494,17 +521,40 @@ mod tests {
             secret: secret_path.clone(),
             proj: proj.clone(),
         };
-        let proj_str = proj.to_str().expect("project path is valid UTF-8");
+        let probe_str = probe_path.to_str().expect("probe path is valid UTF-8");
         let secret = secret_path.to_str().expect("secret path is valid UTF-8");
-        let shell_cmd = format!(
-            "cat /usr/lib/dyld >/dev/null 2>&1 && echo SYS_OK; \
-             cat \"{proj_str}/probe\" >/dev/null 2>&1 && echo CWD_OK; \
-             cat \"{secret}\" >/dev/null 2>&1 && echo HOME_READABLE || echo HOME_DENIED",
-        );
+        let probe_bin = sandbox_probe_path();
+        let probe_bin_str = probe_bin
+            .to_str()
+            .expect("sandbox-probe path is valid UTF-8");
+        // The paths ride in `env`, not argv: `launch_reallows` re-allows any `run[1..]` token
+        // that is itself an absolute, existing path (a launched script's own path argument), and
+        // `SECRET_PATH` is exactly the path this test proves is denied — naming it in argv would
+        // re-allow it and the assertion below would pass for the wrong reason.
+        let run = [
+            probe_bin_str,
+            "--read-env",
+            "SYS_PATH",
+            "SYS_OK",
+            "SYS_DENIED",
+            "--read-env",
+            "CWD_PATH",
+            "CWD_OK",
+            "CWD_DENIED",
+            "--read-env",
+            "SECRET_PATH",
+            "HOME_READABLE",
+            "HOME_DENIED",
+        ];
 
-        let mut denied = spec(&["/bin/sh", "-c", shell_cmd.as_str()]);
+        let mut denied = spec(&run);
         denied.sandbox = SandboxLevel::Default;
         denied.cwd = Some(proj.clone());
+        denied.env = vec![
+            ("SYS_PATH".to_string(), "/usr/lib/dyld".to_string()),
+            ("CWD_PATH".to_string(), probe_str.to_string()),
+            ("SECRET_PATH".to_string(), secret.to_string()),
+        ];
         let logs = empty_sink();
         let (mut child, _clip) = spawn(&denied, logs.clone())
             .unwrap_or_else(|e| panic!("sandboxed spawn should succeed: {e}"));
@@ -544,18 +594,18 @@ mod tests {
     #[test]
     #[cfg(target_os = "macos")]
     fn default_sandbox_reaches_launch_target_under_home_when_cwd_is_elsewhere() {
-        use std::os::unix::fs::PermissionsExt;
-
         let home = std::env::var("HOME").expect("HOME must be set");
-        let script_dir =
+        let target_dir =
             std::path::Path::new(&home).join(format!("glass-sbx-target-{}", std::process::id()));
-        std::fs::create_dir_all(&script_dir).expect("create script dir under $HOME");
-        let script_path = script_dir.join("run.sh");
+        std::fs::create_dir_all(&target_dir).expect("create target dir under $HOME");
+        // A copy of the probe binary itself, not a `#!/bin/sh` script: the interpreter named by
+        // a shebang is what actually gets exec'd and injected into, so a script would hit the
+        // same arm64e mismatch `sandbox_probe_path`'s doc comment describes for `/bin/sh`.
+        // `fs::copy` preserves the source's executable bit, so no `chmod` is needed here.
+        let target_path = target_dir.join("glass-macos-sandbox-probe");
+        std::fs::copy(sandbox_probe_path(), &target_path)
+            .expect("copy sandbox-probe fixture under $HOME");
         let sentinel = format!("GLASS_SBX_SENTINEL_{}", std::process::id());
-        std::fs::write(&script_path, format!("#!/bin/sh\necho {sentinel}\n"))
-            .expect("write script under $HOME");
-        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
-            .expect("chmod +x script");
 
         // Drop guard so the dir under $HOME is removed even if an assertion below panics.
         struct Cleanup(std::path::PathBuf);
@@ -564,10 +614,10 @@ mod tests {
                 let _ = std::fs::remove_dir_all(&self.0);
             }
         }
-        let _cleanup = Cleanup(script_dir.clone());
+        let _cleanup = Cleanup(target_dir.clone());
 
-        let script_str = script_path.to_str().expect("script path is valid UTF-8");
-        let mut launch = spec(&[script_str]);
+        let target_str = target_path.to_str().expect("target path is valid UTF-8");
+        let mut launch = spec(&[target_str, "--print", sentinel.as_str()]);
         launch.sandbox = SandboxLevel::Default;
         // Deliberately OUTSIDE $HOME: proves the launch target is reachable via its OWN
         // re-allow, not merely because it happens to sit under a reallowed cwd.

--- a/crates/glass-macos/src/process.rs
+++ b/crates/glass-macos/src/process.rs
@@ -479,7 +479,8 @@ mod tests {
         assert!(
             probe.is_file(),
             "{probe:?} not built; run `cargo build -p glass-macos --bin {PROBE_BIN_NAME}` \
-             first (scripts/test-macos.sh does this automatically)"
+             (matching this run's profile, e.g. add --release) first — \
+             scripts/test-macos.sh does this automatically"
         );
         probe
     }
@@ -556,8 +557,16 @@ mod tests {
             ("SECRET_PATH".to_string(), secret.to_string()),
         ];
         let logs = empty_sink();
-        let (mut child, _clip) = spawn(&denied, logs.clone())
+        let (mut child, clip) = spawn(&denied, logs.clone())
             .unwrap_or_else(|e| panic!("sandboxed spawn should succeed: {e}"));
+        // The probe is a plain, unsigned arm64 binary — always injectable — so a `None` here
+        // means the shim never resolved (most likely `glass-clip-shim-macos` wasn't built; see
+        // scripts/test-macos.sh), not that containment itself is untested. Assert it explicitly
+        // rather than letting the containment checks below pass without exercising injection.
+        assert!(
+            clip.is_some(),
+            "clip shim was not injected into the sandboxed probe; is glass-clip-shim-macos built?"
+        );
         child.wait().expect("wait");
         std::thread::sleep(Duration::from_millis(100));
         let out: Vec<String> = logs
@@ -624,12 +633,19 @@ mod tests {
         launch.cwd = Some(std::env::temp_dir());
 
         let logs = empty_sink();
-        let (mut child, _clip) = spawn(&launch, logs.clone()).unwrap_or_else(|e| {
+        let (mut child, clip) = spawn(&launch, logs.clone()).unwrap_or_else(|e| {
             panic!(
                 "sandboxed spawn of a launch target under $HOME (cwd outside $HOME) should \
                  succeed: {e}"
             )
         });
+        // See default_sandbox_runs_but_contains_filesystem's identical assertion: the copied
+        // probe is always injectable, so `None` means the shim never resolved, not that the
+        // reachability behaviour below is untested.
+        assert!(
+            clip.is_some(),
+            "clip shim was not injected into the sandboxed probe; is glass-clip-shim-macos built?"
+        );
         child.wait().expect("wait");
         std::thread::sleep(Duration::from_millis(100));
 

--- a/crates/glass-proc-linux/Cargo.toml
+++ b/crates/glass-proc-linux/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
-[dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 rustix.workspace = true
 
 [lints]

--- a/crates/glass-proc-linux/src/lib.rs
+++ b/crates/glass-proc-linux/src/lib.rs
@@ -15,6 +15,8 @@
 //! bubblewrap). The Windows peer (`descendant_pids`, Toolhelp-based) lives with
 //! the Windows backend for the same reason — the OS APIs can't share an impl.
 
+#![cfg(target_os = "linux")]
+
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::{BufRead, BufReader, Read};
 use std::process::Child;

--- a/crates/glass-sandbox-linux/Cargo.toml
+++ b/crates/glass-sandbox-linux/Cargo.toml
@@ -6,11 +6,11 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
-[dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 glass-core.workspace = true
 glass-sandbox-core.workspace = true
 
-[dev-dependencies]
+[target.'cfg(target_os = "linux")'.dev-dependencies]
 tempfile.workspace = true
 
 [lints]

--- a/crates/glass-testapp/Cargo.toml
+++ b/crates/glass-testapp/Cargo.toml
@@ -12,10 +12,6 @@ x11rb.workspace = true
 [dev-dependencies]
 glass-core.workspace = true
 tempfile.workspace = true
-glass-x11 = { path = "../glass-x11" }
-glass-wayland.workspace = true
-# Teardown tests assert against the shared close/reap graces rather than restating them.
-glass-proc-linux = { path = "../glass-proc-linux" }
 x11rb.workspace = true
 # Network pixel-over-HTTP e2e (tests/network.rs). `glass-mcp`'s `network`
 # feature is default-on. rmcp client transport is generic over the HTTP client;
@@ -28,6 +24,12 @@ tokio = { version = "1", features = ["full"] }
 base64 = "0.23"
 image = { version = "0.25", default-features = false, features = ["webp"] }
 serde_json = "1"
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+glass-x11 = { path = "../glass-x11" }
+glass-wayland.workspace = true
+# Teardown tests assert against the shared close/reap graces rather than restating them.
+glass-proc-linux = { path = "../glass-proc-linux" }
 
 [lints]
 workspace = true

--- a/crates/glass-testapp/tests/common/mod.rs
+++ b/crates/glass-testapp/tests/common/mod.rs
@@ -1,8 +1,8 @@
-#![cfg(target_os = "linux")]
 //! Test-only helper: a private Xvfb for integration tests. Delegates to the
 //! production `glass_x11::Xvfb` so there is one implementation; this wrapper just
 //! supplies the test screen size and panics on failure (what tests expect).
 
+#![cfg(target_os = "linux")]
 #![allow(dead_code)]
 
 use std::ops::Deref;

--- a/crates/glass-testapp/tests/common/mod.rs
+++ b/crates/glass-testapp/tests/common/mod.rs
@@ -1,3 +1,4 @@
+#![cfg(target_os = "linux")]
 //! Test-only helper: a private Xvfb for integration tests. Delegates to the
 //! production `glass_x11::Xvfb` so there is one implementation; this wrapper just
 //! supplies the test screen size and panics on failure (what tests expect).

--- a/crates/glass-testapp/tests/harness_smoke.rs
+++ b/crates/glass-testapp/tests/harness_smoke.rs
@@ -1,3 +1,4 @@
+#![cfg(target_os = "linux")]
 //! Smoke test for the Xvfb harness itself. #[ignore]d so the default
 //! `cargo test` stays green without a display; run via scripts/test-x11.sh.
 

--- a/crates/glass-testapp/tests/harness_smoke.rs
+++ b/crates/glass-testapp/tests/harness_smoke.rs
@@ -1,6 +1,7 @@
-#![cfg(target_os = "linux")]
 //! Smoke test for the Xvfb harness itself. #[ignore]d so the default
 //! `cargo test` stays green without a display; run via scripts/test-x11.sh.
+
+#![cfg(target_os = "linux")]
 
 mod common;
 

--- a/crates/glass-testapp/tests/host_conformance.rs
+++ b/crates/glass-testapp/tests/host_conformance.rs
@@ -1,4 +1,3 @@
-#![cfg(target_os = "linux")]
 //! Host-conformance: prove glass's host-facing MCP surface on BOTH transports
 //! (a spawned stdio child + an in-process HTTP server), the way a real MCP host
 //! consumes it. Each path asserts: `initialize` negotiates a protocol version,
@@ -11,6 +10,7 @@
 //! `./scripts/test-x11.sh stdio_host_can` (the bare file name `host_conformance`
 //! is not a test name and matches nothing).
 
+#![cfg(target_os = "linux")]
 // The HTTP path needs one `unsafe { env::set_var }` for pre-spawn setup (mirrors
 // tests/network.rs); opt out of the workspace `unsafe_code = "deny"`.
 #![allow(unsafe_code)]

--- a/crates/glass-testapp/tests/host_conformance.rs
+++ b/crates/glass-testapp/tests/host_conformance.rs
@@ -1,3 +1,4 @@
+#![cfg(target_os = "linux")]
 //! Host-conformance: prove glass's host-facing MCP surface on BOTH transports
 //! (a spawned stdio child + an in-process HTTP server), the way a real MCP host
 //! consumes it. Each path asserts: `initialize` negotiates a protocol version,

--- a/crates/glass-testapp/tests/ignore_regions_e2e.rs
+++ b/crates/glass-testapp/tests/ignore_regions_e2e.rs
@@ -1,10 +1,10 @@
-#![cfg(target_os = "linux")]
 //! End-to-end: drive glass-mcp over HTTP (the real MCP tool schema, not glass-core's library
 //! API — see `common::mcp_ignore` for why) against a `--blink`ing glass-testapp under Xvfb, to
 //! prove `ignore` regions work through the whole stack: parameter parsing, coordinate mapping,
 //! and the settle/diff logic together. `#[ignore]`d; run via
 //! `./scripts/test-x11.sh blink_region_settles_with_ignore_and_masks_diff`.
 
+#![cfg(target_os = "linux")]
 // This test needs one `unsafe { env::set_var }` for pre-spawn setup (see the `// SAFETY:` note
 // below), so it opts out of the workspace `unsafe_code = "deny"` — same as network.rs.
 #![allow(unsafe_code)]

--- a/crates/glass-testapp/tests/ignore_regions_e2e.rs
+++ b/crates/glass-testapp/tests/ignore_regions_e2e.rs
@@ -1,3 +1,4 @@
+#![cfg(target_os = "linux")]
 //! End-to-end: drive glass-mcp over HTTP (the real MCP tool schema, not glass-core's library
 //! API — see `common::mcp_ignore` for why) against a `--blink`ing glass-testapp under Xvfb, to
 //! prove `ignore` regions work through the whole stack: parameter parsing, coordinate mapping,

--- a/crates/glass-testapp/tests/integration.rs
+++ b/crates/glass-testapp/tests/integration.rs
@@ -1,3 +1,4 @@
+#![cfg(target_os = "linux")]
 //! End-to-end X11 tests. These are `#[ignore]`d so the default `cargo test`
 //! stays green without a display; run them via `scripts/test-x11.sh`.
 

--- a/crates/glass-testapp/tests/integration.rs
+++ b/crates/glass-testapp/tests/integration.rs
@@ -1,7 +1,7 @@
-#![cfg(target_os = "linux")]
 //! End-to-end X11 tests. These are `#[ignore]`d so the default `cargo test`
 //! stays green without a display; run them via `scripts/test-x11.sh`.
 
+#![cfg(target_os = "linux")]
 // A few tests set `PATH` / `GLASS_DBUS_DAEMON` on the process to force a launch failure that
 // has no other seam. `env::set_var` is `unsafe` from edition 2024 on (it races concurrent env
 // readers); `scripts/test-x11.sh` runs this suite with `--test-threads=1`, so there are none.

--- a/crates/glass-testapp/tests/network.rs
+++ b/crates/glass-testapp/tests/network.rs
@@ -1,7 +1,7 @@
-#![cfg(target_os = "linux")]
 //! End-to-end: drive glass-mcp over HTTP against the testapp under Xvfb. `#[ignore]d`;
 //! run via `./scripts/test-x11.sh network_screenshot_over_http`.
 
+#![cfg(target_os = "linux")]
 // This test needs one `unsafe { env::set_var }` for pre-spawn setup (see the `// SAFETY:` note
 // below), so it opts out of the workspace `unsafe_code = "deny"`.
 #![allow(unsafe_code)]

--- a/crates/glass-testapp/tests/network.rs
+++ b/crates/glass-testapp/tests/network.rs
@@ -1,3 +1,4 @@
+#![cfg(target_os = "linux")]
 //! End-to-end: drive glass-mcp over HTTP against the testapp under Xvfb. `#[ignore]d`;
 //! run via `./scripts/test-x11.sh network_screenshot_over_http`.
 

--- a/crates/glass-testapp/tests/software_render.rs
+++ b/crates/glass-testapp/tests/software_render.rs
@@ -1,3 +1,4 @@
+#![cfg(target_os = "linux")]
 //! GTK4/GPU-toolkit apps render (not black) under containment on the headless X11 display —
 //! proof that glass injects software-render env defaults for sandboxed launches. `#[ignore]d`
 //! (needs Xvfb + python3-gi/GTK 4); run via `./scripts/test-x11.sh`.

--- a/crates/glass-testapp/tests/software_render.rs
+++ b/crates/glass-testapp/tests/software_render.rs
@@ -1,7 +1,8 @@
-#![cfg(target_os = "linux")]
 //! GTK4/GPU-toolkit apps render (not black) under containment on the headless X11 display —
 //! proof that glass injects software-render env defaults for sandboxed launches. `#[ignore]d`
 //! (needs Xvfb + python3-gi/GTK 4); run via `./scripts/test-x11.sh`.
+
+#![cfg(target_os = "linux")]
 
 mod common;
 

--- a/crates/glass-testapp/tests/verification_cost.rs
+++ b/crates/glass-testapp/tests/verification_cost.rs
@@ -1,8 +1,8 @@
-#![cfg(target_os = "linux")]
 //! End-to-end: measure the cost of glass's verification loop by driving one fixed task two
 //! ways against glass-fixture-egui over the real MCP path. `#[ignore]`d; run via
 //! `./scripts/verification-cost.sh`. See docs/how-to/verification-cost.md.
 
+#![cfg(target_os = "linux")]
 // One `unsafe { env::set_var }` for pre-spawn GLASS_DISPLAY setup (see SAFETY note),
 // same opt-out as ignore_regions_e2e.rs / network.rs.
 #![allow(unsafe_code)]

--- a/crates/glass-testapp/tests/verification_cost.rs
+++ b/crates/glass-testapp/tests/verification_cost.rs
@@ -1,3 +1,4 @@
+#![cfg(target_os = "linux")]
 //! End-to-end: measure the cost of glass's verification loop by driving one fixed task two
 //! ways against glass-fixture-egui over the real MCP path. `#[ignore]`d; run via
 //! `./scripts/verification-cost.sh`. See docs/how-to/verification-cost.md.

--- a/crates/glass-testapp/tests/wayland.rs
+++ b/crates/glass-testapp/tests/wayland.rs
@@ -1,7 +1,7 @@
-#![cfg(target_os = "linux")]
 //! End-to-end Wayland-backend tests. `#[ignore]`d; run via
 //! `scripts/test-wayland.sh` (which skips if no glass-discoverable sway >=1.12).
 
+#![cfg(target_os = "linux")]
 // Two tests set `PATH` on the process to force a launch failure that has no other seam.
 // `env::set_var` is `unsafe` from edition 2024 on (it races concurrent env readers);
 // `scripts/test-wayland.sh` runs this suite with `--test-threads=1`, so there are none.

--- a/crates/glass-testapp/tests/wayland.rs
+++ b/crates/glass-testapp/tests/wayland.rs
@@ -1,3 +1,4 @@
+#![cfg(target_os = "linux")]
 //! End-to-end Wayland-backend tests. `#[ignore]`d; run via
 //! `scripts/test-wayland.sh` (which skips if no glass-discoverable sway >=1.12).
 

--- a/crates/glass-testapp/tests/wayland_geometry_settle_measurement.rs
+++ b/crates/glass-testapp/tests/wayland_geometry_settle_measurement.rs
@@ -1,3 +1,4 @@
+#![cfg(target_os = "linux")]
 //! MEASUREMENT, not an assertion: how often does Wayland's `start_app` return a geometry that
 //! disagrees with a geometry re-read immediately afterwards? Whether Wayland races the launch
 //! geometry the way the macOS backend does (#263) decides whether the settle belongs here too

--- a/crates/glass-testapp/tests/wayland_geometry_settle_measurement.rs
+++ b/crates/glass-testapp/tests/wayland_geometry_settle_measurement.rs
@@ -1,4 +1,3 @@
-#![cfg(target_os = "linux")]
 //! MEASUREMENT, not an assertion: how often does Wayland's `start_app` return a geometry that
 //! disagrees with a geometry re-read immediately afterwards? Whether Wayland races the launch
 //! geometry the way the macOS backend does (#263) decides whether the settle belongs here too
@@ -7,6 +6,8 @@
 //! Its own test target — not `tests/wayland.rs`, which `scripts/test-wayland.sh` runs on every
 //! CI job — so this measurement's 20 extra cold launches + sway spawns per run don't ride along
 //! with output CI discards. Run via `scripts/wayland-geometry-settle-measurement.sh`.
+
+#![cfg(target_os = "linux")]
 
 use glass_core::{AppSpec, Platform, WindowOp};
 use glass_wayland::WaylandPlatform;

--- a/crates/glass-testapp/tests/wayland_ignore_regions_e2e.rs
+++ b/crates/glass-testapp/tests/wayland_ignore_regions_e2e.rs
@@ -1,3 +1,4 @@
+#![cfg(target_os = "linux")]
 //! End-to-end: the Wayland-backend twin of `ignore_regions_e2e.rs` — same assertion, same real
 //! glass-mcp server over HTTP, against sway/Xwayland instead of Xvfb (no private display setup
 //! needed here; `WaylandPlatform` manages its own compositor). The diff/settle path is shared

--- a/crates/glass-testapp/tests/wayland_ignore_regions_e2e.rs
+++ b/crates/glass-testapp/tests/wayland_ignore_regions_e2e.rs
@@ -1,10 +1,11 @@
-#![cfg(target_os = "linux")]
 //! End-to-end: the Wayland-backend twin of `ignore_regions_e2e.rs` — same assertion, same real
 //! glass-mcp server over HTTP, against sway/Xwayland instead of Xvfb (no private display setup
 //! needed here; `WaylandPlatform` manages its own compositor). The diff/settle path is shared
 //! with X11, so a failure here that X11 doesn't reproduce points at the fixture or the backend,
 //! not the mask. `#[ignore]`d; run via
 //! `./scripts/test-wayland.sh blink_region_settles_with_ignore_and_masks_diff`.
+
+#![cfg(target_os = "linux")]
 
 mod common;
 

--- a/crates/glass-testapp/tests/x11_geometry_settle_measurement.rs
+++ b/crates/glass-testapp/tests/x11_geometry_settle_measurement.rs
@@ -1,3 +1,4 @@
+#![cfg(target_os = "linux")]
 //! MEASUREMENT, not an assertion: how often does X11's `start_app` return a geometry that
 //! disagrees with a geometry re-read immediately afterwards? Whether X11 races the launch
 //! geometry the way the macOS backend does (#263) decides whether the settle belongs here too

--- a/crates/glass-testapp/tests/x11_geometry_settle_measurement.rs
+++ b/crates/glass-testapp/tests/x11_geometry_settle_measurement.rs
@@ -1,4 +1,3 @@
-#![cfg(target_os = "linux")]
 //! MEASUREMENT, not an assertion: how often does X11's `start_app` return a geometry that
 //! disagrees with a geometry re-read immediately afterwards? Whether X11 races the launch
 //! geometry the way the macOS backend does (#263) decides whether the settle belongs here too
@@ -7,6 +6,8 @@
 //! Its own test target — not `tests/integration.rs`, which `scripts/test-x11.sh` runs on every
 //! CI job — so this measurement's 20 extra cold launches per run don't ride along with output CI
 //! discards. Run via `scripts/x11-geometry-settle-measurement.sh`.
+
+#![cfg(target_os = "linux")]
 
 mod common;
 

--- a/crates/glass-wayland/Cargo.toml
+++ b/crates/glass-wayland/Cargo.toml
@@ -11,7 +11,7 @@ publish.workspace = true
 [lib]
 bench = false
 
-[dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 glass-core.workspace = true
 # The desktop-a11y capability signal (AT-SPI launcher present) lives with the a11y reader
 # and its doctor. This backend->a11y-reader direction mirrors glass-windows -> glass-a11y-windows
@@ -34,7 +34,7 @@ x11rb.workspace = true
 tempfile.workspace = true
 rustix.workspace = true
 
-[dev-dependencies]
+[target.'cfg(target_os = "linux")'.dev-dependencies]
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/glass-wayland/benches/pixels.rs
+++ b/crates/glass-wayland/benches/pixels.rs
@@ -3,15 +3,26 @@
 //! Uses a padded stride (`w*4 + PAD`) so the row loop does real work dropping
 //! padding, and `Xrgb8888` so it exercises the R/B-swap path.
 
+// Gated per-item, not with a single `#![cfg]`: that would empty the crate root and leave
+// no `fn main` (`criterion_main!` below provides it only on Linux, where the dependency
+// itself is present). The stub `main` at the bottom keeps the target linkable elsewhere.
+
+#[cfg(target_os = "linux")]
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+#[cfg(target_os = "linux")]
 use glass_wayland::pixels::to_rgba;
+#[cfg(target_os = "linux")]
 use std::hint::black_box;
+#[cfg(target_os = "linux")]
 use wayland_client::protocol::wl_shm::Format;
 
+#[cfg(target_os = "linux")]
 const SIZES: &[(u32, u32)] = &[(320, 240), (800, 600), (1920, 1080)];
+#[cfg(target_os = "linux")]
 const PAD: u32 = 16; // extra stride padding per row
 
 /// A deterministic strided source buffer (4 bytes/pixel + row padding).
+#[cfg(target_os = "linux")]
 fn buffer(h: u32, stride: u32) -> Vec<u8> {
     let mut d = vec![0u8; (stride as usize) * (h as usize)];
     for (i, b) in d.iter_mut().enumerate() {
@@ -20,6 +31,7 @@ fn buffer(h: u32, stride: u32) -> Vec<u8> {
     d
 }
 
+#[cfg(target_os = "linux")]
 fn bench(c: &mut Criterion) {
     let mut g = c.benchmark_group("wl_to_rgba");
     for &(w, h) in SIZES {
@@ -39,5 +51,10 @@ fn bench(c: &mut Criterion) {
     g.finish();
 }
 
+#[cfg(target_os = "linux")]
 criterion_group!(benches, bench);
+#[cfg(target_os = "linux")]
 criterion_main!(benches);
+
+#[cfg(not(target_os = "linux"))]
+fn main() {}

--- a/crates/glass-wayland/src/lib.rs
+++ b/crates/glass-wayland/src/lib.rs
@@ -1,6 +1,8 @@
 //! glass-wayland: the Linux/Wayland `Platform` backend (wlroots protocols,
 //! per-session headless `sway` compositor).
 
+#![cfg(target_os = "linux")]
+
 use glass_core::capability::{CapabilityMap, CapabilityStatus};
 
 pub mod clipboard;

--- a/crates/glass-x11/Cargo.toml
+++ b/crates/glass-x11/Cargo.toml
@@ -11,7 +11,7 @@ publish.workspace = true
 [lib]
 bench = false
 
-[dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 glass-core.workspace = true
 # The desktop-a11y capability signal (AT-SPI launcher present) lives with the a11y reader
 # and its doctor. This backend->a11y-reader direction mirrors glass-windows -> glass-a11y-windows
@@ -24,7 +24,7 @@ glass-proc-linux.workspace = true
 glass-dbus-linux.workspace = true
 x11rb.workspace = true
 
-[dev-dependencies]
+[target.'cfg(target_os = "linux")'.dev-dependencies]
 criterion = { workspace = true }
 tempfile = { workspace = true }
 

--- a/crates/glass-x11/benches/pixels.rs
+++ b/crates/glass-x11/benches/pixels.rs
@@ -1,12 +1,21 @@
 //! Benchmark the per-capture BGRX→RGBA conversion.
 
+// Gated per-item, not with a single `#![cfg]`: that would empty the crate root and leave
+// no `fn main` (`criterion_main!` below provides it only on Linux, where the dependency
+// itself is present). The stub `main` at the bottom keeps the target linkable elsewhere.
+
+#[cfg(target_os = "linux")]
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+#[cfg(target_os = "linux")]
 use glass_x11::pixels::xdata_to_rgba;
+#[cfg(target_os = "linux")]
 use std::hint::black_box;
 
+#[cfg(target_os = "linux")]
 const SIZES: &[(u32, u32)] = &[(320, 240), (800, 600), (1920, 1080)];
 
 /// A deterministic raw BGRX buffer (4 bytes/pixel), no `rand` dependency.
+#[cfg(target_os = "linux")]
 fn bgrx(w: u32, h: u32) -> Vec<u8> {
     let n = (w as usize) * (h as usize);
     let mut d = Vec::with_capacity(n * 4);
@@ -20,6 +29,7 @@ fn bgrx(w: u32, h: u32) -> Vec<u8> {
     d
 }
 
+#[cfg(target_os = "linux")]
 fn bench(c: &mut Criterion) {
     let mut g = c.benchmark_group("xdata_to_rgba");
     for &(w, h) in SIZES {
@@ -36,5 +46,10 @@ fn bench(c: &mut Criterion) {
     g.finish();
 }
 
+#[cfg(target_os = "linux")]
 criterion_group!(benches, bench);
+#[cfg(target_os = "linux")]
 criterion_main!(benches);
+
+#[cfg(not(target_os = "linux"))]
+fn main() {}

--- a/crates/glass-x11/src/lib.rs
+++ b/crates/glass-x11/src/lib.rs
@@ -1,5 +1,7 @@
 //! glass-x11: the Linux/X11 `glass_core::Platform` backend.
 
+#![cfg(target_os = "linux")]
+
 // Modules are added task-by-task.
 
 use glass_core::capability::{CapabilityMap, CapabilityStatus};

--- a/scripts/test-macos.sh
+++ b/scripts/test-macos.sh
@@ -12,6 +12,14 @@ fi
 # (mirrors scripts/test-x11.sh / test-wayland.sh / test-windows.sh).
 cd "$(dirname "$0")/.."
 
+# process::tests' SandboxLevel::Default tests spawn this fixture (see src/bin/sandbox_probe.rs);
+# `cargo test -p glass-macos --lib` below does NOT build sibling `[[bin]]` targets on its own
+# (only `--lib`-selected targets), so build it explicitly rather than relying on an earlier,
+# separate `cargo build --workspace` step having happened to build it first — that exact kind
+# of incidental ordering is what let those two tests run for years without ever spawning a
+# binary the injected clip shim could actually load into (see process.rs's spawn doc).
+cargo build -p glass-macos --bin glass-macos-sandbox-probe
+
 # Pure + macOS unit tests only (`--lib`), minus the `#[ignore]`d ones that need a window
 # server (GLASS_MACOS_ONBOX below runs those). `crates/glass-macos/tests/capture.rs` is now a
 # real `[[test]]` target (see Cargo.toml), so a plain `cargo test -p glass-macos` with no

--- a/scripts/test-macos.sh
+++ b/scripts/test-macos.sh
@@ -12,15 +12,15 @@ fi
 # (mirrors scripts/test-x11.sh / test-wayland.sh / test-windows.sh).
 cd "$(dirname "$0")/.."
 
-# process::tests' SandboxLevel::Default tests (landed 2026-07-01) spawn this fixture and assert
-# the clip shim (injection support added 2026-07-02) was actually injected into it — see
-# src/bin/sandbox_probe.rs and process.rs's spawn doc. Neither the fixture nor the shim is a
-# Cargo dependency of glass-macos, so `cargo test -p glass-macos --lib` below builds neither on
-# its own: build both explicitly rather than relying on an earlier, separate `cargo build
-# --workspace` step having happened to build them first. That exact incidental ordering — the
-# shim dylib not existing when a scoped `-p glass-macos` test run built nothing else — is what
-# let the tests pass for about a month (2026-07-02 until this fix) without the shim ever
-# resolving, so injection was silently skipped every time.
+# process::tests' SandboxLevel::Default tests (landed 2026-07-01 and 2026-07-20) spawn this
+# fixture and assert the clip shim (injection support added 2026-07-02) was actually injected
+# into it — see src/bin/sandbox_probe.rs and process.rs's spawn doc. Neither the fixture nor the
+# shim is a Cargo dependency of glass-macos, so `cargo test -p glass-macos --lib` below builds
+# neither on its own: build both explicitly rather than relying on an earlier, separate `cargo
+# build --workspace` step having happened to build them first. That exact incidental ordering —
+# the shim dylib not existing when a scoped `-p glass-macos` test run built nothing else — is
+# what let both tests pass without the shim ever resolving, from whenever each landed until this
+# fix, so injection was silently skipped every time.
 #
 # Two separate invocations, not one `-p glass-macos --bin ... -p glass-clip-shim-macos`: a
 # `--bin NAME` filter applies across every `-p` package in the same command, and

--- a/scripts/test-macos.sh
+++ b/scripts/test-macos.sh
@@ -12,13 +12,23 @@ fi
 # (mirrors scripts/test-x11.sh / test-wayland.sh / test-windows.sh).
 cd "$(dirname "$0")/.."
 
-# process::tests' SandboxLevel::Default tests spawn this fixture (see src/bin/sandbox_probe.rs);
-# `cargo test -p glass-macos --lib` below does NOT build sibling `[[bin]]` targets on its own
-# (only `--lib`-selected targets), so build it explicitly rather than relying on an earlier,
-# separate `cargo build --workspace` step having happened to build it first — that exact kind
-# of incidental ordering is what let those two tests run for years without ever spawning a
-# binary the injected clip shim could actually load into (see process.rs's spawn doc).
+# process::tests' SandboxLevel::Default tests (landed 2026-07-01) spawn this fixture and assert
+# the clip shim (injection support added 2026-07-02) was actually injected into it — see
+# src/bin/sandbox_probe.rs and process.rs's spawn doc. Neither the fixture nor the shim is a
+# Cargo dependency of glass-macos, so `cargo test -p glass-macos --lib` below builds neither on
+# its own: build both explicitly rather than relying on an earlier, separate `cargo build
+# --workspace` step having happened to build them first. That exact incidental ordering — the
+# shim dylib not existing when a scoped `-p glass-macos` test run built nothing else — is what
+# let the tests pass for about a month (2026-07-02 until this fix) without the shim ever
+# resolving, so injection was silently skipped every time.
+#
+# Two separate invocations, not one `-p glass-macos --bin ... -p glass-clip-shim-macos`: a
+# `--bin NAME` filter applies across every `-p` package in the same command, and
+# glass-clip-shim-macos has no bin target named `glass-macos-sandbox-probe` — combined, cargo
+# silently builds nothing for it rather than erroring (verified: 0.04s, no `Compiling` line, no
+# dylib on disk afterward).
 cargo build -p glass-macos --bin glass-macos-sandbox-probe
+cargo build -p glass-clip-shim-macos
 
 # Pure + macOS unit tests only (`--lib`), minus the `#[ignore]`d ones that need a window
 # server (GLASS_MACOS_ONBOX below runs those). `crates/glass-macos/tests/capture.rs` is now a

--- a/scripts/test-macos.sh
+++ b/scripts/test-macos.sh
@@ -12,21 +12,15 @@ fi
 # (mirrors scripts/test-x11.sh / test-wayland.sh / test-windows.sh).
 cd "$(dirname "$0")/.."
 
-# process::tests' SandboxLevel::Default tests (landed 2026-07-01 and 2026-07-20) spawn this
-# fixture and assert the clip shim (injection support added 2026-07-02) was actually injected
-# into it — see src/bin/sandbox_probe.rs and process.rs's spawn doc. Neither the fixture nor the
-# shim is a Cargo dependency of glass-macos, so `cargo test -p glass-macos --lib` below builds
-# neither on its own: build both explicitly rather than relying on an earlier, separate `cargo
-# build --workspace` step having happened to build them first. That exact incidental ordering —
-# the shim dylib not existing when a scoped `-p glass-macos` test run built nothing else — is
-# what let both tests pass without the shim ever resolving, from whenever each landed until this
-# fix, so injection was silently skipped every time.
+# process::tests' SandboxLevel::Default tests spawn this fixture and assert the clip shim was
+# actually injected — see src/bin/sandbox_probe.rs and process.rs's spawn doc. Neither is a
+# Cargo dependency of glass-macos, so a scoped `cargo test -p glass-macos --lib` builds neither
+# on its own: build both explicitly, not relying on an earlier `cargo build --workspace` step
+# having happened first.
 #
-# Two separate invocations, not one `-p glass-macos --bin ... -p glass-clip-shim-macos`: a
-# `--bin NAME` filter applies across every `-p` package in the same command, and
-# glass-clip-shim-macos has no bin target named `glass-macos-sandbox-probe` — combined, cargo
-# silently builds nothing for it rather than erroring (verified: 0.04s, no `Compiling` line, no
-# dylib on disk afterward).
+# Two separate invocations: a `--bin NAME` filter applies across every `-p` package in the same
+# command, and glass-clip-shim-macos has no bin named `glass-macos-sandbox-probe` — combined,
+# cargo silently builds nothing for it instead of erroring (verified: 0.04s, no dylib produced).
 cargo build -p glass-macos --bin glass-macos-sandbox-probe
 cargo build -p glass-clip-shim-macos
 


### PR DESCRIPTION
## Summary

`cargo build/clippy/test --workspace` could not run on macOS, so workspace-wide commands had to
be re-scoped by hand with `-p`. That hid a real gap: a branch's `cfg(target_os = "macos")` code
could go unlinted because the Linux `--workspace` gate reports clean without ever compiling it.

Two separate failures had to be fixed, not one:

- A crate-root `#![cfg(target_os = "linux")]` alone doesn't help. Cargo resolves and builds a
  crate's dependencies for the target regardless of any `cfg` gate in its source, so a Linux-only
  crate with an ungated `[dependencies]` table still fails to build elsewhere even once its own
  code compiles to nothing there.
- `smithay-client-toolkit` (a `glass-wayland` dependency) isn't buildable for apple targets at
  all — no amount of gating glass's own source could have fixed that; only moving the dependency
  declaration itself behind `[target.'cfg(target_os = "linux")'.dependencies]` does.

Every Linux-only crate (`glass-x11`, `glass-wayland`, `glass-a11y-linux`, `glass-dbus-linux`,
`glass-proc-linux`, `glass-sandbox-linux`) now carries the crate-root gate **and** has all of its
dependencies, including dev-dependencies, moved into target-gated Cargo.toml tables. The two
`[[bench]]` targets and `glass-testapp`'s Linux dev-dependencies plus its eleven test files (and
the shared `tests/common/mod.rs` most of them pull in) get the same treatment.

## Before / after

- Before: `cargo clippy --target x86_64-apple-darwin --workspace -- -D warnings` failed to
  compile (`#293`'s reproduction).
- After: it exits 0 — a lib-only darwin cross-check, run from a Linux box via `--target` with a
  fresh `CARGO_TARGET_DIR` (a repeat run against a warm one is a cache hit that reports clean
  without compiling anything).
- `--all-targets` on darwin is unverifiable from this Linux box for exactly two crates:
  `glass-core` and `glass-windows` each carry a correctly-ungated `criterion` dev-dependency
  whose C build script needs a macOS SDK. That's first exercised when the macOS CI job in this
  PR actually runs, not verified locally.
- The rest of `--all-targets` on darwin *is* verifiable, though: `cargo clippy --target
  x86_64-apple-darwin --workspace --all-targets --exclude glass-core --exclude glass-windows
  --locked -- -D warnings` exits 0 from a Linux box in a fresh scratch `CARGO_TARGET_DIR`. That
  covers the `--all-targets` leg for 17 of 19 crates — including all eleven now-empty
  `glass-testapp` test binaries and their dev-dependency closure, both bench stubs, `glass-mcp`'s
  six test targets, and `glass-ios`/`glass-android`'s tests. The residual is exactly the two
  crates above, which fail in `cc-rs` building the `alloca` C shim for lack of a macOS
  cross-toolchain — an environment gap, not a source problem.

On Linux, nothing regressed: `cargo build/clippy/test --workspace --all-targets` stays green, and
the X11 and Wayland integration suites still run their usual counts — 51 and 25 tests passed.

## CI

The macOS job's hand-maintained `-p ` list — one block per Mac-relevant crate, each with
its own explanatory comment — is deleted, not duplicated: `cargo build`/`cargo clippy` now run
`--workspace --all-targets` there directly. That gains macOS a workspace-wide build and lint gate,
not the equal test coverage Linux runs. `cargo test --workspace` is deliberately not added:
`glass-macos` registers five of its seven `harness = false` test targets (`capture`, `input`,
`windows`, `a11y`, `bundle_launch`) that hard-fail without the TCC grants the runner doesn't have
(the two probe targets, `role_probe` and `window_adopt_probe`, exit 0 unconfigured), and
`--workspace` can't exclude individual targets the way the old `-p` list could.
`./scripts/test-macos.sh`'s `--lib` run still covers macOS unit tests there, and a scoped
`cargo test -p glass-mcp -p glass-a11y-macos -p glass-sandbox-macos` (none of which register a
`harness = false` target) keeps covering the `cfg(target_os = "macos")` unit tests in those three
crates that the old per-crate list used to run individually.

Windows is untested by this change. `#294` tracks the broader "one command per host" question
this and `#293` both sit under.

Fixes #293. Related: #294.

## Follow-up: the macOS job's `--workspace` build surfaced a latent test bug

Building `--workspace --all-targets` before `test-macos.sh` (as this PR now does) means
`glass-clip-shim-macos`'s dylib exists by the time the `glass-macos` unit tests run — and two
`SandboxLevel::Default` tests (`process::tests::default_sandbox_runs_but_contains_filesystem`,
`process::tests::default_sandbox_reaches_launch_target_under_home_when_cwd_is_elsewhere`) spawned
`/bin/sh` as their sandboxed target. `/bin/sh` is Apple platform code; on CI, injecting the
`arm64` clip shim into it aborts on an architecture mismatch (it ships `arm64e`-only on Apple
Silicon). These tests had never actually exercised shim injection: on `master` a scoped `cargo
test -p glass-macos --lib` never builds the shim, so injection was silently skipped there
instead.

Fixed by replacing `/bin/sh` with a small new fixture binary
(`crates/glass-macos/src/bin/sandbox_probe.rs`, a plain cargo-built binary — not restricted
platform code, and arch-matched with the shim by construction) both tests now spawn, so
injection genuinely succeeds while the containment assertions are unchanged. Both tests also now
bind `spawn()`'s injection result and assert it actually happened, rather than only asserting on
downstream sandbox behavior that could pass either way.

Verified on real Apple Silicon hardware, including proving the new assertion actually catches a
missing shim: with `glass-clip-shim-macos` deliberately not built, both tests fail loudly with
the new assertion message; with it built (the normal path — `scripts/test-macos.sh` now builds
it explicitly rather than relying on incidental prior build order), both pass, reproducibly
across repeated runs. Confirmed the shim is genuinely loaded into the new fixture with
`DYLD_PRINT_LIBRARIES=1` (shows the dylib's load line), in contrast to `/bin/sh`, where the same
check shows nothing at all — this host's newer dyld silently drops `DYLD_*` env vars for
restricted platform code rather than erroring on it, a second, independent reason `/bin/sh` could
never have exercised real injection.
