### PR TITLE
Gate glass-ios's crate root to cfg(unix); unblock --workspace build/clippy on Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,13 +220,13 @@ jobs:
         with:
           workspaces: .
       # The Linux-only and unix-only crates gate themselves (#293), so --workspace
-      # resolves here for build/clippy. cargo test stays scoped: every other crate's
-      # tests are platform-independent and already run via the Linux job's `cargo test
-      # --workspace`, so this `-p` list exists to run the Windows-specific tests —
-      # except glass-android, glass-sandbox-core and glass-sandbox-macos, whose tests
-      # assert POSIX-style absolute paths that fail under real Windows path semantics
-      # (#TODO_ISSUE_NUMBER, pre-existing, unrelated to the gating above). Fixing that
-      # lets this step go --workspace too.
+      # resolves here for build/clippy. cargo test stays scoped for now — this same
+      # `-p` list is what hid 19 pre-existing Windows-path-semantics failures in
+      # glass-android, glass-sandbox-core and glass-sandbox-macos (POSIX-style
+      # absolute-path assertions that don't hold on Windows), tracked in #299.
+      # Every other crate's tests are platform-independent and already covered by
+      # the Linux job's `cargo test --workspace`; once #299 lands, drop this list
+      # and go --workspace here too.
       - run: cargo build  --workspace --all-targets --locked
       - run: cargo clippy --workspace --all-targets --locked -- -D warnings
       - run: cargo test   -p glass-core -p glass-windows -p glass-a11y-windows -p glass-mcp --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,13 +219,13 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: .
-      # --workspace can't be used: glass-ios is Unix-only (unconditional std::os::unix /
-      # Permissions::from_mode use) and ungated, unlike the Linux backends (#293). Scope to
-      # the Windows crate closure with an explicit -p list (a future Unix-only crate
-      # won't get silently pulled, unlike --exclude). --all-targets compiles the
-      # glass-windows examples natively.
-      - run: cargo build  -p glass-core -p glass-windows -p glass-a11y-windows -p glass-mcp --all-targets --locked
-      - run: cargo clippy -p glass-core -p glass-windows -p glass-a11y-windows -p glass-mcp --all-targets --locked -- -D warnings
+      # The Linux-only and unix-only crates gate themselves (#293), so --workspace
+      # resolves here for build/clippy. cargo test stays scoped: glass-android,
+      # glass-sandbox-core and glass-sandbox-macos assert on POSIX-style absolute
+      # paths that don't hold under Windows path semantics — pre-existing, unrelated
+      # to the gating above.
+      - run: cargo build  --workspace --all-targets --locked
+      - run: cargo clippy --workspace --all-targets --locked -- -D warnings
       - run: cargo test   -p glass-core -p glass-windows -p glass-a11y-windows -p glass-mcp --locked
 
   coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,10 +220,13 @@ jobs:
         with:
           workspaces: .
       # The Linux-only and unix-only crates gate themselves (#293), so --workspace
-      # resolves here for build/clippy. cargo test stays scoped: glass-android,
-      # glass-sandbox-core and glass-sandbox-macos assert on POSIX-style absolute
-      # paths that don't hold under Windows path semantics — pre-existing, unrelated
-      # to the gating above.
+      # resolves here for build/clippy. cargo test stays scoped: every other crate's
+      # tests are platform-independent and already run via the Linux job's `cargo test
+      # --workspace`, so this `-p` list exists to run the Windows-specific tests —
+      # except glass-android, glass-sandbox-core and glass-sandbox-macos, whose tests
+      # assert POSIX-style absolute paths that fail under real Windows path semantics
+      # (#TODO_ISSUE_NUMBER, pre-existing, unrelated to the gating above). Fixing that
+      # lets this step go --workspace too.
       - run: cargo build  --workspace --all-targets --locked
       - run: cargo clippy --workspace --all-targets --locked -- -D warnings
       - run: cargo test   -p glass-core -p glass-windows -p glass-a11y-windows -p glass-mcp --locked

--- a/crates/glass-ios/Cargo.toml
+++ b/crates/glass-ios/Cargo.toml
@@ -9,7 +9,9 @@ publish.workspace = true
 [lib]
 bench = false
 
-[dependencies]
+# The whole crate body is `#![cfg(unix)]`-gated (src/lib.rs), so every dependency is
+# too — mirrors glass-x11/glass-wayland, the workspace's other fully-gated crates.
+[target.'cfg(unix)'.dependencies]
 glass-core.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
@@ -27,6 +29,10 @@ tokio-stream.workspace = true
 tower = { version = "0.5", features = ["util"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 
+# Deliberately not target-gated: `[target.'cfg(...)'.build-dependencies]` is evaluated
+# against the host, not the compile target, so a `cfg(unix)` table here would not drop
+# these when cross-compiling to Windows from a unix host (confirmed by testing it).
+# build.rs skips codegen off-unix via `CARGO_CFG_UNIX` instead.
 [build-dependencies]
 tonic-prost-build.workspace = true
 protox.workspace = true

--- a/crates/glass-ios/Cargo.toml
+++ b/crates/glass-ios/Cargo.toml
@@ -29,10 +29,11 @@ tokio-stream.workspace = true
 tower = { version = "0.5", features = ["util"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 
-# Deliberately not target-gated: `[target.'cfg(...)'.build-dependencies]` is evaluated
-# against the host, not the compile target, so a `cfg(unix)` table here would not drop
-# these when cross-compiling to Windows from a unix host (confirmed by testing it).
-# build.rs skips codegen off-unix via `CARGO_CFG_UNIX` instead.
+# Deliberately not target-gated: build.rs references these crates unconditionally, so
+# they must resolve on every host, Windows included — gating this table would break a
+# native Windows build (`[target.'cfg(...)'.build-dependencies]` is host-keyed, so on a
+# Windows host a `cfg(unix)` table here would drop them there too). build.rs skips the
+# codegen itself off-unix via `CARGO_CFG_UNIX` instead.
 [build-dependencies]
 tonic-prost-build.workspace = true
 protox.workspace = true

--- a/crates/glass-ios/build.rs
+++ b/crates/glass-ios/build.rs
@@ -4,6 +4,12 @@
 use std::path::PathBuf;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // The generated client's only consumer, the `idb` module, is `#![cfg(unix)]`-gated
+    // in lib.rs; skip codegen when it won't be compiled in. `CARGO_CFG_UNIX` reflects the
+    // compile target, not the host, so this holds under cross-compilation too.
+    if std::env::var_os("CARGO_CFG_UNIX").is_none() {
+        return Ok(());
+    }
     let proto = "proto/idb.proto";
     println!("cargo:rerun-if-changed={proto}");
     // protox parses the proto and returns a prost `FileDescriptorSet`.

--- a/crates/glass-ios/src/lib.rs
+++ b/crates/glass-ios/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg(unix)]
 //! iOS Simulator backend for glass: drives native apps over `xcrun simctl`.
 //!
 //! macOS-only in practice (the tools are Apple's), but the code links nothing

--- a/crates/glass-ios/src/lib.rs
+++ b/crates/glass-ios/src/lib.rs
@@ -1,14 +1,16 @@
-#![cfg(unix)]
 //! iOS Simulator backend for glass: drives native apps over `xcrun simctl`.
 //!
 //! macOS-only in practice — `xcrun simctl` and `idb_companion` are both Apple
 //! tools, and the accessibility/input transport is a Unix-domain-socket gRPC
 //! client to `idb_companion`, so the crate is `cfg(unix)`-gated and compiles
-//! to nothing off unix. The Simulator is the isolation boundary, so there is
-//! no sandbox machinery here. The backend drives input (tap, type, swipe,
-//! scroll) and reads the accessibility tree via `idb_companion`; multi-touch
-//! gestures are unsupported — `idb`'s raw-touch primitive is single-contact,
-//! with no general N-finger primitive to drive them.
+//! to nothing off unix. Gated to `unix` rather than macOS so the crate's pure
+//! logic still compiles and unit-tests on the free Linux runner.
+//! The Simulator is the isolation boundary, so there is no sandbox machinery
+//! here. The backend drives input (tap, type, swipe, scroll) and reads the
+//! accessibility tree via `idb_companion`; multi-touch gestures are
+//! unsupported — `idb`'s raw-touch primitive is single-contact, with no
+//! general N-finger primitive to drive them.
+#![cfg(unix)]
 #![forbid(unsafe_code)]
 
 mod a11y;

--- a/crates/glass-ios/src/lib.rs
+++ b/crates/glass-ios/src/lib.rs
@@ -1,12 +1,14 @@
 #![cfg(unix)]
 //! iOS Simulator backend for glass: drives native apps over `xcrun simctl`.
 //!
-//! macOS-only in practice (the tools are Apple's), but the code links nothing
-//! platform-specific — it shells out. The Simulator is the isolation boundary,
-//! so there is no sandbox machinery here. The backend drives input (tap, type,
-//! swipe, scroll) and reads the accessibility tree via `idb_companion`;
-//! multi-touch gestures are unsupported — `idb`'s raw-touch primitive is
-//! single-contact, with no general N-finger primitive to drive them.
+//! macOS-only in practice — `xcrun simctl` and `idb_companion` are both Apple
+//! tools, and the accessibility/input transport is a Unix-domain-socket gRPC
+//! client to `idb_companion`, so the crate is `cfg(unix)`-gated and compiles
+//! to nothing off unix. The Simulator is the isolation boundary, so there is
+//! no sandbox machinery here. The backend drives input (tap, type, swipe,
+//! scroll) and reads the accessibility tree via `idb_companion`; multi-touch
+//! gestures are unsupported — `idb`'s raw-touch primitive is single-contact,
+//! with no general N-finger primitive to drive them.
 #![forbid(unsafe_code)]
 
 mod a11y;

--- a/crates/glass-ios/tests/drive_integration.rs
+++ b/crates/glass-ios/tests/drive_integration.rs
@@ -1,3 +1,4 @@
+#![cfg(unix)]
 //! End-to-end drive test for the iOS Simulator backend's input + accessibility.
 //!
 //! Launches a real fixture app on a booted Simulator and drives it through the public

--- a/crates/glass-ios/tests/drive_integration.rs
+++ b/crates/glass-ios/tests/drive_integration.rs
@@ -1,4 +1,3 @@
-#![cfg(unix)]
 //! End-to-end drive test for the iOS Simulator backend's input + accessibility.
 //!
 //! Launches a real fixture app on a booted Simulator and drives it through the public
@@ -26,6 +25,8 @@
 //! READY, flips to TAPPED when the button is tapped), `tapButton`, `inputField`, and
 //! `echoLabel` (mirrors the field's text, or `(empty)`) — see
 //! `examples/ios-fixture/README.md`.
+
+#![cfg(unix)]
 
 use std::time::Duration;
 

--- a/crates/glass-ios/tests/launch_args_integration.rs
+++ b/crates/glass-ios/tests/launch_args_integration.rs
@@ -1,4 +1,3 @@
-#![cfg(unix)]
 //! End-to-end proof that `AppSpec::run`'s tail reaches the launched app.
 //!
 //! `run[1..]` is documented as the program's arguments, and every desktop backend spawns them
@@ -20,6 +19,8 @@
 //!
 //! A separate variable from `GLASS_IOS_APP` on purpose: the sibling integration tests drive
 //! `examples/ios-fixture/`, which has no launch-argument surface to check.
+
+#![cfg(unix)]
 
 use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTree, WalkLimits};
 use glass_core::{AppSpec, Platform, SandboxLevel};

--- a/crates/glass-ios/tests/launch_args_integration.rs
+++ b/crates/glass-ios/tests/launch_args_integration.rs
@@ -1,3 +1,4 @@
+#![cfg(unix)]
 //! End-to-end proof that `AppSpec::run`'s tail reaches the launched app.
 //!
 //! `run[1..]` is documented as the program's arguments, and every desktop backend spawns them

--- a/crates/glass-ios/tests/launch_liveness_integration.rs
+++ b/crates/glass-ios/tests/launch_liveness_integration.rs
@@ -1,3 +1,4 @@
+#![cfg(unix)]
 //! End-to-end proof that an app which dies on launch is reported as failed, not started.
 //!
 //! `simctl launch` exits 0 as soon as launchd has spawned the process, so a backend that trusts

--- a/crates/glass-ios/tests/launch_liveness_integration.rs
+++ b/crates/glass-ios/tests/launch_liveness_integration.rs
@@ -1,4 +1,3 @@
-#![cfg(unix)]
 //! End-to-end proof that an app which dies on launch is reported as failed, not started.
 //!
 //! `simctl launch` exits 0 as soon as launchd has spawned the process, so a backend that trusts
@@ -26,6 +25,8 @@
 //! GLASS_IOS_ROLE_FIXTURE="$PWD/examples/ios-role-fixture/build/RoleFixture.app" \
 //!   cargo test -p glass-ios --test launch_liveness_integration -- --ignored --test-threads=1
 //! ```
+
+#![cfg(unix)]
 
 use glass_core::{AppSpec, Platform, SandboxLevel};
 use glass_ios::{IosPlatform, SimulatorRegistry};

--- a/crates/glass-ios/tests/launch_liveness_observe_only_integration.rs
+++ b/crates/glass-ios/tests/launch_liveness_observe_only_integration.rs
@@ -1,4 +1,3 @@
-#![cfg(unix)]
 //! The launch-liveness check on the observe-only path — no `idb_companion`, so no scale
 //! discovery, so the least work between the launch and the check.
 //!
@@ -18,6 +17,7 @@
 //!   cargo test -p glass-ios --test launch_liveness_observe_only_integration -- --ignored
 //! ```
 
+#![cfg(unix)]
 // `env::set_var` is `unsafe` from edition 2024 on (it races concurrent env readers). This binary
 // holds exactly one test, so nothing else in the process reads the environment while it is set.
 // The site carries a `// SAFETY:` note; the file opts out of `unsafe_code = "deny"`. Mirrors

--- a/crates/glass-ios/tests/launch_liveness_observe_only_integration.rs
+++ b/crates/glass-ios/tests/launch_liveness_observe_only_integration.rs
@@ -1,3 +1,4 @@
+#![cfg(unix)]
 //! The launch-liveness check on the observe-only path — no `idb_companion`, so no scale
 //! discovery, so the least work between the launch and the check.
 //!

--- a/crates/glass-ios/tests/observe_only_integration.rs
+++ b/crates/glass-ios/tests/observe_only_integration.rs
@@ -1,4 +1,3 @@
-#![cfg(unix)]
 //! On-box test that the iOS Simulator backend degrades gracefully when `idb_companion`
 //! is unavailable: capture / logs / clipboard keep working (observe-only), while input
 //! and the accessibility tree report a clear `Unsupported` rather than a hard start-up
@@ -17,6 +16,7 @@
 //!   cargo test -p glass-ios --test observe_only_integration -- --ignored --nocapture
 //! ```
 
+#![cfg(unix)]
 // `env::set_var` is `unsafe` from edition 2024 on (it races concurrent env readers). This
 // binary holds exactly one test, so nothing else in the process reads the environment while
 // it is set. The site carries a `// SAFETY:` note; the file opts out of `unsafe_code = "deny"`.

--- a/crates/glass-ios/tests/observe_only_integration.rs
+++ b/crates/glass-ios/tests/observe_only_integration.rs
@@ -1,3 +1,4 @@
+#![cfg(unix)]
 //! On-box test that the iOS Simulator backend degrades gracefully when `idb_companion`
 //! is unavailable: capture / logs / clipboard keep working (observe-only), while input
 //! and the accessibility tree report a clear `Unsupported` rather than a hard start-up

--- a/crates/glass-ios/tests/role_probe.rs
+++ b/crates/glass-ios/tests/role_probe.rs
@@ -1,4 +1,3 @@
-#![cfg(unix)]
 //! Role-histogram PROBE for the iOS half of the accessibility role-parity work — not a
 //! pass/fail assertion test. Launches whatever apps `GLASS_A11Y_PROBE_APPS` names (a
 //! comma-separated list of bundle ids or `.app` paths — exactly what `AppSpec::run`'s first
@@ -25,6 +24,8 @@
 //!
 //! With `GLASS_A11Y_PROBE_APPS` unset (or set but empty) it prints what to set and passes
 //! without probing, so a run that did not ask for this never fails because of it.
+
+#![cfg(unix)]
 
 use std::time::Duration;
 

--- a/crates/glass-ios/tests/role_probe.rs
+++ b/crates/glass-ios/tests/role_probe.rs
@@ -1,3 +1,4 @@
+#![cfg(unix)]
 //! Role-histogram PROBE for the iOS half of the accessibility role-parity work — not a
 //! pass/fail assertion test. Launches whatever apps `GLASS_A11Y_PROBE_APPS` names (a
 //! comma-separated list of bundle ids or `.app` paths — exactly what `AppSpec::run`'s first

--- a/crates/glass-ios/tests/smoke_integration.rs
+++ b/crates/glass-ios/tests/smoke_integration.rs
@@ -1,4 +1,3 @@
-#![cfg(unix)]
 //! On-box smoke test for the iOS Simulator backend: launches a real `.app` on a booted
 //! Simulator and drives it through `glass_core::Platform`'s core surface — start, capture,
 //! clipboard round-trip, stop — exactly the sequence `glass_start`/`glass_screenshot`/
@@ -19,6 +18,8 @@
 //! it itself — no separate `simctl install` step is required. `GLASS_IOS_UDID` / `GLASS_IOS_DEVICE`
 //! / `GLASS_SIMULATOR_KEEP` (all optional) select and manage the Simulator the same way they do
 //! for `glass-mcp`; see `docs/how-to/setup-ios.md`.
+
+#![cfg(unix)]
 
 use glass_core::{AppSpec, Platform, SandboxLevel};
 use glass_ios::{IosPlatform, SimulatorRegistry};

--- a/crates/glass-ios/tests/smoke_integration.rs
+++ b/crates/glass-ios/tests/smoke_integration.rs
@@ -1,3 +1,4 @@
+#![cfg(unix)]
 //! On-box smoke test for the iOS Simulator backend: launches a real `.app` on a booted
 //! Simulator and drives it through `glass_core::Platform`'s core surface — start, capture,
 //! clipboard round-trip, stop — exactly the sequence `glass_start`/`glass_screenshot`/

--- a/crates/glass-ios/tests/startup_log_integration.rs
+++ b/crates/glass-ios/tests/startup_log_integration.rs
@@ -1,4 +1,3 @@
-#![cfg(unix)]
 //! On-box proof for glass-ios #136: a log line an app emits at launch — before its first
 //! frame — is captured.
 //!
@@ -27,6 +26,8 @@
 //! The marker MUST be emitted at the app's earliest launch point (not a delayed `onAppear`),
 //! so it exercises the race the fix closes. `GLASS_IOS_UDID` / `GLASS_IOS_DEVICE` select the
 //! Simulator the same way they do for `glass-mcp`; see `docs/how-to/setup-ios.md`.
+
+#![cfg(unix)]
 
 use std::time::Duration;
 

--- a/crates/glass-ios/tests/startup_log_integration.rs
+++ b/crates/glass-ios/tests/startup_log_integration.rs
@@ -1,3 +1,4 @@
+#![cfg(unix)]
 //! On-box proof for glass-ios #136: a log line an app emits at launch — before its first
 //! frame — is captured.
 //!

--- a/crates/glass-mcp/Cargo.toml
+++ b/crates/glass-mcp/Cargo.toml
@@ -59,7 +59,7 @@ glass-sandbox-macos.workspace = true
 # The iOS Simulator backend links `image`'s `png` codec chain (see glass-ios/Cargo.toml);
 # macOS is the only host that can actually drive `xcrun simctl`, so keep that chain out of
 # the Linux/Windows glass-mcp binary. glass-ios stays a workspace member either way — its
-# own unit tests still run on every host.
+# own unit tests still run on every unix host.
 glass-ios = { path = "../glass-ios" }
 # `setup`'s `gui/<uid>` LaunchAgent install (`rustix::process::getuid`) — a safe syscall
 # wrapper, so no `unsafe` FFI is needed for this. Already a workspace dependency (glass-macos

--- a/crates/glass-sandbox-core/src/lib.rs
+++ b/crates/glass-sandbox-core/src/lib.rs
@@ -71,7 +71,9 @@ pub fn dir_of(p: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
     use std::ffi::OsStr;
+    #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
 
@@ -88,6 +90,7 @@ mod tests {
         assert_eq!(abs_token(Path::new("x/y"), None), None);
     }
 
+    #[cfg(unix)]
     #[test]
     fn resolve_on_path_in_finds_first_executable_match() {
         let dir = tempfile::tempdir().unwrap();
@@ -101,6 +104,7 @@ mod tests {
     /// Pins the documented "first `$PATH` entry wins" contract (`execvp` semantics): with two
     /// directories on `$PATH`, each holding an executable of the SAME name, the match from the
     /// FIRST directory must be returned, not merely any match.
+    #[cfg(unix)]
     #[test]
     fn resolve_on_path_in_returns_the_first_match() {
         let first = tempfile::tempdir().unwrap();
@@ -118,6 +122,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn resolve_on_path_in_skips_non_executable_and_missing() {
         let dir = tempfile::tempdir().unwrap();
@@ -151,6 +156,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn is_executable_file_true_for_exec_false_for_dir_and_plain() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/glass-sandbox-macos/src/reachability.rs
+++ b/crates/glass-sandbox-macos/src/reachability.rs
@@ -231,6 +231,7 @@ mod tests {
     // 6. Symlink program: literal dir AND resolved-target dir both re-allowed.
     // REAL: exercises push_reallows's dual-dir (literal + resolved target) dedup logic.
     // -------------------------------------------------------------------------
+    #[cfg(unix)]
     #[test]
     fn symlink_program_reallows_literal_and_target_dirs() {
         let bindir_root = tempfile::tempdir().unwrap();


### PR DESCRIPTION
`cargo build` and `cargo clippy` now work with `--workspace` on Windows, so the Windows CI job no longer maintains a list of packages by hand.

## Why it didn't

`glass-ios` talks to `idb_companion` over a Unix domain socket, which has no Windows equivalent — and needs none, since `xcrun simctl` and `idb_companion` are Apple tools that cannot run there. Two sandbox crates each had one test reaching `std::os::unix` unconditionally.

None of it was visible: the Windows job's `-p` list never compiled those crates, so the code that made scoping necessary was also the code the scoping hid.

## What changed

- `glass-ios` is gated to `cfg(unix)` — crate root, its 8 integration test binaries, and its dependency table. Windows no longer builds `tonic`/`prost` or runs the `protox` codegen for a client it cannot use.
- One test each in `glass-sandbox-core` and `glass-sandbox-macos` gated to `cfg(unix)`, rather than their whole modules.
- The Windows job's build and clippy steps take `--workspace --all-targets`.

`cfg(unix)` rather than `cfg(target_os = "macos")` deliberately: `unix` covers macOS too, so the crate's 190 pure unit tests keep compiling and running on the Linux runner. Tightening the predicate would still pass CI while silently dropping them.

One wrinkle worth knowing if you touch `glass-ios/Cargo.toml`: `[target.'cfg(…)'.build-dependencies]` is keyed on the **host**, not the compile target, so gating that table would break a native Windows build rather than trim it. `build.rs` skips its codegen via `CARGO_CFG_UNIX` instead.

## Verifying

```
cargo clippy --target x86_64-pc-windows-gnu --workspace --all-targets -- -D warnings   # clean
cargo test -p glass-ios --lib                                                          # 192 tests
```

The test count is the load-bearing check: gating that swallowed something portable would show up here as a smaller number, not as a Windows error. It is unchanged at 192, with `glass-sandbox-core` at 7 and `glass-sandbox-macos` at 34.

`x86_64-pc-windows-msvc` is what CI builds; it can't be exercised from a Linux host, so this job is the first msvc run of the change.

## Not included

The Windows `cargo test` step stays scoped. Three crates have pre-existing test failures under Windows path semantics — 19 in total, tracked in #299 — and widening the step before those are fixed would just turn them red. Once #299 lands, the list goes and the step follows build and clippy to `--workspace`.

Closes the Windows half of #293.
