### PR TITLE
fix(ci): run cargo test --workspace on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,16 +220,12 @@ jobs:
         with:
           workspaces: .
       # The Linux-only and unix-only crates gate themselves (#293), so --workspace
-      # resolves here for build/clippy. cargo test stays scoped for now — this same
-      # `-p` list is what hid 19 pre-existing Windows-path-semantics failures in
-      # glass-android, glass-sandbox-core and glass-sandbox-macos (POSIX-style
-      # absolute-path assertions that don't hold on Windows), tracked in #299.
-      # Every other crate's tests are platform-independent and already covered by
-      # the Linux job's `cargo test --workspace`; once #299 lands, drop this list
-      # and go --workspace here too.
+      # resolves here. Keep all three steps --workspace: a hand-maintained `-p` list
+      # stops compiling what it omits, so it hides the very failures that argue for
+      # keeping it (#299 found 19 across three crates that way).
       - run: cargo build  --workspace --all-targets --locked
       - run: cargo clippy --workspace --all-targets --locked -- -D warnings
-      - run: cargo test   -p glass-core -p glass-windows -p glass-a11y-windows -p glass-mcp --locked
+      - run: cargo test   --workspace --locked
 
   coverage:
     name: coverage (report-only)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,7 +1172,6 @@ dependencies = [
  "glass-dbus-linux",
  "glass-ios",
  "glass-macos",
- "glass-sandbox-core",
  "glass-sandbox-linux",
  "glass-sandbox-macos",
  "glass-wayland",

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -342,8 +342,20 @@ mod tests {
 
         // Built by running a real timeout rather than typed here: the gate keys on wording that
         // `glass-core` owns, so a fixture repeating that wording could not notice it drifting.
+        //
+        // `ping` stands in for `sleep` on Windows (no `/bin/sh` there) — it paces one echo per
+        // second even when transmission fails, so it reliably outlives the 200ms budget.
+        #[cfg(unix)]
+        let mut hang = std::process::Command::new("/bin/sh");
+        #[cfg(unix)]
+        hang.args(["-c", "sleep 30"]);
+        #[cfg(windows)]
+        let mut hang = std::process::Command::new("ping");
+        #[cfg(windows)]
+        hang.args(["-n", "31", "127.0.0.1"]);
+
         let real_timeout = glass_core::run_bounded(
-            std::process::Command::new("/bin/sh").args(["-c", "sleep 30"]),
+            &mut hang,
             std::time::Duration::from_millis(200),
             "adb:shell",
         )

--- a/crates/glass-android/src/avd.rs
+++ b/crates/glass-android/src/avd.rs
@@ -307,23 +307,27 @@ mod tests {
         };
         assert_eq!(resolve_emulator_bin(&env, &|_| true), "/custom/emulator");
 
+        // Built the same way `resolve_emulator_bin` builds it, so this pins the host-correct
+        // separator and `.exe` suffix rather than a POSIX literal.
+        let want_bin = |root: &str| {
+            std::path::PathBuf::from(root)
+                .join("emulator")
+                .join(emulator_exe())
+                .to_string_lossy()
+                .into_owned()
+        };
+
         let env = |k: &str| match k {
             "ANDROID_SDK_ROOT" => Some("/sdk".to_string()),
             _ => None,
         };
-        assert_eq!(
-            resolve_emulator_bin(&env, &|_| true),
-            "/sdk/emulator/emulator"
-        );
+        assert_eq!(resolve_emulator_bin(&env, &|_| true), want_bin("/sdk"));
 
         let env = |k: &str| match k {
             "ANDROID_HOME" => Some("/home/sdk".to_string()),
             _ => None,
         };
-        assert_eq!(
-            resolve_emulator_bin(&env, &|_| true),
-            "/home/sdk/emulator/emulator"
-        );
+        assert_eq!(resolve_emulator_bin(&env, &|_| true), want_bin("/home/sdk"));
 
         let env = |_: &str| None;
         assert_eq!(resolve_emulator_bin(&env, &|_| false), "emulator");

--- a/crates/glass-android/src/sdk.rs
+++ b/crates/glass-android/src/sdk.rs
@@ -232,6 +232,37 @@ mod tests {
         assert_eq!(resolve_adb(&get, &|_| true).bin(), "/custom/adb");
     }
 
+    // One variant per OS: a single HOME-based fixture would silently no-op on Windows,
+    // which keys its default location off LOCALAPPDATA, not HOME.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn adb_from_discovered_sdk() {
+        let get = getter(&[("LOCALAPPDATA", r"C:\Users\u\AppData\Local")]);
+        let root = Path::new(r"C:\Users\u\AppData\Local")
+            .join("Android")
+            .join("Sdk");
+        let bin = root.join("platform-tools").join(adb_exe());
+        let exists = |p: &Path| p == root.as_path() || p == bin.as_path();
+        match resolve_adb(&get, &exists) {
+            AdbResolution::Sdk { bin: got, .. } => assert_eq!(got, bin.to_string_lossy()),
+            other => panic!("expected Sdk, got {other:?}"),
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn adb_from_discovered_sdk() {
+        let get = getter(&[("HOME", "/home/u")]);
+        let root = PathBuf::from("/home/u/Library/Android/sdk");
+        let bin = root.join("platform-tools").join(adb_exe());
+        let exists = |p: &Path| p == root.as_path() || p == bin.as_path();
+        match resolve_adb(&get, &exists) {
+            AdbResolution::Sdk { bin: got, .. } => assert_eq!(got, bin.to_string_lossy()),
+            other => panic!("expected Sdk, got {other:?}"),
+        }
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     #[test]
     fn adb_from_discovered_sdk() {
         let get = getter(&[("HOME", "/home/u")]);
@@ -270,6 +301,35 @@ mod tests {
         assert!(d.contains("discovered"), "got {d}");
     }
 
+    // One variant per OS, same reason as `adb_from_discovered_sdk` above: `sdk_search_trail`
+    // also reads through `default_locations`.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn trail_lists_env_then_defaults() {
+        let get = getter(&[("LOCALAPPDATA", r"C:\Users\u\AppData\Local")]);
+        let t = sdk_search_trail(&get);
+        assert_eq!(&t[0], "ANDROID_SDK_ROOT");
+        assert_eq!(&t[1], "ANDROID_HOME");
+        assert!(
+            t.iter().any(|s| s.contains("Android") && s.contains("Sdk")),
+            "trail: {t:?}"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn trail_lists_env_then_defaults() {
+        let get = getter(&[("HOME", "/home/u")]);
+        let t = sdk_search_trail(&get);
+        assert_eq!(&t[0], "ANDROID_SDK_ROOT");
+        assert_eq!(&t[1], "ANDROID_HOME");
+        assert!(
+            t.iter().any(|s| s.contains("Library/Android")),
+            "trail: {t:?}"
+        );
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     #[test]
     fn trail_lists_env_then_defaults() {
         let get = getter(&[("HOME", "/home/u")]);
@@ -306,7 +366,13 @@ mod tests {
             &get,
             &exists,
         );
-        assert_eq!(r.as_deref(), Some("/data/glass/glass-agent.jar"));
+        // Joined rather than a POSIX literal: `resolve_artifact` builds the path with `Path::join`,
+        // which uses `\` on Windows.
+        let want = PathBuf::from("/data/glass")
+            .join("glass-agent.jar")
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(r.as_deref(), Some(want.as_str()));
     }
 
     #[test]

--- a/crates/glass-mcp/Cargo.toml
+++ b/crates/glass-mcp/Cargo.toml
@@ -19,9 +19,6 @@ network = [
 [dependencies]
 glass-android.workspace = true
 glass-core.workspace = true
-# Not for sandboxing: `smoke`'s target-app probe reuses its `$PATH` resolver, which already
-# has execvp's semantics (executable regular file, first match wins).
-glass-sandbox-core.workspace = true
 rmcp = { version = "2.2", features = ["server", "macros", "transport-io"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/glass-sandbox-core/src/lib.rs
+++ b/crates/glass-sandbox-core/src/lib.rs
@@ -1,8 +1,12 @@
-//! Pure, portable launch-target *resolution* atoms shared by glass's per-OS sandbox crates
+//! Launch-target *resolution* atoms shared by glass's per-OS sandbox crates
 //! (`glass-sandbox-linux`, `glass-sandbox-macos`). No OS-specific containment logic lives here —
 //! only "given a program + args + cwd, what absolute host paths does the launch actually touch,
 //! resolved the way the child is exec'd." Each backend applies its OWN exposure guard/emit on top.
-//! std-only; builds on every target so a `--workspace` build never breaks.
+//!
+//! Unix-only, because both consumers are: bwrap and Seatbelt have no Windows counterpart. Gating
+//! the crate is what lets `is_absolute()` and the execute-bit check mean what they say — compiled
+//! for Windows, `/a/b` reads as relative and the mode check has nothing to test.
+#![cfg(unix)]
 #![forbid(unsafe_code)]
 
 use std::ffi::OsStr;
@@ -36,20 +40,12 @@ pub fn resolve_on_path_in(program: &OsStr, path: &OsStr) -> Option<PathBuf> {
 }
 
 /// Whether `p` is (or resolves through symlinks to) a regular file that is executable — `execvp`'s
-/// "is this runnable" test. The execute-bit check is a Unix concept (mode `& 0o111`); on non-unix
-/// hosts (where glass has no Seatbelt/bwrap sandbox) it degrades to "is a regular file" so the
-/// crate still compiles as a `--workspace` member.
-#[cfg(unix)]
+/// "is this runnable" test.
 pub(crate) fn is_executable_file(p: &Path) -> bool {
     use std::os::unix::fs::PermissionsExt;
     std::fs::metadata(p)
         .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
         .unwrap_or(false)
-}
-
-#[cfg(not(unix))]
-pub(crate) fn is_executable_file(p: &Path) -> bool {
-    std::fs::metadata(p).map(|m| m.is_file()).unwrap_or(false)
 }
 
 /// Best-effort path canonicalization that never panics on a nonexistent path: the resolved path,
@@ -71,9 +67,7 @@ pub fn dir_of(p: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(unix)]
     use std::ffi::OsStr;
-    #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
 
@@ -90,7 +84,6 @@ mod tests {
         assert_eq!(abs_token(Path::new("x/y"), None), None);
     }
 
-    #[cfg(unix)]
     #[test]
     fn resolve_on_path_in_finds_first_executable_match() {
         let dir = tempfile::tempdir().unwrap();
@@ -104,7 +97,6 @@ mod tests {
     /// Pins the documented "first `$PATH` entry wins" contract (`execvp` semantics): with two
     /// directories on `$PATH`, each holding an executable of the SAME name, the match from the
     /// FIRST directory must be returned, not merely any match.
-    #[cfg(unix)]
     #[test]
     fn resolve_on_path_in_returns_the_first_match() {
         let first = tempfile::tempdir().unwrap();
@@ -122,7 +114,6 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[test]
     fn resolve_on_path_in_skips_non_executable_and_missing() {
         let dir = tempfile::tempdir().unwrap();
@@ -156,7 +147,6 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[test]
     fn is_executable_file_true_for_exec_false_for_dir_and_plain() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/glass-sandbox-macos/src/lib.rs
+++ b/crates/glass-sandbox-macos/src/lib.rs
@@ -1,15 +1,18 @@
 //! macOS process containment (Seatbelt) for glass, implementing `SandboxLevel::Default`/
-//! `Strict`. The pure [`build_profile`] SBPL generator ([`profile`]) is cross-platform and
-//! unit-tested on any host — likewise [`launch_reallows`] ([`reachability`]), which
-//! computes the re-allows a launch needs to reach its own target under the profile's home
-//! deny; the `sandbox_init` FFI ([`ffi`]) is macOS-only mechanism. [`doctor`] is
-//! cross-platform: it reports `Ok` on macOS and `Unavailable` elsewhere, so `glass doctor`
-//! can report on this crate from any host. Mirrors `glass-sandbox-linux`'s split (pure
-//! `wrap_argv` + OS mechanism).
+//! `Strict`. The pure [`build_profile`] SBPL generator ([`profile`]) and [`launch_reallows`]
+//! ([`reachability`]) — which computes the re-allows a launch needs to reach its own target
+//! under the profile's home deny — describe POSIX paths, so they build and unit-test on any
+//! unix host; the `sandbox_init` FFI ([`ffi`]) is macOS-only mechanism. [`doctor`] reports
+//! `Ok` on macOS and `Unavailable` on other unix hosts. Mirrors `glass-sandbox-linux`'s split
+//! (pure `wrap_argv` + OS mechanism).
+//!
+//! Unix-only: Seatbelt has no Windows counterpart, and `glass-mcp` links this crate only under
+//! `cfg(target_os = "macos")`.
 
 // FFI backend: the `sandbox_init` mechanism needs `unsafe`, so this crate opts out of the
 // workspace `unsafe_code = "deny"`; each site carries a `// SAFETY:` note (see CLAUDE.md). The
 // pure `profile`/`doctor` modules stay `unsafe`-free by convention.
+#![cfg(unix)]
 #![allow(unsafe_code)]
 
 pub mod doctor;

--- a/crates/glass-sandbox-macos/src/reachability.rs
+++ b/crates/glass-sandbox-macos/src/reachability.rs
@@ -231,7 +231,6 @@ mod tests {
     // 6. Symlink program: literal dir AND resolved-target dir both re-allowed.
     // REAL: exercises push_reallows's dual-dir (literal + resolved target) dedup logic.
     // -------------------------------------------------------------------------
-    #[cfg(unix)]
     #[test]
     fn symlink_program_reallows_literal_and_target_dirs() {
         let bindir_root = tempfile::tempdir().unwrap();


### PR DESCRIPTION
The Windows CI job now runs `cargo test --workspace`, like the Linux and macOS jobs. The hand-written `-p` package list is gone.

That list ran 922 tests. `--workspace` runs 1297.

A scoped list stops compiling the crates it omits, so the failures that justify keeping it accumulate where nothing can see them — and the justification sustains itself. There were 19, in two unrelated categories.

## glass-android

This crate is host-OS-agnostic: it drives an emulator over `adb` from Linux, macOS or Windows. Its production code was already correct, joining with the platform separator and appending `.exe`. The tests asserted POSIX literals, so they demanded the wrong answer on Windows:

```
left:  "/sdk\\emulator\\emulator.exe"   ← what the code produces
right: "/sdk/emulator/emulator"         ← what the test asserted
```

Two others failed for a more interesting reason. They set only `HOME`, so on Windows they missed `default_locations`' `LOCALAPPDATA` branch entirely — not a string mismatch but a resolution path no test had ever entered, on the one platform where that branch exists.

## The sandbox crates

`glass-sandbox-core` and `glass-sandbox-macos` are now `cfg(unix)` at the crate root.

That is what they already were. `glass-sandbox-core` has exactly two consumers, `glass-sandbox-linux` (bwrap) and `glass-sandbox-macos` (Seatbelt), and neither has a Windows counterpart; `glass-mcp` links the macOS crate only under `cfg(target_os = "macos")`, and its dependency on the core crate was unused, with a comment describing a caller that doesn't exist.

Compiling them for Windows regardless is what made `Path::is_absolute()` look like a bug. It isn't one: on unix it is defined as `has_root()`, exactly the "starts with `/`" test this code wants when it describes bwrap arguments and Seatbelt profiles. The apparent failures were an artifact of building POSIX path logic for a target it never ships on.

Gating the crates is therefore a narrowing, not a workaround — it deletes code rather than adding it, and both crates run the same 7 and 34 tests on Linux as before.

## Verifying

```
cargo test --workspace                                    # Linux: 1796 passed
cargo clippy --workspace --all-targets -- -D warnings     # clean
```

On a Windows host, `cargo test --workspace` should report 1297 passed. Cross-checking from Linux needs the gnu triple — msvc can't link without `lib.exe`:

```
CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUNNER=wine \
  cargo test --workspace --target x86_64-pc-windows-gnu --no-fail-fast
```

wine is reliable for *failures* in path-string logic, since `PathBuf` formatting and the executable suffix are baked in per target rather than emulated. This job is the first msvc run either way.

## Not included

Four test-quality issues in `glass-android`, filed as #300: a timeout test that would also accept a spawn failure, an executable-suffix assertion that can't fail because it builds its expectation with the same helper the code calls, three tests still Linux-only that leave the `LOCALAPPDATA` branch uncovered, and one over-loose `contains()`. All predate this change and none affect the CI move.

Closes #299.
