### PR TITLE
refactor: rename glass-sandbox-core to glass-sandbox-unix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,18 +1200,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "glass-sandbox-core"
-version = "0.0.0"
-dependencies = [
- "tempfile",
-]
-
-[[package]]
 name = "glass-sandbox-linux"
 version = "0.0.0"
 dependencies = [
  "glass-core",
- "glass-sandbox-core",
+ "glass-sandbox-unix",
  "tempfile",
 ]
 
@@ -1220,7 +1213,14 @@ name = "glass-sandbox-macos"
 version = "0.0.0"
 dependencies = [
  "glass-core",
- "glass-sandbox-core",
+ "glass-sandbox-unix",
+ "tempfile",
+]
+
+[[package]]
+name = "glass-sandbox-unix"
+version = "0.0.0"
+dependencies = [
  "tempfile",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/glass-core", "crates/glass-x11", "crates/glass-testapp", "crates/glass-mcp", "crates/glass-wayland", "crates/glass-a11y-linux", "crates/glass-windows", "crates/glass-a11y-windows", "crates/glass-sandbox-core", "crates/glass-sandbox-linux", "crates/glass-proc-linux", "crates/glass-clip-hook", "crates/glass-dbus-linux", "crates/glass-android", "crates/glass-macos", "crates/glass-a11y-macos", "crates/glass-sandbox-macos", "crates/glass-clip-shim-macos", "crates/glass-ios"]
+members = ["crates/glass-core", "crates/glass-x11", "crates/glass-testapp", "crates/glass-mcp", "crates/glass-wayland", "crates/glass-a11y-linux", "crates/glass-windows", "crates/glass-a11y-windows", "crates/glass-sandbox-unix", "crates/glass-sandbox-linux", "crates/glass-proc-linux", "crates/glass-clip-hook", "crates/glass-dbus-linux", "crates/glass-android", "crates/glass-macos", "crates/glass-a11y-macos", "crates/glass-sandbox-macos", "crates/glass-clip-shim-macos", "crates/glass-ios"]
 # glass-fixture-egui is intentionally excluded: heavy egui deps, only exercised by #[ignore]d
 # on-box a11y tests CI can't run. Built on-demand on the box.
 exclude = ["crates/glass-fixture-egui"]
@@ -40,7 +40,7 @@ x11rb = { version = "0.14", features = ["xtest"] }
 glass-android = { path = "crates/glass-android" }
 glass-ios = { path = "crates/glass-ios" }
 glass-core = { path = "crates/glass-core" }
-glass-sandbox-core = { path = "crates/glass-sandbox-core" }
+glass-sandbox-unix = { path = "crates/glass-sandbox-unix" }
 glass-sandbox-linux = { path = "crates/glass-sandbox-linux" }
 glass-sandbox-macos = { path = "crates/glass-sandbox-macos" }
 glass-proc-linux = { path = "crates/glass-proc-linux" }

--- a/crates/glass-sandbox-linux/Cargo.toml
+++ b/crates/glass-sandbox-linux/Cargo.toml
@@ -8,7 +8,7 @@ publish.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 glass-core.workspace = true
-glass-sandbox-core.workspace = true
+glass-sandbox-unix.workspace = true
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 tempfile.workspace = true

--- a/crates/glass-sandbox-linux/src/lib.rs
+++ b/crates/glass-sandbox-linux/src/lib.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use glass_core::{AppSpec, Check, CheckStatus, GlassError, Result, SandboxLevel};
-use glass_sandbox_core::{abs_token, canon, dir_of, resolve_on_path_in};
+use glass_sandbox_unix::{abs_token, canon, dir_of, resolve_on_path_in};
 
 /// App-level environment that makes GUI toolkits present frames without X11 MIT-SHM. glass's
 /// containment breaks shared-memory rendering on the headless display: `wrap_argv` passes

--- a/crates/glass-sandbox-macos/Cargo.toml
+++ b/crates/glass-sandbox-macos/Cargo.toml
@@ -8,7 +8,7 @@ publish.workspace = true
 
 [dependencies]
 glass-core.workspace = true
-glass-sandbox-core.workspace = true
+glass-sandbox-unix.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/glass-sandbox-macos/src/reachability.rs
+++ b/crates/glass-sandbox-macos/src/reachability.rs
@@ -1,12 +1,12 @@
 //! Compute the Seatbelt re-allows that make a sandboxed launch's OWN target reachable under the
 //! `/Users` read-deny, without re-exposing home. Resolution is shared with the Linux backend
-//! (`glass-sandbox-core`); only the emit differs: a safe directory becomes a `(subpath …)`
+//! (`glass-sandbox-unix`); only the emit differs: a safe directory becomes a `(subpath …)`
 //! re-allow (ro_binds), a file directly under a bare home root becomes a single-file `(literal …)`
 //! re-allow (ro_files), and a target that IS a home root or above contributes nothing.
 
 use std::path::{Path, PathBuf};
 
-use glass_sandbox_core::{abs_token, canon, dir_of, resolve_on_path};
+use glass_sandbox_unix::{abs_token, canon, dir_of, resolve_on_path};
 
 use crate::profile::{is_home_root_or_above, is_safe_reallow, under_users};
 

--- a/crates/glass-sandbox-unix/Cargo.toml
+++ b/crates/glass-sandbox-unix/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "glass-sandbox-core"
+name = "glass-sandbox-unix"
 version = "0.0.0"
 edition.workspace = true
 license.workspace = true

--- a/crates/glass-sandbox-unix/src/lib.rs
+++ b/crates/glass-sandbox-unix/src/lib.rs
@@ -1,11 +1,11 @@
-//! Launch-target *resolution* atoms shared by glass's per-OS sandbox crates
-//! (`glass-sandbox-linux`, `glass-sandbox-macos`). No OS-specific containment logic lives here —
-//! only "given a program + args + cwd, what absolute host paths does the launch actually touch,
-//! resolved the way the child is exec'd." Each backend applies its OWN exposure guard/emit on top.
+//! Launch-target *resolution* atoms shared by glass's two sandbox backends, bwrap on Linux
+//! (`glass-sandbox-linux`) and Seatbelt on macOS (`glass-sandbox-macos`) — unix both, which is
+//! what makes this crate unix. No OS-specific containment logic lives here: only "given a
+//! program + args + cwd, what absolute host paths does the launch actually touch, resolved the
+//! way the child is exec'd." Each backend applies its OWN exposure guard/emit on top.
 //!
-//! Unix-only, because both consumers are: bwrap and Seatbelt have no Windows counterpart. Gating
-//! the crate is what lets `is_absolute()` and the execute-bit check mean what they say — compiled
-//! for Windows, `/a/b` reads as relative and the mode check has nothing to test.
+//! Everything here reads POSIX semantics — `/`-rooted paths, the execute bit, `execvp` lookup —
+//! so compiled off unix `is_absolute()` and the mode check would quietly mean something else.
 #![cfg(unix)]
 #![forbid(unsafe_code)]
 


### PR DESCRIPTION
`-core` means "platform-agnostic" in this workspace — that is what `glass-core` is. This crate isn't.

Its production consumers are bwrap on Linux (`glass-sandbox-linux`) and Seatbelt on macOS (`glass-sandbox-macos`), both unix, and everything in it reads POSIX semantics: `/`-rooted paths, the execute bit, `execvp` lookup. The old name promised a portability the crate does not have, which is how #299 ended up inventing an `is_posix_absolute` whose name existed only to apologize for the crate it lived in.

Rename only — no behaviour change. Nothing in the workspace is published, so there is no external consumer to break.

## Verifying

```
cargo test --workspace     # 1796 passed, unchanged
cargo clippy --workspace --all-targets -- -D warnings
```

Windows is unchanged at 1297 (`cargo test --workspace --target x86_64-pc-windows-gnu`, wine runner).

## Note on the sibling crates

`glass-sandbox-macos` and `glass-ios` both carry `#![cfg(unix)]` roots while naming a single platform. That is not the same defect: their production use *is* macOS and iOS respectively, and the broader gate only lets their pure logic build and unit-test on the Linux runner. Names track production use, so those stay.