### PR TITLE
test(android): make four assertions able to fail

### DIFF
--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -201,7 +201,7 @@ fn exit_error(bin: &str, argv: &[String], out: &Output) -> GlassError {
 #[cfg(test)]
 mod tests {
     use super::{Adb, AdbOp, build_argv, with_adb_hint};
-    use glass_core::GlassError;
+    use glass_core::{GlassError, TIMED_OUT};
     use std::time::Duration;
 
     /// Live proof that a wedged adb call ends instead of hanging. Ignored by default:
@@ -360,6 +360,12 @@ mod tests {
             "adb:shell",
         )
         .expect_err("must time out");
+        // A spawn failure is also an Err: it sails past `expect_err`, then fails the hint
+        // assertion below, blaming `with_adb_hint` for a missing binary.
+        assert!(
+            real_timeout.to_string().contains(TIMED_OUT),
+            "expected a timeout, got: {real_timeout}"
+        );
         let timeout = with_adb_hint(real_timeout);
         assert!(timeout.to_string().contains("adb kill-server"), "{timeout}");
         // Extending the message must not wrap one Backend in another: Display prints its prefix

--- a/crates/glass-android/src/avd.rs
+++ b/crates/glass-android/src/avd.rs
@@ -307,8 +307,9 @@ mod tests {
         };
         assert_eq!(resolve_emulator_bin(&env, &|_| true), "/custom/emulator");
 
-        // Built the same way `resolve_emulator_bin` builds it, so this pins the host-correct
-        // separator and `.exe` suffix rather than a POSIX literal.
+        // Shares `emulator_exe()` with the code under test, so this pins root selection and the
+        // `emulator/` segment but NOT the leaf name — `emulator_exe_carries_the_platform_suffix`
+        // does that.
         let want_bin = |root: &str| {
             std::path::PathBuf::from(root)
                 .join("emulator")
@@ -333,8 +334,18 @@ mod tests {
         assert_eq!(resolve_emulator_bin(&env, &|_| false), "emulator");
     }
 
-    // Default install locations are OS-specific (Linux paths here); gate so the
-    // cross-platform CI (incl. the Windows job) doesn't run this assertion.
+    /// Pins the leaf name directly: every other assertion builds its expectation with
+    /// `emulator_exe()` itself, so none of them can falsify the suffix.
+    #[test]
+    fn emulator_exe_carries_the_platform_suffix() {
+        #[cfg(windows)]
+        assert_eq!(emulator_exe(), "emulator.exe");
+        #[cfg(not(windows))]
+        assert_eq!(emulator_exe(), "emulator");
+    }
+
+    // One variant per OS: the Windows arm keys off LOCALAPPDATA, so a HOME-only fixture finds
+    // nothing and passes while proving nothing.
     #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     #[test]
     fn emulator_from_discovered_default_sdk() {
@@ -347,6 +358,36 @@ mod tests {
         assert_eq!(
             resolve_emulator_bin(&env, &exists),
             "/home/u/android-sdk/emulator/emulator"
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn emulator_from_discovered_default_sdk() {
+        let env = |k: &str| match k {
+            "LOCALAPPDATA" => Some(r"C:\Users\u\AppData\Local".to_string()),
+            _ => None,
+        };
+        let root = r"C:\Users\u\AppData\Local\Android\Sdk";
+        let exists = |p: &std::path::Path| p == std::path::Path::new(root);
+        assert_eq!(
+            resolve_emulator_bin(&env, &exists),
+            format!(r"{root}\emulator\emulator.exe")
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn emulator_from_discovered_default_sdk() {
+        let env = |k: &str| match k {
+            "HOME" => Some("/Users/u".to_string()),
+            _ => None,
+        };
+        let root = "/Users/u/Library/Android/sdk";
+        let exists = |p: &std::path::Path| p == std::path::Path::new(root);
+        assert_eq!(
+            resolve_emulator_bin(&env, &exists),
+            format!("{root}/emulator/emulator")
         );
     }
 

--- a/crates/glass-android/src/sdk.rs
+++ b/crates/glass-android/src/sdk.rs
@@ -310,8 +310,10 @@ mod tests {
         let t = sdk_search_trail(&get);
         assert_eq!(&t[0], "ANDROID_SDK_ROOT");
         assert_eq!(&t[1], "ANDROID_HOME");
-        assert!(
-            t.iter().any(|s| s.contains("Android") && s.contains("Sdk")),
+        // The exact path, not a `contains` pair: `Android` and `Sdk` both appearing also holds
+        // for `…\Sdk\Android`.
+        assert_eq!(
+            &t[2], r"C:\Users\u\AppData\Local\Android\Sdk",
             "trail: {t:?}"
         );
     }
@@ -323,10 +325,7 @@ mod tests {
         let t = sdk_search_trail(&get);
         assert_eq!(&t[0], "ANDROID_SDK_ROOT");
         assert_eq!(&t[1], "ANDROID_HOME");
-        assert!(
-            t.iter().any(|s| s.contains("Library/Android")),
-            "trail: {t:?}"
-        );
+        assert_eq!(&t[2], "/home/u/Library/Android/sdk", "trail: {t:?}");
     }
 
     #[cfg(not(any(target_os = "windows", target_os = "macos")))]
@@ -404,6 +403,18 @@ mod tests {
         assert_eq!(r.as_deref(), Some("/explicit/missing.jar"));
     }
 
+    /// Pins the leaf name directly: the other assertions build their expectation with
+    /// `adb_exe()`, so none can catch it returning the wrong name.
+    #[test]
+    fn adb_exe_carries_the_platform_suffix() {
+        #[cfg(windows)]
+        assert_eq!(adb_exe(), "adb.exe");
+        #[cfg(not(windows))]
+        assert_eq!(adb_exe(), "adb");
+    }
+
+    // One variant per OS: the Windows arm reads APPDATA/LOCALAPPDATA, vars no Linux run can
+    // exercise.
     #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     #[test]
     fn data_dirs_prefer_xdg_then_home() {
@@ -413,6 +424,32 @@ mod tests {
         assert_eq!(
             artifact_data_dirs(&get2)[0],
             PathBuf::from("/home/u/.local/share/glass")
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn data_dirs_list_appdata_then_localappdata() {
+        let get = getter(&[
+            ("APPDATA", r"C:\Users\u\AppData\Roaming"),
+            ("LOCALAPPDATA", r"C:\Users\u\AppData\Local"),
+        ]);
+        let d = artifact_data_dirs(&get);
+        assert_eq!(d[0], PathBuf::from(r"C:\Users\u\AppData\Roaming\glass"));
+        assert_eq!(d[1], PathBuf::from(r"C:\Users\u\AppData\Local\glass"));
+
+        // HOME is not a Windows source — set alone it yields nothing, the silent no-op a
+        // HOME-only fixture passed through.
+        assert!(artifact_data_dirs(&getter(&[("HOME", r"C:\Users\u")])).is_empty());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn data_dirs_use_application_support() {
+        let get = getter(&[("HOME", "/Users/u")]);
+        assert_eq!(
+            artifact_data_dirs(&get)[0],
+            PathBuf::from("/Users/u/Library/Application Support/glass")
         );
     }
 
@@ -435,14 +472,34 @@ mod tests {
         assert_eq!(r.source, SdkSource::Env("ANDROID_HOME"));
     }
 
-    // Default install locations are OS-specific (Linux paths here); gate so the
-    // cross-platform CI (incl. the Windows job) doesn't run this assertion.
+    // One variant per OS: the Windows arm keys off LOCALAPPDATA, so a HOME-only fixture finds
+    // nothing and passes while proving nothing.
     #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     #[test]
     fn discovers_default_location_with_no_env() {
         let get = getter(&[("HOME", "/home/u")]);
         let r = resolve_sdk_root(&get, &|p| p == Path::new("/home/u/android-sdk")).unwrap();
         assert_eq!(r.path, PathBuf::from("/home/u/android-sdk"));
+        assert_eq!(r.source, SdkSource::Default);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn discovers_default_location_with_no_env() {
+        let get = getter(&[("LOCALAPPDATA", r"C:\Users\u\AppData\Local")]);
+        let want = Path::new(r"C:\Users\u\AppData\Local\Android\Sdk");
+        let r = resolve_sdk_root(&get, &|p| p == want).unwrap();
+        assert_eq!(r.path, want.to_path_buf());
+        assert_eq!(r.source, SdkSource::Default);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn discovers_default_location_with_no_env() {
+        let get = getter(&[("HOME", "/Users/u")]);
+        let want = Path::new("/Users/u/Library/Android/sdk");
+        let r = resolve_sdk_root(&get, &|p| p == want).unwrap();
+        assert_eq!(r.path, want.to_path_buf());
         assert_eq!(r.source, SdkSource::Default);
     }
 


### PR DESCRIPTION
Four assertions in `glass-android` passed regardless of what the code did. `glass-android` runs on Windows hosts, so these were real gaps rather than artifacts of testing a crate off its platform.

## What was wrong

**A timeout test that accepted a spawn failure.** `only_a_timeout_gets_the_kill_server_remedy` builds a real timeout by running a hanging process, but `expect_err("must time out")` is equally satisfied by `Backend("adb:shell: failed to start: …")`. On a host without `sh` or `ping` it failed a line later on the `kill-server` assertion, pointing at `with_adb_hint` rather than at the missing binary. It now pins `TIMED_OUT` — the constant `with_adb_hint` itself gates on — before passing the error along.

**An executable suffix nothing could falsify.** `adb_exe()` and `emulator_exe()` had no test of their own, and every assertion that exercised them built its expectation by calling them. On Windows and macOS that closed the loop entirely: the `exists` closure reported whichever leaf name the helper returned, and the assertion then compared that to itself. Both are now pinned directly, per OS. The Linux variants used literals and did catch a broken helper.

**Two Windows-only branches with no coverage on any platform.** `artifact_data_dirs`' `APPDATA`/`LOCALAPPDATA` arm and the Windows default SDK location were tested only by Linux-gated tests — and those are branches Linux cannot reach. They now have per-OS variants, matching the two neighbouring tests that already had them.

**A `contains` pair that accepted the wrong path.** The Windows trail asserted `contains("Android") && contains("Sdk")`, which also holds for `…\Sdk\Android`. Pinned to the exact path `default_locations` produces.

## Evidence

Each fix was confirmed by breaking the behaviour it names and observing the failure, not by observing green:

| broken | result |
|---|---|
| point the hang at a nonexistent binary | `expected a timeout, got: … failed to start: No such file or directory` |
| `adb_exe()` returns the wrong name | new pin fails; `adb_glass_override_wins` / `adb_falls_back_to_path` still pass |
| `emulator_exe()` returns the wrong name | new pin fails; `emulator_bin_prefers_glass_then_sdk_then_path` **still passes** — the tautology, confirmed |
| drop `LOCALAPPDATA` from `artifact_data_dirs` | Windows data-dirs test fails |
| swap the default location to `…\Sdk\Android` | `left: …\Local\Sdk\Android`, `right: …\Local\Android\Sdk` — exactly what the old `contains` pair allowed |

## Verifying

```
cargo test --workspace                                    # Linux: 1802 (was 1800)
cargo clippy --workspace --all-targets -- -D warnings
```

Windows: 1306 (was 1301), via `cargo test --workspace --target x86_64-pc-windows-gnu` under wine. The rise is the point — three of the new tests exist only on Windows, covering branches that exist only there.

`emulator_bin_prefers_glass_then_sdk_then_path` keeps building its expectation with the helper: it still pins root selection and the `emulator/` segment on every host, which is worth keeping. Its comment no longer claims to pin the leaf name, since it demonstrably doesn't.

## Known limitation

The three `cfg(target_os = "macos")` variants added here **compile on the macOS runner but do not execute**. That job's test step is a scoped `-p` list that omits `glass-android`, so a macOS-gated test can be added and pass review while never running — the same blind spot #299 removed on the Windows side.

Widening it to `cargo test --workspace --lib` was tried here and reverted: it fails two pre-existing `glass-core` wait tests that assert a rate against wall-clock on a runner whose speed they don't control. That is its own change, tracked in #305, rather than a glass-core timing fix smuggled into an android test PR.

Closes #300.