### PR TITLE
ci(macos): run every crate's lib tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,12 +178,9 @@ jobs:
       - run: cargo build  --workspace --all-targets --locked
       - run: cargo clippy --workspace --all-targets --locked -- -D warnings
       - run: ./scripts/test-macos.sh
-      # glass-mcp, glass-a11y-macos and glass-sandbox-macos carry cfg(target_os = "macos")
-      # unit tests (e.g. glass-a11y-macos::reader's set_value_took, glass-mcp::doctor's
-      # backend-resolution tests). None of their test targets is harness = false (unlike
-      # glass-macos above), so `cargo test -p` on them runs ungranted exactly as it did
-      # before #293 — this is still the only job that compiles and runs that code at all.
-      - run: cargo test -p glass-mcp -p glass-a11y-macos -p glass-sandbox-macos --locked
+      # `--lib` rather than plain `--workspace`: it excludes the harness = false integration
+      # targets above, which need the TCC grants this runner lacks.
+      - run: cargo test --workspace --lib --locked
       # Builds the Swift fixture (crates/glass-macos/fixture/a11y_fixture.swift) — the one
       # thing `cargo build --workspace --all-targets` above doesn't reach — and re-links the
       # harness=false `a11y` integration test (crates/glass-macos/tests/a11y.rs) as a belt-

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -1227,6 +1227,27 @@ mod tests {
     }
 
     /// A condition the fixed fake tree never satisfies, so the wait runs its full budget.
+    /// Walks driven by one 600ms wait at a 20ms interval under `signal`.
+    ///
+    /// `None` gives the control the two pacing tests compare against: a backend with no event
+    /// stream re-walks every interval, so the count is what this machine manages now. A fixed
+    /// number cannot — a runner whose 20ms sleeps land at 50ms fits a third as many in.
+    ///
+    /// 600ms rather than the 200ms the deadline needs: the comparison is between two runs, so it
+    /// carries both their jitter, and +/-1 walk is 25% of a four-sample run but 3% of a thirty-
+    /// sample one.
+    fn walks_in_a_paced_wait(signal: Option<fn() -> Box<dyn ChangeSignal>>) -> usize {
+        let (mut g, walks) = glass_with_a11y_counted(
+            FakePlatform::new(100, 100),
+            vec![fake_tree_enabled()],
+            signal,
+        );
+        g.start(&spec()).unwrap();
+        let o = g.wait_for_element(&never_matches(20, 600)).unwrap();
+        assert!(!o.matched);
+        walks.load(Ordering::Relaxed)
+    }
+
     fn never_matches(interval_ms: u64, timeout_ms: u64) -> WaitElementParams {
         WaitElementParams {
             name: Some("Save".into()),
@@ -1313,23 +1334,23 @@ mod tests {
 
     #[test]
     fn a_signal_that_never_stops_firing_stays_bounded_by_the_deadline() {
-        let (mut g, walks) = glass_with_a11y_counted(
-            FakePlatform::new(100, 100),
-            vec![fake_tree_enabled()],
-            Some(|| Box::new(AlwaysSignals) as Box<dyn ChangeSignal>),
-        );
-        g.start(&spec()).unwrap();
+        let polled = walks_in_a_paced_wait(None);
+        let n = walks_in_a_paced_wait(Some(|| Box::new(AlwaysSignals) as Box<dyn ChangeSignal>));
 
-        let o = g.wait_for_element(&never_matches(20, 200)).unwrap();
-
-        assert!(!o.matched);
-        let n = walks.load(Ordering::Relaxed);
         // A band, not a ceiling. Too many: waking early removed the interval's pacing, and a
-        // chatty app drives back-to-back walks against the bus it is trying to serve. Too few: the
-        // pacing over-sleeps, making the wake slower than the polling it replaced.
+        // chatty app drives back-to-back walks against the bus it is trying to serve. Absolute,
+        // because the deadline caps a paced run at thirty intervals on any machine, while losing the
+        // pacing runs to thousands.
         assert!(
-            (7..=12).contains(&n),
-            "a chatty app drove {n} walks in 200ms at a 20ms interval"
+            n <= 36,
+            "a chatty app drove {n} walks in 600ms at a 20ms interval"
+        );
+        // Too few: the wake ended up slower than the polling it replaced. This signal answers
+        // instantly, so `d.saturating_sub(~0)` is `d` — the pacing arithmetic cannot be wrong
+        // here; the mid-interval test tells the two apart.
+        assert!(
+            n * 6 >= polled * 5,
+            "a chatty app drove {n} walks where polling drove {polled} in the same wait"
         );
     }
 
@@ -1429,20 +1450,20 @@ mod tests {
         // The pacing is "wake early, but no sooner than one interval after the last read". A signal
         // whose change lands halfway through is what tells the two arithmetics apart: sleeping the
         // *remainder* keeps one read per interval, sleeping the elapsed time again halves the rate.
-        let (mut g, walks) = glass_with_a11y_counted(
-            FakePlatform::new(100, 100),
-            vec![fake_tree_enabled()],
-            Some(|| Box::new(ChangesMidInterval) as Box<dyn ChangeSignal>),
-        );
-        g.start(&spec()).unwrap();
+        let polled = walks_in_a_paced_wait(None);
+        let n = walks_in_a_paced_wait(Some(|| {
+            Box::new(ChangesMidInterval) as Box<dyn ChangeSignal>
+        }));
 
-        let o = g.wait_for_element(&never_matches(20, 200)).unwrap();
-
-        assert!(!o.matched);
-        let n = walks.load(Ordering::Relaxed);
         assert!(
-            (7..=12).contains(&n),
-            "a mid-interval change drove {n} walks in 200ms at a 20ms interval"
+            n <= 36,
+            "a mid-interval change drove {n} walks in 600ms at a 20ms interval"
+        );
+        // Sleeping the elapsed time again rather than the remainder costs a third of the rate:
+        // 10ms of signal wait, then a full 20ms instead of the 10ms remaining.
+        assert!(
+            n * 6 >= polled * 5,
+            "a mid-interval change drove {n} walks where polling drove {polled} in the same wait"
         );
     }
 


### PR DESCRIPTION
The macOS job's test step was `cargo test -p glass-mcp -p glass-a11y-macos -p glass-sandbox-macos`. Every other crate was compiled there by `cargo build --workspace --all-targets` and never run — so #304 could add three `cfg(target_os = "macos")` tests to `glass-android` that passed review while never executing. Same shape as the Windows `-p` list removed in #299.

It now runs `cargo test --workspace --lib --locked`.

`--lib` rather than plain `--workspace` is what makes this safe: it excludes `glass-macos`'s `harness = false` integration targets, five of which hard-fail without the TCC grants the runner lacks. That constraint is the reason this job never followed build and clippy to `--workspace`, and `--lib` sidesteps it rather than working around it.

## What widening it found

Two `glass-core` wait tests that have never run on macOS, both asserting a rate against hardware they don't control:

```
a_signal_that_never_stops_firing_stays_bounded_by_the_deadline   drove 3   (band 7..=12)
a_change_arriving_mid_interval_still_paces_the_next_read         drove 4
```

The runner spends ~46ms per walk against a 20ms interval, so ~4 iterations fit in the 200ms budget instead of 10.

The band's halves are not equally sound, and only one of them needed changing:

- The **upper** bound holds on any machine — the deadline caps a paced run at ten intervals, while losing the pacing runs to thousands. Kept as an absolute.
- The **lower** bound cannot distinguish "the pacing over-slept" from "the machine is slow". It now compares against a polling run taken on the same machine inside the same test: a backend with no signal re-walks every interval, so anything that slows one run slows both.

## Evidence

Both directions were checked rather than inferred:

| probe | result |
|---|---|
| fake walk costs 46ms, old band | `drove 4 walks in 200ms` — the macOS failure reproduced on Linux, same count |
| fake walk costs 46ms, new assertion | passes |
| pacing broken (`sleep(d)` instead of `sleep(d - elapsed)`) | `8 walks where polling drove 11` — fails, 5 runs, no variance |

The threshold is 5/6 rather than a tighter ratio because the bug costs a third of the rate, not half: the mid-interval signal waits 10ms, then the broken arithmetic sleeps a full 20ms instead of the 10ms remaining.

One thing the old comment implied that isn't true: `AlwaysSignals` cannot catch the pacing bug at all. It answers instantly, so `d.saturating_sub(~0)` and `d` are the same expression for it — only the mid-interval signal tells the two arithmetics apart, exactly as that test's own comment claims. Its lower bound guards "the wake is not slower than the polling it replaced" instead, which is what the original wording actually described. Both sites now say which job they do.

## Verifying

```
cargo test --workspace                 # Linux: 1802
cargo test --workspace --lib           # Linux: 1726 — the shape the macOS job now runs
cargo clippy --workspace --all-targets -- -D warnings
```

The macOS job's test count is the number to watch on this PR: it goes from three crates' worth to the whole workspace's lib tests.

Closes #305.