### PR TITLE
docs(ci): correct a macOS comment that contradicts its own step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,18 +168,15 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: .
-      # The Linux-only crates gate themselves off macOS (#293), so --workspace resolves
-      # here now: a workspace-wide build + lint gate, with the gated crates compiling to
-      # nothing. No `cargo test --workspace` here — five of glass-macos's seven
-      # `harness = false` integration targets (capture, input, windows, a11y, bundle_launch)
-      # hard-fail without the TCC grants this runner doesn't have (the other two, role_probe
-      # and window_adopt_probe, exit 0 unconfigured); ./scripts/test-macos.sh below runs
-      # `--lib` instead.
+      # The Linux-only crates gate themselves off macOS (#293), so --workspace resolves here.
       - run: cargo build  --workspace --all-targets --locked
       - run: cargo clippy --workspace --all-targets --locked -- -D warnings
+      # Also builds the sandbox probe and the injected clip shim, which the tests need. Its own
+      # `-p glass-macos --lib` run is repeated by the workspace step below — kept because this
+      # script is the standalone entry point on a dev box, where nothing else runs them.
       - run: ./scripts/test-macos.sh
       # `--lib` rather than plain `--workspace`: it excludes the harness = false integration
-      # targets above, which need the TCC grants this runner lacks.
+      # targets, which need the TCC grants this runner lacks.
       - run: cargo test --workspace --lib --locked
       # Builds the Swift fixture (crates/glass-macos/fixture/a11y_fixture.swift) — the one
       # thing `cargo build --workspace --all-targets` above doesn't reach — and re-links the


### PR DESCRIPTION
#306 widened the macOS job to `cargo test --workspace --lib` but left the comment above it saying:

> No `cargo test --workspace` here … `./scripts/test-macos.sh` below runs `--lib` instead.

Six lines above the step that now runs exactly that. The block also repeated the `harness = false` / TCC explanation the job header already gives.

Replaced with the two things a reader can't derive from the steps: why `test-macos.sh` is still there when the workspace run repeats its `-p glass-macos --lib` (it builds the sandbox probe and the injected clip shim the tests need, and it's the standalone entry point on a dev box), and why the workspace step is `--lib` rather than plain `--workspace`.

Comment-only — the diff contains no non-comment lines, and the YAML still parses.