### PR TITLE
docs: say what to run to cover a change, per host

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,11 @@ cargo clippy --workspace --all-targets -- -D warnings   # lint gate — keep cle
 ```
 The workspace is pinned to nightly via `rust-toolchain.toml`.
 
+Those cover Linux. They do **not** compile `cfg(target_os = "macos")` or `cfg(windows)` code, so on
+a change to a platform crate they report clean without having looked at it —
+[docs/how-to/verify-a-change.md](docs/how-to/verify-a-change.md) has the per-target commands that
+do, most of which run from any host.
+
 ## Invariants
 
 - **External automation only** — drive apps as a black box; never require the app to be glass-aware.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to glass
+
+## Build and run
+
+[Build from source](docs/how-to/build-from-source.md). The toolchain is pinned in
+`rust-toolchain.toml`, so rustup installs it on the first build — there is nothing to choose.
+
+## Before you open a PR
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --locked -- -D warnings
+cargo test --workspace --locked
+```
+
+**If you changed platform code, those three are not enough.** `cargo test --workspace` on Linux does
+not compile `cfg(target_os = "macos")` or `cfg(windows)` modules at all — it reports clean without
+having looked at them. [Verify a change](docs/how-to/verify-a-change.md) gives the per-target
+commands that do cover them, most of which run from any host.
+
+## What CI runs
+
+Linux, macOS and Windows each run build, clippy and test across the whole workspace, plus the X11,
+Wayland and AT-SPI integration suites on Linux. Mutation testing runs sharded on CI and should not
+be run locally — it saturates the machine.
+
+## House style
+
+- **No silent fallbacks.** A failed capture or input returns a structured error, never a blank or
+  stale frame.
+- **`glass-core` stays platform-agnostic.** OS types live behind the `Platform` seam.
+- **Avoid `unsafe`.** Where it is unavoidable, isolate it and document each site with `// SAFETY:`.
+- **Permissively-licensed dependencies only** (MIT/Apache; no copyleft).
+- **Comments carry a fact, not an argument** — one sentence with something the code cannot say for
+  itself.
+
+`CLAUDE.md` holds the same invariants in the form an agent working in this repo needs.
+
+## Licensing
+
+Apache-2.0. By contributing you agree your contributions are licensed under it.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ The full docs — tutorial, how-to guides, reference, and explanations — are u
 **[`docs/`](docs/README.md)**. See [`CHANGELOG.md`](CHANGELOG.md) for release notes, and
 [Stability and versioning](docs/reference/stability.md) for what a 1.0 release guarantees.
 
+Contributing? [`CONTRIBUTING.md`](CONTRIBUTING.md) has the gates a PR has to pass, and
+[Verify a change](docs/how-to/verify-a-change.md) covers platform code your own host cannot run.
+
 ## License
 
 glass is **open core**, licensed **Apache-2.0** — see [`LICENSE-APACHE`](LICENSE-APACHE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,8 @@ way it does? The explanations.
 **Contribute**
 
 - [Build from source](how-to/build-from-source.md) — all platforms; macOS signing + LaunchAgent
+- [Verify a change](how-to/verify-a-change.md) — the gates, and how to cover platform code your
+  host cannot run
 - [Benchmark and profile](how-to/benchmarking.md)
 - [Measure what the verification loop costs](how-to/verification-cost.md) — semantic vs
   screenshot-every-step, round-trips and tokens

--- a/docs/how-to/verify-a-change.md
+++ b/docs/how-to/verify-a-change.md
@@ -1,0 +1,122 @@
+# Verify a change
+
+What to run so a change is covered before it reaches CI — including code for a platform you are not
+on. Every command here is run from the repo root.
+
+## The gates, on any host
+
+These three are what CI fails a PR on, and they are the same everywhere:
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --locked -- -D warnings
+cargo test --workspace --locked
+```
+
+`--workspace` resolves on Linux, macOS and Windows alike: the platform crates gate themselves, so
+the ones that do not apply to your host compile to nothing rather than failing.
+
+Integration tests are `#[ignore]`d and do not run here — see [below](#integration-suites-linux).
+
+## The gap this guide exists for
+
+`cargo test --workspace` on Linux does not compile `cfg(target_os = "macos")` or `cfg(windows)`
+code **at all**. It reports clean without having looked at it. If you changed a platform module,
+the gates above are close to vacuous for the thing you changed, and nothing in their output says so.
+
+The fix is to name the target.
+
+## Cover the Windows code from Linux
+
+```bash
+rustup target add x86_64-pc-windows-gnu
+
+cargo clippy --target x86_64-pc-windows-gnu --workspace --all-targets --locked -- -D warnings
+```
+
+That needs no linker and no Windows machine: `cargo check` and `cargo clippy` emit metadata and
+never link.
+
+To actually *run* the Windows-target tests you need a cross-linker and wine (Debian/Ubuntu:
+`sudo apt install gcc-mingw-w64 wine`):
+
+```bash
+CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUNNER=wine \
+  CARGO_TARGET_DIR=/tmp/glass-win \
+  cargo test --workspace --target x86_64-pc-windows-gnu --locked --no-fail-fast
+```
+
+Three things to know before trusting the result:
+
+- **CI builds `x86_64-pc-windows-msvc`, and that triple cannot be completed from Linux** — the
+  `libudis86-sys` build script needs a C toolchain it cannot get here. Use `-gnu` and treat the CI
+  run as the first msvc build.
+- **wine is strong evidence for a failure, weaker for a pass.** `PathBuf` formatting and the
+  executable suffix are compiled in per target rather than emulated, so a path-semantics bug fails
+  here for the same reason it fails on Windows. Anything touching a real OS service is a different
+  matter.
+- **Use a fresh `CARGO_TARGET_DIR`.** A second run against a warm one is a cache hit that prints a
+  clean result without compiling anything.
+
+## Cover the macOS code from Linux
+
+```bash
+rustup target add x86_64-apple-darwin
+
+cargo clippy --target x86_64-apple-darwin \
+  -p glass-macos -p glass-a11y-macos -p glass-sandbox-macos -p glass-clip-shim-macos \
+  --all-targets --locked -- -D warnings
+```
+
+This compiles the `cfg(target_os = "macos")` modules for real — a type error inside one fails the
+command from Linux.
+
+- **`--workspace` does not work for this target.** `criterion`, a dev-dependency of `glass-core`,
+  pulls `alloca`, whose build script passes `-arch` and `-mmacosx-version-min` to the host `cc`.
+  Scope with `-p` to the crates you touched.
+- **You cannot link or run.** That needs the macOS SDK and a Mac. For anything past type-checking,
+  push and let the macOS CI job run it, or run it on a Mac.
+
+## Integration suites (Linux)
+
+`#[ignore]`d, so the ordinary `cargo test` never starts them. Each self-starts what it needs.
+
+```bash
+./scripts/test-x11.sh [name]        # X11 suite; starts its own Xvfb
+./scripts/test-wayland.sh [name]    # Wayland suite; needs sway >= 1.12
+./scripts/test-a11y.sh [name]       # AT-SPI suite; starts a private bus + registry
+```
+
+Pass a substring to run one test.
+
+## What only CI or a real host can do
+
+| | where |
+|---|---|
+| `x86_64-pc-windows-msvc` build | CI, or a Windows box |
+| macOS link, and any test execution | CI, or a Mac |
+| macOS capture / input / a11y integration targets | a Mac with the TCC grants — see [build-from-source](build-from-source.md) |
+| Windows on-box validation (Sandboxie, clipboard shim) | a Windows box, driven by `scripts/test-windows.sh` |
+| Mutation testing | CI only; it is sharded there, and a local sweep saturates the machine |
+
+## The scripts
+
+Fourteen run locally. One drives another machine.
+
+| script | what it does |
+|---|---|
+| `test-x11.sh` | X11 integration suite; self-starts Xvfb |
+| `test-wayland.sh` | Wayland suite; needs sway >= 1.12 |
+| `test-a11y.sh` | AT-SPI suite; private bus + registry |
+| `test-macos.sh` | glass-macos suite; exits 0 off macOS, so it is safe to call anywhere |
+| `test-macos-a11y.sh` | compile/link gate for the macOS a11y integration test |
+| `test-macos-mcp.sh` | headless stdio MCP smoke — server boots and lists its tools |
+| **`test-windows.sh`** | **drives a REMOTE Windows box over SSH**; skips cleanly when none is configured |
+| `sandbox-xvfb.sh` | manage the sandbox X display glass-mcp drives |
+| `bench.sh` | run the benchmarks, or flamegraph one |
+| `coverage.sh` | coverage via cargo-llvm-cov |
+| `mutants.sh` | mutation-test glass-core (CI does this; see the table above) |
+| `build-bundle.sh` | build the distribution bundle |
+| `verification-cost.sh` | measure what the verification loop costs |
+| `x11-geometry-settle-measurement.sh` | one-off X11 launch-geometry measurement |
+| `wayland-geometry-settle-measurement.sh` | the Wayland counterpart |

--- a/docs/how-to/verify-a-change.md
+++ b/docs/how-to/verify-a-change.md
@@ -63,17 +63,20 @@ Three things to know before trusting the result:
 ```bash
 rustup target add x86_64-apple-darwin
 
-cargo clippy --target x86_64-apple-darwin \
-  -p glass-macos -p glass-a11y-macos -p glass-sandbox-macos -p glass-clip-shim-macos \
-  --all-targets --locked -- -D warnings
+cargo clippy --target x86_64-apple-darwin --workspace --lib --locked -- -D warnings
 ```
 
 This compiles the `cfg(target_os = "macos")` modules for real — a type error inside one fails the
 command from Linux.
 
-- **`--workspace` does not work for this target.** `criterion`, a dev-dependency of `glass-core`,
-  pulls `alloca`, whose build script passes `-arch` and `-mmacosx-version-min` to the host `cc`.
-  Scope with `-p` to the crates you touched.
+- **`--lib` is what makes it work, and it is not the same reason the macOS CI job uses `--lib`.**
+  Here it is because `--lib` does not build dev-dependencies: `--all-targets` pulls `criterion`,
+  which depends unconditionally on `alloca`, whose build script compiles C — and cross-compiling
+  that runs the *host* `cc` with `-arch` and `-mmacosx-version-min`, which Linux `gcc` rejects.
+  Building it would need a darwin cross-toolchain such as osxcross.
+- To include tests and benches for one crate, scope with `-p`:
+  `cargo clippy --target x86_64-apple-darwin -p glass-macos --all-targets -- -D warnings` works,
+  because `glass-macos` does not dev-depend on `criterion`.
 - **You cannot link or run.** That needs the macOS SDK and a Mac. For anything past type-checking,
   push and let the macOS CI job run it, or run it on a Mac.
 


### PR DESCRIPTION
`cargo test --workspace` on Linux does not compile `cfg(target_os = "macos")` or `cfg(windows)` code **at all**. On a change to a platform crate it reports clean without having looked at it, and nothing in the repo said which command would.

Adds `docs/how-to/verify-a-change.md`, plus a `CONTRIBUTING.md` (there was none, so the PR UI offered contributors nothing).

## The commands, verified rather than recalled

Each was run against this checkout while writing the page.

**Windows, from Linux.** `cargo clippy --target x86_64-pc-windows-gnu --workspace --all-targets` needs no linker and no Windows machine — `check`/`clippy` emit metadata and never link. Running the tests additionally needs `gcc-mingw-w64` and `wine`.

**macOS, from Linux — this one corrects an assumption.** I had believed, and #294 originally said, that macOS code cannot be checked off a Mac. It can:

```bash
cargo clippy --target x86_64-apple-darwin --workspace --lib -- -D warnings
```

This compiles the `cfg(target_os = "macos")` modules for real. Confirmed by injecting a type error into a macOS-only module in `glass-sandbox-macos/src/ffi.rs` and watching it fail from Linux with `error[E0308]: expected u32, found &str`. So the "concrete failure" #294 was filed over — a branch's macOS code going unlinted while the Linux gates reported clean — was avoidable all along, by a command nobody had written down.

## The boundaries, with their causes

Stated in the page because a caveat without a reason gets ignored:

- `x86_64-pc-windows-msvc`, which CI actually builds, **cannot** be completed from Linux: `libudis86-sys`'s build script needs a C toolchain it can't get. Use `-gnu` and treat CI as the first msvc build.
- `--all-targets` does **not** work for the darwin target, and the cause is dev-dependencies rather than the crate set: `criterion` depends on `alloca` unconditionally (not behind `html_reports`), `alloca`'s build script compiles C, and cross-compiling that runs the *host* `gcc` with `-arch` and `-mmacosx-version-min`. `--lib` does not build dev-deps, so it sidesteps the whole thing; `-p <crate> --all-targets` also works for crates that don't dev-depend on criterion.
- wine is strong evidence for a *failure* in path-string logic — `PathBuf` formatting and the executable suffix are compiled in per target rather than emulated — and weaker for a pass.
- A warm `CARGO_TARGET_DIR` makes a repeat cross-check a cache hit that prints clean without compiling.

## Also

- Indexes the fifteen scripts, marking the one (`test-windows.sh`) that drives a **remote** machine over SSH rather than running locally — nothing at the entry point distinguished them.
- A table of what genuinely needs CI or real hardware: the msvc build, macOS linking and test execution, the granted macOS integration targets, Windows on-box validation, and mutation testing.
- `CLAUDE.md` keeps its Linux command list but now says plainly that it does not cover platform code, and points here.

Docs only — no code changes. Gates green: fmt, clippy, `cargo test --workspace` 1802 passed.

Closes #294.
