### PR TITLE
fix(test): remove a pacing floor that cannot fail, and an ordering bias

### DIFF
--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -1334,23 +1334,18 @@ mod tests {
 
     #[test]
     fn a_signal_that_never_stops_firing_stays_bounded_by_the_deadline() {
-        let polled = walks_in_a_paced_wait(None);
         let n = walks_in_a_paced_wait(Some(|| Box::new(AlwaysSignals) as Box<dyn ChangeSignal>));
 
-        // A band, not a ceiling. Too many: waking early removed the interval's pacing, and a
-        // chatty app drives back-to-back walks against the bus it is trying to serve. Absolute,
-        // because the deadline caps a paced run at thirty intervals on any machine, while losing the
-        // pacing runs to thousands.
+        // A ceiling only. Waking early removes the interval's pacing, and a chatty app then drives
+        // back-to-back walks against the bus it is trying to serve; the deadline caps a paced run
+        // at thirty intervals on any machine, while losing the pacing runs to thousands.
+        //
+        // No lower bound: this signal answers instantly, so `d.saturating_sub(~0)` is `d` and the
+        // pacing arithmetic cannot be wrong here — `a_change_arriving_mid_interval_still_paces_the_next_read`
+        // is what tells the two apart. A floor would only add timing flake for nothing.
         assert!(
             n <= 36,
             "a chatty app drove {n} walks in 600ms at a 20ms interval"
-        );
-        // Too few: the wake ended up slower than the polling it replaced. This signal answers
-        // instantly, so `d.saturating_sub(~0)` is `d` — the pacing arithmetic cannot be wrong
-        // here; the mid-interval test tells the two apart.
-        assert!(
-            n * 6 >= polled * 5,
-            "a chatty app drove {n} walks where polling drove {polled} in the same wait"
         );
     }
 
@@ -1450,10 +1445,14 @@ mod tests {
         // The pacing is "wake early, but no sooner than one interval after the last read". A signal
         // whose change lands halfway through is what tells the two arithmetics apart: sleeping the
         // *remainder* keeps one read per interval, sleeping the elapsed time again halves the rate.
-        let polled = walks_in_a_paced_wait(None);
+        // Sampled either side of the subject, smallest wins. One control run before it would bias
+        // the comparison on a runner that gets busier as it goes: the subject, running second,
+        // would look slower than the pacing made it.
+        let before = walks_in_a_paced_wait(None);
         let n = walks_in_a_paced_wait(Some(|| {
             Box::new(ChangesMidInterval) as Box<dyn ChangeSignal>
         }));
+        let polled = before.min(walks_in_a_paced_wait(None));
 
         assert!(
             n <= 36,


### PR DESCRIPTION
`a_signal_that_never_stops_firing_stays_bounded_by_the_deadline` failed on the macOS runner:

```
drove 7 walks where polling drove 12 in the same wait
```

Both problems are in the assertions I added in #306, not in the code under test.

## The floor could not fail

`AlwaysSignals` answers `Changed` immediately, so `paused_at.elapsed()` is ~0 and `d.saturating_sub(~0)` is just `d` — the correct and broken pacing arithmetic are the *same expression* for that signal. The floor was never able to catch the bug it sat beside; only `a_change_arriving_mid_interval_still_paces_the_next_read` discriminates them, which is what that test's own comment has always said.

So it was carrying timing flake and guarding nothing. Removed. The ceiling stays — that one is a genuine invariant on any machine, since the deadline caps a paced run at thirty intervals while losing the pacing runs to thousands.

## The control ran first, every time

```rust
let polled = walks_in_a_paced_wait(None);      // control
let n = walks_in_a_paced_wait(Some(...));      // subject, always second
```

On a runner that gets busier as it goes, the subject is measured under worse conditions than its own control. That is a systematic bias rather than noise, and 7-against-12 is its shape.

The surviving comparison now samples the control on **both** sides of the subject and takes the smaller, so drift in either direction cannot inflate the control relative to the conditions the subject actually ran under.

## Still catches what it exists for

Breaking the pacing — `sleep(d)` instead of `sleep(d - elapsed)` — fails it at **21 walks against 31**, five runs, no variance. Margin is 126 vs 155, unchanged from before this fix.

Linux gates green: fmt, clippy, `cargo test --workspace` 1802 passed.

The macOS runner is where this has to prove itself, so CI is the verification here rather than a local run.