### PR TITLE
fix(a11y): disclose subtrees dropped by a failed child read

### DIFF
--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -181,6 +181,7 @@ async fn snapshot_async(ctx: &AxContext) -> Result<AxTree> {
     let root_node = Box::pin(walk(&app, &zbus_conn, 0, &mut budget)).await?;
     let mut tree = AxTree::new(root_node);
     tree.truncated = budget.truncation();
+    tree.unreadable = budget.unreadable();
     tree.assign_ids();
     Ok(tree)
 }
@@ -328,6 +329,8 @@ async fn find_nth(
             break;
         }
         let Ok(child) = child_ref.as_accessible_proxy(conn).await else {
+            // Counted in `walk` too, so the two traversals report the same drop.
+            budget.note_unreadable();
             continue;
         };
         if let Some(found) = Box::pin(find_nth(
@@ -447,6 +450,7 @@ async fn walk(
                 break;
             }
             let Ok(child) = child_ref.as_accessible_proxy(conn).await else {
+                budget.note_unreadable();
                 continue;
             };
             children.push(Box::pin(walk(&child, conn, depth + 1, budget)).await?);

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -87,6 +87,7 @@ impl Accessibility for MacosA11y {
         let root = walk(&window_el, &ctx.window, scale, 0, &mut budget);
         let mut tree = AxTree::new(root);
         tree.truncated = budget.truncation();
+        tree.unreadable = budget.unreadable();
         // Ids/count are assigned by `glass-core` (`AxTree::assign_ids`) so numbering is
         // identical across OS backends.
         Ok(tree)
@@ -475,12 +476,13 @@ fn walk(
     // `AXChildren`) node and only `Err` for a *real* AX read failure. Degrade a real
     // failure to "no children" so one broken node can't fail the whole snapshot — but log
     // it (mirroring `select_window`'s no-match diagnostic) so the dropped subtree is
-    // observable, never silent. This is a different condition from a bound firing (below),
-    // and already reports itself via the log line, so it never touches `budget`.
+    // observable, never silent. Counted on `budget` as well — the log serves whoever reads
+    // stderr, the count reaches the agent.
     //
     // Resolved before the gate below: a childless node must never be reported truncated
     // for declining to explore a list that was already empty.
     let child_els = ffi::children(el).unwrap_or_else(|err| {
+        budget.note_unreadable();
         eprintln!(
             "glass-a11y-macos: walk: AXChildren read failed for role={raw_role:?} \
              bounds={bounds:?}: {err}; treating as no children"
@@ -580,7 +582,15 @@ fn find_nth(
     budget.visit();
     // Resolved before the gate: a childless node must never be reported truncated for
     // declining to explore a list that was already empty.
-    let child_els = ffi::children(&el).unwrap_or_default();
+    // Counted and logged exactly as `walk` does — the same failure was diagnosable in one
+    // traversal and invisible in the other.
+    let child_els = ffi::children(&el).unwrap_or_else(|err| {
+        budget.note_unreadable();
+        eprintln!(
+            "glass-a11y-macos: find_nth: AXChildren read failed: {err}; treating as no children"
+        );
+        Vec::new()
+    });
     // Same gap as `walk`: gated on the raw `child_els`, before `should_skip` runs. A node whose
     // children are all skipped, reached once the budget is spent, still records a truncation
     // though nothing real was declined — left as-is for the same reason: pre-filtering means

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -119,6 +119,7 @@ fn run_snapshot(ctx: &AxContext) -> Result<AxTree> {
     let root_node = walk(&walker, &window, origin, 0, &mut budget)?;
     let mut tree = AxTree::new(root_node);
     tree.truncated = budget.truncation();
+    tree.unreadable = budget.unreadable();
     tree.assign_ids();
     Ok(tree)
 }
@@ -137,6 +138,23 @@ pub(crate) fn find_app_window(automation: &UIAutomation, ctx: &AxContext) -> Res
     automation
         .element_from_handle(Handle::from(handle as isize))
         .map_err(uia_err)
+}
+
+/// A tree-walker step's result, with a genuine read failure counted on `budget`.
+///
+/// UIA reports "there is no such element" as `S_OK` with a NULL out-param, which `windows-rs`
+/// cannot build an interface from — so absence arrives as an `Err` too. It is separable because
+/// that error's code reaches us as **zero** (`windows_result::Error::code` maps its internal
+/// empty-error sentinel back to `HRESULT(0)`), while a real failure carries a negative HRESULT,
+/// and `uiautomation::Error::result` is `Some` only for a negative code. A plain `.ok()` collapses
+/// the two, which is what let a dropped subtree read as an empty one.
+fn step(r: uiautomation::Result<UIElement>, budget: &mut WalkBudget) -> Option<UIElement> {
+    r.inspect_err(|e| {
+        if e.result().is_some() {
+            budget.note_unreadable();
+        }
+    })
+    .ok()
 }
 
 /// Recursively build a normalized node, bounded by [`WalkBudget`] (node count, nesting depth,
@@ -165,7 +183,7 @@ fn walk(
     let mut children = Vec::new();
     // Resolved before the gate: a childless node must never be reported truncated for
     // declining to explore a list that was already empty.
-    let first_child = walker.get_first_child(el).ok();
+    let first_child = step(walker.get_first_child(el), budget);
     // Tests only whether a first child exists, before `is_offscreen` filters it. A node whose
     // children are all offscreen, reached once the budget is spent, still records a truncation
     // though nothing real was declined. Pre-filtering would mean walking the whole
@@ -192,7 +210,7 @@ fn walk(
             if !c.is_offscreen().unwrap_or(false) {
                 children.push(walk(walker, &c, origin, depth + 1, budget)?);
             }
-            child = walker.get_next_sibling(&c).ok();
+            child = step(walker.get_next_sibling(&c), budget);
         }
     }
 
@@ -543,7 +561,7 @@ fn find_nth(
     budget.visit();
     // Resolved before the gate: a childless node must never be reported truncated for
     // declining to explore a list that was already empty.
-    let first_child = walker.get_first_child(el).ok();
+    let first_child = step(walker.get_first_child(el), budget);
     // Same gap as `walk`: only tests whether a first child exists, before `is_offscreen` runs.
     // A node whose children are all offscreen, reached once the budget is spent, still records
     // a truncation though nothing real was declined — left as-is for the same reason: it would
@@ -570,7 +588,7 @@ fn find_nth(
         {
             return Some(found);
         }
-        child = walker.get_next_sibling(&c).ok();
+        child = step(walker.get_next_sibling(&c), budget);
     }
     None
 }
@@ -579,6 +597,31 @@ fn find_nth(
 mod tests {
     use super::*;
     use glass_core::{MAX_DEPTH, MAX_NODES};
+
+    /// The failure mode this guards: if an absent child ever stopped arriving as a zero code,
+    /// every leaf in every snapshot would report an unreadable subtree. Builds the error
+    /// directly rather than driving a walker, so it needs no COM.
+    #[test]
+    fn an_absent_child_is_not_counted_as_unreadable() {
+        let mut budget = WalkBudget::new();
+        // Zero is what the real chain yields for an absent child — see `step`.
+        let absent = uiautomation::Error::new(0, "no such element");
+        assert!(step(Err(absent), &mut budget).is_none());
+        assert_eq!(
+            budget.unreadable(),
+            0,
+            "S_OK with a null out-param means no such element, not a failed read"
+        );
+    }
+
+    #[test]
+    fn a_failed_child_read_is_counted_as_unreadable() {
+        let mut budget = WalkBudget::new();
+        // UIA_E_ELEMENTNOTAVAILABLE — a real failure, negative like every HRESULT error.
+        let failed = uiautomation::Error::new(-2147220991, "element not available");
+        assert!(step(Err(failed), &mut budget).is_none());
+        assert_eq!(budget.unreadable(), 1);
+    }
 
     #[test]
     fn below_the_caps_children_may_be_explored_and_nothing_is_recorded() {

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -441,6 +441,7 @@ impl Truncation {
 pub struct WalkBudget {
     count: usize,
     truncated: Option<Truncation>,
+    unreadable: usize,
     limits: WalkLimits,
 }
 
@@ -455,6 +456,7 @@ impl WalkBudget {
         WalkBudget {
             count: 0,
             truncated: None,
+            unreadable: 0,
             limits,
         }
     }
@@ -481,6 +483,20 @@ impl WalkBudget {
     /// Whether `depth` has reached the nesting bound (so children must not be walked).
     pub fn depth_exhausted(&self, depth: usize) -> bool {
         depth >= self.limits.depth
+    }
+
+    /// Record a subtree dropped because the platform refused to read a child.
+    ///
+    /// Distinct from [`WalkBudget::hit`]: a bound is a limit glass chose and can raise, while
+    /// this is the walk wanting to continue and being unable to. Call it wherever a child read
+    /// errors and the traversal skips on.
+    pub fn note_unreadable(&mut self) {
+        self.unreadable += 1;
+    }
+
+    /// How many subtrees were dropped because a child read failed.
+    pub fn unreadable(&self) -> usize {
+        self.unreadable
     }
 
     /// Record that a bound stopped the walk. Only the FIRST hit is kept: it is the cause,
@@ -514,6 +530,9 @@ pub struct AxTree {
     /// `Some` when the backend stopped walking early — see [`Truncation`]. `None` means the
     /// tree is complete.
     pub truncated: Option<Truncation>,
+    /// Subtrees dropped because a child read failed. Independent of [`AxTree::truncated`]: a
+    /// tree can hit no bound at all and still be missing elements this way.
+    pub unreadable: usize,
 }
 
 impl AxTree {
@@ -524,6 +543,7 @@ impl AxTree {
             root,
             count: 0,
             truncated: None,
+            unreadable: 0,
         }
     }
 
@@ -591,6 +611,27 @@ impl AxTree {
     /// envelope the app-derived outline is wrapped in. `None` when the tree is complete.
     pub fn truncation_notice(&self) -> Option<String> {
         self.truncated.map(|t| t.notice())
+    }
+
+    /// Disclosure for subtrees the platform refused to read. Separate from
+    /// [`AxTree::truncation_notice`] because the recourse differs: a bound is raisable and
+    /// deterministic, whereas a failed child read is usually an element that went away
+    /// mid-walk, so retrying is worth a try where widening a cap is not.
+    ///
+    /// Without this, such a tree renders exactly like one that genuinely had nothing there,
+    /// and an agent concludes the element does not exist.
+    pub fn unreadable_notice(&self) -> Option<String> {
+        (self.unreadable > 0).then(|| {
+            let (n, s) = (self.unreadable, if self.unreadable == 1 { "" } else { "s" });
+            format!(
+                "… {n} subtree{s} could not be read and {} missing from this outline. Those \
+                 elements are NOT shown and cannot be addressed by id. The read usually fails \
+                 because the element went away mid-walk, so a fresh glass_a11y_snapshot may \
+                 show them; otherwise drive that area by pixels: glass_screenshot, then \
+                 glass_click at x,y.",
+                if self.unreadable == 1 { "is" } else { "are" },
+            )
+        })
     }
 
     /// Guidance to surface when a snapshot exposes nothing to address — only the window
@@ -2299,6 +2340,59 @@ mod tests {
         assert!(
             b.depth_exhausted(MAX_DEPTH),
             "the depth safety rail is preserved under a lifted node cap"
+        );
+    }
+
+    #[test]
+    fn a_complete_tree_discloses_nothing() {
+        let t = AxTree::new(leaf(AxRole::Window, "w"));
+        assert_eq!(t.unreadable_notice(), None);
+        assert_eq!(t.truncation_notice(), None);
+    }
+
+    /// The bug this exists for — see [`AxTree::unreadable_notice`].
+    #[test]
+    fn an_unreadable_subtree_is_disclosed_even_when_no_bound_was_hit() {
+        let mut t = AxTree::new(leaf(AxRole::Window, "w"));
+        t.unreadable = 1;
+        assert_eq!(t.truncated, None, "no bound fired");
+        let n = t
+            .unreadable_notice()
+            .expect("an unreadable subtree must disclose");
+        assert!(n.contains("1 subtree"), "{n}");
+        assert!(n.contains("cannot be addressed by id"), "{n}");
+        assert!(
+            n.contains("glass_a11y_snapshot"),
+            "retry is the recourse here: {n}"
+        );
+    }
+
+    /// Singular and plural both read as English, since the count is agent-facing text.
+    #[test]
+    fn the_unreadable_notice_agrees_in_number() {
+        let mut t = AxTree::new(leaf(AxRole::Window, "w"));
+        t.unreadable = 1;
+        let one = t.unreadable_notice().unwrap();
+        assert!(one.contains("1 subtree could not be read and is"), "{one}");
+        t.unreadable = 3;
+        let many = t.unreadable_notice().unwrap();
+        assert!(
+            many.contains("3 subtrees could not be read and are"),
+            "{many}"
+        );
+    }
+
+    #[test]
+    fn the_budget_counts_each_unreadable_subtree_separately_from_bounds() {
+        let mut b = WalkBudget::new();
+        assert_eq!(b.unreadable(), 0);
+        b.note_unreadable();
+        b.note_unreadable();
+        assert_eq!(b.unreadable(), 2);
+        assert_eq!(
+            b.truncation(),
+            None,
+            "an unreadable read is not a bound hit"
         );
     }
 

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -289,6 +289,16 @@ fn a11y_truncation_steer(tree: &glass_core::AxTree) -> Option<String> {
     })
 }
 
+/// Every disclosure a snapshot owes the agent about elements it does not show: the truncation
+/// steer, and the unreadable-subtree notice. Two blocks rather than one because a tree can hit a
+/// bound, lose a subtree to a failed child read, or both, and the recourse differs.
+fn a11y_partial_steers(tree: &glass_core::AxTree) -> Vec<String> {
+    [a11y_truncation_steer(tree), tree.unreadable_notice()]
+        .into_iter()
+        .flatten()
+        .collect()
+}
+
 pub fn a11y_snapshot(glass: &mut Glass, a: &A11ySnapshotArgs) -> ToolResult {
     let tree = glass
         .a11y_snapshot(a.max_nodes.map(|n| n as usize))
@@ -306,9 +316,7 @@ pub fn a11y_snapshot(glass: &mut Glass, a: &A11ySnapshotArgs) -> ToolResult {
     if let Some(hint) = tree.empty_guidance() {
         contents.push(OutContent::Text(hint.to_string()));
     }
-    if let Some(steer) = a11y_truncation_steer(&tree) {
-        contents.push(OutContent::Text(steer));
-    }
+    contents.extend(a11y_partial_steers(&tree).into_iter().map(OutContent::Text));
     Ok(ToolOutput::result_with(
         "glass_a11y_snapshot",
         serde_json::json!({}),
@@ -383,9 +391,7 @@ fn resolve_return(
             if let Some(hint) = tree.empty_guidance() {
                 extra.push(OutContent::Text(hint.to_string()));
             }
-            if let Some(steer) = a11y_truncation_steer(&tree) {
-                extra.push(OutContent::Text(steer));
-            }
+            extra.extend(a11y_partial_steers(&tree).into_iter().map(OutContent::Text));
             Ok((None, extra))
         }
         Some(o) => Err(format!("unknown return '{o}' (use none/settle/snapshot)")),


### PR DESCRIPTION
`AxTree.truncated` discloses bound hits only — depth, nodes, siblings. A subtree that vanished because a child *read* failed rendered as a complete tree, reading identically to one that genuinely had nothing there. An agent concludes the element does not exist and routes around it, with no signal the tree was partial.

The drop is now counted on `WalkBudget`, carried on `AxTree`, and disclosed as its own MCP content block beside the truncation notice. Two blocks rather than one because the conditions are independent and the recourse differs: a bound is a limit glass chose and can raise, while a failed child read is usually an element that went away mid-walk, so a fresh snapshot may show it.

## Per backend

**Linux** skipped an unresolvable child silently in both `walk` and `find_nth`; both now count it.

**macOS** logged the failure in `walk` and swallowed it in `find_nth` — the internal inconsistency the issue named. Both now count and log. Its `ffi::children` returns `Ok(vec![])` for a genuinely childless node and `Err` only for a real failure, so there is no ambiguity to resolve.

**Windows was the one that could have gone badly.** The obvious fix — count every `Err` from `get_first_child`/`get_next_sibling` — is wrong. UIA reports "there is no such element" as `S_OK` with a NULL out-param, which `windows-rs` cannot build an interface from, so **absence arrives as an `Err` too**. Counting naively would mark *every leaf node* as an unreadable subtree: a false disclosure on every snapshot.

They are separable because that error's code reaches us as **zero** — `windows_result::Error::code` maps its internal empty-error sentinel back to `HRESULT(0)`, and `uiautomation::Error` stores `code().0` — while a real failure carries a negative HRESULT, and `uiautomation::Error::result` is `Some` only for a negative code. A `step()` helper keys on exactly that, at all four `walk`/`find_nth` sites.

## Verification

| | |
|---|---|
| Linux | `cargo test --workspace` — 1806 passed (1802 before, +4) |
| Windows target | 1312 passed under wine, incl. 2 new `step()` tests |
| clippy | clean on host, `x86_64-pc-windows-gnu`, and `x86_64-apple-darwin --workspace --lib` |

Every new assertion was shown failing before passing. The load-bearing one: making `step` count every `Err` fails `an_absent_child_is_not_counted_as_unreadable` with `left: 1, right: 0` — that is the every-leaf-reports-unreadable bug, pinned by a test that runs on the existing wine leg, so an upstream `windows-rs` change to that null-out-param behaviour cannot land silently.

Id lockstep is preserved: `walk` and `find_nth` assign ids by pre-order arrival index and `set_value` re-walks to a caller-supplied id, so the two must apply the same bounds at the same points. Every edit here is value-preserving (`.ok()` → `inspect_err().ok()`, `unwrap_or_default()` → `unwrap_or_else(…)`), changing no traversal on any backend. Counting is separate from `visit()`/`count`, so it cannot affect numbering either way.

Android and iOS build trees from a JSON dump with no per-child live read, so they have no such failure mode and are untouched.

## Not covered

The Windows and macOS changes were cross-compiled and lint-clean, and the Windows discrimination is unit-tested under wine — but neither was **executed on its own platform**. Whether UIA delivers absence as `S_OK`+NULL for the providers glass actually drives is reasoned from crate source, not observed on-box; `scripts/test-windows.sh` is what would confirm it.

Closes #278.