### PR TITLE
fix(windows): probe WGC on a thread this code owns

### DIFF
--- a/crates/glass-windows/Cargo.toml
+++ b/crates/glass-windows/Cargo.toml
@@ -28,8 +28,9 @@ windows = { version = "0.62", features = [
   "Win32_System_JobObjects", "Win32_System_Diagnostics_ToolHelp",
   # clipboard: CF_UNICODETEXT global memory clipboard
   "Win32_System_DataExchange", "Win32_System_Memory", "Win32_System_Ole",
-  # doctor: session (RemoteDesktop), WGC support probe, true build via RtlGetVersion
-  "Win32_System_RemoteDesktop", "Graphics_Capture",
+  # doctor: session (RemoteDesktop), WGC support probe, true build via RtlGetVersion.
+  # Win32_System_Com is for the WGC probe's own apartment — see `gather_wgc`.
+  "Win32_System_RemoteDesktop", "Graphics_Capture", "Win32_System_Com",
   "Wdk_System_SystemServices", "Win32_System_SystemInformation",
   # private clipboard: host named-pipe server + scoped security descriptor
   "Win32_System_Pipes", "Win32_Storage_FileSystem", "Win32_System_IO",

--- a/crates/glass-windows/src/doctor.rs
+++ b/crates/glass-windows/src/doctor.rs
@@ -309,17 +309,42 @@ fn gather_session() -> SessionKind {
 
 /// Whether Windows.Graphics.Capture is usable on this system (the real capability gate).
 ///
-/// Probed once per process. `IsSupported` activates a WinRT runtime class on the calling thread,
-/// and activating it concurrently from several threads faults with `STATUS_ACCESS_VIOLATION` —
-/// `cargo test --workspace` on Windows crashed the `glass-mcp` test binary about half the time,
-/// libtest giving each test its own thread. The answer is a fixed property of the machine, so
-/// caching is also the honest shape: nothing here can change while the process runs.
+/// Probed once, on a thread this function owns. `IsSupported` activates a WinRT runtime class on
+/// whatever thread calls it, and doing that on a borrowed thread that later exits faults with
+/// `STATUS_ACCESS_VIOLATION`: `cargo test --workspace` on Windows crashed the `glass-mcp` test
+/// binary about half the time, libtest giving each test its own short-lived thread. Caching alone
+/// does not fix it — one activation on a borrowed thread is enough — so the apartment is
+/// initialized and torn down here, on a thread whose lifetime is bounded by the `join` below.
 #[cfg(windows)]
 fn gather_wgc() -> bool {
     use std::sync::OnceLock;
-    use windows::Graphics::Capture::GraphicsCaptureSession;
     static SUPPORTED: OnceLock<bool> = OnceLock::new();
-    *SUPPORTED.get_or_init(|| GraphicsCaptureSession::IsSupported().unwrap_or(false))
+    *SUPPORTED.get_or_init(probe_wgc)
+}
+
+/// The WGC probe, on its own COM-initialized thread. Separate from [`gather_wgc`] so the caching
+/// and the apartment handling read apart.
+#[cfg(windows)]
+fn probe_wgc() -> bool {
+    use windows::Graphics::Capture::GraphicsCaptureSession;
+    use windows::Win32::System::Com::{COINIT_MULTITHREADED, CoInitializeEx, CoUninitialize};
+    std::thread::spawn(|| {
+        // SAFETY: takes only scalars and borrows nothing. The thread it initializes is created
+        // here and joined below, so the apartment cannot outlive its pairing with the
+        // `CoUninitialize`.
+        let entered = unsafe { CoInitializeEx(None, COINIT_MULTITHREADED) };
+        // Safe: `IsSupported` is a WinRT projection, not an FFI call.
+        let supported = GraphicsCaptureSession::IsSupported().unwrap_or(false);
+        if entered.is_ok() {
+            // SAFETY: balances the `CoInitializeEx` above on this same thread. Gated on
+            // `is_ok`, so it runs for S_OK and S_FALSE but never for `RPC_E_CHANGED_MODE`,
+            // where this thread entered no apartment to leave.
+            unsafe { CoUninitialize() };
+        }
+        supported
+    })
+    .join()
+    .unwrap_or(false)
 }
 
 /// Port of the validated PMv2 probe: classify the thread's DPI-awareness context.

--- a/crates/glass-windows/src/doctor.rs
+++ b/crates/glass-windows/src/doctor.rs
@@ -308,10 +308,18 @@ fn gather_session() -> SessionKind {
 }
 
 /// Whether Windows.Graphics.Capture is usable on this system (the real capability gate).
+///
+/// Probed once per process. `IsSupported` activates a WinRT runtime class on the calling thread,
+/// and activating it concurrently from several threads faults with `STATUS_ACCESS_VIOLATION` —
+/// `cargo test --workspace` on Windows crashed the `glass-mcp` test binary about half the time,
+/// libtest giving each test its own thread. The answer is a fixed property of the machine, so
+/// caching is also the honest shape: nothing here can change while the process runs.
 #[cfg(windows)]
 fn gather_wgc() -> bool {
+    use std::sync::OnceLock;
     use windows::Graphics::Capture::GraphicsCaptureSession;
-    GraphicsCaptureSession::IsSupported().unwrap_or(false)
+    static SUPPORTED: OnceLock<bool> = OnceLock::new();
+    *SUPPORTED.get_or_init(|| GraphicsCaptureSession::IsSupported().unwrap_or(false))
 }
 
 /// Port of the validated PMv2 probe: classify the thread's DPI-awareness context.


### PR DESCRIPTION
`cargo test --workspace` on Windows crashed the `glass-mcp` test binary about half the time:

```
error: test failed, to rerun pass `-p glass-mcp --lib`
  process didn't exit successfully: glass_mcp-….exe (exit code: 0xc0000005, STATUS_ACCESS_VIOLATION)
```

No panic, no failing assertion, and no `test result:` summary line — the process died before libtest could print one.

## Cause

`doctor.rs`'s `gather_wgc` called `GraphicsCaptureSession::IsSupported()`, which activates a WinRT runtime class **on whatever thread calls it**. libtest gives each test its own short-lived thread, so the activation landed on a borrowed thread that then exited.

Isolated on the Windows box by holding everything else fixed:

| configuration | result |
|---|---|
| full suite, unmodified | 2/4 FAILED |
| full suite, `--test-threads=1` | pass — libtest runs tests on the **main** thread |
| doctor tests alone, in parallel | 6/6 pass — short run |
| full suite, `--skip doctor` | 5/5 pass |
| full suite, **only this call stubbed to `false`** | 5/5 pass |

## Caching alone is not the fix

The obvious first attempt — a `OnceLock`, since the value is a fixed property of the machine — was measured and **refuted**: 8 of 10 full-suite runs still faulted. One activation on a borrowed thread is enough, so reducing N activations to one changes nothing.

That is what identifies the real condition: not concurrent activation, but activation on a thread whose lifetime this code does not control.

## The fix

The probe runs on a thread created and joined here, with the apartment entered and left around it. The `OnceLock` stays — not as the fix, but because re-probing an unchanging machine property on every call was wrong on its own terms.

`unsafe` is scoped to the two COM calls that need it, each with its own `// SAFETY:`; `IsSupported` is a safe WinRT projection and sits outside them. `CoUninitialize` is gated on `is_ok`, so it runs for `S_OK`/`S_FALSE` but never for `RPC_E_CHANGED_MODE`, where the thread entered no apartment to leave.

## Verification, on the box

| | before | after |
|---|---|---|
| `cargo test -p glass-mcp --lib` ×10 | ~50% fault | **10/10 pass** |
| `cargo test --workspace` ×4 | 2/4 fault | **4/4 pass**, 1312 passed / 0 failed |

Ten consecutive passes against a ~50% baseline is roughly 1-in-1000 by chance.

`glass-mcp doctor` prints the identical WGC line on this branch and on master, so the reported answer is unchanged.

## Not verified

Both A/B doctor runs were over SSH — session 0, where WGC is genuinely unsupported — so they agree on `false` but do not prove the probe still returns **true** where it should. A session-1 run would settle that. The WGC line is diagnostic only and gates no capture path, so a wrong `false` would mislead rather than break, but it is unconfirmed either way.

This is pre-existing, not a regression — though #301 raised its cost by making the Windows CI job run `cargo test --workspace`.