### PR TITLE
fix(a11y-android): bound a dump attempt as a whole, not per adb call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,13 @@ internal refactors, CI, or test-only changes.
   Android paths have no such live check.
 
 ### Fixed
+- An Android accessibility read now keeps the deadline it promises. One `uiautomator dump` is three
+  adb calls, and each carried a timeout of its own, so a snapshot against a slow or wedged device
+  could run about 50 seconds — well past the `glass_wait_for_element` that asked for it, which
+  re-reads the tree on every tick of its own timeout. The three calls now share one snapshot's
+  20-second deadline, and the wait between retries on a device that cannot serve a dump yet counts
+  inside the retry budget instead of extending it. A read that runs out of that time is reported as
+  the timeout it is, rather than as a `uiautomator dump` that wrote no tree.
 - On macOS, `glass_start` now reports a window's settled geometry rather than a frame of its
   opening animation. It used to return whatever geometry it read the instant it found the newly
   launched window; measured across cold launches, that geometry disagreed with the window's

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -6,8 +6,8 @@ use std::time::{Duration, Instant};
 
 use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, AxTree};
 use glass_core::{
-    GlassError, KeyEvent, MouseButton, PointerEvent, Result, WindowGeometry, typed_clear_landed,
-    typed_text_landed,
+    GlassError, KeyEvent, MouseButton, NOT_STARTED, PointerEvent, Result, TIMED_OUT,
+    WindowGeometry, typed_clear_landed, typed_text_landed,
 };
 
 use crate::adb::{Adb, AdbOp};
@@ -21,8 +21,9 @@ const DUMP_PATH: &str = "/sdcard/glass_dump.xml";
 /// dump: a device reaches `sys.boot_completed` — all the platform waits for before
 /// reporting the app up — several seconds before the dump can serve one. Later snapshots
 /// must not wait, or a caller like `wait_for_element`, which runs a snapshot per tick
-/// inside its own budget, would be held long past it. This is time spent *retrying*; what
-/// one attempt may take is [`attempt_deadline`], and a snapshot can cost both.
+/// inside its own budget, would be held long past it. This is time spent *retrying*; one
+/// attempt costs `AdbOp::Dump`'s budget on top of it (see [`attempt_deadline`]), which a
+/// warmed snapshot pays too.
 const DUMP_READY_TIMEOUT_MS: u64 = 30_000;
 const DUMP_POLL_INTERVAL_MS: u64 = 1_000;
 
@@ -41,8 +42,9 @@ pub(crate) fn adb_runner(
 /// must be done by.
 ///
 /// The three share [`AdbOp::Dump`]'s budget, which is what that budget already describes: one
-/// snapshot. A step carrying its own instead let an attempt cost the sum of all three, which is
-/// more than any caller's deadline had allowed for.
+/// snapshot. The removal classifies as `AdbOp::Shell` and keeps its own 10s ceiling within that.
+/// A step carrying only its own budget let an attempt cost the sum of all three — 50s, against the
+/// 10s a `glass_wait_for_element` asks for by default and re-snapshots inside.
 pub(crate) fn attempt_deadline() -> Instant {
     Instant::now() + AdbOp::Dump.budget()
 }
@@ -62,14 +64,27 @@ pub(crate) fn dump_once(run: &mut AdbRunner<'_>, path: &str, deadline: Instant) 
         // The dump explained itself on stderr: that is why there is no file, and it names
         // the dump rather than the read that came up empty. Its stdout is never the reason
         // — it carries only the success line.
-        Err(_) if !stderr.trim().is_empty() => Err(GlassError::AccessibilityUnavailable(format!(
-            "uiautomator dump did not write {path}: {}",
-            stderr.trim()
-        ))),
+        Err(e) if !stderr.trim().is_empty() && !bound_fired(&e) => {
+            Err(GlassError::AccessibilityUnavailable(format!(
+                "uiautomator dump did not write {path}: {}",
+                stderr.trim()
+            )))
+        }
         // A dump that said nothing leaves the read as the only evidence, and a read that
         // fails on its own is about the device rather than a dump yet to become possible.
         Err(e) => Err(e),
     }
+}
+
+/// Whether an error is the attempt's own deadline firing rather than the device answering.
+///
+/// A read that ran out of the attempt's time never reached the device, so it is no evidence about
+/// the dump: substituting the dump's stderr for it would report a tree nobody looked for as one the
+/// dump failed to write, and — since that substitution is retryable — would keep retrying a device
+/// that had answered. Matched on the phrases `glass_core` publishes for exactly this.
+fn bound_fired(e: &GlassError) -> bool {
+    let msg = e.to_string();
+    msg.contains(TIMED_OUT) || msg.contains(NOT_STARTED)
 }
 
 /// Dump, retrying while `uiautomator` reports it cannot serve one yet, up to `budget`.
@@ -77,10 +92,9 @@ pub(crate) fn dump_once(run: &mut AdbRunner<'_>, path: &str, deadline: Instant) 
 /// Only that one failure resolves by waiting: an adb or device error is returned at once,
 /// so a device that has gone away is not retried for the whole budget.
 ///
-/// Returns within `budget` plus one [`attempt_deadline`]: `budget` bounds the retrying, and the
-/// last attempt it starts still has a whole dump to make. A caller that must not be held longer
-/// than that — `wait_for_element` re-snapshots inside a budget of its own — sizes `budget` knowing
-/// the attempt is on top of it.
+/// Returns within `budget` plus one attempt — `AdbOp::Dump`'s budget, per [`attempt_deadline`].
+/// `budget` bounds the retrying, waits between attempts included, and the last attempt it starts
+/// still has a whole dump to make.
 fn dump_until_ready(
     run: &mut AdbRunner<'_>,
     path: &str,
@@ -93,10 +107,13 @@ fn dump_until_ready(
             Ok(xml) => return Ok(xml),
             Err(e) => {
                 let retryable = matches!(e, GlassError::AccessibilityUnavailable(_));
-                if !retryable || Instant::now() >= retry_until {
+                let left = retry_until.saturating_duration_since(Instant::now());
+                if !retryable || left.is_zero() {
                     return Err(e);
                 }
-                std::thread::sleep(interval);
+                // Clamped, so the attempt this wait leads to still starts inside `budget` — an
+                // unclamped wait would put a whole further attempt past it.
+                std::thread::sleep(interval.min(left));
             }
         }
     }
@@ -167,9 +184,10 @@ const VERIFY_ATTEMPTS: usize = 3;
 const VERIFY_SETTLE_MS: u64 = 300;
 
 /// Readiness budget for one post-write read-back. Do NOT reuse [`DUMP_READY_TIMEOUT_MS`] here: that
-/// is the once-per-session cold-boot budget, and at [`VERIFY_ATTEMPTS`] attempts it would let a
-/// routine write hold the single-threaded tool loop for a minute and a half. What this waits out is
-/// an IME animation, which takes hundreds of milliseconds.
+/// is the once-per-session cold-boot budget, and each read-back also pays for the attempt it ends
+/// with, so at [`VERIFY_ATTEMPTS`] attempts it would let a routine write hold the single-threaded
+/// tool loop for two and a half minutes. What this waits out is an IME animation, which takes
+/// hundreds of milliseconds.
 const VERIFY_READY_BUDGET_MS: u64 = 2_000;
 
 /// Reads the active window's accessibility tree via `uiautomator`.
@@ -500,8 +518,7 @@ mod tests {
             seen[0] >= started + AdbOp::Dump.budget(),
             "an attempt must get a whole dump's worth, not what is left of the loop's budget"
         );
-        // Slack for the test's own work between `started` and the attempt; far short of the 50s an
-        // attempt cost when each step carried its own budget.
+        // Slack for the test's own work between `started` and the attempt.
         assert!(
             seen[0] <= started + AdbOp::Dump.budget() + Duration::from_secs(1),
             "an attempt must not be allowed the sum of its steps' budgets"
@@ -509,17 +526,20 @@ mod tests {
     }
 
     #[test]
-    fn a_retried_attempt_gets_a_fresh_deadline_inside_the_loops_whole_promise() {
-        let ready_budget = Duration::from_secs(5);
+    fn a_retried_attempt_gets_a_fresh_deadline() {
         let mut seen: Vec<Instant> = Vec::new();
         let mut cold = fake(1);
         let mut run = |argv: &[&str], deadline: Instant| -> Result<(String, String)> {
             seen.push(deadline);
             cold(argv, deadline)
         };
-        let started = Instant::now();
-        let xml = dump_until_ready(&mut run, PATH, ready_budget, Duration::from_millis(1))
-            .expect("the second attempt succeeds");
+        let xml = dump_until_ready(
+            &mut run,
+            PATH,
+            Duration::from_secs(5),
+            Duration::from_millis(1),
+        )
+        .expect("the second attempt succeeds");
 
         assert_eq!(xml, XML);
         assert_eq!(seen.len(), 6, "two attempts of three adb calls");
@@ -527,12 +547,82 @@ mod tests {
             seen[3] > seen[0],
             "a retry must be given its own deadline, not the spent remains of the first attempt's"
         );
-        // What the loop can now promise a caller: the time it may spend retrying, plus the one
-        // attempt that retry starts.
-        let ceiling = started + ready_budget + AdbOp::Dump.budget();
+    }
+
+    #[test]
+    fn the_wait_between_attempts_cannot_push_one_past_the_retry_budget() {
+        // The loop's whole promise — retry budget plus one attempt — with an interval far longer
+        // than the budget, which is where an unclamped wait would spend a further 2s and then start
+        // an attempt licensed to run 20s past the ceiling.
+        let budget = Duration::from_millis(50);
+        let mut seen: Vec<Instant> = Vec::new();
+        let mut cold = fake(usize::MAX);
+        let mut run = |argv: &[&str], deadline: Instant| -> Result<(String, String)> {
+            seen.push(deadline);
+            cold(argv, deadline)
+        };
+        let started = Instant::now();
+        dump_until_ready(&mut run, PATH, budget, Duration::from_secs(2))
+            .expect_err("a device that never becomes ready");
+
+        assert!(
+            started.elapsed() < Duration::from_millis(500),
+            "the wait ran past the budget it was supposed to fit inside: {:?}",
+            started.elapsed()
+        );
+        // Slack for the scheduler: a sleep clamped to the budget still wakes a little after it.
+        let ceiling = started + budget + AdbOp::Dump.budget() + Duration::from_millis(250);
         assert!(
             seen.iter().all(|d| *d <= ceiling),
             "no call may outlive the loop's budget plus one attempt"
+        );
+    }
+
+    #[test]
+    fn a_read_that_ran_out_of_the_attempts_time_is_not_reported_as_a_dump_that_wrote_nothing() {
+        // Sharing one deadline across the three steps is what makes this reachable: the read no
+        // longer gets a fresh budget, so an earlier slow step can leave it none. Blaming the dump's
+        // stderr for it would report a tree nobody looked for as one the dump failed to write —
+        // and, being retryable, would go on retrying a device that had answered.
+        //
+        // The error is the one `glass_core` really produces for a spent deadline, not a fixture
+        // repeating wording this crate does not own. Nothing is spawned on that path, so it needs
+        // no real command.
+        let spent = glass_core::run_bounded_until(
+            &mut std::process::Command::new("adb"),
+            Duration::from_secs(10),
+            Instant::now(),
+            "adb:uiautomator dump",
+        )
+        .expect_err("a spent deadline starts nothing")
+        .to_string();
+
+        let mut attempts = 0;
+        let mut run = |argv: &[&str], _deadline: Instant| -> Result<(String, String)> {
+            match argv {
+                ["shell", "uiautomator", "dump", _] => {
+                    attempts += 1;
+                    Ok((String::new(), format!("{NOT_READY}\n")))
+                }
+                ["shell", "cat", _] => Err(GlassError::Backend(spent.clone())),
+                _ => Ok((String::new(), String::new())),
+            }
+        };
+        let e =
+            dump_until_ready(&mut run, PATH, Duration::from_secs(30), Duration::ZERO).unwrap_err();
+
+        let msg = e.to_string();
+        assert!(
+            msg.contains(glass_core::NOT_STARTED),
+            "the step that ran out of time must be the one reported: {msg}"
+        );
+        assert!(
+            !msg.contains("did not write"),
+            "a read that never ran is no evidence about the dump: {msg}"
+        );
+        assert_eq!(
+            attempts, 1,
+            "an attempt that ran out of time is not a device that is not ready yet"
         );
     }
 

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -10,7 +10,7 @@ use glass_core::{
     typed_text_landed,
 };
 
-use crate::adb::Adb;
+use crate::adb::{Adb, AdbOp};
 use crate::axmap::build_tree;
 use crate::input::{key_commands, pointer_commands};
 use crate::target::{choose_serial, parse_devices};
@@ -21,29 +21,43 @@ const DUMP_PATH: &str = "/sdcard/glass_dump.xml";
 /// dump: a device reaches `sys.boot_completed` — all the platform waits for before
 /// reporting the app up — several seconds before the dump can serve one. Later snapshots
 /// must not wait, or a caller like `wait_for_element`, which runs a snapshot per tick
-/// inside its own budget, would be held long past it.
+/// inside its own budget, would be held long past it. This is time spent *retrying*; what
+/// one attempt may take is [`attempt_deadline`], and a snapshot can cost both.
 const DUMP_READY_TIMEOUT_MS: u64 = 30_000;
 const DUMP_POLL_INTERVAL_MS: u64 = 1_000;
 
-/// Runs one adb command and returns its `(stdout, stderr)` — the seam that lets the dump
-/// sequence be driven by a fake instead of a device.
-type AdbRunner<'a> = dyn FnMut(&[&str]) -> Result<(String, String)> + 'a;
+/// Runs one adb command, no further out than `deadline`, and returns its `(stdout, stderr)` — the
+/// seam that lets the dump sequence be driven by a fake instead of a device.
+type AdbRunner<'a> = dyn FnMut(&[&str], Instant) -> Result<(String, String)> + 'a;
 
 /// Bind a runner to a real device.
-pub(crate) fn adb_runner(adb: &Adb) -> impl FnMut(&[&str]) -> Result<(String, String)> + '_ {
-    move |argv| adb.run_streams(argv.iter().copied())
+pub(crate) fn adb_runner(
+    adb: &Adb,
+) -> impl FnMut(&[&str], Instant) -> Result<(String, String)> + '_ {
+    move |argv, deadline| adb.run_streams_until(argv.iter().copied(), deadline)
 }
 
-/// One `uiautomator dump`, returning the XML it wrote.
+/// When one whole dump attempt — the stale-file removal, the dump, and the read of what it wrote —
+/// must be done by.
+///
+/// The three share [`AdbOp::Dump`]'s budget, which is what that budget already describes: one
+/// snapshot. A step carrying its own instead let an attempt cost the sum of all three, which is
+/// more than any caller's deadline had allowed for.
+pub(crate) fn attempt_deadline() -> Instant {
+    Instant::now() + AdbOp::Dump.budget()
+}
+
+/// One `uiautomator dump`, returning the XML it wrote. Every step is bounded by `deadline` — see
+/// [`attempt_deadline`].
 ///
 /// `uiautomator dump` exits 0 even when it fails and reports the reason on stderr, so
 /// neither its exit status nor its stdout can be trusted; the file it was asked to write
 /// is the only reliable success signal. A stale file is removed first, best-effort, so a
 /// previous run's tree does not stand in for one this dump never wrote.
-pub(crate) fn dump_once(run: &mut AdbRunner<'_>, path: &str) -> Result<String> {
-    let _ = run(&["shell", "rm", "-f", path]);
-    let (_, stderr) = run(&["shell", "uiautomator", "dump", path])?;
-    match run(&["shell", "cat", path]) {
+pub(crate) fn dump_once(run: &mut AdbRunner<'_>, path: &str, deadline: Instant) -> Result<String> {
+    let _ = run(&["shell", "rm", "-f", path], deadline);
+    let (_, stderr) = run(&["shell", "uiautomator", "dump", path], deadline)?;
+    match run(&["shell", "cat", path], deadline) {
         Ok((xml, _)) => Ok(xml),
         // The dump explained itself on stderr: that is why there is no file, and it names
         // the dump rather than the read that came up empty. Its stdout is never the reason
@@ -62,19 +76,24 @@ pub(crate) fn dump_once(run: &mut AdbRunner<'_>, path: &str) -> Result<String> {
 ///
 /// Only that one failure resolves by waiting: an adb or device error is returned at once,
 /// so a device that has gone away is not retried for the whole budget.
+///
+/// Returns within `budget` plus one [`attempt_deadline`]: `budget` bounds the retrying, and the
+/// last attempt it starts still has a whole dump to make. A caller that must not be held longer
+/// than that — `wait_for_element` re-snapshots inside a budget of its own — sizes `budget` knowing
+/// the attempt is on top of it.
 fn dump_until_ready(
     run: &mut AdbRunner<'_>,
     path: &str,
     budget: Duration,
     interval: Duration,
 ) -> Result<String> {
-    let deadline = Instant::now() + budget;
+    let retry_until = Instant::now() + budget;
     loop {
-        match dump_once(run, path) {
+        match dump_once(run, path, attempt_deadline()) {
             Ok(xml) => return Ok(xml),
             Err(e) => {
                 let retryable = matches!(e, GlassError::AccessibilityUnavailable(_));
-                if !retryable || Instant::now() >= deadline {
+                if !retryable || Instant::now() >= retry_until {
                     return Err(e);
                 }
                 std::thread::sleep(interval);
@@ -344,9 +363,15 @@ mod tests {
     use super::{
         dump_once, dump_until_ready, editable_target, locate_editable_target, verify_write,
     };
+    use crate::adb::AdbOp;
     use glass_core::accessibility::{AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree};
     use glass_core::{GlassError, Result, WindowGeometry};
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
+
+    /// A deadline no test reaches, for the cases that are not about the bound.
+    fn ample() -> Instant {
+        Instant::now() + Duration::from_secs(60)
+    }
 
     const PATH: &str = "/sdcard/glass_dump.xml";
     const XML: &str = "<?xml version='1.0'?><hierarchy rotation=\"0\"></hierarchy>";
@@ -369,10 +394,10 @@ mod tests {
 
     /// An adb whose `uiautomator dump` fails as a cold device's does for `cold` attempts,
     /// then succeeds. Records every command it is given.
-    fn fake(cold: usize) -> impl FnMut(&[&str]) -> Result<(String, String)> {
+    fn fake(cold: usize) -> impl FnMut(&[&str], Instant) -> Result<(String, String)> {
         let mut dumps = 0;
         let mut wrote = false;
-        move |argv: &[&str]| match argv {
+        move |argv: &[&str], _deadline: Instant| match argv {
             ["shell", "rm", "-f", _] => {
                 wrote = false;
                 Ok((String::new(), String::new()))
@@ -396,7 +421,7 @@ mod tests {
     #[test]
     fn dump_reports_the_dump_that_wrote_nothing_not_the_read_that_found_nothing() {
         let mut run = fake(1);
-        let e = dump_once(&mut run, PATH).unwrap_err();
+        let e = dump_once(&mut run, PATH, ample()).unwrap_err();
         let msg = e.to_string();
         assert!(
             msg.contains(&format!("uiautomator dump did not write {PATH}")),
@@ -415,14 +440,14 @@ mod tests {
     #[test]
     fn dump_clears_a_stale_file_before_dumping() {
         let mut seen: Vec<String> = Vec::new();
-        let mut run = |argv: &[&str]| -> Result<(String, String)> {
+        let mut run = |argv: &[&str], _deadline: Instant| -> Result<(String, String)> {
             seen.push(argv.join(" "));
             match argv {
                 ["shell", "cat", _] => Ok((XML.to_string(), String::new())),
                 _ => Ok((String::new(), String::new())),
             }
         };
-        dump_once(&mut run, PATH).unwrap();
+        dump_once(&mut run, PATH, ample()).unwrap();
         assert_eq!(
             seen,
             vec![
@@ -438,15 +463,77 @@ mod tests {
     fn a_read_failure_the_dump_did_not_explain_is_returned_as_it_stands() {
         // The dump succeeded and said so; the read then failed on its own. Blaming the dump
         // here would repeat the misattribution this fix exists to remove.
-        let mut run = |argv: &[&str]| -> Result<(String, String)> {
+        let mut run = |argv: &[&str], _deadline: Instant| -> Result<(String, String)> {
             match argv {
                 ["shell", "cat", _] => Err(read_err()),
                 _ => Ok((DUMPED.to_string(), String::new())),
             }
         };
-        let e = dump_once(&mut run, PATH).unwrap_err();
+        let e = dump_once(&mut run, PATH, ample()).unwrap_err();
         assert!(matches!(e, GlassError::Backend(_)), "{e}");
         assert!(!e.to_string().contains("did not write"), "{e}");
+    }
+
+    #[test]
+    fn the_three_steps_of_one_dump_share_one_deadline_worth_a_single_dump() {
+        // The defect this fixes: each step carrying its own budget let one attempt cost their sum
+        // (10s + 20s + 20s), which the loop's own deadline — checked only between attempts — could
+        // not see. The lower bound is the other half: an attempt is given a whole dump's worth even
+        // when, as here, the loop has no budget to retry with.
+        let mut seen: Vec<Instant> = Vec::new();
+        let mut run = |argv: &[&str], deadline: Instant| -> Result<(String, String)> {
+            seen.push(deadline);
+            match argv {
+                ["shell", "cat", _] => Ok((XML.to_string(), String::new())),
+                _ => Ok((String::new(), String::new())),
+            }
+        };
+        let started = Instant::now();
+        dump_until_ready(&mut run, PATH, Duration::ZERO, Duration::ZERO).unwrap();
+
+        assert_eq!(seen.len(), 3, "one attempt is three adb calls");
+        assert!(
+            seen.iter().all(|d| *d == seen[0]),
+            "the steps of one dump must share one deadline"
+        );
+        assert!(
+            seen[0] >= started + AdbOp::Dump.budget(),
+            "an attempt must get a whole dump's worth, not what is left of the loop's budget"
+        );
+        // Slack for the test's own work between `started` and the attempt; far short of the 50s an
+        // attempt cost when each step carried its own budget.
+        assert!(
+            seen[0] <= started + AdbOp::Dump.budget() + Duration::from_secs(1),
+            "an attempt must not be allowed the sum of its steps' budgets"
+        );
+    }
+
+    #[test]
+    fn a_retried_attempt_gets_a_fresh_deadline_inside_the_loops_whole_promise() {
+        let ready_budget = Duration::from_secs(5);
+        let mut seen: Vec<Instant> = Vec::new();
+        let mut cold = fake(1);
+        let mut run = |argv: &[&str], deadline: Instant| -> Result<(String, String)> {
+            seen.push(deadline);
+            cold(argv, deadline)
+        };
+        let started = Instant::now();
+        let xml = dump_until_ready(&mut run, PATH, ready_budget, Duration::from_millis(1))
+            .expect("the second attempt succeeds");
+
+        assert_eq!(xml, XML);
+        assert_eq!(seen.len(), 6, "two attempts of three adb calls");
+        assert!(
+            seen[3] > seen[0],
+            "a retry must be given its own deadline, not the spent remains of the first attempt's"
+        );
+        // What the loop can now promise a caller: the time it may spend retrying, plus the one
+        // attempt that retry starts.
+        let ceiling = started + ready_budget + AdbOp::Dump.budget();
+        assert!(
+            seen.iter().all(|d| *d <= ceiling),
+            "no call may outlive the loop's budget plus one attempt"
+        );
     }
 
     #[test]
@@ -469,7 +556,7 @@ mod tests {
         // A device that has gone away will not come back by waiting, and a caller polling
         // with its own timeout must not be held past it.
         let mut attempts = 0;
-        let mut run = |argv: &[&str]| -> Result<(String, String)> {
+        let mut run = |argv: &[&str], _deadline: Instant| -> Result<(String, String)> {
             match argv {
                 ["shell", "uiautomator", "dump", _] => {
                     attempts += 1;

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -41,10 +41,10 @@ pub(crate) fn adb_runner(
 /// When one whole dump attempt — the stale-file removal, the dump, and the read of what it wrote —
 /// must be done by.
 ///
-/// The three share [`AdbOp::Dump`]'s budget, which is what that budget already describes: one
-/// snapshot. The removal classifies as `AdbOp::Shell` and keeps its own 10s ceiling within that.
-/// A step carrying only its own budget let an attempt cost the sum of all three — 50s, against the
-/// 10s a `glass_wait_for_element` asks for by default and re-snapshots inside.
+/// The three share [`AdbOp::Dump`]'s budget — one snapshot's worth — with the removal keeping its
+/// own `AdbOp::Shell` ceiling inside that. A step carrying only its own budget let an attempt cost
+/// the sum of all three, 50s against the 10s a `glass_wait_for_element` asks for by default and
+/// re-snapshots inside.
 pub(crate) fn attempt_deadline() -> Instant {
     Instant::now() + AdbOp::Dump.budget()
 }
@@ -78,10 +78,9 @@ pub(crate) fn dump_once(run: &mut AdbRunner<'_>, path: &str, deadline: Instant) 
 
 /// Whether an error is the attempt's own deadline firing rather than the device answering.
 ///
-/// A read that ran out of the attempt's time never reached the device, so it is no evidence about
-/// the dump: substituting the dump's stderr for it would report a tree nobody looked for as one the
-/// dump failed to write, and — since that substitution is retryable — would keep retrying a device
-/// that had answered. Matched on the phrases `glass_core` publishes for exactly this.
+/// A read that ran out of the attempt's time never reached the device, so the dump's stderr is no
+/// explanation for it — and that substitution is retryable, so the loop would go on retrying a
+/// device that had answered. Matched on the phrases `glass_core` publishes for exactly this.
 fn bound_fired(e: &GlassError) -> bool {
     let msg = e.to_string();
     msg.contains(TIMED_OUT) || msg.contains(NOT_STARTED)
@@ -495,9 +494,9 @@ mod tests {
     #[test]
     fn the_three_steps_of_one_dump_share_one_deadline_worth_a_single_dump() {
         // The defect this fixes: each step carrying its own budget let one attempt cost their sum
-        // (10s + 20s + 20s), which the loop's own deadline — checked only between attempts — could
-        // not see. The lower bound is the other half: an attempt is given a whole dump's worth even
-        // when, as here, the loop has no budget to retry with.
+        // (10s + 20s + 20s), which the loop's deadline — checked only between attempts — could not
+        // see. The lower bound is the other half: an attempt gets a whole dump's worth even when,
+        // as here, the loop has no budget to retry with.
         let mut seen: Vec<Instant> = Vec::new();
         let mut run = |argv: &[&str], deadline: Instant| -> Result<(String, String)> {
             seen.push(deadline);
@@ -551,9 +550,8 @@ mod tests {
 
     #[test]
     fn the_wait_between_attempts_cannot_push_one_past_the_retry_budget() {
-        // The loop's whole promise — retry budget plus one attempt — with an interval far longer
-        // than the budget, which is where an unclamped wait would spend a further 2s and then start
-        // an attempt licensed to run 20s past the ceiling.
+        // An interval far longer than the budget is where an unclamped wait would spend a further
+        // 2s and then start an attempt licensed to run 20s past the ceiling.
         let budget = Duration::from_millis(50);
         let mut seen: Vec<Instant> = Vec::new();
         let mut cold = fake(usize::MAX);
@@ -580,10 +578,8 @@ mod tests {
 
     #[test]
     fn a_read_that_ran_out_of_the_attempts_time_is_not_reported_as_a_dump_that_wrote_nothing() {
-        // Sharing one deadline across the three steps is what makes this reachable: the read no
-        // longer gets a fresh budget, so an earlier slow step can leave it none. Blaming the dump's
-        // stderr for it would report a tree nobody looked for as one the dump failed to write —
-        // and, being retryable, would go on retrying a device that had answered.
+        // Sharing one deadline across the three steps is what makes this reachable: an earlier slow
+        // step can leave the read none.
         //
         // The error is the one `glass_core` really produces for a spent deadline, not a fixture
         // repeating wording this crate does not own. Nothing is spawned on that path, so it needs

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -12,8 +12,10 @@ use glass_core::{GlassError, Result, TIMED_OUT, run_bounded, run_bounded_until};
 /// that fires on a loaded-but-working device is worse than the hang it replaces.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AdbOp {
-    /// `uiautomator dump`, and the `cat` that reads the tree it wrote — the two halves of one
-    /// snapshot, so they share a deadline rather than the read-back inheriting a tap's.
+    /// `uiautomator dump`, and the `cat` that reads the tree it wrote — two steps of one snapshot,
+    /// so they share a deadline rather than the read-back inheriting a tap's. That deadline bounds
+    /// the whole snapshot: `a11y::attempt_deadline` runs all three of its steps inside this budget,
+    /// including the stale-file removal, which classifies as [`AdbOp::Shell`].
     Dump,
     /// `exec-out screencap` — encodes a full-resolution frame.
     Screencap,
@@ -30,7 +32,8 @@ pub enum AdbOp {
 }
 
 impl AdbOp {
-    /// The deadline for this kind of call.
+    /// The deadline for this kind of call, and — where a caller passes one to
+    /// [`Adb::run_streams_until`] — the ceiling a call gets rather than the deadline itself.
     pub fn budget(self) -> Duration {
         match self {
             Self::Dump => Duration::from_secs(20),
@@ -259,6 +262,32 @@ mod tests {
         // connection wedged behind it.
         let devices = adb.run(["devices"]).expect("adb usable after a timeout");
         assert!(devices.contains("List of devices"), "{devices}");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_deadline_handed_to_adb_reaches_the_process_that_runs() {
+        // The wiring the whole fix rests on: `output` must pass the deadline to the bounded runner,
+        // not merely accept one. `/bin/sh` stands in for adb — `AdbOp::Shell`'s 10s budget is what
+        // this call would otherwise wait out.
+        let adb = Adb {
+            bin: "/bin/sh".to_string(),
+            serial: None,
+        };
+        let started = std::time::Instant::now();
+        let err = adb
+            .run_streams_until(
+                ["-c", "sleep 30"],
+                std::time::Instant::now() + Duration::from_millis(300),
+            )
+            .expect_err("a step must not outlive the deadline it serves");
+
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "waited {:?} — the deadline never reached the process",
+            started.elapsed()
+        );
+        assert!(err.to_string().contains(TIMED_OUT), "{err}");
     }
 
     #[test]

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -126,9 +126,9 @@ impl Adb {
     ///
     /// Two streams because a command whose exit status does not signal success — `uiautomator dump`
     /// exits 0 when it fails, and explains itself on stderr — leaves the caller to judge the outcome
-    /// from the streams itself. `deadline` bounds the sequence: the call gets its operation's budget
-    /// or what is left of that, whichever is nearer, so the steps of one dump cannot together cost
-    /// the sum of their budgets.
+    /// from the streams itself. The call gets its operation's budget or what is left of `deadline`,
+    /// whichever is nearer, so the steps of one dump cannot together cost the sum of their
+    /// budgets.
     pub fn run_streams_until<'a, I>(&self, args: I, deadline: Instant) -> Result<(String, String)>
     where
         I: IntoIterator<Item = &'a str>,
@@ -267,8 +267,8 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn a_deadline_handed_to_adb_reaches_the_process_that_runs() {
-        // The wiring the whole fix rests on: `output` must pass the deadline to the bounded runner,
-        // not merely accept one. `/bin/sh` stands in for adb — `AdbOp::Shell`'s 10s budget is what
+        // The wiring the fix rests on: `output` must pass the deadline to the bounded runner, not
+        // merely accept one. `/bin/sh` stands in for adb, and `AdbOp::Shell`'s 10s budget is what
         // this call would otherwise wait out.
         let adb = Adb {
             bin: "/bin/sh".to_string(),

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -1,7 +1,7 @@
 use std::process::{Command, Output};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use glass_core::{GlassError, Result, TIMED_OUT, run_bounded};
+use glass_core::{GlassError, Result, TIMED_OUT, run_bounded, run_bounded_until};
 
 /// What an adb invocation is doing, which is what decides how long it may take.
 ///
@@ -115,18 +115,22 @@ impl Adb {
     where
         I: IntoIterator<Item = &'a str>,
     {
-        let out = self.output(args)?;
+        let out = self.output(args, None)?;
         Ok(String::from_utf8_lossy(&out.stdout).into_owned())
     }
 
-    /// Run adb capturing stdout *and* stderr. For a command whose exit status does not
-    /// signal success — `uiautomator dump` exits 0 when it fails, and explains itself on
-    /// stderr — the caller has to judge the outcome from the streams itself.
-    pub fn run_streams<'a, I>(&self, args: I) -> Result<(String, String)>
+    /// Run adb capturing stdout *and* stderr, as one step of a sequence that answers as a whole.
+    ///
+    /// Two streams because a command whose exit status does not signal success — `uiautomator dump`
+    /// exits 0 when it fails, and explains itself on stderr — leaves the caller to judge the outcome
+    /// from the streams itself. `deadline` bounds the sequence: the call gets its operation's budget
+    /// or what is left of that, whichever is nearer, so the steps of one dump cannot together cost
+    /// the sum of their budgets.
+    pub fn run_streams_until<'a, I>(&self, args: I, deadline: Instant) -> Result<(String, String)>
     where
         I: IntoIterator<Item = &'a str>,
     {
-        let out = self.output(args)?;
+        let out = self.output(args, Some(deadline))?;
         Ok((
             String::from_utf8_lossy(&out.stdout).into_owned(),
             String::from_utf8_lossy(&out.stderr).into_owned(),
@@ -138,12 +142,13 @@ impl Adb {
     where
         I: IntoIterator<Item = &'a str>,
     {
-        Ok(self.output(args)?.stdout)
+        Ok(self.output(args, None)?.stdout)
     }
 
     /// Run adb and return the completed process, erroring on spawn failure or non-zero
-    /// exit so every caller reports those two the same way.
-    fn output<'a, I>(&self, args: I) -> Result<Output>
+    /// exit so every caller reports those two the same way. `deadline` is the outer bound of a
+    /// multi-call sequence, where there is one.
+    fn output<'a, I>(&self, args: I, deadline: Option<Instant>) -> Result<Output>
     where
         I: IntoIterator<Item = &'a str>,
     {
@@ -154,7 +159,11 @@ impl Adb {
         cmd.args(&argv);
         // A wedged adb server answers nothing at all, and the fix is one command — so the remedy
         // rides in the error the caller sees rather than in a log line nobody reads.
-        let out = run_bounded(&mut cmd, op.budget(), op.label()).map_err(with_adb_hint)?;
+        let out = match deadline {
+            Some(d) => run_bounded_until(&mut cmd, op.budget(), d, op.label()),
+            None => run_bounded(&mut cmd, op.budget(), op.label()),
+        }
+        .map_err(with_adb_hint)?;
         if out.status.success() {
             Ok(out)
         } else {

--- a/crates/glass-android/src/doctor.rs
+++ b/crates/glass-android/src/doctor.rs
@@ -6,7 +6,7 @@
 
 use glass_core::{Check, CheckStatus};
 
-use crate::a11y::{adb_runner, dump_once};
+use crate::a11y::{adb_runner, attempt_deadline, dump_once};
 use crate::adb::Adb;
 use crate::avd::{Action, Lifecycle, decide, parse_list_avds, resolve_emulator_bin};
 use crate::target::{Device, parse_devices};
@@ -230,7 +230,7 @@ fn deep_probe(adb: &Adb, serial: &str) -> DeepProbe {
     // Deliberately one attempt, where AndroidA11y retries: doctor reports what the device
     // can do now, and a dump that only succeeds after a wait is what this check exists to
     // reveal.
-    let uiautomator = match dump_once(&mut adb_runner(&dev), DUMP_PATH) {
+    let uiautomator = match dump_once(&mut adb_runner(&dev), DUMP_PATH, attempt_deadline()) {
         Ok(xml) if xml.contains("<hierarchy") => Ok("a11y dump OK".to_string()),
         Ok(_) => Err("uiautomator dump produced no hierarchy".to_string()),
         Err(e) => Err(e.to_string()),

--- a/crates/glass-core/src/bounded.rs
+++ b/crates/glass-core/src/bounded.rs
@@ -56,6 +56,28 @@ pub fn run_bounded(cmd: &mut Command, budget: Duration, op: &str) -> Result<Outp
     run_bounded_inner(cmd, budget, op, None)
 }
 
+/// [`run_bounded`], but never outliving `deadline` — the bound of the larger call this one serves.
+///
+/// Several calls can answer one request: one `uiautomator dump` is a remove, a dump and a read.
+/// Each carrying only its own budget makes the sequence cost their sum, so the caller's deadline
+/// travels down and each step gets whichever bound is nearer. A step with nothing left is not
+/// started at all — its outcome is already decided, and spawning it would cost a process and the
+/// wait to kill it.
+pub fn run_bounded_until(
+    cmd: &mut Command,
+    budget: Duration,
+    deadline: Instant,
+    op: &str,
+) -> Result<Output> {
+    let budget = budget_within(budget, deadline, Instant::now());
+    if budget.is_zero() {
+        return Err(GlassError::Backend(format!(
+            "{op}: {TIMED_OUT} the time left of the deadline it serves, so it was not started"
+        )));
+    }
+    run_bounded_inner(cmd, budget, op, None)
+}
+
 /// [`run_bounded`], but writing `stdin` to the child first.
 ///
 /// The write happens on its own thread for the same reason the reads do: a tool that answers before
@@ -286,6 +308,12 @@ fn next_wait(previous: Duration) -> Duration {
 /// Whether appending `n` more bytes to a buffer of `len` would pass [`MAX_CAPTURE`].
 fn would_exceed_capture(len: usize, n: usize) -> bool {
     len + n > MAX_CAPTURE
+}
+
+/// The budget a call actually gets: its own, or what is left of the deadline it serves, whichever
+/// is nearer. Its own function so the rule is pinned by a test, which a timing test cannot do.
+fn budget_within(budget: Duration, deadline: Instant, now: Instant) -> Duration {
+    budget.min(deadline.saturating_duration_since(now))
 }
 
 /// Whether `deadline` has arrived. Its own function so the boundary — a deadline exactly reached
@@ -693,6 +721,89 @@ mod tests {
             !msg.contains("stdout:"),
             "nothing was written to stdout: {msg}"
         );
+    }
+
+    #[test]
+    fn a_call_gets_the_nearer_of_its_own_budget_and_the_deadline_it_serves() {
+        // The rule the deadline-taking runner exists for, pinned where no timing test can reach it.
+        let now = Instant::now();
+        assert_eq!(
+            budget_within(Duration::from_secs(20), now + Duration::from_secs(5), now),
+            Duration::from_secs(5)
+        );
+        assert_eq!(
+            budget_within(Duration::from_secs(3), now + Duration::from_secs(5), now),
+            Duration::from_secs(3)
+        );
+        assert_eq!(
+            budget_within(Duration::from_secs(20), now, now),
+            Duration::ZERO
+        );
+        let past = now.checked_sub(Duration::from_secs(1)).unwrap_or(now);
+        assert_eq!(
+            budget_within(Duration::from_secs(20), past, now),
+            Duration::ZERO
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_call_dies_at_the_deadline_it_serves_rather_than_at_its_own_budget() {
+        // A step of a longer sequence gets what is left of the sequence's deadline. Without this,
+        // three steps each carrying their own budget cost the sum of all three.
+        let started = Instant::now();
+        let err = run_bounded_until(
+            Command::new("/bin/sh").args(["-c", "sleep 30"]),
+            Duration::from_secs(20),
+            Instant::now() + Duration::from_millis(300),
+            "test:outer-deadline",
+        )
+        .expect_err("must not wait out its own budget past the deadline it serves");
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "waited {:?}",
+            started.elapsed()
+        );
+        assert!(err.to_string().contains("test:outer-deadline"), "{err}");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_deadline_further_out_than_the_budget_leaves_the_budget_in_charge() {
+        // The clamp is a ceiling, not a replacement: a call with room to spare still dies at the
+        // budget its own operation was given.
+        let err = run_bounded_until(
+            Command::new("/bin/sh").args(["-c", "sleep 30"]),
+            Duration::from_millis(300),
+            Instant::now() + Duration::from_secs(60),
+            "test:own-budget",
+        )
+        .expect_err("must time out");
+        assert!(err.to_string().contains("300ms"), "{err}");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_call_with_no_time_left_is_not_started_at_all() {
+        // Spawning a child only to kill it at once costs a process and a wait; the failure is
+        // already decided. Proven by side effect — the command creates a file if it ever runs.
+        let marker =
+            std::env::temp_dir().join(format!("glass-spent-deadline-{}", std::process::id()));
+        let _ = std::fs::remove_file(&marker);
+        let err = run_bounded_until(
+            Command::new("/bin/sh").args(["-c", &format!("touch '{}'", marker.display())]),
+            Duration::from_secs(20),
+            Instant::now(),
+            "test:spent-deadline",
+        )
+        .expect_err("a call with no time left must fail rather than run");
+        assert!(
+            !marker.exists(),
+            "the command ran despite having no time left"
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("test:spent-deadline"), "{msg}");
+        assert!(msg.contains(TIMED_OUT), "{msg}");
     }
 
     #[test]

--- a/crates/glass-core/src/bounded.rs
+++ b/crates/glass-core/src/bounded.rs
@@ -20,8 +20,8 @@ use crate::{GlassError, Result};
 pub const TIMED_OUT: &str = "no answer within";
 
 /// The phrase an error carries when a call was never started, because the deadline it serves was
-/// already spent. Deliberately not [`TIMED_OUT`]: nothing was asked, so nothing failed to answer,
-/// and the remedies for a wedged tool do not apply.
+/// already spent. Deliberately not [`TIMED_OUT`]: the remedies for a tool that hung do not apply to
+/// one that never ran.
 pub const NOT_STARTED: &str = "was not started";
 
 /// Longest gap between checks on a child that has not exited yet. The wait starts far tighter and
@@ -65,11 +65,9 @@ pub fn run_bounded(cmd: &mut Command, budget: Duration, op: &str) -> Result<Outp
 /// serves. Killing and draining a child still runs after that, as it does for a plain budget.
 ///
 /// Several calls can answer one request: one `uiautomator dump` is a remove, a dump and a read.
-/// Each carrying only its own budget makes the sequence cost their sum, so the caller's deadline
-/// travels down and each step gets whichever bound is nearer. A step with nothing left is not
-/// started at all — its outcome is already decided, and spawning it would cost a process and the
-/// wait to kill it. That step's error says [`NOT_STARTED`] rather than [`TIMED_OUT`], so a caller
-/// does not answer it with a remedy for a tool that never ran.
+/// Each carrying only its own budget makes the sequence cost their sum, so the deadline travels
+/// down and each step gets whichever bound is nearer. A step with nothing left is not started at
+/// all, and says [`NOT_STARTED`].
 pub fn run_bounded_until(
     cmd: &mut Command,
     budget: Duration,
@@ -757,8 +755,8 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn a_call_dies_at_the_deadline_it_serves_rather_than_at_its_own_budget() {
-        // A step of a longer sequence gets what is left of the sequence's deadline. Without this,
-        // three steps each carrying their own budget cost the sum of all three.
+        // A step of a longer sequence gets what is left of the sequence's deadline, not the sum of
+        // three steps' budgets.
         let started = Instant::now();
         let err = run_bounded_until(
             Command::new("/bin/sh").args(["-c", "sleep 30"]),
@@ -793,9 +791,8 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn a_call_with_no_time_left_is_not_started_at_all() {
-        // Spawning a child only to kill it at once costs a process and a wait; the failure is
-        // already decided. The wording is what proves it: spawning would time out at 0ns and say
-        // so, which is a different sentence and one a caller answers differently.
+        // Spawning a child only to kill it at once costs a process and a wait. The wording is what
+        // discriminates: spawning would time out at 0ns and say so.
         let started = Instant::now();
         let err = run_bounded_until(
             Command::new("/bin/sh").args(["-c", "sleep 30"]),

--- a/crates/glass-core/src/bounded.rs
+++ b/crates/glass-core/src/bounded.rs
@@ -19,6 +19,11 @@ use crate::{GlassError, Result};
 /// does not own — `glass-android` offers `adb kill-server` for a timeout and for nothing else.
 pub const TIMED_OUT: &str = "no answer within";
 
+/// The phrase an error carries when a call was never started, because the deadline it serves was
+/// already spent. Deliberately not [`TIMED_OUT`]: nothing was asked, so nothing failed to answer,
+/// and the remedies for a wedged tool do not apply.
+pub const NOT_STARTED: &str = "was not started";
+
 /// Longest gap between checks on a child that has not exited yet. The wait starts far tighter and
 /// backs off to this, so a one-shot that answers in a millisecond is not billed a full tick and a
 /// long wait settles to one wakeup every 20ms.
@@ -56,13 +61,15 @@ pub fn run_bounded(cmd: &mut Command, budget: Duration, op: &str) -> Result<Outp
     run_bounded_inner(cmd, budget, op, None)
 }
 
-/// [`run_bounded`], but never outliving `deadline` — the bound of the larger call this one serves.
+/// [`run_bounded`], but waiting no later than `deadline` — the bound of the larger call this one
+/// serves. Killing and draining a child still runs after that, as it does for a plain budget.
 ///
 /// Several calls can answer one request: one `uiautomator dump` is a remove, a dump and a read.
 /// Each carrying only its own budget makes the sequence cost their sum, so the caller's deadline
 /// travels down and each step gets whichever bound is nearer. A step with nothing left is not
 /// started at all — its outcome is already decided, and spawning it would cost a process and the
-/// wait to kill it.
+/// wait to kill it. That step's error says [`NOT_STARTED`] rather than [`TIMED_OUT`], so a caller
+/// does not answer it with a remedy for a tool that never ran.
 pub fn run_bounded_until(
     cmd: &mut Command,
     budget: Duration,
@@ -72,7 +79,8 @@ pub fn run_bounded_until(
     let budget = budget_within(budget, deadline, Instant::now());
     if budget.is_zero() {
         return Err(GlassError::Backend(format!(
-            "{op}: {TIMED_OUT} the time left of the deadline it serves, so it was not started"
+            "{op}: the deadline it shares with the rest of the call was already spent, so it \
+             {NOT_STARTED}"
         )));
     }
     run_bounded_inner(cmd, budget, op, None)
@@ -786,24 +794,43 @@ mod tests {
     #[cfg(unix)]
     fn a_call_with_no_time_left_is_not_started_at_all() {
         // Spawning a child only to kill it at once costs a process and a wait; the failure is
-        // already decided. Proven by side effect — the command creates a file if it ever runs.
-        let marker =
-            std::env::temp_dir().join(format!("glass-spent-deadline-{}", std::process::id()));
-        let _ = std::fs::remove_file(&marker);
+        // already decided. The wording is what proves it: spawning would time out at 0ns and say
+        // so, which is a different sentence and one a caller answers differently.
+        let started = Instant::now();
         let err = run_bounded_until(
-            Command::new("/bin/sh").args(["-c", &format!("touch '{}'", marker.display())]),
+            Command::new("/bin/sh").args(["-c", "sleep 30"]),
             Duration::from_secs(20),
             Instant::now(),
             "test:spent-deadline",
         )
         .expect_err("a call with no time left must fail rather than run");
         assert!(
-            !marker.exists(),
-            "the command ran despite having no time left"
+            started.elapsed() < Duration::from_millis(200),
+            "spawning and killing a doomed child takes longer than this: {:?}",
+            started.elapsed()
         );
         let msg = err.to_string();
         assert!(msg.contains("test:spent-deadline"), "{msg}");
-        assert!(msg.contains(TIMED_OUT), "{msg}");
+        assert!(msg.contains(NOT_STARTED), "{msg}");
+        // Nothing was asked, so nothing failed to answer — and `with_adb_hint` and its kind key on
+        // this phrase to offer remedies for a wedged tool.
+        assert!(!msg.contains(TIMED_OUT), "{msg}");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_command_that_finishes_inside_both_bounds_returns_its_output() {
+        // The deadline-taking runner has the same contract as the plain one on the way out: the
+        // output is returned, and a non-zero exit is the caller's to judge, not a failure here.
+        let out = run_bounded_until(
+            Command::new("/bin/sh").args(["-c", "printf ready; exit 3"]),
+            Duration::from_secs(10),
+            Instant::now() + Duration::from_secs(10),
+            "test:until-fast",
+        )
+        .expect("a fast command yields its Output");
+        assert_eq!(String::from_utf8_lossy(&out.stdout), "ready");
+        assert_eq!(out.status.code(), Some(3));
     }
 
     #[test]

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -13,7 +13,7 @@ pub mod toolpath;
 pub use toolpath::tool_path;
 
 pub mod bounded;
-pub use bounded::{TIMED_OUT, run_bounded, run_bounded_with_stdin};
+pub use bounded::{TIMED_OUT, run_bounded, run_bounded_until, run_bounded_with_stdin};
 
 pub mod set_value;
 pub use set_value::{read_back_confirms, typed_clear_landed, typed_text_landed};

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -13,7 +13,7 @@ pub mod toolpath;
 pub use toolpath::tool_path;
 
 pub mod bounded;
-pub use bounded::{TIMED_OUT, run_bounded, run_bounded_until, run_bounded_with_stdin};
+pub use bounded::{NOT_STARTED, TIMED_OUT, run_bounded, run_bounded_until, run_bounded_with_stdin};
 
 pub mod set_value;
 pub use set_value::{read_back_confirms, typed_clear_landed, typed_text_landed};


### PR DESCRIPTION
`dump_until_ready` checked its deadline only between attempts, while one attempt is three adb calls each carrying its own budget — `shell rm -f` at 10s, `uiautomator dump` at 20s, `shell cat` at 20s. An attempt could run 50s against a 30s loop, and the overrun landed on `glass_wait_for_element`, which re-snapshots per tick inside a budget of its own.

`glass_core::run_bounded_until` takes the deadline of the larger call a step serves and gives the step whichever bound is nearer; a step with nothing left is not started and says `NOT_STARTED` rather than `TIMED_OUT`, so `with_adb_hint` no longer offers `adb kill-server` for a call adb never received. `Adb::run_streams_until` threads that deadline down, and the three steps of one dump now share `AdbOp::Dump`'s budget — which is what that budget already described.

The loop's promise is now its retry budget plus one attempt: the wait between attempts is clamped to what is left of the budget, so a retry cannot start past it. `dump_once` no longer substitutes the dump's stderr for a read that ran out of the attempt's time — that substitution is retryable, and would have the loop retrying a device that had answered.

Verified on Linux: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --locked` (1817 tests), plus `--target x86_64-pc-windows-gnu --all-targets` and `--target x86_64-apple-darwin --lib` clippy.

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)