### PR TITLE
fix(a11y-android): answer for the app that was asked about

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,7 +201,8 @@ internal refactors, CI, or test-only changes.
   — the ids address whatever app the tree described, and hold as long as that app stays
   foreground. A reconnect that cannot confirm the same foreground held refuses the action rather
   than replaying it: a read of the wrong app costs a turn, a write cannot be taken back. Requires
-  the updated companion; an older one is unaffected and reports nothing.
+  the updated companion; an older one reports no subject, and a reconnect can no longer re-send a
+  click or `set_value` against it — it fails closed instead.
 - An Android accessibility read can no longer answer with a tree captured before the interaction it
   was asked about. Every read wrote to one file on the device, and a read that ends at its deadline
   ends the local `adb` client only — the `uiautomator dump` it started keeps running on the device

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,17 @@ internal refactors, CI, or test-only changes.
   Android paths have no such live check.
 
 ### Fixed
+- An Android accessibility snapshot taken through the optional on-device companion now says when
+  it describes a different app than the one asked about. The companion answered with whatever
+  window was in front — a system dialog, a permission prompt — and reported it as the requested
+  app's tree, so an element selected from it addressed the wrong app. The tree still comes back,
+  since that dialog is usually what needs reading, but it now states which app its ids address. A
+  native click or `set_value` through the companion is refused once the foreground app has changed
+  since the tree it acts against was served, not once it differs from the app that was asked about
+  — the ids address whatever app the tree described, and hold as long as that app stays
+  foreground. A reconnect that cannot confirm the same foreground held refuses the action rather
+  than replaying it: a read of the wrong app costs a turn, a write cannot be taken back. Requires
+  the updated companion; an older one is unaffected and reports nothing.
 - An Android accessibility read can no longer answer with a tree captured before the interaction it
   was asked about. Every read wrote to one file on the device, and a read that ends at its deadline
   ends the local `adb` client only — the `uiautomator dump` it started keeps running on the device

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,8 +201,8 @@ internal refactors, CI, or test-only changes.
   — the ids address whatever app the tree described, and hold as long as that app stays
   foreground. A reconnect that cannot confirm the same foreground held refuses the action rather
   than replaying it: a read of the wrong app costs a turn, a write cannot be taken back. Requires
-  the updated companion; an older one reports no subject, and a reconnect can no longer re-send a
-  click or `set_value` against it — it fails closed instead.
+  the updated companion; an older one says nothing about which app it answered for, and a
+  reconnect can no longer re-send a click or `set_value` against it — it fails closed instead.
 - An Android accessibility read can no longer answer with a tree captured before the interaction it
   was asked about. Every read wrote to one file on the device, and a read that ends at its deadline
   ends the local `adb` client only — the `uiautomator dump` it started keeps running on the device

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -272,19 +272,17 @@ impl ServiceClient {
     }
 }
 
-/// Re-serve `tree` for `pkg` on a freshly reconnected connection, and confirm the reply names
-/// `pkg` before letting the pending request that triggered the reconnect follow it. `pkg` must
-/// be the app the *served* tree actually described (its `AxTree::subject`'s `actual`, when set)
-/// — the one whose refs the pending request addresses — not the one originally asked about; a
-/// permission dialog's tree answers for the dialog, not the app behind it. Silently re-arming
-/// with whatever is foreground *now* would make the packages match by construction and
-/// authorise the pending request against a window its ref never came from — so a mismatch, or a
-/// reply that names nothing, must return without letting that request go out.
+/// Re-serve `tree` for `pkg` on a freshly reconnected connection, and confirm the reply still
+/// names `pkg` before letting the pending request that triggered the reconnect follow it.
 ///
-/// Returns a plain [`GlassError`], never a [`CallFailure`]: whether the tree call itself failed,
-/// or it answered but named the wrong package (or none), says nothing about whether the
-/// *pending* request was delivered — only the caller's own `f` gets to say that (see
-/// [`ServiceClient::call_with`]).
+/// `pkg` must be the app the *served* tree actually described (`AxTree::subject`'s `actual`,
+/// when set) — the one whose refs the pending request addresses — not the one originally asked
+/// about: a permission dialog's tree answers for the dialog, not the app behind it. Re-arming
+/// against whatever is foreground *now* would match by construction and authorise the pending
+/// request against a window its ref never came from.
+///
+/// Returns a plain [`GlassError`], never a [`CallFailure`] — only the caller's own `f` (see
+/// [`ServiceClient::call_with`]) classifies whether the *pending* request was delivered.
 fn rearm_tree(conn: &mut Conn, pkg: &str) -> Result<()> {
     let reply = conn
         .call(json!({"op": "tree", "package": pkg}))
@@ -356,10 +354,8 @@ impl ServiceA11y {
     /// step and this one — a window `invoke`'s own straight-line execution never otherwise
     /// exposes to a caller.
     ///
-    /// `subject` is the plan's tree's own (from `AxTree::subject`), passed separately rather than
-    /// folded into `InvokePlan` since it re-arms a reconnect and says nothing about the click
-    /// itself. It borrows the tree, not `self`, so the caller can still hand it to this
-    /// `&mut self` method.
+    /// `subject` (the plan's tree's own `AxTree::subject`) is passed separately from `plan`: it
+    /// borrows the tree, not `self`, so the caller can still hand it to this `&mut self` method.
     fn dispatch_click(
         &mut self,
         ctx: &AxContext,
@@ -1799,11 +1795,9 @@ mod tests {
         DropWithoutAnswering,
     }
 
-    /// What a fake `tree` reply's `package` field says, relative to what was asked — added for
-    /// glass#286's B2b, whose re-arm tests need a later connection's reply to disagree with an
-    /// earlier one, which a bare echo cannot express.
+    /// What a fake `tree` reply's `package` field says, relative to what was asked.
     enum TreePackage {
-        /// Whatever the request asked for — `fake_service`'s only behavior before this enum.
+        /// Whatever the request asked for.
         Echo,
         /// A different package than asked — the foreground changed since the last `tree`.
         Other(String),
@@ -1813,9 +1807,8 @@ mod tests {
     }
 
     /// Whether a fake `tree` request is served normally (per `packages`) or refused outright —
-    /// the `tree`-request analogue of `OnAction::DropWithoutAnswering`, needed to test a re-arm
-    /// the companion refuses (mirrors the shipped companion's `Server.kt`, which answers
-    /// `Response.error(id, "no active window")` when nothing is in the foreground).
+    /// mirrors the shipped companion's `Server.kt`, which answers `Response.error(id, "no
+    /// active window")` when nothing is in the foreground.
     #[derive(Clone, Copy)]
     enum OnTree {
         Serve,
@@ -2099,11 +2092,9 @@ mod tests {
     #[test]
     fn set_values_call_site_sends_its_own_configured_package_to_the_rearm() {
         // Pins `set_value`'s fallback to `self.package` when the served tree carries no subject
-        // (`TreePackage::Echo`, so asked == actual): the re-arm reply's package is fixed to
-        // "com.example.app" regardless of what was asked, so this only passes if `ServiceA11y`
-        // actually falls back to its OWN configured package — a swapped argument or a literal ""
-        // would ask for something else and be refused as a mismatch, which `reader()` (built
-        // with `String::new()`) could never catch.
+        // (`TreePackage::Echo`, so asked == actual): the re-arm reply's package is fixed
+        // regardless of what was asked, so this only passes if the fallback is `ServiceA11y`'s
+        // own configured package.
         let field = |value: &str| {
             json!({
                 "class": "android.widget.FrameLayout",
@@ -2134,14 +2125,12 @@ mod tests {
     #[test]
     fn invokes_call_site_sends_its_own_configured_package_to_the_rearm() {
         // Mirrors the `set_value` test above, for `invoke`'s fallback to `self.package` when the
-        // plan's tree carries no subject. `click`'s resend fires only on
-        // `CallFailure::NotSent` — a real write failure, never `AnswerLost` — which only arises
-        // strictly BETWEEN `invoke`'s snapshot/plan step and its click, a window `invoke`'s own
-        // single call never exposes to a caller (`OnAction::DropWithoutAnswering` gives
-        // `AnswerLost`, which a click never resends on). So this drives `invoke`'s own two
-        // halves directly — its own snapshot/plan step, then `dispatch_click` (split out for
-        // exactly this seam) — with a real `shutdown(Write)` sequenced between them: not a race,
-        // since nothing else runs until the test's own next line calls `dispatch_click`.
+        // plan's tree carries no subject. `click`'s resend fires only on a real
+        // `CallFailure::NotSent`, never `AnswerLost`, and that failure only arises strictly
+        // BETWEEN `invoke`'s snapshot/plan step and its click — a window `invoke`'s own single
+        // call never exposes to a caller. So this drives `invoke`'s own two halves directly —
+        // snapshot/plan, then `dispatch_click` (split out for exactly this seam) — with a real
+        // `shutdown(Write)` between them.
         let clickable = json!({
             "class": "android.widget.FrameLayout",
             "bounds": {"x": 0, "y": 0, "w": 1080, "h": 2400},
@@ -2185,9 +2174,8 @@ mod tests {
 
     #[test]
     fn dispatch_clicks_rearm_asks_about_the_acting_app_not_the_asked_about_one() {
-        // Sibling of the test above, on the same `shutdown(Write)` seam (a click's resend needs
-        // a real `NotSent`, never the `AnswerLost` `DropWithoutAnswering` gives), but with a
-        // subject: the served tree answered for `com.other.app`, not the configured
+        // Sibling of the test above, on the same `shutdown(Write)` seam, but with a subject:
+        // the served tree answered for `com.other.app`, not the configured
         // `com.example.app` — `target`'s ref is numbered from THAT tree. The rearm's reply names
         // the ASKED app instead. Comparing against the asked app (the bug) would match by
         // construction and replay the click against whatever unrelated node ref 1 resolves to in

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -8,7 +8,7 @@ use serde_json::{Value, json};
 
 use glass_core::accessibility::{
     Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree,
-    TruncationLimit, WalkBudget, WalkLimits,
+    Subject, TruncationLimit, WalkBudget, WalkLimits,
 };
 use glass_core::platform::WindowGeometry;
 use glass_core::{GlassError, Result};
@@ -157,6 +157,14 @@ pub(crate) fn tree_from_json(
     Ok(tree)
 }
 
+/// A `tree` reply: the tree, and the window it came from when the companion names one.
+struct TreeReply {
+    tree: Value,
+    /// The package the companion actually answered about, when it names one. `None` on an
+    /// older companion that predates this field — absent, not a mismatch.
+    package: Option<String>,
+}
+
 /// Line-JSON client to the on-device a11y service (mirrors `AgentClient`).
 pub struct ServiceClient {
     conn: Mutex<Conn>,
@@ -205,13 +213,18 @@ impl ServiceClient {
         self.call_with(req, CallFailure::nothing_sent)
     }
 
-    fn tree(&self, package: &str) -> Result<Value> {
+    fn tree(&self, package: &str) -> Result<TreeReply> {
         let r = self
             .call(json!({"op": "tree", "package": package}))
             .map_err(CallFailure::into_error)?;
-        r.get("tree")
+        let tree = r
+            .get("tree")
             .cloned()
-            .ok_or_else(|| GlassError::AccessibilityUnavailable("no tree in response".into()))
+            .ok_or_else(|| GlassError::AccessibilityUnavailable("no tree in response".into()))?;
+        Ok(TreeReply {
+            tree,
+            package: r.get("package").and_then(Value::as_str).map(str::to_owned),
+        })
     }
 
     /// Fire `ACTION_CLICK` on device node `ref_id`. Never re-sent once delivered; the failure
@@ -277,10 +290,22 @@ impl ServiceA11y {
     }
 }
 
+/// What the tree describes, when the companion named a window and it is not the one asked about.
+/// A companion that names none makes no claim — absent is not a mismatch.
+fn subject_of(asked: &str, actual: Option<&str>) -> Option<Subject> {
+    let actual = actual?;
+    (actual != asked).then(|| Subject {
+        asked: asked.to_owned(),
+        actual: actual.to_owned(),
+    })
+}
+
 impl Accessibility for ServiceA11y {
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
-        let tree = self.client.tree(&self.package)?;
-        tree_from_json(&tree, &ctx.window, ctx.limits)
+        let reply = self.client.tree(&self.package)?;
+        let mut tree = tree_from_json(&reply.tree, &ctx.window, ctx.limits)?;
+        tree.subject = subject_of(&self.package, reply.package.as_deref());
+        Ok(tree)
     }
 
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
@@ -923,6 +948,32 @@ mod tests {
             tree.truncated.map(|t| t.limit),
             Some(TruncationLimit::Nodes)
         );
+    }
+
+    #[test]
+    fn a_reply_naming_another_app_discloses_it() {
+        let subject = subject_of(
+            "com.example.app",
+            Some("com.google.android.permissioncontroller"),
+        );
+        assert_eq!(
+            subject,
+            Some(Subject {
+                asked: "com.example.app".into(),
+                actual: "com.google.android.permissioncontroller".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn a_reply_naming_the_app_asked_for_discloses_nothing() {
+        assert_eq!(subject_of("com.example.app", Some("com.example.app")), None);
+    }
+
+    #[test]
+    fn an_older_companion_that_names_no_window_makes_no_claim() {
+        // The key is absent, not null: nothing is known, which is not the same as a mismatch.
+        assert_eq!(subject_of("com.example.app", None), None);
     }
 
     #[test]
@@ -1681,6 +1732,10 @@ mod tests {
                 {
                     break;
                 }
+                // The real companion refuses `action` until a `tree` naming a matching package
+                // has been served on this SAME connection — a fresh one starts unconfirmed. This
+                // fake echoes the asked package back as served, so it matches by construction.
+                let mut tree_confirmed = false;
                 loop {
                     let mut line = String::new();
                     if !matches!(r.read_line(&mut line), Ok(n) if n > 0) {
@@ -1693,7 +1748,15 @@ mod tests {
                             log.lock().unwrap().push(format!("conn{conn}:tree"));
                             let t = trees[served.min(trees.len() - 1)].clone();
                             served += 1;
-                            json!({"id": id, "ok": true, "tree": t})
+                            tree_confirmed = true;
+                            json!({"id": id, "ok": true, "tree": t, "package": req["package"]})
+                        }
+                        "action" if !tree_confirmed => {
+                            log.lock()
+                                .unwrap()
+                                .push(format!("conn{conn}:action-refused-no-tree"));
+                            json!({"id": id, "ok": false,
+                                   "error": "no tree has been served on this connection"})
                         }
                         "action" => {
                             log.lock().unwrap().push(format!(
@@ -1739,6 +1802,58 @@ mod tests {
 
     fn ops_of(ops: &Arc<Mutex<Vec<String>>>) -> Vec<String> {
         ops.lock().unwrap().clone()
+    }
+
+    #[test]
+    fn an_action_before_any_tree_on_this_connection_is_refused() {
+        // A fresh connection — including one opened by a client reconnect — has served no
+        // tree yet, so an action on it must be refused rather than answered `ok:true`.
+        let (port, ops) = fake_service(vec![compose_like()], OnAction::Ok);
+        let client = ServiceClient::connect(port).expect("connect to the fake service");
+        let e = client
+            .click(1)
+            .expect_err("no tree has been served on this connection yet");
+        assert!(matches!(e, CallFailure::Refused(_)), "{}", e.into_error());
+        assert_eq!(
+            ops_of(&ops),
+            vec!["conn1:action-refused-no-tree".to_string()]
+        );
+    }
+
+    #[test]
+    fn snapshot_discloses_a_reply_naming_a_different_app() {
+        // Exercises `ServiceA11y::snapshot`'s wiring end-to-end (asked vs. the reply's
+        // `package`), not just the pure `subject_of` comparison tested above in isolation.
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        std::thread::spawn(move || {
+            let (sock, _) = listener.accept().expect("accept");
+            let mut w = sock.try_clone().expect("clone");
+            let mut r = std::io::BufReader::new(sock);
+            writeln!(w, r#"{{"hello":{{"proto":1}}}}"#)
+                .and_then(|()| w.flush())
+                .expect("hello");
+            let mut line = String::new();
+            r.read_line(&mut line).expect("read request");
+            let req: Value = serde_json::from_str(&line).expect("request is json");
+            let reply = json!({
+                "id": req["id"], "ok": true, "tree": compose_like(),
+                "package": "com.google.android.permissioncontroller"
+            });
+            writeln!(w, "{reply}")
+                .and_then(|()| w.flush())
+                .expect("write reply");
+        });
+        let client = ServiceClient::connect(port).expect("connect");
+        let mut a = ServiceA11y::new(client, "com.example.app".to_string());
+        let tree = a.snapshot(&ctx()).expect("snapshot");
+        assert_eq!(
+            tree.subject,
+            Some(Subject {
+                asked: "com.example.app".into(),
+                actual: "com.google.android.permissioncontroller".into(),
+            })
+        );
     }
 
     #[test]

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -273,10 +273,13 @@ impl ServiceClient {
 }
 
 /// Re-serve `tree` for `pkg` on a freshly reconnected connection, and confirm the reply names
-/// `pkg` before letting the pending request that triggered the reconnect follow it. Silently
-/// re-arming with whatever is foreground *now* would make the packages match by construction
-/// and authorise the pending request against a window its ref never came from — so a mismatch,
-/// or a reply that names nothing, must return without letting that request go out.
+/// `pkg` before letting the pending request that triggered the reconnect follow it. `pkg` must
+/// be the app the *served* tree actually described (its `AxTree::subject`'s `actual`, when set)
+/// — the one whose refs the pending request addresses — not the one originally asked about; a
+/// permission dialog's tree answers for the dialog, not the app behind it. Silently re-arming
+/// with whatever is foreground *now* would make the packages match by construction and
+/// authorise the pending request against a window its ref never came from — so a mismatch, or a
+/// reply that names nothing, must return without letting that request go out.
 ///
 /// Returns a plain [`GlassError`], never a [`CallFailure`]: whether the tree call itself failed,
 /// or it answered but named the wrong package (or none), says nothing about whether the
@@ -352,14 +355,21 @@ impl ServiceA11y {
     /// Split out of `invoke` so a test can force a reconnect strictly between the snapshot/plan
     /// step and this one — a window `invoke`'s own straight-line execution never otherwise
     /// exposes to a caller.
+    ///
+    /// `subject` is the plan's tree's own (from `AxTree::subject`), passed separately rather than
+    /// folded into `InvokePlan` since it re-arms a reconnect and says nothing about the click
+    /// itself. It borrows the tree, not `self`, so the caller can still hand it to this
+    /// `&mut self` method.
     fn dispatch_click(
         &mut self,
         ctx: &AxContext,
         target: &AxTarget,
         plan: &InvokePlan,
+        subject: Option<&Subject>,
     ) -> Result<Option<AxNodeId>> {
+        let acting_on = subject.map_or(self.package.as_str(), |s| s.actual.as_str());
         self.client
-            .click(plan.actuated.id.0, &self.package)
+            .click(plan.actuated.id.0, acting_on)
             .map_err(|f| action_error(target.id.0, f))?;
         if let Some(want) = plan.want_checked {
             self.wait_for_check(ctx, plan, want)?;
@@ -395,7 +405,13 @@ impl Accessibility for ServiceA11y {
             t
         };
         crate::a11y::editable_target(&tree, target)?;
-        self.client.set_text(target.id.0, text, &self.package)?;
+        // Re-arm against the app the served tree actually described, not the one asked about —
+        // that's the app `target`'s ref came from (see `rearm_tree`).
+        let acting_on = tree
+            .subject
+            .as_ref()
+            .map_or(self.package.as_str(), |s| s.actual.as_str());
+        self.client.set_text(target.id.0, text, acting_on)?;
         // Verify the value actually took. ACTION_SET_TEXT returns success but silently no-ops when
         // *replacing* existing text in a Compose field, so a bare Ok could lie (glass forbids silent
         // fallbacks). The set is async (Compose recompose → a11y update), so poll briefly for the
@@ -442,7 +458,7 @@ impl Accessibility for ServiceA11y {
             t
         };
         let plan = invoke_plan(&tree, target)?;
-        self.dispatch_click(ctx, target, &plan)
+        self.dispatch_click(ctx, target, &plan, tree.subject.as_ref())
     }
 }
 
@@ -2082,11 +2098,12 @@ mod tests {
 
     #[test]
     fn set_values_call_site_sends_its_own_configured_package_to_the_rearm() {
-        // Pins `set_value`'s `self.client.set_text(target.id.0, text, &self.package)`: the
-        // re-arm reply's package is fixed to "com.example.app" regardless of what was asked, so
-        // this only passes if `ServiceA11y` actually threads its OWN configured package through
-        // — a swapped argument or a literal "" would ask for something else and be refused as a
-        // mismatch, which `reader()` (built with `String::new()`) could never catch.
+        // Pins `set_value`'s fallback to `self.package` when the served tree carries no subject
+        // (`TreePackage::Echo`, so asked == actual): the re-arm reply's package is fixed to
+        // "com.example.app" regardless of what was asked, so this only passes if `ServiceA11y`
+        // actually falls back to its OWN configured package — a swapped argument or a literal ""
+        // would ask for something else and be refused as a mismatch, which `reader()` (built
+        // with `String::new()`) could never catch.
         let field = |value: &str| {
             json!({
                 "class": "android.widget.FrameLayout",
@@ -2116,8 +2133,8 @@ mod tests {
 
     #[test]
     fn invokes_call_site_sends_its_own_configured_package_to_the_rearm() {
-        // Mirrors the `set_value` test above, for `invoke`'s
-        // `self.client.click(plan.actuated.id.0, &self.package)`. `click`'s resend fires only on
+        // Mirrors the `set_value` test above, for `invoke`'s fallback to `self.package` when the
+        // plan's tree carries no subject. `click`'s resend fires only on
         // `CallFailure::NotSent` — a real write failure, never `AnswerLost` — which only arises
         // strictly BETWEEN `invoke`'s snapshot/plan step and its click, a window `invoke`'s own
         // single call never exposes to a caller (`OnAction::DropWithoutAnswering` gives
@@ -2162,8 +2179,109 @@ mod tests {
             .shutdown(std::net::Shutdown::Write)
             .expect("shutdown");
 
-        a.dispatch_click(&ctx(), &target, &plan)
+        a.dispatch_click(&ctx(), &target, &plan, tree.subject.as_ref())
             .expect("the caller's own configured package must match the rearm's fixed reply");
+    }
+
+    /// A field whose editable EditText reports `value`, wrapped exactly like the fixture used by
+    /// [`set_values_call_site_sends_its_own_configured_package_to_the_rearm`].
+    fn editable_field(value: &str) -> Value {
+        json!({
+            "class": "android.widget.FrameLayout",
+            "bounds": {"x": 0, "y": 0, "w": 1080, "h": 2400},
+            "children": [
+                {"class": "android.widget.EditText", "text": value, "desc": "Email",
+                 "bounds": {"x": 0, "y": 100, "w": 600, "h": 120},
+                 "editable": true, "clickable": true, "enabled": true}
+            ]
+        })
+    }
+
+    #[test]
+    fn a_rearm_matching_the_asked_about_app_does_not_authorise_a_stale_acting_apps_ref() {
+        // The served tree answered for `com.other.app` (a dialog), not the configured
+        // `com.example.app` — `target`'s ref is numbered from the DIALOG's nodes. `set_text` is
+        // dropped in flight; while reconnecting the dialog dismisses and `com.example.app` (the
+        // asked-about app) comes forward, so the rearm's reply names it. Comparing against the
+        // ASKED app (the bug) would match by construction here and replay the write against
+        // whatever unrelated node ref 1 resolves to in the real app — it must instead compare
+        // against the ACTING app (`com.other.app`), see the reply naming something else, and
+        // refuse.
+        let (port, ops) = fake_service_ex(
+            vec![
+                editable_field("old"),
+                editable_field("old"),
+                editable_field("new"),
+            ],
+            vec![OnAction::DropWithoutAnswering, OnAction::Ok],
+            vec![
+                TreePackage::Other("com.other.app".into()),
+                TreePackage::Other("com.example.app".into()),
+            ],
+        );
+        let client = ServiceClient::connect(port).expect("connect to the fake service");
+        let mut a = ServiceA11y::new(client, "com.example.app".to_string());
+        let t = built(&editable_field("old"));
+        let target = target_for(&t, AxNodeId(1));
+
+        // `OnAction::Ok` is wired for conn2 so a wrongly-authorised resend would go on to
+        // SUCCEED — the false success this pins, not just a differently-worded refusal.
+        let e = a
+            .set_value(&ctx(), &target, "new")
+            .expect_err("the rearm names the asked-about app, not the dialog the ref came from");
+        let msg = e.to_string();
+        assert!(msg.contains("com.other.app"), "{msg}");
+        assert!(msg.contains("com.example.app"), "{msg}");
+        assert!(msg.contains("moved"), "{msg}");
+        assert_eq!(
+            ops_of(&ops),
+            vec![
+                "conn1:tree".to_string(),
+                "conn1:set_text ref=1".to_string(),
+                "conn2:tree".to_string(),
+            ],
+            "no set_text on conn2 — comparing against the acting app must stop the resend"
+        );
+    }
+
+    #[test]
+    fn a_rearm_matching_the_acting_app_resends_even_though_it_differs_from_the_asked_about_app() {
+        // Mirrors the test above with the dialog still foreground at the rearm: the reply again
+        // names `com.other.app`, the same app the served tree described, so this is safe to
+        // resend even though it still differs from the configured `com.example.app`. Comparing
+        // against the asked app (the bug) would see that mismatch and spuriously refuse a resend
+        // that was actually safe.
+        let (port, ops) = fake_service_ex(
+            vec![
+                editable_field("old"),
+                editable_field("old"),
+                editable_field("new"),
+            ],
+            vec![OnAction::DropWithoutAnswering, OnAction::Ok],
+            vec![
+                TreePackage::Other("com.other.app".into()),
+                TreePackage::Other("com.other.app".into()),
+            ],
+        );
+        let client = ServiceClient::connect(port).expect("connect to the fake service");
+        let mut a = ServiceA11y::new(client, "com.example.app".to_string());
+        let t = built(&editable_field("old"));
+        let target = target_for(&t, AxNodeId(1));
+
+        a.set_value(&ctx(), &target, "new")
+            .expect("the acting app did not change, so the resend must go through");
+        assert_eq!(
+            ops_of(&ops),
+            vec![
+                "conn1:tree".to_string(),
+                "conn1:set_text ref=1".to_string(),
+                "conn2:tree".to_string(),
+                "conn2:set_text ref=1".to_string(),
+                "conn2:tree".to_string(),
+            ],
+            "conn2:set_text (the resend) must follow conn2:tree (the rearm); the last conn2:tree \
+             is set_value's own post-write verification read"
+        );
     }
 
     #[test]

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -160,8 +160,9 @@ pub(crate) fn tree_from_json(
 /// A `tree` reply: the tree, and the window it came from when the companion names one.
 struct TreeReply {
     tree: Value,
-    /// The package the companion actually answered about, when it names one. `None` on an
-    /// older companion that predates this field — absent, not a mismatch.
+    /// The package the companion actually answered about, when it names one. `None` either
+    /// on an older companion that predates this field, or on a current one that cannot name
+    /// the active window on this platform/state — either way, absent is not a mismatch.
     package: Option<String>,
 }
 
@@ -1732,9 +1733,14 @@ mod tests {
                 {
                     break;
                 }
-                // The real companion refuses `action` until a `tree` naming a matching package
-                // has been served on this SAME connection — a fresh one starts unconfirmed. This
-                // fake echoes the asked package back as served, so it matches by construction.
+                // The real companion re-checks its last-served package against the active
+                // window at the moment of each `action`, refusing if the window changed since;
+                // this fake models only the coarser gate glass#286 needed (some prior `tree`,
+                // ever, on this connection) via a one-way flip that never re-closes. It also
+                // cannot produce a `tree` reply with `package` absent (it always echoes
+                // `req["package"]` back) or express that an unnamed-package `tree` must not
+                // satisfy the gate (the real companion's `served == null` refuses) — both are
+                // covered instead by the pure `subject_of` tests above, not through this socket.
                 let mut tree_confirmed = false;
                 loop {
                     let mut line = String::new();

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -242,9 +242,9 @@ impl ServiceClient {
         })
     }
 
-    /// Fire `ACTION_CLICK` on device node `ref_id` in `package`. Never re-sent once delivered;
-    /// the failure keeps its delivery classification. `package` re-arms a reconnected
-    /// connection — see [`Self::call_with`].
+    /// Fire `ACTION_CLICK` on device node `ref_id`. Never re-sent once delivered; the failure
+    /// keeps its delivery classification. `package` never reaches the wire here — it only
+    /// re-arms a reconnected connection's `tree` call — see [`Self::call_with`].
     fn click(&self, ref_id: u32, package: &str) -> std::result::Result<(), CallFailure> {
         self.call_once_sent(
             json!({"op": "action", "ref": ref_id, "action": "click"}),
@@ -253,9 +253,9 @@ impl ServiceClient {
         .map(|_| ())
     }
 
-    /// Fire `ACTION_SET_TEXT` on device node `ref_id` in `package`. Idempotent, so this takes
-    /// the reconnecting path; `package` re-arms a reconnected connection — see
-    /// [`Self::call_with`].
+    /// Fire `ACTION_SET_TEXT` on device node `ref_id`. Idempotent, so this takes the
+    /// reconnecting path. `package` never reaches the wire here — it only re-arms a
+    /// reconnected connection's `tree` call — see [`Self::call_with`].
     fn set_text(&self, ref_id: u32, text: &str, package: &str) -> Result<()> {
         self.call(
             json!({"op": "action", "ref": ref_id, "action": "set_text", "text": text}),
@@ -2181,6 +2181,64 @@ mod tests {
 
         a.dispatch_click(&ctx(), &target, &plan, tree.subject.as_ref())
             .expect("the caller's own configured package must match the rearm's fixed reply");
+    }
+
+    #[test]
+    fn dispatch_clicks_rearm_asks_about_the_acting_app_not_the_asked_about_one() {
+        // Sibling of the test above, on the same `shutdown(Write)` seam (a click's resend needs
+        // a real `NotSent`, never the `AnswerLost` `DropWithoutAnswering` gives), but with a
+        // subject: the served tree answered for `com.other.app`, not the configured
+        // `com.example.app` — `target`'s ref is numbered from THAT tree. The rearm's reply names
+        // the ASKED app instead. Comparing against the asked app (the bug) would match by
+        // construction and replay the click against whatever unrelated node ref 1 resolves to in
+        // the real app; comparing against the acting app (`com.other.app`) sees the mismatch and
+        // refuses.
+        let clickable = json!({
+            "class": "android.widget.FrameLayout",
+            "bounds": {"x": 0, "y": 0, "w": 1080, "h": 2400},
+            "children": [
+                {"class": "android.widget.Button", "desc": "Save",
+                 "bounds": {"x": 0, "y": 100, "w": 200, "h": 100},
+                 "clickable": true, "enabled": true}
+            ]
+        });
+        let (port, ops) = fake_service_ex(
+            vec![clickable.clone()],
+            vec![OnAction::Ok],
+            vec![
+                TreePackage::Other("com.other.app".into()),
+                TreePackage::Other("com.example.app".into()),
+            ],
+        );
+        let client = ServiceClient::connect(port).expect("connect to the fake service");
+        let mut a = ServiceA11y::new(client, "com.example.app".to_string());
+        let t = built(&clickable);
+        let target = target_for(&t, AxNodeId(1));
+
+        let mut tree = a.snapshot(&ctx()).expect("snapshot");
+        tree.assign_ids();
+        let plan = invoke_plan(&tree, &target).expect("plan resolves");
+
+        a.client
+            .conn
+            .lock()
+            .expect("lock")
+            .writer
+            .shutdown(std::net::Shutdown::Write)
+            .expect("shutdown");
+
+        let e = a
+            .dispatch_click(&ctx(), &target, &plan, tree.subject.as_ref())
+            .expect_err("the rearm names the asked-about app, not the app the ref came from");
+        let msg = e.to_string();
+        assert!(msg.contains("com.other.app"), "{msg}");
+        assert!(msg.contains("com.example.app"), "{msg}");
+        assert!(msg.contains("moved"), "{msg}");
+        assert_eq!(
+            ops_of(&ops),
+            vec!["conn1:tree".to_string(), "conn2:tree".to_string()],
+            "no click on conn2 — comparing against the acting app must stop the resend"
+        );
     }
 
     /// A field whose editable EditText reports `value`, wrapped exactly like the fixture used by

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -347,6 +347,25 @@ impl ServiceA11y {
             std::thread::sleep(CHECK_POLL);
         }
     }
+
+    /// Fire the click for an already-resolved `plan`, then confirm any expected state change.
+    /// Split out of `invoke` so a test can force a reconnect strictly between the snapshot/plan
+    /// step and this one — a window `invoke`'s own straight-line execution never otherwise
+    /// exposes to a caller.
+    fn dispatch_click(
+        &mut self,
+        ctx: &AxContext,
+        target: &AxTarget,
+        plan: &InvokePlan,
+    ) -> Result<Option<AxNodeId>> {
+        self.client
+            .click(plan.actuated.id.0, &self.package)
+            .map_err(|f| action_error(target.id.0, f))?;
+        if let Some(want) = plan.want_checked {
+            self.wait_for_check(ctx, plan, want)?;
+        }
+        Ok(plan.substituted())
+    }
 }
 
 /// What the tree describes, when the companion named a window and it is not the one asked about.
@@ -423,13 +442,7 @@ impl Accessibility for ServiceA11y {
             t
         };
         let plan = invoke_plan(&tree, target)?;
-        self.client
-            .click(plan.actuated.id.0, &self.package)
-            .map_err(|f| action_error(target.id.0, f))?;
-        if let Some(want) = plan.want_checked {
-            self.wait_for_check(ctx, &plan, want)?;
-        }
-        Ok(plan.substituted())
+        self.dispatch_click(ctx, target, &plan)
     }
 }
 
@@ -2098,6 +2111,58 @@ mod tests {
         let t = built(&field("old"));
         let target = target_for(&t, AxNodeId(1));
         a.set_value(&ctx(), &target, "new")
+            .expect("the caller's own configured package must match the rearm's fixed reply");
+    }
+
+    #[test]
+    fn invokes_call_site_sends_its_own_configured_package_to_the_rearm() {
+        // Mirrors the `set_value` test above, for `invoke`'s
+        // `self.client.click(plan.actuated.id.0, &self.package)`. `click`'s resend fires only on
+        // `CallFailure::NotSent` — a real write failure, never `AnswerLost` — which only arises
+        // strictly BETWEEN `invoke`'s snapshot/plan step and its click, a window `invoke`'s own
+        // single call never exposes to a caller (`OnAction::DropWithoutAnswering` gives
+        // `AnswerLost`, which a click never resends on). So this drives `invoke`'s own two
+        // halves directly — its own snapshot/plan step, then `dispatch_click` (split out for
+        // exactly this seam) — with a real `shutdown(Write)` sequenced between them: not a race,
+        // since nothing else runs until the test's own next line calls `dispatch_click`.
+        let clickable = json!({
+            "class": "android.widget.FrameLayout",
+            "bounds": {"x": 0, "y": 0, "w": 1080, "h": 2400},
+            "children": [
+                {"class": "android.widget.Button", "desc": "Save",
+                 "bounds": {"x": 0, "y": 100, "w": 200, "h": 100},
+                 "clickable": true, "enabled": true}
+            ]
+        });
+        let (port, _ops) = fake_service_ex(
+            vec![clickable.clone()],
+            vec![OnAction::Ok],
+            vec![
+                TreePackage::Echo,
+                TreePackage::Other("com.example.app".into()),
+            ],
+        );
+        let client = ServiceClient::connect(port).expect("connect to the fake service");
+        let mut a = ServiceA11y::new(client, "com.example.app".to_string());
+        let t = built(&clickable);
+        let target = target_for(&t, AxNodeId(1));
+
+        // `invoke`'s own first half, called directly: snapshot + resolve the plan.
+        let mut tree = a.snapshot(&ctx()).expect("snapshot");
+        tree.assign_ids();
+        let plan = invoke_plan(&tree, &target).expect("plan resolves");
+
+        // Break the connection's write half — deterministic, not raced: this line has already
+        // returned before `dispatch_click` is called below.
+        a.client
+            .conn
+            .lock()
+            .expect("lock")
+            .writer
+            .shutdown(std::net::Shutdown::Write)
+            .expect("shutdown");
+
+        a.dispatch_click(&ctx(), &target, &plan)
             .expect("the caller's own configured package must match the rearm's fixed reply");
     }
 

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -203,7 +203,9 @@ impl ServiceClient {
                 // The service's accept loop accepts a fresh connection after a drop.
                 *conn = Conn::open(self.port).map_err(|e| f.with_error(e))?;
                 if let Some(pkg) = rearm {
-                    rearm_tree(&mut conn, pkg)?;
+                    // `f`'s classification, not the re-arm's own: recovering from `f` says no
+                    // more about whether `req` was delivered, whichever step trips.
+                    rearm_tree(&mut conn, pkg).map_err(|e| f.with_error(e))?;
                 }
                 conn.call(req)
             }
@@ -276,35 +278,33 @@ impl ServiceClient {
 /// and authorise the pending request against a window its ref never came from — so a mismatch,
 /// or a reply that names nothing, must return without letting that request go out.
 ///
-/// The re-arm's own failure is kept distinct from the pending request's: its message says the
-/// reconnect could not re-arm, never that the request itself was refused.
-fn rearm_tree(conn: &mut Conn, pkg: &str) -> std::result::Result<(), CallFailure> {
+/// Returns a plain [`GlassError`], never a [`CallFailure`]: whether the tree call itself failed,
+/// or it answered but named the wrong package (or none), says nothing about whether the
+/// *pending* request was delivered — only the caller's own `f` gets to say that (see
+/// [`ServiceClient::call_with`]).
+fn rearm_tree(conn: &mut Conn, pkg: &str) -> Result<()> {
     let reply = conn
         .call(json!({"op": "tree", "package": pkg}))
         .map_err(|f| {
-            let detail = match &f {
-                CallFailure::NotSent(e) | CallFailure::AnswerLost(e) | CallFailure::Refused(e) => {
-                    e.to_string()
-                }
-            };
-            f.with_error(GlassError::Backend(format!(
-                "reconnect could not re-arm the connection: {detail}"
-            )))
+            GlassError::Backend(format!(
+                "reconnect could not re-arm the connection: {}",
+                f.into_error()
+            ))
         })?;
     let actual = reply.get("package").and_then(Value::as_str);
     let Some(actual) = actual else {
-        return Err(CallFailure::NotSent(GlassError::Backend(format!(
+        return Err(GlassError::Backend(format!(
             "the reconnect could not confirm {pkg} is still the foreground app; the pending \
              request was not re-sent"
-        ))));
+        )));
     };
     match subject_of(pkg, Some(actual)) {
         None => Ok(()),
-        Some(s) => Err(CallFailure::NotSent(GlassError::Backend(format!(
+        Some(s) => Err(GlassError::Backend(format!(
             "the foreground app moved from {} to {} while reconnecting; the pending request \
              was not re-sent",
             s.asked, s.actual
-        )))),
+        ))),
     }
 }
 
@@ -1783,6 +1783,16 @@ mod tests {
         Unnamed,
     }
 
+    /// Whether a fake `tree` request is served normally (per `packages`) or refused outright —
+    /// the `tree`-request analogue of `OnAction::DropWithoutAnswering`, needed to test a re-arm
+    /// the companion refuses (mirrors the shipped companion's `Server.kt`, which answers
+    /// `Response.error(id, "no active window")` when nothing is in the foreground).
+    #[derive(Clone, Copy)]
+    enum OnTree {
+        Serve,
+        Refused(&'static str),
+    }
+
     /// A fake on-device service on a local TCP listener: serves `tree` from a script (the last
     /// entry repeating) and records every request, tagged with the connection it arrived on so
     /// a re-send after a reconnect is visible in the log.
@@ -1790,13 +1800,14 @@ mod tests {
         fake_service_ex(trees, vec![on_action], vec![TreePackage::Echo])
     }
 
-    /// [`fake_service`], varying two things **per connection** (index 0 = the first
-    /// connection, clamped to the last entry, same convention as `trees`):
-    /// - `on_action` — a later connection's action can succeed after an earlier one failed,
+    /// [`fake_service`], plus two knobs, each varying by its own count (not each other's):
+    /// - `on_action` — indexed **by connection** (index 0 = the first connection, clamped to
+    ///   the last entry): a later connection's action can succeed after an earlier one failed,
     ///   needed to observe a reconnect's resend land.
-    /// - `packages` — indexed by how many `tree`s have been served *in total* across every
-    ///   connection, not by connection; a later entry can name a different package than asked
-    ///   or omit the field, modelling a foreground that changed by the time a reconnect re-arms.
+    /// - `packages` — indexed by how many `tree`s have been served *in total*, across every
+    ///   connection (same convention as `trees`): a later entry can name a different package
+    ///   than asked, or omit the field, modelling a foreground that changed by the time a
+    ///   reconnect re-arms.
     ///
     /// The real companion re-checks its last-served package against the active window at the
     /// moment of each `action`, refusing if the window changed since; this fake still models
@@ -1807,6 +1818,19 @@ mod tests {
         trees: Vec<Value>,
         on_action: Vec<OnAction>,
         packages: Vec<TreePackage>,
+    ) -> (u16, Arc<Mutex<Vec<String>>>) {
+        fake_service_full(trees, on_action, packages, vec![OnTree::Serve])
+    }
+
+    /// [`fake_service_ex`], plus `on_tree` (same indexing convention as `packages`: by how many
+    /// `tree`s have been served in total) — a served-index that resolves to `OnTree::Refused`
+    /// answers `ok:false` instead of consulting `trees`/`packages`, and does not advance
+    /// `served` or arm the connection's gate, since nothing was actually served.
+    fn fake_service_full(
+        trees: Vec<Value>,
+        on_action: Vec<OnAction>,
+        packages: Vec<TreePackage>,
+        on_tree: Vec<OnTree>,
     ) -> (u16, Arc<Mutex<Vec<String>>>) {
         let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind");
         let port = listener.local_addr().expect("addr").port();
@@ -1835,20 +1859,28 @@ mod tests {
                     let req: Value = serde_json::from_str(&line).expect("request is json");
                     let id = req["id"].clone();
                     let reply = match req["op"].as_str().unwrap_or_default() {
-                        "tree" => {
-                            log.lock().unwrap().push(format!("conn{conn}:tree"));
-                            let t = trees[served.min(trees.len() - 1)].clone();
-                            let pkg = &packages[served.min(packages.len() - 1)];
-                            served += 1;
-                            tree_confirmed = true;
-                            let mut reply = json!({"id": id, "ok": true, "tree": t});
-                            match pkg {
-                                TreePackage::Echo => reply["package"] = req["package"].clone(),
-                                TreePackage::Other(p) => reply["package"] = json!(p),
-                                TreePackage::Unnamed => {}
+                        "tree" => match on_tree[served.min(on_tree.len() - 1)] {
+                            OnTree::Refused(msg) => {
+                                log.lock().unwrap().push(format!("conn{conn}:tree-refused"));
+                                json!({"id": id, "ok": false, "error": msg})
                             }
-                            reply
-                        }
+                            OnTree::Serve => {
+                                log.lock().unwrap().push(format!("conn{conn}:tree"));
+                                let t = trees[served.min(trees.len() - 1)].clone();
+                                let pkg = &packages[served.min(packages.len() - 1)];
+                                served += 1;
+                                tree_confirmed = true;
+                                let mut reply = json!({"id": id, "ok": true, "tree": t});
+                                match pkg {
+                                    TreePackage::Echo => {
+                                        reply["package"] = req["package"].clone();
+                                    }
+                                    TreePackage::Other(p) => reply["package"] = json!(p),
+                                    TreePackage::Unnamed => {}
+                                }
+                                reply
+                            }
+                        },
                         "action" if !tree_confirmed => {
                             log.lock()
                                 .unwrap()
@@ -2003,6 +2035,70 @@ mod tests {
             ],
             "no set_text on conn2 — an unconfirmed foreground must stop the resend"
         );
+    }
+
+    #[test]
+    fn a_rearm_refused_by_the_companion_keeps_the_original_failures_own_classification() {
+        // conn1's action is dropped (AnswerLost); the re-arm on conn2 is then refused outright
+        // (`Server.kt`'s `Response.error(id, "no active window")`, `CallFailure::Refused`).
+        // Read via `call` directly, not `set_text`: `set_text`'s public `Result<()>` erases
+        // which `CallFailure` variant it was, and that variant is exactly what this pins.
+        let (port, _ops) = fake_service_full(
+            vec![json!({})],
+            vec![OnAction::DropWithoutAnswering],
+            vec![TreePackage::Echo],
+            vec![OnTree::Serve, OnTree::Refused("no active window")],
+        );
+        let client = ServiceClient::connect(port).expect("connect to the fake service");
+        client.tree("com.example.app").expect("primes conn1");
+        let e = client
+            .call(
+                json!({"op": "action", "ref": 1, "action": "set_text", "text": "hi"}),
+                Some("com.example.app"),
+            )
+            .expect_err("a refused re-arm must still fail — just not overwrite the original's classification");
+        assert!(
+            matches!(e, CallFailure::AnswerLost(_)),
+            "conn1's own failure was AnswerLost; a re-arm the companion refuses must not \
+             relabel it Refused (which a click would then report as the action itself having \
+             failed, or worse — Refused's own AnswerLost sibling would read as a lost result \
+             for an action that never left the host): {}",
+            e.into_error()
+        );
+    }
+
+    #[test]
+    fn set_values_call_site_sends_its_own_configured_package_to_the_rearm() {
+        // Pins `set_value`'s `self.client.set_text(target.id.0, text, &self.package)`: the
+        // re-arm reply's package is fixed to "com.example.app" regardless of what was asked, so
+        // this only passes if `ServiceA11y` actually threads its OWN configured package through
+        // — a swapped argument or a literal "" would ask for something else and be refused as a
+        // mismatch, which `reader()` (built with `String::new()`) could never catch.
+        let field = |value: &str| {
+            json!({
+                "class": "android.widget.FrameLayout",
+                "bounds": {"x": 0, "y": 0, "w": 1080, "h": 2400},
+                "children": [
+                    {"class": "android.widget.EditText", "text": value, "desc": "Email",
+                     "bounds": {"x": 0, "y": 100, "w": 600, "h": 120},
+                     "editable": true, "clickable": true, "enabled": true}
+                ]
+            })
+        };
+        let (port, _ops) = fake_service_ex(
+            vec![field("old"), field("old"), field("new")],
+            vec![OnAction::DropWithoutAnswering, OnAction::Ok],
+            vec![
+                TreePackage::Echo,
+                TreePackage::Other("com.example.app".into()),
+            ],
+        );
+        let client = ServiceClient::connect(port).expect("connect to the fake service");
+        let mut a = ServiceA11y::new(client, "com.example.app".to_string());
+        let t = built(&field("old"));
+        let target = target_for(&t, AxNodeId(1));
+        a.set_value(&ctx(), &target, "new")
+            .expect("the caller's own configured package must match the rearm's fixed reply");
     }
 
     #[test]

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -182,10 +182,15 @@ impl ServiceClient {
     }
 
     /// Run a request, reconnecting once and re-sending when `resend` accepts the failure.
+    /// `rearm` is `None` for a request needing no served tree (`ping`) or that IS the re-arm
+    /// (`tree`); `Some(pkg)` re-serves `tree` for `pkg` on the fresh connection first and, only
+    /// once its reply confirms `pkg` is still foreground, lets `req` follow it — see
+    /// [`rearm_tree`].
     fn call_with(
         &self,
         req: Value,
         resend: fn(&CallFailure) -> bool,
+        rearm: Option<&str>,
     ) -> std::result::Result<Value, CallFailure> {
         let mut conn = self.conn.lock().map_err(|_| {
             CallFailure::NotSent(GlassError::Backend(
@@ -197,6 +202,9 @@ impl ServiceClient {
             Err(f) if resend(&f) => {
                 // The service's accept loop accepts a fresh connection after a drop.
                 *conn = Conn::open(self.port).map_err(|e| f.with_error(e))?;
+                if let Some(pkg) = rearm {
+                    rearm_tree(&mut conn, pkg)?;
+                }
                 conn.call(req)
             }
             Err(f) => Err(f),
@@ -205,18 +213,22 @@ impl ServiceClient {
 
     /// Run a request that can be run twice without consequence, transparently reconnecting
     /// once if the socket dropped. A dead socket usually surfaces on the *read*, not the write.
-    fn call(&self, req: Value) -> std::result::Result<Value, CallFailure> {
-        self.call_with(req, CallFailure::is_transport)
+    fn call(&self, req: Value, rearm: Option<&str>) -> std::result::Result<Value, CallFailure> {
+        self.call_with(req, CallFailure::is_transport, rearm)
     }
 
     /// [`Self::call`] for a side-effecting request: re-send only what provably never went out.
-    fn call_once_sent(&self, req: Value) -> std::result::Result<Value, CallFailure> {
-        self.call_with(req, CallFailure::nothing_sent)
+    fn call_once_sent(
+        &self,
+        req: Value,
+        rearm: Option<&str>,
+    ) -> std::result::Result<Value, CallFailure> {
+        self.call_with(req, CallFailure::nothing_sent, rearm)
     }
 
     fn tree(&self, package: &str) -> Result<TreeReply> {
         let r = self
-            .call(json!({"op": "tree", "package": package}))
+            .call(json!({"op": "tree", "package": package}), None)
             .map_err(CallFailure::into_error)?;
         let tree = r
             .get("tree")
@@ -228,25 +240,71 @@ impl ServiceClient {
         })
     }
 
-    /// Fire `ACTION_CLICK` on device node `ref_id`. Never re-sent once delivered; the failure
-    /// keeps its delivery classification.
-    fn click(&self, ref_id: u32) -> std::result::Result<(), CallFailure> {
-        self.call_once_sent(json!({"op": "action", "ref": ref_id, "action": "click"}))
-            .map(|_| ())
+    /// Fire `ACTION_CLICK` on device node `ref_id` in `package`. Never re-sent once delivered;
+    /// the failure keeps its delivery classification. `package` re-arms a reconnected
+    /// connection — see [`Self::call_with`].
+    fn click(&self, ref_id: u32, package: &str) -> std::result::Result<(), CallFailure> {
+        self.call_once_sent(
+            json!({"op": "action", "ref": ref_id, "action": "click"}),
+            Some(package),
+        )
+        .map(|_| ())
     }
 
-    /// Fire `ACTION_SET_TEXT` on device node `ref_id`. Idempotent, so this takes the
-    /// reconnecting path.
-    fn set_text(&self, ref_id: u32, text: &str) -> Result<()> {
-        self.call(json!({"op": "action", "ref": ref_id, "action": "set_text", "text": text}))
-            .map(|_| ())
-            .map_err(CallFailure::into_error)
+    /// Fire `ACTION_SET_TEXT` on device node `ref_id` in `package`. Idempotent, so this takes
+    /// the reconnecting path; `package` re-arms a reconnected connection — see
+    /// [`Self::call_with`].
+    fn set_text(&self, ref_id: u32, text: &str, package: &str) -> Result<()> {
+        self.call(
+            json!({"op": "action", "ref": ref_id, "action": "set_text", "text": text}),
+            Some(package),
+        )
+        .map(|_| ())
+        .map_err(CallFailure::into_error)
     }
 
     pub fn ping(&self) -> Result<()> {
-        self.call(json!({"op": "ping"}))
+        self.call(json!({"op": "ping"}), None)
             .map(|_| ())
             .map_err(CallFailure::into_error)
+    }
+}
+
+/// Re-serve `tree` for `pkg` on a freshly reconnected connection, and confirm the reply names
+/// `pkg` before letting the pending request that triggered the reconnect follow it. Silently
+/// re-arming with whatever is foreground *now* would make the packages match by construction
+/// and authorise the pending request against a window its ref never came from — so a mismatch,
+/// or a reply that names nothing, must return without letting that request go out.
+///
+/// The re-arm's own failure is kept distinct from the pending request's: its message says the
+/// reconnect could not re-arm, never that the request itself was refused.
+fn rearm_tree(conn: &mut Conn, pkg: &str) -> std::result::Result<(), CallFailure> {
+    let reply = conn
+        .call(json!({"op": "tree", "package": pkg}))
+        .map_err(|f| {
+            let detail = match &f {
+                CallFailure::NotSent(e) | CallFailure::AnswerLost(e) | CallFailure::Refused(e) => {
+                    e.to_string()
+                }
+            };
+            f.with_error(GlassError::Backend(format!(
+                "reconnect could not re-arm the connection: {detail}"
+            )))
+        })?;
+    let actual = reply.get("package").and_then(Value::as_str);
+    let Some(actual) = actual else {
+        return Err(CallFailure::NotSent(GlassError::Backend(format!(
+            "the reconnect could not confirm {pkg} is still the foreground app; the pending \
+             request was not re-sent"
+        ))));
+    };
+    match subject_of(pkg, Some(actual)) {
+        None => Ok(()),
+        Some(s) => Err(CallFailure::NotSent(GlassError::Backend(format!(
+            "the foreground app moved from {} to {} while reconnecting; the pending request \
+             was not re-sent",
+            s.asked, s.actual
+        )))),
     }
 }
 
@@ -318,7 +376,7 @@ impl Accessibility for ServiceA11y {
             t
         };
         crate::a11y::editable_target(&tree, target)?;
-        self.client.set_text(target.id.0, text)?;
+        self.client.set_text(target.id.0, text, &self.package)?;
         // Verify the value actually took. ACTION_SET_TEXT returns success but silently no-ops when
         // *replacing* existing text in a Compose field, so a bare Ok could lie (glass forbids silent
         // fallbacks). The set is async (Compose recompose → a11y update), so poll briefly for the
@@ -366,7 +424,7 @@ impl Accessibility for ServiceA11y {
         };
         let plan = invoke_plan(&tree, target)?;
         self.client
-            .click(plan.actuated.id.0)
+            .click(plan.actuated.id.0, &self.package)
             .map_err(|f| action_error(target.id.0, f))?;
         if let Some(want) = plan.want_checked {
             self.wait_for_check(ctx, &plan, want)?;
@@ -1712,19 +1770,54 @@ mod tests {
         DropWithoutAnswering,
     }
 
+    /// What a fake `tree` reply's `package` field says, relative to what was asked — added for
+    /// glass#286's B2b, whose re-arm tests need a later connection's reply to disagree with an
+    /// earlier one, which a bare echo cannot express.
+    enum TreePackage {
+        /// Whatever the request asked for — `fake_service`'s only behavior before this enum.
+        Echo,
+        /// A different package than asked — the foreground changed since the last `tree`.
+        Other(String),
+        /// The key omitted, as an older companion sends it, or one that cannot name the active
+        /// window.
+        Unnamed,
+    }
+
     /// A fake on-device service on a local TCP listener: serves `tree` from a script (the last
     /// entry repeating) and records every request, tagged with the connection it arrived on so
     /// a re-send after a reconnect is visible in the log.
     fn fake_service(trees: Vec<Value>, on_action: OnAction) -> (u16, Arc<Mutex<Vec<String>>>) {
+        fake_service_ex(trees, vec![on_action], vec![TreePackage::Echo])
+    }
+
+    /// [`fake_service`], varying two things **per connection** (index 0 = the first
+    /// connection, clamped to the last entry, same convention as `trees`):
+    /// - `on_action` — a later connection's action can succeed after an earlier one failed,
+    ///   needed to observe a reconnect's resend land.
+    /// - `packages` — indexed by how many `tree`s have been served *in total* across every
+    ///   connection, not by connection; a later entry can name a different package than asked
+    ///   or omit the field, modelling a foreground that changed by the time a reconnect re-arms.
+    ///
+    /// The real companion re-checks its last-served package against the active window at the
+    /// moment of each `action`, refusing if the window changed since; this fake still models
+    /// only the coarser gate glass#286 needed (some prior `tree`, ever, on THIS connection) via
+    /// a one-way flip that never re-closes — `packages` does not make the gate itself re-check
+    /// anything.
+    fn fake_service_ex(
+        trees: Vec<Value>,
+        on_action: Vec<OnAction>,
+        packages: Vec<TreePackage>,
+    ) -> (u16, Arc<Mutex<Vec<String>>>) {
         let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind");
         let port = listener.local_addr().expect("addr").port();
         let ops: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
         let log = Arc::clone(&ops);
         std::thread::spawn(move || {
-            let mut conn = 0;
+            let mut conn = 0usize;
             let mut served = 0usize;
             while let Ok((sock, _)) = listener.accept() {
                 conn += 1;
+                let this_action = on_action[(conn - 1).min(on_action.len() - 1)];
                 let Ok(mut w) = sock.try_clone() else { break };
                 let mut r = std::io::BufReader::new(sock);
                 if writeln!(w, r#"{{"hello":{{"proto":1}}}}"#)
@@ -1733,14 +1826,6 @@ mod tests {
                 {
                     break;
                 }
-                // The real companion re-checks its last-served package against the active
-                // window at the moment of each `action`, refusing if the window changed since;
-                // this fake models only the coarser gate glass#286 needed (some prior `tree`,
-                // ever, on this connection) via a one-way flip that never re-closes. It also
-                // cannot produce a `tree` reply with `package` absent (it always echoes
-                // `req["package"]` back) or express that an unnamed-package `tree` must not
-                // satisfy the gate (the real companion's `served == null` refuses) — both are
-                // covered instead by the pure `subject_of` tests above, not through this socket.
                 let mut tree_confirmed = false;
                 loop {
                     let mut line = String::new();
@@ -1753,9 +1838,16 @@ mod tests {
                         "tree" => {
                             log.lock().unwrap().push(format!("conn{conn}:tree"));
                             let t = trees[served.min(trees.len() - 1)].clone();
+                            let pkg = &packages[served.min(packages.len() - 1)];
                             served += 1;
                             tree_confirmed = true;
-                            json!({"id": id, "ok": true, "tree": t, "package": req["package"]})
+                            let mut reply = json!({"id": id, "ok": true, "tree": t});
+                            match pkg {
+                                TreePackage::Echo => reply["package"] = req["package"].clone(),
+                                TreePackage::Other(p) => reply["package"] = json!(p),
+                                TreePackage::Unnamed => {}
+                            }
+                            reply
                         }
                         "action" if !tree_confirmed => {
                             log.lock()
@@ -1770,7 +1862,7 @@ mod tests {
                                 req["action"].as_str().unwrap_or_default(),
                                 req["ref"]
                             ));
-                            match on_action {
+                            match this_action {
                                 OnAction::Ok => json!({"id": id, "ok": true}),
                                 OnAction::DropWithoutAnswering => break,
                             }
@@ -1817,12 +1909,99 @@ mod tests {
         let (port, ops) = fake_service(vec![compose_like()], OnAction::Ok);
         let client = ServiceClient::connect(port).expect("connect to the fake service");
         let e = client
-            .click(1)
+            .click(1, "com.example.app")
             .expect_err("no tree has been served on this connection yet");
         assert!(matches!(e, CallFailure::Refused(_)), "{}", e.into_error());
         assert_eq!(
             ops_of(&ops),
             vec!["conn1:action-refused-no-tree".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_reconnect_re_arms_the_fresh_connection_before_resending() {
+        // conn1's tree primes its gate; the set_text is then dropped in flight (a transport
+        // failure, not a refusal), so the idempotent path reconnects.
+        let (port, ops) = fake_service_ex(
+            vec![json!({})],
+            vec![OnAction::DropWithoutAnswering, OnAction::Ok],
+            vec![TreePackage::Echo],
+        );
+        let client = ServiceClient::connect(port).expect("connect to the fake service");
+        client.tree("com.example.app").expect("primes conn1");
+        client
+            .set_text(1, "hi", "com.example.app")
+            .expect("re-arm confirms the same package, so the resend goes through");
+        assert_eq!(
+            ops_of(&ops),
+            vec![
+                "conn1:tree".to_string(),
+                "conn1:set_text ref=1".to_string(),
+                "conn2:tree".to_string(),
+                "conn2:set_text ref=1".to_string(),
+            ],
+            "conn2:tree (the re-arm) must precede conn2:set_text (the resend)"
+        );
+    }
+
+    #[test]
+    fn a_reconnect_whose_rearm_names_a_different_package_is_refused_without_resending() {
+        // The foreground moved between the dropped attempt and the reconnect: re-sending
+        // anyway would authorise the action against a window the caller's ref never came from.
+        let (port, ops) = fake_service_ex(
+            vec![json!({})],
+            vec![OnAction::DropWithoutAnswering],
+            vec![
+                TreePackage::Echo,
+                TreePackage::Other("com.other.app".into()),
+            ],
+        );
+        let client = ServiceClient::connect(port).expect("connect to the fake service");
+        client.tree("com.example.app").expect("primes conn1");
+        let e = client
+            .set_text(1, "hi", "com.example.app")
+            .expect_err("a different foreground must refuse the resend");
+        let msg = e.to_string();
+        assert!(msg.contains("com.example.app"), "{msg}");
+        assert!(msg.contains("com.other.app"), "{msg}");
+        assert!(msg.contains("moved"), "{msg}");
+        assert_eq!(
+            ops_of(&ops),
+            vec![
+                "conn1:tree".to_string(),
+                "conn1:set_text ref=1".to_string(),
+                "conn2:tree".to_string(),
+            ],
+            "no set_text on conn2 — the mismatch must stop the resend, not just be reported"
+        );
+    }
+
+    #[test]
+    fn a_reconnect_whose_rearm_names_no_package_cannot_confirm_and_is_refused() {
+        // An older companion, or one that cannot name the active window, on the re-arm: absent
+        // is not a match, so it cannot authorise the resend either.
+        let (port, ops) = fake_service_ex(
+            vec![json!({})],
+            vec![OnAction::DropWithoutAnswering],
+            vec![TreePackage::Echo, TreePackage::Unnamed],
+        );
+        let client = ServiceClient::connect(port).expect("connect to the fake service");
+        client.tree("com.example.app").expect("primes conn1");
+        let e = client
+            .set_text(1, "hi", "com.example.app")
+            .expect_err("an unconfirmed foreground must refuse the resend");
+        let msg = e.to_string();
+        assert!(msg.contains("com.example.app"), "{msg}");
+        assert!(msg.contains("could not confirm"), "{msg}");
+        assert!(!msg.contains("moved"), "{msg}");
+        assert_eq!(
+            ops_of(&ops),
+            vec![
+                "conn1:tree".to_string(),
+                "conn1:set_text ref=1".to_string(),
+                "conn2:tree".to_string(),
+            ],
+            "no set_text on conn2 — an unconfirmed foreground must stop the resend"
         );
     }
 

--- a/crates/glass-android/tests/a11y_loop.rs
+++ b/crates/glass-android/tests/a11y_loop.rs
@@ -248,9 +248,8 @@ fn set_value_reports_whether_the_write_landed() {
 }
 
 /// Bring `component` (`pkg/.Activity`) to the foreground with a bare `am start` — bypassing
-/// `AndroidPlatform::start_app`, which only ever tracks the one app it launched. That gap is the
-/// point: the platform's own bookkeeping still names the fixture, but the device's real
-/// foreground has moved to something else.
+/// `AndroidPlatform::start_app`, whose bookkeeping only ever tracks the one app it launched, so
+/// it still names the fixture while the device's real foreground has moved to something else.
 fn bring_to_front(component: &str) {
     let adb = std::env::var("GLASS_ADB").unwrap_or_else(|_| "adb".to_string());
     let out = std::process::Command::new(&adb)

--- a/crates/glass-android/tests/a11y_loop.rs
+++ b/crates/glass-android/tests/a11y_loop.rs
@@ -246,3 +246,78 @@ fn set_value_reports_whether_the_write_landed() {
     drop(platform);
     agents.shutdown();
 }
+
+/// Bring `component` (`pkg/.Activity`) to the foreground with a bare `am start` — bypassing
+/// `AndroidPlatform::start_app`, which only ever tracks the one app it launched. That gap is the
+/// point: the platform's own bookkeeping still names the fixture, but the device's real
+/// foreground has moved to something else.
+fn bring_to_front(component: &str) {
+    let adb = std::env::var("GLASS_ADB").unwrap_or_else(|_| "adb".to_string());
+    let out = std::process::Command::new(&adb)
+        .args(["shell", "am", "start", "-n", component])
+        .output()
+        .expect("adb shell am start");
+    assert!(
+        out.status.success(),
+        "am start {component} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// The service reader answering while something else holds the foreground. Ignored by default:
+///   GLASS_ADB=$HOME/android-sdk/platform-tools/adb GLASS_ANDROID_A11Y_APK=... \
+///     cargo test -p glass-android --test a11y_loop -- --ignored --nocapture --test-threads=1
+///
+/// Only a device shows this: the unit tests model the companion's replies with a fake, so a
+/// mismatched reply is whatever the fixture hands the fake — never proof that a real
+/// `AccessibilityService` names the true foreground window (glass#286).
+#[test]
+#[ignore = "requires a booted AVD + the a11y companion installed and enabled"]
+fn a_snapshot_taken_while_another_app_is_foreground_says_so() {
+    let get = |k: &str| std::env::var(k).ok();
+    let apk = glass_android::a11y_apk(&get)
+        .expect("set GLASS_ANDROID_A11Y_APK to the built a11y-debug.apk");
+
+    let agents = glass_android::AgentRegistry::new();
+    let mut platform =
+        glass_android::AndroidPlatform::from_env(&glass_android::EmulatorRegistry::new(), &agents)
+            .expect("attach");
+    let window = platform
+        .start_app(&settings_spec())
+        .expect("launch settings (the fixture asked about)");
+    std::thread::sleep(std::time::Duration::from_millis(1200));
+
+    bring_to_front("com.google.android.deskclock/com.android.deskclock.DeskClock");
+    std::thread::sleep(std::time::Duration::from_millis(1500));
+
+    let a11y_registry = glass_android::A11yServiceRegistry::new();
+    let client = a11y_registry
+        .ensure(&platform.resolved_adb(), &apk)
+        .expect("install + enable the service");
+    let mut svc = glass_android::ServiceA11y::new(client, "com.android.settings".to_string());
+
+    let ctx = AxContext {
+        pids: platform.app_pids(),
+        window,
+        window_handle: None,
+        a11y_bus_addr: None,
+        limits: WalkLimits::DEFAULT,
+    };
+    let tree = svc
+        .snapshot(&ctx)
+        .expect("a snapshot must still succeed for the wrong app");
+    let subject = tree
+        .subject
+        .expect("the service must disclose it answered about the foreground app, not Settings");
+    assert_eq!(subject.asked, "com.android.settings");
+    assert_eq!(subject.actual, "com.google.android.deskclock");
+
+    let adb = std::env::var("GLASS_ADB").unwrap_or_else(|_| "adb".to_string());
+    let _ = std::process::Command::new(&adb)
+        .args(["shell", "am", "force-stop", "com.google.android.deskclock"])
+        .output();
+    platform.stop_app().expect("stop");
+    drop(platform);
+    agents.shutdown();
+    a11y_registry.shutdown();
+}

--- a/crates/glass-android/tests/a11y_loop.rs
+++ b/crates/glass-android/tests/a11y_loop.rs
@@ -2,14 +2,13 @@
 //!   GLASS_ADB=$HOME/android-sdk/platform-tools/adb \
 //!     cargo test -p glass-android --test a11y_loop -- --ignored --nocapture --test-threads=1
 //!
-//! `--test-threads=1` is required, not tidiness: both tests drive Settings on the one attached
+//! `--test-threads=1` is required, not tidiness: these tests drive Settings on the one attached
 //! device, so in parallel each tears down the app the other is mid-interaction with.
 //!
-//! Launches com.android.settings, snapshots its a11y tree, and asserts the tree
-//! is non-trivial and carries named, role-typed elements. A second test writes into a real
-//! `EditText` and checks that a landed write is confirmed against the live field — and that a
-//! clear cannot be confirmed here at all, because this platform reports the emptied field's hint
-//! as its text.
+//! They cover a non-trivial tree with named, role-typed elements; a write confirmed against the
+//! live field — and a clear that cannot be confirmed here at all, because this platform reports
+//! the emptied field's hint as its text; that a read takes its dump file with it; and that a
+//! snapshot taken while another app is foreground says which app it describes.
 
 use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, WalkLimits};
 use glass_core::{AppSpec, GlassError, MouseButton, Platform, PointerEvent, SandboxLevel};

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -521,6 +521,16 @@ impl WalkBudget {
     }
 }
 
+/// What a caller asked a backend about, and what it answered about, when those differ.
+///
+/// Only a backend addressed by *name* can tell — the desktop readers are handed a window and have
+/// nothing to compare. `None` on a tree means no claim either way, not agreement.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Subject {
+    pub asked: String,
+    pub actual: String,
+}
+
 /// The active window's accessibility subtree.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AxTree {
@@ -533,6 +543,9 @@ pub struct AxTree {
     /// Subtrees dropped because a child read failed. Independent of [`AxTree::truncated`]: a
     /// tree can hit no bound at all and still be missing elements this way.
     pub unreadable: usize,
+    /// `Some` when the backend answered about something other than what it was asked about —
+    /// see [`Subject`].
+    pub subject: Option<Subject>,
 }
 
 impl AxTree {
@@ -544,6 +557,7 @@ impl AxTree {
             count: 0,
             truncated: None,
             unreadable: 0,
+            subject: None,
         }
     }
 
@@ -630,6 +644,18 @@ impl AxTree {
                  show them; otherwise drive that area by pixels: glass_screenshot, then \
                  glass_click at x,y.",
                 if self.unreadable == 1 { "is" } else { "are" },
+            )
+        })
+    }
+
+    /// Disclosure for a tree that describes something other than what was asked for. The ids in it
+    /// address what it actually describes, so this states the subject rather than warning about it.
+    pub fn subject_notice(&self) -> Option<String> {
+        self.subject.as_ref().map(|s| {
+            format!(
+                "… this describes {}, not the {} that was asked for — the ids above address that \
+                 window, and a fresh glass_a11y_snapshot will follow the foreground.",
+                s.actual, s.asked,
             )
         })
     }
@@ -2456,6 +2482,28 @@ mod tests {
     #[test]
     fn new_builds_a_complete_tree() {
         assert_eq!(AxTree::new(leaf(AxRole::Window, "App")).truncated, None);
+    }
+
+    #[test]
+    fn a_tree_that_answered_for_another_subject_says_which() {
+        let mut t = AxTree::new(leaf(AxRole::Window, "w"));
+        t.subject = Some(Subject {
+            asked: "com.example.app".into(),
+            actual: "com.google.android.permissioncontroller".into(),
+        });
+        let notice = t
+            .subject_notice()
+            .expect("a mismatch owes the caller a notice");
+        assert!(notice.contains("com.google.android.permissioncontroller"));
+        assert!(notice.contains("com.example.app"));
+    }
+
+    #[test]
+    fn a_tree_that_answered_for_what_was_asked_says_nothing() {
+        assert_eq!(
+            AxTree::new(leaf(AxRole::Window, "w")).subject_notice(),
+            None
+        );
     }
 
     #[test]

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -648,8 +648,8 @@ impl AxTree {
         })
     }
 
-    /// Disclosure for a tree that describes something other than what was asked for. The ids in it
-    /// address what it actually describes, so this states the subject rather than warning about it.
+    /// Disclosure for a tree that describes something other than what was asked for — the ids in
+    /// it still address what it actually describes.
     pub fn subject_notice(&self) -> Option<String> {
         self.subject.as_ref().map(|s| {
             format!(

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -2494,8 +2494,15 @@ mod tests {
         let notice = t
             .subject_notice()
             .expect("a mismatch owes the caller a notice");
-        assert!(notice.contains("com.google.android.permissioncontroller"));
-        assert!(notice.contains("com.example.app"));
+        // Pin the order, not just presence: a swapped `actual`/`asked` pair would still
+        // contain both strings but invert the claim — telling the caller it's looking at
+        // what it asked for while the ids actually address the other app.
+        assert!(
+            notice.contains(
+                "describes com.google.android.permissioncontroller, not the com.example.app"
+            ),
+            "{notice}"
+        );
     }
 
     #[test]

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -78,8 +78,8 @@ pub mod accessibility;
 pub use accessibility::{
     Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree,
     ChangeSignal, ChangeWait, ClickMethod, ElementCondition, ElementInfo, ElementMatch, MAX_DEPTH,
-    MAX_NODES, MAX_SIBLINGS, Truncation, TruncationLimit, WalkBudget, WalkLimits, element_match,
-    normalize_description,
+    MAX_NODES, MAX_SIBLINGS, Subject, Truncation, TruncationLimit, WalkBudget, WalkLimits,
+    element_match, normalize_description,
 };
 
 pub mod marks;

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -289,14 +289,18 @@ fn a11y_truncation_steer(tree: &glass_core::AxTree) -> Option<String> {
     })
 }
 
-/// Every disclosure a snapshot owes the agent about elements it does not show: the truncation
-/// steer, and the unreadable-subtree notice. Two blocks rather than one because a tree can hit a
-/// bound, lose a subtree to a failed child read, or both, and the recourse differs.
-fn a11y_partial_steers(tree: &glass_core::AxTree) -> Vec<String> {
-    [a11y_truncation_steer(tree), tree.unreadable_notice()]
-        .into_iter()
-        .flatten()
-        .collect()
+/// Every disclosure a snapshot owes the agent: the elements it does not show, and what it turned
+/// out to describe. One function, not three call-site lists, so `a11y_snapshot` and the
+/// `return:"snapshot"` fold disclose identically.
+fn a11y_steers(tree: &glass_core::AxTree) -> Vec<String> {
+    [
+        a11y_truncation_steer(tree),
+        tree.unreadable_notice(),
+        tree.subject_notice(),
+    ]
+    .into_iter()
+    .flatten()
+    .collect()
 }
 
 pub fn a11y_snapshot(glass: &mut Glass, a: &A11ySnapshotArgs) -> ToolResult {
@@ -316,7 +320,7 @@ pub fn a11y_snapshot(glass: &mut Glass, a: &A11ySnapshotArgs) -> ToolResult {
     if let Some(hint) = tree.empty_guidance() {
         contents.push(OutContent::Text(hint.to_string()));
     }
-    contents.extend(a11y_partial_steers(&tree).into_iter().map(OutContent::Text));
+    contents.extend(a11y_steers(&tree).into_iter().map(OutContent::Text));
     Ok(ToolOutput::result_with(
         "glass_a11y_snapshot",
         serde_json::json!({}),
@@ -391,7 +395,7 @@ fn resolve_return(
             if let Some(hint) = tree.empty_guidance() {
                 extra.push(OutContent::Text(hint.to_string()));
             }
-            extra.extend(a11y_partial_steers(&tree).into_iter().map(OutContent::Text));
+            extra.extend(a11y_steers(&tree).into_iter().map(OutContent::Text));
             Ok((None, extra))
         }
         Some(o) => Err(format!("unknown return '{o}' (use none/settle/snapshot)")),
@@ -1241,6 +1245,22 @@ mod tests {
             }
             _ => panic!("expected the trusted truncation-steer text"),
         }
+    }
+
+    #[test]
+    fn a_snapshot_of_another_app_says_so_in_its_text() {
+        let mut tree = empty_tree();
+        tree.subject = Some(glass_core::Subject {
+            asked: "com.example.app".into(),
+            actual: "com.google.android.permissioncontroller".into(),
+        });
+        let steers = a11y_steers(&tree);
+        assert!(
+            steers
+                .iter()
+                .any(|s| s.contains("com.google.android.permissioncontroller")),
+            "the agent is told which app the ids address: {steers:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #286. Host half; the companion half is fixed-width/glass-android-agent#9.

The on-device accessibility companion discarded the `package` argument on its `tree` op and answered with whatever window was active, so a snapshot could describe a different app than the caller asked about with nothing marking it — a system dialog, a permission prompt — and an element selected from that tree addressed the wrong app.

## What changed

- `glass-core` gains `Subject { asked, actual }`, `AxTree::subject` and `AxTree::subject_notice()`: the platform-agnostic way for a tree to say it describes something other than what was asked about. `None` means no claim either way, not agreement — only a backend addressed by name can tell.
- The Android service reader compares the reply's package to the one it asked for and sets `subject` on a mismatch. An absent package is the older-companion path and never reads as a mismatch.
- `glass-mcp` folds the notice into the helper both snapshot paths already share, so `glass_a11y_snapshot` and the `return:"snapshot"` fold disclose identically.
- The companion's action gate is per socket connection, and the host reconnects and re-sends on transport failure — landing on a connection that has served no tree. The host now re-arms it with a `tree` first, and verifies that reply before re-sending: a silent re-arm would make the packages match by construction and authorise the pending write against a window its ref never came from. The comparison is against the app the acting tree described, not the app that was asked about — those differ exactly when the snapshot came back describing a dialog, which is the case this change exists for.

## Verification

`cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all -- --check` clean.

On an AVD, through the real companion: a snapshot targeting `com.android.settings` while `com.google.android.deskclock` held the foreground came back with `subject` naming deskclock, and the test was confirmed to fail with the disclosure stubbed out.

The re-arm's refusals are mutation-verified in both directions — a re-arm naming the asked-about app must not authorise a stale acting app's ref, and one naming the acting app must still re-send — each confirmed red against the pre-fix comparison.

## Known limits

`glass_wait_for_element` and `glass_scroll_to_element` return an element payload rather than an outline, so the notice does not reach them; an id handed out that way carries no disclosure. Filed separately.