### PR TITLE
test(a11y-android): pin what click resolution accepts

### DIFF
--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -1309,8 +1309,8 @@ mod tests {
         assert!(encloses(Some(same), Some(same)));
     }
 
-    /// Defensive default, pinned on purpose: `encloses`'s own doc calls both arms unreachable
-    /// through this reader, but not through every backend, so they stay covered.
+    /// Defensive default, pinned on purpose: the signature admits `None`, even though no caller
+    /// in this file currently supplies it — `encloses`'s own doc explains why.
     #[test]
     fn a_node_without_bounds_neither_encloses_nor_is_enclosed() {
         let rect = AxRect {
@@ -1580,16 +1580,18 @@ mod tests {
     /// test is the expectation it must consciously change.
     #[test]
     fn a_same_named_sibling_that_inherited_the_id_is_accepted_as_the_control() {
-        // Ids shifted between the click and this read-back: an already-checked impostor slid
-        // into id 1, and the control actually clicked is now id 2, still unchecked.
-        let impostor = checkable_json("android.widget.CheckBox", "Agree", true);
+        // `plan.actuated` is recorded from this tree, where id 1 really is the control clicked.
         let mut clicked = checkable_json("android.widget.CheckBox", "Agree", false);
         clicked["bounds"] = json!({"x": 40, "y": 400, "w": 200, "h": 100});
-        let after = after_tree(vec![impostor, clicked]);
+        let before = after_tree(vec![clicked.clone()]);
+        let plan = invoke_plan(&before, &target_for(&before, AxNodeId(1))).unwrap();
 
-        let act = actuated(1, AxRole::CheckBox, "Agree");
+        // Ids shifted between the click and this read-back: an already-checked impostor now
+        // occupies id 1, and the control actually clicked is id 2, still unchecked.
+        let impostor = checkable_json("android.widget.CheckBox", "Agree", true);
+        let after = after_tree(vec![impostor, clicked]);
         assert_eq!(
-            check_state(&after, &act),
+            check_state(&after, &plan.actuated),
             CheckState::Reached(true),
             "a same-named sibling is indistinguishable to a role+name fingerprint"
         );
@@ -1600,7 +1602,7 @@ mod tests {
     /// same role and name — it must not be read as `checked == false`.
     #[test]
     fn a_same_named_node_no_longer_checkable_is_not_read_as_the_control() {
-        let mut node = checkable_json("android.widget.CheckBox", "Agree", false);
+        let mut node = checkable_json("android.widget.CheckedTextView", "Agree", false);
         node["checkable"] = json!(false);
         let after = after_tree(vec![node]);
         let act = actuated(1, AxRole::CheckBox, "Agree");

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -741,7 +741,9 @@ enum CheckState {
 ///
 /// The id alone cannot accept a state change: it is positional, so a node the click added above
 /// the control shifts every later id, and `checked` reads `false` on any node with no checked
-/// state — between them, an inert label sliding into the id reads as a flip.
+/// state — between them, an inert label sliding into the id reads as a flip. Role and name are
+/// what stand in its place, so a same-named sibling that inherits the id is accepted as the
+/// control; `fingerprinted` compares bounds and value too, for the same job before the click.
 fn check_state(after: &AxTree, act: &Actuated) -> CheckState {
     match after.find(act.id) {
         Some(n) if n.states.checkable && n.role == act.role && n.name == act.name => {
@@ -1556,6 +1558,29 @@ mod tests {
         )]);
         let act = actuated(1, AxRole::CheckBox, "Agree");
         assert_eq!(check_state(&after, &act), CheckState::Gone);
+    }
+
+    /// The known weakness, pinned rather than fixed: the fingerprint is `checkable` + role +
+    /// name, so a same-named sibling that inherits the id is accepted as the control that was
+    /// clicked, and its state is reported as the flip. `Actuated` records no rect, so nothing
+    /// here can tell the two apart. Strengthening this is glass#319's job — when it lands, this
+    /// test is the expectation it must consciously change.
+    #[test]
+    fn a_same_named_sibling_that_inherited_the_id_is_accepted_as_the_control() {
+        let mut first = checkable_json("android.widget.CheckBox", "Agree", true);
+        first["bounds"] = json!({"x": 40, "y": 200, "w": 200, "h": 100});
+        let mut second = checkable_json("android.widget.CheckBox", "Agree", false);
+        second["bounds"] = json!({"x": 40, "y": 400, "w": 200, "h": 100});
+        let after = after_tree(vec![first, second]);
+
+        // Id 1 is the FIRST of the two. Had the click been on the second, `check_state` would
+        // still answer from id 1 and report its state as the outcome.
+        let act = actuated(1, AxRole::CheckBox, "Agree");
+        assert_eq!(
+            check_state(&after, &act),
+            CheckState::Reached(true),
+            "a same-named sibling is indistinguishable to a role+name fingerprint"
+        );
     }
 
     /// A clickable card wrapping a clickable button wrapping its label — nested clickables are

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -786,8 +786,9 @@ fn path_to<'a>(node: &'a AxNode, id: AxNodeId, out: &mut Vec<&'a AxNode>) -> boo
     false
 }
 
-/// Whether `outer` fully contains `inner`. A node without bounds encloses nothing — the climb
-/// must not reach past a node whose geometry it cannot check.
+/// Whether `outer` fully contains `inner`, edges inclusive. Either side missing bounds is false —
+/// the climb must not reach past geometry it cannot check — though neither arm is reachable
+/// through this reader, since `json_to_node` errors a snapshot on a node with no bounds.
 fn encloses(outer: Option<AxRect>, inner: Option<AxRect>) -> bool {
     let (Some(o), Some(i)) = (outer, inner) else {
         return false;
@@ -1290,6 +1291,32 @@ mod tests {
             bounds: n.bounds,
             value: n.value.clone(),
         }
+    }
+
+    /// Bounds equal on every edge. `actuable_node` climbs to the nearest enclosing clickable
+    /// ancestor, and a Compose touch target's rect routinely equals its label's — a strict
+    /// comparison here sends every such click to the pointer path instead.
+    #[test]
+    fn a_rect_encloses_one_that_shares_all_four_edges() {
+        let same = AxRect {
+            x: 40,
+            y: 200,
+            width: 200,
+            height: 100,
+        };
+        assert!(encloses(Some(same), Some(same)));
+    }
+
+    #[test]
+    fn a_node_without_bounds_neither_encloses_nor_is_enclosed() {
+        let rect = AxRect {
+            x: 40,
+            y: 200,
+            width: 200,
+            height: 100,
+        };
+        assert!(!encloses(None, Some(rect)), "an outer with no bounds");
+        assert!(!encloses(Some(rect), None), "an inner with no bounds");
     }
 
     #[test]

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -1309,8 +1309,8 @@ mod tests {
         assert!(encloses(Some(same), Some(same)));
     }
 
-    /// Defensive default, pinned on purpose: the signature admits `None`, even though no caller
-    /// in this file currently supplies it — `encloses`'s own doc explains why.
+    /// Defensive default, pinned on purpose: the signature admits `None`, though no production
+    /// caller supplies it — `encloses`'s own doc explains why.
     #[test]
     fn a_node_without_bounds_neither_encloses_nor_is_enclosed() {
         let rect = AxRect {

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -1309,6 +1309,8 @@ mod tests {
         assert!(encloses(Some(same), Some(same)));
     }
 
+    /// Defensive default, pinned on purpose: `encloses`'s own doc calls both arms unreachable
+    /// through this reader, but not through every backend, so they stay covered.
     #[test]
     fn a_node_without_bounds_neither_encloses_nor_is_enclosed() {
         let rect = AxRect {
@@ -1350,6 +1352,17 @@ mod tests {
             actuable_node(&t, &label),
             Err(GlassError::AxActionUnavailable(2))
         ));
+    }
+
+    /// The clickable node's box shares all four edges with its label's, the coincident-edge case
+    /// `encloses` itself is unit-tested against — this proves the climb actually takes that arm.
+    #[test]
+    fn a_climb_reaches_a_clickable_ancestor_whose_bounds_exactly_match_the_target() {
+        let mut v = compose_like();
+        v["children"][0]["bounds"] = json!({"x": 120, "y": 520, "w": 80, "h": 50});
+        let t = built(&v);
+        let label = target_for(&t, AxNodeId(2));
+        assert_eq!(actuable_node(&t, &label).unwrap().id, AxNodeId(1));
     }
 
     #[test]
@@ -1567,20 +1580,40 @@ mod tests {
     /// test is the expectation it must consciously change.
     #[test]
     fn a_same_named_sibling_that_inherited_the_id_is_accepted_as_the_control() {
-        let mut first = checkable_json("android.widget.CheckBox", "Agree", true);
-        first["bounds"] = json!({"x": 40, "y": 200, "w": 200, "h": 100});
-        let mut second = checkable_json("android.widget.CheckBox", "Agree", false);
-        second["bounds"] = json!({"x": 40, "y": 400, "w": 200, "h": 100});
-        let after = after_tree(vec![first, second]);
+        // Ids shifted between the click and this read-back: an already-checked impostor slid
+        // into id 1, and the control actually clicked is now id 2, still unchecked.
+        let impostor = checkable_json("android.widget.CheckBox", "Agree", true);
+        let mut clicked = checkable_json("android.widget.CheckBox", "Agree", false);
+        clicked["bounds"] = json!({"x": 40, "y": 400, "w": 200, "h": 100});
+        let after = after_tree(vec![impostor, clicked]);
 
-        // Id 1 is the FIRST of the two. Had the click been on the second, `check_state` would
-        // still answer from id 1 and report its state as the outcome.
         let act = actuated(1, AxRole::CheckBox, "Agree");
         assert_eq!(
             check_state(&after, &act),
             CheckState::Reached(true),
             "a same-named sibling is indistinguishable to a role+name fingerprint"
         );
+    }
+
+    /// `CheckedTextView` also maps to `AxRole::CheckBox` (see `axmap.rs`), so a node that lost
+    /// its checkable state between the click and the read-back is still reachable under the
+    /// same role and name — it must not be read as `checked == false`.
+    #[test]
+    fn a_same_named_node_no_longer_checkable_is_not_read_as_the_control() {
+        let mut node = checkable_json("android.widget.CheckBox", "Agree", false);
+        node["checkable"] = json!(false);
+        let after = after_tree(vec![node]);
+        let act = actuated(1, AxRole::CheckBox, "Agree");
+        assert_eq!(check_state(&after, &act), CheckState::Gone);
+    }
+
+    /// A `Switch` maps to `AxRole::ToggleButton`, not `AxRole::CheckBox` — role is as much a
+    /// stand-in for the id as name, and this is the case that isolates it from name.
+    #[test]
+    fn a_same_named_node_of_a_different_role_is_not_read_as_the_control() {
+        let after = after_tree(vec![checkable_json("android.widget.Switch", "Agree", true)]);
+        let act = actuated(1, AxRole::CheckBox, "Agree");
+        assert_eq!(check_state(&after, &act), CheckState::Gone);
     }
 
     /// A clickable card wrapping a clickable button wrapping its label — nested clickables are


### PR DESCRIPTION
Closes #290. Tests and comments only — `encloses` and `check_state` are byte-identical to master.

Both behaviours were correct but unpinned: nothing said what they accept, so a later edit could weaken either and the suite would stay green.

## What is pinned, and the mutation each dies under

- **Enclosure is inclusive at every edge.** `actuable_node` climbs to the nearest ancestor that advertises a click *and encloses* the target, and a Compose touch target's rect frequently equals its label's exactly — so a strict comparison makes the climb pass the real touch target and take a larger enclosing clickable, or fall through to a pointer tap. Pinned twice: directly on `encloses` (sole killer of all four comparisons flipped to strict) and at the climb call site, so the pin survives someone replacing the private helper.
- **`check_state`'s fingerprint is `checkable` + role + name.** Three tests, each the sole killer of dropping its conjunct. The `checkable` one matters because `CheckedTextView` maps to `AxRole::CheckBox`, so a same-role, same-name node that is no longer checkable would otherwise read as "the control did not take the click".
- **A same-named sibling that inherits the id is accepted as the control.** Recorded as a known weakness, not a guarantee — #319 tracks strengthening it. The fixture builds the real shape: an impostor already in the wanted state occupies id 1 while the control that was clicked has shifted to id 2. Its `Actuated` comes from `invoke_plan` rather than being hand-written, so #319 populates the rect by construction and there is no call site a future author can get wrong.
- The bounds-missing arms of `encloses` are covered too; they are unreachable through this reader, and the doc now says so rather than describing only one of them.

## Verification

Every test here asserts existing behaviour, so all of them passed the moment they were written. Each was therefore run against the mutation it exists to catch, and confirmed red — including the sibling pin against a faithful simulation of #319 (a `bounds` field on `Actuated`, populated in `invoke_plan`, compared in `check_state`), with production restored byte-identical afterwards.

`cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all -- --check` clean.