### PR TITLE
ci(android): a scheduled Android device leg

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -192,3 +192,66 @@ jobs:
           path: diagnostics/
           if-no-files-found: error
           retention-days: 14
+
+  android-lifecycle:
+    name: Managed AVD lifecycle (glass boots its own)
+    runs-on: Android-CI
+    timeout-minutes: 30
+    # No `needs:` — this is independent of the device suite and should still report if that fails.
+    # Deliberately does NOT use android-emulator-runner: that action boots the emulator and runs
+    # your script inside it, which is the exact precondition managed_avd requires to be absent.
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install pinned toolchain
+        run: rustup show
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: .
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
+
+      - name: Install the system image and define an AVD, without booting it
+        run: |
+          img="system-images;android-${API_LEVEL};${EMULATOR_TARGET};${EMULATOR_ARCH}"
+          yes | sdkmanager --licenses > /dev/null 2>&1 || true
+          sdkmanager "platform-tools" "emulator" "$img"
+          # --device matches EMULATOR_PROFILE so this AVD is the same device as the "android"
+          # job's, not whatever avdmanager would otherwise default to.
+          echo no | avdmanager create avd -n glass -k "$img" --device "$EMULATOR_PROFILE" --force
+          # Prove nothing is running: the test's subject is the boot itself.
+          "$ANDROID_SDK_ROOT/platform-tools/adb" devices
+
+      - name: Run the lifecycle test
+        env:
+          GLASS_AVD: glass
+          GLASS_EMULATOR_BOOT_TIMEOUT_MS: '300000'
+        run: |
+          export GLASS_ADB="$ANDROID_SDK_ROOT/platform-tools/adb"
+          set +e
+          ./scripts/test-android-lifecycle.sh
+          rc=$?
+          if [ $rc -ne 0 ]; then
+            mkdir -p diagnostics
+            "$GLASS_ADB" devices              > diagnostics/adb-devices.txt 2>&1
+            "$GLASS_ADB" logcat -d            > diagnostics/logcat.txt      2>&1
+            ls -la "$HOME/.android/avd"       > diagnostics/avd-dir.txt     2>&1
+          fi
+          exit $rc
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: android-lifecycle-diagnostics-${{ github.run_id }}
+          path: diagnostics/
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,7 +28,7 @@ on:
     - cron: '0 9 * * *'   # 09:00 UTC (02:00 PT in summer, 01:00 in winter)
   workflow_dispatch:
   push:
-    branches: [master, android-ci-leg]   # TEMPORARY: verification only, removed before merge
+    branches: [master]
 
 concurrency:
   # One group covers the schedule, push:master and dispatch, so cancelling would let a merge

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,7 +28,7 @@ on:
     - cron: '0 9 * * *'   # 09:00 UTC (02:00 PT in summer, 01:00 in winter)
   workflow_dispatch:
   push:
-    branches: [master]
+    branches: [master, android-ci-leg]   # TEMPORARY: verification only, removed before merge
 
 concurrency:
   # One group covers the schedule, push:master and dispatch, so cancelling would let a merge

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -201,6 +201,15 @@ jobs:
     # No `needs:` — this is independent of the device suite and should still report if that fails.
     # Deliberately does NOT use android-emulator-runner: that action boots the emulator and runs
     # your script inside it, which is the exact precondition managed_avd requires to be absent.
+    env:
+      # avdmanager and the native `emulator` binary default to different AVD directories on this
+      # runner (avdmanager: ~/.config/.android/avd; emulator: ~/.android/avd, it doesn't
+      # recognize ANDROID_USER_HOME) — an unpinned AVD is invisible to glass (run 30874077553).
+      # ANDROID_AVD_HOME is the override both honor (confirmed via `strings` on each; the
+      # deprecated ANDROID_SDK_HOME is one word from ANDROID_SDK_ROOT below and means something
+      # else). Job-level: a step's `env:` doesn't reach the next step, and the create step here
+      # and glass's own `emulator` invocation in the test step both need to agree.
+      ANDROID_AVD_HOME: ${{ github.workspace }}/.android-avd
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -226,6 +235,7 @@ jobs:
           img="system-images;android-${API_LEVEL};${EMULATOR_TARGET};${EMULATOR_ARCH}"
           yes | sdkmanager --licenses > /dev/null 2>&1 || true
           sdkmanager "platform-tools" "emulator" "$img"
+          mkdir -p "$ANDROID_AVD_HOME"
 
           # --device matches EMULATOR_PROFILE so this AVD is the same device as the "android"
           # job's, not whatever avdmanager would otherwise default to.
@@ -249,8 +259,8 @@ jobs:
           echo "HOME=${HOME:-<unset>}"
           echo "--- avdmanager's own view ---"
           avdmanager list avd
-          echo "--- \$HOME/.android/avd contents ---"
-          ls -la "$HOME/.android/avd" 2>&1
+          echo "--- \$ANDROID_AVD_HOME contents ---"
+          ls -la "$ANDROID_AVD_HOME" 2>&1
 
           # Matches glass's own resolution exactly: GLASS_EMULATOR is unset here, so
           # resolve_emulator_bin falls through to $ANDROID_SDK_ROOT/emulator/emulator, and
@@ -293,8 +303,8 @@ jobs:
             timeout 10 "$ANDROID_SDK_ROOT/emulator/emulator" -list-avds > diagnostics/emulator-list-avds.txt 2>&1
             timeout 10 "$GLASS_ADB" devices                             > diagnostics/adb-devices.txt      2>&1
             timeout 10 "$GLASS_ADB" logcat -d                           > diagnostics/logcat.txt           2>&1
-            ls -la "$HOME/.android/avd"                                 > diagnostics/avd-dir.txt          2>&1
-            find "$HOME/.android" -maxdepth 3 -iname '*.log'            > diagnostics/android-home-logs.txt 2>&1
+            ls -la "$ANDROID_AVD_HOME"                                  > diagnostics/avd-dir.txt          2>&1
+            find "$HOME/.android" "$ANDROID_AVD_HOME" -maxdepth 3 -iname '*.log' > diagnostics/android-logs.txt 2>&1
           fi
           exit $rc
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -82,6 +82,13 @@ jobs:
             echo "GLASS_ADB=$ANDROID_SDK_ROOT/platform-tools/adb"
           } >> "$GITHUB_ENV"
 
+      # The steps below (through "Point the suite at the fixture") build an APK that no currently
+      # enabled test consumes: native_invoke_actuates_the_fixture, the only test that reads
+      # GLASS_ANDROID_FIXTURE_APK, is excluded by scripts/test-android.sh's --skip pending glass#324.
+      # Kept anyway, deliberately: the cache makes the marginal cost of a cache-hit run a restore,
+      # not a rebuild, and re-adding this whole section later would be more churn than this comment.
+      # Remove the --skip in scripts/test-android.sh and this section is live again with no other
+      # change needed.
       - name: Cache the built fixture APK
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: fixture-cache

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -76,8 +76,8 @@ jobs:
             echo "GLASS_ADB=$ANDROID_SDK_ROOT/platform-tools/adb"
           } >> "$GITHUB_ENV"
 
-      - name: Cache the AVD
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Restore the AVD cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: avd-cache
         with:
           path: |
@@ -109,20 +109,28 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          # Diagnostics are collected INSIDE the emulator script: the action shuts the device down
-          # when this step ends, so an `if: failure()` step afterwards would have no adb to talk to.
-          script: |
-            set +e
-            ./scripts/test-android.sh --skip native_invoke_actuates_the_fixture
-            rc=$?
-            if [ $rc -ne 0 ]; then
-              mkdir -p diagnostics
-              adb logcat -d                  > diagnostics/logcat.txt         2>&1
-              adb shell dumpsys window       > diagnostics/dumpsys-window.txt 2>&1
-              adb shell dumpsys activity top > diagnostics/dumpsys-top.txt    2>&1
-              adb exec-out screencap -p      > diagnostics/screen.png         2>/dev/null
-            fi
-            exit $rc
+          # `script:` cannot hold this run-then-collect logic directly: the action splits it on
+          # newlines and runs each line as its own independent `sh -c`, abandoning the rest the
+          # moment one line fails — so a later `if failed, collect diagnostics` line never runs.
+          # scripts/ci-android-suite.sh is one script, invoked as one line, for exactly that
+          # reason; its own header has the full account. It can't be a separate `if: failure()`
+          # step afterwards either: the action shuts the device down when this step ends, so a
+          # later step has no adb to talk to.
+          script: ./scripts/ci-android-suite.sh --skip native_invoke_actuates_the_fixture
+
+      - name: Save the AVD cache
+        # Runs even on a failed suite: the AVD snapshot this caches comes from the earlier
+        # "Create the AVD snapshot" step, not from the test run, so a failing suite is no reason
+        # to keep re-paying full AVD creation on every following run. Mirrors actions/cache's own
+        # post-save condition (skip on a cache hit) since that behavior is no longer automatic
+        # once restore/save are split.
+        if: always() && steps.avd-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ env.API_LEVEL }}-${{ env.EMULATOR_TARGET }}-${{ env.EMULATOR_ARCH }}
 
       - name: Upload failure diagnostics
         if: failure()
@@ -130,5 +138,5 @@ jobs:
         with:
           name: android-diagnostics-${{ github.run_id }}
           path: diagnostics/
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -304,7 +304,11 @@ jobs:
             timeout 10 "$GLASS_ADB" devices                             > diagnostics/adb-devices.txt      2>&1
             timeout 10 "$GLASS_ADB" logcat -d                           > diagnostics/logcat.txt           2>&1
             ls -la "$ANDROID_AVD_HOME"                                  > diagnostics/avd-dir.txt          2>&1
-            find "$HOME/.android" "$ANDROID_AVD_HOME" -maxdepth 3 -iname '*.log' > diagnostics/android-logs.txt 2>&1
+            # No android-logs.txt: avd.rs spawns the emulator with stdout null and stderr piped
+            # only into the glass process, never written to disk, so `find -iname '*.log'` here
+            # always comes back empty (confirmed 0 bytes against a real failure) — an empty file
+            # would read as "collected" when nothing was. The real fix is capturing that stderr in
+            # avd.rs, out of scope here; list-avds/adb/AVD-dir above are what's actually on disk.
           fi
           exit $rc
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -32,6 +32,12 @@ env:
   API_LEVEL: '34'
   EMULATOR_TARGET: google_apis
   EMULATOR_ARCH: x86_64
+  # The tests assert against real on-screen layout (tap targets, scroll deltas), so the device
+  # profile is part of the test contract, not a default to inherit — the emulator-runner action's
+  # own default (no `profile:`) is a 320x640 mdpi device, nothing like a real phone. pixel_6
+  # matches the profile docs/how-to/setup-android.md has contributors create locally
+  # (1080x2400 @420dpi), so CI and a dev box assert against the same geometry.
+  EMULATOR_PROFILE: pixel_6
 
 jobs:
   android:
@@ -83,7 +89,10 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-${{ env.API_LEVEL }}-${{ env.EMULATOR_TARGET }}-${{ env.EMULATOR_ARCH }}
+          # The profile is part of this key: an AVD cached under a key that doesn't mention it
+          # would restore silently with whatever profile happened to create it, defeating
+          # EMULATOR_PROFILE below without any signal that it happened.
+          key: avd-${{ env.API_LEVEL }}-${{ env.EMULATOR_TARGET }}-${{ env.EMULATOR_ARCH }}-${{ env.EMULATOR_PROFILE }}
 
       - name: Create the AVD snapshot (cache miss only)
         if: steps.avd-cache.outputs.cache-hit != 'true'
@@ -92,6 +101,7 @@ jobs:
           api-level: ${{ env.API_LEVEL }}
           target: ${{ env.EMULATOR_TARGET }}
           arch: ${{ env.EMULATOR_ARCH }}
+          profile: ${{ env.EMULATOR_PROFILE }}
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
@@ -106,6 +116,7 @@ jobs:
           api-level: ${{ env.API_LEVEL }}
           target: ${{ env.EMULATOR_TARGET }}
           arch: ${{ env.EMULATOR_ARCH }}
+          profile: ${{ env.EMULATOR_PROFILE }}
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
@@ -130,7 +141,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-${{ env.API_LEVEL }}-${{ env.EMULATOR_TARGET }}-${{ env.EMULATOR_ARCH }}
+          key: avd-${{ env.API_LEVEL }}-${{ env.EMULATOR_TARGET }}-${{ env.EMULATOR_ARCH }}-${{ env.EMULATOR_PROFILE }}
 
       - name: Upload failure diagnostics
         if: failure()

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -196,7 +196,8 @@ jobs:
   android-lifecycle:
     name: Managed AVD lifecycle (glass boots its own)
     runs-on: Android-CI
-    timeout-minutes: 30
+    # Budget: 5min boot timeout + SDK/system-image setup + cold-cache cargo build + reuse/cleanup.
+    timeout-minutes: 15
     # No `needs:` — this is independent of the device suite and should still report if that fails.
     # Deliberately does NOT use android-emulator-runner: that action boots the emulator and runs
     # your script inside it, which is the exact precondition managed_avd requires to be absent.
@@ -221,14 +222,50 @@ jobs:
 
       - name: Install the system image and define an AVD, without booting it
         run: |
+          set +e
           img="system-images;android-${API_LEVEL};${EMULATOR_TARGET};${EMULATOR_ARCH}"
           yes | sdkmanager --licenses > /dev/null 2>&1 || true
           sdkmanager "platform-tools" "emulator" "$img"
+
           # --device matches EMULATOR_PROFILE so this AVD is the same device as the "android"
           # job's, not whatever avdmanager would otherwise default to.
           echo no | avdmanager create avd -n glass -k "$img" --device "$EMULATOR_PROFILE" --force
+          rc=$?
+          echo "avdmanager exit code: $rc"
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::avdmanager create avd failed (exit $rc)"
+            exit "$rc"
+          fi
+
+          # avdmanager warns and continues rather than failing, so exit 0 above is not proof the
+          # AVD exists where glass looks (crates/glass-android/src/sdk.rs resolve_sdk_root,
+          # avd.rs resolve_emulator_bin).
+          echo "--- AVD-location env vars ---"
+          echo "ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT:-<unset>}"
+          echo "ANDROID_HOME=${ANDROID_HOME:-<unset>}"
+          echo "ANDROID_AVD_HOME=${ANDROID_AVD_HOME:-<unset>}"
+          echo "ANDROID_SDK_HOME=${ANDROID_SDK_HOME:-<unset>}"
+          echo "ANDROID_USER_HOME=${ANDROID_USER_HOME:-<unset>}"
+          echo "HOME=${HOME:-<unset>}"
+          echo "--- avdmanager's own view ---"
+          avdmanager list avd
+          echo "--- \$HOME/.android/avd contents ---"
+          ls -la "$HOME/.android/avd" 2>&1
+
+          # Matches glass's own resolution exactly: GLASS_EMULATOR is unset here, so
+          # resolve_emulator_bin falls through to $ANDROID_SDK_ROOT/emulator/emulator, and
+          # boot_avd parses this binary's -list-avds — not avdmanager's or adb's.
+          avds="$("$ANDROID_SDK_ROOT/emulator/emulator" -list-avds)"
+          echo "--- emulator -list-avds output ---"
+          echo "$avds"
+          if ! echo "$avds" | grep -qx glass; then
+            echo "::error::AVD 'glass' is not in \`\$ANDROID_SDK_ROOT/emulator/emulator -list-avds\` output — this is exactly what glass's boot_avd calls, so the test would fail with an empty AVD list regardless of what avdmanager or adb reported"
+            exit 1
+          fi
+
           # Prove nothing is running: the test's subject is the boot itself.
           "$ANDROID_SDK_ROOT/platform-tools/adb" devices
+          exit 0
 
       - name: Run the lifecycle test
         env:
@@ -241,9 +278,23 @@ jobs:
           rc=$?
           if [ $rc -ne 0 ]; then
             mkdir -p diagnostics
-            "$GLASS_ADB" devices              > diagnostics/adb-devices.txt 2>&1
-            "$GLASS_ADB" logcat -d            > diagnostics/logcat.txt      2>&1
-            ls -la "$HOME/.android/avd"       > diagnostics/avd-dir.txt     2>&1
+            {
+              echo "ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT:-<unset>}"
+              echo "ANDROID_HOME=${ANDROID_HOME:-<unset>}"
+              echo "ANDROID_AVD_HOME=${ANDROID_AVD_HOME:-<unset>}"
+              echo "ANDROID_SDK_HOME=${ANDROID_SDK_HOME:-<unset>}"
+              echo "ANDROID_USER_HOME=${ANDROID_USER_HOME:-<unset>}"
+              echo "HOME=${HOME:-<unset>}"
+            } > diagnostics/env.txt 2>&1
+            # timeout-bounded: unlike `adb devices`, `adb logcat` blocks waiting for a device
+            # instead of returning empty — exactly this job's failure mode. Without the
+            # `timeout`, this once hung 28min until the job was cancelled, skipping upload
+            # entirely.
+            timeout 10 "$ANDROID_SDK_ROOT/emulator/emulator" -list-avds > diagnostics/emulator-list-avds.txt 2>&1
+            timeout 10 "$GLASS_ADB" devices                             > diagnostics/adb-devices.txt      2>&1
+            timeout 10 "$GLASS_ADB" logcat -d                           > diagnostics/logcat.txt           2>&1
+            ls -la "$HOME/.android/avd"                                 > diagnostics/avd-dir.txt          2>&1
+            find "$HOME/.android" -maxdepth 3 -iname '*.log'            > diagnostics/android-home-logs.txt 2>&1
           fi
           exit $rc
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -25,14 +25,17 @@ name: Android
 
 on:
   schedule:
-    - cron: '0 9 * * *'   # 02:00 PT
+    - cron: '0 9 * * *'   # 09:00 UTC (02:00 PT in summer, 01:00 in winter)
   workflow_dispatch:
   push:
     branches: [master]
 
 concurrency:
+  # One group covers the schedule, push:master and dispatch, so cancelling would let a merge
+  # landing mid-nightly kill it, with no artifacts and no failure to show for it. ci.yml cancels
+  # because it gates a PR; this leg detects, so it follows release.yml.
   group: android-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -100,8 +103,8 @@ jobs:
       # not a rebuild, and re-adding this whole section later would be more churn than this comment.
       # Remove the --skip in scripts/test-android.sh and this section is live again with no other
       # change needed.
-      - name: Cache the built fixture APK
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Restore the fixture APK cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: fixture-cache
         with:
           path: ~/glass-fixture
@@ -124,6 +127,7 @@ jobs:
           cache: gradle
 
       - name: Build the fixture APK (cache miss only)
+        id: fixture-build
         # Built from source rather than downloaded: the fixture is a test artifact with no
         # user-facing form, so it does not belong on the release page docs point users at. The
         # jar and a11y APK go the other way for the mirror-image reason — see the step above.
@@ -139,7 +143,12 @@ jobs:
           cp fixture-compose/build/outputs/apk/debug/fixture-compose-debug.apk "$HOME/glass-fixture/"
 
       - name: Point the suite at the fixture
-        run: echo "GLASS_ANDROID_FIXTURE_APK=$HOME/glass-fixture/fixture-compose-debug.apk" >> "$GITHUB_ENV"
+        # A cache hit restores the path without proving what is in it; check rather than hand the
+        # suite a variable pointing at nothing.
+        run: |
+          apk="$HOME/glass-fixture/fixture-compose-debug.apk"
+          test -f "$apk"
+          echo "GLASS_ANDROID_FIXTURE_APK=$apk" >> "$GITHUB_ENV"
 
       - name: Restore the AVD cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -150,8 +159,11 @@ jobs:
             ~/.android/adb*
           # The profile is part of this key: an AVD cached under a key that doesn't mention it
           # would restore silently with whatever profile happened to create it, defeating
-          # EMULATOR_PROFILE below without any signal that it happened.
-          key: avd-${{ env.API_LEVEL }}-${{ env.EMULATOR_TARGET }}-${{ env.EMULATOR_ARCH }}-${{ env.EMULATOR_PROFILE }}
+          # EMULATOR_PROFILE below without any signal that it happened. The workflow hash covers
+          # the rest of what decides what the cached AVD *is* — the emulator-runner action SHA,
+          # the create step's emulator-options, disable-animations. Without it the entry never
+          # self-corrects: the nightly refreshes the LRU clock and save is skipped on a hit.
+          key: avd-${{ env.API_LEVEL }}-${{ env.EMULATOR_TARGET }}-${{ env.EMULATOR_ARCH }}-${{ env.EMULATOR_PROFILE }}-${{ hashFiles('.github/workflows/android.yml') }}
 
       - name: Create the AVD snapshot (cache miss only)
         if: steps.avd-cache.outputs.cache-hit != 'true'
@@ -171,6 +183,10 @@ jobs:
         env:
           # The 120s default was tuned on a warm dev box, not a cold runner.
           GLASS_EMULATOR_BOOT_TIMEOUT_MS: '300000'
+          # This job's device is the action's. glass defaults to attach-or-boot, so if that
+          # emulator dies mid-suite glass would quietly boot its own and the remaining tests
+          # would pass against a different device.
+          GLASS_ANDROID_LIFECYCLE: attach
         with:
           api-level: ${{ env.API_LEVEL }}
           target: ${{ env.EMULATOR_TARGET }}
@@ -188,6 +204,17 @@ jobs:
           # later step has no adb to talk to.
           script: ./scripts/ci-android-suite.sh
 
+      - name: Save the fixture APK cache
+        # Split from the restore above for the same reason as the AVD pair: the fixture comes
+        # from the build step, not from the test run, so a failing suite is no reason to rebuild
+        # it next time. Skipped on a hit (no longer automatic once split) and when the build that
+        # produces the path was skipped or failed — cache/save errors on a path that isn't there.
+        if: always() && steps.fixture-cache.outputs.cache-hit != 'true' && steps.fixture-build.outcome == 'success'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/glass-fixture
+          key: glass-fixture-${{ env.AGENT_TAG }}
+
       - name: Save the AVD cache
         # Runs even on a failed suite: the AVD snapshot this caches comes from the earlier
         # "Create the AVD snapshot" step, not from the test run, so a failing suite is no reason
@@ -200,7 +227,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-${{ env.API_LEVEL }}-${{ env.EMULATOR_TARGET }}-${{ env.EMULATOR_ARCH }}-${{ env.EMULATOR_PROFILE }}
+          key: avd-${{ env.API_LEVEL }}-${{ env.EMULATOR_TARGET }}-${{ env.EMULATOR_ARCH }}-${{ env.EMULATOR_PROFILE }}-${{ hashFiles('.github/workflows/android.yml') }}
 
       - name: Upload failure diagnostics
         if: failure()
@@ -336,5 +363,5 @@ jobs:
         with:
           name: android-lifecycle-diagnostics-${{ github.run_id }}
           path: diagnostics/
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,23 +1,34 @@
 name: Android
 
-# WHY THIS NEVER RUNS ON PULL REQUESTS
+# WHY THIS RUNS ON A SCHEDULE AND NOT ON PULL REQUESTS
 #
-# glass CI goes green in 3-4 minutes; its longest job (AT-SPI) is 3m. This leg cannot approach
-# that. Cold-booting an emulator is a 4-6 minute floor before a single test runs, and the device
-# tests are serialized by construction (--test-threads=1, one attached device, and an on-device
-# a11y service that accepts one connection at a time). End to end this leg is ~10-18 minutes.
+# Not because it is slow. A warm run is ~3-4 minutes, comparable to the rest of CI: the device
+# suite and the lifecycle job run in parallel at roughly 3m and 2m, and the tests themselves
+# total ~70 seconds. Almost all of the cost is setup, and the AVD snapshot is cached.
 #
-# That gap does not close with tuning, so there is no promotion path and this will not become a
-# required check. What the leg buys is detection with attribution: the push-to-master trigger
-# names the merge that broke Android within ~15 minutes, instead of "someone will notice when
-# they next run the suite by hand". It does not prevent a bad merge. See glass#320.
+# The reasons it stays off pull requests:
+#
+#   - A cache miss is not 3 minutes. A cold run pays full AVD creation, and bumping AGENT_TAG
+#     additionally pays a JDK install and a Gradle fixture build -- landing on whichever PR
+#     happens to follow an eviction or an agent release.
+#   - These are larger-runner minutes, billed per run, multiplied by every push to every branch.
+#   - The suite's flake profile is young. Bringing it up found three separate intermittent
+#     tests; two were fixed by bounded polling, one is excluded pending glass#324.
+#   - It does not yet cover everything it should: two tests are excluded (glass#323, glass#324),
+#     and #324 is the native-invoke path glass#320 cared most about.
+#
+# So this detects rather than prevents. A PR that drops every click to a pointer tap still
+# merges green; the push-to-master trigger then names the merge that broke it, within minutes,
+# instead of whenever someone next runs the suite by hand. See glass#320.
+#
+# Worth revisiting once glass#324 is fixed and there is real nightly history.
 
 on:
   schedule:
     - cron: '0 9 * * *'   # 02:00 PT
   workflow_dispatch:
   push:
-    branches: [master, android-ci-leg]   # android-ci-leg is temporary; removed in Task 7
+    branches: [master]
 
 concurrency:
   group: android-${{ github.ref }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -82,6 +82,47 @@ jobs:
             echo "GLASS_ADB=$ANDROID_SDK_ROOT/platform-tools/adb"
           } >> "$GITHUB_ENV"
 
+      - name: Cache the built fixture APK
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        id: fixture-cache
+        with:
+          path: ~/glass-fixture
+          key: glass-fixture-${{ env.AGENT_TAG }}
+
+      - name: Check out the agent repo to build the fixture (cache miss only)
+        if: steps.fixture-cache.outputs.cache-hit != 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: fixed-width/glass-android-agent
+          ref: ${{ env.AGENT_TAG }}
+          path: agent-src
+
+      - name: Set up JDK 17 for the fixture build (cache miss only)
+        if: steps.fixture-cache.outputs.cache-hit != 'true'
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Build the fixture APK (cache miss only)
+        # Built from source rather than downloaded: the fixture is a test artifact with no
+        # user-facing form, so it does not belong on the release page docs point users at. The
+        # jar and a11y APK go the other way for the mirror-image reason — see the step above.
+        # The cache key is the agent tag, so this runs once per agent release and never again.
+        if: steps.fixture-cache.outputs.cache-hit != 'true'
+        run: |
+          sdk="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
+          yes | "$sdk" --licenses > /dev/null 2>&1 || true
+          "$sdk" "platforms;android-34" "build-tools;34.0.0"
+          cd agent-src
+          ./gradlew :fixture-compose:assembleDebug
+          mkdir -p "$HOME/glass-fixture"
+          cp fixture-compose/build/outputs/apk/debug/fixture-compose-debug.apk "$HOME/glass-fixture/"
+
+      - name: Point the suite at the fixture
+        run: echo "GLASS_ANDROID_FIXTURE_APK=$HOME/glass-fixture/fixture-compose-debug.apk" >> "$GITHUB_ENV"
+
       - name: Restore the AVD cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: avd-cache
@@ -127,7 +168,7 @@ jobs:
           # reason; its own header has the full account. It can't be a separate `if: failure()`
           # step afterwards either: the action shuts the device down when this step ends, so a
           # later step has no adb to talk to.
-          script: ./scripts/ci-android-suite.sh --skip native_invoke_actuates_the_fixture
+          script: ./scripts/ci-android-suite.sh
 
       - name: Save the AVD cache
         # Runs even on a failed suite: the AVD snapshot this caches comes from the earlier

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,134 @@
+name: Android
+
+# WHY THIS NEVER RUNS ON PULL REQUESTS
+#
+# glass CI goes green in 3-4 minutes; its longest job (AT-SPI) is 3m. This leg cannot approach
+# that. Cold-booting an emulator is a 4-6 minute floor before a single test runs, and the device
+# tests are serialized by construction (--test-threads=1, one attached device, and an on-device
+# a11y service that accepts one connection at a time). End to end this leg is ~10-18 minutes.
+#
+# That gap does not close with tuning, so there is no promotion path and this will not become a
+# required check. What the leg buys is detection with attribution: the push-to-master trigger
+# names the merge that broke Android within ~15 minutes, instead of "someone will notice when
+# they next run the suite by hand". It does not prevent a bad merge. See glass#320.
+
+on:
+  schedule:
+    - cron: '0 9 * * *'   # 02:00 PT
+  workflow_dispatch:
+  push:
+    branches: [master, android-ci-leg]   # android-ci-leg is temporary; removed in Task 7
+
+concurrency:
+  group: android-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  AGENT_TAG: v0.6.0
+  API_LEVEL: '34'
+  EMULATOR_TARGET: google_apis
+  EMULATOR_ARCH: x86_64
+
+jobs:
+  android:
+    name: Android device suite (AVD)
+    runs-on: Android-CI
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install pinned toolchain
+        run: rustup show
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: .
+
+      - name: Enable KVM
+        # Hardware acceleration is available on every GitHub-hosted Linux runner, but the runner
+        # user is not in the kvm group by default.
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Fetch the companion jar + a11y APK from the pinned agent release
+        # These come from the release channel on purpose: it is the artifact users actually
+        # install (docs/how-to/setup-android.md sends them to that page), so a from-source build
+        # would be testing something nobody runs.
+        run: |
+          mkdir -p "$HOME/glass-android"
+          cd "$HOME/glass-android"
+          base="https://github.com/fixed-width/glass-android-agent/releases/download/${AGENT_TAG}"
+          for f in glass-agent.jar glass-a11y.apk; do
+            curl -fsSL -O "$base/$f"
+            curl -fsSL -O "$base/$f.sha256"
+            sha256sum -c "$f.sha256"
+          done
+          {
+            echo "GLASS_ANDROID_AGENT_JAR=$PWD/glass-agent.jar"
+            echo "GLASS_ANDROID_A11Y_APK=$PWD/glass-a11y.apk"
+            echo "GLASS_ADB=$ANDROID_SDK_ROOT/platform-tools/adb"
+          } >> "$GITHUB_ENV"
+
+      - name: Cache the AVD
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ env.API_LEVEL }}-${{ env.EMULATOR_TARGET }}-${{ env.EMULATOR_ARCH }}
+
+      - name: Create the AVD snapshot (cache miss only)
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
+        with:
+          api-level: ${{ env.API_LEVEL }}
+          target: ${{ env.EMULATOR_TARGET }}
+          arch: ${{ env.EMULATOR_ARCH }}
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "AVD snapshot generated."
+
+      - name: Run the device suite
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
+        env:
+          # The 120s default was tuned on a warm dev box, not a cold runner.
+          GLASS_EMULATOR_BOOT_TIMEOUT_MS: '300000'
+        with:
+          api-level: ${{ env.API_LEVEL }}
+          target: ${{ env.EMULATOR_TARGET }}
+          arch: ${{ env.EMULATOR_ARCH }}
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          # Diagnostics are collected INSIDE the emulator script: the action shuts the device down
+          # when this step ends, so an `if: failure()` step afterwards would have no adb to talk to.
+          script: |
+            set +e
+            ./scripts/test-android.sh --skip native_invoke_actuates_the_fixture
+            rc=$?
+            if [ $rc -ne 0 ]; then
+              mkdir -p diagnostics
+              adb logcat -d                  > diagnostics/logcat.txt         2>&1
+              adb shell dumpsys window       > diagnostics/dumpsys-window.txt 2>&1
+              adb shell dumpsys activity top > diagnostics/dumpsys-top.txt    2>&1
+              adb exec-out screencap -p      > diagnostics/screen.png         2>/dev/null
+            fi
+            exit $rc
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: android-diagnostics-${{ github.run_id }}
+          path: diagnostics/
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,24 +2,18 @@ name: Android
 
 # WHY THIS RUNS ON A SCHEDULE AND NOT ON PULL REQUESTS
 #
-# Not because it is slow. A warm run is ~3-4 minutes, comparable to the rest of CI: the device
-# suite and the lifecycle job run in parallel at roughly 3m and 2m, and the tests themselves
-# total ~70 seconds. Almost all of the cost is setup, and the AVD snapshot is cached.
+# Not for speed: a warm run is ~3-4 minutes, the two jobs in parallel, of which the tests are
+# ~70 seconds. It stays off pull requests because:
 #
-# The reasons it stays off pull requests:
+#   - A cache miss is not 3 minutes — a cold run pays full AVD creation, and bumping AGENT_TAG
+#     also pays a JDK install and a Gradle build, landing on whichever PR follows an eviction.
+#   - These are larger-runner minutes, billed per run, on every push to every branch.
+#   - The flake profile is young: bringing this up found three intermittent tests.
+#   - Two tests are excluded (glass#323, glass#324), and #324 is the native-invoke path
+#     glass#320 cared most about.
 #
-#   - A cache miss is not 3 minutes. A cold run pays full AVD creation, and bumping AGENT_TAG
-#     additionally pays a JDK install and a Gradle fixture build -- landing on whichever PR
-#     happens to follow an eviction or an agent release.
-#   - These are larger-runner minutes, billed per run, multiplied by every push to every branch.
-#   - The suite's flake profile is young. Bringing it up found three separate intermittent
-#     tests; two were fixed by bounded polling, one is excluded pending glass#324.
-#   - It does not yet cover everything it should: two tests are excluded (glass#323, glass#324),
-#     and #324 is the native-invoke path glass#320 cared most about.
-#
-# So this detects rather than prevents. A PR that drops every click to a pointer tap still
-# merges green; the push-to-master trigger then names the merge that broke it, within minutes,
-# instead of whenever someone next runs the suite by hand. See glass#320.
+# So this detects rather than prevents: a PR that drops every click to a pointer tap still merges
+# green, and the push-to-master trigger then names the merge that broke it. See glass#320.
 #
 # Worth revisiting once glass#324 is fixed and there is real nightly history.
 
@@ -32,8 +26,7 @@ on:
 
 concurrency:
   # One group covers the schedule, push:master and dispatch, so cancelling would let a merge
-  # landing mid-nightly kill it, with no artifacts and no failure to show for it. ci.yml cancels
-  # because it gates a PR; this leg detects, so it follows release.yml.
+  # landing mid-nightly kill it — cancelled is not failed, so no artifacts and no signal.
   group: android-${{ github.ref }}
   cancel-in-progress: false
 
@@ -46,11 +39,10 @@ env:
   API_LEVEL: '34'
   EMULATOR_TARGET: google_apis
   EMULATOR_ARCH: x86_64
-  # The tests assert against real on-screen layout (tap targets, scroll deltas), so the device
-  # profile is part of the test contract, not a default to inherit — the emulator-runner action's
-  # own default (no `profile:`) is a 320x640 mdpi device, nothing like a real phone. pixel_6
-  # matches the profile docs/how-to/setup-android.md has contributors create locally
-  # (1080x2400 @420dpi), so CI and a dev box assert against the same geometry.
+  # The tests assert against real on-screen layout, so the profile is part of the test contract:
+  # the emulator-runner action's default (no `profile:`) is a 320x640 mdpi device, on which a tap
+  # aimed at a list row lands in the app bar. pixel_6 (1080x2400 @420dpi) is what
+  # docs/how-to/setup-android.md has contributors create, so CI and a dev box share geometry.
   EMULATOR_PROFILE: pixel_6
 
 jobs:
@@ -96,13 +88,10 @@ jobs:
             echo "GLASS_ADB=$ANDROID_SDK_ROOT/platform-tools/adb"
           } >> "$GITHUB_ENV"
 
-      # The steps below (through "Point the suite at the fixture") build an APK that no currently
-      # enabled test consumes: native_invoke_actuates_the_fixture, the only test that reads
-      # GLASS_ANDROID_FIXTURE_APK, is excluded by scripts/test-android.sh's --skip pending glass#324.
-      # Kept anyway, deliberately: the cache makes the marginal cost of a cache-hit run a restore,
-      # not a rebuild, and re-adding this whole section later would be more churn than this comment.
-      # Remove the --skip in scripts/test-android.sh and this section is live again with no other
-      # change needed.
+      # Do not delete as dead: the steps through "Point the suite at the fixture" build an APK no
+      # currently enabled test consumes, because its only reader —
+      # native_invoke_actuates_the_fixture — is --skipped pending glass#324. Dropping that --skip
+      # makes this section live again with no other change.
       - name: Restore the fixture APK cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: fixture-cache
@@ -129,9 +118,7 @@ jobs:
       - name: Build the fixture APK (cache miss only)
         id: fixture-build
         # Built from source rather than downloaded: the fixture is a test artifact with no
-        # user-facing form, so it does not belong on the release page docs point users at. The
-        # jar and a11y APK go the other way for the mirror-image reason — see the step above.
-        # The cache key is the agent tag, so this runs once per agent release and never again.
+        # user-facing form, so it does not belong on the release page docs point users at.
         if: steps.fixture-cache.outputs.cache-hit != 'true'
         run: |
           sdk="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
@@ -157,12 +144,10 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          # The profile is part of this key: an AVD cached under a key that doesn't mention it
-          # would restore silently with whatever profile happened to create it, defeating
-          # EMULATOR_PROFILE below without any signal that it happened. The workflow hash covers
-          # the rest of what decides what the cached AVD *is* — the emulator-runner action SHA,
-          # the create step's emulator-options, disable-animations. Without it the entry never
-          # self-corrects: the nightly refreshes the LRU clock and save is skipped on a hit.
+          # Every input that decides what the cached AVD *is* must appear here — the profile, and
+          # via the workflow hash the action SHA, emulator-options and disable-animations.
+          # Otherwise a changed device restores the old snapshot forever: the nightly refreshes
+          # the LRU clock and save is skipped on a hit, so the entry never self-corrects.
           key: avd-${{ env.API_LEVEL }}-${{ env.EMULATOR_TARGET }}-${{ env.EMULATOR_ARCH }}-${{ env.EMULATOR_PROFILE }}-${{ hashFiles('.github/workflows/android.yml') }}
 
       - name: Create the AVD snapshot (cache miss only)
@@ -195,20 +180,14 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          # `script:` cannot hold this run-then-collect logic directly: the action splits it on
-          # newlines and runs each line as its own independent `sh -c`, abandoning the rest the
-          # moment one line fails — so a later `if failed, collect diagnostics` line never runs.
-          # scripts/ci-android-suite.sh is one script, invoked as one line, for exactly that
-          # reason; its own header has the full account. It can't be a separate `if: failure()`
-          # step afterwards either: the action shuts the device down when this step ends, so a
-          # later step has no adb to talk to.
+          # Do not inline this script's contents here, and do not move the diagnostics into a
+          # later `if: failure()` step — scripts/ci-android-suite.sh's header says why both fail.
           script: ./scripts/ci-android-suite.sh
 
       - name: Save the fixture APK cache
-        # Split from the restore above for the same reason as the AVD pair: the fixture comes
-        # from the build step, not from the test run, so a failing suite is no reason to rebuild
-        # it next time. Skipped on a hit (no longer automatic once split) and when the build that
-        # produces the path was skipped or failed — cache/save errors on a path that isn't there.
+        # Runs on a failed suite: the APK comes from the build step, not the test run. Skipping on
+        # a hit is no longer automatic once restore/save are split, and cache/save errors outright
+        # on a path that isn't there.
         if: always() && steps.fixture-cache.outputs.cache-hit != 'true' && steps.fixture-build.outcome == 'success'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -216,11 +195,9 @@ jobs:
           key: glass-fixture-${{ env.AGENT_TAG }}
 
       - name: Save the AVD cache
-        # Runs even on a failed suite: the AVD snapshot this caches comes from the earlier
-        # "Create the AVD snapshot" step, not from the test run, so a failing suite is no reason
-        # to keep re-paying full AVD creation on every following run. Mirrors actions/cache's own
-        # post-save condition (skip on a cache hit) since that behavior is no longer automatic
-        # once restore/save are split.
+        # Runs even on a failed suite: the snapshot comes from "Create the AVD snapshot", not the
+        # test run, so a red suite would otherwise re-pay full AVD creation every run. Skipping on
+        # a hit is no longer automatic once restore/save are split.
         if: always() && steps.avd-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -182,10 +182,9 @@ impl ServiceClient {
     }
 
     /// Run a request, reconnecting once and re-sending when `resend` accepts the failure.
-    /// `rearm` is `None` for a request needing no served tree (`ping`) or that IS the re-arm
-    /// (`tree`); `Some(pkg)` re-serves `tree` for `pkg` on the fresh connection first and, only
-    /// once its reply confirms `pkg` is still foreground, lets `req` follow it — see
-    /// [`rearm_tree`].
+    /// `rearm` is `None` for a request that IS the re-arm (`tree`); `Some(pkg)` re-serves `tree`
+    /// for `pkg` on the fresh connection first and, only once its reply confirms `pkg` is still
+    /// foreground, lets `req` follow it — see [`rearm_tree`].
     fn call_with(
         &self,
         req: Value,
@@ -263,12 +262,6 @@ impl ServiceClient {
         )
         .map(|_| ())
         .map_err(CallFailure::into_error)
-    }
-
-    pub fn ping(&self) -> Result<()> {
-        self.call(json!({"op": "ping"}), None)
-            .map(|_| ())
-            .map_err(CallFailure::into_error)
     }
 }
 
@@ -528,8 +521,9 @@ impl A11yServiceRegistry {
         Self::default()
     }
 
-    /// Install + enable the service on `adb`'s device, forward a port, connect, ping. Returns a
-    /// connected `ServiceClient`. The apk path is resolved from env by the caller.
+    /// Install + enable the service on `adb`'s device, forward a port, and connect. Returns a
+    /// `ServiceClient` only once the service has served a window. The apk path is resolved from
+    /// env by the caller.
     pub fn ensure(&self, adb: &Adb, apk: &str) -> Result<ServiceClient> {
         install_service(adb, apk)?;
         let get = |k: &str| {
@@ -554,34 +548,27 @@ impl A11yServiceRegistry {
         } else {
             format!("{prior}:{SERVICE_COMPONENT}")
         };
-        adb.run([
-            "shell",
-            "settings",
-            "put",
-            "secure",
-            "enabled_accessibility_services",
-            &want,
-        ])?;
-        adb.run([
-            "shell",
-            "settings",
-            "put",
-            "secure",
-            "accessibility_enabled",
-            "1",
-        ])?;
+        put_enabled_services(adb, &want)?;
+        put_secure(adb, "accessibility_enabled", "1")?;
         let out = adb.run(["forward", "tcp:0", &format!("localabstract:{SOCKET}")])?;
         let port = crate::agent::parse_forward_port(&out)
             .ok_or_else(|| GlassError::Backend(format!("adb forward gave no port: {out:?}")))?;
         // From here, a failure must roll back the settings + forward, else a failed `ensure` leaks
         // an enabled service and a forward slot.
-        let client = match wait_for_service(port) {
-            Ok(c) => c,
-            Err(e) => {
-                restore_a11y(adb, prior, prior_a11y, port);
-                return Err(e);
-            }
-        };
+        let client = ready_or_restore(
+            port,
+            READY_ATTEMPT,
+            READY_ATTEMPTS,
+            &|step| {
+                // Last resort: the reinstall is what SIGKILLs the service and starts this
+                // race, and also the only step observed to bring a stuck binding back.
+                if step + 1 == READY_ATTEMPTS {
+                    install_service(adb, apk)?;
+                }
+                force_rebind(adb, &want)
+            },
+            &|| restore_a11y(adb, prior, prior_a11y, port),
+        )?;
         *self.state.lock().unwrap() = Some(Active {
             serial: adb.serial().map(str::to_string),
             port,
@@ -606,47 +593,136 @@ impl A11yServiceRegistry {
     }
 }
 
-/// Restore `enabled_accessibility_services` + `accessibility_enabled` to their prior values and
-/// remove the forwarded port. Shared by `shutdown` and the failed-`ensure` rollback. Best-effort.
-fn restore_a11y(adb: &Adb, prior_enabled: &str, prior_a11y_enabled: &str, port: u16) {
-    if prior_enabled.is_empty() {
-        // `settings put ... ""` errors ("Bad arguments"); delete to clear the list instead.
-        let _ = adb.run([
+fn put_secure(adb: &Adb, key: &str, value: &str) -> Result<()> {
+    adb.run(["shell", "settings", "put", "secure", key, value])
+        .map(|_| ())
+}
+
+/// Write `enabled_accessibility_services`. An empty list is a `delete`: `settings put ... ""`
+/// errors ("Bad arguments").
+fn put_enabled_services(adb: &Adb, list: &str) -> Result<()> {
+    if list.is_empty() {
+        adb.run([
             "shell",
             "settings",
             "delete",
             "secure",
             "enabled_accessibility_services",
-        ]);
+        ])
+        .map(|_| ())
     } else {
-        let _ = adb.run([
-            "shell",
-            "settings",
-            "put",
-            "secure",
-            "enabled_accessibility_services",
-            prior_enabled,
-        ]);
+        put_secure(adb, "enabled_accessibility_services", list)
     }
-    let _ = adb.run([
-        "shell",
-        "settings",
-        "put",
-        "secure",
-        "accessibility_enabled",
-        prior_a11y_enabled,
-    ]);
+}
+
+/// `list` with this service's component removed — the colon-separated list the platform reads.
+fn without_service(list: &str) -> String {
+    list.split(':')
+        .filter(|s| !s.is_empty() && *s != SERVICE_COMPONENT)
+        .collect::<Vec<_>>()
+        .join(":")
+}
+
+/// Make the platform tear this service's accessibility binding down and build a fresh one, by
+/// disabling and re-enabling it. The process is left alone: a restart is what glass#324 recovers
+/// from, not a remedy for it.
+fn force_rebind(adb: &Adb, enabled: &str) -> Result<()> {
+    put_secure(adb, "accessibility_enabled", "0")?;
+    put_enabled_services(adb, &without_service(enabled))?;
+    put_enabled_services(adb, enabled)?;
+    put_secure(adb, "accessibility_enabled", "1")
+}
+
+/// Restore `enabled_accessibility_services` + `accessibility_enabled` to their prior values and
+/// remove the forwarded port. Shared by `shutdown` and the failed-`ensure` rollback. Best-effort.
+fn restore_a11y(adb: &Adb, prior_enabled: &str, prior_a11y_enabled: &str, port: u16) {
+    let _ = put_enabled_services(adb, prior_enabled);
+    let _ = put_secure(adb, "accessibility_enabled", prior_a11y_enabled);
     let _ = adb.run(["forward", "--remove", &format!("tcp:{port}")]);
 }
 
-/// Connect to the forwarded service port, retrying briefly while the service binds + listens.
-pub(crate) fn wait_for_service(port: u16) -> Result<ServiceClient> {
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+/// How long ONE readiness attempt polls for a served window. On a cold-booted device readiness
+/// that succeeds at all has done so in 0.7-2.5s, and one still refused at 6s ran out a 20s budget
+/// too (glass#324).
+const READY_ATTEMPT: std::time::Duration = std::time::Duration::from_secs(6);
+const READY_POLL: std::time::Duration = std::time::Duration::from_millis(150);
+
+/// Readiness attempts [`A11yServiceRegistry::ensure`] makes, the first included: poll, force a
+/// rebind, poll, reinstall + force a rebind, poll. Three of these is 18s of polling.
+const READY_ATTEMPTS: u32 = 3;
+
+/// Wait for readiness on `port`, and when an attempt is refused for its whole budget, force the
+/// service's binding to be rebuilt and try again — `rebind(step)` for the `step`th recovery,
+/// escalating with the number. `attempts` counts the first, so it makes `attempts - 1` rebinds.
+///
+/// `restore` runs on exactly one path, giving up — here rather than at the caller so retrying
+/// cannot grow a second way out that forgets it.
+fn ready_or_restore(
+    port: u16,
+    attempt: std::time::Duration,
+    attempts: u32,
+    rebind: &dyn Fn(u32) -> Result<()>,
+    restore: &dyn Fn(),
+) -> Result<ServiceClient> {
+    let started = std::time::Instant::now();
+    let mut refusal = match wait_for_ready(port, attempt) {
+        Ok(client) => return Ok(client),
+        Err(e) => e,
+    };
+    let mut rebinds = 0u32;
+    for step in 1..attempts {
+        if let Err(e) = rebind(step) {
+            restore();
+            return Err(GlassError::Backend(format!(
+                "could not force the on-device a11y service on :{port} to rebind after {step} \
+                 readiness attempts, {}ms total: {e} — last attempt: {refusal}",
+                started.elapsed().as_millis()
+            )));
+        }
+        rebinds += 1;
+        match wait_for_ready(port, attempt) {
+            Ok(client) => return Ok(client),
+            Err(e) => refusal = e,
+        }
+    }
+    restore();
+    Err(GlassError::AccessibilityUnavailable(format!(
+        "the on-device a11y service on :{port} never served a window: {} readiness attempts of \
+         {attempt:?}, {rebinds} forced rebinds between them, {}ms total — last attempt: {refusal}",
+        rebinds + 1,
+        started.elapsed().as_millis()
+    )))
+}
+
+/// One readiness attempt against the binding currently on `port`: connect, then poll `tree`
+/// until one is served. Both gates share the one budget. The error is a message, not a
+/// `GlassError`: [`ready_or_restore`] classifies the sequence, and a variant here would nest a
+/// second "accessibility unavailable:" inside the first.
+fn wait_for_ready(
+    port: u16,
+    timeout: std::time::Duration,
+) -> std::result::Result<ServiceClient, String> {
+    let deadline = std::time::Instant::now() + timeout;
+    let client = loop {
+        match ServiceClient::connect(port) {
+            Ok(c) => break c,
+            Err(e) if std::time::Instant::now() >= deadline => {
+                return Err(format!("never accepted a connection in {timeout:?}: {e}"));
+            }
+            Err(_) => std::thread::sleep(READY_POLL),
+        }
+    };
     loop {
-        match ServiceClient::connect(port).and_then(|c| c.ping().map(|_| c)) {
-            Ok(c) => return Ok(c),
-            Err(e) if std::time::Instant::now() >= deadline => return Err(e),
-            Err(_) => std::thread::sleep(std::time::Duration::from_millis(150)),
+        // `ping` proves only that the process is up; a served tree proves the capability. The
+        // empty package asks for the active window, exactly what the reader asks for. One
+        // connection throughout — `ServiceClient` reopens its own socket when a call finds the
+        // service gone.
+        match client.tree("") {
+            Ok(_) => return Ok(client),
+            Err(e) if std::time::Instant::now() >= deadline => {
+                return Err(format!("answered but served no window in {timeout:?}: {e}"));
+            }
+            Err(_) => std::thread::sleep(READY_POLL),
         }
     }
 }
@@ -857,6 +933,7 @@ mod tests {
     use glass_core::accessibility::AxRole;
     use serde_json::json;
     use std::io::{BufRead, Write};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     fn win() -> WindowGeometry {
         WindowGeometry {
@@ -1900,6 +1977,9 @@ mod tests {
     enum OnTree {
         Serve,
         Refused(&'static str),
+        /// Refused "no active window" until the flag is set, then served: a binding that starts
+        /// serving only once something off the request path makes the platform rebuild it.
+        RefusedUntil(&'static AtomicBool),
     }
 
     /// A fake on-device service on a local TCP listener: serves `tree` from a script (the last
@@ -1931,10 +2011,12 @@ mod tests {
         fake_service_full(trees, on_action, packages, vec![OnTree::Serve])
     }
 
-    /// [`fake_service_ex`], plus `on_tree` (same indexing convention as `packages`: by how many
-    /// `tree`s have been served in total) — a served-index that resolves to `OnTree::Refused`
-    /// answers `ok:false` instead of consulting `trees`/`packages`, and does not advance
-    /// `served` or arm the connection's gate, since nothing was actually served.
+    /// [`fake_service_ex`], plus `on_tree` — indexed by how many `tree` requests have *arrived*
+    /// across every connection (last entry repeating), not by how many were served the way
+    /// `trees`/`packages` are: a refusal serves nothing, so a served-index would trap it on its
+    /// first entry and could never model a service that refuses and then starts serving. An
+    /// `OnTree::Refused` entry answers `ok:false` without consulting `trees`/`packages`, and
+    /// advances neither `served` nor the connection's gate.
     fn fake_service_full(
         trees: Vec<Value>,
         on_action: Vec<OnAction>,
@@ -1948,6 +2030,7 @@ mod tests {
         std::thread::spawn(move || {
             let mut conn = 0usize;
             let mut served = 0usize;
+            let mut requested = 0usize;
             while let Ok((sock, _)) = listener.accept() {
                 conn += 1;
                 let this_action = on_action[(conn - 1).min(on_action.len() - 1)];
@@ -1968,28 +2051,41 @@ mod tests {
                     let req: Value = serde_json::from_str(&line).expect("request is json");
                     let id = req["id"].clone();
                     let reply = match req["op"].as_str().unwrap_or_default() {
-                        "tree" => match on_tree[served.min(on_tree.len() - 1)] {
-                            OnTree::Refused(msg) => {
-                                log.lock().unwrap().push(format!("conn{conn}:tree-refused"));
-                                json!({"id": id, "ok": false, "error": msg})
-                            }
-                            OnTree::Serve => {
-                                log.lock().unwrap().push(format!("conn{conn}:tree"));
-                                let t = trees[served.min(trees.len() - 1)].clone();
-                                let pkg = &packages[served.min(packages.len() - 1)];
-                                served += 1;
-                                tree_confirmed = true;
-                                let mut reply = json!({"id": id, "ok": true, "tree": t});
-                                match pkg {
-                                    TreePackage::Echo => {
-                                        reply["package"] = req["package"].clone();
-                                    }
-                                    TreePackage::Other(p) => reply["package"] = json!(p),
-                                    TreePackage::Unnamed => {}
+                        "tree" => {
+                            let this_tree = on_tree[requested.min(on_tree.len() - 1)];
+                            requested += 1;
+                            let refusal = match this_tree {
+                                OnTree::Refused(msg) => Some(msg),
+                                OnTree::RefusedUntil(gate)
+                                    if !gate.load(std::sync::atomic::Ordering::Relaxed) =>
+                                {
+                                    Some("no active window")
                                 }
-                                reply
+                                _ => None,
+                            };
+                            match refusal {
+                                Some(msg) => {
+                                    log.lock().unwrap().push(format!("conn{conn}:tree-refused"));
+                                    json!({"id": id, "ok": false, "error": msg})
+                                }
+                                None => {
+                                    log.lock().unwrap().push(format!("conn{conn}:tree"));
+                                    let t = trees[served.min(trees.len() - 1)].clone();
+                                    let pkg = &packages[served.min(packages.len() - 1)];
+                                    served += 1;
+                                    tree_confirmed = true;
+                                    let mut reply = json!({"id": id, "ok": true, "tree": t});
+                                    match pkg {
+                                        TreePackage::Echo => {
+                                            reply["package"] = req["package"].clone();
+                                        }
+                                        TreePackage::Other(p) => reply["package"] = json!(p),
+                                        TreePackage::Unnamed => {}
+                                    }
+                                    reply
+                                }
                             }
-                        },
+                        }
                         "action" if !tree_confirmed => {
                             log.lock()
                                 .unwrap()
@@ -2174,6 +2270,268 @@ mod tests {
              for an action that never left the host): {}",
             e.into_error()
         );
+    }
+
+    #[test]
+    fn readiness_waits_for_a_served_window_not_just_a_live_socket() {
+        // glass#324. Reinstalling the APK makes Android SIGKILL the process hosting the
+        // AccessibilityService; the restart binds its socket — and answers `ping` — before the
+        // window manager has reattached a root window, so every `tree` until then is refused
+        // "no active window".
+        let (port, ops) = fake_service_full(
+            vec![compose_like()],
+            vec![OnAction::Ok],
+            vec![TreePackage::Echo],
+            vec![
+                OnTree::Refused("no active window"),
+                OnTree::Refused("no active window"),
+                OnTree::Serve,
+            ],
+        );
+        let client =
+            wait_for_ready(port, READY_ATTEMPT).expect("the third tree serves, inside the budget");
+        assert_eq!(
+            ops_of(&ops),
+            vec![
+                "conn1:tree-refused".to_string(),
+                "conn1:tree-refused".to_string(),
+                "conn1:tree".to_string(),
+            ],
+            "readiness must poll `tree` until one is served, on the one connection"
+        );
+        client
+            .tree("com.example.app")
+            .expect("the client handed back is the live, serving one");
+    }
+
+    #[test]
+    fn readiness_gives_up_within_its_budget_naming_the_refusal_not_just_the_wait() {
+        // The refusal never clears — a genuinely stuck service, not one mid-restart. The budget
+        // is what stops the retrying, and the error must carry what the device said: a bare
+        // "timed out" sends the reader hunting the host's socket, not the device's missing
+        // window.
+        let timeout = std::time::Duration::from_millis(400);
+        let (port, ops) = fake_service_full(
+            vec![compose_like()],
+            vec![OnAction::Ok],
+            vec![TreePackage::Echo],
+            vec![OnTree::Refused("no active window")],
+        );
+        let started = std::time::Instant::now();
+        let Err(e) = wait_for_ready(port, timeout) else {
+            panic!("a service that never serves a window is not ready");
+        };
+        let waited = started.elapsed();
+        assert!(
+            waited >= timeout,
+            "gave up after {waited:?}, before the budget"
+        );
+        assert!(
+            waited < timeout * 10,
+            "waited {waited:?} — the budget passed in must be the one that bounds it"
+        );
+        let msg = e.to_string();
+        assert!(msg.contains("no active window"), "{msg}");
+        let ops = ops_of(&ops);
+        assert!(
+            ops.len() > 1,
+            "one refusal is transient, not fatal — it must be retried: {ops:?}"
+        );
+        assert!(ops.iter().all(|o| o == "conn1:tree-refused"), "{ops:?}");
+    }
+
+    #[test]
+    fn the_disable_half_of_a_rebind_drops_our_service_and_keeps_the_devices_own() {
+        // The platform unbinds a service when it leaves `enabled_accessibility_services`. Leave
+        // ours in and the rebind degrades to a global `accessibility_enabled` toggle, which was
+        // seen recovering the platform's own reader without recovering our binding.
+        let other = "com.example.reader/.TalkBack";
+        assert_eq!(
+            without_service(&format!("{other}:{SERVICE_COMPONENT}")),
+            other,
+            "ours goes, the device's own stays"
+        );
+        assert_eq!(without_service(SERVICE_COMPONENT), "");
+        assert_eq!(without_service(""), "");
+    }
+
+    /// A fake service that refuses every `tree` until `gate` opens.
+    fn refusing_service(gate: &'static AtomicBool) -> (u16, Arc<Mutex<Vec<String>>>) {
+        fake_service_full(
+            vec![compose_like()],
+            vec![OnAction::Ok],
+            vec![TreePackage::Echo],
+            vec![OnTree::RefusedUntil(gate)],
+        )
+    }
+
+    #[test]
+    fn a_refused_readiness_forces_a_rebind_and_the_attempt_after_it_serves() {
+        // glass#324. The refusal is bimodal on a cold-booted device: readiness either succeeds
+        // in a couple of seconds or is still refused 20s later, and the only thing observed to
+        // clear the late case is re-establishing the service's binding.
+        static SERVING: AtomicBool = AtomicBool::new(false);
+        let (port, ops) = refusing_service(&SERVING);
+        let steps = Mutex::new(Vec::new());
+        let restores = AtomicUsize::new(0);
+        let client = ready_or_restore(
+            port,
+            std::time::Duration::from_millis(100),
+            3,
+            &|step| {
+                steps.lock().unwrap().push(step);
+                SERVING.store(true, Ordering::Relaxed);
+                Ok(())
+            },
+            &|| {
+                restores.fetch_add(1, Ordering::Relaxed);
+            },
+        )
+        .expect("the attempt after the rebind serves");
+        assert_eq!(
+            *steps.lock().unwrap(),
+            vec![1],
+            "one rebind, and no second one once readiness came back"
+        );
+        assert_eq!(
+            restores.load(Ordering::Relaxed),
+            0,
+            "readiness succeeded — rolling the device back would tear down what it just got"
+        );
+        let ops = ops_of(&ops);
+        assert_eq!(
+            ops.last().map(String::as_str),
+            Some("conn2:tree"),
+            "the serve must land on the attempt after the rebind: {ops:?}"
+        );
+        assert!(
+            ops[..ops.len() - 1]
+                .iter()
+                .all(|o| o == "conn1:tree-refused"),
+            "{ops:?}"
+        );
+        client
+            .tree("com.example.app")
+            .expect("the client handed back is the serving one");
+    }
+
+    #[test]
+    fn readiness_stops_rebinding_at_its_budget_and_says_what_it_tried() {
+        // A CI log is all anyone gets: the give-up has to name what the device said, how hard
+        // it was pushed to rebind, and over how long.
+        static NEVER: AtomicBool = AtomicBool::new(false);
+        let attempt = std::time::Duration::from_millis(200);
+        let (port, ops) = refusing_service(&NEVER);
+        let steps = Mutex::new(Vec::new());
+        let started = std::time::Instant::now();
+        let Err(e) = ready_or_restore(
+            port,
+            attempt,
+            3,
+            &|step| {
+                steps.lock().unwrap().push(step);
+                Ok(())
+            },
+            &|| {},
+        ) else {
+            panic!("a device that never serves a window is not ready");
+        };
+        let waited = started.elapsed();
+        assert_eq!(
+            *steps.lock().unwrap(),
+            vec![1, 2],
+            "a rebind between each pair of attempts, escalating, and none after the last"
+        );
+        assert!(
+            waited >= attempt * 3,
+            "gave up after {waited:?} — each attempt gets the budget it was given"
+        );
+        assert!(
+            waited < attempt * 3 * 3,
+            "waited {waited:?} — retrying must spend a bounded total, not a fresh budget each time"
+        );
+        let msg = e.to_string();
+        assert!(msg.contains("3 readiness attempts"), "{msg}");
+        assert!(msg.contains("2 forced rebinds"), "{msg}");
+        assert!(msg.contains("ms total"), "{msg}");
+        assert!(msg.contains("no active window"), "{msg}");
+        assert!(
+            ops_of(&ops).iter().all(|o| o.ends_with(":tree-refused")),
+            "{ops:?}"
+        );
+    }
+
+    #[test]
+    fn readiness_that_gives_up_restores_the_device_exactly_once() {
+        // The rollback is what keeps a failed `ensure` from leaving the service enabled and the
+        // port forwarded. Retrying is where that goes wrong: once per attempt tears down the
+        // settings the next attempt needs, and none at all leaks both.
+        static NEVER: AtomicBool = AtomicBool::new(false);
+        let (port, _ops) = refusing_service(&NEVER);
+        let steps = Mutex::new(Vec::new());
+        let restores = AtomicUsize::new(0);
+        let Err(_) = ready_or_restore(
+            port,
+            std::time::Duration::from_millis(100),
+            3,
+            &|step| {
+                steps.lock().unwrap().push(step);
+                assert_eq!(
+                    restores.load(Ordering::Relaxed),
+                    0,
+                    "a rebind after the restore would re-enable the service it just tore down"
+                );
+                Ok(())
+            },
+            &|| {
+                restores.fetch_add(1, Ordering::Relaxed);
+            },
+        ) else {
+            panic!("a device that never serves a window is not ready");
+        };
+        assert_eq!(*steps.lock().unwrap(), vec![1, 2], "every retry ran");
+        assert_eq!(
+            restores.load(Ordering::Relaxed),
+            1,
+            "the device is restored once, after the last attempt — not once per attempt"
+        );
+    }
+
+    #[test]
+    fn a_rebind_that_fails_restores_the_device_and_stops_retrying() {
+        // The other give-up path: adb itself failed. Its early return is the easiest place to
+        // leak an enabled service and a forwarded port.
+        static NEVER: AtomicBool = AtomicBool::new(false);
+        let (port, _ops) = refusing_service(&NEVER);
+        let steps = Mutex::new(Vec::new());
+        let restores = AtomicUsize::new(0);
+        let Err(e) = ready_or_restore(
+            port,
+            std::time::Duration::from_millis(100),
+            3,
+            &|step| {
+                steps.lock().unwrap().push(step);
+                Err(GlassError::Backend("device offline".into()))
+            },
+            &|| {
+                restores.fetch_add(1, Ordering::Relaxed);
+            },
+        ) else {
+            panic!("a rebind that cannot reach the device is not readiness");
+        };
+        assert_eq!(
+            *steps.lock().unwrap(),
+            vec![1],
+            "a rebind adb could not deliver is not worth repeating"
+        );
+        assert_eq!(
+            restores.load(Ordering::Relaxed),
+            1,
+            "the device must still be restored when the recovery step is what failed"
+        );
+        let msg = e.to_string();
+        assert!(msg.contains("device offline"), "{msg}");
+        assert!(msg.contains("no active window"), "{msg}");
     }
 
     #[test]

--- a/crates/glass-android/tests/input_loop.rs
+++ b/crates/glass-android/tests/input_loop.rs
@@ -37,8 +37,7 @@ fn settle() {
 // Trims the tail of a capture-and-diff cycle, which costs several times this on an AVD — that
 // cycle sets the loop's cadence, not this interval.
 const DIFF_POLL_INTERVAL: Duration = Duration::from_millis(150);
-// Several times the 800ms that wasn't enough, but still short enough to bound a genuine
-// failure.
+// Several times the 800ms that wasn't enough.
 const DIFF_POLL_DEADLINE: Duration = Duration::from_secs(6);
 // Android draws touch feedback — a pressed-state ripple, an overscroll bounce — well over
 // CHANGE_THRESHOLD_PCT and gone a moment later, so a crossing counts only once a later sample

--- a/crates/glass-android/tests/input_loop.rs
+++ b/crates/glass-android/tests/input_loop.rs
@@ -6,7 +6,11 @@
 //! Drives com.android.settings and asserts (via frame diff) that a scroll and a
 //! tap each change the screen — i.e. injection reaches the device.
 
-use glass_core::{AppSpec, MouseButton, Platform, PointerEvent, SandboxLevel};
+use glass_core::{
+    AppSpec, Frame, IgnoreMask, MouseButton, Platform, PointerEvent, Region, SandboxLevel,
+    StabilityTracker,
+};
+use std::time::{Duration, Instant};
 
 fn settings_spec() -> AppSpec {
     AppSpec {
@@ -22,36 +26,94 @@ fn settings_spec() -> AppSpec {
 }
 
 fn settle() {
-    std::thread::sleep(std::time::Duration::from_millis(800));
+    std::thread::sleep(Duration::from_millis(800));
 }
 
-// A fixed settle() here (800ms, tuned on a warm dev box) proved too tight on a cold CI
-// emulator: 2 failures in 9 runs, e.g. "tap should change the screen, got 0.05320216%" — the
-// screen had started changing but the frame was grabbed mid-transition. Poll instead: a
-// screen that never changes still fails, with the last percentage and elapsed wait reported.
+// A fixed settle() before the diff (800ms, tuned on a warm dev box) proved too tight on a cold
+// CI emulator: 2 failures in 9 runs, e.g. "tap should change the screen, got 0.05320216%" — the
+// frame was grabbed mid-transition. Polling instead must not weaken it: a screen that only
+// flashes still has to fail, hence the confirming sample below.
 
-// 150ms re-checks promptly without busy-looping against a capture-and-diff cycle.
-const DIFF_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(150);
+// Trims the tail of a capture-and-diff cycle, which costs several times this on an AVD — that
+// cycle sets the loop's cadence, not this interval.
+const DIFF_POLL_INTERVAL: Duration = Duration::from_millis(150);
 // Several times the 800ms that wasn't enough, but still short enough to bound a genuine
 // failure.
-const DIFF_POLL_DEADLINE: std::time::Duration = std::time::Duration::from_secs(6);
+const DIFF_POLL_DEADLINE: Duration = Duration::from_secs(6);
+// Android draws touch feedback — a pressed-state ripple, an overscroll bounce — well over
+// CHANGE_THRESHOLD_PCT and gone a moment later, so a crossing counts only once a later sample
+// still clears the threshold. A full second, not the ~300ms the animation runs: confirming
+// sooner caught the tail of an overscroll on an AVD.
+const CHANGE_CONFIRM_DELAY: Duration = Duration::from_secs(1);
+const CHANGE_THRESHOLD_PCT: f32 = 1.0;
+// Shared by the settle comparison and the change assertions so both judge "different" alike.
+const DIFF_TOLERANCE: u8 = 10;
+const SETTLE_FRAMES: u32 = 2;
+const SETTLE_DEADLINE: Duration = Duration::from_secs(6);
 
-/// Re-diffs `before` against a fresh capture until `changed_pct` clears `threshold` or the
-/// deadline expires. Returns the last diff and elapsed wait either way, so a timed-out call
-/// still has a diagnostic to report.
-fn diff_until_changed(
-    p: &mut glass_android::AndroidPlatform,
-    before: &glass_core::Frame,
-    threshold: f32,
-) -> (glass_core::DiffResult, std::time::Duration) {
-    let start = std::time::Instant::now();
+/// The status bar, whose clock ticks on its own: excluded from the settle comparison so an
+/// otherwise-still screen can actually read as settled.
+fn status_bar_mask(frame: &Frame) -> IgnoreMask {
+    let bar = Region {
+        x: 0,
+        y: 0,
+        width: frame.width,
+        height: (frame.height / 20).max(1),
+    };
+    IgnoreMask::new(&[bar], frame.width, frame.height).expect("status-bar mask")
+}
+
+/// Captures until [`StabilityTracker`] reports the screen has stopped moving, returning that
+/// settled frame. Panics if it is still moving at `SETTLE_DEADLINE`: a baseline taken mid-motion
+/// lets the next assertion pass on leftover motion instead of on the action under test.
+fn settled_frame(p: &mut glass_android::AndroidPlatform, what: &str) -> Frame {
+    let start = Instant::now();
+    let mut tracker: Option<StabilityTracker> = None;
+    loop {
+        let frame = p.capture_frame(None).expect("frame while settling");
+        let t = tracker.get_or_insert_with(|| {
+            StabilityTracker::with_mask(SETTLE_FRAMES, DIFF_TOLERANCE, status_bar_mask(&frame))
+        });
+        if t.observe(frame).expect("settle diff") {
+            return t.last().cloned().expect("a frame was just observed");
+        }
+        assert!(
+            start.elapsed() < SETTLE_DEADLINE,
+            "screen never settled {what}, so no trustworthy baseline: still moving after {}ms",
+            start.elapsed().as_millis()
+        );
+    }
+}
+
+/// Re-diffs `before` against fresh captures and asserts the screen changed and *stayed* changed:
+/// the first sample over `CHANGE_THRESHOLD_PCT` is confirmed by another `CHANGE_CONFIRM_DELAY`
+/// later, so a momentary flash does not satisfy it. On timeout the panic reports the largest
+/// change seen, not the last.
+fn assert_screen_changed(p: &mut glass_android::AndroidPlatform, before: &Frame, what: &str) {
+    let start = Instant::now();
+    let mut peak_pct = 0.0f32;
+    let mut confirming = false;
     loop {
         let after = p.capture_frame(None).expect("frame after action");
-        let d = glass_core::diff(before, &after, 10).expect("diff");
-        let elapsed = start.elapsed();
-        if d.changed_pct > threshold || elapsed >= DIFF_POLL_DEADLINE {
-            return (d, elapsed);
+        let pct = glass_core::diff(before, &after, DIFF_TOLERANCE)
+            .expect("diff")
+            .changed_pct;
+        peak_pct = peak_pct.max(pct);
+        if pct > CHANGE_THRESHOLD_PCT {
+            if confirming {
+                return;
+            }
+            confirming = true;
+            std::thread::sleep(CHANGE_CONFIRM_DELAY);
+            continue;
         }
+        confirming = false;
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < DIFF_POLL_DEADLINE,
+            "{what} should change the screen and keep it changed, peaked at {peak_pct}% over {}ms",
+            elapsed.as_millis()
+        );
         std::thread::sleep(DIFF_POLL_INTERVAL);
     }
 }
@@ -78,16 +140,12 @@ fn scroll_and_tap_change_the_screen() {
         modifiers: vec![],
     })
     .expect("scroll");
-    let (d, elapsed) = diff_until_changed(&mut p, &before, 1.0);
-    assert!(
-        d.changed_pct > 1.0,
-        "scroll should change the screen, got {}% after {}ms",
-        d.changed_pct,
-        elapsed.as_millis()
-    );
+    assert_screen_changed(&mut p, &before, "scroll");
 
-    // Tap a list row near the top — navigating should change the screen too.
-    let before = p.capture_frame(None).expect("frame before tap");
+    // Tap a list row near the top — navigating should change the screen too. The baseline waits
+    // for the fling to stop: Scroll is a 300ms swipe the list keeps moving after, and a mid-fling
+    // baseline would let this leg pass on that motion.
+    let before = settled_frame(&mut p, "after the scroll");
     p.send_pointer(&PointerEvent::Click {
         x: cx,
         y: geo.height as i32 / 6,
@@ -96,13 +154,7 @@ fn scroll_and_tap_change_the_screen() {
         modifiers: vec![],
     })
     .expect("tap");
-    let (d, elapsed) = diff_until_changed(&mut p, &before, 1.0);
-    assert!(
-        d.changed_pct > 1.0,
-        "tap should change the screen, got {}% after {}ms",
-        d.changed_pct,
-        elapsed.as_millis()
-    );
+    assert_screen_changed(&mut p, &before, "tap");
 
     p.stop_app().expect("stop");
     drop(p); // close the platform's agent connection (if any) first

--- a/crates/glass-android/tests/input_loop.rs
+++ b/crates/glass-android/tests/input_loop.rs
@@ -25,6 +25,37 @@ fn settle() {
     std::thread::sleep(std::time::Duration::from_millis(800));
 }
 
+// A fixed settle() here (800ms, tuned on a warm dev box) proved too tight on a cold CI
+// emulator: 2 failures in 9 runs, e.g. "tap should change the screen, got 0.05320216%" — the
+// screen had started changing but the frame was grabbed mid-transition. Poll instead: a
+// screen that never changes still fails, with the last percentage and elapsed wait reported.
+
+// 150ms re-checks promptly without busy-looping against a capture-and-diff cycle.
+const DIFF_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(150);
+// Several times the 800ms that wasn't enough, but still short enough to bound a genuine
+// failure.
+const DIFF_POLL_DEADLINE: std::time::Duration = std::time::Duration::from_secs(6);
+
+/// Re-diffs `before` against a fresh capture until `changed_pct` clears `threshold` or the
+/// deadline expires. Returns the last diff and elapsed wait either way, so a timed-out call
+/// still has a diagnostic to report.
+fn diff_until_changed(
+    p: &mut glass_android::AndroidPlatform,
+    before: &glass_core::Frame,
+    threshold: f32,
+) -> (glass_core::DiffResult, std::time::Duration) {
+    let start = std::time::Instant::now();
+    loop {
+        let after = p.capture_frame(None).expect("frame after action");
+        let d = glass_core::diff(before, &after, 10).expect("diff");
+        let elapsed = start.elapsed();
+        if d.changed_pct > threshold || elapsed >= DIFF_POLL_DEADLINE {
+            return (d, elapsed);
+        }
+        std::thread::sleep(DIFF_POLL_INTERVAL);
+    }
+}
+
 #[test]
 #[ignore = "requires a booted AVD + GLASS_ANDROID_SERIAL/GLASS_ADB"]
 fn scroll_and_tap_change_the_screen() {
@@ -47,13 +78,12 @@ fn scroll_and_tap_change_the_screen() {
         modifiers: vec![],
     })
     .expect("scroll");
-    settle();
-    let after = p.capture_frame(None).expect("frame after scroll");
-    let d = glass_core::diff(&before, &after, 10).expect("diff");
+    let (d, elapsed) = diff_until_changed(&mut p, &before, 1.0);
     assert!(
         d.changed_pct > 1.0,
-        "scroll should change the screen, got {}%",
-        d.changed_pct
+        "scroll should change the screen, got {}% after {}ms",
+        d.changed_pct,
+        elapsed.as_millis()
     );
 
     // Tap a list row near the top — navigating should change the screen too.
@@ -66,13 +96,12 @@ fn scroll_and_tap_change_the_screen() {
         modifiers: vec![],
     })
     .expect("tap");
-    settle();
-    let after = p.capture_frame(None).expect("frame after tap");
-    let d = glass_core::diff(&before, &after, 10).expect("diff");
+    let (d, elapsed) = diff_until_changed(&mut p, &before, 1.0);
     assert!(
         d.changed_pct > 1.0,
-        "tap should change the screen, got {}%",
-        d.changed_pct
+        "tap should change the screen, got {}% after {}ms",
+        d.changed_pct,
+        elapsed.as_millis()
     );
 
     p.stop_app().expect("stop");

--- a/crates/glass-android/tests/managed_avd.rs
+++ b/crates/glass-android/tests/managed_avd.rs
@@ -37,7 +37,7 @@ fn online_count() -> usize {
 // online_count() shells out to adb, so re-reading faster would mostly measure process spawns.
 const KILL_POLL_INTERVAL: Duration = Duration::from_secs(1);
 // A headless AVD went offline ~2s after kill_all on a warm dev box; 30s is headroom for a
-// loaded CI runner while still bounding a genuine failure.
+// loaded CI runner.
 const KILL_POLL_DEADLINE: Duration = Duration::from_secs(30);
 
 /// What [`await_offline`] observed. Only `confirmed` may be read as a successful shutdown;

--- a/crates/glass-android/tests/managed_avd.rs
+++ b/crates/glass-android/tests/managed_avd.rs
@@ -20,6 +20,27 @@ fn online_count() -> usize {
         .count()
 }
 
+// kill_all only sends `adb emu kill` — a fire-and-forget console command, not a wait for
+// exit — so checking online_count() right after it returns races the shutdown.
+const KILL_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+// Tearing down a QEMU process and its GPU renderer is heavier than a UI transition and can
+// run long on a cold CI runner; 30s gives that room while still bounding a genuine failure.
+const KILL_POLL_DEADLINE: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Polls `online_count()` until it reaches 0 or `KILL_POLL_DEADLINE` expires. Returns the
+/// last count and elapsed wait either way, so a timed-out call still has a diagnostic.
+fn await_offline() -> (usize, std::time::Duration) {
+    let start = std::time::Instant::now();
+    loop {
+        let n = online_count();
+        let elapsed = start.elapsed();
+        if n == 0 || elapsed >= KILL_POLL_DEADLINE {
+            return (n, elapsed);
+        }
+        std::thread::sleep(KILL_POLL_INTERVAL);
+    }
+}
+
 #[test]
 #[ignore = "requires NO running emulator + the Android SDK (GLASS_AVD)"]
 fn boots_reuses_and_cleans_up() {
@@ -48,10 +69,11 @@ fn boots_reuses_and_cleans_up() {
     agents1.shutdown(); // tear down any launched agent — these tests must not leak it
     agents2.shutdown();
     registry.kill_all();
-    std::thread::sleep(std::time::Duration::from_secs(3));
+    let (n, elapsed) = await_offline();
     assert_eq!(
-        online_count(),
+        n,
         0,
-        "kill_all should stop the booted emulator"
+        "kill_all should stop the booted emulator; still {n} online after {}ms",
+        elapsed.as_millis()
     );
 }

--- a/crates/glass-android/tests/managed_avd.rs
+++ b/crates/glass-android/tests/managed_avd.rs
@@ -7,35 +7,69 @@
 
 use glass_android::EmulatorRegistry;
 use std::process::Command;
+use std::time::{Duration, Instant};
 
 fn adb() -> String {
     std::env::var("GLASS_ADB").unwrap_or_else(|_| "adb".into())
 }
 
+/// Emulators reporting `device` to `adb devices`. Panics rather than returning 0 when adb
+/// itself fails: a server restart, an `offline`/`unauthorized` transport and a plain error all
+/// print no `\tdevice` line, so a silent 0 would read as "cleanly shut down" on exactly the
+/// runs where nothing is known.
 fn online_count() -> usize {
-    let out = Command::new(adb()).arg("devices").output().unwrap();
+    let out = Command::new(adb())
+        .arg("devices")
+        .output()
+        .unwrap_or_else(|e| panic!("run `{} devices`: {e}", adb()));
+    assert!(
+        out.status.success(),
+        "`adb devices` exited {}: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr).trim()
+    );
     String::from_utf8_lossy(&out.stdout)
         .lines()
         .filter(|l| l.contains("\tdevice"))
         .count()
 }
 
-// kill_all only sends `adb emu kill` — a fire-and-forget console command, not a wait for
-// exit — so checking online_count() right after it returns races the shutdown.
-const KILL_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
-// Tearing down a QEMU process and its GPU renderer is heavier than a UI transition and can
-// run long on a cold CI runner; 30s gives that room while still bounding a genuine failure.
-const KILL_POLL_DEADLINE: std::time::Duration = std::time::Duration::from_secs(30);
+// online_count() shells out to adb, so re-reading faster would mostly measure process spawns.
+const KILL_POLL_INTERVAL: Duration = Duration::from_secs(1);
+// A headless AVD went offline ~2s after kill_all on a warm dev box; 30s is headroom for a
+// loaded CI runner while still bounding a genuine failure.
+const KILL_POLL_DEADLINE: Duration = Duration::from_secs(30);
 
-/// Polls `online_count()` until it reaches 0 or `KILL_POLL_DEADLINE` expires. Returns the
-/// last count and elapsed wait either way, so a timed-out call still has a diagnostic.
-fn await_offline() -> (usize, std::time::Duration) {
-    let start = std::time::Instant::now();
+/// What [`await_offline`] observed. Only `confirmed` may be read as a successful shutdown;
+/// `last_count` is a diagnostic.
+struct OfflineWait {
+    confirmed: bool,
+    last_count: usize,
+    elapsed: Duration,
+}
+
+/// Polls `online_count()` until it reads 0 twice running, or `KILL_POLL_DEADLINE` expires.
+/// Polls at all because kill_all only sends `adb emu kill`, a fire-and-forget console command
+/// that does not wait for exit. Twice running because an emulator that stays up but flickers
+/// offline under load produces a lone 0.
+fn await_offline() -> OfflineWait {
+    let start = Instant::now();
+    let mut zeros_running = 0u32;
     loop {
-        let n = online_count();
+        let last_count = online_count();
+        zeros_running = if last_count == 0 {
+            zeros_running + 1
+        } else {
+            0
+        };
         let elapsed = start.elapsed();
-        if n == 0 || elapsed >= KILL_POLL_DEADLINE {
-            return (n, elapsed);
+        let confirmed = zeros_running >= 2;
+        if confirmed || elapsed >= KILL_POLL_DEADLINE {
+            return OfflineWait {
+                confirmed,
+                last_count,
+                elapsed,
+            };
         }
         std::thread::sleep(KILL_POLL_INTERVAL);
     }
@@ -69,11 +103,11 @@ fn boots_reuses_and_cleans_up() {
     agents1.shutdown(); // tear down any launched agent — these tests must not leak it
     agents2.shutdown();
     registry.kill_all();
-    let (n, elapsed) = await_offline();
-    assert_eq!(
-        n,
-        0,
-        "kill_all should stop the booted emulator; still {n} online after {}ms",
-        elapsed.as_millis()
+    let w = await_offline();
+    assert!(
+        w.confirmed,
+        "kill_all should stop the booted emulator; no two consecutive zero readings in {}ms, last read {} online",
+        w.elapsed.as_millis(),
+        w.last_count
     );
 }

--- a/crates/glass-android/tests/see_loop.rs
+++ b/crates/glass-android/tests/see_loop.rs
@@ -42,4 +42,5 @@ fn see_loop_launches_and_captures_settings() {
     p.stop_app().expect("stop");
     drop(p); // close the platform's agent connection (if any) first
     agents.shutdown(); // tear down a launched agent — these tests must not leak it
+    panic!("deliberate failure to verify CI diagnostics collection");
 }

--- a/crates/glass-android/tests/see_loop.rs
+++ b/crates/glass-android/tests/see_loop.rs
@@ -42,5 +42,4 @@ fn see_loop_launches_and_captures_settings() {
     p.stop_app().expect("stop");
     drop(p); // close the platform's agent connection (if any) first
     agents.shutdown(); // tear down a launched agent — these tests must not leak it
-    panic!("deliberate failure to verify CI diagnostics collection");
 }

--- a/crates/glass-android/tests/see_loop.rs
+++ b/crates/glass-android/tests/see_loop.rs
@@ -42,4 +42,6 @@ fn see_loop_launches_and_captures_settings() {
     p.stop_app().expect("stop");
     drop(p); // close the platform's agent connection (if any) first
     agents.shutdown(); // tear down a launched agent — these tests must not leak it
+
+    panic!("deliberate failure to verify CI diagnostics collection");
 }

--- a/crates/glass-android/tests/see_loop.rs
+++ b/crates/glass-android/tests/see_loop.rs
@@ -42,6 +42,4 @@ fn see_loop_launches_and_captures_settings() {
     p.stop_app().expect("stop");
     drop(p); // close the platform's agent connection (if any) first
     agents.shutdown(); // tear down a launched agent — these tests must not leak it
-
-    panic!("deliberate failure to verify CI diagnostics collection");
 }

--- a/docs/how-to/setup-android.md
+++ b/docs/how-to/setup-android.md
@@ -128,3 +128,23 @@ GLASS_BACKEND=android glass-mcp doctor --deep
 
 Reports `adb`, the emulator + AVDs, the online/attachable device, and the agent + a11y-service status.
 Then [connect your agent](connect-an-agent.md).
+
+## Running the device suites
+
+The Android tests are `#[ignore]`d — they need a real device. Two scripts run them the same way CI does:
+
+```bash
+# Against an already-booted emulator. Needs the jar + APKs from the sections above.
+GLASS_ADB=$HOME/android-sdk/platform-tools/adb \
+  GLASS_ANDROID_AGENT_JAR=/path/to/glass-agent.jar \
+  GLASS_ANDROID_A11Y_APK=/path/to/glass-a11y.apk \
+  GLASS_ANDROID_FIXTURE_APK=/path/to/fixture-compose-debug.apk \
+  ./scripts/test-android.sh
+
+# With NO emulator running — this one is about glass booting its own.
+ANDROID_SDK_ROOT=$HOME/android-sdk GLASS_AVD=glass ./scripts/test-android-lifecycle.sh
+```
+
+The role-histogram probes in `crates/glass-android/tests/role_probe.rs` are deliberately not in
+either script; they print evidence for a human rather than asserting, and take
+`GLASS_A11Y_PROBE_APPS`. Run them by hand when mapping new widget classes.

--- a/docs/how-to/setup-android.md
+++ b/docs/how-to/setup-android.md
@@ -149,6 +149,12 @@ GLASS_ADB=$HOME/android-sdk/platform-tools/adb \
 ANDROID_SDK_ROOT=$HOME/android-sdk GLASS_AVD=glass ./scripts/test-android-lifecycle.sh
 ```
 
+Two tests are skipped by default: `set_value_reports_whether_the_write_landed`
+([#323](https://github.com/fixed-width/glass/issues/323)) and
+`native_invoke_actuates_the_fixture` ([#324](https://github.com/fixed-width/glass/issues/324)).
+The second is the only consumer of `GLASS_ANDROID_FIXTURE_APK`, so that variable matters only once
+#324 lands; the jar and a11y APK are needed either way.
+
 The role-histogram probes in `crates/glass-android/tests/role_probe.rs` are deliberately not in
 either script; they print evidence for a human rather than asserting, and take
 `GLASS_A11Y_PROBE_APPS`. Run them by hand when mapping new widget classes.

--- a/docs/how-to/setup-android.md
+++ b/docs/how-to/setup-android.md
@@ -52,6 +52,10 @@ sdkmanager "system-images;android-34;google_apis;x86_64"
 avdmanager create avd -n glass -k "system-images;android-34;google_apis;x86_64" --device pixel_6
 ```
 
+> If `emulator -list-avds` doesn't list an AVD you just created, `avdmanager` and `emulator`
+> disagree on where AVDs live on your system (e.g. an XDG `~/.config/.android/avd` vs. legacy
+> `~/.android/avd` split) — set `ANDROID_AVD_HOME` to one directory so both agree.
+
 ## Managed AVD (attach-or-boot)
 
 Like Android Studio, glass prefers to attach: if an emulator is already online it uses it

--- a/scripts/ci-android-suite.sh
+++ b/scripts/ci-android-suite.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Run the Android device suite and, only on failure, collect on-device diagnostics into
+# ./diagnostics/. Exists as its own repo script rather than inline in the workflow's
+# `script:` block for two reasons:
+#
+# 1. reactivecircus/android-emulator-runner does not run `script:` as one shell session: it
+#    splits the block on newlines and runs EACH LINE as its own independent `sh -c`, and stops
+#    the moment one line exits non-zero (src/script-parser.ts + the for-loop over exec.exec in
+#    src/main.ts, at the pin this repo uses). A multi-line `run the suite; if it failed, collect
+#    diagnostics` block there is silently fragmented: the collection lines are later, unreached
+#    iterations of an already-abandoned loop, not later lines of one script. Confirmed against a
+#    real CI failure where the diagnostics step logged "No files were found" — the collection
+#    commands never ran at all. Putting the whole sequence in one script file gives the workflow
+#    a single `script:` line, which is exactly the unit that action's model handles correctly.
+#
+# 2. Collection can't be a later `if: failure()` step in the workflow either: the emulator-runner
+#    action tears the emulator down the instant its own step ends, so a subsequent step has no
+#    adb device left to talk to. It has to happen here, inside the same script invocation that
+#    ran the tests, while the emulator is still up.
+#
+# logcat is cleared before the run and dumped bounded (-t 5000) after: cleared so the failure
+# window isn't buried under whatever the AVD logged before this suite started, bounded so a run
+# that fails early doesn't wait on (or get truncated by) an oversized buffer.
+#
+#   ./scripts/ci-android-suite.sh --skip native_invoke_actuates_the_fixture
+#
+# Not -e: a failing test suite is the expected path this script exists to handle, not a bug in
+# the script — it must survive scripts/test-android.sh's failure long enough to collect
+# diagnostics and still exit with the real code afterward.
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+
+adb logcat -c
+
+./scripts/test-android.sh "$@"
+rc=$?
+
+if [ "$rc" -ne 0 ]; then
+  mkdir -p diagnostics
+  adb logcat -d -t 5000           > diagnostics/logcat.txt         2>&1
+  adb shell dumpsys window        > diagnostics/dumpsys-window.txt 2>&1
+  adb shell dumpsys activity top  > diagnostics/dumpsys-top.txt    2>&1
+  adb exec-out screencap -p       > diagnostics/screen.png         2>/dev/null
+fi
+
+exit "$rc"

--- a/scripts/ci-android-suite.sh
+++ b/scripts/ci-android-suite.sh
@@ -1,50 +1,32 @@
 #!/usr/bin/env bash
-# Run the Android device suite, always saving its output into ./diagnostics/test-output.txt, and
-# on failure also collect on-device diagnostics there. Exists as its own repo script rather than
-# inline in the workflow's
-# `script:` block for two reasons:
+# Run the Android device suite, saving its output to ./diagnostics/test-output.txt and, on
+# failure, on-device diagnostics alongside it. Do not inline this back into the workflow's
+# `script:` block, for two reasons:
 #
-# 1. reactivecircus/android-emulator-runner does not run `script:` as one shell session: it
-#    splits the block on newlines and runs EACH LINE as its own independent `sh -c`, and stops
-#    the moment one line exits non-zero (src/script-parser.ts + the for-loop over exec.exec in
-#    src/main.ts, at the pin this repo uses). A multi-line `run the suite; if it failed, collect
-#    diagnostics` block there is silently fragmented: the collection lines are later, unreached
-#    iterations of an already-abandoned loop, not later lines of one script. Confirmed against a
-#    real CI failure where the diagnostics step logged "No files were found" — the collection
-#    commands never ran at all. Putting the whole sequence in one script file gives the workflow
-#    a single `script:` line, which is exactly the unit that action's model handles correctly.
+# 1. reactivecircus/android-emulator-runner splits `script:` on newlines and runs EACH LINE as
+#    its own independent `sh -c`, stopping the moment one exits non-zero (src/script-parser.ts
+#    and the exec.exec loop in src/main.ts, at the pin this repo uses). A multi-line
+#    run-then-collect block there is silently fragmented and the collection never runs.
+# 2. Collection cannot be a later `if: failure()` step either: the action tears the emulator down
+#    the instant its own step ends, leaving no adb device to talk to.
 #
-# 2. Collection can't be a later `if: failure()` step in the workflow either: the emulator-runner
-#    action tears the emulator down the instant its own step ends, so a subsequent step has no
-#    adb device left to talk to. It has to happen here, inside the same script invocation that
-#    ran the tests, while the emulator is still up.
+# diagnostics/test-output.txt carries which test failed and why; that text otherwise exists only
+# in the ephemeral job log.
 #
-# diagnostics/test-output.txt captures the suite's own stdout/stderr: which test failed and why,
-# not just what the device was doing (the diagnostics below) — that text otherwise exists only in
-# the ephemeral job log. Captured unconditionally rather than only on failure: `tee` still streams
-# it live to the job log, and the upload step is already `if: failure()`, so a passing run costs
-# nothing either way.
+# logcat is cleared before the run so the failure window isn't buried under what the AVD logged
+# beforehand, and dumped bounded (-t 5000) so an early failure isn't truncated by an oversized
+# buffer.
 #
-# logcat is cleared before the run and dumped bounded (-t 5000) after: cleared so the failure
-# window isn't buried under whatever the AVD logged before this suite started, bounded so a run
-# that fails early doesn't wait on (or get truncated by) an oversized buffer.
-#
-# The screenshot is named screen-after-teardown.png, not screen.png, because that is genuinely
-# what it is: scripts/test-android.sh has already returned by the time this fires, so whatever app
-# the failing test was mid-interaction with may have already been torn down — for a test that
-# stops its own app under test, the capture shows the launcher and proves nothing about the
-# failure. It is kept anyway because it is the fastest available signal for whole-device failures
-# (the emulator never booted, a black screen, a stuck ANR/crash dialog, sitting on the lock
-# screen) — exactly the cases where logcat is largest and least focused. The name states when it
-# was taken so it can't be mistaken for a frame at the moment of failure.
+# screen-after-teardown.png is named for when it is taken: test-android.sh has already returned,
+# so a test that stops its own app leaves only the launcher on screen. Kept because it is the
+# fastest signal for whole-device failures — never booted, black screen, stuck ANR dialog, lock
+# screen — where logcat is largest and least focused.
 #
 #   ./scripts/ci-android-suite.sh [extra cargo-test filters]
 #
-# Not -e: a failing test suite is the expected path this script exists to handle, not a bug in
-# the script — it must survive scripts/test-android.sh's failure long enough to collect
-# diagnostics and still exit with the real code afterward. Piping through `tee` below normally
-# replaces $? with tee's own status; PIPESTATUS[0] is used instead so rc is the test command's
-# exit code even if tee itself fails (pipefail alone would not guarantee that).
+# Do not add -e: this script must survive test-android.sh's failure to collect diagnostics. Piping
+# through `tee` replaces $? with tee's status, so rc comes from PIPESTATUS[0] (pipefail alone
+# would not guarantee it).
 set -uo pipefail
 cd "$(dirname "$0")/.." || exit 1
 

--- a/scripts/ci-android-suite.sh
+++ b/scripts/ci-android-suite.sh
@@ -38,7 +38,7 @@
 # screen) — exactly the cases where logcat is largest and least focused. The name states when it
 # was taken so it can't be mistaken for a frame at the moment of failure.
 #
-#   ./scripts/ci-android-suite.sh --skip native_invoke_actuates_the_fixture
+#   ./scripts/ci-android-suite.sh [extra cargo-test filters]
 #
 # Not -e: a failing test suite is the expected path this script exists to handle, not a bug in
 # the script — it must survive scripts/test-android.sh's failure long enough to collect
@@ -48,17 +48,26 @@
 set -uo pipefail
 cd "$(dirname "$0")/.." || exit 1
 
-adb logcat -c
+# Resolve adb the way the tests do, and fail here if it isn't there. Without -e, an unresolvable
+# adb below would not stop anything: each redirect would write "command not found" into a
+# diagnostics file, which then uploads and reads as collected evidence.
+adb="${GLASS_ADB:-adb}"
+if ! command -v "$adb" > /dev/null 2>&1; then
+  echo "ci-android-suite: adb not found (GLASS_ADB=${GLASS_ADB:-<unset>})" >&2
+  exit 1
+fi
+
+"$adb" logcat -c
 mkdir -p diagnostics
 
 ./scripts/test-android.sh "$@" 2>&1 | tee diagnostics/test-output.txt
 rc=${PIPESTATUS[0]}
 
 if [ "$rc" -ne 0 ]; then
-  adb logcat -d -t 5000           > diagnostics/logcat.txt         2>&1
-  adb shell dumpsys window        > diagnostics/dumpsys-window.txt 2>&1
-  adb shell dumpsys activity top  > diagnostics/dumpsys-top.txt    2>&1
-  adb exec-out screencap -p       > diagnostics/screen-after-teardown.png 2>/dev/null
+  "$adb" logcat -d -t 5000           > diagnostics/logcat.txt         2>&1
+  "$adb" shell dumpsys window        > diagnostics/dumpsys-window.txt 2>&1
+  "$adb" shell dumpsys activity top  > diagnostics/dumpsys-top.txt    2>&1
+  "$adb" exec-out screencap -p       > diagnostics/screen-after-teardown.png 2>/dev/null
 fi
 
 exit "$rc"

--- a/scripts/ci-android-suite.sh
+++ b/scripts/ci-android-suite.sh
@@ -22,6 +22,15 @@
 # window isn't buried under whatever the AVD logged before this suite started, bounded so a run
 # that fails early doesn't wait on (or get truncated by) an oversized buffer.
 #
+# The screenshot is named screen-after-teardown.png, not screen.png, because that is genuinely
+# what it is: scripts/test-android.sh has already returned by the time this fires, so whatever app
+# the failing test was mid-interaction with may have already been torn down — for a test that
+# stops its own app under test, the capture shows the launcher and proves nothing about the
+# failure. It is kept anyway because it is the fastest available signal for whole-device failures
+# (the emulator never booted, a black screen, a stuck ANR/crash dialog, sitting on the lock
+# screen) — exactly the cases where logcat is largest and least focused. The name states when it
+# was taken so it can't be mistaken for a frame at the moment of failure.
+#
 #   ./scripts/ci-android-suite.sh --skip native_invoke_actuates_the_fixture
 #
 # Not -e: a failing test suite is the expected path this script exists to handle, not a bug in
@@ -40,7 +49,7 @@ if [ "$rc" -ne 0 ]; then
   adb logcat -d -t 5000           > diagnostics/logcat.txt         2>&1
   adb shell dumpsys window        > diagnostics/dumpsys-window.txt 2>&1
   adb shell dumpsys activity top  > diagnostics/dumpsys-top.txt    2>&1
-  adb exec-out screencap -p       > diagnostics/screen.png         2>/dev/null
+  adb exec-out screencap -p       > diagnostics/screen-after-teardown.png 2>/dev/null
 fi
 
 exit "$rc"

--- a/scripts/ci-android-suite.sh
+++ b/scripts/ci-android-suite.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Run the Android device suite and, only on failure, collect on-device diagnostics into
-# ./diagnostics/. Exists as its own repo script rather than inline in the workflow's
+# Run the Android device suite, always saving its output into ./diagnostics/test-output.txt, and
+# on failure also collect on-device diagnostics there. Exists as its own repo script rather than
+# inline in the workflow's
 # `script:` block for two reasons:
 #
 # 1. reactivecircus/android-emulator-runner does not run `script:` as one shell session: it
@@ -17,6 +18,12 @@
 #    action tears the emulator down the instant its own step ends, so a subsequent step has no
 #    adb device left to talk to. It has to happen here, inside the same script invocation that
 #    ran the tests, while the emulator is still up.
+#
+# diagnostics/test-output.txt captures the suite's own stdout/stderr: which test failed and why,
+# not just what the device was doing (the diagnostics below) — that text otherwise exists only in
+# the ephemeral job log. Captured unconditionally rather than only on failure: `tee` still streams
+# it live to the job log, and the upload step is already `if: failure()`, so a passing run costs
+# nothing either way.
 #
 # logcat is cleared before the run and dumped bounded (-t 5000) after: cleared so the failure
 # window isn't buried under whatever the AVD logged before this suite started, bounded so a run
@@ -35,17 +42,19 @@
 #
 # Not -e: a failing test suite is the expected path this script exists to handle, not a bug in
 # the script — it must survive scripts/test-android.sh's failure long enough to collect
-# diagnostics and still exit with the real code afterward.
+# diagnostics and still exit with the real code afterward. Piping through `tee` below normally
+# replaces $? with tee's own status; PIPESTATUS[0] is used instead so rc is the test command's
+# exit code even if tee itself fails (pipefail alone would not guarantee that).
 set -uo pipefail
 cd "$(dirname "$0")/.." || exit 1
 
 adb logcat -c
+mkdir -p diagnostics
 
-./scripts/test-android.sh "$@"
-rc=$?
+./scripts/test-android.sh "$@" 2>&1 | tee diagnostics/test-output.txt
+rc=${PIPESTATUS[0]}
 
 if [ "$rc" -ne 0 ]; then
-  mkdir -p diagnostics
   adb logcat -d -t 5000           > diagnostics/logcat.txt         2>&1
   adb shell dumpsys window        > diagnostics/dumpsys-window.txt 2>&1
   adb shell dumpsys activity top  > diagnostics/dumpsys-top.txt    2>&1

--- a/scripts/test-android-lifecycle.sh
+++ b/scripts/test-android-lifecycle.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Run the managed-AVD lifecycle test: glass boots an emulator itself, reuses it on a second
+# resolve, and kills it on cleanup. Requires the Android SDK and an AVD definition, and requires
+# that NO emulator is already running — the test's whole subject is the boot.
+#
+#   ANDROID_SDK_ROOT=$HOME/android-sdk GLASS_ADB=$ANDROID_SDK_ROOT/platform-tools/adb \
+#     GLASS_AVD=glass ./scripts/test-android-lifecycle.sh
+#
+# Kept out of scripts/test-android.sh because that script's tests need a booted device, which is
+# exactly the precondition this one requires to be absent.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+exec cargo test -p glass-android --test managed_avd -- --ignored --test-threads=1 "$@"

--- a/scripts/test-android.sh
+++ b/scripts/test-android.sh
@@ -9,50 +9,36 @@
 #     GLASS_ANDROID_FIXTURE_APK=/path/to/fixture-compose-debug.apk \
 #     ./scripts/test-android.sh
 #
-# The jar and APKs come from the glass-android-agent repo. Three of the tests that run fail
-# loudly without them (a11y_service_loop's snapshot test, agent_loop, and a11y_loop's
-# foreground-app test) rather than self-skipping, so GLASS_ANDROID_AGENT_JAR and
-# GLASS_ANDROID_A11Y_APK are not optional. GLASS_ANDROID_FIXTURE_APK currently is: its only
-# consumer, native_invoke_actuates_the_fixture, is excluded below until glass#324 lands.
+# Three tests fail loudly without the jar and a11y APK rather than self-skipping, so neither is
+# optional. GLASS_ANDROID_FIXTURE_APK currently is: its only consumer,
+# native_invoke_actuates_the_fixture, is excluded below until glass#324 lands.
 #
-# --test-threads=1 is required, not tidiness: every test drives the one attached device, so in
-# parallel each tears down the app another is mid-interaction with.
+# --test-threads=1 is required: every test drives the one attached device, so in parallel each
+# tears down the app another is mid-interaction with.
 #
-# --no-fail-fast is required, not a debugging aid: without it cargo stops at the first failing
-# --test binary and never runs the rest, so a CI leg would need one run per failing binary to see
-# the full picture. This script's main consumer is a scheduled diagnostic leg (glass#320), where
-# the value is the complete list of what broke overnight, not the first thing that broke — so
-# every binary always runs, and cargo's own exit code still goes nonzero if any test anywhere
-# failed.
+# --no-fail-fast is required: without it cargo stops at the first failing --test binary, so a
+# scheduled run would report one failure per night instead of the night's full list.
 #
 # Two files are deliberately absent from the target list below:
 #
-#   role_probe   — a PROBE, not an assertion suite. It prints a widget-class histogram for a
-#                  human to read and needs GLASS_A11Y_PROBE_APPS to name app components. A green
-#                  run carries no information, so automating it would manufacture a signal.
-#   managed_avd  — requires NO emulator running. It asserts glass boots one itself, reuses it,
-#                  and kills it. It cannot share a run with tests that need a booted device;
-#                  scripts/test-android-lifecycle.sh runs it instead.
+#   role_probe   — prints a widget-class histogram for a human and needs GLASS_A11Y_PROBE_APPS to
+#                  name app components; a green run carries no information.
+#   managed_avd  — requires NO emulator running, so it cannot share a run with tests that need a
+#                  booted device. scripts/test-android-lifecycle.sh runs it instead.
 #
 # Two tests are filtered out below rather than excluding the whole file each belongs to:
 #
 #   set_value_reports_whether_the_write_landed (a11y_loop) — fails on a cold CI emulator with
-#   AxElementChanged(16), glass's staleness guard refusing the write because the a11y node
-#   changed between snapshot and write; passes on a warm dev box. Deterministic, not a flake.
-#   Tracked at glass#323; remove this --skip once #323 lands. While it is off the a11y write path
-#   has no device coverage at all: the only other set_value call (a11y_service_loop) is
-#   best-effort behind "if this screen has an editable field", which Settings' top screen does not.
+#   AxElementChanged(16), glass's staleness guard refusing the write; passes warm. Tracked at
+#   glass#323. While it is off the a11y write path has no device coverage: the only other
+#   set_value call (a11y_service_loop) sits behind "if this screen has an editable field", which
+#   Settings' top screen does not.
 #
-#   native_invoke_actuates_the_fixture (a11y_service_loop) — fails 4 times in 9 CI runs (~45%) on
-#   a cold emulator with Backend("agent: no active window"), at varying sites in
-#   a11y_service_loop.rs; passes warm. Tracked at glass#324; remove this --skip once #324 lands.
+#   native_invoke_actuates_the_fixture (a11y_service_loop) — fails ~45% of CI runs with
+#   Backend("agent: no active window") at varying sites; passes warm. Tracked at glass#324.
 #
-# Multiple --skip flags compose rather than the later one overriding the earlier: the test
-# harness ORs them together, so both names above are excluded. Each is matched as a SUBSTRING,
-# not an exact name — a future test whose name contains either of these would be excluded too,
-# with no signal that it was. (--exact would stop that, but it applies to every filter, including
-# the ones a caller passes through "$@".) "$@" below still forwards any further filter on top of
-# these two.
+# Multiple --skip flags compose rather than overriding. Each matches as a SUBSTRING: a future test
+# whose name contains either of these would be excluded too, with no signal that it was.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 exec cargo test --no-fail-fast -p glass-android \

--- a/scripts/test-android.sh
+++ b/scripts/test-android.sh
@@ -16,6 +16,13 @@
 # --test-threads=1 is required, not tidiness: every test drives the one attached device, so in
 # parallel each tears down the app another is mid-interaction with.
 #
+# --no-fail-fast is required, not a debugging aid: without it cargo stops at the first failing
+# --test binary and never runs the rest, so a CI leg would need one run per failing binary to see
+# the full picture. This script's main consumer is a scheduled diagnostic leg (glass#320), where
+# the value is the complete list of what broke overnight, not the first thing that broke — so
+# every binary always runs, and cargo's own exit code still goes nonzero if any test anywhere
+# failed.
+#
 # Two files are deliberately absent from the target list below:
 #
 #   role_probe   — a PROBE, not an assertion suite. It prints a widget-class histogram for a
@@ -26,7 +33,7 @@
 #                  scripts/test-android-lifecycle.sh runs it instead.
 set -euo pipefail
 cd "$(dirname "$0")/.."
-exec cargo test -p glass-android \
+exec cargo test --no-fail-fast -p glass-android \
   --test a11y_loop \
   --test a11y_service_loop \
   --test agent_loop \

--- a/scripts/test-android.sh
+++ b/scripts/test-android.sh
@@ -31,6 +31,17 @@
 #   managed_avd  — requires NO emulator running. It asserts glass boots one itself, reuses it,
 #                  and kills it. It cannot share a run with tests that need a booted device;
 #                  scripts/test-android-lifecycle.sh runs it instead.
+#
+# One test within a11y_loop is filtered out below rather than excluding the whole file:
+#
+#   set_value_reports_whether_the_write_landed — fails on a cold CI emulator with
+#   AxElementChanged(16), glass's staleness guard refusing the write because the a11y node
+#   changed between snapshot and write; passes on a warm dev box. Deterministic, not a flake.
+#   Tracked at glass#323; remove this --skip once #323 lands.
+#
+# --skip composes with the workflow's own `--skip native_invoke_actuates_the_fixture`, forwarded
+# through "$@" below: the test harness ORs multiple --skip filters together, so both apply and
+# each still removes only the one test it names.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 exec cargo test --no-fail-fast -p glass-android \
@@ -41,4 +52,4 @@ exec cargo test --no-fail-fast -p glass-android \
   --test input_loop \
   --test see_loop \
   --test window_loop \
-  -- --ignored --test-threads=1 "$@"
+  -- --ignored --test-threads=1 --skip set_value_reports_whether_the_write_landed "$@"

--- a/scripts/test-android.sh
+++ b/scripts/test-android.sh
@@ -9,9 +9,11 @@
 #     GLASS_ANDROID_FIXTURE_APK=/path/to/fixture-compose-debug.apk \
 #     ./scripts/test-android.sh
 #
-# The jar and APKs come from the glass-android-agent repo. Four tests fail loudly without them
-# (a11y_service_loop's two, agent_loop, and a11y_loop's foreground-app test) rather than
-# self-skipping, so the paths are not optional.
+# The jar and APKs come from the glass-android-agent repo. Three of the tests that run fail
+# loudly without them (a11y_service_loop's snapshot test, agent_loop, and a11y_loop's
+# foreground-app test) rather than self-skipping, so GLASS_ANDROID_AGENT_JAR and
+# GLASS_ANDROID_A11Y_APK are not optional. GLASS_ANDROID_FIXTURE_APK currently is: its only
+# consumer, native_invoke_actuates_the_fixture, is excluded below until glass#324 lands.
 #
 # --test-threads=1 is required, not tidiness: every test drives the one attached device, so in
 # parallel each tears down the app another is mid-interaction with.
@@ -37,15 +39,20 @@
 #   set_value_reports_whether_the_write_landed (a11y_loop) — fails on a cold CI emulator with
 #   AxElementChanged(16), glass's staleness guard refusing the write because the a11y node
 #   changed between snapshot and write; passes on a warm dev box. Deterministic, not a flake.
-#   Tracked at glass#323; remove this --skip once #323 lands.
+#   Tracked at glass#323; remove this --skip once #323 lands. While it is off the a11y write path
+#   has no device coverage at all: the only other set_value call (a11y_service_loop) is
+#   best-effort behind "if this screen has an editable field", which Settings' top screen does not.
 #
 #   native_invoke_actuates_the_fixture (a11y_service_loop) — fails 4 times in 9 CI runs (~45%) on
 #   a cold emulator with Backend("agent: no active window"), at varying sites in
 #   a11y_service_loop.rs; passes warm. Tracked at glass#324; remove this --skip once #324 lands.
 #
 # Multiple --skip flags compose rather than the later one overriding the earlier: the test
-# harness ORs them together, so both names above are excluded and nothing else is. "$@" below
-# still forwards any further filter a caller adds on top of these two.
+# harness ORs them together, so both names above are excluded. Each is matched as a SUBSTRING,
+# not an exact name — a future test whose name contains either of these would be excluded too,
+# with no signal that it was. (--exact would stop that, but it applies to every filter, including
+# the ones a caller passes through "$@".) "$@" below still forwards any further filter on top of
+# these two.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 exec cargo test --no-fail-fast -p glass-android \

--- a/scripts/test-android.sh
+++ b/scripts/test-android.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Run the Android device suite: the #[ignore]d tests across 7 of the 9 files in
+# crates/glass-android/tests/. Requires an already-booted emulator — this script does not
+# start one (scripts/test-android-lifecycle.sh is the one that exercises glass booting its own).
+#
+#   GLASS_ADB=$HOME/android-sdk/platform-tools/adb \
+#     GLASS_ANDROID_AGENT_JAR=/path/to/glass-agent.jar \
+#     GLASS_ANDROID_A11Y_APK=/path/to/glass-a11y.apk \
+#     GLASS_ANDROID_FIXTURE_APK=/path/to/fixture-compose-debug.apk \
+#     ./scripts/test-android.sh
+#
+# The jar and APKs come from the glass-android-agent repo. Four tests fail loudly without them
+# (a11y_service_loop's two, agent_loop, and a11y_loop's foreground-app test) rather than
+# self-skipping, so the paths are not optional.
+#
+# --test-threads=1 is required, not tidiness: every test drives the one attached device, so in
+# parallel each tears down the app another is mid-interaction with.
+#
+# Two files are deliberately absent from the target list below:
+#
+#   role_probe   — a PROBE, not an assertion suite. It prints a widget-class histogram for a
+#                  human to read and needs GLASS_A11Y_PROBE_APPS to name app components. A green
+#                  run carries no information, so automating it would manufacture a signal.
+#   managed_avd  — requires NO emulator running. It asserts glass boots one itself, reuses it,
+#                  and kills it. It cannot share a run with tests that need a booted device;
+#                  scripts/test-android-lifecycle.sh runs it instead.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+exec cargo test -p glass-android \
+  --test a11y_loop \
+  --test a11y_service_loop \
+  --test agent_loop \
+  --test doctor_loop \
+  --test input_loop \
+  --test see_loop \
+  --test window_loop \
+  -- --ignored --test-threads=1 "$@"

--- a/scripts/test-android.sh
+++ b/scripts/test-android.sh
@@ -32,16 +32,20 @@
 #                  and kills it. It cannot share a run with tests that need a booted device;
 #                  scripts/test-android-lifecycle.sh runs it instead.
 #
-# One test within a11y_loop is filtered out below rather than excluding the whole file:
+# Two tests are filtered out below rather than excluding the whole file each belongs to:
 #
-#   set_value_reports_whether_the_write_landed — fails on a cold CI emulator with
+#   set_value_reports_whether_the_write_landed (a11y_loop) — fails on a cold CI emulator with
 #   AxElementChanged(16), glass's staleness guard refusing the write because the a11y node
 #   changed between snapshot and write; passes on a warm dev box. Deterministic, not a flake.
 #   Tracked at glass#323; remove this --skip once #323 lands.
 #
-# --skip composes with the workflow's own `--skip native_invoke_actuates_the_fixture`, forwarded
-# through "$@" below: the test harness ORs multiple --skip filters together, so both apply and
-# each still removes only the one test it names.
+#   native_invoke_actuates_the_fixture (a11y_service_loop) — fails 4 times in 9 CI runs (~45%) on
+#   a cold emulator with Backend("agent: no active window"), at varying sites in
+#   a11y_service_loop.rs; passes warm. Tracked at glass#324; remove this --skip once #324 lands.
+#
+# Multiple --skip flags compose rather than the later one overriding the earlier: the test
+# harness ORs them together, so both names above are excluded and nothing else is. "$@" below
+# still forwards any further filter a caller adds on top of these two.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 exec cargo test --no-fail-fast -p glass-android \
@@ -52,4 +56,6 @@ exec cargo test --no-fail-fast -p glass-android \
   --test input_loop \
   --test see_loop \
   --test window_loop \
-  -- --ignored --test-threads=1 --skip set_value_reports_whether_the_write_landed "$@"
+  -- --ignored --test-threads=1 \
+  --skip set_value_reports_whether_the_write_landed \
+  --skip native_invoke_actuates_the_fixture "$@"


### PR DESCRIPTION
Gives glass's `#[ignore]`d Android device tests an automated home. Refs #320.

**Not ready to merge.** Held open as the base for #324 work — see "Open defects" below.

## What runs

`.github/workflows/android.yml`, nightly and on master pushes — never on pull
requests. Two independent jobs on the `Android-CI` runner:

- **`android`** — boots a cached `pixel_6` AVD (API 34, google_apis, x86_64) and
  runs the device suite via `scripts/test-android.sh`.
- **`android-lifecycle`** — creates an AVD but deliberately does not boot one, so
  `managed_avd` can assert that glass boots, reuses and tears down its own.

A warm run is ~3-4 minutes; the jobs run in parallel.

## Test coverage

Of the 14 `#[ignore]`d tests: 9 run in `android`, 1 in `android-lifecycle`, 2 are
excluded and tracked (#323, #324), and `role_probe`'s 2 stay manual — it prints a
widget-class histogram for a human to read rather than asserting, so automating it
would manufacture a signal.

## Artifacts

The companion jar and a11y APK come from the pinned `glass-android-agent`
release, sha256-verified — that is what users install. The Compose fixture is
built from source and cached on the agent tag, because it has no user-facing form
and does not belong on a download page.

## On failure

`scripts/ci-android-suite.sh` collects logcat, dumpsys window/activity, a
screenshot and the suite's own output into an uploaded artifact. Collection runs
inside the emulator step, since the action tears the device down when its step
ends.

## Test changes

Two fixed settles tuned on a warm dev box proved too tight on a cold runner and
are now bounded polls (`input_loop.rs`, `managed_avd.rs`).

Review found that a naive poll is *weaker* than the sleep it replaces: it can
latch a transient — Android's touch feedback alone clears the frame-diff
threshold — and pass while navigation is broken. Both polls therefore require the
condition to **persist** (a re-check after a delay; two consecutive readings for
the emulator count) rather than returning on first sight, and `online_count()`
now fails loudly on an adb error instead of reading it as zero. The tap's
baseline is captured from a settled screen so it cannot ride residual scroll
motion.

## Open defects

- **#324 is broader than first filed.** The `agent: no active window` error also
  hits `a11y_service_snapshot_and_actions`, which is *not* excluded — so the
  defect affects the a11y-service path generally, not just the fixture test.
- Stability sampling to date was predominantly against a **warm cached AVD**. The
  cold-AVD path is less well characterised and is where #324 has surfaced.

Requires `glass-android-agent` v0.6.0.