### PR TITLE
fix(android): make a11y-service readiness survive the reinstall rebind

### DIFF
--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -548,34 +548,27 @@ impl A11yServiceRegistry {
         } else {
             format!("{prior}:{SERVICE_COMPONENT}")
         };
-        adb.run([
-            "shell",
-            "settings",
-            "put",
-            "secure",
-            "enabled_accessibility_services",
-            &want,
-        ])?;
-        adb.run([
-            "shell",
-            "settings",
-            "put",
-            "secure",
-            "accessibility_enabled",
-            "1",
-        ])?;
+        put_enabled_services(adb, &want)?;
+        put_secure(adb, "accessibility_enabled", "1")?;
         let out = adb.run(["forward", "tcp:0", &format!("localabstract:{SOCKET}")])?;
         let port = crate::agent::parse_forward_port(&out)
             .ok_or_else(|| GlassError::Backend(format!("adb forward gave no port: {out:?}")))?;
         // From here, a failure must roll back the settings + forward, else a failed `ensure` leaks
         // an enabled service and a forward slot.
-        let client = match wait_for_service(port) {
-            Ok(c) => c,
-            Err(e) => {
-                restore_a11y(adb, prior, prior_a11y, port);
-                return Err(e);
-            }
-        };
+        let client = ready_or_restore(
+            port,
+            READY_ATTEMPT,
+            READY_ATTEMPTS,
+            &|step| {
+                // Last resort: the reinstall is what SIGKILLs the service and starts this
+                // race, and also the only step observed to bring a stuck binding back.
+                if step + 1 == READY_ATTEMPTS {
+                    install_service(adb, apk)?;
+                }
+                force_rebind(adb, &want)
+            },
+            &|| restore_a11y(adb, prior, prior_a11y, port),
+        )?;
         *self.state.lock().unwrap() = Some(Active {
             serial: adb.serial().map(str::to_string),
             port,
@@ -600,65 +593,121 @@ impl A11yServiceRegistry {
     }
 }
 
-/// Restore `enabled_accessibility_services` + `accessibility_enabled` to their prior values and
-/// remove the forwarded port. Shared by `shutdown` and the failed-`ensure` rollback. Best-effort.
-fn restore_a11y(adb: &Adb, prior_enabled: &str, prior_a11y_enabled: &str, port: u16) {
-    if prior_enabled.is_empty() {
-        // `settings put ... ""` errors ("Bad arguments"); delete to clear the list instead.
-        let _ = adb.run([
+fn put_secure(adb: &Adb, key: &str, value: &str) -> Result<()> {
+    adb.run(["shell", "settings", "put", "secure", key, value])
+        .map(|_| ())
+}
+
+/// Write `enabled_accessibility_services`. An empty list is a `delete`: `settings put ... ""`
+/// errors ("Bad arguments").
+fn put_enabled_services(adb: &Adb, list: &str) -> Result<()> {
+    if list.is_empty() {
+        adb.run([
             "shell",
             "settings",
             "delete",
             "secure",
             "enabled_accessibility_services",
-        ]);
+        ])
+        .map(|_| ())
     } else {
-        let _ = adb.run([
-            "shell",
-            "settings",
-            "put",
-            "secure",
-            "enabled_accessibility_services",
-            prior_enabled,
-        ]);
+        put_secure(adb, "enabled_accessibility_services", list)
     }
-    let _ = adb.run([
-        "shell",
-        "settings",
-        "put",
-        "secure",
-        "accessibility_enabled",
-        prior_a11y_enabled,
-    ]);
+}
+
+/// `list` with this service's component removed — the colon-separated list the platform reads.
+fn without_service(list: &str) -> String {
+    list.split(':')
+        .filter(|s| !s.is_empty() && *s != SERVICE_COMPONENT)
+        .collect::<Vec<_>>()
+        .join(":")
+}
+
+/// Make the platform tear this service's accessibility binding down and build a fresh one, by
+/// disabling and re-enabling it. The process is left alone: a restart is what glass#324 recovers
+/// from, not a remedy for it.
+fn force_rebind(adb: &Adb, enabled: &str) -> Result<()> {
+    put_secure(adb, "accessibility_enabled", "0")?;
+    put_enabled_services(adb, &without_service(enabled))?;
+    put_enabled_services(adb, enabled)?;
+    put_secure(adb, "accessibility_enabled", "1")
+}
+
+/// Restore `enabled_accessibility_services` + `accessibility_enabled` to their prior values and
+/// remove the forwarded port. Shared by `shutdown` and the failed-`ensure` rollback. Best-effort.
+fn restore_a11y(adb: &Adb, prior_enabled: &str, prior_a11y_enabled: &str, port: u16) {
+    let _ = put_enabled_services(adb, prior_enabled);
+    let _ = put_secure(adb, "accessibility_enabled", prior_a11y_enabled);
     let _ = adb.run(["forward", "--remove", &format!("tcp:{port}")]);
 }
 
-/// How long [`wait_for_service`] waits for the service to bind *and* serve a window. Sized for
-/// a cold-booted device: the install just before it makes Android restart the service (glass#324),
-/// whose socket is back in a fraction of a second but whose window manager takes seconds more to
-/// reattach a root window. Overrunning only delays the caller's fall back to the uiautomator
-/// reader.
-const READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+/// How long ONE readiness attempt polls for a served window. On a cold-booted device readiness
+/// that succeeds at all has done so in 0.7-2.5s, and one still refused at 6s ran out a 20s budget
+/// too (glass#324).
+const READY_ATTEMPT: std::time::Duration = std::time::Duration::from_secs(6);
 const READY_POLL: std::time::Duration = std::time::Duration::from_millis(150);
 
-/// Connect to the forwarded service port and wait until the service can answer what the caller
-/// came for: a tree. Both gates share the one budget.
-pub(crate) fn wait_for_service(port: u16) -> Result<ServiceClient> {
-    wait_for_ready(port, READY_TIMEOUT)
+/// Readiness attempts [`A11yServiceRegistry::ensure`] makes, the first included: poll, force a
+/// rebind, poll, reinstall + force a rebind, poll. Three of these is 18s of polling.
+const READY_ATTEMPTS: u32 = 3;
+
+/// Wait for readiness on `port`, and when an attempt is refused for its whole budget, force the
+/// service's binding to be rebuilt and try again — `rebind(step)` for the `step`th recovery,
+/// escalating with the number. `attempts` counts the first, so it makes `attempts - 1` rebinds.
+///
+/// `restore` runs on exactly one path, giving up — here rather than at the caller so retrying
+/// cannot grow a second way out that forgets it.
+fn ready_or_restore(
+    port: u16,
+    attempt: std::time::Duration,
+    attempts: u32,
+    rebind: &dyn Fn(u32) -> Result<()>,
+    restore: &dyn Fn(),
+) -> Result<ServiceClient> {
+    let started = std::time::Instant::now();
+    let mut refusal = match wait_for_ready(port, attempt) {
+        Ok(client) => return Ok(client),
+        Err(e) => e,
+    };
+    let mut rebinds = 0u32;
+    for step in 1..attempts {
+        if let Err(e) = rebind(step) {
+            restore();
+            return Err(GlassError::Backend(format!(
+                "could not force the on-device a11y service on :{port} to rebind after {step} \
+                 readiness attempts, {}ms total: {e} — last attempt: {refusal}",
+                started.elapsed().as_millis()
+            )));
+        }
+        rebinds += 1;
+        match wait_for_ready(port, attempt) {
+            Ok(client) => return Ok(client),
+            Err(e) => refusal = e,
+        }
+    }
+    restore();
+    Err(GlassError::AccessibilityUnavailable(format!(
+        "the on-device a11y service on :{port} never served a window: {} readiness attempts of \
+         {attempt:?}, {rebinds} forced rebinds between them, {}ms total — last attempt: {refusal}",
+        rebinds + 1,
+        started.elapsed().as_millis()
+    )))
 }
 
-/// [`wait_for_service`] with the budget passed in, so a test watching the give-up path does not
-/// wait out the production one.
-fn wait_for_ready(port: u16, timeout: std::time::Duration) -> Result<ServiceClient> {
+/// One readiness attempt against the binding currently on `port`: connect, then poll `tree`
+/// until one is served. Both gates share the one budget. The error is a message, not a
+/// `GlassError`: [`ready_or_restore`] classifies the sequence, and a variant here would nest a
+/// second "accessibility unavailable:" inside the first.
+fn wait_for_ready(
+    port: u16,
+    timeout: std::time::Duration,
+) -> std::result::Result<ServiceClient, String> {
     let deadline = std::time::Instant::now() + timeout;
     let client = loop {
         match ServiceClient::connect(port) {
             Ok(c) => break c,
             Err(e) if std::time::Instant::now() >= deadline => {
-                return Err(GlassError::Backend(format!(
-                    "the on-device a11y service never accepted a connection on :{port} within \
-                     {timeout:?}: {e}"
-                )));
+                return Err(format!("never accepted a connection in {timeout:?}: {e}"));
             }
             Err(_) => std::thread::sleep(READY_POLL),
         }
@@ -671,10 +720,7 @@ fn wait_for_ready(port: u16, timeout: std::time::Duration) -> Result<ServiceClie
         match client.tree("") {
             Ok(_) => return Ok(client),
             Err(e) if std::time::Instant::now() >= deadline => {
-                return Err(GlassError::AccessibilityUnavailable(format!(
-                    "the on-device a11y service on :{port} answered but never served a window \
-                     within {timeout:?}: {e}"
-                )));
+                return Err(format!("answered but served no window in {timeout:?}: {e}"));
             }
             Err(_) => std::thread::sleep(READY_POLL),
         }
@@ -887,6 +933,7 @@ mod tests {
     use glass_core::accessibility::AxRole;
     use serde_json::json;
     use std::io::{BufRead, Write};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     fn win() -> WindowGeometry {
         WindowGeometry {
@@ -1930,6 +1977,9 @@ mod tests {
     enum OnTree {
         Serve,
         Refused(&'static str),
+        /// Refused "no active window" until the flag is set, then served: a binding that starts
+        /// serving only once something off the request path makes the platform rebuild it.
+        RefusedUntil(&'static AtomicBool),
     }
 
     /// A fake on-device service on a local TCP listener: serves `tree` from a script (the last
@@ -2004,12 +2054,21 @@ mod tests {
                         "tree" => {
                             let this_tree = on_tree[requested.min(on_tree.len() - 1)];
                             requested += 1;
-                            match this_tree {
-                                OnTree::Refused(msg) => {
+                            let refusal = match this_tree {
+                                OnTree::Refused(msg) => Some(msg),
+                                OnTree::RefusedUntil(gate)
+                                    if !gate.load(std::sync::atomic::Ordering::Relaxed) =>
+                                {
+                                    Some("no active window")
+                                }
+                                _ => None,
+                            };
+                            match refusal {
+                                Some(msg) => {
                                     log.lock().unwrap().push(format!("conn{conn}:tree-refused"));
                                     json!({"id": id, "ok": false, "error": msg})
                                 }
-                                OnTree::Serve => {
+                                None => {
                                     log.lock().unwrap().push(format!("conn{conn}:tree"));
                                     let t = trees[served.min(trees.len() - 1)].clone();
                                     let pkg = &packages[served.min(packages.len() - 1)];
@@ -2229,7 +2288,8 @@ mod tests {
                 OnTree::Serve,
             ],
         );
-        let client = wait_for_service(port).expect("the third tree serves, well inside the budget");
+        let client =
+            wait_for_ready(port, READY_ATTEMPT).expect("the third tree serves, inside the budget");
         assert_eq!(
             ops_of(&ops),
             vec![
@@ -2278,6 +2338,200 @@ mod tests {
             "one refusal is transient, not fatal — it must be retried: {ops:?}"
         );
         assert!(ops.iter().all(|o| o == "conn1:tree-refused"), "{ops:?}");
+    }
+
+    #[test]
+    fn the_disable_half_of_a_rebind_drops_our_service_and_keeps_the_devices_own() {
+        // The platform unbinds a service when it leaves `enabled_accessibility_services`. Leave
+        // ours in and the rebind degrades to a global `accessibility_enabled` toggle, which was
+        // seen recovering the platform's own reader without recovering our binding.
+        let other = "com.example.reader/.TalkBack";
+        assert_eq!(
+            without_service(&format!("{other}:{SERVICE_COMPONENT}")),
+            other,
+            "ours goes, the device's own stays"
+        );
+        assert_eq!(without_service(SERVICE_COMPONENT), "");
+        assert_eq!(without_service(""), "");
+    }
+
+    /// A fake service that refuses every `tree` until `gate` opens.
+    fn refusing_service(gate: &'static AtomicBool) -> (u16, Arc<Mutex<Vec<String>>>) {
+        fake_service_full(
+            vec![compose_like()],
+            vec![OnAction::Ok],
+            vec![TreePackage::Echo],
+            vec![OnTree::RefusedUntil(gate)],
+        )
+    }
+
+    #[test]
+    fn a_refused_readiness_forces_a_rebind_and_the_attempt_after_it_serves() {
+        // glass#324. The refusal is bimodal on a cold-booted device: readiness either succeeds
+        // in a couple of seconds or is still refused 20s later, and the only thing observed to
+        // clear the late case is re-establishing the service's binding.
+        static SERVING: AtomicBool = AtomicBool::new(false);
+        let (port, ops) = refusing_service(&SERVING);
+        let steps = Mutex::new(Vec::new());
+        let restores = AtomicUsize::new(0);
+        let client = ready_or_restore(
+            port,
+            std::time::Duration::from_millis(100),
+            3,
+            &|step| {
+                steps.lock().unwrap().push(step);
+                SERVING.store(true, Ordering::Relaxed);
+                Ok(())
+            },
+            &|| {
+                restores.fetch_add(1, Ordering::Relaxed);
+            },
+        )
+        .expect("the attempt after the rebind serves");
+        assert_eq!(
+            *steps.lock().unwrap(),
+            vec![1],
+            "one rebind, and no second one once readiness came back"
+        );
+        assert_eq!(
+            restores.load(Ordering::Relaxed),
+            0,
+            "readiness succeeded — rolling the device back would tear down what it just got"
+        );
+        let ops = ops_of(&ops);
+        assert_eq!(
+            ops.last().map(String::as_str),
+            Some("conn2:tree"),
+            "the serve must land on the attempt after the rebind: {ops:?}"
+        );
+        assert!(
+            ops[..ops.len() - 1]
+                .iter()
+                .all(|o| o == "conn1:tree-refused"),
+            "{ops:?}"
+        );
+        client
+            .tree("com.example.app")
+            .expect("the client handed back is the serving one");
+    }
+
+    #[test]
+    fn readiness_stops_rebinding_at_its_budget_and_says_what_it_tried() {
+        // A CI log is all anyone gets: the give-up has to name what the device said, how hard
+        // it was pushed to rebind, and over how long.
+        static NEVER: AtomicBool = AtomicBool::new(false);
+        let attempt = std::time::Duration::from_millis(200);
+        let (port, ops) = refusing_service(&NEVER);
+        let steps = Mutex::new(Vec::new());
+        let started = std::time::Instant::now();
+        let Err(e) = ready_or_restore(
+            port,
+            attempt,
+            3,
+            &|step| {
+                steps.lock().unwrap().push(step);
+                Ok(())
+            },
+            &|| {},
+        ) else {
+            panic!("a device that never serves a window is not ready");
+        };
+        let waited = started.elapsed();
+        assert_eq!(
+            *steps.lock().unwrap(),
+            vec![1, 2],
+            "a rebind between each pair of attempts, escalating, and none after the last"
+        );
+        assert!(
+            waited >= attempt * 3,
+            "gave up after {waited:?} — each attempt gets the budget it was given"
+        );
+        assert!(
+            waited < attempt * 3 * 3,
+            "waited {waited:?} — retrying must spend a bounded total, not a fresh budget each time"
+        );
+        let msg = e.to_string();
+        assert!(msg.contains("3 readiness attempts"), "{msg}");
+        assert!(msg.contains("2 forced rebinds"), "{msg}");
+        assert!(msg.contains("ms total"), "{msg}");
+        assert!(msg.contains("no active window"), "{msg}");
+        assert!(
+            ops_of(&ops).iter().all(|o| o.ends_with(":tree-refused")),
+            "{ops:?}"
+        );
+    }
+
+    #[test]
+    fn readiness_that_gives_up_restores_the_device_exactly_once() {
+        // The rollback is what keeps a failed `ensure` from leaving the service enabled and the
+        // port forwarded. Retrying is where that goes wrong: once per attempt tears down the
+        // settings the next attempt needs, and none at all leaks both.
+        static NEVER: AtomicBool = AtomicBool::new(false);
+        let (port, _ops) = refusing_service(&NEVER);
+        let steps = Mutex::new(Vec::new());
+        let restores = AtomicUsize::new(0);
+        let Err(_) = ready_or_restore(
+            port,
+            std::time::Duration::from_millis(100),
+            3,
+            &|step| {
+                steps.lock().unwrap().push(step);
+                assert_eq!(
+                    restores.load(Ordering::Relaxed),
+                    0,
+                    "a rebind after the restore would re-enable the service it just tore down"
+                );
+                Ok(())
+            },
+            &|| {
+                restores.fetch_add(1, Ordering::Relaxed);
+            },
+        ) else {
+            panic!("a device that never serves a window is not ready");
+        };
+        assert_eq!(*steps.lock().unwrap(), vec![1, 2], "every retry ran");
+        assert_eq!(
+            restores.load(Ordering::Relaxed),
+            1,
+            "the device is restored once, after the last attempt — not once per attempt"
+        );
+    }
+
+    #[test]
+    fn a_rebind_that_fails_restores_the_device_and_stops_retrying() {
+        // The other give-up path: adb itself failed. Its early return is the easiest place to
+        // leak an enabled service and a forwarded port.
+        static NEVER: AtomicBool = AtomicBool::new(false);
+        let (port, _ops) = refusing_service(&NEVER);
+        let steps = Mutex::new(Vec::new());
+        let restores = AtomicUsize::new(0);
+        let Err(e) = ready_or_restore(
+            port,
+            std::time::Duration::from_millis(100),
+            3,
+            &|step| {
+                steps.lock().unwrap().push(step);
+                Err(GlassError::Backend("device offline".into()))
+            },
+            &|| {
+                restores.fetch_add(1, Ordering::Relaxed);
+            },
+        ) else {
+            panic!("a rebind that cannot reach the device is not readiness");
+        };
+        assert_eq!(
+            *steps.lock().unwrap(),
+            vec![1],
+            "a rebind adb could not deliver is not worth repeating"
+        );
+        assert_eq!(
+            restores.load(Ordering::Relaxed),
+            1,
+            "the device must still be restored when the recovery step is what failed"
+        );
+        let msg = e.to_string();
+        assert!(msg.contains("device offline"), "{msg}");
+        assert!(msg.contains("no active window"), "{msg}");
     }
 
     #[test]

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -641,6 +641,13 @@ fn restore_a11y(adb: &Adb, prior_enabled: &str, prior_a11y_enabled: &str, port: 
 const READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
 const READY_POLL: std::time::Duration = std::time::Duration::from_millis(150);
 
+/// How many connections [`wait_for_ready`] splits its budget across. A refusal can clear on the
+/// device — the platform's own reader was seen serving the window again — without the connection
+/// held open across the outage recovering with it, so a stuck one is replaced, not re-asked.
+/// Four gives each 5s of the 20s, longer than any readiness that went on to succeed. Do not
+/// escalate here to the reinstall that provokes the restart in the first place.
+const READY_CONNECTIONS: u32 = 4;
+
 /// Connect to the forwarded service port and wait until the service can answer what the caller
 /// came for: a tree. Both gates share the one budget.
 pub(crate) fn wait_for_service(port: u16) -> Result<ServiceClient> {
@@ -651,31 +658,56 @@ pub(crate) fn wait_for_service(port: u16) -> Result<ServiceClient> {
 /// wait out the production one.
 fn wait_for_ready(port: u16, timeout: std::time::Duration) -> Result<ServiceClient> {
     let deadline = std::time::Instant::now() + timeout;
-    let client = loop {
-        match ServiceClient::connect(port) {
-            Ok(c) => break c,
-            Err(e) if std::time::Instant::now() >= deadline => {
-                return Err(GlassError::Backend(format!(
-                    "the on-device a11y service never accepted a connection on :{port} within \
-                     {timeout:?}: {e}"
-                )));
-            }
-            Err(_) => std::thread::sleep(READY_POLL),
-        }
-    };
+    let window = timeout / READY_CONNECTIONS;
+    let mut connections = 0u32;
     loop {
-        // `ping` proves only that the process is up; a served tree proves the capability. The
-        // empty package asks for the active window, exactly what the reader asks for. One
-        // connection throughout — `ServiceClient` reopens its own socket when a call finds the
-        // service gone.
-        match client.tree("") {
-            Ok(_) => return Ok(client),
-            Err(e) if std::time::Instant::now() >= deadline => {
-                return Err(GlassError::AccessibilityUnavailable(format!(
-                    "the on-device a11y service on :{port} answered but never served a window \
-                     within {timeout:?}: {e}"
+        let client = match connect_until(port, deadline) {
+            Ok(c) => c,
+            Err(e) => {
+                let seen = if connections == 0 {
+                    "never accepted a connection".to_string()
+                } else {
+                    format!("stopped accepting connections after {connections}")
+                };
+                return Err(GlassError::Backend(format!(
+                    "the on-device a11y service {seen} on :{port} within {timeout:?}: {e}"
                 )));
             }
+        };
+        connections += 1;
+        let window_end = std::time::Instant::now() + window;
+        loop {
+            // `ping` proves only that the process is up; a served tree proves the capability. The
+            // empty package asks for the active window, exactly what the reader asks for. A `tree`
+            // is a read, so asking again — here or on a fresh connection — actuates nothing.
+            match client.tree("") {
+                Ok(_) => return Ok(client),
+                Err(e) if std::time::Instant::now() >= deadline => {
+                    return Err(GlassError::AccessibilityUnavailable(format!(
+                        "the on-device a11y service on :{port} answered but never served a window \
+                         across {connections} connections in {timeout:?}: {e}"
+                    )));
+                }
+                Err(_) => {}
+            }
+            let asked_at = std::time::Instant::now();
+            std::thread::sleep(READY_POLL.min(deadline.saturating_duration_since(asked_at)));
+            let now = std::time::Instant::now();
+            // Only worth abandoning this connection while there is budget left to ask on a
+            // fresh one; past the deadline, one more ask here gives the error its refusal.
+            if now >= window_end && now < deadline {
+                break;
+            }
+        }
+    }
+}
+
+/// Open a connection to `port`, retrying every [`READY_POLL`] until `deadline`.
+fn connect_until(port: u16, deadline: std::time::Instant) -> Result<ServiceClient> {
+    loop {
+        match ServiceClient::connect(port) {
+            Ok(c) => return Ok(c),
+            Err(e) if std::time::Instant::now() >= deadline => return Err(e),
             Err(_) => std::thread::sleep(READY_POLL),
         }
     }
@@ -2277,7 +2309,82 @@ mod tests {
             ops.len() > 1,
             "one refusal is transient, not fatal — it must be retried: {ops:?}"
         );
-        assert!(ops.iter().all(|o| o == "conn1:tree-refused"), "{ops:?}");
+        assert!(ops.iter().all(|o| o.ends_with(":tree-refused")), "{ops:?}");
+    }
+
+    /// The distinct connections `ops` was recorded across, in order of first appearance.
+    fn conns_of(ops: &[String]) -> Vec<&str> {
+        let mut seen: Vec<&str> = Vec::new();
+        for c in ops.iter().filter_map(|o| o.split(':').next()) {
+            if !seen.contains(&c) {
+                seen.push(c);
+            }
+        }
+        seen
+    }
+
+    #[test]
+    fn readiness_reconnects_when_one_connection_stays_refused() {
+        // glass#324, second half. On a cold boot the accessibility layer goes transiently
+        // unavailable and recovers, but the connection held open across the outage need not
+        // recover with it — the platform's own reader was seen serving that window again while
+        // ours kept being refused for the rest of the budget.
+        //
+        // A budget whose per-connection share is under one [`READY_POLL`] gives each connection
+        // exactly one ask, so which connection the serve lands on is the assertion, not timing.
+        let timeout = std::time::Duration::from_millis(500);
+        let (port, ops) = fake_service_full(
+            vec![compose_like()],
+            vec![OnAction::Ok],
+            vec![TreePackage::Echo],
+            vec![OnTree::Refused("no active window"), OnTree::Serve],
+        );
+        let client = wait_for_ready(port, timeout).expect("a later connection serves the window");
+        assert_eq!(
+            ops_of(&ops),
+            vec!["conn1:tree-refused".to_string(), "conn2:tree".to_string()],
+            "the serve must land on a new connection — re-polling conn1 is the bug"
+        );
+        client
+            .tree("com.example.app")
+            .expect("the client handed back is the reconnected, serving one");
+    }
+
+    #[test]
+    fn readiness_stops_reconnecting_at_the_budget_and_says_how_many_it_tried() {
+        // Reconnecting spends the one budget, not a fresh one each time, and the count has to
+        // reach the caller: a device that refused every fresh connection needs a fresh
+        // install+enable, not more retries here.
+        let timeout = std::time::Duration::from_millis(400);
+        let (port, ops) = fake_service_full(
+            vec![compose_like()],
+            vec![OnAction::Ok],
+            vec![TreePackage::Echo],
+            vec![OnTree::Refused("no active window")],
+        );
+        let started = std::time::Instant::now();
+        let Err(e) = wait_for_ready(port, timeout) else {
+            panic!("a device that never serves a window is not ready");
+        };
+        let waited = started.elapsed();
+        assert!(waited >= timeout, "gave up after {waited:?}");
+        assert!(
+            waited < timeout * 10,
+            "waited {waited:?} — reconnecting must spend the budget, not extend it"
+        );
+        let ops = ops_of(&ops);
+        let conns = conns_of(&ops);
+        assert!(
+            conns.len() > 1,
+            "a stuck connection must be replaced, not just re-asked: {ops:?}"
+        );
+        let msg = e.to_string();
+        assert!(
+            msg.contains(&format!("{} connections", conns.len())),
+            "the error must name the {} connections actually tried: {msg}",
+            conns.len()
+        );
+        assert!(msg.contains("no active window"), "{msg}");
     }
 
     #[test]

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -182,10 +182,9 @@ impl ServiceClient {
     }
 
     /// Run a request, reconnecting once and re-sending when `resend` accepts the failure.
-    /// `rearm` is `None` for a request needing no served tree (`ping`) or that IS the re-arm
-    /// (`tree`); `Some(pkg)` re-serves `tree` for `pkg` on the fresh connection first and, only
-    /// once its reply confirms `pkg` is still foreground, lets `req` follow it — see
-    /// [`rearm_tree`].
+    /// `rearm` is `None` for a request that IS the re-arm (`tree`); `Some(pkg)` re-serves `tree`
+    /// for `pkg` on the fresh connection first and, only once its reply confirms `pkg` is still
+    /// foreground, lets `req` follow it — see [`rearm_tree`].
     fn call_with(
         &self,
         req: Value,
@@ -263,12 +262,6 @@ impl ServiceClient {
         )
         .map(|_| ())
         .map_err(CallFailure::into_error)
-    }
-
-    pub fn ping(&self) -> Result<()> {
-        self.call(json!({"op": "ping"}), None)
-            .map(|_| ())
-            .map_err(CallFailure::into_error)
     }
 }
 
@@ -528,8 +521,9 @@ impl A11yServiceRegistry {
         Self::default()
     }
 
-    /// Install + enable the service on `adb`'s device, forward a port, connect, ping. Returns a
-    /// connected `ServiceClient`. The apk path is resolved from env by the caller.
+    /// Install + enable the service on `adb`'s device, forward a port, and connect. Returns a
+    /// `ServiceClient` only once the service has served a window. The apk path is resolved from
+    /// env by the caller.
     pub fn ensure(&self, adb: &Adb, apk: &str) -> Result<ServiceClient> {
         install_service(adb, apk)?;
         let get = |k: &str| {
@@ -639,14 +633,50 @@ fn restore_a11y(adb: &Adb, prior_enabled: &str, prior_a11y_enabled: &str, port: 
     let _ = adb.run(["forward", "--remove", &format!("tcp:{port}")]);
 }
 
-/// Connect to the forwarded service port, retrying briefly while the service binds + listens.
+/// How long [`wait_for_service`] waits for the service to bind *and* serve a window. Sized for
+/// a cold-booted device: the install just before it makes Android restart the service (glass#324),
+/// whose socket is back in a fraction of a second but whose window manager takes seconds more to
+/// reattach a root window. Overrunning only delays the caller's fall back to the uiautomator
+/// reader.
+const READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+const READY_POLL: std::time::Duration = std::time::Duration::from_millis(150);
+
+/// Connect to the forwarded service port and wait until the service can answer what the caller
+/// came for: a tree. Both gates share the one budget.
 pub(crate) fn wait_for_service(port: u16) -> Result<ServiceClient> {
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    wait_for_ready(port, READY_TIMEOUT)
+}
+
+/// [`wait_for_service`] with the budget passed in, so a test watching the give-up path does not
+/// wait out the production one.
+fn wait_for_ready(port: u16, timeout: std::time::Duration) -> Result<ServiceClient> {
+    let deadline = std::time::Instant::now() + timeout;
+    let client = loop {
+        match ServiceClient::connect(port) {
+            Ok(c) => break c,
+            Err(e) if std::time::Instant::now() >= deadline => {
+                return Err(GlassError::Backend(format!(
+                    "the on-device a11y service never accepted a connection on :{port} within \
+                     {timeout:?}: {e}"
+                )));
+            }
+            Err(_) => std::thread::sleep(READY_POLL),
+        }
+    };
     loop {
-        match ServiceClient::connect(port).and_then(|c| c.ping().map(|_| c)) {
-            Ok(c) => return Ok(c),
-            Err(e) if std::time::Instant::now() >= deadline => return Err(e),
-            Err(_) => std::thread::sleep(std::time::Duration::from_millis(150)),
+        // `ping` proves only that the process is up; a served tree proves the capability. The
+        // empty package asks for the active window, exactly what the reader asks for. One
+        // connection throughout — `ServiceClient` reopens its own socket when a call finds the
+        // service gone.
+        match client.tree("") {
+            Ok(_) => return Ok(client),
+            Err(e) if std::time::Instant::now() >= deadline => {
+                return Err(GlassError::AccessibilityUnavailable(format!(
+                    "the on-device a11y service on :{port} answered but never served a window \
+                     within {timeout:?}: {e}"
+                )));
+            }
+            Err(_) => std::thread::sleep(READY_POLL),
         }
     }
 }
@@ -1931,10 +1961,12 @@ mod tests {
         fake_service_full(trees, on_action, packages, vec![OnTree::Serve])
     }
 
-    /// [`fake_service_ex`], plus `on_tree` (same indexing convention as `packages`: by how many
-    /// `tree`s have been served in total) — a served-index that resolves to `OnTree::Refused`
-    /// answers `ok:false` instead of consulting `trees`/`packages`, and does not advance
-    /// `served` or arm the connection's gate, since nothing was actually served.
+    /// [`fake_service_ex`], plus `on_tree` — indexed by how many `tree` requests have *arrived*
+    /// across every connection (last entry repeating), not by how many were served the way
+    /// `trees`/`packages` are: a refusal serves nothing, so a served-index would trap it on its
+    /// first entry and could never model a service that refuses and then starts serving. An
+    /// `OnTree::Refused` entry answers `ok:false` without consulting `trees`/`packages`, and
+    /// advances neither `served` nor the connection's gate.
     fn fake_service_full(
         trees: Vec<Value>,
         on_action: Vec<OnAction>,
@@ -1948,6 +1980,7 @@ mod tests {
         std::thread::spawn(move || {
             let mut conn = 0usize;
             let mut served = 0usize;
+            let mut requested = 0usize;
             while let Ok((sock, _)) = listener.accept() {
                 conn += 1;
                 let this_action = on_action[(conn - 1).min(on_action.len() - 1)];
@@ -1968,28 +2001,32 @@ mod tests {
                     let req: Value = serde_json::from_str(&line).expect("request is json");
                     let id = req["id"].clone();
                     let reply = match req["op"].as_str().unwrap_or_default() {
-                        "tree" => match on_tree[served.min(on_tree.len() - 1)] {
-                            OnTree::Refused(msg) => {
-                                log.lock().unwrap().push(format!("conn{conn}:tree-refused"));
-                                json!({"id": id, "ok": false, "error": msg})
-                            }
-                            OnTree::Serve => {
-                                log.lock().unwrap().push(format!("conn{conn}:tree"));
-                                let t = trees[served.min(trees.len() - 1)].clone();
-                                let pkg = &packages[served.min(packages.len() - 1)];
-                                served += 1;
-                                tree_confirmed = true;
-                                let mut reply = json!({"id": id, "ok": true, "tree": t});
-                                match pkg {
-                                    TreePackage::Echo => {
-                                        reply["package"] = req["package"].clone();
-                                    }
-                                    TreePackage::Other(p) => reply["package"] = json!(p),
-                                    TreePackage::Unnamed => {}
+                        "tree" => {
+                            let this_tree = on_tree[requested.min(on_tree.len() - 1)];
+                            requested += 1;
+                            match this_tree {
+                                OnTree::Refused(msg) => {
+                                    log.lock().unwrap().push(format!("conn{conn}:tree-refused"));
+                                    json!({"id": id, "ok": false, "error": msg})
                                 }
-                                reply
+                                OnTree::Serve => {
+                                    log.lock().unwrap().push(format!("conn{conn}:tree"));
+                                    let t = trees[served.min(trees.len() - 1)].clone();
+                                    let pkg = &packages[served.min(packages.len() - 1)];
+                                    served += 1;
+                                    tree_confirmed = true;
+                                    let mut reply = json!({"id": id, "ok": true, "tree": t});
+                                    match pkg {
+                                        TreePackage::Echo => {
+                                            reply["package"] = req["package"].clone();
+                                        }
+                                        TreePackage::Other(p) => reply["package"] = json!(p),
+                                        TreePackage::Unnamed => {}
+                                    }
+                                    reply
+                                }
                             }
-                        },
+                        }
                         "action" if !tree_confirmed => {
                             log.lock()
                                 .unwrap()
@@ -2174,6 +2211,73 @@ mod tests {
              for an action that never left the host): {}",
             e.into_error()
         );
+    }
+
+    #[test]
+    fn readiness_waits_for_a_served_window_not_just_a_live_socket() {
+        // glass#324. Reinstalling the APK makes Android SIGKILL the process hosting the
+        // AccessibilityService; the restart binds its socket — and answers `ping` — before the
+        // window manager has reattached a root window, so every `tree` until then is refused
+        // "no active window".
+        let (port, ops) = fake_service_full(
+            vec![compose_like()],
+            vec![OnAction::Ok],
+            vec![TreePackage::Echo],
+            vec![
+                OnTree::Refused("no active window"),
+                OnTree::Refused("no active window"),
+                OnTree::Serve,
+            ],
+        );
+        let client = wait_for_service(port).expect("the third tree serves, well inside the budget");
+        assert_eq!(
+            ops_of(&ops),
+            vec![
+                "conn1:tree-refused".to_string(),
+                "conn1:tree-refused".to_string(),
+                "conn1:tree".to_string(),
+            ],
+            "readiness must poll `tree` until one is served, on the one connection"
+        );
+        client
+            .tree("com.example.app")
+            .expect("the client handed back is the live, serving one");
+    }
+
+    #[test]
+    fn readiness_gives_up_within_its_budget_naming_the_refusal_not_just_the_wait() {
+        // The refusal never clears — a genuinely stuck service, not one mid-restart. The budget
+        // is what stops the retrying, and the error must carry what the device said: a bare
+        // "timed out" sends the reader hunting the host's socket, not the device's missing
+        // window.
+        let timeout = std::time::Duration::from_millis(400);
+        let (port, ops) = fake_service_full(
+            vec![compose_like()],
+            vec![OnAction::Ok],
+            vec![TreePackage::Echo],
+            vec![OnTree::Refused("no active window")],
+        );
+        let started = std::time::Instant::now();
+        let Err(e) = wait_for_ready(port, timeout) else {
+            panic!("a service that never serves a window is not ready");
+        };
+        let waited = started.elapsed();
+        assert!(
+            waited >= timeout,
+            "gave up after {waited:?}, before the budget"
+        );
+        assert!(
+            waited < timeout * 10,
+            "waited {waited:?} — the budget passed in must be the one that bounds it"
+        );
+        let msg = e.to_string();
+        assert!(msg.contains("no active window"), "{msg}");
+        let ops = ops_of(&ops);
+        assert!(
+            ops.len() > 1,
+            "one refusal is transient, not fatal — it must be retried: {ops:?}"
+        );
+        assert!(ops.iter().all(|o| o == "conn1:tree-refused"), "{ops:?}");
     }
 
     #[test]

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -641,13 +641,6 @@ fn restore_a11y(adb: &Adb, prior_enabled: &str, prior_a11y_enabled: &str, port: 
 const READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
 const READY_POLL: std::time::Duration = std::time::Duration::from_millis(150);
 
-/// How many connections [`wait_for_ready`] splits its budget across. A refusal can clear on the
-/// device — the platform's own reader was seen serving the window again — without the connection
-/// held open across the outage recovering with it, so a stuck one is replaced, not re-asked.
-/// Four gives each 5s of the 20s, longer than any readiness that went on to succeed. Do not
-/// escalate here to the reinstall that provokes the restart in the first place.
-const READY_CONNECTIONS: u32 = 4;
-
 /// Connect to the forwarded service port and wait until the service can answer what the caller
 /// came for: a tree. Both gates share the one budget.
 pub(crate) fn wait_for_service(port: u16) -> Result<ServiceClient> {
@@ -658,56 +651,31 @@ pub(crate) fn wait_for_service(port: u16) -> Result<ServiceClient> {
 /// wait out the production one.
 fn wait_for_ready(port: u16, timeout: std::time::Duration) -> Result<ServiceClient> {
     let deadline = std::time::Instant::now() + timeout;
-    let window = timeout / READY_CONNECTIONS;
-    let mut connections = 0u32;
-    loop {
-        let client = match connect_until(port, deadline) {
-            Ok(c) => c,
-            Err(e) => {
-                let seen = if connections == 0 {
-                    "never accepted a connection".to_string()
-                } else {
-                    format!("stopped accepting connections after {connections}")
-                };
+    let client = loop {
+        match ServiceClient::connect(port) {
+            Ok(c) => break c,
+            Err(e) if std::time::Instant::now() >= deadline => {
                 return Err(GlassError::Backend(format!(
-                    "the on-device a11y service {seen} on :{port} within {timeout:?}: {e}"
+                    "the on-device a11y service never accepted a connection on :{port} within \
+                     {timeout:?}: {e}"
                 )));
             }
-        };
-        connections += 1;
-        let window_end = std::time::Instant::now() + window;
-        loop {
-            // `ping` proves only that the process is up; a served tree proves the capability. The
-            // empty package asks for the active window, exactly what the reader asks for. A `tree`
-            // is a read, so asking again — here or on a fresh connection — actuates nothing.
-            match client.tree("") {
-                Ok(_) => return Ok(client),
-                Err(e) if std::time::Instant::now() >= deadline => {
-                    return Err(GlassError::AccessibilityUnavailable(format!(
-                        "the on-device a11y service on :{port} answered but never served a window \
-                         across {connections} connections in {timeout:?}: {e}"
-                    )));
-                }
-                Err(_) => {}
-            }
-            let asked_at = std::time::Instant::now();
-            std::thread::sleep(READY_POLL.min(deadline.saturating_duration_since(asked_at)));
-            let now = std::time::Instant::now();
-            // Only worth abandoning this connection while there is budget left to ask on a
-            // fresh one; past the deadline, one more ask here gives the error its refusal.
-            if now >= window_end && now < deadline {
-                break;
-            }
+            Err(_) => std::thread::sleep(READY_POLL),
         }
-    }
-}
-
-/// Open a connection to `port`, retrying every [`READY_POLL`] until `deadline`.
-fn connect_until(port: u16, deadline: std::time::Instant) -> Result<ServiceClient> {
+    };
     loop {
-        match ServiceClient::connect(port) {
-            Ok(c) => return Ok(c),
-            Err(e) if std::time::Instant::now() >= deadline => return Err(e),
+        // `ping` proves only that the process is up; a served tree proves the capability. The
+        // empty package asks for the active window, exactly what the reader asks for. One
+        // connection throughout — `ServiceClient` reopens its own socket when a call finds the
+        // service gone.
+        match client.tree("") {
+            Ok(_) => return Ok(client),
+            Err(e) if std::time::Instant::now() >= deadline => {
+                return Err(GlassError::AccessibilityUnavailable(format!(
+                    "the on-device a11y service on :{port} answered but never served a window \
+                     within {timeout:?}: {e}"
+                )));
+            }
             Err(_) => std::thread::sleep(READY_POLL),
         }
     }
@@ -2309,82 +2277,7 @@ mod tests {
             ops.len() > 1,
             "one refusal is transient, not fatal — it must be retried: {ops:?}"
         );
-        assert!(ops.iter().all(|o| o.ends_with(":tree-refused")), "{ops:?}");
-    }
-
-    /// The distinct connections `ops` was recorded across, in order of first appearance.
-    fn conns_of(ops: &[String]) -> Vec<&str> {
-        let mut seen: Vec<&str> = Vec::new();
-        for c in ops.iter().filter_map(|o| o.split(':').next()) {
-            if !seen.contains(&c) {
-                seen.push(c);
-            }
-        }
-        seen
-    }
-
-    #[test]
-    fn readiness_reconnects_when_one_connection_stays_refused() {
-        // glass#324, second half. On a cold boot the accessibility layer goes transiently
-        // unavailable and recovers, but the connection held open across the outage need not
-        // recover with it — the platform's own reader was seen serving that window again while
-        // ours kept being refused for the rest of the budget.
-        //
-        // A budget whose per-connection share is under one [`READY_POLL`] gives each connection
-        // exactly one ask, so which connection the serve lands on is the assertion, not timing.
-        let timeout = std::time::Duration::from_millis(500);
-        let (port, ops) = fake_service_full(
-            vec![compose_like()],
-            vec![OnAction::Ok],
-            vec![TreePackage::Echo],
-            vec![OnTree::Refused("no active window"), OnTree::Serve],
-        );
-        let client = wait_for_ready(port, timeout).expect("a later connection serves the window");
-        assert_eq!(
-            ops_of(&ops),
-            vec!["conn1:tree-refused".to_string(), "conn2:tree".to_string()],
-            "the serve must land on a new connection — re-polling conn1 is the bug"
-        );
-        client
-            .tree("com.example.app")
-            .expect("the client handed back is the reconnected, serving one");
-    }
-
-    #[test]
-    fn readiness_stops_reconnecting_at_the_budget_and_says_how_many_it_tried() {
-        // Reconnecting spends the one budget, not a fresh one each time, and the count has to
-        // reach the caller: a device that refused every fresh connection needs a fresh
-        // install+enable, not more retries here.
-        let timeout = std::time::Duration::from_millis(400);
-        let (port, ops) = fake_service_full(
-            vec![compose_like()],
-            vec![OnAction::Ok],
-            vec![TreePackage::Echo],
-            vec![OnTree::Refused("no active window")],
-        );
-        let started = std::time::Instant::now();
-        let Err(e) = wait_for_ready(port, timeout) else {
-            panic!("a device that never serves a window is not ready");
-        };
-        let waited = started.elapsed();
-        assert!(waited >= timeout, "gave up after {waited:?}");
-        assert!(
-            waited < timeout * 10,
-            "waited {waited:?} — reconnecting must spend the budget, not extend it"
-        );
-        let ops = ops_of(&ops);
-        let conns = conns_of(&ops);
-        assert!(
-            conns.len() > 1,
-            "a stuck connection must be replaced, not just re-asked: {ops:?}"
-        );
-        let msg = e.to_string();
-        assert!(
-            msg.contains(&format!("{} connections", conns.len())),
-            "the error must name the {} connections actually tried: {msg}",
-            conns.len()
-        );
-        assert!(msg.contains("no active window"), "{msg}");
+        assert!(ops.iter().all(|o| o == "conn1:tree-refused"), "{ops:?}");
     }
 
     #[test]


### PR DESCRIPTION
Closes #324.

Stacked on #325 (`android-ci-leg`), which is where the Android CI leg that found
this lives. Base that, not master.

## The bug

`A11yServiceRegistry::ensure()` runs `adb install -r`. Reinstalling a package that
hosts an `AccessibilityService` makes Android SIGKILL it:

```
ActivityManager: Killing 2852:com.fixedwidth.glassa11y (adj 999):
                 stop com.fixedwidth.glassa11y due to installPackageLI
```

Readiness then accepted a TCP connect plus a `ping` as proof the service was
usable — but `Server.kt`'s ping handler never touches `rootInActiveWindow`. So
callers proceeded against a service that was up and had no window, and the device
answered `no active window`.

Sometimes the restarted service's binding does not come back at all: the process
stays alive, the socket listens, the config is right, the OS has a stable focused
window, and `getRootInActiveWindow()` stays null indefinitely. Only re-establishing
the binding clears it.

## The fix

Readiness now proves the capability callers need — that the service serves a
window — and re-establishes the binding when it does not:

1. poll `tree` for 6s
2. force a rebind: disable accessibility, drop our component from
   `enabled_accessibility_services`, restore it, re-enable
3. poll 6s
4. reinstall **and** rebind
5. poll 6s, then give up

Reinstall is last because it is what causes the SIGKILL, and it is also the only
step measured to recover a dead binding.

Worst case ~23s, against the 20s single window it replaces. On exhaustion the error
reports what was observed — attempts, rebinds, elapsed, and the device's own last
refusal — rather than a bare timeout.

Host-side only. The companion agent behaved correctly throughout and is unchanged,
so no APK or agent release is needed.

## Measured

Bare cold-booted emulators (`-wipe-data`), both `a11y_service_loop` tests:

| | failures |
|---|---|
| before | 5 / 6 |
| after | **0 / 12** |

The `installPackageLI` kill still fires on every run, so the race is still
exercised. Across 24 readiness calls in the verification run: 22 succeeded on the
first poll (0.7-3.0s), 2 needed one rebind (~7s), none reached the reinstall rung.

## Not covered

`native_invoke_actuates_the_fixture` stays `--skip`ped: it now fails ~2/12 on a
different defect, #326 (`live node gone`, an exact-bounds re-find in the companion),
which needs a device-side change.