### PR TITLE
fix(a11y-android): a control that moved is the same control

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -88,10 +88,6 @@ jobs:
             echo "GLASS_ADB=$ANDROID_SDK_ROOT/platform-tools/adb"
           } >> "$GITHUB_ENV"
 
-      # Do not delete as dead: the steps through "Point the suite at the fixture" build an APK no
-      # currently enabled test consumes, because its only reader —
-      # native_invoke_actuates_the_fixture — is --skipped pending glass#324. Dropping that --skip
-      # makes this section live again with no other change.
       - name: Restore the fixture APK cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: fixture-cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -404,6 +404,13 @@ internal refactors, CI, or test-only changes.
   it prints now names each candidate's `AXRole` and the raw `AXError` behind a failed read, and
   window adoption itself now records which on-screen window it took out of what else was
   available. `WindowNotFound` no longer asserts a timing cause it cannot know.
+- Android: a native click through the optional on-device companion no longer acts on a control
+  that is still moving. A screen whose open transition is still animating reports its content at
+  an offset that decays over about half a second, so a click aimed at an element read mid-flight
+  either failed as `element changed; re-snapshot` or missed the node on the device. The click now
+  re-reads until the element and the control it actuates hold still, and gives up with what it
+  saw — the bounds, the offset, how long it watched — if they never do. A control that is not
+  moving costs one extra read and no wait.
 
 ## [1.1.0] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,16 +191,6 @@ internal refactors, CI, or test-only changes.
   Android paths have no such live check.
 
 ### Fixed
-- An Android accessibility snapshot taken through the optional on-device companion no longer
-  describes a screen mid-animation. A screen whose open transition is still playing reports its
-  content at an offset that decays over about half a second, so a tree read then placed every
-  element a few dozen pixels from where it settles — and a click aimed at one of those positions
-  failed as `element changed; re-snapshot`, or missed the element on the device, or found no
-  control to actuate. A snapshot now re-reads until two reads a quarter-second apart describe the
-  same geometry and hands back that one, so the coordinates a caller reads are the ones the screen
-  keeps. It errors, naming what moved and by how much, if the screen never holds still. A screen
-  that is not moving costs one extra read; a small tree, whose reads are near-instant, also waits
-  out the quarter-second.
 - An Android accessibility snapshot taken through the optional on-device companion now says when
   it describes a different app than the one asked about. The companion answered with whatever
   window was in front — a system dialog, a permission prompt — and reported it as the requested

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -404,6 +404,17 @@ internal refactors, CI, or test-only changes.
   it prints now names each candidate's `AXRole` and the raw `AXError` behind a failed read, and
   window adoption itself now records which on-screen window it took out of what else was
   available. `WindowNotFound` no longer asserts a timing cause it cannot know.
+- A native Android click or `set_value` through the optional on-device companion no longer fails
+  just because the control moved. A screen whose open transition is playing reports its content at
+  an offset that decays over about half a second, so glass could read the element tens of pixels
+  from where your snapshot had it — and the check that stops an action landing on the wrong element
+  refused it, although its role, name, value and size all still matched. A control that only moved
+  is now accepted where it now is. It is still refused when more than one element in the tree
+  matches it on role, name, value and size, and the error names each of their positions: an element
+  that cannot be told from another is not one glass will guess at. Everything else is unchanged —
+  a resize, a changed role, name or value, an absent element, a disabled control and one exposing
+  no click action are all refused exactly as before, no action is ever sent twice, and this costs
+  no extra read and no wait.
 
 ## [1.1.0] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -404,17 +404,6 @@ internal refactors, CI, or test-only changes.
   it prints now names each candidate's `AXRole` and the raw `AXError` behind a failed read, and
   window adoption itself now records which on-screen window it took out of what else was
   available. `WindowNotFound` no longer asserts a timing cause it cannot know.
-- A native Android click or `set_value` through the optional on-device companion no longer fails
-  just because the screen was still animating. A screen whose open transition is playing reports its
-  content at an offset that decays over about half a second, so the tree glass reads to aim the
-  action could place the element tens of pixels from where your snapshot had it — and the check that
-  stops an action landing on the wrong element refused it. Glass now re-reads and tries again, up to
-  four reads spread over about six-tenths of a second, acting on the first read that agrees with your
-  snapshot. An element that moved under every read is still refused, now naming where each read found
-  it rather than only that it changed. Nothing else changes: an element that is genuinely a different
-  one, disabled, or exposing no click action is refused on the first read as before; an action that
-  may already have reached the device is never sent twice; and a screen that is not moving costs no
-  extra read and no wait.
 
 ## [1.1.0] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -404,6 +404,17 @@ internal refactors, CI, or test-only changes.
   it prints now names each candidate's `AXRole` and the raw `AXError` behind a failed read, and
   window adoption itself now records which on-screen window it took out of what else was
   available. `WindowNotFound` no longer asserts a timing cause it cannot know.
+- A native Android click or `set_value` through the optional on-device companion no longer fails
+  just because the screen was still animating. A screen whose open transition is playing reports its
+  content at an offset that decays over about half a second, so the tree glass reads to aim the
+  action could place the element tens of pixels from where your snapshot had it — and the check that
+  stops an action landing on the wrong element refused it. Glass now re-reads and tries again, up to
+  four reads spread over about six-tenths of a second, acting on the first read that agrees with your
+  snapshot. An element that moved under every read is still refused, now naming where each read found
+  it rather than only that it changed. Nothing else changes: an element that is genuinely a different
+  one, disabled, or exposing no click action is refused on the first read as before; an action that
+  may already have reached the device is never sent twice; and a screen that is not moving costs no
+  extra read and no wait.
 
 ## [1.1.0] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,16 @@ internal refactors, CI, or test-only changes.
   Android paths have no such live check.
 
 ### Fixed
+- An Android accessibility snapshot taken through the optional on-device companion no longer
+  describes a screen mid-animation. A screen whose open transition is still playing reports its
+  content at an offset that decays over about half a second, so a tree read then placed every
+  element a few dozen pixels from where it settles — and a click aimed at one of those positions
+  failed as `element changed; re-snapshot`, or missed the element on the device, or found no
+  control to actuate. A snapshot now re-reads until two reads a quarter-second apart describe the
+  same geometry and hands back that one, so the coordinates a caller reads are the ones the screen
+  keeps. It errors, naming what moved and by how much, if the screen never holds still. A screen
+  that is not moving costs one extra read; a small tree, whose reads are near-instant, also waits
+  out the quarter-second.
 - An Android accessibility snapshot taken through the optional on-device companion now says when
   it describes a different app than the one asked about. The companion answered with whatever
   window was in front — a system dialog, a permission prompt — and reported it as the requested

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -404,13 +404,6 @@ internal refactors, CI, or test-only changes.
   it prints now names each candidate's `AXRole` and the raw `AXError` behind a failed read, and
   window adoption itself now records which on-screen window it took out of what else was
   available. `WindowNotFound` no longer asserts a timing cause it cannot know.
-- Android: a native click through the optional on-device companion no longer acts on a control
-  that is still moving. A screen whose open transition is still animating reports its content at
-  an offset that decays over about half a second, so a click aimed at an element read mid-flight
-  either failed as `element changed; re-snapshot` or missed the node on the device. The click now
-  re-reads until the element and the control it actuates hold still, and gives up with what it
-  saw — the bounds, the offset, how long it watched — if they never do. A control that is not
-  moving costs one extra read and no wait.
 
 ## [1.1.0] - 2026-07-23
 

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -306,28 +306,6 @@ fn rearm_tree(conn: &mut Conn, pkg: &str) -> Result<()> {
 const CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 const CHECK_POLL: std::time::Duration = std::time::Duration::from_millis(150);
 
-/// How many times [`ServiceA11y::on_a_fresh_tree`] may read the tree, how long it waits between
-/// reads, and the wall clock the whole ladder may spend — all three spent only after a refusal.
-///
-/// An activity-open transition slides its content for ~600 ms and holds each position for up to
-/// ~365 ms, so the reads have to be *spread* rather than merely repeated: four reads one pause
-/// apart span ~600 ms and cross every plateau. The budget ends the ladder early on a tree whose
-/// own reads cover that span in fewer attempts (several hundred nodes read in ~180 ms).
-const RETRY_ATTEMPTS: usize = 4;
-const RETRY_PAUSE: std::time::Duration = std::time::Duration::from_millis(200);
-const RETRY_BUDGET: std::time::Duration = std::time::Duration::from_millis(900);
-
-/// A failed attempt at reading the tree, resolving a target in it and acting on it — and whether
-/// repeating the whole attempt can act twice.
-#[derive(Debug)]
-enum Refusal {
-    /// Raised because the target was somewhere else, and raised before anything reached the
-    /// control. A later read may find it where the caller saw it.
-    Moved(GlassError),
-    /// Everything else, including every outcome that may already have reached the device.
-    Final(GlassError),
-}
-
 /// The Accessibility reader backed by the on-device service. `package` is the target app.
 pub struct ServiceA11y {
     client: ServiceClient,
@@ -377,51 +355,15 @@ impl ServiceA11y {
         target: &AxTarget,
         plan: &InvokePlan,
         subject: Option<&Subject>,
-    ) -> std::result::Result<Option<AxNodeId>, Refusal> {
+    ) -> Result<Option<AxNodeId>> {
         let acting_on = subject.map_or(self.package.as_str(), |s| s.actual.as_str());
         self.client
             .click(plan.actuated.id.0, acting_on)
-            .map_err(|f| click_refusal(target.id.0, f))?;
+            .map_err(|f| action_error(target.id.0, f))?;
         if let Some(want) = plan.want_checked {
-            // The click has gone out; from here nothing may be repeated.
-            self.wait_for_check(ctx, plan, want)
-                .map_err(Refusal::Final)?;
+            self.wait_for_check(ctx, plan, want)?;
         }
         Ok(plan.substituted())
-    }
-
-    /// Read + number the tree, run `attempt` against it, and repeat while `attempt` reports the
-    /// target moved under it — up to [`RETRY_ATTEMPTS`] reads, [`RETRY_PAUSE`] apart, within
-    /// [`RETRY_BUDGET`].
-    ///
-    /// The whole attempt is re-run, so it is sound only because [`Refusal::Moved`] is reserved
-    /// for refusals raised before anything reached the control.
-    fn on_a_fresh_tree<T>(
-        &mut self,
-        ctx: &AxContext,
-        target: &AxTarget,
-        mut attempt: impl FnMut(&mut Self, &AxTree) -> std::result::Result<T, Refusal>,
-    ) -> Result<T> {
-        let started = std::time::Instant::now();
-        let mut found_at = Vec::new();
-        loop {
-            let tree = {
-                let mut t = self.snapshot(ctx)?;
-                t.assign_ids();
-                t
-            };
-            match attempt(self, &tree) {
-                Ok(v) => return Ok(v),
-                Err(Refusal::Final(e)) => return Err(e),
-                Err(Refusal::Moved(e)) => {
-                    found_at.push(tree.find(target.id).and_then(|n| n.bounds));
-                    if found_at.len() >= RETRY_ATTEMPTS || started.elapsed() >= RETRY_BUDGET {
-                        return Err(kept_moving(target, &found_at, started.elapsed(), e));
-                    }
-                    std::thread::sleep(RETRY_PAUSE);
-                }
-            }
-        }
     }
 }
 
@@ -446,21 +388,19 @@ impl Accessibility for ServiceA11y {
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
         // Guard: re-snapshot and verify the ref still points at the same editable element before
         // acting. Shared with `AndroidA11y::set_value`, so both readers refuse the same drift.
-        self.on_a_fresh_tree(ctx, target, |a, tree| {
-            crate::a11y::editable_target(tree, target)
-                .map_err(|e| moved_or_final(e, tree, target))?;
-            // Re-arm against the app the served tree actually described, not the one asked about —
-            // that's the app `target`'s ref came from (see `rearm_tree`).
-            let acting_on = tree
-                .subject
-                .as_ref()
-                .map_or(a.package.as_str(), |s| s.actual.as_str());
-            // `set_text` consumes its own `CallFailure`, so its refusals cannot be told apart
-            // by delivery here.
-            a.client
-                .set_text(target.id.0, text, acting_on)
-                .map_err(Refusal::Final)
-        })?;
+        let tree = {
+            let mut t = self.snapshot(ctx)?;
+            t.assign_ids();
+            t
+        };
+        crate::a11y::editable_target(&tree, target)?;
+        // Re-arm against the app the served tree actually described, not the one asked about —
+        // that's the app `target`'s ref came from (see `rearm_tree`).
+        let acting_on = tree
+            .subject
+            .as_ref()
+            .map_or(self.package.as_str(), |s| s.actual.as_str());
+        self.client.set_text(target.id.0, text, acting_on)?;
         // Verify the value actually took. ACTION_SET_TEXT returns success but silently no-ops when
         // *replacing* existing text in a Compose field, so a bare Ok could lie (glass forbids silent
         // fallbacks). The set is async (Compose recompose → a11y update), so poll briefly for the
@@ -501,10 +441,13 @@ impl Accessibility for ServiceA11y {
     }
 
     fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<Option<AxNodeId>> {
-        self.on_a_fresh_tree(ctx, target, |a, tree| {
-            let plan = invoke_plan(tree, target).map_err(|e| moved_or_final(e, tree, target))?;
-            a.dispatch_click(ctx, target, &plan, tree.subject.as_ref())
-        })
+        let tree = {
+            let mut t = self.snapshot(ctx)?;
+            t.assign_ids();
+            t
+        };
+        let plan = invoke_plan(&tree, target)?;
+        self.dispatch_click(ctx, target, &plan, tree.subject.as_ref())
     }
 }
 
@@ -963,81 +906,6 @@ fn action_error(target: u32, f: CallFailure) -> GlassError {
         )),
         CallFailure::Refused(e) => GlassError::AxActionFailed(target, e.to_string()),
     }
-}
-
-/// [`action_error`], plus whether the companion refused before it touched the control — the only
-/// click failure a fresh attempt may repeat.
-fn click_refusal(target: u32, f: CallFailure) -> Refusal {
-    let repeatable = refused_before_acting(&f);
-    let e = action_error(target, f);
-    if repeatable {
-        Refusal::Moved(e)
-    } else {
-        Refusal::Final(e)
-    }
-}
-
-/// The companion's `matchLive` refusal: its live re-read holds no node at the bounds of the tree
-/// it served, thrown before `performOn` (`GlassA11yService.kt`'s `liveSink`), so the control was
-/// never touched. Matched on the message because the protocol carries no error code.
-///
-/// Do not widen: every other `Refused` either ran the action or is an answer this client could
-/// not read, and neither says the control was left alone.
-fn refused_before_acting(f: &CallFailure) -> bool {
-    matches!(f, CallFailure::Refused(e) if e.to_string().contains("live node gone"))
-}
-
-/// Classify a resolution failure raised against `tree`: only [`GlassError::AxElementChanged`]
-/// for an element that is still itself is worth another read.
-///
-/// `crate::a11y::fingerprinted` rejects on role/name, on bounds and on value, so role, name and
-/// value still matching means the bounds rejected — the element standing somewhere else, which a
-/// later read can find. A role/name/value drift is a different element that inherited the id.
-fn moved_or_final(e: GlassError, tree: &AxTree, target: &AxTarget) -> Refusal {
-    let still_itself = tree.find(target.id).is_some_and(|n| {
-        target.matches(n.role, n.name.as_deref()) && target.value_consistent(n.value.as_deref())
-    });
-    if matches!(e, GlassError::AxElementChanged(_)) && still_itself {
-        Refusal::Moved(e)
-    } else {
-        Refusal::Final(e)
-    }
-}
-
-/// The refusal for a target that every read found somewhere else. It names where each read found
-/// it because `last` alone says only that the two disagree, and which of them is the stale one is
-/// not something this side can tell.
-fn kept_moving(
-    target: &AxTarget,
-    found_at: &[Option<AxRect>],
-    elapsed: std::time::Duration,
-    last: GlassError,
-) -> GlassError {
-    let found = found_at
-        .iter()
-        .copied()
-        .map(rect)
-        .collect::<Vec<_>>()
-        .join(", ");
-    GlassError::AxActionFailed(
-        target.id.0,
-        format!(
-            "the element moved under all {} reads taken over {} ms, so nothing was dispatched: \
-             the snapshot has it at {}, the re-reads found it at {found} ({last}). A screen whose \
-             open transition is still animating settles in about half a second — retry once it has",
-            found_at.len(),
-            elapsed.as_millis(),
-            rect(target.bounds),
-        ),
-    )
-}
-
-/// `(x,y wxh)`, or `absent` for an element no longer in the tree.
-fn rect(b: Option<AxRect>) -> String {
-    b.map_or_else(
-        || "absent".to_string(),
-        |r| format!("({},{} {}x{})", r.x, r.y, r.width, r.height),
-    )
 }
 
 /// The error for a control whose click was accepted but whose state never reached `want`.
@@ -2089,11 +1957,6 @@ mod tests {
         /// Read the request, then drop the socket without answering — the shape of an answer
         /// lost to a read timeout, a rebinding service or a reset `adb forward` tunnel.
         DropWithoutAnswering,
-        /// Answer `ok:false` with `msg` for the first `n` actions on each connection, then answer
-        /// normally — the shape of the companion's own per-action refusals (`matchLive` failing),
-        /// which leave the socket up. Logged as `{action}-refused`, so a request the device threw
-        /// out before touching the control is distinguishable from one it actuated.
-        RefusedFirst(usize, &'static str),
     }
 
     /// What a fake `tree` reply's `package` field says, relative to what was asked.
@@ -2180,7 +2043,6 @@ mod tests {
                     break;
                 }
                 let mut tree_confirmed = false;
-                let mut refused = 0usize;
                 loop {
                     let mut line = String::new();
                     if !matches!(r.read_line(&mut line), Ok(n) if n > 0) {
@@ -2232,27 +2094,14 @@ mod tests {
                                    "error": "no tree has been served on this connection"})
                         }
                         "action" => {
-                            let act = req["action"].as_str().unwrap_or_default();
-                            let r = &req["ref"];
-                            let record = |suffix: &str| {
-                                log.lock()
-                                    .unwrap()
-                                    .push(format!("conn{conn}:{act}{suffix} ref={r}"));
-                            };
+                            log.lock().unwrap().push(format!(
+                                "conn{conn}:{} ref={}",
+                                req["action"].as_str().unwrap_or_default(),
+                                req["ref"]
+                            ));
                             match this_action {
-                                OnAction::RefusedFirst(n, msg) if refused < n => {
-                                    refused += 1;
-                                    record("-refused");
-                                    json!({"id": id, "ok": false, "error": msg})
-                                }
-                                OnAction::DropWithoutAnswering => {
-                                    record("");
-                                    break;
-                                }
-                                OnAction::Ok | OnAction::RefusedFirst(..) => {
-                                    record("");
-                                    json!({"id": id, "ok": true})
-                                }
+                                OnAction::Ok => json!({"id": id, "ok": true}),
+                                OnAction::DropWithoutAnswering => break,
                             }
                         }
                         _ => json!({"id": id, "ok": true}),
@@ -2811,14 +2660,9 @@ mod tests {
             .shutdown(std::net::Shutdown::Write)
             .expect("shutdown");
 
-        let refusal = a
+        let e = a
             .dispatch_click(&ctx(), &target, &plan, tree.subject.as_ref())
             .expect_err("the rearm names the asked-about app, not the app the ref came from");
-        // Final, not Moved: only the companion's pre-`performOn` refusal is repeatable, and a
-        // rearm that could not confirm the acting app says nothing about what the click did.
-        let Refusal::Final(e) = refusal else {
-            panic!("a click that may already have gone out must not be repeatable: {refusal:?}")
-        };
         let msg = e.to_string();
         assert!(msg.contains("com.other.app"), "{msg}");
         assert!(msg.contains("com.example.app"), "{msg}");
@@ -3043,224 +2887,6 @@ mod tests {
                 "conn1:tree".to_string()
             ],
             "the click went out and the state was read back"
-        );
-    }
-
-    /// `v` with every node's `x` moved by `dx`, and nothing else touched — the shape of the
-    /// activity-open transition #326 reproduces, in which only `x` ever changes.
-    fn slid(v: &Value, dx: i64) -> Value {
-        fn shift(v: &mut Value, dx: i64) {
-            if let Some(x) = v.pointer_mut("/bounds/x") {
-                *x = json!(x.as_i64().unwrap_or(0) + dx);
-            }
-            for c in v
-                .get_mut("children")
-                .and_then(Value::as_array_mut)
-                .into_iter()
-                .flatten()
-            {
-                shift(c, dx);
-            }
-        }
-        let mut v = v.clone();
-        shift(&mut v, dx);
-        v
-    }
-
-    #[test]
-    fn a_target_that_moved_under_the_first_read_is_actuated_from_a_second() {
-        // The caller's target came from the settled tree; `invoke`'s own read catches the open
-        // transition 79 px along, so the guard's ±8 px check refuses it.
-        let (port, ops) = fake_service(
-            vec![slid(&compose_like(), 79), compose_like()],
-            OnAction::Ok,
-        );
-        let mut a = reader(port, std::time::Duration::ZERO);
-        let t = built(&compose_like());
-        let substituted = a
-            .invoke(&ctx(), &target_for(&t, AxNodeId(2)))
-            .expect("a re-read that finds the target where the caller saw it must actuate it");
-        assert_eq!(substituted, Some(AxNodeId(1)), "the climb is disclosed");
-        assert_eq!(
-            ops_of(&ops),
-            vec![
-                "conn1:tree".to_string(),
-                "conn1:tree".to_string(),
-                "conn1:click ref=1".to_string(),
-            ],
-            "one re-read, then exactly one dispatch"
-        );
-    }
-
-    #[test]
-    fn a_click_the_device_refused_before_touching_the_control_is_retried_on_a_fresh_read() {
-        // "live node gone" is the companion's `matchLive` finding no node at the bounds of the
-        // tree it served (`GlassA11yService.kt`'s `liveSink`); it throws before `performOn`, so
-        // nothing was actuated and the whole attempt may be repeated.
-        let (port, ops) = fake_service_ex(
-            vec![compose_like()],
-            vec![OnAction::RefusedFirst(1, "live node gone")],
-            vec![TreePackage::Echo],
-        );
-        let mut a = reader(port, std::time::Duration::ZERO);
-        let t = built(&compose_like());
-        a.invoke(&ctx(), &target_for(&t, AxNodeId(2)))
-            .expect("a refusal raised before the control was touched must be retried");
-        assert_eq!(
-            ops_of(&ops),
-            vec![
-                "conn1:tree".to_string(),
-                "conn1:click-refused ref=1".to_string(),
-                "conn1:tree".to_string(),
-                "conn1:click ref=1".to_string(),
-            ],
-            "exactly one dispatch: the refused frame never reached the control"
-        );
-    }
-
-    #[test]
-    fn a_target_that_never_stops_moving_is_refused_within_the_bound_and_names_where_it_went() {
-        let (port, ops) = fake_service(
-            vec![
-                slid(&compose_like(), 79),
-                slid(&compose_like(), 31),
-                slid(&compose_like(), 23),
-                slid(&compose_like(), 18),
-            ],
-            OnAction::Ok,
-        );
-        let mut a = reader(port, std::time::Duration::ZERO);
-        let t = built(&compose_like());
-        let started = std::time::Instant::now();
-        let e = a
-            .invoke(&ctx(), &target_for(&t, AxNodeId(2)))
-            .expect_err("a target that never stops moving must not be clicked");
-        let elapsed = started.elapsed();
-        assert!(!e.invoke_fallback_eligible(), "{e}");
-        let msg = e.to_string();
-        for want in [
-            "#2",
-            "(120,420 80x50)",
-            "(199,420 80x50)",
-            "(151,420 80x50)",
-            "(143,420 80x50)",
-            "(138,420 80x50)",
-            "re-snapshot",
-        ] {
-            assert!(msg.contains(want), "{want:?} missing from: {msg}");
-        }
-        assert_eq!(
-            ops_of(&ops),
-            vec!["conn1:tree".to_string(); 4],
-            "four reads, and nothing dispatched at any point"
-        );
-        assert!(
-            elapsed >= std::time::Duration::from_millis(600),
-            "the reads must be spread across the slide, not merely repeated: {elapsed:?}"
-        );
-    }
-
-    #[test]
-    fn a_click_whose_answer_was_lost_is_never_retried_even_when_the_retry_would_succeed() {
-        // The ambiguous class: the request went out and no answer came back. `on_action`'s second
-        // entry answers `ok` on the connection a retry would open, so a retry here would report a
-        // clean success having actuated the control twice.
-        let (port, ops) = fake_service_ex(
-            vec![compose_like()],
-            vec![OnAction::DropWithoutAnswering, OnAction::Ok],
-            vec![TreePackage::Echo],
-        );
-        let mut a = reader(port, std::time::Duration::ZERO);
-        let t = built(&compose_like());
-        let e = a
-            .invoke(&ctx(), &target_for(&t, AxNodeId(2)))
-            .expect_err("a lost answer is not a success");
-        assert!(
-            e.to_string().contains("may or may not have actuated"),
-            "{e}"
-        );
-        assert_eq!(
-            ops_of(&ops),
-            vec!["conn1:tree".to_string(), "conn1:click ref=1".to_string()],
-            "exactly one click frame — a failure that may have reached the device is never repeated"
-        );
-    }
-
-    #[test]
-    fn an_invoke_on_a_tree_that_did_not_move_costs_no_extra_read_and_no_wait() {
-        let (port, ops) = fake_service(vec![compose_like()], OnAction::Ok);
-        let mut a = reader(port, std::time::Duration::ZERO);
-        let t = built(&compose_like());
-        let started = std::time::Instant::now();
-        a.invoke(&ctx(), &target_for(&t, AxNodeId(2)))
-            .expect("clicks");
-        let elapsed = started.elapsed();
-        assert_eq!(
-            ops_of(&ops),
-            vec!["conn1:tree".to_string(), "conn1:click ref=1".to_string()],
-            "the read the plan came from, and the click — nothing else"
-        );
-        assert!(
-            elapsed < RETRY_PAUSE,
-            "not even one pause may be spent when there is nothing to recover from: {elapsed:?}"
-        );
-    }
-
-    #[test]
-    fn an_element_that_exposes_no_activation_action_is_refused_without_spending_the_budget() {
-        // Permanent, and the one resolution error the caller may answer with a pointer click —
-        // re-reading for it delays a fallback that already works.
-        let mut v = compose_like();
-        v["children"][0]["clickable"] = json!(false);
-        let (port, ops) = fake_service(vec![v.clone()], OnAction::Ok);
-        let mut a = reader(port, std::time::Duration::ZERO);
-        let t = built(&v);
-        let e = a
-            .invoke(&ctx(), &target_for(&t, AxNodeId(2)))
-            .expect_err("nothing on the path advertises a click");
-        assert!(e.invoke_fallback_eligible(), "{e}");
-        assert_eq!(ops_of(&ops), vec!["conn1:tree".to_string()]);
-    }
-
-    #[test]
-    fn a_target_whose_name_drifted_is_refused_on_the_first_read() {
-        // The other half of `AxElementChanged`: a different element inherited the id. No re-read
-        // undoes that, and the crisp "re-snapshot" verdict must not be buried under a wait.
-        let (port, ops) = fake_service(vec![compose_like()], OnAction::Ok);
-        let mut a = reader(port, std::time::Duration::ZERO);
-        let t = built(&compose_like());
-        let mut label = target_for(&t, AxNodeId(2));
-        label.name = Some("Send".into());
-        let e = a
-            .invoke(&ctx(), &label)
-            .expect_err("a renamed target must not report success");
-        assert!(matches!(e, GlassError::AxElementChanged(2)), "{e}");
-        assert_eq!(ops_of(&ops), vec!["conn1:tree".to_string()]);
-    }
-
-    #[test]
-    fn set_values_guard_re_reads_a_target_that_moved_rather_than_refusing_it() {
-        // `set_value` guards with `crate::a11y::editable_target` → the same `fingerprinted`, the
-        // same ±8 px bounds check — so a field sliding through an open transition refuses a write
-        // for exactly the reason it refuses a click.
-        let settled = editable_field("old");
-        let (port, ops) = fake_service(
-            vec![slid(&settled, 79), settled.clone(), editable_field("new")],
-            OnAction::Ok,
-        );
-        let mut a = reader(port, std::time::Duration::ZERO);
-        let t = built(&settled);
-        a.set_value(&ctx(), &target_for(&t, AxNodeId(1)), "new")
-            .expect("a re-read that finds the field where the caller saw it must write to it");
-        assert_eq!(
-            ops_of(&ops),
-            vec![
-                "conn1:tree".to_string(),
-                "conn1:tree".to_string(),
-                "conn1:set_text ref=1".to_string(),
-                "conn1:tree".to_string(),
-            ],
-            "one re-read, one write, one read-back"
         );
     }
 

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -773,7 +773,9 @@ fn same_element_moved(target: &AxTarget, node: &AxNode) -> bool {
         )
 }
 
-/// Every node [`same_element_moved`] accepts for `target`, in pre-order.
+/// Every node [`same_element_moved`] accepts for `target`, in pre-order. Searched tree-wide, not
+/// among siblings, so a second identical control anywhere refuses the whole relaxation — a list of
+/// same-size items sharing one label keeps the strict bounds guard.
 fn movement_candidates<'a>(tree: &'a AxTree, target: &AxTarget) -> Vec<&'a AxNode> {
     fn walk<'a>(node: &'a AxNode, target: &AxTarget, out: &mut Vec<&'a AxNode>) {
         if same_element_moved(target, node) {

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -306,6 +306,16 @@ fn rearm_tree(conn: &mut Conn, pkg: &str) -> Result<()> {
 const CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 const CHECK_POLL: std::time::Duration = std::time::Duration::from_millis(150);
 
+/// The wall clock two agreeing reads must span before [`ServiceA11y::snapshot`] calls the tree
+/// still. A screen whose open transition is animating reports its content at an offset that
+/// decays in *steps*, so two reads inside one step agree without proving anything; the longest
+/// step measured held ~160 ms, in a ~600 ms slide that stepped nine times (glass#326).
+const SETTLE_SPAN: std::time::Duration = std::time::Duration::from_millis(250);
+/// How long [`ServiceA11y::snapshot`] keeps re-reading for the tree to hold still. Room for the
+/// ~600 ms slide, one span of agreement after it, and the reads themselves — a single read of a
+/// 300-node tree costs up to ~600 ms.
+const SETTLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
 /// The Accessibility reader backed by the on-device service. `package` is the target app.
 pub struct ServiceA11y {
     client: ServiceClient,
@@ -323,13 +333,24 @@ impl ServiceA11y {
         }
     }
 
+    /// One tree, as the device answered it. [`Accessibility::snapshot`] settles over this. The
+    /// two read-back loops use it directly: each watches a state (a `checked` flag, a written
+    /// value) after its action has gone out, where a verdict about motion would report a change
+    /// that landed as failed.
+    fn read_tree(&mut self, ctx: &AxContext) -> Result<AxTree> {
+        let reply = self.client.tree(&self.package)?;
+        let mut tree = tree_from_json(&reply.tree, &ctx.window, ctx.limits)?;
+        tree.subject = subject_of(&self.package, reply.package.as_deref());
+        Ok(tree)
+    }
+
     /// Poll until the actuated control reports `checked == want`. The toolkit's UI update
     /// reaches the accessibility tree a beat after the action; `set_value` polls for the same
     /// reason.
     fn wait_for_check(&mut self, ctx: &AxContext, plan: &InvokePlan, want: bool) -> Result<()> {
         let deadline = std::time::Instant::now() + self.check_timeout;
         loop {
-            let mut after = self.snapshot(ctx)?;
+            let mut after = self.read_tree(ctx)?;
             after.assign_ids();
             let seen = check_state(&after, &plan.actuated);
             if seen == CheckState::Reached(want) {
@@ -378,11 +399,36 @@ fn subject_of(asked: &str, actual: Option<&str>) -> Option<Subject> {
 }
 
 impl Accessibility for ServiceA11y {
+    /// Re-read until two reads a [`SETTLE_SPAN`] apart describe the same geometry, and hand back
+    /// the later one.
+    ///
+    /// glass#326: a window whose activity-open transition is still animating reports its content
+    /// at an +x offset that decays in steps, so reads milliseconds apart place the same control
+    /// in two places. Every guard downstream — the ±8 px staleness check, the companion's exact
+    /// re-find, the climb to an enclosing clickable ancestor — compares one such read against
+    /// another, so settling *here* rather than in `invoke` is what leaves them nothing to
+    /// disagree about: the caller's own tree is the settled one.
+    ///
+    /// The span carries the proof, not mere consecutiveness — two reads inside one step agree
+    /// while the slide is still running. A read counts toward the span: a walk that outlasts a
+    /// step comes back with its own nodes on different frames and matches nothing exactly.
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
-        let reply = self.client.tree(&self.package)?;
-        let mut tree = tree_from_json(&reply.tree, &ctx.window, ctx.limits)?;
-        tree.subject = subject_of(&self.package, reply.package.as_deref());
-        Ok(tree)
+        let started = std::time::Instant::now();
+        let mut since = started;
+        let mut seen = geometry_of(&self.read_tree(ctx)?);
+        loop {
+            std::thread::sleep(SETTLE_SPAN.saturating_sub(since.elapsed()));
+            let issued = std::time::Instant::now();
+            let next = self.read_tree(ctx)?;
+            let now = geometry_of(&next);
+            if now == seen {
+                return Ok(next);
+            }
+            if started.elapsed() >= SETTLE_TIMEOUT {
+                return Err(never_settled(&seen, &now, started.elapsed()));
+            }
+            (since, seen) = (issued, now);
+        }
     }
 
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
@@ -407,7 +453,7 @@ impl Accessibility for ServiceA11y {
         // value to land; error honestly only on timeout.
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
         loop {
-            let mut after = self.snapshot(ctx)?;
+            let mut after = self.read_tree(ctx)?;
             after.assign_ids();
             let node = after.find(target.id);
             let got = node.and_then(|n| n.value.clone());
@@ -846,6 +892,78 @@ fn actuable_node<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&'a AxNode> 
         .find(|n| n.states.focusable && (n.id == target.id || encloses(n.bounds, want)))
         .copied()
         .ok_or(GlassError::AxActionUnavailable(target.id.0))
+}
+
+/// Every node's bounds in pre-order — what [`ServiceA11y::snapshot`] watches for motion; the
+/// whole tree, since a snapshot names no target. Position `n` is the node
+/// `AxTree::assign_ids` will number `AxNodeId(n)`.
+fn geometry_of(tree: &AxTree) -> Vec<Option<AxRect>> {
+    fn walk(node: &AxNode, out: &mut Vec<Option<AxRect>>) {
+        out.push(node.bounds);
+        for c in &node.children {
+            walk(c, out);
+        }
+    }
+    let mut out = Vec::new();
+    walk(&tree.root, &mut out);
+    out
+}
+
+/// How two reads disagreed, worded for [`never_settled`].
+fn drift_between(before: &[Option<AxRect>], after: &[Option<AxRect>]) -> String {
+    for (id, (from, to)) in before.iter().zip(after).enumerate() {
+        if from != to {
+            return format!("element #{id} moved {}", movement(*from, *to));
+        }
+    }
+    format!(
+        "the tree changed shape between reads ({} elements, then {})",
+        before.len(),
+        after.len()
+    )
+}
+
+/// `from` → `to`, with the per-edge deltas when both sides reported bounds.
+fn movement(from: Option<AxRect>, to: Option<AxRect>) -> String {
+    let deltas = match (from, to) {
+        (Some(f), Some(t)) => format!(
+            " (dx {}, dy {}, dw {}, dh {})",
+            i64::from(t.x) - i64::from(f.x),
+            i64::from(t.y) - i64::from(f.y),
+            i64::from(t.width) - i64::from(f.width),
+            i64::from(t.height) - i64::from(f.height),
+        ),
+        _ => String::new(),
+    };
+    format!("from {} to {}{deltas}", rect(from), rect(to))
+}
+
+/// One rect as `(x,y wxh)`, or `no bounds`.
+fn rect(r: Option<AxRect>) -> String {
+    r.map_or_else(
+        || "no bounds".to_string(),
+        |r| format!("({},{} {}x{})", r.x, r.y, r.width, r.height),
+    )
+}
+
+/// Nothing was read out: the tree never held still inside the budget.
+///
+/// A refusal, not the last read with a warning: the degraded trees this reader can hand back —
+/// truncated, unreadable, another app — each ride an `AxTree` field the MCP boundary surfaces as
+/// its own block, and motion has no such channel.
+fn never_settled(
+    before: &[Option<AxRect>],
+    after: &[Option<AxRect>],
+    elapsed: std::time::Duration,
+) -> GlassError {
+    GlassError::Backend(format!(
+        "the accessibility tree is still moving after {} ms of re-reads, so no snapshot was \
+         taken: {}. A screen whose open transition is still animating settles in about half a \
+         second — retry once it has. If it never stops, drive that area by pixels: \
+         glass_screenshot, then glass_click at x,y",
+        elapsed.as_millis(),
+        drift_between(before, after),
+    ))
 }
 
 /// The root-to-`id` path, inclusive of both ends. False when `id` is not in this subtree,
@@ -1352,6 +1470,32 @@ mod tests {
                  ]}
             ]
         })
+    }
+
+    /// `v` with everything below its root shifted `dx` px right — what a window reports while
+    /// its activity-open transition animates: a uniform +x offset on the content, decaying to
+    /// zero over the ~500 ms the transition runs (glass#326).
+    fn shifted(v: &Value, dx: i64) -> Value {
+        fn kids(v: &mut Value) -> impl Iterator<Item = &mut Value> {
+            v.get_mut("children")
+                .and_then(Value::as_array_mut)
+                .into_iter()
+                .flatten()
+        }
+        fn shift(v: &mut Value, dx: i64) {
+            if let Some(x) = v["bounds"]["x"].as_i64() {
+                v["bounds"]["x"] = json!(x + dx);
+            }
+            for c in kids(v) {
+                shift(c, dx);
+            }
+        }
+        let mut v = v.clone();
+        // The window frame stays put; only its content slides.
+        for c in kids(&mut v) {
+            shift(c, dx);
+        }
+        v
     }
 
     fn built(v: &Value) -> AxTree {
@@ -2023,6 +2167,40 @@ mod tests {
         packages: Vec<TreePackage>,
         on_tree: Vec<OnTree>,
     ) -> (u16, Arc<Mutex<Vec<String>>>) {
+        fake_service_clocked(trees, TreeClock::PerRead, on_action, packages, on_tree)
+    }
+
+    /// Which scripted tree a fake answers with.
+    enum TreeClock {
+        /// The next one each time, last entry repeating.
+        PerRead,
+        /// By wall clock since the first `tree` request: entry `i` takes over `holds[i]` after
+        /// it. A per-read script advances at whatever rate the reader reads, so only this can
+        /// express a *plateau* — a position the device keeps reporting for a while and leaves.
+        Timed(Vec<std::time::Duration>),
+    }
+
+    /// [`fake_service`] with the trees keyed by wall clock — see [`TreeClock::Timed`].
+    fn fake_service_timed(
+        trees: Vec<Value>,
+        holds: Vec<std::time::Duration>,
+    ) -> (u16, Arc<Mutex<Vec<String>>>) {
+        fake_service_clocked(
+            trees,
+            TreeClock::Timed(holds),
+            vec![OnAction::Ok],
+            vec![TreePackage::Echo],
+            vec![OnTree::Serve],
+        )
+    }
+
+    fn fake_service_clocked(
+        trees: Vec<Value>,
+        clock: TreeClock,
+        on_action: Vec<OnAction>,
+        packages: Vec<TreePackage>,
+        on_tree: Vec<OnTree>,
+    ) -> (u16, Arc<Mutex<Vec<String>>>) {
         let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind");
         let port = listener.local_addr().expect("addr").port();
         let ops: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
@@ -2031,6 +2209,7 @@ mod tests {
             let mut conn = 0usize;
             let mut served = 0usize;
             let mut requested = 0usize;
+            let mut clock_start = None;
             while let Ok((sock, _)) = listener.accept() {
                 conn += 1;
                 let this_action = on_action[(conn - 1).min(on_action.len() - 1)];
@@ -2070,7 +2249,16 @@ mod tests {
                                 }
                                 None => {
                                     log.lock().unwrap().push(format!("conn{conn}:tree"));
-                                    let t = trees[served.min(trees.len() - 1)].clone();
+                                    let picked = match &clock {
+                                        TreeClock::PerRead => served,
+                                        TreeClock::Timed(holds) => {
+                                            let t0 = *clock_start
+                                                .get_or_insert_with(std::time::Instant::now);
+                                            let e = t0.elapsed();
+                                            holds.iter().filter(|h| **h <= e).count() - 1
+                                        }
+                                    };
+                                    let t = trees[picked.min(trees.len() - 1)].clone();
                                     let pkg = &packages[served.min(packages.len() - 1)];
                                     served += 1;
                                     tree_confirmed = true;
@@ -2554,7 +2742,9 @@ mod tests {
         let (port, _ops) = fake_service_ex(
             vec![field("old"), field("old"), field("new")],
             vec![OnAction::DropWithoutAnswering, OnAction::Ok],
+            // Both of the guard snapshot's reads answer `Echo`; only the rearm's reply is fixed.
             vec![
+                TreePackage::Echo,
                 TreePackage::Echo,
                 TreePackage::Other("com.example.app".into()),
             ],
@@ -2588,7 +2778,9 @@ mod tests {
         let (port, _ops) = fake_service_ex(
             vec![clickable.clone()],
             vec![OnAction::Ok],
+            // Both of the snapshot's reads answer `Echo`; only the rearm's reply is fixed.
             vec![
+                TreePackage::Echo,
                 TreePackage::Echo,
                 TreePackage::Other("com.example.app".into()),
             ],
@@ -2638,7 +2830,10 @@ mod tests {
         let (port, ops) = fake_service_ex(
             vec![clickable.clone()],
             vec![OnAction::Ok],
+            // Both of the snapshot's reads describe the dialog; the rearm's reply names the
+            // asked-about app.
             vec![
+                TreePackage::Other("com.other.app".into()),
                 TreePackage::Other("com.other.app".into()),
                 TreePackage::Other("com.example.app".into()),
             ],
@@ -2669,7 +2864,11 @@ mod tests {
         assert!(msg.contains("moved"), "{msg}");
         assert_eq!(
             ops_of(&ops),
-            vec!["conn1:tree".to_string(), "conn2:tree".to_string()],
+            vec![
+                "conn1:tree".to_string(),
+                "conn1:tree".to_string(),
+                "conn2:tree".to_string()
+            ],
             "no click on conn2 — comparing against the acting app must stop the resend"
         );
     }
@@ -2705,7 +2904,10 @@ mod tests {
                 editable_field("new"),
             ],
             vec![OnAction::DropWithoutAnswering, OnAction::Ok],
+            // Both of the guard snapshot's reads describe the dialog; the rearm's reply names
+            // the asked-about app.
             vec![
+                TreePackage::Other("com.other.app".into()),
                 TreePackage::Other("com.other.app".into()),
                 TreePackage::Other("com.example.app".into()),
             ],
@@ -2727,6 +2929,7 @@ mod tests {
         assert_eq!(
             ops_of(&ops),
             vec![
+                "conn1:tree".to_string(),
                 "conn1:tree".to_string(),
                 "conn1:set_text ref=1".to_string(),
                 "conn2:tree".to_string(),
@@ -2765,6 +2968,7 @@ mod tests {
             ops_of(&ops),
             vec![
                 "conn1:tree".to_string(),
+                "conn1:tree".to_string(),
                 "conn1:set_text ref=1".to_string(),
                 "conn2:tree".to_string(),
                 "conn2:set_text ref=1".to_string(),
@@ -2788,16 +2992,20 @@ mod tests {
             writeln!(w, r#"{{"hello":{{"proto":1}}}}"#)
                 .and_then(|()| w.flush())
                 .expect("hello");
+            // Answers every read, not just the first: a snapshot re-reads until the geometry
+            // repeats.
             let mut line = String::new();
-            r.read_line(&mut line).expect("read request");
-            let req: Value = serde_json::from_str(&line).expect("request is json");
-            let reply = json!({
-                "id": req["id"], "ok": true, "tree": compose_like(),
-                "package": "com.google.android.permissioncontroller"
-            });
-            writeln!(w, "{reply}")
-                .and_then(|()| w.flush())
-                .expect("write reply");
+            while matches!(r.read_line(&mut line), Ok(n) if n > 0) {
+                let req: Value = serde_json::from_str(&line).expect("request is json");
+                let reply = json!({
+                    "id": req["id"], "ok": true, "tree": compose_like(),
+                    "package": "com.google.android.permissioncontroller"
+                });
+                if writeln!(w, "{reply}").and_then(|()| w.flush()).is_err() {
+                    break;
+                }
+                line.clear();
+            }
         });
         let client = ServiceClient::connect(port).expect("connect");
         let mut a = ServiceA11y::new(client, "com.example.app".to_string());
@@ -2829,8 +3037,13 @@ mod tests {
         );
         assert_eq!(
             ops_of(&ops),
-            vec!["conn1:tree".to_string(), "conn1:click ref=1".to_string()],
-            "exactly one click frame, on the one connection"
+            vec![
+                "conn1:tree".to_string(),
+                "conn1:tree".to_string(),
+                "conn1:click ref=1".to_string()
+            ],
+            "exactly one click frame, on the one connection (the second read is the one that \
+             proved the tree had stopped moving)"
         );
     }
 
@@ -2847,7 +3060,11 @@ mod tests {
         assert_eq!(substituted, Some(AxNodeId(1)), "the climb is disclosed");
         assert_eq!(
             ops_of(&ops),
-            vec!["conn1:tree".to_string(), "conn1:click ref=1".to_string()]
+            vec![
+                "conn1:tree".to_string(),
+                "conn1:tree".to_string(),
+                "conn1:click ref=1".to_string()
+            ]
         );
     }
 
@@ -2863,7 +3080,7 @@ mod tests {
         assert!(e.to_string().contains("disabled"), "{e}");
         assert_eq!(
             ops_of(&ops),
-            vec!["conn1:tree".to_string()],
+            vec!["conn1:tree".to_string(), "conn1:tree".to_string()],
             "the refusal must happen before anything is dispatched"
         );
     }
@@ -2883,17 +3100,197 @@ mod tests {
             ops_of(&ops),
             vec![
                 "conn1:tree".to_string(),
+                "conn1:tree".to_string(),
                 "conn1:click ref=1".to_string(),
                 "conn1:tree".to_string()
             ],
-            "the click went out and the state was read back"
+            "the click went out and the state was read back — once, not settled: the read-back \
+             watches a flag, not geometry"
+        );
+    }
+
+    /// The outline of a tree as a caller would read it, ids assigned — bounds included, so two
+    /// of these differ exactly when something moved.
+    fn outline_of(t: &AxTree) -> String {
+        let mut t = t.clone();
+        t.assign_ids();
+        t.to_outline()
+    }
+
+    #[test]
+    fn a_tree_that_plateaus_and_then_moves_again_is_not_handed_back_mid_plateau() {
+        // glass#326, and the exact shape that beat the first attempt at it: the offset decays
+        // in *steps*, so two reads a few ms apart agree across a plateau and prove nothing.
+        // Whatever proves stillness must span longer than a plateau lasts.
+        let (port, _ops) = fake_service_timed(
+            vec![shifted(&compose_like(), 79), compose_like()],
+            vec![
+                std::time::Duration::ZERO,
+                std::time::Duration::from_millis(150),
+            ],
+        );
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let tree = a
+            .snapshot(&ctx())
+            .expect("the content stops moving 150 ms in");
+        assert_eq!(
+            outline_of(&tree),
+            outline_of(&built(&compose_like())),
+            "a plateau is not stillness — the tree handed back must be the settled one"
+        );
+    }
+
+    #[test]
+    fn a_tree_that_stops_moving_is_handed_back_where_it_stopped() {
+        // Every read taken before the offset holds disagrees with the one before it, so the
+        // first pair that agrees is the settled position.
+        let (port, ops) = fake_service(
+            vec![
+                shifted(&compose_like(), 79),
+                shifted(&compose_like(), 31),
+                compose_like(),
+            ],
+            OnAction::Ok,
+        );
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let tree = a
+            .snapshot(&ctx())
+            .expect("it settles well inside the budget");
+        assert_eq!(outline_of(&tree), outline_of(&built(&compose_like())));
+        assert_eq!(
+            ops_of(&ops).len(),
+            4,
+            "three reads to watch the decay, one more to agree with the last"
+        );
+    }
+
+    #[test]
+    fn a_tree_that_never_holds_still_fails_inside_its_budget_and_names_what_moved() {
+        // Bounded, and the give-up carries what was seen. Nothing but reads may repeat.
+        let jitter: Vec<Value> = (0..64)
+            .map(|i| shifted(&compose_like(), if i % 2 == 0 { 0 } else { 20 }))
+            .collect();
+        let (port, ops) = fake_service(jitter, OnAction::Ok);
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let started = std::time::Instant::now();
+        let e = a
+            .snapshot(&ctx())
+            .expect_err("a tree that never holds still is not a snapshot");
+        let waited = started.elapsed();
+        assert!(
+            waited >= SETTLE_TIMEOUT,
+            "gave up after {waited:?}, before the budget it was given"
+        );
+        let m = e.to_string();
+        assert!(m.contains("element #1"), "names what moved: {m}");
+        assert!(m.contains("moving"), "{m}");
+        assert!(
+            m.contains("dx 20") || m.contains("dx -20"),
+            "the delta: {m}"
+        );
+        assert!(m.contains("ms"), "how long it watched: {m}");
+        assert!(
+            ops_of(&ops).iter().all(|o| o == "conn1:tree"),
+            "only tree reads may repeat: {:?}",
+            ops_of(&ops)
+        );
+    }
+
+    #[test]
+    fn a_target_on_a_tree_that_never_holds_still_is_never_clicked() {
+        let jitter: Vec<Value> = (0..64)
+            .map(|i| shifted(&compose_like(), if i % 2 == 0 { 0 } else { 20 }))
+            .collect();
+        let (port, ops) = fake_service(jitter, OnAction::Ok);
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let t = built(&compose_like());
+        let e = a
+            .invoke(&ctx(), &target_for(&t, AxNodeId(2)))
+            .expect_err("a control that never holds still must not be actuated");
+        assert!(
+            !e.invoke_fallback_eligible(),
+            "a moving control must not take a pointer click either: {e}"
+        );
+        assert!(
+            ops_of(&ops).iter().all(|o| o == "conn1:tree"),
+            "nothing may be dispatched: {:?}",
+            ops_of(&ops)
+        );
+    }
+
+    #[test]
+    fn a_still_tree_costs_one_extra_read_and_one_span_of_wall_clock() {
+        // The common path pays for the read that proves stillness and one span, and nothing
+        // beyond it — so a later change cannot quietly put a second wait on every read.
+        let (port, ops) = fake_service(vec![compose_like()], OnAction::Ok);
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let started = std::time::Instant::now();
+        a.snapshot(&ctx()).expect("nothing is moving");
+        let elapsed = started.elapsed();
+        assert_eq!(
+            ops_of(&ops),
+            vec!["conn1:tree".to_string(), "conn1:tree".to_string()],
+            "the read that proved stillness, and nothing beyond it"
+        );
+        assert!(
+            elapsed >= SETTLE_SPAN,
+            "the compared reads must be a span apart; took {elapsed:?}"
+        );
+        assert!(
+            elapsed < SETTLE_SPAN * 2,
+            "one span, not two; took {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn a_settled_target_that_moved_since_the_caller_looked_is_still_refused() {
+        // Settling must not launder a stale target — these reads agree with each other and
+        // still sit 20 px from where the caller looked.
+        let (port, ops) = fake_service(vec![shifted(&compose_like(), 20)], OnAction::Ok);
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let t = built(&compose_like());
+        let e = a
+            .invoke(&ctx(), &target_for(&t, AxNodeId(2)))
+            .expect_err("an element that moved since the caller's snapshot must not be actuated");
+        assert!(matches!(e, GlassError::AxElementChanged(2)), "{e}");
+        assert!(!e.invoke_fallback_eligible(), "{e}");
+        assert_eq!(
+            ops_of(&ops),
+            vec!["conn1:tree".to_string(), "conn1:tree".to_string()],
+            "the refusal must happen before anything is dispatched"
+        );
+    }
+
+    #[test]
+    fn set_values_guard_reads_a_settled_tree_and_its_read_back_does_not() {
+        // `set_value` runs the same fingerprint guard as `invoke` over the tree `snapshot`
+        // hands it, so settling covers it with no change of its own; its post-write read-back
+        // does not settle, having run after the write went out.
+        let (port, ops) = fake_service(vec![editable_field("new")], OnAction::Ok);
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let t = built(&editable_field("new"));
+        a.set_value(&ctx(), &target_for(&t, AxNodeId(1)), "new")
+            .expect("the field is not moving and already reads back the value");
+        assert_eq!(
+            ops_of(&ops),
+            vec![
+                "conn1:tree".to_string(),
+                "conn1:tree".to_string(),
+                "conn1:set_text ref=1".to_string(),
+                "conn1:tree".to_string(),
+            ],
+            "two reads to settle the guard's tree, one to read the write back"
         );
     }
 
     #[test]
     fn a_toggle_that_flips_is_reported_clicked() {
+        // The plan comes from the read that proved stillness, so a box already reading checked
+        // by then would be planned as a flip back to false. Stillness is geometry — a `checked`
+        // that changes under the re-read is not motion.
         let (port, _) = fake_service(
             vec![
+                one_checkable("android.widget.CheckBox", false),
                 one_checkable("android.widget.CheckBox", false),
                 one_checkable("android.widget.CheckBox", true),
             ],

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -306,26 +306,12 @@ fn rearm_tree(conn: &mut Conn, pkg: &str) -> Result<()> {
 const CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 const CHECK_POLL: std::time::Duration = std::time::Duration::from_millis(150);
 
-/// How long [`ServiceA11y::settled_tree`] re-reads waiting for the target to stop moving. An
-/// activity-open transition animates for ~500 ms, and its offsets reach the accessibility tree
-/// up to ~100 ms after the platform calls it finished.
-const SETTLE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(1500);
-/// The pause after two reads that disagreed — a device read costs ~50 ms on its own, against an
-/// offset that steps in ~60 ms jumps.
-const SETTLE_POLL: std::time::Duration = std::time::Duration::from_millis(20);
-
 /// The Accessibility reader backed by the on-device service. `package` is the target app.
 pub struct ServiceA11y {
     client: ServiceClient,
     package: String,
     /// How long [`Self::wait_for_check`] polls; [`CHECK_TIMEOUT`] outside tests.
     check_timeout: std::time::Duration,
-    /// How long [`Self::settled_tree`] re-reads; [`SETTLE_TIMEOUT`] outside tests.
-    settle_timeout: std::time::Duration,
-    /// What [`Self::settled_tree`] waits after two reads that disagreed; [`SETTLE_POLL`] outside
-    /// tests, where the still-path test inflates it so a wait added there cannot hide in
-    /// loopback latency.
-    settle_poll: std::time::Duration,
 }
 
 impl ServiceA11y {
@@ -334,8 +320,6 @@ impl ServiceA11y {
             client,
             package,
             check_timeout: CHECK_TIMEOUT,
-            settle_timeout: SETTLE_TIMEOUT,
-            settle_poll: SETTLE_POLL,
         }
     }
 
@@ -355,63 +339,6 @@ impl ServiceA11y {
                 return Err(check_timeout(plan.target.0, &plan.actuated, want, seen));
             }
             std::thread::sleep(CHECK_POLL);
-        }
-    }
-
-    /// One numbered snapshot — the pair of steps every guard in this reader starts from.
-    fn numbered_snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
-        let mut t = self.snapshot(ctx)?;
-        t.assign_ids();
-        Ok(t)
-    }
-
-    /// Re-read until `target`'s geometry holds still, and hand back the read that proved it.
-    ///
-    /// glass#326: a window whose activity-open transition is still animating reports its content
-    /// at an +x offset that decays in steps, so two reads milliseconds apart describe the same
-    /// control in two places. Acting on such a read is what trips the ±8 px staleness check here
-    /// and the companion's exact re-find on the device.
-    ///
-    /// What has to hold still is the root→target path: the target itself (what the staleness
-    /// check compares) and its ancestors (where [`actuable_node`] climbs, and the node the
-    /// companion re-finds by exact bounds). Nodes off that path are not watched, so an animation
-    /// elsewhere in the app cannot make every click time out.
-    fn settled_tree(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<AxTree> {
-        let started = std::time::Instant::now();
-        let deadline = started + self.settle_timeout;
-        let first = self.numbered_snapshot(ctx)?;
-        // A read the target is not in is not something re-reading fixes; `invoke_plan` names it.
-        let Some(mut seen) = chain_bounds(&first, target.id) else {
-            return Ok(first);
-        };
-        let mut drift = None;
-        let mut agreed = 0usize;
-        loop {
-            let next = self.numbered_snapshot(ctx)?;
-            let Some(chain) = chain_bounds(&next, target.id) else {
-                return Ok(next);
-            };
-            if chain == seen {
-                agreed += 1;
-                // One agreement stands only while nothing has been seen moving: an offset that
-                // decays in steps holds still across a single pair of reads (measured: the same
-                // bounds 157 ms apart, then a new position 7 ms later).
-                if agreed >= if drift.is_some() { 2 } else { 1 } {
-                    return Ok(next);
-                }
-            } else {
-                drift = Some(drift_between(&seen, &chain));
-                agreed = 0;
-            }
-            seen = chain;
-            if std::time::Instant::now() >= deadline {
-                return Err(never_settled(
-                    target.id.0,
-                    drift.as_deref(),
-                    started.elapsed(),
-                ));
-            }
-            std::thread::sleep(self.settle_poll);
         }
     }
 
@@ -514,10 +441,11 @@ impl Accessibility for ServiceA11y {
     }
 
     fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<Option<AxNodeId>> {
-        // Settling comes before the plan, not after it: the plan's guards compare a live read
-        // against the caller's snapshot, and a read taken mid-animation is what makes them
-        // reject a target that is fine.
-        let tree = self.settled_tree(ctx, target)?;
+        let tree = {
+            let mut t = self.snapshot(ctx)?;
+            t.assign_ids();
+            t
+        };
         let plan = invoke_plan(&tree, target)?;
         self.dispatch_click(ctx, target, &plan, tree.subject.as_ref())
     }
@@ -918,70 +846,6 @@ fn actuable_node<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&'a AxNode> 
         .find(|n| n.states.focusable && (n.id == target.id || encloses(n.bounds, want)))
         .copied()
         .ok_or(GlassError::AxActionUnavailable(target.id.0))
-}
-
-/// Every node on the root→`id` path as `(id, bounds)`, target last — the geometry
-/// [`ServiceA11y::settled_tree`] watches. `None` when `id` is not in this tree.
-fn chain_bounds(tree: &AxTree, id: AxNodeId) -> Option<Vec<(AxNodeId, Option<AxRect>)>> {
-    let mut path = Vec::new();
-    path_to(&tree.root, id, &mut path).then(|| path.iter().map(|n| (n.id, n.bounds)).collect())
-}
-
-/// How two reads of the target's path disagreed, worded for [`never_settled`].
-fn drift_between(a: &[(AxNodeId, Option<AxRect>)], b: &[(AxNodeId, Option<AxRect>)]) -> String {
-    for (&(id, from), &(other, to)) in a.iter().zip(b) {
-        if id != other {
-            return format!(
-                "the path to it now runs through element #{} where it ran through #{}",
-                other.0, id.0
-            );
-        }
-        if from != to {
-            return format!("element #{} moved {}", id.0, movement(from, to));
-        }
-    }
-    format!(
-        "the path to it changed length between reads ({} nodes, then {})",
-        a.len(),
-        b.len()
-    )
-}
-
-/// `from` → `to`, with the per-edge deltas when both sides reported bounds.
-fn movement(from: Option<AxRect>, to: Option<AxRect>) -> String {
-    let deltas = match (from, to) {
-        (Some(f), Some(t)) => format!(
-            " (dx {}, dy {}, dw {}, dh {})",
-            i64::from(t.x) - i64::from(f.x),
-            i64::from(t.y) - i64::from(f.y),
-            i64::from(t.width) - i64::from(f.width),
-            i64::from(t.height) - i64::from(f.height),
-        ),
-        _ => String::new(),
-    };
-    format!("from {} to {}{deltas}", rect(from), rect(to))
-}
-
-/// One rect as `(x,y wxh)`, or `no bounds`.
-fn rect(r: Option<AxRect>) -> String {
-    r.map_or_else(
-        || "no bounds".to_string(),
-        |r| format!("({},{} {}x{})", r.x, r.y, r.width, r.height),
-    )
-}
-
-/// Nothing was dispatched: the target never stopped moving inside the budget. Deliberately not
-/// `invoke_fallback_eligible` — a control that is mid-animation is the last thing to aim a
-/// pointer click at.
-fn never_settled(id: u32, drift: Option<&str>, elapsed: std::time::Duration) -> GlassError {
-    GlassError::Backend(format!(
-        "element #{id} is still moving after {} ms of re-reads, so nothing was clicked: {}. An \
-         activity-open transition settles in about half a second — re-snapshot until the bounds \
-         repeat, then retry",
-        elapsed.as_millis(),
-        // Unreachable: reaching the deadline takes a disagreement, which records one.
-        drift.unwrap_or("its bounds kept changing between reads"),
-    ))
 }
 
 /// The root-to-`id` path, inclusive of both ends. False when `id` is not in this subtree,
@@ -1488,28 +1352,6 @@ mod tests {
                  ]}
             ]
         })
-    }
-
-    /// [`compose_like`] with everything below the root shifted `dx` px right. A Compose window
-    /// whose activity-open transition is still animating reports exactly this: a uniform +x
-    /// offset on the content, decaying to zero over the ~500 ms the transition runs (glass#326).
-    fn compose_shifted(dx: i64) -> Value {
-        fn shift(v: &mut Value, dx: i64) {
-            if let Some(x) = v["bounds"]["x"].as_i64() {
-                v["bounds"]["x"] = json!(x + dx);
-            }
-            for c in v["children"].as_array_mut().into_iter().flatten() {
-                shift(c, dx);
-            }
-        }
-        let mut v = compose_like();
-        for c in v["children"]
-            .as_array_mut()
-            .expect("compose_like has children")
-        {
-            shift(c, dx);
-        }
-        v
     }
 
     fn built(v: &Value) -> AxTree {
@@ -2987,13 +2829,8 @@ mod tests {
         );
         assert_eq!(
             ops_of(&ops),
-            vec![
-                "conn1:tree".to_string(),
-                "conn1:tree".to_string(),
-                "conn1:click ref=1".to_string()
-            ],
-            "exactly one click frame, on the one connection (the second tree is the re-read \
-             that proved the target had stopped moving)"
+            vec!["conn1:tree".to_string(), "conn1:click ref=1".to_string()],
+            "exactly one click frame, on the one connection"
         );
     }
 
@@ -3010,154 +2847,7 @@ mod tests {
         assert_eq!(substituted, Some(AxNodeId(1)), "the climb is disclosed");
         assert_eq!(
             ops_of(&ops),
-            vec![
-                "conn1:tree".to_string(),
-                "conn1:tree".to_string(),
-                "conn1:click ref=1".to_string()
-            ]
-        );
-    }
-
-    #[test]
-    fn a_target_whose_bounds_are_still_moving_is_not_clicked_until_they_hold_still() {
-        // glass#326. The caller's target holds the settled geometry; every read taken while the
-        // activity-open transition animates describes the same control somewhere else, and
-        // acting on one of those either trips the host's staleness guard or hands the companion
-        // bounds it can no longer re-find.
-        let (port, ops) = fake_service(
-            vec![compose_shifted(79), compose_shifted(31), compose_like()],
-            OnAction::Ok,
-        );
-        let mut a = reader(port, std::time::Duration::ZERO);
-        let t = built(&compose_like());
-        let substituted = a
-            .invoke(&ctx(), &target_for(&t, AxNodeId(2)))
-            .expect("the reads that agreed describe the element the caller named");
-        assert_eq!(substituted, Some(AxNodeId(1)), "the climb is disclosed");
-        assert_eq!(
-            ops_of(&ops),
-            vec![
-                "conn1:tree".to_string(),
-                "conn1:tree".to_string(),
-                "conn1:tree".to_string(),
-                "conn1:tree".to_string(),
-                "conn1:tree".to_string(),
-                "conn1:click ref=1".to_string(),
-            ],
-            "exactly one click, after the reads agreed — nothing may go out while it moves"
-        );
-    }
-
-    #[test]
-    fn a_still_target_whose_clickable_ancestor_moves_is_not_clicked_either() {
-        // One walk is not atomic, so a moving window can report the label at its settled
-        // position and its clickable parent an animation frame behind. The parent is the node
-        // the click is addressed to, and the one the companion re-finds by exact bounds.
-        let mut moving_parent = compose_like();
-        moving_parent["children"][0]["bounds"]["x"] = json!(139); // its settled 60, offset by 79
-        let (port, ops) = fake_service(vec![moving_parent, compose_like()], OnAction::Ok);
-        let mut a = reader(port, std::time::Duration::ZERO);
-        let t = built(&compose_like());
-        a.invoke(&ctx(), &target_for(&t, AxNodeId(2)))
-            .expect("the reads that agreed describe a control that has stopped moving");
-        assert_eq!(
-            ops_of(&ops),
-            vec![
-                "conn1:tree".to_string(),
-                "conn1:tree".to_string(),
-                "conn1:tree".to_string(),
-                "conn1:tree".to_string(),
-                "conn1:click ref=1".to_string(),
-            ],
-            "the target never moved, but the node being clicked did"
-        );
-    }
-
-    #[test]
-    fn a_still_target_is_clicked_after_two_agreeing_reads_and_no_wait_at_all() {
-        // The common case pays for the re-read that proves nothing is moving and nothing else —
-        // no sleep, no third read — so a later change cannot quietly put a wait on the path
-        // every click takes.
-        let (port, ops) = fake_service(vec![compose_like()], OnAction::Ok);
-        let mut a = reader(port, std::time::Duration::ZERO);
-        // Outsized on purpose: a loopback round trip already costs ~40 ms here, so a wait at the
-        // production 20 ms would not stand out.
-        a.settle_poll = std::time::Duration::from_secs(5);
-        let t = built(&compose_like());
-        let started = std::time::Instant::now();
-        a.invoke(&ctx(), &target_for(&t, AxNodeId(2)))
-            .expect("nothing is moving");
-        let elapsed = started.elapsed();
-        assert_eq!(
-            ops_of(&ops),
-            vec![
-                "conn1:tree".to_string(),
-                "conn1:tree".to_string(),
-                "conn1:click ref=1".to_string(),
-            ],
-            "the re-read that proved stillness, and nothing beyond it"
-        );
-        assert!(
-            elapsed < std::time::Duration::from_secs(1),
-            "two agreeing reads must proceed without waiting; took {elapsed:?}"
-        );
-    }
-
-    #[test]
-    fn a_target_that_never_stops_moving_fails_inside_its_budget_and_names_what_moved() {
-        // Bounded: the reads never agree, so nothing is ever actuated, and the give-up carries
-        // what was seen. The script holds far more entries than the budget can consume — the
-        // fake repeats its last tree, which would look settled.
-        let jitter: Vec<Value> = (0..64)
-            .map(|i| compose_shifted(if i % 2 == 0 { 0 } else { 20 }))
-            .collect();
-        let (port, ops) = fake_service(jitter, OnAction::Ok);
-        let mut a = reader(port, std::time::Duration::ZERO);
-        let budget = std::time::Duration::from_millis(200);
-        a.settle_timeout = budget;
-        let t = built(&compose_like());
-        let started = std::time::Instant::now();
-        let e = a
-            .invoke(&ctx(), &target_for(&t, AxNodeId(2)))
-            .expect_err("a control that never holds still must not be actuated");
-        let waited = started.elapsed();
-        assert!(
-            waited >= budget,
-            "gave up after {waited:?}, before the budget it was given"
-        );
-        let m = e.to_string();
-        assert!(m.contains("element #2"), "{m}");
-        assert!(m.contains("moving"), "{m}");
-        assert!(m.contains("dx"), "the delta it kept seeing: {m}");
-        assert!(m.contains("ms"), "how long it watched: {m}");
-        assert!(
-            !e.invoke_fallback_eligible(),
-            "a moving control must not take a pointer click either: {e}"
-        );
-        let ops = ops_of(&ops);
-        assert!(
-            ops.iter().all(|o| o == "conn1:tree"),
-            "nothing may be dispatched: {ops:?}"
-        );
-    }
-
-    #[test]
-    fn a_settled_target_that_moved_since_the_caller_looked_is_still_refused() {
-        // Waiting for stillness must not launder a stale target: these reads agree with each
-        // other and sit 20 px from where the caller saw the element, which is what the ±8 px
-        // staleness guard is for.
-        let (port, ops) = fake_service(vec![compose_shifted(20)], OnAction::Ok);
-        let mut a = reader(port, std::time::Duration::ZERO);
-        let t = built(&compose_like());
-        let e = a
-            .invoke(&ctx(), &target_for(&t, AxNodeId(2)))
-            .expect_err("an element that moved since the caller's snapshot must not be actuated");
-        assert!(matches!(e, GlassError::AxElementChanged(2)), "{e}");
-        assert!(!e.invoke_fallback_eligible(), "{e}");
-        assert_eq!(
-            ops_of(&ops),
-            vec!["conn1:tree".to_string(), "conn1:tree".to_string()],
-            "the refusal must happen before anything is dispatched"
+            vec!["conn1:tree".to_string(), "conn1:click ref=1".to_string()]
         );
     }
 
@@ -3173,7 +2863,7 @@ mod tests {
         assert!(e.to_string().contains("disabled"), "{e}");
         assert_eq!(
             ops_of(&ops),
-            vec!["conn1:tree".to_string(), "conn1:tree".to_string()],
+            vec!["conn1:tree".to_string()],
             "the refusal must happen before anything is dispatched"
         );
     }
@@ -3193,7 +2883,6 @@ mod tests {
             ops_of(&ops),
             vec![
                 "conn1:tree".to_string(),
-                "conn1:tree".to_string(),
                 "conn1:click ref=1".to_string(),
                 "conn1:tree".to_string()
             ],
@@ -3203,12 +2892,8 @@ mod tests {
 
     #[test]
     fn a_toggle_that_flips_is_reported_clicked() {
-        // Two unchecked reads, then the flipped one: the plan comes from the read that proved
-        // stillness, so a box already checked by then would be planned as a flip back to false.
-        // Stillness is geometry — a `checked` that changes under the re-read is not motion.
         let (port, _) = fake_service(
             vec![
-                one_checkable("android.widget.CheckBox", false),
                 one_checkable("android.widget.CheckBox", false),
                 one_checkable("android.widget.CheckBox", true),
             ],

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -306,6 +306,28 @@ fn rearm_tree(conn: &mut Conn, pkg: &str) -> Result<()> {
 const CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 const CHECK_POLL: std::time::Duration = std::time::Duration::from_millis(150);
 
+/// How many times [`ServiceA11y::on_a_fresh_tree`] may read the tree, how long it waits between
+/// reads, and the wall clock the whole ladder may spend — all three spent only after a refusal.
+///
+/// An activity-open transition slides its content for ~600 ms and holds each position for up to
+/// ~365 ms, so the reads have to be *spread* rather than merely repeated: four reads one pause
+/// apart span ~600 ms and cross every plateau. The budget ends the ladder early on a tree whose
+/// own reads cover that span in fewer attempts (several hundred nodes read in ~180 ms).
+const RETRY_ATTEMPTS: usize = 4;
+const RETRY_PAUSE: std::time::Duration = std::time::Duration::from_millis(200);
+const RETRY_BUDGET: std::time::Duration = std::time::Duration::from_millis(900);
+
+/// A failed attempt at reading the tree, resolving a target in it and acting on it — and whether
+/// repeating the whole attempt can act twice.
+#[derive(Debug)]
+enum Refusal {
+    /// Raised because the target was somewhere else, and raised before anything reached the
+    /// control. A later read may find it where the caller saw it.
+    Moved(GlassError),
+    /// Everything else, including every outcome that may already have reached the device.
+    Final(GlassError),
+}
+
 /// The Accessibility reader backed by the on-device service. `package` is the target app.
 pub struct ServiceA11y {
     client: ServiceClient,
@@ -355,15 +377,51 @@ impl ServiceA11y {
         target: &AxTarget,
         plan: &InvokePlan,
         subject: Option<&Subject>,
-    ) -> Result<Option<AxNodeId>> {
+    ) -> std::result::Result<Option<AxNodeId>, Refusal> {
         let acting_on = subject.map_or(self.package.as_str(), |s| s.actual.as_str());
         self.client
             .click(plan.actuated.id.0, acting_on)
-            .map_err(|f| action_error(target.id.0, f))?;
+            .map_err(|f| click_refusal(target.id.0, f))?;
         if let Some(want) = plan.want_checked {
-            self.wait_for_check(ctx, plan, want)?;
+            // The click has gone out; from here nothing may be repeated.
+            self.wait_for_check(ctx, plan, want)
+                .map_err(Refusal::Final)?;
         }
         Ok(plan.substituted())
+    }
+
+    /// Read + number the tree, run `attempt` against it, and repeat while `attempt` reports the
+    /// target moved under it — up to [`RETRY_ATTEMPTS`] reads, [`RETRY_PAUSE`] apart, within
+    /// [`RETRY_BUDGET`].
+    ///
+    /// The whole attempt is re-run, so it is sound only because [`Refusal::Moved`] is reserved
+    /// for refusals raised before anything reached the control.
+    fn on_a_fresh_tree<T>(
+        &mut self,
+        ctx: &AxContext,
+        target: &AxTarget,
+        mut attempt: impl FnMut(&mut Self, &AxTree) -> std::result::Result<T, Refusal>,
+    ) -> Result<T> {
+        let started = std::time::Instant::now();
+        let mut found_at = Vec::new();
+        loop {
+            let tree = {
+                let mut t = self.snapshot(ctx)?;
+                t.assign_ids();
+                t
+            };
+            match attempt(self, &tree) {
+                Ok(v) => return Ok(v),
+                Err(Refusal::Final(e)) => return Err(e),
+                Err(Refusal::Moved(e)) => {
+                    found_at.push(tree.find(target.id).and_then(|n| n.bounds));
+                    if found_at.len() >= RETRY_ATTEMPTS || started.elapsed() >= RETRY_BUDGET {
+                        return Err(kept_moving(target, &found_at, started.elapsed(), e));
+                    }
+                    std::thread::sleep(RETRY_PAUSE);
+                }
+            }
+        }
     }
 }
 
@@ -388,19 +446,21 @@ impl Accessibility for ServiceA11y {
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
         // Guard: re-snapshot and verify the ref still points at the same editable element before
         // acting. Shared with `AndroidA11y::set_value`, so both readers refuse the same drift.
-        let tree = {
-            let mut t = self.snapshot(ctx)?;
-            t.assign_ids();
-            t
-        };
-        crate::a11y::editable_target(&tree, target)?;
-        // Re-arm against the app the served tree actually described, not the one asked about —
-        // that's the app `target`'s ref came from (see `rearm_tree`).
-        let acting_on = tree
-            .subject
-            .as_ref()
-            .map_or(self.package.as_str(), |s| s.actual.as_str());
-        self.client.set_text(target.id.0, text, acting_on)?;
+        self.on_a_fresh_tree(ctx, target, |a, tree| {
+            crate::a11y::editable_target(tree, target)
+                .map_err(|e| moved_or_final(e, tree, target))?;
+            // Re-arm against the app the served tree actually described, not the one asked about —
+            // that's the app `target`'s ref came from (see `rearm_tree`).
+            let acting_on = tree
+                .subject
+                .as_ref()
+                .map_or(a.package.as_str(), |s| s.actual.as_str());
+            // `set_text` consumes its own `CallFailure`, so its refusals cannot be told apart
+            // by delivery here.
+            a.client
+                .set_text(target.id.0, text, acting_on)
+                .map_err(Refusal::Final)
+        })?;
         // Verify the value actually took. ACTION_SET_TEXT returns success but silently no-ops when
         // *replacing* existing text in a Compose field, so a bare Ok could lie (glass forbids silent
         // fallbacks). The set is async (Compose recompose → a11y update), so poll briefly for the
@@ -441,13 +501,10 @@ impl Accessibility for ServiceA11y {
     }
 
     fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<Option<AxNodeId>> {
-        let tree = {
-            let mut t = self.snapshot(ctx)?;
-            t.assign_ids();
-            t
-        };
-        let plan = invoke_plan(&tree, target)?;
-        self.dispatch_click(ctx, target, &plan, tree.subject.as_ref())
+        self.on_a_fresh_tree(ctx, target, |a, tree| {
+            let plan = invoke_plan(tree, target).map_err(|e| moved_or_final(e, tree, target))?;
+            a.dispatch_click(ctx, target, &plan, tree.subject.as_ref())
+        })
     }
 }
 
@@ -906,6 +963,81 @@ fn action_error(target: u32, f: CallFailure) -> GlassError {
         )),
         CallFailure::Refused(e) => GlassError::AxActionFailed(target, e.to_string()),
     }
+}
+
+/// [`action_error`], plus whether the companion refused before it touched the control — the only
+/// click failure a fresh attempt may repeat.
+fn click_refusal(target: u32, f: CallFailure) -> Refusal {
+    let repeatable = refused_before_acting(&f);
+    let e = action_error(target, f);
+    if repeatable {
+        Refusal::Moved(e)
+    } else {
+        Refusal::Final(e)
+    }
+}
+
+/// The companion's `matchLive` refusal: its live re-read holds no node at the bounds of the tree
+/// it served, thrown before `performOn` (`GlassA11yService.kt`'s `liveSink`), so the control was
+/// never touched. Matched on the message because the protocol carries no error code.
+///
+/// Do not widen: every other `Refused` either ran the action or is an answer this client could
+/// not read, and neither says the control was left alone.
+fn refused_before_acting(f: &CallFailure) -> bool {
+    matches!(f, CallFailure::Refused(e) if e.to_string().contains("live node gone"))
+}
+
+/// Classify a resolution failure raised against `tree`: only [`GlassError::AxElementChanged`]
+/// for an element that is still itself is worth another read.
+///
+/// `crate::a11y::fingerprinted` rejects on role/name, on bounds and on value, so role, name and
+/// value still matching means the bounds rejected — the element standing somewhere else, which a
+/// later read can find. A role/name/value drift is a different element that inherited the id.
+fn moved_or_final(e: GlassError, tree: &AxTree, target: &AxTarget) -> Refusal {
+    let still_itself = tree.find(target.id).is_some_and(|n| {
+        target.matches(n.role, n.name.as_deref()) && target.value_consistent(n.value.as_deref())
+    });
+    if matches!(e, GlassError::AxElementChanged(_)) && still_itself {
+        Refusal::Moved(e)
+    } else {
+        Refusal::Final(e)
+    }
+}
+
+/// The refusal for a target that every read found somewhere else. It names where each read found
+/// it because `last` alone says only that the two disagree, and which of them is the stale one is
+/// not something this side can tell.
+fn kept_moving(
+    target: &AxTarget,
+    found_at: &[Option<AxRect>],
+    elapsed: std::time::Duration,
+    last: GlassError,
+) -> GlassError {
+    let found = found_at
+        .iter()
+        .copied()
+        .map(rect)
+        .collect::<Vec<_>>()
+        .join(", ");
+    GlassError::AxActionFailed(
+        target.id.0,
+        format!(
+            "the element moved under all {} reads taken over {} ms, so nothing was dispatched: \
+             the snapshot has it at {}, the re-reads found it at {found} ({last}). A screen whose \
+             open transition is still animating settles in about half a second — retry once it has",
+            found_at.len(),
+            elapsed.as_millis(),
+            rect(target.bounds),
+        ),
+    )
+}
+
+/// `(x,y wxh)`, or `absent` for an element no longer in the tree.
+fn rect(b: Option<AxRect>) -> String {
+    b.map_or_else(
+        || "absent".to_string(),
+        |r| format!("({},{} {}x{})", r.x, r.y, r.width, r.height),
+    )
 }
 
 /// The error for a control whose click was accepted but whose state never reached `want`.
@@ -1957,6 +2089,11 @@ mod tests {
         /// Read the request, then drop the socket without answering — the shape of an answer
         /// lost to a read timeout, a rebinding service or a reset `adb forward` tunnel.
         DropWithoutAnswering,
+        /// Answer `ok:false` with `msg` for the first `n` actions on each connection, then answer
+        /// normally — the shape of the companion's own per-action refusals (`matchLive` failing),
+        /// which leave the socket up. Logged as `{action}-refused`, so a request the device threw
+        /// out before touching the control is distinguishable from one it actuated.
+        RefusedFirst(usize, &'static str),
     }
 
     /// What a fake `tree` reply's `package` field says, relative to what was asked.
@@ -2043,6 +2180,7 @@ mod tests {
                     break;
                 }
                 let mut tree_confirmed = false;
+                let mut refused = 0usize;
                 loop {
                     let mut line = String::new();
                     if !matches!(r.read_line(&mut line), Ok(n) if n > 0) {
@@ -2094,14 +2232,27 @@ mod tests {
                                    "error": "no tree has been served on this connection"})
                         }
                         "action" => {
-                            log.lock().unwrap().push(format!(
-                                "conn{conn}:{} ref={}",
-                                req["action"].as_str().unwrap_or_default(),
-                                req["ref"]
-                            ));
+                            let act = req["action"].as_str().unwrap_or_default();
+                            let r = &req["ref"];
+                            let record = |suffix: &str| {
+                                log.lock()
+                                    .unwrap()
+                                    .push(format!("conn{conn}:{act}{suffix} ref={r}"));
+                            };
                             match this_action {
-                                OnAction::Ok => json!({"id": id, "ok": true}),
-                                OnAction::DropWithoutAnswering => break,
+                                OnAction::RefusedFirst(n, msg) if refused < n => {
+                                    refused += 1;
+                                    record("-refused");
+                                    json!({"id": id, "ok": false, "error": msg})
+                                }
+                                OnAction::DropWithoutAnswering => {
+                                    record("");
+                                    break;
+                                }
+                                OnAction::Ok | OnAction::RefusedFirst(..) => {
+                                    record("");
+                                    json!({"id": id, "ok": true})
+                                }
                             }
                         }
                         _ => json!({"id": id, "ok": true}),
@@ -2660,9 +2811,14 @@ mod tests {
             .shutdown(std::net::Shutdown::Write)
             .expect("shutdown");
 
-        let e = a
+        let refusal = a
             .dispatch_click(&ctx(), &target, &plan, tree.subject.as_ref())
             .expect_err("the rearm names the asked-about app, not the app the ref came from");
+        // Final, not Moved: only the companion's pre-`performOn` refusal is repeatable, and a
+        // rearm that could not confirm the acting app says nothing about what the click did.
+        let Refusal::Final(e) = refusal else {
+            panic!("a click that may already have gone out must not be repeatable: {refusal:?}")
+        };
         let msg = e.to_string();
         assert!(msg.contains("com.other.app"), "{msg}");
         assert!(msg.contains("com.example.app"), "{msg}");
@@ -2887,6 +3043,224 @@ mod tests {
                 "conn1:tree".to_string()
             ],
             "the click went out and the state was read back"
+        );
+    }
+
+    /// `v` with every node's `x` moved by `dx`, and nothing else touched — the shape of the
+    /// activity-open transition #326 reproduces, in which only `x` ever changes.
+    fn slid(v: &Value, dx: i64) -> Value {
+        fn shift(v: &mut Value, dx: i64) {
+            if let Some(x) = v.pointer_mut("/bounds/x") {
+                *x = json!(x.as_i64().unwrap_or(0) + dx);
+            }
+            for c in v
+                .get_mut("children")
+                .and_then(Value::as_array_mut)
+                .into_iter()
+                .flatten()
+            {
+                shift(c, dx);
+            }
+        }
+        let mut v = v.clone();
+        shift(&mut v, dx);
+        v
+    }
+
+    #[test]
+    fn a_target_that_moved_under_the_first_read_is_actuated_from_a_second() {
+        // The caller's target came from the settled tree; `invoke`'s own read catches the open
+        // transition 79 px along, so the guard's ±8 px check refuses it.
+        let (port, ops) = fake_service(
+            vec![slid(&compose_like(), 79), compose_like()],
+            OnAction::Ok,
+        );
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let t = built(&compose_like());
+        let substituted = a
+            .invoke(&ctx(), &target_for(&t, AxNodeId(2)))
+            .expect("a re-read that finds the target where the caller saw it must actuate it");
+        assert_eq!(substituted, Some(AxNodeId(1)), "the climb is disclosed");
+        assert_eq!(
+            ops_of(&ops),
+            vec![
+                "conn1:tree".to_string(),
+                "conn1:tree".to_string(),
+                "conn1:click ref=1".to_string(),
+            ],
+            "one re-read, then exactly one dispatch"
+        );
+    }
+
+    #[test]
+    fn a_click_the_device_refused_before_touching_the_control_is_retried_on_a_fresh_read() {
+        // "live node gone" is the companion's `matchLive` finding no node at the bounds of the
+        // tree it served (`GlassA11yService.kt`'s `liveSink`); it throws before `performOn`, so
+        // nothing was actuated and the whole attempt may be repeated.
+        let (port, ops) = fake_service_ex(
+            vec![compose_like()],
+            vec![OnAction::RefusedFirst(1, "live node gone")],
+            vec![TreePackage::Echo],
+        );
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let t = built(&compose_like());
+        a.invoke(&ctx(), &target_for(&t, AxNodeId(2)))
+            .expect("a refusal raised before the control was touched must be retried");
+        assert_eq!(
+            ops_of(&ops),
+            vec![
+                "conn1:tree".to_string(),
+                "conn1:click-refused ref=1".to_string(),
+                "conn1:tree".to_string(),
+                "conn1:click ref=1".to_string(),
+            ],
+            "exactly one dispatch: the refused frame never reached the control"
+        );
+    }
+
+    #[test]
+    fn a_target_that_never_stops_moving_is_refused_within_the_bound_and_names_where_it_went() {
+        let (port, ops) = fake_service(
+            vec![
+                slid(&compose_like(), 79),
+                slid(&compose_like(), 31),
+                slid(&compose_like(), 23),
+                slid(&compose_like(), 18),
+            ],
+            OnAction::Ok,
+        );
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let t = built(&compose_like());
+        let started = std::time::Instant::now();
+        let e = a
+            .invoke(&ctx(), &target_for(&t, AxNodeId(2)))
+            .expect_err("a target that never stops moving must not be clicked");
+        let elapsed = started.elapsed();
+        assert!(!e.invoke_fallback_eligible(), "{e}");
+        let msg = e.to_string();
+        for want in [
+            "#2",
+            "(120,420 80x50)",
+            "(199,420 80x50)",
+            "(151,420 80x50)",
+            "(143,420 80x50)",
+            "(138,420 80x50)",
+            "re-snapshot",
+        ] {
+            assert!(msg.contains(want), "{want:?} missing from: {msg}");
+        }
+        assert_eq!(
+            ops_of(&ops),
+            vec!["conn1:tree".to_string(); 4],
+            "four reads, and nothing dispatched at any point"
+        );
+        assert!(
+            elapsed >= std::time::Duration::from_millis(600),
+            "the reads must be spread across the slide, not merely repeated: {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn a_click_whose_answer_was_lost_is_never_retried_even_when_the_retry_would_succeed() {
+        // The ambiguous class: the request went out and no answer came back. `on_action`'s second
+        // entry answers `ok` on the connection a retry would open, so a retry here would report a
+        // clean success having actuated the control twice.
+        let (port, ops) = fake_service_ex(
+            vec![compose_like()],
+            vec![OnAction::DropWithoutAnswering, OnAction::Ok],
+            vec![TreePackage::Echo],
+        );
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let t = built(&compose_like());
+        let e = a
+            .invoke(&ctx(), &target_for(&t, AxNodeId(2)))
+            .expect_err("a lost answer is not a success");
+        assert!(
+            e.to_string().contains("may or may not have actuated"),
+            "{e}"
+        );
+        assert_eq!(
+            ops_of(&ops),
+            vec!["conn1:tree".to_string(), "conn1:click ref=1".to_string()],
+            "exactly one click frame — a failure that may have reached the device is never repeated"
+        );
+    }
+
+    #[test]
+    fn an_invoke_on_a_tree_that_did_not_move_costs_no_extra_read_and_no_wait() {
+        let (port, ops) = fake_service(vec![compose_like()], OnAction::Ok);
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let t = built(&compose_like());
+        let started = std::time::Instant::now();
+        a.invoke(&ctx(), &target_for(&t, AxNodeId(2)))
+            .expect("clicks");
+        let elapsed = started.elapsed();
+        assert_eq!(
+            ops_of(&ops),
+            vec!["conn1:tree".to_string(), "conn1:click ref=1".to_string()],
+            "the read the plan came from, and the click — nothing else"
+        );
+        assert!(
+            elapsed < RETRY_PAUSE,
+            "not even one pause may be spent when there is nothing to recover from: {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn an_element_that_exposes_no_activation_action_is_refused_without_spending_the_budget() {
+        // Permanent, and the one resolution error the caller may answer with a pointer click —
+        // re-reading for it delays a fallback that already works.
+        let mut v = compose_like();
+        v["children"][0]["clickable"] = json!(false);
+        let (port, ops) = fake_service(vec![v.clone()], OnAction::Ok);
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let t = built(&v);
+        let e = a
+            .invoke(&ctx(), &target_for(&t, AxNodeId(2)))
+            .expect_err("nothing on the path advertises a click");
+        assert!(e.invoke_fallback_eligible(), "{e}");
+        assert_eq!(ops_of(&ops), vec!["conn1:tree".to_string()]);
+    }
+
+    #[test]
+    fn a_target_whose_name_drifted_is_refused_on_the_first_read() {
+        // The other half of `AxElementChanged`: a different element inherited the id. No re-read
+        // undoes that, and the crisp "re-snapshot" verdict must not be buried under a wait.
+        let (port, ops) = fake_service(vec![compose_like()], OnAction::Ok);
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let t = built(&compose_like());
+        let mut label = target_for(&t, AxNodeId(2));
+        label.name = Some("Send".into());
+        let e = a
+            .invoke(&ctx(), &label)
+            .expect_err("a renamed target must not report success");
+        assert!(matches!(e, GlassError::AxElementChanged(2)), "{e}");
+        assert_eq!(ops_of(&ops), vec!["conn1:tree".to_string()]);
+    }
+
+    #[test]
+    fn set_values_guard_re_reads_a_target_that_moved_rather_than_refusing_it() {
+        // `set_value` guards with `crate::a11y::editable_target` → the same `fingerprinted`, the
+        // same ±8 px bounds check — so a field sliding through an open transition refuses a write
+        // for exactly the reason it refuses a click.
+        let settled = editable_field("old");
+        let (port, ops) = fake_service(
+            vec![slid(&settled, 79), settled.clone(), editable_field("new")],
+            OnAction::Ok,
+        );
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let t = built(&settled);
+        a.set_value(&ctx(), &target_for(&t, AxNodeId(1)), "new")
+            .expect("a re-read that finds the field where the caller saw it must write to it");
+        assert_eq!(
+            ops_of(&ops),
+            vec![
+                "conn1:tree".to_string(),
+                "conn1:tree".to_string(),
+                "conn1:set_text ref=1".to_string(),
+                "conn1:tree".to_string(),
+            ],
+            "one re-read, one write, one read-back"
         );
     }
 

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -387,13 +387,13 @@ impl Accessibility for ServiceA11y {
 
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
         // Guard: re-snapshot and verify the ref still points at the same editable element before
-        // acting. Shared with `AndroidA11y::set_value`, so both readers refuse the same drift.
+        // acting — `invoke`'s guard plus the editable check.
         let tree = {
             let mut t = self.snapshot(ctx)?;
             t.assign_ids();
             t
         };
-        crate::a11y::editable_target(&tree, target)?;
+        resolved_editable_target(&tree, target)?;
         // Re-arm against the app the served tree actually described, not the one asked about —
         // that's the app `target`'s ref came from (see `rearm_tree`).
         let acting_on = tree
@@ -762,13 +762,108 @@ fn toggles(role: AxRole) -> bool {
     matches!(role, AxRole::CheckBox | AxRole::ToggleButton)
 }
 
+/// Whether `node` is the element `target` names, wherever it now sits: same role, name and value,
+/// and exactly the same size.
+fn same_element_moved(target: &AxTarget, node: &AxNode) -> bool {
+    target.matches(node.role, node.name.as_deref())
+        && target.value_consistent(node.value.as_deref())
+        && matches!(
+            (target.bounds, node.bounds),
+            (Some(a), Some(b)) if a.width == b.width && a.height == b.height
+        )
+}
+
+/// Every node [`same_element_moved`] accepts for `target`, in pre-order.
+fn movement_candidates<'a>(tree: &'a AxTree, target: &AxTarget) -> Vec<&'a AxNode> {
+    fn walk<'a>(node: &'a AxNode, target: &AxTarget, out: &mut Vec<&'a AxNode>) {
+        if same_element_moved(target, node) {
+            out.push(node);
+        }
+        for c in &node.children {
+            walk(c, target, out);
+        }
+    }
+    let mut out = Vec::new();
+    walk(&tree.root, target, &mut out);
+    out
+}
+
+/// A rectangle as `(x,y wxh)`.
+fn rect(b: Option<AxRect>) -> String {
+    b.map_or_else(
+        || "(no bounds)".to_string(),
+        |r| format!("({},{} {}x{})", r.x, r.y, r.width, r.height),
+    )
+}
+
+/// The refusal for a target more than one node now matches on everything but position, so its id
+/// no longer picks one of them out.
+fn indistinguishable(target: &AxTarget, candidates: &[&AxNode]) -> GlassError {
+    let at: Vec<String> = candidates.iter().map(|n| rect(n.bounds)).collect();
+    GlassError::AxActionFailed(
+        target.id.0,
+        format!(
+            "{} elements now match its role, name, value and size — at {} — and it is no longer \
+             at {}, so which one it is cannot be told and nothing was dispatched; re-snapshot",
+            candidates.len(),
+            at.join(", "),
+            rect(target.bounds),
+        ),
+    )
+}
+
+/// [`crate::a11y::fingerprinted`], with a control's *position* taken out of its identity.
+///
+/// glass#326: an activity-open transition slides a control tens of px while the caller's snapshot
+/// still holds where it was, and the strict guard refuses it although role, name and value all
+/// match and only x differs.
+///
+/// Do not widen further. The node is still the one on `target.id` — nothing is searched for — its
+/// size must match exactly, and it is accepted only while no other node in the tree carries the
+/// same role, name, value and size. That uniqueness stands in for the bounds comparison: what
+/// `AxTarget::bounds` guards against is a *different* same-role+name element inheriting the id
+/// after drift, and there is no different one here to inherit it. Two candidates and this refuses.
+///
+/// `AndroidA11y`'s `set_value` keeps the strict core helper; only this reader relaxes.
+fn resolved_target<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&'a AxNode> {
+    let strict = match crate::a11y::fingerprinted(tree, target) {
+        Ok(node) => return Ok(node),
+        Err(e) => e,
+    };
+    // Only the bounds verdict is revisited; an absent target and every other refusal pass through.
+    if !matches!(strict, GlassError::AxElementChanged(_)) {
+        return Err(strict);
+    }
+    let Some(node) = tree.find(target.id) else {
+        return Err(strict);
+    };
+    if !same_element_moved(target, node) {
+        return Err(strict);
+    }
+    let candidates = movement_candidates(tree, target);
+    if candidates.len() == 1 {
+        return Ok(node);
+    }
+    Err(indistinguishable(target, &candidates))
+}
+
+/// [`resolved_target`], plus [`crate::a11y::editable_target`]'s editable check. `set_value` shares
+/// `invoke`'s guard, so it shares the relaxation.
+fn resolved_editable_target<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&'a AxNode> {
+    let node = resolved_target(tree, target)?;
+    if !node.states.editable {
+        return Err(GlassError::AxElementNotEditable(target.id.0));
+    }
+    Ok(node)
+}
+
 /// Decide what an `invoke` does with `target`: which node to actuate, and what the tree must
 /// show afterwards. Pure, so the decision is testable without a device.
 ///
 /// The order is load-bearing: a Compose control omits `ACTION_CLICK` while disabled, so a climb
 /// run before the target's own `enabled` check walks past it and actuates whatever encloses it.
 fn invoke_plan(tree: &AxTree, target: &AxTarget) -> Result<InvokePlan> {
-    let node = crate::a11y::fingerprinted(tree, target)?;
+    let node = resolved_target(tree, target)?;
     if !node.states.enabled {
         return Err(disabled_error(target.id.0, target.id));
     }
@@ -1351,6 +1446,39 @@ mod tests {
                      "editable": false, "clickable": false, "enabled": true, "scrollable": false}
                  ]}
             ]
+        })
+    }
+
+    /// [`compose_like`] with its content slid `dx` px along x and nothing resized — the
+    /// activity-open transition glass#326 measured, where the window stays put and its content
+    /// moves.
+    fn compose_like_slid(dx: i64) -> Value {
+        let mut v = compose_like();
+        v["children"][0]["bounds"] = json!({"x": 60 + dx, "y": 480, "w": 210, "h": 130});
+        v["children"][0]["children"][0]["bounds"] =
+            json!({"x": 120 + dx, "y": 520, "w": 80, "h": 50});
+        v
+    }
+
+    /// Two clickable cards holding a "Save" label each, identical in role, name, value and size.
+    fn two_identical_saves() -> Value {
+        let card = |x: i64| {
+            json!({
+                "class": "android.view.View",
+                "bounds": {"x": x, "y": 480, "w": 210, "h": 130},
+                "editable": false, "clickable": true, "enabled": true, "scrollable": false,
+                "children": [
+                    {"class": "android.widget.TextView", "text": "Save",
+                     "bounds": {"x": x + 60, "y": 520, "w": 80, "h": 50},
+                     "editable": false, "clickable": false, "enabled": true, "scrollable": false}
+                ]
+            })
+        };
+        json!({
+            "class": "android.widget.FrameLayout",
+            "bounds": {"x": 0, "y": 100, "w": 1080, "h": 2300},
+            "editable": false, "clickable": false, "enabled": true, "scrollable": false,
+            "children": [card(60), card(600)]
         })
     }
 
@@ -2688,6 +2816,13 @@ mod tests {
         })
     }
 
+    /// [`editable_field`] with the field slid `dx` px along x and nothing resized.
+    fn editable_field_slid(value: &str, dx: i64) -> Value {
+        let mut v = editable_field(value);
+        v["children"][0]["bounds"] = json!({"x": dx, "y": 100, "w": 600, "h": 120});
+        v
+    }
+
     #[test]
     fn a_rearm_matching_the_asked_about_app_does_not_authorise_a_stale_acting_apps_ref() {
         // The served tree answered for `com.other.app` (a dialog), not the configured
@@ -2906,6 +3041,177 @@ mod tests {
                 .expect("clicks"),
             None,
             "the target actuated itself, so nothing was substituted"
+        );
+    }
+
+    #[test]
+    fn a_target_that_only_moved_is_actuated_where_it_now_is() {
+        // glass#326: every observed refusal had role, name and value matching with only x
+        // different.
+        let (port, ops) = fake_service(vec![compose_like_slid(79)], OnAction::Ok);
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let seen = built(&compose_like());
+        let substituted = a
+            .invoke(&ctx(), &target_for(&seen, AxNodeId(2)))
+            .expect("a control that only moved is still that control");
+        assert_eq!(substituted, Some(AxNodeId(1)), "the climb is disclosed");
+        assert_eq!(
+            ops_of(&ops),
+            vec!["conn1:tree".to_string(), "conn1:click ref=1".to_string()],
+            "one read, one dispatch, against the moved node"
+        );
+    }
+
+    #[test]
+    fn two_elements_that_cannot_be_told_apart_are_refused_rather_than_guessed() {
+        // Position is what `AxTarget::bounds` exists to discriminate on. Forgiving it is only
+        // safe while nothing else in the tree could be mistaken for the target.
+        let (port, ops) = fake_service(vec![two_identical_saves()], OnAction::Ok);
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let seen = built(&two_identical_saves());
+        let mut label = target_for(&seen, AxNodeId(2));
+        label.bounds = Some(AxRect {
+            x: 199,
+            ..label.bounds.expect("the fixture carries bounds")
+        });
+        let e = a
+            .invoke(&ctx(), &label)
+            .expect_err("two indistinguishable candidates must not be guessed between");
+        let msg = e.to_string();
+        assert!(msg.contains("2 elements"), "{msg}");
+        assert!(msg.contains("(120,420 80x50)"), "{msg}");
+        assert!(msg.contains("(660,420 80x50)"), "{msg}");
+        assert!(!e.invoke_fallback_eligible(), "{e}");
+        assert_eq!(
+            ops_of(&ops),
+            vec!["conn1:tree".to_string()],
+            "nothing may be dispatched at a guess"
+        );
+    }
+
+    #[test]
+    fn a_target_whose_name_changed_is_refused_however_far_it_moved() {
+        let mut renamed = compose_like_slid(79);
+        renamed["children"][0]["children"][0]["text"] = json!("Send");
+        let (port, ops) = fake_service(vec![renamed], OnAction::Ok);
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let seen = built(&compose_like());
+        let e = a
+            .invoke(&ctx(), &target_for(&seen, AxNodeId(2)))
+            .expect_err("only position is forgiven");
+        assert!(matches!(e, GlassError::AxElementChanged(2)), "{e}");
+        assert_eq!(
+            ops_of(&ops),
+            vec!["conn1:tree".to_string()],
+            "nothing may be dispatched"
+        );
+    }
+
+    #[test]
+    fn a_field_whose_value_changed_is_refused_however_far_it_moved() {
+        // The recycled-row hazard `AxTarget::value` exists for: same role, name and size,
+        // different data.
+        let (port, ops) = fake_service(
+            vec![editable_field_slid("someone.else@example.com", 79)],
+            OnAction::Ok,
+        );
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let seen = built(&editable_field("old@example.com"));
+        let e = a
+            .set_value(&ctx(), &target_for(&seen, AxNodeId(1)), "new@example.com")
+            .expect_err("a field holding other data is not the field that was addressed");
+        assert!(matches!(e, GlassError::AxElementChanged(1)), "{e}");
+        assert_eq!(
+            ops_of(&ops),
+            vec!["conn1:tree".to_string()],
+            "nothing may be written"
+        );
+    }
+
+    #[test]
+    fn a_target_that_is_no_longer_in_the_tree_is_still_refused_as_absent() {
+        // Through `set_value`: the ref that reaches the device is the caller's `target.id`, so a
+        // guard that re-found the element by identity anywhere in the tree would authorise a
+        // write addressed to a node it never looked at.
+        let (port, ops) = fake_service(vec![editable_field_slid("old", 79)], OnAction::Ok);
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let seen = built(&editable_field("old"));
+        let mut gone = target_for(&seen, AxNodeId(1));
+        gone.id = AxNodeId(9);
+        let e = a
+            .set_value(&ctx(), &gone, "new")
+            .expect_err("an id that resolves to nothing is absent, not moved");
+        assert!(matches!(e, GlassError::AxElementNotFound(9)), "{e}");
+        assert_eq!(
+            ops_of(&ops),
+            vec!["conn1:tree".to_string()],
+            "nothing may be written"
+        );
+    }
+
+    #[test]
+    fn a_target_that_changed_size_is_refused_even_where_it_still_sits() {
+        let mut resized = compose_like();
+        resized["children"][0]["children"][0]["bounds"] =
+            json!({"x": 120, "y": 520, "w": 140, "h": 50});
+        let (port, ops) = fake_service(vec![resized], OnAction::Ok);
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let seen = built(&compose_like());
+        let e = a
+            .invoke(&ctx(), &target_for(&seen, AxNodeId(2)))
+            .expect_err("a resize is not a translation");
+        assert!(matches!(e, GlassError::AxElementChanged(2)), "{e}");
+        assert_eq!(
+            ops_of(&ops),
+            vec!["conn1:tree".to_string()],
+            "nothing may be dispatched"
+        );
+    }
+
+    #[test]
+    fn an_invoke_on_a_target_that_did_not_move_costs_no_extra_read_and_no_wait() {
+        let (port, ops) = fake_service(vec![compose_like()], OnAction::Ok);
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let seen = built(&compose_like());
+        let started = std::time::Instant::now();
+        a.invoke(&ctx(), &target_for(&seen, AxNodeId(2)))
+            .expect("clicks");
+        let elapsed = started.elapsed();
+        assert_eq!(
+            ops_of(&ops),
+            vec!["conn1:tree".to_string(), "conn1:click ref=1".to_string()],
+            "forgiving position must not buy itself a second read"
+        );
+        // The cheapest settle proposed for this path was 250ms, and the fake's two loopback
+        // round-trips measure a stable ~80ms, so this bound sits between the two rather than
+        // above both — a wait no op-count can see still has to fail here.
+        assert!(
+            elapsed < std::time::Duration::from_millis(150),
+            "no wait may be added to the path every invoke takes: {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn set_values_guard_accepts_a_field_that_only_moved() {
+        let (port, ops) = fake_service(
+            vec![
+                editable_field_slid("old", 79),
+                editable_field_slid("new", 79),
+            ],
+            OnAction::Ok,
+        );
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let seen = built(&editable_field("old"));
+        a.set_value(&ctx(), &target_for(&seen, AxNodeId(1)), "new")
+            .expect("a field that only slid is still that field");
+        assert_eq!(
+            ops_of(&ops),
+            vec![
+                "conn1:tree".to_string(),
+                "conn1:set_text ref=1".to_string(),
+                "conn1:tree".to_string()
+            ],
+            "the guard's read, the write, and the read-back"
         );
     }
 }

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -306,12 +306,26 @@ fn rearm_tree(conn: &mut Conn, pkg: &str) -> Result<()> {
 const CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 const CHECK_POLL: std::time::Duration = std::time::Duration::from_millis(150);
 
+/// How long [`ServiceA11y::settled_tree`] re-reads waiting for the target to stop moving. An
+/// activity-open transition animates for ~500 ms, and its offsets reach the accessibility tree
+/// up to ~100 ms after the platform calls it finished.
+const SETTLE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(1500);
+/// The pause after two reads that disagreed — a device read costs ~50 ms on its own, against an
+/// offset that steps in ~60 ms jumps.
+const SETTLE_POLL: std::time::Duration = std::time::Duration::from_millis(20);
+
 /// The Accessibility reader backed by the on-device service. `package` is the target app.
 pub struct ServiceA11y {
     client: ServiceClient,
     package: String,
     /// How long [`Self::wait_for_check`] polls; [`CHECK_TIMEOUT`] outside tests.
     check_timeout: std::time::Duration,
+    /// How long [`Self::settled_tree`] re-reads; [`SETTLE_TIMEOUT`] outside tests.
+    settle_timeout: std::time::Duration,
+    /// What [`Self::settled_tree`] waits after two reads that disagreed; [`SETTLE_POLL`] outside
+    /// tests, where the still-path test inflates it so a wait added there cannot hide in
+    /// loopback latency.
+    settle_poll: std::time::Duration,
 }
 
 impl ServiceA11y {
@@ -320,6 +334,8 @@ impl ServiceA11y {
             client,
             package,
             check_timeout: CHECK_TIMEOUT,
+            settle_timeout: SETTLE_TIMEOUT,
+            settle_poll: SETTLE_POLL,
         }
     }
 
@@ -339,6 +355,63 @@ impl ServiceA11y {
                 return Err(check_timeout(plan.target.0, &plan.actuated, want, seen));
             }
             std::thread::sleep(CHECK_POLL);
+        }
+    }
+
+    /// One numbered snapshot — the pair of steps every guard in this reader starts from.
+    fn numbered_snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
+        let mut t = self.snapshot(ctx)?;
+        t.assign_ids();
+        Ok(t)
+    }
+
+    /// Re-read until `target`'s geometry holds still, and hand back the read that proved it.
+    ///
+    /// glass#326: a window whose activity-open transition is still animating reports its content
+    /// at an +x offset that decays in steps, so two reads milliseconds apart describe the same
+    /// control in two places. Acting on such a read is what trips the ±8 px staleness check here
+    /// and the companion's exact re-find on the device.
+    ///
+    /// What has to hold still is the root→target path: the target itself (what the staleness
+    /// check compares) and its ancestors (where [`actuable_node`] climbs, and the node the
+    /// companion re-finds by exact bounds). Nodes off that path are not watched, so an animation
+    /// elsewhere in the app cannot make every click time out.
+    fn settled_tree(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<AxTree> {
+        let started = std::time::Instant::now();
+        let deadline = started + self.settle_timeout;
+        let first = self.numbered_snapshot(ctx)?;
+        // A read the target is not in is not something re-reading fixes; `invoke_plan` names it.
+        let Some(mut seen) = chain_bounds(&first, target.id) else {
+            return Ok(first);
+        };
+        let mut drift = None;
+        let mut agreed = 0usize;
+        loop {
+            let next = self.numbered_snapshot(ctx)?;
+            let Some(chain) = chain_bounds(&next, target.id) else {
+                return Ok(next);
+            };
+            if chain == seen {
+                agreed += 1;
+                // One agreement stands only while nothing has been seen moving: an offset that
+                // decays in steps holds still across a single pair of reads (measured: the same
+                // bounds 157 ms apart, then a new position 7 ms later).
+                if agreed >= if drift.is_some() { 2 } else { 1 } {
+                    return Ok(next);
+                }
+            } else {
+                drift = Some(drift_between(&seen, &chain));
+                agreed = 0;
+            }
+            seen = chain;
+            if std::time::Instant::now() >= deadline {
+                return Err(never_settled(
+                    target.id.0,
+                    drift.as_deref(),
+                    started.elapsed(),
+                ));
+            }
+            std::thread::sleep(self.settle_poll);
         }
     }
 
@@ -441,11 +514,10 @@ impl Accessibility for ServiceA11y {
     }
 
     fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<Option<AxNodeId>> {
-        let tree = {
-            let mut t = self.snapshot(ctx)?;
-            t.assign_ids();
-            t
-        };
+        // Settling comes before the plan, not after it: the plan's guards compare a live read
+        // against the caller's snapshot, and a read taken mid-animation is what makes them
+        // reject a target that is fine.
+        let tree = self.settled_tree(ctx, target)?;
         let plan = invoke_plan(&tree, target)?;
         self.dispatch_click(ctx, target, &plan, tree.subject.as_ref())
     }
@@ -846,6 +918,70 @@ fn actuable_node<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&'a AxNode> 
         .find(|n| n.states.focusable && (n.id == target.id || encloses(n.bounds, want)))
         .copied()
         .ok_or(GlassError::AxActionUnavailable(target.id.0))
+}
+
+/// Every node on the root→`id` path as `(id, bounds)`, target last — the geometry
+/// [`ServiceA11y::settled_tree`] watches. `None` when `id` is not in this tree.
+fn chain_bounds(tree: &AxTree, id: AxNodeId) -> Option<Vec<(AxNodeId, Option<AxRect>)>> {
+    let mut path = Vec::new();
+    path_to(&tree.root, id, &mut path).then(|| path.iter().map(|n| (n.id, n.bounds)).collect())
+}
+
+/// How two reads of the target's path disagreed, worded for [`never_settled`].
+fn drift_between(a: &[(AxNodeId, Option<AxRect>)], b: &[(AxNodeId, Option<AxRect>)]) -> String {
+    for (&(id, from), &(other, to)) in a.iter().zip(b) {
+        if id != other {
+            return format!(
+                "the path to it now runs through element #{} where it ran through #{}",
+                other.0, id.0
+            );
+        }
+        if from != to {
+            return format!("element #{} moved {}", id.0, movement(from, to));
+        }
+    }
+    format!(
+        "the path to it changed length between reads ({} nodes, then {})",
+        a.len(),
+        b.len()
+    )
+}
+
+/// `from` → `to`, with the per-edge deltas when both sides reported bounds.
+fn movement(from: Option<AxRect>, to: Option<AxRect>) -> String {
+    let deltas = match (from, to) {
+        (Some(f), Some(t)) => format!(
+            " (dx {}, dy {}, dw {}, dh {})",
+            i64::from(t.x) - i64::from(f.x),
+            i64::from(t.y) - i64::from(f.y),
+            i64::from(t.width) - i64::from(f.width),
+            i64::from(t.height) - i64::from(f.height),
+        ),
+        _ => String::new(),
+    };
+    format!("from {} to {}{deltas}", rect(from), rect(to))
+}
+
+/// One rect as `(x,y wxh)`, or `no bounds`.
+fn rect(r: Option<AxRect>) -> String {
+    r.map_or_else(
+        || "no bounds".to_string(),
+        |r| format!("({},{} {}x{})", r.x, r.y, r.width, r.height),
+    )
+}
+
+/// Nothing was dispatched: the target never stopped moving inside the budget. Deliberately not
+/// `invoke_fallback_eligible` — a control that is mid-animation is the last thing to aim a
+/// pointer click at.
+fn never_settled(id: u32, drift: Option<&str>, elapsed: std::time::Duration) -> GlassError {
+    GlassError::Backend(format!(
+        "element #{id} is still moving after {} ms of re-reads, so nothing was clicked: {}. An \
+         activity-open transition settles in about half a second — re-snapshot until the bounds \
+         repeat, then retry",
+        elapsed.as_millis(),
+        // Unreachable: reaching the deadline takes a disagreement, which records one.
+        drift.unwrap_or("its bounds kept changing between reads"),
+    ))
 }
 
 /// The root-to-`id` path, inclusive of both ends. False when `id` is not in this subtree,
@@ -1352,6 +1488,28 @@ mod tests {
                  ]}
             ]
         })
+    }
+
+    /// [`compose_like`] with everything below the root shifted `dx` px right. A Compose window
+    /// whose activity-open transition is still animating reports exactly this: a uniform +x
+    /// offset on the content, decaying to zero over the ~500 ms the transition runs (glass#326).
+    fn compose_shifted(dx: i64) -> Value {
+        fn shift(v: &mut Value, dx: i64) {
+            if let Some(x) = v["bounds"]["x"].as_i64() {
+                v["bounds"]["x"] = json!(x + dx);
+            }
+            for c in v["children"].as_array_mut().into_iter().flatten() {
+                shift(c, dx);
+            }
+        }
+        let mut v = compose_like();
+        for c in v["children"]
+            .as_array_mut()
+            .expect("compose_like has children")
+        {
+            shift(c, dx);
+        }
+        v
     }
 
     fn built(v: &Value) -> AxTree {
@@ -2829,8 +2987,13 @@ mod tests {
         );
         assert_eq!(
             ops_of(&ops),
-            vec!["conn1:tree".to_string(), "conn1:click ref=1".to_string()],
-            "exactly one click frame, on the one connection"
+            vec![
+                "conn1:tree".to_string(),
+                "conn1:tree".to_string(),
+                "conn1:click ref=1".to_string()
+            ],
+            "exactly one click frame, on the one connection (the second tree is the re-read \
+             that proved the target had stopped moving)"
         );
     }
 
@@ -2847,7 +3010,154 @@ mod tests {
         assert_eq!(substituted, Some(AxNodeId(1)), "the climb is disclosed");
         assert_eq!(
             ops_of(&ops),
-            vec!["conn1:tree".to_string(), "conn1:click ref=1".to_string()]
+            vec![
+                "conn1:tree".to_string(),
+                "conn1:tree".to_string(),
+                "conn1:click ref=1".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn a_target_whose_bounds_are_still_moving_is_not_clicked_until_they_hold_still() {
+        // glass#326. The caller's target holds the settled geometry; every read taken while the
+        // activity-open transition animates describes the same control somewhere else, and
+        // acting on one of those either trips the host's staleness guard or hands the companion
+        // bounds it can no longer re-find.
+        let (port, ops) = fake_service(
+            vec![compose_shifted(79), compose_shifted(31), compose_like()],
+            OnAction::Ok,
+        );
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let t = built(&compose_like());
+        let substituted = a
+            .invoke(&ctx(), &target_for(&t, AxNodeId(2)))
+            .expect("the reads that agreed describe the element the caller named");
+        assert_eq!(substituted, Some(AxNodeId(1)), "the climb is disclosed");
+        assert_eq!(
+            ops_of(&ops),
+            vec![
+                "conn1:tree".to_string(),
+                "conn1:tree".to_string(),
+                "conn1:tree".to_string(),
+                "conn1:tree".to_string(),
+                "conn1:tree".to_string(),
+                "conn1:click ref=1".to_string(),
+            ],
+            "exactly one click, after the reads agreed — nothing may go out while it moves"
+        );
+    }
+
+    #[test]
+    fn a_still_target_whose_clickable_ancestor_moves_is_not_clicked_either() {
+        // One walk is not atomic, so a moving window can report the label at its settled
+        // position and its clickable parent an animation frame behind. The parent is the node
+        // the click is addressed to, and the one the companion re-finds by exact bounds.
+        let mut moving_parent = compose_like();
+        moving_parent["children"][0]["bounds"]["x"] = json!(139); // its settled 60, offset by 79
+        let (port, ops) = fake_service(vec![moving_parent, compose_like()], OnAction::Ok);
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let t = built(&compose_like());
+        a.invoke(&ctx(), &target_for(&t, AxNodeId(2)))
+            .expect("the reads that agreed describe a control that has stopped moving");
+        assert_eq!(
+            ops_of(&ops),
+            vec![
+                "conn1:tree".to_string(),
+                "conn1:tree".to_string(),
+                "conn1:tree".to_string(),
+                "conn1:tree".to_string(),
+                "conn1:click ref=1".to_string(),
+            ],
+            "the target never moved, but the node being clicked did"
+        );
+    }
+
+    #[test]
+    fn a_still_target_is_clicked_after_two_agreeing_reads_and_no_wait_at_all() {
+        // The common case pays for the re-read that proves nothing is moving and nothing else —
+        // no sleep, no third read — so a later change cannot quietly put a wait on the path
+        // every click takes.
+        let (port, ops) = fake_service(vec![compose_like()], OnAction::Ok);
+        let mut a = reader(port, std::time::Duration::ZERO);
+        // Outsized on purpose: a loopback round trip already costs ~40 ms here, so a wait at the
+        // production 20 ms would not stand out.
+        a.settle_poll = std::time::Duration::from_secs(5);
+        let t = built(&compose_like());
+        let started = std::time::Instant::now();
+        a.invoke(&ctx(), &target_for(&t, AxNodeId(2)))
+            .expect("nothing is moving");
+        let elapsed = started.elapsed();
+        assert_eq!(
+            ops_of(&ops),
+            vec![
+                "conn1:tree".to_string(),
+                "conn1:tree".to_string(),
+                "conn1:click ref=1".to_string(),
+            ],
+            "the re-read that proved stillness, and nothing beyond it"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_secs(1),
+            "two agreeing reads must proceed without waiting; took {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn a_target_that_never_stops_moving_fails_inside_its_budget_and_names_what_moved() {
+        // Bounded: the reads never agree, so nothing is ever actuated, and the give-up carries
+        // what was seen. The script holds far more entries than the budget can consume — the
+        // fake repeats its last tree, which would look settled.
+        let jitter: Vec<Value> = (0..64)
+            .map(|i| compose_shifted(if i % 2 == 0 { 0 } else { 20 }))
+            .collect();
+        let (port, ops) = fake_service(jitter, OnAction::Ok);
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let budget = std::time::Duration::from_millis(200);
+        a.settle_timeout = budget;
+        let t = built(&compose_like());
+        let started = std::time::Instant::now();
+        let e = a
+            .invoke(&ctx(), &target_for(&t, AxNodeId(2)))
+            .expect_err("a control that never holds still must not be actuated");
+        let waited = started.elapsed();
+        assert!(
+            waited >= budget,
+            "gave up after {waited:?}, before the budget it was given"
+        );
+        let m = e.to_string();
+        assert!(m.contains("element #2"), "{m}");
+        assert!(m.contains("moving"), "{m}");
+        assert!(m.contains("dx"), "the delta it kept seeing: {m}");
+        assert!(m.contains("ms"), "how long it watched: {m}");
+        assert!(
+            !e.invoke_fallback_eligible(),
+            "a moving control must not take a pointer click either: {e}"
+        );
+        let ops = ops_of(&ops);
+        assert!(
+            ops.iter().all(|o| o == "conn1:tree"),
+            "nothing may be dispatched: {ops:?}"
+        );
+    }
+
+    #[test]
+    fn a_settled_target_that_moved_since_the_caller_looked_is_still_refused() {
+        // Waiting for stillness must not launder a stale target: these reads agree with each
+        // other and sit 20 px from where the caller saw the element, which is what the ±8 px
+        // staleness guard is for.
+        let (port, ops) = fake_service(vec![compose_shifted(20)], OnAction::Ok);
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let t = built(&compose_like());
+        let e = a
+            .invoke(&ctx(), &target_for(&t, AxNodeId(2)))
+            .expect_err("an element that moved since the caller's snapshot must not be actuated");
+        assert!(matches!(e, GlassError::AxElementChanged(2)), "{e}");
+        assert!(!e.invoke_fallback_eligible(), "{e}");
+        assert_eq!(
+            ops_of(&ops),
+            vec!["conn1:tree".to_string(), "conn1:tree".to_string()],
+            "the refusal must happen before anything is dispatched"
         );
     }
 
@@ -2863,7 +3173,7 @@ mod tests {
         assert!(e.to_string().contains("disabled"), "{e}");
         assert_eq!(
             ops_of(&ops),
-            vec!["conn1:tree".to_string()],
+            vec!["conn1:tree".to_string(), "conn1:tree".to_string()],
             "the refusal must happen before anything is dispatched"
         );
     }
@@ -2883,6 +3193,7 @@ mod tests {
             ops_of(&ops),
             vec![
                 "conn1:tree".to_string(),
+                "conn1:tree".to_string(),
                 "conn1:click ref=1".to_string(),
                 "conn1:tree".to_string()
             ],
@@ -2892,8 +3203,12 @@ mod tests {
 
     #[test]
     fn a_toggle_that_flips_is_reported_clicked() {
+        // Two unchecked reads, then the flipped one: the plan comes from the read that proved
+        // stillness, so a box already checked by then would be planned as a flip back to false.
+        // Stillness is geometry — a `checked` that changes under the re-read is not motion.
         let (port, _) = fake_service(
             vec![
+                one_checkable("android.widget.CheckBox", false),
                 one_checkable("android.widget.CheckBox", false),
                 one_checkable("android.widget.CheckBox", true),
             ],

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -306,16 +306,6 @@ fn rearm_tree(conn: &mut Conn, pkg: &str) -> Result<()> {
 const CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 const CHECK_POLL: std::time::Duration = std::time::Duration::from_millis(150);
 
-/// The wall clock two agreeing reads must span before [`ServiceA11y::snapshot`] calls the tree
-/// still. A screen whose open transition is animating reports its content at an offset that
-/// decays in *steps*, so two reads inside one step agree without proving anything; the longest
-/// step measured held ~160 ms, in a ~600 ms slide that stepped nine times (glass#326).
-const SETTLE_SPAN: std::time::Duration = std::time::Duration::from_millis(250);
-/// How long [`ServiceA11y::snapshot`] keeps re-reading for the tree to hold still. Room for the
-/// ~600 ms slide, one span of agreement after it, and the reads themselves — a single read of a
-/// 300-node tree costs up to ~600 ms.
-const SETTLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
-
 /// The Accessibility reader backed by the on-device service. `package` is the target app.
 pub struct ServiceA11y {
     client: ServiceClient,
@@ -333,24 +323,13 @@ impl ServiceA11y {
         }
     }
 
-    /// One tree, as the device answered it. [`Accessibility::snapshot`] settles over this. The
-    /// two read-back loops use it directly: each watches a state (a `checked` flag, a written
-    /// value) after its action has gone out, where a verdict about motion would report a change
-    /// that landed as failed.
-    fn read_tree(&mut self, ctx: &AxContext) -> Result<AxTree> {
-        let reply = self.client.tree(&self.package)?;
-        let mut tree = tree_from_json(&reply.tree, &ctx.window, ctx.limits)?;
-        tree.subject = subject_of(&self.package, reply.package.as_deref());
-        Ok(tree)
-    }
-
     /// Poll until the actuated control reports `checked == want`. The toolkit's UI update
     /// reaches the accessibility tree a beat after the action; `set_value` polls for the same
     /// reason.
     fn wait_for_check(&mut self, ctx: &AxContext, plan: &InvokePlan, want: bool) -> Result<()> {
         let deadline = std::time::Instant::now() + self.check_timeout;
         loop {
-            let mut after = self.read_tree(ctx)?;
+            let mut after = self.snapshot(ctx)?;
             after.assign_ids();
             let seen = check_state(&after, &plan.actuated);
             if seen == CheckState::Reached(want) {
@@ -399,36 +378,11 @@ fn subject_of(asked: &str, actual: Option<&str>) -> Option<Subject> {
 }
 
 impl Accessibility for ServiceA11y {
-    /// Re-read until two reads a [`SETTLE_SPAN`] apart describe the same geometry, and hand back
-    /// the later one.
-    ///
-    /// glass#326: a window whose activity-open transition is still animating reports its content
-    /// at an +x offset that decays in steps, so reads milliseconds apart place the same control
-    /// in two places. Every guard downstream — the ±8 px staleness check, the companion's exact
-    /// re-find, the climb to an enclosing clickable ancestor — compares one such read against
-    /// another, so settling *here* rather than in `invoke` is what leaves them nothing to
-    /// disagree about: the caller's own tree is the settled one.
-    ///
-    /// The span carries the proof, not mere consecutiveness — two reads inside one step agree
-    /// while the slide is still running. A read counts toward the span: a walk that outlasts a
-    /// step comes back with its own nodes on different frames and matches nothing exactly.
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
-        let started = std::time::Instant::now();
-        let mut since = started;
-        let mut seen = geometry_of(&self.read_tree(ctx)?);
-        loop {
-            std::thread::sleep(SETTLE_SPAN.saturating_sub(since.elapsed()));
-            let issued = std::time::Instant::now();
-            let next = self.read_tree(ctx)?;
-            let now = geometry_of(&next);
-            if now == seen {
-                return Ok(next);
-            }
-            if started.elapsed() >= SETTLE_TIMEOUT {
-                return Err(never_settled(&seen, &now, started.elapsed()));
-            }
-            (since, seen) = (issued, now);
-        }
+        let reply = self.client.tree(&self.package)?;
+        let mut tree = tree_from_json(&reply.tree, &ctx.window, ctx.limits)?;
+        tree.subject = subject_of(&self.package, reply.package.as_deref());
+        Ok(tree)
     }
 
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
@@ -453,7 +407,7 @@ impl Accessibility for ServiceA11y {
         // value to land; error honestly only on timeout.
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
         loop {
-            let mut after = self.read_tree(ctx)?;
+            let mut after = self.snapshot(ctx)?;
             after.assign_ids();
             let node = after.find(target.id);
             let got = node.and_then(|n| n.value.clone());
@@ -892,78 +846,6 @@ fn actuable_node<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&'a AxNode> 
         .find(|n| n.states.focusable && (n.id == target.id || encloses(n.bounds, want)))
         .copied()
         .ok_or(GlassError::AxActionUnavailable(target.id.0))
-}
-
-/// Every node's bounds in pre-order — what [`ServiceA11y::snapshot`] watches for motion; the
-/// whole tree, since a snapshot names no target. Position `n` is the node
-/// `AxTree::assign_ids` will number `AxNodeId(n)`.
-fn geometry_of(tree: &AxTree) -> Vec<Option<AxRect>> {
-    fn walk(node: &AxNode, out: &mut Vec<Option<AxRect>>) {
-        out.push(node.bounds);
-        for c in &node.children {
-            walk(c, out);
-        }
-    }
-    let mut out = Vec::new();
-    walk(&tree.root, &mut out);
-    out
-}
-
-/// How two reads disagreed, worded for [`never_settled`].
-fn drift_between(before: &[Option<AxRect>], after: &[Option<AxRect>]) -> String {
-    for (id, (from, to)) in before.iter().zip(after).enumerate() {
-        if from != to {
-            return format!("element #{id} moved {}", movement(*from, *to));
-        }
-    }
-    format!(
-        "the tree changed shape between reads ({} elements, then {})",
-        before.len(),
-        after.len()
-    )
-}
-
-/// `from` → `to`, with the per-edge deltas when both sides reported bounds.
-fn movement(from: Option<AxRect>, to: Option<AxRect>) -> String {
-    let deltas = match (from, to) {
-        (Some(f), Some(t)) => format!(
-            " (dx {}, dy {}, dw {}, dh {})",
-            i64::from(t.x) - i64::from(f.x),
-            i64::from(t.y) - i64::from(f.y),
-            i64::from(t.width) - i64::from(f.width),
-            i64::from(t.height) - i64::from(f.height),
-        ),
-        _ => String::new(),
-    };
-    format!("from {} to {}{deltas}", rect(from), rect(to))
-}
-
-/// One rect as `(x,y wxh)`, or `no bounds`.
-fn rect(r: Option<AxRect>) -> String {
-    r.map_or_else(
-        || "no bounds".to_string(),
-        |r| format!("({},{} {}x{})", r.x, r.y, r.width, r.height),
-    )
-}
-
-/// Nothing was read out: the tree never held still inside the budget.
-///
-/// A refusal, not the last read with a warning: the degraded trees this reader can hand back —
-/// truncated, unreadable, another app — each ride an `AxTree` field the MCP boundary surfaces as
-/// its own block, and motion has no such channel.
-fn never_settled(
-    before: &[Option<AxRect>],
-    after: &[Option<AxRect>],
-    elapsed: std::time::Duration,
-) -> GlassError {
-    GlassError::Backend(format!(
-        "the accessibility tree is still moving after {} ms of re-reads, so no snapshot was \
-         taken: {}. A screen whose open transition is still animating settles in about half a \
-         second — retry once it has. If it never stops, drive that area by pixels: \
-         glass_screenshot, then glass_click at x,y",
-        elapsed.as_millis(),
-        drift_between(before, after),
-    ))
 }
 
 /// The root-to-`id` path, inclusive of both ends. False when `id` is not in this subtree,
@@ -1470,32 +1352,6 @@ mod tests {
                  ]}
             ]
         })
-    }
-
-    /// `v` with everything below its root shifted `dx` px right — what a window reports while
-    /// its activity-open transition animates: a uniform +x offset on the content, decaying to
-    /// zero over the ~500 ms the transition runs (glass#326).
-    fn shifted(v: &Value, dx: i64) -> Value {
-        fn kids(v: &mut Value) -> impl Iterator<Item = &mut Value> {
-            v.get_mut("children")
-                .and_then(Value::as_array_mut)
-                .into_iter()
-                .flatten()
-        }
-        fn shift(v: &mut Value, dx: i64) {
-            if let Some(x) = v["bounds"]["x"].as_i64() {
-                v["bounds"]["x"] = json!(x + dx);
-            }
-            for c in kids(v) {
-                shift(c, dx);
-            }
-        }
-        let mut v = v.clone();
-        // The window frame stays put; only its content slides.
-        for c in kids(&mut v) {
-            shift(c, dx);
-        }
-        v
     }
 
     fn built(v: &Value) -> AxTree {
@@ -2167,40 +2023,6 @@ mod tests {
         packages: Vec<TreePackage>,
         on_tree: Vec<OnTree>,
     ) -> (u16, Arc<Mutex<Vec<String>>>) {
-        fake_service_clocked(trees, TreeClock::PerRead, on_action, packages, on_tree)
-    }
-
-    /// Which scripted tree a fake answers with.
-    enum TreeClock {
-        /// The next one each time, last entry repeating.
-        PerRead,
-        /// By wall clock since the first `tree` request: entry `i` takes over `holds[i]` after
-        /// it. A per-read script advances at whatever rate the reader reads, so only this can
-        /// express a *plateau* — a position the device keeps reporting for a while and leaves.
-        Timed(Vec<std::time::Duration>),
-    }
-
-    /// [`fake_service`] with the trees keyed by wall clock — see [`TreeClock::Timed`].
-    fn fake_service_timed(
-        trees: Vec<Value>,
-        holds: Vec<std::time::Duration>,
-    ) -> (u16, Arc<Mutex<Vec<String>>>) {
-        fake_service_clocked(
-            trees,
-            TreeClock::Timed(holds),
-            vec![OnAction::Ok],
-            vec![TreePackage::Echo],
-            vec![OnTree::Serve],
-        )
-    }
-
-    fn fake_service_clocked(
-        trees: Vec<Value>,
-        clock: TreeClock,
-        on_action: Vec<OnAction>,
-        packages: Vec<TreePackage>,
-        on_tree: Vec<OnTree>,
-    ) -> (u16, Arc<Mutex<Vec<String>>>) {
         let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind");
         let port = listener.local_addr().expect("addr").port();
         let ops: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
@@ -2209,7 +2031,6 @@ mod tests {
             let mut conn = 0usize;
             let mut served = 0usize;
             let mut requested = 0usize;
-            let mut clock_start = None;
             while let Ok((sock, _)) = listener.accept() {
                 conn += 1;
                 let this_action = on_action[(conn - 1).min(on_action.len() - 1)];
@@ -2249,16 +2070,7 @@ mod tests {
                                 }
                                 None => {
                                     log.lock().unwrap().push(format!("conn{conn}:tree"));
-                                    let picked = match &clock {
-                                        TreeClock::PerRead => served,
-                                        TreeClock::Timed(holds) => {
-                                            let t0 = *clock_start
-                                                .get_or_insert_with(std::time::Instant::now);
-                                            let e = t0.elapsed();
-                                            holds.iter().filter(|h| **h <= e).count() - 1
-                                        }
-                                    };
-                                    let t = trees[picked.min(trees.len() - 1)].clone();
+                                    let t = trees[served.min(trees.len() - 1)].clone();
                                     let pkg = &packages[served.min(packages.len() - 1)];
                                     served += 1;
                                     tree_confirmed = true;
@@ -2742,9 +2554,7 @@ mod tests {
         let (port, _ops) = fake_service_ex(
             vec![field("old"), field("old"), field("new")],
             vec![OnAction::DropWithoutAnswering, OnAction::Ok],
-            // Both of the guard snapshot's reads answer `Echo`; only the rearm's reply is fixed.
             vec![
-                TreePackage::Echo,
                 TreePackage::Echo,
                 TreePackage::Other("com.example.app".into()),
             ],
@@ -2778,9 +2588,7 @@ mod tests {
         let (port, _ops) = fake_service_ex(
             vec![clickable.clone()],
             vec![OnAction::Ok],
-            // Both of the snapshot's reads answer `Echo`; only the rearm's reply is fixed.
             vec![
-                TreePackage::Echo,
                 TreePackage::Echo,
                 TreePackage::Other("com.example.app".into()),
             ],
@@ -2830,10 +2638,7 @@ mod tests {
         let (port, ops) = fake_service_ex(
             vec![clickable.clone()],
             vec![OnAction::Ok],
-            // Both of the snapshot's reads describe the dialog; the rearm's reply names the
-            // asked-about app.
             vec![
-                TreePackage::Other("com.other.app".into()),
                 TreePackage::Other("com.other.app".into()),
                 TreePackage::Other("com.example.app".into()),
             ],
@@ -2864,11 +2669,7 @@ mod tests {
         assert!(msg.contains("moved"), "{msg}");
         assert_eq!(
             ops_of(&ops),
-            vec![
-                "conn1:tree".to_string(),
-                "conn1:tree".to_string(),
-                "conn2:tree".to_string()
-            ],
+            vec!["conn1:tree".to_string(), "conn2:tree".to_string()],
             "no click on conn2 — comparing against the acting app must stop the resend"
         );
     }
@@ -2904,10 +2705,7 @@ mod tests {
                 editable_field("new"),
             ],
             vec![OnAction::DropWithoutAnswering, OnAction::Ok],
-            // Both of the guard snapshot's reads describe the dialog; the rearm's reply names
-            // the asked-about app.
             vec![
-                TreePackage::Other("com.other.app".into()),
                 TreePackage::Other("com.other.app".into()),
                 TreePackage::Other("com.example.app".into()),
             ],
@@ -2929,7 +2727,6 @@ mod tests {
         assert_eq!(
             ops_of(&ops),
             vec![
-                "conn1:tree".to_string(),
                 "conn1:tree".to_string(),
                 "conn1:set_text ref=1".to_string(),
                 "conn2:tree".to_string(),
@@ -2968,7 +2765,6 @@ mod tests {
             ops_of(&ops),
             vec![
                 "conn1:tree".to_string(),
-                "conn1:tree".to_string(),
                 "conn1:set_text ref=1".to_string(),
                 "conn2:tree".to_string(),
                 "conn2:set_text ref=1".to_string(),
@@ -2992,20 +2788,16 @@ mod tests {
             writeln!(w, r#"{{"hello":{{"proto":1}}}}"#)
                 .and_then(|()| w.flush())
                 .expect("hello");
-            // Answers every read, not just the first: a snapshot re-reads until the geometry
-            // repeats.
             let mut line = String::new();
-            while matches!(r.read_line(&mut line), Ok(n) if n > 0) {
-                let req: Value = serde_json::from_str(&line).expect("request is json");
-                let reply = json!({
-                    "id": req["id"], "ok": true, "tree": compose_like(),
-                    "package": "com.google.android.permissioncontroller"
-                });
-                if writeln!(w, "{reply}").and_then(|()| w.flush()).is_err() {
-                    break;
-                }
-                line.clear();
-            }
+            r.read_line(&mut line).expect("read request");
+            let req: Value = serde_json::from_str(&line).expect("request is json");
+            let reply = json!({
+                "id": req["id"], "ok": true, "tree": compose_like(),
+                "package": "com.google.android.permissioncontroller"
+            });
+            writeln!(w, "{reply}")
+                .and_then(|()| w.flush())
+                .expect("write reply");
         });
         let client = ServiceClient::connect(port).expect("connect");
         let mut a = ServiceA11y::new(client, "com.example.app".to_string());
@@ -3037,13 +2829,8 @@ mod tests {
         );
         assert_eq!(
             ops_of(&ops),
-            vec![
-                "conn1:tree".to_string(),
-                "conn1:tree".to_string(),
-                "conn1:click ref=1".to_string()
-            ],
-            "exactly one click frame, on the one connection (the second read is the one that \
-             proved the tree had stopped moving)"
+            vec!["conn1:tree".to_string(), "conn1:click ref=1".to_string()],
+            "exactly one click frame, on the one connection"
         );
     }
 
@@ -3060,11 +2847,7 @@ mod tests {
         assert_eq!(substituted, Some(AxNodeId(1)), "the climb is disclosed");
         assert_eq!(
             ops_of(&ops),
-            vec![
-                "conn1:tree".to_string(),
-                "conn1:tree".to_string(),
-                "conn1:click ref=1".to_string()
-            ]
+            vec!["conn1:tree".to_string(), "conn1:click ref=1".to_string()]
         );
     }
 
@@ -3080,7 +2863,7 @@ mod tests {
         assert!(e.to_string().contains("disabled"), "{e}");
         assert_eq!(
             ops_of(&ops),
-            vec!["conn1:tree".to_string(), "conn1:tree".to_string()],
+            vec!["conn1:tree".to_string()],
             "the refusal must happen before anything is dispatched"
         );
     }
@@ -3100,197 +2883,17 @@ mod tests {
             ops_of(&ops),
             vec![
                 "conn1:tree".to_string(),
-                "conn1:tree".to_string(),
                 "conn1:click ref=1".to_string(),
                 "conn1:tree".to_string()
             ],
-            "the click went out and the state was read back — once, not settled: the read-back \
-             watches a flag, not geometry"
-        );
-    }
-
-    /// The outline of a tree as a caller would read it, ids assigned — bounds included, so two
-    /// of these differ exactly when something moved.
-    fn outline_of(t: &AxTree) -> String {
-        let mut t = t.clone();
-        t.assign_ids();
-        t.to_outline()
-    }
-
-    #[test]
-    fn a_tree_that_plateaus_and_then_moves_again_is_not_handed_back_mid_plateau() {
-        // glass#326, and the exact shape that beat the first attempt at it: the offset decays
-        // in *steps*, so two reads a few ms apart agree across a plateau and prove nothing.
-        // Whatever proves stillness must span longer than a plateau lasts.
-        let (port, _ops) = fake_service_timed(
-            vec![shifted(&compose_like(), 79), compose_like()],
-            vec![
-                std::time::Duration::ZERO,
-                std::time::Duration::from_millis(150),
-            ],
-        );
-        let mut a = reader(port, std::time::Duration::ZERO);
-        let tree = a
-            .snapshot(&ctx())
-            .expect("the content stops moving 150 ms in");
-        assert_eq!(
-            outline_of(&tree),
-            outline_of(&built(&compose_like())),
-            "a plateau is not stillness — the tree handed back must be the settled one"
-        );
-    }
-
-    #[test]
-    fn a_tree_that_stops_moving_is_handed_back_where_it_stopped() {
-        // Every read taken before the offset holds disagrees with the one before it, so the
-        // first pair that agrees is the settled position.
-        let (port, ops) = fake_service(
-            vec![
-                shifted(&compose_like(), 79),
-                shifted(&compose_like(), 31),
-                compose_like(),
-            ],
-            OnAction::Ok,
-        );
-        let mut a = reader(port, std::time::Duration::ZERO);
-        let tree = a
-            .snapshot(&ctx())
-            .expect("it settles well inside the budget");
-        assert_eq!(outline_of(&tree), outline_of(&built(&compose_like())));
-        assert_eq!(
-            ops_of(&ops).len(),
-            4,
-            "three reads to watch the decay, one more to agree with the last"
-        );
-    }
-
-    #[test]
-    fn a_tree_that_never_holds_still_fails_inside_its_budget_and_names_what_moved() {
-        // Bounded, and the give-up carries what was seen. Nothing but reads may repeat.
-        let jitter: Vec<Value> = (0..64)
-            .map(|i| shifted(&compose_like(), if i % 2 == 0 { 0 } else { 20 }))
-            .collect();
-        let (port, ops) = fake_service(jitter, OnAction::Ok);
-        let mut a = reader(port, std::time::Duration::ZERO);
-        let started = std::time::Instant::now();
-        let e = a
-            .snapshot(&ctx())
-            .expect_err("a tree that never holds still is not a snapshot");
-        let waited = started.elapsed();
-        assert!(
-            waited >= SETTLE_TIMEOUT,
-            "gave up after {waited:?}, before the budget it was given"
-        );
-        let m = e.to_string();
-        assert!(m.contains("element #1"), "names what moved: {m}");
-        assert!(m.contains("moving"), "{m}");
-        assert!(
-            m.contains("dx 20") || m.contains("dx -20"),
-            "the delta: {m}"
-        );
-        assert!(m.contains("ms"), "how long it watched: {m}");
-        assert!(
-            ops_of(&ops).iter().all(|o| o == "conn1:tree"),
-            "only tree reads may repeat: {:?}",
-            ops_of(&ops)
-        );
-    }
-
-    #[test]
-    fn a_target_on_a_tree_that_never_holds_still_is_never_clicked() {
-        let jitter: Vec<Value> = (0..64)
-            .map(|i| shifted(&compose_like(), if i % 2 == 0 { 0 } else { 20 }))
-            .collect();
-        let (port, ops) = fake_service(jitter, OnAction::Ok);
-        let mut a = reader(port, std::time::Duration::ZERO);
-        let t = built(&compose_like());
-        let e = a
-            .invoke(&ctx(), &target_for(&t, AxNodeId(2)))
-            .expect_err("a control that never holds still must not be actuated");
-        assert!(
-            !e.invoke_fallback_eligible(),
-            "a moving control must not take a pointer click either: {e}"
-        );
-        assert!(
-            ops_of(&ops).iter().all(|o| o == "conn1:tree"),
-            "nothing may be dispatched: {:?}",
-            ops_of(&ops)
-        );
-    }
-
-    #[test]
-    fn a_still_tree_costs_one_extra_read_and_one_span_of_wall_clock() {
-        // The common path pays for the read that proves stillness and one span, and nothing
-        // beyond it — so a later change cannot quietly put a second wait on every read.
-        let (port, ops) = fake_service(vec![compose_like()], OnAction::Ok);
-        let mut a = reader(port, std::time::Duration::ZERO);
-        let started = std::time::Instant::now();
-        a.snapshot(&ctx()).expect("nothing is moving");
-        let elapsed = started.elapsed();
-        assert_eq!(
-            ops_of(&ops),
-            vec!["conn1:tree".to_string(), "conn1:tree".to_string()],
-            "the read that proved stillness, and nothing beyond it"
-        );
-        assert!(
-            elapsed >= SETTLE_SPAN,
-            "the compared reads must be a span apart; took {elapsed:?}"
-        );
-        assert!(
-            elapsed < SETTLE_SPAN * 2,
-            "one span, not two; took {elapsed:?}"
-        );
-    }
-
-    #[test]
-    fn a_settled_target_that_moved_since_the_caller_looked_is_still_refused() {
-        // Settling must not launder a stale target — these reads agree with each other and
-        // still sit 20 px from where the caller looked.
-        let (port, ops) = fake_service(vec![shifted(&compose_like(), 20)], OnAction::Ok);
-        let mut a = reader(port, std::time::Duration::ZERO);
-        let t = built(&compose_like());
-        let e = a
-            .invoke(&ctx(), &target_for(&t, AxNodeId(2)))
-            .expect_err("an element that moved since the caller's snapshot must not be actuated");
-        assert!(matches!(e, GlassError::AxElementChanged(2)), "{e}");
-        assert!(!e.invoke_fallback_eligible(), "{e}");
-        assert_eq!(
-            ops_of(&ops),
-            vec!["conn1:tree".to_string(), "conn1:tree".to_string()],
-            "the refusal must happen before anything is dispatched"
-        );
-    }
-
-    #[test]
-    fn set_values_guard_reads_a_settled_tree_and_its_read_back_does_not() {
-        // `set_value` runs the same fingerprint guard as `invoke` over the tree `snapshot`
-        // hands it, so settling covers it with no change of its own; its post-write read-back
-        // does not settle, having run after the write went out.
-        let (port, ops) = fake_service(vec![editable_field("new")], OnAction::Ok);
-        let mut a = reader(port, std::time::Duration::ZERO);
-        let t = built(&editable_field("new"));
-        a.set_value(&ctx(), &target_for(&t, AxNodeId(1)), "new")
-            .expect("the field is not moving and already reads back the value");
-        assert_eq!(
-            ops_of(&ops),
-            vec![
-                "conn1:tree".to_string(),
-                "conn1:tree".to_string(),
-                "conn1:set_text ref=1".to_string(),
-                "conn1:tree".to_string(),
-            ],
-            "two reads to settle the guard's tree, one to read the write back"
+            "the click went out and the state was read back"
         );
     }
 
     #[test]
     fn a_toggle_that_flips_is_reported_clicked() {
-        // The plan comes from the read that proved stillness, so a box already reading checked
-        // by then would be planned as a flip back to false. Stillness is geometry — a `checked`
-        // that changes under the re-read is not motion.
         let (port, _) = fake_service(
             vec![
-                one_checkable("android.widget.CheckBox", false),
                 one_checkable("android.widget.CheckBox", false),
                 one_checkable("android.widget.CheckBox", true),
             ],

--- a/docs/how-to/setup-android.md
+++ b/docs/how-to/setup-android.md
@@ -101,6 +101,14 @@ and sets editable fields via the real `ACTION_SET_TEXT`; glass enables it and re
 prior accessibility state on teardown. Without `glass-a11y.apk`, glass uses the `uiautomator` reader.
 Set `GLASS_ANDROID_A11Y=off` to force `uiautomator` even when the APK is present.
 
+A snapshot through this reader waits for the screen to stop moving. A screen whose open transition is
+still playing reports its content at an offset that decays over about half a second, so the tree is
+re-read until two reads a quarter-second apart agree on every element's bounds — the coordinates you
+get are the ones the screen keeps, and a click aimed at them still resolves. A still screen costs one
+extra read; a small tree also waits out the quarter-second, since its reads are near-instant. A screen
+that never holds still errors, naming what moved and by how much, rather than reporting positions the
+UI has already left.
+
 The service also backs **`glass_click_element`**, which actuates through Android's `ACTION_CLICK`
 instead of tapping the element's centre. That reaches a control scrolled far below the fold or
 covered by something else, and it makes two outcomes honest that a tap cannot:

--- a/docs/how-to/setup-android.md
+++ b/docs/how-to/setup-android.md
@@ -101,14 +101,6 @@ and sets editable fields via the real `ACTION_SET_TEXT`; glass enables it and re
 prior accessibility state on teardown. Without `glass-a11y.apk`, glass uses the `uiautomator` reader.
 Set `GLASS_ANDROID_A11Y=off` to force `uiautomator` even when the APK is present.
 
-A snapshot through this reader waits for the screen to stop moving. A screen whose open transition is
-still playing reports its content at an offset that decays over about half a second, so the tree is
-re-read until two reads a quarter-second apart agree on every element's bounds — the coordinates you
-get are the ones the screen keeps, and a click aimed at them still resolves. A still screen costs one
-extra read; a small tree also waits out the quarter-second, since its reads are near-instant. A screen
-that never holds still errors, naming what moved and by how much, rather than reporting positions the
-UI has already left.
-
 The service also backs **`glass_click_element`**, which actuates through Android's `ACTION_CLICK`
 instead of tapping the element's centre. That reaches a control scrolled far below the fold or
 covered by something else, and it makes two outcomes honest that a tap cannot:

--- a/docs/how-to/setup-android.md
+++ b/docs/how-to/setup-android.md
@@ -103,11 +103,14 @@ Set `GLASS_ANDROID_A11Y=off` to force `uiautomator` even when the APK is present
 
 The service also backs **`glass_click_element`**, which actuates through Android's `ACTION_CLICK`
 instead of tapping the element's centre. That reaches a control scrolled far below the fold or
-covered by something else, and it makes two outcomes honest that a tap cannot:
+covered by something else, and it makes three outcomes honest that a tap cannot:
 
 - Clicking a **disabled** control is an error, not a tap that silently does nothing.
 - A **checkbox or switch** is only reported clicked once its state is read back changed; a radio
   button or tab that was already selected counts as clicked, since re-selecting it is a no-op.
+- A control that is still **moving** — a screen whose open transition is still animating — is
+  re-read until its bounds hold still before anything is sent, and errors if they never do,
+  rather than acting on a position the control has already left.
 
 Where a control's label is a separate element from the control itself — the usual Jetpack Compose
 shape — the action fires on the enclosing control that handles the tap, and the result names it in

--- a/docs/how-to/setup-android.md
+++ b/docs/how-to/setup-android.md
@@ -101,6 +101,15 @@ and sets editable fields via the real `ACTION_SET_TEXT`; glass enables it and re
 prior accessibility state on teardown. Without `glass-a11y.apk`, glass uses the `uiautomator` reader.
 Set `GLASS_ANDROID_A11Y=off` to force `uiautomator` even when the APK is present.
 
+A click or `set_value` through this reader recovers from a screen that is still moving. A screen
+whose open transition is playing reports its content at an offset that decays over about half a
+second, so glass can read the element tens of pixels from where your snapshot had it, and the check
+that stops an action landing on the wrong element refuses it. Glass re-reads and tries again — up to
+four reads spread over about six-tenths of a second — and acts on the first one that agrees with your
+snapshot. An element that moved under every read is refused, naming where each read found it;
+re-snapshot once the screen has settled. Only reads repeat: an action that may already have reached
+the device is never sent twice, and an element that has not moved costs no extra read and no wait.
+
 The service also backs **`glass_click_element`**, which actuates through Android's `ACTION_CLICK`
 instead of tapping the element's centre. That reaches a control scrolled far below the fold or
 covered by something else, and it makes two outcomes honest that a tap cannot:

--- a/docs/how-to/setup-android.md
+++ b/docs/how-to/setup-android.md
@@ -103,14 +103,11 @@ Set `GLASS_ANDROID_A11Y=off` to force `uiautomator` even when the APK is present
 
 The service also backs **`glass_click_element`**, which actuates through Android's `ACTION_CLICK`
 instead of tapping the element's centre. That reaches a control scrolled far below the fold or
-covered by something else, and it makes three outcomes honest that a tap cannot:
+covered by something else, and it makes two outcomes honest that a tap cannot:
 
 - Clicking a **disabled** control is an error, not a tap that silently does nothing.
 - A **checkbox or switch** is only reported clicked once its state is read back changed; a radio
   button or tab that was already selected counts as clicked, since re-selecting it is a no-op.
-- A control that is still **moving** — a screen whose open transition is still animating — is
-  re-read until its bounds hold still before anything is sent, and errors if they never do,
-  rather than acting on a position the control has already left.
 
 Where a control's label is a separate element from the control itself — the usual Jetpack Compose
 shape — the action fires on the enclosing control that handles the tap, and the result names it in

--- a/docs/how-to/setup-android.md
+++ b/docs/how-to/setup-android.md
@@ -101,15 +101,6 @@ and sets editable fields via the real `ACTION_SET_TEXT`; glass enables it and re
 prior accessibility state on teardown. Without `glass-a11y.apk`, glass uses the `uiautomator` reader.
 Set `GLASS_ANDROID_A11Y=off` to force `uiautomator` even when the APK is present.
 
-A click or `set_value` through this reader recovers from a screen that is still moving. A screen
-whose open transition is playing reports its content at an offset that decays over about half a
-second, so glass can read the element tens of pixels from where your snapshot had it, and the check
-that stops an action landing on the wrong element refuses it. Glass re-reads and tries again — up to
-four reads spread over about six-tenths of a second — and acts on the first one that agrees with your
-snapshot. An element that moved under every read is refused, naming where each read found it;
-re-snapshot once the screen has settled. Only reads repeat: an action that may already have reached
-the device is never sent twice, and an element that has not moved costs no extra read and no wait.
-
 The service also backs **`glass_click_element`**, which actuates through Android's `ACTION_CLICK`
 instead of tapping the element's centre. That reaches a control scrolled far below the fold or
 covered by something else, and it makes two outcomes honest that a tap cannot:

--- a/docs/how-to/setup-android.md
+++ b/docs/how-to/setup-android.md
@@ -101,6 +101,13 @@ and sets editable fields via the real `ACTION_SET_TEXT`; glass enables it and re
 prior accessibility state on teardown. Without `glass-a11y.apk`, glass uses the `uiautomator` reader.
 Set `GLASS_ANDROID_A11Y=off` to force `uiautomator` even when the APK is present.
 
+A click or `set_value` through this reader tolerates a control that moved. A screen whose open
+transition is playing reports its content at an offset that decays over about half a second, so
+glass can read the element tens of pixels from where your snapshot had it; where its role, name,
+value and size all still match, it acts on it where it now is. Where two elements in the tree match
+on all four, it refuses and names both positions rather than guess between them — as it does for an
+element that was resized, renamed, now holds different data, or is gone.
+
 The service also backs **`glass_click_element`**, which actuates through Android's `ACTION_CLICK`
 instead of tapping the element's centre. That reaches a control scrolled far below the fold or
 covered by something else, and it makes two outcomes honest that a tap cannot:

--- a/scripts/test-android.sh
+++ b/scripts/test-android.sh
@@ -29,16 +29,14 @@
 # Two tests are filtered out below rather than excluding the whole file each belongs to:
 #
 #   set_value_reports_whether_the_write_landed (a11y_loop) — fails on a cold CI emulator with
-#   AxElementChanged(16), glass's staleness guard refusing the write; passes warm. Tracked at
+#   AxElementChanged(16), AndroidA11y's staleness guard refusing the write; passes warm. Tracked at
 #   glass#323. While it is off the a11y write path has no device coverage: the only other
 #   set_value call (a11y_service_loop) sits behind "if this screen has an editable field", which
-#   Settings' top screen does not.
+#   Settings' top screen does not. Note glass#326's fix does not reach this — it relaxed the same
+#   guard in ServiceA11y, and this test drives AndroidA11y.
 #
-#   native_invoke_actuates_the_fixture (a11y_service_loop) — fails ~45% of CI runs with
-#   Backend("agent: no active window") at varying sites; passes warm. Tracked at glass#324.
-#
-# Multiple --skip flags compose rather than overriding. Each matches as a SUBSTRING: a future test
-# whose name contains either of these would be excluded too, with no signal that it was.
+# --skip matches as a SUBSTRING: a future test whose name contains this one's would be excluded
+# too, with no signal that it was.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 exec cargo test --no-fail-fast -p glass-android \
@@ -50,5 +48,4 @@ exec cargo test --no-fail-fast -p glass-android \
   --test see_loop \
   --test window_loop \
   -- --ignored --test-threads=1 \
-  --skip set_value_reports_whether_the_write_landed \
-  --skip native_invoke_actuates_the_fixture "$@"
+  --skip set_value_reports_whether_the_write_landed "$@"


### PR DESCRIPTION
Closes #326. Re-enables `native_invoke_actuates_the_fixture` in the Android CI leg.

## The bug

Compose nodes carry a transient uniform X offset that decays over an
activity-open transition — measured +79 → +31 → +23 → +18 → +14 → +11 → +5 → 0,
resolving in roughly 600ms. A caller that snapshots during that slide and then
invokes gets refused: the host's staleness guard compares the caller's target
against a live read at ±8px and sees the element somewhere else.

Every observed failure reported `role_name_ok=true value_ok=true bounds_ok=false`.
The element was always identifiable; only its position had changed.

## The fix

Position is not identity. When the guard would raise `AxElementChanged`, the node
still resolved by `target.id` is accepted if role, name, value and width/height
match exactly — and only if it is the **unique** such node in the tree. Two or
more candidates refuse, naming the ambiguity, because that is the case the bounds
check exists for.

Scope is `ServiceA11y` (the on-device companion reader). `AndroidA11y`,
`glass-core`, the other backends and the companion itself are untouched. Nothing
waits, nothing retries, and no extra tree read is taken.

## Measured

Forcing probe, 1423 invokes, against a same-session pre-fix control on the same
emulator, per 1000 invokes:

| | before | after |
|---|---|---|
| `AxElementChanged` | 13.1 | **0** |
| `AxActionUnavailable` | 0 | **0** |
| all failures | 15.4 | **4.2** |

Real test: **0/60 warm**, **0/24 cold-booted** (from ~2/12; p≈0.013).

Runtime is unchanged — `native_invoke_actuates_the_fixture` 8.33 → 7.90s, the
whole `a11y_service_loop` binary 10.24 → 10.07s.

No misdirected actuation: the disclosed actuated node was correct for all 1417
successes, and the fixture's own state assertions never fired.

## Residual

`live node gone` remains at its historical baseline (4.2/1000 in the probe, **0 in
84 real-test runs**). It originates in the companion comparing two of its own
device reads 1-6ms apart at zero tolerance, so no host-side change reaches it;
closing it would need an APK and an agent release.

## Known blind spot, measured

The relaxation applies only when exactly one node in the tree matches. The search is
tree-wide, not sibling-scoped, so a second identical control anywhere refuses it.

Probed on nine real screens (Settings top level, Apps, Accessibility, Display,
Sound; Clock; Quick Settings; launcher home and all-apps): 337 nodes, 21 collision
groups, 77 nodes (23%) in a group, largest group 12.

But 20 of the 21 groups are anonymous nodes (`name: None, value: None`) —
unnamed row and tile containers. The one named group is not clickable. **No named,
valued node collided with anything actuable.** Since an invoke target is normally
the named leaf a caller identified by its visible text, exposure is narrow: it
would bite an agent invoking an anonymous container or an icon-only tile, such as
a Quick Settings tile.

Exact size is doing real work here: the launcher duplicates Clock/Photos/Settings/
YouTube between its predicted shelf and the full grid — same role, same name, both
clickable — and they do not collide, because the two contexts render at different
heights (315px vs 283px).

## Not covered

#323 stays excluded. It hits the same guard in `AndroidA11y`, a different backend
that this change deliberately leaves strict.