### PR TITLE
fix(a11y-android): an element that is gone is not an element that changed

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,13 +9,11 @@ name: Android
 #     also pays a JDK install and a Gradle build, landing on whichever PR follows an eviction.
 #   - These are larger-runner minutes, billed per run, on every push to every branch.
 #   - The flake profile is young: bringing this up found three intermittent tests.
-#   - Two tests are excluded (glass#323, glass#324), and #324 is the native-invoke path
-#     glass#320 cared most about.
 #
 # So this detects rather than prevents: a PR that drops every click to a pointer tap still merges
 # green, and the push-to-master trigger then names the merge that broke it. See glass#320.
 #
-# Worth revisiting once glass#324 is fixed and there is real nightly history.
+# Worth revisiting once there is real nightly history.
 
 on:
   schedule:

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -305,8 +305,7 @@ impl Default for AndroidA11y {
 }
 
 /// Whether any node in `tree` still presents as `target` — same role and name, wherever it sits.
-/// A control's identity, not one particular reading of it: bounds and value both move under a
-/// live app without the control going anywhere.
+/// Bounds and value are excluded: both move under a live app without the control going anywhere.
 fn still_on_screen(tree: &AxTree, target: &AxTarget) -> bool {
     fn walk(node: &AxNode, target: &AxTarget) -> bool {
         target.matches(node.role, node.name.as_deref())
@@ -317,14 +316,12 @@ fn still_on_screen(tree: &AxTree, target: &AxTarget) -> bool {
 
 /// Which of the two disagreements a tree that no longer agrees with `target` has.
 ///
-/// [`GlassError::AxElementChanged`] — "this id now denotes something else" — sends the reader
-/// looking for where the element went, worth doing only while it is still somewhere. When nothing
-/// in the tree carries its role and name, the cause is that the screen was replaced or the app
-/// that drew it restarted (glass#323).
+/// `AxElementChanged` sends the reader looking for where the element went, which is worth doing
+/// only while it is still somewhere; nothing carrying its role and name means the screen was
+/// replaced or the app that drew it restarted (glass#323).
 ///
-/// Both Android readers get this. `a11y_service`'s bounds relaxation still sees
-/// `AxElementChanged` in every case it can relax — relaxing at all requires the node on the id to
-/// match role and name, which is already enough for [`still_on_screen`].
+/// Both Android readers get this. Do not tighten [`still_on_screen`] to include bounds or value:
+/// `a11y_service`'s relaxation needs `AxElementChanged` in every case it can relax.
 fn drifted(tree: &AxTree, target: &AxTarget) -> GlassError {
     if still_on_screen(tree, target) {
         GlassError::AxElementChanged(target.id.0)
@@ -336,9 +333,8 @@ fn drifted(tree: &AxTree, target: &AxTarget) -> GlassError {
 /// Find `target.id` and reject a tree that drifted under it — shared by [`editable_target`]
 /// and the service reader's `invoke`, which needs the same rejection without the editable check.
 ///
-/// An id that resolves to nothing stays [`GlassError::AxElementNotFound`]: "that id is not in the
-/// tree" is a different report from "that id is occupied by something unrelated", and only the
-/// second is what [`drifted`] classifies.
+/// An id that resolves to nothing stays [`GlassError::AxElementNotFound`]; [`drifted`] classifies
+/// only an id occupied by something unrelated.
 pub(crate) fn fingerprinted<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&'a AxNode> {
     let node = tree
         .find(target.id)
@@ -1071,8 +1067,7 @@ mod tests {
     #[test]
     fn an_element_nothing_in_the_tree_resembles_is_element_gone() {
         // glass#323: a first-boot platform kill destroyed the search activity mid-write, and the
-        // id then denoted a container in the tree that replaced it. "Changed" reads as "it moved"
-        // and sends the reader hunting a drift that never happened.
+        // id then denoted a container in the tree that replaced it.
         let t = a_different_screen();
         let e = locate_editable_target(&t, &target(0, Some("Search"), Some(BOUNDS)), &WIN)
             .expect_err("a container from another activity is not the field");

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -199,11 +199,11 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
                 t.limit_value,
                 t.limit.label(),
             )),
-            None => GlassError::AxElementChanged(target.id.0),
+            None => drifted(after_tree, target),
         });
     };
     if !target.matches(node.role, node.name.as_deref()) || !node.states.editable {
-        return Err(GlassError::AxElementChanged(target.id.0));
+        return Err(drifted(after_tree, target));
     }
     let landed = if text.is_empty() {
         typed_clear_landed(node.value.as_deref())
@@ -304,8 +304,41 @@ impl Default for AndroidA11y {
     }
 }
 
+/// Whether any node in `tree` still presents as `target` — same role and name, wherever it sits.
+/// A control's identity, not one particular reading of it: bounds and value both move under a
+/// live app without the control going anywhere.
+fn still_on_screen(tree: &AxTree, target: &AxTarget) -> bool {
+    fn walk(node: &AxNode, target: &AxTarget) -> bool {
+        target.matches(node.role, node.name.as_deref())
+            || node.children.iter().any(|c| walk(c, target))
+    }
+    walk(&tree.root, target)
+}
+
+/// Which of the two disagreements a tree that no longer agrees with `target` has.
+///
+/// [`GlassError::AxElementChanged`] — "this id now denotes something else" — sends the reader
+/// looking for where the element went, worth doing only while it is still somewhere. When nothing
+/// in the tree carries its role and name, the cause is that the screen was replaced or the app
+/// that drew it restarted (glass#323).
+///
+/// Both Android readers get this. `a11y_service`'s bounds relaxation still sees
+/// `AxElementChanged` in every case it can relax — relaxing at all requires the node on the id to
+/// match role and name, which is already enough for [`still_on_screen`].
+fn drifted(tree: &AxTree, target: &AxTarget) -> GlassError {
+    if still_on_screen(tree, target) {
+        GlassError::AxElementChanged(target.id.0)
+    } else {
+        GlassError::AxElementGone(target.id.0)
+    }
+}
+
 /// Find `target.id` and reject a tree that drifted under it — shared by [`editable_target`]
 /// and the service reader's `invoke`, which needs the same rejection without the editable check.
+///
+/// An id that resolves to nothing stays [`GlassError::AxElementNotFound`]: "that id is not in the
+/// tree" is a different report from "that id is occupied by something unrelated", and only the
+/// second is what [`drifted`] classifies.
 pub(crate) fn fingerprinted<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&'a AxNode> {
     let node = tree
         .find(target.id)
@@ -314,7 +347,7 @@ pub(crate) fn fingerprinted<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&
         || !target.bounds_consistent(node.bounds, 8)
         || !target.value_consistent(node.value.as_deref())
     {
-        return Err(GlassError::AxElementChanged(target.id.0));
+        return Err(drifted(tree, target));
     }
     Ok(node)
 }
@@ -837,6 +870,26 @@ mod tests {
         t
     }
 
+    /// `inner`'s root one level down, under a container that has taken over its id — the shape a
+    /// tree that grew a node above the element arrives in.
+    fn under_a_container(inner: AxTree) -> AxTree {
+        let mut t = tree(AxRole::Group, None, Some(BOUNDS), false);
+        t.root.children.push(inner.root);
+        t.assign_ids();
+        t
+    }
+
+    /// A tree with nothing resembling the target in it — Settings' home screen after the search
+    /// activity that owned the field was killed (glass#323).
+    fn a_different_screen() -> AxTree {
+        tree(
+            AxRole::Group,
+            None,
+            Some(AxRect { y: 900, ..BOUNDS }),
+            false,
+        )
+    }
+
     /// Like `tree`, but also holding `value` — see `editable_target`'s doc for why that's part of
     /// the fingerprint too. Always at `BOUNDS`, always editable.
     fn tree_with_value(role: AxRole, name: Option<&str>, value: Option<&str>) -> AxTree {
@@ -925,12 +978,22 @@ mod tests {
     fn a_target_that_moved_is_reported_as_changed_not_as_a_failed_write() {
         // The write may well have landed — on something that then moved. Saying "not applied"
         // would send an agent to retype into whatever now sits at that id.
-        let after = tree_holding(Some("world"));
-        let t = target(0, Some("A different field"), Some(BOUNDS));
+        let after = under_a_container(tree_holding(Some("world")));
+        let t = target(0, Some("Search"), Some(BOUNDS));
         assert!(matches!(
             verify_write(&after, &t, "world"),
             Err(GlassError::AxElementChanged(0))
         ));
+    }
+
+    #[test]
+    fn a_read_back_of_a_screen_that_was_replaced_reports_the_element_gone() {
+        // glass#323's other half: the kill can land between the write and the read-back, which
+        // is where four of the nine observed refusals came from.
+        let t = target(0, Some("Search"), Some(BOUNDS));
+        let e = verify_write(&a_different_screen(), &t, "world")
+            .expect_err("the field the write was aimed at is not in this tree");
+        assert!(matches!(e, GlassError::AxElementGone(0)), "{e}");
     }
 
     #[test]
@@ -948,6 +1011,8 @@ mod tests {
 
     #[test]
     fn a_target_missing_from_the_read_back_is_reported_as_changed() {
+        // The element is still in the tree, just no longer at that id — renumbered, which is what
+        // "changed" means.
         let after = tree_holding(Some("world"));
         let t = target(7, Some("Search"), Some(BOUNDS));
         assert!(matches!(
@@ -993,13 +1058,56 @@ mod tests {
     }
 
     #[test]
-    fn drifted_name_is_element_changed() {
-        // Same id lands on a different-named element (tree drift) — must refuse, not overwrite.
-        let t = tree(AxRole::TextField, Some("Search"), Some(BOUNDS), true);
+    fn an_element_that_moved_to_another_id_is_element_changed() {
+        // Same id lands on a different element (tree drift) — must refuse, not overwrite, and
+        // the element is still there to be re-addressed.
+        let t = under_a_container(tree(AxRole::TextField, Some("Search"), Some(BOUNDS), true));
         assert!(matches!(
-            locate_editable_target(&t, &target(0, Some("Other"), Some(BOUNDS)), &WIN),
+            locate_editable_target(&t, &target(0, Some("Search"), Some(BOUNDS)), &WIN),
             Err(GlassError::AxElementChanged(0))
         ));
+    }
+
+    #[test]
+    fn an_element_nothing_in_the_tree_resembles_is_element_gone() {
+        // glass#323: a first-boot platform kill destroyed the search activity mid-write, and the
+        // id then denoted a container in the tree that replaced it. "Changed" reads as "it moved"
+        // and sends the reader hunting a drift that never happened.
+        let t = a_different_screen();
+        let e = locate_editable_target(&t, &target(0, Some("Search"), Some(BOUNDS)), &WIN)
+            .expect_err("a container from another activity is not the field");
+        assert!(matches!(e, GlassError::AxElementGone(0)), "{e}");
+    }
+
+    #[test]
+    fn renaming_a_refusal_never_turns_it_into_a_write() {
+        // The taxonomy changes what a refusal is called, not when one happens.
+        let field = tree(AxRole::TextField, Some("Search"), Some(BOUNDS), true);
+        let nested = under_a_container(tree(AxRole::TextField, Some("Search"), Some(BOUNDS), true));
+        let replaced = a_different_screen();
+        let here = target(0, Some("Search"), Some(BOUNDS));
+        let moved = target(0, Some("Search"), Some(AxRect { x: 700, ..BOUNDS }));
+        for (what, got) in [
+            (
+                "a screen that was replaced",
+                editable_target(&replaced, &here),
+            ),
+            (
+                "the element one level down",
+                editable_target(&nested, &here),
+            ),
+            ("bounds that drifted", editable_target(&field, &moved)),
+            (
+                "a name no node carries",
+                editable_target(&field, &target(0, Some("Other"), Some(BOUNDS))),
+            ),
+            (
+                "an id that resolves to nothing",
+                editable_target(&field, &target(9, Some("Search"), Some(BOUNDS))),
+            ),
+        ] {
+            assert!(got.is_err(), "{what} must not authorise a write");
+        }
     }
 
     #[test]

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -1595,12 +1595,14 @@ mod tests {
 
     #[test]
     fn a_target_whose_name_drifted_is_rejected_before_any_climb() {
+        // No node in this tree is called "Send", so the refusal is `fingerprinted`'s gone
+        // verdict rather than its changed one.
         let t = built(&compose_like());
         let mut label = target_for(&t, AxNodeId(2));
         label.name = Some("Send".into());
         assert!(matches!(
             invoke_plan(&t, &label),
-            Err(GlassError::AxElementChanged(2))
+            Err(GlassError::AxElementGone(2))
         ));
     }
 
@@ -3101,7 +3103,9 @@ mod tests {
         let e = a
             .invoke(&ctx(), &target_for(&seen, AxNodeId(2)))
             .expect_err("only position is forgiven");
-        assert!(matches!(e, GlassError::AxElementChanged(2)), "{e}");
+        // Renaming the node left nothing in the tree presenting as the target, so the
+        // relaxation is never reached.
+        assert!(matches!(e, GlassError::AxElementGone(2)), "{e}");
         assert_eq!(
             ops_of(&ops),
             vec!["conn1:tree".to_string()],

--- a/crates/glass-android/tests/a11y_loop.rs
+++ b/crates/glass-android/tests/a11y_loop.rs
@@ -122,6 +122,186 @@ fn find<'a>(node: &'a AxNode, want: &dyn Fn(&AxNode) -> bool) -> Option<&'a AxNo
     node.children.iter().find_map(|c| find(c, want))
 }
 
+/// An attempt that saw nothing which is evidence about `set_value` — Settings' search screen went
+/// away under it, or the device could not be read — carrying the step that noticed. Abandoned for
+/// a retry rather than asserted on; every reason reaches the final failure.
+struct Abandoned(String);
+
+/// How long [`set_value_reports_whether_the_write_landed`] may spend getting Settings' search
+/// screen to stay up, and the pause between attempts at it.
+///
+/// A device's FIRST boot after a data wipe takes both these away from the test, and neither is
+/// anything glass did (glass#323):
+///
+///   - `com.google.android.settings.intelligence` — a different package from the
+///     `com.android.settings` this test launches, and the one that owns the search screen — takes
+///     a Phenotype config commit ~10s after `boot_completed`, and the platform force-stops it:
+///     `Killing …/u0a118 (adj 0): change com.google.android.settings.intelligence`, then `Force
+///     removing ActivityRecord{…SearchActivity}: app died, no saved state`. The field the write
+///     is aimed at is destroyed and Settings' home screen resumes under it.
+///   - Until that package is serving, Settings' home screen draws no search entry at all, so
+///     there is nothing to tap.
+///
+/// Both settle within the first half-minute of a boot. A warm device pays nothing: the first
+/// attempt succeeds and the budget is never consulted. Do not delete this as defensive noise —
+/// without it this test is red on a fresh CI emulator (12/12 on wiped cold boots, 0/22 warm).
+const SETUP_BUDGET: std::time::Duration = std::time::Duration::from_secs(60);
+const SETUP_PAUSE: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Whether Settings still has its search screen up — the premise every assertion in the write leg
+/// rests on. An editable field is what this test drives, and Settings' home screen has none.
+fn search_field_is_up(a11y: &mut glass_android::AndroidA11y, ctx: &AxContext) -> bool {
+    match a11y.snapshot(ctx) {
+        Ok(mut t) => {
+            t.assign_ids();
+            find(&t.root, &|n| n.states.editable).is_some()
+        }
+        Err(_) => false,
+    }
+}
+
+/// A step of the write leg did not do what it must. Panics when the field is still on screen,
+/// and abandons the attempt only when the screen the step was judging has gone. A guard bug
+/// refuses with the field still there, so it can never be retried away.
+fn abandon_or_fail(
+    a11y: &mut glass_android::AndroidA11y,
+    ctx: &AxContext,
+    what: String,
+) -> Abandoned {
+    assert!(!search_field_is_up(a11y, ctx), "{what}");
+    Abandoned(what)
+}
+
+/// One attempt at the write leg, opening the search screen it needs for itself.
+fn write_leg(
+    platform: &mut glass_android::AndroidPlatform,
+    a11y: &mut glass_android::AndroidA11y,
+    ctx: &AxContext,
+) -> Result<(), Abandoned> {
+    // Tap the search entry so Settings puts up its EditText.
+    let mut tree = a11y
+        .snapshot(ctx)
+        .map_err(|e| Abandoned(format!("snapshot: {e}")))?;
+    tree.assign_ids();
+    let search = find(&tree.root, &|n| {
+        n.name.as_deref().is_some_and(|s| s.contains("Search"))
+    })
+    .and_then(|n| n.bounds)
+    .and_then(|b| b.clamped_center(ctx.window.width, ctx.window.height))
+    .ok_or_else(|| Abandoned("Settings shows no search entry".into()))?;
+    platform
+        .send_pointer(&PointerEvent::Click {
+            x: search.0,
+            y: search.1,
+            button: MouseButton::Left,
+            count: 1,
+            modifiers: vec![],
+        })
+        .expect("tap search");
+    std::thread::sleep(std::time::Duration::from_millis(1500));
+
+    let mut tree = a11y
+        .snapshot(ctx)
+        .map_err(|e| Abandoned(format!("re-snapshot: {e}")))?;
+    tree.assign_ids();
+    let field = find(&tree.root, &|n| n.states.editable)
+        .ok_or_else(|| Abandoned("no editable field after the tap".into()))?;
+    let target = AxTarget {
+        id: field.id,
+        role: field.role,
+        name: field.name.clone(),
+        bounds: field.bounds,
+        value: field.value.clone(),
+    };
+
+    // A write that lands: reported Ok, and the node at that id holds it afterwards.
+    if let Err(e) = a11y.set_value(ctx, &target, "glass") {
+        return Err(abandon_or_fail(
+            a11y,
+            ctx,
+            format!("a real write into a real field must succeed: {e}"),
+        ));
+    }
+    let mut after = a11y
+        .snapshot(ctx)
+        .map_err(|e| Abandoned(format!("snapshot after write: {e}")))?;
+    after.assign_ids();
+    let held = after
+        .find(target.id)
+        .and_then(|n| n.value.clone())
+        .unwrap_or_default();
+    if !held.contains("glass") {
+        return Err(abandon_or_fail(
+            a11y,
+            ctx,
+            format!("field holds {held:?} after the write"),
+        ));
+    }
+
+    // Clearing the field, on the device whose behaviour decided the rule: an emptied Android
+    // `EditText` reports its *hint* as its text and `uiautomator` exposes no hint attribute, so a
+    // clear cannot be confirmed here at all — the deliberate cost of judging one by "reads back
+    // empty". What the device still has to show is that the text went.
+    //
+    // The target is re-located first: typing into Settings' search renders a results list, so the
+    // screen the pre-write target was captured against is gone.
+    let mut before_clear = a11y
+        .snapshot(ctx)
+        .map_err(|e| Abandoned(format!("snapshot before the clear: {e}")))?;
+    before_clear.assign_ids();
+    let field = find(&before_clear.root, &|n| n.states.editable)
+        .ok_or_else(|| Abandoned("the field went before the clear".into()))?;
+    let target = AxTarget {
+        id: field.id,
+        role: field.role,
+        name: field.name.clone(),
+        bounds: field.bounds,
+        value: field.value.clone(),
+    };
+    let verdict = a11y.set_value(ctx, &target, "");
+    if !matches!(verdict, Err(GlassError::AxValueNotApplied(_))) {
+        return Err(abandon_or_fail(
+            a11y,
+            ctx,
+            format!("a field that reports its hint cannot confirm a clear: {verdict:?}"),
+        ));
+    }
+    let mut cleared = a11y
+        .snapshot(ctx)
+        .map_err(|e| Abandoned(format!("snapshot after clear: {e}")))?;
+    cleared.assign_ids();
+    // Found by what it is, not by an id the clear may have shifted, so this cannot pass by failing
+    // to look.
+    let field = find(&cleared.root, &|n| n.states.editable)
+        .ok_or_else(|| Abandoned("the field went during the clear".into()))?;
+    assert_ne!(
+        field.value.as_deref(),
+        Some("glass"),
+        "the typed text is gone from the field"
+    );
+
+    // A stale target is refused before anything is typed — the pre-write fingerprint check, which
+    // predates the read-back. Kept as a regression guard, not as evidence about the read-back.
+    let stale = AxTarget {
+        id: target.id,
+        role: target.role,
+        name: Some("not the field that is there".into()),
+        bounds: target.bounds,
+        value: target.value.clone(),
+    };
+    // Any of the three refusals: nothing on this screen carries that name, so the usual verdict
+    // is `AxElementGone`, but a tree that renumbered or lost the id answers first.
+    match a11y.set_value(ctx, &stale, "ignored") {
+        Err(
+            GlassError::AxElementGone(_)
+            | GlassError::AxElementChanged(_)
+            | GlassError::AxElementNotFound(_),
+        ) => {}
+        other => panic!("a stale target must not report success: {other:?}"),
+    }
+    Ok(())
+}
+
 /// A real write into a real field, and a real clear of it.
 ///
 /// Settings has no editable field until its search entry is tapped, so the test taps it first and
@@ -142,109 +322,25 @@ fn set_value_reports_whether_the_write_landed() {
 
     let ctx = AxContext {
         pids: platform.app_pids(),
-        window: window.clone(),
+        window,
         window_handle: None,
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
     };
     let mut a11y = glass_android::AndroidA11y::new();
 
-    // Tap the search entry so Settings puts up its EditText.
-    let mut tree = a11y.snapshot(&ctx).expect("snapshot");
-    tree.assign_ids();
-    let search = find(&tree.root, &|n| {
-        n.name.as_deref().is_some_and(|s| s.contains("Search"))
-    })
-    .and_then(|n| n.bounds)
-    .and_then(|b| b.clamped_center(window.width, window.height))
-    .expect("Settings shows a search entry");
-    platform
-        .send_pointer(&PointerEvent::Click {
-            x: search.0,
-            y: search.1,
-            button: MouseButton::Left,
-            count: 1,
-            modifiers: vec![],
-        })
-        .expect("tap search");
-    std::thread::sleep(std::time::Duration::from_millis(1500));
-
-    let mut tree = a11y.snapshot(&ctx).expect("re-snapshot");
-    tree.assign_ids();
-    let field = find(&tree.root, &|n| n.states.editable).expect("an editable field after the tap");
-    let target = AxTarget {
-        id: field.id,
-        role: field.role,
-        name: field.name.clone(),
-        bounds: field.bounds,
-        value: field.value.clone(),
-    };
-
-    // A write that lands: reported Ok, and the node at that id holds it afterwards.
-    a11y.set_value(&ctx, &target, "glass")
-        .expect("a real write into a real field must succeed");
-    let mut after = a11y.snapshot(&ctx).expect("snapshot after write");
-    after.assign_ids();
-    let held = after
-        .find(target.id)
-        .and_then(|n| n.value.clone())
-        .unwrap_or_default();
-    assert!(
-        held.contains("glass"),
-        "field holds {held:?} after the write"
-    );
-
-    // Clearing the field, on the device whose behaviour decided the rule: an emptied Android
-    // `EditText` reports its *hint* as its text and `uiautomator` exposes no hint attribute, so a
-    // clear cannot be confirmed here at all — the deliberate cost of judging one by "reads back
-    // empty". What the device still has to show is that the text went.
-    //
-    // The target is re-located first: typing into Settings' search renders a results list, so the
-    // screen the pre-write target was captured against is gone.
-    let mut before_clear = a11y.snapshot(&ctx).expect("snapshot before the clear");
-    before_clear.assign_ids();
-    let field = find(&before_clear.root, &|n| n.states.editable).expect("the field is still there");
-    let target = AxTarget {
-        id: field.id,
-        role: field.role,
-        name: field.name.clone(),
-        bounds: field.bounds,
-        value: field.value.clone(),
-    };
-    match a11y.set_value(&ctx, &target, "") {
-        Err(GlassError::AxValueNotApplied(_)) => {}
-        other => panic!("a field that reports its hint cannot confirm a clear: {other:?}"),
-    }
-    let mut cleared = a11y.snapshot(&ctx).expect("snapshot after clear");
-    cleared.assign_ids();
-    // Found by what it is, not by an id the clear may have shifted, so this cannot pass by failing
-    // to look.
-    let field = find(&cleared.root, &|n| n.states.editable)
-        .expect("the field is still there after the clear");
-    assert_ne!(
-        field.value.as_deref(),
-        Some("glass"),
-        "the typed text is gone from the field"
-    );
-
-    // A stale target is refused before anything is typed — the pre-write fingerprint check, which
-    // predates the read-back. Kept as a regression guard, not as evidence about the read-back.
-    let stale = AxTarget {
-        id: target.id,
-        role: target.role,
-        name: Some("not the field that is there".into()),
-        bounds: target.bounds,
-        value: target.value.clone(),
-    };
-    // Any of the three refusals: nothing on this screen carries that name, so the usual verdict
-    // is `AxElementGone`, but a tree that renumbered or lost the id answers first.
-    match a11y.set_value(&ctx, &stale, "ignored") {
-        Err(
-            GlassError::AxElementGone(_)
-            | GlassError::AxElementChanged(_)
-            | GlassError::AxElementNotFound(_),
-        ) => {}
-        other => panic!("a stale target must not report success: {other:?}"),
+    let deadline = std::time::Instant::now() + SETUP_BUDGET;
+    let mut abandoned: Vec<String> = Vec::new();
+    while let Err(Abandoned(why)) = write_leg(&mut platform, &mut a11y, &ctx) {
+        eprintln!("abandoned: {why}; reopening Settings");
+        abandoned.push(why);
+        assert!(
+            std::time::Instant::now() < deadline,
+            "Settings never held its search screen up for one write leg in {SETUP_BUDGET:?}: \
+             {abandoned:?}"
+        );
+        reopen_settings();
+        std::thread::sleep(SETUP_PAUSE);
     }
 
     platform.stop_app().expect("stop");
@@ -266,6 +362,27 @@ fn bring_to_front(component: &str) {
         "am start {component} failed: {}",
         String::from_utf8_lossy(&out.stderr)
     );
+}
+
+/// Restart Settings from nothing, for [`set_value_reports_whether_the_write_landed`]'s retry.
+///
+/// The force-stop is what makes it a restart. Settings is already the front-most activity by then,
+/// so a bare `am start` is only delivered to it — `START … result code=3` — and redraws nothing;
+/// measured on this AVD, a home screen that lost its search entry when
+/// `com.google.android.settings.intelligence` was killed never grew one back without a fresh
+/// `com.android.settings` process.
+fn reopen_settings() {
+    let adb = std::env::var("GLASS_ADB").unwrap_or_else(|_| "adb".to_string());
+    let out = std::process::Command::new(&adb)
+        .args(["shell", "am", "force-stop", "com.android.settings"])
+        .output()
+        .expect("adb shell am force-stop");
+    assert!(
+        out.status.success(),
+        "am force-stop com.android.settings failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    bring_to_front("com.android.settings/.Settings");
 }
 
 /// The service reader answering while something else holds the foreground. Ignored by default:

--- a/crates/glass-android/tests/a11y_loop.rs
+++ b/crates/glass-android/tests/a11y_loop.rs
@@ -236,8 +236,14 @@ fn set_value_reports_whether_the_write_landed() {
         bounds: target.bounds,
         value: target.value.clone(),
     };
+    // Any of the three refusals: nothing on this screen carries that name, so the usual verdict
+    // is `AxElementGone`, but a tree that renumbered or lost the id answers first.
     match a11y.set_value(&ctx, &stale, "ignored") {
-        Err(GlassError::AxElementChanged(_)) | Err(GlassError::AxElementNotFound(_)) => {}
+        Err(
+            GlassError::AxElementGone(_)
+            | GlassError::AxElementChanged(_)
+            | GlassError::AxElementNotFound(_),
+        ) => {}
         other => panic!("a stale target must not report success: {other:?}"),
     }
 

--- a/crates/glass-android/tests/a11y_loop.rs
+++ b/crates/glass-android/tests/a11y_loop.rs
@@ -122,29 +122,26 @@ fn find<'a>(node: &'a AxNode, want: &dyn Fn(&AxNode) -> bool) -> Option<&'a AxNo
     node.children.iter().find_map(|c| find(c, want))
 }
 
-/// An attempt that saw nothing which is evidence about `set_value` — Settings' search screen went
-/// away under it, or the device could not be read — carrying the step that noticed. Abandoned for
-/// a retry rather than asserted on; every reason reaches the final failure.
+/// An attempt that saw nothing which is evidence about `set_value` — the search screen went away
+/// under it, or the device could not be read — carrying the step that noticed. Retried rather
+/// than asserted on.
 struct Abandoned(String);
 
 /// How long [`set_value_reports_whether_the_write_landed`] may spend getting Settings' search
 /// screen to stay up, and the pause between attempts at it.
 ///
-/// A device's FIRST boot after a data wipe takes both these away from the test, and neither is
-/// anything glass did (glass#323):
+/// A device's FIRST boot after a data wipe takes the search screen away twice over, neither of
+/// them anything glass did (glass#323), and both settle within the first half-minute:
 ///
-///   - `com.google.android.settings.intelligence` — a different package from the
-///     `com.android.settings` this test launches, and the one that owns the search screen — takes
-///     a Phenotype config commit ~10s after `boot_completed`, and the platform force-stops it:
-///     `Killing …/u0a118 (adj 0): change com.google.android.settings.intelligence`, then `Force
-///     removing ActivityRecord{…SearchActivity}: app died, no saved state`. The field the write
-///     is aimed at is destroyed and Settings' home screen resumes under it.
-///   - Until that package is serving, Settings' home screen draws no search entry at all, so
-///     there is nothing to tap.
+///   - `com.google.android.settings.intelligence` owns the search screen and is a different
+///     package from the `com.android.settings` this test launches. It takes a Phenotype config
+///     commit ~10s after `boot_completed` and the platform force-stops it — `Killing …(adj 0):
+///     change com.google.android.settings.intelligence`, then `Force removing
+///     ActivityRecord{…SearchActivity}: app died, no saved state`.
+///   - Until that package is serving, Settings' home screen draws no search entry to tap.
 ///
-/// Both settle within the first half-minute of a boot. A warm device pays nothing: the first
-/// attempt succeeds and the budget is never consulted. Do not delete this as defensive noise —
-/// without it this test is red on a fresh CI emulator (12/12 on wiped cold boots, 0/22 warm).
+/// Do not delete this as defensive noise: without it the test is 12/12 red on wiped cold boots
+/// (0/22 warm).
 const SETUP_BUDGET: std::time::Duration = std::time::Duration::from_secs(60);
 const SETUP_PAUSE: std::time::Duration = std::time::Duration::from_secs(3);
 
@@ -305,9 +302,8 @@ fn write_leg(
 /// A real write into a real field, and a real clear of it.
 ///
 /// Settings has no editable field until its search entry is tapped, so the test taps it first and
-/// then drives `set_value` against the `EditText` that appears — which is the point: this exercises
-/// the tap-clear-type path on a live toolkit, where the read-back has to come from `uiautomator`'s
-/// own view of the field rather than from anything glass remembers writing.
+/// drives `set_value` against the `EditText` that appears. The read-back comes from `uiautomator`'s
+/// view of the field, not from anything glass remembers writing.
 #[test]
 #[ignore = "requires a booted AVD + GLASS_ANDROID_SERIAL/GLASS_ADB"]
 fn set_value_reports_whether_the_write_landed() {
@@ -366,11 +362,9 @@ fn bring_to_front(component: &str) {
 
 /// Restart Settings from nothing, for [`set_value_reports_whether_the_write_landed`]'s retry.
 ///
-/// The force-stop is what makes it a restart. Settings is already the front-most activity by then,
-/// so a bare `am start` is only delivered to it — `START … result code=3` — and redraws nothing;
-/// measured on this AVD, a home screen that lost its search entry when
-/// `com.google.android.settings.intelligence` was killed never grew one back without a fresh
-/// `com.android.settings` process.
+/// Do not drop the force-stop: Settings is already front-most by then, so a bare `am start` is
+/// only delivered to it — `START … result code=3` — and a home screen that lost its search entry
+/// never grew one back without a fresh `com.android.settings` process.
 fn reopen_settings() {
     let adb = std::env::var("GLASS_ADB").unwrap_or_else(|_| "adb".to_string());
     let out = std::process::Command::new(&adb)

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -305,8 +305,6 @@ mod tests {
 
     #[test]
     fn a_gone_element_forecloses_the_drift_hunt_its_neighbour_invites() {
-        // "changed" reads as "it moved", and a reader who takes that at face value looks for a
-        // drift that never happened (glass#323).
         assert_eq!(
             GlassError::AxElementGone(16).to_string(),
             "element #16 is gone — nothing in the tree carries its role and name any more, so it \

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -99,6 +99,15 @@ pub enum GlassError {
     #[error("element #{0} changed since the snapshot; re-snapshot")]
     AxElementChanged(u32),
 
+    /// Raised in place of [`Self::AxElementChanged`] when nothing in the tree presents as the
+    /// element any more.
+    #[error(
+        "element #{0} is gone — nothing in the tree carries its role and name any more, so it has \
+         not moved or been renumbered; the screen it was on was replaced, or the app that drew it \
+         restarted. Re-snapshot to see where the app is now rather than re-addressing this element"
+    )]
+    AxElementGone(u32),
+
     #[error(
         "set_value on element #{0} did not take — the element does not hold the requested value. On \
          a desktop backend this usually means a read-only accessibility projection, so try \
@@ -295,6 +304,19 @@ mod tests {
     }
 
     #[test]
+    fn a_gone_element_forecloses_the_drift_hunt_its_neighbour_invites() {
+        // "changed" reads as "it moved", and a reader who takes that at face value looks for a
+        // drift that never happened (glass#323).
+        assert_eq!(
+            GlassError::AxElementGone(16).to_string(),
+            "element #16 is gone — nothing in the tree carries its role and name any more, so it \
+             has not moved or been renumbered; the screen it was on was replaced, or the app that \
+             drew it restarted. Re-snapshot to see where the app is now rather than re-addressing \
+             this element"
+        );
+    }
+
+    #[test]
     fn ax_action_errors_name_the_element_and_cause() {
         assert_eq!(
             GlassError::AxActionUnavailable(7).to_string(),
@@ -322,6 +344,7 @@ mod tests {
             GlassError::AxActionFailed(3, "boom".into()),
             GlassError::AccessibilityUnavailable("invoke timed out".into()),
             GlassError::AxElementChanged(3),
+            GlassError::AxElementGone(3),
             GlassError::NoAxSnapshot,
             GlassError::AxElementNotFound(3),
             GlassError::NoActiveSession,
@@ -341,6 +364,7 @@ mod tests {
         for e in [
             GlassError::AxElementNotFound(3),
             GlassError::AxElementChanged(3),
+            GlassError::AxElementGone(3),
             GlassError::AxElementNotEditable(3),
             GlassError::AxElementNotClickable(3),
             GlassError::AxUnsupported,

--- a/docs/how-to/setup-android.md
+++ b/docs/how-to/setup-android.md
@@ -156,11 +156,8 @@ GLASS_ADB=$HOME/android-sdk/platform-tools/adb \
 ANDROID_SDK_ROOT=$HOME/android-sdk GLASS_AVD=glass ./scripts/test-android-lifecycle.sh
 ```
 
-Two tests are skipped by default: `set_value_reports_whether_the_write_landed`
-([#323](https://github.com/fixed-width/glass/issues/323)) and
-`native_invoke_actuates_the_fixture` ([#324](https://github.com/fixed-width/glass/issues/324)).
-The second is the only consumer of `GLASS_ANDROID_FIXTURE_APK`, so that variable matters only once
-#324 lands; the jar and a11y APK are needed either way.
+No test is skipped, so all three artifacts are required: `native_invoke_actuates_the_fixture` is
+the only consumer of `GLASS_ANDROID_FIXTURE_APK`, and fails loudly without it.
 
 The role-histogram probes in `crates/glass-android/tests/role_probe.rs` are deliberately not in
 either script; they print evidence for a human rather than asserting, and take

--- a/scripts/test-android.sh
+++ b/scripts/test-android.sh
@@ -9,9 +9,8 @@
 #     GLASS_ANDROID_FIXTURE_APK=/path/to/fixture-compose-debug.apk \
 #     ./scripts/test-android.sh
 #
-# Three tests fail loudly without the jar and a11y APK rather than self-skipping, so neither is
-# optional. GLASS_ANDROID_FIXTURE_APK currently is: its only consumer,
-# native_invoke_actuates_the_fixture, is excluded below until glass#324 lands.
+# Every test needing the jar, the a11y APK or the fixture APK fails loudly without it rather than
+# self-skipping, so all three are required.
 #
 # --test-threads=1 is required: every test drives the one attached device, so in parallel each
 # tears down the app another is mid-interaction with.
@@ -26,17 +25,8 @@
 #   managed_avd  — requires NO emulator running, so it cannot share a run with tests that need a
 #                  booted device. scripts/test-android-lifecycle.sh runs it instead.
 #
-# Two tests are filtered out below rather than excluding the whole file each belongs to:
-#
-#   set_value_reports_whether_the_write_landed (a11y_loop) — fails on a cold CI emulator with
-#   AxElementChanged(16), AndroidA11y's staleness guard refusing the write; passes warm. Tracked at
-#   glass#323. While it is off the a11y write path has no device coverage: the only other
-#   set_value call (a11y_service_loop) sits behind "if this screen has an editable field", which
-#   Settings' top screen does not. Note glass#326's fix does not reach this — it relaxed the same
-#   guard in ServiceA11y, and this test drives AndroidA11y.
-#
-# --skip matches as a SUBSTRING: a future test whose name contains this one's would be excluded
-# too, with no signal that it was.
+# Nothing is filtered out. If a test ever has to be, use --skip and say why here — it matches as a
+# SUBSTRING, so a future test whose name contains the excluded one's would go too, unannounced.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 exec cargo test --no-fail-fast -p glass-android \
@@ -47,5 +37,4 @@ exec cargo test --no-fail-fast -p glass-android \
   --test input_loop \
   --test see_loop \
   --test window_loop \
-  -- --ignored --test-threads=1 \
-  --skip set_value_reports_whether_the_write_landed "$@"
+  -- --ignored --test-threads=1 "$@"


### PR DESCRIPTION
Closes #323. Re-enables `set_value_reports_whether_the_write_landed`.

## What #323 actually was

Not a glass defect. On a first boot after a wipe, `com.google.android.settings.intelligence`
— a different package from the `com.android.settings` the test launches — takes a
Phenotype config commit ~10-12s after `boot_completed`, and the platform kills it:

```
ActivityManager: Killing … (adj 0): change com.google.android.settings.intelligence
Force removing ActivityRecord{…SearchActivity}: app died, no saved state
```

The search field was **destroyed, not moved**: every refusal had
`role_name_ok=false bounds_ok=false value_ok=false`. The guard was correct — it
stopped a write into a `List` container. The test's fixed 1500ms settle was
innocent; the captured target was byte-identical across all 34 runs.

Reproduced 12/12 on cold boots with `-wipe-data`, 0/22 warm, 0/4 cold without a
wipe, 0/2 with a 150s settle.

## Change 1: say what happened

`AxElementChanged` was reported for every disagreement, including when the element
no longer exists. "Changed" reads as "it moved", which sends the reader hunting a
drift that never happened.

A shared classifier now asks one question — does any node still carry the target's
role and name?

- yes → `AxElementChanged`, as before: renumbered, re-address it
- no → new `AxElementGone`: re-snapshotting will not help, the screen changed

The two have different remedies, which is why this is a new variant rather than a
reuse of `AxElementNotFound` ("that id is not in the tree" is a third thing).
Applied at both `fingerprinted` and `verify_write`.

This changes what a refusal is *called*, never when one happens. #328's relaxation
is untouched — it fires only when the node at the id matches role and name, which
is strictly stronger than the new check, so it still sees `AxElementChanged`.

## Change 2: survive the environment

The write leg is now one attempt inside a 60s budget. A step that fails **with the
field still on screen** panics exactly as before, so a guard bug can never be
retried away; only a step failing with the screen gone abandons and retries.
Because `am start` on the front-most activity redraws nothing (`result code=3`),
the retry force-stops and relaunches Settings.

Every assertion is unchanged.

## Measured

| | before | after |
|---|---|---|
| cold boot, `-wipe-data` | 12/12 fail | **8/8 pass** |
| warm | 0/22 fail | **10/10 pass** |

The retry fired and recovered on 4 of the 8 cold runs, from the exact signatures
(`field holds "" after the write`, `element #16 is gone`).

## Also

Removes the last `--skip` from `scripts/test-android.sh`, so the scheduled Android
leg now runs all 11 device tests plus the lifecycle test. Corrects two stale claims
in that script's header.