### PR TITLE
test(a11y-android): prove a session click takes the native action

### DIFF
--- a/crates/glass-mcp/tests/android_session_loop.rs
+++ b/crates/glass-mcp/tests/android_session_loop.rs
@@ -1,0 +1,124 @@
+//! The Android click path as a user reaches it: a session whose backend comes from the real
+//! `make_platform` factory, so the reader it selects is the one under test. Ignored; run with a
+//! booted AVD + the built APKs (both come from the glass-android-agent repo:
+//! `./gradlew :a11y:assembleDebug :fixture-compose:assembleDebug`):
+//!   GLASS_ADB=/path/to/platform-tools/adb \
+//!   GLASS_ANDROID_A11Y_APK=/path/to/a11y-debug.apk \
+//!   GLASS_ANDROID_FIXTURE_APK=/path/to/fixture-compose-debug.apk \
+//!     cargo test -p glass-mcp --test android_session_loop -- --ignored --nocapture
+
+use glass_android::{A11yServiceRegistry, AgentRegistry, AndroidPlatform, EmulatorRegistry};
+use glass_core::accessibility::{AxNode, AxTree, ClickMethod};
+use glass_core::{AppSpec, BaselineStore, Glass, PlatformFactory, SandboxLevel};
+
+/// Ceiling on the wait for the fixture's counter to reflect the click — the poll returns as soon
+/// as it changes.
+const AWAIT_DEADLINE: std::time::Duration = std::time::Duration::from_secs(5);
+const AWAIT_INTERVAL: std::time::Duration = std::time::Duration::from_millis(150);
+
+/// glass#287: the glass-android device tests build `ServiceA11y` by hand, so none of them can see
+/// which reader a session would have picked — and picking the uiautomator one makes every click a
+/// pointer tap that still reports `Ok`.
+#[test]
+#[ignore = "requires a booted AVD + GLASS_ADB + GLASS_ANDROID_A11Y_APK + GLASS_ANDROID_FIXTURE_APK"]
+fn a_session_click_reports_the_native_accessibility_action() {
+    // An unset APK path is itself the degradation this test detects, so it has to fail as
+    // misconfiguration rather than as a verdict.
+    std::env::var("GLASS_ANDROID_A11Y_APK").expect("set GLASS_ANDROID_A11Y_APK");
+    let fixture =
+        std::env::var("GLASS_ANDROID_FIXTURE_APK").expect("set GLASS_ANDROID_FIXTURE_APK");
+
+    // Under the default attach-or-boot lifecycle a second `EmulatorRegistry` with no device
+    // attached boots a second emulator, so the install below and the factory share one.
+    let registry = EmulatorRegistry::new();
+    let agents = AgentRegistry::new();
+    let a11y = A11yServiceRegistry::new();
+
+    {
+        let p = AndroidPlatform::from_env(&registry, &agents).expect("attach to a device");
+        p.resolved_adb()
+            .run(["install", "-r", "-g", &fixture])
+            .expect("install the fixture APK");
+    }
+
+    // The two shapes of `boot`'s own factory closure — `make_platform` takes the iOS Simulator
+    // registry on macOS only.
+    #[cfg(target_os = "macos")]
+    let sim = glass_ios::SimulatorRegistry::new();
+    #[cfg(target_os = "macos")]
+    let factory: PlatformFactory =
+        Box::new(move |b| glass_mcp::make_platform(b, &registry, &agents, &a11y, &sim));
+    #[cfg(not(target_os = "macos"))]
+    let factory: PlatformFactory =
+        Box::new(move |b| glass_mcp::make_platform(b, &registry, &agents, &a11y));
+
+    let baselines = tempfile::tempdir().expect("a temp dir for the baseline store");
+    let mut glass = Glass::new(
+        factory,
+        "android".to_string(),
+        BaselineStore::new(baselines.path()),
+        10_000,
+    );
+    glass
+        .start(&AppSpec {
+            build: None,
+            run: vec!["com.fixedwidth.glassfixture/.InvokeViewFixtureActivity".to_string()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 10_000,
+            sandbox: SandboxLevel::Off,
+            a11y: false,
+        })
+        .expect("launch the view fixture");
+
+    let tree = glass.a11y_snapshot(None).expect("snapshot");
+    let before = counter(&tree);
+    let save = find(&tree.root, "SaveBtn").expect("the fixture's SaveBtn is present");
+    let method = glass.click_element(save.id).expect("click SaveBtn");
+
+    // `Pointer`'s `native_fallback` names the error that sent the click down the synthetic path.
+    assert!(
+        matches!(method, ClickMethod::NativeAction { .. }),
+        "a session click on an enabled button must fire the native action, got {method:?}"
+    );
+
+    // `NativeAction` is the session's claim about which path it took; the counter is the
+    // fixture's report that something actuated.
+    await_change("SaveBtn's click to register", &before, || {
+        counter(&glass.a11y_snapshot(None).expect("snapshot"))
+    });
+}
+
+/// The fixture's click counter, as the a11y tree reports it.
+fn counter(tree: &AxTree) -> String {
+    find(&tree.root, "Counter")
+        .and_then(|n| n.name.clone().or_else(|| n.value.clone()))
+        .expect("the fixture's Counter is present")
+}
+
+/// The first node in `n`'s subtree whose description or name is `label`.
+fn find<'a>(n: &'a AxNode, label: &str) -> Option<&'a AxNode> {
+    if n.description.as_deref() == Some(label) || n.name.as_deref() == Some(label) {
+        return Some(n);
+    }
+    n.children.iter().find_map(|c| find(c, label))
+}
+
+/// Poll `read` until it differs from `before`. A timeout is a real failure, not a silent pass.
+fn await_change(what: &str, before: &str, mut read: impl FnMut() -> String) {
+    let start = std::time::Instant::now();
+    loop {
+        let now = read();
+        if now != before {
+            return;
+        }
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < AWAIT_DEADLINE,
+            "timed out after {elapsed:?} waiting for {what}; still reads {now:?} \
+             (started at {before:?})"
+        );
+        std::thread::sleep(AWAIT_INTERVAL);
+    }
+}

--- a/docs/how-to/setup-android.md
+++ b/docs/how-to/setup-android.md
@@ -156,8 +156,13 @@ GLASS_ADB=$HOME/android-sdk/platform-tools/adb \
 ANDROID_SDK_ROOT=$HOME/android-sdk GLASS_AVD=glass ./scripts/test-android-lifecycle.sh
 ```
 
-No test is skipped, so all three artifacts are required: `native_invoke_actuates_the_fixture` is
-the only consumer of `GLASS_ANDROID_FIXTURE_APK`, and fails loudly without it.
+No test is skipped, so all three artifacts are required. `GLASS_ANDROID_FIXTURE_APK` is read by
+`native_invoke_actuates_the_fixture` and by the session-level click leg in
+`crates/glass-mcp/tests/android_session_loop.rs`; both fail loudly without it.
+
+That leg is the reason `./scripts/test-android.sh` runs `cargo test` twice. It lives in
+`glass-mcp` because that crate owns the backend factory choosing a session's accessibility
+reader, and it is the only test that can see a session fall back to pointer taps.
 
 The role-histogram probes in `crates/glass-android/tests/role_probe.rs` are deliberately not in
 either script; they print evidence for a human rather than asserting, and take

--- a/scripts/test-android.sh
+++ b/scripts/test-android.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Run the Android device suite: the #[ignore]d tests across 7 of the 9 files in
-# crates/glass-android/tests/. Requires an already-booted emulator — this script does not
-# start one (scripts/test-android-lifecycle.sh is the one that exercises glass booting its own).
+# crates/glass-android/tests/, plus the session-level click leg in
+# crates/glass-mcp/tests/android_session_loop.rs. Requires an already-booted emulator — this
+# script does not start one (scripts/test-android-lifecycle.sh exercises glass booting its own).
 #
 #   GLASS_ADB=$HOME/android-sdk/platform-tools/adb \
 #     GLASS_ANDROID_AGENT_JAR=/path/to/glass-agent.jar \
@@ -29,7 +30,13 @@
 # SUBSTRING, so a future test whose name contains the excluded one's would go too, unannounced.
 set -euo pipefail
 cd "$(dirname "$0")/.."
-exec cargo test --no-fail-fast -p glass-android \
+
+# Two invocations, not one `-p glass-android -p glass-mcp`: a `--test` filter applies to every
+# `-p` package, so neither package matches the other's targets and the run exits 0 having tested
+# nothing.
+rc=0
+
+cargo test --no-fail-fast -p glass-android \
   --test a11y_loop \
   --test a11y_service_loop \
   --test agent_loop \
@@ -37,4 +44,13 @@ exec cargo test --no-fail-fast -p glass-android \
   --test input_loop \
   --test see_loop \
   --test window_loop \
-  -- --ignored --test-threads=1 "$@"
+  -- --ignored --test-threads=1 "$@" || rc=$?
+
+# The session-level click leg (glass#287): it lives in glass-mcp because that crate owns the
+# factory deciding which accessibility reader a session gets, and it costs a glass-mcp build the
+# rest of the suite does not need.
+cargo test --no-fail-fast -p glass-mcp \
+  --test android_session_loop \
+  -- --ignored --test-threads=1 "$@" || rc=$?
+
+exit "$rc"


### PR DESCRIPTION
Closes #287.

## The gap

Every Android device test constructs its accessibility reader directly, so none of them exercises the choice `glass-mcp`'s backend factory actually makes. `crates/glass-mcp/src/lib.rs:76-99` picks `ServiceA11y` when `a11y_apk()` finds the APK and `A11yServiceRegistry::ensure` connects, and `AndroidA11y` (uiautomator) otherwise. `AndroidA11y` defines no `invoke`, so it takes the trait default — `AxUnsupported` — which *is* `invoke_fallback_eligible`, and `click_element` degrades to a synthetic tap and returns `Ok(ClickMethod::Pointer { .. })`.

A renamed variable or a failed service install therefore turns every Android click into a pointer tap that reports success, with the whole suite green.

## The leg

`crates/glass-mcp/tests/android_session_loop.rs` builds a session from `make_platform`, clicks the fixture's `SaveBtn`, and asserts the disclosed method is `NativeAction`. The fixture's counter is then polled for a change, because the method is only the session's claim about which path it took.

It lives in `glass-mcp` because that crate owns the factory. That is why `scripts/test-android.sh` now runs `cargo test` twice: a `--test` filter applies to every `-p` package, so a single invocation naming both would match neither package's targets for the other and exit 0 having tested nothing.

## Verification

On a freshly booted `verify_pixel6` AVD (1080x2400, matching CI's profile):

- The leg passes in ~4s.
- Negative control — `GLASS_ANDROID_A11Y_APK` pointed at a path that does not exist, forcing the factory's uiautomator arm:

  ```
  glass-android: a11y service unavailable, using uiautomator: ... No such file or directory
  a session click on an enabled button must fire the native action,
    got Pointer { native_fallback: "backend has no native action path" }
  ```

  The counter still moves in that run — a pointer tap on `SaveBtn` works — so the method assertion is the discriminating one.
- Full `./scripts/test-android.sh`: the first invocation failed on `a_snapshot_taken_while_another_app_is_foreground_says_so` (#331), the remaining six glass-android binaries still ran, the second invocation ran and passed, and the script exited 101.
- `cargo test --workspace --locked`, `cargo clippy -p glass-mcp --all-targets --locked -- -D warnings`, `cargo fmt --all -- --check`: clean.

## Note

Not covered: `boot`'s backend-name resolution, since the test names the `android` backend directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
