### PR TITLE
refactor(android): let the backend choose its own accessibility reader

### DIFF
--- a/crates/glass-android/src/lib.rs
+++ b/crates/glass-android/src/lib.rs
@@ -34,12 +34,13 @@ use glass_core::capability::{CapabilityMap, CapabilityStatus};
 /// This backend's canonical name (matches the `glass_capabilities` / `GLASS_BACKEND` value).
 pub const BACKEND: &str = "android";
 
-/// This backend's live capability map. `input` degrades and `multi_touch`/`clipboard`
-/// need the on-device agent — gated on [`agent::agent_enabled`], the same predicate the
-/// runtime uses to pick `AgentInjector` vs `ShellInjector`, so this can't disagree with
-/// real behavior. `accessibility` degrades without the a11y APK — gated on
-/// [`a11y_service::a11y_apk`], the same predicate the runtime uses to pick the Compose-rich
-/// reader vs the basic `uiautomator` one.
+/// This backend's live capability map. `input`, `multi_touch` and `clipboard` are gated on
+/// [`agent::agent_enabled`]; `accessibility` on [`a11y_service::a11y_apk`].
+///
+/// Both gates answer whether a companion is *configured*, not whether it comes up: one that
+/// fails to install or connect degrades at runtime with a note on stderr
+/// ([`AndroidPlatform::from_env`] for the agent, [`AndroidPlatform::accessibility`] for the a11y
+/// service). This map is computed without a device, so it cannot see that.
 pub fn capabilities() -> CapabilityMap {
     let get = |k: &str| std::env::var(k).ok();
     capabilities_with(

--- a/crates/glass-android/src/platform.rs
+++ b/crates/glass-android/src/platform.rs
@@ -7,6 +7,8 @@ use glass_core::{
     WindowId, WindowInfo, WindowOp,
 };
 
+use crate::a11y::AndroidA11y;
+use crate::a11y_service::{A11yServiceRegistry, ServiceA11y};
 use crate::adb::Adb;
 use crate::agent::{AgentClient, AgentRegistry};
 use crate::build::run_build;
@@ -88,6 +90,31 @@ impl AndroidPlatform {
     /// the platform resolved (possibly a freshly booted AVD `choose_serial` can't disambiguate).
     pub fn resolved_adb(&self) -> Adb {
         self.target.adb().clone()
+    }
+
+    /// This device's accessibility reader: the Compose-rich [`ServiceA11y`] when the companion
+    /// APK resolves and its service installs and connects, else the basic `uiautomator`
+    /// [`AndroidA11y`]. Never absent — `uiautomator` needs nothing beyond `adb`.
+    ///
+    /// The input agent, the other optional companion, degrades the same way in
+    /// [`AndroidPlatform::from_env`].
+    pub fn accessibility(
+        &self,
+        services: &A11yServiceRegistry,
+    ) -> Box<dyn glass_core::Accessibility + Send> {
+        let get = |k: &str| std::env::var(k).ok();
+        let Some(apk) = crate::a11y_service::a11y_apk(&get) else {
+            return Box::new(AndroidA11y::for_adb(self.resolved_adb()));
+        };
+        match services.ensure(&self.resolved_adb(), &apk) {
+            // The package isn't known until start_app; the device service serves the ACTIVE
+            // window regardless, so an empty package is correct for the MVP.
+            Ok(client) => Box::new(ServiceA11y::new(client, String::new())),
+            Err(e) => {
+                eprintln!("glass-android: a11y service unavailable, using uiautomator: {e}");
+                Box::new(AndroidA11y::for_adb(self.resolved_adb()))
+            }
+        }
     }
 
     /// Re-read the active window's current on-screen frame before capturing — a rotation or

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -74,34 +74,13 @@ pub fn make_platform(
         });
     }
     if backend == "android" {
+        // Do not expand this back into a reader choice here — that is what let it drift from
+        // the capability gate that reports it.
         let platform = glass_android::AndroidPlatform::from_env(registry, agents)?;
-        let get = |k: &str| std::env::var(k).ok();
-        let accessibility: Option<Box<dyn glass_core::Accessibility + Send>> =
-            match glass_android::a11y_apk(&get) {
-                Some(apk) => match a11y.ensure(&platform.resolved_adb(), &apk) {
-                    // The package isn't known until start_app; the device service serves the
-                    // ACTIVE window regardless, so an empty package is correct for the MVP.
-                    Ok(client) => Some(Box::new(glass_android::ServiceA11y::new(
-                        client,
-                        String::new(),
-                    ))),
-                    Err(e) => {
-                        eprintln!(
-                            "glass-android: a11y service unavailable, using uiautomator: {e}"
-                        );
-                        Some(Box::new(glass_android::AndroidA11y::for_adb(
-                            platform.resolved_adb(),
-                        )))
-                    }
-                },
-                None => Some(Box::new(glass_android::AndroidA11y::for_adb(
-                    platform.resolved_adb(),
-                ))),
-            };
-        let platform: Box<dyn Platform + Send> = Box::new(platform);
+        let accessibility = platform.accessibility(a11y);
         return Ok(Backend {
-            platform,
-            accessibility,
+            platform: Box::new(platform),
+            accessibility: Some(accessibility),
         });
     }
     let platform: Box<dyn Platform + Send> = match backend {


### PR DESCRIPTION
Follow-up to #334, which could only be written because this policy lived in the wrong crate.

## The smell

`glass-mcp`'s android arm reached into `a11y_apk`, `A11yServiceRegistry::ensure` and both reader constructors to choose between the a11y-service reader and `uiautomator`, and owned the stderr note for the fallback. The iOS arm twenty lines above already delegates (`IosPlatform::accessibility()`), and `AndroidPlatform::from_env` already handles the *input agent* — the other optional companion — with exactly this try-then-degrade shape. Android's a11y was the one that leaked out.

## What it cost

Three places answered "which reader is in play", with three predicates:

| Site | Predicate |
|---|---|
| `capabilities()` | `a11y_apk().is_some()` |
| `doctor` | `a11y_apk()` + path exists + not `A11Y=off`; runs `ensure()` on `--deep` |
| `make_platform` | `a11y_apk().is_some()` **&&** `ensure().is_ok()` |

`a11y_apk()` passes an explicit `GLASS_ANDROID_A11Y_APK` through without checking it exists — deliberately, since silently ignoring a path the user set would be worse. So a configured-but-broken path made `capabilities()` report `accessibility: Supported` while every click was really a pointer tap, and its doc comment asserted the gate was *"the same predicate the runtime uses ... so this can't disagree with real behavior"*.

The agent gate carries the same overclaim: `agent_enabled` is "not off && jar resolves", but `from_env` additionally requires `ensure().and_then(connect)` and falls back on `Err`.

## The change

`AndroidPlatform::accessibility(&A11yServiceRegistry) -> Box<dyn Accessibility + Send>` owns the choice and the fallback. It returns no `Option` — `uiautomator` needs nothing beyond `adb`, so Android always has a reader — which is why it does not mirror iOS's `Result<Option<_>>` exactly.

`glass-mcp`'s arm becomes the three lines the iOS arm already was. `capabilities()`' doc now says what its gates answer — whether a companion is *configured*, not whether it comes up — and that a map computed without a device cannot see the difference.

## Verification

No behavior change intended, and the fallback path is the one that would show it.

- Booted `verify_pixel6` AVD: `android_session_loop` passes.
- `GLASS_ANDROID_A11Y_APK` pointed at a nonexistent path: same stderr note (now emitted from glass-android), same verdict — `Pointer { native_fallback: "backend has no native action path" }`.
- Full `./scripts/test-android.sh`: byte-identical outcome to a run on `master` an hour earlier — one failure, `a_snapshot_taken_while_another_app_is_foreground_says_so` (#331), everything else green, exit 101.
- `cargo test --workspace --locked`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo fmt --all -- --check`: clean.

## Not covered

`capabilities()` still cannot report a companion that is configured but fails to come up. That is inherent — it runs without a device. The change makes the doc honest about it rather than closing the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
