### PR TITLE
docs: a terse-comments sweep over the whole workspace

### DIFF
--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -274,12 +274,8 @@ async fn set_value_async(ctx: &AxContext, target: &AxTarget, text: &str) -> Resu
 /// that divergence impossible to introduce by editing only one of them.
 //
 // The exactly-at-cap boundary — a *complete* tree of exactly MAX_NODES must report `None`, since
-// the last node to arrive wasn't declined — is unit-tested in the Android/iOS mappers, which
-// build a synthetic tree of a precise size in-process (a live GTK tree can't be sized to the node
-// exactly). The live *over-cap* path — a real AT-SPI tree past MAX_NODES yields a bounded,
-// complete prefix flagged `Nodes` — is covered by `snapshot_past_node_cap_is_bounded_complete_and_flagged`
-// in tests/integration.rs (run via scripts/test-a11y.sh). `walk` issues each node's independent
-// reads concurrently, so a cap-sized live tree snapshots well within `SNAPSHOT_TIMEOUT`.
+// the last node to arrive wasn't declined — is unit-tested in the Android/iOS mappers, which can
+// size a synthetic tree to the node. A live GTK tree can't be.
 fn may_explore_children(budget: &mut WalkBudget, depth: usize) -> bool {
     if budget.depth_exhausted(depth) {
         budget.hit(TruncationLimit::Depth);
@@ -411,11 +407,10 @@ async fn walk(
     budget.visit();
     // Issue the seven independent per-node reads concurrently on the shared connection and await
     // the slowest, instead of paying seven sequential D-Bus round-trips (~7x the per-node
-    // latency). zbus multiplexes concurrent method calls over one connection. Traversal order,
-    // `budget` accounting, the child-gate, and child recursion below are all unchanged, so node
-    // ids stay in lockstep with `find_nth`. On the error path `join!` completes all seven before
-    // we bail (vs. short-circuiting) — the result is identical, at the cost of a few reads on a
-    // snapshot that was already failing.
+    // latency); zbus multiplexes concurrent method calls over one connection. Traversal order and
+    // `budget` accounting are unchanged, so node ids stay in lockstep with `find_nth`. On the
+    // error path `join!` completes all seven before bailing — the same result, at the cost of a
+    // few reads on a snapshot that was already failing.
     let (role_res, raw_role_res, name_res, description_res, state_res, bounds, child_refs_res) = tokio::join!(
         proxy.get_role(),
         proxy.get_role_name(),

--- a/crates/glass-a11y-linux/tests/integration.rs
+++ b/crates/glass-a11y-linux/tests/integration.rs
@@ -683,13 +683,9 @@ fn set_value_selects_dropdown_option() {
 // A whole-frame pixel diff is too weak a check here: opening the GtkDropDown also
 // repaints the combo button itself (pressed style / arrow), which lives in the main
 // window's own drawable and would change even under the OLD (buggy) window-drawable
-// capture. So the comparison is scoped to the region strictly BELOW the combo button —
-// where the popover's option rows draw, and where the main window's own content (e.g.
-// the switch) does NOT change when the dropdown opens. Only the new root capture can
-// see anything change there, because that's where the popover (a separate top-level X
-// window) is composited on top; the old window-drawable capture would show that band
-// completely unchanged. So a substantial pixel change confined to that band is
-// specific evidence the popover itself was captured, not just the button's own repaint.
+// capture. So the comparison is scoped to the band strictly BELOW the combo button —
+// where only the popover's option rows draw, and which the old window-drawable capture
+// would show completely unchanged.
 #[test]
 #[ignore = "needs session bus + AT-SPI registry + GTK4 fixture; run via scripts/test-a11y.sh"]
 fn screenshot_includes_open_popover() {

--- a/crates/glass-a11y-macos/src/ffi.rs
+++ b/crates/glass-a11y-macos/src/ffi.rs
@@ -59,13 +59,12 @@ pub(crate) mod attr {
 
 // `AXIsProcessTrusted` is a plain C predicate not surfaced by the objc2 bindings, declared
 // with the same contained `extern "C"` pattern `permissions.rs` uses. It is a public,
-// documented, stable AX API (unlike `axwindow.rs`'s `_AXUIElementGetWindow`, a private
-// symbol that carries its own version-fragility caveat, which doesn't apply here).
-// `AXUIElementIsAttributeSettable`/`AXUIElementSetAttributeValue` are *not* declared this
-// way — `AXUIElement` already exposes them as safe-shaped methods
-// (`is_attribute_settable`/`set_attribute_value`, both gated behind the `AXError` feature
-// this crate already enables), so [`is_settable`]/[`set_string_value`] call those directly
-// instead of duplicating the raw externs.
+// documented, stable AX API — unlike `axwindow.rs`'s private `_AXUIElementGetWindow`, whose
+// version-fragility caveat doesn't apply here.
+//
+// `AXUIElementIsAttributeSettable`/`AXUIElementSetAttributeValue` are deliberately NOT
+// declared this way: `AXUIElement` already exposes them as safe-shaped methods, so
+// [`is_settable`]/[`set_string_value`] call those instead of duplicating the raw externs.
 #[link(name = "ApplicationServices", kind = "framework")]
 unsafe extern "C" {
     // Apple declares this `Boolean` (= `unsigned char`), NOT C99 `_Bool`. Binding it as

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -416,21 +416,18 @@ fn walk(
     let ax_role = ffi::attribute_string(el, attr::ROLE).unwrap_or_default();
     let subrole = read_subrole(el, &ax_role);
     let role = mapping::map_role(&ax_role, subrole.as_deref());
-    // `raw_role` is normally the same AX role string `map_role` just matched on — the token, not
+    // `raw_role` is normally the same AX role string `map_role` matched on — the token, not
     // `AXRoleDescription`'s localized human phrase ("button" / "bouton"), which is useless as a
-    // mapping key and not worth a second attribute read on every node. A subrole is appended
-    // (`"AXRow/AXOutlineRow"`, `"AXCheckBox/AXSwitch"`) only when it *decided* the mapped role, so
-    // it is the evidence for a role the base token does not explain. Deliberately not appended
-    // otherwise: the gate reads a subrole for every button, and decorating them all would rename
-    // `AXButton` to `AXButton/AXCloseButton` across every window's controls and split the role
-    // histogram the probe prints, for a token nothing maps.
+    // mapping key. A subrole is appended (`"AXRow/AXOutlineRow"`) only when it *decided* the
+    // mapped role. Deliberately not appended otherwise: the gate reads a subrole for every
+    // button, and decorating them all would rename `AXButton` to `AXButton/AXCloseButton`
+    // across every window's controls and split the role histogram the probe prints.
     //
     // The fallback is conditional because that trade only holds while `AXRole` says something.
-    // A custom or non-standard control is expected to report a generic role — `AXUnknown`, or no
-    // `AXRole` at all — and put what distinguishes it in `AXRoleDescription`; there the
-    // description is the only descriptor there is, so read it rather than emit a node nothing
-    // can identify. Ordinary nodes never pay for the second read. If both are absent `raw_role`
-    // stays the empty string — a "role unknown" signal, not a guaranteed-populated field.
+    // A custom control reports a generic role — `AXUnknown`, or no `AXRole` at all — and puts
+    // what distinguishes it in `AXRoleDescription`, which is then the only descriptor there is.
+    // If both are absent `raw_role` stays empty: a "role unknown" signal, not a guaranteed
+    // field.
     let raw_role = if ax_role.is_empty() || ax_role == "AXUnknown" {
         ffi::attribute_string(el, attr::ROLE_DESCRIPTION).unwrap_or(ax_role)
     } else {
@@ -449,13 +446,10 @@ fn walk(
     // surfaces as `AXDescription`). Never fold in `AXValue`: it's volatile content, and a
     // node's name must stay stable for the `AxTarget` fingerprint `set_value` relies on.
     //
-    // Which attribute is left to describe the node therefore depends on which one named it, so
-    // both labels are decided in one place. `AXDescription` costs at most one read per node
-    // either way: as the name when there is no title, as the description only when there IS a
-    // title and no `AXHelp` — worth reading there, unlike the untitled case where
-    // `AXDescription` IS the name and could only ever normalize away as a duplicate of it. (A
-    // titled node whose title and description hold the same string still normalizes away — the
-    // value check, not the branch, is what drops it.)
+    // Which attribute is left to describe the node depends on which one named it, so both
+    // labels are decided in one place. `AXDescription` costs at most one read per node either
+    // way: as the name when there is no title, as the description only when there IS a title
+    // and no `AXHelp`.
     let (name, secondary) = match read_label(el, attr::TITLE) {
         Some(title) => (
             Some(title),

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -141,16 +141,14 @@ pub(crate) fn tree_from_json(
 ) -> Result<AxTree> {
     let mut budget = WalkBudget::with_limits(limits);
     let mut root = json_to_node(tree, win, 0, &mut budget)?;
-    // The device answers with the root of the ACTIVE WINDOW, so this node is the window —
-    // whatever layout class it happens to carry. Say so, for the same reason the
-    // uiautomator reader wraps its dump in a Window root: both Android readers have to
-    // agree about the root, or a `role:` selector written against one misses on the other.
-    // The node itself is untouched — no synthetic wrapper — because `AxNodeId(n)` is the
-    // device's `ref` n and an extra node would shift every id `set_value` addresses by.
-    // `raw_role` keeps the device's class on the node, so anything that reads the node itself
-    // — the role histogram, a structured client — still has it. It no longer reaches the
-    // outline, though: the outline names a native token only for an element glass has no role
-    // for, and this one is now a Window.
+    // The device answers with the root of the ACTIVE WINDOW, so this node is the window
+    // whatever layout class it carries. Both Android readers have to agree about the root, or
+    // a `role:` selector written against one misses on the other.
+    //
+    // No synthetic wrapper: `AxNodeId(n)` is the device's `ref` n, and an extra node would
+    // shift every id `set_value` addresses by. `raw_role` keeps the device's class on the
+    // node, though it no longer reaches the outline, which names a native token only for an
+    // element glass has no role for.
     root.role = AxRole::Window;
     let mut tree = AxTree::new(root);
     tree.truncated = budget.truncation();
@@ -1418,9 +1416,7 @@ mod tests {
     fn an_editable_nodes_name_is_the_desc_not_the_raw_resource_id() {
         // The only fixture here with both `desc` and `resource_id` present, so it is what
         // pins the precedence between them. (`LabelInputs`'s named fields, not this test, are
-        // what stop the call site transposing the two.) The older-companion path (neither key
-        // sent) needs no dedicated test — every fixture above that omits them already
-        // exercises it.
+        // what stop the call site transposing the two.)
         let node = mapped_full(
             Some("joe@x.com"),
             Some("Email"),

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -1033,11 +1033,10 @@ mod tests {
                         "{role:?} is produced by a class but the matrix does not declare it"
                     );
                     // The named class must not resolve to the very role the cell says is out
-                    // of reach. Largely a second line behind the `!mapped` assertion above —
-                    // if the class produced the role, that one fires too — but it pins the
-                    // token itself, so a cell rewritten to name a different class is checked
-                    // against the map rather than against nothing. A misspelt class resolves
-                    // to `Other` and passes: only an on-box read catches that.
+                    // of reach. Largely a second line behind the `!mapped` assertion above,
+                    // but it pins the token itself, so a cell rewritten to name a different
+                    // class is checked against the map. A misspelt class resolves to `Other`
+                    // and passes — only an on-box read catches that.
                     if let Some(token) = cell.named_token() {
                         assert_ne!(
                             class_to_role(token),

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -226,9 +226,8 @@ impl AxRect {
     /// click on the window edge that never lands on the element (the "no silent fallbacks"
     /// invariant).
     fn visible_intersection(&self, win_w: u32, win_h: u32) -> Option<(i32, i32, i32, i32)> {
-        // No zero-area early return: the emptiness test below already covers it. A zero-width
-        // rect forces `right <= left`, a zero-width window forces `right <= 0 <= left`, and
-        // both dimensions are symmetric — so a separate guard is a branch nothing can observe.
+        // No zero-area early return: the emptiness test below already covers it — a zero-width
+        // rect or window forces `right <= left`, so a separate guard is unobservable.
         let left = self.x.max(0);
         let top = self.y.max(0);
         let right = (self.x + self.width as i32).min(win_w as i32);
@@ -1051,13 +1050,11 @@ pub fn element_match<'a>(
     value_contains: Option<&str>,
     condition: ElementCondition,
 ) -> ElementMatch<'a> {
-    // Role filter: exact match, OR — when an interactable role is requested *and* a name or
-    // value disambiguator is also present — an actable node the backend left generically
-    // classified. Toolkits like Jetpack Compose surface a real button as a clickable
-    // `Group`/`Other` (the role is lost), so an exact filter would miss it; matching by
-    // name + actability finds it anyway. The disambiguator is required: without it, a
-    // role-only query would match the first focusable container in the tree — a confident
-    // wrong match reported as success rather than an honest miss.
+    // Jetpack Compose surfaces a real button as a clickable `Group`/`Other` with the role
+    // lost, so an exact filter misses it; name + actability finds it anyway.
+    //
+    // The disambiguator is required: without it a role-only query would match the first
+    // focusable container in the tree — a confident wrong match, not an honest miss.
     let has_disambiguator = name.is_some() || value_contains.is_some();
     let role_match = |n: &AxNode, r: AxRole| {
         n.role == r

--- a/crates/glass-core/src/bounded.rs
+++ b/crates/glass-core/src/bounded.rs
@@ -174,8 +174,7 @@ fn run_bounded_inner(
     let (err_bytes, err_done) = stderr.take(settled_by);
     // A short read must never pass for a complete answer: `dumpsys window windows` is parsed by a
     // tolerant line scanner that would read a truncated dump as a shorter window list, and glass
-    // would then report the wrong geometry. `Command::output` cannot produce this — it reads to EOF
-    // — so failing here keeps the contract callers already had.
+    // would then report the wrong geometry.
     //
     // Bounded by the same `settled_by` as the pipes, and for the same reason: a grandchild holding
     // the read end keeps the write blocked exactly as it keeps a drain from reaching EOF. A write
@@ -610,10 +609,9 @@ mod tests {
 
     #[test]
     fn the_capture_cap_holds_the_largest_real_payload_and_stops_just_past_itself() {
-        // The cap exists to bound an abandoned drain thread, so it has to clear the biggest thing a
-        // one-shot really produces — a ~10MB `exec-out screencap` — by a wide margin.
-        // A const block, per clippy: the cap is a constant, so this is a compile-time claim. Under
-        // a mutation that shrinks it the crate stops compiling, which the gate counts too.
+        // The cap bounds an abandoned drain thread, so it must clear the biggest thing a
+        // one-shot really produces — a ~10MB `exec-out screencap` — by a wide margin. A const
+        // block, so a mutation that shrinks it stops the crate compiling, which the gate counts.
         const { assert!(MAX_CAPTURE >= 10 * 1024 * 1024) };
         // Exactly at the cap is still allowed; one byte past it is not.
         assert!(!would_exceed_capture(MAX_CAPTURE, 0));

--- a/crates/glass-core/src/diff.rs
+++ b/crates/glass-core/src/diff.rs
@@ -1491,10 +1491,8 @@ mod tests {
 
     #[test]
     fn for_region_rejects_a_zero_area_rect_before_intersecting() {
-        // `for_region` validates zero-area up front — before intersecting with the
-        // region — so region-scoping can't launder a zero-area rect into a silent
-        // drop. Exercises `for_region`'s own validation branch, distinct from
-        // `new`'s (covered by `zero_area_rect_is_an_error`).
+        // `for_region` validates zero-area up front, before intersecting with the region, so
+        // region-scoping can't launder a zero-area rect into a silent drop.
         let region = rect(0, 0, 10, 10);
         assert!(matches!(
             IgnoreMask::for_region(&[rect(0, 0, 0, 4)], &region).unwrap_err(),
@@ -1767,13 +1765,10 @@ mod tests {
 
         let masked = diff_perceptual_with_mask(&a, &b, 0.1, &mask).unwrap();
 
-        // The real invariant: every surviving pixel must classify exactly as it
-        // would from the true, unmutated frames. `reference_perceptual_masked`
-        // is that definition made concrete — it calls `classify` on `a.pixels`
-        // and `b.pixels` verbatim and never mutates either frame. Equality here
-        // is what "in-loop masking never disturbs anti-alias classification"
-        // means; it would still hold trivially if this fixture didn't
-        // discriminate, which is why the concrete counts below matter too.
+        // The real invariant: every surviving pixel must classify exactly as it would from
+        // the true, unmutated frames. `reference_perceptual_masked` is that definition made
+        // concrete — it calls `classify` on `a.pixels` and `b.pixels` verbatim and mutates
+        // neither frame.
         let reference = reference_perceptual_masked(&a, &b, 0.1, &mask);
         assert_eq!(
             masked, reference,

--- a/crates/glass-core/src/role_support.rs
+++ b/crates/glass-core/src/role_support.rs
@@ -820,8 +820,7 @@ mod tests {
     fn a_cell_naming_a_token_names_one_token_and_not_prose() {
         // The token is machine-checked by each backend's column test, so it has to be a token:
         // a phrase slipped into the field would resolve to `Other` and pass every check
-        // vacuously, which is exactly the "reads plausible, proves nothing" failure this
-        // field exists to end.
+        // vacuously.
         for (role, cells) in ROLE_SUPPORT {
             for (i, cell) in cells.iter().enumerate() {
                 let Some(token) = cell.named_token() else {

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -28,9 +28,8 @@ impl Glass {
     /// relative, ids assigned by the core). Caches it for `click_element`.
     /// `AxUnsupported` if the backend has no accessibility reader.
     pub fn a11y_snapshot(&mut self, max_nodes: Option<usize>) -> Result<AxTree> {
-        // A user-facing snapshot sets the limits for the id-space that follows: `set_value`
-        // re-walks with them, and internal re-snapshots reuse them via `a11y_resnapshot`. So
-        // this is the ONLY place that changes `a11y_limits` from a caller's `max_nodes`.
+        // The ONLY place `a11y_limits` changes from a caller's `max_nodes` — every other walk
+        // reuses them.
         self.active_mut()?.a11y_limits =
             crate::accessibility::WalkLimits::from_max_nodes(max_nodes);
         self.snapshot_at_current_limits()
@@ -43,14 +42,11 @@ impl Glass {
     /// pause between ticks.
     pub(crate) fn subscribe_a11y_changes(&mut self) -> Option<Box<dyn ChangeSignal>> {
         let s = self.active_mut().ok()?;
-        // Reader check first, like `snapshot_at_current_limits`: the accessors below are platform
-        // round-trips (`app_pids` shells out to `adb` on Android). A reader that has no event
-        // stream still pays them once per wait, inside the caller's budget — nothing short of
-        // asking it can tell.
+        // Reader check first: the accessors below are platform round-trips (`app_pids` shells
+        // out to `adb` on Android).
         s.accessibility.as_ref()?;
-        // The cached geometry, deliberately: subscribing must not depend on a window round-trip
-        // that can fail, because failing to subscribe has to degrade to polling rather than to an
-        // error. The reader only needs enough context to identify the app.
+        // Cached geometry deliberately: a failed window round-trip must degrade to polling,
+        // not to an error.
         let ctx = AxContext {
             pids: s.platform.app_pids(),
             window: s.geometry.clone(),
@@ -80,15 +76,11 @@ impl Glass {
         if s.accessibility.is_none() {
             return Err(GlassError::AxUnsupported);
         }
-        // Re-read the current window geometry: an app can resize itself (open a sidebar / panel)
-        // without a glass_window op, leaving `s.geometry` stale so the tree's scale/origin — and
-        // the subsequent click_element clamp / set_value context, which read `s.geometry` — would
-        // map to the old window bounds and clip elements now beyond them. Strict by design: a
-        // failure propagates rather than silently reusing a stale cache. Note: on macOS this
-        // resolves the window via ScreenCaptureKit, so a snapshot depends on that and can fail on
-        // a momentarily off-screen window — accepted for correctness. (Android reports a cached
-        // fullscreen window, so a freeform self-resize wouldn't refresh — a residual limitation,
-        // moot while Android apps run fullscreen.)
+        // Re-read: an app can resize itself (open a sidebar / panel) with no glass_window op, and
+        // stale geometry maps the tree to the old bounds and clips elements now beyond them.
+        // macOS resolves this window via ScreenCaptureKit, so a momentarily off-screen window
+        // fails here. Android reports a cached fullscreen window, so a freeform self-resize
+        // would not refresh.
         let window = s.platform.window(&WindowOp::Geometry)?;
         s.geometry = window.clone();
         let pids = s.platform.app_pids();
@@ -156,15 +148,12 @@ impl Glass {
     }
 
     fn click_element_inner(&mut self, id: AxNodeId) -> Result<ClickMethod> {
-        // Native action first: works for occluded/off-screen/boundless elements and
-        // (on backends whose action API is out-of-band) doesn't move the cursor.
+        // Native action first: works for occluded/off-screen/boundless elements, and on a
+        // backend whose action API is out-of-band it doesn't move the cursor.
         //
-        // Falling back is an allowlist, not a denylist: only an attempt that dispatched
-        // NOTHING may be retried with the pointer (see
-        // [`GlassError::invoke_fallback_eligible`]). Anything else — a reported action
-        // failure, an ambiguous transport error, a drifted tree, the pre-check errors —
-        // propagates, because clicking on top of a native action that may still land would
-        // actuate the control twice while the result claimed only "pointer" ran.
+        // Do not widen the fallback to a denylist: only an attempt that dispatched NOTHING may
+        // retry with the pointer (see [`GlassError::invoke_fallback_eligible`]), or a native
+        // action that may still land actuates the control twice.
         let native_fallback = match self.try_native_invoke(id) {
             Ok(actuated) => return Ok(ClickMethod::NativeAction { actuated }),
             Err(e) if !e.invoke_fallback_eligible() => return Err(e),
@@ -192,17 +181,12 @@ impl Glass {
                 s.geometry.clone(),
             )
         };
-        // The element's a11y bounds are reported relative to the active window, but it
-        // may actually render in a separate popover window (e.g. an open dropdown's
-        // option list) whose own origin they don't reflect. Detect that and route the
-        // click into the popover instead of silently missing.
+        // a11y bounds are relative to the active window, but the element may render in a
+        // separate popover window (an open dropdown's option list) whose own origin they
+        // don't reflect.
         //
-        // This enumeration is a best-effort popover probe, not something an ordinary
-        // click depends on: a backend where `list_windows` is heavier or flaky must
-        // never turn a normal click into a failure just because the probe failed. An
-        // `Err` here degrades to an empty list, which makes `owning_popover` return
-        // `None` below and falls straight through to the unchanged `clamped_center`
-        // click path.
+        // The probe is best-effort: an `Err` degrades to an empty list rather than failing a
+        // normal click on a backend where `list_windows` is heavy or flaky.
         let windows = self.list_windows().unwrap_or_default();
         if let Some(popover_id) = owning_popover(bounds, &active_geo, &windows) {
             let popover_geo = windows
@@ -231,15 +215,13 @@ impl Glass {
             }
             return result;
         }
-        // A switch whose backend reports the whole row as its frame with the control at the
-        // trailing edge (iOS/idb) is mis-tapped at the geometric center — that lands on the inert
-        // label, and even aimed at the control a `UISwitch` does NOT actuate on a tap: it needs a
-        // short swipe (see `AxRect::trailing_toggle_swipe`). For such a backend, swipe a
-        // row-shaped checkable's trailing control instead of clicking it. Gated on the backend
-        // capability, NOT geometry alone: a wide *labeled* checkbox on a desktop backend is also
-        // row-shaped but has its indicator at the LEADING edge, so the trailing-aim must not
-        // apply there. The row-shape test uses the raw-bounds aspect as a cheap pre-filter;
-        // `trailing_toggle_swipe` derives its inset from the clamped visible height.
+        // On a backend that frames a switch as its whole row with the control at the trailing
+        // edge (iOS/idb), a center tap lands on the inert label — and a `UISwitch` does NOT
+        // actuate on a tap even when aimed at the control, it needs a short swipe (see
+        // `AxRect::trailing_toggle_swipe`).
+        //
+        // Gate on the backend capability, NOT geometry alone: a wide labeled checkbox on a
+        // desktop backend is row-shaped too, but its indicator is at the LEADING edge.
         let row_shaped_toggle = checkable
             && trailing_toggle_backend
             && bounds.width > bounds.height.saturating_mul(ROW_ASPECT);
@@ -282,16 +264,12 @@ impl Glass {
             if s.accessibility.is_none() {
                 return Err(GlassError::AxUnsupported);
             }
-            // Re-read the window geometry, as `a11y_snapshot` does: the Windows/macOS `invoke`
-            // fingerprints the element by window-RELATIVE bounds derived from `ctx.window`, so
-            // a window the user moved since the snapshot would make every element look
-            // displaced and reject the invoke as drift. Storing it back also keeps the pointer
-            // fallback clamping against the same window.
+            // Re-read the window geometry: the Windows/macOS `invoke` fingerprints the element
+            // by window-RELATIVE bounds derived from `ctx.window`, so a window moved since the
+            // snapshot reads as drift and rejects.
             //
-            // Best-effort, unlike the snapshot's strict refresh: a click must not become
-            // unclickable because a geometry probe hiccuped, so an `Err` keeps the cached
-            // value and carries on — worst case the fingerprint check below rejects, exactly
-            // as it did before this refresh existed.
+            // Best-effort, unlike the snapshot's strict refresh: an `Err` keeps the cached
+            // value so a geometry-probe hiccup can't make a click unclickable.
             if let Ok(window) = s.platform.window(&WindowOp::Geometry) {
                 s.geometry = window;
             }
@@ -345,20 +323,17 @@ impl Glass {
     fn set_value_inner(&mut self, id: AxNodeId, text: &str) -> Result<()> {
         {
             let s = self.active_mut()?;
-            // Check for reader availability before consulting the snapshot, so that
-            // `AxUnsupported` takes precedence when there is no accessibility backend — and so
-            // a reader-less backend skips the geometry round-trip below.
+            // Reader-presence check up front so `AxUnsupported` keeps precedence over — and a
+            // reader-less backend skips — the geometry round-trip below.
             if s.accessibility.is_none() {
                 return Err(GlassError::AxUnsupported);
             }
-            // Re-read the window geometry, as `a11y_snapshot` and `try_native_invoke` do: the
-            // Windows/macOS `set_value` fingerprints the element by window-RELATIVE bounds
-            // derived from `ctx.window`, so a window moved since the snapshot would make every
-            // element look displaced and reject the write as drift.
+            // Re-read the window geometry: the Windows/macOS `set_value` fingerprints the
+            // element by window-RELATIVE bounds derived from `ctx.window`, so a window moved
+            // since the snapshot reads as drift and rejects.
             //
-            // Best-effort, unlike the snapshot's strict refresh: a write must not fail because
-            // a geometry probe hiccuped, so an `Err` keeps the cached value and carries on —
-            // worst case the backend's own fingerprint check rejects, exactly as before.
+            // Best-effort, unlike the snapshot's strict refresh: an `Err` keeps the cached
+            // value so a geometry-probe hiccup can't fail a write.
             if let Ok(window) = s.platform.window(&WindowOp::Geometry) {
                 s.geometry = window;
             }
@@ -383,24 +358,22 @@ impl Glass {
             };
             (target, ctx)
         };
-        // A dropdown/combo has no committing accessibility write: its `Selection`
-        // interface only moves the popup's *preview* selection, and the model commits
-        // only on row activation (Enter/click). So drive it like a person does —
-        // open it, keyboard-navigate to the option, and press Enter.
+        // A combo has no committing accessibility write: its `Selection` interface moves only
+        // the popup's *preview* selection, and the model commits on row activation (Enter/click).
         //
-        // No cache patch on this path: every `Ok` it returns either actuated nothing or followed
-        // an `a11y_resnapshot`, which replaces `last_ax` wholesale — a fresher fact than a patch.
+        // No cache patch on this path: every `Ok` either actuated nothing or followed an
+        // `a11y_resnapshot`, which replaces `last_ax` wholesale.
         if target.role == AxRole::ComboBox {
             return self.set_combo_value(id, &target, text);
         }
-        // iOS's value-set (tap+type) doesn't apply to a checkable — a tap doesn't toggle a
-        // UISwitch and there's no text to type — so a checkable is driven by the trailing-edge
-        // swipe instead. Set-to-target = toggle iff current != target, then verify by a bounded
-        // poll (never a silent ok). Gated on `checkable` alone (NOT row-shape): a checkable
-        // switch that isn't row-shaped on a trailing backend must still fail-safe through this
-        // branch (parse/verify → error) rather than fall through to the delegate below, which
-        // would silently tap the inert label and type into nothing. Read the needed state and
-        // DROP the `&self` borrow before calling click_element_inner (which needs `&mut self`).
+        // iOS's value-set (tap+type) can't drive a checkable: a tap doesn't toggle a UISwitch
+        // and there's no text to type, so it takes the trailing-edge swipe instead.
+        //
+        // Gate on `checkable` alone, NOT row-shape: a checkable that isn't row-shaped must
+        // fail-safe through this branch rather than fall through to the delegate below, which
+        // would silently tap the inert label and type into nothing.
+        //
+        // DROP the `&self` borrow before `click_element_inner`, which needs `&mut self`.
         let (trailing, node_state) = {
             let s = self.require_active()?;
             (
@@ -415,22 +388,18 @@ impl Glass {
             && let Some(st) = node_state
             && st.checkable
         {
-            // A checkable switch expects a boolean; unrecognized text must NOT fall
-            // through to the tap+type delegate (which would silently no-op a UISwitch).
-            // Erroring here preserves the "never a silent ok" invariant — and the error
-            // must tell the agent to pass a boolean, not misdirect it (a generic
-            // "value not applied — use keystrokes" would send it down a futile path).
+            // Unrecognized text must NOT fall through to the tap+type delegate, which would
+            // silently no-op a UISwitch — and the error has to name "boolean", or a generic
+            // "use keystrokes" sends the agent down a futile path.
             let want = parse_bool(text)
                 .ok_or_else(|| GlassError::AxValueNotBoolean(id.0, text.to_string()))?;
             if st.checked == want {
                 return Ok(()); // truthful no-op, no actuation
             }
-            // No cache patch here either, for the combo path's reason: the verify poll below
-            // re-snapshots, so `last_ax` holds the tree that observed the toggle.
+            // No cache patch here either: the verify poll below re-snapshots, so `last_ax`
+            // holds the tree that observed the toggle.
             self.click_element_inner(id)?; // the toggle actuation (a swipe for a row-shaped control)
-            // Not event-gated, and cannot be: this branch runs only on a backend that frames a
-            // switch as its whole row, which today is iOS alone — a reader with no event stream to
-            // subscribe to.
+            // Not event-gated: this branch runs only on iOS, whose reader has no event stream.
             let outcome = crate::poll::poll_until(
                 TOGGLE_VERIFY_INTERVAL_MS,
                 TOGGLE_VERIFY_TIMEOUT_MS,
@@ -454,11 +423,10 @@ impl Glass {
             .ok_or(GlassError::AxUnsupported)?
             .set_value(&ctx, &target, text);
         if let Err(e) = result {
-            // A failure after dispatch doesn't mean the field is unchanged — Android types before
-            // it verifies, so a partial type or the AVD's documented placeholder-on-clear can
-            // still have altered it. Invalidate (not gate) so a retry with no intervening snapshot
-            // isn't rejected as drift; every other failure keeps its value, for the asymmetry
-            // `set_value_failed_after_writing` documents.
+            // A failure after dispatch doesn't mean the field is unchanged: Android types before
+            // it verifies, so a partial type or the AVD's placeholder-on-clear can still have
+            // altered it. Invalidate rather than gate, so a retry with no intervening snapshot
+            // isn't rejected as drift.
             if e.set_value_failed_after_writing()
                 && let Some(node) = s.last_ax.as_mut().and_then(|t| t.find_mut(id))
             {
@@ -466,9 +434,9 @@ impl Glass {
             }
             return Err(e);
         }
-        // `Ok`'s guarantee varies by backend — see `AxTarget::value`'s doc — but patching to the
-        // requested text still beats leaving the pre-write value, which is definitely stale, not
-        // just possibly imprecise. Patch by id; a re-snapshot would cost a whole walk for one field.
+        // `Ok`'s guarantee varies by backend (see `AxTarget::value`), but the requested text
+        // still beats the definitely-stale pre-write value. Patch by id; a re-snapshot would
+        // cost a whole walk for one field.
         if let Some(node) = s.last_ax.as_mut().and_then(|t| t.find_mut(id)) {
             node.value = (!text.is_empty()).then(|| text.to_string());
         }
@@ -489,12 +457,9 @@ impl Glass {
         {
             return Ok(());
         }
-        // Open the popup with a real pointer click, deliberately NOT the native action (the
-        // combo button is in the main window, so this click lands). A programmatic expand —
-        // UIA's `ExpandCollapsePattern` is the concrete case — opens the popup without moving
-        // keyboard focus, and everything below is keyboard navigation (Down/Up/Return), which
-        // would then go to whatever held focus instead of the popup. Clicking focuses the
-        // combo the way a person's click does.
+        // A real pointer click, deliberately NOT the native action: a programmatic expand
+        // (UIA's `ExpandCollapsePattern`) opens the popup without moving keyboard focus, so the
+        // Down/Up/Return below would go to whatever held focus instead.
         self.audited_click(id, |g, id| {
             g.click_element_pointer_only(id)
                 .map(|()| ClickMethod::Pointer {
@@ -502,9 +467,8 @@ impl Glass {
                 })
         })?;
         self.settle_for_popup();
-        // Re-read the realized options + which one is currently selected. The open
-        // combo is `expanded`; when several combos exist, ids don't survive the
-        // re-snapshot, so fall back to the one nearest the target's bounds.
+        // Ids don't survive a re-snapshot, so match the open (`expanded`) combo, else the one
+        // nearest the target's bounds.
         let tree = self.a11y_resnapshot()?;
         let combo = find_expanded_combo(&tree.root)
             .or_else(|| find_combo_near(&tree.root, target.bounds.as_ref()))
@@ -533,9 +497,8 @@ impl Glass {
         // Opening focuses the current selection; step from it to the target, then Enter.
         let current_idx = options.iter().position(|(_, sel)| *sel).unwrap_or(0);
         let delta = target_idx as i32 - current_idx as i32;
-        // `is_negative` rather than a comparison against 0: the two differ only at delta == 0,
-        // where the loop below runs zero times and the chord is never sent, so which comparison
-        // is written cannot be observed.
+        // `is_negative` and `< 0` differ only at delta == 0, where the loop runs zero times and
+        // the chord is never sent — not observable either way.
         let chord = if delta.is_negative() { "Up" } else { "Down" };
         for _ in 0..delta.unsigned_abs() {
             self.key(&KeyEvent::Chord(chord.to_string()))?;
@@ -856,10 +819,8 @@ mod tests {
             Some(AxNodeId(1)),
             "a tie must not be taken by the later node"
         );
-        // The distance is a difference of coordinates, squared and summed. Candidates near the
-        // origin cannot tell that apart from a ratio or a product: put the target far from the
-        // origin and give each candidate its whole error on one axis, so a divide collapses one
-        // term to nothing and a product collapses both.
+        // Near the origin a difference of coordinates is indistinguishable from a ratio or a
+        // product — put the target far out and give each candidate its whole error on one axis.
         let far_x = ax_node(4, AxRole::ComboBox, Some(rect(-5, 995, 10, 10)), vec![]);
         let near_y = ax_node(5, AxRole::ComboBox, Some(rect(995, 985, 10, 10)), vec![]);
         let root_x = ax_node(
@@ -1066,8 +1027,7 @@ mod tests {
             width: 400,
             height: 400,
         };
-        // 10x100 (area 1000, sum 110) vs 60x60 (area 3600, sum 120): the first wins on area,
-        // and on sum too — so make the sums disagree with the areas.
+        // The sums must disagree with the areas, or the test cannot tell the two rules apart.
         let thin = WindowGeometry {
             x: 100,
             y: 100,
@@ -1332,12 +1292,10 @@ mod tests {
 
     #[test]
     fn menu_container_bounds_prefers_closest_size_over_nearest_ancestor() {
-        // Reproduces the real GTK4 widget tree (captured from the Xvfb spike): several
-        // layout wrapper `Group`s sit between the option row and the actual menu `List`,
-        // and their bounds *also* fall within the 16px tolerance of the popover's size —
-        // so picking the ancestor NEAREST `target` returns a wrapper Group, not the real
-        // container. The real container (List, id 2) must win because its size is
-        // closest to the popover's, even though it's farther up the chain.
+        // The real GTK4 widget tree from the Xvfb spike: layout wrapper `Group`s sit between
+        // the option row and the menu `List`, and their bounds *also* fall within the 16px
+        // tolerance — so picking the ancestor NEAREST `target` returns a wrapper, not the
+        // container.
         let popover = WindowGeometry {
             x: -3,
             y: 220,
@@ -1426,13 +1384,9 @@ mod tests {
 
     #[test]
     fn menu_container_bounds_prefers_content_container_over_window_root_sized_ancestor() {
-        // Disambiguates the two kinds of ancestor that both commonly fall within
-        // tolerance of the popover's size: an outer node sized like the popover
-        // window's own frame (e.g. the toplevel root, a few px *larger* — decorations/
-        // margins), and the inner content container a few px *smaller* (the real
-        // GTK4 shape: a `List` a little inside the window's own bounds). Both are
-        // "near" the popover size, so this proves the scoring picks whichever is
-        // numerically closest — the content container — not whichever is outermost.
+        // Two kinds of ancestor commonly fall within tolerance: an outer node sized like the
+        // popover window's own frame (a few px *larger* — decorations/margins) and the inner
+        // content container a few px *smaller* (the real GTK4 shape).
         let popover = WindowGeometry {
             x: -3,
             y: 220,
@@ -1510,10 +1464,9 @@ mod tests {
 
     #[test]
     fn a11y_snapshot_refreshes_geometry_so_click_element_uses_current_window() {
-        // #6: an app resizes itself (opens a sidebar) without a glass_window op; a11y_snapshot
-        // must re-read the current geometry, else click_element clamps against the stale (smaller)
-        // window and clips elements now beyond it. Start 230 wide, platform now reports 458; a
-        // Button at x=292 is off a stale 230 window but on-screen in the real 458 one.
+        // #6: an app resizes itself (opens a sidebar) with no glass_window op, and a stale
+        // window clips elements now beyond it. Start 230 wide, platform now reports 458; a
+        // Button at x=292 is off a stale 230 window but on-screen in the real 458.
         let clicks = Arc::new(Mutex::new(Vec::new()));
         let bounds = AxRect {
             x: 292,
@@ -1568,12 +1521,9 @@ mod tests {
 
     #[test]
     fn click_element_refreshes_geometry_so_the_native_invoke_sees_the_current_window() {
-        // The Windows/macOS `invoke` fingerprints the element by window-RELATIVE bounds,
-        // derived from `ctx.window`. If the window moved since the snapshot and the click
-        // handed the backend the stale origin, every element would look displaced and the
-        // invoke would be rejected as drift. The snapshot refreshes geometry, so the invoke
-        // path must too: script the geometry read to report a moved window after the
-        // snapshot's own read, and prove the ctx the backend received carries the new origin.
+        // The Windows/macOS `invoke` fingerprints by window-RELATIVE bounds from `ctx.window`,
+        // so a window moved since the snapshot reads as drift. Script the geometry read to
+        // report a moved window after the snapshot's own read.
         let snapshot_geo = WindowGeometry {
             x: 0,
             y: 0,
@@ -1752,8 +1702,7 @@ mod tests {
     fn click_element_action_failure_propagates_and_never_pointer_clicks() {
         // A native action that reported failure may still have been DISPATCHED (the backend
         // fires it on a detached worker and can lose the answer), so a pointer click on top
-        // of it would actuate the control twice. Only outcomes that dispatched nothing may
-        // fall back — everything else fails closed.
+        // of it would actuate the control twice.
         let clicks = Arc::new(Mutex::new(Vec::new()));
         let platform = FakePlatform::new(100, 100).with_click_log(clicks.clone());
         let (mut g, _) = glass_with_a11y_invoke(platform, fake_tree(), InvokeBehavior::Fail);
@@ -1884,10 +1833,9 @@ mod tests {
 
     #[test]
     fn click_element_swipes_the_trailing_control_for_a_row_shaped_checkable() {
-        // A checkable node whose bounds are row-shaped (w > 4h) — a backend (iOS/idb) that
-        // reports the whole cell as a switch's frame. A `UISwitch` does not actuate on a tap, so
-        // the click must emit a swipe across the trailing control instead of a `Click`; a
-        // non-checkable node of the SAME bounds still clicks center.
+        // A checkable node with row-shaped bounds (w > 4h) on a backend that reports the whole
+        // cell as the switch's frame: it must swipe the trailing control, while a non-checkable
+        // node of the SAME bounds still clicks center.
         let clicks = Arc::new(Mutex::new(Vec::new()));
         let drags: Arc<Mutex<Vec<PointerEvent>>> = Arc::new(Mutex::new(Vec::new()));
         let bounds = AxRect {
@@ -1988,11 +1936,9 @@ mod tests {
 
     #[test]
     fn click_element_uses_center_for_a_row_shaped_checkable_on_a_non_trailing_backend() {
-        // The trailing-aim is opt-in per backend. A desktop backend (default FakePlatform: no
-        // `with_trailing_toggle_backend`) frames a labeled checkbox as a wide row too, but its
-        // indicator is at the LEADING edge — so a row-shaped checkable here must still click
-        // center, never trailing. This is the guard that keeps the iOS fix from misfiring
-        // on macOS/Windows/Linux/Android.
+        // The trailing-aim is opt-in per backend: a desktop backend frames a labeled checkbox
+        // as a wide row too, but its indicator is at the LEADING edge, so a row-shaped
+        // checkable here must still click center.
         let clicks = Arc::new(Mutex::new(Vec::new()));
         let bounds = AxRect {
             x: 10,
@@ -2256,9 +2202,8 @@ mod tests {
 
     #[test]
     fn click_element_native_invoke_succeeds_for_popover_hosted_element_without_window_select() {
-        // The native action addresses the element directly, so the whole popover machinery —
-        // enumerate windows, select the popover, click at a container-relative offset, restore
-        // the previous window — must be skipped: no focus change, no pointer event.
+        // The native action addresses the element directly, so the whole popover machinery is
+        // skipped: no focus change, no pointer event.
         let clicks = Arc::new(Mutex::new(Vec::new()));
         let select_log = Arc::new(Mutex::new(Vec::new()));
         let (mut g, invoke_log) = glass_with_a11y_invoke(
@@ -2321,11 +2266,9 @@ mod tests {
         // Same popover-owning geometry, but the target has no List-sized ancestor to
         // recover a container origin from — must error, not silently mis-click.
         //
-        // This also stands in for the residual `owning_popover` false-positive case
-        // documented on that function: a normal element whose projected point happens to
-        // land inside another real window is indistinguishable, geometrically, from a
-        // genuine popover — the size-matching gate is what turns that misdetection into
-        // this clear, catchable error instead of a silent click into the wrong window.
+        // This also stands in for the residual `owning_popover` false positive documented on
+        // that function: the size-matching gate turns a geometric misdetection into this
+        // catchable error instead of a silent click into the wrong window.
         let globex = AxNode {
             id: AxNodeId(0),
             role: AxRole::ListItem,
@@ -2598,11 +2541,9 @@ mod tests {
 
     #[test]
     fn set_value_on_a_combo_opens_the_popup_with_a_pointer_click_even_when_invoke_succeeds() {
-        // The combo commit loop is keyboard navigation (Down/Up/Return), so the popup must be
-        // opened by something that takes keyboard focus. A native "expand" action doesn't
-        // (UIA's ExpandCollapsePattern is the concrete case), which would send the keystrokes
-        // to whatever had focus instead. So this one click stays pointer-only even on a
-        // backend whose invoke works.
+        // The combo commit loop is keyboard navigation, so the popup must be opened by
+        // something that takes keyboard focus — a native expand (UIA's ExpandCollapsePattern)
+        // doesn't, and the keystrokes would go to whatever had focus instead.
         let clicks = Arc::new(Mutex::new(Vec::new()));
         let platform = FakePlatform::new(340, 300).with_click_log(clicks.clone());
         let (mut g, invoke_log) = glass_with_a11y_seq_invoke(
@@ -2665,10 +2606,8 @@ mod tests {
 
     #[test]
     fn set_value_refreshes_geometry_so_the_backend_sees_the_current_window() {
-        // The mirror of `click_element_refreshes_geometry_so_the_native_invoke_sees_the_current_window`:
-        // `set_value` fingerprints the element the same way `invoke` does (Windows/macOS compare
-        // window-RELATIVE bounds derived from `ctx.window`), so a window moved since the snapshot
-        // would make every element look displaced and reject the write as drift.
+        // The mirror of the `invoke` case: `set_value` fingerprints by window-RELATIVE bounds
+        // from `ctx.window` too, so a window moved since the snapshot reads as drift.
         let snapshot_geo = WindowGeometry {
             x: 0,
             y: 0,
@@ -3000,12 +2939,9 @@ mod tests {
 
     #[test]
     fn a11y_snapshot_threads_max_nodes_into_ctx_limits_and_set_value_reuses_them() {
-        // Same mock harness as `set_value_passes_target_and_text_to_backend`, but this
-        // time inspecting `ctx_log` — the `AxContext.limits` the backend actually
-        // received — to prove `max_nodes` reaches the ctx, and that `set_value` reuses
-        // whatever the last `a11y_snapshot` recorded rather than falling back to the
-        // default cap. Real backends still ignore `limits` in this task (they build
-        // `WalkBudget::new()`), so this is the only way to observe the plumbing.
+        // Inspects `ctx_log` — the `AxContext.limits` the backend actually received. Real
+        // backends still ignore `limits` (they build `WalkBudget::new()`), so this is the only
+        // way to observe the plumbing.
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().join("baselines");
         std::mem::forget(dir);
@@ -3245,11 +3181,9 @@ mod tests {
 
     #[test]
     fn set_value_false_swipes_a_checked_ios_switch_and_verifies() {
-        // The mirror of `set_value_true_swipes_an_unchecked_ios_switch_and_verifies` — proves
-        // the toggle path handles a checked -> unchecked transition too, not just off -> on.
         // The fixed swipe is a TOGGLE gesture (proven on-device: identical swipes alternate
         // off/on/off/on — see `AxRect::trailing_toggle_swipe`), so the same swipe that turns a
-        // switch on also turns it off; there is no direction logic to exercise separately.
+        // switch on turns it off; there is no direction logic to exercise separately.
         let drags: Arc<Mutex<Vec<PointerEvent>>> = Arc::new(Mutex::new(Vec::new()));
         let platform = FakePlatform::new(400, 400)
             .with_drag_log(drags.clone())
@@ -3332,11 +3266,8 @@ mod tests {
     #[test]
     fn set_value_true_verifies_the_target_by_bounds_when_a_same_named_sibling_is_already_checked() {
         // The sibling "Sw" is already checked (the wanted state) throughout; only the TARGET
-        // flips false -> true on the verify re-snapshot. A name-only verify (the old,
-        // pre-order-first `find_named`) would match the sibling — listed first — and return Ok
-        // regardless of whether the target itself ever moved. The bounds-nearest verify must
-        // instead confirm THIS node (the target, at its own captured bounds) reached the
-        // wanted state.
+        // flips false -> true on the verify re-snapshot. A name-only verify would match the
+        // sibling — listed first — and return Ok whether or not the target ever moved.
         let drags: Arc<Mutex<Vec<PointerEvent>>> = Arc::new(Mutex::new(Vec::new()));
         let platform = FakePlatform::new(400, 400)
             .with_drag_log(drags.clone())
@@ -3356,12 +3287,9 @@ mod tests {
 
     #[test]
     fn set_value_true_errors_when_only_a_same_named_sibling_is_checked() {
-        // Same same-named-sibling setup, but this time the swipe "does not take": the target
-        // stays unchecked on the verify re-snapshot while the sibling remains (coincidentally)
-        // already checked. A name-only verify would match the sibling first and return a false
-        // Ok — exactly the silent-success bug this fixture guards against. The bounds-nearest
-        // verify must instead see the ACTUAL target still unchecked and report
-        // `AxValueNotApplied`, proving a same-name collision can never fake a false ok.
+        // Same setup, but the swipe "does not take": the target stays unchecked on the verify
+        // re-snapshot while the sibling remains (coincidentally) already checked. A name-only
+        // verify would match the sibling first and return a false Ok.
         let platform = FakePlatform::new(400, 400)
             .with_drag_log(Arc::new(Mutex::new(Vec::new())))
             .with_trailing_toggle_backend();
@@ -3378,15 +3306,10 @@ mod tests {
 
     #[test]
     fn set_value_on_a_non_checkable_element_ignores_the_trailing_toggle_gate() {
-        // The iOS toggle gate (`set_value_inner`'s trailing-toggle branch) must only intercept
-        // CHECKABLE elements — `checkable` is the discriminator, not "did the text parse as a
-        // bool". Uses a BOOLEAN value ("true") deliberately: with non-bool text, a dropped
-        // `checkable` guard is invisible (both arms fall through to the delegate the same way),
-        // so this must exercise the boolean path to actually catch a removed guard. A boolean
-        // value on a non-checkable element (e.g. a plain button) must still fall straight
-        // through to the normal accessibility `set_value` delegate path, unchanged — no
-        // swipe/drag is ever emitted, and the backend's `set_value` is the one that actually
-        // runs.
+        // The toggle gate must intercept only CHECKABLE elements — `checkable` is the
+        // discriminator, not "did the text parse as a bool". Uses a BOOLEAN value ("true")
+        // deliberately: with non-bool text both arms fall through to the delegate alike, so a
+        // dropped `checkable` guard would be invisible.
         let drags: Arc<Mutex<Vec<PointerEvent>>> = Arc::new(Mutex::new(Vec::new()));
         let log = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let dir = tempfile::tempdir().unwrap();
@@ -3433,10 +3356,9 @@ mod tests {
 
     #[test]
     fn set_value_on_a_checkable_rejects_non_boolean_text() {
-        // FIX 1's core invariant: a non-boolean value on a checkable+trailing target must ERROR,
-        // never fall through to the tap+type delegate (which would tap the inert label, type
-        // into nothing, and still report Ok — the exact silent success this branch exists to
-        // kill). No actuation (no swipe) and no delegate call either.
+        // A non-boolean value on a checkable+trailing target must ERROR, never fall through to
+        // the tap+type delegate, which would tap the inert label, type into nothing, and still
+        // report Ok.
         let drags: Arc<Mutex<Vec<PointerEvent>>> = Arc::new(Mutex::new(Vec::new()));
         let log = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let dir = tempfile::tempdir().unwrap();

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -3020,12 +3020,12 @@ mod tests {
         ));
     }
 
-    /// A row-shaped CheckBox "Sw" (300x30 at the origin) as the single child of a root Window —
-    /// the iOS-switch fixture shared by the trailing-toggle `set_value` tests below. Pre-order
-    /// numbering gives the switch id 1.
-    /// A switch as the readers report one *after* the subrole normalization: `ToggleButton`, row
-    /// shaped, checkable — a fixture still calling a switch a `CheckBox` would test the swipe path
-    /// against a role no backend produces.
+    /// A switch "Sw" as the readers report one *after* subrole normalization: `ToggleButton`,
+    /// row shaped (300x30 at the origin), checkable — the single child of a root Window, so
+    /// pre-order numbering gives it id 1. Shared by the trailing-toggle `set_value` tests below.
+    ///
+    /// Do not re-role it to `CheckBox`: that tests the swipe path against a role no backend
+    /// produces.
     fn sw(checked: bool) -> AxTree {
         let switch = AxNode {
             id: AxNodeId(0),

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -338,14 +338,11 @@ impl Glass {
         }
         let region = params.stability_region;
         let window = params.window;
-        // The mask is built lazily, on the first poll tick, sized from that
-        // captured frame's own dimensions rather than the session's cached
-        // geometry — which can belong to a different window than the one being
-        // watched, or be stale if the watched window resized itself since the
-        // cache was last refreshed. `for_region` intersects `ignore` with
-        // `region` and translates into region-local coordinates (`capture`
-        // crops to `region` when one is set, so the settle comparison and the
-        // mask must agree on that same cropped space).
+        // Built lazily on the first tick and sized from that frame, not the session's
+        // cached geometry, which can belong to a different window or be stale after a
+        // self-resize. `for_region` intersects `ignore` with `region` and translates into
+        // region-local coordinates, since `capture` crops to `region` and the settle
+        // comparison and the mask must agree on that space.
         let mut tracker: Option<StabilityTracker> = None;
         let outcome = crate::poll::poll_until(params.interval_ms, params.timeout_ms, || {
             // Poll only the watched region (cheap) when one is set; else the full window.
@@ -396,10 +393,9 @@ impl Glass {
         let mut signal = (params.interval_ms > 0)
             .then(|| self.subscribe_a11y_changes())
             .flatten();
-        // Subscribing spends the caller's budget, so the poll loop gets what is left. That bounds
-        // the polling, not the call: a reader bounds its own handshake in seconds, so a wait told
-        // to give up after 500ms can return later than that. `elapsed_ms` is measured from before
-        // the subscribe and reports it.
+        // Subscribing spends the caller's budget, so the poll loop gets what is left. That
+        // bounds the polling, not the call: a reader bounds its own handshake in seconds, so a
+        // wait told to give up after 500ms can return later than that.
         let remaining = params
             .timeout_ms
             .saturating_sub(started.elapsed().as_millis() as u64);
@@ -501,12 +497,9 @@ impl Glass {
         self.require_active()?;
         let start = std::time::Instant::now();
         let geo = self.geometry()?;
-        // Return a match once scrolling can't improve its visibility: it has an
-        // on-screen clickable center, or its bounds are unknown (a backend that can't
-        // read an element's geometry keeps `bounds: None` — scrolling won't populate
-        // them, and `click_element` reports that state honestly). Only a known
-        // off-screen element (bounds present but no on-screen intersection) is worth
-        // scrolling past.
+        // Return a match once scrolling can't improve its visibility: it has an on-screen
+        // clickable center, or its bounds are unknown (scrolling won't populate a
+        // `bounds: None` a backend couldn't read).
         let ready = |info: &ElementInfo| match info.bounds {
             Some(b) => b.clamped_center(geo.width, geo.height).is_some(),
             None => true,
@@ -634,13 +627,10 @@ impl Glass {
             }
             None => self.capture(params.window, params.region.as_ref())?,
         };
-        // The mask is built once, sized from `reference` — the frame that will
-        // actually be compared every tick — not from the session's cached window
-        // geometry, which can be stale or belong to a different window (the same
-        // trap `wait_stable` hit: see its mask-build comment). Every polled
-        // `current` frame is required to match `reference`'s size (the masked
-        // diff functions error otherwise via `SizeMismatch`), so `reference`'s own
-        // dimensions are exactly the comparison's real size, cropped or not.
+        // Built once, sized from `reference` — the frame actually compared every tick — not
+        // from the session's cached geometry, which can be stale or belong to a different
+        // window. Every polled frame must match `reference`'s size (`SizeMismatch` otherwise),
+        // so those dimensions are the comparison's real size, cropped or not.
         let mask = mask_for(
             &params.ignore,
             params.region.as_ref(),
@@ -842,14 +832,9 @@ mod tests {
         // clock — while the rest of the 4x4 frame stays constant black. Masking
         // it lets the (otherwise-constant) frame settle on the scripted frames.
         //
-        // `settled` alone is NOT the discriminator: without the mask the stream
-        // still settles, just *late*. `FakePlatform` repeats its last supplied
-        // frame forever once exhausted, so once polling outlasts the 3 scripted
-        // frames it compares that repeated final frame to itself and "settles"
-        // trivially — proving nothing about `ignore`. Pinning the capture count to
-        // exactly 3 (the frames actually supplied) rules that out: settling within
-        // them can only happen if the blink was masked from the very first
-        // comparison.
+        // `settled` alone is NOT the discriminator: `FakePlatform` repeats its last supplied
+        // frame forever, so polling past the 3 scripted frames compares that repeat to itself
+        // and settles trivially. Pinning the capture count to 3 rules that out.
         let log = Arc::new(Mutex::new(Vec::new()));
         let f0 = frame_4x4_corner([10, 0, 0, 255]);
         let f1 = frame_4x4_corner([20, 0, 0, 255]);
@@ -922,16 +907,10 @@ mod tests {
 
     #[test]
     fn wait_stable_masks_by_captured_frame_size_not_stale_cached_geometry() {
-        // The cached window geometry is a deliberately stale/smaller 2x2 —
-        // `FakePlatform::new(2, 2)` — while `with_frames` serves the same 4x4
-        // blinking frames as the sibling test above. This models watching a
-        // window whose real size the session's geometry cache doesn't reflect
-        // (a different window, or a self-resize since the cache was last
-        // refreshed). The `ignore` rect at (3,3) falls outside the stale 2x2
-        // bounds but inside the actual 4x4 frame: if the mask were ever sized
-        // from the cached geometry instead of the captured frame, (3,3) would be
-        // clamped away, the blink would go unmasked, and the frames would never
-        // settle within the timeout.
+        // The cached geometry is a deliberately stale 2x2 while the frames are 4x4 — a window
+        // whose real size the cache doesn't reflect. The `ignore` rect at (3,3) is outside the
+        // stale bounds but inside the real frame, so a mask sized from the cache would clamp
+        // it away and the blink would never settle.
         let log = Arc::new(Mutex::new(Vec::new()));
         let f0 = frame_4x4_corner([10, 0, 0, 255]);
         let f1 = frame_4x4_corner([20, 0, 0, 255]);
@@ -1342,7 +1321,7 @@ mod tests {
         //
         // No lower bound: this signal answers instantly, so `d.saturating_sub(~0)` is `d` and the
         // pacing arithmetic cannot be wrong here — `a_change_arriving_mid_interval_still_paces_the_next_read`
-        // is what tells the two apart. A floor would only add timing flake for nothing.
+        // tells the two apart.
         assert!(
             n <= 36,
             "a chatty app drove {n} walks in 600ms at a 20ms interval"
@@ -1616,7 +1595,6 @@ mod tests {
         // report a misleading `matched:false`.
         let scrolls = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let platform = FakePlatform::new(100, 100).with_scroll_log(scrolls.clone());
-        // A Button with no bounds (a backend that can't read geometry keeps it None).
         let tree = tree_with(100, 100, vec![ax_node(1, AxRole::Button, None, vec![])]);
         let mut g = glass_with_a11y(platform, tree);
         g.start(&spec()).unwrap();
@@ -2059,17 +2037,13 @@ mod tests {
 
     #[test]
     fn wait_for_region_ignore_masks_a_changing_rect_so_changes_never_matches() {
-        // Pixel (3,3) blinks every frame — a stand-in for a blinking caret or a
-        // clock — while the rest of the 4x4 frame stays constant. Masking it means
-        // `until: Changes` has nothing left to react to: the corner is the only
-        // pixel that ever differs, and it is excluded from the comparison.
+        // Pixel (3,3) blinks every frame — a stand-in for a blinking caret or a clock — while
+        // the rest of the 4x4 frame stays constant, so masking it leaves `until: Changes`
+        // nothing to react to.
         //
-        // `timeout_ms: 0` bounds the wait to exactly one poll after the reference
-        // capture (see `poll_until`), so a generous timeout letting `FakePlatform`
-        // outlast its scripted frames into its repeat-forever fallback can't be
-        // what makes this pass — the outcome is decided by that single real
-        // comparison. Pinning the capture count to 2 (reference + one poll) makes
-        // that explicit.
+        // `timeout_ms: 0` bounds the wait to one poll after the reference capture, so a
+        // generous timeout outlasting the scripted frames into `FakePlatform`'s
+        // repeat-forever fallback can't be what makes this pass.
         let log = Arc::new(Mutex::new(Vec::new()));
         let f0 = frame_4x4_corner([10, 0, 0, 255]);
         let f1 = frame_4x4_corner([20, 0, 0, 255]);
@@ -2110,18 +2084,12 @@ mod tests {
 
     #[test]
     fn wait_for_region_ignore_is_window_relative_under_a_region() {
-        // (3,3) blinks and is INSIDE the watched region (2,2,2,2), so the cropped
-        // frames differ every poll; only a window-relative rect translated into
-        // region-local space masks it. The region-scoped path was the last one
-        // left unexercised for `ignore`; the siblings are
-        // `wait_stable_ignore_is_window_relative_under_a_stability_region` and
-        // `baseline_ignore_is_window_relative_under_a_region`.
+        // (3,3) blinks and is INSIDE the watched region (2,2,2,2), so the cropped frames
+        // differ every poll; only a window-relative rect translated into region-local space
+        // masks it.
         //
-        // Pinning the capture count to 2 (reference + exactly one poll, via
-        // `timeout_ms: 0`) makes the translation load-bearing: this can only be
-        // `!matched` if the window-relative rect was translated into region-local
-        // space and masked the blink on that single real comparison. Drop the
-        // translation (build the mask with no region) and the rect lands outside
+        // Pinning the capture count to 2 (reference + one poll, via `timeout_ms: 0`) makes the
+        // translation load-bearing: build the mask with no region and the rect lands outside
         // the 2x2 crop, the blink registers, and this flips to `matched`.
         let log = Arc::new(Mutex::new(Vec::new()));
         let f0 = frame_4x4_corner([10, 0, 0, 255]);
@@ -2168,15 +2136,12 @@ mod tests {
 
     #[test]
     fn wait_for_region_ignore_lets_matches_converge_despite_a_changing_rect() {
-        // The baseline is saved while the corner is 10; the polled stream then
-        // serves a frame with the corner at 20 — otherwise identical. Without
-        // masking, that real corner difference would keep `until: Matches` from
-        // ever being satisfied; masking it lets the (otherwise-constant) rest of
-        // the frame converge on the very first poll.
+        // The baseline is saved while the corner is 10; the polled frame has it at 20,
+        // otherwise identical. Unmasked, that difference keeps `until: Matches` from ever
+        // being satisfied.
         //
-        // Pinning the capture count to 2 (the baseline save + one poll) rules out
-        // a generous timeout eventually matching by other means: it can only
-        // happen if the corner was masked from that first real comparison.
+        // Pinning the capture count to 2 (baseline save + one poll) rules out a generous
+        // timeout matching by other means.
         let log = Arc::new(Mutex::new(Vec::new()));
         let f0 = frame_4x4_corner([10, 0, 0, 255]);
         let f1 = frame_4x4_corner([20, 0, 0, 255]);
@@ -2546,7 +2511,7 @@ mod tests {
             Some(ScrollDirection::Left)
         );
         assert_eq!(offscreen_direction(at(-9, 50), 100, 100), None);
-        // Same on the vertical axis, including the Up case the older test omits.
+        // Same on the vertical axis, Up included.
         assert_eq!(
             offscreen_direction(at(50, 100), 100, 100),
             Some(ScrollDirection::Down)

--- a/crates/glass-ios/src/axmap.rs
+++ b/crates/glass-ios/src/axmap.rs
@@ -44,12 +44,11 @@ pub const ROLE_TOKENS: &[(&str, AxRole)] = &[
     ("AXTabBar", AxRole::TabList),
     ("AXApplication", AxRole::Application),
     ("AXWindow", AxRole::Window),
-    // A content container, and the only structural token most probed screens exposed: navigation
-    // bars, tab bars and collections all arrived as AXGroup, named by the element's identifier
-    // rather than by its role. That is what was seen, not a rule about UIKit — an app that does
-    // report AXNavigationBar or AXTabBar still maps to Toolbar or TabList through the rows above.
-    // The Toolbar, TabList and List rows of `glass_core::role_support::ROLE_SUPPORT` carry what
-    // each was read to report.
+    // A content container, and the only structural token most probed screens exposed:
+    // navigation bars, tab bars and collections all arrived as AXGroup, named by the element's
+    // identifier rather than by its role. That is what was observed, not a rule about UIKit —
+    // an app that does report AXNavigationBar or AXTabBar still maps to Toolbar or TabList
+    // through the rows above.
     ("AXGroup", AxRole::Group),
     // A screen or section title.
     ("AXHeading", AxRole::Heading),
@@ -833,11 +832,10 @@ mod tests {
                         "{role:?} is produced by a token but the matrix does not declare it"
                     );
                     // The named token must not resolve to the very role the cell says is out
-                    // of reach. Largely a second line behind the `!mapped` assertion above —
-                    // if the token produced the role, that one fires too — but it pins the
-                    // token itself, so a cell rewritten to name a different token is checked
-                    // against the map rather than against nothing. A misspelt token resolves
-                    // to `Other` and passes: only an on-box read catches that.
+                    // of reach. Largely a second line behind the `!mapped` assertion above,
+                    // but it pins the token itself, so a cell rewritten to name a different
+                    // token is checked against the map. A misspelt token resolves to `Other`
+                    // and passes — only an on-box read catches that.
                     if let Some(token) = cell.named_token() {
                         assert_ne!(
                             ax_role(token),

--- a/crates/glass-ios/src/idb/client.rs
+++ b/crates/glass-ios/src/idb/client.rs
@@ -377,12 +377,11 @@ mod tests {
         // A stale socket file — the companion died, leaving its socket behind. Whether the
         // failure surfaces at `connect` or at the first RPC is a tonic/HTTP-2 timing detail:
         // `connect` can return `Ok` once the stream dials and the client preface is buffered,
-        // before the peer's reset is observed. `connect` makes no promise to reject a dead
-        // socket — liveness is really validated earlier (the companion's `await_socket` at
-        // spawn) and backstopped by `RPC_TIMEOUT` on the first RPC. What we guarantee, and
-        // assert here deterministically so it can't flake on connect's timing, is that a dead
-        // socket is handled cleanly: a structured `Backend` error, never a panic, at one of
-        // those two points (`map_timed` folds every RPC transport error/timeout into `Backend`).
+        // before the peer's reset is observed. Liveness is really validated earlier (the
+        // companion's `await_socket` at spawn) and backstopped by `RPC_TIMEOUT`.
+        //
+        // Asserted deterministically so it can't flake on connect's timing: a dead socket
+        // yields a structured `Backend` error, never a panic, at one of those two points.
         let dir = tempfile::tempdir().expect("tempdir");
         let sock = dir.path().join("idb.sock");
         {

--- a/crates/glass-ios/src/platform.rs
+++ b/crates/glass-ios/src/platform.rs
@@ -489,19 +489,16 @@ impl Platform for IosPlatform {
             None => None,
         };
         // Everything above would look identical for an app that died on launch: `simctl launch`
-        // exits 0 once launchd has spawned the process, and the screenshot then captures whatever
-        // the Simulator is showing — the home screen — which would be reported as the app's
-        // window, leaving the caller to snapshot SpringBoard with nothing saying why.
+        // exits 0 once launchd has spawned the process, and the screenshot then captures
+        // whatever the Simulator is showing — the home screen — reported as the app's window.
         //
-        // Asked once at least [`LAUNCH_DEATH_WINDOW`] has passed since the launch, at the last
-        // moment before success is reported: an app that aborts takes a beat to actually go. The
-        // work above usually covers that beat, but an observe-only launch skips scale discovery,
+        // Asked once at least [`LAUNCH_DEATH_WINDOW`] has passed since the launch: an app that
+        // aborts takes a beat to actually go, and an observe-only launch skips scale discovery,
         // so the remainder is waited for rather than assumed.
         //
-        // This bounds startup only. An app that dies later is NOT noticed by this backend — every
-        // operation gates on the session being registered, not on the process being alive — so a
-        // capture or snapshot after that describes whatever the Simulator is showing. Closing
-        // that needs a liveness probe on the operation path, which is why the pid is kept.
+        // This bounds startup only. An app that dies later is NOT noticed — every operation
+        // gates on the session being registered, not on the process being alive — which is why
+        // the pid is kept.
         if let Some(pid) = launch_pid {
             let elapsed = launched_at.elapsed();
             if let Some(remaining) = LAUNCH_DEATH_WINDOW.checked_sub(elapsed) {

--- a/crates/glass-macos/src/axwindow.rs
+++ b/crates/glass-macos/src/axwindow.rs
@@ -61,17 +61,13 @@ use glass_core::{GlassError, Result};
 
 use crate::coords::point_to_global_pixel;
 
-// The private CGWindowID<->AXUIElement bridge (see module doc). Declared here, not
-// available from `objc2-application-services` (it's undocumented and intentionally absent
-// from Apple's public headers, so no binding crate exposes it) — the same contained
-// `extern "C"` pattern `permissions.rs` uses for `AXIsProcessTrusted`/
-// `CGPreflightScreenCaptureAccess`.
+// The private CGWindowID<->AXUIElement bridge (see module doc), declared here because it is
+// intentionally absent from Apple's public headers, so no binding crate exposes it.
 //
-// VERSION FRAGILITY: undocumented and unversioned; Apple could rename or remove it in any
-// macOS release without notice. Re-validate (does it still link? does it still return
-// `.Success` for real windows?) whenever this crate bumps its minimum-supported macOS
-// major. `ax_window_for_cgwindowid`'s geometry fallback exists specifically so a broken
-// symbol degrades this crate's window ops rather than making them entirely non-functional.
+// VERSION FRAGILITY: undocumented and unversioned — Apple could rename or remove it in any
+// macOS release. Re-validate whenever this crate bumps its minimum-supported macOS major;
+// `ax_window_for_cgwindowid`'s geometry fallback is what keeps a broken symbol from taking
+// out this crate's window ops entirely.
 #[link(name = "ApplicationServices", kind = "framework")]
 unsafe extern "C" {
     fn _AXUIElementGetWindow(element: &AXUIElement, out_wid: *mut u32) -> AXError;

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -1134,12 +1134,10 @@ mod tests {
 
     #[test]
     fn stop_app_clears_clipboard_route() {
-        // start_app decides clipboard_route for the session; stop_app must reset it to the
-        // fail-closed default (Unsupported) too, so a later start_app on the same
-        // MacosPlatform never inherits a stale contained-session route (here a
-        // `Private(name)`, which would wrongly route get_clipboard/set_clipboard to a private
-        // pasteboard that no longer applies) before the next start_app decides fresh. `clip`
-        // is None so stop_app touches no pasteboard here.
+        // `stop_app` must reset the route to the fail-closed default, so a later `start_app`
+        // on the same MacosPlatform never inherits a stale `Private(name)` that would route
+        // get_clipboard/set_clipboard to a pasteboard no longer in play. `clip` is None here,
+        // so no pasteboard is touched.
         let mut p = MacosPlatform {
             logs: Arc::new(Mutex::new(Vec::new())),
             app_pid: Some(42),
@@ -1155,12 +1153,9 @@ mod tests {
 
     #[test]
     fn stop_app_clears_clip() {
-        // start_app stores process::spawn's ClipLaunch facts for a later clipboard-routing
-        // decision; stop_app must clear them too, so a later start_app on the same
-        // MacosPlatform never leaks a previous session's shim facts (e.g. a stale private
-        // pasteboard name) into a new one. With `clip` set, stop_app also exercises the
-        // `release_named` path for the content + `.ready` boards (harmless on names no live
-        // shim ever wrote).
+        // `stop_app` must clear the stored `ClipLaunch` facts too, so a later session never
+        // inherits a previous one's private pasteboard name. With `clip` set, this also runs
+        // the `release_named` path for the content + `.ready` boards.
         let mut p = MacosPlatform {
             logs: Arc::new(Mutex::new(Vec::new())),
             app_pid: Some(42),
@@ -1598,11 +1593,9 @@ mod tests {
 
     #[test]
     fn resize_was_refused_catches_a_total_refusal_of_a_small_requested_delta() {
-        // Regression test for final-review fix 3: a small (> REQUEST_EPSILON_PX, but within
-        // the old WINDOW_OP_TOLERANCE_PX-based "was a change requested" threshold) resize
-        // request that's fully refused must now be caught. Before this fix, a 5px delta
-        // wasn't even considered "a change was requested" (5 <= the old 8px threshold), so a
-        // total no-op silently reported success.
+        // A small resize request — over REQUEST_EPSILON_PX but under the old
+        // WINDOW_OP_TOLERANCE_PX threshold — that is fully refused must be caught. A 5px delta
+        // did not used to count as "a change was requested", so a total no-op reported success.
         let before = WindowGeometry {
             x: 0,
             y: 0,

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -315,9 +315,8 @@ impl MacosPlatform {
         let (geometry, outcome) =
             settle_by_polling(seed_geometry, SETTLE_BUDGET, SETTLE_POLL_INTERVAL, || {
                 // `.map`, not `?`: `?` asks for `E: From<GlassError>` and leaves `E` itself
-                // unconstrained (`settle_by_polling`'s `E` is otherwise only ever produced, never
-                // consumed), which `rustc` can't resolve on its own. `.map` keeps the `Result`'s
-                // error type exactly `GlassError`, pinning `E` without a turbofish.
+                // unconstrained, which `rustc` can't resolve on its own. `.map` pins the error
+                // type to exactly `GlassError` without a turbofish.
                 crate::scwindow::find_window_by_id(window_id, &[pid], SETTLE_RESOLVE_TIMEOUT).map(
                     |m| {
                         let geometry = m.geometry.clone();
@@ -446,24 +445,19 @@ impl MacosPlatform {
                 Ok(m.geometry)
             }
             Err(e) => {
-                // The direct-spawned process is done with — dead (an `AppExited` stub) or
-                // simply never grew a window. Tear it down: terminate the child and release
-                // any clip-shim pasteboards it created. On a *successful* handoff `clip` is
-                // always `None` (handoff requires sandbox:off, which is never shim-injected),
-                // so `release_clip` there is a no-op; it does real work only for a contained
-                // launch that failed (a plain failure, or a contained stub the gate rejects
-                // just below).
+                // The direct-spawned process is done with — dead, or it never grew a window.
+                // On a *successful* handoff `clip` is always `None` (handoff requires
+                // sandbox:off, which is never shim-injected), so `release_clip` does real work
+                // only for a contained launch that failed.
                 process::terminate(&mut child);
                 release_clip(clip.as_ref());
-                // Only an early inner-exec exit (`AppExited`) is the handoff signal. Any other
-                // failure (e.g. `Timeout`: the process is alive but never grew a window) is
-                // propagated as-is, exactly as the plain-exec path does.
+                // Only an early inner-exec exit (`AppExited`) is the handoff signal; any other
+                // failure is propagated as-is.
                 //
-                // NOTE: `AppExited` conflates several things — an app that re-execs itself
-                // through LaunchServices and leaves a dead stub, a genuine early crash of the
-                // inner exec, and (before the platform-code check above) the kernel killing a
-                // system app for a launch-constraint violation. All fall through to the handoff,
-                // which then either finds/relaunches a real window or fails.
+                // `AppExited` conflates an app that re-execs itself through LaunchServices and
+                // leaves a dead stub, a genuine early crash of the inner exec, and the kernel
+                // killing a system app for a launch-constraint violation. All fall through to
+                // the handoff.
                 let GlassError::AppExited(_) = e else {
                     return Err(e);
                 };
@@ -488,13 +482,9 @@ impl MacosPlatform {
         let id = crate::bundle::bundle_identifier(bundle)?;
         let (pid, disposition) = match crate::ffi::running_pid_for_bundle_id(&id) {
             Some(pid) => (pid, crate::bundle::Disposition::PreExisting),
-            // NOTE (runtime-verified in Task 4): `ffi::launch_bundle` blocks this
-            // thread on a channel until `NSWorkspace`'s completion handler fires: if
-            // LaunchServices needs the main run loop to spin to complete the launch,
-            // and this call runs on the true main thread (see this module's
-            // main-thread-affinity notes), that handler could need a run-loop turn this
-            // blocked thread isn't pumping. Wired here per the design; the on-box round
-            // confirms whether it actually stalls.
+            // `ffi::launch_bundle` blocks this thread on a channel until `NSWorkspace`'s
+            // completion handler fires — on the true main thread, that handler could need a
+            // run-loop turn this blocked thread isn't pumping.
             None => match crate::ffi::launch_bundle(
                 bundle,
                 spec.run.get(1..).unwrap_or_default(),
@@ -533,11 +523,8 @@ impl MacosPlatform {
             }
         };
         self.child = None;
-        // `app_pid` is `u32` (every other pid in this struct comes from
-        // `std::process::Child::id()`); AppKit's pids are `i32` but always
-        // non-negative for a real process, so this cast is exact, matching every
-        // other `pid as {i32,u32}` cast in this file (see e.g. `resolve_active_window`'s
-        // call sites, which cast the other direction).
+        // AppKit's pids are `i32` but always non-negative for a real process, so the cast to
+        // `app_pid`'s `u32` is exact.
         self.app_pid = Some(pid as u32);
         self.active_window = Some(m.window_id);
         self.adopted = Some(Adopted { pid, disposition });
@@ -754,21 +741,16 @@ impl Platform for MacosPlatform {
                     // `stop_app`/`Drop`'s reap blast radius (symmetric with `start_bundle`'s
                     // handoff path clearing `self.child`).
                     self.adopted = None;
-                    // NOTE: this seeds the active-window model (Plan 4 design decision 2): the
-                    // first window discovered for the launched app becomes the implicit target
-                    // of capture/input, exactly as `select_window` (a later task) will retarget
-                    // it to a different window later. `resolve_active_window` (used by
-                    // `capture_frame`/`send_pointer`/`send_key` below) is what actually honors
-                    // this field on every call.
+                    // The first window discovered for the launched app becomes the implicit
+                    // target of capture/input, until `select_window` retargets it.
+                    // `resolve_active_window` is what honors this field on every call.
                     self.active_window = Some(m.window_id);
                     // Decide the session's clipboard route now that the launched window is
                     // confirmed — see `decide_clip`'s doc.
                     self.clipboard_route = decide_clip(spec.sandbox, clip.as_ref());
                     self.clip = clip;
                     // Scale/origin/geometry are NOT cached here: `send_pointer` re-resolves the
-                    // window fresh on every call instead (see its doc) since it may move/resize
-                    // after this initial discovery. Only the initial geometry is returned to the
-                    // caller, matching every other backend's `start_app` contract.
+                    // window on every call, since it may move or resize after this discovery.
                     m.geometry
                 }
                 Err(e) => {
@@ -808,20 +790,16 @@ impl Platform for MacosPlatform {
         if let Some(mut child) = self.child.take() {
             process::terminate(&mut child);
         }
-        // Release this session's named pasteboards (the content board + its `.ready` sentinel
-        // board) before dropping the shim facts. Named pasteboards persist system-wide until
-        // released, and a leftover sentinel could otherwise mask a failed injection in a later
-        // session (see `crate::clipboard_route`). Only released when a shim launch name is
-        // known (an injectable, contained launch); uncontained/hardened launches have none.
+        // Named pasteboards persist system-wide until released, and a leftover `.ready`
+        // sentinel could mask a failed injection in a later session. Only released when a shim
+        // launch name is known — uncontained/hardened launches have none.
         release_clip(self.clip.as_ref());
         self.app_pid = None;
         self.active_window = None;
-        // Reset the clipboard route too, so a later start_app on the same MacosPlatform can't
-        // have a stale route (e.g. a previous session's Private(name)) leak into
+        // Reset the route too, so a previous session's `Private(name)` can't leak into
         // get_clipboard/set_clipboard before the next start_app decides fresh.
         self.clipboard_route = ClipboardRoute::default();
-        // Same reasoning for the clip-shim facts: a stale `Some` from a previous session must
-        // not leak into a later one's clipboard routing.
+        // Same for the clip-shim facts.
         self.clip = None;
         Ok(())
     }

--- a/crates/glass-macos/src/capture.rs
+++ b/crates/glass-macos/src/capture.rs
@@ -155,10 +155,8 @@ fn capture_resolved(
                     // `CGImage` itself never leaves this block.
                     let image: &CGImage = unsafe { &*image_ptr };
                     // `Frame` is captured in backing PIXELS (`contentRect.size *
-                    // pointPixelScale`), and `region` is already window-relative PIXELS
-                    // too — the tool boundary's unit throughout (see `coords.rs`'s module
-                    // doc and `scwindow.rs`'s `WindowMatch::geometry`) — so `crop_to_region`
-                    // crops directly, no unit conversion needed.
+                    // pointPixelScale`) and `region` is already window-relative PIXELS, so
+                    // `crop_to_region` crops directly with no unit conversion.
                     let result = rgba_frame_from_cgimage(image)
                         .and_then(|frame| crop_to_region(frame, region_owned.as_ref()));
                     let _ = tx_img.send(match result {
@@ -169,9 +167,8 @@ fn capture_resolved(
 
             // SAFETY: `image_block` matches
             // `captureImageWithFilter:configuration:completionHandler:`'s documented
-            // signature (`*mut CGImage, *mut NSError`, per the generated binding) — the
-            // exact sequence the spike proved end-to-end. The call itself has no other
-            // preconditions.
+            // signature (`*mut CGImage, *mut NSError`, per the generated binding). The call
+            // itself has no other preconditions.
             unsafe {
                 SCScreenshotManager::captureImageWithFilter_configuration_completionHandler(
                     &filter,

--- a/crates/glass-macos/src/ffi.rs
+++ b/crates/glass-macos/src/ffi.rs
@@ -108,13 +108,10 @@ pub(crate) fn app_kit_init() {
     if APP_KIT_INIT.is_completed() {
         return;
     }
-    // TOCTOU between the check above and `MainThreadMarker::new()` below is
-    // theoretical-only under the current call graph: every call site reaches this after
-    // `init_main_thread()` has already run on the process's real main thread before any
-    // worker thread is spawned (see this fn's and `init_main_thread`'s docs), so by the
-    // time a second/concurrent call could race the check, `is_completed()` is already
-    // `true`. A future call site that violated "init before spawning workers" would
-    // surface as a loud panic here (below), not silent UB.
+    // TOCTOU between the check above and `MainThreadMarker::new()` below is theoretical under
+    // the current call graph: every call site reaches this after `init_main_thread()` has run
+    // on the process's real main thread, before any worker is spawned. A future call site
+    // that violated that would surface as a loud panic here, not silent UB.
     let mtm = MainThreadMarker::new().expect("app_kit_init must run on the main thread");
     APP_KIT_INIT.call_once(|| {
         let _app = NSApplication::sharedApplication(mtm);
@@ -201,17 +198,12 @@ pub(crate) fn launch_bundle(bundle: &Path, args: &[String], timeout_ms: u64) -> 
 
     let url = NSURL::fileURLWithPath(&NSString::from_str(&bundle.to_string_lossy()));
     let configuration = NSWorkspaceOpenConfiguration::configuration();
-    // `AppSpec::run[1..]` are the app's arguments, and this path must not be the one that quietly
-    // loses them: the direct spawn above passes them to the process, so a bundle that falls back
-    // to LaunchServices has to carry them too, or the same spec would launch two different apps
-    // depending on which arm ran.
+    // `AppSpec::run[1..]` are the app's arguments, and this path must not lose them: the direct
+    // spawn above passes them to the process, so a bundle that falls back to LaunchServices has
+    // to carry them too, or the same spec launches two different apps depending on which arm ran.
     //
-    // Behaviourally unproven on hardware: `tests/bundle_launch.rs`'s handoff check adopts
-    // TextEdit, and handing it a document changes the window it opens enough that the check's own
-    // window discovery stops matching — so the observation costs a second fixture bundle (one
-    // whose stub exits, forcing this path, and which records its argv). Until that exists this
-    // rests on `setArguments:` doing what it documents, which is weaker evidence than the rest of
-    // this module carries.
+    // Behaviourally unproven on hardware: observing it costs a second fixture bundle whose stub
+    // exits and records its argv, so this rests on `setArguments:` doing what it documents.
     if !args.is_empty() {
         let args: Vec<Retained<NSString>> = args.iter().map(|a| NSString::from_str(a)).collect();
         let args: Vec<&NSString> = args.iter().map(|a| a.as_ref()).collect();
@@ -292,9 +284,7 @@ mod tests {
     fn app_kit_init_panics_off_the_main_thread() {
         // libtest always runs each #[test] on a freshly spawned worker thread, never the
         // process's real main thread, so `MainThreadMarker::new()` is `None` here — this
-        // exercises the off-main-thread guard rather than the real NSApplication touch.
-        // The real call only happens from Task 2's `MacosPlatform::start_app`, which
-        // glass always drives from the main thread.
+        // exercises the off-main-thread guard, not the real NSApplication touch.
         app_kit_init();
     }
 }

--- a/crates/glass-macos/src/input.rs
+++ b/crates/glass-macos/src/input.rs
@@ -77,11 +77,10 @@ pub(crate) fn send_pointer(
     scale: f64,
     origin_pt: (f64, f64),
 ) -> Result<()> {
-    // `Gesture` is unconditionally unsupported on macOS regardless of `pid`'s validity (see
-    // the `PointerEvent::Gesture` arm below) — checked first, ahead of `focus`, so this
-    // fails fast without the side effect of raising/activating `pid`'s app for an operation
-    // that can never succeed (also keeps `focus`'s now-fallible missing-process check, fix
-    // 4, from masking this call-shape error behind an unrelated `AppExited`).
+    // `Gesture` is unconditionally unsupported on macOS regardless of `pid`'s validity —
+    // checked ahead of `focus` so it fails fast without raising/activating the app for an
+    // operation that can never succeed, and so `focus`'s missing-process check can't mask
+    // this call-shape error behind an unrelated `AppExited`.
     if matches!(event, PointerEvent::Gesture { .. }) {
         return Err(GlassError::unsupported(
             "multi_touch",

--- a/crates/glass-macos/src/menubar.rs
+++ b/crates/glass-macos/src/menubar.rs
@@ -222,11 +222,7 @@ pub fn run(actions: MenuBarActions) -> Result<()> {
     // background threads. `status_item`, `menu`, and `target` must outlive this call
     // (`setTarget:` holds only a weak reference), so they stay bound below.
     //
-    // VERIFY on-box: the status item shows the `title` ("glass ●"), the dropdown lists the
-    // greyed status line plus "Copy endpoint", "Restart", "Quit glass", and "Uninstall glass…";
-    // "Copy endpoint"/"Restart"/"Uninstall glass…" invoke their callbacks (the uninstall one
-    // raising the host's confirm dialog first), and "Quit glass" (⌘Q → `terminate:`) exits the
-    // process cleanly. None of this is checkable off a real WindowServer/AppKit run loop; the
+    // None of the menu's behaviour is checkable off a real WindowServer/AppKit run loop; the
     // darwin build only proves it compiles.
     app.run();
 

--- a/crates/glass-macos/src/onboarding_window.rs
+++ b/crates/glass-macos/src/onboarding_window.rs
@@ -144,13 +144,10 @@ impl WindowDelegate {
     }
 }
 
-// Fixed-frame layout (points). Auto Layout / `NSStackView` would add a second constraint
-// API surface (and its own feature) for no benefit at this size, so rows are placed with
-// plain frames — computed top-down and converted to AppKit's bottom-left origin by `rect`.
+// Fixed-frame layout (points): rows are placed with plain frames, computed top-down and
+// converted to AppKit's bottom-left origin by `rect`.
 //
-// VERIFY on-box: these constants are eyeballed, not measured — confirm on a real render that
-// labels aren't clipped, the ✓/○ glyph and the "Request…" button sit level with each
-// row's name, and nothing overlaps at the default system font size; nudge the constants if so.
+// These constants are eyeballed, not measured against a real render.
 const WIDTH: f64 = 480.0;
 const H_MARGIN: f64 = 24.0;
 const V_MARGIN: f64 = 20.0;
@@ -361,13 +358,11 @@ pub fn run_checklist(actions: ChecklistActions) -> Result<(), String> {
     let delegate = WindowDelegate::new(mtm);
     window.setDelegate(Some(ProtocolObject::from_ref(&*delegate)));
 
-    // Center, show, and force to the front. A just-launched `LSUIElement` app does not come
-    // forward on its own, and the modern cooperative `activate()` (macOS 14+) deliberately
-    // refuses to steal focus from the app that launched us — Finder, immediately after a
-    // double-click — so the checklist would open *behind* the Finder window and look like
-    // nothing happened. Use the forceful path instead: `activateIgnoringOtherApps` (deprecated
-    // but still the reliable escape hatch for a user-initiated launch) plus
-    // `orderFrontRegardless`, which raises the window even before the app is fully active.
+    // A just-launched `LSUIElement` app does not come forward on its own, and the cooperative
+    // `activate()` (macOS 14+) refuses to steal focus from the app that launched us — Finder,
+    // right after a double-click — so the checklist would open *behind* the Finder window.
+    // `activateIgnoringOtherApps` is deprecated but still the reliable escape hatch, and
+    // `orderFrontRegardless` raises the window before the app is fully active.
     window.center();
     window.makeKeyAndOrderFront(None);
     #[allow(deprecated)]
@@ -378,11 +373,8 @@ pub fn run_checklist(actions: ChecklistActions) -> Result<(), String> {
     // every `ButtonTarget` must outlive this call (`setTarget:`/`setDelegate:` hold only weak
     // references), so they stay bound until after `run` returns.
     //
-    // VERIFY on-box: the window shows the title "glass permissions", the instruction line,
-    // one row per permission (✓ for granted, ○ for not) each with a working "Request…"
-    // button, and a "Re-check" button that fires `on_recheck`; the window comes to the
-    // front on launch; closing it exits the process. None of this is checkable off a real
-    // WindowServer/AppKit run loop — the darwin build only proves it compiles.
+    // None of the rendering is checkable off a real WindowServer/AppKit run loop — the darwin
+    // build only proves it compiles.
     app.run();
 
     // Reached only if the run loop stops without the process exiting. Keep the AppKit

--- a/crates/glass-macos/src/permissions.rs
+++ b/crates/glass-macos/src/permissions.rs
@@ -152,11 +152,10 @@ pub fn open_pane(url: &str) -> Result<()> {
 
 // --- Guided setup: prompting requests --------------------------------------------------
 //
-// Everything above this point only *reads* TCC state (`screen_recording_granted`,
-// `accessibility_granted`, `preflight`) — safe to call from `doctor` on every run. The two
-// functions below are the opposite: they actively trigger the OS consent flow (a system
-// dialog, on first request). They exist only for the future interactive `setup` command
-// and must never be called from `preflight`/`doctor`, which must stay non-prompting.
+// Everything above this point only *reads* TCC state — safe to call from `doctor` on every
+// run. The two functions below actively trigger the OS consent flow (a system dialog, on
+// first request), and must never be called from `preflight`/`doctor`, which stay
+// non-prompting.
 
 #[link(name = "CoreGraphics", kind = "framework")]
 unsafe extern "C" {
@@ -251,11 +250,8 @@ mod tests {
         assert!(accessibility_pane_url().contains("Privacy_Accessibility"));
     }
 
-    // `request_screen_recording`/`request_accessibility` are deliberately not exercised
-    // here: unlike every predicate above, they have a real side effect (they can pop the
-    // OS consent dialog), which is unsafe to trigger unattended in CI — a headless runner
-    // has no user to click through it, and a real one shouldn't have its TCC state
-    // mutated by every test run. Their FFI plumbing is verified by hand against the
-    // granted dev Mac; `open_pane` is likewise
-    // side-effecting (launches System Settings) and not called here for the same reason.
+    // `request_screen_recording`/`request_accessibility` are deliberately not exercised here:
+    // they can pop the OS consent dialog, which a headless runner has no user to click through
+    // and a real one shouldn't have its TCC state mutated by every test run. `open_pane`
+    // launches System Settings and is skipped for the same reason.
 }

--- a/crates/glass-macos/src/process.rs
+++ b/crates/glass-macos/src/process.rs
@@ -201,12 +201,10 @@ const EXIT_POLL: Duration = Duration::from_millis(20);
 pub(crate) fn spawn(spec: &AppSpec, logs: LogSink) -> Result<(Child, Option<ClipLaunch>)> {
     let mut cmd = Command::new(&spec.run[0]);
 
-    // Apply the caller's env FIRST, so glass's own containment/injection vars (set inside the
-    // block below) are written LAST and always win last-write-wins. Otherwise a caller (or an
-    // LLM footgun) could blank `DYLD_INSERT_LIBRARIES`/`GLASS_CLIP_PASTEBOARD` via `spec.env`
-    // and silently defeat injection while the profile had already granted the pasteboard —
-    // fail-OPEN. When not injecting (`sandbox: off` or a non-injectable target), caller env
-    // simply applies normally.
+    // Apply the caller's env FIRST, so glass's own containment/injection vars are written LAST
+    // and win. Otherwise a caller could blank `DYLD_INSERT_LIBRARIES`/`GLASS_CLIP_PASTEBOARD`
+    // via `spec.env` and silently defeat injection while the profile had already granted the
+    // pasteboard — fail-OPEN.
     for (k, v) in &spec.env {
         cmd.env(k, v);
     }
@@ -285,11 +283,9 @@ pub(crate) fn spawn(spec: &AppSpec, logs: LogSink) -> Result<(Child, Option<Clip
             // dyld can't open it, injection silently fails, and the sandboxed app never sees
             // the shim. Re-allow only the file (not its whole directory) — least privilege.
             shim_file = Some(dylib.clone());
-            // Set LAST (after `spec.env` above) and BEFORE `cmd.spawn()`: `Command`'s envp is
-            // applied at the `exec` that follows `pre_exec`'s `sandbox_init` call (not at
-            // fork/`pre_exec` time), so both vars are present in the launched app's
-            // environment, having survived the sandbox — same timing guarantee the profile
-            // CString relies on.
+            // Set LAST (after `spec.env`) and BEFORE `cmd.spawn()`: `Command`'s envp is applied
+            // at the `exec` that follows `pre_exec`'s `sandbox_init`, not at fork time, so both
+            // vars survive the sandbox into the launched app's environment.
             cmd.env("DYLD_INSERT_LIBRARIES", &dylib);
             cmd.env("GLASS_CLIP_PASTEBOARD", &name);
             clip = Some(ClipLaunch { name });
@@ -300,9 +296,8 @@ pub(crate) fn spawn(spec: &AppSpec, logs: LogSink) -> Result<(Child, Option<Clip
         // un-canonicalized `effective_cwd` (not `cwd_canon`) so relative tokens resolve against
         // where glass was actually invoked.
         let reallows = launch_reallows(&spec.run, effective_cwd.as_deref());
-        // Union the arg-literal re-allows with the shim file (if injecting); the shim file lives in
-        // glass's own target dir and is not expected to collide with a launch target, and the
-        // `.contains()` dedup below is defensive regardless (not load-bearing on that expectation).
+        // Union the arg-literal re-allows with the shim file. The `.contains()` dedup below is
+        // defensive — the shim lives in glass's own target dir and shouldn't collide.
         let mut ro_files = reallows.ro_files;
         if let Some(f) = shim_file
             && !ro_files.contains(&f)
@@ -342,11 +337,9 @@ pub(crate) fn spawn(spec: &AppSpec, logs: LogSink) -> Result<(Child, Option<Clip
     cmd.stderr(Stdio::piped());
 
     let mut child = cmd.spawn().map_err(|e| {
-        // A PermissionDenied under containment could be `sandbox_init` rejecting the profile in
-        // pre_exec, OR a plain EACCES on a non-executable binary — the two are indistinguishable
-        // from this `io::Error` alone. Surface the actionable SandboxUnavailable either way
-        // (the failure is real regardless of cause: fail-closed, never unconfined), but don't
-        // overclaim which one it was.
+        // A PermissionDenied under containment could be `sandbox_init` rejecting the profile,
+        // or a plain EACCES on a non-executable binary — indistinguishable from this
+        // `io::Error` alone. Surface SandboxUnavailable either way without overclaiming which.
         if spec.sandbox != SandboxLevel::Off && e.kind() == std::io::ErrorKind::PermissionDenied {
             GlassError::SandboxUnavailable(format!(
                 "launch failed under containment (sandbox != off): sandbox_init rejected the profile, or the program could not be exec'd: {e}"

--- a/crates/glass-macos/src/scwindow.rs
+++ b/crates/glass-macos/src/scwindow.rs
@@ -52,14 +52,9 @@ use crate::adoption_log::CandidateWindow;
 /// A discovered on-screen window: enough to re-find or capture it later without holding
 /// a live `Retained<SCWindow>` across the completion handler's thread boundary (see
 /// module doc).
-// `geometry`/`scale`/`origin_pt` are read by `start_app` (via `backend.rs::discover_window`
-// -> `query_once_with_candidates`) and by `send_pointer`/`capture_frame`/`send_key` (via
-// `backend.rs`'s per-call `find_window_for_pids`/`find_window_by_id` resolution);
-// `window_id` is read by `start_app` too (to seed `MacosPlatform::active_window`, Plan 4
-// Task 1). `pid` is read by `send_pointer`/`send_key` (via `resolve_active_window`'s
-// per-call resolution) as the CGEvent focus/AX-scoping target, and by every
-// `find_window_by_id` call site's pid-scoping check (Plan 4 final-review fix 1) — every
-// field is read somewhere.
+// Every field is read: `geometry`/`scale`/`origin_pt` by `start_app` and the per-call window
+// resolution, `window_id` to seed `MacosPlatform::active_window`, and `pid` as the CGEvent
+// focus/AX-scoping target and for each `find_window_by_id` call site's pid-scoping check.
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct WindowMatch {
     /// The owning process's pid — one of the `pids` passed to `find_window_for_pids`.

--- a/crates/glass-macos/src/session.rs
+++ b/crates/glass-macos/src/session.rs
@@ -25,22 +25,14 @@ use objc2_core_foundation::{CFBoolean, CFDictionary, CFNumber, CFRetained, CFStr
 const SCREEN_IS_LOCKED_KEY: &str = "CGSSessionScreenIsLocked";
 
 // `CGSessionCopyCurrentDictionary` is a long-standing (if formally undocumented)
-// CoreGraphics entry point — the standard way idle-time/lock-state tools read the
-// window server's session dictionary. `objc2-core-graphics` doesn't bind it, so it's
-// declared manually here, the same way `permissions.rs` declares
-// `CGPreflightScreenCaptureAccess`/`AXIsProcessTrusted`.
+// CoreGraphics entry point — the standard way idle-time/lock-state tools read the window
+// server's session dictionary. `objc2-core-graphics` doesn't bind it, so it's declared here.
 //
-// The return type is written as the parameterized `*mut CFDictionary<CFString,
-// CFType>` rather than an untyped `*mut c_void` (this is the first FFI declaration in
-// the crate to do so). That's sound: `CFDictionary<K, V>` is a zero-cost phantom
-// wrapper around the same `CFDictionaryRef` C ABI regardless of `K`/`V` — the type
-// parameters only narrow what `objc2-core-foundation`'s safe accessors (`get`,
-// `from_slices`, ...) let Rust assume about the *values*, they don't change the
-// pointer's layout or the call's ABI. `CFType` is `objc2-core-foundation`'s top type
-// (every CF object downcasts to it), so `CFType` values are always a safe upper bound
-// for "whatever this dictionary actually holds" — declaring the precise
-// `CFDictionary<CFString, CFType>` here (instead of a bare pointer + a manual cast at
-// every call site) pushes the unsafety to one declaration instead of many.
+// The return type is the parameterized `*mut CFDictionary<CFString, CFType>` rather than an
+// untyped `*mut c_void`: `CFDictionary<K, V>` is a zero-cost phantom wrapper over the same
+// `CFDictionaryRef` ABI, and `CFType` is the top type every CF object downcasts to — so
+// declaring it precisely here pushes the unsafety into one declaration instead of a manual
+// cast at every call site.
 #[link(name = "CoreGraphics", kind = "framework")]
 unsafe extern "C" {
     fn CGSessionCopyCurrentDictionary() -> *mut CFDictionary<CFString, CFType>;

--- a/crates/glass-macos/tests/bundle_launch.rs
+++ b/crates/glass-macos/tests/bundle_launch.rs
@@ -415,13 +415,10 @@ mod macos_main {
             Ok(())
         });
 
-        // Orphan check: only meaningful once the main check above actually adopted
-        // TextEdit, and only asserted when this test's own call was the fresh launch —
-        // re-run the same `process_running` probe used above (now post-`stop_app`, via
-        // `with_stop_app`) rather than tracking the adopted pid directly, since
-        // `MacosPlatform`'s `adopted`/`app_pid` fields are private to `glass-macos`. A
-        // `match` on both facts (rather than if/else-if) keeps all three outcomes explicit,
-        // including the "main check already failed" case, which has nothing to verify here.
+        // Orphan check: only meaningful once the main check above actually adopted TextEdit,
+        // and only asserted when this test's own call was the fresh launch. Re-runs the
+        // `process_running` probe rather than tracking the adopted pid directly, since
+        // `MacosPlatform`'s `adopted`/`app_pid` fields are private to `glass-macos`.
         match (&result, text_edit_was_running) {
             (Ok(()), false) => {
                 std::thread::sleep(TERMINATE_SETTLE);
@@ -496,10 +493,8 @@ mod macos_main {
         // No blanket precondition gate here — each check declines itself (returning
         // `Outcome::Skipped`) when the ONE precondition it needs is absent, so a missing
         // `swiftc` can never skip the handoff/fail-closed checks and a missing `TextEdit.app`
-        // can never skip the foreground check. Failures fail the run; skips are reported
-        // distinctly (SKIPPED, never counted as a pass) and do not block the PASS banner for
-        // the checks that did run and pass. On the dev Mac both preconditions are present, so
-        // all three run.
+        // can never skip the foreground check. Skips are reported distinctly, never counted
+        // as a pass.
         let mut failures = Vec::new();
         let mut skips = Vec::new();
 

--- a/crates/glass-macos/tests/capture.rs
+++ b/crates/glass-macos/tests/capture.rs
@@ -211,12 +211,9 @@ mod macos_main {
         let geometry = try_expect(platform.start_app(&spec), "start_app")?;
         println!("started fixture window: {geometry:?}");
 
-        // start_app only waits for the window to *exist* (SCShareableContent
-        // enumeration), not for its first paint to land — give the initial draw() a
-        // moment to complete before capturing. This fixture draws once, synchronously,
-        // immediately on launch, so a fixed sleep is sufficient here; it is NOT a
-        // wait-for-first-paint pattern to reuse for apps with slower or async first
-        // paints.
+        // start_app only waits for the window to *exist*, not for its first paint to land.
+        // This fixture draws once, synchronously, on launch, so a fixed sleep suffices — do
+        // NOT reuse it as a wait-for-first-paint pattern for apps with slower or async paints.
         std::thread::sleep(Duration::from_millis(500));
 
         let frame = try_expect(platform.capture_frame(None), "capture_frame(None)")?;
@@ -299,11 +296,9 @@ mod macos_main {
 
         let result = run_checks(&mut platform, &fixture_bin);
 
-        // Reached regardless of outcome, and BEFORE any process::exit below: stop_app is
-        // documented idempotent (a no-op if start_app never got far enough to spawn a
-        // child), so this is always safe and is what guarantees the fixture's `quadrants`
-        // process never survives a failed run. Best-effort temp dir cleanup rides along
-        // here too, on both the success and failure paths.
+        // Reached regardless of outcome and BEFORE any process::exit below: `stop_app` is
+        // documented idempotent, so this is what guarantees the fixture's `quadrants` process
+        // never survives a failed run.
         let stop_result = platform.stop_app();
         let _ = std::fs::remove_dir_all(&fixture_dir);
 

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -141,20 +141,14 @@ fn diagnose_inner(deep: bool, audit: Option<&crate::audit::AuditReport>) -> Diag
         )],
     );
 
-    // Only show sections for backends actually compiled into THIS binary — absent
-    // backends (e.g. windows on a Linux build, or macos on a non-macOS build) are
-    // omitted rather than listed as "not built into this binary" placeholders.
-    // Accessibility is per-OS (AT-SPI on Linux, UIA on Windows); macOS instead gets three
-    // sections below — "macos" (the platform backend's own TCC posture), "sandbox" (Seatbelt
-    // containment posture, mirroring the Linux/Windows "sandbox" sections), and
-    // "accessibility (macos)" (the a11y-tool reader's readiness, kept separate from "macos" —
-    // see the comment there for why). Android is the exception: it shells out to a separate
-    // SDK's own tools (adb/emulator) rather than linking an OS framework, so it's
-    // host-OS-agnostic and always compiled in — its section is always emitted, gated at
-    // runtime (see below) rather than by cfg. iOS also shells out to a separate SDK's tools
-    // (`xcrun simctl`), but only macOS can actually run them, and `glass-ios` pulls in an
-    // `image` PNG codec chain that a non-macOS binary has no use for — so glass-mcp only
-    // depends on `glass-ios` on macOS, and its section is compiled in accordingly.
+    // Only sections for backends actually compiled into THIS binary — an absent backend is
+    // omitted, never listed as a "not built into this binary" placeholder.
+    //
+    // Android is host-OS-agnostic (it shells out to adb/emulator rather than linking an OS
+    // framework), so it is always compiled in and gated at runtime instead of by cfg. iOS
+    // also shells out (`xcrun simctl`), but only macOS can run those tools and `glass-ios`
+    // pulls in an `image` PNG codec chain a non-macOS binary has no use for — so glass-mcp
+    // depends on it on macOS only.
     let mut sections = vec![general, network];
 
     #[cfg(target_os = "linux")]
@@ -207,14 +201,11 @@ fn diagnose_inner(deep: bool, audit: Option<&crate::audit::AuditReport>) -> Diag
         ));
         // Mirrors the Linux/Windows "sandbox" section: Seatbelt containment posture.
         sections.push(Section::new("sandbox", None, glass_sandbox_macos::checks()));
-        // Mirrors "accessibility (linux)"/"accessibility (windows)": a dedicated section
-        // for the a11y-tool reader itself (glass_a11y_snapshot/marks/click_element/
-        // set_value), distinct from the "macos" section above which covers the platform
-        // backend's own TCC posture (Screen Recording, session state, ...). The
-        // Accessibility grant check is intentionally duplicated between the two sections
-        // — here it answers "will the a11y tools work", there it answers "is this Mac
-        // set up at all" — both reuse the same `glass_macos::accessibility_granted()`
-        // fact and remedy string, so there's no risk of the two drifting apart.
+        // A dedicated section for the a11y-tool reader itself, distinct from the "macos"
+        // section above (the platform backend's own TCC posture). The Accessibility grant
+        // check is deliberately duplicated: here it answers "will the a11y tools work",
+        // there "is this Mac set up at all". Both read the same
+        // `glass_macos::accessibility_granted()` fact and remedy string.
         sections.push(Section::new(
             "accessibility (macos)",
             None,
@@ -226,12 +217,11 @@ fn diagnose_inner(deep: bool, audit: Option<&crate::audit::AuditReport>) -> Diag
         ));
     }
 
-    // Android is host-OS-agnostic (drives an AVD over adb), so the crate is always compiled
-    // in. Run its basic presence checks unconditionally — like the desktop backends — so the
-    // doctor gives android pre-flight regardless of the (launch-frozen) GLASS_BACKEND. Only
-    // the expensive/mutating deep probes (boot AVD, install agent) stay gated to the selected
-    // backend. When android isn't active, soften any Fail to Warn so an irrelevant missing
-    // adb/emulator doesn't fail the overall verdict for a desktop user.
+    // Android is host-OS-agnostic, so the crate is always compiled in. Its basic presence
+    // checks run unconditionally, so doctor gives android pre-flight whatever the
+    // launch-frozen GLASS_BACKEND is; only the expensive/mutating deep probes (boot AVD,
+    // install agent) stay gated to the selected backend. When android isn't active, soften
+    // Fail to Warn so a missing adb doesn't fail a desktop user's overall verdict.
     let android_selected = backend == "android";
     let mut android_checks = glass_android::doctor::checks(deep && android_selected);
     if !android_selected {
@@ -252,11 +242,9 @@ fn diagnose_inner(deep: bool, audit: Option<&crate::audit::AuditReport>) -> Diag
     {
         let ios_selected = backend == "ios";
         let base = glass_ios::doctor::checks(deep && ios_selected);
-        // The companion gates all iOS input + accessibility, so its status is *always* surfaced —
-        // an operator driving iOS per-call from a macos-default server still needs to see it. Only
-        // the expensive --deep spawn probe is gated to the selected backend (mirroring android's
-        // gated deep probes): spawn against a booted sim (else a bounded self-test) when driving
-        // iOS with --deep, otherwise just report resolvable-on-PATH presence.
+        // The companion gates all iOS input + accessibility, so its status is *always*
+        // surfaced — an operator driving iOS per-call from a macos-default server still needs
+        // to see it. Only the expensive --deep spawn probe is gated to the selected backend.
         let companion = if ios_selected && deep {
             companion_deep_check(glass_ios::doctor::probe_companion())
         } else {
@@ -494,11 +482,9 @@ fn macos_checks_from(
                  (see docs/how-to/build-from-source.md)",
             ),
         },
-        // The `general` section already prints the resolved default backend
-        // (`default backend`, above); this doesn't re-discover that fact, it just
-        // views it through a macOS-specific lens — is the backend this *macOS*
-        // binary resolved to actually macOS, e.g. flagging a `GLASS_BACKEND`
-        // override that names a backend not even compiled into this build.
+        // Not a re-discovery of `general`'s `default backend` line: this asks whether the
+        // backend this *macOS* binary resolved to is actually macOS, flagging a
+        // `GLASS_BACKEND` override naming a backend not compiled into this build.
         if resolved_backend == "macos" {
             Check::new("backend", CheckStatus::Ok, "resolved to macos")
         } else {
@@ -856,11 +842,8 @@ mod tests {
         let d = diagnose(false);
         let titles: Vec<&str> = d.sections.iter().map(|s| s.title.as_str()).collect();
         // Platform-gated backends compiled into THIS binary get a section; android is always
-        // present (a host-OS-agnostic crate) via a runtime gate. iOS is compiled into
-        // glass-mcp — and so gets a section — only on macOS (see this crate's Cargo.toml).
-        // No "not built into this binary" placeholders. Accessibility is per-OS (AT-SPI on
-        // Linux, UIA on Windows); macOS's grants (Screen Recording, Accessibility) live
-        // inside its own "macos" section rather than a separate accessibility section.
+        // present via a runtime gate, and iOS only on macOS. No "not built into this binary"
+        // placeholders.
         #[cfg(target_os = "linux")]
         assert_eq!(
             titles,

--- a/crates/glass-mcp/src/lib.rs
+++ b/crates/glass-mcp/src/lib.rs
@@ -104,14 +104,11 @@ pub fn make_platform(
             )));
         }
     };
-    // On Linux, AT-SPI serves both display backends, so the same reader is attached
-    // to each. It connects lazily on first snapshot; an absent a11y bus surfaces as
-    // AccessibilityUnavailable at call time, not here.
-    // Accessibility is per-OS: AT-SPI on Linux, UI Automation on Windows, AXUIElement on
-    // macOS. Each reader is attached unconditionally here — no silent fallback: a
-    // reader-specific failure (e.g. Linux's AT-SPI bus being unreachable, or macOS's
-    // Accessibility TCC grant being missing) surfaces as `AccessibilityUnavailable`
-    // (Linux/Windows) or `PermissionDenied` (macOS) at call time, not here.
+    // Accessibility is per-OS: AT-SPI on Linux (serving both display backends), UI Automation
+    // on Windows, AXUIElement on macOS. Each reader is attached unconditionally, with no
+    // silent fallback — a reader-specific failure (an unreachable AT-SPI bus, a missing macOS
+    // Accessibility grant) surfaces as `AccessibilityUnavailable` or `PermissionDenied` at
+    // call time, not here.
     #[cfg(windows)]
     let accessibility: Option<Box<dyn glass_core::Accessibility + Send>> =
         Some(Box::new(glass_a11y_windows::WindowsA11y::new()));

--- a/crates/glass-mcp/src/main.rs
+++ b/crates/glass-mcp/src/main.rs
@@ -8,17 +8,13 @@ use glass_mcp::{
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // One-time AppKit/WindowServer init (`NSApplication.sharedApplication`) — must run on
-    // the process's real main thread ("thread 0"), exactly once, before anything spawns the
-    // `glass-platform` worker thread that `GlassServer::new` (server.rs) parents every
-    // `MacosPlatform` call to. This is the FIRST statement of `main()`, with no `.await`
-    // above it: `#[tokio::main]`'s expansion builds the runtime and calls `Runtime::block_on`
-    // on the thread that invoked `main()` (thread 0), and `block_on` polls the async body
-    // itself on that same calling thread — so this line runs synchronously on thread 0
-    // during that first poll, strictly before `boot()`/`run_stdio()` below ever construct a
-    // `GlassServer` and spawn its worker thread. See glass-macos's `ffi::app_kit_init` doc
-    // for why one call here is sufficient —
-    // every later `MacosPlatform` call, from any thread, is a cheap no-op after this.
+    // One-time AppKit/WindowServer init — must run on the process's real main thread
+    // ("thread 0"), exactly once, before anything spawns the `glass-platform` worker thread
+    // that `GlassServer::new` parents every `MacosPlatform` call to. This is the FIRST
+    // statement of `main()`, with no `.await` above it: `#[tokio::main]` calls
+    // `Runtime::block_on` on the thread that invoked `main()` and polls the async body on
+    // that same thread, so this runs synchronously on thread 0, strictly before
+    // `boot()`/`run_stdio()` construct a `GlassServer`.
     #[cfg(target_os = "macos")]
     glass_macos::init_main_thread();
 

--- a/crates/glass-mcp/src/menubar.rs
+++ b/crates/glass-mcp/src/menubar.rs
@@ -100,12 +100,11 @@ mod macos {
         };
 
         if let Some(std_listener) = listener {
-            // We're on the `#[tokio::main]` block_on thread, so the runtime context is entered:
-            // `TcpListener::from_std` (reactor registration) and `tokio::spawn` both work here.
-            // VERIFY on-box: with the main thread blocked in `NSApplication::run`, the
-            // multi-thread runtime's worker threads must keep driving the I/O reactor + this
-            // spawned task — confirm the server actually accepts MCP connections while the menu
-            // bar is up (the whole premise of the visible daemon).
+            // We're on the `#[tokio::main]` block_on thread, so the runtime context is
+            // entered: `TcpListener::from_std` (reactor registration) and `tokio::spawn` both
+            // work here. With the main thread blocked in `NSApplication::run`, the
+            // multi-thread runtime's worker threads are what keep driving the I/O reactor and
+            // this spawned task.
             std_listener
                 .set_nonblocking(true)
                 .map_err(|e| anyhow::anyhow!("making the listener non-blocking: {e}"))?;

--- a/crates/glass-mcp/src/serve/mod.rs
+++ b/crates/glass-mcp/src/serve/mod.rs
@@ -100,14 +100,13 @@ fn build_router(cfg: &ServeConfig, server: GlassServer, cancel: &CancellationTok
     // `StreamableHttpServerConfig` is `#[non_exhaustive]`, so build it via the builder
     // rather than a struct literal.
     //
-    // rmcp's default `allowed_hosts` is loopback-only (`localhost`/`127.0.0.1`/`::1`) —
-    // a DNS-rebinding defense for *token-less* browser attacks. When a token is set,
-    // that allow-list would wrongly 403 a legitimate LAN client whose `Host` is the
-    // bind IP (the spec D1/D4 trusted-LAN-with-token case, incl. a `0.0.0.0` bind whose
-    // reachable IP we can't enumerate here). The bearer token is the real access
-    // control, and a rebinding attacker can't supply it, so the Host allow-list adds
-    // nothing once a token is required — disable it. With NO token (loopback-only per
-    // D4) we keep the default allow-list, where DNS-rebinding protection still matters.
+    // rmcp's default `allowed_hosts` is loopback-only (`localhost`/`127.0.0.1`/`::1`) — a
+    // DNS-rebinding defense for *token-less* browser attacks. When a token is set, that
+    // allow-list would wrongly 403 a legitimate LAN client whose `Host` is the bind IP,
+    // including a `0.0.0.0` bind whose reachable IP can't be enumerated here. The bearer
+    // token is the real access control and a rebinding attacker can't supply it, so the
+    // allow-list adds nothing once a token is required. With NO token we keep the default,
+    // where DNS-rebinding protection still matters.
     let mut http_cfg =
         StreamableHttpServerConfig::default().with_cancellation_token(cancel.clone());
     if cfg.token.is_some() {

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -118,11 +118,10 @@ impl GlassServer {
         F: FnOnce(&mut Glass) -> ToolResult + Send + 'static,
     {
         // Hand the (synchronous, possibly slow) tool body to the dedicated glass-platform
-        // thread and await its result. That thread — not an ephemeral blocking-pool thread —
-        // is the parent of any process the body spawns, so a sandboxed app's
-        // `--die-with-parent` only fires when glass itself exits. It also keeps blocking work
-        // off the async executor and serializes tools (glass has one session). A handler
-        // panic comes back as a loud error, never an unanswered request.
+        // thread and await its result: that thread, not an ephemeral blocking-pool thread,
+        // parents any process the body spawns, so a sandboxed app's `--die-with-parent` only
+        // fires when glass itself exits. A handler panic comes back as a loud error, never an
+        // unanswered request.
         let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
         if self.jobs.send((Box::new(f), reply_tx)).is_err() {
             return Ok(map_tool_result(Err(

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -1189,11 +1189,10 @@ mod tests {
 
     #[test]
     fn a11y_snapshot_truncation_steer_is_a_trusted_block_outside_the_untrusted_envelope() {
-        // Regression for the finding that glass's own truncation steer was getting baked
-        // into `render_compact`'s output and so ended up buried inside the untrusted
-        // envelope — under a directive telling the agent to ignore instructions in that
-        // block, even though the steer ("drive by pixels…") IS an instruction from glass
-        // itself. It must be its own trusted, unwrapped `OutContent::Text` block.
+        // glass's own truncation steer must not be baked into `render_compact`'s output, or
+        // it ends up inside the untrusted envelope — under a directive telling the agent to
+        // ignore instructions in that block, even though the steer ("drive by pixels…") IS
+        // one of glass's own. It gets its own trusted, unwrapped block.
         let mut g = glass_with_a11y(FakePlatform::new(100, 100), truncated_tree());
         g.start(&AppSpec {
             build: None,

--- a/crates/glass-mcp/src/tools/batch.rs
+++ b/crates/glass-mcp/src/tools/batch.rs
@@ -328,18 +328,14 @@ mod tests {
 
     #[test]
     fn then_settle_ignore_masks_a_blinking_pixel_so_it_settles() {
-        // Regression for `settle_args()` silently dropping `SettleArgs.ignore`
-        // instead of forwarding it into `WaitStableParams.ignore`: with no
-        // `#[serde(deny_unknown_fields)]` in this crate, a dropped field would
-        // still parse fine and just do nothing. Pixel (1,1) blinks across the
-        // three scripted frames — a stand-in for a blinking caret — while the
-        // rest of the 2x2 frame stays constant; only masking that rect lets it
-        // settle within `settle_frames`.
+        // `settle_args()` must forward `SettleArgs.ignore` into `WaitStableParams.ignore`:
+        // with no `#[serde(deny_unknown_fields)]` in this crate, a dropped field still parses
+        // and just does nothing. Pixel (1,1) blinks across the three scripted frames while
+        // the rest of the 2x2 stays constant, so only masking it settles within
+        // `settle_frames`.
         //
-        // Pinning the capture count to 3 (the frames actually supplied) rules
-        // out a generous timeout settling by outlasting the scripted frames
-        // into `FakePlatform`'s repeat-forever fallback, which would "settle"
-        // even without masking by comparing the repeated final frame to itself.
+        // Pinning the capture count to 3 rules out settling by outlasting the frames into
+        // `FakePlatform`'s repeat-forever fallback.
         let log = Arc::new(Mutex::new(0usize));
         let mut f0 = Frame::solid(2, 2, [10, 10, 10, 255]);
         let mut f1 = f0.clone();

--- a/crates/glass-mcp/src/tools/capture.rs
+++ b/crates/glass-mcp/src/tools/capture.rs
@@ -390,19 +390,14 @@ mod tests {
 
     #[test]
     fn wait_stable_with_ignore_masks_saw_motion_without_outlasting_scripted_frames() {
-        // Pixel (3,3) blinks every frame — a stand-in for a blinking text
-        // caret, a clock, a spinner — while the rest of the 4x4 frame stays
-        // constant. Without `ignore` reaching `WaitStableParams`, the full-
-        // frame comparison would never settle; masking it lets the
-        // otherwise-constant stream settle normally.
+        // Pixel (3,3) blinks every frame — a stand-in for a caret, a clock, a spinner —
+        // while the rest of the 4x4 frame stays constant, so without `ignore` reaching
+        // `WaitStableParams` the full-frame comparison never settles.
         //
-        // `settled:true` alone is NOT the discriminator here: a generous
-        // timeout would eventually settle even without `ignore` reaching
-        // core, once polling outlasts the 3 scripted frames into
-        // `FakePlatform`'s repeat-forever fallback (the repeated final frame
-        // compared to itself "settles" trivially, proving nothing about the
-        // wiring). `saw_motion:false` and pinning the capture count to
-        // exactly 3 (the frames actually supplied) are what rule that out.
+        // `settled:true` alone is NOT the discriminator: `FakePlatform` repeats its last
+        // supplied frame forever, so polling past the 3 scripted frames settles trivially
+        // even without `ignore` reaching core. `saw_motion:false` and pinning the capture
+        // count to 3 are what rule that out.
         let log = std::sync::Arc::new(std::sync::Mutex::new(0usize));
         let f0 = frame_4x4_corner([10, 0, 0, 255]);
         let f1 = frame_4x4_corner([20, 0, 0, 255]);

--- a/crates/glass-mcp/src/tools/wait.rs
+++ b/crates/glass-mcp/src/tools/wait.rs
@@ -271,14 +271,11 @@ mod tests {
 
     #[test]
     fn scroll_to_element_output_includes_resolved_direction() {
-        // Save is already on-screen and direction is omitted, so the resolved axis
-        // falls back to the default vertical sweep and is serialized under
-        // `scrolled.direction` — guarding `as_str` and the shape of the JSON output.
-        // This alone can't discriminate the `None`-inference wiring itself (see
-        // `scroll_to_element_infers_right_direction_for_offscreen_element` below):
-        // an on-screen target resolves to the same "down" default whether `None`
-        // correctly falls through to inference-then-default, or a regression just
-        // hardcodes `Some(Down)`.
+        // Save is already on-screen and `direction` is omitted, so the resolved axis falls
+        // back to the default vertical sweep — this guards `as_str` and the JSON shape. It
+        // cannot discriminate the `None`-inference wiring itself: an on-screen target
+        // resolves to "down" whether inference-then-default runs or a regression hardcodes
+        // `Some(Down)`. The off-screen test below is what tells those apart.
         let mut g = started_a11y();
         let mut a = scroll_args();
         a.name = Some("Save".into());
@@ -364,14 +361,10 @@ mod tests {
 
     #[test]
     fn scroll_to_element_infers_right_direction_for_offscreen_element() {
-        // Save sits off-screen to the right; `direction` is omitted. The static
-        // fixture tree never changes, so the sweep saturates after one step per
-        // direction without ever realizing Save on-screen — `matched:false`. But
-        // `scrolled.direction` reports the *resolved* direction regardless of
-        // `matched` (see `scroll_to_element`'s shared `outcome` tail), so asserting
-        // "direction":"right" here genuinely guards the `None`-inference wiring: a
-        // `None => Some(Down)` regression would report "down" instead, which this
-        // test would catch and the on-screen test above would not.
+        // Save sits off-screen to the right with `direction` omitted. The static fixture
+        // never changes, so the sweep saturates without realizing Save — `matched:false` —
+        // but `scrolled.direction` reports the *resolved* direction regardless, so "right"
+        // here guards the `None`-inference wiring the on-screen test above cannot.
         let mut g = started_a11y_with(fake_tree_offscreen_right());
         let mut a = scroll_args();
         a.name = Some("Save".into());
@@ -596,12 +589,9 @@ mod tests {
 
     #[test]
     fn region_bbox_is_window_relative_not_crop_relative() {
-        // A non-zero-origin region must report its change bbox in WINDOW
-        // coordinates, not relative to the crop (the window-relative-at-the-
-        // tool-boundary invariant; also keeps it consistent with glass_diff).
-        // Window 4x4, region {2,2,2,2}; the whole region flips black->white so
-        // the bbox covers the full crop: crop-relative would be (0,0), but
-        // window-relative must be (2,2).
+        // A non-zero-origin region must report its change bbox in WINDOW coordinates, not
+        // relative to the crop. Window 4x4, region {2,2,2,2}; the whole region flips
+        // black->white, so crop-relative would be (0,0) and window-relative must be (2,2).
         let black = Frame::solid(4, 4, [0, 0, 0, 255]);
         let white = Frame::solid(4, 4, [255, 255, 255, 255]);
         let mut g = glass_with(FakePlatform::new(4, 4).with_frames(vec![black, white]));
@@ -691,19 +681,13 @@ mod tests {
 
     #[test]
     fn region_with_ignore_masks_a_changing_rect_so_changes_never_matches() {
-        // Pixel (3,3) blinks between the reference (captured at call start,
-        // since no baseline is given) and the polled frame — a stand-in for a
-        // blinking text caret or a clock — while the rest of the 4x4 frame
-        // stays constant. Masking it means `until: "changes"` (the default)
-        // has nothing left to react to: the corner is the only pixel that
-        // ever differs, and it is excluded from the comparison.
+        // Pixel (3,3) blinks between the reference (captured at call start) and the polled
+        // frame — a stand-in for a blinking caret or a clock — while the rest of the 4x4
+        // stays constant, so masking it leaves `until: "changes"` nothing to react to.
         //
-        // `timeout_ms: 0` bounds the wait to exactly one poll after the
-        // reference capture, so a generous timeout letting `FakePlatform`
-        // outlast its scripted frames into its repeat-forever fallback can't
-        // be what makes this pass — the outcome is decided by that single
-        // real comparison. Pinning the capture count to 2 (reference + one
-        // poll) makes that explicit.
+        // `timeout_ms: 0` bounds the wait to one poll after the reference capture, so a
+        // generous timeout outlasting the scripted frames into `FakePlatform`'s
+        // repeat-forever fallback can't be what makes this pass.
         let log = std::sync::Arc::new(std::sync::Mutex::new(0usize));
         let f0 = frame_4x4_corner([10, 0, 0, 255]);
         let f1 = frame_4x4_corner([20, 0, 0, 255]);

--- a/crates/glass-sandbox-linux/src/lib.rs
+++ b/crates/glass-sandbox-linux/src/lib.rs
@@ -220,17 +220,15 @@ pub fn wrap_argv(program: &OsStr, args: &[OsString], opts: &WrapOpts) -> Vec<OsS
     for f in [
         "--unshare-user",
         "--unshare-ipc",
-        // NOTE: --unshare-pid is intentionally OMITTED: a PID namespace makes the
-        // child's std::process::id() return a namespace-relative PID (often 2),
-        // which is what it would write into _NET_WM_PID. glass's window-discovery
-        // then can't match the child by PID (it holds the host PID). Filesystem
-        // and network isolation are the threat-model goals; PID enumeration
-        // isolation is unnecessary when glass owns the sandboxed process.
+        // NOTE: --unshare-pid is intentionally OMITTED: a PID namespace makes the child's
+        // std::process::id() return a namespace-relative PID (often 2), which is what it
+        // would write into _NET_WM_PID — glass's window discovery then can't match the child,
+        // since it holds the host PID.
+        //
         // Security note: without a PID namespace the contained process can see host PIDs in
-        // /proc and send signals to same-UID processes (kill() needs no capability), including
-        // glass-mcp itself. This is an accepted trade-off for this slice — the primary goals are
-        // filesystem and network containment. A future improvement could pass _NET_WM_PID via an
-        // out-of-band channel (e.g. bwrap --json-status-fd) to restore PID-namespace isolation.
+        // /proc and can signal same-UID processes, glass-mcp included. Accepted trade-off —
+        // filesystem and network containment are the goals. Passing _NET_WM_PID out-of-band
+        // (bwrap --json-status-fd) would restore PID-namespace isolation.
         "--unshare-uts",
         "--unshare-cgroup-try",
         "--die-with-parent",
@@ -280,15 +278,13 @@ pub fn wrap_argv(program: &OsStr, args: &[OsString], opts: &WrapOpts) -> Vec<OsS
         // ancestor of one. Mirrors the `shadowed_roots` prefix logic in `launch_ro_binds`.
         //
         // `--tmpfs <home>` and `--tmpfs /tmp` mount ephemeral tmpfs over the real $HOME (hiding
-        // ~/.ssh etc.) and /tmp. If we also emit `--bind <cwd> <cwd>` and cwd equals a shadowed
-        // root (or is a parent of one — e.g. cwd="/home" with home="/home/u", or cwd="/tmp" now
-        // that cwd defaults to glass's current dir), that bind re-mounts the real subtree OVER the
-        // tmpfs, re-exposing everything we just hid.
+        // ~/.ssh etc.) and /tmp. A `--bind <cwd> <cwd>` where cwd equals a shadowed root — or
+        // is a parent of one, e.g. cwd="/home" with home="/home/u" — would re-mount the real
+        // subtree OVER the tmpfs, re-exposing everything just hidden.
         //
-        // `root.starts_with(&cwd_c)` is true when cwd equals a root or is an ancestor of it, so we
-        // skip the bind in both cases. The common subdir case (cwd="/home/u/proj" or "/tmp/scratch")
-        // gives false and is bound rw as usual. The `--ro-bind / /` + tmpfs already provide the path
-        // for the skipped cases so `--chdir` still works.
+        // `root.starts_with(&cwd_c)` is true in both cases. The common subdir case gives false
+        // and is bound rw as usual; `--ro-bind / /` plus the tmpfs still provide the path for
+        // the skipped cases, so `--chdir` works.
         let shadowed_roots = [home_c.as_path(), std::path::Path::new("/tmp")];
         if !shadowed_roots.iter().any(|root| root.starts_with(&cwd_c)) {
             v.push(OsString::from("--bind"));

--- a/crates/glass-sandbox-macos/src/reachability.rs
+++ b/crates/glass-sandbox-macos/src/reachability.rs
@@ -278,16 +278,11 @@ mod tests {
 
     // -------------------------------------------------------------------------
     // 8. Invariant over a mixed launch: no ro_binds entry is /, /Users, or a bare home root.
-    // LOAD-BEARING. MIXED: the REAL half runs a mixed launch (project dir, directory arg, relative
-    // arg, and the real "/" arg) through launch_reallows and asserts the invariant on the actual
-    // output. The PREDICATE half closes the gap the real half can't reach on this box (no /Users
-    // tree): it sweeps representative home-root paths and proves algebraically that
-    // `push_reallows` could never place one in ro_binds — is_home_root_or_above is true for /,
-    // /Users, and every bare home root (so push_reallows returns before touching either list), and
-    // for a file living directly under a bare home root, is_safe_reallow(dir_of(file)) is false (so
-    // even when not skipped outright, the routing is forced to ro_files, never ro_binds). Together
-    // these are exactly the two branches push_reallows has for reaching ro_binds — proving neither
-    // can produce a home-root entry closes the invariant.
+    // LOAD-BEARING. MIXED: the REAL half runs a mixed launch through launch_reallows and asserts
+    // the invariant on the actual output. The PREDICATE half closes the gap the real half can't
+    // reach on this box (no /Users tree): is_home_root_or_above is true for /, /Users and every
+    // bare home root, and for a file directly under a bare home root is_safe_reallow(dir_of) is
+    // false — exactly the two branches push_reallows has for reaching ro_binds.
     // -------------------------------------------------------------------------
     #[test]
     fn no_ro_bind_is_a_home_root_or_above() {

--- a/crates/glass-testapp/tests/common/mod.rs
+++ b/crates/glass-testapp/tests/common/mod.rs
@@ -15,12 +15,9 @@ use std::ops::Deref;
 pub mod mcp_ignore;
 
 // Verification-loop cost benchmark harness. Like `mcp_ignore` above, `pub mod mcp_cost;`
-// compiles this into every test binary that declares `mod common;` (integration.rs,
-// network.rs, harness_smoke.rs, ignore_regions_e2e.rs, wayland_ignore_regions_e2e.rs,
-// verification_cost.rs) — only verification_cost.rs actually calls it, but its
-// `#[cfg(test)]` unit tests run under `cargo test --workspace` regardless of which binary
-// pulls them in; this file's `#![allow(dead_code)]` covers the runtime-unused public API
-// for the other binaries.
+// compiles this into every test binary declaring `mod common;`, though only
+// verification_cost.rs calls it — this file's `#![allow(dead_code)]` covers the
+// runtime-unused public API for the others.
 pub mod mcp_cost;
 
 pub struct Xvfb(glass_x11::Xvfb);

--- a/crates/glass-wayland/src/command.rs
+++ b/crates/glass-wayland/src/command.rs
@@ -56,11 +56,10 @@ pub fn sway_config(spec: &AppSpec, runtime_dir: &Path, a11y_bind_dir: Option<&Pa
             let args: Vec<OsString> = spec.run[1..].iter().map(OsString::from).collect();
             // Default the working directory to glass's own cwd when the spec sets none, so a
             // contained launch with no `cwd` still gets `--chdir` + a guarded rw bind of that
-            // directory (matching `sandbox:"off"`) and any relative launch token resolves against
-            // it. Computed ONCE (as an `Option<PathBuf>`) and shared by both consumers verbatim:
-            // `launch_ro_binds` via `as_deref()` and `WrapOpts.cwd` by move. If `current_dir()`
-            // fails, the error is logged and both consumers see `None` (no `--chdir`/bind; relative
-            // tokens are skipped, never resolved against a wrong root).
+            // directory and any relative launch token resolves against it. Computed ONCE and
+            // shared by both consumers verbatim. If `current_dir()` fails, both see `None` —
+            // no `--chdir`/bind, and relative tokens are skipped rather than resolved against
+            // a wrong root.
             let effective_cwd = spec.cwd.clone().or_else(|| {
                 std::env::current_dir()
                     .inspect_err(|e| {

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -1037,16 +1037,13 @@ impl Platform for WaylandPlatform {
         // Runs once: a retried compositor bring-up must not re-run the build.
         glass_sandbox_linux::run_build(spec)?;
 
-        // Bring up the per-session compositor, retrying a transient failure once.
-        // A freshly-spawned headless Xwayland occasionally crashes mid-startup
-        // ("failed to read Wayland events: Broken pipe") on the GPU-less CI renderer
-        // — after the app has already mapped its window — leaving sway alive but the
-        // window never stable in its tree, so discovery times out. The crash is rare
-        // and independent per spawn, so re-spawning a fresh compositor makes it
-        // reliable. Only transient bring-up failures retry (Timeout / Backend); a
-        // genuine app exit or a config/sandbox error fails immediately. `bring_up`
-        // reaps its own sway+Xwayland process group on failure, so a retry never
-        // races a leftover compositor.
+        // Bring up the per-session compositor, retrying a transient failure once. A
+        // freshly-spawned headless Xwayland occasionally crashes mid-startup ("failed to read
+        // Wayland events: Broken pipe") on the GPU-less CI renderer — after the app has
+        // already mapped its window — leaving sway alive but the window never stable in its
+        // tree. The crash is rare and independent per spawn, so a fresh compositor makes it
+        // reliable. Only transient bring-up failures retry (Timeout / Backend); `bring_up`
+        // reaps its own process group, so a retry never races a leftover compositor.
         self.dbus = if spec.a11y {
             Some(glass_dbus_linux::PrivateBus::start().map_err(|e| {
                 GlassError::AccessibilityUnavailable(format!(

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -592,12 +592,11 @@ fn onbox_handoff_grace() {
         std::thread::sleep(Duration::from_millis(800));
     }
 
-    // Win11 Notepad's launcher hands its UI to a DESCENDANT process and the launcher exits, so the
-    // window is owned by a child in the pid-set (a cold no-hint launch was measured to yield
-    // app_pids=[<descendant>, <root>] and a real window). discover_window's grace period — keep polling
-    // while the pid-set still holds a live descendant — must adopt that window even with NO hint
-    // (the PR #14 behavior; pre-#14 this fast-failed AppExited before the descendant's window mapped).
-    // The no-hint fast-fail-on-true-crash path is covered by the discovery::poll_decision unit tests.
+    // Win11 Notepad's launcher hands its UI to a DESCENDANT process and the launcher exits, so
+    // the window is owned by a child in the pid-set (a cold no-hint launch was measured to
+    // yield app_pids=[<descendant>, <root>] and a real window). discover_window's grace period
+    // — keep polling while the pid-set still holds a live descendant — must adopt that window
+    // even with NO hint.
     kill_notepad();
     let mut p = WindowsPlatform::new().expect("WindowsPlatform::new");
     let spec = AppSpec {

--- a/crates/glass-x11/src/command.rs
+++ b/crates/glass-x11/src/command.rs
@@ -34,11 +34,10 @@ pub fn build_command(spec: &AppSpec, display: &str, a11y: Option<glass_core::A11
             let args: Vec<OsString> = spec.run[1..].iter().map(OsString::from).collect();
             // Default the working directory to glass's own cwd when the spec sets none, so a
             // contained launch with no `cwd` still gets `--chdir` + a guarded rw bind of that
-            // directory (matching `sandbox:"off"`) and any relative launch token resolves against
-            // it. Computed ONCE (as an `Option<PathBuf>`) and shared by both consumers verbatim:
-            // `launch_ro_binds` via `as_deref()` and `WrapOpts.cwd` by move. If `current_dir()`
-            // fails, the error is logged and both consumers see `None` (no `--chdir`/bind; relative
-            // tokens are skipped, never resolved against a wrong root).
+            // directory and any relative launch token resolves against it. Computed ONCE and
+            // shared by both consumers verbatim. If `current_dir()` fails, both see `None` —
+            // no `--chdir`/bind, and relative tokens are skipped rather than resolved against
+            // a wrong root.
             let effective_cwd = spec.cwd.clone().or_else(|| {
                 std::env::current_dir()
                     .inspect_err(|e| {

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -1062,15 +1062,12 @@ impl Platform for X11Platform {
             )));
         }
         glass_sandbox_linux::run_build(spec)?;
-        // Opt-in private, isolated a11y bus (its own XDG_RUNTIME_DIR — never touches the
-        // host /run/user/UID/at-spi/) so the launched app publishes an AT-SPI tree. Only
-        // when the caller asked for it (`a11y: true`). The caller explicitly opted into
-        // a11y, so a bus that can't start now fails the launch with the real cause rather
-        // than silently degrading — nothing is leaked on this early return (`PrivateBus::start`
-        // reaps its own partial children on failure, and no app child / per-launch resource
-        // has been spawned yet at this `?`). For sandboxed launches, `spawn` binds the private
-        // bus dir into the bwrap run so the confined app can reach the advertised
-        // unix:path= sockets.
+        // Opt-in private, isolated a11y bus (its own XDG_RUNTIME_DIR — never the host
+        // /run/user/UID/at-spi/) so the launched app publishes an AT-SPI tree. The caller
+        // explicitly opted in, so a bus that can't start fails the launch with the real cause
+        // rather than silently degrading; nothing is leaked on this early return, since
+        // `PrivateBus::start` reaps its own partial children and no app child exists yet. For
+        // sandboxed launches, `spawn` binds the private bus dir into the bwrap run.
         self.dbus = if spec.a11y {
             Some(glass_dbus_linux::PrivateBus::start().map_err(|e| {
                 glass_core::GlassError::AccessibilityUnavailable(format!(


### PR DESCRIPTION
A comment carries one fact the reader cannot get from the code, in one
sentence. This applies that across all 20 crates: the fact stays, the
sentences arguing for it go.

**Comments only.** Almost entirely non-doc `//` comments — `// SAFETY:`
blocks are left as they stand, since a soundness argument is the point
rather than padding. One `///` block is touched, for a contradiction
rather than for length (see below). The diff contains no code lines:

```
git diff master -U0 | rg '^[+-]' | rg -v '^[+-]{3}' \
  | rg -v '^[+-]\s*(//|/\*|\*)' | rg -v '^[+-]\s*$'
```

is empty over the whole branch. 46 files, 10747 -> 6347 words (-41%).

## What was kept

Every hazard and platform fact, including the ones that are the whole
reason a comment exists:

- the trailing-toggle gate keyed on backend capability, not geometry —
  a desktop labeled checkbox is row-shaped too, with a *leading*
  indicator
- the native-invoke fallback allowlist: only an attempt that dispatched
  nothing may retry with the pointer, or the control actuates twice
- `PR_SET_PDEATHSIG` being thread-scoped, so a sandboxed app must be
  parented to a process-lifetime thread
- Sandboxie filtering `WM_CLOSE` across the box boundary
- the ~25s D-Bus portal-activation hang a `<servicedir>`-less config avoids
- `ERROR_PIPE_CONNECTED` being a connected client that `.is_ok()` drops
- the X11 teardown measurement where 4 of 10 runs lost the close request
- the two distinguishable Wayland typing flakes — a substitution must
  never be retried away, a dropped key may be

Also kept: the fixture notes that say what makes a test discriminate
(`FakePlatform` repeating its last frame forever is why capture counts
are pinned), and the role-matrix epistemics — what was observed on a
device versus what is a rule about the platform.

## What went

The sentence after the fact: the restatement at greater length, the
defence against an objection the code does not invite, the enumeration
a named helper already carries, and coverage narration about which
sibling test covers which path.

Two things surfaced that are worth a look independent of the wording:

- **Stale planning references in public trees.** `Plan 4 design
  decision 2`, `Task 1/2/4`, `final-review fix 1/3`, `fix 4`, two
  `VERIFY on-box:` checklists reading as open work, and a private-spec
  `D1/D4` reference in `serve/mod.rs`. The fact under each is kept; the
  narration is gone.
- **`fn sw()` in `glass-core/src/session/a11y.rs` had two stacked `///`
  blocks that contradicted each other** — the first called the fixture
  a `CheckBox`, the code builds `AxRole::ToggleButton`, and the second
  block existed to say so. The first predates the switch subrole
  normalization and was never removed. Merged into one block, keeping
  every fact and stating the hazard once. A scan for the same signature
  across the workspace found no other instance.

## Verification

- whole-branch diff proven comment-only (command above)
- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace` — 1883 passed, 0 failed
- all 18 CI checks green, including the macOS and Windows legs, whose
  cfg-gated bodies do not build on a Linux host

🤖 Generated with [Claude Code](https://claude.com/claude-code)