### PR TITLE
docs: a terse-comments sweep over the workspace's doc comments

### DIFF
--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -363,9 +363,9 @@ impl WalkLimits {
     /// controls the node count ONLY — `depth` and `siblings` always keep their defaults. Those
     /// two are structural safety rails, not a size budget: the recursive native-tree walkers
     /// (AT-SPI / AX / UIA) have no cycle detection, so an unbounded depth on a cyclic or
-    /// pathological tree would recurse to a stack overflow (which aborts the process). The
-    /// generous defaults (`MAX_DEPTH`/`MAX_SIBLINGS`) never bite a real UI, so keeping them costs
-    /// the caller nothing while preserving that backstop even under `max_nodes: 0`.
+    /// pathological tree would recurse to a stack overflow, which aborts the process.
+    /// `MAX_DEPTH`/`MAX_SIBLINGS` never bite a real UI, so the backstop holds even at
+    /// `max_nodes: 0`.
     pub fn from_max_nodes(max_nodes: Option<usize>) -> WalkLimits {
         match max_nodes {
             None => WalkLimits::DEFAULT,
@@ -813,10 +813,9 @@ pub trait Accessibility {
 
     /// Subscribe to change notifications for the app described by `ctx`.
     ///
-    /// `None` — the default — means this reader has no event stream, and its callers keep polling
-    /// exactly as they did before. Two readers cannot have one as built: Android's `uiautomator`
-    /// reader is a dump per call and iOS's is an `idb describe` per call. Android's *other* reader,
-    /// the on-device accessibility service, is driven by events and is the natural next one.
+    /// `None` — the default — means this reader has no event stream and its callers keep polling.
+    /// Two readers cannot have one as built: Android's `uiautomator` reader is a dump per call,
+    /// and iOS's is an `idb describe` per call.
     ///
     /// Subscribe before the first read, not after: a change that lands after a read but before the
     /// subscription is announced to nobody, and the caller then waits out its *entire* budget on a

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -677,9 +677,7 @@ fn first_label(node: &AxNode) -> Option<String> {
 /// contains the point; the smallest-area match wins when several do (an outer window
 /// fully behind/around a smaller popover shouldn't shadow it). If several windows tie
 /// on area, the first one in `windows`' order wins (`min_by_key` keeps the first
-/// minimum) — i.e. whatever order the platform's `list_windows` enumerated them in;
-/// this doesn't matter in practice since same-area overlapping windows aren't a shape
-/// any backend produces.
+/// minimum) — whatever order the platform's `list_windows` enumerated them in.
 ///
 /// Known best-effort limitation: this detection is purely geometric — it has no way to
 /// tell "the app's own popover" apart from an unrelated second top-level window of the
@@ -740,8 +738,7 @@ fn ancestor_path(root: &AxNode, target: AxNodeId) -> Option<Vec<&AxNode>> {
 /// tracks the popover's size most tightly, while wrappers trimmed by padding/scrollbars
 /// drift further from it. Ties (equal score) break toward the shallower ancestor — the
 /// one closer to `root` — since `ancestor_path` walks root-to-target and `min_by_key`
-/// keeps the first minimum; in practice two ancestors matching to the exact same pixel
-/// is vanishingly rare (padding/scrollbar trims almost always differ by at least 1px).
+/// keeps the first minimum.
 fn menu_container_bounds(
     root: &AxNode,
     target: AxNodeId,

--- a/crates/glass-macos/src/axwindow.rs
+++ b/crates/glass-macos/src/axwindow.rs
@@ -11,11 +11,10 @@
 //! [`_AXUIElementGetWindow`] is the well-known private symbol every AX-based window
 //! manager (Rectangle, yabai, BetterDisplay, Hammerspoon) uses for exactly this: given an
 //! `AXUIElementRef`, it writes out the `CGWindowID` that window belongs to. It is
-//! undocumented, unversioned, and Apple could remove or rename it in any macOS release —
-//! the same posture this codebase takes with other private APIs (e.g. the planned
-//! `CGVirtualDisplay` provider): contained in one module, never the *only* path, and
-//! flagged here so a later maintainer knows to re-validate it against each new macOS
-//! major. [`ax_window_for_cgwindowid`] never trusts it exclusively: if the private call
+//! undocumented, unversioned, and Apple could remove or rename it in any macOS release, so
+//! it is contained in one module, never the *only* path, and flagged here so a later
+//! maintainer knows to re-validate it against each new macOS major.
+//! [`ax_window_for_cgwindowid`] never trusts it exclusively: if the private call
 //! errors on *every* enumerated window (the "symbol looks broken" signal — distinct from
 //! "this particular window just isn't among them"), it falls back to matching the
 //! `AXUIElement`'s own position/size (converted points -> pixels via

--- a/crates/glass-macos/src/backend.rs
+++ b/crates/glass-macos/src/backend.rs
@@ -1,6 +1,4 @@
-//! The macOS `Platform` backend. Plan 1 lands the struct + trait surface with the
-//! window-server methods stubbed; Plan 2 fills capture + display provisioning, Plan 3
-//! input, Plan 4 windows. `new()` runs the TCC preflight so a missing grant fails fast.
+//! The macOS `Platform` backend. `new()` runs the TCC preflight so a missing grant fails fast.
 
 use std::path::Path;
 use std::process::Child;
@@ -25,41 +23,32 @@ use crate::permissions;
 use crate::process::{self, ClipLaunch, LogSink};
 use crate::settle::{SettleOutcome, settle_by_polling};
 
-/// Poll interval between discovery attempts in [`MacosPlatform::discover_window`] —
-/// matches `scwindow::find_window_for_pids`'s own poll cadence
-/// (`poll_until(100, ..)`), which that loop takes over here so it can also race
-/// against `child.try_wait()`.
+/// Poll interval between discovery attempts in [`MacosPlatform::discover_window`], which
+/// reimplements `scwindow::find_window_for_pids`'s `poll_until(100, ..)` loop so it can also
+/// race `child.try_wait()`.
 const DISCOVERY_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Timeout for the fresh per-call window re-resolution [`MacosPlatform::capture_frame`],
-/// [`MacosPlatform::send_pointer`], and [`MacosPlatform::send_key`] each do on every call
-/// (via `scwindow::find_window_by_id` when `active_window` is set, else
-/// `scwindow::find_window_for_pids`). Short (unlike `start_app`'s `spec.timeout_ms`, which
-/// waits for a brand-new window to first appear): the window is already known to have
-/// existed as of the last successful call, so this only needs to cover the ordinary
-/// query-round-trip latency, not a real "is the app even launching" wait.
+/// [`MacosPlatform::send_pointer`], and [`MacosPlatform::send_key`] each do (via
+/// `scwindow::find_window_by_id` when `active_window` is set, else
+/// `scwindow::find_window_for_pids`). Covers a query round trip, not a launch: the window
+/// existed as of the last successful call, unlike `start_app`'s `spec.timeout_ms`.
 const WINDOW_RESOLVE_TIMEOUT: Duration = Duration::from_millis(2000);
 
 /// How often to re-read an adopted window's geometry while waiting for it to stop changing, and
 /// how long to keep waiting. macOS reports a window's geometry while it is still opening, so the
-/// reading adoption captured is routinely a frame of the open animation (#263). `settle_window`'s
-/// own read is an `SCShareableContent` query; its per-call cost was never isolated here — that
-/// would need an A/B against a build without the settle. The only measured number available is a
-/// different reader's: the probe's dense early-sampling loop (`tests/window_adopt_probe.rs`)
-/// clocked `platform.window(&WindowOp::Geometry)`, an AX read, at ~45-100ms per call. Adding
-/// `SETTLE_POLL_INTERVAL` gives ~70-125ms as arithmetic, not a measurement of this path. A window
-/// still moving at adoption needs at least one further poll before two consecutive readings can
-/// agree — 11 of the 12 cold launches measured for #263 fell into that case. The budget bounds a
-/// window that never stops moving at all (a clock, a video player, an animating splash).
+/// reading adoption captured is routinely a frame of the open animation — 11 of the 12 cold
+/// launches measured for #263 needed at least one further poll before two readings agreed. This
+/// path's own per-poll cost was never isolated; the nearest measurement is a different reader's,
+/// `tests/window_adopt_probe.rs` clocking an AX `WindowOp::Geometry` read at ~45-100ms. The
+/// budget bounds a window that never stops moving at all (a clock, a video player, a splash).
 const SETTLE_POLL_INTERVAL: Duration = Duration::from_millis(25);
 const SETTLE_BUDGET: Duration = Duration::from_millis(500);
-/// Per-poll resolution bound, deliberately far below [`WINDOW_RESOLVE_TIMEOUT`] (a tenth of it):
-/// a settle poll that cannot find the window ends the settle attempt outright rather than
-/// retrying (see [`crate::settle::settle_by_polling`]'s `ReadFailed` handling), so this only
-/// bounds how long that one lookup burns before giving up. `settle_by_polling` checks its
-/// deadline only between reads, never mid-read, so `SETTLE_BUDGET` is a soft cap: a resolve
-/// that runs close to this full timeout right before the deadline can push actual elapsed time
-/// past `SETTLE_BUDGET` by nearly as much.
+/// Per-poll resolution bound, a tenth of [`WINDOW_RESOLVE_TIMEOUT`]: a settle poll that cannot
+/// find the window ends the settle attempt outright rather than retrying (see
+/// [`crate::settle::settle_by_polling`]'s `ReadFailed` handling). `settle_by_polling` checks its
+/// deadline only between reads, so `SETTLE_BUDGET` is a soft cap — a resolve starting just
+/// before the deadline can overrun it by nearly this much.
 const SETTLE_RESOLVE_TIMEOUT: Duration = Duration::from_millis(200);
 
 /// Read-back tolerance (pixels) [`MacosPlatform::window`]'s mutating ops use to decide
@@ -69,31 +58,22 @@ const SETTLE_RESOLVE_TIMEOUT: Duration = Duration::from_millis(200);
 /// enough to absorb point<->pixel rounding across a position/size round trip without masking
 /// a real refusal.
 ///
-/// This is deliberately a *separate* constant from [`REQUEST_EPSILON_PX`] (final-review fix
-/// 3): using this same 8px value to also decide "was a change requested at all" let a
-/// fully-refused Move/Resize whose target happened to be within 8px of the window's starting
-/// position report success — the read-back (unchanged, since it was refused) was
-/// coincidentally within 8px of a target that was itself only a few pixels away. Splitting
-/// "was a change requested" (tight, `REQUEST_EPSILON_PX`) from "does the read-back match"
-/// (loose, this constant) closes that hole.
+/// Do not also use this to decide whether a change was requested at all (that is
+/// [`REQUEST_EPSILON_PX`]): with one 8px constant for both roles, a fully-refused Move/Resize
+/// whose target sat within 8px of the window's starting position reported success.
 const WINDOW_OP_TOLERANCE_PX: i32 = 8;
 
 /// Threshold (pixels) [`move_took_effect`]/[`resize_was_refused`] use to decide whether a
-/// `Move`/`Resize` request asked for a genuinely different position/size than the window
-/// already had — as opposed to [`WINDOW_OP_TOLERANCE_PX`], which judges whether the
-/// *read-back* matches the *request*. Kept tight (well under `WINDOW_OP_TOLERANCE_PX`) so a
-/// real (if small) requested change that's totally refused — the read-back stays at the
-/// window's original position/size — is still caught as a refusal rather than waved through
-/// because the unmoved position happens to already sit within `WINDOW_OP_TOLERANCE_PX` of
-/// the target. See both functions' docs for the exact logic.
+/// `Move`/`Resize` asked for a genuinely different position/size than the window already had —
+/// as opposed to [`WINDOW_OP_TOLERANCE_PX`], which judges whether the *read-back* matches the
+/// *request*. Must stay well under it, or a small real change that was totally refused reads as
+/// no change requested.
 const REQUEST_EPSILON_PX: i32 = 2;
 
-/// macOS backend. v1 renders the target app onto a `CGVirtualDisplay` (Plan 2) and
-/// drives it with ScreenCaptureKit + CGEvent + AXUIElement.
+/// macOS backend, driving the target app with ScreenCaptureKit + CGEvent + AXUIElement.
 pub struct MacosPlatform {
-    /// Logs drained by `drain_logs`, filled by `process::spawn`'s per-stream reader
-    /// threads once `start_app` exists (Plan 2). `Arc<Mutex<_>>` because those threads
-    /// push into it concurrently with `drain_logs` reading it here. Empty until
+    /// Logs drained by `drain_logs`, filled by `process::spawn`'s per-stream reader threads —
+    /// `Arc<Mutex<_>>` because those threads push while `drain_logs` reads. Empty until
     /// `start_app` launches a child.
     logs: LogSink,
     /// The launched app's root pid; `None` until `start_app`.
@@ -102,13 +82,10 @@ pub struct MacosPlatform {
     /// it. `None` until `start_app` and after `stop_app` (idempotent).
     child: Option<Child>,
     /// The active window's `CGWindowID` — the implicit target of `capture_frame`/
-    /// `send_pointer`/`send_key`, per the `Platform` contract. `start_app` sets it to the
-    /// first window discovered for the launched app; `select_window` (Plan 4 Task 5) is
-    /// the only other place that changes it, and is exactly the "retargeting" the
-    /// `Platform` contract describes — once an agent picks a different window, capture and
-    /// input follow it. `None` only before any `start_app` call (or after `stop_app`),
-    /// meaning "no window chosen yet"; every per-call resolver below falls back to the
-    /// original first-on-screen-by-pid lookup in that case.
+    /// `send_pointer`/`send_key`, per the `Platform` contract. Set by `start_app` to the first
+    /// window discovered, and by `select_window`; `None` before `start_app` and after
+    /// `stop_app`, where every per-call resolver below falls back to the
+    /// first-on-screen-by-pid lookup.
     active_window: Option<u32>,
     /// How `get_clipboard`/`set_clipboard` route the active session's clipboard. Decided in
     /// `start_app` (success path, from `clip` below plus a live `clipboard::shim_present`
@@ -116,29 +93,21 @@ pub struct MacosPlatform {
     /// `crate::clipboard_route`'s module doc for the full decision and the three routes.
     clipboard_route: ClipboardRoute,
     /// The clip-shim launch facts `process::spawn` produced for the current session's app —
-    /// `Some` only for a contained, injectable launch (see `process::ClipLaunch`'s doc).
-    /// `None` until `start_app`, and whenever the launch was uncontained or non-injectable.
-    /// Held here (rather than consumed inside `start_app`) so the clipboard-routing decision
-    /// that depends on it can run after the launched window is confirmed; reset in
+    /// `Some` only for a contained, injectable launch (see `process::ClipLaunch`'s doc), `None`
+    /// otherwise and until `start_app`. Held here, not consumed inside `start_app`, so the
+    /// clipboard-routing decision can run after the launched window is confirmed; reset in
     /// `stop_app`.
     clip: Option<ClipLaunch>,
     /// Set when the active window belongs to a LaunchServices-adopted app — one `start_bundle`
-    /// handed off to `NSWorkspace` because the direct-spawned inner executable exited before a
-    /// window appeared (see `start_bundle`'s doc). `None` in every other case, including a
-    /// bundle that direct-spawned successfully (`self.child` is `Some` then, same as a plain
-    /// exec). The [`Adopted`]'s `disposition` records how `stop_app`/`Drop` must reap it:
-    /// `Fresh` when this call's own `ffi::launch_bundle` started the app (glass terminates it),
-    /// `PreExisting` when `ffi::running_pid_for_bundle_id` found an instance already running
-    /// before this call (glass leaves it running rather than killing an app it didn't start).
+    /// handed off to `NSWorkspace` (see its doc). `None` otherwise, including a bundle that
+    /// direct-spawned successfully. The [`Adopted`]'s `disposition` records how `stop_app`/
+    /// `Drop` must reap it: `Fresh` when `ffi::launch_bundle` started the app (glass terminates
+    /// it), `PreExisting` when it was already running (glass leaves it).
     adopted: Option<Adopted>,
 }
 
-/// A LaunchServices-adopted app tracked by `start_bundle`'s handoff path, bundled with the
-/// decision of how `stop_app`/`Drop` must reap it. Replaces the former bare `(i32, bool)`
-/// pair so the pid and its reap disposition travel together as one named unit, and the reap
-/// decision itself lives in a pure, testable predicate
-/// ([`crate::bundle::Disposition::should_terminate`]) rather than a lone `bool` hand-decoded
-/// identically at the two reap sites.
+/// A LaunchServices-adopted app tracked by `start_bundle`'s handoff path, paired with how
+/// `stop_app`/`Drop` must reap it ([`crate::bundle::Disposition::should_terminate`]).
 struct Adopted {
     /// The adopted app's pid — an `NSRunningApplication` process id, always non-negative.
     pid: i32,
@@ -149,15 +118,11 @@ struct Adopted {
 
 impl Adopted {
     /// Reap the adopted app iff glass started it
-    /// ([`crate::bundle::Disposition::should_terminate`]). Uses [`crate::ffi::terminate_app`],
-    /// which is graceful-only (`-[NSRunningApplication terminate]`, no `SIGKILL`
-    /// escalation): an app that vetoes quit (e.g. an unsaved-changes sheet) is left running
-    /// by design, trading a possible stray process for never forcibly killing an app
-    /// mid-edit and losing the user's work.
-    ///
-    /// Having no escalation to fall back to is exactly why a failed request is *reported*: it
-    /// is the only thing left to do with it, and `stop_app` otherwise returns success while an
-    /// app glass launched is still on screen.
+    /// ([`crate::bundle::Disposition::should_terminate`]). [`crate::ffi::terminate_app`] is
+    /// graceful-only (`-[NSRunningApplication terminate]`, no `SIGKILL` escalation), so an app
+    /// that vetoes quit (an unsaved-changes sheet) is left running by design rather than killed
+    /// mid-edit. With no escalation to fall back to, a failed request is reported: otherwise
+    /// `stop_app` returns success while an app glass launched is still on screen.
     fn reap(self) {
         if self.disposition.should_terminate() && !crate::ffi::terminate_app(self.pid) {
             eprintln!(
@@ -211,18 +176,13 @@ impl MacosPlatform {
     /// Poll for `child`'s window, alternating a single
     /// [`crate::scwindow::query_once_with_candidates`] discovery attempt with
     /// `child.try_wait()` so a crashed launch fails fast with [`GlassError::AppExited`]
-    /// instead of riding out the whole `timeout_ms` budget waiting for a window that will
-    /// never appear — mirrors `glass-x11/src/platform.rs`'s `discover_window`. Can't
-    /// delegate this to `scwindow::find_window_for_pids`: that helper owns its *entire*
-    /// poll loop internally, with no child handle to race against.
+    /// instead of riding out the whole `timeout_ms` budget — mirrors
+    /// `glass-x11/src/platform.rs`'s `discover_window`. Can't delegate to
+    /// `scwindow::find_window_for_pids`: that helper owns its *entire* poll loop internally,
+    /// with no child handle to race against.
     ///
-    /// Returns the whole [`crate::scwindow::WindowMatch`] (not just its `geometry`), even
-    /// though `start_app` only reads `geometry` from it today — `send_pointer` does its own
-    /// independent, fresh `scwindow::find_window_for_pids` resolution per call rather than
-    /// reusing anything cached here (see its doc), so this return type is just the natural
-    /// shape of a `query_once_with_candidates` result, not evidence of caching elsewhere. The
-    /// match's `geometry` is the settled one — [`Self::settle_window`] re-reads past the
-    /// adoption instant before this returns (#263).
+    /// Returns the whole [`crate::scwindow::WindowMatch`], whose `geometry` is the settled one
+    /// — [`Self::settle_window`] re-reads past the adoption instant before this returns (#263).
     fn discover_window(
         child: &mut Child,
         pid: u32,
@@ -255,13 +215,11 @@ impl MacosPlatform {
     }
 
     /// Poll for a window owned by `pid` alone, with no `Child` to race against —
-    /// `start_bundle`'s handoff path adopts a pid `NSWorkspace`/LaunchServices owns (found
-    /// already-running via `ffi::running_pid_for_bundle_id`, or just started via
-    /// `ffi::launch_bundle`), so unlike [`discover_window`] there is no local `Child` handle
-    /// (`std::process::Child`) to `try_wait` if the adopted app dies before its window
-    /// appears; this loop only re-queries `scwindow::query_once_with_candidates` until
-    /// `timeout_ms` elapses. Like [`discover_window`], the returned match's `geometry` is the
-    /// settled one, not the adoption-instant reading.
+    /// `start_bundle`'s handoff path adopts a pid LaunchServices owns, so unlike
+    /// [`discover_window`] there is no `std::process::Child` to `try_wait` if the adopted app
+    /// dies before its window appears; this loop only re-queries
+    /// `scwindow::query_once_with_candidates` until `timeout_ms` elapses. The returned match's
+    /// `geometry` is the settled one.
     fn discover_window_pid(pid: i32, timeout_ms: u64) -> Result<crate::scwindow::WindowMatch> {
         crate::ffi::app_kit_init();
         let deadline = Instant::now() + Duration::from_millis(timeout_ms.max(1));
@@ -282,29 +240,22 @@ impl MacosPlatform {
     /// carrying that settled geometry.
     ///
     /// Adoption reads the window's geometry the moment it finds it, which on macOS is routinely
-    /// mid-open-animation — 11 of 12 cold launches measured on 2026-08-01 returned a geometry a few
-    /// pixels off the settled one, and the geometry `start_app` reports for it is what
-    /// `Glass::start_on_inner` hands the caller and caches as the session's geometry.
+    /// mid-open-animation — 11 of 12 cold launches measured on 2026-08-01 returned a geometry a
+    /// few pixels off the settled one, and that geometry is what `Glass::start_on_inner` hands
+    /// the caller and caches as the session's geometry.
     ///
-    /// Thin glue over [`settle_by_polling`]: this only builds the per-poll re-resolution closure
-    /// (fixed to `window_id` and `pid`, since a re-resolved match always carries the same two —
-    /// `find_window_by_id` is what pins them) and turns its [`SettleOutcome`] into the
-    /// stderr disclosure. Never fails the launch: a window that never stops changing (a clock, a
-    /// video player, an animating splash) would otherwise become unlaunchable, so a budget expiry
-    /// reports the freshest reading rather than an error, and likewise a resolve that fails
-    /// mid-settle, where the window was already confirmed present at adoption. Neither path is
-    /// silent.
+    /// Never fails the launch: a window that never stops changing (a clock, a video player, an
+    /// animating splash) would otherwise become unlaunchable, so a budget expiry reports the
+    /// freshest reading rather than an error, as does a resolve that fails mid-settle. Neither
+    /// path is silent.
     ///
     /// Settles on `geometry` alone, not the whole [`crate::scwindow::WindowMatch`] — `geometry`
     /// is rounded-to-pixel (`(v * scale).round()`), but `WindowMatch::origin_pt` is the raw
-    /// unrounded point origin it was rounded from, so two readings can agree on `geometry` while
-    /// `origin_pt` keeps drifting inside the same pixel. Comparing the whole match would make
-    /// that drift block settling forever for a window whose on-screen geometry had already
-    /// stopped changing (#263 review). The closure captures every other field of the freshest
-    /// successful read in `freshest` as it goes, so the returned match still carries them.
-    ///
-    /// Only *when* the geometry is read changes here. Which window was adopted is already decided
-    /// by the time this runs.
+    /// unrounded point origin, so two readings can agree on `geometry` while `origin_pt` keeps
+    /// drifting inside the same pixel. Comparing the whole match makes that drift block settling
+    /// forever for a window that had already stopped moving on screen (#263 review). The closure
+    /// captures every other field of the freshest successful read, so the returned match still
+    /// carries them.
     fn settle_window(
         pid: i32,
         adopted: crate::scwindow::WindowMatch,
@@ -353,19 +304,13 @@ impl MacosPlatform {
     }
 
     /// Resolve the window `capture_frame`/`send_pointer`/`send_key` should target *this*
-    /// call: `scwindow::find_window_by_id(active_window, [pid], ..)` once `select_window`
-    /// (or `start_app`'s initial discovery) has set an active `CGWindowID` — the retargeting
-    /// the `Platform` contract requires (see the `active_window` field's doc) — falling back
-    /// to the pre-Plan-4 "first on-screen window for this pid" lookup when nothing is
-    /// selected yet. Always fresh (never cached): mirrors `find_window_for_pids`'s own
-    /// per-call re-resolution, since the window may have moved/resized/closed since the last
-    /// call.
+    /// call: `scwindow::find_window_by_id(active_window, [pid], ..)` once an active
+    /// `CGWindowID` is set, falling back to the "first on-screen window for this pid" lookup
+    /// when nothing is selected yet. Always fresh (never cached): the window may have
+    /// moved/resized/closed since the last call.
     ///
-    /// Passes `&[pid]` to `find_window_by_id` (final-review fix 1): `active_window` is only
-    /// ever set to an id this backend itself resolved for `pid`, but scoping the lookup here
-    /// too means a stale/foreign id can never silently resolve to another app's window — it
-    /// surfaces `GlassError::WindowNotFound` instead, exactly like every other resolution
-    /// path in this module.
+    /// Scoped to `&[pid]` so a stale or foreign id can never silently resolve to another app's
+    /// window — it surfaces `GlassError::WindowNotFound` instead.
     fn resolve_active_window(&self, pid: i32) -> Result<crate::scwindow::WindowMatch> {
         match self.active_window {
             Some(id) => crate::scwindow::find_window_by_id(id, &[pid], WINDOW_RESOLVE_TIMEOUT),
@@ -374,47 +319,35 @@ impl MacosPlatform {
     }
 
     /// `start_app`'s bundle path, taken when `spec.run[0]` names a `.app` directory
-    /// (`bundle::is_app_bundle`): A-preferred, direct-spawn the bundle's inner executable
+    /// (`bundle::is_app_bundle`): direct-spawn the bundle's inner executable
     /// (`bundle::resolve_inner_exec`) exactly like a plain exec — same logs, containment, and
-    /// window-tracking as the non-bundle path — and only fall back to handing the launch off
-    /// to `NSWorkspace` if that direct spawn's process exits before a window ever appears
-    /// (`GlassError::AppExited` — an app that re-execs itself via LaunchServices and leaves the
-    /// direct-spawned process a dead stub, or one the kernel refused to run as a child at all;
-    /// see the platform-code note below). Any other discovery failure (e.g.
-    /// `GlassError::Timeout`) is NOT treated as a handoff signal — the direct-spawned process
-    /// is still alive and simply never grew a window, so it's terminated and the error
-    /// propagated, same as the plain-exec path.
+    /// window-tracking as the non-bundle path — and fall back to handing the launch off to
+    /// `NSWorkspace` only if that direct spawn's process exits before a window ever appears
+    /// (`GlassError::AppExited`). Any other discovery failure (e.g. `GlassError::Timeout`) is
+    /// NOT a handoff signal — the direct-spawned process is still alive and simply never grew a
+    /// window, so it's terminated and the error propagated.
     ///
-    /// The handoff itself can't be Seatbelt-contained (`bundle::handoff_gate` fails closed:
-    /// only `sandbox: off` may adopt it), and has no clipboard shim (an
-    /// `NSWorkspace`-launched process is never `direct.env`'s `DYLD_INSERT_LIBRARIES`
-    /// target), so its `ClipboardRoute` is decided directly as the sandbox-off/no-shim case
-    /// rather than via [`decide_clip`].
+    /// The handoff can't be Seatbelt-contained (`bundle::handoff_gate` fails closed: only
+    /// `sandbox: off` may adopt it) and has no clipboard shim (an `NSWorkspace`-launched process
+    /// is never `direct.env`'s `DYLD_INSERT_LIBRARIES` target), so its `ClipboardRoute` is
+    /// decided directly rather than via [`decide_clip`].
     ///
     /// **Apple platform code is handed off without attempting the spawn**, when the spec allows
     /// a handoff at all. macOS gives a system app a launch constraint requiring it to be started
     /// by launchd/LaunchServices, and the kernel `SIGKILL`s one spawned as another process's
     /// child — `EXC_CRASH SIGKILL (Code Signature Invalid)`, `CODESIGNING` / "Launch Constraint
-    /// Violation". The launch still succeeded, via the fallback below, but every attempt left a
-    /// crash report and a "quit unexpectedly" dialog for the user. Measured: 10 of 12 stock apps
-    /// tried (Notes, Preview, Calculator, TextEdit, Reminders, Music, Chess, Dictionary, Console,
-    /// Activity Monitor) die that way; Terminal and Disk Utility survive, as does Safari.
+    /// Violation" — leaving a crash report and a "quit unexpectedly" dialog behind each time.
+    /// Measured: 10 of 12 stock apps tried (Notes, Preview, Calculator, TextEdit, Reminders,
+    /// Music, Chess, Dictionary, Console, Activity Monitor) die that way; Terminal, Disk Utility
+    /// and Safari survive. Nothing in the signature distinguishes the two groups — both are
+    /// `Platform identifier=` code, and App Sandbox does not correlate (Music and Console carry
+    /// no app-sandbox entitlement and still die) — so this cannot predict which system apps
+    /// *would* have spawned, and gives up the attempt for all of them at the cost of their piped
+    /// logs (an `NSWorkspace` launch has no stdio to capture).
     ///
-    /// Nothing in the signature distinguishes those two groups — both are `Platform identifier=`
-    /// code, and App Sandbox does not correlate (Music and Console carry no app-sandbox
-    /// entitlement and still die) — so this cannot predict which system apps *would* have
-    /// spawned. It gives up the attempt for all of them rather than crash-report its way to the
-    /// same place, which costs those few their piped logs: an `NSWorkspace` launch has no stdio
-    /// to capture.
-    ///
-    /// **Only when `sandbox: off`.** A contained launch cannot be handed off at all (the gate),
-    /// so extending this to one would turn "run this system app contained" into an error whose
-    /// only remedy is `sandbox: off` — pushing the caller to run system code *less* contained
-    /// than they asked for, to avoid a crash dialog. Not a trade worth making: contained system
-    /// apps do work (Terminal and Disk Utility run fine under the profile), and glass's
-    /// containment is there for the app under development, which is never Apple platform code.
-    /// A constrained app asked for with containment therefore still attempts the spawn, dies,
-    /// and reaches the same gate error it always did.
+    /// A contained launch can't be handed off at all, so a constrained app asked for with
+    /// containment still attempts the spawn, dies, and reaches the gate error — rather than
+    /// glass pushing the caller to `sandbox: off` to avoid a crash dialog.
     fn start_bundle(&mut self, spec: &AppSpec, bundle: &Path) -> Result<WindowGeometry> {
         if spec.sandbox == SandboxLevel::Off && process::is_apple_platform_code(bundle) {
             return self.adopt_via_launch_services(spec, bundle);
@@ -535,13 +468,11 @@ impl MacosPlatform {
 }
 
 /// Decide the launched session's `ClipboardRoute` from the sandbox level and the clip-shim
-/// launch facts `process::spawn` produced (`None` for an uncontained or non-injectable
-/// launch) — shared by `start_app`'s and `start_bundle`'s direct-spawn success paths, both of
-/// which reach this only once the launched window is confirmed. `clip`'s presence only means
-/// the launch was injectable; a live `clipboard::shim_present` check confirms the swizzle
-/// actually took before a `Private` route is trusted (an injectable target whose injection
-/// silently failed must still land on `Unsupported`, not a `Private` route to a pasteboard
-/// the app was never redirected to).
+/// launch facts `process::spawn` produced (`None` for an uncontained or non-injectable launch)
+/// — shared by `start_app`'s and `start_bundle`'s direct-spawn success paths. `clip`'s presence
+/// only means the launch was injectable; a live `clipboard::shim_present` check confirms the
+/// swizzle actually took, so an injectable target whose injection silently failed lands on
+/// `Unsupported` rather than a `Private` route to a pasteboard the app never saw.
 fn decide_clip(sandbox: SandboxLevel, clip: Option<&ClipLaunch>) -> ClipboardRoute {
     match clip {
         Some(c) => {
@@ -554,9 +485,8 @@ fn decide_clip(sandbox: SandboxLevel, clip: Option<&ClipLaunch>) -> ClipboardRou
 
 /// Release `clip`'s named pasteboards (the content board and its `.ready` sentinel), a no-op
 /// when `clip` is `None`. Named pasteboards persist system-wide until released, so every path
-/// that ends a `ClipLaunch`'s lifetime — `start_app`'s/`start_bundle`'s discovery-failure arms
-/// (the launch never became a session), and `stop_app`/`Drop` (an established session ended) —
-/// must release it here, or the boards leak for the life of the host process.
+/// that ends a `ClipLaunch`'s lifetime — the discovery-failure arms, `stop_app`, `Drop` — must
+/// call this or the boards leak for the life of the host process.
 fn release_clip(clip: Option<&ClipLaunch>) {
     if let Some(c) = clip {
         crate::clipboard::release_named(&c.name);
@@ -566,15 +496,12 @@ fn release_clip(clip: Option<&ClipLaunch>) {
 
 /// Bring the launched app (`app_pid`) frontmost so its windows register with the AX API —
 /// otherwise `glass_a11y_snapshot` `WindowNotFound`s until the first input activates it. This
-/// front-loads the raise the first `glass_click`/`glass_type` would do anyway (`send_pointer`/
-/// `send_key` both call `input::focus` first).
+/// front-loads the raise the first `glass_click`/`glass_type` would do anyway.
 ///
-/// **Best-effort — never fatal.** `input::focus` already tolerates an OS-deprioritized
-/// (declined) activation by discarding `activateWithOptions`'s `false` and returning `Ok`, so
-/// the *only* error it can yield is `AppExited` — the app died in the gap after
-/// `discover_window` confirmed its window. The launch still succeeded (the returned geometry is
-/// from a window that was confirmed present), and the next capture/a11y/input op surfaces that
-/// `AppExited` with a structured error, so here we log and continue rather than fail the launch.
+/// **Best-effort — never fatal.** `input::focus` discards an OS-declined activation and returns
+/// `Ok`, so its only possible error is `AppExited`: the app died after `discover_window`
+/// confirmed its window. The launch still succeeded, and the next capture/a11y/input op
+/// surfaces that `AppExited`, so this logs and continues.
 fn activate_launched(app_pid: Option<u32>) {
     if let Some(pid) = app_pid
         && let Err(e) = crate::input::focus(pid as i32)
@@ -585,15 +512,12 @@ fn activate_launched(app_pid: Option<u32>) {
 
 /// Bounds-check every window-relative coordinate `event` carries against `geom` via
 /// `coords::check_in_bounds`, failing with `GlassError::CoordOutOfBounds` before
-/// `input::send_pointer` ever maps a coordinate to a global point — the "no
-/// silently-wrong click" invariant. `glass_core::session` already runs an equivalent check
-/// (`Session::check_bounds`) above every backend, but that's not a substitute here: this
-/// crate's mac-gated integration tests (Task 6) call `MacosPlatform::send_pointer`
-/// directly, bypassing the session layer entirely, so the backend must not depend on a
-/// caller it can't guarantee sits in front of it. Mirrors `Session::check_bounds`'s own
-/// per-variant coverage (both endpoints of a `Drag`, every pointer of a `Gesture`) even
-/// though `Gesture` itself is `Unsupported` on macOS — bounds-checking still runs first so
-/// an out-of-bounds `Gesture` reports `CoordOutOfBounds`, not `Unsupported`.
+/// `input::send_pointer` maps a coordinate to a global point — the "no silently-wrong click"
+/// invariant. Do not drop this as redundant with `glass_core::session`'s equivalent
+/// `Session::check_bounds`: this crate's mac-gated integration tests call
+/// `MacosPlatform::send_pointer` directly, bypassing the session layer. Mirrors
+/// `Session::check_bounds`'s per-variant coverage (both endpoints of a `Drag`, every pointer of
+/// a `Gesture`) so an out-of-bounds `Gesture` reports `CoordOutOfBounds`, not `Unsupported`.
 fn check_pointer_bounds(event: &PointerEvent, geom: &WindowGeometry) -> Result<()> {
     let check = |x: i32, y: i32| coords::check_in_bounds(x, y, geom.width, geom.height);
     match *event {
@@ -620,10 +544,9 @@ fn check_pointer_bounds(event: &PointerEvent, geom: &WindowGeometry) -> Result<(
     }
 }
 
-/// Map one `scwindow::AppWindow` into the `WindowInfo` [`MacosPlatform::list_windows`]
-/// returns, given the backend's current `active_window`. Factored out of `list_windows` as
-/// a pure step so it's unit-testable without a live `SCShareableContent` query — runtime
-/// enumeration coverage is Task 6's.
+/// Map one `scwindow::AppWindow` into the `WindowInfo` [`MacosPlatform::list_windows`] returns,
+/// given the backend's current `active_window`. A pure step so it's unit-testable without a live
+/// `SCShareableContent` query.
 fn window_info_from(w: crate::scwindow::AppWindow, active_window: Option<u32>) -> WindowInfo {
     WindowInfo {
         id: WindowId(w.window_id as u64),
@@ -637,10 +560,8 @@ fn window_info_from(w: crate::scwindow::AppWindow, active_window: Option<u32>) -
 /// Read `el`'s current `AXPosition`/`AXSize` (points) and convert to the pixel
 /// `WindowGeometry` [`MacosPlatform::window`] returns for every op — the shared read-back
 /// step after `Focus`/`Move`/`Resize`'s mutation, and the sole step for `Geometry`. Reuses
-/// `coords::pixel_geometry_from_content_rect`'s point->pixel scaling rather than
-/// reimplementing it: an AX position+size pair is exactly that function's `x`/`y`/`width`/
-/// `height` args (see `coords.rs`'s module doc), so this crate keeps one scaling
-/// implementation, not two.
+/// `coords::pixel_geometry_from_content_rect`'s point->pixel scaling so this crate keeps one
+/// scaling implementation, not two.
 fn read_ax_geometry(el: &AXUIElement, scale: f64) -> Result<WindowGeometry> {
     let (x, y) = axwindow::ax_position(el)?;
     let (width, height) = axwindow::ax_size(el)?;
@@ -650,15 +571,11 @@ fn read_ax_geometry(el: &AXUIElement, scale: f64) -> Result<WindowGeometry> {
 }
 
 /// True if a `Move { x, y }` request succeeded: either `x`/`y` was already (within
-/// [`REQUEST_EPSILON_PX`]) `before`'s own position — no real change was requested, so
-/// whatever `after` reads back as is fine — or `after` is within [`WINDOW_OP_TOLERANCE_PX`]
-/// of the target AND the window actually moved away from `before` (not just coincidentally
-/// unmoved-but-within-tolerance-of-a-nearby-target — see [`WINDOW_OP_TOLERANCE_PX`]/
-/// [`REQUEST_EPSILON_PX`]'s docs for why both checks are needed). The signal `window(op)`'s
-/// `Move` branch uses to catch a macOS window that silently ignores `AXPosition` (the
-/// no-silent-no-op contract `window(op)`'s doc describes). Computed in `i64` before `.abs()`
-/// so no cast can wrap for any input (matches `coords.rs`'s house rule). Pure so it's
-/// unit-testable without a live `AXUIElement`.
+/// [`REQUEST_EPSILON_PX`]) `before`'s own position, or `after` is within
+/// [`WINDOW_OP_TOLERANCE_PX`] of the target AND the window actually moved away from `before`.
+/// Both checks are needed — see those constants' docs. The signal `window(op)`'s `Move` branch
+/// uses to catch a macOS window that silently ignores `AXPosition`. Computed in `i64` before
+/// `.abs()` so no cast can wrap (matches `coords.rs`'s house rule).
 fn move_took_effect(before: &WindowGeometry, after: &WindowGeometry, x: i32, y: i32) -> bool {
     let requested_a_change = (i64::from(x) - i64::from(before.x)).abs()
         > i64::from(REQUEST_EPSILON_PX)
@@ -678,16 +595,10 @@ fn move_took_effect(before: &WindowGeometry, after: &WindowGeometry, x: i32, y: 
 /// True if a `Resize { width, height }` had no visible effect at all: `after` is (within
 /// [`WINDOW_OP_TOLERANCE_PX`]) the same size as `before`, even though `width`/`height` asked
 /// for a genuinely different size than `before`'s own (more than [`REQUEST_EPSILON_PX`]
-/// different — see that constant's doc for why this must be tighter than
-/// `WINDOW_OP_TOLERANCE_PX`, otherwise a small-but-real requested resize that's totally
-/// refused would not even count as "a change was requested"). This is deliberately narrower
-/// than "does `after` exactly match the request": macOS may legitimately clamp to an
-/// intermediate size (a window's min/max content-size constraint), which is expected
-/// behavior, not a bug — the resulting `after` geometry is still returned to the caller in
-/// that case (see `window(op)`'s `Resize` doc). Only a total no-op (the size never moved,
-/// despite a real change being requested) is treated as the "macOS refused the resize"
-/// failure. Computed in `i64` before `.abs()` so no cast can wrap for any input (matches
-/// `coords.rs`'s house rule). Pure so it's unit-testable without a live `AXUIElement`.
+/// different). Deliberately narrower than "does `after` exactly match the request": macOS may
+/// legitimately clamp to an intermediate size (a min/max content-size constraint), and that
+/// `after` geometry is still returned to the caller. Only a total no-op counts as a refusal.
+/// Computed in `i64` before `.abs()` so no cast can wrap (matches `coords.rs`'s house rule).
 fn resize_was_refused(
     before: &WindowGeometry,
     after: &WindowGeometry,
@@ -705,22 +616,17 @@ fn resize_was_refused(
 }
 
 impl Platform for MacosPlatform {
-    /// Run the optional build step, spawn the app, then confirm a window appears for its
-    /// pid within `spec.timeout_ms` via ScreenCaptureKit's `SCShareableContent`
-    /// enumeration — alternated with `child.try_wait()` so a crashed launch fails fast
-    /// with `GlassError::AppExited` instead of riding out the whole timeout (see
-    /// `discover_window`).
+    /// Run the optional build step, spawn the app, then confirm a window appears for its pid
+    /// within `spec.timeout_ms` via ScreenCaptureKit's `SCShareableContent` enumeration —
+    /// alternated with `child.try_wait()` so a crashed launch fails fast with
+    /// `GlassError::AppExited` (see `discover_window`).
     ///
-    /// **Main-thread affinity:** `discover_window` calls `ffi::app_kit_init()`, which
-    /// requires the true main thread (`MainThreadMarker` panics off it). In Plan 2 this is
-    /// exercised only by Task 6's `harness=false` main-thread test; wiring it under
-    /// glass-mcp's worker-thread dispatcher (main-thread marshaling) is deferred to Plan 5.
+    /// **Main-thread affinity:** `discover_window` calls `ffi::app_kit_init()`, which requires
+    /// the true main thread (`MainThreadMarker` panics off it).
     ///
     /// **`.app` bundles:** when `spec.run[0]` names a `.app` bundle directory
-    /// (`bundle::is_app_bundle`), this delegates to [`Self::start_bundle`] instead of the
-    /// plain-exec path below — see its doc for the direct-spawn-then-NSWorkspace-handoff
-    /// design. Every other `run[0]` (the plain-exec case) takes the unchanged path that
-    /// follows.
+    /// (`bundle::is_app_bundle`), this delegates to [`Self::start_bundle`]; every other
+    /// `run[0]` takes the plain-exec path below.
     fn start_app(&mut self, spec: &AppSpec) -> Result<WindowGeometry> {
         Self::run_build(spec)?;
         let run0 = spec
@@ -774,15 +680,10 @@ impl Platform for MacosPlatform {
     /// Terminate the launched app (however it was launched) and clear the active pid/window.
     /// Idempotent — a call with nothing running is `Ok(())`.
     ///
-    /// An `adopted` app (`start_bundle`'s NSWorkspace-handoff path — no `self.child` to
-    /// terminate) is reaped first: a freshly-launched adoptee is terminated via
-    /// `ffi::terminate_app` (glass started it, so glass stops it), while an activated-existing
-    /// one is left running (glass only raised it, so it isn't glass's to kill) — see the
-    /// `adopted` field's doc. This then falls through to the child/pasteboard cleanup below
-    /// rather than returning early: a session is only ever `adopted` XOR `child`-backed, so the
-    /// fall-through is a no-op for an adopted session, but it keeps `stop_app` and `Drop`
-    /// structurally identical (both reap `adopted`, then `child`, then release pasteboards)
-    /// instead of `stop_app` carrying its own divergent early-return.
+    /// An `adopted` app (`start_bundle`'s NSWorkspace-handoff path, no `self.child`) is reaped
+    /// first, per the `adopted` field's doc. This then falls through to the child/pasteboard
+    /// cleanup rather than returning early: a session is `adopted` XOR `child`-backed, so the
+    /// fall-through is a no-op, and it keeps `stop_app` and `Drop` structurally identical.
     fn stop_app(&mut self) -> Result<()> {
         if let Some(a) = self.adopted.take() {
             a.reap();
@@ -805,24 +706,17 @@ impl Platform for MacosPlatform {
     }
 
     /// Capture the active window as an RGBA8 frame, re-resolving it fresh on every call
-    /// (see `scwindow.rs`'s module doc — a `Retained<SCWindow>` can't be cached across
-    /// calls).
+    /// (see `scwindow.rs`'s module doc — a `Retained<SCWindow>` can't be cached across calls).
     ///
-    /// NOTE: targets `active_window` when set (`capture::capture_window_by_id`, exact
-    /// `CGWindowID` match scoped to `&[pid]` — final-review fix 1, same rationale as
-    /// `resolve_active_window`'s doc) — the retargeting `select_window` (a later task)
-    /// drives, per the `Platform` contract's "implicit target of capture/input" — else falls
-    /// back to the pre-Plan-4 first-on-screen-window-for-this-pid path
-    /// (`capture::capture_window`). `resolve_active_window`'s doc covers the shared
-    /// decision; capture takes its own `capture_window`/`capture_window_by_id` branch
-    /// (rather than calling `resolve_active_window` itself) because capture needs the live
-    /// `SCWindow` inside a single completion-handler callback to build its
-    /// `SCContentFilter`, not just the `WindowMatch` snapshot `resolve_active_window`
-    /// returns.
+    /// Targets `active_window` when set (`capture::capture_window_by_id`, exact `CGWindowID`
+    /// match scoped to `&[pid]`), else the first-on-screen-window-for-this-pid path
+    /// (`capture::capture_window`). Takes its own branch rather than calling
+    /// `resolve_active_window` because capture needs the live `SCWindow` inside a single
+    /// completion-handler callback to build its `SCContentFilter`, not just a `WindowMatch`
+    /// snapshot.
     ///
-    /// **Main-thread affinity:** like `start_app`, this reaches `ffi::app_kit_init()`
-    /// (via `capture::capture_window`/`capture_window_by_id`) and must run on the true main
-    /// thread; see the note on `start_app`.
+    /// **Main-thread affinity:** like `start_app`, this reaches `ffi::app_kit_init()` and must
+    /// run on the true main thread.
     fn capture_frame(&mut self, region: Option<&Region>) -> Result<Frame> {
         permissions::preflight()?;
         let pid = self.app_pid.ok_or(GlassError::NoActiveSession)?;
@@ -831,22 +725,16 @@ impl Platform for MacosPlatform {
             None => crate::capture::capture_window(&[pid as i32], region),
         }
     }
-    /// Map the active window into `input::send_pointer` — see `input.rs`'s module doc for
-    /// the CGEvent details and its main-thread-affinity note (shared with
-    /// `start_app`/`capture_frame` above).
+    /// Map the active window into `input::send_pointer` — see `input.rs`'s module doc for the
+    /// CGEvent details and its main-thread-affinity note.
     ///
-    /// NOTE: re-resolves the window fresh via `resolve_active_window` on every call —
-    /// targeting `active_window` when set (the retargeting `select_window`, a later task,
-    /// drives), else falling back to the pre-Plan-4 first-on-screen-window-for-this-pid
-    /// path — mirroring `capture_frame`'s per-call resolution above. The window may have
-    /// moved or resized since `start_app` (or any earlier `send_pointer` call), so a
-    /// `scale`/`origin_pt`/geometry cached once at `start_app` would go stale. Both the
-    /// bounds check (`check_pointer_bounds`, see its doc) and the coordinate mapping use
-    /// this freshly-resolved geometry/scale/origin; the CGEvent focus target is the
-    /// resolved window's own owning pid (`m.pid`, from the fresh `SCShareableContent`
-    /// lookup), not necessarily `self.app_pid` — today they're always the same pid (glass
-    /// launches one app per session), but `m.pid` is the one actually tied to the window
-    /// being clicked.
+    /// Re-resolves the window fresh via `resolve_active_window` on every call, like
+    /// `capture_frame`: the window may have moved or resized since `start_app`, so a
+    /// `scale`/`origin_pt`/geometry cached once would go stale. Both the bounds check
+    /// (`check_pointer_bounds`) and the coordinate mapping use the freshly-resolved values. The
+    /// CGEvent focus target is the resolved window's own owning pid (`m.pid`), not
+    /// `self.app_pid` — the same pid today, but `m.pid` is the one tied to the window being
+    /// clicked.
     fn send_pointer(&mut self, event: &PointerEvent) -> Result<()> {
         permissions::preflight()?;
         let pid = self.app_pid.ok_or(GlassError::NoActiveSession)?;
@@ -857,15 +745,12 @@ impl Platform for MacosPlatform {
     /// Map the active window into `input::send_key` — see `input.rs`'s module doc for the
     /// CGEvent keyboard details.
     ///
-    /// NOTE: re-resolves the active window via `resolve_active_window` first, same as
-    /// `send_pointer`, even though keyboard CGEvents target a *process* (`focus(pid)`
-    /// activates the app, and the posted event then goes to whatever window that app
-    /// currently has key/main — there is no per-window keyboard targeting yet; that needs
-    /// AXUIElement raise/main, Plan 4 Task 4). The resolution here still matters: if
-    /// `active_window` is set but that window has closed, this surfaces
-    /// `GlassError::WindowNotFound` instead of silently posting keys to whatever else
-    /// happens to be focused — the same no-silent-wrong-target discipline `send_pointer`'s
-    /// bounds check enforces for clicks.
+    /// Re-resolves the active window via `resolve_active_window` first, same as `send_pointer`,
+    /// even though keyboard CGEvents target a *process*: `focus(pid)` activates the app and the
+    /// event goes to whatever window that app currently has key/main, so there is no per-window
+    /// keyboard targeting. The resolution still matters — if `active_window` is set but that
+    /// window has closed, this surfaces `GlassError::WindowNotFound` instead of silently posting
+    /// keys to whatever else is focused.
     fn send_key(&mut self, event: &KeyEvent) -> Result<()> {
         permissions::preflight()?;
         let pid = self.app_pid.ok_or(GlassError::NoActiveSession)?;
@@ -873,30 +758,24 @@ impl Platform for MacosPlatform {
         crate::input::send_key(event, m.pid)
     }
     /// Resolve the active window's `AXUIElement` (fresh every call, same rationale as
-    /// `resolve_active_window`: the window may have moved/resized/closed since the last
-    /// call) and dispatch `op` onto it:
+    /// `resolve_active_window`) and dispatch `op` onto it:
     ///
-    /// - `Focus` activates the owning app (`input::focus`, the same
-    ///   `NSRunningApplication::activate` call `send_pointer`/`send_key` already make),
-    ///   then `AXRaise`s and marks the window `AXMain` — CGEvents alone can't target a
-    ///   specific window (see `send_key`'s doc), this is what actually does. Propagates
-    ///   `input::focus`'s error (final-review fix 4) if the owning app is no longer running
-    ///   rather than silently raising/main-ing an `AXUIElement` for a process that's gone.
+    /// - `Focus` activates the owning app (`input::focus`), then `AXRaise`s and marks the
+    ///   window `AXMain` — CGEvents alone can't target a specific window (see `send_key`'s
+    ///   doc), this is what does. Propagates `input::focus`'s error if the owning app is gone
+    ///   rather than raising an `AXUIElement` for a dead process.
     /// - `Move { x, y }` converts the target from global-screen PIXELS to Quartz POINTS
     ///   (`coords::global_pixel_to_point`) and sets `AXPosition`.
-    /// - `Resize { width, height }` sets `AXSize`, then re-sets `AXPosition` to its
-    ///   just-read current value, then sets `AXSize` again — the brief-specified workaround
-    ///   (verified by the Task 6 window integration test) for a window that won't grow past
-    ///   its current on-screen bounds via a single `AXSize` set alone.
+    /// - `Resize { width, height }` sets `AXSize`, re-sets `AXPosition` to its just-read
+    ///   current value, then sets `AXSize` again — a window won't grow past its current
+    ///   on-screen bounds via a single `AXSize` set alone.
     /// - `Geometry` performs no mutation.
     ///
-    /// Every branch reads back the window's position/size afterward
-    /// ([`read_ax_geometry`]) and returns it in pixels — the tool boundary's unit. `Move`/
-    /// `Resize` additionally check the read-back actually reflects the request
-    /// ([`move_took_effect`]/[`resize_was_refused`]), returning `GlassError::Backend`
-    /// naming what didn't take rather than silently reporting success on a macOS window
-    /// that refused the change; `Focus`/`Geometry` have no such check since they assert
-    /// nothing about position/size.
+    /// Every branch reads back the window's position/size afterward ([`read_ax_geometry`]) and
+    /// returns it in pixels — the tool boundary's unit. `Move`/`Resize` additionally check the
+    /// read-back reflects the request ([`move_took_effect`]/[`resize_was_refused`]), returning
+    /// `GlassError::Backend` naming what didn't take rather than reporting success on a window
+    /// that refused the change.
     fn window(&mut self, op: &WindowOp) -> Result<WindowGeometry> {
         permissions::preflight()?;
         let id = self.active_window.ok_or(GlassError::NoActiveSession)?;
@@ -946,12 +825,11 @@ impl Platform for MacosPlatform {
         }
     }
     /// Enumerate every on-screen window owned by the launched app's pid via
-    /// `scwindow::list_app_windows` (one `SCShareableContent` query, all matches — not just
-    /// the active one), mapping each into a `WindowInfo` via [`window_info_from`].
+    /// `scwindow::list_app_windows` (one `SCShareableContent` query, all matches), mapping each
+    /// into a `WindowInfo` via [`window_info_from`].
     ///
-    /// **Main-thread affinity:** like `start_app`/`capture_frame`, reaches
-    /// `ffi::app_kit_init()` (via `scwindow::list_app_windows`) and must run on the true
-    /// main thread; see the note on `start_app`.
+    /// **Main-thread affinity:** reaches `ffi::app_kit_init()` and must run on the true main
+    /// thread.
     fn list_windows(&mut self) -> Result<Vec<WindowInfo>> {
         permissions::preflight()?;
         let pid = self.app_pid.ok_or(GlassError::NoActiveSession)?;
@@ -961,38 +839,25 @@ impl Platform for MacosPlatform {
             .map(|w| window_info_from(w, self.active_window))
             .collect())
     }
-    /// Retarget `active_window` to `id` — the `Platform` contract's "make `id` the
-    /// active window, the implicit target of capture/input/window ops" (see
-    /// `glass_core::platform`'s doc on this method).
+    /// Retarget `active_window` to `id` — the `Platform` contract's "make `id` the active
+    /// window, the implicit target of capture/input/window ops".
     ///
-    /// First confirms `id` is currently on-screen AND owned by `self.app_pid` via
-    /// `scwindow::find_window_by_id(id, &[app_pid], ..)` (final-review fix 1 — pid-scoped,
-    /// unlike the pre-fix version which matched any on-screen `CGWindowID` system-wide),
-    /// which already maps a lookup that never turns up `id` before `WINDOW_RESOLVE_TIMEOUT`
-    /// elapses to `GlassError::WindowNotFound` (see that function's own doc) — exactly this
-    /// method's "not currently one of the app's windows" contract, so no extra `Timeout` ->
-    /// `WindowNotFound` mapping is needed here. Only after that check succeeds does
-    /// `active_window` actually change — a failed `select_window` must leave the previous
-    /// target in place, not (say) clear it.
+    /// First confirms `id` is on-screen AND owned by `self.app_pid` via
+    /// `scwindow::find_window_by_id(id, &[app_pid], ..)`, which already maps a lookup that never
+    /// turns up `id` before `WINDOW_RESOLVE_TIMEOUT` elapses to `GlassError::WindowNotFound` —
+    /// exactly this method's "not currently one of the app's windows" contract, so no extra
+    /// `Timeout` -> `WindowNotFound` mapping is needed. Only then does `active_window` change: a
+    /// failed `select_window` leaves the previous target in place rather than clearing it.
     ///
-    /// Then raises and focuses the newly-selected window by delegating to
-    /// `self.window(&WindowOp::Focus)` rather than duplicating its AXUIElement logic: that
-    /// path re-resolves `id`'s `AXUIElement` scoped to `self.app_pid`
-    /// (`axwindow::ax_window_for_cgwindowid`) too, via a completely independent lookup path
-    /// (`SCShareableContent` above vs. `AXUIElementCreateApplication` here) — belt-and-
-    /// suspenders with the pid-scoped check above, not a second layer this method actually
-    /// depends on. `window(Focus)`'s own read-back ([`read_ax_geometry`]) supplies the pixel
-    /// `WindowGeometry` this method returns, so the window is queried fresh exactly once
-    /// more (mirroring every other op's no-caching discipline) rather than reusing the first
-    /// lookup's now-slightly-stale geometry.
+    /// Then raises and focuses the window by delegating to `self.window(&WindowOp::Focus)`
+    /// rather than duplicating its AXUIElement logic; that path's own read-back
+    /// ([`read_ax_geometry`]) supplies the pixel `WindowGeometry` returned here, so the window
+    /// is queried fresh once more rather than reusing the first lookup's stale geometry.
     ///
-    /// If `self.window(&WindowOp::Focus)` fails after `active_window` has already been
-    /// retargeted — e.g. the window closed in the gap between the check above and the
-    /// `AXRaise`/`AXMain` calls — `active_window` is rolled back to its prior value
-    /// (final-review fix 2) rather than left pointing at a window this call never actually
-    /// confirmed glass can operate on. Belt-and-suspenders with the pid-scoped check above:
-    /// that check already rejects a foreign/stale `id` before any mutation, so this rollback
-    /// only matters for the narrower window-closed-mid-call race.
+    /// If `self.window(&WindowOp::Focus)` fails after `active_window` was retargeted — the
+    /// window closed in the gap between the check and the `AXRaise`/`AXMain` calls —
+    /// `active_window` is rolled back rather than left pointing at a window this call never
+    /// confirmed glass can operate on.
     fn select_window(&mut self, id: WindowId) -> Result<WindowGeometry> {
         permissions::preflight()?;
         let pid = self.app_pid.ok_or(GlassError::NoActiveSession)?;
@@ -1037,15 +902,12 @@ impl Platform for MacosPlatform {
 
 impl Drop for MacosPlatform {
     /// Reap a still-running launched app on drop — parity with the X11/Wayland/Windows
-    /// backends, so a backend dropped without an explicit `stop_app()` (panic-unwind, or
-    /// the process-exit backstop path) does not orphan its child. `process::terminate`
-    /// is idempotent, and `child.take()` in `stop_app` means this is a no-op if
-    /// `stop_app` already ran.
+    /// backends, so a backend dropped without an explicit `stop_app()` (panic-unwind, or the
+    /// process-exit backstop) does not orphan its child. `process::terminate` is idempotent, and
+    /// `child.take()` in `stop_app` means this is a no-op if `stop_app` already ran.
     ///
-    /// A freshly-launched `adopted` app (`start_bundle`'s handoff path — no `self.child`)
-    /// gets the same treatment via `ffi::terminate_app`, for the same "don't orphan what
-    /// this backend launched" reason; an activated-existing adoptee is left running, same as
-    /// in `stop_app`.
+    /// A freshly-launched `adopted` app gets the same treatment via `ffi::terminate_app`; an
+    /// activated-existing adoptee is left running, same as in `stop_app`.
     fn drop(&mut self) {
         if let Some(a) = self.adopted.take() {
             a.reap();

--- a/crates/glass-macos/src/bundle.rs
+++ b/crates/glass-macos/src/bundle.rs
@@ -2,9 +2,8 @@
 //! containment gate. Host-agnostic (no FFI) so it unit-tests on any host, like
 //! `glass-windows/src/discovery.rs`.
 #![forbid(unsafe_code)]
-// These fns are consumed by the cfg(macos) launch path (tasks 2/3) and exercised by the
-// unit tests below, so off-macOS non-test builds see them as dead. Keep the lint live on
-// macOS. Same pattern as `glass-windows/src/doctor.rs`.
+// These fns are consumed by the cfg(macos) launch path and exercised by the unit tests below,
+// so off-macOS non-test builds see them as dead. Keep the lint live on macOS.
 #![cfg_attr(not(target_os = "macos"), allow(dead_code))]
 
 use glass_core::{GlassError, Result, platform::SandboxLevel};
@@ -82,11 +81,9 @@ pub(crate) enum Disposition {
 }
 
 impl Disposition {
-    /// Pure reap predicate: only a `Fresh` adoption is terminated on `stop_app`/`Drop`. Kept
-    /// as a standalone predicate (rather than an inline `if fresh`) so the "which
-    /// disposition gets terminated" decision has one unit-testable definition — a boolean
-    /// inversion here would terminate a user's pre-existing app, so it carries a dedicated
-    /// off-macOS test (see `disposition_only_terminates_fresh`).
+    /// Pure reap predicate: only a `Fresh` adoption is terminated on `stop_app`/`Drop`. A
+    /// boolean inversion here would terminate a user's pre-existing app, hence the dedicated
+    /// off-macOS test `disposition_only_terminates_fresh`.
     pub(crate) fn should_terminate(self) -> bool {
         matches!(self, Disposition::Fresh)
     }

--- a/crates/glass-macos/src/capture.rs
+++ b/crates/glass-macos/src/capture.rs
@@ -2,8 +2,7 @@
 //!
 //! Re-resolves the target window fresh on every call — a `Retained<SCWindow>` can't be
 //! held across calls or across the completion-handler's thread boundary (see
-//! `scwindow.rs`'s module doc) — via the nested async flow proven end-to-end in the objc2
-//! spike:
+//! `scwindow.rs`'s module doc) — via a nested async flow:
 //! `SCShareableContent` → [`crate::scwindow::find_on_screen_window`]/
 //! [`crate::scwindow::find_on_screen_window_by_id`] (pid-set lookup for `capture_window`,
 //! exact-`CGWindowID` lookup for `capture_window_by_id` — see [`capture_resolved`]) →
@@ -34,9 +33,9 @@ use glass_core::{GlassError, Result};
 
 use crate::scwindow::{find_on_screen_window, find_on_screen_window_by_id};
 
-/// Max wait for one capture round trip (`SCShareableContent` + `SCScreenshotManager`
-/// both completing). Generous relative to the spike's sub-second observations — this
-/// covers a wedged completion handler, not normal latency.
+/// Max wait for one capture round trip (`SCShareableContent` + `SCScreenshotManager` both
+/// completing). Generous relative to observed sub-second round trips — this covers a wedged
+/// completion handler, not normal latency.
 const CAPTURE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Capture the first on-screen window owned by one of `pids` as an RGBA8 [`Frame`],
@@ -58,12 +57,10 @@ pub(crate) fn capture_window(pids: &[i32], region: Option<&Region>) -> Result<Fr
 /// `owningApplication().processID() ∈ pids` as an RGBA8 [`Frame`], optionally cropped to a
 /// window-relative `region`. Same error mapping as [`capture_window`]. This is
 /// `backend.rs::capture_frame`'s active-window (retargeted) path: once
-/// `MacosPlatform::active_window` is set (by `start_app`, later by `select_window`), capture
-/// must target that *exact* window rather than "first on-screen window for this pid" — a
-/// multi-window app would otherwise silently capture the wrong window (Plan 4's design
-/// decision 2). The `pids` scoping (final-review fix 1) additionally guards against a
-/// stale/foreign `active_window` id: without it, `window_id` alone could match a window
-/// owned by a completely different app, silently capturing its pixels instead of erroring.
+/// `MacosPlatform::active_window` is set, capture must target that *exact* window rather than
+/// "first on-screen window for this pid", or a multi-window app silently captures the wrong
+/// one. The `pids` scoping additionally guards a stale or foreign `active_window` id — without
+/// it, `window_id` alone could match a window owned by a completely different app.
 pub(crate) fn capture_window_by_id(
     window_id: u32,
     pids: &[i32],
@@ -78,11 +75,9 @@ pub(crate) fn capture_window_by_id(
 /// Shared nested-async capture body for [`capture_window`]/[`capture_window_by_id`]: resolve
 /// the target `SCWindow` via `resolve` (the only thing that differs between a pid-set lookup
 /// and an exact-`CGWindowID` lookup), then build the `SCContentFilter`/`SCStreamConfiguration`
-/// and run `SCScreenshotManager`'s capture — identical for both callers, so this is the one
-/// place that logic lives (no risk of the two paths drifting on filter/config/crop
-/// handling). `resolve` runs inside the `SCShareableContent` completion block, so it must be
-/// `Send` (queue-hopped, like every other closure this module posts across the FFI
-/// boundary — see `ffi.rs`'s async-bridge doc) but does not need to be `Sync` (called once).
+/// and run `SCScreenshotManager`'s capture — identical for both callers, so the two paths can't
+/// drift on filter/config/crop handling. `resolve` runs inside the `SCShareableContent`
+/// completion block, so it must be `Send` (queue-hopped) but not `Sync` (called once).
 fn capture_resolved(
     region: Option<&Region>,
     resolve: impl Fn(&SCShareableContent) -> Option<(Retained<SCWindow>, i32)> + Send + 'static,
@@ -210,11 +205,9 @@ enum CaptureReply {
 }
 
 /// Crop `frame` to `region`, clamping to the captured frame first via
-/// [`crate::coords::clamp_region`] (defense in depth — the session layer should already
-/// validate the region against the window before it reaches the backend, per
-/// `glass_core::frame::Region::check_fits`'s doc). `region` is already window-relative
-/// PIXELS, the same unit `frame` itself is in — no scaling needed. `None` returns `frame`
-/// unchanged.
+/// [`crate::coords::clamp_region`] (defense in depth — the session layer already validates the
+/// region against the window, per `glass_core::frame::Region::check_fits`). `region` is already
+/// window-relative PIXELS, the same unit `frame` is in. `None` returns `frame` unchanged.
 fn crop_to_region(frame: Frame, region: Option<&Region>) -> Result<Frame> {
     let Some(r) = region else { return Ok(frame) };
     let clamped = crate::coords::clamp_region(
@@ -228,13 +221,10 @@ fn crop_to_region(frame: Frame, region: Option<&Region>) -> Result<Frame> {
     frame.crop(&clamped)
 }
 
-/// Draw a captured `CGImage` into a tightly-packed RGBA8 (premultiplied-last, host byte
-/// order) bitmap context and hand back the raw bytes as a [`Frame`] — the spike's
-/// `analyze_and_write` bitmap path, minus the luma-sampling/PNG-writing (capture only
-/// needs the pixels). `CGContextDrawImage`'s internal colorspace conversion means this
-/// yields tightly-packed RGBA bytes directly regardless of the source image's own pixel
-/// format (BGRA for SDR captures, per `SCScreenshotManager`'s docs) — no separate swizzle
-/// needed.
+/// Draw a captured `CGImage` into a tightly-packed RGBA8 (premultiplied-last, host byte order)
+/// bitmap context and hand back the raw bytes as a [`Frame`]. `CGContextDrawImage`'s internal
+/// colorspace conversion yields tightly-packed RGBA bytes regardless of the source image's own
+/// pixel format (BGRA for SDR captures, per `SCScreenshotManager`'s docs) — no swizzle needed.
 fn rgba_frame_from_cgimage(image: &CGImage) -> Result<Frame> {
     let w = CGImage::width(Some(image));
     let h = CGImage::height(Some(image));

--- a/crates/glass-macos/src/ffi.rs
+++ b/crates/glass-macos/src/ffi.rs
@@ -4,10 +4,8 @@
 //!
 //! ## The reusable pattern: async completion-handler → channel bridge
 //!
-//! Proven end-to-end against ScreenCaptureKit's nested `SCShareableContent` →
-//! `SCScreenshotManager` completion
-//! handlers. The concrete `block2::RcBlock`s live at each call site (capture, display
-//! provisioning, etc. — Plan 2 tasks 2+), not here; this is the recipe they all follow:
+//! The concrete `block2::RcBlock`s live at each call site, not here; this is the recipe they
+//! all follow:
 //!
 //! 1. Build the block with `block2::RcBlock::new(move |raw_ptr_args...| { ... })`, typed
 //!    exactly to match the generated binding's completion-handler signature (check each
@@ -25,7 +23,7 @@
 //!    on whatever queue the framework was told to use (or a GCD default) — it does not
 //!    require the caller to be pumping a run loop.
 //!
-//! ## Gotchas carried forward from the spike (keep in mind at every call site)
+//! ## Gotchas that apply at every call site
 //!
 //! - `use objc2::AnyThread;` must be in scope for `ClassType::alloc()` on
 //!   any-thread-usable classes — otherwise the compiler reports "no associated function
@@ -80,30 +78,19 @@ static APP_KIT_INIT: Once = Once::new();
 /// verbatim in the spike's TCC-declined run.
 const TCC_DECLINE_CODE: isize = -3801;
 
-/// Touch `NSApplication.shared` exactly once to establish this process's connection to
-/// the window server. Without it, ScreenCaptureKit/CoreGraphics calls from a bare CLI
-/// binary abort with `CGS_REQUIRE_INIT` (proven in the objc2 spike; see the module doc
-/// above). The *first* call must happen on the main thread; safe to call repeatedly
-/// (including from any other thread) afterward — only the first call does anything.
+/// Touch `NSApplication.shared` exactly once to establish this process's connection to the
+/// window server. Without it, ScreenCaptureKit/CoreGraphics calls from a bare CLI binary abort
+/// with `CGS_REQUIRE_INIT`. The *first* call must happen on the main thread; safe to call
+/// repeatedly (including from any other thread) afterward — only the first call does anything.
 ///
-/// The completed-check runs *before* touching `MainThreadMarker` at all: once the
-/// one-time init has actually happened, this becomes a cheap, thread-agnostic no-op, so
-/// every call site that only cares "has `app_kit_init` run yet" (all of them — see below)
-/// can be reached from a non-main worker thread once startup has called
-/// [`init_main_thread`] once. This is sound because the WindowServer
-/// connection `NSApplication.sharedApplication` establishes is a process-wide, one-time
+/// The completed-check runs *before* touching `MainThreadMarker` at all, so once the one-time
+/// init has happened this is a cheap thread-agnostic no-op reachable from any worker thread.
+/// The WindowServer connection `NSApplication.sharedApplication` establishes is a process-wide
 /// resource, not a per-thread one.
 ///
-/// The main-thread check (for the first, real call) runs *before* `call_once`, not
-/// inside its closure: a panic inside `Once::call_once` poisons the `Once` forever
-/// (every later call — even a correct one, from the real main thread — would then panic
-/// too with "Once instance has previously been poisoned"). Checking first means a single
-/// off-thread misuse can't permanently wedge the one-time init for the rest of the
-/// process.
-///
-/// Called by `backend.rs`'s `discover_window` (before `start_app`'s window-discovery poll
-/// loop) and by `capture::capture_window` (before every capture) — safe and cheap to call
-/// redundantly, since only the first call does anything.
+/// Do not move the main-thread check inside `call_once`: a panic in its closure poisons the
+/// `Once` forever ("Once instance has previously been poisoned"), so one off-thread misuse
+/// would wedge the init for the rest of the process.
 pub(crate) fn app_kit_init() {
     if APP_KIT_INIT.is_completed() {
         return;
@@ -118,28 +105,23 @@ pub(crate) fn app_kit_init() {
     });
 }
 
-/// Public entry point for a host process (e.g. `glass-mcp`'s `main()`) to perform the
-/// one-time AppKit/WindowServer init from the process's real main thread at startup,
-/// before spawning any worker thread that will later call into `MacosPlatform`. Thin
-/// wrapper over [`app_kit_init`] — see its doc for the full contract. After this returns,
-/// every subsequent `app_kit_init()` call (transitively, every `MacosPlatform` operation)
-/// is a cheap no-op safe to call from any thread.
+/// Public entry point for a host process (e.g. `glass-mcp`'s `main()`) to perform the one-time
+/// AppKit/WindowServer init from the process's real main thread at startup, before spawning any
+/// worker thread that will later call into `MacosPlatform`. After this returns, every
+/// subsequent `app_kit_init()` call is a cheap no-op safe to call from any thread.
 pub fn init_main_thread() {
     app_kit_init();
 }
 
 /// Classify a `null` async ScreenCaptureKit result's paired `NSError`:
 /// [`GlassError::PermissionDenied`] for a Screen Recording TCC decline (domain
-/// `SCStreamErrorDomain`, code `-3801`, and/or a "declined" description — the spike
-/// observed all three together, but any one is treated as authoritative since Apple
-/// doesn't document which fields are stable across OS versions), [`GlassError::CaptureFailed`]
-/// otherwise. `fallback_msg` covers the (framework-contract-violating, but defensively
-/// handled) case where both the result and the error came back null.
+/// `SCStreamErrorDomain`, code `-3801`, and/or a "declined" description — observed together,
+/// but any one is treated as authoritative since Apple doesn't document which fields are stable
+/// across OS versions), [`GlassError::CaptureFailed`] otherwise. `fallback_msg` covers the
+/// framework-contract-violating case where both the result and the error came back null.
 ///
-/// Shared by every completion handler in this crate that can hand back a null result —
-/// `scwindow.rs`'s discovery query and `capture.rs`'s content/image queries — per this
-/// module's async-bridge convention, so a TCC decline is classified identically everywhere
-/// instead of each call site rolling its own (partial) version of this check.
+/// Shared by every completion handler in this crate that can hand back a null result, so a TCC
+/// decline is classified identically everywhere.
 pub(crate) fn classify_null_result(err_ptr: *mut NSError, fallback_msg: &str) -> GlassError {
     if err_ptr.is_null() {
         return GlassError::CaptureFailed(fallback_msg.to_string());
@@ -162,14 +144,10 @@ pub(crate) fn classify_null_result(err_ptr: *mut NSError, fallback_msg: &str) ->
     }
 }
 
-/// The first running application whose `CFBundleIdentifier` equals `bundle_id`, or `None`
-/// if none is currently running. `backend.rs`'s bundle-launch path (task 3) uses
-/// this to detect that `LaunchServices` handed the launch off to an already-running
-/// instance rather than spawning the process this call started.
-///
-/// No `unsafe` needed: `NSRunningApplication::runningApplicationsWithBundleIdentifier` and
-/// `processIdentifier` are both plain safe bindings (see this module's doc) — same shape as
-/// `input.rs::focus`'s `runningApplicationWithProcessIdentifier` lookup.
+/// The first running application whose `CFBundleIdentifier` equals `bundle_id`, or `None` if
+/// none is currently running. `backend.rs`'s bundle-launch path uses this to detect that
+/// LaunchServices handed the launch off to an already-running instance rather than spawning the
+/// process this call started.
 pub(crate) fn running_pid_for_bundle_id(bundle_id: &str) -> Option<i32> {
     let id = NSString::from_str(bundle_id);
     let apps = NSRunningApplication::runningApplicationsWithBundleIdentifier(&id);
@@ -185,14 +163,12 @@ pub(crate) fn running_pid_for_bundle_id(bundle_id: &str) -> Option<i32> {
 /// app's pid.
 ///
 /// [`GlassError::AppNotStarted`] carries the framework's own `NSError` description when the
-/// completion handler reports failure. `NSWorkspace` documents the handler as being called
-/// with either a non-nil app or a non-nil error, never neither — but per
-/// [`classify_null_result`]'s identical stance on ScreenCaptureKit's completion handlers,
-/// that contract is handled defensively rather than assumed, so a (framework-violating)
-/// null/null callback still yields a message instead of silently dropping the reply.
-/// [`GlassError::Timeout`] covers a completion handler that never fires within `timeout_ms`;
-/// a handler dropped without ever firing (the channel sender gone) is reported as
-/// [`GlassError::AppNotStarted`] instead, kept distinct from that never-fired-in-time timeout.
+/// completion handler reports failure. `NSWorkspace` documents the handler as being called with
+/// either a non-nil app or a non-nil error, never neither, but that contract is handled
+/// defensively rather than assumed, so a null/null callback still yields a message instead of
+/// silently dropping the reply. [`GlassError::Timeout`] covers a completion handler that never
+/// fires within `timeout_ms`; a handler dropped without ever firing (the channel sender gone) is
+/// reported as [`GlassError::AppNotStarted`], kept distinct from that timeout.
 pub(crate) fn launch_bundle(bundle: &Path, args: &[String], timeout_ms: u64) -> Result<i32> {
     let (tx, rx) = mpsc::channel::<std::result::Result<i32, String>>();
 
@@ -266,10 +242,10 @@ pub(crate) fn launch_bundle(bundle: &Path, args: &[String], timeout_ms: u64) -> 
 /// app, which ran that method and exited a few hundred milliseconds after being asked this way,
 /// and did not run it under `SIGTERM`.
 ///
-/// The `false` return is advisory, not an error. `backend.rs`'s `stop_app` path doesn't need
-/// to know whether the app was already gone before it asked (unlike `input.rs::focus`'s
-/// identical lookup, which treats a missing pid as the hard error `GlassError::AppExited`
-/// because a caller is depending on the activation landing).
+/// The `false` return is advisory, not an error: `stop_app` doesn't need to know whether the
+/// app was already gone before it asked. `input.rs::focus`'s identical lookup does treat a
+/// missing pid as the hard error `GlassError::AppExited`, since a caller depends on the
+/// activation landing.
 pub(crate) fn terminate_app(pid: i32) -> bool {
     NSRunningApplication::runningApplicationWithProcessIdentifier(pid)
         .is_some_and(|app| app.terminate())

--- a/crates/glass-macos/src/input.rs
+++ b/crates/glass-macos/src/input.rs
@@ -6,34 +6,24 @@
 //! `glass_core::platform::PointerEvent`'s doc. `send_key` does the same focus-before-inject,
 //! then posts `KeyEvent::Text`/`Chord` as keyboard CGEvents.
 //!
-//! Ported from the proven reference `tools/macos-validation/inject_input.swift`'s
-//! `clickGlobal`/`postKey`/`typeString` (down/up via `CGEvent(mouseEventSource:...)`/
-//! `CGEvent(keyboardEventSource:virtualKey:keyDown:)` + `.post(tap: .cghidEventTap)`) and its
-//! focus-before-inject (`NSRunningApplication(processIdentifier:).activate()`), onto
-//! `objc2-core-graphics`'s generated bindings — which expose `CGEvent`'s
-//! constructors/accessors as **associated** functions taking `Option<&CGEvent>` (e.g.
-//! `CGEvent::post(tap, event)`, `CGEvent::set_flags(event, flags)`), not Swift's
-//! `self`-methods. header-translator marks all of them (and
-//! `NSRunningApplication::activateWithOptions`) as plain safe Rust functions — their only
-//! precondition, a live `CGEvent`/`CGEventSource`/`NSRunningApplication` reference, is
-//! already enforced by the type system — so no `unsafe` block is needed anywhere in this
-//! file.
+//! Ported from `tools/macos-validation/inject_input.swift`'s
+//! `clickGlobal`/`postKey`/`typeString` onto `objc2-core-graphics`'s generated bindings, which
+//! expose `CGEvent`'s constructors/accessors as **associated** functions taking
+//! `Option<&CGEvent>` (e.g. `CGEvent::post(tap, event)`), not Swift's `self`-methods.
+//! header-translator marks all of them (and `NSRunningApplication::activateWithOptions`) plain
+//! safe: their only precondition, a live `CGEvent`/`CGEventSource`/`NSRunningApplication`
+//! reference, is already enforced by the type system, so this file needs no `unsafe` block.
 //!
-//! Drag/scroll/text reuse glass_core's shared, already-unit-tested drivers
-//! ([`glass_core::run_drag`]/[`glass_core::DragGesture`], [`glass_core::run_scroll`],
-//! [`glass_core::run_type`]) — the same ones `glass-windows`/`glass-x11` sequence through
-//! their own `DragSink`/`ScrollSink`/`TypeSink` — so the waypoint interpolation/pacing/dwell
-//! math isn't reimplemented here. `KeyEvent::Chord` does not: unlike Windows/X11 (where a
-//! held modifier is a real separate key down/up event, needing `glass_core::run_chord`'s
-//! cross-frame hold-then-release ordering), macOS conveys a held modifier via
-//! `CGEventFlags` stamped directly on the key's own down/up events — the same technique
-//! `to_flags`/`MacDragSink`/`MacScrollSink` already use for pointer modifiers below — so
-//! there is no separate modifier event to sequence.
+//! Drag/scroll/text reuse glass_core's shared drivers ([`glass_core::run_drag`]/
+//! [`glass_core::DragGesture`], [`glass_core::run_scroll`], [`glass_core::run_type`]) — the
+//! same ones `glass-windows`/`glass-x11` sequence through their own
+//! `DragSink`/`ScrollSink`/`TypeSink`. `KeyEvent::Chord` does not: unlike Windows/X11, where a
+//! held modifier is a real separate key down/up event needing `glass_core::run_chord`'s
+//! hold-then-release ordering, macOS conveys a held modifier via `CGEventFlags` stamped
+//! directly on the key's own down/up events, so there is no separate event to sequence.
 //!
-//! **Main-thread affinity:** like `backend.rs`'s `start_app`/`capture_frame`, this is called
-//! from `MacosPlatform::send_pointer`/`send_key`, which glass always drives from the main
-//! thread; wiring that under glass-mcp's worker-thread dispatcher is deferred to Plan 5 (see
-//! `backend.rs`'s module doc).
+//! **Main-thread affinity:** called from `MacosPlatform::send_pointer`/`send_key`, which glass
+//! always drives from the main thread.
 
 use std::thread;
 use std::time::Duration;
@@ -62,9 +52,8 @@ fn to_cgpoint(x: i32, y: i32, scale: f64, origin_pt: (f64, f64)) -> CGPoint {
 }
 
 /// Settle after raising the target app before the first event, so the window server has
-/// finished the activation before input lands. The validated probe (`inject_input.swift`)
-/// used 300ms after `activate()`; glass's own activation call is otherwise identical, so this
-/// uses the same 300ms settle time to clear the focus-before-inject race.
+/// finished the activation before input lands. 300ms, the value the validated probe
+/// (`inject_input.swift`) used after `activate()`.
 const FOCUS_SETTLE: Duration = Duration::from_millis(300);
 
 /// Inject `event` (already window-relative PIXELS) as CGEvents targeting the app at `pid`,
@@ -184,11 +173,9 @@ pub(crate) fn send_pointer(
     Ok(())
 }
 
-/// Inter-keystroke delay for `KeyEvent::Text` typing — matches the proven reference
-/// (`inject_input.swift`'s `typeString`'s `usleep(12_000)`), so each keystroke is its own
-/// committed HID post before the next one lands (the same self-committing-per-keystroke
-/// discipline `glass-windows`/`glass-x11`/`glass-wayland` already need — see
-/// `glass_core::run_type`'s doc).
+/// Inter-keystroke delay for `KeyEvent::Text` typing — matches `inject_input.swift`'s
+/// `typeString`'s `usleep(12_000)`, so each keystroke is its own committed HID post before the
+/// next one lands (see `glass_core::run_type`'s doc).
 const KEY_TYPE_DWELL: Duration = Duration::from_millis(12);
 
 /// Inject `event` as keyboard CGEvents targeting the app at `pid`, focusing it first (same
@@ -239,11 +226,9 @@ fn tap_key(source: Option<&CGEventSource>, keycode: u16, flags: CGEventFlags) ->
 
 /// `TypeSink` for macOS: one keyDown+keyUp CGEvent pair per character — already a
 /// self-committed HID post (`CGEventPost` delivers synchronously) — so `run_type`'s
-/// inter-character dwell (`KEY_TYPE_DWELL`) lands between keystrokes exactly like the
-/// validated `inject_input.swift` probe. An unmappable char (no US-layout key —
-/// `keymap::key_for` returns `None`) fails the whole call rather than silently skipping it,
-/// per the no-silent-fallback invariant (`inject_input.swift`'s probe skips-and-warns; this
-/// backend does not).
+/// inter-character dwell (`KEY_TYPE_DWELL`) lands between keystrokes. An unmappable char (no
+/// US-layout key — `keymap::key_for` returns `None`) fails the whole call rather than silently
+/// skipping it, per the no-silent-fallback invariant.
 struct MacTypeSink<'a> {
     source: Option<&'a CGEventSource>,
 }
@@ -315,20 +300,13 @@ fn resolve_chord_key(token: &str) -> Option<(u16, bool)> {
 /// the pointer into an app it already knows the geometry of.
 ///
 /// A missing/exited process (`runningApplicationWithProcessIdentifier` returns `None`) is a
-/// hard error (final-review fix 4), not best-effort: silently posting input to "whatever
-/// currently has focus" when the target app is actually gone is exactly the kind of
-/// silent-wrong-target failure the rest of this crate's pid-scoping goes out of its way to
-/// avoid (see `scwindow.rs`'s `find_window_by_id` doc) — an agent driving a dead app should
-/// see `GlassError::AppExited`, not a keystroke/click that silently landed somewhere else. A
-/// *declined* activation (`activateWithOptions` returns `false`, e.g. the OS deprioritizes a
-/// background-app activation request) still doesn't fail the call: the process is
-/// confirmed alive, and the event still posts to whatever currently has focus, matching
-/// `glass-windows::input::send_pointer`'s own best-effort `focus_window` nudge for that
-/// narrower case.
+/// hard error, not best-effort: an agent driving a dead app should see
+/// `GlassError::AppExited`, not a keystroke that silently landed somewhere else. A *declined*
+/// activation (`activateWithOptions` returns `false`, e.g. the OS deprioritizes a background-app
+/// request) does not fail the call — the process is confirmed alive and the event still posts.
 ///
-/// `pub(crate)`: also the `NSRunningApplication(pid).activate()` step of
-/// `backend::MacosPlatform::window`'s `WindowOp::Focus` branch (Plan 4 Task 4), ahead of that
-/// branch's `axwindow::ax_raise`/`ax_set_main` — one activation call site rather than two.
+/// `pub(crate)`: also the activation step of `backend::MacosPlatform::window`'s
+/// `WindowOp::Focus` branch, ahead of its `axwindow::ax_raise`/`ax_set_main`.
 pub(crate) fn focus(pid: i32) -> Result<()> {
     let app = NSRunningApplication::runningApplicationWithProcessIdentifier(pid)
         .ok_or(GlassError::AppExited(None))?;
@@ -402,11 +380,10 @@ fn to_flags(modifiers: &[Modifier]) -> CGEventFlags {
     })
 }
 
-/// Lets `glass_core::run_drag` drive a macOS drag through CGEvent. Unlike Windows'
-/// `SendInput` (no per-event flags field, so held modifiers are real key down/up events) or
-/// X11 (XTEST key press/release), a CGEvent's `CGEventFlags` are stamped directly on every
-/// posted event — so `flags` is computed once from the gesture's modifiers and applied to
-/// every `place`/`move_to`/`button` call; `modifiers()` itself has nothing to emit.
+/// Lets `glass_core::run_drag` drive a macOS drag through CGEvent. A CGEvent's `CGEventFlags`
+/// are stamped directly on every posted event — unlike Windows' `SendInput` or X11's XTEST,
+/// where a held modifier is a real key down/up — so `flags` is computed once from the gesture's
+/// modifiers and applied to every `place`/`move_to`/`button` call; `modifiers()` emits nothing.
 struct MacDragSink<'a> {
     source: Option<&'a CGEventSource>,
     scale: f64,

--- a/crates/glass-macos/src/lib.rs
+++ b/crates/glass-macos/src/lib.rs
@@ -1,5 +1,4 @@
-//! The macOS `Platform` backend for glass (ScreenCaptureKit + CGEvent + AXUIElement,
-//! rendered onto a `CGVirtualDisplay`).
+//! The macOS `Platform` backend for glass (ScreenCaptureKit + CGEvent + AXUIElement).
 //!
 //! Like `glass-windows`, the pure logic ([`keymap`], [`coords`], [`clipboard_route`],
 //! [`shim_path`], [`bundle`], [`adoption_log`], [`settle`]) is crate-level and unit-tested on

--- a/crates/glass-macos/src/menubar.rs
+++ b/crates/glass-macos/src/menubar.rs
@@ -1,8 +1,7 @@
 //! The visible menu-bar UI: an `NSStatusItem` + `NSMenu` driven on the main-thread AppKit
 //! run loop. This module owns *only* the AppKit surface — the host (`glass-mcp`) supplies the
 //! text to show and boxed callbacks for the actionable items, so this crate stays free of
-//! glass-mcp's serve/onboarding logic (matching how every other objc2/AppKit call in this
-//! crate is confined to `glass-macos`).
+//! glass-mcp's serve/onboarding logic.
 //!
 //! ## Threading
 //!
@@ -17,11 +16,10 @@
 //! ## Actions
 //!
 //! "Quit glass" uses AppKit's built-in `terminate:` routed through the responder chain to
-//! `NSApp` (no custom target needed). "Copy endpoint", "Restart", and "Uninstall glass…" are
-//! wired to a minimal custom [`MenuTarget`] (an `objc2` `define_class!` object) that just
-//! invokes the boxed callbacks the host supplied. `setTarget:` is a *weak* reference, so the
-//! retained `MenuTarget` (and the status item and menu) are held in locals across `run`'s
-//! `NSApplication::run` call for the whole lifetime of the app.
+//! `NSApp`. "Copy endpoint", "Restart", and "Uninstall glass…" are wired to a minimal custom
+//! [`MenuTarget`] (an `objc2` `define_class!` object) that invokes the boxed callbacks the host
+//! supplied. `setTarget:` is a *weak* reference, so the retained `MenuTarget` (and the status
+//! item and menu) are held in locals across `run`'s `NSApplication::run` call.
 
 use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, NSObject, NSObjectProtocol, Sel};

--- a/crates/glass-macos/src/onboarding_window.rs
+++ b/crates/glass-macos/src/onboarding_window.rs
@@ -14,22 +14,18 @@
 //! `MainThreadMarker::new()`, `None` off the main thread) and blocks that thread on
 //! `NSApplication::run`, exactly like the menu-bar app.
 //!
-//! Unlike the menu bar, the onboarder does **not** serve: there is no background tokio
-//! server running alongside this window. The onboarding process exists only to show this
-//! window and run its loop, so `run_checklist` owns the whole main thread for its lifetime
-//! and nothing needs to have been spawned before it.
+//! Unlike the menu bar, the onboarder does **not** serve: there is no background tokio server
+//! alongside this window, so `run_checklist` owns the whole main thread for its lifetime.
 //!
 //! ## Actions
 //!
 //! Each row's "Request…" button and the footer "Re-check" button are wired to a tiny
-//! per-button [`ButtonTarget`] (an `objc2` `define_class!` object holding one boxed
-//! closure), all responding to the same `fire:` selector — the same minimal-target idiom
-//! `menubar.rs` uses, one instance per button so no selector/tag dispatch is needed. A
-//! [`WindowDelegate`] terminates the process on `windowWillClose:` so closing the window
-//! ends the run loop (the onboarder has no other windows and no server to keep alive).
-//! `setTarget:`/`setDelegate:` hold only weak references, so the retained targets, the
-//! delegate, the content view and the window are all kept in locals across
-//! `NSApplication::run` for the whole lifetime of the app.
+//! per-button [`ButtonTarget`] (an `objc2` `define_class!` object holding one boxed closure),
+//! all responding to the same `fire:` selector — one instance per button, so no selector/tag
+//! dispatch is needed. A [`WindowDelegate`] terminates the process on `windowWillClose:` so
+//! closing the window ends the run loop. `setTarget:`/`setDelegate:` hold only weak references,
+//! so the targets, the delegate, the content view and the window are all kept in locals across
+//! `NSApplication::run`.
 
 use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, NSObject, NSObjectProtocol, ProtocolObject};
@@ -201,15 +197,12 @@ fn rect(content_h: f64, x: f64, top: f64, w: f64, h: f64) -> CGRect {
 /// the process terminates (either via a row/re-check action that relaunches-and-exits, or
 /// via the window's close button → [`WindowDelegate::window_will_close`] → `terminate:`).
 ///
-/// Main-thread only, like [`crate::menubar::run`]: it takes a [`MainThreadMarker`] and
-/// blocks the calling thread (thread 0, the `#[tokio::main]` `block_on` thread) on
-/// `NSApplication::run`. Unlike the menu bar there is no background server here — the
-/// onboarder does nothing but run this window loop.
+/// Main-thread only, like [`crate::menubar::run`]: it takes a [`MainThreadMarker`] and blocks
+/// the calling thread (thread 0, the `#[tokio::main]` `block_on` thread) on
+/// `NSApplication::run`.
 ///
 /// Returns `Err` only for the one precondition this crate can enforce off a real AppKit run
-/// loop: being called off the main thread. Everything else (the window appearing, the
-/// buttons firing their callbacks, the delegate terminating on close) is main-thread AppKit
-/// runtime behavior verified on-box.
+/// loop: being called off the main thread.
 pub fn run_checklist(actions: ChecklistActions) -> Result<(), String> {
     let mtm = MainThreadMarker::new().ok_or_else(|| {
         "the onboarding checklist window must start on the main thread".to_string()

--- a/crates/glass-macos/src/permissions.rs
+++ b/crates/glass-macos/src/permissions.rs
@@ -12,10 +12,8 @@ use objc2_core_foundation::{
 
 use glass_core::Result;
 
-/// The two macOS TCC grants glass needs. A local enum keeps the permission names in
-/// one place (no stringly-typed drift) and lets the preflight test assert the specific
-/// missing grant. Converted to a `String` only at the `GlassError` boundary — the shared
-/// `glass-core` error stays platform-agnostic.
+/// The two macOS TCC grants glass needs. Converted to a `String` only at the `GlassError`
+/// boundary, so the shared `glass-core` error stays platform-agnostic.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum Permission {
     ScreenRecording,
@@ -46,12 +44,10 @@ impl Permission {
         }
     }
 
-    /// Like [`Permission::denied`], but appends a caller-supplied diagnostic (e.g. the
-    /// raw `NSError` ScreenCaptureKit reported for a TCC decline) to the remedy text, so
-    /// the agent sees both the actionable fix and the underlying OS-reported reason.
-    /// `pub(crate)` (unlike `denied`) so other modules — e.g. `scwindow`'s
-    /// `SCShareableContent` preflight — can reuse this wording instead of hand-rolling
-    /// their own remedy string.
+    /// Like [`Permission::denied`], but appends a caller-supplied diagnostic (e.g. the raw
+    /// `NSError` ScreenCaptureKit reported for a TCC decline) to the remedy text, so the agent
+    /// sees both the actionable fix and the underlying OS-reported reason. `pub(crate)` so
+    /// other modules can reuse this wording rather than hand-rolling a remedy string.
     pub(crate) fn denied_with_detail(
         self,
         detail: impl std::fmt::Display,

--- a/crates/glass-macos/src/process.rs
+++ b/crates/glass-macos/src/process.rs
@@ -9,8 +9,7 @@
 //! reimplemented here (rather than depending on that crate) because it is `/proc`-based
 //! and therefore Linux-only.
 //!
-//! Window discovery is a separate concern ([`crate::scwindow::find_window_for_pids`]);
-//! this module only owns the process lifecycle.
+//! Window discovery is a separate concern ([`crate::scwindow::find_window_for_pids`]).
 //!
 //! Clip-shim injection: a contained launch whose target is not hardened-runtime signed
 //! ([`target_is_injectable`]) gets `glass-clip-shim-macos`'s built dylib
@@ -20,9 +19,8 @@
 //! `cmd.spawn()` in [`spawn`]. `Command`'s envp is applied at the `exec` that follows
 //! `pre_exec`'s `sandbox_init` call (not at fork/`pre_exec` time), so both vars are present
 //! in the launched app's environment, having survived the sandbox. [`ClipLaunch`] carries
-//! those facts back to `start_app`, which holds them until the launched window is
-//! confirmed and the clipboard route can be decided (a later step; not this module's
-//! concern).
+//! those facts back to `start_app`, which holds them until the launched window is confirmed
+//! and the clipboard route can be decided.
 
 use std::ffi::CString;
 use std::io::{BufRead, BufReader};
@@ -43,15 +41,14 @@ use glass_sandbox_macos::{ProfileOpts, build_profile, launch_reallows};
 /// [`crate::clipboard_route::session_pasteboard_name`] (combined there with this process's pid
 /// and a wall-clock nonce). It only disambiguates multiple launches WITHIN a single `glass-mcp`
 /// run; the pid+nonce components are what prevent name reuse ACROSS runs (a bare counter resets
-/// to its start value on every restart). The exact starting value has no significance.
+/// to its start value on every restart).
 static CLIP_TOKEN: AtomicU64 = AtomicU64::new(1);
 
 /// Clip-shim facts for one contained, injectable launch: the private pasteboard name the
 /// shim redirects `NSPasteboard.generalPasteboard` to. Produced only when [`spawn`] actually
-/// set up injection (its second return value is `Some`), so injectability is encoded by the
-/// `Option` itself — there is no separate flag. `start_app` holds this until the launched
-/// window is confirmed, then combines `name` with a live shim-confirmation check to decide the
-/// session's `ClipboardRoute` (`crate::clipboard_route::decide_route`).
+/// set up injection, so injectability is encoded by the `Option` itself. `start_app` holds this
+/// until the launched window is confirmed, then combines `name` with a live shim-confirmation
+/// check to decide the session's `ClipboardRoute` (`crate::clipboard_route::decide_route`).
 #[derive(Debug)]
 pub(crate) struct ClipLaunch {
     pub name: String,
@@ -59,9 +56,8 @@ pub(crate) struct ClipLaunch {
 
 /// Whether `stderr` — a `codesign --display --verbose=2` report, with `status_success`
 /// codesign's exit status — shows a RECOGNIZED non-hardened signature, i.e.
-/// `DYLD_INSERT_LIBRARIES` injection can take on this target. Factored out of
-/// [`target_is_injectable`] as a pure function so the decision is unit-testable without
-/// shelling out to `codesign`.
+/// `DYLD_INSERT_LIBRARIES` injection can take on this target. Pure, so the decision is
+/// unit-testable without shelling out to `codesign`.
 ///
 /// Fail-closed: `true` only on a recognized non-hardened signal, `false` otherwise (including
 /// any unrecognized/garbled output). Injectable iff either:
@@ -87,12 +83,11 @@ fn injectable_from_codesign_report(stderr: &str, status_success: bool) -> bool {
 }
 
 /// True iff `program` is not hardened-runtime signed, so injecting the clip shim via
-/// `DYLD_INSERT_LIBRARIES` can take. Shells out to `codesign --display --verbose=2`
-/// (codesign writes its report to stderr, not stdout) rather than linking a
-/// Security-framework binding — simplest option, no new framework dependency.
+/// `DYLD_INSERT_LIBRARIES` can take. Shells out to `codesign --display --verbose=2`, which
+/// writes its report to stderr, not stdout.
 ///
-/// Conservative and fail-closed: any uncertainty (`codesign` missing or unspawnable, its
-/// output not valid UTF-8, or an unrecognized report) reports `false` (non-injectable). See
+/// Fail-closed: any uncertainty (`codesign` missing or unspawnable, its output not valid UTF-8,
+/// or an unrecognized report) reports `false` (non-injectable). See
 /// [`injectable_from_codesign_report`] for the exact recognized-signal logic.
 fn target_is_injectable(program: &Path) -> bool {
     let Ok(output) = Command::new("codesign")
@@ -136,9 +131,8 @@ pub(crate) fn is_apple_platform_code(bundle: &Path) -> bool {
 const SHIM_DYLIB_ENV: &str = "GLASS_CLIP_SHIM_DYLIB";
 
 /// [`crate::shim_path::resolve_shim`] against the real environment: the running executable's
-/// directory and [`SHIM_DYLIB_ENV`]. The tier logic itself is pure and lives in
-/// [`crate::shim_path`] (unit-tested on any host); this wrapper only supplies the
-/// two OS-touching inputs it needs.
+/// directory and [`SHIM_DYLIB_ENV`]. This wrapper supplies only those two OS-touching inputs;
+/// the tier logic itself is pure and lives in [`crate::shim_path`].
 fn shim_dylib_path() -> Option<PathBuf> {
     shim_dylib_path_with(std::env::var(SHIM_DYLIB_ENV).ok().map(PathBuf::from))
 }
@@ -383,8 +377,7 @@ fn spawn_reader<R: std::io::Read + Send + 'static>(reader: R, stream: Stream, si
 /// AppKit installs no `SIGTERM` handler, so the default disposition ends the process with
 /// `applicationWillTerminate:` never called and nothing flushed — measured, not assumed (see
 /// [`crate::ffi::terminate_app`]). An app that ignores or vetoes the request still gets the
-/// full signal ladder afterwards, so teardown always completes; this only adds the chance to
-/// leave cleanly, it does not make the process harder to stop.
+/// full signal ladder afterwards.
 ///
 /// This is the child-backed path. A LaunchServices-adopted app (`backend.rs`'s `Adopted`) that
 /// glass started is asked the same way but never escalated — glass will not force-kill an app it
@@ -586,13 +579,11 @@ mod tests {
         );
     }
 
-    /// Regression test for the fix this branch ships: `launch_reallows` re-allows the launch
-    /// target's OWN directory independent of `cwd` — previously only `cwd` was reallowed under the
-    /// `/Users` read-deny, so a launch target (the program itself) living under `$HOME` but
-    /// launched with a `cwd` OUTSIDE `$HOME` would fail to start (it could not even be read to be
-    /// exec'd). This is the macOS analog of the Linux
-    /// `sandbox_default_reaches_launch_target_via_argument_path` integration test; it runs on real
-    /// macOS hardware (CI macOS runner + on-device) only.
+    /// `launch_reallows` re-allows the launch target's OWN directory independent of `cwd`. With
+    /// only `cwd` reallowed under the `/Users` read-deny, a launch target living under `$HOME`
+    /// but launched with a `cwd` OUTSIDE `$HOME` could not even be read to be exec'd. The macOS
+    /// analog of the Linux `sandbox_default_reaches_launch_target_via_argument_path` integration
+    /// test; runs on real macOS hardware only.
     #[test]
     #[cfg(target_os = "macos")]
     fn default_sandbox_reaches_launch_target_under_home_when_cwd_is_elsewhere() {

--- a/crates/glass-macos/src/scwindow.rs
+++ b/crates/glass-macos/src/scwindow.rs
@@ -1,37 +1,28 @@
-//! `SCShareableContent` window discovery by pid, and by `CGWindowID` (Plan 4's
-//! active-window retargeting).
+//! `SCShareableContent` window discovery by pid, and by `CGWindowID` (active-window
+//! retargeting).
 //!
-//! Polls ScreenCaptureKit's `SCShareableContent` enumeration — the same async
-//! completion-handler API proven end-to-end in the objc2 spike — for the first on-screen
-//! window
-//! owned by one of a set of pids ([`find_window_for_pids`], the launched app's process
-//! set) or for the specific on-screen window with a given `CGWindowID` that is *also* owned
-//! by one of that same pid set ([`find_window_by_id`], `MacosPlatform`'s active window once
-//! `select_window` has run — the pid scoping closes a silent-wrong-target hole a bare
-//! `CGWindowID` match would otherwise open, since window ids are not namespaced per app),
-//! following `ffi.rs`'s documented async-bridge convention.
+//! Polls ScreenCaptureKit's `SCShareableContent` enumeration for the first on-screen window
+//! owned by one of a set of pids ([`find_window_for_pids`], the launched app's process set) or
+//! for the specific on-screen window with a given `CGWindowID` that is *also* owned by one of
+//! that same pid set ([`find_window_by_id`]) — window ids are not namespaced per app, so the
+//! pid scoping closes a silent-wrong-target hole a bare `CGWindowID` match would open. Follows
+//! `ffi.rs`'s documented async-bridge convention.
 //!
 //! ## Why this returns [`WindowMatch`], not `Retained<SCWindow>`
 //!
-//! The natural signature would return `(Retained<SCWindow>, WindowGeometry)`. That isn't
-//! achievable safely: `SCShareableContent`'s completion handler fires on an internal
-//! ScreenCaptureKit queue, not this function's calling thread, and `objc2`'s
-//! `Retained<T>` is only `Send`/`Sync` when `T: Send + Sync`
-//! (`unsafe impl<T: ?Sized + Sync + Send> Send for Retained<T> {}` in `objc2`'s
-//! `rc::retained` module) — `SCWindow` (an `extern_class!`-declared binding with no such
-//! bound, confirmed by reading the generated source: no `unsafe impl Send`/`Sync` for it
-//! anywhere in `objc2-screen-capture-kit`) is neither. Apple never documents `SCWindow`'s
-//! methods as safe to call concurrently from multiple threads, so `objc2` doesn't assert
-//! it either. Smuggling a `Retained<SCWindow>` out of the completion block via a raw
-//! pointer + `unsafe impl Send` wrapper would compile, but there'd be no real safety
-//! argument backing it — exactly the gotcha `ffi.rs`'s module doc warns against ("never
-//! send a `Retained<T>`/raw objc2 object across the channel").
+//! `SCShareableContent`'s completion handler fires on an internal ScreenCaptureKit queue, not
+//! the calling thread, and `objc2`'s `Retained<T>` is only `Send`/`Sync` when `T: Send + Sync`
+//! (`unsafe impl<T: ?Sized + Sync + Send> Send for Retained<T> {}` in `objc2`'s `rc::retained`
+//! module). `SCWindow` is neither: `objc2-screen-capture-kit` declares it via `extern_class!`
+//! with no such bound, and Apple never documents its methods as safe to call concurrently.
+//! Smuggling one out of the completion block via a raw pointer + `unsafe impl Send` wrapper
+//! compiles with no safety argument behind it — the gotcha `ffi.rs`'s module doc warns against
+//! ("never send a `Retained<T>`/raw objc2 object across the channel").
 //!
-//! Instead, [`find_window_for_pids`] returns [`WindowMatch`]: the owning pid, the
-//! `CGWindowID` (a plain `u32`, stable for the window's lifetime and re-findable via a
-//! fresh query), and the geometry. That's everything a later capture call needs to
-//! re-resolve the exact window — which it must do per-call anyway, since a
-//! `Retained<SCWindow>` can't be cached across the same thread-crossing boundary.
+//! Instead, [`find_window_for_pids`] returns [`WindowMatch`]: the owning pid, the `CGWindowID`
+//! (a plain `u32`, stable for the window's lifetime and re-findable via a fresh query), and the
+//! geometry — everything a later capture call needs to re-resolve the exact window, which it
+//! must do per-call anyway.
 
 use std::sync::mpsc;
 use std::time::Duration;
@@ -76,12 +67,10 @@ pub(crate) struct WindowMatch {
     pub(crate) origin_pt: (f64, f64),
 }
 
-/// A discovered on-screen window, as returned by [`list_app_windows`] (Plan 4's
-/// `list_windows`): the `CGWindowID`, pixel geometry, title, and owning application name —
-/// everything `backend::list_windows` needs to build a `WindowInfo` per window. Same
-/// can't-hold-a-live-`SCWindow`-across-the-completion-boundary rationale as [`WindowMatch`]
-/// (see the module doc); `title`/`application_name` are read out as owned `String`s inside
-/// the completion block for the same reason `WindowMatch`'s fields are plain owned data.
+/// A discovered on-screen window, as returned by [`list_app_windows`]: the `CGWindowID`, pixel
+/// geometry, title, and owning application name — everything `backend::list_windows` needs to
+/// build a `WindowInfo` per window. `title`/`application_name` are read out as owned `String`s
+/// inside the completion block, same rationale as [`WindowMatch`] (see the module doc).
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct AppWindow {
     /// `SCWindow.windowID()` (`CGWindowID`) — becomes `WindowInfo.id`.
@@ -100,8 +89,6 @@ pub(crate) struct AppWindow {
 
 /// Poll `SCShareableContent` roughly every 100ms for the first on-screen window whose
 /// `owningApplication().processID()` is in `pids`, until found or `timeout` elapses.
-/// Multi-window selection (picking among several matches for the same app) is Plan 4;
-/// this returns the first on-screen match.
 ///
 /// Calls [`crate::ffi::app_kit_init`] first to establish the window-server connection —
 /// required before any ScreenCaptureKit call from a bare CLI process (see `ffi.rs`).
@@ -111,15 +98,11 @@ pub(crate) struct AppWindow {
 /// [`GlassError::CaptureFailed`] for anything else) or [`GlassError::Timeout`] if no
 /// matching window appears before `timeout` elapses.
 ///
-/// `MacosPlatform::start_app` still can't use this directly: it runs its own poll loop
-/// (`backend.rs::discover_window`) that alternates a single `query_once_with_candidates`
-/// attempt with `child.try_wait()` so a crashed launch fails fast with `AppExited`, and
-/// this function's self-contained `poll_until` has no child handle to race against. But
-/// `MacosPlatform::send_pointer` does call this directly on every invocation, to
-/// re-resolve the window's current geometry/scale/origin fresh (the window may have moved
-/// or resized since `start_app`, or since the previous `send_pointer` call) — there's no
-/// child handle to race there either (the session is already established), so this
-/// self-contained poll-until-found-or-timeout is exactly what it needs.
+/// `MacosPlatform::start_app` can't use this: it runs its own poll loop
+/// (`backend.rs::discover_window`) alternating a single `query_once_with_candidates` attempt
+/// with `child.try_wait()`, and this function's self-contained `poll_until` has no child handle
+/// to race against. `MacosPlatform::send_pointer` does call it directly on every invocation, to
+/// re-resolve the window's current geometry/scale/origin fresh.
 pub(crate) fn find_window_for_pids(pids: &[i32], timeout: Duration) -> Result<WindowMatch> {
     crate::ffi::app_kit_init();
 
@@ -130,26 +113,20 @@ pub(crate) fn find_window_for_pids(pids: &[i32], timeout: Duration) -> Result<Wi
 
 /// Poll `SCShareableContent` roughly every 100ms for the on-screen window whose
 /// `windowID() == window_id` AND `owningApplication().processID() ∈ pids`, until found or
-/// `timeout` elapses. This is Plan 4's active-window retargeting lookup: `backend.rs` calls
-/// it on every `capture_frame`/`send_pointer`/`send_key` once `select_window` has set an
-/// active `CGWindowID`, in place of [`find_window_for_pids`]'s first-on-screen-by-pid
-/// resolution — see its module doc for why re-resolving fresh per call (rather than caching
-/// a `Retained<SCWindow>`) is the only safe option.
+/// `timeout` elapses. The active-window retargeting lookup: `backend.rs` calls it on every
+/// `capture_frame`/`send_pointer`/`send_key` once `select_window` has set an active
+/// `CGWindowID`, in place of [`find_window_for_pids`]'s first-on-screen-by-pid resolution.
 ///
-/// The `pids` filter (final-review fix 1) closes a silent-wrong-target hole: without it, a
-/// stale/foreign `CGWindowID` — e.g. left over in `MacosPlatform::active_window` after the
-/// windowing system recycles an id, or a bug that stores an id from a window that was never
-/// actually confirmed to belong to this app — would happily match *any* on-screen window
-/// system-wide, and every caller would silently capture/click/type into someone else's
-/// window. Scoping the match to `pids` turns that into a loud [`GlassError::WindowNotFound`]
-/// instead.
+/// Do not drop the `pids` filter: `windowID` is not scoped to any app, so without it a
+/// stale or foreign `CGWindowID` — one left over in `MacosPlatform::active_window` after the
+/// windowing system recycles an id — matches *any* on-screen window system-wide, and callers
+/// silently capture/click/type into someone else's window. Scoped, that becomes a loud
+/// [`GlassError::WindowNotFound`].
 ///
-/// Unlike `find_window_for_pids`'s [`GlassError::Timeout`] (appropriate while waiting for a
-/// brand-new window to first appear at launch), a `window_id` that never turns up here means
-/// a *previously known* window is gone — closed, no longer owned by `pids`, or the id was
-/// never valid — so this returns [`GlassError::WindowNotFound`] instead, matching the
-/// `Platform` contract's `select_window`/window-op error (`glass_core::platform`'s doc) for
-/// exactly that case.
+/// Unlike `find_window_for_pids`'s [`GlassError::Timeout`] (waiting for a brand-new window at
+/// launch), a `window_id` that never turns up here means a *previously known* window is gone —
+/// closed, no longer owned by `pids`, or never valid — so this returns
+/// [`GlassError::WindowNotFound`], matching the `Platform` contract's `select_window` error.
 ///
 /// Returns a classified [`GlassError::PermissionDenied`]/[`GlassError::CaptureFailed`]
 /// immediately on a genuine `SCShareableContent` failure, same as `find_window_for_pids`.
@@ -167,12 +144,10 @@ pub(crate) fn find_window_by_id(
 
 /// Whether a scan should also collect a summary of every candidate it saw.
 ///
-/// [`Candidates::Skip`] stops at the first match and allocates nothing — `capture_window`'s
-/// and `find_window_for_pids`'s fallback, reached only while `active_window` is unset; once a
-/// session has adopted a window, `capture_frame`/`resolve_active_window` resolve by id via
-/// `find_window_by_id` instead, a separate loop this enum doesn't touch. [`Candidates::Collect`]
-/// is the once-per-session adoption path, which pays for a full pass so the adoption record can
-/// name what it chose between (#263).
+/// [`Candidates::Skip`] stops at the first match and allocates nothing — `capture_window`'s and
+/// `find_window_for_pids`'s fallback, reached only while `active_window` is unset.
+/// [`Candidates::Collect`] is the once-per-session adoption path, which pays for a full pass so
+/// the adoption record can name what it chose between (#263).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum Candidates {
     Skip,
@@ -184,9 +159,8 @@ pub(crate) enum Candidates {
 /// summary of every such window in the same order, with the returned one marked adopted.
 ///
 /// One loop for both modes so the hot lookup and the adoption record can never disagree about
-/// what "the target window" means. [`find_on_screen_window_by_id`] keeps its own separate
-/// loop rather than sharing this one — it matches by `window_id` + pid, not pid alone, so
-/// there's no `Candidates`-style mode to dedup against here.
+/// what "the target window" means. [`find_on_screen_window_by_id`] keeps its own loop — it
+/// matches by `window_id` + pid, not pid alone.
 pub(crate) fn scan_on_screen_windows(
     content: &SCShareableContent,
     pids: &[i32],
@@ -252,19 +226,13 @@ pub(crate) fn find_on_screen_window(
 
 /// Find the on-screen `SCWindow` in `content.windows()` whose `windowID() == window_id` AND
 /// `owningApplication().processID() ∈ pids`, returning it alongside its owning pid. The
-/// `find_window_by_id`-side counterpart of [`find_on_screen_window`] (which filters by
-/// owning pid alone instead of a specific window + pid set): its own copy of the same
-/// on-screen filter shape as [`scan_on_screen_windows`]'s loop, not a shared call — keeping
-/// the two in sync on what "on-screen" means is a discipline, not something enforced.
-/// The `pids` check (final-review fix 1) is load-bearing, not defensive: `windowID` alone
-/// is not scoped to any particular app, so without it this would match *any* on-screen
-/// window system-wide, letting a stale/foreign `CGWindowID` silently resolve to someone
-/// else's window — see [`find_window_by_id`]'s doc. Used by [`query_once_by_id`] (which
-/// then builds a [`WindowMatch`] snapshot via [`window_match_from`], the same builder
-/// `query_once_inner` uses) and by `capture::capture_window_by_id` (which, like
-/// `capture_window`, needs the live `SCWindow` itself, still inside the same
-/// completion-handler callback, to build an `SCContentFilter` — see
-/// [`find_on_screen_window`]'s doc).
+/// `find_window_by_id`-side counterpart of [`find_on_screen_window`] (which filters by owning
+/// pid alone). Carries its own copy of [`scan_on_screen_windows`]'s on-screen filter rather
+/// than sharing it — keeping the two in sync on what "on-screen" means is a discipline, not
+/// something enforced. The `pids` check is load-bearing, not defensive: see
+/// [`find_window_by_id`]'s doc. Used by [`query_once_by_id`] and by
+/// `capture::capture_window_by_id`, which needs the live `SCWindow` itself inside the
+/// completion-handler callback to build an `SCContentFilter`.
 pub(crate) fn find_on_screen_window_by_id(
     content: &SCShareableContent,
     window_id: u32,
@@ -343,14 +311,12 @@ fn window_match_from(w: &SCWindow, pid: i32) -> WindowMatch {
 }
 
 /// Build an [`AppWindow`] snapshot from a live `SCWindow` + its already-resolved owning
-/// `app` — [`list_app_windows`]'s per-window counterpart of [`window_match_from`], reading
-/// out title and owning application name as owned `String`s alongside the same pixel
-/// geometry derivation. Takes `app` rather than re-deriving it via `w.owningApplication()`
-/// (final-review fix M3): `list_app_windows`'s loop has already called that getter once to
-/// filter by pid, so a second call here would be redundant — and since that filter already
-/// guarantees every `w` passed here has an owning application, `application_name` is always
-/// `Some` (the field stays `Option<String>` to match `AppWindow`'s general shape, matching
-/// `WindowInfo::class`'s own `Option<String>`).
+/// `app` — [`list_app_windows`]'s per-window counterpart of [`window_match_from`], reading out
+/// title and owning application name as owned `String`s alongside the same pixel geometry
+/// derivation. Takes `app` rather than re-deriving it via `w.owningApplication()`, which
+/// `list_app_windows`'s loop has already called to filter by pid. That filter also guarantees
+/// every `w` here has an owning application, so `application_name` is always `Some`; the field
+/// stays `Option<String>` to match `WindowInfo::class`.
 fn app_window_from(w: &SCWindow, app: &SCRunningApplication) -> AppWindow {
     // SAFETY: `w` is live (see `window_geometry_and_scale`'s identical note); these are
     // plain property getters with no other preconditions.
@@ -371,11 +337,10 @@ fn app_window_from(w: &SCWindow, app: &SCRunningApplication) -> AppWindow {
 }
 
 /// Enumerate every on-screen window owned by one of `pids`, via a single `SCShareableContent`
-/// query (the multi-window counterpart of [`find_window_for_pids`]'s first-match lookup —
-/// Plan 4's `list_windows`). Unlike [`find_window_for_pids`]/[`find_window_by_id`], this does
-/// not `poll_until` retry: it's a one-shot snapshot, and an app legitimately having zero
-/// on-screen windows at some moment is a normal `Ok(vec![])`, not a `Timeout`/`WindowNotFound`
-/// condition worth retrying.
+/// query (the multi-window counterpart of [`find_window_for_pids`]'s first-match lookup).
+/// Unlike [`find_window_for_pids`]/[`find_window_by_id`], this does not `poll_until` retry:
+/// it's a one-shot snapshot, and an app legitimately having zero on-screen windows at some
+/// moment is a normal `Ok(vec![])`.
 ///
 /// Calls [`crate::ffi::app_kit_init`] first, same as `find_window_for_pids`. Returns a
 /// classified error immediately on a genuine `SCShareableContent` failure (same
@@ -458,12 +423,10 @@ pub(crate) fn list_app_windows(pids: &[i32]) -> Result<Vec<AppWindow>> {
 }
 
 /// Cap on a single [`query_once`]/[`query_once_with_candidates`] attempt's wait for its
-/// `SCShareableContent` completion handler. A query resolves in well under a second in the
-/// spike's observations, so this is a wedged-handler backstop, not normal latency; kept
-/// small (rather than the old 5s) so it can't itself eat much of the outer poll loop's
-/// `timeout_ms`/deadline budget on a single bad tick — that budget is owned by the caller
-/// (`find_window_for_pids`'s `poll_until`, or `backend.rs::discover_window`'s own loop),
-/// which retries (or times out) regardless of this cap.
+/// `SCShareableContent` completion handler. A query resolves in well under a second, so this is
+/// a wedged-handler backstop, not normal latency. Kept small so it can't eat much of the outer
+/// poll loop's deadline budget on a single bad tick — that budget belongs to the caller
+/// (`find_window_for_pids`'s `poll_until`, or `backend.rs::discover_window`'s own loop).
 const QUERY_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// The shared body of [`query_once`] and [`query_once_with_candidates`]: one
@@ -477,10 +440,9 @@ const QUERY_TIMEOUT: Duration = Duration::from_secs(1);
 /// pays nothing for a candidate summary it never uses.
 ///
 /// The adopted window's geometry is read once here, from the `WindowMatch` snapshot
-/// ([`window_match_from`]) — not re-derived from the scan's own (separately-read) candidate
-/// entry — so the printed record and the geometry glass goes on to use can't diverge even in
-/// theory (final-review fix, #263): whichever candidate is `adopted` gets its `geometry`
-/// overwritten with the `WindowMatch`'s.
+/// ([`window_match_from`]) — not re-derived from the scan's own separately-read candidate entry
+/// — so the printed record and the geometry glass goes on to use can't diverge (#263):
+/// whichever candidate is `adopted` gets its `geometry` overwritten with the `WindowMatch`'s.
 fn query_once_inner(
     pids: &[i32],
     collect: Candidates,
@@ -568,8 +530,8 @@ enum CandidateQueryReply {
 
 /// [`find_window_by_id`]'s per-attempt round trip — identical shape to [`query_once`] (same
 /// `RcBlock` -> `mpsc` bridge, same `QUERY_TIMEOUT` cap, same error classification) but
-/// matching on a specific `window_id` (scoped to `pids`, final-review fix 1) via
-/// [`find_on_screen_window_by_id`] instead of an owning-pid set alone.
+/// matching on a specific `window_id` (scoped to `pids`) via [`find_on_screen_window_by_id`]
+/// instead of an owning-pid set alone.
 fn query_once_by_id(window_id: u32, pids: &[i32]) -> Result<Option<WindowMatch>> {
     let (tx, rx) = mpsc::channel::<QueryReply>();
     let pids_owned: Vec<i32> = pids.to_vec();

--- a/crates/glass-macos/src/session.rs
+++ b/crates/glass-macos/src/session.rs
@@ -9,16 +9,11 @@
 //! There's a second, distinct failure mode: `CGSessionCopyCurrentDictionary` returns
 //! NULL when there's no active graphical (Aqua) login session on the *console* at
 //! all — before anyone has logged in, after everyone has logged out, or on a headless
-//! boot with auto-login off. Note this is a console-wide fact, not one scoped to the
-//! calling process: it isn't "returns NULL whenever you're on a bare SSH shell" — a
-//! bare-SSH `doctor` run on a box where an account IS logged in at the console still
-//! sees that account's real (locked/unlocked) session dict, same as a GUI-launched
-//! process would (verified by hand: `doctor` run over plain SSH against the dev Mac
-//! host, logged-in-but-unattended, reported the true unlocked state, not NoSession).
-//! What NULL actually signals is "capture/input have nothing to attach to *regardless
-//! of who calls this*" — which is not "a present, unlocked session" and so
-//! [`SessionState`] keeps it as its own variant rather than folding it into
-//! `Unlocked` the way an early version of this predicate did.
+//! boot with auto-login off. This is a console-wide fact, not one scoped to the calling
+//! process: a bare-SSH run on a box where an account IS logged in at the console still
+//! sees that account's real locked/unlocked session dict (verified by hand). NULL means
+//! "capture/input have nothing to attach to regardless of who calls this", which is not
+//! "a present, unlocked session" — so [`SessionState`] keeps it as its own variant.
 
 use objc2_core_foundation::{CFBoolean, CFDictionary, CFNumber, CFRetained, CFString, CFType};
 
@@ -38,13 +33,10 @@ unsafe extern "C" {
     fn CGSessionCopyCurrentDictionary() -> *mut CFDictionary<CFString, CFType>;
 }
 
-/// The three states the console session can be in. Collapsing all of these to a
-/// single `bool` (as an earlier version of this predicate did) hides
-/// [`SessionState::NoSession`] behind "unlocked", which would let a box with nobody
-/// logged in at the console sail through `doctor` with a clean bill of health while
-/// capture/input silently fail. Keeping the three states distinct lets callers —
-/// [`session_state`]'s only consumer today is `glass-mcp`'s doctor — report each
-/// honestly.
+/// The three states the console session can be in. Do not collapse them to a single `bool`:
+/// that hides [`SessionState::NoSession`] behind "unlocked", letting a box with nobody logged
+/// in at the console sail through `doctor` with a clean bill of health while capture/input
+/// silently fail.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SessionState {
     /// A console session is logged in and its display is unlocked/awake.
@@ -88,17 +80,13 @@ fn copy_session_dictionary() -> Option<CFRetained<CFDictionary<CFString, CFType>
     Some(unsafe { CFRetained::from_raw(nn) })
 }
 
-/// Pure: map a session dictionary (or its absence) to a [`SessionState`]. Fully safe
-/// (no OS calls), so it's unit-tested directly against synthetic dictionaries and a
-/// missing one. A `None` dictionary is [`SessionState::NoSession`] (see the module
-/// docs) — everything else means *some* window-server session is attached, so it's
-/// `Locked`/`Unlocked` depending on the key. Apple's documented type for the key is
-/// `CFBoolean`; a `CFNumber` fallback costs nothing and keeps this robust if that ever
-/// changes. A value of neither type is indeterminate — fail safe as `Locked` rather than
-/// silently reporting `Unlocked`, since `doctor` treats `Unlocked` as "capture/input
-/// should work" and a false-negative there just means a redundant "recover with
-/// `caffeinate -d`" hint, while a false-positive `Unlocked` would hide a real capture/
-/// input failure behind a clean bill of health.
+/// Pure: map a session dictionary (or its absence) to a [`SessionState`]. A `None` dictionary
+/// is [`SessionState::NoSession`] (see the module docs); everything else means *some*
+/// window-server session is attached, so it's `Locked`/`Unlocked` depending on the key. Apple's
+/// documented type for the key is `CFBoolean`, with a `CFNumber` fallback in case that changes.
+/// A value of neither type is indeterminate and fails safe as `Locked`: a false `Locked` costs
+/// a redundant "recover with `caffeinate -d`" hint, while a false `Unlocked` would hide a real
+/// capture/input failure behind a clean bill of health.
 fn dict_reports_state(dict: Option<&CFDictionary<CFString, CFType>>) -> SessionState {
     let Some(dict) = dict else {
         return SessionState::NoSession;

--- a/crates/glass-macos/src/settle.rs
+++ b/crates/glass-macos/src/settle.rs
@@ -5,8 +5,7 @@
 //! [`SettleTracker`] decides when a run of readings has stopped changing; [`settle_by_polling`]
 //! owns the poll loop itself (sleeping between reads) so a caller only has to supply how to take
 //! one reading. Kept generic and out of the `#[cfg(target_os = "macos")]` modules so the rule is
-//! unit-tested on any host, and so `glass-core` could adopt it if the other backends turn out to
-//! race the same way.
+//! unit-tested on any host.
 #![forbid(unsafe_code)]
 
 use std::time::{Duration, Instant};
@@ -23,11 +22,10 @@ pub(crate) enum SettleStep<T> {
 
 /// Feeds readings in, one at a time, and reports the first time two consecutive readings agree.
 ///
-/// Two samples rather than three or a fixed duration: a value that was already stable when first
-/// read needs only one more reading to confirm it — the cheapest path through this loop, though
-/// not the likely one. On the macOS backend that motivated this (#263), it was the minority
-/// outcome: 1 of 12 measured cold launches was already stable at adoption; the other 11 needed
-/// further polling before settling.
+/// Two samples rather than three or a fixed duration: a value already stable when first read
+/// needs only one more reading to confirm it. On the macOS backend that motivated this (#263)
+/// that was the minority outcome — 1 of 12 measured cold launches was already stable at
+/// adoption; the other 11 needed further polling.
 #[derive(Clone, Debug)]
 pub(crate) struct SettleTracker<T> {
     previous: Option<T>,
@@ -79,19 +77,15 @@ pub enum SettleOutcome<E> {
 /// `read` never succeeded — paired with how the poll ended.
 ///
 /// `interval` throttles `read`: a value that never settles is called roughly
-/// `budget / (interval + read's own cost)` times — `interval` alone only bounds the count when
-/// `read` is cheap relative to it, which is true of the tests below (an instant closure) but not
-/// of a real `read` that does I/O. `Duration::ZERO` busy-spins between calls rather than pacing
-/// them — fine for a test with a cheap, instant `read`, but not the shape a real caller wants.
-/// The one production caller today (macOS's `settle_window`, #263) uses 25ms, well under its
-/// own `read`'s cost (a live query), so pacing there comes mostly from the query itself.
+/// `budget / (interval + read's own cost)` times, so `interval` alone bounds the count only when
+/// `read` is cheap relative to it — true of the tests below (an instant closure), not of a real
+/// `read` that does I/O. `Duration::ZERO` busy-spins between calls rather than pacing them.
 ///
-/// `T`'s `PartialEq` decides settlement on the *whole* value — pick a `T` that carries only the
+/// `T`'s `PartialEq` decides settlement on the *whole* value — pick a `T` carrying only the
 /// fields that should hold the loop open while they change. A `T` with an extra field that never
-/// repeats (an unrounded coordinate a rounded one was derived from, say) never settles, even once
-/// the fields that actually matter have stopped moving; see the caller-side regression this was
-/// built to close, `settle_window` (`backend.rs`, #263), and this module's own
-/// `a_wide_t_never_settles_while_any_of_its_fields_keeps_drifting` test.
+/// repeats (an unrounded coordinate a rounded one was derived from, say) never settles, even
+/// once the fields that matter have stopped moving; see `settle_window` (`backend.rs`, #263) and
+/// the `a_wide_t_never_settles_while_any_of_its_fields_keeps_drifting` test below.
 pub fn settle_by_polling<T, E>(
     seed: T,
     budget: Duration,
@@ -249,8 +243,7 @@ mod tests {
 
     /// A `read` that fails on its very first call — before any reading past the seed ever
     /// succeeded — must report the seed itself, per `settle_by_polling`'s own doc ("seed itself
-    /// if `read` never succeeded"). The previous failure test only proves a *later* failure keeps
-    /// the last good reading; this covers the zero-successes case that doc separately promises.
+    /// if `read` never succeeded").
     #[test]
     fn a_read_failure_on_the_first_poll_reports_the_seed() {
         let (value, outcome) =

--- a/crates/glass-macos/tests/bundle_launch.rs
+++ b/crates/glass-macos/tests/bundle_launch.rs
@@ -1,4 +1,4 @@
-//! Mac-gated `.app`-bundle-launch integration test — the first real-bundle proof of
+//! Mac-gated `.app`-bundle-launch integration test over
 //! `MacosPlatform::start_app`'s `.app` branch (`backend.rs::start_bundle`): direct-spawn
 //! the bundle's inner executable first, fall back to an `NSWorkspace` handoff only if that
 //! stub exits before a window appears, and fail closed if the handoff would need
@@ -75,11 +75,9 @@ mod macos_main {
     /// A stock-macOS handoff app. NOTE the mechanism is not what it looks like: it does not
     /// re-exec itself through LaunchServices. Directly spawning `Contents/MacOS/TextEdit` gets
     /// the process `SIGKILL`ed by the kernel for a launch-constraint violation (`CODESIGNING`),
-    /// which used to reach `start_bundle` as the same `AppExited` signal a re-exec stub would —
-    /// and left a crash report each time. `start_bundle` now recognizes platform code and hands
-    /// off without spawning, which is the path checks 2
-    /// and 3 need, without shipping a second custom `.app`. Present on every stock macOS
-    /// install (unlike a third-party app), so no availability probe is needed.
+    /// so `start_bundle` recognizes platform code and hands off without spawning — the path
+    /// checks 2 and 3 need. Present on every stock macOS install, so no availability probe is
+    /// needed.
     const TEXT_EDIT: &str = "/System/Applications/TextEdit.app";
 
     /// `CFBundleIdentifier` [`build_demo_app`] writes into the fixture's `Info.plist` —
@@ -198,10 +196,9 @@ mod macos_main {
         Ok((bundle, out_dir))
     }
 
-    /// Build the `AppSpec` every check here launches: `run[0]` is `run0` (a `.app` bundle
-    /// path in every call site), sandboxed at `sandbox`, with the fixed no-build/no-a11y/
-    /// 8s-timeout settings none of the three checks vary. Extracted because checks 2 and 3
-    /// launch the identical `TEXT_EDIT` target and differ only in `sandbox`.
+    /// Build the `AppSpec` every check here launches: `run[0]` is `run0` (a `.app` bundle path
+    /// in every call site), sandboxed at `sandbox`, with the fixed no-build/no-a11y/8s-timeout
+    /// settings none of the three checks vary.
     fn bundle_spec(run0: impl Into<String>, sandbox: SandboxLevel) -> AppSpec {
         AppSpec {
             build: None,
@@ -216,13 +213,9 @@ mod macos_main {
     }
 
     /// Run `body`, then always call `platform.stop_app()` before returning — regardless of
-    /// whether `body` succeeded — so a failing check never leaks whatever it started.
-    /// Mirrors the sibling tests' `run()`/`run_checks` cleanup-always-runs discipline,
-    /// collapsed into one helper since each check function here owns a short-lived
-    /// `MacosPlatform` of its own rather than sharing one across the whole file. On success,
-    /// a `stop_app` failure becomes the check's own failure; on an already-failing `body`,
-    /// a `stop_app` failure is only logged (the original failure is more informative and
-    /// must not be masked).
+    /// whether `body` succeeded — so a failing check never leaks whatever it started. On
+    /// success, a `stop_app` failure becomes the check's own failure; on an already-failing
+    /// `body` it is only logged, so it can't mask the original failure.
     fn with_stop_app<T>(
         platform: &mut MacosPlatform,
         body: impl FnOnce(&mut MacosPlatform) -> Result<T, String>,
@@ -240,13 +233,12 @@ mod macos_main {
         }
     }
 
-    /// The result of running one check. Kept distinct from a plain `Result` so a missing
-    /// precondition for ONE check (`Skipped`) is reported as skipped-not-passed and, crucially,
-    /// never causes the OTHER checks to be skipped — the pathological "the whole test silently
-    /// passes because a single precondition was absent" shape. `Ran(Ok(()))` passed;
-    /// `Ran(Err(_))` failed with a reason; `Skipped(_)` asserted nothing. Each check gates
-    /// itself on ONLY the precondition it actually needs (swiftc for check 1; `TextEdit.app`
-    /// for checks 2/3), so `run` no longer has any blanket gate that could skip everything.
+    /// The result of running one check. Distinct from a plain `Result` so a missing precondition
+    /// for ONE check (`Skipped`) is reported as skipped-not-passed and never causes the OTHER
+    /// checks to be skipped — the pathological "the whole test silently passes because a single
+    /// precondition was absent" shape. `Ran(Ok(()))` passed; `Ran(Err(_))` failed with a reason;
+    /// `Skipped(_)` asserted nothing. Each check gates itself on ONLY the precondition it needs
+    /// (swiftc for check 1; `TextEdit.app` for checks 2/3) — do not add a blanket gate in `run`.
     enum Outcome {
         Ran(Result<(), String>),
         Skipped(String),

--- a/crates/glass-macos/tests/role_probe.rs
+++ b/crates/glass-macos/tests/role_probe.rs
@@ -148,7 +148,7 @@ mod macos_main {
     ///
     /// Never asserted and never fatal: a latency bound would flake on a loaded box, and a snapshot
     /// that fails here must not cost this app its role-parity check or the later apps their runs.
-    /// Twin of `render_snapshot_cost` in `glass-windows/tests/onbox.rs` — keep the two in step.
+    /// Twin of `render_snapshot_cost` in `glass-windows/tests/onbox.rs`.
     fn print_snapshot_cost(a11y: &mut MacosA11y, ctx: &AxContext) {
         let mut samples = Vec::with_capacity(COST_REPEATS);
         for repeat in 0..COST_REPEATS {
@@ -218,13 +218,12 @@ mod macos_main {
     /// regardless; see [`WalkLimits::from_max_nodes`]), print its role histogram, then stop
     /// it. Returns `Err` when the app could not be launched, a snapshot could not be taken at
     /// all, or a token glass maps came back unmapped ([`mapped_token_violations`]) — never
-    /// merely because an app exposed something unexpected (see this file's module doc). Beyond
-    /// that one check the histogram's contents are never asserted; reading the printed output
-    /// to decide which `Gap` cell in `glass_core::role_support::ROLE_SUPPORT` a real native
-    /// token now justifies filling is the human's job.
-    /// `Ok` carries how many of this app's nodes the reader gave a description — an observation
-    /// per app (an app with no `AXHelp` is a legitimate zero), summed by [`run`] so a whole run
-    /// of zeros can be challenged there.
+    /// merely because an app exposed something unexpected. Beyond that one check the histogram's
+    /// contents are never asserted; deciding which `Gap` cell in
+    /// `glass_core::role_support::ROLE_SUPPORT` a real native token justifies filling is the
+    /// human's job. `Ok` carries how many of this app's nodes the reader gave a description (an
+    /// app with no `AXHelp` is a legitimate zero), summed by [`run`] so a whole run of zeros can
+    /// be challenged there.
     fn probe_one(run0: &str) -> Result<usize, String> {
         println!("\n--- launching {run0} ---");
         let mut platform =

--- a/crates/glass-macos/tests/window_adopt_probe.rs
+++ b/crates/glass-macos/tests/window_adopt_probe.rs
@@ -85,14 +85,13 @@ mod macos_main {
     /// How often, and for how long, to re-read the adopted window's geometry once the first
     /// enumeration pass has run (see `ENUMERATIONS`) — so sampling starts one `list_windows` round
     /// trip after `start_app` returns, not at zero. macOS reports a window's geometry while it is
-    /// still opening, so the value adoption captured can be a frame of that animation; sampling
-    /// densely is how the shape of the animation becomes visible rather than inferred. 10ms is a
+    /// still opening, so the value adoption captured can be a frame of that animation. 10ms is a
     /// floor, not a guarantee — each sample is a real round trip
-    /// (`platform.window(&WindowOp::Geometry)`, an AX read — the same reader #263's actual symptom
-    /// was about, not the `SCShareableContent` path `start_app`/`settle_window` themselves poll),
-    /// so the printed offsets are what actually happened. Those offsets are relative to sampling's
-    /// own start; the enumeration series prints `t+` from `start_app`'s return, so the two blocks'
-    /// timestamps share a format but not an origin.
+    /// (`platform.window(&WindowOp::Geometry)`, an AX read — the reader #263's symptom was about,
+    /// not the `SCShareableContent` path `start_app`/`settle_window` poll), so the printed
+    /// offsets are what actually happened. Those offsets are relative to sampling's own start;
+    /// the enumeration series prints `t+` from `start_app`'s return, so the two blocks' timestamps
+    /// share a format but not an origin.
     const EARLY_SAMPLE_INTERVAL: Duration = Duration::from_millis(10);
     const EARLY_SAMPLE_WINDOW: Duration = Duration::from_millis(300);
 
@@ -149,8 +148,7 @@ mod macos_main {
     /// `start_app` itself took: its total end-to-end wall clock (process launch through
     /// LaunchServices, first-window creation, window discovery, and the settle — `MacosPlatform`
     /// is already constructed by the time this timer starts, so its own AX/Screen-Recording
-    /// preflight is not part of it), launch-dominated rather than the settle's own increment —
-    /// isolating that would need an A/B sweep against a build without it.
+    /// preflight is not part of it). Launch-dominated, not the settle's own increment.
     struct RunOutcome {
         matched: bool,
         snapshot_ok: bool,

--- a/crates/glass-macos/tests/windows.rs
+++ b/crates/glass-macos/tests/windows.rs
@@ -1,15 +1,15 @@
-//! Mac-gated window-management integration test — the first real-window proof of
-//! `list_windows`/`select_window`/`window(op)` end-to-end, and in particular of the private
-//! `CGWindowID` <-> `AXUIElement` correlation (`axwindow::ax_window_for_cgwindowid`'s private
-//! `_AXUIElementGetWindow` call, contained + geometry-fallback — see `axwindow.rs`'s module
-//! doc). Every earlier Plan 4 task exercised this only against a *single* on-screen window,
-//! where "the app's only window" and "the correlated window" happen to be the same thing
-//! even if the correlation itself were silently broken. This test launches the extended
-//! `fixture/quadrants.swift` with TWO windows and drives ops against the *non-default* one
+//! Mac-gated window-management integration test over `list_windows`/`select_window`/
+//! `window(op)` end-to-end, and in particular the private `CGWindowID` <-> `AXUIElement`
+//! correlation (`axwindow::ax_window_for_cgwindowid`'s private `_AXUIElementGetWindow` call,
+//! contained + geometry-fallback — see `axwindow.rs`'s module doc).
+//!
+//! Must drive TWO windows: against a single on-screen window, "the app's only window" and "the
+//! correlated window" are the same thing even if the correlation is silently broken. So this
+//! launches `fixture/quadrants.swift` with two and drives ops against the *non-default* one
 //! (`select_window` to a specific `CGWindowID`, then `Move`/`Resize`/`Geometry`/
-//! `capture_frame` against it) — a wrong correlation would move/resize/capture the WRONG
-//! window, which the assertions below would catch (the moved/resized window's own geometry
-//! reads back wrong, or the captured pixels show the other window's palette).
+//! `capture_frame`) — a wrong correlation moves/resizes/captures the WRONG window, and the
+//! assertions below catch it (the geometry reads back wrong, or the captured pixels show the
+//! other window's palette).
 //!
 //! **`harness = false`** (see `Cargo.toml`'s `[[test]] name = "windows"` entry) for the exact
 //! same reason as `tests/capture.rs`/`tests/input.rs`: `start_app`/`list_windows`/`window`/
@@ -62,14 +62,11 @@ mod macos_main {
     /// fixed sleep for the single-window case).
     const STARTUP_SETTLE: Duration = Duration::from_millis(500);
 
-    /// Settle after `window(Resize)` before `capture_frame(None)`. Discovered empirically:
-    /// `window(Resize)`'s own read-back goes through `AXUIElement` (synchronous, and already
-    /// reflects the new size immediately), but `capture_frame`'s `SCShareableContent`/
-    /// ScreenCaptureKit path lags slightly behind the on-screen compositor catching up to a
-    /// just-resized window — capturing with zero delay observed a captured `Frame` still
-    /// reporting the PRE-resize dimensions, with pixels beyond the window's actual new bounds
-    /// reading back as transparent black. Generous relative to `input.rs`'s 400ms
-    /// `ACTION_SETTLE` for the same class of "let the window system catch up" reason.
+    /// Settle after `window(Resize)` before `capture_frame(None)`. `window(Resize)`'s own
+    /// read-back goes through `AXUIElement` and reflects the new size immediately, but
+    /// `capture_frame`'s ScreenCaptureKit path lags the compositor catching up to a just-resized
+    /// window: capturing with zero delay observed a `Frame` still reporting the PRE-resize
+    /// dimensions, with pixels beyond the new bounds reading back as transparent black.
     const RESIZE_SETTLE: Duration = Duration::from_millis(500);
 
     /// `WindowOp::Move` target, in global screen PIXELS — comfortably away from (0,0) and

--- a/crates/glass-mcp/src/doctor.rs
+++ b/crates/glass-mcp/src/doctor.rs
@@ -56,11 +56,9 @@ fn default_backend_check(raw: Option<&str>) -> Check {
 /// level (`GLASS_SANDBOX_FLOOR`, consumed by `tools::resolve_sandbox`), so an operator can
 /// confirm their policy is actually in effect without reading source or triggering a launch.
 /// Host-level and backend-independent, hence its home in `general` rather than a per-backend
-/// `sandbox` section. Pure in `raw` (the read `GLASS_SANDBOX_FLOOR` value) so it's unit-tested
-/// without touching the process environment, mirroring [`default_backend_check`]. Unlike a
-/// mis-set `GLASS_BACKEND` (which silently falls back to a host default), a `GLASS_SANDBOX_FLOOR`
-/// that fails to parse makes `resolve_sandbox` reject *every* `glass_start` call — so that case is
-/// a `Fail`, not a `Warn`.
+/// `sandbox` section. Pure in `raw`. Unlike a mis-set `GLASS_BACKEND` (which silently falls back
+/// to a host default), a `GLASS_SANDBOX_FLOOR` that fails to parse makes `resolve_sandbox`
+/// reject *every* `glass_start` call — so that case is a `Fail`, not a `Warn`.
 fn sandbox_floor_check(raw: Option<&str>, not_utf8: bool) -> Check {
     if not_utf8 {
         // A set-but-non-UTF-8 floor is treated as fail-closed by `start` (the launch is refused),
@@ -324,14 +322,12 @@ fn soften_inactive_android(checks: &mut [Check], deep_requested: bool) {
 
 /// Assemble the `[ios]` section: the base toolchain checks (`glass_ios::doctor::checks`) plus the
 /// always-present `idb_companion` check, then — when ios isn't the selected backend — soften any
-/// `Fail` to an advisory `Warn` via the shared [`soften_inactive_fails`], so a missing tool for a
-/// backend the user isn't driving doesn't fail the overall diagnosis. The companion line is
-/// appended unconditionally: it gates all iOS input + a11y, so an operator must see its status even
-/// when driving iOS per-call from a macos-default server, where an absent companion then reads as
-/// that advisory `Warn` rather than an omitted line. Unlike android, `glass_ios::doctor::checks`
-/// emits no "run with --deep" skip line, so there is no skip message to re-point. Pure over its
-/// inputs (no OS probes) so this behaviour is unit-tested on every host, not only macOS; kept out
-/// of `#[cfg]` (only its caller is macOS-only), mirroring [`idb_companion_check`].
+/// `Fail` via the shared [`soften_inactive_fails`]. The companion line is appended
+/// unconditionally: it gates all iOS input + a11y, so an operator must see its status even when
+/// driving iOS per-call from a macos-default server, where an absent companion reads as that
+/// advisory `Warn` rather than an omitted line. Unlike android, `glass_ios::doctor::checks`
+/// emits no "run with --deep" skip line, so there is no skip message to re-point. Pure, and kept
+/// out of `#[cfg]` (only its caller is macOS-only) so it is tested on every host.
 #[cfg_attr(not(any(target_os = "macos", test)), allow(dead_code))]
 fn ios_checks_assembled(mut base: Vec<Check>, companion: Check, ios_selected: bool) -> Vec<Check> {
     base.push(companion);
@@ -419,17 +415,13 @@ pub(crate) fn companion_deep_check(probe: glass_ios::doctor::CompanionProbe) -> 
     }
 }
 
-/// macOS checks: the two TCC grants (Screen Recording, Accessibility), the console
-/// session's three-way state (unlocked/locked/nobody-logged-in), and the resolved
-/// backend. Pure — takes already-gathered facts, makes no OS calls itself — so it's
-/// unit-tested without needing real grants or a particular session state;
-/// [`macos_checks`] gathers the real facts via `glass_macos`. A locked/asleep session
-/// is a `Warn`, not a `Fail`: it's recoverable in-place (`caffeinate -d`), unlike a
-/// genuinely missing grant. No account being logged in at the console at all
-/// (`SessionState::NoSession` — see `glass_macos::session`, verified to be a
-/// console-wide fact, not merely "called over SSH") is also a `Warn`: distinct from
-/// both, not fixable by unlocking, but still surfaced without failing the whole
-/// doctor run over what's usually a launch-configuration issue rather than a broken
+/// macOS checks: the two TCC grants (Screen Recording, Accessibility), the console session's
+/// three-way state (unlocked/locked/nobody-logged-in), and the resolved backend. Pure;
+/// [`macos_checks`] gathers the real facts via `glass_macos`. A locked/asleep session is a
+/// `Warn`, not a `Fail`: it's recoverable in-place (`caffeinate -d`), unlike a genuinely missing
+/// grant. No account logged in at the console at all (`SessionState::NoSession` — see
+/// `glass_macos::session`, a console-wide fact, not merely "called over SSH") is also a `Warn`:
+/// not fixable by unlocking, but usually a launch-configuration issue rather than a broken
 /// install.
 #[cfg(target_os = "macos")]
 fn macos_checks_from(

--- a/crates/glass-mcp/src/onboarding.rs
+++ b/crates/glass-mcp/src/onboarding.rs
@@ -113,8 +113,8 @@ fn grant_rows(accessibility: bool, screen_recording: bool) -> [(&'static str, bo
 
 /// Build the checklist's row widgets from this launch's TCC grant snapshot: one [`GrantRow`]
 /// per permission, each carrying its live snapshot and the "Request…" closure that requests
-/// the grant. Factored out of [`run`] so the menu-bar self-onboard fallback (Task 4) can reuse
-/// the *identical* row wiring.
+/// the grant. Shared with the menu-bar self-onboard fallback, which reuses the *identical* row
+/// wiring.
 ///
 /// Only the row widgets are shared, not a whole [`ChecklistActions`] — `on_recheck` is
 /// necessarily per-caller: the onboarder's recheck relaunches a fresh process and `exit(0)`s

--- a/crates/glass-mcp/src/setup.rs
+++ b/crates/glass-mcp/src/setup.rs
@@ -9,17 +9,15 @@
 //! This module is split so the parts that don't need macOS are unit-testable on Linux:
 //! [`RunMode`], [`registration_line`], [`fill_launch_agent`], [`run_mode_from_flags`],
 //! [`is_inside_app_bundle`], [`codesign_report_is_unstable`], [`parse_health_response`], and
-//! [`fetch_health`] are pure/cross-platform — a raw TCP `GET /healthz` and a JSON parse, no
-//! macOS-specific call — and are exercised (or, for `fetch_health`, reachable) on every
-//! target: `glass-mcp status` (`status.rs`) polls a running server's health on any OS, not
-//! just macOS. The interactive grant flow itself (`#[cfg(target_os = "macos")]` inside
-//! [`run`], plumbed through the private `macos_impl` submodule) is macOS-only: permission
-//! prompts, `codesign`/`launchctl` shell-outs, real file writes. `fetch_health` stays its own
-//! top-level `pub(crate) fn` rather than moving into `macos_impl` (itself macOS-only) since
-//! it has callers both outside that module and outside macOS entirely (see its doc comment).
-//! The onboarding module also needs to install the LaunchAgent, so a thin top-level
-//! `install_launch_agent` forwards to `macos_impl::install_launch_agent` for the same reason:
-//! a private `mod` can't be named from a sibling module regardless of its items' visibility.
+//! [`fetch_health`] are pure/cross-platform. The interactive grant flow itself
+//! (`#[cfg(target_os = "macos")]` inside [`run`], plumbed through the private `macos_impl`
+//! submodule) is macOS-only: permission prompts, `codesign`/`launchctl` shell-outs, real file
+//! writes.
+//!
+//! The thin top-level forwarders to `macos_impl` ([`fetch_health`], `install_launch_agent`,
+//! `restart_launch_agent`, `uninstall_launch_agent`) exist because a private `mod` can't be
+//! named from a sibling module regardless of its items' visibility, and those items have
+//! callers in `onboarding`/`menubar`/`status`.
 
 // `GlassError` itself is only named in the `#[cfg(not(target_os = "macos"))]` arm of `run`
 // (and its test) — on a macOS build that arm doesn't exist, so import only `Result` here
@@ -126,10 +124,8 @@ pub fn surviving_placeholders(filled: &str, fields: LaunchAgentFields<'_>) -> Ve
 
 /// Decide the run mode from the `--launchagent`/`--no-launchagent` flags alone, without
 /// prompting. `None` means neither flag forced a choice — the caller must ask interactively,
-/// or fall back to a non-prompting default (`--non-interactive`). Pure — no OS call, no IO —
-/// same Linux-testable shape as [`registration_line`]/[`fill_launch_agent`] above; the actual
-/// prompt (when both flags are absent and the run is interactive) lives in the macOS-only
-/// body of [`run`], since reading stdin isn't something to unit-test here.
+/// or fall back to a non-prompting default (`--non-interactive`). Pure; the actual prompt (when
+/// both flags are absent and the run is interactive) lives in the macOS-only body of [`run`].
 ///
 /// Precedence: `--launchagent` wins over `--no-launchagent`. Clap's `conflicts_with` makes the
 /// `(true, true)` combination unreachable from the CLI, so the `debug_assert!` documents that
@@ -152,9 +148,8 @@ pub fn run_mode_from_flags(launchagent: bool, no_launchagent: bool) -> Option<Ru
 /// `packaging/macos/build-app.sh` produces. A TCC grant is recorded against the *process's*
 /// Designated Requirement (bundle id + signing certificate); running a bare binary outside a
 /// bundle means a grant given today has nothing stable to attach to. Advisory only — [`run`]
-/// warns, never refuses, since `setup` should still be usable from `cargo run` while
-/// iterating. Pure (no filesystem access — just path-shape matching), so it's unit-tested on
-/// Linux against fabricated paths.
+/// warns, never refuses, so `setup` stays usable from `cargo run`. Pure path-shape matching,
+/// no filesystem access.
 pub fn is_inside_app_bundle(exe: &Path) -> bool {
     let macos_dir = exe.parent();
     let contents_dir = macos_dir.and_then(Path::parent);
@@ -397,13 +392,6 @@ pub fn run(args: SetupArgs) -> Result<()> {
 /// — never a fabricated [`HealthStatus`]. Pure `std::net::TcpStream` networking, so — unlike
 /// the rest of this module — it isn't macOS-specific: cross-platform so `status::run`
 /// (`status.rs`) can poll a running server's health on any OS.
-///
-/// `pub(crate)`, and kept at the top level rather than nested in the private, macOS-only
-/// `macos_impl` module, because it has callers outside that module and outside macOS
-/// entirely — `run`'s guided-enable poll (via `macos_impl::guide_enable_and_verify` right
-/// here in `setup.rs`, macOS-only), the onboarding module's already-running health short-circuit
-/// (macOS-only), and `status::run` (every platform) — and a private `mod` can't be named from a sibling module
-/// regardless of its items' visibility. Crate-internal, so `pub(crate)`, not `pub`.
 pub(crate) fn fetch_health(addr: &str) -> Option<HealthStatus> {
     use std::io::{Read, Write};
     use std::net::{TcpStream, ToSocketAddrs};
@@ -428,12 +416,7 @@ pub(crate) fn fetch_health(addr: &str) -> Option<HealthStatus> {
 }
 
 /// Install (or reload) the LaunchAgent — a thin `pub(crate)` forwarder to
-/// [`macos_impl::install_launch_agent`]. Kept at the top level rather than called via its
-/// `macos_impl::` path, for the same reason [`fetch_health`] is: `macos_impl` is a private
-/// module, so a sibling `onboarding` module can't name `crate::setup::macos_impl::...` at
-/// all — module privacy is checked per path segment — regardless of the item's own
-/// visibility. Only a `pub(crate)` item defined directly in `setup` (this module) is
-/// reachable from a sibling module.
+/// [`macos_impl::install_launch_agent`] for `onboarding` (see this module's doc).
 #[cfg(target_os = "macos")]
 pub(crate) fn install_launch_agent(
     app_bin: &str,
@@ -443,25 +426,20 @@ pub(crate) fn install_launch_agent(
 }
 
 /// Restart the already-installed LaunchAgent — a thin `pub(crate)` forwarder to
-/// [`macos_impl::restart_launch_agent`], for the same reason [`install_launch_agent`] above
-/// has one (a sibling module can't name the private `macos_impl` module at all). A fresh
-/// process re-reads TCC (the Screen Recording grant is cached per-process at launch), so the
-/// menu-bar app's "Restart" item (`crate::menubar`) restarts after a grant changes — independent
-/// of `KeepAlive`, which is `false` precisely so the LaunchAgent itself never does this uninvited.
+/// [`macos_impl::restart_launch_agent`] (see this module's doc). A fresh process re-reads TCC
+/// (the Screen Recording grant is cached per-process at launch), so the menu-bar app's
+/// "Restart" item (`crate::menubar`) restarts after a grant changes — independent of
+/// `KeepAlive`, which is `false` precisely so the LaunchAgent never does this uninvited.
 ///
-/// Gated to `network` + macOS to match that sole caller (`crate::menubar` is itself
-/// `#[cfg(feature = "network")]`): the onboarder re-reads TCC by relaunching a fresh *process*
-/// (`open -n`, see `crate::onboarding`), not by restarting the agent, so without the `network`
-/// feature a plain macOS build would have no caller and flag this dead.
+/// Gated to `network` + macOS to match its sole caller: the onboarder re-reads TCC by
+/// relaunching a fresh *process* (`open -n`), not by restarting the agent.
 #[cfg(all(target_os = "macos", feature = "network"))]
 pub(crate) fn restart_launch_agent() -> Result<()> {
     macos_impl::restart_launch_agent()
 }
 
 /// Remove the login LaunchAgent so glass stops auto-starting — a thin `pub(crate)` forwarder to
-/// [`macos_impl::uninstall_launch_agent`], for the same reason [`install_launch_agent`] above has
-/// one (a sibling module can't name the private `macos_impl` module at all regardless of an
-/// item's own visibility).
+/// [`macos_impl::uninstall_launch_agent`] (see this module's doc).
 #[cfg(target_os = "macos")]
 pub(crate) fn uninstall_launch_agent() -> Result<()> {
     macos_impl::uninstall_launch_agent()
@@ -799,10 +777,6 @@ mod macos_impl {
     ///
     /// Errors surface (`kickstart` failing to spawn, or exiting non-zero) rather than being
     /// silently swallowed.
-    ///
-    /// Reached through [`super::restart_launch_agent`] from the menu-bar app's "Restart" item;
-    /// gated to the `network` feature to match it (see the forwarder's note), so it isn't dead
-    /// code in a plain macOS build where the menu bar isn't compiled.
     #[cfg(feature = "network")]
     pub(super) fn restart_launch_agent() -> Result<()> {
         let target = super::launch_agent_target(self_uid());

--- a/crates/glass-windows/src/input.rs
+++ b/crates/glass-windows/src/input.rs
@@ -1,4 +1,4 @@
-//! Input injection via `SendInput` (Task 7a).
+//! Input injection via `SendInput`.
 //!
 //! The pointer + Unicode-text paths are a port of the validated probe
 //! `tools/windows-validation/src/input.rs`; the chord (X keysym -> VK) mapping is

--- a/crates/glass-windows/src/lib.rs
+++ b/crates/glass-windows/src/lib.rs
@@ -128,7 +128,7 @@ mod backend {
         /// The active window, stored as a raw `HWND` (`isize`) so the backend stays
         /// `Send` (a raw `*mut c_void` is not). Reconstruct with
         /// [`crate::util::raw_to_hwnd`] at the point of use. `None` until window
-        /// discovery (here) or select (Task 6) sets it.
+        /// discovery or `select_window` sets it.
         active_hwnd: Option<isize>,
     }
 

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -1070,17 +1070,12 @@ fn onbox_contained_launch_adopts_app_not_console() {
     p.stop_app().expect("stop_app");
 }
 
-/// Where the role-histogram probe writes its report: `.windows-artifacts` under the repo
-/// root. Mirrors `examples/onbox.rs`'s `out_dir()`/`save()` convention (a resolved-at-runtime
-/// directory + a small write-and-report helper) — but targets `.windows-artifacts` directly
-/// rather than `%USERPROFILE%`. That example's `%USERPROFILE%` files get swept into
-/// `.windows-artifacts` by a step in `tools/windows-validation/run-onbox.ps1` that runs only
-/// for the plain `onbox` example; an `--ignored` test run (this probe's path, via
-/// `scripts/test-windows.sh --tests`) has no such sweep. `.windows-artifacts` itself, though,
-/// is scp'd back to the caller by `scripts/test-windows.sh` after every run regardless — and
-/// it must be, since this probe's stdout is captured by the schtasks bounce into the
-/// interactive session and never reaches the caller at all. So this file is the only way the
-/// histogram gets out.
+/// Where the role-histogram probe writes its report: `.windows-artifacts` under the repo root.
+/// Targets that directly rather than `%USERPROFILE%`, which `run-onbox.ps1` sweeps into
+/// `.windows-artifacts` only for the plain `onbox` example — an `--ignored` test run (this
+/// probe's path) gets no such sweep. `scripts/test-windows.sh` scp's `.windows-artifacts` back
+/// after every run, and it must: this probe's stdout is captured by the schtasks bounce into
+/// the interactive session and never reaches the caller, so the file is the only way out.
 fn artifacts_dir() -> std::path::PathBuf {
     repo_root().join(".windows-artifacts")
 }
@@ -1153,7 +1148,7 @@ const COST_REPEATS: usize = 10;
 /// Never asserted and never fatal: a latency bound would flake on a loaded box, and a snapshot that
 /// fails here must not strand the window the caller is about to close, cost the later probes their
 /// evidence, or skip the artifacts write. Twin of `print_snapshot_cost` in
-/// `glass-macos/tests/role_probe.rs` — keep the two in step.
+/// `glass-macos/tests/role_probe.rs`.
 fn render_snapshot_cost(a11y: &mut WindowsA11y, ctx: &AxContext) -> String {
     let mut samples = Vec::with_capacity(COST_REPEATS);
     for repeat in 0..COST_REPEATS {
@@ -1365,11 +1360,8 @@ fn probe_role_histogram(label: &str, spec: &AppSpec, report: &mut String) -> Pro
 /// map to is never asserted here; that is the human's reading.
 ///
 /// The histogram is both printed to stdout AND written to `role-histogram-windows.txt` under
-/// [`artifacts_dir`] (see that function's doc for why the file is required, not just a nicety
-/// on top of stdout): run through `scripts/test-windows.sh`, this test's stdout is captured by
-/// the schtasks bounce into the interactive session and never reaches the caller, so the file
-/// is the only way the evidence gets out of that path. Printing it too costs nothing and helps
-/// anyone running the test directly on a box with a desktop session.
+/// [`artifacts_dir`] — see that function's doc for why the file, not stdout, is the only way
+/// the evidence gets out of a `scripts/test-windows.sh` run.
 ///
 /// Runs charmap, Notepad, Task Manager, and File Explorer. charmap/Notepad alone gave clean
 /// output but no tabular UI, so `DataItem` (UIA id 50029), `Header` (50034), and


### PR DESCRIPTION
Phase 2 of the `terse-comments` sweep: the `///` and `//!` surface, after #336 covered
non-doc `//` comments.

Doc comments play by different rules — the skill lists API doc as one of the three kinds
that earn their length — so this cuts only argumentation: defence against objections the
code does not invite, self-restatement, and narration of work that has since landed. The
what, the parameters and the return of every item are unchanged.

10,736 → 6,600 words across 26 files. The diff is proven to contain no code lines.

## `params.rs` is excluded

`crates/glass-mcp/src/params.rs` derives `JsonSchema`, and schemars renders its `///`
blocks verbatim into the MCP `inputSchema.description` fields agents read to decide how to
call glass. Terse-ing it would degrade a shipped surface, so it is untouched, as are the
`#[tool(description = …)]` literals in `server.rs`.

Verified rather than assumed: `tools/list` from the release binary is byte-identical to
master's — 59,290 bytes, 30 tools, sha256 `d79df21e23f12a57`.

## Two corrections

- `CGVirtualDisplay` appeared in three glass-macos doc comments and nowhere in the code.
  `lib.rs` and `backend.rs` asserted it as current behaviour ("rendered onto a
  `CGVirtualDisplay`"); `axwindow.rs` cited it as a planned provider. All three dropped.
- `setup.rs` carried the same fact — that a private `mod` cannot be named from a sibling
  module — once per forwarder, five times over. It now appears once in the module doc.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` — 1883 passed, 0 failed
- glass-macos, glass-windows and glass-ios bodies are `cfg`-gated and do not compile on
  Linux; the per-OS CI legs are the build evidence for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)