### PR TITLE
ci(android): stream logcat for the whole run, not a dump at teardown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ mutants.out.old/
 # Pulled-back artifacts from scripts/test-windows.sh on-box runs
 /.windows-artifacts/
 
+# On-device diagnostics from scripts/ci-android-suite.sh — CI uploads these as an artifact; a local
+# run leaves a device screenshot and a whole-run logcat here.
+/diagnostics/
+
 # Fixture cruft
 **/__pycache__/
 

--- a/scripts/ci-android-suite.sh
+++ b/scripts/ci-android-suite.sh
@@ -13,9 +13,13 @@
 # diagnostics/test-output.txt carries which test failed and why; that text otherwise exists only
 # in the ephemeral job log.
 #
-# logcat is cleared before the run so the failure window isn't buried under what the AVD logged
-# beforehand, and dumped bounded (-t 5000) so an early failure isn't truncated by an oversized
-# buffer.
+# logcat streams to a file for the whole run instead of being dumped at teardown, which cannot
+# reach back to the failure. Measured on an API 34 pixel_6 AVD: still churning after a snapshot
+# restore — the package scans and Phenotype config of glass#331 — it logs 1235 lines/s, falling to
+# ~1 line/s once that settles. In that churn `logcat -d -t 5000` reaches back four seconds and the
+# 2 MiB ring buffer thirteen, against the 86s between glass#338's failure and its teardown. A whole
+# run costs tens of MB, which the upload compresses. Nothing is filtered: which tag explains the
+# next failure is not knowable in advance.
 #
 # screen-after-teardown.png is named for when it is taken: test-android.sh has already returned,
 # so a test that stops its own app leaves only the launcher on screen. Kept because it is the
@@ -39,17 +43,36 @@ if ! command -v "$adb" > /dev/null 2>&1; then
   exit 1
 fi
 
-"$adb" logcat -c
 mkdir -p diagnostics
+
+# Cleared, then opened before the suite starts, so this file's first line is the run's own first
+# line. threadtime for the pid/tid a bare timestamp doesn't carry.
+"$adb" logcat -c
+"$adb" logcat -v threadtime > diagnostics/logcat.txt 2>&1 &
+logcat_pid=$!
+# The action tears the emulator down the moment its step ends, so a writer left running meets that
+# teardown rather than this kill.
+trap 'kill "$logcat_pid" 2>/dev/null' EXIT
 
 ./scripts/test-android.sh "$@" 2>&1 | tee diagnostics/test-output.txt
 rc=${PIPESTATUS[0]}
 
 if [ "$rc" -ne 0 ]; then
-  "$adb" logcat -d -t 5000           > diagnostics/logcat.txt         2>&1
   "$adb" shell dumpsys window        > diagnostics/dumpsys-window.txt 2>&1
   "$adb" shell dumpsys activity top  > diagnostics/dumpsys-top.txt    2>&1
   "$adb" exec-out screencap -p       > diagnostics/screen-after-teardown.png 2>/dev/null
 fi
+
+# Stopped last: the capture then covers the collection above, and that collection is also the
+# drain. A line still in flight when the kill lands is lost — measured, and host-side line
+# buffering does not change it. A writer that died on its own leaves a short file that reads as a
+# complete one.
+if ! kill -0 "$logcat_pid" 2>/dev/null; then
+  echo "ci-android-suite: the logcat writer exited before the suite did; this capture ends early" \
+    | tee -a diagnostics/logcat.txt >&2
+fi
+kill "$logcat_pid" 2>/dev/null
+wait "$logcat_pid" 2>/dev/null
+trap - EXIT
 
 exit "$rc"


### PR DESCRIPTION
The nightly's logcat could not explain any of its own failures. `logcat -d -t 5000` keeps the
*newest* 5000 lines, so it truncates early failures rather than protecting them as its comment
claimed, and #338's three failures were ~86s before teardown.

Measured on an API 34 pixel_6 AVD: still churning after a snapshot restore, the device logs 1235
lines/s, falling to ~1 line/s once that settles. In that churn the flag reached back four seconds
and the 2 MiB ring buffer thirteen. Neither reaches the failure.

A writer now runs for the whole suite and stops after the on-device diagnostics, so the capture
covers those too. A writer that died on its own says so in the file rather than ending silently
mid-run.

Nothing is filtered by tag: which tag explains the next failure is not knowable in advance, and a
whole run is tens of MB the artifact upload compresses.

`/diagnostics/` is now ignored — a local suite run left an untracked device screenshot and logcat
in the tree.

## Verification

Against a live API 34 pixel_6 AVD:

| | |
|---|---|
| Pass path | rc=0, `see_loop_launches_and_captures_settings` passed on-device |
| Capture spans the run | suite 08:17:51→08:17:56, logcat 08:17:51.390→08:17:56.312 |
| Fail path | rc=101, all four diagnostics collected, capture ran past the dumpsys collection |
| Writer-died disclosure | fault-injected a dying writer; fires to stderr and into `logcat.txt` |
| Orphan writers | none |
| shellcheck, `cargo fmt --check`, clippy, `cargo test --workspace` | clean; 1883 passed |

No PR check covers this: the workflow is schedule-only since #339, so it is validated by a
`workflow_dispatch` run against this branch.

Refs #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)