### PR TITLE
fix(a11y-android): retry a uiautomator dump that crashed without saying why

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,18 @@ internal refactors, CI, or test-only changes.
   Android paths have no such live check.
 
 ### Fixed
+- An Android accessibility read no longer gives up when `uiautomator` crashes on a screen that is
+  still settling. `uiautomator dump` dies with a `NullPointerException` walking a tree whose nodes
+  are still coming and going, and it exits non-zero with nothing on stderr — its trace goes to
+  logcat — so glass saw only a bare failure and returned it as a backend error, which its readiness
+  retry deliberately does not wait out. That landed on a session's very first snapshot, the one
+  read that carries a 30-second budget for a device that is not ready, and spent none of it.
+  A dump that fails without saying why is now treated as the device not being ready, so it is
+  retried inside that budget, and the partial file such a crash leaves behind is removed rather
+  than stranded on the device once per attempt. A device that has genuinely gone away still fails
+  at once, since adb says so. Measured on an API 34 emulator entered straight from a snapshot
+  restore: 3 failures in 14 runs before, none in 10 after, including one run where the crash
+  happened and the read recovered.
 - An Android accessibility snapshot taken through the optional on-device companion now says when
   it describes a different app than the one asked about. The companion answered with whatever
   window was in front — a system dialog, a permission prompt — and reported it as the requested

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -87,8 +87,9 @@ pub(crate) fn attempt_deadline() -> Instant {
 /// One `uiautomator dump`, returning the XML it wrote. Every step is bounded by `deadline` — see
 /// [`attempt_deadline`].
 ///
-/// `uiautomator dump` exits 0 even when it fails and reports the reason on stderr, so
-/// neither its exit status nor its stdout can be trusted; the file it was asked to write
+/// `uiautomator dump` fails in two shapes: it exits 0 with the reason on stderr, or it crashes and
+/// exits non-zero with stderr empty, its trace going to logcat instead (glass#341). Neither its
+/// exit status nor its stdout can be trusted; the file it was asked to write
 /// is the only reliable success signal. That file is this attempt's alone — see
 /// [`attempt_path`], which `prefix` names the family for — so no other dump can stand in for one
 /// this attempt never wrote.
@@ -101,7 +102,19 @@ pub(crate) fn dump_once(
     deadline: Instant,
 ) -> Result<String> {
     let path = attempt_path(prefix);
-    let (_, stderr) = run(&["shell", "uiautomator", "dump", &path], deadline)?;
+    let stderr = match run(&["shell", "uiautomator", "dump", &path], deadline) {
+        Ok((_, stderr)) => stderr,
+        Err(e) if died_unexplained(&e) => {
+            // The crash is raised mid-walk, after the file is opened, so this attempt can own one
+            // even though it never finished it. Retried, each crash would strand another.
+            let _ = run(&["shell", "rm", "-f", &path], deadline);
+            return Err(GlassError::AccessibilityUnavailable(format!(
+                "uiautomator dump exited without writing {path} and without saying why; \
+                 its reason, if any, is in logcat"
+            )));
+        }
+        Err(e) => return Err(e),
+    };
     let read = run(&["shell", "cat", &path], deadline);
     let _ = run(&["shell", "rm", "-f", &path], deadline);
     match read {
@@ -131,10 +144,21 @@ fn bound_fired(e: &GlassError) -> bool {
     msg.contains(TIMED_OUT) || msg.contains(NOT_STARTED)
 }
 
-/// Dump, retrying while `uiautomator` reports it cannot serve one yet, up to `budget`.
+/// Whether a failed dump gave no reason of its own — the mark of a `uiautomator` that crashed.
 ///
-/// Only that one failure resolves by waiting: an adb or device error is returned at once,
-/// so a device that has gone away is not retried for the whole budget.
+/// It dies with a `NullPointerException` walking a tree that is still changing, exiting non-zero
+/// with an empty stderr because the trace goes to logcat via `AndroidRuntime` (glass#341). That
+/// resolves by waiting. adb's own failures — a device that is gone, a wedged server — always carry
+/// a reason and do not, so only the silent one is treated as a readiness problem.
+fn died_unexplained(e: &GlassError) -> bool {
+    !bound_fired(e) && e.to_string().trim_end().ends_with("failed:")
+}
+
+/// Dump, retrying while `uiautomator` cannot serve one yet, up to `budget`.
+///
+/// Two failures resolve by waiting — a bridge not serving yet, and the crash
+/// [`died_unexplained`] names. An adb or device error is returned at once, so a device that has
+/// gone away is not retried for the whole budget.
 ///
 /// Returns within `budget` plus one attempt — `AdbOp::Dump`'s budget, per [`attempt_deadline`].
 /// `budget` bounds the retrying, waits between attempts included, and the last attempt it starts
@@ -488,6 +512,31 @@ mod tests {
         ))
     }
 
+    /// What `Adb` raises for a `uiautomator` that crashed: a non-zero exit with **nothing** on
+    /// stderr, because the trace went to logcat via `AndroidRuntime` (glass#341).
+    fn crash_err(path: &str) -> GlassError {
+        GlassError::Backend(format!("`adb shell uiautomator dump {path}` failed: "))
+    }
+
+    /// An adb whose `uiautomator dump` crashes for `crashes` attempts, then succeeds.
+    fn fake_crashing(crashes: usize) -> impl FnMut(&[&str], Instant) -> Result<(String, String)> {
+        let mut dumps = 0;
+        move |argv: &[&str], _deadline: Instant| match argv {
+            ["shell", "uiautomator", "dump", path] => {
+                dumps += 1;
+                if dumps > crashes {
+                    Ok((DUMPED.to_string(), String::new()))
+                } else {
+                    Err(crash_err(path))
+                }
+            }
+            ["shell", "cat", _] if dumps > crashes => Ok((XML.to_string(), String::new())),
+            ["shell", "cat", path] => Err(read_err(path)),
+            ["shell", "rm", "-f", _] => Ok((String::new(), String::new())),
+            other => panic!("unexpected adb command: {other:?}"),
+        }
+    }
+
     /// An adb whose `uiautomator dump` fails as a cold device's does for `cold` attempts,
     /// then succeeds.
     fn fake(cold: usize) -> impl FnMut(&[&str], Instant) -> Result<(String, String)> {
@@ -821,6 +870,60 @@ mod tests {
         assert_eq!(
             attempts, 1,
             "must not wait out the budget on a device error"
+        );
+    }
+
+    #[test]
+    fn a_dump_that_died_without_explaining_itself_is_retried() {
+        // `uiautomator` crashes walking a tree that is still changing, exiting non-zero with an
+        // empty stderr because the trace went to logcat (glass#341). Measured at 3 failures in 14
+        // runs; a later dump against a settled tree succeeds, so waiting is the whole remedy.
+        let mut run = fake_crashing(2);
+        let xml = dump_until_ready(&mut run, PREFIX, Duration::from_secs(30), Duration::ZERO)
+            .expect("a dump that crashed must be retried inside the budget");
+        assert_eq!(xml, XML);
+    }
+
+    #[test]
+    fn a_dump_that_crashed_takes_its_partial_file_with_it() {
+        // The crash is raised inside `dumpWindowToFile`, so the file can already exist when
+        // uiautomator dies. Retrying a crash that leaves its file behind would strand one per
+        // attempt on /sdcard.
+        let mut files: HashMap<String, String> = HashMap::new();
+        let mut dumps = 0;
+        {
+            let mut run = |argv: &[&str], _deadline: Instant| -> Result<(String, String)> {
+                match argv {
+                    ["shell", "uiautomator", "dump", path] => {
+                        dumps += 1;
+                        // Opened before the walk that dies, so a crashed attempt still has one.
+                        files.insert((*path).to_string(), String::new());
+                        if dumps > 2 {
+                            files.insert((*path).to_string(), XML.to_string());
+                            Ok((DUMPED.to_string(), String::new()))
+                        } else {
+                            Err(crash_err(path))
+                        }
+                    }
+                    ["shell", "cat", path] => match files.get(*path) {
+                        Some(xml) => Ok((xml.clone(), String::new())),
+                        None => Err(read_err(path)),
+                    },
+                    ["shell", "rm", "-f", path] => {
+                        files.remove(*path);
+                        Ok((String::new(), String::new()))
+                    }
+                    other => panic!("unexpected adb command: {other:?}"),
+                }
+            };
+            dump_until_ready(&mut run, PREFIX, Duration::from_secs(30), Duration::ZERO)
+                .expect("the attempt after the crashes dumps");
+        }
+
+        assert!(
+            files.is_empty(),
+            "crashed attempts stranded {:?}",
+            files.keys().collect::<Vec<_>>()
         );
     }
 

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -105,8 +105,8 @@ pub(crate) fn dump_once(
     let stderr = match run(&["shell", "uiautomator", "dump", &path], deadline) {
         Ok((_, stderr)) => stderr,
         Err(e) if died_unexplained(&e) => {
-            // The crash is raised mid-walk, after the file is opened, so this attempt can own one
-            // even though it never finished it. Retried, each crash would strand another.
+            // The crash is raised after the file is opened, so this attempt can own one. Retried,
+            // each crash would strand another.
             let _ = run(&["shell", "rm", "-f", &path], deadline);
             return Err(GlassError::AccessibilityUnavailable(format!(
                 "uiautomator dump exited without writing {path} and without saying why; \
@@ -149,7 +149,7 @@ fn bound_fired(e: &GlassError) -> bool {
 /// It dies with a `NullPointerException` walking a tree that is still changing, exiting non-zero
 /// with an empty stderr because the trace goes to logcat via `AndroidRuntime` (glass#341). That
 /// resolves by waiting. adb's own failures — a device that is gone, a wedged server — always carry
-/// a reason and do not, so only the silent one is treated as a readiness problem.
+/// a reason and do not.
 fn died_unexplained(e: &GlassError) -> bool {
     !bound_fired(e) && e.to_string().trim_end().ends_with("failed:")
 }
@@ -512,8 +512,7 @@ mod tests {
         ))
     }
 
-    /// What `Adb` raises for a `uiautomator` that crashed: a non-zero exit with **nothing** on
-    /// stderr, because the trace went to logcat via `AndroidRuntime` (glass#341).
+    /// What `Adb` raises for the crash [`died_unexplained`] names: non-zero exit, empty stderr.
     fn crash_err(path: &str) -> GlassError {
         GlassError::Backend(format!("`adb shell uiautomator dump {path}` failed: "))
     }
@@ -875,9 +874,8 @@ mod tests {
 
     #[test]
     fn a_dump_that_died_without_explaining_itself_is_retried() {
-        // `uiautomator` crashes walking a tree that is still changing, exiting non-zero with an
-        // empty stderr because the trace went to logcat (glass#341). Measured at 3 failures in 14
-        // runs; a later dump against a settled tree succeeds, so waiting is the whole remedy.
+        // Measured at 3 failures in 14 runs entering the suite straight from a snapshot restore;
+        // a later dump against a settled tree succeeds, so waiting is the whole remedy.
         let mut run = fake_crashing(2);
         let xml = dump_until_ready(&mut run, PREFIX, Duration::from_secs(30), Duration::ZERO)
             .expect("a dump that crashed must be retried inside the budget");
@@ -886,9 +884,7 @@ mod tests {
 
     #[test]
     fn a_dump_that_crashed_takes_its_partial_file_with_it() {
-        // The crash is raised inside `dumpWindowToFile`, so the file can already exist when
-        // uiautomator dies. Retrying a crash that leaves its file behind would strand one per
-        // attempt on /sdcard.
+        // The crash is raised inside `dumpWindowToFile`, so a dead attempt can still own a file.
         let mut files: HashMap<String, String> = HashMap::new();
         let mut dumps = 0;
         {


### PR DESCRIPTION
Closes #341.

`uiautomator dump` dies with a `NullPointerException` walking a tree whose nodes are still coming and going — AOSP's `AccessibilityNodeInfoDumper.childNafCheck` calls `getContentDescription()` on a child that `getChild(i)` returned null for. It exits non-zero with **an empty stderr**, because the trace goes to logcat via `AndroidRuntime`.

glass saw a bare adb failure and raised `GlassError::Backend`, which `dump_until_ready` does not retry. That is a deliberate choice — a device that has gone away should not be waited on — but it also landed on a session's *first* snapshot, the one read carrying `DUMP_READY_TIMEOUT_MS`, and spent none of its 30 seconds.

## The change

A dump that fails **and says nothing** is now `AccessibilityUnavailable`, so the budget that already exists applies to it:

```rust
fn died_unexplained(e: &GlassError) -> bool {
    !bound_fired(e) && e.to_string().trim_end().ends_with("failed:")
}
```

adb's own failures always carry a reason, so a gone device still fails at once and `an_adb_failure_is_not_retried` still holds. **No budget or timeout value was changed.**

The crash is raised inside `dumpWindowToFile`, after the file is opened, so a crashed attempt can already own one. Without removing it, each retry stranded another on `/sdcard` — exactly what `a_snapshot_leaves_no_dump_file_on_the_device` exists to catch. That regression was caught by writing the test before assuming cleanup was unnecessary.

Also corrects two comments this falsified: `dump_once` claimed the dump always exits 0 and always explains itself on stderr, and `dump_until_ready` claimed only one failure resolves by waiting.

## Verification

On an API 34 `pixel_6` AVD entered ~250 ms after `boot_completed` from a snapshot restore — the condition #331 describes:

| | failures |
|---|---|
| before | **3 / 14 (21%)** |
| after | **0 / 10** |

10/10 green would be weak on its own at a 21% rate. The evidence is the correlation — run 08's logcat carries the crash *and* the run passes:

```
10:31:30.853  E AndroidRuntime: NullPointerException … childNafCheck(AccessibilityNodeInfoDumper.java:296)
10:31:32.140  D AndroidRuntime: Calling main entry com.android.commands.uiautomator   ← the retry
test a_snapshot_leaves_no_dump_file_on_the_device ... ok
```

Two new unit tests, each watched failing first: `a_dump_that_died_without_explaining_itself_is_retried` (failed returning `Backend(…failed: )` on attempt 1) and `a_dump_that_crashed_takes_its_partial_file_with_it` (failed with two stranded files).

`cargo fmt --check`, clippy `-D warnings`, 1885 workspace tests: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)