### PR TITLE
fix(android): say what was on screen when no window appeared, not just how long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,15 @@ internal refactors, CI, or test-only changes.
   of parsing prose. Purely additive: `report` is unchanged.
 
 ### Changed
+- A `glass_start` on Android that finds no window now says what it saw instead of just how long it
+  waited. `operation timed out after 15000 ms` gave an agent nothing to act on, and the four device
+  states behind it need different responses: the app has opened no window, its window is behind
+  another app's, it is still on its splash screen, or the window manager reported no frame for it.
+  The error now names the package it wanted and, where something else holds the screen, which
+  packages those are — for instance `no window for com.android.settings appeared within 15000 ms —
+  its window is not on screen; on screen: com.google.android.settings.intelligence`. Diagnosing
+  that one previously took a whole-run device log. The wait itself is unchanged, and so is
+  `timeout_ms`.
 - On Linux and Windows, `glass_wait_for_element` no longer re-reads the whole accessibility tree on
   a timer. Where the platform can say whether anything changed, a wait for something that has not
   happened yet now reads the tree when something changes instead of once per interval — measured at

--- a/crates/glass-android/src/parse.rs
+++ b/crates/glass-android/src/parse.rs
@@ -31,24 +31,16 @@ pub struct ParsedWindow {
 struct WinBlock {
     id: u64,
     title: String,
-    pkg_match: bool,
+    package: Option<String>,
     on_screen: bool,
     frame: Option<WindowGeometry>,
 }
 
-fn finish_block(b: WinBlock, out: &mut Vec<ParsedWindow>) {
-    // Skip the transient starting window (title `Splash Screen <pkg>`): a real app-package
-    // window during launch, but not one the agent should drive.
-    if b.pkg_match
-        && b.on_screen
-        && !b.title.starts_with("Splash Screen")
-        && let Some(frame) = b.frame
-    {
-        out.push(ParsedWindow {
-            id: b.id,
-            title: b.title,
-            frame,
-        });
+impl WinBlock {
+    /// The transient starting window, title `Splash Screen <pkg>` — a real app-package window
+    /// during launch, but not one the agent should drive.
+    fn is_splash(&self) -> bool {
+        self.title.starts_with("Splash Screen")
     }
 }
 
@@ -69,20 +61,21 @@ fn parse_window_header(t: &str) -> Option<(u64, String)> {
     Some((id, name))
 }
 
-/// All on-screen windows owned by `package`, in dumpsys z-order (topmost first).
-pub fn parse_app_windows(dump: &str, package: &str) -> Vec<ParsedWindow> {
+/// Every `Window #N` block in a `dumpsys window windows` dump, in z-order (topmost first).
+///
+/// Package-agnostic so [`parse_app_windows`] and [`describe_missing_window`] share one parse — a
+/// description derived from a second could contradict the search.
+fn parse_blocks(dump: &str) -> Vec<WinBlock> {
     let mut out = Vec::new();
     let mut cur: Option<WinBlock> = None;
     for line in dump.lines() {
         let t = line.trim_start();
         if let Some((id, title)) = parse_window_header(t) {
-            if let Some(b) = cur.take() {
-                finish_block(b, &mut out);
-            }
+            out.extend(cur.take());
             cur = Some(WinBlock {
                 id,
                 title,
-                pkg_match: false,
+                package: None,
                 on_screen: false,
                 frame: None,
             });
@@ -93,14 +86,12 @@ pub fn parse_app_windows(dump: &str, package: &str) -> Vec<ParsedWindow> {
         // app's `package=`) don't leak into the last real window block.
         let indent = line.len() - t.len();
         if !t.is_empty() && indent < 4 {
-            if let Some(b) = cur.take() {
-                finish_block(b, &mut out);
-            }
+            out.extend(cur.take());
             continue;
         }
         if let Some(b) = cur.as_mut() {
             if let Some(rest) = line.split("package=").nth(1) {
-                b.pkg_match = rest.split_whitespace().next() == Some(package);
+                b.package = rest.split_whitespace().next().map(str::to_string);
             }
             if line.contains("isOnScreen=true") {
                 b.on_screen = true;
@@ -120,10 +111,74 @@ pub fn parse_app_windows(dump: &str, package: &str) -> Vec<ParsedWindow> {
             }
         }
     }
-    if let Some(b) = cur.take() {
-        finish_block(b, &mut out);
+    out.extend(cur.take());
+    out
+}
+
+/// All on-screen windows owned by `package`, in dumpsys z-order (topmost first).
+pub fn parse_app_windows(dump: &str, package: &str) -> Vec<ParsedWindow> {
+    let mut out = Vec::new();
+    for b in parse_blocks(dump) {
+        if b.package.as_deref() != Some(package) || !b.on_screen || b.is_splash() {
+            continue;
+        }
+        if let Some(frame) = b.frame {
+            out.push(ParsedWindow {
+                id: b.id,
+                title: b.title,
+                frame,
+            });
+        }
     }
     out
+}
+
+/// Packages owning an on-screen window other than `exclude`, deduped, in z-order.
+fn on_screen_packages(blocks: &[WinBlock], exclude: &str) -> String {
+    let mut seen: Vec<&str> = Vec::new();
+    for b in blocks.iter().filter(|b| b.on_screen) {
+        if let Some(p) = b.package.as_deref()
+            && p != exclude
+            && !seen.contains(&p)
+        {
+            seen.push(p);
+        }
+    }
+    if seen.is_empty() {
+        return "nothing else is on screen".to_string();
+    }
+    format!("on screen: {}", seen.join(", "))
+}
+
+/// Why [`parse_app_windows`] found nothing for `package`, read off the dump it just searched.
+///
+/// It rejects a block for one of four reasons an agent would act on differently, and an empty
+/// result tells none of them apart: no window opened, the window is behind another app's, it is
+/// still a splash screen, or the dump carried no frame (glass#338).
+pub fn describe_missing_window(dump: &str, package: &str) -> String {
+    let blocks = parse_blocks(dump);
+    let mine: Vec<&WinBlock> = blocks
+        .iter()
+        .filter(|b| b.package.as_deref() == Some(package))
+        .collect();
+
+    if mine.is_empty() {
+        return format!(
+            "no window belongs to it yet; {}",
+            on_screen_packages(&blocks, package)
+        );
+    }
+    if !mine.iter().any(|b| b.on_screen) {
+        return format!(
+            "its window is not on screen; {}",
+            on_screen_packages(&blocks, package)
+        );
+    }
+    if !mine.iter().any(|b| b.on_screen && !b.is_splash()) {
+        return "only its splash screen is on screen".to_string();
+    }
+    // The other three reasons are eliminated, so the frame is the one left.
+    "its window is on screen but the dump carried no frame for it".to_string()
 }
 
 /// `adb install` → Ok on `Success`, else `AppNotStarted` with the failure reason.
@@ -194,6 +249,68 @@ mod tests {
         assert_eq!(parse_pid("4321\n"), Some(4321));
         assert_eq!(parse_pid("\n"), None);
         assert_eq!(parse_pids("4321 4322 4400\n"), vec![4321, 4322, 4400]);
+    }
+
+    /// The state behind glass#338: the app is up, with a window of a *different* package in
+    /// front of it.
+    #[test]
+    fn a_window_hidden_behind_another_package_is_reported_as_hidden_and_names_it() {
+        let dump = concat!(
+            "  Window #0 Window{aaa111 u0 com.google.android.settings.intelligence/.SearchActivity}:\n",
+            "    package=com.google.android.settings.intelligence appop=NONE\n",
+            "    mFrame=[0,0][1080,2400] isOnScreen=true\n",
+            "  Window #1 Window{bbb222 u0 com.android.settings/.Settings}:\n",
+            "    package=com.android.settings appop=NONE\n",
+            "    mFrame=[0,0][1080,2400] isOnScreen=false\n",
+        );
+        assert!(parse_app_windows(dump, "com.android.settings").is_empty());
+
+        let why = describe_missing_window(dump, "com.android.settings");
+        assert!(why.contains("not on screen"), "{why}");
+        assert!(
+            why.contains("com.google.android.settings.intelligence"),
+            "{why}"
+        );
+    }
+
+    #[test]
+    fn an_app_with_no_window_at_all_is_told_apart_from_one_that_is_covered() {
+        let dump = concat!(
+            "  Window #0 Window{aaa111 u0 NexusLauncherActivity}:\n",
+            "    package=com.google.android.apps.nexuslauncher appop=NONE\n",
+            "    mFrame=[0,0][1080,2400] isOnScreen=true\n",
+        );
+        let why = describe_missing_window(dump, "com.android.settings");
+        assert!(why.contains("no window"), "{why}");
+        assert!(
+            why.contains("com.google.android.apps.nexuslauncher"),
+            "{why}"
+        );
+    }
+
+    #[test]
+    fn an_app_still_on_its_splash_screen_says_so_rather_than_reporting_no_window() {
+        let dump = concat!(
+            "  Window #0 Window{ccc333 u0 Splash Screen com.example.app}:\n",
+            "    package=com.example.app appop=NONE\n",
+            "    mFrame=[0,0][1080,2400] isOnScreen=true\n",
+        );
+        assert!(parse_app_windows(dump, "com.example.app").is_empty());
+        let why = describe_missing_window(dump, "com.example.app");
+        assert!(why.contains("splash"), "{why}");
+    }
+
+    /// The fourth rejection reason, so no device state maps to a message naming the wrong one.
+    #[test]
+    fn an_on_screen_window_whose_frame_did_not_parse_says_that() {
+        let dump = concat!(
+            "  Window #0 Window{ddd444 u0 com.example.app/.MainActivity}:\n",
+            "    package=com.example.app appop=NONE\n",
+            "    isOnScreen=true\n",
+        );
+        assert!(parse_app_windows(dump, "com.example.app").is_empty());
+        let why = describe_missing_window(dump, "com.example.app");
+        assert!(why.contains("frame"), "{why}");
     }
 
     const WINDOWS: &str = concat!(

--- a/crates/glass-android/src/platform.rs
+++ b/crates/glass-android/src/platform.rs
@@ -15,7 +15,10 @@ use crate::build::run_build;
 use crate::cmd::{force_stop_args, install_args, launch_args, parse_launch};
 use crate::input::{AgentInjector, Injector, ShellInjector};
 use crate::logs::{LogSink, LogcatStream};
-use crate::parse::{check_am_start, check_install, parse_app_windows, parse_pid, parse_pids};
+use crate::parse::{
+    check_am_start, check_install, describe_missing_window, parse_app_windows, parse_pid,
+    parse_pids,
+};
 use crate::screencap::decode_screencap;
 use crate::target::AdbTarget;
 
@@ -157,10 +160,20 @@ impl AndroidPlatform {
                 return Ok((WindowId(w.id), w.frame));
             }
             if Instant::now() >= deadline {
-                return Err(GlassError::Timeout(timeout_ms));
+                return Err(window_never_appeared(&dump, package, timeout_ms));
             }
             std::thread::sleep(Duration::from_millis(150));
         }
+    }
+}
+
+/// What a discovery reports when its budget ran out, diagnosed from the last dump it read — not a
+/// fresh one, which would describe a different moment.
+fn window_never_appeared(dump: &str, package: &str, timeout_ms: u64) -> GlassError {
+    GlassError::AppWindowNotVisible {
+        package: package.to_string(),
+        timeout_ms,
+        observed: describe_missing_window(dump, package),
     }
 }
 
@@ -367,6 +380,27 @@ impl Platform for AndroidPlatform {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// glass#338's failure, now readable in the error rather than only in a whole-run device log.
+    #[test]
+    fn a_discovery_that_ran_out_of_time_says_what_was_on_screen_instead() {
+        let dump = concat!(
+            "  Window #0 Window{aaa111 u0 com.google.android.settings.intelligence/.SearchActivity}:\n",
+            "    package=com.google.android.settings.intelligence appop=NONE\n",
+            "    mFrame=[0,0][1080,2400] isOnScreen=true\n",
+            "  Window #1 Window{bbb222 u0 com.android.settings/.Settings}:\n",
+            "    package=com.android.settings appop=NONE\n",
+            "    mFrame=[0,0][1080,2400] isOnScreen=false\n",
+        );
+        let msg = window_never_appeared(dump, "com.android.settings", 15_000).to_string();
+        assert!(msg.contains("com.android.settings"), "{msg}");
+        assert!(msg.contains("15000 ms"), "{msg}");
+        assert!(msg.contains("not on screen"), "{msg}");
+        assert!(
+            msg.contains("com.google.android.settings.intelligence"),
+            "{msg}"
+        );
+    }
 
     #[test]
     fn visible_window_region_full_onscreen_is_identity() {

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -37,6 +37,17 @@ pub enum GlassError {
     )]
     WindowNotFound,
 
+    /// A launch was accepted but produced no window glass can drive before the deadline, carrying
+    /// what the backend saw on screen instead. Distinct from [`Self::AppNotStarted`], which means
+    /// the launch itself failed: the app here may be running, with another app's window in front
+    /// of it — which a bare [`Self::Timeout`] cannot say (glass#338).
+    #[error("no window for {package} appeared within {timeout_ms} ms — {observed}")]
+    AppWindowNotVisible {
+        package: String,
+        timeout_ms: u64,
+        observed: String,
+    },
+
     #[error("capture failed: {0}")]
     CaptureFailed(String),
 


### PR DESCRIPTION
A `glass_start` on Android that finds no window reported `operation timed out after 15000 ms`.
That gives an agent nothing to act on, and four device states reach it, each wanting a different
response: the app has opened no window, its window is behind another app's, it is still on its
splash screen, or the window manager reported no frame for it.

Diagnosing one instance of the second case (#338) took a whole-run device log.

## What changed

`parse_app_windows` admits a window only if it is owned by the package, on screen, not a splash
screen, and carries a frame — so the dump that failed the search already holds the reason. The
block parse is now split out of it and package-agnostic, and the search and the diagnosis read the
same parse; a second parse could contradict the first.

`GlassError::AppWindowNotVisible` carries the package, the budget, and the observation. It is
distinct from `AppNotStarted`, which means the launch itself failed — here the app may be running
perfectly well with something in front of it — and from `Timeout`, which cannot say either way.

Before:

```
launch settings: Timeout(15000)
```

After, from an AVD reproducing #338's cascade:

```
no window for com.android.settings appeared within 15000 ms — its window is not on screen;
on screen: com.android.systemui, com.google.android.inputmethod.latin,
com.google.android.settings.intelligence
```

The wait itself is unchanged, and so is `timeout_ms`.

## Verification

Five new unit tests, one per device state plus the error rendering; the nine existing
`parse_app_windows` tests pass unchanged through the refactor. On a local AVD: the message above
against a live hidden-window state, and `a11y_loop` (5/5), `window_loop`, `see_loop` and
`input_loop` green, so normal discovery still works. `cargo fmt --check`, clippy `-D warnings`,
1892 workspace tests.

Only Android raises the new variant. The same diagnostic gap is noted on `WindowNotFound` for the
other backends and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)