### PR TITLE
fix(a11y): let a caller's timeout reach the accessibility reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,17 @@ internal refactors, CI, or test-only changes.
   Android paths have no such live check.
 
 ### Fixed
+- `glass_wait_for_element`'s `timeout_ms` now bounds the reader too, so on Android a wait can no
+  longer return at twice the timeout it was given. Each tick re-reads the accessibility tree, and a
+  single `uiautomator` read carried its own 20-second ceiling — so a wait told to give up after 10
+  seconds could sit inside one read for 20. The timeout now reaches the reader, which stops a read
+  it cannot finish in time and starts no read once the wait is over. A wait that ends that way
+  still answers `{matched: false}` rather than failing, and a wait that never saw a tree at all
+  reports what the device last said, so a slow device and a missing element stay distinguishable.
+  Knowing the timeout also lets the Android reader retry a device that is momentarily unable to
+  serve a tree — mid-animation, or with the accessibility bridge still registering — where before
+  it had to give up after one read to avoid overrunning. Tools that take no timeout are
+  unaffected: `glass_a11y_snapshot` and `glass_set_value` leave the reader its own ceiling.
 - `glass_set_value` on Android now really does retry the read-back that confirms a write, instead
   of retrying only when the device happened to be fast. The retry allowance was two seconds of
   wall-clock, but a single `uiautomator` attempt costs seconds on a loaded device — measured at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,17 +200,21 @@ internal refactors, CI, or test-only changes.
   Android paths have no such live check.
 
 ### Fixed
-- `glass_wait_for_element`'s `timeout_ms` now bounds the reader too, so on Android a wait can no
-  longer return at twice the timeout it was given. Each tick re-reads the accessibility tree, and a
-  single `uiautomator` read carried its own 20-second ceiling — so a wait told to give up after 10
-  seconds could sit inside one read for 20. The timeout now reaches the reader, which stops a read
-  it cannot finish in time and starts no read once the wait is over. A wait that ends that way
-  still answers `{matched: false}` rather than failing, and a wait that never saw a tree at all
-  reports what the device last said, so a slow device and a missing element stay distinguishable.
-  Knowing the timeout also lets the Android reader retry a device that is momentarily unable to
-  serve a tree — mid-animation, or with the accessibility bridge still registering — where before
-  it had to give up after one read to avoid overrunning. Tools that take no timeout are
-  unaffected: `glass_a11y_snapshot` and `glass_set_value` leave the reader its own ceiling.
+- `glass_wait_for_element`'s `timeout_ms` now bounds the accessibility reader too, so a wait can no
+  longer sit inside a single read for far longer than the time it was given. Each tick re-reads the
+  tree, and a read carried a flat ceiling of its own — 20 seconds per `uiautomator dump` on Android,
+  10 on Linux and Windows — which the wait had no way to interrupt. The timeout now reaches the
+  reader, which stops a read it cannot finish in time and starts none once the wait is over. The
+  first read of a wait is deliberately still unbounded: a wait must look at least once, so
+  `timeout_ms: 0` keeps meaning "check now" rather than "answer without looking". Honoured by the
+  Android readers (both the `uiautomator` one and the on-device companion) and by the Linux and
+  Windows readers; macOS and iOS still spend their own budgets.
+- `glass_wait_for_element` no longer fails when its last read runs out of time. A wait that read
+  the accessibility tree and did not find the element answers `{matched:false}`, as its
+  documentation has always said; only a wait that never managed to read a tree at all reports why,
+  which is the case where "the element is missing" would be the wrong answer. Previously a single
+  not-ready read anywhere in the wait — including the one that ends it — turned the whole call into
+  an error, so on a slow-to-start app the documented soft timeout could not be reached.
 - `glass_set_value` on Android now really does retry the read-back that confirms a write, instead
   of retrying only when the device happened to be fast. The retry allowance was two seconds of
   wall-clock, but a single `uiautomator` attempt costs seconds on a loaded device — measured at

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -3,21 +3,49 @@
 //! runtime), finds the launched app by PID, and walks its subtree into an `AxTree`.
 
 use std::sync::mpsc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use atspi::connection::AccessibilityConnection;
 use atspi::proxy::accessible::{AccessibleProxy, ObjectRefExt};
 use atspi::proxy::component::ComponentProxy;
 use atspi_common::{CoordType, ObjectRefOwned};
 use glass_core::{
-    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget, AxTree, GlassError, Result,
-    TruncationLimit, WalkBudget, normalize_description,
+    Accessibility, AxContext, AxDeadline, AxNode, AxNodeId, AxRect, AxTarget, AxTree, GlassError,
+    Result, TruncationLimit, WalkBudget, normalize_description,
 };
 
 use crate::mapping::{map_role, map_states};
 
 /// Hard cap so a wedged a11y bus can't hang the calling tool forever.
 const SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// How long a read may block for its worker, and whether the caller's deadline — not
+/// [`SNAPSHOT_TIMEOUT`] — is what ends the wait.
+///
+/// Both come from one comparison, decided before the wait: a read the *caller* cut short is a
+/// spent budget, a read that used the whole ceiling is a bus that stopped answering, and inferring
+/// which afterwards is the mistake glass#341 recorded.
+fn bounded_wait(deadline: AxDeadline) -> (Duration, bool) {
+    let own = Instant::now() + SNAPSHOT_TIMEOUT;
+    (
+        deadline.cap(own).saturating_duration_since(Instant::now()),
+        deadline.governs(own),
+    )
+}
+
+/// What a read reports when it never answered: the caller's own deadline ending it is
+/// `AccessibilityNotReady`, which [`glass_core::Glass::wait_for_element`] polls through, where the
+/// bus going quiet for a whole [`SNAPSHOT_TIMEOUT`] is not.
+fn never_answered(by_caller: bool) -> GlassError {
+    if by_caller {
+        return GlassError::AccessibilityNotReady(
+            "no accessibility tree within the time this call allowed".into(),
+        );
+    }
+    GlassError::AccessibilityUnavailable(
+        "accessibility snapshot timed out (a11y bus not responding)".into(),
+    )
+}
 
 #[derive(Default)]
 pub struct LinuxA11y;
@@ -34,6 +62,13 @@ impl Accessibility for LinuxA11y {
     }
 
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
+        // Checked before the spawn: the worker below is detached and holds its own bus
+        // connection, so one started for a caller that has stopped waiting outlives the answer
+        // nobody reads.
+        if ctx.deadline.has_passed() {
+            return Err(never_answered(true));
+        }
+        let (wait, by_caller) = bounded_wait(ctx.deadline);
         let ctx = ctx.clone();
         let (tx, rx) = mpsc::channel();
         // atspi is async and may be invoked from within a tokio runtime, where
@@ -42,11 +77,9 @@ impl Accessibility for LinuxA11y {
         std::thread::spawn(move || {
             let _ = tx.send(run_snapshot(&ctx));
         });
-        match rx.recv_timeout(SNAPSHOT_TIMEOUT) {
+        match rx.recv_timeout(wait) {
             Ok(r) => r,
-            Err(_) => Err(GlassError::AccessibilityUnavailable(
-                "accessibility snapshot timed out (a11y bus not responding)".into(),
-            )),
+            Err(_) => Err(never_answered(by_caller)),
         }
     }
 
@@ -764,6 +797,38 @@ fn nonempty(s: String) -> Option<String> {
 mod tests {
     use super::*;
     use glass_core::{MAX_DEPTH, MAX_NODES};
+
+    /// glass#338: only the reader can hold a read inside the caller's timeout — the worker below
+    /// is detached, so nothing outside it can shorten one that has started.
+    #[test]
+    fn a_read_is_bounded_by_the_caller_when_that_falls_first() {
+        let (wait, by_caller) = bounded_wait(AxDeadline::from_millis(50));
+        assert!(wait <= Duration::from_millis(50), "{wait:?}");
+        assert!(by_caller);
+    }
+
+    /// The other direction: without it the test above passes on a reader that waits for nothing.
+    #[test]
+    fn a_caller_that_names_no_deadline_leaves_the_read_its_own_ceiling() {
+        let (wait, by_caller) = bounded_wait(AxDeadline::UNBOUNDED);
+        assert!(wait > SNAPSHOT_TIMEOUT - Duration::from_secs(1), "{wait:?}");
+        assert!(!by_caller);
+    }
+
+    /// The variant decides whether a wait polls on or fails, so the two causes must not collapse:
+    /// a bus that went quiet for the whole ceiling is a real fault, and a caller that ran out of
+    /// its own time is not.
+    #[test]
+    fn a_read_the_caller_cut_short_reads_as_not_ready_where_a_quiet_bus_does_not() {
+        assert!(matches!(
+            never_answered(true),
+            GlassError::AccessibilityNotReady(_)
+        ));
+        assert!(matches!(
+            never_answered(false),
+            GlassError::AccessibilityUnavailable(_)
+        ));
+    }
 
     #[test]
     fn below_the_caps_children_may_be_explored_and_nothing_is_recorded() {

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -7,8 +7,8 @@ use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use glass_core::{
-    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget, AxTree, ChangeSignal, GlassError,
-    Result, TruncationLimit, WalkBudget, normalize_description, read_back_confirms,
+    Accessibility, AxContext, AxDeadline, AxNode, AxNodeId, AxRect, AxTarget, AxTree, ChangeSignal,
+    GlassError, Result, TruncationLimit, WalkBudget, normalize_description, read_back_confirms,
 };
 use uiautomation::patterns::{
     UIExpandCollapsePattern, UIInvokePattern, UIRangeValuePattern, UISelectionItemPattern,
@@ -19,6 +19,34 @@ use uiautomation::{UIAutomation, UIElement, UITreeWalker};
 
 /// Hard cap so a hung UIA provider can't block the calling tool forever.
 const SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// How long a read may block for its worker, and whether the caller's deadline — not
+/// [`SNAPSHOT_TIMEOUT`] — is what ends the wait.
+///
+/// Both come from one comparison, decided before the wait: a read the *caller* cut short is a
+/// spent budget, a read that used the whole ceiling is UIA that stopped answering, and inferring
+/// which afterwards is the mistake glass#341 recorded.
+fn bounded_wait(deadline: AxDeadline) -> (Duration, bool) {
+    let own = Instant::now() + SNAPSHOT_TIMEOUT;
+    (
+        deadline.cap(own).saturating_duration_since(Instant::now()),
+        deadline.governs(own),
+    )
+}
+
+/// What a read reports when it never answered: the caller's own deadline ending it is
+/// `AccessibilityNotReady`, which [`glass_core::Glass::wait_for_element`] polls through, where UIA
+/// going quiet for a whole [`SNAPSHOT_TIMEOUT`] is not.
+fn never_answered(by_caller: bool) -> GlassError {
+    if by_caller {
+        return GlassError::AccessibilityNotReady(
+            "no accessibility tree within the time this call allowed".into(),
+        );
+    }
+    GlassError::AccessibilityUnavailable(
+        "accessibility snapshot timed out (UIA not responding)".into(),
+    )
+}
 /// Per-edge tolerance (px) for the set_value bounds-fingerprint check. Window-relative
 /// bounds are stable for a static element across snapshot→set_value (window moves cancel),
 /// so this only absorbs sub-pixel/timing jitter; a different element that drift landed on
@@ -42,6 +70,12 @@ impl WindowsA11y {
 
 impl Accessibility for WindowsA11y {
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
+        // Checked before the spawn: the worker below is detached and holds its own COM apartment,
+        // so one started for a caller that has stopped waiting outlives the answer nobody reads.
+        if ctx.deadline.has_passed() {
+            return Err(never_answered(true));
+        }
+        let (wait, by_caller) = bounded_wait(ctx.deadline);
         let ctx = ctx.clone();
         let (tx, rx) = mpsc::channel();
         // UIA is COM and thread-affine; run it on a fresh OS thread, fully decoupled
@@ -49,11 +83,9 @@ impl Accessibility for WindowsA11y {
         std::thread::spawn(move || {
             let _ = tx.send(run_snapshot(&ctx));
         });
-        match rx.recv_timeout(SNAPSHOT_TIMEOUT) {
+        match rx.recv_timeout(wait) {
             Ok(r) => r,
-            Err(_) => Err(GlassError::AccessibilityUnavailable(
-                "accessibility snapshot timed out (UIA not responding)".into(),
-            )),
+            Err(_) => Err(never_answered(by_caller)),
         }
     }
 
@@ -597,6 +629,38 @@ fn find_nth(
 mod tests {
     use super::*;
     use glass_core::{MAX_DEPTH, MAX_NODES};
+
+    /// glass#338: only the reader can hold a read inside the caller's timeout — the worker below
+    /// is detached, so nothing outside it can shorten one that has started.
+    #[test]
+    fn a_read_is_bounded_by_the_caller_when_that_falls_first() {
+        let (wait, by_caller) = bounded_wait(AxDeadline::from_millis(50));
+        assert!(wait <= Duration::from_millis(50), "{wait:?}");
+        assert!(by_caller);
+    }
+
+    /// The other direction: without it the test above passes on a reader that waits for nothing.
+    #[test]
+    fn a_caller_that_names_no_deadline_leaves_the_read_its_own_ceiling() {
+        let (wait, by_caller) = bounded_wait(AxDeadline::UNBOUNDED);
+        assert!(wait > SNAPSHOT_TIMEOUT - Duration::from_secs(1), "{wait:?}");
+        assert!(!by_caller);
+    }
+
+    /// The variant decides whether a wait polls on or fails, so the two causes must not collapse:
+    /// a bus that went quiet for the whole ceiling is a real fault, and a caller that ran out of
+    /// its own time is not.
+    #[test]
+    fn a_read_the_caller_cut_short_reads_as_not_ready_where_a_quiet_bus_does_not() {
+        assert!(matches!(
+            never_answered(true),
+            GlassError::AccessibilityNotReady(_)
+        ));
+        assert!(matches!(
+            never_answered(false),
+            GlassError::AccessibilityUnavailable(_)
+        ));
+    }
 
     /// The failure mode this guards: if an absent child ever stopped arriving as a zero code,
     /// every leaf in every snapshot would report an unreadable subtree. Builds the error

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -54,9 +54,9 @@ fn process_tag() -> &'static str {
 
 /// What the *first* snapshot of a session may spend waiting for `uiautomator` to become able to
 /// dump: a device reaches `sys.boot_completed` — all the platform waits for before reporting the
-/// app up — several seconds before the dump can serve one. Later snapshots must not wait like
-/// this, or a caller like `wait_for_element`, which runs a snapshot per tick inside its own
-/// budget, would be held long past it.
+/// app up — several seconds before the dump can serve one. Later snapshots retry only inside the
+/// caller's deadline (see [`snapshot_bound`]); this bound is for the first read, which has no
+/// caller's window to borrow.
 const COLD_BOUND: RetryBound = RetryBound {
     least: 2,
     then_within: Duration::from_millis(30_000),
@@ -88,6 +88,17 @@ pub(crate) fn attempt_deadline() -> Instant {
     Instant::now() + AdbOp::Dump.budget()
 }
 
+/// When the removal of a dump file must be done by: `attempt`'s deadline, floored so a spent one
+/// still leaves room to remove the file.
+///
+/// The device writes the file whether or not anyone is still waiting for it and nothing sweeps
+/// `/sdcard`, so without the floor every attempt the caller's deadline abandons strands one. It is
+/// a ceiling on a millisecond round-trip, not a wait — [`glass_core::TEARDOWN_BUDGET`] is this
+/// codebase's bound for cleanup whose own work has already stopped.
+fn reap_deadline(attempt: Instant) -> Instant {
+    attempt.max(Instant::now() + glass_core::TEARDOWN_BUDGET)
+}
+
 /// What a read reports when the caller's deadline, not the device, ended it — naming what the last
 /// attempt saw, where there was one.
 ///
@@ -114,12 +125,14 @@ pub(crate) enum Attempt {
     Dumped(String),
     /// The device cannot serve a dump *yet* — waiting is what resolves it.
     NotReady(GlassError),
-    /// Waiting cannot help: adb is gone, the device is wedged, or the attempt's deadline fired.
+    /// Waiting cannot help *this attempt*: adb is gone, the device is wedged, or a deadline
+    /// fired — which may be the caller's, and [`dump_until_ready`] re-reads that case as a spent
+    /// budget rather than a device that failed.
     Fatal(GlassError),
 }
 
 /// One `uiautomator dump`, returning the XML it wrote. Every step is bounded by `deadline` — see
-/// [`attempt_deadline`].
+/// [`dump_until_ready`], which caps [`attempt_deadline`] by the caller's.
 ///
 /// `uiautomator dump` fails in two shapes: it exits 0 with the reason on stderr, or it crashes and
 /// exits non-zero with stderr empty, its trace going to logcat instead (glass#341). Neither its
@@ -130,6 +143,9 @@ pub(crate) enum Attempt {
 ///
 /// The removal is last and best-effort, and names one path: a concurrent attempt's file is not
 /// exposed to it, and housekeeping cannot spend the deadline the read needs.
+///
+/// It runs on [`reap_deadline`] rather than on `deadline`, which the caller's may have already
+/// spent.
 pub(crate) fn dump_once(run: &mut AdbRunner<'_>, prefix: &str, deadline: Instant) -> Attempt {
     let path = attempt_path(prefix);
     let stderr = match run(&["shell", "uiautomator", "dump", &path], deadline) {
@@ -137,7 +153,7 @@ pub(crate) fn dump_once(run: &mut AdbRunner<'_>, prefix: &str, deadline: Instant
         Err(e) if died_unexplained(&e) => {
             // The crash is raised after the file is opened, so this attempt can own one. Retried,
             // each crash would strand another.
-            let _ = run(&["shell", "rm", "-f", &path], deadline);
+            let _ = run(&["shell", "rm", "-f", &path], reap_deadline(deadline));
             return Attempt::NotReady(GlassError::AccessibilityUnavailable(format!(
                 "uiautomator dump exited without writing {path} and without saying why; \
                  its reason, if any, is in logcat"
@@ -146,7 +162,7 @@ pub(crate) fn dump_once(run: &mut AdbRunner<'_>, prefix: &str, deadline: Instant
         Err(e) => return Attempt::Fatal(e),
     };
     let read = run(&["shell", "cat", &path], deadline);
-    let _ = run(&["shell", "rm", "-f", &path], deadline);
+    let _ = run(&["shell", "rm", "-f", &path], reap_deadline(deadline));
     match read {
         Ok((xml, _)) => Attempt::Dumped(xml),
         // The dump explained itself on stderr: that is why there is no file, and it names
@@ -166,9 +182,10 @@ pub(crate) fn dump_once(run: &mut AdbRunner<'_>, prefix: &str, deadline: Instant
 
 /// Whether an error is the attempt's own deadline firing rather than the device answering.
 ///
-/// A read that ran out of the attempt's time never reached the device, so the dump's stderr is no
+/// A read that ran out of its time never reached the device, so the dump's stderr is no
 /// explanation for it — and that substitution is retryable, so the loop would go on retrying a
-/// device that had answered. Matched on the phrases `glass_core` publishes for exactly this.
+/// device that had answered. Matched on the phrases `glass_core` publishes for exactly this, which
+/// is why it says only *that* a bound fired: which one is settled before the attempt.
 fn bound_fired(e: &GlassError) -> bool {
     let msg = e.to_string();
     msg.contains(TIMED_OUT) || msg.contains(NOT_STARTED)
@@ -192,9 +209,11 @@ fn died_unexplained(e: &GlassError) -> bool {
 /// budget that never retried (glass#338).
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct RetryBound {
-    /// Attempts owed however long each one takes; 1 means no retry at all.
+    /// Attempts owed however long each one takes, while the caller is still waiting; 1 means no
+    /// retry at all.
     least: u32,
-    /// Once `least` is met, keep retrying while this much wall-clock remains.
+    /// Once `least` is met, keep retrying while this much wall-clock remains, or the caller's
+    /// deadline, whichever is nearer.
     then_within: Duration,
 }
 
@@ -226,9 +245,10 @@ fn dump_until_ready(
     // Kept so a spent caller deadline can name what the device last said, not just the budget.
     let mut unready: Option<GlassError> = None;
     loop {
-        // Checked rather than left to the cap below, which would still spawn an adb process to
-        // abandon.
-        if caller.is_spent() {
+        // Answered here rather than through the cap below: the runner seam does not promise a
+        // spent deadline is refused, and a read that never happened should not have to be
+        // inferred from the error it returns.
+        if caller.has_passed() {
             return Err(out_of_time(unready.as_ref()));
         }
         let own = attempt_deadline();
@@ -237,8 +257,12 @@ fn dump_until_ready(
             Attempt::Dumped(xml) => return Ok(xml),
             // An attempt the *caller's* deadline cut short is not a device that failed. Which
             // bound governs is settled before the attempt, not read off its error (glass#341).
-            Attempt::Fatal(e) if ends < own && bound_fired(&e) => {
-                return Err(out_of_time(unready.as_ref()));
+            //
+            // The abandoned attempt's own error is carried, not dropped: a wedged adb reaches
+            // here too — it cannot be told apart from a slow one at the moment the budget ends —
+            // and its message is the only place glass names the `adb kill-server` remedy.
+            Attempt::Fatal(e) if caller.governs(own) && bound_fired(&e) => {
+                return Err(out_of_time(Some(&e)));
             }
             Attempt::Fatal(e) => return Err(e),
             Attempt::NotReady(e) => {
@@ -247,7 +271,7 @@ fn dump_until_ready(
                 if owed == 0 && left.is_zero() {
                     // The caller closing the window is about the budget, not the device — even
                     // with the device's own answer in hand.
-                    return Err(if caller.is_spent() {
+                    return Err(if caller.has_passed() {
                         out_of_time(Some(&e))
                     } else {
                         e
@@ -346,6 +370,35 @@ const VERIFY_BOUND: RetryBound = RetryBound {
 /// attempt in flight, which [`VERIFY_BOUND`] still owes its second dump.
 const VERIFY_PHASE_BUDGET_MS: u64 = 20_000;
 
+/// One snapshot over a supplied runner: the whole of [`AndroidA11y::snapshot_within`] except
+/// binding to a device.
+///
+/// Split out so a host test can see the join: inline, replacing `ctx.deadline` with
+/// [`AxDeadline::UNBOUNDED`] left every non-device test green.
+fn snapshot_with_runner(
+    run: &mut AdbRunner<'_>,
+    ctx: &AxContext,
+    bound: RetryBound,
+) -> Result<AxTree> {
+    let xml = dump_until_ready(
+        run,
+        DUMP_PREFIX,
+        bound,
+        Duration::from_millis(DUMP_POLL_INTERVAL_MS),
+        ctx.deadline,
+    )?;
+    build_tree(&xml, &ctx.window, ctx.limits)
+}
+
+/// Whether a dump has ever succeeded on this reader, which decides how long its next one may wait.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Warmth {
+    /// No dump has succeeded yet, so the accessibility bridge may still be registering.
+    Cold,
+    /// One has, so the device can serve a tree and a read that cannot is a passing condition.
+    Warmed,
+}
+
 /// How much retrying one [`Accessibility::snapshot`] is worth, from whether a dump has ever
 /// succeeded on this reader and how long the caller said it would wait.
 ///
@@ -356,8 +409,8 @@ const VERIFY_PHASE_BUDGET_MS: u64 = 20_000;
 ///
 /// The cold wait is not capped here: [`dump_until_ready`] caps every wait by the caller, and this
 /// one must still *owe* the two attempts the accessibility bridge's registration needs.
-fn snapshot_bound(warmed: bool, deadline: AxDeadline) -> RetryBound {
-    if !warmed {
+fn snapshot_bound(warmth: Warmth, deadline: AxDeadline) -> RetryBound {
+    if warmth == Warmth::Cold {
         return COLD_BOUND;
     }
     match deadline.remaining() {
@@ -387,23 +440,16 @@ impl AndroidA11y {
         }
     }
 
-    /// One dump, retrying a not-ready device within `bound`.
+    /// One dump, retrying a not-ready device within `bound` and `ctx.deadline`.
     ///
     /// Split out of [`Accessibility::snapshot`] so a caller that knows the UI is mid-flux can ask
     /// for retries a [`snapshot_bound`] would not give it — immediately after typing, where the
     /// tree is expected to be unreadable for a moment and no deadline says how long to allow.
     fn snapshot_within(&mut self, ctx: &AxContext, bound: RetryBound) -> Result<AxTree> {
-        let window = ctx.window.clone();
         let adb = self.ensure_adb()?;
-        let xml = dump_until_ready(
-            &mut adb_runner(&adb),
-            DUMP_PREFIX,
-            bound,
-            Duration::from_millis(DUMP_POLL_INTERVAL_MS),
-            ctx.deadline,
-        )?;
+        let tree = snapshot_with_runner(&mut adb_runner(&adb), ctx, bound)?;
         self.warmed = true;
-        build_tree(&xml, &window, ctx.limits)
+        Ok(tree)
     }
 
     /// Bind directly to an already-resolved (serial-bound) adb client. Used in production so
@@ -413,6 +459,15 @@ impl AndroidA11y {
             adb,
             resolved: true,
             warmed: false,
+        }
+    }
+
+    /// Whether a dump has ever succeeded on this reader.
+    fn warmth(&self) -> Warmth {
+        if self.warmed {
+            Warmth::Warmed
+        } else {
+            Warmth::Cold
         }
     }
 
@@ -518,7 +573,7 @@ fn locate_editable_target(
 
 impl Accessibility for AndroidA11y {
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
-        self.snapshot_within(ctx, snapshot_bound(self.warmed, ctx.deadline))
+        self.snapshot_within(ctx, snapshot_bound(self.warmth(), ctx.deadline))
     }
 
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
@@ -586,12 +641,13 @@ impl Accessibility for AndroidA11y {
 #[cfg(test)]
 mod tests {
     use super::{
-        Attempt, COLD_BOUND, RetryBound, dump_once, dump_until_ready, editable_target,
-        locate_editable_target, snapshot_bound, verify_write,
+        Attempt, COLD_BOUND, RetryBound, Warmth, dump_once, dump_until_ready, editable_target,
+        locate_editable_target, snapshot_bound, snapshot_with_runner, verify_write,
     };
     use crate::adb::AdbOp;
     use glass_core::accessibility::{
-        AxDeadline, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree,
+        AxContext, AxDeadline, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree,
+        WalkLimits,
     };
     use glass_core::{GlassError, Result, WindowGeometry};
     use std::collections::HashMap;
@@ -721,7 +777,7 @@ mod tests {
                 then_within: Duration::from_millis(10),
             },
             Duration::ZERO,
-            AxDeadline::NONE,
+            AxDeadline::UNBOUNDED,
         )
         .expect("the second attempt is owed however long the first took");
 
@@ -729,12 +785,15 @@ mod tests {
         assert_eq!(dumps, 2, "exactly the attempt that was owed");
     }
 
-    /// A runner that answers every step, recording the deadline each was given.
+    /// A runner that answers every step, recording the subcommand and the deadline each was given.
     fn recording(
-        seen: &mut Vec<Instant>,
+        seen: &mut Vec<(String, Instant)>,
     ) -> impl FnMut(&[&str], Instant) -> Result<(String, String)> {
         move |argv: &[&str], deadline: Instant| {
-            seen.push(deadline);
+            seen.push((
+                argv.get(1).copied().unwrap_or_default().to_string(),
+                deadline,
+            ));
             match argv {
                 ["shell", "uiautomator", "dump", _] => Ok((DUMPED.to_string(), String::new())),
                 ["shell", "cat", _] => Ok((XML.to_string(), String::new())),
@@ -746,9 +805,13 @@ mod tests {
 
     /// glass#338: `wait_for_element` re-reads from a synchronous tick, so only the reader can
     /// hold a read inside the timeout.
+    ///
+    /// The removal is excluded deliberately — it is not part of the answer the caller is waiting
+    /// for, and [`reap_deadline`] floors it so a spent caller cannot skip it. It is asserted below
+    /// instead, against that floor, so it still cannot hang.
     #[test]
-    fn every_step_is_bounded_by_the_callers_deadline_not_by_the_dump_budget() {
-        let mut seen: Vec<Instant> = Vec::new();
+    fn every_read_step_is_bounded_by_the_callers_deadline_not_by_the_dump_budget() {
+        let mut seen: Vec<(String, Instant)> = Vec::new();
         {
             let mut run = recording(&mut seen);
             dump_until_ready(
@@ -756,28 +819,60 @@ mod tests {
                 PREFIX,
                 RetryBound::ONCE,
                 Duration::ZERO,
-                AxDeadline::in_ms(50),
+                AxDeadline::from_millis(50),
             )
             .expect("the dump succeeds");
         }
 
-        assert!(!seen.is_empty(), "no adb step ran");
         // The caller's instant was fixed before this line, so it passes however slow the machine
         // is; `AdbOp::Dump`'s 20s budget cannot.
         let latest = Instant::now() + Duration::from_millis(50);
-        for (i, d) in seen.iter().enumerate() {
+        let reads: Vec<_> = seen.iter().filter(|(step, _)| step != "rm").collect();
+        assert_eq!(reads.len(), 2, "expected the dump and the read: {seen:?}");
+        for (step, d) in reads {
             assert!(
                 *d <= latest,
-                "step {i} was given {:?} past the caller's deadline",
+                "the {step} step was given {:?} past the caller's deadline",
                 d.saturating_duration_since(latest)
             );
         }
+
+        let reap = seen
+            .iter()
+            .find(|(step, _)| step == "rm")
+            .expect("the attempt removes the file it read");
+        assert!(
+            reap.1 <= Instant::now() + glass_core::TEARDOWN_BUDGET,
+            "the removal outlives its own floor, so a wedged device can hang on cleanup"
+        );
+    }
+
+    /// A file the caller stopped waiting for is still removed. The device writes it whether or not
+    /// anyone reads it, and nothing sweeps `/sdcard` — so a removal that inherited the spent
+    /// deadline would strand one file per abandoned attempt, which every timed-out wait produces.
+    #[test]
+    fn the_removal_survives_an_attempt_deadline_that_is_already_spent() {
+        let spent = Instant::now();
+        let mut seen: Vec<(String, Instant)> = Vec::new();
+        {
+            let mut run = recording(&mut seen);
+            let _ = dump_once(&mut run, PREFIX, spent);
+        }
+
+        let reap = seen
+            .iter()
+            .find(|(step, _)| step == "rm")
+            .expect("the attempt removes the file it read");
+        assert!(
+            reap.1 > spent,
+            "the removal inherited a deadline it could not run in"
+        );
     }
 
     /// Without this the test above passes on a reader that caps every step at nothing.
     #[test]
     fn a_caller_that_names_no_deadline_leaves_the_reader_its_own_budget() {
-        let mut seen: Vec<Instant> = Vec::new();
+        let mut seen: Vec<(String, Instant)> = Vec::new();
         let at_least = Instant::now() + AdbOp::Dump.budget() - Duration::from_secs(1);
         {
             let mut run = recording(&mut seen);
@@ -786,14 +881,14 @@ mod tests {
                 PREFIX,
                 RetryBound::ONCE,
                 Duration::ZERO,
-                AxDeadline::NONE,
+                AxDeadline::UNBOUNDED,
             )
             .expect("the dump succeeds");
         }
 
         assert!(!seen.is_empty(), "no adb step ran");
         assert!(
-            seen.iter().all(|d| *d >= at_least),
+            seen.iter().all(|(_, d)| *d >= at_least),
             "a caller that asked for nothing had the dump budget cut anyway"
         );
     }
@@ -811,7 +906,7 @@ mod tests {
             PREFIX,
             patient(),
             Duration::ZERO,
-            AxDeadline::in_ms(0),
+            AxDeadline::from_millis(0),
         )
         .expect_err("the caller had stopped waiting");
 
@@ -826,13 +921,13 @@ mod tests {
     /// nothing else bounded a retry.
     #[test]
     fn a_warmed_reader_retries_only_inside_the_deadline_the_caller_named() {
-        let told = snapshot_bound(true, AxDeadline::in_ms(5_000));
+        let told = snapshot_bound(Warmth::Warmed, AxDeadline::from_millis(5_000));
         assert!(
             told.then_within > Duration::from_secs(4) && told.then_within <= Duration::from_secs(5),
             "the retry window is not the caller's: {told:?}"
         );
 
-        let untold = snapshot_bound(true, AxDeadline::NONE);
+        let untold = snapshot_bound(Warmth::Warmed, AxDeadline::UNBOUNDED);
         assert_eq!(
             untold.then_within,
             Duration::ZERO,
@@ -841,18 +936,19 @@ mod tests {
         assert_eq!(untold.least, 1, "{untold:?}");
     }
 
-    /// The first snapshot of a session waits out a boot whatever the caller allowed: the bridge
-    /// registration it is owed two attempts for is not negotiable, and `dump_until_ready` caps the
-    /// wall-clock by the caller regardless.
+    /// [`snapshot_bound`] does not pre-trim the cold bound to what the caller has left —
+    /// `dump_until_ready` is the single place the caller's deadline is applied, so trimming here
+    /// would apply it twice and leave the attempts the bridge's registration needs unasked.
     #[test]
     fn a_cold_reader_is_owed_its_attempts_however_little_the_caller_allowed() {
-        let bound = snapshot_bound(false, AxDeadline::in_ms(1));
+        let bound = snapshot_bound(Warmth::Cold, AxDeadline::from_millis(1));
         assert_eq!(bound.least, COLD_BOUND.least, "{bound:?}");
         assert_eq!(bound.then_within, COLD_BOUND.then_within, "{bound:?}");
     }
 
-    /// A [`RetryBound`] outliving the caller sleeps out a whole interval before noticing nobody
-    /// is waiting — and the interval is sized against a cold boot, not against any one caller.
+    /// Uncapped, a [`RetryBound`] outliving the caller would sleep out a whole interval before
+    /// noticing nobody is waiting — and the interval is sized against a cold boot, not against any
+    /// one caller.
     #[test]
     fn the_retry_window_ends_with_the_caller_even_when_the_bound_would_run_longer() {
         let mut run = |argv: &[&str], _d: Instant| -> Result<(String, String)> {
@@ -874,7 +970,7 @@ mod tests {
             PREFIX,
             patient(),
             Duration::from_secs(5),
-            AxDeadline::in_ms(10),
+            AxDeadline::from_millis(10),
         )
         .expect_err("the caller's deadline passed during the attempt");
 
@@ -886,9 +982,102 @@ mod tests {
         );
     }
 
+    /// The caller's deadline in the `AxContext` is what bounds the adb steps — the join between
+    /// the seam and the reader, which only the device test covered.
+    #[test]
+    fn a_snapshot_bounds_its_steps_by_the_deadline_in_the_context() {
+        let mut seen: Vec<(String, Instant)> = Vec::new();
+        let ctx = AxContext {
+            pids: vec![],
+            window: WindowGeometry {
+                x: 0,
+                y: 0,
+                width: 100,
+                height: 100,
+            },
+            window_handle: None,
+            a11y_bus_addr: None,
+            limits: WalkLimits::DEFAULT,
+            deadline: AxDeadline::from_millis(50),
+        };
+        {
+            let mut run = recording(&mut seen);
+            snapshot_with_runner(&mut run, &ctx, RetryBound::ONCE).expect("the dump succeeds");
+        }
+
+        let latest = Instant::now() + Duration::from_millis(50);
+        let reads: Vec<_> = seen.iter().filter(|(step, _)| step != "rm").collect();
+        assert_eq!(reads.len(), 2, "expected the dump and the read: {seen:?}");
+        for (step, d) in reads {
+            assert!(
+                *d <= latest,
+                "the {step} step ignored the context's deadline by {:?}",
+                d.saturating_duration_since(latest)
+            );
+        }
+    }
+
+    /// The retry the deadline exists to permit actually happens: a caller still waiting gets its
+    /// second attempt.
+    ///
+    /// Both other `owed` tests use a caller who named nothing or one already gone, so an
+    /// implementation reading any deadline at all as "no retries" passes them — and would give a
+    /// cold Android reader one attempt under every `wait_for_element`, which is the bridge-
+    /// registration race of glass#338 back again.
+    #[test]
+    fn a_retry_the_caller_still_has_time_for_is_taken() {
+        let mut cold = fake(1);
+        let xml = dump_until_ready(
+            &mut cold,
+            PREFIX,
+            COLD_BOUND,
+            Duration::ZERO,
+            AxDeadline::from_millis(5_000),
+        )
+        .expect("the second attempt runs inside the window the caller is still waiting through");
+
+        assert_eq!(xml, XML);
+    }
+
+    /// A device that failed is reported as one even while a deadline is in force, which is the
+    /// whole load `bound_fired` carries in that guard.
+    ///
+    /// Without this, dropping `bound_fired` kills no test: every other test reaching the guard
+    /// either has no caller deadline, so the guard is false whatever the error, or pairs a
+    /// deadline with a timeout, so both halves are true. A `wait_for_element` always sets a
+    /// deadline, so the mutant would report every dead emulator as an app that is slow to publish.
+    #[test]
+    fn an_adb_failure_under_a_live_deadline_is_still_a_broken_device() {
+        let mut gone = |argv: &[&str], _d: Instant| -> Result<(String, String)> {
+            match argv {
+                ["shell", "uiautomator", "dump", _] => Err(GlassError::Backend(
+                    "`adb shell uiautomator dump` failed: error: device 'emulator-5554' not found"
+                        .into(),
+                )),
+                _ => Ok((String::new(), String::new())),
+            }
+        };
+        let e = dump_until_ready(
+            &mut gone,
+            PREFIX,
+            RetryBound::ONCE,
+            Duration::ZERO,
+            // Nearer than `AdbOp::Dump`'s budget, so the caller's bound governs the attempt —
+            // which is true of every read a `wait_for_element` makes.
+            AxDeadline::from_millis(5_000),
+        )
+        .expect_err("the device is gone");
+
+        assert!(matches!(e, GlassError::Backend(_)), "{e}");
+        assert!(
+            !e.to_string().contains("within the time this call allowed"),
+            "a dead device was reported as a spent caller budget: {e}"
+        );
+    }
+
     /// [`RetryBound::least`] says how many attempts the *device* is owed, not how many a caller
     /// must pay for: an owed attempt is not started once the caller has stopped waiting. Both
-    /// production bounds owe two, so this is the shape a real not-ready read takes.
+    /// *retrying* bounds owe two, so this is the shape a real not-ready read takes.
     #[test]
     fn an_owed_attempt_is_not_started_once_the_caller_has_stopped_waiting() {
         let mut dumps = 0;
@@ -910,7 +1099,7 @@ mod tests {
             PREFIX,
             COLD_BOUND,
             Duration::ZERO,
-            AxDeadline::in_ms(10),
+            AxDeadline::from_millis(10),
         )
         .expect_err("the caller's deadline passed during the first attempt");
 
@@ -938,10 +1127,16 @@ mod tests {
             PREFIX,
             RetryBound::ONCE,
             Duration::ZERO,
-            AxDeadline::in_ms(20),
+            AxDeadline::from_millis(20),
         )
         .expect_err("the attempt was abandoned");
         assert!(matches!(e, GlassError::AccessibilityNotReady(_)), "{e}");
+        // A wedged adb reaches this arm too, and its message is the only place glass names the
+        // `adb kill-server` remedy — dropping it leaves an operator reading "the app is slow".
+        assert!(
+            e.to_string().contains(glass_core::TIMED_OUT),
+            "the abandoned attempt's own error was discarded: {e}"
+        );
 
         // The control: the same timeout with no caller deadline is glass's own 20s budget firing,
         // which *is* about the device — reporting it as a spent caller budget would hide a hang.
@@ -951,7 +1146,7 @@ mod tests {
             PREFIX,
             RetryBound::ONCE,
             Duration::ZERO,
-            AxDeadline::NONE,
+            AxDeadline::UNBOUNDED,
         )
         .expect_err("the attempt timed out");
         assert!(matches!(e, GlassError::Backend(_)), "{e}");
@@ -1152,7 +1347,7 @@ mod tests {
             PREFIX,
             RetryBound::ONCE,
             Duration::ZERO,
-            AxDeadline::NONE,
+            AxDeadline::UNBOUNDED,
         )
         .unwrap();
 
@@ -1188,7 +1383,7 @@ mod tests {
                 then_within: Duration::from_secs(5),
             },
             Duration::from_millis(1),
-            AxDeadline::NONE,
+            AxDeadline::UNBOUNDED,
         )
         .expect("the second attempt succeeds");
 
@@ -1222,7 +1417,7 @@ mod tests {
             PREFIX,
             bound,
             Duration::from_secs(2),
-            AxDeadline::NONE,
+            AxDeadline::UNBOUNDED,
         )
         .expect_err("a device that never becomes ready");
 
@@ -1272,7 +1467,7 @@ mod tests {
             PREFIX,
             patient(),
             Duration::ZERO,
-            AxDeadline::NONE,
+            AxDeadline::UNBOUNDED,
         )
         .unwrap_err();
 
@@ -1299,7 +1494,7 @@ mod tests {
             PREFIX,
             patient(),
             Duration::ZERO,
-            AxDeadline::NONE,
+            AxDeadline::UNBOUNDED,
         )
         .expect("a device that becomes ready within the budget must produce a tree");
         assert_eq!(xml, XML);
@@ -1313,10 +1508,17 @@ mod tests {
             PREFIX,
             RetryBound::ONCE,
             Duration::ZERO,
-            AxDeadline::NONE,
+            AxDeadline::UNBOUNDED,
         )
         .unwrap_err();
         assert!(e.to_string().contains(NOT_READY), "{e}");
+        // The variant, not just the text: `out_of_time` embeds the device's last reason too, so a
+        // substring alone passes on both branches — and the two send `wait_for_element` opposite
+        // ways, one polling on and one failing at once.
+        assert!(
+            matches!(e, GlassError::AccessibilityUnavailable(_)),
+            "a device that never became ready was reported as a spent caller budget: {e}"
+        );
     }
 
     #[test]
@@ -1340,7 +1542,7 @@ mod tests {
             PREFIX,
             patient(),
             Duration::ZERO,
-            AxDeadline::NONE,
+            AxDeadline::UNBOUNDED,
         )
         .unwrap_err();
         assert!(matches!(e, GlassError::Backend(_)), "{e}");
@@ -1360,7 +1562,7 @@ mod tests {
             PREFIX,
             patient(),
             Duration::ZERO,
-            AxDeadline::NONE,
+            AxDeadline::UNBOUNDED,
         )
         .expect("a dump that crashed must be retried inside the budget");
         assert_eq!(xml, XML);
@@ -1401,7 +1603,7 @@ mod tests {
                 PREFIX,
                 patient(),
                 Duration::ZERO,
-                AxDeadline::NONE,
+                AxDeadline::UNBOUNDED,
             )
             .expect("the attempt after the crashes dumps");
         }

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -6,7 +6,7 @@ use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, AxTree};
+use glass_core::accessibility::{Accessibility, AxContext, AxDeadline, AxNode, AxTarget, AxTree};
 use glass_core::{
     GlassError, KeyEvent, MouseButton, NOT_STARTED, PointerEvent, Result, TIMED_OUT,
     WindowGeometry, typed_clear_landed, typed_text_landed,
@@ -75,14 +75,33 @@ pub(crate) fn adb_runner(
 }
 
 /// When one whole dump attempt — the dump, the read of what it wrote, and the removal of the file
-/// it read — must be done by.
+/// it read — must be done by, ignoring any deadline the caller set.
 ///
 /// The three share [`AdbOp::Dump`]'s budget — one snapshot's worth — with the removal keeping its
 /// own `AdbOp::Shell` ceiling inside that. A step carrying only its own budget let an attempt cost
 /// the sum of all three, 50s against the 10s a `glass_wait_for_element` asks for by default and
 /// re-snapshots inside.
+///
+/// A caller that named a deadline gets [`AxDeadline::cap`] of this instead — see
+/// [`dump_until_ready`], which needs both to tell which of them ended an attempt.
 pub(crate) fn attempt_deadline() -> Instant {
     Instant::now() + AdbOp::Dump.budget()
+}
+
+/// What a read reports when the caller's deadline, not the device, ended it — naming what the last
+/// attempt saw, where there was one.
+///
+/// [`GlassError::AccessibilityNotReady`] rather than the timeout adb raised: that is the variant
+/// `wait_for_element` polls through, keeping a spent budget distinguishable from an element that
+/// is genuinely absent (glass#329).
+fn out_of_time(last: Option<&GlassError>) -> GlassError {
+    let seen = match last {
+        Some(e) => format!(" (last attempt: {e})"),
+        None => String::new(),
+    };
+    GlassError::AccessibilityNotReady(format!(
+        "uiautomator served no tree within the time this call allowed{seen}"
+    ))
 }
 
 /// What one dump attempt settled, for a loop deciding whether another would help.
@@ -187,31 +206,54 @@ impl RetryBound {
     };
 }
 
-/// Dump, retrying while `uiautomator` cannot serve one yet, within `bound`.
+/// Dump, retrying while `uiautomator` cannot serve one yet, within `bound` and `caller`.
 ///
 /// Only [`Attempt::NotReady`] is retried, so a device that has gone away is reported at once
 /// rather than waited on.
 ///
 /// Returns after `bound.least` attempts plus however many more start while `bound.then_within`
-/// remains — each costing up to `AdbOp::Dump`'s budget, per [`attempt_deadline`].
+/// remains — each costing up to `AdbOp::Dump`'s budget, per [`attempt_deadline`] — and no later
+/// than `caller`, which caps both the attempts and the window they retry in.
 fn dump_until_ready(
     run: &mut AdbRunner<'_>,
     prefix: &str,
     bound: RetryBound,
     interval: Duration,
+    caller: AxDeadline,
 ) -> Result<String> {
-    let retry_until = Instant::now() + bound.then_within;
+    let retry_until = caller.cap(Instant::now() + bound.then_within);
     let mut owed = bound.least.max(1);
+    // Kept so a spent caller deadline can name what the device last said, not just the budget.
+    let mut unready: Option<GlassError> = None;
     loop {
-        match dump_once(run, prefix, attempt_deadline()) {
+        // Checked rather than left to the cap below, which would still spawn an adb process to
+        // abandon.
+        if caller.is_spent() {
+            return Err(out_of_time(unready.as_ref()));
+        }
+        let own = attempt_deadline();
+        let ends = caller.cap(own);
+        match dump_once(run, prefix, ends) {
             Attempt::Dumped(xml) => return Ok(xml),
+            // An attempt the *caller's* deadline cut short is not a device that failed. Which
+            // bound governs is settled before the attempt, not read off its error (glass#341).
+            Attempt::Fatal(e) if ends < own && bound_fired(&e) => {
+                return Err(out_of_time(unready.as_ref()));
+            }
             Attempt::Fatal(e) => return Err(e),
             Attempt::NotReady(e) => {
                 owed = owed.saturating_sub(1);
                 let left = retry_until.saturating_duration_since(Instant::now());
                 if owed == 0 && left.is_zero() {
-                    return Err(e);
+                    // The caller closing the window is about the budget, not the device — even
+                    // with the device's own answer in hand.
+                    return Err(if caller.is_spent() {
+                        out_of_time(Some(&e))
+                    } else {
+                        e
+                    });
                 }
+                unready = Some(e);
                 // Clamped, so an attempt the ceiling still governs starts inside it — unclamped, a
                 // whole further attempt would land past the bound. An owed attempt waits only what
                 // is left, which a spent ceiling makes zero.
@@ -304,6 +346,30 @@ const VERIFY_BOUND: RetryBound = RetryBound {
 /// attempt in flight, which [`VERIFY_BOUND`] still owes its second dump.
 const VERIFY_PHASE_BUDGET_MS: u64 = 20_000;
 
+/// How much retrying one [`Accessibility::snapshot`] is worth, from whether a dump has ever
+/// succeeded on this reader and how long the caller said it would wait.
+///
+/// A warmed reader gets no retry of its own — only what the caller's deadline pays for. Retrying
+/// without one is what a `glass_wait_for_element` cannot afford: it re-reads on its own schedule,
+/// so a second attempt here costs it another whole [`AdbOp::Dump`] budget past its timeout
+/// (glass#338).
+///
+/// The cold wait is not capped here: [`dump_until_ready`] caps every wait by the caller, and this
+/// one must still *owe* the two attempts the accessibility bridge's registration needs.
+fn snapshot_bound(warmed: bool, deadline: AxDeadline) -> RetryBound {
+    if !warmed {
+        return COLD_BOUND;
+    }
+    match deadline.remaining() {
+        // Nothing bounds a retry, so there is no retry.
+        None => RetryBound::ONCE,
+        Some(left) => RetryBound {
+            least: 1,
+            then_within: left,
+        },
+    }
+}
+
 /// Reads the active window's accessibility tree via `uiautomator`.
 pub struct AndroidA11y {
     adb: Adb,
@@ -324,8 +390,8 @@ impl AndroidA11y {
     /// One dump, retrying a not-ready device within `bound`.
     ///
     /// Split out of [`Accessibility::snapshot`] so a caller that knows the UI is mid-flux can ask
-    /// for retries even on a warmed reader: `snapshot` gives a warmed reader one attempt, which is
-    /// right for a `wait_for_element` tick and wrong immediately after typing.
+    /// for retries a [`snapshot_bound`] would not give it — immediately after typing, where the
+    /// tree is expected to be unreadable for a moment and no deadline says how long to allow.
     fn snapshot_within(&mut self, ctx: &AxContext, bound: RetryBound) -> Result<AxTree> {
         let window = ctx.window.clone();
         let adb = self.ensure_adb()?;
@@ -334,6 +400,7 @@ impl AndroidA11y {
             DUMP_PREFIX,
             bound,
             Duration::from_millis(DUMP_POLL_INTERVAL_MS),
+            ctx.deadline,
         )?;
         self.warmed = true;
         build_tree(&xml, &window, ctx.limits)
@@ -451,15 +518,7 @@ fn locate_editable_target(
 
 impl Accessibility for AndroidA11y {
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
-        let bound = if self.warmed {
-            // One attempt, because this reader cannot see the caller's deadline: `wait_for_element`
-            // re-snapshots on its own schedule, and a second attempt here could cost it another
-            // whole `AdbOp::Dump` budget past the timeout it was given.
-            RetryBound::ONCE
-        } else {
-            COLD_BOUND
-        };
-        self.snapshot_within(ctx, bound)
+        self.snapshot_within(ctx, snapshot_bound(self.warmed, ctx.deadline))
     }
 
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
@@ -527,11 +586,13 @@ impl Accessibility for AndroidA11y {
 #[cfg(test)]
 mod tests {
     use super::{
-        Attempt, RetryBound, dump_once, dump_until_ready, editable_target, locate_editable_target,
-        verify_write,
+        Attempt, COLD_BOUND, RetryBound, dump_once, dump_until_ready, editable_target,
+        locate_editable_target, snapshot_bound, verify_write,
     };
     use crate::adb::AdbOp;
-    use glass_core::accessibility::{AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree};
+    use glass_core::accessibility::{
+        AxDeadline, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree,
+    };
     use glass_core::{GlassError, Result, WindowGeometry};
     use std::collections::HashMap;
     use std::time::{Duration, Instant};
@@ -660,11 +721,240 @@ mod tests {
                 then_within: Duration::from_millis(10),
             },
             Duration::ZERO,
+            AxDeadline::NONE,
         )
         .expect("the second attempt is owed however long the first took");
 
         assert_eq!(xml, XML);
         assert_eq!(dumps, 2, "exactly the attempt that was owed");
+    }
+
+    /// A runner that answers every step, recording the deadline each was given.
+    fn recording(
+        seen: &mut Vec<Instant>,
+    ) -> impl FnMut(&[&str], Instant) -> Result<(String, String)> {
+        move |argv: &[&str], deadline: Instant| {
+            seen.push(deadline);
+            match argv {
+                ["shell", "uiautomator", "dump", _] => Ok((DUMPED.to_string(), String::new())),
+                ["shell", "cat", _] => Ok((XML.to_string(), String::new())),
+                ["shell", "rm", "-f", _] => Ok((String::new(), String::new())),
+                other => panic!("unexpected adb command: {other:?}"),
+            }
+        }
+    }
+
+    /// glass#338: `wait_for_element` re-reads from a synchronous tick, so only the reader can
+    /// hold a read inside the timeout.
+    #[test]
+    fn every_step_is_bounded_by_the_callers_deadline_not_by_the_dump_budget() {
+        let mut seen: Vec<Instant> = Vec::new();
+        {
+            let mut run = recording(&mut seen);
+            dump_until_ready(
+                &mut run,
+                PREFIX,
+                RetryBound::ONCE,
+                Duration::ZERO,
+                AxDeadline::in_ms(50),
+            )
+            .expect("the dump succeeds");
+        }
+
+        assert!(!seen.is_empty(), "no adb step ran");
+        // The caller's instant was fixed before this line, so it passes however slow the machine
+        // is; `AdbOp::Dump`'s 20s budget cannot.
+        let latest = Instant::now() + Duration::from_millis(50);
+        for (i, d) in seen.iter().enumerate() {
+            assert!(
+                *d <= latest,
+                "step {i} was given {:?} past the caller's deadline",
+                d.saturating_duration_since(latest)
+            );
+        }
+    }
+
+    /// Without this the test above passes on a reader that caps every step at nothing.
+    #[test]
+    fn a_caller_that_names_no_deadline_leaves_the_reader_its_own_budget() {
+        let mut seen: Vec<Instant> = Vec::new();
+        let at_least = Instant::now() + AdbOp::Dump.budget() - Duration::from_secs(1);
+        {
+            let mut run = recording(&mut seen);
+            dump_until_ready(
+                &mut run,
+                PREFIX,
+                RetryBound::ONCE,
+                Duration::ZERO,
+                AxDeadline::NONE,
+            )
+            .expect("the dump succeeds");
+        }
+
+        assert!(!seen.is_empty(), "no adb step ran");
+        assert!(
+            seen.iter().all(|d| *d >= at_least),
+            "a caller that asked for nothing had the dump budget cut anyway"
+        );
+    }
+
+    /// The error names the budget rather than a device that was never consulted.
+    #[test]
+    fn a_dump_the_caller_stopped_waiting_for_is_not_started() {
+        let mut ran = false;
+        let mut run = |_argv: &[&str], _d: Instant| -> Result<(String, String)> {
+            ran = true;
+            Ok((DUMPED.to_string(), String::new()))
+        };
+        let e = dump_until_ready(
+            &mut run,
+            PREFIX,
+            patient(),
+            Duration::ZERO,
+            AxDeadline::in_ms(0),
+        )
+        .expect_err("the caller had stopped waiting");
+
+        assert!(
+            !ran,
+            "an adb step ran for a caller that had stopped waiting"
+        );
+        assert!(matches!(e, GlassError::AccessibilityNotReady(_)), "{e}");
+    }
+
+    /// glass#338: before the deadline reached the reader, one attempt was the only safe number —
+    /// nothing else bounded a retry.
+    #[test]
+    fn a_warmed_reader_retries_only_inside_the_deadline_the_caller_named() {
+        let told = snapshot_bound(true, AxDeadline::in_ms(5_000));
+        assert!(
+            told.then_within > Duration::from_secs(4) && told.then_within <= Duration::from_secs(5),
+            "the retry window is not the caller's: {told:?}"
+        );
+
+        let untold = snapshot_bound(true, AxDeadline::NONE);
+        assert_eq!(
+            untold.then_within,
+            Duration::ZERO,
+            "retried on a budget no caller had agreed to: {untold:?}"
+        );
+        assert_eq!(untold.least, 1, "{untold:?}");
+    }
+
+    /// The first snapshot of a session waits out a boot whatever the caller allowed: the bridge
+    /// registration it is owed two attempts for is not negotiable, and `dump_until_ready` caps the
+    /// wall-clock by the caller regardless.
+    #[test]
+    fn a_cold_reader_is_owed_its_attempts_however_little_the_caller_allowed() {
+        let bound = snapshot_bound(false, AxDeadline::in_ms(1));
+        assert_eq!(bound.least, COLD_BOUND.least, "{bound:?}");
+        assert_eq!(bound.then_within, COLD_BOUND.then_within, "{bound:?}");
+    }
+
+    /// A [`RetryBound`] outliving the caller sleeps out a whole interval before noticing nobody
+    /// is waiting — and the interval is sized against a cold boot, not against any one caller.
+    #[test]
+    fn the_retry_window_ends_with_the_caller_even_when_the_bound_would_run_longer() {
+        let mut run = |argv: &[&str], _d: Instant| -> Result<(String, String)> {
+            match argv {
+                ["shell", "uiautomator", "dump", _] => {
+                    // Outlasts the caller's deadline, so it expires mid-attempt rather than before
+                    // the loop can start one.
+                    std::thread::sleep(Duration::from_millis(30));
+                    Ok((String::new(), format!("{NOT_READY}\n")))
+                }
+                ["shell", "cat", path] => Err(read_err(path)),
+                ["shell", "rm", "-f", _] => Ok((String::new(), String::new())),
+                other => panic!("unexpected adb command: {other:?}"),
+            }
+        };
+        let started = Instant::now();
+        let e = dump_until_ready(
+            &mut run,
+            PREFIX,
+            patient(),
+            Duration::from_secs(5),
+            AxDeadline::in_ms(10),
+        )
+        .expect_err("the caller's deadline passed during the attempt");
+
+        assert!(matches!(e, GlassError::AccessibilityNotReady(_)), "{e}");
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "slept a retry interval for a caller that had stopped waiting: {:?}",
+            started.elapsed()
+        );
+    }
+
+    /// [`RetryBound::least`] says how many attempts the *device* is owed, not how many a caller
+    /// must pay for: an owed attempt is not started once the caller has stopped waiting. Both
+    /// production bounds owe two, so this is the shape a real not-ready read takes.
+    #[test]
+    fn an_owed_attempt_is_not_started_once_the_caller_has_stopped_waiting() {
+        let mut dumps = 0;
+        let mut run = |argv: &[&str], _d: Instant| -> Result<(String, String)> {
+            match argv {
+                ["shell", "uiautomator", "dump", _] => {
+                    dumps += 1;
+                    // Outlasts the caller, so the deadline passes with an attempt still owed.
+                    std::thread::sleep(Duration::from_millis(30));
+                    Ok((String::new(), format!("{NOT_READY}\n")))
+                }
+                ["shell", "cat", path] => Err(read_err(path)),
+                ["shell", "rm", "-f", _] => Ok((String::new(), String::new())),
+                other => panic!("unexpected adb command: {other:?}"),
+            }
+        };
+        let e = dump_until_ready(
+            &mut run,
+            PREFIX,
+            COLD_BOUND,
+            Duration::ZERO,
+            AxDeadline::in_ms(10),
+        )
+        .expect_err("the caller's deadline passed during the first attempt");
+
+        assert_eq!(dumps, 1, "the owed attempt ran for a caller that had gone");
+        assert!(
+            e.to_string().contains("null root node"),
+            "the spent-budget error dropped what the device had said: {e}"
+        );
+    }
+
+    /// An attempt the caller's deadline cut short is a spent budget, not a broken device — and a
+    /// wait told the difference reports `{matched:false}` instead of failing.
+    #[test]
+    fn an_attempt_the_caller_cut_short_reports_the_budget_rather_than_the_device() {
+        let timed_out = |_argv: &[&str], _d: Instant| -> Result<(String, String)> {
+            Err(GlassError::Backend(format!(
+                "`adb shell uiautomator dump` {}",
+                glass_core::TIMED_OUT
+            )))
+        };
+
+        let mut cut_short = timed_out;
+        let e = dump_until_ready(
+            &mut cut_short,
+            PREFIX,
+            RetryBound::ONCE,
+            Duration::ZERO,
+            AxDeadline::in_ms(20),
+        )
+        .expect_err("the attempt was abandoned");
+        assert!(matches!(e, GlassError::AccessibilityNotReady(_)), "{e}");
+
+        // The control: the same timeout with no caller deadline is glass's own 20s budget firing,
+        // which *is* about the device — reporting it as a spent caller budget would hide a hang.
+        let mut hung = timed_out;
+        let e = dump_until_ready(
+            &mut hung,
+            PREFIX,
+            RetryBound::ONCE,
+            Duration::ZERO,
+            AxDeadline::NONE,
+        )
+        .expect_err("the attempt timed out");
+        assert!(matches!(e, GlassError::Backend(_)), "{e}");
     }
 
     /// Retryability is the attempt's own verdict, not a guess from the error variant it carries:
@@ -857,7 +1147,14 @@ mod tests {
             }
         };
         let started = Instant::now();
-        dump_until_ready(&mut run, PREFIX, RetryBound::ONCE, Duration::ZERO).unwrap();
+        dump_until_ready(
+            &mut run,
+            PREFIX,
+            RetryBound::ONCE,
+            Duration::ZERO,
+            AxDeadline::NONE,
+        )
+        .unwrap();
 
         assert_eq!(seen.len(), 3, "one attempt is three adb calls");
         assert!(
@@ -891,6 +1188,7 @@ mod tests {
                 then_within: Duration::from_secs(5),
             },
             Duration::from_millis(1),
+            AxDeadline::NONE,
         )
         .expect("the second attempt succeeds");
 
@@ -919,8 +1217,14 @@ mod tests {
             cold(argv, deadline)
         };
         let started = Instant::now();
-        dump_until_ready(&mut run, PREFIX, bound, Duration::from_secs(2))
-            .expect_err("a device that never becomes ready");
+        dump_until_ready(
+            &mut run,
+            PREFIX,
+            bound,
+            Duration::from_secs(2),
+            AxDeadline::NONE,
+        )
+        .expect_err("a device that never becomes ready");
 
         assert!(
             started.elapsed() < Duration::from_millis(500),
@@ -963,7 +1267,14 @@ mod tests {
                 _ => Ok((String::new(), String::new())),
             }
         };
-        let e = dump_until_ready(&mut run, PREFIX, patient(), Duration::ZERO).unwrap_err();
+        let e = dump_until_ready(
+            &mut run,
+            PREFIX,
+            patient(),
+            Duration::ZERO,
+            AxDeadline::NONE,
+        )
+        .unwrap_err();
 
         let msg = e.to_string();
         assert!(
@@ -983,15 +1294,28 @@ mod tests {
     #[test]
     fn a_dump_that_is_not_ready_yet_is_retried_until_it_is() {
         let mut run = fake(3);
-        let xml = dump_until_ready(&mut run, PREFIX, patient(), Duration::ZERO)
-            .expect("a device that becomes ready within the budget must produce a tree");
+        let xml = dump_until_ready(
+            &mut run,
+            PREFIX,
+            patient(),
+            Duration::ZERO,
+            AxDeadline::NONE,
+        )
+        .expect("a device that becomes ready within the budget must produce a tree");
         assert_eq!(xml, XML);
     }
 
     #[test]
     fn a_dump_that_never_becomes_ready_fails_with_the_last_reason() {
         let mut run = fake(usize::MAX);
-        let e = dump_until_ready(&mut run, PREFIX, RetryBound::ONCE, Duration::ZERO).unwrap_err();
+        let e = dump_until_ready(
+            &mut run,
+            PREFIX,
+            RetryBound::ONCE,
+            Duration::ZERO,
+            AxDeadline::NONE,
+        )
+        .unwrap_err();
         assert!(e.to_string().contains(NOT_READY), "{e}");
     }
 
@@ -1011,7 +1335,14 @@ mod tests {
                 _ => Ok((String::new(), String::new())),
             }
         };
-        let e = dump_until_ready(&mut run, PREFIX, patient(), Duration::ZERO).unwrap_err();
+        let e = dump_until_ready(
+            &mut run,
+            PREFIX,
+            patient(),
+            Duration::ZERO,
+            AxDeadline::NONE,
+        )
+        .unwrap_err();
         assert!(matches!(e, GlassError::Backend(_)), "{e}");
         assert_eq!(
             attempts, 1,
@@ -1024,8 +1355,14 @@ mod tests {
         // Measured at 3 failures in 14 runs entering the suite straight from a snapshot restore;
         // a later dump against a settled tree succeeds, so waiting is the whole remedy.
         let mut run = fake_crashing(2);
-        let xml = dump_until_ready(&mut run, PREFIX, patient(), Duration::ZERO)
-            .expect("a dump that crashed must be retried inside the budget");
+        let xml = dump_until_ready(
+            &mut run,
+            PREFIX,
+            patient(),
+            Duration::ZERO,
+            AxDeadline::NONE,
+        )
+        .expect("a dump that crashed must be retried inside the budget");
         assert_eq!(xml, XML);
     }
 
@@ -1059,8 +1396,14 @@ mod tests {
                     other => panic!("unexpected adb command: {other:?}"),
                 }
             };
-            dump_until_ready(&mut run, PREFIX, patient(), Duration::ZERO)
-                .expect("the attempt after the crashes dumps");
+            dump_until_ready(
+                &mut run,
+                PREFIX,
+                patient(),
+                Duration::ZERO,
+                AxDeadline::NONE,
+            )
+            .expect("the attempt after the crashes dumps");
         }
 
         assert!(

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -1025,7 +1025,7 @@ fn check_timeout(target: u32, act: &Actuated, want: bool, seen: CheckState) -> G
 #[cfg(test)]
 mod tests {
     use super::*;
-    use glass_core::accessibility::AxRole;
+    use glass_core::accessibility::{AxDeadline, AxRole};
     use serde_json::json;
     use std::io::{BufRead, Write};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -2260,6 +2260,7 @@ mod tests {
             window_handle: None,
             a11y_bus_addr: None,
             limits: WalkLimits::DEFAULT,
+            deadline: AxDeadline::NONE,
         }
     }
 

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -7,8 +7,8 @@ use std::sync::Mutex;
 use serde_json::{Value, json};
 
 use glass_core::accessibility::{
-    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree,
-    Subject, TruncationLimit, WalkBudget, WalkLimits,
+    Accessibility, AxContext, AxDeadline, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget,
+    AxTree, Subject, TruncationLimit, WalkBudget, WalkLimits,
 };
 use glass_core::platform::WindowGeometry;
 use glass_core::{GlassError, Result};
@@ -210,6 +210,19 @@ impl ServiceClient {
         }
     }
 
+    /// Bound the connection's reads by `deadline` for as long as the returned guard lives, and
+    /// restore the standing timeout when it drops.
+    ///
+    /// Scoped rather than set-and-leave: the connection outlives any one request, so a bound left
+    /// behind would apply to a later call that never agreed to it — and to the *reconnect* path,
+    /// where a fresh `Conn` starts from the standing timeout again.
+    fn read_within(&self, deadline: AxDeadline) -> ReadBound<'_> {
+        if let Ok(mut conn) = self.conn.lock() {
+            conn.read_within(deadline.remaining());
+        }
+        ReadBound { client: self }
+    }
+
     /// Run a request that can be run twice without consequence, transparently reconnecting
     /// once if the socket dropped. A dead socket usually surfaces on the *read*, not the write.
     fn call(&self, req: Value, rearm: Option<&str>) -> std::result::Result<Value, CallFailure> {
@@ -225,7 +238,18 @@ impl ServiceClient {
         self.call_with(req, CallFailure::nothing_sent, rearm)
     }
 
+    /// Serve the tree for `package` on the connection's standing timeout — the readiness probe and
+    /// the tests, neither of which has a caller waiting on a clock.
     fn tree(&self, package: &str) -> Result<TreeReply> {
+        self.tree_within(package, AxDeadline::UNBOUNDED)
+    }
+
+    /// Serve the tree for `package`, blocking no longer than `deadline` allows.
+    ///
+    /// The bound covers the reconnect-and-re-send too, so one call cannot cost two socket
+    /// timeouts against a caller who asked for less than one (glass#338).
+    fn tree_within(&self, package: &str, deadline: AxDeadline) -> Result<TreeReply> {
+        let _bound = self.read_within(deadline);
         let r = self
             .call(json!({"op": "tree", "package": package}), None)
             .map_err(CallFailure::into_error)?;
@@ -375,9 +399,30 @@ fn subject_of(asked: &str, actual: Option<&str>) -> Option<Subject> {
     })
 }
 
+/// Restores [`ServiceClient`]'s standing read timeout when it drops, so a bound one call set
+/// cannot be inherited by the next.
+struct ReadBound<'a> {
+    client: &'a ServiceClient,
+}
+
+impl Drop for ReadBound<'_> {
+    fn drop(&mut self) {
+        if let Ok(mut conn) = self.client.conn.lock() {
+            conn.read_within(None);
+        }
+    }
+}
+
 impl Accessibility for ServiceA11y {
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
-        let reply = self.client.tree(&self.package)?;
+        // Checked before the round-trip: a companion that answers after the caller has gone costs
+        // a socket timeout nobody is waiting through.
+        if ctx.deadline.has_passed() {
+            return Err(GlassError::AccessibilityNotReady(
+                "no accessibility tree within the time this call allowed".into(),
+            ));
+        }
+        let reply = self.client.tree_within(&self.package, ctx.deadline)?;
         let mut tree = tree_from_json(&reply.tree, &ctx.window, ctx.limits)?;
         tree.subject = subject_of(&self.package, reply.package.as_deref());
         Ok(tree)
@@ -2260,12 +2305,37 @@ mod tests {
             window_handle: None,
             a11y_bus_addr: None,
             limits: WalkLimits::DEFAULT,
-            deadline: AxDeadline::NONE,
+            deadline: AxDeadline::UNBOUNDED,
         }
     }
 
     fn ops_of(ops: &Arc<Mutex<Vec<String>>>) -> Vec<String> {
         ops.lock().unwrap().clone()
+    }
+
+    /// glass#338: this reader is the one the platform *prefers* once the companion is installed,
+    /// so a deadline it ignores is a deadline the dogfood configuration ignores.
+    ///
+    /// A caller that has stopped waiting is answered without a round-trip at all — the socket's
+    /// standing timeout is 30s and a failed call reconnects and re-sends, so one snapshot can
+    /// outlast a whole `glass_wait_for_element` twice over.
+    #[test]
+    fn a_snapshot_the_caller_stopped_waiting_for_never_reaches_the_device() {
+        let (port, ops) = fake_service(vec![compose_like()], OnAction::Ok);
+        let mut a11y = reader(port, std::time::Duration::ZERO);
+        let mut ctx = ctx();
+        ctx.deadline = AxDeadline::from_millis(0);
+
+        let e = a11y
+            .snapshot(&ctx)
+            .expect_err("the caller had stopped waiting");
+
+        assert!(matches!(e, GlassError::AccessibilityNotReady(_)), "{e}");
+        assert!(
+            ops_of(&ops).is_empty(),
+            "the device was asked for a tree nobody was waiting for: {:?}",
+            ops_of(&ops)
+        );
     }
 
     #[test]

--- a/crates/glass-android/src/conn.rs
+++ b/crates/glass-android/src/conn.rs
@@ -55,6 +55,11 @@ impl CallFailure {
 }
 
 /// A live connection to the agent: a framed line reader/writer + a monotonic id.
+/// How long a read blocks for the companion when no caller named a bound — long enough that a
+/// stalled agent surfaces as a transport error the reconnect path handles, rather than hanging the
+/// single-threaded MCP loop forever.
+const STANDING_TIMEOUT: Duration = Duration::from_secs(30);
+
 pub(crate) struct Conn {
     pub(crate) writer: TcpStream,
     pub(crate) reader: BufReader<TcpStream>,
@@ -68,9 +73,8 @@ impl Conn {
             .map_err(|e| GlassError::Backend(format!("agent connect :{port}: {e}")))?;
         // Set read/write timeouts so a stalled agent surfaces as a transport error (which
         // the existing reconnect path handles) rather than hanging the MCP thread forever.
-        let to = Duration::from_secs(30);
-        stream.set_read_timeout(Some(to)).ok();
-        stream.set_write_timeout(Some(to)).ok();
+        stream.set_read_timeout(Some(STANDING_TIMEOUT)).ok();
+        stream.set_write_timeout(Some(STANDING_TIMEOUT)).ok();
         let reader = BufReader::new(
             stream
                 .try_clone()
@@ -106,6 +110,17 @@ impl Conn {
             return Err(GlassError::Backend("agent closed the connection".into()));
         }
         Ok(line.trim_end().to_string())
+    }
+
+    /// Bound how long the next reads may block for, or restore the standing timeout when the
+    /// caller named nothing.
+    ///
+    /// Per-call rather than per-connection: the socket outlives any one request, so a bound left
+    /// behind would be applied to a later call that never agreed to it.
+    pub(crate) fn read_within(&mut self, wait: Option<Duration>) {
+        self.writer
+            .set_read_timeout(Some(wait.unwrap_or(STANDING_TIMEOUT)))
+            .ok();
     }
 
     /// Send one request object (an `id` is injected) and return the response `Value`.

--- a/crates/glass-android/tests/a11y_loop.rs
+++ b/crates/glass-android/tests/a11y_loop.rs
@@ -7,11 +7,14 @@
 //!
 //! They cover a non-trivial tree with named, role-typed elements; a write confirmed against the
 //! live field — and a clear that cannot be confirmed here at all, because this platform reports
-//! the emptied field's hint as its text; that a read takes its dump file with it; that a
-//! snapshot taken while another app is foreground says which app it describes; and that a test
-//! which fails mid-interaction still hands the device back launchable.
+//! the emptied field's hint as its text; that a read takes its dump file with it; that a read
+//! stops at the deadline its caller named; that a snapshot taken while another app is foreground
+//! says which app it describes; and that a test which fails mid-interaction still hands the
+//! device back launchable.
 
-use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, WalkLimits};
+use glass_core::accessibility::{
+    Accessibility, AxContext, AxDeadline, AxNode, AxTarget, WalkLimits,
+};
 use glass_core::{
     AppSpec, GlassError, MouseButton, Platform, PointerEvent, SandboxLevel, WindowGeometry,
 };
@@ -83,6 +86,7 @@ impl Session {
             window_handle: None,
             a11y_bus_addr: None,
             limits: WalkLimits::DEFAULT,
+            deadline: AxDeadline::NONE,
         }
     }
 
@@ -150,6 +154,40 @@ fn snapshot_has_named_role_typed_nodes() {
         n.name.is_some() || n.children.iter().any(any_named)
     }
     assert!(any_named(&tree.root), "expected at least one named node");
+}
+
+/// glass#338: the caller's deadline reaches the device, so a read told to be done in 50ms stops
+/// there rather than spending `AdbOp::Dump`'s 20s budget.
+///
+/// Only a device shows this: the unit tests drive a fake runner, which cannot be slow the way a
+/// real `uiautomator dump` is.
+#[test]
+#[ignore = "requires a booted AVD + GLASS_ANDROID_SERIAL/GLASS_ADB"]
+fn a_read_stops_at_the_deadline_its_caller_named() {
+    let mut session = Session::start();
+    let mut a11y = glass_android::AndroidA11y::new();
+    // Warmed first: a cold reader is owed its attempts however little the caller allowed, so an
+    // unwarmed one would prove nothing about the deadline.
+    let ctx = session.ctx();
+    a11y.snapshot(&ctx)
+        .expect("the first snapshot warms the reader");
+
+    let mut hurried = session.ctx();
+    hurried.deadline = AxDeadline::in_ms(50);
+    let started = std::time::Instant::now();
+    let e = a11y
+        .snapshot(&hurried)
+        .expect_err("50ms is not enough for a dump this device serves in seconds");
+    let took = started.elapsed();
+
+    assert!(
+        matches!(e, GlassError::AccessibilityNotReady(_)),
+        "a read the caller cut short must not read as a broken device: {e}"
+    );
+    assert!(
+        took < std::time::Duration::from_secs(5),
+        "the read outlived the 50ms it was given by {took:?} — the dump budget still governs"
+    );
 }
 
 /// The dump files on the device, as `adb shell ls` reports them.

--- a/crates/glass-android/tests/a11y_loop.rs
+++ b/crates/glass-android/tests/a11y_loop.rs
@@ -86,7 +86,7 @@ impl Session {
             window_handle: None,
             a11y_bus_addr: None,
             limits: WalkLimits::DEFAULT,
-            deadline: AxDeadline::NONE,
+            deadline: AxDeadline::UNBOUNDED,
         }
     }
 
@@ -173,7 +173,7 @@ fn a_read_stops_at_the_deadline_its_caller_named() {
         .expect("the first snapshot warms the reader");
 
     let mut hurried = session.ctx();
-    hurried.deadline = AxDeadline::in_ms(50);
+    hurried.deadline = AxDeadline::from_millis(50);
     let started = std::time::Instant::now();
     let e = a11y
         .snapshot(&hurried)

--- a/crates/glass-android/tests/a11y_service_loop.rs
+++ b/crates/glass-android/tests/a11y_service_loop.rs
@@ -10,7 +10,9 @@ use std::sync::Mutex;
 use glass_android::{
     A11yServiceRegistry, AgentRegistry, AndroidPlatform, EmulatorRegistry, ServiceA11y,
 };
-use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, WalkLimits};
+use glass_core::accessibility::{
+    Accessibility, AxContext, AxDeadline, AxNode, AxTarget, WalkLimits,
+};
 use glass_core::{AppSpec, Platform, SandboxLevel, WindowGeometry};
 
 /// Serialize the two tests below: the on-device accessibility service accepts one connection
@@ -55,6 +57,7 @@ fn a11y_service_snapshot_and_actions() {
         window_handle: None,
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
+        deadline: AxDeadline::NONE,
     };
 
     let mut tree = a11y.snapshot(&ctx).expect("snapshot");
@@ -137,6 +140,7 @@ fn native_invoke_actuates_the_fixture() {
         window_handle: None,
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
+        deadline: AxDeadline::NONE,
     };
 
     fn by_desc<'a>(n: &'a AxNode, desc: &str) -> Option<&'a AxNode> {

--- a/crates/glass-android/tests/a11y_service_loop.rs
+++ b/crates/glass-android/tests/a11y_service_loop.rs
@@ -57,7 +57,7 @@ fn a11y_service_snapshot_and_actions() {
         window_handle: None,
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
-        deadline: AxDeadline::NONE,
+        deadline: AxDeadline::UNBOUNDED,
     };
 
     let mut tree = a11y.snapshot(&ctx).expect("snapshot");
@@ -140,7 +140,7 @@ fn native_invoke_actuates_the_fixture() {
         window_handle: None,
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
-        deadline: AxDeadline::NONE,
+        deadline: AxDeadline::UNBOUNDED,
     };
 
     fn by_desc<'a>(n: &'a AxNode, desc: &str) -> Option<&'a AxNode> {

--- a/crates/glass-android/tests/role_probe.rs
+++ b/crates/glass-android/tests/role_probe.rs
@@ -36,7 +36,7 @@ use std::time::Duration;
 use glass_android::{
     A11yServiceRegistry, AgentRegistry, AndroidA11y, AndroidPlatform, EmulatorRegistry, ServiceA11y,
 };
-use glass_core::accessibility::{Accessibility, AxContext, WalkLimits};
+use glass_core::accessibility::{Accessibility, AxContext, AxDeadline, WalkLimits};
 use glass_core::{
     AppSpec, AxRole, AxTree, DescriptionSourcing, Platform, SandboxLevel,
     description_census_report, role_histogram,
@@ -258,6 +258,7 @@ fn uiautomator_role_histogram_probe() {
             window_handle: None,
             a11y_bus_addr: None,
             limits: uncapped(),
+            deadline: AxDeadline::NONE,
         };
         let mut a11y = AndroidA11y::new();
         let mut tree = a11y
@@ -339,6 +340,7 @@ fn service_role_histogram_probe() {
             window_handle: None,
             a11y_bus_addr: None,
             limits: uncapped(),
+            deadline: AxDeadline::NONE,
         };
         let mut tree = a11y
             .snapshot(&ctx)

--- a/crates/glass-android/tests/role_probe.rs
+++ b/crates/glass-android/tests/role_probe.rs
@@ -258,7 +258,7 @@ fn uiautomator_role_histogram_probe() {
             window_handle: None,
             a11y_bus_addr: None,
             limits: uncapped(),
-            deadline: AxDeadline::NONE,
+            deadline: AxDeadline::UNBOUNDED,
         };
         let mut a11y = AndroidA11y::new();
         let mut tree = a11y
@@ -340,7 +340,7 @@ fn service_role_histogram_probe() {
             window_handle: None,
             a11y_bus_addr: None,
             limits: uncapped(),
-            deadline: AxDeadline::NONE,
+            deadline: AxDeadline::UNBOUNDED,
         };
         let mut tree = a11y
             .snapshot(&ctx)

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -698,6 +698,50 @@ pub struct AxContext {
     /// Set from the session's stored limits so a snapshot and a later `set_value` walk the
     /// tree with the same bounds (ids stay resolvable).
     pub limits: WalkLimits,
+    /// The time bound for this call, as [`Self::limits`] is its size bound.
+    pub deadline: AxDeadline,
+}
+
+/// When the caller stops waiting for the accessibility call this context belongs to.
+///
+/// A reader must cap its own per-call budgets by this, because the caller cannot interrupt one:
+/// [`crate::Glass::wait_for_element`] re-reads the tree from a synchronous tick, so a 20s
+/// `uiautomator dump` answered a 10s wait (glass#338).
+///
+/// [`Self::NONE`] means the caller named no instant, leaving the reader its own budget — NOT that
+/// there is no time.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AxDeadline(Option<std::time::Instant>);
+
+impl AxDeadline {
+    /// The caller named no instant to stop at.
+    pub const NONE: Self = Self(None);
+
+    /// Stop `ms` milliseconds from now.
+    pub fn in_ms(ms: u64) -> Self {
+        Self(Some(
+            std::time::Instant::now() + std::time::Duration::from_millis(ms),
+        ))
+    }
+
+    /// `proposed`, or this deadline when it falls first — the bound one step of a call runs under.
+    pub fn cap(self, proposed: std::time::Instant) -> std::time::Instant {
+        match self.0 {
+            Some(d) => proposed.min(d),
+            None => proposed,
+        }
+    }
+
+    /// How long is left, or `None` when the caller named no instant. Zero once it has passed.
+    pub fn remaining(self) -> Option<std::time::Duration> {
+        self.0
+            .map(|d| d.saturating_duration_since(std::time::Instant::now()))
+    }
+
+    /// Whether the caller named an instant that has passed — work started now cannot be wanted.
+    pub fn is_spent(self) -> bool {
+        self.remaining().is_some_and(|left| left.is_zero())
+    }
 }
 
 /// A fingerprint identifying the element a value-set targets: its synthetic id
@@ -1191,6 +1235,7 @@ mod tests {
             window_handle: None,
             a11y_bus_addr: None,
             limits: WalkLimits::DEFAULT,
+            deadline: AxDeadline::NONE,
         };
         let err = Bare
             .set_value(&ctx, &target, "x")
@@ -2528,6 +2573,7 @@ mod tests {
             window_handle: None,
             a11y_bus_addr: None,
             limits: WalkLimits::DEFAULT,
+            deadline: AxDeadline::NONE,
         };
         let target = AxTarget {
             id: AxNodeId(1),

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -721,9 +721,13 @@ impl AxDeadline {
 
     /// Stop `ms` milliseconds from now.
     pub fn from_millis(ms: u64) -> Self {
-        Self(Some(
-            std::time::Instant::now() + std::time::Duration::from_millis(ms),
-        ))
+        Self::at(std::time::Instant::now() + std::time::Duration::from_millis(ms))
+    }
+
+    /// Stop at `instant` — for a caller that already holds the moment it stops waiting, and for a
+    /// test that needs the same instant on both sides of a comparison.
+    pub const fn at(instant: std::time::Instant) -> Self {
+        Self(Some(instant))
     }
 
     /// `proposed`, or this deadline when it falls first — the bound one step of a call runs under.
@@ -1184,6 +1188,9 @@ mod tests {
         assert!(soon.governs(now + std::time::Duration::from_secs(60)));
         assert!(!soon.governs(now));
         assert!(!AxDeadline::UNBOUNDED.governs(now + std::time::Duration::from_secs(60)));
+        // The tie itself, which only a shared instant can express: `<=` here would blame the
+        // caller for a backend that hung for exactly its own ceiling.
+        assert!(!AxDeadline::at(now).governs(now));
     }
 
     #[test]

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -1129,6 +1129,38 @@ pub fn element_match<'a>(
 mod tests {
     use super::*;
 
+    /// The two bounds a reader holds — its own and its caller's — resolve to whichever falls
+    /// first, in both directions.
+    #[test]
+    fn a_deadline_caps_a_proposed_instant_only_when_it_falls_first() {
+        let soon = AxDeadline::in_ms(1_000);
+        let later = std::time::Instant::now() + std::time::Duration::from_secs(60);
+        assert!(soon.cap(later) < later, "the nearer bound did not govern");
+
+        let now = std::time::Instant::now();
+        assert_eq!(
+            soon.cap(now),
+            now,
+            "a reader's own nearer bound was widened"
+        );
+    }
+
+    /// A caller that named no instant leaves the reader whatever it proposed — [`AxDeadline::NONE`]
+    /// is not a deadline of zero, which would stop every read before it started.
+    #[test]
+    fn no_deadline_caps_nothing_and_is_never_spent() {
+        let proposed = std::time::Instant::now() + std::time::Duration::from_secs(60);
+        assert_eq!(AxDeadline::NONE.cap(proposed), proposed);
+        assert_eq!(AxDeadline::NONE.remaining(), None);
+        assert!(!AxDeadline::NONE.is_spent());
+    }
+
+    #[test]
+    fn a_deadline_is_spent_once_its_instant_has_passed() {
+        assert!(AxDeadline::in_ms(0).is_spent());
+        assert!(!AxDeadline::in_ms(60_000).is_spent());
+    }
+
     /// Compile-time guard for [`AxRole::ALL`] — never called, and exists only for its exhaustive
     /// match. The role-parity tests and [`crate::role_support::ROLE_SUPPORT`] quantify their
     /// completeness claims over `ALL`, so a new variant missing from it would silently weaken

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -704,21 +704,23 @@ pub struct AxContext {
 
 /// When the caller stops waiting for the accessibility call this context belongs to.
 ///
-/// A reader must cap its own per-call budgets by this, because the caller cannot interrupt one:
-/// [`crate::Glass::wait_for_element`] re-reads the tree from a synchronous tick, so a 20s
-/// `uiautomator dump` answered a 10s wait (glass#338).
+/// A reader cannot be interrupted mid-read — [`crate::Glass::wait_for_element`] re-reads from a
+/// synchronous tick — so a 20s `uiautomator dump` answered a 10s wait until readers took this
+/// (glass#338). The obligation is stated on [`Accessibility::snapshot`], where an implementer
+/// meets it.
 ///
-/// [`Self::NONE`] means the caller named no instant, leaving the reader its own budget — NOT that
-/// there is no time.
+/// [`Self::UNBOUNDED`] leaves the reader its own budget: it is the *widest* value, as `WalkLimits`'
+/// unbounded is, and not a deadline of zero.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[must_use]
 pub struct AxDeadline(Option<std::time::Instant>);
 
 impl AxDeadline {
     /// The caller named no instant to stop at.
-    pub const NONE: Self = Self(None);
+    pub const UNBOUNDED: Self = Self(None);
 
     /// Stop `ms` milliseconds from now.
-    pub fn in_ms(ms: u64) -> Self {
+    pub fn from_millis(ms: u64) -> Self {
         Self(Some(
             std::time::Instant::now() + std::time::Duration::from_millis(ms),
         ))
@@ -732,6 +734,15 @@ impl AxDeadline {
         }
     }
 
+    /// Whether this deadline falls before `proposed`, so a step that runs out was cut off rather
+    /// than unanswered.
+    ///
+    /// A tie is deliberately not this deadline: reporting a backend that hung for its whole
+    /// ceiling as a spent caller budget hides it.
+    pub fn governs(self, proposed: std::time::Instant) -> bool {
+        self.0.is_some_and(|d| d < proposed)
+    }
+
     /// How long is left, or `None` when the caller named no instant. Zero once it has passed.
     pub fn remaining(self) -> Option<std::time::Duration> {
         self.0
@@ -739,7 +750,10 @@ impl AxDeadline {
     }
 
     /// Whether the caller named an instant that has passed — work started now cannot be wanted.
-    pub fn is_spent(self) -> bool {
+    ///
+    /// `false` for [`Self::UNBOUNDED`] — this asks whether the caller has gone, not whether
+    /// budget remains, and a reader reading it as the latter would retry an untimed call forever.
+    pub fn has_passed(self) -> bool {
         self.remaining().is_some_and(|left| left.is_zero())
     }
 }
@@ -853,6 +867,12 @@ pub trait Accessibility {
     /// Snapshot the active window's accessibility subtree, normalized and in
     /// window-relative coordinates. Node ids are assigned by the caller
     /// afterward via [`AxTree::assign_ids`]; the backend need not set them.
+    ///
+    /// **Cap every budget of your own by [`AxContext::deadline`]**, and report a read it ended as
+    /// [`crate::GlassError::AccessibilityNotReady`] — the variant
+    /// [`crate::Glass::wait_for_element`] polls through rather than failing on. Honouring it is
+    /// per-reader: the Android, Linux and Windows readers do, so a wait's timeout does not yet
+    /// bind on macOS or iOS.
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree>;
 
     /// Subscribe to change notifications for the app described by `ctx`.
@@ -1133,7 +1153,7 @@ mod tests {
     /// first, in both directions.
     #[test]
     fn a_deadline_caps_a_proposed_instant_only_when_it_falls_first() {
-        let soon = AxDeadline::in_ms(1_000);
+        let soon = AxDeadline::from_millis(1_000);
         let later = std::time::Instant::now() + std::time::Duration::from_secs(60);
         assert!(soon.cap(later) < later, "the nearer bound did not govern");
 
@@ -1145,20 +1165,31 @@ mod tests {
         );
     }
 
-    /// A caller that named no instant leaves the reader whatever it proposed — [`AxDeadline::NONE`]
+    /// A caller that named no instant leaves the reader whatever it proposed — [`AxDeadline::UNBOUNDED`]
     /// is not a deadline of zero, which would stop every read before it started.
     #[test]
     fn no_deadline_caps_nothing_and_is_never_spent() {
         let proposed = std::time::Instant::now() + std::time::Duration::from_secs(60);
-        assert_eq!(AxDeadline::NONE.cap(proposed), proposed);
-        assert_eq!(AxDeadline::NONE.remaining(), None);
-        assert!(!AxDeadline::NONE.is_spent());
+        assert_eq!(AxDeadline::UNBOUNDED.cap(proposed), proposed);
+        assert_eq!(AxDeadline::UNBOUNDED.remaining(), None);
+        assert!(!AxDeadline::UNBOUNDED.has_passed());
+    }
+
+    /// The tie-break is load-bearing: a reader blames its own bound when both fall together, so a
+    /// backend that hung for its whole ceiling is never reported as a caller who ran out of time.
+    #[test]
+    fn a_deadline_governs_a_step_only_when_it_falls_strictly_first() {
+        let now = std::time::Instant::now();
+        let soon = AxDeadline::from_millis(1_000);
+        assert!(soon.governs(now + std::time::Duration::from_secs(60)));
+        assert!(!soon.governs(now));
+        assert!(!AxDeadline::UNBOUNDED.governs(now + std::time::Duration::from_secs(60)));
     }
 
     #[test]
-    fn a_deadline_is_spent_once_its_instant_has_passed() {
-        assert!(AxDeadline::in_ms(0).is_spent());
-        assert!(!AxDeadline::in_ms(60_000).is_spent());
+    fn a_deadline_has_passed_once_its_instant_has_passed() {
+        assert!(AxDeadline::from_millis(0).has_passed());
+        assert!(!AxDeadline::from_millis(60_000).has_passed());
     }
 
     /// Compile-time guard for [`AxRole::ALL`] — never called, and exists only for its exhaustive
@@ -1267,7 +1298,7 @@ mod tests {
             window_handle: None,
             a11y_bus_addr: None,
             limits: WalkLimits::DEFAULT,
-            deadline: AxDeadline::NONE,
+            deadline: AxDeadline::UNBOUNDED,
         };
         let err = Bare
             .set_value(&ctx, &target, "x")
@@ -2605,7 +2636,7 @@ mod tests {
             window_handle: None,
             a11y_bus_addr: None,
             limits: WalkLimits::DEFAULT,
-            deadline: AxDeadline::NONE,
+            deadline: AxDeadline::UNBOUNDED,
         };
         let target = AxTarget {
             id: AxNodeId(1),

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -76,10 +76,10 @@ pub use platform::{
 
 pub mod accessibility;
 pub use accessibility::{
-    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree,
-    ChangeSignal, ChangeWait, ClickMethod, ElementCondition, ElementInfo, ElementMatch, MAX_DEPTH,
-    MAX_NODES, MAX_SIBLINGS, Subject, Truncation, TruncationLimit, WalkBudget, WalkLimits,
-    element_match, normalize_description,
+    Accessibility, AxContext, AxDeadline, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget,
+    AxTree, ChangeSignal, ChangeWait, ClickMethod, ElementCondition, ElementInfo, ElementMatch,
+    MAX_DEPTH, MAX_NODES, MAX_SIBLINGS, Subject, Truncation, TruncationLimit, WalkBudget,
+    WalkLimits, element_match, normalize_description,
 };
 
 pub mod marks;

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -32,7 +32,9 @@ impl Glass {
         // reuses them.
         self.active_mut()?.a11y_limits =
             crate::accessibility::WalkLimits::from_max_nodes(max_nodes);
-        self.snapshot_at_current_limits()
+        // The tool takes no timeout, so the reader keeps its own budget. Inventing one here would
+        // cap a plain snapshot at a number no caller asked for.
+        self.snapshot_at_current_limits(AxDeadline::NONE)
     }
 
     /// Subscribe to the backend's change notifications for the active app, if it has any.
@@ -40,7 +42,10 @@ impl Glass {
     /// Callers hold the returned signal in a local, never in the session: a poll loop's tick
     /// closure borrows `self` mutably, so a signal stored here could not be waited on from the
     /// pause between ticks.
-    pub(crate) fn subscribe_a11y_changes(&mut self) -> Option<Box<dyn ChangeSignal>> {
+    pub(crate) fn subscribe_a11y_changes(
+        &mut self,
+        deadline: AxDeadline,
+    ) -> Option<Box<dyn ChangeSignal>> {
         let s = self.active_mut().ok()?;
         // Reader check first: the accessors below are platform round-trips (`app_pids` shells
         // out to `adb` on Android).
@@ -53,6 +58,7 @@ impl Glass {
             window_handle: s.platform.active_window_handle(),
             a11y_bus_addr: s.platform.a11y_bus_addr(),
             limits: s.a11y_limits,
+            deadline,
         };
         s.accessibility.as_mut()?.subscribe_changes(&ctx)
     }
@@ -61,14 +67,17 @@ impl Glass {
     /// reset them. Used by compound operations (the `return:"snapshot"` fold, `wait_for_element`,
     /// and the scroll/combo/toggle loops) so an agent working in a raised-cap tree keeps that
     /// id-space instead of silently reverting to the default cap on the next internal snapshot.
-    pub fn a11y_resnapshot(&mut self) -> Result<AxTree> {
-        self.snapshot_at_current_limits()
+    ///
+    /// `deadline` is the enclosing operation's bound, not this walk's — see [`AxDeadline`]. A
+    /// caller with no timeout of its own passes [`AxDeadline::NONE`].
+    pub fn a11y_resnapshot(&mut self, deadline: AxDeadline) -> Result<AxTree> {
+        self.snapshot_at_current_limits(deadline)
     }
 
     /// The snapshot worker: walks the active window's tree bounded by the session's current
     /// `a11y_limits` and caches it. Callers set `a11y_limits` first (or reuse it) — see
     /// [`Glass::a11y_snapshot`] / [`Glass::a11y_resnapshot`].
-    fn snapshot_at_current_limits(&mut self) -> Result<AxTree> {
+    fn snapshot_at_current_limits(&mut self, deadline: AxDeadline) -> Result<AxTree> {
         let s = self.active_mut()?;
         let limits = s.a11y_limits;
         // Reader-presence check up front (mirrors set_value_inner) so `AxUnsupported` keeps
@@ -93,6 +102,7 @@ impl Glass {
             window_handle,
             a11y_bus_addr,
             limits,
+            deadline,
         })?;
         tree.assign_ids();
         s.last_ax = Some(tree.clone());
@@ -105,7 +115,7 @@ impl Glass {
     /// Caches the snapshot, so `click_element` resolves a mark's id afterward.
     pub fn a11y_marks(&mut self) -> Result<(Frame, Vec<Mark>)> {
         let frame = self.screenshot(None, None)?;
-        let tree = self.a11y_resnapshot()?;
+        let tree = self.a11y_resnapshot(AxDeadline::NONE)?;
         Ok(crate::marks::render(&frame, &tree))
     }
 
@@ -291,6 +301,7 @@ impl Glass {
                 window_handle: s.platform.active_window_handle(),
                 a11y_bus_addr: s.platform.a11y_bus_addr(),
                 limits: s.a11y_limits,
+                deadline: AxDeadline::NONE,
             };
             (target, ctx)
         };
@@ -355,6 +366,7 @@ impl Glass {
                 window_handle: s.platform.active_window_handle(),
                 a11y_bus_addr: s.platform.a11y_bus_addr(),
                 limits: s.a11y_limits,
+                deadline: AxDeadline::NONE,
             };
             (target, ctx)
         };
@@ -400,11 +412,13 @@ impl Glass {
             // holds the tree that observed the toggle.
             self.click_element_inner(id)?; // the toggle actuation (a swipe for a row-shaped control)
             // Not event-gated: this branch runs only on iOS, whose reader has no event stream.
+            // No deadline either: `AxDeadline` carries the *caller's* bound, and
+            // `TOGGLE_VERIFY_TIMEOUT_MS` is glass's own.
             let outcome = crate::poll::poll_until(
                 TOGGLE_VERIFY_INTERVAL_MS,
                 TOGGLE_VERIFY_TIMEOUT_MS,
                 || {
-                    let tree = self.a11y_resnapshot()?;
+                    let tree = self.a11y_resnapshot(AxDeadline::NONE)?;
                     let now = find_checkable_near(&tree.root, target.bounds.as_ref())
                         .is_some_and(|n| n.states.checked == want);
                     Ok(now.then_some(()))
@@ -469,7 +483,7 @@ impl Glass {
         self.settle_for_popup();
         // Ids don't survive a re-snapshot, so match the open (`expanded`) combo, else the one
         // nearest the target's bounds.
-        let tree = self.a11y_resnapshot()?;
+        let tree = self.a11y_resnapshot(AxDeadline::NONE)?;
         let combo = find_expanded_combo(&tree.root)
             .or_else(|| find_combo_near(&tree.root, target.bounds.as_ref()))
             .ok_or(GlassError::AxElementChanged(id.0))?;
@@ -507,7 +521,7 @@ impl Glass {
         self.settle_for_popup();
         // Verify the model actually committed — the *target* combo (matched by bounds,
         // now closed so nothing is `expanded`) must read the wanted label.
-        let tree = self.a11y_resnapshot()?;
+        let tree = self.a11y_resnapshot(AxDeadline::NONE)?;
         let ok = find_combo_near(&tree.root, target.bounds.as_ref())
             .and_then(|c| c.name.as_deref())
             .is_some_and(|n| n.eq_ignore_ascii_case(want));
@@ -2932,6 +2946,24 @@ mod tests {
                 "no write may land on the drifted row"
             );
         }
+    }
+
+    /// The control for the wait's deadline test: a reader handed an invented deadline abandons a
+    /// read it was never told to hurry.
+    #[test]
+    fn a_snapshot_no_caller_timed_leaves_the_reader_its_own_budget() {
+        let (mut g, ctx_log) = glass_with_a11y_ctx(FakePlatform::new(100, 100), fake_tree());
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot(None).unwrap();
+        assert_eq!(
+            ctx_log
+                .lock()
+                .unwrap()
+                .as_ref()
+                .expect("snapshot recorded its ctx")
+                .deadline,
+            AxDeadline::NONE,
+        );
     }
 
     #[test]

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -34,7 +34,7 @@ impl Glass {
             crate::accessibility::WalkLimits::from_max_nodes(max_nodes);
         // The tool takes no timeout, so the reader keeps its own budget. Inventing one here would
         // cap a plain snapshot at a number no caller asked for.
-        self.snapshot_at_current_limits(AxDeadline::NONE)
+        self.snapshot_at_current_limits(AxDeadline::UNBOUNDED)
     }
 
     /// Subscribe to the backend's change notifications for the active app, if it has any.
@@ -42,6 +42,10 @@ impl Glass {
     /// Callers hold the returned signal in a local, never in the session: a poll loop's tick
     /// closure borrows `self` mutably, so a signal stored here could not be waited on from the
     /// pause between ticks.
+    ///
+    /// `deadline` is passed for the handshake, which spends the caller's budget before the poll
+    /// loop starts. No reader bounds its subscription by it yet — the two that have event streams
+    /// bound their own registration — so today it only travels.
     pub(crate) fn subscribe_a11y_changes(
         &mut self,
         deadline: AxDeadline,
@@ -69,7 +73,7 @@ impl Glass {
     /// id-space instead of silently reverting to the default cap on the next internal snapshot.
     ///
     /// `deadline` is the enclosing operation's bound, not this walk's — see [`AxDeadline`]. A
-    /// caller with no timeout of its own passes [`AxDeadline::NONE`].
+    /// caller with no timeout of its own passes [`AxDeadline::UNBOUNDED`].
     pub fn a11y_resnapshot(&mut self, deadline: AxDeadline) -> Result<AxTree> {
         self.snapshot_at_current_limits(deadline)
     }
@@ -115,7 +119,7 @@ impl Glass {
     /// Caches the snapshot, so `click_element` resolves a mark's id afterward.
     pub fn a11y_marks(&mut self) -> Result<(Frame, Vec<Mark>)> {
         let frame = self.screenshot(None, None)?;
-        let tree = self.a11y_resnapshot(AxDeadline::NONE)?;
+        let tree = self.a11y_resnapshot(AxDeadline::UNBOUNDED)?;
         Ok(crate::marks::render(&frame, &tree))
     }
 
@@ -301,7 +305,7 @@ impl Glass {
                 window_handle: s.platform.active_window_handle(),
                 a11y_bus_addr: s.platform.a11y_bus_addr(),
                 limits: s.a11y_limits,
-                deadline: AxDeadline::NONE,
+                deadline: AxDeadline::UNBOUNDED,
             };
             (target, ctx)
         };
@@ -366,7 +370,7 @@ impl Glass {
                 window_handle: s.platform.active_window_handle(),
                 a11y_bus_addr: s.platform.a11y_bus_addr(),
                 limits: s.a11y_limits,
-                deadline: AxDeadline::NONE,
+                deadline: AxDeadline::UNBOUNDED,
             };
             (target, ctx)
         };
@@ -418,7 +422,7 @@ impl Glass {
                 TOGGLE_VERIFY_INTERVAL_MS,
                 TOGGLE_VERIFY_TIMEOUT_MS,
                 || {
-                    let tree = self.a11y_resnapshot(AxDeadline::NONE)?;
+                    let tree = self.a11y_resnapshot(AxDeadline::UNBOUNDED)?;
                     let now = find_checkable_near(&tree.root, target.bounds.as_ref())
                         .is_some_and(|n| n.states.checked == want);
                     Ok(now.then_some(()))
@@ -483,7 +487,7 @@ impl Glass {
         self.settle_for_popup();
         // Ids don't survive a re-snapshot, so match the open (`expanded`) combo, else the one
         // nearest the target's bounds.
-        let tree = self.a11y_resnapshot(AxDeadline::NONE)?;
+        let tree = self.a11y_resnapshot(AxDeadline::UNBOUNDED)?;
         let combo = find_expanded_combo(&tree.root)
             .or_else(|| find_combo_near(&tree.root, target.bounds.as_ref()))
             .ok_or(GlassError::AxElementChanged(id.0))?;
@@ -521,7 +525,7 @@ impl Glass {
         self.settle_for_popup();
         // Verify the model actually committed — the *target* combo (matched by bounds,
         // now closed so nothing is `expanded`) must read the wanted label.
-        let tree = self.a11y_resnapshot(AxDeadline::NONE)?;
+        let tree = self.a11y_resnapshot(AxDeadline::UNBOUNDED)?;
         let ok = find_combo_near(&tree.root, target.bounds.as_ref())
             .and_then(|c| c.name.as_deref())
             .is_some_and(|n| n.eq_ignore_ascii_case(want));
@@ -2962,7 +2966,7 @@ mod tests {
                 .as_ref()
                 .expect("snapshot recorded its ctx")
                 .deadline,
-            AxDeadline::NONE,
+            AxDeadline::UNBOUNDED,
         );
     }
 

--- a/crates/glass-core/src/session/mod.rs
+++ b/crates/glass-core/src/session/mod.rs
@@ -2,8 +2,8 @@
 //! its operations are grouped into submodules (each adds an `impl Glass` block).
 
 use crate::accessibility::{
-    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxTarget, AxTree, ChangeSignal,
-    ChangeWait, ClickMethod, ElementCondition, ElementInfo, ElementMatch, WalkLimits,
+    Accessibility, AxContext, AxDeadline, AxNode, AxNodeId, AxRect, AxRole, AxTarget, AxTree,
+    ChangeSignal, ChangeWait, ClickMethod, ElementCondition, ElementInfo, ElementMatch, WalkLimits,
     element_match,
 };
 use crate::baseline::BaselineStore;

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -357,6 +357,12 @@ impl Accessibility for FakeAccessibility {
         *self.ctx_log.lock().unwrap() = Some(ctx.clone());
         Ok(self.tree.clone())
     }
+    /// Records the context and declines, so the wait falls back to polling exactly as it does
+    /// against a reader with no event stream — but the bound it was handed is now observable.
+    fn subscribe_changes(&mut self, ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
+        *self.ctx_log.lock().unwrap() = Some(ctx.clone());
+        None
+    }
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
         *self.ctx_log.lock().unwrap() = Some(ctx.clone());
         if self.set_fail {
@@ -949,6 +955,47 @@ impl Accessibility for NotReadyThenTree {
         }
         Ok(self.tree.clone())
     }
+}
+
+/// A reader that answers while the caller's deadline has time and gives up once it is spent —
+/// what a backend honouring [`AxDeadline`] does on the tick that ends a wait.
+///
+/// Every other fake here ignores `ctx.deadline`, so none of them can reach the case a wait's own
+/// deadline creates.
+pub(crate) struct UntilDeadline {
+    pub(crate) tree: AxTree,
+    /// How long every read was left, in order, *measured at the read* — a deadline read back
+    /// afterwards has always expired. `None` is a read the caller left unbounded, which the first
+    /// one is on purpose.
+    pub(crate) seen: Arc<Mutex<Vec<Option<std::time::Duration>>>>,
+}
+
+impl Accessibility for UntilDeadline {
+    fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
+        self.seen.lock().unwrap().push(ctx.deadline.remaining());
+        if ctx.deadline.has_passed() {
+            return Err(GlassError::AccessibilityNotReady(
+                "no accessibility tree within the time this call allowed".into(),
+            ));
+        }
+        Ok(self.tree.clone())
+    }
+}
+
+/// A session whose reader answers until the caller's deadline is spent, reporting the bound each
+/// read was given.
+pub(crate) fn glass_with_a11y_until_deadline(
+    platform: FakePlatform,
+) -> (Glass, Arc<Mutex<Vec<Option<std::time::Duration>>>>) {
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let g = glass_with_backend(
+        platform,
+        Box::new(UntilDeadline {
+            tree: fake_tree_enabled(),
+            seen: seen.clone(),
+        }),
+    );
+    (g, seen)
 }
 
 /// A session whose reader publishes nothing for its first `silent` snapshots, reporting its

--- a/crates/glass-core/src/session/test_support.rs
+++ b/crates/glass-core/src/session/test_support.rs
@@ -514,6 +514,13 @@ pub(crate) fn glass_with_a11y(platform: FakePlatform, tree: AxTree) -> Glass {
     )
 }
 
+/// [`glass_with_a11y`] plus the ctx log — for a test that must prove what reached the backend
+/// rather than what the session recorded, without also scripting `invoke`.
+pub(crate) fn glass_with_a11y_ctx(platform: FakePlatform, tree: AxTree) -> (Glass, CtxLog) {
+    let (g, _, ctx_log) = glass_with_a11y_invoke_ctx(platform, tree, InvokeBehavior::Unsupported);
+    (g, ctx_log)
+}
+
 /// Like `glass_with_a11y`, but scripts the backend's `invoke` outcome — for tests of the
 /// native-invoke-first `click_element` path. Returns the invoke log alongside the session
 /// so a test can assert what (if anything) was "actuated" natively.

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -387,7 +387,7 @@ impl Glass {
         let started = std::time::Instant::now();
         // Every read this wait makes carries when the wait stops: the tick is synchronous, so the
         // loop cannot take back a read a reader has started (glass#338).
-        let deadline = AxDeadline::in_ms(params.timeout_ms);
+        let deadline = AxDeadline::from_millis(params.timeout_ms);
         // Before the first walk, not after: a change landing in that gap is announced to nobody,
         // and the wait then burns its whole budget on a condition that already holds.
         //
@@ -404,8 +404,15 @@ impl Glass {
             .saturating_sub(started.elapsed().as_millis() as u64);
         // Starts now rather than at the first read: the first tick follows immediately.
         let mut last_read = std::time::Instant::now();
-        // Never cleared: a tree that arrives leaves the match to answer for the result.
-        let mut never_published: Option<GlassError> = None;
+        // Only a wait that never saw a tree reports why it saw none. A reader honouring
+        // `deadline` gives up on the tick that ends the wait, so without this every unmatched wait
+        // on such a backend failed instead of answering `{matched:false}` (glass#338).
+        let mut unread: Option<GlassError> = None;
+        let mut saw_a_tree = false;
+        // The first read carries no deadline: `poll_until_with_pause` guarantees one tick, so a
+        // wait must look once, and `timeout_ms: 0` ("check now") would otherwise error against a
+        // healthy app nobody consulted. Reads after it carry the bound.
+        let mut looked = false;
         let outcome = crate::poll::poll_until_with_pause(
             params.interval_ms,
             remaining,
@@ -436,11 +443,20 @@ impl Glass {
             },
             || {
                 // fresh snapshot; assigns ids, caches, pumps
-                let tree = match self.a11y_resnapshot(deadline) {
-                    Ok(t) => t,
+                let bound = if looked {
+                    deadline
+                } else {
+                    AxDeadline::UNBOUNDED
+                };
+                looked = true;
+                let tree = match self.a11y_resnapshot(bound) {
+                    Ok(t) => {
+                        saw_a_tree = true;
+                        t
+                    }
                     // Kept so a spent budget can report this instead of "not found" (glass#329).
                     Err(e @ GlassError::AccessibilityNotReady(_)) => {
-                        never_published = Some(e);
+                        unread = Some(e);
                         return Ok(None);
                     }
                     Err(e) => return Err(e),
@@ -460,7 +476,8 @@ impl Glass {
             },
         )?;
         if outcome.value.is_none()
-            && let Some(e) = never_published
+            && !saw_a_tree
+            && let Some(e) = unread
         {
             return Err(e);
         }
@@ -603,7 +620,7 @@ impl Glass {
         // No deadline, though the sweep has a `timeout_ms`: this read propagates its error with
         // `?`, so a reader giving up at the deadline would turn the sweep's soft `{matched:false}`
         // into an error.
-        let tree = self.a11y_resnapshot(AxDeadline::NONE)?;
+        let tree = self.a11y_resnapshot(AxDeadline::UNBOUNDED)?;
         let found = match element_match(
             &tree,
             params.name.as_deref(),
@@ -1230,36 +1247,121 @@ mod tests {
     /// glass#338: on Android a `uiautomator dump` spending its own 20s budget answered a 10s
     /// wait, because `poll_until_with_pause` ticks synchronously and only the reader can stop one
     /// read early.
+    ///
+    /// This asserts over the reads *after* the first, which is deliberately unbounded — see
+    /// [`a_wait_looks_once_however_little_time_it_was_given`].
     #[test]
     fn a_wait_tells_the_reader_when_it_stops_waiting() {
-        let (mut g, ctx_log) =
-            glass_with_a11y_ctx(FakePlatform::new(100, 100), fake_tree_enabled());
+        let (mut g, seen) = glass_with_a11y_until_deadline(FakePlatform::new(100, 100));
         g.start(&spec()).unwrap();
         g.wait_for_element(&WaitElementParams {
-            name: Some("Save".into()),
-            role: Some(AxRole::Button),
+            name: Some("Ghost".into()), // never matches, so the wait reads more than once
+            role: None,
             value_contains: None,
-            condition: ElementCondition::Enabled,
-            interval_ms: 0,
-            timeout_ms: 5_000,
+            condition: ElementCondition::Appears,
+            interval_ms: 5,
+            timeout_ms: 400,
         })
         .unwrap();
 
-        let left = ctx_log
-            .lock()
-            .unwrap()
-            .as_ref()
-            .expect("the reader was called")
-            .deadline
-            .remaining()
-            .expect("the wait named the instant it stops waiting at");
+        let seen = seen.lock().unwrap();
+        assert!(seen.len() > 1, "the wait read only once: {}", seen.len());
+        let left = seen[1].expect("the read after the first is bounded by the wait's timeout");
+        // A lower bound as well as an upper one: a deadline built from `interval_ms`, or from any
+        // constant smaller than the timeout, passes an upper bound alone (glass#284).
         assert!(
-            left <= std::time::Duration::from_millis(5_000),
-            "a deadline past the wait's own timeout bounds nothing: {left:?}"
+            left > std::time::Duration::from_millis(200),
+            "the second read's bound is not the wait's 400ms timeout: {left:?}"
         );
         assert!(
-            !left.is_zero(),
-            "the reader was handed a deadline already spent"
+            left <= std::time::Duration::from_millis(400),
+            "a deadline past the wait's own timeout bounds nothing: {left:?}"
+        );
+    }
+
+    /// A wait that read the tree and did not find the element answers `{matched:false}`, which is
+    /// what `glass_wait_for_element`'s schema and the tool description promise.
+    ///
+    /// The poll loop checks its budget *after* a tick, so the last read always starts at the
+    /// deadline and a reader honouring it always gives up there.
+    #[test]
+    fn a_wait_that_read_the_tree_reports_no_match_even_when_its_last_read_ran_out_of_time() {
+        let (mut g, seen) = glass_with_a11y_until_deadline(FakePlatform::new(100, 100));
+        g.start(&spec()).unwrap();
+        let o = g
+            .wait_for_element(&WaitElementParams {
+                name: Some("Ghost".into()), // never in the tree
+                role: None,
+                value_contains: None,
+                condition: ElementCondition::Appears,
+                interval_ms: 10,
+                timeout_ms: 120,
+            })
+            .expect("a wait that read the UI reports the element absent, it does not fail");
+
+        assert!(!o.matched);
+        assert!(
+            seen.lock().unwrap().len() > 1,
+            "the wait answered from one read, so it never reached the read that runs out of time"
+        );
+    }
+
+    /// A wait looks once however little time it was given: `poll_until_with_pause` guarantees one
+    /// tick, and `timeout_ms: 0` means "check now" — answering for a device nobody consulted is
+    /// the one outcome worse than answering late.
+    #[test]
+    fn a_wait_looks_once_however_little_time_it_was_given() {
+        let (mut g, seen) = glass_with_a11y_until_deadline(FakePlatform::new(100, 100));
+        g.start(&spec()).unwrap();
+        let o = g
+            .wait_for_element(&WaitElementParams {
+                name: Some("Save".into()),
+                role: Some(AxRole::Button),
+                value_contains: None,
+                condition: ElementCondition::Appears,
+                interval_ms: 0,
+                timeout_ms: 0,
+            })
+            .expect("a wait given no time still looks once");
+
+        assert!(o.matched, "the element is in the very first tree read");
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(
+            seen[0], None,
+            "the one look a wait is guaranteed was handed a bound it could not meet"
+        );
+    }
+
+    /// The sweep has a `timeout_ms` of its own and still leaves the reader unbounded, because its
+    /// read propagates with `?` — a reader giving up at the deadline would turn the soft
+    /// `{matched:false}` a spent sweep promises into an error.
+    ///
+    /// The asymmetry with `wait_for_element` is deliberate and lived only in a comment, one line
+    /// from a `timeout_ms` inviting a contributor to "fix" it.
+    #[test]
+    fn a_scroll_sweep_leaves_the_reader_its_own_budget() {
+        let (mut g, ctx_log) = glass_with_a11y_ctx(FakePlatform::new(100, 100), fake_tree());
+        g.start(&spec()).unwrap();
+        g.scroll_to_element(&ScrollToElementParams {
+            name: Some("Ghost".into()),
+            role: None,
+            value_contains: None,
+            direction: Some(ScrollDirection::Down),
+            anchor: None,
+            step: SCROLL_TO_DEFAULT_STEP,
+            timeout_ms: 20_000,
+        })
+        .unwrap();
+
+        assert_eq!(
+            ctx_log
+                .lock()
+                .unwrap()
+                .as_ref()
+                .expect("the sweep read the tree")
+                .deadline,
+            AxDeadline::UNBOUNDED,
         );
     }
 

--- a/crates/glass-core/src/session/wait.rs
+++ b/crates/glass-core/src/session/wait.rs
@@ -385,17 +385,20 @@ impl Glass {
     pub fn wait_for_element(&mut self, params: &WaitElementParams) -> Result<WaitElementOutcome> {
         self.require_active()?; // fail fast; a11y_snapshot rechecks inside the loop
         let started = std::time::Instant::now();
+        // Every read this wait makes carries when the wait stops: the tick is synchronous, so the
+        // loop cannot take back a read a reader has started (glass#338).
+        let deadline = AxDeadline::in_ms(params.timeout_ms);
         // Before the first walk, not after: a change landing in that gap is announced to nobody,
         // and the wait then burns its whole budget on a condition that already holds.
         //
         // An interval of 0 means "re-read as fast as you can", which never pauses — so there is
         // nothing for a signal to save, and subscribing would only cost a round-trip.
         let mut signal = (params.interval_ms > 0)
-            .then(|| self.subscribe_a11y_changes())
+            .then(|| self.subscribe_a11y_changes(deadline))
             .flatten();
         // Subscribing spends the caller's budget, so the poll loop gets what is left. That
-        // bounds the polling, not the call: a reader bounds its own handshake in seconds, so a
-        // wait told to give up after 500ms can return later than that.
+        // bounds the polling, not the call: a reader that does not honour `deadline` bounds its
+        // own handshake in seconds, so a wait told to give up after 500ms can return later.
         let remaining = params
             .timeout_ms
             .saturating_sub(started.elapsed().as_millis() as u64);
@@ -433,7 +436,7 @@ impl Glass {
             },
             || {
                 // fresh snapshot; assigns ids, caches, pumps
-                let tree = match self.a11y_resnapshot() {
+                let tree = match self.a11y_resnapshot(deadline) {
                     Ok(t) => t,
                     // Kept so a spent budget can report this instead of "not found" (glass#329).
                     Err(e @ GlassError::AccessibilityNotReady(_)) => {
@@ -597,7 +600,10 @@ impl Glass {
         &mut self,
         params: &ScrollToElementParams,
     ) -> Result<(Option<ElementInfo>, String)> {
-        let tree = self.a11y_resnapshot()?;
+        // No deadline, though the sweep has a `timeout_ms`: this read propagates its error with
+        // `?`, so a reader giving up at the deadline would turn the sweep's soft `{matched:false}`
+        // into an error.
+        let tree = self.a11y_resnapshot(AxDeadline::NONE)?;
         let found = match element_match(
             &tree,
             params.name.as_deref(),
@@ -1219,6 +1225,42 @@ mod tests {
         let e = o.element.expect("matched element");
         assert_eq!(e.id, AxNodeId(1));
         assert_eq!(e.name.as_deref(), Some("Save"));
+    }
+
+    /// glass#338: on Android a `uiautomator dump` spending its own 20s budget answered a 10s
+    /// wait, because `poll_until_with_pause` ticks synchronously and only the reader can stop one
+    /// read early.
+    #[test]
+    fn a_wait_tells_the_reader_when_it_stops_waiting() {
+        let (mut g, ctx_log) =
+            glass_with_a11y_ctx(FakePlatform::new(100, 100), fake_tree_enabled());
+        g.start(&spec()).unwrap();
+        g.wait_for_element(&WaitElementParams {
+            name: Some("Save".into()),
+            role: Some(AxRole::Button),
+            value_contains: None,
+            condition: ElementCondition::Enabled,
+            interval_ms: 0,
+            timeout_ms: 5_000,
+        })
+        .unwrap();
+
+        let left = ctx_log
+            .lock()
+            .unwrap()
+            .as_ref()
+            .expect("the reader was called")
+            .deadline
+            .remaining()
+            .expect("the wait named the instant it stops waiting at");
+        assert!(
+            left <= std::time::Duration::from_millis(5_000),
+            "a deadline past the wait's own timeout bounds nothing: {left:?}"
+        );
+        assert!(
+            !left.is_zero(),
+            "the reader was handed a deadline already spent"
+        );
     }
 
     #[test]

--- a/crates/glass-ios/tests/drive_integration.rs
+++ b/crates/glass-ios/tests/drive_integration.rs
@@ -30,7 +30,9 @@
 
 use std::time::Duration;
 
-use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTarget, AxTree, WalkLimits};
+use glass_core::accessibility::{
+    Accessibility, AxContext, AxDeadline, AxNode, AxTarget, AxTree, WalkLimits,
+};
 use glass_core::{AppSpec, KeyEvent, MouseButton, Platform, PointerEvent, SandboxLevel};
 use glass_ios::{IosA11y, IosPlatform, SimulatorRegistry};
 
@@ -134,6 +136,7 @@ fn drive_fixture_snapshot_tap_and_type_end_to_end() {
         window_handle: None,
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
+        deadline: AxDeadline::NONE,
     };
 
     // 1) Snapshot: the fixture's elements must appear, and the status starts at READY. The

--- a/crates/glass-ios/tests/drive_integration.rs
+++ b/crates/glass-ios/tests/drive_integration.rs
@@ -136,7 +136,7 @@ fn drive_fixture_snapshot_tap_and_type_end_to_end() {
         window_handle: None,
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
-        deadline: AxDeadline::NONE,
+        deadline: AxDeadline::UNBOUNDED,
     };
 
     // 1) Snapshot: the fixture's elements must appear, and the status starts at READY. The

--- a/crates/glass-ios/tests/launch_args_integration.rs
+++ b/crates/glass-ios/tests/launch_args_integration.rs
@@ -73,7 +73,7 @@ fn screen_of(spec: &AppSpec) -> AxTree {
         window_handle: None,
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
-        deadline: AxDeadline::NONE,
+        deadline: AxDeadline::UNBOUNDED,
     };
     // UIKit keeps building the hierarchy for a beat after the app is up, so a tree read straight
     // after `start_app` can be half-drawn — which would fail here as "the argument did not

--- a/crates/glass-ios/tests/launch_args_integration.rs
+++ b/crates/glass-ios/tests/launch_args_integration.rs
@@ -22,7 +22,7 @@
 
 #![cfg(unix)]
 
-use glass_core::accessibility::{Accessibility, AxContext, AxNode, AxTree, WalkLimits};
+use glass_core::accessibility::{Accessibility, AxContext, AxDeadline, AxNode, AxTree, WalkLimits};
 use glass_core::{AppSpec, Platform, SandboxLevel};
 use glass_ios::{IosPlatform, SimulatorRegistry};
 
@@ -73,6 +73,7 @@ fn screen_of(spec: &AppSpec) -> AxTree {
         window_handle: None,
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
+        deadline: AxDeadline::NONE,
     };
     // UIKit keeps building the hierarchy for a beat after the app is up, so a tree read straight
     // after `start_app` can be half-drawn — which would fail here as "the argument did not

--- a/crates/glass-ios/tests/role_probe.rs
+++ b/crates/glass-ios/tests/role_probe.rs
@@ -30,7 +30,7 @@
 use std::time::Duration;
 
 use glass_core::Accessibility; // the trait must be in scope to call `snapshot` on the boxed reader
-use glass_core::accessibility::{AxContext, WalkLimits};
+use glass_core::accessibility::{AxContext, AxDeadline, WalkLimits};
 use glass_core::{
     AppSpec, AxRole, AxTree, DescriptionSourcing, Platform, SandboxLevel,
     description_census_report, role_histogram,
@@ -225,6 +225,7 @@ fn role_histogram_probe() {
             // The node cap lifted, so a big app's tree is never truncated mid-probe. Depth
             // and per-level sibling rails keep their generous structural defaults regardless.
             limits: WalkLimits::from_max_nodes(Some(0)),
+            deadline: AxDeadline::NONE,
         };
         let mut tree = a11y
             .snapshot(&ctx)

--- a/crates/glass-ios/tests/role_probe.rs
+++ b/crates/glass-ios/tests/role_probe.rs
@@ -225,7 +225,7 @@ fn role_histogram_probe() {
             // The node cap lifted, so a big app's tree is never truncated mid-probe. Depth
             // and per-level sibling rails keep their generous structural defaults regardless.
             limits: WalkLimits::from_max_nodes(Some(0)),
-            deadline: AxDeadline::NONE,
+            deadline: AxDeadline::UNBOUNDED,
         };
         let mut tree = a11y
             .snapshot(&ctx)

--- a/crates/glass-macos/tests/a11y.rs
+++ b/crates/glass-macos/tests/a11y.rs
@@ -61,8 +61,8 @@ mod macos_main {
 
     use glass_core::platform::{MouseButton, PointerEvent};
     use glass_core::{
-        Accessibility, AppSpec, AxContext, AxNode, AxRole, AxTarget, GlassError, Platform,
-        SandboxLevel, Stream, WalkLimits,
+        Accessibility, AppSpec, AxContext, AxDeadline, AxNode, AxRole, AxTarget, GlassError,
+        Platform, SandboxLevel, Stream, WalkLimits,
     };
     use glass_macos::MacosPlatform;
 
@@ -219,6 +219,7 @@ mod macos_main {
             window_handle: None,
             a11y_bus_addr: None,
             limits: WalkLimits::DEFAULT,
+            deadline: AxDeadline::NONE,
         };
 
         let mut a11y = glass_a11y_macos::MacosA11y::new();

--- a/crates/glass-macos/tests/a11y.rs
+++ b/crates/glass-macos/tests/a11y.rs
@@ -219,7 +219,7 @@ mod macos_main {
             window_handle: None,
             a11y_bus_addr: None,
             limits: WalkLimits::DEFAULT,
-            deadline: AxDeadline::NONE,
+            deadline: AxDeadline::UNBOUNDED,
         };
 
         let mut a11y = glass_a11y_macos::MacosA11y::new();

--- a/crates/glass-macos/tests/bundle_launch.rs
+++ b/crates/glass-macos/tests/bundle_launch.rs
@@ -68,7 +68,8 @@ mod macos_main {
     use glass_a11y_macos::MacosA11y;
     use glass_core::platform::{MouseButton, PointerEvent};
     use glass_core::{
-        Accessibility, AppSpec, AxContext, GlassError, Platform, SandboxLevel, Stream, WalkLimits,
+        Accessibility, AppSpec, AxContext, AxDeadline, GlassError, Platform, SandboxLevel, Stream,
+        WalkLimits,
     };
     use glass_macos::MacosPlatform;
 
@@ -392,6 +393,7 @@ mod macos_main {
                 window_handle: None,
                 a11y_bus_addr: None,
                 limits: WalkLimits::DEFAULT,
+                deadline: AxDeadline::NONE,
             };
             let mut a11y = MacosA11y::new();
             let mut tree = try_expect(a11y.snapshot(&ctx), "a11y snapshot(TextEdit)")?;

--- a/crates/glass-macos/tests/bundle_launch.rs
+++ b/crates/glass-macos/tests/bundle_launch.rs
@@ -393,7 +393,7 @@ mod macos_main {
                 window_handle: None,
                 a11y_bus_addr: None,
                 limits: WalkLimits::DEFAULT,
-                deadline: AxDeadline::NONE,
+                deadline: AxDeadline::UNBOUNDED,
             };
             let mut a11y = MacosA11y::new();
             let mut tree = try_expect(a11y.snapshot(&ctx), "a11y snapshot(TextEdit)")?;

--- a/crates/glass-macos/tests/role_probe.rs
+++ b/crates/glass-macos/tests/role_probe.rs
@@ -43,8 +43,9 @@ mod macos_main {
 
     use glass_a11y_macos::MacosA11y;
     use glass_core::{
-        Accessibility, AppSpec, AxContext, AxRole, AxTree, DescriptionSourcing, Platform,
-        SandboxLevel, WalkLimits, description_census, description_census_report, role_histogram,
+        Accessibility, AppSpec, AxContext, AxDeadline, AxRole, AxTree, DescriptionSourcing,
+        Platform, SandboxLevel, WalkLimits, description_census, description_census_report,
+        role_histogram,
     };
     use glass_macos::MacosPlatform;
 
@@ -253,6 +254,7 @@ mod macos_main {
                 window_handle: None,
                 a11y_bus_addr: None,
                 limits: WalkLimits::from_max_nodes(Some(0)),
+                deadline: AxDeadline::NONE,
             };
             let mut a11y = MacosA11y::new();
             let mut tree = a11y

--- a/crates/glass-macos/tests/role_probe.rs
+++ b/crates/glass-macos/tests/role_probe.rs
@@ -254,7 +254,7 @@ mod macos_main {
                 window_handle: None,
                 a11y_bus_addr: None,
                 limits: WalkLimits::from_max_nodes(Some(0)),
-                deadline: AxDeadline::NONE,
+                deadline: AxDeadline::UNBOUNDED,
             };
             let mut a11y = MacosA11y::new();
             let mut tree = a11y

--- a/crates/glass-macos/tests/window_adopt_probe.rs
+++ b/crates/glass-macos/tests/window_adopt_probe.rs
@@ -298,7 +298,7 @@ mod macos_main {
                 // Only Ok/Err is read below, and that outcome turns on root window resolution,
                 // not tree size — cap at 1 node instead of paying for the full tree.
                 limits: WalkLimits::from_max_nodes(Some(1)),
-                deadline: AxDeadline::NONE,
+                deadline: AxDeadline::UNBOUNDED,
             };
             let snapshot_ok = match MacosA11y::new().snapshot(&ctx) {
                 Ok(_) => {

--- a/crates/glass-macos/tests/window_adopt_probe.rs
+++ b/crates/glass-macos/tests/window_adopt_probe.rs
@@ -57,8 +57,8 @@ mod macos_main {
 
     use glass_a11y_macos::MacosA11y;
     use glass_core::{
-        Accessibility, AppSpec, AxContext, Platform, SandboxLevel, WalkLimits, WindowGeometry,
-        WindowInfo, WindowOp,
+        Accessibility, AppSpec, AxContext, AxDeadline, Platform, SandboxLevel, WalkLimits,
+        WindowGeometry, WindowInfo, WindowOp,
     };
     use glass_macos::MacosPlatform;
 
@@ -298,6 +298,7 @@ mod macos_main {
                 // Only Ok/Err is read below, and that outcome turns on root window resolution,
                 // not tree size — cap at 1 node instead of paying for the full tree.
                 limits: WalkLimits::from_max_nodes(Some(1)),
+                deadline: AxDeadline::NONE,
             };
             let snapshot_ok = match MacosA11y::new().snapshot(&ctx) {
                 Ok(_) => {

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -386,7 +386,9 @@ fn resolve_return(
             let _ = glass.wait_stable(&settle_params());
             // Reuse the session's current limits so a fold after a raised/unbounded snapshot
             // isn't silently re-truncated to the default cap.
-            let tree = glass.a11y_resnapshot().map_err(|e| e.to_string())?;
+            let tree = glass
+                .a11y_resnapshot(glass_core::AxDeadline::NONE)
+                .map_err(|e| e.to_string())?;
             // Same shape as `a11y_snapshot`: the app-derived outline stays untrusted-wrapped;
             // glass's own steers are separate trusted blocks, not baked into that body.
             let mut extra = vec![OutContent::Text(crate::untrusted::wrap_untrusted(

--- a/crates/glass-mcp/src/tools.rs
+++ b/crates/glass-mcp/src/tools.rs
@@ -387,7 +387,7 @@ fn resolve_return(
             // Reuse the session's current limits so a fold after a raised/unbounded snapshot
             // isn't silently re-truncated to the default cap.
             let tree = glass
-                .a11y_resnapshot(glass_core::AxDeadline::NONE)
+                .a11y_resnapshot(glass_core::AxDeadline::UNBOUNDED)
                 .map_err(|e| e.to_string())?;
             // Same shape as `a11y_snapshot`: the app-derived outline stays untrusted-wrapped;
             // glass's own steers are separate trusted blocks, not baked into that body.

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -14,10 +14,10 @@ use std::time::{Duration, Instant};
 
 use glass_a11y_windows::WindowsA11y;
 use glass_core::{
-    Accessibility, AppSpec, AxContext, AxNode, AxRole, AxTarget, AxTree, Backend, BaselineStore,
-    ChangeSignal, DescriptionSourcing, Glass, GlassError, KeyEvent, Modifier, MouseButton,
-    Platform, PlatformFactory, PointerEvent, WalkLimits, WindowGeometry, WindowHint, WindowOp,
-    description_census, description_census_report, role_histogram,
+    Accessibility, AppSpec, AxContext, AxDeadline, AxNode, AxRole, AxTarget, AxTree, Backend,
+    BaselineStore, ChangeSignal, DescriptionSourcing, Glass, GlassError, KeyEvent, Modifier,
+    MouseButton, Platform, PlatformFactory, PointerEvent, WalkLimits, WindowGeometry, WindowHint,
+    WindowOp, description_census, description_census_report, role_histogram,
 };
 use glass_windows::WindowsPlatform;
 
@@ -640,6 +640,7 @@ fn onbox_modifier_click() {
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
+        deadline: AxDeadline::NONE,
     };
     let tree = a11y.snapshot(&ctx).expect("a11y snapshot");
     let mut hit = None;
@@ -761,6 +762,7 @@ fn onbox_a11y_set_value() {
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
+        deadline: AxDeadline::NONE,
     };
     let tree = a11y.snapshot(&ctx).expect("a11y snapshot");
 
@@ -829,6 +831,7 @@ fn onbox_egui_set_value_honesty() {
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
+        deadline: AxDeadline::NONE,
     };
     let tree = a11y
         .snapshot(&ctx)
@@ -1012,6 +1015,7 @@ fn onbox_a11y_edge_multiprocess() {
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
+        deadline: AxDeadline::NONE,
     };
     let tree = a11y
         .snapshot(&ctx)
@@ -1276,6 +1280,7 @@ fn probe_role_histogram(label: &str, spec: &AppSpec, report: &mut String) -> Pro
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
         limits: WalkLimits::from_max_nodes(Some(0)),
+        deadline: AxDeadline::NONE,
     };
     let tree = a11y
         .snapshot(&ctx)
@@ -1448,6 +1453,7 @@ fn onbox_a11y_subscription_reports_a_real_change() {
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
+        deadline: AxDeadline::NONE,
     };
 
     // Before the first read, as the seam requires: a change landing between a read and the
@@ -1509,6 +1515,7 @@ fn onbox_a11y_subscription_is_quiet_on_an_idle_app() {
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
+        deadline: AxDeadline::NONE,
     };
     let mut signal = a11y
         .subscribe_changes(&ctx)
@@ -1861,6 +1868,7 @@ fn independent_ctx(handle: i64) -> AxContext {
         window_handle: Some(handle),
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
+        deadline: AxDeadline::NONE,
     }
 }
 

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -640,7 +640,7 @@ fn onbox_modifier_click() {
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
-        deadline: AxDeadline::NONE,
+        deadline: AxDeadline::UNBOUNDED,
     };
     let tree = a11y.snapshot(&ctx).expect("a11y snapshot");
     let mut hit = None;
@@ -762,7 +762,7 @@ fn onbox_a11y_set_value() {
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
-        deadline: AxDeadline::NONE,
+        deadline: AxDeadline::UNBOUNDED,
     };
     let tree = a11y.snapshot(&ctx).expect("a11y snapshot");
 
@@ -831,7 +831,7 @@ fn onbox_egui_set_value_honesty() {
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
-        deadline: AxDeadline::NONE,
+        deadline: AxDeadline::UNBOUNDED,
     };
     let tree = a11y
         .snapshot(&ctx)
@@ -1015,7 +1015,7 @@ fn onbox_a11y_edge_multiprocess() {
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
-        deadline: AxDeadline::NONE,
+        deadline: AxDeadline::UNBOUNDED,
     };
     let tree = a11y
         .snapshot(&ctx)
@@ -1280,7 +1280,7 @@ fn probe_role_histogram(label: &str, spec: &AppSpec, report: &mut String) -> Pro
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
         limits: WalkLimits::from_max_nodes(Some(0)),
-        deadline: AxDeadline::NONE,
+        deadline: AxDeadline::UNBOUNDED,
     };
     let tree = a11y
         .snapshot(&ctx)
@@ -1453,7 +1453,7 @@ fn onbox_a11y_subscription_reports_a_real_change() {
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
-        deadline: AxDeadline::NONE,
+        deadline: AxDeadline::UNBOUNDED,
     };
 
     // Before the first read, as the seam requires: a change landing between a read and the
@@ -1515,7 +1515,7 @@ fn onbox_a11y_subscription_is_quiet_on_an_idle_app() {
         window_handle: p.active_window_handle(),
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
-        deadline: AxDeadline::NONE,
+        deadline: AxDeadline::UNBOUNDED,
     };
     let mut signal = a11y
         .subscribe_changes(&ctx)
@@ -1868,7 +1868,7 @@ fn independent_ctx(handle: i64) -> AxContext {
         window_handle: Some(handle),
         a11y_bus_addr: None,
         limits: WalkLimits::DEFAULT,
-        deadline: AxDeadline::NONE,
+        deadline: AxDeadline::UNBOUNDED,
     }
 }
 


### PR DESCRIPTION
Does the separate change #346 called for, and closes the gap its "what this deliberately does not
change" section named.

A `glass_wait_for_element` re-reads the tree from a synchronous poll tick, so nothing outside the
reader can stop a read once it has started. Every reader therefore spent a flat budget of its own —
20s per `uiautomator dump` on Android, 10s per snapshot on Linux and Windows — which the wait had no
way to interrupt.

## The seam

`AxContext` gains a `deadline`: the time bound of a call, as `limits` is its size bound.
`wait_for_element` sets it from its `timeout_ms`. A tool that takes no timeout passes
`AxDeadline::UNBOUNDED`, which leaves the reader its own budget — the *widest* value, as
`WalkLimits`' unbounded is, not a deadline of zero.

The obligation lives on `Accessibility::snapshot`, where an implementer meets it, and says plainly
which readers honour it: Android (both readers), Linux and Windows do; macOS and iOS still spend
their own budgets.

The **first** read of a wait deliberately carries no deadline. `poll_until_with_pause` guarantees
one tick, so a wait must look once — otherwise `timeout_ms: 0` ("check now") errors against a
healthy app nobody consulted.

`scroll_to_element` passes `UNBOUNDED` despite having a `timeout_ms`: its read propagates with `?`,
so a reader giving up at the deadline would turn the sweep's soft `{matched:false}` into an error.
That asymmetry now has a test, not just a comment.

## The soft timeout a deadline-honouring reader would have broken

`wait_for_element` surfaced its stashed "no tree" reason whenever nothing matched, not only when no
read ever produced one — though its own comment claimed the latter. A reader honouring the deadline
gives up on the tick that ends the wait *by construction*, so every unmatched wait would have become
an error and the `{matched:false}` the schema and tool description promise would have been
unreachable.

A wait now reports that reason only when it never saw a tree. This also fixes the same latent case
on Linux, where an app slow to publish its tree poisoned a wait that afterwards read fine.

## What the readers do with it

Each attempt is capped by whichever of the caller's deadline and the reader's own ceiling falls
first; no read starts once the caller has gone; and a read the *caller's* deadline cut short reports
`AccessibilityNotReady` — the variant `wait_for_element` polls through — carrying the abandoned
attempt's own error, because a wedged adb reaches that arm too and its message is the only place
glass names the `adb kill-server` remedy.

Which bound governed is settled before the attempt via `AxDeadline::governs`, whose tie deliberately
favours the reader's own ceiling: calling a backend that hung for exactly its budget "a spent caller
budget" would hide the hang.

Knowing the deadline is also what lets a warmed Android reader retry at all — it had exactly one
attempt because a second could cost a wait another whole dump budget past its timeout.

Two consequences worth calling out:

- The dump-file removal gets its own floor rather than the attempt's possibly-spent deadline. The
  device writes the file whether or not anyone waits for it and nothing sweeps `/sdcard`, so every
  abandoned attempt stranded one.
- The on-device companion reader honours it too. The platform *prefers* that reader when the
  companion is installed, and its 30s socket plus reconnect-and-resend could outlast a wait twice
  over, so leaving it out would have made the fix inert on the recommended Android setup.

## Verification

Every mechanism was deleted in turn and killed exactly one test, with no crosstalk. Both directions
are pinned throughout: a reader that caps every step at *nothing* fails too, and a caller that named
no deadline keeps its full budget.

On a booted AVD: `a11y_loop` 6/6, including a new device test that a read told to finish in 50ms
stops there instead of spending the 20s budget — and the device is left with **zero** stranded dump
files, where the pre-fix code left one per abandoned attempt. AT-SPI suite 29/29 for the Linux
reader.

`cargo fmt --check`, clippy `-D warnings` and the workspace tests on Linux; clippy `-D warnings` for
`x86_64-pc-windows-gnu` (`--all-targets`) and `x86_64-apple-darwin` (workspace `--lib`, plus
`--all-targets` for `glass-macos` and `glass-ios`).

## Deliberately not here

- #348 — the Android reader classifies deadline failures by matching error prose. `bounded.rs` is
  shared with every non-a11y adb call, so changing what its errors carry is wider than this seam.
- #338 row 1 (`set_value`'s pre-write snapshot) carries no caller deadline, so this does not reach
  it; row 2 still has no capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
