### PR TITLE
ci(android): wait for the device to settle before the suite starts

### DIFF
--- a/scripts/ci-android-suite.sh
+++ b/scripts/ci-android-suite.sh
@@ -54,6 +54,52 @@ logcat_pid=$!
 # teardown rather than this kill.
 trap 'kill "$logcat_pid" 2>/dev/null' EXIT
 
+# `boot_completed` is not readiness: the action restores a cached AVD snapshot and reports boot
+# the moment the property flips, while package scans and GMS's Phenotype config commits keep
+# force-stopping apps for another ~15s — including `com.google.android.settings.intelligence`,
+# which the search-screen tests drive. Starting there made the leg red ~25% of runs (glass#331).
+#
+# The signal is this file's own growth rate, so it costs no adb call and needs no message to be
+# matched. Measured on an idle API 34 AVD from `boot_completed`, lines per 5s:
+#
+#   +0s 4561   +5s 5127   +10s 1132   +15s 787   +20s 229   +25s 14   +30s 50 …
+#
+# No window before +25s is under 100 and the first that is falls 16x, so the threshold sits in a
+# wide gap rather than on a slope. Two consecutive quiet windows, because GMS goes on producing
+# bursts (+60s, +100s, +150s here).
+#
+# It never fails the run: a device that stays busy is a slow one, and the suite is what decides
+# that. Both outcomes are logged, or a gate that stopped waiting would read like one that worked.
+settle_window=5
+settle_quiet=100
+settle_needed=2
+settle_budget=120
+
+settled=0
+quiet=0
+waited=0
+while [ "$waited" -lt "$settle_budget" ]; do
+  before=$(wc -l < diagnostics/logcat.txt 2>/dev/null || echo 0)
+  sleep "$settle_window"
+  waited=$((waited + settle_window))
+  grew=$(( $(wc -l < diagnostics/logcat.txt 2>/dev/null || echo 0) - before ))
+  if [ "$grew" -lt "$settle_quiet" ]; then
+    quiet=$((quiet + 1))
+    if [ "$quiet" -ge "$settle_needed" ]; then
+      settled=1
+      break
+    fi
+  else
+    quiet=0
+  fi
+done
+if [ "$settled" -eq 1 ]; then
+  echo "ci-android-suite: device settled after ${waited}s (last window ${grew} lines)"
+else
+  echo "ci-android-suite: device still busy after ${settle_budget}s (last window ${grew} lines); \
+running the suite anyway" >&2
+fi
+
 ./scripts/test-android.sh "$@" 2>&1 | tee diagnostics/test-output.txt
 rc=${PIPESTATUS[0]}
 


### PR DESCRIPTION
Closes #331, taking that issue's option (1) — a readiness gate — rather than (2), raising
`SETUP_BUDGET`, which targets one symptom.

## The evidence

`boot_completed` is not readiness. The action restores a cached AVD snapshot and reports boot the
moment the property flips; the suite then launched Settings **344 ms later**, while package scans
and GMS's Phenotype config commits were still force-stopping apps. From a failing run's logcat:

```
21:15:39.425  BOOT_COMPLETED posted
21:15:39.769  the suite launches Settings
21:15:52.072  Killing …settings.intelligence (adj 0): change <pkg>
21:15:52.078  Force removing ActivityRecord{SearchActivity}: app died, no saved state
```

`com.google.android.settings.intelligence` is the package the search-screen tests drive, which is
why `set_value_reports_whether_the_write_landed` was the recurring failure.

## The signal, chosen from measurement

The issue asked for "a real readiness signal chosen from evidence, not a fixed sleep". The gate
waits on the **logcat file's own growth rate** — already being written, so it costs no adb call and
does not depend on any message being matched (cf. #348).

Measured on an idle API 34 AVD from `boot_completed`, lines per 5 s:

```
+0s 4561   +5s 5127   +10s 1132   +15s 787   +20s 229   +25s 14   +30s 50
```

No window before +25 s is under 100, and the first that is falls **16×**. The threshold sits in a
wide gap rather than on a slope. Two consecutive quiet windows are required, because GMS keeps
producing bursts (+60 s, +100 s, +150 s) and one lull is not the end of it.

It never fails the run: a device that stays busy is a slow one, and the suite is what decides that.
Both outcomes are logged, so a gate that stopped waiting cannot read like one that worked.

## Verification

On this box against a cold-booted AVD, all three paths:

| path | result |
|---|---|
| from `boot_completed` | waits — 30 s and 35 s on two boots |
| already-settled device | passes at the 10 s floor (two windows) |
| threshold forced unreachable | gives up at its budget and runs the suite anyway |

The a11y suite is 6/6 through the gate. (Three other tests fail locally on `NotPresent` for
`GLASS_ANDROID_FIXTURE_APK`/`GLASS_ANDROID_AGENT_JAR`, which CI supplies.)

## What this does not do

It does not stop the churn. A **second** wave arrives ~60 s in, and it is self-inflicted: the
suite's own companion install writes `secure/accessibility_enabled`, which GMS answers with a fresh
round of config commits. That lands mid-suite, where a gate cannot help — the tests' own retries
are what cover it (#349, and `SETUP_BUDGET`).

Local cold boot is also not identical to CI's snapshot restore; the shape should hold and the
threshold has 16× of headroom, but the rate itself may differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
