### PR TITLE
ci(android): size the settle budget from CI, not from the dev box

### DIFF
--- a/scripts/ci-android-suite.sh
+++ b/scripts/ci-android-suite.sh
@@ -68,12 +68,20 @@ trap 'kill "$logcat_pid" 2>/dev/null' EXIT
 # wide gap rather than on a slope. Two consecutive quiet windows, because GMS goes on producing
 # bursts (+60s, +100s, +150s here).
 #
+# The budget is a CEILING, not a wait: a device that settles in 30s pays 30s whatever it is set to,
+# so it is sized for "this device is broken" rather than "this device is slow". Ten reruns of the
+# same CI job settled at 85 90 90 95 95 95 95 105 105 110s, which is 71-92% of the 120s this
+# replaces — one slow run from giving up and starting the suite anyway.
+#
+# Do NOT re-size this from a local run: the same measurement on this project's dev box was 25-30s,
+# 3-4x faster than the CI snapshot restore it has to cover.
+#
 # It never fails the run: a device that stays busy is a slow one, and the suite is what decides
 # that. Both outcomes are logged, or a gate that stopped waiting would read like one that worked.
 settle_window=5
 settle_quiet=100
 settle_needed=2
-settle_budget=120
+settle_budget=300
 
 settled=0
 quiet=0


### PR DESCRIPTION
Follow-up to #351, from its first real CI data.

The gate works: ten reruns of the same job all green, all settling before their budget. But the
settle times say the budget is too tight.

```
85  90  90  95  95  95  95  105  105  110      (median 95, max 110)
```

That is **71–92% of the 120s budget**, with the whole distribution inside it. The tail of a
ten-sample distribution is not its maximum, so a slightly slower device exhausts the budget, logs
`still busy`, and starts the suite anyway — back to what #331 recorded, with one log line as the
only sign it happened.

## Why the number was wrong

I sized it from this dev box, where the same measurement is 25–30s. CI's snapshot restore is 3–4×
slower than a local cold boot, so that was the wrong population — and I said as much in #351's
"local cold boot is not identical to CI's snapshot restore", without acting on it.

The comment now carries the CI distribution and a note not to re-measure locally, because the
obvious reaction to a 300s budget is to time it on a laptop and shrink it back.

## Why 300s costs nothing

The budget is a **ceiling, not a wait**. A device that settles in 95s pays 95s whatever the budget
is; the budget only bounds the pathological case. 300s is ~2.7× the observed maximum and 11% of the
job's own 45-minute timeout.

## On the ten green runs

Worth stating plainly, since it is the headline: #331's baseline was **2 of 8** dispatch runs of one
commit failing. This is **0 of 10** attempts of one commit. Like-for-like in design.

By counts alone that is not conclusive — Fisher's exact on 2/8 vs 0/10 is p≈0.08 one-tailed, and the
rule of three puts the 95% upper bound on the new rate at ~30%. What carries the result is the
mechanism evidence behind each fix (#344, #345, #346, #347, #349, #350, #351), each with a measured
cause and a test that dies without it. The ten runs corroborate that; they do not replace it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
