### PR TITLE
fix(android): classify tool failures by their kind, not by their wording

### DIFF
--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -186,11 +186,9 @@ pub(crate) fn dump_once(run: &mut AdbRunner<'_>, prefix: &str, deadline: Instant
 /// explanation for it — and that substitution is retryable, so the loop would go on retrying a
 /// device that had answered.
 ///
-/// Says only *that* a bound fired, not which *deadline* governed — the caller's or the attempt's
-/// own, which [`dump_until_ready`] settles before the attempt rather than reading back out of the
-/// error. Read off the bound's own signal rather than the message, which `Adb::exit_error`
-/// composes partly from the device's output — the device could otherwise answer for glass's
-/// deadline (glass#348).
+/// Says only *that* a bound fired, not which deadline governed — [`dump_until_ready`] settles
+/// that before the attempt. Read off the bound's signal rather than the message, which
+/// `Adb::exit_error` composes partly from the device's output (glass#348).
 fn bound_fired(e: &GlassError) -> bool {
     e.bound().is_some()
 }
@@ -1168,8 +1166,8 @@ mod tests {
     /// really raised rather than against a constant both sides share.
     ///
     /// `bound_fired` recognises any [`BoundKind`], so what it can miss is a bound arriving as some
-    /// other variant — which `with_adb_hint` rebuilding a hinted timeout could silently do, and no
-    /// test of either side alone would see.
+    /// other variant — which a wrapper on the way out of `Adb` could silently do, and no test of
+    /// either side alone would see.
     #[test]
     fn every_bound_glass_core_fires_is_one_the_classifier_recognises() {
         for (want, e) in [
@@ -1185,9 +1183,8 @@ mod tests {
     /// ended its sentence — that crash is retried, so reading one as the other retries a deadline
     /// nobody is waiting on any more.
     ///
-    /// The stderr is what makes this bite: `said_before_the_kill` quotes it into the timeout
-    /// message, so the message really does end in `failed:`, which is the whole of the other
-    /// classifier's test.
+    /// The stderr matters: `said_before_the_kill` quotes it into the timeout message, so the
+    /// message really does end in `failed:`.
     #[test]
     #[cfg(unix)]
     fn a_bound_that_fired_is_no_crash_even_when_the_message_ends_as_one() {
@@ -1213,9 +1210,8 @@ mod tests {
     }
 
     /// Text the device wrote is not a bound of glass's own. `Adb::exit_error` interpolates the
-    /// child's stderr verbatim, so a phrase glass *once read* as its own deadline still arrives
-    /// intact — and keyed on the message it was reported as a spent budget, which
-    /// `wait_for_element` polls through rather than surfaces (glass#348).
+    /// child's stderr verbatim, so keyed on the message this was reported as a spent budget —
+    /// which `wait_for_element` polls through rather than surfaces (glass#348).
     ///
     /// The stderr below is constructed rather than observed: no device is known to print it, and
     /// nothing stops one.

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -186,9 +186,11 @@ pub(crate) fn dump_once(run: &mut AdbRunner<'_>, prefix: &str, deadline: Instant
 /// explanation for it — and that substitution is retryable, so the loop would go on retrying a
 /// device that had answered.
 ///
-/// Says only *that* a bound fired, not which: which one is settled before the attempt. Read off
-/// the bound's own signal rather than the message, which `Adb::exit_error` composes partly from
-/// the device's output — the device could otherwise answer for glass's deadline (glass#348).
+/// Says only *that* a bound fired, not which *deadline* governed — the caller's or the attempt's
+/// own, which [`dump_until_ready`] settles before the attempt rather than reading back out of the
+/// error. Read off the bound's own signal rather than the message, which `Adb::exit_error`
+/// composes partly from the device's output — the device could otherwise answer for glass's
+/// deadline (glass#348).
 fn bound_fired(e: &GlassError) -> bool {
     e.bound().is_some()
 }
@@ -674,7 +676,7 @@ mod tests {
         dump_until_ready, editable_target, locate_editable_target, locate_for_write,
         snapshot_bound, snapshot_with_runner, verify_write,
     };
-    use crate::adb::{AdbOp, with_adb_hint};
+    use crate::adb::{AdbOp, a_real_timeout_hinted};
     use glass_core::accessibility::{
         AxContext, AxDeadline, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree,
         WalkLimits,
@@ -686,32 +688,6 @@ mod tests {
     /// A deadline no test reaches, for the cases that are not about the bound.
     fn ample() -> Instant {
         Instant::now() + Duration::from_secs(60)
-    }
-
-    /// A timeout as `glass_core` really raises one, hinted as every adb call's is.
-    ///
-    /// Run rather than typed: a fixture that builds the error itself measures the classifier's
-    /// agreement with the fixture, and would stay green through a runner that had stopped raising
-    /// what the classifier reads (glass#348).
-    ///
-    /// `/bin/sh` stands in for adb; `ping` does on Windows, which has no `/bin/sh` and paces one
-    /// echo per second whether or not the transmission succeeds.
-    fn cut_short_by_a_bound() -> GlassError {
-        #[cfg(unix)]
-        let mut hang = std::process::Command::new("/bin/sh");
-        #[cfg(unix)]
-        hang.args(["-c", "sleep 30"]);
-        #[cfg(windows)]
-        let mut hang = std::process::Command::new("ping");
-        #[cfg(windows)]
-        hang.args(["-n", "31", "127.0.0.1"]);
-
-        let e = glass_core::run_bounded(&mut hang, Duration::from_millis(200), "adb:shell")
-            .expect_err("must time out");
-        // A spawn failure is also an `Err`, and would sail through as a device error nobody
-        // classified.
-        assert_eq!(e.bound(), Some(BoundKind::TimedOut), "{e}");
-        with_adb_hint(e)
     }
 
     /// A spent-deadline error as `glass_core` really raises one. Nothing is spawned on that path,
@@ -1191,22 +1167,55 @@ mod tests {
     /// Both bounds `glass_core` fires are the ones the classifier reads, checked against errors it
     /// really raised rather than against a constant both sides share.
     ///
-    /// The two are otherwise coupled only by convention: nothing stops the runner reporting a
-    /// bound the classifier does not recognise, and no test of either side alone would see it.
+    /// `bound_fired` recognises any [`BoundKind`], so what it can miss is a bound arriving as some
+    /// other variant — which `with_adb_hint` rebuilding a hinted timeout could silently do, and no
+    /// test of either side alone would see.
     #[test]
     fn every_bound_glass_core_fires_is_one_the_classifier_recognises() {
-        for e in [cut_short_by_a_bound(), never_started_for_want_of_time()] {
+        for (want, e) in [
+            (BoundKind::TimedOut, a_real_timeout_hinted()),
+            (BoundKind::NotStarted, never_started_for_want_of_time()),
+        ] {
+            assert_eq!(e.bound(), Some(want), "{e}");
             assert!(bound_fired(&e), "{e}");
-            // A bound firing says nothing about the tool, so it is never the silent crash that
-            // `died_unexplained` names — which is retried, and would retry a spent deadline.
-            assert!(!died_unexplained(&e), "{e}");
         }
     }
 
+    /// A bound that fired is never the silent crash `died_unexplained` names, however the device
+    /// ended its sentence — that crash is retried, so reading one as the other retries a deadline
+    /// nobody is waiting on any more.
+    ///
+    /// The stderr is what makes this bite: `said_before_the_kill` quotes it into the timeout
+    /// message, so the message really does end in `failed:`, which is the whole of the other
+    /// classifier's test.
+    #[test]
+    #[cfg(unix)]
+    fn a_bound_that_fired_is_no_crash_even_when_the_message_ends_as_one() {
+        let mut hang = std::process::Command::new("/bin/sh");
+        hang.args([
+            "-c",
+            "printf '`adb shell uiautomator dump /sdcard/x.xml` failed:' >&2; sleep 30",
+        ]);
+        let e = glass_core::run_bounded(
+            &mut hang,
+            Duration::from_millis(200),
+            "adb:uiautomator dump",
+        )
+        .expect_err("must time out");
+
+        assert_eq!(e.bound(), Some(BoundKind::TimedOut), "{e}");
+        // Without this the test stops discriminating the moment the quoting changes shape.
+        assert!(
+            e.to_string().trim_end().ends_with("failed:"),
+            "the fixture no longer bites: {e}"
+        );
+        assert!(!died_unexplained(&e), "{e}");
+    }
+
     /// Text the device wrote is not a bound of glass's own. `Adb::exit_error` interpolates the
-    /// child's stderr verbatim, so a phrase glass reads as its own deadline reaches the classifier
-    /// intact — and a device reported as a spent budget is one `wait_for_element` polls through
-    /// rather than surfaces.
+    /// child's stderr verbatim, so a phrase glass *once read* as its own deadline still arrives
+    /// intact — and keyed on the message it was reported as a spent budget, which
+    /// `wait_for_element` polls through rather than surfaces (glass#348).
     ///
     /// The stderr below is constructed rather than observed: no device is known to print it, and
     /// nothing stops one.
@@ -1274,7 +1283,7 @@ mod tests {
     #[test]
     fn an_attempt_the_caller_cut_short_reports_the_budget_rather_than_the_device() {
         let timed_out = |_argv: &[&str], _d: Instant| -> Result<(String, String)> {
-            Err(cut_short_by_a_bound())
+            Err(a_real_timeout_hinted())
         };
 
         let mut cut_short = timed_out;
@@ -1355,7 +1364,7 @@ mod tests {
                     dumps += 1;
                     if dumps == 1 {
                         abandoned = Some((*path).to_string());
-                        return Err(cut_short_by_a_bound());
+                        return Err(a_real_timeout_hinted());
                     }
                     files.insert((*path).to_string(), XML.to_string());
                     Ok((DUMPED.to_string(), String::new()))

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -8,8 +8,8 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use glass_core::accessibility::{Accessibility, AxContext, AxDeadline, AxNode, AxTarget, AxTree};
 use glass_core::{
-    GlassError, KeyEvent, MouseButton, NOT_STARTED, PointerEvent, Result, TIMED_OUT,
-    WindowGeometry, typed_clear_landed, typed_text_landed,
+    GlassError, KeyEvent, MouseButton, PointerEvent, Result, WindowGeometry, typed_clear_landed,
+    typed_text_landed,
 };
 
 use crate::adb::{Adb, AdbOp};
@@ -180,15 +180,17 @@ pub(crate) fn dump_once(run: &mut AdbRunner<'_>, prefix: &str, deadline: Instant
     }
 }
 
-/// Whether an error is the attempt's own deadline firing rather than the device answering.
+/// Whether an error is a deadline firing rather than the device answering.
 ///
 /// A read that ran out of its time never reached the device, so the dump's stderr is no
 /// explanation for it — and that substitution is retryable, so the loop would go on retrying a
-/// device that had answered. Matched on the phrases `glass_core` publishes for exactly this, which
-/// is why it says only *that* a bound fired: which one is settled before the attempt.
+/// device that had answered.
+///
+/// Says only *that* a bound fired, not which: which one is settled before the attempt. Read off
+/// the bound's own signal rather than the message, which `Adb::exit_error` composes partly from
+/// the device's output — the device could otherwise answer for glass's deadline (glass#348).
 fn bound_fired(e: &GlassError) -> bool {
-    let msg = e.to_string();
-    msg.contains(TIMED_OUT) || msg.contains(NOT_STARTED)
+    e.bound().is_some()
 }
 
 /// Whether a failed dump gave no reason of its own — the mark of a `uiautomator` that crashed.
@@ -668,22 +670,60 @@ impl Accessibility for AndroidA11y {
 #[cfg(test)]
 mod tests {
     use super::{
-        Attempt, COLD_BOUND, RetryBound, Warmth, dump_once, dump_until_ready, editable_target,
-        locate_editable_target, locate_for_write, snapshot_bound, snapshot_with_runner,
-        verify_write,
+        Attempt, COLD_BOUND, RetryBound, Warmth, bound_fired, died_unexplained, dump_once,
+        dump_until_ready, editable_target, locate_editable_target, locate_for_write,
+        snapshot_bound, snapshot_with_runner, verify_write,
     };
-    use crate::adb::AdbOp;
+    use crate::adb::{AdbOp, with_adb_hint};
     use glass_core::accessibility::{
         AxContext, AxDeadline, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree,
         WalkLimits,
     };
-    use glass_core::{GlassError, Result, WindowGeometry};
+    use glass_core::{BoundKind, GlassError, Result, WindowGeometry};
     use std::collections::HashMap;
     use std::time::{Duration, Instant};
 
     /// A deadline no test reaches, for the cases that are not about the bound.
     fn ample() -> Instant {
         Instant::now() + Duration::from_secs(60)
+    }
+
+    /// A timeout as `glass_core` really raises one, hinted as every adb call's is.
+    ///
+    /// Run rather than typed: a fixture that builds the error itself measures the classifier's
+    /// agreement with the fixture, and would stay green through a runner that had stopped raising
+    /// what the classifier reads (glass#348).
+    ///
+    /// `/bin/sh` stands in for adb; `ping` does on Windows, which has no `/bin/sh` and paces one
+    /// echo per second whether or not the transmission succeeds.
+    fn cut_short_by_a_bound() -> GlassError {
+        #[cfg(unix)]
+        let mut hang = std::process::Command::new("/bin/sh");
+        #[cfg(unix)]
+        hang.args(["-c", "sleep 30"]);
+        #[cfg(windows)]
+        let mut hang = std::process::Command::new("ping");
+        #[cfg(windows)]
+        hang.args(["-n", "31", "127.0.0.1"]);
+
+        let e = glass_core::run_bounded(&mut hang, Duration::from_millis(200), "adb:shell")
+            .expect_err("must time out");
+        // A spawn failure is also an `Err`, and would sail through as a device error nobody
+        // classified.
+        assert_eq!(e.bound(), Some(BoundKind::TimedOut), "{e}");
+        with_adb_hint(e)
+    }
+
+    /// A spent-deadline error as `glass_core` really raises one. Nothing is spawned on that path,
+    /// so it needs no real command.
+    fn never_started_for_want_of_time() -> GlassError {
+        glass_core::run_bounded_until(
+            &mut std::process::Command::new("adb"),
+            Duration::from_secs(10),
+            Instant::now(),
+            "adb:uiautomator dump",
+        )
+        .expect_err("a spent deadline starts nothing")
     }
 
     /// An attempt as a plain `Result`, for the tests about what a dump reports rather than about
@@ -1148,6 +1188,52 @@ mod tests {
         );
     }
 
+    /// Both bounds `glass_core` fires are the ones the classifier reads, checked against errors it
+    /// really raised rather than against a constant both sides share.
+    ///
+    /// The two are otherwise coupled only by convention: nothing stops the runner reporting a
+    /// bound the classifier does not recognise, and no test of either side alone would see it.
+    #[test]
+    fn every_bound_glass_core_fires_is_one_the_classifier_recognises() {
+        for e in [cut_short_by_a_bound(), never_started_for_want_of_time()] {
+            assert!(bound_fired(&e), "{e}");
+            // A bound firing says nothing about the tool, so it is never the silent crash that
+            // `died_unexplained` names — which is retried, and would retry a spent deadline.
+            assert!(!died_unexplained(&e), "{e}");
+        }
+    }
+
+    /// Text the device wrote is not a bound of glass's own. `Adb::exit_error` interpolates the
+    /// child's stderr verbatim, so a phrase glass reads as its own deadline reaches the classifier
+    /// intact — and a device reported as a spent budget is one `wait_for_element` polls through
+    /// rather than surfaces.
+    ///
+    /// The stderr below is constructed rather than observed: no device is known to print it, and
+    /// nothing stops one.
+    #[test]
+    fn a_device_failure_that_quotes_the_deadline_wording_is_still_a_broken_device() {
+        let mut quoting = |argv: &[&str], _d: Instant| -> Result<(String, String)> {
+            match argv {
+                ["shell", "uiautomator", "dump", _] => Err(GlassError::Backend(
+                    "`adb shell uiautomator dump` failed: java.lang.IllegalStateException: \
+                     UiAutomation was not started"
+                        .into(),
+                )),
+                _ => Ok((String::new(), String::new())),
+            }
+        };
+        let e = dump_until_ready(
+            &mut quoting,
+            PREFIX,
+            RetryBound::ONCE,
+            Duration::ZERO,
+            AxDeadline::from_millis(5_000),
+        )
+        .expect_err("the device failed");
+
+        assert!(matches!(e, GlassError::Backend(_)), "{e}");
+    }
+
     /// [`RetryBound::least`] says how many attempts the *device* is owed, not how many a caller
     /// must pay for: an owed attempt is not started once the caller has stopped waiting. Both
     /// *retrying* bounds owe two, so this is the shape a real not-ready read takes.
@@ -1188,10 +1274,7 @@ mod tests {
     #[test]
     fn an_attempt_the_caller_cut_short_reports_the_budget_rather_than_the_device() {
         let timed_out = |_argv: &[&str], _d: Instant| -> Result<(String, String)> {
-            Err(GlassError::Backend(format!(
-                "`adb shell uiautomator dump` {}",
-                glass_core::TIMED_OUT
-            )))
+            Err(cut_short_by_a_bound())
         };
 
         let mut cut_short = timed_out;
@@ -1207,7 +1290,7 @@ mod tests {
         // A wedged adb reaches this arm too, and its message is the only place glass names the
         // `adb kill-server` remedy — dropping it leaves an operator reading "the app is slow".
         assert!(
-            e.to_string().contains(glass_core::TIMED_OUT),
+            e.to_string().contains("adb kill-server"),
             "the abandoned attempt's own error was discarded: {e}"
         );
 
@@ -1222,7 +1305,7 @@ mod tests {
             AxDeadline::UNBOUNDED,
         )
         .expect_err("the attempt timed out");
-        assert!(matches!(e, GlassError::Backend(_)), "{e}");
+        assert_eq!(e.bound(), Some(BoundKind::TimedOut), "{e}");
     }
 
     /// Retryability is the attempt's own verdict, not a guess from the error variant it carries:
@@ -1272,10 +1355,7 @@ mod tests {
                     dumps += 1;
                     if dumps == 1 {
                         abandoned = Some((*path).to_string());
-                        return Err(GlassError::Backend(format!(
-                            "`adb shell uiautomator dump` {}",
-                            glass_core::TIMED_OUT
-                        )));
+                        return Err(cut_short_by_a_bound());
                     }
                     files.insert((*path).to_string(), XML.to_string());
                     Ok((DUMPED.to_string(), String::new()))
@@ -1511,19 +1591,6 @@ mod tests {
     fn a_read_that_ran_out_of_the_attempts_time_is_not_reported_as_a_dump_that_wrote_nothing() {
         // Sharing one deadline across the three steps is what makes this reachable: an earlier slow
         // step can leave the read none.
-        //
-        // The error is the one `glass_core` really produces for a spent deadline, not a fixture
-        // repeating wording this crate does not own. Nothing is spawned on that path, so it needs
-        // no real command.
-        let spent = glass_core::run_bounded_until(
-            &mut std::process::Command::new("adb"),
-            Duration::from_secs(10),
-            Instant::now(),
-            "adb:uiautomator dump",
-        )
-        .expect_err("a spent deadline starts nothing")
-        .to_string();
-
         let mut attempts = 0;
         let mut run = |argv: &[&str], _deadline: Instant| -> Result<(String, String)> {
             match argv {
@@ -1531,7 +1598,7 @@ mod tests {
                     attempts += 1;
                     Ok((String::new(), format!("{NOT_READY}\n")))
                 }
-                ["shell", "cat", _] => Err(GlassError::Backend(spent.clone())),
+                ["shell", "cat", _] => Err(never_started_for_want_of_time()),
                 _ => Ok((String::new(), String::new())),
             }
         };
@@ -1545,8 +1612,9 @@ mod tests {
         .unwrap_err();
 
         let msg = e.to_string();
-        assert!(
-            msg.contains(glass_core::NOT_STARTED),
+        assert_eq!(
+            e.bound(),
+            Some(BoundKind::NotStarted),
             "the step that ran out of time must be the one reported: {msg}"
         );
         assert!(

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -678,7 +678,7 @@ mod tests {
         editable_target, locate_editable_target, locate_for_write, snapshot_bound,
         snapshot_with_runner, verify_write,
     };
-    use crate::adb::{AdbOp, a_failed_call, a_real_timeout_hinted};
+    use crate::adb::{AdbOp, a_failed_call, a_real_spawn_failure, a_real_timeout_hinted};
     use glass_core::accessibility::{
         AxContext, AxDeadline, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree,
         WalkLimits,
@@ -790,6 +790,20 @@ mod tests {
             ["shell", "cat", path] => Err(read_err(path)),
             ["shell", "rm", "-f", _] => Ok((String::new(), String::new())),
             other => panic!("unexpected adb command: {other:?}"),
+        }
+    }
+
+    /// An adb whose `uiautomator dump` fails with `said` on stderr, answering every other call —
+    /// the `rm -f` that follows a crash included — emptily.
+    ///
+    /// `said` is the whole variable: empty is the crash [`died_unexplained`] names, anything else a
+    /// device that gave a reason.
+    fn fake_failing_dump(
+        said: &'static str,
+    ) -> impl FnMut(&[&str], Instant) -> Result<(String, String)> {
+        move |argv: &[&str], _deadline: Instant| match argv {
+            ["shell", "uiautomator", "dump", _] => Err(a_failed_call(argv, said)),
+            _ => Ok((String::new(), String::new())),
         }
     }
 
@@ -1143,15 +1157,7 @@ mod tests {
     /// deadline, so the mutant would report every dead emulator as an app that is slow to publish.
     #[test]
     fn an_adb_failure_under_a_live_deadline_is_still_a_broken_device() {
-        let mut gone = |argv: &[&str], _d: Instant| -> Result<(String, String)> {
-            match argv {
-                ["shell", "uiautomator", "dump", path] => Err(a_failed_call(
-                    &["shell", "uiautomator", "dump", path],
-                    "error: device 'emulator-5554' not found",
-                )),
-                _ => Ok((String::new(), String::new())),
-            }
-        };
+        let mut gone = fake_failing_dump("error: device 'emulator-5554' not found");
         let e = dump_until_ready(
             &mut gone,
             PREFIX,
@@ -1164,9 +1170,9 @@ mod tests {
         .expect_err("the device is gone");
 
         assert_eq!(
-            e.bound(),
-            None,
-            "a dead device was read as a bound of glass's: {e}"
+            e.tool_said(),
+            Some("error: device 'emulator-5554' not found"),
+            "a dead device's own reason was replaced: {e}"
         );
         assert!(
             !e.to_string().contains("within the time this call allowed"),
@@ -1191,38 +1197,47 @@ mod tests {
         }
     }
 
-    /// A bound that fired is never the silent crash `died_unexplained` names, however the device
-    /// ended its sentence — that crash is retried, so reading one as the other retries a deadline
-    /// nobody is waiting on any more.
-    ///
-    /// The stderr matters: `said_before_the_kill` quotes it into the timeout message, so the
-    /// message really does end in `failed:` — which is what the old prose match keyed on.
+    /// A crash that managed only a newline is still a crash. `exit_error` trims on the way in and
+    /// [`GlassError::tool_said`] on the way out, so removing either leaves the other holding this.
     #[test]
-    #[cfg(unix)]
-    fn a_bound_that_fired_is_no_crash_even_when_the_message_ends_as_one() {
-        // Imported here, not with the module's other uses: this is the only test that needs it, so
-        // a `use` up there is an unused import on every non-unix target, which `-D warnings` fails.
-        use super::died_unexplained;
+    fn a_dump_that_crashed_writing_only_whitespace_is_still_retried() {
+        let mut barely = fake_failing_dump("\n  ");
+        assert!(matches!(
+            dump_once(&mut barely, PREFIX, ample()),
+            Attempt::NotReady(_)
+        ));
+    }
 
-        let mut hang = std::process::Command::new("/bin/sh");
-        hang.args([
-            "-c",
-            "printf '`adb shell uiautomator dump /sdcard/x.xml` failed:' >&2; sleep 30",
-        ]);
-        let e = glass_core::run_bounded(
-            &mut hang,
-            Duration::from_millis(200),
-            "adb:uiautomator dump",
-        )
-        .expect_err("must time out");
+    /// A call that never reached the tool is not a tool that said nothing — the distinction
+    /// [`GlassError::tool_said`] draws, and the one a missing `adb` turns on.
+    ///
+    /// Without this nothing exercises `Backend` through `dump_once` at all: every fake in this
+    /// module now raises the variant a tool that *ran* produces.
+    #[test]
+    fn a_dump_whose_adb_could_not_start_is_not_the_crash_that_waiting_resolves() {
+        let mut missing = |_argv: &[&str], _d: Instant| -> Result<(String, String)> {
+            Err(a_real_spawn_failure())
+        };
+        assert!(matches!(
+            dump_once(&mut missing, PREFIX, ample()),
+            Attempt::Fatal(_)
+        ));
+    }
 
-        assert_eq!(e.bound(), Some(BoundKind::TimedOut), "{e}");
-        // Without this the test stops discriminating the moment the quoting changes shape.
-        assert!(
-            e.to_string().trim_end().ends_with("failed:"),
-            "the fixture no longer bites: {e}"
-        );
-        assert!(!died_unexplained(&e), "{e}");
+    /// Only the *dump* step's silence is retried. A `cat` that dies the same way is fatal — the
+    /// dump already reported success, so a read that cannot speak for itself is about the device.
+    #[test]
+    fn a_read_that_failed_silently_is_not_retried_the_way_a_silent_dump_is() {
+        let mut run = |argv: &[&str], _d: Instant| -> Result<(String, String)> {
+            match argv {
+                ["shell", "cat", path] => Err(a_failed_call(&["shell", "cat", path], "")),
+                _ => Ok((DUMPED.to_string(), String::new())),
+            }
+        };
+        assert!(matches!(
+            dump_once(&mut run, PREFIX, ample()),
+            Attempt::Fatal(_)
+        ));
     }
 
     /// Text the device wrote is not a bound of glass's own. `Adb::exit_error` interpolates the
@@ -1233,15 +1248,8 @@ mod tests {
     /// nothing stops one.
     #[test]
     fn a_device_failure_that_quotes_the_deadline_wording_is_still_a_broken_device() {
-        let mut quoting = |argv: &[&str], _d: Instant| -> Result<(String, String)> {
-            match argv {
-                ["shell", "uiautomator", "dump", path] => Err(a_failed_call(
-                    &["shell", "uiautomator", "dump", path],
-                    "java.lang.IllegalStateException: UiAutomation was not started",
-                )),
-                _ => Ok((String::new(), String::new())),
-            }
-        };
+        let mut quoting =
+            fake_failing_dump("java.lang.IllegalStateException: UiAutomation was not started");
         let e = dump_until_ready(
             &mut quoting,
             PREFIX,
@@ -1347,15 +1355,7 @@ mod tests {
             Attempt::NotReady(_)
         ));
 
-        let mut gone = |argv: &[&str], _d: Instant| -> Result<(String, String)> {
-            match argv {
-                ["shell", "uiautomator", "dump", path] => Err(a_failed_call(
-                    &["shell", "uiautomator", "dump", path],
-                    "device offline",
-                )),
-                _ => Ok((String::new(), String::new())),
-            }
-        };
+        let mut gone = fake_failing_dump("device offline");
         assert!(matches!(
             dump_once(&mut gone, PREFIX, ample()),
             Attempt::Fatal(_)
@@ -1370,15 +1370,7 @@ mod tests {
     /// line this way, and nothing stops one.
     #[test]
     fn a_device_that_explained_itself_is_not_a_crash_however_its_message_ends() {
-        let mut explained = |argv: &[&str], _d: Instant| -> Result<(String, String)> {
-            match argv {
-                ["shell", "uiautomator", "dump", path] => Err(a_failed_call(
-                    &["shell", "uiautomator", "dump", path],
-                    "java.lang.SecurityException: dump failed:",
-                )),
-                _ => Ok((String::new(), String::new())),
-            }
-        };
+        let mut explained = fake_failing_dump("java.lang.SecurityException: dump failed:");
         let Attempt::Fatal(e) = dump_once(&mut explained, PREFIX, ample()) else {
             panic!("a device that gave a reason is not a crash that waiting resolves");
         };

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -670,9 +670,9 @@ impl Accessibility for AndroidA11y {
 #[cfg(test)]
 mod tests {
     use super::{
-        Attempt, COLD_BOUND, RetryBound, Warmth, bound_fired, died_unexplained, dump_once,
-        dump_until_ready, editable_target, locate_editable_target, locate_for_write,
-        snapshot_bound, snapshot_with_runner, verify_write,
+        Attempt, COLD_BOUND, RetryBound, Warmth, bound_fired, dump_once, dump_until_ready,
+        editable_target, locate_editable_target, locate_for_write, snapshot_bound,
+        snapshot_with_runner, verify_write,
     };
     use crate::adb::{AdbOp, a_real_timeout_hinted};
     use glass_core::accessibility::{
@@ -1188,6 +1188,10 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn a_bound_that_fired_is_no_crash_even_when_the_message_ends_as_one() {
+        // Imported here, not with the module's other uses: this is the only test that needs it, so
+        // a `use` up there is an unused import on every non-unix target, which `-D warnings` fails.
+        use super::died_unexplained;
+
         let mut hang = std::process::Command::new("/bin/sh");
         hang.args([
             "-c",

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -1197,8 +1197,8 @@ mod tests {
         }
     }
 
-    /// A crash that managed only a newline is still a crash. `exit_error` trims on the way in and
-    /// [`GlassError::tool_said`] on the way out, so removing either leaves the other holding this.
+    /// A crash that managed only a newline is still a crash — `exit_error` trims on the way in and
+    /// [`GlassError::tool_said`] on the way out.
     #[test]
     fn a_dump_that_crashed_writing_only_whitespace_is_still_retried() {
         let mut barely = fake_failing_dump("\n  ");
@@ -1208,11 +1208,10 @@ mod tests {
         ));
     }
 
-    /// A call that never reached the tool is not a tool that said nothing — the distinction
-    /// [`GlassError::tool_said`] draws, and the one a missing `adb` turns on.
+    /// A call that never reached the tool is not a tool that said nothing.
     ///
-    /// Without this nothing exercises `Backend` through `dump_once` at all: every fake in this
-    /// module now raises the variant a tool that *ran* produces.
+    /// Without this nothing exercises `Backend` through `dump_once` at all: every other fake in
+    /// this module raises the variant a tool that *ran* produces.
     #[test]
     fn a_dump_whose_adb_could_not_start_is_not_the_crash_that_waiting_resolves() {
         let mut missing = |_argv: &[&str], _d: Instant| -> Result<(String, String)> {

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -118,9 +118,9 @@ fn out_of_time(last: Option<&GlassError>) -> GlassError {
 /// What one dump attempt settled, for a loop deciding whether another would help.
 ///
 /// The judgement is made here, where the failure is diagnosed, rather than inferred by the caller
-/// from which error variant escaped: `uiautomator` crashing without a word arrived as
-/// `GlassError::Backend`, and the `matches!` gate on `AccessibilityUnavailable` that refused to
-/// retry it was repaired by restating the error rather than by fixing the gate (glass#341).
+/// from which error variant escaped: `uiautomator` crashing without a word arrived as an ordinary
+/// backend failure, and the `matches!` gate on `AccessibilityUnavailable` that refused to retry it
+/// was repaired by restating the error rather than by fixing the gate (glass#341).
 pub(crate) enum Attempt {
     Dumped(String),
     /// The device cannot serve a dump *yet* — waiting is what resolves it.
@@ -199,8 +199,12 @@ fn bound_fired(e: &GlassError) -> bool {
 /// with an empty stderr because the trace goes to logcat via `AndroidRuntime` (glass#341). That
 /// resolves by waiting. adb's own failures — a device that is gone, a wedged server — always carry
 /// a reason and do not.
+///
+/// Read off the stderr the error carries rather than the message it renders, which ends in that
+/// same stderr: a device whose last word was "failed:" used to answer this for `uiautomator`
+/// (glass#348).
 fn died_unexplained(e: &GlassError) -> bool {
-    !bound_fired(e) && e.to_string().trim_end().ends_with("failed:")
+    e.tool_said().is_some_and(str::is_empty)
 }
 
 /// How long a readiness wait may retry for, and how many attempts it owes regardless.
@@ -674,7 +678,7 @@ mod tests {
         editable_target, locate_editable_target, locate_for_write, snapshot_bound,
         snapshot_with_runner, verify_write,
     };
-    use crate::adb::{AdbOp, a_real_timeout_hinted};
+    use crate::adb::{AdbOp, a_failed_call, a_real_timeout_hinted};
     use glass_core::accessibility::{
         AxContext, AxDeadline, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree,
         WalkLimits,
@@ -735,14 +739,18 @@ mod tests {
     /// The `cat` of a file the dump never wrote — the error the old code surfaced in place
     /// of the dump's own.
     fn read_err(path: &str) -> GlassError {
-        GlassError::Backend(format!(
-            "`adb shell cat {path}` failed: cat: {path}: No such file"
-        ))
+        a_failed_call(
+            &["shell", "cat", path],
+            &format!("cat: {path}: No such file"),
+        )
     }
 
     /// What `Adb` raises for the crash [`died_unexplained`] names: non-zero exit, empty stderr.
+    ///
+    /// Built by `Adb`'s own constructor, so a fixture cannot go on describing a crash the classifier
+    /// has stopped recognising.
     fn crash_err(path: &str) -> GlassError {
-        GlassError::Backend(format!("`adb shell uiautomator dump {path}` failed: "))
+        a_failed_call(&["shell", "uiautomator", "dump", path], "")
     }
 
     /// An adb whose `uiautomator dump` crashes for `crashes` attempts, then succeeds.
@@ -1137,9 +1145,9 @@ mod tests {
     fn an_adb_failure_under_a_live_deadline_is_still_a_broken_device() {
         let mut gone = |argv: &[&str], _d: Instant| -> Result<(String, String)> {
             match argv {
-                ["shell", "uiautomator", "dump", _] => Err(GlassError::Backend(
-                    "`adb shell uiautomator dump` failed: error: device 'emulator-5554' not found"
-                        .into(),
+                ["shell", "uiautomator", "dump", path] => Err(a_failed_call(
+                    &["shell", "uiautomator", "dump", path],
+                    "error: device 'emulator-5554' not found",
                 )),
                 _ => Ok((String::new(), String::new())),
             }
@@ -1155,7 +1163,11 @@ mod tests {
         )
         .expect_err("the device is gone");
 
-        assert!(matches!(e, GlassError::Backend(_)), "{e}");
+        assert_eq!(
+            e.bound(),
+            None,
+            "a dead device was read as a bound of glass's: {e}"
+        );
         assert!(
             !e.to_string().contains("within the time this call allowed"),
             "a dead device was reported as a spent caller budget: {e}"
@@ -1184,7 +1196,7 @@ mod tests {
     /// nobody is waiting on any more.
     ///
     /// The stderr matters: `said_before_the_kill` quotes it into the timeout message, so the
-    /// message really does end in `failed:`.
+    /// message really does end in `failed:` — which is what the old prose match keyed on.
     #[test]
     #[cfg(unix)]
     fn a_bound_that_fired_is_no_crash_even_when_the_message_ends_as_one() {
@@ -1223,10 +1235,9 @@ mod tests {
     fn a_device_failure_that_quotes_the_deadline_wording_is_still_a_broken_device() {
         let mut quoting = |argv: &[&str], _d: Instant| -> Result<(String, String)> {
             match argv {
-                ["shell", "uiautomator", "dump", _] => Err(GlassError::Backend(
-                    "`adb shell uiautomator dump` failed: java.lang.IllegalStateException: \
-                     UiAutomation was not started"
-                        .into(),
+                ["shell", "uiautomator", "dump", path] => Err(a_failed_call(
+                    &["shell", "uiautomator", "dump", path],
+                    "java.lang.IllegalStateException: UiAutomation was not started",
                 )),
                 _ => Ok((String::new(), String::new())),
             }
@@ -1240,7 +1251,11 @@ mod tests {
         )
         .expect_err("the device failed");
 
-        assert!(matches!(e, GlassError::Backend(_)), "{e}");
+        assert_eq!(e.bound(), None, "{e}");
+        assert!(
+            e.to_string().contains("IllegalStateException"),
+            "the device's own reason was replaced: {e}"
+        );
     }
 
     /// [`RetryBound::least`] says how many attempts the *device* is owed, not how many a caller
@@ -1318,7 +1333,7 @@ mod tests {
     }
 
     /// Retryability is the attempt's own verdict, not a guess from the error variant it carries:
-    /// both of these are `GlassError::Backend` underneath.
+    /// both of these are `GlassError::ToolFailed` underneath, differing only in what the tool said.
     #[test]
     fn an_attempt_says_whether_waiting_could_help_rather_than_leaving_it_to_be_inferred() {
         let mut crashed = |argv: &[&str], _d: Instant| -> Result<(String, String)> {
@@ -1334,8 +1349,9 @@ mod tests {
 
         let mut gone = |argv: &[&str], _d: Instant| -> Result<(String, String)> {
             match argv {
-                ["shell", "uiautomator", "dump", _] => Err(GlassError::Backend(
-                    "`adb shell uiautomator dump` failed: device offline".into(),
+                ["shell", "uiautomator", "dump", path] => Err(a_failed_call(
+                    &["shell", "uiautomator", "dump", path],
+                    "device offline",
                 )),
                 _ => Ok((String::new(), String::new())),
             }
@@ -1344,6 +1360,29 @@ mod tests {
             dump_once(&mut gone, PREFIX, ample()),
             Attempt::Fatal(_)
         ));
+    }
+
+    /// A device that said why is never the silent crash, whatever its last word was. The crash is
+    /// retried and its reason replaced with "without saying why", so misreading one loses the only
+    /// explanation there was and sends an operator to a log that has nothing.
+    ///
+    /// The stderr below is constructed rather than observed: no `uiautomator` is known to end a
+    /// line this way, and nothing stops one.
+    #[test]
+    fn a_device_that_explained_itself_is_not_a_crash_however_its_message_ends() {
+        let mut explained = |argv: &[&str], _d: Instant| -> Result<(String, String)> {
+            match argv {
+                ["shell", "uiautomator", "dump", path] => Err(a_failed_call(
+                    &["shell", "uiautomator", "dump", path],
+                    "java.lang.SecurityException: dump failed:",
+                )),
+                _ => Ok((String::new(), String::new())),
+            }
+        };
+        let Attempt::Fatal(e) = dump_once(&mut explained, PREFIX, ample()) else {
+            panic!("a device that gave a reason is not a crash that waiting resolves");
+        };
+        assert!(e.to_string().contains("SecurityException"), "{e}");
     }
 
     #[test]
@@ -1485,7 +1524,11 @@ mod tests {
             }
         };
         let e = settled(dump_once(&mut run, PREFIX, ample())).unwrap_err();
-        assert!(matches!(e, GlassError::Backend(_)), "{e}");
+        assert!(
+            e.tool_said()
+                .is_some_and(|said| said.contains("No such file")),
+            "the read's own reason was replaced: {e}"
+        );
         assert!(!e.to_string().contains("did not write"), "{e}");
     }
 
@@ -1678,10 +1721,11 @@ mod tests {
         let mut attempts = 0;
         let mut run = |argv: &[&str], _deadline: Instant| -> Result<(String, String)> {
             match argv {
-                ["shell", "uiautomator", "dump", _] => {
+                ["shell", "uiautomator", "dump", path] => {
                     attempts += 1;
-                    Err(GlassError::Backend(
-                        "device 'emulator-5554' not found".into(),
+                    Err(a_failed_call(
+                        &["shell", "uiautomator", "dump", path],
+                        "device 'emulator-5554' not found",
                     ))
                 }
                 _ => Ok((String::new(), String::new())),
@@ -1695,7 +1739,7 @@ mod tests {
             AxDeadline::UNBOUNDED,
         )
         .unwrap_err();
-        assert!(matches!(e, GlassError::Backend(_)), "{e}");
+        assert!(e.to_string().contains("not found"), "{e}");
         assert_eq!(
             attempts, 1,
             "must not wait out the budget on a device error"

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -505,9 +505,9 @@ const SOCKET: &str = "glass-a11y";
 /// True when an `adb install` failure is the "existing package signed differently" case
 /// that only an uninstall can clear (e.g. a release APK over a local debug build).
 ///
-/// Read from what the tool said, never from the rendered message: that also names the argv, which
-/// carries the caller's APK path, so a path quoting either phrase would send every install failure
-/// down the uninstall branch — the hazard `AdbOp::for_args` documents for argv (glass#348).
+/// Read from what the tool said, never from the rendered message: that also names the argv, so an
+/// APK path quoting either phrase sent every install failure down the uninstall branch — the
+/// hazard `AdbOp::for_args` documents for argv (glass#348).
 fn is_signature_mismatch(e: &GlassError) -> bool {
     e.tool_said().is_some_and(|said| {
         said.contains("INSTALL_FAILED_UPDATE_INCOMPATIBLE")
@@ -1108,10 +1108,8 @@ mod tests {
         assert!(!is_signature_mismatch(&failed("error: device offline")));
     }
 
-    /// The verdict is the device's, so only the device's words may carry it. `GLASS_ANDROID_A11Y_APK`
-    /// is caller-supplied and lands in the argv the error names, so a path that quotes the phrase
-    /// used to make every install failure take the uninstall branch — the hazard `AdbOp::for_args`
-    /// already warns about for argv, one file over.
+    /// `GLASS_ANDROID_A11Y_APK` is caller-supplied and lands in the argv the error names, so a
+    /// path quoting the phrase used to make every install failure take the uninstall branch.
     #[test]
     fn a_phrase_in_the_apk_path_does_not_make_an_unrelated_failure_a_signature_mismatch() {
         let poisoned = "/home/u/signatures do not match/glass-a11y.apk";

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -504,8 +504,15 @@ const SOCKET: &str = "glass-a11y";
 
 /// True when an `adb install` failure is the "existing package signed differently" case
 /// that only an uninstall can clear (e.g. a release APK over a local debug build).
-fn is_signature_mismatch(err: &str) -> bool {
-    err.contains("INSTALL_FAILED_UPDATE_INCOMPATIBLE") || err.contains("signatures do not match")
+///
+/// Read from what the tool said, never from the rendered message: that also names the argv, which
+/// carries the caller's APK path, so a path quoting either phrase would send every install failure
+/// down the uninstall branch — the hazard `AdbOp::for_args` documents for argv (glass#348).
+fn is_signature_mismatch(e: &GlassError) -> bool {
+    e.tool_said().is_some_and(|said| {
+        said.contains("INSTALL_FAILED_UPDATE_INCOMPATIBLE")
+            || said.contains("signatures do not match")
+    })
 }
 
 /// Install the service APK, recovering from a signature mismatch. glass owns this package
@@ -514,7 +521,7 @@ fn is_signature_mismatch(err: &str) -> bool {
 fn install_service(adb: &Adb, apk: &str) -> Result<()> {
     match adb.run(["install", "-r", apk]) {
         Ok(_) => Ok(()),
-        Err(e) if is_signature_mismatch(&e.to_string()) => {
+        Err(e) if is_signature_mismatch(&e) => {
             eprintln!(
                 "glass-a11y: replacing a differently-signed existing install of {SERVICE_PACKAGE}"
             );
@@ -1086,16 +1093,43 @@ mod tests {
 
     #[test]
     fn signature_mismatch_detected() {
-        assert!(is_signature_mismatch(
+        let failed = |said: &str| {
+            crate::adb::a_failed_call(&["install", "-r", "/opt/glass/glass-a11y.apk"], said)
+        };
+        assert!(is_signature_mismatch(&failed(
             "Failure [INSTALL_FAILED_UPDATE_INCOMPATIBLE: Existing package signatures do not match newer version; ignoring!]"
-        ));
-        assert!(is_signature_mismatch(
+        )));
+        assert!(is_signature_mismatch(&failed(
             "signatures do not match newer version"
-        ));
-        assert!(!is_signature_mismatch(
+        )));
+        assert!(!is_signature_mismatch(&failed(
             "Failure [INSTALL_FAILED_INSUFFICIENT_STORAGE]"
-        ));
-        assert!(!is_signature_mismatch("error: device offline"));
+        )));
+        assert!(!is_signature_mismatch(&failed("error: device offline")));
+    }
+
+    /// The verdict is the device's, so only the device's words may carry it. `GLASS_ANDROID_A11Y_APK`
+    /// is caller-supplied and lands in the argv the error names, so a path that quotes the phrase
+    /// used to make every install failure take the uninstall branch — the hazard `AdbOp::for_args`
+    /// already warns about for argv, one file over.
+    #[test]
+    fn a_phrase_in_the_apk_path_does_not_make_an_unrelated_failure_a_signature_mismatch() {
+        let poisoned = "/home/u/signatures do not match/glass-a11y.apk";
+        for said in [
+            "Failure [INSTALL_FAILED_INSUFFICIENT_STORAGE]",
+            "error: device offline",
+        ] {
+            let e = crate::adb::a_failed_call(&["install", "-r", poisoned], said);
+            assert!(!is_signature_mismatch(&e), "{e}");
+        }
+    }
+
+    /// A timed-out install says nothing about signatures: it names no exit status, and the message
+    /// it does carry quotes whatever the child printed first.
+    #[test]
+    fn an_install_that_timed_out_is_not_a_signature_mismatch() {
+        let e = crate::adb::a_real_timeout_hinted();
+        assert!(!is_signature_mismatch(&e), "{e}");
     }
 
     #[test]

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -170,7 +170,11 @@ impl Adb {
         if out.status.success() {
             Ok(out)
         } else {
-            Err(exit_error(&self.bin, &argv, &out))
+            Err(exit_error(
+                &self.bin,
+                &argv,
+                &String::from_utf8_lossy(&out.stderr),
+            ))
         }
     }
 }
@@ -243,12 +247,20 @@ pub(crate) fn build_argv(serial: Option<&str>, args: &[&str]) -> Vec<String> {
     v
 }
 
-fn exit_error(bin: &str, argv: &[String], out: &Output) -> GlassError {
-    GlassError::Backend(format!(
-        "`{bin} {}` failed: {}",
-        argv.join(" "),
-        String::from_utf8_lossy(&out.stderr).trim()
-    ))
+/// The error for a call that ran and exited non-zero. `said` is what it wrote to stderr.
+fn exit_error(bin: &str, argv: &[String], said: &str) -> GlassError {
+    GlassError::ToolFailed {
+        call: format!("`{bin} {}`", argv.join(" ")),
+        said: said.trim().to_string(),
+    }
+}
+
+/// [`exit_error`] as production builds it, for a test that needs a chosen `said` — the whole
+/// question `a11y::died_unexplained` asks is whether that is empty.
+#[cfg(test)]
+pub(crate) fn a_failed_call(argv: &[&str], said: &str) -> GlassError {
+    let argv: Vec<String> = argv.iter().map(|a| (*a).to_string()).collect();
+    exit_error("adb", &argv, said)
 }
 
 #[cfg(test)]

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -177,24 +177,60 @@ impl Adb {
 
 /// Add adb's one-command remedy to a TIMEOUT, and nothing else.
 ///
-/// Extends the message rather than wrapping the error: nesting one `Backend` inside another makes
-/// `Display` print its prefix twice, and an agent reads this text. Gated on the timeout because the
-/// other failure is a spawn failure — a missing or mis-resolved binary, the most common Android
-/// setup problem — where `adb kill-server` is advice for a binary that is not there.
-///
-/// The rebuilt error keeps its [`BoundKind`]: `a11y::bound_fired` reads it downstream of this, so
-/// dropping it here reports every hint-carrying timeout as a device that failed.
-pub(crate) fn with_adb_hint(e: GlassError) -> GlassError {
-    match e {
-        GlassError::Bounded {
-            kind: kind @ BoundKind::TimedOut,
-            message,
-        } => GlassError::Bounded {
-            kind,
-            message: format!("{message}; if this repeats, run `adb kill-server` and retry"),
-        },
-        other => other,
+/// Appended in place rather than wrapped: nesting one error inside another makes `Display` print
+/// `"backend error: "` twice, and an agent reads this text. Editing the message also leaves the
+/// [`BoundKind`] where it was, which `a11y::bound_fired` reads downstream of this — a rebuild that
+/// dropped it would report every hint-carrying timeout as a device that failed.
+fn with_adb_hint(mut e: GlassError) -> GlassError {
+    if let GlassError::Bounded { kind, message, .. } = &mut e {
+        match kind {
+            BoundKind::TimedOut => {
+                message.push_str("; if this repeats, run `adb kill-server` and retry");
+            }
+            // adb was never asked, so nothing about the server is implicated — and the other
+            // failure it could be advice for is a missing or mis-resolved binary, the most common
+            // Android setup problem.
+            BoundKind::NotStarted => {}
+        }
     }
+    e
+}
+
+/// A timeout as `glass_core` really raises one for an adb call, before [`with_adb_hint`].
+///
+/// Run rather than typed: every caller keys on a bound `glass-core` sets, so a fixture that set it
+/// too could not notice the runner stopping (glass#348).
+///
+/// `/bin/sh` stands in for adb; `ping` does on Windows, which has no `/bin/sh` — it paces one echo
+/// per second even when transmission fails, so it outlives the 200ms budget either way.
+#[cfg(test)]
+pub(crate) fn a_real_timeout() -> GlassError {
+    #[cfg(unix)]
+    let (bin, args): (&str, &[&str]) = ("/bin/sh", &["-c", "sleep 30"]);
+    #[cfg(windows)]
+    let (bin, args): (&str, &[&str]) = ("ping", &["-n", "31", "127.0.0.1"]);
+
+    let e = run_bounded(
+        Command::new(bin).args(args),
+        Duration::from_millis(200),
+        "adb:shell",
+    )
+    .expect_err("must time out");
+    // A spawn failure is also an `Err`: it sails past `expect_err`, then fails whatever the caller
+    // asserts next, blaming the code under test for a missing binary.
+    assert_eq!(
+        e.bound(),
+        Some(BoundKind::TimedOut),
+        "expected a timeout, got: {e}"
+    );
+    e
+}
+
+/// [`a_real_timeout`] as a caller outside this module meets one: every adb error leaves
+/// [`Adb::output`] through [`with_adb_hint`], and `a11y`'s classifier reads what comes out.
+#[cfg(test)]
+pub(crate) fn a_real_timeout_hinted() -> GlassError {
+    with_adb_hint(a_real_timeout())
 }
 
 /// Build the adb argument vector, prefixing `-s <serial>` when targeting a device.
@@ -219,7 +255,7 @@ fn exit_error(bin: &str, argv: &[String], out: &Output) -> GlassError {
 
 #[cfg(test)]
 mod tests {
-    use super::{Adb, AdbOp, build_argv, with_adb_hint};
+    use super::{Adb, AdbOp, a_real_timeout, build_argv, with_adb_hint};
     use glass_core::{BoundKind, GlassError};
     use std::time::Duration;
 
@@ -394,40 +430,11 @@ mod tests {
         ));
         assert!(!spawn.to_string().contains("kill-server"), "{spawn}");
 
-        // Built by running a real timeout rather than typed here: the gate keys on a bound
-        // `glass-core` sets, so a fixture setting it too could not notice the runner stopping.
-        //
-        // `ping` stands in for `sleep` on Windows (no `/bin/sh` there) — it paces one echo per
-        // second even when transmission fails, so it reliably outlives the 200ms budget.
-        #[cfg(unix)]
-        let mut hang = std::process::Command::new("/bin/sh");
-        #[cfg(unix)]
-        hang.args(["-c", "sleep 30"]);
-        #[cfg(windows)]
-        let mut hang = std::process::Command::new("ping");
-        #[cfg(windows)]
-        hang.args(["-n", "31", "127.0.0.1"]);
-
-        let real_timeout = glass_core::run_bounded(
-            &mut hang,
-            std::time::Duration::from_millis(200),
-            "adb:shell",
-        )
-        .expect_err("must time out");
-        // A spawn failure is also an Err: it sails past `expect_err`, then fails the hint
-        // assertion below, blaming `with_adb_hint` for a missing binary.
-        assert_eq!(
-            real_timeout.bound(),
-            Some(BoundKind::TimedOut),
-            "expected a timeout, got: {real_timeout}"
-        );
-        let timeout = with_adb_hint(real_timeout);
+        let timeout = with_adb_hint(a_real_timeout());
         assert!(timeout.to_string().contains("adb kill-server"), "{timeout}");
-        // Extending the message must not wrap one Backend in another: Display prints its prefix
-        // per layer, and "backend error: backend error: ..." is what an agent would read.
+        // Extending the message must not wrap one error in another: Display prints its prefix per
+        // layer, and "backend error: backend error: ..." is what an agent would read.
         assert_eq!(timeout.to_string().matches("backend error").count(), 1);
-        // The hinted error is what reaches `a11y::bound_fired`, so the rebuild must keep the bound:
-        // without it every timed-out read is reported as a device that failed.
         assert_eq!(timeout.bound(), Some(BoundKind::TimedOut), "{timeout}");
     }
 

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -178,18 +178,16 @@ impl Adb {
 /// Add adb's one-command remedy to a TIMEOUT, and nothing else.
 ///
 /// Appended in place rather than wrapped: nesting one error inside another makes `Display` print
-/// `"backend error: "` twice, and an agent reads this text. Editing the message also leaves the
-/// [`BoundKind`] where it was, which `a11y::bound_fired` reads downstream of this — a rebuild that
-/// dropped it would report every hint-carrying timeout as a device that failed.
+/// `"backend error: "` twice, and an agent reads this text. In place also keeps the [`BoundKind`],
+/// which `a11y::bound_fired` reads downstream — a rebuild that dropped it would report every
+/// hint-carrying timeout as a device that failed.
 fn with_adb_hint(mut e: GlassError) -> GlassError {
     if let GlassError::Bounded { kind, message, .. } = &mut e {
         match kind {
             BoundKind::TimedOut => {
                 message.push_str("; if this repeats, run `adb kill-server` and retry");
             }
-            // adb was never asked, so nothing about the server is implicated — and the other
-            // failure it could be advice for is a missing or mis-resolved binary, the most common
-            // Android setup problem.
+            // adb was never asked, so nothing about the server is implicated.
             BoundKind::NotStarted => {}
         }
     }
@@ -432,8 +430,8 @@ mod tests {
 
         let timeout = with_adb_hint(a_real_timeout());
         assert!(timeout.to_string().contains("adb kill-server"), "{timeout}");
-        // Extending the message must not wrap one error in another: Display prints its prefix per
-        // layer, and "backend error: backend error: ..." is what an agent would read.
+        // Display prints its prefix per layer, and "backend error: backend error: ..." is what
+        // an agent would read.
         assert_eq!(timeout.to_string().matches("backend error").count(), 1);
         assert_eq!(timeout.bound(), Some(BoundKind::TimedOut), "{timeout}");
     }

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -170,11 +170,8 @@ impl Adb {
         if out.status.success() {
             Ok(out)
         } else {
-            Err(exit_error(
-                &self.bin,
-                &argv,
-                &String::from_utf8_lossy(&out.stderr),
-            ))
+            let said = String::from_utf8_lossy(&out.stderr);
+            Err(exit_error(&self.bin, &argv, &said))
         }
     }
 }
@@ -250,7 +247,7 @@ pub(crate) fn build_argv(serial: Option<&str>, args: &[&str]) -> Vec<String> {
 /// The error for a call that ran and exited non-zero. `said` is what it wrote to stderr.
 fn exit_error(bin: &str, argv: &[String], said: &str) -> GlassError {
     GlassError::ToolFailed {
-        call: format!("`{bin} {}`", argv.join(" ")),
+        call: format!("{bin} {}", argv.join(" ")),
         said: said.trim().to_string(),
     }
 }
@@ -263,9 +260,29 @@ pub(crate) fn a_failed_call(argv: &[&str], said: &str) -> GlassError {
     exit_error("adb", &argv, said)
 }
 
+/// The error a call to a *missing* binary raises — the shape `a11y` must not read as a tool that
+/// ran and said nothing.
+#[cfg(test)]
+pub(crate) fn a_real_spawn_failure() -> GlassError {
+    let adb = Adb {
+        bin: "/nonexistent/glass-test-adb".to_string(),
+        serial: None,
+    };
+    let e = adb
+        .run(["devices"])
+        .expect_err("a missing binary cannot run");
+    assert_eq!(e.bound(), None, "a missing binary is not a bound: {e}");
+    assert_eq!(
+        e.tool_said(),
+        None,
+        "a tool that never ran said nothing: {e}"
+    );
+    e
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{Adb, AdbOp, a_real_timeout, build_argv, with_adb_hint};
+    use super::{Adb, AdbOp, a_failed_call, a_real_timeout, build_argv, with_adb_hint};
     use glass_core::{BoundKind, GlassError};
     use std::time::Duration;
 
@@ -341,6 +358,75 @@ mod tests {
             started.elapsed()
         );
         assert_eq!(err.bound(), Some(BoundKind::TimedOut), "{err}");
+    }
+
+    /// Which stream `said` comes from, proven against a real non-zero exit rather than asserted in
+    /// a doc comment.
+    ///
+    /// `Adb::output` picks the stream, and nothing else exercises that branch: passing `out.stdout`
+    /// instead leaves the whole workspace green while a dead emulator — which writes its reason to
+    /// stderr — reads as the silent crash `a11y` retries for the cold bound, its only explanation
+    /// replaced by "without saying why".
+    ///
+    /// `/bin/sh` stands in for adb; `cmd` does on Windows.
+    #[test]
+    fn a_tool_that_exits_non_zero_carries_its_stderr_and_not_its_stdout() {
+        #[cfg(unix)]
+        let (bin, loud): (&str, &[&str]) = (
+            "/bin/sh",
+            &["-c", "printf not-this; printf boom 1>&2; exit 1"],
+        );
+        #[cfg(windows)]
+        let (bin, loud): (&str, &[&str]) =
+            ("cmd", &["/c", "echo not-this& echo boom 1>&2& exit 1"]);
+        let adb = Adb {
+            bin: bin.to_string(),
+            serial: None,
+        };
+
+        let e = adb
+            .run(loud.iter().copied())
+            .expect_err("a non-zero exit is a failure");
+        // Only `said` discriminates: the message also carries the argv, and the argv here is the
+        // shell command that prints the stdout text, so searching the message finds it either way.
+        assert_eq!(
+            e.tool_said(),
+            Some("boom"),
+            "stdout was read as the reason: {e}"
+        );
+    }
+
+    /// A real silent exit is the crash `a11y::died_unexplained` names — the one fact this whole
+    /// classification turns on, and the one a typed fixture cannot prove.
+    #[test]
+    fn a_tool_that_exits_non_zero_saying_nothing_reads_as_having_said_nothing() {
+        #[cfg(unix)]
+        let (bin, quiet): (&str, &[&str]) = ("/bin/sh", &["-c", "exit 9"]);
+        #[cfg(windows)]
+        let (bin, quiet): (&str, &[&str]) = ("cmd", &["/c", "exit 9"]);
+        let adb = Adb {
+            bin: bin.to_string(),
+            serial: None,
+        };
+
+        let e = adb
+            .run(quiet.iter().copied())
+            .expect_err("a non-zero exit is a failure");
+        assert_eq!(e.tool_said(), Some(""), "{e}");
+        assert_eq!(e.bound(), None, "{e}");
+    }
+
+    /// The fixture the `a11y` tests build their device failures from renders what production does.
+    #[test]
+    fn the_failed_call_fixture_renders_what_a_real_exit_error_does() {
+        assert_eq!(
+            a_failed_call(
+                &["shell", "cat", "/sdcard/x.xml"],
+                "cat: /sdcard/x.xml: No such file"
+            )
+            .to_string(),
+            "backend error: `adb shell cat /sdcard/x.xml` failed: cat: /sdcard/x.xml: No such file"
+        );
     }
 
     #[test]

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -1,7 +1,7 @@
 use std::process::{Command, Output};
 use std::time::{Duration, Instant};
 
-use glass_core::{GlassError, Result, TIMED_OUT, run_bounded, run_bounded_until};
+use glass_core::{BoundKind, GlassError, Result, run_bounded, run_bounded_until};
 
 /// What an adb invocation is doing, which is what decides how long it may take.
 ///
@@ -181,11 +181,18 @@ impl Adb {
 /// `Display` print its prefix twice, and an agent reads this text. Gated on the timeout because the
 /// other failure is a spawn failure — a missing or mis-resolved binary, the most common Android
 /// setup problem — where `adb kill-server` is advice for a binary that is not there.
-fn with_adb_hint(e: GlassError) -> GlassError {
+///
+/// The rebuilt error keeps its [`BoundKind`]: `a11y::bound_fired` reads it downstream of this, so
+/// dropping it here reports every hint-carrying timeout as a device that failed.
+pub(crate) fn with_adb_hint(e: GlassError) -> GlassError {
     match e {
-        GlassError::Backend(msg) if msg.contains(TIMED_OUT) => GlassError::Backend(format!(
-            "{msg}; if this repeats, run `adb kill-server` and retry"
-        )),
+        GlassError::Bounded {
+            kind: kind @ BoundKind::TimedOut,
+            message,
+        } => GlassError::Bounded {
+            kind,
+            message: format!("{message}; if this repeats, run `adb kill-server` and retry"),
+        },
         other => other,
     }
 }
@@ -213,7 +220,7 @@ fn exit_error(bin: &str, argv: &[String], out: &Output) -> GlassError {
 #[cfg(test)]
 mod tests {
     use super::{Adb, AdbOp, build_argv, with_adb_hint};
-    use glass_core::{GlassError, TIMED_OUT};
+    use glass_core::{BoundKind, GlassError};
     use std::time::Duration;
 
     /// Live proof that a wedged adb call ends instead of hanging. Ignored by default:
@@ -287,7 +294,7 @@ mod tests {
             "waited {:?} — the deadline never reached the process",
             started.elapsed()
         );
-        assert!(err.to_string().contains(TIMED_OUT), "{err}");
+        assert_eq!(err.bound(), Some(BoundKind::TimedOut), "{err}");
     }
 
     #[test]
@@ -387,8 +394,8 @@ mod tests {
         ));
         assert!(!spawn.to_string().contains("kill-server"), "{spawn}");
 
-        // Built by running a real timeout rather than typed here: the gate keys on wording that
-        // `glass-core` owns, so a fixture repeating that wording could not notice it drifting.
+        // Built by running a real timeout rather than typed here: the gate keys on a bound
+        // `glass-core` sets, so a fixture setting it too could not notice the runner stopping.
         //
         // `ping` stands in for `sleep` on Windows (no `/bin/sh` there) — it paces one echo per
         // second even when transmission fails, so it reliably outlives the 200ms budget.
@@ -409,8 +416,9 @@ mod tests {
         .expect_err("must time out");
         // A spawn failure is also an Err: it sails past `expect_err`, then fails the hint
         // assertion below, blaming `with_adb_hint` for a missing binary.
-        assert!(
-            real_timeout.to_string().contains(TIMED_OUT),
+        assert_eq!(
+            real_timeout.bound(),
+            Some(BoundKind::TimedOut),
             "expected a timeout, got: {real_timeout}"
         );
         let timeout = with_adb_hint(real_timeout);
@@ -418,6 +426,9 @@ mod tests {
         // Extending the message must not wrap one Backend in another: Display prints its prefix
         // per layer, and "backend error: backend error: ..." is what an agent would read.
         assert_eq!(timeout.to_string().matches("backend error").count(), 1);
+        // The hinted error is what reaches `a11y::bound_fired`, so the rebuild must keep the bound:
+        // without it every timed-out read is reported as a device that failed.
+        assert_eq!(timeout.bound(), Some(BoundKind::TimedOut), "{timeout}");
     }
 
     #[test]

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -363,10 +363,9 @@ mod tests {
     /// Which stream `said` comes from, proven against a real non-zero exit rather than asserted in
     /// a doc comment.
     ///
-    /// `Adb::output` picks the stream, and nothing else exercises that branch: passing `out.stdout`
-    /// instead leaves the whole workspace green while a dead emulator — which writes its reason to
-    /// stderr — reads as the silent crash `a11y` retries for the cold bound, its only explanation
-    /// replaced by "without saying why".
+    /// `Adb::output` picks the stream and nothing else exercises that branch: passing `out.stdout`
+    /// leaves the workspace green while a dead emulator, which writes its reason to stderr, reads
+    /// as the silent crash `a11y` retries.
     ///
     /// `/bin/sh` stands in for adb; `cmd` does on Windows.
     #[test]

--- a/crates/glass-core/src/bounded.rs
+++ b/crates/glass-core/src/bounded.rs
@@ -13,16 +13,17 @@ use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
-use crate::{GlassError, Result};
+use crate::{BoundKind, GlassError, Result};
 
-/// The phrase a timeout error carries, so a caller can recognise one without matching on prose it
-/// does not own — `glass-android` offers `adb kill-server` for a timeout and for nothing else.
-pub const TIMED_OUT: &str = "no answer within";
+/// The phrase a timeout error carries, for a reader of the message. What a *caller* keys on is
+/// [`BoundKind::TimedOut`] — this text is composed partly from the child's own output, so anything
+/// matching on it is matching on prose the device helps write (glass#348).
+const TIMED_OUT: &str = "no answer within";
 
 /// The phrase an error carries when a call was never started, because the deadline it serves was
 /// already spent. Deliberately not [`TIMED_OUT`]: the remedies for a tool that hung do not apply to
-/// one that never ran.
-pub const NOT_STARTED: &str = "was not started";
+/// one that never ran, and [`BoundKind`] keeps the two apart for callers.
+const NOT_STARTED: &str = "was not started";
 
 /// Longest gap between checks on a child that has not exited yet. The wait starts far tighter and
 /// backs off to this, so a one-shot that answers in a millisecond is not billed a full tick and a
@@ -76,10 +77,13 @@ pub fn run_bounded_until(
 ) -> Result<Output> {
     let budget = budget_within(budget, deadline, Instant::now());
     if budget.is_zero() {
-        return Err(GlassError::Backend(format!(
-            "{op}: the deadline it shares with the rest of the call was already spent, so it \
-             {NOT_STARTED}"
-        )));
+        return Err(GlassError::Bounded {
+            kind: BoundKind::NotStarted,
+            message: format!(
+                "{op}: the deadline it shares with the rest of the call was already spent, so it \
+                 {NOT_STARTED}"
+            ),
+        });
     }
     run_bounded_inner(cmd, budget, op, None)
 }
@@ -384,7 +388,10 @@ fn timed_out(
     } else {
         "so the process was killed, though it had not exited yet (it may be stuck in the kernel)"
     };
-    GlassError::Backend(format!("{op}: {TIMED_OUT} {budget:?}, {fate}; {said}"))
+    GlassError::Bounded {
+        kind: BoundKind::TimedOut,
+        message: format!("{op}: {TIMED_OUT} {budget:?}, {fate}; {said}"),
+    }
 }
 #[cfg(test)]
 mod tests {
@@ -826,6 +833,56 @@ mod tests {
         .expect("a fast command yields its Output");
         assert_eq!(String::from_utf8_lossy(&out.stdout), "ready");
         assert_eq!(out.status.code(), Some(3));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_call_that_ended_at_a_bound_says_which_one_as_a_value() {
+        // Which bound fired decides whether a backend retries, whether it offers the wedged-adb
+        // remedy, and whether a caller's spent budget is reported as a device failure. The runner
+        // knows it exactly; a caller reconstructing it from the message reads a message the child's
+        // own output helps write.
+        let hung = run_bounded(
+            Command::new("/bin/sh").args(["-c", "sleep 30"]),
+            Duration::from_millis(300),
+            "test:kind-timeout",
+        )
+        .expect_err("must time out");
+        assert_eq!(hung.bound(), Some(BoundKind::TimedOut), "{hung}");
+
+        let spent = run_bounded_until(
+            Command::new("/bin/sh").args(["-c", "sleep 30"]),
+            Duration::from_secs(20),
+            Instant::now(),
+            "test:kind-not-started",
+        )
+        .expect_err("a call with no time left must fail rather than run");
+        assert_eq!(spent.bound(), Some(BoundKind::NotStarted), "{spent}");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_failure_that_is_not_a_bound_firing_carries_no_kind() {
+        // The classification must not widen to "this call failed": a wedged adb and a crashed
+        // `uiautomator` both reach the same guards, and only a bound firing means the deadline —
+        // not the device — ended the call.
+        let spawn = run_bounded(
+            &mut Command::new("/nonexistent/glass-test-binary"),
+            Duration::from_secs(10),
+            "test:kind-spawn",
+        )
+        .expect_err("spawn must fail");
+        assert_eq!(spawn.bound(), None, "{spawn}");
+
+        let held_open = run_bounded(
+            Command::new("/bin/sh").args(["-c", "printf head; { sleep 1; printf tail; } &"]),
+            Duration::from_secs(20),
+            "test:kind-incomplete",
+        )
+        .expect_err("an incomplete read is an error");
+        assert_eq!(held_open.bound(), None, "{held_open}");
+
+        assert_eq!(GlassError::Backend("device offline".into()).bound(), None);
     }
 
     #[test]

--- a/crates/glass-core/src/bounded.rs
+++ b/crates/glass-core/src/bounded.rs
@@ -840,7 +840,7 @@ mod tests {
     fn a_call_killed_at_its_bound_says_it_timed_out_as_a_value() {
         // That a bound fired decides whether a backend retries and whether a caller's spent budget
         // is reported as a device failure; which one decides whether the wedged-tool remedy is
-        // offered. The runner knows both exactly, and used to discard them into the message.
+        // offered.
         let hung = run_bounded(
             Command::new("/bin/sh").args(["-c", "sleep 30"]),
             Duration::from_millis(300),
@@ -852,8 +852,8 @@ mod tests {
 
     #[test]
     fn a_call_with_nothing_left_says_it_never_started_as_a_value() {
-        // Portable: this path returns before anything is spawned, so the binary need not exist —
-        // which is what lets the Windows leg cover the kind a `wait_for_element` polls through.
+        // This path returns before anything is spawned, so the binary need not exist — which is
+        // what lets the Windows leg cover the kind a `wait_for_element` polls through.
         let spent = run_bounded_until(
             &mut Command::new("/nonexistent/glass-test-binary"),
             Duration::from_secs(20),
@@ -866,10 +866,9 @@ mod tests {
 
     #[test]
     fn a_failure_that_is_not_a_bound_firing_carries_no_kind() {
-        // The classification must not widen to "this call failed": a missing or mis-resolved binary
-        // is the commonest Android setup problem, and read as a bound it becomes a wait polling on
-        // for its whole timeout instead of failing at once. Portable, so the Windows leg — where
-        // that binary is likeliest to be missing — covers this direction too.
+        // The classification must not widen to "this call failed": a missing binary read as a
+        // bound becomes a wait polling on for its whole timeout instead of failing at once.
+        // Portable, so the Windows leg covers this direction too.
         let spawn = run_bounded(
             &mut Command::new("/nonexistent/glass-test-binary"),
             Duration::from_secs(10),

--- a/crates/glass-core/src/bounded.rs
+++ b/crates/glass-core/src/bounded.rs
@@ -16,8 +16,8 @@ use std::time::{Duration, Instant};
 use crate::{BoundKind, GlassError, Result};
 
 /// The phrase a timeout error carries, for a reader of the message. What a *caller* keys on is
-/// [`BoundKind::TimedOut`] — this text is composed partly from the child's own output, so anything
-/// matching on it is matching on prose the device helps write (glass#348).
+/// [`BoundKind::TimedOut`]: the message this appears in embeds the child's own output, so matching
+/// on it is matching prose the device helps write (glass#348).
 const TIMED_OUT: &str = "no answer within";
 
 /// The phrase an error carries when a call was never started, because the deadline it serves was
@@ -68,7 +68,7 @@ pub fn run_bounded(cmd: &mut Command, budget: Duration, op: &str) -> Result<Outp
 /// Several calls can answer one request: one `uiautomator dump` is a remove, a dump and a read.
 /// Each carrying only its own budget makes the sequence cost their sum, so the deadline travels
 /// down and each step gets whichever bound is nearer. A step with nothing left is not started at
-/// all, and says [`NOT_STARTED`].
+/// all, and fails with [`BoundKind::NotStarted`].
 pub fn run_bounded_until(
     cmd: &mut Command,
     budget: Duration,
@@ -814,8 +814,8 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("test:spent-deadline"), "{msg}");
         assert!(msg.contains(NOT_STARTED), "{msg}");
-        // Nothing was asked, so nothing failed to answer — and `with_adb_hint` and its kind key on
-        // this phrase to offer remedies for a wedged tool.
+        // Nothing was asked, so nothing failed to answer — a reader must not be told the tool
+        // hung. Callers key on `BoundKind`, not on this phrase.
         assert!(!msg.contains(TIMED_OUT), "{msg}");
     }
 
@@ -837,11 +837,10 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
-    fn a_call_that_ended_at_a_bound_says_which_one_as_a_value() {
-        // Which bound fired decides whether a backend retries, whether it offers the wedged-adb
-        // remedy, and whether a caller's spent budget is reported as a device failure. The runner
-        // knows it exactly; a caller reconstructing it from the message reads a message the child's
-        // own output helps write.
+    fn a_call_killed_at_its_bound_says_it_timed_out_as_a_value() {
+        // That a bound fired decides whether a backend retries and whether a caller's spent budget
+        // is reported as a device failure; which one decides whether the wedged-tool remedy is
+        // offered. The runner knows both exactly, and used to discard them into the message.
         let hung = run_bounded(
             Command::new("/bin/sh").args(["-c", "sleep 30"]),
             Duration::from_millis(300),
@@ -849,9 +848,14 @@ mod tests {
         )
         .expect_err("must time out");
         assert_eq!(hung.bound(), Some(BoundKind::TimedOut), "{hung}");
+    }
 
+    #[test]
+    fn a_call_with_nothing_left_says_it_never_started_as_a_value() {
+        // Portable: this path returns before anything is spawned, so the binary need not exist —
+        // which is what lets the Windows leg cover the kind a `wait_for_element` polls through.
         let spent = run_bounded_until(
-            Command::new("/bin/sh").args(["-c", "sleep 30"]),
+            &mut Command::new("/nonexistent/glass-test-binary"),
             Duration::from_secs(20),
             Instant::now(),
             "test:kind-not-started",
@@ -861,11 +865,11 @@ mod tests {
     }
 
     #[test]
-    #[cfg(unix)]
     fn a_failure_that_is_not_a_bound_firing_carries_no_kind() {
-        // The classification must not widen to "this call failed": a wedged adb and a crashed
-        // `uiautomator` both reach the same guards, and only a bound firing means the deadline —
-        // not the device — ended the call.
+        // The classification must not widen to "this call failed": a missing or mis-resolved binary
+        // is the commonest Android setup problem, and read as a bound it becomes a wait polling on
+        // for its whole timeout instead of failing at once. Portable, so the Windows leg — where
+        // that binary is likeliest to be missing — covers this direction too.
         let spawn = run_bounded(
             &mut Command::new("/nonexistent/glass-test-binary"),
             Duration::from_secs(10),
@@ -874,6 +878,14 @@ mod tests {
         .expect_err("spawn must fail");
         assert_eq!(spawn.bound(), None, "{spawn}");
 
+        assert_eq!(GlassError::Backend("device offline".into()).bound(), None);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_child_that_answered_before_a_glass_side_timer_elapsed_is_no_bound_firing() {
+        // `DRAIN_SETTLE` does elapse here, so this is the case that looks most like a bound and is
+        // not one: the child exited on its own, and the deadline never came near.
         let held_open = run_bounded(
             Command::new("/bin/sh").args(["-c", "printf head; { sleep 1; printf tail; } &"]),
             Duration::from_secs(20),
@@ -881,8 +893,6 @@ mod tests {
         )
         .expect_err("an incomplete read is an error");
         assert_eq!(held_open.bound(), None, "{held_open}");
-
-        assert_eq!(GlassError::Backend("device offline".into()).bound(), None);
     }
 
     #[test]

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -195,11 +195,15 @@ pub enum GlassError {
 
     /// A tool glass drove ran and exited non-zero, carrying what it wrote to stderr.
     ///
-    /// `said` is empty when the tool failed without a word — for `uiautomator` that is a crash
-    /// whose trace went to the platform log instead (glass#341), and waiting resolves it where an
-    /// explained failure will not. It is a fact about the tool, not about this message, which the
-    /// tool's own output is otherwise free to imitate (glass#348).
-    #[error("backend error: {call} failed: {said}")]
+    /// `said` is that stderr, trimmed — empty when the tool failed without a word, which for
+    /// `uiautomator` is a crash whose trace went to the platform log instead (glass#341), and
+    /// waiting resolves it where an explained failure will not. Read it through [`Self::tool_said`]
+    /// rather than out of the rendered message, which the tool's own output is free to imitate
+    /// (glass#348). A tool that explains itself on *stdout* reads as silent here.
+    ///
+    /// Not `#[non_exhaustive]`, unlike its sibling [`Self::Bounded`]: every backend that drives an
+    /// external tool raises this legitimately, where only glass's own clock raises a bound.
+    #[error("backend error: `{call}` failed: {said}")]
     ToolFailed { call: String, said: String },
 
     /// A bounded call that ended at one of its bounds instead of at an answer, naming which.
@@ -270,14 +274,17 @@ impl GlassError {
         }
     }
 
-    /// What a tool wrote to stderr before exiting non-zero, if this is a tool that ran at all.
+    /// What a tool wrote to stderr before exiting non-zero, trimmed, if a tool ran at all.
     ///
     /// `Some("")` is the one a backend acts on: a tool that failed saying nothing crashed, and
     /// crashes are worth retrying where a refusal it explained is not. `None` for every other
     /// failure, including a bound firing, and for any variant added later.
+    ///
+    /// Trimmed here and not only at construction, so a producer that forgets cannot turn a crash
+    /// that wrote a bare newline into a refusal glass stops retrying.
     pub fn tool_said(&self) -> Option<&str> {
         match self {
-            GlassError::ToolFailed { said, .. } => Some(said),
+            GlassError::ToolFailed { said, .. } => Some(said.trim()),
             _ => None,
         }
     }
@@ -359,7 +366,7 @@ mod tests {
         // tool which said nothing leaves.
         assert_eq!(
             GlassError::ToolFailed {
-                call: "`adb shell cat /sdcard/x.xml`".into(),
+                call: "adb shell cat /sdcard/x.xml".into(),
                 said: "cat: /sdcard/x.xml: No such file".into(),
             }
             .to_string(),
@@ -367,7 +374,7 @@ mod tests {
         );
         assert_eq!(
             GlassError::ToolFailed {
-                call: "`adb shell uiautomator dump /sdcard/x.xml`".into(),
+                call: "adb shell uiautomator dump /sdcard/x.xml".into(),
                 said: String::new(),
             }
             .to_string(),
@@ -378,10 +385,11 @@ mod tests {
     #[test]
     fn only_a_tool_that_ran_and_said_nothing_reads_as_a_crash() {
         // `Some("")` and `None` are the two a backend must not confuse: one is a tool that failed
-        // without a word, which waiting can resolve, the other is a call that never reached one.
+        // without a word, which waiting can resolve; the other has no stderr to speak for it at
+        // all, a killed call included — [`BoundKind::TimedOut`] ran the tool.
         assert_eq!(
             GlassError::ToolFailed {
-                call: "`adb shell uiautomator dump /sdcard/x.xml`".into(),
+                call: "adb shell uiautomator dump /sdcard/x.xml".into(),
                 said: String::new(),
             }
             .tool_said(),
@@ -389,7 +397,7 @@ mod tests {
         );
         assert_eq!(
             GlassError::ToolFailed {
-                call: "`adb shell cat /sdcard/x.xml`".into(),
+                call: "adb shell cat /sdcard/x.xml".into(),
                 said: "No such file".into(),
             }
             .tool_said(),
@@ -401,9 +409,26 @@ mod tests {
                 kind: BoundKind::TimedOut,
                 message: "adb:shell: no answer within 10s".into(),
             },
+            GlassError::AccessibilityUnavailable("uiautomator dump wrote nothing".into()),
+            GlassError::AccessibilityNotReady("no tree yet".into()),
         ] {
             assert_eq!(e.tool_said(), None, "{e}");
         }
+    }
+
+    #[test]
+    fn a_tool_that_wrote_only_whitespace_still_reads_as_having_said_nothing() {
+        // A crash that manages a bare newline is still a crash. Trimmed on the way out as well as
+        // on the way in, so a producer that forgets cannot turn one into a refusal glass stops
+        // retrying.
+        assert_eq!(
+            GlassError::ToolFailed {
+                call: "adb shell uiautomator dump /sdcard/x.xml".into(),
+                said: "\n  ".into(),
+            }
+            .tool_said(),
+            Some("")
+        );
     }
 
     #[test]
@@ -495,7 +520,7 @@ mod tests {
                 message: "adb:shell: no answer within 10s".into(),
             },
             GlassError::ToolFailed {
-                call: "`adb shell input tap 1 2`".into(),
+                call: "adb shell input tap 1 2".into(),
                 said: String::new(),
             },
         ] {
@@ -524,7 +549,7 @@ mod tests {
                 message: "adb:uiautomator dump: no answer within 20s".into(),
             },
             GlassError::ToolFailed {
-                call: "`adb shell uiautomator dump /sdcard/x.xml`".into(),
+                call: "adb shell uiautomator dump /sdcard/x.xml".into(),
                 said: String::new(),
             },
         ] {

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -186,11 +186,21 @@ pub enum GlassError {
     #[error("{which} permission denied: {remedy}")]
     PermissionDenied { which: String, remedy: String },
 
-    /// A backend failure the backend itself reported. A call that ended at one of glass's own
-    /// bounds is [`Self::Bounded`], which displays identically — classify with [`Self::bound`]
-    /// rather than by matching this variant, which is false for it.
+    /// A backend failure the backend itself reported. Two neighbours display identically and this
+    /// variant is false for both — [`Self::Bounded`] for a call that ended at one of glass's own
+    /// bounds, [`Self::ToolFailed`] for a tool that ran and exited non-zero. Classify with
+    /// [`Self::bound`] and [`Self::tool_said`] rather than by matching this variant.
     #[error("backend error: {0}")]
     Backend(String),
+
+    /// A tool glass drove ran and exited non-zero, carrying what it wrote to stderr.
+    ///
+    /// `said` is empty when the tool failed without a word — for `uiautomator` that is a crash
+    /// whose trace went to the platform log instead (glass#341), and waiting resolves it where an
+    /// explained failure will not. It is a fact about the tool, not about this message, which the
+    /// tool's own output is otherwise free to imitate (glass#348).
+    #[error("backend error: {call} failed: {said}")]
+    ToolFailed { call: String, said: String },
 
     /// A bounded call that ended at one of its bounds instead of at an answer, naming which.
     ///
@@ -239,7 +249,7 @@ impl GlassError {
     /// re-snapshot, recoverable. Dropping it can only make the guard accept more, and what it then
     /// accepts is a write onto the wrong element, reported as `Ok`.
     ///
-    /// Some verdicts cannot be classified at all: Android raises `Backend`, `Bounded` and
+    /// Some verdicts cannot be classified at all: Android raises `ToolFailed`, `Bounded` and
     /// `AccessibilityUnavailable` on *both* sides of the dispatch — its pre-write re-snapshot and
     /// adb handshake fail the same way its post-write read-back does — so no variant-level split
     /// separates them, and the recoverable answer has to win.
@@ -256,6 +266,18 @@ impl GlassError {
     pub fn bound(&self) -> Option<BoundKind> {
         match self {
             GlassError::Bounded { kind, .. } => Some(*kind),
+            _ => None,
+        }
+    }
+
+    /// What a tool wrote to stderr before exiting non-zero, if this is a tool that ran at all.
+    ///
+    /// `Some("")` is the one a backend acts on: a tool that failed saying nothing crashed, and
+    /// crashes are worth retrying where a refusal it explained is not. `None` for every other
+    /// failure, including a bound firing, and for any variant added later.
+    pub fn tool_said(&self) -> Option<&str> {
+        match self {
+            GlassError::ToolFailed { said, .. } => Some(said),
             _ => None,
         }
     }
@@ -328,6 +350,60 @@ mod tests {
             "window not found — the app may not have opened its window yet, or the window glass \
              is targeting is no longer one of its windows"
         );
+    }
+
+    #[test]
+    fn a_tool_failure_reads_exactly_as_the_backend_error_it_replaced() {
+        // The split is a channel for glass, not a message change for the agent — `glass-android`
+        // built this string by hand before it was a variant, down to the trailing space that a
+        // tool which said nothing leaves.
+        assert_eq!(
+            GlassError::ToolFailed {
+                call: "`adb shell cat /sdcard/x.xml`".into(),
+                said: "cat: /sdcard/x.xml: No such file".into(),
+            }
+            .to_string(),
+            "backend error: `adb shell cat /sdcard/x.xml` failed: cat: /sdcard/x.xml: No such file"
+        );
+        assert_eq!(
+            GlassError::ToolFailed {
+                call: "`adb shell uiautomator dump /sdcard/x.xml`".into(),
+                said: String::new(),
+            }
+            .to_string(),
+            "backend error: `adb shell uiautomator dump /sdcard/x.xml` failed: "
+        );
+    }
+
+    #[test]
+    fn only_a_tool_that_ran_and_said_nothing_reads_as_a_crash() {
+        // `Some("")` and `None` are the two a backend must not confuse: one is a tool that failed
+        // without a word, which waiting can resolve, the other is a call that never reached one.
+        assert_eq!(
+            GlassError::ToolFailed {
+                call: "`adb shell uiautomator dump /sdcard/x.xml`".into(),
+                said: String::new(),
+            }
+            .tool_said(),
+            Some("")
+        );
+        assert_eq!(
+            GlassError::ToolFailed {
+                call: "`adb shell cat /sdcard/x.xml`".into(),
+                said: "No such file".into(),
+            }
+            .tool_said(),
+            Some("No such file")
+        );
+        for e in [
+            GlassError::Backend("device offline".into()),
+            GlassError::Bounded {
+                kind: BoundKind::TimedOut,
+                message: "adb:shell: no answer within 10s".into(),
+            },
+        ] {
+            assert_eq!(e.tool_said(), None, "{e}");
+        }
     }
 
     #[test]
@@ -418,6 +494,10 @@ mod tests {
                 kind: BoundKind::TimedOut,
                 message: "adb:shell: no answer within 10s".into(),
             },
+            GlassError::ToolFailed {
+                call: "`adb shell input tap 1 2`".into(),
+                said: String::new(),
+            },
         ] {
             assert!(!e.invoke_fallback_eligible(), "{e}");
         }
@@ -442,6 +522,10 @@ mod tests {
             GlassError::Bounded {
                 kind: BoundKind::TimedOut,
                 message: "adb:uiautomator dump: no answer within 20s".into(),
+            },
+            GlassError::ToolFailed {
+                call: "`adb shell uiautomator dump /sdcard/x.xml`".into(),
+                said: String::new(),
             },
         ] {
             assert!(!e.set_value_failed_after_writing(), "{e}");

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -4,8 +4,12 @@ use thiserror::Error;
 /// [`crate::run_bounded_until`] makes and [`GlassError::Bounded`] carries.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BoundKind {
-    /// The call ran and was killed when its own budget elapsed. The tool may be wedged, so the
-    /// remedies for one apply.
+    /// The call ran and was killed when its effective bound elapsed — its own budget or the
+    /// deadline it shares, whichever was nearer.
+    ///
+    /// It does not say which of the two governed, so a caller that passed a deadline must still
+    /// compare them: its own budget firing is evidence the tool is wedged, and its caller's is
+    /// evidence of nothing at all (glass#341, glass#347).
     TimedOut,
     /// The call never ran: the deadline it shares with the rest of a sequence was already spent.
     /// Nothing was asked, so nothing about the tool is known.
@@ -182,14 +186,22 @@ pub enum GlassError {
     #[error("{which} permission denied: {remedy}")]
     PermissionDenied { which: String, remedy: String },
 
+    /// A backend failure the backend itself reported. A call that ended at one of glass's own
+    /// bounds is [`Self::Bounded`], which displays identically — classify with [`Self::bound`]
+    /// rather than by matching this variant, which is false for it.
     #[error("backend error: {0}")]
     Backend(String),
 
     /// A bounded call that ended at one of its bounds instead of at an answer, naming which.
     ///
-    /// Displayed exactly as [`Self::Backend`], and it is one: the split exists so glass can tell
-    /// its own deadline firing from the tool failing without reading that back out of the message,
-    /// which carries the child's own output verbatim (glass#348).
+    /// Displays exactly as [`Self::Backend`] — an agent reads the same text — but is a distinct
+    /// variant, so glass can tell its own deadline firing from the tool failing without reading
+    /// that back out of the message, which carries the child's own output verbatim (glass#348).
+    ///
+    /// `#[non_exhaustive]` so [`crate::bounded`] stays the only crate that can raise one: a bound
+    /// forged elsewhere — an iOS gRPC deadline, say — would make [`Self::bound`] answer for a
+    /// clock glass does not own.
+    #[non_exhaustive]
     #[error("backend error: {message}")]
     Bounded { kind: BoundKind, message: String },
 
@@ -227,7 +239,7 @@ impl GlassError {
     /// re-snapshot, recoverable. Dropping it can only make the guard accept more, and what it then
     /// accepts is a write onto the wrong element, reported as `Ok`.
     ///
-    /// Some verdicts cannot be classified at all: Android raises `Backend` and
+    /// Some verdicts cannot be classified at all: Android raises `Backend`, `Bounded` and
     /// `AccessibilityUnavailable` on *both* sides of the dispatch — its pre-write re-snapshot and
     /// adb handshake fail the same way its post-write read-back does — so no variant-level split
     /// separates them, and the recoverable answer has to win.
@@ -235,11 +247,12 @@ impl GlassError {
         matches!(self, GlassError::AxValueNotApplied(_))
     }
 
-    /// Which bound ended this call, if a bound did rather than the tool answering.
+    /// Which of glass's own bounds ended this call, if one did rather than the tool answering.
     ///
     /// The question a backend asks before retrying, before offering a wedged-tool remedy, and
     /// before reporting a caller's spent budget as a device failure. `None` for every other
-    /// failure, including ones a bounded call raises for a tool that did answer.
+    /// failure — including ones a bounded call raises for a tool that did answer, and any variant
+    /// added later, which reads as the tool having failed rather than as a bound of glass's.
     pub fn bound(&self) -> Option<BoundKind> {
         match self {
             GlassError::Bounded { kind, .. } => Some(*kind),
@@ -401,6 +414,10 @@ mod tests {
             GlassError::NoActiveSession,
             GlassError::Timeout(10),
             GlassError::Backend("bus died".into()),
+            GlassError::Bounded {
+                kind: BoundKind::TimedOut,
+                message: "adb:shell: no answer within 10s".into(),
+            },
         ] {
             assert!(!e.invoke_fallback_eligible(), "{e}");
         }
@@ -422,6 +439,10 @@ mod tests {
             GlassError::AccessibilityUnavailable("uiautomator dump not ready".into()),
             GlassError::Backend("adb died".into()),
             GlassError::Timeout(10),
+            GlassError::Bounded {
+                kind: BoundKind::TimedOut,
+                message: "adb:uiautomator dump: no answer within 20s".into(),
+            },
         ] {
             assert!(!e.set_value_failed_after_writing(), "{e}");
         }

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -186,20 +186,19 @@ pub enum GlassError {
     #[error("{which} permission denied: {remedy}")]
     PermissionDenied { which: String, remedy: String },
 
-    /// A backend failure the backend itself reported. Two neighbours display identically and this
-    /// variant is false for both — [`Self::Bounded`] for a call that ended at one of glass's own
-    /// bounds, [`Self::ToolFailed`] for a tool that ran and exited non-zero. Classify with
-    /// [`Self::bound`] and [`Self::tool_said`] rather than by matching this variant.
+    /// A backend failure the backend itself reported. [`Self::Bounded`] and [`Self::ToolFailed`]
+    /// display identically and this variant is false for both, so classify with [`Self::bound`]
+    /// and [`Self::tool_said`] rather than by matching it.
     #[error("backend error: {0}")]
     Backend(String),
 
     /// A tool glass drove ran and exited non-zero, carrying what it wrote to stderr.
     ///
     /// `said` is that stderr, trimmed — empty when the tool failed without a word, which for
-    /// `uiautomator` is a crash whose trace went to the platform log instead (glass#341), and
-    /// waiting resolves it where an explained failure will not. Read it through [`Self::tool_said`]
-    /// rather than out of the rendered message, which the tool's own output is free to imitate
-    /// (glass#348). A tool that explains itself on *stdout* reads as silent here.
+    /// `uiautomator` is a crash whose trace went to the platform log instead (glass#341) and
+    /// waiting resolves. Read it through [`Self::tool_said`], never out of the rendered message,
+    /// which the tool's own output can imitate (glass#348). A tool that explains itself on
+    /// *stdout* reads as silent here.
     ///
     /// Not `#[non_exhaustive]`, unlike its sibling [`Self::Bounded`]: every backend that drives an
     /// external tool raises this legitimately, where only glass's own clock raises a bound.
@@ -281,7 +280,7 @@ impl GlassError {
     /// failure, including a bound firing, and for any variant added later.
     ///
     /// Trimmed here and not only at construction, so a producer that forgets cannot turn a crash
-    /// that wrote a bare newline into a refusal glass stops retrying.
+    /// into a refusal.
     pub fn tool_said(&self) -> Option<&str> {
         match self {
             GlassError::ToolFailed { said, .. } => Some(said.trim()),
@@ -418,9 +417,8 @@ mod tests {
 
     #[test]
     fn a_tool_that_wrote_only_whitespace_still_reads_as_having_said_nothing() {
-        // A crash that manages a bare newline is still a crash. Trimmed on the way out as well as
-        // on the way in, so a producer that forgets cannot turn one into a refusal glass stops
-        // retrying.
+        // A crash that manages a bare newline is still a crash — trimmed on the way out as well
+        // as on the way in, so removing either leaves the other holding this.
         assert_eq!(
             GlassError::ToolFailed {
                 call: "adb shell uiautomator dump /sdcard/x.xml".into(),

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -1,5 +1,17 @@
 use thiserror::Error;
 
+/// Which bound ended a call that produced no answer — the distinction
+/// [`crate::run_bounded_until`] makes and [`GlassError::Bounded`] carries.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BoundKind {
+    /// The call ran and was killed when its own budget elapsed. The tool may be wedged, so the
+    /// remedies for one apply.
+    TimedOut,
+    /// The call never ran: the deadline it shares with the rest of a sequence was already spent.
+    /// Nothing was asked, so nothing about the tool is known.
+    NotStarted,
+}
+
 /// All fallible glass-core operations return this error.
 ///
 /// Variants map to the actionable error kinds the MCP layer surfaces to the
@@ -173,6 +185,14 @@ pub enum GlassError {
     #[error("backend error: {0}")]
     Backend(String),
 
+    /// A bounded call that ended at one of its bounds instead of at an answer, naming which.
+    ///
+    /// Displayed exactly as [`Self::Backend`], and it is one: the split exists so glass can tell
+    /// its own deadline firing from the tool failing without reading that back out of the message,
+    /// which carries the child's own output verbatim (glass#348).
+    #[error("backend error: {message}")]
+    Bounded { kind: BoundKind, message: String },
+
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 }
@@ -213,6 +233,18 @@ impl GlassError {
     /// separates them, and the recoverable answer has to win.
     pub fn set_value_failed_after_writing(&self) -> bool {
         matches!(self, GlassError::AxValueNotApplied(_))
+    }
+
+    /// Which bound ended this call, if a bound did rather than the tool answering.
+    ///
+    /// The question a backend asks before retrying, before offering a wedged-tool remedy, and
+    /// before reporting a caller's spent budget as a device failure. `None` for every other
+    /// failure, including ones a bounded call raises for a tool that did answer.
+    pub fn bound(&self) -> Option<BoundKind> {
+        match self {
+            GlassError::Bounded { kind, .. } => Some(*kind),
+            _ => None,
+        }
     }
 
     /// Runtime "this operation is unsupported on the active backend" error, worded

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -7,13 +7,13 @@
 // Modules are added task-by-task.
 
 pub mod error;
-pub use error::{GlassError, Result};
+pub use error::{BoundKind, GlassError, Result};
 
 pub mod toolpath;
 pub use toolpath::tool_path;
 
 pub mod bounded;
-pub use bounded::{NOT_STARTED, TIMED_OUT, run_bounded, run_bounded_until, run_bounded_with_stdin};
+pub use bounded::{run_bounded, run_bounded_until, run_bounded_with_stdin};
 
 pub mod set_value;
 pub use set_value::{read_back_confirms, typed_clear_landed, typed_text_landed};


### PR DESCRIPTION
Closes #348.

## The defect

Two classifiers in `glass-android` decided what a failure *meant* by substring-matching the rendered error message — and those messages are composed partly from the device's own output, so the device could answer for glass.

| Classifier | Asked | By matching | Wrong answer means |
|---|---|---|---|
| `bound_fired` | did a deadline fire? | `"no answer within"` / `"was not started"` anywhere in the message | a device failure surfaces as `AccessibilityNotReady`, which `glass_wait_for_element` polls through — a dead emulator read as a slow app |
| `died_unexplained` | did the tool exit saying nothing? | message ends in `"failed:"` | a device that *explained itself* is retried, its only reason replaced with "without saying why; its reason, if any, is in logcat" |

Both are reachable. The first is proven red on master by `a_device_failure_that_quotes_the_deadline_wording_is_still_a_broken_device`; the second by `a_device_that_explained_itself_is_not_a_crash_however_its_message_ends`.

Prose could not be repaired in place. Any glass-owned phrase is equally spoofable, because the device's stderr is always the *tail* of the message.

## The change

Both facts were structural at the point of failure and were being discarded into a string:

- `run_bounded_until` knows which bound fired → `GlassError::Bounded { kind: BoundKind, message }`, read via `bound()`.
- `exit_error` knows whether stderr was empty → `GlassError::ToolFailed { call, said }`, read via `tool_said()`. `said` **is** the stderr, so `is_empty()` cannot be imitated by its contents.

`TIMED_OUT` / `NOT_STARTED` are no longer public — their documented purpose was to let a caller recognise a bound without matching prose it doesn't own, and the kind does that properly.

**No agent-visible text changes.** Both variants Display byte-identically to the strings they replace, trailing space included, pinned by a test.

## Also fixed: the uninstall gate

`a11y_service::is_signature_mismatch` scanned the whole rendered message, which names the argv, which carries the caller-supplied APK path (`GLASS_ANDROID_A11Y_APK`). An APK under a directory quoting the phrase made **any** install failure take the uninstall branch. Same defect class, and the repo already forbids it one file over — `AdbOp::for_args` documents that argv must never be scanned for substrings, citing an APK path.

## Verification

Every mechanism verified by probe rather than by inspection — each fix has a test that dies when the mechanism does:

| Probe | Result |
|---|---|
| `with_adb_hint` rebuilds as `Backend`, dropping the kind | 4 tests fail |
| runner reports `NotStarted` untyped | 3 fail — one by retrying a spent deadline for the full 30s budget |
| `exit_error` fed `out.stdout` instead of `out.stderr` | 1 fails |
| `died_unexplained` widened to `tool_said().is_some()` | 4 fail |
| `died_unexplained` reverted to the prose match | 2 fail |
| uninstall gate reads the whole message again | 1 fails |

Test fixtures were the other half of the problem: they *described* failures in the same prose the matchers read, so they measured each matcher's agreement with itself. They now come from real `run_bounded` / `Adb::output` failures, and `a_tool_that_exits_non_zero_carries_its_stderr_and_not_its_stdout` binds the producer end to end.

Gate run against all three targets CI builds, not just the host.

## Not changed

No CHANGELOG entry: no message an agent reads changes, and neither misclassification has been observed in the wild — both need device output that imitates glass's own wording.