### PR TITLE
fix(build): make a local build's version name the commit it was built from

### DIFF
--- a/crates/glass-mcp/build.rs
+++ b/crates/glass-mcp/build.rs
@@ -39,16 +39,15 @@ fn main() {
 /// Declare the git files a local build's version is derived from, so cargo re-runs this script when
 /// the commit moves.
 ///
-/// Without them the only triggers are `build.rs` itself and the two env vars above, so a rebuild
-/// after committing keeps the version string of whatever commit last forced a re-run: a binary was
-/// observed reporting `1.1.0-84-g96fac4f` while its own tree was 17 commits further on. A CI tag
-/// build takes its version from `GITHUB_REF_NAME` and does not depend on any of this.
+/// Without them the only triggers are `build.rs` and the two env vars above, so a rebuild after
+/// committing keeps an older commit's version — observed reporting `1.1.0-84-g96fac4f` from a tree
+/// 17 commits further on. A CI tag build reads `GITHUB_REF_NAME` and none of this.
 ///
-/// The `-dirty` suffix reflects the working tree, which no declared path can stand in for, so an
-/// uncommitted edit still needs this file touched to surface.
+/// `-dirty` reflects the working tree, which no declared path stands in for, so an uncommitted edit
+/// still needs this file touched to surface.
 fn watch_git_head() {
-    // HEAD moves on checkout; the ref it names moves on commit; `packed-refs` is where a gc'd tag
-    // or branch ends up, so `describe` can read its answer from there instead.
+    // HEAD moves on checkout, the ref it names moves on commit, and a gc'd branch or tag moves into
+    // `packed-refs`, where `describe` reads it instead.
     watch_git_path("HEAD");
     watch_git_path("packed-refs");
     // A detached HEAD names no ref, and HEAD alone already covers it.
@@ -59,10 +58,9 @@ fn watch_git_head() {
 
 /// Declare one path inside the git directory, if it is there.
 ///
-/// Resolved with `--git-path` rather than joined onto `.git/`: in a worktree the refs live in the
-/// common directory, not beside that worktree's HEAD. A path that does not exist is skipped
-/// deliberately — cargo re-runs a build script unconditionally when a declared path is missing, and
-/// a source tarball with no VCS would take that penalty on every build for a version it never reads.
+/// Resolve with `--git-path`, not by joining onto `.git/`: a worktree keeps its refs in the common
+/// directory. Skip a path that does not exist — cargo re-runs a build script unconditionally when a
+/// declared path is missing, so a checkout with no VCS would rebuild every time.
 fn watch_git_path(name: &str) {
     let Some(path) = git_output(&["rev-parse", "--git-path", name]) else {
         return;
@@ -73,7 +71,7 @@ fn watch_git_path(name: &str) {
 }
 
 /// Run a git command and return its trimmed stdout, or `None` if git is absent or the command
-/// failed. Every caller has a working answer for "this is not a git checkout".
+/// failed.
 fn git_output(args: &[&str]) -> Option<String> {
     let out = Command::new("git").args(args).output().ok()?;
     out.status
@@ -96,7 +94,7 @@ fn glass_version() -> String {
     }
     // Local builds: derive from the nearest tag (with a `-dirty` / commit suffix when not exactly
     // on a tag), so a dev binary reports an honest version rather than 0.0.0. `watch_git_head`
-    // declares the files this reads, so the answer moves with the commit.
+    // declares the files this reads.
     if let Some(d) = git_output(&["describe", "--tags", "--always", "--dirty"])
         && !d.is_empty()
     {

--- a/crates/glass-mcp/build.rs
+++ b/crates/glass-mcp/build.rs
@@ -7,6 +7,8 @@
 //! Mirrors the validated probe at tools/windows-validation/build.rs.
 use embed_manifest::manifest::{DpiAwareness, Setting};
 use embed_manifest::{embed_manifest, new_manifest};
+use std::path::Path;
+use std::process::Command;
 
 fn main() {
     if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
@@ -31,6 +33,52 @@ fn main() {
     println!("cargo:rerun-if-env-changed=GITHUB_REF_NAME");
     println!("cargo:rerun-if-env-changed=GITHUB_REF_TYPE");
     println!("cargo:rerun-if-changed=build.rs");
+    watch_git_head();
+}
+
+/// Declare the git files a local build's version is derived from, so cargo re-runs this script when
+/// the commit moves.
+///
+/// Without them the only triggers are `build.rs` itself and the two env vars above, so a rebuild
+/// after committing keeps the version string of whatever commit last forced a re-run: a binary was
+/// observed reporting `1.1.0-84-g96fac4f` while its own tree was 17 commits further on. A CI tag
+/// build takes its version from `GITHUB_REF_NAME` and does not depend on any of this.
+///
+/// The `-dirty` suffix reflects the working tree, which no declared path can stand in for, so an
+/// uncommitted edit still needs this file touched to surface.
+fn watch_git_head() {
+    // HEAD moves on checkout; the ref it names moves on commit; `packed-refs` is where a gc'd tag
+    // or branch ends up, so `describe` can read its answer from there instead.
+    watch_git_path("HEAD");
+    watch_git_path("packed-refs");
+    // A detached HEAD names no ref, and HEAD alone already covers it.
+    if let Some(head_ref) = git_output(&["symbolic-ref", "-q", "HEAD"]) {
+        watch_git_path(&head_ref);
+    }
+}
+
+/// Declare one path inside the git directory, if it is there.
+///
+/// Resolved with `--git-path` rather than joined onto `.git/`: in a worktree the refs live in the
+/// common directory, not beside that worktree's HEAD. A path that does not exist is skipped
+/// deliberately — cargo re-runs a build script unconditionally when a declared path is missing, and
+/// a source tarball with no VCS would take that penalty on every build for a version it never reads.
+fn watch_git_path(name: &str) {
+    let Some(path) = git_output(&["rev-parse", "--git-path", name]) else {
+        return;
+    };
+    if Path::new(&path).exists() {
+        println!("cargo:rerun-if-changed={path}");
+    }
+}
+
+/// Run a git command and return its trimmed stdout, or `None` if git is absent or the command
+/// failed. Every caller has a working answer for "this is not a git checkout".
+fn git_output(args: &[&str]) -> Option<String> {
+    let out = Command::new("git").args(args).output().ok()?;
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
 }
 
 /// Resolve the version string embedded at build time. Strips a leading `v` so `v1.0.1` → `1.0.1`.
@@ -47,16 +95,12 @@ fn glass_version() -> String {
         }
     }
     // Local builds: derive from the nearest tag (with a `-dirty` / commit suffix when not exactly
-    // on a tag), so a dev binary reports an honest version rather than 0.0.0.
-    if let Ok(out) = std::process::Command::new("git")
-        .args(["describe", "--tags", "--always", "--dirty"])
-        .output()
-        && out.status.success()
+    // on a tag), so a dev binary reports an honest version rather than 0.0.0. `watch_git_head`
+    // declares the files this reads, so the answer moves with the commit.
+    if let Some(d) = git_output(&["describe", "--tags", "--always", "--dirty"])
+        && !d.is_empty()
     {
-        let d = String::from_utf8_lossy(&out.stdout).trim().to_string();
-        if !d.is_empty() {
-            return d.strip_prefix('v').unwrap_or(&d).to_string();
-        }
+        return d.strip_prefix('v').unwrap_or(&d).to_string();
     }
     // No tag and no git (e.g. a source tarball with no VCS): fall back to the crate version.
     env!("CARGO_PKG_VERSION").to_string()


### PR DESCRIPTION
`GLASS_VERSION` is derived from `git describe` for a local build, but the only things that made cargo re-run the script were `build.rs` itself and the two `GITHUB_REF_*` variables. Neither moves when you commit, so a rebuild kept the version string of whatever commit last forced a re-run.

Observed at `1.1.0-84-g96fac4f` on a tree that was at `1.1.0-101-g36eafb9` — a binary naming a commit **17 behind the code inside it**. That string is reported by `--version`, `doctor` and the MCP handshake, and it is how a pre-release smoke report identifies what it tested, which is the point of printing it at all.

## The change

The script now declares HEAD, `packed-refs`, and the ref HEAD names.

- Resolved through `git rev-parse --git-path`, so a **worktree** — whose refs live in the common directory rather than beside its own HEAD — resolves correctly.
- A path that is absent is **skipped rather than declared**: cargo re-runs a build script unconditionally when a declared path is missing, so a source tarball with no VCS would otherwise pay that on every build, for a version it never reads.
- A detached HEAD names no ref; HEAD alone already covers it.

A CI **tag build is unaffected** — it takes its version from `GITHUB_REF_NAME` and reads none of this.

## Verification

Proved with an **empty commit**, which changes nothing on disk but the ref, so only the new `rerun-if-changed` can make the version move:

```
1.1.0-102-gfa80bd6   ->   1.1.0-103-gaf9da3c
```

Before this change the script would not have re-run at all. And a no-change rebuild still finishes in **0.1s without recompiling**, twice in a row, so no unconditional re-run was introduced — the failure mode the skipped-if-absent rule exists to avoid.

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test -p glass-mcp` (313 passed) are all clean.

## Known limit

The `-dirty` suffix reflects the working tree, which no declared path stands in for, so an uncommitted edit still needs `build.rs` touched to surface. Documented in the function's own doc comment rather than left to be rediscovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)