### PR TITLE
fix(ios): say the element is gone when the write replaced the screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,16 @@ internal refactors, CI, or test-only changes.
   Android paths have no such live check.
 
 ### Fixed
+- On the iOS Simulator, a `glass_set_value` whose own write replaced the screen now reports the
+  element as gone rather than as changed. Typing into a field that navigates — a search box is the
+  ordinary case — replaces the tree the element was addressed in, and glass answered `element #N
+  changed since the snapshot; re-snapshot`. That reads as an instruction to re-address that id, and
+  the write it would have repeated has already landed: measured on the Simulator, typing into
+  Settings' search field takes the tree from 16 elements to 5, the field is no longer in it, and the
+  text is on screen. glass now asks whether anything in the tree still carries the element's role
+  and name — the question Android has asked since it learned the same lesson — and where nothing
+  does, says the element is gone and to look at where the app is now instead of writing again. When
+  a write is refused has not changed; only what the refusal is called.
 - A native Android click or `set_value` through the optional on-device companion no longer acts on a
   different element than the one you named when the snapshot was truncated. glass numbered elements
   by their position in the tree it kept and dispatched the action by that number, but the companion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,16 +200,18 @@ internal refactors, CI, or test-only changes.
   Android paths have no such live check.
 
 ### Fixed
-- On the iOS Simulator, a `glass_set_value` whose own write replaced the screen now reports the
-  element as gone rather than as changed. Typing into a field that navigates — a search box is the
-  ordinary case — replaces the tree the element was addressed in, and glass answered `element #N
-  changed since the snapshot; re-snapshot`. That reads as an instruction to re-address that id, and
-  the write it would have repeated has already landed: measured on the Simulator, typing into
-  Settings' search field takes the tree from 16 elements to 5, the field is no longer in it, and the
-  text is on screen. glass now asks whether anything in the tree still carries the element's role
-  and name — the question Android has asked since it learned the same lesson — and where nothing
-  does, says the element is gone and to look at where the app is now instead of writing again. When
-  a write is refused has not changed; only what the refusal is called.
+- On the iOS Simulator, a `glass_set_value` that cannot confirm its write now distinguishes an
+  element that moved from one that is no longer there. Both used to come back as `element #N changed
+  since the snapshot; re-snapshot`, which tells you to re-address that id — the wrong advice when
+  the screen the element was on has been replaced, because the id now belongs to something else and
+  the write it would repeat has already landed. Where nothing in the tree still carries the
+  element's role and name, glass now says the element is gone and to look at where the app is now.
+  Android has answered this way since it learned the same lesson.
+- An accessibility read that stopped early can no longer report an element as gone. "Gone" states
+  that nothing carries the element's role and name any more, which a tree cut short by the element
+  cap — or missing a subtree a failed child read dropped — only shows for the part it covered. Such
+  a read now reports the element as changed, which sends you to re-snapshot rather than to conclude
+  the screen was replaced. Affects Android as well as iOS.
 - A native Android click or `set_value` through the optional on-device companion no longer acts on a
   different element than the one you named when the snapshot was truncated. glass numbered elements
   by their position in the tree it kept and dispatched the action by that number, but the companion

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -329,11 +329,11 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
                 t.limit_value,
                 t.limit.label(),
             )),
-            None => drifted(after_tree, target),
+            None => target.drifted(after_tree),
         });
     };
     if !target.matches(node.role, node.name.as_deref()) || !node.states.editable {
-        return Err(drifted(after_tree, target));
+        return Err(target.drifted(after_tree));
     }
     let landed = if text.is_empty() {
         typed_clear_landed(node.value.as_deref())
@@ -502,32 +502,6 @@ impl Default for AndroidA11y {
     }
 }
 
-/// Whether any node in `tree` still presents as `target` — same role and name, wherever it sits.
-/// Bounds and value are excluded: both move under a live app without the control going anywhere.
-fn still_on_screen(tree: &AxTree, target: &AxTarget) -> bool {
-    fn walk(node: &AxNode, target: &AxTarget) -> bool {
-        target.matches(node.role, node.name.as_deref())
-            || node.children.iter().any(|c| walk(c, target))
-    }
-    walk(&tree.root, target)
-}
-
-/// Which of the two disagreements a tree that no longer agrees with `target` has.
-///
-/// `AxElementChanged` sends the reader looking for where the element went, which is worth doing
-/// only while it is still somewhere; nothing carrying its role and name means the screen was
-/// replaced or the app that drew it restarted (glass#323).
-///
-/// Both Android readers get this. Do not tighten [`still_on_screen`] to include bounds or value:
-/// `a11y_service`'s relaxation needs `AxElementChanged` in every case it can relax.
-fn drifted(tree: &AxTree, target: &AxTarget) -> GlassError {
-    if still_on_screen(tree, target) {
-        GlassError::AxElementChanged(target.id.0)
-    } else {
-        GlassError::AxElementGone(target.id.0)
-    }
-}
-
 /// Find `target.id` and reject a tree that drifted under it — shared by [`editable_target`]
 /// and the service reader's `invoke`, which needs the same rejection without the editable check.
 ///
@@ -541,7 +515,7 @@ pub(crate) fn fingerprinted<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&
         || !target.bounds_consistent(node.bounds, 8)
         || !target.value_consistent(node.value.as_deref())
     {
-        return Err(drifted(tree, target));
+        return Err(target.drifted(tree));
     }
     Ok(node)
 }

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -305,8 +305,8 @@ fn dump_until_ready(
 /// what is on screen. Raising the soft keyboard does not: measured on the dogfood AVD with
 /// `mInputShown=true`, `uiautomator dump` emits the focused window only and no IME window, so the
 /// keyboard cannot shift ids. A tap that navigates — Settings' search entry opens a different
-/// window — does shift them, so a mismatch is [`GlassError::AxElementChanged`] ("re-snapshot")
-/// rather than a claim about the write.
+/// window — does shift them, so a mismatch is a claim about the tree rather than about the write;
+/// [`AxTarget::drift_error`] decides which of the two it is.
 ///
 /// Role and name are checked but bounds deliberately are not, unlike the pre-write
 /// [`locate_editable_target`]: the IME reflows the layout under the field it is typing into, so a
@@ -329,11 +329,11 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
                 t.limit_value,
                 t.limit.label(),
             )),
-            None => target.drifted(after_tree),
+            None => target.drift_error(after_tree),
         });
     };
     if !target.matches(node.role, node.name.as_deref()) || !node.states.editable {
-        return Err(target.drifted(after_tree));
+        return Err(target.drift_error(after_tree));
     }
     let landed = if text.is_empty() {
         typed_clear_landed(node.value.as_deref())
@@ -505,8 +505,8 @@ impl Default for AndroidA11y {
 /// Find `target.id` and reject a tree that drifted under it — shared by [`editable_target`]
 /// and the service reader's `invoke`, which needs the same rejection without the editable check.
 ///
-/// An id that resolves to nothing stays [`GlassError::AxElementNotFound`]; [`drifted`] classifies
-/// only an id occupied by something unrelated.
+/// An id that resolves to nothing stays [`GlassError::AxElementNotFound`];
+/// [`AxTarget::drift_error`] classifies only an id occupied by something unrelated.
 pub(crate) fn fingerprinted<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&'a AxNode> {
     let node = tree
         .find(target.id)
@@ -515,15 +515,16 @@ pub(crate) fn fingerprinted<'a>(tree: &'a AxTree, target: &AxTarget) -> Result<&
         || !target.bounds_consistent(node.bounds, 8)
         || !target.value_consistent(node.value.as_deref())
     {
-        return Err(target.drifted(tree));
+        return Err(target.drift_error(tree));
     }
     Ok(node)
 }
 
 /// Re-resolve `target` in an already-numbered `tree` and return the node only if it is still the
-/// element that was addressed and still editable. Errors specifically when the target is gone
-/// (`AxElementNotFound`), has drifted in role/name/bounds/value (`AxElementChanged`), or is not
-/// editable (`AxElementNotEditable`).
+/// element that was addressed and still editable. Errors specifically when the id resolves to
+/// nothing (`AxElementNotFound`), when it has drifted in role/name/bounds/value
+/// (`AxElementChanged`, or `AxElementGone` where nothing in the tree presents as it — see
+/// [`AxTarget::drift_error`]), or when it is not editable (`AxElementNotEditable`).
 ///
 /// Both Android readers' `set_value` guards route through this — the check that stops a write
 /// landing on whatever inherited the id between the snapshot the caller read and the one the write

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -800,12 +800,11 @@ impl AxTarget {
     }
 
     /// Whether any node in `tree` still presents as this target — same role and name, wherever it
-    /// sits. Bounds and value are excluded: both move under a live app without the control going
-    /// anywhere.
+    /// sits.
     ///
-    /// Do not tighten this to include bounds or value. Android's service reader relaxes a moved
-    /// control back into a write, and that relaxation needs [`Self::drifted`] to answer
-    /// `AxElementChanged` in every case it can relax.
+    /// Do not tighten this to include bounds or value: both move under a live app without the
+    /// control going anywhere, and Android's service reader relaxes a moved control back into a
+    /// write, which needs [`Self::drifted`] to answer `AxElementChanged` in every case it can relax.
     pub fn still_on_screen(&self, tree: &AxTree) -> bool {
         fn walk(node: &AxNode, target: &AxTarget) -> bool {
             target.matches(node.role, node.name.as_deref())
@@ -816,15 +815,13 @@ impl AxTarget {
 
     /// Which of the two disagreements a tree that no longer agrees with this target has.
     ///
-    /// [`GlassError::AxElementChanged`] sends the reader looking for where the element went, which
-    /// is worth doing only while it is still somewhere. Nothing carrying its role and name means
-    /// the screen was replaced or the app that drew it restarted (glass#323), and re-addressing
-    /// that id would land on whatever now occupies it — for a `set_value` read-back, that is how a
-    /// write that already landed gets typed a second time.
+    /// [`GlassError::AxElementChanged`] sends the reader looking for where the element went, worth
+    /// doing only while it is still somewhere. Nothing carrying its role and name means the screen
+    /// was replaced or the app that drew it restarted (glass#323); telling that caller to
+    /// re-address the id is how a `set_value` read-back retypes a write that already landed.
     ///
-    /// Shared rather than per-backend: both Android readers and iOS ask this same question, and
-    /// the two implementations had already drifted apart once — Android learned to tell the cases
-    /// apart while iOS went on calling every disagreement `AxElementChanged`.
+    /// Keep this shared. Android and iOS ask the same question, and per-backend copies drifted
+    /// apart once already — Android learned to tell the cases apart, iOS did not.
     pub fn drifted(&self, tree: &AxTree) -> GlassError {
         if self.still_on_screen(tree) {
             GlassError::AxElementChanged(self.id.0)
@@ -2026,8 +2023,7 @@ mod tests {
 
     #[test]
     fn a_target_still_on_screen_is_changed_not_gone() {
-        // Renumbered, not removed: re-snapshotting finds it again, which is what `AxElementChanged`
-        // tells the caller to do.
+        // Renumbered, not removed — re-snapshotting finds it again.
         let tree = drift_tree(vec![
             leaf(AxRole::Label, "Heading"),
             leaf(AxRole::TextField, "Note"),
@@ -2041,8 +2037,7 @@ mod tests {
 
     #[test]
     fn a_target_no_longer_anywhere_is_gone_not_changed() {
-        // The screen was replaced. Telling the caller to re-address that id would send a set_value
-        // read-back to retype a write that already landed.
+        // The screen was replaced.
         let tree = drift_tree(vec![leaf(AxRole::Label, "No Results")]);
         assert!(!drift_target().still_on_screen(&tree));
         assert!(matches!(

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -548,6 +548,16 @@ pub struct AxTree {
 }
 
 impl AxTree {
+    /// Whether this tree describes everything the backend walked — no bound stopped it early and
+    /// no child read dropped a subtree.
+    ///
+    /// Both fields, because they are independent: a tree can hit no cap at all and still be missing
+    /// a subtree.
+    #[must_use]
+    pub fn is_complete(&self) -> bool {
+        self.truncated.is_none() && self.unreadable == 0
+    }
+
     /// A complete (non-truncated) tree. Callers still run [`AxTree::assign_ids`]. A backend
     /// that stopped early sets [`AxTree::truncated`] afterward.
     pub fn new(root: AxNode) -> AxTree {
@@ -799,13 +809,15 @@ impl AxTarget {
         self.role == role && self.name.as_deref() == name
     }
 
-    /// Whether any node in `tree` still presents as this target — same role and name, wherever it
-    /// sits.
+    /// Whether any node in `tree` carries this target's role and name, wherever it sits. Says
+    /// nothing about visibility: a scrolled-away row counts.
     ///
     /// Do not tighten this to include bounds or value: both move under a live app without the
     /// control going anywhere, and Android's service reader relaxes a moved control back into a
-    /// write, which needs [`Self::drifted`] to answer `AxElementChanged` in every case it can relax.
-    pub fn still_on_screen(&self, tree: &AxTree) -> bool {
+    /// write, which needs [`Self::drift_error`] to answer `AxElementChanged` in every case it can
+    /// relax. Pinned by `a_relaxable_move_is_never_reported_as_gone` below, and from the other side
+    /// by `a11y_service`'s `a_target_that_only_moved_is_actuated_where_it_now_is`.
+    fn still_present(&self, tree: &AxTree) -> bool {
         fn walk(node: &AxNode, target: &AxTarget) -> bool {
             target.matches(node.role, node.name.as_deref())
                 || node.children.iter().any(|c| walk(c, target))
@@ -820,10 +832,16 @@ impl AxTarget {
     /// was replaced or the app that drew it restarted (glass#323); telling that caller to
     /// re-address the id is how a `set_value` read-back retypes a write that already landed.
     ///
-    /// Keep this shared. Android and iOS ask the same question, and per-backend copies drifted
-    /// apart once already — Android learned to tell the cases apart, iOS did not.
-    pub fn drifted(&self, tree: &AxTree) -> GlassError {
-        if self.still_on_screen(tree) {
+    /// An incomplete tree cannot support that second answer: it shows absence only for the part it
+    /// kept, so one that is not [`AxTree::is_complete`] gets the recoverable `AxElementChanged`.
+    ///
+    /// Keep this shared. The two snapshot-tree backends ask the same question, and their
+    /// `verify_write` twins drifted apart once already — Android learned to tell the cases apart in
+    /// glass#330, iOS not until glass#360. The desktop readers cannot use it: they re-resolve
+    /// against live platform elements and never hold an `AxTree` to search.
+    #[must_use]
+    pub fn drift_error(&self, tree: &AxTree) -> GlassError {
+        if self.still_present(tree) || !tree.is_complete() {
             GlassError::AxElementChanged(self.id.0)
         } else {
             GlassError::AxElementGone(self.id.0)
@@ -2022,15 +2040,14 @@ mod tests {
     }
 
     #[test]
-    fn a_target_still_on_screen_is_changed_not_gone() {
+    fn a_target_still_present_is_changed_not_gone() {
         // Renumbered, not removed — re-snapshotting finds it again.
         let tree = drift_tree(vec![
             leaf(AxRole::Label, "Heading"),
             leaf(AxRole::TextField, "Note"),
         ]);
-        assert!(drift_target().still_on_screen(&tree));
         assert!(matches!(
-            drift_target().drifted(&tree),
+            drift_target().drift_error(&tree),
             GlassError::AxElementChanged(1)
         ));
     }
@@ -2039,19 +2056,77 @@ mod tests {
     fn a_target_no_longer_anywhere_is_gone_not_changed() {
         // The screen was replaced.
         let tree = drift_tree(vec![leaf(AxRole::Label, "No Results")]);
-        assert!(!drift_target().still_on_screen(&tree));
         assert!(matches!(
-            drift_target().drifted(&tree),
+            drift_target().drift_error(&tree),
             GlassError::AxElementGone(1)
         ));
     }
 
     #[test]
-    fn a_same_named_element_of_another_role_does_not_keep_a_target_on_screen() {
+    fn a_same_named_element_of_another_role_is_not_the_target() {
         // Role and name together, not name alone — otherwise a heading that happens to repeat the
         // field's label would report a replaced screen as merely renumbered.
         let tree = drift_tree(vec![leaf(AxRole::Label, "Note")]);
-        assert!(!drift_target().still_on_screen(&tree));
+        assert!(matches!(
+            drift_target().drift_error(&tree),
+            GlassError::AxElementGone(1)
+        ));
+    }
+
+    #[test]
+    fn a_relaxable_move_is_never_reported_as_gone() {
+        // The tightening `still_present`'s doc forbids, pinned in this crate rather than only from
+        // `a11y_service`: every node that reader relaxes back into a write matches on role and name
+        // while differing in bounds and value, so folding either into the walk kills the relaxation.
+        let mut moved = leaf(AxRole::TextField, "Note");
+        moved.bounds = Some(AxRect {
+            x: 0,
+            y: 400,
+            width: 200,
+            height: 40,
+        });
+        moved.value = Some("typed since the snapshot".into());
+        let tree = drift_tree(vec![moved]);
+        let mut target = drift_target();
+        target.bounds = Some(AxRect {
+            x: 0,
+            y: 0,
+            width: 200,
+            height: 40,
+        });
+        target.value = Some("before the write".into());
+        assert!(matches!(
+            target.drift_error(&tree),
+            GlassError::AxElementChanged(1)
+        ));
+    }
+
+    #[test]
+    fn an_incomplete_tree_never_reports_the_target_gone() {
+        // Both fields, because they are independent: a tree can hit no cap and still drop a subtree.
+        let replaced = || drift_tree(vec![leaf(AxRole::Label, "No Results")]);
+        let mut capped = replaced();
+        capped.truncated = Some(Truncation {
+            limit: TruncationLimit::Nodes,
+            limit_value: 1,
+            nodes_walked: 1,
+        });
+        assert!(matches!(
+            drift_target().drift_error(&capped),
+            GlassError::AxElementChanged(1)
+        ));
+        let mut dropped = replaced();
+        dropped.unreadable = 1;
+        assert!(matches!(
+            drift_target().drift_error(&dropped),
+            GlassError::AxElementChanged(1)
+        ));
+        // The same tree, complete, is the case that may answer gone — otherwise this test would
+        // pass against a `drift_error` that never says gone at all.
+        assert!(matches!(
+            drift_target().drift_error(&replaced()),
+            GlassError::AxElementGone(1)
+        ));
     }
 
     #[test]

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -550,9 +550,6 @@ pub struct AxTree {
 impl AxTree {
     /// Whether this tree describes everything the backend walked — no bound stopped it early and
     /// no child read dropped a subtree.
-    ///
-    /// Both fields, because they are independent: a tree can hit no cap at all and still be missing
-    /// a subtree.
     #[must_use]
     pub fn is_complete(&self) -> bool {
         self.truncated.is_none() && self.unreadable == 0
@@ -809,14 +806,14 @@ impl AxTarget {
         self.role == role && self.name.as_deref() == name
     }
 
-    /// Whether any node in `tree` carries this target's role and name, wherever it sits. Says
-    /// nothing about visibility: a scrolled-away row counts.
+    /// Whether any node in `tree` carries this target's role and name, wherever it sits.
     ///
     /// Do not tighten this to include bounds or value: both move under a live app without the
     /// control going anywhere, and Android's service reader relaxes a moved control back into a
     /// write, which needs [`Self::drift_error`] to answer `AxElementChanged` in every case it can
-    /// relax. Pinned by `a_relaxable_move_is_never_reported_as_gone` below, and from the other side
-    /// by `a11y_service`'s `a_target_that_only_moved_is_actuated_where_it_now_is`.
+    /// relax. Pinned by `a_relaxable_move_is_never_reported_as_gone` below and, across the crate
+    /// boundary the rule actually spans, by `a11y_service`'s
+    /// `a_target_that_only_moved_is_actuated_where_it_now_is`.
     fn still_present(&self, tree: &AxTree) -> bool {
         fn walk(node: &AxNode, target: &AxTarget) -> bool {
             target.matches(node.role, node.name.as_deref())
@@ -2020,7 +2017,7 @@ mod tests {
         }
     }
 
-    /// A target naming the `TextField "Note"` that `drift_tree` puts on screen.
+    /// A target naming a `TextField "Note"` — in some `drift_tree` trees below, absent from others.
     fn drift_target() -> AxTarget {
         AxTarget {
             id: AxNodeId(1),
@@ -2041,7 +2038,7 @@ mod tests {
 
     #[test]
     fn a_target_still_present_is_changed_not_gone() {
-        // Renumbered, not removed — re-snapshotting finds it again.
+        // Renumbered, not removed.
         let tree = drift_tree(vec![
             leaf(AxRole::Label, "Heading"),
             leaf(AxRole::TextField, "Note"),

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -6,7 +6,7 @@
 //! `glass-a11y-linux`) map their native roles/states into the normalized types
 //! here; no OS/AT-SPI/D-Bus types appear in this module.
 
-use crate::error::Result;
+use crate::error::{GlassError, Result};
 use crate::platform::{Segment, WindowGeometry};
 
 /// Normalized accessibility role — the union of the AT-SPI / AX / UIA
@@ -797,6 +797,40 @@ impl AxTarget {
     /// Whether a reached node's role + name match this target.
     pub fn matches(&self, role: AxRole, name: Option<&str>) -> bool {
         self.role == role && self.name.as_deref() == name
+    }
+
+    /// Whether any node in `tree` still presents as this target — same role and name, wherever it
+    /// sits. Bounds and value are excluded: both move under a live app without the control going
+    /// anywhere.
+    ///
+    /// Do not tighten this to include bounds or value. Android's service reader relaxes a moved
+    /// control back into a write, and that relaxation needs [`Self::drifted`] to answer
+    /// `AxElementChanged` in every case it can relax.
+    pub fn still_on_screen(&self, tree: &AxTree) -> bool {
+        fn walk(node: &AxNode, target: &AxTarget) -> bool {
+            target.matches(node.role, node.name.as_deref())
+                || node.children.iter().any(|c| walk(c, target))
+        }
+        walk(&tree.root, self)
+    }
+
+    /// Which of the two disagreements a tree that no longer agrees with this target has.
+    ///
+    /// [`GlassError::AxElementChanged`] sends the reader looking for where the element went, which
+    /// is worth doing only while it is still somewhere. Nothing carrying its role and name means
+    /// the screen was replaced or the app that drew it restarted (glass#323), and re-addressing
+    /// that id would land on whatever now occupies it — for a `set_value` read-back, that is how a
+    /// write that already landed gets typed a second time.
+    ///
+    /// Shared rather than per-backend: both Android readers and iOS ask this same question, and
+    /// the two implementations had already drifted apart once — Android learned to tell the cases
+    /// apart while iOS went on calling every disagreement `AxElementChanged`.
+    pub fn drifted(&self, tree: &AxTree) -> GlassError {
+        if self.still_on_screen(tree) {
+            GlassError::AxElementChanged(self.id.0)
+        } else {
+            GlassError::AxElementGone(self.id.0)
+        }
     }
 
     /// Whether a reached element's bounds `got` are consistent with the bounds
@@ -1969,6 +2003,60 @@ mod tests {
             bounds: None,
             children: vec![],
         }
+    }
+
+    /// A target naming the `TextField "Note"` that `drift_tree` puts on screen.
+    fn drift_target() -> AxTarget {
+        AxTarget {
+            id: AxNodeId(1),
+            role: AxRole::TextField,
+            name: Some("Note".into()),
+            bounds: None,
+            value: None,
+        }
+    }
+
+    fn drift_tree(children: Vec<AxNode>) -> AxTree {
+        let mut root = leaf(AxRole::Window, "App");
+        root.children = children;
+        let mut t = AxTree::new(root);
+        t.assign_ids();
+        t
+    }
+
+    #[test]
+    fn a_target_still_on_screen_is_changed_not_gone() {
+        // Renumbered, not removed: re-snapshotting finds it again, which is what `AxElementChanged`
+        // tells the caller to do.
+        let tree = drift_tree(vec![
+            leaf(AxRole::Label, "Heading"),
+            leaf(AxRole::TextField, "Note"),
+        ]);
+        assert!(drift_target().still_on_screen(&tree));
+        assert!(matches!(
+            drift_target().drifted(&tree),
+            GlassError::AxElementChanged(1)
+        ));
+    }
+
+    #[test]
+    fn a_target_no_longer_anywhere_is_gone_not_changed() {
+        // The screen was replaced. Telling the caller to re-address that id would send a set_value
+        // read-back to retype a write that already landed.
+        let tree = drift_tree(vec![leaf(AxRole::Label, "No Results")]);
+        assert!(!drift_target().still_on_screen(&tree));
+        assert!(matches!(
+            drift_target().drifted(&tree),
+            GlassError::AxElementGone(1)
+        ));
+    }
+
+    #[test]
+    fn a_same_named_element_of_another_role_does_not_keep_a_target_on_screen() {
+        // Role and name together, not name alone — otherwise a heading that happens to repeat the
+        // field's label would report a replaced screen as merely renumbered.
+        let tree = drift_tree(vec![leaf(AxRole::Label, "Note")]);
+        assert!(!drift_target().still_on_screen(&tree));
     }
 
     #[test]

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -104,11 +104,8 @@ const VERIFY_ATTEMPTS: usize = 3;
 ///
 /// The element is re-resolved by its pre-order id, which the write itself can perturb (a tap that
 /// navigates renumbers everything after it), so a mismatch is a claim about the tree rather than
-/// about the write. [`AxTarget::drifted`] decides which: still somewhere → `AxElementChanged`,
-/// nowhere → `AxElementGone`. The difference matters most where the write itself replaced the
-/// screen — typing into a search field — because "re-snapshot" reads as "re-address that id", and
-/// the write it would repeat has already landed. A tree cut short by the walk caps explains an
-/// absent element better than either, so that case says so instead.
+/// about the write; [`AxTarget::drifted`] decides which. A tree cut short by the walk caps explains
+/// an absent element better than either, so that case says so instead.
 ///
 /// The node must also still be editable: for a non-editable node `axmap` puts the element's AXLabel
 /// in `value`, so a label that changed inside the settle window would otherwise read as a successful
@@ -372,10 +369,8 @@ mod tests {
     #[test]
     fn a_write_that_replaced_the_screen_says_the_element_is_gone() {
         // Measured on the Simulator: typing into Settings' search field replaces the settings list
-        // with a results screen, taking the tree from 16 nodes to 5 and the field with it. The
-        // write had landed — the results read "No Results for …" and the field held the text — but
-        // "changed; re-snapshot" tells an agent to re-address that id, which is how a landed write
-        // gets typed twice. Nothing here presents as the target, so the honest answer is gone.
+        // with a results screen, taking the tree from 16 nodes to 5 and the field with it, while
+        // the write itself lands (glass#359).
         let replaced = tree_with(leaf(0, AxRole::Label, "No Results", FIELD));
         assert!(matches!(
             verify_write(&replaced, &matching_target(), "world"),

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -102,10 +102,11 @@ const VERIFY_ATTEMPTS: usize = 3;
 /// `glass_core::typed_clear_landed` carry the rules and the cost of them. Twin of `verify_write` in
 /// `glass-android/src/a11y.rs` — keep the two in step.
 ///
-/// The element is re-resolved by its pre-order id, which the write itself can perturb (a tap that
-/// navigates renumbers everything after it), so a mismatch is a claim about the tree rather than
-/// about the write; [`AxTarget::drift_error`] decides which of the two. A tree cut short by the walk
-/// caps explains an absent element better than either, so that case says so instead.
+/// The element is re-resolved by its pre-order id, which the write itself perturbs: measured on the
+/// Simulator, the focusing tap raises the soft keyboard and inserts two nodes ahead of the field
+/// (glass#359). So a mismatch is a claim about the tree rather than about the write, and
+/// [`AxTarget::drift_error`] decides which of the two. A tree cut short by the walk caps explains an
+/// absent element better than either, so that case says so instead.
 ///
 /// The node must also still be editable: for a non-editable node `axmap` puts the element's AXLabel
 /// in `value`, so a label that changed inside the settle window would otherwise read as a successful
@@ -329,9 +330,8 @@ mod tests {
 
     #[test]
     fn a_target_that_moved_is_reported_as_changed_not_as_a_failed_write() {
-        // A genuine move: something else now occupies the target's id, but the field itself is
-        // still on screen further down. Renumbering is recoverable by re-snapshotting, which is
-        // what `AxElementChanged` tells the caller to do.
+        // A genuine move: something else now occupies the target's id, and the field is further
+        // down the tree.
         let mut root_field = leaf(0, AxRole::Label, "Heading", FIELD);
         let mut moved = leaf(0, AxRole::TextField, "Note", FIELD);
         moved.value = Some("world".into());
@@ -377,10 +377,8 @@ mod tests {
 
     #[test]
     fn an_id_past_the_end_of_a_replaced_tree_says_gone_not_changed() {
-        // The arm the measured case actually takes, and the one the test above does not reach: on
-        // the Simulator the target was #15 against a tree the write had cut to five nodes, so the
-        // id resolves to nothing rather than to something unrelated. `tree_with` roots at a Window,
-        // so an id inside the tree still resolves and exercises the other refusal site.
+        // The arm the measured case takes, and the one the test above cannot reach: `tree_with`
+        // roots at a Window, so an id inside the tree resolves and lands on the other refusal site.
         let replaced = tree_with(leaf(0, AxRole::Label, "No Results", FIELD));
         let mut t = matching_target();
         t.id = AxNodeId(15);

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -102,10 +102,13 @@ const VERIFY_ATTEMPTS: usize = 3;
 /// `glass_core::typed_clear_landed` carry the rules and the cost of them. Twin of `verify_write` in
 /// `glass-android/src/a11y.rs` — keep the two in step.
 ///
-/// The element is re-resolved by its pre-order id, which the write itself can perturb (the keyboard
-/// appears between the two describes), so a mismatch is [`GlassError::AxElementChanged`] —
-/// "re-snapshot" — rather than a claim about the write. A tree cut short by the walk caps explains an
-/// absent element better than drift does, so that case says so instead.
+/// The element is re-resolved by its pre-order id, which the write itself can perturb (a tap that
+/// navigates renumbers everything after it), so a mismatch is a claim about the tree rather than
+/// about the write. [`AxTarget::drifted`] decides which: still somewhere → `AxElementChanged`,
+/// nowhere → `AxElementGone`. The difference matters most where the write itself replaced the
+/// screen — typing into a search field — because "re-snapshot" reads as "re-address that id", and
+/// the write it would repeat has already landed. A tree cut short by the walk caps explains an
+/// absent element better than either, so that case says so instead.
 ///
 /// The node must also still be editable: for a non-editable node `axmap` puts the element's AXLabel
 /// in `value`, so a label that changed inside the settle window would otherwise read as a successful
@@ -122,11 +125,11 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
                 t.limit_value,
                 t.limit.label(),
             )),
-            None => GlassError::AxElementChanged(target.id.0),
+            None => target.drifted(after_tree),
         });
     };
     if !target.matches(node.role, node.name.as_deref()) || !node.states.editable {
-        return Err(GlassError::AxElementChanged(target.id.0));
+        return Err(target.drifted(after_tree));
     }
     let landed = if text.is_empty() {
         typed_clear_landed(node.value.as_deref())
@@ -329,11 +332,16 @@ mod tests {
 
     #[test]
     fn a_target_that_moved_is_reported_as_changed_not_as_a_failed_write() {
-        let after = tree_with_value(Some("world"));
-        let mut t = matching_target();
-        t.name = Some("A different field".into());
+        // A genuine move: something else now occupies the target's id, but the field itself is
+        // still on screen further down. Renumbering is recoverable by re-snapshotting, which is
+        // what `AxElementChanged` tells the caller to do.
+        let mut root_field = leaf(0, AxRole::Label, "Heading", FIELD);
+        let mut moved = leaf(0, AxRole::TextField, "Note", FIELD);
+        moved.value = Some("world".into());
+        root_field.children.push(moved);
+        let after = tree_with(root_field);
         assert!(matches!(
-            verify_write(&after, &t, "world"),
+            verify_write(&after, &matching_target(), "world"),
             Err(GlassError::AxElementChanged(1))
         ));
     }
@@ -358,6 +366,20 @@ mod tests {
         assert!(matches!(
             verify_write(&after, &t, "world"),
             Err(GlassError::AxElementChanged(9))
+        ));
+    }
+
+    #[test]
+    fn a_write_that_replaced_the_screen_says_the_element_is_gone() {
+        // Measured on the Simulator: typing into Settings' search field replaces the settings list
+        // with a results screen, taking the tree from 16 nodes to 5 and the field with it. The
+        // write had landed — the results read "No Results for …" and the field held the text — but
+        // "changed; re-snapshot" tells an agent to re-address that id, which is how a landed write
+        // gets typed twice. Nothing here presents as the target, so the honest answer is gone.
+        let replaced = tree_with(leaf(0, AxRole::Label, "No Results", FIELD));
+        assert!(matches!(
+            verify_write(&replaced, &matching_target(), "world"),
+            Err(GlassError::AxElementGone(1))
         ));
     }
 

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -104,8 +104,8 @@ const VERIFY_ATTEMPTS: usize = 3;
 ///
 /// The element is re-resolved by its pre-order id, which the write itself can perturb (a tap that
 /// navigates renumbers everything after it), so a mismatch is a claim about the tree rather than
-/// about the write; [`AxTarget::drifted`] decides which. A tree cut short by the walk caps explains
-/// an absent element better than either, so that case says so instead.
+/// about the write; [`AxTarget::drift_error`] decides which of the two. A tree cut short by the walk
+/// caps explains an absent element better than either, so that case says so instead.
 ///
 /// The node must also still be editable: for a non-editable node `axmap` puts the element's AXLabel
 /// in `value`, so a label that changed inside the settle window would otherwise read as a successful
@@ -122,11 +122,11 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
                 t.limit_value,
                 t.limit.label(),
             )),
-            None => target.drifted(after_tree),
+            None => target.drift_error(after_tree),
         });
     };
     if !target.matches(node.role, node.name.as_deref()) || !node.states.editable {
-        return Err(target.drifted(after_tree));
+        return Err(target.drift_error(after_tree));
     }
     let landed = if text.is_empty() {
         typed_clear_landed(node.value.as_deref())
@@ -368,13 +368,59 @@ mod tests {
 
     #[test]
     fn a_write_that_replaced_the_screen_says_the_element_is_gone() {
-        // Measured on the Simulator: typing into Settings' search field replaces the settings list
-        // with a results screen, taking the tree from 16 nodes to 5 and the field with it, while
-        // the write itself lands (glass#359).
         let replaced = tree_with(leaf(0, AxRole::Label, "No Results", FIELD));
         assert!(matches!(
             verify_write(&replaced, &matching_target(), "world"),
             Err(GlassError::AxElementGone(1))
+        ));
+    }
+
+    #[test]
+    fn an_id_past_the_end_of_a_replaced_tree_says_gone_not_changed() {
+        // The arm the measured case actually takes, and the one the test above does not reach: on
+        // the Simulator the target was #15 against a tree the write had cut to five nodes, so the
+        // id resolves to nothing rather than to something unrelated. `tree_with` roots at a Window,
+        // so an id inside the tree still resolves and exercises the other refusal site.
+        let replaced = tree_with(leaf(0, AxRole::Label, "No Results", FIELD));
+        let mut t = matching_target();
+        t.id = AxNodeId(15);
+        assert!(replaced.is_complete(), "a capped tree would answer Changed");
+        assert!(matches!(
+            verify_write(&replaced, &t, "world"),
+            Err(GlassError::AxElementGone(15))
+        ));
+    }
+
+    #[test]
+    fn an_incomplete_tree_cannot_report_the_element_gone() {
+        // A cap that fired hides elements, so absence from what was kept is not absence.
+        let mut replaced = tree_with(leaf(0, AxRole::Label, "No Results", FIELD));
+        replaced.truncated = Some(glass_core::accessibility::Truncation {
+            limit: glass_core::accessibility::TruncationLimit::Nodes,
+            limit_value: 2,
+            nodes_walked: 2,
+        });
+        let mut t = matching_target();
+        t.id = AxNodeId(15);
+        assert!(matches!(
+            verify_write(&replaced, &t, "world"),
+            Err(GlassError::AccessibilityUnavailable(_))
+        ));
+        // The mismatched-id arm has no truncation branch of its own and must not assert gone.
+        assert!(matches!(
+            verify_write(&replaced, &matching_target(), "world"),
+            Err(GlassError::AxElementChanged(1))
+        ));
+    }
+
+    #[test]
+    fn a_dropped_subtree_cannot_report_the_element_gone() {
+        // `unreadable` is independent of the caps, and equally unable to support "gone".
+        let mut replaced = tree_with(leaf(0, AxRole::Label, "No Results", FIELD));
+        replaced.unreadable = 1;
+        assert!(matches!(
+            verify_write(&replaced, &matching_target(), "world"),
+            Err(GlassError::AxElementChanged(1))
         ));
     }
 


### PR DESCRIPTION
iOS reported every element-identity disagreement in a `set_value` read-back as `AxElementChanged`, whose message tells the caller to re-snapshot and re-address that id. For a read-back that advice is actively wrong when the screen has been replaced: the id now belongs to something else, and the write it would repeat has already landed.

Android has told the two apart since #330 (`drifted()`), and the iOS function's own doc called them *"twins … keep the two in step"*. They had not been since #330. The classifier moves to `AxTarget::still_present` / `AxTarget::drift_error` in glass-core; Android delegates, iOS uses it at both refusal sites.

## Measured

Typing `glassprobe7391` into Settings' search field, through the real MCP surface from a granted `GlassMcp.app`:

| | |
|---|---|
| tree | 16 elements → 5; the `TextField` is not in the result |
| screen | `No Results for "glassprobe7391"` |
| `wait_for_element(role=TextField, value_contains=…)` | `{"matched": true}` |
| `glass_set_value` | `element #15 changed since the snapshot; re-snapshot` |

A successful write, reported as an error, with the one remedy that would repeat it. (A later run showed the field surviving its own relayout at a new id — the `AxElementChanged` case, which is why both branches exist.)

## Also in this PR — from the pre-merge review panel

**An incomplete tree could report an element gone.** `AxElementGone` asserts nothing carries the role and name *any more*; a tree stopped at a cap, or missing a subtree a failed child read dropped, shows that only for the part it kept. `verify_write` guarded truncation on the not-found arm and not on the mismatched arm, one line apart. `drift_error` now requires `AxTree::is_complete` before it will say gone — the recoverable direction when the evidence cannot discriminate.

**The arm the bug takes was untested.** `a_write_that_replaced_the_screen_says_the_element_is_gone` reaches Gone through the *mismatch* arm, because `tree_with` roots at a Window so its target id resolves. The measured case takes the `find(id) == None` arm. Reverting that arm to `AxElementChanged` left iOS 191/191 and Android 329/329 green. Three tests added: the id-past-the-end arm, a truncated tree, a dropped subtree.

**The tightening ban was guarded only from another crate.** `still_present`'s doc forbids folding in bounds or value; until now only `a11y_service`'s tests would catch it. `a_relaxable_move_is_never_reported_as_gone` pins it in the crate that states the rule.

**API shape.** `still_on_screen` was public with no consumer outside the classifier and promised something it does not check (it is true for a scrolled-away row) — now private, `still_present`. `drifted` read as a predicate among `matches`/`bounds_consistent`/`value_consistent` while returning an error value — now `drift_error`, `#[must_use]`.

**Doc corrections.** The Android half of the twin-pair still named `AxElementChanged` with a worked example that now returns `AxElementGone`; `fingerprinted`'s doc linked a function this PR deleted (dangling link confirmed with `cargo doc`, now clean); `editable_target`'s doc listed only the old variant.

## Verification

`cargo test --workspace` — **1947 passed, 0 failed**. `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean.

Mutation-measured: inverting `drift_error` reds **31** tests (6 core, 8 iOS, 17 Android); dropping the completeness guard alone reds 5; reverting the `find(id) == None` arm reds 2 — it red **0** before this round.

On device, the classifier takes the correct branch where the field survives at a new id. The `AxElementGone` branch has not reproduced on the Simulator since the fix; it is pinned by unit tests, not by a device run.

## Not fixed here

Verification still re-resolves by pre-order id, so a landed write into a field that was not already focused cannot be confirmed — **#359**, which this branch's testing showed to be broader than originally filed. Two adjacent problems that predate this PR are filed rather than folded in: **#361** (the pre-write guard's untyped errors) and **#362** (gone-vs-changed decided from a single sample).

🤖 Generated with [Claude Code](https://claude.com/claude-code)