### PR TITLE
fix(a11y): confirm a write against the element wherever it moved to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,21 +201,24 @@ internal refactors, CI, or test-only changes.
 
 ### Fixed
 - `glass_set_value` now confirms a write into a field that was not already focused, instead of
-  reporting it as an element that had changed or gone missing. Both mobile backends confirm a write
-  by re-reading the element afterwards, and they used to re-find it by its position in the
-  accessibility tree — which the write itself moves: typing into an unfocused field raises the
-  keyboard, and on the iOS Simulator that inserts elements ahead of the field. A landed write could
-  not be confirmed, on the ordinary path of writing into a field you have not touched yet. The
-  read-back now re-finds the element by its role and name wherever it moved to, and refuses if more
-  than one element now matches, since then which one holds the text cannot be told.
-- A `glass_set_value` that cannot confirm its write — the element is gone, several now match it, the
-  read stopped early, or it is no longer editable to read back — now says the text was typed and
-  names what to re-snapshot for, instead of reporting only that the element could not be
-  re-addressed, which reads as an instruction to write again when the write has already gone out. A
-  read cut short by the node cap still names the cap, so raising `max_nodes` is the fix when that's
-  the reason. Writing an empty value to clear a field is the one case re-finding the element isn't
-  enough to confirm: an empty field alone isn't evidence it's the right one, so a clear whose element
-  had to be re-found by role and name reports unconfirmed rather than a success it cannot prove.
+  reporting it as an element that had changed or gone missing. On iOS, and on Android's
+  `uiautomator` reader, a write taps the field and types into it, then confirms by re-reading the
+  element afterwards — and used to re-find it by its position in the accessibility tree, which the
+  write itself moves: typing into an unfocused field raises the keyboard, and on the iOS Simulator
+  that inserts elements ahead of the field. A landed write could not be confirmed, on the ordinary
+  path of writing into a field you have not touched yet. The read-back now re-finds the element by
+  its role and name wherever it moved to, and refuses if more than one element now matches, since
+  then which one holds the text cannot be told. The optional on-device companion sets a field's
+  value directly rather than typing into it, so it was never affected.
+- A `glass_set_value` that cannot confirm its write on either of those two readers — the element is
+  gone, several now match it, the read stopped early, or it is no longer editable to read back — now
+  says the text was typed and names what to re-snapshot for, instead of reporting only that the
+  element could not be re-addressed, which reads as an instruction to write again when the write has
+  already gone out. A read cut short by the node cap still names the cap, so raising `max_nodes` is
+  the fix when that's the reason. Writing an empty value to clear a field is the one case re-finding
+  the element isn't enough to confirm: an empty field alone isn't evidence it's the right one, so a
+  clear whose element had to be re-found by role and name reports unconfirmed rather than a success
+  it cannot prove.
 - A native Android click or `set_value` through the optional on-device companion no longer acts on a
   different element than the one you named when the snapshot was truncated. glass numbered elements
   by their position in the tree it kept and dispatched the action by that number, but the companion
@@ -243,9 +246,8 @@ internal refactors, CI, or test-only changes.
   that no longer exists. It now asks whether anything in the tree still carries that element's role
   and name: if something might, the refusal still reads as before; if nothing does, and the read
   covered the whole tree, it reports the element as gone instead, which re-snapshotting the same
-  screen will not fix. A read cut short by the node cap, or missing a subtree a failed child read
-  dropped, only shows absence for the part it covered, so that weaker read still answers changed
-  rather than gone.
+  screen will not fix. A read cut short by the node cap only shows absence for the part it covered,
+  so that weaker read still answers changed rather than gone.
 - The accessibility tree now discloses subtrees it could not read. A child read that fails drops
   everything beneath it, and the tree came back looking complete — indistinguishable from one where
   there was genuinely nothing there, so an agent concludes an element does not exist and routes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,21 +204,26 @@ internal refactors, CI, or test-only changes.
   reporting it as an element that had changed or gone missing. On iOS, and on Android's
   `uiautomator` reader, a write taps the field and types into it, then confirms by re-reading the
   element afterwards — and used to re-find it by its position in the accessibility tree, which the
-  write itself moves: typing into an unfocused field raises the keyboard, and on the iOS Simulator
-  that inserts elements ahead of the field. A landed write could not be confirmed, on the ordinary
-  path of writing into a field you have not touched yet. The read-back now re-finds the element by
-  its role and name wherever it moved to, and refuses if more than one element now matches, since
-  then which one holds the text cannot be told. The optional on-device companion sets a field's
-  value directly rather than typing into it, so it was never affected.
+  write itself moves. On the iOS Simulator, typing into an unfocused field raises the keyboard and
+  that inserts elements ahead of the field, so a landed write could not be confirmed on the ordinary
+  path of writing into a field you have not touched yet. On Android the keyboard leaves the numbering
+  alone; what moves the element there is a tap that navigates, reopening the field inside a different
+  window. The read-back now re-finds the element by its role and name wherever it moved to, and
+  refuses if more than one element now matches, since then which one holds the text cannot be told.
+  An element re-found that way is accepted only from a read that covered the whole tree, and only
+  while it is still drawn overlapping where it was — so a same-named field on a screen the tap
+  navigated to is reported as unconfirmed instead of confirming a write that landed elsewhere. The
+  optional on-device companion sets a field's value directly rather than typing into it, so it was
+  never affected.
 - A `glass_set_value` that cannot confirm its write on either of those two readers — the element is
-  gone, several now match it, the read stopped early, or it is no longer editable to read back — now
-  says the text was typed and names what to re-snapshot for, instead of reporting only that the
-  element could not be re-addressed, which reads as an instruction to write again when the write has
-  already gone out. A read cut short by the node cap still names the cap, so raising `max_nodes` is
-  the fix when that's the reason. Writing an empty value to clear a field is the one case re-finding
-  the element isn't enough to confirm: an empty field alone isn't evidence it's the right one, so a
-  clear whose element had to be re-found by role and name reports unconfirmed rather than a success
-  it cannot prove.
+  gone, several now match it, the read stopped early or covered only part of the tree, it is no
+  longer editable to read back, or the read-back itself failed — now says the text was typed and
+  names what to re-snapshot for, instead of reporting only that the element could not be
+  re-addressed, which reads as an instruction to write again when the write has already gone out. A
+  read cut short by the node cap still names the cap, so raising `max_nodes` is the fix when that's
+  the reason. Writing an empty value to clear a field needs the element to have a name: an empty
+  field is not by itself evidence the clear landed on the element you meant, so a nameless one
+  reports unconfirmed rather than a success it cannot prove.
 - A native Android click or `set_value` through the optional on-device companion no longer acts on a
   different element than the one you named when the snapshot was truncated. glass numbered elements
   by their position in the tree it kept and dispatched the action by that number, but the companion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,18 +200,22 @@ internal refactors, CI, or test-only changes.
   Android paths have no such live check.
 
 ### Fixed
-- On the iOS Simulator, a `glass_set_value` that cannot confirm its write now distinguishes an
-  element that moved from one that is no longer there. Both used to come back as `element #N changed
-  since the snapshot; re-snapshot`, which tells you to re-address that id — the wrong advice when
-  the screen the element was on has been replaced, because the id now belongs to something else and
-  the write it would repeat has already landed. Where nothing in the tree still carries the
-  element's role and name, glass now says the element is gone and to look at where the app is now.
-  Android has answered this way since it learned the same lesson.
-- An accessibility read that stopped early can no longer report an element as gone. "Gone" states
-  that nothing carries the element's role and name any more, which a tree cut short by the element
-  cap — or missing a subtree a failed child read dropped — only shows for the part it covered. Such
-  a read now reports the element as changed, which sends you to re-snapshot rather than to conclude
-  the screen was replaced. Affects Android as well as iOS.
+- `glass_set_value` now confirms a write into a field that was not already focused, instead of
+  reporting it as an element that had changed or gone missing. Both mobile backends confirm a write
+  by re-reading the element afterwards, and they used to re-find it by its position in the
+  accessibility tree — which the write itself moves: typing into an unfocused field raises the
+  keyboard, and on the iOS Simulator that inserts elements ahead of the field. A landed write could
+  not be confirmed, on the ordinary path of writing into a field you have not touched yet. The
+  read-back now re-finds the element by its role and name wherever it moved to, and refuses if more
+  than one element now matches, since then which one holds the text cannot be told.
+- A `glass_set_value` that cannot confirm its write — the element is gone, several now match it, the
+  read stopped early, or it is no longer editable to read back — now says the text was typed and
+  names what to re-snapshot for, instead of reporting only that the element could not be
+  re-addressed, which reads as an instruction to write again when the write has already gone out. A
+  read cut short by the node cap still names the cap, so raising `max_nodes` is the fix when that's
+  the reason. Writing an empty value to clear a field is the one case re-finding the element isn't
+  enough to confirm: an empty field alone isn't evidence it's the right one, so a clear whose element
+  had to be re-found by role and name reports unconfirmed rather than a success it cannot prove.
 - A native Android click or `set_value` through the optional on-device companion no longer acts on a
   different element than the one you named when the snapshot was truncated. glass numbered elements
   by their position in the tree it kept and dispatched the action by that number, but the companion
@@ -232,13 +236,16 @@ internal refactors, CI, or test-only changes.
   before. The same defect could send an unrelated install failure down the reinstall-on-signature-
   mismatch path, because the message names the caller's own `GLASS_ANDROID_A11Y_APK` argument: an
   APK kept under a directory whose name quoted the phrase changed what any install failure did.
-- Android now says when the element you addressed is gone, instead of reporting it as changed. Every
-  disagreement between your snapshot and the tree at write time came back as `element … changed
-  since the snapshot; re-snapshot`, including the case where the screen the element was on had been
-  destroyed — so the advice was to re-snapshot a screen that no longer exists. glass now asks
-  whether anything in the tree still carries that element's role and name: if so the refusal reads
-  as before, and if not it reports the element as gone, which re-snapshotting will not fix. When a
-  refusal happens is unchanged.
+- Android's check before it acts on an addressed element — the guard a click or `set_value` makes to
+  confirm the id still names what the caller thinks it does — tells two disagreements apart. Every
+  mismatch used to come back as `element … changed since the snapshot; re-snapshot`, including when
+  the screen the element was on had been replaced entirely, so the advice was to re-snapshot a screen
+  that no longer exists. It now asks whether anything in the tree still carries that element's role
+  and name: if something might, the refusal still reads as before; if nothing does, and the read
+  covered the whole tree, it reports the element as gone instead, which re-snapshotting the same
+  screen will not fix. A read cut short by the node cap, or missing a subtree a failed child read
+  dropped, only shows absence for the part it covered, so that weaker read still answers changed
+  rather than gone.
 - The accessibility tree now discloses subtrees it could not read. A child read that fails drops
   everything beneath it, and the tree came back looking complete — indistinguishable from one where
   there was genuinely nothing there, so an agent concludes an element does not exist and routes

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -6,7 +6,9 @@ use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use glass_core::accessibility::{Accessibility, AxContext, AxDeadline, AxNode, AxTarget, AxTree};
+use glass_core::accessibility::{
+    Accessibility, AxContext, AxDeadline, AxNode, AxTarget, AxTree, Located,
+};
 use glass_core::{
     GlassError, KeyEvent, MouseButton, PointerEvent, Result, WindowGeometry, typed_clear_landed,
     typed_text_landed,
@@ -299,14 +301,15 @@ fn dump_until_ready(
 /// Exact match, not "changed from before": tap-and-type is not atomic, so a dropped key or an input
 /// filter leaves the field holding something that is neither the request nor the old value, and
 /// calling that success is the failure this check exists to prevent. `glass_core::typed_text_landed`
-/// and `glass_core::typed_clear_landed` carry the rules and the cost of them.
+/// and `glass_core::typed_clear_landed` carry the rules and the cost of them. Twin of `verify_write`
+/// in `glass-ios/src/a11y.rs` — keep the two in step.
 ///
-/// The element is re-resolved by its pre-order id, which the write can perturb if the tap changes
-/// what is on screen. Raising the soft keyboard does not: measured on the dogfood AVD with
-/// `mInputShown=true`, `uiautomator dump` emits the focused window only and no IME window, so the
-/// keyboard cannot shift ids. A tap that navigates — Settings' search entry opens a different
-/// window — does shift them, so a mismatch is a claim about the tree rather than about the write;
-/// [`AxTarget::drift_error`] decides which of the two it is.
+/// The element is re-resolved by identity (role + name) via [`AxTarget::relocate`], not by its
+/// pre-order id. The soft keyboard does not itself shift ids — measured on the dogfood AVD with
+/// `mInputShown=true`, `uiautomator dump` emits the focused window only and no IME window — but a
+/// tap that navigates does: Settings' search entry opens a different window, and the field can turn
+/// up renumbered inside it rather than gone. Re-finding by identity is what lets that be confirmed
+/// instead of refused.
 ///
 /// Role and name are checked but bounds deliberately are not, unlike the pre-write
 /// [`locate_editable_target`]: the IME reflows the layout under the field it is typing into, so a
@@ -315,24 +318,44 @@ fn dump_until_ready(
 /// The node must also still be editable, which excludes a non-editable neighbour that inherited the
 /// id — but not a second nameless editable, since an editable's name comes from `content-desc` alone
 /// and `AxTarget::matches` compares `None` to `None`. The exact-value requirement is what covers
-/// that case.
+/// that case. A node reached by [`Located::AtId`] or [`Located::Moved`] already carries the target's
+/// role and name, so an editability mismatch there is always a change, never a disappearance —
+/// [`AxTarget::drift_error`] cannot return `AxElementGone` on this path.
 fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()> {
-    let Some(node) = after_tree.find(target.id) else {
-        // A tree cut short by the node cap explains an absent element better than "it moved" does.
-        return Err(match &after_tree.truncated {
-            // `Truncation::notice()` is written to close a rendered outline — a leading ellipsis
-            // and its own pixel-fallback advice — so this states the cap itself instead.
-            Some(t) => GlassError::AccessibilityUnavailable(format!(
-                "set_value: the text was typed, but the read-back could not find element {} \
-                 because the tree was truncated at {} {}; re-snapshot rather than retyping",
+    let node = match target.relocate(after_tree) {
+        Located::AtId(node) | Located::Moved(node) => node,
+        Located::Ambiguous(candidates) => {
+            return Err(GlassError::AxWriteUnconfirmed(
                 target.id.0,
-                t.limit_value,
-                t.limit.label(),
-            )),
-            None => target.drift_error(after_tree),
-        });
+                format!(
+                    "{} elements now match its role and name, so which one holds it cannot be told",
+                    candidates.len()
+                ),
+            ));
+        }
+        Located::Gone => {
+            return Err(GlassError::AxWriteUnconfirmed(
+                target.id.0,
+                "nothing in the tree carries its role and name, so the screen it was on was \
+                 replaced"
+                    .into(),
+            ));
+        }
+        Located::Unproven => {
+            // Keep the cap in the message: it is what tells a caller to raise `max_nodes`, and
+            // existing tests assert it. `unreadable` has no number to name, so it says why instead.
+            let why = match &after_tree.truncated {
+                Some(t) => format!(
+                    "the tree was truncated at {} {}, so the element may be past the cap",
+                    t.limit_value,
+                    t.limit.label()
+                ),
+                None => "a subtree could not be read, so the element may be inside it".to_string(),
+            };
+            return Err(GlassError::AxWriteUnconfirmed(target.id.0, why));
+        }
     };
-    if !target.matches(node.role, node.name.as_deref()) || !node.states.editable {
+    if !node.states.editable {
         return Err(target.drift_error(after_tree));
     }
     let landed = if text.is_empty() {
@@ -1922,25 +1945,39 @@ mod tests {
     }
 
     #[test]
-    fn a_target_that_moved_is_reported_as_changed_not_as_a_failed_write() {
-        // The write may well have landed — on something that then moved. Saying "not applied"
-        // would send an agent to retype into whatever now sits at that id.
+    fn a_write_confirmed_at_a_new_id_is_a_success() {
+        // A node grew above the field, so its id moved. The field is still there holding exactly
+        // what was asked for, and re-finding it by role and name is what lets that be confirmed
+        // instead of refused (glass#359).
         let after = under_a_container(tree_holding(Some("world")));
+        let t = target(0, Some("Search"), Some(BOUNDS));
+        assert!(verify_write(&after, &t, "world").is_ok());
+    }
+
+    #[test]
+    fn a_write_confirmed_at_a_new_id_still_checks_what_landed() {
+        // Re-finding must not weaken the value check: the field is found, and holds the wrong text.
+        let after = under_a_container(tree_holding(Some("worl")));
         let t = target(0, Some("Search"), Some(BOUNDS));
         assert!(matches!(
             verify_write(&after, &t, "world"),
-            Err(GlassError::AxElementChanged(0))
+            Err(GlassError::AxValueNotApplied(0))
         ));
     }
 
     #[test]
-    fn a_read_back_of_a_screen_that_was_replaced_reports_the_element_gone() {
+    fn a_write_whose_screen_was_replaced_says_it_was_typed_but_unconfirmed() {
         // glass#323's other half: the kill can land between the write and the read-back, which
         // is where four of the nine observed refusals came from.
-        let t = target(0, Some("Search"), Some(BOUNDS));
-        let e = verify_write(&a_different_screen(), &t, "world")
-            .expect_err("the field the write was aimed at is not in this tree");
-        assert!(matches!(e, GlassError::AxElementGone(0)), "{e}");
+        let err = verify_write(
+            &a_different_screen(),
+            &target(0, Some("Search"), Some(BOUNDS)),
+            "world",
+        )
+        .unwrap_err();
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(0, _)), "{err}");
+        assert!(err.to_string().contains("the text was typed"), "{err}");
+        assert!(err.to_string().contains("replaced"), "{err}");
     }
 
     #[test]
@@ -1957,32 +1994,61 @@ mod tests {
     }
 
     #[test]
-    fn a_target_missing_from_the_read_back_is_reported_as_changed() {
-        // The element is still in the tree, just no longer at that id — renumbered, which is what
-        // "changed" means.
+    fn an_id_past_the_end_still_confirms_a_landed_write() {
+        // The mirror image of the renumbering case: the keyboard dismissing after a landed write
+        // can shrink the tree back down, leaving the field's old id past the end of it — nothing
+        // resolves there, but the field itself never moved and still holds the text.
         let after = tree_holding(Some("world"));
         let t = target(7, Some("Search"), Some(BOUNDS));
-        assert!(matches!(
-            verify_write(&after, &t, "world"),
-            Err(GlassError::AxElementChanged(7))
-        ));
+        assert!(verify_write(&after, &t, "world").is_ok());
     }
 
     #[test]
     fn a_truncated_read_back_says_so_rather_than_blaming_drift() {
-        // The tree carries the reason the element is absent; reporting "it moved" would throw away
-        // the one fact that explains it.
-        let mut after = tree_holding(Some("world"));
+        // No node here carries the target's role and name, so a complete tree would call this
+        // Gone — the cap is what keeps it Unproven, and the cap is what tells a caller to raise
+        // max_nodes, so the message must keep naming it.
+        let mut after = tree(AxRole::Label, Some("No Results"), Some(BOUNDS), false);
         after.truncated = Some(glass_core::accessibility::Truncation {
             limit: glass_core::accessibility::TruncationLimit::Nodes,
             limit_value: 1,
             nodes_walked: 1,
         });
         let t = target(7, Some("Search"), Some(BOUNDS));
-        assert!(matches!(
-            verify_write(&after, &t, "world"),
-            Err(GlassError::AccessibilityUnavailable(_))
-        ));
+        let err = verify_write(&after, &t, "world").unwrap_err();
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(7, _)), "{err}");
+        assert!(err.to_string().contains("truncated at 1 nodes"), "{err}");
+    }
+
+    #[test]
+    fn two_matching_fields_refuse_and_name_where_they_are() {
+        // The target's own id must land on something else first — a node still holding it would
+        // take the AtId fast path and never learn a second candidate exists.
+        let mut container = tree(AxRole::Group, None, Some(BOUNDS), false);
+        let mut a = tree(AxRole::TextField, Some("Search"), Some(BOUNDS), true);
+        a.root.value = Some("world".into());
+        let mut b = tree(AxRole::TextField, Some("Search"), Some(BOUNDS), true);
+        b.root.value = Some("world".into());
+        container.root.children = vec![a.root, b.root];
+        container.assign_ids();
+        let t = target(0, Some("Search"), Some(BOUNDS));
+        let err = verify_write(&container, &t, "world").unwrap_err();
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(0, _)), "{err}");
+        assert!(err.to_string().contains('2'), "names how many: {err}");
+    }
+
+    #[test]
+    fn an_incomplete_tree_does_not_claim_the_element_vanished() {
+        // `unreadable` is independent of the caps, and equally unable to support "replaced".
+        let mut after = tree(AxRole::Label, Some("No Results"), Some(BOUNDS), false);
+        after.unreadable = 1;
+        let t = target(9, Some("Search"), Some(BOUNDS));
+        let err = verify_write(&after, &t, "world").unwrap_err();
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(9, _)), "{err}");
+        assert!(
+            !err.to_string().contains("replaced"),
+            "an incomplete read must not assert the screen changed: {err}"
+        );
     }
 
     #[test]

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -296,7 +296,7 @@ fn dump_until_ready(
 }
 
 /// Judge a typed `set_value` from a tree read back after it. `Ok(())` only when the field holds
-/// exactly what was asked for, or — for a clear confirmed at its own id — reads back empty.
+/// exactly what was asked for, or — for a named field — reads back empty after a clear.
 ///
 /// Exact match, not "changed from before": tap-and-type is not atomic, so a dropped key or an input
 /// filter leaves the field holding something that is neither the request nor the old value, and
@@ -311,9 +311,14 @@ fn dump_until_ready(
 /// up renumbered inside it rather than gone. Re-finding by identity is what lets that be confirmed
 /// instead of refused.
 ///
-/// Role and name are checked but bounds deliberately are not, unlike the pre-write
+/// Bounds are deliberately no part of that identity, unlike the pre-write
 /// [`locate_editable_target`]: the IME reflows the layout under the field it is typing into, so a
-/// moved-but-correct element is the normal case here.
+/// moved-but-correct element is the normal case here. `relocate` does require a re-found node to
+/// still *overlap* where the target was, which is what separates that reflow from a field on
+/// another screen entirely — and this reader needs it most, because [`crate::axmap::labels`] names
+/// an editable from its resource-id leaf whenever `content-desc` is absent, which is most of the
+/// time. A leaf like `search_src_text` names a *layout*: it repeats across every instance of it,
+/// and across apps, so a navigating tap can find the next screen's field matching uniquely.
 ///
 /// [`Located::AtId`] and [`Located::Moved`] both already carry the target's role and name —
 /// `relocate` requires the match on the first, and finds the second by searching for exactly that
@@ -322,18 +327,15 @@ fn dump_until_ready(
 /// this point, so that is [`GlassError::AxWriteUnconfirmed`], not the pre-write
 /// [`AxTarget::drift_error`].
 ///
-/// Role+name identity is weakest for a nameless editable — Android names one from `content-desc`
-/// alone, absent on most `EditText`s. A second one elsewhere in the tree is [`Located::Ambiguous`]
-/// and refused; one that happens to sit at the target's own id is accepted on that position alone —
-/// `relocate` never searches once `AtId` matches, and [`AxTarget::matches`] compares `None` to
-/// `None`. A non-empty write's exact-text check is what would catch a coincidental match there; a
-/// clear has nothing for it to catch, so a clear (`text` empty) is confirmed by an empty read-back
-/// only on `AtId`. [`Located::Moved`] found its node purely by search, with no such grounding, so a
-/// clear reached that way is refused as unconfirmed instead.
+/// A clear (`text` empty) is confirmed only for a target that carries a name. An empty read-back is
+/// what any untouched same-role, same-name field would also show, so it is evidence of the write
+/// only inasmuch as the identity that found the field is discriminating — a non-empty write's
+/// exact-text check grounds itself, a clear has nothing to. A nameless target is refused however it
+/// was reached, its own id included: [`AxTarget::matches`] compares `None` to `None`, so `AtId`
+/// there accepts whatever nameless editable renumbering slid onto the id.
 fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()> {
-    let (node, relocated) = match target.relocate(after_tree) {
-        Located::AtId(node) => (node, false),
-        Located::Moved(node) => (node, true),
+    let node = match target.relocate(after_tree) {
+        Located::AtId(node) | Located::Moved(node) => node,
         Located::Ambiguous(candidates) => {
             return Err(GlassError::AxWriteUnconfirmed(
                 target.id.0,
@@ -353,14 +355,23 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
         }
         Located::Unproven => {
             // Keep the cap in the message: it is what tells a caller to raise `max_nodes`, and
-            // existing tests assert it. `unreadable` has no number to name, so it says why instead.
-            let why = match &after_tree.truncated {
-                Some(t) => format!(
-                    "the tree was truncated at {} {}, so the element may be past the cap",
+            // existing tests assert it. A complete tree has no hole to blame, so the one way it
+            // reaches here is a lone match drawn clear of where the element was.
+            let why = if let Some(t) = &after_tree.truncated {
+                format!(
+                    "the tree was truncated at {} {}, so the element — or a second one matching \
+                     it — may be past the cap",
                     t.limit_value,
                     t.limit.label()
-                ),
-                None => "a subtree could not be read, so the element may be inside it".to_string(),
+                )
+            } else if after_tree.unreadable > 0 {
+                "a subtree could not be read, so the element — or a second one matching it — may \
+                 be inside it"
+                    .to_string()
+            } else {
+                "the only element carrying its role and name is drawn clear of where this one \
+                 was, so it may be a different one"
+                    .to_string()
             };
             return Err(GlassError::AxWriteUnconfirmed(target.id.0, why));
         }
@@ -372,11 +383,11 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
                 .into(),
         ));
     }
-    if relocated && text.is_empty() {
+    if text.is_empty() && target.name.is_none() {
         return Err(GlassError::AxWriteUnconfirmed(
             target.id.0,
-            "the element had to be re-found by role and name, so an empty field alone cannot \
-             confirm a clear landed on it"
+            "the element has no name, so nothing but its position identifies it and an empty \
+             field cannot confirm a clear landed on it"
                 .into(),
         ));
     }
@@ -390,6 +401,15 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
     } else {
         Err(GlassError::AxValueNotApplied(target.id.0))
     }
+}
+
+/// The read-back's own failure, reported as an unconfirmed write.
+///
+/// Post-dispatch by construction: its only caller is the loop that runs after the keystrokes went
+/// out. A verdict `GlassError::set_value_failed_after_writing` rejects would leave the session
+/// holding the value it cached for a write that already landed, and refuse the retry as drift.
+fn read_back_failed(target: &AxTarget, e: &GlassError) -> GlassError {
+    GlassError::AxWriteUnconfirmed(target.id.0, format!("reading the element back failed: {e}"))
 }
 
 /// How many times to read the element back before reporting the write as not applied. A landed
@@ -669,12 +689,9 @@ impl Accessibility for AndroidA11y {
         let mut last = None;
         for _ in 0..VERIFY_ATTEMPTS {
             std::thread::sleep(Duration::from_millis(VERIFY_SETTLE_MS));
-            let mut after = self.snapshot_within(ctx, VERIFY_BOUND).map_err(|e| {
-                GlassError::AccessibilityUnavailable(format!(
-                    "set_value: the text was typed, but reading the element back failed: {e}; \
-                         re-snapshot to see whether it landed rather than retyping"
-                ))
-            })?;
+            let mut after = self
+                .snapshot_within(ctx, VERIFY_BOUND)
+                .map_err(|e| read_back_failed(target, &e))?;
             after.assign_ids();
             match verify_write(&after, target, text) {
                 Ok(()) => return Ok(()),
@@ -695,8 +712,8 @@ impl Accessibility for AndroidA11y {
 mod tests {
     use super::{
         Attempt, COLD_BOUND, RetryBound, Warmth, bound_fired, dump_once, dump_until_ready,
-        editable_target, locate_editable_target, locate_for_write, snapshot_bound,
-        snapshot_with_runner, verify_write,
+        editable_target, locate_editable_target, locate_for_write, read_back_failed,
+        snapshot_bound, snapshot_with_runner, verify_write,
     };
     use crate::adb::{AdbOp, a_failed_call, a_real_spawn_failure, a_real_timeout_hinted};
     use glass_core::accessibility::{
@@ -2017,23 +2034,103 @@ mod tests {
         assert!(err.to_string().contains("editable"), "{err}");
     }
 
+    /// The field with no name at all, which is where role+name identity runs out. An `EditText` with
+    /// neither a `content-desc` nor a resource id arrives exactly this way.
+    fn nameless(value: Option<&str>) -> (AxTree, AxTarget) {
+        let mut tree = tree(AxRole::TextField, None, Some(BOUNDS), true);
+        tree.root.value = value.map(Into::into);
+        tree.assign_ids();
+        (tree, target(0, None, Some(BOUNDS)))
+    }
+
     #[test]
-    fn a_clear_confirmed_only_by_relocating_is_unconfirmed_not_a_success() {
-        // An empty read-back is what any untouched same-role, same-name field would also show, so
-        // Located::Moved's search-only grounding is not enough to trust it: only AtId's own-id
-        // match is. The keystrokes may never have reached this element.
+    fn a_named_field_clears_after_being_re_found() {
+        // Keying the refusal on "it relocated" refused a clear whenever anything grew above the
+        // field; the name is what identifies it, and the name survives the move.
         let after = under_a_container(tree_holding(None));
         let t = target(0, Some("Search"), Some(BOUNDS));
+        assert!(verify_write(&after, &t, "").is_ok());
+    }
+
+    #[test]
+    fn a_nameless_field_cannot_confirm_a_clear_at_its_own_id() {
+        // `AxTarget::matches` compares None to None, so the id alone accepts whatever nameless
+        // editable renumbering slid onto it — and an empty read-back is exactly what that one shows
+        // too. Nothing but the position says the keystrokes reached this field.
+        let (after, t) = nameless(None);
         let err = verify_write(&after, &t, "").unwrap_err();
         assert!(matches!(err, GlassError::AxWriteUnconfirmed(0, _)), "{err}");
         assert!(err.to_string().contains("clear"), "{err}");
     }
 
     #[test]
+    fn a_nameless_field_still_confirms_the_text_it_was_given() {
+        // The identity is just as weak here; the typed text is what grounds it instead.
+        let (after, t) = nameless(Some("world"));
+        assert!(verify_write(&after, &t, "world").is_ok());
+    }
+
+    #[test]
+    fn losing_editability_outranks_the_clear_refusal() {
+        // Both refusals fit a nameless non-editable node. Editability is the specific fact, and a
+        // caller told only "an empty field cannot confirm a clear" would go on hunting for a field.
+        let (mut after, t) = nameless(None);
+        after.root.states.editable = false;
+        let err = verify_write(&after, &t, "").unwrap_err();
+        assert!(err.to_string().contains("editable"), "{err}");
+    }
+
+    #[test]
+    fn a_field_drawn_clear_of_the_target_does_not_confirm_the_write() {
+        // The navigating tap: an editable is usually named by its resource-id leaf, so
+        // `search_src_text` matches on every screen built from that layout, and the next screen's
+        // field would otherwise confirm a write the keystrokes landed somewhere else.
+        let mut elsewhere = tree_holding(Some("world"));
+        elsewhere.root.bounds = Some(AxRect { y: 900, ..BOUNDS });
+        let after = under_a_container(elsewhere);
+        let t = target(0, Some("Search"), Some(BOUNDS));
+        let err = verify_write(&after, &t, "world").unwrap_err();
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(0, _)), "{err}");
+        assert!(err.to_string().contains("drawn clear of where"), "{err}");
+    }
+
+    #[test]
+    fn a_truncated_tree_cannot_confirm_a_write_against_its_one_match() {
+        // One match in the part that was kept is not one match in the tree: the second may be past
+        // the cap, which is the refusal a complete tree makes as Ambiguous.
+        let mut after = under_a_container(tree_holding(Some("world")));
+        after.truncated = Some(glass_core::accessibility::Truncation {
+            limit: glass_core::accessibility::TruncationLimit::Nodes,
+            limit_value: 2,
+            nodes_walked: 2,
+        });
+        let t = target(0, Some("Search"), Some(BOUNDS));
+        let err = verify_write(&after, &t, "world").unwrap_err();
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(0, _)), "{err}");
+        assert!(err.to_string().contains("truncated at 2 nodes"), "{err}");
+    }
+
+    #[test]
+    fn a_failed_read_back_reports_the_write_as_unconfirmed() {
+        // The read runs after the keystrokes went out, so a dump failure here must be a verdict
+        // `set_value_failed_after_writing` accepts — otherwise the session keeps the value it cached
+        // for a write that already landed and refuses the retry as drift.
+        let t = target(0, Some("Search"), Some(BOUNDS));
+        let err = read_back_failed(
+            &t,
+            &GlassError::AccessibilityUnavailable("no window roots".into()),
+        );
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(0, _)), "{err}");
+        assert!(err.set_value_failed_after_writing(), "{err}");
+        assert!(err.to_string().contains("no window roots"), "{err}");
+    }
+
+    #[test]
     fn an_id_past_the_end_still_confirms_a_landed_write() {
-        // The mirror image of the renumbering case: the keyboard dismissing after a landed write
-        // can shrink the tree back down, leaving the field's old id past the end of it — nothing
-        // resolves there, but the field itself never moved and still holds the text.
+        // The mirror image of the renumbering case, and not the keyboard's doing — that measurably
+        // does not shift ids here (see `verify_write`'s doc). A tap that navigates can land on a
+        // smaller window, leaving the field's old id past the end of the tree: nothing resolves
+        // there, but the field itself carries the identity and holds the text.
         let after = tree_holding(Some("world"));
         let t = target(7, Some("Search"), Some(BOUNDS));
         assert!(verify_write(&after, &t, "world").is_ok());
@@ -2057,7 +2154,7 @@ mod tests {
     }
 
     #[test]
-    fn two_matching_fields_refuse_and_name_where_they_are() {
+    fn two_matching_fields_refuse_and_say_how_many() {
         // The target's own id must land on something else first — a node still holding it would
         // take the AtId fast path and never learn a second candidate exists.
         let mut container = tree(AxRole::Group, None, Some(BOUNDS), false);
@@ -2070,7 +2167,10 @@ mod tests {
         let t = target(0, Some("Search"), Some(BOUNDS));
         let err = verify_write(&container, &t, "world").unwrap_err();
         assert!(matches!(err, GlassError::AxWriteUnconfirmed(0, _)), "{err}");
-        assert!(err.to_string().contains('2'), "names how many: {err}");
+        assert!(
+            err.to_string().contains("2 elements now match"),
+            "names how many, not just some digit: {err}"
+        );
     }
 
     #[test]

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -296,7 +296,7 @@ fn dump_until_ready(
 }
 
 /// Judge a typed `set_value` from a tree read back after it. `Ok(())` only when the field holds
-/// exactly what was asked for, or — for a clear — reads back empty.
+/// exactly what was asked for, or — for a clear confirmed at its own id — reads back empty.
 ///
 /// Exact match, not "changed from before": tap-and-type is not atomic, so a dropped key or an input
 /// filter leaves the field holding something that is neither the request nor the old value, and
@@ -315,15 +315,25 @@ fn dump_until_ready(
 /// [`locate_editable_target`]: the IME reflows the layout under the field it is typing into, so a
 /// moved-but-correct element is the normal case here.
 ///
-/// The node must also still be editable, which excludes a non-editable neighbour that inherited the
-/// id — but not a second nameless editable, since an editable's name comes from `content-desc` alone
-/// and `AxTarget::matches` compares `None` to `None`. The exact-value requirement is what covers
-/// that case. A node reached by [`Located::AtId`] or [`Located::Moved`] already carries the target's
-/// role and name, so an editability mismatch there is always a change, never a disappearance —
-/// [`AxTarget::drift_error`] cannot return `AxElementGone` on this path.
+/// [`Located::AtId`] and [`Located::Moved`] both already carry the target's role and name —
+/// `relocate` requires the match on the first, and finds the second by searching for exactly that
+/// role and name. So a node reached here that is not editable is not a neighbour that inherited the
+/// id; it is the identified element having lost editability. The write has already dispatched by
+/// this point, so that is [`GlassError::AxWriteUnconfirmed`], not the pre-write
+/// [`AxTarget::drift_error`].
+///
+/// Role+name identity is weakest for a nameless editable — Android names one from `content-desc`
+/// alone, absent on most `EditText`s. A second one elsewhere in the tree is [`Located::Ambiguous`]
+/// and refused; one that happens to sit at the target's own id is accepted on that position alone —
+/// `relocate` never searches once `AtId` matches, and [`AxTarget::matches`] compares `None` to
+/// `None`. A non-empty write's exact-text check is what would catch a coincidental match there; a
+/// clear has nothing for it to catch, so a clear (`text` empty) is confirmed by an empty read-back
+/// only on `AtId`. [`Located::Moved`] found its node purely by search, with no such grounding, so a
+/// clear reached that way is refused as unconfirmed instead.
 fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()> {
-    let node = match target.relocate(after_tree) {
-        Located::AtId(node) | Located::Moved(node) => node,
+    let (node, relocated) = match target.relocate(after_tree) {
+        Located::AtId(node) => (node, false),
+        Located::Moved(node) => (node, true),
         Located::Ambiguous(candidates) => {
             return Err(GlassError::AxWriteUnconfirmed(
                 target.id.0,
@@ -356,7 +366,19 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
         }
     };
     if !node.states.editable {
-        return Err(target.drift_error(after_tree));
+        return Err(GlassError::AxWriteUnconfirmed(
+            target.id.0,
+            "the element at that id is no longer editable, so the value could not be read back"
+                .into(),
+        ));
+    }
+    if relocated && text.is_empty() {
+        return Err(GlassError::AxWriteUnconfirmed(
+            target.id.0,
+            "the element had to be re-found by role and name, so an empty field alone cannot \
+             confirm a clear landed on it"
+                .into(),
+        ));
     }
     let landed = if text.is_empty() {
         typed_clear_landed(node.value.as_deref())
@@ -1981,16 +2003,30 @@ mod tests {
     }
 
     #[test]
-    fn a_non_editable_node_at_the_id_is_reported_as_changed() {
-        // Excludes a non-editable neighbour that inherited the id — a label, or a container the
-        // walk shifted into place.
+    fn a_node_that_lost_editability_is_unconfirmed_not_changed() {
+        // relocate's own role+name match already excludes an unrelated neighbour that inherited
+        // the id, so a non-editable node reached here is the identified element having lost
+        // editability after the write dispatched — AxWriteUnconfirmed, not the pre-write
+        // AxElementChanged, or a caller reading "not dispatched" off it would retype into whatever
+        // it collapsed into.
         let mut after = tree_holding(Some("world"));
         after.root.states.editable = false;
         let t = target(0, Some("Search"), Some(BOUNDS));
-        assert!(matches!(
-            verify_write(&after, &t, "world"),
-            Err(GlassError::AxElementChanged(0))
-        ));
+        let err = verify_write(&after, &t, "world").unwrap_err();
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(0, _)), "{err}");
+        assert!(err.to_string().contains("editable"), "{err}");
+    }
+
+    #[test]
+    fn a_clear_confirmed_only_by_relocating_is_unconfirmed_not_a_success() {
+        // An empty read-back is what any untouched same-role, same-name field would also show, so
+        // Located::Moved's search-only grounding is not enough to trust it: only AtId's own-id
+        // match is. The keystrokes may never have reached this element.
+        let after = under_a_container(tree_holding(None));
+        let t = target(0, Some("Search"), Some(BOUNDS));
+        let err = verify_write(&after, &t, "").unwrap_err();
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(0, _)), "{err}");
+        assert!(err.to_string().contains("clear"), "{err}");
     }
 
     #[test]

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -718,7 +718,7 @@ mod tests {
     use crate::adb::{AdbOp, a_failed_call, a_real_spawn_failure, a_real_timeout_hinted};
     use glass_core::accessibility::{
         AxContext, AxDeadline, AxNode, AxNodeId, AxRect, AxRole, AxStates, AxTarget, AxTree,
-        WalkLimits,
+        Located, WalkLimits,
     };
     use glass_core::{BoundKind, GlassError, Result, WindowGeometry};
     use std::collections::HashMap;
@@ -2061,6 +2061,27 @@ mod tests {
         let err = verify_write(&after, &t, "").unwrap_err();
         assert!(matches!(err, GlassError::AxWriteUnconfirmed(0, _)), "{err}");
         assert!(err.to_string().contains("clear"), "{err}");
+    }
+
+    #[test]
+    fn a_nameless_field_cannot_confirm_a_clear_after_being_re_found_either() {
+        // The `Moved` half of the same hole: `matches` compares None to None during the search too,
+        // so one nameless editable elsewhere is found by identity alone. Refusing only on `AtId`
+        // would let this one through.
+        let after = under_a_container(tree(AxRole::TextField, None, Some(BOUNDS), true));
+        let t = target(0, None, Some(BOUNDS));
+        // Pin the arm: without this the fixture could drift onto AtId and still refuse, for the
+        // reason the test above already covers.
+        assert!(
+            matches!(t.relocate(&after), Located::Moved(n) if n.id == AxNodeId(1)),
+            "fixture must reach the Moved arm"
+        );
+        let err = verify_write(&after, &t, "").unwrap_err();
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(0, _)), "{err}");
+        assert!(
+            err.to_string().contains("no name"),
+            "refused for the identity, not for having relocated: {err}"
+        );
     }
 
     #[test]

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -308,8 +308,7 @@ fn dump_until_ready(
 /// pre-order id. The soft keyboard does not itself shift ids — measured on the dogfood AVD with
 /// `mInputShown=true`, `uiautomator dump` emits the focused window only and no IME window — but a
 /// tap that navigates does: Settings' search entry opens a different window, and the field can turn
-/// up renumbered inside it rather than gone. Re-finding by identity is what lets that be confirmed
-/// instead of refused.
+/// up renumbered inside it rather than gone.
 ///
 /// Bounds are deliberately no part of that identity, unlike the pre-write
 /// [`locate_editable_target`]: the IME reflows the layout under the field it is typing into, so a
@@ -320,11 +319,9 @@ fn dump_until_ready(
 /// time. A leaf like `search_src_text` names a *layout*: it repeats across every instance of it,
 /// and across apps, so a navigating tap can find the next screen's field matching uniquely.
 ///
-/// [`Located::AtId`] and [`Located::Moved`] both already carry the target's role and name —
-/// `relocate` requires the match on the first, and finds the second by searching for exactly that
-/// role and name. So a node reached here that is not editable is not a neighbour that inherited the
-/// id; it is the identified element having lost editability. The write has already dispatched by
-/// this point, so that is [`GlassError::AxWriteUnconfirmed`], not the pre-write
+/// Both arms carry the target's role and name, so a node reached here that is not editable is not a
+/// neighbour that inherited the id; it is the identified element having lost editability. The write
+/// has already dispatched by this point, so that is [`GlassError::AxWriteUnconfirmed`], not the
 /// [`AxTarget::drift_error`].
 ///
 /// A clear (`text` empty) is confirmed only for a target that carries a name. An empty read-back is
@@ -354,8 +351,8 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
             ));
         }
         Located::Unproven => {
-            // Keep the cap in the message: it is what tells a caller to raise `max_nodes`, and
-            // existing tests assert it. A complete tree has no hole to blame, so the one way it
+            // Keep the cap in the message: it is what tells a caller to raise `max_nodes`. A
+            // complete tree has no hole to blame, so the one way it
             // reaches here is a lone match drawn clear of where the element was.
             let why = if let Some(t) = &after_tree.truncated {
                 format!(
@@ -2021,11 +2018,8 @@ mod tests {
 
     #[test]
     fn a_node_that_lost_editability_is_unconfirmed_not_changed() {
-        // relocate's own role+name match already excludes an unrelated neighbour that inherited
-        // the id, so a non-editable node reached here is the identified element having lost
-        // editability after the write dispatched — AxWriteUnconfirmed, not the pre-write
-        // AxElementChanged, or a caller reading "not dispatched" off it would retype into whatever
-        // it collapsed into.
+        // A caller reading "not dispatched" off this would retype into whatever the field
+        // collapsed into.
         let mut after = tree_holding(Some("world"));
         after.root.states.editable = false;
         let t = target(0, Some("Search"), Some(BOUNDS));

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -800,6 +800,21 @@ pub struct AxTarget {
     pub value: Option<String>,
 }
 
+/// Where a target turned up in a tree read after it was captured — see [`AxTarget::relocate`].
+#[derive(Debug)]
+pub enum Located<'a> {
+    /// Still at its own id. The common case, and the only one that costs no walk.
+    AtId(&'a AxNode),
+    /// Exactly one node elsewhere carries its role and name.
+    Moved(&'a AxNode),
+    /// Several do, so the id no longer picks one out. Carries them for the error to name.
+    Ambiguous(Vec<&'a AxNode>),
+    /// None does, in a tree complete enough to say so.
+    Gone,
+    /// None does, but the read stopped early — absence is not shown.
+    Unproven,
+}
+
 impl AxTarget {
     /// Whether a reached node's role + name match this target.
     pub fn matches(&self, role: AxRole, name: Option<&str>) -> bool {
@@ -820,6 +835,33 @@ impl AxTarget {
                 || node.children.iter().any(|c| walk(c, target))
         }
         walk(&tree.root, self)
+    }
+
+    /// Where `tree` now holds this target, if anywhere.
+    ///
+    /// The id is a pre-order index, so anything inserted ahead of the element moves it: on the iOS
+    /// Simulator the focusing tap of a write raises the soft keyboard and shifts the field two places
+    /// (glass#359). Re-finding by identity rather than by index is what lets a read-back confirm a
+    /// write it just performed.
+    ///
+    /// Identity is role and name. Not `value`, which a write changes by definition, and not `bounds`,
+    /// which move under a live app — measured, a field narrowed 1008→828px as its clear button
+    /// appeared. That leaves a weak key, so [`Located::Ambiguous`] refuses rather than picking: a
+    /// second control matching the target anywhere means its id no longer tells them apart.
+    pub fn relocate<'a>(&self, tree: &'a AxTree) -> Located<'a> {
+        if let Some(node) = tree.find(self.id)
+            && self.matches(node.role, node.name.as_deref())
+        {
+            return Located::AtId(node);
+        }
+        let mut candidates = Vec::new();
+        collect(&tree.root, self, &mut candidates);
+        match candidates.len() {
+            1 => Located::Moved(candidates[0]),
+            0 if tree.is_complete() => Located::Gone,
+            0 => Located::Unproven,
+            _ => Located::Ambiguous(candidates),
+        }
     }
 
     /// Which of the two disagreements a tree that no longer agrees with this target has.
@@ -870,6 +912,16 @@ impl AxTarget {
     /// emptied field as no value at all, which is a real change, not a missing observation.
     pub fn value_consistent(&self, got: Option<&str>) -> bool {
         self.value.is_none() || self.value.as_deref() == got
+    }
+}
+
+/// Every node carrying `target`'s role and name, in pre-order.
+fn collect<'a>(node: &'a AxNode, target: &AxTarget, out: &mut Vec<&'a AxNode>) {
+    if target.matches(node.role, node.name.as_deref()) {
+        out.push(node);
+    }
+    for child in &node.children {
+        collect(child, target, out);
     }
 }
 
@@ -2047,6 +2099,67 @@ mod tests {
             drift_target().drift_error(&tree),
             GlassError::AxElementChanged(1)
         ));
+    }
+
+    #[test]
+    fn a_target_still_at_its_id_is_located_there() {
+        let tree = drift_tree(vec![leaf(AxRole::TextField, "Note")]);
+        assert!(matches!(drift_target().relocate(&tree), Located::AtId(n) if n.id == AxNodeId(1)));
+    }
+
+    #[test]
+    fn a_target_renumbered_is_located_at_its_new_id() {
+        // The measured case: the write's keyboard inserts a node ahead of the field.
+        let tree = drift_tree(vec![
+            leaf(AxRole::Label, "Suggestions"),
+            leaf(AxRole::TextField, "Note"),
+        ]);
+        assert!(matches!(drift_target().relocate(&tree), Located::Moved(n) if n.id == AxNodeId(2)));
+    }
+
+    #[test]
+    fn a_second_node_matching_the_target_refuses_rather_than_guessing() {
+        let tree = drift_tree(vec![
+            leaf(AxRole::Label, "Suggestions"),
+            leaf(AxRole::TextField, "Note"),
+            leaf(AxRole::TextField, "Note"),
+        ]);
+        assert!(matches!(drift_target().relocate(&tree), Located::Ambiguous(c) if c.len() == 2));
+    }
+
+    #[test]
+    fn a_target_nothing_matches_in_a_complete_tree_is_gone() {
+        let tree = drift_tree(vec![leaf(AxRole::Label, "No Results")]);
+        assert!(matches!(drift_target().relocate(&tree), Located::Gone));
+    }
+
+    #[test]
+    fn a_truncated_tree_cannot_prove_the_target_absent() {
+        let mut tree = drift_tree(vec![leaf(AxRole::Label, "No Results")]);
+        tree.truncated = Some(Truncation {
+            limit: TruncationLimit::Nodes,
+            limit_value: 1,
+            nodes_walked: 1,
+        });
+        assert!(matches!(drift_target().relocate(&tree), Located::Unproven));
+    }
+
+    #[test]
+    fn a_dropped_subtree_cannot_prove_the_target_absent() {
+        // `unreadable` is independent of the caps.
+        let mut tree = drift_tree(vec![leaf(AxRole::Label, "No Results")]);
+        tree.unreadable = 1;
+        assert!(matches!(drift_target().relocate(&tree), Located::Unproven));
+    }
+
+    #[test]
+    fn a_node_at_the_id_that_is_not_the_target_does_not_shortcut_the_search() {
+        // The id resolves, but to something else; the field is elsewhere. Without the match check on
+        // the AtId path this would return the wrong node.
+        let mut occupied = leaf(AxRole::Button, "Cancel");
+        occupied.children = vec![leaf(AxRole::TextField, "Note")];
+        let tree = drift_tree(vec![occupied]);
+        assert!(matches!(drift_target().relocate(&tree), Located::Moved(n) if n.id == AxNodeId(2)));
     }
 
     #[test]

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -217,6 +217,31 @@ pub struct AxRect {
 }
 
 impl AxRect {
+    /// Whether this rect shares any area with `other`.
+    ///
+    /// Deliberately the weakest geometric relation there is: it admits a control that moved or
+    /// resized under a live app — measured, a field kept its origin and narrowed 1008→828px as its
+    /// clear button appeared — while still separating it from one drawn somewhere else entirely.
+    /// [`AxTarget::bounds_consistent`] is the strict counterpart, for a caller that can demand the
+    /// element has not moved at all. Edges are exclusive, matching
+    /// [`Self::visible_intersection`]'s emptiness test: a zero-area rect overlaps nothing.
+    ///
+    /// `i64` internally so a rect at `i32::MAX` cannot overflow its own right edge.
+    pub fn overlaps(&self, other: AxRect) -> bool {
+        fn edges(r: AxRect) -> (i64, i64, i64, i64) {
+            let (left, top) = (i64::from(r.x), i64::from(r.y));
+            (
+                left,
+                top,
+                left + i64::from(r.width),
+                top + i64::from(r.height),
+            )
+        }
+        let (l1, t1, r1, b1) = edges(*self);
+        let (l2, t2, r2, b2) = edges(other);
+        l1.max(l2) < r1.min(r2) && t1.max(t2) < b1.min(b2)
+    }
+
     /// The element's visible intersection with `[0,win_w) × [0,win_h)`, as
     /// `(left, top, right, bottom)`. `None` when the rect or window has zero area, or the element
     /// has no visible overlap with the window (fully clipped off-screen). Every actuation point
@@ -803,15 +828,19 @@ pub struct AxTarget {
 /// Where a target turned up in a tree read after it was captured — see [`AxTarget::relocate`].
 #[derive(Debug)]
 pub enum Located<'a> {
-    /// Still at its own id. The common case, and the only one that costs no walk.
+    /// Still at its own id. The common case, and the only one that needs no second, full-tree
+    /// search.
     AtId(&'a AxNode),
-    /// Exactly one node elsewhere carries its role and name.
+    /// One node elsewhere carries its role and name, in a tree complete enough for that to mean
+    /// it is the only one, and it overlaps where the target was.
     Moved(&'a AxNode),
     /// Several do, so the id no longer picks one out. Carries them for the error to name.
     Ambiguous(Vec<&'a AxNode>),
     /// None does, in a tree complete enough to say so.
     Gone,
-    /// None does, but the read stopped early — absence is not shown.
+    /// The tree cannot answer: it is missing part of itself (a cap fired, or a subtree could not be
+    /// read and it completed with a hole), or the one node carrying the identity is nowhere near
+    /// where the target was.
     Unproven,
 }
 
@@ -845,9 +874,22 @@ impl AxTarget {
     /// write it just performed.
     ///
     /// Identity is role and name. Not `value`, which a write changes by definition, and not `bounds`,
-    /// which move under a live app — measured, a field narrowed 1008→828px as its clear button
-    /// appeared. That leaves a weak key, so [`Located::Ambiguous`] refuses rather than picking: a
-    /// second control matching the target anywhere means its id no longer tells them apart.
+    /// which move under a live app. That leaves a weak key — on Android an editable's name is
+    /// usually its resource-id leaf, which names a *layout* and so repeats across every screen
+    /// built from it — so [`Located::Moved`] is not granted on the search alone. It also needs:
+    ///
+    /// * [`AxTree::is_complete`], because "one node matches" is a claim about the whole tree and a
+    ///   read that stopped early can only make it about the part it kept; and
+    /// * the candidate's bounds to *overlap* the target's, so a same-named field on a screen the
+    ///   write navigated to is not mistaken for the one that was written into.
+    ///
+    /// Overlap rather than equality: a control moves and resizes without going anywhere, so
+    /// [`AxRect::overlaps`] is the weakest test that still separates two screens. A side with no
+    /// bounds cannot contradict, and does not (see [`Self::bounds_overlap`]). Failing either
+    /// condition is [`Located::Unproven`] — refusing, not accepting on weaker evidence.
+    ///
+    /// The bounds are a disqualifier on acceptance, never part of the search: `matches` stays
+    /// role+name for the reason `still_present`'s doc gives.
     pub fn relocate<'a>(&self, tree: &'a AxTree) -> Located<'a> {
         if let Some(node) = tree.find(self.id)
             && self.matches(node.role, node.name.as_deref())
@@ -855,11 +897,13 @@ impl AxTarget {
             return Located::AtId(node);
         }
         let mut candidates = Vec::new();
-        collect(&tree.root, self, &mut candidates);
+        collect_matches(&tree.root, self, &mut candidates);
         match candidates.len() {
-            1 => Located::Moved(candidates[0]),
+            1 if tree.is_complete() && self.bounds_overlap(candidates[0].bounds) => {
+                Located::Moved(candidates[0])
+            }
             0 if tree.is_complete() => Located::Gone,
-            0 => Located::Unproven,
+            0 | 1 => Located::Unproven,
             _ => Located::Ambiguous(candidates),
         }
     }
@@ -874,10 +918,11 @@ impl AxTarget {
     /// An incomplete tree cannot support that second answer: it shows absence only for the part it
     /// kept, so one that is not [`AxTree::is_complete`] gets the recoverable `AxElementChanged`.
     ///
-    /// Keep this shared. The two snapshot-tree backends ask the same question, and their
-    /// `verify_write` twins drifted apart once already — Android learned to tell the cases apart in
-    /// glass#330, iOS not until glass#360. The desktop readers cannot use it: they re-resolve
-    /// against live platform elements and never hold an `AxTree` to search.
+    /// Lives in core rather than in its caller because the question is not Android's: any reader
+    /// holding an `AxTree` asks it before a write, and the desktop ones would if they had a tree
+    /// (they re-resolve against live platform elements instead). Its one production caller today is
+    /// `glass-android`'s `fingerprinted`; a write's *post*-dispatch read-back answers with
+    /// [`Self::relocate`] and [`GlassError::AxWriteUnconfirmed`], never with this.
     #[must_use]
     pub fn drift_error(&self, tree: &AxTree) -> GlassError {
         if self.still_present(tree) || !tree.is_complete() {
@@ -905,6 +950,17 @@ impl AxTarget {
         }
     }
 
+    /// Whether a reached element's bounds `got` still share any area with this target's captured
+    /// bounds. `true` when either side has none: an absent observation cannot contradict a present
+    /// one. The loose counterpart to [`Self::bounds_consistent`] — see [`AxRect::overlaps`] — and
+    /// what [`Self::relocate`] disqualifies a re-found candidate on.
+    pub fn bounds_overlap(&self, got: Option<AxRect>) -> bool {
+        match (self.bounds, got) {
+            (Some(a), Some(b)) => a.overlaps(b),
+            _ => true,
+        }
+    }
+
     /// Whether a reached element's value `got` is consistent with the value captured for this
     /// target. `true` when none was captured: a captured `None` says the element held no value
     /// then, not which element it was, so gating on it would make every element that never held
@@ -916,12 +972,12 @@ impl AxTarget {
 }
 
 /// Every node carrying `target`'s role and name, in pre-order.
-fn collect<'a>(node: &'a AxNode, target: &AxTarget, out: &mut Vec<&'a AxNode>) {
+fn collect_matches<'a>(node: &'a AxNode, target: &AxTarget, out: &mut Vec<&'a AxNode>) {
     if target.matches(node.role, node.name.as_deref()) {
         out.push(node);
     }
     for child in &node.children {
-        collect(child, target, out);
+        collect_matches(child, target, out);
     }
 }
 
@@ -2150,6 +2206,124 @@ mod tests {
         let mut tree = drift_tree(vec![leaf(AxRole::Label, "No Results")]);
         tree.unreadable = 1;
         assert!(matches!(drift_target().relocate(&tree), Located::Unproven));
+    }
+
+    /// Where the measured iOS field sat before the write: origin `(99,2409)`, 1008px wide.
+    const CAPTURED: AxRect = AxRect {
+        x: 99,
+        y: 2409,
+        width: 1008,
+        height: 44,
+    };
+
+    /// The `TextField "Note"` `drift_target` names, drawn at `bounds`.
+    fn field_at(bounds: AxRect) -> AxNode {
+        let mut node = leaf(AxRole::TextField, "Note");
+        node.bounds = Some(bounds);
+        node
+    }
+
+    /// [`drift_target`], captured at `bounds` rather than with none.
+    fn target_at(bounds: AxRect) -> AxTarget {
+        AxTarget {
+            bounds: Some(bounds),
+            ..drift_target()
+        }
+    }
+
+    /// The renumbered-field tree, with `moved` standing in for the field at its new id.
+    fn renumbered(moved: AxNode) -> AxTree {
+        drift_tree(vec![leaf(AxRole::Label, "Suggestions"), moved])
+    }
+
+    #[test]
+    fn a_truncated_tree_cannot_prove_the_only_match_is_the_only_one() {
+        // Moved is a claim about the whole tree — this node and no other. A cap that fired makes it
+        // a claim about the part that was kept, and the second field may be the one past the cap.
+        let mut tree = renumbered(leaf(AxRole::TextField, "Note"));
+        tree.truncated = Some(Truncation {
+            limit: TruncationLimit::Nodes,
+            limit_value: 2,
+            nodes_walked: 2,
+        });
+        assert!(matches!(drift_target().relocate(&tree), Located::Unproven));
+    }
+
+    #[test]
+    fn a_dropped_subtree_cannot_prove_the_only_match_is_the_only_one() {
+        // Independent of the caps: the read completed, with a hole the second field could be in.
+        let mut tree = renumbered(leaf(AxRole::TextField, "Note"));
+        tree.unreadable = 1;
+        assert!(matches!(drift_target().relocate(&tree), Located::Unproven));
+    }
+
+    #[test]
+    fn a_match_drawn_somewhere_else_is_not_the_element_that_moved() {
+        // An Android editable is usually named by its resource-id leaf, which names a layout rather
+        // than an instance, so a tap that navigates finds the next screen's field matching uniquely
+        // on role and name. Geometry is the only thing that says it is not the one written into.
+        let elsewhere = renumbered(field_at(AxRect { y: 120, ..CAPTURED }));
+        assert!(matches!(
+            target_at(CAPTURED).relocate(&elsewhere),
+            Located::Unproven
+        ));
+    }
+
+    #[test]
+    fn a_match_that_only_resized_is_still_the_element() {
+        // Why overlap and not equality: measured, the field kept its origin and narrowed 1008→828px
+        // as its clear button appeared. Demanding the same rect would refuse the very write the
+        // relocation exists to confirm.
+        let narrowed = renumbered(field_at(AxRect {
+            width: 828,
+            ..CAPTURED
+        }));
+        assert!(
+            matches!(target_at(CAPTURED).relocate(&narrowed), Located::Moved(n) if n.id == AxNodeId(2))
+        );
+    }
+
+    #[test]
+    fn bounds_disqualify_a_match_only_when_both_sides_have_them() {
+        // A missing observation cannot contradict a present one, on either side — and gating on one
+        // would make every element a backend reports without geometry unconfirmable.
+        let bounded = renumbered(field_at(CAPTURED));
+        assert!(matches!(
+            drift_target().relocate(&bounded),
+            Located::Moved(_)
+        ));
+        let unbounded = renumbered(leaf(AxRole::TextField, "Note"));
+        assert!(matches!(
+            target_at(CAPTURED).relocate(&unbounded),
+            Located::Moved(_)
+        ));
+    }
+
+    #[test]
+    fn a_genuine_match_at_the_id_beats_a_second_one_elsewhere() {
+        // The AtId fast path is checked before the search on purpose: the node on the target's own
+        // id carries its role and name, so the id does still pick one out, and a same-named control
+        // elsewhere does not make that ambiguous. Returning Ambiguous first leaves the rest green.
+        let tree = drift_tree(vec![
+            leaf(AxRole::TextField, "Note"),
+            leaf(AxRole::TextField, "Note"),
+        ]);
+        assert!(matches!(drift_target().relocate(&tree), Located::AtId(n) if n.id == AxNodeId(1)));
+    }
+
+    #[test]
+    fn rects_overlap_only_where_they_share_area() {
+        let a = AxRect {
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 10,
+        };
+        assert!(a.overlaps(AxRect { x: 9, y: 9, ..a }));
+        // Edge-to-edge is not shared area, and a zero-area rect covers nothing.
+        assert!(!a.overlaps(AxRect { x: 10, ..a }));
+        assert!(!a.overlaps(AxRect { y: 10, ..a }));
+        assert!(!a.overlaps(AxRect { width: 0, ..a }));
     }
 
     #[test]

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -135,6 +135,14 @@ pub enum GlassError {
     )]
     AxElementGone(u32),
 
+    /// A write that went out and could not then be confirmed. Distinct from the pre-write
+    /// refusals because only this one has dispatched — see `set_value_failed_after_writing`.
+    #[error(
+        "element #{0}: the text was typed, but the write could not be confirmed — {1}. Re-snapshot \
+         to see where it landed rather than typing it again"
+    )]
+    AxWriteUnconfirmed(u32, String),
+
     #[error(
         "set_value on element #{0} did not take — the element does not hold the requested value. On \
          a desktop backend this usually means a read-only accessibility projection, so try \
@@ -242,9 +250,10 @@ impl GlassError {
     }
 
     /// Whether a failed value-write is **proven** to have gone out before failing — the only case
-    /// where the session's captured value is stale and must be dropped. True for the read-back
-    /// verdict [`GlassError::AxValueNotApplied`], raised only after a write was dispatched; false
-    /// for everything else, including variants added later.
+    /// where the session's captured value is stale and must be dropped. True for two post-dispatch
+    /// verdicts: [`GlassError::AxValueNotApplied`] and [`GlassError::AxWriteUnconfirmed`], both
+    /// raised only after a write was dispatched; false for everything else, including variants
+    /// added later.
     ///
     /// Same "did anything dispatch?" question as [`Self::invoke_fallback_eligible`], but decided by
     /// an allowlist, because the two mistakes are not symmetric. Keeping the value can only make
@@ -257,7 +266,10 @@ impl GlassError {
     /// adb handshake fail the same way its post-write read-back does — so no variant-level split
     /// separates them, and the recoverable answer has to win.
     pub fn set_value_failed_after_writing(&self) -> bool {
-        matches!(self, GlassError::AxValueNotApplied(_))
+        matches!(
+            self,
+            GlassError::AxValueNotApplied(_) | GlassError::AxWriteUnconfirmed(..)
+        )
     }
 
     /// Which of glass's own bounds ended this call, if one did rather than the tool answering.
@@ -553,6 +565,37 @@ mod tests {
         ] {
             assert!(!e.set_value_failed_after_writing(), "{e}");
         }
+    }
+
+    #[test]
+    fn an_unconfirmed_write_says_the_text_was_typed() {
+        let e = GlassError::AxWriteUnconfirmed(
+            7,
+            "nothing in the tree carries its role and name".into(),
+        );
+        let msg = e.to_string();
+        assert!(msg.contains("the text was typed"), "{msg}");
+        assert!(
+            msg.contains("nothing in the tree carries its role and name"),
+            "{msg}"
+        );
+        assert!(
+            msg.contains("rather than"),
+            "names what to do instead of retyping: {msg}"
+        );
+    }
+
+    #[test]
+    fn an_unconfirmed_write_counts_as_dispatched() {
+        // The session must drop its cached value: the write went out, so the value it holds is stale.
+        assert!(GlassError::AxWriteUnconfirmed(7, "x".into()).set_value_failed_after_writing());
+    }
+
+    #[test]
+    fn a_pre_write_refusal_still_counts_as_not_dispatched() {
+        // AxElementGone is raised on both sides of the write on Android, so it must stay out.
+        assert!(!GlassError::AxElementGone(7).set_value_failed_after_writing());
+        assert!(!GlassError::AxElementChanged(7).set_value_failed_after_writing());
     }
 
     #[test]

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -579,6 +579,9 @@ mod tests {
             msg.contains("nothing in the tree carries its role and name"),
             "{msg}"
         );
+        // The id is what a caller re-addresses; dropping `element #{0}` from the template left
+        // every other assertion here green.
+        assert!(msg.contains("element #7"), "names the element: {msg}");
         assert!(
             msg.contains("rather than"),
             "names what to do instead of retyping: {msg}"

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -445,6 +445,30 @@ mod tests {
     }
 
     #[test]
+    fn a_nameless_field_cannot_confirm_a_clear_after_being_re_found_either() {
+        // The `Moved` half of the same hole: `matches` compares None to None during the search too,
+        // so one nameless editable elsewhere is found by identity alone. Refusing only on `AtId`
+        // would let this one through.
+        let mut moved = leaf(0, AxRole::TextField, "Note", FIELD);
+        moved.name = None;
+        let after = tree_with(vec![leaf(0, AxRole::Label, "Suggestions", FIELD), moved]);
+        let mut target = matching_target();
+        target.name = None;
+        // Pin the arm: without this the fixture could drift onto AtId and still refuse, for the
+        // reason the test above already covers.
+        assert!(
+            matches!(target.relocate(&after), Located::Moved(n) if n.id == AxNodeId(2)),
+            "fixture must reach the Moved arm"
+        );
+        let err = verify_write(&after, &target, "").unwrap_err();
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(1, _)), "{err}");
+        assert!(
+            err.to_string().contains("no name"),
+            "refused for the identity, not for having relocated: {err}"
+        );
+    }
+
+    #[test]
     fn a_nameless_field_still_confirms_the_text_it_was_given() {
         // The identity is just as weak here; the typed text is what grounds it instead.
         let (after, target) = nameless(Some("world"));

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -94,7 +94,7 @@ const VERIFY_SETTLE: Duration = Duration::from_millis(300);
 const VERIFY_ATTEMPTS: usize = 3;
 
 /// Judge a typed `set_value` from a tree described after it. `Ok(())` only when the field holds
-/// exactly what was asked for, or — for a clear confirmed at its own id — reads back empty.
+/// exactly what was asked for, or — for a named field — reads back empty after a clear.
 ///
 /// Exact match, not "changed from before": tap-and-type is not atomic, so a dropped key or a field
 /// that filters input leaves something that is neither the request nor the old value, and calling
@@ -104,25 +104,27 @@ const VERIFY_ATTEMPTS: usize = 3;
 ///
 /// The element is re-resolved by identity (role + name) via [`AxTarget::relocate`], not by its
 /// pre-order id: measured on the Simulator, the focusing tap raises the soft keyboard and inserts
-/// two nodes ahead of the field (glass#359), so the id itself is not stable across the write.
+/// two nodes ahead of the field (glass#359), so the id itself is not stable across the write. A node
+/// re-found that way is accepted only from a complete tree and only where it still overlaps where
+/// the target was, so a same-named field on a screen the tap navigated to is refused instead.
 ///
 /// The node must also still be editable: for a non-editable node `axmap` puts the element's AXLabel
 /// in `value`, so a label that changed inside the settle window would otherwise read as a successful
 /// write into a Label. [`Located::AtId`] and [`Located::Moved`] both already carry the target's role
 /// and name, so a node reached here that is not editable is not a neighbour that inherited the id —
-/// it is the identified element having lost editability. The write has already dispatched by this
-/// point, so that is [`GlassError::AxWriteUnconfirmed`], not the pre-write [`AxTarget::drift_error`].
+/// it is the identified element having lost editability. Every refusal here is post-dispatch, hence
+/// [`GlassError::AxWriteUnconfirmed`] throughout; the pre-write guard is `verify` above, which still
+/// answers in `Backend` strings (glass#361).
 ///
-/// A clear (`text` empty) is confirmed by an empty read-back only on [`Located::AtId`]: a non-empty
-/// write's exact-text check is itself evidence the right element was found, but an empty field is
-/// not — any untouched same-role, same-name neighbour would read back the same way. `AtId` still
-/// trusts it, matching this reader's existing tolerance for that coincidence; [`Located::Moved`]
-/// found the node purely by searching for role and name, with no such grounding, so a clear reached
-/// that way is refused as unconfirmed instead.
+/// A clear (`text` empty) is confirmed only for a target that carries a name. An empty read-back is
+/// what any untouched same-role, same-name field would also show, so it is evidence of the write
+/// only inasmuch as the identity that found the field is discriminating — a non-empty write's
+/// exact-text check grounds itself, a clear has nothing to. A nameless target is refused however it
+/// was reached, its own id included: [`AxTarget::matches`] compares `None` to `None`, so `AtId`
+/// there accepts whatever nameless editable renumbering slid onto the id.
 fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()> {
-    let (node, relocated) = match target.relocate(after_tree) {
-        Located::AtId(node) => (node, false),
-        Located::Moved(node) => (node, true),
+    let node = match target.relocate(after_tree) {
+        Located::AtId(node) | Located::Moved(node) => node,
         Located::Ambiguous(candidates) => {
             return Err(GlassError::AxWriteUnconfirmed(
                 target.id.0,
@@ -142,14 +144,23 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
         }
         Located::Unproven => {
             // Keep the cap in the message: it is what tells a caller to raise `max_nodes`, and
-            // existing tests assert it. `unreadable` has no number to name, so it says why instead.
-            let why = match &after_tree.truncated {
-                Some(t) => format!(
-                    "the tree was truncated at {} {}, so the element may be past the cap",
+            // existing tests assert it. A complete tree has no hole to blame, so the one way it
+            // reaches here is a lone match drawn clear of where the element was.
+            let why = if let Some(t) = &after_tree.truncated {
+                format!(
+                    "the tree was truncated at {} {}, so the element — or a second one matching \
+                     it — may be past the cap",
                     t.limit_value,
                     t.limit.label()
-                ),
-                None => "a subtree could not be read, so the element may be inside it".to_string(),
+                )
+            } else if after_tree.unreadable > 0 {
+                "a subtree could not be read, so the element — or a second one matching it — may \
+                 be inside it"
+                    .to_string()
+            } else {
+                "the only element carrying its role and name is drawn clear of where this one \
+                 was, so it may be a different one"
+                    .to_string()
             };
             return Err(GlassError::AxWriteUnconfirmed(target.id.0, why));
         }
@@ -161,11 +172,11 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
                 .into(),
         ));
     }
-    if relocated && text.is_empty() {
+    if text.is_empty() && target.name.is_none() {
         return Err(GlassError::AxWriteUnconfirmed(
             target.id.0,
-            "the element had to be re-found by role and name, so an empty field alone cannot \
-             confirm a clear landed on it"
+            "the element has no name, so nothing but its position identifies it and an empty \
+             field cannot confirm a clear landed on it"
                 .into(),
         ));
     }
@@ -179,6 +190,15 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
     } else {
         Err(GlassError::AxValueNotApplied(target.id.0))
     }
+}
+
+/// The read-back's own failure, reported as an unconfirmed write.
+///
+/// Post-dispatch by construction: its only caller is the loop that runs after the keystrokes went
+/// out. A verdict `GlassError::set_value_failed_after_writing` rejects would leave the session
+/// holding the value it cached for a write that already landed, and refuse the retry as drift.
+fn read_back_failed(target: &AxTarget, e: &GlassError) -> GlassError {
+    GlassError::AxWriteUnconfirmed(target.id.0, format!("reading the element back failed: {e}"))
 }
 
 impl Accessibility for IosA11y {
@@ -217,12 +237,9 @@ impl Accessibility for IosA11y {
         let mut last = None;
         for _ in 0..VERIFY_ATTEMPTS {
             std::thread::sleep(VERIFY_SETTLE);
-            let (after, _) = self.describe(ctx).map_err(|e| {
-                GlassError::Backend(format!(
-                    "a11y set_value: the text was typed, but reading the element back failed: {e}; \
-                     re-snapshot to see whether it landed rather than retyping"
-                ))
-            })?;
+            let (after, _) = self
+                .describe(ctx)
+                .map_err(|e| read_back_failed(target, &e))?;
             match verify_write(&after, target, text) {
                 Ok(()) => return Ok(()),
                 // Only a not-applied verdict can change on a later describe: drift and truncation
@@ -386,9 +403,9 @@ mod tests {
     fn a_node_that_lost_editability_is_unconfirmed_not_changed() {
         // relocate's own role+name match already excludes an unrelated neighbour that inherited
         // the id, so a non-editable node reached here is the identified element having lost
-        // editability after the write dispatched — AxWriteUnconfirmed, not the pre-write
-        // AxElementChanged, or a caller reading "not dispatched" off it would retype into whatever
-        // it collapsed into.
+        // editability after the write dispatched. That has to be AxWriteUnconfirmed and not the
+        // AxElementNotEditable the pre-write `verify` raises, or a caller reading "not dispatched"
+        // off it would retype into whatever the element collapsed into.
         let mut after = tree_with_value(Some("world"));
         after.root.children[0].states.editable = false;
         let err = verify_write(&after, &matching_target(), "world").unwrap_err();
@@ -396,16 +413,95 @@ mod tests {
         assert!(err.to_string().contains("editable"), "{err}");
     }
 
+    /// The field with no name at all, which is where role+name identity runs out.
+    fn nameless(value: Option<&str>) -> (AxTree, AxTarget) {
+        let mut field = leaf(0, AxRole::TextField, "Note", FIELD);
+        field.name = None;
+        field.value = value.map(Into::into);
+        let mut target = matching_target();
+        target.name = None;
+        (tree_with(vec![field]), target)
+    }
+
     #[test]
-    fn a_clear_confirmed_only_by_relocating_is_unconfirmed_not_a_success() {
-        // An empty read-back is what any untouched same-role, same-name field would also show, so
-        // Located::Moved's search-only grounding is not enough to trust it: only AtId's own-id
-        // match is. The keystrokes may never have reached this element.
+    fn a_named_field_clears_after_being_re_found() {
+        // The write's own focusing tap inserts two nodes ahead of the field, so a clear into a field
+        // that was not already focused ALWAYS relocates. Keying the refusal on that made it fail by
+        // construction; the name is what identifies the field, and the name survives the move.
         let moved = leaf(0, AxRole::TextField, "Note", FIELD);
         let after = tree_with(vec![leaf(0, AxRole::Label, "Suggestions", FIELD), moved]);
-        let err = verify_write(&after, &matching_target(), "").unwrap_err();
+        assert!(verify_write(&after, &matching_target(), "").is_ok());
+    }
+
+    #[test]
+    fn a_nameless_field_cannot_confirm_a_clear_at_its_own_id() {
+        // `AxTarget::matches` compares None to None, so the id alone accepts whatever nameless
+        // editable renumbering slid onto it — and an empty read-back is exactly what that one shows
+        // too. Nothing but the position says the keystrokes reached this field.
+        let (after, target) = nameless(None);
+        let err = verify_write(&after, &target, "").unwrap_err();
         assert!(matches!(err, GlassError::AxWriteUnconfirmed(1, _)), "{err}");
         assert!(err.to_string().contains("clear"), "{err}");
+    }
+
+    #[test]
+    fn a_nameless_field_still_confirms_the_text_it_was_given() {
+        // The identity is just as weak here; the typed text is what grounds it instead.
+        let (after, target) = nameless(Some("world"));
+        assert!(verify_write(&after, &target, "world").is_ok());
+    }
+
+    #[test]
+    fn losing_editability_outranks_the_clear_refusal() {
+        // Both refusals fit a nameless non-editable node. Editability is the specific fact, and a
+        // caller told only "an empty field cannot confirm a clear" would go on hunting for a field.
+        let (mut after, target) = nameless(None);
+        after.root.children[0].states.editable = false;
+        let err = verify_write(&after, &target, "").unwrap_err();
+        assert!(err.to_string().contains("editable"), "{err}");
+    }
+
+    #[test]
+    fn a_field_drawn_clear_of_the_target_does_not_confirm_the_write() {
+        // Role and name pick out exactly one node, and it is nowhere near where the element was —
+        // the shape of a tap that navigated, where the keystrokes went to another screen's field.
+        let mut moved = leaf(0, AxRole::TextField, "Note", AxRect { y: 600, ..FIELD });
+        moved.value = Some("world".into());
+        let after = tree_with(vec![leaf(0, AxRole::Label, "Suggestions", FIELD), moved]);
+        let err = verify_write(&after, &matching_target(), "world").unwrap_err();
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(1, _)), "{err}");
+        assert!(err.to_string().contains("drawn clear of where"), "{err}");
+    }
+
+    #[test]
+    fn a_truncated_tree_cannot_confirm_a_write_against_its_one_match() {
+        // One match in the part that was kept is not one match in the tree: the second may be past
+        // the cap, which is the refusal a complete tree makes as Ambiguous.
+        let mut moved = leaf(0, AxRole::TextField, "Note", FIELD);
+        moved.value = Some("world".into());
+        let mut after = tree_with(vec![leaf(0, AxRole::Label, "Suggestions", FIELD), moved]);
+        after.truncated = Some(glass_core::accessibility::Truncation {
+            limit: glass_core::accessibility::TruncationLimit::Nodes,
+            limit_value: 3,
+            nodes_walked: 3,
+        });
+        let err = verify_write(&after, &matching_target(), "world").unwrap_err();
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(1, _)), "{err}");
+        assert!(err.to_string().contains("truncated at 3 nodes"), "{err}");
+    }
+
+    #[test]
+    fn a_failed_read_back_reports_the_write_as_unconfirmed() {
+        // The read runs after the keystrokes went out, so a transport failure here must be a verdict
+        // `set_value_failed_after_writing` accepts — otherwise the session keeps the value it cached
+        // for a write that already landed and refuses the retry as drift.
+        let err = read_back_failed(
+            &matching_target(),
+            &GlassError::Backend("idb: connection reset".into()),
+        );
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(1, _)), "{err}");
+        assert!(err.set_value_failed_after_writing(), "{err}");
+        assert!(err.to_string().contains("connection reset"), "{err}");
     }
 
     #[test]
@@ -447,7 +543,7 @@ mod tests {
     }
 
     #[test]
-    fn two_matching_fields_refuse_and_name_where_they_are() {
+    fn two_matching_fields_refuse_and_say_how_many() {
         // The target's own id must land on something else first — a node still holding it would
         // take the AtId fast path and never learn a second candidate exists.
         let mut a = leaf(0, AxRole::TextField, "Note", FIELD);
@@ -457,7 +553,10 @@ mod tests {
         let after = tree_with(vec![leaf(0, AxRole::Label, "Suggestions", FIELD), a, b]);
         let err = verify_write(&after, &matching_target(), "world").unwrap_err();
         assert!(matches!(err, GlassError::AxWriteUnconfirmed(1, _)), "{err}");
-        assert!(err.to_string().contains('2'), "names how many: {err}");
+        assert!(
+            err.to_string().contains("2 elements now match"),
+            "names how many, not just some digit: {err}"
+        );
     }
 
     #[test]

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -143,8 +143,8 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
             ));
         }
         Located::Unproven => {
-            // Keep the cap in the message: it is what tells a caller to raise `max_nodes`, and
-            // existing tests assert it. A complete tree has no hole to blame, so the one way it
+            // Keep the cap in the message: it is what tells a caller to raise `max_nodes`. A
+            // complete tree has no hole to blame, so the one way it
             // reaches here is a lone match drawn clear of where the element was.
             let why = if let Some(t) = &after_tree.truncated {
                 format!(
@@ -401,11 +401,8 @@ mod tests {
 
     #[test]
     fn a_node_that_lost_editability_is_unconfirmed_not_changed() {
-        // relocate's own role+name match already excludes an unrelated neighbour that inherited
-        // the id, so a non-editable node reached here is the identified element having lost
-        // editability after the write dispatched. That has to be AxWriteUnconfirmed and not the
-        // AxElementNotEditable the pre-write `verify` raises, or a caller reading "not dispatched"
-        // off it would retype into whatever the element collapsed into.
+        // Not the `AxElementNotEditable` the pre-write `verify` raises: a caller reading "not
+        // dispatched" off that would retype into whatever the element collapsed into.
         let mut after = tree_with_value(Some("world"));
         after.root.children[0].states.editable = false;
         let err = verify_write(&after, &matching_target(), "world").unwrap_err();

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -94,7 +94,7 @@ const VERIFY_SETTLE: Duration = Duration::from_millis(300);
 const VERIFY_ATTEMPTS: usize = 3;
 
 /// Judge a typed `set_value` from a tree described after it. `Ok(())` only when the field holds
-/// exactly what was asked for, or — for a clear — reads back empty.
+/// exactly what was asked for, or — for a clear confirmed at its own id — reads back empty.
 ///
 /// Exact match, not "changed from before": tap-and-type is not atomic, so a dropped key or a field
 /// that filters input leaves something that is neither the request nor the old value, and calling
@@ -108,12 +108,21 @@ const VERIFY_ATTEMPTS: usize = 3;
 ///
 /// The node must also still be editable: for a non-editable node `axmap` puts the element's AXLabel
 /// in `value`, so a label that changed inside the settle window would otherwise read as a successful
-/// write into a Label. A node reached by [`Located::AtId`] or [`Located::Moved`] already carries the
-/// target's role and name, so an editability mismatch there is always a change, never a disappearance
-/// — [`AxTarget::drift_error`] cannot return `AxElementGone` on this path.
+/// write into a Label. [`Located::AtId`] and [`Located::Moved`] both already carry the target's role
+/// and name, so a node reached here that is not editable is not a neighbour that inherited the id —
+/// it is the identified element having lost editability. The write has already dispatched by this
+/// point, so that is [`GlassError::AxWriteUnconfirmed`], not the pre-write [`AxTarget::drift_error`].
+///
+/// A clear (`text` empty) is confirmed by an empty read-back only on [`Located::AtId`]: a non-empty
+/// write's exact-text check is itself evidence the right element was found, but an empty field is
+/// not — any untouched same-role, same-name neighbour would read back the same way. `AtId` still
+/// trusts it, matching this reader's existing tolerance for that coincidence; [`Located::Moved`]
+/// found the node purely by searching for role and name, with no such grounding, so a clear reached
+/// that way is refused as unconfirmed instead.
 fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()> {
-    let node = match target.relocate(after_tree) {
-        Located::AtId(node) | Located::Moved(node) => node,
+    let (node, relocated) = match target.relocate(after_tree) {
+        Located::AtId(node) => (node, false),
+        Located::Moved(node) => (node, true),
         Located::Ambiguous(candidates) => {
             return Err(GlassError::AxWriteUnconfirmed(
                 target.id.0,
@@ -146,7 +155,19 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
         }
     };
     if !node.states.editable {
-        return Err(target.drift_error(after_tree));
+        return Err(GlassError::AxWriteUnconfirmed(
+            target.id.0,
+            "the element at that id is no longer editable, so the value could not be read back"
+                .into(),
+        ));
+    }
+    if relocated && text.is_empty() {
+        return Err(GlassError::AxWriteUnconfirmed(
+            target.id.0,
+            "the element had to be re-found by role and name, so an empty field alone cannot \
+             confirm a clear landed on it"
+                .into(),
+        ));
     }
     let landed = if text.is_empty() {
         typed_clear_landed(node.value.as_deref())
@@ -362,15 +383,29 @@ mod tests {
     }
 
     #[test]
-    fn a_non_editable_node_at_the_id_is_reported_as_changed() {
-        // For a non-editable node this reader puts the element's AXLabel in `value`, so without the
-        // editable gate a label that changed inside the settle window read as a successful write.
+    fn a_node_that_lost_editability_is_unconfirmed_not_changed() {
+        // relocate's own role+name match already excludes an unrelated neighbour that inherited
+        // the id, so a non-editable node reached here is the identified element having lost
+        // editability after the write dispatched — AxWriteUnconfirmed, not the pre-write
+        // AxElementChanged, or a caller reading "not dispatched" off it would retype into whatever
+        // it collapsed into.
         let mut after = tree_with_value(Some("world"));
         after.root.children[0].states.editable = false;
-        assert!(matches!(
-            verify_write(&after, &matching_target(), "world"),
-            Err(GlassError::AxElementChanged(1))
-        ));
+        let err = verify_write(&after, &matching_target(), "world").unwrap_err();
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(1, _)), "{err}");
+        assert!(err.to_string().contains("editable"), "{err}");
+    }
+
+    #[test]
+    fn a_clear_confirmed_only_by_relocating_is_unconfirmed_not_a_success() {
+        // An empty read-back is what any untouched same-role, same-name field would also show, so
+        // Located::Moved's search-only grounding is not enough to trust it: only AtId's own-id
+        // match is. The keystrokes may never have reached this element.
+        let moved = leaf(0, AxRole::TextField, "Note", FIELD);
+        let after = tree_with(vec![leaf(0, AxRole::Label, "Suggestions", FIELD), moved]);
+        let err = verify_write(&after, &matching_target(), "").unwrap_err();
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(1, _)), "{err}");
+        assert!(err.to_string().contains("clear"), "{err}");
     }
 
     #[test]

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -2,7 +2,7 @@
 //! nested JSON to an AxTree; set_value re-verifies the target element (guarding
 //! against a stale id landing on a different element), focuses it, clears it, and
 //! types the new text via synthetic HID input, then reads the element back and reports the write as not applied if it does not hold it.
-use glass_core::accessibility::{Accessibility, AxContext, AxRect, AxTarget, AxTree};
+use glass_core::accessibility::{Accessibility, AxContext, AxRect, AxTarget, AxTree, Located};
 use std::time::Duration;
 
 use glass_core::{
@@ -102,31 +102,50 @@ const VERIFY_ATTEMPTS: usize = 3;
 /// `glass_core::typed_clear_landed` carry the rules and the cost of them. Twin of `verify_write` in
 /// `glass-android/src/a11y.rs` — keep the two in step.
 ///
-/// The element is re-resolved by its pre-order id, which the write itself perturbs: measured on the
-/// Simulator, the focusing tap raises the soft keyboard and inserts two nodes ahead of the field
-/// (glass#359). So a mismatch is a claim about the tree rather than about the write, and
-/// [`AxTarget::drift_error`] decides which of the two. A tree cut short by the walk caps explains an
-/// absent element better than either, so that case says so instead.
+/// The element is re-resolved by identity (role + name) via [`AxTarget::relocate`], not by its
+/// pre-order id: measured on the Simulator, the focusing tap raises the soft keyboard and inserts
+/// two nodes ahead of the field (glass#359), so the id itself is not stable across the write.
 ///
 /// The node must also still be editable: for a non-editable node `axmap` puts the element's AXLabel
 /// in `value`, so a label that changed inside the settle window would otherwise read as a successful
-/// write into a Label.
+/// write into a Label. A node reached by [`Located::AtId`] or [`Located::Moved`] already carries the
+/// target's role and name, so an editability mismatch there is always a change, never a disappearance
+/// — [`AxTarget::drift_error`] cannot return `AxElementGone` on this path.
 fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()> {
-    let Some(node) = after_tree.find(target.id) else {
-        return Err(match &after_tree.truncated {
-            // `Truncation::notice()` is written to close a rendered outline — a leading ellipsis and
-            // its own pixel-fallback advice — so this states the cap itself instead.
-            Some(t) => GlassError::AccessibilityUnavailable(format!(
-                "a11y set_value: the text was typed, but the read-back could not find element {} \
-                 because the tree was truncated at {} {}; re-snapshot rather than retyping",
+    let node = match target.relocate(after_tree) {
+        Located::AtId(node) | Located::Moved(node) => node,
+        Located::Ambiguous(candidates) => {
+            return Err(GlassError::AxWriteUnconfirmed(
                 target.id.0,
-                t.limit_value,
-                t.limit.label(),
-            )),
-            None => target.drift_error(after_tree),
-        });
+                format!(
+                    "{} elements now match its role and name, so which one holds it cannot be told",
+                    candidates.len()
+                ),
+            ));
+        }
+        Located::Gone => {
+            return Err(GlassError::AxWriteUnconfirmed(
+                target.id.0,
+                "nothing in the tree carries its role and name, so the screen it was on was \
+                 replaced"
+                    .into(),
+            ));
+        }
+        Located::Unproven => {
+            // Keep the cap in the message: it is what tells a caller to raise `max_nodes`, and
+            // existing tests assert it. `unreadable` has no number to name, so it says why instead.
+            let why = match &after_tree.truncated {
+                Some(t) => format!(
+                    "the tree was truncated at {} {}, so the element may be past the cap",
+                    t.limit_value,
+                    t.limit.label()
+                ),
+                None => "a subtree could not be read, so the element may be inside it".to_string(),
+            };
+            return Err(GlassError::AxWriteUnconfirmed(target.id.0, why));
+        }
     };
-    if !target.matches(node.role, node.name.as_deref()) || !node.states.editable {
+    if !node.states.editable {
         return Err(target.drift_error(after_tree));
     }
     let landed = if text.is_empty() {
@@ -217,7 +236,7 @@ mod tests {
         }
     }
 
-    fn tree_with(field: AxNode) -> AxTree {
+    fn tree_with(children: Vec<AxNode>) -> AxTree {
         let root = AxNode {
             id: AxNodeId(0),
             role: AxRole::Window,
@@ -232,7 +251,7 @@ mod tests {
                 width: 400,
                 height: 800,
             }),
-            children: vec![field],
+            children,
         };
         let mut t = AxTree::new(root);
         t.assign_ids();
@@ -250,7 +269,7 @@ mod tests {
     fn tree_with_value(value: Option<&str>) -> AxTree {
         let mut field = leaf(0, AxRole::TextField, "Note", FIELD);
         field.value = value.map(Into::into);
-        tree_with(field)
+        tree_with(vec![field])
     }
 
     /// A target matching that field as the snapshot before the write saw it.
@@ -293,19 +312,17 @@ mod tests {
     #[test]
     fn a_truncated_read_back_says_so_rather_than_blaming_drift() {
         // The iOS tree carries the same truncation record Android's does; reporting "it moved" would
-        // throw away the one fact that explains the absence.
-        let mut after = tree_with_value(Some("world"));
+        // throw away the one fact that explains the absence. No node here carries the target's role
+        // and name, so a complete tree would call this Gone — the cap is what keeps it Unproven.
+        let mut after = tree_with(vec![leaf(0, AxRole::Label, "No Results", FIELD)]);
         after.truncated = Some(glass_core::accessibility::Truncation {
             limit: glass_core::accessibility::TruncationLimit::Nodes,
             limit_value: 1,
             nodes_walked: 1,
         });
-        let mut t = matching_target();
-        t.id = AxNodeId(99);
-        assert!(matches!(
-            verify_write(&after, &t, "world"),
-            Err(GlassError::AccessibilityUnavailable(_))
-        ));
+        let err = verify_write(&after, &matching_target(), "world").unwrap_err();
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(1, _)), "{err}");
+        assert!(err.to_string().contains("truncated at 1 nodes"), "{err}");
     }
 
     #[test]
@@ -329,17 +346,18 @@ mod tests {
     }
 
     #[test]
-    fn a_target_that_moved_is_reported_as_changed_not_as_a_failed_write() {
-        // A genuine move: something else now occupies the target's id, and the field is further
-        // down the tree.
+    fn a_relocated_write_still_checks_what_landed() {
+        // Re-finding by identity must not shortcut the value check: something else now occupies the
+        // target's id, the field is elsewhere in the tree, and it holds text other than what was
+        // typed — still not a successful write.
         let mut root_field = leaf(0, AxRole::Label, "Heading", FIELD);
         let mut moved = leaf(0, AxRole::TextField, "Note", FIELD);
-        moved.value = Some("world".into());
+        moved.value = Some("hello".into());
         root_field.children.push(moved);
-        let after = tree_with(root_field);
+        let after = tree_with(vec![root_field]);
         assert!(matches!(
             verify_write(&after, &matching_target(), "world"),
-            Err(GlassError::AxElementChanged(1))
+            Err(GlassError::AxValueNotApplied(1))
         ));
     }
 
@@ -356,43 +374,40 @@ mod tests {
     }
 
     #[test]
-    fn a_target_missing_from_the_read_back_is_reported_as_changed() {
-        let after = tree_with_value(Some("world"));
-        let mut t = matching_target();
-        t.id = AxNodeId(9);
-        assert!(matches!(
-            verify_write(&after, &t, "world"),
-            Err(GlassError::AxElementChanged(9))
-        ));
+    fn a_write_confirmed_at_a_new_id_is_a_success() {
+        // glass#359, the measured case: the keyboard renumbered the field and the text landed.
+        let mut moved = leaf(0, AxRole::TextField, "Note", FIELD);
+        moved.value = Some("world".into());
+        let after = tree_with(vec![leaf(0, AxRole::Label, "Suggestions", FIELD), moved]);
+        assert!(verify_write(&after, &matching_target(), "world").is_ok());
     }
 
     #[test]
-    fn a_write_that_replaced_the_screen_says_the_element_is_gone() {
-        let replaced = tree_with(leaf(0, AxRole::Label, "No Results", FIELD));
-        assert!(matches!(
-            verify_write(&replaced, &matching_target(), "world"),
-            Err(GlassError::AxElementGone(1))
-        ));
+    fn a_write_that_replaced_the_screen_says_it_was_typed_but_unconfirmed() {
+        let replaced = tree_with(vec![leaf(0, AxRole::Label, "No Results", FIELD)]);
+        let err = verify_write(&replaced, &matching_target(), "world").unwrap_err();
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(1, _)), "{err}");
+        assert!(err.to_string().contains("the text was typed"), "{err}");
     }
 
     #[test]
-    fn an_id_past_the_end_of_a_replaced_tree_says_gone_not_changed() {
-        // The arm the measured case takes, and the one the test above cannot reach: `tree_with`
-        // roots at a Window, so an id inside the tree resolves and lands on the other refusal site.
-        let replaced = tree_with(leaf(0, AxRole::Label, "No Results", FIELD));
-        let mut t = matching_target();
-        t.id = AxNodeId(15);
-        assert!(replaced.is_complete(), "a capped tree would answer Changed");
-        assert!(matches!(
-            verify_write(&replaced, &t, "world"),
-            Err(GlassError::AxElementGone(15))
-        ));
+    fn two_matching_fields_refuse_and_name_where_they_are() {
+        // The target's own id must land on something else first — a node still holding it would
+        // take the AtId fast path and never learn a second candidate exists.
+        let mut a = leaf(0, AxRole::TextField, "Note", FIELD);
+        a.value = Some("world".into());
+        let mut b = leaf(0, AxRole::TextField, "Note", FIELD);
+        b.value = Some("world".into());
+        let after = tree_with(vec![leaf(0, AxRole::Label, "Suggestions", FIELD), a, b]);
+        let err = verify_write(&after, &matching_target(), "world").unwrap_err();
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(1, _)), "{err}");
+        assert!(err.to_string().contains('2'), "names how many: {err}");
     }
 
     #[test]
     fn an_incomplete_tree_cannot_report_the_element_gone() {
         // A cap that fired hides elements, so absence from what was kept is not absence.
-        let mut replaced = tree_with(leaf(0, AxRole::Label, "No Results", FIELD));
+        let mut replaced = tree_with(vec![leaf(0, AxRole::Label, "No Results", FIELD)]);
         replaced.truncated = Some(glass_core::accessibility::Truncation {
             limit: glass_core::accessibility::TruncationLimit::Nodes,
             limit_value: 2,
@@ -400,26 +415,39 @@ mod tests {
         });
         let mut t = matching_target();
         t.id = AxNodeId(15);
-        assert!(matches!(
-            verify_write(&replaced, &t, "world"),
-            Err(GlassError::AccessibilityUnavailable(_))
-        ));
-        // The mismatched-id arm has no truncation branch of its own and must not assert gone.
-        assert!(matches!(
-            verify_write(&replaced, &matching_target(), "world"),
-            Err(GlassError::AxElementChanged(1))
-        ));
+        let err = verify_write(&replaced, &t, "world").unwrap_err();
+        assert!(
+            matches!(err, GlassError::AxWriteUnconfirmed(15, _)),
+            "{err}"
+        );
+        assert!(err.to_string().contains("truncated at 2 nodes"), "{err}");
     }
 
     #[test]
-    fn a_dropped_subtree_cannot_report_the_element_gone() {
-        // `unreadable` is independent of the caps, and equally unable to support "gone".
-        let mut replaced = tree_with(leaf(0, AxRole::Label, "No Results", FIELD));
+    fn an_id_resolving_to_a_mismatch_takes_the_same_truncation_branch() {
+        // The id-mismatch arm used to skip the truncation check entirely; it must fall through to
+        // the same search, and the same cap, as an out-of-range id.
+        let mut replaced = tree_with(vec![leaf(0, AxRole::Label, "No Results", FIELD)]);
+        replaced.truncated = Some(glass_core::accessibility::Truncation {
+            limit: glass_core::accessibility::TruncationLimit::Nodes,
+            limit_value: 2,
+            nodes_walked: 2,
+        });
+        let err = verify_write(&replaced, &matching_target(), "world").unwrap_err();
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(1, _)), "{err}");
+        assert!(err.to_string().contains("truncated at 2 nodes"), "{err}");
+    }
+
+    #[test]
+    fn an_incomplete_tree_does_not_claim_the_element_vanished() {
+        let mut replaced = tree_with(vec![leaf(0, AxRole::Label, "No Results", FIELD)]);
         replaced.unreadable = 1;
-        assert!(matches!(
-            verify_write(&replaced, &matching_target(), "world"),
-            Err(GlassError::AxElementChanged(1))
-        ));
+        let err = verify_write(&replaced, &matching_target(), "world").unwrap_err();
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(1, _)), "{err}");
+        assert!(
+            !err.to_string().contains("replaced"),
+            "an incomplete read must not assert the screen changed: {err}"
+        );
     }
 
     #[test]
@@ -430,7 +458,7 @@ mod tests {
             width: 100,
             height: 30,
         };
-        let tree = tree_with(leaf(0, AxRole::TextField, "inputField", r));
+        let tree = tree_with(vec![leaf(0, AxRole::TextField, "inputField", r)]);
         let target = AxTarget {
             id: AxNodeId(1),
             role: AxRole::TextField,
@@ -449,7 +477,7 @@ mod tests {
             width: 100,
             height: 30,
         };
-        let tree = tree_with(leaf(0, AxRole::Button, "inputField", r));
+        let tree = tree_with(vec![leaf(0, AxRole::Button, "inputField", r)]);
         let target = AxTarget {
             id: AxNodeId(1),
             role: AxRole::TextField,
@@ -469,7 +497,7 @@ mod tests {
             height: 30,
         };
         // The tree only has ids 0 (root) and 1 (the field); id 9 resolves to nothing.
-        let tree = tree_with(leaf(0, AxRole::TextField, "inputField", r));
+        let tree = tree_with(vec![leaf(0, AxRole::TextField, "inputField", r)]);
         let target = AxTarget {
             id: AxNodeId(9),
             role: AxRole::TextField,
@@ -493,7 +521,7 @@ mod tests {
             width: 100,
             height: 30,
         };
-        let tree = tree_with(leaf(0, AxRole::TextField, "inputField", r));
+        let tree = tree_with(vec![leaf(0, AxRole::TextField, "inputField", r)]);
         // Same role+name, but the target's captured bounds sit far from the node's —
         // beyond the tolerance, so a drifted id landing on a same-role element is rejected.
         let target = AxTarget {

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -383,11 +383,32 @@ mod tests {
     }
 
     #[test]
+    fn an_id_past_the_end_still_confirms_a_landed_write() {
+        // The mirror image of the renumbering case: the keyboard dismissing after a landed write
+        // can shrink the tree back down, leaving the field's old id past the end of it — nothing
+        // resolves there, but the field itself never moved and still holds the text.
+        let after = tree_with_value(Some("world"));
+        let mut t = matching_target();
+        t.id = AxNodeId(9);
+        assert!(verify_write(&after, &t, "world").is_ok());
+    }
+
+    #[test]
     fn a_write_that_replaced_the_screen_says_it_was_typed_but_unconfirmed() {
         let replaced = tree_with(vec![leaf(0, AxRole::Label, "No Results", FIELD)]);
+        // A capped tree would answer Unproven, not Gone; pin the fixture so a future change to
+        // `tree_with` cannot silently move this test onto the wrong arm and still pass.
+        assert!(
+            replaced.is_complete(),
+            "a capped tree would answer Unproven, not Gone"
+        );
         let err = verify_write(&replaced, &matching_target(), "world").unwrap_err();
         assert!(matches!(err, GlassError::AxWriteUnconfirmed(1, _)), "{err}");
+        // "the text was typed" is common to every AxWriteUnconfirmed arm (it's in the #[error]
+        // template, not this arm's own clause) — assert the Gone arm's own sentence too, or a
+        // change to just this arm's message would leave the suite green.
         assert!(err.to_string().contains("the text was typed"), "{err}");
+        assert!(err.to_string().contains("replaced"), "{err}");
     }
 
     #[test]

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -467,7 +467,11 @@ impl GlassServer {
                        three accessibility reads, since a field may commit a frame or two later. \
                        Errors if the element isn't editable, if it changed \
                        since the snapshot (re-snapshot), if the element does not hold the requested \
-                       value afterwards, or if the app exposes no accessibility tree. \
+                       value afterwards, or if the app exposes no accessibility tree. A separate \
+                       error says the text WAS typed but the write could not be confirmed — the \
+                       read-back failed, or could not tell which element now holds it. Do NOT write \
+                       again on that one: the keystrokes already went out, and re-snapshotting is \
+                       how you see where they landed. \
                        Optional `return`: \"snapshot\" settles the UI then folds a fresh a11y \
                        tree into the result (and refreshes the snapshot cache); \"settle\" waits \
                        for the UI to stop \

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -557,6 +557,16 @@ snapshot, does not hold the requested value afterwards, or the app exposes no ac
 field that reformats what it is given, and a cleared field that reports its placeholder as its text,
 both read as not applied even though the text arrived — read the element to see what it holds.
 
+One error is not a refusal: *the text was typed, but the write could not be confirmed*. The
+keystrokes went out and the read-back afterwards could not establish where they landed — it failed
+outright, several elements now match the one you named, nothing does, the read was cut short, or the
+element is no longer editable to read back. **Do not call `glass_set_value` again on that error** —
+the app has the text already, and writing again types it twice. Re-snapshot and read the element to
+see what it holds. When the message names a node cap, raising `max_nodes` on the snapshot is what
+fixes it. Clearing a field (`text: ""`) additionally needs the element to have a `name`: an empty
+field is not by itself evidence the clear landed on the element you meant, so a nameless one reports
+unconfirmed rather than a success it cannot prove.
+
 - `id` (integer, **required**) — the element's `#id`.
 - `text` (string, **required**) — the value to set.
 - `return` (string) — `"snapshot"`, `"settle"`, or `"none"` (default), as for `glass_click_element`.


### PR DESCRIPTION
Closes #359.

`glass_set_value` confirms a write by re-reading the element afterwards, and re-found it by its **pre-order index** — which the write itself moves. On the iOS Simulator the focusing tap raises the soft keyboard, inserting two nodes ahead of the field. A landed write was then refused, on the ordinary path of writing into a field you have not already touched.

## Measured, before and after

12 runs on the mini against `examples/ios-role-fixture`, driving the real MCP surface from a granted `GlassMcp.app`:

| | keyboard down (16 nodes) | keyboard up (18 nodes) |
|---|---|---|
| before | fails **by mechanism** — field at #11, write moves it to #13, refused | passes |
| after | **8 of 9 pass**, reporting `element #11 took the value` | 2 of 3 pass |

Zero `AxElementChanged` failures across all 12 runs. The two residual failures are a different verdict (`AxValueNotApplied`) on both arms — a pre-existing write-landing flake this fix **unmasked**, since the old code refused on identity before it ever judged the value. Filed as #363; not a regression and not a merge gate.

## The change

`AxTarget::relocate` in glass-core returns where the target now is: `AtId`, `Moved`, `Ambiguous`, `Gone`, or `Unproven`. Both mobile `verify_write` twins consume it, and post-write refusals return the new `GlassError::AxWriteUnconfirmed`, which says **the text was typed** and to re-snapshot rather than write again — the previous message read as an instruction to retype.

Identity is role + name. Not `value`, which a write changes by definition; not `bounds`, which move — measured, a field narrowed 1008→828px as its clear button appeared.

Three conditions keep that weak key honest:

- **More than one match refuses** rather than guessing.
- **`Moved` requires a complete tree and bounds overlap.** A truncated read cannot support a tree-wide uniqueness claim, and on Android an editable's name is usually its resource-id leaf — `search_src_text` names a *layout*, repeating across instances and across apps — so a navigating tap can find the next screen's field matching uniquely. Overlap, not equality, so the measured narrowing and an IME reflow still pass.
- **A clear is confirmed only for a named target.** An empty read-back is what any untouched same-role field shows; a typed write grounds itself on its own text, a clear has nothing to.

## Verification

`cargo test --workspace` — **1985 passed, 0 failed**. `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean.

Mutation-checked rather than assumed: inverting the classifier, relaxing uniqueness to "at least one", dropping the completeness gate, using equality instead of overlap, reordering `Ambiguous` ahead of the `AtId` fast path, and reverting the `find(id) == None` arm each red at least one test. Every new assertion was shown failing first.

The two `verify_write` bodies are byte-for-byte identical, which the docs have asked for since they drifted apart across #330 and #360.

## Reviewed before opening

A six-lens panel ran on the whole branch. It found four things per-task review structurally could not: `Moved` drawing a tree-wide conclusion from a partial read; the clear guard keyed on relocation rather than on identity strength, which left half the hole open and made clearing a named iOS field impossible; the agent-facing tool description still teaching agents to retype after this exact failure; and Android's identity key naming a layout rather than an instance. All fixed here.

## Deliberately not fixed

**#361** the pre-write guard's untyped errors, **#362** gone-vs-changed judged from a single sample, **#363** the write-landing flake above. Also flagged for a later call: extracting the identical twins into glass-core, and `a11y_service`'s third write path, whose parity comment this branch makes stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)