### PR TITLE
fix(a11y-ios): resolve a write's target by identity, and send its keystrokes together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,24 @@ internal refactors, CI, or test-only changes.
   the reason. Writing an empty value to clear a field needs the element to have a name: an empty
   field is not by itself evidence the clear landed on the element you meant, so a nameless one
   reports unconfirmed rather than a success it cannot prove.
+- `glass_set_value` on the iOS Simulator no longer refuses a write because the accessibility tree
+  was renumbered between the snapshot you read and the write itself. The check that runs before a
+  write re-walked to the element's position in the tree and refused when something else was there —
+  and on the Simulator a soft keyboard raised by an earlier interaction inserts elements ahead of a
+  field, which is enough to move it. The write now re-finds the element by its role and name, the
+  same way the check after the write does, and acts on it wherever it now is, so a field that simply
+  moved is written where it is rather than refused. The refusals it does still make say which
+  happened — the element is gone, several now match it, the read covered only part of the tree, it
+  is no longer editable, or it reports no on-screen geometry — where before every one of them was
+  the same "re-snapshot" sentence.
+- A `glass_set_value` on the iOS Simulator no longer intermittently leaves the field without the
+  text it was given. Clearing the field and typing the new text went to the device as separate
+  calls, and the field stops accepting typed input within a fraction of a second of the clear:
+  measured against [`examples/ios-role-fixture`](examples/ios-role-fixture/), text sent straight
+  after the clear lands every time, and text sent a third of a second later never does. A single
+  slow call was enough to open that gap, and the write then reported — correctly — that the element
+  did not hold the requested value. The clear and the text now go to the device together, so no call
+  can open a gap between them.
 - A native Android click or `set_value` through the optional on-device companion no longer acts on a
   different element than the one you named when the snapshot was truncated. glass numbered elements
   by their position in the tree it kept and dispatched the action by that number, but the companion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,12 +228,14 @@ internal refactors, CI, or test-only changes.
   was renumbered between the snapshot you read and the write itself. The check that runs before a
   write re-walked to the element's position in the tree and refused when something else was there —
   and on the Simulator a soft keyboard raised by an earlier interaction inserts elements ahead of a
-  field, which is enough to move it. The write now re-finds the element by its role and name, the
-  same way the check after the write does, and acts on it wherever it now is, so a field that simply
-  moved is written where it is rather than refused. The refusals it does still make say which
-  happened — the element is gone, several now match it, the read covered only part of the tree, it
-  is no longer editable, or it reports no on-screen geometry — where before every one of them was
-  the same "re-snapshot" sentence.
+  field, which is enough to move it. The write now re-finds the element by its role and name and
+  acts on it wherever it now is, so a field that shifted is written where it is rather than refused.
+  Role and name alone do not decide it — they repeat across a form's rows and are both absent on an
+  unlabelled field, so the element must also still be drawn overlapping where you saw it and still
+  hold the value you saw, which is what stops a write landing on a neighbouring row. The refusals it
+  does make now say which happened — the element is gone, several now match it, it no longer looks
+  like what you addressed, the read covered only part of the tree, it is not editable, or it reports
+  no on-screen geometry — where before every one of them was the same "re-snapshot" sentence.
 - A `glass_set_value` on the iOS Simulator no longer intermittently leaves the field without the
   text it was given. Clearing the field and typing the new text went to the device as separate
   calls, and the field stops accepting typed input within a fraction of a second of the clear:

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -373,6 +373,14 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
             return Err(GlassError::AxWriteUnconfirmed(target.id.0, why));
         }
     };
+    if !target.bounds_overlap(node.bounds) {
+        return Err(GlassError::AxWriteUnconfirmed(
+            target.id.0,
+            "the element carrying its role and name is drawn clear of where this one was, so the \
+             text may have gone to a different one"
+                .into(),
+        ));
+    }
     if !node.states.editable {
         return Err(GlassError::AxWriteUnconfirmed(
             target.id.0,

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -797,10 +797,10 @@ impl AxDeadline {
 /// A fingerprint identifying the element a value-set targets: its synthetic id
 /// (pre-order index), the role/name the caller saw in the snapshot, the
 /// element's window-relative bounds when known, and the value it held. The
-/// backend re-walks to the id and verifies role+name (and bounds, when present;
-/// on Android the value too) so a stale id — or tree drift that lands a
-/// *different* same-role+name element on the id — errors rather than
-/// overwriting the wrong element.
+/// backend re-resolves the element and verifies role+name (and bounds, when
+/// present; on the two mobile backends the value too) so a stale id — or tree
+/// drift that lands a *different* same-role+name element on the id — errors
+/// rather than overwriting the wrong element.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AxTarget {
     pub id: AxNodeId,
@@ -811,10 +811,11 @@ pub struct AxTarget {
     /// same-role+name element if the tree drifted, and that element sits
     /// elsewhere — see [`Self::bounds_consistent`].
     pub bounds: Option<AxRect>,
-    /// The element's value at snapshot time, when it had one. Captured on every backend, but
-    /// compared only by Android's `set_value` guard (`editable_target`), where a recycled list
-    /// row reuses the same view — role, name and rect all identical, only this different. The
-    /// other backends carry it without reading it; see [`Self::value_consistent`].
+    /// The element's value at snapshot time, when it had one. Captured on every backend, and
+    /// compared by both mobile `set_value` guards — Android's `editable_target` and iOS's
+    /// `verify` — where a recycled list row reuses the same view, so role, name and rect are all
+    /// identical and only this differs. The desktop backends carry it without reading it; see
+    /// [`Self::value_consistent`].
     ///
     /// After a successful write the session cache patches this to the text that was requested —
     /// an exact fact only on a typed-write backend (Android/iOS, verified by

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -920,9 +920,11 @@ impl AxTarget {
     ///
     /// Lives in core rather than in its caller because the question is not Android's: any reader
     /// holding an `AxTree` asks it before a write, and the desktop ones would if they had a tree
-    /// (they re-resolve against live platform elements instead). Its one production caller today is
-    /// `glass-android`'s `fingerprinted`; a write's *post*-dispatch read-back answers with
-    /// [`Self::relocate`] and [`GlassError::AxWriteUnconfirmed`], never with this.
+    /// (they re-resolve against live platform elements instead). Both mobile pre-write guards call
+    /// it — `glass-android`'s `fingerprinted`, which reaches it from a plain id walk, and
+    /// `glass-ios`'s `verify`, which reaches it from [`Self::relocate`]'s unlocated arms. A write's
+    /// *post*-dispatch read-back never answers with this: it owes the caller
+    /// [`GlassError::AxWriteUnconfirmed`], which says the text went out.
     #[must_use]
     pub fn drift_error(&self, tree: &AxTree) -> GlassError {
         if self.still_present(tree) || !tree.is_complete() {

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -94,9 +94,9 @@ fn verify(tree: &AxTree, target: &AxTarget) -> Result<AxRect> {
     if !target.bounds_overlap(node.bounds) || !target.value_consistent(node.value.as_deref()) {
         return Err(target.drift_error(tree));
     }
-    // Defence in depth rather than a reachable arm: iOS derives `editable` from the role alone, and
-    // `relocate` already required the roles to match, so a target that was editable resolves to a
-    // node that still is.
+    // Nothing upstream checks this: `glass_set_value` reaches here for any element the caller
+    // names, so a Label addressed by mistake resolves and matches. Without this the write would tap
+    // an inert label and type into whatever had focus instead.
     if !node.states.editable {
         return Err(GlassError::AxElementNotEditable(target.id.0));
     }
@@ -125,8 +125,12 @@ const VERIFY_ATTEMPTS: usize = 3;
 /// The element is re-resolved by identity (role + name) via [`AxTarget::relocate`], not by its
 /// pre-order id: measured on the Simulator, the focusing tap raises the soft keyboard and inserts
 /// two nodes ahead of the field (glass#359), so the id itself is not stable across the write. A node
-/// re-found that way is accepted only from a complete tree and only where it still overlaps where
-/// the target was, so a same-named field on a screen the tap navigated to is refused instead.
+/// re-found that way is accepted only from a complete tree, and whichever node was reached must
+/// still overlap where the target was — so a same-named field on a screen the tap navigated to is
+/// refused instead. Overlap is checked here and not left to [`Located::Moved`]: the write's own tap
+/// is what renumbers the tree, so the id can land on a neighbouring row that shares role and name,
+/// and [`Located::AtId`] grants that without consulting bounds. An untouched neighbour reads back
+/// empty, which is indistinguishable from a landed clear.
 ///
 /// The node must also still be editable: for a non-editable node `axmap` puts the element's AXLabel
 /// in `value`, so a label that changed inside the settle window would otherwise read as a successful
@@ -185,6 +189,14 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
             return Err(GlassError::AxWriteUnconfirmed(target.id.0, why));
         }
     };
+    if !target.bounds_overlap(node.bounds) {
+        return Err(GlassError::AxWriteUnconfirmed(
+            target.id.0,
+            "the element carrying its role and name is drawn clear of where this one was, so the \
+             text may have gone to a different one"
+                .into(),
+        ));
+    }
     if !node.states.editable {
         return Err(GlassError::AxWriteUnconfirmed(
             target.id.0,
@@ -607,6 +619,23 @@ mod tests {
     }
 
     #[test]
+    fn a_clear_is_not_confirmed_against_a_sibling_row_at_the_id() {
+        // The write's own tap is what renumbers the tree, so at read-back the id can resolve to a
+        // neighbouring field that shares role and name. An untouched one reads back empty, which is
+        // exactly what a landed clear looks like — so without a positional check the clear is
+        // confirmed against a row nothing was typed into.
+        let sibling = leaf(0, AxRole::TextField, "Note", AxRect { y: 600, ..FIELD });
+        let after = tree_with(vec![sibling]);
+        assert!(
+            matches!(matching_target().relocate(&after), Located::AtId(_)),
+            "the fixture must reach AtId, the arm relocate grants without checking bounds"
+        );
+        let err = verify_write(&after, &matching_target(), "").unwrap_err();
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(1, _)), "{err}");
+        assert!(err.to_string().contains("drawn clear of where"), "{err}");
+    }
+
+    #[test]
     fn a_write_confirmed_at_a_new_id_is_a_success() {
         // glass#359, the measured case: the keyboard renumbered the field and the text landed.
         let mut moved = leaf(0, AxRole::TextField, "Note", FIELD);
@@ -924,7 +953,7 @@ mod tests {
             leaf(0, AxRole::TextField, "Note", shifted),
         ]);
         assert!(
-            matches!(matching_target().relocate(&tree), Located::Moved(_)),
+            matches!(shifted_target().relocate(&tree), Located::Moved(_)),
             "the fixture must reach Moved"
         );
         assert_eq!(verify(&tree, &shifted_target()).unwrap(), shifted);

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -1,7 +1,8 @@
-//! iOS accessibility reader over idb's `accessibility_info`. Snapshot maps the
-//! nested JSON to an AxTree; set_value re-verifies the target element (guarding
-//! against a stale id landing on a different element), focuses it, clears it, and
-//! types the new text via synthetic HID input, then reads the element back and reports the write as not applied if it does not hold it.
+//! iOS accessibility reader over idb's `accessibility_info`. Snapshot maps the nested JSON to an
+//! AxTree; set_value re-finds the target element by identity (guarding against a stale id landing
+//! on a different element), focuses it, then clears and types it in one batch of synthetic HID
+//! input, and finally reads the element back and reports the write as not applied if it does not
+//! hold the text.
 use glass_core::accessibility::{Accessibility, AxContext, AxRect, AxTarget, AxTree, Located};
 use std::time::Duration;
 
@@ -11,6 +12,7 @@ use glass_core::{
 
 use crate::axmap;
 use crate::idb::client::IdbClient;
+use crate::idb::proto;
 use crate::injector::IdbInjector;
 
 /// Reads and writes the accessibility tree of the app under test in the
@@ -122,8 +124,8 @@ const VERIFY_ATTEMPTS: usize = 3;
 /// write into a Label. [`Located::AtId`] and [`Located::Moved`] both already carry the target's role
 /// and name, so a node reached here that is not editable is not a neighbour that inherited the id —
 /// it is the identified element having lost editability. Every refusal here is post-dispatch, hence
-/// [`GlassError::AxWriteUnconfirmed`] throughout; the pre-write guard is `verify` above, which still
-/// answers in `Backend` strings (glass#361).
+/// [`GlassError::AxWriteUnconfirmed`] throughout, where `verify` above refuses before the write goes
+/// out and answers in drift verdicts.
 ///
 /// A clear (`text` empty) is confirmed only for a target that carries a name. An empty read-back is
 /// what any untouched same-role, same-name field would also show, so it is evidence of the write
@@ -201,6 +203,21 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
     }
 }
 
+/// The whole write as one batch of HID events: select-all, delete, then the text.
+///
+/// One batch because each `IdbClient::hid` is its own RPC, and a pause between the delete and the
+/// text loses the text. Measured on the Simulator against `examples/ios-role-fixture`: back to
+/// back it lands 12/12, and with a pause in between 2/4 at 0.14s, 0/4 at 0.34s and 0/4 at 2s
+/// (glass#363). Sending them a call each let one slow round-trip open that window, which is what
+/// made the write fail roughly one run in six. Do not split this back into a call per keystroke
+/// for readability — the failure it prevents is invisible on a fast, idle host.
+fn clear_and_type_keys(injector: &IdbInjector, text: &str) -> Result<Vec<proto::HidEvent>> {
+    let mut events = injector.key_events(&KeyEvent::Chord("super+a".into()))?;
+    events.extend(injector.key_events(&KeyEvent::Chord("Delete".into()))?);
+    events.extend(injector.key_events(&KeyEvent::Text(text.to_string()))?);
+    Ok(events)
+}
+
 /// The read-back's own failure, reported as an unconfirmed write.
 ///
 /// Post-dispatch by construction: its only caller is the loop that runs after the keystrokes went
@@ -234,12 +251,10 @@ impl Accessibility for IosA11y {
             modifiers: vec![],
         };
         self.client.hid(injector.pointer_events(&tap)?)?;
-        self.client
-            .hid(injector.key_events(&KeyEvent::Chord("super+a".into()))?)?;
-        self.client
-            .hid(injector.key_events(&KeyEvent::Chord("Delete".into()))?)?;
-        self.client
-            .hid(injector.key_events(&KeyEvent::Text(text.to_string()))?)?;
+        // A gap before the keystrokes is harmless, so the tap stays its own call — the field has
+        // to become first responder before they arrive. A gap *within* them is not: see
+        // `clear_and_type_keys`.
+        self.client.hid(clear_and_type_keys(&injector, text)?)?;
 
         // A failure of this read is not a failure of the write — the field has already been cleared
         // and typed into — so it says so rather than letting a caller retry blindly and type twice.
@@ -633,6 +648,53 @@ mod tests {
             !err.to_string().contains("replaced"),
             "an incomplete read must not assert the screen changed: {err}"
         );
+    }
+
+    #[test]
+    fn the_clear_and_the_text_go_out_as_one_batch() {
+        // What makes the single `hid` call possible, and the thing a later refactor would undo:
+        // the three keystroke groups have to arrive concatenated, in order, in one vector. A
+        // pause between the delete and the text loses the text on the Simulator (glass#363), and
+        // nothing downstream of here can tell that it happened.
+        let injector = IdbInjector::new(2.0);
+        let select_all = injector
+            .key_events(&KeyEvent::Chord("super+a".into()))
+            .unwrap();
+        let delete = injector
+            .key_events(&KeyEvent::Chord("Delete".into()))
+            .unwrap();
+        let text = injector.key_events(&KeyEvent::Text("hi".into())).unwrap();
+
+        let batch = clear_and_type_keys(&injector, "hi").unwrap();
+
+        assert_eq!(
+            batch.len(),
+            select_all.len() + delete.len() + text.len(),
+            "every keystroke of all three groups travels in the one batch"
+        );
+        assert_eq!(batch[..select_all.len()], select_all[..]);
+        assert_eq!(
+            batch[select_all.len()..select_all.len() + delete.len()],
+            delete[..]
+        );
+        assert_eq!(batch[select_all.len() + delete.len()..], text[..]);
+    }
+
+    #[test]
+    fn a_clear_still_sends_the_keystrokes_that_empty_the_field() {
+        // `set_value(id, "")` types nothing, so the batch is select-all + delete alone — and it
+        // must still be non-empty, or a clear would dispatch no keystrokes at all.
+        let injector = IdbInjector::new(2.0);
+        let batch = clear_and_type_keys(&injector, "").unwrap();
+        let cleared = injector
+            .key_events(&KeyEvent::Chord("super+a".into()))
+            .unwrap()
+            .len()
+            + injector
+                .key_events(&KeyEvent::Chord("Delete".into()))
+                .unwrap()
+                .len();
+        assert_eq!(batch.len(), cleared);
     }
 
     #[test]

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -63,21 +63,27 @@ impl IosA11y {
 /// Locate `target` in a tree described for the write and return its window-relative pixel bounds —
 /// the guard every write runs before it dispatches.
 ///
-/// Re-resolved by identity via [`AxTarget::relocate`], not by pre-order id. The caller's snapshot
-/// and this describe are separate reads of a live app, so anything that shifted the tree between
-/// them renumbers the field without moving it — the soft keyboard an earlier write raised is the
-/// measured case, inserting two nodes ahead of it (glass#361). Same resolution the read-back uses,
-/// so a write is refused before it dispatches only where it would also be refused after.
+/// Re-resolved by identity via [`AxTarget::relocate`], not by pre-order id alone. The caller's
+/// snapshot and this describe are separate reads of a live app, so anything that shifted the tree
+/// between them renumbers the field without moving it — the soft keyboard an earlier write raised is
+/// the measured case, inserting two nodes ahead of it (glass#361). The read-back resolves the same
+/// way, so no write is refused here for an identity the read-back would have accepted.
 ///
-/// Bounds are no longer compared against the snapshot's. [`Located::Moved`] already requires the
-/// re-found node to overlap where the target was, which is where bounds carry evidence; on
-/// [`Located::AtId`] the id and the identity already agree, and a field that legitimately moved
-/// should be tapped where it now is rather than refused.
+/// Identity alone does not decide it. Role and name repeat across a form's rows and are both `None`
+/// on an unlabelled field, and [`Located::AtId`] is granted on that key plus a pre-order index this
+/// very write perturbs — so on its own it would accept whatever editable renumbering slid onto the
+/// id, tap it, and type into it, and the read-back would confirm the text in that same wrong node.
+/// Bounds and value are therefore checked on whichever node was reached: overlap rather than
+/// equality, so a field the keyboard shifted is still written where it now is, and value because a
+/// recycled row keeps its identifier and its rect and differs only there — the discriminator
+/// `AxTarget::value` exists for and Android's `fingerprinted` has always compared.
 ///
-/// Every refusal is pre-dispatch, so each is a typed drift verdict from
-/// [`AxTarget::drift_error`] — `AxElementGone` where nothing presents as the element, and
-/// `AxElementChanged` otherwise, truncation included (glass#361 replaced the `Backend` strings that
-/// told an agent to re-snapshot without saying which had happened).
+/// Every refusal is pre-dispatch. One the tree can no longer place, or that no longer looks like
+/// what was addressed, answers with a typed drift verdict from [`AxTarget::drift_error`] —
+/// `AxElementGone` where nothing presents as the element, `AxElementChanged` otherwise, truncation
+/// included. A node that *is* the element but is no longer editable, or reports no bounds, answers
+/// `AxElementNotEditable` / `AxElementNotClickable`. glass#361 replaced the `Backend` strings that
+/// told an agent to re-snapshot without saying which had happened.
 fn verify(tree: &AxTree, target: &AxTarget) -> Result<AxRect> {
     let node = match target.relocate(tree) {
         Located::AtId(node) | Located::Moved(node) => node,
@@ -85,9 +91,12 @@ fn verify(tree: &AxTree, target: &AxTarget) -> Result<AxRect> {
             return Err(target.drift_error(tree));
         }
     };
-    // Android and macOS gate on this and iOS did not, which mattered once the write is checked: for
-    // a non-editable node `axmap` puts the element's AXLabel in `value`, so a label that changed for
-    // any reason inside the settle window would have read as a successful write into a Label.
+    if !target.bounds_overlap(node.bounds) || !target.value_consistent(node.value.as_deref()) {
+        return Err(target.drift_error(tree));
+    }
+    // Defence in depth rather than a reachable arm: iOS derives `editable` from the role alone, and
+    // `relocate` already required the roles to match, so a target that was editable resolves to a
+    // node that still is.
     if !node.states.editable {
         return Err(GlassError::AxElementNotEditable(target.id.0));
     }
@@ -125,7 +134,7 @@ const VERIFY_ATTEMPTS: usize = 3;
 /// and name, so a node reached here that is not editable is not a neighbour that inherited the id —
 /// it is the identified element having lost editability. Every refusal here is post-dispatch, hence
 /// [`GlassError::AxWriteUnconfirmed`] throughout, where `verify` above refuses before the write goes
-/// out and answers in drift verdicts.
+/// out and answers in pre-write verdicts — drift, not-editable or not-clickable.
 ///
 /// A clear (`text` empty) is confirmed only for a target that carries a name. An empty read-back is
 /// what any untouched same-role, same-name field would also show, so it is evidence of the write
@@ -203,19 +212,51 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
     }
 }
 
-/// The whole write as one batch of HID events: select-all, delete, then the text.
+/// The write's keystrokes as one batch of HID events: select-all, delete, then the text.
 ///
 /// One batch because each `IdbClient::hid` is its own RPC, and a pause between the delete and the
-/// text loses the text. Measured on the Simulator against `examples/ios-role-fixture`: back to
-/// back it lands 12/12, and with a pause in between 2/4 at 0.14s, 0/4 at 0.34s and 0/4 at 2s
-/// (glass#363). Sending them a call each let one slow round-trip open that window, which is what
-/// made the write fail roughly one run in six. Do not split this back into a call per keystroke
-/// for readability — the failure it prevents is invisible on a fast, idle host.
+/// text loses the text. Measured on the Simulator against `examples/ios-role-fixture`: back to back
+/// the text lands 12/12; with a screenshot in between (0.14s) 2/4, with an accessibility read
+/// (0.34s) 0/4, and with a bare sleep making no call at all (2s) 0/4 — so it is elapsed time, not
+/// the extra request. Sending the groups a call each let one slow round-trip open that window
+/// (glass#363). Do not split this back into a call per group for readability — the failure it
+/// prevents is invisible on a fast, idle host.
 fn clear_and_type_keys(injector: &IdbInjector, text: &str) -> Result<Vec<proto::HidEvent>> {
     let mut events = injector.key_events(&KeyEvent::Chord("super+a".into()))?;
     events.extend(injector.key_events(&KeyEvent::Chord("Delete".into()))?);
     events.extend(injector.key_events(&KeyEvent::Text(text.to_string()))?);
     Ok(events)
+}
+
+/// Send the whole write: the focusing tap, then the keystrokes, in exactly two calls.
+///
+/// Over a `send` seam rather than [`IdbClient`] directly so the call *count* is testable without a
+/// device. That count is the fix for glass#363 — [`clear_and_type_keys`] returns a plain `Vec`, so
+/// nothing but this function stops a caller sending it in pieces again.
+///
+/// The batch is built before the tap goes out: `KeyEvent::Text` refuses a non-ASCII character, and
+/// building afterwards spent a tap that raised the keyboard and moved first responder before
+/// reporting a write that never happened.
+///
+/// A failure of the second send is post-dispatch and says so. The batch clears the field before it
+/// types, and `IdbClient::hid` streams it, so a failure part-way through can leave the field emptied
+/// with the text lost — reporting that as a bare transport error would tell an agent nothing was
+/// sent, and the session would keep the value it cached.
+fn dispatch_write(
+    send: &mut dyn FnMut(Vec<proto::HidEvent>) -> Result<()>,
+    injector: &IdbInjector,
+    tap: &PointerEvent,
+    target_id: u32,
+    text: &str,
+) -> Result<()> {
+    let keys = clear_and_type_keys(injector, text)?;
+    send(injector.pointer_events(tap)?)?;
+    send(keys).map_err(|e| {
+        GlassError::AxWriteUnconfirmed(
+            target_id,
+            format!("sending the keystrokes failed part-way through ({e}), so the field may have been cleared without receiving the text"),
+        )
+    })
 }
 
 /// The read-back's own failure, reported as an unconfirmed write.
@@ -233,8 +274,8 @@ impl Accessibility for IosA11y {
     }
 
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
-        // One describe yields both the id-assigned tree and the scale to place input at;
-        // the ids here are final, not walked again.
+        // One describe serves both the guard and the injector's scale — no second read before the
+        // keystrokes go out.
         let (tree, scale) = self.describe(ctx)?;
         let bounds = verify(&tree, target)?;
         let (cx, cy) = bounds
@@ -250,11 +291,17 @@ impl Accessibility for IosA11y {
             count: 1,
             modifiers: vec![],
         };
-        self.client.hid(injector.pointer_events(&tap)?)?;
-        // A gap before the keystrokes is harmless, so the tap stays its own call — the field has
-        // to become first responder before they arrive. A gap *within* them is not: see
-        // `clear_and_type_keys`.
-        self.client.hid(clear_and_type_keys(&injector, text)?)?;
+        // The tap keeps its own call — the field has to become first responder before the
+        // keystrokes arrive, and a gap there is harmless (measured: the same write with 400ms
+        // inserted between the two passes the smoke 6/6). A gap *within* the keystrokes is not.
+        let client = &self.client;
+        dispatch_write(
+            &mut |events| client.hid(events),
+            &injector,
+            &tap,
+            target.id.0,
+            text,
+        )?;
 
         // A failure of this read is not a failure of the write — the field has already been cleared
         // and typed into — so it says so rather than letting a caller retry blindly and type twice.
@@ -332,6 +379,16 @@ mod tests {
         let mut field = leaf(0, AxRole::TextField, "Note", FIELD);
         field.value = value.map(Into::into);
         tree_with(vec![field])
+    }
+
+    /// A target whose captured rect overlaps `shifted` in
+    /// `a_renumbered_field_that_also_shifted_is_tapped_where_it_now_is` — the keyboard moving a
+    /// field a little, not a different field elsewhere.
+    fn shifted_target() -> AxTarget {
+        AxTarget {
+            bounds: Some(AxRect { y: 30, ..FIELD }),
+            ..matching_target()
+        }
     }
 
     /// A target matching that field as the snapshot before the write saw it.
@@ -650,12 +707,107 @@ mod tests {
         );
     }
 
+    /// A `send` that records what it was handed instead of reaching a device, so a test can assert
+    /// how many calls the write made — the property glass#363 turns on.
+    fn recording_send(
+        log: &mut Vec<Vec<proto::HidEvent>>,
+    ) -> impl FnMut(Vec<proto::HidEvent>) -> Result<()> {
+        move |events| {
+            log.push(events);
+            Ok(())
+        }
+    }
+
+    fn a_tap() -> PointerEvent {
+        PointerEvent::Click {
+            x: 10,
+            y: 20,
+            button: MouseButton::Left,
+            count: 1,
+            modifiers: vec![],
+        }
+    }
+
     #[test]
-    fn the_clear_and_the_text_go_out_as_one_batch() {
-        // What makes the single `hid` call possible, and the thing a later refactor would undo:
-        // the three keystroke groups have to arrive concatenated, in order, in one vector. A
-        // pause between the delete and the text loses the text on the Simulator (glass#363), and
-        // nothing downstream of here can tell that it happened.
+    fn the_whole_write_goes_out_in_exactly_two_calls() {
+        // glass#363: each call is its own RPC, and a pause between the clear and the text loses the
+        // text. One call for the tap, one for every keystroke — three calls reinstates the bug, and
+        // `clear_and_type_keys` returning a plain Vec is what would let someone split it again.
+        let injector = IdbInjector::new(2.0);
+        let mut log = Vec::new();
+        dispatch_write(&mut recording_send(&mut log), &injector, &a_tap(), 1, "hi").unwrap();
+
+        assert_eq!(log.len(), 2, "the tap, then every keystroke in one call");
+        assert_eq!(log[0], injector.pointer_events(&a_tap()).unwrap());
+        assert_eq!(log[1], clear_and_type_keys(&injector, "hi").unwrap());
+    }
+
+    #[test]
+    fn a_failed_focus_tap_never_dispatches_the_keystrokes() {
+        // Typing into whatever had focus before is worse than not writing at all.
+        let injector = IdbInjector::new(2.0);
+        let mut calls = 0;
+        let mut send = |_events| {
+            calls += 1;
+            Err(GlassError::Backend("idb: connection reset".into()))
+        };
+        let err = dispatch_write(&mut send, &injector, &a_tap(), 1, "hi").unwrap_err();
+        assert_eq!(calls, 1, "the keystrokes must not follow a tap that failed");
+        assert!(
+            !err.set_value_failed_after_writing(),
+            "nothing was typed, so the session must keep its cached value: {err}"
+        );
+    }
+
+    #[test]
+    fn keystrokes_lost_part_way_report_the_field_may_be_cleared() {
+        // The batch clears before it types, so a stream that dies between the two leaves the field
+        // empty. Reporting that as a bare transport error would read as "nothing was sent".
+        let injector = IdbInjector::new(2.0);
+        let mut calls = 0;
+        let mut send = |_events| {
+            calls += 1;
+            if calls == 1 {
+                Ok(())
+            } else {
+                Err(GlassError::Backend("idb hid timed out after 30s".into()))
+            }
+        };
+        let err = dispatch_write(&mut send, &injector, &a_tap(), 7, "hi").unwrap_err();
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(7, _)), "{err}");
+        assert!(
+            err.set_value_failed_after_writing(),
+            "the session must drop the value it cached: {err}"
+        );
+        assert!(err.to_string().contains("may have been cleared"), "{err}");
+    }
+
+    #[test]
+    fn text_the_backend_cannot_type_refuses_before_anything_is_sent() {
+        // Building the batch before the tap is what makes this a true no-op: under the old order
+        // the clear had already emptied the field when the text was found to be untypeable.
+        let injector = IdbInjector::new(2.0);
+        let mut log = Vec::new();
+        let err = dispatch_write(
+            &mut recording_send(&mut log),
+            &injector,
+            &a_tap(),
+            1,
+            "café",
+        )
+        .unwrap_err();
+        assert!(matches!(err, GlassError::Unsupported(_)), "{err}");
+        assert!(
+            log.is_empty(),
+            "nothing may be sent for a write that cannot be built"
+        );
+        assert!(!err.set_value_failed_after_writing(), "{err}");
+    }
+
+    #[test]
+    fn clear_and_type_keys_concatenates_the_three_groups_in_order() {
+        // Content and order only — that these leave in ONE call is
+        // `the_whole_write_goes_out_in_exactly_two_calls`.
         let injector = IdbInjector::new(2.0);
         let select_all = injector
             .key_events(&KeyEvent::Chord("super+a".into()))
@@ -682,19 +834,23 @@ mod tests {
 
     #[test]
     fn a_clear_still_sends_the_keystrokes_that_empty_the_field() {
-        // `set_value(id, "")` types nothing, so the batch is select-all + delete alone — and it
-        // must still be non-empty, or a clear would dispatch no keystrokes at all.
+        // `set_value(id, "")` types nothing, so the batch is select-all then delete and nothing
+        // else. Assert both, in order: a length total alone passes with the two swapped, which on
+        // a device deletes one character instead of the field.
         let injector = IdbInjector::new(2.0);
-        let batch = clear_and_type_keys(&injector, "").unwrap();
-        let cleared = injector
+        let mut expected = injector
             .key_events(&KeyEvent::Chord("super+a".into()))
-            .unwrap()
-            .len()
-            + injector
+            .unwrap();
+        expected.extend(
+            injector
                 .key_events(&KeyEvent::Chord("Delete".into()))
-                .unwrap()
-                .len();
-        assert_eq!(batch.len(), cleared);
+                .unwrap(),
+        );
+
+        let batch = clear_and_type_keys(&injector, "").unwrap();
+
+        assert!(!batch.is_empty(), "a clear must still dispatch keystrokes");
+        assert_eq!(batch, expected);
     }
 
     #[test]
@@ -749,17 +905,92 @@ mod tests {
             leaf(0, AxRole::Label, "Suggestions", FIELD),
             leaf(0, AxRole::TextField, "Note", FIELD),
         ]);
+        // Pin the arm: `AtId` returns the same rect, so without this the test would keep passing
+        // while no longer exercising the relocation it is named for.
+        assert!(
+            matches!(matching_target().relocate(&tree), Located::Moved(_)),
+            "the fixture must reach Moved"
+        );
         assert_eq!(verify(&tree, &matching_target()).unwrap(), FIELD);
     }
 
     #[test]
-    fn a_field_that_moved_but_kept_its_id_is_tapped_where_it_now_is() {
-        // The tap is placed at the bounds this returns, so a field the keyboard pushed up the
-        // screen must yield its current rect. Comparing against the snapshot's would refuse a
-        // write that has nothing wrong with it.
-        let moved = AxRect { y: 600, ..FIELD };
-        let tree = tree_with(vec![leaf(0, AxRole::TextField, "Note", moved)]);
-        assert_eq!(verify(&tree, &matching_target()).unwrap(), moved);
+    fn a_renumbered_field_that_also_shifted_is_tapped_where_it_now_is() {
+        // The tap goes to the rect this returns, so it must be the node's current one and not the
+        // target's — the keyboard both renumbers the field and moves it.
+        let shifted = AxRect { y: 45, ..FIELD };
+        let tree = tree_with(vec![
+            leaf(0, AxRole::Label, "Suggestions", FIELD),
+            leaf(0, AxRole::TextField, "Note", shifted),
+        ]);
+        assert!(
+            matches!(matching_target().relocate(&tree), Located::Moved(_)),
+            "the fixture must reach Moved"
+        );
+        assert_eq!(verify(&tree, &shifted_target()).unwrap(), shifted);
+    }
+
+    #[test]
+    fn a_same_named_field_elsewhere_at_the_id_refuses_the_write() {
+        // A form's rows share role and name, and an unlabelled field has neither, so identity plus
+        // a pre-order index the write itself perturbs is not identification. Without a positional
+        // check this is tapped and typed into, and the read-back — resolving the same way — reads
+        // the text back out of it and calls the write a success.
+        let other_row = AxRect { y: 600, ..FIELD };
+        let tree = tree_with(vec![leaf(0, AxRole::TextField, "Note", other_row)]);
+        assert!(
+            matches!(matching_target().relocate(&tree), Located::AtId(_)),
+            "the fixture must reach AtId, the arm without a positional check of its own"
+        );
+        assert!(matches!(
+            verify(&tree, &matching_target()),
+            Err(GlassError::AxElementChanged(1))
+        ));
+    }
+
+    #[test]
+    fn a_recycled_row_holding_a_different_value_refuses_the_write() {
+        // A scrolled table reuses the cell, so role, name and rect all survive and only the value
+        // differs — the one discriminator left, and the reason `AxTarget::value` is captured.
+        let mut recycled = leaf(0, AxRole::TextField, "Note", FIELD);
+        recycled.value = Some("row 9".into());
+        let tree = tree_with(vec![recycled]);
+        let mut target = matching_target();
+        target.value = Some("row 3".into());
+        assert!(matches!(
+            verify(&tree, &target),
+            Err(GlassError::AxElementChanged(1))
+        ));
+    }
+
+    #[test]
+    fn a_field_drawn_clear_of_the_target_refuses_the_write_before_it_dispatches() {
+        // The tap navigated to another screen carrying a same-named field. The read-back refuses
+        // this after the write; the guard must refuse it before one goes out.
+        let tree = tree_with(vec![
+            leaf(0, AxRole::Label, "Suggestions", FIELD),
+            leaf(0, AxRole::TextField, "Note", AxRect { y: 600, ..FIELD }),
+        ]);
+        assert!(
+            matches!(matching_target().relocate(&tree), Located::Unproven),
+            "the fixture must reach Unproven"
+        );
+        assert!(matches!(
+            verify(&tree, &matching_target()),
+            Err(GlassError::AxElementChanged(1))
+        ));
+    }
+
+    #[test]
+    fn a_tree_with_an_unreadable_subtree_refuses_the_write_as_changed_not_gone() {
+        // Independent of the node cap: a subtree that could not be read hides elements just as a
+        // cap does, so absence from what was read is not absence.
+        let mut tree = tree_with(vec![leaf(0, AxRole::Label, "No Results", FIELD)]);
+        tree.unreadable = 1;
+        assert!(matches!(
+            verify(&tree, &matching_target()),
+            Err(GlassError::AxElementChanged(1))
+        ));
     }
 
     #[test]

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -63,27 +63,19 @@ impl IosA11y {
 /// Locate `target` in a tree described for the write and return its window-relative pixel bounds —
 /// the guard every write runs before it dispatches.
 ///
-/// Re-resolved by identity via [`AxTarget::relocate`], not by pre-order id alone. The caller's
-/// snapshot and this describe are separate reads of a live app, so anything that shifted the tree
-/// between them renumbers the field without moving it — the soft keyboard an earlier write raised is
-/// the measured case, inserting two nodes ahead of it (glass#361). The read-back resolves the same
-/// way, so no write is refused here for an identity the read-back would have accepted.
+/// Re-resolved by identity via [`AxTarget::relocate`], not by pre-order id alone: on the Simulator
+/// a soft keyboard raised by an earlier write inserts nodes ahead of the field, renumbering it
+/// without moving it (glass#361).
 ///
-/// Identity alone does not decide it. Role and name repeat across a form's rows and are both `None`
-/// on an unlabelled field, and [`Located::AtId`] is granted on that key plus a pre-order index this
-/// very write perturbs — so on its own it would accept whatever editable renumbering slid onto the
-/// id, tap it, and type into it, and the read-back would confirm the text in that same wrong node.
-/// Bounds and value are therefore checked on whichever node was reached: overlap rather than
-/// equality, so a field the keyboard shifted is still written where it now is, and value because a
-/// recycled row keeps its identifier and its rect and differs only there — the discriminator
-/// `AxTarget::value` exists for and Android's `fingerprinted` has always compared.
+/// Bounds and value are then checked on whichever node was reached — do not drop them again.
+/// [`Located::AtId`] is granted on role+name plus that same unstable id, and role and name repeat
+/// across a form's rows and are absent on an unlabelled field, so identity alone accepts a
+/// neighbour and the read-back confirms the text in it. Overlap, not equality, so a field the
+/// keyboard shifted is still written where it now is.
 ///
-/// Every refusal is pre-dispatch. One the tree can no longer place, or that no longer looks like
-/// what was addressed, answers with a typed drift verdict from [`AxTarget::drift_error`] —
-/// `AxElementGone` where nothing presents as the element, `AxElementChanged` otherwise, truncation
-/// included. A node that *is* the element but is no longer editable, or reports no bounds, answers
-/// `AxElementNotEditable` / `AxElementNotClickable`. glass#361 replaced the `Backend` strings that
-/// told an agent to re-snapshot without saying which had happened.
+/// Refusals are pre-dispatch: [`AxTarget::drift_error`] for a node the tree cannot place or that no
+/// longer looks like what was addressed, `AxElementNotEditable` / `AxElementNotClickable` for one
+/// that is the element but cannot be written or tapped.
 fn verify(tree: &AxTree, target: &AxTarget) -> Result<AxRect> {
     let node = match target.relocate(tree) {
         Located::AtId(node) | Located::Moved(node) => node,
@@ -94,9 +86,8 @@ fn verify(tree: &AxTree, target: &AxTarget) -> Result<AxRect> {
     if !target.bounds_overlap(node.bounds) || !target.value_consistent(node.value.as_deref()) {
         return Err(target.drift_error(tree));
     }
-    // Nothing upstream checks this: `glass_set_value` reaches here for any element the caller
-    // names, so a Label addressed by mistake resolves and matches. Without this the write would tap
-    // an inert label and type into whatever had focus instead.
+    // Load-bearing, not belt-and-braces: nothing upstream rejects a non-editable target, so without
+    // this a Label addressed by mistake is tapped and the text goes to whatever had focus.
     if !node.states.editable {
         return Err(GlassError::AxElementNotEditable(target.id.0));
     }
@@ -124,13 +115,12 @@ const VERIFY_ATTEMPTS: usize = 3;
 ///
 /// The element is re-resolved by identity (role + name) via [`AxTarget::relocate`], not by its
 /// pre-order id: measured on the Simulator, the focusing tap raises the soft keyboard and inserts
-/// two nodes ahead of the field (glass#359), so the id itself is not stable across the write. A node
+/// nodes ahead of the field (glass#359), so the id itself is not stable across the write. A node
 /// re-found that way is accepted only from a complete tree, and whichever node was reached must
 /// still overlap where the target was — so a same-named field on a screen the tap navigated to is
-/// refused instead. Overlap is checked here and not left to [`Located::Moved`]: the write's own tap
-/// is what renumbers the tree, so the id can land on a neighbouring row that shares role and name,
-/// and [`Located::AtId`] grants that without consulting bounds. An untouched neighbour reads back
-/// empty, which is indistinguishable from a landed clear.
+/// refused instead. Overlap is checked here rather than left to [`Located::Moved`] because the
+/// write's own tap renumbers the tree onto a neighbouring row, which [`Located::AtId`] accepts
+/// without consulting bounds and which reads back empty like a landed clear.
 ///
 /// The node must also still be editable: for a non-editable node `axmap` puts the element's AXLabel
 /// in `value`, so a label that changed inside the settle window would otherwise read as a successful
@@ -226,13 +216,9 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
 
 /// The write's keystrokes as one batch of HID events: select-all, delete, then the text.
 ///
-/// One batch because each `IdbClient::hid` is its own RPC, and a pause between the delete and the
-/// text loses the text. Measured on the Simulator against `examples/ios-role-fixture`: back to back
-/// the text lands 12/12; with a screenshot in between (0.14s) 2/4, with an accessibility read
-/// (0.34s) 0/4, and with a bare sleep making no call at all (2s) 0/4 — so it is elapsed time, not
-/// the extra request. Sending the groups a call each let one slow round-trip open that window
-/// (glass#363). Do not split this back into a call per group for readability — the failure it
-/// prevents is invisible on a fast, idle host.
+/// Do not send these a group at a time again: each `IdbClient::hid` is its own RPC, and the
+/// Simulator drops typed text arriving a fraction of a second after the field is cleared
+/// (glass#363).
 fn clear_and_type_keys(injector: &IdbInjector, text: &str) -> Result<Vec<proto::HidEvent>> {
     let mut events = injector.key_events(&KeyEvent::Chord("super+a".into()))?;
     events.extend(injector.key_events(&KeyEvent::Chord("Delete".into()))?);
@@ -242,18 +228,13 @@ fn clear_and_type_keys(injector: &IdbInjector, text: &str) -> Result<Vec<proto::
 
 /// Send the whole write: the focusing tap, then the keystrokes, in exactly two calls.
 ///
-/// Over a `send` seam rather than [`IdbClient`] directly so the call *count* is testable without a
-/// device. That count is the fix for glass#363 — [`clear_and_type_keys`] returns a plain `Vec`, so
-/// nothing but this function stops a caller sending it in pieces again.
+/// Over a `send` seam so the call count — the fix for glass#363 — is testable without a device.
 ///
 /// The batch is built before the tap goes out: `KeyEvent::Text` refuses a non-ASCII character, and
-/// building afterwards spent a tap that raised the keyboard and moved first responder before
-/// reporting a write that never happened.
+/// building afterwards spent a tap that had already moved first responder.
 ///
-/// A failure of the second send is post-dispatch and says so. The batch clears the field before it
-/// types, and `IdbClient::hid` streams it, so a failure part-way through can leave the field emptied
-/// with the text lost — reporting that as a bare transport error would tell an agent nothing was
-/// sent, and the session would keep the value it cached.
+/// The second send's failure is post-dispatch: the batch clears before it types, so a stream dying
+/// part-way through leaves the field emptied with the text lost.
 fn dispatch_write(
     send: &mut dyn FnMut(Vec<proto::HidEvent>) -> Result<()>,
     injector: &IdbInjector,
@@ -303,9 +284,8 @@ impl Accessibility for IosA11y {
             count: 1,
             modifiers: vec![],
         };
-        // The tap keeps its own call — the field has to become first responder before the
-        // keystrokes arrive, and a gap there is harmless (measured: the same write with 400ms
-        // inserted between the two passes the smoke 6/6). A gap *within* the keystrokes is not.
+        // The tap keeps its own call: a delay here is harmless where one inside the keystrokes
+        // loses the text.
         let client = &self.client;
         dispatch_write(
             &mut |events| client.hid(events),
@@ -515,7 +495,7 @@ mod tests {
 
     #[test]
     fn a_named_field_clears_after_being_re_found() {
-        // The write's own focusing tap inserts two nodes ahead of the field, so a clear into a field
+        // The write's own focusing tap inserts nodes ahead of the field, so a clear into a field
         // that was not already focused ALWAYS relocates. Keying the refusal on that made it fail by
         // construction; the name is what identifies the field, and the name survives the move.
         let moved = leaf(0, AxRole::TextField, "Note", FIELD);
@@ -759,9 +739,8 @@ mod tests {
 
     #[test]
     fn the_whole_write_goes_out_in_exactly_two_calls() {
-        // glass#363: each call is its own RPC, and a pause between the clear and the text loses the
-        // text. One call for the tap, one for every keystroke — three calls reinstates the bug, and
-        // `clear_and_type_keys` returning a plain Vec is what would let someone split it again.
+        // Three calls reinstates glass#363: each is its own RPC, and a pause between the clear and
+        // the text loses the text.
         let injector = IdbInjector::new(2.0);
         let mut log = Vec::new();
         dispatch_write(&mut recording_send(&mut log), &injector, &a_tap(), 1, "hi").unwrap();
@@ -790,8 +769,8 @@ mod tests {
 
     #[test]
     fn keystrokes_lost_part_way_report_the_field_may_be_cleared() {
-        // The batch clears before it types, so a stream that dies between the two leaves the field
-        // empty. Reporting that as a bare transport error would read as "nothing was sent".
+        // The batch clears before it types, so a stream dying between the two leaves the field
+        // empty — a bare transport error would read as "nothing was sent".
         let injector = IdbInjector::new(2.0);
         let mut calls = 0;
         let mut send = |_events| {
@@ -813,8 +792,8 @@ mod tests {
 
     #[test]
     fn text_the_backend_cannot_type_refuses_before_anything_is_sent() {
-        // Building the batch before the tap is what makes this a true no-op: under the old order
-        // the clear had already emptied the field when the text was found to be untypeable.
+        // Under the old order the clear had already emptied the field by the time the text was
+        // found to be untypeable.
         let injector = IdbInjector::new(2.0);
         let mut log = Vec::new();
         let err = dispatch_write(
@@ -863,9 +842,8 @@ mod tests {
 
     #[test]
     fn a_clear_still_sends_the_keystrokes_that_empty_the_field() {
-        // `set_value(id, "")` types nothing, so the batch is select-all then delete and nothing
-        // else. Assert both, in order: a length total alone passes with the two swapped, which on
-        // a device deletes one character instead of the field.
+        // Assert content and order, not a length total: a total passes with the two swapped, which
+        // on a device deletes one character instead of the field.
         let injector = IdbInjector::new(2.0);
         let mut expected = injector
             .key_events(&KeyEvent::Chord("super+a".into()))
@@ -927,9 +905,8 @@ mod tests {
 
     #[test]
     fn a_renumbered_field_is_located_by_identity_before_the_write() {
-        // glass#361, the measured case: between the caller's snapshot and the write's own describe
-        // the soft keyboard inserted nodes ahead of the field, so its id now resolves elsewhere.
-        // The field itself never moved, and the write must reach it rather than refuse.
+        // glass#361, the measured case: the soft keyboard inserted nodes ahead of the field between
+        // the caller's snapshot and the write's describe, so its id now resolves elsewhere.
         let tree = tree_with(vec![
             leaf(0, AxRole::Label, "Suggestions", FIELD),
             leaf(0, AxRole::TextField, "Note", FIELD),
@@ -945,8 +922,7 @@ mod tests {
 
     #[test]
     fn a_renumbered_field_that_also_shifted_is_tapped_where_it_now_is() {
-        // The tap goes to the rect this returns, so it must be the node's current one and not the
-        // target's — the keyboard both renumbers the field and moves it.
+        // The tap goes to the rect this returns, so it must be the node's and not the target's.
         let shifted = AxRect { y: 45, ..FIELD };
         let tree = tree_with(vec![
             leaf(0, AxRole::Label, "Suggestions", FIELD),
@@ -962,9 +938,8 @@ mod tests {
     #[test]
     fn a_same_named_field_elsewhere_at_the_id_refuses_the_write() {
         // A form's rows share role and name, and an unlabelled field has neither, so identity plus
-        // a pre-order index the write itself perturbs is not identification. Without a positional
-        // check this is tapped and typed into, and the read-back — resolving the same way — reads
-        // the text back out of it and calls the write a success.
+        // an id the write itself perturbs is not identification — and the read-back, resolving the
+        // same way, would read the text back out of the wrong node and call it a success.
         let other_row = AxRect { y: 600, ..FIELD };
         let tree = tree_with(vec![leaf(0, AxRole::TextField, "Note", other_row)]);
         assert!(
@@ -980,7 +955,7 @@ mod tests {
     #[test]
     fn a_recycled_row_holding_a_different_value_refuses_the_write() {
         // A scrolled table reuses the cell, so role, name and rect all survive and only the value
-        // differs — the one discriminator left, and the reason `AxTarget::value` is captured.
+        // differs.
         let mut recycled = leaf(0, AxRole::TextField, "Note", FIELD);
         recycled.value = Some("row 9".into());
         let tree = tree_with(vec![recycled]);
@@ -994,8 +969,8 @@ mod tests {
 
     #[test]
     fn a_field_drawn_clear_of_the_target_refuses_the_write_before_it_dispatches() {
-        // The tap navigated to another screen carrying a same-named field. The read-back refuses
-        // this after the write; the guard must refuse it before one goes out.
+        // A tap that navigated to another screen carrying a same-named field — refused after the
+        // write, so it must be refused before one goes out.
         let tree = tree_with(vec![
             leaf(0, AxRole::Label, "Suggestions", FIELD),
             leaf(0, AxRole::TextField, "Note", AxRect { y: 600, ..FIELD }),

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -58,22 +58,31 @@ impl IosA11y {
     }
 }
 
-/// Re-walk to `target.id`, confirm role+name (and bounds when known), return its
-/// window-relative pixel bounds. Errors if the element drifted or vanished.
+/// Locate `target` in a tree described for the write and return its window-relative pixel bounds —
+/// the guard every write runs before it dispatches.
+///
+/// Re-resolved by identity via [`AxTarget::relocate`], not by pre-order id. The caller's snapshot
+/// and this describe are separate reads of a live app, so anything that shifted the tree between
+/// them renumbers the field without moving it — the soft keyboard an earlier write raised is the
+/// measured case, inserting two nodes ahead of it (glass#361). Same resolution the read-back uses,
+/// so a write is refused before it dispatches only where it would also be refused after.
+///
+/// Bounds are no longer compared against the snapshot's. [`Located::Moved`] already requires the
+/// re-found node to overlap where the target was, which is where bounds carry evidence; on
+/// [`Located::AtId`] the id and the identity already agree, and a field that legitimately moved
+/// should be tapped where it now is rather than refused.
+///
+/// Every refusal is pre-dispatch, so each is a typed drift verdict from
+/// [`AxTarget::drift_error`] — `AxElementGone` where nothing presents as the element, and
+/// `AxElementChanged` otherwise, truncation included (glass#361 replaced the `Backend` strings that
+/// told an agent to re-snapshot without saying which had happened).
 fn verify(tree: &AxTree, target: &AxTarget) -> Result<AxRect> {
-    let node = tree
-        .find(target.id)
-        .ok_or(GlassError::AxElementNotFound(target.id.0))?;
-    if !target.matches(node.role, node.name.as_deref()) {
-        return Err(GlassError::Backend(
-            "a11y set_value: element at that id changed since the snapshot; re-snapshot".into(),
-        ));
-    }
-    if !target.bounds_consistent(node.bounds, 2) {
-        return Err(GlassError::Backend(
-            "a11y set_value: element moved since the snapshot; re-snapshot".into(),
-        ));
-    }
+    let node = match target.relocate(tree) {
+        Located::AtId(node) | Located::Moved(node) => node,
+        Located::Ambiguous(_) | Located::Gone | Located::Unproven => {
+            return Err(target.drift_error(tree));
+        }
+    };
     // Android and macOS gate on this and iOS did not, which mattered once the write is checked: for
     // a non-editable node `axmap` puts the element's AXLabel in `value`, so a label that changed for
     // any reason inside the settle window would have read as a successful write into a Label.
@@ -81,7 +90,7 @@ fn verify(tree: &AxTree, target: &AxTarget) -> Result<AxRect> {
         return Err(GlassError::AxElementNotEditable(target.id.0));
     }
     node.bounds
-        .ok_or_else(|| GlassError::Backend("a11y set_value: element has no bounds".into()))
+        .ok_or(GlassError::AxElementNotClickable(target.id.0))
 }
 
 /// How long to let the app commit typed text before each read-back attempt. Generous next to a
@@ -213,7 +222,7 @@ impl Accessibility for IosA11y {
         let bounds = verify(&tree, target)?;
         let (cx, cy) = bounds
             .clamped_center(ctx.window.width, ctx.window.height)
-            .ok_or_else(|| GlassError::Backend("a11y set_value: element not on screen".into()))?;
+            .ok_or(GlassError::AxElementNotClickable(target.id.0))?;
         // Focus by tapping the element, select-all + delete to clear, then type — all
         // through an injector at this describe's scale.
         let injector = IdbInjector::new(scale);
@@ -661,57 +670,88 @@ mod tests {
             bounds: Some(r),
             value: None,
         };
-        assert!(verify(&tree, &target).is_err());
-    }
-
-    #[test]
-    fn verify_rejects_missing_id() {
-        let r = AxRect {
-            x: 10,
-            y: 20,
-            width: 100,
-            height: 30,
-        };
-        // The tree only has ids 0 (root) and 1 (the field); id 9 resolves to nothing.
-        let tree = tree_with(vec![leaf(0, AxRole::TextField, "inputField", r)]);
-        let target = AxTarget {
-            id: AxNodeId(9),
-            role: AxRole::TextField,
-            name: Some("inputField".into()),
-            bounds: Some(r),
-            value: None,
-        };
-        // Pin the variant: an unresolved id must report AxElementNotFound (naming the id),
-        // not the generic AxUnsupported — both are `Err`, so `.is_err()` alone wouldn't guard it.
+        // Nothing in a complete tree carries the target's role, so the element is gone rather
+        // than merely changed.
         assert!(matches!(
             verify(&tree, &target),
-            Err(GlassError::AxElementNotFound(id)) if id == target.id.0
+            Err(GlassError::AxElementGone(1))
         ));
     }
 
     #[test]
-    fn verify_rejects_bounds_drift() {
-        let r = AxRect {
-            x: 10,
-            y: 20,
-            width: 100,
-            height: 30,
-        };
-        let tree = tree_with(vec![leaf(0, AxRole::TextField, "inputField", r)]);
-        // Same role+name, but the target's captured bounds sit far from the node's —
-        // beyond the tolerance, so a drifted id landing on a same-role element is rejected.
-        let target = AxTarget {
-            id: AxNodeId(1),
-            role: AxRole::TextField,
-            name: Some("inputField".into()),
-            bounds: Some(AxRect {
-                x: 200,
-                y: 400,
-                width: 100,
-                height: 30,
-            }),
-            value: None,
-        };
-        assert!(verify(&tree, &target).is_err());
+    fn a_renumbered_field_is_located_by_identity_before_the_write() {
+        // glass#361, the measured case: between the caller's snapshot and the write's own describe
+        // the soft keyboard inserted nodes ahead of the field, so its id now resolves elsewhere.
+        // The field itself never moved, and the write must reach it rather than refuse.
+        let tree = tree_with(vec![
+            leaf(0, AxRole::Label, "Suggestions", FIELD),
+            leaf(0, AxRole::TextField, "Note", FIELD),
+        ]);
+        assert_eq!(verify(&tree, &matching_target()).unwrap(), FIELD);
+    }
+
+    #[test]
+    fn a_field_that_moved_but_kept_its_id_is_tapped_where_it_now_is() {
+        // The tap is placed at the bounds this returns, so a field the keyboard pushed up the
+        // screen must yield its current rect. Comparing against the snapshot's would refuse a
+        // write that has nothing wrong with it.
+        let moved = AxRect { y: 600, ..FIELD };
+        let tree = tree_with(vec![leaf(0, AxRole::TextField, "Note", moved)]);
+        assert_eq!(verify(&tree, &matching_target()).unwrap(), moved);
+    }
+
+    #[test]
+    fn two_matching_fields_refuse_the_write_as_changed() {
+        // The id must land on something else first, or the AtId path would take the first one
+        // and never learn a second exists.
+        let tree = tree_with(vec![
+            leaf(0, AxRole::Label, "Suggestions", FIELD),
+            leaf(0, AxRole::TextField, "Note", FIELD),
+            leaf(0, AxRole::TextField, "Note", FIELD),
+        ]);
+        assert!(matches!(
+            verify(&tree, &matching_target()),
+            Err(GlassError::AxElementChanged(1))
+        ));
+    }
+
+    #[test]
+    fn a_truncated_tree_refuses_the_write_as_changed_not_gone() {
+        // A cap that fired hides elements, so absence from what was kept is not absence — the
+        // element may be past the cap, which `AxElementGone` would assert it is not.
+        let mut tree = tree_with(vec![leaf(0, AxRole::Label, "No Results", FIELD)]);
+        tree.truncated = Some(glass_core::accessibility::Truncation {
+            limit: glass_core::accessibility::TruncationLimit::Nodes,
+            limit_value: 2,
+            nodes_walked: 2,
+        });
+        assert!(matches!(
+            verify(&tree, &matching_target()),
+            Err(GlassError::AxElementChanged(1))
+        ));
+    }
+
+    #[test]
+    fn a_non_editable_element_refuses_the_write() {
+        let mut field = leaf(0, AxRole::TextField, "Note", FIELD);
+        field.states.editable = false;
+        let tree = tree_with(vec![field]);
+        assert!(matches!(
+            verify(&tree, &matching_target()),
+            Err(GlassError::AxElementNotEditable(1))
+        ));
+    }
+
+    #[test]
+    fn an_element_without_bounds_refuses_the_write_as_not_clickable() {
+        // The write's only way in is a tap at the element's center, so a node reporting no
+        // geometry has to say that rather than fail later as a write that did not take.
+        let mut field = leaf(0, AxRole::TextField, "Note", FIELD);
+        field.bounds = None;
+        let tree = tree_with(vec![field]);
+        assert!(matches!(
+            verify(&tree, &matching_target()),
+            Err(GlassError::AxElementNotClickable(1))
+        ));
     }
 }


### PR DESCRIPTION
Closes #361. Addresses part of #363 — see below; that issue stays open.

## The pre-write guard (#361)

`set_value` on the iOS Simulator re-walked to the target's pre-order id and refused when the node there carried a different role or name. The caller's snapshot and the write's own describe are separate reads of a live app, and a soft keyboard raised by an earlier interaction inserts elements ahead of a field — enough to renumber it without moving it. A perfectly good write was refused for drift that had not happened.

The guard now resolves by identity via `AxTarget::relocate`, the same search the read-back uses, and acts on the element wherever it now is. Role and name alone do not decide it: they repeat across a form's rows and are both absent on an unlabelled field, so the element must also still overlap where it was and still hold the value that was captured — the pair Android's guard has always compared. Without that, a write can land on a neighbouring row and the read-back, resolving the same way, reads the text back out of it and reports success.

Every refusal on this path was a `GlassError::Backend` string telling the agent to re-snapshot without saying what had happened. They are typed now — `AxElementGone`, `AxElementChanged`, `AxElementNotEditable`, `AxElementNotClickable`.

The same positional check is applied to the read-back, where an untouched sibling row reads back empty and is indistinguishable from a landed clear.

## The keystrokes (#363)

`set_value` sent select-all, delete and the text as three separate idb `hid` RPCs. The Simulator drops typed text that arrives a fraction of a second after the field is cleared, so one slow round-trip lost the write. They now go out as a single call, over a seam that makes the call count testable without a device.

Measured on the mac mini against `examples/ios-role-fixture`, driving the public tools:

| between the clear and the text | text lands |
|---|---|
| nothing | 12/12 |
| a screenshot (0.14s) | 2/4 |
| an accessibility read (0.34s) | 0/4 |
| a bare sleep, no call at all (2s) | 0/4 |

The sleep makes no request, so the cause is elapsed time rather than the extra round-trip. Confirmed through the pre-release smoke leg: master with a deliberate 400ms delay in that exact position fails 0/6, every run with the same verdict this issue reports.

**#363 is not fully fixed.** With the gap closed the leg still fails roughly 1 run in 50 with the same `AxValueNotApplied`, load-dependent and cause unknown — master measured 35/36 and this branch 61/62 over the same night, which do not distinguish. A 150ms settle after the focusing tap was tested as the next hypothesis and showed nothing (14/14 both arms), so no sleep was added. #363 stays open, re-scoped to that residual.

## Verification

- `cargo test --workspace`, `cargo clippy --workspace --all-targets`, `cargo fmt --check` all clean.
- Each new guard is mutation-proven: removing it turns the named test red.
- iOS smoke leg on device: 12/12 on the final build, with no false refusals introduced by the tightened guard.
- The `verify_write` twins in `glass-ios` and `glass-android` remain byte-for-byte identical.