### PR TITLE
test(android): kill the crate's mutation survivors, and gate it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,9 +287,9 @@ jobs:
           # `:(glob)` so `**` spans directories, matching scripts/mutants.sh's --file; without
           # it git reads `**` as an ordinary fnmatch pattern and selects nothing at all.
           #
-          # Keep these pathspecs in step with the --package list below: a crate mutated without
-          # its files in the diff draws no mutants and gates nothing, and one diffed without
-          # being named as a package is mutated under the other's --file glob.
+          # Keep these pathspecs in step with the --package list below. --package is what sets
+          # the --file glob, so a crate named there but absent here draws no mutants and gates
+          # nothing, and one present here but not named there is never mutated at all.
           git diff "origin/$BASE_REF...HEAD" \
             -- ':(glob)crates/glass-core/src/**/*.rs' \
                ':(glob)crates/glass-android/src/**/*.rs' > "$RUNNER_TEMP/pr.diff"
@@ -326,9 +326,8 @@ jobs:
   # A matrix job's checks are named per shard, so the branch ruleset has nothing stable
   # to require. This one has a fixed name and fails if any shard did.
   #
-  # That name is what the ruleset's required check matches on, so it is frozen: renaming it
-  # leaves the ruleset waiting on a check that never reports, and every pull request blocks.
-  # It now gates glass-android too — rename it only together with the ruleset entry.
+  # The ruleset's required check matches this name, so it is frozen — renaming it blocks every
+  # pull request. It gates glass-android too despite the name; rename only with the ruleset.
   mutants-gate:
     name: Mutation gate (glass-core)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
           if-no-files-found: warn
 
   mutants:
-    name: Mutation shard ${{ matrix.shard }} (glass-core)
+    name: Mutation shard ${{ matrix.shard }} (glass-core, glass-android)
     runs-on: ubuntu-latest
     # A push carries no base ref to diff against; this gate is a pull-request check.
     if: github.event_name == 'pull_request'
@@ -273,7 +273,7 @@ jobs:
           # `--in-diff` needs a merge base to diff against; the default depth-1 checkout has
           # none, which would yield an empty diff, mutate nothing, and pass green.
           fetch-depth: 0
-      - name: Diff glass-core against the merge base
+      - name: Diff the gated crates against the merge base
         id: diff
         # A ref name may contain `;`, `` ` ``, `$` and more, so it reaches the shell as data.
         env:
@@ -286,14 +286,19 @@ jobs:
           }
           # `:(glob)` so `**` spans directories, matching scripts/mutants.sh's --file; without
           # it git reads `**` as an ordinary fnmatch pattern and selects nothing at all.
+          #
+          # Keep these pathspecs in step with the --package list below: a crate mutated without
+          # its files in the diff draws no mutants and gates nothing, and one diffed without
+          # being named as a package is mutated under the other's --file glob.
           git diff "origin/$BASE_REF...HEAD" \
-            -- ':(glob)crates/glass-core/src/**/*.rs' > "$RUNNER_TEMP/pr.diff"
+            -- ':(glob)crates/glass-core/src/**/*.rs' \
+               ':(glob)crates/glass-android/src/**/*.rs' > "$RUNNER_TEMP/pr.diff"
           wc -l "$RUNNER_TEMP/pr.diff"
           if [ -s "$RUNNER_TEMP/pr.diff" ]; then
             echo "touched=true" >> "$GITHUB_OUTPUT"
           else
             echo "touched=false" >> "$GITHUB_OUTPUT"
-            echo "this PR changes no .rs file under crates/glass-core/src/ — nothing to mutate"
+            echo "this PR changes no .rs file under the gated crates' src/ — nothing to mutate"
           fi
       # Installing a toolchain and two cargo tools costs more than the check itself,
       # so a PR that touches no smoke file skips straight past them.
@@ -314,11 +319,16 @@ jobs:
         run: |
           scripts/mutants.sh "$RUNNER_TEMP/mutants" \
             --test-tool nextest \
+            --package glass-core --package glass-android \
             --shard ${{ matrix.shard }}/8 --sharding round-robin \
             --in-diff "$RUNNER_TEMP/pr.diff"
 
   # A matrix job's checks are named per shard, so the branch ruleset has nothing stable
   # to require. This one has a fixed name and fails if any shard did.
+  #
+  # That name is what the ruleset's required check matches on, so it is frozen: renaming it
+  # leaves the ruleset waiting on a check that never reports, and every pull request blocks.
+  # It now gates glass-android too — rename it only together with the ruleset entry.
   mutants-gate:
     name: Mutation gate (glass-core)
     runs-on: ubuntu-latest

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   sweep:
-    name: Mutation sweep shard ${{ matrix.shard }} (glass-core)
+    name: Mutation sweep shard ${{ matrix.shard }} (glass-core, glass-android)
     runs-on: ubuntu-latest
     strategy:
       # Every shard reports: one red shard must not hide a second one.
@@ -37,6 +37,7 @@ jobs:
         run: |
           scripts/mutants.sh "$RUNNER_TEMP/mutants" \
             --test-tool nextest \
+            --package glass-core --package glass-android \
             --shard ${{ matrix.shard }}/8 --sharding round-robin
       - name: Upload the outcome
         if: always()

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -2199,6 +2199,51 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
+    fn a_dump_that_exits_zero_and_explains_itself_on_stderr_is_read_as_a_failure() {
+        // `uiautomator dump` reports failure by exiting 0 with its reason on stderr and no file
+        // written. Judging it by exit status alone would take it for a tree that arrived, and the
+        // read that follows would be blamed for the emptiness instead.
+        use super::AndroidA11y;
+        use crate::adb::{Answer, FakeAdb};
+        use glass_core::Accessibility;
+
+        let fake = FakeAdb::new(&[
+            (
+                "*uiautomator dump*",
+                Answer::warns("ERROR: could not get idle state.\n"),
+            ),
+            // No file was written, so the read that follows finds nothing.
+            ("*shell cat*", Answer::fails("No such file or directory")),
+            ("*", Answer::Silent),
+        ]);
+
+        let mut reader = AndroidA11y::for_adb(fake.adb().clone());
+        let ctx = AxContext {
+            pids: vec![],
+            window: WindowGeometry {
+                x: 0,
+                y: 0,
+                width: 1080,
+                height: 2400,
+            },
+            window_handle: None,
+            a11y_bus_addr: None,
+            limits: WalkLimits::DEFAULT,
+            deadline: AxDeadline::from_millis(300),
+        };
+
+        let err = reader
+            .snapshot(&ctx)
+            .expect_err("a dump that wrote no tree did not serve one");
+        // The device's own words, not a complaint about the read that came up empty.
+        assert!(
+            err.to_string().contains("could not get idle state"),
+            "the reason must come from the dump: {err}"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
     fn a_reader_binds_to_the_serial_it_was_asked_for_when_several_are_online() {
         // Two online devices is ambiguous on its own; `GLASS_ANDROID_SERIAL` is what resolves it,
         // and it is read when the reader is made rather than when it resolves.

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -2138,9 +2138,8 @@ mod tests {
 
     #[test]
     fn an_unreadable_subtree_cannot_confirm_a_write_against_its_one_match() {
-        // The twin of the truncation case above: a subtree the walk could not read is the other
-        // place a second match can be hiding, and it needs a different remedy from a raised cap,
-        // so the message must not collapse into the drifted-element one.
+        // An unreadable subtree is the other place a second match can hide, and its remedy is
+        // not a raised cap, so its message must not collapse into the drifted-element one.
         let mut after = under_a_container(tree_holding(Some("world")));
         after.unreadable = 1;
         let t = target(0, Some("Search"), Some(BOUNDS));
@@ -2151,8 +2150,8 @@ mod tests {
 
     #[test]
     fn a_dump_path_names_this_process_and_never_repeats() {
-        // Two hosts can drive one device, and a retry must not read the file a previous attempt
-        // wrote — the file is the only signal that a dump succeeded at all.
+        // Two hosts can drive one device, and the file is the only signal a dump succeeded, so
+        // a retry must not read one a previous attempt wrote.
         let tag = super::process_tag();
         assert!(
             tag.starts_with(&format!("{}_", std::process::id())),
@@ -2201,8 +2200,7 @@ mod tests {
     #[cfg(unix)]
     fn a_dump_that_exits_zero_and_explains_itself_on_stderr_is_read_as_a_failure() {
         // `uiautomator dump` reports failure by exiting 0 with its reason on stderr and no file
-        // written. Judging it by exit status alone would take it for a tree that arrived, and the
-        // read that follows would be blamed for the emptiness instead.
+        // written, so its exit status alone reads as a tree that arrived.
         use super::AndroidA11y;
         use crate::adb::{Answer, FakeAdb};
         use glass_core::Accessibility;
@@ -2314,9 +2312,8 @@ mod tests {
         use crate::adb::{Answer, FakeAdb};
         use glass_core::Accessibility;
 
-        // The field still reads as the old text on the first read-back and as the new one on the
-        // second: the IME and its suggestion strip are still settling, which is exactly the
-        // moment a single read would call a good write failed.
+        // Old text on the first read-back, new on the second: the IME is still settling, which
+        // is when a single read would call a good write failed.
         let before = Answer::says(one_field_holding("hello"));
         let after = Answer::says(one_field_holding("world"));
         let fake = FakeAdb::scripted(&[

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -505,6 +505,9 @@ pub struct AndroidA11y {
     resolved: bool,
     /// Set once a dump has succeeded, after which snapshots stop waiting for readiness.
     warmed: bool,
+    /// `GLASS_ANDROID_SERIAL` as it stood when this reader was made. Read once rather than at
+    /// resolution, so the device a session is reading cannot change under it midway.
+    want_serial: Option<String>,
 }
 
 impl AndroidA11y {
@@ -513,6 +516,7 @@ impl AndroidA11y {
             adb: Adb::from_env(),
             resolved: false,
             warmed: false,
+            want_serial: std::env::var("GLASS_ANDROID_SERIAL").ok(),
         }
     }
 
@@ -535,6 +539,7 @@ impl AndroidA11y {
             adb,
             resolved: true,
             warmed: false,
+            want_serial: None,
         }
     }
 
@@ -555,10 +560,7 @@ impl AndroidA11y {
                 .into_iter()
                 .filter(|d| d.state == "device")
                 .collect();
-            let serial = choose_serial(
-                std::env::var("GLASS_ANDROID_SERIAL").ok().as_deref(),
-                &online,
-            )?;
+            let serial = choose_serial(self.want_serial.as_deref(), &online)?;
             self.adb = self.adb.with_serial(serial);
             self.resolved = true;
         }
@@ -2131,6 +2133,205 @@ mod tests {
         let err = verify_write(&after, &t, "world").unwrap_err();
         assert!(matches!(err, GlassError::AxWriteUnconfirmed(0, _)), "{err}");
         assert!(err.to_string().contains("truncated at 2 nodes"), "{err}");
+    }
+
+    #[test]
+    fn an_unreadable_subtree_cannot_confirm_a_write_against_its_one_match() {
+        // The twin of the truncation case above: a subtree the walk could not read is the other
+        // place a second match can be hiding, and it needs a different remedy from a raised cap,
+        // so the message must not collapse into the drifted-element one.
+        let mut after = under_a_container(tree_holding(Some("world")));
+        after.unreadable = 1;
+        let t = target(0, Some("Search"), Some(BOUNDS));
+        let err = verify_write(&after, &t, "world").unwrap_err();
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(0, _)), "{err}");
+        assert!(err.to_string().contains("could not be read"), "{err}");
+    }
+
+    #[test]
+    fn a_dump_path_names_this_process_and_never_repeats() {
+        // Two hosts can drive one device, and a retry must not read the file a previous attempt
+        // wrote — the file is the only signal that a dump succeeded at all.
+        let tag = super::process_tag();
+        assert!(
+            tag.starts_with(&format!("{}_", std::process::id())),
+            "the tag must identify this process, got {tag:?}"
+        );
+        let first = super::attempt_path("/sdcard/glass_dump");
+        assert!(first.contains(tag), "{first}");
+        assert_ne!(first, super::attempt_path("/sdcard/glass_dump"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_reader_resolves_its_device_once_and_only_among_the_online_ones() {
+        use super::AndroidA11y;
+        use crate::adb::{Answer, FakeAdb};
+
+        let fake = FakeAdb::new(&[(
+            "devices",
+            Answer::says(
+                "List of devices attached\nemulator-5554\tdevice\nemulator-5556\toffline\n",
+            ),
+        )]);
+        let mut reader = AndroidA11y {
+            adb: fake.adb().clone(),
+            resolved: false,
+            warmed: false,
+            want_serial: None,
+        };
+
+        let bound = reader.ensure_adb().expect("one device is online");
+        assert_eq!(bound.serial(), Some("emulator-5554"));
+
+        // Resolved once: a session's reads must not re-ask, or a device appearing mid-session
+        // could move the reader to a different one than the platform is driving.
+        let again = reader.ensure_adb().expect("already resolved");
+        assert_eq!(again.serial(), Some("emulator-5554"));
+        assert_eq!(
+            fake.calls().iter().filter(|c| *c == "devices").count(),
+            1,
+            "{:?}",
+            fake.calls()
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_reader_handed_a_resolved_client_does_not_go_looking_for_a_device() {
+        // The platform has already chosen — possibly a freshly booted AVD that `choose_serial`
+        // could not have disambiguated — so asking again could land on a different device.
+        use super::AndroidA11y;
+        use crate::adb::{Answer, FakeAdb};
+
+        let fake = FakeAdb::new(&[("*", Answer::says(""))]);
+        let mut reader = AndroidA11y::for_adb(fake.adb().with_serial("emulator-5556"));
+
+        let bound = reader.ensure_adb().expect("already resolved");
+        assert_eq!(bound.serial(), Some("emulator-5556"));
+        assert!(!fake.called("devices"), "{:?}", fake.calls());
+    }
+
+    /// A uiautomator dump of one editable field holding `text`.
+    #[cfg(unix)]
+    fn one_field_holding(text: &str) -> String {
+        format!(
+            concat!(
+                "<?xml version='1.0'?><hierarchy rotation=\"0\">",
+                "<node index=\"0\" text=\"{}\" class=\"android.widget.EditText\" ",
+                "package=\"com.example.app\" content-desc=\"Search\" enabled=\"true\" ",
+                "focusable=\"true\" focused=\"true\" bounds=\"[100,200][500,300]\" />",
+                "</hierarchy>"
+            ),
+            text
+        )
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_write_taps_the_field_clears_it_types_and_waits_for_the_value_to_land() {
+        use super::AndroidA11y;
+        use crate::adb::{Answer, FakeAdb};
+        use glass_core::Accessibility;
+
+        // The field still reads as the old text on the first read-back and as the new one on the
+        // second: the IME and its suggestion strip are still settling, which is exactly the
+        // moment a single read would call a good write failed.
+        let before = Answer::says(one_field_holding("hello"));
+        let after = Answer::says(one_field_holding("world"));
+        let fake = FakeAdb::scripted(&[
+            ("*shell cat*", vec![&before, &before, &after]),
+            ("*", vec![&Answer::Silent]),
+        ]);
+
+        let mut reader = AndroidA11y::for_adb(fake.adb().clone());
+        let ctx = AxContext {
+            pids: vec![],
+            window: WindowGeometry {
+                x: 0,
+                y: 0,
+                width: 1080,
+                height: 2400,
+            },
+            window_handle: None,
+            a11y_bus_addr: None,
+            limits: WalkLimits::DEFAULT,
+            deadline: AxDeadline::from_millis(30_000),
+        };
+        // The synthetic Window root is id 0, so the field is id 1.
+        let field = AxTarget {
+            id: AxNodeId(1),
+            role: AxRole::TextField,
+            name: Some("Search".into()),
+            bounds: Some(AxRect {
+                x: 100,
+                y: 200,
+                width: 400,
+                height: 100,
+            }),
+            value: None,
+        };
+
+        reader
+            .set_value(&ctx, &field, "world")
+            .expect("the value lands on the second read-back");
+
+        // Tapped at the field's centre, then cleared, then typed — in that order.
+        assert!(fake.called("input tap 300 250"), "{:?}", fake.calls());
+        assert!(fake.called("input text"), "{:?}", fake.calls());
+        let cleared = fake
+            .calls()
+            .iter()
+            .any(|c| c.contains("input keyevent") || c.contains("keycombination"));
+        assert!(
+            cleared,
+            "the field must be cleared first: {:?}",
+            fake.calls()
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_write_that_never_lands_is_reported_rather_than_assumed() {
+        use super::AndroidA11y;
+        use crate::adb::{Answer, FakeAdb};
+        use glass_core::Accessibility;
+
+        let stuck = Answer::says(one_field_holding("hello"));
+        let fake =
+            FakeAdb::scripted(&[("*shell cat*", vec![&stuck]), ("*", vec![&Answer::Silent])]);
+
+        let mut reader = AndroidA11y::for_adb(fake.adb().clone());
+        let ctx = AxContext {
+            pids: vec![],
+            window: WindowGeometry {
+                x: 0,
+                y: 0,
+                width: 1080,
+                height: 2400,
+            },
+            window_handle: None,
+            a11y_bus_addr: None,
+            limits: WalkLimits::DEFAULT,
+            deadline: AxDeadline::from_millis(30_000),
+        };
+        let field = AxTarget {
+            id: AxNodeId(1),
+            role: AxRole::TextField,
+            name: Some("Search".into()),
+            bounds: Some(AxRect {
+                x: 100,
+                y: 200,
+                width: 400,
+                height: 100,
+            }),
+            value: None,
+        };
+
+        let err = reader
+            .set_value(&ctx, &field, "world")
+            .expect_err("a field still holding the old text has not taken the write");
+        assert!(matches!(err, GlassError::AxValueNotApplied(1)), "{err}");
     }
 
     #[test]

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -505,8 +505,9 @@ pub struct AndroidA11y {
     resolved: bool,
     /// Set once a dump has succeeded, after which snapshots stop waiting for readiness.
     warmed: bool,
-    /// `GLASS_ANDROID_SERIAL` as it stood when this reader was made. Read once rather than at
-    /// resolution, so the device a session is reading cannot change under it midway.
+    /// `GLASS_ANDROID_SERIAL` as it stood when `new` was called — `for_adb` is already resolved
+    /// and leaves it unset. Read once rather than at resolution, so the device a session is
+    /// reading cannot change under it midway.
     want_serial: Option<String>,
 }
 
@@ -2198,6 +2199,40 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
+    fn a_reader_binds_to_the_serial_it_was_asked_for_when_several_are_online() {
+        // Two online devices is ambiguous on its own; `GLASS_ANDROID_SERIAL` is what resolves it,
+        // and it is read when the reader is made rather than when it resolves.
+        use super::AndroidA11y;
+        use crate::adb::{Answer, FakeAdb};
+
+        let fake = FakeAdb::new(&[(
+            "devices",
+            Answer::says(
+                "List of devices attached\nemulator-5554\tdevice\nemulator-5556\tdevice\n",
+            ),
+        )]);
+        let mut reader = AndroidA11y {
+            adb: fake.adb().clone(),
+            resolved: false,
+            warmed: false,
+            want_serial: Some("emulator-5556".to_string()),
+        };
+
+        let bound = reader.ensure_adb().expect("the named device is online");
+        assert_eq!(bound.serial(), Some("emulator-5556"));
+
+        // Without the preference the same listing is refused rather than guessed at.
+        let mut blind = AndroidA11y {
+            adb: fake.adb().clone(),
+            resolved: false,
+            warmed: false,
+            want_serial: None,
+        };
+        assert!(blind.ensure_adb().is_err(), "two devices cannot be guessed");
+    }
+
+    #[test]
+    #[cfg(unix)]
     fn a_reader_handed_a_resolved_client_does_not_go_looking_for_a_device() {
         // The platform has already chosen — possibly a freshly booted AVD that `choose_serial`
         // could not have disambiguated — so asking again could land on a different device.
@@ -2276,7 +2311,8 @@ mod tests {
             .set_value(&ctx, &field, "world")
             .expect("the value lands on the second read-back");
 
-        // Tapped at the field's centre, then cleared, then typed — in that order.
+        // Tapped at the field's centre, cleared, and typed. Order is not asserted here; the
+        // read-back below is what proves the field ended up holding the new text and not both.
         assert!(fake.called("input tap 300 250"), "{:?}", fake.calls());
         assert!(fake.called("input text"), "{:?}", fake.calls());
         let cleared = fake

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -684,12 +684,10 @@ impl A11yServiceRegistry {
     }
 }
 
-/// The recovery for the `step`th readiness attempt that was refused for its whole budget: force
-/// the service's binding to be rebuilt, and on the LAST attempt reinstall the APK first.
+/// The recovery for the `step`th readiness attempt refused for its whole budget.
 ///
-/// The reinstall is what SIGKILLs the service and starts this race in the first place, and also
-/// the only step observed to bring a stuck binding back — so it is the last resort rather than
-/// the first move.
+/// The reinstall is last, not first: it is what SIGKILLs the service and starts this race, and
+/// also the only step observed to bring a stuck binding back.
 fn escalate(adb: &Adb, apk: &str, want: &str, step: u32, attempts: u32) -> Result<()> {
     if step + 1 == attempts {
         install_service(adb, apk)?;
@@ -1253,9 +1251,8 @@ mod tests {
 
     #[test]
     fn a_node_is_placed_relative_to_the_window_and_reported_visible() {
-        // The device sends screen-absolute bounds and the window here starts at y=100, so an
-        // offset applied the wrong way puts every node twice the status bar's height down the
-        // screen — and a click lands there.
+        // The device sends screen-absolute bounds, so an offset applied the wrong way puts
+        // every node twice the window's inset down the screen, and a click lands there.
         let node = mapped(Some("Save"), None);
         let bounds = node.bounds.expect("the device always sends bounds");
         assert_eq!(
@@ -1270,8 +1267,6 @@ mod tests {
 
     #[test]
     fn a_child_list_stops_at_the_node_budget_and_says_so() {
-        // The cap is checked before each child rather than after, so the child that merely
-        // completes the tree is not mistaken for one the walk declined to visit.
         let wide = json!({
             "class": "android.widget.FrameLayout",
             "bounds": {"x": 0, "y": 100, "w": 100, "h": 100},
@@ -1334,7 +1329,7 @@ mod tests {
 
     #[test]
     fn a_node_whose_children_are_past_the_depth_cap_does_report_truncation() {
-        // The other side of it, so the case above is not simply asserting the cap never fires.
+        // Paired with the case above, which would otherwise pass if the cap never fired.
         let child_at_the_cap = json!({
             "class": "android.widget.FrameLayout",
             "bounds": {"x": 0, "y": 100, "w": 100, "h": 100},
@@ -2945,9 +2940,8 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn enabling_the_service_adds_it_to_whatever_the_device_already_had() {
-        // The device's other accessibility services must survive: dropping them would turn off
-        // a screen reader for the duration of a glass session and leave it off if teardown is
-        // missed.
+        // Dropping the device's other services would turn off a screen reader for the session,
+        // and leave it off if teardown is missed.
         let (port, _ops) = fake_service(vec![compose_like()], OnAction::Ok);
         let fake = a_device_ready_to_enable("com.other/.Reader", "1", port);
 
@@ -3054,7 +3048,7 @@ mod tests {
     #[cfg(unix)]
     fn a_rebind_reinstalls_only_as_a_last_resort() {
         // The reinstall is what SIGKILLs the service and starts the binding race, so trying it
-        // first would restart the very thing being waited on.
+        // first restarts the thing being waited on.
         use crate::adb::{Answer, FakeAdb};
         let want = format!("com.other/.Reader:{SERVICE_COMPONENT}");
 
@@ -3105,8 +3099,8 @@ mod tests {
 
     #[test]
     fn readiness_gives_up_on_a_socket_that_never_greets() {
-        // The other side of the case above: a service that never comes back has to end the
-        // attempt, or `ensure` waits on it for as long as the process lives.
+        // A service that never comes back has to end the attempt, or `ensure` waits on it for
+        // as long as the process lives.
         let (port, _ops) = fake_service_stumbling(
             vec![compose_like()],
             vec![OnAction::Ok],
@@ -3128,9 +3122,8 @@ mod tests {
 
     #[test]
     fn a_bounded_read_does_not_leave_its_bound_on_the_connection() {
-        // The socket outlives any one request, so a bound left behind would apply to a later
-        // call that never agreed to it — including a snapshot with no deadline at all, which
-        // would then give up in whatever time the last bounded caller happened to name.
+        // The socket outlives any one request, so a bound left behind applies to a later call
+        // that never agreed to it — including a snapshot with no deadline at all.
         let (port, _ops) = fake_service(vec![compose_like()], OnAction::Ok);
         let mut a = reader(port, std::time::Duration::ZERO);
         let mut bounded = ctx();
@@ -3153,8 +3146,8 @@ mod tests {
 
     #[test]
     fn a_toggle_that_flips_a_beat_later_is_waited_for() {
-        // The toolkit updates its UI, and only then does the accessibility tree catch up, so the
-        // first read back after the click legitimately still shows the old state.
+        // The accessibility tree catches up after the toolkit's own UI, so the first read back
+        // legitimately still shows the old state.
         let (port, ops) = fake_service(
             vec![
                 one_checkable("android.widget.CheckBox", false),
@@ -3884,8 +3877,8 @@ mod tests {
 
     #[test]
     fn a_node_is_placed_relative_to_a_window_that_is_not_at_the_origin() {
-        // A window inset on both axes — the split-screen and freeform cases. With either offset
-        // at zero the arithmetic reads the same whichever way round it is, so both are non-zero.
+        // Both offsets non-zero: at zero the arithmetic reads the same whichever way round it
+        // is combined.
         let inset = WindowGeometry {
             x: 40,
             y: 100,

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -1302,6 +1302,68 @@ mod tests {
     }
 
     #[test]
+    fn a_childless_node_at_the_depth_cap_records_no_truncation() {
+        // The device sends `"children": []` for a leaf. Reaching one with the depth budget
+        // already spent declines nothing, so reporting the tree truncated is a false positive —
+        // and the caller's remedy for it, raising `max_depth`, returns the identical tree.
+        let leaf_at_the_cap = json!({
+            "class": "android.widget.FrameLayout",
+            "bounds": {"x": 0, "y": 100, "w": 100, "h": 100},
+            "enabled": true,
+            "children": [{
+                "class": "android.widget.TextView",
+                "text": "leaf",
+                "bounds": {"x": 0, "y": 100, "w": 10, "h": 10},
+                "enabled": true,
+                "children": [],
+            }],
+        });
+        let mut walk = Walk::new(WalkLimits {
+            depth: 1,
+            ..WalkLimits::DEFAULT
+        });
+        let root = json_to_node(&with_refs(&leaf_at_the_cap), &win(), 0, &mut walk).expect("maps");
+
+        assert_eq!(root.children.len(), 1, "the leaf is still mapped");
+        assert!(
+            walk.budget.truncation().is_none(),
+            "nothing was declined: {:?}",
+            walk.budget.truncation()
+        );
+    }
+
+    #[test]
+    fn a_node_whose_children_are_past_the_depth_cap_does_report_truncation() {
+        // The other side of it, so the case above is not simply asserting the cap never fires.
+        let child_at_the_cap = json!({
+            "class": "android.widget.FrameLayout",
+            "bounds": {"x": 0, "y": 100, "w": 100, "h": 100},
+            "enabled": true,
+            "children": [{
+                "class": "android.widget.FrameLayout",
+                "bounds": {"x": 0, "y": 100, "w": 50, "h": 50},
+                "enabled": true,
+                "children": [{
+                    "class": "android.widget.TextView",
+                    "text": "too deep",
+                    "bounds": {"x": 0, "y": 100, "w": 10, "h": 10},
+                    "enabled": true,
+                }],
+            }],
+        });
+        let mut walk = Walk::new(WalkLimits {
+            depth: 1,
+            ..WalkLimits::DEFAULT
+        });
+        let _ = json_to_node(&with_refs(&child_at_the_cap), &win(), 0, &mut walk).expect("maps");
+
+        assert_eq!(
+            walk.budget.truncation().map(|t| t.limit),
+            Some(TruncationLimit::Depth)
+        );
+    }
+
+    #[test]
     fn enclosure_is_measured_from_each_rectangle_far_edge() {
         let rect = |x, y, width, height| {
             Some(AxRect {

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -93,7 +93,7 @@ fn json_to_node(v: &Value, win: &WindowGeometry, depth: usize, walk: &mut Walk) 
     let (x, y, w, h) = (bi("x"), bi("y"), bu("w"), bu("h"));
     // Recursion is bounded by `budget` (depth, node count, siblings per level), so a
     // pathologically deep or wide device tree cannot blow the stack or the token budget.
-    // The child array is resolved before either bound is consulted: a childless node must
+    // The child array is resolved before any bound is consulted: a childless node must
     // never be reported truncated for declining to explore a list that was already empty.
     let children = match v.get("children").and_then(Value::as_array) {
         None => vec![],
@@ -1289,7 +1289,11 @@ mod tests {
         });
         let root = json_to_node(&with_refs(&wide), &win(), 0, &mut walk).expect("maps");
 
-        assert!(root.children.len() < 8, "the cap must stop the walk");
+        assert!(
+            (1..8).contains(&root.children.len()),
+            "the cap must stop the walk part-way, not before it starts: {}",
+            root.children.len()
+        );
         assert_eq!(
             walk.budget.truncation().map(|t| t.limit),
             Some(TruncationLimit::Nodes),

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -102,10 +102,6 @@ fn json_to_node(v: &Value, win: &WindowGeometry, depth: usize, walk: &mut Walk) 
             walk.budget.hit(TruncationLimit::Depth);
             vec![]
         }
-        Some(_) if walk.budget.nodes_exhausted() => {
-            walk.budget.hit(TruncationLimit::Nodes);
-            vec![]
-        }
         Some(arr) => {
             let mut out = Vec::new();
             for (i, c) in arr.iter().enumerate() {
@@ -607,7 +603,9 @@ pub fn a11y_apk(get: &dyn Fn(&str) -> Option<String>) -> Option<String> {
 }
 
 struct Active {
-    serial: Option<String>,
+    /// The client the service was enabled through, kept rather than resolved again at teardown:
+    /// `Adb::from_env` reads the environment as it is *then*, which need not be what set this up.
+    adb: Adb,
     port: u16,
     prior_enabled: String,
     prior_a11y_enabled: String,
@@ -663,18 +661,11 @@ impl A11yServiceRegistry {
             port,
             READY_ATTEMPT,
             READY_ATTEMPTS,
-            &|step| {
-                // Last resort: the reinstall is what SIGKILLs the service and starts this
-                // race, and also the only step observed to bring a stuck binding back.
-                if step + 1 == READY_ATTEMPTS {
-                    install_service(adb, apk)?;
-                }
-                force_rebind(adb, &want)
-            },
+            &|step| escalate(adb, apk, &want, step, READY_ATTEMPTS),
             &|| restore_a11y(adb, prior, prior_a11y, port),
         )?;
         *self.state.lock().unwrap() = Some(Active {
-            serial: adb.serial().map(str::to_string),
+            adb: adb.clone(),
             port,
             prior_enabled: prior.to_string(),
             prior_a11y_enabled: prior_a11y.to_string(),
@@ -688,13 +679,22 @@ impl A11yServiceRegistry {
         if let Ok(mut g) = self.state.lock()
             && let Some(a) = g.take()
         {
-            let adb = match &a.serial {
-                Some(s) => Adb::from_env().with_serial(s.clone()),
-                None => Adb::from_env(),
-            };
-            restore_a11y(&adb, &a.prior_enabled, &a.prior_a11y_enabled, a.port);
+            restore_a11y(&a.adb, &a.prior_enabled, &a.prior_a11y_enabled, a.port);
         }
     }
+}
+
+/// The recovery for the `step`th readiness attempt that was refused for its whole budget: force
+/// the service's binding to be rebuilt, and on the LAST attempt reinstall the APK first.
+///
+/// The reinstall is what SIGKILLs the service and starts this race in the first place, and also
+/// the only step observed to bring a stuck binding back — so it is the last resort rather than
+/// the first move.
+fn escalate(adb: &Adb, apk: &str, want: &str, step: u32, attempts: u32) -> Result<()> {
+    if step + 1 == attempts {
+        install_service(adb, apk)?;
+    }
+    force_rebind(adb, want)
 }
 
 fn put_secure(adb: &Adb, key: &str, value: &str) -> Result<()> {
@@ -1186,6 +1186,147 @@ mod tests {
             "Failure [INSTALL_FAILED_INSUFFICIENT_STORAGE]"
         )));
         assert!(!is_signature_mismatch(&failed("error: device offline")));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn an_install_recovers_from_a_differently_signed_build_and_reports_anything_else() {
+        use crate::adb::{Answer, FakeAdb};
+
+        // A clean install: one call, nothing removed.
+        let clean = FakeAdb::new(&[("*", Answer::Silent)]);
+        install_service(clean.adb(), "/opt/glass/glass-a11y.apk").expect("a clean install");
+        assert_eq!(clean.calls(), ["install -r /opt/glass/glass-a11y.apk"]);
+
+        // A differently-signed build already present: glass owns this package, so the stale copy
+        // goes and a fresh one is installed rather than the launch failing.
+        let stale_ok = Answer::fails(
+            "Failure [INSTALL_FAILED_UPDATE_INCOMPATIBLE: Existing package signatures do not \
+             match newer version; ignoring!]",
+        );
+        let fresh = Answer::Silent;
+        let mismatched = FakeAdb::scripted(&[
+            ("install *", vec![&stale_ok, &fresh]),
+            ("*", vec![&Answer::Silent]),
+        ]);
+        install_service(mismatched.adb(), "/opt/glass/glass-a11y.apk")
+            .expect("a signature mismatch is recovered from");
+        assert!(
+            mismatched.called(&format!("uninstall {SERVICE_PACKAGE}")),
+            "{:?}",
+            mismatched.calls()
+        );
+
+        // Any other failure is reported, and nothing is uninstalled on the strength of it.
+        let other = FakeAdb::new(&[(
+            "install *",
+            Answer::fails("Failure [INSTALL_FAILED_INSUFFICIENT_STORAGE]"),
+        )]);
+        let err = install_service(other.adb(), "/opt/glass/glass-a11y.apk")
+            .expect_err("a full device is not a signature mismatch");
+        assert!(err.to_string().contains("INSUFFICIENT_STORAGE"), "{err}");
+        assert!(!other.called("uninstall"), "{:?}", other.calls());
+    }
+
+    #[test]
+    fn the_service_apk_is_the_configured_one_unless_accessibility_is_turned_off() {
+        let configured = |k: &str| match k {
+            "GLASS_ANDROID_A11Y_APK" => Some("/opt/glass/glass-a11y.apk".to_string()),
+            _ => None,
+        };
+        assert_eq!(
+            a11y_apk(&configured).as_deref(),
+            Some("/opt/glass/glass-a11y.apk")
+        );
+
+        let turned_off = |k: &str| match k {
+            "GLASS_ANDROID_A11Y" => Some("off".to_string()),
+            "GLASS_ANDROID_A11Y_APK" => Some("/opt/glass/glass-a11y.apk".to_string()),
+            _ => None,
+        };
+        assert_eq!(
+            a11y_apk(&turned_off),
+            None,
+            "off must win over a configured path, or the reader installs what it was told not to"
+        );
+    }
+
+    #[test]
+    fn a_node_is_placed_relative_to_the_window_and_reported_visible() {
+        // The device sends screen-absolute bounds and the window here starts at y=100, so an
+        // offset applied the wrong way puts every node twice the status bar's height down the
+        // screen — and a click lands there.
+        let node = mapped(Some("Save"), None);
+        let bounds = node.bounds.expect("the device always sends bounds");
+        assert_eq!(
+            (bounds.x, bounds.y),
+            (0, 0),
+            "screen y=100 in a window at y=100"
+        );
+        // The companion only ever describes what is on screen, and a node reported invisible is
+        // one `wait_for_element` will never settle on.
+        assert!(node.states.visible);
+    }
+
+    #[test]
+    fn a_child_list_stops_at_the_node_budget_and_says_so() {
+        // The cap is checked before each child rather than after, so the child that merely
+        // completes the tree is not mistaken for one the walk declined to visit.
+        let wide = json!({
+            "class": "android.widget.FrameLayout",
+            "bounds": {"x": 0, "y": 100, "w": 100, "h": 100},
+            "enabled": true,
+            "children": (0..8).map(|i| json!({
+                "class": "android.widget.TextView",
+                "text": format!("row {i}"),
+                "bounds": {"x": 0, "y": 100, "w": 10, "h": 10},
+                "enabled": true,
+            })).collect::<Vec<_>>(),
+        });
+        let mut walk = Walk::new(WalkLimits {
+            nodes: 4,
+            ..WalkLimits::DEFAULT
+        });
+        let root = json_to_node(&with_refs(&wide), &win(), 0, &mut walk).expect("maps");
+
+        assert!(root.children.len() < 8, "the cap must stop the walk");
+        assert_eq!(
+            walk.budget.truncation().map(|t| t.limit),
+            Some(TruncationLimit::Nodes),
+            "a walk that declined children must say which cap did it"
+        );
+    }
+
+    #[test]
+    fn enclosure_is_measured_from_each_rectangle_far_edge() {
+        let rect = |x, y, width, height| {
+            Some(AxRect {
+                x,
+                y,
+                width,
+                height,
+            })
+        };
+        let outer = rect(0, 0, 100, 100);
+
+        assert!(
+            encloses(outer, rect(10, 10, 50, 50)),
+            "a box wholly inside is enclosed"
+        );
+        assert!(
+            !encloses(outer, rect(60, 10, 60, 50)),
+            "one whose right edge is past the outer's is not"
+        );
+        assert!(
+            !encloses(outer, rect(10, 60, 50, 60)),
+            "nor one whose bottom edge is"
+        );
+        assert!(
+            encloses(outer, rect(0, 0, 100, 100)),
+            "edges are inclusive, so an exact fit encloses"
+        );
+        assert!(!encloses(outer, None), "geometry that cannot be checked");
+        assert!(!encloses(None, rect(10, 10, 10, 10)));
     }
 
     /// `GLASS_ANDROID_A11Y_APK` is caller-supplied and lands in the argv the error names, so a
@@ -2405,6 +2546,18 @@ mod tests {
         packages: Vec<TreePackage>,
         on_tree: Vec<OnTree>,
     ) -> (u16, Arc<Mutex<Vec<String>>>) {
+        fake_service_stumbling(trees, on_action, packages, on_tree, 0)
+    }
+
+    /// [`fake_service_full`], dropping the first `stumbles` connections before the hello — a
+    /// service whose socket is up but which is not answering yet.
+    fn fake_service_stumbling(
+        trees: Vec<Value>,
+        on_action: Vec<OnAction>,
+        packages: Vec<TreePackage>,
+        on_tree: Vec<OnTree>,
+        stumbles: usize,
+    ) -> (u16, Arc<Mutex<Vec<String>>>) {
         // Numbered on the way out, like the real companion's `treeJson`, so a fixture never has
         // to restate what every device reply carries.
         let trees: Vec<Value> = trees.iter().map(with_refs).collect();
@@ -2418,6 +2571,10 @@ mod tests {
             let mut requested = 0usize;
             while let Ok((sock, _)) = listener.accept() {
                 conn += 1;
+                if conn <= stumbles {
+                    log.lock().unwrap().push(format!("conn{conn}:dropped"));
+                    continue;
+                }
                 let this_action = on_action[(conn - 1).min(on_action.len() - 1)];
                 let Ok(mut w) = sock.try_clone() else { break };
                 let mut r = std::io::BufReader::new(sock);
@@ -2680,6 +2837,275 @@ mod tests {
              failed, or worse — Refused's own AnswerLost sibling would read as a lost result \
              for an action that never left the host): {}",
             e.into_error()
+        );
+    }
+
+    /// A device that answers everything `ensure` asks, with `enabled_accessibility_services`
+    /// already reading `prior` and the forward landing on `port`.
+    #[cfg(unix)]
+    fn a_device_ready_to_enable(
+        prior: &str,
+        prior_enabled: &str,
+        port: u16,
+    ) -> crate::adb::FakeAdb {
+        use crate::adb::{Answer, FakeAdb};
+        FakeAdb::new(&[
+            (
+                "*settings get secure enabled_accessibility_services",
+                Answer::says(format!("{prior}\n")),
+            ),
+            (
+                "*settings get secure accessibility_enabled",
+                Answer::says(format!("{prior_enabled}\n")),
+            ),
+            ("*forward tcp:0 *", Answer::says(format!("{port}\n"))),
+            ("*", Answer::Silent),
+        ])
+    }
+
+    /// The value the last `settings put secure enabled_accessibility_services` wrote.
+    #[cfg(unix)]
+    fn enabled_list_written(fake: &crate::adb::FakeAdb) -> String {
+        fake.calls()
+            .iter()
+            .filter_map(|c| {
+                c.split_once("settings put secure enabled_accessibility_services ")
+                    .map(|(_, v)| v.to_string())
+            })
+            .next_back()
+            .unwrap_or_default()
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn enabling_the_service_adds_it_to_whatever_the_device_already_had() {
+        // The device's other accessibility services must survive: dropping them would turn off
+        // a screen reader for the duration of a glass session and leave it off if teardown is
+        // missed.
+        let (port, _ops) = fake_service(vec![compose_like()], OnAction::Ok);
+        let fake = a_device_ready_to_enable("com.other/.Reader", "1", port);
+
+        let registry = A11yServiceRegistry::new();
+        registry
+            .ensure(fake.adb(), "/opt/glass/glass-a11y.apk")
+            .expect("the service is installed, enabled and serving");
+
+        assert_eq!(
+            enabled_list_written(&fake),
+            format!("com.other/.Reader:{SERVICE_COMPONENT}"),
+            "{:?}",
+            fake.calls()
+        );
+        assert!(
+            fake.called("settings put secure accessibility_enabled 1"),
+            "{:?}",
+            fake.calls()
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn enabling_a_service_the_device_already_lists_does_not_list_it_twice() {
+        let (port, _ops) = fake_service(vec![compose_like()], OnAction::Ok);
+        let already = format!("com.other/.Reader:{SERVICE_COMPONENT}");
+        let fake = a_device_ready_to_enable(&already, "1", port);
+
+        let registry = A11yServiceRegistry::new();
+        registry
+            .ensure(fake.adb(), "/opt/glass/glass-a11y.apk")
+            .expect("the service is already listed");
+
+        assert_eq!(enabled_list_written(&fake), already, "{:?}", fake.calls());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_device_with_no_accessibility_at_all_is_restored_to_exactly_that() {
+        // `settings get` prints the string "null" for an unset key. Carrying that through as a
+        // value would enable a service literally named `null` and restore one on teardown.
+        let (port, _ops) = fake_service(vec![compose_like()], OnAction::Ok);
+        let fake = a_device_ready_to_enable("null", "null", port);
+
+        let registry = A11yServiceRegistry::new();
+        registry
+            .ensure(fake.adb(), "/opt/glass/glass-a11y.apk")
+            .expect("the service comes up on a device with none enabled");
+        assert_eq!(
+            enabled_list_written(&fake),
+            SERVICE_COMPONENT,
+            "{:?}",
+            fake.calls()
+        );
+
+        registry.shutdown();
+
+        // An empty list is a `delete`, and the global flag goes back to off rather than to "null".
+        assert!(
+            fake.called("settings delete secure enabled_accessibility_services"),
+            "{:?}",
+            fake.calls()
+        );
+        assert!(
+            fake.called("settings put secure accessibility_enabled 0"),
+            "{:?}",
+            fake.calls()
+        );
+        assert!(
+            fake.called(&format!("forward --remove tcp:{port}")),
+            "{:?}",
+            fake.calls()
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn shutting_down_restores_what_the_device_had_and_only_once() {
+        let (port, _ops) = fake_service(vec![compose_like()], OnAction::Ok);
+        let fake = a_device_ready_to_enable("com.other/.Reader", "1", port);
+
+        let registry = A11yServiceRegistry::new();
+        registry
+            .ensure(fake.adb(), "/opt/glass/glass-a11y.apk")
+            .expect("the service comes up");
+        registry.shutdown();
+
+        assert_eq!(
+            enabled_list_written(&fake),
+            "com.other/.Reader",
+            "the device's own service is put back, without glass's"
+        );
+
+        let after = fake.calls().len();
+        registry.shutdown();
+        assert_eq!(
+            fake.calls().len(),
+            after,
+            "a second shutdown must not touch a device glass no longer owns"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_rebind_reinstalls_only_as_a_last_resort() {
+        // The reinstall is what SIGKILLs the service and starts the binding race, so trying it
+        // first would restart the very thing being waited on.
+        use crate::adb::{Answer, FakeAdb};
+        let want = format!("com.other/.Reader:{SERVICE_COMPONENT}");
+
+        let early = FakeAdb::new(&[("*", Answer::Silent)]);
+        escalate(early.adb(), "/opt/glass/glass-a11y.apk", &want, 0, 3)
+            .expect("a rebind on its own");
+        assert!(!early.called("install"), "{:?}", early.calls());
+        // It disables and re-enables, which is what makes the platform rebuild the binding.
+        assert!(
+            early.called("settings put secure accessibility_enabled 0"),
+            "{:?}",
+            early.calls()
+        );
+        assert!(
+            early.called("settings put secure accessibility_enabled 1"),
+            "{:?}",
+            early.calls()
+        );
+
+        let last = FakeAdb::new(&[("*", Answer::Silent)]);
+        escalate(last.adb(), "/opt/glass/glass-a11y.apk", &want, 2, 3)
+            .expect("the last attempt reinstalls first");
+        assert!(last.called("install -r"), "{:?}", last.calls());
+    }
+
+    #[test]
+    fn readiness_keeps_trying_a_socket_that_is_not_answering_yet() {
+        // Between the reinstall's SIGKILL and the rebind the service accepts and then drops the
+        // connection. Taking that first refusal as the answer would fail a launch that is a
+        // fraction of a second from working.
+        let (port, ops) = fake_service_stumbling(
+            vec![compose_like()],
+            vec![OnAction::Ok],
+            vec![TreePackage::Echo],
+            vec![OnTree::Serve],
+            2,
+        );
+        wait_for_ready(port, READY_ATTEMPT).expect("the third connection is greeted");
+        assert_eq!(
+            ops_of(&ops),
+            vec![
+                "conn1:dropped".to_string(),
+                "conn2:dropped".to_string(),
+                "conn3:tree".to_string(),
+            ],
+        );
+    }
+
+    #[test]
+    fn readiness_gives_up_on_a_socket_that_never_greets() {
+        // The other side of the case above: a service that never comes back has to end the
+        // attempt, or `ensure` waits on it for as long as the process lives.
+        let (port, _ops) = fake_service_stumbling(
+            vec![compose_like()],
+            vec![OnAction::Ok],
+            vec![TreePackage::Echo],
+            vec![OnTree::Serve],
+            usize::MAX,
+        );
+        let started = std::time::Instant::now();
+        let Err(err) = wait_for_ready(port, std::time::Duration::from_millis(300)) else {
+            panic!("a socket that never answers cannot become ready");
+        };
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(5),
+            "waited {:?} — the deadline never ended the wait",
+            started.elapsed()
+        );
+        assert!(err.contains("never accepted a connection"), "{err}");
+    }
+
+    #[test]
+    fn a_bounded_read_does_not_leave_its_bound_on_the_connection() {
+        // The socket outlives any one request, so a bound left behind would apply to a later
+        // call that never agreed to it — including a snapshot with no deadline at all, which
+        // would then give up in whatever time the last bounded caller happened to name.
+        let (port, _ops) = fake_service(vec![compose_like()], OnAction::Ok);
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let mut bounded = ctx();
+        bounded.deadline = AxDeadline::from_millis(500);
+        a.snapshot(&bounded).expect("a bounded snapshot");
+
+        let left = a
+            .client
+            .conn
+            .lock()
+            .expect("conn lock")
+            .writer
+            .read_timeout()
+            .expect("the socket has a read timeout");
+        assert!(
+            left.is_none_or(|d| d > std::time::Duration::from_secs(5)),
+            "the next call would inherit {left:?} from this one"
+        );
+    }
+
+    #[test]
+    fn a_toggle_that_flips_a_beat_later_is_waited_for() {
+        // The toolkit updates its UI, and only then does the accessibility tree catch up, so the
+        // first read back after the click legitimately still shows the old state.
+        let (port, ops) = fake_service(
+            vec![
+                one_checkable("android.widget.CheckBox", false),
+                one_checkable("android.widget.CheckBox", false),
+                one_checkable("android.widget.CheckBox", true),
+            ],
+            OnAction::Ok,
+        );
+        let mut a = reader(port, std::time::Duration::from_secs(2));
+        let t = built(&one_checkable("android.widget.CheckBox", false));
+        a.invoke(&ctx(), &target_for(&t, AxNodeId(1)))
+            .expect("the state moves on the second read-back");
+        assert_eq!(
+            ops_of(&ops).iter().filter(|o| o.ends_with(":tree")).count(),
+            3,
+            "the plan's read plus two read-backs: {:?}",
+            ops_of(&ops)
         );
     }
 
@@ -3388,6 +3814,50 @@ mod tests {
             vec!["conn1:tree".to_string()],
             "nothing may be dispatched"
         );
+    }
+
+    #[test]
+    fn a_node_is_placed_relative_to_a_window_that_is_not_at_the_origin() {
+        // A window inset on both axes — the split-screen and freeform cases. With either offset
+        // at zero the arithmetic reads the same whichever way round it is, so both are non-zero.
+        let inset = WindowGeometry {
+            x: 40,
+            y: 100,
+            width: 600,
+            height: 800,
+        };
+        let node = json_to_node(
+            &with_refs(&json!({
+                "class": "android.widget.Button",
+                "bounds": {"x": 140, "y": 300, "w": 10, "h": 10},
+                "enabled": true,
+            })),
+            &inset,
+            0,
+            &mut Walk::new(WalkLimits::DEFAULT),
+        )
+        .expect("maps");
+        let bounds = node.bounds.expect("the device always sends bounds");
+        assert_eq!((bounds.x, bounds.y), (100, 200));
+    }
+
+    #[test]
+    fn a_value_that_lands_a_beat_later_is_waited_for_rather_than_called_a_failure() {
+        // ACTION_SET_TEXT is async — Compose recomposes, then the accessibility tree catches up
+        // — so the first read-back legitimately still shows the old text. Reporting that would
+        // send a caller to clear a field that is about to be right.
+        let (port, _ops) = fake_service(
+            vec![
+                editable_field("old"),
+                editable_field("old"),
+                editable_field("new"),
+            ],
+            OnAction::Ok,
+        );
+        let mut a = reader(port, std::time::Duration::ZERO);
+        let seen = built(&editable_field("old"));
+        a.set_value(&ctx(), &target_for(&seen, AxNodeId(1)), "new")
+            .expect("the value lands on the second read-back");
     }
 
     #[test]

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -3135,12 +3135,14 @@ mod tests {
             .conn
             .lock()
             .expect("conn lock")
-            .writer
+            .reader
+            .get_ref()
             .read_timeout()
             .expect("the socket has a read timeout");
-        assert!(
-            left.is_none_or(|d| d > std::time::Duration::from_secs(5)),
-            "the next call would inherit {left:?} from this one"
+        assert_eq!(
+            left,
+            Some(crate::conn::STANDING_TIMEOUT),
+            "the next call would inherit this one's bound"
         );
     }
 

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -270,6 +270,9 @@ pub(crate) enum Answer {
     Fails(Vec<u8>),
     /// Exit 0 having said nothing, like `am force-stop` on success.
     Silent,
+    /// Stay up rather than returning, like the backgrounded `adb shell` that holds the on-device
+    /// agent open. Writes its pid to `linger.pid` so a test can watch for it being killed.
+    Lingers,
 }
 
 #[cfg(all(test, unix))]
@@ -317,9 +320,15 @@ while IFS='\t' read -r glob answers stem; do
             [ -f \"$dir/$stem.seen\" ] && n=$(cat \"$dir/$stem.seen\")
             printf '%s' \"$((n + 1))\" > \"$dir/$stem.seen\"
             [ \"$n\" -ge \"$answers\" ] && n=$((answers - 1))
+            code=$(cat \"$dir/${stem}_$n.code\")
+            if [ \"$code\" = linger ]; then
+                printf '%s' \"$$\" > \"$dir/linger.pid\"
+                sleep 30
+                exit 0
+            fi
             cat \"$dir/${stem}_$n.out\"
             cat \"$dir/${stem}_$n.err\" >&2
-            exit \"$(cat \"$dir/${stem}_$n.code\")\"
+            exit \"$code\"
             ;;
     esac
 done < \"$dir/rules\"
@@ -360,15 +369,16 @@ impl FakeAdb {
             assert!(!answers.is_empty(), "rule {glob:?} answers nothing");
             let stem = format!("r{i}");
             for (k, answer) in answers.iter().enumerate() {
-                let (code, out, err): (i32, &[u8], &[u8]) = match answer {
-                    Answer::Says(s) => (0, s, b""),
-                    Answer::Fails(s) => (1, b"", s),
-                    Answer::Silent => (0, b"", b""),
+                let (code, out, err): (&str, &[u8], &[u8]) = match answer {
+                    Answer::Says(s) => ("0", s, b""),
+                    Answer::Fails(s) => ("1", b"", s),
+                    Answer::Silent => ("0", b"", b""),
+                    Answer::Lingers => ("linger", b"", b""),
                 };
                 let at = |ext| dir.join(format!("{stem}_{k}.{ext}"));
                 std::fs::write(at("out"), out).expect("write the fake adb's stdout");
                 std::fs::write(at("err"), err).expect("write the fake adb's stderr");
-                std::fs::write(at("code"), code.to_string()).expect("write the fake adb's status");
+                std::fs::write(at("code"), code).expect("write the fake adb's status");
             }
             rendered.push_str(&format!("{glob}\t{}\t{stem}\n", answers.len()));
         }
@@ -429,6 +439,19 @@ impl Drop for FakeAdb {
     fn drop(&mut self) {
         let _ = std::fs::remove_dir_all(&self.dir);
     }
+}
+
+/// Whether `pid` is still a live process. A child that was killed *and reaped* is gone rather
+/// than left as a zombie, which would still answer here.
+#[cfg(all(test, unix))]
+pub(crate) fn still_running(pid: &str) -> bool {
+    Command::new("kill")
+        .args(["-0", pid])
+        // A gone process is the answer this asks for, not a problem to report on stderr.
+        .stderr(std::process::Stdio::null())
+        .status()
+        .expect("kill -0")
+        .success()
 }
 
 /// The error a call to a *missing* binary raises — the shape `a11y` must not read as a tool that

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -260,6 +260,177 @@ pub(crate) fn a_failed_call(argv: &[&str], said: &str) -> GlassError {
     exit_error("adb", &argv, said)
 }
 
+/// What the fake adb does for one invocation it matches.
+#[cfg(all(test, unix))]
+pub(crate) enum Answer {
+    /// Exit 0, writing these bytes on stdout.
+    Says(Vec<u8>),
+    /// Exit non-zero, writing these bytes on stderr — what [`Adb::output`] turns into
+    /// `ToolFailed`, and the stream `a11y` reads a device's reason from.
+    Fails(Vec<u8>),
+    /// Exit 0 having said nothing, like `am force-stop` on success.
+    Silent,
+}
+
+#[cfg(all(test, unix))]
+impl Answer {
+    pub(crate) fn says(s: impl AsRef<[u8]>) -> Answer {
+        Answer::Says(s.as_ref().to_vec())
+    }
+    pub(crate) fn fails(s: impl AsRef<[u8]>) -> Answer {
+        Answer::Fails(s.as_ref().to_vec())
+    }
+}
+
+/// An `adb` that is a shell script rather than the real tool: it answers the first rule whose
+/// glob matches the argv and records every invocation.
+///
+/// The seam is the one production already has — [`Adb`] runs whatever `bin` names — so nothing is
+/// stubbed out and the argv under test is the argv that would reach a device. What a call *did*
+/// is otherwise invisible: a backend method replaced by `Ok(Default::default())` returns the same
+/// shape as one that ran, and only the reply it parsed or the call it made tells them apart.
+///
+/// Unix-only: it is a `/bin/sh` script. The mutation gate and the coverage run are Linux, and
+/// `adb.rs` already gates its process-level tests this way.
+#[cfg(all(test, unix))]
+pub(crate) struct FakeAdb {
+    dir: std::path::PathBuf,
+    adb: Adb,
+}
+
+/// Each answer lives in files rather than inline in the rules line: `adb devices` prints
+/// tab-separated rows and `exec-out screencap` prints raw bytes, and a tab-separated line can
+/// express neither — POSIX `read` folds repeated tabs together, and `printf %b` has no way to
+/// write an arbitrary byte.
+#[cfg(all(test, unix))]
+const FAKE_ADB_SCRIPT: &str = "\
+#!/bin/sh
+# Stand-in for the adb binary; see FakeAdb in adb.rs. Records the argv, then answers the first
+# rule whose glob matches it, stepping through that rule's answers and repeating the last. An
+# unmatched call exits 0 saying nothing.
+dir=$(dirname \"$0\")
+printf '%s\\n' \"$*\" >> \"$dir/calls\"
+while IFS='\t' read -r glob answers stem; do
+    case \"$*\" in
+        $glob)
+            n=0
+            [ -f \"$dir/$stem.seen\" ] && n=$(cat \"$dir/$stem.seen\")
+            printf '%s' \"$((n + 1))\" > \"$dir/$stem.seen\"
+            [ \"$n\" -ge \"$answers\" ] && n=$((answers - 1))
+            cat \"$dir/${stem}_$n.out\"
+            cat \"$dir/${stem}_$n.err\" >&2
+            exit \"$(cat \"$dir/${stem}_$n.code\")\"
+            ;;
+    esac
+done < \"$dir/rules\"
+exit 0
+";
+
+#[cfg(all(test, unix))]
+impl FakeAdb {
+    /// Serve `rules` — an argv glob and what to answer — tried in order.
+    ///
+    /// The glob is matched against the whole argv joined by spaces, as adb received it: that is
+    /// *after* `-s <serial>` is prefixed, so a rule for a serial-bound call has to allow for it.
+    pub(crate) fn new(rules: &[(&str, Answer)]) -> FakeAdb {
+        let scripted: Vec<(&str, Vec<&Answer>)> =
+            rules.iter().map(|(g, a)| (*g, vec![a])).collect();
+        FakeAdb::scripted(&scripted)
+    }
+
+    /// [`FakeAdb::new`], but each rule steps through a sequence: the k'th call matching that glob
+    /// gets the k'th answer, and the last answer repeats.
+    ///
+    /// A device changes under the caller — an emulator that was not in `adb devices` a moment ago
+    /// is there now — and a fake that answers the same thing forever can only model a device that
+    /// never does.
+    pub(crate) fn scripted(rules: &[(&str, Vec<&Answer>)]) -> FakeAdb {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static NEXT: AtomicU32 = AtomicU32::new(0);
+
+        let dir = std::env::temp_dir().join(format!(
+            "glass-fake-adb-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&dir).expect("create the fake adb's directory");
+
+        let mut rendered = String::new();
+        for (i, (glob, answers)) in rules.iter().enumerate() {
+            assert!(!answers.is_empty(), "rule {glob:?} answers nothing");
+            let stem = format!("r{i}");
+            for (k, answer) in answers.iter().enumerate() {
+                let (code, out, err): (i32, &[u8], &[u8]) = match answer {
+                    Answer::Says(s) => (0, s, b""),
+                    Answer::Fails(s) => (1, b"", s),
+                    Answer::Silent => (0, b"", b""),
+                };
+                let at = |ext| dir.join(format!("{stem}_{k}.{ext}"));
+                std::fs::write(at("out"), out).expect("write the fake adb's stdout");
+                std::fs::write(at("err"), err).expect("write the fake adb's stderr");
+                std::fs::write(at("code"), code.to_string()).expect("write the fake adb's status");
+            }
+            rendered.push_str(&format!("{glob}\t{}\t{stem}\n", answers.len()));
+        }
+        std::fs::write(dir.join("rules"), rendered).expect("write the fake adb's rules");
+
+        let bin = dir.join("adb");
+        std::fs::write(&bin, FAKE_ADB_SCRIPT).expect("write the fake adb");
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755))
+            .expect("make the fake adb executable");
+
+        FakeAdb {
+            adb: Adb {
+                bin: bin.to_string_lossy().into_owned(),
+                serial: None,
+            },
+            dir,
+        }
+    }
+
+    pub(crate) fn adb(&self) -> &Adb {
+        &self.adb
+    }
+
+    /// The argv of every invocation so far, in order, joined by spaces.
+    pub(crate) fn calls(&self) -> Vec<String> {
+        std::fs::read_to_string(self.dir.join("calls"))
+            .unwrap_or_default()
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+
+    /// Whether any invocation's argv contains `needle`.
+    pub(crate) fn called(&self, needle: &str) -> bool {
+        self.calls().iter().any(|c| c.contains(needle))
+    }
+
+    /// Write another executable script into this fake's directory and return its path — an
+    /// `emulator` to stand beside the `adb`, cleaned up with it.
+    pub(crate) fn alongside(&self, name: &str, script: &str) -> std::path::PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let path = self.dir.join(name);
+        std::fs::write(&path, script).expect("write the stand-in tool");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+            .expect("make the stand-in tool executable");
+        path
+    }
+
+    /// A file in this fake's directory, for a stand-in tool that records what it was asked.
+    pub(crate) fn read(&self, name: &str) -> String {
+        std::fs::read_to_string(self.dir.join(name)).unwrap_or_default()
+    }
+}
+
+#[cfg(all(test, unix))]
+impl Drop for FakeAdb {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
 /// The error a call to a *missing* binary raises — the shape `a11y` must not read as a tool that
 /// ran and said nothing.
 #[cfg(test)]
@@ -474,6 +645,12 @@ mod tests {
                 vec!["shell", "rm", "-f", "/sdcard/glass_dump_1_2_0.xml"],
                 AdbOp::Shell,
             ),
+            // `am` alone is not a launch: force-stop runs during teardown, inside
+            // TEARDOWN_BUDGET, and a 60s deadline there would outlast the budget that calls it.
+            (
+                vec!["shell", "am", "force-stop", "com.example.app"],
+                AdbOp::Shell,
+            ),
             (vec!["shell", "pidof", "com.example.app"], AdbOp::Shell),
             (vec!["shell", "dumpsys", "window", "windows"], AdbOp::Shell),
             (vec!["devices"], AdbOp::Shell),
@@ -534,6 +711,27 @@ mod tests {
     }
 
     #[test]
+    fn every_operation_names_the_tool_that_hung() {
+        // A timeout message carries nothing else about which call stalled, and every one of
+        // these deadlines exists because something did.
+        let labelled = [
+            (AdbOp::Dump, "adb:uiautomator dump"),
+            (AdbOp::Screencap, "adb:screencap"),
+            (AdbOp::Transfer, "adb:file transfer"),
+            (AdbOp::Launch, "adb:am start"),
+            (AdbOp::Shell, "adb:shell"),
+        ];
+        for (op, want) in labelled {
+            assert_eq!(op.label(), want, "{op:?}");
+        }
+        // Distinct, so the message tells the operations apart rather than merely naming adb.
+        let mut labels: Vec<&str> = labelled.iter().map(|(_, l)| *l).collect();
+        labels.sort_unstable();
+        labels.dedup();
+        assert_eq!(labels.len(), labelled.len());
+    }
+
+    #[test]
     fn a_launch_is_not_billed_as_a_tap() {
         // Ordering only; the variant doc explains why a launch is not a tap.
         assert!(AdbOp::Launch.budget() > AdbOp::Shell.budget());
@@ -544,6 +742,120 @@ mod tests {
         // Fail fast beats hanging for two minutes when a future caller forgets to extend the
         // classifier.
         assert_eq!(AdbOp::for_args(&["some-future-subcommand"]), AdbOp::Shell);
+    }
+
+    /// The fixture itself: a rule's reply must reach the caller and the argv must reach the log,
+    /// or every test built on it would pass against a fake that does nothing.
+    #[test]
+    #[cfg(unix)]
+    fn the_fake_adb_answers_its_rules_and_records_what_it_was_asked() {
+        use super::{Answer, FakeAdb};
+
+        let fake = FakeAdb::new(&[
+            (
+                "devices",
+                Answer::says("List of devices attached\nemulator-5554\tdevice\n"),
+            ),
+            ("shell getprop *", Answer::says("1\n")),
+            ("shell am force-stop *", Answer::Silent),
+            ("install *", Answer::fails("adb: failed to install")),
+        ]);
+        let adb = fake.adb();
+
+        // Tab-separated rows survive the rules file, which is itself tab-separated.
+        assert_eq!(
+            adb.run(["devices"]).unwrap(),
+            "List of devices attached\nemulator-5554\tdevice\n"
+        );
+        assert_eq!(
+            adb.run(["shell", "getprop", "sys.boot_completed"]).unwrap(),
+            "1\n"
+        );
+        assert_eq!(adb.run(["shell", "am", "force-stop", "com.x"]).unwrap(), "");
+
+        let err = adb
+            .run(["install", "-r", "/tmp/app.apk"])
+            .expect_err("a non-zero exit is a failure");
+        assert_eq!(err.tool_said(), Some("adb: failed to install"), "{err}");
+
+        assert_eq!(
+            fake.calls(),
+            [
+                "devices",
+                "shell getprop sys.boot_completed",
+                "shell am force-stop com.x",
+                "install -r /tmp/app.apk",
+            ]
+        );
+    }
+
+    /// The scripted form, which everything modelling a device that changes rests on.
+    #[test]
+    #[cfg(unix)]
+    fn a_scripted_rule_steps_through_its_answers_and_then_repeats_the_last() {
+        use super::{Answer, FakeAdb};
+
+        let (empty, one) = (Answer::says("none\n"), Answer::says("one\n"));
+        let fake = FakeAdb::scripted(&[("devices", vec![&empty, &one])]);
+        let adb = fake.adb();
+
+        assert_eq!(adb.run(["devices"]).unwrap(), "none\n");
+        assert_eq!(adb.run(["devices"]).unwrap(), "one\n");
+        assert_eq!(
+            adb.run(["devices"]).unwrap(),
+            "one\n",
+            "the last answer repeats"
+        );
+        assert_eq!(fake.calls().len(), 3);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_serial_bound_client_names_its_device_on_every_call() {
+        use super::{Answer, FakeAdb};
+
+        let fake = FakeAdb::new(&[("*", Answer::says("ok\n"))]);
+        let adb = fake.adb().with_serial("emulator-5556");
+
+        assert_eq!(adb.serial(), Some("emulator-5556"));
+        adb.run(["shell", "input", "tap", "1", "2"]).unwrap();
+
+        // `bin()` is for callers that spawn their own adb process — `LogcatStream` does — so
+        // what it owes them is a runnable binary, not merely a string.
+        let spawned = std::process::Command::new(adb.bin())
+            .arg("version")
+            .status()
+            .expect("bin() must name something that runs");
+        assert!(spawned.success());
+
+        // The serial reaches the wire, not just the struct: an accessor that answered `None`
+        // would send every call to whichever device adb picked for itself.
+        assert!(
+            fake.called("-s emulator-5556 shell input tap 1 2"),
+            "{:?}",
+            fake.calls()
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn raw_bytes_come_back_exactly_as_the_device_wrote_them() {
+        use super::{Answer, FakeAdb};
+
+        // A screencap header: little-endian 1x1, format 1, then four pixel bytes. Raw bytes
+        // rather than text, because that is what `exec-out screencap` returns — including the
+        // zeroes and the high bytes no string payload would survive.
+        let mut frame = Vec::new();
+        frame.extend_from_slice(&1u32.to_le_bytes()); // width
+        frame.extend_from_slice(&1u32.to_le_bytes()); // height
+        frame.extend_from_slice(&1u32.to_le_bytes()); // RGBA_8888
+        frame.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+        let fake = FakeAdb::new(&[("exec-out screencap", Answer::says(&frame))]);
+
+        let bytes = fake.adb().run_bytes(["exec-out", "screencap"]).unwrap();
+        assert_eq!(bytes.len(), 16, "got {bytes:?}");
+        assert_eq!(&bytes[0..4], &1u32.to_le_bytes());
+        assert_eq!(&bytes[12..], &[0xde, 0xad, 0xbe, 0xef]);
     }
 
     #[test]

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -384,11 +384,7 @@ impl FakeAdb {
         }
         std::fs::write(dir.join("rules"), rendered).expect("write the fake adb's rules");
 
-        let bin = dir.join("adb");
-        std::fs::write(&bin, FAKE_ADB_SCRIPT).expect("write the fake adb");
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755))
-            .expect("make the fake adb executable");
+        let bin = write_executable(&dir, "adb", FAKE_ADB_SCRIPT);
 
         FakeAdb {
             adb: Adb {
@@ -420,18 +416,32 @@ impl FakeAdb {
     /// Write another executable script into this fake's directory and return its path — an
     /// `emulator` to stand beside the `adb`, cleaned up with it.
     pub(crate) fn alongside(&self, name: &str, script: &str) -> std::path::PathBuf {
-        use std::os::unix::fs::PermissionsExt;
-        let path = self.dir.join(name);
-        std::fs::write(&path, script).expect("write the stand-in tool");
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
-            .expect("make the stand-in tool executable");
-        path
+        write_executable(&self.dir, name, script)
     }
 
     /// A file in this fake's directory, for a stand-in tool that records what it was asked.
     pub(crate) fn read(&self, name: &str) -> String {
         std::fs::read_to_string(self.dir.join(name)).unwrap_or_default()
     }
+}
+
+/// Write `script` into `dir` as an executable `name`, and return its path.
+///
+/// Written under a temporary name and renamed into place, never opened for writing at its final
+/// path: these tests run in parallel, and a `Command::spawn` on one thread forks while another is
+/// mid-write, so the child inherits the write handle. Executing a file some process holds open
+/// for writing is `ETXTBSY`, which surfaces as an unrelated test failing to run its adb at all.
+#[cfg(all(test, unix))]
+fn write_executable(dir: &std::path::Path, name: &str, script: &str) -> std::path::PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let staged = dir.join(format!("{name}.staged"));
+    let path = dir.join(name);
+    std::fs::write(&staged, script).expect("write the stand-in tool");
+    std::fs::set_permissions(&staged, std::fs::Permissions::from_mode(0o755))
+        .expect("make the stand-in tool executable");
+    std::fs::rename(&staged, &path).expect("move the stand-in tool into place");
+    path
 }
 
 #[cfg(all(test, unix))]

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -270,6 +270,12 @@ pub(crate) enum Answer {
     /// Exit non-zero, writing these bytes on stderr — what [`Adb::output`] turns into
     /// `ToolFailed`, and the stream `a11y` reads a device's reason from.
     Fails(Vec<u8>),
+    /// Exit 0, writing these bytes on stderr and nothing on stdout.
+    ///
+    /// The shape [`Adb::run_streams_until`] exists for: `uiautomator dump` reports failure by
+    /// exiting 0 and explaining itself on stderr, so a caller that read only the exit status
+    /// would take it for a dump that worked.
+    Warns(Vec<u8>),
     /// Exit 0 having said nothing, like `am force-stop` on success.
     Silent,
     /// Stay up rather than returning, like the backgrounded `adb shell` that holds the on-device
@@ -285,6 +291,9 @@ impl Answer {
     }
     pub(crate) fn fails(s: impl AsRef<[u8]>) -> Answer {
         Answer::Fails(s.as_ref().to_vec())
+    }
+    pub(crate) fn warns(s: impl AsRef<[u8]>) -> Answer {
+        Answer::Warns(s.as_ref().to_vec())
     }
 }
 
@@ -380,6 +389,7 @@ impl FakeAdb {
                 let (code, out, err): (&str, &[u8], &[u8]) = match answer {
                     Answer::Says(s) => ("0", s, b""),
                     Answer::Fails(s) => ("1", b"", s),
+                    Answer::Warns(s) => ("0", b"", s),
                     Answer::Silent => ("0", b"", b""),
                     Answer::Lingers => ("linger", b"", b""),
                 };

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -205,7 +205,8 @@ fn with_adb_hint(mut e: GlassError) -> GlassError {
 #[cfg(test)]
 pub(crate) fn a_real_timeout() -> GlassError {
     #[cfg(unix)]
-    let (bin, args): (&str, &[&str]) = ("/bin/sh", &["-c", "sleep 30"]);
+    // `exec` so the shell becomes the sleep rather than forking one that outlives the kill.
+    let (bin, args): (&str, &[&str]) = ("/bin/sh", &["-c", "exec sleep 30"]);
     #[cfg(windows)]
     let (bin, args): (&str, &[&str]) = ("ping", &["-n", "31", "127.0.0.1"]);
 
@@ -261,7 +262,8 @@ pub(crate) fn a_failed_call(argv: &[&str], said: &str) -> GlassError {
 }
 
 /// What the fake adb does for one invocation it matches.
-#[cfg(all(test, unix))]
+#[cfg(test)]
+#[cfg(unix)]
 pub(crate) enum Answer {
     /// Exit 0, writing these bytes on stdout.
     Says(Vec<u8>),
@@ -275,7 +277,8 @@ pub(crate) enum Answer {
     Lingers,
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
+#[cfg(unix)]
 impl Answer {
     pub(crate) fn says(s: impl AsRef<[u8]>) -> Answer {
         Answer::Says(s.as_ref().to_vec())
@@ -295,22 +298,25 @@ impl Answer {
 ///
 /// Unix-only: it is a `/bin/sh` script. The mutation gate and the coverage run are Linux, and
 /// `adb.rs` already gates its process-level tests this way.
-#[cfg(all(test, unix))]
+#[cfg(test)]
+#[cfg(unix)]
 pub(crate) struct FakeAdb {
     dir: std::path::PathBuf,
     adb: Adb,
 }
 
 /// Each answer lives in files rather than inline in the rules line: `adb devices` prints
-/// tab-separated rows and `exec-out screencap` prints raw bytes, and a tab-separated line can
-/// express neither — POSIX `read` folds repeated tabs together, and `printf %b` has no way to
-/// write an arbitrary byte.
-#[cfg(all(test, unix))]
+/// tab-separated rows and `exec-out screencap` prints raw bytes, and a line read into a shell
+/// variable can carry neither — a run of tabs folds into one delimiter, and a newline or a NUL
+/// cannot survive the variable at all.
+#[cfg(test)]
+#[cfg(unix)]
 const FAKE_ADB_SCRIPT: &str = "\
 #!/bin/sh
 # Stand-in for the adb binary; see FakeAdb in adb.rs. Records the argv, then answers the first
 # rule whose glob matches it, stepping through that rule's answers and repeating the last. An
 # unmatched call exits 0 saying nothing.
+[ \"$1\" = --glass-probe ] && exit 0
 dir=$(dirname \"$0\")
 printf '%s\\n' \"$*\" >> \"$dir/calls\"
 while IFS='\t' read -r glob answers stem; do
@@ -323,8 +329,9 @@ while IFS='\t' read -r glob answers stem; do
             code=$(cat \"$dir/${stem}_$n.code\")
             if [ \"$code\" = linger ]; then
                 printf '%s' \"$$\" > \"$dir/linger.pid\"
-                sleep 30
-                exit 0
+                # `exec` so the shell BECOMES the sleep: `$$` then names the process that is
+                # actually killed, and there is no grandchild to outlive it.
+                exec sleep 30
             fi
             cat \"$dir/${stem}_$n.out\"
             cat \"$dir/${stem}_$n.err\" >&2
@@ -335,7 +342,8 @@ done < \"$dir/rules\"
 exit 0
 ";
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
+#[cfg(unix)]
 impl FakeAdb {
     /// Serve `rules` — an argv glob and what to answer — tried in order.
     ///
@@ -413,6 +421,35 @@ impl FakeAdb {
         self.calls().iter().any(|c| c.contains(needle))
     }
 
+    /// [`FakeAdb::called`], waiting up to `within` for the call to arrive.
+    ///
+    /// A call production *spawned* rather than waited for — `adb logcat`, the agent's
+    /// `app_process` — has not necessarily reached the log by the time the spawning function
+    /// returns, so asserting on it immediately is a race that fails in whichever direction the
+    /// scheduler picks.
+    pub(crate) fn wait_called(&self, needle: &str, within: Duration) -> bool {
+        self.wait_until(within, || self.called(needle))
+    }
+
+    /// The contents of `name` once it is non-empty, waiting up to `within`. Empty if it never is.
+    pub(crate) fn wait_read(&self, name: &str, within: Duration) -> String {
+        self.wait_until(within, || !self.read(name).is_empty());
+        self.read(name)
+    }
+
+    fn wait_until(&self, within: Duration, ready: impl Fn() -> bool) -> bool {
+        let deadline = Instant::now() + within;
+        loop {
+            if ready() {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
     /// Write another executable script into this fake's directory and return its path — an
     /// `emulator` to stand beside the `adb`, cleaned up with it.
     pub(crate) fn alongside(&self, name: &str, script: &str) -> std::path::PathBuf {
@@ -425,13 +462,24 @@ impl FakeAdb {
     }
 }
 
-/// Write `script` into `dir` as an executable `name`, and return its path.
+/// Write `script` into `dir` as an executable `name`, and return its path — runnable, which is
+/// the part that takes work.
 ///
-/// Written under a temporary name and renamed into place, never opened for writing at its final
-/// path: these tests run in parallel, and a `Command::spawn` on one thread forks while another is
-/// mid-write, so the child inherits the write handle. Executing a file some process holds open
-/// for writing is `ETXTBSY`, which surfaces as an unrelated test failing to run its adb at all.
-#[cfg(all(test, unix))]
+/// These tests run in parallel, and `ETXTBSY` is raised on the INODE of a file some process holds
+/// open for writing, not on its path: a `Command::spawn` on one thread forks while another is
+/// mid-write here, and the child inherits the write handle until it execs. Staging under another
+/// name and renaming does NOT help — `rename` carries the same inode to the new name.
+///
+/// So this does what glass-ios does for its own fixtures (`doctor.rs`, `idb/companion.rs`):
+/// retries past the transient error. Retried HERE rather than at the call sites, because the exec
+/// under test happens inside `Adb::output`, which is production code and must not learn about it.
+/// Once a probe run succeeds, the inherited fd is gone and this inode is safe for good — nothing
+/// opens it for writing again.
+///
+/// The rename is kept for a smaller reason: the final name never exists half-written or not yet
+/// executable.
+#[cfg(test)]
+#[cfg(unix)]
 fn write_executable(dir: &std::path::Path, name: &str, script: &str) -> std::path::PathBuf {
     use std::os::unix::fs::PermissionsExt;
 
@@ -441,10 +489,23 @@ fn write_executable(dir: &std::path::Path, name: &str, script: &str) -> std::pat
     std::fs::set_permissions(&staged, std::fs::Permissions::from_mode(0o755))
         .expect("make the stand-in tool executable");
     std::fs::rename(&staged, &path).expect("move the stand-in tool into place");
-    path
+
+    // `--glass-probe` is the one argument both stand-ins answer by exiting immediately, so this
+    // costs nothing and records nothing.
+    for _ in 0..100 {
+        match Command::new(&path).arg("--glass-probe").status() {
+            Ok(_) => return path,
+            Err(e) if e.kind() == std::io::ErrorKind::ExecutableFileBusy => {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(e) => panic!("the stand-in {name} is not runnable: {e}"),
+        }
+    }
+    panic!("{name} was still ETXTBSY after 100 retries");
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
+#[cfg(unix)]
 impl Drop for FakeAdb {
     fn drop(&mut self) {
         let _ = std::fs::remove_dir_all(&self.dir);
@@ -455,20 +516,28 @@ impl Drop for FakeAdb {
 /// [`FakeAdb::alongside`]. `-list-avds` prints the contents of an `avds` file in the same
 /// directory; anything else records its argv in `boots` and then stays up, which is what a boot
 /// waits on.
-#[cfg(all(test, unix))]
+///
+/// It stays up for seconds rather than minutes because `boot_avd` deliberately does not kill the
+/// emulator it started — on a device that is the point, but here it would leave one stand-in per
+/// test run idling, and a mutation shard runs the suite hundreds of times. A boot poll settles
+/// well inside this.
+#[cfg(test)]
+#[cfg(unix)]
 pub(crate) const FAKE_EMULATOR_SCRIPT: &str = r#"#!/bin/sh
+[ "$1" = --glass-probe ] && exit 0
 dir=$(dirname "$0")
 if [ "$1" = "-list-avds" ]; then
     cat "$dir/avds"
     exit 0
 fi
 printf '%s\n' "$*" >> "$dir/boots"
-sleep 30
+exec sleep 5
 "#;
 
 /// Whether `pid` is still a live process. A child that was killed *and reaped* is gone rather
 /// than left as a zombie, which would still answer here.
-#[cfg(all(test, unix))]
+#[cfg(test)]
+#[cfg(unix)]
 pub(crate) fn still_running(pid: &str) -> bool {
     Command::new("kill")
         .args(["-0", pid])
@@ -566,7 +635,9 @@ mod tests {
         let started = std::time::Instant::now();
         let err = adb
             .run_streams_until(
-                ["-c", "sleep 30"],
+                // `exec` so the bound kills the sleep itself; without it the shell is what dies
+                // and the sleep is orphaned for its full thirty seconds.
+                ["-c", "exec sleep 30"],
                 std::time::Instant::now() + Duration::from_millis(300),
             )
             .expect_err("a step must not outlive the deadline it serves");

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -300,13 +300,8 @@ impl Answer {
 /// An `adb` that is a shell script rather than the real tool: it answers the first rule whose
 /// glob matches the argv and records every invocation.
 ///
-/// The seam is the one production already has — [`Adb`] runs whatever `bin` names — so nothing is
-/// stubbed out and the argv under test is the argv that would reach a device. What a call *did*
-/// is otherwise invisible: a backend method replaced by `Ok(Default::default())` returns the same
-/// shape as one that ran, and only the reply it parsed or the call it made tells them apart.
-///
-/// Unix-only: it is a `/bin/sh` script. The mutation gate and the coverage run are Linux, and
-/// `adb.rs` already gates its process-level tests this way.
+/// Records the argv because a method stubbed to `Ok(Default::default())` is otherwise
+/// indistinguishable from one that ran. Unix-only: it is a `/bin/sh` script.
 #[cfg(test)]
 #[cfg(unix)]
 pub(crate) struct FakeAdb {
@@ -314,10 +309,9 @@ pub(crate) struct FakeAdb {
     adb: Adb,
 }
 
-/// Each answer lives in files rather than inline in the rules line: `adb devices` prints
-/// tab-separated rows and `exec-out screencap` prints raw bytes, and a line read into a shell
-/// variable can carry neither — a run of tabs folds into one delimiter, and a newline or a NUL
-/// cannot survive the variable at all.
+/// Do not move an answer inline into the rules line: a line read into a shell variable folds a
+/// run of tabs into one delimiter and carries neither a newline nor a NUL, and `adb devices`
+/// prints tab-separated rows while `exec-out screencap` prints raw bytes.
 #[cfg(test)]
 #[cfg(unix)]
 const FAKE_ADB_SCRIPT: &str = "\
@@ -365,11 +359,7 @@ impl FakeAdb {
     }
 
     /// [`FakeAdb::new`], but each rule steps through a sequence: the k'th call matching that glob
-    /// gets the k'th answer, and the last answer repeats.
-    ///
-    /// A device changes under the caller — an emulator that was not in `adb devices` a moment ago
-    /// is there now — and a fake that answers the same thing forever can only model a device that
-    /// never does.
+    /// gets the k'th answer, and the last answer repeats — a device changes under the caller.
     pub(crate) fn scripted(rules: &[(&str, Vec<&Answer>)]) -> FakeAdb {
         use std::sync::atomic::{AtomicU32, Ordering};
         static NEXT: AtomicU32 = AtomicU32::new(0);
@@ -434,9 +424,7 @@ impl FakeAdb {
     /// [`FakeAdb::called`], waiting up to `within` for the call to arrive.
     ///
     /// A call production *spawned* rather than waited for — `adb logcat`, the agent's
-    /// `app_process` — has not necessarily reached the log by the time the spawning function
-    /// returns, so asserting on it immediately is a race that fails in whichever direction the
-    /// scheduler picks.
+    /// `app_process` — may not have reached the log when the spawning function returns.
     pub(crate) fn wait_called(&self, needle: &str, within: Duration) -> bool {
         self.wait_until(within, || self.called(needle))
     }
@@ -472,22 +460,11 @@ impl FakeAdb {
     }
 }
 
-/// Write `script` into `dir` as an executable `name`, and return its path — runnable, which is
-/// the part that takes work.
+/// Write `script` into `dir` as an executable `name`, and return its path, runnable.
 ///
-/// These tests run in parallel, and `ETXTBSY` is raised on the INODE of a file some process holds
-/// open for writing, not on its path: a `Command::spawn` on one thread forks while another is
-/// mid-write here, and the child inherits the write handle until it execs. Staging under another
-/// name and renaming does NOT help — `rename` carries the same inode to the new name.
-///
-/// So this does what glass-ios does for its own fixtures (`doctor.rs`, `idb/companion.rs`):
-/// retries past the transient error. Retried HERE rather than at the call sites, because the exec
-/// under test happens inside `Adb::output`, which is production code and must not learn about it.
-/// Once a probe run succeeds, the inherited fd is gone and this inode is safe for good — nothing
-/// opens it for writing again.
-///
-/// The rename is kept for a smaller reason: the final name never exists half-written or not yet
-/// executable.
+/// Do not swap the retry for a staged write and a rename: `ETXTBSY` is raised on the inode, which
+/// `rename` carries to the new name, so a sibling thread's fork still holding the write fd blocks
+/// the exec anyway. The rename stays only so the final name is never half-written.
 #[cfg(test)]
 #[cfg(unix)]
 fn write_executable(dir: &std::path::Path, name: &str, script: &str) -> std::path::PathBuf {
@@ -527,10 +504,8 @@ impl Drop for FakeAdb {
 /// directory; anything else records its argv in `boots` and then stays up, which is what a boot
 /// waits on.
 ///
-/// It stays up for seconds rather than minutes because `boot_avd` deliberately does not kill the
-/// emulator it started — on a device that is the point, but here it would leave one stand-in per
-/// test run idling, and a mutation shard runs the suite hundreds of times. A boot poll settles
-/// well inside this.
+/// Seconds, not minutes: `boot_avd` never kills the emulator it started, so each run leaves one
+/// idling and a mutation shard runs the suite hundreds of times.
 #[cfg(test)]
 #[cfg(unix)]
 pub(crate) const FAKE_EMULATOR_SCRIPT: &str = r#"#!/bin/sh

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -441,6 +441,21 @@ impl Drop for FakeAdb {
     }
 }
 
+/// A stand-in for the `emulator` binary, to sit beside a [`FakeAdb`] via
+/// [`FakeAdb::alongside`]. `-list-avds` prints the contents of an `avds` file in the same
+/// directory; anything else records its argv in `boots` and then stays up, which is what a boot
+/// waits on.
+#[cfg(all(test, unix))]
+pub(crate) const FAKE_EMULATOR_SCRIPT: &str = r#"#!/bin/sh
+dir=$(dirname "$0")
+if [ "$1" = "-list-avds" ]; then
+    cat "$dir/avds"
+    exit 0
+fi
+printf '%s\n' "$*" >> "$dir/boots"
+sleep 30
+"#;
+
 /// Whether `pid` is still a live process. A child that was killed *and reaped* is gone rather
 /// than left as a zombie, which would still answer here.
 #[cfg(all(test, unix))]

--- a/crates/glass-android/src/agent.rs
+++ b/crates/glass-android/src/agent.rs
@@ -132,11 +132,9 @@ pub(crate) fn parse_forward_port(out: &str) -> Option<u16> {
 /// matching `responses[i]`, the request's own id spliced in. Returns the port and the requests it
 /// read.
 ///
-/// The requests are the point. The companion is an APK on an emulator, so a unit test can only
-/// reach this protocol — and a client method that returns `Ok(())` having sent nothing looks
-/// exactly like one that worked until something reads back what went out.
-///
-/// Lives beside the code rather than in `mod tests` so `input`'s injector tests can reach it too.
+/// Records the requests because a client method that returns `Ok(())` having sent nothing is
+/// otherwise indistinguishable from one that worked. Lives outside `mod tests` so `input`'s
+/// injector tests can reach it.
 #[cfg(test)]
 pub(crate) fn fake_agent(
     hello: &'static str,
@@ -219,8 +217,8 @@ pub struct AgentRegistry {
 /// A launched agent: the backgrounded `adb shell` child (killing it SIGHUPs the device
 /// process — no `pkill`), the forwarded local port, and the adb client it was reached through.
 ///
-/// The client is kept rather than resolved again at teardown: `Adb::from_env` reads the
-/// environment as it is *then*, which need not be what launched the agent.
+/// Do not resolve a client at teardown instead: `Adb::from_env` reads the environment as it is
+/// *then*, which need not be what launched the agent.
 struct AgentProc {
     child: Child,
     port: u16,
@@ -485,8 +483,7 @@ mod tests {
     #[test]
     fn a_call_whose_socket_dropped_is_retried_on_a_fresh_connection() {
         // The device's accept loop takes a new connection after a drop, so a dead socket is not
-        // a dead agent. Reporting one as a failed input would surface a transport hiccup as a
-        // tap that did not happen.
+        // a dead agent — reporting one would surface a hiccup as a tap that never happened.
         let (port, seen) = fake_agent_sessions(HELLO, vec![vec![], vec![OK]]);
         let c = AgentClient::connect(port).unwrap();
         c.ping()
@@ -515,9 +512,8 @@ mod tests {
 
     #[test]
     fn an_agent_that_is_not_answering_yet_is_retried_rather_than_given_up_on() {
-        // The device takes about a second to bind, so a first attempt that fails is the ordinary
-        // case rather than the failure. A deadline computed backwards — or a comparison the
-        // wrong way round — makes that first attempt the answer.
+        // The device takes about a second to bind, so a failed first attempt is the ordinary
+        // case; a backwards deadline makes it the answer instead.
         let port = agent_that_answers_after(1);
         wait_for_agent(port).expect("an agent that answers on the second try must be waited for");
     }

--- a/crates/glass-android/src/agent.rs
+++ b/crates/glass-android/src/agent.rs
@@ -179,7 +179,12 @@ pub(crate) fn fake_agent_sessions(
                 let id = req["id"].as_i64().expect("request id");
                 recorded.lock().expect("seen lock").push(req);
                 let mut out: Value = serde_json::from_str(resp).expect("response json");
-                out["id"] = json!(id);
+                // A scripted response that names its own id keeps it. Otherwise it answers the
+                // request it was sent, which is the ordinary case — but leaves no way to model
+                // an answer addressed to a *different* request, which the client must refuse.
+                if out.get("id").is_none() {
+                    out["id"] = json!(id);
+                }
                 if writeln!(w, "{out}").is_err() {
                     break;
                 }
@@ -237,7 +242,6 @@ impl AgentRegistry {
     /// Ensure the agent server is running on `adb`'s device and return the forwarded local
     /// port. Idempotent: a second call returns the cached port when the device serial matches.
     /// If the serial changed (a different device), the stale agent is torn down first.
-    /// The jar is resolved from env.
     ///
     /// `get` reads the environment — the jar's location is all it needs from there — passed in
     /// rather than read here, so a test can point it at a jar without touching the environment
@@ -339,7 +343,6 @@ impl AgentRegistry {
 /// How long the agent gets to bind its socket and start answering. It takes ~1s in practice.
 const AGENT_BIND_BUDGET: Duration = Duration::from_secs(5);
 
-/// How long to leave the agent alone between attempts.
 const AGENT_RETRY_PAUSE: Duration = Duration::from_millis(200);
 
 /// Poll until the agent accepts a connection (it takes ~1s to bind).
@@ -533,7 +536,7 @@ mod tests {
             ("shell CLASSPATH=*", vec![&lingers]),
             ("*", vec![&silent]),
         ]);
-        // The jar has to be a file on disk, and the fake adb's own script is one.
+        // Any path will do: nothing checks the jar exists before pushing it.
         let jar = fake.adb().bin().to_string();
         let get = move |k: &str| match k {
             "GLASS_ANDROID_AGENT_JAR" => Some(jar.clone()),
@@ -563,7 +566,7 @@ mod tests {
         );
 
         // The launch is a child that stays up; killing it is what SIGHUPs the device process.
-        let child = fake.read("linger.pid");
+        let child = fake.wait_read("linger.pid", Duration::from_secs(5));
         assert!(!child.is_empty(), "the launch should still be running");
         assert!(still_running(&child));
 
@@ -601,7 +604,7 @@ mod tests {
             .expect_err("a forward that names no port cannot be connected to");
         assert!(err.to_string().contains("no port"), "{err}");
 
-        let child = fake.read("linger.pid");
+        let child = fake.wait_read("linger.pid", Duration::from_secs(5));
         assert!(!child.is_empty(), "the launch should have happened");
         assert!(!still_running(&child), "the failed launch leaked its child");
     }

--- a/crates/glass-android/src/agent.rs
+++ b/crates/glass-android/src/agent.rs
@@ -5,6 +5,7 @@
 
 use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use glass_core::{GlassError, Result};
 use serde_json::{Value, json};
@@ -120,12 +121,82 @@ pub fn agent_enabled(get: &dyn Fn(&str) -> Option<String>) -> bool {
 }
 
 /// Parse the local port `adb forward tcp:0 …` prints on stdout.
-/// Skips blank lines and `* daemon …` noise that adb emits on a cold start.
+///
+/// The first line that reads as a port is it: the blank lines and the `* daemon …` noise adb
+/// emits on a cold start read as no port at all, so neither needs a rule of its own.
 pub(crate) fn parse_forward_port(out: &str) -> Option<u16> {
-    out.lines()
-        .map(str::trim)
-        .filter(|l| !l.is_empty() && !l.starts_with('*'))
-        .find_map(|l| l.parse().ok())
+    out.lines().map(str::trim).find_map(|l| l.parse().ok())
+}
+
+/// A fake agent on a loopback socket: sends `hello`, then answers each request line with the
+/// matching `responses[i]`, the request's own id spliced in. Returns the port and the requests it
+/// read.
+///
+/// The requests are the point. The companion is an APK on an emulator, so a unit test can only
+/// reach this protocol — and a client method that returns `Ok(())` having sent nothing looks
+/// exactly like one that worked until something reads back what went out.
+///
+/// Lives beside the code rather than in `mod tests` so `input`'s injector tests can reach it too.
+#[cfg(test)]
+pub(crate) fn fake_agent(
+    hello: &'static str,
+    responses: Vec<&'static str>,
+) -> (u16, Arc<Mutex<Vec<Value>>>) {
+    fake_agent_sessions(hello, vec![responses])
+}
+
+/// [`fake_agent`] across successive connections: `sessions[i]` scripts the i'th connection, whose
+/// socket closes once its answers run out. Two sessions is what a dropped-socket reconnect needs.
+#[cfg(test)]
+pub(crate) fn fake_agent_sessions(
+    hello: &'static str,
+    sessions: Vec<Vec<&'static str>>,
+) -> (u16, Arc<Mutex<Vec<Value>>>) {
+    use std::io::{BufRead, BufReader, Write};
+
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind loopback");
+    let port = listener.local_addr().expect("local addr").port();
+    let seen = Arc::new(Mutex::new(Vec::new()));
+
+    let recorded = Arc::clone(&seen);
+    std::thread::spawn(move || {
+        for session in sessions {
+            let Some(sock) = listener.incoming().flatten().next() else {
+                return;
+            };
+            let mut w = sock.try_clone().expect("clone socket");
+            let mut r = BufReader::new(sock);
+            if writeln!(w, "{hello}").is_err() {
+                return;
+            }
+            for resp in session {
+                let mut line = String::new();
+                match r.read_line(&mut line) {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => {}
+                }
+                let req: Value = serde_json::from_str(&line).expect("request json");
+                let id = req["id"].as_i64().expect("request id");
+                recorded.lock().expect("seen lock").push(req);
+                let mut out: Value = serde_json::from_str(resp).expect("response json");
+                out["id"] = json!(id);
+                if writeln!(w, "{out}").is_err() {
+                    break;
+                }
+            }
+        }
+    });
+    (port, seen)
+}
+
+/// The `op` of each request the fake agent read, in order.
+#[cfg(test)]
+pub(crate) fn ops_seen(seen: &Arc<Mutex<Vec<Value>>>) -> Vec<String> {
+    seen.lock()
+        .expect("seen lock")
+        .iter()
+        .filter_map(|r| r.get("op").and_then(Value::as_str).map(str::to_string))
+        .collect()
 }
 
 const REMOTE_JAR: &str = "/data/local/tmp/glass-agent.jar";
@@ -265,10 +336,20 @@ impl AgentRegistry {
     }
 }
 
-/// Poll until the agent accepts a connection (it takes ~1s to bind), up to ~5s.
+/// How long the agent gets to bind its socket and start answering. It takes ~1s in practice.
+const AGENT_BIND_BUDGET: Duration = Duration::from_secs(5);
+
+/// How long to leave the agent alone between attempts.
+const AGENT_RETRY_PAUSE: Duration = Duration::from_millis(200);
+
+/// Poll until the agent accepts a connection (it takes ~1s to bind).
 fn wait_for_agent(port: u16) -> Result<AgentClient> {
-    use std::time::{Duration, Instant};
-    let deadline = Instant::now() + Duration::from_secs(5);
+    wait_for_agent_until(port, Instant::now() + AGENT_BIND_BUDGET)
+}
+
+/// [`wait_for_agent`] against a deadline the caller names, so a test can watch it give up without
+/// waiting out the production budget.
+fn wait_for_agent_until(port: u16, deadline: Instant) -> Result<AgentClient> {
     loop {
         match AgentClient::connect(port) {
             Ok(c) => return Ok(c),
@@ -277,7 +358,7 @@ fn wait_for_agent(port: u16) -> Result<AgentClient> {
                     "agent never came up on :{port}: {e}"
                 )));
             }
-            Err(_) => std::thread::sleep(Duration::from_millis(200)),
+            Err(_) => std::thread::sleep(AGENT_RETRY_PAUSE),
         }
     }
 }
@@ -285,7 +366,7 @@ fn wait_for_agent(port: u16) -> Result<AgentClient> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::{BufRead, BufReader, Write};
+    use std::io::Write;
     use std::net::TcpListener;
 
     #[test]
@@ -317,57 +398,27 @@ mod tests {
         );
     }
 
-    /// Spawn a one-shot fake agent that sends `hello`, then for each request line writes
-    /// the matching `responses[i]` (with the request's id spliced in). Returns the port.
-    fn fake_agent(hello: &'static str, responses: Vec<&'static str>) -> u16 {
-        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
-        let port = listener.local_addr().unwrap().port();
-        std::thread::spawn(move || {
-            let (sock, _) = listener.accept().unwrap();
-            let mut w = sock.try_clone().unwrap();
-            let mut r = BufReader::new(sock);
-            writeln!(w, "{hello}").unwrap();
-            w.flush().unwrap();
-            for resp in responses {
-                let mut line = String::new();
-                if r.read_line(&mut line).unwrap() == 0 {
-                    break;
-                }
-                let id = serde_json::from_str::<Value>(&line).unwrap()["id"]
-                    .as_i64()
-                    .unwrap();
-                let mut out: Value = serde_json::from_str(resp).unwrap();
-                out["id"] = json!(id);
-                writeln!(w, "{out}").unwrap();
-                w.flush().unwrap();
-            }
-        });
-        port
-    }
+    const HELLO: &str = r#"{"hello":{"proto":1}}"#;
+    const OK: &str = r#"{"ok":true}"#;
 
     #[test]
     fn connect_checks_proto() {
-        let bad = fake_agent(r#"{"hello":{"proto":99}}"#, vec![]);
+        let (bad, _) = fake_agent(r#"{"hello":{"proto":99}}"#, vec![]);
         assert!(AgentClient::connect(bad).is_err());
     }
 
     #[test]
     fn clipboard_roundtrip_and_ok() {
-        let port = fake_agent(
-            r#"{"hello":{"proto":1}}"#,
-            vec![r#"{"ok":true}"#, r#"{"ok":true,"text":"hey"}"#],
-        );
+        let (port, seen) = fake_agent(HELLO, vec![OK, r#"{"ok":true,"text":"hey"}"#]);
         let c = AgentClient::connect(port).unwrap();
         c.clipboard_set("hey").unwrap();
         assert_eq!(c.clipboard_get().unwrap(), "hey");
+        assert_eq!(ops_seen(&seen), ["clipboard_set", "clipboard_get"]);
     }
 
     #[test]
     fn error_response_becomes_backend_error() {
-        let port = fake_agent(
-            r#"{"hello":{"proto":1}}"#,
-            vec![r#"{"ok":false,"error":"nope"}"#],
-        );
+        let (port, _) = fake_agent(HELLO, vec![r#"{"ok":false,"error":"nope"}"#]);
         let c = AgentClient::connect(port).unwrap();
         let e = c.ping().unwrap_err();
         assert!(e.to_string().contains("nope"));
@@ -375,35 +426,115 @@ mod tests {
 
     #[test]
     fn clipboard_get_missing_text_errors() {
-        let port = fake_agent(r#"{"hello":{"proto":1}}"#, vec![r#"{"ok":true}"#]);
+        let (port, _) = fake_agent(HELLO, vec![OK]);
         let c = AgentClient::connect(port).unwrap();
         assert!(c.clipboard_get().is_err());
     }
 
     #[test]
     fn clipboard_get_empty_is_ok() {
-        let port = fake_agent(r#"{"hello":{"proto":1}}"#, vec![r#"{"ok":true,"text":""}"#]);
+        let (port, _) = fake_agent(HELLO, vec![r#"{"ok":true,"text":""}"#]);
         let c = AgentClient::connect(port).unwrap();
         assert_eq!(c.clipboard_get().unwrap(), "");
     }
 
+    /// Every input method, checked by what reached the wire rather than by its return value.
+    ///
+    /// The device is what carries these out, so one that answered `Ok` having sent nothing would
+    /// be indistinguishable here until something reads the request back.
     #[test]
-    fn pointer_and_key_send_ok() {
-        let port = fake_agent(
-            r#"{"hello":{"proto":1}}"#,
-            vec![r#"{"ok":true}"#, r#"{"ok":true}"#, r#"{"ok":true}"#],
-        );
+    fn each_input_method_sends_its_own_request() {
+        let (port, seen) = fake_agent(HELLO, vec![OK, OK, OK, OK]);
         let c = AgentClient::connect(port).unwrap();
-        c.pointer(
-            &[Pt {
+        let path = vec![
+            Pt {
                 x: 5,
                 y: 10,
                 t_ms: 0,
-            }],
-            "left",
-        )
-        .unwrap();
+            },
+            Pt {
+                x: 7,
+                y: 12,
+                t_ms: 40,
+            },
+        ];
+
+        c.pointer(&path, "left").unwrap();
+        c.gesture(&[path.clone(), path]).unwrap();
         c.key("ctrl+a").unwrap();
         c.text("hi").unwrap();
+
+        assert_eq!(ops_seen(&seen), ["pointer", "gesture", "key", "text"]);
+        let sent = seen.lock().unwrap();
+        assert_eq!(
+            sent[0]["gesture"],
+            json!([{"x": 5, "y": 10, "t_ms": 0}, {"x": 7, "y": 12, "t_ms": 40}])
+        );
+        assert_eq!(sent[0]["button"], "left");
+        // One array per pointer, each carrying that pointer's whole path — the shape
+        // multi-touch needs, and the one a flattened list would quietly lose.
+        assert_eq!(sent[1]["pointers"].as_array().map(Vec::len), Some(2));
+        assert_eq!(sent[1]["pointers"][1][1]["x"], 7);
+        assert_eq!(sent[2]["chord"], "ctrl+a");
+        assert_eq!(sent[3]["text"], "hi");
+    }
+
+    #[test]
+    fn a_call_whose_socket_dropped_is_retried_on_a_fresh_connection() {
+        // The device's accept loop takes a new connection after a drop, so a dead socket is not
+        // a dead agent. Reporting one as a failed input would surface a transport hiccup as a
+        // tap that did not happen.
+        let (port, seen) = fake_agent_sessions(HELLO, vec![vec![], vec![OK]]);
+        let c = AgentClient::connect(port).unwrap();
+        c.ping()
+            .expect("a dropped socket must be reconnected, not reported");
+        assert_eq!(ops_seen(&seen), ["ping"]);
+    }
+
+    /// A listener that closes the first `stumbles` connections without a hello — an agent whose
+    /// socket is up but which is not answering yet — and then serves one properly.
+    fn agent_that_answers_after(stumbles: usize) -> u16 {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind loopback");
+        let port = listener.local_addr().expect("local addr").port();
+        std::thread::spawn(move || {
+            let mut closed = 0;
+            for mut stream in listener.incoming().flatten() {
+                if closed < stumbles {
+                    closed += 1;
+                    continue; // dropping the stream closes it, having said nothing
+                }
+                let _ = writeln!(stream, "{HELLO}");
+                return;
+            }
+        });
+        port
+    }
+
+    #[test]
+    fn an_agent_that_is_not_answering_yet_is_retried_rather_than_given_up_on() {
+        // The device takes about a second to bind, so a first attempt that fails is the ordinary
+        // case rather than the failure. A deadline computed backwards — or a comparison the
+        // wrong way round — makes that first attempt the answer.
+        let port = agent_that_answers_after(1);
+        wait_for_agent(port).expect("an agent that answers on the second try must be waited for");
+    }
+
+    #[test]
+    fn an_agent_that_never_answers_is_given_up_on_at_the_deadline() {
+        let port = agent_that_answers_after(usize::MAX);
+        let started = Instant::now();
+        let Err(err) = wait_for_agent_until(port, Instant::now() + Duration::from_millis(300))
+        else {
+            panic!("an agent that never answers must not be waited on forever");
+        };
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "waited {:?} — the deadline never ended the loop",
+            started.elapsed()
+        );
+        assert!(
+            err.to_string().contains(&port.to_string()),
+            "the error must name the port: {err}"
+        );
     }
 }

--- a/crates/glass-android/src/agent.rs
+++ b/crates/glass-android/src/agent.rs
@@ -212,11 +212,14 @@ pub struct AgentRegistry {
 }
 
 /// A launched agent: the backgrounded `adb shell` child (killing it SIGHUPs the device
-/// process — no `pkill`), the forwarded local port, and the device serial it was bound to.
+/// process — no `pkill`), the forwarded local port, and the adb client it was reached through.
+///
+/// The client is kept rather than resolved again at teardown: `Adb::from_env` reads the
+/// environment as it is *then*, which need not be what launched the agent.
 struct AgentProc {
     child: Child,
     port: u16,
-    serial: Option<String>,
+    adb: Adb,
 }
 
 impl Drop for AgentProc {
@@ -235,7 +238,11 @@ impl AgentRegistry {
     /// port. Idempotent: a second call returns the cached port when the device serial matches.
     /// If the serial changed (a different device), the stale agent is torn down first.
     /// The jar is resolved from env.
-    pub fn ensure(&self, adb: &Adb) -> Result<u16> {
+    ///
+    /// `get` reads the environment — the jar's location is all it needs from there — passed in
+    /// rather than read here, so a test can point it at a jar without touching the environment
+    /// the whole process shares.
+    pub fn ensure(&self, adb: &Adb, get: &dyn Fn(&str) -> Option<String>) -> Result<u16> {
         let mut guard = self
             .state
             .lock()
@@ -243,24 +250,20 @@ impl AgentRegistry {
 
         // Cache hit: same serial (or both unset) — reuse the existing port.
         if let Some(p) = guard.as_ref()
-            && p.serial.as_deref() == adb.serial()
+            && p.adb.serial() == adb.serial()
         {
             return Ok(p.port);
         }
         // Serial changed (or first-ever call with a stale entry): tear down the stale agent.
         // Taking it out of the guard drops it, which kills + reaps the child via Drop.
         if let Some(stale) = guard.take() {
-            let stale_adb = Adb::from_env();
-            let stale_adb = match &stale.serial {
-                Some(s) => stale_adb.with_serial(s.clone()),
-                None => stale_adb,
-            };
-            let _ = stale_adb.run(["forward", "--remove", &format!("tcp:{}", stale.port)]);
+            let _ = stale
+                .adb
+                .run(["forward", "--remove", &format!("tcp:{}", stale.port)]);
             // stale drops here → Drop kills + reaps the child
         }
 
-        let get = |k: &str| std::env::var(k).ok();
-        let jar = agent_jar(&get)
+        let jar = agent_jar(get)
             .ok_or_else(|| GlassError::Backend("GLASS_ANDROID_AGENT_JAR not set".into()))?;
 
         // Push the jar (idempotent).
@@ -315,7 +318,7 @@ impl AgentRegistry {
         *guard = Some(AgentProc {
             child,
             port,
-            serial,
+            adb: adb.clone(),
         });
         Ok(port)
     }
@@ -325,12 +328,9 @@ impl AgentRegistry {
         if let Ok(mut guard) = self.state.lock()
             && let Some(p) = guard.take()
         {
-            let adb = Adb::from_env();
-            let adb = match &p.serial {
-                Some(s) => adb.with_serial(s.clone()),
-                None => adb,
-            };
-            let _ = adb.run(["forward", "--remove", &format!("tcp:{}", p.port)]);
+            let _ = p
+                .adb
+                .run(["forward", "--remove", &format!("tcp:{}", p.port)]);
             // p drops here → Drop kills + reaps the child
         }
     }
@@ -517,6 +517,93 @@ mod tests {
         // wrong way round — makes that first attempt the answer.
         let port = agent_that_answers_after(1);
         wait_for_agent(port).expect("an agent that answers on the second try must be waited for");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn ensuring_the_agent_pushes_it_launches_it_and_forwards_a_port_to_it() {
+        use crate::adb::{Answer, FakeAdb, still_running};
+
+        let (agent_port, _) = fake_agent(HELLO, vec![OK]);
+        let forwarded = Answer::says(format!("{agent_port}\n"));
+        let (lingers, silent) = (Answer::Lingers, Answer::Silent);
+        // Specific rules first: the catch-all would otherwise answer everything.
+        let fake = FakeAdb::scripted(&[
+            ("forward tcp:0 *", vec![&forwarded]),
+            ("shell CLASSPATH=*", vec![&lingers]),
+            ("*", vec![&silent]),
+        ]);
+        // The jar has to be a file on disk, and the fake adb's own script is one.
+        let jar = fake.adb().bin().to_string();
+        let get = move |k: &str| match k {
+            "GLASS_ANDROID_AGENT_JAR" => Some(jar.clone()),
+            _ => None,
+        };
+
+        let registry = AgentRegistry::new();
+        let port = registry
+            .ensure(fake.adb(), &get)
+            .expect("the agent answers on the port adb forwarded");
+
+        assert_eq!(
+            port, agent_port,
+            "the forwarded port is the one handed back"
+        );
+        assert!(fake.called("push"), "{:?}", fake.calls());
+        assert!(fake.called("app_process"), "{:?}", fake.calls());
+
+        // A second call reuses the running agent. Pushing and relaunching per call would
+        // restart the companion under whatever was mid-gesture against it.
+        assert_eq!(registry.ensure(fake.adb(), &get).unwrap(), agent_port);
+        assert_eq!(
+            fake.calls().iter().filter(|c| c.contains("push")).count(),
+            1,
+            "{:?}",
+            fake.calls()
+        );
+
+        // The launch is a child that stays up; killing it is what SIGHUPs the device process.
+        let child = fake.read("linger.pid");
+        assert!(!child.is_empty(), "the launch should still be running");
+        assert!(still_running(&child));
+
+        registry.shutdown();
+        assert!(fake.called("forward --remove"), "{:?}", fake.calls());
+        assert!(
+            !still_running(&child),
+            "the adb shell holding the device agent outlived shutdown"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn an_agent_that_cannot_be_forwarded_a_port_leaves_no_child_behind() {
+        // Every failure after the launch has to kill and reap the child itself: `Child::drop`
+        // does not, so a bailout that forgets leaves one adb shell — and one device-side
+        // app_process — per attempt.
+        use crate::adb::{Answer, FakeAdb, still_running};
+
+        let (lingers, quiet) = (Answer::Lingers, Answer::says(""));
+        let fake = FakeAdb::scripted(&[
+            ("forward tcp:0 *", vec![&quiet]),
+            ("shell CLASSPATH=*", vec![&lingers]),
+            ("*", vec![&Answer::Silent]),
+        ]);
+        let jar = fake.adb().bin().to_string();
+        let get = move |k: &str| match k {
+            "GLASS_ANDROID_AGENT_JAR" => Some(jar.clone()),
+            _ => None,
+        };
+
+        let registry = AgentRegistry::new();
+        let err = registry
+            .ensure(fake.adb(), &get)
+            .expect_err("a forward that names no port cannot be connected to");
+        assert!(err.to_string().contains("no port"), "{err}");
+
+        let child = fake.read("linger.pid");
+        assert!(!child.is_empty(), "the launch should have happened");
+        assert!(!still_running(&child), "the failed launch leaked its child");
     }
 
     #[test]

--- a/crates/glass-android/src/avd.rs
+++ b/crates/glass-android/src/avd.rs
@@ -176,9 +176,8 @@ impl EmulatorRegistry {
 
     /// Record an emulator glass booted, along with the adb client that reaches it.
     ///
-    /// The client is kept rather than resolved again at shutdown: `Adb::from_env` reads
-    /// `GLASS_ADB` and the SDK layout as they are *then*, which need not be what booted the
-    /// device — and the kill would go to a different adb than the boot did.
+    /// Do not resolve one at shutdown instead: `Adb::from_env` reads `GLASS_ADB` and the SDK
+    /// layout as they are *then*, so the kill could go to a different adb than the boot did.
     pub fn register(&self, adb: &Adb, serial: String) {
         if let Ok(mut g) = self.booted.lock() {
             g.push(adb.with_serial(serial));
@@ -412,8 +411,8 @@ mod tests {
 
     #[test]
     fn a_noise_line_is_dropped_for_whichever_reason_gives_it_away() {
-        // The line above carries a pipe AND spaces, so it cannot show which rule did the work.
-        // An AVD name has neither, and each of these has exactly one.
+        // `list_avds_parses_names_only`'s noise line carries a pipe AND spaces, so it cannot
+        // show which rule did the work. Each of these has exactly one.
         assert_eq!(parse_list_avds("INFO|crashdata\nglass\n"), ["glass"]);
         assert_eq!(parse_list_avds("Storing crashdata\nglass\n"), ["glass"]);
         assert_eq!(parse_list_avds("\n\nglass\n"), ["glass"]);

--- a/crates/glass-android/src/avd.rs
+++ b/crates/glass-android/src/avd.rs
@@ -524,19 +524,6 @@ mod tests {
         assert_eq!(fake.calls().len(), 2);
     }
 
-    /// A stand-in for the `emulator` binary. `-list-avds` prints the names it was given; a boot
-    /// records its argv and then stays up, which is what `boot_avd` waits on.
-    #[cfg(unix)]
-    const FAKE_EMULATOR: &str = r#"#!/bin/sh
-dir=$(dirname "$0")
-if [ "$1" = "-list-avds" ]; then
-    cat "$dir/avds"
-    exit 0
-fi
-printf '%s\n' "$*" >> "$dir/boots"
-sleep 30
-"#;
-
     #[test]
     #[cfg(unix)]
     fn booting_waits_for_the_device_to_appear_and_finish_booting() {
@@ -555,7 +542,7 @@ sleep 30
                 vec![&booted],
             ),
         ]);
-        let emulator = fake.alongside("emulator", FAKE_EMULATOR);
+        let emulator = fake.alongside("emulator", crate::adb::FAKE_EMULATOR_SCRIPT);
         std::fs::write(emulator.parent().unwrap().join("avds"), "Pixel_6\nglass\n").unwrap();
 
         let get = |k: &str| match k {
@@ -581,7 +568,7 @@ sleep 30
 
         let none = Answer::says("List of devices attached\n\n");
         let fake = FakeAdb::scripted(&[("devices", vec![&none])]);
-        let emulator = fake.alongside("emulator", FAKE_EMULATOR);
+        let emulator = fake.alongside("emulator", crate::adb::FAKE_EMULATOR_SCRIPT);
         std::fs::write(emulator.parent().unwrap().join("avds"), "glass\n").unwrap();
 
         let get = |k: &str| match k {
@@ -608,7 +595,7 @@ sleep 30
         use crate::adb::{Answer, FakeAdb};
 
         let fake = FakeAdb::new(&[("devices", Answer::says("List of devices attached\n\n"))]);
-        let emulator = fake.alongside("emulator", FAKE_EMULATOR);
+        let emulator = fake.alongside("emulator", crate::adb::FAKE_EMULATOR_SCRIPT);
         std::fs::write(emulator.parent().unwrap().join("avds"), "Pixel_6\nglass\n").unwrap();
 
         let get = |k: &str| match k {

--- a/crates/glass-android/src/avd.rs
+++ b/crates/glass-android/src/avd.rs
@@ -166,7 +166,7 @@ pub fn decide(online: &[Device], serial_env: Option<&str>, lifecycle: Lifecycle)
 /// factory (to register boots) and another into the `Glass` shutdown hook (to kill).
 #[derive(Clone, Default)]
 pub struct EmulatorRegistry {
-    booted: Arc<Mutex<Vec<String>>>,
+    booted: Arc<Mutex<Vec<Adb>>>,
 }
 
 impl EmulatorRegistry {
@@ -174,30 +174,40 @@ impl EmulatorRegistry {
         Self::default()
     }
 
-    /// Record an emulator serial glass booted.
-    pub fn register(&self, serial: String) {
+    /// Record an emulator glass booted, along with the adb client that reaches it.
+    ///
+    /// The client is kept rather than resolved again at shutdown: `Adb::from_env` reads
+    /// `GLASS_ADB` and the SDK layout as they are *then*, which need not be what booted the
+    /// device — and the kill would go to a different adb than the boot did.
+    pub fn register(&self, adb: &Adb, serial: String) {
         if let Ok(mut g) = self.booted.lock() {
-            g.push(serial);
+            g.push(adb.with_serial(serial));
         }
     }
 
     /// Stop every registered emulator (`adb -s <serial> emu kill`) and clear the list.
-    /// Best-effort: a device already gone is fine. Resolves adb from env.
+    /// Best-effort: a device already gone is fine.
     pub fn kill_all(&self) {
-        let adb = Adb::from_env();
-        let serials = self
+        let clients = self
             .booted
             .lock()
             .map(|mut g| std::mem::take(&mut *g))
             .unwrap_or_default();
-        for s in serials {
-            let _ = adb.with_serial(s).run(["emu", "kill"]);
+        for adb in clients {
+            let _ = adb.run(["emu", "kill"]);
         }
     }
 
     #[cfg(test)]
     pub fn serials(&self) -> Vec<String> {
-        self.booted.lock().map(|g| g.clone()).unwrap_or_default()
+        self.booted
+            .lock()
+            .map(|g| {
+                g.iter()
+                    .filter_map(|a| a.serial().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 }
 
@@ -401,6 +411,15 @@ mod tests {
     }
 
     #[test]
+    fn a_noise_line_is_dropped_for_whichever_reason_gives_it_away() {
+        // The line above carries a pipe AND spaces, so it cannot show which rule did the work.
+        // An AVD name has neither, and each of these has exactly one.
+        assert_eq!(parse_list_avds("INFO|crashdata\nglass\n"), ["glass"]);
+        assert_eq!(parse_list_avds("Storing crashdata\nglass\n"), ["glass"]);
+        assert_eq!(parse_list_avds("\n\nglass\n"), ["glass"]);
+    }
+
+    #[test]
     fn choose_avd_sole_or_named_or_errors() {
         assert_eq!(choose_avd(None, &["glass".into()]).unwrap(), "glass");
         assert_eq!(
@@ -467,14 +486,140 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn registry_records_serials() {
+        use crate::adb::{Answer, FakeAdb};
+        let fake = FakeAdb::new(&[("*", Answer::Silent)]);
         let r = EmulatorRegistry::new();
         let r2 = r.clone();
-        r.register("emulator-5554".into());
-        r2.register("emulator-5556".into());
+        r.register(fake.adb(), "emulator-5554".into());
+        r2.register(fake.adb(), "emulator-5556".into());
         assert_eq!(
             r.serials(),
             vec!["emulator-5554".to_string(), "emulator-5556".to_string()]
         );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn killing_them_all_stops_each_registered_emulator_and_forgets_it() {
+        // The shutdown hook calls this once. An emulator it fails to stop holds its AVD lock,
+        // and the next run cannot boot the same one — the failure lands a session later, on
+        // work that did nothing wrong.
+        use crate::adb::{Answer, FakeAdb};
+        let fake = FakeAdb::new(&[("*", Answer::Silent)]);
+        let registry = EmulatorRegistry::new();
+        registry.register(fake.adb(), "emulator-5554".into());
+        registry.register(fake.adb(), "emulator-5556".into());
+
+        registry.kill_all();
+
+        assert_eq!(
+            fake.calls(),
+            ["-s emulator-5554 emu kill", "-s emulator-5556 emu kill",]
+        );
+        // Cleared, so a second shutdown does not kill a device someone has since started.
+        assert!(registry.serials().is_empty());
+        registry.kill_all();
+        assert_eq!(fake.calls().len(), 2);
+    }
+
+    /// A stand-in for the `emulator` binary. `-list-avds` prints the names it was given; a boot
+    /// records its argv and then stays up, which is what `boot_avd` waits on.
+    #[cfg(unix)]
+    const FAKE_EMULATOR: &str = r#"#!/bin/sh
+dir=$(dirname "$0")
+if [ "$1" = "-list-avds" ]; then
+    cat "$dir/avds"
+    exit 0
+fi
+printf '%s\n' "$*" >> "$dir/boots"
+sleep 30
+"#;
+
+    #[test]
+    #[cfg(unix)]
+    fn booting_waits_for_the_device_to_appear_and_finish_booting() {
+        use crate::adb::{Answer, FakeAdb};
+
+        // `devices` is asked repeatedly: once for the "before" snapshot, then in the poll loop.
+        // The emulator is not there for the first two, so the boot is genuinely waited out
+        // rather than answered by the very first look.
+        let none = Answer::says("List of devices attached\n\n");
+        let up = Answer::says("List of devices attached\nemulator-5554\tdevice\n\n");
+        let booted = Answer::says("1\n");
+        let fake = FakeAdb::scripted(&[
+            ("devices", vec![&none, &none, &up]),
+            (
+                "-s emulator-5554 shell getprop sys.boot_completed",
+                vec![&booted],
+            ),
+        ]);
+        let emulator = fake.alongside("emulator", FAKE_EMULATOR);
+        std::fs::write(emulator.parent().unwrap().join("avds"), "Pixel_6\nglass\n").unwrap();
+
+        let get = |k: &str| match k {
+            "GLASS_EMULATOR" => Some(emulator.to_string_lossy().into_owned()),
+            "GLASS_AVD" => Some("glass".to_string()),
+            _ => None,
+        };
+
+        let serial = boot_avd(fake.adb(), &get).expect("the emulator comes up on the third look");
+        assert_eq!(serial, "emulator-5554");
+        // The AVD it was told to boot, not whichever one came first out of `-list-avds`.
+        assert!(
+            fake.read("boots").contains("-avd glass"),
+            "{:?}",
+            fake.read("boots")
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn booting_gives_up_when_the_device_never_appears() {
+        use crate::adb::{Answer, FakeAdb};
+
+        let none = Answer::says("List of devices attached\n\n");
+        let fake = FakeAdb::scripted(&[("devices", vec![&none])]);
+        let emulator = fake.alongside("emulator", FAKE_EMULATOR);
+        std::fs::write(emulator.parent().unwrap().join("avds"), "glass\n").unwrap();
+
+        let get = |k: &str| match k {
+            "GLASS_EMULATOR" => Some(emulator.to_string_lossy().into_owned()),
+            "GLASS_EMULATOR_BOOT_TIMEOUT_MS" => Some("600".to_string()),
+            _ => None,
+        };
+
+        let started = std::time::Instant::now();
+        let err = boot_avd(fake.adb(), &get).expect_err("a device that never appears is a failure");
+        assert!(
+            started.elapsed() < Duration::from_secs(20),
+            "waited {:?} — the deadline never ended the wait",
+            started.elapsed()
+        );
+        assert!(err.to_string().contains("sys.boot_completed"), "{err}");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_named_avd_that_the_sdk_does_not_have_is_refused_before_anything_boots() {
+        // The listing is what `run_emulator_list` returns; an empty or invented one would send
+        // `emulator -avd` after a device that does not exist.
+        use crate::adb::{Answer, FakeAdb};
+
+        let fake = FakeAdb::new(&[("devices", Answer::says("List of devices attached\n\n"))]);
+        let emulator = fake.alongside("emulator", FAKE_EMULATOR);
+        std::fs::write(emulator.parent().unwrap().join("avds"), "Pixel_6\nglass\n").unwrap();
+
+        let get = |k: &str| match k {
+            "GLASS_EMULATOR" => Some(emulator.to_string_lossy().into_owned()),
+            "GLASS_AVD" => Some("not_an_avd".to_string()),
+            _ => None,
+        };
+
+        let err = boot_avd(fake.adb(), &get).expect_err("an unknown AVD cannot be booted");
+        assert!(err.to_string().contains("not_an_avd"), "{err}");
+        // It never got as far as spawning one.
+        assert_eq!(fake.read("boots"), "");
     }
 }

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -410,14 +410,16 @@ mod tests {
 
     #[test]
     fn bounds_become_window_relative() {
+        // Both offsets are non-zero: an `x` of 0 subtracts and adds alike, so the x path would
+        // report clean however it combined the two.
         let win = WindowGeometry {
-            x: 0,
+            x: 24,
             y: 63,
             width: 1080,
             height: 2337,
         };
         let r = parse_bounds("[40,100][300,160]", &win).unwrap();
-        assert_eq!((r.x, r.y, r.width, r.height), (40, 37, 260, 60));
+        assert_eq!((r.x, r.y, r.width, r.height), (16, 37, 260, 60));
         assert!(parse_bounds("garbage", &win).is_none());
     }
 
@@ -507,6 +509,61 @@ mod tests {
         assert_eq!(
             tree.truncated.map(|t| t.limit),
             Some(TruncationLimit::Nodes)
+        );
+    }
+
+    /// `levels` nested `<node>` elements, each the only child of the one above it.
+    fn deep_hierarchy_xml(levels: usize) -> String {
+        let open = r#"<node class="android.widget.FrameLayout" bounds="[0,0][100,100]">"#;
+        format!(
+            "<?xml version='1.0'?><hierarchy rotation=\"0\">{}{}</hierarchy>",
+            open.repeat(levels),
+            "</node>".repeat(levels)
+        )
+    }
+
+    #[test]
+    fn a_tree_deeper_than_the_depth_cap_reports_depth_truncation() {
+        // Each level is walked at one deeper than its parent. A recursion that handed the
+        // parent's own depth back down would never reach the cap at all, and the depth cap is
+        // the rail that keeps a pathological tree off the stack.
+        let limits = WalkLimits {
+            depth: 3,
+            ..WalkLimits::DEFAULT
+        };
+        let deep = build_tree(&deep_hierarchy_xml(8), &win(), limits).unwrap();
+        assert_eq!(
+            deep.truncated.map(|t| t.limit),
+            Some(TruncationLimit::Depth)
+        );
+
+        // The same cap over a tree that fits, so the case above is not simply always-truncating.
+        let shallow = build_tree(&deep_hierarchy_xml(2), &win(), limits).unwrap();
+        assert_eq!(shallow.truncated, None);
+    }
+
+    #[test]
+    fn the_walk_maps_node_elements_and_leaves_every_other_element_out() {
+        // Only `<node>` describes a UI element. Matching on the tag OR on being an element —
+        // rather than both — would map whatever else the document carries as a node, at the
+        // root and at every level below it.
+        let xml = concat!(
+            r#"<?xml version='1.0'?><hierarchy rotation="0">"#,
+            r#"<other/>"#,
+            r#"<node class="android.widget.FrameLayout" bounds="[0,0][100,100]">"#,
+            r#"<decoration/>"#,
+            r#"</node>"#,
+            "</hierarchy>",
+        );
+        let tree = build_tree(xml, &win(), WalkLimits::DEFAULT).unwrap();
+        assert_eq!(
+            tree.root.children.len(),
+            1,
+            "<other/> is not a node, so the root has one child"
+        );
+        assert!(
+            tree.root.children[0].children.is_empty(),
+            "<decoration/> is not a node either"
         );
     }
 

--- a/crates/glass-android/src/axmap.rs
+++ b/crates/glass-android/src/axmap.rs
@@ -537,7 +537,7 @@ mod tests {
             Some(TruncationLimit::Depth)
         );
 
-        // The same cap over a tree that fits, so the case above is not simply always-truncating.
+        // The same cap over a tree that fits, which would otherwise pass if it always truncated.
         let shallow = build_tree(&deep_hierarchy_xml(2), &win(), limits).unwrap();
         assert_eq!(shallow.truncated, None);
     }

--- a/crates/glass-android/src/build.rs
+++ b/crates/glass-android/src/build.rs
@@ -61,6 +61,7 @@ fn push_lines(sink: &LogSink, stream: Stream, bytes: &[u8]) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
     use std::sync::{Arc, Mutex};
 
     /// A spec whose only interesting field is the build command — the rest is what the launch

--- a/crates/glass-android/src/build.rs
+++ b/crates/glass-android/src/build.rs
@@ -61,6 +61,62 @@ fn push_lines(sink: &LogSink, stream: Stream, bytes: &[u8]) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Arc, Mutex};
+
+    /// A spec whose only interesting field is the build command — the rest is what the launch
+    /// would need, and `run_build` never reaches it.
+    #[cfg(unix)]
+    fn spec_that_builds_with(build: &str) -> AppSpec {
+        AppSpec {
+            build: Some(build.to_string()),
+            run: vec!["com.example.app/.MainActivity".to_string()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 15_000,
+            sandbox: glass_core::SandboxLevel::Off,
+            a11y: true,
+        }
+    }
+
+    /// Both streams of a build, as `drain_logs` would hand them to the caller.
+    #[cfg(unix)]
+    fn run_and_collect(build: &str) -> (Result<()>, Vec<(Stream, String)>) {
+        let sink: LogSink = Arc::new(Mutex::new(Vec::new()));
+        let outcome = run_build(&spec_that_builds_with(build), &sink);
+        let lines = sink.lock().expect("sink lock").clone();
+        (outcome, lines)
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_build_that_fails_says_so_and_keeps_what_it_printed() {
+        // A build that reports success is an app launched against stale artifacts, and the
+        // compiler error explaining why is in the output this folds into the log.
+        let (outcome, lines) =
+            run_and_collect("printf 'made it\\n'; printf 'boom\\n' 1>&2; exit 3");
+        let err = outcome.expect_err("a non-zero build must not read as a launch that can go on");
+        assert!(matches!(err, GlassError::AppNotStarted(_)), "{err}");
+        assert!(
+            lines.contains(&(Stream::Stdout, "made it".to_string())),
+            "{lines:?}"
+        );
+        assert!(
+            lines.contains(&(Stream::Stderr, "boom".to_string())),
+            "{lines:?}"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_build_that_succeeds_is_ok_and_still_keeps_its_output() {
+        let (outcome, lines) = run_and_collect("printf 'built\\n'");
+        outcome.expect("a zero exit is a build that worked");
+        assert!(
+            lines.contains(&(Stream::Stdout, "built".to_string())),
+            "{lines:?}"
+        );
+    }
 
     #[test]
     fn empty_build_is_a_noop_command() {

--- a/crates/glass-android/src/cmd.rs
+++ b/crates/glass-android/src/cmd.rs
@@ -258,4 +258,48 @@ mod tests {
         let run = vec!["com.example.app/.Main/extra".to_string()];
         assert!(parse_launch(&run).is_err());
     }
+
+    #[test]
+    fn a_slash_with_nothing_after_it_is_not_a_component() {
+        // The charset check passes vacuously on an empty activity, so this is the one part of
+        // the shape that only the emptiness guard rules out. Admitting it would run
+        // `am start -n com.example/`, which names no activity at all.
+        let run = vec!["com.example/".to_string()];
+        let message = parse_launch(&run).unwrap_err().to_string();
+        assert!(message.contains("com.example/"), "got: {message}");
+    }
+
+    #[test]
+    fn a_package_that_does_not_begin_with_a_letter_is_not_a_component() {
+        // The charset alone would admit this: `1abc` is entirely alphanumeric. A Java package
+        // cannot start with a digit, and only the leading-letter check says so.
+        let run = vec!["1abc/.Main".to_string()];
+        let message = parse_launch(&run).unwrap_err().to_string();
+        assert!(message.contains("1abc/.Main"), "got: {message}");
+    }
+
+    #[test]
+    fn underscores_belong_to_both_halves_of_a_component() {
+        let run = vec!["com.my_app/.My_Activity".to_string()];
+        let target = parse_launch(&run).expect("underscores are legal Java identifiers");
+        assert_eq!(target.package, "com.my_app");
+        assert_eq!(target.component, "com.my_app/.My_Activity");
+    }
+
+    #[test]
+    fn an_inner_class_activity_keeps_its_dollar_sign() {
+        // `pkg/.Outer$Inner` is how an activity declared as an inner class is named.
+        let run = vec!["com.example/.Outer$Inner".to_string()];
+        let target = parse_launch(&run).expect("an inner class is a legal activity");
+        assert_eq!(target.component, "com.example/.Outer$Inner");
+    }
+
+    #[test]
+    fn a_hyphen_keeps_an_element_out_of_both_halves() {
+        // A hyphen is legal in neither, and it is what the flags a caller might pass carry.
+        for stray in ["com.my-app/.Main", "com.example/.My-Activity"] {
+            let message = parse_launch(&[stray.to_string()]).unwrap_err().to_string();
+            assert!(message.contains(stray), "got: {message}");
+        }
+    }
 }

--- a/crates/glass-android/src/conn.rs
+++ b/crates/glass-android/src/conn.rs
@@ -157,3 +157,75 @@ impl Conn {
         Ok(resp)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::fake_agent;
+    use std::io::Write;
+    use std::net::TcpListener;
+    use std::time::Instant;
+
+    const HELLO: &str = r#"{"hello":{"proto":1}}"#;
+    const OK: &str = r#"{"ok":true}"#;
+
+    /// A listener that says hello and then answers nothing, holding the connection open — a
+    /// companion that stopped responding without dropping the socket, which is the only case a
+    /// read timeout is there for. A closed socket ends the read on its own.
+    fn silent_after_hello() -> u16 {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind loopback");
+        let port = listener.local_addr().expect("local addr").port();
+        std::thread::spawn(move || {
+            for mut stream in listener.incoming().flatten() {
+                let _ = writeln!(stream, "{HELLO}");
+                std::thread::sleep(Duration::from_secs(60));
+            }
+        });
+        port
+    }
+
+    #[test]
+    fn a_bounded_read_gives_up_at_the_bound_and_not_at_the_standing_timeout() {
+        // A caller that named a deadline gets it. Without this the wait is the 30s standing
+        // timeout, which is the single-threaded MCP loop blocked for half a minute on a
+        // companion that has already stopped talking.
+        let mut conn = Conn::open(silent_after_hello()).expect("the hello arrives");
+        conn.read_within(Some(Duration::from_millis(200)));
+
+        let started = Instant::now();
+        let Err(failure) = conn.call(json!({"op": "ping"})) else {
+            panic!("a companion that answers nothing cannot have answered");
+        };
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "waited {:?} — the bound never reached the socket",
+            started.elapsed()
+        );
+        assert!(
+            failure.is_transport(),
+            "a read that ran out of time is a transport failure, not a refusal"
+        );
+    }
+
+    #[test]
+    fn every_request_carries_an_id_of_its_own() {
+        // The id is what matches an answer to its question. Ids that repeat — or that run
+        // backwards into one already used — let a late answer satisfy a later call, and on this
+        // protocol that means one tap's reply standing in for another's.
+        let (port, seen) = fake_agent(HELLO, vec![OK, OK, OK]);
+        let mut conn = Conn::open(port).expect("the hello arrives");
+        for _ in 0..3 {
+            conn.call(json!({"op": "ping"}))
+                .map_err(CallFailure::into_error)
+                .expect("the fake answers every ping");
+        }
+
+        let ids: Vec<i64> = seen
+            .lock()
+            .expect("seen lock")
+            .iter()
+            .filter_map(|r| r.get("id").and_then(Value::as_i64))
+            .collect();
+        assert_eq!(ids, [1, 2, 3]);
+    }
+}

--- a/crates/glass-android/src/conn.rs
+++ b/crates/glass-android/src/conn.rs
@@ -58,7 +58,7 @@ impl CallFailure {
 /// How long a read blocks for the companion when no caller named a bound — long enough that a
 /// stalled agent surfaces as a transport error the reconnect path handles, rather than hanging the
 /// single-threaded MCP loop forever.
-const STANDING_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const STANDING_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub(crate) struct Conn {
     pub(crate) writer: TcpStream,
@@ -71,15 +71,15 @@ impl Conn {
     pub(crate) fn open(port: u16) -> glass_core::Result<Conn> {
         let stream = TcpStream::connect(("127.0.0.1", port))
             .map_err(|e| GlassError::Backend(format!("agent connect :{port}: {e}")))?;
-        // Set read/write timeouts so a stalled agent surfaces as a transport error (which
-        // the existing reconnect path handles) rather than hanging the MCP thread forever.
-        stream.set_read_timeout(Some(STANDING_TIMEOUT)).ok();
+        // Timeouts so a stalled agent surfaces as a transport error the reconnect path handles,
+        // rather than hanging the MCP thread forever. Each goes on the handle that does that
+        // half's work — see `read_within` for what puts the read one on the reader.
         stream.set_write_timeout(Some(STANDING_TIMEOUT)).ok();
-        let reader = BufReader::new(
-            stream
-                .try_clone()
-                .map_err(|e| GlassError::Backend(format!("agent clone: {e}")))?,
-        );
+        let read_half = stream
+            .try_clone()
+            .map_err(|e| GlassError::Backend(format!("agent clone: {e}")))?;
+        read_half.set_read_timeout(Some(STANDING_TIMEOUT)).ok();
+        let reader = BufReader::new(read_half);
         let mut c = Conn {
             writer: stream,
             reader,
@@ -117,8 +117,12 @@ impl Conn {
     ///
     /// Per-call rather than per-connection: the socket outlives any one request, so a bound left
     /// behind would be applied to a later call that never agreed to it.
+    ///
+    /// Do not set this on `writer`: a read timeout does not carry across `try_clone` on Windows,
+    /// where a bound set there left the read on the 30s standing one instead.
     pub(crate) fn read_within(&mut self, wait: Option<Duration>) {
-        self.writer
+        self.reader
+            .get_ref()
             .set_read_timeout(Some(wait.unwrap_or(STANDING_TIMEOUT)))
             .ok();
     }

--- a/crates/glass-android/src/conn.rs
+++ b/crates/glass-android/src/conn.rs
@@ -208,6 +208,28 @@ mod tests {
     }
 
     #[test]
+    fn an_answer_addressed_to_another_request_is_refused_rather_than_retried() {
+        // The id is what matches an answer to its question, and a mismatch must classify as
+        // `Refused`: `is_transport` is what decides whether the caller re-sends, and re-sending
+        // an `ACTION_CLICK` whose answer merely went astray taps the control a second time.
+        let (port, _seen) = fake_agent(HELLO, vec![r#"{"id":999,"ok":true}"#]);
+        let mut conn = Conn::open(port).expect("the hello arrives");
+
+        let Err(failure) = conn.call(json!({"op": "ping"})) else {
+            panic!("an answer to a different request is not an answer to this one");
+        };
+        assert!(
+            !failure.is_transport(),
+            "a device that answered is not a transport failure, and must not be re-sent to"
+        );
+        assert!(!failure.nothing_sent());
+        assert!(
+            failure.into_error().to_string().contains("id mismatch"),
+            "the error must say what did not line up"
+        );
+    }
+
+    #[test]
     fn every_request_carries_an_id_of_its_own() {
         // The id is what matches an answer to its question. Ids that repeat — or that run
         // backwards into one already used — let a late answer satisfy a later call, and on this

--- a/crates/glass-android/src/doctor.rs
+++ b/crates/glass-android/src/doctor.rs
@@ -79,17 +79,28 @@ pub fn checks(deep: bool) -> Vec<Check> {
 
 fn probe(deep_requested: bool) -> Probe {
     let get = |k: &str| std::env::var(k).ok();
-    let adb_resolution = crate::sdk::resolve_adb(&get, &|p| p.exists());
+    probe_with(deep_requested, &Adb::from_env(), &get, &|p| p.exists())
+}
+
+/// [`probe`] against a given adb and environment, so the whole probe can be exercised without a
+/// device: what it reports is read back out of the tools it ran, and every branch here turns on
+/// what they said.
+fn probe_with(
+    deep_requested: bool,
+    adb: &Adb,
+    get: &dyn Fn(&str) -> Option<String>,
+    exists: &dyn Fn(&std::path::Path) -> bool,
+) -> Probe {
+    let adb_resolution = crate::sdk::resolve_adb(get, exists);
     let adb_detail = adb_resolution.describe();
-    let adb_trail = crate::sdk::sdk_search_trail(&get);
-    let adb = Adb::from_env();
+    let adb_trail = crate::sdk::sdk_search_trail(get);
     let adb_bin = adb.bin().to_string();
     let adb_version = adb
         .run(["version"])
         .ok()
         .map(|s| first_line(&s))
         .filter(|s| !s.is_empty());
-    let emulator_bin = resolve_emulator_bin(&get, &|p| p.exists());
+    let emulator_bin = resolve_emulator_bin(get, exists);
     let avds = list_avds(&emulator_bin);
 
     let online_devices: Vec<Device> = if adb_version.is_some() {
@@ -112,14 +123,14 @@ fn probe(deep_requested: bool) -> Probe {
 
     // Deep-probe exactly the device glass would attach to (it never boots one).
     let deep = match &selection {
-        Action::Attach(serial) if deep_requested => Some(deep_probe(&adb, serial)),
+        Action::Attach(serial) if deep_requested => Some(deep_probe(adb, serial)),
         _ => None,
     };
 
     let agent_off = get("GLASS_ANDROID_AGENT")
         .map(|v| v.eq_ignore_ascii_case("off"))
         .unwrap_or(false);
-    let agent_jar = crate::agent::agent_jar(&get);
+    let agent_jar = crate::agent::agent_jar(get);
     let agent_jar_exists = agent_jar
         .as_deref()
         .map(|p| std::path::Path::new(p).is_file())
@@ -130,7 +141,7 @@ fn probe(deep_requested: bool) -> Probe {
         Action::Attach(serial) if deep_requested && !agent_off && agent_jar_exists => {
             let reg = crate::agent::AgentRegistry::new();
             let r = reg
-                .ensure(&adb.with_serial(serial.clone()), &get)
+                .ensure(&adb.with_serial(serial.clone()), get)
                 .map(|_| ())
                 .map_err(|e| e.to_string());
             reg.shutdown();
@@ -142,7 +153,7 @@ fn probe(deep_requested: bool) -> Probe {
     let a11y_off = get("GLASS_ANDROID_A11Y")
         .map(|v| v.eq_ignore_ascii_case("off"))
         .unwrap_or(false);
-    let a11y_apk = crate::a11y_service::a11y_apk(&get);
+    let a11y_apk = crate::a11y_service::a11y_apk(get);
     let a11y_apk_exists = a11y_apk
         .as_deref()
         .map(|p| std::path::Path::new(p).is_file())
@@ -490,6 +501,223 @@ mod tests {
             screencap: Ok("captured 1080x2400, 10368016 bytes raw".into()),
             uiautomator: Ok("a11y dump OK".into()),
         }
+    }
+
+    /// A probe run against a fake adb and a chosen environment.
+    ///
+    /// The device tools all fail here, deliberately: the guards under test decide *whether* a
+    /// deep probe runs, and a probe that ran and failed is `Some` just as one that succeeded is.
+    #[cfg(unix)]
+    fn probe_against_a_fake(deep: bool, env: &[(&str, &str)]) -> Probe {
+        use crate::adb::{Answer, FakeAdb};
+
+        let fake = FakeAdb::new(&[
+            (
+                "version",
+                Answer::says("Android Debug Bridge version 1.0.41\nInstalled as /x/adb\n"),
+            ),
+            (
+                "devices",
+                Answer::says(
+                    "List of devices attached\nemulator-5554\tdevice\nemulator-5556\toffline\n",
+                ),
+            ),
+            // Fail the two deep companions fast, so a guard that lets them through is visible
+            // as `Some(Err(..))` without waiting out a readiness budget.
+            ("* forward tcp:0 *", Answer::says("")),
+            ("* install *", Answer::fails("INSTALL_FAILED_INVALID_APK")),
+            ("*", Answer::Silent),
+        ]);
+
+        // The jar and the APK have to be files on disk; the fake adb's own script is one.
+        let real_file = fake.adb().bin().to_string();
+        let owned: Vec<(String, String)> = env
+            .iter()
+            .map(|(k, v)| {
+                let v = if *v == "@file" {
+                    real_file.clone()
+                } else {
+                    (*v).to_string()
+                };
+                ((*k).to_string(), v)
+            })
+            .collect();
+        let get = move |k: &str| {
+            owned
+                .iter()
+                .find(|(key, _)| key == k)
+                .map(|(_, v)| v.clone())
+        };
+
+        probe_with(deep, fake.adb(), &get, &|_| false)
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn probing_reports_the_adb_version_and_only_the_online_devices() {
+        let p = probe_against_a_fake(false, &[]);
+        assert_eq!(
+            p.adb_version.as_deref(),
+            Some("Android Debug Bridge version 1.0.41"),
+            "the version is the first line of what adb said"
+        );
+        assert_eq!(
+            p.online,
+            ["emulator-5554"],
+            "an offline device is not one glass can attach to"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_deep_probe_runs_only_when_it_was_asked_for() {
+        // `checks(false)` is the default path, and running the device probes there would make
+        // every plain `glass_doctor` install an APK and launch a companion.
+        let shallow = probe_against_a_fake(
+            false,
+            &[
+                ("GLASS_ANDROID_AGENT_JAR", "@file"),
+                ("GLASS_ANDROID_A11Y_APK", "@file"),
+            ],
+        );
+        assert!(shallow.deep.is_none());
+        assert!(shallow.agent_deep.is_none());
+        assert!(shallow.a11y_deep.is_none());
+
+        let deep = probe_against_a_fake(
+            true,
+            &[
+                ("GLASS_ANDROID_AGENT_JAR", "@file"),
+                ("GLASS_ANDROID_A11Y_APK", "@file"),
+            ],
+        );
+        assert!(deep.deep.is_some());
+        assert!(deep.agent_deep.is_some(), "configured and asked for");
+        assert!(deep.a11y_deep.is_some(), "configured and asked for");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_deep_probe_skips_a_companion_that_is_off_or_unconfigured() {
+        // Each half of the guard in turn: turned off, and configured-but-absent.
+        let off = probe_against_a_fake(
+            true,
+            &[
+                ("GLASS_ANDROID_AGENT", "off"),
+                ("GLASS_ANDROID_AGENT_JAR", "@file"),
+                ("GLASS_ANDROID_A11Y", "off"),
+                ("GLASS_ANDROID_A11Y_APK", "@file"),
+            ],
+        );
+        assert!(
+            off.agent_deep.is_none(),
+            "an agent that is off is not probed"
+        );
+        assert!(
+            off.a11y_deep.is_none(),
+            "a service that is off is not probed"
+        );
+
+        let missing = probe_against_a_fake(
+            true,
+            &[
+                ("GLASS_ANDROID_AGENT_JAR", "/nonexistent/glass-agent.jar"),
+                ("GLASS_ANDROID_A11Y_APK", "/nonexistent/glass-a11y.apk"),
+            ],
+        );
+        assert!(!missing.agent_jar_exists);
+        assert!(missing.agent_deep.is_none(), "there is nothing to launch");
+        assert!(missing.a11y_deep.is_none(), "there is nothing to install");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn the_avd_list_comes_from_the_emulator_and_is_absent_when_it_cannot_answer() {
+        use crate::adb::{Answer, FAKE_EMULATOR_SCRIPT, FakeAdb};
+
+        let fake = FakeAdb::new(&[("*", Answer::Silent)]);
+        let emulator = fake.alongside("emulator", FAKE_EMULATOR_SCRIPT);
+        std::fs::write(
+            emulator.parent().expect("a parent").join("avds"),
+            "Pixel_6\nglass\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            list_avds(&emulator.to_string_lossy()),
+            Some(vec!["Pixel_6".to_string(), "glass".to_string()])
+        );
+        // A binary that cannot be run answers nothing, which is not the same as a device with no
+        // AVDs — the remedy the caller is given differs.
+        assert_eq!(list_avds("/nonexistent/emulator"), None);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_deep_probe_reads_the_frame_and_the_tree_it_captured() {
+        use crate::adb::{Answer, FakeAdb};
+
+        let mut frame = Vec::new();
+        frame.extend_from_slice(&2u32.to_le_bytes());
+        frame.extend_from_slice(&3u32.to_le_bytes());
+        frame.extend_from_slice(&1u32.to_le_bytes());
+        frame.extend_from_slice(&[0u8; 2 * 3 * 4]);
+
+        let fake = FakeAdb::new(&[
+            ("* exec-out screencap", Answer::says(&frame)),
+            (
+                "* shell cat *",
+                Answer::says(r#"<?xml version='1.0'?><hierarchy rotation="0"></hierarchy>"#),
+            ),
+            ("*", Answer::Silent),
+        ]);
+
+        let probed = deep_probe(fake.adb(), "emulator-5554");
+        assert_eq!(
+            probed.screencap.as_deref(),
+            Ok("captured 2x3, 36 bytes raw"),
+            "the frame is decoded, not merely fetched"
+        );
+        assert_eq!(probed.uiautomator.as_deref(), Ok("a11y dump OK"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_dump_without_a_hierarchy_is_reported_rather_than_passed() {
+        // `uiautomator dump` exits 0 having written nothing usable, so the content is the only
+        // thing that says whether the tree arrived.
+        use crate::adb::{Answer, FakeAdb};
+
+        let fake = FakeAdb::new(&[
+            ("* shell cat *", Answer::says("Killed\n")),
+            ("*", Answer::Silent),
+        ]);
+
+        let probed = deep_probe(fake.adb(), "emulator-5554");
+        assert_eq!(
+            probed.uiautomator.as_deref().map_err(String::as_str),
+            Err("uiautomator dump produced no hierarchy")
+        );
+    }
+
+    #[test]
+    fn a_device_still_to_be_booted_is_named_as_such_rather_than_as_unattachable() {
+        // Deep, configured, but no device yet: `glass_start` will boot one, so this is not the
+        // same as devices being present and refused, and the remedy differs.
+        let mut p = base_probe();
+        p.deep_requested = true;
+        p.online = vec![];
+        p.selection = Action::Boot;
+        assert_eq!(
+            find(&build_checks(&p), "agent").detail,
+            "no online device to probe (glass will boot one on start)"
+        );
+
+        p.selection = Action::Error("2 online devices; set GLASS_ANDROID_SERIAL".into());
+        assert_eq!(
+            find(&build_checks(&p), "agent").detail,
+            "no attachable device to probe (see the device check)"
+        );
     }
 
     fn find<'a>(checks: &'a [Check], name: &str) -> &'a Check {

--- a/crates/glass-android/src/doctor.rs
+++ b/crates/glass-android/src/doctor.rs
@@ -130,7 +130,7 @@ fn probe(deep_requested: bool) -> Probe {
         Action::Attach(serial) if deep_requested && !agent_off && agent_jar_exists => {
             let reg = crate::agent::AgentRegistry::new();
             let r = reg
-                .ensure(&adb.with_serial(serial.clone()))
+                .ensure(&adb.with_serial(serial.clone()), &get)
                 .map(|_| ())
                 .map_err(|e| e.to_string());
             reg.shutdown();

--- a/crates/glass-android/src/doctor.rs
+++ b/crates/glass-android/src/doctor.rs
@@ -83,8 +83,10 @@ fn probe(deep_requested: bool) -> Probe {
 }
 
 /// [`probe`] against a given adb and environment, so the whole probe can be exercised without a
-/// device: what it reports is read back out of the tools it ran, and every branch here turns on
-/// what they said.
+/// device.
+///
+/// `exists` covers the SDK lookups only — the jar and the APK are still checked against the real
+/// filesystem, so a test that needs one present has to point at a file that is.
 fn probe_with(
     deep_requested: bool,
     adb: &Adb,
@@ -505,7 +507,7 @@ mod tests {
 
     /// A probe run against a fake adb and a chosen environment.
     ///
-    /// The device tools all fail here, deliberately: the guards under test decide *whether* a
+    /// The two deep companions fail here, deliberately: the guards under test decide *whether* a
     /// deep probe runs, and a probe that ran and failed is `Some` just as one that succeeded is.
     #[cfg(unix)]
     fn probe_against_a_fake(deep: bool, env: &[(&str, &str)]) -> Probe {

--- a/crates/glass-android/src/doctor.rs
+++ b/crates/glass-android/src/doctor.rs
@@ -82,11 +82,10 @@ fn probe(deep_requested: bool) -> Probe {
     probe_with(deep_requested, &Adb::from_env(), &get, &|p| p.exists())
 }
 
-/// [`probe`] against a given adb and environment, so the whole probe can be exercised without a
-/// device.
+/// [`probe`] against a given adb and environment, so it can be exercised without a device.
 ///
-/// `exists` covers the SDK lookups only — the jar and the APK are still checked against the real
-/// filesystem, so a test that needs one present has to point at a file that is.
+/// `exists` covers the SDK lookups only: the jar and the APK are still checked against the real
+/// filesystem, so a test that needs one present must point at a file that is.
 fn probe_with(
     deep_requested: bool,
     adb: &Adb,
@@ -505,10 +504,9 @@ mod tests {
         }
     }
 
-    /// A probe run against a fake adb and a chosen environment.
-    ///
-    /// The two deep companions fail here, deliberately: the guards under test decide *whether* a
-    /// deep probe runs, and a probe that ran and failed is `Some` just as one that succeeded is.
+    /// A probe run against a fake adb and a chosen environment. The two deep companions fail
+    /// deliberately: the guards under test decide *whether* one runs, and a probe that ran and
+    /// failed is `Some` either way.
     #[cfg(unix)]
     fn probe_against_a_fake(deep: bool, env: &[(&str, &str)]) -> Probe {
         use crate::adb::{Answer, FakeAdb};

--- a/crates/glass-android/src/input.rs
+++ b/crates/glass-android/src/input.rs
@@ -592,9 +592,8 @@ mod agent_inject_tests {
 
     #[test]
     fn a_scroll_that_overshoots_stops_at_the_window_far_edge_in_both_mappings() {
-        // Every scroll case above runs downward, which clamps at the window's origin — the near
-        // edge, where the window's own size never enters the arithmetic. Only an overshoot the
-        // other way reaches the far edge, and the two mappings compute it separately.
+        // A downward scroll clamps at the window's origin, where its size never enters the
+        // arithmetic. Only an overshoot the other way reaches the far edge.
         let o = origin(); // 500x800 at (100, 200) → far edges 599 and 999
         let up_and_left = PointerEvent::Scroll {
             x: 250,
@@ -614,10 +613,8 @@ mod agent_inject_tests {
 
     #[test]
     fn a_drag_takes_its_sample_count_from_its_longer_axis() {
-        // The count is what makes a drag a drag rather than the DOWN/UP pair touch-slop
-        // swallows, and the cases above only assert it clears the floor of 8. Each of these
-        // travels 500px on one axis, so the sample count is pinned exactly — and each leaves
-        // the other axis short, where a distance taken from the wrong one would show.
+        // Each travels 500px on ONE axis and leaves the other short, so a distance taken from
+        // the wrong axis changes the count. Below the floor of 8 the clamp would hide it.
         for (to_x, to_y, longer) in [(500, 300, "x"), (100, 500, "y")] {
             let ev = PointerEvent::Drag {
                 from_x: 0,
@@ -639,7 +636,7 @@ mod agent_inject_tests {
 
     #[test]
     fn a_gesture_paces_its_samples_by_the_longest_segment_on_either_axis() {
-        // As above, on the multi-touch path: 160px of travel, on one axis at a time.
+        // The same on the multi-touch path: 160px of travel, one axis at a time.
         for (segment, longer) in [
             (
                 Segment {

--- a/crates/glass-android/src/input.rs
+++ b/crates/glass-android/src/input.rs
@@ -708,8 +708,10 @@ mod agent_inject_tests {
 }
 
 #[cfg(test)]
+#[cfg(unix)]
 mod injector_tests {
     use super::*;
+    use crate::adb::{Answer, FakeAdb};
     use crate::agent::{fake_agent, ops_seen};
     use glass_core::{KeyEvent, MouseButton, PointerEvent, Segment, WindowGeometry};
 
@@ -743,13 +745,20 @@ mod injector_tests {
         let injector = AgentInjector {
             agent: Arc::new(AgentClient::connect(port).expect("connect to the fake agent")),
         };
-        let adb = Adb::from_env(); // unused by this injector — it reaches the agent's socket
+        // A fake rather than `Adb::from_env()`: this injector should never reach adb at all,
+        // and a real client would send taps to whatever device the developer has attached.
+        let fake = FakeAdb::new(&[("*", Answer::Silent)]);
 
-        injector.pointer(&adb, &origin(), &click()).unwrap();
-        injector.key(&adb, &KeyEvent::Text("hi".into())).unwrap();
-        injector.key(&adb, &KeyEvent::Text(String::new())).unwrap();
+        injector.pointer(fake.adb(), &origin(), &click()).unwrap();
+        injector
+            .key(fake.adb(), &KeyEvent::Text("hi".into()))
+            .unwrap();
+        injector
+            .key(fake.adb(), &KeyEvent::Text(String::new()))
+            .unwrap();
 
         assert_eq!(ops_seen(&seen), ["pointer", "text"]);
+        assert!(fake.calls().is_empty(), "{:?}", fake.calls());
     }
 
     #[test]
@@ -765,18 +774,24 @@ mod injector_tests {
             }],
             duration_ms: 100,
         };
+        let fake = FakeAdb::new(&[("*", Answer::Silent)]);
         let err = ShellInjector
-            .pointer(&Adb::from_env(), &origin(), &gesture)
+            .pointer(fake.adb(), &origin(), &gesture)
             .unwrap_err();
         assert!(matches!(err, GlassError::Unsupported(_)), "{err}");
+        // Refused BEFORE anything reached the device — otherwise this "unsupported" gesture
+        // would have half-happened.
+        assert!(fake.calls().is_empty(), "{:?}", fake.calls());
     }
 
     #[test]
     fn the_shell_injector_reports_a_chord_it_cannot_map() {
+        let fake = FakeAdb::new(&[("*", Answer::Silent)]);
         let err = ShellInjector
-            .key(&Adb::from_env(), &KeyEvent::Chord("ctrl+/".into()))
+            .key(fake.adb(), &KeyEvent::Chord("ctrl+/".into()))
             .unwrap_err();
         assert!(matches!(err, GlassError::InvalidKey(_)), "{err}");
+        assert!(fake.calls().is_empty(), "{:?}", fake.calls());
     }
 }
 

--- a/crates/glass-android/src/input.rs
+++ b/crates/glass-android/src/input.rs
@@ -589,6 +589,195 @@ mod agent_inject_tests {
         let end = spath[0].last().unwrap();
         assert_eq!((end.x, end.y), (350, 480));
     }
+
+    #[test]
+    fn a_scroll_that_overshoots_stops_at_the_window_far_edge_in_both_mappings() {
+        // Every scroll case above runs downward, which clamps at the window's origin — the near
+        // edge, where the window's own size never enters the arithmetic. Only an overshoot the
+        // other way reaches the far edge, and the two mappings compute it separately.
+        let o = origin(); // 500x800 at (100, 200) → far edges 599 and 999
+        let up_and_left = PointerEvent::Scroll {
+            x: 250,
+            y: 400,
+            dx: -100,
+            dy: -100,
+            modifiers: vec![],
+        };
+
+        let argv = pointer_commands(&o, &up_and_left);
+        assert_eq!((argv[0][5].as_str(), argv[0][6].as_str()), ("599", "999"));
+
+        let path = agent_pointer(&o, &up_and_left);
+        let end = path[0].last().copied().unwrap();
+        assert_eq!((end.x, end.y), (599, 999));
+    }
+
+    #[test]
+    fn a_drag_takes_its_sample_count_from_its_longer_axis() {
+        // The count is what makes a drag a drag rather than the DOWN/UP pair touch-slop
+        // swallows, and the cases above only assert it clears the floor of 8. Each of these
+        // travels 500px on one axis, so the sample count is pinned exactly — and each leaves
+        // the other axis short, where a distance taken from the wrong one would show.
+        for (to_x, to_y, longer) in [(500, 300, "x"), (100, 500, "y")] {
+            let ev = PointerEvent::Drag {
+                from_x: 0,
+                from_y: 0,
+                to_x,
+                to_y,
+                duration_ms: 250,
+                button: MouseButton::Left,
+                modifiers: vec![],
+            };
+            let path = &agent_pointer(&origin(), &ev)[0];
+            assert_eq!(
+                path.len(),
+                32,
+                "500px at {AGENT_STEP_PX}px a sample, {longer}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_gesture_paces_its_samples_by_the_longest_segment_on_either_axis() {
+        // As above, on the multi-touch path: 160px of travel, on one axis at a time.
+        for (segment, longer) in [
+            (
+                Segment {
+                    from_x: 30,
+                    from_y: 0,
+                    to_x: 190,
+                    to_y: 0,
+                },
+                "x",
+            ),
+            (
+                Segment {
+                    from_x: 10,
+                    from_y: 40,
+                    to_x: 10,
+                    to_y: 200,
+                },
+                "y",
+            ),
+        ] {
+            let paths = agent_gesture_paths(&origin(), &[segment], 200);
+            assert_eq!(
+                paths[0].len(),
+                11,
+                "160px at {AGENT_STEP_PX}px a sample, {longer}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_vertical_gesture_interpolates_its_y_the_way_a_horizontal_one_does_its_x() {
+        // Every segment in `gesture_builds_time_aligned_absolute_paths` is horizontal or held,
+        // so a gesture path's y was never once asserted to move.
+        let segments = [Segment {
+            from_x: 10,
+            from_y: 40,
+            to_x: 10,
+            to_y: 200,
+        }];
+        let path = &agent_gesture_paths(&origin(), &segments, 200)[0];
+        assert_eq!(
+            path.first().copied().unwrap(),
+            Pt {
+                x: 110,
+                y: 240,
+                t_ms: 0
+            }
+        );
+        assert_eq!(
+            path[path.len() / 2],
+            Pt {
+                x: 110,
+                y: 320,
+                t_ms: 100
+            }
+        );
+        assert_eq!(
+            path.last().copied().unwrap(),
+            Pt {
+                x: 110,
+                y: 400,
+                t_ms: 200
+            }
+        );
+    }
+}
+
+#[cfg(test)]
+mod injector_tests {
+    use super::*;
+    use crate::agent::{fake_agent, ops_seen};
+    use glass_core::{KeyEvent, MouseButton, PointerEvent, Segment, WindowGeometry};
+
+    const HELLO: &str = r#"{"hello":{"proto":1}}"#;
+    const OK: &str = r#"{"ok":true}"#;
+
+    fn origin() -> WindowGeometry {
+        WindowGeometry {
+            x: 100,
+            y: 200,
+            width: 500,
+            height: 800,
+        }
+    }
+
+    fn click() -> PointerEvent {
+        PointerEvent::Click {
+            x: 10,
+            y: 20,
+            button: MouseButton::Left,
+            count: 1,
+            modifiers: vec![],
+        }
+    }
+
+    #[test]
+    fn the_agent_injector_asks_the_device_for_each_event_but_not_for_an_empty_write() {
+        // A third answer is scripted so that an injector which sends the empty write anyway is
+        // answered and fails on the count, rather than blocking on a reply that never comes.
+        let (port, seen) = fake_agent(HELLO, vec![OK, OK, OK]);
+        let injector = AgentInjector {
+            agent: Arc::new(AgentClient::connect(port).expect("connect to the fake agent")),
+        };
+        let adb = Adb::from_env(); // unused by this injector — it reaches the agent's socket
+
+        injector.pointer(&adb, &origin(), &click()).unwrap();
+        injector.key(&adb, &KeyEvent::Text("hi".into())).unwrap();
+        injector.key(&adb, &KeyEvent::Text(String::new())).unwrap();
+
+        assert_eq!(ops_seen(&seen), ["pointer", "text"]);
+    }
+
+    #[test]
+    fn the_shell_injector_refuses_multi_touch_rather_than_reporting_it_done() {
+        // `adb shell input` has no multi-touch at all, so a silent success here would be a
+        // gesture the caller believes happened.
+        let gesture = PointerEvent::Gesture {
+            pointers: vec![Segment {
+                from_x: 0,
+                from_y: 0,
+                to_x: 10,
+                to_y: 10,
+            }],
+            duration_ms: 100,
+        };
+        let err = ShellInjector
+            .pointer(&Adb::from_env(), &origin(), &gesture)
+            .unwrap_err();
+        assert!(matches!(err, GlassError::Unsupported(_)), "{err}");
+    }
+
+    #[test]
+    fn the_shell_injector_reports_a_chord_it_cannot_map() {
+        let err = ShellInjector
+            .key(&Adb::from_env(), &KeyEvent::Chord("ctrl+/".into()))
+            .unwrap_err();
+        assert!(matches!(err, GlassError::InvalidKey(_)), "{err}");
+    }
 }
 
 #[cfg(test)]

--- a/crates/glass-android/src/logs.rs
+++ b/crates/glass-android/src/logs.rs
@@ -27,6 +27,18 @@ pub struct LogcatStream {
     _reader: JoinHandle<()>,
 }
 
+/// Classify and file each line of `stdout` into `sink` until the pipe ends.
+fn drain_into(stdout: std::process::ChildStdout, sink: LogSink) -> JoinHandle<()> {
+    thread::spawn(move || {
+        for line in BufReader::new(stdout).lines().map_while(|r| r.ok()) {
+            let stream = classify_logcat_line(&line);
+            if let Ok(mut g) = sink.lock() {
+                g.push((stream, line));
+            }
+        }
+    })
+}
+
 impl LogcatStream {
     pub fn spawn(adb: &Adb, pid: u32, sink: LogSink) -> Result<Self> {
         // Build argv via the same serial-prefixing path the Adb client uses.
@@ -42,17 +54,9 @@ impl LogcatStream {
             .stdout
             .take()
             .ok_or_else(|| GlassError::Backend("adb logcat produced no stdout pipe".into()))?;
-        let reader = thread::spawn(move || {
-            for line in BufReader::new(stdout).lines().map_while(|r| r.ok()) {
-                let stream = classify_logcat_line(&line);
-                if let Ok(mut g) = sink.lock() {
-                    g.push((stream, line));
-                }
-            }
-        });
         Ok(Self {
             child,
-            _reader: reader,
+            _reader: drain_into(stdout, sink),
         })
     }
 
@@ -73,6 +77,67 @@ impl Drop for LogcatStream {
 mod tests {
     use super::*;
     use glass_core::Stream;
+
+    /// A `LogcatStream` over a stand-in child that will outlive the test unless something kills
+    /// it. `adb logcat` itself needs a device; what these pin is the killing, built through the
+    /// same drain the real spawn uses.
+    #[cfg(unix)]
+    fn stream_over_a_sleeping_child() -> (LogcatStream, u32) {
+        let sink: LogSink = Arc::new(Mutex::new(Vec::new()));
+        let mut child = Command::new("/bin/sh")
+            .args(["-c", "sleep 30"])
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn the stand-in");
+        let pid = child.id();
+        let stdout = child.stdout.take().expect("piped stdout");
+        let stream = LogcatStream {
+            child,
+            _reader: drain_into(stdout, sink),
+        };
+        (stream, pid)
+    }
+
+    /// Whether `pid` is still a live process. A killed child is reaped by `stop`, so its pid is
+    /// gone rather than left as a zombie that would still answer here.
+    #[cfg(unix)]
+    fn still_running(pid: u32) -> bool {
+        Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            // A gone process is the answer this asks for, not a problem to report on stderr.
+            .stderr(Stdio::null())
+            .status()
+            .expect("kill -0")
+            .success()
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn stopping_the_stream_kills_the_logcat_process() {
+        let (mut stream, pid) = stream_over_a_sleeping_child();
+        assert!(
+            still_running(pid),
+            "the stand-in should be up to begin with"
+        );
+        stream.stop();
+        assert!(
+            !still_running(pid),
+            "logcat outlived stop(), holding the device's log open behind it"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn dropping_the_stream_kills_the_logcat_process() {
+        // Every teardown path reaches this through Drop rather than by calling stop, so a Drop
+        // that does nothing leaks one `adb logcat` per app the session ever started.
+        let (stream, pid) = stream_over_a_sleeping_child();
+        drop(stream);
+        assert!(
+            !still_running(pid),
+            "logcat outlived the stream that owned it"
+        );
+    }
 
     #[test]
     fn error_and_fatal_map_to_stderr() {

--- a/crates/glass-android/src/logs.rs
+++ b/crates/glass-android/src/logs.rs
@@ -79,10 +79,7 @@ mod tests {
     use glass_core::Stream;
 
     /// A `LogcatStream` over a stand-in child that prints `lines` and then stays up until killed,
-    /// plus its pid and the sink it drains into. `adb logcat` itself needs a device; this is the
-    /// same child shape, built through the same drain the real spawn uses.
-    ///
-    /// `lines` must carry no single quote — they are the test's own literals.
+    /// plus its pid and the sink it drains into. `lines` must carry no single quote.
     #[cfg(unix)]
     fn stream_over_a_child_printing(lines: &[&str]) -> (LogcatStream, u32, LogSink) {
         let sink: LogSink = Arc::new(Mutex::new(Vec::new()));

--- a/crates/glass-android/src/logs.rs
+++ b/crates/glass-android/src/logs.rs
@@ -98,17 +98,11 @@ mod tests {
         (stream, pid)
     }
 
-    /// Whether `pid` is still a live process. A killed child is reaped by `stop`, so its pid is
-    /// gone rather than left as a zombie that would still answer here.
+    /// Whether `pid` is still a live process — `stop` reaps what it kills, so a stopped child's
+    /// pid is gone rather than left as a zombie that would still answer.
     #[cfg(unix)]
     fn still_running(pid: u32) -> bool {
-        Command::new("kill")
-            .args(["-0", &pid.to_string()])
-            // A gone process is the answer this asks for, not a problem to report on stderr.
-            .stderr(Stdio::null())
-            .status()
-            .expect("kill -0")
-            .success()
+        crate::adb::still_running(&pid.to_string())
     }
 
     #[test]

--- a/crates/glass-android/src/logs.rs
+++ b/crates/glass-android/src/logs.rs
@@ -85,7 +85,9 @@ mod tests {
     fn stream_over_a_sleeping_child() -> (LogcatStream, u32) {
         let sink: LogSink = Arc::new(Mutex::new(Vec::new()));
         let mut child = Command::new("/bin/sh")
-            .args(["-c", "sleep 30"])
+            // `exec` so the shell becomes the sleep: the kill under test reaches the process
+            // whose pid this returns, with no grandchild left orphaned behind it.
+            .args(["-c", "exec sleep 30"])
             .stdout(Stdio::piped())
             .spawn()
             .expect("spawn the stand-in");

--- a/crates/glass-android/src/logs.rs
+++ b/crates/glass-android/src/logs.rs
@@ -78,16 +78,20 @@ mod tests {
     use super::*;
     use glass_core::Stream;
 
-    /// A `LogcatStream` over a stand-in child that will outlive the test unless something kills
-    /// it. `adb logcat` itself needs a device; what these pin is the killing, built through the
-    /// same drain the real spawn uses.
+    /// A `LogcatStream` over a stand-in child that prints `lines` and then stays up until killed,
+    /// plus its pid and the sink it drains into. `adb logcat` itself needs a device; this is the
+    /// same child shape, built through the same drain the real spawn uses.
+    ///
+    /// `lines` must carry no single quote — they are the test's own literals.
     #[cfg(unix)]
-    fn stream_over_a_sleeping_child() -> (LogcatStream, u32) {
+    fn stream_over_a_child_printing(lines: &[&str]) -> (LogcatStream, u32, LogSink) {
         let sink: LogSink = Arc::new(Mutex::new(Vec::new()));
+        let said: Vec<String> = lines.iter().map(|l| format!("'{l}'")).collect();
+        // `exec` so the shell becomes the sleep: the kill under test reaches the process whose
+        // pid this returns, with no grandchild left orphaned behind it.
+        let script = format!("printf '%s\\n' {}; exec sleep 30", said.join(" "));
         let mut child = Command::new("/bin/sh")
-            // `exec` so the shell becomes the sleep: the kill under test reaches the process
-            // whose pid this returns, with no grandchild left orphaned behind it.
-            .args(["-c", "exec sleep 30"])
+            .args(["-c", &script])
             .stdout(Stdio::piped())
             .spawn()
             .expect("spawn the stand-in");
@@ -95,9 +99,44 @@ mod tests {
         let stdout = child.stdout.take().expect("piped stdout");
         let stream = LogcatStream {
             child,
-            _reader: drain_into(stdout, sink),
+            _reader: drain_into(stdout, Arc::clone(&sink)),
         };
+        (stream, pid, sink)
+    }
+
+    #[cfg(unix)]
+    fn stream_over_a_sleeping_child() -> (LogcatStream, u32) {
+        let (stream, pid, _) = stream_over_a_child_printing(&[]);
         (stream, pid)
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn each_line_reaches_the_sink_classified_by_its_priority() {
+        // What `glass_logs` hands the caller. An error line arriving as stdout sends whoever
+        // reads it straight past the thing that broke — and until now the drain was built by
+        // every test here and run by none of them.
+        let (_stream, _pid, sink) = stream_over_a_child_printing(&[
+            "06-15 12:00:00.0  1 1 I Tag: starting up",
+            "06-15 12:00:00.0  1 1 E Tag: boom",
+        ]);
+
+        // The drain reads on its own thread, so wait for it rather than racing it.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while sink.lock().expect("sink").len() < 2 && std::time::Instant::now() < deadline {
+            thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        let lines = sink.lock().expect("sink").clone();
+        assert_eq!(lines.len(), 2, "{lines:?}");
+        assert_eq!(lines[0].0, Stream::Stdout);
+        assert!(lines[0].1.contains("starting up"), "{lines:?}");
+        assert_eq!(
+            lines[1].0,
+            Stream::Stderr,
+            "an E line is the app's error output: {lines:?}"
+        );
+        assert!(lines[1].1.contains("boom"), "{lines:?}");
     }
 
     /// Whether `pid` is still a live process — `stop` reaps what it kills, so a stopped child's

--- a/crates/glass-android/src/parse.rs
+++ b/crates/glass-android/src/parse.rs
@@ -237,9 +237,8 @@ mod tests {
 
     #[test]
     fn either_marker_alone_still_picks_the_reason_out_of_the_progress_lines() {
-        // The line above carries one marker and not the other. Requiring both would find no
-        // line at all and fall back to the whole output, burying the reason in the noise —
-        // which the case above cannot show, its line carrying both.
+        // Each line here carries one marker and not the other; requiring both would find none
+        // and fall back to the whole output, burying the reason in the progress lines.
         for (output, reason) in [
             (
                 "Performing Streamed Install\nFailure [INSTALL_PARSE_FAILED_NO_CERTIFICATES]\n",

--- a/crates/glass-android/src/parse.rs
+++ b/crates/glass-android/src/parse.rs
@@ -236,6 +236,30 @@ mod tests {
     }
 
     #[test]
+    fn either_marker_alone_still_picks_the_reason_out_of_the_progress_lines() {
+        // The line above carries one marker and not the other. Requiring both would find no
+        // line at all and fall back to the whole output, burying the reason in the noise —
+        // which the case above cannot show, its line carrying both.
+        for (output, reason) in [
+            (
+                "Performing Streamed Install\nFailure [INSTALL_PARSE_FAILED_NO_CERTIFICATES]\n",
+                "Failure [INSTALL_PARSE_FAILED_NO_CERTIFICATES]",
+            ),
+            (
+                "Performing Streamed Install\nError [INSTALL_FAILED_INSUFFICIENT_STORAGE]\n",
+                "Error [INSTALL_FAILED_INSUFFICIENT_STORAGE]",
+            ),
+        ] {
+            let message = check_install(output).unwrap_err().to_string();
+            assert!(message.contains(reason), "got: {message}");
+            assert!(
+                !message.contains("Performing Streamed Install"),
+                "the reason must be the failing line, not the whole output: {message}"
+            );
+        }
+    }
+
+    #[test]
     fn am_start_error_is_detected() {
         assert!(check_am_start("Starting: Intent {...}\nStatus: ok\n").is_ok());
         let err =

--- a/crates/glass-android/src/platform.rs
+++ b/crates/glass-android/src/platform.rs
@@ -50,11 +50,11 @@ impl AndroidPlatform {
         emulators: &crate::avd::EmulatorRegistry,
         agents: &AgentRegistry,
     ) -> Result<Self> {
+        let get = |k: &str| std::env::var(k).ok();
         let base = Adb::from_env();
-        let target = crate::target::resolve(base, emulators)?;
+        let target = crate::target::resolve(base, emulators, &get)?;
 
         // Best-effort: use the agent when enabled; on any failure, fall back to adb paths.
-        let get = |k: &str| std::env::var(k).ok();
         let agent = if crate::agent::agent_enabled(&get) {
             match agents.ensure(target.adb()).and_then(AgentClient::connect) {
                 Ok(client) => Some(Arc::new(client)),

--- a/crates/glass-android/src/platform.rs
+++ b/crates/glass-android/src/platform.rs
@@ -380,8 +380,8 @@ impl Platform for AndroidPlatform {
     }
 }
 
-// Unix-gated as a whole: `FakeAdb` is a `/bin/sh` script, so every test here needs one and the
-// import cannot be resolved on Windows.
+// Unix-gated as a whole: `FakeAdb` is a `/bin/sh` script, so this import breaks the Windows
+// build without it.
 #[cfg(test)]
 #[cfg(unix)]
 mod platform_tests {

--- a/crates/glass-android/src/platform.rs
+++ b/crates/glass-android/src/platform.rs
@@ -380,7 +380,10 @@ impl Platform for AndroidPlatform {
     }
 }
 
+// Unix-gated as a whole: `FakeAdb` is a `/bin/sh` script, so every test here needs one and the
+// import cannot be resolved on Windows.
 #[cfg(test)]
+#[cfg(unix)]
 mod platform_tests {
     use super::*;
     use crate::adb::{Answer, FakeAdb};
@@ -479,6 +482,13 @@ mod platform_tests {
         assert_eq!((window.width, window.height), (800, 800));
         assert!(fake.called("am start -W -n com.example.app/.MainActivity"));
         assert_eq!(platform.app_pid(), Some(4321), "logcat needs the app's pid");
+        // Scoped to the app: without `--pid` this streams the whole device's log, which is
+        // every other app's output presented as this session's.
+        assert!(
+            fake.wait_called("logcat -v threadtime --pid=4321", Duration::from_secs(5)),
+            "{:?}",
+            fake.calls()
+        );
     }
 
     #[test]
@@ -550,7 +560,9 @@ mod platform_tests {
 
         platform
             .stop_app()
-            .expect("stop is best-effort but reports");
+            // A failed force-stop is NOT surfaced — `stop_app` discards it — so this asserts
+            // only that the call was made and the session ended, not that the app died.
+            .expect("ending a session reports");
 
         assert!(
             fake.called("am force-stop com.example.app"),

--- a/crates/glass-android/src/platform.rs
+++ b/crates/glass-android/src/platform.rs
@@ -381,6 +381,440 @@ impl Platform for AndroidPlatform {
 }
 
 #[cfg(test)]
+mod platform_tests {
+    use super::*;
+    use crate::adb::{Answer, FakeAdb};
+    use crate::target::AttachedDevice;
+    use glass_core::{MouseButton, SandboxLevel};
+
+    /// Two on-screen windows for the app — a dialog on top of its main activity — plus windows
+    /// owned by other packages, as `dumpsys window windows` really lays them out.
+    const WINDOWS: &str = concat!(
+        "  Window #0 Window{aaa111 u0 StatusBar}:\n",
+        "    mOwnerUid=10168 showForAllUsers=true package=com.android.systemui appop=NONE\n",
+        "    mFrame=[0,0][1080,80] isOnScreen=true\n",
+        "  Window #1 Window{bbb222 u0 com.example.app/com.example.app.MyDialog}:\n",
+        "    mOwnerUid=1000 showForAllUsers=false package=com.example.app appop=NONE\n",
+        "    mFrame=[140,800][940,1600] isOnScreen=true\n",
+        "  Window #2 Window{ddd444 u0 com.example.app/com.example.app.MainActivity}:\n",
+        "    mOwnerUid=1000 showForAllUsers=false package=com.example.app appop=NONE\n",
+        "    mFrame=[0,0][1080,2400] isOnScreen=true\n",
+    );
+
+    /// The same dump with the dialog gone — the app's window list after it is dismissed.
+    const WINDOWS_WITHOUT_THE_DIALOG: &str = concat!(
+        "  Window #0 Window{aaa111 u0 StatusBar}:\n",
+        "    mOwnerUid=10168 showForAllUsers=true package=com.android.systemui appop=NONE\n",
+        "    mFrame=[0,0][1080,80] isOnScreen=true\n",
+        "  Window #2 Window{ddd444 u0 com.example.app/com.example.app.MainActivity}:\n",
+        "    mOwnerUid=1000 showForAllUsers=false package=com.example.app appop=NONE\n",
+        "    mFrame=[0,0][1080,2400] isOnScreen=true\n",
+    );
+
+    fn spec() -> AppSpec {
+        AppSpec {
+            build: None,
+            run: vec!["com.example.app/.MainActivity".to_string()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 2_000,
+            sandbox: SandboxLevel::Off,
+            a11y: false,
+        }
+    }
+
+    /// A screencap of `w`x`h` opaque pixels, as `exec-out screencap` returns one.
+    fn frame_bytes(w: u32, h: u32) -> Vec<u8> {
+        let mut v = Vec::new();
+        v.extend_from_slice(&w.to_le_bytes());
+        v.extend_from_slice(&h.to_le_bytes());
+        v.extend_from_slice(&1u32.to_le_bytes());
+        v.extend(std::iter::repeat_n(0xffu8, (w * h * 4) as usize));
+        v
+    }
+
+    /// A platform bound to `fake`, with no on-device companion — the adb fallback paths.
+    fn platform_over(fake: &FakeAdb) -> AndroidPlatform {
+        AndroidPlatform {
+            target: Box::new(AttachedDevice::from_adb(fake.adb().clone())),
+            injector: Box::new(ShellInjector),
+            agent: None,
+            logs: Arc::new(Mutex::new(Vec::new())),
+            app: None,
+        }
+    }
+
+    /// A device that answers everything a healthy launch asks of it.
+    fn launchable() -> FakeAdb {
+        FakeAdb::new(&[
+            (
+                "shell am start *",
+                Answer::says("Starting: Intent {...}\nStatus: ok\n"),
+            ),
+            ("shell dumpsys window windows", Answer::says(WINDOWS)),
+            ("shell pidof *", Answer::says("4321\n")),
+            ("exec-out screencap", Answer::says(frame_bytes(1080, 2400))),
+            ("*", Answer::Silent),
+        ])
+    }
+
+    /// A launched app on a fake device, ready for the calls that need a session.
+    fn started(fake: &FakeAdb) -> AndroidPlatform {
+        let mut platform = platform_over(fake);
+        platform.start_app(&spec()).expect("the launch succeeds");
+        platform
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn starting_an_app_launches_it_and_reports_its_topmost_window() {
+        let fake = launchable();
+        let mut platform = platform_over(&fake);
+
+        let window = platform.start_app(&spec()).expect("the launch succeeds");
+
+        // The dialog is topmost, so that is the window the session drives.
+        assert_eq!((window.x, window.y), (140, 800));
+        assert_eq!((window.width, window.height), (800, 800));
+        assert!(fake.called("am start -W -n com.example.app/.MainActivity"));
+        assert_eq!(platform.app_pid(), Some(4321), "logcat needs the app's pid");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_launch_that_the_device_refuses_is_not_reported_as_started() {
+        let fake = FakeAdb::new(&[(
+            "shell am start *",
+            Answer::says("Starting: Intent {...}\nError: Activity not started\n"),
+        )]);
+        let mut platform = platform_over(&fake);
+        assert!(platform.start_app(&spec()).is_err());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_window_that_takes_a_moment_to_appear_is_waited_for() {
+        // The activity is up before its window is laid out, so the first dump legitimately
+        // shows nothing. A deadline computed backwards makes that first look the answer.
+        let empty = Answer::says("");
+        let windows = Answer::says(WINDOWS);
+        let started = Answer::says("Starting: Intent {...}\nStatus: ok\n");
+        let pid = Answer::says("4321\n");
+        let silent = Answer::Silent;
+        let fake = FakeAdb::scripted(&[
+            ("shell am start *", vec![&started]),
+            (
+                "shell dumpsys window windows",
+                vec![&empty, &empty, &windows],
+            ),
+            ("shell pidof *", vec![&pid]),
+            ("*", vec![&silent]),
+        ]);
+
+        let mut platform = platform_over(&fake);
+        let window = platform
+            .start_app(&spec())
+            .expect("the window arrives on the third look");
+        assert_eq!((window.x, window.y), (140, 800));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_window_that_never_appears_ends_the_launch_rather_than_the_wait_going_on() {
+        let empty = Answer::says("");
+        let started = Answer::says("Starting: Intent {...}\nStatus: ok\n");
+        let fake = FakeAdb::scripted(&[
+            ("shell am start *", vec![&started]),
+            ("shell dumpsys window windows", vec![&empty]),
+            ("*", vec![&Answer::Silent]),
+        ]);
+
+        let mut platform = platform_over(&fake);
+        let mut spec = spec();
+        spec.timeout_ms = 300;
+        let at = Instant::now();
+        assert!(platform.start_app(&spec).is_err());
+        assert!(
+            at.elapsed() < Duration::from_secs(20),
+            "waited {:?}",
+            at.elapsed()
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn stopping_an_app_force_stops_its_package_and_ends_the_session() {
+        let fake = launchable();
+        let mut platform = started(&fake);
+
+        platform
+            .stop_app()
+            .expect("stop is best-effort but reports");
+
+        assert!(
+            fake.called("am force-stop com.example.app"),
+            "{:?}",
+            fake.calls()
+        );
+        assert!(matches!(
+            platform.window(&WindowOp::Geometry),
+            Err(GlassError::NoActiveSession)
+        ));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_capture_is_cropped_to_the_window_rather_than_the_display() {
+        let fake = launchable();
+        let mut platform = started(&fake);
+
+        let frame = platform.capture_frame(None).expect("the device captures");
+
+        // The dialog's frame, not the 1080x2400 display behind it.
+        assert_eq!((frame.width, frame.height), (800, 800));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn the_window_is_re_read_before_a_capture_so_a_move_is_not_missed() {
+        // The cached geometry is from launch; a rotation or a layout change moves the window
+        // under it, and cropping to a stale rect captures the wrong pixels.
+        let windows = Answer::says(WINDOWS);
+        let moved = Answer::says(concat!(
+            "  Window #1 Window{bbb222 u0 com.example.app/com.example.app.MyDialog}:
+",
+            "    mOwnerUid=1000 showForAllUsers=false package=com.example.app appop=NONE
+",
+            "    mFrame=[0,0][600,400] isOnScreen=true
+",
+        ));
+        let started_ok = Answer::says("Starting: Intent {...}\nStatus: ok\n");
+        let pid = Answer::says("4321\n");
+        let shot = Answer::says(frame_bytes(1080, 2400));
+        let fake = FakeAdb::scripted(&[
+            ("shell am start *", vec![&started_ok]),
+            ("shell dumpsys window windows", vec![&windows, &moved]),
+            ("shell pidof *", vec![&pid]),
+            ("exec-out screencap", vec![&shot]),
+            ("*", vec![&Answer::Silent]),
+        ]);
+
+        let mut platform = platform_over(&fake);
+        platform.start_app(&spec()).expect("the launch succeeds");
+        let frame = platform.capture_frame(None).expect("the device captures");
+        assert_eq!(
+            (frame.width, frame.height),
+            (600, 400),
+            "the capture used the window's current frame"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn pointer_and_key_events_reach_the_device() {
+        let fake = launchable();
+        let mut platform = started(&fake);
+
+        platform
+            .send_pointer(&PointerEvent::Click {
+                x: 10,
+                y: 20,
+                button: MouseButton::Left,
+                count: 1,
+                modifiers: vec![],
+            })
+            .expect("a tap is sent");
+        platform
+            .send_key(&KeyEvent::Text("hi".into()))
+            .expect("text is sent");
+
+        // Window-relative (10,20) inside a window at (140,800) is absolute (150,820).
+        assert!(fake.called("input tap 150 820"), "{:?}", fake.calls());
+        assert!(fake.called("input text"), "{:?}", fake.calls());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn input_without_a_session_is_refused_rather_than_sent_nowhere() {
+        let fake = launchable();
+        let mut platform = platform_over(&fake);
+        assert!(platform.send_key(&KeyEvent::Text("hi".into())).is_err());
+        assert!(!fake.called("input text"), "{:?}", fake.calls());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn focusing_relaunches_the_activity_and_re_reads_the_window() {
+        let fake = launchable();
+        let mut platform = started(&fake);
+
+        let window = platform.window(&WindowOp::Focus).expect("focus succeeds");
+
+        assert_eq!((window.x, window.y), (140, 800));
+        assert_eq!(
+            fake.calls()
+                .iter()
+                .filter(|c| c.contains("am start"))
+                .count(),
+            2,
+            "focus re-issues the launch intent"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn moving_or_resizing_a_window_is_refused_on_this_platform() {
+        let fake = launchable();
+        let mut platform = started(&fake);
+        assert!(matches!(
+            platform.window(&WindowOp::Resize {
+                width: 100,
+                height: 100
+            }),
+            Err(GlassError::Unsupported(_))
+        ));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn listing_windows_marks_the_selected_one_active() {
+        let fake = launchable();
+        let mut platform = started(&fake);
+
+        let windows = platform.list_windows().expect("the app has windows");
+
+        assert_eq!(windows.len(), 2, "{windows:?}");
+        assert_eq!(windows[0].geometry.x, 140, "topmost first");
+        assert!(windows[0].active, "the session drives the topmost window");
+        assert!(!windows[1].active);
+        assert_eq!(windows[0].class.as_deref(), Some("com.example.app"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_list_whose_selected_window_is_gone_falls_back_to_the_topmost() {
+        // The dialog the session was driving has been dismissed. Marking nothing active would
+        // leave the caller with a list it cannot act on.
+        let windows = Answer::says(WINDOWS);
+        let without = Answer::says(WINDOWS_WITHOUT_THE_DIALOG);
+        let started_ok = Answer::says("Starting: Intent {...}\nStatus: ok\n");
+        let pid = Answer::says("4321\n");
+        let fake = FakeAdb::scripted(&[
+            ("shell am start *", vec![&started_ok]),
+            ("shell dumpsys window windows", vec![&windows, &without]),
+            ("shell pidof *", vec![&pid]),
+            ("*", vec![&Answer::Silent]),
+        ]);
+
+        let mut platform = platform_over(&fake);
+        platform.start_app(&spec()).expect("the launch succeeds");
+        let listed = platform.list_windows().expect("the app still has a window");
+
+        assert_eq!(listed.len(), 1, "{listed:?}");
+        assert!(
+            listed[0].active,
+            "with the selection gone, the topmost window is the active one"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn selecting_a_window_switches_to_it_and_an_unknown_id_is_refused() {
+        let fake = launchable();
+        let mut platform = started(&fake);
+
+        let main = platform
+            .list_windows()
+            .expect("windows")
+            .into_iter()
+            .find(|w| w.geometry.x == 0)
+            .expect("the main activity is listed");
+
+        let geometry = platform.select_window(main.id).expect("it is one of ours");
+        assert_eq!((geometry.width, geometry.height), (1080, 2400));
+        // The selection sticks: the session now drives the main activity.
+        assert_eq!(platform.window(&WindowOp::Geometry).unwrap().x, 0);
+
+        assert!(matches!(
+            platform.select_window(WindowId(0xdead_beef)),
+            Err(GlassError::WindowNotFound)
+        ));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn logs_are_handed_over_once_and_then_gone() {
+        let fake = launchable();
+        let mut platform = started(&fake);
+        platform
+            .logs
+            .lock()
+            .unwrap()
+            .push((Stream::Stdout, "hello".to_string()));
+
+        assert_eq!(
+            platform.drain_logs(),
+            [(Stream::Stdout, "hello".to_string())]
+        );
+        assert!(
+            platform.drain_logs().is_empty(),
+            "a drained line must not be handed out twice"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn the_clipboard_says_it_needs_the_companion_rather_than_answering_emptily() {
+        // An empty string would read as an empty clipboard, and a silent `set` as one that
+        // worked — neither is true without the agent.
+        let fake = launchable();
+        let mut platform = started(&fake);
+
+        let read = platform
+            .get_clipboard()
+            .expect_err("no agent, no clipboard");
+        assert!(matches!(read, GlassError::Unsupported(_)), "{read}");
+        assert!(read.to_string().contains("agent"), "{read}");
+
+        let written = platform
+            .set_clipboard("x")
+            .expect_err("no agent, no clipboard");
+        assert!(matches!(written, GlassError::Unsupported(_)), "{written}");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn the_app_pids_are_re_read_from_the_device_and_fall_back_to_the_known_one() {
+        let fake = launchable();
+        let platform = started(&fake);
+        // `pidof` lists every process of the package; the launch recorded only the first.
+        assert_eq!(platform.app_pid(), Some(4321));
+
+        let started_ok = Answer::says("Starting: Intent {...}\nStatus: ok\n");
+        let windows = Answer::says(WINDOWS);
+        let one = Answer::says("4321\n");
+        let many = Answer::says("4321 4322 4323\n");
+        let none = Answer::says("\n");
+        let fake = FakeAdb::scripted(&[
+            ("shell am start *", vec![&started_ok]),
+            ("shell dumpsys window windows", vec![&windows]),
+            ("shell pidof *", vec![&one, &many, &none]),
+            ("*", vec![&Answer::Silent]),
+        ]);
+        let mut platform = platform_over(&fake);
+        platform.start_app(&spec()).expect("the launch succeeds");
+
+        assert_eq!(platform.app_pids(), [4321, 4322, 4323], "a live re-scan");
+        assert_eq!(
+            platform.app_pids(),
+            [4321],
+            "a scan that finds nothing falls back to the pid the launch recorded"
+        );
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/crates/glass-android/src/platform.rs
+++ b/crates/glass-android/src/platform.rs
@@ -56,7 +56,10 @@ impl AndroidPlatform {
 
         // Best-effort: use the agent when enabled; on any failure, fall back to adb paths.
         let agent = if crate::agent::agent_enabled(&get) {
-            match agents.ensure(target.adb()).and_then(AgentClient::connect) {
+            match agents
+                .ensure(target.adb(), &get)
+                .and_then(AgentClient::connect)
+            {
                 Ok(client) => Some(Arc::new(client)),
                 Err(e) => {
                     eprintln!("glass-android: agent unavailable, using adb fallback: {e}");

--- a/crates/glass-android/src/screencap.rs
+++ b/crates/glass-android/src/screencap.rs
@@ -97,4 +97,17 @@ mod tests {
             Err(GlassError::CaptureFailed(_))
         ));
     }
+
+    #[test]
+    fn twelve_bytes_is_a_whole_header_and_reads_as_a_missing_payload() {
+        // The boundary the length check sits on: twelve bytes carry width, height and format
+        // and nothing else, so what did not arrive is the pixels. Blaming the header instead
+        // sends whoever reads it to the wrong end of the capture.
+        let err = decode_screencap(&buf(4, 4, 1, false, &[])).unwrap_err();
+        let GlassError::CaptureFailed(message) = err else {
+            panic!("a short capture is a CaptureFailed: {err}");
+        };
+        assert!(message.contains("payload bytes"), "got: {message}");
+        assert!(!message.contains("no header"), "got: {message}");
+    }
 }

--- a/crates/glass-android/src/sdk.rs
+++ b/crates/glass-android/src/sdk.rs
@@ -25,8 +25,8 @@ pub struct SdkRoot {
 /// unset: an empty path would otherwise be probed as the root of the filesystem.
 ///
 /// Shared by every branch below rather than repeated inside each one. The per-OS branches are
-/// compiled only on the OS they name, so a check written inside them is a check no other target's
-/// test run can reach — and the mutation gate runs on one.
+/// compiled only on the targets they select, so a check written inside them is one no other
+/// target's test run can reach — and the mutation gate runs on one.
 fn non_empty(get: &dyn Fn(&str) -> Option<String>, key: &str) -> Option<String> {
     get(key).filter(|s| !s.is_empty())
 }

--- a/crates/glass-android/src/sdk.rs
+++ b/crates/glass-android/src/sdk.rs
@@ -21,21 +21,31 @@ pub struct SdkRoot {
     pub source: SdkSource,
 }
 
+/// An environment variable with something in it. A variable set to the empty string counts as
+/// unset: an empty path would otherwise be probed as the root of the filesystem.
+///
+/// Shared by every branch below rather than repeated inside each one. The per-OS branches are
+/// compiled only on the OS they name, so a check written inside them is a check no other target's
+/// test run can reach — and the mutation gate runs on one.
+fn non_empty(get: &dyn Fn(&str) -> Option<String>, key: &str) -> Option<String> {
+    get(key).filter(|s| !s.is_empty())
+}
+
 /// Default SDK install locations to probe for the current OS, given `$HOME`
 /// (and `%LOCALAPPDATA%` on Windows) read via `get`.
 fn default_locations(get: &dyn Fn(&str) -> Option<String>) -> Vec<PathBuf> {
     let mut v = Vec::new();
     #[cfg(target_os = "windows")]
-    if let Some(la) = get("LOCALAPPDATA").filter(|s| !s.is_empty()) {
+    if let Some(la) = non_empty(get, "LOCALAPPDATA") {
         v.push(PathBuf::from(format!(r"{la}\Android\Sdk")));
     }
     #[cfg(target_os = "macos")]
-    if let Some(h) = get("HOME").filter(|s| !s.is_empty()) {
+    if let Some(h) = non_empty(get, "HOME") {
         v.push(PathBuf::from(format!("{h}/Library/Android/sdk")));
     }
     #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     {
-        if let Some(h) = get("HOME").filter(|s| !s.is_empty()) {
+        if let Some(h) = non_empty(get, "HOME") {
             v.push(PathBuf::from(format!("{h}/Android/Sdk")));
             v.push(PathBuf::from(format!("{h}/android-sdk")));
         }
@@ -164,21 +174,21 @@ pub fn artifact_data_dirs(get: &dyn Fn(&str) -> Option<String>) -> Vec<PathBuf> 
     let mut v = Vec::new();
     #[cfg(target_os = "windows")]
     for var in ["APPDATA", "LOCALAPPDATA"] {
-        if let Some(d) = get(var).filter(|s| !s.is_empty()) {
+        if let Some(d) = non_empty(get, var) {
             v.push(PathBuf::from(d).join("glass"));
         }
     }
     #[cfg(target_os = "macos")]
-    if let Some(h) = get("HOME").filter(|s| !s.is_empty()) {
+    if let Some(h) = non_empty(get, "HOME") {
         v.push(PathBuf::from(format!(
             "{h}/Library/Application Support/glass"
         )));
     }
     #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     {
-        if let Some(x) = get("XDG_DATA_HOME").filter(|s| !s.is_empty()) {
+        if let Some(x) = non_empty(get, "XDG_DATA_HOME") {
             v.push(PathBuf::from(x).join("glass"));
-        } else if let Some(h) = get("HOME").filter(|s| !s.is_empty()) {
+        } else if let Some(h) = non_empty(get, "HOME") {
             v.push(PathBuf::from(format!("{h}/.local/share/glass")));
         }
     }
@@ -507,5 +517,28 @@ mod tests {
     fn none_when_nothing_exists() {
         let get = getter(&[("HOME", "/home/u")]);
         assert!(resolve_sdk_root(&get, &|_| false).is_none());
+    }
+
+    #[test]
+    fn an_env_var_set_to_nothing_counts_as_unset() {
+        // An empty value would otherwise be joined into a path and probed as the filesystem
+        // root — every relative lookup below it silently answering about the wrong tree.
+        let get = getter(&[("HOME", "")]);
+        assert_eq!(non_empty(&get, "HOME"), None);
+        assert_eq!(non_empty(&get, "ABSENT"), None);
+        assert_eq!(
+            non_empty(&getter(&[("HOME", "/home/u")]), "HOME").as_deref(),
+            Some("/home/u")
+        );
+    }
+
+    #[test]
+    fn the_executable_directory_is_the_one_the_running_binary_sits_in() {
+        // Artifacts dropped beside `glass-mcp` are found through this, so a `None` — or an
+        // empty path, which joins into a bare relative name — drops that lookup entirely.
+        let dir = exe_dir().expect("a running test binary has a directory");
+        assert!(dir.is_dir(), "{dir:?} is not a directory");
+        let exe = std::env::current_exe().expect("current exe");
+        assert_eq!(exe.parent(), Some(dir.as_path()));
     }
 }

--- a/crates/glass-android/src/sdk.rs
+++ b/crates/glass-android/src/sdk.rs
@@ -24,9 +24,8 @@ pub struct SdkRoot {
 /// An environment variable with something in it. A variable set to the empty string counts as
 /// unset: an empty path would otherwise be probed as the root of the filesystem.
 ///
-/// Shared by every branch below rather than repeated inside each one. The per-OS branches are
-/// compiled only on the targets they select, so a check written inside them is one no other
-/// target's test run can reach — and the mutation gate runs on one.
+/// Do not push this check back inside the per-OS branches: they compile only on the target they
+/// select, and the mutation gate runs on one, so no test there could reach it.
 fn non_empty(get: &dyn Fn(&str) -> Option<String>, key: &str) -> Option<String> {
     get(key).filter(|s| !s.is_empty())
 }

--- a/crates/glass-android/src/target.rs
+++ b/crates/glass-android/src/target.rs
@@ -29,10 +29,24 @@ impl AttachedDevice {
     }
 }
 
+/// Whether an emulator glass booted itself should be registered for cleanup.
+/// `GLASS_EMULATOR_KEEP` set to anything non-empty leaves it up for the next run to attach to.
+fn should_register(get: &dyn Fn(&str) -> Option<String>) -> bool {
+    get("GLASS_EMULATOR_KEEP")
+        .filter(|v| !v.is_empty())
+        .is_none()
+}
+
 /// Resolve an adb target: attach to an online device, or (lifecycle `auto`) boot the
 /// configured AVD, register it for cleanup, and attach. Attach-preferred.
-pub fn resolve(base: Adb, registry: &EmulatorRegistry) -> Result<AttachedDevice> {
-    let get = |k: &str| std::env::var(k).ok();
+///
+/// `get` reads the environment, passed in rather than read here so a test can choose a
+/// lifecycle and a serial without touching the one the process shares.
+pub fn resolve(
+    base: Adb,
+    registry: &EmulatorRegistry,
+    get: &dyn Fn(&str) -> Option<String>,
+) -> Result<AttachedDevice> {
     let online: Vec<Device> = parse_devices(&base.run(["devices"])?)
         .into_iter()
         .filter(|d| d.state == "device")
@@ -42,12 +56,9 @@ pub fn resolve(base: Adb, registry: &EmulatorRegistry) -> Result<AttachedDevice>
         Action::Attach(s) => s,
         Action::Error(msg) => return Err(GlassError::Backend(msg)),
         Action::Boot => {
-            let s = boot_avd(&base, &get)?;
-            if get("GLASS_EMULATOR_KEEP")
-                .filter(|v| !v.is_empty())
-                .is_none()
-            {
-                registry.register(s.clone());
+            let s = boot_avd(&base, get)?;
+            if should_register(get) {
+                registry.register(&base, s.clone());
             }
             s
         }
@@ -128,6 +139,73 @@ mod tests {
     const LISTING: &str = "List of devices attached\n\
                            emulator-5554\tdevice\n\
                            emulator-5556\toffline\n";
+
+    /// An env reader over a fixed table, so a test can choose a lifecycle without touching the
+    /// environment the whole process shares.
+    fn getter(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> + use<> {
+        let owned: Vec<(String, String)> = pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        move |k: &str| {
+            owned
+                .iter()
+                .find(|(key, _)| key == k)
+                .map(|(_, v)| v.clone())
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_device_that_has_not_finished_booting_is_not_attached_to() {
+        // Attaching mid-boot hands the caller a device whose home screen is not up yet, and
+        // every launch against it fails for reasons that look like the app's fault. The
+        // property is the only thing that tells them apart.
+        use crate::adb::{Answer, FakeAdb};
+        for (property, ready) in [("1\n", true), ("0\n", false), ("\n", false)] {
+            let fake =
+                FakeAdb::new(&[("shell getprop sys.boot_completed", Answer::says(property))]);
+            assert_eq!(
+                ensure_booted(fake.adb()).is_ok(),
+                ready,
+                "sys.boot_completed = {property:?}"
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn resolve_attaches_to_the_online_device_and_not_the_offline_one() {
+        use crate::adb::{Answer, FakeAdb};
+        let fake = FakeAdb::new(&[
+            ("devices", Answer::says(LISTING)),
+            (
+                "-s emulator-5554 shell getprop sys.boot_completed",
+                Answer::says("1\n"),
+            ),
+        ]);
+
+        let registry = EmulatorRegistry::new();
+        let target = resolve(fake.adb().clone(), &registry, &getter(&[]))
+            .expect("exactly one device is online");
+
+        assert_eq!(target.adb().serial(), Some("emulator-5554"));
+        // Nothing was booted, so nothing is owed cleanup.
+        assert!(registry.serials().is_empty());
+    }
+
+    #[test]
+    fn an_emulator_is_registered_for_cleanup_unless_the_caller_asked_to_keep_it() {
+        assert!(
+            should_register(&getter(&[])),
+            "unset means glass stops what it started"
+        );
+        assert!(
+            should_register(&getter(&[("GLASS_EMULATOR_KEEP", "")])),
+            "set to nothing is not asking for anything"
+        );
+        assert!(!should_register(&getter(&[("GLASS_EMULATOR_KEEP", "1")])));
+    }
 
     #[test]
     fn parse_devices_skips_header_and_keeps_state() {

--- a/scripts/mutants.sh
+++ b/scripts/mutants.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Mutation-test glass-core with cargo-mutants and grade the outcome.
+# Mutation-test one or more crates with cargo-mutants and grade the outcome.
 #
 # Why this wrapper rather than a bare `cargo mutants`: its exit code alone cannot
 # tell a clean run from one that gated nothing.
@@ -49,8 +49,8 @@ shift
 
 # glass-core is the platform-agnostic heart — the Platform/Accessibility seams, session,
 # frame diffing, stability, the log buffer — so it is pure logic that mutates meaningfully and
-# tests without a display. Changing this default changes what CI gates — `--package` scopes a
-# run to another crate without touching it.
+# tests without a display. CI names its packages explicitly, so this default now covers only a
+# bare local run — `--package` scopes a run to other crates.
 readonly DEFAULT_PACKAGE='glass-core'
 
 # A package's own sources. `**` so a file moved into a subdirectory stays covered; keep this in


### PR DESCRIPTION
`glass-android` had no mutation gate. A sweep of the crate left 187 survivors, among them every
method of the `Platform` impl and every input method of `AgentClient` — whose tests called them
and asserted only that they returned `Ok`, which a body replaced by `Ok(())` does too.

## Tests

340 → 434 unit tests; the suite is still ~1.4s and needs no device. What they close:

- **The agent client asserts what reached the wire.** Its fake now records the requests it read,
  so a method that answered `Ok` having sent nothing is no longer indistinguishable from one that
  worked.
- **The whole `Platform` impl runs under test** — launch, capture, input, window selection, logs.
  A launch waits for a window that is not laid out yet rather than taking the first empty dump as
  the answer; a capture re-reads the window so a move is not cropped from a stale rect; a window
  list whose selection has gone falls back to the topmost rather than marking nothing active.
- **`conn.rs` had no tests at all.** A bounded read now ends at its bound rather than the 30s
  standing timeout, each request carries an id of its own, and an answer addressed to a different
  request is refused rather than re-sent — a re-sent click actuates the control twice.
- The a11y service's install, enable and teardown run end to end: the device's own accessibility
  services survive being added to, an unset setting reads as the string `null` and must not be
  carried through as a value, and teardown restores exactly what was there, once.

## Two fixtures

Both stand in for a device at a seam production already has, so nothing is stubbed out:

- **`FakeAdb`** — `Adb` runs whatever `bin` names, so the fake is a shell script that answers the
  first rule whose glob matches the argv and records every invocation. Rules can be scripted in
  sequence, because a device changes under the caller: an emulator absent from `adb devices` a
  moment ago is there now.
- **`fake_agent`** — the companion's line-delimited JSON over a loopback socket.

## Production changes

Each either creates one of those seams or removes code the sweep proved unreachable:

- `EmulatorRegistry`, `AgentRegistry` and `A11yServiceRegistry` keep the adb client they set a
  device up through, instead of calling `Adb::from_env()` again at teardown — which reads the
  environment as it is *then*, so the kill could go to a different adb than the setup did.
- `AndroidA11y` reads `GLASS_ANDROID_SERIAL` when it is constructed rather than when it resolves,
  so the device a session is reading cannot change under it midway.
- `target::resolve`, `AgentRegistry::ensure` and `doctor::probe` take the environment through a
  passed-in `get`, matching the rest of the crate.
- Two branches removed as dead: `parse_forward_port`'s filter, which its own `parse` already
  subsumed, and `json_to_node`'s node-cap arm, which made the same decision as the loop below it.

## CI

`glass-android` joins `glass-core` in both mutation jobs — the per-PR `--in-diff` gate and the
weekly sweep. The `Mutation gate (glass-core)` job name is unchanged on purpose: the branch
ruleset requires that exact string, so renaming it would block every pull request.

Two things a reviewer may want to know:

- The fixtures carry `#[cfg(test)]` and `#[cfg(unix)]` as separate attributes rather than
  `#[cfg(all(test, unix))]`. cargo-mutants cannot parse the nested form and would mutate them as
  production code.
- This is the first run of `scripts/mutants.sh` with two `--package` arguments.

No changelog entry: the file's maintenance note excludes CI and test-only changes.

Follow-ups filed rather than folded in: #368 (a failed a11y-service `ensure` leaves the device's
accessibility settings modified) and #369 (`FakeAdb` ergonomics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)