### PR TITLE
test(x11): kill the crate's mutation survivors, and gate it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,8 @@ jobs:
           # nothing, and one present here but not named there is never mutated at all.
           git diff "origin/$BASE_REF...HEAD" \
             -- ':(glob)crates/glass-core/src/**/*.rs' \
-               ':(glob)crates/glass-android/src/**/*.rs' > "$RUNNER_TEMP/pr.diff"
+               ':(glob)crates/glass-android/src/**/*.rs' \
+               ':(glob)crates/glass-x11/src/**/*.rs' > "$RUNNER_TEMP/pr.diff"
           wc -l "$RUNNER_TEMP/pr.diff"
           if [ -s "$RUNNER_TEMP/pr.diff" ]; then
             echo "touched=true" >> "$GITHUB_OUTPUT"
@@ -313,13 +314,21 @@ jobs:
         if: steps.diff.outputs.touched == 'true'
         with:
           tool: cargo-mutants,cargo-nextest
+      - name: Install the X and a11y stack glass-x11's tests drive
+        if: steps.diff.outputs.touched == 'true'
+        # xvfb: those tests each start a private headless display (~45ms) and drive real X
+        # protocol against it, which is the only way most of that backend is reachable at all.
+        # at-spi2-core: one test starts the private a11y bus, the only source of the address
+        # `a11y_bus_addr` reports. Absent either, the tests fail and every mutant reads as
+        # caught.
+        run: sudo apt-get update && sudo apt-get install -y xvfb at-spi2-core
       - name: Mutation gate
         if: steps.diff.outputs.touched == 'true'
         # nextest runs each test in its own process, so slow tests overlap rather than sum.
         run: |
           scripts/mutants.sh "$RUNNER_TEMP/mutants" \
             --test-tool nextest \
-            --package glass-core --package glass-android \
+            --package glass-core --package glass-android --package glass-x11 \
             --shard ${{ matrix.shard }}/8 --sharding round-robin \
             --in-diff "$RUNNER_TEMP/pr.diff"
 
@@ -327,7 +336,8 @@ jobs:
   # to require. This one has a fixed name and fails if any shard did.
   #
   # The ruleset's required check matches this name, so it is frozen — renaming it blocks every
-  # pull request. It gates glass-android too despite the name; rename only with the ruleset.
+  # pull request. It gates glass-android and glass-x11 too despite the name; rename only with
+  # the ruleset.
   mutants-gate:
     name: Mutation gate (glass-core)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: .
+      - name: Install the X and a11y stack glass-x11's unit tests need
+        # `cargo test --workspace` now covers glass-x11's Xvfb-backed tests — they start a
+        # private display each, and one starts a private a11y bus. Neither package ships on
+        # the runner, and these are not `#[ignore]`d because the mutation gate has to run them.
+        run: sudo apt-get update && sudo apt-get install -y xvfb at-spi2-core
       - run: cargo build --workspace --all-targets --locked
       - run: cargo clippy --workspace --all-targets --locked -- -D warnings
       - run: cargo test --workspace --locked
@@ -247,7 +252,7 @@ jobs:
         # them for bubblewrap (no-op on images without the knob).
         # python3-gi + gir1.2-gtk-4.0: the software_render integration test drives a real GTK4 app.
         run: |
-          sudo apt-get update && sudo apt-get install -y xvfb bubblewrap python3-gi gir1.2-gtk-4.0
+          sudo apt-get update && sudo apt-get install -y xvfb bubblewrap python3-gi gir1.2-gtk-4.0 at-spi2-core
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
       - name: Measure coverage (unit + X11; Wayland/AT-SPI self-skip)
         run: ./scripts/coverage.sh --lcov
@@ -258,7 +263,7 @@ jobs:
           if-no-files-found: warn
 
   mutants:
-    name: Mutation shard ${{ matrix.shard }} (glass-core, glass-android)
+    name: Mutation shard ${{ matrix.shard }} (glass-core, glass-android, glass-x11)
     runs-on: ubuntu-latest
     # A push carries no base ref to diff against; this gate is a pull-request check.
     if: github.event_name == 'pull_request'
@@ -317,8 +322,8 @@ jobs:
       - name: Install the X and a11y stack glass-x11's tests drive
         if: steps.diff.outputs.touched == 'true'
         # xvfb for the private headless displays those tests start; at-spi2-core for the one
-        # that starts a private a11y bus. Absent either they all fail, and a failing suite
-        # reads as every mutant caught.
+        # that starts a private a11y bus. Absent either, cargo-mutants' unmutated baseline
+        # fails and the run grades nothing.
         run: sudo apt-get update && sudo apt-get install -y xvfb at-spi2-core
       - name: Mutation gate
         if: steps.diff.outputs.touched == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,11 +316,9 @@ jobs:
           tool: cargo-mutants,cargo-nextest
       - name: Install the X and a11y stack glass-x11's tests drive
         if: steps.diff.outputs.touched == 'true'
-        # xvfb: those tests each start a private headless display (~45ms) and drive real X
-        # protocol against it, which is the only way most of that backend is reachable at all.
-        # at-spi2-core: one test starts the private a11y bus, the only source of the address
-        # `a11y_bus_addr` reports. Absent either, the tests fail and every mutant reads as
-        # caught.
+        # xvfb for the private headless displays those tests start; at-spi2-core for the one
+        # that starts a private a11y bus. Absent either they all fail, and a failing suite
+        # reads as every mutant caught.
         run: sudo apt-get update && sudo apt-get install -y xvfb at-spi2-core
       - name: Mutation gate
         if: steps.diff.outputs.touched == 'true'

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   sweep:
-    name: Mutation sweep shard ${{ matrix.shard }} (glass-core, glass-android)
+    name: Mutation sweep shard ${{ matrix.shard }} (glass-core, glass-android, glass-x11)
     runs-on: ubuntu-latest
     strategy:
       # Every shard reports: one red shard must not hide a second one.
@@ -32,12 +32,17 @@ jobs:
       - uses: taiki-e/install-action@ed67fa35ac944f3a9b33f12c4dd43b6f31a47e20 # v2.83.3
         with:
           tool: cargo-mutants,cargo-nextest
+      - name: Install the X and a11y stack glass-x11's tests drive
+        # xvfb for the private headless displays those tests start; at-spi2-core for the one
+        # that starts a private a11y bus. Absent either, they fail and every mutant reads as
+        # caught.
+        run: sudo apt-get update && sudo apt-get install -y xvfb at-spi2-core
       - name: Sweep
         # nextest runs each test in its own process, so slow tests overlap rather than sum.
         run: |
           scripts/mutants.sh "$RUNNER_TEMP/mutants" \
             --test-tool nextest \
-            --package glass-core --package glass-android \
+            --package glass-core --package glass-android --package glass-x11 \
             --shard ${{ matrix.shard }}/8 --sharding round-robin
       - name: Upload the outcome
         if: always()

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -34,8 +34,8 @@ jobs:
           tool: cargo-mutants,cargo-nextest
       - name: Install the X and a11y stack glass-x11's tests drive
         # xvfb for the private headless displays those tests start; at-spi2-core for the one
-        # that starts a private a11y bus. Absent either, they fail and every mutant reads as
-        # caught.
+        # that starts a private a11y bus. Absent either, cargo-mutants' unmutated baseline
+        # fails and the run grades nothing.
         run: sudo apt-get update && sudo apt-get install -y xvfb at-spi2-core
       - name: Sweep
         # nextest runs each test in its own process, so slow tests overlap rather than sum.

--- a/crates/glass-x11/src/clipboard.rs
+++ b/crates/glass-x11/src/clipboard.rs
@@ -497,8 +497,7 @@ mod tests {
     use super::*;
     use crate::testx::TestX;
 
-    /// Long enough that a truncated read is visibly short: the property read asks for a
-    /// length in 4-byte units, and a slip there caps the text at a handful of bytes.
+    /// Long enough that a truncated read comes back visibly short.
     const LONG_TEXT: &str = "the quick brown fox jumps over the lazy dog";
 
     /// Wait for `f` to hold, up to `within`. The owner thread runs on its own connection, so

--- a/crates/glass-x11/src/clipboard.rs
+++ b/crates/glass-x11/src/clipboard.rs
@@ -77,7 +77,9 @@ pub fn get(display: &str) -> Result<String> {
 
     let atoms = intern_get_atoms(&req_conn)?;
 
-    // Create a temporary INPUT_ONLY window to receive the SelectionNotify.
+    // A temporary INPUT_ONLY window to receive the SelectionNotify. It needs no explicit
+    // teardown: `req_conn` is dropped when this returns, and an X server destroys everything
+    // a client created once its connection closes (close-down mode defaults to DestroyAll).
     let win = req_conn
         .generate_id()
         .map_err(|e| GlassError::Backend(format!("generate_id: {e}")))?;
@@ -98,11 +100,6 @@ pub fn get(display: &str) -> Result<String> {
         .map_err(|e| GlassError::Backend(format!("create temp window: {e}")))?
         .check()
         .map_err(|e| GlassError::Backend(format!("create temp window check: {e}")))?;
-
-    let _cleanup = WindowGuard {
-        conn: &req_conn,
-        win,
-    };
 
     // Request the selection conversion.
     req_conn
@@ -168,19 +165,6 @@ pub fn get(display: &str) -> Result<String> {
                 std::thread::sleep(Duration::from_millis(10));
             }
         }
-    }
-}
-
-/// RAII guard that destroys the temp window when it goes out of scope.
-struct WindowGuard<'a> {
-    conn: &'a RustConnection,
-    win: Window,
-}
-
-impl Drop for WindowGuard<'_> {
-    fn drop(&mut self) {
-        let _ = self.conn.destroy_window(self.win);
-        let _ = self.conn.flush();
     }
 }
 
@@ -278,14 +262,6 @@ impl ClipboardOwner {
     /// selection; `false` means `SelectionClear` was received).
     pub fn is_alive(&self) -> bool {
         !self.stop.load(Ordering::Relaxed)
-    }
-
-    /// Signal the thread to stop and wait for it to exit.
-    pub fn stop(mut self) {
-        self.stop.store(true, Ordering::Relaxed);
-        if let Some(h) = self.handle.take() {
-            let _ = h.join();
-        }
     }
 }
 
@@ -514,4 +490,138 @@ fn handle_selection_request(
         .check()?;
     conn.flush()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testx::TestX;
+
+    /// Long enough that a truncated read is visibly short: the property read asks for a
+    /// length in 4-byte units, and a slip there caps the text at a handful of bytes.
+    const LONG_TEXT: &str = "the quick brown fox jumps over the lazy dog";
+
+    /// Wait for `f` to hold, up to `within`. The owner thread runs on its own connection, so
+    /// what it has done is observed rather than sequenced.
+    fn eventually(within: Duration, mut f: impl FnMut() -> bool) -> bool {
+        let deadline = Instant::now() + within;
+        while Instant::now() < deadline {
+            if f() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        f()
+    }
+
+    #[test]
+    fn an_unowned_clipboard_reads_as_empty_rather_than_failing() {
+        // A display where nothing has ever copied is the normal starting state, not an error.
+        let x = TestX::start();
+        assert_eq!(get(x.display()).expect("get"), "");
+    }
+
+    #[test]
+    fn repeated_reads_leave_no_windows_behind() {
+        // Each read creates a temporary window to receive the SelectionNotify on. An agent
+        // polls the clipboard, so one leaked window per read accumulates for the session.
+        let x = TestX::start();
+        let _owner =
+            ClipboardOwner::spawn(x.display().to_string(), "text".to_string()).expect("spawn");
+        let before = x.root_child_count();
+        for _ in 0..5 {
+            get(x.display()).expect("get");
+        }
+        assert_eq!(
+            x.root_child_count(),
+            before,
+            "five reads should leave the window tree as they found it"
+        );
+    }
+
+    #[test]
+    fn text_handed_to_the_owner_reads_back_whole() {
+        let x = TestX::start();
+        let _owner = ClipboardOwner::spawn(x.display().to_string(), LONG_TEXT.to_string())
+            .expect("the owner should take the selection");
+        assert_eq!(get(x.display()).expect("get"), LONG_TEXT);
+    }
+
+    #[test]
+    fn a_later_copy_replaces_what_the_owner_serves() {
+        let x = TestX::start();
+        let owner =
+            ClipboardOwner::spawn(x.display().to_string(), "first".to_string()).expect("spawn");
+        assert_eq!(get(x.display()).expect("get"), "first");
+        owner.set_text("second");
+        assert_eq!(get(x.display()).expect("get"), "second");
+    }
+
+    #[test]
+    fn the_owner_is_alive_until_it_is_dropped_and_then_serves_nothing() {
+        let x = TestX::start();
+        let owner =
+            ClipboardOwner::spawn(x.display().to_string(), "gone soon".to_string()).expect("spawn");
+        assert!(owner.is_alive());
+        drop(owner);
+        assert_eq!(
+            get(x.display()).expect("get"),
+            "",
+            "a dropped owner must release the selection, not keep serving it"
+        );
+    }
+
+    #[test]
+    fn another_client_taking_the_selection_retires_the_owner() {
+        // The server sends SelectionClear; ignoring it leaves a thread that believes it still
+        // owns a selection it does not, so the next copy is served by nobody.
+        let x = TestX::start();
+        let owner =
+            ClipboardOwner::spawn(x.display().to_string(), "ours".to_string()).expect("spawn");
+        assert!(owner.is_alive());
+
+        x.take_clipboard();
+        assert!(
+            eventually(Duration::from_secs(3), || !owner.is_alive()),
+            "the owner should have retired when another client took the selection"
+        );
+    }
+
+    #[test]
+    fn the_owner_advertises_the_targets_it_can_convert_to() {
+        let x = TestX::start();
+        let _owner =
+            ClipboardOwner::spawn(x.display().to_string(), "text".to_string()).expect("spawn");
+        let targets = x.intern(b"TARGETS");
+        let granted = x
+            .request_selection(targets, Duration::from_secs(2))
+            .expect("the owner should answer a TARGETS request");
+        assert_ne!(
+            granted,
+            x11rb::NONE,
+            "TARGETS is a request every selection owner must answer"
+        );
+    }
+
+    #[test]
+    fn a_target_the_owner_cannot_produce_is_refused_rather_than_answered_wrongly() {
+        // Refusal is `property = NONE`. Answering with the text regardless would hand a
+        // requestor asking for an image a string it cannot use.
+        let x = TestX::start();
+        let _owner =
+            ClipboardOwner::spawn(x.display().to_string(), "text".to_string()).expect("spawn");
+        let png = x.intern(b"image/png");
+        let granted = x
+            .request_selection(png, Duration::from_secs(2))
+            .expect("the owner should still reply");
+        assert_eq!(granted, x11rb::NONE);
+    }
+
+    #[test]
+    fn spawning_against_an_unreachable_display_fails_instead_of_hanging() {
+        let Err(err) = ClipboardOwner::spawn(":9999".to_string(), "text".to_string()) else {
+            panic!("there is no server on :9999, so no owner can take its selection");
+        };
+        assert!(matches!(err, GlassError::Backend(_)), "{err:?}");
+    }
 }

--- a/crates/glass-x11/src/clipboard.rs
+++ b/crates/glass-x11/src/clipboard.rs
@@ -180,7 +180,7 @@ enum ReadyState {
 }
 
 /// A background thread that owns the X11 CLIPBOARD selection and serves paste
-/// requests.  Created by `ClipboardOwner::spawn`; torn down by `stop()`/`Drop`.
+/// requests. Created by `ClipboardOwner::spawn`; torn down by dropping it.
 pub struct ClipboardOwner {
     text: Arc<Mutex<String>>,
     stop: Arc<AtomicBool>,
@@ -531,10 +531,13 @@ mod tests {
         for _ in 0..5 {
             get(x.display()).expect("get");
         }
-        assert_eq!(
-            x.root_child_count(),
-            before,
-            "five reads should leave the window tree as they found it"
+        // Polled, not asserted outright: each temp window dies when the server processes its
+        // own connection closing, and no request this connection can send is ordered against
+        // that.
+        assert!(
+            eventually(Duration::from_secs(3), || x.root_child_count() == before),
+            "five reads left {} windows behind",
+            x.root_child_count() - before
         );
     }
 
@@ -592,13 +595,19 @@ mod tests {
         let _owner =
             ClipboardOwner::spawn(x.display().to_string(), "text".to_string()).expect("spawn");
         let targets = x.intern(b"TARGETS");
-        let granted = x
+        let utf8 = x.intern(b"UTF8_STRING");
+        let (requestor, granted) = x
             .request_selection(targets, Duration::from_secs(2))
             .expect("the owner should answer a TARGETS request");
         assert_ne!(
             granted,
             x11rb::NONE,
             "TARGETS is a request every selection owner must answer"
+        );
+        assert!(
+            x.property_atoms(requestor, granted).contains(&utf8),
+            "a requestor branches on this list, so it has to name the target glass can \
+             actually convert to"
         );
     }
 
@@ -609,8 +618,14 @@ mod tests {
         let x = TestX::start();
         let _owner =
             ClipboardOwner::spawn(x.display().to_string(), "text".to_string()).expect("spawn");
+        assert_ne!(
+            x.clipboard_owner(),
+            x11rb::NONE,
+            "with nobody owning the selection the SERVER replies NONE, and this test would \
+             pass without glass having refused anything"
+        );
         let png = x.intern(b"image/png");
-        let granted = x
+        let (_requestor, granted) = x
             .request_selection(png, Duration::from_secs(2))
             .expect("the owner should still reply");
         assert_eq!(granted, x11rb::NONE);

--- a/crates/glass-x11/src/coords.rs
+++ b/crates/glass-x11/src/coords.rs
@@ -71,7 +71,9 @@ pub(crate) fn clip_capture_to_display(
              via GLASS_XVFB_SCREEN={need_w}x{need_h}x24."
         )));
     }
-    let clipped = ix != rx || iy != ry || iw != w || ih != h;
+    // Size alone: a shifted origin cannot leave the size intact, since `ix` only moves when
+    // `rx` is negative, which shortens `iw` by the same amount.
+    let clipped = iw != w || ih != h;
     Ok(ClippedRect {
         sx: ix as i32,
         sy: iy as i32,
@@ -247,6 +249,94 @@ mod tests {
         assert!(
             msg.to_lowercase().contains("outside"),
             "explains nothing is on-screen: {msg}"
+        );
+    }
+
+    #[test]
+    fn a_region_offsets_the_window_origin_on_both_axes() {
+        // Both coordinates are non-zero and differ, so an axis that dropped its region
+        // offset — or applied the other axis's — lands somewhere else.
+        let geo = WindowGeometry {
+            x: 100,
+            y: 50,
+            width: 800,
+            height: 600,
+        };
+        let region = Region {
+            x: 30,
+            y: 20,
+            width: 100,
+            height: 100,
+        };
+        let r = clip_capture_to_display(&geo, Some(&region), (1280, 800)).unwrap();
+        assert_eq!(
+            r,
+            ClippedRect {
+                sx: 130,
+                sy: 70,
+                w: 100,
+                h: 100,
+                clipped: false
+            }
+        );
+    }
+
+    #[test]
+    fn a_window_off_only_the_right_edge_is_clipped() {
+        // Clipped on one axis only, and by a shrunk width rather than a moved origin —
+        // the case that separates "the size changed" from "the origin moved".
+        let geo = WindowGeometry {
+            x: 1000,
+            y: 10,
+            width: 500,
+            height: 100,
+        };
+        let r = clip_capture_to_display(&geo, None, (1280, 800)).unwrap();
+        assert_eq!(
+            r,
+            ClippedRect {
+                sx: 1000,
+                sy: 10,
+                w: 280,
+                h: 100,
+                clipped: true
+            }
+        );
+    }
+
+    #[test]
+    fn the_offscreen_error_sizes_a_display_that_would_reach_the_window() {
+        // The suggested screen must actually contain the window: 2000+100 across, and the
+        // display's own height where the window is already within it.
+        let geo = WindowGeometry {
+            x: 2000,
+            y: 0,
+            width: 100,
+            height: 100,
+        };
+        let msg = clip_capture_to_display(&geo, None, (1280, 800))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            msg.contains("GLASS_XVFB_SCREEN=2100x800x24"),
+            "should suggest a display reaching the window's right edge: {msg}"
+        );
+    }
+
+    #[test]
+    fn the_offscreen_error_sizes_the_vertical_axis_too() {
+        let geo = WindowGeometry {
+            x: 0,
+            y: 2000,
+            width: 100,
+            height: 100,
+        };
+        let msg = clip_capture_to_display(&geo, None, (1280, 800))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            msg.contains("GLASS_XVFB_SCREEN=1280x2100x24"),
+            "should suggest a display reaching the window's bottom edge: {msg}"
         );
     }
 

--- a/crates/glass-x11/src/doctor.rs
+++ b/crates/glass-x11/src/doctor.rs
@@ -3,6 +3,7 @@
 //! [`checks`] gathers the real environment; the pure [`x11_checks`] maps gathered
 //! facts to [`Check`]s and is unit-tested without a display.
 
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::time::Duration;
@@ -14,13 +15,19 @@ use crate::xvfb::Xvfb;
 /// Probe the X11 backend's environment. `deep` additionally spawns and tears down a
 /// private Xvfb (when in self-spawn mode) to prove it actually starts.
 pub fn checks(deep: bool) -> Vec<Check> {
-    let glass_display = std::env::var("GLASS_DISPLAY").ok();
-    let gd = glass_display
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty());
-    let xvfb = resolve_bin(&glass_core::tool_path("GLASS_XVFB", "Xvfb"));
-    let attach_reachable = gd.map(|d| can_connect(&normalize_display(d)));
+    checks_for(std::env::var("GLASS_DISPLAY").ok().as_deref(), deep)
+}
+
+/// The gathering layer, with the one value that selects between attach and self-spawn mode
+/// passed in — mutating `GLASS_DISPLAY` to reach the other mode is `unsafe` under edition
+/// 2024, and process-global besides.
+fn checks_for(glass_display: Option<&str>, deep: bool) -> Vec<Check> {
+    let gd = glass_display.map(str::trim).filter(|s| !s.is_empty());
+    let xvfb = resolve_bin(
+        &glass_core::tool_path("GLASS_XVFB", "Xvfb"),
+        std::env::var_os("PATH").as_deref(),
+    );
+    let attach_reachable = gd.map(|d| can_connect(&crate::platform::normalize_display(d)));
     let deep_spawn = (deep && gd.is_none()).then(probe_xvfb);
     x11_checks(gd, xvfb.as_deref(), attach_reachable, deep_spawn)
 }
@@ -84,30 +91,21 @@ fn x11_checks(
     checks
 }
 
-/// First executable named `name` on `PATH`.
-fn which(name: &str) -> Option<PathBuf> {
-    let path = std::env::var_os("PATH")?;
-    std::env::split_paths(&path)
+/// First existing file named `name` in `path`, a `PATH`-style separated list.
+fn which_in(path: &OsStr, name: &str) -> Option<PathBuf> {
+    std::env::split_paths(path)
         .map(|d| d.join(name))
         .find(|p| p.is_file())
 }
 
 /// Resolve a configured binary to an existing path: an explicit path (contains `/`) must
-/// be an existing file; a bare name is looked up on `PATH`.
-fn resolve_bin(bin: &str) -> Option<PathBuf> {
+/// be an existing file; a bare name is looked up in `path`.
+fn resolve_bin(bin: &str, path: Option<&OsStr>) -> Option<PathBuf> {
     if bin.contains('/') {
         let p = PathBuf::from(bin);
         p.is_file().then_some(p)
     } else {
-        which(bin)
-    }
-}
-
-fn normalize_display(d: &str) -> String {
-    if d.starts_with(':') {
-        d.to_string()
-    } else {
-        format!(":{d}")
+        which_in(path?, bin)
     }
 }
 
@@ -115,17 +113,22 @@ fn can_connect(display: &str) -> bool {
     x11rb::connect(Some(display)).is_ok()
 }
 
+/// Margin over `Xvfb::start`'s own worst case, so the backstop effectively never fires and
+/// the probe thread always finishes and reaps its child.
+const PROBE_MARGIN: Duration = Duration::from_secs(2);
+
+/// How long the deep probe waits. Must exceed `Xvfb::start`'s OWN worst case, which
+/// includes one retry of a wedged server: a shorter budget reports Fail for the exact
+/// transient class the start path survives, with a wrong remedy.
+fn probe_budget() -> Duration {
+    crate::xvfb::start_deadline() + PROBE_MARGIN
+}
+
 /// Spawn a private Xvfb and tear it down, with a timeout so a wedged Xvfb can't hang
 /// doctor. Returns the display it came up on, or an error string.
-///
-/// The budget must cover `Xvfb::start`'s OWN worst case (which includes one
-/// retry of a wedged server) plus margin — a shorter budget here would report
-/// Fail for the exact transient class the start path survives, with a wrong
-/// remedy. Sized that way, the backstop effectively never fires and the probe
-/// thread always finishes and reaps its child (no orphan).
 fn probe_xvfb() -> Result<String, String> {
     let screen = std::env::var("GLASS_XVFB_SCREEN").unwrap_or_else(|_| "1280x800x24".into());
-    let budget = crate::xvfb::start_deadline() + Duration::from_secs(2);
+    let budget = probe_budget();
     let (tx, rx) = mpsc::channel();
     std::thread::spawn(move || {
         // The Xvfb is dropped at the end of `map` (after we read its display),
@@ -180,6 +183,127 @@ mod tests {
         let bad = x11_checks(Some(":42"), None, Some(false), None);
         assert_eq!(bad[0].status, CheckStatus::Fail);
         assert!(bad[0].remedy.is_some());
+    }
+
+    /// A directory holding an executable `name`, plus a second empty directory, returned as
+    /// a `PATH`-style list with the empty one first — so a hit proves the search walked on
+    /// rather than stopping at the head.
+    fn path_containing(name: &str) -> (tempfile::TempDir, std::ffi::OsString, PathBuf) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let empty = dir.path().join("empty");
+        let holding = dir.path().join("holding");
+        std::fs::create_dir_all(&empty).unwrap();
+        std::fs::create_dir_all(&holding).unwrap();
+        let bin = holding.join(name);
+        std::fs::write(&bin, "#!/bin/sh\n").unwrap();
+        let list = std::env::join_paths([&empty, &holding]).expect("join paths");
+        (dir, list, bin)
+    }
+
+    #[test]
+    fn a_bare_name_resolves_to_the_first_directory_holding_it() {
+        let (_dir, path, bin) = path_containing("Xvfb");
+        assert_eq!(resolve_bin("Xvfb", Some(&path)), Some(bin));
+    }
+
+    #[test]
+    fn a_bare_name_absent_from_the_path_resolves_to_nothing() {
+        let (_dir, path, _bin) = path_containing("Xvfb");
+        assert_eq!(resolve_bin("Xorg", Some(&path)), None);
+    }
+
+    #[test]
+    fn an_explicit_path_is_taken_as_given_and_must_exist() {
+        let (_dir, _path, bin) = path_containing("Xvfb");
+        // A configured GLASS_XVFB is a path, not a name to search for — resolving it
+        // through the search list would silently run a different binary.
+        assert_eq!(resolve_bin(bin.to_str().unwrap(), None), Some(bin.clone()));
+        assert_eq!(resolve_bin("/nonexistent/Xvfb", None), None);
+    }
+
+    #[test]
+    fn a_bare_name_with_no_search_list_resolves_to_nothing() {
+        assert_eq!(resolve_bin("Xvfb", None), None);
+    }
+
+    #[test]
+    fn a_live_display_is_reachable_and_an_unused_number_is_not() {
+        let server = Xvfb::start("640x480x24").expect("Xvfb should start");
+        assert!(
+            can_connect(&server.display),
+            "the display we just started must be reachable"
+        );
+        drop(server);
+        assert!(
+            !can_connect(":9999"),
+            "an unused display number must not read as reachable"
+        );
+    }
+
+    #[test]
+    fn the_deep_probe_starts_a_real_display_and_takes_it_back_down() {
+        let display = probe_xvfb().expect("the deep probe should start a display");
+        assert!(
+            display.starts_with(':'),
+            "must report the display it came up on, got {display:?}"
+        );
+        assert!(
+            !can_connect(&display),
+            "{display} outlived the probe that started it"
+        );
+    }
+
+    #[test]
+    fn the_probe_budget_outlasts_the_start_it_wraps() {
+        // Shorter than `Xvfb::start`'s own worst case and the probe reports Fail for the
+        // wedge-and-retry the start path recovers from, with a remedy for the wrong problem.
+        assert!(
+            probe_budget() > crate::xvfb::start_deadline(),
+            "probe budget {:?} must exceed the start deadline {:?}",
+            probe_budget(),
+            crate::xvfb::start_deadline()
+        );
+    }
+
+    #[test]
+    fn a_blank_glass_display_is_treated_as_unset() {
+        // Blank means "self-spawn", so it must not be carried into attach mode and
+        // reported as an unreachable display named "".
+        let cs = checks_for(Some("   "), false);
+        assert!(
+            cs.iter().any(|c| c.name == "Xvfb"),
+            "blank should select self-spawn mode, which checks for Xvfb: {cs:?}"
+        );
+    }
+
+    #[test]
+    fn a_named_glass_display_selects_attach_mode() {
+        let cs = checks_for(Some(":9999"), false);
+        assert!(
+            cs.iter().all(|c| c.name != "Xvfb"),
+            "attach mode must not require Xvfb: {cs:?}"
+        );
+        assert_eq!(cs[0].status, CheckStatus::Fail, "{cs:?}");
+    }
+
+    #[test]
+    fn a_shallow_check_never_spawns_a_display() {
+        // The deep probe costs a real Xvfb start; running it on a shallow check makes
+        // `glass doctor` spawn a server nobody asked for.
+        let cs = checks_for(None, false);
+        assert!(
+            cs.iter().all(|c| c.name != "Xvfb spawn (deep)"),
+            "shallow mode must not run the deep probe: {cs:?}"
+        );
+    }
+
+    #[test]
+    fn the_public_entry_point_reports_the_display_mode() {
+        let cs = checks(false);
+        assert!(
+            cs.iter().any(|c| c.name == "GLASS_DISPLAY"),
+            "doctor must always say which display mode it is in: {cs:?}"
+        );
     }
 
     #[test]

--- a/crates/glass-x11/src/doctor.rs
+++ b/crates/glass-x11/src/doctor.rs
@@ -254,8 +254,6 @@ mod tests {
 
     #[test]
     fn the_probe_budget_outlasts_the_start_it_wraps() {
-        // Shorter than `Xvfb::start`'s own worst case and the probe reports Fail for the
-        // wedge-and-retry the start path recovers from, with a remedy for the wrong problem.
         assert!(
             probe_budget() > crate::xvfb::start_deadline(),
             "probe budget {:?} must exceed the start deadline {:?}",

--- a/crates/glass-x11/src/doctor.rs
+++ b/crates/glass-x11/src/doctor.rs
@@ -189,6 +189,7 @@ mod tests {
     /// a `PATH`-style list with the empty one first — so a hit proves the search walked on
     /// rather than stopping at the head.
     fn path_containing(name: &str) -> (tempfile::TempDir, std::ffi::OsString, PathBuf) {
+        use std::os::unix::fs::PermissionsExt;
         let dir = tempfile::tempdir().expect("temp dir");
         let empty = dir.path().join("empty");
         let holding = dir.path().join("holding");
@@ -196,6 +197,9 @@ mod tests {
         std::fs::create_dir_all(&holding).unwrap();
         let bin = holding.join(name);
         std::fs::write(&bin, "#!/bin/sh\n").unwrap();
+        // Executable, so the test is about the search and not about accepting a file that
+        // could never be spawned.
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
         let list = std::env::join_paths([&empty, &holding]).expect("join paths");
         (dir, list, bin)
     }

--- a/crates/glass-x11/src/doctor.rs
+++ b/crates/glass-x11/src/doctor.rs
@@ -243,13 +243,12 @@ mod tests {
     #[test]
     fn the_deep_probe_starts_a_real_display_and_takes_it_back_down() {
         let display = probe_xvfb().expect("the deep probe should start a display");
+        // Only the report is asserted. Whether the number still answers is not this test's
+        // to check: display numbers are a machine-wide namespace, and the next server to
+        // start — in this suite or outside it — takes the one the probe just released.
         assert!(
             display.starts_with(':'),
             "must report the display it came up on, got {display:?}"
-        );
-        assert!(
-            !can_connect(&display),
-            "{display} outlived the probe that started it"
         );
     }
 

--- a/crates/glass-x11/src/lib.rs
+++ b/crates/glass-x11/src/lib.rs
@@ -12,6 +12,10 @@ pub mod coords;
 pub mod doctor;
 pub mod pixels;
 pub mod platform;
+// A separate file, declared `#[cfg(test)]`: cargo-mutants stops at an excluded `mod` before
+// it records the external file, so the harness itself never gets mutated.
+#[cfg(test)]
+mod testx;
 pub mod xvfb;
 pub use platform::X11Platform;
 pub use xvfb::Xvfb;

--- a/crates/glass-x11/src/lib.rs
+++ b/crates/glass-x11/src/lib.rs
@@ -1,4 +1,10 @@
 //! glass-x11: the Linux/X11 `glass_core::Platform` backend.
+//!
+//! Half this backend's coverage lives elsewhere: the `#[ignore]`d X11 suite in
+//! `crates/glass-testapp/tests/integration.rs` drives it end to end against a real app
+//! (`scripts/test-x11.sh`). Do not read "no test here" as untested. The two halves do not
+//! substitute for each other — that suite cannot kill a mutant, because the gate runs
+//! `cargo nextest run -p glass-x11` and skips `#[ignore]`d tests in another package.
 
 #![cfg(target_os = "linux")]
 

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -2076,6 +2076,556 @@ mod display_tests {
         assert_eq!(x.focused(), win);
     }
 
+    // --- the Platform surface --------------------------------------------------------
+
+    /// A real child to stand in for a launched app. The pid accessors, window enumeration
+    /// and the close ladder all read `self.child`, and `_NET_WM_PID` matching needs a pid
+    /// that is genuinely in `/proc`. `sleep` leaves on its own, so a test that panics before
+    /// its teardown cannot strand it.
+    fn spawn_stand_in() -> std::process::Child {
+        std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("the stand-in app should spawn")
+    }
+
+    /// The buttons and their positions a watching window saw, as `(detail, x, y)`.
+    fn clicks_seen(x: &TestX) -> Vec<(u8, i16, i16)> {
+        x.drain_events(Duration::from_millis(80))
+            .into_iter()
+            .filter_map(|e| match e {
+                x11rb::protocol::Event::ButtonPress(b) => Some((b.detail, b.event_x, b.event_y)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn the_app_pid_and_its_tree_are_empty_until_something_is_launched() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        assert_eq!(plat.app_pid(), None);
+        assert!(plat.app_pids().is_empty());
+
+        let child = spawn_stand_in();
+        let pid = child.id();
+        plat.child = Some(child);
+        assert_eq!(plat.app_pid(), Some(pid));
+        assert!(
+            plat.app_pids().contains(&pid),
+            "the process tree must include the launched child itself"
+        );
+    }
+
+    #[test]
+    fn there_is_no_a11y_bus_address_without_a_bus() {
+        let x = TestX::start();
+        let plat = x.platform();
+        assert_eq!(
+            plat.a11y_bus_addr(),
+            None,
+            "a launch that did not ask for a11y must not advertise an address"
+        );
+    }
+
+    #[test]
+    fn draining_logs_hands_over_the_buffer_and_leaves_it_empty() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        plat.logs
+            .lock()
+            .expect("log buffer")
+            .push((Stream::Stdout, "hello".to_string()));
+        assert_eq!(
+            plat.drain_logs(),
+            vec![(Stream::Stdout, "hello".to_string())]
+        );
+        assert!(
+            plat.drain_logs().is_empty(),
+            "a drain must not hand back what it already returned"
+        );
+    }
+
+    #[test]
+    fn a_click_presses_the_mapped_button_at_the_requested_point() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let win = x
+            .window()
+            .at(0, 0)
+            .sized(400, 400)
+            .watching_input()
+            .create();
+        plat.window = Some(win);
+        let _ = x.drain_events(Duration::from_millis(50));
+
+        plat.send_pointer(&PointerEvent::Click {
+            x: 30,
+            y: 40,
+            button: glass_core::MouseButton::Right,
+            count: 2,
+            modifiers: vec![],
+        })
+        .expect("click");
+
+        assert_eq!(
+            clicks_seen(&x),
+            vec![(3, 30, 40), (3, 30, 40)],
+            "a double right-click is button 3 twice, at the point asked for"
+        );
+    }
+
+    #[test]
+    fn a_scroll_clicks_the_wheel_buttons_for_each_axis() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let win = x
+            .window()
+            .at(0, 0)
+            .sized(400, 400)
+            .watching_input()
+            .create();
+        plat.window = Some(win);
+        let _ = x.drain_events(Duration::from_millis(50));
+
+        plat.send_pointer(&PointerEvent::Scroll {
+            x: 5,
+            y: 5,
+            dx: 0,
+            dy: -2,
+            modifiers: vec![],
+        })
+        .expect("scroll");
+
+        let buttons: Vec<u8> = clicks_seen(&x).into_iter().map(|(b, _, _)| b).collect();
+        assert_eq!(buttons, vec![4, 4], "scrolling up twice is button 4 twice");
+    }
+
+    #[test]
+    fn a_drag_presses_at_the_start_and_releases_at_the_end() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let win = x
+            .window()
+            .at(0, 0)
+            .sized(400, 400)
+            .watching_input()
+            .create();
+        plat.window = Some(win);
+        let _ = x.drain_events(Duration::from_millis(50));
+
+        plat.send_pointer(&PointerEvent::Drag {
+            from_x: 10,
+            from_y: 10,
+            to_x: 200,
+            to_y: 150,
+            button: glass_core::MouseButton::Left,
+            modifiers: vec![],
+            duration_ms: 40,
+        })
+        .expect("drag");
+
+        let events = x.drain_events(Duration::from_millis(80));
+        let press = events.iter().find_map(|e| match e {
+            x11rb::protocol::Event::ButtonPress(b) => Some((b.event_x, b.event_y)),
+            _ => None,
+        });
+        let release = events.iter().find_map(|e| match e {
+            x11rb::protocol::Event::ButtonRelease(b) => Some((b.event_x, b.event_y)),
+            _ => None,
+        });
+        assert_eq!(press, Some((10, 10)), "the button goes down at the start");
+        assert_eq!(release, Some((200, 150)), "and comes up at the end");
+    }
+
+    #[test]
+    fn a_multi_touch_gesture_is_refused_by_this_backend() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let win = x.window().create();
+        plat.window = Some(win);
+        let err = plat
+            .send_pointer(&PointerEvent::Gesture {
+                pointers: vec![glass_core::Segment {
+                    from_x: 0,
+                    from_y: 0,
+                    to_x: 10,
+                    to_y: 10,
+                }],
+                duration_ms: 10,
+            })
+            .expect_err("X11 has no multi-touch");
+        assert!(err.to_string().contains("multi_touch"), "{err}");
+    }
+
+    #[test]
+    fn typed_text_sends_one_key_per_character() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let win = x.window().watching_input().create();
+        plat.window = Some(win);
+        plat.focus_window(win).expect("focus");
+        commit(&plat);
+        let _ = x.drain_events(Duration::from_millis(50));
+
+        plat.send_key(&KeyEvent::Text("ab".to_string()))
+            .expect("type");
+
+        let pressed: Vec<u8> = x
+            .drain_events(Duration::from_millis(120))
+            .into_iter()
+            .filter_map(|e| match e {
+                x11rb::protocol::Event::KeyPress(k) => Some(k.detail),
+                _ => None,
+            })
+            .collect();
+        let a = plat.keycode_for(KEYSYM_A).expect("a").0;
+        let b = plat.keycode_for(0x62).expect("b").0;
+        assert_eq!(pressed, vec![a, b], "each character in order");
+    }
+
+    #[test]
+    fn a_chord_holds_its_modifier_across_the_key() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let win = x.window().watching_input().create();
+        plat.window = Some(win);
+        plat.focus_window(win).expect("focus");
+        commit(&plat);
+        let _ = x.drain_events(Duration::from_millis(50));
+
+        plat.send_key(&KeyEvent::Chord("ctrl+a".to_string()))
+            .expect("chord");
+
+        let control = plat
+            .modifier_keycode(glass_core::keys::Modifier::Control)
+            .expect("control");
+        let a = plat.keycode_for(KEYSYM_A).expect("a").0;
+        let pressed: Vec<u8> = x
+            .drain_events(Duration::from_millis(80))
+            .into_iter()
+            .filter_map(|e| match e {
+                x11rb::protocol::Event::KeyPress(k) => Some(k.detail),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            pressed,
+            vec![control, a],
+            "the modifier goes down before the key it modifies"
+        );
+    }
+
+    #[test]
+    fn a_window_op_moves_and_resizes_and_reports_the_result() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let win = x.window().at(5, 5).sized(100, 80).create();
+        plat.window = Some(win);
+
+        let resized = plat
+            .window(&WindowOp::Resize {
+                width: 321,
+                height: 211,
+            })
+            .expect("resize");
+        assert_eq!((resized.width, resized.height), (321, 211));
+
+        let moved = plat.window(&WindowOp::Move { x: 40, y: 60 }).expect("move");
+        assert_eq!((moved.x, moved.y), (40, 60));
+        assert_eq!(
+            (moved.width, moved.height),
+            (321, 211),
+            "a move must not resize"
+        );
+
+        let same = plat.window(&WindowOp::Geometry).expect("geometry");
+        assert_eq!(same, moved, "a bare geometry read changes nothing");
+    }
+
+    #[test]
+    fn listing_windows_reports_the_apps_windows_and_marks_the_active_one() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let child = spawn_stand_in();
+        let pid = child.id();
+        plat.child = Some(child);
+        let main = x
+            .window()
+            .owned_by(pid)
+            .named("main")
+            .classed("app", "App")
+            .at(3, 4)
+            .sized(150, 120)
+            .create();
+        let other = x.window().owned_by(pid).named("other").create();
+        plat.window = Some(main);
+
+        let listed = plat.list_windows().expect("list");
+        let entry = listed
+            .iter()
+            .find(|w| w.id == WindowId(main as u64))
+            .expect("the active window must be listed");
+        assert_eq!(entry.title.as_deref(), Some("main"));
+        assert_eq!(entry.class.as_deref(), Some("App"));
+        assert_eq!(
+            entry.geometry,
+            WindowGeometry {
+                x: 3,
+                y: 4,
+                width: 150,
+                height: 120
+            }
+        );
+        assert!(entry.active, "the active window must be flagged as active");
+        let sibling = listed
+            .iter()
+            .find(|w| w.id == WindowId(other as u64))
+            .expect("the app's other window must be listed too");
+        assert!(!sibling.active, "only one window is the active one");
+    }
+
+    #[test]
+    fn listing_windows_without_an_active_one_is_an_error_not_an_empty_list() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        assert!(matches!(
+            plat.list_windows(),
+            Err(GlassError::WindowNotFound)
+        ));
+    }
+
+    #[test]
+    fn selecting_a_window_makes_it_active_and_refuses_one_that_is_not_the_apps() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let child = spawn_stand_in();
+        let pid = child.id();
+        plat.child = Some(child);
+        let mine = x.window().owned_by(pid).at(9, 8).sized(70, 60).create();
+        let stranger = x.window().owned_by(999_999).create();
+        plat.window = Some(mine);
+
+        let geo = plat
+            .select_window(WindowId(mine as u64))
+            .expect("selecting the app's own window");
+        assert_eq!((geo.x, geo.y, geo.width, geo.height), (9, 8, 70, 60));
+        assert_eq!(plat.window, Some(mine));
+
+        assert!(
+            matches!(
+                plat.select_window(WindowId(stranger as u64)),
+                Err(GlassError::WindowNotFound)
+            ),
+            "a window outside the launched process tree is not selectable"
+        );
+    }
+
+    #[test]
+    fn capturing_a_named_window_reads_that_windows_own_area() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let child = spawn_stand_in();
+        let pid = child.id();
+        plat.child = Some(child);
+        let win = x
+            .window()
+            .owned_by(pid)
+            .at(0, 0)
+            .sized(48, 32)
+            .filled_with(0x0000_00ff)
+            .create();
+        plat.window = Some(win);
+        x.flush();
+
+        let frame = plat
+            .capture_window(WindowId(win as u64), None)
+            .expect("capture");
+        assert_eq!((frame.width, frame.height), (48, 32));
+
+        let stranger = x.window().owned_by(999_999).create();
+        assert!(
+            matches!(
+                plat.capture_window(WindowId(stranger as u64), None),
+                Err(GlassError::WindowNotFound)
+            ),
+            "a window the app does not own is not capturable"
+        );
+    }
+
+    // --- the close ladder ------------------------------------------------------------
+
+    #[test]
+    fn only_a_window_advertising_wm_delete_window_can_be_asked_to_close() {
+        let x = TestX::start();
+        let plat = x.platform();
+        let protocols = plat.intern(b"WM_PROTOCOLS").expect("intern");
+        let delete = plat.intern(b"WM_DELETE_WINDOW").expect("intern");
+
+        let polite = x.window().accepting_delete().create();
+        let silent = x.window().create();
+        assert!(plat.accepts_delete(polite, protocols, delete));
+        assert!(
+            !plat.accepts_delete(silent, protocols, delete),
+            "a window with no WM_PROTOCOLS cannot be asked, and must not be counted as asked"
+        );
+    }
+
+    #[test]
+    fn a_close_request_arrives_as_the_delete_client_message() {
+        let x = TestX::start();
+        let plat = x.platform();
+        let protocols = plat.intern(b"WM_PROTOCOLS").expect("intern");
+        let delete = plat.intern(b"WM_DELETE_WINDOW").expect("intern");
+        let win = x.window().accepting_delete().create();
+
+        plat.send_delete(win, protocols, delete).expect("send");
+        commit(&plat);
+
+        let message = x
+            .next_event(Duration::from_secs(2))
+            .expect("the window's owner should receive the request");
+        match message {
+            x11rb::protocol::Event::ClientMessage(m) => {
+                assert_eq!(m.window, win);
+                assert_eq!(m.type_, protocols);
+                assert_eq!(
+                    m.data.as_data32()[0],
+                    delete,
+                    "the protocol atom comes first, as ICCCM 4.2.8 specifies"
+                );
+            }
+            other => panic!("expected a ClientMessage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn asking_the_app_to_close_reaches_every_window_that_accepts_it() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let child = spawn_stand_in();
+        let pid = child.id();
+        plat.child = Some(child);
+        let polite = x.window().owned_by(pid).accepting_delete().create();
+        plat.window = Some(polite);
+
+        let asked = plat.request_close(pid);
+        assert!(asked.any(), "the app's window should have been asked");
+        assert!(
+            x.next_event(Duration::from_secs(2)).is_some(),
+            "the request must actually reach the window"
+        );
+    }
+
+    #[test]
+    fn an_app_with_no_window_is_not_reported_as_asked() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let child = spawn_stand_in();
+        let pid = child.id();
+        plat.child = Some(child);
+        assert!(
+            !plat.request_close(pid).any(),
+            "there was no window to ask, so nothing was asked"
+        );
+    }
+
+    #[test]
+    fn the_bounded_ask_reaches_the_window_through_its_own_connection() {
+        // The ask runs on a second connection so the caller can abandon it without leaving
+        // this backend's connection stopped mid-request.
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let child = spawn_stand_in();
+        let pid = child.id();
+        plat.child = Some(child);
+        let polite = x.window().owned_by(pid).accepting_delete().create();
+        plat.window = Some(polite);
+
+        assert!(plat.request_close_bounded(pid).any());
+        assert!(
+            x.next_event(Duration::from_secs(2)).is_some(),
+            "the bounded ask must deliver the same request"
+        );
+    }
+
+    #[test]
+    fn stopping_the_app_reaps_the_child_and_forgets_it() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let child = spawn_stand_in();
+        let pid = child.id();
+        plat.child = Some(child);
+
+        plat.stop_app().expect("stop");
+        assert_eq!(plat.app_pid(), None, "the child must be forgotten");
+        assert!(
+            !std::path::Path::new(&format!("/proc/{pid}")).exists(),
+            "pid {pid} outlived the stop that was supposed to reap it"
+        );
+    }
+
+    #[test]
+    fn dropping_the_backend_reaps_an_app_that_was_never_stopped() {
+        // Parity with the other backends: a panic-unwind or the process-exit backstop must
+        // not leave the launched app running.
+        let x = TestX::start();
+        let pid = {
+            let mut plat = x.platform();
+            let child = spawn_stand_in();
+            let pid = child.id();
+            plat.child = Some(child);
+            pid
+        };
+        assert!(
+            !std::path::Path::new(&format!("/proc/{pid}")).exists(),
+            "pid {pid} outlived the backend that launched it"
+        );
+    }
+
+    #[test]
+    fn a_launch_whose_app_never_appears_is_a_timeout_and_leaves_nothing_running() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let spec = AppSpec {
+            build: None,
+            run: vec!["sleep".to_string(), "30".to_string()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 250,
+            sandbox: glass_core::SandboxLevel::Off,
+            a11y: false,
+        };
+        let err = plat
+            .start_app(&spec)
+            .expect_err("a command that maps no window cannot be launched");
+        assert!(matches!(err, GlassError::Timeout(250)), "{err:?}");
+        assert_eq!(
+            plat.app_pid(),
+            None,
+            "a launch that failed must not leave its child behind"
+        );
+    }
+
+    #[test]
+    fn a_launch_whose_command_does_not_exist_reports_the_spawn_failure() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let spec = AppSpec {
+            build: None,
+            run: vec!["/nonexistent/glass-test-binary".to_string()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 250,
+            sandbox: glass_core::SandboxLevel::Off,
+            a11y: false,
+        };
+        let err = plat.start_app(&spec).expect_err("nothing to spawn");
+        assert!(matches!(err, GlassError::AppNotStarted(_)), "{err:?}");
+    }
+
     // --- capture ---------------------------------------------------------------------
 
     #[test]

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -688,19 +688,14 @@ impl X11Platform {
             .map_err(|e| GlassError::Backend(format!("get_keyboard_mapping: {e}")))?
             .reply()
             .map_err(|e| GlassError::Backend(format!("keyboard mapping reply: {e}")))?;
-        let per = mapping.keysyms_per_keycode as usize;
-        for kc in min..=max {
-            let base = (kc as usize - min as usize) * per;
-            if mapping.keysyms.get(base) == Some(&keysym) {
-                return Ok((kc, false));
-            }
-            if per > 1 && mapping.keysyms.get(base + 1) == Some(&keysym) {
-                return Ok((kc, true));
-            }
-        }
-        Err(GlassError::InvalidKey(format!(
-            "no keycode for keysym 0x{keysym:x}"
-        )))
+        keycode_in(
+            &mapping.keysyms,
+            mapping.keysyms_per_keycode as usize,
+            min,
+            max,
+            keysym,
+        )
+        .ok_or_else(|| GlassError::InvalidKey(format!("no keycode for keysym 0x{keysym:x}")))
     }
 
     fn modifier_keycode(&self, m: glass_core::keys::Modifier) -> Result<u8> {
@@ -875,18 +870,24 @@ impl X11Platform {
     }
 }
 
-/// Emit a one-line diagnostic when a capture was clipped to the display, so the
-/// smaller-than-requested frame the caller receives isn't a silent surprise.
-/// glass's own stderr is its diagnostic channel (same as the focus-on-launch
-/// warning); the MCP `screenshot` result additionally reports the true (clipped)
-/// dimensions, so a frame smaller than the window/region signals the clip.
-fn note_if_clipped(rect: &crate::coords::ClippedRect) {
-    if rect.clipped {
-        eprintln!(
+/// The diagnostic for a capture that was clipped to the display, or `None` when the whole
+/// requested rectangle was read — so the smaller-than-requested frame the caller receives
+/// isn't a silent surprise. glass's own stderr is its diagnostic channel (same as the
+/// focus-on-launch warning); the MCP `screenshot` result additionally reports the true
+/// (clipped) dimensions, so a frame smaller than the window/region signals the clip.
+fn clip_note(rect: &crate::coords::ClippedRect) -> Option<String> {
+    rect.clipped.then(|| {
+        format!(
             "glass: capture reached past the headless display and was clipped to the visible \
              {}x{} region at ({},{}); returning a partial frame",
             rect.w, rect.h, rect.sx, rect.sy
-        );
+        )
+    })
+}
+
+fn note_if_clipped(rect: &crate::coords::ClippedRect) {
+    if let Some(note) = clip_note(rect) {
+        eprintln!("{note}");
     }
 }
 
@@ -1400,6 +1401,25 @@ impl Drop for X11Platform {
     }
 }
 
+/// Search a `GetKeyboardMapping` table for `keysym`, returning the keycode that produces it
+/// and whether Shift is needed — column 0 is the unshifted keysym, column 1 the shifted one.
+///
+/// `keysyms` is the flat table for keycodes `min..=max`, `per` entries each. Split out from
+/// the request around it so the indexing is reachable from a test with a table it chose:
+/// against a live server every arithmetic slip here still lands on *some* real key.
+fn keycode_in(keysyms: &[u32], per: usize, min: u8, max: u8, keysym: u32) -> Option<(u8, bool)> {
+    for kc in min..=max {
+        let base = (kc as usize - min as usize) * per;
+        if keysyms.get(base) == Some(&keysym) {
+            return Some((kc, false));
+        }
+        if per > 1 && keysyms.get(base + 1) == Some(&keysym) {
+            return Some((kc, true));
+        }
+    }
+    None
+}
+
 fn button_number(button: glass_core::MouseButton) -> u8 {
     match button {
         glass_core::MouseButton::Left => 1,
@@ -1722,6 +1742,377 @@ mod display_tests {
         let win = x.window().owned_by(4242).create();
         x.set_client_list(&[win]);
         assert_eq!(plat.scan_all_windows(&[4242]).expect("scan"), vec![win]);
+    }
+
+    // --- XTEST input -----------------------------------------------------------------
+    //
+    // Every assertion here reads the server's own state or the events a watching window
+    // received. `Ok(())` from an input call means the request was written, not that anything
+    // moved — which is exactly what the mutants replacing these bodies return.
+
+    /// The keysym for a plain lowercase `a`, and for the shifted `A` on the same key.
+    const KEYSYM_A: u32 = 0x61;
+    const KEYSYM_SHIFT_A: u32 = 0x41;
+    const KEYSYM_SHIFT_L: u32 = 0xffe1;
+
+    /// Push the backend's buffered requests and wait for the server to have processed them.
+    /// The input primitives do not flush — the sinks above them commit a whole gesture at
+    /// once — and a flush alone would not be enough here anyway: these tests read the result
+    /// over a *second* connection, which is ordered against the first only by a round trip.
+    fn commit(plat: &X11Platform) {
+        plat.conn.sync().expect("sync");
+    }
+
+    #[test]
+    fn a_warp_moves_the_pointer_to_the_windows_origin_plus_the_offset() {
+        let x = TestX::start();
+        let plat = x.platform();
+        plat.warp(100, 50, 7, 9).expect("warp");
+        commit(&plat);
+        let (px, py, _) = x.pointer();
+        assert_eq!((px, py), (107, 59));
+    }
+
+    #[test]
+    fn a_button_press_is_held_until_it_is_released() {
+        let x = TestX::start();
+        let plat = x.platform();
+        plat.button(XT_BTN_PRESS, 1).expect("press");
+        commit(&plat);
+        assert!(
+            x.pointer().2.contains(KeyButMask::BUTTON1),
+            "button 1 should read as down between press and release"
+        );
+        plat.button(XT_BTN_RELEASE, 1).expect("release");
+        commit(&plat);
+        assert!(!x.pointer().2.contains(KeyButMask::BUTTON1));
+    }
+
+    /// The buttons a window watching input saw pressed, in order.
+    fn buttons_pressed(x: &TestX) -> Vec<u8> {
+        x.drain_events(Duration::from_millis(50))
+            .into_iter()
+            .filter_map(|e| match e {
+                x11rb::protocol::Event::ButtonPress(b) => Some(b.detail),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn a_positive_scroll_clicks_the_positive_button_once_per_step() {
+        let x = TestX::start();
+        let plat = x.platform();
+        let win = x
+            .window()
+            .at(0, 0)
+            .sized(400, 400)
+            .watching_input()
+            .create();
+        plat.warp(0, 0, 10, 10).expect("warp into the window");
+        commit(&plat);
+        let _ = x.drain_events(Duration::from_millis(50));
+
+        plat.scroll_button(4, 5, 3).expect("scroll");
+        commit(&plat);
+        assert_eq!(buttons_pressed(&x), vec![4, 4, 4], "window {win}");
+    }
+
+    #[test]
+    fn a_negative_scroll_clicks_the_negative_button_that_many_times() {
+        // The magnitude, not the signed value: a step count that stayed negative would
+        // produce an empty range and scroll nothing at all.
+        let x = TestX::start();
+        let plat = x.platform();
+        x.window()
+            .at(0, 0)
+            .sized(400, 400)
+            .watching_input()
+            .create();
+        plat.warp(0, 0, 10, 10).expect("warp into the window");
+        commit(&plat);
+        let _ = x.drain_events(Duration::from_millis(50));
+
+        plat.scroll_button(4, 5, -2).expect("scroll");
+        commit(&plat);
+        assert_eq!(buttons_pressed(&x), vec![5, 5]);
+    }
+
+    #[test]
+    fn an_unmapped_keysym_is_an_invalid_key_not_some_other_keycode() {
+        let x = TestX::start();
+        let plat = x.platform();
+        let err = plat
+            .keycode_for(0x00ff_fffe)
+            .expect_err("a keysym no key produces has no keycode");
+        assert!(matches!(err, GlassError::InvalidKey(_)), "{err:?}");
+    }
+
+    #[test]
+    fn a_keysym_resolves_to_a_keycode_that_really_carries_it() {
+        // Checked against the server's own table rather than a hardcoded keycode, which
+        // varies with the keymap the runner happens to load.
+        let x = TestX::start();
+        let plat = x.platform();
+        let (min, _max, per, keysyms) = x.keymap();
+
+        let (kc, shifted) = plat.keycode_for(KEYSYM_A).expect("`a` must be typeable");
+        let base = (kc as usize - min as usize) * per;
+        assert!(!shifted, "plain `a` needs no Shift");
+        assert_eq!(keysyms.get(base), Some(&KEYSYM_A));
+
+        let (kc_upper, shifted_upper) = plat
+            .keycode_for(KEYSYM_SHIFT_A)
+            .expect("`A` must be typeable");
+        assert!(shifted_upper, "`A` is the shifted column of its key");
+        let base_upper = (kc_upper as usize - min as usize) * per;
+        assert_eq!(keysyms.get(base_upper + 1), Some(&KEYSYM_SHIFT_A));
+    }
+
+    #[test]
+    fn every_keysym_the_server_maps_can_be_resolved() {
+        // A mapping request one keycode short still resolves nearly everything; only the
+        // keys at the very end of the range go missing.
+        let x = TestX::start();
+        let plat = x.platform();
+        let (min, max, per, keysyms) = x.keymap();
+        let mut checked = 0;
+        for kc in min..=max {
+            let base = (kc as usize - min as usize) * per;
+            for col in 0..per.min(2) {
+                match keysyms.get(base + col) {
+                    Some(&sym) if sym != 0 => {
+                        assert!(
+                            plat.keycode_for(sym).is_ok(),
+                            "keysym 0x{sym:x} is on keycode {kc} but did not resolve"
+                        );
+                        checked += 1;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        assert!(checked > 20, "the keymap looks empty ({checked} keysyms)");
+    }
+
+    #[test]
+    fn each_modifier_resolves_to_its_own_real_keycode() {
+        let x = TestX::start();
+        let plat = x.platform();
+        use glass_core::keys::Modifier;
+        let shift = plat.modifier_keycode(Modifier::Shift).expect("shift");
+        let control = plat.modifier_keycode(Modifier::Control).expect("control");
+        assert_eq!(
+            shift,
+            plat.keycode_for(KEYSYM_SHIFT_L).expect("shift sym").0
+        );
+        assert_ne!(
+            shift, control,
+            "distinct modifiers cannot share one keycode"
+        );
+    }
+
+    #[test]
+    fn tapping_a_keycode_presses_and_releases_it_at_the_focused_window() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let win = x.window().watching_input().create();
+        plat.focus_window(win).expect("focus");
+        commit(&plat);
+        let _ = x.drain_events(Duration::from_millis(50));
+
+        let (kc, _) = plat.keycode_for(KEYSYM_A).expect("keycode");
+        plat.tap_keycode(kc).expect("tap");
+        commit(&plat);
+
+        let events = x.drain_events(Duration::from_millis(50));
+        let presses: Vec<u8> = events
+            .iter()
+            .filter_map(|e| match e {
+                x11rb::protocol::Event::KeyPress(k) => Some(k.detail),
+                _ => None,
+            })
+            .collect();
+        let releases: Vec<u8> = events
+            .iter()
+            .filter_map(|e| match e {
+                x11rb::protocol::Event::KeyRelease(k) => Some(k.detail),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(presses, vec![kc], "{events:?}");
+        assert_eq!(releases, vec![kc], "a tap must not leave the key down");
+    }
+
+    #[test]
+    fn pressing_modifiers_holds_them_down_and_releasing_lets_them_go() {
+        let x = TestX::start();
+        let plat = x.platform();
+        use glass_core::keys::Modifier;
+        let held = plat
+            .press_mods(&[Modifier::Shift, Modifier::Control])
+            .expect("press");
+        commit(&plat);
+        assert_eq!(
+            held,
+            vec![
+                plat.modifier_keycode(Modifier::Shift).unwrap(),
+                plat.modifier_keycode(Modifier::Control).unwrap()
+            ],
+            "the returned keycodes are what release_mods is given"
+        );
+        for kc in &held {
+            assert!(x.key_is_down(*kc), "keycode {kc} should be held down");
+        }
+        plat.release_mods(&held).expect("release");
+        commit(&plat);
+        for kc in &held {
+            assert!(!x.key_is_down(*kc), "keycode {kc} was left down");
+        }
+    }
+
+    /// The keycodes a watching window saw pressed while `f` ran, with focus already on it.
+    fn keys_pressed_during(
+        x: &TestX,
+        plat: &mut X11Platform,
+        f: impl FnOnce(&mut X11Platform),
+    ) -> Vec<u8> {
+        let win = x.window().watching_input().create();
+        plat.focus_window(win).expect("focus");
+        commit(plat);
+        let _ = x.drain_events(Duration::from_millis(50));
+        f(plat);
+        commit(plat);
+        x.drain_events(Duration::from_millis(50))
+            .into_iter()
+            .filter_map(|e| match e {
+                x11rb::protocol::Event::KeyPress(k) => Some(k.detail),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn an_uppercase_letter_is_typed_with_shift_held() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let shift = plat
+            .modifier_keycode(glass_core::keys::Modifier::Shift)
+            .expect("shift");
+        let pressed = keys_pressed_during(&x, &mut plat, |p| {
+            p.key_with_mods(KEYSYM_SHIFT_A, false, &[]).expect("type A");
+        });
+        assert!(
+            pressed.contains(&shift),
+            "`A` lives in the shifted column, so Shift must go down first: {pressed:?}"
+        );
+    }
+
+    #[test]
+    fn a_lowercase_letter_is_typed_without_shift() {
+        // Holding Shift for an unshifted key turns `a` into `A` at the application.
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let shift = plat
+            .modifier_keycode(glass_core::keys::Modifier::Shift)
+            .expect("shift");
+        let pressed = keys_pressed_during(&x, &mut plat, |p| {
+            p.key_with_mods(KEYSYM_A, false, &[]).expect("type a");
+        });
+        assert!(
+            !pressed.contains(&shift),
+            "Shift must not be pressed for a plain `a`: {pressed:?}"
+        );
+    }
+
+    #[test]
+    fn focusing_a_window_makes_the_server_route_keys_to_it() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let win = x.window().create();
+        plat.focus_window(win).expect("focus");
+        commit(&plat);
+        assert_eq!(x.focused(), win);
+    }
+
+    // --- capture ---------------------------------------------------------------------
+
+    #[test]
+    fn a_zero_area_region_is_rejected_before_a_doomed_get_image() {
+        let x = TestX::start();
+        let plat = x.platform();
+        let geo = WindowGeometry {
+            x: 0,
+            y: 0,
+            width: 200,
+            height: 100,
+        };
+        let flat = Region {
+            x: 0,
+            y: 0,
+            width: 0,
+            height: 40,
+        };
+        assert!(
+            plat.resolve_capture_rect(&geo, Some(&flat)).is_err(),
+            "a region with no width has no pixels to read"
+        );
+        let thin = Region {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 0,
+        };
+        assert!(plat.resolve_capture_rect(&geo, Some(&thin)).is_err());
+        assert!(
+            plat.resolve_capture_rect(&geo, None).is_ok(),
+            "a window with area must still resolve"
+        );
+    }
+
+    #[test]
+    fn a_capture_reads_the_pixels_that_are_actually_on_screen() {
+        // Everything in the decode path — the plane mask, the depth lookup and the
+        // bytes-per-pixel it yields — is only observable in the pixels that come back.
+        let x = TestX::start();
+        let plat = x.platform();
+        x.window()
+            .at(0, 0)
+            .sized(64, 64)
+            .filled_with(0x00ff_0000)
+            .create();
+        x.flush();
+
+        let frame = plat.capture_screen_rect(0, 0, 64, 64).expect("capture");
+        assert_eq!((frame.width, frame.height), (64, 64));
+        let px = &frame.pixels[..4];
+        assert_eq!(
+            (px[0], px[1], px[2]),
+            (0xff, 0x00, 0x00),
+            "the red window should read back as red, got {px:?}"
+        );
+    }
+
+    #[test]
+    fn a_clip_note_is_produced_only_when_the_capture_was_clipped() {
+        use crate::coords::ClippedRect;
+        let clipped = ClippedRect {
+            sx: 0,
+            sy: 0,
+            w: 320,
+            h: 200,
+            clipped: true,
+        };
+        let note = clip_note(&clipped).expect("a clipped capture must say so");
+        assert!(note.contains("320x200"), "{note}");
+        assert!(
+            clip_note(&ClippedRect {
+                clipped: false,
+                ..clipped
+            })
+            .is_none(),
+            "an unclipped capture has nothing to report"
+        );
     }
 
     #[test]

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -1480,6 +1480,270 @@ mod tests {
     }
 }
 
+/// Everything the backend can only do against a real display: enumerating windows, reading
+/// their properties, translating the server's errors, and driving XTEST.
+#[cfg(test)]
+mod display_tests {
+    use super::*;
+    use crate::testx::TestX;
+
+    /// A pid no window on a fresh private display can be carrying.
+    const OTHER_PID: u32 = 999_999;
+
+    #[test]
+    fn interning_is_stable_per_name_and_distinct_across_names() {
+        let x = TestX::start();
+        let plat = x.platform();
+        let pid = plat.intern(b"_NET_WM_PID").expect("intern");
+        assert_ne!(pid, 0, "an interned atom is never the null atom");
+        assert_eq!(pid, plat.intern(b"_NET_WM_PID").expect("intern"));
+        assert_ne!(pid, plat.intern(b"_NET_CLIENT_LIST").expect("intern"));
+    }
+
+    #[test]
+    fn there_is_no_active_window_until_one_is_selected() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        assert!(matches!(
+            plat.require_window(),
+            Err(GlassError::WindowNotFound)
+        ));
+        let win = x.window().create();
+        plat.window = Some(win);
+        assert_eq!(plat.require_window().expect("now set"), win);
+    }
+
+    #[test]
+    fn a_windows_name_is_read_back_and_absence_is_not_an_empty_string() {
+        let x = TestX::start();
+        let plat = x.platform();
+        let named = x.window().named("Calculator").create();
+        let anonymous = x.window().create();
+        assert_eq!(plat.window_name(named).as_deref(), Some("Calculator"));
+        assert_eq!(
+            plat.window_name(anonymous),
+            None,
+            "a window with no WM_NAME has no name, rather than an empty one"
+        );
+    }
+
+    #[test]
+    fn a_windows_class_is_read_back_as_the_instance_class_pair() {
+        let x = TestX::start();
+        let plat = x.platform();
+        let win = x.window().classed("xcalc", "XCalc").create();
+        assert_eq!(
+            plat.window_class(win),
+            Some(("xcalc".to_string(), "XCalc".to_string()))
+        );
+        assert_eq!(plat.window_class(x.window().create()), None);
+    }
+
+    #[test]
+    fn a_single_component_class_stands_for_both_halves() {
+        // ICCCM wants `instance\0class\0`; some apps write only one string, and dropping the
+        // pair rather than doubling it would make their windows unmatchable by class.
+        let x = TestX::start();
+        let plat = x.platform();
+        let win = x.window().classed("solo", "").create();
+        assert_eq!(
+            plat.window_class(win),
+            Some(("solo".to_string(), "solo".to_string()))
+        );
+    }
+
+    #[test]
+    fn geometry_is_reported_in_root_coordinates() {
+        let x = TestX::start();
+        let plat = x.platform();
+        let win = x.window().at(37, 53).sized(321, 211).create();
+        assert_eq!(
+            plat.geometry_of(win).expect("geometry"),
+            WindowGeometry {
+                x: 37,
+                y: 53,
+                width: 321,
+                height: 211
+            }
+        );
+    }
+
+    #[test]
+    fn the_active_windows_geometry_is_its_own() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let win = x.window().at(11, 22).sized(133, 144).create();
+        plat.window = Some(win);
+        assert_eq!(
+            plat.window_geometry().expect("geometry"),
+            WindowGeometry {
+                x: 11,
+                y: 22,
+                width: 133,
+                height: 144
+            }
+        );
+    }
+
+    #[test]
+    fn an_op_on_a_destroyed_window_reports_it_gone_and_forgets_it() {
+        // The stale id must not come back on the next call as a raw protocol error — the
+        // caller gets one actionable WindowNotFound either way.
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let win = x.window().create();
+        plat.window = Some(win);
+        x.destroy(win);
+        assert!(matches!(
+            plat.window_geometry(),
+            Err(GlassError::WindowNotFound)
+        ));
+        assert_eq!(plat.window, None, "the stale id must be forgotten");
+    }
+
+    #[test]
+    fn a_dead_display_is_a_backend_failure_not_a_closed_window() {
+        // Only `BadWindow`/`BadDrawable` mean the window went away. Reporting a lost
+        // connection as WindowNotFound would send the caller looking for an app that closed,
+        // when the whole display is gone — and would drop the window id it can still use.
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let win = x.window().create();
+        plat.window = Some(win);
+        drop(x);
+
+        let err = plat
+            .window_geometry()
+            .expect_err("a request on a dead display cannot succeed");
+        assert!(
+            matches!(err, GlassError::Backend(_)),
+            "expected a backend failure, got {err:?}"
+        );
+        assert_eq!(
+            plat.window,
+            Some(win),
+            "a dead display must not make glass forget which window it was driving"
+        );
+    }
+
+    #[test]
+    fn the_client_list_is_read_from_the_root_and_empty_when_unset() {
+        let x = TestX::start();
+        let plat = x.platform();
+        let atom = plat.intern(b"_NET_CLIENT_LIST").expect("intern");
+        assert!(
+            plat.client_list_windows(atom).is_empty(),
+            "a bare Xvfb has no window manager and so no client list"
+        );
+        let (a, b) = (x.window().create(), x.window().create());
+        x.set_client_list(&[a, b]);
+        assert_eq!(plat.client_list_windows(atom), vec![a, b]);
+    }
+
+    #[test]
+    fn a_mapped_window_owned_by_the_app_matches() {
+        let x = TestX::start();
+        let plat = x.platform();
+        let pid_atom = plat.intern(b"_NET_WM_PID").expect("intern");
+        let win = x.window().owned_by(4242).create();
+        assert!(
+            plat.window_matches(win, &[4242], pid_atom, None)
+                .expect("match")
+        );
+        assert!(
+            !plat
+                .window_matches(win, &[OTHER_PID], pid_atom, None)
+                .expect("match"),
+            "another process's window is not the app's"
+        );
+    }
+
+    #[test]
+    fn an_unmapped_window_never_matches() {
+        // Windows exist in the tree before they are shown; treating one as the app's window
+        // hands back a target with nothing on screen.
+        let x = TestX::start();
+        let plat = x.platform();
+        let pid_atom = plat.intern(b"_NET_WM_PID").expect("intern");
+        let hidden = x.window().owned_by(4242).unmapped().create();
+        assert!(
+            !plat
+                .window_matches(hidden, &[4242], pid_atom, None)
+                .expect("match")
+        );
+    }
+
+    #[test]
+    fn a_window_hint_matches_a_window_outside_the_pid_set() {
+        // The fallback for apps that never set _NET_WM_PID.
+        let x = TestX::start();
+        let plat = x.platform();
+        let pid_atom = plat.intern(b"_NET_WM_PID").expect("intern");
+        let win = x.window().named("Calculator").create();
+        let hint = WindowHint {
+            title: Some("Calculator".into()),
+            class: None,
+        };
+        assert!(
+            plat.window_matches(win, &[], pid_atom, Some(&hint))
+                .expect("match")
+        );
+        let wrong = WindowHint {
+            title: Some("Spreadsheet".into()),
+            class: None,
+        };
+        assert!(
+            !plat
+                .window_matches(win, &[], pid_atom, Some(&wrong))
+                .expect("match")
+        );
+    }
+
+    #[test]
+    fn scanning_returns_every_window_the_app_owns_and_nothing_else() {
+        let x = TestX::start();
+        let plat = x.platform();
+        let main = x.window().owned_by(4242).named("main").create();
+        let dialog = x.window().owned_by(4242).named("dialog").create();
+        let _stranger = x.window().owned_by(OTHER_PID).named("stranger").create();
+        let mut found = plat.scan_all_windows(&[4242]).expect("scan");
+        found.sort_unstable();
+        let mut want = vec![main, dialog];
+        want.sort_unstable();
+        assert_eq!(found, want);
+    }
+
+    #[test]
+    fn a_window_listed_twice_is_returned_once() {
+        // `_NET_CLIENT_LIST` and the root's children overlap whenever a window is not
+        // reparented, which is every window under a bare Xvfb.
+        let x = TestX::start();
+        let plat = x.platform();
+        let win = x.window().owned_by(4242).create();
+        x.set_client_list(&[win]);
+        assert_eq!(plat.scan_all_windows(&[4242]).expect("scan"), vec![win]);
+    }
+
+    #[test]
+    fn scanning_for_one_window_finds_a_match_and_reports_none_otherwise() {
+        let x = TestX::start();
+        let plat = x.platform();
+        let pid_atom = plat.intern(b"_NET_WM_PID").expect("intern");
+        let list_atom = plat.intern(b"_NET_CLIENT_LIST").expect("intern");
+        let win = x.window().owned_by(4242).create();
+        assert_eq!(
+            plat.scan_for_window(&[4242], pid_atom, list_atom, None)
+                .expect("scan"),
+            Some(win)
+        );
+        assert_eq!(
+            plat.scan_for_window(&[OTHER_PID], pid_atom, list_atom, None)
+                .expect("scan"),
+            None
+        );
+    }
+}
+
 #[cfg(test)]
 mod env_display_tests {
     use super::{DisplayTarget, display_target, normalize_display};

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -232,6 +232,15 @@ impl X11Platform {
         })
     }
 
+    /// Send everything buffered so far, without waiting for a reply. The input sinks commit
+    /// each step this way: a client that renders per frame sees a gesture unfold, where one
+    /// flush at the end delivers it as a single jump.
+    fn commit(&self) -> Result<()> {
+        self.conn
+            .flush()
+            .map_err(|e| GlassError::Backend(format!("flush: {e}")))
+    }
+
     /// Intern an atom by name (small helper for the multi-window scans).
     fn intern(&self, name: &[u8]) -> Result<Atom> {
         Ok(self
@@ -799,10 +808,7 @@ impl X11Platform {
         self.conn
             .set_input_focus(InputFocus::PARENT, win, x11rb::CURRENT_TIME)
             .map_err(|e| GlassError::Backend(format!("set_input_focus: {e}")))?;
-        self.conn
-            .flush()
-            .map_err(|e| GlassError::Backend(format!("flush: {e}")))?;
-        Ok(())
+        self.commit()
     }
 
     /// Resolve a window-relative `region` (or the whole window) against `geo`
@@ -901,27 +907,18 @@ struct X11DragSink<'a> {
     kcs: Vec<u8>,
 }
 
-impl X11DragSink<'_> {
-    fn flush(&self) -> Result<()> {
-        self.p
-            .conn
-            .flush()
-            .map_err(|e| GlassError::Backend(format!("flush: {e}")))
-    }
-}
-
 impl glass_core::DragSink for X11DragSink<'_> {
     fn place(&mut self, x: i32, y: i32) -> Result<()> {
         self.move_to(x, y)
     }
     fn move_to(&mut self, x: i32, y: i32) -> Result<()> {
         self.p.warp(self.ox, self.oy, x, y)?;
-        self.flush()
+        self.p.commit()
     }
     fn button(&mut self, down: bool) -> Result<()> {
         let kind = if down { XT_BTN_PRESS } else { XT_BTN_RELEASE };
         self.p.button(kind, self.b)?;
-        self.flush()
+        self.p.commit()
     }
     fn modifiers(&mut self, down: bool) -> Result<()> {
         if down {
@@ -929,7 +926,7 @@ impl glass_core::DragSink for X11DragSink<'_> {
         } else {
             self.p.release_mods(&self.kcs)?;
         }
-        self.flush()
+        self.p.commit()
     }
 }
 
@@ -950,10 +947,7 @@ impl glass_core::TypeSink for X11TypeSink<'_> {
         })?;
         self.idx += 1;
         self.p.key_with_mods(keysym, false, &[])?;
-        self.p
-            .conn
-            .flush()
-            .map_err(|e| GlassError::Backend(format!("flush: {e}")))
+        self.p.commit()
     }
 }
 
@@ -967,15 +961,6 @@ struct X11ChordSink<'a> {
     kcs: Vec<u8>,
 }
 
-impl X11ChordSink<'_> {
-    fn flush(&self) -> Result<()> {
-        self.p
-            .conn
-            .flush()
-            .map_err(|e| GlassError::Backend(format!("flush: {e}")))
-    }
-}
-
 impl glass_core::ChordSink for X11ChordSink<'_> {
     fn modifiers(&mut self, down: bool) -> Result<()> {
         if down {
@@ -983,7 +968,7 @@ impl glass_core::ChordSink for X11ChordSink<'_> {
         } else {
             self.p.release_mods(&self.kcs)?;
         }
-        self.flush()
+        self.p.commit()
     }
     fn key(&mut self, down: bool) -> Result<()> {
         let kind = if down { XT_KEY_PRESS } else { XT_KEY_RELEASE };
@@ -999,7 +984,7 @@ impl glass_core::ChordSink for X11ChordSink<'_> {
                 0,
             )
             .map_err(|e| GlassError::Backend(format!("xtest key: {e}")))?;
-        self.flush()
+        self.p.commit()
     }
 }
 
@@ -1018,15 +1003,6 @@ struct X11ScrollSink<'a> {
     kcs: Vec<u8>,
 }
 
-impl X11ScrollSink<'_> {
-    fn flush(&self) -> Result<()> {
-        self.p
-            .conn
-            .flush()
-            .map_err(|e| GlassError::Backend(format!("flush: {e}")))
-    }
-}
-
 impl glass_core::ScrollSink for X11ScrollSink<'_> {
     fn modifiers(&mut self, down: bool) -> Result<()> {
         if down {
@@ -1034,27 +1010,21 @@ impl glass_core::ScrollSink for X11ScrollSink<'_> {
         } else {
             self.p.release_mods(&self.kcs)?;
         }
-        self.flush()
+        self.p.commit()
     }
     fn wheel(&mut self) -> Result<()> {
         self.p.warp(self.ox, self.oy, self.x, self.y)?;
         // 4=up,5=down,6=left,7=right; click |delta| times.
         self.p.scroll_button(5, 4, self.dy)?;
         self.p.scroll_button(7, 6, self.dx)?;
-        self.flush()
+        self.p.commit()
     }
 }
 
 impl Platform for X11Platform {
     fn start_app(&mut self, spec: &AppSpec) -> Result<WindowGeometry> {
-        if spec.sandbox != glass_core::SandboxLevel::Off
-            && let glass_sandbox_linux::Availability::Unavailable(why) =
-                glass_sandbox_linux::availability()
-        {
-            return Err(GlassError::SandboxUnavailable(format!(
-                "{why}. Install bubblewrap / enable unprivileged user namespaces, or pass \
-                     sandbox:\"off\" (GLASS_SANDBOX=off) to run unconfined. See `glass-mcp doctor`."
-            )));
+        if let Some(e) = sandbox_refusal(spec.sandbox, glass_sandbox_linux::availability()) {
+            return Err(e);
         }
         glass_sandbox_linux::run_build(spec)?;
         // Opt-in private, isolated a11y bus (its own XDG_RUNTIME_DIR — never the host
@@ -1213,10 +1183,7 @@ impl Platform for X11Platform {
                 return Err(crate::unsupported_multi_touch());
             }
         }
-        self.conn
-            .flush()
-            .map_err(|e| GlassError::Backend(format!("flush: {e}")))?;
-        Ok(())
+        self.commit()
     }
 
     fn send_key(&mut self, event: &KeyEvent) -> Result<()> {
@@ -1245,10 +1212,7 @@ impl Platform for X11Platform {
                 glass_core::run_chord(&mut sink)?;
             }
         }
-        self.conn
-            .flush()
-            .map_err(|e| GlassError::Backend(format!("flush: {e}")))?;
-        Ok(())
+        self.commit()
     }
 
     fn get_clipboard(&mut self) -> Result<String> {
@@ -1399,6 +1363,27 @@ impl Drop for X11Platform {
     }
 }
 
+/// Why a launch cannot go ahead under the requested containment, or `None` when it can.
+/// A `sandbox:"off"` launch never consults availability — bubblewrap being absent is not a
+/// reason to refuse a launch that was never going to use it.
+///
+/// Split from the probe so both answers are reachable from a test: whether bubblewrap works
+/// is a property of the machine the tests run on, not something they can choose.
+fn sandbox_refusal(
+    level: glass_core::SandboxLevel,
+    availability: glass_sandbox_linux::Availability,
+) -> Option<GlassError> {
+    match (level, availability) {
+        (glass_core::SandboxLevel::Off, _) | (_, glass_sandbox_linux::Availability::Ok) => None,
+        (_, glass_sandbox_linux::Availability::Unavailable(why)) => {
+            Some(GlassError::SandboxUnavailable(format!(
+                "{why}. Install bubblewrap / enable unprivileged user namespaces, or pass \
+                 sandbox:\"off\" (GLASS_SANDBOX=off) to run unconfined. See `glass-mcp doctor`."
+            )))
+        }
+    }
+}
+
 /// Search a `GetKeyboardMapping` table for `keysym`, returning the keycode that produces it
 /// and whether Shift is needed — column 0 is the unshifted keysym, column 1 the shifted one.
 ///
@@ -1532,6 +1517,40 @@ mod tests {
         let map = vec![0xaa, 0xbb, 0xcc];
         assert_eq!(super::keycode_in(&map, 1, 8, 10, 0xbb), Some((9, false)));
         assert_eq!(super::keycode_in(&map, 1, 8, 10, 0xcc), Some((10, false)));
+    }
+
+    #[test]
+    fn an_unconfined_launch_does_not_need_bubblewrap() {
+        use glass_core::SandboxLevel;
+        use glass_sandbox_linux::Availability;
+        assert!(
+            super::sandbox_refusal(
+                SandboxLevel::Off,
+                Availability::Unavailable("no bwrap".into())
+            )
+            .is_none(),
+            "sandbox:off never uses bubblewrap, so its absence cannot refuse the launch"
+        );
+    }
+
+    #[test]
+    fn a_contained_launch_is_refused_when_bubblewrap_cannot_work() {
+        use glass_core::{GlassError, SandboxLevel};
+        use glass_sandbox_linux::Availability;
+        let err = super::sandbox_refusal(
+            SandboxLevel::Default,
+            Availability::Unavailable("no user namespaces".into()),
+        )
+        .expect("a contained launch cannot proceed without containment");
+        assert!(matches!(err, GlassError::SandboxUnavailable(_)), "{err:?}");
+        assert!(
+            err.to_string().contains("no user namespaces"),
+            "the real cause must survive into the message: {err}"
+        );
+        assert!(
+            super::sandbox_refusal(SandboxLevel::Default, Availability::Ok).is_none(),
+            "a working bubblewrap refuses nothing"
+        );
     }
 
     #[test]
@@ -2239,6 +2258,94 @@ mod display_tests {
     }
 
     #[test]
+    fn a_drag_with_a_modifier_holds_it_from_before_the_press_to_after_the_release() {
+        // A constrained drag (shift to snap an axis, ctrl to copy) is a different gesture
+        // from the same drag unmodified.
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let win = x
+            .window()
+            .at(0, 0)
+            .sized(400, 400)
+            .watching_input()
+            .create();
+        plat.window = Some(win);
+        plat.focus_window(win).expect("focus");
+        commit(&plat);
+        let _ = x.drain_events(Duration::from_millis(50));
+
+        plat.send_pointer(&PointerEvent::Drag {
+            from_x: 10,
+            from_y: 10,
+            to_x: 80,
+            to_y: 80,
+            button: glass_core::MouseButton::Left,
+            modifiers: vec![glass_core::keys::Modifier::Shift],
+            duration_ms: 40,
+        })
+        .expect("drag");
+
+        let shift = plat
+            .modifier_keycode(glass_core::keys::Modifier::Shift)
+            .expect("shift");
+        let events = x.drain_events(Duration::from_millis(120));
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                x11rb::protocol::Event::KeyPress(k) if k.detail == shift
+            )),
+            "the modifier must go down for a modified drag: {events:?}"
+        );
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                x11rb::protocol::Event::KeyRelease(k) if k.detail == shift
+            )),
+            "and must not be left held afterwards: {events:?}"
+        );
+    }
+
+    #[test]
+    fn a_long_drag_reaches_the_window_while_it_is_still_running() {
+        // Each step commits on its own. Held to one flush at the end, a client that renders
+        // per frame — a browser — sees the pointer jump rather than drag.
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let win = x
+            .window()
+            .at(0, 0)
+            .sized(400, 400)
+            .watching_input()
+            .create();
+        plat.window = Some(win);
+        let _ = x.drain_events(Duration::from_millis(50));
+
+        let arrived_early = std::thread::scope(|s| {
+            s.spawn(|| {
+                plat.send_pointer(&PointerEvent::Drag {
+                    from_x: 10,
+                    from_y: 10,
+                    to_x: 300,
+                    to_y: 300,
+                    button: glass_core::MouseButton::Left,
+                    modifiers: vec![],
+                    duration_ms: 600,
+                })
+                .expect("drag");
+            });
+            // A third of the way in: far enough that the press and several motions are due,
+            // far enough from the end that a loaded machine cannot blur the two.
+            std::thread::sleep(Duration::from_millis(200));
+            !x.drain_events(Duration::ZERO).is_empty()
+        });
+
+        assert!(
+            arrived_early,
+            "nothing had reached the window 200ms into a 600ms drag"
+        );
+    }
+
+    #[test]
     fn a_multi_touch_gesture_is_refused_by_this_backend() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -2605,6 +2712,118 @@ mod display_tests {
             plat.app_pid(),
             None,
             "a launch that failed must not leave its child behind"
+        );
+    }
+
+    #[test]
+    fn a_launch_waits_out_its_timeout_before_giving_up() {
+        // A deadline computed backwards, or a comparison the wrong way round, still reports a
+        // Timeout — it just reports it immediately, turning the caller's budget into nothing
+        // and failing every app slower than instant.
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let spec = AppSpec {
+            build: None,
+            run: vec!["sleep".to_string(), "30".to_string()],
+            cwd: None,
+            env: vec![],
+            window_hint: None,
+            timeout_ms: 400,
+            sandbox: glass_core::SandboxLevel::Off,
+            a11y: false,
+        };
+        let started = Instant::now();
+        let err = plat.start_app(&spec).expect_err("no window ever appears");
+        let waited = started.elapsed();
+        assert!(matches!(err, GlassError::Timeout(400)), "{err:?}");
+        assert!(
+            waited >= Duration::from_millis(350),
+            "gave up after {waited:?}, which is not the 400ms budget it was given"
+        );
+    }
+
+    #[test]
+    fn an_untypable_character_is_reported_at_its_own_index() {
+        // The index is all the error may carry — naming the character would put typed
+        // content into the unredacted audit log — so it has to advance per character.
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let win = x.window().create();
+        plat.window = Some(win);
+        let err = plat
+            .send_key(&KeyEvent::Text("a€".to_string()))
+            .expect_err("€ has no X11 keysym");
+        assert!(err.to_string().contains("index 1"), "{err}");
+    }
+
+    #[test]
+    fn a_scroll_with_a_modifier_holds_it_across_the_wheel() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let win = x
+            .window()
+            .at(0, 0)
+            .sized(400, 400)
+            .watching_input()
+            .create();
+        plat.window = Some(win);
+        plat.focus_window(win).expect("focus");
+        commit(&plat);
+        let _ = x.drain_events(Duration::from_millis(50));
+
+        plat.send_pointer(&PointerEvent::Scroll {
+            x: 5,
+            y: 5,
+            dx: 0,
+            dy: -1,
+            modifiers: vec![glass_core::keys::Modifier::Control],
+        })
+        .expect("scroll");
+
+        let control = plat
+            .modifier_keycode(glass_core::keys::Modifier::Control)
+            .expect("control");
+        let keys: Vec<u8> = x
+            .drain_events(Duration::from_millis(150))
+            .into_iter()
+            .filter_map(|e| match e {
+                x11rb::protocol::Event::KeyPress(k) => Some(k.detail),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            keys.contains(&control),
+            "a modified scroll must hold the modifier down: {keys:?}"
+        );
+    }
+
+    #[test]
+    fn a_chord_whose_key_needs_shift_gets_shift_as_well_as_its_own_modifiers() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        let win = x.window().watching_input().create();
+        plat.window = Some(win);
+        plat.focus_window(win).expect("focus");
+        commit(&plat);
+        let _ = x.drain_events(Duration::from_millis(50));
+
+        plat.send_key(&KeyEvent::Chord("ctrl+A".to_string()))
+            .expect("chord");
+
+        let shift = plat
+            .modifier_keycode(glass_core::keys::Modifier::Shift)
+            .expect("shift");
+        let keys: Vec<u8> = x
+            .drain_events(Duration::from_millis(100))
+            .into_iter()
+            .filter_map(|e| match e {
+                x11rb::protocol::Event::KeyPress(k) => Some(k.detail),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            keys.contains(&shift),
+            "`A` sits in the shifted column, so ctrl+A is ctrl+shift+a: {keys:?}"
         );
     }
 

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -876,10 +876,7 @@ impl X11Platform {
 }
 
 /// The diagnostic for a capture that was clipped to the display, or `None` when the whole
-/// requested rectangle was read — so the smaller-than-requested frame the caller receives
-/// isn't a silent surprise. glass's own stderr is its diagnostic channel (same as the
-/// focus-on-launch warning); the MCP `screenshot` result additionally reports the true
-/// (clipped) dimensions, so a frame smaller than the window/region signals the clip.
+/// requested rectangle was read.
 fn clip_note(rect: &crate::coords::ClippedRect) -> Option<String> {
     rect.clipped.then(|| {
         format!(
@@ -1361,11 +1358,10 @@ impl Drop for X11Platform {
 }
 
 /// Why a launch cannot go ahead under the requested containment, or `None` when it can.
-/// A `sandbox:"off"` launch never consults availability — bubblewrap being absent is not a
-/// reason to refuse a launch that was never going to use it.
+/// A `sandbox:"off"` launch never consults availability.
 ///
-/// Split from the probe so both answers are reachable from a test: whether bubblewrap works
-/// is a property of the machine the tests run on, not something they can choose.
+/// Do not fold this back into the probe: whether bubblewrap works is a property of the
+/// machine, so in place only one of the two answers is ever reachable from a test.
 fn sandbox_refusal(
     level: glass_core::SandboxLevel,
     availability: glass_sandbox_linux::Availability,
@@ -1384,9 +1380,9 @@ fn sandbox_refusal(
 /// Search a `GetKeyboardMapping` table for `keysym`, returning the keycode that produces it
 /// and whether Shift is needed — column 0 is the unshifted keysym, column 1 the shifted one.
 ///
-/// `keysyms` is the flat table for keycodes `min..=max`, `per` entries each. Split out from
-/// the request around it so the indexing is reachable from a test with a table it chose:
-/// against a live server every arithmetic slip here still lands on *some* real key.
+/// `keysyms` is the flat table for keycodes `min..=max`, `per` entries each. Do not fold this
+/// back into the request around it: against a live server every arithmetic slip here still
+/// lands on *some* real key.
 fn keycode_in(keysyms: &[u32], per: usize, min: u8, max: u8, keysym: u32) -> Option<(u8, bool)> {
     for kc in min..=max {
         let base = (kc as usize - min as usize) * per;
@@ -2755,9 +2751,8 @@ mod display_tests {
 
     #[test]
     fn a_launch_waits_out_its_timeout_before_giving_up() {
-        // A deadline computed backwards, or a comparison the wrong way round, still reports a
-        // Timeout — it just reports it immediately, turning the caller's budget into nothing
-        // and failing every app slower than instant.
+        // The budget has to be spent, not just reported: a launch that gives up at once
+        // fails every app slower than instant.
         let x = TestX::start();
         let mut plat = x.platform();
         let spec = AppSpec {

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -85,7 +85,7 @@ fn display_target(glass_display: Option<&str>) -> DisplayTarget {
 }
 
 /// Accept both `:42` and bare `42`.
-fn normalize_display(d: &str) -> String {
+pub(crate) fn normalize_display(d: &str) -> String {
     if d.starts_with(':') {
         d.to_string()
     } else {

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -1019,9 +1019,7 @@ impl glass_core::ScrollSink for X11ScrollSink<'_> {
 
 impl Platform for X11Platform {
     fn start_app(&mut self, spec: &AppSpec) -> Result<WindowGeometry> {
-        if let Some(e) = sandbox_refusal(spec.sandbox, glass_sandbox_linux::availability()) {
-            return Err(e);
-        }
+        ensure_sandbox_available(spec.sandbox, glass_sandbox_linux::availability)?;
         glass_sandbox_linux::run_build(spec)?;
         // Opt-in private, isolated a11y bus (its own XDG_RUNTIME_DIR — never the host
         // /run/user/UID/at-spi/) so the launched app publishes an AT-SPI tree. The caller
@@ -1249,9 +1247,7 @@ impl Platform for X11Platform {
             }
             WindowOp::Geometry => {}
         }
-        self.conn
-            .flush()
-            .map_err(|e| GlassError::Backend(format!("flush: {e}")))?;
+        self.commit()?;
         self.window_geometry()
     }
 
@@ -1350,26 +1346,26 @@ impl Drop for X11Platform {
     /// `self.child.take()`, so this is idempotent with `stop_app`. Field order then
     /// drops `xvfb`, tearing down any private display we spawned.
     fn drop(&mut self) {
-        self.kill_child(); // also drops clipboard_owner
-        // Redundant safety: kill_child already clears it, but be explicit in case
-        // clipboard_owner was set after the last kill_child call.
-        self.clipboard_owner = None;
+        self.kill_child(); // takes the child, and drops the clipboard owner with it
     }
 }
 
-/// Why a launch cannot go ahead under the requested containment, or `None` when it can.
-/// A `sandbox:"off"` launch never consults availability.
+/// Fail a launch that asked for containment this machine cannot provide.
 ///
-/// Do not fold this back into the probe: whether bubblewrap works is a property of the
-/// machine, so in place only one of the two answers is ever reachable from a test.
-fn sandbox_refusal(
+/// `probe` is a thunk because it forks bubblewrap, and `sandbox:"off"` is the escape hatch
+/// for machines where that is exactly what does not work. Kept out of `start_app` so both
+/// answers are reachable from a test.
+fn ensure_sandbox_available(
     level: glass_core::SandboxLevel,
-    availability: glass_sandbox_linux::Availability,
-) -> Option<GlassError> {
-    match (level, availability) {
-        (glass_core::SandboxLevel::Off, _) | (_, glass_sandbox_linux::Availability::Ok) => None,
-        (_, glass_sandbox_linux::Availability::Unavailable(why)) => {
-            Some(GlassError::SandboxUnavailable(format!(
+    probe: impl FnOnce() -> glass_sandbox_linux::Availability,
+) -> Result<()> {
+    if level == glass_core::SandboxLevel::Off {
+        return Ok(());
+    }
+    match probe() {
+        glass_sandbox_linux::Availability::Ok => Ok(()),
+        glass_sandbox_linux::Availability::Unavailable(why) => {
+            Err(GlassError::SandboxUnavailable(format!(
                 "{why}. Install bubblewrap / enable unprivileged user namespaces, or pass \
                  sandbox:\"off\" (GLASS_SANDBOX=off) to run unconfined. See `glass-mcp doctor`."
             )))
@@ -1513,37 +1509,30 @@ mod tests {
     }
 
     #[test]
-    fn an_unconfined_launch_does_not_need_bubblewrap() {
+    fn an_unconfined_launch_never_runs_the_bubblewrap_probe() {
+        // A panicking probe is the only way to assert the probe is never called.
         use glass_core::SandboxLevel;
-        use glass_sandbox_linux::Availability;
-        assert!(
-            super::sandbox_refusal(
-                SandboxLevel::Off,
-                Availability::Unavailable("no bwrap".into())
-            )
-            .is_none(),
-            "sandbox:off never uses bubblewrap, so its absence cannot refuse the launch"
-        );
+        super::ensure_sandbox_available(SandboxLevel::Off, || {
+            panic!("sandbox:off must not probe for bubblewrap")
+        })
+        .expect("an unconfined launch is always allowed");
     }
 
     #[test]
     fn a_contained_launch_is_refused_when_bubblewrap_cannot_work() {
         use glass_core::{GlassError, SandboxLevel};
         use glass_sandbox_linux::Availability;
-        let err = super::sandbox_refusal(
-            SandboxLevel::Default,
-            Availability::Unavailable("no user namespaces".into()),
-        )
-        .expect("a contained launch cannot proceed without containment");
+        let err = super::ensure_sandbox_available(SandboxLevel::Default, || {
+            Availability::Unavailable("no user namespaces".into())
+        })
+        .expect_err("a contained launch cannot proceed without containment");
         assert!(matches!(err, GlassError::SandboxUnavailable(_)), "{err:?}");
         assert!(
             err.to_string().contains("no user namespaces"),
             "the real cause must survive into the message: {err}"
         );
-        assert!(
-            super::sandbox_refusal(SandboxLevel::Default, Availability::Ok).is_none(),
-            "a working bubblewrap refuses nothing"
-        );
+        super::ensure_sandbox_available(SandboxLevel::Default, || Availability::Ok)
+            .expect("a working bubblewrap refuses nothing");
     }
 
     #[test]
@@ -1809,9 +1798,8 @@ mod display_tests {
     const KEYSYM_SHIFT_L: u32 = 0xffe1;
 
     /// Push the backend's buffered requests and wait for the server to have processed them.
-    /// The input primitives do not flush — the sinks above them commit a whole gesture at
-    /// once — and a flush alone would not be enough here anyway: these tests read the result
-    /// over a *second* connection, which is ordered against the first only by a round trip.
+    /// The input primitives do not flush, and a flush would not be enough anyway: these tests
+    /// read the result over a *second* connection, ordered against the first only by a reply.
     fn commit(plat: &X11Platform) {
         plat.conn.sync().expect("sync");
     }
@@ -2095,10 +2083,14 @@ mod display_tests {
     /// that is genuinely in `/proc`. `sleep` leaves on its own, so a test that panics before
     /// its teardown cannot strand it.
     fn spawn_stand_in() -> std::process::Child {
-        std::process::Command::new("sleep")
-            .arg("30")
-            .spawn()
-            .expect("the stand-in app should spawn")
+        use std::os::unix::process::CommandExt as _;
+        let mut cmd = std::process::Command::new("sleep");
+        cmd.arg("30");
+        // As production spawns an app (`command.rs`). `reap_launch` signals `child.id()` as a
+        // process GROUP; on a child that is not a group leader that pgid belongs to somebody
+        // else, and teardown SIGKILLs an unrelated group.
+        cmd.process_group(0);
+        cmd.spawn().expect("the stand-in app should spawn")
     }
 
     /// The buttons and their positions a watching window saw, as `(detail, x, y)`.
@@ -2527,6 +2519,11 @@ mod display_tests {
             ),
             "a window outside the launched process tree is not selectable"
         );
+        assert_eq!(
+            plat.window,
+            Some(mine),
+            "a refused selection must leave the active window where it was"
+        );
     }
 
     #[test]
@@ -2536,10 +2533,12 @@ mod display_tests {
         let child = spawn_stand_in();
         let pid = child.id();
         plat.child = Some(child);
+        // Away from the origin, and filled: a capture that ignored the window's position would
+        // read the root's black from (0,0) and still be the right size.
         let win = x
             .window()
             .owned_by(pid)
-            .at(0, 0)
+            .at(120, 60)
             .sized(48, 32)
             .filled_with(0x0000_00ff)
             .create();
@@ -2550,6 +2549,12 @@ mod display_tests {
             .capture_window(WindowId(win as u64), None)
             .expect("capture");
         assert_eq!((frame.width, frame.height), (48, 32));
+        let px = &frame.pixels[..4];
+        assert_eq!(
+            (px[0], px[1], px[2]),
+            (0x00, 0x00, 0xff),
+            "should read the window's own pixels, got {px:?}"
+        );
 
         let stranger = x.window().owned_by(999_999).create();
         assert!(
@@ -2605,8 +2610,22 @@ mod display_tests {
         plat.set_clipboard("ours").expect("set");
         assert_eq!(plat.get_clipboard().expect("get"), "ours");
 
-        x.take_clipboard();
-        std::thread::sleep(Duration::from_millis(200));
+        let thief = x.take_clipboard();
+        assert_eq!(
+            x.clipboard_owner(),
+            thief,
+            "the test client should hold it now"
+        );
+
+        // Wait for glass's owner to RETIRE, not merely for the selection to change hands: it
+        // notices SelectionClear on its own 10ms loop, and copying before it does hands the
+        // text to an owner that no longer serves anything.
+        let deadline = Instant::now() + Duration::from_secs(3);
+        while Instant::now() < deadline
+            && plat.clipboard_owner.as_ref().is_some_and(|o| o.is_alive())
+        {
+            std::thread::sleep(Duration::from_millis(10));
+        }
 
         plat.set_clipboard("ours again")
             .expect("set after losing it");

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -2577,6 +2577,25 @@ mod display_tests {
     }
 
     #[test]
+    fn a_second_copy_updates_the_owner_it_already_has() {
+        // Re-taking the selection for every copy is visible to every other client on the
+        // display: a clipboard manager watching ownership sees churn that did not happen.
+        let x = TestX::start();
+        let mut plat = x.platform();
+        plat.set_clipboard("first").expect("set");
+        let owner = x.clipboard_owner();
+        assert_ne!(owner, x11rb::NONE, "the first copy takes the selection");
+
+        plat.set_clipboard("second").expect("set again");
+        assert_eq!(
+            x.clipboard_owner(),
+            owner,
+            "a live owner should be handed the new text, not replaced"
+        );
+        assert_eq!(plat.get_clipboard().expect("get"), "second");
+    }
+
+    #[test]
     fn a_copy_after_another_client_took_the_selection_starts_a_fresh_owner() {
         // glass's owner retires when something else takes CLIPBOARD. Handing the next copy to
         // that retired owner puts the text somewhere nothing serves it, and the paste that
@@ -2750,11 +2769,13 @@ mod display_tests {
     }
 
     #[test]
-    fn a_launch_waits_out_its_timeout_before_giving_up() {
-        // The budget has to be spent, not just reported: a launch that gives up at once
-        // fails every app slower than instant.
+    fn discovery_waits_out_its_timeout_before_giving_up() {
+        // The budget has to be spent, not just reported: giving up at once fails every app
+        // slower than instant. Timed around `discover_window`, so a spawn that fails under
+        // load cannot read as a deadline that was not honoured.
         let x = TestX::start();
         let mut plat = x.platform();
+        plat.child = Some(spawn_stand_in());
         let spec = AppSpec {
             build: None,
             run: vec!["sleep".to_string(), "30".to_string()],
@@ -2766,7 +2787,9 @@ mod display_tests {
             a11y: false,
         };
         let started = Instant::now();
-        let err = plat.start_app(&spec).expect_err("no window ever appears");
+        let err = plat
+            .discover_window(&spec)
+            .expect_err("the stand-in never maps a window");
         let waited = started.elapsed();
         assert!(matches!(err, GlassError::Timeout(400)), "{err:?}");
         assert!(

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -483,9 +483,8 @@ impl X11Platform {
         // covers `start_app`'s failure path (which calls `kill_child`), so a launch
         // that never finds a window doesn't leave the bus running until Drop.
         self.dbus = None;
-        if let Some(owner) = self.clipboard_owner.take() {
-            owner.stop();
-        }
+        // Dropping the owner stops its thread and releases the CLIPBOARD selection.
+        self.clipboard_owner = None;
     }
 
     /// Poll the window tree until a top-level window matches a pid in the process
@@ -1354,12 +1353,10 @@ impl Drop for X11Platform {
     /// `self.child.take()`, so this is idempotent with `stop_app`. Field order then
     /// drops `xvfb`, tearing down any private display we spawned.
     fn drop(&mut self) {
-        self.kill_child(); // also stops clipboard_owner
-        // Redundant safety: kill_child already calls take(), but be explicit
-        // in case clipboard_owner was set after the last kill_child call.
-        if let Some(owner) = self.clipboard_owner.take() {
-            owner.stop();
-        }
+        self.kill_child(); // also drops clipboard_owner
+        // Redundant safety: kill_child already clears it, but be explicit in case
+        // clipboard_owner was set after the last kill_child call.
+        self.clipboard_owner = None;
     }
 }
 
@@ -2137,13 +2134,21 @@ mod display_tests {
     }
 
     #[test]
-    fn there_is_no_a11y_bus_address_without_a_bus() {
+    fn the_a11y_bus_address_is_the_private_buss_own_and_absent_without_one() {
+        // The a11y reader connects to whatever this returns. Reporting nothing for a launch
+        // that did start a bus leaves the tree unreadable; reporting something for one that
+        // did not points the reader at the host's bus.
         let x = TestX::start();
-        let plat = x.platform();
-        assert_eq!(
-            plat.a11y_bus_addr(),
-            None,
-            "a launch that did not ask for a11y must not advertise an address"
+        let mut plat = x.platform();
+        assert_eq!(plat.a11y_bus_addr(), None);
+
+        let bus = glass_dbus_linux::PrivateBus::start().expect("a private a11y bus should start");
+        let expected = bus.a11y_bus_address().to_string();
+        plat.dbus = Some(bus);
+        assert_eq!(plat.a11y_bus_addr().as_deref(), Some(expected.as_str()));
+        assert!(
+            !expected.is_empty(),
+            "an address that is blank reaches nothing"
         );
     }
 
@@ -2558,6 +2563,39 @@ mod display_tests {
             ),
             "a window the app does not own is not capturable"
         );
+    }
+
+    #[test]
+    fn the_clipboard_round_trips_through_the_backend() {
+        let x = TestX::start();
+        let mut plat = x.platform();
+        assert_eq!(
+            plat.get_clipboard().expect("get"),
+            "",
+            "nothing has been copied on this display yet"
+        );
+        plat.set_clipboard("copied text").expect("set");
+        assert_eq!(plat.get_clipboard().expect("get"), "copied text");
+        plat.set_clipboard("replaced").expect("set again");
+        assert_eq!(plat.get_clipboard().expect("get"), "replaced");
+    }
+
+    #[test]
+    fn a_copy_after_another_client_took_the_selection_starts_a_fresh_owner() {
+        // glass's owner retires when something else takes CLIPBOARD. Handing the next copy to
+        // that retired owner puts the text somewhere nothing serves it, and the paste that
+        // follows returns the other application's clipboard instead.
+        let x = TestX::start();
+        let mut plat = x.platform();
+        plat.set_clipboard("ours").expect("set");
+        assert_eq!(plat.get_clipboard().expect("get"), "ours");
+
+        x.take_clipboard();
+        std::thread::sleep(Duration::from_millis(200));
+
+        plat.set_clipboard("ours again")
+            .expect("set after losing it");
+        assert_eq!(plat.get_clipboard().expect("get"), "ours again");
     }
 
     // --- the close ladder ------------------------------------------------------------

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -885,12 +885,6 @@ fn clip_note(rect: &crate::coords::ClippedRect) -> Option<String> {
     })
 }
 
-fn note_if_clipped(rect: &crate::coords::ClippedRect) {
-    if let Some(note) = clip_note(rect) {
-        eprintln!("{note}");
-    }
-}
-
 // The process-tree walk (`/proc`-based) that maps the spawned child to the
 // real app's descendants now lives in the shared `glass-proc-linux` crate
 // (`proc_tree_pids`), used by both the X11 and Wayland backends.
@@ -1115,7 +1109,9 @@ impl Platform for X11Platform {
         // the "is there an active window" guard — no separate binding needed.
         let geo = self.window_geometry()?;
         let rect = self.resolve_capture_rect(&geo, region)?;
-        note_if_clipped(&rect);
+        if let Some(note) = clip_note(&rect) {
+            eprintln!("{note}");
+        }
         // Capture from ROOT over the window's screen region so overlapping popovers
         // (separate override-redirect top-levels) are included, not just this window's
         // own (possibly-obscured) drawable.
@@ -1143,7 +1139,9 @@ impl Platform for X11Platform {
             r.check_fits(geo.width, geo.height)?;
         }
         let rect = self.resolve_capture_rect(&geo, region)?;
-        note_if_clipped(&rect);
+        if let Some(note) = clip_note(&rect) {
+            eprintln!("{note}");
+        }
         self.capture_screen_rect(rect.sx, rect.sy, rect.w, rect.h)
     }
 
@@ -1491,6 +1489,49 @@ mod tests {
             Some(("xcalc", "XCalc")),
             &h
         ));
+    }
+
+    /// Keycodes 8, 9, 10 with two columns each: unshifted then shifted.
+    fn two_column_map() -> Vec<u32> {
+        vec![0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]
+    }
+
+    #[test]
+    fn a_keysym_in_the_unshifted_column_needs_no_shift() {
+        let map = two_column_map();
+        assert_eq!(
+            super::keycode_in(&map, 2, 8, 10, 0xcc),
+            Some((9, false)),
+            "0xcc is keycode 9's unshifted keysym"
+        );
+    }
+
+    #[test]
+    fn a_keysym_in_the_shifted_column_reports_that_shift_is_needed() {
+        let map = two_column_map();
+        assert_eq!(super::keycode_in(&map, 2, 8, 10, 0xbb), Some((8, true)));
+    }
+
+    #[test]
+    fn the_last_keycode_in_the_range_is_still_searched() {
+        let map = two_column_map();
+        assert_eq!(super::keycode_in(&map, 2, 8, 10, 0xee), Some((10, false)));
+        assert_eq!(super::keycode_in(&map, 2, 8, 10, 0xff), Some((10, true)));
+    }
+
+    #[test]
+    fn a_keysym_the_map_does_not_carry_is_not_found() {
+        let map = two_column_map();
+        assert_eq!(super::keycode_in(&map, 2, 8, 10, 0x99), None);
+    }
+
+    #[test]
+    fn a_single_column_map_never_reads_into_the_next_keycode() {
+        // With one keysym per keycode there is no shifted column, and index `base + 1` is
+        // already the *next* key — reading it would report the wrong keycode entirely.
+        let map = vec![0xaa, 0xbb, 0xcc];
+        assert_eq!(super::keycode_in(&map, 1, 8, 10, 0xbb), Some((9, false)));
+        assert_eq!(super::keycode_in(&map, 1, 8, 10, 0xcc), Some((10, false)));
     }
 
     #[test]
@@ -2053,17 +2094,24 @@ mod display_tests {
             width: 0,
             height: 40,
         };
-        assert!(
-            plat.resolve_capture_rect(&geo, Some(&flat)).is_err(),
-            "a region with no width has no pixels to read"
-        );
+        // Asserting the message, not just an error: clipping rejects an empty rectangle too,
+        // so "it failed" would pass even if the zero-area check had stopped running.
+        let flat_err = plat
+            .resolve_capture_rect(&geo, Some(&flat))
+            .expect_err("a region with no width has no pixels to read")
+            .to_string();
+        assert!(flat_err.contains("zero area"), "{flat_err}");
         let thin = Region {
             x: 0,
             y: 0,
             width: 40,
             height: 0,
         };
-        assert!(plat.resolve_capture_rect(&geo, Some(&thin)).is_err());
+        let thin_err = plat
+            .resolve_capture_rect(&geo, Some(&thin))
+            .expect_err("a region with no height has no pixels to read")
+            .to_string();
+        assert!(thin_err.contains("zero area"), "{thin_err}");
         assert!(
             plat.resolve_capture_rect(&geo, None).is_ok(),
             "a window with area must still resolve"

--- a/crates/glass-x11/src/testx.rs
+++ b/crates/glass-x11/src/testx.rs
@@ -166,7 +166,7 @@ impl TestX {
     pub(crate) fn request_selection(&self, target: Atom, within: Duration) -> Option<Atom> {
         let requestor = self.window().unmapped().create();
         let clipboard = self.intern(b"CLIPBOARD");
-        let into = self.intern(b"GLASS_TEST_CLIP");
+        let into = self.intern(b"TEST_CLIP_TRANSFER");
         self.conn
             .convert_selection(requestor, clipboard, target, into, x11rb::CURRENT_TIME)
             .expect("convert_selection");

--- a/crates/glass-x11/src/testx.rs
+++ b/crates/glass-x11/src/testx.rs
@@ -52,10 +52,6 @@ impl TestX {
         &self.xvfb.display
     }
 
-    pub(crate) fn root(&self) -> Window {
-        self.root
-    }
-
     /// A backend attached to this display.
     pub(crate) fn platform(&self) -> X11Platform {
         X11Platform::connect(Some(self.display())).expect("the backend should connect")
@@ -150,6 +146,53 @@ impl TestX {
             .change_property32(PropMode::REPLACE, self.root, atom, AtomEnum::WINDOW, wins)
             .expect("set _NET_CLIENT_LIST");
         self.flush();
+    }
+
+    /// Take the CLIPBOARD selection for this client, which is how another application
+    /// displaces glass's owner — the server sends the previous owner a `SelectionClear`.
+    /// Returns the window now holding it.
+    pub(crate) fn take_clipboard(&self) -> Window {
+        let win = self.window().unmapped().create();
+        let clipboard = self.intern(b"CLIPBOARD");
+        self.conn
+            .set_selection_owner(win, clipboard, x11rb::CURRENT_TIME)
+            .expect("set_selection_owner");
+        self.flush();
+        win
+    }
+
+    /// Ask the current CLIPBOARD owner to convert the selection to `target`, and return the
+    /// property named in the reply — `x11rb::NONE` when the owner refuses.
+    pub(crate) fn request_selection(&self, target: Atom, within: Duration) -> Option<Atom> {
+        let requestor = self.window().unmapped().create();
+        let clipboard = self.intern(b"CLIPBOARD");
+        let into = self.intern(b"GLASS_TEST_CLIP");
+        self.conn
+            .convert_selection(requestor, clipboard, target, into, x11rb::CURRENT_TIME)
+            .expect("convert_selection");
+        self.flush();
+        let deadline = Instant::now() + within;
+        while Instant::now() < deadline {
+            if let Some(Event::SelectionNotify(n)) =
+                self.conn.poll_for_event().expect("poll_for_event")
+                && n.requestor == requestor
+            {
+                return Some(n.property);
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        None
+    }
+
+    /// How many windows the root currently has — a leaked temporary shows up here.
+    pub(crate) fn root_child_count(&self) -> usize {
+        self.conn
+            .query_tree(self.root)
+            .expect("query_tree")
+            .reply()
+            .expect("query_tree reply")
+            .children
+            .len()
     }
 
     pub(crate) fn destroy(&self, win: Window) {

--- a/crates/glass-x11/src/testx.rs
+++ b/crates/glass-x11/src/testx.rs
@@ -1,0 +1,237 @@
+//! A private X server and real client windows, for the tests that need actual X protocol.
+//!
+//! The backend's methods talk to a display, so most of them have no seam to fake at: there is
+//! no subprocess to stand in for and no trait to implement. An `Xvfb` starts in ~45ms, though,
+//! so the tests drive a real server and put real windows in front of the code instead.
+//!
+//! The windows belong to a *second* connection. A window the backend created itself would be
+//! matched by ids it already holds, which is not what enumeration has to do.
+
+use std::time::{Duration, Instant};
+
+use x11rb::connection::Connection;
+use x11rb::protocol::Event;
+use x11rb::protocol::xproto::*;
+use x11rb::rust_connection::RustConnection;
+use x11rb::wrapper::ConnectionExt as _;
+
+use crate::platform::X11Platform;
+use crate::xvfb::Xvfb;
+
+/// A private headless display, plus a client on it that is not the code under test.
+pub(crate) struct TestX {
+    xvfb: Xvfb,
+    conn: RustConnection,
+    root: Window,
+    root_visual: Visualid,
+}
+
+impl TestX {
+    /// A display at the size production defaults to.
+    pub(crate) fn start() -> TestX {
+        TestX::sized("1280x800x24")
+    }
+
+    /// A display at `screen` (`WxHxDepth`), for the capture tests, which are about what
+    /// happens at the display's edges.
+    pub(crate) fn sized(screen: &str) -> TestX {
+        let xvfb = Xvfb::start(screen).expect("a private Xvfb should start");
+        let (conn, screen_num) =
+            x11rb::connect(Some(&xvfb.display)).expect("the test client should connect");
+        let setup = &conn.setup().roots[screen_num];
+        let (root, root_visual) = (setup.root, setup.root_visual);
+        TestX {
+            xvfb,
+            conn,
+            root,
+            root_visual,
+        }
+    }
+
+    pub(crate) fn display(&self) -> &str {
+        &self.xvfb.display
+    }
+
+    pub(crate) fn root(&self) -> Window {
+        self.root
+    }
+
+    /// A backend attached to this display.
+    pub(crate) fn platform(&self) -> X11Platform {
+        X11Platform::connect(Some(self.display())).expect("the backend should connect")
+    }
+
+    pub(crate) fn intern(&self, name: &[u8]) -> Atom {
+        self.conn
+            .intern_atom(false, name)
+            .expect("intern")
+            .reply()
+            .expect("intern reply")
+            .atom
+    }
+
+    /// Start describing a window. Nothing is created until [`TestWindow::create`].
+    pub(crate) fn window(&self) -> TestWindow<'_> {
+        TestWindow {
+            x: self,
+            name: None,
+            class: None,
+            pid: None,
+            rect: (0, 0, 200, 100),
+            accepts_delete: false,
+            map: true,
+        }
+    }
+
+    /// Publish `wins` as the root's `_NET_CLIENT_LIST`, the list a window manager maintains.
+    /// Xvfb runs without one, so a test that is about that path has to write it.
+    pub(crate) fn set_client_list(&self, wins: &[Window]) {
+        let atom = self.intern(b"_NET_CLIENT_LIST");
+        self.conn
+            .change_property32(PropMode::REPLACE, self.root, atom, AtomEnum::WINDOW, wins)
+            .expect("set _NET_CLIENT_LIST");
+        self.flush();
+    }
+
+    pub(crate) fn destroy(&self, win: Window) {
+        self.conn.destroy_window(win).expect("destroy_window");
+        self.flush();
+    }
+
+    /// Block until the server has processed everything sent so far, so a subsequent read on
+    /// the backend's own connection cannot race the writes above it.
+    pub(crate) fn flush(&self) {
+        self.conn.sync().expect("sync");
+    }
+
+    /// The next event this client receives, or `None` once `within` elapses. Used to prove a
+    /// message the backend claims to have sent actually arrived.
+    pub(crate) fn next_event(&self, within: Duration) -> Option<Event> {
+        let deadline = Instant::now() + within;
+        while Instant::now() < deadline {
+            match self.conn.poll_for_event().expect("poll_for_event") {
+                Some(e) => return Some(e),
+                None => std::thread::sleep(Duration::from_millis(5)),
+            }
+        }
+        None
+    }
+}
+
+/// A window to create on the test display. Only the properties a test is about need naming.
+pub(crate) struct TestWindow<'a> {
+    x: &'a TestX,
+    name: Option<String>,
+    class: Option<(String, String)>,
+    pid: Option<u32>,
+    rect: (i16, i16, u16, u16),
+    accepts_delete: bool,
+    map: bool,
+}
+
+impl TestWindow<'_> {
+    /// Sets `WM_NAME`, what `window_name` reads.
+    pub(crate) fn named(mut self, name: &str) -> Self {
+        self.name = Some(name.to_string());
+        self
+    }
+
+    /// Sets `WM_CLASS` as the NUL-separated `instance\0class\0` pair ICCCM specifies.
+    pub(crate) fn classed(mut self, instance: &str, class: &str) -> Self {
+        self.class = Some((instance.to_string(), class.to_string()));
+        self
+    }
+
+    /// Sets `_NET_WM_PID`, the property window enumeration filters the app's windows by.
+    pub(crate) fn owned_by(mut self, pid: u32) -> Self {
+        self.pid = Some(pid);
+        self
+    }
+
+    pub(crate) fn at(mut self, x: i16, y: i16) -> Self {
+        self.rect.0 = x;
+        self.rect.1 = y;
+        self
+    }
+
+    pub(crate) fn sized(mut self, w: u16, h: u16) -> Self {
+        self.rect.2 = w;
+        self.rect.3 = h;
+        self
+    }
+
+    /// Advertises `WM_DELETE_WINDOW` in `WM_PROTOCOLS`, making the window one the close
+    /// request can be sent to.
+    pub(crate) fn accepting_delete(mut self) -> Self {
+        self.accepts_delete = true;
+        self
+    }
+
+    /// Leaves the window unmapped — present in the tree but not on screen.
+    pub(crate) fn unmapped(mut self) -> Self {
+        self.map = false;
+        self
+    }
+
+    pub(crate) fn create(self) -> Window {
+        let conn = &self.x.conn;
+        let win = conn.generate_id().expect("generate_id");
+        let (x, y, w, h) = self.rect;
+        conn.create_window(
+            x11rb::COPY_DEPTH_FROM_PARENT,
+            win,
+            self.x.root,
+            x,
+            y,
+            w,
+            h,
+            0,
+            WindowClass::INPUT_OUTPUT,
+            self.x.root_visual,
+            &CreateWindowAux::new(),
+        )
+        .expect("create_window");
+
+        if let Some(name) = &self.name {
+            conn.change_property8(
+                PropMode::REPLACE,
+                win,
+                AtomEnum::WM_NAME,
+                AtomEnum::STRING,
+                name.as_bytes(),
+            )
+            .expect("WM_NAME");
+        }
+        if let Some((instance, class)) = &self.class {
+            let mut value = Vec::new();
+            value.extend_from_slice(instance.as_bytes());
+            value.push(0);
+            value.extend_from_slice(class.as_bytes());
+            value.push(0);
+            conn.change_property8(
+                PropMode::REPLACE,
+                win,
+                AtomEnum::WM_CLASS,
+                AtomEnum::STRING,
+                &value,
+            )
+            .expect("WM_CLASS");
+        }
+        if let Some(pid) = self.pid {
+            let atom = self.x.intern(b"_NET_WM_PID");
+            conn.change_property32(PropMode::REPLACE, win, atom, AtomEnum::CARDINAL, &[pid])
+                .expect("_NET_WM_PID");
+        }
+        if self.accepts_delete {
+            let protocols = self.x.intern(b"WM_PROTOCOLS");
+            let delete = self.x.intern(b"WM_DELETE_WINDOW");
+            conn.change_property32(PropMode::REPLACE, win, protocols, AtomEnum::ATOM, &[delete])
+                .expect("WM_PROTOCOLS");
+        }
+        if self.map {
+            conn.map_window(win).expect("map_window");
+        }
+        self.x.flush();
+        win
+    }
+}

--- a/crates/glass-x11/src/testx.rs
+++ b/crates/glass-x11/src/testx.rs
@@ -80,7 +80,66 @@ impl TestX {
             rect: (0, 0, 200, 100),
             accepts_delete: false,
             map: true,
+            events: EventMask::NO_EVENT,
+            background: None,
         }
+    }
+
+    /// Where the pointer is, in root coordinates, and which buttons are down — how a test
+    /// sees the effect of XTEST motion and button events.
+    pub(crate) fn pointer(&self) -> (i16, i16, KeyButMask) {
+        let p = self
+            .conn
+            .query_pointer(self.root)
+            .expect("query_pointer")
+            .reply()
+            .expect("query_pointer reply");
+        (p.root_x, p.root_y, p.mask)
+    }
+
+    /// Whether `keycode` is currently held down, read from the server's own keyboard state.
+    pub(crate) fn key_is_down(&self, keycode: u8) -> bool {
+        let keys = self
+            .conn
+            .query_keymap()
+            .expect("query_keymap")
+            .reply()
+            .expect("query_keymap reply")
+            .keys;
+        keys[keycode as usize / 8] & (1 << (keycode % 8)) != 0
+    }
+
+    /// The window the server currently sends key events to.
+    pub(crate) fn focused(&self) -> Window {
+        self.conn
+            .get_input_focus()
+            .expect("get_input_focus")
+            .reply()
+            .expect("get_input_focus reply")
+            .focus
+    }
+
+    /// The whole keyboard mapping, as `keycode_for` reads it: `(min, max, per, keysyms)`.
+    pub(crate) fn keymap(&self) -> (u8, u8, usize, Vec<u32>) {
+        let setup = self.conn.setup();
+        let (min, max) = (setup.min_keycode, setup.max_keycode);
+        let m = self
+            .conn
+            .get_keyboard_mapping(min, max - min + 1)
+            .expect("get_keyboard_mapping")
+            .reply()
+            .expect("keyboard mapping reply");
+        (min, max, m.keysyms_per_keycode as usize, m.keysyms)
+    }
+
+    /// Drain and return every event queued for this client.
+    pub(crate) fn drain_events(&self, settle: Duration) -> Vec<Event> {
+        std::thread::sleep(settle);
+        let mut out = Vec::new();
+        while let Some(e) = self.conn.poll_for_event().expect("poll_for_event") {
+            out.push(e);
+        }
+        out
     }
 
     /// Publish `wins` as the root's `_NET_CLIENT_LIST`, the list a window manager maintains.
@@ -127,9 +186,28 @@ pub(crate) struct TestWindow<'a> {
     rect: (i16, i16, u16, u16),
     accepts_delete: bool,
     map: bool,
+    events: EventMask,
+    background: Option<u32>,
 }
 
 impl TestWindow<'_> {
+    /// Selects the input events XTEST synthesises, so a test can read back what the backend
+    /// actually sent rather than only that the call returned `Ok`.
+    pub(crate) fn watching_input(mut self) -> Self {
+        self.events = EventMask::KEY_PRESS
+            | EventMask::KEY_RELEASE
+            | EventMask::BUTTON_PRESS
+            | EventMask::BUTTON_RELEASE;
+        self
+    }
+
+    /// Fills the window with `pixel`, giving a capture something other than the root's black
+    /// to read.
+    pub(crate) fn filled_with(mut self, pixel: u32) -> Self {
+        self.background = Some(pixel);
+        self
+    }
+
     /// Sets `WM_NAME`, what `window_name` reads.
     pub(crate) fn named(mut self, name: &str) -> Self {
         self.name = Some(name.to_string());
@@ -177,6 +255,10 @@ impl TestWindow<'_> {
         let conn = &self.x.conn;
         let win = conn.generate_id().expect("generate_id");
         let (x, y, w, h) = self.rect;
+        let mut aux = CreateWindowAux::new().event_mask(self.events);
+        if let Some(pixel) = self.background {
+            aux = aux.background_pixel(pixel);
+        }
         conn.create_window(
             x11rb::COPY_DEPTH_FROM_PARENT,
             win,
@@ -188,7 +270,7 @@ impl TestWindow<'_> {
             0,
             WindowClass::INPUT_OUTPUT,
             self.x.root_visual,
-            &CreateWindowAux::new(),
+            &aux,
         )
         .expect("create_window");
 

--- a/crates/glass-x11/src/testx.rs
+++ b/crates/glass-x11/src/testx.rs
@@ -1,11 +1,13 @@
 //! A private X server and real client windows, for the tests that need actual X protocol.
 //!
 //! The backend's methods talk to a display, so most of them have no seam to fake at: there is
-//! no subprocess to stand in for and no trait to implement. An `Xvfb` starts in ~45ms, though,
-//! so the tests drive a real server and put real windows in front of the code instead.
+//! no subprocess to stand in for and no trait to implement. Starting a server per test is
+//! cheap enough, so the tests drive a real one and put real windows in front of the code.
 //!
-//! The windows belong to a *second* connection. A window the backend created itself would be
-//! matched by ids it already holds, which is not what enumeration has to do.
+//! The windows belong to a *second* connection, for two reasons: the X server delivers a
+//! window's input events to the client that created it, so the harness needs an event queue
+//! of its own; and two connections have no ordering between them, which is why every read of
+//! the server's state goes through a round trip ([`TestX::flush`]).
 
 use std::time::{Duration, Instant};
 
@@ -161,9 +163,14 @@ impl TestX {
         win
     }
 
-    /// Ask the current CLIPBOARD owner to convert the selection to `target`, and return the
-    /// property named in the reply — `x11rb::NONE` when the owner refuses.
-    pub(crate) fn request_selection(&self, target: Atom, within: Duration) -> Option<Atom> {
+    /// Ask the current CLIPBOARD owner to convert the selection to `target`. Returns the
+    /// requestor window and the property named in the reply — `x11rb::NONE` when the owner
+    /// refuses. The window comes back because that is where the converted value was written.
+    pub(crate) fn request_selection(
+        &self,
+        target: Atom,
+        within: Duration,
+    ) -> Option<(Window, Atom)> {
         let requestor = self.window().unmapped().create();
         let clipboard = self.intern(b"CLIPBOARD");
         let into = self.intern(b"TEST_CLIP_TRANSFER");
@@ -177,11 +184,23 @@ impl TestX {
                 self.conn.poll_for_event().expect("poll_for_event")
                 && n.requestor == requestor
             {
-                return Some(n.property);
+                return Some((requestor, n.property));
             }
             std::thread::sleep(Duration::from_millis(5));
         }
         None
+    }
+
+    /// The atoms stored in `prop` on `win` — how a requestor reads a TARGETS reply.
+    pub(crate) fn property_atoms(&self, win: Window, prop: Atom) -> Vec<Atom> {
+        self.conn
+            .get_property(false, win, prop, AtomEnum::ATOM, 0, 64)
+            .expect("get_property")
+            .reply()
+            .expect("get_property reply")
+            .value32()
+            .map(|it| it.collect())
+            .unwrap_or_default()
     }
 
     /// The window currently holding the CLIPBOARD selection, or `x11rb::NONE`.

--- a/crates/glass-x11/src/testx.rs
+++ b/crates/glass-x11/src/testx.rs
@@ -184,6 +184,17 @@ impl TestX {
         None
     }
 
+    /// The window currently holding the CLIPBOARD selection, or `x11rb::NONE`.
+    pub(crate) fn clipboard_owner(&self) -> Window {
+        let clipboard = self.intern(b"CLIPBOARD");
+        self.conn
+            .get_selection_owner(clipboard)
+            .expect("get_selection_owner")
+            .reply()
+            .expect("get_selection_owner reply")
+            .owner
+    }
+
     /// How many windows the root currently has — a leaked temporary shows up here.
     pub(crate) fn root_child_count(&self) -> usize {
         self.conn

--- a/crates/glass-x11/src/xvfb.rs
+++ b/crates/glass-x11/src/xvfb.rs
@@ -176,10 +176,7 @@ fn with_stderr(msg: String, stderr: &str) -> String {
     if stderr.len() <= STDERR_SHOWN {
         return format!("{msg}; Xvfb stderr: {stderr}");
     }
-    let mut cut = STDERR_SHOWN;
-    while !stderr.is_char_boundary(cut) {
-        cut -= 1;
-    }
+    let cut = stderr.floor_char_boundary(STDERR_SHOWN);
     format!(
         "{msg}; Xvfb stderr (first {cut} bytes of {}): {}…",
         stderr.len(),
@@ -325,6 +322,30 @@ mod tests {
         panic!("ETXTBSY persisted after 100 retries: {last:?}")
     }
 
+    /// Spawn a fixture script directly with its stderr piped, for the tests that drive
+    /// `StderrTail` rather than a whole start. Retries past ETXTBSY for the same reason
+    /// `start_fixture` does.
+    fn spawn_fixture(script: &std::path::Path) -> std::process::Child {
+        for _ in 0..100 {
+            match Command::new(script)
+                .stdout(Stdio::null())
+                .stderr(Stdio::piped())
+                .spawn()
+            {
+                Ok(child) => return child,
+                Err(e) if e.kind() == std::io::ErrorKind::ExecutableFileBusy => {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(e) => panic!("the fixture {} is not runnable: {e}", script.display()),
+            }
+        }
+        panic!("the fixture stayed ETXTBSY after 100 retries")
+    }
+
+    fn running(pid: u32) -> bool {
+        std::path::Path::new(&format!("/proc/{pid}")).exists()
+    }
+
     /// Write an executable fake-Xvfb shell script into a unique temp dir and
     /// return its path. `$0.ran` is the script's own scratch marker.
     fn fixture(name: &str, body: &str) -> std::path::PathBuf {
@@ -335,6 +356,87 @@ mod tests {
         std::fs::write(&p, format!("#!/bin/sh\n{body}")).unwrap();
         std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
         p
+    }
+
+    #[test]
+    fn the_start_deadline_covers_both_attempts_and_both_reaps() {
+        // doctor's deep probe puts its own timeout around `Xvfb::start`. Budget less than
+        // the wedge-retry ladder actually takes and it reports a start that the retry
+        // would have completed as a failure.
+        let one_attempt = super::READY_TIMEOUT + glass_proc_linux::REAP_GRACE;
+        assert!(
+            super::start_deadline() >= one_attempt + one_attempt,
+            "a caller budgeting {:?} cannot outlast two wedged attempts",
+            super::start_deadline()
+        );
+    }
+
+    #[test]
+    fn a_multibyte_char_straddling_the_clip_point_is_not_split() {
+        // Xvfb's stderr is whatever the server prints, which is not guaranteed ASCII;
+        // slicing mid-character would panic on the error path itself.
+        let head = "a".repeat(super::STDERR_SHOWN - 1);
+        let out = super::with_stderr("Xvfb failed".into(), &format!("{head}é{}", "b".repeat(600)));
+        assert!(
+            out.contains(&format!("first {} bytes", super::STDERR_SHOWN - 1)),
+            "must clip back to the boundary before the two-byte char: {out}"
+        );
+    }
+
+    #[test]
+    fn the_drain_stops_keeping_bytes_at_the_documented_cap() {
+        // A server dumping megabytes must cost bounded memory, while the kept head stays
+        // large enough for a real Xvfb option table (~5KB).
+        let script = fixture(
+            "flood.sh",
+            "dd if=/dev/zero bs=1024 count=64 2>/dev/null | tr '\\0' e >&2\n",
+        );
+        let mut child = spawn_fixture(&script);
+        let tail = super::StderrTail::drain(child.stderr.take().expect("piped stderr"));
+        child.wait().expect("fixture exits");
+        assert_eq!(tail.snapshot(Duration::from_secs(5)).len(), 8 * 1024);
+    }
+
+    #[test]
+    fn a_snapshot_waits_for_the_pipe_to_close_before_reading() {
+        // The diagnostics arrive after the caller asks for them. Read without waiting for
+        // EOF and a failed start reports an empty stderr — the only clue it had.
+        let script = fixture(
+            "late-stderr.sh",
+            "sleep 0.3\nprintf 'the fatal line\\n' >&2\n",
+        );
+        let mut child = spawn_fixture(&script);
+        let tail = super::StderrTail::drain(child.stderr.take().expect("piped stderr"));
+        let captured = tail.snapshot(Duration::from_secs(5));
+        child.wait().expect("fixture exits");
+        assert_eq!(captured, "the fatal line");
+    }
+
+    #[test]
+    fn the_reported_pid_is_the_server_itself() {
+        // A test that SIGSTOPs this pid to make the display unresponsive stops something
+        // else entirely if it is wrong.
+        let script = fixture("pid.sh", "echo 4321\nexec sleep 30\n");
+        let server = start_fixture(&script, Duration::from_secs(5)).expect("must start");
+        let cmdline = std::fs::read(format!("/proc/{}/cmdline", server.pid()))
+            .expect("the reported pid must be a live process");
+        let cmdline = String::from_utf8_lossy(&cmdline);
+        assert!(
+            cmdline.contains("pid.sh"),
+            "the reported pid must be this fixture's server, not another process: {cmdline}"
+        );
+    }
+
+    #[test]
+    fn dropping_the_server_reaps_it() {
+        // Without this the display outlives the session that spawned it, and a run that
+        // starts a few of them leaves an X server per launch behind.
+        let script = fixture("reap.sh", "echo 4321\nexec sleep 30\n");
+        let server = start_fixture(&script, Duration::from_secs(5)).expect("must start");
+        let pid = server.pid();
+        assert!(running(pid), "the fixture server should be up first");
+        drop(server);
+        assert!(!running(pid), "pid {pid} outlived the Xvfb that owned it");
     }
 
     #[test]

--- a/crates/glass-x11/src/xvfb.rs
+++ b/crates/glass-x11/src/xvfb.rs
@@ -282,38 +282,42 @@ fn read_displayfd(
     }
 }
 
-/// The pid inside `/tmp/.X{num}-lock`, which an X server fills with its own. The only way to
-/// tell a lock this server left behind from one the next server on that number just created.
-fn lock_holder(num: &str) -> Option<u32> {
-    std::fs::read_to_string(format!("/tmp/.X{num}-lock"))
-        .ok()?
-        .trim()
-        .parse()
-        .ok()
+fn socket_path(num: &str) -> String {
+    format!("/tmp/.X11-unix/X{num}")
+}
+
+/// Whether display `num`'s socket exists with nothing listening on it. Do not tell a
+/// leftover from a live server by inode instead: an inode is recycled onto whatever binds
+/// the path next.
+fn socket_is_stale(num: &str) -> bool {
+    matches!(
+        std::os::unix::net::UnixStream::connect(socket_path(num)),
+        Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused
+    )
 }
 
 impl Drop for Xvfb {
     fn drop(&mut self) {
-        let pid = self.child.id();
         glass_proc_linux::reap_graceful(&mut self.child, glass_proc_linux::REAP_GRACE);
-        // Fallback: Xvfb removes its own lock/socket on SIGTERM, but if it had to be
-        // SIGKILLed (ignored SIGTERM) they linger.
+        // Fallback for a server that had to be SIGKILLed: SIGTERM makes Xvfb remove its own
+        // socket, SIGKILL leaves it behind. (`-displayfd` mode takes no `/tmp/.X{N}-lock`,
+        // so there is never one of those to clean up.)
         //
-        // Do not remove these unconditionally: the display number is free the moment the
-        // process dies, so another Xvfb can already hold it and the removal deletes a live
-        // server's socket. Socket first — nobody can take the number while our lock is there.
+        // Do not remove it unconditionally: the display number is free the moment the
+        // process dies, so another Xvfb can already have bound that path. Nor skip the
+        // cleanup — Xvfb passes over a number whose socket is present, so each leftover
+        // costs one.
         if let Some(num) = self.display.strip_prefix(':')
-            && lock_holder(num) == Some(pid)
+            && socket_is_stale(num)
         {
-            let _ = std::fs::remove_file(format!("/tmp/.X11-unix/X{num}"));
-            let _ = std::fs::remove_file(format!("/tmp/.X{num}-lock"));
+            let _ = std::fs::remove_file(socket_path(num));
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{ReadErr, Xvfb, read_displayfd, start_binary};
+    use super::{ReadErr, Xvfb, read_displayfd, socket_path, start_binary};
     use glass_core::{GlassError, Result};
     use std::process::{Command, Stdio};
     use std::time::Duration;
@@ -361,6 +365,32 @@ mod tests {
 
     fn running(pid: u32) -> bool {
         std::path::Path::new(&format!("/proc/{pid}")).exists()
+    }
+
+    fn exists(path: &str) -> bool {
+        std::path::Path::new(path).exists()
+    }
+
+    /// A signalled child stays in `/proc` as a zombie until its parent reaps it, so "gone"
+    /// here means gone or dead-but-unreaped.
+    fn dead(pid: u32) -> bool {
+        match std::fs::read_to_string(format!("/proc/{pid}/status")) {
+            Err(_) => true,
+            Ok(status) => status
+                .lines()
+                .any(|l| l.starts_with("State:") && l.contains('Z')),
+        }
+    }
+
+    /// Wait up to a second for `f` to hold.
+    fn eventually(mut f: impl FnMut() -> bool) -> bool {
+        for _ in 0..100 {
+            if f() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        f()
     }
 
     /// Write an executable fake-Xvfb shell script into a unique temp dir and
@@ -457,6 +487,7 @@ mod tests {
         // process already on its way out.
         let live = Xvfb::start("640x480x24").expect("a server should start");
         let display = live.display.clone();
+        let num = display.trim_start_matches(':').to_string();
 
         let mut placeholder = Command::new("sleep")
             .arg("30")
@@ -469,11 +500,45 @@ mod tests {
             display: display.clone(),
             displayfd,
         });
+        assert!(
+            exists(&socket_path(&num)),
+            "{display}\'s socket was deleted"
+        );
 
         assert!(
             x11rb::connect(Some(&display)).is_ok(),
             "{display} stopped answering when a server that no longer owned it was torn down"
         );
+    }
+
+    #[test]
+    fn a_server_that_had_to_be_killed_has_its_socket_removed() {
+        // The only case that reaches the fallback: a server sent SIGTERM removes its own
+        // socket, leaving nothing to clean up.
+        let server = Xvfb::start("640x480x24").expect("a server should start");
+        let num = server
+            .display
+            .strip_prefix(':')
+            .expect("a display is :N")
+            .to_string();
+        let socket = socket_path(&num);
+        assert!(exists(&socket), "a live server holds {socket}");
+
+        Command::new("kill")
+            .args(["-9", &server.pid().to_string()])
+            .status()
+            .expect("kill");
+        assert!(
+            eventually(|| dead(server.pid())),
+            "the server should be gone after SIGKILL"
+        );
+        assert!(
+            exists(&socket),
+            "a killed server cannot have removed {socket} itself"
+        );
+
+        drop(server);
+        assert!(!exists(&socket), "{socket} was left behind");
     }
 
     #[test]

--- a/crates/glass-x11/src/xvfb.rs
+++ b/crates/glass-x11/src/xvfb.rs
@@ -437,12 +437,19 @@ mod tests {
         // else entirely if it is wrong.
         let script = fixture("pid.sh", "echo 4321\nexec sleep 30\n");
         let server = start_fixture(&script, Duration::from_secs(5)).expect("must start");
-        let cmdline = std::fs::read(format!("/proc/{}/cmdline", server.pid()))
+        // Its parent, not its command line: the fixture `exec`s, so what it is running
+        // changes under it, while who spawned it does not.
+        let status = std::fs::read_to_string(format!("/proc/{}/status", server.pid()))
             .expect("the reported pid must be a live process");
-        let cmdline = String::from_utf8_lossy(&cmdline);
-        assert!(
-            cmdline.contains("pid.sh"),
-            "the reported pid must be this fixture's server, not another process: {cmdline}"
+        let parent = status
+            .lines()
+            .find_map(|l| l.strip_prefix("PPid:"))
+            .map(|v| v.trim().to_string())
+            .expect("every process reports a parent");
+        assert_eq!(
+            parent,
+            std::process::id().to_string(),
+            "the reported pid must be the server this test spawned, not another process"
         );
     }
 

--- a/crates/glass-x11/src/xvfb.rs
+++ b/crates/glass-x11/src/xvfb.rs
@@ -299,11 +299,9 @@ impl Drop for Xvfb {
         // Fallback: Xvfb removes its own lock/socket on SIGTERM, but if it had to be
         // SIGKILLed (ignored SIGTERM) they linger.
         //
-        // Only when the lock still names OUR server. The display number is free the moment
-        // the process dies, so by the time this runs another Xvfb can already hold it, and
-        // removing unconditionally deletes a live server's socket — after which a start that
-        // reported ready refuses the very next connection. Socket first: nobody else can take
-        // the number while the lock we own is still there.
+        // Do not remove these unconditionally: the display number is free the moment the
+        // process dies, so another Xvfb can already hold it and the removal deletes a live
+        // server's socket. Socket first — nobody can take the number while our lock is there.
         if let Some(num) = self.display.strip_prefix(':')
             && lock_holder(num) == Some(pid)
         {
@@ -455,9 +453,8 @@ mod tests {
 
     #[test]
     fn tearing_down_a_departed_server_leaves_its_reused_display_number_alone() {
-        // A display number is free the moment its server's process dies, so the next Xvfb can
-        // hold it before the previous one's cleanup runs. `departed` stands in for that
-        // previous server: same number, process already on its way out.
+        // `departed` stands in for a server that held this number first: same display,
+        // process already on its way out.
         let live = Xvfb::start("640x480x24").expect("a server should start");
         let display = live.display.clone();
 

--- a/crates/glass-x11/src/xvfb.rs
+++ b/crates/glass-x11/src/xvfb.rs
@@ -282,42 +282,18 @@ fn read_displayfd(
     }
 }
 
-fn socket_path(num: &str) -> String {
-    format!("/tmp/.X11-unix/X{num}")
-}
-
-/// Whether display `num`'s socket exists with nothing listening on it. Do not tell a
-/// leftover from a live server by inode instead: an inode is recycled onto whatever binds
-/// the path next.
-fn socket_is_stale(num: &str) -> bool {
-    matches!(
-        std::os::unix::net::UnixStream::connect(socket_path(num)),
-        Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused
-    )
-}
-
 impl Drop for Xvfb {
+    /// Reaping is the whole teardown. Do not add back a sweep of `/tmp/.X11-unix/X{N}`: the
+    /// next Xvfb connect-probes that path and rebinds a refusing one, so a SIGKILLed server's
+    /// leftover costs nothing — while unlinking it cuts off whoever reclaimed the number.
     fn drop(&mut self) {
         glass_proc_linux::reap_graceful(&mut self.child, glass_proc_linux::REAP_GRACE);
-        // Fallback for a server that had to be SIGKILLed: SIGTERM makes Xvfb remove its own
-        // socket, SIGKILL leaves it behind. (`-displayfd` mode takes no `/tmp/.X{N}-lock`,
-        // so there is never one of those to clean up.)
-        //
-        // Do not remove it unconditionally: the display number is free the moment the
-        // process dies, so another Xvfb can already have bound that path. Nor skip the
-        // cleanup — Xvfb passes over a number whose socket is present, so each leftover
-        // costs one.
-        if let Some(num) = self.display.strip_prefix(':')
-            && socket_is_stale(num)
-        {
-            let _ = std::fs::remove_file(socket_path(num));
-        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{ReadErr, Xvfb, read_displayfd, socket_path, start_binary};
+    use super::{ReadErr, Xvfb, read_displayfd, start_binary};
     use glass_core::{GlassError, Result};
     use std::process::{Command, Stdio};
     use std::time::Duration;
@@ -365,32 +341,6 @@ mod tests {
 
     fn running(pid: u32) -> bool {
         std::path::Path::new(&format!("/proc/{pid}")).exists()
-    }
-
-    fn exists(path: &str) -> bool {
-        std::path::Path::new(path).exists()
-    }
-
-    /// A signalled child stays in `/proc` as a zombie until its parent reaps it, so "gone"
-    /// here means gone or dead-but-unreaped.
-    fn dead(pid: u32) -> bool {
-        match std::fs::read_to_string(format!("/proc/{pid}/status")) {
-            Err(_) => true,
-            Ok(status) => status
-                .lines()
-                .any(|l| l.starts_with("State:") && l.contains('Z')),
-        }
-    }
-
-    /// Wait up to a second for `f` to hold.
-    fn eventually(mut f: impl FnMut() -> bool) -> bool {
-        for _ in 0..100 {
-            if f() {
-                return true;
-            }
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        f()
     }
 
     /// Write an executable fake-Xvfb shell script into a unique temp dir and
@@ -479,66 +429,6 @@ mod tests {
             std::process::id().to_string(),
             "the reported pid must be the server this test spawned, not another process"
         );
-    }
-
-    #[test]
-    fn tearing_down_a_departed_server_leaves_its_reused_display_number_alone() {
-        // `departed` stands in for a server that held this number first: same display,
-        // process already on its way out.
-        let live = Xvfb::start("640x480x24").expect("a server should start");
-        let display = live.display.clone();
-        let num = display.trim_start_matches(':').to_string();
-
-        let mut placeholder = Command::new("sleep")
-            .arg("30")
-            .stdout(Stdio::piped())
-            .spawn()
-            .expect("spawn the placeholder");
-        let displayfd = placeholder.stdout.take().expect("piped stdout");
-        drop(Xvfb {
-            child: placeholder,
-            display: display.clone(),
-            displayfd,
-        });
-        assert!(
-            exists(&socket_path(&num)),
-            "{display}\'s socket was deleted"
-        );
-
-        assert!(
-            x11rb::connect(Some(&display)).is_ok(),
-            "{display} stopped answering when a server that no longer owned it was torn down"
-        );
-    }
-
-    #[test]
-    fn a_server_that_had_to_be_killed_has_its_socket_removed() {
-        // The only case that reaches the fallback: a server sent SIGTERM removes its own
-        // socket, leaving nothing to clean up.
-        let server = Xvfb::start("640x480x24").expect("a server should start");
-        let num = server
-            .display
-            .strip_prefix(':')
-            .expect("a display is :N")
-            .to_string();
-        let socket = socket_path(&num);
-        assert!(exists(&socket), "a live server holds {socket}");
-
-        Command::new("kill")
-            .args(["-9", &server.pid().to_string()])
-            .status()
-            .expect("kill");
-        assert!(
-            eventually(|| dead(server.pid())),
-            "the server should be gone after SIGKILL"
-        );
-        assert!(
-            exists(&socket),
-            "a killed server cannot have removed {socket} itself"
-        );
-
-        drop(server);
-        assert!(!exists(&socket), "{socket} was left behind");
     }
 
     #[test]

--- a/crates/glass-x11/src/xvfb.rs
+++ b/crates/glass-x11/src/xvfb.rs
@@ -282,14 +282,33 @@ fn read_displayfd(
     }
 }
 
+/// The pid inside `/tmp/.X{num}-lock`, which an X server fills with its own. The only way to
+/// tell a lock this server left behind from one the next server on that number just created.
+fn lock_holder(num: &str) -> Option<u32> {
+    std::fs::read_to_string(format!("/tmp/.X{num}-lock"))
+        .ok()?
+        .trim()
+        .parse()
+        .ok()
+}
+
 impl Drop for Xvfb {
     fn drop(&mut self) {
+        let pid = self.child.id();
         glass_proc_linux::reap_graceful(&mut self.child, glass_proc_linux::REAP_GRACE);
-        // Fallback: Xvfb removes its own lock/socket on SIGTERM, but if it had to
-        // be SIGKILLed (ignored SIGTERM) they linger; clean them up.
-        if let Some(num) = self.display.strip_prefix(':') {
-            let _ = std::fs::remove_file(format!("/tmp/.X{num}-lock"));
+        // Fallback: Xvfb removes its own lock/socket on SIGTERM, but if it had to be
+        // SIGKILLed (ignored SIGTERM) they linger.
+        //
+        // Only when the lock still names OUR server. The display number is free the moment
+        // the process dies, so by the time this runs another Xvfb can already hold it, and
+        // removing unconditionally deletes a live server's socket — after which a start that
+        // reported ready refuses the very next connection. Socket first: nobody else can take
+        // the number while the lock we own is still there.
+        if let Some(num) = self.display.strip_prefix(':')
+            && lock_holder(num) == Some(pid)
+        {
             let _ = std::fs::remove_file(format!("/tmp/.X11-unix/X{num}"));
+            let _ = std::fs::remove_file(format!("/tmp/.X{num}-lock"));
         }
     }
 }
@@ -424,6 +443,32 @@ mod tests {
         assert!(
             cmdline.contains("pid.sh"),
             "the reported pid must be this fixture's server, not another process: {cmdline}"
+        );
+    }
+
+    #[test]
+    fn tearing_down_a_departed_server_leaves_its_reused_display_number_alone() {
+        // A display number is free the moment its server's process dies, so the next Xvfb can
+        // hold it before the previous one's cleanup runs. `departed` stands in for that
+        // previous server: same number, process already on its way out.
+        let live = Xvfb::start("640x480x24").expect("a server should start");
+        let display = live.display.clone();
+
+        let mut placeholder = Command::new("sleep")
+            .arg("30")
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn the placeholder");
+        let displayfd = placeholder.stdout.take().expect("piped stdout");
+        drop(Xvfb {
+            child: placeholder,
+            display: display.clone(),
+            displayfd,
+        });
+
+        assert!(
+            x11rb::connect(Some(&display)).is_ok(),
+            "{display} stopped answering when a server that no longer owned it was torn down"
         );
     }
 


### PR DESCRIPTION
Brings `glass-x11` to zero mutation survivors and adds it to both mutation jobs, alongside `glass-core` and `glass-android`.

Most of this backend's methods talk to a display, so there is no subprocess to stand in for and no trait to implement. Starting an `Xvfb` per test is cheap, so the tests drive a real server and put real windows in front of the code; the windows belong to a second connection, because the X server delivers a window's input events to the client that created it. Every input assertion reads the server's own state — `query_pointer`, `query_keymap`, `get_input_focus` — or the events a watching window received, since `Ok(())` from an input call means the request was written, not that anything moved.

52 → 153 unit tests, suite ~4s, no app or toolkit required.

## Production changes

Three fixes, each measured on a real server:

- **`Xvfb::drop` no longer sweeps `/tmp/.X11-unix/X{N}`.** It unlinked the socket unconditionally, which cut off any session that had already reclaimed the display number. The sweep bought nothing to offset that: the next Xvfb connect-probes the path and rebinds a refusing one, so a SIGKILLed server's leftover costs no display number. Teardown is now reaping alone.
- **`sandbox:"off"` no longer forks bubblewrap.** The availability probe runs `bwrap --unshare-user`; it is now behind a thunk, so the one setting that exists for machines where bubblewrap does not work no longer pays for it on every launch.
- **`Conn`-adjacent seams extracted so both answers are reachable from a test**: `keycode_in` (against a live server every arithmetic slip in the keymap search still lands on some real key), `ensure_sandbox_available`, `clip_note`, `probe_budget`, `which_in`/`resolve_bin`, `checks_for`, and one `X11Platform::commit` in place of three byte-identical per-sink helpers.

Five things came out as provably redundant, each confirmed by ablation: the origin terms of `clipped` in `coords` (a shifted origin cannot leave the size intact), the hand-rolled char-boundary loop, `WindowGuard`, `ClipboardOwner::stop`, and those three `flush` helpers.

## CI

Both mutation jobs gate `glass-x11`; `check` and `coverage` gain `xvfb` and `at-spi2-core`, without which `cargo test --workspace` fails on a clean runner. The `Mutation gate (glass-core)` job name is unchanged — it is the required status check in the branch ruleset, and renaming it blocks every pull request.

## Follow-ups

Pre-existing issues found on the way, filed rather than folded in: #371, #372, #373, #374, #375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)