### PR TITLE
test(x11): ignore the display-backed tests, and run them where a display is

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,9 +327,8 @@ jobs:
           tool: cargo-mutants,cargo-nextest
       - name: Install the X and a11y stack glass-x11's tests drive
         if: steps.diff.outputs.touched == 'true'
-        # scripts/mutants.sh runs the `#[ignore]`d tests, so these are needed here even though
-        # the `check` job no longer wants them. Absent either, the unmutated baseline fails and
-        # the run grades nothing.
+        # The mutation wrapper runs the `#[ignore]`d tests (see its header); absent either
+        # package the unmutated baseline fails and the run grades nothing.
         run: sudo apt-get update && sudo apt-get install -y xvfb at-spi2-core
       - name: Mutation gate
         if: steps.diff.outputs.touched == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,8 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: .
-      # glass-x11's Xvfb-backed tests still run here; glass-wayland's are `#[ignore]`d and run
-      # only under the mutation gate and the Wayland job.
-      - run: sudo apt-get update && sudo apt-get install -y xvfb at-spi2-core
+      # No display stack: every test that wants one is `#[ignore]`d, so this job — and a
+      # contributor's bare checkout — needs nothing installed.
       - run: cargo build --workspace --all-targets --locked
       - run: cargo clippy --workspace --all-targets --locked -- -D warnings
       - run: cargo test --workspace --locked
@@ -89,6 +88,9 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y xvfb bubblewrap python3-gi gir1.2-gtk-4.0 zenity at-spi2-core
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+      # glass-x11's display-backed unit tests are `#[ignore]`d so a bare checkout can run the
+      # suite; this is the job with the display, so it is where they run.
+      - run: cargo test -p glass-x11 --locked -- --include-ignored
       - run: ./scripts/test-x11.sh
 
   a11y:
@@ -248,8 +250,9 @@ jobs:
         with:
           workspaces: .
       - name: Install system deps
-        # xvfb + at-spi2-core: glass-x11's unit tests start a private display each, and one starts
-        # a private a11y bus — needed by `cargo test --workspace` here, not only by the X11 suite.
+        # xvfb + at-spi2-core: the X11 suite, and the `#[ignore]`d glass-x11 unit tests
+        # coverage.sh runs explicitly once it sees a display — without them that half of the
+        # crate reports uncovered rather than skipped.
         # bubblewrap for the sandbox_* tests, whose unprivileged user namespaces Ubuntu 24.04
         # restricts via AppArmor (the sysctl is a no-op on images without the knob), and GTK4 for
         # the software_render test's real app.
@@ -324,7 +327,9 @@ jobs:
           tool: cargo-mutants,cargo-nextest
       - name: Install the X and a11y stack glass-x11's tests drive
         if: steps.diff.outputs.touched == 'true'
-        # Absent either, the unmutated baseline fails and the run grades nothing.
+        # scripts/mutants.sh runs the `#[ignore]`d tests, so these are needed here even though
+        # the `check` job no longer wants them. Absent either, the unmutated baseline fails and
+        # the run grades nothing.
         run: sudo apt-get update && sudo apt-get install -y xvfb at-spi2-core
       - name: Mutation gate
         if: steps.diff.outputs.touched == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: .
-      # No display stack: every test that wants one is `#[ignore]`d, so this job — and a
-      # contributor's bare checkout — needs nothing installed.
+      # No display stack: every test that wants one is `#[ignore]`d, here and on a bare checkout.
       - run: cargo build --workspace --all-targets --locked
       - run: cargo clippy --workspace --all-targets --locked -- -D warnings
       - run: cargo test --workspace --locked
@@ -88,8 +87,7 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y xvfb bubblewrap python3-gi gir1.2-gtk-4.0 zenity at-spi2-core
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
-      # glass-x11's display-backed unit tests are `#[ignore]`d so a bare checkout can run the
-      # suite; this is the job with the display, so it is where they run.
+      # glass-x11's display-backed unit tests are `#[ignore]`d; this is the job with a display.
       - run: cargo test -p glass-x11 --locked -- --include-ignored
       - run: ./scripts/test-x11.sh
 
@@ -250,9 +248,8 @@ jobs:
         with:
           workspaces: .
       - name: Install system deps
-        # xvfb + at-spi2-core: the X11 suite, and the `#[ignore]`d glass-x11 unit tests
-        # coverage.sh runs explicitly once it sees a display — without them that half of the
-        # crate reports uncovered rather than skipped.
+        # xvfb + at-spi2-core: the X11 suite, plus the `#[ignore]`d glass-x11 unit tests
+        # coverage.sh runs once it sees a display — absent, half the crate reports uncovered.
         # bubblewrap for the sandbox_* tests, whose unprivileged user namespaces Ubuntu 24.04
         # restricts via AppArmor (the sysctl is a no-op on images without the knob), and GTK4 for
         # the software_render test's real app.

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -33,7 +33,9 @@ jobs:
         with:
           tool: cargo-mutants,cargo-nextest
       - name: Install the X and a11y stack glass-x11's tests drive
-        # Absent either, the unmutated baseline fails and the run grades nothing.
+        # scripts/mutants.sh runs the `#[ignore]`d tests, so these are needed here even though
+        # the `check` job no longer wants them. Absent either, the unmutated baseline fails and
+        # the run grades nothing.
         run: sudo apt-get update && sudo apt-get install -y xvfb at-spi2-core
       - name: Sweep
         # nextest runs each test in its own process, so slow tests overlap rather than sum.

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -33,9 +33,8 @@ jobs:
         with:
           tool: cargo-mutants,cargo-nextest
       - name: Install the X and a11y stack glass-x11's tests drive
-        # scripts/mutants.sh runs the `#[ignore]`d tests, so these are needed here even though
-        # the `check` job no longer wants them. Absent either, the unmutated baseline fails and
-        # the run grades nothing.
+        # The mutation wrapper runs the `#[ignore]`d tests (see its header); absent either
+        # package the unmutated baseline fails and the run grades nothing.
         run: sudo apt-get update && sudo apt-get install -y xvfb at-spi2-core
       - name: Sweep
         # nextest runs each test in its own process, so slow tests overlap rather than sum.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,11 @@ separate repo `github.com/fixed-width/glass-android-agent`, driven over `adb for
 
 ```bash
 cargo build
-cargo test --workspace                    # unit tests (integration tests are #[ignore]d)
+cargo test --workspace                    # needs nothing installed; anything wanting a
+                                          # display or device is #[ignore]d
 cargo clippy --workspace --all-targets -- -D warnings   # lint gate — keep clean
+cargo test -p glass-x11 -- --include-ignored      # + its 73 Xvfb-backed unit tests
+cargo test -p glass-wayland -- --include-ignored  # + its 61 sway-backed unit tests
 ./scripts/test-x11.sh [name]              # X11 integration suite (self-starts Xvfb)
 ./scripts/test-wayland.sh [name]          # Wayland suite (needs sway >=1.12)
 ./scripts/test-a11y.sh [name]             # AT-SPI suite

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,9 @@ cargo clippy --workspace --all-targets --locked -- -D warnings
 cargo test --workspace --locked
 ```
 
+Those three need nothing installed: every test wanting a display, a compositor or a device is
+`#[ignore]`d.
+
 **If you changed platform code, those three are not enough.** `cargo test --workspace` on Linux does
 not compile `cfg(target_os = "macos")` or `cfg(windows)` modules at all — it reports clean without
 having looked at them. [Verify a change](docs/how-to/verify-a-change.md) gives the per-target

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -571,6 +571,12 @@ mod tests {
     #[test]
     #[ignore = "requires a booted AVD + GLASS_ADB"]
     fn a_shell_call_that_never_answers_dies_at_its_budget() {
+        // `#[ignore]` is not enough on its own: the mutation gate runs the ignored tests too
+        // (scripts/mutants.sh), and there is no AVD there.
+        if std::env::var("GLASS_ADB").is_err() {
+            println!("no GLASS_ADB, so no AVD to wedge a call against — skipping");
+            return;
+        }
         let adb = Adb::from_env();
         let budget = AdbOp::Shell.budget();
 

--- a/crates/glass-android/src/adb.rs
+++ b/crates/glass-android/src/adb.rs
@@ -571,12 +571,6 @@ mod tests {
     #[test]
     #[ignore = "requires a booted AVD + GLASS_ADB"]
     fn a_shell_call_that_never_answers_dies_at_its_budget() {
-        // `#[ignore]` is not enough on its own: the mutation gate runs the ignored tests too
-        // (scripts/mutants.sh), and there is no AVD there.
-        if std::env::var("GLASS_ADB").is_err() {
-            println!("no GLASS_ADB, so no AVD to wedge a call against — skipping");
-            return;
-        }
         let adb = Adb::from_env();
         let budget = AdbOp::Shell.budget();
 

--- a/crates/glass-x11/src/clipboard.rs
+++ b/crates/glass-x11/src/clipboard.rs
@@ -514,6 +514,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn an_unowned_clipboard_reads_as_empty_rather_than_failing() {
         // A display where nothing has ever copied is the normal starting state, not an error.
         let x = TestX::start();
@@ -521,6 +522,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn repeated_reads_leave_no_windows_behind() {
         // Each read creates a temporary window to receive the SelectionNotify on. An agent
         // polls the clipboard, so one leaked window per read accumulates for the session.
@@ -542,6 +544,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn text_handed_to_the_owner_reads_back_whole() {
         let x = TestX::start();
         let _owner = ClipboardOwner::spawn(x.display().to_string(), LONG_TEXT.to_string())
@@ -550,6 +553,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_later_copy_replaces_what_the_owner_serves() {
         let x = TestX::start();
         let owner =
@@ -560,6 +564,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn the_owner_is_alive_until_it_is_dropped_and_then_serves_nothing() {
         let x = TestX::start();
         let owner =
@@ -574,6 +579,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn another_client_taking_the_selection_retires_the_owner() {
         // The server sends SelectionClear; ignoring it leaves a thread that believes it still
         // owns a selection it does not, so the next copy is served by nobody.
@@ -590,6 +596,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn the_owner_advertises_the_targets_it_can_convert_to() {
         let x = TestX::start();
         let _owner =
@@ -612,6 +619,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_target_the_owner_cannot_produce_is_refused_rather_than_answered_wrongly() {
         // Refusal is `property = NONE`. Answering with the text regardless would hand a
         // requestor asking for an image a string it cannot use.

--- a/crates/glass-x11/src/doctor.rs
+++ b/crates/glass-x11/src/doctor.rs
@@ -231,6 +231,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_live_display_is_reachable_and_an_unused_number_is_not() {
         let server = Xvfb::start("640x480x24").expect("Xvfb should start");
         assert!(
@@ -245,6 +246,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn the_deep_probe_starts_a_real_display_and_takes_it_back_down() {
         let display = probe_xvfb().expect("the deep probe should start a display");
         // Only the report is asserted. Whether the number still answers is not this test's

--- a/crates/glass-x11/src/lib.rs
+++ b/crates/glass-x11/src/lib.rs
@@ -3,8 +3,11 @@
 //! Half this backend's coverage lives elsewhere: the `#[ignore]`d X11 suite in
 //! `crates/glass-testapp/tests/integration.rs` drives it end to end against a real app
 //! (`scripts/test-x11.sh`). Do not read "no test here" as untested. The two halves do not
-//! substitute for each other — that suite cannot kill a mutant, because the gate's test run is
-//! scoped to the gated packages and that suite is in another one.
+//! substitute for each other — that suite cannot kill a mutant, because cargo-mutants scopes
+//! each mutant's test run to the package the mutant is in, and `glass-testapp` is not gated.
+//!
+//! This crate's own display-backed tests are `#[ignore]`d so a bare checkout can run the suite;
+//! `cargo test -p glass-x11 -- --include-ignored` runs them.
 
 #![cfg(target_os = "linux")]
 

--- a/crates/glass-x11/src/lib.rs
+++ b/crates/glass-x11/src/lib.rs
@@ -3,8 +3,8 @@
 //! Half this backend's coverage lives elsewhere: the `#[ignore]`d X11 suite in
 //! `crates/glass-testapp/tests/integration.rs` drives it end to end against a real app
 //! (`scripts/test-x11.sh`). Do not read "no test here" as untested. The two halves do not
-//! substitute for each other — that suite cannot kill a mutant, because the gate runs
-//! `cargo nextest run -p glass-x11` and skips `#[ignore]`d tests in another package.
+//! substitute for each other — that suite cannot kill a mutant, because the gate's test run is
+//! scoped to the gated packages and that suite is in another one.
 
 #![cfg(target_os = "linux")]
 

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -1553,6 +1553,7 @@ mod display_tests {
     const OTHER_PID: u32 = 999_999;
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn interning_is_stable_per_name_and_distinct_across_names() {
         let x = TestX::start();
         let plat = x.platform();
@@ -1563,6 +1564,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn there_is_no_active_window_until_one_is_selected() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -1576,6 +1578,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_windows_name_is_read_back_and_absence_is_not_an_empty_string() {
         let x = TestX::start();
         let plat = x.platform();
@@ -1590,6 +1593,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_windows_class_is_read_back_as_the_instance_class_pair() {
         let x = TestX::start();
         let plat = x.platform();
@@ -1602,6 +1606,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_single_component_class_stands_for_both_halves() {
         // ICCCM wants `instance\0class\0`; some apps write only one string, and dropping the
         // pair rather than doubling it would make their windows unmatchable by class.
@@ -1615,6 +1620,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn geometry_is_reported_in_root_coordinates() {
         let x = TestX::start();
         let plat = x.platform();
@@ -1631,6 +1637,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn the_active_windows_geometry_is_its_own() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -1648,6 +1655,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn an_op_on_a_destroyed_window_reports_it_gone_and_forgets_it() {
         // The stale id must not come back on the next call as a raw protocol error — the
         // caller gets one actionable WindowNotFound either way.
@@ -1664,6 +1672,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_dead_display_is_a_backend_failure_not_a_closed_window() {
         // Only `BadWindow`/`BadDrawable` mean the window went away. Reporting a lost
         // connection as WindowNotFound would send the caller looking for an app that closed,
@@ -1689,6 +1698,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn the_client_list_is_read_from_the_root_and_empty_when_unset() {
         let x = TestX::start();
         let plat = x.platform();
@@ -1703,6 +1713,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_mapped_window_owned_by_the_app_matches() {
         let x = TestX::start();
         let plat = x.platform();
@@ -1721,6 +1732,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn an_unmapped_window_never_matches() {
         // Windows exist in the tree before they are shown; treating one as the app's window
         // hands back a target with nothing on screen.
@@ -1736,6 +1748,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_window_hint_matches_a_window_outside_the_pid_set() {
         // The fallback for apps that never set _NET_WM_PID.
         let x = TestX::start();
@@ -1762,6 +1775,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn scanning_returns_every_window_the_app_owns_and_nothing_else() {
         let x = TestX::start();
         let plat = x.platform();
@@ -1776,6 +1790,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_window_listed_twice_is_returned_once() {
         // `_NET_CLIENT_LIST` and the root's children overlap whenever a window is not
         // reparented, which is every window under a bare Xvfb.
@@ -1805,6 +1820,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_warp_moves_the_pointer_to_the_windows_origin_plus_the_offset() {
         let x = TestX::start();
         let plat = x.platform();
@@ -1815,6 +1831,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_button_press_is_held_until_it_is_released() {
         let x = TestX::start();
         let plat = x.platform();
@@ -1841,6 +1858,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_positive_scroll_clicks_the_positive_button_once_per_step() {
         let x = TestX::start();
         let plat = x.platform();
@@ -1860,6 +1878,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_negative_scroll_clicks_the_negative_button_that_many_times() {
         // The magnitude, not the signed value: a step count that stayed negative would
         // produce an empty range and scroll nothing at all.
@@ -1880,6 +1899,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn an_unmapped_keysym_is_an_invalid_key_not_some_other_keycode() {
         let x = TestX::start();
         let plat = x.platform();
@@ -1890,6 +1910,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_keysym_resolves_to_a_keycode_that_really_carries_it() {
         // Checked against the server's own table rather than a hardcoded keycode, which
         // varies with the keymap the runner happens to load.
@@ -1911,6 +1932,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn every_keysym_the_server_maps_can_be_resolved() {
         // A mapping request one keycode short still resolves nearly everything; only the
         // keys at the very end of the range go missing.
@@ -1937,6 +1959,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn each_modifier_resolves_to_its_own_real_keycode() {
         let x = TestX::start();
         let plat = x.platform();
@@ -1954,6 +1977,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn tapping_a_keycode_presses_and_releases_it_at_the_focused_window() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -1986,6 +2010,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn pressing_modifiers_holds_them_down_and_releasing_lets_them_go() {
         let x = TestX::start();
         let plat = x.platform();
@@ -2034,6 +2059,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn an_uppercase_letter_is_typed_with_shift_held() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -2050,6 +2076,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_lowercase_letter_is_typed_without_shift() {
         // Holding Shift for an unshifted key turns `a` into `A` at the application.
         let x = TestX::start();
@@ -2067,6 +2094,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn focusing_a_window_makes_the_server_route_keys_to_it() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -2105,6 +2133,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn the_app_pid_and_its_tree_are_empty_until_something_is_launched() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -2122,6 +2151,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server and a private AT-SPI bus; needs Xvfb and at-spi2-core"]
     fn the_a11y_bus_address_is_the_private_buss_own_and_absent_without_one() {
         // The a11y reader connects to whatever this returns. Reporting nothing for a launch
         // that did start a bus leaves the tree unreadable; reporting something for one that
@@ -2141,6 +2171,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn draining_logs_hands_over_the_buffer_and_leaves_it_empty() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -2159,6 +2190,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_click_presses_the_mapped_button_at_the_requested_point() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -2188,6 +2220,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_scroll_clicks_the_wheel_buttons_for_each_axis() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -2214,6 +2247,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_drag_presses_at_the_start_and_releases_at_the_end() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -2251,6 +2285,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_drag_with_a_modifier_holds_it_from_before_the_press_to_after_the_release() {
         // A constrained drag (shift to snap an axis, ctrl to copy) is a different gesture
         // from the same drag unmodified.
@@ -2299,6 +2334,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_long_drag_reaches_the_window_while_it_is_still_running() {
         // Each step commits on its own. Held to one flush at the end, a client that renders
         // per frame — a browser — sees the pointer jump rather than drag.
@@ -2339,6 +2375,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_multi_touch_gesture_is_refused_by_this_backend() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -2359,6 +2396,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn typed_text_sends_one_key_per_character() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -2385,6 +2423,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_chord_holds_its_modifier_across_the_key() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -2417,6 +2456,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_window_op_moves_and_resizes_and_reports_the_result() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -2444,6 +2484,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn listing_windows_reports_the_apps_windows_and_marks_the_active_one() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -2486,6 +2527,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn listing_windows_without_an_active_one_is_an_error_not_an_empty_list() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -2496,6 +2538,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn selecting_a_window_makes_it_active_and_refuses_one_that_is_not_the_apps() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -2527,6 +2570,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn capturing_a_named_window_reads_that_windows_own_area() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -2567,6 +2611,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn the_clipboard_round_trips_through_the_backend() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -2582,6 +2627,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_second_copy_updates_the_owner_it_already_has() {
         // Re-taking the selection for every copy is visible to every other client on the
         // display: a clipboard manager watching ownership sees churn that did not happen.
@@ -2601,6 +2647,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_copy_after_another_client_took_the_selection_starts_a_fresh_owner() {
         // glass's owner retires when something else takes CLIPBOARD. Handing the next copy to
         // that retired owner puts the text somewhere nothing serves it, and the paste that
@@ -2635,6 +2682,7 @@ mod display_tests {
     // --- the close ladder ------------------------------------------------------------
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn only_a_window_advertising_wm_delete_window_can_be_asked_to_close() {
         let x = TestX::start();
         let plat = x.platform();
@@ -2651,6 +2699,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_close_request_arrives_as_the_delete_client_message() {
         let x = TestX::start();
         let plat = x.platform();
@@ -2679,6 +2728,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn asking_the_app_to_close_reaches_every_window_that_accepts_it() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -2697,6 +2747,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn an_app_with_no_window_is_not_reported_as_asked() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -2710,6 +2761,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn the_bounded_ask_reaches_the_window_through_its_own_connection() {
         // The ask runs on a second connection so the caller can abandon it without leaving
         // this backend's connection stopped mid-request.
@@ -2729,6 +2781,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn stopping_the_app_reaps_the_child_and_forgets_it() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -2745,6 +2798,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn dropping_the_backend_reaps_an_app_that_was_never_stopped() {
         // Parity with the other backends: a panic-unwind or the process-exit backstop must
         // not leave the launched app running.
@@ -2763,6 +2817,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_launch_whose_app_never_appears_is_a_timeout_and_leaves_nothing_running() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -2788,6 +2843,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn discovery_waits_out_its_timeout_before_giving_up() {
         // The budget has to be spent, not just reported: giving up at once fails every app
         // slower than instant. Timed around `discover_window`, so a spawn that fails under
@@ -2818,6 +2874,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn an_untypable_character_is_reported_at_its_own_index() {
         // The index is all the error may carry — naming the character would put typed
         // content into the unredacted audit log — so it has to advance per character.
@@ -2832,6 +2889,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_scroll_with_a_modifier_holds_it_across_the_wheel() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -2873,6 +2931,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_chord_whose_key_needs_shift_gets_shift_as_well_as_its_own_modifiers() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -2903,6 +2962,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_launch_whose_command_does_not_exist_reports_the_spawn_failure() {
         let x = TestX::start();
         let mut plat = x.platform();
@@ -2923,6 +2983,7 @@ mod display_tests {
     // --- capture ---------------------------------------------------------------------
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_zero_area_region_is_rejected_before_a_doomed_get_image() {
         let x = TestX::start();
         let plat = x.platform();
@@ -2963,6 +3024,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn a_capture_reads_the_pixels_that_are_actually_on_screen() {
         // Everything in the decode path — the plane mask, the depth lookup and the
         // bytes-per-pixel it yields — is only observable in the pixels that come back.
@@ -3008,6 +3070,7 @@ mod display_tests {
     }
 
     #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
     fn scanning_for_one_window_finds_a_match_and_reports_none_otherwise() {
         let x = TestX::start();
         let plat = x.platform();

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -1540,10 +1540,33 @@ mod tests {
         let h = hint(None, None);
         assert!(!hint_matches(Some("anything"), Some(("a", "b")), &h));
     }
+
+    #[test]
+    fn a_clip_note_is_produced_only_when_the_capture_was_clipped() {
+        use crate::coords::ClippedRect;
+        let clipped = ClippedRect {
+            sx: 0,
+            sy: 0,
+            w: 320,
+            h: 200,
+            clipped: true,
+        };
+        let note = super::clip_note(&clipped).expect("a clipped capture must say so");
+        assert!(note.contains("320x200"), "{note}");
+        assert!(
+            super::clip_note(&ClippedRect {
+                clipped: false,
+                ..clipped
+            })
+            .is_none(),
+            "an unclipped capture has nothing to report"
+        );
+    }
 }
 
 /// Everything the backend can only do against a real display: enumerating windows, reading
-/// their properties, translating the server's errors, and driving XTEST.
+/// their properties, translating the server's errors, and driving XTEST. Every test here is
+/// `#[ignore]`d — that is what the module is for, so a display-free test does not belong in it.
 #[cfg(test)]
 mod display_tests {
     use super::*;
@@ -3044,28 +3067,6 @@ mod display_tests {
             (px[0], px[1], px[2]),
             (0xff, 0x00, 0x00),
             "the red window should read back as red, got {px:?}"
-        );
-    }
-
-    #[test]
-    fn a_clip_note_is_produced_only_when_the_capture_was_clipped() {
-        use crate::coords::ClippedRect;
-        let clipped = ClippedRect {
-            sx: 0,
-            sy: 0,
-            w: 320,
-            h: 200,
-            clipped: true,
-        };
-        let note = clip_note(&clipped).expect("a clipped capture must say so");
-        assert!(note.contains("320x200"), "{note}");
-        assert!(
-            clip_note(&ClippedRect {
-                clipped: false,
-                ..clipped
-            })
-            .is_none(),
-            "an unclipped capture has nothing to report"
         );
     }
 

--- a/docs/how-to/verify-a-change.md
+++ b/docs/how-to/verify-a-change.md
@@ -16,7 +16,8 @@ cargo test --workspace --locked
 `--workspace` resolves on Linux, macOS and Windows alike: the platform crates gate themselves, so
 the ones that do not apply to your host compile to nothing rather than failing.
 
-Integration tests are `#[ignore]`d and do not run here — see [below](#integration-suites-linux).
+They need nothing installed. Anything wanting a display, a compositor or a device is
+`#[ignore]`d and does not run here — see [below](#integration-suites-linux).
 
 ## The gap this guide exists for
 
@@ -91,6 +92,15 @@ command from Linux.
 ```
 
 Pass a substring to run one test.
+
+The X11 and Wayland **backend crates** also keep their display-backed unit tests behind
+`#[ignore]`, and no harness script runs those — if you changed `glass-x11` or `glass-wayland`,
+the command above covers the end-to-end suite but not them:
+
+```bash
+cargo test -p glass-x11 -- --include-ignored       # 73 tests; needs xvfb + at-spi2-core
+cargo test -p glass-wayland -- --include-ignored   # 61 tests; needs sway >= 1.12, Mesa, Xwayland
+```
 
 ## What only CI or a real host can do
 

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -25,7 +25,8 @@
 #   scripts/coverage.sh --lcov          # also write target/llvm-cov/glass.lcov (for CI upload)
 # Extra args after a `--` are passed to the final `cargo llvm-cov report`.
 set -uo pipefail
-cd "$(dirname "$0")/.."   # -> rust/
+cd "$(dirname "$0")/.." || exit 1 # the workspace root
+. scripts/lib/have-sway.sh
 
 if ! cargo llvm-cov --version >/dev/null 2>&1; then
     echo "coverage: cargo-llvm-cov is not installed." >&2
@@ -81,15 +82,21 @@ classify_suite() {  # label cmd...
     fi
 }
 
-# A plain `cargo test` run rather than a harness: no skip sentinel to read, so the exit
-# status is the whole story.
+# A plain `cargo test` run rather than a harness. Its output must NOT be grepped for the skip
+# sentinel the way `classify_suite` does — a self-skipping test prints "skipping" too, and one
+# of them would file the whole run as skipped.
 classify_tests() { # label cmd...
-    local label="$1"
+    local label="$1" out
     shift
-    if "$@" >/dev/null; then
-        ran+=("$label")
-    else
+    if ! out=$("$@" 2>&1); then
         failed+=("$label")
+        printf '%s\n' "$out" | tail -n 30
+    elif printf '%s\n' "$out" | grep -qE '^test result: ok\. 0 passed'; then
+        # Exit 0 having run nothing: every test filtered or ignored. Recording that as coverage
+        # is how a crate drops out of the report without anyone seeing it go.
+        failed+=("$label (ran no tests)")
+    else
+        ran+=("$label")
     fi
 }
 
@@ -109,11 +116,11 @@ if [ "$unit_only" -eq 0 ]; then
         classify_tests x11-unit cargo test -p glass-x11 --no-fail-fast -- --include-ignored
         classify_suite x11 ./scripts/test-x11.sh
     else
-        skipped+=("x11 (no Xvfb)")
+        skipped+=("x11-unit (no Xvfb)" "x11 (no Xvfb)")
     fi
 
     echo "coverage: running Wayland integration suite (needs sway >=1.12)…"
-    if command -v sway >/dev/null 2>&1; then
+    if have_sway; then
         classify_tests wayland-unit cargo test -p glass-wayland --no-fail-fast -- --include-ignored
     else
         skipped+=("wayland-unit (no sway)")

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -92,8 +92,8 @@ classify_tests() { # label cmd...
         failed+=("$label")
         printf '%s\n' "$out" | tail -n 30
     elif printf '%s\n' "$out" | grep -qE '^test result: ok\. 0 passed'; then
-        # Exit 0 having run nothing: every test filtered or ignored. Recording that as coverage
-        # is how a crate drops out of the report without anyone seeing it go.
+        # Exit 0 having run nothing: every test filtered or ignored. Recording that as
+        # coverage is how a crate drops out of the report unseen.
         failed+=("$label (ran no tests)")
     else
         ran+=("$label")
@@ -111,8 +111,8 @@ if [ "$unit_only" -eq 0 ]; then
     # test-x11.sh does NOT self-skip (it errors if Xvfb is absent), so probe first.
     echo "coverage: running X11 integration suite (needs Xvfb; sandbox_* need bubblewrap)…"
     if command -v Xvfb >/dev/null 2>&1; then
-        # The workspace run above skipped glass-x11's display-backed unit tests, which are
-        # `#[ignore]`d — half the crate's coverage, and this host has the display they want.
+        # The workspace run above skipped glass-x11's `#[ignore]`d display tests — half the
+        # crate's coverage.
         classify_tests x11-unit cargo test -p glass-x11 --no-fail-fast -- --include-ignored
         classify_suite x11 ./scripts/test-x11.sh
     else

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -81,10 +81,22 @@ classify_suite() {  # label cmd...
     fi
 }
 
+# A plain `cargo test` run rather than a harness: no skip sentinel to read, so the exit
+# status is the whole story.
+classify_tests() { # label cmd...
+    local label="$1"
+    shift
+    if "$@" >/dev/null; then
+        ran+=("$label")
+    else
+        failed+=("$label")
+    fi
+}
+
 # Always: the workspace unit tests (and the always-on integration tests). Keep
 # going on failure so a single failing test still yields a coverage report.
 echo "coverage: running workspace unit tests…"
-if cargo test --workspace --no-fail-fast >/dev/null; then ran+=("unit"); else failed+=("unit"); fi
+classify_tests unit cargo test --workspace --no-fail-fast
 
 if [ "$unit_only" -eq 0 ]; then
     # Each harness exits 0 and self-skips when its prerequisites are missing, so we
@@ -92,12 +104,20 @@ if [ "$unit_only" -eq 0 ]; then
     # test-x11.sh does NOT self-skip (it errors if Xvfb is absent), so probe first.
     echo "coverage: running X11 integration suite (needs Xvfb; sandbox_* need bubblewrap)…"
     if command -v Xvfb >/dev/null 2>&1; then
+        # The workspace run above skipped glass-x11's display-backed unit tests, which are
+        # `#[ignore]`d — half the crate's coverage, and this host has the display they want.
+        classify_tests x11-unit cargo test -p glass-x11 --no-fail-fast -- --include-ignored
         classify_suite x11 ./scripts/test-x11.sh
     else
         skipped+=("x11 (no Xvfb)")
     fi
 
     echo "coverage: running Wayland integration suite (needs sway >=1.12)…"
+    if command -v sway >/dev/null 2>&1; then
+        classify_tests wayland-unit cargo test -p glass-wayland --no-fail-fast -- --include-ignored
+    else
+        skipped+=("wayland-unit (no sway)")
+    fi
     classify_suite wayland ./scripts/test-wayland.sh
 
     echo "coverage: running AT-SPI integration suite (needs dbus/at-spi2/GTK4)…"

--- a/scripts/lib/have-sway.sh
+++ b/scripts/lib/have-sway.sh
@@ -1,0 +1,14 @@
+# shellcheck shell=bash
+# Whether a sway the Wayland backend will actually accept is installed.
+#
+# One copy because two disagreed: `command -v sway` alone is wrong in both directions. The
+# documented install puts the bundle in $XDG_DATA_HOME and NOT on PATH, and Ubuntu ships 1.9,
+# which `resolve_sway` rejects. Keep this in step with `resolve_sway` in
+# crates/glass-wayland/src/platform.rs.
+have_sway() {
+    local bundle="${XDG_DATA_HOME:-$HOME/.local/share}/glass/sway/bin/sway"
+    [ -x "$bundle" ] && return 0
+    [ -n "${GLASS_SWAY:-}" ] && [ -x "${GLASS_SWAY:-}" ] && return 0
+    command -v sway >/dev/null 2>&1 &&
+        sway --version 2>/dev/null | grep -qE 'version 1\.(1[2-9]|[2-9][0-9])'
+}

--- a/scripts/mutants.sh
+++ b/scripts/mutants.sh
@@ -29,17 +29,23 @@
 #
 #   scripts/mutants.sh target/mutants                      # the whole default crate
 #   scripts/mutants.sh target/mutants --in-diff pr.diff    # only what a diff touched
-#   scripts/mutants.sh target/mutants --package glass-android
-#   scripts/mutants.sh target/mutants --package glass-core --package glass-android
+#   scripts/mutants.sh target/mutants --package glass-android --test-tool nextest
+#   scripts/mutants.sh target/mutants --package glass-core --package glass-x11
 #
 # `--package` is read here, not forwarded: it sets the `--file` glob too, and forwarding it
 # alone would mutate only the default package's files under a widened package set — a clean
 # run over a crate that was never in scope. Repeat it for more.
 #
-# Ignored tests are run, and that is set here rather than left to the caller: both test runners
-# skip `#[ignore]` by default, and a mutant no test ran against is graded caught, so a crate
-# whose display-dependent tests are ignored would sweep clean having tested nothing. A caller
-# who forgets the flag would see that as a pass.
+# Ignored tests are run, and that is set here rather than left to the caller: a crate whose
+# display-backed tests are `#[ignore]`d would otherwise have every mutant those tests cover come
+# back a survivor, failing the run over code that is in fact tested.
+#
+# The hazard in the other direction is narrower than it looks, and worth stating exactly, because
+# the obvious guess is wrong. cargo-mutants grades a mutant caught when the test command exits
+# NON-ZERO (`outcome.rs`), so a run that tests nothing and exits 0 is a survivor — loud. Only one
+# shape is silent: nextest exits 4 when no test matched, and cargo-mutants lists that among its
+# allowed nextest codes, so a package left with zero tests grades every mutant caught with no
+# warning. Keep every gated package's test set non-empty (see the filterset below).
 #
 # MUTANTS_JOBS sets concurrency (default 2); `--jobs` cannot be passed through,
 # because cargo-mutants rejects it twice over.
@@ -104,22 +110,30 @@ for p in "${packages[@]}"; do
     pkg_args+=(--package "$p")
 done
 
-# glass-android's integration binaries are all AVD loops, and there is no device here — every
-# test in them is `#[ignore]`d, so excluding them costs the run nothing today. Getting this
-# wrong fails loudly: an excluded test kills no mutant and a survivor fails the run, which is
-# the opposite of what a missing `--run-ignored` does.
-readonly NO_DEVICE='not (package(glass-android) and kind(test))'
+# Running the ignored tests reaches glass-android's device tests, which have no device here.
+# Excluded rather than made to self-skip: a hardware test that passes without its hardware
+# asserts nothing and says so nowhere (the same reasoning as glass-macos `process.rs`).
+#
+# This filterset must leave at least one test in every gated package — empty is the one input
+# nextest reports in a way cargo-mutants reads as every mutant caught (see the header).
+readonly NEEDS_A_DEVICE='(package(glass-android) and kind(test))
+    or test(=adb::tests::a_shell_call_that_never_answers_dies_at_its_budget)'
 
 # Run the `#[ignore]`d tests too (see the header). cargo-mutants appends these to the end of the
 # test command and to the test phase only, so the nextest flag needs no `--` and the cargo one
-# does. A test ignored because it needs hardware must self-skip when that hardware is absent —
-# `#[ignore]` no longer keeps it from running here.
+# does.
 case " ${passthrough[*]-} " in
     *" --test-tool nextest "* | *" --test-tool=nextest "*)
         run_ignored=(--cargo-test-arg=--run-ignored=all
-            --cargo-test-arg=-E --cargo-test-arg="$NO_DEVICE")
+            --cargo-test-arg=-E --cargo-test-arg="not ($NEEDS_A_DEVICE)")
         ;;
     *)
+        # `cargo test` takes no filterset, so the device tests cannot be excluded here.
+        if printf '%s\n' "${packages[@]}" | grep -qx glass-android; then
+            echo "glass-android's tests need a device, and only the nextest path can filter" >&2
+            echo "them out — re-run with --test-tool nextest." >&2
+            exit 2
+        fi
         run_ignored=(--cargo-test-arg=-- --cargo-test-arg=--include-ignored)
         ;;
 esac
@@ -129,8 +143,24 @@ esac
 # question is answered before a single mutant is compiled — and answered for the whole
 # run rather than for one shard, which may legitimately receive none.
 list_count() {
-    cargo mutants --list "${pkg_args[@]}" "$@" \
-        ${diff_file:+--in-diff "$diff_file"} 2>/dev/null | wc -l
+    # stderr to a file, not into stdout: it is the count of the lines below, and a cargo
+    # warning merged in would inflate it. Discarding it instead — what this used to do — makes
+    # a failed `--list` take the whole script down under `set -e` with an empty log, never
+    # reaching the "gated nothing" message.
+    local out err rc=0
+    err=$(mktemp)
+    out=$(cargo mutants --list "${pkg_args[@]}" "$@" \
+        ${diff_file:+--in-diff "$diff_file"} 2>"$err") || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "cargo mutants --list failed, so whether this run would gate anything is unknown:" >&2
+        cat "$err" >&2
+        rm -f "$err"
+        exit 2
+    fi
+    rm -f "$err"
+    # `printf` on an empty string still emits a newline, which `wc -l` would count as one mutant.
+    [ -z "$out" ] && { echo 0; return; }
+    printf '%s\n' "$out" | wc -l
 }
 
 total=0 caught=0 missed=0 timed_out=0 unviable=0 status=0

--- a/scripts/mutants.sh
+++ b/scripts/mutants.sh
@@ -36,6 +36,11 @@
 # alone would mutate only the default package's files under a widened package set — a clean
 # run over a crate that was never in scope. Repeat it for more.
 #
+# Ignored tests are run, and that is set here rather than left to the caller: both test runners
+# skip `#[ignore]` by default, and a mutant no test ran against is graded caught, so a crate
+# whose display-dependent tests are ignored would sweep clean having tested nothing. A caller
+# who forgets the flag would see that as a pass.
+#
 # MUTANTS_JOBS sets concurrency (default 2); `--jobs` cannot be passed through,
 # because cargo-mutants rejects it twice over.
 set -euo pipefail
@@ -99,6 +104,26 @@ for p in "${packages[@]}"; do
     pkg_args+=(--package "$p")
 done
 
+# glass-android's integration binaries are all AVD loops, and there is no device here — every
+# test in them is `#[ignore]`d, so excluding them costs the run nothing today. Getting this
+# wrong fails loudly: an excluded test kills no mutant and a survivor fails the run, which is
+# the opposite of what a missing `--run-ignored` does.
+readonly NO_DEVICE='not (package(glass-android) and kind(test))'
+
+# Run the `#[ignore]`d tests too (see the header). cargo-mutants appends these to the end of the
+# test command and to the test phase only, so the nextest flag needs no `--` and the cargo one
+# does. A test ignored because it needs hardware must self-skip when that hardware is absent —
+# `#[ignore]` no longer keeps it from running here.
+case " ${passthrough[*]-} " in
+    *" --test-tool nextest "* | *" --test-tool=nextest "*)
+        run_ignored=(--cargo-test-arg=--run-ignored=all
+            --cargo-test-arg=-E --cargo-test-arg="$NO_DEVICE")
+        ;;
+    *)
+        run_ignored=(--cargo-test-arg=-- --cargo-test-arg=--include-ignored)
+        ;;
+esac
+
 # How many mutants a set of scope arguments yields, ignoring any `--shard` the caller
 # passed. Listing costs ~0.1s and builds nothing, so the "did this gate anything"
 # question is answered before a single mutant is compiled — and answered for the whole
@@ -119,6 +144,7 @@ attempt() {
     cargo mutants \
         "${pkg_args[@]}" \
         --cargo-arg=--locked \
+        "${run_ignored[@]}" \
         --timeout "$MUTANT_TIMEOUT" \
         -j "${MUTANTS_JOBS:-2}" \
         --output "$dir" \

--- a/scripts/mutants.sh
+++ b/scripts/mutants.sh
@@ -40,12 +40,11 @@
 # display-backed tests are `#[ignore]`d would otherwise have every mutant those tests cover come
 # back a survivor, failing the run over code that is in fact tested.
 #
-# The hazard in the other direction is narrower than it looks, and worth stating exactly, because
-# the obvious guess is wrong. cargo-mutants grades a mutant caught when the test command exits
-# NON-ZERO (`outcome.rs`), so a run that tests nothing and exits 0 is a survivor — loud. Only one
-# shape is silent: nextest exits 4 when no test matched, and cargo-mutants lists that among its
-# allowed nextest codes, so a package left with zero tests grades every mutant caught with no
-# warning. Keep every gated package's test set non-empty (see the filterset below).
+# The silent direction is narrower than the obvious guess. cargo-mutants grades a mutant caught
+# when the test command exits NON-ZERO (`outcome.rs`), so a run that tests nothing and exits 0 is
+# a survivor — loud. Only nextest is quiet: it exits 4 when no test matched, and cargo-mutants
+# lists that among its allowed codes, so a package left with zero tests grades every mutant
+# caught with no warning. Keep every gated package's test set non-empty.
 #
 # MUTANTS_JOBS sets concurrency (default 2); `--jobs` cannot be passed through,
 # because cargo-mutants rejects it twice over.
@@ -112,10 +111,10 @@ done
 
 # Running the ignored tests reaches glass-android's device tests, which have no device here.
 # Excluded rather than made to self-skip: a hardware test that passes without its hardware
-# asserts nothing and says so nowhere (the same reasoning as glass-macos `process.rs`).
+# asserts nothing and says so nowhere — same reasoning as glass-macos `process.rs`.
 #
-# This filterset must leave at least one test in every gated package — empty is the one input
-# nextest reports in a way cargo-mutants reads as every mutant caught (see the header).
+# This filterset must leave at least one test in every gated package: empty is the one input
+# nextest reports in a way cargo-mutants reads as every mutant caught.
 readonly NEEDS_A_DEVICE='(package(glass-android) and kind(test))
     or test(=adb::tests::a_shell_call_that_never_answers_dies_at_its_budget)'
 
@@ -143,10 +142,9 @@ esac
 # question is answered before a single mutant is compiled — and answered for the whole
 # run rather than for one shard, which may legitimately receive none.
 list_count() {
-    # stderr to a file, not into stdout: it is the count of the lines below, and a cargo
-    # warning merged in would inflate it. Discarding it instead — what this used to do — makes
-    # a failed `--list` take the whole script down under `set -e` with an empty log, never
-    # reaching the "gated nothing" message.
+    # stderr to a file, not into stdout, which is counted below — a cargo warning merged in
+    # would inflate the count. Do not discard it either: a failed `--list` then takes the whole
+    # script down under `set -e` with an empty log, never reaching the "gated nothing" message.
     local out err rc=0
     err=$(mktemp)
     out=$(cargo mutants --list "${pkg_args[@]}" "$@" \

--- a/scripts/test-wayland.sh
+++ b/scripts/test-wayland.sh
@@ -12,8 +12,8 @@
 # sandbox level explicitly in the AppSpec.
 set -euo pipefail
 cd "$(dirname "$0")/.."
-SWAY_BUNDLE="${XDG_DATA_HOME:-$HOME/.local/share}/glass/sway/bin/sway"
-if [ ! -x "$SWAY_BUNDLE" ] && ! { command -v sway >/dev/null 2>&1 && sway --version 2>/dev/null | grep -qE 'version 1\.(1[2-9]|[2-9][0-9])'; }; then
+. scripts/lib/have-sway.sh
+if ! have_sway; then
     echo "no glass-discoverable sway >=1.12; build+install via https://github.com/fixed-width/sway-build. Skipping Wayland tests."
     exit 0
 fi


### PR DESCRIPTION
73 of `glass-x11`'s 153 unit tests start a private Xvfb, and one of those also starts a private AT-SPI bus. They were not `#[ignore]`d, so every job running `cargo test --workspace` had to install the display stack, and a contributor on a bare checkout got failures rather than skips.

They are now `#[ignore]`d and run where a display exists: the X11 integration job, `coverage.sh`, and the mutation gate. The `check` job installs nothing, and a bare `cargo test --workspace` passes with Xvfb, sway, Xwayland, dbus-daemon, at-spi and zenity all shimmed to exit 127.

`display_tests` is now exactly the ignored set — the one display-free test in it moved to `mod tests` — so module membership carries the rule rather than 73 hand-copied attributes.

## The gate

`scripts/mutants.sh` sets the run-ignored flag itself rather than leaving it to the caller. Running the ignored tests reaches `glass-android`'s device suites, so a nextest filterset excludes them; `cargo test` takes no filterset, so that path refuses `glass-android` outright rather than starting sixteen device tests against nothing.

Baseline under the gate's exact test command: **1137 pass, 17 excluded**, against 1064 before.

## A correction to #385

The issue's stated rationale is wrong, and worth recording because the fix was designed around it. It said dropping the flag would grade every mutant caught — "a perfect score meaning nothing". cargo-mutants grades a mutant caught when the test command exits **non-zero** (`outcome.rs:249`). Without the flag, `glass-x11`'s other 80 tests still run and exit 0, so the display-only mutants come back as **survivors** and the run fails. Loud, not silent.

One shape is genuinely silent: nextest exits 4 when no test matched, `cargo.rs:25` lists that among its allowed codes, and `Exit::Failure(4)` reads as caught with the warning suppressed. A package left with **zero** tests is the only input that reaches it. The filterset is the one construct here that can, so the invariant it must hold — leave at least one test in every gated package — is stated at that site.

## Also in the diff

- `coverage.sh` recorded a run that executed zero tests as coverage and discarded the output that would have shown it. It now fails such a run and prints the tail.
- `command -v sway` was wrong in both directions: the documented install puts the bundle off `PATH`, and Ubuntu ships 1.9, which `resolve_sway` rejects. The predicate `test-wayland.sh` already had is now shared.
- `list_count` discarded stderr, so a failed `--list` took the script down under `set -e` with an empty log.
- `CLAUDE.md`, `CONTRIBUTING.md` and `verify-a-change.md` described the old meaning of `cargo test --workspace` and named no way to run the 73.

Master's `check`-job comment claimed glass-wayland's ignored tests "run under the mutation gate". They did not: glass-wayland is not in the gate's package list, and the gate never ran ignored tests at all.

## Review

Four-lens panel run before pushing. It corrected two things the first pass had wrong: the grading claim above, and a self-skip added to `glass-android`'s one ignored lib test — no context runs that crate's lib ignored tests, so the guard fired every time, and `glass-macos` `process.rs:784` already writes the rule it broke. That test is excluded by name in the filterset instead.

The ignored set was re-derived under `env -u DISPLAY -u XAUTHORITY -u WAYLAND_DISPLAY` rather than a broken `GLASS_XVFB` alone, which would have missed a test riding the ambient display: 80 pass / 73 skip, and `--run-ignored ignored-only` gives 73 run / 73 failed. Both directions.

Closes #385
