### PR TITLE
fix(coverage): the zero-test guard matched a crate's empty second target

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -91,9 +91,11 @@ classify_tests() { # label cmd...
     if ! out=$("$@" 2>&1); then
         failed+=("$label")
         printf '%s\n' "$out" | tail -n 30
-    elif printf '%s\n' "$out" | grep -qE '^test result: ok\. 0 passed'; then
+    elif ! printf '%s\n' "$out" | grep -qE '^test result: ok\. [1-9][0-9]* passed'; then
         # Exit 0 having run nothing: every test filtered or ignored. Recording that as
-        # coverage is how a crate drops out of the report unseen.
+        # coverage is how a crate drops out of the report unseen. Look for a target that DID
+        # run something — a crate reports one line per target, and the empty ones read
+        # `0 passed` however well the rest went.
         failed+=("$label (ran no tests)")
     else
         ran+=("$label")


### PR DESCRIPTION
Follow-up to #387, which merged a minute before this fix was pushed.

#387 taught `coverage.sh` to fail a run that exited 0 having executed nothing — the shape that lets a crate drop out of the report unseen. The predicate was wrong: it matched *any* `test result: ok. 0 passed` line, and `cargo test -p glass-x11` emits two, one per target:

```
test result: ok. 153 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 0 passed;   0 failed; 0 ignored; 0 measured; 0 filtered out
```

The second is an empty target, so a full 153-test run was filed as having tested nothing. #387's own coverage job said so:

```
coverage: suites with failing tests (coverage still collected): x11-unit (ran no tests)
```

Now it looks for a target that *did* run something. Verified both directions against real output: the run above reads as ran, and `cargo test -p glass-x11 -- --include-ignored no_such_test` (153 filtered out) still reads as `ran no tests`.
