### PR TITLE
fix(coverage): pipefail turned a successful grep -q into a failure

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -72,7 +72,9 @@ classify_suite() {  # label cmd...
     local label="$1"; shift
     local out
     if out=$("$@" 2>&1); then
-        if printf '%s\n' "$out" | grep -qi 'skipping'; then
+        # Here-string, not `printf | grep -q`: under `pipefail` the early-exiting grep SIGPIPEs
+        # the printf, and the pipeline reports 141 on a MATCH. Only bites past a pipe buffer.
+        if grep -qi 'skipping' <<<"$out"; then
             skipped+=("$label")
         else
             ran+=("$label")
@@ -90,8 +92,8 @@ classify_tests() { # label cmd...
     shift
     if ! out=$("$@" 2>&1); then
         failed+=("$label")
-        printf '%s\n' "$out" | tail -n 30
-    elif ! printf '%s\n' "$out" | grep -qE '^test result: ok\. [1-9][0-9]* passed'; then
+        tail -n 30 <<<"$out"
+    elif ! grep -qE '^test result: ok\. [1-9][0-9]* passed' <<<"$out"; then
         # Exit 0 having run nothing: every test filtered or ignored. Recording that as
         # coverage is how a crate drops out of the report unseen. Look for a target that DID
         # run something — a crate reports one line per target, and the empty ones read


### PR DESCRIPTION
The coverage job has been red since #388. It reports:

```
coverage: suites with failing tests (coverage still collected): unit (ran no tests)
./scripts/coverage.sh: line 94: printf: write error: Broken pipe
```

`coverage.sh` runs under `set -uo pipefail`. In `printf '%s\n' "$out" | grep -q PATTERN`, `grep -q` exits the moment it matches, `printf` takes SIGPIPE, and `pipefail` makes the pipeline report **141 on a successful match**. So the check inverts — but only once the output outgrows the pipe buffer, which is why `x11-unit` classified correctly and the whole-workspace run did not.

Reproduction:

```
$ bash -c 'set -uo pipefail; out=$(seq 1 200000)
           printf "%s\n" "$out" | grep -q "^1$"; echo $?'
141
```

Both call sites now use a here-string. `classify_suite`'s `grep -qi skipping` had the same latent bug — a large enough harness output would have filed a skip as a run.

Verified by ablation under `set -uo pipefail` against the real workspace output: the fixed helpers classify `unit` as **ran**, a filtered-to-nothing run as **ran no tests**, and a "Skipping" harness as **skipped**; the version on master classifies that same `unit` run as `(ran no tests)`.

Why #388 did not catch it: I checked the predicate in an interactive shell, which has no `pipefail`. Verifying a script's logic outside the script's own shell options tests something else.
