### PR TITLE
fix: resolve external tools to runnable binaries, not merely existing files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
           if-no-files-found: warn
 
   mutants:
-    name: Mutation shard ${{ matrix.shard }} (glass-core, glass-android, glass-x11)
+    name: Mutation shard ${{ matrix.shard }} (glass-core, glass-android, glass-x11, glass-exec-unix)
     runs-on: ubuntu-latest
     # A push carries no base ref to diff against; this gate is a pull-request check.
     if: github.event_name == 'pull_request'
@@ -301,7 +301,8 @@ jobs:
           git diff "origin/$BASE_REF...HEAD" \
             -- ':(glob)crates/glass-core/src/**/*.rs' \
                ':(glob)crates/glass-android/src/**/*.rs' \
-               ':(glob)crates/glass-x11/src/**/*.rs' > "$RUNNER_TEMP/pr.diff"
+               ':(glob)crates/glass-x11/src/**/*.rs' \
+               ':(glob)crates/glass-exec-unix/src/**/*.rs' > "$RUNNER_TEMP/pr.diff"
           wc -l "$RUNNER_TEMP/pr.diff"
           if [ -s "$RUNNER_TEMP/pr.diff" ]; then
             echo "touched=true" >> "$GITHUB_OUTPUT"
@@ -334,6 +335,7 @@ jobs:
           scripts/mutants.sh "$RUNNER_TEMP/mutants" \
             --test-tool nextest \
             --package glass-core --package glass-android --package glass-x11 \
+            --package glass-exec-unix \
             --shard ${{ matrix.shard }}/8 --sharding round-robin \
             --in-diff "$RUNNER_TEMP/pr.diff"
 
@@ -341,8 +343,8 @@ jobs:
   # to require. This one has a fixed name and fails if any shard did.
   #
   # The ruleset's required check matches this name, so it is frozen — renaming it blocks every
-  # pull request. It gates glass-android and glass-x11 too despite the name; rename only with
-  # the ruleset.
+  # pull request. It gates glass-android, glass-x11 and glass-exec-unix too despite the name;
+  # rename only with the ruleset.
   mutants-gate:
     name: Mutation gate (glass-core)
     runs-on: ubuntu-latest

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   sweep:
-    name: Mutation sweep shard ${{ matrix.shard }} (glass-core, glass-android, glass-x11)
+    name: Mutation sweep shard ${{ matrix.shard }} (glass-core, glass-android, glass-x11, glass-exec-unix)
     runs-on: ubuntu-latest
     strategy:
       # Every shard reports: one red shard must not hide a second one.
@@ -42,6 +42,7 @@ jobs:
           scripts/mutants.sh "$RUNNER_TEMP/mutants" \
             --test-tool nextest \
             --package glass-core --package glass-android --package glass-x11 \
+            --package glass-exec-unix \
             --shard ${{ matrix.shard }}/8 --sharding round-robin
       - name: Upload the outcome
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@ internal refactors, CI, or test-only changes.
   `at-spi-bus-launcher` you had pointed `GLASS_ATSPI_LAUNCHER` at was reported as an at-spi2-core
   package you needed to install, with accessibility quietly falling back to pixel-only. Each of
   these now names the file and says it is not executable, and the doctor's `[a11y]` check no longer
-  reports a launcher present in the same run that reports it missing. The check is the kernel's own
+  counts a launcher it cannot spawn as present — one cause of a single run reporting that launcher
+  both present and missing. The check is the kernel's own
   — a binary you are not permitted to execute is not runnable even with an execute bit set for
   somebody else. A tool named by a bare name is still searched along `$PATH` and one that cannot be
   run is stepped over, so a good copy later on `$PATH` is used, as your shell would; the private

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,24 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+### Fixed
+- A helper binary that is installed but cannot be run is now reported as exactly that, instead of
+  as missing. glass resolves several external tools — `Xvfb`, `sway`, `bwrap`, `dbus-daemon`,
+  `at-spi-bus-launcher` — and used to accept any file at the path, so one whose execute permission
+  was missing (a `chmod` gone wrong, an archive unzipped rather than untarred, a copy across
+  machines, a `noexec` mount) passed every check and then failed at launch. `glass doctor` reported
+  `Xvfb ✓ Ok` and the launch died with a permission error; `sway >=1.12 Fail not found` named a
+  file sitting right there and told you to build a sway you had already built; and an
+  `at-spi-bus-launcher` you had pointed `GLASS_ATSPI_LAUNCHER` at was reported as an at-spi2-core
+  package you needed to install, with accessibility quietly falling back to pixel-only. Each of
+  these now names the file and says it is not executable, and the doctor's `[a11y]` check no longer
+  reports a launcher present in the same run that reports it missing. The check is the kernel's own
+  — a binary you are not permitted to execute is not runnable even with an execute bit set for
+  somebody else. A tool named by a bare name is still searched along `$PATH` and one that cannot be
+  run is stepped over, so a good copy later on `$PATH` is used, as your shell would; the private
+  accessibility bus's preflight now searches `$PATH` for `dbus-daemon` too, rather than only
+  checking an explicitly configured path.
+
 ## [1.2.0] - 2026-08-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,12 +31,11 @@ internal refactors, CI, or test-only changes.
   package you needed to install, with accessibility quietly falling back to pixel-only. Each of
   these now names the file and says it is not executable, and the doctor's `[a11y]` check no longer
   counts a launcher it cannot spawn as present — one cause of a single run reporting that launcher
-  both present and missing. The check is the kernel's own
-  — a binary you are not permitted to execute is not runnable even with an execute bit set for
-  somebody else. A tool named by a bare name is still searched along `$PATH` and one that cannot be
-  run is stepped over, so a good copy later on `$PATH` is used, as your shell would; the private
-  accessibility bus's preflight now searches `$PATH` for `dbus-daemon` too, rather than only
-  checking an explicitly configured path.
+  both present and missing. The check is the kernel's own — a binary you are not permitted to
+  execute is not runnable even with an execute bit set for somebody else. A tool named by a bare
+  name is still searched along `$PATH` and one that cannot be run is stepped over, so a good copy
+  later on `$PATH` is used, as your shell would; the private accessibility bus's preflight now
+  searches `$PATH` for `dbus-daemon` too, rather than only checking an explicitly configured path.
 
 ## [1.2.0] - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ internal refactors, CI, or test-only changes.
   name is still searched along `$PATH` and one that cannot be run is stepped over, so a good copy
   later on `$PATH` is used, as your shell would; the private accessibility bus's preflight now
   searches `$PATH` for `dbus-daemon` too, rather than only checking an explicitly configured path.
+- One `$PATH` entry glass cannot start no longer makes it report that no sway is installed. While
+  looking for a sway ≥1.12, glass runs each candidate with `--version`; if a candidate could not be
+  started at all — something else is writing the file, or it is not a binary — that ended the
+  search outright, so a perfectly good sway further along your `$PATH` was never reached and you
+  were told to build one. Such a candidate is now stepped over and the search carries on. A
+  candidate that does start and reports a version glass cannot use is unchanged: the search stops
+  there rather than silently running a different sway further along your `$PATH`.
 
 ## [1.2.0] - 2026-08-07
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,6 +1036,7 @@ dependencies = [
  "atspi",
  "atspi-common",
  "glass-core",
+ "glass-exec-unix",
  "glass-wayland",
  "glass-x11",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,6 +1115,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "glass-exec-unix"
+version = "0.0.0"
+dependencies = [
+ "tempfile",
+]
+
+[[package]]
 name = "glass-ios"
 version = "0.0.0"
 dependencies = [
@@ -1204,6 +1211,7 @@ name = "glass-sandbox-linux"
 version = "0.0.0"
 dependencies = [
  "glass-core",
+ "glass-exec-unix",
  "glass-sandbox-unix",
  "tempfile",
 ]
@@ -1213,6 +1221,7 @@ name = "glass-sandbox-macos"
 version = "0.0.0"
 dependencies = [
  "glass-core",
+ "glass-exec-unix",
  "glass-sandbox-unix",
  "tempfile",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,6 +1261,7 @@ dependencies = [
  "glass-a11y-linux",
  "glass-core",
  "glass-dbus-linux",
+ "glass-exec-unix",
  "glass-proc-linux",
  "glass-sandbox-linux",
  "rustix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,6 +1119,7 @@ dependencies = [
 name = "glass-exec-unix"
 version = "0.0.0"
 dependencies = [
+ "rustix",
  "tempfile",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,6 +1108,7 @@ version = "0.0.0"
 dependencies = [
  "atspi",
  "glass-core",
+ "glass-exec-unix",
  "glass-proc-linux",
  "tempfile",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,6 +1295,7 @@ dependencies = [
  "glass-a11y-linux",
  "glass-core",
  "glass-dbus-linux",
+ "glass-exec-unix",
  "glass-proc-linux",
  "glass-sandbox-linux",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/glass-core", "crates/glass-x11", "crates/glass-testapp", "crates/glass-mcp", "crates/glass-wayland", "crates/glass-a11y-linux", "crates/glass-windows", "crates/glass-a11y-windows", "crates/glass-sandbox-unix", "crates/glass-sandbox-linux", "crates/glass-proc-linux", "crates/glass-clip-shim-windows", "crates/glass-dbus-linux", "crates/glass-android", "crates/glass-macos", "crates/glass-a11y-macos", "crates/glass-sandbox-macos", "crates/glass-clip-shim-macos", "crates/glass-ios"]
+members = ["crates/glass-core", "crates/glass-x11", "crates/glass-testapp", "crates/glass-mcp", "crates/glass-wayland", "crates/glass-a11y-linux", "crates/glass-windows", "crates/glass-a11y-windows", "crates/glass-exec-unix", "crates/glass-sandbox-unix", "crates/glass-sandbox-linux", "crates/glass-proc-linux", "crates/glass-clip-shim-windows", "crates/glass-dbus-linux", "crates/glass-android", "crates/glass-macos", "crates/glass-a11y-macos", "crates/glass-sandbox-macos", "crates/glass-clip-shim-macos", "crates/glass-ios"]
 # glass-fixture-egui is intentionally excluded: heavy egui deps, only exercised by #[ignore]d
 # on-box a11y tests CI can't run. Built on-demand on the box.
 exclude = ["crates/glass-fixture-egui"]
@@ -40,6 +40,7 @@ x11rb = { version = "0.14", features = ["xtest"] }
 glass-android = { path = "crates/glass-android" }
 glass-ios = { path = "crates/glass-ios" }
 glass-core = { path = "crates/glass-core" }
+glass-exec-unix = { path = "crates/glass-exec-unix" }
 glass-sandbox-unix = { path = "crates/glass-sandbox-unix" }
 glass-sandbox-linux = { path = "crates/glass-sandbox-linux" }
 glass-sandbox-macos = { path = "crates/glass-sandbox-macos" }

--- a/crates/glass-a11y-linux/Cargo.toml
+++ b/crates/glass-a11y-linux/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [target.'cfg(target_os = "linux")'.dependencies]
 glass-core.workspace = true
+glass-exec-unix.workspace = true
 atspi.workspace = true
 atspi-common.workspace = true
 zbus.workspace = true

--- a/crates/glass-a11y-linux/src/doctor.rs
+++ b/crates/glass-a11y-linux/src/doctor.rs
@@ -380,9 +380,9 @@ mod tests {
         assert_eq!(find_launcher(&[], root.path().to_str().unwrap()), None);
     }
 
-    /// This signal is `glass doctor`'s `[a11y]` verdict and the `glass_capabilities`
-    /// accessibility cell. A launcher glass cannot spawn reported as present is the same run
-    /// answering "at-spi-bus-launcher present" and "not found" about one file.
+    /// Feeds both `glass doctor`'s `[a11y]` verdict and the `glass_capabilities` accessibility
+    /// cell — counted present, an unspawnable launcher makes one run answer
+    /// "at-spi-bus-launcher present" and "not found" about one file.
     #[test]
     fn find_launcher_does_not_count_a_candidate_it_could_not_spawn() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/glass-a11y-linux/src/doctor.rs
+++ b/crates/glass-a11y-linux/src/doctor.rs
@@ -267,11 +267,13 @@ fn find_registry() -> Option<std::path::PathBuf> {
 /// `multiarch_root/<triplet>/at-spi2-core/at-spi-bus-launcher`. The triplet directory is
 /// arch-specific (`x86_64-linux-gnu`, `aarch64-linux-gnu`, …), so scanning rather than
 /// hardcoding one arch keeps the AT-SPI-present signal correct on non-x86_64 hosts.
+///
+/// A candidate glass could not spawn is not present: what this feeds says a11y is ready.
 fn find_launcher(fixed: &[&str], multiarch_root: &str) -> Option<std::path::PathBuf> {
     if let Some(p) = fixed
         .iter()
         .map(std::path::PathBuf::from)
-        .find(|p| p.is_file())
+        .find(|p| glass_exec_unix::is_executable_file(p))
     {
         return Some(p);
     }
@@ -279,7 +281,7 @@ fn find_launcher(fixed: &[&str], multiarch_root: &str) -> Option<std::path::Path
         .ok()?
         .flatten()
         .map(|e| e.path().join("at-spi2-core/at-spi-bus-launcher"))
-        .find(|p| p.is_file())
+        .find(|p| glass_exec_unix::is_executable_file(p))
 }
 
 /// Try to reach the accessibility bus exactly the way the reader does — on a private
@@ -336,11 +338,20 @@ mod tests {
     }
 
     // ---- launcher discovery (impure FS scan, driven with a tempdir) ----
+
+    /// Write `path` at `mode`, creating its parents.
+    fn launcher_at(path: &std::path::Path, mode: u32) {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, b"").unwrap();
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).unwrap();
+    }
+
     #[test]
     fn find_launcher_prefers_a_present_fixed_candidate() {
         let dir = tempfile::tempdir().unwrap();
         let fixed = dir.path().join("at-spi-bus-launcher");
-        std::fs::write(&fixed, b"").unwrap();
+        launcher_at(&fixed, 0o755);
         let fixed_str = fixed.to_str().unwrap();
         assert_eq!(
             find_launcher(&[fixed_str], "/nonexistent-root"),
@@ -356,8 +367,7 @@ mod tests {
         let launcher = root
             .path()
             .join("aarch64-linux-gnu/at-spi2-core/at-spi-bus-launcher");
-        std::fs::create_dir_all(launcher.parent().unwrap()).unwrap();
-        std::fs::write(&launcher, b"").unwrap();
+        launcher_at(&launcher, 0o755);
         assert_eq!(
             find_launcher(&[], root.path().to_str().unwrap()),
             Some(launcher)
@@ -367,6 +377,29 @@ mod tests {
     #[test]
     fn find_launcher_none_when_absent() {
         let root = tempfile::tempdir().unwrap();
+        assert_eq!(find_launcher(&[], root.path().to_str().unwrap()), None);
+    }
+
+    /// This signal is `glass doctor`'s `[a11y]` verdict and the `glass_capabilities`
+    /// accessibility cell. A launcher glass cannot spawn reported as present is the same run
+    /// answering "at-spi-bus-launcher present" and "not found" about one file.
+    #[test]
+    fn find_launcher_does_not_count_a_candidate_it_could_not_spawn() {
+        let dir = tempfile::tempdir().unwrap();
+        let fixed = dir.path().join("at-spi-bus-launcher");
+        launcher_at(&fixed, 0o644);
+        assert_eq!(
+            find_launcher(&[fixed.to_str().unwrap()], "/nonexistent-root"),
+            None
+        );
+
+        let root = tempfile::tempdir().unwrap();
+        launcher_at(
+            &root
+                .path()
+                .join("aarch64-linux-gnu/at-spi2-core/at-spi-bus-launcher"),
+            0o644,
+        );
         assert_eq!(find_launcher(&[], root.path().to_str().unwrap()), None);
     }
 

--- a/crates/glass-dbus-linux/Cargo.toml
+++ b/crates/glass-dbus-linux/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [target.'cfg(target_os = "linux")'.dependencies]
 glass-core.workspace = true
+glass-exec-unix.workspace = true
 glass-proc-linux.workspace = true
 zbus.workspace = true
 tokio.workspace = true

--- a/crates/glass-dbus-linux/src/lib.rs
+++ b/crates/glass-dbus-linux/src/lib.rs
@@ -248,8 +248,8 @@ fn find_launcher() -> Resolved {
 /// names the launcher outright and is not searched for among `candidates`.
 ///
 /// The scan takes the first runnable candidate and, failing that, reports the first present-but-
-/// unrunnable one it walked past rather than [`Resolved::Absent`] — the same rule `resolve_bin`
-/// applies to a `$PATH` walk, and for the same reason: that file is what the user can act on.
+/// unrunnable one it walked past rather than [`Resolved::Absent`] — the rule `resolve_bin`
+/// applies to a `$PATH` walk.
 fn find_launcher_with(override_value: Option<OsString>, candidates: &[&str]) -> Resolved {
     if let Some(p) = override_value.filter(|s| !s.is_empty()) {
         return resolve_path(Path::new(&p));
@@ -267,10 +267,9 @@ fn find_launcher_with(override_value: Option<OsString>, candidates: &[&str]) -> 
     first_non_executable.map_or(Resolved::Absent, Resolved::NotExecutable)
 }
 
-/// The launcher to spawn, or why there is none — shared by the preflight and the bring-up so
-/// they cannot disagree. A launcher that is present but unrunnable is named as such: telling
-/// someone who set `GLASS_ATSPI_LAUNCHER` themselves to install at-spi2-core sends them to fix
-/// something that is not broken.
+/// The launcher to spawn, or why there is none — one mapping, so the preflight and the bring-up
+/// cannot disagree. A present-but-unrunnable launcher is named, because "install at-spi2-core"
+/// about a path the user set themselves sends them to fix what is not broken.
 fn launcher_or_reason(resolved: Resolved) -> std::result::Result<PathBuf, String> {
     match resolved {
         Resolved::Found(p) => Ok(p),
@@ -446,9 +445,8 @@ mod tests {
         dir
     }
 
-    /// glass#374: the override was accepted on `is_file()`. Reporting a mere `None` here was the
-    /// second half of the defect — the caller then said "install at-spi2-core" about a path the
-    /// user had named themselves.
+    /// glass#374: the override was accepted on `is_file()`, and reporting a mere `None` let the
+    /// caller say "install at-spi2-core" about a path the user had named themselves.
     #[test]
     fn a_non_executable_launcher_override_is_reported_as_present_but_unrunnable() {
         let dir = dir_with("at-spi-bus-launcher", 0o644);
@@ -507,7 +505,6 @@ mod tests {
         );
     }
 
-    /// Both halves resolvable is the only Ok.
     #[test]
     fn available_is_ok_when_both_binaries_are_runnable() {
         let launcher = dir_with("at-spi-bus-launcher", 0o755);
@@ -579,8 +576,6 @@ mod tests {
         );
     }
 
-    /// The regression this branch would otherwise have introduced: a launcher the user named
-    /// themselves, present but unrunnable, must be named — not reported as an absent package.
     #[test]
     fn available_names_a_launcher_that_is_present_but_not_executable() {
         let dir = dir_with("at-spi-bus-launcher", 0o644);

--- a/crates/glass-dbus-linux/src/lib.rs
+++ b/crates/glass-dbus-linux/src/lib.rs
@@ -507,10 +507,9 @@ mod tests {
 
     #[test]
     fn available_is_ok_when_both_binaries_are_runnable() {
-        let launcher = dir_with("at-spi-bus-launcher", 0o755);
         let daemon = dir_with("dbus-daemon", 0o755);
         available_with(
-            Resolved::Found(launcher.path().join("at-spi-bus-launcher")),
+            Resolved::Found(PathBuf::from("/bin/true")),
             daemon
                 .path()
                 .join("dbus-daemon")

--- a/crates/glass-dbus-linux/src/lib.rs
+++ b/crates/glass-dbus-linux/src/lib.rs
@@ -299,10 +299,9 @@ pub fn available() -> std::result::Result<(), String> {
     )
 }
 
-/// [`available`] against explicit inputs — the testable seam (no global env), so a test can force
-/// any branch without `set_var` racing a concurrent env reader. `path` is the search list a bare
-/// `dbus-daemon` is looked up in; the bring-up spawns from this same process, so it is the list
-/// the spawn will use.
+/// [`available`] against explicit inputs — the testable seam (no global env). `path` is the search
+/// list a bare `dbus-daemon` is looked up in; the bring-up spawns from this same process, so it is
+/// the list the spawn will use.
 fn available_with(
     launcher: Resolved,
     dbus: &str,
@@ -438,9 +437,7 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
     use std::time::Instant;
 
-    /// A directory holding `name` at `mode`. Drives the seams with real files rather than setting
-    /// `GLASS_ATSPI_LAUNCHER`/`PATH` — mutating the process environment races every other test in
-    /// this binary (and is `unsafe` from edition 2024 on).
+    /// A directory holding `name` at `mode`.
     fn dir_with(name: &str, mode: u32) -> tempfile::TempDir {
         let dir = tempfile::tempdir().expect("tempdir");
         let bin = dir.path().join(name);
@@ -472,7 +469,6 @@ mod tests {
         );
     }
 
-    /// A non-executable candidate does not stop the scan: a later one that IS runnable wins.
     #[test]
     fn the_candidate_scan_walks_past_a_non_executable_one() {
         let broken = dir_with("at-spi-bus-launcher", 0o644);

--- a/crates/glass-dbus-linux/src/lib.rs
+++ b/crates/glass-dbus-linux/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![cfg(target_os = "linux")]
 
+use std::ffi::OsString;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use std::process::{Child, ChildStdout, Command, Stdio};
@@ -13,6 +14,7 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 use glass_core::{GlassError, Result};
+use glass_exec_unix::{Resolved, is_executable_file, resolve_bin};
 
 const READY_TIMEOUT: Duration = Duration::from_secs(5);
 /// Hard ceiling on the whole a11y-bus resolution (connect → proxy → GetAddress poll). The
@@ -229,18 +231,33 @@ fn xml_escape(s: &str) -> String {
         .replace('\'', "&apos;")
 }
 
+/// The four paths distributions install `at-spi-bus-launcher` to.
+const LAUNCHER_CANDIDATES: &[&str] = &[
+    "/usr/libexec/at-spi-bus-launcher",
+    "/usr/lib/at-spi2-core/at-spi-bus-launcher",
+    "/usr/lib/at-spi2/at-spi-bus-launcher",
+    "/usr/lib/x86_64-linux-gnu/at-spi2-core/at-spi-bus-launcher",
+];
+
 fn find_launcher() -> Option<PathBuf> {
-    if let Some(p) = std::env::var_os("GLASS_ATSPI_LAUNCHER").filter(|s| !s.is_empty()) {
+    find_launcher_with(
+        std::env::var_os("GLASS_ATSPI_LAUNCHER"),
+        LAUNCHER_CANDIDATES,
+    )
+}
+
+/// [`find_launcher`] against explicit inputs — the testable seam (no global env). An override
+/// names the launcher outright and is not searched for among `candidates`; either way the result
+/// must be runnable, since the only thing done with it is spawning it.
+fn find_launcher_with(override_value: Option<OsString>, candidates: &[&str]) -> Option<PathBuf> {
+    if let Some(p) = override_value.filter(|s| !s.is_empty()) {
         let p = PathBuf::from(p);
-        return p.is_file().then_some(p);
+        return is_executable_file(&p).then_some(p);
     }
-    const CANDIDATES: &[&str] = &[
-        "/usr/libexec/at-spi-bus-launcher",
-        "/usr/lib/at-spi2-core/at-spi-bus-launcher",
-        "/usr/lib/at-spi2/at-spi-bus-launcher",
-        "/usr/lib/x86_64-linux-gnu/at-spi2-core/at-spi-bus-launcher",
-    ];
-    CANDIDATES.iter().map(PathBuf::from).find(|p| p.is_file())
+    candidates
+        .iter()
+        .map(PathBuf::from)
+        .find(|p| is_executable_file(p))
 }
 
 /// Cheap, non-spawning preflight: are the binaries a private a11y bus needs resolvable on
@@ -267,8 +284,14 @@ fn available_with(launcher: Option<PathBuf>, dbus: &str) -> std::result::Result<
                 .into(),
         );
     }
-    if dbus.contains('/') && !std::path::Path::new(dbus).is_file() {
-        return Err(format!("dbus-daemon not found at {dbus}"));
+    if dbus.contains('/') {
+        match resolve_bin(dbus, None) {
+            Resolved::Found(_) => {}
+            Resolved::NotExecutable(p) => {
+                return Err(format!("dbus-daemon at {} is not executable", p.display()));
+            }
+            Resolved::Absent => return Err(format!("dbus-daemon not found at {dbus}")),
+        }
     }
     Ok(())
 }
@@ -388,7 +411,68 @@ fn resolve_a11y_address(session_addr: &str) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::fs::PermissionsExt;
     use std::time::Instant;
+
+    /// glass#374: the launcher was accepted on `is_file()`, so a mode-644 override read as present
+    /// and `PrivateBus::start` then failed at spawn. Drives the seam directly rather than setting
+    /// `GLASS_ATSPI_LAUNCHER` — mutating the process environment races every other test in this
+    /// binary (and is `unsafe` from edition 2024 on).
+    #[test]
+    fn a_non_executable_launcher_override_is_not_accepted() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let launcher = dir.path().join("at-spi-bus-launcher");
+        std::fs::write(&launcher, b"").expect("write");
+        std::fs::set_permissions(&launcher, std::fs::Permissions::from_mode(0o644)).expect("chmod");
+        assert_eq!(
+            find_launcher_with(Some(launcher.into_os_string()), &[]),
+            None
+        );
+    }
+
+    #[test]
+    fn an_executable_launcher_override_is_accepted() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let launcher = dir.path().join("at-spi-bus-launcher");
+        std::fs::write(&launcher, b"").expect("write");
+        std::fs::set_permissions(&launcher, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        assert_eq!(
+            find_launcher_with(Some(launcher.clone().into_os_string()), &[]),
+            Some(launcher)
+        );
+    }
+
+    /// A non-executable candidate does not stop the scan: a later one that IS runnable wins.
+    #[test]
+    fn the_candidate_scan_walks_past_a_non_executable_one() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let broken = dir.path().join("broken");
+        let working = dir.path().join("working");
+        std::fs::write(&broken, b"").expect("write");
+        std::fs::set_permissions(&broken, std::fs::Permissions::from_mode(0o644)).expect("chmod");
+        std::fs::write(&working, b"").expect("write");
+        std::fs::set_permissions(&working, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        let candidates = [
+            broken.to_str().expect("utf-8 temp path"),
+            working.to_str().expect("utf-8 temp path"),
+        ];
+        assert_eq!(find_launcher_with(None, &candidates), Some(working));
+    }
+
+    /// The preflight's other half: an explicit `$GLASS_DBUS_DAEMON` that exists but cannot be run.
+    #[test]
+    fn available_errors_when_an_explicit_dbus_daemon_path_is_not_executable() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let daemon = dir.path().join("dbus-daemon");
+        std::fs::write(&daemon, b"").expect("write");
+        std::fs::set_permissions(&daemon, std::fs::Permissions::from_mode(0o644)).expect("chmod");
+        let err = available_with(
+            Some(PathBuf::from("/bin/true")),
+            daemon.to_str().expect("utf-8 temp path"),
+        )
+        .expect_err("a dbus-daemon that cannot be run must be reported");
+        assert!(err.contains("not executable"), "actionable: {err}");
+    }
 
     /// An unresolvable launcher must report unavailable with an actionable message, whether or
     /// not at-spi2-core is installed on the test host. Drives the seam directly rather than

--- a/crates/glass-dbus-linux/src/lib.rs
+++ b/crates/glass-dbus-linux/src/lib.rs
@@ -6,15 +6,15 @@
 
 #![cfg(target_os = "linux")]
 
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::io::{BufRead, BufReader};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdout, Command, Stdio};
 use std::sync::mpsc;
 use std::time::Duration;
 
 use glass_core::{GlassError, Result};
-use glass_exec_unix::{Resolved, is_executable_file, resolve_bin};
+use glass_exec_unix::{Resolved, resolve_bin, resolve_path};
 
 const READY_TIMEOUT: Duration = Duration::from_secs(5);
 /// Hard ceiling on the whole a11y-bus resolution (connect → proxy → GetAddress poll). The
@@ -105,14 +105,12 @@ impl PrivateBus {
             }
         };
 
-        let launcher = match find_launcher() {
-            Some(l) => l,
-            None => {
+        let launcher = match launcher_or_reason(find_launcher()) {
+            Ok(l) => l,
+            Err(why) => {
                 let _ = dbus.kill();
                 let _ = dbus.wait();
-                return Err(GlassError::Backend(
-                    "at-spi-bus-launcher not found (install at-spi2-core), or set GLASS_ATSPI_LAUNCHER".into(),
-                ));
+                return Err(GlassError::Backend(why));
             }
         };
 
@@ -239,7 +237,7 @@ const LAUNCHER_CANDIDATES: &[&str] = &[
     "/usr/lib/x86_64-linux-gnu/at-spi2-core/at-spi-bus-launcher",
 ];
 
-fn find_launcher() -> Option<PathBuf> {
+fn find_launcher() -> Resolved {
     find_launcher_with(
         std::env::var_os("GLASS_ATSPI_LAUNCHER"),
         LAUNCHER_CANDIDATES,
@@ -247,17 +245,44 @@ fn find_launcher() -> Option<PathBuf> {
 }
 
 /// [`find_launcher`] against explicit inputs — the testable seam (no global env). An override
-/// names the launcher outright and is not searched for among `candidates`; either way the result
-/// must be runnable, since the only thing done with it is spawning it.
-fn find_launcher_with(override_value: Option<OsString>, candidates: &[&str]) -> Option<PathBuf> {
+/// names the launcher outright and is not searched for among `candidates`.
+///
+/// The scan takes the first runnable candidate and, failing that, reports the first present-but-
+/// unrunnable one it walked past rather than [`Resolved::Absent`] — the same rule `resolve_bin`
+/// applies to a `$PATH` walk, and for the same reason: that file is what the user can act on.
+fn find_launcher_with(override_value: Option<OsString>, candidates: &[&str]) -> Resolved {
     if let Some(p) = override_value.filter(|s| !s.is_empty()) {
-        let p = PathBuf::from(p);
-        return is_executable_file(&p).then_some(p);
+        return resolve_path(Path::new(&p));
     }
-    candidates
-        .iter()
-        .map(PathBuf::from)
-        .find(|p| is_executable_file(p))
+    let mut first_non_executable = None;
+    for cand in candidates.iter().map(Path::new) {
+        match resolve_path(cand) {
+            Resolved::Found(p) => return Resolved::Found(p),
+            Resolved::NotExecutable(p) => {
+                first_non_executable.get_or_insert(p);
+            }
+            Resolved::Absent => {}
+        }
+    }
+    first_non_executable.map_or(Resolved::Absent, Resolved::NotExecutable)
+}
+
+/// The launcher to spawn, or why there is none — shared by the preflight and the bring-up so
+/// they cannot disagree. A launcher that is present but unrunnable is named as such: telling
+/// someone who set `GLASS_ATSPI_LAUNCHER` themselves to install at-spi2-core sends them to fix
+/// something that is not broken.
+fn launcher_or_reason(resolved: Resolved) -> std::result::Result<PathBuf, String> {
+    match resolved {
+        Resolved::Found(p) => Ok(p),
+        Resolved::NotExecutable(p) => Err(format!(
+            "at-spi-bus-launcher at {} is not executable",
+            p.display()
+        )),
+        Resolved::Absent => Err(
+            "at-spi-bus-launcher not found (install at-spi2-core), or set GLASS_ATSPI_LAUNCHER"
+                .into(),
+        ),
+    }
 }
 
 /// Cheap, non-spawning preflight: are the binaries a private a11y bus needs resolvable on
@@ -267,33 +292,32 @@ fn find_launcher_with(override_value: Option<OsString>, candidates: &[&str]) -> 
 /// resolvable binary can still fail to spawn — but it catches the common "AT-SPI not
 /// installed" and misconfigured-path cases.
 pub fn available() -> std::result::Result<(), String> {
-    // `tool_path` returns an explicit path (from GLASS_DBUS_DAEMON) or the bare "dbus-daemon"
-    // name resolved on PATH at spawn time. Only an explicit path can be checked here.
     available_with(
         find_launcher(),
         &glass_core::tool_path("GLASS_DBUS_DAEMON", "dbus-daemon"),
+        std::env::var_os("PATH").as_deref(),
     )
 }
 
-/// [`available`] against already-resolved inputs — the testable seam (no global env), so a test
-/// can force either branch without `set_var` racing a concurrent env reader.
-fn available_with(launcher: Option<PathBuf>, dbus: &str) -> std::result::Result<(), String> {
-    if launcher.is_none() {
-        return Err(
-            "at-spi-bus-launcher not found (install at-spi2-core), or set GLASS_ATSPI_LAUNCHER"
-                .into(),
-        );
-    }
-    if dbus.contains('/') {
-        match resolve_bin(dbus, None) {
-            Resolved::Found(_) => {}
-            Resolved::NotExecutable(p) => {
-                return Err(format!("dbus-daemon at {} is not executable", p.display()));
-            }
-            Resolved::Absent => return Err(format!("dbus-daemon not found at {dbus}")),
+/// [`available`] against explicit inputs — the testable seam (no global env), so a test can force
+/// any branch without `set_var` racing a concurrent env reader. `path` is the search list a bare
+/// `dbus-daemon` is looked up in; the bring-up spawns from this same process, so it is the list
+/// the spawn will use.
+fn available_with(
+    launcher: Resolved,
+    dbus: &str,
+    path: Option<&OsStr>,
+) -> std::result::Result<(), String> {
+    launcher_or_reason(launcher)?;
+    match resolve_bin(dbus, path) {
+        Resolved::Found(_) => Ok(()),
+        Resolved::NotExecutable(p) => {
+            Err(format!("dbus-daemon at {} is not executable", p.display()))
         }
+        Resolved::Absent => Err(format!(
+            "dbus-daemon ({dbus}) not found (install dbus, or set GLASS_DBUS_DAEMON to its path)"
+        )),
     }
-    Ok(())
 }
 
 #[zbus::proxy(
@@ -414,86 +438,182 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
     use std::time::Instant;
 
-    /// glass#374: the launcher was accepted on `is_file()`, so a mode-644 override read as present
-    /// and `PrivateBus::start` then failed at spawn. Drives the seam directly rather than setting
-    /// `GLASS_ATSPI_LAUNCHER` — mutating the process environment races every other test in this
-    /// binary (and is `unsafe` from edition 2024 on).
-    #[test]
-    fn a_non_executable_launcher_override_is_not_accepted() {
+    /// A directory holding `name` at `mode`. Drives the seams with real files rather than setting
+    /// `GLASS_ATSPI_LAUNCHER`/`PATH` — mutating the process environment races every other test in
+    /// this binary (and is `unsafe` from edition 2024 on).
+    fn dir_with(name: &str, mode: u32) -> tempfile::TempDir {
         let dir = tempfile::tempdir().expect("tempdir");
+        let bin = dir.path().join(name);
+        std::fs::write(&bin, b"").expect("write");
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(mode)).expect("chmod");
+        dir
+    }
+
+    /// glass#374: the override was accepted on `is_file()`. Reporting a mere `None` here was the
+    /// second half of the defect — the caller then said "install at-spi2-core" about a path the
+    /// user had named themselves.
+    #[test]
+    fn a_non_executable_launcher_override_is_reported_as_present_but_unrunnable() {
+        let dir = dir_with("at-spi-bus-launcher", 0o644);
         let launcher = dir.path().join("at-spi-bus-launcher");
-        std::fs::write(&launcher, b"").expect("write");
-        std::fs::set_permissions(&launcher, std::fs::Permissions::from_mode(0o644)).expect("chmod");
         assert_eq!(
-            find_launcher_with(Some(launcher.into_os_string()), &[]),
-            None
+            find_launcher_with(Some(launcher.clone().into_os_string()), &[]),
+            Resolved::NotExecutable(launcher)
         );
     }
 
     #[test]
     fn an_executable_launcher_override_is_accepted() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = dir_with("at-spi-bus-launcher", 0o755);
         let launcher = dir.path().join("at-spi-bus-launcher");
-        std::fs::write(&launcher, b"").expect("write");
-        std::fs::set_permissions(&launcher, std::fs::Permissions::from_mode(0o755)).expect("chmod");
         assert_eq!(
             find_launcher_with(Some(launcher.clone().into_os_string()), &[]),
-            Some(launcher)
+            Resolved::Found(launcher)
         );
     }
 
     /// A non-executable candidate does not stop the scan: a later one that IS runnable wins.
     #[test]
     fn the_candidate_scan_walks_past_a_non_executable_one() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let broken = dir.path().join("broken");
-        let working = dir.path().join("working");
-        std::fs::write(&broken, b"").expect("write");
-        std::fs::set_permissions(&broken, std::fs::Permissions::from_mode(0o644)).expect("chmod");
-        std::fs::write(&working, b"").expect("write");
-        std::fs::set_permissions(&working, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        let broken = dir_with("at-spi-bus-launcher", 0o644);
+        let working = dir_with("at-spi-bus-launcher", 0o755);
         let candidates = [
-            broken.to_str().expect("utf-8 temp path"),
-            working.to_str().expect("utf-8 temp path"),
+            broken
+                .path()
+                .join("at-spi-bus-launcher")
+                .to_str()
+                .expect("utf-8 temp path")
+                .to_owned(),
+            working
+                .path()
+                .join("at-spi-bus-launcher")
+                .to_str()
+                .expect("utf-8 temp path")
+                .to_owned(),
         ];
-        assert_eq!(find_launcher_with(None, &candidates), Some(working));
+        let candidates: Vec<&str> = candidates.iter().map(String::as_str).collect();
+        assert_eq!(
+            find_launcher_with(None, &candidates),
+            Resolved::Found(working.path().join("at-spi-bus-launcher"))
+        );
+    }
+
+    /// Nothing runnable in the whole scan still beats `Absent`: an at-spi2-core install whose
+    /// launcher lost its execute bit is a chmod away, not a reinstall.
+    #[test]
+    fn a_scan_finding_only_a_non_executable_candidate_names_it() {
+        let dir = dir_with("at-spi-bus-launcher", 0o644);
+        let launcher = dir.path().join("at-spi-bus-launcher");
+        let candidates = [launcher.to_str().expect("utf-8 temp path")];
+        assert_eq!(
+            find_launcher_with(None, &candidates),
+            Resolved::NotExecutable(launcher)
+        );
+    }
+
+    /// Both halves resolvable is the only Ok.
+    #[test]
+    fn available_is_ok_when_both_binaries_are_runnable() {
+        let launcher = dir_with("at-spi-bus-launcher", 0o755);
+        let daemon = dir_with("dbus-daemon", 0o755);
+        available_with(
+            Resolved::Found(launcher.path().join("at-spi-bus-launcher")),
+            daemon
+                .path()
+                .join("dbus-daemon")
+                .to_str()
+                .expect("utf-8 temp path"),
+            None,
+        )
+        .expect("two runnable binaries are available");
     }
 
     /// The preflight's other half: an explicit `$GLASS_DBUS_DAEMON` that exists but cannot be run.
     #[test]
     fn available_errors_when_an_explicit_dbus_daemon_path_is_not_executable() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let daemon = dir.path().join("dbus-daemon");
-        std::fs::write(&daemon, b"").expect("write");
-        std::fs::set_permissions(&daemon, std::fs::Permissions::from_mode(0o644)).expect("chmod");
+        let dir = dir_with("dbus-daemon", 0o644);
         let err = available_with(
-            Some(PathBuf::from("/bin/true")),
-            daemon.to_str().expect("utf-8 temp path"),
+            Resolved::Found(PathBuf::from("/bin/true")),
+            dir.path()
+                .join("dbus-daemon")
+                .to_str()
+                .expect("utf-8 temp path"),
+            None,
         )
         .expect_err("a dbus-daemon that cannot be run must be reported");
         assert!(err.contains("not executable"), "actionable: {err}");
     }
 
+    /// A bare `dbus-daemon` is looked up on the search list, so one that is simply not installed
+    /// is caught by the preflight instead of surfacing as a spawn failure mid-bring-up.
+    #[test]
+    fn available_errors_when_a_bare_dbus_daemon_is_not_on_the_search_list() {
+        let empty = tempfile::tempdir().expect("tempdir");
+        let path = std::env::join_paths([empty.path()]).expect("join paths");
+        let err = available_with(
+            Resolved::Found(PathBuf::from("/bin/true")),
+            "dbus-daemon",
+            Some(&path),
+        )
+        .expect_err("a bare name absent from the search list must be reported");
+        assert!(err.contains("not found"), "actionable: {err}");
+    }
+
+    #[test]
+    fn available_finds_a_bare_dbus_daemon_on_the_search_list() {
+        let dir = dir_with("dbus-daemon", 0o755);
+        let path = std::env::join_paths([dir.path()]).expect("join paths");
+        available_with(
+            Resolved::Found(PathBuf::from("/bin/true")),
+            "dbus-daemon",
+            Some(&path),
+        )
+        .expect("a bare name on the search list resolves");
+    }
+
     /// An unresolvable launcher must report unavailable with an actionable message, whether or
-    /// not at-spi2-core is installed on the test host. Drives the seam directly rather than
-    /// pointing `GLASS_ATSPI_LAUNCHER` at a nonexistent path — mutating the process environment
-    /// would race every other test in this binary (and is `unsafe` from edition 2024 on).
+    /// not at-spi2-core is installed on the test host.
     #[test]
     fn available_errors_when_the_atspi_launcher_is_missing() {
-        let err = available_with(None, "dbus-daemon")
+        let err = available_with(Resolved::Absent, "/bin/true", None)
             .expect_err("missing launcher must report unavailable");
         assert!(
-            err.contains("at-spi-bus-launcher"),
+            err.contains("at-spi-bus-launcher") && err.contains("install at-spi2-core"),
             "actionable message: {err}"
+        );
+    }
+
+    /// The regression this branch would otherwise have introduced: a launcher the user named
+    /// themselves, present but unrunnable, must be named — not reported as an absent package.
+    #[test]
+    fn available_names_a_launcher_that_is_present_but_not_executable() {
+        let dir = dir_with("at-spi-bus-launcher", 0o644);
+        let launcher = dir.path().join("at-spi-bus-launcher");
+        let err = available_with(Resolved::NotExecutable(launcher.clone()), "/bin/true", None)
+            .expect_err("a launcher that cannot be run must report unavailable");
+        assert!(
+            err.contains(&launcher.display().to_string()) && err.contains("not executable"),
+            "must name the file and say why: {err}"
+        );
+        assert!(
+            !err.contains("install at-spi2-core"),
+            "the package is installed; sending the user to reinstall it is the misdirection: {err}"
         );
     }
 
     /// The other preflight branch: an explicit `$GLASS_DBUS_DAEMON` path that is not a file.
     #[test]
     fn available_errors_when_an_explicit_dbus_daemon_path_is_missing() {
-        let err = available_with(Some(PathBuf::from("/bin/true")), "/nonexistent/dbus-daemon")
-            .expect_err("an explicit dbus-daemon path that is not a file must be reported");
-        assert!(err.contains("dbus-daemon not found"), "actionable: {err}");
+        let err = available_with(
+            Resolved::Found(PathBuf::from("/bin/true")),
+            "/nonexistent/dbus-daemon",
+            None,
+        )
+        .expect_err("an explicit dbus-daemon path that is not a file must be reported");
+        assert!(
+            err.contains("not found") && err.contains("/nonexistent/dbus-daemon"),
+            "actionable: {err}"
+        );
     }
 
     #[test]

--- a/crates/glass-exec-unix/Cargo.toml
+++ b/crates/glass-exec-unix/Cargo.toml
@@ -1,15 +1,10 @@
 [package]
-name = "glass-sandbox-macos"
+name = "glass-exec-unix"
 version = "0.0.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 publish.workspace = true
-
-[dependencies]
-glass-core.workspace = true
-glass-exec-unix.workspace = true
-glass-sandbox-unix.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/glass-exec-unix/Cargo.toml
+++ b/crates/glass-exec-unix/Cargo.toml
@@ -6,6 +6,11 @@ license.workspace = true
 repository.workspace = true
 publish.workspace = true
 
+[dependencies]
+# Asking the kernel whether a file is executable, rather than reading mode bits and guessing:
+# a `noexec` mount, an ACL, or a class the caller isn't in are all invisible to `st_mode`.
+rustix.workspace = true
+
 [dev-dependencies]
 tempfile.workspace = true
 

--- a/crates/glass-exec-unix/src/lib.rs
+++ b/crates/glass-exec-unix/src/lib.rs
@@ -1,15 +1,19 @@
-//! Unix exec resolution: given a program name or path, what will actually run. `execvp`'s own
-//! tests — the execute bit, and `$PATH` lookup for a bare name — so a caller can tell a missing
+//! Unix exec resolution: given a program name or path, what will actually run — the kernel's own
+//! execute-permission answer, plus `$PATH` lookup for a bare name, so a caller can tell a missing
 //! binary from an installed one it cannot spawn.
 //!
-//! Used by every glass component that resolves an external tool: the sandbox backends
-//! (`glass-sandbox-linux`, `glass-sandbox-macos`), the X11 and Wayland backends, and the AT-SPI bus
-//! launcher.
+//! One gap against `execvp` remains: with `$PATH` unset `execvp` searches `confstr(_CS_PATH)`,
+//! while [`resolve_bin`] given no search list reports [`Resolved::Absent`].
+//!
+//! Consumers: the X11 and Wayland backends (`glass-x11`, `glass-wayland`), the AT-SPI bus launcher
+//! and its doctor check (`glass-dbus-linux`, `glass-a11y-linux`), and the sandbox backends
+//! (`glass-sandbox-linux`, `glass-sandbox-macos`). `glass-android` and `glass-ios` resolve their
+//! device tooling themselves.
 //!
 //! Which host paths a launch touches is a different question, answered by `glass-sandbox-unix`.
 //!
-//! Everything here reads POSIX semantics — the execute bit, `execvp` lookup — so compiled off unix
-//! the mode check would quietly mean something else.
+//! Everything here reads POSIX semantics — execute permission, `execvp` lookup — so compiled off
+//! unix it would quietly mean something else.
 #![cfg(unix)]
 #![forbid(unsafe_code)]
 
@@ -32,13 +36,23 @@ pub fn resolve_on_path_in(program: &OsStr, path: &OsStr) -> Option<PathBuf> {
         .find(|cand| is_executable_file(cand))
 }
 
-/// Whether `p` is (or resolves through symlinks to) a regular file that is executable — `execvp`'s
-/// "is this runnable" test.
+/// Whether `p` is (or resolves through symlinks to) a regular file this process may execute.
+///
+/// The permission half is the kernel's own answer, against the effective ids `exec` will use, so
+/// it accounts for which class the caller falls in, for a `noexec` mount, and for anything else
+/// the kernel consults — none of which are visible in `st_mode`. `access(2)` also grants `X_OK` on
+/// a searchable directory, hence the regular-file half.
 pub fn is_executable_file(p: &Path) -> bool {
-    use std::os::unix::fs::PermissionsExt;
-    std::fs::metadata(p)
-        .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
-        .unwrap_or(false)
+    if !std::fs::metadata(p).is_ok_and(|m| m.is_file()) {
+        return false;
+    }
+    rustix::fs::accessat(
+        rustix::fs::CWD,
+        p,
+        rustix::fs::Access::EXEC_OK,
+        rustix::fs::AtFlags::EACCESS,
+    )
+    .is_ok()
 }
 
 /// What resolving a configured tool found.
@@ -184,8 +198,26 @@ mod tests {
         );
     }
 
-    /// A directory holding `name` at `mode`. 0o755 is runnable, 0o644 is the case
-    /// `is_file()` used to accept.
+    /// Mode 0o011 carries execute bits, so `mode & 0o111 != 0` calls it runnable — but the owner
+    /// class is the one that applies to the file's owner, and it denies exec, so the spawn gets
+    /// EACCES. Same shape as a `noexec` mount or a denying ACL: permission the mode bits don't say.
+    #[test]
+    fn a_file_whose_own_class_denies_exec_is_not_executable() {
+        if rustix::process::geteuid().is_root() {
+            eprintln!("skipped: root may exec a file carrying any execute bit");
+            return;
+        }
+        let dir = dir_with("Xvfb", 0o011);
+        let bin = dir.path().join("Xvfb");
+        assert!(!is_executable_file(&bin));
+        assert_eq!(
+            resolve_bin(bin.to_str().expect("utf-8 temp path"), None),
+            Resolved::NotExecutable(bin),
+            "the file is there — the user needs to hear that, not 'not found'"
+        );
+    }
+
+    /// A directory holding `name` at `mode`.
     fn dir_with(name: &str, mode: u32) -> tempfile::TempDir {
         let dir = tempfile::tempdir().expect("tempdir");
         let bin = dir.path().join(name);

--- a/crates/glass-exec-unix/src/lib.rs
+++ b/crates/glass-exec-unix/src/lib.rs
@@ -39,9 +39,8 @@ pub fn resolve_on_path_in(program: &OsStr, path: &OsStr) -> Option<PathBuf> {
 /// Whether `p` is (or resolves through symlinks to) a regular file this process may execute.
 ///
 /// The permission half is the kernel's own answer, against the effective ids `exec` will use, so
-/// it accounts for which class the caller falls in, for a `noexec` mount, and for anything else
-/// the kernel consults — none of which are visible in `st_mode`. `access(2)` also grants `X_OK` on
-/// a searchable directory, hence the regular-file half.
+/// a `noexec` mount or a class the caller is not in reads false where `st_mode` reads true.
+/// `access(2)` grants `X_OK` on a searchable directory, hence the regular-file half.
 pub fn is_executable_file(p: &Path) -> bool {
     if !std::fs::metadata(p).is_ok_and(|m| m.is_file()) {
         return false;
@@ -187,8 +186,8 @@ mod tests {
     }
 
     /// Mode 0o011 carries execute bits, so `mode & 0o111 != 0` calls it runnable — but the owner
-    /// class is the one that applies to the file's owner, and it denies exec, so the spawn gets
-    /// EACCES. Same shape as a `noexec` mount or a denying ACL: permission the mode bits don't say.
+    /// class applies to the owner and denies exec, so `exec` returns EACCES. Same shape as a
+    /// `noexec` mount or a denying ACL: permission the mode bits do not say.
     #[test]
     fn a_file_whose_own_class_denies_exec_is_not_executable() {
         if rustix::process::geteuid().is_root() {

--- a/crates/glass-exec-unix/src/lib.rs
+++ b/crates/glass-exec-unix/src/lib.rs
@@ -291,7 +291,7 @@ mod tests {
     }
 
     #[test]
-    fn found_exposes_the_path_and_the_other_states_do_not() {
+    fn a_found_result_exposes_its_path() {
         let dir = dir_with("Xvfb", 0o755);
         let bin = dir.path().join("Xvfb");
         assert_eq!(Resolved::Found(bin.clone()).found(), Some(bin.as_path()));
@@ -301,5 +301,11 @@ mod tests {
     fn a_non_executable_result_does_not_read_as_found() {
         let dir = dir_with("Xvfb", 0o644);
         assert!(!Resolved::NotExecutable(dir.path().join("Xvfb")).is_found());
+    }
+
+    #[test]
+    fn an_absent_result_exposes_no_path_and_does_not_read_as_found() {
+        assert_eq!(Resolved::Absent.found(), None);
+        assert!(!Resolved::Absent.is_found());
     }
 }

--- a/crates/glass-exec-unix/src/lib.rs
+++ b/crates/glass-exec-unix/src/lib.rs
@@ -118,6 +118,28 @@ mod tests {
     use std::ffi::OsStr;
     use std::os::unix::fs::PermissionsExt;
 
+    /// The one test here that reads the real `$PATH`: this wrapper is nothing *but* the env read,
+    /// so driving `resolve_on_path_in` like its neighbours do would leave it uncovered. Reading
+    /// the environment is safe — mutating it is what races a concurrent reader.
+    ///
+    /// `is_some()` alone would not pin it: an empty `PathBuf` is still `Some`. The assertions name
+    /// the binary found.
+    #[test]
+    fn resolve_on_path_finds_a_program_every_posix_host_has() {
+        let found = resolve_on_path(OsStr::new("sh")).expect("POSIX requires an sh on $PATH");
+        assert_eq!(
+            found.file_name(),
+            Some(OsStr::new("sh")),
+            "must resolve to the program asked for, got {}",
+            found.display()
+        );
+        assert!(
+            is_executable_file(&found),
+            "must resolve to something runnable, got {}",
+            found.display()
+        );
+    }
+
     #[test]
     fn resolve_on_path_in_finds_first_executable_match() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/glass-exec-unix/src/lib.rs
+++ b/crates/glass-exec-unix/src/lib.rs
@@ -41,6 +41,76 @@ pub fn is_executable_file(p: &Path) -> bool {
         .unwrap_or(false)
 }
 
+/// What resolving a configured tool found.
+///
+/// The `NotExecutable` case is the reason this is not an `Option<PathBuf>`: a caller that only
+/// learns "no" cannot tell a missing binary from an installed one whose execute bit is off, and
+/// sends the user to reinstall a package that is already there.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Resolved {
+    /// A runnable binary.
+    Found(PathBuf),
+    /// A regular file is there but carries no execute bit.
+    NotExecutable(PathBuf),
+    /// Nothing by that name.
+    Absent,
+}
+
+impl Resolved {
+    /// The runnable path, or `None` for either failure.
+    pub fn found(&self) -> Option<&Path> {
+        match self {
+            Self::Found(p) => Some(p),
+            Self::NotExecutable(_) | Self::Absent => None,
+        }
+    }
+
+    /// Whether a runnable binary was found.
+    pub fn is_found(&self) -> bool {
+        self.found().is_some()
+    }
+}
+
+/// Resolve a configured tool the way the child will be exec'd: a token containing `/` is an
+/// explicit path taken as given, anything else is a bare name looked up in `path` (a `PATH`-style
+/// separated list).
+///
+/// A search returns the first *executable* match and walks past non-executable ones, as `execvp`
+/// does — resolving to one of those would run a different binary than the user's shell. When the
+/// walk turns up no runnable match, the first non-executable it passed is reported rather than
+/// [`Resolved::Absent`], because that is the fact the user can act on.
+pub fn resolve_bin(bin: &str, path: Option<&OsStr>) -> Resolved {
+    if bin.contains('/') {
+        return classify(PathBuf::from(bin));
+    }
+    let Some(path) = path else {
+        return Resolved::Absent;
+    };
+    let mut first_non_executable = None;
+    for cand in std::env::split_paths(path).map(|dir| dir.join(bin)) {
+        match classify(cand) {
+            Resolved::Found(p) => return Resolved::Found(p),
+            Resolved::NotExecutable(p) => {
+                first_non_executable.get_or_insert(p);
+            }
+            Resolved::Absent => {}
+        }
+    }
+    first_non_executable.map_or(Resolved::Absent, Resolved::NotExecutable)
+}
+
+/// One candidate path's state. A directory is [`Resolved::Absent`]: it is not a launch target
+/// however its mode bits read.
+fn classify(p: PathBuf) -> Resolved {
+    if is_executable_file(&p) {
+        Resolved::Found(p)
+    } else if p.is_file() {
+        Resolved::NotExecutable(p)
+    } else {
+        Resolved::Absent
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -112,5 +182,124 @@ mod tests {
             !is_executable_file(&subdir),
             "a directory (even an 'executable'-mode one) must be false"
         );
+    }
+
+    /// A directory holding `name` at `mode`. 0o755 is runnable, 0o644 is the case
+    /// `is_file()` used to accept.
+    fn dir_with(name: &str, mode: u32) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bin = dir.path().join(name);
+        std::fs::write(&bin, b"").expect("write");
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(mode)).expect("chmod");
+        dir
+    }
+
+    #[test]
+    fn an_explicit_path_to_an_executable_is_found() {
+        let dir = dir_with("Xvfb", 0o755);
+        let bin = dir.path().join("Xvfb");
+        assert_eq!(
+            resolve_bin(bin.to_str().expect("utf-8 temp path"), None),
+            Resolved::Found(bin)
+        );
+    }
+
+    /// The defect in glass#374: this input used to resolve as success.
+    #[test]
+    fn an_explicit_path_to_a_non_executable_file_is_not_executable() {
+        let dir = dir_with("Xvfb", 0o644);
+        let bin = dir.path().join("Xvfb");
+        assert_eq!(
+            resolve_bin(bin.to_str().expect("utf-8 temp path"), None),
+            Resolved::NotExecutable(bin)
+        );
+    }
+
+    #[test]
+    fn an_explicit_path_to_nothing_is_absent() {
+        assert_eq!(resolve_bin("/nonexistent/Xvfb", None), Resolved::Absent);
+    }
+
+    /// A directory is not a launch target, however its mode bits read.
+    #[test]
+    fn an_explicit_path_to_a_directory_is_absent() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert_eq!(
+            resolve_bin(dir.path().to_str().expect("utf-8 temp path"), None),
+            Resolved::Absent
+        );
+    }
+
+    #[test]
+    fn a_bare_name_resolves_against_the_search_list() {
+        let dir = dir_with("Xvfb", 0o755);
+        let path = std::env::join_paths([dir.path()]).expect("join paths");
+        assert_eq!(
+            resolve_bin("Xvfb", Some(&path)),
+            Resolved::Found(dir.path().join("Xvfb"))
+        );
+    }
+
+    /// `execvp` semantics: a non-executable match does not stop the search. Departing from this
+    /// would make glass run a different binary than the user's shell does.
+    #[test]
+    fn the_search_walks_past_a_non_executable_match_to_a_later_executable_one() {
+        let first = dir_with("Xvfb", 0o644);
+        let second = dir_with("Xvfb", 0o755);
+        let path = std::env::join_paths([first.path(), second.path()]).expect("join paths");
+        assert_eq!(
+            resolve_bin("Xvfb", Some(&path)),
+            Resolved::Found(second.path().join("Xvfb")),
+            "a non-executable match must not shadow a runnable one later on the list"
+        );
+    }
+
+    /// When the walk finds nothing runnable, the non-executable it passed is the actionable
+    /// fact — reporting `Absent` would send the user to install what is already installed.
+    #[test]
+    fn a_search_finding_only_a_non_executable_match_reports_it_rather_than_absent() {
+        let dir = dir_with("Xvfb", 0o644);
+        let path = std::env::join_paths([dir.path()]).expect("join paths");
+        assert_eq!(
+            resolve_bin("Xvfb", Some(&path)),
+            Resolved::NotExecutable(dir.path().join("Xvfb"))
+        );
+    }
+
+    /// The FIRST non-executable, not merely any — it is the one the user's `PATH` order points at.
+    #[test]
+    fn a_search_reports_the_first_non_executable_match_it_passed() {
+        let first = dir_with("Xvfb", 0o644);
+        let second = dir_with("Xvfb", 0o600);
+        let path = std::env::join_paths([first.path(), second.path()]).expect("join paths");
+        assert_eq!(
+            resolve_bin("Xvfb", Some(&path)),
+            Resolved::NotExecutable(first.path().join("Xvfb"))
+        );
+    }
+
+    #[test]
+    fn a_bare_name_with_no_search_list_is_absent() {
+        assert_eq!(resolve_bin("Xvfb", None), Resolved::Absent);
+    }
+
+    #[test]
+    fn a_bare_name_absent_from_the_search_list_is_absent() {
+        let dir = dir_with("Xvfb", 0o755);
+        let path = std::env::join_paths([dir.path()]).expect("join paths");
+        assert_eq!(resolve_bin("Xorg", Some(&path)), Resolved::Absent);
+    }
+
+    #[test]
+    fn found_exposes_the_path_and_the_other_states_do_not() {
+        let dir = dir_with("Xvfb", 0o755);
+        let bin = dir.path().join("Xvfb");
+        assert_eq!(Resolved::Found(bin.clone()).found(), Some(bin.as_path()));
+    }
+
+    #[test]
+    fn a_non_executable_result_does_not_read_as_found() {
+        let dir = dir_with("Xvfb", 0o644);
+        assert!(!Resolved::NotExecutable(dir.path().join("Xvfb")).is_found());
     }
 }

--- a/crates/glass-exec-unix/src/lib.rs
+++ b/crates/glass-exec-unix/src/lib.rs
@@ -61,28 +61,15 @@ pub fn is_executable_file(p: &Path) -> bool {
 /// learns "no" cannot tell a missing binary from an installed one whose execute bit is off, and
 /// sends the user to reinstall a package that is already there.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
 pub enum Resolved {
     /// A runnable binary.
     Found(PathBuf),
-    /// A regular file is there but carries no execute bit.
+    /// A regular file is there, and this process may not execute it.
     NotExecutable(PathBuf),
-    /// Nothing by that name.
+    /// Nothing to point the user at: no such path, a directory, a path that cannot be stat'd, or
+    /// — from [`resolve_bin`] — a bare name with no search list to look it up in.
     Absent,
-}
-
-impl Resolved {
-    /// The runnable path, or `None` for either failure.
-    pub fn found(&self) -> Option<&Path> {
-        match self {
-            Self::Found(p) => Some(p),
-            Self::NotExecutable(_) | Self::Absent => None,
-        }
-    }
-
-    /// Whether a runnable binary was found.
-    pub fn is_found(&self) -> bool {
-        self.found().is_some()
-    }
 }
 
 /// Resolve a configured tool the way the child will be exec'd: a token containing `/` is an
@@ -95,14 +82,14 @@ impl Resolved {
 /// [`Resolved::Absent`], because that is the fact the user can act on.
 pub fn resolve_bin(bin: &str, path: Option<&OsStr>) -> Resolved {
     if bin.contains('/') {
-        return classify(PathBuf::from(bin));
+        return resolve_path(Path::new(bin));
     }
     let Some(path) = path else {
         return Resolved::Absent;
     };
     let mut first_non_executable = None;
     for cand in std::env::split_paths(path).map(|dir| dir.join(bin)) {
-        match classify(cand) {
+        match resolve_path(&cand) {
             Resolved::Found(p) => return Resolved::Found(p),
             Resolved::NotExecutable(p) => {
                 first_non_executable.get_or_insert(p);
@@ -113,13 +100,14 @@ pub fn resolve_bin(bin: &str, path: Option<&OsStr>) -> Resolved {
     first_non_executable.map_or(Resolved::Absent, Resolved::NotExecutable)
 }
 
-/// One candidate path's state. A directory is [`Resolved::Absent`]: it is not a launch target
+/// The verdict on one path, with no `$PATH` search — for a caller holding a single candidate
+/// rather than a name to look up. A directory is [`Resolved::Absent`]: it is not a launch target
 /// however its mode bits read.
-fn classify(p: PathBuf) -> Resolved {
-    if is_executable_file(&p) {
-        Resolved::Found(p)
+pub fn resolve_path(p: &Path) -> Resolved {
+    if is_executable_file(p) {
+        Resolved::Found(p.to_path_buf())
     } else if p.is_file() {
-        Resolved::NotExecutable(p)
+        Resolved::NotExecutable(p.to_path_buf())
     } else {
         Resolved::Absent
     }
@@ -336,21 +324,27 @@ mod tests {
     }
 
     #[test]
-    fn a_found_result_exposes_its_path() {
-        let dir = dir_with("Xvfb", 0o755);
-        let bin = dir.path().join("Xvfb");
-        assert_eq!(Resolved::Found(bin.clone()).found(), Some(bin.as_path()));
-    }
+    fn resolve_path_separates_runnable_from_present_from_nothing() {
+        let runnable = dir_with("sway", 0o755);
+        assert_eq!(
+            resolve_path(&runnable.path().join("sway")),
+            Resolved::Found(runnable.path().join("sway"))
+        );
 
-    #[test]
-    fn a_non_executable_result_does_not_read_as_found() {
-        let dir = dir_with("Xvfb", 0o644);
-        assert!(!Resolved::NotExecutable(dir.path().join("Xvfb")).is_found());
-    }
+        let present = dir_with("sway", 0o644);
+        assert_eq!(
+            resolve_path(&present.path().join("sway")),
+            Resolved::NotExecutable(present.path().join("sway"))
+        );
 
-    #[test]
-    fn an_absent_result_exposes_no_path_and_does_not_read_as_found() {
-        assert_eq!(Resolved::Absent.found(), None);
-        assert!(!Resolved::Absent.is_found());
+        assert_eq!(
+            resolve_path(Path::new("/nonexistent/sway")),
+            Resolved::Absent
+        );
+        assert_eq!(
+            resolve_path(runnable.path()),
+            Resolved::Absent,
+            "a directory answers X_OK but is not a launch target"
+        );
     }
 }

--- a/crates/glass-exec-unix/src/lib.rs
+++ b/crates/glass-exec-unix/src/lib.rs
@@ -240,7 +240,6 @@ mod tests {
         assert_eq!(resolve_bin("/nonexistent/Xvfb", None), Resolved::Absent);
     }
 
-    /// A directory is not a launch target, however its mode bits read.
     #[test]
     fn an_explicit_path_to_a_directory_is_absent() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -260,8 +259,6 @@ mod tests {
         );
     }
 
-    /// `execvp` semantics: a non-executable match does not stop the search. Departing from this
-    /// would make glass run a different binary than the user's shell does.
     #[test]
     fn the_search_walks_past_a_non_executable_match_to_a_later_executable_one() {
         let first = dir_with("Xvfb", 0o644);
@@ -287,8 +284,6 @@ mod tests {
         );
     }
 
-    /// When the walk finds nothing runnable, the non-executable it passed is the actionable
-    /// fact — reporting `Absent` would send the user to install what is already installed.
     #[test]
     fn a_search_finding_only_a_non_executable_match_reports_it_rather_than_absent() {
         let dir = dir_with("Xvfb", 0o644);

--- a/crates/glass-exec-unix/src/lib.rs
+++ b/crates/glass-exec-unix/src/lib.rs
@@ -118,12 +118,11 @@ mod tests {
     use std::ffi::OsStr;
     use std::os::unix::fs::PermissionsExt;
 
-    /// The one test here that reads the real `$PATH`: this wrapper is nothing *but* the env read,
-    /// so driving `resolve_on_path_in` like its neighbours do would leave it uncovered. Reading
-    /// the environment is safe — mutating it is what races a concurrent reader.
+    /// The one test here that reads the real `$PATH` — this wrapper is nothing but the env read,
+    /// so driving `resolve_on_path_in` like its neighbours would leave it uncovered. Reading the
+    /// environment is safe; mutating it is not.
     ///
-    /// `is_some()` alone would not pin it: an empty `PathBuf` is still `Some`. The assertions name
-    /// the binary found.
+    /// Do not weaken to `is_some()`: an empty `PathBuf` is still `Some`.
     #[test]
     fn resolve_on_path_finds_a_program_every_posix_host_has() {
         let found = resolve_on_path(OsStr::new("sh")).expect("POSIX requires an sh on $PATH");

--- a/crates/glass-exec-unix/src/lib.rs
+++ b/crates/glass-exec-unix/src/lib.rs
@@ -1,0 +1,116 @@
+//! Unix exec resolution: given a program name or path, what will actually run. `execvp`'s own
+//! tests — the execute bit, and `$PATH` lookup for a bare name — so a caller can tell a missing
+//! binary from an installed one it cannot spawn.
+//!
+//! Used by every glass component that resolves an external tool: the sandbox backends
+//! (`glass-sandbox-linux`, `glass-sandbox-macos`), the X11 and Wayland backends, and the AT-SPI bus
+//! launcher.
+//!
+//! Which host paths a launch touches is a different question, answered by `glass-sandbox-unix`.
+//!
+//! Everything here reads POSIX semantics — the execute bit, `execvp` lookup — so compiled off unix
+//! the mode check would quietly mean something else.
+#![cfg(unix)]
+#![forbid(unsafe_code)]
+
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+
+/// The first `$PATH` entry holding an executable regular file named `program`, resolved the way
+/// `execvp` resolves a bare command name. `None` when `$PATH` is unset or nothing matches.
+pub fn resolve_on_path(program: &OsStr) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    resolve_on_path_in(program, &path)
+}
+
+/// [`resolve_on_path`] against an explicit `$PATH` value — the testable seam (no global env).
+/// Public so the backends' own resolution paths can be tested the same way, without a test
+/// mutating the process environment (unsound: `set_var` races any concurrent reader).
+pub fn resolve_on_path_in(program: &OsStr, path: &OsStr) -> Option<PathBuf> {
+    std::env::split_paths(path)
+        .map(|dir| dir.join(program))
+        .find(|cand| is_executable_file(cand))
+}
+
+/// Whether `p` is (or resolves through symlinks to) a regular file that is executable — `execvp`'s
+/// "is this runnable" test.
+pub fn is_executable_file(p: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(p)
+        .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsStr;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn resolve_on_path_in_finds_first_executable_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let exe = dir.path().join("mytool");
+        std::fs::write(&exe, b"").unwrap();
+        std::fs::set_permissions(&exe, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let path = std::env::join_paths([dir.path()]).unwrap();
+        assert_eq!(resolve_on_path_in(OsStr::new("mytool"), &path), Some(exe));
+    }
+
+    /// Pins the documented "first `$PATH` entry wins" contract (`execvp` semantics): with two
+    /// directories on `$PATH`, each holding an executable of the SAME name, the match from the
+    /// FIRST directory must be returned, not merely any match.
+    #[test]
+    fn resolve_on_path_in_returns_the_first_match() {
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        for dir in [&first, &second] {
+            let exe = dir.path().join("mytool");
+            std::fs::write(&exe, b"").unwrap();
+            std::fs::set_permissions(&exe, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let path = std::env::join_paths([first.path(), second.path()]).unwrap();
+        assert_eq!(
+            resolve_on_path_in(OsStr::new("mytool"), &path),
+            Some(first.path().join("mytool")),
+            "must return the FIRST $PATH entry's match, not merely any match"
+        );
+    }
+
+    #[test]
+    fn resolve_on_path_in_skips_non_executable_and_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let plain = dir.path().join("mytool");
+        std::fs::write(&plain, b"").unwrap();
+        std::fs::set_permissions(&plain, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let path = std::env::join_paths([dir.path()]).unwrap();
+        assert_eq!(resolve_on_path_in(OsStr::new("mytool"), &path), None);
+        assert_eq!(resolve_on_path_in(OsStr::new("absent"), &path), None);
+    }
+
+    #[test]
+    fn is_executable_file_true_for_exec_false_for_dir_and_plain() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let exe = dir.path().join("exe");
+        std::fs::write(&exe, b"").unwrap();
+        std::fs::set_permissions(&exe, std::fs::Permissions::from_mode(0o755)).unwrap();
+        assert!(is_executable_file(&exe), "an exec-bit file must be true");
+
+        let plain = dir.path().join("plain");
+        std::fs::write(&plain, b"").unwrap();
+        std::fs::set_permissions(&plain, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert!(
+            !is_executable_file(&plain),
+            "a non-exec plain file must be false"
+        );
+
+        let subdir = dir.path().join("subdir");
+        std::fs::create_dir_all(&subdir).unwrap();
+        std::fs::set_permissions(&subdir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        assert!(
+            !is_executable_file(&subdir),
+            "a directory (even an 'executable'-mode one) must be false"
+        );
+    }
+}

--- a/crates/glass-exec-unix/src/lib.rs
+++ b/crates/glass-exec-unix/src/lib.rs
@@ -254,6 +254,19 @@ mod tests {
         );
     }
 
+    /// Distinct from the non-executable case above: here the earlier `PATH` entry has no
+    /// candidate at all, not one it can't run.
+    #[test]
+    fn the_search_walks_past_an_entry_lacking_the_binary_to_a_later_match() {
+        let empty = tempfile::tempdir().expect("tempdir");
+        let holding = dir_with("Xvfb", 0o755);
+        let path = std::env::join_paths([empty.path(), holding.path()]).expect("join paths");
+        assert_eq!(
+            resolve_bin("Xvfb", Some(&path)),
+            Resolved::Found(holding.path().join("Xvfb"))
+        );
+    }
+
     /// When the walk finds nothing runnable, the non-executable it passed is the actionable
     /// fact — reporting `Absent` would send the user to install what is already installed.
     #[test]

--- a/crates/glass-sandbox-linux/Cargo.toml
+++ b/crates/glass-sandbox-linux/Cargo.toml
@@ -8,6 +8,7 @@ publish.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 glass-core.workspace = true
+glass-exec-unix.workspace = true
 glass-sandbox-unix.workspace = true
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]

--- a/crates/glass-sandbox-linux/src/lib.rs
+++ b/crates/glass-sandbox-linux/src/lib.rs
@@ -990,12 +990,43 @@ mod tests {
         );
     }
 
+    /// Both messages name GLASS_BWRAP, so asserting only that cannot tell the two apart.
     #[test]
     fn an_absent_bwrap_is_unavailable_and_points_at_the_override() {
         let Availability::Unavailable(msg) = availability_with("bwrap", Resolved::Absent) else {
             panic!("an absent bwrap must not report available");
         };
-        assert!(msg.contains("GLASS_BWRAP"), "actionable message: {msg}");
+        assert!(
+            msg.contains("GLASS_BWRAP") && msg.contains("not found"),
+            "actionable message: {msg}"
+        );
+    }
+
+    /// The arm no other test reaches. Left unpinned, replacing it with `Unavailable` refuses
+    /// every sandboxed launch on every host with the suite still green — each test that really
+    /// launches under bwrap is `#[ignore]`d.
+    #[test]
+    fn a_runnable_bwrap_clears_the_resolution_stage() {
+        assert!(
+            matches!(
+                availability_with("bwrap", Resolved::Found(PathBuf::from("/usr/bin/bwrap"))),
+                Availability::Ok
+            ),
+            "a runnable bwrap must reach the user-namespace probe"
+        );
+    }
+
+    /// The probe's spawn-failure arm, which needs no bwrap on the host: naming the binary is the
+    /// only way the user learns which one glass tried.
+    #[test]
+    fn a_bwrap_that_cannot_be_spawned_reports_why() {
+        let Availability::Unavailable(msg) = userns_availability("/nonexistent/bwrap") else {
+            panic!("a bwrap that cannot be spawned must not report available");
+        };
+        assert!(
+            msg.contains("could not run") && msg.contains("/nonexistent/bwrap"),
+            "must name what it tried to run: {msg}"
+        );
     }
 
     fn make_spec(build: Option<&str>, sandbox: SandboxLevel) -> AppSpec {

--- a/crates/glass-sandbox-linux/src/lib.rs
+++ b/crates/glass-sandbox-linux/src/lib.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use glass_core::{AppSpec, Check, CheckStatus, GlassError, Result, SandboxLevel};
-use glass_exec_unix::resolve_on_path_in;
+use glass_exec_unix::{Resolved, resolve_bin, resolve_on_path_in};
 use glass_sandbox_unix::{abs_token, canon, dir_of};
 
 /// App-level environment that makes GUI toolkits present frames without X11 MIT-SHM. glass's
@@ -51,18 +51,6 @@ fn bwrap_bin() -> String {
 /// The POSIX shell glass runs the build command with: `$GLASS_SH`, else `sh`.
 fn sh_bin() -> String {
     glass_core::tool_path("GLASS_SH", "sh")
-}
-
-/// Whether `bin` is reachable: an explicit path (contains `/`) must be an existing
-/// file; a bare name must be found on `PATH`.
-fn runnable(bin: &str) -> bool {
-    if bin.contains('/') {
-        std::path::Path::new(bin).is_file()
-    } else {
-        std::env::var_os("PATH")
-            .map(|p| std::env::split_paths(&p).any(|d| d.join(bin).is_file()))
-            .unwrap_or(false)
-    }
 }
 
 /// Inputs `wrap_argv` needs. `level` is never `Off` (the caller skips wrapping).
@@ -343,12 +331,35 @@ pub enum Availability {
 /// Probe: the configured `bwrap` reachable and an unprivileged user namespace usable.
 pub fn availability() -> Availability {
     let bin = bwrap_bin();
-    if !runnable(&bin) {
-        return Availability::Unavailable(format!(
-            "bubblewrap ({bin}) not found (set GLASS_BWRAP to its path)"
-        ));
+    let resolved = resolve_bin(&bin, std::env::var_os("PATH").as_deref());
+    match availability_with(&bin, resolved) {
+        Availability::Ok => userns_availability(&bin),
+        unavailable => unavailable,
     }
-    match Command::new(&bin)
+}
+
+/// Pure: what resolving `bwrap` alone decides — the testable seam (no global env), so a test can
+/// force either failure without `set_var` racing a concurrent reader. `Ok` here means only that
+/// a runnable `bwrap` exists; [`availability`] still has to prove it can create a namespace.
+///
+/// `bin` is the configured name, needed for the [`Resolved::Absent`] message because that variant
+/// carries no path.
+fn availability_with(bin: &str, bwrap: Resolved) -> Availability {
+    match bwrap {
+        Resolved::Found(_) => Availability::Ok,
+        Resolved::NotExecutable(p) => Availability::Unavailable(format!(
+            "bubblewrap ({}) is not executable (chmod +x it, or set GLASS_BWRAP to a runnable binary)",
+            p.display()
+        )),
+        Resolved::Absent => Availability::Unavailable(format!(
+            "bubblewrap ({bin}) not found (set GLASS_BWRAP to its path)"
+        )),
+    }
+}
+
+/// Run `bwrap` to prove an unprivileged user namespace can actually be created here.
+fn userns_availability(bin: &str) -> Availability {
+    match Command::new(bin)
         .args(["--unshare-user", "--ro-bind", "/", "/", "--", "true"])
         .output()
     {
@@ -960,6 +971,31 @@ mod tests {
             !g.to_lowercase().contains("apparmor"),
             "generic remedy must not claim AppArmor: {g}"
         );
+    }
+
+    /// glass#374: `runnable` used `is_file()`, so a mode-644 `$GLASS_BWRAP` read as reachable and
+    /// the launch then failed at spawn. Driven through the seam rather than by setting the
+    /// environment, which is `unsafe` from edition 2024 on and races concurrent readers.
+    #[test]
+    fn a_non_executable_bwrap_is_unavailable_and_says_so() {
+        let Availability::Unavailable(msg) = availability_with(
+            "/opt/bin/bwrap",
+            Resolved::NotExecutable(PathBuf::from("/opt/bin/bwrap")),
+        ) else {
+            panic!("a non-executable bwrap must not report available");
+        };
+        assert!(
+            msg.contains("/opt/bin/bwrap") && msg.contains("not executable"),
+            "must name the file and say why: {msg}"
+        );
+    }
+
+    #[test]
+    fn an_absent_bwrap_is_unavailable_and_points_at_the_override() {
+        let Availability::Unavailable(msg) = availability_with("bwrap", Resolved::Absent) else {
+            panic!("an absent bwrap must not report available");
+        };
+        assert!(msg.contains("GLASS_BWRAP"), "actionable message: {msg}");
     }
 
     fn make_spec(build: Option<&str>, sandbox: SandboxLevel) -> AppSpec {

--- a/crates/glass-sandbox-linux/src/lib.rs
+++ b/crates/glass-sandbox-linux/src/lib.rs
@@ -12,7 +12,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use glass_core::{AppSpec, Check, CheckStatus, GlassError, Result, SandboxLevel};
-use glass_sandbox_unix::{abs_token, canon, dir_of, resolve_on_path_in};
+use glass_exec_unix::resolve_on_path_in;
+use glass_sandbox_unix::{abs_token, canon, dir_of};
 
 /// App-level environment that makes GUI toolkits present frames without X11 MIT-SHM. glass's
 /// containment breaks shared-memory rendering on the headless display: `wrap_argv` passes

--- a/crates/glass-sandbox-linux/src/lib.rs
+++ b/crates/glass-sandbox-linux/src/lib.rs
@@ -974,10 +974,9 @@ mod tests {
     }
 
     /// glass#374: `runnable` used `is_file()`, so a mode-644 `$GLASS_BWRAP` reached the
-    /// user-namespace probe, which forked it only to be told "could not run …: Permission
-    /// denied". The launch was refused either way — no app was ever spawned. What changes is
-    /// that the message names the fix, and that glass stops forking a binary to learn what a
-    /// `stat` had already answered.
+    /// user-namespace probe, which forked it and reported "could not run …: Permission denied" —
+    /// the launch was refused, no app spawned. What changes: the message names the fix, and glass
+    /// stops forking a binary to learn what a `stat` answers.
     #[test]
     fn a_non_executable_bwrap_is_unavailable_and_says_so() {
         let Availability::Unavailable(msg) = availability_with(
@@ -1004,9 +1003,9 @@ mod tests {
         );
     }
 
-    /// The arm no other test reaches. Left unpinned, replacing it with `Unavailable` refuses
-    /// every sandboxed launch on every host with the suite still green — each test that really
-    /// launches under bwrap is `#[ignore]`d.
+    /// The arm no other test reaches: replacing it with `Unavailable` refuses every sandboxed
+    /// launch on every host and the suite stays green, since each test that really launches
+    /// under bwrap is `#[ignore]`d.
     #[test]
     fn a_runnable_bwrap_clears_the_resolution_stage() {
         assert!(

--- a/crates/glass-sandbox-linux/src/lib.rs
+++ b/crates/glass-sandbox-linux/src/lib.rs
@@ -121,7 +121,7 @@ pub fn launch_ro_binds(
 }
 
 /// [`launch_ro_binds`] against an explicit `$PATH` value — the testable seam (no global env), so
-/// a test can exercise the bare-name branch without `set_var` racing a concurrent env reader.
+/// a test can exercise the bare-name branch.
 fn launch_ro_binds_in(
     program: &OsStr,
     args: &[OsString],
@@ -338,9 +338,9 @@ pub fn availability() -> Availability {
     }
 }
 
-/// Pure: what resolving `bwrap` alone decides — the testable seam (no global env), so a test can
-/// force either failure without `set_var` racing a concurrent reader. `Ok` here means only that
-/// a runnable `bwrap` exists; [`availability`] still has to prove it can create a namespace.
+/// Pure: what resolving `bwrap` alone decides — the testable seam (no global env). `Ok` here means
+/// only that a runnable `bwrap` exists; [`availability`] still has to prove it can create a
+/// namespace.
 ///
 /// `bin` is the configured name, needed for the [`Resolved::Absent`] message because that variant
 /// carries no path.
@@ -973,9 +973,11 @@ mod tests {
         );
     }
 
-    /// glass#374: `runnable` used `is_file()`, so a mode-644 `$GLASS_BWRAP` read as reachable and
-    /// the launch then failed at spawn. Driven through the seam rather than by setting the
-    /// environment, which is `unsafe` from edition 2024 on and races concurrent readers.
+    /// glass#374: `runnable` used `is_file()`, so a mode-644 `$GLASS_BWRAP` reached the
+    /// user-namespace probe, which forked it only to be told "could not run …: Permission
+    /// denied". The launch was refused either way — no app was ever spawned. What changes is
+    /// that the message names the fix, and that glass stops forking a binary to learn what a
+    /// `stat` had already answered.
     #[test]
     fn a_non_executable_bwrap_is_unavailable_and_says_so() {
         let Availability::Unavailable(msg) = availability_with(

--- a/crates/glass-sandbox-macos/src/reachability.rs
+++ b/crates/glass-sandbox-macos/src/reachability.rs
@@ -1,12 +1,14 @@
 //! Compute the Seatbelt re-allows that make a sandboxed launch's OWN target reachable under the
 //! `/Users` read-deny, without re-exposing home. Resolution is shared with the Linux backend
-//! (`glass-sandbox-unix`); only the emit differs: a safe directory becomes a `(subpath …)`
-//! re-allow (ro_binds), a file directly under a bare home root becomes a single-file `(literal …)`
-//! re-allow (ro_files), and a target that IS a home root or above contributes nothing.
+//! (`glass-exec-unix`, `glass-sandbox-unix`); only the emit differs: a safe directory becomes a
+//! `(subpath …)` re-allow (ro_binds), a file directly under a bare home root becomes a
+//! single-file `(literal …)` re-allow (ro_files), and a target that IS a home root or above
+//! contributes nothing.
 
 use std::path::{Path, PathBuf};
 
-use glass_sandbox_unix::{abs_token, canon, dir_of, resolve_on_path};
+use glass_exec_unix::resolve_on_path;
+use glass_sandbox_unix::{abs_token, canon, dir_of};
 
 use crate::profile::{is_home_root_or_above, is_safe_reallow, under_users};
 

--- a/crates/glass-sandbox-unix/src/lib.rs
+++ b/crates/glass-sandbox-unix/src/lib.rs
@@ -1,8 +1,8 @@
-//! Bind-path resolution atoms shared by glass's two sandbox backends, bwrap on Linux
+//! Bind-path atoms shared by glass's two sandbox backends, bwrap on Linux
 //! (`glass-sandbox-linux`) and Seatbelt on macOS (`glass-sandbox-macos`) — unix both, which is what
-//! makes this crate unix. Given a program + args + cwd, which absolute host paths does the launch
-//! actually touch. No OS-specific containment logic lives here: each backend applies its OWN
-//! exposure guard/emit on top.
+//! makes this crate unix. One token to an absolute host path, and the directory to expose for a
+//! path. Which tokens a launch has, and how the results are guarded and emitted, is each backend's
+//! own: nothing here sees a program or an argument list.
 //!
 //! Whether a resolved path can be *run* is a different question, answered by `glass-exec-unix`.
 //!

--- a/crates/glass-sandbox-unix/src/lib.rs
+++ b/crates/glass-sandbox-unix/src/lib.rs
@@ -1,15 +1,15 @@
-//! Launch-target *resolution* atoms shared by glass's two sandbox backends, bwrap on Linux
-//! (`glass-sandbox-linux`) and Seatbelt on macOS (`glass-sandbox-macos`) — unix both, which is
-//! what makes this crate unix. No OS-specific containment logic lives here: only "given a
-//! program + args + cwd, what absolute host paths does the launch actually touch, resolved the
-//! way the child is exec'd." Each backend applies its OWN exposure guard/emit on top.
+//! Bind-path resolution atoms shared by glass's two sandbox backends, bwrap on Linux
+//! (`glass-sandbox-linux`) and Seatbelt on macOS (`glass-sandbox-macos`) — unix both, which is what
+//! makes this crate unix. Given a program + args + cwd, which absolute host paths does the launch
+//! actually touch. No OS-specific containment logic lives here: each backend applies its OWN
+//! exposure guard/emit on top.
 //!
-//! Everything here reads POSIX semantics — `/`-rooted paths, the execute bit, `execvp` lookup —
-//! so compiled off unix `is_absolute()` and the mode check would quietly mean something else.
+//! Whether a resolved path can be *run* is a different question, answered by `glass-exec-unix`.
+//!
+//! `is_absolute()` reads POSIX semantics, so compiled off unix it would quietly mean something else.
 #![cfg(unix)]
 #![forbid(unsafe_code)]
 
-use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
 /// Resolve a token to an absolute host path: an absolute token as-is, a relative one against
@@ -21,31 +21,6 @@ pub fn abs_token(tok: &Path, cwd: Option<&Path>) -> Option<PathBuf> {
     } else {
         cwd.map(|c| c.join(tok))
     }
-}
-
-/// The first `$PATH` entry holding an executable regular file named `program`, resolved the way
-/// `execvp` resolves a bare command name. `None` when `$PATH` is unset or nothing matches.
-pub fn resolve_on_path(program: &OsStr) -> Option<PathBuf> {
-    let path = std::env::var_os("PATH")?;
-    resolve_on_path_in(program, &path)
-}
-
-/// [`resolve_on_path`] against an explicit `$PATH` value — the testable seam (no global env).
-/// Public so the backends' own resolution paths can be tested the same way, without a test
-/// mutating the process environment (unsound: `set_var` races any concurrent reader).
-pub fn resolve_on_path_in(program: &OsStr, path: &OsStr) -> Option<PathBuf> {
-    std::env::split_paths(path)
-        .map(|dir| dir.join(program))
-        .find(|cand| is_executable_file(cand))
-}
-
-/// Whether `p` is (or resolves through symlinks to) a regular file that is executable — `execvp`'s
-/// "is this runnable" test.
-pub(crate) fn is_executable_file(p: &Path) -> bool {
-    use std::os::unix::fs::PermissionsExt;
-    std::fs::metadata(p)
-        .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
-        .unwrap_or(false)
 }
 
 /// Best-effort path canonicalization that never panics on a nonexistent path: the resolved path,
@@ -67,9 +42,6 @@ pub fn dir_of(p: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ffi::OsStr;
-    use std::os::unix::fs::PermissionsExt;
-    use std::path::{Path, PathBuf};
 
     #[test]
     fn abs_token_absolute_passes_through_relative_needs_cwd() {
@@ -82,47 +54,6 @@ mod tests {
             Some(PathBuf::from("/c/x/y"))
         );
         assert_eq!(abs_token(Path::new("x/y"), None), None);
-    }
-
-    #[test]
-    fn resolve_on_path_in_finds_first_executable_match() {
-        let dir = tempfile::tempdir().unwrap();
-        let exe = dir.path().join("mytool");
-        std::fs::write(&exe, b"").unwrap();
-        std::fs::set_permissions(&exe, std::fs::Permissions::from_mode(0o755)).unwrap();
-        let path = std::env::join_paths([dir.path()]).unwrap();
-        assert_eq!(resolve_on_path_in(OsStr::new("mytool"), &path), Some(exe));
-    }
-
-    /// Pins the documented "first `$PATH` entry wins" contract (`execvp` semantics): with two
-    /// directories on `$PATH`, each holding an executable of the SAME name, the match from the
-    /// FIRST directory must be returned, not merely any match.
-    #[test]
-    fn resolve_on_path_in_returns_the_first_match() {
-        let first = tempfile::tempdir().unwrap();
-        let second = tempfile::tempdir().unwrap();
-        for dir in [&first, &second] {
-            let exe = dir.path().join("mytool");
-            std::fs::write(&exe, b"").unwrap();
-            std::fs::set_permissions(&exe, std::fs::Permissions::from_mode(0o755)).unwrap();
-        }
-        let path = std::env::join_paths([first.path(), second.path()]).unwrap();
-        assert_eq!(
-            resolve_on_path_in(OsStr::new("mytool"), &path),
-            Some(first.path().join("mytool")),
-            "must return the FIRST $PATH entry's match, not merely any match"
-        );
-    }
-
-    #[test]
-    fn resolve_on_path_in_skips_non_executable_and_missing() {
-        let dir = tempfile::tempdir().unwrap();
-        let plain = dir.path().join("mytool");
-        std::fs::write(&plain, b"").unwrap();
-        std::fs::set_permissions(&plain, std::fs::Permissions::from_mode(0o644)).unwrap();
-        let path = std::env::join_paths([dir.path()]).unwrap();
-        assert_eq!(resolve_on_path_in(OsStr::new("mytool"), &path), None);
-        assert_eq!(resolve_on_path_in(OsStr::new("absent"), &path), None);
     }
 
     #[test]
@@ -144,32 +75,6 @@ mod tests {
         assert_eq!(
             canon(Path::new("/no/such/glass/path")),
             PathBuf::from("/no/such/glass/path")
-        );
-    }
-
-    #[test]
-    fn is_executable_file_true_for_exec_false_for_dir_and_plain() {
-        let dir = tempfile::tempdir().unwrap();
-
-        let exe = dir.path().join("exe");
-        std::fs::write(&exe, b"").unwrap();
-        std::fs::set_permissions(&exe, std::fs::Permissions::from_mode(0o755)).unwrap();
-        assert!(is_executable_file(&exe), "an exec-bit file must be true");
-
-        let plain = dir.path().join("plain");
-        std::fs::write(&plain, b"").unwrap();
-        std::fs::set_permissions(&plain, std::fs::Permissions::from_mode(0o644)).unwrap();
-        assert!(
-            !is_executable_file(&plain),
-            "a non-exec plain file must be false"
-        );
-
-        let subdir = dir.path().join("subdir");
-        std::fs::create_dir_all(&subdir).unwrap();
-        std::fs::set_permissions(&subdir, std::fs::Permissions::from_mode(0o755)).unwrap();
-        assert!(
-            !is_executable_file(&subdir),
-            "a directory (even an 'executable'-mode one) must be false"
         );
     }
 }

--- a/crates/glass-wayland/Cargo.toml
+++ b/crates/glass-wayland/Cargo.toml
@@ -13,6 +13,7 @@ bench = false
 
 [target.'cfg(target_os = "linux")'.dependencies]
 glass-core.workspace = true
+glass-exec-unix.workspace = true
 # The desktop-a11y capability signal (AT-SPI launcher present) lives with the a11y reader
 # and its doctor. This backend->a11y-reader direction mirrors glass-windows -> glass-a11y-windows
 # (which is acyclic). Here it forms a Cargo-legal *dev*-dependency cycle: glass-a11y-linux

--- a/crates/glass-wayland/src/doctor.rs
+++ b/crates/glass-wayland/src/doctor.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use glass_core::{AppSpec, Check, CheckStatus};
 
 use crate::command::{build_sway_command, sway_config};
-use crate::platform::resolve_sway;
+use crate::platform::{NoSway, resolve_sway_verdict};
 use crate::swayipc::Ipc;
 
 /// Probe the Wayland backend's environment. `deep` additionally spawns and tears down
@@ -26,7 +26,7 @@ pub fn checks(deep: bool) -> Vec<Check> {
 
 /// Pure: build the Wayland checks from gathered facts.
 fn wayland_checks(
-    sway: &Result<(PathBuf, String), String>,
+    sway: &Result<(PathBuf, String), NoSway>,
     gl_present: bool,
     deep_spawn: Option<Result<(), String>>,
 ) -> Vec<Check> {
@@ -37,8 +37,10 @@ fn wayland_checks(
             CheckStatus::Ok,
             format!("{ver} at {}", path.display()),
         ),
-        Err(remedy) => {
-            Check::new("sway >=1.12", CheckStatus::Fail, "not found").with_remedy(remedy.clone())
+        // The detail is the cause, not a fixed "not found": a sway that is present and cannot be
+        // run is a different problem, and reported as missing it reads as a build that never ran.
+        Err(no) => {
+            Check::new("sway >=1.12", CheckStatus::Fail, no.cause.clone()).with_remedy(no.remedy)
         }
     });
     checks.push(if gl_present {
@@ -71,14 +73,10 @@ fn wayland_checks(
 }
 
 /// Resolve sway (path) and read its version string for display.
-fn discover_sway() -> Result<(PathBuf, String), String> {
-    match resolve_sway() {
-        Ok(path) => {
-            let ver = sway_version(&path);
-            Ok((path, ver))
-        }
-        Err(e) => Err(e.to_string()),
-    }
+fn discover_sway() -> Result<(PathBuf, String), NoSway> {
+    let path = resolve_sway_verdict()?;
+    let ver = sway_version(&path);
+    Ok((path, ver))
 }
 
 fn sway_version(path: &Path) -> String {
@@ -188,9 +186,34 @@ mod tests {
 
     #[test]
     fn sway_missing_fails_with_remedy() {
-        let cs = wayland_checks(&Err("build it with sway-build".into()), true, None);
+        let cs = wayland_checks(
+            &Err(NoSway {
+                cause: "no sway >=1.12 found".into(),
+                remedy: "build it with sway-build",
+            }),
+            true,
+            None,
+        );
         assert_eq!(cs[0].status, CheckStatus::Fail);
+        assert_eq!(cs[0].detail, "no sway >=1.12 found");
         assert_eq!(cs[0].remedy.as_deref(), Some("build it with sway-build"));
+    }
+
+    /// A sway that is present and unrunnable must not print "not found": the fixed detail sent
+    /// the user to build a sway they had already built, at the path in front of them.
+    #[test]
+    fn a_sway_that_cannot_be_run_is_reported_as_such_not_as_missing() {
+        let cs = wayland_checks(
+            &Err(NoSway {
+                cause: "/opt/glass/sway/bin/sway is not executable".into(),
+                remedy: "chmod +x it",
+            }),
+            true,
+            None,
+        );
+        assert_eq!(cs[0].status, CheckStatus::Fail);
+        assert_eq!(cs[0].detail, "/opt/glass/sway/bin/sway is not executable");
+        assert_eq!(cs[0].remedy.as_deref(), Some("chmod +x it"));
     }
 
     #[test]
@@ -247,7 +270,11 @@ mod tests {
     #[ignore = "starts a real compositor or X server; needs sway, Mesa, Xwayland or Xvfb"]
     fn discover_sway_reports_the_real_binary_and_its_version() {
         let (path, ver) = discover_sway().expect("this box has a discoverable sway");
-        assert!(path.is_file(), "{}", path.display());
+        assert!(
+            glass_exec_unix::is_executable_file(&path),
+            "discovery must yield something glass can spawn: {}",
+            path.display()
+        );
         assert!(ver.contains("sway version"), "{ver}");
     }
 

--- a/crates/glass-wayland/src/doctor.rs
+++ b/crates/glass-wayland/src/doctor.rs
@@ -37,8 +37,8 @@ fn wayland_checks(
             CheckStatus::Ok,
             format!("{ver} at {}", path.display()),
         ),
-        // The detail is the cause, not a fixed "not found": a sway that is present and cannot be
-        // run is a different problem, and reported as missing it reads as a build that never ran.
+        // The detail is the cause, not a fixed "not found": a present sway reported as missing
+        // reads as a build that never ran.
         Err(no) => {
             Check::new("sway >=1.12", CheckStatus::Fail, no.cause.clone()).with_remedy(no.remedy)
         }
@@ -199,8 +199,8 @@ mod tests {
         assert_eq!(cs[0].remedy.as_deref(), Some("build it with sway-build"));
     }
 
-    /// A sway that is present and unrunnable must not print "not found": the fixed detail sent
-    /// the user to build a sway they had already built, at the path in front of them.
+    /// The fixed "not found" detail sent the user to build a sway they had already built, at the
+    /// path in front of them.
     #[test]
     fn a_sway_that_cannot_be_run_is_reported_as_such_not_as_missing() {
         let cs = wayland_checks(

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -10,6 +10,7 @@ use glass_core::{
     AppSpec, Frame, GlassError, KeyEvent, Platform, PointerEvent, Region, Result, Stream,
     TEARDOWN_BUDGET, WindowGeometry, WindowId, WindowInfo, WindowOp,
 };
+use glass_exec_unix::is_executable_file;
 use glass_proc_linux::{APP_REAP_GRACE, Asked, CLOSE_GRACE};
 use smithay_client_toolkit::delegate_dispatch2;
 use smithay_client_toolkit::delegate_registry;
@@ -236,7 +237,7 @@ pub(crate) fn resolve_sway() -> Result<PathBuf> {
         .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/share")));
     if let Some(d) = data {
         let cand = d.join("glass/sway/bin/sway");
-        if cand.is_file() {
+        if is_executable_file(&cand) {
             return Ok(cand);
         }
     }
@@ -244,7 +245,7 @@ pub(crate) fn resolve_sway() -> Result<PathBuf> {
         && let Some(dir) = exe.parent()
     {
         let cand = dir.join("sway/bin/sway");
-        if cand.is_file() {
+        if is_executable_file(&cand) {
             return Ok(cand);
         }
     }
@@ -261,7 +262,7 @@ pub(crate) fn resolve_sway() -> Result<PathBuf> {
 /// file — falling back to discovery would chase a version-specific bug in a different binary.
 fn sway_override(value: Option<std::ffi::OsString>) -> Option<Result<PathBuf>> {
     let p = PathBuf::from(value.filter(|s| !s.is_empty())?);
-    Some(if p.is_file() {
+    Some(if is_executable_file(&p) {
         Ok(p)
     } else {
         Err(GlassError::Backend(format!(
@@ -278,7 +279,7 @@ fn sway_override(value: Option<std::ffi::OsString>) -> Option<Result<PathBuf>> {
 fn sway_in_dirs(dirs: impl Iterator<Item = PathBuf>) -> Option<PathBuf> {
     for dir in dirs {
         let cand = dir.join("sway");
-        if !cand.is_file() {
+        if !is_executable_file(&cand) {
             continue;
         }
         let out = std::process::Command::new(&cand)
@@ -1524,6 +1525,8 @@ impl Platform for WaylandPlatform {
 
 #[cfg(test)]
 mod pure_tests {
+    use std::os::unix::fs::PermissionsExt as _;
+
     use super::*;
 
     fn win(identifier: &str, x11: Option<u32>) -> SwayWindow {
@@ -1667,6 +1670,40 @@ mod pure_tests {
             .expect("a choice was made")
             .expect_err("a named path that is not there must not fall back");
         assert!(err.to_string().contains("/nonexistent/sway"), "{err}");
+    }
+
+    /// glass#374: the override was checked with `is_file()` while the error it produces has always
+    /// said "is not an executable file".
+    #[test]
+    fn an_override_naming_a_non_executable_file_is_an_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bin = dir.path().join("sway");
+        std::fs::write(&bin, b"").expect("write");
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o644)).expect("chmod");
+        let err = sway_override(Some(bin.clone().into_os_string()))
+            .expect("a choice was made")
+            .expect_err("a file that cannot be run must not be trusted");
+        assert!(
+            err.to_string().contains(&bin.display().to_string()),
+            "{err}"
+        );
+    }
+
+    /// A non-executable `sway` early on `PATH` used to abort discovery outright: the candidate was
+    /// accepted on `is_file()`, `--version` then failed to spawn, and `.output().ok()?` returned
+    /// `None` from the whole function — so the bundled build was never reached.
+    #[test]
+    fn a_non_executable_sway_on_the_path_does_not_abort_discovery() {
+        let broken = tempfile::tempdir().expect("tempdir");
+        let bin = broken.path().join("sway");
+        std::fs::write(&bin, b"").expect("write");
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o644)).expect("chmod");
+        let good = fake_sway("sway version 1.12-abc (Jun 3 2026)");
+        assert_eq!(
+            sway_in_dirs([broken.path().to_path_buf(), good.path().to_path_buf()].into_iter()),
+            Some(good.path().join("sway")),
+            "a sway that cannot be run must be skipped, not treated as the answer"
+        );
     }
 
     #[test]

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -331,14 +331,13 @@ fn sway_override(
 
 /// The first `sway` in `dirs` whose `--version` reports >= 1.12.
 ///
-/// Only an *answer* ends the walk. A candidate that ran and reported a version decides the
-/// outcome, even a bad one: too old or unparseable means fall back to the bundle, never a
-/// different sway further along, because `PATH` order is a precedence the user expressed and
-/// substituting past it is what [`sway_override`] refuses.
+/// Only an answer ends the walk. A candidate that ran decides the outcome even when the version
+/// is too old or unreadable — that means the bundle, never a different sway further along, since
+/// `PATH` order is a precedence the user expressed.
 ///
-/// A candidate that never ran expressed nothing, so it is stepped over and the walk goes on —
-/// no execute permission, or a spawn that failed outright (`ENOEXEC` for a file that is not a
-/// binary, `ETXTBSY` while something else still holds it open for writing).
+/// A candidate that never ran expressed nothing, so it is stepped over: no execute permission, or
+/// a spawn that failed outright (`ENOEXEC` for a file that is not a binary, `ETXTBSY` while
+/// something else holds it open for writing).
 fn sway_in_dirs(dirs: impl Iterator<Item = PathBuf>) -> Option<PathBuf> {
     for dir in dirs {
         let cand = dir.join("sway");
@@ -351,7 +350,7 @@ fn sway_in_dirs(dirs: impl Iterator<Item = PathBuf>) -> Option<PathBuf> {
         let ver = String::from_utf8_lossy(&out.stdout);
         return match parse_sway_version(&ver) {
             Some((maj, min)) if (maj, min) >= (1, 12) => Some(cand),
-            _ => None, // it answered, and the answer was not a sway >=1.12 -> use the bundle
+            _ => None, // answered, just not usably -> the bundle, not a later sway
         };
     }
     None
@@ -1765,9 +1764,9 @@ mod pure_tests {
         );
     }
 
-    /// An empty file at 0o755 passes the permission check and then fails to exec (`ENOEXEC`) —
+    /// An empty file at 0o755 clears the permission check and then fails to exec (`ENOEXEC`) —
     /// the deterministic twin of the `ETXTBSY` a concurrent write raises. Ending the walk on
-    /// either made glass conclude there was no sway on `$PATH` at all.
+    /// either made glass report no sway on `$PATH` at all.
     #[test]
     fn a_sway_that_fails_to_spawn_does_not_hide_a_later_one() {
         let unspawnable = tempfile::tempdir().expect("tempdir");

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -10,7 +10,7 @@ use glass_core::{
     AppSpec, Frame, GlassError, KeyEvent, Platform, PointerEvent, Region, Result, Stream,
     TEARDOWN_BUDGET, WindowGeometry, WindowId, WindowInfo, WindowOp,
 };
-use glass_exec_unix::is_executable_file;
+use glass_exec_unix::{Resolved, is_executable_file, resolve_path};
 use glass_proc_linux::{APP_REAP_GRACE, Asked, CLOSE_GRACE};
 use smithay_client_toolkit::delegate_dispatch2;
 use smithay_client_toolkit::delegate_registry;
@@ -217,10 +217,48 @@ impl Drop for WaylandPlatform {
     }
 }
 
+/// Why no sway was resolved. Two fields because doctor prints the cause and the fix in separate
+/// columns, while the launch path has one message to say both in.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NoSway {
+    pub(crate) cause: String,
+    pub(crate) remedy: &'static str,
+}
+
+const BUILD_A_SWAY: &str = "build it with https://github.com/fixed-width/sway-build \
+     (./build.sh && ./build.sh install), or install a distro sway >=1.12";
+const MAKE_IT_RUNNABLE: &str = "chmod +x it, or point GLASS_SWAY at a runnable sway >=1.12";
+
+impl NoSway {
+    fn nothing_qualifies() -> Self {
+        NoSway {
+            cause: "no sway >=1.12 found".into(),
+            remedy: BUILD_A_SWAY,
+        }
+    }
+
+    fn not_runnable(cause: String) -> Self {
+        NoSway {
+            cause,
+            remedy: MAKE_IT_RUNNABLE,
+        }
+    }
+
+    /// Cause and fix in one string, for the launch path's single error message.
+    fn message(&self) -> String {
+        format!("{} — {}", self.cause, self.remedy)
+    }
+}
+
 /// Find a sway ≥1.12 with no env-var config: PATH (if recent enough) → the glass
 /// data dir (where the build tool installs the bundle) → next to this executable.
 /// No silent fallback — a clear error if none qualifies.
 pub(crate) fn resolve_sway() -> Result<PathBuf> {
+    resolve_sway_verdict().map_err(|no| GlassError::Backend(no.message()))
+}
+
+/// [`resolve_sway`] keeping the cause and the fix apart, for doctor.
+pub(crate) fn resolve_sway_verdict() -> std::result::Result<PathBuf, NoSway> {
     if let Some(overridden) = sway_override(std::env::var_os("GLASS_SWAY")) {
         return overridden;
     }
@@ -235,37 +273,56 @@ pub(crate) fn resolve_sway() -> Result<PathBuf> {
     let data = std::env::var_os("XDG_DATA_HOME")
         .map(PathBuf::from)
         .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/share")));
-    if let Some(d) = data {
-        let cand = d.join("glass/sway/bin/sway");
-        if is_executable_file(&cand) {
-            return Ok(cand);
+    let exe_dir = std::env::current_exe()
+        .ok()
+        .and_then(|exe| exe.parent().map(Path::to_path_buf));
+    match sway_bundle_in(data, exe_dir) {
+        Resolved::Found(p) => Ok(p),
+        Resolved::NotExecutable(p) => Err(NoSway::not_runnable(format!(
+            "{} is not executable",
+            p.display()
+        ))),
+        Resolved::Absent => Err(NoSway::nothing_qualifies()),
+    }
+}
+
+/// The bundled sway: under the glass data dir, where the build tool installs it, then next to
+/// this executable. The testable seam — both roots come from the environment.
+///
+/// A bundle that is there but cannot be run is reported as such rather than skipped. It is the
+/// path the user installed to (a `cp` across machines or an unzip drops the execute bit), and
+/// "no sway found, build one" would send them to rebuild what they already have.
+fn sway_bundle_in(data: Option<PathBuf>, exe_dir: Option<PathBuf>) -> Resolved {
+    let candidates = [
+        data.map(|d| d.join("glass/sway/bin/sway")),
+        exe_dir.map(|d| d.join("sway/bin/sway")),
+    ];
+    let mut first_non_executable = None;
+    for cand in candidates.into_iter().flatten() {
+        match resolve_path(&cand) {
+            Resolved::Found(p) => return Resolved::Found(p),
+            Resolved::NotExecutable(p) => {
+                first_non_executable.get_or_insert(p);
+            }
+            Resolved::Absent => {}
         }
     }
-    if let Ok(exe) = std::env::current_exe()
-        && let Some(dir) = exe.parent()
-    {
-        let cand = dir.join("sway/bin/sway");
-        if is_executable_file(&cand) {
-            return Ok(cand);
-        }
-    }
-    Err(GlassError::Backend(
-        "no sway >=1.12 found. Build it with https://github.com/fixed-width/sway-build (./build.sh && ./build.sh install), \
-         or install a distro sway >=1.12."
-            .into(),
-    ))
+    first_non_executable.map_or(Resolved::Absent, Resolved::NotExecutable)
 }
 
 /// What `GLASS_SWAY` decides, or `None` when it is unset or empty and discovery should run.
 ///
-/// An override skips the version gate, and fails closed when it names something that is not a
-/// file — falling back to discovery would chase a version-specific bug in a different binary.
-fn sway_override(value: Option<std::ffi::OsString>) -> Option<Result<PathBuf>> {
+/// An override skips the version gate, and fails closed when it names something glass cannot
+/// spawn — whether that is nothing at all or a file without execute permission. Falling back to
+/// discovery would chase a version-specific bug in a different binary.
+fn sway_override(
+    value: Option<std::ffi::OsString>,
+) -> Option<std::result::Result<PathBuf, NoSway>> {
     let p = PathBuf::from(value.filter(|s| !s.is_empty())?);
     Some(if is_executable_file(&p) {
         Ok(p)
     } else {
-        Err(GlassError::Backend(format!(
+        Err(NoSway::not_runnable(format!(
             "GLASS_SWAY={} is not an executable file",
             p.display()
         )))
@@ -274,8 +331,10 @@ fn sway_override(value: Option<std::ffi::OsString>) -> Option<Result<PathBuf>> {
 
 /// The first `sway` in `dirs` whose `--version` reports >= 1.12.
 ///
-/// A too-old one is not skipped in favour of a later directory: `PATH` order is the user's own
-/// precedence, and walking past it is the substitution [`sway_override`] refuses.
+/// Precedence is the user's: a too-old sway ends the walk rather than being skipped for a later
+/// directory, because `PATH` order is a choice they expressed and substituting past it is what
+/// [`sway_override`] refuses. One glass could not have run is a different matter — it was never a
+/// choice between binaries — so it is skipped and the walk goes on.
 fn sway_in_dirs(dirs: impl Iterator<Item = PathBuf>) -> Option<PathBuf> {
     for dir in dirs {
         let cand = dir.join("sway");
@@ -1669,7 +1728,7 @@ mod pure_tests {
         let err = sway_override(Some("/nonexistent/sway".into()))
             .expect("a choice was made")
             .expect_err("a named path that is not there must not fall back");
-        assert!(err.to_string().contains("/nonexistent/sway"), "{err}");
+        assert!(err.cause.contains("/nonexistent/sway"), "{err:?}");
     }
 
     /// glass#374: the override was checked with `is_file()` while the error it produces has always
@@ -1683,17 +1742,14 @@ mod pure_tests {
         let err = sway_override(Some(bin.clone().into_os_string()))
             .expect("a choice was made")
             .expect_err("a file that cannot be run must not be trusted");
-        assert!(
-            err.to_string().contains(&bin.display().to_string()),
-            "{err}"
-        );
+        assert!(err.cause.contains(&bin.display().to_string()), "{err:?}");
     }
 
-    /// A non-executable `sway` early on `PATH` used to abort discovery outright: the candidate was
-    /// accepted on `is_file()`, `--version` then failed to spawn, and `.output().ok()?` returned
-    /// `None` from the whole function — so the bundled build was never reached.
+    /// A non-executable `sway` early on `PATH` used to cost every later `PATH` entry: the
+    /// candidate was accepted on `is_file()`, `--version` then failed to spawn, and
+    /// `.output().ok()?` ended the walk — so a good distro sway further along was never seen.
     #[test]
-    fn a_non_executable_sway_on_the_path_does_not_abort_discovery() {
+    fn a_non_executable_sway_early_on_the_path_does_not_hide_a_later_one() {
         let broken = tempfile::tempdir().expect("tempdir");
         let bin = broken.path().join("sway");
         std::fs::write(&bin, b"").expect("write");
@@ -1706,11 +1762,88 @@ mod pure_tests {
         );
     }
 
+    /// A bundle root holding `glass/sway/bin/sway` (the data-dir layout) or `sway/bin/sway`
+    /// (next to the executable) at `mode`.
+    fn bundle_at(relative: &str, mode: u32) -> tempfile::TempDir {
+        use std::os::unix::fs::PermissionsExt as _;
+        let root = tempfile::tempdir().expect("tempdir");
+        let bin = root.path().join(relative);
+        std::fs::create_dir_all(bin.parent().expect("has a parent")).expect("mkdir");
+        std::fs::write(&bin, b"").expect("write");
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(mode)).expect("chmod");
+        root
+    }
+
+    #[test]
+    fn a_runnable_bundle_in_the_data_dir_is_found() {
+        let root = bundle_at("glass/sway/bin/sway", 0o755);
+        assert_eq!(
+            sway_bundle_in(Some(root.path().to_path_buf()), None),
+            Resolved::Found(root.path().join("glass/sway/bin/sway"))
+        );
+    }
+
+    /// A bundle whose execute bit was lost (unzipped rather than untarred, copied across
+    /// machines, on a `noexec` mount) used to be accepted and fail at spawn; skipping it
+    /// silently is no better, because the resulting "build a sway" names the path just skipped.
+    #[test]
+    fn a_bundle_that_cannot_be_run_is_named_rather_than_skipped() {
+        let root = bundle_at("glass/sway/bin/sway", 0o644);
+        assert_eq!(
+            sway_bundle_in(Some(root.path().to_path_buf()), None),
+            Resolved::NotExecutable(root.path().join("glass/sway/bin/sway"))
+        );
+    }
+
+    /// The data dir is searched first, but an unrunnable bundle there is not the answer when a
+    /// runnable one sits next to the executable.
+    #[test]
+    fn a_runnable_bundle_beside_the_executable_beats_an_unrunnable_data_dir_one() {
+        let data = bundle_at("glass/sway/bin/sway", 0o644);
+        let exe = bundle_at("sway/bin/sway", 0o755);
+        assert_eq!(
+            sway_bundle_in(
+                Some(data.path().to_path_buf()),
+                Some(exe.path().to_path_buf())
+            ),
+            Resolved::Found(exe.path().join("sway/bin/sway"))
+        );
+    }
+
+    #[test]
+    fn no_bundle_in_either_root_is_absent() {
+        let empty = tempfile::tempdir().expect("tempdir");
+        assert_eq!(
+            sway_bundle_in(
+                Some(empty.path().to_path_buf()),
+                Some(empty.path().to_path_buf())
+            ),
+            Resolved::Absent
+        );
+        assert_eq!(sway_bundle_in(None, None), Resolved::Absent);
+    }
+
+    /// The launch path gets one string where doctor gets two columns, so it must carry both.
+    #[test]
+    fn a_failure_message_carries_the_cause_and_the_fix() {
+        let msg = NoSway::not_runnable("/opt/sway is not executable".into()).message();
+        assert!(msg.contains("/opt/sway is not executable"), "{msg}");
+        assert!(msg.contains("chmod +x"), "{msg}");
+
+        let msg = NoSway::nothing_qualifies().message();
+        assert!(msg.contains("no sway >=1.12 found"), "{msg}");
+        assert!(msg.contains("sway-build"), "{msg}");
+    }
+
     #[test]
     #[ignore = "starts a real compositor or X server; needs sway, Mesa, Xwayland or Xvfb"]
     fn discovery_finds_a_real_sway_on_this_machine() {
         let found = resolve_sway().expect("a discoverable sway");
-        assert!(found.is_file(), "{}", found.display());
+        assert!(
+            is_executable_file(&found),
+            "discovery must yield something glass can spawn: {}",
+            found.display()
+        );
     }
 
     /// A probe that panics is the only way to assert something is *not* called. Note this drives

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -217,8 +217,8 @@ impl Drop for WaylandPlatform {
     }
 }
 
-/// Why no sway was resolved. Two fields because doctor prints the cause and the fix in separate
-/// columns, while the launch path has one message to say both in.
+/// Why no sway was resolved. Two fields: doctor prints cause and fix in separate columns, the
+/// launch path joins them into one message.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct NoSway {
     pub(crate) cause: String,
@@ -289,9 +289,9 @@ pub(crate) fn resolve_sway_verdict() -> std::result::Result<PathBuf, NoSway> {
 /// The bundled sway: under the glass data dir, where the build tool installs it, then next to
 /// this executable. The testable seam — both roots come from the environment.
 ///
-/// A bundle that is there but cannot be run is reported as such rather than skipped. It is the
-/// path the user installed to (a `cp` across machines or an unzip drops the execute bit), and
-/// "no sway found, build one" would send them to rebuild what they already have.
+/// A bundle there but unrunnable is named rather than skipped: a `cp` across machines or an unzip
+/// drops the execute bit, and "no sway found, build one" would send the user to rebuild what they
+/// already have.
 fn sway_bundle_in(data: Option<PathBuf>, exe_dir: Option<PathBuf>) -> Resolved {
     let candidates = [
         data.map(|d| d.join("glass/sway/bin/sway")),
@@ -332,9 +332,8 @@ fn sway_override(
 /// The first `sway` in `dirs` whose `--version` reports >= 1.12.
 ///
 /// Precedence is the user's: a too-old sway ends the walk rather than being skipped for a later
-/// directory, because `PATH` order is a choice they expressed and substituting past it is what
-/// [`sway_override`] refuses. One glass could not have run is a different matter — it was never a
-/// choice between binaries — so it is skipped and the walk goes on.
+/// directory, because `PATH` order is a choice they expressed. One glass could never have run was
+/// not such a choice, so it is skipped and the walk goes on.
 fn sway_in_dirs(dirs: impl Iterator<Item = PathBuf>) -> Option<PathBuf> {
     for dir in dirs {
         let cand = dir.join("sway");
@@ -1783,9 +1782,8 @@ mod pure_tests {
         );
     }
 
-    /// A bundle whose execute bit was lost (unzipped rather than untarred, copied across
-    /// machines, on a `noexec` mount) used to be accepted and fail at spawn; skipping it
-    /// silently is no better, because the resulting "build a sway" names the path just skipped.
+    /// Skipping it silently is no better than accepting it and failing at spawn: the resulting
+    /// "build a sway" names the path just skipped.
     #[test]
     fn a_bundle_that_cannot_be_run_is_named_rather_than_skipped() {
         let root = bundle_at("glass/sway/bin/sway", 0o644);
@@ -1795,8 +1793,6 @@ mod pure_tests {
         );
     }
 
-    /// The data dir is searched first, but an unrunnable bundle there is not the answer when a
-    /// runnable one sits next to the executable.
     #[test]
     fn a_runnable_bundle_beside_the_executable_beats_an_unrunnable_data_dir_one() {
         let data = bundle_at("glass/sway/bin/sway", 0o644);

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -1666,13 +1666,14 @@ mod pure_tests {
         assert_eq!(next, 2, "re-fetching must not consume an id");
     }
 
-    /// Serializes the tests that write a fixture and then exec it.
+    /// Serializes the tests that exec a fixture they just wrote.
     ///
-    /// `fs::write` holds a write fd on the fixture, and a `fork` on any other thread inherits it
-    /// for the instant before its own exec — so a sibling spawning at the wrong moment makes this
-    /// one's exec fail `ETXTBSY` and the search find nothing. The race is the harness's; glass
-    /// never writes a binary it is about to probe. Poison is ignored so one test's panic cannot
-    /// fail its siblings.
+    /// Another thread's `fork` inherits the write fd `fs::write` holds, until that child execs —
+    /// so a sibling spawning mid-write fails this exec with `ETXTBSY`, and the lock must cover
+    /// the write, not just the exec. Not a product bug: glass never writes a binary it is about
+    /// to probe.
+    ///
+    /// Poison is ignored — one test's panic must not fail its siblings.
     fn one_spawner_at_a_time() -> std::sync::MutexGuard<'static, ()> {
         static SPAWN: std::sync::Mutex<()> = std::sync::Mutex::new(());
         SPAWN

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -1666,6 +1666,20 @@ mod pure_tests {
         assert_eq!(next, 2, "re-fetching must not consume an id");
     }
 
+    /// Serializes the tests that write a fixture and then exec it.
+    ///
+    /// `fs::write` holds a write fd on the fixture, and a `fork` on any other thread inherits it
+    /// for the instant before its own exec — so a sibling spawning at the wrong moment makes this
+    /// one's exec fail `ETXTBSY` and the search find nothing. The race is the harness's; glass
+    /// never writes a binary it is about to probe. Poison is ignored so one test's panic cannot
+    /// fail its siblings.
+    fn one_spawner_at_a_time() -> std::sync::MutexGuard<'static, ()> {
+        static SPAWN: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        SPAWN
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
     /// A directory holding a `sway` that answers `--version` with `reply`.
     fn fake_sway(reply: &str) -> tempfile::TempDir {
         use std::os::unix::fs::PermissionsExt as _;
@@ -1678,6 +1692,7 @@ mod pure_tests {
 
     #[test]
     fn a_recent_sway_on_the_path_is_used() {
+        let _guard = one_spawner_at_a_time();
         let dir = fake_sway("sway version 1.12-abc (Jun 3 2026)");
         assert_eq!(
             sway_in_dirs([dir.path().to_path_buf()].into_iter()),
@@ -1689,6 +1704,7 @@ mod pure_tests {
     /// sway through IPC and protocol surface it only has from 1.12.
     #[test]
     fn an_old_or_unreadable_sway_on_the_path_is_not_used() {
+        let _guard = one_spawner_at_a_time();
         for reply in ["sway version 1.9", "sway version 1.11-x", "wat"] {
             let dir = fake_sway(reply);
             assert_eq!(
@@ -1752,6 +1768,7 @@ mod pure_tests {
     /// `.output().ok()?` ended the walk — so a good distro sway further along was never seen.
     #[test]
     fn a_non_executable_sway_early_on_the_path_does_not_hide_a_later_one() {
+        let _guard = one_spawner_at_a_time();
         let broken = tempfile::tempdir().expect("tempdir");
         let bin = broken.path().join("sway");
         std::fs::write(&bin, b"").expect("write");
@@ -1769,6 +1786,7 @@ mod pure_tests {
     /// either made glass report no sway on `$PATH` at all.
     #[test]
     fn a_sway_that_fails_to_spawn_does_not_hide_a_later_one() {
+        let _guard = one_spawner_at_a_time();
         let unspawnable = tempfile::tempdir().expect("tempdir");
         let bin = unspawnable.path().join("sway");
         std::fs::write(&bin, b"").expect("write");

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -331,23 +331,27 @@ fn sway_override(
 
 /// The first `sway` in `dirs` whose `--version` reports >= 1.12.
 ///
-/// Precedence is the user's: a too-old sway ends the walk rather than being skipped for a later
-/// directory, because `PATH` order is a choice they expressed. One glass could never have run was
-/// not such a choice, so it is skipped and the walk goes on.
+/// Only an *answer* ends the walk. A candidate that ran and reported a version decides the
+/// outcome, even a bad one: too old or unparseable means fall back to the bundle, never a
+/// different sway further along, because `PATH` order is a precedence the user expressed and
+/// substituting past it is what [`sway_override`] refuses.
+///
+/// A candidate that never ran expressed nothing, so it is stepped over and the walk goes on —
+/// no execute permission, or a spawn that failed outright (`ENOEXEC` for a file that is not a
+/// binary, `ETXTBSY` while something else still holds it open for writing).
 fn sway_in_dirs(dirs: impl Iterator<Item = PathBuf>) -> Option<PathBuf> {
     for dir in dirs {
         let cand = dir.join("sway");
         if !is_executable_file(&cand) {
             continue;
         }
-        let out = std::process::Command::new(&cand)
-            .arg("--version")
-            .output()
-            .ok()?;
+        let Ok(out) = std::process::Command::new(&cand).arg("--version").output() else {
+            continue;
+        };
         let ver = String::from_utf8_lossy(&out.stdout);
         return match parse_sway_version(&ver) {
             Some((maj, min)) if (maj, min) >= (1, 12) => Some(cand),
-            _ => None, // a sway is on PATH but too old/unparseable -> use the bundle
+            _ => None, // it answered, and the answer was not a sway >=1.12 -> use the bundle
         };
     }
     None
@@ -1758,6 +1762,27 @@ mod pure_tests {
             sway_in_dirs([broken.path().to_path_buf(), good.path().to_path_buf()].into_iter()),
             Some(good.path().join("sway")),
             "a sway that cannot be run must be skipped, not treated as the answer"
+        );
+    }
+
+    /// An empty file at 0o755 passes the permission check and then fails to exec (`ENOEXEC`) —
+    /// the deterministic twin of the `ETXTBSY` a concurrent write raises. Ending the walk on
+    /// either made glass conclude there was no sway on `$PATH` at all.
+    #[test]
+    fn a_sway_that_fails_to_spawn_does_not_hide_a_later_one() {
+        let unspawnable = tempfile::tempdir().expect("tempdir");
+        let bin = unspawnable.path().join("sway");
+        std::fs::write(&bin, b"").expect("write");
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        assert!(
+            is_executable_file(&bin),
+            "the fixture must clear the permission check, or this pins the wrong branch"
+        );
+        let good = fake_sway("sway version 1.12-abc (Jun 3 2026)");
+        assert_eq!(
+            sway_in_dirs([unspawnable.path().to_path_buf(), good.path().to_path_buf()].into_iter()),
+            Some(good.path().join("sway")),
+            "a candidate that never ran must be stepped over, not end the walk"
         );
     }
 

--- a/crates/glass-x11/Cargo.toml
+++ b/crates/glass-x11/Cargo.toml
@@ -13,6 +13,7 @@ bench = false
 
 [target.'cfg(target_os = "linux")'.dependencies]
 glass-core.workspace = true
+glass-exec-unix.workspace = true
 # The desktop-a11y capability signal (AT-SPI launcher present) lives with the a11y reader
 # and its doctor. This backend->a11y-reader direction mirrors glass-windows -> glass-a11y-windows
 # (which is acyclic). Here it forms a Cargo-legal *dev*-dependency cycle: glass-a11y-linux

--- a/crates/glass-x11/src/doctor.rs
+++ b/crates/glass-x11/src/doctor.rs
@@ -3,12 +3,11 @@
 //! [`checks`] gathers the real environment; the pure [`x11_checks`] maps gathered
 //! facts to [`Check`]s and is unit-tested without a display.
 
-use std::ffi::OsStr;
-use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::time::Duration;
 
 use glass_core::{Check, CheckStatus};
+use glass_exec_unix::{Resolved, resolve_bin};
 
 use crate::xvfb::Xvfb;
 
@@ -29,13 +28,13 @@ fn checks_for(glass_display: Option<&str>, deep: bool) -> Vec<Check> {
     );
     let attach_reachable = gd.map(|d| can_connect(&crate::platform::normalize_display(d)));
     let deep_spawn = (deep && gd.is_none()).then(probe_xvfb);
-    x11_checks(gd, xvfb.as_deref(), attach_reachable, deep_spawn)
+    x11_checks(gd, &xvfb, attach_reachable, deep_spawn)
 }
 
 /// Pure: build the X11 checks from gathered facts.
 fn x11_checks(
     glass_display: Option<&str>,
-    xvfb: Option<&Path>,
+    xvfb: &Resolved,
     attach_reachable: Option<bool>,
     deep_spawn: Option<Result<String, String>>,
 ) -> Vec<Check> {
@@ -49,8 +48,17 @@ fn x11_checks(
                 "unset — glass will spawn a private headless Xvfb",
             ));
             checks.push(match xvfb {
-                Some(p) => Check::new("Xvfb", CheckStatus::Ok, p.display().to_string()),
-                None => Check::new("Xvfb", CheckStatus::Fail, "not found").with_remedy(
+                Resolved::Found(p) => Check::new("Xvfb", CheckStatus::Ok, p.display().to_string()),
+                Resolved::NotExecutable(p) => Check::new(
+                    "Xvfb",
+                    CheckStatus::Fail,
+                    format!("{} — not executable", p.display()),
+                )
+                .with_remedy(format!(
+                    "chmod +x {}, or point GLASS_XVFB at a runnable binary",
+                    p.display()
+                )),
+                Resolved::Absent => Check::new("Xvfb", CheckStatus::Fail, "not found").with_remedy(
                     "install it (e.g. `apt install xvfb`), set GLASS_XVFB to its path, or set \
                      GLASS_DISPLAY=:N to attach to an existing display",
                 ),
@@ -89,24 +97,6 @@ fn x11_checks(
         }
     }
     checks
-}
-
-/// First existing file named `name` in `path`, a `PATH`-style separated list.
-fn which_in(path: &OsStr, name: &str) -> Option<PathBuf> {
-    std::env::split_paths(path)
-        .map(|d| d.join(name))
-        .find(|p| p.is_file())
-}
-
-/// Resolve a configured binary to an existing path: an explicit path (contains `/`) must
-/// be an existing file; a bare name is looked up in `path`.
-fn resolve_bin(bin: &str, path: Option<&OsStr>) -> Option<PathBuf> {
-    if bin.contains('/') {
-        let p = PathBuf::from(bin);
-        p.is_file().then_some(p)
-    } else {
-        which_in(path?, bin)
-    }
 }
 
 fn can_connect(display: &str) -> bool {
@@ -150,12 +140,18 @@ fn probe_xvfb() -> Result<String, String> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
 
     #[test]
     fn self_spawn_with_xvfb_present_is_ok() {
-        let p = PathBuf::from("/usr/bin/Xvfb");
-        let cs = x11_checks(None, Some(&p), None, None);
+        let cs = x11_checks(
+            None,
+            &Resolved::Found(PathBuf::from("/usr/bin/Xvfb")),
+            None,
+            None,
+        );
         assert_eq!(cs[0].name, "GLASS_DISPLAY");
         assert_eq!(cs[0].status, CheckStatus::Ok);
         assert_eq!(cs[1].name, "Xvfb");
@@ -165,7 +161,7 @@ mod tests {
 
     #[test]
     fn self_spawn_without_xvfb_fails_with_remedy() {
-        let cs = x11_checks(None, None, None, None);
+        let cs = x11_checks(None, &Resolved::Absent, None, None);
         let xvfb = cs.iter().find(|c| c.name == "Xvfb").unwrap();
         assert_eq!(xvfb.status, CheckStatus::Fail);
         assert!(xvfb.remedy.as_deref().unwrap().contains("apt install xvfb"));
@@ -173,61 +169,16 @@ mod tests {
 
     #[test]
     fn attach_reachable_is_ok_unreachable_fails() {
-        let ok = x11_checks(Some(":42"), None, Some(true), None);
+        let ok = x11_checks(Some(":42"), &Resolved::Absent, Some(true), None);
         assert_eq!(ok[0].status, CheckStatus::Ok);
         assert!(
             ok.iter().all(|c| c.name != "Xvfb"),
             "attach mode shouldn't require Xvfb"
         );
 
-        let bad = x11_checks(Some(":42"), None, Some(false), None);
+        let bad = x11_checks(Some(":42"), &Resolved::Absent, Some(false), None);
         assert_eq!(bad[0].status, CheckStatus::Fail);
         assert!(bad[0].remedy.is_some());
-    }
-
-    /// A directory holding an executable `name`, plus a second empty directory, returned as
-    /// a `PATH`-style list with the empty one first — so a hit proves the search walked on
-    /// rather than stopping at the head.
-    fn path_containing(name: &str) -> (tempfile::TempDir, std::ffi::OsString, PathBuf) {
-        use std::os::unix::fs::PermissionsExt;
-        let dir = tempfile::tempdir().expect("temp dir");
-        let empty = dir.path().join("empty");
-        let holding = dir.path().join("holding");
-        std::fs::create_dir_all(&empty).unwrap();
-        std::fs::create_dir_all(&holding).unwrap();
-        let bin = holding.join(name);
-        std::fs::write(&bin, "#!/bin/sh\n").unwrap();
-        // Executable, so the test is about the search and not about accepting a file that
-        // could never be spawned.
-        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
-        let list = std::env::join_paths([&empty, &holding]).expect("join paths");
-        (dir, list, bin)
-    }
-
-    #[test]
-    fn a_bare_name_resolves_to_the_first_directory_holding_it() {
-        let (_dir, path, bin) = path_containing("Xvfb");
-        assert_eq!(resolve_bin("Xvfb", Some(&path)), Some(bin));
-    }
-
-    #[test]
-    fn a_bare_name_absent_from_the_path_resolves_to_nothing() {
-        let (_dir, path, _bin) = path_containing("Xvfb");
-        assert_eq!(resolve_bin("Xorg", Some(&path)), None);
-    }
-
-    #[test]
-    fn an_explicit_path_is_taken_as_given_and_must_exist() {
-        let (_dir, _path, bin) = path_containing("Xvfb");
-        // A configured GLASS_XVFB is a path, not a name to search for — resolving it
-        // through the search list would silently run a different binary.
-        assert_eq!(resolve_bin(bin.to_str().unwrap(), None), Some(bin.clone()));
-        assert_eq!(resolve_bin("/nonexistent/Xvfb", None), None);
-    }
-
-    #[test]
-    fn a_bare_name_with_no_search_list_resolves_to_nothing() {
-        assert_eq!(resolve_bin("Xvfb", None), None);
     }
 
     #[test]
@@ -309,11 +260,34 @@ mod tests {
         );
     }
 
+    /// glass#374: `GLASS_XVFB` pointing at a file without the execute bit used to report `Ok`,
+    /// and `Xvfb::start` then failed with EACCES — the one outcome doctor exists to prevent.
+    /// "not found" would be wrong too: the file is there, so installing xvfb again cannot help.
+    #[test]
+    fn a_non_executable_xvfb_fails_with_a_chmod_remedy() {
+        let p = PathBuf::from("/opt/x/Xvfb");
+        let cs = x11_checks(None, &Resolved::NotExecutable(p), None, None);
+        let xvfb = cs.iter().find(|c| c.name == "Xvfb").expect("an Xvfb check");
+        assert_eq!(xvfb.status, CheckStatus::Fail);
+        assert!(
+            xvfb.detail.contains("/opt/x/Xvfb") && xvfb.detail.contains("not executable"),
+            "must name the file and say why: {:?}",
+            xvfb.detail
+        );
+        assert!(
+            xvfb.remedy
+                .as_deref()
+                .is_some_and(|r| r.contains("chmod +x")),
+            "the remedy is chmod, not a reinstall: {:?}",
+            xvfb.remedy
+        );
+    }
+
     #[test]
     fn deep_spawn_failure_is_reported() {
         let cs = x11_checks(
             None,
-            Some(Path::new("/usr/bin/Xvfb")),
+            &Resolved::Found(PathBuf::from("/usr/bin/Xvfb")),
             None,
             Some(Err("boom".into())),
         );


### PR DESCRIPTION
Five places resolved an external tool with `Path::is_file()` and treated the answer as "glass can run this". `is_file()` says nothing about whether the file can be executed, so a binary that is present but unrunnable was reported as healthy and the launch then failed anyway — the one outcome a preflight exists to prevent.

`GLASS_XVFB` pointing at a mode-644 file made `glass doctor` print `✓ Xvfb`, and `Xvfb::start` then failed with `EACCES`. Reporting `not found` for that input would be wrong too: the file is there, so "install xvfb" sends you to fix something that is not broken.

## What changed

A new `glass-exec-unix` crate answers *what will actually exec*, and `glass-sandbox-unix` keeps the bind-path helpers that answer *what host paths must be exposed*. Neither depends on the other. Resolution returns a three-state `Resolved { Found, NotExecutable, Absent }` so a caller can say which failure it hit, and implements `execvp`'s `$PATH` rule once: the first *executable* match wins, and the walk steps over entries that are missing or cannot be run.

The runnability test is the kernel's own (`faccessat` with `X_OK`), not an inspection of mode bits — a binary you are not permitted to execute is not runnable even when an execute bit is set for somebody else, and one on a `noexec` mount is not runnable at all.

Five sites now use it: the X11 doctor (`Xvfb`), the Linux sandbox probe (`bwrap`), the private accessibility bus preflight (`at-spi-bus-launcher`, `dbus-daemon`), the accessibility capability check, and Wayland compositor resolution (`sway`).

## What you will notice

- A tool that is present but not executable is named, and the remedy is `chmod +x`, not a reinstall.
- A tool that is genuinely missing keeps the install remedy it had.
- The `[a11y]` doctor check no longer counts a launcher it cannot spawn as present.
- Wayland reports a `sway` that is present but unrunnable as such, instead of telling you to build one you already built.
- A `sway` early on `$PATH` that cannot be run no longer stops the search; a good copy later on `$PATH` is used, as your shell would.
- The accessibility bus preflight now searches `$PATH` for `dbus-daemon` rather than only checking an explicitly configured path, so a host without it reports accessibility unavailable up front instead of failing during bring-up.
- A candidate that fails to *start* while glass is probing `$PATH` for a compositor no longer ends the
  search. Previously one failed spawn — a binary being replaced under you, a `sway` that is not a valid
  executable — made glass conclude there was no sway anywhere; now that candidate is skipped and the
  search continues. This is beyond the issue's scope, but the branch had left the function contradicting
  its own rule that a candidate which cannot be run is stepped over.

Fixes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)
