### PR TITLE
fix(clipboard): bound the transfers that wait on an arbitrary app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,8 @@ cargo build
 cargo test --workspace                    # needs nothing installed; anything wanting a
                                           # display or device is #[ignore]d
 cargo clippy --workspace --all-targets -- -D warnings   # lint gate — keep clean
-cargo test -p glass-x11 -- --include-ignored      # + its 73 Xvfb-backed unit tests
-cargo test -p glass-wayland -- --include-ignored  # + its 61 sway-backed unit tests
+cargo test -p glass-x11 -- --include-ignored      # + its 74 Xvfb-backed unit tests
+cargo test -p glass-wayland -- --include-ignored  # + its 64 sway-backed unit tests
 ./scripts/test-x11.sh [name]              # X11 integration suite (self-starts Xvfb)
 ./scripts/test-wayland.sh [name]          # Wayland suite (needs sway >=1.12)
 ./scripts/test-a11y.sh [name]             # AT-SPI suite

--- a/crates/glass-wayland/src/clipboard.rs
+++ b/crates/glass-wayland/src/clipboard.rs
@@ -676,11 +676,11 @@ impl ClipboardOwner {
             stop.store(true, Ordering::Relaxed);
             // Deliberately not joined: timing out means the thread hasn't reached the loop that
             // reads `stop`, so a join would wait on the wedged compositor with no bound.
-            // Detaching is self-cleaning in all three of the outcomes left to it: the setup fails
-            // and the thread exits; the setup finishes and the `stop` check `serve_loop` makes
-            // before `create_data_source` returns without ever taking the selection; or `stop`
-            // arrives after that check and the first pump iteration breaks out. Drop that check
-            // and this becomes a thread that unwedges later and steals a live owner's selection.
+            // Detaching is self-cleaning: the setup fails and the thread exits; the setup
+            // finishes and the `stop` check `serve_loop` makes before `create_data_source`
+            // returns without ever taking the selection; or `stop` arrives after that check and
+            // the first pump iteration breaks out. Drop that check and it can unwedge later and
+            // steal a live owner's selection.
             if handle.is_finished() && handle.join().is_err() {
                 // Finished without ever signalling: it panicked during setup. Reporting that as a
                 // timeout would send the reader looking for a slow compositor.

--- a/crates/glass-wayland/src/clipboard.rs
+++ b/crates/glass-wayland/src/clipboard.rs
@@ -11,7 +11,7 @@ use std::os::fd::{AsFd, OwnedFd};
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Condvar, Mutex, PoisonError};
 use std::time::{Duration, Instant};
 
 /// Cap on how long `get()` waits for the selection owner to finish writing the
@@ -608,16 +608,28 @@ impl ClipboardOwner {
         let (lock, cvar) = &*ready;
         let result = cvar
             .wait_timeout_while(
-                lock.lock().expect("clipboard ready mutex"),
+                lock.lock().unwrap_or_else(PoisonError::into_inner),
                 Duration::from_secs(2),
                 |s| matches!(s, ReadyState::Pending),
             )
-            .unwrap();
+            // A poisoned lock means the serving thread panicked holding it. The state behind it
+            // still says what happened; panicking here turns a reportable clipboard failure into
+            // a crashed tool call.
+            .unwrap_or_else(PoisonError::into_inner);
 
         if result.1.timed_out() {
-            // The thread is still running but didn't signal in time; stop it.
             stop.store(true, Ordering::Relaxed);
-            let _ = handle.join();
+            // Deliberately not joined. Timing out means the thread has not reached the loop that
+            // reads `stop`, so a join waits on the wedged compositor with no bound — the hang
+            // this 2 s bound exists to prevent. Detaching is self-cleaning: the setup either
+            // fails and the thread exits, or it completes and the first pump iteration stops.
+            if handle.is_finished() && handle.join().is_err() {
+                // Finished without ever signalling: it panicked during setup. Reporting that as a
+                // timeout would send the reader looking for a slow compositor.
+                return Err(GlassError::Backend(
+                    "clipboard set: owner thread panicked during setup".into(),
+                ));
+            }
             return Err(GlassError::Backend(
                 "clipboard set: timed out waiting for selection registration".into(),
             ));
@@ -666,7 +678,7 @@ impl Drop for ClipboardOwner {
 /// Signal the ready condvar. Helper to reduce repetition.
 fn signal_ready(ready: &Arc<(Mutex<ReadyState>, Condvar)>, state: ReadyState) {
     let (lock, cvar) = &**ready;
-    *lock.lock().expect("clipboard ready mutex") = state;
+    *lock.lock().unwrap_or_else(PoisonError::into_inner) = state;
     cvar.notify_one();
 }
 
@@ -917,6 +929,42 @@ mod tests {
             Err(e) => e,
         };
         assert!(matches!(err, GlassError::Backend(_)), "{err}");
+    }
+
+    /// A compositor that accepts the connection and then never answers is what the 2 s readiness
+    /// bound is for. Joining the setup thread there waits on the wedged peer with no bound at
+    /// all, so spawn has to return without it — every tool call is behind the session lock this
+    /// holds.
+    #[test]
+    fn an_owner_gives_up_on_a_peer_that_accepts_and_never_answers() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket = dir.path().join("wayland-silent");
+        let listener = std::os::unix::net::UnixListener::bind(&socket).expect("bind");
+        let accepted = std::thread::spawn(move || listener.accept().map(|(s, _)| s));
+
+        // On its own thread: pre-fix this call never returns, and a direct call would wedge the
+        // whole suite instead of failing this test.
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let outcome = ClipboardOwner::spawn(socket, "text".into())
+                .err()
+                .map(|e| e.to_string());
+            let _ = tx.send(outcome);
+        });
+
+        let outcome = rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("spawn must return when its own 2 s bound expires, not wait on the peer");
+        let msg = outcome.expect("a peer that never answers is not a served clipboard");
+        assert!(msg.contains("timed out"), "{msg}");
+
+        // Closing the server side lets the detached setup thread fail and exit.
+        drop(
+            accepted
+                .join()
+                .expect("accept thread")
+                .expect("accepted stream"),
+        );
     }
 
     /// A signal arriving mid-read costs nothing and the read resumes. Every other failure is a

--- a/crates/glass-wayland/src/clipboard.rs
+++ b/crates/glass-wayland/src/clipboard.rs
@@ -846,8 +846,8 @@ fn serve_loop(
 #[cfg(test)]
 mod tests {
     use super::{
-        CLIP_READ_TIMEOUT, CLIP_WRITE_TIMEOUT, ClipboardOwner, get, is_retryable,
-        read_to_eof_bounded, write_all_bounded,
+        CLIP_READ_TIMEOUT, CLIP_WRITE_TIMEOUT, ClipboardOwner, ReadyState, get, is_retryable,
+        read_to_eof_bounded, serve_loop, write_all_bounded,
     };
     use crate::testw::Launch;
     use glass_core::GlassError;
@@ -930,6 +930,34 @@ mod tests {
         assert_eq!(get(&socket).expect("get"), "");
     }
 
+    /// A detached setup thread that unwedges after `spawn` already gave up is in exactly this
+    /// state: still running, with `stop` already true. Calling `serve_loop` directly with `stop`
+    /// pre-set reproduces it without needing a compositor that actually stalls — it must stand
+    /// down before `set_selection`, not take the selection from whatever owner is now live.
+    #[test]
+    #[ignore = "starts a real compositor or X server; needs sway, Mesa, Xwayland or Xvfb"]
+    fn a_stopped_serve_loop_does_not_take_the_selection_from_a_live_owner() {
+        let s = Launch::new().start();
+        let socket = s.wayland_socket();
+        let live = ClipboardOwner::spawn(socket.clone(), "mine".into()).expect("spawn");
+        assert_eq!(get(&socket).expect("get"), "mine");
+
+        let text = std::sync::Arc::new(std::sync::Mutex::new("stolen".to_string()));
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let ready = std::sync::Arc::new((
+            std::sync::Mutex::new(ReadyState::Pending),
+            std::sync::Condvar::new(),
+        ));
+        serve_loop(socket.clone(), text, stop, ready)
+            .expect("a detached thread standing down is not a serve error");
+
+        assert!(
+            live.is_alive(),
+            "the live owner must still be serving after a detached thread stands down"
+        );
+        assert_eq!(get(&socket).expect("get"), "mine");
+    }
+
     /// A compositor that is gone cannot be served. Reporting success would leave the caller
     /// believing the clipboard holds text no app can ever read.
     #[test]
@@ -968,11 +996,17 @@ mod tests {
             .recv_timeout(Duration::from_secs(10))
             .expect("spawn must return when its own 2 s bound expires, not wait on the peer");
         // Ties the test to the 2 s bound itself, not just to the 10 s ceiling above: a bound
-        // loosened to e.g. 9 s would still return before the ceiling but fail this.
+        // loosened to e.g. 9 s would still return before the ceiling but fail this, and a bound
+        // shrunk to ~0 (which would also pass the ceiling and still contain "timed out") fails
+        // the lower check below.
+        let elapsed = started.elapsed();
         assert!(
-            started.elapsed() < Duration::from_secs(5),
-            "spawn took {:?}, expected it to give up near its own 2 s bound",
-            started.elapsed()
+            elapsed < Duration::from_secs(5),
+            "spawn took {elapsed:?}, expected it to give up near its own 2 s bound"
+        );
+        assert!(
+            elapsed >= Duration::from_secs(1),
+            "spawn took only {elapsed:?}, expected it to wait close to its own 2 s bound"
         );
         let msg = outcome.expect("a peer that never answers is not a served clipboard");
         assert!(msg.contains("timed out"), "{msg}");

--- a/crates/glass-wayland/src/clipboard.rs
+++ b/crates/glass-wayland/src/clipboard.rs
@@ -202,6 +202,8 @@ struct ServeState {
     output: OutputState,
     shm: Shm,
     /// The shared text to serve on `Send` events.
+    // `expect`, not the readiness lock's `PoisonError::into_inner`: this one is off the readiness
+    // path and its two holders only clone the string or assign to it, so nothing under it panics.
     text: Arc<Mutex<String>>,
     /// The owner's stop flag, so a `Send` arriving after the owner was dropped is not served.
     stop: Arc<AtomicBool>,
@@ -571,6 +573,7 @@ fn write_all_bounded(fd: OwnedFd, buf: &[u8], timeout: Duration) -> Result<()> {
 /// clipboard text to any app that requests a paste. Mirrors the X11
 /// `ClipboardOwner` pattern.
 pub struct ClipboardOwner {
+    // See [`ServeState::text`] for why this lock keeps `expect` where the readiness lock does not.
     text: Arc<Mutex<String>>,
     stop: Arc<AtomicBool>,
     handle: Option<std::thread::JoinHandle<()>>,
@@ -581,6 +584,21 @@ enum ReadyState {
     Pending,
     Ok,
     Err(String),
+}
+
+/// Recover a poisoned readiness lock instead of propagating the panic, and say so.
+///
+/// The state behind the lock still says what happened, so panicking here would turn a reportable
+/// clipboard failure into a crashed tool call — but recovering in silence leaves the serving thread
+/// that panicked invisible.
+fn recover_readiness<T>(what: &str, r: std::result::Result<T, PoisonError<T>>) -> T {
+    match r {
+        Ok(v) => v,
+        Err(poisoned) => {
+            eprintln!("glass-wayland: clipboard {what}: a thread panicked holding this lock");
+            poisoned.into_inner()
+        }
+    }
 }
 
 impl ClipboardOwner {
@@ -614,28 +632,35 @@ impl ClipboardOwner {
         // Block until the thread signals that it has called set_selection +
         // roundtripped (or encountered an error), with a 2 s timeout.
         let (lock, cvar) = &*ready;
-        let result = cvar
-            .wait_timeout_while(
-                lock.lock().unwrap_or_else(PoisonError::into_inner),
+        let result = recover_readiness(
+            "set: readiness wait",
+            cvar.wait_timeout_while(
+                recover_readiness("set: readiness lock", lock.lock()),
                 Duration::from_secs(2),
                 |s| matches!(s, ReadyState::Pending),
-            )
-            // A poisoned lock means the serving thread panicked holding it. The state behind it
-            // still says what happened; panicking here turns a reportable clipboard failure into
-            // a crashed tool call.
-            .unwrap_or_else(PoisonError::into_inner);
+            ),
+        );
 
         let timed_out = result.1.timed_out();
+        // Copy the outcome out and release the ready lock before either path below touches
+        // `handle`: a signal_ready reachable from a thread-exit path would otherwise deadlock the
+        // join.
+        let failure = match &*result.0 {
+            ReadyState::Err(msg) => Some(msg.clone()),
+            // Unreachable: the wait only returns without timing out once the predicate is false.
+            ReadyState::Ok | ReadyState::Pending => None,
+        };
+        drop(result);
 
         if timed_out {
-            // Release the ready lock before touching `handle`: a future signal_ready reachable
-            // from a thread-exit path would otherwise deadlock the join below on this thread.
-            drop(result);
             stop.store(true, Ordering::Relaxed);
             // Deliberately not joined: timing out means the thread hasn't reached the loop that
             // reads `stop`, so a join would wait on the wedged compositor with no bound.
-            // Detaching is self-cleaning — the setup either fails and the thread exits, or it
-            // completes and the first pump iteration stops.
+            // Detaching is self-cleaning in all three of the outcomes left to it: the setup fails
+            // and the thread exits; the setup finishes and the `stop` check `serve_loop` makes
+            // before `create_data_source` returns without ever taking the selection; or `stop`
+            // arrives after that check and the first pump iteration breaks out. Drop that check
+            // and this becomes a thread that unwedges later and steals a live owner's selection.
             if handle.is_finished() && handle.join().is_err() {
                 // Finished without ever signalling: it panicked during setup. Reporting that as a
                 // timeout would send the reader looking for a slow compositor.
@@ -648,14 +673,10 @@ impl ClipboardOwner {
             ));
         }
 
-        match &*result.0 {
-            ReadyState::Ok | ReadyState::Pending /* unreachable but safe */ => {}
-            ReadyState::Err(msg) => {
-                let _ = handle.join();
-                return Err(GlassError::Backend(format!("clipboard set: {msg}")));
-            }
+        if let Some(msg) = failure {
+            let _ = handle.join();
+            return Err(GlassError::Backend(format!("clipboard set: {msg}")));
         }
-        drop(result);
 
         Ok(Self {
             text,
@@ -691,7 +712,7 @@ impl Drop for ClipboardOwner {
 /// Signal the ready condvar. Helper to reduce repetition.
 fn signal_ready(ready: &Arc<(Mutex<ReadyState>, Condvar)>, state: ReadyState) {
     let (lock, cvar) = &**ready;
-    *lock.lock().unwrap_or_else(PoisonError::into_inner) = state;
+    *recover_readiness("serve: readiness signal", lock.lock()) = state;
     cvar.notify_one();
 }
 
@@ -748,7 +769,8 @@ fn serve_loop(
     })?;
 
     // A detached thread (spawn already timed out and returned to the caller) must not take a
-    // selection the caller has already been told it failed to get.
+    // selection the caller has already been told it failed to get. `spawn`'s detach comment counts on this
+    // check.
     if stop.load(Ordering::Relaxed) {
         return Ok(());
     }
@@ -855,8 +877,9 @@ fn serve_loop(
 #[cfg(test)]
 mod tests {
     use super::{
-        CLIP_READ_TIMEOUT, CLIP_WRITE_TIMEOUT, ClipboardOwner, ReadyState, get, is_retryable,
-        read_to_eof_bounded, serve_loop, write_all_bounded,
+        Arc, CLIP_READ_TIMEOUT, CLIP_WRITE_TIMEOUT, ClipboardOwner, Condvar, Mutex, PoisonError,
+        ReadyState, get, is_retryable, read_to_eof_bounded, serve_loop, signal_ready,
+        write_all_bounded,
     };
     use crate::testw::Launch;
     use glass_core::GlassError;
@@ -1043,6 +1066,33 @@ mod tests {
                 .join()
                 .expect("accept thread")
                 .expect("accepted stream"),
+        );
+    }
+
+    /// A serving thread that panics holding the readiness lock poisons it. The readiness path has
+    /// to keep working through that: propagating the poison instead turns a clipboard failure the
+    /// caller could report into a second panic in the caller.
+    #[test]
+    fn a_poisoned_readiness_lock_is_recovered_rather_than_propagated() {
+        let ready = Arc::new((Mutex::new(ReadyState::Pending), Condvar::new()));
+        let poisoner = Arc::clone(&ready);
+        let panicked = std::thread::spawn(move || {
+            let _held = poisoner.0.lock().expect("lock");
+            // The panic message below is the test working, not the test failing.
+            panic!("a serving thread panicking with the readiness lock held");
+        })
+        .join();
+        assert!(panicked.is_err(), "the thread was supposed to panic");
+        assert!(
+            ready.0.is_poisoned(),
+            "a panic under the lock is what poisons it; without that this test proves nothing"
+        );
+
+        signal_ready(&ready, ReadyState::Ok);
+        let state = ready.0.lock().unwrap_or_else(PoisonError::into_inner);
+        assert!(
+            matches!(*state, ReadyState::Ok),
+            "signalling through a poisoned lock must still land the state"
         );
     }
 

--- a/crates/glass-wayland/src/clipboard.rs
+++ b/crates/glass-wayland/src/clipboard.rs
@@ -948,8 +948,25 @@ mod tests {
             std::sync::Mutex::new(ReadyState::Pending),
             std::sync::Condvar::new(),
         ));
-        serve_loop(socket.clone(), text, stop, ready)
-            .expect("a detached thread standing down is not a serve error");
+
+        // On its own thread: a compositor stalled in the setup roundtrip (or, on an ablated
+        // build, the trailing one after set_selection) would otherwise hang this call forever,
+        // and a direct call would wedge the whole suite instead of failing this test.
+        let (tx, rx) = std::sync::mpsc::channel();
+        let socket_thread = socket.clone();
+        std::thread::spawn(move || {
+            let outcome = serve_loop(socket_thread, text, stop, ready)
+                .err()
+                .map(|e| e.to_string());
+            let _ = tx.send(outcome);
+        });
+
+        let outcome = rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("a stalled compositor must fail this test, not hang the whole suite");
+        if let Some(msg) = outcome {
+            panic!("a detached thread standing down is not a serve error: {msg}");
+        }
 
         assert!(
             live.is_alive(),

--- a/crates/glass-wayland/src/clipboard.rs
+++ b/crates/glass-wayland/src/clipboard.rs
@@ -469,6 +469,92 @@ fn read_to_eof_bounded(fd: OwnedFd, timeout: Duration) -> Result<Vec<u8>> {
     }
 }
 
+/// Cap on how long the serving thread spends handing one paste to a requesting app. Its own
+/// constant rather than a reuse of [`CLIP_READ_TIMEOUT`]: that bounds an app glass reads from,
+/// this bounds an app glass writes to, and moving one should not move the other.
+// The `Send` handler wiring lands separately; until then only the tests below call this.
+#[cfg_attr(not(test), allow(dead_code))]
+const CLIP_WRITE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Whether a failed write should be retried — nothing was lost and the pipe may take more. A
+/// signal arrived (`Interrupted`), or the pipe filled between the poll and the write
+/// (`WouldBlock`, which non-blocking mode reports instead of parking). `WouldBlock` is retryable
+/// here and not in [`is_retryable`] for exactly that reason: only this side sets `O_NONBLOCK`.
+#[cfg_attr(not(test), allow(dead_code))]
+fn is_write_retryable(e: &std::io::Error) -> bool {
+    matches!(
+        e.kind(),
+        std::io::ErrorKind::Interrupted | std::io::ErrorKind::WouldBlock
+    )
+}
+
+/// Write `buf` to `fd`, but give up after `timeout`. The mirror of [`read_to_eof_bounded`] on the
+/// serving side: the receiver is an arbitrary external app, and one that opens the transfer but
+/// never reads blocks this write as soon as `buf` passes the pipe buffer (64 KiB by default).
+/// That block lands on the owner thread inside `dispatch_pending`, so its loop never reaches the
+/// stop check — and `ClipboardOwner::drop` joins a thread that can no longer return.
+///
+/// The fd is made non-blocking first. `POLLOUT` promises only that one byte fits, while a
+/// blocking `write` of more than `PIPE_BUF` waits for the whole payload: polling a blocking fd
+/// would leave the same unbounded wait one syscall further down.
+#[cfg_attr(not(test), allow(dead_code))]
+fn write_all_bounded(fd: OwnedFd, buf: &[u8], timeout: Duration) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    let flags = rustix::fs::fcntl_getfl(&fd)
+        .map_err(|e| GlassError::Backend(format!("clipboard serve: fcntl_getfl: {e}")))?;
+    rustix::fs::fcntl_setfl(&fd, flags | rustix::fs::OFlags::NONBLOCK)
+        .map_err(|e| GlassError::Backend(format!("clipboard serve: fcntl_setfl: {e}")))?;
+
+    let mut file = std::fs::File::from(fd);
+    let total = buf.len();
+    let mut written = 0usize;
+    while written < total {
+        let now = Instant::now();
+        if now >= deadline {
+            return Err(GlassError::Timeout(timeout.as_millis() as u64));
+        }
+        let remaining = deadline - now;
+        let ts = rustix::event::Timespec {
+            tv_sec: remaining.as_secs() as i64,
+            tv_nsec: remaining.subsec_nanos() as i64,
+        };
+        // The PollFd borrows `file` only for this statement, freeing it before the write below.
+        let ready = rustix::event::poll(
+            &mut [rustix::event::PollFd::new(
+                &file,
+                rustix::event::PollFlags::OUT,
+            )],
+            Some(&ts),
+        );
+        match ready {
+            Ok(0) => return Err(GlassError::Timeout(timeout.as_millis() as u64)),
+            Ok(_) => match file.write(&buf[written..]) {
+                Ok(0) => {
+                    return Err(GlassError::Backend(format!(
+                        "clipboard serve: paste transfer stalled at {written} of {total} bytes"
+                    )));
+                }
+                Ok(n) => written += n,
+                Err(e) if is_write_retryable(&e) => continue,
+                Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {
+                    return Err(GlassError::Backend(format!(
+                        "clipboard serve: paste receiver closed the transfer after {written} of {total} bytes"
+                    )));
+                }
+                Err(e) => {
+                    return Err(GlassError::Backend(format!(
+                        "clipboard serve: write pipe: {e} after {written} of {total} bytes"
+                    )));
+                }
+            },
+            // The poll's half of the rule `is_write_retryable` names for the write.
+            Err(rustix::io::Errno::INTR) => continue,
+            Err(e) => return Err(GlassError::Backend(format!("clipboard serve: poll: {e}"))),
+        }
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // `ClipboardOwner` — serving thread for `set`
 // ---------------------------------------------------------------------------
@@ -736,7 +822,10 @@ fn serve_loop(
 
 #[cfg(test)]
 mod tests {
-    use super::{CLIP_READ_TIMEOUT, ClipboardOwner, get, is_retryable, read_to_eof_bounded};
+    use super::{
+        CLIP_READ_TIMEOUT, CLIP_WRITE_TIMEOUT, ClipboardOwner, get, is_retryable,
+        read_to_eof_bounded, write_all_bounded,
+    };
     use crate::testw::Launch;
     use glass_core::GlassError;
     use std::io::Write;
@@ -887,5 +976,55 @@ mod tests {
         // No text representation offered -> None (get short-circuits to an empty string).
         assert_eq!(pick_mime(&list(&["image/png", "text/html"])), None);
         assert_eq!(pick_mime(&[]), None);
+    }
+
+    /// A payload past the pipe buffer cannot be handed over in one `write`. An implementation
+    /// that writes once and trusts the count truncates the paste, and the app pasting has no way
+    /// to tell a short clipboard from a short write.
+    #[test]
+    fn a_bounded_write_delivers_a_payload_larger_than_the_pipe_buffer() {
+        use std::io::Read as _;
+        let (read_end, write_end) = rustix::pipe::pipe().expect("pipe");
+        // 256 KiB — four times the default 64 KiB pipe buffer.
+        let payload = vec![b'x'; 256 * 1024];
+        let reader = std::thread::spawn(move || {
+            let mut got = Vec::new();
+            std::fs::File::from(read_end)
+                .read_to_end(&mut got)
+                .expect("read");
+            got
+        });
+        write_all_bounded(write_end, &payload, Duration::from_secs(10)).expect("write ok");
+        let got = reader.join().expect("reader thread");
+        assert_eq!(got.len(), payload.len(), "every byte reaches the reader");
+        assert!(got == payload, "the bytes that arrive are the bytes sent");
+    }
+
+    /// An app that requests a paste and then stops reading is the case this bound exists for:
+    /// the write blocks once the pipe fills, on the thread whose loop honours the stop flag.
+    #[test]
+    fn a_bounded_write_times_out_when_the_reader_never_reads() {
+        let (read_end, write_end) = rustix::pipe::pipe().expect("pipe");
+        let payload = vec![b'x'; 256 * 1024];
+        let r = write_all_bounded(write_end, &payload, Duration::from_millis(200));
+        assert!(
+            matches!(r, Err(GlassError::Timeout(_))),
+            "expected Timeout, got {r:?}"
+        );
+        // read_end stays alive until here: a closed one would fail as EPIPE, not as a timeout.
+        drop(read_end);
+    }
+
+    /// The common real failure: the app took what it wanted and closed the transfer. Silence here
+    /// leaves a truncated paste indistinguishable from an empty clipboard.
+    #[test]
+    fn a_bounded_write_reports_a_receiver_that_closed_the_transfer() {
+        let (read_end, write_end) = rustix::pipe::pipe().expect("pipe");
+        drop(read_end);
+        let err = write_all_bounded(write_end, b"clip!", CLIP_WRITE_TIMEOUT)
+            .expect_err("a closed receiver is not a delivered paste");
+        let msg = err.to_string();
+        assert!(msg.contains("closed the transfer"), "{msg}");
+        assert!(msg.contains("0 of 5 bytes"), "{msg}");
     }
 }

--- a/crates/glass-wayland/src/clipboard.rs
+++ b/crates/glass-wayland/src/clipboard.rs
@@ -348,6 +348,21 @@ impl Dispatch<ZwlrDataControlSourceV1, ()> for ServeState {
 /// event queue, does a roundtrip to collect the selection offer, then reads the
 /// pipe transfer.
 pub fn get(socket: &Path) -> Result<String> {
+    let Some(read_end) = open_transfer(socket)? else {
+        return Ok(String::new());
+    };
+    // Read to EOF from the read end, bounded by a deadline so a misbehaving
+    // selection owner can't hang us forever (see CLIP_READ_TIMEOUT).
+    let buf = read_to_eof_bounded(read_end, CLIP_READ_TIMEOUT)?;
+    Ok(String::from_utf8_lossy(&buf).into_owned())
+}
+
+/// Ask the selection owner for a text transfer and return the pipe's read end, or `None` when
+/// there is nothing to read — no selection, or no text MIME on offer.
+///
+/// Once this returns the owner is writing, whether or not anybody reads: [`get`] is this plus the
+/// bounded read, and a test that wants the owner stuck mid-write is this without it.
+fn open_transfer(socket: &Path) -> Result<Option<OwnedFd>> {
     let stream = UnixStream::connect(socket)
         .map_err(|e| GlassError::Backend(format!("clipboard get: connect: {e}")))?;
     let conn = Connection::from_socket(stream)
@@ -389,14 +404,14 @@ pub fn get(socket: &Path) -> Result<String> {
 
     let (offer, mimes) = match state.selection.take() {
         Some(v) => v,
-        None => return Ok(String::new()), // no clipboard content
+        None => return Ok(None), // no clipboard content
     };
 
     let mime = match pick_mime(&mimes) {
         Some(m) => m.to_string(),
         None => {
             offer.destroy();
-            return Ok(String::new()); // no text MIME offered
+            return Ok(None); // no text MIME offered
         }
     };
 
@@ -418,13 +433,11 @@ pub fn get(socket: &Path) -> Result<String> {
         .roundtrip(&mut state)
         .map_err(|e| GlassError::Backend(format!("clipboard get: roundtrip3: {e}")))?;
 
-    // Read to EOF from the read end, bounded by a deadline so a misbehaving
-    // selection owner can't hang us forever (see CLIP_READ_TIMEOUT).
-    let buf = read_to_eof_bounded(read_end, CLIP_READ_TIMEOUT)?;
-
+    // The fd is already with the owner, so destroying the offer and dropping `conn` here cannot
+    // cut the read short.
     offer.destroy();
 
-    Ok(String::from_utf8_lossy(&buf).into_owned())
+    Ok(Some(read_end))
 }
 
 /// Whether a failed read should be retried — a signal arrived and nothing was lost. Retrying
@@ -885,8 +898,8 @@ fn serve_loop(
 mod tests {
     use super::{
         Arc, AtomicBool, CLIP_READ_TIMEOUT, CLIP_WRITE_TIMEOUT, ClipboardOwner, Condvar, Mutex,
-        PoisonError, ReadyState, get, is_retryable, read_to_eof_bounded, serve_loop, signal_ready,
-        write_all_bounded,
+        PoisonError, ReadyState, get, is_retryable, open_transfer, read_to_eof_bounded, serve_loop,
+        signal_ready, write_all_bounded,
     };
     use crate::testw::Launch;
     use glass_core::GlassError;
@@ -966,6 +979,47 @@ mod tests {
             "dropping an owner must stop its thread, not wait on it forever",
             move || drop(owner),
         );
+    }
+
+    /// An app that opens a paste and then stops reading is what the write bound exists for: the
+    /// transfer blocks once the pipe fills, on the serving thread, which is also the thread `Drop`
+    /// joins. Unbounded, that join never returns and takes session teardown with it.
+    #[test]
+    #[ignore = "starts a real compositor or X server; needs sway, Mesa, Xwayland or Xvfb"]
+    fn an_owner_stays_droppable_while_a_paste_is_going_unread() {
+        let s = Launch::new().start();
+        let socket = s.wayland_socket();
+        // Four times the default 64 KiB pipe buffer: a payload that fits is handed over in one
+        // write that never blocks, so a smaller one would pass with no bound at all.
+        let owner = ClipboardOwner::spawn(socket.clone(), "x".repeat(256 * 1024)).expect("spawn");
+
+        let transfer = open_transfer(&socket)
+            .expect("open a transfer")
+            .expect("a live owner offers text to transfer");
+        // Wait for the first bytes: they are what says the serving thread is past its stop check
+        // and inside the write. Nothing is read off the pipe, so it stays full and the write
+        // stays blocked.
+        let ready = rustix::event::poll(
+            &mut [rustix::event::PollFd::new(
+                &transfer,
+                rustix::event::PollFlags::IN,
+            )],
+            Some(&rustix::event::Timespec {
+                tv_sec: 10,
+                tv_nsec: 0,
+            }),
+        )
+        .expect("poll the transfer");
+        assert!(ready > 0, "the owner never started writing the paste");
+
+        on_a_thread(
+            Duration::from_secs(15),
+            "dropping an owner must not wait out a paste nobody is reading",
+            move || drop(owner),
+        );
+        // Held until here: closing the read end early fails the write as EPIPE, which would let
+        // even an unbounded write return.
+        drop(transfer);
     }
 
     /// Dropping gives up the selection. A thread that kept running would keep answering pastes

--- a/crates/glass-wayland/src/clipboard.rs
+++ b/crates/glass-wayland/src/clipboard.rs
@@ -203,6 +203,8 @@ struct ServeState {
     shm: Shm,
     /// The shared text to serve on `Send` events.
     text: Arc<Mutex<String>>,
+    /// The owner's stop flag, so a `Send` arriving after the owner was dropped is not served.
+    stop: Arc<AtomicBool>,
     /// Set to true when the source is `Cancelled`.
     cancelled: bool,
 }
@@ -310,12 +312,19 @@ impl Dispatch<ZwlrDataControlSourceV1, ()> for ServeState {
     ) {
         match event {
             zwlr_data_control_source_v1::Event::Send { mime_type: _, fd } => {
-                // Cloned out before the write — holding the mutex across it would queue set_text
-                // and every later paste behind one slow reader for up to CLIP_WRITE_TIMEOUT.
+                // `dispatch_pending` runs every queued event before returning and the loop's stop
+                // check is after it, so without this a drop waits out CLIP_WRITE_TIMEOUT per queued
+                // paste. Dropping `fd` unwritten gives the requester a clean EOF.
+                if state.stop.load(Ordering::Relaxed) {
+                    return;
+                }
+                // Cloned out before the write: `set_text` runs on another thread and would block on
+                // the mutex for up to CLIP_WRITE_TIMEOUT. Later pastes gain nothing — they are
+                // dispatched in series on this thread either way.
                 let text = state.text.lock().expect("clipboard text mutex").clone();
-                // Failures are printed, not returned — a Dispatch callback has nowhere to return
-                // them, and printing is what makes a truncated paste distinguishable from an
-                // empty clipboard.
+                // Printed, not returned: a Dispatch callback has nowhere to return an error. Only
+                // stderr records it — the requesting app sees a transfer that ended, with no
+                // in-band way to tell a short paste from a short clipboard.
                 if let Err(e) = write_all_bounded(fd, text.as_bytes(), CLIP_WRITE_TIMEOUT) {
                     eprintln!("glass-wayland: clipboard serve: paste transfer: {e}");
                 }
@@ -722,6 +731,7 @@ fn serve_loop(
         output: OutputState::new(&globals, &qh),
         shm,
         text,
+        stop: Arc::clone(&stop),
         cancelled: false,
     };
 

--- a/crates/glass-wayland/src/clipboard.rs
+++ b/crates/glass-wayland/src/clipboard.rs
@@ -310,12 +310,16 @@ impl Dispatch<ZwlrDataControlSourceV1, ()> for ServeState {
     ) {
         match event {
             zwlr_data_control_source_v1::Event::Send { mime_type: _, fd } => {
-                // Write the current text to the fd and close it.
+                // Cloned out before the write, not held across it: the write can take up to
+                // CLIP_WRITE_TIMEOUT, and holding the mutex would queue set_text and every later
+                // paste behind one slow reader.
                 let text = state.text.lock().expect("clipboard text mutex").clone();
-                // fd is OwnedFd; wrap in File and write (file closes on drop).
-                let mut file = std::fs::File::from(fd);
-                let _ = file.write_all(text.as_bytes());
-                // file drops here, closing the write end.
+                // Failures are printed, not returned: a Dispatch impl has nowhere to return to,
+                // and the paste happens long after set_clipboard answered its caller. Printing is
+                // what makes a truncated paste distinguishable from an empty clipboard.
+                if let Err(e) = write_all_bounded(fd, text.as_bytes(), CLIP_WRITE_TIMEOUT) {
+                    eprintln!("glass-wayland: clipboard serve: paste transfer: {e}");
+                }
             }
             zwlr_data_control_source_v1::Event::Cancelled => {
                 state.cancelled = true;
@@ -472,15 +476,12 @@ fn read_to_eof_bounded(fd: OwnedFd, timeout: Duration) -> Result<Vec<u8>> {
 /// Cap on how long the serving thread spends handing one paste to a requesting app. Its own
 /// constant rather than a reuse of [`CLIP_READ_TIMEOUT`]: that bounds an app glass reads from,
 /// this bounds an app glass writes to, and moving one should not move the other.
-// The `Send` handler wiring lands separately; until then only the tests below call this.
-#[cfg_attr(not(test), allow(dead_code))]
 const CLIP_WRITE_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Whether a failed write should be retried — nothing was lost and the pipe may take more. A
 /// signal arrived (`Interrupted`), or the pipe filled between the poll and the write
 /// (`WouldBlock`, which non-blocking mode reports instead of parking). `WouldBlock` is retryable
 /// here and not in [`is_retryable`] for exactly that reason: only this side sets `O_NONBLOCK`.
-#[cfg_attr(not(test), allow(dead_code))]
 fn is_write_retryable(e: &std::io::Error) -> bool {
     matches!(
         e.kind(),
@@ -497,7 +498,6 @@ fn is_write_retryable(e: &std::io::Error) -> bool {
 /// The fd is made non-blocking first. `POLLOUT` promises only that one byte fits, while a
 /// blocking `write` of more than `PIPE_BUF` waits for the whole payload: polling a blocking fd
 /// would leave the same unbounded wait one syscall further down.
-#[cfg_attr(not(test), allow(dead_code))]
 fn write_all_bounded(fd: OwnedFd, buf: &[u8], timeout: Duration) -> Result<()> {
     let deadline = Instant::now() + timeout;
     let flags = rustix::fs::fcntl_getfl(&fd)
@@ -976,6 +976,18 @@ mod tests {
         // No text representation offered -> None (get short-circuits to an empty string).
         assert_eq!(pick_mime(&list(&["image/png", "text/html"])), None);
         assert_eq!(pick_mime(&[]), None);
+    }
+
+    /// A paste bigger than the pipe buffer is handed over in several writes. The transfer has to
+    /// survive that: a truncated one reaches the pasting app as silently-short text.
+    #[test]
+    #[ignore = "starts a real compositor or X server; needs sway, Mesa, Xwayland or Xvfb"]
+    fn a_paste_larger_than_the_pipe_buffer_arrives_whole() {
+        let s = Launch::new().start();
+        let socket = s.wayland_socket();
+        let big = "x".repeat(128 * 1024);
+        let _owner = ClipboardOwner::spawn(socket.clone(), big.clone()).expect("spawn");
+        assert_eq!(get(&socket).expect("get"), big);
     }
 
     /// A payload past the pipe buffer cannot be handed over in one `write`. An implementation

--- a/crates/glass-wayland/src/clipboard.rs
+++ b/crates/glass-wayland/src/clipboard.rs
@@ -617,7 +617,12 @@ impl ClipboardOwner {
             // a crashed tool call.
             .unwrap_or_else(PoisonError::into_inner);
 
-        if result.1.timed_out() {
+        let timed_out = result.1.timed_out();
+
+        if timed_out {
+            // Release the ready lock before touching `handle`: a future signal_ready reachable
+            // from a thread-exit path would otherwise deadlock the join below on this thread.
+            drop(result);
             stop.store(true, Ordering::Relaxed);
             // Deliberately not joined. Timing out means the thread has not reached the loop that
             // reads `stop`, so a join waits on the wedged compositor with no bound — the hang
@@ -732,6 +737,12 @@ fn serve_loop(
         signal_ready(&ready, ReadyState::Err(msg.clone()));
         GlassError::Backend(format!("clipboard serve: {msg}"))
     })?;
+
+    // A detached thread (spawn already timed out and returned to the caller) must not take a
+    // selection the caller has already been told it failed to get.
+    if stop.load(Ordering::Relaxed) {
+        return Ok(());
+    }
 
     let source = manager.create_data_source(&qh, ());
     source.offer(MIME_UTF8.to_string());
@@ -945,6 +956,7 @@ mod tests {
         // On its own thread: pre-fix this call never returns, and a direct call would wedge the
         // whole suite instead of failing this test.
         let (tx, rx) = std::sync::mpsc::channel();
+        let started = std::time::Instant::now();
         std::thread::spawn(move || {
             let outcome = ClipboardOwner::spawn(socket, "text".into())
                 .err()
@@ -955,6 +967,13 @@ mod tests {
         let outcome = rx
             .recv_timeout(Duration::from_secs(10))
             .expect("spawn must return when its own 2 s bound expires, not wait on the peer");
+        // Ties the test to the 2 s bound itself, not just to the 10 s ceiling above: a bound
+        // loosened to e.g. 9 s would still return before the ceiling but fail this.
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "spawn took {:?}, expected it to give up near its own 2 s bound",
+            started.elapsed()
+        );
         let msg = outcome.expect("a peer that never answers is not a served clipboard");
         assert!(msg.contains("timed out"), "{msg}");
 

--- a/crates/glass-wayland/src/clipboard.rs
+++ b/crates/glass-wayland/src/clipboard.rs
@@ -360,8 +360,9 @@ pub fn get(socket: &Path) -> Result<String> {
 /// Ask the selection owner for a text transfer and return the pipe's read end, or `None` when
 /// there is nothing to read — no selection, or no text MIME on offer.
 ///
-/// Once this returns the owner is writing, whether or not anybody reads: [`get`] is this plus the
-/// bounded read, and a test that wants the owner stuck mid-write is this without it.
+/// Returning means the transfer has been requested and the compositor has routed the fd, not that
+/// the owner has dispatched the `Send` yet: [`get`] is this plus the bounded read, and a test that
+/// wants the owner stuck mid-write is this plus a wait for the first bytes.
 fn open_transfer(socket: &Path) -> Result<Option<OwnedFd>> {
     let stream = UnixStream::connect(socket)
         .map_err(|e| GlassError::Backend(format!("clipboard get: connect: {e}")))?;
@@ -667,7 +668,8 @@ impl ClipboardOwner {
         // join.
         let failure = match &*result.0 {
             ReadyState::Err(msg) => Some(msg.clone()),
-            // Unreachable: the wait only returns without timing out once the predicate is false.
+            // `Pending` is the state on the timed-out path, handled by the branch below;
+            // either way there is no failure message to carry.
             ReadyState::Ok | ReadyState::Pending => None,
         };
         drop(result);
@@ -789,8 +791,8 @@ fn serve_loop(
     })?;
 
     // A detached thread (spawn already timed out and returned to the caller) must not take a
-    // selection the caller has already been told it failed to get. `spawn`'s detach comment counts on this
-    // check.
+    // selection the caller has already been told it failed to get. `spawn`'s detach comment
+    // counts on this check.
     if stop.load(Ordering::Relaxed) {
         return Ok(());
     }
@@ -1012,10 +1014,24 @@ mod tests {
         .expect("poll the transfer");
         assert!(ready > 0, "the owner never started writing the paste");
 
+        let started = std::time::Instant::now();
         on_a_thread(
             Duration::from_secs(15),
             "dropping an owner must not wait out a paste nobody is reading",
             move || drop(owner),
+        );
+        // Ties the test to CLIP_WRITE_TIMEOUT rather than to the ceiling above, which any bound
+        // under ~13 s would still pass. The upper check carries the owner's 50 ms dispatch tick
+        // and a loaded machine on top of the 2 s bound; the lower one fails a bound shrunk to ~0,
+        // which would return promptly and truncate every real paste.
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < Duration::from_secs(6),
+            "dropping took {elapsed:?}, expected it to return near the 2 s write bound"
+        );
+        assert!(
+            elapsed >= Duration::from_secs(1),
+            "dropping took only {elapsed:?}, expected the write bound to be what released it"
         );
         // Held until here: closing the read end early fails the write as EPIPE, which would let
         // even an unbounded write return.

--- a/crates/glass-wayland/src/clipboard.rs
+++ b/crates/glass-wayland/src/clipboard.rs
@@ -433,6 +433,23 @@ fn is_retryable(e: &std::io::Error) -> bool {
     e.kind() == std::io::ErrorKind::Interrupted
 }
 
+/// How long is left before `deadline`, as a poll timeout — or `None` once it has passed.
+///
+/// The expiry check is explicit rather than left to the poll: `Instant` subtraction saturates to
+/// zero, and a zero-timeout poll still reports a ready fd, so a caller relying on that alone would
+/// run past its own deadline for as long as the other end kept the pipe ready.
+fn remaining_timespec(deadline: Instant) -> Option<rustix::event::Timespec> {
+    let now = Instant::now();
+    if now >= deadline {
+        return None;
+    }
+    let remaining = deadline - now;
+    Some(rustix::event::Timespec {
+        tv_sec: remaining.as_secs() as i64,
+        tv_nsec: remaining.subsec_nanos() as i64,
+    })
+}
+
 /// Read `fd` to EOF, but give up after `timeout`. The selection owner is an
 /// arbitrary external app; one that opens the transfer but never finishes
 /// writing (or never closes its write end) would otherwise block this read —
@@ -445,14 +462,8 @@ fn read_to_eof_bounded(fd: OwnedFd, timeout: Duration) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
     let mut chunk = [0u8; 8192];
     loop {
-        let now = Instant::now();
-        if now >= deadline {
+        let Some(ts) = remaining_timespec(deadline) else {
             return Err(GlassError::Timeout(timeout.as_millis() as u64));
-        }
-        let remaining = deadline - now;
-        let ts = rustix::event::Timespec {
-            tv_sec: remaining.as_secs() as i64,
-            tv_nsec: remaining.subsec_nanos() as i64,
         };
         // The PollFd borrows `file` only for this statement, freeing it before
         // the read below.
@@ -508,25 +519,21 @@ fn is_write_retryable(e: &std::io::Error) -> bool {
 /// The fd is made non-blocking first. `POLLOUT` promises only that one byte fits, while a
 /// blocking `write` of more than `PIPE_BUF` waits for the whole payload: polling a blocking fd
 /// would leave the same unbounded wait one syscall further down.
+// The messages below name only the failure: the one caller prints them behind its own
+// "clipboard serve: paste transfer" prefix.
 fn write_all_bounded(fd: OwnedFd, buf: &[u8], timeout: Duration) -> Result<()> {
     let deadline = Instant::now() + timeout;
     let flags = rustix::fs::fcntl_getfl(&fd)
-        .map_err(|e| GlassError::Backend(format!("clipboard serve: fcntl_getfl: {e}")))?;
+        .map_err(|e| GlassError::Backend(format!("fcntl_getfl: {e}")))?;
     rustix::fs::fcntl_setfl(&fd, flags | rustix::fs::OFlags::NONBLOCK)
-        .map_err(|e| GlassError::Backend(format!("clipboard serve: fcntl_setfl: {e}")))?;
+        .map_err(|e| GlassError::Backend(format!("fcntl_setfl: {e}")))?;
 
     let mut file = std::fs::File::from(fd);
     let total = buf.len();
     let mut written = 0usize;
     while written < total {
-        let now = Instant::now();
-        if now >= deadline {
+        let Some(ts) = remaining_timespec(deadline) else {
             return Err(GlassError::Timeout(timeout.as_millis() as u64));
-        }
-        let remaining = deadline - now;
-        let ts = rustix::event::Timespec {
-            tv_sec: remaining.as_secs() as i64,
-            tv_nsec: remaining.subsec_nanos() as i64,
         };
         // The PollFd borrows `file` only for this statement, freeing it before the write below.
         let ready = rustix::event::poll(
@@ -541,25 +548,25 @@ fn write_all_bounded(fd: OwnedFd, buf: &[u8], timeout: Duration) -> Result<()> {
             Ok(_) => match file.write(&buf[written..]) {
                 Ok(0) => {
                     return Err(GlassError::Backend(format!(
-                        "clipboard serve: paste transfer stalled at {written} of {total} bytes"
+                        "stalled at {written} of {total} bytes"
                     )));
                 }
                 Ok(n) => written += n,
                 Err(e) if is_write_retryable(&e) => continue,
                 Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {
                     return Err(GlassError::Backend(format!(
-                        "clipboard serve: paste receiver closed the transfer after {written} of {total} bytes"
+                        "receiver closed the transfer after {written} of {total} bytes"
                     )));
                 }
                 Err(e) => {
                     return Err(GlassError::Backend(format!(
-                        "clipboard serve: write pipe: {e} after {written} of {total} bytes"
+                        "write pipe: {e} after {written} of {total} bytes"
                     )));
                 }
             },
             // The poll's half of the rule `is_write_retryable` names for the write.
             Err(rustix::io::Errno::INTR) => continue,
-            Err(e) => return Err(GlassError::Backend(format!("clipboard serve: poll: {e}"))),
+            Err(e) => return Err(GlassError::Backend(format!("poll: {e}"))),
         }
     }
     Ok(())
@@ -877,13 +884,28 @@ fn serve_loop(
 #[cfg(test)]
 mod tests {
     use super::{
-        Arc, CLIP_READ_TIMEOUT, CLIP_WRITE_TIMEOUT, ClipboardOwner, Condvar, Mutex, PoisonError,
-        ReadyState, get, is_retryable, read_to_eof_bounded, serve_loop, signal_ready,
+        Arc, AtomicBool, CLIP_READ_TIMEOUT, CLIP_WRITE_TIMEOUT, ClipboardOwner, Condvar, Mutex,
+        PoisonError, ReadyState, get, is_retryable, read_to_eof_bounded, serve_loop, signal_ready,
         write_all_bounded,
     };
     use crate::testw::Launch;
     use glass_core::GlassError;
     use std::io::Write;
+
+    /// Run `f` on its own thread and wait `within` for its result, failing with `what` if it does
+    /// not arrive. The calls these tests bound hang outright when the bound under test is missing,
+    /// and a hang on the test thread wedges the whole suite.
+    fn on_a_thread<T: Send + 'static>(
+        within: Duration,
+        what: &str,
+        f: impl FnOnce() -> T + Send + 'static,
+    ) -> T {
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(f());
+        });
+        rx.recv_timeout(within).expect(what)
+    }
 
     /// The serving thread is the clipboard — it holds the selection while it runs, and a pasting
     /// app reads from it over a pipe. Nothing under that is fakeable, so these use a real one.
@@ -939,13 +961,11 @@ mod tests {
     fn dropping_an_owner_does_not_block() {
         let s = Launch::new().start();
         let owner = ClipboardOwner::spawn(s.wayland_socket(), "held".into()).expect("spawn");
-        let (tx, rx) = std::sync::mpsc::channel();
-        std::thread::spawn(move || {
-            drop(owner);
-            let _ = tx.send(());
-        });
-        rx.recv_timeout(Duration::from_secs(10))
-            .expect("dropping an owner must stop its thread, not wait on it forever");
+        on_a_thread(
+            Duration::from_secs(10),
+            "dropping an owner must stop its thread, not wait on it forever",
+            move || drop(owner),
+        );
     }
 
     /// Dropping gives up the selection. A thread that kept running would keep answering pastes
@@ -974,28 +994,22 @@ mod tests {
         let live = ClipboardOwner::spawn(socket.clone(), "mine".into()).expect("spawn");
         assert_eq!(get(&socket).expect("get"), "mine");
 
-        let text = std::sync::Arc::new(std::sync::Mutex::new("stolen".to_string()));
-        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
-        let ready = std::sync::Arc::new((
-            std::sync::Mutex::new(ReadyState::Pending),
-            std::sync::Condvar::new(),
-        ));
+        let text = Arc::new(Mutex::new("stolen".to_string()));
+        let stop = Arc::new(AtomicBool::new(true));
+        let ready = Arc::new((Mutex::new(ReadyState::Pending), Condvar::new()));
 
         // On its own thread: a compositor stalled in the setup roundtrip (or, on an ablated
-        // build, the trailing one after set_selection) would otherwise hang this call forever,
-        // and a direct call would wedge the whole suite instead of failing this test.
-        let (tx, rx) = std::sync::mpsc::channel();
+        // build, the trailing one after set_selection) would otherwise hang this call forever.
         let socket_thread = socket.clone();
-        std::thread::spawn(move || {
-            let outcome = serve_loop(socket_thread, text, stop, ready)
-                .err()
-                .map(|e| e.to_string());
-            let _ = tx.send(outcome);
-        });
-
-        let outcome = rx
-            .recv_timeout(Duration::from_secs(10))
-            .expect("a stalled compositor must fail this test, not hang the whole suite");
+        let outcome = on_a_thread(
+            Duration::from_secs(10),
+            "a stalled compositor must fail this test, not hang the whole suite",
+            move || {
+                serve_loop(socket_thread, text, stop, ready)
+                    .err()
+                    .map(|e| e.to_string())
+            },
+        );
         if let Some(msg) = outcome {
             panic!("a detached thread standing down is not a serve error: {msg}");
         }
@@ -1030,20 +1044,18 @@ mod tests {
         let listener = std::os::unix::net::UnixListener::bind(&socket).expect("bind");
         let accepted = std::thread::spawn(move || listener.accept().map(|(s, _)| s));
 
-        // On its own thread: pre-fix this call never returns, and a direct call would wedge the
-        // whole suite instead of failing this test.
-        let (tx, rx) = std::sync::mpsc::channel();
+        // On its own thread: a spawn that never returns must fail this test, not wedge the whole
+        // suite.
         let started = std::time::Instant::now();
-        std::thread::spawn(move || {
-            let outcome = ClipboardOwner::spawn(socket, "text".into())
-                .err()
-                .map(|e| e.to_string());
-            let _ = tx.send(outcome);
-        });
-
-        let outcome = rx
-            .recv_timeout(Duration::from_secs(10))
-            .expect("spawn must return when its own 2 s bound expires, not wait on the peer");
+        let outcome = on_a_thread(
+            Duration::from_secs(10),
+            "spawn must return when its own 2 s bound expires, not wait on the peer",
+            move || {
+                ClipboardOwner::spawn(socket, "text".into())
+                    .err()
+                    .map(|e| e.to_string())
+            },
+        );
         // Ties the test to the 2 s bound itself, not just to the 10 s ceiling above: a bound
         // loosened to e.g. 9 s would still return before the ceiling but fail this, and a bound
         // shrunk to ~0 (which would also pass the ceiling and still contain "timed out") fails

--- a/crates/glass-wayland/src/clipboard.rs
+++ b/crates/glass-wayland/src/clipboard.rs
@@ -310,13 +310,12 @@ impl Dispatch<ZwlrDataControlSourceV1, ()> for ServeState {
     ) {
         match event {
             zwlr_data_control_source_v1::Event::Send { mime_type: _, fd } => {
-                // Cloned out before the write, not held across it: the write can take up to
-                // CLIP_WRITE_TIMEOUT, and holding the mutex would queue set_text and every later
-                // paste behind one slow reader.
+                // Cloned out before the write — holding the mutex across it would queue set_text
+                // and every later paste behind one slow reader for up to CLIP_WRITE_TIMEOUT.
                 let text = state.text.lock().expect("clipboard text mutex").clone();
-                // Failures are printed, not returned: a Dispatch impl has nowhere to return to,
-                // and the paste happens long after set_clipboard answered its caller. Printing is
-                // what makes a truncated paste distinguishable from an empty clipboard.
+                // Failures are printed, not returned — a Dispatch callback has nowhere to return
+                // them, and printing is what makes a truncated paste distinguishable from an
+                // empty clipboard.
                 if let Err(e) = write_all_bounded(fd, text.as_bytes(), CLIP_WRITE_TIMEOUT) {
                     eprintln!("glass-wayland: clipboard serve: paste transfer: {e}");
                 }
@@ -473,9 +472,9 @@ fn read_to_eof_bounded(fd: OwnedFd, timeout: Duration) -> Result<Vec<u8>> {
     }
 }
 
-/// Cap on how long the serving thread spends handing one paste to a requesting app. Its own
-/// constant rather than a reuse of [`CLIP_READ_TIMEOUT`]: that bounds an app glass reads from,
-/// this bounds an app glass writes to, and moving one should not move the other.
+/// Cap on how long the serving thread spends handing one paste to a requesting app — separate
+/// from [`CLIP_READ_TIMEOUT`], which bounds reads, so that changing one does not change the
+/// other.
 const CLIP_WRITE_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Whether a failed write should be retried — nothing was lost and the pipe may take more. A
@@ -624,10 +623,10 @@ impl ClipboardOwner {
             // from a thread-exit path would otherwise deadlock the join below on this thread.
             drop(result);
             stop.store(true, Ordering::Relaxed);
-            // Deliberately not joined. Timing out means the thread has not reached the loop that
-            // reads `stop`, so a join waits on the wedged compositor with no bound — the hang
-            // this 2 s bound exists to prevent. Detaching is self-cleaning: the setup either
-            // fails and the thread exits, or it completes and the first pump iteration stops.
+            // Deliberately not joined: timing out means the thread hasn't reached the loop that
+            // reads `stop`, so a join would wait on the wedged compositor with no bound.
+            // Detaching is self-cleaning — the setup either fails and the thread exits, or it
+            // completes and the first pump iteration stops.
             if handle.is_finished() && handle.join().is_err() {
                 // Finished without ever signalling: it panicked during setup. Reporting that as a
                 // timeout would send the reader looking for a slow compositor.

--- a/crates/glass-x11/src/clipboard.rs
+++ b/crates/glass-x11/src/clipboard.rs
@@ -2,7 +2,7 @@
 //! set via a dedicated owner thread that serves `SelectionRequest` events.
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Condvar, Mutex, PoisonError};
 use std::time::{Duration, Instant};
 
 use x11rb::connection::Connection;
@@ -222,16 +222,33 @@ impl ClipboardOwner {
         let (lock, cvar) = &*ready;
         let result = cvar
             .wait_timeout_while(
-                lock.lock().expect("clipboard ready mutex"),
+                lock.lock().unwrap_or_else(PoisonError::into_inner),
                 Duration::from_secs(2),
                 |s| matches!(s, ReadyState::Pending),
             )
-            .unwrap();
+            // A poisoned lock means the owner thread panicked holding it. The state behind it
+            // still says what happened; panicking here turns a reportable clipboard failure into
+            // a crashed tool call.
+            .unwrap_or_else(PoisonError::into_inner);
 
-        if result.1.timed_out() {
-            // Thread still running but didn't signal in time; stop it.
+        let timed_out = result.1.timed_out();
+
+        if timed_out {
+            // Release the ready lock before touching `handle`: a future signal_ready reachable
+            // from a thread-exit path would otherwise deadlock the join below on this thread.
+            drop(result);
             stop.store(true, Ordering::Relaxed);
-            let _ = handle.join();
+            // Deliberately not joined. Timing out means the thread has not reached the loop that
+            // reads `stop`, so a join waits on the wedged X server with no bound — the hang this
+            // 2 s bound exists to prevent. Detaching is self-cleaning: the setup either fails and
+            // the thread exits, or it completes and the first serving iteration stops.
+            if handle.is_finished() && handle.join().is_err() {
+                // Finished without ever signalling: it panicked during setup. Reporting that as a
+                // timeout would send the reader looking for a slow X server.
+                return Err(GlassError::Backend(
+                    "clipboard set: owner thread panicked during setup".into(),
+                ));
+            }
             return Err(GlassError::Backend(
                 "clipboard set: timed out waiting for selection ownership".into(),
             ));
@@ -281,7 +298,7 @@ impl Drop for ClipboardOwner {
 /// Signal the ready condvar from the owner thread. Helper to reduce repetition.
 fn signal_ready(ready: &Arc<(Mutex<ReadyState>, Condvar)>, state: ReadyState) {
     let (lock, cvar) = &**ready;
-    *lock.lock().expect("clipboard ready mutex") = state;
+    *lock.lock().unwrap_or_else(PoisonError::into_inner) = state;
     cvar.notify_one();
 }
 
@@ -382,6 +399,12 @@ fn owner_thread(
         stop.store(true, Ordering::Relaxed);
         msg
     })?;
+
+    // A detached thread (spawn already timed out and returned to the caller) must not take a
+    // selection the caller has already been told it failed to get.
+    if stop.load(Ordering::Relaxed) {
+        return Ok(());
+    }
 
     // Take ownership of CLIPBOARD.
     conn.set_selection_owner(win, clipboard, x11rb::CURRENT_TIME)
@@ -639,11 +662,115 @@ mod tests {
         assert_eq!(granted, x11rb::NONE);
     }
 
+    /// A detached setup thread that unwedges after `spawn` already gave up is in exactly this
+    /// state: still running, with `stop` already true. Calling `owner_thread` directly with
+    /// `stop` pre-set reproduces it without needing a server that actually stalls — it must
+    /// stand down before `set_selection_owner`, not take the selection from whatever owner is
+    /// now live.
+    #[test]
+    #[ignore = "starts a real X server; needs Xvfb"]
+    fn a_stopped_owner_thread_does_not_take_the_selection_from_a_live_owner() {
+        let x = TestX::start();
+        let live =
+            ClipboardOwner::spawn(x.display().to_string(), "mine".to_string()).expect("spawn");
+        assert_eq!(get(x.display()).expect("get"), "mine");
+
+        let text = Arc::new(Mutex::new("stolen".to_string()));
+        let stop = Arc::new(AtomicBool::new(true));
+        let ready = Arc::new((Mutex::new(ReadyState::Pending), Condvar::new()));
+
+        // On its own thread: a stalled X server (or, on an ablated build, the trailing
+        // set_selection_owner) would otherwise hang this call forever, and a direct call would
+        // wedge the whole suite instead of failing this test.
+        let (tx, rx) = std::sync::mpsc::channel();
+        let display = x.display().to_string();
+        std::thread::spawn(move || {
+            let outcome = owner_thread(&display, text, stop, ready)
+                .err()
+                .map(|e| e.to_string());
+            let _ = tx.send(outcome);
+        });
+
+        let outcome = rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("a stalled X server must fail this test, not hang the whole suite");
+        if let Some(msg) = outcome {
+            panic!("a detached thread standing down is not an owner error: {msg}");
+        }
+
+        assert!(
+            live.is_alive(),
+            "the live owner must still be serving after a detached thread stands down"
+        );
+        assert_eq!(get(x.display()).expect("get"), "mine");
+    }
+
     #[test]
     fn spawning_against_an_unreachable_display_fails_instead_of_hanging() {
         let Err(err) = ClipboardOwner::spawn(":9999".to_string(), "text".to_string()) else {
             panic!("there is no server on :9999, so no owner can take its selection");
         };
         assert!(matches!(err, GlassError::Backend(_)), "{err:?}");
+    }
+
+    /// Bind the X11 TCP port of the first free display number, returning a listener and the
+    /// display string that reaches it. x11rb maps `host:N` to TCP port 6000+N, and a non-empty
+    /// host means it never looks at /tmp/.X11-unix — so this fakes a server without writing into
+    /// shared host state.
+    fn wedged_x_server() -> (std::net::TcpListener, String) {
+        for n in 40..80 {
+            if let Ok(l) = std::net::TcpListener::bind(("127.0.0.1", 6000 + n)) {
+                return (l, format!("127.0.0.1:{n}"));
+            }
+        }
+        panic!("no free X11 TCP port in 6040..6080");
+    }
+
+    /// An X server that accepts the connection and never sends its greeting is what the 2 s
+    /// readiness bound is for. Joining the setup thread there waits on the wedged server with no
+    /// bound at all, so spawn has to return without it — every tool call is behind the session
+    /// lock this holds.
+    #[test]
+    fn an_owner_gives_up_on_a_server_that_accepts_and_never_answers() {
+        let (listener, display) = wedged_x_server();
+        let accepted = std::thread::spawn(move || listener.accept().map(|(s, _)| s));
+
+        // On its own thread: pre-fix this call never returns, and a direct call would wedge the
+        // whole suite instead of failing this test.
+        let (tx, rx) = std::sync::mpsc::channel();
+        let started = Instant::now();
+        std::thread::spawn(move || {
+            let outcome = ClipboardOwner::spawn(display, "text".to_string())
+                .err()
+                .map(|e| e.to_string());
+            let _ = tx.send(outcome);
+        });
+
+        let outcome = rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("spawn must return when its own 2 s bound expires, not wait on the server");
+        // Ties the test to the 2 s bound itself, not just to the 10 s ceiling above: a bound
+        // loosened to e.g. 9 s would still return before the ceiling but fail this, and a bound
+        // shrunk to ~0 (which would also pass the ceiling and still contain "timed out") fails
+        // the lower check below.
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "spawn took {elapsed:?}, expected it to give up near its own 2 s bound"
+        );
+        assert!(
+            elapsed >= Duration::from_secs(1),
+            "spawn took only {elapsed:?}, expected it to wait close to its own 2 s bound"
+        );
+        let msg = outcome.expect("a server that never answers is not an owned selection");
+        assert!(msg.contains("timed out"), "{msg}");
+
+        // Closing the server side lets the detached setup thread fail and exit.
+        drop(
+            accepted
+                .join()
+                .expect("accept thread")
+                .expect("accepted stream"),
+        );
     }
 }

--- a/crates/glass-x11/src/clipboard.rs
+++ b/crates/glass-x11/src/clipboard.rs
@@ -252,7 +252,8 @@ impl ClipboardOwner {
         // join.
         let failure = match &*result.0 {
             ReadyState::Err(msg) => Some(msg.clone()),
-            // Unreachable: the wait only returns without timing out once the predicate is false.
+            // `Pending` is the state on the timed-out path, handled by the branch below;
+            // either way there is no failure message to carry.
             ReadyState::Ok | ReadyState::Pending => None,
         };
         drop(result);
@@ -421,8 +422,8 @@ fn owner_thread(
     })?;
 
     // A detached thread (spawn already timed out and returned to the caller) must not take a
-    // selection the caller has already been told it failed to get. `spawn`'s detach comment counts on this
-    // check.
+    // selection the caller has already been told it failed to get. `spawn`'s detach comment
+    // counts on this check.
     if stop.load(Ordering::Relaxed) {
         // Skips the `destroy_window` the normal exit performs: `conn` is dropped on the way out,
         // and an X server destroys everything a client created once its connection closes

--- a/crates/glass-x11/src/clipboard.rs
+++ b/crates/glass-x11/src/clipboard.rs
@@ -179,9 +179,26 @@ enum ReadyState {
     Err(String),
 }
 
+/// Recover a poisoned readiness lock instead of propagating the panic, and say so.
+///
+/// The state behind the lock still says what happened, so panicking here would turn a reportable
+/// clipboard failure into a crashed tool call — but recovering in silence leaves the owner thread
+/// that panicked invisible.
+fn recover_readiness<T>(what: &str, r: std::result::Result<T, PoisonError<T>>) -> T {
+    match r {
+        Ok(v) => v,
+        Err(poisoned) => {
+            eprintln!("glass: clipboard {what}: a thread panicked holding this lock");
+            poisoned.into_inner()
+        }
+    }
+}
+
 /// A background thread that owns the X11 CLIPBOARD selection and serves paste
 /// requests. Created by `ClipboardOwner::spawn`; torn down by dropping it.
 pub struct ClipboardOwner {
+    // `expect`, not the readiness lock's `PoisonError::into_inner`: this one is off the readiness
+    // path and its two holders only clone the string or assign to it, so nothing under it panics.
     text: Arc<Mutex<String>>,
     stop: Arc<AtomicBool>,
     handle: Option<std::thread::JoinHandle<()>>,
@@ -220,28 +237,35 @@ impl ClipboardOwner {
         // Block until the thread signals that it has taken ownership (or
         // encountered an error), with a 2 s timeout.
         let (lock, cvar) = &*ready;
-        let result = cvar
-            .wait_timeout_while(
-                lock.lock().unwrap_or_else(PoisonError::into_inner),
+        let result = recover_readiness(
+            "set: readiness wait",
+            cvar.wait_timeout_while(
+                recover_readiness("set: readiness lock", lock.lock()),
                 Duration::from_secs(2),
                 |s| matches!(s, ReadyState::Pending),
-            )
-            // A poisoned lock means the owner thread panicked holding it. The state behind it
-            // still says what happened; panicking here turns a reportable clipboard failure into
-            // a crashed tool call.
-            .unwrap_or_else(PoisonError::into_inner);
+            ),
+        );
 
         let timed_out = result.1.timed_out();
+        // Copy the outcome out and release the ready lock before either path below touches
+        // `handle`: a signal_ready reachable from a thread-exit path would otherwise deadlock the
+        // join.
+        let failure = match &*result.0 {
+            ReadyState::Err(msg) => Some(msg.clone()),
+            // Unreachable: the wait only returns without timing out once the predicate is false.
+            ReadyState::Ok | ReadyState::Pending => None,
+        };
+        drop(result);
 
         if timed_out {
-            // Release the ready lock before touching `handle`: a future signal_ready reachable
-            // from a thread-exit path would otherwise deadlock the join below on this thread.
-            drop(result);
             stop.store(true, Ordering::Relaxed);
             // Deliberately not joined: timing out means the thread hasn't reached the loop that
-            // reads `stop`, so a join would wait on the wedged X server with no bound.
-            // Detaching is self-cleaning — the setup either fails and the thread exits, or it
-            // completes and the first serving iteration stops.
+            // reads `stop`, so a join would wait on the wedged X server with no bound. Detaching
+            // is self-cleaning in all three of the outcomes left to it: the setup fails and the
+            // thread exits; the setup finishes and the `stop` check `owner_thread` makes before
+            // `set_selection_owner` returns without ever taking the selection; or `stop` arrives
+            // after that check and the first serving iteration breaks out. Drop that check and
+            // this becomes a thread that unwedges later and steals a live owner's selection.
             if handle.is_finished() && handle.join().is_err() {
                 // Finished without ever signalling: it panicked during setup. Reporting that as a
                 // timeout would send the reader looking for a slow X server.
@@ -254,14 +278,10 @@ impl ClipboardOwner {
             ));
         }
 
-        match &*result.0 {
-            ReadyState::Ok | ReadyState::Pending /* unreachable but safe */ => {}
-            ReadyState::Err(msg) => {
-                let _ = handle.join();
-                return Err(GlassError::Backend(format!("clipboard set: {msg}")));
-            }
+        if let Some(msg) = failure {
+            let _ = handle.join();
+            return Err(GlassError::Backend(format!("clipboard set: {msg}")));
         }
-        drop(result);
 
         Ok(Self {
             text,
@@ -298,7 +318,7 @@ impl Drop for ClipboardOwner {
 /// Signal the ready condvar from the owner thread. Helper to reduce repetition.
 fn signal_ready(ready: &Arc<(Mutex<ReadyState>, Condvar)>, state: ReadyState) {
     let (lock, cvar) = &**ready;
-    *lock.lock().unwrap_or_else(PoisonError::into_inner) = state;
+    *recover_readiness("owner: readiness signal", lock.lock()) = state;
     cvar.notify_one();
 }
 
@@ -401,8 +421,12 @@ fn owner_thread(
     })?;
 
     // A detached thread (spawn already timed out and returned to the caller) must not take a
-    // selection the caller has already been told it failed to get.
+    // selection the caller has already been told it failed to get. `spawn`'s detach comment counts on this
+    // check.
     if stop.load(Ordering::Relaxed) {
+        // Skips the `destroy_window` the normal exit performs: `conn` is dropped on the way out,
+        // and an X server destroys everything a client created once its connection closes
+        // (close-down mode defaults to DestroyAll).
         return Ok(());
     }
 
@@ -703,6 +727,33 @@ mod tests {
             "the live owner must still be serving after a detached thread stands down"
         );
         assert_eq!(get(x.display()).expect("get"), "mine");
+    }
+
+    /// An owner thread that panics holding the readiness lock poisons it. The readiness path has
+    /// to keep working through that: propagating the poison instead turns a clipboard failure the
+    /// caller could report into a second panic in the caller.
+    #[test]
+    fn a_poisoned_readiness_lock_is_recovered_rather_than_propagated() {
+        let ready = Arc::new((Mutex::new(ReadyState::Pending), Condvar::new()));
+        let poisoner = Arc::clone(&ready);
+        let panicked = std::thread::spawn(move || {
+            let _held = poisoner.0.lock().expect("lock");
+            // The panic message below is the test working, not the test failing.
+            panic!("an owner thread panicking with the readiness lock held");
+        })
+        .join();
+        assert!(panicked.is_err(), "the thread was supposed to panic");
+        assert!(
+            ready.0.is_poisoned(),
+            "a panic under the lock is what poisons it; without that this test proves nothing"
+        );
+
+        signal_ready(&ready, ReadyState::Ok);
+        let state = ready.0.lock().unwrap_or_else(PoisonError::into_inner);
+        assert!(
+            matches!(*state, ReadyState::Ok),
+            "signalling through a poisoned lock must still land the state"
+        );
     }
 
     #[test]

--- a/crates/glass-x11/src/clipboard.rs
+++ b/crates/glass-x11/src/clipboard.rs
@@ -238,10 +238,10 @@ impl ClipboardOwner {
             // from a thread-exit path would otherwise deadlock the join below on this thread.
             drop(result);
             stop.store(true, Ordering::Relaxed);
-            // Deliberately not joined. Timing out means the thread has not reached the loop that
-            // reads `stop`, so a join waits on the wedged X server with no bound — the hang this
-            // 2 s bound exists to prevent. Detaching is self-cleaning: the setup either fails and
-            // the thread exits, or it completes and the first serving iteration stops.
+            // Deliberately not joined: timing out means the thread hasn't reached the loop that
+            // reads `stop`, so a join would wait on the wedged X server with no bound.
+            // Detaching is self-cleaning — the setup either fails and the thread exits, or it
+            // completes and the first serving iteration stops.
             if handle.is_finished() && handle.join().is_err() {
                 // Finished without ever signalling: it panicked during setup. Reporting that as a
                 // timeout would send the reader looking for a slow X server.

--- a/crates/glass-x11/src/clipboard.rs
+++ b/crates/glass-x11/src/clipboard.rs
@@ -560,6 +560,21 @@ mod tests {
         f()
     }
 
+    /// Run `f` on its own thread and wait `within` for its result, failing with `what` if it does
+    /// not arrive. The calls these tests bound hang outright when the bound under test is missing,
+    /// and a hang on the test thread wedges the whole suite.
+    fn on_a_thread<T: Send + 'static>(
+        within: Duration,
+        what: &str,
+        f: impl FnOnce() -> T + Send + 'static,
+    ) -> T {
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(f());
+        });
+        rx.recv_timeout(within).expect(what)
+    }
+
     #[test]
     #[ignore = "starts a real X server; needs Xvfb"]
     fn an_unowned_clipboard_reads_as_empty_rather_than_failing() {
@@ -704,20 +719,17 @@ mod tests {
         let ready = Arc::new((Mutex::new(ReadyState::Pending), Condvar::new()));
 
         // On its own thread: a stalled X server (or, on an ablated build, the trailing
-        // set_selection_owner) would otherwise hang this call forever, and a direct call would
-        // wedge the whole suite instead of failing this test.
-        let (tx, rx) = std::sync::mpsc::channel();
+        // set_selection_owner) would otherwise hang this call forever.
         let display = x.display().to_string();
-        std::thread::spawn(move || {
-            let outcome = owner_thread(&display, text, stop, ready)
-                .err()
-                .map(|e| e.to_string());
-            let _ = tx.send(outcome);
-        });
-
-        let outcome = rx
-            .recv_timeout(Duration::from_secs(10))
-            .expect("a stalled X server must fail this test, not hang the whole suite");
+        let outcome = on_a_thread(
+            Duration::from_secs(10),
+            "a stalled X server must fail this test, not hang the whole suite",
+            move || {
+                owner_thread(&display, text, stop, ready)
+                    .err()
+                    .map(|e| e.to_string())
+            },
+        );
         if let Some(msg) = outcome {
             panic!("a detached thread standing down is not an owner error: {msg}");
         }
@@ -786,20 +798,18 @@ mod tests {
         let (listener, display) = wedged_x_server();
         let accepted = std::thread::spawn(move || listener.accept().map(|(s, _)| s));
 
-        // On its own thread: pre-fix this call never returns, and a direct call would wedge the
-        // whole suite instead of failing this test.
-        let (tx, rx) = std::sync::mpsc::channel();
+        // On its own thread: a spawn that never returns must fail this test, not wedge the whole
+        // suite.
         let started = Instant::now();
-        std::thread::spawn(move || {
-            let outcome = ClipboardOwner::spawn(display, "text".to_string())
-                .err()
-                .map(|e| e.to_string());
-            let _ = tx.send(outcome);
-        });
-
-        let outcome = rx
-            .recv_timeout(Duration::from_secs(10))
-            .expect("spawn must return when its own 2 s bound expires, not wait on the server");
+        let outcome = on_a_thread(
+            Duration::from_secs(10),
+            "spawn must return when its own 2 s bound expires, not wait on the server",
+            move || {
+                ClipboardOwner::spawn(display, "text".to_string())
+                    .err()
+                    .map(|e| e.to_string())
+            },
+        );
         // Ties the test to the 2 s bound itself, not just to the 10 s ceiling above: a bound
         // loosened to e.g. 9 s would still return before the ceiling but fail this, and a bound
         // shrunk to ~0 (which would also pass the ceiling and still contain "timed out") fails

--- a/crates/glass-x11/src/clipboard.rs
+++ b/crates/glass-x11/src/clipboard.rs
@@ -261,11 +261,11 @@ impl ClipboardOwner {
             stop.store(true, Ordering::Relaxed);
             // Deliberately not joined: timing out means the thread hasn't reached the loop that
             // reads `stop`, so a join would wait on the wedged X server with no bound. Detaching
-            // is self-cleaning in all three of the outcomes left to it: the setup fails and the
-            // thread exits; the setup finishes and the `stop` check `owner_thread` makes before
-            // `set_selection_owner` returns without ever taking the selection; or `stop` arrives
-            // after that check and the first serving iteration breaks out. Drop that check and
-            // this becomes a thread that unwedges later and steals a live owner's selection.
+            // is self-cleaning: the setup fails and the thread exits; the setup finishes and the
+            // `stop` check `owner_thread` makes before `set_selection_owner` returns without ever
+            // taking the selection; or `stop` arrives after that check and the first serving
+            // iteration breaks out. Drop that check and it can unwedge later and steal a live
+            // owner's selection.
             if handle.is_finished() && handle.join().is_err() {
                 // Finished without ever signalling: it panicked during setup. Reporting that as a
                 // timeout would send the reader looking for a slow X server.


### PR DESCRIPTION
Two clipboard paths waited on an app glass does not control, with no bound the waiting code could reach.

**The paste write (#377).** The Wayland owner thread served a paste with a blocking `write_all` whose result it discarded. An app that opened the transfer and stopped reading blocked that write once the payload passed the pipe buffer — on the very thread whose loop honours the stop flag, so `ClipboardOwner::drop` then joined a thread that could no longer return, and `kill_session` hung with it. A short or failed write reached the pasting app in silence, leaving a truncated paste indistinguishable from an empty clipboard.

`write_all_bounded` is now the mirror of the existing `read_to_eof_bounded`: the fd goes non-blocking, the write polls against a deadline and advances an offset, and a receiver that closes the transfer is reported with the byte counts rather than swallowed.

**The readiness bound (#378).** `ClipboardOwner::spawn` waits 2s for its serving thread to register the selection, then on timeout set `stop` and joined. But `stop` is only read inside the pump loop, and timing out means the thread never reached it — so the join waited on the wedged compositor with no bound, holding the session lock. It now detaches, and reports a thread that panicked during setup as a panic instead of a timeout.

Detaching exposed a second hole: the setup path took the selection unconditionally, so a thread that unwedged after `spawn` gave up could take it from a later successful owner and destroy it on exit. Both backends now stand down before taking a selection the caller has already been told they failed to get.

**The X11 owner carried the same #378 defect** — the Wayland one was modelled on it — and is fixed the same way.

Tests run with no display and no compositor: the bounded write against a reader that never reads, one that closes the transfer, and a payload four times the pipe buffer; and both owners against a peer that accepts and never answers, asserting the 2s bound rather than the test's own ceiling. The two selection-theft regressions are pinned on a real sway and a real Xvfb.

Closes #377
Closes #378
