### PR TITLE
test(a11y): kill the glass-dbus-linux mutation survivors and gate the crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
           if-no-files-found: warn
 
   mutants:
-    name: Mutation shard ${{ matrix.shard }} (glass-core, glass-android, glass-x11, glass-exec-unix)
+    name: Mutation shard ${{ matrix.shard }} (glass-core, glass-android, glass-x11, glass-exec-unix, glass-dbus-linux)
     runs-on: ubuntu-latest
     # A push carries no base ref to diff against; this gate is a pull-request check.
     if: github.event_name == 'pull_request'
@@ -302,7 +302,8 @@ jobs:
             -- ':(glob)crates/glass-core/src/**/*.rs' \
                ':(glob)crates/glass-android/src/**/*.rs' \
                ':(glob)crates/glass-x11/src/**/*.rs' \
-               ':(glob)crates/glass-exec-unix/src/**/*.rs' > "$RUNNER_TEMP/pr.diff"
+               ':(glob)crates/glass-exec-unix/src/**/*.rs' \
+               ':(glob)crates/glass-dbus-linux/src/**/*.rs' > "$RUNNER_TEMP/pr.diff"
           wc -l "$RUNNER_TEMP/pr.diff"
           if [ -s "$RUNNER_TEMP/pr.diff" ]; then
             echo "touched=true" >> "$GITHUB_OUTPUT"
@@ -335,7 +336,7 @@ jobs:
           scripts/mutants.sh "$RUNNER_TEMP/mutants" \
             --test-tool nextest \
             --package glass-core --package glass-android --package glass-x11 \
-            --package glass-exec-unix \
+            --package glass-exec-unix --package glass-dbus-linux \
             --shard ${{ matrix.shard }}/8 --sharding round-robin \
             --in-diff "$RUNNER_TEMP/pr.diff"
 
@@ -343,8 +344,8 @@ jobs:
   # to require. This one has a fixed name and fails if any shard did.
   #
   # The ruleset's required check matches this name, so it is frozen — renaming it blocks every
-  # pull request. It gates glass-android, glass-x11 and glass-exec-unix too despite the name;
-  # rename only with the ruleset.
+  # pull request. It gates glass-android, glass-x11, glass-exec-unix and glass-dbus-linux too
+  # despite the name; rename only with the ruleset.
   mutants-gate:
     name: Mutation gate (glass-core)
     runs-on: ubuntu-latest

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   sweep:
-    name: Mutation sweep shard ${{ matrix.shard }} (glass-core, glass-android, glass-x11, glass-exec-unix)
+    name: Mutation sweep shard ${{ matrix.shard }} (glass-core, glass-android, glass-x11, glass-exec-unix, glass-dbus-linux)
     runs-on: ubuntu-latest
     strategy:
       # Every shard reports: one red shard must not hide a second one.
@@ -42,7 +42,7 @@ jobs:
           scripts/mutants.sh "$RUNNER_TEMP/mutants" \
             --test-tool nextest \
             --package glass-core --package glass-android --package glass-x11 \
-            --package glass-exec-unix \
+            --package glass-exec-unix --package glass-dbus-linux \
             --shard ${{ matrix.shard }}/8 --sharding round-robin
       - name: Upload the outcome
         if: always()

--- a/crates/glass-dbus-linux/src/lib.rs
+++ b/crates/glass-dbus-linux/src/lib.rs
@@ -166,6 +166,12 @@ impl PrivateBus {
     }
 }
 
+/// The address `org.a11y.Bus.GetAddress` answered, if it named a bus — the launcher owns the name
+/// before it has one to give, and answers `""` until then.
+fn usable_address(answer: String) -> Option<String> {
+    (!answer.is_empty()).then_some(answer)
+}
+
 /// Tear down the private bus, atspi-launcher FIRST then the session dbus-daemon.
 ///
 /// SIGTERM-first (graceful), not SIGKILL: `at-spi-bus-launcher` *forks its own*
@@ -489,21 +495,23 @@ fn resolve_a11y_address(session_addr: &str) -> Result<String> {
                 let proxy = A11yBusProxy::new(&conn)
                     .await
                     .map_err(|e| GlassError::Backend(format!("org.a11y.Bus proxy: {e}")))?;
-                let mut last = String::new();
+                let mut answered_empty = false;
                 let mut last_err: Option<String> = None;
                 for _ in 0..50 {
                     match proxy.get_address().await {
-                        Ok(a) if !a.is_empty() => {
-                            advertise_screen_reader(&conn).await;
-                            return Ok(a);
-                        }
-                        Ok(a) => last = a,
+                        Ok(a) => match usable_address(a) {
+                            Some(addr) => {
+                                advertise_screen_reader(&conn).await;
+                                return Ok(addr);
+                            }
+                            None => answered_empty = true,
+                        },
                         Err(e) => last_err = Some(e.to_string()),
                     }
                     tokio::time::sleep(Duration::from_millis(100)).await;
                 }
                 Err(GlassError::Backend(format!(
-                    "org.a11y.Bus.GetAddress did not yield an address after 5s (last ok: {last:?}, last err: {last_err:?})"
+                    "org.a11y.Bus.GetAddress did not yield an address after 5s (answered empty: {answered_empty}, last err: {last_err:?})"
                 )))
             };
             match tokio::time::timeout(A11Y_RESOLVE_TIMEOUT, resolve).await {
@@ -1000,6 +1008,38 @@ mod tests {
         assert!(
             extra.is_empty(),
             "private bus must expose no auto-activatable services, found: {extra:?}"
+        );
+    }
+
+    /// Nothing else reaps them: a `Child` that is only dropped is left running, so without this
+    /// every session teardown would leak a dbus-daemon and an at-spi-bus-launcher.
+    #[test]
+    #[ignore = "spawns a private dbus-daemon + at-spi-bus-launcher; run via test-a11y.sh"]
+    fn dropping_the_bus_reaps_both_children() {
+        let bus = PrivateBus::start().expect("start private bus");
+        let pids = [bus.dbus.id(), bus.atspi.id()];
+        drop(bus);
+        let alive = glass_proc_linux::any_alive(&pids);
+        // Cleaned up before asserting: under a regression they are still running, and panicking
+        // first would leak them for the rest of the run.
+        if alive {
+            for pid in pids {
+                let _ = Command::new("kill").arg("-9").arg(pid.to_string()).status();
+            }
+        }
+        assert!(!alive, "a child survived the drop: {pids:?}");
+    }
+
+    #[test]
+    fn an_empty_getaddress_answer_is_not_an_address() {
+        assert_eq!(usable_address(String::new()), None);
+    }
+
+    #[test]
+    fn a_non_empty_getaddress_answer_is_the_address() {
+        assert_eq!(
+            usable_address("unix:path=/run/user/1000/at-spi/bus_0".to_owned()),
+            Some("unix:path=/run/user/1000/at-spi/bus_0".to_owned())
         );
     }
 

--- a/crates/glass-dbus-linux/tests/preflight_env.rs
+++ b/crates/glass-dbus-linux/tests/preflight_env.rs
@@ -1,0 +1,43 @@
+//! `available()` reads the environment, so the `available_with` seam tests cannot reach it — the
+//! seam can be right while the wrapper hands it something else.
+//!
+//! Its own test binary: it mutates the process environment, and the crate's other tests spawn
+//! buses whose threads read it while they live.
+
+#![cfg(target_os = "linux")]
+
+use std::ffi::OsString;
+
+/// Restores the variable's prior value rather than unsetting it — both of these are documented
+/// escape hatches an operator may already have set when running the suite.
+struct EnvGuard(&'static str, Option<OsString>);
+
+#[allow(unsafe_code)]
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: this binary holds exactly one test, so nothing else in the process is reading
+        // the environment while it is mutated.
+        match self.1.take() {
+            Some(v) => unsafe { std::env::set_var(self.0, v) },
+            None => unsafe { std::env::remove_var(self.0) },
+        }
+    }
+}
+
+#[allow(unsafe_code)]
+fn set(name: &'static str, value: &str) -> EnvGuard {
+    let guard = EnvGuard(name, std::env::var_os(name));
+    // SAFETY: as above — one test in this binary.
+    unsafe { std::env::set_var(name, value) };
+    guard
+}
+
+#[test]
+fn the_preflight_reports_a_dbus_daemon_that_is_not_there() {
+    // A runnable launcher pins the other half of the preflight, so this passes on a host with no
+    // at-spi2-core installed — which the workspace test job is.
+    let _launcher = set("GLASS_ATSPI_LAUNCHER", "/bin/true");
+    let _daemon = set("GLASS_DBUS_DAEMON", "/nonexistent/dbus-daemon");
+    let err = glass_dbus_linux::available().expect_err("a missing dbus-daemon must be reported");
+    assert!(err.contains("dbus-daemon"), "{err}");
+}


### PR DESCRIPTION
A mutation sweep over `glass-dbus-linux` (41 mutants, run with `--run-ignored=all`) left three alive. All three are killed here, and the crate joins the gate.

**`reap_children` could be emptied with the suite green.** A `std::process::Child` that is only dropped is left running, so the mutant leaks a `dbus-daemon` and an `at-spi-bus-launcher` on every session teardown — the exact failure the function's own comment describes, and nothing observed it. Pinned by recording both pids and asserting they are gone after the drop.

**`available()` could return `Ok(())` unconditionally.** Every test drove the `available_with` seam, so the wrapper that reads `GLASS_DBUS_DAEMON` and `$PATH` was never exercised. It gets its own test binary, since it mutates the environment.

**The `!a.is_empty()` match guard in `resolve_a11y_address` could be replaced with `true`**, which accepts the empty address `org.a11y.Bus.GetAddress` answers with while the launcher is still bringing the bus up. Killing that in place needs a fake `org.a11y.Bus`; instead the rule moves into `usable_address`, a pure function with unit tests, and the guard disappears with it. The loop's `last` only ever held an empty string, so the error message now reports whether an empty answer was seen rather than printing `""`.

The crate is added to the pathspec list and the `--package` list in step, and to the weekly sweep. Per-shard job names change; the required check, `Mutation gate (glass-core)`, does not.

## Verification

`cargo test --workspace` 2216 passed / 0 failed; `./scripts/test-a11y.sh` 6 + 29 + 1; clippy `-D warnings` and `cargo fmt --check` clean. Each mutant above is killed by a test that fails without its fix.
