### PR TITLE
fix(wayland): bound the sway --version probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ internal refactors, CI, or test-only changes.
   were told to build one. Such a candidate is now stepped over and the search carries on. A
   candidate that does start and reports a version glass cannot use is unchanged: the search stops
   there rather than silently running a different sway further along your `$PATH`.
+- A `sway` that never answers no longer hangs `glass_start` and `glass doctor` indefinitely. The
+  same `--version` probe waited for its answer with no time limit, so a candidate that started and
+  then never exited — wedged on a lock, on a stalled filesystem, or waiting on input — stopped both
+  with nothing to recover from. Each probe is now bounded at 5 seconds; a candidate that has not
+  answered by then is killed and stepped over like one that never started, and the search carries
+  on. `glass doctor` says such a binary gave no `--version` answer, rather than reporting its
+  version as merely unknown.
 - Accessibility now works on Debian/Ubuntu machines that are not x86-64. `glass doctor` said
   `at-spi-bus-launcher present` while every a11y launch on the same machine failed to find it —
   quietly dropping to pixel-only by default, or failing outright with `a11y: true` — because the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,11 +45,13 @@ internal refactors, CI, or test-only changes.
   there rather than silently running a different sway further along your `$PATH`.
 - A `sway` that never answers no longer hangs `glass_start` and `glass doctor` indefinitely. The
   same `--version` probe waited for its answer with no time limit, so a candidate that started and
-  then never exited — wedged on a lock, on a stalled filesystem, or waiting on input — stopped both
-  with nothing to recover from. Each probe is now bounded at 5 seconds; a candidate that has not
-  answered by then is killed and stepped over like one that never started, and the search carries
-  on. `glass doctor` says such a binary gave no `--version` answer, rather than reporting its
-  version as merely unknown.
+  then never exited — wedged on a lock, or on a stalled filesystem — stopped both with nothing to
+  recover from. Each candidate now gets 5 seconds; one that has not answered by then is killed and
+  stepped over like one that never started, and the search carries on. If nothing else qualifies,
+  the error names that binary and what it did rather than telling you no sway is installed, and
+  `glass doctor` no longer ticks `sway ✓` for a sway it could not get a version out of — a
+  `GLASS_SWAY` override and the bundled sway skip the version check when glass resolves them, so
+  doctor's probe is the first `--version` either is ever put to.
 - Accessibility now works on Debian/Ubuntu machines that are not x86-64. `glass doctor` said
   `at-spi-bus-launcher present` while every a11y launch on the same machine failed to find it —
   quietly dropping to pixel-only by default, or failing outright with `a11y: true` — because the

--- a/crates/glass-wayland/src/doctor.rs
+++ b/crates/glass-wayland/src/doctor.rs
@@ -10,7 +10,8 @@ use glass_core::{AppSpec, Check, CheckStatus};
 
 use crate::command::{build_sway_command, sway_config};
 use crate::platform::{
-    NoSway, VERSION_PROBE_BUDGET, VersionAnswer, ask_sway_version, resolve_sway_verdict,
+    CHECK_THAT_SWAY, NoSway, VERSION_PROBE_BUDGET, VersionAnswer, ask_sway_version,
+    resolve_sway_verdict,
 };
 use crate::swayipc::Ipc;
 
@@ -28,17 +29,13 @@ pub fn checks(deep: bool) -> Vec<Check> {
 
 /// Pure: build the Wayland checks from gathered facts.
 fn wayland_checks(
-    sway: &Result<(PathBuf, String), NoSway>,
+    sway: &Result<(PathBuf, VersionAnswer), NoSway>,
     gl_present: bool,
     deep_spawn: Option<Result<(), String>>,
 ) -> Vec<Check> {
     let mut checks = Vec::new();
     checks.push(match sway {
-        Ok((path, ver)) => Check::new(
-            "sway >=1.12",
-            CheckStatus::Ok,
-            format!("{ver} at {}", path.display()),
-        ),
+        Ok((path, answer)) => sway_check(path, answer),
         // The detail is the cause, not a fixed "not found": a present sway reported as missing
         // reads as a build that never ran.
         Err(no) => {
@@ -74,24 +71,45 @@ fn wayland_checks(
     checks
 }
 
-/// Resolve sway (path) and read its version string for display.
-fn discover_sway() -> Result<(PathBuf, String), NoSway> {
+/// Resolve sway (path) and ask it its version.
+///
+/// `resolve_sway_verdict` version-probes only its `PATH` walk, so a `GLASS_SWAY` override and the
+/// bundled sway reach here having never been asked — doctor's is the first `--version` either is
+/// put to.
+fn discover_sway() -> Result<(PathBuf, VersionAnswer), NoSway> {
     let path = resolve_sway_verdict()?;
-    let ver = describe_version(ask_sway_version(&path, VERSION_PROBE_BUDGET));
-    Ok((path, ver))
+    let answer = ask_sway_version(&path, VERSION_PROBE_BUDGET);
+    Ok((path, answer))
 }
 
-/// How doctor names what the version probe got back.
+/// The `sway >=1.12` check for a sway that resolved.
 ///
-/// A binary that answers nothing and one that answers nothing *in time* are different faults:
-/// only the second explains a launch that also gets no answer. An override or a bundled sway
-/// reaches here unprobed, so doctor is where a hung one is first seen.
-fn describe_version(answer: VersionAnswer) -> String {
+/// A binary that gave no version is not a proven >=1.12, so it does not get a tick. `Warn` and not
+/// `Fail` because resolution stands: an override and the bundle skip the version gate by design,
+/// so glass will still try to launch it.
+fn sway_check(path: &Path, answer: &VersionAnswer) -> Check {
+    let at = path.display();
     match answer {
-        VersionAnswer::Answered(v) if !v.trim().is_empty() => v.trim().to_string(),
-        VersionAnswer::Answered(_) | VersionAnswer::DidNotRun => "sway (version unknown)".into(),
-        VersionAnswer::TimedOut => {
-            format!("sway (no --version answer within {VERSION_PROBE_BUDGET:?})")
+        VersionAnswer::Answered(v) if !v.trim().is_empty() => Check::new(
+            "sway >=1.12",
+            CheckStatus::Ok,
+            format!("{} at {at}", v.trim()),
+        ),
+        VersionAnswer::Answered(_) => Check::new(
+            "sway >=1.12",
+            CheckStatus::Warn,
+            format!("{at} ran but reported no version"),
+        )
+        .with_remedy(CHECK_THAT_SWAY),
+        VersionAnswer::TimedOut(budget) => Check::new(
+            "sway >=1.12",
+            CheckStatus::Warn,
+            format!("{at} did not answer `--version` within {budget:?}"),
+        )
+        .with_remedy(CHECK_THAT_SWAY),
+        VersionAnswer::NoReply(why) => {
+            Check::new("sway >=1.12", CheckStatus::Warn, format!("{at}: {why}"))
+                .with_remedy(CHECK_THAT_SWAY)
         }
     }
 }
@@ -180,15 +198,19 @@ fn probe_sway(sway: &Path) -> Result<(), String> {
 mod tests {
     use super::*;
 
+    /// A resolved sway that answered, trimmed of the newline its `--version` ends with.
     #[test]
     fn sway_found_is_ok_with_version() {
-        let cs = wayland_checks(
-            &Ok((PathBuf::from("/usr/bin/sway"), "sway version 1.12".into())),
-            true,
-            None,
-        );
+        let cs = wayland_checks(&answered("sway version 1.12\n"), true, None);
         assert_eq!(cs[0].status, CheckStatus::Ok);
-        assert!(cs[0].detail.contains("1.12"));
+        assert_eq!(cs[0].detail, "sway version 1.12 at /usr/bin/sway");
+    }
+
+    fn answered(v: &str) -> Result<(PathBuf, VersionAnswer), NoSway> {
+        Ok((
+            PathBuf::from("/usr/bin/sway"),
+            VersionAnswer::Answered(v.into()),
+        ))
     }
 
     #[test]
@@ -225,7 +247,7 @@ mod tests {
 
     #[test]
     fn missing_gl_is_a_warning_with_remedy() {
-        let cs = wayland_checks(&Ok((PathBuf::from("/x"), "1.12".into())), false, None);
+        let cs = wayland_checks(&answered("1.12"), false, None);
         let gl = cs.iter().find(|c| c.name == "software GL (Mesa)").unwrap();
         assert_eq!(gl.status, CheckStatus::Warn);
         assert!(gl.remedy.as_deref().unwrap().contains("libgl1-mesa-dri"));
@@ -276,70 +298,59 @@ mod tests {
     #[test]
     #[ignore = "starts a real compositor or X server; needs sway, Mesa, Xwayland or Xvfb"]
     fn discover_sway_reports_the_real_binary_and_its_version() {
-        let (path, ver) = discover_sway().expect("this box has a discoverable sway");
+        let (path, answer) = discover_sway().expect("this box has a discoverable sway");
         assert!(
             glass_exec_unix::is_executable_file(&path),
             "discovery must yield something glass can spawn: {}",
             path.display()
         );
+        let VersionAnswer::Answered(ver) = &answer else {
+            panic!("a real sway answers --version: {answer:?}");
+        };
         assert!(ver.contains("sway version"), "{ver}");
     }
 
+    /// glass#392: a binary that never answers used to hang doctor here, and now gets no tick —
+    /// the check is named `sway >=1.12` and nothing established that.
     #[test]
-    #[ignore = "starts a real compositor or X server; needs sway, Mesa, Xwayland or Xvfb"]
-    fn sway_version_reads_the_binarys_own_output() {
-        let (path, _) = discover_sway().expect("sway");
-        let ver = describe_version(ask_sway_version(&path, VERSION_PROBE_BUDGET));
-        assert!(ver.contains("sway version"), "{ver}");
-    }
-
-    /// A binary that prints nothing is not a version, and doctor's job is to say what it found.
-    ///
-    /// Not `/bin/true`: GNU coreutils answers `--version` with its own version string.
-    #[test]
-    #[ignore = "starts a real compositor or X server; needs sway, Mesa, Xwayland or Xvfb"]
-    fn a_silent_binary_reports_an_unknown_version_not_an_empty_one() {
-        use std::os::unix::fs::PermissionsExt as _;
-        let dir = tempfile::tempdir().expect("tempdir");
-        let bin = dir.path().join("mute");
-        std::fs::write(&bin, b"#!/bin/sh\nexit 0\n").expect("write");
-        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).expect("chmod");
-        assert_eq!(
-            describe_version(ask_sway_version(&bin, VERSION_PROBE_BUDGET)),
-            "sway (version unknown)"
+    fn a_sway_that_never_answered_is_not_reported_as_a_working_one() {
+        let cs = wayland_checks(
+            &Ok((
+                PathBuf::from("/opt/sway/bin/sway"),
+                VersionAnswer::TimedOut(Duration::from_millis(1500)),
+            )),
+            true,
+            None,
         );
+        assert_eq!(cs[0].status, CheckStatus::Warn);
+        assert!(cs[0].detail.contains("/opt/sway/bin/sway"), "{:?}", cs[0]);
+        // The budget it actually waited, not whatever constant doctor happens to import.
+        assert!(cs[0].detail.contains("1.5s"), "{:?}", cs[0]);
+        assert_eq!(cs[0].remedy.as_deref(), Some(CHECK_THAT_SWAY));
     }
 
+    /// Ran and said nothing, and could not be asked at all — neither is a proven >=1.12, and the
+    /// second carries the runner's reason.
     #[test]
-    fn an_answer_is_reported_trimmed() {
-        assert_eq!(
-            describe_version(VersionAnswer::Answered("sway version 1.12-abc\n".into())),
-            "sway version 1.12-abc"
-        );
-    }
-
-    /// glass#392: a binary that never answers used to hang doctor here. Reported as its own fault,
-    /// not as the silence of a binary that ran — a hang is what the user came to doctor about.
-    #[test]
-    fn a_probe_that_timed_out_says_so_rather_than_reporting_an_unknown_version() {
-        let said = describe_version(VersionAnswer::TimedOut);
-        assert!(said.contains("no --version answer"), "{said}");
+    fn a_sway_that_gave_no_version_is_not_reported_as_a_working_one() {
+        let silent = wayland_checks(&answered(" \n"), true, None);
+        assert_eq!(silent[0].status, CheckStatus::Warn);
         assert!(
-            said.contains(&format!("{VERSION_PROBE_BUDGET:?}")),
-            "{said}"
+            silent[0].detail.contains("reported no version"),
+            "{:?}",
+            silent[0]
         );
-    }
 
-    #[test]
-    fn a_binary_that_said_nothing_or_never_ran_has_an_unknown_version() {
-        assert_eq!(
-            describe_version(VersionAnswer::Answered(String::new())),
-            "sway (version unknown)"
+        let cs = wayland_checks(
+            &Ok((
+                PathBuf::from("/usr/bin/sway"),
+                VersionAnswer::NoReply("failed to start: Exec format error".into()),
+            )),
+            true,
+            None,
         );
-        assert_eq!(
-            describe_version(VersionAnswer::DidNotRun),
-            "sway (version unknown)"
-        );
+        assert_eq!(cs[0].status, CheckStatus::Warn);
+        assert!(cs[0].detail.contains("Exec format error"), "{:?}", cs[0]);
     }
 
     #[test]
@@ -397,11 +408,7 @@ mod tests {
 
     #[test]
     fn deep_spawn_failure_is_reported() {
-        let cs = wayland_checks(
-            &Ok((PathBuf::from("/x"), "1.12".into())),
-            true,
-            Some(Err("no come up".into())),
-        );
+        let cs = wayland_checks(&answered("1.12"), true, Some(Err("no come up".into())));
         let deep = cs.iter().find(|c| c.name == "sway spawn (deep)").unwrap();
         assert_eq!(deep.status, CheckStatus::Fail);
         assert_eq!(deep.detail, "no come up");

--- a/crates/glass-wayland/src/doctor.rs
+++ b/crates/glass-wayland/src/doctor.rs
@@ -9,7 +9,9 @@ use std::time::Duration;
 use glass_core::{AppSpec, Check, CheckStatus};
 
 use crate::command::{build_sway_command, sway_config};
-use crate::platform::{NoSway, resolve_sway_verdict};
+use crate::platform::{
+    NoSway, VERSION_PROBE_BUDGET, VersionAnswer, ask_sway_version, resolve_sway_verdict,
+};
 use crate::swayipc::Ipc;
 
 /// Probe the Wayland backend's environment. `deep` additionally spawns and tears down
@@ -75,18 +77,23 @@ fn wayland_checks(
 /// Resolve sway (path) and read its version string for display.
 fn discover_sway() -> Result<(PathBuf, String), NoSway> {
     let path = resolve_sway_verdict()?;
-    let ver = sway_version(&path);
+    let ver = describe_version(ask_sway_version(&path, VERSION_PROBE_BUDGET));
     Ok((path, ver))
 }
 
-fn sway_version(path: &Path) -> String {
-    std::process::Command::new(path)
-        .arg("--version")
-        .output()
-        .ok()
-        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "sway (version unknown)".into())
+/// How doctor names what the version probe got back.
+///
+/// A binary that answers nothing and one that answers nothing *in time* are different faults:
+/// only the second explains a launch that also gets no answer. An override or a bundled sway
+/// reaches here unprobed, so doctor is where a hung one is first seen.
+fn describe_version(answer: VersionAnswer) -> String {
+    match answer {
+        VersionAnswer::Answered(v) if !v.trim().is_empty() => v.trim().to_string(),
+        VersionAnswer::Answered(_) | VersionAnswer::DidNotRun => "sway (version unknown)".into(),
+        VersionAnswer::TimedOut => {
+            format!("sway (no --version answer within {VERSION_PROBE_BUDGET:?})")
+        }
+    }
 }
 
 /// Where a distro puts libEGL.
@@ -282,7 +289,8 @@ mod tests {
     #[ignore = "starts a real compositor or X server; needs sway, Mesa, Xwayland or Xvfb"]
     fn sway_version_reads_the_binarys_own_output() {
         let (path, _) = discover_sway().expect("sway");
-        assert!(sway_version(&path).contains("sway version"));
+        let ver = describe_version(ask_sway_version(&path, VERSION_PROBE_BUDGET));
+        assert!(ver.contains("sway version"), "{ver}");
     }
 
     /// A binary that prints nothing is not a version, and doctor's job is to say what it found.
@@ -296,7 +304,42 @@ mod tests {
         let bin = dir.path().join("mute");
         std::fs::write(&bin, b"#!/bin/sh\nexit 0\n").expect("write");
         std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).expect("chmod");
-        assert_eq!(sway_version(&bin), "sway (version unknown)");
+        assert_eq!(
+            describe_version(ask_sway_version(&bin, VERSION_PROBE_BUDGET)),
+            "sway (version unknown)"
+        );
+    }
+
+    #[test]
+    fn an_answer_is_reported_trimmed() {
+        assert_eq!(
+            describe_version(VersionAnswer::Answered("sway version 1.12-abc\n".into())),
+            "sway version 1.12-abc"
+        );
+    }
+
+    /// glass#392: a binary that never answers used to hang doctor here. Reported as its own fault,
+    /// not as the silence of a binary that ran — a hang is what the user came to doctor about.
+    #[test]
+    fn a_probe_that_timed_out_says_so_rather_than_reporting_an_unknown_version() {
+        let said = describe_version(VersionAnswer::TimedOut);
+        assert!(said.contains("no --version answer"), "{said}");
+        assert!(
+            said.contains(&format!("{VERSION_PROBE_BUDGET:?}")),
+            "{said}"
+        );
+    }
+
+    #[test]
+    fn a_binary_that_said_nothing_or_never_ran_has_an_unknown_version() {
+        assert_eq!(
+            describe_version(VersionAnswer::Answered(String::new())),
+            "sway (version unknown)"
+        );
+        assert_eq!(
+            describe_version(VersionAnswer::DidNotRun),
+            "sway (version unknown)"
+        );
     }
 
     #[test]

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -228,12 +228,22 @@ pub(crate) struct NoSway {
 const BUILD_A_SWAY: &str = "build it with https://github.com/fixed-width/sway-build \
      (./build.sh && ./build.sh install), or install a distro sway >=1.12";
 const MAKE_IT_RUNNABLE: &str = "chmod +x it, or point GLASS_SWAY at a runnable sway >=1.12";
+pub(crate) const CHECK_THAT_SWAY: &str =
+    "check that binary, or point GLASS_SWAY at a working sway >=1.12";
 
 impl NoSway {
     fn nothing_qualifies() -> Self {
         NoSway {
             cause: "no sway >=1.12 found".into(),
             remedy: BUILD_A_SWAY,
+        }
+    }
+
+    /// A sway that is installed and runnable but told glass nothing.
+    fn silent(path: &Path, why: &str) -> Self {
+        NoSway {
+            cause: format!("{}: {why}", path.display()),
+            remedy: CHECK_THAT_SWAY,
         }
     }
 
@@ -265,9 +275,10 @@ pub(crate) fn resolve_sway_verdict() -> std::result::Result<PathBuf, NoSway> {
     // Inlined rather than wrapped: a `fn` that only splits PATH and delegates has a
     // constant-return mutation nothing can kill on a host where the true answer is that constant
     // — here, any machine with no sway on PATH.
-    if let Some(p) = std::env::var_os("PATH")
-        .and_then(|path| sway_in_dirs(std::env::split_paths(&path), VERSION_PROBE_BUDGET))
-    {
+    let walk = std::env::var_os("PATH").map_or_else(PathWalk::default, |path| {
+        sway_in_dirs(std::env::split_paths(&path), VERSION_PROBE_BUDGET)
+    });
+    if let Some(p) = walk.found {
         return Ok(p);
     }
     let data = std::env::var_os("XDG_DATA_HOME")
@@ -282,7 +293,9 @@ pub(crate) fn resolve_sway_verdict() -> std::result::Result<PathBuf, NoSway> {
             "{} is not executable",
             p.display()
         ))),
-        Resolved::Absent => Err(NoSway::nothing_qualifies()),
+        // A silent candidate on PATH outranks "nothing qualifies" — telling the user to build one
+        // sends them past the sway they have.
+        Resolved::Absent => Err(walk.silent.unwrap_or_else(NoSway::nothing_qualifies)),
     }
 }
 
@@ -329,35 +342,57 @@ fn sway_override(
     })
 }
 
-/// How long a candidate gets to answer `--version`.
+/// How long ONE candidate gets to answer `--version`.
 ///
-/// Printing a version string is not work; the budget only has to cover an `exec` on a loaded
-/// host. Unbounded, a `sway` that never exits hung `glass_start` and `glass doctor` forever.
+/// The budget only has to cover an `exec` on a loaded host. Unbounded, a `sway` that never exits
+/// hung `glass_start` and `glass doctor` forever.
+///
+/// Per candidate, not one deadline across the walk: a first candidate that spent a shared deadline
+/// would leave a good sway further along `PATH` unprobed — the failure glass#374 fixed.
 pub(crate) const VERSION_PROBE_BUDGET: Duration = Duration::from_secs(5);
 
 /// What a candidate said when asked for its version.
+///
+/// Not `Option<String>`: a binary that answered nothing, one that never answered, and one glass
+/// could not run at all send a reader to three different remedies.
 #[derive(Debug, PartialEq, Eq)]
+#[must_use]
 pub(crate) enum VersionAnswer {
-    /// It ran and exited; whatever it wrote to stdout.
+    /// It ran and exited; whatever it wrote to stdout, untrimmed and possibly empty. Empty or
+    /// unparseable still counts as an answer — see [`sway_in_dirs`].
     Answered(String),
-    /// The spawn failed, so the candidate never ran at all.
-    DidNotRun,
-    /// Still running when the budget ran out; it was killed.
-    TimedOut,
+    /// Nothing came back within the budget it carries, so the child was sent SIGKILL. Only the
+    /// direct child: anything it forked before wedging outlives the probe.
+    TimedOut(Duration),
+    /// No answer to be had, and why. The candidate may still have run — one that exited leaving
+    /// something it started holding its output pipe lands here too.
+    NoReply(String),
 }
 
 /// Ask `sway` for its version, under a time bound.
 ///
-/// Shared by discovery and doctor so the two cannot disagree about how long a binary may take to
-/// answer, or about what a silence means.
+/// Shared by discovery and doctor so the two classify a silence the same way. Both production
+/// callers pass [`VERSION_PROBE_BUDGET`]; the parameter is for tests.
 pub(crate) fn ask_sway_version(sway: &Path, budget: Duration) -> VersionAnswer {
     let mut cmd = std::process::Command::new(sway);
     cmd.arg("--version");
     match glass_core::run_bounded(&mut cmd, budget, "sway:--version") {
         Ok(out) => VersionAnswer::Answered(String::from_utf8_lossy(&out.stdout).into_owned()),
-        Err(e) if e.bound() == Some(glass_core::BoundKind::TimedOut) => VersionAnswer::TimedOut,
-        Err(_) => VersionAnswer::DidNotRun,
+        Err(e) if e.bound() == Some(glass_core::BoundKind::TimedOut) => {
+            VersionAnswer::TimedOut(budget)
+        }
+        Err(e) => VersionAnswer::NoReply(e.to_string()),
     }
+}
+
+/// The outcome of walking `PATH`: the sway to use, and the first candidate that was there and
+/// gave no answer.
+///
+/// The second field is kept so a walk that ends empty can name it rather than report no sway.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct PathWalk {
+    found: Option<PathBuf>,
+    silent: Option<NoSway>,
 }
 
 /// The first `sway` in `dirs` whose `--version` reports >= 1.12.
@@ -366,24 +401,36 @@ pub(crate) fn ask_sway_version(sway: &Path, budget: Duration) -> VersionAnswer {
 /// is too old or unreadable — that means the bundle, never a different sway further along, since
 /// `PATH` order is a precedence the user expressed.
 ///
-/// A candidate that never ran expressed nothing, so it is stepped over: no execute permission, a
-/// spawn that failed outright (`ENOEXEC` for a file that is not a binary, `ETXTBSY` while
-/// something else holds it open for writing), or one that outstayed `budget`.
-fn sway_in_dirs(dirs: impl Iterator<Item = PathBuf>, budget: Duration) -> Option<PathBuf> {
+/// A candidate that gave no answer expressed nothing, so it is stepped over: no execute
+/// permission, a spawn that failed outright (`ENOEXEC` for a file that is not a binary, `ETXTBSY`
+/// while something else holds it open for writing), or a wait that outstayed `budget`.
+fn sway_in_dirs(dirs: impl Iterator<Item = PathBuf>, budget: Duration) -> PathWalk {
+    let mut walk = PathWalk::default();
     for dir in dirs {
         let cand = dir.join("sway");
         if !is_executable_file(&cand) {
             continue;
         }
-        let VersionAnswer::Answered(ver) = ask_sway_version(&cand, budget) else {
-            continue;
+        let why = match ask_sway_version(&cand, budget) {
+            VersionAnswer::Answered(ver) => {
+                walk.found = match parse_sway_version(&ver) {
+                    Some((maj, min)) if (maj, min) >= (1, 12) => Some(cand),
+                    _ => None, // answered, just not usably -> the bundle, not a later sway
+                };
+                return walk;
+            }
+            VersionAnswer::TimedOut(budget) => {
+                format!("did not answer `--version` within {budget:?}")
+            }
+            VersionAnswer::NoReply(why) => why,
         };
-        return match parse_sway_version(&ver) {
-            Some((maj, min)) if (maj, min) >= (1, 12) => Some(cand),
-            _ => None, // answered, just not usably -> the bundle, not a later sway
-        };
+        // Logged even when a later candidate answers — the step-over costs a whole budget on
+        // every launch and is otherwise invisible.
+        eprintln!("glass-wayland: skipping {}: {why}", cand.display());
+        walk.silent
+            .get_or_insert_with(|| NoSway::silent(&cand, &why));
     }
-    None
+    walk
 }
 
 /// Parse `"sway version 1.12-abc (...)"` -> `(1, 12)`.
@@ -1711,22 +1758,46 @@ mod pure_tests {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
-    /// A directory holding a `sway` that answers `--version` with `reply`.
-    fn fake_sway(reply: &str) -> tempfile::TempDir {
-        use std::os::unix::fs::PermissionsExt as _;
+    /// A directory holding an executable `sway` running `script`.
+    ///
+    /// Every fixture refuses any argument but `--version`: a probe that stopped passing it would
+    /// otherwise fail first on a user's machine, where the walk would *launch a compositor* per
+    /// candidate and then report no sway installed.
+    fn sway_script(script: &str) -> tempfile::TempDir {
         let dir = tempfile::tempdir().expect("tempdir");
         let bin = dir.path().join("sway");
-        std::fs::write(&bin, format!("#!/bin/sh\necho '{reply}'\n")).expect("write");
+        let guard = "[ \"$1\" = --version ] || exit 3\n";
+        std::fs::write(&bin, format!("#!/bin/sh\n{guard}{script}")).expect("write");
         std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).expect("chmod");
         dir
     }
 
-    /// How long the hung fixture lives if nothing kills it. Long enough that a lost bound reads as
-    /// a hang against [`HUNG_PROBE_BUDGET`], short enough that such a test fails rather than
-    /// wedging the suite.
-    const HUNG_SWAY_LIFETIME: Duration = Duration::from_secs(30);
-    /// The budget the hung-candidate tests probe under. Only has to exceed a `sh` startup.
+    /// A directory holding a `sway` that answers `--version` with `reply`.
+    fn fake_sway(reply: &str) -> tempfile::TempDir {
+        sway_script(&format!("echo '{reply}'\n"))
+    }
+
+    /// A directory holding an empty `sway` at `mode`. At 0o644 it is a candidate glass may not
+    /// execute; at 0o755 one that clears the permission check and then fails to exec (`ENOEXEC`)
+    /// — the deterministic twin of the `ETXTBSY` a concurrent write raises.
+    fn empty_sway(mode: u32) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bin = dir.path().join("sway");
+        std::fs::write(&bin, b"").expect("write");
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(mode)).expect("chmod");
+        dir
+    }
+
+    /// How long the hung fixture lives if nothing kills it, in whole seconds: a sub-second
+    /// `Duration` here would truncate to `sleep 0`, leaving the timeout tests no hang to bound.
+    const HUNG_SWAY_SECS: u64 = 30;
+    /// The budget the hung-candidate tests probe under. Wide enough for `sh` to start and record
+    /// its pid, narrow enough that [`VERSION_PROBE_BUDGET`] silently replacing it overshoots the
+    /// ceiling those tests assert.
     const HUNG_PROBE_BUDGET: Duration = Duration::from_millis(300);
+    /// The budget for the walk tests, which probe a *good* fixture under it too — so it has to
+    /// cover a whole successful `sh` run on a loaded host, not just the hung candidate's poll.
+    const WALK_PROBE_BUDGET: Duration = Duration::from_secs(2);
 
     /// A directory holding a `sway` that never answers `--version`, and the file it writes its own
     /// pid to.
@@ -1734,31 +1805,32 @@ mod pure_tests {
     /// `exec`, so that pid stays the sleeping process: a shell that forked its sleep would hand
     /// the probe a child whose death proves nothing about the process actually left behind.
     fn hung_sway() -> (tempfile::TempDir, PathBuf) {
-        use std::os::unix::fs::PermissionsExt as _;
-        let dir = tempfile::tempdir().expect("tempdir");
-        let bin = dir.path().join("sway");
+        let dir = sway_script("");
         let pidfile = dir.path().join("pid");
+        let bin = dir.path().join("sway");
+        let guard = "[ \"$1\" = --version ] || exit 3\n";
         std::fs::write(
             &bin,
             format!(
-                "#!/bin/sh\necho $$ > {}\nexec sleep {}\n",
-                pidfile.display(),
-                HUNG_SWAY_LIFETIME.as_secs()
+                "#!/bin/sh\n{guard}echo $$ > {}\nexec sleep {HUNG_SWAY_SECS}\n",
+                pidfile.display()
             ),
         )
         .expect("write");
-        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).expect("chmod");
         (dir, pidfile)
+    }
+
+    /// [`sway_in_dirs`] over `dirs` at the budget the product uses. A test about a candidate that
+    /// never answers passes its own, tighter budget to `sway_in_dirs` directly.
+    fn sway_in(dirs: &[&Path]) -> PathWalk {
+        sway_in_dirs(dirs.iter().map(|d| d.to_path_buf()), VERSION_PROBE_BUDGET)
     }
 
     #[test]
     fn a_recent_sway_on_the_path_is_used() {
         let _guard = one_spawner_at_a_time();
         let dir = fake_sway("sway version 1.12-abc (Jun 3 2026)");
-        assert_eq!(
-            sway_in_dirs([dir.path().to_path_buf()].into_iter(), VERSION_PROBE_BUDGET),
-            Some(dir.path().join("sway"))
-        );
+        assert_eq!(sway_in(&[dir.path()]).found, Some(dir.path().join("sway")));
     }
 
     /// Too old, or a version this cannot read, means fall through to the bundle — glass drives
@@ -1768,24 +1840,14 @@ mod pure_tests {
         let _guard = one_spawner_at_a_time();
         for reply in ["sway version 1.9", "sway version 1.11-x", "wat"] {
             let dir = fake_sway(reply);
-            assert_eq!(
-                sway_in_dirs([dir.path().to_path_buf()].into_iter(), VERSION_PROBE_BUDGET),
-                None,
-                "{reply:?}"
-            );
+            assert_eq!(sway_in(&[dir.path()]).found, None, "{reply:?}");
         }
     }
 
     #[test]
     fn a_path_with_no_sway_on_it_finds_nothing() {
         let empty = tempfile::tempdir().expect("tempdir");
-        assert_eq!(
-            sway_in_dirs(
-                [empty.path().to_path_buf()].into_iter(),
-                VERSION_PROBE_BUDGET
-            ),
-            None
-        );
+        assert_eq!(sway_in(&[empty.path()]), PathWalk::default());
     }
 
     /// glass#392: the probe ran `--version` with no bound at all, so a `sway` that never exits
@@ -1796,20 +1858,37 @@ mod pure_tests {
         let (hung, _pidfile) = hung_sway();
         let good = fake_sway("sway version 1.12-abc (Jun 3 2026)");
         let started = Instant::now();
-        let found = sway_in_dirs(
+        let walk = sway_in_dirs(
             [hung.path().to_path_buf(), good.path().to_path_buf()].into_iter(),
-            HUNG_PROBE_BUDGET,
+            WALK_PROBE_BUDGET,
         );
         assert_eq!(
-            found,
+            walk.found,
             Some(good.path().join("sway")),
             "a candidate that never answered must be stepped over, not end the walk"
         );
         assert!(
-            started.elapsed() < HUNG_SWAY_LIFETIME / 3,
+            started.elapsed() < Duration::from_secs(HUNG_SWAY_SECS) / 3,
             "the walk waited out the whole candidate: {:?}",
             started.elapsed()
         );
+    }
+
+    /// A walk that ends empty must name the sway the user has: `nothing_qualifies` sends them
+    /// past it to build another.
+    #[test]
+    fn a_walk_that_finds_only_a_silent_sway_names_it() {
+        let _guard = one_spawner_at_a_time();
+        let (hung, _pidfile) = hung_sway();
+        let walk = sway_in_dirs([hung.path().to_path_buf()].into_iter(), HUNG_PROBE_BUDGET);
+        assert_eq!(walk.found, None);
+        let no = walk.silent.expect("the hung candidate must be recorded");
+        assert!(
+            no.cause.contains(&hung.path().display().to_string()),
+            "{no:?}"
+        );
+        assert!(no.cause.contains("did not answer"), "{no:?}");
+        assert_eq!(no.remedy, CHECK_THAT_SWAY);
     }
 
     /// A bound that returns while leaving the process behind trades one hang for a leak: every
@@ -1818,9 +1897,17 @@ mod pure_tests {
     fn a_probe_that_times_out_kills_the_candidate() {
         let _guard = one_spawner_at_a_time();
         let (hung, pidfile) = hung_sway();
+        let started = Instant::now();
         assert_eq!(
             ask_sway_version(&hung.path().join("sway"), HUNG_PROBE_BUDGET),
-            VersionAnswer::TimedOut
+            VersionAnswer::TimedOut(HUNG_PROBE_BUDGET)
+        );
+        // Against the budget passed: ignoring the parameter for VERSION_PROBE_BUDGET would still
+        // return, just far later.
+        assert!(
+            started.elapsed() < HUNG_PROBE_BUDGET * 4,
+            "the probe outstayed the budget it was given: {:?}",
+            started.elapsed()
         );
         let pid: u32 = std::fs::read_to_string(&pidfile)
             .expect("the fixture records its pid before it sleeps")
@@ -1833,8 +1920,8 @@ mod pure_tests {
         );
     }
 
-    /// The three answers doctor tells apart. A spawn failure reported as an empty answer would
-    /// have doctor say a binary ran and said nothing.
+    /// Ran-and-said-nothing kept apart from could-not-be-run: the walk ends on the first, an
+    /// answer even when empty, and steps over the second.
     #[test]
     fn a_candidate_that_runs_is_distinguished_from_one_that_cannot() {
         let _guard = one_spawner_at_a_time();
@@ -1843,14 +1930,36 @@ mod pure_tests {
             ask_sway_version(&good.path().join("sway"), VERSION_PROBE_BUDGET),
             VersionAnswer::Answered("sway version 1.12-abc (Jun 3 2026)\n".into())
         );
-        // An empty file at 0o755 clears the permission check and then fails to exec (`ENOEXEC`).
-        let dir = tempfile::tempdir().expect("tempdir");
-        let bin = dir.path().join("sway");
-        std::fs::write(&bin, b"").expect("write");
-        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        // Not `/bin/true`: GNU coreutils answers `--version` with its own version string.
+        let silent = sway_script("exit 0\n");
         assert_eq!(
-            ask_sway_version(&bin, VERSION_PROBE_BUDGET),
-            VersionAnswer::DidNotRun
+            ask_sway_version(&silent.path().join("sway"), VERSION_PROBE_BUDGET),
+            VersionAnswer::Answered(String::new())
+        );
+        let cannot_exec = empty_sway(0o755);
+        assert!(
+            matches!(
+                ask_sway_version(&cannot_exec.path().join("sway"), VERSION_PROBE_BUDGET),
+                VersionAnswer::NoReply(_)
+            ),
+            "a candidate that cannot be exec'd must not read as one that answered"
+        );
+    }
+
+    /// A candidate that exits leaving something it started holding its stdout: glass never reaches
+    /// end-of-file, so it has no answer it may act on.
+    #[test]
+    fn a_candidate_whose_output_is_never_finished_is_not_an_answer() {
+        let _guard = one_spawner_at_a_time();
+        let leaky = sway_script(&format!(
+            "echo 'sway version 1.12-abc'\nsleep {HUNG_SWAY_SECS} &\n"
+        ));
+        assert!(
+            matches!(
+                ask_sway_version(&leaky.path().join("sway"), VERSION_PROBE_BUDGET),
+                VersionAnswer::NoReply(_)
+            ),
+            "output glass could not finish reading is not a version it may act on"
         );
     }
 
@@ -1886,10 +1995,8 @@ mod pure_tests {
     /// said "is not an executable file".
     #[test]
     fn an_override_naming_a_non_executable_file_is_an_error() {
-        let dir = tempfile::tempdir().expect("tempdir");
+        let dir = empty_sway(0o644);
         let bin = dir.path().join("sway");
-        std::fs::write(&bin, b"").expect("write");
-        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o644)).expect("chmod");
         let err = sway_override(Some(bin.clone().into_os_string()))
             .expect("a choice was made")
             .expect_err("a file that cannot be run must not be trusted");
@@ -1902,16 +2009,10 @@ mod pure_tests {
     #[test]
     fn a_non_executable_sway_early_on_the_path_does_not_hide_a_later_one() {
         let _guard = one_spawner_at_a_time();
-        let broken = tempfile::tempdir().expect("tempdir");
-        let bin = broken.path().join("sway");
-        std::fs::write(&bin, b"").expect("write");
-        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o644)).expect("chmod");
+        let broken = empty_sway(0o644);
         let good = fake_sway("sway version 1.12-abc (Jun 3 2026)");
         assert_eq!(
-            sway_in_dirs(
-                [broken.path().to_path_buf(), good.path().to_path_buf()].into_iter(),
-                VERSION_PROBE_BUDGET,
-            ),
+            sway_in(&[broken.path(), good.path()]).found,
             Some(good.path().join("sway")),
             "a sway that cannot be run must be skipped, not treated as the answer"
         );
@@ -1923,20 +2024,15 @@ mod pure_tests {
     #[test]
     fn a_sway_that_fails_to_spawn_does_not_hide_a_later_one() {
         let _guard = one_spawner_at_a_time();
-        let unspawnable = tempfile::tempdir().expect("tempdir");
+        let unspawnable = empty_sway(0o755);
         let bin = unspawnable.path().join("sway");
-        std::fs::write(&bin, b"").expect("write");
-        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).expect("chmod");
         assert!(
             is_executable_file(&bin),
             "the fixture must clear the permission check, or this pins the wrong branch"
         );
         let good = fake_sway("sway version 1.12-abc (Jun 3 2026)");
         assert_eq!(
-            sway_in_dirs(
-                [unspawnable.path().to_path_buf(), good.path().to_path_buf()].into_iter(),
-                VERSION_PROBE_BUDGET,
-            ),
+            sway_in(&[unspawnable.path(), good.path()]).found,
             Some(good.path().join("sway")),
             "a candidate that never ran must be stepped over, not end the walk"
         );

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -265,8 +265,8 @@ pub(crate) fn resolve_sway_verdict() -> std::result::Result<PathBuf, NoSway> {
     // Inlined rather than wrapped: a `fn` that only splits PATH and delegates has a
     // constant-return mutation nothing can kill on a host where the true answer is that constant
     // — here, any machine with no sway on PATH.
-    if let Some(p) =
-        std::env::var_os("PATH").and_then(|path| sway_in_dirs(std::env::split_paths(&path)))
+    if let Some(p) = std::env::var_os("PATH")
+        .and_then(|path| sway_in_dirs(std::env::split_paths(&path), VERSION_PROBE_BUDGET))
     {
         return Ok(p);
     }
@@ -329,25 +329,55 @@ fn sway_override(
     })
 }
 
+/// How long a candidate gets to answer `--version`.
+///
+/// Printing a version string is not work; the budget only has to cover an `exec` on a loaded
+/// host. Unbounded, a `sway` that never exits hung `glass_start` and `glass doctor` forever.
+pub(crate) const VERSION_PROBE_BUDGET: Duration = Duration::from_secs(5);
+
+/// What a candidate said when asked for its version.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum VersionAnswer {
+    /// It ran and exited; whatever it wrote to stdout.
+    Answered(String),
+    /// The spawn failed, so the candidate never ran at all.
+    DidNotRun,
+    /// Still running when the budget ran out; it was killed.
+    TimedOut,
+}
+
+/// Ask `sway` for its version, under a time bound.
+///
+/// Shared by discovery and doctor so the two cannot disagree about how long a binary may take to
+/// answer, or about what a silence means.
+pub(crate) fn ask_sway_version(sway: &Path, budget: Duration) -> VersionAnswer {
+    let mut cmd = std::process::Command::new(sway);
+    cmd.arg("--version");
+    match glass_core::run_bounded(&mut cmd, budget, "sway:--version") {
+        Ok(out) => VersionAnswer::Answered(String::from_utf8_lossy(&out.stdout).into_owned()),
+        Err(e) if e.bound() == Some(glass_core::BoundKind::TimedOut) => VersionAnswer::TimedOut,
+        Err(_) => VersionAnswer::DidNotRun,
+    }
+}
+
 /// The first `sway` in `dirs` whose `--version` reports >= 1.12.
 ///
 /// Only an answer ends the walk. A candidate that ran decides the outcome even when the version
 /// is too old or unreadable — that means the bundle, never a different sway further along, since
 /// `PATH` order is a precedence the user expressed.
 ///
-/// A candidate that never ran expressed nothing, so it is stepped over: no execute permission, or
-/// a spawn that failed outright (`ENOEXEC` for a file that is not a binary, `ETXTBSY` while
-/// something else holds it open for writing).
-fn sway_in_dirs(dirs: impl Iterator<Item = PathBuf>) -> Option<PathBuf> {
+/// A candidate that never ran expressed nothing, so it is stepped over: no execute permission, a
+/// spawn that failed outright (`ENOEXEC` for a file that is not a binary, `ETXTBSY` while
+/// something else holds it open for writing), or one that outstayed `budget`.
+fn sway_in_dirs(dirs: impl Iterator<Item = PathBuf>, budget: Duration) -> Option<PathBuf> {
     for dir in dirs {
         let cand = dir.join("sway");
         if !is_executable_file(&cand) {
             continue;
         }
-        let Ok(out) = std::process::Command::new(&cand).arg("--version").output() else {
+        let VersionAnswer::Answered(ver) = ask_sway_version(&cand, budget) else {
             continue;
         };
-        let ver = String::from_utf8_lossy(&out.stdout);
         return match parse_sway_version(&ver) {
             Some((maj, min)) if (maj, min) >= (1, 12) => Some(cand),
             _ => None, // answered, just not usably -> the bundle, not a later sway
@@ -1691,12 +1721,42 @@ mod pure_tests {
         dir
     }
 
+    /// How long the hung fixture lives if nothing kills it. Long enough that a lost bound reads as
+    /// a hang against [`HUNG_PROBE_BUDGET`], short enough that such a test fails rather than
+    /// wedging the suite.
+    const HUNG_SWAY_LIFETIME: Duration = Duration::from_secs(30);
+    /// The budget the hung-candidate tests probe under. Only has to exceed a `sh` startup.
+    const HUNG_PROBE_BUDGET: Duration = Duration::from_millis(300);
+
+    /// A directory holding a `sway` that never answers `--version`, and the file it writes its own
+    /// pid to.
+    ///
+    /// `exec`, so that pid stays the sleeping process: a shell that forked its sleep would hand
+    /// the probe a child whose death proves nothing about the process actually left behind.
+    fn hung_sway() -> (tempfile::TempDir, PathBuf) {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bin = dir.path().join("sway");
+        let pidfile = dir.path().join("pid");
+        std::fs::write(
+            &bin,
+            format!(
+                "#!/bin/sh\necho $$ > {}\nexec sleep {}\n",
+                pidfile.display(),
+                HUNG_SWAY_LIFETIME.as_secs()
+            ),
+        )
+        .expect("write");
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        (dir, pidfile)
+    }
+
     #[test]
     fn a_recent_sway_on_the_path_is_used() {
         let _guard = one_spawner_at_a_time();
         let dir = fake_sway("sway version 1.12-abc (Jun 3 2026)");
         assert_eq!(
-            sway_in_dirs([dir.path().to_path_buf()].into_iter()),
+            sway_in_dirs([dir.path().to_path_buf()].into_iter(), VERSION_PROBE_BUDGET),
             Some(dir.path().join("sway"))
         );
     }
@@ -1709,7 +1769,7 @@ mod pure_tests {
         for reply in ["sway version 1.9", "sway version 1.11-x", "wat"] {
             let dir = fake_sway(reply);
             assert_eq!(
-                sway_in_dirs([dir.path().to_path_buf()].into_iter()),
+                sway_in_dirs([dir.path().to_path_buf()].into_iter(), VERSION_PROBE_BUDGET),
                 None,
                 "{reply:?}"
             );
@@ -1719,7 +1779,79 @@ mod pure_tests {
     #[test]
     fn a_path_with_no_sway_on_it_finds_nothing() {
         let empty = tempfile::tempdir().expect("tempdir");
-        assert_eq!(sway_in_dirs([empty.path().to_path_buf()].into_iter()), None);
+        assert_eq!(
+            sway_in_dirs(
+                [empty.path().to_path_buf()].into_iter(),
+                VERSION_PROBE_BUDGET
+            ),
+            None
+        );
+    }
+
+    /// glass#392: the probe ran `--version` with no bound at all, so a `sway` that never exits
+    /// hung `resolve_sway` — and with it `glass_start` — for as long as it stayed up.
+    #[test]
+    fn a_sway_that_never_answers_is_stepped_over_within_its_budget() {
+        let _guard = one_spawner_at_a_time();
+        let (hung, _pidfile) = hung_sway();
+        let good = fake_sway("sway version 1.12-abc (Jun 3 2026)");
+        let started = Instant::now();
+        let found = sway_in_dirs(
+            [hung.path().to_path_buf(), good.path().to_path_buf()].into_iter(),
+            HUNG_PROBE_BUDGET,
+        );
+        assert_eq!(
+            found,
+            Some(good.path().join("sway")),
+            "a candidate that never answered must be stepped over, not end the walk"
+        );
+        assert!(
+            started.elapsed() < HUNG_SWAY_LIFETIME / 3,
+            "the walk waited out the whole candidate: {:?}",
+            started.elapsed()
+        );
+    }
+
+    /// A bound that returns while leaving the process behind trades one hang for a leak: every
+    /// launch would add another wedged candidate to the machine.
+    #[test]
+    fn a_probe_that_times_out_kills_the_candidate() {
+        let _guard = one_spawner_at_a_time();
+        let (hung, pidfile) = hung_sway();
+        assert_eq!(
+            ask_sway_version(&hung.path().join("sway"), HUNG_PROBE_BUDGET),
+            VersionAnswer::TimedOut
+        );
+        let pid: u32 = std::fs::read_to_string(&pidfile)
+            .expect("the fixture records its pid before it sleeps")
+            .trim()
+            .parse()
+            .expect("a pid");
+        assert!(
+            !glass_proc_linux::any_alive(&[pid]),
+            "the probe left its candidate ({pid}) running"
+        );
+    }
+
+    /// The three answers doctor tells apart. A spawn failure reported as an empty answer would
+    /// have doctor say a binary ran and said nothing.
+    #[test]
+    fn a_candidate_that_runs_is_distinguished_from_one_that_cannot() {
+        let _guard = one_spawner_at_a_time();
+        let good = fake_sway("sway version 1.12-abc (Jun 3 2026)");
+        assert_eq!(
+            ask_sway_version(&good.path().join("sway"), VERSION_PROBE_BUDGET),
+            VersionAnswer::Answered("sway version 1.12-abc (Jun 3 2026)\n".into())
+        );
+        // An empty file at 0o755 clears the permission check and then fails to exec (`ENOEXEC`).
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bin = dir.path().join("sway");
+        std::fs::write(&bin, b"").expect("write");
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        assert_eq!(
+            ask_sway_version(&bin, VERSION_PROBE_BUDGET),
+            VersionAnswer::DidNotRun
+        );
     }
 
     /// An unset or empty override is not a choice; discovery runs.
@@ -1776,7 +1908,10 @@ mod pure_tests {
         std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o644)).expect("chmod");
         let good = fake_sway("sway version 1.12-abc (Jun 3 2026)");
         assert_eq!(
-            sway_in_dirs([broken.path().to_path_buf(), good.path().to_path_buf()].into_iter()),
+            sway_in_dirs(
+                [broken.path().to_path_buf(), good.path().to_path_buf()].into_iter(),
+                VERSION_PROBE_BUDGET,
+            ),
             Some(good.path().join("sway")),
             "a sway that cannot be run must be skipped, not treated as the answer"
         );
@@ -1798,7 +1933,10 @@ mod pure_tests {
         );
         let good = fake_sway("sway version 1.12-abc (Jun 3 2026)");
         assert_eq!(
-            sway_in_dirs([unspawnable.path().to_path_buf(), good.path().to_path_buf()].into_iter()),
+            sway_in_dirs(
+                [unspawnable.path().to_path_buf(), good.path().to_path_buf()].into_iter(),
+                VERSION_PROBE_BUDGET,
+            ),
             Some(good.path().join("sway")),
             "a candidate that never ran must be stepped over, not end the walk"
         );

--- a/crates/glass-wayland/tests/sway_probe_bound.rs
+++ b/crates/glass-wayland/tests/sway_probe_bound.rs
@@ -1,0 +1,86 @@
+//! glass#392, doctor's half: `glass doctor` asked a resolved sway for its version and waited
+//! forever if it never answered.
+//!
+//! Nothing in the unit tests reaches this: they pass their own short budget, so
+//! `VERSION_PROBE_BUDGET` could be raised to an hour, or doctor's probe returned to an unbounded
+//! `Command::output()`, with every one of them still green.
+//!
+//! Its own test binary: it mutates the process environment, and the crate's other tests run
+//! sessions whose threads read it while they live.
+
+#![cfg(target_os = "linux")]
+
+use std::ffi::OsString;
+use std::time::{Duration, Instant};
+
+/// How long the fixture lives if nothing kills it, in whole seconds. Far past the probe's budget,
+/// so a lost bound fails this test rather than wedging the suite.
+const FIXTURE_SECS: u64 = 30;
+
+/// Restores the variable's prior value rather than unsetting it — an operator whose sway lives off
+/// the well-known paths runs this suite with `GLASS_SWAY` already set.
+struct EnvGuard(Option<OsString>);
+
+#[allow(unsafe_code)]
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: this binary holds exactly one test, so nothing else in the process is reading
+        // the environment while it is mutated.
+        match self.0.take() {
+            Some(v) => unsafe { std::env::set_var("GLASS_SWAY", v) },
+            None => unsafe { std::env::remove_var("GLASS_SWAY") },
+        }
+    }
+}
+
+#[allow(unsafe_code)]
+fn point_glass_sway_at(path: &std::path::Path) -> EnvGuard {
+    let guard = EnvGuard(std::env::var_os("GLASS_SWAY"));
+    // SAFETY: as above — one test in this binary.
+    unsafe { std::env::set_var("GLASS_SWAY", path) };
+    guard
+}
+
+/// A `sway` that accepts `--version` and then never answers it.
+///
+/// `exec`, so the sleeping process is the one glass spawned — a shell that forked its sleep would
+/// leave the sleeper behind a kill that reached only the shell.
+fn hung_sway(dir: &std::path::Path) -> std::path::PathBuf {
+    use std::os::unix::fs::PermissionsExt as _;
+    let bin = dir.join("sway");
+    std::fs::write(
+        &bin,
+        format!("#!/bin/sh\n[ \"$1\" = --version ] || exit 3\nexec sleep {FIXTURE_SECS}\n"),
+    )
+    .expect("write");
+    std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+    bin
+}
+
+#[test]
+fn doctor_reports_a_sway_that_never_answers_instead_of_waiting_for_it() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // An override is the reachable case: `resolve_sway_verdict` version-probes only its `PATH`
+    // walk, so a `GLASS_SWAY` binary reaches doctor never having been asked.
+    let _guard = point_glass_sway_at(&hung_sway(dir.path()));
+
+    let started = Instant::now();
+    let checks = glass_wayland::doctor::checks(false);
+    assert!(
+        started.elapsed() < Duration::from_secs(FIXTURE_SECS) / 2,
+        "doctor waited out the binary rather than bounding it: {:?}",
+        started.elapsed()
+    );
+
+    let sway = checks
+        .iter()
+        .find(|c| c.name == "sway >=1.12")
+        .expect("doctor reports on sway");
+    assert_ne!(
+        sway.status,
+        glass_core::CheckStatus::Ok,
+        "a sway that never answered is not a proven >=1.12: {sway:?}"
+    );
+    assert!(sway.detail.contains("did not answer"), "{sway:?}");
+    assert!(sway.remedy.is_some(), "{sway:?}");
+}


### PR DESCRIPTION
Sway discovery probed each candidate with `Command::new(cand).arg("--version").output()`, which blocks until the child exits. A `sway` that started and never returned — wedged on a lock, or on a stalled filesystem — hung `resolve_sway`, and with it `glass_start` and `glass doctor`, for as long as it stayed up. The doctor path carried a second copy of the same unbounded probe.

## What changed

Both sites now share one bounded helper over `glass_core::run_bounded`, which drains the pipes on their own threads and kills a child that outstays its budget. Each candidate gets 5 seconds — deliberately per candidate rather than one deadline across the walk, since a first candidate that spent a shared deadline would leave a good sway further along `$PATH` unprobed, the failure #374 fixed.

A timeout joins a spawn failure as "this candidate did not answer": the walk steps over it and carries on. If nothing else qualifies, the error names that binary and what it did, instead of reporting that no sway is installed and sending the user past the one they have.

`glass doctor` no longer ticks `sway >=1.12 ✓` for a binary it could not get a version out of. A `GLASS_SWAY` override and the bundled sway skip the version gate when glass resolves them, so doctor's probe is the first `--version` either is ever put to; the answer now reaches the pure check mapper, which reports `Warn` with a remedy.

## Verification

`cargo test --workspace` (81 targets, 0 failures), `cargo test -p glass-wayland -- --include-ignored` (200 passed, including the 62 sway-backed), `./scripts/test-wayland.sh` (25 passed against a real compositor), clippy `-D warnings` and `cargo fmt --check` clean.

Each behaviour is pinned by a test that fails without its fix, confirmed by reverting the code and watching it go red:

- the bound itself, and the walk stepping over a candidate that never answers
- the kill: the fixture records its own pid and `exec`s its sleep, so the assertion is about the process actually left behind
- the production budget and doctor's half, via a `tests/` binary that drives `doctor::checks` against a binary that never answers — nothing in the unit tests reaches either
- `--version` being passed at all: every fixture refuses any other argument, because a probe that stopped passing it would launch a compositor per candidate on a real machine

Fixes #392
