### PR TITLE
fix(sandbox): bound the bubblewrap user-namespace probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,26 @@ internal refactors, CI, or test-only changes.
   `glass doctor` no longer ticks `sway ✓` for a sway it could not get a version out of — a
   `GLASS_SWAY` override and the bundled sway skip the version check when glass resolves them, so
   doctor's probe is the first `--version` either is ever put to.
+- A `bwrap` that never answers no longer hangs `glass_start` and `glass doctor` either. Before a
+  sandboxed launch — the default — glass runs bubblewrap once to prove this machine can create an
+  unprivileged user namespace, and waited for that answer with no time limit. The check read-only
+  binds the whole root, so one mount that has stopped responding (an unreachable network
+  filesystem) was enough to stop every launch, and the doctor with it. Bubblewrap now gets 10
+  seconds — generous, since the check does real kernel work and a working-but-slow bubblewrap
+  reported as broken would send you to fix a sandbox that is fine. One that has not answered by
+  then is sent `SIGKILL` and the sandbox reported unavailable, so the launch fails rather than
+  hanging, and `glass doctor` reports how long a bubblewrap that did answer took, since a machine
+  near that limit can pass the doctor and fail the next launch.
+- The fix `glass` offers for an unusable sandbox now matches what is actually wrong with it. Every
+  cause got the same sentence — "install bubblewrap / enable unprivileged user namespaces" — so a
+  machine whose bubblewrap is installed and wedged, or installed and refused by AppArmor, was told
+  to install it, and one with no bubblewrap at all could be told to change an AppArmor setting that
+  was not the problem. Each cause now carries its own: install it, enable user namespaces (naming
+  the AppArmor knob when that is what is holding them), or go looking for the unresponsive mount.
+  `glass doctor` and a failed launch give the same answer for the same machine, and both still say
+  how to launch unconfined. A bubblewrap that exits without a word — killed by the OOM killer, say
+  — is reported with its exit status rather than as a refusal to create a namespace it never
+  mentioned.
 - Accessibility now works on Debian/Ubuntu machines that are not x86-64. `glass doctor` said
   `at-spi-bus-launcher present` while every a11y launch on the same machine failed to find it —
   quietly dropping to pixel-only by default, or failing outright with `a11y: true` — because the

--- a/crates/glass-sandbox-linux/src/lib.rs
+++ b/crates/glass-sandbox-linux/src/lib.rs
@@ -10,8 +10,9 @@ use std::ffi::{OsStr, OsString};
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::{Duration, Instant};
 
-use glass_core::{AppSpec, Check, CheckStatus, GlassError, Result, SandboxLevel};
+use glass_core::{AppSpec, BoundKind, Check, CheckStatus, GlassError, Result, SandboxLevel};
 use glass_exec_unix::{Resolved, resolve_bin, resolve_on_path_in};
 use glass_sandbox_unix::{abs_token, canon, dir_of};
 
@@ -330,45 +331,136 @@ pub enum Availability {
 
 /// Probe: the configured `bwrap` reachable and an unprivileged user namespace usable.
 pub fn availability() -> Availability {
-    let bin = bwrap_bin();
-    let resolved = resolve_bin(&bin, std::env::var_os("PATH").as_deref());
-    match availability_with(&bin, resolved) {
-        Availability::Ok => userns_availability(&bin),
-        unavailable => unavailable,
+    availability_of(probe(), apparmor_userns_restricted() == Some(true))
+}
+
+/// Pure: what a probe means to a caller that needs only go/no-go.
+fn availability_of(probe: Probed, apparmor_restricted: bool) -> Availability {
+    match probe {
+        Ok(_) => Availability::Ok,
+        Err(no) => Availability::Unavailable(no.message(apparmor_restricted)),
     }
 }
 
-/// Pure: what resolving `bwrap` alone decides — the testable seam (no global env). `Ok` here means
-/// only that a runnable `bwrap` exists; [`availability`] still has to prove it can create a
-/// namespace.
+/// What the probe answered: how long the namespace took to create, or why it could not be.
+type Probed = std::result::Result<Duration, NoSandbox>;
+
+/// Why the sandbox cannot be used, one variant per remedy — telling causes apart by their message
+/// prose is what glass#348 forbids.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
+enum NoSandbox {
+    /// Nothing to run: no `bwrap` resolved, or the one that did cannot be executed.
+    Missing(String),
+    /// bwrap ran and exited non-zero, including without saying why.
+    Refused(String),
+    /// bwrap had not exited when its budget ran out, so it was sent SIGKILL — which one wedged in
+    /// the kernel does not take until it surfaces. Only the direct child is signalled; anything it
+    /// had already forked outlives it.
+    TimedOut(String),
+    /// The call could not be completed, so nothing about namespaces was learned. bwrap may well
+    /// have run: one that exited leaving something holding its output pipe lands here too.
+    Unfinished(String),
+}
+
+const INSTALL_BWRAP: &str = "install `bubblewrap`, or point GLASS_BWRAP at a copy this machine can \
+     execute; or run with sandbox:\"off\" (GLASS_SANDBOX=off) to launch unconfined";
+const CHECK_THE_MOUNTS: &str = "the probe read-only-binds the whole root, so a mount that has \
+     stopped responding (an unreachable network filesystem) can hold it there; check for one, or \
+     run with sandbox:\"off\" (GLASS_SANDBOX=off) to launch unconfined";
+const NOTHING_LEARNED: &str = "nothing here says the sandbox is broken — glass could not finish \
+     asking; try again, or run with sandbox:\"off\" (GLASS_SANDBOX=off) to launch unconfined";
+
+impl NoSandbox {
+    fn why(&self) -> &str {
+        match self {
+            NoSandbox::Missing(why)
+            | NoSandbox::Refused(why)
+            | NoSandbox::TimedOut(why)
+            | NoSandbox::Unfinished(why) => why,
+        }
+    }
+
+    /// The fix, tailored to the cause. A bubblewrap that said nothing gets neither stock remedy:
+    /// it is installed, and AppArmor's knob fails `unshare` with EPERM at once.
+    fn remedy(&self, apparmor_restricted: bool) -> &'static str {
+        match self {
+            NoSandbox::Missing(_) => INSTALL_BWRAP,
+            NoSandbox::Refused(_) => refusal_remedy(apparmor_restricted),
+            NoSandbox::TimedOut(_) => CHECK_THE_MOUNTS,
+            NoSandbox::Unfinished(_) => NOTHING_LEARNED,
+        }
+    }
+
+    /// Cause and fix in one string, for the launch path's single error message.
+    fn message(&self, apparmor_restricted: bool) -> String {
+        format!("{} — {}", self.why(), self.remedy(apparmor_restricted))
+    }
+}
+
+/// Resolve `bwrap` and put it to the user-namespace question. The only caller that supplies
+/// [`USERNS_PROBE_BUDGET`]; `tests/bwrap_probe_bound.rs` is what holds that wiring in place.
+fn probe() -> Probed {
+    let bin = bwrap_bin();
+    let resolved = resolve_bin(&bin, std::env::var_os("PATH").as_deref());
+    userns_probe(&resolved_bwrap(&bin, resolved)?, USERNS_PROBE_BUDGET)
+}
+
+/// Pure: what resolving `bwrap` alone decides — the testable seam (no global env). `Ok` carries the
+/// file to probe; that it is runnable is all resolution proves.
 ///
 /// `bin` is the configured name, needed for the [`Resolved::Absent`] message because that variant
 /// carries no path.
-fn availability_with(bin: &str, bwrap: Resolved) -> Availability {
+fn resolved_bwrap(bin: &str, bwrap: Resolved) -> std::result::Result<PathBuf, NoSandbox> {
     match bwrap {
-        Resolved::Found(_) => Availability::Ok,
-        Resolved::NotExecutable(p) => Availability::Unavailable(format!(
-            "bubblewrap ({}) is not executable (chmod +x it, or set GLASS_BWRAP to a runnable binary)",
+        Resolved::Found(p) => Ok(p),
+        Resolved::NotExecutable(p) => Err(NoSandbox::Missing(format!(
+            "bubblewrap ({}) is not executable",
             p.display()
-        )),
-        Resolved::Absent => Availability::Unavailable(format!(
-            "bubblewrap ({bin}) not found (set GLASS_BWRAP to its path)"
-        )),
+        ))),
+        Resolved::Absent => Err(NoSandbox::Missing(format!("bubblewrap ({bin}) not found"))),
     }
 }
 
-/// Run `bwrap` to prove an unprivileged user namespace can actually be created here.
-fn userns_availability(bin: &str) -> Availability {
-    match Command::new(bin)
-        .args(["--unshare-user", "--ro-bind", "/", "/", "--", "true"])
-        .output()
-    {
-        Ok(o) if o.status.success() => Availability::Ok,
-        Ok(o) => Availability::Unavailable(format!(
-            "bubblewrap cannot create a user namespace: {}",
-            String::from_utf8_lossy(&o.stderr).trim()
+/// How long `bwrap` gets to answer the user-namespace question.
+///
+/// The probe does real kernel work: it creates an unprivileged user namespace and `--ro-bind / /`s
+/// the root — the same bind `wrap_argv` emits for a real launch, so a mount that hangs the probe
+/// would have hung the launch.
+const USERNS_PROBE_BUDGET: Duration = Duration::from_secs(10);
+
+/// A shrunken budget is the failure no test can see: every fixture answers in milliseconds, so the
+/// suite stays green while no sandboxed launch on a loaded host works at all. The ceiling keeps
+/// `tests/bwrap_probe_bound.rs`'s 15s bound discriminating.
+const _: () = assert!(USERNS_PROBE_BUDGET.as_secs() >= 5 && USERNS_PROBE_BUDGET.as_secs() <= 15);
+
+/// Run `bwrap` to prove an unprivileged user namespace can actually be created here, returning how
+/// long it took to say so.
+///
+/// A timeout is not stepped over: the launch fails closed rather than hand the app to a bwrap that
+/// never answered.
+fn userns_probe(bwrap: &Path, budget: Duration) -> Probed {
+    let mut cmd = Command::new(bwrap);
+    cmd.args(["--unshare-user", "--ro-bind", "/", "/", "--", "true"]);
+    let at = bwrap.display();
+    let started = Instant::now();
+    match glass_core::run_bounded(&mut cmd, budget, "bwrap:userns") {
+        Ok(o) if o.status.success() => Ok(started.elapsed()),
+        Ok(o) => Err(NoSandbox::Refused(
+            match String::from_utf8_lossy(&o.stderr).trim() {
+                // Nothing said establishes nothing about namespaces — a signal death (the OOM
+                // killer, a segfault) lands here.
+                "" => format!("bubblewrap ({at}) failed without saying why ({})", o.status),
+                said => format!("bubblewrap ({at}) cannot create a user namespace: {said}"),
+            },
         )),
-        Err(e) => Availability::Unavailable(format!("could not run {bin}: {e}")),
+        // The runner's own message carries what bwrap said before it wedged, and whether the kill
+        // was collected — a bwrap that SIGKILL could not reach is itself evidence for the mount the
+        // remedy asks the reader to go find.
+        Err(e) if e.bound() == Some(BoundKind::TimedOut) => {
+            Err(NoSandbox::TimedOut(format!("bubblewrap ({at}): {e}")))
+        }
+        Err(e) => Err(NoSandbox::Unfinished(format!("bubblewrap ({at}): {e}"))),
     }
 }
 
@@ -381,43 +473,35 @@ fn apparmor_userns_restricted() -> Option<bool> {
         .map(|s| s.trim() == "1")
 }
 
-/// Pure: the remedy for an unavailable sandbox, tailored to whether AppArmor's
-/// unprivileged-userns restriction is the likely cause (Ubuntu 23.10+).
-fn unavailable_remedy(apparmor_restricted: bool) -> String {
+/// Pure: the fix for a bwrap that ran and refused, tailored to whether AppArmor's
+/// unprivileged-userns restriction is the likely cause (Ubuntu 23.10+). It never mentions
+/// installing bubblewrap: one that answered is installed.
+fn refusal_remedy(apparmor_restricted: bool) -> &'static str {
     if apparmor_restricted {
         "this system restricts unprivileged user namespaces via AppArmor \
          (kernel.apparmor_restrict_unprivileged_userns=1), which bubblewrap requires. Allow them \
          with `sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0` (persist via a file \
-         in /etc/sysctl.d/), or run with sandbox:\"off\""
-            .into()
+         in /etc/sysctl.d/), or run with sandbox:\"off\" (GLASS_SANDBOX=off)"
     } else {
-        "install `bubblewrap` (or set GLASS_BWRAP to its path) and enable unprivileged user \
-         namespaces (e.g. `sysctl kernel.unprivileged_userns_clone=1`), or run with sandbox:\"off\""
-            .into()
+        "enable unprivileged user namespaces (e.g. `sysctl kernel.unprivileged_userns_clone=1`), \
+         or run with sandbox:\"off\" (GLASS_SANDBOX=off) to launch unconfined"
     }
 }
 
-/// Pure: map probed facts to a doctor check. `bin` is the resolved bubblewrap binary;
-/// `apparmor_restricted` tailors the remedy to the AppArmor userns restriction.
-fn sandbox_checks(
-    available: bool,
-    bin: &str,
-    why: Option<String>,
-    apparmor_restricted: bool,
-) -> Vec<Check> {
-    let check = if available {
-        Check::new(
-            "sandbox (bubblewrap)",
+/// Pure: map probed facts to a doctor check, which prints cause and fix in separate columns.
+/// `bin` is the configured name, not the resolved path.
+fn sandbox_checks(bin: &str, probe: Probed, apparmor_restricted: bool) -> Vec<Check> {
+    let name = "sandbox (bubblewrap)";
+    let check = match probe {
+        // The elapsed time is the only warning of a host near the budget, where doctor and the next
+        // launch can disagree about the same machine.
+        Ok(took) => Check::new(
+            name,
             CheckStatus::Ok,
-            format!("{bin} present; user namespaces usable"),
-        )
-    } else {
-        Check::new(
-            "sandbox (bubblewrap)",
-            CheckStatus::Fail,
-            why.unwrap_or_else(|| "unavailable".into()),
-        )
-        .with_remedy(unavailable_remedy(apparmor_restricted))
+            format!("{bin} present; user namespaces usable (answered in {took:?})"),
+        ),
+        Err(no) => Check::new(name, CheckStatus::Fail, no.why())
+            .with_remedy(no.remedy(apparmor_restricted)),
     };
     vec![check]
 }
@@ -426,12 +510,7 @@ fn sandbox_checks(
 pub fn checks() -> Vec<Check> {
     let bin = bwrap_bin();
     let apparmor_restricted = apparmor_userns_restricted() == Some(true);
-    match availability() {
-        Availability::Ok => sandbox_checks(true, &bin, None, apparmor_restricted),
-        Availability::Unavailable(why) => {
-            sandbox_checks(false, &bin, Some(why), apparmor_restricted)
-        }
-    }
+    sandbox_checks(&bin, probe(), apparmor_restricted)
 }
 
 #[cfg(test)]
@@ -938,14 +1017,45 @@ mod tests {
         );
     }
 
+    /// Every way the sandbox can turn out unusable, for the properties that hold across all of
+    /// them. Each carries a cause a real probe would produce.
+    fn every_cause() -> Vec<NoSandbox> {
+        vec![
+            NoSandbox::Missing("bubblewrap (bwrap) not found".into()),
+            NoSandbox::Refused(
+                "bubblewrap (/usr/bin/bwrap) cannot create a user namespace: \
+                                setting up uid map: Permission denied"
+                    .into(),
+            ),
+            NoSandbox::TimedOut(
+                "bubblewrap (/usr/bin/bwrap): bwrap:userns: no answer within 10s".into(),
+            ),
+            NoSandbox::Unfinished(
+                "bubblewrap (/usr/bin/bwrap): bwrap:userns: could not check whether the process \
+                 had exited"
+                    .into(),
+            ),
+        ]
+    }
+
     #[test]
     fn doctor_reports_ok_and_failure() {
         use glass_core::CheckStatus;
-        let ok = sandbox_checks(true, "bwrap", None, false);
+        let ok = sandbox_checks("bwrap", Ok(Duration::from_millis(9)), false);
         assert_eq!(ok[0].status, CheckStatus::Ok);
-        let bad = sandbox_checks(false, "bwrap", Some("bwrap not found".into()), false);
-        assert_eq!(bad[0].status, CheckStatus::Fail);
-        assert!(bad[0].remedy.is_some());
+        for no in every_cause() {
+            let bad = sandbox_checks("bwrap", Err(no.clone()), false);
+            assert_eq!(bad[0].status, CheckStatus::Fail, "{no:?}");
+            assert_eq!(bad[0].detail, no.why(), "{no:?}");
+            assert!(bad[0].remedy.is_some(), "{no:?}");
+        }
+    }
+
+    /// The elapsed time is the only sign of a host near the budget.
+    #[test]
+    fn doctor_says_how_long_the_probe_took() {
+        let ok = sandbox_checks("bwrap", Ok(Duration::from_millis(1250)), false);
+        assert!(ok[0].detail.contains("1.25s"), "{:?}", ok[0]);
     }
 
     #[test]
@@ -954,9 +1064,8 @@ mod tests {
         // "setting up uid map: Permission denied"). When that's the cause, the remedy must
         // name the exact knob; otherwise it must not falsely claim AppArmor.
         let restricted = sandbox_checks(
-            false,
             "bwrap",
-            Some("uid map: Permission denied".into()),
+            Err(NoSandbox::Refused("uid map: Permission denied".into())),
             true,
         );
         let r = restricted[0].remedy.clone().unwrap();
@@ -965,11 +1074,92 @@ mod tests {
             "got: {r}"
         );
 
-        let generic = sandbox_checks(false, "bwrap", Some("bwrap not found".into()), false);
+        let generic = sandbox_checks(
+            "bwrap",
+            Err(NoSandbox::Refused("uid map: Permission denied".into())),
+            false,
+        );
         let g = generic[0].remedy.clone().unwrap();
         assert!(
             !g.to_lowercase().contains("apparmor"),
             "generic remedy must not claim AppArmor: {g}"
+        );
+    }
+
+    /// A bubblewrap that answered is installed, whatever it answered.
+    #[test]
+    fn a_refusal_is_never_answered_with_install_it() {
+        for apparmor in [false, true] {
+            let r = refusal_remedy(apparmor);
+            assert!(
+                !r.to_lowercase().contains("install"),
+                "apparmor={apparmor}: {r}"
+            );
+        }
+    }
+
+    /// A bubblewrap that is not there cannot be refusing anything, so AppArmor's knob is not the
+    /// fix — and a restricted host with no bwrap installed is reachable.
+    #[test]
+    fn an_absent_bwrap_is_never_blamed_on_apparmor() {
+        for apparmor in [false, true] {
+            let checks = sandbox_checks(
+                "bwrap",
+                Err(NoSandbox::Missing("bubblewrap (bwrap) not found".into())),
+                apparmor,
+            );
+            let r = checks[0].remedy.clone().unwrap();
+            assert!(
+                !r.to_lowercase().contains("apparmor") && r.contains("install"),
+                "apparmor={apparmor}: {r}"
+            );
+        }
+    }
+
+    /// A bubblewrap that said nothing is installed and may well work, so neither stock remedy fits.
+    /// Asserted as the absence of that advice — a remedy that merely appended a clause to either
+    /// would pass an inequality.
+    #[test]
+    fn a_silent_bwrap_is_answered_with_neither_stock_remedy() {
+        for apparmor in [false, true] {
+            let checks = sandbox_checks(
+                "bwrap",
+                Err(NoSandbox::TimedOut("bwrap: no answer within 10s".into())),
+                apparmor,
+            );
+            assert_eq!(checks[0].status, glass_core::CheckStatus::Fail);
+            let r = checks[0].remedy.clone().unwrap().to_lowercase();
+            assert!(!r.contains("install"), "apparmor={apparmor}: {r}");
+            assert!(!r.contains("apparmor"), "apparmor={apparmor}: {r}");
+            assert!(r.contains("mount"), "must name what to look for: {r}");
+        }
+    }
+
+    /// Whatever is wrong with the sandbox, a launch can decline it — and the launch path can only
+    /// say so if the message it is handed already does.
+    #[test]
+    fn every_unusable_sandbox_reaches_the_launch_path_with_its_own_fix() {
+        for no in every_cause() {
+            for apparmor in [false, true] {
+                let Availability::Unavailable(msg) = availability_of(Err(no.clone()), apparmor)
+                else {
+                    panic!("{no:?} must not clear a sandboxed launch");
+                };
+                assert!(msg.starts_with(no.why()), "the cause is not remade: {msg}");
+                assert!(msg.contains(no.remedy(apparmor)), "no fix travelled: {msg}");
+                assert!(msg.contains("sandbox:\"off\""), "no way to launch: {msg}");
+            }
+        }
+    }
+
+    #[test]
+    fn a_proven_namespace_clears_the_launch_path() {
+        assert!(
+            matches!(
+                availability_of(Ok(Duration::from_millis(9)), false),
+                Availability::Ok
+            ),
+            "a bwrap that created a namespace must not refuse the launch"
         );
     }
 
@@ -979,54 +1169,187 @@ mod tests {
     /// stops forking a binary to learn what a `stat` answers.
     #[test]
     fn a_non_executable_bwrap_is_unavailable_and_says_so() {
-        let Availability::Unavailable(msg) = availability_with(
+        let Err(no) = resolved_bwrap(
             "/opt/bin/bwrap",
             Resolved::NotExecutable(PathBuf::from("/opt/bin/bwrap")),
         ) else {
-            panic!("a non-executable bwrap must not report available");
+            panic!("a non-executable bwrap must not be probed");
         };
         assert!(
-            msg.contains("/opt/bin/bwrap") && msg.contains("not executable"),
-            "must name the file and say why: {msg}"
+            no.why().contains("/opt/bin/bwrap") && no.why().contains("not executable"),
+            "must name the file and say why: {no:?}"
+        );
+        assert!(
+            no.remedy(false).contains("GLASS_BWRAP"),
+            "the override is the fix for a bwrap glass cannot run: {no:?}"
         );
     }
 
-    /// Both messages name GLASS_BWRAP, so asserting only that cannot tell the two apart.
+    /// Both causes are a bubblewrap glass has nothing to run, so asserting the variant alone cannot
+    /// tell them apart.
     #[test]
-    fn an_absent_bwrap_is_unavailable_and_points_at_the_override() {
-        let Availability::Unavailable(msg) = availability_with("bwrap", Resolved::Absent) else {
-            panic!("an absent bwrap must not report available");
+    fn an_absent_bwrap_is_unavailable_and_says_so() {
+        let Err(no) = resolved_bwrap("bwrap", Resolved::Absent) else {
+            panic!("an absent bwrap must not be probed");
         };
         assert!(
-            msg.contains("GLASS_BWRAP") && msg.contains("not found"),
-            "actionable message: {msg}"
+            no.why().contains("bwrap") && no.why().contains("not found"),
+            "actionable message: {no:?}"
         );
     }
 
-    /// The arm no other test reaches: replacing it with `Unavailable` refuses every sandboxed
-    /// launch on every host and the suite stays green, since each test that really launches
-    /// under bwrap is `#[ignore]`d.
+    /// The arm no other test reaches: making it an error refuses every sandboxed launch on every
+    /// host and the suite stays green, since each test that really launches under bwrap is
+    /// `#[ignore]`d.
     #[test]
     fn a_runnable_bwrap_clears_the_resolution_stage() {
-        assert!(
-            matches!(
-                availability_with("bwrap", Resolved::Found(PathBuf::from("/usr/bin/bwrap"))),
-                Availability::Ok
-            ),
-            "a runnable bwrap must reach the user-namespace probe"
+        assert_eq!(
+            resolved_bwrap("bwrap", Resolved::Found(PathBuf::from("/usr/bin/bwrap"))),
+            Ok(PathBuf::from("/usr/bin/bwrap")),
+            "a runnable bwrap must reach the user-namespace probe, by its resolved path"
         );
     }
 
     /// The probe's spawn-failure arm, which needs no bwrap on the host: naming the binary is the
-    /// only way the user learns which one glass tried.
+    /// only way the user learns which one glass tried. Not [`NoSandbox::Refused`] — nothing here
+    /// says anything about namespaces, so the remedy must not send the user to enable them.
     #[test]
     fn a_bwrap_that_cannot_be_spawned_reports_why() {
-        let Availability::Unavailable(msg) = userns_availability("/nonexistent/bwrap") else {
+        let Err(no) = userns_probe(Path::new("/nonexistent/bwrap"), USERNS_PROBE_BUDGET) else {
             panic!("a bwrap that cannot be spawned must not report available");
         };
         assert!(
-            msg.contains("could not run") && msg.contains("/nonexistent/bwrap"),
-            "must name what it tried to run: {msg}"
+            matches!(no, NoSandbox::Unfinished(_)),
+            "a call that never happened is not a refusal: {no:?}"
+        );
+        assert!(
+            no.why().contains("/nonexistent/bwrap"),
+            "must name what it tried to run: {no:?}"
+        );
+    }
+
+    /// How long the never-answering fixture lives if nothing kills it. Whole seconds because it is
+    /// interpolated into `sleep`, and far past any budget these tests pass, so a lost bound fails
+    /// them rather than passing.
+    const HUNG_FIXTURE_SECS: u64 = 30;
+
+    /// Budget for the test that wants a timeout. Short enough to keep the suite quick; the elapsed
+    /// assertion allows ten times it, so a loaded machine does not read a bound that fired as one
+    /// that did not.
+    const HUNG_PROBE_BUDGET: Duration = Duration::from_millis(300);
+
+    /// A fake `bwrap` running `body`, which refuses any argv but the probe's own.
+    ///
+    /// Without that guard, dropping the probe's arguments would leave every test here green while
+    /// glass asked a real bubblewrap a different question entirely. `$#` as well as `$*`, which
+    /// cannot tell six arguments from one containing spaces.
+    fn fake_bwrap(dir: &Path, body: &str) -> PathBuf {
+        let bin = dir.join("bwrap");
+        std::fs::write(
+            &bin,
+            format!(
+                "#!/bin/sh\n[ $# -eq 6 ] || exit 3\n\
+                 [ \"$*\" = '--unshare-user --ro-bind / / -- true' ] || exit 3\n{body}"
+            ),
+        )
+        .expect("write the fake bwrap");
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        wait_until_executable(&bin);
+        bin
+    }
+
+    /// `exec` of a just-written file fails ETXTBSY while any process still holds it open for
+    /// writing — including a sibling test's child, which inherits every fd across the fork and
+    /// drops them only at its own exec. This binary spawns constantly, so without this the probe
+    /// tests fail as `Unfinished` about half the time. Spawning is the only way to ask; the argv
+    /// guard rejects this call, which is all this needs.
+    fn wait_until_executable(bin: &Path) {
+        /// ETXTBSY. `ErrorKind::ExecutableFileBusy` would say it, but only on the io_error_more
+        /// nightly feature.
+        const TEXT_FILE_BUSY: i32 = 26;
+        for _ in 0..100 {
+            match Command::new(bin).arg("--ready").output() {
+                Err(e) if e.raw_os_error() == Some(TEXT_FILE_BUSY) => {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                _ => return,
+            }
+        }
+    }
+
+    /// glass#398: the probe ran through `Command::output()`, which waits for the child however long
+    /// it takes, so a `bwrap` wedged on a mount under `/` hung `glass_start` and `glass doctor`
+    /// with nothing to recover from.
+    #[test]
+    fn a_bwrap_that_never_answers_is_bounded_and_named() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // `exec`, so the killed pid is the sleeper: a forked one would be orphaned and hold both
+        // output pipes for the rest of its 30s, past the end of the test.
+        let bin = fake_bwrap(dir.path(), &format!("exec sleep {HUNG_FIXTURE_SECS}\n"));
+
+        let started = Instant::now();
+        let Err(no) = userns_probe(&bin, HUNG_PROBE_BUDGET) else {
+            panic!("a bwrap that never answered has proven no namespace");
+        };
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < HUNG_PROBE_BUDGET * 10,
+            "the budget it was passed is not the one it waited: {elapsed:?}"
+        );
+        assert!(
+            matches!(no, NoSandbox::TimedOut(_)),
+            "a bwrap that ran and said nothing has not refused: {no:?}"
+        );
+        assert!(
+            no.why().contains(bin.to_str().unwrap()) && no.why().contains("no answer within"),
+            "must name the binary and what it did: {no:?}"
+        );
+    }
+
+    /// The arm every sandboxed launch on a healthy host takes.
+    #[test]
+    fn a_bwrap_that_answers_clears_the_probe() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bin = fake_bwrap(dir.path(), "exit 0\n");
+        let took = userns_probe(&bin, USERNS_PROBE_BUDGET)
+            .expect("a bwrap that answered the probe's own question must clear it");
+        assert!(took < USERNS_PROBE_BUDGET, "{took:?}");
+    }
+
+    /// What bubblewrap itself says is the actionable part — "cannot create a user namespace" alone
+    /// does not distinguish an AppArmor refusal from a kernel without the feature.
+    #[test]
+    fn a_bwrap_that_refuses_the_namespace_repeats_what_it_said() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bin = fake_bwrap(
+            dir.path(),
+            "echo 'setting up uid map: Permission denied' >&2\nexit 1\n",
+        );
+        let Err(no) = userns_probe(&bin, USERNS_PROBE_BUDGET) else {
+            panic!("a bwrap that refused must not report available");
+        };
+        assert!(
+            no.why().contains("cannot create a user namespace") && no.why().contains("uid map"),
+            "must carry bwrap's own words: {no:?}"
+        );
+    }
+
+    /// A bwrap killed by a signal (the OOM killer, a segfault) exits non-zero saying nothing.
+    /// Reporting that as "cannot create a user namespace: " asserts a cause nothing established.
+    #[test]
+    fn a_bwrap_that_dies_without_a_word_is_not_reported_as_a_namespace_refusal() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bin = fake_bwrap(dir.path(), "exit 1\n");
+        let Err(no) = userns_probe(&bin, USERNS_PROBE_BUDGET) else {
+            panic!("a bwrap that exited non-zero must not report available");
+        };
+        assert!(
+            !no.why().contains("cannot create a user namespace"),
+            "silence is not a refusal to create a namespace: {no:?}"
+        );
+        assert!(
+            no.why().contains("exit status: 1"),
+            "the status is all that is left to report: {no:?}"
         );
     }
 

--- a/crates/glass-sandbox-linux/tests/bwrap_probe_bound.rs
+++ b/crates/glass-sandbox-linux/tests/bwrap_probe_bound.rs
@@ -1,0 +1,105 @@
+//! glass#398, the live path: the user-namespace probe waited for `bwrap` however long it took.
+//!
+//! The unit tests reach `userns_probe` directly with their own short budget, so `probe()` could
+//! pass an hour — or go back to an unbounded `Command::output()` — with every one of them still
+//! green. This drives the real constant through `checks()`, which shares its probe with
+//! `availability()`, the launch path `glass_start` takes.
+//!
+//! Kept out of the crate's `mod tests`, and kept to ONE test: it sets `GLASS_BWRAP`, which those
+//! tests read (`wrap_argv` asserts on `argv[0]`). A second test here would race that mutation and
+//! invalidate the `SAFETY` notes below.
+
+#![cfg(target_os = "linux")]
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+/// How long the fixture lives if nothing kills it, in whole seconds. Far past the probe's budget,
+/// so a lost bound fails this test rather than wedging the suite.
+const FIXTURE_SECS: u64 = 30;
+
+/// Restores rather than unsets, so this stays correct if the file ever grows a second test.
+struct EnvGuard(Option<OsString>);
+
+#[allow(unsafe_code)]
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: one test in this binary, so every environment read is on this thread, between
+        // this mutation and the last. The only other threads are `run_bounded`'s pipe drains,
+        // which never touch the environment.
+        match self.0.take() {
+            Some(v) => unsafe { std::env::set_var("GLASS_BWRAP", v) },
+            None => unsafe { std::env::remove_var("GLASS_BWRAP") },
+        }
+    }
+}
+
+#[allow(unsafe_code)]
+fn point_glass_bwrap_at(path: &Path) -> EnvGuard {
+    let guard = EnvGuard(std::env::var_os("GLASS_BWRAP"));
+    // SAFETY: as above — one test in this binary.
+    unsafe { std::env::set_var("GLASS_BWRAP", path) };
+    guard
+}
+
+/// A `bwrap` that takes the probe's question and never answers it.
+///
+/// `exec`, so the sleeping process is the one glass spawned — a shell that forked its sleep would
+/// leave the sleeper behind a kill that reached only the shell.
+fn hung_bwrap(dir: &Path) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt as _;
+    let bin = dir.join("bwrap");
+    std::fs::write(
+        &bin,
+        format!(
+            "#!/bin/sh\n[ $# -eq 6 ] || exit 3\n\
+             [ \"$*\" = '--unshare-user --ro-bind / / -- true' ] || exit 3\n\
+             exec sleep {FIXTURE_SECS}\n"
+        ),
+    )
+    .expect("write the fake bwrap");
+    std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+    bin
+}
+
+#[test]
+fn a_bwrap_that_never_answers_is_reported_rather_than_waited_out() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let _guard = point_glass_bwrap_at(&hung_bwrap(dir.path()));
+
+    let started = Instant::now();
+    let checks = glass_sandbox_linux::checks();
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(FIXTURE_SECS) / 2,
+        "the probe waited the binary out rather than bounding it: {elapsed:?}"
+    );
+    // The other end of the bracket, and the one no fixture can fail: every fake bwrap answers in
+    // milliseconds, so a budget cut to nothing would leave the whole suite green while a real
+    // `--ro-bind /` timed out and no sandboxed launch worked at all.
+    assert!(
+        elapsed >= Duration::from_secs(5),
+        "the probe's budget is no longer generous enough for real kernel work: {elapsed:?}"
+    );
+
+    let sandbox = checks
+        .iter()
+        .find(|c| c.name == "sandbox (bubblewrap)")
+        .expect("doctor reports on the sandbox");
+    assert_eq!(
+        sandbox.status,
+        glass_core::CheckStatus::Fail,
+        "a bubblewrap that answered nothing has proven no namespace: {sandbox:?}"
+    );
+    assert!(sandbox.detail.contains("no answer within"), "{sandbox:?}");
+    // The remedy for this cause specifically: every remedy ends in `sandbox:"off"`, so asserting
+    // that alone would pass for the install advice this binary is here to keep out.
+    assert!(
+        sandbox
+            .remedy
+            .as_deref()
+            .is_some_and(|r| r.contains("mount") && !r.contains("install")),
+        "{sandbox:?}"
+    );
+}

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -963,12 +963,12 @@ fn ensure_sandbox_available(
     }
     match probe() {
         glass_sandbox_linux::Availability::Ok => Ok(()),
-        glass_sandbox_linux::Availability::Unavailable(why) => {
-            Err(GlassError::SandboxUnavailable(format!(
-                "{why}. Install bubblewrap / enable unprivileged user namespaces, or pass \
-                 sandbox:\"off\" (GLASS_SANDBOX=off) to run unconfined. See `glass-mcp doctor`."
-            )))
-        }
+        // The fix travels with the cause: only the probe knows whether bubblewrap is missing,
+        // refusing, or wedged. Telling a user to install one that is installed sends them past the
+        // mount holding it.
+        glass_sandbox_linux::Availability::Unavailable(why) => Err(GlassError::SandboxUnavailable(
+            format!("{why}. See `glass-mcp doctor`."),
+        )),
     }
 }
 
@@ -2136,8 +2136,10 @@ mod pure_tests {
         })
         .expect_err("fail closed rather than launching unconfined");
         assert!(matches!(err, GlassError::SandboxUnavailable(_)), "{err}");
+        // The cause and its fix are the probe's to write — glass-sandbox-linux asserts that every
+        // one of them offers `sandbox:"off"`.
         assert!(err.to_string().contains("no bwrap here"), "{err}");
-        assert!(err.to_string().contains("sandbox:\"off\""), "{err}");
+        assert!(err.to_string().contains("glass-mcp doctor"), "{err}");
     }
 
     #[test]

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -1364,12 +1364,12 @@ fn ensure_sandbox_available(
     }
     match probe() {
         glass_sandbox_linux::Availability::Ok => Ok(()),
-        glass_sandbox_linux::Availability::Unavailable(why) => {
-            Err(GlassError::SandboxUnavailable(format!(
-                "{why}. Install bubblewrap / enable unprivileged user namespaces, or pass \
-                 sandbox:\"off\" (GLASS_SANDBOX=off) to run unconfined. See `glass-mcp doctor`."
-            )))
-        }
+        // The fix travels with the cause: only the probe knows whether bubblewrap is missing,
+        // refusing, or wedged. Telling a user to install one that is installed sends them past the
+        // mount holding it.
+        glass_sandbox_linux::Availability::Unavailable(why) => Err(GlassError::SandboxUnavailable(
+            format!("{why}. See `glass-mcp doctor`."),
+        )),
     }
 }
 


### PR DESCRIPTION
Fixes #398.

`availability` ran `bwrap --unshare-user --ro-bind / / -- true` through `Command::output()`, which waits for the child however long it takes. The probe binds every mount under the root, so a filesystem that has stopped answering could leave it there — hanging `glass_start` for any launch whose sandbox is not `off` (the default, on both Linux backends) and `glass doctor` with it.

## The bound

The probe runs through `glass_core::run_bounded` with a 10s budget — wide enough for the kernel work it does, and bracketed by a `const` assertion because a budget cut too fine refuses every launch on a healthy host and no fixture answers slowly enough for a test to notice. A bubblewrap that has not answered is killed and the sandbox reported unavailable: one that cannot prove it can create a namespace has not proven it, and the alternative is handing the app to a bwrap that never answered.

## The diagnosis

Every cause of an unusable sandbox got the same sentence — "install bubblewrap / enable unprivileged user namespaces" — which is wrong for most of them, and the launch path re-derived it from a bare string rather than taking the probe's. A private `NoSandbox` keeps the cause off the message prose (glass#348) and maps one variant to one remedy:

- **missing or not executable** — install it, or point `GLASS_BWRAP` somewhere runnable
- **ran and refused** — enable unprivileged user namespaces, naming the AppArmor knob when that is what is holding them, and never suggesting an install
- **never answered** — go looking for the unresponsive mount
- **the call could not be finished** — nothing here says the sandbox is broken

The launch path prints the probe's cause and fix; `glass doctor` prints them in its own columns. A bwrap that exits saying nothing reports its exit status rather than a refusal to create a namespace it never mentioned, and a working probe's elapsed time appears in the doctor detail — the only sign of a host near the budget, where doctor and the next launch can disagree about the same machine.

## Tests

Fixture-based unit tests cover each arm; every fixture rejects any argv but the probe's own, so dropping the probe's arguments fails them rather than launching something else on a user's machine. `tests/bwrap_probe_bound.rs` drives the production constant through `checks()` and brackets it from both ends. Each behavioural assertion was ablated red and restored.