### PR TITLE
fix(wayland): bound capture_frame's wait on the compositor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,12 +73,15 @@ internal refactors, CI, or test-only changes.
   — is reported with its exit status rather than as a refusal to create a namespace it never
   mentioned.
 - A capture on the Wayland backend no longer waits indefinitely on a compositor that has gone
-  quiet. `glass_screenshot` gave the compositor 5 seconds to hand over the frame, but only looked
-  at the clock after the compositor had said something — so a compositor that stopped answering
-  altogether, rather than refusing, was waited on with no limit at all. glass serves one tool call
-  at a time, so every later call queued behind it. The 5 seconds are now a real limit: a capture
-  the compositor has not answered by then fails, naming what never arrived, and the session stays
-  usable.
+  quiet — `glass_screenshot` and everything built on it (`glass_diff`, `glass_wait_stable`,
+  `glass_wait_for_region`, `glass_baseline_save`, `glass_do`'s observe step). glass gave the
+  compositor 5 seconds to hand over the frame, but only looked at the clock after the compositor
+  had said something, so one that stopped answering altogether — rather than refusing — was waited
+  on with no limit at all. glass serves one tool call at a time, so every later call queued behind
+  it. The 5 seconds are now a real limit: a capture the compositor has not answered by then fails
+  and names the event that never arrived, and the capture after it is unaffected by the one that
+  gave up. Other calls on a compositor that stays quiet can still wait on it; only captures are
+  bounded so far.
 - Accessibility now works on Debian/Ubuntu machines that are not x86-64. `glass doctor` said
   `at-spi-bus-launcher present` while every a11y launch on the same machine failed to find it —
   quietly dropping to pixel-only by default, or failing outright with `a11y: true` — because the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,13 @@ internal refactors, CI, or test-only changes.
   how to launch unconfined. A bubblewrap that exits without a word — killed by the OOM killer, say
   — is reported with its exit status rather than as a refusal to create a namespace it never
   mentioned.
+- A capture on the Wayland backend no longer waits indefinitely on a compositor that has gone
+  quiet. `glass_screenshot` gave the compositor 5 seconds to hand over the frame, but only looked
+  at the clock after the compositor had said something — so a compositor that stopped answering
+  altogether, rather than refusing, was waited on with no limit at all. glass serves one tool call
+  at a time, so every later call queued behind it. The 5 seconds are now a real limit: a capture
+  the compositor has not answered by then fails, naming what never arrived, and the session stays
+  usable.
 - Accessibility now works on Debian/Ubuntu machines that are not x86-64. `glass doctor` said
   `at-spi-bus-launcher present` while every a11y launch on the same machine failed to find it —
   quietly dropping to pixel-only by default, or failing outright with `a11y: true` — because the

--- a/crates/glass-wayland/src/clipboard.rs
+++ b/crates/glass-wayland/src/clipboard.rs
@@ -850,9 +850,8 @@ fn serve_loop(
             break;
         }
 
-        // Prepare to read new events from the socket. `None` says the backend's own queue needs
-        // draining — a libwayland condition the pure-Rust backend glass builds never reports — so
-        // loop back to dispatch_pending rather than waiting on the fd.
+        // `None` says the backend's own queue needs draining — a libwayland condition the
+        // pure-Rust backend glass builds never reports.
         let guard = match queue.prepare_read() {
             Some(g) => g,
             None => continue,

--- a/crates/glass-wayland/src/clipboard.rs
+++ b/crates/glass-wayland/src/clipboard.rs
@@ -452,7 +452,7 @@ fn is_retryable(e: &std::io::Error) -> bool {
 /// The expiry check is explicit rather than left to the poll: `Instant` subtraction saturates to
 /// zero, and a zero-timeout poll still reports a ready fd, so a caller relying on that alone would
 /// run past its own deadline for as long as the other end kept the pipe ready.
-fn remaining_timespec(deadline: Instant) -> Option<rustix::event::Timespec> {
+pub(crate) fn remaining_timespec(deadline: Instant) -> Option<rustix::event::Timespec> {
     let now = Instant::now();
     if now >= deadline {
         return None;

--- a/crates/glass-wayland/src/clipboard.rs
+++ b/crates/glass-wayland/src/clipboard.rs
@@ -451,7 +451,7 @@ fn is_retryable(e: &std::io::Error) -> bool {
 ///
 /// The expiry check is explicit rather than left to the poll: `Instant` subtraction saturates to
 /// zero, and a zero-timeout poll still reports a ready fd, so a caller relying on that alone would
-/// run past its own deadline for as long as the other end kept the pipe ready.
+/// run past its own deadline for as long as the fd kept reporting ready.
 pub(crate) fn remaining_timespec(deadline: Instant) -> Option<rustix::event::Timespec> {
     let now = Instant::now();
     if now >= deadline {
@@ -850,12 +850,12 @@ fn serve_loop(
             break;
         }
 
-        // Prepare to read new events from the socket. If the queue already has
-        // pending events, `prepare_read` returns `None`; in that case loop
-        // straight back to dispatch_pending without waiting on the fd.
+        // Prepare to read new events from the socket. `None` says the backend's own queue needs
+        // draining — a libwayland condition the pure-Rust backend glass builds never reports — so
+        // loop back to dispatch_pending rather than waiting on the fd.
         let guard = match queue.prepare_read() {
             Some(g) => g,
-            None => continue, // unread events still in queue
+            None => continue,
         };
 
         // Poll the connection fd with a short timeout so we can check `stop`
@@ -903,24 +903,9 @@ mod tests {
         PoisonError, ReadyState, get, is_retryable, open_transfer, read_to_eof_bounded, serve_loop,
         signal_ready, write_all_bounded,
     };
-    use crate::testw::Launch;
+    use crate::testw::{Launch, on_a_thread};
     use glass_core::GlassError;
     use std::io::Write;
-
-    /// Run `f` on its own thread and wait `within` for its result, failing with `what` if it does
-    /// not arrive. The calls these tests bound hang outright when the bound under test is missing,
-    /// and a hang on the test thread wedges the whole suite.
-    fn on_a_thread<T: Send + 'static>(
-        within: Duration,
-        what: &str,
-        f: impl FnOnce() -> T + Send + 'static,
-    ) -> T {
-        let (tx, rx) = std::sync::mpsc::channel();
-        std::thread::spawn(move || {
-            let _ = tx.send(f());
-        });
-        rx.recv_timeout(within).expect(what)
-    }
 
     /// The serving thread is the clipboard — it holds the selection while it runs, and a pasting
     /// app reads from it over a pipe. Nothing under that is fakeable, so these use a real one.

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -145,7 +145,7 @@ impl WaylandPlatform {
     /// The compositor's own pid, for a test that has to act on the compositor rather than through
     /// it — signalling it, which no session method exposes.
     pub(crate) fn session_compositor_pid(&self) -> Option<u32> {
-        Some(self.active.as_ref()?.child.id())
+        self.active.as_ref().map(|s| s.child.id())
     }
 }
 
@@ -500,27 +500,37 @@ fn rect_to_geom(r: &crate::swayipc::Rect) -> WindowGeometry {
     }
 }
 
-/// How long one capture may spend waiting on the compositor, across both of its dispatch phases.
-const CAPTURE_BUDGET: Duration = Duration::from_millis(5000);
+/// How long one capture may take, from the copy request to the last event it needs.
+const CAPTURE_BUDGET: Duration = Duration::from_secs(5);
 
 /// A capture waits on a compositor that is also driving the app being captured, so the budget has
-/// to cover a loaded host, and the whole session lock is held meanwhile. The floor is what no test
-/// can see: `capture_frame`'s live test only proves the wait ends.
+/// to cover a loaded host — and the session lock is held for all of it, so it cannot be generous.
+/// Both ends are also asserted live, but only by a test that needs sway: on every other CI leg
+/// this is the whole guard.
 const _: () = assert!(
-    CAPTURE_BUDGET.as_millis() >= 2000 && CAPTURE_BUDGET.as_millis() <= 15_000,
+    CAPTURE_BUDGET.as_secs() >= 2 && CAPTURE_BUDGET.as_secs() <= 15,
     "the capture budget must leave a loaded compositor time to answer, without holding the session lock for long"
 );
 
-/// Wait for the compositor to send something, giving up at `deadline`.
+/// When the capture starting now must be over. A function, so removing the last use of
+/// [`CAPTURE_BUDGET`] from the capture path is a dead-code error rather than a constant left
+/// bracketed and unread.
+fn capture_deadline() -> Instant {
+    Instant::now() + CAPTURE_BUDGET
+}
+
+/// Dispatch whatever the compositor has sent, waiting no later than `deadline` for it to send
+/// something.
 ///
-/// `blocking_dispatch` returns only once an event has arrived, so a deadline checked after it is
-/// not a bound: a compositor that goes quiet after the last event glass reacts to holds the caller
-/// — and, through the session lock, every other tool call — indefinitely (glass#383). Poll the
-/// connection fd for what is left of the deadline instead, as the clipboard's owner loop does.
+/// `blocking_dispatch` waits on the socket with no timeout, so a deadline checked after it is not
+/// a bound: a compositor that goes quiet after the last event glass reacts to holds the caller —
+/// and, through the session lock, every other tool call — indefinitely (glass#383). Poll the
+/// connection fd for what is left of the deadline instead, the shape the clipboard's bounded
+/// transfers use.
 ///
-/// Returns once events have been dispatched, or once the deadline passed with nothing to read; the
-/// caller re-checks its own condition and its own deadline either way, so expiry is not an error
-/// here.
+/// Expiry is not an error here: this returns having made whatever progress it could, and
+/// [`wait_for`] owns the deadline. What is already in the queue is always dispatched first, so a
+/// budget spent down to nothing still delivers an answer that had already arrived.
 ///
 /// Generic over the queue's state only so the bound can be tested against a socket with no
 /// compositor behind it; capture is the sole caller, hence the error variant.
@@ -533,34 +543,96 @@ fn dispatch_until<S>(
     fn failed(what: &str, e: impl std::fmt::Display) -> GlassError {
         GlassError::CaptureFailed(format!("screencopy: {what}: {e}"))
     }
+    let dispatch = |queue: &mut EventQueue<S>, state: &mut S| {
+        queue
+            .dispatch_pending(state)
+            .map_err(|e| failed("dispatch", e))
+    };
     conn.flush().map_err(|e| failed("flush", e))?;
-    // `None` means events are already queued: dispatch them rather than waiting for more.
-    if let Some(guard) = queue.prepare_read() {
-        let Some(ts) = remaining_timespec(deadline) else {
-            return Ok(());
-        };
-        let fd = conn.as_fd();
-        match rustix::event::poll(
-            &mut [rustix::event::PollFd::new(
-                &fd,
-                rustix::event::PollFlags::IN,
-            )],
-            Some(&ts),
-        ) {
-            Ok(0) => return Ok(()),
-            Ok(_) => {
-                guard.read().map_err(|e| failed("read", e))?;
-            }
-            // A signal arrived and nothing was lost; the caller's deadline decides whether there
-            // is time to ask again.
-            Err(rustix::io::Errno::INTR) => return Ok(()),
-            Err(e) => return Err(failed("poll", e)),
+    if dispatch(queue, state)? > 0 {
+        return Ok(());
+    }
+    // `None` is a libwayland-backend condition glass cannot reach (the pure-Rust backend always
+    // prepares), and it means the backend's own queue needs draining, not this one's.
+    let Some(guard) = queue.prepare_read() else {
+        return Ok(());
+    };
+    let Some(ts) = remaining_timespec(deadline) else {
+        return Ok(());
+    };
+    // The guard's fd, not the queue's: a queue is a dispatch bucket and has no socket of its own.
+    let fd = guard.connection_fd();
+    // A compositor that went away wakes this poll too: POSIX reports POLLHUP in `revents` whether
+    // or not it was asked for, and the read below then fails with EPIPE rather than spinning.
+    match rustix::event::poll(
+        &mut [rustix::event::PollFd::new(
+            &fd,
+            rustix::event::PollFlags::IN,
+        )],
+        Some(&ts),
+    ) {
+        Ok(0) => return Ok(()),
+        Ok(_) => match guard.read() {
+            Ok(_) => {}
+            // What the socket held was the front of a message whose rest has not arrived. Upstream
+            // treats this as a retry, and so must this: it is a loaded host, not a fault.
+            Err(wayland_client::backend::WaylandError::Io(e))
+                if e.kind() == std::io::ErrorKind::WouldBlock => {}
+            Err(e) => return Err(failed("read", e)),
+        },
+        // A signal arrived and nothing was lost; the caller's deadline decides whether there is
+        // time to ask again.
+        Err(rustix::io::Errno::INTR) => return Ok(()),
+        Err(e) => return Err(failed("poll", e)),
+    }
+    dispatch(queue, state)?;
+    Ok(())
+}
+
+/// Dispatch until `answered` has one, or until `deadline` passes with `expired` to say why not.
+///
+/// The deadline check lives here rather than in each caller's own loop: [`dispatch_until`] returns
+/// at once once the budget is spent, so a loop that forgot to check would not hang as it did
+/// before glass#383 — it would spin on a core holding the session lock, which is worse.
+fn wait_for<S, T>(
+    conn: &Connection,
+    queue: &mut EventQueue<S>,
+    state: &mut S,
+    deadline: Instant,
+    expired: &str,
+    mut answered: impl FnMut(&mut S) -> Option<Result<T>>,
+) -> Result<T> {
+    loop {
+        dispatch_until(conn, queue, state, deadline)?;
+        if let Some(answer) = answered(state) {
+            return answer;
+        }
+        if Instant::now() >= deadline {
+            return Err(GlassError::CaptureFailed(expired.to_string()));
         }
     }
-    queue
-        .dispatch_pending(state)
-        .map_err(|e| failed("dispatch", e))?;
-    Ok(())
+}
+
+/// The wayland objects one capture owns, destroyed when it ends however it ends.
+///
+/// Dropping a proxy destroys nothing: the object stays alive on the compositor, which goes on
+/// sending events for it — and `ready` is not a destructor, the client is what must destroy a
+/// screencopy frame. The per-capture scratch in [`State`] is keyed by nothing, so a frame this
+/// capture gave up on would have its late `ready` taken by the next capture, which then reads a
+/// buffer nothing wrote and returns it as a screenshot. Bounding the wait (glass#383) is what
+/// makes that next capture reachable at all.
+struct CaptureObjects {
+    frame: ZwlrScreencopyFrameV1,
+    buffer: Option<wl_buffer::WlBuffer>,
+}
+
+impl Drop for CaptureObjects {
+    fn drop(&mut self) {
+        if let Some(buffer) = self.buffer.take() {
+            buffer.destroy();
+        }
+        self.frame.destroy();
+    }
 }
 
 /// SCTK state: registry + output (for the output extent), shm (for capture
@@ -1382,66 +1454,80 @@ impl Platform for WaylandPlatform {
             Some(r) => (wr.x + r.x as i32, wr.y + r.y as i32, r.width, r.height),
             None => (wr.x, wr.y, wr.width, wr.height),
         };
-        let frame = session.manager.capture_output_region(
-            0,
-            &session.output,
-            cx,
-            cy,
-            cw as i32,
-            ch as i32,
-            &qh,
-            (),
-        );
+        let mut owned = CaptureObjects {
+            frame: session.manager.capture_output_region(
+                0,
+                &session.output,
+                cx,
+                cy,
+                cw as i32,
+                ch as i32,
+                &qh,
+                (),
+            ),
+            buffer: None,
+        };
 
-        let deadline = Instant::now() + CAPTURE_BUDGET;
+        let deadline = capture_deadline();
 
         // Phase 1: dispatch until the compositor has advertised its buffer formats, then pick one
         // we can convert (preferring 32-bit). `buffer_done` marks the end of the list — a v3
         // event, which is why the manager is bound at v3 exactly.
-        let (format, w, h, stride) = loop {
-            dispatch_until(
-                &session.conn,
-                &mut session.queue,
-                &mut session.state,
-                deadline,
-            )?;
-            if session.state.buffer_done {
-                break crate::pixels::pick_shm_format(&session.state.shm_buffers).ok_or_else(
-                    || GlassError::CaptureFailed("screencopy: no shm format advertised".into()),
-                )?;
+        let (format, w, h, stride) = wait_for(
+            &session.conn,
+            &mut session.queue,
+            &mut session.state,
+            deadline,
+            "screencopy: no buffer event",
+            |s| {
+                if s.buffer_done {
+                    return Some(
+                        crate::pixels::pick_shm_format(&s.shm_buffers).ok_or_else(|| {
+                            GlassError::CaptureFailed("screencopy: no shm format advertised".into())
+                        }),
+                    );
+                }
+                match s.capture_done.take() {
+                    Some(Err(e)) => Some(Err(e)),
+                    // Nothing has been asked to be copied yet, so a `ready` here belongs to no
+                    // request of this capture's.
+                    Some(Ok(())) => Some(Err(GlassError::CaptureFailed(
+                        "screencopy: ready before the buffer list ended".into(),
+                    ))),
+                    None => None,
+                }
+            },
+        )
+        // A compositor that advertises formats and never ends the list is a different fault from
+        // one that says nothing, and only one of them is about the version glass binds.
+        .map_err(|e| {
+            match (&e, session.state.shm_buffers.is_empty()) {
+            (GlassError::CaptureFailed(m), false) if m == "screencopy: no buffer event" => {
+                GlassError::CaptureFailed(
+                    "screencopy: buffer formats advertised, but no buffer_done (v3) to end the list"
+                        .into(),
+                )
             }
-            if let Some(Err(e)) = session.state.capture_done.take() {
-                return Err(e);
-            }
-            if Instant::now() >= deadline {
-                return Err(GlassError::CaptureFailed(
-                    "screencopy: no buffer event".into(),
-                ));
-            }
-        };
+            _ => e,
+        }
+        })?;
 
         // Allocate a matching shm buffer and request the copy.
         let mut pool = RawPool::new((stride * h) as usize, &session.state.shm)
             .map_err(|e| GlassError::CaptureFailed(format!("shm pool: {e}")))?;
         let buffer = pool.create_buffer(0, w as i32, h as i32, stride as i32, format, (), &qh);
-        frame.copy(&buffer);
+        owned.frame.copy(&buffer);
+        owned.buffer = Some(buffer);
 
         // Phase 2: dispatch until ready/failed.
-        loop {
-            dispatch_until(
-                &session.conn,
-                &mut session.queue,
-                &mut session.state,
-                deadline,
-            )?;
-            if let Some(done) = session.state.capture_done.take() {
-                done?;
-                break;
-            }
-            if Instant::now() >= deadline {
-                return Err(GlassError::CaptureFailed("screencopy timed out".into()));
-            }
-        }
+        wait_for(
+            &session.conn,
+            &mut session.queue,
+            &mut session.state,
+            deadline,
+            "screencopy: no ready event after the copy request",
+            |s| s.capture_done.take(),
+        )?;
 
         // The captured buffer already matches the requested region, so no CPU crop.
         let rgba = crate::pixels::to_rgba(pool.mmap(), format, w, h, stride)?;
@@ -1740,29 +1826,104 @@ mod pure_tests {
     use std::os::unix::fs::PermissionsExt as _;
 
     use super::*;
+    use crate::testw::on_a_thread;
+
+    /// How long the pure waits below get before the test decides they are never coming back. Well
+    /// past their own budget, which is what makes a lost bound a failure rather than a hang.
+    const PURE_WAIT_BUDGET: Duration = Duration::from_millis(300);
+
+    /// [`wait_for`] over a socket with nothing behind it, answering a question the peer is never
+    /// told about — so only the deadline can end it. `speak` acts as the peer and hands back the
+    /// end to keep open, or `None` to close it.
+    fn wait_over_a_socket(
+        speak: impl FnOnce(UnixStream) -> Option<UnixStream>,
+    ) -> (std::result::Result<(), GlassError>, Duration) {
+        let (ours, theirs) = UnixStream::pair().expect("socketpair");
+        let conn = Connection::from_socket(ours).expect("a connection over the socket");
+        let mut queue = conn.new_event_queue::<()>();
+        let _peer = speak(theirs);
+        let started = Instant::now();
+        let outcome = wait_for(
+            &conn,
+            &mut queue,
+            &mut (),
+            Instant::now() + PURE_WAIT_BUDGET,
+            "nothing arrived",
+            |()| None,
+        );
+        (outcome, started.elapsed())
+    }
 
     /// The other end stays open and silent, so nothing can arrive and nothing signals the end of
     /// the connection either — what a wedged compositor looks like from this side.
     #[test]
-    fn a_dispatch_gives_up_on_a_peer_that_never_speaks() {
-        let (ours, _theirs) = UnixStream::pair().expect("socketpair");
-        let conn = Connection::from_socket(ours).expect("a connection over the socket");
-        let mut queue = conn.new_event_queue::<()>();
-        let budget = Duration::from_millis(300);
+    fn a_wait_gives_up_on_a_peer_that_never_speaks() {
+        let (outcome, elapsed) = on_a_thread(
+            PURE_WAIT_BUDGET * 20,
+            "the wait was not bounded: it never came back",
+            || wait_over_a_socket(Some),
+        );
 
-        let started = Instant::now();
-        dispatch_until(&conn, &mut queue, &mut (), Instant::now() + budget)
-            .expect("silence is the caller's to interpret, not an error here");
-        let elapsed = started.elapsed();
-
+        let err = outcome.expect_err("a question nothing answered is a failure");
+        assert!(err.to_string().contains("nothing arrived"), "{err}");
         assert!(
-            elapsed < budget * 10,
-            "the wait was not bounded by the deadline: {elapsed:?}"
+            elapsed < PURE_WAIT_BUDGET * 10,
+            "the wait outlived its deadline by too much to be bounded by it: {elapsed:?}"
         );
         assert!(
-            elapsed >= budget,
+            elapsed >= PURE_WAIT_BUDGET,
             "the deadline was cut short, so a compositor merely slow to answer would be given up \
              on: {elapsed:?}"
+        );
+    }
+
+    /// The half of the contract silence cannot show: the poll must return on the fd, not sleep out
+    /// the deadline. A wait that ignored readiness would still pass the test above.
+    #[test]
+    fn a_wait_stops_waiting_as_soon_as_the_peer_speaks() {
+        let (outcome, elapsed) = on_a_thread(
+            PURE_WAIT_BUDGET * 20,
+            "the wait ignored a peer that spoke",
+            || {
+                wait_over_a_socket(|mut theirs| {
+                    // Bytes no wayland event could be made of: what they mean is not the point —
+                    // the wait must come back rather than sit out its budget.
+                    theirs
+                        .write_all(&[0xff; 32])
+                        .expect("write to the socketpair");
+                    Some(theirs)
+                })
+            },
+        );
+
+        assert!(
+            outcome.is_err(),
+            "the peer said something unreadable; that is not an answer to the question"
+        );
+        assert!(
+            elapsed < PURE_WAIT_BUDGET / 2,
+            "the wait sat out its deadline with an answer already on the socket: {elapsed:?}"
+        );
+    }
+
+    /// A compositor that exits is a different fault from one that goes quiet, and reporting it as
+    /// a timeout would send the reader looking for a stall that never happened.
+    #[test]
+    fn a_wait_reports_a_peer_that_went_away_rather_than_timing_out() {
+        let (outcome, elapsed) = on_a_thread(
+            PURE_WAIT_BUDGET * 20,
+            "the wait did not notice the peer had gone",
+            || wait_over_a_socket(|_| None),
+        );
+
+        let err = outcome.expect_err("a connection that ended cannot answer");
+        assert!(
+            !err.to_string().contains("nothing arrived"),
+            "the end of the connection was reported as silence: {err}"
+        );
+        assert!(
+            elapsed < PURE_WAIT_BUDGET / 2,
+            "a closed connection should be noticed at once: {elapsed:?}"
         );
     }
 
@@ -2742,12 +2903,12 @@ mod session_tests {
         assert_eq!(px[3], 255, "opaque");
     }
 
-    /// How long a suspended compositor stays suspended if nothing resumes it. Past the capture
-    /// budget, so a capture that is bounded is over long before this fires.
+    /// How long a suspended compositor stays suspended if nothing resumes it. The bracket
+    /// assertion on `CAPTURE_BUDGET` caps a capture at 15s, so a bounded one is always over first.
     const SUSPENSION: Duration = Duration::from_secs(30);
 
-    /// SIGSTOPs a process until dropped: a compositor that holds the connection open and answers
-    /// nothing, which is the one thing a live sway will not do on request.
+    /// SIGSTOPs a process until dropped: a compositor holding its connection open and answering
+    /// nothing. sway has no IPC command that does this, which is why the test signals it.
     ///
     /// A stuck capture cannot be failed from the test thread — it is the test thread — so the
     /// resume also runs from a watchdog after [`SUSPENSION`]. Without it a lost bound would wedge
@@ -2759,14 +2920,18 @@ mod session_tests {
 
     impl Suspended {
         fn process(pid: u32) -> Suspended {
-            let pid = rustix::process::Pid::from_raw(pid as i32).expect("a live pid");
+            let pid = rustix::process::Pid::from_raw(pid as i32).expect("a non-zero pid");
             rustix::process::kill_process(pid, rustix::process::Signal::STOP).expect("SIGSTOP");
             let (resume, wait) = std::sync::mpsc::channel();
             let watchdog = std::thread::spawn(move || {
-                // Either end of the wait resumes it: the drop below, or the timeout.
+                // Either end of the wait resumes it: the drop below, or the timeout. The pid
+                // cannot have been recycled by then — the session still holds it as an unreaped
+                // child, and `Drop` joins this thread before teardown reaps it.
                 let _ = wait.recv_timeout(SUSPENSION);
-                let _ = rustix::process::kill_process(pid, rustix::process::Signal::CONT);
+                rustix::process::kill_process(pid, rustix::process::Signal::CONT)
+                    .expect("SIGCONT the suspended compositor");
             });
+            wait_until_stopped(pid);
             Suspended {
                 resume: Some(resume),
                 watchdog: Some(watchdog),
@@ -2778,11 +2943,33 @@ mod session_tests {
         fn drop(&mut self) {
             drop(self.resume.take());
             // Joined, so the compositor is running again before the session teardown that follows
-            // asks it to close.
+            // asks it to close. A watchdog that panicked left it stopped, which is worth the test
+            // — but not at the cost of aborting the process over an unrelated failure.
             if let Some(w) = self.watchdog.take() {
-                let _ = w.join();
+                let joined = w.join();
+                if !std::thread::panicking() {
+                    joined.expect("the watchdog resumed the compositor");
+                }
             }
         }
+    }
+
+    /// Spin until the kernel reports the process stopped. `kill` returns once the signal is
+    /// pending, so without this a compositor on another core can still service the request the
+    /// test is about to make.
+    fn wait_until_stopped(pid: rustix::process::Pid) {
+        let stat = format!("/proc/{}/stat", pid.as_raw_nonzero());
+        for _ in 0..1000 {
+            // Field 3, after the comm field — which is parenthesised and may itself contain
+            // spaces, so the split starts at the last ')'.
+            let read = std::fs::read_to_string(&stat).expect("the compositor's /proc entry");
+            let after_comm = read.rsplit_once(')').expect("a comm field").1;
+            if after_comm.split_whitespace().next() == Some("T") {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        panic!("the compositor never reached the stopped state");
     }
 
     /// glass#383: the capture checked its deadline only after `blocking_dispatch` returned, and
@@ -2801,19 +2988,20 @@ mod session_tests {
         let _suspended = Suspended::process(pid);
 
         let started = Instant::now();
-        let err = s
-            .platform()
-            .capture_frame(None)
-            .expect_err("a suspended compositor cannot answer a capture");
+        // Not `expect_err`: on the failure this test exists to catch, the watchdog resumes the
+        // compositor and the capture succeeds — printing a whole window of pixels as the reason.
+        let Err(err) = s.platform().capture_frame(None) else {
+            panic!("the capture was not bounded: it waited the compositor out and then succeeded");
+        };
         let elapsed = started.elapsed();
 
         assert!(
             elapsed < SUSPENSION * 2 / 3,
             "the capture waited the compositor out rather than bounding it: {elapsed:?}"
         );
-        // The other end of the bracket: every other capture test answers in milliseconds, so a
-        // budget cut to nothing would leave them green while a loaded compositor's captures all
-        // failed.
+        // The other end of the bracket: the fast capture tests cannot tell a 5s budget from a 5ms
+        // one, so without this a budget cut to nothing leaves them green while every capture on a
+        // loaded compositor fails.
         assert!(
             elapsed >= Duration::from_secs(2),
             "the capture budget is no longer generous enough for a compositor under load: \
@@ -2822,6 +3010,50 @@ mod session_tests {
         assert!(
             err.to_string().contains("no buffer event"),
             "the capture should report what never arrived: {err}"
+        );
+    }
+
+    /// The frame a bounded-out capture abandons is still the compositor's to answer, and the
+    /// per-capture scratch it answers into is keyed by nothing — so the next capture takes those
+    /// events for its own unless the abandoned frame is destroyed. Sizes differ so a stolen
+    /// `buffer` event is a visible fault rather than a coincidence.
+    #[test]
+    #[ignore = "starts a real compositor or X server; needs sway, Mesa, Xwayland or Xvfb"]
+    fn a_capture_that_follows_an_abandoned_one_reads_its_own_frame() {
+        let mut s = Launch::new().windows(&["cap:cap:200x160"]).start_mapped();
+        let pid = s
+            .platform()
+            .session_compositor_pid()
+            .expect("a started session has a compositor");
+
+        let region = |width, height| Region {
+            x: 0,
+            y: 0,
+            width,
+            height,
+        };
+        {
+            let _suspended = Suspended::process(pid);
+            s.platform()
+                .capture_frame(Some(&region(50, 40)))
+                .expect_err("a suspended compositor cannot answer a capture");
+        }
+
+        // The compositor is running again and still owes the abandoned frame its buffer events.
+        let frame = s
+            .platform()
+            .capture_frame(Some(&region(100, 80)))
+            .expect("the compositor is answering again");
+        assert_eq!(
+            (frame.width, frame.height),
+            (100, 80),
+            "the region this capture asked for, not the one before it"
+        );
+        let px = &frame.pixels[..4];
+        assert_eq!(
+            (px[0], px[1], px[2]),
+            crate::testw::window_fill_rgb(0),
+            "the window's own pixels, not a buffer nothing wrote"
         );
     }
 

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -500,7 +500,8 @@ fn rect_to_geom(r: &crate::swayipc::Rect) -> WindowGeometry {
     }
 }
 
-/// How long one capture may take, from the copy request to the last event it needs.
+/// How long one capture may take, from its request to the last event it needs — the format list,
+/// the copy, and the `ready` that ends it.
 const CAPTURE_BUDGET: Duration = Duration::from_secs(5);
 
 /// A capture waits on a compositor that is also driving the app being captured, so the budget has
@@ -512,15 +513,20 @@ const _: () = assert!(
     "the capture budget must leave a loaded compositor time to answer, without holding the session lock for long"
 );
 
-/// When the capture starting now must be over. A function, so removing the last use of
-/// [`CAPTURE_BUDGET`] from the capture path is a dead-code error rather than a constant left
-/// bracketed and unread.
-fn capture_deadline() -> Instant {
-    Instant::now() + CAPTURE_BUDGET
+fn capture_failed(what: &str, e: impl std::fmt::Display) -> GlassError {
+    GlassError::CaptureFailed(format!("screencopy: {what}: {e}"))
 }
 
-/// Dispatch whatever the compositor has sent, waiting no later than `deadline` for it to send
-/// something.
+/// Send what is queued and dispatch what has already arrived, without waiting for more.
+fn drain<S>(conn: &Connection, queue: &mut EventQueue<S>, state: &mut S) -> Result<()> {
+    conn.flush().map_err(|e| capture_failed("flush", e))?;
+    queue
+        .dispatch_pending(state)
+        .map_err(|e| capture_failed("dispatch", e))?;
+    Ok(())
+}
+
+/// Wait for the compositor to send something, no later than `deadline`, and dispatch it.
 ///
 /// `blocking_dispatch` waits on the socket with no timeout, so a deadline checked after it is not
 /// a bound: a compositor that goes quiet after the last event glass reacts to holds the caller —
@@ -529,8 +535,7 @@ fn capture_deadline() -> Instant {
 /// transfers use.
 ///
 /// Expiry is not an error here: this returns having made whatever progress it could, and
-/// [`wait_for`] owns the deadline. What is already in the queue is always dispatched first, so a
-/// budget spent down to nothing still delivers an answer that had already arrived.
+/// [`wait_for`] owns the deadline.
 ///
 /// Generic over the queue's state only so the bound can be tested against a socket with no
 /// compositor behind it; capture is the sole caller, hence the error variant.
@@ -540,22 +545,10 @@ fn dispatch_until<S>(
     state: &mut S,
     deadline: Instant,
 ) -> Result<()> {
-    fn failed(what: &str, e: impl std::fmt::Display) -> GlassError {
-        GlassError::CaptureFailed(format!("screencopy: {what}: {e}"))
-    }
-    let dispatch = |queue: &mut EventQueue<S>, state: &mut S| {
-        queue
-            .dispatch_pending(state)
-            .map_err(|e| failed("dispatch", e))
-    };
-    conn.flush().map_err(|e| failed("flush", e))?;
-    if dispatch(queue, state)? > 0 {
-        return Ok(());
-    }
     // `None` is a libwayland-backend condition glass cannot reach (the pure-Rust backend always
     // prepares), and it means the backend's own queue needs draining, not this one's.
     let Some(guard) = queue.prepare_read() else {
-        return Ok(());
+        return drain(conn, queue, state);
     };
     let Some(ts) = remaining_timespec(deadline) else {
         return Ok(());
@@ -578,14 +571,16 @@ fn dispatch_until<S>(
             // treats this as a retry, and so must this: it is a loaded host, not a fault.
             Err(wayland_client::backend::WaylandError::Io(e))
                 if e.kind() == std::io::ErrorKind::WouldBlock => {}
-            Err(e) => return Err(failed("read", e)),
+            Err(e) => return Err(capture_failed("read", e)),
         },
         // A signal arrived and nothing was lost; the caller's deadline decides whether there is
         // time to ask again.
         Err(rustix::io::Errno::INTR) => return Ok(()),
-        Err(e) => return Err(failed("poll", e)),
+        Err(e) => return Err(capture_failed("poll", e)),
     }
-    dispatch(queue, state)?;
+    queue
+        .dispatch_pending(state)
+        .map_err(|e| capture_failed("dispatch", e))?;
     Ok(())
 }
 
@@ -594,22 +589,26 @@ fn dispatch_until<S>(
 /// The deadline check lives here rather than in each caller's own loop: [`dispatch_until`] returns
 /// at once once the budget is spent, so a loop that forgot to check would not hang as it did
 /// before glass#383 — it would spin on a core holding the session lock, which is worse.
+///
+/// An answer already in hand is taken before the deadline is judged, so a phase that inherits a
+/// spent budget reports what arrived rather than a timeout.
 fn wait_for<S, T>(
     conn: &Connection,
     queue: &mut EventQueue<S>,
     state: &mut S,
     deadline: Instant,
-    expired: &str,
+    expired: impl FnOnce(&S) -> String,
     mut answered: impl FnMut(&mut S) -> Option<Result<T>>,
 ) -> Result<T> {
     loop {
-        dispatch_until(conn, queue, state, deadline)?;
+        drain(conn, queue, state)?;
         if let Some(answer) = answered(state) {
             return answer;
         }
         if Instant::now() >= deadline {
-            return Err(GlassError::CaptureFailed(expired.to_string()));
+            return Err(GlassError::CaptureFailed(expired(state)));
         }
+        dispatch_until(conn, queue, state, deadline)?;
     }
 }
 
@@ -635,6 +634,50 @@ impl Drop for CaptureObjects {
     }
 }
 
+/// What the compositor has said about the capture in flight. Held apart from the connection so
+/// that reading a capture out of it stays a plain function, testable without a compositor.
+#[derive(Default)]
+struct CaptureScratch {
+    shm_buffers: Vec<(wl_shm::Format, u32, u32, u32)>, // advertised formats (format, w, h, stride)
+    buffer_done: bool,                                 // v3: end of the format advertisement list
+    done: Option<Result<()>>,                          // Some(Ok)=ready, Some(Err)=failed
+}
+
+impl CaptureScratch {
+    /// The buffer to allocate, once the compositor has finished advertising formats.
+    ///
+    /// `None` while the list is still arriving — the caller's only reason to keep waiting.
+    fn advertised(&mut self) -> Option<Result<(wl_shm::Format, u32, u32, u32)>> {
+        if self.buffer_done {
+            return Some(
+                crate::pixels::pick_shm_format(&self.shm_buffers).ok_or_else(|| {
+                    GlassError::CaptureFailed("screencopy: no shm format advertised".into())
+                }),
+            );
+        }
+        match self.done.take() {
+            Some(Err(e)) => Some(Err(e)),
+            // Nothing has been asked to be copied yet, so a `ready` belongs to no request of this
+            // capture's.
+            Some(Ok(())) => Some(Err(GlassError::CaptureFailed(
+                "screencopy: ready before the buffer list ended".into(),
+            ))),
+            None => None,
+        }
+    }
+
+    /// Why the format list never finished. A compositor that advertised formats and never ended
+    /// the list is a different fault from one that said nothing, and only one of them is about the
+    /// version glass binds.
+    fn no_formats(&self) -> String {
+        if self.shm_buffers.is_empty() {
+            "screencopy: no buffer event".into()
+        } else {
+            "screencopy: buffer formats advertised, but no buffer_done (v3) to end the list".into()
+        }
+    }
+}
+
 /// SCTK state: registry + output (for the output extent), shm (for capture
 /// buffers), and the per-capture wlr-screencopy scratch (reset before each
 /// capture). Window enumeration is via sway IPC, not foreign-toplevel.
@@ -642,9 +685,7 @@ struct State {
     registry: RegistryState,
     output: OutputState,
     shm: Shm,
-    shm_buffers: Vec<(wl_shm::Format, u32, u32, u32)>, // advertised formats (format, w, h, stride)
-    buffer_done: bool,                                 // v3: end of the format advertisement list
-    capture_done: Option<Result<()>>,                  // Some(Ok)=ready, Some(Err)=failed
+    capture: CaptureScratch,
 }
 
 impl ProvidesRegistryState for State {
@@ -719,12 +760,12 @@ impl Dispatch<ZwlrScreencopyFrameV1, ()> for State {
                 height,
                 stride,
             } => {
-                state.shm_buffers.push((f, width, height, stride));
+                state.capture.shm_buffers.push((f, width, height, stride));
             }
-            Event::BufferDone => state.buffer_done = true,
-            Event::Ready { .. } => state.capture_done = Some(Ok(())),
+            Event::BufferDone => state.capture.buffer_done = true,
+            Event::Ready { .. } => state.capture.done = Some(Ok(())),
             Event::Failed => {
-                state.capture_done =
+                state.capture.done =
                     Some(Err(GlassError::CaptureFailed("screencopy failed".into())))
             }
             _ => {} // Flags, Damage, LinuxDmabuf, etc.
@@ -830,9 +871,7 @@ fn open_session(
         registry: RegistryState::new(&globals),
         output: OutputState::new(&globals, &qh),
         shm: Shm::bind(&globals, &qh).map_err(|e| GlassError::Backend(format!("bind shm: {e}")))?,
-        shm_buffers: Vec::new(),
-        buffer_done: false,
-        capture_done: None,
+        capture: CaptureScratch::default(),
     };
     // v3 exactly, not 1..=3: capture waits for `buffer_done`, which only v3 sends. The v1/v2
     // branch that waited differently was unreachable — glass only talks to the sway it launched.
@@ -1438,9 +1477,7 @@ impl Platform for WaylandPlatform {
 
     fn capture_frame(&mut self, region: Option<&Region>) -> Result<Frame> {
         let session = self.active.as_mut().ok_or(GlassError::NoActiveSession)?;
-        session.state.shm_buffers.clear();
-        session.state.buffer_done = false;
-        session.state.capture_done = None;
+        session.state.capture = CaptureScratch::default();
         let qh = session.queue.handle();
 
         // Map the (window-relative) request to OUTPUT coordinates by the active
@@ -1468,7 +1505,7 @@ impl Platform for WaylandPlatform {
             buffer: None,
         };
 
-        let deadline = capture_deadline();
+        let deadline = Instant::now() + CAPTURE_BUDGET;
 
         // Phase 1: dispatch until the compositor has advertised its buffer formats, then pick one
         // we can convert (preferring 32-bit). `buffer_done` marks the end of the list — a v3
@@ -1478,39 +1515,9 @@ impl Platform for WaylandPlatform {
             &mut session.queue,
             &mut session.state,
             deadline,
-            "screencopy: no buffer event",
-            |s| {
-                if s.buffer_done {
-                    return Some(
-                        crate::pixels::pick_shm_format(&s.shm_buffers).ok_or_else(|| {
-                            GlassError::CaptureFailed("screencopy: no shm format advertised".into())
-                        }),
-                    );
-                }
-                match s.capture_done.take() {
-                    Some(Err(e)) => Some(Err(e)),
-                    // Nothing has been asked to be copied yet, so a `ready` here belongs to no
-                    // request of this capture's.
-                    Some(Ok(())) => Some(Err(GlassError::CaptureFailed(
-                        "screencopy: ready before the buffer list ended".into(),
-                    ))),
-                    None => None,
-                }
-            },
-        )
-        // A compositor that advertises formats and never ends the list is a different fault from
-        // one that says nothing, and only one of them is about the version glass binds.
-        .map_err(|e| {
-            match (&e, session.state.shm_buffers.is_empty()) {
-            (GlassError::CaptureFailed(m), false) if m == "screencopy: no buffer event" => {
-                GlassError::CaptureFailed(
-                    "screencopy: buffer formats advertised, but no buffer_done (v3) to end the list"
-                        .into(),
-                )
-            }
-            _ => e,
-        }
-        })?;
+            |s| s.capture.no_formats(),
+            |s| s.capture.advertised(),
+        )?;
 
         // Allocate a matching shm buffer and request the copy.
         let mut pool = RawPool::new((stride * h) as usize, &session.state.shm)
@@ -1519,14 +1526,16 @@ impl Platform for WaylandPlatform {
         owned.frame.copy(&buffer);
         owned.buffer = Some(buffer);
 
-        // Phase 2: dispatch until ready/failed.
+        // Phase 2: dispatch until ready/failed. Bounded by the same `wait_for` as phase 1 and the
+        // same budget; nothing live proves this call site is the bounded one, so a change here has
+        // only the pure tests behind it.
         wait_for(
             &session.conn,
             &mut session.queue,
             &mut session.state,
             deadline,
-            "screencopy: no ready event after the copy request",
-            |s| s.capture_done.take(),
+            |_| "screencopy: no ready event after the copy request".into(),
+            |s| s.capture.done.take(),
         )?;
 
         // The captured buffer already matches the requested region, so no CPU crop.
@@ -1832,10 +1841,15 @@ mod pure_tests {
     /// past their own budget, which is what makes a lost bound a failure rather than a hang.
     const PURE_WAIT_BUDGET: Duration = Duration::from_millis(300);
 
+    /// Room for a wait that answers at once to be scheduled on a runner busy with the sway-backed
+    /// tests. Its own budget cannot be raised: the tests that use it assert on a fraction of it.
+    const PROMPT_WAIT_BUDGET: Duration = Duration::from_secs(1);
+
     /// [`wait_for`] over a socket with nothing behind it, answering a question the peer is never
     /// told about — so only the deadline can end it. `speak` acts as the peer and hands back the
     /// end to keep open, or `None` to close it.
     fn wait_over_a_socket(
+        budget: Duration,
         speak: impl FnOnce(UnixStream) -> Option<UnixStream>,
     ) -> (std::result::Result<(), GlassError>, Duration) {
         let (ours, theirs) = UnixStream::pair().expect("socketpair");
@@ -1847,8 +1861,8 @@ mod pure_tests {
             &conn,
             &mut queue,
             &mut (),
-            Instant::now() + PURE_WAIT_BUDGET,
-            "nothing arrived",
+            Instant::now() + budget,
+            |()| "nothing arrived".into(),
             |()| None,
         );
         (outcome, started.elapsed())
@@ -1860,8 +1874,8 @@ mod pure_tests {
     fn a_wait_gives_up_on_a_peer_that_never_speaks() {
         let (outcome, elapsed) = on_a_thread(
             PURE_WAIT_BUDGET * 20,
-            "the wait was not bounded: it never came back",
-            || wait_over_a_socket(Some),
+            "the wait never came back, so it is not bounded by its deadline",
+            || wait_over_a_socket(PURE_WAIT_BUDGET, Some),
         );
 
         let err = outcome.expect_err("a question nothing answered is a failure");
@@ -1882,12 +1896,12 @@ mod pure_tests {
     #[test]
     fn a_wait_stops_waiting_as_soon_as_the_peer_speaks() {
         let (outcome, elapsed) = on_a_thread(
-            PURE_WAIT_BUDGET * 20,
-            "the wait ignored a peer that spoke",
+            PROMPT_WAIT_BUDGET * 20,
+            "the wait did not come back from a peer that spoke",
             || {
-                wait_over_a_socket(|mut theirs| {
-                    // Bytes no wayland event could be made of: what they mean is not the point —
-                    // the wait must come back rather than sit out its budget.
+                wait_over_a_socket(PROMPT_WAIT_BUDGET, |mut theirs| {
+                    // A whole message, and nonsense: what it means is not the point — the wait
+                    // must come back rather than sit out its budget.
                     theirs
                         .write_all(&[0xff; 32])
                         .expect("write to the socketpair");
@@ -1901,8 +1915,37 @@ mod pure_tests {
             "the peer said something unreadable; that is not an answer to the question"
         );
         assert!(
-            elapsed < PURE_WAIT_BUDGET / 2,
-            "the wait sat out its deadline with an answer already on the socket: {elapsed:?}"
+            elapsed < PROMPT_WAIT_BUDGET / 2,
+            "the wait sat out its deadline with something already on the socket: {elapsed:?}"
+        );
+    }
+
+    /// Half a message is not a fault: the rest is still on its way, and upstream's own reader
+    /// retries. Failing the capture here would make a screenshot flake on a loaded host, where a
+    /// write is likeliest to be split.
+    #[test]
+    fn a_wait_keeps_waiting_through_half_a_message() {
+        let (outcome, elapsed) = on_a_thread(
+            PURE_WAIT_BUDGET * 20,
+            "the wait never came back from a partial message",
+            || {
+                // Under the 8 bytes a wayland message header takes, so the read consumes it and
+                // finds nothing behind it.
+                wait_over_a_socket(PURE_WAIT_BUDGET, |mut theirs| {
+                    theirs.write_all(&[0; 4]).expect("write to the socketpair");
+                    Some(theirs)
+                })
+            },
+        );
+
+        let err = outcome.expect_err("half a message answers nothing");
+        assert!(
+            err.to_string().contains("nothing arrived"),
+            "a partial message was reported as a read failure: {err}"
+        );
+        assert!(
+            elapsed >= PURE_WAIT_BUDGET,
+            "the wait gave up on the rest of the message instead of waiting for it: {elapsed:?}"
         );
     }
 
@@ -1911,19 +1954,131 @@ mod pure_tests {
     #[test]
     fn a_wait_reports_a_peer_that_went_away_rather_than_timing_out() {
         let (outcome, elapsed) = on_a_thread(
-            PURE_WAIT_BUDGET * 20,
+            PROMPT_WAIT_BUDGET * 20,
             "the wait did not notice the peer had gone",
-            || wait_over_a_socket(|_| None),
+            || wait_over_a_socket(PROMPT_WAIT_BUDGET, |_| None),
         );
 
         let err = outcome.expect_err("a connection that ended cannot answer");
         assert!(
-            !err.to_string().contains("nothing arrived"),
-            "the end of the connection was reported as silence: {err}"
+            err.to_string().contains("read"),
+            "the end of the connection should be reported where it was found: {err}"
         );
         assert!(
-            elapsed < PURE_WAIT_BUDGET / 2,
+            elapsed < PROMPT_WAIT_BUDGET / 2,
             "a closed connection should be noticed at once: {elapsed:?}"
+        );
+    }
+
+    /// A phase that inherits a budget the phase before it spent still has an answer in hand, and a
+    /// timeout would discard it — the compositor did everything asked of it.
+    #[test]
+    fn a_wait_takes_an_answer_already_in_hand_over_a_spent_budget() {
+        let (ours, _theirs) = UnixStream::pair().expect("socketpair");
+        let conn = Connection::from_socket(ours).expect("a connection over the socket");
+        let mut queue = conn.new_event_queue::<()>();
+
+        let answered = wait_for(
+            &conn,
+            &mut queue,
+            &mut (),
+            Instant::now() - Duration::from_secs(1),
+            |()| "nothing arrived".into(),
+            |()| Some(Ok(7)),
+        );
+
+        assert_eq!(answered.expect("the answer, not the expired budget"), 7);
+    }
+
+    /// A scratch holding one advertised format, as the compositor's `buffer` event leaves it.
+    fn advertised_one() -> CaptureScratch {
+        CaptureScratch {
+            shm_buffers: vec![(wl_shm::Format::Xrgb8888, 40, 30, 160)],
+            ..CaptureScratch::default()
+        }
+    }
+
+    #[test]
+    fn a_finished_format_list_yields_the_buffer_to_allocate() {
+        let mut scratch = CaptureScratch {
+            buffer_done: true,
+            ..advertised_one()
+        };
+        assert_eq!(
+            scratch
+                .advertised()
+                .expect("the list ended")
+                .expect("a format"),
+            (wl_shm::Format::Xrgb8888, 40, 30, 160)
+        );
+    }
+
+    /// A list that ends with nothing glass can convert is a failure, not a wait: no further event
+    /// is coming.
+    #[test]
+    fn a_finished_but_empty_format_list_is_a_failure() {
+        let mut scratch = CaptureScratch {
+            buffer_done: true,
+            ..CaptureScratch::default()
+        };
+        let err = scratch
+            .advertised()
+            .expect("the list ended")
+            .expect_err("nothing to allocate");
+        assert!(
+            err.to_string().contains("no shm format advertised"),
+            "{err}"
+        );
+    }
+
+    /// A refusal is the compositor's final word, so it ends the wait rather than running it out.
+    #[test]
+    fn a_refusal_during_the_format_list_ends_the_wait() {
+        let mut scratch = CaptureScratch {
+            done: Some(Err(GlassError::CaptureFailed("screencopy failed".into()))),
+            ..CaptureScratch::default()
+        };
+        let err = scratch
+            .advertised()
+            .expect("a refusal is an answer")
+            .expect_err("the refusal");
+        assert!(err.to_string().contains("screencopy failed"), "{err}");
+    }
+
+    /// Nothing has been asked to be copied yet, so a `ready` cannot be this capture's. Taking it
+    /// as one ends the next phase over a buffer nothing wrote.
+    #[test]
+    fn a_ready_before_the_format_list_ends_is_a_failure() {
+        let mut scratch = CaptureScratch {
+            done: Some(Ok(())),
+            ..CaptureScratch::default()
+        };
+        let err = scratch
+            .advertised()
+            .expect("a ready is an answer, wrong as it is")
+            .expect_err("not this capture's");
+        assert!(
+            err.to_string().contains("ready before the buffer list"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn an_unfinished_format_list_is_not_yet_an_answer() {
+        assert!(advertised_one().advertised().is_none());
+    }
+
+    /// Silence and a list that never ends are different faults, and only the second is about the
+    /// protocol version glass binds.
+    #[test]
+    fn a_timeout_names_silence_and_an_unfinished_list_apart() {
+        assert_eq!(
+            CaptureScratch::default().no_formats(),
+            "screencopy: no buffer event"
+        );
+        assert!(
+            advertised_one().no_formats().contains("buffer_done"),
+            "a list that started and never ended should say so"
         );
     }
 
@@ -3011,6 +3166,35 @@ mod session_tests {
             err.to_string().contains("no buffer event"),
             "the capture should report what never arrived: {err}"
         );
+    }
+
+    /// The frame is what a capture that gave up must not leave behind; the buffer is what keeps
+    /// the compositor's mapping of that frame's memory resident, which no capture reaches through
+    /// `capture_frame` (only a copy that timed out owns one) and every capture in a
+    /// `glass_wait_stable` loop would add to.
+    #[test]
+    #[ignore = "starts a real compositor or X server; needs sway, Mesa, Xwayland or Xvfb"]
+    fn the_objects_a_capture_owns_are_destroyed_with_it() {
+        use wayland_client::Proxy as _;
+
+        let mut s = Launch::new().start();
+        let session = s.platform().active.as_mut().expect("a started session");
+        let qh = session.queue.handle();
+        let frame = session
+            .manager
+            .capture_output_region(0, &session.output, 0, 0, 8, 8, &qh, ());
+        let mut pool = RawPool::new(8 * 4 * 8, &session.state.shm).expect("shm pool");
+        let buffer = pool.create_buffer(0, 8, 8, 8 * 4, wl_shm::Format::Xrgb8888, (), &qh);
+        // Clones of the same objects: a proxy reports the object's state, not its own.
+        let (frame_after, buffer_after) = (frame.clone(), buffer.clone());
+
+        drop(CaptureObjects {
+            frame,
+            buffer: Some(buffer),
+        });
+
+        assert!(!frame_after.is_alive(), "the frame outlived its capture");
+        assert!(!buffer_after.is_alive(), "the buffer outlived its capture");
     }
 
     /// The frame a bounded-out capture abandons is still the compositor's to answer, and the

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -35,6 +35,7 @@ use wayland_protocols_wlr::virtual_pointer::v1::client::zwlr_virtual_pointer_v1:
 
 use std::collections::HashMap;
 
+use crate::clipboard::remaining_timespec;
 use crate::command::{LogSink, build_sway_command, sway_config};
 use crate::input::evdev_button;
 use crate::swayipc::{Ipc, Window as SwayWindow};
@@ -139,6 +140,12 @@ impl WaylandPlatform {
     /// IPC socket. Lets a test observe the session over a connection this backend does not own.
     pub(crate) fn session_runtime_dir(&self) -> Option<&Path> {
         self.active.as_ref()?.socket_path.parent()
+    }
+
+    /// The compositor's own pid, for a test that has to act on the compositor rather than through
+    /// it — signalling it, which no session method exposes.
+    pub(crate) fn session_compositor_pid(&self) -> Option<u32> {
+        Some(self.active.as_ref()?.child.id())
     }
 }
 
@@ -491,6 +498,69 @@ fn rect_to_geom(r: &crate::swayipc::Rect) -> WindowGeometry {
         width: r.width.max(0) as u32,
         height: r.height.max(0) as u32,
     }
+}
+
+/// How long one capture may spend waiting on the compositor, across both of its dispatch phases.
+const CAPTURE_BUDGET: Duration = Duration::from_millis(5000);
+
+/// A capture waits on a compositor that is also driving the app being captured, so the budget has
+/// to cover a loaded host, and the whole session lock is held meanwhile. The floor is what no test
+/// can see: `capture_frame`'s live test only proves the wait ends.
+const _: () = assert!(
+    CAPTURE_BUDGET.as_millis() >= 2000 && CAPTURE_BUDGET.as_millis() <= 15_000,
+    "the capture budget must leave a loaded compositor time to answer, without holding the session lock for long"
+);
+
+/// Wait for the compositor to send something, giving up at `deadline`.
+///
+/// `blocking_dispatch` returns only once an event has arrived, so a deadline checked after it is
+/// not a bound: a compositor that goes quiet after the last event glass reacts to holds the caller
+/// — and, through the session lock, every other tool call — indefinitely (glass#383). Poll the
+/// connection fd for what is left of the deadline instead, as the clipboard's owner loop does.
+///
+/// Returns once events have been dispatched, or once the deadline passed with nothing to read; the
+/// caller re-checks its own condition and its own deadline either way, so expiry is not an error
+/// here.
+///
+/// Generic over the queue's state only so the bound can be tested against a socket with no
+/// compositor behind it; capture is the sole caller, hence the error variant.
+fn dispatch_until<S>(
+    conn: &Connection,
+    queue: &mut EventQueue<S>,
+    state: &mut S,
+    deadline: Instant,
+) -> Result<()> {
+    fn failed(what: &str, e: impl std::fmt::Display) -> GlassError {
+        GlassError::CaptureFailed(format!("screencopy: {what}: {e}"))
+    }
+    conn.flush().map_err(|e| failed("flush", e))?;
+    // `None` means events are already queued: dispatch them rather than waiting for more.
+    if let Some(guard) = queue.prepare_read() {
+        let Some(ts) = remaining_timespec(deadline) else {
+            return Ok(());
+        };
+        let fd = conn.as_fd();
+        match rustix::event::poll(
+            &mut [rustix::event::PollFd::new(
+                &fd,
+                rustix::event::PollFlags::IN,
+            )],
+            Some(&ts),
+        ) {
+            Ok(0) => return Ok(()),
+            Ok(_) => {
+                guard.read().map_err(|e| failed("read", e))?;
+            }
+            // A signal arrived and nothing was lost; the caller's deadline decides whether there
+            // is time to ask again.
+            Err(rustix::io::Errno::INTR) => return Ok(()),
+            Err(e) => return Err(failed("poll", e)),
+        }
+    }
+    queue
+        .dispatch_pending(state)
+        .map_err(|e| failed("dispatch", e))?;
+    Ok(())
 }
 
 /// SCTK state: registry + output (for the output extent), shm (for capture
@@ -1323,16 +1393,18 @@ impl Platform for WaylandPlatform {
             (),
         );
 
-        let deadline = Instant::now() + Duration::from_millis(5000);
+        let deadline = Instant::now() + CAPTURE_BUDGET;
 
         // Phase 1: dispatch until the compositor has advertised its buffer formats, then pick one
         // we can convert (preferring 32-bit). `buffer_done` marks the end of the list — a v3
         // event, which is why the manager is bound at v3 exactly.
         let (format, w, h, stride) = loop {
-            session
-                .queue
-                .blocking_dispatch(&mut session.state)
-                .map_err(|e| GlassError::CaptureFailed(format!("dispatch: {e}")))?;
+            dispatch_until(
+                &session.conn,
+                &mut session.queue,
+                &mut session.state,
+                deadline,
+            )?;
             if session.state.buffer_done {
                 break crate::pixels::pick_shm_format(&session.state.shm_buffers).ok_or_else(
                     || GlassError::CaptureFailed("screencopy: no shm format advertised".into()),
@@ -1356,10 +1428,12 @@ impl Platform for WaylandPlatform {
 
         // Phase 2: dispatch until ready/failed.
         loop {
-            session
-                .queue
-                .blocking_dispatch(&mut session.state)
-                .map_err(|e| GlassError::CaptureFailed(format!("dispatch: {e}")))?;
+            dispatch_until(
+                &session.conn,
+                &mut session.queue,
+                &mut session.state,
+                deadline,
+            )?;
             if let Some(done) = session.state.capture_done.take() {
                 done?;
                 break;
@@ -1666,6 +1740,31 @@ mod pure_tests {
     use std::os::unix::fs::PermissionsExt as _;
 
     use super::*;
+
+    /// The other end stays open and silent, so nothing can arrive and nothing signals the end of
+    /// the connection either — what a wedged compositor looks like from this side.
+    #[test]
+    fn a_dispatch_gives_up_on_a_peer_that_never_speaks() {
+        let (ours, _theirs) = UnixStream::pair().expect("socketpair");
+        let conn = Connection::from_socket(ours).expect("a connection over the socket");
+        let mut queue = conn.new_event_queue::<()>();
+        let budget = Duration::from_millis(300);
+
+        let started = Instant::now();
+        dispatch_until(&conn, &mut queue, &mut (), Instant::now() + budget)
+            .expect("silence is the caller's to interpret, not an error here");
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < budget * 10,
+            "the wait was not bounded by the deadline: {elapsed:?}"
+        );
+        assert!(
+            elapsed >= budget,
+            "the deadline was cut short, so a compositor merely slow to answer would be given up \
+             on: {elapsed:?}"
+        );
+    }
 
     fn win(identifier: &str, x11: Option<u32>) -> SwayWindow {
         SwayWindow {
@@ -2641,6 +2740,89 @@ mod session_tests {
             "the window's own fill colour, not the compositor's background"
         );
         assert_eq!(px[3], 255, "opaque");
+    }
+
+    /// How long a suspended compositor stays suspended if nothing resumes it. Past the capture
+    /// budget, so a capture that is bounded is over long before this fires.
+    const SUSPENSION: Duration = Duration::from_secs(30);
+
+    /// SIGSTOPs a process until dropped: a compositor that holds the connection open and answers
+    /// nothing, which is the one thing a live sway will not do on request.
+    ///
+    /// A stuck capture cannot be failed from the test thread — it is the test thread — so the
+    /// resume also runs from a watchdog after [`SUSPENSION`]. Without it a lost bound would wedge
+    /// the whole suite instead of failing one test.
+    struct Suspended {
+        resume: Option<std::sync::mpsc::Sender<()>>,
+        watchdog: Option<std::thread::JoinHandle<()>>,
+    }
+
+    impl Suspended {
+        fn process(pid: u32) -> Suspended {
+            let pid = rustix::process::Pid::from_raw(pid as i32).expect("a live pid");
+            rustix::process::kill_process(pid, rustix::process::Signal::STOP).expect("SIGSTOP");
+            let (resume, wait) = std::sync::mpsc::channel();
+            let watchdog = std::thread::spawn(move || {
+                // Either end of the wait resumes it: the drop below, or the timeout.
+                let _ = wait.recv_timeout(SUSPENSION);
+                let _ = rustix::process::kill_process(pid, rustix::process::Signal::CONT);
+            });
+            Suspended {
+                resume: Some(resume),
+                watchdog: Some(watchdog),
+            }
+        }
+    }
+
+    impl Drop for Suspended {
+        fn drop(&mut self) {
+            drop(self.resume.take());
+            // Joined, so the compositor is running again before the session teardown that follows
+            // asks it to close.
+            if let Some(w) = self.watchdog.take() {
+                let _ = w.join();
+            }
+        }
+    }
+
+    /// glass#383: the capture checked its deadline only after `blocking_dispatch` returned, and
+    /// that returns only when an event arrives — so a compositor that went quiet held the capture,
+    /// and with it the session lock every other tool call waits on.
+    #[test]
+    #[ignore = "starts a real compositor or X server; needs sway, Mesa, Xwayland or Xvfb"]
+    fn a_capture_gives_up_on_a_compositor_that_stops_answering() {
+        let mut s = Launch::new().start_mapped();
+        let pid = s
+            .platform()
+            .session_compositor_pid()
+            .expect("a started session has a compositor");
+        // Declared after the session, so it resumes the compositor before the session is torn
+        // down over it.
+        let _suspended = Suspended::process(pid);
+
+        let started = Instant::now();
+        let err = s
+            .platform()
+            .capture_frame(None)
+            .expect_err("a suspended compositor cannot answer a capture");
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < SUSPENSION * 2 / 3,
+            "the capture waited the compositor out rather than bounding it: {elapsed:?}"
+        );
+        // The other end of the bracket: every other capture test answers in milliseconds, so a
+        // budget cut to nothing would leave them green while a loaded compositor's captures all
+        // failed.
+        assert!(
+            elapsed >= Duration::from_secs(2),
+            "the capture budget is no longer generous enough for a compositor under load: \
+             {elapsed:?}"
+        );
+        assert!(
+            err.to_string().contains("no buffer event"),
+            "the capture should report what never arrived: {err}"
+        );
     }
 
     /// A refused capture must surface as an error: a caller cannot tell a blank frame from a

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -142,8 +142,7 @@ impl WaylandPlatform {
         self.active.as_ref()?.socket_path.parent()
     }
 
-    /// The compositor's own pid, for a test that has to act on the compositor rather than through
-    /// it — signalling it, which no session method exposes.
+    /// The compositor's own pid, for a test that must signal it rather than talk to it.
     pub(crate) fn session_compositor_pid(&self) -> Option<u32> {
         self.active.as_ref().map(|s| s.child.id())
     }
@@ -504,10 +503,8 @@ fn rect_to_geom(r: &crate::swayipc::Rect) -> WindowGeometry {
 /// the copy, and the `ready` that ends it.
 const CAPTURE_BUDGET: Duration = Duration::from_secs(5);
 
-/// A capture waits on a compositor that is also driving the app being captured, so the budget has
-/// to cover a loaded host — and the session lock is held for all of it, so it cannot be generous.
-/// Both ends are also asserted live, but only by a test that needs sway: on every other CI leg
-/// this is the whole guard.
+/// Both ends are asserted live too, but only by a test that needs sway: on every other CI leg this
+/// is the whole guard.
 const _: () = assert!(
     CAPTURE_BUDGET.as_secs() >= 2 && CAPTURE_BUDGET.as_secs() <= 15,
     "the capture budget must leave a loaded compositor time to answer, without holding the session lock for long"
@@ -529,24 +526,21 @@ fn drain<S>(conn: &Connection, queue: &mut EventQueue<S>, state: &mut S) -> Resu
 /// Wait for the compositor to send something, no later than `deadline`, and dispatch it.
 ///
 /// `blocking_dispatch` waits on the socket with no timeout, so a deadline checked after it is not
-/// a bound: a compositor that goes quiet after the last event glass reacts to holds the caller —
-/// and, through the session lock, every other tool call — indefinitely (glass#383). Poll the
-/// connection fd for what is left of the deadline instead, the shape the clipboard's bounded
-/// transfers use.
+/// a bound: a compositor that goes quiet holds the caller, and through the session lock every
+/// other tool call (glass#383).
 ///
-/// Expiry is not an error here: this returns having made whatever progress it could, and
-/// [`wait_for`] owns the deadline.
+/// Expiry is not an error here — [`wait_for`] owns the deadline.
 ///
-/// Generic over the queue's state only so the bound can be tested against a socket with no
-/// compositor behind it; capture is the sole caller, hence the error variant.
+/// Generic over the queue's state only so the bound can be tested with no compositor behind the
+/// socket; capture is its only caller, hence the error variant.
 fn dispatch_until<S>(
     conn: &Connection,
     queue: &mut EventQueue<S>,
     state: &mut S,
     deadline: Instant,
 ) -> Result<()> {
-    // `None` is a libwayland-backend condition glass cannot reach (the pure-Rust backend always
-    // prepares), and it means the backend's own queue needs draining, not this one's.
+    // `None` means the backend's own queue needs draining — a libwayland condition the pure-Rust
+    // backend glass builds never reports.
     let Some(guard) = queue.prepare_read() else {
         return drain(conn, queue, state);
     };
@@ -555,8 +549,8 @@ fn dispatch_until<S>(
     };
     // The guard's fd, not the queue's: a queue is a dispatch bucket and has no socket of its own.
     let fd = guard.connection_fd();
-    // A compositor that went away wakes this poll too: POSIX reports POLLHUP in `revents` whether
-    // or not it was asked for, and the read below then fails with EPIPE rather than spinning.
+    // POSIX reports POLLHUP in `revents` unasked, so a compositor that went away wakes this poll
+    // and the read below fails with EPIPE rather than spinning.
     match rustix::event::poll(
         &mut [rustix::event::PollFd::new(
             &fd,
@@ -567,14 +561,13 @@ fn dispatch_until<S>(
         Ok(0) => return Ok(()),
         Ok(_) => match guard.read() {
             Ok(_) => {}
-            // What the socket held was the front of a message whose rest has not arrived. Upstream
-            // treats this as a retry, and so must this: it is a loaded host, not a fault.
+            // Half a message, which upstream's own reader retries rather than fails: a split
+            // write means a loaded host, not a fault.
             Err(wayland_client::backend::WaylandError::Io(e))
                 if e.kind() == std::io::ErrorKind::WouldBlock => {}
             Err(e) => return Err(capture_failed("read", e)),
         },
-        // A signal arrived and nothing was lost; the caller's deadline decides whether there is
-        // time to ask again.
+        // A signal arrived and nothing was lost.
         Err(rustix::io::Errno::INTR) => return Ok(()),
         Err(e) => return Err(capture_failed("poll", e)),
     }
@@ -586,12 +579,12 @@ fn dispatch_until<S>(
 
 /// Dispatch until `answered` has one, or until `deadline` passes with `expired` to say why not.
 ///
-/// The deadline check lives here rather than in each caller's own loop: [`dispatch_until`] returns
-/// at once once the budget is spent, so a loop that forgot to check would not hang as it did
-/// before glass#383 — it would spin on a core holding the session lock, which is worse.
+/// The deadline check lives here rather than in each caller's loop: [`dispatch_until`] returns at
+/// once once the budget is spent, so a loop that forgot to check would spin on a core holding the
+/// session lock rather than hang.
 ///
-/// An answer already in hand is taken before the deadline is judged, so a phase that inherits a
-/// spent budget reports what arrived rather than a timeout.
+/// An answer in hand is taken before the deadline is judged, so a phase inheriting a spent budget
+/// reports what arrived rather than a timeout.
 fn wait_for<S, T>(
     conn: &Connection,
     queue: &mut EventQueue<S>,
@@ -614,12 +607,10 @@ fn wait_for<S, T>(
 
 /// The wayland objects one capture owns, destroyed when it ends however it ends.
 ///
-/// Dropping a proxy destroys nothing: the object stays alive on the compositor, which goes on
-/// sending events for it — and `ready` is not a destructor, the client is what must destroy a
-/// screencopy frame. The per-capture scratch in [`State`] is keyed by nothing, so a frame this
-/// capture gave up on would have its late `ready` taken by the next capture, which then reads a
-/// buffer nothing wrote and returns it as a screenshot. Bounding the wait (glass#383) is what
-/// makes that next capture reachable at all.
+/// Dropping a proxy destroys nothing, and `ready` is not a destructor — the client is what must
+/// destroy a screencopy frame. The scratch in [`State`] is keyed by nothing, so an abandoned
+/// frame's late events are taken by the next capture, which then reads a buffer nothing wrote;
+/// bounding the wait (glass#383) is what makes that next capture reachable.
 struct CaptureObjects {
     frame: ZwlrScreencopyFrameV1,
     buffer: Option<wl_buffer::WlBuffer>,
@@ -634,8 +625,8 @@ impl Drop for CaptureObjects {
     }
 }
 
-/// What the compositor has said about the capture in flight. Held apart from the connection so
-/// that reading a capture out of it stays a plain function, testable without a compositor.
+/// What the compositor has said about the capture in flight, held apart from the connection so
+/// that reading a capture out of it is a plain function, testable without one.
 #[derive(Default)]
 struct CaptureScratch {
     shm_buffers: Vec<(wl_shm::Format, u32, u32, u32)>, // advertised formats (format, w, h, stride)
@@ -657,8 +648,7 @@ impl CaptureScratch {
         }
         match self.done.take() {
             Some(Err(e)) => Some(Err(e)),
-            // Nothing has been asked to be copied yet, so a `ready` belongs to no request of this
-            // capture's.
+            // Nothing has been asked to be copied yet, so a `ready` is no request of this one's.
             Some(Ok(())) => Some(Err(GlassError::CaptureFailed(
                 "screencopy: ready before the buffer list ended".into(),
             ))),
@@ -666,9 +656,8 @@ impl CaptureScratch {
         }
     }
 
-    /// Why the format list never finished. A compositor that advertised formats and never ended
-    /// the list is a different fault from one that said nothing, and only one of them is about the
-    /// version glass binds.
+    /// Why the format list never finished — a list that started and stopped is a different fault
+    /// from silence, and only it is about the version glass binds.
     fn no_formats(&self) -> String {
         if self.shm_buffers.is_empty() {
             "screencopy: no buffer event".into()
@@ -1526,9 +1515,8 @@ impl Platform for WaylandPlatform {
         owned.frame.copy(&buffer);
         owned.buffer = Some(buffer);
 
-        // Phase 2: dispatch until ready/failed. Bounded by the same `wait_for` as phase 1 and the
-        // same budget; nothing live proves this call site is the bounded one, so a change here has
-        // only the pure tests behind it.
+        // Phase 2: dispatch until ready/failed. No live test reaches this call site's bound —
+        // only the pure `wait_for` tests stand behind a change here.
         wait_for(
             &session.conn,
             &mut session.queue,
@@ -1837,12 +1825,12 @@ mod pure_tests {
     use super::*;
     use crate::testw::on_a_thread;
 
-    /// How long the pure waits below get before the test decides they are never coming back. Well
-    /// past their own budget, which is what makes a lost bound a failure rather than a hang.
+    /// The budget the pure waits below are given. `on_a_thread` allows a multiple of it, so a lost
+    /// bound fails the test rather than hanging the suite.
     const PURE_WAIT_BUDGET: Duration = Duration::from_millis(300);
 
     /// Room for a wait that answers at once to be scheduled on a runner busy with the sway-backed
-    /// tests. Its own budget cannot be raised: the tests that use it assert on a fraction of it.
+    /// tests, which assert on a fraction of it.
     const PROMPT_WAIT_BUDGET: Duration = Duration::from_secs(1);
 
     /// [`wait_for`] over a socket with nothing behind it, answering a question the peer is never
@@ -1868,8 +1856,8 @@ mod pure_tests {
         (outcome, started.elapsed())
     }
 
-    /// The other end stays open and silent, so nothing can arrive and nothing signals the end of
-    /// the connection either — what a wedged compositor looks like from this side.
+    /// An open, silent peer: nothing arrives and nothing ends the connection either, which is what
+    /// a wedged compositor looks like from this side.
     #[test]
     fn a_wait_gives_up_on_a_peer_that_never_speaks() {
         let (outcome, elapsed) = on_a_thread(
@@ -1891,8 +1879,8 @@ mod pure_tests {
         );
     }
 
-    /// The half of the contract silence cannot show: the poll must return on the fd, not sleep out
-    /// the deadline. A wait that ignored readiness would still pass the test above.
+    /// The half of the contract silence cannot show: a wait that slept out its deadline instead of
+    /// polling the fd would still pass the test above.
     #[test]
     fn a_wait_stops_waiting_as_soon_as_the_peer_speaks() {
         let (outcome, elapsed) = on_a_thread(
@@ -1900,8 +1888,7 @@ mod pure_tests {
             "the wait did not come back from a peer that spoke",
             || {
                 wait_over_a_socket(PROMPT_WAIT_BUDGET, |mut theirs| {
-                    // A whole message, and nonsense: what it means is not the point — the wait
-                    // must come back rather than sit out its budget.
+                    // Nonsense, and a whole message of it: what it means is not the point.
                     theirs
                         .write_all(&[0xff; 32])
                         .expect("write to the socketpair");
@@ -1920,17 +1907,15 @@ mod pure_tests {
         );
     }
 
-    /// Half a message is not a fault: the rest is still on its way, and upstream's own reader
-    /// retries. Failing the capture here would make a screenshot flake on a loaded host, where a
-    /// write is likeliest to be split.
+    /// Half a message is not a fault — failing the capture on one would flake a screenshot on the
+    /// loaded host where a split write is likeliest.
     #[test]
     fn a_wait_keeps_waiting_through_half_a_message() {
         let (outcome, elapsed) = on_a_thread(
             PURE_WAIT_BUDGET * 20,
             "the wait never came back from a partial message",
             || {
-                // Under the 8 bytes a wayland message header takes, so the read consumes it and
-                // finds nothing behind it.
+                // Under the 8 bytes a wayland message header takes.
                 wait_over_a_socket(PURE_WAIT_BUDGET, |mut theirs| {
                     theirs.write_all(&[0; 4]).expect("write to the socketpair");
                     Some(theirs)
@@ -1949,8 +1934,8 @@ mod pure_tests {
         );
     }
 
-    /// A compositor that exits is a different fault from one that goes quiet, and reporting it as
-    /// a timeout would send the reader looking for a stall that never happened.
+    /// Reporting a compositor that exited as a timeout sends the reader looking for a stall that
+    /// never happened.
     #[test]
     fn a_wait_reports_a_peer_that_went_away_rather_than_timing_out() {
         let (outcome, elapsed) = on_a_thread(
@@ -1970,8 +1955,8 @@ mod pure_tests {
         );
     }
 
-    /// A phase that inherits a budget the phase before it spent still has an answer in hand, and a
-    /// timeout would discard it — the compositor did everything asked of it.
+    /// A timeout here would discard an answer the compositor did give, on a budget the phase
+    /// before it spent.
     #[test]
     fn a_wait_takes_an_answer_already_in_hand_over_a_spent_budget() {
         let (ours, _theirs) = UnixStream::pair().expect("socketpair");
@@ -2013,8 +1998,7 @@ mod pure_tests {
         );
     }
 
-    /// A list that ends with nothing glass can convert is a failure, not a wait: no further event
-    /// is coming.
+    /// Nothing glass can convert is a failure rather than a wait: no further event is coming.
     #[test]
     fn a_finished_but_empty_format_list_is_a_failure() {
         let mut scratch = CaptureScratch {
@@ -2031,7 +2015,7 @@ mod pure_tests {
         );
     }
 
-    /// A refusal is the compositor's final word, so it ends the wait rather than running it out.
+    /// A refusal is the compositor's final word — waiting it out gains nothing.
     #[test]
     fn a_refusal_during_the_format_list_ends_the_wait() {
         let mut scratch = CaptureScratch {
@@ -2045,8 +2029,8 @@ mod pure_tests {
         assert!(err.to_string().contains("screencopy failed"), "{err}");
     }
 
-    /// Nothing has been asked to be copied yet, so a `ready` cannot be this capture's. Taking it
-    /// as one ends the next phase over a buffer nothing wrote.
+    /// Nothing has been asked to be copied yet, so taking a `ready` as this capture's ends the
+    /// next phase over a buffer nothing wrote.
     #[test]
     fn a_ready_before_the_format_list_ends_is_a_failure() {
         let mut scratch = CaptureScratch {
@@ -2068,8 +2052,7 @@ mod pure_tests {
         assert!(advertised_one().advertised().is_none());
     }
 
-    /// Silence and a list that never ends are different faults, and only the second is about the
-    /// protocol version glass binds.
+    /// Only one of these two faults is about the protocol version glass binds.
     #[test]
     fn a_timeout_names_silence_and_an_unfinished_list_apart() {
         assert_eq!(
@@ -3058,16 +3041,16 @@ mod session_tests {
         assert_eq!(px[3], 255, "opaque");
     }
 
-    /// How long a suspended compositor stays suspended if nothing resumes it. The bracket
-    /// assertion on `CAPTURE_BUDGET` caps a capture at 15s, so a bounded one is always over first.
+    /// How long a suspended compositor stays suspended if nothing resumes it. `CAPTURE_BUDGET`'s
+    /// bracket assertion caps a capture at 15s, so a bounded one is always over first.
     const SUSPENSION: Duration = Duration::from_secs(30);
 
     /// SIGSTOPs a process until dropped: a compositor holding its connection open and answering
-    /// nothing. sway has no IPC command that does this, which is why the test signals it.
+    /// nothing, which no sway IPC command will do.
     ///
     /// A stuck capture cannot be failed from the test thread — it is the test thread — so the
-    /// resume also runs from a watchdog after [`SUSPENSION`]. Without it a lost bound would wedge
-    /// the whole suite instead of failing one test.
+    /// resume also runs from a watchdog after [`SUSPENSION`], without which a lost bound wedges
+    /// the whole suite.
     struct Suspended {
         resume: Option<std::sync::mpsc::Sender<()>>,
         watchdog: Option<std::thread::JoinHandle<()>>,
@@ -3080,8 +3063,8 @@ mod session_tests {
             let (resume, wait) = std::sync::mpsc::channel();
             let watchdog = std::thread::spawn(move || {
                 // Either end of the wait resumes it: the drop below, or the timeout. The pid
-                // cannot have been recycled by then — the session still holds it as an unreaped
-                // child, and `Drop` joins this thread before teardown reaps it.
+                // cannot have been recycled by then — the session holds it as an unreaped child
+                // until after `Drop` joins this thread.
                 let _ = wait.recv_timeout(SUSPENSION);
                 rustix::process::kill_process(pid, rustix::process::Signal::CONT)
                     .expect("SIGCONT the suspended compositor");
@@ -3097,9 +3080,9 @@ mod session_tests {
     impl Drop for Suspended {
         fn drop(&mut self) {
             drop(self.resume.take());
-            // Joined, so the compositor is running again before the session teardown that follows
-            // asks it to close. A watchdog that panicked left it stopped, which is worth the test
-            // — but not at the cost of aborting the process over an unrelated failure.
+            // Joined, so the compositor is running again before the teardown that follows asks it
+            // to close. A watchdog that panicked left it stopped — worth the test, but not worth
+            // aborting the process during someone else's unwind.
             if let Some(w) = self.watchdog.take() {
                 let joined = w.join();
                 if !std::thread::panicking() {
@@ -3110,13 +3093,12 @@ mod session_tests {
     }
 
     /// Spin until the kernel reports the process stopped. `kill` returns once the signal is
-    /// pending, so without this a compositor on another core can still service the request the
-    /// test is about to make.
+    /// pending, so a compositor on another core can still service the request that follows.
     fn wait_until_stopped(pid: rustix::process::Pid) {
         let stat = format!("/proc/{}/stat", pid.as_raw_nonzero());
         for _ in 0..1000 {
-            // Field 3, after the comm field — which is parenthesised and may itself contain
-            // spaces, so the split starts at the last ')'.
+            // Field 3, after a parenthesised comm field that may itself contain spaces and
+            // parens — hence the split at the last ')'.
             let read = std::fs::read_to_string(&stat).expect("the compositor's /proc entry");
             let after_comm = read.rsplit_once(')').expect("a comm field").1;
             if after_comm.split_whitespace().next() == Some("T") {
@@ -3127,9 +3109,9 @@ mod session_tests {
         panic!("the compositor never reached the stopped state");
     }
 
-    /// glass#383: the capture checked its deadline only after `blocking_dispatch` returned, and
-    /// that returns only when an event arrives — so a compositor that went quiet held the capture,
-    /// and with it the session lock every other tool call waits on.
+    /// glass#383: the deadline was checked only after `blocking_dispatch` returned, and that
+    /// returns only when an event arrives — so a compositor that went quiet held the capture, and
+    /// with it the session lock.
     #[test]
     #[ignore = "starts a real compositor or X server; needs sway, Mesa, Xwayland or Xvfb"]
     fn a_capture_gives_up_on_a_compositor_that_stops_answering() {
@@ -3138,13 +3120,12 @@ mod session_tests {
             .platform()
             .session_compositor_pid()
             .expect("a started session has a compositor");
-        // Declared after the session, so it resumes the compositor before the session is torn
-        // down over it.
+        // Declared after the session, so it resumes the compositor before teardown needs it.
         let _suspended = Suspended::process(pid);
 
         let started = Instant::now();
-        // Not `expect_err`: on the failure this test exists to catch, the watchdog resumes the
-        // compositor and the capture succeeds — printing a whole window of pixels as the reason.
+        // Not `expect_err`: on the failure this test exists to catch the capture succeeds, and
+        // `Frame`'s `Debug` prints a whole window of pixels as the reason.
         let Err(err) = s.platform().capture_frame(None) else {
             panic!("the capture was not bounded: it waited the compositor out and then succeeded");
         };
@@ -3155,8 +3136,7 @@ mod session_tests {
             "the capture waited the compositor out rather than bounding it: {elapsed:?}"
         );
         // The other end of the bracket: the fast capture tests cannot tell a 5s budget from a 5ms
-        // one, so without this a budget cut to nothing leaves them green while every capture on a
-        // loaded compositor fails.
+        // one, so a budget cut to nothing would leave them green.
         assert!(
             elapsed >= Duration::from_secs(2),
             "the capture budget is no longer generous enough for a compositor under load: \
@@ -3168,10 +3148,9 @@ mod session_tests {
         );
     }
 
-    /// The frame is what a capture that gave up must not leave behind; the buffer is what keeps
-    /// the compositor's mapping of that frame's memory resident, which no capture reaches through
-    /// `capture_frame` (only a copy that timed out owns one) and every capture in a
-    /// `glass_wait_stable` loop would add to.
+    /// An undestroyed buffer keeps the compositor's mapping of that frame's memory resident, and
+    /// a `glass_wait_stable` loop adds one per capture. Only a copy that timed out owns a buffer,
+    /// so no test reaching this through `capture_frame` can cover it.
     #[test]
     #[ignore = "starts a real compositor or X server; needs sway, Mesa, Xwayland or Xvfb"]
     fn the_objects_a_capture_owns_are_destroyed_with_it() {
@@ -3197,10 +3176,9 @@ mod session_tests {
         assert!(!buffer_after.is_alive(), "the buffer outlived its capture");
     }
 
-    /// The frame a bounded-out capture abandons is still the compositor's to answer, and the
-    /// per-capture scratch it answers into is keyed by nothing — so the next capture takes those
-    /// events for its own unless the abandoned frame is destroyed. Sizes differ so a stolen
-    /// `buffer` event is a visible fault rather than a coincidence.
+    /// The frame a bounded-out capture abandons is still the compositor's to answer, into a
+    /// scratch keyed by nothing. The two regions differ in size so that a stolen `buffer` event is
+    /// a visible fault rather than a coincidence.
     #[test]
     #[ignore = "starts a real compositor or X server; needs sway, Mesa, Xwayland or Xvfb"]
     fn a_capture_that_follows_an_abandoned_one_reads_its_own_frame() {

--- a/crates/glass-wayland/src/testw.rs
+++ b/crates/glass-wayland/src/testw.rs
@@ -234,6 +234,21 @@ impl Session {
     }
 }
 
+/// Run `f` on its own thread and wait `within` for its result, failing with `what` if it does not
+/// arrive. The calls these tests bound hang outright when the bound under test is missing, and a
+/// hang on the test thread wedges the whole suite.
+pub(crate) fn on_a_thread<T: Send + 'static>(
+    within: Duration,
+    what: &str,
+    f: impl FnOnce() -> T + Send + 'static,
+) -> T {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(f());
+    });
+    rx.recv_timeout(within).expect(what)
+}
+
 /// The event-clock stamps the fixture echoed, in arrival order.
 ///
 /// Each input line carries the compositor timestamp as a `t<N>` word (see the fixture's


### PR DESCRIPTION
Closes #383.

`capture_frame` set a 5s deadline and checked it after each `blocking_dispatch`, which returns only once an event arrives. A compositor that went quiet after the last event glass reacts to was waited on with no limit, holding the session lock and every tool call behind it.

Both dispatch phases now go through one `wait_for`, which drains what has already arrived, takes an answer in hand before judging the deadline, and otherwise polls the connection fd for what is left of it. Expiry is not an error inside the wait: the caller's condition names the event that never came.

## Also in this branch

- **The frame a capture gives up on is now destroyed.** `ready` is not a destructor, and the per-capture scratch is keyed by nothing, so an abandoned frame's later events were taken by the next capture. Bounding the wait is what makes a next capture reachable, so the fix has to come with it — without the destroy, the capture after an abandoned one dies with `invalid buffer dimensions`, a protocol error that takes the whole connection with it. The `wl_buffer` is destroyed too; it kept the compositor's mapping of that frame's memory resident.
- **`WouldBlock` from `read` is retried, not fatal.** It means half a message, which upstream's own reader retries — failing there would flake a screenshot on exactly the loaded host the budget exists for.
- **A capture that never sees `buffer_done` is told apart from one that hears nothing**, and a `ready` arriving before the format list ends is an error rather than silently dropped.
- The capture scratch moved into `CaptureScratch`, whose decisions are plain functions with unit tests.

## Verification

`cargo test --workspace` (82 result lines, no failures), `cargo test -p glass-wayland -- --include-ignored` (215), clippy and `cargo fmt --check` clean.

Every new test was ablated: reverting phase 1 to `blocking_dispatch` fails the live test at 30.0s rather than wedging the suite; deleting the deadline check fails the pure test in 6s; removing the frame destroy fails with the protocol error above; removing the buffer destroy leaves the proxy alive; dropping the `WouldBlock` arm reports a partial message as a read failure.

## Not in this branch

The crate's twelve `roundtrip` calls — `send_pointer`, `list_windows`, the input sinks — wait on the compositor the same unbounded way, and the clipboard owner loop treats `WouldBlock` and `EINTR` as fatal. Same rules, different subsystems; filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)