### PR TITLE
fix(wayland): bound every wait on the compositor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,8 +80,15 @@ internal refactors, CI, or test-only changes.
   on with no limit at all. glass serves one tool call at a time, so every later call queued behind
   it. The 5 seconds are now a real limit: a capture the compositor has not answered by then fails
   and names the event that never arrived, and the capture after it is unaffected by the one that
-  gave up. Other calls on a compositor that stays quiet can still wait on it; only captures are
-  bounded so far.
+  gave up.
+- No tool call on the Wayland backend waits on a quiet compositor indefinitely now. Every request
+  glass sends ends by asking the compositor to confirm it has caught up, and that wait had no
+  limit — so a compositor that stopped answering hung `glass_click`, `glass_type`, `glass_scroll`,
+  `glass_list_windows`, a launch, and reading or writing the clipboard, each holding the session
+  and everything queued behind it. The compositor now gets 5 seconds to answer any one of those,
+  and a request it does not answer fails saying which request it was. A clipboard owner also no
+  longer drops the selection when a message arrives split across two reads, which a loaded machine
+  makes likelier.
 - Accessibility now works on Debian/Ubuntu machines that are not x86-64. `glass doctor` said
   `at-spi-bus-launcher present` while every a11y launch on the same machine failed to find it —
   quietly dropping to pixel-only by default, or failing outright with `a11y: true` — because the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,14 +81,24 @@ internal refactors, CI, or test-only changes.
   it. The 5 seconds are now a real limit: a capture the compositor has not answered by then fails
   and names the event that never arrived, and the capture after it is unaffected by the one that
   gave up.
-- No tool call on the Wayland backend waits on a quiet compositor indefinitely now. Every request
-  glass sends ends by asking the compositor to confirm it has caught up, and that wait had no
-  limit — so a compositor that stopped answering hung `glass_click`, `glass_type`, `glass_scroll`,
-  `glass_list_windows`, a launch, and reading or writing the clipboard, each holding the session
-  and everything queued behind it. The compositor now gets 5 seconds to answer any one of those,
-  and a request it does not answer fails saying which request it was. A clipboard owner also no
-  longer drops the selection when a message arrives split across two reads, which a loaded machine
-  makes likelier.
+- No tool call on the Wayland backend waits on a quiet compositor without a limit now. Every
+  request glass sends ends by asking the compositor to confirm it has caught up, and that wait had
+  none — so a compositor that stopped answering hung `glass_click`, `glass_type`, `glass_scroll`,
+  `glass_list_windows`, a launch, and reading the clipboard, each holding the session and
+  everything queued behind it. Opening a connection at all had the same problem, which is why
+  reading the clipboard — which opens its own — could hang before it reached any of the rest. The
+  compositor now gets 5 seconds to answer a request, or the remainder of your `timeout_ms` during
+  a launch, and one it does not answer fails saying which request it was. Note the limit is per
+  request: a compositor that answers everything slowly can still make a long `glass_type` or
+  `glass_drag` take the sum of its parts.
+- Input is no longer left half-applied when the compositor stops answering mid-gesture. The press
+  had already been sent, so a `glass_click` or `glass_type` that failed while waiting could leave
+  a mouse button or a modifier key held down, and the next call would inherit it — clicking where
+  it meant to move, or typing control characters. The counterpart is now sent before the failure
+  is reported.
+- A clipboard owner no longer drops the selection when a message arrives split across two reads,
+  or when a signal interrupts it — after either, the clipboard read empty until something set it
+  again.
 - Accessibility now works on Debian/Ubuntu machines that are not x86-64. `glass doctor` said
   `at-spi-bus-launcher present` while every a11y launch on the same machine failed to find it —
   quietly dropping to pixel-only by default, or failing outright with `a11y: true` — because the

--- a/crates/glass-wayland/src/clipboard.rs
+++ b/crates/glass-wayland/src/clipboard.rs
@@ -8,7 +8,6 @@
 
 use std::io::{Read, Write};
 use std::os::fd::{AsFd, OwnedFd};
-use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex, PoisonError};
@@ -19,7 +18,12 @@ use std::time::{Duration, Instant};
 /// must not hang the server (the X11 backend guards the analogous read with 1s).
 const CLIP_READ_TIMEOUT: Duration = Duration::from_secs(2);
 
-use wayland_client::globals::registry_queue_init;
+/// How long `set_clipboard` waits for the serving thread to register the selection — and, since
+/// the thread is detached when it expires, the whole budget that thread's own setup has to fit
+/// inside. A setup allowed longer would answer after the caller had stopped listening, leaving
+/// the named failure on a channel nobody reads.
+const SPAWN_READY_BUDGET: Duration = Duration::from_secs(2);
+
 use wayland_client::protocol::wl_seat;
 use wayland_client::{Connection, Dispatch, EventQueue, QueueHandle};
 use wayland_protocols_wlr::data_control::v1::client::{
@@ -392,13 +396,15 @@ pub fn get(socket: &Path) -> Result<String> {
 /// the owner has dispatched the `Send` yet: [`get`] is this plus the bounded read, and a test that
 /// wants the owner stuck mid-write is this plus a wait for the first bytes.
 fn open_transfer(socket: &Path) -> Result<Option<OwnedFd>> {
-    let stream = UnixStream::connect(socket)
-        .map_err(|e| GlassError::Backend(format!("clipboard get: connect: {e}")))?;
-    let conn = Connection::from_socket(stream)
-        .map_err(|e| GlassError::Backend(format!("clipboard get: wayland connection: {e}")))?;
-
-    let (globals, mut queue): (_, EventQueue<ClipState>) = registry_queue_init(&conn)
-        .map_err(|e| GlassError::Backend(format!("clipboard get: registry: {e}")))?;
+    // One deadline for the whole read, not one per step: the point of the bound is what the
+    // session lock is held for, and this holds it from the first connect to the last sync.
+    let deadline = Instant::now() + CLIP_READ_TIMEOUT;
+    let (conn, globals, mut queue): (_, _, EventQueue<ClipState>) =
+        crate::platform::connect_bounded(
+            socket,
+            deadline.saturating_duration_since(Instant::now()),
+            "clipboard get: setup",
+        )?;
 
     let qh = queue.handle();
     let mut state = ClipState {
@@ -423,8 +429,20 @@ fn open_transfer(socket: &Path) -> Result<Option<OwnedFd>> {
 
     // Collect the initial selection advertisement, then once more so `pending_mimes` has
     // accumulated.
-    crate::platform::roundtrip(&conn, &mut queue, &mut state, "clipboard get: selection")?;
-    crate::platform::roundtrip(&conn, &mut queue, &mut state, "clipboard get: mime types")?;
+    crate::platform::roundtrip_until(
+        &conn,
+        &mut queue,
+        &mut state,
+        deadline,
+        "clipboard get: selection",
+    )?;
+    crate::platform::roundtrip_until(
+        &conn,
+        &mut queue,
+        &mut state,
+        deadline,
+        "clipboard get: mime types",
+    )?;
 
     let (offer, mimes) = match state.selection.take() {
         Some(v) => v,
@@ -451,7 +469,13 @@ fn open_transfer(socket: &Path) -> Result<Option<OwnedFd>> {
 
     // Let the compositor service the receive request and tell the source to write. The source
     // writes on a separate connection, so all this waits for is the fd being routed.
-    crate::platform::roundtrip(&conn, &mut queue, &mut state, "clipboard get: transfer")?;
+    crate::platform::roundtrip_until(
+        &conn,
+        &mut queue,
+        &mut state,
+        deadline,
+        "clipboard get: transfer",
+    )?;
 
     // The fd is already with the owner, so destroying the offer and dropping `conn` here cannot
     // cut the read short.
@@ -669,14 +693,14 @@ impl ClipboardOwner {
             })
             .map_err(GlassError::Io)?;
 
-        // Block until the thread signals that it has called set_selection +
-        // roundtripped (or encountered an error), with a 2 s timeout.
+        // Block until the thread signals that it has called set_selection + roundtripped (or
+        // encountered an error).
         let (lock, cvar) = &*ready;
         let result = recover_readiness(
             "set: readiness wait",
             cvar.wait_timeout_while(
                 recover_readiness("set: readiness lock", lock.lock()),
-                Duration::from_secs(2),
+                SPAWN_READY_BUDGET,
                 |s| matches!(s, ReadyState::Pending),
             ),
         );
@@ -764,22 +788,19 @@ fn serve_loop(
     stop: Arc<AtomicBool>,
     ready: Arc<(Mutex<ReadyState>, Condvar)>,
 ) -> Result<()> {
-    let stream = UnixStream::connect(&socket).map_err(|e| {
-        let msg = format!("connect: {e}");
-        signal_ready(&ready, ReadyState::Err(msg.clone()));
-        GlassError::Backend(format!("clipboard serve: {msg}"))
-    })?;
-    let conn = Connection::from_socket(stream).map_err(|e| {
-        let msg = format!("wayland connection: {e}");
-        signal_ready(&ready, ReadyState::Err(msg.clone()));
-        GlassError::Backend(format!("clipboard serve: {msg}"))
-    })?;
-
-    let (globals, mut queue): (_, EventQueue<ServeState>) =
-        registry_queue_init(&conn).map_err(|e| {
-            let msg = format!("registry: {e}");
+    // Inside the readiness wait `spawn` gives this thread: a setup that took longer would have
+    // its answer arrive after the caller had already given up on it.
+    let deadline = Instant::now() + SPAWN_READY_BUDGET;
+    let (conn, globals, mut queue): (_, _, EventQueue<ServeState>) =
+        crate::platform::connect_bounded(
+            &socket,
+            deadline.saturating_duration_since(Instant::now()),
+            "clipboard serve: setup",
+        )
+        .map_err(|e| {
+            let msg = e.to_string();
             signal_ready(&ready, ReadyState::Err(msg.clone()));
-            GlassError::Backend(format!("clipboard serve: {msg}"))
+            GlassError::Backend(msg)
         })?;
 
     let qh = queue.handle();
@@ -832,8 +853,14 @@ fn serve_loop(
     // Roundtrip so the compositor registers the selection before we return to
     // the caller. This is what makes set_clipboard synchronous: spawn() blocks
     // on the ready signal below, which is only sent after this roundtrip.
-    crate::platform::roundtrip(&conn, &mut queue, &mut state, "clipboard serve: selection")
-        .inspect_err(|e| signal_ready(&ready, ReadyState::Err(e.to_string())))?;
+    crate::platform::roundtrip_until(
+        &conn,
+        &mut queue,
+        &mut state,
+        deadline,
+        "clipboard serve: selection",
+    )
+    .inspect_err(|e| signal_ready(&ready, ReadyState::Err(e.to_string())))?;
 
     // Selection is now registered with the compositor — unblock spawn().
     signal_ready(&ready, ReadyState::Ok);
@@ -889,10 +916,8 @@ fn serve_loop(
         ) {
             Ok(n) if n > 0 => match guard.read() {
                 Ok(_) => {}
-                // Half a message, which upstream's own reader retries rather than fails. Breaking
-                // here drops the selection over a split write (glass#402).
-                Err(wayland_client::backend::WaylandError::Io(e))
-                    if e.kind() == std::io::ErrorKind::WouldBlock => {}
+                // Breaking here would drop the selection over a split write (glass#402).
+                Err(e) if crate::platform::is_partial_read(&e) => {}
                 Err(e) => {
                     eprintln!("glass-wayland: clipboard serve: read: {e}");
                     break;
@@ -902,7 +927,7 @@ fn serve_loop(
                 // Timeout — loop back and check the stop flag.
                 drop(guard);
             }
-            // A signal arrived and nothing was lost; the stop flag is checked next pass anyway.
+            // A signal arrived and nothing was lost.
             Err(rustix::io::Errno::INTR) => drop(guard),
             Err(e) => {
                 eprintln!("glass-wayland: clipboard serve: poll: {e}");
@@ -1149,6 +1174,48 @@ mod tests {
         assert!(msg.contains("timed out"), "{msg}");
 
         // Closing the server side lets the detached setup thread fail and exit.
+        drop(
+            accepted
+                .join()
+                .expect("accept thread")
+                .expect("accepted stream"),
+        );
+    }
+
+    /// Reading the clipboard opens its own connection, and the compositor's globals arrive over
+    /// an upstream roundtrip that polls with no timeout — so this hung outright until glass#402,
+    /// with the session lock held. No compositor needed: a listener that accepts and answers
+    /// nothing is what a wedged one looks like from this side.
+    #[test]
+    fn a_paste_gives_up_on_a_peer_that_accepts_and_never_answers() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket = dir.path().join("wayland-silent");
+        let listener = std::os::unix::net::UnixListener::bind(&socket).expect("bind");
+        let accepted = std::thread::spawn(move || listener.accept().map(|(s, _)| s));
+
+        let started = std::time::Instant::now();
+        let outcome = on_a_thread(
+            Duration::from_secs(20),
+            "a paste must return when its own bound expires, not wait on the peer",
+            move || get(&socket).err().map(|e| e.to_string()),
+        );
+        let elapsed = started.elapsed();
+
+        let msg = outcome.expect("a peer that never answers has no clipboard to read");
+        assert!(
+            msg.contains("clipboard get"),
+            "the failure should name the read that made it: {msg}"
+        );
+        assert!(
+            elapsed < CLIP_READ_TIMEOUT * 5,
+            "the paste outlived its own bound by too much to be bounded by it: {elapsed:?}"
+        );
+        assert!(
+            elapsed >= CLIP_READ_TIMEOUT / 2,
+            "the bound was cut short, so a compositor merely slow to answer would be given up \
+             on: {elapsed:?}"
+        );
+
         drop(
             accepted
                 .join()

--- a/crates/glass-wayland/src/clipboard.rs
+++ b/crates/glass-wayland/src/clipboard.rs
@@ -36,7 +36,7 @@ use smithay_client_toolkit::registry::{ProvidesRegistryState, RegistryState};
 use smithay_client_toolkit::registry_handlers;
 use smithay_client_toolkit::shm::{Shm, ShmHandler};
 use smithay_client_toolkit::{delegate_dispatch2, delegate_registry};
-use wayland_client::protocol::{wl_buffer, wl_output};
+use wayland_client::protocol::{wl_buffer, wl_callback, wl_output};
 
 // ---- MIME types we offer / accept ----
 pub const MIME_UTF8: &str = "text/plain;charset=utf-8";
@@ -104,6 +104,20 @@ impl Dispatch<wl_buffer::WlBuffer, ()> for ClipState {
         _: &Connection,
         _: &QueueHandle<Self>,
     ) {
+    }
+}
+
+/// The compositor's answer to a `wl_display.sync`, which is what a bounded roundtrip waits for.
+impl Dispatch<wl_callback::WlCallback, crate::platform::SyncDone> for ClipState {
+    fn event(
+        _: &mut Self,
+        _: &wl_callback::WlCallback,
+        _: wl_callback::Event,
+        done: &crate::platform::SyncDone,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        done.store(true, Ordering::Relaxed);
     }
 }
 
@@ -245,6 +259,20 @@ impl Dispatch<wl_buffer::WlBuffer, ()> for ServeState {
         _: &Connection,
         _: &QueueHandle<Self>,
     ) {
+    }
+}
+
+/// The compositor's answer to a `wl_display.sync`, which is what a bounded roundtrip waits for.
+impl Dispatch<wl_callback::WlCallback, crate::platform::SyncDone> for ServeState {
+    fn event(
+        _: &mut Self,
+        _: &wl_callback::WlCallback,
+        _: wl_callback::Event,
+        done: &crate::platform::SyncDone,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        done.store(true, Ordering::Relaxed);
     }
 }
 
@@ -393,15 +421,10 @@ fn open_transfer(socket: &Path) -> Result<Option<OwnedFd>> {
     // get_data_device triggers `data_offer` + `offer*` + `selection` events.
     let _device = manager.get_data_device(&seat, &qh, ());
 
-    // Roundtrip: collect the initial selection advertisement.
-    queue
-        .roundtrip(&mut state)
-        .map_err(|e| GlassError::Backend(format!("clipboard get: roundtrip: {e}")))?;
-
-    // One more roundtrip to make sure pending_mimes have been accumulated.
-    queue
-        .roundtrip(&mut state)
-        .map_err(|e| GlassError::Backend(format!("clipboard get: roundtrip2: {e}")))?;
+    // Collect the initial selection advertisement, then once more so `pending_mimes` has
+    // accumulated.
+    crate::platform::roundtrip(&conn, &mut queue, &mut state, "clipboard get: selection")?;
+    crate::platform::roundtrip(&conn, &mut queue, &mut state, "clipboard get: mime types")?;
 
     let (offer, mimes) = match state.selection.take() {
         Some(v) => v,
@@ -426,13 +449,9 @@ fn open_transfer(socket: &Path) -> Result<Option<OwnedFd>> {
     conn.flush()
         .map_err(|e| GlassError::Backend(format!("clipboard get: flush: {e}")))?;
 
-    // Roundtrip so the compositor can service our receive request and tell the
-    // source to write data. The source's write happens in a separate connection
-    // (either ours or another client), so we just need to let the compositor
-    // route the fd.
-    queue
-        .roundtrip(&mut state)
-        .map_err(|e| GlassError::Backend(format!("clipboard get: roundtrip3: {e}")))?;
+    // Let the compositor service the receive request and tell the source to write. The source
+    // writes on a separate connection, so all this waits for is the fd being routed.
+    crate::platform::roundtrip(&conn, &mut queue, &mut state, "clipboard get: transfer")?;
 
     // The fd is already with the owner, so destroying the offer and dropping `conn` here cannot
     // cut the read short.
@@ -813,11 +832,8 @@ fn serve_loop(
     // Roundtrip so the compositor registers the selection before we return to
     // the caller. This is what makes set_clipboard synchronous: spawn() blocks
     // on the ready signal below, which is only sent after this roundtrip.
-    queue.roundtrip(&mut state).map_err(|e| {
-        let msg = format!("initial roundtrip: {e}");
-        signal_ready(&ready, ReadyState::Err(msg.clone()));
-        GlassError::Backend(format!("clipboard serve: {msg}"))
-    })?;
+    crate::platform::roundtrip(&conn, &mut queue, &mut state, "clipboard serve: selection")
+        .inspect_err(|e| signal_ready(&ready, ReadyState::Err(e.to_string())))?;
 
     // Selection is now registered with the compositor — unblock spawn().
     signal_ready(&ready, ReadyState::Ok);
@@ -871,17 +887,23 @@ fn serve_loop(
             )],
             Some(&timeout),
         ) {
-            Ok(n) if n > 0 => {
-                // Data available: read into the queue.
-                if let Err(e) = guard.read() {
+            Ok(n) if n > 0 => match guard.read() {
+                Ok(_) => {}
+                // Half a message, which upstream's own reader retries rather than fails. Breaking
+                // here drops the selection over a split write (glass#402).
+                Err(wayland_client::backend::WaylandError::Io(e))
+                    if e.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(e) => {
                     eprintln!("glass-wayland: clipboard serve: read: {e}");
                     break;
                 }
-            }
+            },
             Ok(_) => {
                 // Timeout — loop back and check the stop flag.
                 drop(guard);
             }
+            // A signal arrived and nothing was lost; the stop flag is checked next pass anyway.
+            Err(rustix::io::Errno::INTR) => drop(guard),
             Err(e) => {
                 eprintln!("glass-wayland: clipboard serve: poll: {e}");
                 drop(guard);

--- a/crates/glass-wayland/src/clipboard.rs
+++ b/crates/glass-wayland/src/clipboard.rs
@@ -13,16 +13,24 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex, PoisonError};
 use std::time::{Duration, Instant};
 
-/// Cap on how long `get()` waits for the selection owner to finish writing the
-/// transfer pipe. The owner is an arbitrary external app, so a stuck/slow one
-/// must not hang the server (the X11 backend guards the analogous read with 1s).
+/// Cap on a whole clipboard read: the connection, the compositor's answers, and the transfer from
+/// the owner. The owner is an arbitrary external app, so a stuck or slow one must not hang the
+/// server (the X11 backend guards the analogous read with 1s).
 const CLIP_READ_TIMEOUT: Duration = Duration::from_secs(2);
 
-/// How long `set_clipboard` waits for the serving thread to register the selection — and, since
-/// the thread is detached when it expires, the whole budget that thread's own setup has to fit
-/// inside. A setup allowed longer would answer after the caller had stopped listening, leaving
-/// the named failure on a channel nobody reads.
+/// How long `set_clipboard` waits for the serving thread to register the selection. The thread is
+/// detached when this expires.
 const SPAWN_READY_BUDGET: Duration = Duration::from_secs(2);
+
+/// What the serving thread's own setup gets. Strictly under [`SPAWN_READY_BUDGET`], so a setup
+/// that cannot finish says so to a caller still listening — tie the two and which of them reports
+/// is decided by a few microseconds of scheduling.
+const SERVE_SETUP_BUDGET: Duration = Duration::from_millis(1750);
+
+const _: () = assert!(
+    SERVE_SETUP_BUDGET.as_millis() < SPAWN_READY_BUDGET.as_millis(),
+    "the serving thread's setup must fail while its caller is still waiting to hear about it"
+);
 
 use wayland_client::protocol::wl_seat;
 use wayland_client::{Connection, Dispatch, EventQueue, QueueHandle};
@@ -380,12 +388,14 @@ impl Dispatch<ZwlrDataControlSourceV1, ()> for ServeState {
 /// event queue, does a roundtrip to collect the selection offer, then reads the
 /// pipe transfer.
 pub fn get(socket: &Path) -> Result<String> {
-    let Some(read_end) = open_transfer(socket)? else {
+    // One deadline for the whole paste — connecting, the syncs, and the read from the owner — so
+    // what the session lock is held for is what the constant says, rather than its sum over the
+    // steps.
+    let deadline = Instant::now() + CLIP_READ_TIMEOUT;
+    let Some(read_end) = open_transfer(socket, deadline)? else {
         return Ok(String::new());
     };
-    // Read to EOF from the read end, bounded by a deadline so a misbehaving
-    // selection owner can't hang us forever (see CLIP_READ_TIMEOUT).
-    let buf = read_to_eof_bounded(read_end, CLIP_READ_TIMEOUT)?;
+    let buf = read_to_eof_bounded(read_end, deadline.saturating_duration_since(Instant::now()))?;
     Ok(String::from_utf8_lossy(&buf).into_owned())
 }
 
@@ -395,10 +405,7 @@ pub fn get(socket: &Path) -> Result<String> {
 /// Returning means the transfer has been requested and the compositor has routed the fd, not that
 /// the owner has dispatched the `Send` yet: [`get`] is this plus the bounded read, and a test that
 /// wants the owner stuck mid-write is this plus a wait for the first bytes.
-fn open_transfer(socket: &Path) -> Result<Option<OwnedFd>> {
-    // One deadline for the whole read, not one per step: the point of the bound is what the
-    // session lock is held for, and this holds it from the first connect to the last sync.
-    let deadline = Instant::now() + CLIP_READ_TIMEOUT;
+fn open_transfer(socket: &Path, deadline: Instant) -> Result<Option<OwnedFd>> {
     let (conn, globals, mut queue): (_, _, EventQueue<ClipState>) =
         crate::platform::connect_bounded(
             socket,
@@ -788,9 +795,7 @@ fn serve_loop(
     stop: Arc<AtomicBool>,
     ready: Arc<(Mutex<ReadyState>, Condvar)>,
 ) -> Result<()> {
-    // Inside the readiness wait `spawn` gives this thread: a setup that took longer would have
-    // its answer arrive after the caller had already given up on it.
-    let deadline = Instant::now() + SPAWN_READY_BUDGET;
+    let deadline = Instant::now() + SERVE_SETUP_BUDGET;
     let (conn, globals, mut queue): (_, _, EventQueue<ServeState>) =
         crate::platform::connect_bounded(
             &socket,
@@ -798,7 +803,12 @@ fn serve_loop(
             "clipboard serve: setup",
         )
         .map_err(|e| {
-            let msg = e.to_string();
+            // The bare cause, not the rendered error: `spawn` prefixes its own, and two variant
+            // names in one sentence say nothing the first did not.
+            let msg = match e {
+                GlassError::Backend(m) => m,
+                other => other.to_string(),
+            };
             signal_ready(&ready, ReadyState::Err(msg.clone()));
             GlassError::Backend(msg)
         })?;
@@ -1026,7 +1036,7 @@ mod tests {
         // write that never blocks, so a smaller one would pass with no bound at all.
         let owner = ClipboardOwner::spawn(socket.clone(), "x".repeat(256 * 1024)).expect("spawn");
 
-        let transfer = open_transfer(&socket)
+        let transfer = open_transfer(&socket, std::time::Instant::now() + CLIP_READ_TIMEOUT)
             .expect("open a transfer")
             .expect("a live owner offers text to transfer");
         // Wait for the first bytes: they are what says the serving thread is past its stop check
@@ -1134,10 +1144,12 @@ mod tests {
         assert!(matches!(err, GlassError::Backend(_)), "{err}");
     }
 
-    /// A compositor that accepts the connection and then never answers is what the 2 s readiness
-    /// bound is for. Joining the setup thread there waits on the wedged peer with no bound at
-    /// all, so spawn has to return without it — every tool call is behind the session lock this
-    /// holds.
+    /// A compositor that accepts the connection and then never answers is what the readiness bound
+    /// is for. Joining the setup thread there waits on the wedged peer with no bound at all, so
+    /// spawn has to return without it — every tool call is behind the session lock this holds.
+    ///
+    /// The setup's own budget is the shorter of the two, so what the caller hears is the step that
+    /// failed rather than the fact that something did.
     #[test]
     fn an_owner_gives_up_on_a_peer_that_accepts_and_never_answers() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -1171,7 +1183,7 @@ mod tests {
             "spawn took only {elapsed:?}, expected it to wait close to its own 2 s bound"
         );
         let msg = outcome.expect("a peer that never answers is not a served clipboard");
-        assert!(msg.contains("timed out"), "{msg}");
+        assert!(msg.contains("clipboard serve: setup"), "{msg}");
 
         // Closing the server side lets the detached setup thread fail and exit.
         drop(

--- a/crates/glass-wayland/src/clipboard.rs
+++ b/crates/glass-wayland/src/clipboard.rs
@@ -23,8 +23,8 @@ const CLIP_READ_TIMEOUT: Duration = Duration::from_secs(2);
 const SPAWN_READY_BUDGET: Duration = Duration::from_secs(2);
 
 /// What the serving thread's own setup gets. Strictly under [`SPAWN_READY_BUDGET`], so a setup
-/// that cannot finish says so to a caller still listening — tie the two and which of them reports
-/// is decided by a few microseconds of scheduling.
+/// that cannot finish says so to a caller still listening; tie the two and a few microseconds of
+/// scheduling decide which of them reports.
 const SERVE_SETUP_BUDGET: Duration = Duration::from_millis(1750);
 
 const _: () = assert!(
@@ -119,7 +119,6 @@ impl Dispatch<wl_buffer::WlBuffer, ()> for ClipState {
     }
 }
 
-/// The compositor's answer to a `wl_display.sync`, which is what a bounded roundtrip waits for.
 impl Dispatch<wl_callback::WlCallback, crate::platform::SyncDone> for ClipState {
     fn event(
         _: &mut Self,
@@ -274,7 +273,6 @@ impl Dispatch<wl_buffer::WlBuffer, ()> for ServeState {
     }
 }
 
-/// The compositor's answer to a `wl_display.sync`, which is what a bounded roundtrip waits for.
 impl Dispatch<wl_callback::WlCallback, crate::platform::SyncDone> for ServeState {
     fn event(
         _: &mut Self,
@@ -388,9 +386,8 @@ impl Dispatch<ZwlrDataControlSourceV1, ()> for ServeState {
 /// event queue, does a roundtrip to collect the selection offer, then reads the
 /// pipe transfer.
 pub fn get(socket: &Path) -> Result<String> {
-    // One deadline for the whole paste — connecting, the syncs, and the read from the owner — so
-    // what the session lock is held for is what the constant says, rather than its sum over the
-    // steps.
+    // One deadline for connecting, the syncs and the read, so the session lock is held for what
+    // the constant says rather than its sum over the steps.
     let deadline = Instant::now() + CLIP_READ_TIMEOUT;
     let Some(read_end) = open_transfer(socket, deadline)? else {
         return Ok(String::new());
@@ -1145,11 +1142,10 @@ mod tests {
     }
 
     /// A compositor that accepts the connection and then never answers is what the readiness bound
-    /// is for. Joining the setup thread there waits on the wedged peer with no bound at all, so
-    /// spawn has to return without it — every tool call is behind the session lock this holds.
+    /// is for: joining the setup thread would wait on the wedged peer with no bound at all, and
+    /// every tool call is behind the session lock this holds.
     ///
-    /// The setup's own budget is the shorter of the two, so what the caller hears is the step that
-    /// failed rather than the fact that something did.
+    /// The setup's budget is the shorter of the two, so the caller hears which step failed.
     #[test]
     fn an_owner_gives_up_on_a_peer_that_accepts_and_never_answers() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -1194,10 +1190,9 @@ mod tests {
         );
     }
 
-    /// Reading the clipboard opens its own connection, and the compositor's globals arrive over
-    /// an upstream roundtrip that polls with no timeout — so this hung outright until glass#402,
-    /// with the session lock held. No compositor needed: a listener that accepts and answers
-    /// nothing is what a wedged one looks like from this side.
+    /// Reading the clipboard opens its own connection, whose globals arrive over an upstream
+    /// roundtrip that polls with no timeout — so this hung outright until glass#402, session lock
+    /// held. A listener that accepts and answers nothing is a wedged compositor from this side.
     #[test]
     fn a_paste_gives_up_on_a_peer_that_accepts_and_never_answers() {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -20,9 +20,9 @@ use smithay_client_toolkit::registry_handlers;
 use smithay_client_toolkit::shm::raw::RawPool;
 use smithay_client_toolkit::shm::{Shm, ShmHandler};
 use tempfile::TempDir;
-use wayland_client::globals::registry_queue_init;
+use wayland_client::globals::{GlobalListContents, registry_queue_init};
 use wayland_client::protocol::wl_pointer::{Axis, ButtonState};
-use wayland_client::protocol::{wl_buffer, wl_callback, wl_output, wl_seat, wl_shm};
+use wayland_client::protocol::{wl_buffer, wl_callback, wl_output, wl_registry, wl_seat, wl_shm};
 use wayland_client::{Connection, Dispatch, EventQueue, QueueHandle, WEnum};
 use wayland_protocols_misc::zwp_virtual_keyboard_v1::client::zwp_virtual_keyboard_manager_v1::ZwpVirtualKeyboardManagerV1;
 use wayland_protocols_misc::zwp_virtual_keyboard_v1::client::zwp_virtual_keyboard_v1::ZwpVirtualKeyboardV1;
@@ -510,8 +510,16 @@ const _: () = assert!(
     "the capture budget must leave a loaded compositor time to answer, without holding the session lock for long"
 );
 
-/// A transport fault, named for the operation that hit it: these say the connection to the
-/// compositor failed, not that the operation was refused.
+/// Half a message: the front of one arrived and the rest has not. Upstream's own reader returns
+/// this as "nothing happened, ask again" rather than a fault, and so must glass — a split write
+/// means a loaded host.
+pub(crate) fn is_partial_read(e: &wayland_client::backend::WaylandError) -> bool {
+    matches!(e, wayland_client::backend::WaylandError::Io(io)
+        if io.kind() == std::io::ErrorKind::WouldBlock)
+}
+
+/// A fault raised while talking to the compositor, named for the operation that hit it. Both a
+/// broken connection and a request the compositor refused (`wl_display.error`) arrive this way.
 fn transport_failed(who: &str, what: &str, e: impl std::fmt::Display) -> GlassError {
     GlassError::Backend(format!("{who}: {what}: {e}"))
 }
@@ -565,10 +573,7 @@ fn dispatch_until<S>(
         Ok(0) => return Ok(()),
         Ok(_) => match guard.read() {
             Ok(_) => {}
-            // Half a message, which upstream's own reader retries rather than fails: a split
-            // write means a loaded host, not a fault.
-            Err(wayland_client::backend::WaylandError::Io(e))
-                if e.kind() == std::io::ErrorKind::WouldBlock => {}
+            Err(e) if is_partial_read(&e) => {}
             Err(e) => return Err(transport_failed(who, "read", e)),
         },
         // A signal arrived and nothing was lost.
@@ -612,9 +617,10 @@ fn wait_for<S, T>(
 
 /// How long the compositor gets to answer one request.
 ///
-/// One sync, not one tool call: a method that commits several (an input settle, a key tap) can
-/// spend this on each. Every wait on this connection is the session lock held, so a compositor
-/// that has stopped answering costs the budget once per request and then reports.
+/// One sync, not one tool call, and a tool call can spend it many times over: `glass_type` syncs
+/// twice per character, `glass_drag` once per waypoint. A compositor that has *stopped* answering
+/// costs one budget, since the first failure ends the call; one that answers every sync just
+/// inside the budget can hold the session lock for their sum.
 const COMPOSITOR_SYNC_BUDGET: Duration = Duration::from_secs(5);
 
 /// Only the sway-backed tests assert this live: on every other CI leg this is the whole guard.
@@ -622,6 +628,11 @@ const _: () = assert!(
     COMPOSITOR_SYNC_BUDGET.as_secs() >= 2 && COMPOSITOR_SYNC_BUDGET.as_secs() <= 15,
     "a sync must have time to answer on a loaded host, without holding the session lock for long"
 );
+
+/// What one pass of a discovery loop gives the compositor. Short, because such a loop is also
+/// watching for things the compositor cannot tell it — that sway exited, that a window needs
+/// re-mapping — and one pass that waited out the whole launch would stop it looking.
+const COMPOSITOR_SERVICE_SLICE: Duration = Duration::from_millis(250);
 
 /// Set by the compositor's answer to `wl_display.sync`, which is what a roundtrip waits for.
 pub(crate) type SyncDone = Arc<std::sync::atomic::AtomicBool>;
@@ -632,8 +643,6 @@ pub(crate) type SyncDone = Arc<std::sync::atomic::AtomicBool>;
 /// that has stopped answering holds the caller forever, exactly as the capture did before
 /// glass#383. This asks the same question and gives it `deadline` to answer.
 ///
-/// `who` names the caller in a failure, since one bad sync otherwise reads the same from every
-/// request on the connection.
 pub(crate) fn roundtrip_until<S>(
     conn: &Connection,
     queue: &mut EventQueue<S>,
@@ -667,6 +676,63 @@ where
                 .then_some(Ok(()))
         },
     )
+}
+
+/// Open a wayland connection and collect the compositor's globals, bounded.
+///
+/// `registry_queue_init` ends in `Connection::roundtrip`, which polls with no timeout — so every
+/// bound below it is unreachable on a fresh connection: connecting to a compositor that has
+/// stopped answering succeeds (the kernel completes an AF_UNIX connect into the listen backlog)
+/// and the setup then waits forever. Upstream offers no bounded form and `GlobalList` cannot be
+/// built here, so the setup runs on its own thread and the socket is shut down under it when the
+/// budget runs out — the only way to end a poll nothing else can reach.
+pub(crate) fn connect_bounded<S>(
+    socket: &Path,
+    budget: Duration,
+    who: &str,
+) -> Result<(
+    Connection,
+    wayland_client::globals::GlobalList,
+    EventQueue<S>,
+)>
+where
+    S: Dispatch<wl_registry::WlRegistry, GlobalListContents> + Send + 'static,
+{
+    let stream = UnixStream::connect(socket)
+        .map_err(|e| GlassError::Backend(format!("{who}: connect: {e}")))?;
+    // The same socket, kept back from the thread: shutting this down is what wakes its poll.
+    let watchdog = stream
+        .try_clone()
+        .map_err(|e| GlassError::Backend(format!("{who}: connect: {e}")))?;
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    let setup = std::thread::spawn(move || {
+        let outcome = Connection::from_socket(stream)
+            .map_err(|e| format!("wayland connection: {e}"))
+            .and_then(|conn| {
+                registry_queue_init::<S>(&conn)
+                    .map(|(globals, queue)| (conn, globals, queue))
+                    .map_err(|e| format!("wayland registry: {e}"))
+            });
+        let _ = tx.send(outcome);
+    });
+
+    match rx.recv_timeout(budget) {
+        Ok(outcome) => {
+            let _ = setup.join();
+            outcome.map_err(|e| GlassError::Backend(format!("{who}: {e}")))
+        }
+        Err(_) => {
+            let _ = watchdog.shutdown(std::net::Shutdown::Both);
+            // Joined, so the thread is gone before its socket is: a setup still running would
+            // otherwise outlive the call that started it.
+            let _ = setup.join();
+            Err(GlassError::Backend(format!(
+                "{who}: the compositor did not answer within {} ms",
+                budget.as_millis()
+            )))
+        }
+    }
 }
 
 /// [`roundtrip_until`] with the standard budget, for the callers with no deadline of their own.
@@ -925,6 +991,7 @@ impl Dispatch<ZwpVirtualKeyboardV1, ()> for State {
 fn open_session(
     socket: &Path,
     runtime_dir: &Path,
+    setup_budget: Duration,
 ) -> Result<(
     Connection,
     EventQueue<State>,
@@ -936,12 +1003,8 @@ fn open_session(
     Ipc,
     (u32, u32),
 )> {
-    let stream = UnixStream::connect(socket)
-        .map_err(|e| GlassError::Backend(format!("connect to wayland socket: {e}")))?;
-    let conn = Connection::from_socket(stream)
-        .map_err(|e| GlassError::Backend(format!("wayland connection: {e}")))?;
-    let (globals, mut queue): (_, EventQueue<State>) = registry_queue_init(&conn)
-        .map_err(|e| GlassError::Backend(format!("wayland registry: {e}")))?;
+    let (conn, globals, mut queue): (_, _, EventQueue<State>) =
+        connect_bounded(socket, setup_budget, "session bring-up")?;
 
     let advertised: Vec<String> = globals
         .contents()
@@ -1084,7 +1147,13 @@ fn bring_up_session(
     };
 
     let (conn, mut queue, mut state, manager, output, pointer, keyboard, mut ipc, output_size) =
-        match open_session(&socket, runtime_dir.path()) {
+        // What is left of the launch the caller asked for, not a budget of this function's own:
+        // `timeout_ms` is the knob for a slow machine, and a fixed one here would ignore it.
+        match open_session(
+            &socket,
+            runtime_dir.path(),
+            deadline.saturating_duration_since(Instant::now()),
+        ) {
             Ok(v) => v,
             Err(e) => {
                 glass_proc_linux::reap_group(&mut child, glass_proc_linux::REAP_GRACE);
@@ -1114,7 +1183,18 @@ fn bring_up_session(
             // Keep the wayland queue serviced, on the loop's own deadline: a fresh budget here
             // would be spent again on every pass, so a compositor that stopped answering would
             // hold the bring-up for the budget times the number of passes.
-            let _ = roundtrip_until(&conn, &mut queue, &mut state, deadline, "launch");
+            // A slice per pass, not the launch's whole budget: this loop has other work — seeing
+            // that sway exited, re-mapping a window Xwayland lost — and one servicing roundtrip
+            // that waited the budget out would stop all of it. The error is dropped rather than
+            // reported: a slice this short is missed by a compositor that is merely loaded, which
+            // is not the fault a launch timeout should name.
+            let _ = roundtrip_until(
+                &conn,
+                &mut queue,
+                &mut state,
+                Instant::now() + COMPOSITOR_SERVICE_SLICE,
+                "launch",
+            );
             // Distinguish "sway says no windows" from "sway did not answer": an unanswered
             // request is not evidence the app has no windows, and feeding that emptiness to the
             // cross-check below would make every window the app really has look lost.
@@ -1184,10 +1264,23 @@ fn bring_up_session(
     Ok((session, geometry))
 }
 
-/// Ask the compositor to answer for what this session has just sent, bounded.
+/// Emit `undo` and get it on the wire if the settle it follows failed.
 ///
-/// `who` is the operation to name if it does not: every request ends in the same sync, so
-/// nothing else tells one caller's failure from another's.
+/// A press is flushed before the wait it fails in, so the compositor has it and will act on it
+/// when it recovers. Returning the error without the counterpart leaves a button or a modifier
+/// latched, and the next tool call — which now runs, where the unbounded wait meant nothing ran
+/// again — inherits a seat holding a key down.
+fn undo_if_unsettled(s: &ActiveSession, settled: Result<()>, undo: impl FnOnce()) -> Result<()> {
+    if settled.is_err() {
+        undo();
+        // Best effort: what just failed is the compositor answering, so there is nothing to wait
+        // for and nothing to do about a flush that fails too.
+        let _ = s.conn.flush();
+    }
+    settled
+}
+
+/// Ask the compositor to answer for what this session has just sent, bounded.
 fn sync_session(s: &mut ActiveSession, who: &str) -> Result<()> {
     roundtrip(&s.conn, &mut s.queue, &mut s.state, who)
 }
@@ -1214,7 +1307,12 @@ fn tap(s: &mut ActiveSession, kb: &ZwpVirtualKeyboardV1, kc: u32) -> Result<()> 
     for state in [1u32, 0] {
         s.time = s.time.wrapping_add(1);
         kb.key(s.time, kc, state);
-        sync_session(s, "key tap")?;
+        let settled = sync_session(s, "key tap");
+        undo_if_unsettled(s, settled, || {
+            if state == 1 {
+                kb.key(s.time, kc, 0);
+            }
+        })?;
         std::thread::sleep(Duration::from_millis(8));
     }
     Ok(())
@@ -1327,7 +1425,13 @@ impl glass_core::DragSink for WaylandDragSink<'_> {
         };
         vp.button(t, self.b, state);
         vp.frame();
-        self.settle()
+        let settled = self.settle();
+        undo_if_unsettled(self.s, settled, || {
+            if down {
+                vp.button(t, self.b, ButtonState::Released);
+                vp.frame();
+            }
+        })
     }
     fn modifiers(&mut self, down: bool) -> Result<()> {
         if self.mask == 0 {
@@ -1342,7 +1446,12 @@ impl glass_core::DragSink for WaylandDragSink<'_> {
         }
         // Self-commit so the modifier change reaches the compositor before the
         // press/release that follows it (matches the X11 sink's flush-per-call).
-        self.settle()
+        let settled = self.settle();
+        undo_if_unsettled(self.s, settled, || {
+            if down {
+                kb.modifiers(0, 0, 0, 0);
+            }
+        })
     }
 }
 
@@ -1379,13 +1488,24 @@ impl glass_core::ChordSink for WaylandChordSink<'_> {
         } else if self.mask != 0 {
             kb.modifiers(0, 0, 0, 0);
         }
-        self.settle()
+        let settled = self.settle();
+        undo_if_unsettled(self.s, settled, || {
+            if down && self.mask != 0 {
+                kb.modifiers(0, 0, 0, 0);
+            }
+        })
     }
     fn key(&mut self, down: bool) -> Result<()> {
         let kb = self.s.keyboard.clone();
         self.s.time = self.s.time.wrapping_add(1);
-        kb.key(self.s.time, 1, u32::from(down)); // keycode 1 = the chord's key; 1=pressed, 0=released
-        self.settle()
+        let t = self.s.time;
+        kb.key(t, 1, u32::from(down)); // keycode 1 = the chord's key; 1=pressed, 0=released
+        let settled = self.settle();
+        undo_if_unsettled(self.s, settled, || {
+            if down {
+                kb.key(t, 1, 0);
+            }
+        })
     }
 }
 
@@ -1436,7 +1556,12 @@ impl glass_core::ScrollSink for WaylandScrollSink<'_> {
         } else {
             kb.modifiers(0, 0, 0, 0);
         }
-        self.settle()
+        let settled = self.settle();
+        undo_if_unsettled(self.s, settled, || {
+            if down {
+                kb.modifiers(0, 0, 0, 0);
+            }
+        })
     }
     fn wheel(&mut self) -> Result<()> {
         let vp = self.s.pointer.clone();
@@ -1688,7 +1813,11 @@ impl Platform for WaylandPlatform {
                 for _ in 0..count.max(1) {
                     vp.button(t, b, ButtonState::Pressed);
                     vp.frame();
-                    settle(session)?;
+                    let settled = settle(session);
+                    undo_if_unsettled(session, settled, || {
+                        vp.button(t, b, ButtonState::Released);
+                        vp.frame();
+                    })?;
                     vp.button(t, b, ButtonState::Released);
                     vp.frame();
                     settle(session)?;
@@ -2126,6 +2255,63 @@ mod pure_tests {
         assert!(
             elapsed >= PURE_WAIT_BUDGET,
             "the deadline was cut short: {elapsed:?}"
+        );
+    }
+
+    /// The three ways a read ends, and only one of them is a fault. Kept apart from the loops
+    /// that act on them so the judgement can be checked without a compositor.
+    #[test]
+    fn only_a_read_that_lost_nothing_is_asked_again() {
+        use wayland_client::backend::WaylandError;
+        let partial = WaylandError::Io(std::io::ErrorKind::WouldBlock.into());
+        let gone = WaylandError::Io(std::io::ErrorKind::BrokenPipe.into());
+        assert!(is_partial_read(&partial), "half a message is not a fault");
+        assert!(
+            !is_partial_read(&gone),
+            "a connection that ended must not be waited on again"
+        );
+    }
+
+    /// The other half of the roundtrip: nothing on a compositor-less CI leg proves the callback is
+    /// wired to the right queue, and a `Dispatch` impl that never fired would turn every request
+    /// into a five-second timeout — visible only where sway runs.
+    #[test]
+    fn a_roundtrip_returns_when_the_compositor_answers_the_sync() {
+        let (ours, mut theirs) = UnixStream::pair().expect("socketpair");
+        let conn = Connection::from_socket(ours).expect("a connection over the socket");
+        let mut queue = conn.new_event_queue::<SyncOnly>();
+
+        let answer = std::thread::spawn(move || {
+            // `wl_callback.done` for object 2 — the display is 1, and the sync's callback is the
+            // first object this connection creates. Written after a beat so it cannot arrive
+            // before the object it names exists.
+            std::thread::sleep(Duration::from_millis(50));
+            let done: [u8; 12] = {
+                let mut m = [0u8; 12];
+                m[0..4].copy_from_slice(&2u32.to_ne_bytes());
+                // Length in the high half, opcode 0 (`done`) in the low.
+                m[4..8].copy_from_slice(&(12u32 << 16).to_ne_bytes());
+                m
+            };
+            theirs.write_all(&done).expect("write the done event");
+            theirs
+        });
+
+        let started = Instant::now();
+        let outcome = roundtrip_until(
+            &conn,
+            &mut queue,
+            &mut SyncOnly,
+            Instant::now() + PROMPT_WAIT_BUDGET,
+            "a caller",
+        );
+        let elapsed = started.elapsed();
+        drop(answer.join().expect("the answering thread"));
+
+        outcome.expect("the compositor answered the sync");
+        assert!(
+            elapsed < PROMPT_WAIT_BUDGET / 2,
+            "the answer was not noticed until the deadline: {elapsed:?}"
         );
     }
 
@@ -3195,8 +3381,9 @@ mod session_tests {
         assert_eq!(px[3], 255, "opaque");
     }
 
-    /// How long a suspended compositor stays suspended if nothing resumes it. `CAPTURE_BUDGET`'s
-    /// bracket assertion caps a capture at 15s, so a bounded one is always over first.
+    /// How long a suspended compositor stays suspended if nothing resumes it. The bracket
+    /// assertions cap both `CAPTURE_BUDGET` and `COMPOSITOR_SYNC_BUDGET` at 15s, so anything
+    /// bounded by either is over first.
     const SUSPENSION: Duration = Duration::from_secs(30);
 
     /// SIGSTOPs a process until dropped: a compositor holding its connection open and answering
@@ -3326,6 +3513,14 @@ mod session_tests {
             elapsed < SUSPENSION * 2 / 3,
             "the input waited the compositor out rather than bounding it: {elapsed:?}"
         );
+        // The other end of the bracket: every healthy sync answers in microseconds, so a budget
+        // cut to nothing would leave the suite green while every click on a loaded compositor
+        // failed.
+        assert!(
+            elapsed >= Duration::from_secs(2),
+            "the sync budget is no longer generous enough for a compositor under load: \
+             {elapsed:?}"
+        );
         assert!(
             err.to_string().contains("input settle"),
             "the failure should name the request that made it: {err}"
@@ -3354,6 +3549,11 @@ mod session_tests {
         assert!(
             elapsed < SUSPENSION * 2 / 3,
             "the enumeration waited the compositor out rather than bounding it: {elapsed:?}"
+        );
+        assert!(
+            elapsed >= Duration::from_secs(2),
+            "the sync budget is no longer generous enough for a compositor under load: \
+             {elapsed:?}"
         );
         assert!(
             err.to_string().contains("window list"),

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -22,7 +22,7 @@ use smithay_client_toolkit::shm::{Shm, ShmHandler};
 use tempfile::TempDir;
 use wayland_client::globals::registry_queue_init;
 use wayland_client::protocol::wl_pointer::{Axis, ButtonState};
-use wayland_client::protocol::{wl_buffer, wl_output, wl_seat, wl_shm};
+use wayland_client::protocol::{wl_buffer, wl_callback, wl_output, wl_seat, wl_shm};
 use wayland_client::{Connection, Dispatch, EventQueue, QueueHandle, WEnum};
 use wayland_protocols_misc::zwp_virtual_keyboard_v1::client::zwp_virtual_keyboard_manager_v1::ZwpVirtualKeyboardManagerV1;
 use wayland_protocols_misc::zwp_virtual_keyboard_v1::client::zwp_virtual_keyboard_v1::ZwpVirtualKeyboardV1;
@@ -510,16 +510,19 @@ const _: () = assert!(
     "the capture budget must leave a loaded compositor time to answer, without holding the session lock for long"
 );
 
-fn capture_failed(what: &str, e: impl std::fmt::Display) -> GlassError {
-    GlassError::CaptureFailed(format!("screencopy: {what}: {e}"))
+/// A transport fault, named for the operation that hit it: these say the connection to the
+/// compositor failed, not that the operation was refused.
+fn transport_failed(who: &str, what: &str, e: impl std::fmt::Display) -> GlassError {
+    GlassError::Backend(format!("{who}: {what}: {e}"))
 }
 
 /// Send what is queued and dispatch what has already arrived, without waiting for more.
-fn drain<S>(conn: &Connection, queue: &mut EventQueue<S>, state: &mut S) -> Result<()> {
-    conn.flush().map_err(|e| capture_failed("flush", e))?;
+fn drain<S>(conn: &Connection, queue: &mut EventQueue<S>, state: &mut S, who: &str) -> Result<()> {
+    conn.flush()
+        .map_err(|e| transport_failed(who, "flush", e))?;
     queue
         .dispatch_pending(state)
-        .map_err(|e| capture_failed("dispatch", e))?;
+        .map_err(|e| transport_failed(who, "dispatch", e))?;
     Ok(())
 }
 
@@ -531,18 +534,19 @@ fn drain<S>(conn: &Connection, queue: &mut EventQueue<S>, state: &mut S) -> Resu
 ///
 /// Expiry is not an error here — [`wait_for`] owns the deadline.
 ///
-/// Generic over the queue's state only so the bound can be tested with no compositor behind the
-/// socket; capture is its only caller, hence the error variant.
+/// Generic over the queue's state so the bound can be tested with no compositor behind the socket,
+/// and so capture and the sync every other request rides on share one implementation.
 fn dispatch_until<S>(
     conn: &Connection,
     queue: &mut EventQueue<S>,
     state: &mut S,
     deadline: Instant,
+    who: &str,
 ) -> Result<()> {
     // `None` means the backend's own queue needs draining — a libwayland condition the pure-Rust
     // backend glass builds never reports.
     let Some(guard) = queue.prepare_read() else {
-        return drain(conn, queue, state);
+        return drain(conn, queue, state, who);
     };
     let Some(ts) = remaining_timespec(deadline) else {
         return Ok(());
@@ -565,15 +569,15 @@ fn dispatch_until<S>(
             // write means a loaded host, not a fault.
             Err(wayland_client::backend::WaylandError::Io(e))
                 if e.kind() == std::io::ErrorKind::WouldBlock => {}
-            Err(e) => return Err(capture_failed("read", e)),
+            Err(e) => return Err(transport_failed(who, "read", e)),
         },
         // A signal arrived and nothing was lost.
         Err(rustix::io::Errno::INTR) => return Ok(()),
-        Err(e) => return Err(capture_failed("poll", e)),
+        Err(e) => return Err(transport_failed(who, "poll", e)),
     }
     queue
         .dispatch_pending(state)
-        .map_err(|e| capture_failed("dispatch", e))?;
+        .map_err(|e| transport_failed(who, "dispatch", e))?;
     Ok(())
 }
 
@@ -590,19 +594,98 @@ fn wait_for<S, T>(
     queue: &mut EventQueue<S>,
     state: &mut S,
     deadline: Instant,
-    expired: impl FnOnce(&S) -> String,
+    who: &str,
+    expired: impl FnOnce(&S) -> GlassError,
     mut answered: impl FnMut(&mut S) -> Option<Result<T>>,
 ) -> Result<T> {
     loop {
-        drain(conn, queue, state)?;
+        drain(conn, queue, state, who)?;
         if let Some(answer) = answered(state) {
             return answer;
         }
         if Instant::now() >= deadline {
-            return Err(GlassError::CaptureFailed(expired(state)));
+            return Err(expired(state));
         }
-        dispatch_until(conn, queue, state, deadline)?;
+        dispatch_until(conn, queue, state, deadline, who)?;
     }
+}
+
+/// How long the compositor gets to answer one request.
+///
+/// One sync, not one tool call: a method that commits several (an input settle, a key tap) can
+/// spend this on each. Every wait on this connection is the session lock held, so a compositor
+/// that has stopped answering costs the budget once per request and then reports.
+const COMPOSITOR_SYNC_BUDGET: Duration = Duration::from_secs(5);
+
+/// Only the sway-backed tests assert this live: on every other CI leg this is the whole guard.
+const _: () = assert!(
+    COMPOSITOR_SYNC_BUDGET.as_secs() >= 2 && COMPOSITOR_SYNC_BUDGET.as_secs() <= 15,
+    "a sync must have time to answer on a loaded host, without holding the session lock for long"
+);
+
+/// Set by the compositor's answer to `wl_display.sync`, which is what a roundtrip waits for.
+pub(crate) type SyncDone = Arc<std::sync::atomic::AtomicBool>;
+
+/// `EventQueue::roundtrip`, bounded — glass#402.
+///
+/// The unbounded one loops `blocking_dispatch` until the sync callback returns, so a compositor
+/// that has stopped answering holds the caller forever, exactly as the capture did before
+/// glass#383. This asks the same question and gives it `deadline` to answer.
+///
+/// `who` names the caller in a failure, since one bad sync otherwise reads the same from every
+/// request on the connection.
+pub(crate) fn roundtrip_until<S>(
+    conn: &Connection,
+    queue: &mut EventQueue<S>,
+    state: &mut S,
+    deadline: Instant,
+    who: &str,
+) -> Result<()>
+where
+    S: Dispatch<wl_callback::WlCallback, SyncDone> + 'static,
+{
+    // Read before the wait, not in the failure: by then there is none left to report.
+    let budget = deadline.saturating_duration_since(Instant::now());
+    let done: SyncDone = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    conn.display().sync(&queue.handle(), Arc::clone(&done));
+    wait_for(
+        conn,
+        queue,
+        state,
+        deadline,
+        who,
+        // Not a bare `GlassError::Timeout`, which names no operation: every request on this
+        // connection ends in a sync, so the caller is the only thing that tells them apart.
+        |_| {
+            GlassError::Backend(format!(
+                "{who}: the compositor did not answer within {} ms",
+                budget.as_millis()
+            ))
+        },
+        |_| {
+            done.load(std::sync::atomic::Ordering::Relaxed)
+                .then_some(Ok(()))
+        },
+    )
+}
+
+/// [`roundtrip_until`] with the standard budget, for the callers with no deadline of their own.
+pub(crate) fn roundtrip<S>(
+    conn: &Connection,
+    queue: &mut EventQueue<S>,
+    state: &mut S,
+    who: &str,
+) -> Result<()>
+where
+    S: Dispatch<wl_callback::WlCallback, SyncDone> + 'static,
+{
+    roundtrip_until(
+        conn,
+        queue,
+        state,
+        Instant::now() + COMPOSITOR_SYNC_BUDGET,
+        who,
+    )
 }
 
 /// The wayland objects one capture owns, destroyed when it ends however it ends.
@@ -720,6 +803,20 @@ impl Dispatch<wl_buffer::WlBuffer, ()> for State {
 }
 
 // --- wlr-screencopy (manager has no events; frame events drive a capture) ---
+/// The compositor's answer to a `wl_display.sync`: the whole of what a roundtrip waits for.
+impl Dispatch<wl_callback::WlCallback, SyncDone> for State {
+    fn event(
+        _: &mut Self,
+        _: &wl_callback::WlCallback,
+        _: wl_callback::Event,
+        done: &SyncDone,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        done.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
 impl Dispatch<ZwlrScreencopyManagerV1, ()> for State {
     fn event(
         _: &mut Self,
@@ -877,9 +974,7 @@ fn open_session(
         .bind(&qh, 1..=1, ())
         .map_err(|e| GlassError::Backend(format!("bind virtual keyboard: {e}")))?;
 
-    queue
-        .roundtrip(&mut state)
-        .map_err(|e| GlassError::Backend(format!("wayland roundtrip: {e}")))?;
+    roundtrip(&conn, &mut queue, &mut state, "session bring-up")?;
 
     let output = state
         .output
@@ -1016,7 +1111,10 @@ fn bring_up_session(
         // other half to notice, re-map, and see the window appear.
         let start_grace = Instant::now() + start_recovery_after(spec.timeout_ms);
         loop {
-            let _ = queue.roundtrip(&mut state); // keep the wayland queue serviced
+            // Keep the wayland queue serviced, on the loop's own deadline: a fresh budget here
+            // would be spent again on every pass, so a compositor that stopped answering would
+            // hold the bring-up for the budget times the number of passes.
+            let _ = roundtrip_until(&conn, &mut queue, &mut state, deadline, "launch");
             // Distinguish "sway says no windows" from "sway did not answer": an unanswered
             // request is not evidence the app has no windows, and feeding that emptiness to the
             // cross-check below would make every window the app really has look lost.
@@ -1086,6 +1184,14 @@ fn bring_up_session(
     Ok((session, geometry))
 }
 
+/// Ask the compositor to answer for what this session has just sent, bounded.
+///
+/// `who` is the operation to name if it does not: every request ends in the same sync, so
+/// nothing else tells one caller's failure from another's.
+fn sync_session(s: &mut ActiveSession, who: &str) -> Result<()> {
+    roundtrip(&s.conn, &mut s.queue, &mut s.state, who)
+}
+
 /// Write the keymap to an unlinked temp file and hand its fd to the compositor,
 /// then settle so Xwayland adopts the new mapping before any key events. No
 /// unsafe: tempfile gives a normal, mmap-able fd; XKB_V1 format == 1.
@@ -1095,9 +1201,7 @@ fn upload_keymap(s: &mut ActiveSession, kb: &ZwpVirtualKeyboardV1, keymap: &str)
     f.write_all(&[0]).map_err(GlassError::Io)?; // keymap string is NUL-terminated
     f.flush().map_err(GlassError::Io)?;
     kb.keymap(1, f.as_fd(), keymap.len() as u32 + 1);
-    s.queue
-        .roundtrip(&mut s.state)
-        .map_err(|e| GlassError::Backend(format!("roundtrip: {e}")))?;
+    sync_session(s, "keymap upload")?;
     std::thread::sleep(Duration::from_millis(8));
     Ok(())
 }
@@ -1110,9 +1214,7 @@ fn tap(s: &mut ActiveSession, kb: &ZwpVirtualKeyboardV1, kc: u32) -> Result<()> 
     for state in [1u32, 0] {
         s.time = s.time.wrapping_add(1);
         kb.key(s.time, kc, state);
-        s.queue
-            .roundtrip(&mut s.state)
-            .map_err(|e| GlassError::Backend(format!("roundtrip: {e}")))?;
+        sync_session(s, "key tap")?;
         std::thread::sleep(Duration::from_millis(8));
     }
     Ok(())
@@ -1184,10 +1286,7 @@ impl WaylandDragSink<'_> {
         (self.oy + y).max(0) as u32
     }
     fn settle(&mut self) -> Result<()> {
-        self.s
-            .queue
-            .roundtrip(&mut self.s.state)
-            .map_err(|e| GlassError::Backend(format!("roundtrip: {e}")))?;
+        sync_session(self.s, "input settle")?;
         std::thread::sleep(Duration::from_millis(8));
         Ok(())
     }
@@ -1258,10 +1357,7 @@ struct WaylandChordSink<'a> {
 
 impl WaylandChordSink<'_> {
     fn settle(&mut self) -> Result<()> {
-        self.s
-            .queue
-            .roundtrip(&mut self.s.state)
-            .map_err(|e| GlassError::Backend(format!("roundtrip: {e}")))?;
+        sync_session(self.s, "input settle")?;
         std::thread::sleep(Duration::from_millis(8));
         Ok(())
     }
@@ -1323,10 +1419,7 @@ impl WaylandScrollSink<'_> {
         (self.oy + y).max(0) as u32
     }
     fn settle(&mut self) -> Result<()> {
-        self.s
-            .queue
-            .roundtrip(&mut self.s.state)
-            .map_err(|e| GlassError::Backend(format!("roundtrip: {e}")))?;
+        sync_session(self.s, "input settle")?;
         std::thread::sleep(Duration::from_millis(8));
         Ok(())
     }
@@ -1504,7 +1597,8 @@ impl Platform for WaylandPlatform {
             &mut session.queue,
             &mut session.state,
             deadline,
-            |s| s.capture.no_formats(),
+            "screencopy",
+            |s| GlassError::CaptureFailed(s.capture.no_formats()),
             |s| s.capture.advertised(),
         )?;
 
@@ -1522,7 +1616,12 @@ impl Platform for WaylandPlatform {
             &mut session.queue,
             &mut session.state,
             deadline,
-            |_| "screencopy: no ready event after the copy request".into(),
+            "screencopy",
+            |_| {
+                GlassError::CaptureFailed(
+                    "screencopy: no ready event after the copy request".into(),
+                )
+            },
             |s| s.capture.done.take(),
         )?;
 
@@ -1545,9 +1644,8 @@ impl Platform for WaylandPlatform {
         let kb = session.keyboard.clone();
         // Flush pending requests and let the compositor + Xwayland process pointer
         // motion (enter/position) before the next event lands.
-        let settle = |q: &mut EventQueue<State>, s: &mut State| -> Result<()> {
-            q.roundtrip(s)
-                .map_err(|e| GlassError::Backend(format!("roundtrip: {e}")))?;
+        let settle = |s: &mut ActiveSession| -> Result<()> {
+            sync_session(s, "input settle")?;
             std::thread::sleep(Duration::from_millis(8));
             Ok(())
         };
@@ -1559,19 +1657,19 @@ impl Platform for WaylandPlatform {
         // then re-assert with a 1px delta to force a fresh focus evaluation now that
         // it is ready. Without this, fast back-to-back launch+click on a loaded host
         // intermittently loses the very first click/scroll (the Wayland flake).
-        let position = |q: &mut EventQueue<State>, s: &mut State, x: i32, y: i32| -> Result<()> {
+        let position = |s: &mut ActiveSession, x: i32, y: i32| -> Result<()> {
             vp.motion_absolute(t, ax(x), ay(y), w, h);
             vp.frame();
-            settle(q, s)?;
+            settle(s)?;
             vp.motion_absolute(t, nudge_x(ax(x), w), ay(y), w, h);
             vp.frame();
             vp.motion_absolute(t, ax(x), ay(y), w, h);
             vp.frame();
-            settle(q, s)
+            settle(s)
         };
         match *event {
             PointerEvent::Move { x, y } => {
-                position(&mut session.queue, &mut session.state, x, y)?;
+                position(session, x, y)?;
             }
             PointerEvent::Click {
                 x,
@@ -1580,7 +1678,7 @@ impl Platform for WaylandPlatform {
                 count,
                 ref modifiers,
             } => {
-                position(&mut session.queue, &mut session.state, x, y)?;
+                position(session, x, y)?;
                 let mask = modifier_mask(modifiers);
                 if mask != 0 {
                     upload_keymap(session, &kb, &crate::keyboard::build_keymap(&[]))?;
@@ -1590,10 +1688,10 @@ impl Platform for WaylandPlatform {
                 for _ in 0..count.max(1) {
                     vp.button(t, b, ButtonState::Pressed);
                     vp.frame();
-                    settle(&mut session.queue, &mut session.state)?;
+                    settle(session)?;
                     vp.button(t, b, ButtonState::Released);
                     vp.frame();
-                    settle(&mut session.queue, &mut session.state)?;
+                    settle(session)?;
                 }
                 if mask != 0 {
                     kb.modifiers(0, 0, 0, 0);
@@ -1738,10 +1836,7 @@ impl Platform for WaylandPlatform {
     fn list_windows(&mut self) -> Result<Vec<WindowInfo>> {
         let session = self.active.as_mut().ok_or(GlassError::NoActiveSession)?;
         // Refresh foreign-toplevel handles so capture can later find them.
-        session
-            .queue
-            .roundtrip(&mut session.state)
-            .map_err(|e| GlassError::Backend(format!("roundtrip: {e}")))?;
+        sync_session(session, "window list")?;
         let mut wins: Vec<SwayWindow> = session.ipc.windows()?;
         // A window the app mapped can be missing here through no fault of the app (see
         // `crate::xwayland`). Enumerating is where that shows up, so it is where glass repairs
@@ -1850,7 +1945,8 @@ mod pure_tests {
             &mut queue,
             &mut (),
             Instant::now() + budget,
-            |()| "nothing arrived".into(),
+            "test",
+            |()| GlassError::Backend("nothing arrived".into()),
             |()| None,
         );
         (outcome, started.elapsed())
@@ -1968,11 +2064,69 @@ mod pure_tests {
             &mut queue,
             &mut (),
             Instant::now() - Duration::from_secs(1),
-            |()| "nothing arrived".into(),
+            "test",
+            |()| GlassError::Backend("nothing arrived".into()),
             |()| Some(Ok(7)),
         );
 
         assert_eq!(answered.expect("the answer, not the expired budget"), 7);
+    }
+
+    /// A state that answers nothing but the sync a roundtrip rides on — all a bounded roundtrip
+    /// needs, and constructible with no compositor.
+    struct SyncOnly;
+
+    impl Dispatch<wl_callback::WlCallback, SyncDone> for SyncOnly {
+        fn event(
+            _: &mut Self,
+            _: &wl_callback::WlCallback,
+            _: wl_callback::Event,
+            done: &SyncDone,
+            _: &Connection,
+            _: &QueueHandle<Self>,
+        ) {
+            done.store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+
+    /// glass#402: `roundtrip` loops `blocking_dispatch` until the compositor answers the sync, so
+    /// a quiet one holds every request that ends in one — which is every request.
+    #[test]
+    fn a_roundtrip_gives_up_on_a_compositor_that_never_answers() {
+        let (outcome, elapsed) = on_a_thread(
+            PURE_WAIT_BUDGET * 20,
+            "the roundtrip never came back, so it is not bounded by its deadline",
+            || {
+                let (ours, theirs) = UnixStream::pair().expect("socketpair");
+                let conn = Connection::from_socket(ours).expect("a connection over the socket");
+                let mut queue = conn.new_event_queue::<SyncOnly>();
+                let started = Instant::now();
+                let outcome = roundtrip_until(
+                    &conn,
+                    &mut queue,
+                    &mut SyncOnly,
+                    Instant::now() + PURE_WAIT_BUDGET,
+                    "a caller",
+                );
+                let elapsed = started.elapsed();
+                drop(theirs);
+                (outcome, elapsed)
+            },
+        );
+
+        let err = outcome.expect_err("a sync nothing answered is a failure");
+        assert!(
+            err.to_string().contains("a caller"),
+            "the failure should name the request that made it: {err}"
+        );
+        assert!(
+            elapsed < PURE_WAIT_BUDGET * 10,
+            "the roundtrip outlived its deadline by too much to be bounded by it: {elapsed:?}"
+        );
+        assert!(
+            elapsed >= PURE_WAIT_BUDGET,
+            "the deadline was cut short: {elapsed:?}"
+        );
     }
 
     /// A scratch holding one advertised format, as the compositor's `buffer` event leaves it.
@@ -3145,6 +3299,65 @@ mod session_tests {
         assert!(
             err.to_string().contains("no buffer event"),
             "the capture should report what never arrived: {err}"
+        );
+    }
+
+    /// glass#402: every request ends in a sync the compositor answers, and waiting for one was
+    /// unbounded — so `glass_click` on a compositor that had gone quiet held the session lock the
+    /// capture, bounded in glass#383, had just stopped holding.
+    #[test]
+    #[ignore = "starts a real compositor or X server; needs sway, Mesa, Xwayland or Xvfb"]
+    fn input_gives_up_on_a_compositor_that_stops_answering() {
+        let mut s = Launch::new().start_mapped();
+        let pid = s
+            .platform()
+            .session_compositor_pid()
+            .expect("a started session has a compositor");
+        let _suspended = Suspended::process(pid);
+
+        let started = Instant::now();
+        let err = s
+            .platform()
+            .send_pointer(&PointerEvent::Move { x: 10, y: 10 })
+            .expect_err("a suspended compositor cannot answer");
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < SUSPENSION * 2 / 3,
+            "the input waited the compositor out rather than bounding it: {elapsed:?}"
+        );
+        assert!(
+            err.to_string().contains("input settle"),
+            "the failure should name the request that made it: {err}"
+        );
+    }
+
+    /// Enumeration reaches the compositor over the wayland connection before it asks sway IPC,
+    /// which has a read timeout of its own — so the bound this needs is the wayland one.
+    #[test]
+    #[ignore = "starts a real compositor or X server; needs sway, Mesa, Xwayland or Xvfb"]
+    fn enumeration_gives_up_on_a_compositor_that_stops_answering() {
+        let mut s = Launch::new().start_mapped();
+        let pid = s
+            .platform()
+            .session_compositor_pid()
+            .expect("a started session has a compositor");
+        let _suspended = Suspended::process(pid);
+
+        let started = Instant::now();
+        let err = s
+            .platform()
+            .list_windows()
+            .expect_err("a suspended compositor cannot answer");
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < SUSPENSION * 2 / 3,
+            "the enumeration waited the compositor out rather than bounding it: {elapsed:?}"
+        );
+        assert!(
+            err.to_string().contains("window list"),
+            "the failure should name the request that made it: {err}"
         );
     }
 

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -510,9 +510,8 @@ const _: () = assert!(
     "the capture budget must leave a loaded compositor time to answer, without holding the session lock for long"
 );
 
-/// Half a message: the front of one arrived and the rest has not. Upstream's own reader returns
-/// this as "nothing happened, ask again" rather than a fault, and so must glass — a split write
-/// means a loaded host.
+/// Half a message: the front arrived and the rest has not. Upstream's own reader returns this as
+/// "nothing happened, ask again" rather than a fault, and a split write means a loaded host.
 pub(crate) fn is_partial_read(e: &wayland_client::backend::WaylandError) -> bool {
     matches!(e, wayland_client::backend::WaylandError::Io(io)
         if io.kind() == std::io::ErrorKind::WouldBlock)
@@ -542,8 +541,8 @@ fn drain<S>(conn: &Connection, queue: &mut EventQueue<S>, state: &mut S, who: &s
 ///
 /// Expiry is not an error here — [`wait_for`] owns the deadline.
 ///
-/// Generic over the queue's state so the bound can be tested with no compositor behind the socket,
-/// and so capture and the sync every other request rides on share one implementation.
+/// Generic over the queue's state so the bound can be tested with no compositor behind the
+/// socket, and so capture and the sync every other request rides on share one implementation.
 fn dispatch_until<S>(
     conn: &Connection,
     queue: &mut EventQueue<S>,
@@ -617,10 +616,10 @@ fn wait_for<S, T>(
 
 /// How long the compositor gets to answer one request.
 ///
-/// One sync, not one tool call, and a tool call can spend it many times over: `glass_type` syncs
-/// twice per character, `glass_drag` once per waypoint. A compositor that has *stopped* answering
-/// costs one budget, since the first failure ends the call; one that answers every sync just
-/// inside the budget can hold the session lock for their sum.
+/// One sync, not one tool call, and a tool call spends it many times over — `glass_type` syncs
+/// twice per character, `glass_drag` once per waypoint. A compositor that has stopped answering
+/// costs one, since the first failure ends the call; one answering just inside the budget every
+/// time can hold the session lock for their sum.
 const COMPOSITOR_SYNC_BUDGET: Duration = Duration::from_secs(5);
 
 /// Only the sway-backed tests assert this live: on every other CI leg this is the whole guard.
@@ -629,13 +628,13 @@ const _: () = assert!(
     "a sync must have time to answer on a loaded host, without holding the session lock for long"
 );
 
-/// What one pass of a discovery loop gives the compositor. Short, because such a loop is also
-/// watching for things the compositor cannot tell it — that sway exited, that a window needs
-/// re-mapping — and one pass that waited out the whole launch would stop it looking.
+/// What one pass of a discovery loop gives the compositor — short, because such a loop is also
+/// watching for what the compositor cannot tell it: that sway exited, that a window needs
+/// re-mapping.
 const COMPOSITOR_SERVICE_SLICE: Duration = Duration::from_millis(250);
 
-/// Short enough that a loop spending one per pass still gets on with its other work, long enough
-/// that a compositor merely busy answers inside it — a slice it misses is discarded, not reported.
+/// A slice a merely-busy compositor answers inside, since one it misses is discarded rather than
+/// reported.
 const _: () = assert!(
     COMPOSITOR_SERVICE_SLICE.as_millis() >= 50 && COMPOSITOR_SERVICE_SLICE.as_millis() <= 1000,
     "a servicing slice must not become a wait in its own right"
@@ -646,9 +645,9 @@ pub(crate) type SyncDone = Arc<std::sync::atomic::AtomicBool>;
 
 /// `EventQueue::roundtrip`, bounded — glass#402.
 ///
-/// The unbounded one loops `blocking_dispatch` until the sync callback returns, so a compositor
-/// that has stopped answering holds the caller forever, exactly as the capture did before
-/// glass#383. This asks the same question and gives it `deadline` to answer.
+/// The unbounded one loops `blocking_dispatch` until the `done` event sets its flag, so a
+/// compositor that has stopped answering holds the caller forever. This asks the same question
+/// and gives it `deadline` to answer.
 ///
 pub(crate) fn roundtrip_until<S>(
     conn: &Connection,
@@ -670,8 +669,8 @@ where
         state,
         deadline,
         who,
-        // Not a bare `GlassError::Timeout`, which names no operation: every request on this
-        // connection ends in a sync, so the caller is the only thing that tells them apart.
+        // Not a bare `GlassError::Timeout`, which names no operation: every request ends in the
+        // same sync, so the caller is all that tells one failure from another.
         |_| {
             GlassError::Backend(format!(
                 "{who}: the compositor did not answer within {} ms",
@@ -687,12 +686,11 @@ where
 
 /// Open a wayland connection and collect the compositor's globals, bounded.
 ///
-/// `registry_queue_init` ends in `Connection::roundtrip`, which polls with no timeout — so every
-/// bound below it is unreachable on a fresh connection: connecting to a compositor that has
-/// stopped answering succeeds (the kernel completes an AF_UNIX connect into the listen backlog)
-/// and the setup then waits forever. Upstream offers no bounded form and `GlobalList` cannot be
-/// built here, so the setup runs on its own thread and the socket is shut down under it when the
-/// budget runs out — the only way to end a poll nothing else can reach.
+/// `registry_queue_init` ends in `Connection::roundtrip`, which polls with no timeout, so every
+/// bound below it is unreachable: an AF_UNIX connect to a compositor that has stopped answering
+/// still succeeds (the kernel completes it into the listen backlog) and the setup then waits
+/// forever. Upstream offers no bounded form and `GlobalList` cannot be built here, so the setup
+/// runs on its own thread and the socket is shut down under it — the only way to end that poll.
 pub(crate) fn connect_bounded<S>(
     socket: &Path,
     budget: Duration,
@@ -707,9 +705,8 @@ where
 {
     let stream = UnixStream::connect(socket)
         .map_err(|e| GlassError::Backend(format!("{who}: connect: {e}")))?;
-    // The same socket, kept back from the thread: shutting this down is what wakes its poll.
-    // `Both`, not `Read`: a setup blocked writing to a compositor that has stopped reading is
-    // just as stuck, and only the write half ends that.
+    // The same socket, kept back from the thread: shutting it down is what wakes its poll, and
+    // `Both` because a setup blocked writing to a compositor that stopped reading is as stuck.
     let watchdog = stream
         .try_clone()
         .map_err(|e| GlassError::Backend(format!("{who}: connect: {e}")))?;
@@ -741,8 +738,7 @@ where
         }
         Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
             let _ = watchdog.shutdown(std::net::Shutdown::Both);
-            // Joined, so the thread is gone before its socket is: a setup still running would
-            // otherwise outlive the call that started it.
+            // Joined, so a setup still running cannot outlive the call that started it.
             let _ = setup.join();
             Err(GlassError::Backend(format!(
                 "{who}: the compositor did not answer within {} ms",
@@ -886,7 +882,6 @@ impl Dispatch<wl_buffer::WlBuffer, ()> for State {
 }
 
 // --- wlr-screencopy (manager has no events; frame events drive a capture) ---
-/// The compositor's answer to a `wl_display.sync`: the whole of what a roundtrip waits for.
 impl Dispatch<wl_callback::WlCallback, SyncDone> for State {
     fn event(
         _: &mut Self,
@@ -1201,14 +1196,9 @@ fn bring_up_session(
         // other half to notice, re-map, and see the window appear.
         let start_grace = Instant::now() + start_recovery_after(spec.timeout_ms);
         loop {
-            // Keep the wayland queue serviced, on the loop's own deadline: a fresh budget here
-            // would be spent again on every pass, so a compositor that stopped answering would
-            // hold the bring-up for the budget times the number of passes.
-            // A slice per pass, not the launch's whole budget: this loop has other work — seeing
-            // that sway exited, re-mapping a window Xwayland lost — and one servicing roundtrip
-            // that waited the budget out would stop all of it. The error is dropped rather than
-            // reported: a slice this short is missed by a compositor that is merely loaded, which
-            // is not the fault a launch timeout should name.
+            // A slice per pass, not the launch's whole budget: this loop is also watching for
+            // sway exiting and for a window Xwayland lost. The error is dropped because a slice
+            // this short is missed by a compositor that is merely loaded.
             let _ = roundtrip_until(
                 &conn,
                 &mut queue,
@@ -1287,15 +1277,12 @@ fn bring_up_session(
 
 /// What a gesture has pressed and not yet put back.
 ///
-/// A press is flushed before the wait it may fail in, so the compositor has it and will act on it
-/// when it recovers. The gesture then unwinds through `?` — `glass_core::run_drag` and its
-/// siblings propagate without cleanup — and every step that would have released it is skipped, so
-/// a button or modifier stays down and the next tool call inherits it. Where the unbounded wait
-/// meant nothing ran again, something now does.
+/// A press is flushed before the wait it may fail in, so the compositor still acts on it, while
+/// the gesture unwinds through `?` past every step that would have released it — leaving a button
+/// or modifier down for the next tool call to inherit.
 ///
-/// Tracked per gesture rather than per settle: the settle that fails is usually not the one that
-/// pressed anything (a drag spends its time in `move_to`), and the release that matters is the one
-/// the gesture never reached.
+/// Per gesture, not per settle: the settle that fails is rarely the one that pressed anything (a
+/// drag spends its time in `move_to`).
 #[derive(Default)]
 struct Held {
     button: Option<u32>,
@@ -1304,8 +1291,8 @@ struct Held {
 }
 
 impl Held {
-    /// Put the seat back. Best effort: what failed is the compositor answering, so there is
-    /// nothing to wait for and nothing to do about a flush that fails too.
+    /// Put the seat back, best effort — what failed is the compositor answering, so there is
+    /// nothing to wait for.
     fn release(&mut self, s: &mut ActiveSession) {
         if self.button.is_none() && self.key.is_none() && !self.modifiers {
             return;
@@ -2262,8 +2249,8 @@ mod pure_tests {
         assert_eq!(answered.expect("the answer, not the expired budget"), 7);
     }
 
-    /// A state that answers nothing but the sync a roundtrip rides on — all a bounded roundtrip
-    /// needs, and constructible with no compositor.
+    /// A state carrying nothing but the sync's `Dispatch` impl, which is all the bound needs and
+    /// is constructible with no compositor.
     struct SyncOnly;
 
     impl Dispatch<wl_callback::WlCallback, SyncDone> for SyncOnly {
@@ -2319,8 +2306,8 @@ mod pure_tests {
         );
     }
 
-    /// The three ways a read ends, and only one of them is a fault. Kept apart from the loops
-    /// that act on them so the judgement can be checked without a compositor.
+    /// Kept apart from the loops that act on it so the judgement can be checked without a
+    /// compositor.
     #[test]
     fn only_a_read_that_lost_nothing_is_asked_again() {
         use wayland_client::backend::WaylandError;
@@ -2333,9 +2320,8 @@ mod pure_tests {
         );
     }
 
-    /// The other half of the roundtrip: nothing on a compositor-less CI leg proves the callback is
-    /// wired to the right queue, and a `Dispatch` impl that never fired would turn every request
-    /// into a five-second timeout — visible only where sway runs.
+    /// Nothing on a compositor-less CI leg proves the callback is wired to the right queue, and a
+    /// `Dispatch` impl that never fired would turn every request into a five-second timeout.
     #[test]
     fn a_roundtrip_returns_when_the_compositor_answers_the_sync() {
         let (ours, mut theirs) = UnixStream::pair().expect("socketpair");
@@ -2343,9 +2329,9 @@ mod pure_tests {
         let mut queue = conn.new_event_queue::<SyncOnly>();
 
         let answer = std::thread::spawn(move || {
-            // `wl_callback.done` for object 2 — the display is 1, and the sync's callback is the
-            // first object this connection creates. Written after a beat so it cannot arrive
-            // before the object it names exists.
+            // `wl_callback.done` for object 2: the display is 1 and the sync's callback is the
+            // first object this connection creates. After a beat, so it cannot precede that
+            // object's creation.
             std::thread::sleep(Duration::from_millis(50));
             let done: [u8; 12] = {
                 let mut m = [0u8; 12];
@@ -3448,9 +3434,8 @@ mod session_tests {
         assert_eq!(px[3], 255, "opaque");
     }
 
-    /// How long a suspended compositor stays suspended if nothing resumes it. The bracket
-    /// assertions cap both `CAPTURE_BUDGET` and `COMPOSITOR_SYNC_BUDGET` at 15s, so anything
-    /// bounded by either is over first.
+    /// How long a suspended compositor stays suspended if nothing resumes it. Both budget
+    /// brackets cap at 15s, so anything bounded by either is over first.
     const SUSPENSION: Duration = Duration::from_secs(30);
 
     /// SIGSTOPs a process until dropped: a compositor holding its connection open and answering
@@ -3556,9 +3541,9 @@ mod session_tests {
         );
     }
 
-    /// A gesture fails between a press and the settle after it — a window no test can hit on
-    /// purpose — but the guard that puts the seat back is a `Drop`, and that can be driven. The
-    /// compositor here is healthy: what is under test is the release, not the bound.
+    /// The window a gesture fails in — between a press and the settle after it — cannot be hit on
+    /// purpose, but the guard that puts the seat back is a `Drop`, which can be driven directly
+    /// against a healthy compositor.
     #[test]
     #[ignore = "starts a real compositor or X server; needs sway, Mesa, Xwayland or Xvfb"]
     fn a_gesture_dropped_after_a_press_releases_the_button() {
@@ -3579,21 +3564,20 @@ mod session_tests {
                 mask: 0,
                 held: Held::default(),
             };
-            // Placed first, as `run_drag` does: sway routes a button only to the surface its
-            // pointer is over, and it evaluates that on motion.
+            // Placed first, as `run_drag` does: sway routes a button to the surface its pointer
+            // is over, and re-evaluates that only on motion.
             sink.place(10, 10).expect("the placement");
             sink.button(true).expect("the press");
             // The sink drops here, as it does when `run_drag` propagates a failure.
         }
 
-        // `272 0` is BTN_LEFT released, so waiting for it is the assertion: a gesture that left
-        // the button down never logs it, and the harness fails the test rather than hanging.
+        // `272 0` is BTN_LEFT released, so the wait is the assertion — a gesture that left the
+        // button down never logs it, and the harness fails rather than hangs.
         s.wait_for_log(" 272 0");
     }
 
-    /// glass#402: every request ends in a sync the compositor answers, and waiting for one was
-    /// unbounded — so `glass_click` on a compositor that had gone quiet held the session lock the
-    /// capture, bounded in glass#383, had just stopped holding.
+    /// glass#402: waiting for the sync every request ends in was unbounded, so `glass_click` on a
+    /// quiet compositor held the session lock that glass#383 had just stopped holding.
     #[test]
     #[ignore = "starts a real compositor or X server; needs sway, Mesa, Xwayland or Xvfb"]
     fn input_gives_up_on_a_compositor_that_stops_answering() {
@@ -3615,9 +3599,8 @@ mod session_tests {
             elapsed < SUSPENSION * 2 / 3,
             "the input waited the compositor out rather than bounding it: {elapsed:?}"
         );
-        // The other end of the bracket: every healthy sync answers in microseconds, so a budget
-        // cut to nothing would leave the suite green while every click on a loaded compositor
-        // failed.
+        // The other end of the bracket: healthy syncs answer in microseconds, so a budget cut to
+        // nothing would leave the suite green.
         assert!(
             elapsed >= Duration::from_secs(2),
             "the sync budget is no longer generous enough for a compositor under load: \
@@ -3629,8 +3612,8 @@ mod session_tests {
         );
     }
 
-    /// The keyboard paths reach the compositor through their own settles, and a bound reverted at
-    /// one of them alone would leave `glass_type` or `glass_key` hanging with the rest green.
+    /// Each path settles through its own site, so a bound reverted at one alone would leave
+    /// `glass_type` or `glass_key` hanging with the rest green.
     #[test]
     #[ignore = "starts a real compositor or X server; needs sway, Mesa, Xwayland or Xvfb"]
     fn the_keyboard_paths_give_up_on_a_compositor_that_stops_answering() {

--- a/crates/glass-wayland/src/platform.rs
+++ b/crates/glass-wayland/src/platform.rs
@@ -634,6 +634,13 @@ const _: () = assert!(
 /// re-mapping — and one pass that waited out the whole launch would stop it looking.
 const COMPOSITOR_SERVICE_SLICE: Duration = Duration::from_millis(250);
 
+/// Short enough that a loop spending one per pass still gets on with its other work, long enough
+/// that a compositor merely busy answers inside it — a slice it misses is discarded, not reported.
+const _: () = assert!(
+    COMPOSITOR_SERVICE_SLICE.as_millis() >= 50 && COMPOSITOR_SERVICE_SLICE.as_millis() <= 1000,
+    "a servicing slice must not become a wait in its own right"
+);
+
 /// Set by the compositor's answer to `wl_display.sync`, which is what a roundtrip waits for.
 pub(crate) type SyncDone = Arc<std::sync::atomic::AtomicBool>;
 
@@ -701,6 +708,8 @@ where
     let stream = UnixStream::connect(socket)
         .map_err(|e| GlassError::Backend(format!("{who}: connect: {e}")))?;
     // The same socket, kept back from the thread: shutting this down is what wakes its poll.
+    // `Both`, not `Read`: a setup blocked writing to a compositor that has stopped reading is
+    // just as stuck, and only the write half ends that.
     let watchdog = stream
         .try_clone()
         .map_err(|e| GlassError::Backend(format!("{who}: connect: {e}")))?;
@@ -722,7 +731,15 @@ where
             let _ = setup.join();
             outcome.map_err(|e| GlassError::Backend(format!("{who}: {e}")))
         }
-        Err(_) => {
+        // The sender went with the thread, so the thread is gone: a panic, not a slow compositor.
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            let panicked = setup.join().is_err();
+            Err(GlassError::Backend(format!(
+                "{who}: the wayland setup ended without an answer{}",
+                if panicked { " (it panicked)" } else { "" }
+            )))
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
             let _ = watchdog.shutdown(std::net::Shutdown::Both);
             // Joined, so the thread is gone before its socket is: a setup still running would
             // otherwise outlive the call that started it.
@@ -1147,12 +1164,16 @@ fn bring_up_session(
     };
 
     let (conn, mut queue, mut state, manager, output, pointer, keyboard, mut ipc, output_size) =
-        // What is left of the launch the caller asked for, not a budget of this function's own:
-        // `timeout_ms` is the knob for a slow machine, and a fixed one here would ignore it.
+        // What is left of the launch the caller asked for — `timeout_ms` is the knob for a slow
+        // machine — but never less than one sync's worth: the socket wait above shares this
+        // deadline, so a compositor slow to create its socket would otherwise leave the setup
+        // that follows a few milliseconds and fail a launch that was merely late.
         match open_session(
             &socket,
             runtime_dir.path(),
-            deadline.saturating_duration_since(Instant::now()),
+            deadline
+                .saturating_duration_since(Instant::now())
+                .max(COMPOSITOR_SYNC_BUDGET),
         ) {
             Ok(v) => v,
             Err(e) => {
@@ -1264,20 +1285,45 @@ fn bring_up_session(
     Ok((session, geometry))
 }
 
-/// Emit `undo` and get it on the wire if the settle it follows failed.
+/// What a gesture has pressed and not yet put back.
 ///
-/// A press is flushed before the wait it fails in, so the compositor has it and will act on it
-/// when it recovers. Returning the error without the counterpart leaves a button or a modifier
-/// latched, and the next tool call — which now runs, where the unbounded wait meant nothing ran
-/// again — inherits a seat holding a key down.
-fn undo_if_unsettled(s: &ActiveSession, settled: Result<()>, undo: impl FnOnce()) -> Result<()> {
-    if settled.is_err() {
-        undo();
-        // Best effort: what just failed is the compositor answering, so there is nothing to wait
-        // for and nothing to do about a flush that fails too.
+/// A press is flushed before the wait it may fail in, so the compositor has it and will act on it
+/// when it recovers. The gesture then unwinds through `?` — `glass_core::run_drag` and its
+/// siblings propagate without cleanup — and every step that would have released it is skipped, so
+/// a button or modifier stays down and the next tool call inherits it. Where the unbounded wait
+/// meant nothing ran again, something now does.
+///
+/// Tracked per gesture rather than per settle: the settle that fails is usually not the one that
+/// pressed anything (a drag spends its time in `move_to`), and the release that matters is the one
+/// the gesture never reached.
+#[derive(Default)]
+struct Held {
+    button: Option<u32>,
+    key: Option<u32>,
+    modifiers: bool,
+}
+
+impl Held {
+    /// Put the seat back. Best effort: what failed is the compositor answering, so there is
+    /// nothing to wait for and nothing to do about a flush that fails too.
+    fn release(&mut self, s: &mut ActiveSession) {
+        if self.button.is_none() && self.key.is_none() && !self.modifiers {
+            return;
+        }
+        s.time = s.time.wrapping_add(1);
+        let t = s.time;
+        if let Some(b) = self.button.take() {
+            s.pointer.button(t, b, ButtonState::Released);
+            s.pointer.frame();
+        }
+        if let Some(kc) = self.key.take() {
+            s.keyboard.key(t, kc, 0);
+        }
+        if std::mem::take(&mut self.modifiers) {
+            s.keyboard.modifiers(0, 0, 0, 0);
+        }
         let _ = s.conn.flush();
     }
-    settled
 }
 
 /// Ask the compositor to answer for what this session has just sent, bounded.
@@ -1304,15 +1350,15 @@ fn upload_keymap(s: &mut ActiveSession, kb: &ZwpVirtualKeyboardV1, keymap: &str)
 /// press/release individually, like the chord sink. A heavy client (e.g. a browser) ignores
 /// taps that are merely queued and flushed once at the end.
 fn tap(s: &mut ActiveSession, kb: &ZwpVirtualKeyboardV1, kc: u32) -> Result<()> {
+    let mut held = Held::default();
     for state in [1u32, 0] {
         s.time = s.time.wrapping_add(1);
         kb.key(s.time, kc, state);
-        let settled = sync_session(s, "key tap");
-        undo_if_unsettled(s, settled, || {
-            if state == 1 {
-                kb.key(s.time, kc, 0);
-            }
-        })?;
+        held.key = (state == 1).then_some(kc);
+        if let Err(e) = sync_session(s, "key tap") {
+            held.release(s);
+            return Err(e);
+        }
         std::thread::sleep(Duration::from_millis(8));
     }
     Ok(())
@@ -1370,6 +1416,15 @@ struct WaylandDragSink<'a> {
     oy: i32,
     b: u32,
     mask: u32,
+    held: Held,
+}
+
+/// A drag that ends early — `run_drag` propagates a failed settle from any of its waypoints —
+/// otherwise leaves the button down.
+impl Drop for WaylandDragSink<'_> {
+    fn drop(&mut self) {
+        self.held.release(self.s);
+    }
 }
 
 impl WaylandDragSink<'_> {
@@ -1425,13 +1480,8 @@ impl glass_core::DragSink for WaylandDragSink<'_> {
         };
         vp.button(t, self.b, state);
         vp.frame();
-        let settled = self.settle();
-        undo_if_unsettled(self.s, settled, || {
-            if down {
-                vp.button(t, self.b, ButtonState::Released);
-                vp.frame();
-            }
-        })
+        self.held.button = down.then_some(self.b);
+        self.settle()
     }
     fn modifiers(&mut self, down: bool) -> Result<()> {
         if self.mask == 0 {
@@ -1444,14 +1494,10 @@ impl glass_core::DragSink for WaylandDragSink<'_> {
         } else {
             kb.modifiers(0, 0, 0, 0);
         }
+        self.held.modifiers = down;
         // Self-commit so the modifier change reaches the compositor before the
         // press/release that follows it (matches the X11 sink's flush-per-call).
-        let settled = self.settle();
-        undo_if_unsettled(self.s, settled, || {
-            if down {
-                kb.modifiers(0, 0, 0, 0);
-            }
-        })
+        self.settle()
     }
 }
 
@@ -1462,6 +1508,14 @@ struct WaylandChordSink<'a> {
     s: &'a mut ActiveSession,
     mask: u32,
     keysym: u32,
+    held: Held,
+}
+
+/// A chord that ends early otherwise leaves its key or its modifier down.
+impl Drop for WaylandChordSink<'_> {
+    fn drop(&mut self) {
+        self.held.release(self.s);
+    }
 }
 
 impl WaylandChordSink<'_> {
@@ -1488,24 +1542,16 @@ impl glass_core::ChordSink for WaylandChordSink<'_> {
         } else if self.mask != 0 {
             kb.modifiers(0, 0, 0, 0);
         }
-        let settled = self.settle();
-        undo_if_unsettled(self.s, settled, || {
-            if down && self.mask != 0 {
-                kb.modifiers(0, 0, 0, 0);
-            }
-        })
+        self.held.modifiers = down && self.mask != 0;
+        self.settle()
     }
     fn key(&mut self, down: bool) -> Result<()> {
         let kb = self.s.keyboard.clone();
         self.s.time = self.s.time.wrapping_add(1);
         let t = self.s.time;
         kb.key(t, 1, u32::from(down)); // keycode 1 = the chord's key; 1=pressed, 0=released
-        let settled = self.settle();
-        undo_if_unsettled(self.s, settled, || {
-            if down {
-                kb.key(t, 1, 0);
-            }
-        })
+        self.held.key = down.then_some(1);
+        self.settle()
     }
 }
 
@@ -1525,6 +1571,15 @@ struct WaylandScrollSink<'a> {
     dx: i32,
     dy: i32,
     mask: u32,
+    held: Held,
+}
+
+/// A scroll that ends early — `wheel` settles three times after the modifier goes down —
+/// otherwise leaves that modifier down.
+impl Drop for WaylandScrollSink<'_> {
+    fn drop(&mut self) {
+        self.held.release(self.s);
+    }
 }
 
 impl WaylandScrollSink<'_> {
@@ -1556,12 +1611,8 @@ impl glass_core::ScrollSink for WaylandScrollSink<'_> {
         } else {
             kb.modifiers(0, 0, 0, 0);
         }
-        let settled = self.settle();
-        undo_if_unsettled(self.s, settled, || {
-            if down {
-                kb.modifiers(0, 0, 0, 0);
-            }
-        })
+        self.held.modifiers = down;
+        self.settle()
     }
     fn wheel(&mut self) -> Result<()> {
         let vp = self.s.pointer.clone();
@@ -1809,22 +1860,29 @@ impl Platform for WaylandPlatform {
                     upload_keymap(session, &kb, &crate::keyboard::build_keymap(&[]))?;
                     kb.modifiers(mask, 0, 0, 0);
                 }
+                let mut held = Held {
+                    modifiers: mask != 0,
+                    ..Held::default()
+                };
                 let b = evdev_button(button);
-                for _ in 0..count.max(1) {
-                    vp.button(t, b, ButtonState::Pressed);
-                    vp.frame();
-                    let settled = settle(session);
-                    undo_if_unsettled(session, settled, || {
+                let clicks = |session: &mut ActiveSession, held: &mut Held| -> Result<()> {
+                    for _ in 0..count.max(1) {
+                        vp.button(t, b, ButtonState::Pressed);
+                        vp.frame();
+                        held.button = Some(b);
+                        settle(session)?;
                         vp.button(t, b, ButtonState::Released);
                         vp.frame();
-                    })?;
-                    vp.button(t, b, ButtonState::Released);
-                    vp.frame();
-                    settle(session)?;
-                }
-                if mask != 0 {
-                    kb.modifiers(0, 0, 0, 0);
-                }
+                        held.button = None;
+                        settle(session)?;
+                    }
+                    Ok(())
+                };
+                let outcome = clicks(session, &mut held);
+                // The same release on both paths: what ends the modifier on a click that worked is
+                // what has to end it on one that did not.
+                held.release(session);
+                outcome?;
             }
             PointerEvent::Drag {
                 from_x,
@@ -1845,6 +1903,7 @@ impl Platform for WaylandPlatform {
                     oy,
                     b: evdev_button(button),
                     mask: modifier_mask(modifiers),
+                    held: Held::default(),
                 };
                 glass_core::run_drag(&mut sink, &gesture)?;
             }
@@ -1868,6 +1927,7 @@ impl Platform for WaylandPlatform {
                     dx,
                     dy,
                     mask: modifier_mask(modifiers),
+                    held: Held::default(),
                 };
                 glass_core::run_scroll(&mut sink, !modifiers.is_empty())?;
             }
@@ -1913,6 +1973,7 @@ impl Platform for WaylandPlatform {
                     s: &mut *session,
                     mask: modifier_mask(&mods),
                     keysym,
+                    held: Held::default(),
                 };
                 glass_core::run_chord(&mut sink)?;
             }
@@ -2298,12 +2359,18 @@ mod pure_tests {
         });
 
         let started = Instant::now();
-        let outcome = roundtrip_until(
-            &conn,
-            &mut queue,
-            &mut SyncOnly,
-            Instant::now() + PROMPT_WAIT_BUDGET,
-            "a caller",
+        let outcome = on_a_thread(
+            PROMPT_WAIT_BUDGET * 20,
+            "the roundtrip never came back from an answered sync",
+            move || {
+                roundtrip_until(
+                    &conn,
+                    &mut queue,
+                    &mut SyncOnly,
+                    Instant::now() + PROMPT_WAIT_BUDGET,
+                    "a caller",
+                )
+            },
         );
         let elapsed = started.elapsed();
         drop(answer.join().expect("the answering thread"));
@@ -3489,6 +3556,41 @@ mod session_tests {
         );
     }
 
+    /// A gesture fails between a press and the settle after it — a window no test can hit on
+    /// purpose — but the guard that puts the seat back is a `Drop`, and that can be driven. The
+    /// compositor here is healthy: what is under test is the release, not the bound.
+    #[test]
+    #[ignore = "starts a real compositor or X server; needs sway, Mesa, Xwayland or Xvfb"]
+    fn a_gesture_dropped_after_a_press_releases_the_button() {
+        use glass_core::DragSink as _;
+
+        let mut s = Launch::new().start_mapped();
+        {
+            let session = s.platform().active.as_mut().expect("a started session");
+            let (w, h) = session.output_size;
+            let (ox, oy) = (session.active_rect.x, session.active_rect.y);
+            let mut sink = WaylandDragSink {
+                s: session,
+                w,
+                h,
+                ox,
+                oy,
+                b: evdev_button(glass_core::MouseButton::Left),
+                mask: 0,
+                held: Held::default(),
+            };
+            // Placed first, as `run_drag` does: sway routes a button only to the surface its
+            // pointer is over, and it evaluates that on motion.
+            sink.place(10, 10).expect("the placement");
+            sink.button(true).expect("the press");
+            // The sink drops here, as it does when `run_drag` propagates a failure.
+        }
+
+        // `272 0` is BTN_LEFT released, so waiting for it is the assertion: a gesture that left
+        // the button down never logs it, and the harness fails the test rather than hanging.
+        s.wait_for_log(" 272 0");
+    }
+
     /// glass#402: every request ends in a sync the compositor answers, and waiting for one was
     /// unbounded — so `glass_click` on a compositor that had gone quiet held the session lock the
     /// capture, bounded in glass#383, had just stopped holding.
@@ -3524,6 +3626,85 @@ mod session_tests {
         assert!(
             err.to_string().contains("input settle"),
             "the failure should name the request that made it: {err}"
+        );
+    }
+
+    /// The keyboard paths reach the compositor through their own settles, and a bound reverted at
+    /// one of them alone would leave `glass_type` or `glass_key` hanging with the rest green.
+    #[test]
+    #[ignore = "starts a real compositor or X server; needs sway, Mesa, Xwayland or Xvfb"]
+    fn the_keyboard_paths_give_up_on_a_compositor_that_stops_answering() {
+        let mut s = Launch::new().start_mapped();
+        let pid = s
+            .platform()
+            .session_compositor_pid()
+            .expect("a started session has a compositor");
+        let _suspended = Suspended::process(pid);
+
+        let started = Instant::now();
+        for key in [KeyEvent::Text("a".into()), KeyEvent::Chord("ctrl+a".into())] {
+            let err = s
+                .platform()
+                .send_key(&key)
+                .expect_err("a suspended compositor cannot answer");
+            // Both paths upload a keymap before they press anything, so that is the settle they
+            // fail in.
+            assert!(
+                err.to_string().contains("keymap upload"),
+                "the failure should name the request that made it: {err}"
+            );
+        }
+        assert!(
+            started.elapsed() < SUSPENSION * 2 / 3,
+            "a keyboard path waited the compositor out: {:?}",
+            started.elapsed()
+        );
+    }
+
+    /// As above for the pointer gestures, which settle through their own sinks.
+    #[test]
+    #[ignore = "starts a real compositor or X server; needs sway, Mesa, Xwayland or Xvfb"]
+    fn the_pointer_gestures_give_up_on_a_compositor_that_stops_answering() {
+        let mut s = Launch::new().start_mapped();
+        let pid = s
+            .platform()
+            .session_compositor_pid()
+            .expect("a started session has a compositor");
+        let _suspended = Suspended::process(pid);
+
+        let started = Instant::now();
+        let gestures = [
+            PointerEvent::Drag {
+                from_x: 10,
+                from_y: 10,
+                to_x: 40,
+                to_y: 40,
+                button: glass_core::MouseButton::Left,
+                modifiers: Vec::new(),
+                duration_ms: 50,
+            },
+            PointerEvent::Scroll {
+                x: 10,
+                y: 10,
+                dx: 0,
+                dy: -1,
+                modifiers: Vec::new(),
+            },
+        ];
+        for gesture in gestures {
+            let err = s
+                .platform()
+                .send_pointer(&gesture)
+                .expect_err("a suspended compositor cannot answer");
+            assert!(
+                err.to_string().contains("input settle"),
+                "the failure should name the request that made it: {err}"
+            );
+        }
+        assert!(
+            started.elapsed() < SUSPENSION * 2 / 3,
+            "a pointer gesture waited the compositor out: {:?}",
+            started.elapsed()
         );
     }
 


### PR DESCRIPTION
Closes #402.

`EventQueue::roundtrip` loops `blocking_dispatch` until the compositor answers a `wl_display.sync`, with no timeout. Every request on this crate's connections ends in one, so a compositor that went quiet held `glass_click`, `glass_type`, `glass_scroll`, `glass_list_windows`, a launch and both clipboard directions — each holding the session lock that #383 had just stopped the capture holding.

`roundtrip_until` asks the same question through the `wait_for` the capture already uses, so both share one bound. Callers name themselves, since every request ends in the same sync and nothing else tells one failure from another.

## What the panel added

- **Opening a connection was the real hang.** `registry_queue_init` ends in an unbounded `Connection::roundtrip` and runs before every bounded call, so `glass_clipboard_get` — which dials a fresh socket each time — still waited forever. Confirmed against a stopped compositor: it returned only when the test watchdog resumed it 30s later. Upstream has no bounded form and `GlobalList` cannot be built here, so the setup runs on its own thread and the socket is shut down under it when the budget expires.
- **A failed settle left the seat latched.** The press is flushed before the wait, so the compositor still acts on it while the gesture unwinds past every step that would have released it — a held button or modifier the next call inherits, where the hang meant nothing ran next. Each sink now releases what it holds on `Drop`, which is where a gesture that propagated a failure ends. The first attempt at this was step-scoped and missed the common case: a drag spends its time in `move_to`, not on the press.
- `WouldBlock` and `EINTR` in the clipboard owner loop are retryable, not fatal; either dropped the selection.
- Budgets that compose: the launch's `timeout_ms` governs its setup with a floor under it, the serving thread's setup is strictly shorter than the readiness wait its caller gives it, and a paste spends one deadline across connect, syncs and read.

## Verification

`cargo test --workspace` (82 result lines, no failures), `cargo test -p glass-wayland -- --include-ignored` (224), clippy and `cargo fmt --check` clean.

Every new test was ablated: reverting the connection setup makes the paste test hang to its harness bound; deleting a sink's `Drop` leaves the button down and the fixture never logs the release; ablating the callback's flag store turns the sync into a timeout; reverting `sync_session` fails the live input test at 30s via the watchdog.

## Known limit

The bound is per request, not per tool call. A compositor answering every sync just inside 5s can still make a long `glass_type` or `glass_drag` take the sum — bounded, but large. The CHANGELOG says so; a per-call deadline would mean threading one through the `Platform` trait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)