### PR TITLE
fix(a11y): name what the element holds when a write does not take

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,13 @@ internal refactors, CI, or test-only changes.
 
 ### Changed
 - `glass_set_value`'s "did not take" error now names both what you asked for and what the element
-  holds, on every backend. The two readings need telling apart: a field that reformats or
-  autocapitalizes what it is given took every keystroke and holds the text in a form the request
-  cannot express, while a value that did not change never received the write. On the iOS Simulator
-  a text field applies sentence autocapitalization to a value typed into a field it considers
-  empty, so a lowercase value can come back capitalized — intermittently, since it turns on whether
-  the field had finished emptying when the first key arrived — and that read as an unexplained "did
+  holds. Three outcomes used to look alike: the element transformed the write and holds it in
+  another form, so writing again changes nothing; it holds part of what you asked for, so a
+  keystroke was dropped and writing again is the fix; or it holds what it held before, so the write
+  never arrived. On the iOS Simulator this is routine — iOS applies sentence autocapitalization to
+  the first character of a field it considers empty, and a write clears the field before it types,
+  so a lowercase value can come back capitalized. It happens intermittently, depending on whether
+  the field had finished emptying when the first key arrived, and it read as an unexplained "did
   not take" before.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ internal refactors, CI, or test-only changes.
 
 ## [Unreleased]
 
+### Changed
+- `glass_set_value`'s "did not take" error now names both what you asked for and what the element
+  holds, on every backend. The two readings need telling apart: a field that reformats or
+  autocapitalizes what it is given took every keystroke and holds the text in a form the request
+  cannot express, while a value that did not change never received the write. On the iOS Simulator
+  a text field applies sentence autocapitalization to a value typed into a field it considers
+  empty, so a lowercase value can come back capitalized — intermittently, since it turns on whether
+  the field had finished emptying when the first key arrived — and that read as an unexplained "did
+  not take" before.
+
 ### Fixed
 - A helper binary that is installed but cannot be run is now reported as exactly that, instead of
   as missing. glass resolves several external tools — `Xvfb`, `sway`, `bwrap`, `dbus-daemon`,

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -634,8 +634,8 @@ async fn set_toggle(
             return Ok(());
         }
     }
-    // Report the state the last poll read, not `!target_on` derived from the request: the two agree
-    // only while the loop's sole exit is this equality, and nothing holds that.
+    // Report the state the last poll read, not `!target_on` derived from the request — the two
+    // agree only while this equality is the loop's sole exit, and nothing holds that.
     Err(GlassError::value_not_applied(
         id,
         requested,
@@ -643,8 +643,8 @@ async fn set_toggle(
     ))
 }
 
-/// How a boolean control's state is named in a verdict the caller reads. `set_value` accepts
-/// `true`/`on`/`1` alike, so the request and the read-back would otherwise be worded differently.
+/// How a boolean control's state is named in a verdict the caller reads — one spelling, where
+/// `set_value` accepts `true`/`on`/`1` for the request alike.
 fn toggle_state_label(on: bool) -> &'static str {
     if on { "on" } else { "off" }
 }
@@ -816,9 +816,8 @@ mod toggle_label_tests {
 
     #[test]
     fn a_control_that_stayed_off_is_reported_as_off() {
-        // The direction is what the verdict rests on: inverted, a `set_value("true")` that failed
-        // would report the control as already on — the state the caller asked for, alongside "did
-        // not take".
+        // Inverted, a failed `set_value("true")` reports the control as already on — the state the
+        // caller asked for, alongside "did not take".
         assert_eq!(toggle_state_label(false), "off");
         assert_eq!(toggle_state_label(true), "on");
     }

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -594,7 +594,8 @@ const TOGGLE_VERIFY_POLLS: usize = 6;
 /// See [`TOGGLE_VERIFY_POLLS`].
 const TOGGLE_VERIFY_INTERVAL: Duration = Duration::from_millis(120);
 
-/// Set a boolean widget (switch/checkbox/toggle/radio) to `target_on`. Idempotent:
+/// Set a boolean widget (switch/checkbox/toggle/radio) to `target_on`, as the caller spelled it in
+/// `requested`. Idempotent:
 /// only invokes the toggle action when the boolean state differs, then confirms the
 /// state actually changed (the toolkit applies the action on its next loop) — so a
 /// no-op activation (e.g. a radio can't be *un*-selected by clicking it) is reported
@@ -624,18 +625,28 @@ async fn set_toggle(
         return Err(GlassError::AxElementNotEditable(id));
     }
     // Poll until the toolkit applies it; a no-op activation never converges.
+    let mut last_on = None;
     for _ in 0..TOGGLE_VERIFY_POLLS {
         tokio::time::sleep(TOGGLE_VERIFY_INTERVAL).await;
-        if node.get_state().await.map_err(bus_err)?.contains(flag) == target_on {
+        let on = node.get_state().await.map_err(bus_err)?.contains(flag);
+        last_on = Some(on);
+        if on == target_on {
             return Ok(());
         }
     }
-    // The last poll read the state, so the control it is still in is observed, not inferred.
+    // Report the state the last poll read, not `!target_on` derived from the request: the two agree
+    // only while the loop's sole exit is this equality, and nothing holds that.
     Err(GlassError::value_not_applied(
         id,
         requested,
-        Some(if target_on { "off" } else { "on" }),
+        last_on.map(toggle_state_label),
     ))
+}
+
+/// How a boolean control's state is named in a verdict the caller reads. `set_value` accepts
+/// `true`/`on`/`1` alike, so the request and the read-back would otherwise be worded differently.
+fn toggle_state_label(on: bool) -> &'static str {
+    if on { "on" } else { "off" }
 }
 
 /// The one AT-SPI action whose meaning is "flip this control's boolean state" — and so the
@@ -797,6 +808,20 @@ async fn read_value(
 
 fn nonempty(s: String) -> Option<String> {
     (!s.is_empty()).then_some(s)
+}
+
+#[cfg(test)]
+mod toggle_label_tests {
+    use super::toggle_state_label;
+
+    #[test]
+    fn a_control_that_stayed_off_is_reported_as_off() {
+        // The direction is what the verdict rests on: inverted, a `set_value("true")` that failed
+        // would report the control as already on — the state the caller asked for, alongside "did
+        // not take".
+        assert_eq!(toggle_state_label(false), "off");
+        assert_eq!(toggle_state_label(true), "on");
+    }
 }
 
 #[cfg(test)]

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -256,7 +256,7 @@ async fn set_value_async(ctx: &AxContext, target: &AxTarget, text: &str) -> Resu
         if matches!(role, CheckBox | ToggleButton | RadioButton)
             && let Some(on) = parse_bool(text)
         {
-            return set_toggle(&conn, &node, role, on, target.id.0).await;
+            return set_toggle(&conn, &node, role, on, text, target.id.0).await;
         }
     }
 
@@ -604,6 +604,7 @@ async fn set_toggle(
     node: &AccessibleProxy<'_>,
     role: glass_core::AxRole,
     target_on: bool,
+    requested: &str,
     id: u32,
 ) -> Result<()> {
     let flag = toggle_state_flag(role);
@@ -629,7 +630,12 @@ async fn set_toggle(
             return Ok(());
         }
     }
-    Err(GlassError::AxValueNotApplied(id))
+    // The last poll read the state, so the control it is still in is observed, not inferred.
+    Err(GlassError::value_not_applied(
+        id,
+        requested,
+        Some(if target_on { "off" } else { "on" }),
+    ))
 }
 
 /// The one AT-SPI action whose meaning is "flip this control's boolean state" — and so the

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -149,7 +149,11 @@ impl Accessibility for MacosA11y {
                 return Ok(());
             }
             if Instant::now() >= deadline {
-                return Err(GlassError::AxValueNotApplied(target.id.0));
+                return Err(GlassError::value_not_applied(
+                    target.id.0,
+                    text,
+                    after.as_deref(),
+                ));
             }
             std::thread::sleep(Duration::from_millis(SET_VALUE_POLL_MS));
         }

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -449,11 +449,16 @@ fn run_set_value(ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
     // a failed post-read nor a failed pre-read can masquerade as a successful change.
     let deadline = Instant::now() + Duration::from_millis(SET_VALUE_VERIFY_MS);
     loop {
-        if read_back_confirms(pat.get_value().ok().as_deref(), before.as_deref(), text) {
+        let after = pat.get_value().ok();
+        if read_back_confirms(after.as_deref(), before.as_deref(), text) {
             return Ok(());
         }
         if Instant::now() >= deadline {
-            return Err(GlassError::AxValueNotApplied(target.id.0));
+            return Err(GlassError::value_not_applied(
+                target.id.0,
+                text,
+                after.as_deref(),
+            ));
         }
         std::thread::sleep(Duration::from_millis(VERIFY_POLL_MS));
     }

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -404,10 +404,12 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
     if landed {
         Ok(())
     } else {
+        // `Some("")`, not `None`: this mapper drops an empty value, so an empty field arrives here
+        // as `None` — the same `None` the verdict reserves for a reading nobody obtained.
         Err(GlassError::value_not_applied(
             target.id.0,
             text,
-            node.value.as_deref(),
+            Some(node.value.as_deref().unwrap_or("")),
         ))
     }
 }
@@ -426,6 +428,10 @@ fn read_back_failed(target: &AxTarget, e: &GlassError) -> GlassError {
 /// frame or two later — a Compose recompose, a debounced handler — which the on-device service
 /// reader polls two whole seconds for.
 const VERIFY_ATTEMPTS: usize = 3;
+const _: () = assert!(
+    VERIFY_ATTEMPTS > 0,
+    "set_value reports the last read-back, so there must be one"
+);
 
 /// How long to let the toolkit commit typed text before reading it back. Generous relative to a
 /// keystroke and small next to the `uiautomator dump` that follows it.
@@ -716,8 +722,8 @@ impl Accessibility for AndroidA11y {
                 break;
             }
         }
-        // `VERIFY_ATTEMPTS` is non-zero, so the loop always reached a verdict; the fallback exists
-        // only to avoid an unwrap and cannot name a read-back nobody took.
+        // The const assert on `VERIFY_ATTEMPTS` is what makes `last` always set; the fallback only
+        // avoids an unwrap, and names no read-back because none was taken.
         Err(last.unwrap_or_else(|| GlassError::value_not_applied(target.id.0, text, None)))
     }
 }
@@ -1986,6 +1992,16 @@ mod tests {
     }
 
     #[test]
+    fn an_empty_field_reports_an_empty_read_back_not_a_missing_one() {
+        // `axmap` drops an empty value, so the node arrives holding `None` — which the verdict
+        // reserves for a reading nobody took. A write that cleared the field and lost its text must
+        // say the field is empty, not that it could not be read.
+        let after = tree_holding(None);
+        let t = target(0, Some("Search"), Some(BOUNDS));
+        assert_not_applied(verify_write(&after, &t, "world"), 0, "world", Some(""));
+    }
+
+    #[test]
     fn a_partly_typed_write_is_not_a_successful_write() {
         // The reason the rule is an exact match; `typed_text_landed` carries the argument.
         let after = tree_holding(Some("worl"));
@@ -2426,6 +2442,63 @@ mod tests {
         assert!(
             matches!(&err, GlassError::AxValueNotApplied { id: 1, requested, observed }
                 if requested == "world" && observed.as_deref() == Some("hello")),
+            "{err}"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn the_verdict_names_the_last_read_back_not_the_first() {
+        // The read-back retries because a field can commit a frame or two late, so the attempts can
+        // disagree: a first read caught mid-write and a second holding what the field settled on.
+        // Reporting the first would tell the caller the write never arrived when it arrived
+        // transformed — the misdiagnosis the two values exist to prevent.
+        use super::AndroidA11y;
+        use crate::adb::{Answer, FakeAdb};
+        use glass_core::Accessibility;
+
+        // Three reads, in order: the pre-write locate, then the two verify attempts that disagree.
+        let locate = Answer::says(one_field_holding("old"));
+        let mid = Answer::says(one_field_holding("hel"));
+        let settled = Answer::says(one_field_holding("Hello"));
+        let fake = FakeAdb::scripted(&[
+            ("*shell cat*", vec![&locate, &mid, &settled]),
+            ("*", vec![&Answer::Silent]),
+        ]);
+
+        let mut reader = AndroidA11y::for_adb(fake.adb().clone());
+        let ctx = AxContext {
+            pids: vec![],
+            window: WindowGeometry {
+                x: 0,
+                y: 0,
+                width: 1080,
+                height: 2400,
+            },
+            window_handle: None,
+            a11y_bus_addr: None,
+            limits: WalkLimits::DEFAULT,
+            deadline: AxDeadline::from_millis(30_000),
+        };
+        let field = AxTarget {
+            id: AxNodeId(1),
+            role: AxRole::TextField,
+            name: Some("Search".into()),
+            bounds: Some(AxRect {
+                x: 100,
+                y: 200,
+                width: 400,
+                height: 100,
+            }),
+            value: None,
+        };
+
+        let err = reader
+            .set_value(&ctx, &field, "hello")
+            .expect_err("neither read holds the requested text");
+        assert!(
+            matches!(&err, GlassError::AxValueNotApplied { observed, .. }
+                if observed.as_deref() == Some("Hello")),
             "{err}"
         );
     }

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -404,7 +404,11 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
     if landed {
         Ok(())
     } else {
-        Err(GlassError::AxValueNotApplied(target.id.0))
+        Err(GlassError::value_not_applied(
+            target.id.0,
+            text,
+            node.value.as_deref(),
+        ))
     }
 }
 
@@ -705,14 +709,16 @@ impl Accessibility for AndroidA11y {
                 Ok(()) => return Ok(()),
                 // Only a not-applied verdict can change on a later read: drift and truncation are
                 // structural, and re-dumping for them costs seconds to reach the same answer.
-                Err(e @ GlassError::AxValueNotApplied(_)) => last = Some(e),
+                Err(e @ GlassError::AxValueNotApplied { .. }) => last = Some(e),
                 Err(e) => return Err(e),
             }
             if Instant::now() >= phase_ends {
                 break;
             }
         }
-        Err(last.unwrap_or(GlassError::AxValueNotApplied(target.id.0)))
+        // `VERIFY_ATTEMPTS` is non-zero, so the loop always reached a verdict; the fallback exists
+        // only to avoid an unwrap and cannot name a read-back nobody took.
+        Err(last.unwrap_or_else(|| GlassError::value_not_applied(target.id.0, text, None)))
     }
 }
 
@@ -1942,6 +1948,24 @@ mod tests {
         assert!(verify_write(&after, &t, "").is_ok());
     }
 
+    /// Pin the whole verdict, not the variant: what the caller does next comes from the two values
+    /// it names, and a field that transformed the text is told apart from one that never received
+    /// it only by reading them (glass#363). Twin of the helper in `glass-ios/src/a11y.rs`.
+    #[track_caller]
+    fn assert_not_applied(outcome: Result<()>, id: u32, requested: &str, observed: Option<&str>) {
+        match outcome {
+            Err(GlassError::AxValueNotApplied {
+                id: got_id,
+                requested: req,
+                observed: obs,
+            }) => assert_eq!(
+                (got_id, req.as_str(), obs.as_deref()),
+                (id, requested, observed)
+            ),
+            other => panic!("expected a not-applied verdict, got {other:?}"),
+        }
+    }
+
     #[test]
     fn a_cleared_field_reporting_its_hint_reads_as_not_applied() {
         // The cost of judging a clear by "reads back empty", pinned as a decision: this device does
@@ -1950,10 +1974,7 @@ mod tests {
         // takes focus, which is the false success this check exists to prevent.
         let after = tree_holding(Some("Search settings"));
         let t = target(0, Some("Search"), Some(BOUNDS));
-        assert!(matches!(
-            verify_write(&after, &t, ""),
-            Err(GlassError::AxValueNotApplied(0))
-        ));
+        assert_not_applied(verify_write(&after, &t, ""), 0, "", Some("Search settings"));
     }
 
     #[test]
@@ -1961,10 +1982,7 @@ mod tests {
         // The case `verify_write`'s doc is about: the field still holds the old text.
         let after = tree_holding(Some("hello"));
         let t = target(0, Some("Search"), Some(BOUNDS));
-        assert!(matches!(
-            verify_write(&after, &t, "world"),
-            Err(GlassError::AxValueNotApplied(0))
-        ));
+        assert_not_applied(verify_write(&after, &t, "world"), 0, "world", Some("hello"));
     }
 
     #[test]
@@ -1972,10 +1990,7 @@ mod tests {
         // The reason the rule is an exact match; `typed_text_landed` carries the argument.
         let after = tree_holding(Some("worl"));
         let t = target(0, Some("Search"), Some(BOUNDS));
-        assert!(matches!(
-            verify_write(&after, &t, "world"),
-            Err(GlassError::AxValueNotApplied(0))
-        ));
+        assert_not_applied(verify_write(&after, &t, "world"), 0, "world", Some("worl"));
     }
 
     #[test]
@@ -1985,10 +2000,12 @@ mod tests {
         // tree and see the value; a false success would have it asserting against the wrong text.
         let after = tree_holding(Some("(123) 456-7890"));
         let t = target(0, Some("Search"), Some(BOUNDS));
-        assert!(matches!(
+        assert_not_applied(
             verify_write(&after, &t, "1234567890"),
-            Err(GlassError::AxValueNotApplied(0))
-        ));
+            0,
+            "1234567890",
+            Some("(123) 456-7890"),
+        );
     }
 
     #[test]
@@ -2006,10 +2023,7 @@ mod tests {
         // Re-finding must not weaken the value check: the field is found, and holds the wrong text.
         let after = under_a_container(tree_holding(Some("worl")));
         let t = target(0, Some("Search"), Some(BOUNDS));
-        assert!(matches!(
-            verify_write(&after, &t, "world"),
-            Err(GlassError::AxValueNotApplied(0))
-        ));
+        assert_not_applied(verify_write(&after, &t, "world"), 0, "world", Some("worl"));
     }
 
     #[test]
@@ -2409,7 +2423,11 @@ mod tests {
         let err = reader
             .set_value(&ctx, &field, "world")
             .expect_err("a field still holding the old text has not taken the write");
-        assert!(matches!(err, GlassError::AxValueNotApplied(1)), "{err}");
+        assert!(
+            matches!(&err, GlassError::AxValueNotApplied { id: 1, requested, observed }
+                if requested == "world" && observed.as_deref() == Some("hello")),
+            "{err}"
+        );
     }
 
     #[test]

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -404,8 +404,8 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
     if landed {
         Ok(())
     } else {
-        // `Some("")`, not `None`: this mapper drops an empty value, so an empty field arrives here
-        // as `None` — the same `None` the verdict reserves for a reading nobody obtained.
+        // The mapper drops an empty value, so an empty field arrives as `None` — which the verdict
+        // reserves for a reading nobody took.
         Err(GlassError::value_not_applied(
             target.id.0,
             text,
@@ -723,7 +723,7 @@ impl Accessibility for AndroidA11y {
             }
         }
         // The const assert on `VERIFY_ATTEMPTS` is what makes `last` always set; the fallback only
-        // avoids an unwrap, and names no read-back because none was taken.
+        // avoids an unwrap.
         Err(last.unwrap_or_else(|| GlassError::value_not_applied(target.id.0, text, None)))
     }
 }
@@ -1954,9 +1954,8 @@ mod tests {
         assert!(verify_write(&after, &t, "").is_ok());
     }
 
-    /// Pin the whole verdict, not the variant: what the caller does next comes from the two values
-    /// it names, and a field that transformed the text is told apart from one that never received
-    /// it only by reading them (glass#363). Twin of the helper in `glass-ios/src/a11y.rs`.
+    /// Pin the whole verdict, not the variant: the two values it names are what a caller acts on
+    /// (glass#363). Twin of the helper in `glass-ios/src/a11y.rs`.
     #[track_caller]
     fn assert_not_applied(outcome: Result<()>, id: u32, requested: &str, observed: Option<&str>) {
         match outcome {
@@ -1993,9 +1992,8 @@ mod tests {
 
     #[test]
     fn an_empty_field_reports_an_empty_read_back_not_a_missing_one() {
-        // `axmap` drops an empty value, so the node arrives holding `None` — which the verdict
-        // reserves for a reading nobody took. A write that cleared the field and lost its text must
-        // say the field is empty, not that it could not be read.
+        // `axmap` drops an empty value, so an emptied field arrives as `None` — which must still
+        // report as empty, not as a reading nobody took.
         let after = tree_holding(None);
         let t = target(0, Some("Search"), Some(BOUNDS));
         assert_not_applied(verify_write(&after, &t, "world"), 0, "world", Some(""));
@@ -2449,10 +2447,8 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn the_verdict_names_the_last_read_back_not_the_first() {
-        // The read-back retries because a field can commit a frame or two late, so the attempts can
-        // disagree: a first read caught mid-write and a second holding what the field settled on.
-        // Reporting the first would tell the caller the write never arrived when it arrived
-        // transformed — the misdiagnosis the two values exist to prevent.
+        // The retries can disagree — a read caught mid-write, then the value the field settled on
+        // — and reporting the first calls a transformed write a lost one.
         use super::AndroidA11y;
         use crate::adb::{Answer, FakeAdb};
         use glass_core::Accessibility;

--- a/crates/glass-android/tests/a11y_loop.rs
+++ b/crates/glass-android/tests/a11y_loop.rs
@@ -497,7 +497,7 @@ fn write_leg(
         value: field.value.clone(),
     };
     let verdict = a11y.set_value(ctx, &target, "");
-    if !matches!(verdict, Err(GlassError::AxValueNotApplied(_))) {
+    if !matches!(verdict, Err(GlassError::AxValueNotApplied { .. })) {
         return Err(abandon_or_fail(
             a11y,
             ctx,

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -18,9 +18,8 @@ pub enum BoundKind {
 
 /// Render a read-back for [`GlassError::AxValueNotApplied`] as the clause following "the element".
 ///
-/// `None` does not mean the element is empty — an empty field reads back as `Some("")`. It means no
-/// reading was obtained at all: the platform's read failed, or nothing matching the element was
-/// found to read. Rendering it as `""` would put a value in the element's mouth.
+/// `None` is not an empty element — that reads back as `Some("")` — it is no reading at all: the
+/// platform's read failed, or nothing matching the element was found.
 fn render_observed(observed: &Option<String>) -> String {
     match observed {
         Some(v) => format!("holds {v:?}"),
@@ -157,12 +156,10 @@ pub enum GlassError {
 
     /// A dispatched write whose read-back does not hold the request.
     ///
-    /// Carries both values because the caller's next move turns on the difference between them,
-    /// and only the code that raised this had them side by side. Three outcomes look alike from
-    /// the id alone: the element transformed the write and holds it in another form (writing again
-    /// changes nothing), it holds part of the request (a keystroke was dropped, so writing again is
-    /// the fix), or it holds what it held before (the write never arrived). Build it with
-    /// [`GlassError::value_not_applied`].
+    /// Carries both values because three outcomes look alike from the id alone: the element
+    /// transformed the write and holds it in another form (writing again changes nothing), it holds
+    /// part of the request (a keystroke was dropped, so writing again is the fix), or it holds what
+    /// it held before (the write never arrived). Build it with [`GlassError::value_not_applied`].
     #[error(
         "set_value on element #{id} did not take — asked for {requested:?}, the element {}. \
          Holding the request in another form means the element transformed it, and writing again \
@@ -175,9 +172,8 @@ pub enum GlassError {
     AxValueNotApplied {
         id: u32,
         requested: String,
-        /// What the element reads as now: the text for a field — `Some("")` when it is empty —
-        /// or `"on"` / `"off"` for a boolean control. `None` only when no reading was obtained,
-        /// never for an element that read back as holding nothing.
+        /// What the element reads as now: the text for a field — `Some("")` when it is empty — or
+        /// `"on"` / `"off"` for a boolean control. `None` only when no reading was obtained.
         observed: Option<String>,
     },
 
@@ -304,10 +300,9 @@ impl GlassError {
 
     /// The verdict for a write that dispatched and whose read-back does not hold the request.
     ///
-    /// Pass the value the verification already read, not a reading taken to fill this in: one taken
-    /// afterwards can catch a value that arrived late and contradict the verdict it explains. A
-    /// backend whose mapper drops an empty value must pass `Some("")` rather than `None` — `None`
-    /// says no reading was obtained, which is a different answer to the caller.
+    /// Pass the value the verification already read: one taken afterwards can catch a value that
+    /// arrived late and contradict the verdict it explains. A backend whose mapper drops an empty
+    /// value must pass `Some("")` rather than `None`, which says no reading was obtained.
     pub fn value_not_applied(id: u32, requested: &str, observed: Option<&str>) -> GlassError {
         GlassError::AxValueNotApplied {
             id,
@@ -584,9 +579,8 @@ mod tests {
 
     #[test]
     fn a_write_that_did_not_take_names_both_the_request_and_the_read_back() {
-        // The whole point of the variant: an iOS field that autocapitalized the first letter took
-        // every keystroke, and only seeing both strings tells the caller that (glass#363). Each is
-        // asserted with the label that binds it — "contains both strings" also passes for a message
+        // glass#363: an iOS field that autocapitalized the first letter took every keystroke. Each
+        // value is asserted with the label that binds it — "contains both" also passes a message
         // that swapped them, which is the inverted diagnosis.
         let msg = GlassError::value_not_applied(13, "glasssmoke3", Some("Glasssmoke3")).to_string();
         assert!(msg.contains("element #13"), "{msg}");
@@ -596,16 +590,16 @@ mod tests {
 
     #[test]
     fn an_empty_read_back_renders_as_an_empty_value() {
-        // An element that read back as empty holds something the caller can act on: the write
-        // arrived and left nothing, which is not the same answer as no reading at all.
+        // An empty read-back says the write arrived and left nothing — not the same answer as no
+        // reading at all.
         let msg = GlassError::value_not_applied(13, "hello", Some("")).to_string();
         assert!(msg.contains("holds \"\""), "{msg}");
     }
 
     #[test]
     fn a_reading_nobody_took_does_not_render_as_a_value() {
-        // `None` is a failed platform read or an element that could not be found. Rendering it as
-        // `""` — or as "holds no value" — states something about the element that nobody observed.
+        // `None` is a failed platform read or an element not found; rendering it as `""`, or as
+        // "holds no value", states something about the element that nobody observed.
         let msg = GlassError::value_not_applied(13, "hello", None).to_string();
         assert!(msg.contains("could not be read back"), "{msg}");
         assert!(!msg.contains("holds"), "{msg}");

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -16,13 +16,15 @@ pub enum BoundKind {
     NotStarted,
 }
 
-/// Render a read-back for [`GlassError::AxValueNotApplied`]. An element reporting no value at all
-/// is a different answer from one holding `""` — a read-only projection that never exposed a value
-/// versus a field that emptied — so it does not render as an empty pair of quotes.
+/// Render a read-back for [`GlassError::AxValueNotApplied`] as the clause following "the element".
+///
+/// `None` does not mean the element is empty — an empty field reads back as `Some("")`. It means no
+/// reading was obtained at all: the platform's read failed, or nothing matching the element was
+/// found to read. Rendering it as `""` would put a value in the element's mouth.
 fn render_observed(observed: &Option<String>) -> String {
     match observed {
-        Some(v) => format!("{v:?}"),
-        None => "no value".to_string(),
+        Some(v) => format!("holds {v:?}"),
+        None => "could not be read back".to_string(),
     }
 }
 
@@ -156,22 +158,26 @@ pub enum GlassError {
     /// A dispatched write whose read-back does not hold the request.
     ///
     /// Carries both values because the caller's next move turns on the difference between them,
-    /// and only the backend that raised this had them side by side. A field that transformed the
-    /// text took the write in a form the request cannot express; one that did not change never
-    /// received it. Build it with [`GlassError::value_not_applied`].
+    /// and only the code that raised this had them side by side. Three outcomes look alike from
+    /// the id alone: the element transformed the write and holds it in another form (writing again
+    /// changes nothing), it holds part of the request (a keystroke was dropped, so writing again is
+    /// the fix), or it holds what it held before (the write never arrived). Build it with
+    /// [`GlassError::value_not_applied`].
     #[error(
-        "set_value on element #{id} did not take — asked for {requested:?}, the element holds {}. \
-         Compare the two: a field that reformats or autocapitalizes what it is given has taken the \
-         keystrokes in a form the request cannot express, while a value that did not change means \
-         the write never reached it — a read-only accessibility projection on a desktop backend, a \
-         tap that missed on Android or the iOS Simulator",
+        "set_value on element #{id} did not take — asked for {requested:?}, the element {}. \
+         Holding the request in another form means the element transformed it, and writing again \
+         will not change that. Holding part of it, or none of it, means the write did not arrive: \
+         on a desktop backend the value is often a read-only projection, so focus the element and \
+         type into it instead; on Android or the iOS Simulator the tap may have missed, so write \
+         again",
         render_observed(.observed)
     )]
     AxValueNotApplied {
         id: u32,
         requested: String,
-        /// What the element reads as now, as its backend renders it: the text for a field, `"on"`
-        /// / `"off"` for a boolean control, `None` for an element reporting no value at all.
+        /// What the element reads as now: the text for a field — `Some("")` when it is empty —
+        /// or `"on"` / `"off"` for a boolean control. `None` only when no reading was obtained,
+        /// never for an element that read back as holding nothing.
         observed: Option<String>,
     },
 
@@ -298,8 +304,10 @@ impl GlassError {
 
     /// The verdict for a write that dispatched and whose read-back does not hold the request.
     ///
-    /// `observed` is what the element reads as now — the value the read-back just fetched, not a
-    /// fresh read and not what the caller believes is there.
+    /// Pass the value the verification already read, not a reading taken to fill this in: one taken
+    /// afterwards can catch a value that arrived late and contradict the verdict it explains. A
+    /// backend whose mapper drops an empty value must pass `Some("")` rather than `None` — `None`
+    /// says no reading was obtained, which is a different answer to the caller.
     pub fn value_not_applied(id: u32, requested: &str, observed: Option<&str>) -> GlassError {
         GlassError::AxValueNotApplied {
             id,
@@ -577,17 +585,30 @@ mod tests {
     #[test]
     fn a_write_that_did_not_take_names_both_the_request_and_the_read_back() {
         // The whole point of the variant: an iOS field that autocapitalized the first letter took
-        // every keystroke, and only seeing both strings tells the caller that (glass#363).
+        // every keystroke, and only seeing both strings tells the caller that (glass#363). Each is
+        // asserted with the label that binds it — "contains both strings" also passes for a message
+        // that swapped them, which is the inverted diagnosis.
         let msg = GlassError::value_not_applied(13, "glasssmoke3", Some("Glasssmoke3")).to_string();
-        assert!(msg.contains("\"glasssmoke3\""), "{msg}");
-        assert!(msg.contains("\"Glasssmoke3\""), "{msg}");
+        assert!(msg.contains("element #13"), "{msg}");
+        assert!(msg.contains("asked for \"glasssmoke3\""), "{msg}");
+        assert!(msg.contains("holds \"Glasssmoke3\""), "{msg}");
     }
 
     #[test]
-    fn an_element_reporting_no_value_does_not_render_as_an_empty_string() {
-        // "holds \"\"" would claim the element exposed an empty value; it exposed none.
+    fn an_empty_read_back_renders_as_an_empty_value() {
+        // An element that read back as empty holds something the caller can act on: the write
+        // arrived and left nothing, which is not the same answer as no reading at all.
+        let msg = GlassError::value_not_applied(13, "hello", Some("")).to_string();
+        assert!(msg.contains("holds \"\""), "{msg}");
+    }
+
+    #[test]
+    fn a_reading_nobody_took_does_not_render_as_a_value() {
+        // `None` is a failed platform read or an element that could not be found. Rendering it as
+        // `""` — or as "holds no value" — states something about the element that nobody observed.
         let msg = GlassError::value_not_applied(13, "hello", None).to_string();
-        assert!(msg.contains("holds no value"), "{msg}");
+        assert!(msg.contains("could not be read back"), "{msg}");
+        assert!(!msg.contains("holds"), "{msg}");
     }
 
     #[test]

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -16,6 +16,16 @@ pub enum BoundKind {
     NotStarted,
 }
 
+/// Render a read-back for [`GlassError::AxValueNotApplied`]. An element reporting no value at all
+/// is a different answer from one holding `""` — a read-only projection that never exposed a value
+/// versus a field that emptied — so it does not render as an empty pair of quotes.
+fn render_observed(observed: &Option<String>) -> String {
+    match observed {
+        Some(v) => format!("{v:?}"),
+        None => "no value".to_string(),
+    }
+}
+
 /// All fallible glass-core operations return this error.
 ///
 /// Variants map to the actionable error kinds the MCP layer surfaces to the
@@ -143,13 +153,27 @@ pub enum GlassError {
     )]
     AxWriteUnconfirmed(u32, String),
 
+    /// A dispatched write whose read-back does not hold the request.
+    ///
+    /// Carries both values because the caller's next move turns on the difference between them,
+    /// and only the backend that raised this had them side by side. A field that transformed the
+    /// text took the write in a form the request cannot express; one that did not change never
+    /// received it. Build it with [`GlassError::value_not_applied`].
     #[error(
-        "set_value on element #{0} did not take — the element does not hold the requested value. On \
-         a desktop backend this usually means a read-only accessibility projection, so try \
-         keystrokes; on Android or the iOS Simulator the write already IS keystrokes, so the tap may \
-         have missed or the field rejected the input — re-snapshot to see what it holds"
+        "set_value on element #{id} did not take — asked for {requested:?}, the element holds {}. \
+         Compare the two: a field that reformats or autocapitalizes what it is given has taken the \
+         keystrokes in a form the request cannot express, while a value that did not change means \
+         the write never reached it — a read-only accessibility projection on a desktop backend, a \
+         tap that missed on Android or the iOS Simulator",
+        render_observed(.observed)
     )]
-    AxValueNotApplied(u32),
+    AxValueNotApplied {
+        id: u32,
+        requested: String,
+        /// What the element reads as now, as its backend renders it: the text for a field, `"on"`
+        /// / `"off"` for a boolean control, `None` for an element reporting no value at all.
+        observed: Option<String>,
+    },
 
     #[error("element #{0} exposes no native activation action")]
     AxActionUnavailable(u32),
@@ -268,8 +292,20 @@ impl GlassError {
     pub fn set_value_failed_after_writing(&self) -> bool {
         matches!(
             self,
-            GlassError::AxValueNotApplied(_) | GlassError::AxWriteUnconfirmed(..)
+            GlassError::AxValueNotApplied { .. } | GlassError::AxWriteUnconfirmed(..)
         )
+    }
+
+    /// The verdict for a write that dispatched and whose read-back does not hold the request.
+    ///
+    /// `observed` is what the element reads as now — the value the read-back just fetched, not a
+    /// fresh read and not what the caller believes is there.
+    pub fn value_not_applied(id: u32, requested: &str, observed: Option<&str>) -> GlassError {
+        GlassError::AxValueNotApplied {
+            id,
+            requested: requested.to_string(),
+            observed: observed.map(str::to_string),
+        }
     }
 
     /// Which of glass's own bounds ended this call, if one did rather than the tool answering.
@@ -539,9 +575,28 @@ mod tests {
     }
 
     #[test]
+    fn a_write_that_did_not_take_names_both_the_request_and_the_read_back() {
+        // The whole point of the variant: an iOS field that autocapitalized the first letter took
+        // every keystroke, and only seeing both strings tells the caller that (glass#363).
+        let msg = GlassError::value_not_applied(13, "glasssmoke3", Some("Glasssmoke3")).to_string();
+        assert!(msg.contains("\"glasssmoke3\""), "{msg}");
+        assert!(msg.contains("\"Glasssmoke3\""), "{msg}");
+    }
+
+    #[test]
+    fn an_element_reporting_no_value_does_not_render_as_an_empty_string() {
+        // "holds \"\"" would claim the element exposed an empty value; it exposed none.
+        let msg = GlassError::value_not_applied(13, "hello", None).to_string();
+        assert!(msg.contains("holds no value"), "{msg}");
+    }
+
+    #[test]
     fn only_a_proven_post_dispatch_verdict_invalidates_the_captured_value() {
         // The read-back verdict is reached only after the write went out.
-        assert!(GlassError::AxValueNotApplied(3).set_value_failed_after_writing());
+        assert!(
+            GlassError::value_not_applied(3, "world", Some("hello"))
+                .set_value_failed_after_writing()
+        );
         // Everything else keeps the captured value: the pre-dispatch rejections, the transport
         // errors raised on either side of the dispatch, and any variant not named (the wildcard).
         for e in [

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -418,8 +418,8 @@ impl Glass {
             // Not event-gated: this branch runs only on iOS, whose reader has no event stream.
             // No deadline either: `AxDeadline` carries the *caller's* bound, and
             // `TOGGLE_VERIFY_TIMEOUT_MS` is glass's own.
-            // Kept as the poll runs rather than re-read afterwards: a read taken after the bound
-            // elapsed could catch a state that arrived late and contradict the verdict.
+            // Kept as the poll runs, not re-read afterwards — a read taken after the bound elapsed
+            // could catch a state that arrived late and contradict the verdict.
             let mut seen = None;
             let outcome = crate::poll::poll_until(
                 TOGGLE_VERIFY_INTERVAL_MS,
@@ -434,8 +434,8 @@ impl Glass {
             return if outcome.value.is_some() {
                 Ok(())
             } else {
-                // `None` is no checkable element near the target's bounds on the last tick — the
-                // swipe moved the screen — so it reports as a reading nobody took, not as a state.
+                // `None` is no checkable near the target's bounds on the last tick — the swipe
+                // moved the screen — so it reports as a reading nobody took, not as a state.
                 Err(GlassError::value_not_applied(
                     id.0,
                     text,
@@ -543,10 +543,9 @@ impl Glass {
         {
             Ok(())
         } else {
-            // A combo carries its selection as its name, so that is the read-back to report; `None`
-            // is the combo no longer being where it was, which is a reading nobody took. `text`,
-            // not the trimmed `want`, so the caller sees what it asked for — as `AxOptionNotFound`
-            // above already does.
+            // A combo carries its selection as its name, so that is the read-back; `None` is the
+            // combo no longer being where it was. `text` rather than the trimmed `want`, so the
+            // caller sees what it asked for, as `AxOptionNotFound` above does.
             Err(GlassError::value_not_applied(id.0, text, shows.as_deref()))
         }
     }
@@ -2444,8 +2443,8 @@ mod tests {
     /// keystrokes: the end state alone is reached by any number of Downs past the target.
     #[test]
     fn a_combo_that_did_not_commit_names_the_selection_it_still_shows() {
-        // The selection a combo shows is its name, so that is the read-back — a future edit reaching
-        // for `value` (which no combo carries) would report every one of them as unreadable.
+        // The selection a combo shows is its name — an edit reaching for `value`, which no combo
+        // carries, would report every one of them as unreadable.
         let platform = FakePlatform::new(340, 300).with_key_log(Arc::new(Mutex::new(Vec::new())));
         let (mut g, _) = glass_with_a11y_seq_invoke(
             platform,
@@ -2469,8 +2468,8 @@ mod tests {
 
     #[test]
     fn a_combo_no_longer_where_it_was_reports_no_reading_rather_than_no_value() {
-        // Committing can reflow the form out from under the combo. Nothing was read, so the verdict
-        // must not claim the combo holds nothing — that reads as a combo with no selection.
+        // Committing can reflow the form out from under the combo; nothing was read, so the verdict
+        // must not claim it holds nothing — that reads as a combo with no selection.
         let platform = FakePlatform::new(340, 300).with_key_log(Arc::new(Mutex::new(Vec::new())));
         let (mut g, _) = glass_with_a11y_seq_invoke(
             platform,
@@ -3265,9 +3264,8 @@ mod tests {
 
     #[test]
     fn a_toggle_whose_control_left_the_screen_reports_no_reading_rather_than_a_state() {
-        // The actuation is a swipe, which can carry the row away or navigate off the screen. No
-        // checkable was read, so the verdict must not name "on" or "off" — either would be a state
-        // nobody observed.
+        // The actuation is a swipe, which can carry the row away; no checkable was read, so naming
+        // "on" or "off" would be a state nobody observed.
         let platform = FakePlatform::new(400, 400)
             .with_drag_log(Arc::new(Mutex::new(Vec::new())))
             .with_trailing_toggle_backend();

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -418,20 +418,28 @@ impl Glass {
             // Not event-gated: this branch runs only on iOS, whose reader has no event stream.
             // No deadline either: `AxDeadline` carries the *caller's* bound, and
             // `TOGGLE_VERIFY_TIMEOUT_MS` is glass's own.
+            // The last tick's reading is what the failure reports, so it is kept as the poll runs
+            // rather than re-read afterwards — a read taken after the bound elapsed could have
+            // caught a state that arrived late and would contradict the verdict.
+            let mut seen = None;
             let outcome = crate::poll::poll_until(
                 TOGGLE_VERIFY_INTERVAL_MS,
                 TOGGLE_VERIFY_TIMEOUT_MS,
                 || {
                     let tree = self.a11y_resnapshot(AxDeadline::UNBOUNDED)?;
-                    let now = find_checkable_near(&tree.root, target.bounds.as_ref())
-                        .is_some_and(|n| n.states.checked == want);
-                    Ok(now.then_some(()))
+                    seen = find_checkable_near(&tree.root, target.bounds.as_ref())
+                        .map(|n| n.states.checked);
+                    Ok((seen == Some(want)).then_some(()))
                 },
             )?;
             return if outcome.value.is_some() {
                 Ok(())
             } else {
-                Err(GlassError::AxValueNotApplied(id.0))
+                Err(GlassError::value_not_applied(
+                    id.0,
+                    text,
+                    seen.map(|on| if on { "on" } else { "off" }),
+                ))
             };
         }
         let s = self.active_mut()?;
@@ -526,13 +534,16 @@ impl Glass {
         // Verify the model actually committed — the *target* combo (matched by bounds,
         // now closed so nothing is `expanded`) must read the wanted label.
         let tree = self.a11y_resnapshot(AxDeadline::UNBOUNDED)?;
-        let ok = find_combo_near(&tree.root, target.bounds.as_ref())
-            .and_then(|c| c.name.as_deref())
-            .is_some_and(|n| n.eq_ignore_ascii_case(want));
-        if ok {
+        let shows =
+            find_combo_near(&tree.root, target.bounds.as_ref()).and_then(|c| c.name.clone());
+        if shows
+            .as_deref()
+            .is_some_and(|n| n.eq_ignore_ascii_case(want))
+        {
             Ok(())
         } else {
-            Err(GlassError::AxValueNotApplied(id.0))
+            // A combo carries its selection as its name, so that is the read-back to report.
+            Err(GlassError::value_not_applied(id.0, want, shows.as_deref()))
         }
     }
 
@@ -2806,7 +2817,7 @@ mod tests {
         fn set_value(&mut self, _ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
             if !self.failed_once {
                 self.failed_once = true;
-                return Err(GlassError::AxValueNotApplied(target.id.0));
+                return Err(GlassError::value_not_applied(target.id.0, text, None));
             }
             self.set_log
                 .lock()
@@ -3209,7 +3220,11 @@ mod tests {
         g.a11y_snapshot(None).unwrap();
 
         let err = g.set_value(AxNodeId(1), "true").unwrap_err();
-        assert!(matches!(err, GlassError::AxValueNotApplied(_)));
+        assert!(
+            matches!(&err, GlassError::AxValueNotApplied { id: 1, requested, observed }
+                if requested == "true" && observed.as_deref() == Some("off")),
+            "{err}"
+        );
     }
 
     #[test]
@@ -3334,7 +3349,11 @@ mod tests {
         g.a11y_snapshot(None).unwrap();
 
         let err = g.set_value(AxNodeId(2), "true").unwrap_err();
-        assert!(matches!(err, GlassError::AxValueNotApplied(2)));
+        assert!(
+            matches!(&err, GlassError::AxValueNotApplied { id: 2, requested, observed }
+                if requested == "true" && observed.as_deref() == Some("off")),
+            "{err}"
+        );
     }
 
     #[test]

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -418,9 +418,8 @@ impl Glass {
             // Not event-gated: this branch runs only on iOS, whose reader has no event stream.
             // No deadline either: `AxDeadline` carries the *caller's* bound, and
             // `TOGGLE_VERIFY_TIMEOUT_MS` is glass's own.
-            // The last tick's reading is what the failure reports, so it is kept as the poll runs
-            // rather than re-read afterwards — a read taken after the bound elapsed could have
-            // caught a state that arrived late and would contradict the verdict.
+            // Kept as the poll runs rather than re-read afterwards: a read taken after the bound
+            // elapsed could catch a state that arrived late and contradict the verdict.
             let mut seen = None;
             let outcome = crate::poll::poll_until(
                 TOGGLE_VERIFY_INTERVAL_MS,
@@ -435,6 +434,8 @@ impl Glass {
             return if outcome.value.is_some() {
                 Ok(())
             } else {
+                // `None` is no checkable element near the target's bounds on the last tick — the
+                // swipe moved the screen — so it reports as a reading nobody took, not as a state.
                 Err(GlassError::value_not_applied(
                     id.0,
                     text,
@@ -542,8 +543,11 @@ impl Glass {
         {
             Ok(())
         } else {
-            // A combo carries its selection as its name, so that is the read-back to report.
-            Err(GlassError::value_not_applied(id.0, want, shows.as_deref()))
+            // A combo carries its selection as its name, so that is the read-back to report; `None`
+            // is the combo no longer being where it was, which is a reading nobody took. `text`,
+            // not the trimmed `want`, so the caller sees what it asked for — as `AxOptionNotFound`
+            // above already does.
+            Err(GlassError::value_not_applied(id.0, text, shows.as_deref()))
         }
     }
 
@@ -2439,6 +2443,56 @@ mod tests {
     /// direction and the number of steps come from their index difference. Asserted on the
     /// keystrokes: the end state alone is reached by any number of Downs past the target.
     #[test]
+    fn a_combo_that_did_not_commit_names_the_selection_it_still_shows() {
+        // The selection a combo shows is its name, so that is the read-back — a future edit reaching
+        // for `value` (which no combo carries) would report every one of them as unreadable.
+        let platform = FakePlatform::new(340, 300).with_key_log(Arc::new(Mutex::new(Vec::new())));
+        let (mut g, _) = glass_with_a11y_seq_invoke(
+            platform,
+            vec![
+                combo("Beta", &[]),
+                combo("Beta", &["Alpha", "Beta", "Gamma", "Delta"]),
+                combo("Beta", &[]),
+            ],
+            InvokeBehavior::Unsupported,
+        );
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot(None).unwrap();
+
+        let err = g.set_value(AxNodeId(1), "Delta").unwrap_err();
+        assert!(
+            matches!(&err, GlassError::AxValueNotApplied { id: 1, requested, observed }
+                if requested == "Delta" && observed.as_deref() == Some("Beta")),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn a_combo_no_longer_where_it_was_reports_no_reading_rather_than_no_value() {
+        // Committing can reflow the form out from under the combo. Nothing was read, so the verdict
+        // must not claim the combo holds nothing — that reads as a combo with no selection.
+        let platform = FakePlatform::new(340, 300).with_key_log(Arc::new(Mutex::new(Vec::new())));
+        let (mut g, _) = glass_with_a11y_seq_invoke(
+            platform,
+            vec![
+                combo("Beta", &[]),
+                combo("Beta", &["Alpha", "Beta", "Gamma", "Delta"]),
+                tree_with(340, 300, vec![]),
+            ],
+            InvokeBehavior::Unsupported,
+        );
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot(None).unwrap();
+
+        let err = g.set_value(AxNodeId(1), "Delta").unwrap_err();
+        assert!(
+            matches!(&err, GlassError::AxValueNotApplied { observed: None, .. }),
+            "{err}"
+        );
+        assert!(err.to_string().contains("could not be read back"), "{err}");
+    }
+
+    #[test]
     fn set_combo_value_steps_from_the_current_selection_to_the_target() {
         let keys = Arc::new(Mutex::new(Vec::new()));
         let platform = FakePlatform::new(340, 300).with_key_log(keys.clone());
@@ -3210,6 +3264,25 @@ mod tests {
     }
 
     #[test]
+    fn a_toggle_whose_control_left_the_screen_reports_no_reading_rather_than_a_state() {
+        // The actuation is a swipe, which can carry the row away or navigate off the screen. No
+        // checkable was read, so the verdict must not name "on" or "off" — either would be a state
+        // nobody observed.
+        let platform = FakePlatform::new(400, 400)
+            .with_drag_log(Arc::new(Mutex::new(Vec::new())))
+            .with_trailing_toggle_backend();
+        let mut g = glass_with_a11y_seq(platform, vec![sw(false), tree_with(400, 400, vec![])]);
+        g.start(&spec()).unwrap();
+        g.a11y_snapshot(None).unwrap();
+
+        let err = g.set_value(AxNodeId(1), "true").unwrap_err();
+        assert!(
+            matches!(&err, GlassError::AxValueNotApplied { observed: None, .. }),
+            "{err}"
+        );
+    }
+
+    #[test]
     fn set_value_errors_when_the_toggle_does_not_apply() {
         let platform = FakePlatform::new(400, 400)
             .with_drag_log(Arc::new(Mutex::new(Vec::new())))
@@ -3444,7 +3517,7 @@ mod tests {
 
         // The error must be the switch-specific "expects a boolean" one, and its message must
         // actually guide the agent (name the accepted values + echo the bad input) — NOT a generic
-        // "value not applied — use keystrokes", which would send the agent down a futile path.
+        // `AxValueNotApplied`, whose remedy is to type into the element — futile for a switch.
         assert!(
             matches!(err, GlassError::AxValueNotBoolean(1, ref got) if got == "banana"),
             "{err}"

--- a/crates/glass-core/src/set_value.rs
+++ b/crates/glass-core/src/set_value.rs
@@ -64,8 +64,8 @@ pub fn read_back_confirms(read_back: Option<&str>, before: Option<&str>, request
 ///
 /// The cost of the strictness: a field that reformats what it is given (a phone number becoming
 /// `"(123) 456-7890"`) reports the write as not applied even though it landed. That is the safer
-/// direction — an agent can re-read the tree and see the value, whereas a false success has it
-/// asserting against a screen that never changed.
+/// direction — [`crate::GlassError::AxValueNotApplied`] names the value it holds, whereas a false
+/// success has an agent asserting against a screen that never changed.
 ///
 /// Not for a clear: see [`typed_clear_landed`].
 pub fn typed_text_landed(read_back: Option<&str>, requested: &str) -> bool {
@@ -80,8 +80,9 @@ pub fn typed_text_landed(read_back: Option<&str>, requested: &str) -> bool {
 ///
 /// The cost is a false *failure*: on the dogfood AVD an emptied `EditText` reports its placeholder as
 /// its text (`text="Search settings"`, and `uiautomator` exposes no separate hint attribute), so a
-/// clear that worked reads as not applied. An agent can read the element and see the placeholder; the
-/// other direction would have it believing an unchanged field was cleared.
+/// clear that worked reads as not applied. [`crate::GlassError::AxValueNotApplied`] names the
+/// placeholder it read back; the other direction would have an agent believing an unchanged field
+/// was cleared.
 pub fn typed_clear_landed(read_back: Option<&str>) -> bool {
     read_back.unwrap_or("").is_empty()
 }

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -103,6 +103,10 @@ const VERIFY_SETTLE: Duration = Duration::from_millis(300);
 /// confirms on the first attempt and pays for one describe; the retries cover a field that commits a
 /// frame or two later.
 const VERIFY_ATTEMPTS: usize = 3;
+const _: () = assert!(
+    VERIFY_ATTEMPTS > 0,
+    "set_value reports the last read-back, so there must be one"
+);
 
 /// Judge a typed `set_value` from a tree described after it. `Ok(())` only when the field holds
 /// exactly what was asked for, or — for a named field — reads back empty after a clear.
@@ -210,10 +214,12 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
     if landed {
         Ok(())
     } else {
+        // `Some("")`, not `None`: this mapper drops an empty value, so an empty field arrives here
+        // as `None` — the same `None` the verdict reserves for a reading nobody obtained.
         Err(GlassError::value_not_applied(
             target.id.0,
             text,
-            node.value.as_deref(),
+            Some(node.value.as_deref().unwrap_or("")),
         ))
     }
 }
@@ -315,8 +321,8 @@ impl Accessibility for IosA11y {
                 Err(e) => return Err(e),
             }
         }
-        // `VERIFY_ATTEMPTS` is non-zero, so the loop always reached a verdict; the fallback exists
-        // only to avoid an unwrap and cannot name a read-back nobody took.
+        // The const assert on `VERIFY_ATTEMPTS` is what makes `last` always set; the fallback only
+        // avoids an unwrap, and names no read-back because none was taken.
         Err(last.unwrap_or_else(|| GlassError::value_not_applied(target.id.0, text, None)))
     }
 }
@@ -402,7 +408,7 @@ mod tests {
 
     /// Pin the whole verdict, not the variant: what the caller does next comes from the two values
     /// it names, and a field that transformed the text is told apart from one that never received
-    /// it only by reading them (glass#363).
+    /// it only by reading them (glass#363). Twin of the helper in `glass-android/src/a11y.rs`.
     #[track_caller]
     fn assert_not_applied(outcome: Result<()>, id: u32, requested: &str, observed: Option<&str>) {
         match outcome {
@@ -470,6 +476,37 @@ mod tests {
             1,
             "world",
             Some("hello"),
+        );
+    }
+
+    #[test]
+    fn an_autocapitalized_first_letter_is_not_a_successful_write() {
+        // glass#363: measured on the Simulator, iOS applies sentence autocapitalization to a value
+        // typed into a field it considers empty, so every keystroke lands and the field holds the
+        // request with its first letter uppercased. Exact match refuses it — accepting a case-only
+        // difference would report a write as landed while the field holds different bytes — and the
+        // verdict names both strings, which is the only way a caller can tell this from a lost
+        // write.
+        let after = tree_with_value(Some("Glasssmoke3"));
+        assert_not_applied(
+            verify_write(&after, &matching_target(), "glasssmoke3"),
+            1,
+            "glasssmoke3",
+            Some("Glasssmoke3"),
+        );
+    }
+
+    #[test]
+    fn an_empty_field_reports_an_empty_read_back_not_a_missing_one() {
+        // `axmap` drops an empty value, so the node arrives holding `None` — which the verdict
+        // reserves for a reading nobody took. A write that cleared the field and lost its text must
+        // say the field is empty, not that it could not be read.
+        let after = tree_with_value(None);
+        assert_not_applied(
+            verify_write(&after, &matching_target(), "world"),
+            1,
+            "world",
+            Some(""),
         );
     }
 

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -214,8 +214,8 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
     if landed {
         Ok(())
     } else {
-        // `Some("")`, not `None`: this mapper drops an empty value, so an empty field arrives here
-        // as `None` — the same `None` the verdict reserves for a reading nobody obtained.
+        // The mapper drops an empty value, so an empty field arrives as `None` — which the verdict
+        // reserves for a reading nobody took.
         Err(GlassError::value_not_applied(
             target.id.0,
             text,
@@ -322,7 +322,7 @@ impl Accessibility for IosA11y {
             }
         }
         // The const assert on `VERIFY_ATTEMPTS` is what makes `last` always set; the fallback only
-        // avoids an unwrap, and names no read-back because none was taken.
+        // avoids an unwrap.
         Err(last.unwrap_or_else(|| GlassError::value_not_applied(target.id.0, text, None)))
     }
 }
@@ -406,9 +406,8 @@ mod tests {
         }
     }
 
-    /// Pin the whole verdict, not the variant: what the caller does next comes from the two values
-    /// it names, and a field that transformed the text is told apart from one that never received
-    /// it only by reading them (glass#363). Twin of the helper in `glass-android/src/a11y.rs`.
+    /// Pin the whole verdict, not the variant: the two values it names are what a caller acts on
+    /// (glass#363). Twin of the helper in `glass-android/src/a11y.rs`.
     #[track_caller]
     fn assert_not_applied(outcome: Result<()>, id: u32, requested: &str, observed: Option<&str>) {
         match outcome {
@@ -481,12 +480,10 @@ mod tests {
 
     #[test]
     fn an_autocapitalized_first_letter_is_not_a_successful_write() {
-        // glass#363: measured on the Simulator, iOS applies sentence autocapitalization to a value
-        // typed into a field it considers empty, so every keystroke lands and the field holds the
-        // request with its first letter uppercased. Exact match refuses it — accepting a case-only
-        // difference would report a write as landed while the field holds different bytes — and the
-        // verdict names both strings, which is the only way a caller can tell this from a lost
-        // write.
+        // glass#363: iOS applies sentence autocapitalization to a value typed into a field it
+        // considers empty, so every keystroke lands and the field holds the request with its first
+        // letter uppercased. Do not relax the match to ignore case — that reports a write as landed
+        // while the field holds different bytes.
         let after = tree_with_value(Some("Glasssmoke3"));
         assert_not_applied(
             verify_write(&after, &matching_target(), "glasssmoke3"),
@@ -498,9 +495,8 @@ mod tests {
 
     #[test]
     fn an_empty_field_reports_an_empty_read_back_not_a_missing_one() {
-        // `axmap` drops an empty value, so the node arrives holding `None` — which the verdict
-        // reserves for a reading nobody took. A write that cleared the field and lost its text must
-        // say the field is empty, not that it could not be read.
+        // `axmap` drops an empty value, so an emptied field arrives as `None` — which must still
+        // report as empty, not as a reading nobody took.
         let after = tree_with_value(None);
         assert_not_applied(
             verify_write(&after, &matching_target(), "world"),

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -210,7 +210,11 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
     if landed {
         Ok(())
     } else {
-        Err(GlassError::AxValueNotApplied(target.id.0))
+        Err(GlassError::value_not_applied(
+            target.id.0,
+            text,
+            node.value.as_deref(),
+        ))
     }
 }
 
@@ -307,11 +311,13 @@ impl Accessibility for IosA11y {
                 Ok(()) => return Ok(()),
                 // Only a not-applied verdict can change on a later describe: drift and truncation
                 // are structural, so re-describing for them reaches the same answer more slowly.
-                Err(e @ GlassError::AxValueNotApplied(_)) => last = Some(e),
+                Err(e @ GlassError::AxValueNotApplied { .. }) => last = Some(e),
                 Err(e) => return Err(e),
             }
         }
-        Err(last.unwrap_or(GlassError::AxValueNotApplied(target.id.0)))
+        // `VERIFY_ATTEMPTS` is non-zero, so the loop always reached a verdict; the fallback exists
+        // only to avoid an unwrap and cannot name a read-back nobody took.
+        Err(last.unwrap_or_else(|| GlassError::value_not_applied(target.id.0, text, None)))
     }
 }
 
@@ -394,6 +400,24 @@ mod tests {
         }
     }
 
+    /// Pin the whole verdict, not the variant: what the caller does next comes from the two values
+    /// it names, and a field that transformed the text is told apart from one that never received
+    /// it only by reading them (glass#363).
+    #[track_caller]
+    fn assert_not_applied(outcome: Result<()>, id: u32, requested: &str, observed: Option<&str>) {
+        match outcome {
+            Err(GlassError::AxValueNotApplied {
+                id: got_id,
+                requested: req,
+                observed: obs,
+            }) => assert_eq!(
+                (got_id, req.as_str(), obs.as_deref()),
+                (id, requested, observed)
+            ),
+            other => panic!("expected a not-applied verdict, got {other:?}"),
+        }
+    }
+
     #[test]
     fn a_write_that_landed_is_reported_as_success() {
         let after = tree_with_value(Some("world"));
@@ -414,10 +438,12 @@ mod tests {
         // the clear can itself change a field that reformats on focus, and accepting that would
         // confirm a clear whose delete never fired.
         let after = tree_with_value(Some("Search settings"));
-        assert!(matches!(
+        assert_not_applied(
             verify_write(&after, &matching_target(), ""),
-            Err(GlassError::AxValueNotApplied(_))
-        ));
+            1,
+            "",
+            Some("Search settings"),
+        );
     }
 
     #[test]
@@ -439,10 +465,12 @@ mod tests {
     #[test]
     fn a_field_that_never_changed_is_not_a_successful_write() {
         let after = tree_with_value(Some("hello"));
-        assert!(matches!(
+        assert_not_applied(
             verify_write(&after, &matching_target(), "world"),
-            Err(GlassError::AxValueNotApplied(1))
-        ));
+            1,
+            "world",
+            Some("hello"),
+        );
     }
 
     #[test]
@@ -450,10 +478,12 @@ mod tests {
         // A dropped keystroke: differs from the old value, so "changed from before" would have
         // called it success.
         let after = tree_with_value(Some("worl"));
-        assert!(matches!(
+        assert_not_applied(
             verify_write(&after, &matching_target(), "world"),
-            Err(GlassError::AxValueNotApplied(1))
-        ));
+            1,
+            "world",
+            Some("worl"),
+        );
     }
 
     #[test]
@@ -466,10 +496,12 @@ mod tests {
         moved.value = Some("hello".into());
         root_field.children.push(moved);
         let after = tree_with(vec![root_field]);
-        assert!(matches!(
+        assert_not_applied(
             verify_write(&after, &matching_target(), "world"),
-            Err(GlassError::AxValueNotApplied(1))
-        ));
+            1,
+            "world",
+            Some("hello"),
+        );
     }
 
     #[test]

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -467,7 +467,11 @@ impl GlassServer {
                        three accessibility reads, since a field may commit a frame or two later. \
                        Errors if the element isn't editable, if it changed \
                        since the snapshot (re-snapshot), if the element does not hold the requested \
-                       value afterwards, or if the app exposes no accessibility tree. A separate \
+                       value afterwards, or if the app exposes no accessibility tree. That \
+                       does-not-hold error names both what you asked for and what the element \
+                       holds: a field that reformats or autocapitalizes what it is given took the \
+                       text in a form the request cannot express, so compare the two before \
+                       writing again. A separate \
                        error says the text WAS typed but the write could not be confirmed — the \
                        read-back failed, or could not tell which element now holds it. Do NOT write \
                        again on that one: the keystrokes already went out, and re-snapshotting is \

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -469,9 +469,10 @@ impl GlassServer {
                        since the snapshot (re-snapshot), if the element does not hold the requested \
                        value afterwards, or if the app exposes no accessibility tree. That \
                        does-not-hold error names both what you asked for and what the element \
-                       holds: a field that reformats or autocapitalizes what it is given took the \
-                       text in a form the request cannot express, so compare the two before \
-                       writing again. A separate \
+                       holds, and which one it is decides your next move: your text in another \
+                       form means the element transformed it and writing again will not help; part \
+                       of your text means a keystroke was dropped, so write again; what it held \
+                       before means the write never arrived. A separate \
                        error says the text WAS typed but the write could not be confirmed — the \
                        read-back failed, or could not tell which element now holds it. Do NOT write \
                        again on that one: the keystrokes already went out, and re-snapshotting is \

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -849,9 +849,8 @@ fn onbox_egui_set_value_honesty() {
         bounds: field.bounds,
         value: field.value.clone(),
     };
-    // The read-back is what makes the projection's shape visible: it still reports the field's own
-    // text, so the verdict must name that and not a failed read — UIA accepted the write and the
-    // value never moved.
+    // UIA accepted the write and the value never moved, so the read-back still reports the field's
+    // own text — the verdict must name that, not a failed read.
     let verdict = a11y.set_value(&ctx, &target, "hello");
     assert!(
         matches!(&verdict, Err(GlassError::AxValueNotApplied { requested, observed, .. })

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -852,7 +852,7 @@ fn onbox_egui_set_value_honesty() {
     assert!(
         matches!(
             a11y.set_value(&ctx, &target, "hello"),
-            Err(GlassError::AxValueNotApplied(_))
+            Err(GlassError::AxValueNotApplied { .. })
         ),
         "set_value on an egui TextEdit must error AxValueNotApplied (read-only projection), not false success"
     );

--- a/crates/glass-windows/tests/onbox.rs
+++ b/crates/glass-windows/tests/onbox.rs
@@ -849,12 +849,15 @@ fn onbox_egui_set_value_honesty() {
         bounds: field.bounds,
         value: field.value.clone(),
     };
+    // The read-back is what makes the projection's shape visible: it still reports the field's own
+    // text, so the verdict must name that and not a failed read — UIA accepted the write and the
+    // value never moved.
+    let verdict = a11y.set_value(&ctx, &target, "hello");
     assert!(
-        matches!(
-            a11y.set_value(&ctx, &target, "hello"),
-            Err(GlassError::AxValueNotApplied { .. })
-        ),
-        "set_value on an egui TextEdit must error AxValueNotApplied (read-only projection), not false success"
+        matches!(&verdict, Err(GlassError::AxValueNotApplied { requested, observed, .. })
+            if requested == "hello" && observed.as_deref() == field.value.as_deref()),
+        "set_value on an egui TextEdit must error AxValueNotApplied naming what the field still \
+         holds (read-only projection), not false success; got {verdict:?}"
     );
 
     let _ = p.stop_app();

--- a/docs/how-to/drive-an-ios-app.md
+++ b/docs/how-to/drive-an-ios-app.md
@@ -144,11 +144,14 @@ detected on top of the semantic check above.
   settle into the call itself.
 - **Toggles:** if a control is a switch, drive it with a short swipe across its trailing edge rather
   than a tap.
-- **A text field may capitalize the first letter of what you write.** iOS applies sentence
-  autocapitalization to a field it considers empty, and `glass_set_value` clears before it types, so
-  a lowercase value can come back capitalized — intermittently, since it turns on whether the field
-  had finished emptying when the first key arrived. Every keystroke landed; the field transformed
-  one. The error names both strings, so compare them rather than writing again, and prefer a value
-  whose first character is not a lowercase letter where you control it.
+- **A text field may capitalize the first letter of what you write**
+  ([#363](https://github.com/fixed-width/glass/issues/363)). iOS applies sentence autocapitalization
+  to a field it considers empty, and `glass_set_value` clears before it types, so a lowercase value
+  can come back capitalized. Every keystroke landed; the field transformed one, and
+  `glass_set_value` reports that it does not hold what you asked for. It happens intermittently —
+  it turns on whether the field had finished emptying when the first key arrived, so a busier host
+  hits it more often. The error names both strings; when they differ only in that first letter, the
+  write is as landed as it is going to get. Where you choose the value, one that does not start
+  with a lowercase letter avoids it entirely.
 - **Multi-touch** gestures (`glass_gesture`) are not supported on the Simulator
   ([#117](https://github.com/fixed-width/glass/issues/117)); drive with taps, swipes, and typing.

--- a/docs/how-to/drive-an-ios-app.md
+++ b/docs/how-to/drive-an-ios-app.md
@@ -144,5 +144,11 @@ detected on top of the semantic check above.
   settle into the call itself.
 - **Toggles:** if a control is a switch, drive it with a short swipe across its trailing edge rather
   than a tap.
+- **A text field may capitalize the first letter of what you write.** iOS applies sentence
+  autocapitalization to a field it considers empty, and `glass_set_value` clears before it types, so
+  a lowercase value can come back capitalized — intermittently, since it turns on whether the field
+  had finished emptying when the first key arrived. Every keystroke landed; the field transformed
+  one. The error names both strings, so compare them rather than writing again, and prefer a value
+  whose first character is not a lowercase letter where you control it.
 - **Multi-touch** gestures (`glass_gesture`) are not supported on the Simulator
   ([#117](https://github.com/fixed-width/glass/issues/117)); drive with taps, swipes, and typing.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -553,9 +553,14 @@ Where the platform can write the value directly this is instant and takes no key
 backend (Android without the on-device accessibility service, and the iOS Simulator) it taps the
 element, clears it and types, then reads the element back to confirm — up to three reads, since a
 field may commit a frame or two later. Errors if the element isn't editable, changed since the
-snapshot, does not hold the requested value afterwards, or the app exposes no accessibility tree. A
-field that reformats what it is given, and a cleared field that reports its placeholder as its text,
-both read as not applied even though the text arrived — read the element to see what it holds.
+snapshot, does not hold the requested value afterwards, or the app exposes no accessibility tree.
+
+The does-not-hold error names both values — what you asked for and what the element holds — because
+the two readings need telling apart. A field that transforms what it is given took the text in a
+form the request cannot express: one that reformats (`"1234567890"` becoming `"(123) 456-7890"`), one
+that autocapitalizes (an iOS text field returning `"Hello"` for a typed `"hello"`, intermittently:
+it depends on whether the field had finished emptying when the first key arrived), or a cleared
+field reporting its placeholder as its text. A value that did not change never received the write.
 
 One error is not a refusal: *the text was typed, but the write could not be confirmed*. The
 keystrokes went out and the read-back afterwards could not establish where they landed — it failed

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -556,11 +556,17 @@ field may commit a frame or two later. Errors if the element isn't editable, cha
 snapshot, does not hold the requested value afterwards, or the app exposes no accessibility tree.
 
 The does-not-hold error names both values — what you asked for and what the element holds — because
-the two readings need telling apart. A field that transforms what it is given took the text in a
-form the request cannot express: one that reformats (`"1234567890"` becoming `"(123) 456-7890"`), one
-that autocapitalizes (an iOS text field returning `"Hello"` for a typed `"hello"`, intermittently:
-it depends on whether the field had finished emptying when the first key arrived), or a cleared
-field reporting its placeholder as its text. A value that did not change never received the write.
+three outcomes look alike without them. An element that **transformed** the write holds your text in
+another form and writing again will not change that: a field that reformats (`"1234567890"` becoming
+`"(123) 456-7890"`), or one that autocapitalizes (an iOS text field returning `"Hello"` for a typed
+`"hello"`, intermittently — it depends on whether the field had finished emptying when the first key
+arrived). An element holding **part** of your text dropped a keystroke, and writing again is the fix.
+An element holding **what it held before** never received the write: on a desktop backend its value
+is usually a read-only projection, so focus it and use `glass_type` instead.
+
+A cleared field (`text: ""`) that reads back holding its placeholder is the one false failure here —
+the clear landed and the accessibility layer substituted the hint. Confirm it with a screenshot
+rather than writing again.
 
 One error is not a refusal: *the text was typed, but the write could not be confirmed*. The
 keystrokes went out and the read-back afterwards could not establish where they landed — it failed


### PR DESCRIPTION
Closes #363.

`glass_set_value` on the iOS Simulator was reported as intermittently not landing its typed text — ~1 run in 6 when filed, load-dependent, and enough to keep the iOS smoke leg out of the merge gate. It lands. Measured against `examples/ios-role-fixture` on a booted iPhone 17 Simulator:

| marker | host load | runs | failures |
|---|---|---|---|
| `glasssmoke<i>` | quiet | 25 | 1 |
| `glasssmoke<i>` | 6.6 | 60 | 5 |
| `7glasssmoke<i>` | 8.8 | 100 | 0 |

Every failure across 85 lowercase runs is one class — asked for `"glasssmoke9"`, the field holds `"Glasssmoke9"`. Every character arrives and nothing of the previous value survives. iOS applies sentence autocapitalization to the first character of a field it considers empty, and a write clears before it types, so the race is whether UIKit finished processing the emptying when the first key arrived. `typed_text_landed` is an exact match, so a complete write reads as not applied. Neither hypothesis the issue had left open — a tap that missed, keys arriving before the field was first responder — occurred once in 185 runs.

`typed_text_landed` is unchanged. Its doc already decides this case: a field that transforms what it is given reads as not-applied, because reporting `"hello"` as landed when the field holds `"Hello"` is the false success the exact match exists to prevent.

What changes is the verdict. `AxValueNotApplied` carried only the element id and ended by telling the caller to re-snapshot to see what the element holds — while the read-back that raised it had just read exactly that. It now carries the requested text and the value read back and quotes both, so the three outcomes that used to look alike are distinguishable: the element transformed the write and holds it in another form (writing again changes nothing), it holds part of the request (a keystroke was dropped, so writing again is the fix), or it holds what it held before (the write never arrived, and on a desktop backend its value is usually a read-only projection, so type into it instead).

`None` is reserved for a reading nobody took — a failed platform read, or an element that could not be found — and renders as that. The mobile mappers drop an empty value, so those sites normalize an empty read to `Some("")` rather than letting it collide.

All eight raise sites supply the read-back they already had: the two keystroke backends from the node they re-found, the macOS and Windows readers from the last poll instead of discarding it, the Linux toggle from the state its last poll read rather than negating the request, and the two session paths from their last tick.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, and `cargo test --workspace` (82 suites) are clean, as are the `x86_64-pc-windows-gnu` and `x86_64-apple-darwin` cross-checks. Seven new or strengthened assertions were each ablated and confirmed to fail without the change. The rebuilt binary was re-run against the Simulator under load: the verdict reads `asked for "glasssmoke19", the element holds "Glasssmoke19"`.

The autocapitalization itself is not pinned by a test — it is a load-dependent device race, and a test that reproduces it would be a flaky test on a product path. Its deterministic consequence is pinned instead, in `glass-ios`.

#405 is a separate defect found on the way: the Android companion service raises its own "did not take" as `GlassError::Backend`, which `set_value_failed_after_writing()` does not classify as post-dispatch, so the session keeps a stale cached value. It changes control flow rather than message contents, so it is not in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)