### PR TITLE
fix(a11y-android): classify every post-dispatch verdict on the companion-service write path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,28 +21,32 @@ internal refactors, CI, or test-only changes.
 
 ### Changed
 - `glass_set_value`'s "did not take" error now names both what you asked for and what the element
-  holds. Three outcomes used to look alike: the element transformed the write and holds it in
-  another form, so writing again changes nothing; it holds part of what you asked for, so a
-  keystroke was dropped and writing again is the fix; or it holds what it held before, so the write
-  never arrived. On the iOS Simulator this is routine — iOS applies sentence autocapitalization to
+  holds, and closes with what the backend that made the write knows about it. Three outcomes used
+  to look alike: the element transformed the write and holds it in another form, so writing again
+  changes nothing; it holds part of what you asked for, so a keystroke was dropped and writing
+  again is the fix; or it holds what it held before, so the write took no effect — and for that
+  last one the error now says why it can happen on the backend you are driving. A desktop
+  element's value is often a read-only accessibility projection; a mobile write is a tap and then
+  keystrokes, so the tap can miss; a *Compose* field driven through Android's on-device
+  accessibility service cannot have its text replaced, only set into an empty field; and a toggle
+  action that fired without moving the control is how a radio button reports that it cannot be
+  unselected.
+- On the iOS Simulator the transformed case is routine: iOS applies sentence autocapitalization to
   the first character of a field it considers empty, and a write clears the field before it types,
   so a lowercase value can come back capitalized. It happens intermittently, depending on whether
   the field had finished emptying when the first key arrived, and it read as an unexplained "did
   not take" before.
-- A `glass_set_value` that does not take now closes with what the backend that made the write knows
-  about it, rather than one shared guess covering all of them: a desktop element's value is often a
-  read-only accessibility projection, a mobile write is a tap and then keystrokes so the tap can
-  miss, an Android field driven through the on-device accessibility service cannot have text
-  replaced (only set into an empty field), and a control whose toggle action fired without moving is
-  how a radio button reports it cannot be unselected.
 
 ### Fixed
 - A `glass_set_value` that failed on Android's on-device accessibility service no longer poisons the
   retry. Three of that path's failures — the write not landing, the field ceasing to report itself
-  editable, and the read-back itself failing — were reported in a shape glass did not recognise as
-  having already written, so it kept the value it had cached for the element. A field that then
+  editable, and the read-back itself failing — along with a write whose answer was lost in
+  transport, were reported as failures glass did not recognise as having already written, so it
+  kept the value it had cached for the element. A field that then
   settled to the new text made the cached value stale, and the next `glass_set_value` on it was
-  refused as drift ("changed since the snapshot") for a write that had in fact succeeded.
+  refused as drift ("changed since the snapshot") for a write that had in fact succeeded. On the
+  same path, an element that left the tree during the write, and a cleared field that stopped
+  reporting itself editable, are no longer reported as an empty reading and a confirmed clear.
 - A helper binary that is installed but cannot be run is now reported as exactly that, instead of
   as missing. glass resolves several external tools — `Xvfb`, `sway`, `bwrap`, `dbus-daemon`,
   `at-spi-bus-launcher` — and used to accept any file at the path, so one whose execute permission

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,20 @@ internal refactors, CI, or test-only changes.
   so a lowercase value can come back capitalized. It happens intermittently, depending on whether
   the field had finished emptying when the first key arrived, and it read as an unexplained "did
   not take" before.
+- A `glass_set_value` that does not take now closes with what the backend that made the write knows
+  about it, rather than one shared guess covering all of them: a desktop element's value is often a
+  read-only accessibility projection, a mobile write is a tap and then keystrokes so the tap can
+  miss, an Android field driven through the on-device accessibility service cannot have text
+  replaced (only set into an empty field), and a control whose toggle action fired without moving is
+  how a radio button reports it cannot be unselected.
 
 ### Fixed
+- A `glass_set_value` that failed on Android's on-device accessibility service no longer poisons the
+  retry. Three of that path's failures — the write not landing, the field ceasing to report itself
+  editable, and the read-back itself failing — were reported in a shape glass did not recognise as
+  having already written, so it kept the value it had cached for the element. A field that then
+  settled to the new text made the cached value stale, and the next `glass_set_value` on it was
+  refused as drift ("changed since the snapshot") for a write that had in fact succeeded.
 - A helper binary that is installed but cannot be run is now reported as exactly that, instead of
   as missing. glass resolves several external tools — `Xvfb`, `sway`, `bwrap`, `dbus-daemon`,
   `at-spi-bus-launcher` — and used to accept any file at the path, so one whose execute permission

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -636,10 +636,12 @@ async fn set_toggle(
     }
     // Report the state the last poll read, not `!target_on` derived from the request — the two
     // agree only while this equality is the loop's sole exit, and nothing holds that.
-    Err(GlassError::value_not_applied(
+    Err(GlassError::value_not_applied_because(
         id,
         requested,
         last_on.map(toggle_state_label),
+        "the control's toggle action fired without moving it, which is how a radio button reports \
+         that it cannot be unselected",
     ))
 }
 

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -636,12 +636,19 @@ async fn set_toggle(
     }
     // Report the state the last poll read, not `!target_on` derived from the request — the two
     // agree only while this equality is the loop's sole exit, and nothing holds that.
+    // The radio note only where the site can see one: `set_toggle` also serves checkboxes and
+    // switches, and a caller asking to *select* a radio is not being refused an un-selection.
+    let why = if role == glass_core::AxRole::RadioButton && !target_on {
+        "the control's toggle action fired without moving it, which is how a radio button reports \
+         that it cannot be unselected"
+    } else {
+        "the control's toggle action fired and its state did not change within the poll window"
+    };
     Err(GlassError::value_not_applied_because(
         id,
         requested,
         last_on.map(toggle_state_label),
-        "the control's toggle action fired without moving it, which is how a radio button reports \
-         that it cannot be unselected",
+        why,
     ))
 }
 

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -637,7 +637,7 @@ async fn set_toggle(
     // Report the state the last poll read, not `!target_on` derived from the request — the two
     // agree only while this equality is the loop's sole exit, and nothing holds that.
     // The radio note only where the site can see one: `set_toggle` also serves checkboxes and
-    // switches, and a caller asking to *select* a radio is not being refused an un-selection.
+    // switches, and asking to *select* a radio is not being refused an un-selection.
     let why = if role == glass_core::AxRole::RadioButton && !target_on {
         "the control's toggle action fired without moving it, which is how a radio button reports \
          that it cannot be unselected"

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -155,8 +155,8 @@ impl Accessibility for MacosA11y {
                 return Ok(());
             }
             if Instant::now() >= deadline {
-                // A projection that accepted the write and kept its value is what this explains. A read
-                // that failed, or one showing a value the element reformatted, is not evidence of it.
+                // A read that failed, or one showing a value the element reformatted, is not
+                // evidence of a projection that accepted the write and kept its value.
                 return Err(match after.as_deref() {
                     Some(seen) if write_took_no_effect(seen, before.as_deref()) => {
                         GlassError::value_not_applied_because(

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -55,6 +55,11 @@ const SET_VALUE_VERIFY_MS: u64 = 800;
 /// Interval between read-back poll attempts.
 const SET_VALUE_POLL_MS: u64 = 20;
 
+/// What a write that never arrived looks like on this backend: the accessibility API accepts a
+/// value the toolkit never applies, which is a read-only projection rather than a lost write.
+const READ_ONLY_PROJECTION: &str = "this element's accessibility value may be a read-only projection that accepts a write without \
+     applying it — focus the element and type into it instead";
+
 /// How long [`resolve_window`] polls for the app's first `AXWindow` to register before giving
 /// up. The window server publishes a freshly-launched window's AX element a beat after the
 /// window exists, so a snapshot taken immediately after `start` can find an empty `AXWindows`
@@ -149,10 +154,11 @@ impl Accessibility for MacosA11y {
                 return Ok(());
             }
             if Instant::now() >= deadline {
-                return Err(GlassError::value_not_applied(
+                return Err(GlassError::value_not_applied_because(
                     target.id.0,
                     text,
                     after.as_deref(),
+                    READ_ONLY_PROJECTION,
                 ));
             }
             std::thread::sleep(Duration::from_millis(SET_VALUE_POLL_MS));

--- a/crates/glass-a11y-macos/src/reader.rs
+++ b/crates/glass-a11y-macos/src/reader.rs
@@ -21,6 +21,7 @@ use glass_core::platform::WindowGeometry;
 use glass_core::{
     Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxRole, AxTarget, AxTree, GlassError,
     Result, TruncationLimit, WalkBudget, normalize_description, read_back_confirms,
+    write_took_no_effect,
 };
 use objc2_application_services::AXUIElement;
 use objc2_core_foundation::CFRetained;
@@ -55,10 +56,10 @@ const SET_VALUE_VERIFY_MS: u64 = 800;
 /// Interval between read-back poll attempts.
 const SET_VALUE_POLL_MS: u64 = 20;
 
-/// What a write that never arrived looks like on this backend: the accessibility API accepts a
-/// value the toolkit never applies, which is a read-only projection rather than a lost write.
-const READ_ONLY_PROJECTION: &str = "this element's accessibility value may be a read-only projection that accepts a write without \
-     applying it — focus the element and type into it instead";
+/// What a write that took no effect looks like on this backend: the accessibility API accepts a
+/// value the toolkit never applies. Twin of the const in `glass-a11y-windows/src/reader.rs`.
+const READ_ONLY_PROJECTION: &str = "this element's accessibility value may be a read-only projection that accepts a write \
+     without applying it — focus the element and type into it instead";
 
 /// How long [`resolve_window`] polls for the app's first `AXWindow` to register before giving
 /// up. The window server publishes a freshly-launched window's AX element a beat after the
@@ -154,12 +155,19 @@ impl Accessibility for MacosA11y {
                 return Ok(());
             }
             if Instant::now() >= deadline {
-                return Err(GlassError::value_not_applied_because(
-                    target.id.0,
-                    text,
-                    after.as_deref(),
-                    READ_ONLY_PROJECTION,
-                ));
+                // A projection that accepted the write and kept its value is what this explains. A read
+                // that failed, or one showing a value the element reformatted, is not evidence of it.
+                return Err(match after.as_deref() {
+                    Some(seen) if write_took_no_effect(seen, before.as_deref()) => {
+                        GlassError::value_not_applied_because(
+                            target.id.0,
+                            text,
+                            Some(seen),
+                            READ_ONLY_PROJECTION,
+                        )
+                    }
+                    seen => GlassError::value_not_applied(target.id.0, text, seen),
+                });
             }
             std::thread::sleep(Duration::from_millis(SET_VALUE_POLL_MS));
         }

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -59,6 +59,11 @@ const SET_VALUE_VERIFY_MS: u64 = 800;
 /// Interval between read-backs while waiting for a write / toggle to land.
 const VERIFY_POLL_MS: u64 = 20;
 
+/// What a write that never arrived looks like on this backend: the accessibility API accepts a
+/// value the toolkit never applies, which is a read-only projection rather than a lost write.
+const READ_ONLY_PROJECTION: &str = "this element's accessibility value may be a read-only projection that accepts a write without \
+     applying it — focus the element and type into it instead";
+
 #[derive(Default)]
 pub struct WindowsA11y;
 
@@ -454,10 +459,11 @@ fn run_set_value(ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
             return Ok(());
         }
         if Instant::now() >= deadline {
-            return Err(GlassError::value_not_applied(
+            return Err(GlassError::value_not_applied_because(
                 target.id.0,
                 text,
                 after.as_deref(),
+                READ_ONLY_PROJECTION,
             ));
         }
         std::thread::sleep(Duration::from_millis(VERIFY_POLL_MS));

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -460,8 +460,8 @@ fn run_set_value(ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
             return Ok(());
         }
         if Instant::now() >= deadline {
-            // A projection that accepted the write and kept its value is what this explains. A read
-            // that failed, or one showing a value the element reformatted, is not evidence of it.
+            // A read that failed, or one showing a value the element reformatted, is not evidence
+            // of a projection that accepted the write and kept its value.
             return Err(match after.as_deref() {
                 Some(seen) if write_took_no_effect(seen, before.as_deref()) => {
                     GlassError::value_not_applied_because(

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 use glass_core::{
     Accessibility, AxContext, AxDeadline, AxNode, AxNodeId, AxRect, AxTarget, AxTree, ChangeSignal,
     GlassError, Result, TruncationLimit, WalkBudget, normalize_description, read_back_confirms,
+    write_took_no_effect,
 };
 use uiautomation::patterns::{
     UIExpandCollapsePattern, UIInvokePattern, UIRangeValuePattern, UISelectionItemPattern,
@@ -59,10 +60,10 @@ const SET_VALUE_VERIFY_MS: u64 = 800;
 /// Interval between read-backs while waiting for a write / toggle to land.
 const VERIFY_POLL_MS: u64 = 20;
 
-/// What a write that never arrived looks like on this backend: the accessibility API accepts a
-/// value the toolkit never applies, which is a read-only projection rather than a lost write.
-const READ_ONLY_PROJECTION: &str = "this element's accessibility value may be a read-only projection that accepts a write without \
-     applying it — focus the element and type into it instead";
+/// What a write that took no effect looks like on this backend: the accessibility API accepts a
+/// value the toolkit never applies. Twin of the const in `glass-a11y-macos/src/reader.rs`.
+const READ_ONLY_PROJECTION: &str = "this element's accessibility value may be a read-only projection that accepts a write \
+     without applying it — focus the element and type into it instead";
 
 #[derive(Default)]
 pub struct WindowsA11y;
@@ -459,12 +460,19 @@ fn run_set_value(ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
             return Ok(());
         }
         if Instant::now() >= deadline {
-            return Err(GlassError::value_not_applied_because(
-                target.id.0,
-                text,
-                after.as_deref(),
-                READ_ONLY_PROJECTION,
-            ));
+            // A projection that accepted the write and kept its value is what this explains. A read
+            // that failed, or one showing a value the element reformatted, is not evidence of it.
+            return Err(match after.as_deref() {
+                Some(seen) if write_took_no_effect(seen, before.as_deref()) => {
+                    GlassError::value_not_applied_because(
+                        target.id.0,
+                        text,
+                        Some(seen),
+                        READ_ONLY_PROJECTION,
+                    )
+                }
+                seen => GlassError::value_not_applied(target.id.0, text, seen),
+            });
         }
         std::thread::sleep(Duration::from_millis(VERIFY_POLL_MS));
     }

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -428,8 +428,8 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
 /// The read-back's own failure, reported as an unconfirmed write.
 ///
 /// For a read-back loop only, which is what makes it post-dispatch: `AndroidA11y`'s keystrokes and
-/// `ServiceA11y`'s `ACTION_SET_TEXT` have both gone out by the time either calls this. A verdict `GlassError::set_value_failed_after_writing` rejects would leave the session
-/// holding the value it cached for a write that already landed, and refuse the retry as drift.
+/// `ServiceA11y`'s `ACTION_SET_TEXT` have both gone out by the time either calls this, so a verdict
+/// `GlassError::set_value_failed_after_writing` rejects would refuse the retry as drift.
 pub(crate) fn read_back_failed(target: &AxTarget, e: &GlassError) -> GlassError {
     GlassError::AxWriteUnconfirmed(target.id.0, format!("reading the element back failed: {e}"))
 }

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -11,7 +11,7 @@ use glass_core::accessibility::{
 };
 use glass_core::{
     GlassError, KeyEvent, MouseButton, PointerEvent, Result, WindowGeometry, typed_clear_landed,
-    typed_text_landed,
+    typed_text_landed, write_took_no_effect,
 };
 
 use crate::adb::{Adb, AdbOp};
@@ -406,25 +406,35 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
     } else {
         // The mapper drops an empty value, so an empty field arrives as `None` — which the verdict
         // reserves for a reading nobody took.
-        Err(GlassError::value_not_applied_because(
-            target.id.0,
-            text,
-            Some(node.value.as_deref().unwrap_or("")),
-            TAP_MAY_HAVE_MISSED,
-        ))
+        let observed = node.value.as_deref().unwrap_or("");
+        // Only where the field never moved: on a value the element transformed — an iOS field
+        // autocapitalizing a typed lowercase letter (glass#363) — the tap landed, and telling the
+        // caller to write again contradicts the sentence this clause hangs off.
+        Err(
+            if write_took_no_effect(observed, Some(target.value.as_deref().unwrap_or(""))) {
+                GlassError::value_not_applied_because(
+                    target.id.0,
+                    text,
+                    Some(observed),
+                    TAP_MAY_HAVE_MISSED,
+                )
+            } else {
+                GlassError::value_not_applied(target.id.0, text, Some(observed))
+            },
+        )
     }
 }
 
 /// The read-back's own failure, reported as an unconfirmed write.
 ///
-/// Post-dispatch by construction: its only caller is the loop that runs after the keystrokes went
-/// out. A verdict `GlassError::set_value_failed_after_writing` rejects would leave the session
+/// For a read-back loop only, which is what makes it post-dispatch: `AndroidA11y`'s keystrokes and
+/// `ServiceA11y`'s `ACTION_SET_TEXT` have both gone out by the time either calls this. A verdict `GlassError::set_value_failed_after_writing` rejects would leave the session
 /// holding the value it cached for a write that already landed, and refuse the retry as drift.
 pub(crate) fn read_back_failed(target: &AxTarget, e: &GlassError) -> GlassError {
     GlassError::AxWriteUnconfirmed(target.id.0, format!("reading the element back failed: {e}"))
 }
 
-/// What a write that never arrived looks like on this backend: `set_value` types, so the tap that
+/// What a write that took no effect looks like on this backend: `set_value` types, so the tap that
 /// aims the keystrokes is the part that can miss. Twin of the const in `glass-ios/src/a11y.rs`.
 const TAP_MAY_HAVE_MISSED: &str = "this write is a tap and then keystrokes, so the tap may have missed the element — writing \
      again is worth one attempt";
@@ -737,9 +747,9 @@ impl Accessibility for AndroidA11y {
 #[cfg(test)]
 mod tests {
     use super::{
-        Attempt, COLD_BOUND, RetryBound, Warmth, bound_fired, dump_once, dump_until_ready,
-        editable_target, locate_editable_target, locate_for_write, read_back_failed,
-        snapshot_bound, snapshot_with_runner, verify_write,
+        Attempt, COLD_BOUND, RetryBound, TAP_MAY_HAVE_MISSED, Warmth, bound_fired, dump_once,
+        dump_until_ready, editable_target, locate_editable_target, locate_for_write,
+        read_back_failed, snapshot_bound, snapshot_with_runner, verify_write,
     };
     use crate::adb::{AdbOp, a_failed_call, a_real_spawn_failure, a_real_timeout_hinted};
     use glass_core::accessibility::{
@@ -1961,18 +1971,25 @@ mod tests {
     }
 
     /// Pin the whole verdict, not the variant: the two values it names are what a caller acts on
-    /// (glass#363). Twin of the helper in `glass-ios/src/a11y.rs`.
+    /// (glass#363), and `why` attaches only to a field that never moved (glass#405). Twin of the
+    /// helper in `glass-ios/src/a11y.rs`.
     #[track_caller]
-    fn assert_not_applied(outcome: Result<()>, id: u32, requested: &str, observed: Option<&str>) {
+    fn assert_not_applied(
+        outcome: Result<()>,
+        id: u32,
+        requested: &str,
+        observed: Option<&str>,
+        why: Option<&str>,
+    ) {
         match outcome {
             Err(GlassError::AxValueNotApplied {
                 id: got_id,
                 requested: req,
                 observed: obs,
-                ..
+                why: got_why,
             }) => assert_eq!(
-                (got_id, req.as_str(), obs.as_deref()),
-                (id, requested, observed)
+                (got_id, req.as_str(), obs.as_deref(), got_why),
+                (id, requested, observed, why)
             ),
             other => panic!("expected a not-applied verdict, got {other:?}"),
         }
@@ -1986,7 +2003,13 @@ mod tests {
         // takes focus, which is the false success this check exists to prevent.
         let after = tree_holding(Some("Search settings"));
         let t = target(0, Some("Search"), Some(BOUNDS));
-        assert_not_applied(verify_write(&after, &t, ""), 0, "", Some("Search settings"));
+        assert_not_applied(
+            verify_write(&after, &t, ""),
+            0,
+            "",
+            Some("Search settings"),
+            None,
+        );
     }
 
     #[test]
@@ -1994,7 +2017,13 @@ mod tests {
         // The case `verify_write`'s doc is about: the field still holds the old text.
         let after = tree_holding(Some("hello"));
         let t = target(0, Some("Search"), Some(BOUNDS));
-        assert_not_applied(verify_write(&after, &t, "world"), 0, "world", Some("hello"));
+        assert_not_applied(
+            verify_write(&after, &t, "world"),
+            0,
+            "world",
+            Some("hello"),
+            None,
+        );
     }
 
     #[test]
@@ -2003,7 +2032,15 @@ mod tests {
         // report as empty, not as a reading nobody took.
         let after = tree_holding(None);
         let t = target(0, Some("Search"), Some(BOUNDS));
-        assert_not_applied(verify_write(&after, &t, "world"), 0, "world", Some(""));
+        assert_not_applied(
+            verify_write(&after, &t, "world"),
+            0,
+            "world",
+            Some(""),
+            // Nothing before, nothing now: the write took no effect, and this backend's own
+            // explanation of that closes the message.
+            Some(TAP_MAY_HAVE_MISSED),
+        );
     }
 
     #[test]
@@ -2011,7 +2048,13 @@ mod tests {
         // The reason the rule is an exact match; `typed_text_landed` carries the argument.
         let after = tree_holding(Some("worl"));
         let t = target(0, Some("Search"), Some(BOUNDS));
-        assert_not_applied(verify_write(&after, &t, "world"), 0, "world", Some("worl"));
+        assert_not_applied(
+            verify_write(&after, &t, "world"),
+            0,
+            "world",
+            Some("worl"),
+            None,
+        );
     }
 
     #[test]
@@ -2026,6 +2069,7 @@ mod tests {
             0,
             "1234567890",
             Some("(123) 456-7890"),
+            None,
         );
     }
 
@@ -2044,11 +2088,17 @@ mod tests {
         // Re-finding must not weaken the value check: the field is found, and holds the wrong text.
         let after = under_a_container(tree_holding(Some("worl")));
         let t = target(0, Some("Search"), Some(BOUNDS));
-        assert_not_applied(verify_write(&after, &t, "world"), 0, "world", Some("worl"));
+        assert_not_applied(
+            verify_write(&after, &t, "world"),
+            0,
+            "world",
+            Some("worl"),
+            None,
+        );
     }
 
     #[test]
-    fn a_write_whose_screen_was_replaced_says_it_was_typed_but_unconfirmed() {
+    fn a_write_whose_screen_was_replaced_says_it_went_out_but_is_unconfirmed() {
         // glass#323's other half: the kill can land between the write and the read-back, which
         // is where four of the nine observed refusals came from.
         let err = verify_write(
@@ -2058,7 +2108,7 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(err, GlassError::AxWriteUnconfirmed(0, _)), "{err}");
-        assert!(err.to_string().contains("the text was typed"), "{err}");
+        assert!(err.to_string().contains("the write went out"), "{err}");
         assert!(err.to_string().contains("replaced"), "{err}");
     }
 

--- a/crates/glass-android/src/a11y.rs
+++ b/crates/glass-android/src/a11y.rs
@@ -406,10 +406,11 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
     } else {
         // The mapper drops an empty value, so an empty field arrives as `None` — which the verdict
         // reserves for a reading nobody took.
-        Err(GlassError::value_not_applied(
+        Err(GlassError::value_not_applied_because(
             target.id.0,
             text,
             Some(node.value.as_deref().unwrap_or("")),
+            TAP_MAY_HAVE_MISSED,
         ))
     }
 }
@@ -419,9 +420,14 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
 /// Post-dispatch by construction: its only caller is the loop that runs after the keystrokes went
 /// out. A verdict `GlassError::set_value_failed_after_writing` rejects would leave the session
 /// holding the value it cached for a write that already landed, and refuse the retry as drift.
-fn read_back_failed(target: &AxTarget, e: &GlassError) -> GlassError {
+pub(crate) fn read_back_failed(target: &AxTarget, e: &GlassError) -> GlassError {
     GlassError::AxWriteUnconfirmed(target.id.0, format!("reading the element back failed: {e}"))
 }
+
+/// What a write that never arrived looks like on this backend: `set_value` types, so the tap that
+/// aims the keystrokes is the part that can miss. Twin of the const in `glass-ios/src/a11y.rs`.
+const TAP_MAY_HAVE_MISSED: &str = "this write is a tap and then keystrokes, so the tap may have missed the element — writing \
+     again is worth one attempt";
 
 /// How many times to read the element back before reporting the write as not applied. A landed
 /// write confirms on the first read and pays for one; the retries exist for a field that commits a
@@ -1963,6 +1969,7 @@ mod tests {
                 id: got_id,
                 requested: req,
                 observed: obs,
+                ..
             }) => assert_eq!(
                 (got_id, req.as_str(), obs.as_deref()),
                 (id, requested, observed)
@@ -2438,7 +2445,7 @@ mod tests {
             .set_value(&ctx, &field, "world")
             .expect_err("a field still holding the old text has not taken the write");
         assert!(
-            matches!(&err, GlassError::AxValueNotApplied { id: 1, requested, observed }
+            matches!(&err, GlassError::AxValueNotApplied { id: 1, requested, observed, .. }
                 if requested == "world" && observed.as_deref() == Some("hello")),
             "{err}"
         );

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -11,7 +11,7 @@ use glass_core::accessibility::{
     AxTree, Subject, TruncationLimit, WalkBudget, WalkLimits,
 };
 use glass_core::platform::WindowGeometry;
-use glass_core::{GlassError, Result};
+use glass_core::{GlassError, Result, write_took_no_effect};
 
 use crate::axmap::{LabelInputs, class_to_role, labels};
 use crate::conn::{CallFailure, Conn};
@@ -333,13 +333,17 @@ impl ServiceClient {
     /// Fire `ACTION_SET_TEXT` on device node `ref_id`. Idempotent, so this takes the
     /// reconnecting path. `package` never reaches the wire here — it only re-arms a
     /// reconnected connection's `tree` call — see [`Self::call_with`].
-    fn set_text(&self, ref_id: u32, text: &str, package: &str) -> Result<()> {
+    fn set_text(
+        &self,
+        ref_id: u32,
+        text: &str,
+        package: &str,
+    ) -> std::result::Result<(), CallFailure> {
         self.call(
             json!({"op": "action", "ref": ref_id, "action": "set_text", "text": text}),
             Some(package),
         )
         .map(|_| ())
-        .map_err(CallFailure::into_error)
     }
 }
 
@@ -390,6 +394,9 @@ pub struct ServiceA11y {
     package: String,
     /// How long [`Self::wait_for_check`] polls; [`CHECK_TIMEOUT`] outside tests.
     check_timeout: std::time::Duration,
+    /// How long [`Accessibility::set_value`] polls for the write; [`WRITE_VERIFY_BUDGET`] outside
+    /// tests.
+    write_verify_budget: std::time::Duration,
 }
 
 impl ServiceA11y {
@@ -398,6 +405,7 @@ impl ServiceA11y {
             client,
             package,
             check_timeout: CHECK_TIMEOUT,
+            write_verify_budget: WRITE_VERIFY_BUDGET,
         }
     }
 
@@ -485,10 +493,20 @@ impl Drop for ReadBound<'_> {
     }
 }
 
-/// What a write that never arrived looks like on this backend: `ACTION_SET_TEXT` reports success
+/// What a write that took no effect looks like on this backend: `ACTION_SET_TEXT` reports success
 /// and silently does nothing when it would *replace* text already in a Compose field.
+///
+/// `GLASS_ANDROID_A11Y=off`, not unsetting `GLASS_ANDROID_A11Y_APK`: the apk is also picked up from
+/// the data dirs and from beside the binary, so unsetting the path leaves this reader selected.
 const COMPOSE_SET_TEXT_NO_OP: &str = "a Compose field that already holds text cannot be replaced via ACTION_SET_TEXT — clear it \
-     first, or unset GLASS_ANDROID_A11Y_APK to use the uiautomator backend";
+     first, or set GLASS_ANDROID_A11Y=off to use the uiautomator backend";
+
+/// How long [`ServiceA11y::set_value`] polls for a write to reach the tree, and the gap between
+/// those reads. Separate from [`CHECK_TIMEOUT`]: a recompose reaching accessibility is not the same
+/// wait as a control's state settling, and a test bounding one must not silently bound the other.
+const WRITE_VERIFY_BUDGET: std::time::Duration = std::time::Duration::from_secs(2);
+/// See [`WRITE_VERIFY_BUDGET`].
+const WRITE_VERIFY_POLL: std::time::Duration = std::time::Duration::from_millis(150);
 
 impl Accessibility for ServiceA11y {
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
@@ -503,12 +521,13 @@ impl Accessibility for ServiceA11y {
         // that ever relaxes into a search cannot dispatch to a node it never approved.
         let device_ref = rt.device_ref(resolved_editable_target(&rt.tree, target)?.id)?;
         self.client
-            .set_text(device_ref, text, rt.acting_on(&self.package))?;
+            .set_text(device_ref, text, rt.acting_on(&self.package))
+            .map_err(|f| write_error(target.id.0, f))?;
         // Verify the value actually took. ACTION_SET_TEXT returns success but silently no-ops when
         // *replacing* existing text in a Compose field, so a bare Ok could lie (glass forbids silent
         // fallbacks). The set is async (Compose recompose → a11y update), so poll briefly for the
         // value to land; error honestly only on timeout.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        let deadline = std::time::Instant::now() + self.write_verify_budget;
         loop {
             // Every exit below this point is post-dispatch, so each must be a verdict
             // `set_value_failed_after_writing` accepts — otherwise the session keeps the value it
@@ -516,18 +535,25 @@ impl Accessibility for ServiceA11y {
             let after = self
                 .snapshot(ctx)
                 .map_err(|e| crate::a11y::read_back_failed(target, &e))?;
-            let node = after.find(target.id);
-            let got = node.and_then(|n| n.value.clone());
-            // An empty field reports no value (None), not Some(""), so compare against "".
-            if got.as_deref().unwrap_or("") == text {
-                return Ok(());
-            }
-            // A field that has stopped reporting `editable` — a submit collapsing it to a display
-            // row, focus lost — also reports no value, which reads exactly like a write that never
-            // landed. Spending the rest of the budget to then blame the write would send the
-            // caller to clear a field that is already correct and to switch backends for nothing.
-            // `AndroidA11y`'s `verify_write` re-checks the same flag for the same reason.
-            if node.is_some_and(|n| !n.states.editable) {
+            // A node that is not there at all is not an empty field: `find` and an emptied value
+            // both answer `None`, and folding them together confirms a clear on the evidence that
+            // the element could not be found. Keep polling — a tree mid-update loses it briefly.
+            let Some(node) = after.find(target.id) else {
+                if std::time::Instant::now() >= deadline {
+                    return Err(GlassError::AxWriteUnconfirmed(
+                        target.id.0,
+                        "the element is no longer in the tree, so its value could not be read back"
+                            .into(),
+                    ));
+                }
+                std::thread::sleep(WRITE_VERIFY_POLL);
+                continue;
+            };
+            // Before the value check, not after: a node that stopped reporting `editable` — a
+            // submit collapsing it to a display row, focus lost — has its text mapped to `name`
+            // and reports no value, so `"" == ""` would confirm a *clear* on the evidence that the
+            // field stopped being a field. `AndroidA11y`'s `verify_write` re-checks the flag too.
+            if !node.states.editable {
                 return Err(GlassError::AxWriteUnconfirmed(
                     target.id.0,
                     "the element no longer reports itself editable, so its value cannot be read \
@@ -535,17 +561,29 @@ impl Accessibility for ServiceA11y {
                         .into(),
                 ));
             }
-            if std::time::Instant::now() >= deadline {
-                return Err(GlassError::value_not_applied_because(
-                    target.id.0,
-                    text,
-                    // This reader keeps `Some("")` for an emptied field; the verdict reserves
-                    // `None` for a reading nobody took.
-                    Some(got.as_deref().unwrap_or("")),
-                    COMPOSE_SET_TEXT_NO_OP,
-                ));
+            let got = node.value.clone();
+            // An empty field reports no value (None), not Some(""), so compare against "".
+            if got.as_deref().unwrap_or("") == text {
+                return Ok(());
             }
-            std::thread::sleep(std::time::Duration::from_millis(150));
+            if std::time::Instant::now() >= deadline {
+                // The mapper drops an empty value, so an emptied field arrives as `None` — which
+                // the verdict reserves for a reading nobody took.
+                let observed = got.as_deref().unwrap_or("");
+                // The clause explains a field that never moved; on one holding something else the
+                // write did reach it, and "clear it first" would name a field already empty.
+                return Err(if write_took_no_effect(observed, target.value.as_deref()) {
+                    GlassError::value_not_applied_because(
+                        target.id.0,
+                        text,
+                        Some(observed),
+                        COMPOSE_SET_TEXT_NO_OP,
+                    )
+                } else {
+                    GlassError::value_not_applied(target.id.0, text, Some(observed))
+                });
+            }
+            std::thread::sleep(WRITE_VERIFY_POLL);
         }
     }
 
@@ -1087,6 +1125,26 @@ fn disabled_error(target: u32, disabled: AxNodeId) -> GlassError {
             disabled.0
         ),
     )
+}
+
+/// Map a `set_text` failure onto the `set_value` contract. Only `NotSent` proves nothing was
+/// written: the other two may already have set the field, so they answer in a verdict
+/// `set_value_failed_after_writing` accepts, or the session keeps a value the device has moved past
+/// and refuses the retry as drift (glass#405).
+fn write_error(target: u32, f: CallFailure) -> GlassError {
+    match f {
+        CallFailure::NotSent(e) => GlassError::AccessibilityUnavailable(format!(
+            "the write to element {target} could not be sent: {e}"
+        )),
+        CallFailure::AnswerLost(e) => GlassError::AxWriteUnconfirmed(
+            target,
+            format!("the write was sent and its result was lost ({e})"),
+        ),
+        CallFailure::Refused(e) => GlassError::AxWriteUnconfirmed(
+            target,
+            format!("the device answered the write with something unreadable ({e})"),
+        ),
+    }
 }
 
 /// Map a click failure onto the invoke contract. No arm is fallback-eligible: a refusal may
@@ -2807,9 +2865,10 @@ mod tests {
         );
         let client = ServiceClient::connect(port).expect("connect to the fake service");
         client.tree("com.example.app").expect("primes conn1");
-        client
-            .set_text(1, "hi", "com.example.app")
-            .expect("re-arm confirms the same package, so the resend goes through");
+        assert!(
+            client.set_text(1, "hi", "com.example.app").is_ok(),
+            "re-arm confirms the same package, so the resend goes through"
+        );
         assert_eq!(
             ops_of(&ops),
             vec![
@@ -2836,10 +2895,10 @@ mod tests {
         );
         let client = ServiceClient::connect(port).expect("connect to the fake service");
         client.tree("com.example.app").expect("primes conn1");
-        let e = client
-            .set_text(1, "hi", "com.example.app")
-            .expect_err("a different foreground must refuse the resend");
-        let msg = e.to_string();
+        let Err(f) = client.set_text(1, "hi", "com.example.app") else {
+            panic!("a different foreground must refuse the resend");
+        };
+        let msg = f.into_error().to_string();
         assert!(msg.contains("com.example.app"), "{msg}");
         assert!(msg.contains("com.other.app"), "{msg}");
         assert!(msg.contains("moved"), "{msg}");
@@ -2865,10 +2924,10 @@ mod tests {
         );
         let client = ServiceClient::connect(port).expect("connect to the fake service");
         client.tree("com.example.app").expect("primes conn1");
-        let e = client
-            .set_text(1, "hi", "com.example.app")
-            .expect_err("an unconfirmed foreground must refuse the resend");
-        let msg = e.to_string();
+        let Err(f) = client.set_text(1, "hi", "com.example.app") else {
+            panic!("an unconfirmed foreground must refuse the resend");
+        };
+        let msg = f.into_error().to_string();
         assert!(msg.contains("com.example.app"), "{msg}");
         assert!(msg.contains("could not confirm"), "{msg}");
         assert!(!msg.contains("moved"), "{msg}");
@@ -3611,14 +3670,22 @@ mod tests {
         v
     }
 
+    /// A reader whose write-verify budget is spent, so a timeout costs no wall clock.
+    fn impatient_writer(port: u16) -> ServiceA11y {
+        let client = ServiceClient::connect(port).expect("connect to the fake service");
+        let mut a = ServiceA11y::new(client, "com.example.app".to_string());
+        a.write_verify_budget = std::time::Duration::ZERO;
+        a
+    }
+
     #[test]
     fn a_write_that_never_lands_names_both_values_and_the_compose_no_op() {
         // ACTION_SET_TEXT reports success and does nothing when it would replace text already in a
         // Compose field, which is a fact only this backend knows — the shared message is written
-        // for no backend in particular (glass#405).
+        // for no backend in particular (glass#405). The verdict must also be one the session reads
+        // as post-dispatch, or it keeps the value it cached and refuses the retry as drift.
         let (port, _ops) = fake_service(vec![editable_field("old")], OnAction::Ok);
-        let client = ServiceClient::connect(port).expect("connect to the fake service");
-        let mut a = ServiceA11y::new(client, "com.example.app".to_string());
+        let mut a = impatient_writer(port);
         let t = built(&editable_field("old"));
 
         let err = a
@@ -3628,24 +3695,91 @@ mod tests {
             matches!(&err, GlassError::AxValueNotApplied { id: 1, requested, observed, why }
                 if requested == "new"
                     && observed.as_deref() == Some("old")
-                    && why.is_some_and(|w| w.contains("ACTION_SET_TEXT"))),
+                    && why.is_some_and(|w| w.contains("ACTION_SET_TEXT")
+                        && w.contains("GLASS_ANDROID_A11Y=off"))),
+            "{err}"
+        );
+        assert!(err.set_value_failed_after_writing(), "{err}");
+    }
+
+    #[test]
+    fn a_field_holding_something_neither_value_gets_no_compose_explanation() {
+        // The clause says a field that already holds text cannot be replaced, and tells the caller
+        // to clear it. A field holding something the write put there was not refused.
+        let (port, _ops) = fake_service(
+            vec![editable_field("old"), editable_field("filtered")],
+            OnAction::Ok,
+        );
+        let mut a = impatient_writer(port);
+        let t = built(&editable_field("old"));
+        let target = target_for(&t, AxNodeId(1));
+
+        let err = a
+            .set_value(&ctx(), &target, "new")
+            .expect_err("the field holds neither the request nor what it held");
+        assert!(
+            matches!(&err, GlassError::AxValueNotApplied { observed, why: None, .. }
+                if observed.as_deref() == Some("filtered")),
             "{err}"
         );
     }
 
     #[test]
-    fn a_write_that_never_lands_invalidates_the_sessions_cached_value() {
-        // The verdict is raised after `set_text` went out, so it must be one the session treats as
-        // post-dispatch — otherwise it keeps the value it cached for a write that dispatched, and
-        // the guard refuses the retry as drift (glass#405).
-        let (port, _ops) = fake_service(vec![editable_field("old")], OnAction::Ok);
-        let client = ServiceClient::connect(port).expect("connect to the fake service");
-        let mut a = ServiceA11y::new(client, "com.example.app".to_string());
+    fn a_clear_is_not_confirmed_by_a_field_that_stopped_being_editable() {
+        // A collapsed row maps its text to `name` and reports no value, so an unguarded `"" == ""`
+        // confirms a clear that may never have fired. The editable check runs first to stop that;
+        // move it back below the value check and this is the only test that notices.
+        let (port, _ops) = fake_service(
+            vec![editable_field("old"), settled_field("old")],
+            OnAction::Ok,
+        );
+        let mut a = impatient_writer(port);
+        let t = built(&editable_field("old"));
+
+        let err = a
+            .set_value(&ctx(), &target_for(&t, AxNodeId(1)), "")
+            .expect_err("an element that stopped being a field cannot confirm a clear");
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(1, _)), "{err}");
+    }
+
+    #[test]
+    fn an_element_gone_from_the_tree_is_unconfirmed_rather_than_an_empty_reading() {
+        // `find` answers `None` for a node that is gone and for one holding nothing. Folding them
+        // together reports a reading nobody took — and confirms a clear, since `"" == ""`.
+        let (port, _ops) = fake_service(
+            vec![
+                editable_field("old"),
+                json!({"class": "android.widget.FrameLayout",
+                       "bounds": {"x": 0, "y": 0, "w": 1080, "h": 2400}, "children": []}),
+            ],
+            OnAction::Ok,
+        );
+        let mut a = impatient_writer(port);
+        let t = built(&editable_field("old"));
+
+        let err = a
+            .set_value(&ctx(), &target_for(&t, AxNodeId(1)), "")
+            .expect_err("a clear cannot be confirmed by an element that left the tree");
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(1, _)), "{err}");
+        assert!(err.to_string().contains("no longer in the tree"), "{err}");
+    }
+
+    #[test]
+    fn a_write_whose_answer_was_lost_is_unconfirmed_rather_than_never_sent() {
+        // `AnswerLost` means the request went out and may have run, so the session must drop the
+        // value it cached — the same reasoning `action_error` applies to a click (glass#405).
+        let (port, _ops) = fake_service_ex(
+            vec![editable_field("old")],
+            vec![OnAction::DropWithoutAnswering],
+            vec![TreePackage::Other("com.other.app".into())],
+        );
+        let mut a = impatient_writer(port);
         let t = built(&editable_field("old"));
 
         let err = a
             .set_value(&ctx(), &target_for(&t, AxNodeId(1)), "new")
-            .expect_err("the field never takes the value");
+            .expect_err("the reconnect cannot re-send into a different foreground app");
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(1, _)), "{err}");
         assert!(err.set_value_failed_after_writing(), "{err}");
     }
 
@@ -3657,8 +3791,7 @@ mod tests {
             vec![editable_field("old"), settled_field("old")],
             OnAction::Ok,
         );
-        let client = ServiceClient::connect(port).expect("connect to the fake service");
-        let mut a = ServiceA11y::new(client, "com.example.app".to_string());
+        let mut a = impatient_writer(port);
         let t = built(&editable_field("old"));
 
         let err = a
@@ -3678,8 +3811,7 @@ mod tests {
             vec![TreePackage::Echo],
             vec![OnTree::Serve, OnTree::Refused("no active window")],
         );
-        let client = ServiceClient::connect(port).expect("connect to the fake service");
-        let mut a = ServiceA11y::new(client, "com.example.app".to_string());
+        let mut a = impatient_writer(port);
         let t = built(&editable_field("old"));
 
         let err = a
@@ -3687,6 +3819,9 @@ mod tests {
             .expect_err("the verification read is refused");
         assert!(matches!(err, GlassError::AxWriteUnconfirmed(1, _)), "{err}");
         assert!(err.set_value_failed_after_writing(), "{err}");
+        // The wrap exists to carry the cause; without it the caller learns only that something
+        // could not be confirmed.
+        assert!(err.to_string().contains("no active window"), "{err}");
     }
 
     #[test]

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -485,6 +485,11 @@ impl Drop for ReadBound<'_> {
     }
 }
 
+/// What a write that never arrived looks like on this backend: `ACTION_SET_TEXT` reports success
+/// and silently does nothing when it would *replace* text already in a Compose field.
+const COMPOSE_SET_TEXT_NO_OP: &str = "a Compose field that already holds text cannot be replaced via ACTION_SET_TEXT — clear it \
+     first, or unset GLASS_ANDROID_A11Y_APK to use the uiautomator backend";
+
 impl Accessibility for ServiceA11y {
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
         Ok(self.snapshot_with_refs(ctx)?.tree)
@@ -505,7 +510,12 @@ impl Accessibility for ServiceA11y {
         // value to land; error honestly only on timeout.
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
         loop {
-            let after = self.snapshot(ctx)?;
+            // Every exit below this point is post-dispatch, so each must be a verdict
+            // `set_value_failed_after_writing` accepts — otherwise the session keeps the value it
+            // cached for a write that went out, and refuses the retry as drift (glass#405).
+            let after = self
+                .snapshot(ctx)
+                .map_err(|e| crate::a11y::read_back_failed(target, &e))?;
             let node = after.find(target.id);
             let got = node.and_then(|n| n.value.clone());
             // An empty field reports no value (None), not Some(""), so compare against "".
@@ -518,20 +528,22 @@ impl Accessibility for ServiceA11y {
             // caller to clear a field that is already correct and to switch backends for nothing.
             // `AndroidA11y`'s `verify_write` re-checks the same flag for the same reason.
             if node.is_some_and(|n| !n.states.editable) {
-                return Err(GlassError::AccessibilityUnavailable(format!(
-                    "set_value on element {} was sent, but the element no longer reports itself \
-                     editable, so its value cannot be read back; re-snapshot to see what it holds \
-                     rather than retyping",
-                    target.id.0
-                )));
+                return Err(GlassError::AxWriteUnconfirmed(
+                    target.id.0,
+                    "the element no longer reports itself editable, so its value cannot be read \
+                     back"
+                        .into(),
+                ));
             }
             if std::time::Instant::now() >= deadline {
-                return Err(GlassError::Backend(format!(
-                    "set_value on element {} did not take (field is {got:?}, wanted {text:?}); a \
-                     Compose field that already holds text can't be replaced via ACTION_SET_TEXT — \
-                     clear it first or unset GLASS_ANDROID_A11Y_APK to use the uiautomator backend",
-                    target.id.0
-                )));
+                return Err(GlassError::value_not_applied_because(
+                    target.id.0,
+                    text,
+                    // This reader keeps `Some("")` for an emptied field; the verdict reserves
+                    // `None` for a reading nobody took.
+                    Some(got.as_deref().unwrap_or("")),
+                    COMPOSE_SET_TEXT_NO_OP,
+                ));
             }
             std::thread::sleep(std::time::Duration::from_millis(150));
         }
@@ -3589,6 +3601,92 @@ mod tests {
         let mut v = editable_field(value);
         v["children"][0]["bounds"] = json!({"x": dx, "y": 100, "w": 600, "h": 120});
         v
+    }
+
+    /// [`editable_field`] with the field no longer editable — a submit collapsing it to a display
+    /// row, which reports no value exactly as a lost write does.
+    fn settled_field(value: &str) -> Value {
+        let mut v = editable_field(value);
+        v["children"][0]["editable"] = json!(false);
+        v
+    }
+
+    #[test]
+    fn a_write_that_never_lands_names_both_values_and_the_compose_no_op() {
+        // ACTION_SET_TEXT reports success and does nothing when it would replace text already in a
+        // Compose field, which is a fact only this backend knows — the shared message is written
+        // for no backend in particular (glass#405).
+        let (port, _ops) = fake_service(vec![editable_field("old")], OnAction::Ok);
+        let client = ServiceClient::connect(port).expect("connect to the fake service");
+        let mut a = ServiceA11y::new(client, "com.example.app".to_string());
+        let t = built(&editable_field("old"));
+
+        let err = a
+            .set_value(&ctx(), &target_for(&t, AxNodeId(1)), "new")
+            .expect_err("the field never takes the value");
+        assert!(
+            matches!(&err, GlassError::AxValueNotApplied { id: 1, requested, observed, why }
+                if requested == "new"
+                    && observed.as_deref() == Some("old")
+                    && why.is_some_and(|w| w.contains("ACTION_SET_TEXT"))),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn a_write_that_never_lands_invalidates_the_sessions_cached_value() {
+        // The verdict is raised after `set_text` went out, so it must be one the session treats as
+        // post-dispatch — otherwise it keeps the value it cached for a write that dispatched, and
+        // the guard refuses the retry as drift (glass#405).
+        let (port, _ops) = fake_service(vec![editable_field("old")], OnAction::Ok);
+        let client = ServiceClient::connect(port).expect("connect to the fake service");
+        let mut a = ServiceA11y::new(client, "com.example.app".to_string());
+        let t = built(&editable_field("old"));
+
+        let err = a
+            .set_value(&ctx(), &target_for(&t, AxNodeId(1)), "new")
+            .expect_err("the field never takes the value");
+        assert!(err.set_value_failed_after_writing(), "{err}");
+    }
+
+    #[test]
+    fn a_field_that_stopped_being_editable_is_unconfirmed_and_post_dispatch() {
+        // Its value cannot be read back, so the write is unconfirmed rather than refused — and the
+        // keystrokes went out either way, so the session must drop its cached value.
+        let (port, _ops) = fake_service(
+            vec![editable_field("old"), settled_field("old")],
+            OnAction::Ok,
+        );
+        let client = ServiceClient::connect(port).expect("connect to the fake service");
+        let mut a = ServiceA11y::new(client, "com.example.app".to_string());
+        let t = built(&editable_field("old"));
+
+        let err = a
+            .set_value(&ctx(), &target_for(&t, AxNodeId(1)), "new")
+            .expect_err("a field that stopped reporting editable cannot confirm the write");
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(1, _)), "{err}");
+        assert!(err.set_value_failed_after_writing(), "{err}");
+    }
+
+    #[test]
+    fn a_read_back_that_fails_is_unconfirmed_and_post_dispatch() {
+        // The read-back runs after `set_text`, so its own failure must not propagate raw: every
+        // transport verdict is classified pre-dispatch, which would keep the stale cached value.
+        let (port, _ops) = fake_service_full(
+            vec![editable_field("old")],
+            vec![OnAction::Ok],
+            vec![TreePackage::Echo],
+            vec![OnTree::Serve, OnTree::Refused("no active window")],
+        );
+        let client = ServiceClient::connect(port).expect("connect to the fake service");
+        let mut a = ServiceA11y::new(client, "com.example.app".to_string());
+        let t = built(&editable_field("old"));
+
+        let err = a
+            .set_value(&ctx(), &target_for(&t, AxNodeId(1)), "new")
+            .expect_err("the verification read is refused");
+        assert!(matches!(err, GlassError::AxWriteUnconfirmed(1, _)), "{err}");
+        assert!(err.set_value_failed_after_writing(), "{err}");
     }
 
     #[test]

--- a/crates/glass-android/src/a11y_service.rs
+++ b/crates/glass-android/src/a11y_service.rs
@@ -529,15 +529,15 @@ impl Accessibility for ServiceA11y {
         // value to land; error honestly only on timeout.
         let deadline = std::time::Instant::now() + self.write_verify_budget;
         loop {
-            // Every exit below this point is post-dispatch, so each must be a verdict
-            // `set_value_failed_after_writing` accepts — otherwise the session keeps the value it
-            // cached for a write that went out, and refuses the retry as drift (glass#405).
+            // Every exit below is post-dispatch, so each must be a verdict
+            // `set_value_failed_after_writing` accepts, or the session keeps the value it cached
+            // for a write that went out and refuses the retry as drift (glass#405).
             let after = self
                 .snapshot(ctx)
                 .map_err(|e| crate::a11y::read_back_failed(target, &e))?;
-            // A node that is not there at all is not an empty field: `find` and an emptied value
-            // both answer `None`, and folding them together confirms a clear on the evidence that
-            // the element could not be found. Keep polling — a tree mid-update loses it briefly.
+            // `find` answers `None` for a node that is gone and for one holding nothing, and
+            // folding them together confirms a clear on the evidence that the element could not be
+            // found. Keep polling — a tree mid-update loses it briefly.
             let Some(node) = after.find(target.id) else {
                 if std::time::Instant::now() >= deadline {
                     return Err(GlassError::AxWriteUnconfirmed(
@@ -549,9 +549,8 @@ impl Accessibility for ServiceA11y {
                 std::thread::sleep(WRITE_VERIFY_POLL);
                 continue;
             };
-            // Before the value check, not after: a node that stopped reporting `editable` — a
-            // submit collapsing it to a display row, focus lost — has its text mapped to `name`
-            // and reports no value, so `"" == ""` would confirm a *clear* on the evidence that the
+            // Before the value check, not after: a collapsed row maps its text to `name` and
+            // reports no value, so `"" == ""` would confirm a *clear* on the evidence that the
             // field stopped being a field. `AndroidA11y`'s `verify_write` re-checks the flag too.
             if !node.states.editable {
                 return Err(GlassError::AxWriteUnconfirmed(
@@ -1128,9 +1127,8 @@ fn disabled_error(target: u32, disabled: AxNodeId) -> GlassError {
 }
 
 /// Map a `set_text` failure onto the `set_value` contract. Only `NotSent` proves nothing was
-/// written: the other two may already have set the field, so they answer in a verdict
-/// `set_value_failed_after_writing` accepts, or the session keeps a value the device has moved past
-/// and refuses the retry as drift (glass#405).
+/// written — the other two may already have set the field, so they answer in a verdict
+/// `set_value_failed_after_writing` accepts (glass#405).
 fn write_error(target: u32, f: CallFailure) -> GlassError {
     match f {
         CallFailure::NotSent(e) => GlassError::AccessibilityUnavailable(format!(
@@ -3662,8 +3660,8 @@ mod tests {
         v
     }
 
-    /// [`editable_field`] with the field no longer editable — a submit collapsing it to a display
-    /// row, which reports no value exactly as a lost write does.
+    /// [`editable_field`] with the field no longer editable — a collapsed display row, whose text
+    /// `labels` maps to `name`, leaving no value to read.
     fn settled_field(value: &str) -> Value {
         let mut v = editable_field(value);
         v["children"][0]["editable"] = json!(false);
@@ -3680,10 +3678,8 @@ mod tests {
 
     #[test]
     fn a_write_that_never_lands_names_both_values_and_the_compose_no_op() {
-        // ACTION_SET_TEXT reports success and does nothing when it would replace text already in a
-        // Compose field, which is a fact only this backend knows — the shared message is written
-        // for no backend in particular (glass#405). The verdict must also be one the session reads
-        // as post-dispatch, or it keeps the value it cached and refuses the retry as drift.
+        // The Compose no-op is a fact only this backend knows, and the verdict must also be one
+        // the session reads as post-dispatch, or it keeps its cached value (glass#405).
         let (port, _ops) = fake_service(vec![editable_field("old")], OnAction::Ok);
         let mut a = impatient_writer(port);
         let t = built(&editable_field("old"));
@@ -3704,8 +3700,8 @@ mod tests {
 
     #[test]
     fn a_field_holding_something_neither_value_gets_no_compose_explanation() {
-        // The clause says a field that already holds text cannot be replaced, and tells the caller
-        // to clear it. A field holding something the write put there was not refused.
+        // The clause tells the caller to clear a field that already holds text; a field holding
+        // something the write put there was not refused.
         let (port, _ops) = fake_service(
             vec![editable_field("old"), editable_field("filtered")],
             OnAction::Ok,
@@ -3726,9 +3722,9 @@ mod tests {
 
     #[test]
     fn a_clear_is_not_confirmed_by_a_field_that_stopped_being_editable() {
-        // A collapsed row maps its text to `name` and reports no value, so an unguarded `"" == ""`
-        // confirms a clear that may never have fired. The editable check runs first to stop that;
-        // move it back below the value check and this is the only test that notices.
+        // A collapsed row reports no value, so an unguarded `"" == ""` confirms a clear that may
+        // never have fired. Move the editable check back below the value check and this is the
+        // only test that notices.
         let (port, _ops) = fake_service(
             vec![editable_field("old"), settled_field("old")],
             OnAction::Ok,
@@ -3785,8 +3781,8 @@ mod tests {
 
     #[test]
     fn a_field_that_stopped_being_editable_is_unconfirmed_and_post_dispatch() {
-        // Its value cannot be read back, so the write is unconfirmed rather than refused — and the
-        // keystrokes went out either way, so the session must drop its cached value.
+        // Its value cannot be read back, so the write is unconfirmed rather than refused — and
+        // `set_text` went out either way, so the session must drop its cached value.
         let (port, _ops) = fake_service(
             vec![editable_field("old"), settled_field("old")],
             OnAction::Ok,
@@ -3803,8 +3799,8 @@ mod tests {
 
     #[test]
     fn a_read_back_that_fails_is_unconfirmed_and_post_dispatch() {
-        // The read-back runs after `set_text`, so its own failure must not propagate raw: every
-        // transport verdict is classified pre-dispatch, which would keep the stale cached value.
+        // The read-back runs after `set_text`, so its own failure must not propagate raw — the
+        // transport verdicts are classified pre-dispatch, which keeps the stale cached value.
         let (port, _ops) = fake_service_full(
             vec![editable_field("old")],
             vec![OnAction::Ok],

--- a/crates/glass-core/src/accessibility.rs
+++ b/crates/glass-core/src/accessibility.rs
@@ -1053,6 +1053,19 @@ pub trait Accessibility {
     /// Set the editable element identified by `target` to `text`. The backend
     /// re-walks pre-order to `target.id`, verifies role+name, then sets via the
     /// native editable interface. Default: unsupported.
+    ///
+    /// # Error contract
+    ///
+    /// Every failure raised once the write has gone out MUST be a verdict
+    /// [`GlassError::set_value_failed_after_writing`] accepts —
+    /// [`GlassError::AxValueNotApplied`] where the element was read back, and
+    /// [`GlassError::AxWriteUnconfirmed`] where it could not be. That is what drops the value the
+    /// session cached for the element; keeping it makes a field that settled *after* the failure
+    /// look like drift, and the caller's retry is refused for a write that succeeded (glass#405).
+    ///
+    /// A transport failure counts as having written whenever the request may have reached the
+    /// device. Classify at the point that knows — do not flatten it into a generic error on the way
+    /// out, which is how three exits of the Android on-device reader came to be misclassified.
     fn set_value(&mut self, _ctx: &AxContext, _target: &AxTarget, _text: &str) -> Result<()> {
         Err(crate::error::GlassError::AxUnsupported)
     }

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -16,6 +16,11 @@ pub enum BoundKind {
     NotStarted,
 }
 
+/// Render a backend's own explanation as the clause closing [`GlassError::AxValueNotApplied`].
+fn render_why(why: &Option<&'static str>) -> String {
+    why.map(|w| format!(" — {w}")).unwrap_or_default()
+}
+
 /// Render a read-back for [`GlassError::AxValueNotApplied`] as the clause following "the element".
 ///
 /// `None` is not an empty element — that reads back as `Some("")` — it is no reading at all: the
@@ -159,15 +164,15 @@ pub enum GlassError {
     /// Carries both values because three outcomes look alike from the id alone: the element
     /// transformed the write and holds it in another form (writing again changes nothing), it holds
     /// part of the request (a keystroke was dropped, so writing again is the fix), or it holds what
-    /// it held before (the write never arrived). Build it with [`GlassError::value_not_applied`].
+    /// it held before (the write never arrived). Build it with [`GlassError::value_not_applied`],
+    /// or [`GlassError::value_not_applied_because`] where the backend can name the last case.
     #[error(
         "set_value on element #{id} did not take — asked for {requested:?}, the element {}. \
          Holding the request in another form means the element transformed it, and writing again \
-         will not change that. Holding part of it, or none of it, means the write did not arrive: \
-         on a desktop backend the value is often a read-only projection, so focus the element and \
-         type into it instead; on Android or the iOS Simulator the tap may have missed, so write \
-         again",
-        render_observed(.observed)
+         will not change that; holding part of it, or none of it, means the write did not \
+         arrive{}",
+        render_observed(.observed),
+        render_why(.why)
     )]
     AxValueNotApplied {
         id: u32,
@@ -175,6 +180,10 @@ pub enum GlassError {
         /// What the element reads as now: the text for a field — `Some("")` when it is empty — or
         /// `"on"` / `"off"` for a boolean control. `None` only when no reading was obtained.
         observed: Option<String>,
+        /// What this element's own backend knows about a write that does not arrive, which the
+        /// shared message cannot say: it is written for no backend in particular, and a remedy
+        /// aimed at the wrong one sends a caller somewhere futile.
+        why: Option<&'static str>,
     },
 
     #[error("element #{0} exposes no native activation action")]
@@ -308,6 +317,26 @@ impl GlassError {
             id,
             requested: requested.to_string(),
             observed: observed.map(str::to_string),
+            why: None,
+        }
+    }
+
+    /// As [`Self::value_not_applied`], plus what this backend knows about a write of its own that
+    /// does not arrive — the mechanism and its remedy, appended to the shared message.
+    ///
+    /// `&'static str` deliberately: a remedy is a fixed explanation of how this backend writes, not
+    /// a place to format the call's data into.
+    pub fn value_not_applied_because(
+        id: u32,
+        requested: &str,
+        observed: Option<&str>,
+        why: &'static str,
+    ) -> GlassError {
+        GlassError::AxValueNotApplied {
+            id,
+            requested: requested.to_string(),
+            observed: observed.map(str::to_string),
+            why: Some(why),
         }
     }
 
@@ -586,6 +615,28 @@ mod tests {
         assert!(msg.contains("element #13"), "{msg}");
         assert!(msg.contains("asked for \"glasssmoke3\""), "{msg}");
         assert!(msg.contains("holds \"Glasssmoke3\""), "{msg}");
+    }
+
+    #[test]
+    fn a_backends_own_explanation_closes_the_message() {
+        // The shared text is written for no backend in particular, so the mechanism and its remedy
+        // come from the site that knows them (glass#405).
+        let msg = GlassError::value_not_applied_because(
+            13,
+            "new",
+            Some("old"),
+            "ACTION_SET_TEXT cannot replace text already in a Compose field",
+        )
+        .to_string();
+        assert!(msg.ends_with("ACTION_SET_TEXT cannot replace text already in a Compose field"));
+        assert!(msg.contains("the write did not arrive —"), "{msg}");
+    }
+
+    #[test]
+    fn a_verdict_with_no_backend_explanation_ends_at_the_shared_text() {
+        // No trailing dash with nothing after it for a site that has nothing to add.
+        let msg = GlassError::value_not_applied(13, "new", Some("old")).to_string();
+        assert!(msg.ends_with("the write did not arrive"), "{msg}");
     }
 
     #[test]

--- a/crates/glass-core/src/error.rs
+++ b/crates/glass-core/src/error.rs
@@ -154,8 +154,8 @@ pub enum GlassError {
     /// A write that went out and could not then be confirmed. Distinct from the pre-write
     /// refusals because only this one has dispatched — see `set_value_failed_after_writing`.
     #[error(
-        "element #{0}: the text was typed, but the write could not be confirmed — {1}. Re-snapshot \
-         to see where it landed rather than typing it again"
+        "element #{0}: the write went out, but could not be confirmed — {1}. Re-snapshot to see \
+         where it landed rather than writing it again"
     )]
     AxWriteUnconfirmed(u32, String),
 
@@ -164,13 +164,14 @@ pub enum GlassError {
     /// Carries both values because three outcomes look alike from the id alone: the element
     /// transformed the write and holds it in another form (writing again changes nothing), it holds
     /// part of the request (a keystroke was dropped, so writing again is the fix), or it holds what
-    /// it held before (the write never arrived). Build it with [`GlassError::value_not_applied`],
-    /// or [`GlassError::value_not_applied_because`] where the backend can name the last case.
+    /// it held before (the write took no effect). Build it with [`GlassError::value_not_applied`],
+    /// or [`GlassError::value_not_applied_because`] for the last case, which is the only one a
+    /// backend's own explanation fits — [`crate::write_took_no_effect`] is the test for it.
     #[error(
         "set_value on element #{id} did not take — asked for {requested:?}, the element {}. \
          Holding the request in another form means the element transformed it, and writing again \
-         will not change that; holding part of it, or none of it, means the write did not \
-         arrive{}",
+         will not change that; holding part of it, or none of it, means the write did not take \
+         effect{}",
         render_observed(.observed),
         render_why(.why)
     )]
@@ -322,7 +323,12 @@ impl GlassError {
     }
 
     /// As [`Self::value_not_applied`], plus what this backend knows about a write of its own that
-    /// does not arrive — the mechanism and its remedy, appended to the shared message.
+    /// takes no effect — the mechanism, and a remedy where there is one, appended to the shared
+    /// message.
+    ///
+    /// Only for a read-back [`crate::write_took_no_effect`] accepts: the clause subordinates to
+    /// that outcome, so attaching it to a transformed value contradicts the sentence before it.
+    /// It is appended after `" — "`, so it reads as a continuation — lowercase, no closing stop.
     ///
     /// `&'static str` deliberately: a remedy is a fixed explanation of how this backend writes, not
     /// a place to format the call's data into.
@@ -629,14 +635,18 @@ mod tests {
         )
         .to_string();
         assert!(msg.ends_with("ACTION_SET_TEXT cannot replace text already in a Compose field"));
-        assert!(msg.contains("the write did not arrive —"), "{msg}");
+        assert!(msg.contains("the write did not take effect —"), "{msg}");
     }
 
     #[test]
     fn a_verdict_with_no_backend_explanation_ends_at_the_shared_text() {
         // No trailing dash with nothing after it for a site that has nothing to add.
         let msg = GlassError::value_not_applied(13, "new", Some("old")).to_string();
-        assert!(msg.ends_with("the write did not arrive"), "{msg}");
+        assert!(msg.ends_with("the write did not take effect"), "{msg}");
+        // The three-outcome reading is the reason the variant carries both values; an edit that
+        // trimmed the message back to its last clause would otherwise keep every test green.
+        assert!(msg.contains("in another form"), "{msg}");
+        assert!(msg.contains("holding part of it"), "{msg}");
     }
 
     #[test]
@@ -695,7 +705,7 @@ mod tests {
             "nothing in the tree carries its role and name".into(),
         );
         let msg = e.to_string();
-        assert!(msg.contains("the text was typed"), "{msg}");
+        assert!(msg.contains("the write went out"), "{msg}");
         assert!(
             msg.contains("nothing in the tree carries its role and name"),
             "{msg}"

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -16,7 +16,9 @@ pub mod bounded;
 pub use bounded::{run_bounded, run_bounded_until, run_bounded_with_stdin};
 
 pub mod set_value;
-pub use set_value::{read_back_confirms, typed_clear_landed, typed_text_landed};
+pub use set_value::{
+    read_back_confirms, typed_clear_landed, typed_text_landed, write_took_no_effect,
+};
 
 pub mod frame;
 pub use frame::{Frame, Region};

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -436,10 +436,11 @@ impl Glass {
             } else {
                 // `None` is no checkable near the target's bounds on the last tick — the swipe
                 // moved the screen — so it reports as a reading nobody took, not as a state.
-                Err(GlassError::value_not_applied(
+                Err(GlassError::value_not_applied_because(
                     id.0,
                     text,
                     seen.map(|on| if on { "on" } else { "off" }),
+                    "the swipe across the control's trailing edge did not move it",
                 ))
             };
         }
@@ -546,7 +547,12 @@ impl Glass {
             // A combo carries its selection as its name, so that is the read-back; `None` is the
             // combo no longer being where it was. `text` rather than the trimmed `want`, so the
             // caller sees what it asked for, as `AxOptionNotFound` above does.
-            Err(GlassError::value_not_applied(id.0, text, shows.as_deref()))
+            Err(GlassError::value_not_applied_because(
+                id.0,
+                text,
+                shows.as_deref(),
+                "the option was stepped to and committed, and the combo still shows another",
+            ))
         }
     }
 
@@ -2961,12 +2967,12 @@ mod tests {
 
     /// [`GuardedAccessibility`] whose first call fails before dispatching anything — the shape of
     /// Android's `set_value`, which re-snapshots and reaches for adb before it taps.
-    struct PreDispatchFailureThenGuarded {
+    struct FirstFailureThenGuarded {
         first_failure: Option<GlassError>,
         guarded: GuardedAccessibility,
     }
 
-    impl Accessibility for PreDispatchFailureThenGuarded {
+    impl Accessibility for FirstFailureThenGuarded {
         fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
             self.guarded.snapshot(ctx)
         }
@@ -2989,7 +2995,7 @@ mod tests {
             GlassError::AccessibilityUnavailable("adb: device offline".into()),
         ] {
             let set_log = Arc::new(Mutex::new(Vec::new()));
-            let mut g = glass_ready_for_set_value(Box::new(PreDispatchFailureThenGuarded {
+            let mut g = glass_ready_for_set_value(Box::new(FirstFailureThenGuarded {
                 first_failure: Some(failure),
                 guarded: GuardedAccessibility {
                     tree: editable_field_tree(Some("Alice")),
@@ -3012,6 +3018,42 @@ mod tests {
             assert!(
                 set_log.lock().unwrap().is_empty(),
                 "no write may land on the drifted row"
+            );
+        }
+    }
+
+    #[test]
+    fn a_post_dispatch_failure_lets_the_retry_through_once_the_field_settles() {
+        // The sequence glass#405 is about, end to end: a write that dispatched and could not be
+        // confirmed, a field that then settles to the text that write sent, and a retry the guard
+        // must accept. Keeping the cached value here makes the settled field look like drift, and
+        // the caller is refused for a write that landed. Both verdicts a backend can raise once it
+        // has written must clear it.
+        for failure in [
+            GlassError::AxWriteUnconfirmed(0, "the result was lost".into()),
+            GlassError::value_not_applied(0, "x", Some("Alice")),
+        ] {
+            let set_log = Arc::new(Mutex::new(Vec::new()));
+            let mut g = glass_ready_for_set_value(Box::new(FirstFailureThenGuarded {
+                first_failure: Some(failure),
+                guarded: GuardedAccessibility {
+                    tree: editable_field_tree(Some("Alice")),
+                    // The device applied the write the caller was told it could not confirm.
+                    held: Some("x".into()),
+                    set_log: set_log.clone(),
+                },
+            }));
+
+            assert!(
+                g.set_value(AxNodeId(0), "x").is_err(),
+                "first write is scripted to fail after dispatch"
+            );
+            g.set_value(AxNodeId(0), "x")
+                .expect("the retry must not be refused as drift for a write that landed");
+            assert_eq!(
+                set_log.lock().unwrap().len(),
+                1,
+                "exactly the retry reaches the element"
             );
         }
     }
@@ -3515,7 +3557,7 @@ mod tests {
 
         // The error must be the switch-specific "expects a boolean" one, and its message must
         // actually guide the agent (name the accepted values + echo the bad input) — NOT a generic
-        // `AxValueNotApplied`, whose remedy is to type into the element — futile for a switch.
+        // `AxValueNotApplied`, which reads as a text field that would not take the text.
         assert!(
             matches!(err, GlassError::AxValueNotBoolean(1, ref got) if got == "banana"),
             "{err}"

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -3025,10 +3025,8 @@ mod tests {
     #[test]
     fn a_post_dispatch_failure_lets_the_retry_through_once_the_field_settles() {
         // The sequence glass#405 is about, end to end: a write that dispatched and could not be
-        // confirmed, a field that then settles to the text that write sent, and a retry the guard
-        // must accept. Keeping the cached value here makes the settled field look like drift, and
-        // the caller is refused for a write that landed. Both verdicts a backend can raise once it
-        // has written must clear it.
+        // confirmed, a field that then settles to the text it sent, and a retry the guard must
+        // accept. Both verdicts a backend can raise once it has written must clear the cache.
         for failure in [
             GlassError::AxWriteUnconfirmed(0, "the result was lost".into()),
             GlassError::value_not_applied(0, "x", Some("Alice")),

--- a/crates/glass-core/src/session/a11y.rs
+++ b/crates/glass-core/src/session/a11y.rs
@@ -2460,7 +2460,7 @@ mod tests {
 
         let err = g.set_value(AxNodeId(1), "Delta").unwrap_err();
         assert!(
-            matches!(&err, GlassError::AxValueNotApplied { id: 1, requested, observed }
+            matches!(&err, GlassError::AxValueNotApplied { id: 1, requested, observed, .. }
                 if requested == "Delta" && observed.as_deref() == Some("Beta")),
             "{err}"
         );
@@ -3292,7 +3292,7 @@ mod tests {
 
         let err = g.set_value(AxNodeId(1), "true").unwrap_err();
         assert!(
-            matches!(&err, GlassError::AxValueNotApplied { id: 1, requested, observed }
+            matches!(&err, GlassError::AxValueNotApplied { id: 1, requested, observed, .. }
                 if requested == "true" && observed.as_deref() == Some("off")),
             "{err}"
         );
@@ -3421,7 +3421,7 @@ mod tests {
 
         let err = g.set_value(AxNodeId(2), "true").unwrap_err();
         assert!(
-            matches!(&err, GlassError::AxValueNotApplied { id: 2, requested, observed }
+            matches!(&err, GlassError::AxValueNotApplied { id: 2, requested, observed, .. }
                 if requested == "true" && observed.as_deref() == Some("off")),
             "{err}"
         );

--- a/crates/glass-core/src/set_value.rs
+++ b/crates/glass-core/src/set_value.rs
@@ -105,6 +105,26 @@ mod tests {
     use super::*;
 
     #[test]
+    fn a_field_still_holding_what_it_held_took_no_effect_from_the_write() {
+        assert!(write_took_no_effect("hello", Some("hello")));
+    }
+
+    #[test]
+    fn a_field_holding_anything_else_took_something_from_the_write() {
+        // Including a transformation: an iOS field that autocapitalized the text it was given
+        // received every keystroke, so a backend's "the tap may have missed" must not attach.
+        assert!(!write_took_no_effect("Hello", Some("hello")));
+    }
+
+    #[test]
+    fn a_read_back_with_no_baseline_cannot_show_a_write_took_no_effect() {
+        // `None` is a pre-write read the backend could not take. Treating it as a match would
+        // attach an explanation of a write that never landed to one nobody can place.
+        assert!(!write_took_no_effect("hello", None));
+        assert!(!write_took_no_effect("", None));
+    }
+
+    #[test]
     fn a_write_that_changed_nothing_did_not_take() {
         // A read-only editable that accepts the write and keeps its value.
         assert!(!set_value_took("#000000", "#000000", "#12AA34"));

--- a/crates/glass-core/src/set_value.rs
+++ b/crates/glass-core/src/set_value.rs
@@ -53,6 +53,19 @@ pub fn read_back_confirms(read_back: Option<&str>, before: Option<&str>, request
     }
 }
 
+/// Whether a read-back shows the element holding exactly what it held before the write — the one
+/// outcome that means the write never took effect, as against arriving and being transformed.
+///
+/// The caller passes a reading it actually took, with an absent value already normalized to `""`:
+/// a mapper that drops empty values reports an empty field as no value, and a backend whose
+/// read-back *failed* has no reading to compare and must not ask.
+///
+/// What a backend's own explanation of a write hangs on — attach it here and nowhere else, or a
+/// field that transformed the text is handed a remedy for one that never received it.
+pub fn write_took_no_effect(observed: &str, before: Option<&str>) -> bool {
+    before.is_some_and(|b| b == observed)
+}
+
 /// Whether a *typed* write landed, judged from the value read back.
 ///
 /// Exact match, unlike [`read_back_confirms`]: keystrokes can land partially, and a field holding

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -224,8 +224,8 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
         // reserves for a reading nobody took.
         let observed = node.value.as_deref().unwrap_or("");
         // Only where the field never moved: on a value the element transformed — an iOS field
-        // autocapitalizing a typed lowercase letter (glass#363) — the tap landed, and telling the
-        // caller to write again contradicts the sentence this clause hangs off.
+        // autocapitalizing a typed lowercase letter (glass#363) — the tap landed, so "write again"
+        // would contradict the sentence this clause hangs off.
         Err(
             if write_took_no_effect(observed, Some(target.value.as_deref().unwrap_or(""))) {
                 GlassError::value_not_applied_because(

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -97,6 +97,11 @@ fn verify(tree: &AxTree, target: &AxTarget) -> Result<AxRect> {
 
 /// How long to let the app commit typed text before each read-back attempt. Generous next to a
 /// keystroke and small next to the `describe` that follows it.
+/// What a write that never arrived looks like on this backend: `set_value` types, so the tap that
+/// aims the keystrokes is the part that can miss.
+const TAP_MAY_HAVE_MISSED: &str = "this write is a tap and then keystrokes, so the tap may have missed the element — writing \
+     again is worth one attempt";
+
 const VERIFY_SETTLE: Duration = Duration::from_millis(300);
 
 /// How many times to read the element back before reporting the write as not applied. A landed write
@@ -216,10 +221,11 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
     } else {
         // The mapper drops an empty value, so an empty field arrives as `None` — which the verdict
         // reserves for a reading nobody took.
-        Err(GlassError::value_not_applied(
+        Err(GlassError::value_not_applied_because(
             target.id.0,
             text,
             Some(node.value.as_deref().unwrap_or("")),
+            TAP_MAY_HAVE_MISSED,
         ))
     }
 }
@@ -415,6 +421,7 @@ mod tests {
                 id: got_id,
                 requested: req,
                 observed: obs,
+                ..
             }) => assert_eq!(
                 (got_id, req.as_str(), obs.as_deref()),
                 (id, requested, observed)

--- a/crates/glass-ios/src/a11y.rs
+++ b/crates/glass-ios/src/a11y.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 
 use glass_core::{
     GlassError, KeyEvent, MouseButton, PointerEvent, Result, typed_clear_landed, typed_text_landed,
+    write_took_no_effect,
 };
 
 use crate::axmap;
@@ -95,13 +96,13 @@ fn verify(tree: &AxTree, target: &AxTarget) -> Result<AxRect> {
         .ok_or(GlassError::AxElementNotClickable(target.id.0))
 }
 
-/// How long to let the app commit typed text before each read-back attempt. Generous next to a
-/// keystroke and small next to the `describe` that follows it.
-/// What a write that never arrived looks like on this backend: `set_value` types, so the tap that
-/// aims the keystrokes is the part that can miss.
+/// What a write that took no effect looks like on this backend: `set_value` types, so the tap that
+/// aims the keystrokes is the part that can miss. Twin of the const in `glass-android/src/a11y.rs`.
 const TAP_MAY_HAVE_MISSED: &str = "this write is a tap and then keystrokes, so the tap may have missed the element — writing \
      again is worth one attempt";
 
+/// How long to let the app commit typed text before each read-back attempt. Generous next to a
+/// keystroke and small next to the `describe` that follows it.
 const VERIFY_SETTLE: Duration = Duration::from_millis(300);
 
 /// How many times to read the element back before reporting the write as not applied. A landed write
@@ -221,12 +222,22 @@ fn verify_write(after_tree: &AxTree, target: &AxTarget, text: &str) -> Result<()
     } else {
         // The mapper drops an empty value, so an empty field arrives as `None` — which the verdict
         // reserves for a reading nobody took.
-        Err(GlassError::value_not_applied_because(
-            target.id.0,
-            text,
-            Some(node.value.as_deref().unwrap_or("")),
-            TAP_MAY_HAVE_MISSED,
-        ))
+        let observed = node.value.as_deref().unwrap_or("");
+        // Only where the field never moved: on a value the element transformed — an iOS field
+        // autocapitalizing a typed lowercase letter (glass#363) — the tap landed, and telling the
+        // caller to write again contradicts the sentence this clause hangs off.
+        Err(
+            if write_took_no_effect(observed, Some(target.value.as_deref().unwrap_or(""))) {
+                GlassError::value_not_applied_because(
+                    target.id.0,
+                    text,
+                    Some(observed),
+                    TAP_MAY_HAVE_MISSED,
+                )
+            } else {
+                GlassError::value_not_applied(target.id.0, text, Some(observed))
+            },
+        )
     }
 }
 
@@ -413,18 +424,25 @@ mod tests {
     }
 
     /// Pin the whole verdict, not the variant: the two values it names are what a caller acts on
-    /// (glass#363). Twin of the helper in `glass-android/src/a11y.rs`.
+    /// (glass#363), and `why` attaches only to a field that never moved (glass#405). Twin of the
+    /// helper in `glass-android/src/a11y.rs`.
     #[track_caller]
-    fn assert_not_applied(outcome: Result<()>, id: u32, requested: &str, observed: Option<&str>) {
+    fn assert_not_applied(
+        outcome: Result<()>,
+        id: u32,
+        requested: &str,
+        observed: Option<&str>,
+        why: Option<&str>,
+    ) {
         match outcome {
             Err(GlassError::AxValueNotApplied {
                 id: got_id,
                 requested: req,
                 observed: obs,
-                ..
+                why: got_why,
             }) => assert_eq!(
-                (got_id, req.as_str(), obs.as_deref()),
-                (id, requested, observed)
+                (got_id, req.as_str(), obs.as_deref(), got_why),
+                (id, requested, observed, why)
             ),
             other => panic!("expected a not-applied verdict, got {other:?}"),
         }
@@ -455,6 +473,7 @@ mod tests {
             1,
             "",
             Some("Search settings"),
+            None,
         );
     }
 
@@ -482,6 +501,7 @@ mod tests {
             1,
             "world",
             Some("hello"),
+            None,
         );
     }
 
@@ -497,6 +517,7 @@ mod tests {
             1,
             "glasssmoke3",
             Some("Glasssmoke3"),
+            None,
         );
     }
 
@@ -510,6 +531,9 @@ mod tests {
             1,
             "world",
             Some(""),
+            // The field held nothing before and holds nothing now, so the write took no effect and
+            // the backend's own explanation of that is what closes the message.
+            Some(TAP_MAY_HAVE_MISSED),
         );
     }
 
@@ -523,6 +547,7 @@ mod tests {
             1,
             "world",
             Some("worl"),
+            None,
         );
     }
 
@@ -541,6 +566,7 @@ mod tests {
             1,
             "world",
             Some("hello"),
+            None,
         );
     }
 
@@ -718,10 +744,10 @@ mod tests {
         );
         let err = verify_write(&replaced, &matching_target(), "world").unwrap_err();
         assert!(matches!(err, GlassError::AxWriteUnconfirmed(1, _)), "{err}");
-        // "the text was typed" is common to every AxWriteUnconfirmed arm (it's in the #[error]
+        // "the write went out" is common to every AxWriteUnconfirmed arm (it's in the #[error]
         // template, not this arm's own clause) — assert the Gone arm's own sentence too, or a
         // change to just this arm's message would leave the suite green.
-        assert!(err.to_string().contains("the text was typed"), "{err}");
+        assert!(err.to_string().contains("the write went out"), "{err}");
         assert!(err.to_string().contains("replaced"), "{err}");
     }
 

--- a/crates/glass-mcp/src/server.rs
+++ b/crates/glass-mcp/src/server.rs
@@ -472,7 +472,8 @@ impl GlassServer {
                        holds, and which one it is decides your next move: your text in another \
                        form means the element transformed it and writing again will not help; part \
                        of your text means a keystroke was dropped, so write again; what it held \
-                       before means the write never arrived. A separate \
+                       before means the write took no effect, and the error then closes with what \
+                       this backend knows about that. A separate \
                        error says the text WAS typed but the write could not be confirmed — the \
                        read-back failed, or could not tell which element now holds it. Do NOT write \
                        again on that one: the keystrokes already went out, and re-snapshotting is \

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -561,8 +561,11 @@ another form and writing again will not change that: a field that reformats (`"1
 `"(123) 456-7890"`), or one that autocapitalizes (an iOS text field returning `"Hello"` for a typed
 `"hello"`, intermittently — it depends on whether the field had finished emptying when the first key
 arrived). An element holding **part** of your text dropped a keystroke, and writing again is the fix.
-An element holding **what it held before** never received the write: on a desktop backend its value
-is usually a read-only projection, so focus it and use `glass_type` instead.
+An element holding **what it held before** never received the write, and the error closes with what
+the backend that made the write knows about that: a desktop element's value is often a read-only
+projection, so focus it and use `glass_type` instead; a mobile write is a tap and then keystrokes,
+so the tap may have missed; and an Android field driven through the on-device accessibility service
+cannot have text *replaced*, only set into an empty field.
 
 A cleared field (`text: ""`) that reads back holding its placeholder is the one false failure here —
 the clear landed and the accessibility layer substituted the hint. Confirm it with a screenshot

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -561,21 +561,22 @@ another form and writing again will not change that: a field that reformats (`"1
 `"(123) 456-7890"`), or one that autocapitalizes (an iOS text field returning `"Hello"` for a typed
 `"hello"`, intermittently — it depends on whether the field had finished emptying when the first key
 arrived). An element holding **part** of your text dropped a keystroke, and writing again is the fix.
-An element holding **what it held before** never received the write, and the error closes with what
-the backend that made the write knows about that: a desktop element's value is often a read-only
-projection, so focus it and use `glass_type` instead; a mobile write is a tap and then keystrokes,
-so the tap may have missed; and an Android field driven through the on-device accessibility service
-cannot have text *replaced*, only set into an empty field.
+An element holding **what it held before** took no effect from the write, and only then does the
+error close with what the backend that made it knows about that: a desktop element's value is often
+a read-only projection, so focus it and use `glass_type` instead; a mobile write is a tap and then
+keystrokes, so the tap may have missed; and a *Compose* field driven through Android's on-device
+accessibility service cannot have its text *replaced*, only set into an empty field.
 
 A cleared field (`text: ""`) that reads back holding its placeholder is the one false failure here —
 the clear landed and the accessibility layer substituted the hint. Confirm it with a screenshot
 rather than writing again.
 
-One error is not a refusal: *the text was typed, but the write could not be confirmed*. The
-keystrokes went out and the read-back afterwards could not establish where they landed — it failed
+One error is not a refusal: *the write went out, but could not be confirmed*. The write reached the
+app and the read-back afterwards could not establish where it landed — it failed
 outright, several elements now match the one you named, nothing does, the read was cut short, or the
 element is no longer editable to read back. **Do not call `glass_set_value` again on that error** —
-the app has the text already, and writing again types it twice. Re-snapshot and read the element to
+the app may have the text already, and on a backend that types, writing again types it twice.
+Re-snapshot and read the element to
 see what it holds. When the message names a node cap, raising `max_nodes` on the snapshot is what
 fixes it. Clearing a field (`text: ""`) additionally needs the element to have a `name`: an empty
 field is not by itself evidence the clear landed on the element you meant, so a nameless one reports


### PR DESCRIPTION
Closes #405.

`GlassError::set_value_failed_after_writing()` decides whether the session drops the value it cached for an element. Get it wrong and a field that settles *after* a failed write looks like drift, so the next `glass_set_value` is refused — "changed since the snapshot" — for a write that succeeded.

Four exits on Android's on-device accessibility-service write path answered in shapes it does not recognise: the write not landing raised `Backend`, the field ceasing to report itself editable raised `AccessibilityUnavailable`, the read-back's own failure propagated whatever the snapshot raised, and `set_text` computed a `CallFailure` — `NotSent` / `AnswerLost` / `Refused`, the last two meaning the request may already have set the field — then discarded it with `into_error()`. The click path beside it keeps that classification for exactly this reason. All four now raise what the other backends raise: `AxValueNotApplied`, and `AxWriteUnconfirmed` where the read-back could not settle it.

Two readings in the same loop were fabricated. `find` answers `None` both for an element that left the tree and for one holding nothing, so a vanished element was reported as holding `""` — and for a clear, `"" == ""` confirmed the write on the evidence that the element could not be found. The editable check now runs before the value check for the same reason: a collapsed row maps its text to `name` and reports no value, so an unguarded clear was confirmed by a field that had stopped being a field.

## The backend's own explanation

`AxValueNotApplied` gains a `why` supplied by the site that made the write. The shared message had been guessing on behalf of four mechanisms at once — offering every caller a desktop read-only projection and a missed tap, neither of which applies to the two boolean paths — while the fact that needed saying had nowhere to live: `ACTION_SET_TEXT` reports success and silently does nothing when it would *replace* text already in a Compose field.

It attaches only where it fits. The clause subordinates to "the write took no effect", so a field that *transformed* the text — an iOS one autocapitalizing a typed lowercase letter, #363's measured case — was being told the tap may have missed and to write again, in the sentence that had just said writing again would not help. `write_took_no_effect` is the shared test, and it is also what stops the Compose remedy telling a caller to clear a field the same message reports as empty.

The shared text said "the write did not arrive", false for three of the four mechanisms — a toggle action that fired, an `ACTION_SET_TEXT` that no-opped and an AX write a projection accepted all arrived. `AxWriteUnconfirmed` likewise no longer says the text was typed, now that a backend dispatching one node-addressed action raises it.

Smaller corrections: the Compose remedy named `GLASS_ANDROID_A11Y_APK`, which does not deselect the reader when the apk is found beside the binary (`GLASS_ANDROID_A11Y=off` does); the Linux clause claimed a radio button for every control that reached it, including a checkbox and a caller asking to *select*; and the post-dispatch rule now lives on the `Accessibility::set_value` trait doc, next to the one `invoke` already carries.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace` (82 suites), and the `x86_64-pc-windows-gnu` and `x86_64-apple-darwin` cross-checks are clean. Every new assertion was ablated and confirmed to fail without the change it covers — including one that first came back green because the ablation was an identity no-op.

`set_value`'s write-verify budget is now a named constant with a test seam rather than a bare literal, which takes the service tests from 2.3s to 1.2s. The end-to-end sequence — dispatched write fails, field settles, retry accepted — is covered at the session level for both verdicts; previously each link was tested alone and the chain was not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)