### PR TITLE
test(proc-linux): stop the SIGTERM-ignored reap test orphaning a sleep

### DIFF
--- a/crates/glass-proc-linux/src/lib.rs
+++ b/crates/glass-proc-linux/src/lib.rs
@@ -392,9 +392,12 @@ mod reap_tests {
 
     #[test]
     fn reap_graceful_sigkills_after_grace_when_sigterm_ignored() {
-        // Echo "ready" after the trap is installed so we don't race the signal.
+        // Echo "ready" after the trap is installed so we don't race the signal. `exec` keeps the
+        // TERM-ignoring process the direct child — SIG_IGN survives execve. Drop it and `sleep` is
+        // a grandchild `reap_graceful` never signals, outliving the test on the inherited stderr
+        // pipe, which nextest reports as LEAK.
         let mut c = Command::new("sh")
-            .args(["-c", "trap '' TERM; echo ready; sleep 30"])
+            .args(["-c", "trap '' TERM; echo ready; exec sleep 30"])
             .stdout(Stdio::piped())
             .spawn()
             .unwrap();


### PR DESCRIPTION
`reap_tests::reap_graceful_sigkills_after_grace_when_sigterm_ignored` was reported `LEAK` by nextest.

The fixture ran `sh -c "trap '' TERM; echo ready; sleep 30"`, so the process ignoring TERM was the shell and `sleep` was a grandchild. `reap_graceful` signals only the direct child by contract, so its SIGKILL ended the shell and reparented `sleep` to init for 30 seconds — still holding the stderr pipe it inherited from the test binary, which under nextest is the capture pipe. Verified on the orphan: `ps` shows `ppid 1`, and `/proc/<pid>/fd/2` is still the inherited pipe.

`exec sleep 30` makes the ignoring process the direct child. SIG_IGN survives `execve`, so the child still ignores the graceful SIGTERM, still rides out the full grace, and still needs the SIGKILL — the assertions are unchanged and the run still takes just over the 300ms grace. Nothing is left behind.

`cargo nextest run --workspace`: 2274 passed, no leaky tests. `cargo fmt --all --check` and clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)