### PR TITLE
refactor: one bounded detached-thread shell for the two thread-affine a11y readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ internal refactors, CI, or test-only changes.
   not take" before.
 
 ### Fixed
+- An accessibility reader that crashes on a particular app's tree now says so, instead of reporting
+  that the backend stopped responding. On Linux and Windows the reader runs each call on its own
+  worker thread; a crash there was indistinguishable from a call that never came back, so a read
+  reported that *you* had run out of time — and `glass_wait_for_element` treats that as "not yet",
+  polling for its whole timeout before reporting the element missing. Both halves were untrue: no
+  time had been spent, and the tree was unreachable rather than slow.
+- A `glass_set_value` that times out now says the write may still land, as `glass_click_element`
+  already did for an action. The work is not cancelled when the call gives up, so a write can arrive
+  after the error does; an agent that read the old message as "nothing happened" and typed the text
+  in by hand could end up with it entered twice.
 - A `glass_set_value` that failed on Android's on-device accessibility service no longer poisons the
   retry. Three of that path's failures — the write not landing, the field ceasing to report itself
   editable, and the read-back itself failing — along with a write whose answer was lost in

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -1,6 +1,7 @@
-//! `LinuxA11y`: the AT-SPI `Accessibility` reader. Connects on a private thread +
-//! current-thread runtime (so it never `block_on`s inside the caller's tokio
-//! runtime), finds the launched app by PID, and walks its subtree into an `AxTree`.
+//! `LinuxA11y`: the AT-SPI `Accessibility` reader. Runs each bounded call on a detached thread
+//! (`glass_core::A11yThread`) with its own current-thread runtime, so it never `block_on`s inside
+//! the caller's tokio runtime; finds the launched app by PID, and walks its subtree into an
+//! `AxTree`.
 
 use std::time::Duration;
 
@@ -9,15 +10,16 @@ use atspi::proxy::accessible::{AccessibleProxy, ObjectRefExt};
 use atspi::proxy::component::ComponentProxy;
 use atspi_common::{CoordType, ObjectRefOwned};
 use glass_core::{
-    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget, AxTree, GlassError, Result,
-    ThreadBoundReader, WalkBudget, normalize_description,
+    A11yThread, Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget, AxTree, GlassError,
+    Result, WalkBudget, normalize_description,
 };
 
 use crate::mapping::{map_role, map_states};
 
-/// Every call runs on a fresh detached thread: atspi is async and would `block_on` inside the
-/// caller's tokio runtime. Ten seconds is the hard cap, so a wedged bus can't hang the calling tool.
-const BUS: ThreadBoundReader = ThreadBoundReader::new("a11y bus", Duration::from_secs(10));
+/// Every bounded call runs on a fresh detached thread: this reader drives an async API with
+/// `block_on`, which panics inside the caller's tokio runtime. The cap is what stops a wedged bus
+/// hanging the calling tool for longer than it.
+static BUS: A11yThread = A11yThread::new("a11y bus", Duration::from_secs(10));
 
 #[derive(Default)]
 pub struct LinuxA11y;
@@ -30,6 +32,8 @@ impl LinuxA11y {
 
 impl Accessibility for LinuxA11y {
     fn subscribe_changes(&mut self, ctx: &AxContext) -> Option<Box<dyn glass_core::ChangeSignal>> {
+        // Not one of [`BUS`]'s bounded calls: the subscription's own thread is the long-lived one,
+        // and `subscribe` already bounds how long it waits for the registrations to land.
         crate::events::subscribe(ctx)
     }
 
@@ -42,14 +46,14 @@ impl Accessibility for LinuxA11y {
         let ctx = ctx.clone();
         let target = target.clone();
         let text = text.to_string();
-        BUS.write(move || run_set_value(&ctx, &target, &text))
+        BUS.set_value(move || run_set_value(&ctx, &target, &text))
     }
 
     fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<Option<AxNodeId>> {
         let ctx = ctx.clone();
         let target = target.clone();
         // This reader actuates the element it resolved, so it never substitutes another.
-        BUS.action(move || run_invoke(&ctx, &target)).map(|()| None)
+        BUS.invoke(move || run_invoke(&ctx, &target)).map(|()| None)
     }
 }
 
@@ -722,13 +726,6 @@ mod toggle_label_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// The name this reader hands `glass_core` — it is what a timeout message blames, and nothing
-    /// else in the crate would notice it changing.
-    #[test]
-    fn a_timeout_from_this_reader_blames_the_a11y_bus() {
-        assert_eq!(BUS.subject(), "a11y bus");
-    }
 
     #[test]
     fn no_matching_app_message_is_developer_framed() {

--- a/crates/glass-a11y-linux/src/reader.rs
+++ b/crates/glass-a11y-linux/src/reader.rs
@@ -2,50 +2,22 @@
 //! current-thread runtime (so it never `block_on`s inside the caller's tokio
 //! runtime), finds the launched app by PID, and walks its subtree into an `AxTree`.
 
-use std::sync::mpsc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use atspi::connection::AccessibilityConnection;
 use atspi::proxy::accessible::{AccessibleProxy, ObjectRefExt};
 use atspi::proxy::component::ComponentProxy;
 use atspi_common::{CoordType, ObjectRefOwned};
 use glass_core::{
-    Accessibility, AxContext, AxDeadline, AxNode, AxNodeId, AxRect, AxTarget, AxTree, GlassError,
-    Result, WalkBudget, normalize_description,
+    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget, AxTree, GlassError, Result,
+    ThreadBoundReader, WalkBudget, normalize_description,
 };
 
 use crate::mapping::{map_role, map_states};
 
-/// Hard cap so a wedged a11y bus can't hang the calling tool forever.
-const SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(10);
-
-/// How long a read may block for its worker, and whether the caller's deadline — not
-/// [`SNAPSHOT_TIMEOUT`] — is what ends the wait.
-///
-/// Both come from one comparison, decided before the wait: a read the *caller* cut short is a
-/// spent budget, a read that used the whole ceiling is a bus that stopped answering, and inferring
-/// which afterwards is the mistake glass#341 recorded.
-fn bounded_wait(deadline: AxDeadline) -> (Duration, bool) {
-    let own = Instant::now() + SNAPSHOT_TIMEOUT;
-    (
-        deadline.cap(own).saturating_duration_since(Instant::now()),
-        deadline.governs(own),
-    )
-}
-
-/// What a read reports when it never answered: the caller's own deadline ending it is
-/// `AccessibilityNotReady`, which [`glass_core::Glass::wait_for_element`] polls through, where the
-/// bus going quiet for a whole [`SNAPSHOT_TIMEOUT`] is not.
-fn never_answered(by_caller: bool) -> GlassError {
-    if by_caller {
-        return GlassError::AccessibilityNotReady(
-            "no accessibility tree within the time this call allowed".into(),
-        );
-    }
-    GlassError::AccessibilityUnavailable(
-        "accessibility snapshot timed out (a11y bus not responding)".into(),
-    )
-}
+/// Every call runs on a fresh detached thread: atspi is async and would `block_on` inside the
+/// caller's tokio runtime. Ten seconds is the hard cap, so a wedged bus can't hang the calling tool.
+const BUS: ThreadBoundReader = ThreadBoundReader::new("a11y bus", Duration::from_secs(10));
 
 #[derive(Default)]
 pub struct LinuxA11y;
@@ -62,62 +34,22 @@ impl Accessibility for LinuxA11y {
     }
 
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
-        // Checked before the spawn: the worker below is detached and holds its own bus
-        // connection, so one started for a caller that has stopped waiting outlives the answer
-        // nobody reads.
-        if ctx.deadline.has_passed() {
-            return Err(never_answered(true));
-        }
-        let (wait, by_caller) = bounded_wait(ctx.deadline);
         let ctx = ctx.clone();
-        let (tx, rx) = mpsc::channel();
-        // atspi is async and may be invoked from within a tokio runtime, where
-        // `block_on` panics. Run on a fresh OS thread with its own current-thread
-        // runtime, fully decoupled from the caller's runtime.
-        std::thread::spawn(move || {
-            let _ = tx.send(run_snapshot(&ctx));
-        });
-        match rx.recv_timeout(wait) {
-            Ok(r) => r,
-            Err(_) => Err(never_answered(by_caller)),
-        }
+        BUS.snapshot(ctx.deadline, move || run_snapshot(&ctx))
     }
 
     fn set_value(&mut self, ctx: &AxContext, target: &AxTarget, text: &str) -> Result<()> {
         let ctx = ctx.clone();
         let target = target.clone();
         let text = text.to_string();
-        let (tx, rx) = mpsc::channel();
-        std::thread::spawn(move || {
-            let _ = tx.send(run_set_value(&ctx, &target, &text));
-        });
-        match rx.recv_timeout(SNAPSHOT_TIMEOUT) {
-            Ok(r) => r,
-            Err(_) => Err(GlassError::AccessibilityUnavailable(
-                "accessibility set_value timed out (a11y bus not responding)".into(),
-            )),
-        }
+        BUS.write(move || run_set_value(&ctx, &target, &text))
     }
 
     fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<Option<AxNodeId>> {
         let ctx = ctx.clone();
         let target = target.clone();
-        let (tx, rx) = mpsc::channel();
-        std::thread::spawn(move || {
-            let _ = tx.send(run_invoke(&ctx, &target));
-        });
-        match rx.recv_timeout(SNAPSHOT_TIMEOUT) {
-            // This reader actuates the element it resolved, so it never substitutes another.
-            Ok(r) => r.map(|()| None),
-            // The worker thread outlives this timeout, so the action may already have been
-            // dispatched — say so. This error is NOT fallback-eligible (see
-            // `GlassError::invoke_fallback_eligible`), so no pointer click is layered on top.
-            Err(_) => Err(GlassError::AccessibilityUnavailable(
-                "accessibility invoke timed out (a11y bus not responding); the action may \
-                 still land — re-snapshot before retrying"
-                    .into(),
-            )),
-        }
+        // This reader actuates the element it resolved, so it never substitutes another.
+        BUS.action(move || run_invoke(&ctx, &target)).map(|()| None)
     }
 }
 
@@ -396,8 +328,7 @@ async fn app_matches(app_ref: &ObjectRefOwned, ctx: &AxContext, conn: &zbus::Con
 
 /// Recursively build a normalized node from an AT-SPI accessible, bounded by
 /// [`WalkBudget`] (node count, nesting depth, and per-level sibling scan) so a
-/// pathological tree can't burn the outer [`SNAPSHOT_TIMEOUT`] with no tree to
-/// show for it.
+/// pathological tree can't burn the reader's whole ceiling with no tree to show for it.
 async fn walk(
     proxy: &AccessibleProxy<'_>,
     conn: &zbus::Connection,
@@ -792,36 +723,11 @@ mod toggle_label_tests {
 mod tests {
     use super::*;
 
-    /// glass#338: only the reader can hold a read inside the caller's timeout — the worker below
-    /// is detached, so nothing outside it can shorten one that has started.
+    /// The name this reader hands `glass_core` — it is what a timeout message blames, and nothing
+    /// else in the crate would notice it changing.
     #[test]
-    fn a_read_is_bounded_by_the_caller_when_that_falls_first() {
-        let (wait, by_caller) = bounded_wait(AxDeadline::from_millis(50));
-        assert!(wait <= Duration::from_millis(50), "{wait:?}");
-        assert!(by_caller);
-    }
-
-    /// The other direction: without it the test above passes on a reader that waits for nothing.
-    #[test]
-    fn a_caller_that_names_no_deadline_leaves_the_read_its_own_ceiling() {
-        let (wait, by_caller) = bounded_wait(AxDeadline::UNBOUNDED);
-        assert!(wait > SNAPSHOT_TIMEOUT - Duration::from_secs(1), "{wait:?}");
-        assert!(!by_caller);
-    }
-
-    /// The variant decides whether a wait polls on or fails, so the two causes must not collapse:
-    /// a bus that went quiet for the whole ceiling is a real fault, and a caller that ran out of
-    /// its own time is not.
-    #[test]
-    fn a_read_the_caller_cut_short_reads_as_not_ready_where_a_quiet_bus_does_not() {
-        assert!(matches!(
-            never_answered(true),
-            GlassError::AccessibilityNotReady(_)
-        ));
-        assert!(matches!(
-            never_answered(false),
-            GlassError::AccessibilityUnavailable(_)
-        ));
+    fn a_timeout_from_this_reader_blames_the_a11y_bus() {
+        assert_eq!(BUS.subject(), "a11y bus");
     }
 
     #[test]

--- a/crates/glass-a11y-windows/src/events.rs
+++ b/crates/glass-a11y-windows/src/events.rs
@@ -1,7 +1,7 @@
 //! UI Automation change notifications, so a wait stops re-walking a tree that has not changed.
 //!
 //! A registration belongs to the COM apartment its thread initialized, so the pump thread outlives
-//! any single read — unlike the reader's per-snapshot threads.
+//! any single read — unlike the reader's per-call threads.
 //!
 //! Handlers run on UIA's own RPC threads, which is why nothing but a unit crosses the channel
 //! (see [`Notify`]).

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -1,13 +1,13 @@
-//! `WindowsA11y`: the UI Automation `Accessibility` reader. Runs UIA on a fresh
-//! per-snapshot thread (COM-isolated, like the AT-SPI reader's private thread),
-//! finds the app's top-level window by PID (geometry fallback), and walks the bounded Control view
-//! into an `AxTree`. Never returns a stub: failures are `AccessibilityUnavailable`.
+//! `WindowsA11y`: the UI Automation `Accessibility` reader. Runs each bounded call on a detached,
+//! COM-isolated thread (`glass_core::A11yThread`), finds the app's top-level window by PID
+//! (geometry fallback), and walks the bounded Control view into an `AxTree`. Never returns a stub:
+//! failures are `AccessibilityUnavailable`.
 
 use std::time::{Duration, Instant};
 
 use glass_core::{
-    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget, AxTree, ChangeSignal, GlassError,
-    Result, ThreadBoundReader, WalkBudget, normalize_description, read_back_confirms,
+    A11yThread, Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget, AxTree, ChangeSignal,
+    GlassError, Result, WalkBudget, normalize_description, read_back_confirms,
     write_took_no_effect,
 };
 use uiautomation::patterns::{
@@ -17,9 +17,10 @@ use uiautomation::patterns::{
 use uiautomation::types::{ExpandCollapseState, Handle, Rect, ToggleState};
 use uiautomation::{UIAutomation, UIElement, UITreeWalker};
 
-/// Every call runs on a fresh detached thread: UIA is COM and thread-affine, so it must not run on
-/// the caller's. Ten seconds is the hard cap, so a hung provider can't block the calling tool.
-const UIA: ThreadBoundReader = ThreadBoundReader::new("UIA", Duration::from_secs(10));
+/// Every bounded call runs on a fresh detached thread: UIA is COM and thread-affine, so it must
+/// not run on the caller's. The cap is what stops a hung provider blocking the calling tool for
+/// longer than it.
+static UIA: A11yThread = A11yThread::new("UIA", Duration::from_secs(10));
 /// Per-edge tolerance (px) for the set_value bounds-fingerprint check. Window-relative
 /// bounds are stable for a static element across snapshot→set_value (window moves cancel),
 /// so this only absorbs sub-pixel/timing jitter; a different element that drift landed on
@@ -63,14 +64,14 @@ impl Accessibility for WindowsA11y {
         let ctx = ctx.clone();
         let target = target.clone();
         let text = text.to_string();
-        UIA.write(move || run_set_value(&ctx, &target, &text))
+        UIA.set_value(move || run_set_value(&ctx, &target, &text))
     }
 
     fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<Option<AxNodeId>> {
         let ctx = ctx.clone();
         let target = target.clone();
         // This reader actuates the element it resolved, so it never substitutes another.
-        UIA.action(move || run_invoke(&ctx, &target)).map(|()| None)
+        UIA.invoke(move || run_invoke(&ctx, &target)).map(|()| None)
     }
 }
 
@@ -550,13 +551,6 @@ fn find_nth(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// The name this reader hands `glass_core` — it is what a timeout message blames, and nothing
-    /// else in the crate would notice it changing.
-    #[test]
-    fn a_timeout_from_this_reader_blames_uia() {
-        assert_eq!(UIA.subject(), "UIA");
-    }
 
     /// The failure mode this guards: if an absent child ever stopped arriving as a zero code,
     /// every leaf in every snapshot would report an unreadable subtree. Builds the error

--- a/crates/glass-a11y-windows/src/reader.rs
+++ b/crates/glass-a11y-windows/src/reader.rs
@@ -3,12 +3,11 @@
 //! finds the app's top-level window by PID (geometry fallback), and walks the bounded Control view
 //! into an `AxTree`. Never returns a stub: failures are `AccessibilityUnavailable`.
 
-use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use glass_core::{
-    Accessibility, AxContext, AxDeadline, AxNode, AxNodeId, AxRect, AxTarget, AxTree, ChangeSignal,
-    GlassError, Result, WalkBudget, normalize_description, read_back_confirms,
+    Accessibility, AxContext, AxNode, AxNodeId, AxRect, AxTarget, AxTree, ChangeSignal, GlassError,
+    Result, ThreadBoundReader, WalkBudget, normalize_description, read_back_confirms,
     write_took_no_effect,
 };
 use uiautomation::patterns::{
@@ -18,36 +17,9 @@ use uiautomation::patterns::{
 use uiautomation::types::{ExpandCollapseState, Handle, Rect, ToggleState};
 use uiautomation::{UIAutomation, UIElement, UITreeWalker};
 
-/// Hard cap so a hung UIA provider can't block the calling tool forever.
-const SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(10);
-
-/// How long a read may block for its worker, and whether the caller's deadline — not
-/// [`SNAPSHOT_TIMEOUT`] — is what ends the wait.
-///
-/// Both come from one comparison, decided before the wait: a read the *caller* cut short is a
-/// spent budget, a read that used the whole ceiling is UIA that stopped answering, and inferring
-/// which afterwards is the mistake glass#341 recorded.
-fn bounded_wait(deadline: AxDeadline) -> (Duration, bool) {
-    let own = Instant::now() + SNAPSHOT_TIMEOUT;
-    (
-        deadline.cap(own).saturating_duration_since(Instant::now()),
-        deadline.governs(own),
-    )
-}
-
-/// What a read reports when it never answered: the caller's own deadline ending it is
-/// `AccessibilityNotReady`, which [`glass_core::Glass::wait_for_element`] polls through, where UIA
-/// going quiet for a whole [`SNAPSHOT_TIMEOUT`] is not.
-fn never_answered(by_caller: bool) -> GlassError {
-    if by_caller {
-        return GlassError::AccessibilityNotReady(
-            "no accessibility tree within the time this call allowed".into(),
-        );
-    }
-    GlassError::AccessibilityUnavailable(
-        "accessibility snapshot timed out (UIA not responding)".into(),
-    )
-}
+/// Every call runs on a fresh detached thread: UIA is COM and thread-affine, so it must not run on
+/// the caller's. Ten seconds is the hard cap, so a hung provider can't block the calling tool.
+const UIA: ThreadBoundReader = ThreadBoundReader::new("UIA", Duration::from_secs(10));
 /// Per-edge tolerance (px) for the set_value bounds-fingerprint check. Window-relative
 /// bounds are stable for a static element across snapshot→set_value (window moves cancel),
 /// so this only absorbs sub-pixel/timing jitter; a different element that drift landed on
@@ -76,23 +48,8 @@ impl WindowsA11y {
 
 impl Accessibility for WindowsA11y {
     fn snapshot(&mut self, ctx: &AxContext) -> Result<AxTree> {
-        // Checked before the spawn: the worker below is detached and holds its own COM apartment,
-        // so one started for a caller that has stopped waiting outlives the answer nobody reads.
-        if ctx.deadline.has_passed() {
-            return Err(never_answered(true));
-        }
-        let (wait, by_caller) = bounded_wait(ctx.deadline);
         let ctx = ctx.clone();
-        let (tx, rx) = mpsc::channel();
-        // UIA is COM and thread-affine; run it on a fresh OS thread, fully decoupled
-        // from the caller's (possibly tokio) thread — mirrors the AT-SPI reader.
-        std::thread::spawn(move || {
-            let _ = tx.send(run_snapshot(&ctx));
-        });
-        match rx.recv_timeout(wait) {
-            Ok(r) => r,
-            Err(_) => Err(never_answered(by_caller)),
-        }
+        UIA.snapshot(ctx.deadline, move || run_snapshot(&ctx))
     }
 
     fn subscribe_changes(&mut self, ctx: &AxContext) -> Option<Box<dyn ChangeSignal>> {
@@ -106,37 +63,14 @@ impl Accessibility for WindowsA11y {
         let ctx = ctx.clone();
         let target = target.clone();
         let text = text.to_string();
-        let (tx, rx) = mpsc::channel();
-        std::thread::spawn(move || {
-            let _ = tx.send(run_set_value(&ctx, &target, &text));
-        });
-        match rx.recv_timeout(SNAPSHOT_TIMEOUT) {
-            Ok(r) => r,
-            Err(_) => Err(GlassError::AccessibilityUnavailable(
-                "accessibility set_value timed out (UIA not responding)".into(),
-            )),
-        }
+        UIA.write(move || run_set_value(&ctx, &target, &text))
     }
 
     fn invoke(&mut self, ctx: &AxContext, target: &AxTarget) -> Result<Option<AxNodeId>> {
         let ctx = ctx.clone();
         let target = target.clone();
-        let (tx, rx) = mpsc::channel();
-        std::thread::spawn(move || {
-            let _ = tx.send(run_invoke(&ctx, &target));
-        });
-        match rx.recv_timeout(SNAPSHOT_TIMEOUT) {
-            // This reader actuates the element it resolved, so it never substitutes another.
-            Ok(r) => r.map(|()| None),
-            // The worker thread outlives this timeout, so the pattern call may already have
-            // been dispatched — say so. This error is NOT fallback-eligible (see
-            // `GlassError::invoke_fallback_eligible`), so no pointer click is layered on top.
-            Err(_) => Err(GlassError::AccessibilityUnavailable(
-                "accessibility invoke timed out (UIA not responding); the action may still \
-                 land — re-snapshot before retrying"
-                    .into(),
-            )),
-        }
+        // This reader actuates the element it resolved, so it never substitutes another.
+        UIA.action(move || run_invoke(&ctx, &target)).map(|()| None)
     }
 }
 
@@ -196,7 +130,7 @@ fn step(r: uiautomation::Result<UIElement>, budget: &mut WalkBudget) -> Option<U
 }
 
 /// Recursively build a normalized node, bounded by [`WalkBudget`] (node count, nesting depth,
-/// and per-level sibling scan) so a pathological tree can't burn the outer [`SNAPSHOT_TIMEOUT`]
+/// and per-level sibling scan) so a pathological tree can't burn the reader's whole ceiling
 /// with no tree to show for it.
 fn walk(
     walker: &UITreeWalker,
@@ -617,36 +551,11 @@ fn find_nth(
 mod tests {
     use super::*;
 
-    /// glass#338: only the reader can hold a read inside the caller's timeout — the worker below
-    /// is detached, so nothing outside it can shorten one that has started.
+    /// The name this reader hands `glass_core` — it is what a timeout message blames, and nothing
+    /// else in the crate would notice it changing.
     #[test]
-    fn a_read_is_bounded_by_the_caller_when_that_falls_first() {
-        let (wait, by_caller) = bounded_wait(AxDeadline::from_millis(50));
-        assert!(wait <= Duration::from_millis(50), "{wait:?}");
-        assert!(by_caller);
-    }
-
-    /// The other direction: without it the test above passes on a reader that waits for nothing.
-    #[test]
-    fn a_caller_that_names_no_deadline_leaves_the_read_its_own_ceiling() {
-        let (wait, by_caller) = bounded_wait(AxDeadline::UNBOUNDED);
-        assert!(wait > SNAPSHOT_TIMEOUT - Duration::from_secs(1), "{wait:?}");
-        assert!(!by_caller);
-    }
-
-    /// The variant decides whether a wait polls on or fails, so the two causes must not collapse:
-    /// a bus that went quiet for the whole ceiling is a real fault, and a caller that ran out of
-    /// its own time is not.
-    #[test]
-    fn a_read_the_caller_cut_short_reads_as_not_ready_where_a_quiet_bus_does_not() {
-        assert!(matches!(
-            never_answered(true),
-            GlassError::AccessibilityNotReady(_)
-        ));
-        assert!(matches!(
-            never_answered(false),
-            GlassError::AccessibilityUnavailable(_)
-        ));
+    fn a_timeout_from_this_reader_blames_uia() {
+        assert_eq!(UIA.subject(), "UIA");
     }
 
     /// The failure mode this guards: if an absent child ever stopped arriving as a zero code,

--- a/crates/glass-core/src/a11y_thread.rs
+++ b/crates/glass-core/src/a11y_thread.rs
@@ -1,0 +1,259 @@
+//! Bounded calls for an accessibility backend whose platform API cannot run on the caller's
+//! thread.
+//!
+//! AT-SPI is async and would `block_on` inside the caller's tokio runtime; UIA is COM and
+//! thread-affine. Both readers therefore run every call on a fresh detached OS thread and wait on
+//! a channel. Detached is the load-bearing word: a wait that ends early does not end the work, so
+//! a caller told "no answer" has to learn *which* bound ended it — its own spent budget, which
+//! [`crate::Glass::wait_for_element`] polls through, or a backend that stopped answering, which it
+//! must not (glass#341).
+//!
+//! The macOS reader runs inline and does not use this: AX has no thread-affinity requirement.
+
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use crate::accessibility::AxDeadline;
+use crate::{GlassError, Result};
+
+/// One backend's detached-thread calls, each bounded by the caller's deadline or the reader's own
+/// ceiling, whichever falls first.
+pub struct ThreadBoundReader {
+    subject: &'static str,
+    ceiling: Duration,
+}
+
+impl ThreadBoundReader {
+    /// `subject` names the platform in a timeout message — "(`{subject}` not responding)" — and
+    /// `ceiling` is the reader's hard cap, so a backend that goes quiet cannot hang the calling
+    /// tool for longer than that.
+    pub const fn new(subject: &'static str, ceiling: Duration) -> ThreadBoundReader {
+        ThreadBoundReader { subject, ceiling }
+    }
+
+    /// The platform name this reader puts in a timeout message.
+    pub const fn subject(&self) -> &'static str {
+        self.subject
+    }
+
+    /// How long a call may block, and whether the caller's deadline — not the ceiling — is what
+    /// ends the wait.
+    ///
+    /// Both come from one comparison, decided before the wait: a call the *caller* cut short is a
+    /// spent budget, one that used the whole ceiling is a backend that stopped answering, and
+    /// inferring which afterwards is the mistake glass#341 recorded.
+    fn bounded_wait(&self, deadline: AxDeadline) -> (Duration, bool) {
+        let own = Instant::now() + self.ceiling;
+        (
+            deadline.cap(own).saturating_duration_since(Instant::now()),
+            deadline.governs(own),
+        )
+    }
+
+    /// Read the tree, bounded by whichever of the caller's deadline and the ceiling falls first.
+    ///
+    /// The deadline is checked before the spawn: a worker started for a caller that has already
+    /// stopped waiting outlives the answer nobody reads.
+    pub fn snapshot<T: Send + 'static>(
+        &self,
+        deadline: AxDeadline,
+        job: impl FnOnce() -> Result<T> + Send + 'static,
+    ) -> Result<T> {
+        if deadline.has_passed() {
+            return Err(self.never_answered(true));
+        }
+        let (wait, by_caller) = self.bounded_wait(deadline);
+        self.detached(wait, job, || self.never_answered(by_caller))
+    }
+
+    /// The verdict for a read that never answered. The caller's own deadline ending it is
+    /// `AccessibilityNotReady`, which [`crate::Glass::wait_for_element`] polls through, where the
+    /// backend going quiet for a whole ceiling is not.
+    fn never_answered(&self, by_caller: bool) -> GlassError {
+        if by_caller {
+            return GlassError::AccessibilityNotReady(
+                "no accessibility tree within the time this call allowed".into(),
+            );
+        }
+        GlassError::AccessibilityUnavailable(format!(
+            "accessibility snapshot timed out ({} not responding)",
+            self.subject
+        ))
+    }
+
+    /// Write a value, bounded by the ceiling alone.
+    pub fn write(&self, job: impl FnOnce() -> Result<()> + Send + 'static) -> Result<()> {
+        self.detached(self.ceiling, job, || {
+            GlassError::AccessibilityUnavailable(format!(
+                "accessibility set_value timed out ({} not responding)",
+                self.subject
+            ))
+        })
+    }
+
+    /// Actuate the element, bounded by the ceiling alone.
+    ///
+    /// Its timeout says the action may still land, because the worker outlives the wait — and it
+    /// is deliberately not fallback-eligible (see [`GlassError::invoke_fallback_eligible`]), so no
+    /// pointer click is layered on top of an action that may be about to fire.
+    pub fn action(&self, job: impl FnOnce() -> Result<()> + Send + 'static) -> Result<()> {
+        self.detached(self.ceiling, job, || {
+            GlassError::AccessibilityUnavailable(format!(
+                "accessibility invoke timed out ({} not responding); the action may still land — \
+                 re-snapshot before retrying",
+                self.subject
+            ))
+        })
+    }
+
+    fn detached<T: Send + 'static>(
+        &self,
+        wait: Duration,
+        job: impl FnOnce() -> Result<T> + Send + 'static,
+        timed_out: impl FnOnce() -> GlassError,
+    ) -> Result<T> {
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(job());
+        });
+        match rx.recv_timeout(wait) {
+            Ok(r) => r,
+            Err(_) => Err(timed_out()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CEILING: Duration = Duration::from_secs(10);
+
+    fn reader() -> ThreadBoundReader {
+        ThreadBoundReader::new("a11y bus", CEILING)
+    }
+
+    /// glass#338: only the reader can hold a call inside the caller's timeout — the worker is
+    /// detached, so nothing outside it can shorten one that has started.
+    #[test]
+    fn a_read_is_bounded_by_the_caller_when_that_falls_first() {
+        let (wait, by_caller) = reader().bounded_wait(AxDeadline::from_millis(50));
+        assert!(wait <= Duration::from_millis(50), "{wait:?}");
+        assert!(by_caller);
+    }
+
+    /// The other direction: without it the test above passes on a reader that waits for nothing.
+    #[test]
+    fn a_caller_that_names_no_deadline_leaves_the_read_its_own_ceiling() {
+        let (wait, by_caller) = reader().bounded_wait(AxDeadline::UNBOUNDED);
+        assert!(wait > CEILING - Duration::from_secs(1), "{wait:?}");
+        assert!(!by_caller);
+    }
+
+    /// The variant decides whether a wait polls on or fails, so the two causes must not collapse:
+    /// a backend that went quiet for the whole ceiling is a real fault, and a caller that ran out
+    /// of its own time is not.
+    #[test]
+    fn a_read_the_caller_cut_short_reads_as_not_ready_where_a_quiet_backend_does_not() {
+        assert!(matches!(
+            reader().never_answered(true),
+            GlassError::AccessibilityNotReady(_)
+        ));
+        assert!(matches!(
+            reader().never_answered(false),
+            GlassError::AccessibilityUnavailable(_)
+        ));
+    }
+
+    #[test]
+    fn a_timeout_names_the_backend_that_stopped_answering() {
+        let e = ThreadBoundReader::new("UIA", CEILING).never_answered(false);
+        assert!(e.to_string().contains("UIA not responding"), "{e}");
+    }
+
+    /// How long to watch for a worker that should not exist. Paired with the control below, which
+    /// fails if this window is ever too short for a spawned worker to report.
+    const WORKER_WATCH: Duration = Duration::from_millis(200);
+
+    #[test]
+    fn a_spent_deadline_is_refused_without_starting_a_worker() {
+        // Not just the verdict: with the pre-check gone the wait computes to zero and the caller
+        // still gets `NotReady`, so only the worker's own silence distinguishes the two.
+        let (started, ran) = mpsc::channel();
+        let r: Result<()> = reader().snapshot(AxDeadline::from_millis(0), move || {
+            let _ = started.send(());
+            Ok(())
+        });
+        assert!(
+            matches!(r, Err(GlassError::AccessibilityNotReady(_))),
+            "{r:?}"
+        );
+        assert!(
+            ran.recv_timeout(WORKER_WATCH).is_err(),
+            "a worker must not be started for a caller that has stopped waiting: it is detached, \
+             holds the backend's connection, and outlives the answer nobody reads"
+        );
+    }
+
+    #[test]
+    fn a_worker_that_is_started_reports_inside_that_same_window() {
+        // The control: without it the test above would pass on a window too short to see any
+        // worker at all.
+        let (started, ran) = mpsc::channel();
+        let _: Result<()> = reader().snapshot(AxDeadline::UNBOUNDED, move || {
+            let _ = started.send(());
+            Ok(())
+        });
+        assert!(ran.recv_timeout(WORKER_WATCH).is_ok());
+    }
+
+    #[test]
+    fn an_answer_within_the_bound_is_returned() {
+        assert_eq!(
+            reader().snapshot(AxDeadline::UNBOUNDED, || Ok(7)).unwrap(),
+            7
+        );
+    }
+
+    #[test]
+    fn the_jobs_own_error_is_returned_rather_than_a_timeout() {
+        let r: Result<()> = reader().write(|| Err(GlassError::AxUnsupported));
+        assert!(matches!(r, Err(GlassError::AxUnsupported)), "{r:?}");
+    }
+
+    #[test]
+    fn a_job_that_outruns_the_ceiling_times_out_naming_the_operation() {
+        let slow = ThreadBoundReader::new("a11y bus", Duration::from_millis(20));
+        let e = slow
+            .write(|| {
+                std::thread::sleep(Duration::from_secs(30));
+                Ok(())
+            })
+            .unwrap_err();
+        assert!(e.to_string().contains("set_value timed out"), "{e}");
+
+        let e = slow
+            .action(|| {
+                std::thread::sleep(Duration::from_secs(30));
+                Ok(())
+            })
+            .unwrap_err();
+        assert!(e.to_string().contains("invoke timed out"), "{e}");
+        assert!(e.to_string().contains("may still land"), "{e}");
+    }
+
+    #[test]
+    fn a_read_that_outruns_the_ceiling_blames_the_backend_not_the_caller() {
+        let slow = ThreadBoundReader::new("a11y bus", Duration::from_millis(20));
+        let e = slow
+            .snapshot(AxDeadline::UNBOUNDED, || {
+                std::thread::sleep(Duration::from_secs(30));
+                Ok(())
+            })
+            .unwrap_err();
+        assert!(
+            matches!(e, GlassError::AccessibilityUnavailable(_)),
+            "a caller that named no deadline cannot be the one that ran out: {e}"
+        );
+    }
+}

--- a/crates/glass-core/src/a11y_thread.rs
+++ b/crates/glass-core/src/a11y_thread.rs
@@ -1,124 +1,201 @@
-//! Bounded calls for an accessibility backend whose platform API cannot run on the caller's
-//! thread.
+//! Bounded accessibility calls for a backend that cannot be driven from the caller's thread.
 //!
-//! AT-SPI is async and would `block_on` inside the caller's tokio runtime; UIA is COM and
-//! thread-affine. Both readers therefore run every call on a fresh detached OS thread and wait on
-//! a channel. Detached is the load-bearing word: a wait that ends early does not end the work, so
-//! a caller told "no answer" has to learn *which* bound ended it — its own spent budget, which
-//! [`crate::Glass::wait_for_element`] polls through, or a backend that stopped answering, which it
-//! must not (glass#341).
+//! UIA is COM and thread-affine; the AT-SPI reader drives an async API with `block_on`, which
+//! panics inside the caller's tokio runtime. Both therefore run every bounded call — snapshot,
+//! set_value, invoke — on a fresh detached OS thread and wait on a channel. (`subscribe_changes`
+//! is not one of them: its own thread is the long-lived one.)
 //!
-//! The macOS reader runs inline and does not use this: AX has no thread-affinity requirement.
+//! Detached is load-bearing: a wait that ends early does not end the work, and the worker holds
+//! the backend's own connection. So a caller told "no answer" has to learn *which* bound ended it —
+//! its own spent budget, which [`crate::Glass::wait_for_element`] polls through, or a backend that
+//! stopped answering, which it must not poll through (glass#341).
+//!
+//! The other readers do not need this: macOS AX runs inline, and the Android and iOS readers bound
+//! their own subprocess calls.
 
-use std::sync::mpsc;
+use std::sync::mpsc::{self, RecvTimeoutError};
 use std::time::{Duration, Instant};
 
 use crate::accessibility::AxDeadline;
 use crate::{GlassError, Result};
 
-/// One backend's detached-thread calls, each bounded by the caller's deadline or the reader's own
-/// ceiling, whichever falls first.
-pub struct ThreadBoundReader {
-    subject: &'static str,
+/// Which bound ended a wait. Decided before the wait, never inferred from its outcome — the
+/// mistake glass#341 recorded.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum EndedBy {
+    /// The caller's own deadline fell first: a spent budget, not a fault.
+    Caller,
+    /// The reader's ceiling ran out: the backend stopped answering.
+    Ceiling,
+}
+
+/// The bounded calls one accessibility backend makes on its detached worker thread.
+///
+/// Configuration only. Anything stateful added here — an in-flight guard, a straggler count, a
+/// reused thread — must be shared across calls, so it belongs behind a lock rather than in a
+/// plain field.
+pub struct A11yThread {
+    backend: &'static str,
     ceiling: Duration,
 }
 
-impl ThreadBoundReader {
-    /// `subject` names the platform in a timeout message — "(`{subject}` not responding)" — and
-    /// `ceiling` is the reader's hard cap, so a backend that goes quiet cannot hang the calling
-    /// tool for longer than that.
-    pub const fn new(subject: &'static str, ceiling: Duration) -> ThreadBoundReader {
-        ThreadBoundReader { subject, ceiling }
+/// A bounded call, for the message its failure carries.
+#[derive(Clone, Copy)]
+enum Op {
+    Snapshot,
+    SetValue,
+    Invoke,
+}
+
+impl Op {
+    fn name(self) -> &'static str {
+        match self {
+            Op::Snapshot => "snapshot",
+            Op::SetValue => "set_value",
+            Op::Invoke => "invoke",
+        }
     }
 
-    /// The platform name this reader puts in a timeout message.
-    pub const fn subject(&self) -> &'static str {
-        self.subject
+    /// What a caller must know when the wait ended but the worker did not: the write or the action
+    /// may yet reach the element. A read has nothing to land, so it says nothing.
+    fn may_still_land(self) -> &'static str {
+        match self {
+            Op::Snapshot => "",
+            Op::SetValue => "; the write may still land — re-snapshot before retrying",
+            Op::Invoke => "; the action may still land — re-snapshot before retrying",
+        }
+    }
+}
+
+impl A11yThread {
+    /// `backend` is what a failure message blames — "(`{backend}` not responding)" — and `ceiling`
+    /// is the reader's hard cap, so a backend that goes quiet cannot hang the calling tool for
+    /// longer than that.
+    pub const fn new(backend: &'static str, ceiling: Duration) -> A11yThread {
+        assert!(!backend.is_empty(), "a failure message must name a backend");
+        assert!(
+            !ceiling.is_zero(),
+            "a zero ceiling fails every call while the work still runs"
+        );
+        A11yThread { backend, ceiling }
     }
 
-    /// How long a call may block, and whether the caller's deadline — not the ceiling — is what
-    /// ends the wait.
+    /// How long a call may block, and which bound ends it.
     ///
-    /// Both come from one comparison, decided before the wait: a call the *caller* cut short is a
-    /// spent budget, one that used the whole ceiling is a backend that stopped answering, and
+    /// Both come from one comparison, made before the wait: a call the *caller* cut short is a
+    /// spent budget and one that used the whole ceiling is a backend that stopped answering, and
     /// inferring which afterwards is the mistake glass#341 recorded.
-    fn bounded_wait(&self, deadline: AxDeadline) -> (Duration, bool) {
+    fn bounded_wait(&self, deadline: AxDeadline) -> (Duration, EndedBy) {
         let own = Instant::now() + self.ceiling;
+        let ended_by = if deadline.governs(own) {
+            EndedBy::Caller
+        } else {
+            EndedBy::Ceiling
+        };
         (
             deadline.cap(own).saturating_duration_since(Instant::now()),
-            deadline.governs(own),
+            ended_by,
         )
     }
 
     /// Read the tree, bounded by whichever of the caller's deadline and the ceiling falls first.
     ///
-    /// The deadline is checked before the spawn: a worker started for a caller that has already
-    /// stopped waiting outlives the answer nobody reads.
+    /// The deadline is checked before the spawn: a worker started for a caller that has stopped
+    /// waiting holds the backend's connection while producing an answer nobody reads.
     pub fn snapshot<T: Send + 'static>(
         &self,
         deadline: AxDeadline,
         job: impl FnOnce() -> Result<T> + Send + 'static,
     ) -> Result<T> {
         if deadline.has_passed() {
-            return Err(self.never_answered(true));
+            return Err(self.never_answered(EndedBy::Caller));
         }
-        let (wait, by_caller) = self.bounded_wait(deadline);
-        self.detached(wait, job, || self.never_answered(by_caller))
+        let (wait, ended_by) = self.bounded_wait(deadline);
+        self.detached(Op::Snapshot, wait, job, ended_by)
+    }
+
+    /// Write a value, bounded by the ceiling alone.
+    ///
+    /// No deadline: the seam places the capping obligation on `snapshot`, and the session builds
+    /// both this context and `invoke`'s with [`AxDeadline::UNBOUNDED`], so there is none to honour.
+    pub fn set_value(&self, job: impl FnOnce() -> Result<()> + Send + 'static) -> Result<()> {
+        self.detached(Op::SetValue, self.ceiling, job, EndedBy::Ceiling)
+    }
+
+    /// Actuate the element, bounded by the ceiling alone.
+    ///
+    /// Its failures stay [`GlassError::AccessibilityUnavailable`], which
+    /// [`GlassError::invoke_fallback_eligible`] excludes — so no pointer click is layered on top of
+    /// an action that may be about to fire.
+    pub fn invoke(&self, job: impl FnOnce() -> Result<()> + Send + 'static) -> Result<()> {
+        self.detached(Op::Invoke, self.ceiling, job, EndedBy::Ceiling)
     }
 
     /// The verdict for a read that never answered. The caller's own deadline ending it is
     /// `AccessibilityNotReady`, which [`crate::Glass::wait_for_element`] polls through, where the
     /// backend going quiet for a whole ceiling is not.
-    fn never_answered(&self, by_caller: bool) -> GlassError {
-        if by_caller {
-            return GlassError::AccessibilityNotReady(
+    fn never_answered(&self, ended_by: EndedBy) -> GlassError {
+        match ended_by {
+            EndedBy::Caller => GlassError::AccessibilityNotReady(
                 "no accessibility tree within the time this call allowed".into(),
-            );
+            ),
+            EndedBy::Ceiling => self.timed_out(Op::Snapshot),
         }
+    }
+
+    fn timed_out(&self, op: Op) -> GlassError {
         GlassError::AccessibilityUnavailable(format!(
-            "accessibility snapshot timed out ({} not responding)",
-            self.subject
+            "accessibility {} timed out ({} not responding){}",
+            op.name(),
+            self.backend,
+            op.may_still_land()
         ))
     }
 
-    /// Write a value, bounded by the ceiling alone.
-    pub fn write(&self, job: impl FnOnce() -> Result<()> + Send + 'static) -> Result<()> {
-        self.detached(self.ceiling, job, || {
-            GlassError::AccessibilityUnavailable(format!(
-                "accessibility set_value timed out ({} not responding)",
-                self.subject
-            ))
-        })
-    }
-
-    /// Actuate the element, bounded by the ceiling alone.
-    ///
-    /// Its timeout says the action may still land, because the worker outlives the wait — and it
-    /// is deliberately not fallback-eligible (see [`GlassError::invoke_fallback_eligible`]), so no
-    /// pointer click is layered on top of an action that may be about to fire.
-    pub fn action(&self, job: impl FnOnce() -> Result<()> + Send + 'static) -> Result<()> {
-        self.detached(self.ceiling, job, || {
-            GlassError::AccessibilityUnavailable(format!(
-                "accessibility invoke timed out ({} not responding); the action may still land — \
-                 re-snapshot before retrying",
-                self.subject
-            ))
-        })
+    /// A worker that unwound. Never `AccessibilityNotReady`: a wait polls through that variant, so
+    /// a reader panicking on every attempt would be reported as a caller running out of time, for
+    /// the caller's whole window. The panic can land either side of the call reaching the element,
+    /// so a write and an action keep their may-still-land caveat.
+    fn worker_panicked(&self, op: Op) -> GlassError {
+        GlassError::AccessibilityUnavailable(format!(
+            "the {} accessibility worker panicked during {} — the panic is on glass's stderr{}",
+            self.backend,
+            op.name(),
+            op.may_still_land()
+        ))
     }
 
     fn detached<T: Send + 'static>(
         &self,
+        op: Op,
         wait: Duration,
         job: impl FnOnce() -> Result<T> + Send + 'static,
-        timed_out: impl FnOnce() -> GlassError,
+        ended_by: EndedBy,
     ) -> Result<T> {
         let (tx, rx) = mpsc::channel();
-        std::thread::spawn(move || {
-            let _ = tx.send(job());
-        });
+        // Named and fallible, unlike a bare `spawn`: a timed-out worker outlives its wait holding
+        // the backend's connection, so several can be alive at once, and the OS refusing one is an
+        // error this call can report rather than a panic in the caller.
+        std::thread::Builder::new()
+            .name(format!("glass-a11y-{}", self.backend))
+            .spawn(move || {
+                let _ = tx.send(job());
+            })
+            .map_err(|e| {
+                GlassError::AccessibilityUnavailable(format!(
+                    "could not start the {} accessibility worker: {e}",
+                    self.backend
+                ))
+            })?;
         match rx.recv_timeout(wait) {
             Ok(r) => r,
-            Err(_) => Err(timed_out()),
+            Err(RecvTimeoutError::Timeout) => Err(match op {
+                Op::Snapshot => self.never_answered(ended_by),
+                _ => self.timed_out(op),
+            }),
+            // The sender drops unsent only when the worker unwinds, so this is a panic, not a
+            // slow answer — a timeout would claim the backend is alive and still working.
+            Err(RecvTimeoutError::Disconnected) => Err(self.worker_panicked(op)),
         }
     }
 }
@@ -128,26 +205,41 @@ mod tests {
     use super::*;
 
     const CEILING: Duration = Duration::from_secs(10);
+    /// Short enough that a test can wait out the whole thing.
+    const IMPATIENT: Duration = Duration::from_millis(20);
 
-    fn reader() -> ThreadBoundReader {
-        ThreadBoundReader::new("a11y bus", CEILING)
+    fn reader() -> A11yThread {
+        A11yThread::new("a11y bus", CEILING)
+    }
+
+    fn impatient() -> A11yThread {
+        A11yThread::new("a11y bus", IMPATIENT)
+    }
+
+    /// A job that never answers inside an [`IMPATIENT`] ceiling. Half a second, not thirty: each
+    /// call leaves this thread sleeping after the test has moved on.
+    fn hangs() -> impl FnOnce() -> Result<()> + Send + 'static {
+        || {
+            std::thread::sleep(Duration::from_millis(500));
+            Ok(())
+        }
     }
 
     /// glass#338: only the reader can hold a call inside the caller's timeout — the worker is
     /// detached, so nothing outside it can shorten one that has started.
     #[test]
     fn a_read_is_bounded_by_the_caller_when_that_falls_first() {
-        let (wait, by_caller) = reader().bounded_wait(AxDeadline::from_millis(50));
+        let (wait, ended_by) = reader().bounded_wait(AxDeadline::from_millis(50));
         assert!(wait <= Duration::from_millis(50), "{wait:?}");
-        assert!(by_caller);
+        assert_eq!(ended_by, EndedBy::Caller);
     }
 
     /// The other direction: without it the test above passes on a reader that waits for nothing.
     #[test]
     fn a_caller_that_names_no_deadline_leaves_the_read_its_own_ceiling() {
-        let (wait, by_caller) = reader().bounded_wait(AxDeadline::UNBOUNDED);
+        let (wait, ended_by) = reader().bounded_wait(AxDeadline::UNBOUNDED);
         assert!(wait > CEILING - Duration::from_secs(1), "{wait:?}");
-        assert!(!by_caller);
+        assert_eq!(ended_by, EndedBy::Ceiling);
     }
 
     /// The variant decides whether a wait polls on or fails, so the two causes must not collapse:
@@ -156,29 +248,27 @@ mod tests {
     #[test]
     fn a_read_the_caller_cut_short_reads_as_not_ready_where_a_quiet_backend_does_not() {
         assert!(matches!(
-            reader().never_answered(true),
+            reader().never_answered(EndedBy::Caller),
             GlassError::AccessibilityNotReady(_)
         ));
         assert!(matches!(
-            reader().never_answered(false),
+            reader().never_answered(EndedBy::Ceiling),
             GlassError::AccessibilityUnavailable(_)
         ));
     }
 
     #[test]
     fn a_timeout_names_the_backend_that_stopped_answering() {
-        let e = ThreadBoundReader::new("UIA", CEILING).never_answered(false);
+        let e = A11yThread::new("UIA", CEILING).never_answered(EndedBy::Ceiling);
         assert!(e.to_string().contains("UIA not responding"), "{e}");
     }
 
-    /// How long to watch for a worker that should not exist. Paired with the control below, which
-    /// fails if this window is ever too short for a spawned worker to report.
-    const WORKER_WATCH: Duration = Duration::from_millis(200);
-
     #[test]
     fn a_spent_deadline_is_refused_without_starting_a_worker() {
-        // Not just the verdict: with the pre-check gone the wait computes to zero and the caller
-        // still gets `NotReady`, so only the worker's own silence distinguishes the two.
+        // With the pre-check gone the wait computes to zero and the caller still gets `NotReady`,
+        // so only the worker's absence distinguishes the two. Asserted as a disconnect rather than
+        // a quiet window, which would be a race: refusing drops `job` unrun and its `Sender` with
+        // it, where a worker that ran would have sent. No load can turn one into the other.
         let (started, ran) = mpsc::channel();
         let r: Result<()> = reader().snapshot(AxDeadline::from_millis(0), move || {
             let _ = started.send(());
@@ -189,22 +279,10 @@ mod tests {
             "{r:?}"
         );
         assert!(
-            ran.recv_timeout(WORKER_WATCH).is_err(),
-            "a worker must not be started for a caller that has stopped waiting: it is detached, \
-             holds the backend's connection, and outlives the answer nobody reads"
+            matches!(ran.try_recv(), Err(mpsc::TryRecvError::Disconnected)),
+            "a worker must not be started for a caller that has stopped waiting: it is detached \
+             and holds the backend's connection while producing an answer nobody reads"
         );
-    }
-
-    #[test]
-    fn a_worker_that_is_started_reports_inside_that_same_window() {
-        // The control: without it the test above would pass on a window too short to see any
-        // worker at all.
-        let (started, ran) = mpsc::channel();
-        let _: Result<()> = reader().snapshot(AxDeadline::UNBOUNDED, move || {
-            let _ = started.send(());
-            Ok(())
-        });
-        assert!(ran.recv_timeout(WORKER_WATCH).is_ok());
     }
 
     #[test]
@@ -217,43 +295,99 @@ mod tests {
 
     #[test]
     fn the_jobs_own_error_is_returned_rather_than_a_timeout() {
-        let r: Result<()> = reader().write(|| Err(GlassError::AxUnsupported));
+        let r: Result<()> = reader().set_value(|| Err(GlassError::AxUnsupported));
         assert!(matches!(r, Err(GlassError::AxUnsupported)), "{r:?}");
     }
 
     #[test]
-    fn a_job_that_outruns_the_ceiling_times_out_naming_the_operation() {
-        let slow = ThreadBoundReader::new("a11y bus", Duration::from_millis(20));
-        let e = slow
-            .write(|| {
-                std::thread::sleep(Duration::from_secs(30));
-                Ok(())
-            })
-            .unwrap_err();
+    fn a_job_that_outruns_the_ceiling_names_the_operation_that_timed_out() {
+        let e = impatient().set_value(hangs()).unwrap_err();
         assert!(e.to_string().contains("set_value timed out"), "{e}");
 
-        let e = slow
-            .action(|| {
-                std::thread::sleep(Duration::from_secs(30));
-                Ok(())
-            })
-            .unwrap_err();
+        let e = impatient().invoke(hangs()).unwrap_err();
         assert!(e.to_string().contains("invoke timed out"), "{e}");
-        assert!(e.to_string().contains("may still land"), "{e}");
+        // The variant, not the prose, is what withholds the pointer-click fallback from an action
+        // that may be about to fire.
+        assert!(!e.invoke_fallback_eligible(), "{e}");
+    }
+
+    /// The worker outlives the wait for a write as it does for an action — an agent told only
+    /// "timed out" retypes the text, and the abandoned worker writes it again.
+    #[test]
+    fn a_write_or_an_action_that_timed_out_says_it_may_still_land() {
+        for e in [
+            impatient().set_value(hangs()).unwrap_err(),
+            impatient().invoke(hangs()).unwrap_err(),
+        ] {
+            assert!(e.to_string().contains("may still land"), "{e}");
+        }
+    }
+
+    /// A read has nothing in flight to land, so the caveat would be noise.
+    #[test]
+    fn a_read_that_timed_out_claims_nothing_about_landing() {
+        let e = impatient()
+            .snapshot(AxDeadline::UNBOUNDED, hangs())
+            .unwrap_err();
+        assert!(e.to_string().contains("snapshot timed out"), "{e}");
+        assert!(!e.to_string().contains("may still land"), "{e}");
+    }
+
+    /// The direction that costs more: blamed on the backend, a slow app during a
+    /// `wait_for_element` aborts the whole wait instead of polling on.
+    #[test]
+    fn a_read_the_caller_ran_out_of_time_for_blames_the_caller_not_the_backend() {
+        // A live deadline well inside the ceiling, against a job that will not answer within it.
+        let r: Result<()> = reader().snapshot(AxDeadline::from_millis(30), hangs());
+        assert!(
+            matches!(r, Err(GlassError::AccessibilityNotReady(_))),
+            "{r:?}"
+        );
     }
 
     #[test]
     fn a_read_that_outruns_the_ceiling_blames_the_backend_not_the_caller() {
-        let slow = ThreadBoundReader::new("a11y bus", Duration::from_millis(20));
-        let e = slow
-            .snapshot(AxDeadline::UNBOUNDED, || {
-                std::thread::sleep(Duration::from_secs(30));
-                Ok(())
-            })
+        let e = impatient()
+            .snapshot(AxDeadline::UNBOUNDED, hangs())
             .unwrap_err();
         assert!(
             matches!(e, GlassError::AccessibilityUnavailable(_)),
             "a caller that named no deadline cannot be the one that ran out: {e}"
         );
+    }
+
+    /// A panicking worker drops its sender, which `recv_timeout` reports at once. Called a
+    /// timeout, that claims the backend is alive and working; for a read it claims the caller ran
+    /// out of time, which `wait_for_element` polls straight through.
+    #[test]
+    fn a_worker_that_panicked_is_not_reported_as_a_backend_that_went_quiet() {
+        let e: GlassError = reader()
+            .set_value(|| panic!("the backend crate unwound"))
+            .unwrap_err();
+        assert!(e.to_string().contains("panicked"), "{e}");
+        assert!(!e.to_string().contains("timed out"), "{e}");
+    }
+
+    #[test]
+    fn a_panicking_read_is_never_the_variant_a_wait_polls_through() {
+        let e = reader()
+            .snapshot(AxDeadline::from_millis(60_000), || -> Result<()> {
+                panic!("the backend crate unwound")
+            })
+            .unwrap_err();
+        assert!(
+            matches!(e, GlassError::AccessibilityUnavailable(_)),
+            "a panic reported as NotReady is re-attempted for the caller's whole window: {e}"
+        );
+    }
+
+    /// A panic can land either side of the call reaching the element, so the caveat a read does
+    /// not need still applies here.
+    #[test]
+    fn a_panicking_action_still_says_it_may_have_landed() {
+        let e = reader()
+            .invoke(|| panic!("unwound after dispatch"))
+            .unwrap_err();
+        assert!(e.to_string().contains("may still land"), "{e}");
     }
 }

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -16,7 +16,7 @@ pub mod bounded;
 pub use bounded::{run_bounded, run_bounded_until, run_bounded_with_stdin};
 
 pub mod a11y_thread;
-pub use a11y_thread::ThreadBoundReader;
+pub use a11y_thread::A11yThread;
 
 pub mod set_value;
 pub use set_value::{

--- a/crates/glass-core/src/lib.rs
+++ b/crates/glass-core/src/lib.rs
@@ -15,6 +15,9 @@ pub use toolpath::tool_path;
 pub mod bounded;
 pub use bounded::{run_bounded, run_bounded_until, run_bounded_with_stdin};
 
+pub mod a11y_thread;
+pub use a11y_thread::ThreadBoundReader;
+
 pub mod set_value;
 pub use set_value::{
     TAP_MAY_HAVE_MISSED, read_back_confirms, read_back_failed, typed_clear_landed,


### PR DESCRIPTION
Next entry from the `cargo dupes` list: `glass-a11y-linux` and `glass-a11y-windows` each carried their own copy of the same detached-thread call shell — `bounded_wait`, `never_answered`, and the wrappers inside `snapshot`/`set_value`/`invoke` — differing only in whether a timeout says "a11y bus" or "UIA".

UIA is COM and thread-affine; the AT-SPI reader drives an async API with `block_on`, which panics inside the caller's tokio runtime. Both answer that the same way, so both now use `A11yThread` from `glass-core`, constructed once per reader with its backend name and its ceiling. `snapshot` is deadline-aware; `set_value` and `invoke` are bounded by the ceiling alone, which is what the seam already did — the session builds both those contexts `UNBOUNDED`. The distinction glass#341 recorded is stated once: a call the caller cut short is a spent budget that `wait_for_element` polls through, and one that used the whole ceiling is a backend that stopped answering, which it must not.

## The defect review found

All six pre-move copies collapsed `recv_timeout`'s two failures into `Err(_)`. `Timeout` means the worker is still running and may yet answer; `Disconnected` is returned only because the worker unwound and dropped the sender. Opposite facts, one verdict.

It is worst where it is least visible. A reader that panics on a particular app's tree returns `AccessibilityNotReady` in microseconds against a ten-second ceiling — the variant `wait_for_element` deliberately polls through — so the wait spends its whole window re-spawning panicking workers and then reports the element missing and the tree never ready. Neither is true: no time was spent, and the tree is unreachable rather than slow. For `invoke`, the message claims the action may still land, which withholds the pointer-click fallback that would have worked.

A panic now has its own verdict and never the poll-through variant. It keeps the may-still-land caveat for a write and an action, since a panic can land either side of the call reaching the element.

`set_value`'s timeout gains the caveat `invoke`'s already had — the worker outlives the wait identically for both, and an agent told only "timed out" retypes the text while the abandoned worker writes it again.

Also: `Builder::spawn` with a named thread, so a refused spawn is a structured error rather than a panic in the caller; `static` rather than `const` in both readers, since a `const` is inlined per use site and would silently copy the first stateful field anyone adds; and `EndedBy` in place of the bool, matching `BoundKind` next door.

## Verification

`cargo nextest run --workspace`: 2270 passed. fmt and workspace clippy clean. The macOS reader cross-compiles clean for `x86_64-apple-darwin`, and the Windows leg was run rather than only compiled — 39 tests under wine with a fresh `CARGO_TARGET_DIR`.

Thirteen ablations across the two commits. Two survived the first pass and are why two tests exist: the glass#341 inversion in the direction that aborts a wait had no test at all, and "no worker is started for a departed caller" was a race a one-nanosecond window would have kept green — it now asserts the disconnect that refusing produces, which no load can turn into a send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)