### PR TITLE
refactor(x11): one way to report a clipboard setup failure, and one way to intern

### DIFF
--- a/crates/glass-x11/src/clipboard.rs
+++ b/crates/glass-x11/src/clipboard.rs
@@ -23,36 +23,30 @@ struct GetAtoms {
     glass_clip: Atom,
 }
 
+/// Intern one atom, naming which half of the round trip failed.
+///
+/// Both halves are named because they fail for different reasons: the request errors when the
+/// connection is already broken, the reply when the server rejected it. `wrap` turns the message
+/// into the caller's error type — the owner thread's has to signal the spawner on its way out.
+fn intern<E>(
+    conn: &RustConnection,
+    name: &str,
+    wrap: impl Fn(String) -> E,
+) -> std::result::Result<Atom, E> {
+    Ok(conn
+        .intern_atom(false, name.as_bytes())
+        .map_err(|e| wrap(format!("intern {name}: {e}")))?
+        .reply()
+        .map_err(|e| wrap(format!("intern {name} reply: {e}")))?
+        .atom)
+}
+
 fn intern_get_atoms(conn: &RustConnection) -> Result<GetAtoms> {
-    let clipboard = conn
-        .intern_atom(false, b"CLIPBOARD")
-        .map_err(|e| GlassError::Backend(format!("intern CLIPBOARD: {e}")))?
-        .reply()
-        .map_err(|e| GlassError::Backend(format!("intern CLIPBOARD reply: {e}")))?
-        .atom;
-    let utf8_string = conn
-        .intern_atom(false, b"UTF8_STRING")
-        .map_err(|e| GlassError::Backend(format!("intern UTF8_STRING: {e}")))?
-        .reply()
-        .map_err(|e| GlassError::Backend(format!("intern UTF8_STRING reply: {e}")))?
-        .atom;
-    let incr = conn
-        .intern_atom(false, b"INCR")
-        .map_err(|e| GlassError::Backend(format!("intern INCR: {e}")))?
-        .reply()
-        .map_err(|e| GlassError::Backend(format!("intern INCR reply: {e}")))?
-        .atom;
-    let glass_clip = conn
-        .intern_atom(false, b"GLASS_CLIP")
-        .map_err(|e| GlassError::Backend(format!("intern GLASS_CLIP: {e}")))?
-        .reply()
-        .map_err(|e| GlassError::Backend(format!("intern GLASS_CLIP reply: {e}")))?
-        .atom;
     Ok(GetAtoms {
-        clipboard,
-        utf8_string,
-        incr,
-        glass_clip,
+        clipboard: intern(conn, "CLIPBOARD", GlassError::Backend)?,
+        utf8_string: intern(conn, "UTF8_STRING", GlassError::Backend)?,
+        incr: intern(conn, "INCR", GlassError::Backend)?,
+        glass_clip: intern(conn, "GLASS_CLIP", GlassError::Backend)?,
     })
 }
 
@@ -323,77 +317,41 @@ fn signal_ready(ready: &Arc<(Mutex<ReadyState>, Condvar)>, state: ReadyState) {
     cvar.notify_one();
 }
 
+/// Report a setup failure to the spawner and stop the thread, handing `msg` back as the error.
+///
+/// Every fallible step before the `ReadyState::Ok` signal must go through this. The spawner blocks
+/// on the condvar, so a step that returns without signalling leaves it waiting out its own timeout
+/// and reporting a timeout for a failure that already had a message.
+fn setup_failed(
+    ready: &Arc<(Mutex<ReadyState>, Condvar)>,
+    stop: &AtomicBool,
+    msg: String,
+) -> String {
+    signal_ready(ready, ReadyState::Err(msg.clone()));
+    stop.store(true, Ordering::Relaxed);
+    msg
+}
+
 fn owner_thread(
     display: &str,
     text: Arc<Mutex<String>>,
     stop: Arc<AtomicBool>,
     ready: Arc<(Mutex<ReadyState>, Condvar)>,
 ) -> std::result::Result<(), Box<dyn std::error::Error>> {
-    let (conn, screen_num) = x11rb::connect(Some(display)).map_err(|e| {
-        let msg = format!("X connect: {e}");
-        signal_ready(&ready, ReadyState::Err(msg.clone()));
-        stop.store(true, Ordering::Relaxed);
-        msg
-    })?;
+    let failed = |msg| setup_failed(&ready, &stop, msg);
+    let (conn, screen_num) =
+        x11rb::connect(Some(display)).map_err(|e| failed(format!("X connect: {e}")))?;
     let root = conn.setup().roots[screen_num].root;
 
     // Intern atoms on this connection.
-    let clipboard = conn
-        .intern_atom(false, b"CLIPBOARD")
-        .map_err(|e| {
-            let msg = format!("intern CLIPBOARD: {e}");
-            signal_ready(&ready, ReadyState::Err(msg.clone()));
-            stop.store(true, Ordering::Relaxed);
-            msg
-        })?
-        .reply()
-        .map_err(|e| {
-            let msg = format!("intern CLIPBOARD reply: {e}");
-            signal_ready(&ready, ReadyState::Err(msg.clone()));
-            stop.store(true, Ordering::Relaxed);
-            msg
-        })?
-        .atom;
-    let utf8_string = conn
-        .intern_atom(false, b"UTF8_STRING")
-        .map_err(|e| {
-            let msg = format!("intern UTF8_STRING: {e}");
-            signal_ready(&ready, ReadyState::Err(msg.clone()));
-            stop.store(true, Ordering::Relaxed);
-            msg
-        })?
-        .reply()
-        .map_err(|e| {
-            let msg = format!("intern UTF8_STRING reply: {e}");
-            signal_ready(&ready, ReadyState::Err(msg.clone()));
-            stop.store(true, Ordering::Relaxed);
-            msg
-        })?
-        .atom;
-    let targets_atom = conn
-        .intern_atom(false, b"TARGETS")
-        .map_err(|e| {
-            let msg = format!("intern TARGETS: {e}");
-            signal_ready(&ready, ReadyState::Err(msg.clone()));
-            stop.store(true, Ordering::Relaxed);
-            msg
-        })?
-        .reply()
-        .map_err(|e| {
-            let msg = format!("intern TARGETS reply: {e}");
-            signal_ready(&ready, ReadyState::Err(msg.clone()));
-            stop.store(true, Ordering::Relaxed);
-            msg
-        })?
-        .atom;
+    let clipboard = intern(&conn, "CLIPBOARD", failed)?;
+    let utf8_string = intern(&conn, "UTF8_STRING", failed)?;
+    let targets_atom = intern(&conn, "TARGETS", failed)?;
 
     // Create the owner window.
-    let win = conn.generate_id().map_err(|e| {
-        let msg = format!("generate_id: {e}");
-        signal_ready(&ready, ReadyState::Err(msg.clone()));
-        stop.store(true, Ordering::Relaxed);
-        msg
-    })?;
+    let win = conn
+        .generate_id()
+        .map_err(|e| failed(format!("generate_id: {e}")))?;
     conn.create_window(
         0,
         win,
@@ -407,19 +365,9 @@ fn owner_thread(
         0,
         &CreateWindowAux::default(),
     )
-    .map_err(|e| {
-        let msg = format!("create_window: {e}");
-        signal_ready(&ready, ReadyState::Err(msg.clone()));
-        stop.store(true, Ordering::Relaxed);
-        msg
-    })?
+    .map_err(|e| failed(format!("create_window: {e}")))?
     .check()
-    .map_err(|e| {
-        let msg = format!("create_window check: {e}");
-        signal_ready(&ready, ReadyState::Err(msg.clone()));
-        stop.store(true, Ordering::Relaxed);
-        msg
-    })?;
+    .map_err(|e| failed(format!("create_window check: {e}")))?;
 
     // A detached thread (spawn already timed out and returned to the caller) must not take a
     // selection the caller has already been told it failed to get. `spawn`'s detach comment
@@ -433,25 +381,11 @@ fn owner_thread(
 
     // Take ownership of CLIPBOARD.
     conn.set_selection_owner(win, clipboard, x11rb::CURRENT_TIME)
-        .map_err(|e| {
-            let msg = format!("set_selection_owner: {e}");
-            signal_ready(&ready, ReadyState::Err(msg.clone()));
-            stop.store(true, Ordering::Relaxed);
-            msg
-        })?
+        .map_err(|e| failed(format!("set_selection_owner: {e}")))?
         .check()
-        .map_err(|e| {
-            let msg = format!("set_selection_owner check: {e}");
-            signal_ready(&ready, ReadyState::Err(msg.clone()));
-            stop.store(true, Ordering::Relaxed);
-            msg
-        })?;
-    conn.flush().map_err(|e| {
-        let msg = format!("flush after set_selection_owner: {e}");
-        signal_ready(&ready, ReadyState::Err(msg.clone()));
-        stop.store(true, Ordering::Relaxed);
-        msg
-    })?;
+        .map_err(|e| failed(format!("set_selection_owner check: {e}")))?;
+    conn.flush()
+        .map_err(|e| failed(format!("flush after set_selection_owner: {e}")))?;
 
     // Signal the spawner that we now own the selection.
     signal_ready(&ready, ReadyState::Ok);
@@ -771,10 +705,42 @@ mod tests {
 
     #[test]
     fn spawning_against_an_unreachable_display_fails_instead_of_hanging() {
+        let started = Instant::now();
         let Err(err) = ClipboardOwner::spawn(":9999".to_string(), "text".to_string()) else {
             panic!("there is no server on :9999, so no owner can take its selection");
         };
         assert!(matches!(err, GlassError::Backend(_)), "{err:?}");
+        // The connect failure's own words, not a generic one: a setup step that reported nothing
+        // would leave the spawner to time out and blame the wait instead.
+        assert!(err.to_string().contains("X connect"), "{err}");
+        // And it must arrive by being signalled, not by the 2 s readiness bound expiring — which
+        // is the only difference a caller sees when a setup step forgets to signal.
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "{:?}",
+            started.elapsed()
+        );
+    }
+
+    /// The one thing every fallible setup step in `owner_thread` must do. A step that returns
+    /// without it leaves the spawner on the condvar until its own bound expires, reporting a
+    /// timeout for a failure that already had a message.
+    #[test]
+    fn a_setup_failure_signals_the_spawner_stops_the_thread_and_keeps_its_message() {
+        let ready = Arc::new((Mutex::new(ReadyState::Pending), Condvar::new()));
+        let stop = Arc::new(AtomicBool::new(false));
+
+        let returned = setup_failed(&ready, &stop, "X connect: refused".to_string());
+
+        assert_eq!(returned, "X connect: refused");
+        assert!(
+            stop.load(Ordering::Relaxed),
+            "the thread must not go on to take the selection"
+        );
+        match &*recover_readiness("test", ready.0.lock()) {
+            ReadyState::Err(msg) => assert_eq!(msg, "X connect: refused"),
+            _ => panic!("the spawner was left on Pending and will wait out its bound"),
+        }
     }
 
     /// Bind the X11 TCP port of the first free display number, returning a listener and the

--- a/crates/glass-x11/src/clipboard.rs
+++ b/crates/glass-x11/src/clipboard.rs
@@ -25,9 +25,8 @@ struct GetAtoms {
 
 /// Intern one atom, naming which half of the round trip failed.
 ///
-/// Both halves are named because a round trip can fail at either end and the remedies differ.
-/// `wrap` turns the message into the caller's error type — the owner thread's has to signal the
-/// spawner on its way out, so it cannot be the one the getter uses.
+/// `wrap` turns the message into the caller's error type: the owner thread's has to signal the
+/// spawner on its way out, so it cannot be the getter's.
 fn intern<E>(
     conn: &RustConnection,
     name: &str,
@@ -319,9 +318,8 @@ fn signal_ready(ready: &Arc<(Mutex<ReadyState>, Condvar)>, state: ReadyState) {
 
 /// A setup failure that has already been reported to the spawner.
 ///
-/// Only [`setup_failed`] constructs one, and [`take_selection`] returns nothing else, so a step in
-/// there cannot report through `GlassError` and leave the spawner waiting out its bound — that
-/// mistake is a compile error rather than a silent two-second stall.
+/// Only [`setup_failed`] constructs one and [`take_selection`] returns nothing else, so reporting
+/// a step's failure through `GlassError` instead is a compile error.
 #[derive(Debug)]
 struct SetupFailed(String);
 
@@ -335,9 +333,9 @@ impl std::error::Error for SetupFailed {}
 
 /// Report a setup failure to the spawner and stop the thread, handing `msg` back as the error.
 ///
-/// Every fallible step before the `ReadyState::Ok` signal must go through this. The spawner blocks
-/// on the condvar, so a step that returns without signalling leaves it waiting out its own timeout
-/// and reporting a timeout for a failure that already had a message.
+/// Every fallible step before the `ReadyState::Ok` signal goes through this: the spawner blocks on
+/// the condvar, so one that returns without signalling leaves it to time out and blame the wait for
+/// a failure that already had a message.
 #[must_use = "the caller must return this, or the spawner is told a failure the thread ignored"]
 fn setup_failed(
     ready: &Arc<(Mutex<ReadyState>, Condvar)>,
@@ -345,8 +343,8 @@ fn setup_failed(
     msg: String,
 ) -> SetupFailed {
     signal_ready(ready, ReadyState::Err(msg.clone()));
-    // Not read on any path a failed setup can reach — `spawn` returns `Err`, so no
-    // `ClipboardOwner` exists to consult `is_alive`. It is here for a caller added later.
+    // Inert today — `spawn` returns `Err`, so no `ClipboardOwner` exists to consult `is_alive`.
+    // Kept for a caller added later.
     stop.store(true, Ordering::Relaxed);
     SetupFailed(msg)
 }
@@ -439,8 +437,8 @@ fn owner_thread(
         return Ok(());
     };
 
-    // Past this point `setup_failed` is out of scope, so a later failure cannot overwrite an `Ok`
-    // the spawner may not have read yet.
+    // Past here `setup_failed` is out of scope, so a later failure cannot overwrite an `Ok` the
+    // spawner may not have read.
     signal_ready(&ready, ReadyState::Ok);
 
     // Event loop: serve SelectionRequest until stopped or SelectionClear arrives.
@@ -763,11 +761,11 @@ mod tests {
             panic!("there is no server on :9999, so no owner can take its selection");
         };
         assert!(matches!(err, GlassError::Backend(_)), "{err:?}");
-        // The connect failure's own words, not a generic one: a setup step that reported nothing
-        // would leave the spawner to time out and blame the wait instead.
+        // The connect failure's own words: a step that reported nothing would leave the spawner
+        // to time out and blame the wait.
         assert!(err.to_string().contains("X connect"), "{err}");
-        // And it must arrive by being signalled, not by the 2 s readiness bound expiring — which
-        // is the only difference a caller sees when a setup step forgets to signal.
+        // Signalled, not the 2 s readiness bound expiring — the only difference a caller sees
+        // when a step forgets to signal.
         assert!(
             started.elapsed() < Duration::from_secs(2),
             "{:?}",
@@ -775,9 +773,8 @@ mod tests {
         );
     }
 
-    /// The one thing every fallible setup step in `owner_thread` must do. A step that returns
-    /// without it leaves the spawner on the condvar until its own bound expires, reporting a
-    /// timeout for a failure that already had a message.
+    /// The signal, the stop and the message: dropping any one leaves the spawner on the condvar
+    /// until its own bound expires.
     #[test]
     fn a_setup_failure_signals_the_spawner_stops_the_thread_and_keeps_its_message() {
         let ready = Arc::new((Mutex::new(ReadyState::Pending), Condvar::new()));

--- a/crates/glass-x11/src/clipboard.rs
+++ b/crates/glass-x11/src/clipboard.rs
@@ -25,9 +25,9 @@ struct GetAtoms {
 
 /// Intern one atom, naming which half of the round trip failed.
 ///
-/// Both halves are named because they fail for different reasons: the request errors when the
-/// connection is already broken, the reply when the server rejected it. `wrap` turns the message
-/// into the caller's error type — the owner thread's has to signal the spawner on its way out.
+/// Both halves are named because a round trip can fail at either end and the remedies differ.
+/// `wrap` turns the message into the caller's error type — the owner thread's has to signal the
+/// spawner on its way out, so it cannot be the one the getter uses.
 fn intern<E>(
     conn: &RustConnection,
     name: &str,
@@ -317,28 +317,56 @@ fn signal_ready(ready: &Arc<(Mutex<ReadyState>, Condvar)>, state: ReadyState) {
     cvar.notify_one();
 }
 
+/// A setup failure that has already been reported to the spawner.
+///
+/// Only [`setup_failed`] constructs one, and [`take_selection`] returns nothing else, so a step in
+/// there cannot report through `GlassError` and leave the spawner waiting out its bound — that
+/// mistake is a compile error rather than a silent two-second stall.
+#[derive(Debug)]
+struct SetupFailed(String);
+
+impl std::fmt::Display for SetupFailed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for SetupFailed {}
+
 /// Report a setup failure to the spawner and stop the thread, handing `msg` back as the error.
 ///
 /// Every fallible step before the `ReadyState::Ok` signal must go through this. The spawner blocks
 /// on the condvar, so a step that returns without signalling leaves it waiting out its own timeout
 /// and reporting a timeout for a failure that already had a message.
+#[must_use = "the caller must return this, or the spawner is told a failure the thread ignored"]
 fn setup_failed(
     ready: &Arc<(Mutex<ReadyState>, Condvar)>,
     stop: &AtomicBool,
     msg: String,
-) -> String {
+) -> SetupFailed {
     signal_ready(ready, ReadyState::Err(msg.clone()));
+    // Not read on any path a failed setup can reach — `spawn` returns `Err`, so no
+    // `ClipboardOwner` exists to consult `is_alive`. It is here for a caller added later.
     stop.store(true, Ordering::Relaxed);
-    msg
+    SetupFailed(msg)
 }
 
-fn owner_thread(
+/// What the serve loop needs, once the selection is ours.
+struct Owned {
+    conn: RustConnection,
+    win: Window,
+    utf8_string: Atom,
+    targets_atom: Atom,
+}
+
+/// Connect, intern, create the window and take CLIPBOARD, reporting any failure to the spawner on
+/// the way out. `None` means the spawner gave up first, so the selection must be left alone.
+fn take_selection(
     display: &str,
-    text: Arc<Mutex<String>>,
-    stop: Arc<AtomicBool>,
-    ready: Arc<(Mutex<ReadyState>, Condvar)>,
-) -> std::result::Result<(), Box<dyn std::error::Error>> {
-    let failed = |msg| setup_failed(&ready, &stop, msg);
+    stop: &AtomicBool,
+    ready: &Arc<(Mutex<ReadyState>, Condvar)>,
+) -> std::result::Result<Option<Owned>, SetupFailed> {
+    let failed = |msg| setup_failed(ready, stop, msg);
     let (conn, screen_num) =
         x11rb::connect(Some(display)).map_err(|e| failed(format!("X connect: {e}")))?;
     let root = conn.setup().roots[screen_num].root;
@@ -376,7 +404,7 @@ fn owner_thread(
         // Skips the `destroy_window` the normal exit performs: `conn` is dropped on the way out,
         // and an X server destroys everything a client created once its connection closes
         // (close-down mode defaults to DestroyAll).
-        return Ok(());
+        return Ok(None);
     }
 
     // Take ownership of CLIPBOARD.
@@ -387,7 +415,32 @@ fn owner_thread(
     conn.flush()
         .map_err(|e| failed(format!("flush after set_selection_owner: {e}")))?;
 
-    // Signal the spawner that we now own the selection.
+    Ok(Some(Owned {
+        conn,
+        win,
+        utf8_string,
+        targets_atom,
+    }))
+}
+
+fn owner_thread(
+    display: &str,
+    text: Arc<Mutex<String>>,
+    stop: Arc<AtomicBool>,
+    ready: Arc<(Mutex<ReadyState>, Condvar)>,
+) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let Some(Owned {
+        conn,
+        win,
+        utf8_string,
+        targets_atom,
+    }) = take_selection(display, &stop, &ready)?
+    else {
+        return Ok(());
+    };
+
+    // Past this point `setup_failed` is out of scope, so a later failure cannot overwrite an `Ok`
+    // the spawner may not have read yet.
     signal_ready(&ready, ReadyState::Ok);
 
     // Event loop: serve SelectionRequest until stopped or SelectionClear arrives.
@@ -732,7 +785,7 @@ mod tests {
 
         let returned = setup_failed(&ready, &stop, "X connect: refused".to_string());
 
-        assert_eq!(returned, "X connect: refused");
+        assert_eq!(returned.to_string(), "X connect: refused");
         assert!(
             stop.load(Ordering::Relaxed),
             "the thread must not go on to take the selection"

--- a/crates/glass-x11/src/platform.rs
+++ b/crates/glass-x11/src/platform.rs
@@ -497,20 +497,8 @@ impl X11Platform {
     /// launches and bwrap-wrapped launches.
     fn discover_window(&mut self, spec: &AppSpec) -> Result<Window> {
         let root_pid = self.child.as_ref().map(|c| c.id());
-        let pid_atom = self
-            .conn
-            .intern_atom(false, b"_NET_WM_PID")
-            .map_err(|e| GlassError::Backend(format!("intern _NET_WM_PID: {e}")))?
-            .reply()
-            .map_err(|e| GlassError::Backend(format!("intern reply: {e}")))?
-            .atom;
-        let client_list_atom = self
-            .conn
-            .intern_atom(false, b"_NET_CLIENT_LIST")
-            .map_err(|e| GlassError::Backend(format!("intern _NET_CLIENT_LIST: {e}")))?
-            .reply()
-            .map_err(|e| GlassError::Backend(format!("intern reply: {e}")))?
-            .atom;
+        let pid_atom = self.intern(b"_NET_WM_PID")?;
+        let client_list_atom = self.intern(b"_NET_CLIENT_LIST")?;
 
         let deadline = Instant::now() + Duration::from_millis(spec.timeout_ms.max(1));
         loop {


### PR DESCRIPTION
Next from the `cargo dupes` list. `crates/glass-x11/src/clipboard.rs` had two duplicated shapes, and consolidating the first turned out to be worth more than the line count suggests.

**Setup failures.** `owner_thread` carried thirteen copies of the same six-line closure: format a message, signal the spawner's condvar with it, set `stop`, hand the message back. The duplication was hiding what the closure is *for* — the spawner blocks on that condvar with a two-second bound, so a step that returns without signalling doesn't merely lose a message, it makes the caller wait out the bound and then report a timeout for a failure that already had words. One `setup_failed` now says that once, on the function every step goes through.

**Interning.** `intern_atom(…).map_err(…)?.reply().map_err(…)?.atom` appeared seven times — four in `intern_get_atoms`, three in `owner_thread` — with the two halves named separately because a round trip can fail at either end. One `intern` generic over the error wrapper serves both, since the owner thread's has to signal on its way out and the getter's does not. `discover_window` in `platform.rs` hand-rolled the same pair for two atoms that `scan_all_windows` already gets through the crate's own helper, rendering byte-identical messages; folded in.

Every message is unchanged — `intern {name}` and `intern {name} reply` render exactly what the eleven literals did.

## What review changed

The consolidation created a footgun. `intern`'s error type was unconstrained and `owner_thread` returned `Box<dyn Error>`, which absorbs both the signalling wrapper and `GlassError::Backend` — so the wrong one at an intern call site compiled, looked identical to the right one one line above, and produced exactly the failure being deleted.

The setup region is now `take_selection`, returning `Result<Option<Owned>, SetupFailed>`. `SetupFailed` has a single constructor, so `?` rejects `GlassError` outright — verified by writing the mistake and watching it fail to compile, not by reasoning about it. Two things follow: `setup_failed` is out of scope past the `ReadyState::Ok` signal, where calling it would overwrite a readiness the spawner may not have read; and `#[must_use]` restores what the inline `map_err(…)?` used to weld together, so signalling without leaving is no longer expressible.

## Verification

`cargo nextest run --workspace`: 2271 passed. The 154 Xvfb-backed glass-x11 unit tests — the ones that actually exercise interning, and the ones the mutation shards run — pass too. fmt and workspace clippy clean.

Both new tests were shown to fail first: dropping the signal, dropping the stop, or discarding the message each go red, and the unreachable-display test asserts the error names the connect *and* arrives before the two-second bound, which is the only thing separating a step that reported itself from one that stayed silent.

One honest gap: nothing drives the `.reply()` half of `intern` to fail, so swapping its message for the request half's survives. That needs a fault-injecting X server; it is not a mutation-gate risk, but it is a hole rather than a covered case.

#412 records a pre-existing bug found while walking this function: an X error while serving the selection propagates out of the thread without setting `stop`, so `is_alive()` reports true forever and every later `set_clipboard` returns success into a void.

🤖 Generated with [Claude Code](https://claude.com/claude-code)