### PR TITLE
test(macos): one tests/common for the harness=false integration targets

### DIFF
--- a/crates/glass-macos/tests/a11y.rs
+++ b/crates/glass-macos/tests/a11y.rs
@@ -43,6 +43,8 @@
 //! `GLASS_A11Y_FIXTURE_BIN` when set (the granted run pre-builds it); otherwise this builds
 //! `fixture/a11y_fixture.swift` with `swiftc`, or skips if neither is available.
 
+mod common;
+
 #[cfg(not(target_os = "macos"))]
 fn main() {
     println!("skipped (not macOS): test");
@@ -55,9 +57,9 @@ fn main() {
 
 #[cfg(target_os = "macos")]
 mod macos_main {
-    use std::path::PathBuf;
-    use std::process::Command;
     use std::time::Duration;
+
+    use std::path::PathBuf;
 
     use glass_core::platform::{MouseButton, PointerEvent};
     use glass_core::{
@@ -65,6 +67,8 @@ mod macos_main {
         Platform, SandboxLevel, Stream, WalkLimits,
     };
     use glass_macos::MacosPlatform;
+
+    use crate::common::{build_fixture, expect, fail, swiftc_available, try_expect};
 
     /// Settle after an action that should print `SAVE_CLICKED` — native `invoke` or the
     /// a11y-bounds pointer click — before draining logs, mirroring `input.rs`'s
@@ -116,75 +120,6 @@ mod macos_main {
         lines
             .iter()
             .any(|(stream, line)| *stream == Stream::Stdout && line.contains(needle))
-    }
-
-    /// Print a clear failure message and exit non-zero — the `harness = false` contract (no
-    /// libtest to format a panic for us). Mirrors `capture.rs`.
-    fn fail(msg: impl AsRef<str>) -> ! {
-        eprintln!("FAIL: {}", msg.as_ref());
-        std::process::exit(1);
-    }
-
-    /// Unwrap a `Result`, failing the process with `context` prefixed on `Err`. Only safe
-    /// before a fixture process is spawned (it skips destructors) — post-spawn failures go
-    /// through `try_expect`/`run_checks` so `stop_app` still runs. Mirrors `capture.rs`.
-    fn expect<T, E: std::fmt::Display>(result: Result<T, E>, context: &str) -> T {
-        match result {
-            Ok(v) => v,
-            Err(e) => fail(format!("{context}: {e}")),
-        }
-    }
-
-    /// Like `expect`, but returns the error as a `String` so a failure flows back to `run()`
-    /// for `stop_app` + temp-dir cleanup before the process exits. Mirrors `capture.rs`.
-    fn try_expect<T, E: std::fmt::Display>(
-        result: Result<T, E>,
-        context: &str,
-    ) -> Result<T, String> {
-        result.map_err(|e| format!("{context}: {e}"))
-    }
-
-    fn swiftc_available() -> bool {
-        Command::new("swiftc")
-            .arg("--version")
-            .output()
-            .is_ok_and(|o| o.status.success())
-    }
-
-    /// Build `fixture/a11y_fixture.swift` to a fresh temp path. Returns the built binary's
-    /// path and the temp build dir it lives in (the caller removes the dir when done).
-    /// Mirrors `capture.rs::build_fixture` (`@main` type -> `-parse-as-library`).
-    fn build_fixture() -> (PathBuf, PathBuf) {
-        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let source = manifest_dir.join("fixture").join("a11y_fixture.swift");
-        if !source.is_file() {
-            fail(format!("fixture source not found at {}", source.display()));
-        }
-
-        let out_dir =
-            std::env::temp_dir().join(format!("glass-macos-a11y-test-{}", std::process::id()));
-        expect(
-            std::fs::create_dir_all(&out_dir),
-            "creating fixture build dir",
-        );
-        let out_bin = out_dir.join("a11y_fixture");
-
-        let status = Command::new("swiftc")
-            .arg("-O")
-            .arg("-parse-as-library")
-            .arg(&source)
-            .arg("-o")
-            .arg(&out_bin)
-            .status();
-        match status {
-            Ok(s) if s.success() => {}
-            Ok(s) => fail(format!(
-                "swiftc exited with {s} building {}",
-                source.display()
-            )),
-            Err(e) => fail(format!("failed to run swiftc: {e}")),
-        }
-        (out_bin, out_dir)
     }
 
     /// Launch the fixture, snapshot its accessibility tree, and assert the outline contains
@@ -442,7 +377,7 @@ mod macos_main {
                     println!("skipped (GLASS_A11Y_FIXTURE_BIN unset and no swiftc)");
                     return;
                 }
-                let (bin, dir) = build_fixture();
+                let (bin, dir) = build_fixture("a11y_fixture", "a11y");
                 (bin, Some(dir))
             }
         };

--- a/crates/glass-macos/tests/a11y.rs
+++ b/crates/glass-macos/tests/a11y.rs
@@ -57,9 +57,8 @@ fn main() {
 
 #[cfg(target_os = "macos")]
 mod macos_main {
-    use std::time::Duration;
-
     use std::path::PathBuf;
+    use std::time::Duration;
 
     use glass_core::platform::{MouseButton, PointerEvent};
     use glass_core::{
@@ -377,7 +376,7 @@ mod macos_main {
                     println!("skipped (GLASS_A11Y_FIXTURE_BIN unset and no swiftc)");
                     return;
                 }
-                let (bin, dir) = build_fixture("a11y_fixture", "a11y");
+                let (bin, dir) = build_fixture("a11y_fixture");
                 (bin, Some(dir))
             }
         };

--- a/crates/glass-macos/tests/bundle_launch.rs
+++ b/crates/glass-macos/tests/bundle_launch.rs
@@ -49,6 +49,8 @@
 //! an unlocked screen session (TextEdit's window must actually receive focus for the AX
 //! snapshot in check 2 to see real content).
 
+mod common;
+
 #[cfg(not(target_os = "macos"))]
 fn main() {
     println!("skipped (not macOS): test");
@@ -72,6 +74,8 @@ mod macos_main {
         WalkLimits,
     };
     use glass_macos::MacosPlatform;
+
+    use crate::common::{fail, swiftc_available, with_stop_app};
 
     /// A stock-macOS handoff app. NOTE the mechanism is not what it looks like: it does not
     /// re-exec itself through LaunchServices. Directly spawning `Contents/MacOS/TextEdit` gets
@@ -102,13 +106,6 @@ mod macos_main {
     /// request and returns; this gives the target process a moment to actually unwind.
     const TERMINATE_SETTLE: Duration = Duration::from_secs(1);
 
-    /// Print a clear failure message and exit non-zero — the `harness = false` contract (no
-    /// libtest to format a panic for us). Mirrors the sibling integration tests.
-    fn fail(msg: impl AsRef<str>) -> ! {
-        eprintln!("FAIL: {}", msg.as_ref());
-        std::process::exit(1);
-    }
-
     /// Like the sibling tests' identical helper: returns the error as a `String` instead of
     /// exiting, so a failure inside a check function still lets that check's own cleanup
     /// (`stop_app`, fixture-dir removal) run before the message propagates.
@@ -117,13 +114,6 @@ mod macos_main {
         context: &str,
     ) -> Result<T, String> {
         result.map_err(|e| format!("{context}: {e}"))
-    }
-
-    fn swiftc_available() -> bool {
-        Command::new("swiftc")
-            .arg("--version")
-            .output()
-            .is_ok_and(|o| o.status.success())
     }
 
     /// True if a process named `name` is currently running (`pgrep -x`) — used by
@@ -213,27 +203,6 @@ mod macos_main {
         }
     }
 
-    /// Run `body`, then always call `platform.stop_app()` before returning — regardless of
-    /// whether `body` succeeded — so a failing check never leaks whatever it started. On
-    /// success, a `stop_app` failure becomes the check's own failure; on an already-failing
-    /// `body` it is only logged, so it can't mask the original failure.
-    fn with_stop_app<T>(
-        platform: &mut MacosPlatform,
-        body: impl FnOnce(&mut MacosPlatform) -> Result<T, String>,
-    ) -> Result<T, String> {
-        let result = body(platform);
-        let stop_result = platform.stop_app();
-        match result {
-            Ok(v) => try_expect(stop_result, "stop_app").map(|()| v),
-            Err(e) => {
-                if let Err(stop_err) = stop_result {
-                    eprintln!("(additionally) stop_app failed: {stop_err}");
-                }
-                Err(e)
-            }
-        }
-    }
-
     /// The result of running one check. Distinct from a plain `Result` so a missing precondition
     /// for ONE check (`Skipped`) is reported as skipped-not-passed and never causes the OTHER
     /// checks to be skipped — the pathological "the whole test silently passes because a single
@@ -278,7 +247,7 @@ mod macos_main {
             }
         };
 
-        let result = with_stop_app(&mut platform, |platform| {
+        let result = with_stop_app(&mut platform, "bundled fixture", |platform| {
             let spec = bundle_spec(bundle.to_string_lossy().into_owned(), SandboxLevel::Default);
             let geometry = try_expect(
                 platform.start_app(&spec),
@@ -370,7 +339,7 @@ mod macos_main {
         let mut platform =
             MacosPlatform::new().map_err(|e| format!("MacosPlatform::new(): {e}"))?;
 
-        let result = with_stop_app(&mut platform, |platform| {
+        let result = with_stop_app(&mut platform, "TextEdit unsandboxed", |platform| {
             let spec = bundle_spec(TEXT_EDIT, SandboxLevel::Off);
             let geometry = try_expect(
                 platform.start_app(&spec),
@@ -461,7 +430,7 @@ mod macos_main {
         let mut platform =
             MacosPlatform::new().map_err(|e| format!("MacosPlatform::new(): {e}"))?;
 
-        with_stop_app(&mut platform, |platform| {
+        with_stop_app(&mut platform, "TextEdit fail-closed", |platform| {
             let spec = bundle_spec(TEXT_EDIT, SandboxLevel::Default);
             match platform.start_app(&spec) {
                 Err(GlassError::AppNotStarted(msg)) => {

--- a/crates/glass-macos/tests/bundle_launch.rs
+++ b/crates/glass-macos/tests/bundle_launch.rs
@@ -75,7 +75,7 @@ mod macos_main {
     };
     use glass_macos::MacosPlatform;
 
-    use crate::common::{fail, swiftc_available, with_stop_app};
+    use crate::common::{fail, swiftc_available, try_expect, with_stop_app};
 
     /// A stock-macOS handoff app. NOTE the mechanism is not what it looks like: it does not
     /// re-exec itself through LaunchServices. Directly spawning `Contents/MacOS/TextEdit` gets
@@ -105,16 +105,6 @@ mod macos_main {
     /// exited (check 2's no-orphan assertion) — `ffi::terminate_app` posts a terminate
     /// request and returns; this gives the target process a moment to actually unwind.
     const TERMINATE_SETTLE: Duration = Duration::from_secs(1);
-
-    /// Like the sibling tests' identical helper: returns the error as a `String` instead of
-    /// exiting, so a failure inside a check function still lets that check's own cleanup
-    /// (`stop_app`, fixture-dir removal) run before the message propagates.
-    fn try_expect<T, E: std::fmt::Display>(
-        result: Result<T, E>,
-        context: &str,
-    ) -> Result<T, String> {
-        result.map_err(|e| format!("{context}: {e}"))
-    }
 
     /// True if a process named `name` is currently running (`pgrep -x`) — used by
     /// [`run_handoff_check`] to tell a genuinely fresh `NSWorkspace` launch (no prior

--- a/crates/glass-macos/tests/capture.rs
+++ b/crates/glass-macos/tests/capture.rs
@@ -19,6 +19,8 @@
 //! inherits the bundle's grants. See `scripts/test-macos.sh`'s `GLASS_MACOS_ONBOX` gate
 //! for how this fits the test scripts.
 
+mod common;
+
 #[cfg(not(target_os = "macos"))]
 fn main() {
     println!("skipped (not macOS): test");
@@ -31,138 +33,19 @@ fn main() {
 
 #[cfg(target_os = "macos")]
 mod macos_main {
-    use std::path::PathBuf;
-    use std::process::Command;
     use std::time::Duration;
 
     use glass_core::{AppSpec, Platform, Region, SandboxLevel};
     use glass_macos::MacosPlatform;
 
-    /// Per-channel RGBA tolerance for a sampled pixel vs. its expected known color.
-    /// Generous relative to `deviceRGB` fills (which should land very close to exact),
-    /// but wide enough to absorb any residual compositor/backing-scale blending at a
-    /// sampled point (sample points are quadrant *centers*, away from color boundaries,
-    /// so this is a safety margin, not a load-bearing tolerance).
-    const TOLERANCE: i32 = 40;
+    use crate::common::{
+        PIXEL_TOLERANCE, assert_pixel, close, pixel_at, run_fixture_test, try_expect,
+    };
 
     const RED: [u8; 4] = [255, 0, 0, 255];
     const GREEN: [u8; 4] = [0, 255, 0, 255];
     const BLUE: [u8; 4] = [0, 0, 255, 255];
     const WHITE: [u8; 4] = [255, 255, 255, 255];
-
-    /// Print a clear failure message and exit non-zero — the `harness = false` contract
-    /// (no libtest to format a panic for us).
-    fn fail(msg: impl AsRef<str>) -> ! {
-        eprintln!("FAIL: {}", msg.as_ref());
-        std::process::exit(1);
-    }
-
-    /// Unwrap a `Result`, failing the whole test process with `context` prefixed to the
-    /// error on `Err`. Only safe to use before a fixture process has been spawned (or
-    /// once all spawn-time cleanup is already done) — it exits immediately, skipping
-    /// destructors, so anything that still needs `MacosPlatform::stop_app()` run against
-    /// it must go through `try_expect`/`run_checks` below instead.
-    fn expect<T, E: std::fmt::Display>(result: Result<T, E>, context: &str) -> T {
-        match result {
-            Ok(v) => v,
-            Err(e) => fail(format!("{context}: {e}")),
-        }
-    }
-
-    /// Like `expect`, but returns the error as a `String` instead of exiting the
-    /// process. Used inside `run_checks`, where a failure must still flow back to
-    /// `run()` so it can `stop_app()` the spawned fixture (and clean up the fixture
-    /// build dir) before the process exits — `std::process::exit` skips Rust
-    /// destructors, so `MacosPlatform::Drop` would never reap the child if we exited
-    /// straight from in here.
-    fn try_expect<T, E: std::fmt::Display>(
-        result: Result<T, E>,
-        context: &str,
-    ) -> Result<T, String> {
-        result.map_err(|e| format!("{context}: {e}"))
-    }
-
-    fn swiftc_available() -> bool {
-        Command::new("swiftc")
-            .arg("--version")
-            .output()
-            .is_ok_and(|o| o.status.success())
-    }
-
-    /// Build `fixture/quadrants.swift` to a fresh temp path. Returns the built binary's
-    /// path and the temp build dir it lives in (the caller is responsible for removing
-    /// the dir once done with it — see `run()`).
-    fn build_fixture() -> (PathBuf, PathBuf) {
-        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let source = manifest_dir.join("fixture").join("quadrants.swift");
-        if !source.is_file() {
-            fail(format!("fixture source not found at {}", source.display()));
-        }
-
-        let out_dir =
-            std::env::temp_dir().join(format!("glass-macos-capture-test-{}", std::process::id()));
-        expect(
-            std::fs::create_dir_all(&out_dir),
-            "creating fixture build dir",
-        );
-        let out_bin = out_dir.join("quadrants");
-
-        let status = Command::new("swiftc")
-            .arg("-O")
-            .arg("-parse-as-library")
-            .arg(&source)
-            .arg("-o")
-            .arg(&out_bin)
-            .status();
-        match status {
-            Ok(s) if s.success() => {}
-            Ok(s) => fail(format!(
-                "swiftc exited with {s} building {}",
-                source.display()
-            )),
-            Err(e) => fail(format!("failed to run swiftc: {e}")),
-        }
-        (out_bin, out_dir)
-    }
-
-    /// Fetch pixel `(x, y)` from a tightly-packed RGBA8 `Frame` buffer.
-    fn pixel_at(pixels: &[u8], frame_width: u32, x: u32, y: u32) -> [u8; 4] {
-        let idx = (y as usize * frame_width as usize + x as usize) * 4;
-        [
-            pixels[idx],
-            pixels[idx + 1],
-            pixels[idx + 2],
-            pixels[idx + 3],
-        ]
-    }
-
-    fn close(a: [u8; 4], b: [u8; 4]) -> bool {
-        a.iter()
-            .zip(b.iter())
-            .all(|(x, y)| (*x as i32 - *y as i32).abs() <= TOLERANCE)
-    }
-
-    /// Assert the pixel at `(x, y)` in `frame` is within tolerance of `expected`,
-    /// returning a detailed `Err` message (including the actual bytes) otherwise. Returns
-    /// `Result` rather than failing the process directly so a mismatch, raised from
-    /// inside `run_checks` with a fixture process already spawned, still flows back to
-    /// `run()`'s cleanup (`stop_app` + temp dir removal) before the process exits.
-    fn assert_pixel(
-        pixels: &[u8],
-        frame_width: u32,
-        x: u32,
-        y: u32,
-        expected: [u8; 4],
-        label: &str,
-    ) -> Result<(), String> {
-        let got = pixel_at(pixels, frame_width, x, y);
-        if !close(got, expected) {
-            return Err(format!(
-                "{label} pixel at ({x},{y}) = {got:?}, expected ~{expected:?} (tolerance {TOLERANCE})"
-            ));
-        }
-        Ok(())
-    }
 
     /// Assert every pixel in a tightly-packed RGBA8 buffer of `w`x`h` is within tolerance
     /// of `expected`. Returns `Result` for the same reason as `assert_pixel`.
@@ -179,7 +62,7 @@ mod macos_main {
                 if !close(got, expected) {
                     return Err(format!(
                         "{label}: non-uniform pixel at ({x},{y}) = {got:?}, expected ~{expected:?} \
-                         (tolerance {TOLERANCE}) within a {w}x{h} region"
+                         (tolerance {PIXEL_TOLERANCE}) within a {w}x{h} region"
                     ));
                 }
             }
@@ -276,47 +159,11 @@ mod macos_main {
     }
 
     pub(super) fn run() {
-        if !swiftc_available() {
-            println!("skipped (no swiftc)");
-            return;
-        }
-
-        let (fixture_bin, fixture_dir) = build_fixture();
-        println!("built fixture at {}", fixture_bin.display());
-
-        let mut platform = match MacosPlatform::new() {
-            Ok(p) => p,
-            Err(e) => {
-                let _ = std::fs::remove_dir_all(&fixture_dir);
-                fail(format!(
-                    "MacosPlatform::new() (Screen Recording / Accessibility grant missing?): {e}"
-                ));
-            }
-        };
-
-        let result = run_checks(&mut platform, &fixture_bin);
-
-        // Reached regardless of outcome and BEFORE any process::exit below: `stop_app` is
-        // documented idempotent, so this is what guarantees the fixture's `quadrants` process
-        // never survives a failed run.
-        let stop_result = platform.stop_app();
-        let _ = std::fs::remove_dir_all(&fixture_dir);
-
-        match result {
-            Ok(()) => {
-                expect(stop_result, "stop_app");
-                println!("CAPTURE_INTEGRATION_PASS");
-                std::process::exit(0);
-            }
-            Err(msg) => {
-                // stop_app is infallible today (always Ok), but surface a future failure
-                // here too rather than silently dropping it — this is the last point
-                // before the process exits, so it's the only chance to report it.
-                if let Err(e) = stop_result {
-                    eprintln!("(additionally) stop_app failed: {e}");
-                }
-                fail(msg);
-            }
-        }
+        run_fixture_test(
+            "quadrants",
+            "capture",
+            "CAPTURE_INTEGRATION_PASS",
+            run_checks,
+        );
     }
 }

--- a/crates/glass-macos/tests/capture.rs
+++ b/crates/glass-macos/tests/capture.rs
@@ -159,11 +159,6 @@ mod macos_main {
     }
 
     pub(super) fn run() {
-        run_fixture_test(
-            "quadrants",
-            "capture",
-            "CAPTURE_INTEGRATION_PASS",
-            run_checks,
-        );
+        run_fixture_test("quadrants", "CAPTURE_INTEGRATION_PASS", run_checks);
     }
 }

--- a/crates/glass-macos/tests/common/mod.rs
+++ b/crates/glass-macos/tests/common/mod.rs
@@ -51,12 +51,15 @@ pub fn swiftc_available() -> bool {
         .is_ok_and(|o| o.status.success())
 }
 
-/// Build `fixture/{stem}.swift` to a fresh temp dir named for `tag`, returning the binary and the
-/// dir. The caller removes the dir; [`run_fixture_test`] does it for the targets that use it.
+/// Build `fixture/{stem}.swift` to a fresh temp dir, returning the binary and the dir. The caller
+/// removes the dir; [`run_fixture_test`] does it for the targets that use it.
 ///
-/// `tag` is the calling target's name so a parallel run of all of them cannot have two targets
-/// building into one dir — the pid alone would not separate them.
-pub fn build_fixture(stem: &str, tag: &str) -> (PathBuf, PathBuf) {
+/// The dir is named for the calling target — `env!` here expands per including target, so the name
+/// cannot desync from it — and for the pid, which is what separates two runs of the same target.
+/// The target's name is what makes a dir left behind by a crashed run say who leaked it, and stops
+/// a later target that draws the same pid from re-entering it.
+pub fn build_fixture(stem: &str) -> (PathBuf, PathBuf) {
+    let tag = env!("CARGO_CRATE_NAME");
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let source = manifest_dir.join("fixture").join(format!("{stem}.swift"));
     if !source.is_file() {
@@ -96,7 +99,6 @@ pub fn build_fixture(stem: &str, tag: &str) -> (PathBuf, PathBuf) {
 /// process alive. `checks` returns `Result` rather than exiting for the same reason.
 pub fn run_fixture_test(
     stem: &str,
-    tag: &str,
     pass_marker: &str,
     checks: impl FnOnce(&mut MacosPlatform, &Path) -> Result<(), String>,
 ) {
@@ -105,7 +107,7 @@ pub fn run_fixture_test(
         return;
     }
 
-    let (fixture_bin, fixture_dir) = build_fixture(stem, tag);
+    let (fixture_bin, fixture_dir) = build_fixture(stem);
     println!("built fixture at {}", fixture_bin.display());
 
     let mut platform = match MacosPlatform::new() {
@@ -141,6 +143,9 @@ pub fn run_fixture_test(
 }
 
 /// Run `body`, then always `stop_app` afterwards, whether or not `body` succeeded.
+///
+/// On success a `stop_app` failure becomes the caller's failure; on an already-failing `body` it is
+/// only logged, so it cannot mask the original.
 pub fn with_stop_app<T>(
     platform: &mut MacosPlatform,
     label: &str,
@@ -161,9 +166,10 @@ pub fn with_stop_app<T>(
     }
 }
 
-/// Per-channel RGBA tolerance for a sampled pixel against its expected colour. Generous next to a
-/// `deviceRGB` fill, which lands close to exact; sample points are quadrant centres, away from
-/// colour boundaries, so this is margin rather than a load-bearing bound.
+/// Per-channel RGBA tolerance for a sampled pixel against its expected colour, shared by the two
+/// targets that sample one. Generous next to a `deviceRGB` fill, which lands close to exact; sample
+/// points are quadrant centres, away from colour boundaries, so this is margin rather than a
+/// load-bearing bound.
 pub const PIXEL_TOLERANCE: i32 = 40;
 
 /// Fetch pixel `(x, y)` from a tightly-packed RGBA8 buffer.

--- a/crates/glass-macos/tests/common/mod.rs
+++ b/crates/glass-macos/tests/common/mod.rs
@@ -1,0 +1,205 @@
+//! Helpers shared by the mac-gated integration tests and probes in this directory.
+//!
+//! All of them exist because these targets are `harness = false` (see `Cargo.toml`): there is no
+//! libtest to format a panic, spawn a thread per test, or reap a fixture process, so each target
+//! has to do those itself — and each had grown its own copy of the same seven or eight functions.
+//!
+//! Cargo does not treat a subdirectory of `tests/` as a target, so this is a module the targets
+//! include rather than a test in its own right.
+#![cfg(target_os = "macos")]
+// Every target compiles the whole module and uses a subset of it — the probes never build a Swift
+// fixture, and only the two pixel tests sample a frame.
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use glass_core::Platform;
+use glass_macos::MacosPlatform;
+
+/// Print a clear failure message and exit non-zero — the `harness = false` contract.
+pub fn fail(msg: impl AsRef<str>) -> ! {
+    eprintln!("FAIL: {}", msg.as_ref());
+    std::process::exit(1);
+}
+
+/// Unwrap a `Result`, failing the whole test process with `context` prefixed to the error.
+///
+/// Only safe before a fixture process has been spawned, or once its cleanup is already done: it
+/// exits immediately, skipping destructors, so anything still needing `stop_app` must go through
+/// [`try_expect`] instead.
+pub fn expect<T, E: std::fmt::Display>(result: Result<T, E>, context: &str) -> T {
+    match result {
+        Ok(v) => v,
+        Err(e) => fail(format!("{context}: {e}")),
+    }
+}
+
+/// Like [`expect`], but returns the error as a `String` rather than exiting, so a failure raised
+/// with a fixture already spawned still flows back to the cleanup that reaps it.
+pub fn try_expect<T, E: std::fmt::Display>(
+    result: Result<T, E>,
+    context: &str,
+) -> Result<T, String> {
+    result.map_err(|e| format!("{context}: {e}"))
+}
+
+pub fn swiftc_available() -> bool {
+    Command::new("swiftc")
+        .arg("--version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+/// Build `fixture/{stem}.swift` to a fresh temp dir named for `tag`, returning the binary and the
+/// dir. The caller removes the dir; [`run_fixture_test`] does it for the targets that use it.
+///
+/// `tag` is the calling target's name so a parallel run of all of them cannot have two targets
+/// building into one dir — the pid alone would not separate them.
+pub fn build_fixture(stem: &str, tag: &str) -> (PathBuf, PathBuf) {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let source = manifest_dir.join("fixture").join(format!("{stem}.swift"));
+    if !source.is_file() {
+        fail(format!("fixture source not found at {}", source.display()));
+    }
+
+    let out_dir =
+        std::env::temp_dir().join(format!("glass-macos-{tag}-test-{}", std::process::id()));
+    expect(
+        std::fs::create_dir_all(&out_dir),
+        "creating fixture build dir",
+    );
+    let out_bin = out_dir.join(stem);
+
+    let status = Command::new("swiftc")
+        .arg("-O")
+        .arg("-parse-as-library")
+        .arg(&source)
+        .arg("-o")
+        .arg(&out_bin)
+        .status();
+    match status {
+        Ok(s) if s.success() => {}
+        Ok(s) => fail(format!(
+            "swiftc exited with {s} building {}",
+            source.display()
+        )),
+        Err(e) => fail(format!("failed to run swiftc: {e}")),
+    }
+    (out_bin, out_dir)
+}
+
+/// Build the fixture, run `checks` against a fresh `MacosPlatform`, and clean up whatever happened.
+///
+/// The cleanup ordering is the point: `stop_app` and the temp-dir removal run before any
+/// `process::exit`, which skips destructors — so without them a failed run leaves the fixture
+/// process alive. `checks` returns `Result` rather than exiting for the same reason.
+pub fn run_fixture_test(
+    stem: &str,
+    tag: &str,
+    pass_marker: &str,
+    checks: impl FnOnce(&mut MacosPlatform, &Path) -> Result<(), String>,
+) {
+    if !swiftc_available() {
+        println!("skipped (no swiftc)");
+        return;
+    }
+
+    let (fixture_bin, fixture_dir) = build_fixture(stem, tag);
+    println!("built fixture at {}", fixture_bin.display());
+
+    let mut platform = match MacosPlatform::new() {
+        Ok(p) => p,
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(&fixture_dir);
+            fail(format!(
+                "MacosPlatform::new() (Screen Recording / Accessibility grant missing?): {e}"
+            ));
+        }
+    };
+
+    let result = checks(&mut platform, &fixture_bin);
+
+    let stop_result = platform.stop_app();
+    let _ = std::fs::remove_dir_all(&fixture_dir);
+
+    match result {
+        Ok(()) => {
+            expect(stop_result, "stop_app");
+            println!("{pass_marker}");
+            std::process::exit(0);
+        }
+        Err(msg) => {
+            // `stop_app` is infallible today, but this is the last point before the process exits
+            // and so the only chance to report a future failure of it.
+            if let Err(e) = stop_result {
+                eprintln!("(additionally) stop_app failed: {e}");
+            }
+            fail(msg);
+        }
+    }
+}
+
+/// Run `body`, then always `stop_app` afterwards, whether or not `body` succeeded.
+pub fn with_stop_app<T>(
+    platform: &mut MacosPlatform,
+    label: &str,
+    body: impl FnOnce(&mut MacosPlatform) -> Result<T, String>,
+) -> Result<T, String> {
+    let result = body(platform);
+    let stop_result = platform.stop_app();
+    match result {
+        Ok(v) => stop_result
+            .map(|()| v)
+            .map_err(|e| format!("stop_app({label}): {e}")),
+        Err(e) => {
+            if let Err(stop_err) = stop_result {
+                eprintln!("(additionally) stop_app({label}) failed: {stop_err}");
+            }
+            Err(e)
+        }
+    }
+}
+
+/// Per-channel RGBA tolerance for a sampled pixel against its expected colour. Generous next to a
+/// `deviceRGB` fill, which lands close to exact; sample points are quadrant centres, away from
+/// colour boundaries, so this is margin rather than a load-bearing bound.
+pub const PIXEL_TOLERANCE: i32 = 40;
+
+/// Fetch pixel `(x, y)` from a tightly-packed RGBA8 buffer.
+pub fn pixel_at(pixels: &[u8], frame_width: u32, x: u32, y: u32) -> [u8; 4] {
+    let idx = (y as usize * frame_width as usize + x as usize) * 4;
+    [
+        pixels[idx],
+        pixels[idx + 1],
+        pixels[idx + 2],
+        pixels[idx + 3],
+    ]
+}
+
+pub fn close(a: [u8; 4], b: [u8; 4]) -> bool {
+    a.iter()
+        .zip(b.iter())
+        .all(|(x, y)| (*x as i32 - *y as i32).abs() <= PIXEL_TOLERANCE)
+}
+
+/// Assert the pixel at `(x, y)` is within tolerance of `expected`, returning the actual bytes on
+/// mismatch. `Result`, not a process exit, so a mismatch found with a fixture spawned still
+/// reaches the cleanup that reaps it.
+pub fn assert_pixel(
+    pixels: &[u8],
+    frame_width: u32,
+    x: u32,
+    y: u32,
+    expected: [u8; 4],
+    label: &str,
+) -> Result<(), String> {
+    let got = pixel_at(pixels, frame_width, x, y);
+    if !close(got, expected) {
+        return Err(format!(
+            "{label} pixel at ({x},{y}) = {got:?}, expected ~{expected:?} \
+             (tolerance {PIXEL_TOLERANCE})"
+        ));
+    }
+    Ok(())
+}

--- a/crates/glass-macos/tests/common/mod.rs
+++ b/crates/glass-macos/tests/common/mod.rs
@@ -1,14 +1,14 @@
 //! Helpers shared by the mac-gated integration tests and probes in this directory.
 //!
-//! All of them exist because these targets are `harness = false` (see `Cargo.toml`): there is no
-//! libtest to format a panic, spawn a thread per test, or reap a fixture process, so each target
-//! has to do those itself — and each had grown its own copy of the same seven or eight functions.
+//! These targets are `harness = false` (see `Cargo.toml`), so there is no libtest to format a
+//! panic, run each test on its own thread, or reap a fixture process — and each target had grown
+//! its own copy of the functions that do.
 //!
-//! Cargo does not treat a subdirectory of `tests/` as a target, so this is a module the targets
-//! include rather than a test in its own right.
+//! Cargo does not treat a subdirectory of `tests/` as a target, so this is a module they include
+//! rather than an eighth test.
 #![cfg(target_os = "macos")]
-// Every target compiles the whole module and uses a subset of it — the probes never build a Swift
-// fixture, and only the two pixel tests sample a frame.
+// Every target compiles the whole module and uses a subset — the probes never build a Swift
+// fixture, and only two of them sample a frame.
 #![allow(dead_code)]
 
 use std::path::{Path, PathBuf};
@@ -54,10 +54,9 @@ pub fn swiftc_available() -> bool {
 /// Build `fixture/{stem}.swift` to a fresh temp dir, returning the binary and the dir. The caller
 /// removes the dir; [`run_fixture_test`] does it for the targets that use it.
 ///
-/// The dir is named for the calling target — `env!` here expands per including target, so the name
-/// cannot desync from it — and for the pid, which is what separates two runs of the same target.
-/// The target's name is what makes a dir left behind by a crashed run say who leaked it, and stops
-/// a later target that draws the same pid from re-entering it.
+/// The dir is named for the pid, which separates two runs, and for the calling target, which makes
+/// a dir a crashed run left behind say who leaked it. `env!` expands per including target, so that
+/// name cannot desync from the target it names.
 pub fn build_fixture(stem: &str) -> (PathBuf, PathBuf) {
     let tag = env!("CARGO_CRATE_NAME");
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -95,7 +94,7 @@ pub fn build_fixture(stem: &str) -> (PathBuf, PathBuf) {
 /// Build the fixture, run `checks` against a fresh `MacosPlatform`, and clean up whatever happened.
 ///
 /// The cleanup ordering is the point: `stop_app` and the temp-dir removal run before any
-/// `process::exit`, which skips destructors — so without them a failed run leaves the fixture
+/// `process::exit`, which skips destructors, so without them a failed run leaves the fixture
 /// process alive. `checks` returns `Result` rather than exiting for the same reason.
 pub fn run_fixture_test(
     stem: &str,
@@ -166,10 +165,9 @@ pub fn with_stop_app<T>(
     }
 }
 
-/// Per-channel RGBA tolerance for a sampled pixel against its expected colour, shared by the two
-/// targets that sample one. Generous next to a `deviceRGB` fill, which lands close to exact; sample
-/// points are quadrant centres, away from colour boundaries, so this is margin rather than a
-/// load-bearing bound.
+/// Per-channel RGBA tolerance for a sampled pixel, shared by the two targets that sample one.
+/// Sample points are quadrant centres, away from colour boundaries, so this is margin rather than
+/// a load-bearing bound.
 pub const PIXEL_TOLERANCE: i32 = 40;
 
 /// Fetch pixel `(x, y)` from a tightly-packed RGBA8 buffer.
@@ -190,8 +188,8 @@ pub fn close(a: [u8; 4], b: [u8; 4]) -> bool {
 }
 
 /// Assert the pixel at `(x, y)` is within tolerance of `expected`, returning the actual bytes on
-/// mismatch. `Result`, not a process exit, so a mismatch found with a fixture spawned still
-/// reaches the cleanup that reaps it.
+/// mismatch. `Result`, not a process exit, so a mismatch still reaches the cleanup that reaps the
+/// fixture.
 pub fn assert_pixel(
     pixels: &[u8],
     frame_width: u32,

--- a/crates/glass-macos/tests/input.rs
+++ b/crates/glass-macos/tests/input.rs
@@ -249,6 +249,6 @@ mod macos_main {
     }
 
     pub(super) fn run() {
-        run_fixture_test("quadrants", "input", "INPUT_INTEGRATION_PASS", run_checks);
+        run_fixture_test("quadrants", "INPUT_INTEGRATION_PASS", run_checks);
     }
 }

--- a/crates/glass-macos/tests/input.rs
+++ b/crates/glass-macos/tests/input.rs
@@ -38,6 +38,8 @@
 //! unaffected by it (compositor output is readable regardless of lock state), which is why
 //! this gap wasn't visible until this file's first real input-posting run.
 
+mod common;
+
 #[cfg(not(target_os = "macos"))]
 fn main() {
     println!("skipped (not macOS): test");
@@ -50,13 +52,13 @@ fn main() {
 
 #[cfg(target_os = "macos")]
 mod macos_main {
-    use std::path::PathBuf;
-    use std::process::Command;
     use std::time::Duration;
 
     use glass_core::platform::{KeyEvent, MouseButton, PointerEvent};
     use glass_core::{AppSpec, Platform, SandboxLevel, Stream};
     use glass_macos::MacosPlatform;
+
+    use crate::common::{run_fixture_test, try_expect};
 
     /// Settle after each injected action before draining logs — generous relative to
     /// `input.rs`'s own internal `FOCUS_SETTLE` (300ms, already paid once per `send_key`/
@@ -71,80 +73,6 @@ mod macos_main {
     /// drift from `CLICK_TARGET` and still count as a correct round trip (rounding in the
     /// pixel<->point conversion, not a loose "close enough").
     const CLICK_TOLERANCE: i32 = 5;
-
-    /// Print a clear failure message and exit non-zero — the `harness = false` contract
-    /// (no libtest to format a panic for us).
-    fn fail(msg: impl AsRef<str>) -> ! {
-        eprintln!("FAIL: {}", msg.as_ref());
-        std::process::exit(1);
-    }
-
-    /// Unwrap a `Result`, failing the whole test process with `context` prefixed to the
-    /// error on `Err`. Only safe to use before a fixture process has been spawned (or once
-    /// all spawn-time cleanup is already done) — see `capture.rs`'s identical helper for why
-    /// anything after that must go through `try_expect`/`run_checks` instead.
-    fn expect<T, E: std::fmt::Display>(result: Result<T, E>, context: &str) -> T {
-        match result {
-            Ok(v) => v,
-            Err(e) => fail(format!("{context}: {e}")),
-        }
-    }
-
-    /// Like `expect`, but returns the error as a `String` instead of exiting the process —
-    /// see `capture.rs`'s identical helper's doc for why: a failure raised inside
-    /// `run_checks` (fixture already spawned) must flow back to `run()` so it can
-    /// `stop_app()` before the process exits, which a direct `std::process::exit` would skip
-    /// (Rust destructors don't run across `exit`).
-    fn try_expect<T, E: std::fmt::Display>(
-        result: Result<T, E>,
-        context: &str,
-    ) -> Result<T, String> {
-        result.map_err(|e| format!("{context}: {e}"))
-    }
-
-    fn swiftc_available() -> bool {
-        Command::new("swiftc")
-            .arg("--version")
-            .output()
-            .is_ok_and(|o| o.status.success())
-    }
-
-    /// Build `fixture/quadrants.swift` to a fresh temp path — identical to `capture.rs`'s
-    /// `build_fixture`, just a distinct temp-dir name so a parallel run of both tests never
-    /// collides. Returns the built binary's path and the temp build dir it lives in (the
-    /// caller removes the dir once done — see `run()`).
-    fn build_fixture() -> (PathBuf, PathBuf) {
-        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let source = manifest_dir.join("fixture").join("quadrants.swift");
-        if !source.is_file() {
-            fail(format!("fixture source not found at {}", source.display()));
-        }
-
-        let out_dir =
-            std::env::temp_dir().join(format!("glass-macos-input-test-{}", std::process::id()));
-        expect(
-            std::fs::create_dir_all(&out_dir),
-            "creating fixture build dir",
-        );
-        let out_bin = out_dir.join("quadrants");
-
-        let status = Command::new("swiftc")
-            .arg("-O")
-            .arg("-parse-as-library")
-            .arg(&source)
-            .arg("-o")
-            .arg(&out_bin)
-            .status();
-        match status {
-            Ok(s) if s.success() => {}
-            Ok(s) => fail(format!(
-                "swiftc exited with {s} building {}",
-                source.display()
-            )),
-            Err(e) => fail(format!("failed to run swiftc: {e}")),
-        }
-        (out_bin, out_dir)
-    }
 
     /// Every stdout line from `lines` that starts with `prefix`, with the prefix stripped —
     /// e.g. `find_reported(lines, "key: ")` yields `["h", "e", ...]` from `quadrants.swift`'s
@@ -321,43 +249,6 @@ mod macos_main {
     }
 
     pub(super) fn run() {
-        if !swiftc_available() {
-            println!("skipped (no swiftc)");
-            return;
-        }
-
-        let (fixture_bin, fixture_dir) = build_fixture();
-        println!("built fixture at {}", fixture_bin.display());
-
-        let mut platform = match MacosPlatform::new() {
-            Ok(p) => p,
-            Err(e) => {
-                let _ = std::fs::remove_dir_all(&fixture_dir);
-                fail(format!(
-                    "MacosPlatform::new() (Screen Recording / Accessibility grant missing?): {e}"
-                ));
-            }
-        };
-
-        let result = run_checks(&mut platform, &fixture_bin);
-
-        // Reached regardless of outcome, and BEFORE any process::exit below — see
-        // capture.rs's identical cleanup ordering for why this must run before any exit.
-        let stop_result = platform.stop_app();
-        let _ = std::fs::remove_dir_all(&fixture_dir);
-
-        match result {
-            Ok(()) => {
-                expect(stop_result, "stop_app");
-                println!("INPUT_INTEGRATION_PASS");
-                std::process::exit(0);
-            }
-            Err(msg) => {
-                if let Err(e) = stop_result {
-                    eprintln!("(additionally) stop_app failed: {e}");
-                }
-                fail(msg);
-            }
-        }
+        run_fixture_test("quadrants", "input", "INPUT_INTEGRATION_PASS", run_checks);
     }
 }

--- a/crates/glass-macos/tests/role_probe.rs
+++ b/crates/glass-macos/tests/role_probe.rs
@@ -27,6 +27,8 @@
 //! TCC grants as `tests/a11y.rs` — see that file's module doc for how a granted run supplies
 //! them.
 
+mod common;
+
 #[cfg(not(target_os = "macos"))]
 fn main() {
     println!("skipped (not macOS): test");
@@ -49,6 +51,8 @@ mod macos_main {
     };
     use glass_macos::MacosPlatform;
 
+    use crate::common::{fail, with_stop_app};
+
     /// Comma-separated launch commands to probe, e.g.
     /// `/System/Applications/TextEdit.app,/System/Applications/Calculator.app`. Each element
     /// is either a `.app` bundle path or a plain executable path — exactly what
@@ -62,13 +66,6 @@ mod macos_main {
     /// accessibility tree behind a window a beat after the window itself appears; mirrors
     /// `tests/a11y.rs`'s identically-reasoned settle.
     const STARTUP_SETTLE: Duration = Duration::from_millis(800);
-
-    /// Print a clear failure message and exit non-zero — the `harness = false` contract (no
-    /// libtest to format a panic for us). Mirrors the sibling integration tests.
-    fn fail(msg: impl AsRef<str>) -> ! {
-        eprintln!("FAIL: {}", msg.as_ref());
-        std::process::exit(1);
-    }
 
     /// AX role tokens glass maps to a role, and that a probed app has actually been seen to
     /// emit. A histogram bucket carrying one of these must not come back [`AxRole::Other`]: the
@@ -190,28 +187,6 @@ mod macos_main {
             .map(|ms| format!("{ms:.0}ms"))
             .collect::<Vec<_>>()
             .join(", ")
-    }
-
-    /// Run `body`, then always call `platform.stop_app()` afterward regardless of whether
-    /// `body` succeeded — mirrors `tests/bundle_launch.rs`'s identically-named helper.
-    fn with_stop_app<T>(
-        platform: &mut MacosPlatform,
-        label: &str,
-        body: impl FnOnce(&mut MacosPlatform) -> Result<T, String>,
-    ) -> Result<T, String> {
-        let result = body(platform);
-        let stop_result = platform.stop_app();
-        match result {
-            Ok(v) => stop_result
-                .map(|()| v)
-                .map_err(|e| format!("stop_app({label}): {e}")),
-            Err(e) => {
-                if let Err(stop_err) = stop_result {
-                    eprintln!("(additionally) stop_app({label}) failed: {stop_err}");
-                }
-                Err(e)
-            }
-        }
     }
 
     /// Launch `run0`, snapshot it with the node cap lifted (so a big app's tree is never

--- a/crates/glass-macos/tests/window_adopt_probe.rs
+++ b/crates/glass-macos/tests/window_adopt_probe.rs
@@ -41,6 +41,8 @@
 //! TCC grants as `tests/a11y.rs` — see that file's module doc for how a granted run supplies
 //! them.
 
+mod common;
+
 #[cfg(not(target_os = "macos"))]
 fn main() {
     println!("skipped (not macOS): test");
@@ -61,6 +63,8 @@ mod macos_main {
         WindowGeometry, WindowInfo, WindowOp,
     };
     use glass_macos::MacosPlatform;
+
+    use crate::common::{fail, with_stop_app};
 
     /// The launch command to probe — a `.app` bundle path or a plain executable path, exactly
     /// what `AppSpec::run`'s first element accepts (see `MacosPlatform::start_app`'s
@@ -95,13 +99,6 @@ mod macos_main {
     const EARLY_SAMPLE_INTERVAL: Duration = Duration::from_millis(10);
     const EARLY_SAMPLE_WINDOW: Duration = Duration::from_millis(300);
 
-    /// Print a clear failure message and exit non-zero — the `harness = false` contract (no
-    /// libtest to format a panic for us). Mirrors the sibling integration tests.
-    fn fail(msg: impl AsRef<str>) -> ! {
-        eprintln!("FAIL: {}", msg.as_ref());
-        std::process::exit(1);
-    }
-
     /// One window as one line: everything needed to tell a real app window from a transient
     /// panel — its id, title, pixel geometry, and whether the backend considers it active.
     fn render_window(w: &WindowInfo) -> String {
@@ -117,28 +114,6 @@ mod macos_main {
             w.geometry.y,
             if w.active { " ACTIVE" } else { "" }
         )
-    }
-
-    /// Run `body`, then always call `platform.stop_app()` afterward regardless of whether
-    /// `body` succeeded — mirrors `tests/role_probe.rs`'s identically-named helper.
-    fn with_stop_app<T>(
-        platform: &mut MacosPlatform,
-        label: &str,
-        body: impl FnOnce(&mut MacosPlatform) -> Result<T, String>,
-    ) -> Result<T, String> {
-        let result = body(platform);
-        let stop_result = platform.stop_app();
-        match result {
-            Ok(v) => stop_result
-                .map(|()| v)
-                .map_err(|e| format!("stop_app({label}): {e}")),
-            Err(e) => {
-                if let Err(stop_err) = stop_result {
-                    eprintln!("(additionally) stop_app({label}) failed: {stop_err}");
-                }
-                Err(e)
-            }
-        }
     }
 
     /// One run's outcome: whether the adopted geometry matched a window the app's pid actually

--- a/crates/glass-macos/tests/windows.rs
+++ b/crates/glass-macos/tests/windows.rs
@@ -383,11 +383,6 @@ mod macos_main {
     }
 
     pub(super) fn run() {
-        run_fixture_test(
-            "quadrants",
-            "windows",
-            "WINDOW_INTEGRATION_PASS",
-            run_checks,
-        );
+        run_fixture_test("quadrants", "WINDOW_INTEGRATION_PASS", run_checks);
     }
 }

--- a/crates/glass-macos/tests/windows.rs
+++ b/crates/glass-macos/tests/windows.rs
@@ -36,6 +36,8 @@
 //! match..."`) — its PRESENCE means the private symbol failed and the geometry fallback
 //! engaged for this run; its ABSENCE means the private correlation itself succeeded.
 
+mod common;
+
 #[cfg(not(target_os = "macos"))]
 fn main() {
     println!("skipped (not macOS): test");
@@ -49,13 +51,13 @@ fn main() {
 #[cfg(target_os = "macos")]
 mod macos_main {
     use std::collections::HashSet;
-    use std::path::PathBuf;
-    use std::process::Command;
     use std::time::Duration;
 
     use glass_core::platform::{WindowGeometry, WindowInfo, WindowOp};
     use glass_core::{AppSpec, Platform, SandboxLevel};
     use glass_macos::MacosPlatform;
+
+    use crate::common::{assert_pixel, run_fixture_test, try_expect};
 
     /// Settle after `start_app` before the first `list_windows` — both fixture windows need
     /// a moment to finish appearing/painting (mirrors `capture.rs`/`input.rs`'s identical
@@ -95,9 +97,6 @@ mod macos_main {
     /// rejects a resize that visibly did nothing, not rounding noise.
     const RESIZE_CHANGE_THRESHOLD_PX: i64 = 20;
 
-    /// Per-channel RGBA tolerance for a sampled pixel vs. its expected known color — same
-    /// value and rationale as `capture.rs`'s identical constant.
-    const PIXEL_TOLERANCE: i32 = 40;
     /// `quadrants.swift`'s `secondaryPalette` ("glass-fixture-2"'s quadrant colors) — see that
     /// file's module doc. Used to confirm `capture_frame(None)` captured the SELECTED
     /// (secondary) window, not the primary one, by pixel color alone.
@@ -105,77 +104,6 @@ mod macos_main {
     const SECONDARY_TOP_RIGHT: [u8; 4] = [255, 0, 255, 255]; // magenta
     const SECONDARY_BOTTOM_LEFT: [u8; 4] = [255, 255, 0, 255]; // yellow
     const SECONDARY_BOTTOM_RIGHT: [u8; 4] = [0, 0, 0, 255]; // black
-
-    /// Print a clear failure message and exit non-zero — the `harness = false` contract (no
-    /// libtest to format a panic for us).
-    fn fail(msg: impl AsRef<str>) -> ! {
-        eprintln!("FAIL: {}", msg.as_ref());
-        std::process::exit(1);
-    }
-
-    /// Unwrap a `Result`, failing the whole test process with `context` prefixed to the error
-    /// on `Err`. Only safe to use before a fixture process has been spawned — see
-    /// `capture.rs`'s identical helper for why anything after that must go through
-    /// `try_expect`/`run_checks` instead.
-    fn expect<T, E: std::fmt::Display>(result: Result<T, E>, context: &str) -> T {
-        match result {
-            Ok(v) => v,
-            Err(e) => fail(format!("{context}: {e}")),
-        }
-    }
-
-    /// Like `expect`, but returns the error as a `String` instead of exiting the process — so
-    /// a failure raised inside `run_checks` (fixture already spawned) still flows back to
-    /// `run()`, which reaches `stop_app()` before the process exits.
-    fn try_expect<T, E: std::fmt::Display>(
-        result: Result<T, E>,
-        context: &str,
-    ) -> Result<T, String> {
-        result.map_err(|e| format!("{context}: {e}"))
-    }
-
-    fn swiftc_available() -> bool {
-        Command::new("swiftc")
-            .arg("--version")
-            .output()
-            .is_ok_and(|o| o.status.success())
-    }
-
-    /// Build `fixture/quadrants.swift` to a fresh temp path — identical to `capture.rs`'s/
-    /// `input.rs`'s `build_fixture`, just a distinct temp-dir name so a parallel run of all
-    /// three tests never collides.
-    fn build_fixture() -> (PathBuf, PathBuf) {
-        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let source = manifest_dir.join("fixture").join("quadrants.swift");
-        if !source.is_file() {
-            fail(format!("fixture source not found at {}", source.display()));
-        }
-
-        let out_dir =
-            std::env::temp_dir().join(format!("glass-macos-windows-test-{}", std::process::id()));
-        expect(
-            std::fs::create_dir_all(&out_dir),
-            "creating fixture build dir",
-        );
-        let out_bin = out_dir.join("quadrants");
-
-        let status = Command::new("swiftc")
-            .arg("-O")
-            .arg("-parse-as-library")
-            .arg(&source)
-            .arg("-o")
-            .arg(&out_bin)
-            .status();
-        match status {
-            Ok(s) if s.success() => {}
-            Ok(s) => fail(format!(
-                "swiftc exited with {s} building {}",
-                source.display()
-            )),
-            Err(e) => fail(format!("failed to run swiftc: {e}")),
-        }
-        (out_bin, out_dir)
-    }
 
     /// Number of `windows` entries with `active == true`.
     fn count_active(windows: &[WindowInfo]) -> usize {
@@ -218,43 +146,6 @@ mod macos_main {
         let dist_after = (after.width as i64 - target.0 as i64).abs()
             + (after.height as i64 - target.1 as i64).abs();
         dist_after <= dist_before
-    }
-
-    /// Fetch pixel `(x, y)` from a tightly-packed RGBA8 `Frame` buffer — identical to
-    /// `capture.rs`'s helper of the same name.
-    fn pixel_at(pixels: &[u8], frame_width: u32, x: u32, y: u32) -> [u8; 4] {
-        let idx = (y as usize * frame_width as usize + x as usize) * 4;
-        [
-            pixels[idx],
-            pixels[idx + 1],
-            pixels[idx + 2],
-            pixels[idx + 3],
-        ]
-    }
-
-    fn close(a: [u8; 4], b: [u8; 4]) -> bool {
-        a.iter()
-            .zip(b.iter())
-            .all(|(x, y)| (*x as i32 - *y as i32).abs() <= PIXEL_TOLERANCE)
-    }
-
-    /// Assert the pixel at `(x, y)` in a tightly-packed RGBA8 buffer is within tolerance of
-    /// `expected` — identical shape to `capture.rs`'s helper of the same name.
-    fn assert_pixel(
-        pixels: &[u8],
-        frame_width: u32,
-        x: u32,
-        y: u32,
-        expected: [u8; 4],
-        label: &str,
-    ) -> Result<(), String> {
-        let got = pixel_at(pixels, frame_width, x, y);
-        if !close(got, expected) {
-            return Err(format!(
-                "{label} pixel at ({x},{y}) = {got:?}, expected ~{expected:?} (tolerance {PIXEL_TOLERANCE})"
-            ));
-        }
-        Ok(())
     }
 
     /// The whole `start_app` -> list/select/move/resize/capture -> assertion flow. Returns
@@ -492,46 +383,11 @@ mod macos_main {
     }
 
     pub(super) fn run() {
-        if !swiftc_available() {
-            println!("skipped (no swiftc)");
-            return;
-        }
-
-        let (fixture_bin, fixture_dir) = build_fixture();
-        println!("built fixture at {}", fixture_bin.display());
-
-        let mut platform = match MacosPlatform::new() {
-            Ok(p) => p,
-            Err(e) => {
-                let _ = std::fs::remove_dir_all(&fixture_dir);
-                fail(format!(
-                    "MacosPlatform::new() (Screen Recording / Accessibility grant missing?): {e}"
-                ));
-            }
-        };
-
-        let result = run_checks(&mut platform, &fixture_bin);
-
-        // Reached regardless of outcome, and BEFORE any process::exit below — see
-        // capture.rs's/input.rs's identical cleanup ordering for why this must run before
-        // any exit (stop_app is idempotent/infallible-today, and this is what guarantees the
-        // fixture's `quadrants` process — now potentially TWO windows' worth of it, still one
-        // process — never survives a failed run).
-        let stop_result = platform.stop_app();
-        let _ = std::fs::remove_dir_all(&fixture_dir);
-
-        match result {
-            Ok(()) => {
-                expect(stop_result, "stop_app");
-                println!("WINDOW_INTEGRATION_PASS");
-                std::process::exit(0);
-            }
-            Err(msg) => {
-                if let Err(e) = stop_result {
-                    eprintln!("(additionally) stop_app failed: {e}");
-                }
-                fail(msg);
-            }
-        }
+        run_fixture_test(
+            "quadrants",
+            "windows",
+            "WINDOW_INTEGRATION_PASS",
+            run_checks,
+        );
     }
 }


### PR DESCRIPTION
Last of the larger `cargo dupes` entries. The seven mac-gated targets in `crates/glass-macos/tests/` are `harness = false`, so each has to do for itself what libtest would — format a failure, exit non-zero, reap the fixture process — and each had grown its own copy: `fail` in all seven, `swiftc_available` and `try_expect` in five, `build_fixture` and `expect` in four, `with_stop_app` in three, the pixel helpers in two, and a 43-line `run()` in three. Their own comments conceded it ("identical to `capture.rs`'s/`input.rs`'s `build_fixture`", "mirrors `tests/bundle_launch.rs`'s identically-named helper").

They now come from `tests/common/mod.rs`, which cargo does not treat as a target because it is a subdirectory. 601 lines out, 205 in.

For `run()` I normalised comments and the pass marker out of all three originals and diffed rather than trusting my eye: byte-identical. That is what made the closure-taking `run_fixture_test` safe, and it keeps the cleanup ordering the copies were most insistent about — `stop_app` and the temp-dir removal before any `process::exit`, which skips destructors.

`with_stop_app` takes the label two of its three copies had and bundle_launch's did not, so its three call sites now name the check they guard.

## What review changed

`build_fixture` took a `tag` for its temp dir, justified by "the pid alone would not separate them" — which is false, since each target is its own binary and so its own process. `env!("CARGO_CRATE_NAME")` inside the shared module expands per *including* target, so the tag is now derived and cannot desync from the target it names. I verified that in a scratch crate with two `harness = false` targets before relying on it, and confirmed on-box that the rendered dir name is unchanged.

`bundle_launch` had kept its own `try_expect`, character-identical to the shared one — the fifth copy, in the one file that opted out of importing it, which is where the next divergence would have started.

## Verification

These targets never run in CI: the macOS leg uses `cargo test --workspace --lib` precisely to exclude them, since the runner has no TCC grants. Compilation is weak evidence for a test refactor, so they were run on the granted Mac through its existing harness — `CAPTURE_INTEGRATION_PASS`, `WINDOW_INTEGRATION_PASS`, `INPUT_INTEGRATION_PASS`, the a11y target's four sub-passes, and `BUNDLE_LAUNCH_INTEGRATION_PASS`, both before and after the review fixes. A scratch clone was used rather than that host's working tree, and removed afterwards.

`role_probe` and `window_adopt_probe` skip without their env vars, which the LaunchAgent does not inherit, so their `with_stop_app` was not exercised on-box — it is the same labelled function bundle_launch ran three times, and the macOS CI job's `clippy --all-targets` is their compile gate.

Workspace: 2271 tests pass; fmt and clippy clean on Linux and for `x86_64-apple-darwin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)